### PR TITLE
fix(perf): measure the true first cold G-13 dispatch-to-commit cycle (rf2-52isf)

### DIFF
--- a/implementation/scripts/_g13-timing-evidence.test.cjs
+++ b/implementation/scripts/_g13-timing-evidence.test.cjs
@@ -24,9 +24,11 @@ const assert = require('assert/strict');
 const {
   RECORDED_SAMPLES,
   PERCENTILE_CONVENTION,
+  COLD_FIRST_DRAIN_PRE_HOT,
   warmPercentile,
   validateWarmSamples,
   summarizeWarm,
+  assertColdIsFirstDrain,
   buildSummary,
 } = require('./lib/g13-timing-evidence.cjs');
 
@@ -171,6 +173,46 @@ test('buildSummary validates each size (a malformed raw array fails loudly)', ()
   const bad = twoSizeResults();
   bad[1].warm['raw-ms'] = [1, 2, 3];
   assert.throws(() => buildSummary(bad), /exactly 9/);
+});
+
+// ----- assertColdIsFirstDrain: the cold-order control (rf2-52isf) ------------
+
+test('COLD_FIRST_DRAIN_PRE_HOT is the mount-seed :hot value (0)', () => {
+  // The fixture seeds app-db :hot=0 at mount; the cold timer must fire before
+  // any drain advances it, so the cold sample's timing-pre-hot must equal 0.
+  assert.equal(COLD_FIRST_DRAIN_PRE_HOT, 0);
+});
+
+test('assertColdIsFirstDrain accepts a cold sample captured before any drain', () => {
+  const cold = { label: 'cold', 'elapsed-ms': 6.25, 'timing-pre-hot': 0 };
+  assert.equal(assertColdIsFirstDrain(cold), cold);
+});
+
+test('assertColdIsFirstDrain rejects correctness running before the cold timer', () => {
+  // A single correctness drain would have advanced :hot from 0 to queued-writes
+  // (8) before the cold timer — the reported "cold" span is then a warmed second
+  // dispatch, and the control must turn red naming the ordering fault.
+  const warmed = { label: 'cold', 'elapsed-ms': 6.25, 'timing-pre-hot': 8 };
+  assert.throws(
+    () => assertColdIsFirstDrain(warmed, 'V=100 cold timing evidence'),
+    /correctness ran before the cold timer/,
+  );
+  assert.throws(
+    () => assertColdIsFirstDrain(warmed, 'V=100 cold timing evidence'),
+    /V=100 cold timing evidence/,
+  );
+});
+
+test('assertColdIsFirstDrain rejects any nonzero pre-hot (a later warmed drain)', () => {
+  assert.throws(
+    () => assertColdIsFirstDrain({ 'timing-pre-hot': 16 }),
+    /first post-mount dispatch/,
+  );
+});
+
+test('assertColdIsFirstDrain rejects a missing pre-hot witness', () => {
+  assert.throws(() => assertColdIsFirstDrain({ label: 'cold' }), /first post-mount dispatch/);
+  assert.throws(() => assertColdIsFirstDrain(null, 'V=500'), /cold sample is missing/);
 });
 
 // ----- runner ----------------------------------------------------------------

--- a/implementation/scripts/lib/g13-timing-evidence.cjs
+++ b/implementation/scripts/lib/g13-timing-evidence.cjs
@@ -80,6 +80,34 @@ function summarizeWarm(raw, where = 'warm timing evidence') {
   };
 }
 
+// rf2-52isf — the cold-order control. G-13's `cold` sample must be the FIRST
+// post-mount dispatch/commit: its timed span cannot sit AFTER this sample's own
+// correctness dispatch, O(V) audit, DOM read, or React/cache warm-up. The
+// fixture seeds app-db `:hot=0` at mount and every drain adds `queued-writes`,
+// so `:timing-pre-hot` — the app-db `:hot` value captured immediately before
+// the cold timing dispatch — is exactly 0 iff no drain preceded the cold timer.
+// A nonzero value means correctness (or a warmup) ran first and the reported
+// "cold" span is actually a warmed second dispatch. Evidence plumbing only — no
+// wall-clock threshold; this pins the cold IDENTITY, not its duration.
+const COLD_FIRST_DRAIN_PRE_HOT = 0;
+
+// Assert the cold sample is the first post-mount drain. `where` labels the call
+// site (e.g. "V=100 cold timing evidence"). Returns the sample on success.
+function assertColdIsFirstDrain(cold, where = 'cold timing evidence') {
+  if (!cold || typeof cold !== 'object') {
+    throw evidenceFail(`${where}: cold sample is missing (got ${JSON.stringify(cold)})`);
+  }
+  const preHot = cold['timing-pre-hot'];
+  if (preHot !== COLD_FIRST_DRAIN_PRE_HOT) {
+    throw evidenceFail(
+      `${where}: cold timer did not measure the first post-mount dispatch ` +
+        `(timing-pre-hot=${JSON.stringify(preHot)}, expected ${COLD_FIRST_DRAIN_PRE_HOT}); ` +
+        'correctness ran before the cold timer',
+    );
+  }
+  return cold;
+}
+
 function fmt(x) {
   return Number(x).toFixed(3);
 }
