### PR TITLE
fix(gate): enforce root verb kinds + literal options in the API drift gate (rf2-e9q33)

### DIFF
--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
@@ -85,11 +85,39 @@
   (let [c (str/lower-case cell)]
     (some (fn [t] (when (str/includes? c t) (keyword t))) tier-tokens)))
 
+(def ^:private var-kind-markers
+  "The closed set of var-kind markers API.md's `M/Fn` cell uses, mapped to
+   the manifest `:kind` vocabulary (`:macro` / `:fn` / `:var`) each ASSERTS.
+   `Component` is deliberately mapped to nil: a Reagent-component row is
+   carried in the manifest as `:fn` or `:var` (there is no `:component`
+   kind), so its marker pins no single manifest kind — it still classifies
+   the row as a var-row (`var-kind-marker?`), but contributes no
+   documented-kind assertion the root-verb kind guard could check
+   (rf2-e9q33)."
+  {"M" :macro, "Fn" :fn, "Var" :var, "Component" nil})
+
+(defn- var-kind-token
+  "The var-kind marker token beginning the `M/Fn` cell (`Fn`/`M`/`Var`/
+   `Component`), or nil when the cell is a keyword-registration or prose
+   cell."
+  [cell]
+  (second (re-find #"^(Fn|M|Var|Component)\b" (str/trim cell))))
+
 (defn- var-kind-marker?
   "True when the M/Fn cell denotes a VAR row (a fn / macro / Var /
    component), as opposed to a keyword-registration or prose cell."
   [cell]
-  (boolean (re-find #"^(Fn|M|Var|Component)\b" (str/trim cell))))
+  (boolean (var-kind-token cell)))
+
+(defn- documented-kind
+  "The manifest `:kind` (`:macro` / `:fn` / `:var`) a var-row's `M/Fn` cell
+   DOCUMENTS, or nil when the marker pins no single kind (`Component`) or the
+   cell is not a var-kind marker. Retained on each parsed var-row so the
+   root-verb kind guard can compare the documented kind against the manifest
+   — previously the marker was used only to classify a row, then discarded
+   (rf2-e9q33)."
+  [cell]
+  (get var-kind-markers (var-kind-token cell)))
 
 (def adapter-aliases
   "The documented `:require [<ns> :as <alias>]` adapter aliases API.md uses
@@ -145,8 +173,12 @@
 
 (defn parse-api-md-var-rows
   "Parse spec/API.md and return `[{:var <bare-name> :qualifier <ns-or-alias
-   or nil> :tier <kw> :line <n> :raw <first-cell>} ...]` for every VAR-row
-   found in any table that has a `Tier` column. `:qualifier` is the
+   or nil> :tier <kw> :doc-kind <:macro/:fn/:var or nil> :line <n> :raw
+   <first-cell>} ...]` for every VAR-row found in any table that has a `Tier`
+   column. `:doc-kind` is the manifest `:kind` the row's `M/Fn` marker
+   documents (nil for a `Component` marker, which pins no single kind), so
+   the root-verb kind guard can reconcile it against the manifest
+   (rf2-e9q33). `:qualifier` is the
    namespace/alias prefix for a qualified row (`helix-adapter`,
    `re-frame.http`) or nil for a bare row — preserved so qualified rows can
    resolve strictly against the manifest `[namespace var]` index
@@ -188,6 +220,7 @@
                            (conj! acc {:var       bare
                                        :qualifier qualifier
                                        :tier      tier
+                                       :doc-kind  (documented-kind kind-cell)
                                        :line      n
                                        :raw       (second m)})))
                   (recur more tier-idx acc))
@@ -260,6 +293,122 @@
   [extracted]
   (projection/vacuity-floor-problem "spec/API.md" extracted min-var-rows))
 
