### PR TITLE
fix: fail closed when stale frame bundles report payloads across reincarnation (rf2-01ihi)

### DIFF
--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -188,6 +188,11 @@
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.live-frame :as live-frame]
+            ;; The reserved `:rf/redacted` egress sentinel. The dead-incarnation
+            ;; emit seam redacts a stale bundle's captured payload to it AT
+            ;; SOURCE (rf2-01ihi), so no same-id successor's elision policy can
+            ;; ever be borrowed to un-redact it downstream.
+            [re-frame.privacy :as privacy]
             ;; The dev-only warning seam (`trace/emit! :warning …`) the
             ;; cross-frame carried-subscribe honesty diagnostic rides
             ;; (rf2-vxgfnd.231). ui ships ABOVE core, so this is a plain static
@@ -1097,18 +1102,43 @@
   HERE — before delegating to core's dispatch/subscribe — so the same failure is
   never ALSO fanned by core's router/subs frame-destroyed path (source-level
   provenance; no double emission). Centralizing all arms through this one helper
-  keeps their two-channel contract from drifting. Never returns."
+  keeps their two-channel contract from drifting. Never returns.
+
+  ## Fail closed for stale-bundle payload egress (rf2-01ihi)
+
+  This seam fires ONLY for a DEAD captured incarnation (a stale bundle op, or a
+  `(frame)` read that resolved a dead incarnation). By the time it runs,
+  `frame-id` NO LONGER names the incarnation the `payload` was captured for: a
+  same-id destroy→reincarnation may have reseated a SUCCESSOR under `frame-id`,
+  or the frame may be absent. The captured incarnation owned the ONLY elision
+  authority for its payload, and that authority is gone with it.
+
+  `emit-error-both!` → `dispatch-on-error!` elides the record's `:event` through
+  `elision/elide-wire-value` under THIS `frame-id`, and that walk fails closed
+  ONLY when `frame-id` is UNRESOLVABLE. A live successor makes it resolvable, so
+  the walk would BORROW the successor's (unrelated, possibly permissive) policy
+  and project incarnation A's raw payload off-box — under BOTH the corpus-wide
+  record AND the frame-owned observability sink route, which `dispatch-on-error!`
+  feeds the RAW event. We therefore redact the payload BODY to the reserved
+  `:rf/redacted` sentinel HERE, at the only site that knows the incarnation is
+  dead: the structural event/query HEAD still rides `:event-id`, no successor
+  policy can be borrowed, and no policy-snapshot machinery is introduced. The
+  absent-frame and destroyed-without-successor arms fail closed identically."
   [frame-id op payload reason]
-  (error-emit/emit-error-both!
-   :rf.error/frame-destroyed
-   payload                         ;; attempted event/query vector (elided as :event); nil for :capture
-   (when payload (first payload))  ;; :event-id / sub-id — the vector head
-   frame-id
-   nil                             ;; no exception — a dead-incarnation op, not a caught throw
-   0                               ;; elapsed-ms — not a timed path
-   (interop/now-ms)                ;; time
-   {:frame frame-id :op op :event payload :reason :frame-destroyed} ;; dev-trace tags (axis 2)
-   {:op op})                       ;; category-specific attribution for the always-on record (axis 1)
+  (let [;; Body redacted at source (rf2-01ihi) — a dead incarnation has no
+        ;; trustworthy policy for its captured payload on EITHER channel. nil
+        ;; for the `:capture` arm (no op was invoked, so no payload to redact).
+        redacted-event (when (some? payload) privacy/redacted-sentinel)]
+    (error-emit/emit-error-both!
+     :rf.error/frame-destroyed
+     redacted-event                  ;; attempted event/query body, redacted at source (elided as :event); nil for :capture
+     (when payload (first payload))  ;; :event-id / sub-id — the structural vector head (survives)
+     frame-id
+     nil                             ;; no exception — a dead-incarnation op, not a caught throw
+     0                               ;; elapsed-ms — not a timed path
+     (interop/now-ms)                ;; time
+     {:frame frame-id :op op :event redacted-event :reason :frame-destroyed} ;; dev-trace tags (axis 2)
+     {:op op}))                      ;; category-specific attribution for the always-on record (axis 1)
   (error/throw-error!
    :rf.error/frame-destroyed 're-frame.ui/frame
    reason

--- a/implementation/ui/test/re_frame/ui/frame_ops_always_on_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_ops_always_on_elision_prod_test.cljs
@@ -24,9 +24,11 @@
   so these tests run only under prod-mode compilation."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core                 :as rf]
+            [re-frame.elision              :as elision]
             [re-frame.error-emit           :as error-emit]
             [re-frame.frame                :as frame]
             [re-frame.live-frame           :as live-frame]
+            [re-frame.privacy              :as privacy]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support         :as test-support]
             [re-frame.ui.frames            :as frames]))