@@ -125,8 +153,10 @@ function buildSummary(results) {
 module.exports = {
   RECORDED_SAMPLES,
   PERCENTILE_CONVENTION,
+  COLD_FIRST_DRAIN_PRE_HOT,
   warmPercentile,
   validateWarmSamples,
   summarizeWarm,
+  assertColdIsFirstDrain,
   buildSummary,
 };

--- a/implementation/scripts/run-ui-g13.cjs
+++ b/implementation/scripts/run-ui-g13.cjs
@@ -20,6 +20,7 @@ const { classifyReleaseBundle } = require('./lib/read-release-bundle.cjs');
 const {
   validateWarmSamples,
   summarizeWarm,
+  assertColdIsFirstDrain,
   buildSummary,
 } = require('./lib/g13-timing-evidence.cjs');
 
@@ -310,6 +311,11 @@ function assertDevResult(result) {
     if (size.cold['fixed-shell-idle-cells'] !== 2) {
       fail(`cold sample at V=${size.v} lost the two ownership-empty HMR shells`);
     }
+    // rf2-52isf — the cold timed span must be the FIRST post-mount drain. A
+    // cold `timing-pre-hot` of 0 (mount seed :hot; +queued-writes per drain)
+    // proves the timer ran before any correctness dispatch or O(V) audit; a
+    // nonzero value means the reported "cold" span is a warmed second dispatch.
+    assertColdIsFirstDrain(size.cold, `V=${size.v} cold timing evidence`);
     if (!Array.isArray(size.samples) || size.samples.length !== 9) {
       fail(`V=${size.v} did not retain exactly nine warm samples`);
     }
@@ -376,6 +382,13 @@ function assertMutationTeeth(result) {
     }],
     ['V-wide port current? scan', (r) => {
       r.results[0].cold.projection['port-candidate-inspections']['current?'] = 500;
+    }],
+    // rf2-52isf — the cold-order tooth. If the correctness cycle (or any drain)
+    // runs before the cold timer, the mount seed :hot=0 has already advanced and
+    // the cold `timing-pre-hot` is nonzero. The reported span would be a warmed
+    // second dispatch mislabelled cold; the order control must reject it.
+    ['correctness ran before the cold timer', (r) => {
+      r.results[0].cold['timing-pre-hot'] = 8;
     }],
     // rf2-vxgfnd.212 — workload-roster teeth. Each must fail validation, proving
     // the exact one-to-one V=100/V=500 roster before projections are compared.

--- a/implementation/ui/g13/re_frame/ui/g13/dev.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/dev.cljs
@@ -59,6 +59,15 @@
 ;; query — are exactly the V-dependent work that must NOT sit inside a
 ;; dispatch-to-commit interval. So the clean timing cycle carries no evidence
 ;; collection at all, and the untimed correctness cycle carries all of it.
+;;
+;; rf2-52isf — ORDER matters as much as separation: `sample!` runs the clean
+;; timing cycle FIRST, then the correctness cycle. For the `cold` sample this
+;; makes the timed span the true FIRST post-mount dispatch/commit — before this
+;; sample's own correctness dispatch, O(V) audit, DOM read, and cache/React
+;; warm-up. `:timing-pre-hot` (the app-db `:hot` value captured just before the
+;; timing dispatch; 0 at the mount seed, +queued-writes per drain) is the causal
+;; witness the gate asserts: a cold `:timing-pre-hot` of 0 proves no drain
+;; preceded the cold timer.
 
 (defn- timing-cycle!
   "CLEAN dispatch-to-commit measurement. The measured interval spans exactly
@@ -193,16 +202,24 @@
               :projection projection}))))))
 
 (defn- sample!
-  "One recorded sample: the untimed correctness cycle (exact-work projection +
-  DOM proof) followed by a separate CLEAN timing cycle. The reported
-  `:elapsed-ms` therefore measures only dispatch-to-commit, while the exact
-  counts come from a cycle that is never on the clock."
+  "One recorded sample: the CLEAN timing cycle FIRST, then the untimed
+  correctness cycle (exact-work projection + DOM proof). Timing runs before
+  correctness so the reported `:elapsed-ms` is a true first-drain
+  dispatch-to-commit span — never the second dispatch after this sample's own
+  O(V) audit, DOM read, and cache/React warm-up. `:timing-pre-hot` is the
+  app-db `:hot` value captured immediately BEFORE the timing dispatch (outside
+  the measured interval): the mount seed leaves it 0 and every drain adds
+  `queued-writes`, so for the `cold` sample it is 0 — the causal proof that the
+  timer measured the FIRST post-mount dispatch, before any correctness-cycle
+  dispatch or audit. The exact counts still come from a cycle never on the clock."
   [root frame v label]