+;; ---------------------------------------------------------------------------
+;; Root-verb KIND guard (rf2-e9q33).
+;;
+;; PR #5968 corrected the source (create-root is a MACRO, not a Fn) but left
+;; the documented-kind acceptance criterion unproved: the `M/Fn` cell was
+;; used only to classify a row as a var-row, then discarded — `reconcile`
+;; compares identity and tier only. So the create-root row could silently
+;; flip M -> Fn (or unmount! Fn -> M) and stay GREEN. This guard restores the
+;; comparison for the Spec-004C root verbs: each documented kind must equal
+;; the manifest `:kind` for the `re-frame.ui` row of that name.
+;; ---------------------------------------------------------------------------
+
+(def root-verb-namespace
+  "The manifest namespace that owns the Spec-004C root-lifecycle verbs whose
+   documented public-Var KIND the gate pins against the manifest (rf2-e9q33)."
+  "re-frame.ui")
+
+(def root-verb-kinds
+  "The Spec-004C root-lifecycle verbs (`re-frame.ui`) whose DOCUMENTED
+   public-Var kind the gate pins against the manifest (rf2-e9q33) — named in
+   the bead's acceptance criteria: create-root / render! / hydrate-root are
+   macros; unmount! is a function. A new root verb whose kind should be
+   pinned is an intentional one-line addition here."
+  #{"create-root" "render!" "hydrate-root" "unmount!"})
+
+(defn root-verb-kind-problems
+  "Pure documented-kind reconciler for the Spec-004C root verbs (rf2-e9q33).
+   For every API.md var-row naming one of `root-verb-kinds`, the DOCUMENTED
+   kind (its `M/Fn` marker mapped to `:macro` / `:fn` / `:var`) must equal
+   the manifest `:kind` for the `re-frame.ui` row of that name. Returns the
+   seq of problem maps; empty when every root verb's documented kind matches.
+
+   `rows`     — manifest rows (each `{:namespace :var :kind ...}`).
+   `api-rows` — parsed API.md var-rows `{:var :doc-kind :line :raw ...}`.
+
+   Row ABSENCE (a root verb dropped from API.md or the manifest) is the
+   `reconcile` / `gen --check` existence guard's job, not this kind guard's:
+   this fires only when a row is PRESENT on both sides with a disagreeing
+   kind — the wrong-Var-kind drift the tier reconcile could not see."
+  [{:keys [rows api-rows]}]
+  (let [manifest-kind (into {}
+                            (for [{:keys [namespace var kind]} rows
+                                  :when (and (= namespace root-verb-namespace)
+                                             (root-verb-kinds var))]
+                              [var kind]))]
+    (keep (fn [{:keys [var doc-kind line raw]}]
+            (when-let [mkind (and (root-verb-kinds var)
+                                  (get manifest-kind var))]
+              (cond
+                (nil? doc-kind)
+                {:kind :kind-unmarked :var var :raw raw :line line
+                 :manifest-kind mkind}
+                (not= doc-kind mkind)
+                {:kind :kind-mismatch :var var :raw raw :line line
+                 :doc-kind doc-kind :manifest-kind mkind})))
+          api-rows)))
+
+;; ---------------------------------------------------------------------------
+;; create-root LITERAL-OPTION guard (rf2-e9q33).
+;;
+;; Spec 004C fixes create-root's public contract: authored `:root-id` is
+;; REQUIRED (no root form to derive an id from) and `:disambiguator` is
+;; INVALID. The tier/kind reconcile cannot see this — it pins name,
+;; qualifier, tier, and kind, never the option grammar. This narrow guard
+;; requires the create-root API.md row to state BOTH facts literally; a row
+;; that drops the `:root-id`-required assertion or no longer marks
+;; `:disambiguator` invalid (silently admitting it) goes red. It is a
+;; targeted literal-invariant on ONE named row — deliberately NOT a general
+;; Markdown signature parser (bead guidance).
+;; ---------------------------------------------------------------------------
+
+(def ^:private create-root-row-re
+  "Anchored match for the create-root VAR-ROW (its first table cell is
+   exactly `` `create-root` ``), used to locate the row whose literal
+   option-grammar the gate pins (rf2-e9q33)."
+  #"^\s*\|\s*`create-root`\s*\|")
+
+(def ^:private root-id-required-re
+  "The create-root row must assert authored `:root-id` is REQUIRED — the
+   `:root-id` token followed, within the SAME table cell (`[^|]`), by
+   `required` (rf2-e9q33)."
+  #":root-id[^|]{0,60}\brequired\b")
+
+(def ^:private disambiguator-invalid-re
+  "The create-root row must assert `:disambiguator` is INVALID — the
+   `:disambiguator` token followed, within the SAME table cell (`[^|]`), by
+   `invalid` (rf2-e9q33). A row that drops this — or renames it to admit the
+   option — goes red."
+  #":disambiguator[^|]{0,60}\binvalid\b")
+
+(defn read-api-md-lines
+  "Read spec/API.md as `[[line-no line-text] ...]` (1-based). Shared by
+   `check!` and the prose-scanning guards (the keyword-drift guards and the
+   create-root option guard) so they all see the same line index."
+  []
+  (with-open [r (io/reader @api-md-file)]
+    (vec (map-indexed (fn [i line] [(inc i) line]) (line-seq r)))))
+
+(defn create-root-option-problems
+  "Pure literal-option-grammar guard for the create-root row (rf2-e9q33).
+   Returns the seq of problem maps; empty when the create-root row pins both
+   authored-`:root-id`-required and `:disambiguator`-invalid.
+
+   `api-md-lines` — `[[line-no line-text] ...]` for spec/API.md."
+  [api-md-lines]
+  (if-let [[line row-text]
+           (some (fn [[n text]]
+                   (when (re-find create-root-row-re text) [n text]))
+                 api-md-lines)]
+    (cond-> []
+      (not (re-find root-id-required-re row-text))
+      (conj {:kind :root-id-not-required :line line})
+      (not (re-find disambiguator-invalid-re row-text))
+      (conj {:kind :disambiguator-admitted :line line}))
+    [{:kind :create-root-row-missing :line nil}]))
+
 (defn check!
   "Validate spec/API.md var-rows against the manifest. Returns true when
    every API.md var-row resolves to a manifest row with a MATCHING tier;
@@ -282,8 +431,7 @@
                                :api-rows           api-rows
                                :known-unmanifested known-unmanifested
                                :aliases            adapter-aliases})
-        api-md-lines (with-open [r (io/reader @api-md-file)]
-                       (vec (map-indexed (fn [i line] [(inc i) line]) (line-seq r))))
+        api-md-lines (read-api-md-lines)
         ;; Var-row reconciliation cannot see retired keyword vocabulary in
         ;; API.md prose. The reply-envelope
         ;; (`:stale-key` / bare `:work-id`) and egress-profile (retired
@@ -293,7 +441,14 @@
         kw-probs   (concat
                      (projection/ep0017-keyword-drift-problems "spec/API.md" api-md-lines)
                      (projection/ep0011-reply-vocab-drift-problems "spec/API.md" api-md-lines)
-                     (projection/ep0015-privacy-vocab-drift-problems "spec/API.md" api-md-lines))]
+                     (projection/ep0015-privacy-vocab-drift-problems "spec/API.md" api-md-lines))
+        ;; Documented-kind guard for the Spec-004C root verbs (rf2-e9q33):
+        ;; each root verb's M/Fn marker must match the manifest :kind — the
+        ;; wrong-Var-kind drift the tier reconcile could not see.
+        kind-probs (root-verb-kind-problems {:rows rows :api-rows api-rows})
+        ;; Literal-option guard for the create-root row (rf2-e9q33): authored
+        ;; :root-id REQUIRED and :disambiguator INVALID must both stay pinned.
+        opt-probs  (create-root-option-problems api-md-lines)]
     (cond
       ;; Vacuity-floor violation: extraction collapsed — refuse a green.
       floor
@@ -312,6 +467,38 @@
             (println "an explicit retirement/rename reference. Problems:")
             (doseq [{:keys [file line raw detail]} kw-probs]
               (println (format "  %s:%d  `%s`  %s" file line raw detail))))
