### PR TITLE
fix(subs): surface native derived subscriber failures after contained fan-out (rf2-qcmzc)

### DIFF
--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -107,64 +107,102 @@
    :queue     (volatile! [])  ;; ordered queue of pending flush thunks
    :queued    (volatile! #{})}) ;; identity set guarding double-enqueue
 
+(def ^:private capture-none
+  "Presence sentinel shared by the two failure seams — the derived fan-out's
+  first-thrown capture (`notify`) and the scheduler drain's first-escape
+  capture (`drain-scheduler!`). A distinct object identity so a subscriber /
+  recompute that throws `nil`/`false` (both legal CLJS throws) is still
+  recorded and re-raised by PRESENCE — never masked by a truthiness test
+  (rf2-vxgfnd.203, rf2-qcmzc)."
+  (js-obj))
+
 (defn- drain-scheduler!
   "Drain the scheduler's pending flush thunks in enqueue order until the
   queue is empty. Re-entrant-safe: an in-progress drain swallows nested
   drain requests (the running loop already observes newly-enqueued
-  thunks). Each thunk recomputes its derived value and, on a `=`-change,
+  thunks). Each thunk recomputes its derived value and, on a movement,
   notifies its watchers — which may enqueue downstream thunks that the
   same loop then drains, preserving topological order.
 
-  Per-thunk throw isolation (rf2-l3lelt). On the production sub graph a
-  flush thunk never throws: the spine compute-fn is
-  `subs.memo/validate-and-trace`, which brackets the user sub body in
-  `try/catch`, emits `:rf.error/sub-exception`, and recovers to nil. A
-  non-catching compute-fn (a RAW derived value built by tooling/tests)
-  can throw, though — and a throw propagating out of the bare drain loop
-  STRANDED every downstream thunk still queued behind it: the `finally`
-  retained them in `@queue`, but their `dirty?` flag stayed `true`, so
-  `mark-dirty!` (guarded by `(when-not @dirty? …)`) could never re-enqueue
-  them on a later source change — a latent stuck-dirty strand. Mirroring
-  `drain-after-render-queue!`, each thunk now runs inside its own
-  `try/catch` that swallows: one misbehaving thunk cannot strand the rest,
-  and the loop drains to completion (the throwing thunk's own `dirty?` was
-  already cleared by `flush!` before `recompute`, so it leaves no stuck
-  guard either)."
+  Per-thunk isolation WITH first-escape surfacing (rf2-l3lelt + rf2-qcmzc).
+  On the production sub graph a flush thunk never throws: the spine
+  compute-fn is `subs.memo/validate-and-trace`, which brackets the user sub
+  body in `try/catch`, emits `:rf.error/sub-exception`, and recovers to nil.
+  A non-catching compute-fn (a RAW derived value built by tooling/tests),
+  or a throwing derived SUBSCRIBER (whose escape the fan-out `notify`
+  re-raises after delivering every sibling), CAN throw though — and this
+  seam owes TWO disciplines at once:
+
+    1. Don't STRAND the tail (rf2-l3lelt). A throw propagating out of a bare
+       drain loop stranded every downstream thunk still queued behind it:
+       the `finally` retained them in `@queue`, but their `dirty?` flag
+       stayed `true`, so `mark-dirty!` (guarded by `(when-not @dirty? …)`)
+       could never re-enqueue them on a later source change — a latent
+       stuck-dirty strand. So each thunk runs inside its own `try/catch` and
+       the loop drains every remaining thunk to completion regardless.
+
+    2. Don't SWALLOW the failure (rf2-qcmzc). The earlier per-thunk guard
+       DISCARDED every escape (`(catch :default _ nil)`), so a programmer
+       error in a raw derived value / subscriber vanished silently and the
+       fan-out's careful re-raise reached a dead end — the source bead's
+       observability criterion unmet. Instead the loop CAPTURES the FIRST
+       escape by PRESENCE (`capture-none`, not truthiness — `nil`/`false`
+       are legal CLJS throws whose identity must survive), keeps draining
+       the tail, restores scheduler state in the `finally`, and THEN
+       re-raises the retained value to the caller (`replace-container!` / a
+       direct source mutation) — the established caller/error channel. The
+       primary failure surfaces WITH identity preserved, AFTER every sibling
+       has been delivered.
+
+  The throwing thunk's own `dirty?` was already cleared by `flush!` before
+  `recompute`, so it leaves no stuck guard either. Queued / re-entrant
+  writes a subscriber triggers mid-drain are a later pass; the FIRST escape
+  is the one surfaced."
   [{:keys [flushing? queue queued] :as _scheduler}]
   (when-not @flushing?
     (vreset! flushing? true)
     ;; Walk the live `@queue` by index rather than re-slicing the head: a
     ;; thunk may `schedule-flush!` downstream thunks, which `conj` onto the
     ;; same vector, so re-reading `(count @queue)` each step keeps the
-    ;; running loop observing newly-enqueued thunks in enqueue order —
-    ;; identical to the previous incremental-`subvec` drain, but without
-    ;; building a chain of nested subvec views per cascade step. The
+    ;; running loop observing newly-enqueued thunks in enqueue order. The
     ;; cursor advances and the entry leaves `queued` BEFORE the thunk runs,
     ;; so a thunk that throws is already considered consumed (matching the
-    ;; old head-pop-before-call ordering). A per-thunk `try/catch` (see the
-    ;; docstring) isolates a throwing thunk so the loop still drains the
-    ;; downstream tail to completion; the `finally` then releases the
-    ;; backing vector for the next epoch.
-    (let [cursor (volatile! 0)]
+    ;; old head-pop-before-call ordering). The per-thunk `try/catch` (see the
+    ;; docstring) BOTH isolates a throwing thunk so the loop drains the
+    ;; downstream tail to completion AND retains its escape for surfacing;
+    ;; the `finally` then restores scheduler state for the next epoch.
+    (let [cursor   (volatile! 0)
+          captured (volatile! capture-none)]
       (try
         (loop []
           (when (< @cursor (count @queue))
             (let [thunk (nth @queue @cursor)]
               (vswap! queued disj thunk)
               (vswap! cursor inc)
-              ;; Per-thunk throw isolation (rf2-l3lelt): swallow so one
-              ;; throwing thunk cannot strand the not-yet-drained tail —
-              ;; mirrors `drain-after-render-queue!`'s per-callback guard.
-              (try (thunk) (catch :default _ nil)))
+              ;; Per-thunk isolation + first-escape capture (rf2-l3lelt +
+              ;; rf2-qcmzc): retain the FIRST escape by presence so it can be
+              ;; surfaced after the drain, while the loop still drains the
+              ;; not-yet-run tail. `capture-none`/`nil`/`false` safe.
+              (try (thunk)
+                   (catch :default e
+                     (when (identical? capture-none @captured)
+                       (vreset! captured e)))))
             (recur)))
         (finally
-          ;; The loop now consumes `@queue` to empty on every
-          ;; non-re-entrant exit (per-thunk isolation means no throw escapes
-          ;; the loop), so the cursor reaches the end and this releases the
-          ;; backing vector for the next epoch. Re-entrant drains still
-          ;; short-circuit on `@flushing?` above and never reach here.
+          ;; The loop consumes `@queue` to empty on every non-re-entrant exit
+          ;; (per-thunk capture means no throw escapes the loop), so the
+          ;; cursor reaches the end and this releases the backing vector for
+          ;; the next epoch. Re-entrant drains short-circuit on `@flushing?`
+          ;; above and never reach here.
           (vreset! queue [])
-          (vreset! flushing? false))))))
+          (vreset! flushing? false)))
+      ;; Scheduler state is restored; NOW surface the FIRST retained escape
+      ;; through the caller/error channel (rf2-qcmzc). Re-raised OUTSIDE the
+      ;; try/finally so scheduler state is clean for the next epoch even on
+      ;; this path, and so the `finally`'s own resets can never mask the
+      ;; primary failure.
+      (when-not (identical? capture-none @captured)
+        (throw @captured)))))
 
 (defn- schedule-flush!
   "Enqueue `thunk` on the scheduler (dedup by identity within the current
@@ -314,13 +352,6 @@
   (or ^boolean (js/Object.is a b)
       (= a b)))
 