@@ -69,6 +71,52 @@
           (is (= :dispatch-sync (:op r)) ":op names the failing bundle operation")
           (is (= :prod.ops/set-n (:event-id r)) ":event-id is the attempted head")
           (is (number? (:time r)) ":time is a wall-clock millis number"))))))
+
+(defn- deep-contains? [x target]
+  (cond
+    (= x target)    true
+    (map? x)        (boolean (some (fn [[k v]] (or (deep-contains? k target)
+                                                   (deep-contains? v target))) x))
+    (sequential? x) (boolean (some #(deep-contains? % target) x))
+    (set? x)        (boolean (some #(deep-contains? % target) x))
+    :else           false))
+
+(deftest stale-bundle-across-reincarnation-fails-closed-under-prod
+  (testing "Per rf2-01ihi: under `:advanced` + goog.DEBUG=false — where the dev
+            trace (axis 2) is DCE'd and the always-on record is the SOLE
+            surviving channel — a stale bundle op fired after a same-id
+            reincarnation redacts the attempted payload at source. Incarnation A
+            owns a sensitive elision policy; successor B is unclassified. The
+            production-survivable record must NOT borrow B's permissive policy to
+            ship A's raw secret; it fails closed to `:rf/redacted` while the
+            structural head, op, and frame survive."
+    (rf/reg-event :prod.reinc/classify
+      (fn [{:keys [db]} _]
+        {:db        (assoc-in db [:secret] "A-owned")
+         :sensitive [[:secret]]}))
+    (make-frame! :prod.reinc/id {:n 1})
+    (let [stale (rf/with-frame :prod.reinc/id (frames/frame-ops))
+          seen  (atom [])]
+      ((:dispatch-sync stale) [:prod.reinc/classify])
+      (is (contains? (elision/sensitive-declarations :prod.reinc/id) [:secret])
+          "incarnation A owns a sensitive elision policy")
+      (frame/destroy-frame! :prod.reinc/id)
+      (make-frame! :prod.reinc/id {:n 41})       ;; unclassified successor B
+      (is (empty? (elision/sensitive-declarations :prod.reinc/id))
+          "successor B is permissive")
+      (rf/register-listener! :errors :prod/recorder (fn [r] (swap! seen conj r)))
+      (is (thrown? js/Error ((:dispatch-sync stale) [:audit/secret {:password :TOP-SECRET}]))
+          "the stale op still fails loud with the typed error under prod")
+      (let [reports (filter #(= :rf.error/frame-destroyed (:error %)) @seen)]
+        (is (= 1 (count reports)) "EXACTLY ONE always-on record survives prod")
+        (let [r (first reports)]
+          (is (= :prod.reinc/id (:frame r)) ":frame names the captured incarnation")
+          (is (= :dispatch-sync (:op r)))
+          (is (= :audit/secret (:event-id r)) ":event-id is the structural head")
+          (is (= privacy/redacted-sentinel (:event r))
+              ":event fails closed to the reserved sentinel — no borrowed successor policy")
+          (is (not (deep-contains? r :TOP-SECRET))
+              "the raw secret reaches the production record NOWHERE"))))))
 
 (deftest absent-capture-fans-one-always-on-record-under-prod
   (testing "Per rf2-vxgfnd.230: the absent/closing `(frame)` CAPTURE arm follows

--- a/implementation/ui/test/re_frame/ui/frame_ops_reincarnation_elision_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/frame_ops_reincarnation_elision_cljs_test.cljc
@@ -1,0 +1,196 @@
+(ns re-frame.ui.frame-ops-reincarnation-elision-cljs-test
+  "rf2-01ihi — FAIL CLOSED when a stale `(frame)` operation bundle reports its
+  captured payload ACROSS a same-id reincarnation.
+
+  A `(frame)` bundle is locked to the exact incarnation A it captured. When A is
+  destroyed and an unclassified successor B is created under the SAME id, an op
+  invoked on A's stale bundle is correctly REJECTED as stale
+  (`:rf.error/frame-destroyed`). But PR #5954 (rf2-vxgfnd.230) made that
+  rejection production-observable by fanning the attempted event/query + frame-id
+  through `error-emit/emit-error-both!`. The always-on path elides the record's
+  `:event` through `elision/elide-wire-value` under that frame-id, and that walk
+  fails closed ONLY when the frame-id is UNRESOLVABLE. The live successor B makes
+  it resolvable, so the walk borrowed B's (unrelated, permissive) elision policy
+  and projected incarnation A's RAW payload off-box — an off-box/log privacy leak
+  (A's payload under unrelated successor B's authority), on BOTH the corpus-wide
+  record and the frame-owned observability sink route.
+
+  These legs pin the fix: the dead-incarnation emit seam
+  (`emit-and-throw-frame-destroyed!`) redacts the payload BODY to `:rf/redacted`
+  AT SOURCE, so no successor policy can be borrowed. The record still retains the
+  category, the captured frame id, the operation, and the structural event/query
+  HEAD (`:event-id`). Dispatch, dispatch-sync, and subscribe stay
+  exact-incarnation fenced and still throw after EXACTLY ONE observability
+  fan-out. The absent-frame and destroyed-without-successor paths fail closed
+  identically.
+
+  Dual-runtime `*_cljs_test.cljc`: the shadow `:node-test` build
+  (`npm run test:cljs`) AND the JVM `clojure -M:test` runner both run it. Plain
+  CLJC; no DOM dependency. The sibling `frame-ops-always-on-elision-prod-test`
+  pins the same survival under `:advanced` + `goog.DEBUG=false`, where the dev
+  trace (axis 2) is DCE'd and the always-on record is the sole surviving channel."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core                 :as rf]
+            [re-frame.elision              :as elision]
+            [re-frame.error-emit           :as error-emit]
+            [re-frame.frame                :as frame]
+            [re-frame.live-frame           :as live-frame]
+            [re-frame.privacy              :as privacy]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.trace                :as trace]
+            [re-frame.ui.frames            :as frames]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       plain-atom/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (error-emit/clear-error-listeners!))})
+  (fn [f]
+    (frames/reset-frame-ops-cache!)
+    (try (f) (finally (frames/reset-frame-ops-cache!)))))
+
+(def ^:private fid :reinc/id)
+
+;; The attempted event / query the stale bundle carries: a keyword head plus a
+;; sensitive body. `:audit/secret` (head) is a structural identifier; the value
+;; `:TOP-SECRET` is the payload that must NEVER egress under a successor policy.
+(def ^:private secret-event [:audit/secret {:password :TOP-SECRET}])
+(def ^:private secret-value :TOP-SECRET)
+
+(defn- make-frame! [id db]
+  (live-frame/make-frame {:id id})
+  (frame/replace-app-db! id db)
+  id)
+
+(defn- err-id [thunk]
+  (try (thunk) nil
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+         (:rf.error/id (ex-data e)))))
+
+(defn- deep-contains?
+  "True when `target` appears anywhere in `x` (as a key, value, or leaf) —
+  the fail-closed proof walks the WHOLE record so a re-keyed leak cannot hide."
+  [x target]
+  (cond
+    (= x target)         true
+    (map? x)             (boolean (some (fn [[k v]] (or (deep-contains? k target)
+                                                        (deep-contains? v target))) x))
+    (sequential? x)      (boolean (some #(deep-contains? % target) x))
+    (set? x)             (boolean (some #(deep-contains? % target) x))
+    :else                false))
+
+(defn- capture-emissions
+  "Run `thunk` (expected to throw `:rf.error/frame-destroyed`), capturing the
+  always-on error records (axis 1) AND the dev-trace error events (axis 2) it
+  fans BEFORE the throw. Returns `{:records [...] :traces [...] :err-id <kw>}`.
+  Freshly-gensym'd listener keys, unregistered on the way out."
+  [thunk]
+  (let [recs   (atom [])
+        traces (atom [])
+        ekey   (keyword "test" (name (gensym "reinc-rec")))
+        tkey   (keyword "test" (name (gensym "reinc-trace")))]
+    (error-emit/register-error-listener! ekey (fn [r] (swap! recs conj r)))
+    (trace/register-listener! tkey
+                              (fn [ev] (when (= :rf.error/frame-destroyed (:operation ev))
+                                         (swap! traces conj ev))))
+    (try
+      (let [caught (err-id thunk)]
+        {:records @recs :traces @traces :err-id caught})
+      (finally
+        (error-emit/unregister-error-listener! ekey)
+        (trace/unregister-listener! tkey)))))
+
+;; ---------------------------------------------------------------------------
+;; The reincarnation composition (the bead's exact reproduction).
+;; ---------------------------------------------------------------------------
+
+(deftest stale-bundle-op-across-reincarnation-fails-closed
+  (testing "Per rf2-01ihi: with DIVERGENT A/B policies — incarnation A OWNS a
+            sensitive elision policy, successor B is unclassified/permissive — a
+            stale bundle op fired after the same-id reincarnation redacts the
+            attempted payload in the always-on record (never borrows B's policy),
+            while retaining the category, captured frame id, operation, and the
+            structural event/query head. Dispatch, dispatch-sync, and subscribe
+            all fail closed, each throwing after EXACTLY ONE fan-out."
+    (rf/reg-event :reinc/classify
+      (fn [{:keys [db]} _]
+        {:db        (assoc-in db [:secret] "A-owned")
+         :sensitive [[:secret]]}))
+    (rf/reg-sub :reinc/n (fn [db _] (:n db)))
+    (doseq [[op invoke head]
+            [[:dispatch      (fn [b] ((:dispatch b) secret-event))      :audit/secret]
+             [:dispatch-sync (fn [b] ((:dispatch-sync b) secret-event)) :audit/secret]
+             [:subscribe     (fn [b] ((:subscribe b) secret-event))     :audit/secret]]]
+      (testing (str "stale " op " across reincarnation")
+        (make-frame! fid {:n 1})
+        (let [stale (rf/with-frame fid (frames/frame-ops))]
+          ;; A owns a sensitive elision policy (create A with elision ownership).
+          ((:dispatch-sync stale) [:reinc/classify])
+          (is (contains? (elision/sensitive-declarations fid) [:secret])
+              "incarnation A owns a non-empty sensitive elision policy")
+          ;; Destroy A; reincarnate an UNCLASSIFIED successor B under the same id.
+          (frame/destroy-frame! fid)
+          (make-frame! fid {:n 41})
+          (is (empty? (elision/sensitive-declarations fid))
+              "successor B is unclassified — a permissive policy that must NOT be borrowed")
+          ;; Fire A's stale bundle op into the same-id successor world.
+          (let [{:keys [records traces err-id]} (capture-emissions #(invoke stale))]
+            (is (= :rf.error/frame-destroyed err-id)
+                "the stale op still fails loud with the canonical typed error")
+            (is (= 1 (count records)) "EXACTLY ONE always-on record")
+            (is (= 1 (count traces))  "EXACTLY ONE dev trace on axis 2")
+            (let [r (first records)]
+              (is (= :rf.error/frame-destroyed (:error r)) "category retained")
+              (is (= fid (:frame r))                       "captured frame id retained")
+              (is (= op (:op r))                           "operation retained")
+              (is (= head (:event-id r))                   "structural event/query head retained")
+              ;; THE FIX: the body is redacted at source — B's permissive policy
+              ;; can never be borrowed to ship A's raw payload.
+              (is (= privacy/redacted-sentinel (:event r))
+                  ":event fails closed to the reserved sentinel, NOT B's identity walk")
+              (is (not (deep-contains? r secret-value))
+                  "the raw secret reaches the always-on record NOWHERE"))
+            ;; The dev trace (axis 2) is fenced at the same source.
+            (is (not (some #(deep-contains? % secret-value) traces))
+                "the raw secret reaches the dev trace NOWHERE either")))))))
+
+;; ---------------------------------------------------------------------------
+;; The sibling dead-incarnation paths fail closed identically.
+;; ---------------------------------------------------------------------------
+
+(deftest destroyed-without-successor-fails-closed
+  (testing "Per rf2-01ihi: the ordinary destroyed-WITHOUT-successor path fails
+            closed too — no successor exists, the frame is unresolvable, and the
+            attempted payload is redacted rather than shipped."
+    (rf/reg-event :reinc/set-n (fn [_ [_ n]] {:db {:n n}}))
+    (make-frame! fid {:n 1})
+    (let [stale (rf/with-frame fid (frames/frame-ops))]
+      (frame/destroy-frame! fid)                 ;; no reincarnation
+      (let [{:keys [records err-id]}
+            (capture-emissions #((:dispatch-sync stale) secret-event))]
+        (is (= :rf.error/frame-destroyed err-id))
+        (is (= 1 (count records)))
+        (let [r (first records)]
+          (is (= :audit/secret (:event-id r)) "structural head retained")
+          (is (= :dispatch-sync (:op r)))
+          (is (= privacy/redacted-sentinel (:event r))
+              ":event fails closed even with no successor to borrow from")
+          (is (not (deep-contains? r secret-value))
+              "the raw secret reaches the record NOWHERE"))))))
+
+(deftest absent-capture-fails-closed
+  (testing "Per rf2-01ihi: the absent-frame `(frame)` CAPTURE arm carries no
+            payload, so there is nothing to leak — it fails closed with the
+            :capture attribution and a payload-free record."
+    (let [{:keys [records err-id]}
+          (capture-emissions
+            #(binding [frame/*current-frame* :reinc/ghost] (frames/frame-ops)))]
+      (is (= :rf.error/frame-destroyed err-id))
+      (is (= 1 (count records)))
+      (let [r (first records)]
+        (is (= :reinc/ghost (:frame r)))
+        (is (= :capture (:op r)) ":op marks the capture-time failure")
+        (is (not (deep-contains? r secret-value))
+            "no payload, so no secret anywhere in the capture-arm record")))))


### PR DESCRIPTION
## What & why

A `(frame)` operation bundle is locked to the exact incarnation A it captured. PR #5954 (rf2-vxgfnd.230) made a stale bundle op's rejection production-observable by fanning the attempted event/query plus frame-id through `error-emit/emit-error-both!`. The always-on path elides the record's `:event` through `elision/elide-wire-value` under that frame-id, and that walk fails closed **only** when the frame-id is UNRESOLVABLE.

When incarnation A is destroyed and an unclassified successor B is created under the **same id**, the frame-id resolves to **live B**, so the elision walk borrowed B's unrelated (permissive) policy and projected incarnation A's **raw** payload off-box — under **both** the corpus-wide record and the frame-owned observability sink route, which `dispatch-on-error!` feeds the raw event. This is an off-box/log privacy leak: A's payload projected under unrelated successor B's authority.

## The fix

Redact at the one seam that knows the incarnation is dead — `emit-and-throw-frame-destroyed!` in `re_frame/ui/frames.cljc`. It fires **only** for a dead captured incarnation (a stale bundle op, or a `(frame)` read that resolved a dead incarnation), so `frame-id` can no longer name the incarnation the payload was captured for. We redact the captured payload **body** to the reserved `:rf/redacted` sentinel **at source**, on both channels, before it can reach `elide-wire-value` / the frame-owned sink under a successor's authority.

- No same-id successor policy can be borrowed to un-redact the payload downstream.
- The record still retains the category, captured frame id, operation, and the **structural event/query head** (`:event-id`).
- Dispatch, dispatch-sync, and subscribe stay exact-incarnation fenced and still throw after **exactly one** observability fan-out.
- Absent-frame and destroyed-without-successor arms fail closed identically.
- **No new error-id**, and no policy-snapshot framework — reuses the existing incarnation fence + `:rf.error/frame-destroyed` mechanism, per the incarnation-fence family (siblings #6072/#6079/#6091/#6089).

Stale-payload path: `implementation/ui/src/re_frame/ui/frames.cljc` — `throw-frame-ops-stale!` → `emit-and-throw-frame-destroyed!` (previously passed the raw `payload` as the axis-1 `:event`).

## Reincarnation proof

- `frame_ops_reincarnation_elision_cljs_test.cljc` (dual-runtime node + JVM): divergent A/B policies (A owns a sensitive elision policy; B unclassified). Across dispatch / dispatch-sync / subscribe, the raw secret reaches neither the always-on record nor the dev trace; `:event` fails closed to `:rf/redacted` while head/op/frame survive. Plus destroyed-without-successor and absent-capture fail-closed legs.
- `frame_ops_always_on_elision_prod_test.cljs`: the advanced-production leg (`:advanced` + `goog.DEBUG=false`, where axis 2 is DCE'd) proves the same for the sole surviving always-on channel.
- **Failing-before verified**: reverting the seam to pass the raw `payload` makes the reincarnation suite go red with `:event` = `[:audit/secret {:password :TOP-SECRET}]` (9 assertions); destroyed-without-successor + absent legs stay green, isolating the reincarnation gap exactly.

## Quality gates

- `clojure -M:test` (ui artefact, owning JVM): **670 tests, 13399 assertions, 0 failures, 0 errors**.
- `npm run test:cljs` (node, core-reachable — includes the new `ui/test` `.cljc` regression): **9694 tests, 47720 assertions, 0 failures, 0 errors**.
- `shadow-cljs compile browser-test-prod-elision` (compile-check for the added prod-elision `.cljs`): **321 files, 0 warnings**. Browser prod-elision run not executed here (CI owns the browser gate).
- New reincarnation suite: fails-before (9 assertions red) / passes-after (green), both hosts.