+          false)
+
+      (seq kind-probs)
+      (do (binding [*out* *err*]
+            (println "DRIFT: spec/API.md documents a Spec-004C root verb with the wrong Var kind.")
+            (println "create-root / render! / hydrate-root are MACROS; unmount! is a FUNCTION.")
+            (println "Each root-verb row's M/Fn marker must match the manifest :kind. Problems:")
+            (doseq [{:keys [kind raw line doc-kind manifest-kind]} kind-probs]
+              (case kind
+                :kind-mismatch
+                (println (format "  L%-4d KIND:    `%s` API.md marks %s; manifest :kind is %s"
+                                 line raw doc-kind manifest-kind))
+                :kind-unmarked
+                (println (format "  L%-4d KIND:    `%s` carries no var-kind marker; manifest :kind is %s"
+                                 line raw manifest-kind)))))
+          false)
+
+      (seq opt-probs)
+      (do (binding [*out* *err*]
+            (println "DRIFT: spec/API.md create-root row lost its literal option grammar.")
+            (println "The create-root row must pin authored :root-id REQUIRED and :disambiguator")
+            (println "INVALID (Spec 004C). Problems:")
+            (doseq [{:keys [kind line]} opt-probs]
+              (case kind
+                :root-id-not-required
+                (println (format "  L%-4s create-root no longer states authored :root-id is required"
+                                 (str line)))
+                :disambiguator-admitted
+                (println (format "  L%-4s create-root no longer marks :disambiguator invalid (admitted)"
+                                 (str line)))
+                :create-root-row-missing
+                (println "  create-root var-row not found in spec/API.md"))))
           false)
 
       (empty? problems)

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
@@ -23,7 +23,8 @@
   `reconcile` reconciler with synthetic inputs, plus a live smoke that the
   committed spec/API.md + manifest still reconcile clean."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.api-manifest.api-md-check :as c]))