-  (-> (correctness-cycle! root frame v label)
-      (.then (fn [c]
-               (-> (timing-cycle! frame)
-                   (.then (fn [elapsed]
-                            (assoc c :elapsed-ms elapsed))))))))
+  (let [timing-pre-hot (:hot (rf/app-db-value frame))]
+    (-> (timing-cycle! frame)
+        (.then (fn [elapsed]
+                 (-> (correctness-cycle! root frame v label)
+                     (.then (fn [c]
+                              (assoc c :elapsed-ms elapsed
+                                     :timing-pre-hot timing-pre-hot)))))))))
 
 (defn- run-size! [v]
   (let [frame (rf/make-frame {:initial-events [[:rf/set-db (fixture/seed v)]]})


### PR DESCRIPTION
## Summary

The G-13 push-economics gate reports a per-size "cold" dispatch-to-commit span, but it was mislabelled. `sample!` ran `correctness-cycle!` **before** `timing-cycle!`, so the timed span for the cold sample was actually the **second** dispatch/commit — taken after a full untimed dispatch, O(V) audit, DOM read, and cache/React warm-up. The warm arrays and the quantile/summary pipeline were already correct; only the cold identity remained mislabelled.

## The fix (measurement-only)

- **`ui/g13/.../dev.cljs`** — reorder `sample!` to run the CLEAN timing cycle **first**, capture its elapsed value at commit, then run the untimed correctness cycle and associate the projection. For the cold sample the timed span is now the true first post-mount dispatch/commit. The two-cycle separation and the correctness cycle itself are unchanged.
- **Causal witness** — each sample now carries `:timing-pre-hot`, the app-db `:hot` value captured immediately **before** the timing dispatch (outside the measured interval). The fixture seeds `:hot=0` at mount and every drain adds `queued-writes`, so a cold `:timing-pre-hot` of **0** is causal proof that no drain preceded the cold timer.
- **Order control** — `assertColdIsFirstDrain` (new, in the pure `g13-timing-evidence` lib) asserts the cold sample's `:timing-pre-hot` is 0; `assertDevResult` calls it; a new mutation tooth flips it to 8 and proves the control turns red if correctness runs before the cold timer. Unit tests pin the control at the pure lib seam.

No production runtime behaviour changes — the fixture (`fixture.cljs`) and all `re-frame.ui` runtime code are untouched. Raw samples, nearest-rank summaries, exact-work projection, and the evidence-only (no-threshold) posture are unchanged.

### Before / after cold-cycle shape

- **Before:** `cold.elapsed-ms` = span of the 2nd dispatch (after the cold sample's own audit/DOM/warm-up). No witness of what preceded it.
- **After:** `cold.elapsed-ms` = span of the 1st post-mount dispatch; `cold.timing-pre-hot == 0` proves it. Later (warm) samples carry nonzero pre-hot values.

## Quality gates

- `node scripts/_g13-timing-evidence.test.cjs` — **25 passed** (19 prior + 6 new for `assertColdIsFirstDrain` / `COLD_FIRST_DRAIN_PRE_HOT`).
- `assertDevResult` cold-order wiring verified against a synthetic dev result (playwright stubbed; `assertDevResult` is pure): valid cold-first result passes; a warmed cold sample (`timing-pre-hot=8`) is rejected at both sizes; the new mutation tooth's exact mutation turns the guard red.
- `dev.cljs` parsed clean with the babashka reader (15 balanced top-level forms).
- Full shadow-cljs `test:ui-g13` browser gate (compile + release + Playwright) is CI-owned (`cljs-ui-g13` job) and not run locally per the browser/compile-sink guidance.
