### PR TITLE
fix(ui): complete cross-frame carried-op schema + production-elision gates (rf2-fagk6)

### DIFF
--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -99,7 +99,20 @@
             ;; reason string (reachable ONLY from the two gated override
             ;; consults) must NOT survive.
             [re-frame.ui :as ui :refer [defview]]
-            [re-frame.ui.reactive :as ui-reactive]))
+            [re-frame.ui.reactive :as ui-reactive]
+            ;; rf2-fagk6 — root the `(frame)` operation-bundle `:subscribe` seam so
+            ;; the dev-only cross-frame carried-op honesty warning
+            ;; (`re-frame.ui.frames/maybe-warn-cross-frame-carried-subscribe!`) sits
+            ;; in the :advanced DCE reachability graph. Its whole body (ambient read,
+            ;; frame comparison, reason string, `:rf.warning/cross-frame-carried-op`
+            ;; emit) is `interop/debug-enabled?`-gated wholesale and must DCE under
+            ;; goog.DEBUG=false. The two live frames the carry crosses are minted via
+            ;; the ENGINE seat `re-frame.frame/upsert-frame!` (NOT the public
+            ;; `make-frame` constructor) so this touch does NOT root the EP-0023
+            ;; image-assembly path — keeping the PROD_ABSENT_WHEN_UNUSED contract
+            ;; (`resolve-within-image`) intact, exactly like `touch-teardown!` /
+            ;; `touch-drain-depth!`.
+            [re-frame.ui.frames :as ui-frames]))
 
 ;; ---- trace listener API ---------------------------------------------------
 
@@ -825,6 +838,48 @@
 (defn ^:export touch-ui-hmr-shell! []
   (react/createElement hmr-shell-elision-probe nil))
 