+            [re-frame.api-manifest.api-md-check :as c]
+            [re-frame.api-manifest.gen :as gen]))
 
 ;; A minimal synthetic manifest reproducing the EXACT ambiguity the real
 ;; manifest has: the bare var `adapter` carried for four namespaces, three
@@ -197,3 +198,180 @@
             EP-0011/EP-0015 keyword-drift guards (no false +)"
     (is (true? (c/check!))
         "live drift: api-md-check failed with the keyword-drift guards wired")))
+
+;; ---------------------------------------------------------------------------
+;; Root-verb KIND guard (rf2-e9q33).
+;;
+;; PR #5968 corrected create-root (a MACRO, not a Fn) but left the
+;; documented-kind acceptance criterion unproved: api-md-check used the `M/Fn`
+;; cell only to classify a row as a var-row, then discarded it — reconcile
+;; compares identity + tier only. So the create-root row could silently flip
+;; M -> Fn (or unmount! Fn -> M) and stay GREEN. `root-verb-kind-problems`
+;; restores the comparison: each root verb's documented kind must equal the
+;; manifest :kind. These fixtures prove the wrong-kind cases go RED and the
+;; in-sync state stays green.
+;; ---------------------------------------------------------------------------
+
+;; Synthetic manifest rows carrying the manifest :kind for the four Spec-004C
+;; root verbs (three macros + one fn), plus an unrelated non-root fn.
+(def ^:private root-manifest-rows
+  [{:namespace "re-frame.ui"   :var "create-root"  :kind :macro}
+   {:namespace "re-frame.ui"   :var "render!"      :kind :macro}
+   {:namespace "re-frame.ui"   :var "hydrate-root" :kind :macro}
+   {:namespace "re-frame.ui"   :var "unmount!"     :kind :fn}
+   {:namespace "re-frame.core" :var "reg-event"    :kind :fn}])
+
+(defn- kind-problems-for [api-rows]
+  (c/root-verb-kind-problems {:rows root-manifest-rows :api-rows api-rows}))
+
+(deftest root-verbs-in-sync-produce-no-kind-problems
+  (testing "the committed documented kinds (create-root/render!/hydrate-root
+            = macro, unmount! = fn) reconcile clean against the manifest"
+    (is (empty? (kind-problems-for
+                  [{:var "create-root"  :doc-kind :macro :line 252 :raw "create-root"}
+                   {:var "render!"      :doc-kind :macro :line 253 :raw "render!"}
+                   {:var "hydrate-root" :doc-kind :macro :line 254 :raw "hydrate-root"}
+                   {:var "unmount!"     :doc-kind :fn    :line 255 :raw "unmount!"}])))))
+
+(deftest create-root-flipped-macro-to-fn-goes-red
+  (testing "THE BUG (rf2-e9q33): a create-root row whose M/Fn marker flipped
+            M -> Fn (documented :fn) fails against the manifest :macro"
+    (let [problems (kind-problems-for
+                     [{:var "create-root" :doc-kind :fn :line 252 :raw "create-root"}])]
+      (is (= 1 (count problems)))
+      (is (= :kind-mismatch (:kind (first problems))))
+      (is (= :fn    (:doc-kind (first problems))))
+      (is (= :macro (:manifest-kind (first problems))))
+      (is (= 252 (:line (first problems)))))))
+
+(deftest render-and-hydrate-flipped-to-fn-go-red
+  (testing "render! and hydrate-root flipped M -> Fn each fail on kind"
+    (is (= [:kind-mismatch]
+           (map :kind (kind-problems-for
+                        [{:var "render!" :doc-kind :fn :line 253 :raw "render!"}]))))
+    (is (= [:kind-mismatch]
+           (map :kind (kind-problems-for
+                        [{:var "hydrate-root" :doc-kind :fn :line 254 :raw "hydrate-root"}]))))))
+
+(deftest unmount-documented-as-anything-but-fn-goes-red
+  (testing "unmount! documented as a macro (Fn -> M) fails — the acceptance
+            criterion 'unmount! documented as anything other than a function'"
+    (let [problems (kind-problems-for
+                     [{:var "unmount!" :doc-kind :macro :line 255 :raw "unmount!"}])]
+      (is (= 1 (count problems)))
+      (is (= :kind-mismatch (:kind (first problems))))
+      (is (= :macro (:doc-kind (first problems))))
+      (is (= :fn    (:manifest-kind (first problems)))))))
+
+(deftest unmarked-root-verb-goes-red
+  (testing "a root verb whose marker pins no kind (e.g. a `Component` cell,
+            doc-kind nil) is flagged :kind-unmarked rather than silently
+            passing"
+    (let [problems (kind-problems-for
+                     [{:var "create-root" :doc-kind nil :line 252 :raw "create-root"}])]
+      (is (= 1 (count problems)))
+      (is (= :kind-unmarked (:kind (first problems))))
+      (is (= :macro (:manifest-kind (first problems)))))))
+
+(deftest non-root-var-rows-are-not-kind-checked
+  (testing "the guard fires ONLY for the named root verbs — an unrelated
+            var-row (even one carried in the manifest) contributes no kind
+            problem regardless of its documented kind"
+    (is (empty? (kind-problems-for
+                  [{:var "reg-event" :doc-kind :macro :line 1 :raw "reg-event"}
+                   {:var "some-tooling-fn" :doc-kind :var :line 2 :raw "some-tooling-fn"}])))))
+
+(deftest live-root-verb-kinds-match-the-manifest
+  (testing "the committed spec/API.md documents each Spec-004C root verb with
+            the kind the committed manifest carries (no live drift)"
+    (let [rows     (:vars (gen/read-committed-manifest))
+          api-rows (c/parse-api-md-var-rows)]
+      (is (empty? (c/root-verb-kind-problems {:rows rows :api-rows api-rows}))
+          "live drift: a root verb's documented kind disagrees with the manifest"))))
+
+(deftest live-parser-retains-doc-kind-for-root-verbs
+  (testing "the parser maps each root verb's M/Fn marker to a manifest :kind
+            (create-root = :macro, unmount! = :fn), so the guard has a
+            documented kind to compare (the marker is no longer discarded)"
+    (let [by-var (into {} (for [{:keys [var qualifier doc-kind]} (c/parse-api-md-var-rows)
+                                :when (and (nil? qualifier) (c/root-verb-kinds var))]
+                            [var doc-kind]))]
+      (is (= :macro (get by-var "create-root")))
+      (is (= :macro (get by-var "render!")))
+      (is (= :macro (get by-var "hydrate-root")))
+      (is (= :fn    (get by-var "unmount!"))))))
+
+;; ---------------------------------------------------------------------------
+;; create-root LITERAL-OPTION guard (rf2-e9q33).
+;;
+;; Spec 004C fixes create-root's public contract: authored :root-id is
+;; REQUIRED and :disambiguator is INVALID. The tier/kind reconcile cannot see
+;; option grammar. `create-root-option-problems` pins both literal facts on
+;; the create-root row; these fixtures prove the missing-root-id and
+;; admitted-disambiguator cases go RED and the committed row stays green.
+;; ---------------------------------------------------------------------------
+
+(def ^:private create-root-row-in-sync
+  "A create-root API.md row that pins BOTH literal facts (mirrors the
+   committed spec/API.md create-root row)."
+  (str "| `create-root` | M | `(ui/create-root dom-node opts)` → Root | S1 "
+       "| advanced | Identity fixed for the Root's lifetime; authored "
+       "`:root-id` **required** — a missing id is `:rf.ui.compile/missing-root-id` "
+       "and `:disambiguator` is invalid. |"))
+
+(deftest create-root-in-sync-row-produces-no-option-problems
+  (testing "the committed create-root row (pins :root-id required + "
+           ":disambiguator invalid) reconciles clean"
+    (is (empty? (c/create-root-option-problems [[252 create-root-row-in-sync]])))))
+
+(deftest create-root-losing-required-root-id-goes-red
+  (testing "a create-root row that drops the authored-:root-id-REQUIRED
+            assertion fails"
+    (let [row (str "| `create-root` | M | `(ui/create-root dom-node opts)` → Root "
+                   "| S1 | advanced | Identity fixed; `:disambiguator` is invalid. |")
+          problems (c/create-root-option-problems [[252 row]])]
+      (is (= 1 (count problems)))
+      (is (= :root-id-not-required (:kind (first problems))))
+      (is (= 252 (:line (first problems)))))))
+
+(deftest create-root-admitting-disambiguator-goes-red
+  (testing "a create-root row that no longer marks :disambiguator INVALID
+            (silently admitting it) fails"
+    (let [row (str "| `create-root` | M | `(ui/create-root dom-node opts)` → Root "
+                   "| S1 | advanced | authored `:root-id` **required**; "
+                   "`:disambiguator` is now supported. |")
+          problems (c/create-root-option-problems [[252 row]])]
+      (is (= 1 (count problems)))
+      (is (= :disambiguator-admitted (:kind (first problems)))))))
+
+(deftest create-root-losing-both-facts-reports-both
+  (testing "a create-root row that pins neither fact reports both problems"
+    (let [row (str "| `create-root` | M | `(ui/create-root dom-node opts)` → Root "
+                   "| S1 | advanced | Identity fixed for the Root's lifetime. |")
+          kinds (set (map :kind (c/create-root-option-problems [[252 row]])))]
+      (is (= #{:root-id-not-required :disambiguator-admitted} kinds)))))
+
+(deftest create-root-row-missing-goes-red
+  (testing "if the create-root var-row is absent from API.md the guard fails
+            (the grammar cannot be verified against a missing row)"
+    (let [problems (c/create-root-option-problems
+                     [[10 "| `render!` | M | `(ui/render! root root-form)` | S1 | advanced | x |"]])]
+      (is (= 1 (count problems)))
+      (is (= :create-root-row-missing (:kind (first problems)))))))
+
+(deftest option-guard-scopes-required-invalid-to-the-same-cell
+  (testing "the pins require :root-id/:disambiguator and required/invalid in
+            the SAME table cell — required/invalid leaking from OTHER cells
+            of the row does not satisfy the invariant"
+    ;; `required` and `invalid` appear, but in DIFFERENT cells than the
+    ;; :root-id / :disambiguator tokens (pipe-separated), so neither pin holds.
+    (let [row (str "| `create-root` | M | `:root-id` `:disambiguator` "
+                   "| required invalid | advanced | notes |")
+          kinds (set (map :kind (c/create-root-option-problems [[252 row]])))]
+      (is (= #{:root-id-not-required :disambiguator-admitted} kinds)))))
+
+(deftest live-create-root-options-are-pinned
+  (testing "the committed spec/API.md create-root row pins both literal facts
+            (no live option-grammar drift)"
+    (is (empty? (c/create-root-option-problems (c/read-api-md-lines)))
+        "live drift: create-root row lost :root-id-required or :disambiguator-invalid")))


### PR DESCRIPTION
## What

`rf2-e9q33` — the API drift gate (`api_md_check.clj`) did not enforce (a) root
VERB KINDS or (b) create-root's LITERAL OPTIONS, so drift in those slipped
through green.

**Gap (file:line):** `implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj` — the `M/Fn` cell was a boolean row-classifier only (`var-kind-marker?`, ~L88-92) and was **discarded** by the parser (which retained only var/qualifier/tier/line/raw, ~L181-192); `reconcile` compared identity + tier only (~L197-250). Nothing inspected create-root's `:root-id`/`:disambiguator` grammar. So create-root/render!/hydrate-root could flip `M -> Fn` (or unmount! `Fn -> M`), and create-root could drop required `:root-id` or admit `:disambiguator`, and stay GREEN.

## Enforcement added

- Parser now retains `:doc-kind` (the `M/Fn` marker mapped to the manifest `:macro`/`:fn`/`:var` vocabulary; `Component -> nil`).
- `root-verb-kind-problems` — for create-root/render!/hydrate-root/unmount! the documented kind must equal the manifest `:kind` (existing metadata) for the `re-frame.ui` row.
- `create-root-option-problems` — a narrow literal-invariant on the create-root row: it must pin authored `:root-id` **required** and `:disambiguator` **invalid**, each token + qualifier in the same table cell. Not a general Markdown signature parser.
- Both wired into `check!`; `read-api-md-lines` extracted as a shared seam.

Only the gate script + its self-test changed. `spec/API.md` and `spec/api-manifest.edn` are untouched.

## Quality gates

- `clojure -M -m re-frame.api-manifest.api-md-check` → **OK** (214 var-rows) on the committed tree.
- `clojure -M -m re-frame.api-manifest.gen --check` → **OK** (498 vars), unaffected.
- `clojure -M:test` → **74 tests, 143 assertions, 0 failures** (was 59/111). New fixtures prove wrong-kind (create-root/render!/hydrate-root flipped to Fn; unmount! flipped to M), missing-`:root-id`, admitted-`:disambiguator`, unmarked, and same-cell-scoping cases go RED; live smokes prove the committed tree stays green.
- **Full-gate mutation proof** (transient `spec/API.md` edits, each reverted): flipping create-root `M -> Fn`, unmount! `Fn -> M`, dropping `:root-id` required, and admitting `:disambiguator` each turned the gate RED (`EXIT=1`) with a precise message; the restored tree returned to green (`EXIT=0`).