-(def ^:private capture-none
-  "Presence sentinel for the derived fan-out's first-thrown capture: a distinct
-  object identity so a subscriber that throws `nil`/`false` (both legal CLJS
-  throws) is still recorded and re-raised by PRESENCE — never masked by a
-  truthiness test (rf2-vxgfnd.203)."
-  (js-obj))
-
 (defn build-recompute-fn
   "Arity-specialised recompute-closure factory for a derived value.
 
@@ -407,26 +438,48 @@
           ;;      The `unset` baseline is never `rf=` a real value, so the first
           ;;      post-construction change still notifies (unchanged).
           ;;
-          ;;   2. CONTAIN a throwing subscriber. Bare `run!` aborted at the
-          ;;      first throw, skipping every later sibling, and the scheduler's
-          ;;      per-thunk drain guard silently swallowed the escape — so ONE
-          ;;      subscriber could permanently suppress another's invalidation,
-          ;;      order-dependently. Instead: snapshot the callbacks (an
-          ;;      add/remove-watch during fan-out is an immutable-map swap, so
-          ;;      this seq is stable and the change lands on the NEXT wave),
-          ;;      attempt EVERY subscriber independently, capture the FIRST
-          ;;      thrown value by PRESENCE (`capture-none`, not truthiness —
-          ;;      `nil`/`false` are legal CLJS throws), then re-raise it AFTER
-          ;;      delivery so the primary failure still surfaces through the
-          ;;      established scheduler error channel (the drain's per-thunk
-          ;;      isolation, rf2-l3lelt) rather than disappearing inside the
-          ;;      fan-out. `vals` over the map (rather than `doseq` over
-          ;;      map-entries) skips a map-entry seq allocation; the zero-
-          ;;      subscriber and no-move paths allocate nothing extra.
+          ;;   2. CONTAIN a throwing subscriber, then SURFACE the primary
+          ;;      failure. Bare `run!` aborted at the first throw, skipping
+          ;;      every later sibling, so ONE subscriber could permanently
+          ;;      suppress another's invalidation, order-dependently. Instead:
+          ;;      snapshot the callbacks (an add/remove-watch during fan-out is
+          ;;      an immutable-map swap, so this seq is stable and the change
+          ;;      lands on the NEXT wave), attempt EVERY subscriber
+          ;;      independently, capture the FIRST thrown value by PRESENCE
+          ;;      (`capture-none`, not truthiness — `nil`/`false` are legal
+          ;;      CLJS throws), then re-raise it AFTER delivery. That re-raise
+          ;;      escapes `flush!` into `drain-scheduler!`, which (rf2-qcmzc)
+          ;;      retains it by presence, drains the rest, restores scheduler
+          ;;      state, and re-raises it to the caller (`replace-container!` /
+          ;;      a direct source mutation) — the established caller/error
+          ;;      channel. So the primary failure SURFACES with identity
+          ;;      preserved rather than disappearing inside the fan-out. (The
+          ;;      earlier code re-raised into a per-thunk drain guard that
+          ;;      SWALLOWED it — the swallow rf2-qcmzc removes.)
+          ;;
+          ;;      Common-path preservation (rf2-vxgfnd.203). The dominant
+          ;;      cardinality is one subscriber (a cache entry's own watch);
+          ;;      that path — and the zero-subscriber / no-move paths — allocate
+          ;;      NOTHING extra: `count` on the map is O(1), and the single
+          ;;      subscriber (no sibling to protect) is invoked directly, its
+          ;;      throw propagating straight through `flush!` into the drain,
+          ;;      which surfaces it identically. Only two-plus subscribers pay
+          ;;      the capture volatile + `run!` closure.
           notify         (fn [prev nu]
                            (when-not (rf= prev nu)
-                             (let [ws (vals @watchers)]
-                               (when (seq ws)
+                             (let [ws @watchers]
+                               (case (count ws)
+                                 0 nil
+                                 ;; Single subscriber: no sibling to protect →
+                                 ;; no capture cell, invoke directly. A throw
+                                 ;; propagates through `flush!` into the drain,
+                                 ;; which surfaces it (rf2-qcmzc) — same outcome,
+                                 ;; zero extra allocation on the common path.
+                                 1 ((val (first ws)) prev nu)
+                                 ;; Two+ subscribers: attempt each independently,
+                                 ;; capture the FIRST escape by presence, re-raise
+                                 ;; after delivery (surfaced via the drain).
+                                 ;; `vals` over the map skips a map-entry seq.
                                  (let [captured (volatile! capture-none)]
                                    (run! (fn [w]
                                            (try
@@ -434,7 +487,7 @@
                                              (catch :default e
                                                (when (identical? capture-none @captured)
                                                  (vreset! captured e)))))
-                                         ws)
+                                         (vals ws))
                                    (when-not (identical? capture-none @captured)
                                      (throw @captured)))))))
           ;; Baseline derived value. LAZY (rf2-ee38b.1 P2): seeded with the

--- a/implementation/core/test/re_frame/substrate/spine_glitch_free_cljs_test.cljs
+++ b/implementation/core/test/re_frame/substrate/spine_glitch_free_cljs_test.cljs
@@ -259,16 +259,17 @@
       (is (= 0 @body-runs)
           "the disposed reaction's flush did not recompute on drain"))))
 