+;; ---- rf2-fagk6: cross-frame carried-op honesty warning DCE ----------------
+;;
+;; A `(frame)` operation bundle captured under frame A can be CARRIED across a
+;; frame boundary (the HOLD semantics) and its `:subscribe` invoked beneath a
+;; DIFFERENT ambient frame B. Frames are ISOLATED contexts, so the runtime emits
+;; `:rf.warning/cross-frame-carried-op` and CONTINUES against the captured
+;; (origin) frame — advisory only. The whole check (ambient read, comparison,
+;; reason-string build, `:origin-frame` / `:ambient-frame` / `:rf.sub/query-v`
+;; evidence map, and the `trace/emit! :warning` call carrying
+;; `:recovery :warned-and-continued`) is wrapped WHOLE in the outermost
+;; `interop/debug-enabled?` gate in `re-frame.ui.frames/maybe-warn-cross-frame-
+;; carried-subscribe!`, so under :advanced + goog.DEBUG=false the category
+;; keyword, the reason prose, and the evidence/recovery slots must ALL DCE.
+;;
+;; Before rf2-fagk6 no probe rooted `mint-frame-ops` → `fence-subscribe` →
+;; `maybe-warn-cross-frame-carried-subscribe!`, so check-elision.cjs carried no
+;; sentinel for this warning — its production absence was UNVERIFIED (PR #5960's
+;; scope note deferred exactly this touch). This roots the gated emit through a
+;; real cross-frame carry (bundle captured under the origin frame, `:subscribe`
+;; invoked under a FOREIGN ambient frame) so the control build (DEBUG=true)
+;; contains the `rf.warning/cross-frame-carried-op` category keyword, the
+;; `beneath a DIFFERENT ambient frame` reason fragment, and the `origin-frame`
+;; evidence slot, and the production build (DEBUG=false) must DCE them.
+
+(defn ^:export touch-carried-op-cross-frame! []
+  (rf/reg-sub :rf.probe/carried-op-sub (fn [db _q] (:carried-op-n db)))
+  ;; ENGINE seat (frame/upsert-frame!, generation-less) — NOT the public
+  ;; make-frame constructor — so this touch keeps the EP-0023 image-assembly
+  ;; path DCE-able when unused (PROD_ABSENT_WHEN_UNUSED), same as the sibling
+  ;; touches above.
+  (frame/upsert-frame! :rf.probe/carried-op-a {})
+  (frame/upsert-frame! :rf.probe/carried-op-b {})
+  (try
+    ;; Capture the ops bundle under frame A (the committed/origin frame), then
+    ;; invoke its `:subscribe` beneath the FOREIGN frame B — the exact cross-
+    ;; frame carry that fires the honesty warning under DEBUG=true.
+    (let [bundle (rf/with-frame :rf.probe/carried-op-a (ui-frames/frame-ops))]
+      (rf/with-frame :rf.probe/carried-op-b
+        ((:subscribe bundle) [:rf.probe/carried-op-sub])))
+    (catch :default _ nil))
+  (ui-frames/reset-frame-ops-cache!))
+
 (defn ^:export run []
   (touch-direct-emit-diagnostics!)
   (touch-drain-depth!)
@@ -843,6 +898,7 @@
   (touch-doc-metadata!)
   (touch-interceptor-override-summary!)
   (touch-override-capture!)
+  (touch-carried-op-cross-frame!)
   (touch-image-frame-provenance!)
   ;; Reference trace/emit! directly through the trace ns alias so its
   ;; body, not just the public re-frame.core re-export, is reachable.

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -616,7 +616,53 @@ const DEV_ONLY_SENTINELS = [
   { source: 're-frame.ui Fast Refresh slot (dynamic descriptor lookup)',
     sentinel: 'hmr-descriptor' },
   { source: 're-frame.ui Fast Refresh slot (stable inner extra Fiber)',
-    sentinel: 'hmr-inner' }
+    sentinel: 'hmr-inner' },
+  // re-frame.ui.frames — :rf.warning/cross-frame-carried-op DEV-ONLY honesty
+  // warning (rf2-vxgfnd.231 shipped the warning in #5960; rf2-fagk6 pins its
+  // production elision). A CARRIED `(frame)` operation bundle's `:subscribe`
+  // ran beneath a DIFFERENT ambient frame than the one it was captured under;
+  // frames are ISOLATED contexts, so the runtime emits this advisory and
+  // CONTINUES the read against the captured (origin) frame. The whole check —
+  // the ambient read, the `(not= ambient origin-frame)` comparison, the
+  // `:origin-frame` / `:ambient-frame` / `:rf.sub/query-v` EVIDENCE map, the
+  // `:reason` prose, the `:recovery :warned-and-continued` slot, and the
+  // `trace/emit! :warning` call — is wrapped WHOLE in the outermost
+  // `(when interop/debug-enabled? ...)` gate in
+  // `re-frame.ui.frames/maybe-warn-cross-frame-carried-subscribe!`, so under
+  // :advanced + goog.DEBUG=false the ENTIRE body DCEs. The elision-probe's
+  // `touch-carried-op-cross-frame!` roots the gated emit through a real cross-
+  // frame carry (bundle captured under origin frame A, `:subscribe` invoked
+  // under a FOREIGN ambient frame B), so the control build (DEBUG=true) contains
+  // these sentinels and the production build (DEBUG=false) must DCE them.
+  //
+  // Three sentinels give the acceptance contract explicit teeth:
+  //   1. the CATEGORY keyword — proves the whole `trace/emit!` call (and the op
+  //      keyword's string) erases. Warning category keywords elide cleanly (they
+  //      are NOT referenced by the always-reachable marks chokepoint
+  //      `re-frame.classification/project-trace-event`, exactly like the sibling
+  //      `rf.warning/missing-doc` / `rf.warning/teardown-hook-exception` above).
+  { source: 're-frame.ui.frames/maybe-warn-cross-frame-carried-subscribe! (rf.warning/cross-frame-carried-op category)',
+    sentinel: 'rf.warning/cross-frame-carried-op' },
+  //   2. the distinctive `:reason` prose fragment — proves the reason-string
+  //      build (which interpolates the origin/query/ambient EVIDENCE via
+  //      `pr-str`) erases. It is one intact string literal between two `pr-str`
+  //      calls in the `(str …)` reason, unique to `ui/frames.cljc` under a global
+  //      grep.
+  { source: 're-frame.ui.frames/maybe-warn-cross-frame-carried-subscribe! (:reason prose)',
+    sentinel: 'beneath a DIFFERENT ambient frame' },
+  //   3. the `:origin-frame` EVIDENCE slot keyword — proves the evidence map's
+  //      key literal erases. `origin-frame` is unique to `ui/frames.cljc` in
+  //      production source (the sibling `:ambient-frame` slot is NOT a usable
+  //      sentinel — its string legitimately survives via other production
+  //      namespaces, e.g. core call-site macros / observation / viewcell — so a
+  //      keyword sentinel there would be a false production-leak positive). The
+  //      `:recovery :warned-and-continued` slot rides the SAME gated emit map as
+  //      these three, so its erasure is transitively proven by them (a keyword
+  //      sentinel for `warned-and-continued` is deliberately NOT added: the
+  //      literal is shared with the sibling dev-only `re-frame.ui.events`
+  //      warnings, so it would couple this gate to a foreign surface's elision).
+  { source: 're-frame.ui.frames/maybe-warn-cross-frame-carried-subscribe! (:origin-frame evidence slot)',
+    sentinel: 'origin-frame' }
   // Note (rf2-7yqn39): the :rf.warning/plain-fn-under-non-default-frame-
   // once warning + its emit helper were RETIRED (EP-0002; superseded by
   // the always-on :rf.error/no-frame-context). There is no longer any

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -775,7 +775,7 @@ Universal trace event shape, including error events.
    [:time      :any]                                                       ;; emit timestamp (host clock)
    [:tags      {:optional true} [:map-of :keyword :any]]                   ;; op-type-specific payload
    [:source    {:optional true} :keyword]                                  ;; (when present) the trigger source
-   [:recovery  {:optional true} [:enum :no-recovery :replaced-with-default :retried :skipped :warned-and-replaced :logged-and-skipped :ignored]]
+   [:recovery  {:optional true} [:enum :no-recovery :replaced-with-default :retried :skipped :warned-and-replaced :warned-and-continued :logged-and-skipped :ignored]]
    [:rf.trace/trigger-handler {:optional true}                              ;; (when present) the in-scope handler at emit time
                               [:map
                                [:kind         [:enum :event :sub :fx :cofx :view]]
@@ -845,7 +845,7 @@ A refinement of `:rf/trace-event` for the unified error/warning envelope. Every 
    [:op-type   [:enum :error :warning]]         ;; :error for failures; :warning for advisories
    [:time      :any]                            ;; emit timestamp (host clock)
    [:source    {:optional true} :keyword]
-   [:recovery  {:optional true} [:enum :no-recovery :replaced-with-default :retried :skipped :warned-and-replaced :logged-and-skipped :ignored]]
+   [:recovery  {:optional true} [:enum :no-recovery :replaced-with-default :retried :skipped :warned-and-replaced :warned-and-continued :logged-and-skipped :ignored]]
    [:rf.trace/trigger-handler {:optional true}
                               [:map
                                [:kind         [:enum :event :sub :fx :cofx :view]]
@@ -1979,6 +1979,35 @@ Common keys (`:category`, `:failing-id`, `:reason`, `:frame`) are inherited from
    [:other-frame  :keyword]                          ;; an arbitrary mid-drain sibling — typically the caller's frame
    [:event        [:vector :any]]
    [:reason       :string]])
+
+;; --- warning: a CARRIED `(frame)` operation bundle's `:subscribe` ran under a foreign ambient frame ---
+;; `:rf.warning/cross-frame-carried-op` (rf2-vxgfnd.231) — a `(frame)` operation
+;; bundle captured under `:origin-frame` was CARRIED across a frame boundary (the
+;; HOLD semantics) and its `:subscribe` invoked beneath a DIFFERENT `:ambient-frame`.
+;; Frames are ISOLATED contexts (a subscription MUST NOT reach across a frame
+;; boundary), so the runtime emits this advisory and CONTINUES the read against the
+;; captured (origin) frame — never a retarget, never a refusal. QUIET when ambient
+;; equals origin (the ordinary in-scope read) or names no frame (an async hop / top-
+;; of-stack caller); NARROW to `:subscribe` (a carried dispatch drives its locked
+;; frame and does not warn). Dev-only — the whole check (ambient read, comparison,
+;; reason string, emit) is `interop/debug-enabled?`-gated wholesale and DCEs under
+;; `:advanced` + `goog.DEBUG=false` (pinned by `check-elision.cjs`; the emit is
+;; sourced by `re-frame.elision-probe/touch-carried-op-cross-frame!`). `:recovery`
+;; rides the envelope top-level after the emit-time hoist (per §`:rf/trace-event`);
+;; pinned here to `:warned-and-continued` for the per-category contract. Emitted by
+;; `re-frame.ui.frames/maybe-warn-cross-frame-carried-subscribe!`. Per the [009 error
+;; catalogue row](009-Instrumentation.md#error-event-catalogue), [002 §Frame target
+;; resolution](002-Frames.md#frame-target-resolution--the-carried-invariant), and
+;; [004 §Roots and mounting](004-Views.md#roots-and-mounting).
+
+(def CrossFrameCarriedOpTags
+  [:map
+   [:category       [:= :rf.warning/cross-frame-carried-op]]
+   [:origin-frame   :keyword]                        ;; the captured (committed) frame the bundle was minted under
+   [:ambient-frame  :keyword]                        ;; the foreign ambient frame the carried `:subscribe` ran beneath
+   [:rf.sub/query-v [:vector :any]]                  ;; the attempted subscription query vector (the read that CONTINUED against origin)
+   [:reason         :string]
+   [:recovery       [:= :warned-and-continued]]])     ;; the read proceeds against the CAPTURED origin frame — advisory only
 
 (def DecodeDefaultedTags
   [:map


### PR DESCRIPTION
## What

PR #5960 shipped the dev-only `:rf.warning/cross-frame-carried-op` honesty warning (rf2-vxgfnd.231) but left two source-bead acceptance gates unlanded (rf2-fagk6):

1. the category had **no per-category `:tags` schema** in `spec/Spec-Schemas.md`; and
2. the production-elision checker carried **no sentinel** for it — its production absence was never verified (a leaked-but-false prod branch could pass unnoticed).

This lands both. Runtime semantics and public API are unchanged — `ui/frames.cljc` is untouched; development behaviour is exactly as shipped in #5960.

## Schema (`spec/Spec-Schemas.md`)

- **`CrossFrameCarriedOpTags`** — the per-category `:tags` contract: `:origin-frame`, `:ambient-frame`, `:rf.sub/query-v` (query evidence), `:reason`, and `[:recovery [:= :warned-and-continued]]`. Placed next to its sibling `CrossFrameDispatchSyncDuringDrainTags`.
- **`:warned-and-continued` added to the `TraceEvent` + `ErrorEvent` `:recovery` enums.** The shipped runtime hoists `:recovery` top-level at emit time (per `build-event`), and `:warned-and-continued` was absent from the enum — so the emitted value failed the normative schema. The addition makes the schema true-to-shipped and also covers the two sibling `re-frame.ui.events` warnings (`unregistered-event-id`, `placeholder-in-dynamic-vector`) that already emit it.

## Elision gate (`scripts/check-elision.cjs` + `elision_probe.cljs`)

- `elision-probe` gains `touch-carried-op-cross-frame!`, rooting `mint-frame-ops` → `fence-subscribe` → `maybe-warn-cross-frame-carried-subscribe!` through a **real cross-frame carry** (bundle captured under origin frame A, `:subscribe` invoked under foreign frame B). It uses the **engine seat `frame/upsert-frame!`** (not the public `make-frame` constructor) so it does **not** root the EP-0023 image-assembly path — `PROD_ABSENT_WHEN_UNUSED` stays intact (the same discipline as `touch-teardown!` / `touch-drain-depth!`).
- Three `DEV_ONLY_SENTINELS` pin the **category** keyword (`rf.warning/cross-frame-carried-op`), the **`:reason` prose** (`beneath a DIFFERENT ambient frame`), and the **`:origin-frame` evidence slot**. The `:warned-and-continued` recovery rides the same gated emit map (transitively proven); no standalone sentinel is added for it (the literal is shared with the sibling `re-frame.ui.events` warnings, so a sentinel there would couple this gate to a foreign surface).

Finding along the way: elision here is **two-layered** — the `(when interop/debug-enabled? ...)` wrapper *and* the `trace/emit!` body-fold that drops the pure keyword/reason/map args as dead in production (the documented rf2-tfiutq direct-call fold). Neutralising only the wrapper does not leak, which is why the mutation proof below drives the bundle-under-test, not the wrapper alone.

## Coordination

No collision with the in-flight `.95.2` compiler work: `ui/frames.cljc` is **not** edited (a transient mutation used for the turns-red proof was reverted; it is absent from the diff). `009-Instrumentation.md` is untouched (the catalogue row already exists). Only `Spec-Schemas.md` (owned this round), the gate script, and the probe change.

## Quality gates

- `cd implementation && npm run test:elision` — **PASS**: `production 55/55 absent (was 52/52 + my 3); EP-0023 1/1 provenance-survives + 2/2 assembly-DCE; control 55/55 present`.
- **Mutation proof (turns RED):** running the real `check-elision.cjs` production absence-check against a bundle where the carried-op strings survive (the `goog.DEBUG=true` control build compiled from the identical probe) flips all three sentinels: `[FAIL] rf.warning/cross-frame-carried-op … expected ABSENT, was PRESENT`, `[FAIL] beneath a DIFFERENT ambient frame … was PRESENT`, `[FAIL] origin-frame … was PRESENT` → `Production elision broke`, exit 1. Restored to green afterward.
- `python -m mkdocs build --strict` — **PASS** (0 warnings under `--strict`).
- `python scripts/check_doc_slugs.py` — **PASS**.
- `npm run test:cljs` — **not run / not applicable**: the schema is normative markdown in `Spec-Schemas.md` (no runtime registry imports the `*Tags` schemas — not core-reachable), and the only CLJS touched (`elision_probe.cljs`) is compiled + linked under `:advanced` by the elision-probe build and is required by no test namespace (verified), so it is not in the node test build.

Closes rf2-fagk6.
