### PR TITLE
docs(spec): correct compiled-frame production + manifest contract prose (rf2-u4g33)

### DIFF
--- a/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
+++ b/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
@@ -43,13 +43,14 @@
       - `day8.re-frame2-xray.runtime` — the discovery sentinel + safe-egress
         entry points.
   - `re-frame.ui` (rf2-qz1h5d; rf2-vxgfnd.83 + rf2-vxgfnd.103) — the Spec-004
-    compiled-view substrate. FULLY-ROWED (both directions): all seventeen blessed
-    exports are rowed — the S1 set, the namespace-specific `frame-root` row
+    compiled-view substrate. FULLY-ROWED (both directions): the entire blessed
+    export set is rowed — the S1 set, the namespace-specific `frame-root` row
     (rf2-vxgfnd.71), `frame-provider`, the S2 SCOPE form (rf2-vxgfnd.83,
     rowed once rf2-vxgfnd.24 blessed it as the native SCOPE grammar),
     `adapter`, the first-party `:rf.adapter/ui` boot adapter Var
-    (rf2-vxgfnd.103 / PR #5809), and `frame`, the S2 ops-bundle body form
-    (rf2-vxgfnd.184). A row
+    (rf2-vxgfnd.103 / PR #5809), `frame`, the S2 ops-bundle body form
+    (rf2-vxgfnd.184), and the S3 additions `event`, `render-fn`, `slot`, and
+    `spread-safe`. A row
     removed / renamed in source → RED (direction 1); a NEW public Var added to
     this closed compiler grammar without a row → RED (direction 2), so an
     accidental public export cannot accumulate silently.
@@ -135,11 +136,12 @@
    "day8.re-frame2-xray.open-in-editor"              (emit-ns-publics day8.re-frame2-xray.open-in-editor)
    "day8.re-frame2-xray.runtime"                     (emit-ns-publics day8.re-frame2-xray.runtime)
    ;; rf2-qz1h5d + rf2-vxgfnd.83 + rf2-vxgfnd.103 — re-frame.ui compiled-view
-   ;; substrate. FULLY-ROWED now: all seventeen blessed exports are rowed (the
+   ;; substrate. FULLY-ROWED now: the entire blessed export set is rowed (the
    ;; S1 set, the namespace-specific `frame-root` row rf2-vxgfnd.71, the S2
    ;; SCOPE form `frame-provider` rf2-vxgfnd.83 — rowed once rf2-vxgfnd.24
-   ;; blessed it — the first-party `adapter` Var rf2-vxgfnd.103, and the `frame`
-   ;; ops-bundle body form rf2-vxgfnd.184), so
+   ;; blessed it — the first-party `adapter` Var rf2-vxgfnd.103, the `frame`
+   ;; ops-bundle body form rf2-vxgfnd.184, and the S3 additions `event`,
+   ;; `render-fn`, `slot`, and `spread-safe`), so
    ;; re-frame.ui is in `fully-rowed` below (both directions checked).
    "re-frame.ui"                                     (emit-ns-publics re-frame.ui)
    ;; rf2-vxgfnd.200 — re-frame.ui.test testing surface. JVM-introspected for
@@ -153,7 +155,8 @@
    adapter API — and `re-frame.ui`, the Spec-004 compiled-view substrate:
    with `frame-provider` rowed (rf2-vxgfnd.83, once rf2-vxgfnd.24 blessed it
    as the native SCOPE form) and the first-party `adapter` Var rowed
-   (rf2-vxgfnd.103) and `frame` (rf2-vxgfnd.184), all seventeen blessed exports are rowed, so a NEW
+   (rf2-vxgfnd.103), `frame` (rf2-vxgfnd.184), and the S3 additions `event` /
+   `render-fn` / `slot` / `spread-safe`, the entire blessed export set is rowed, so a NEW
    accidental public Var added to this first-party closed compiler grammar
    fails direction-2 completeness. The Xray mount surface stays a curated
    subset (direction 1 only), so it is deliberately absent here."

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -423,7 +423,8 @@ most views need only `sub` and bare event vectors.
 - **Exact-incarnation stable identity.** The bundle is cached per live frame incarnation,
   so repeated `(frame)` reads across re-renders return the **identical** map — it is
   `rf=`-stable and safe to thread through the memo comparator and effect deps, and a render
-  performs a single map lookup, not a bundle construction (see production cost below). A
+  performs a few bounded cache/lifecycle reads — never a bundle construction (see production
+  cost below). A
   destroyed-then-recreated frame — even under the **same id** — is a new incarnation and
   mints a fresh bundle.
 
@@ -448,8 +449,12 @@ most views need only `sub` and bare event vectors.
   so a production error boundary that swallows the throw still leaves the failure visible
   under `goog.DEBUG=false` (the §View identity error-emit axis).
 
-- **Production cost.** The hot path is one map lookup per render; the incarnation cache is
-  pruned when the frame is destroyed, so a bundle's closures never outlive the frame's id.
+- **Production cost.** The hot path is bounded per render — a live-incarnation token read, a
+  closing/liveness check, a cache lookup, and a token-identity compare — never a bundle
+  construction. Destroying a frame removes the incarnation cache's reference to its bundle,
+  but a caller that deliberately retained a stale bundle may still outlive that destruction;
+  every op is incarnation-fenced, so the carried bundle fails loud through the fence with
+  `:rf.error/frame-destroyed` rather than acting on a same-id replacement.
 
 ## Local state — `local` — and the placement rule (this Spec owns the rule)
 

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -204,11 +204,11 @@
   ;;     are carried HERE (not JVM-introspected by the generator) so the curated
   ;;     order + tiers stay verbatim from spec/API.md §Compiled views. The rows
   ;;     below ARE the COMPLETE blessed export set (spec/API.md §Compiled views +
-  ;;     the Spec-004 `export-surface-is-exactly-the-blessed-set` JVM conformance):
-  ;;     defview / custom-element / sub / lease / raw / html / raw-fn / spread /
-  ;;     mount / create-root / render! / hydrate-root / unmount! / frame-root /
-  ;;     frame-provider / adapter / frame / event — all EIGHTEEN live public vars,
-  ;;     so re-frame.ui is now
+  ;;     the Spec-004 `export-surface-is-exactly-the-blessed-set` JVM conformance).
+  ;;     The rows themselves are the authoritative roster (defview through
+  ;;     spread-safe) — no hand-maintained count is kept here; the probe
+  ;;     reconciles these rows against the live `re-frame.ui` publics in both
+  ;;     directions, so the rows are the truth. re-frame.ui is now
   ;;     :FULLY-ROWED (BOTH directions checked — see the probe note below).
   ;;     `frame-root` (rf2-vxgfnd.71) is NAMESPACE-SPECIFIC — the compiled-view
   ;;     ENSURE root-form marker (a compile-marker `defn`, :kind :fn), rowed


### PR DESCRIPTION
Corrects two stale prose surfaces on `main` (bead rf2-u4g33, discovered from rf2-vxgfnd.232 / PR #5963). Prose-only; no runtime, no API-manifest row, no generated output changed.

## Compiled-frame production (spec/004-Views.md §The committed-frame ops bundle)

Two claims were untrue against the shipped `(frame)` bridge in `implementation/ui/src/re_frame/ui/frames.cljc`:

- **"one map lookup per render"** — the committed-site bridge `frame-ops-for` (frames.cljc:1280) performs bounded reads on the hot path: an incarnation-token read (`frame/frame-incarnation-token`), a closing/liveness check (`frame-incarnation-closing?`), a cache lookup (`get @frame-ops-cache`), and a token-identity compare (`identical? token (:token entry)`). Corrected the stable-identity note and the production-cost bullet to "a few bounded cache/lifecycle reads … never a bundle construction".
- **"a bundle's closures never outlive the frame's id"** — false. The `:ui/on-frame-destroyed!` hook only `dissoc`s the cache entry (frames.cljc:1416), removing the *cache's* reference. A caller that deliberately retained a stale bundle outlives destruction and fails loud through the incarnation fence with the canonical `:rf.error/frame-destroyed` (`throw-stale-carried-op!`, frames.cljc:1135). Corrected the production-cost bullet to distinguish cache retention from caller retention and describe the fenced failure.

## Manifest contract — re-frame.ui export count

`spec/API.md` §Compiled views (line 225) already reports the live blessed set as **twenty-one** vars (S1 14 + S2 `frame-provider`/`adapter`/`frame` + S3 `event`/`render-fn`/`slot`/`spread-safe`). Two descriptive count claims had not been updated for the S3 additions:

- `spec/api-manifest-metadata.edn` comment said "all EIGHTEEN live public vars" — removed the fragile hand-maintained count (the 21 rows below it are the authoritative roster; the probe reconciles them against the live publics in both directions).
- `implementation/scripts/api-manifest/probe/test/…/cljs_manifest_probe_cljs_test.cljs` said "all seventeen blessed exports" in three comments — completed the enumerations with the S3 additions and dropped the drift-prone number.

Row data and the generated `spec/api-manifest.edn` are untouched; the executable row reconciliation was already green and stays green.

## Quality gates

- `python -m mkdocs build --strict` — PASS (built in 24.3s; only pre-existing INFO notices)
- `python scripts/check_doc_slugs.py` — PASS (exit 0)
- `python scripts/check_keyword_catalogue_drift.py` — PASS (exit 0)
- `clojure -M -m re-frame.api-manifest.gen --check` — PASS ("OK: spec/api-manifest.edn in sync (498 public vars)")

Test suites not run (prose/comment-only change, no runtime surface).