-;; ---- throw mid-drain does NOT strand downstream thunks --------------------
-;; (rf2-l3lelt)
+;; ---- throw mid-drain: drains the tail (no strand) AND surfaces ------------
+;; (rf2-l3lelt + rf2-qcmzc)
 
 (deftest throwing-thunk-mid-drain-does-not-strand-downstream
   (testing "a derived value whose compute-fn THROWS during the epoch drain
             must not strand the downstream thunks still queued behind it:
-            the throw is contained (it does not escape replace-container!),
-            the surviving sibling drains its flush in the SAME epoch, and —
-            critically — its dirty? guard is cleared so a LATER source change
-            can re-enqueue it (no stuck-dirty strand).
+            the surviving sibling drains its flush in the SAME epoch (BEFORE
+            the throw surfaces), its dirty? guard is cleared so a LATER source
+            change can re-enqueue it (no stuck-dirty strand), AND the throw is
+            SURFACED to the caller after the drain completes (rf2-qcmzc)
+            rather than swallowed by the per-thunk guard.
 
             Wiring mirrors the real graph: both layer-1 values watch the root
             and so both enqueue a flush thunk on the ONE shared scheduler per
@@ -295,13 +296,18 @@
       ;; Arm the throw, then ONE replace-container! queues BOTH flush thunks;
       ;; the thrower's recompute throws mid-drain.
       (reset! boom? true)
-      (is (nil? (replace! root {:a 99 :b 20}))
-          "the mid-drain throw is contained — replace-container! returns
-           normally (the per-thunk guard swallows; the throw does not escape
-           the drain)")
+      (let [caught (atom ::none)]
+        (try (replace! root {:a 99 :b 20})
+             (catch :default e (reset! caught e)))
+        (is (instance? js/Error @caught)
+            "the mid-drain recompute throw is SURFACED to the caller AFTER the
+             drain (rf2-qcmzc) — no longer swallowed by the per-thunk guard")
+        (is (= "boom" (.-message @caught))
+            "the surfaced value is the original thrown error (identity carried
+             through the drain's caller/error channel)"))
       (is (= [[10 20]] @notes)
-          "the survivor's flush STILL ran in the same epoch — it was not
-           stranded behind the throwing thunk")
+          "the survivor's flush STILL ran in the same epoch BEFORE the throw
+           surfaced — it was not stranded behind the throwing thunk")
       (is (= 20 @survivor) "survivor deref reflects the settled value")
       ;; The load-bearing strand assertion: disarm the throw and change the
       ;; survivor's slice AGAIN. With the bug its dirty? was stuck true (its
@@ -330,8 +336,11 @@
       (add-watch thrower :w (fn [_ _ prev nu] (swap! notes conj [prev nu])))
       ;; First write throws mid-drain.
       (reset! boom? true)
-      (is (nil? (replace! root {:a 2 :b 10}))
-          "the throw is contained")
+      (let [caught (atom ::none)]
+        (try (replace! root {:a 2 :b 10})
+             (catch :default e (reset! caught e)))
+        (is (instance? js/Error @caught)
+            "the throw is SURFACED to the caller after the drain (rf2-qcmzc)"))
       (is (= [] @notes)
           "the throwing flush did not notify (its recompute never returned)")
       ;; Disarm; a fresh change must re-enqueue + flush the (formerly
@@ -399,9 +408,10 @@
   (testing "with the throwing subscriber registered FIRST (drained first), a
             later sibling still receives the same movement. Bare `run!`
             aborted at the throw and skipped every later subscriber; the fan-
-            out now attempts each independently. The throw is contained — it
-            re-raises through the scheduler's per-thunk drain isolation, so
-            replace-container! returns normally. (rf2-vxgfnd.203)"
+            out now attempts each independently, then re-raises the captured
+            failure AFTER delivery — the drain surfaces it to the caller
+            (rf2-qcmzc), so replace-container! throws the primary value while
+            every sibling still fired. (rf2-vxgfnd.203 + rf2-qcmzc)"
     (let [{:keys [make-derived replace! root]} (build-graph)
           l1      (make-derived [root] (fn [db] (:a db)))
           a-fired (atom 0)
@@ -412,12 +422,17 @@
                          (swap! a-fired inc)
                          (throw (js/Error. "subscriber A boom"))))
       (add-watch l1 :b (fn [_ _ _ _] (swap! b-fired inc)))
-      (is (nil? (replace! root {:a 2 :b 10}))
-          "the subscriber throw is contained — replace-container! returns nil")
-      (is (= 1 @a-fired) "the throwing subscriber ran")
-      (is (= 1 @b-fired)
-          "the later sibling STILL fired despite A throwing (bare run! would
-           have skipped it)"))))
+      (let [caught (atom ::none)]
+        (try (replace! root {:a 2 :b 10})
+             (catch :default e (reset! caught e)))
+        (is (= 1 @a-fired) "the throwing subscriber ran")
+        (is (= 1 @b-fired)
+            "the later sibling STILL fired despite A throwing (bare run! would
+             have skipped it)")
+        (is (and (instance? js/Error @caught)
+                 (= "subscriber A boom" (.-message @caught)))
+            "A's throw is SURFACED to the caller AFTER B was delivered
+             (rf2-qcmzc) — not swallowed inside the fan-out")))))
 
 (deftest throwing-subscriber-delivery-is-order-independent
   (testing "a throwing subscriber in the MIDDLE of the registration order does
@@ -436,17 +451,25 @@
                          (swap! fired conj :a)
                          (throw (js/Error. "middle subscriber boom"))))
       (add-watch l1 :c (fn [_ _ _ _] (swap! fired conj :c)))
-      (is (nil? (replace! root {:a 2 :b 10}))
-          "the middle throw is contained")
-      (is (= #{:a :b :c} @fired)
-          "every subscriber fired — the earlier (:b), the thrower (:a), AND the
-           later (:c) sibling a bare run! would have skipped"))))
+      (let [caught (atom ::none)]
+        (try (replace! root {:a 2 :b 10})
+             (catch :default e (reset! caught e)))
+        (is (= #{:a :b :c} @fired)
+            "every subscriber fired — the earlier (:b), the thrower (:a), AND the
+             later (:c) sibling a bare run! would have skipped")
+        (is (and (instance? js/Error @caught)
+                 (= "middle subscriber boom" (.-message @caught)))
+            "the middle subscriber's throw is SURFACED to the caller after ALL
+             siblings were delivered (rf2-qcmzc)")))))
 
-(deftest falsey-subscriber-throws-are-contained-by-presence
+(deftest falsey-subscriber-throws-are-surfaced-by-presence
   (testing "a subscriber that throws a FALSEY value (`false` / `nil` — both
             legal CLJS throws) is captured by PRESENCE, so a later sibling
-            still fires and the primary failure is not masked by a truthiness
-            test. (rf2-vxgfnd.203)"
+            still fires AND the primary failure is SURFACED to the caller with
+            its exact identity — never masked by a truthiness test. Against
+            #5961 the falsey value was captured but the whole failure was then
+            swallowed by the drain, so the caller saw nil either way; this pins
+            that the caller observes the ORIGINAL falsey throw. (rf2-qcmzc)"
     (doseq [thrown-val [false nil]]
       (let [{:keys [make-derived replace! root]} (build-graph)
             l1      (make-derived [root] (fn [db] (:a db)))
@@ -454,8 +477,159 @@
         (is (= 1 @l1) "baseline deref establishes prev-state")
         (add-watch l1 :a (fn [_ _ _ _] (throw thrown-val)))
         (add-watch l1 :b (fn [_ _ _ _] (swap! b-fired inc)))
-        (is (nil? (replace! root {:a 2 :b 10}))
-            (str "a `" (pr-str thrown-val) "` throw is contained"))
+        (let [caught (atom ::none)
+              threw? (atom false)]
+          (try (replace! root {:a 2 :b 10})
+               (catch :default e (reset! threw? true) (reset! caught e)))
+          (is @threw?
+              (str "replace! SURFACED the `" (pr-str thrown-val) "` throw — "
+                   "presence capture means a falsey primary is not lost"))
+          (is (identical? thrown-val @caught)
+              (str "the surfaced value IS the original `" (pr-str thrown-val)
+                   "` throw — identity preserved by presence, not truthiness"))
+          (is (= 1 @b-fired)
+              (str "sibling still fired after the `" (pr-str thrown-val)
+                   "` throw — captured by presence, delivered before surfacing")))))))
+
+;; ---- native derived subscriber failures SURFACE after fan-out -------------
+;; (rf2-qcmzc)
+;;
+;; #5961 contained a throwing derived subscriber (every sibling still
+;; delivers) and re-raised the captured value AFTER delivery — but that
+;; re-raise escaped `flush!` straight into `drain-scheduler!`'s per-thunk
+;; `(catch :default _ nil)`, which DISCARDED it. So the primary failure
+;; vanished silently: `replace-container!` returned normally and the
+;; programmer error never surfaced. These tests observe the ORIGINAL thrown
+;; value at the caller (identity preserved), which is exactly what the
+;; swallowing #5961 path could not deliver — they are RED against #5961.
+
+(deftest primary-subscriber-throw-surfaces-with-object-identity
+  (testing "the FIRST subscriber's thrown value is SURFACED to the caller with
+            EXACT object identity preserved, AFTER every later sibling has been
+            delivered. #5961 delivered the siblings but the drain swallowed the
+            primary, so the caller never observed the thrown object; rf2-qcmzc
+            surfaces it through the drain's caller/error channel. (rf2-qcmzc)"
+    (let [{:keys [make-derived replace! root]} (build-graph)
+          l1       (make-derived [root] (fn [db] (:a db)))
+          ;; A distinct object — assert IDENTITY, not just class/message, so
+          ;; nothing along the fan-out→drain→caller path can substitute a
+          ;; look-alike.
+          sentinel (js/Error. "primary failure")
+          b-fired  (atom 0)]
+      (is (= 1 @l1) "baseline deref establishes prev-state")
+      ;; :a registered FIRST → throws the sentinel; :b registered second.
+      (add-watch l1 :a (fn [_ _ _ _] (throw sentinel)))
+      (add-watch l1 :b (fn [_ _ _ _] (swap! b-fired inc)))
+      (let [caught (atom ::none)]
+        (try (replace! root {:a 2 :b 10})
+             (catch :default e (reset! caught e)))
+        (is (identical? sentinel @caught)
+            "the EXACT thrown object surfaced to the caller — identity preserved
+             through the fan-out capture AND the drain caller/error channel")
         (is (= 1 @b-fired)
-            (str "sibling still fired after a `" (pr-str thrown-val)
-                 "` throw — captured by presence, not truthiness"))))))
+            "the later sibling was delivered BEFORE the primary surfaced")))))
+
+(deftest single-subscriber-throw-surfaces-on-fast-path
+  (testing "the allocation-free single-subscriber fast path still SURFACES a
+            throwing subscriber's failure with identity preserved. With exactly
+            one watcher there is no sibling to protect, so the fan-out invokes
+            it directly (no capture volatile) and its throw propagates through
+            flush! into the drain, which surfaces it to the caller. Guards
+            against the fast path silently dropping the sole subscriber's throw.
+            (rf2-qcmzc common-path preservation)"
+    (let [{:keys [make-derived replace! root]} (build-graph)
+          l1       (make-derived [root] (fn [db] (:a db)))
+          sentinel (js/Error. "solo boom")]
+      (is (= 1 @l1) "baseline deref establishes prev-state")
+      (add-watch l1 :only (fn [_ _ _ _] (throw sentinel)))
+      (let [caught (atom ::none)]
+        (try (replace! root {:a 2 :b 10})
+             (catch :default e (reset! caught e)))
+        (is (identical? sentinel @caught)
+            "the sole subscriber's throw surfaced with identity preserved on the
+             allocation-free fast path")))))
+
+;; ---- watcher add/remove during fan-out lands on the NEXT wave --------------
+;; (rf2-qcmzc — snapshot semantics)
+
+(deftest watcher-add-remove-during-fan-out-snapshots-to-next-wave
+  (testing "the fan-out iterates a SNAPSHOT of the watcher map (@watchers is an
+            immutable map derefed once). A subscriber that add-watches / remove-
+            watches DURING fan-out therefore lands on the NEXT movement, not the
+            current one: a watcher REMOVED mid-fan-out still fires this wave (it
+            is in the snapshot), and a watcher ADDED mid-fan-out does NOT fire
+            this wave (it is not). On the following movement the roles flip.
+            (rf2-qcmzc)"
+    (let [{:keys [make-derived replace! root]} (build-graph)
+          l1      (make-derived [root] (fn [db] (:a db)))
+          a-count (atom 0)
+          c-count (atom 0)
+          d-count (atom 0)
+          mutated (atom false)]
+      (is (= 1 @l1) "baseline deref establishes prev-state")
+      ;; Registration (== iteration) order: :a, :mutator, :c. The mutator, on
+      ;; the FIRST wave only, adds :d and removes :c — mutating the watchers
+      ;; atom mid-fan-out.
+      (add-watch l1 :a (fn [_ _ _ _] (swap! a-count inc)))
+      (add-watch l1 :mutator (fn [_ _ _ _]
+                               (when-not @mutated
+                                 (reset! mutated true)
+                                 (add-watch l1 :d (fn [_ _ _ _] (swap! d-count inc)))
+                                 (remove-watch l1 :c))))
+      (add-watch l1 :c (fn [_ _ _ _] (swap! c-count inc)))
+      ;; Wave 1 (1→2): snapshot = [:a :mutator :c]. :a fires; :mutator adds :d +
+      ;; removes :c; :c STILL fires (in the snapshot); :d does NOT (not in it).
+      (replace! root {:a 2 :b 10})
+      (is (= 1 @a-count) "wave 1: :a fired")
+      (is (= 1 @c-count)
+          "wave 1: :c fired from the SNAPSHOT even though the mutator removed it
+           mid-fan-out — the removal lands on the next wave")
+      (is (= 0 @d-count)
+          "wave 1: :d added mid-fan-out did NOT fire this wave — it lands on the
+           next wave")
+      ;; Wave 2 (2→3): watcher map is now {:a :mutator :d} (:c gone, :d present).
+      (replace! root {:a 3 :b 10})
+      (is (= 2 @a-count) "wave 2: :a fired again")
+      (is (= 1 @c-count) "wave 2: :c did NOT fire — it was removed on wave 1")
+      (is (= 1 @d-count)
+          "wave 2: :d NOW fires — the mid-fan-out add took effect on this wave"))))
+
+;; ---- re-entrant write from a subscriber during fan-out --------------------
+;; (rf2-qcmzc — pins current behavior; full re-entrant-write ordering is a
+;; later pass per the bead)
+
+(deftest re-entrant-write-from-subscriber-coalesces-into-outer-drain
+  (testing "a subscriber that performs a re-entrant replace! during fan-out has
+            its write coalesced into the SAME outer drain: the nested epoch's
+            drain is a no-op while the outer drain still holds `flushing?`, so
+            the re-enqueued flush is picked up by the running outer loop. The
+            derived value settles to the re-entrant value and the subscriber
+            observes BOTH movements in order. Pins the current behavior — the
+            bead scopes full queued / re-entrant-write ordering to a later pass.
+            (rf2-qcmzc)"
+    (let [{:keys [make-derived replace! root]} (build-graph)
+          l1    (make-derived [root] (fn [db] (:a db)))
+          seen  (atom [])
+          done? (atom false)]
+      (is (= 1 @l1) "baseline deref establishes prev-state")
+      (add-watch l1 :w (fn [_ _ prev nu]
+                         (swap! seen conj [prev nu])
+                         (when-not @done?
+                           (reset! done? true)
+                           ;; Re-entrant write DURING fan-out (single subscriber
+                           ;; → exercises the fast path). Guarded so it fires
+                           ;; exactly once (an unconditional re-entrant write
+                           ;; would spin forever).
+                           (replace! root {:a 3 :b 10}))))
+      (replace! root {:a 2 :b 10})
+      (is (= [[1 2] [2 3]] @seen)
+          "the subscriber saw the original 1→2 movement then the re-entrant 2→3
+           movement, both drained within the one outer epoch")
+      (is (= 3 @l1) "the derived value settled to the re-entrant value")
+      ;; A subsequent ordinary write still flushes cleanly — the scheduler state
+      ;; was fully restored after the re-entrant cascade (no stuck flushing?).
+      (reset! seen [])
+      (replace! root {:a 4 :b 10})
+      (is (= [[3 4]] @seen)
+          "a later write flushes normally — scheduler state restored after the
+           re-entrant cascade"))))


### PR DESCRIPTION
## What

PR #5961 contained a throwing derived subscriber at the React-hook spine's `make-derived-value` fan-out (every sibling still delivers) and re-raised the captured value AFTER delivery. But that re-raise escaped `flush!` straight into `drain-scheduler!`'s per-thunk `(catch :default _ nil)` (`spine.cljs:158`), which **discarded** it. So a programmer error in a raw derived value / subscriber vanished silently — `replace-container!` returned normally and the source bead's observability acceptance criterion went unmet.

## The swallowed-failure path (pre-fix)

1. `notify` (fan-out) captures the first subscriber throw by presence and re-raises via `(throw @captured)`.
2. That escapes `flush!` (the scheduler thunk).
3. `drain-scheduler!` runs each thunk inside `(try (thunk) (catch :default _ nil))` — **the escape is discarded here.**

The same seam also swallowed a throwing raw *recompute* (compute-fn).

## Fix (bounded to the existing scheduler/fan-out seam)

- **`drain-scheduler!`** now CAPTURES the first escaping thunk value **by PRESENCE** (`capture-none`, not truthiness — `nil`/`false` are legal CLJS throws whose identity must survive), keeps draining the tail to completion (rf2-l3lelt: no stuck-dirty strand), restores scheduler state in the `finally`, and THEN re-raises the retained value to the caller (`replace-container!` / a direct source mutation) — the established caller/error channel. The primary failure surfaces **with identity preserved, after every sibling has been delivered**.
- **`notify`** gains an **allocation-free 0/1-subscriber fast path** (rf2-vxgfnd.203 common-path preservation): `count` on the map is O(1); the single subscriber — no sibling to protect — is invoked directly, its throw propagating straight into the drain which surfaces it. Only two-plus subscribers pay the capture volatile + `run!` closure. Removes the volatile #5961 allocated on every movement.
- `capture-none` hoisted above `drain-scheduler!` (now shared by both failure seams; avoids a forward-ref warning).

**Scope:** the React-hook spine only (`make-react-spine` → re-frame.ui / UIx / Helix). The ratom family (Reagent / reagent-slim) uses a native `make-reaction` with no scheduler and is **untouched** — `reactive.cljc` / the digest carrier not touched; the ui compiler not touched.

No new error-id (the original thrown value is re-raised, not wrapped), so no Spec 009 catalogue/manifest change.

## Red-before / green-after

New + updated tests in `spine_glitch_free_cljs_test.cljs` now OBSERVE the surfaced value at the caller with identity preserved (incl. `false`/`nil`), cover both subscriber orders, and add watcher add/remove snapshot-to-next-wave + re-entrant-write coverage.

- Against **#5961** (spine reverted, my tests kept): **11 failures, 0 errors** — every failure a surfacing assertion; sibling-delivery and snapshot/re-entrant assertions stay green, isolating the surfacing delta.
- With the fix restored: **0 failures**.

## Quality gates

Run foreground from the worktree (base `origin/main`):

- `implementation/core` JVM — `clojure -M:test` → **2026 tests / 9457 assertions, 0 failures, 0 errors**
- `implementation` node CLJS — `npm run test:cljs` → **9698 tests / 47744 assertions, 0 failures, 0 errors**

Closes rf2-qcmzc.
