### PR TITLE
fix(gate): catch host-specific arity changes in re-frame.ui.test API drift enforcement (rf2-5bcdi)

### DIFF
--- a/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_probe.cljc
+++ b/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_probe.cljc
@@ -105,6 +105,65 @@
   [result]
   (every? empty? (vals result)))
 
+;; ---------------------------------------------------------------------------
+;; Host-arity reconciliation (rf2-5bcdi — the CLJS lane of the ui.test
+;; host-arity guard; the JVM lane lives in api-md-check).
+;;
+;; The manifest carries name + :kind but NO arity, so a re-frame.ui.test
+;; FUNCTION can reshape a supported arity and stay green — and its contract is
+;; host-specific (`flush!` is 0-arity on the JVM, 0/1-arity on CLJS). This
+;; reconciles the live CLJS analyzer arities against the `:cljs` half of the
+;; sidecar signature authority.
+;; ---------------------------------------------------------------------------
+
+(defn signature-problems
+  "Pure host-arity reconciler for the CLJS (:cljs) lane (rf2-5bcdi). Compares
+   the declared `:cljs` signature contract against the live CLJS analyzer
+   arities. Returns a sorted problems vector; empty ⇒ in sync.
+
+   `contract` — the `:vars` map `{var {:kind :fn|:macro :clj #{..} :cljs #{..}}}`.
+   `live`     — `{var (#{arity} | nil)}` from `cljs-publics/emit-ns-signatures`.
+
+   Only FUNCTION vars are reconciled: a re-frame.ui.test function can carry a
+   host-specific runtime arity, so the CLJS surface is where a CLJS-only arity
+   reshape must go RED (the reader-conditional `:clj`/`:cljs` difference is
+   represented intentionally, never forced equal). MACROS are host-invariant
+   (one `.cljc` definition expanded on both hosts), so their programmer-visible
+   call grammar is pinned once on the JVM lane, and the analyzer does not
+   reliably surface their arglists anyway. A FUNCTION the analyzer surfaces no
+   arity for is itself drift (`:arity-unobserved`)."
+  [contract live]
+  (->> contract
+       (keep (fn [[var {:keys [kind cljs]}]]
+               (when (= kind :fn)
+                 (let [got (get live var)]
+                   (cond
+                     (nil? got)      {:kind :arity-unobserved :var var :expected cljs}
+                     (not= cljs got) {:kind :arity-mismatch   :var var :expected cljs :got got})))))
+       (sort-by :var)
+       vec))
+
+(defn signature-report
+  "Render a `signature-problems` seq to an actionable multi-line string — the
+   message the probe's failing arity assertion prints."
+  [problems]
+  (str/join
+   "\n"
+   (concat
+    ["CLJS ui.test host-arity DRIFT (rf2-5bcdi): a re-frame.ui.test FUNCTION's"
+     "live CLJS arity no longer matches the :cljs signature contract in"
+     "spec/api-manifest-metadata.edn (:ui-test-signatures). Reshape the source"
+     "or reconcile the contract until this is green. Problems:"]
+    (map (fn [{:keys [kind var expected got]}]
+           (case kind
+             :arity-mismatch
+             (str "    " var ": live CLJS " (pr-str got)
+                  " ; contract :cljs " (pr-str expected))
+             :arity-unobserved
+             (str "    " var ": the analyzer surfaced NO arity (expected :cljs "
+                  (pr-str expected) ") — a function must be observable")))
+         problems))))
+
 (defn report
   "Render a `reconcile` result to an actionable multi-line string —
    the message the probe's failing assertion prints. Mirrors the tone of

--- a/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj
+++ b/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj
@@ -66,6 +66,69 @@
        vec))
 
 ;; ---------------------------------------------------------------------------
+;; Host-arity enumeration (rf2-5bcdi — the CLJS companion to the JVM
+;; api-md-check host-arity guard).
+;;
+;; The manifest carries name + :kind but NO arity, so a re-frame.ui.test
+;; function can reshape a supported arity and stay green — and the ui.test
+;; contract is host-specific (`flush!` is 0-arity on the JVM, 0/1-arity on
+;; CLJS). This side reads each covered var's live ANALYZER arities so the
+;; probe can reconcile them against the `:cljs` signature contract.
+;; ---------------------------------------------------------------------------
+
+(defn- strip-implicit-macro-params
+  "Drop a macro's compiler-supplied `&form` / `&env` positional params so only
+   PROGRAMMER-VISIBLE params are counted (bead AC: compiler-internal
+   parameters must not leak). Mirrors the JVM lane's
+   `re-frame.api-manifest.api-md-check/strip-implicit-macro-params`."
+  [arglist]
+  (remove (fn [p] (and (symbol? p) (contains? #{"&form" "&env"} (name p))))
+          arglist))
+
+(defn arglist->arity
+  "Normalize one arglist to a PROGRAMMER-VISIBLE arity vector: `[n]` for a
+   fixed n-arg call, `[n :&]` for a variadic call with n fixed args. A nested
+   destructuring vector counts as ONE positional. Mirrors the JVM lane's
+   `re-frame.api-manifest.api-md-check/arglist->arity` exactly so the two
+   hosts normalize identically."
+  [arglist]
+  (let [al        (strip-implicit-macro-params arglist)
+        fixed     (count (take-while #(not= '& %) al))
+        variadic? (boolean (some #(= '& %) al))]
+    (if variadic? [fixed :&] [fixed])))
+
+(defn- unwrap-arglists
+  "The analyzer stores `:arglists` either bare or wrapped in `(quote ...)`
+   (metadata form). Return the raw seq-of-arglists, or nil."
+  [raw]
+  (cond
+    (nil? raw)                              nil
+    (and (seq? raw) (= 'quote (first raw))) (second raw)
+    :else                                   raw))
+
+(defn info->arities
+  "The set of programmer-visible arity vectors for a CLJS analyzer var-info
+   map, or nil when the analyzer surfaces no `:arglists` for it (a plain
+   value `:var`, or a macro whose arglists the analyzer erases — the probe
+   treats an unobserved FUNCTION as drift, but never a macro, whose grammar
+   is host-invariant and pinned on the JVM lane)."
+  [info]
+  (when-let [arglists (or (unwrap-arglists (:arglists info))
+                          (unwrap-arglists (:arglists (:meta info))))]
+    (into #{} (map arglist->arity) arglists)))
+
+(defn ns-public-signatures
+  "Return `{var-name-string (#{arity-vector ...} | nil)}` for every public
+   var of `ns-sym` in the analyzer compilation env `state`, minus the
+   `^:no-doc` carve-outs. The driver behind `emit-ns-signatures`; exposed as
+   a plain fn so it can be unit-tested off a synthetic compiler-state atom."
+  [state ns-sym]
+  (->> (ana-api/ns-publics state ns-sym)
+       (remove (fn [[_ info]] (:no-doc (:meta info))))
+       (map (fn [[sym info]] [(name sym) (info->arities info)]))
+       (into {})))
+
+;; ---------------------------------------------------------------------------
 ;; Locating + reading the curated sidecar at compile time.
 ;;
 ;; The probe reconciles the live CLJS publics against the `:cljs-only`
@@ -142,3 +205,30 @@
                 ns-sym)
         pairs (ns-public-pairs env/*compiler* sym)]
     `[~@(map (fn [[v k]] [v k]) pairs)]))
+
+(defmacro emit-ns-signatures
+  "Expand to a literal `{var-name #{arity-vector ...}}` map for the public
+   vars of `ns-sym` (a quoted symbol), read from the CLJS analyzer's
+   compilation environment at macro-expansion time (rf2-5bcdi). A var the
+   analyzer surfaces no arglists for maps to `nil`. The target namespace must
+   already be analysed — `:require` it from the calling namespace first.
+
+   The emitted map is self-evaluating data (strings → sets of vectors of
+   numbers / the `:&` keyword), so — like `emit-cljs-only-rows` — the value
+   is returned directly. It is the live CLJS arity surface the probe
+   reconciles against the `:cljs` signature contract."
+  [ns-sym]
+  (let [sym (if (and (seq? ns-sym) (= 'quote (first ns-sym)))
+              (second ns-sym)
+              ns-sym)]
+    (ns-public-signatures env/*compiler* sym)))
+
+(defmacro emit-ui-test-signature-contract
+  "Expand to the sidecar's `:ui-test-signatures` authority map
+   (`{:namespace :vars {var {:kind :clj #{..} :cljs #{..}}}}`), read from
+   `spec/api-manifest-metadata.edn` at macro-expansion time (rf2-5bcdi). The
+   single machine-readable host-aware signature source, embedded so the probe
+   checks the same committed contract the JVM lane joins against with no
+   runtime filesystem dependency."
+  []
+  (-> (find-sidecar) slurp edn/read-string :ui-test-signatures))

--- a/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
+++ b/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
@@ -64,7 +64,8 @@
   mechanism for it (see rf2-2mtte PR notes)."
   (:require-macros [re-frame.api-manifest.cljs-publics
                     :refer [emit-ns-publics emit-cljs-only-rows
-                            emit-classification-rows]])
+                            emit-classification-rows emit-ns-signatures
+                            emit-ui-test-signature-contract]])
   (:require [cljs.test :refer-macros [deftest is testing]]
             [re-frame.api-manifest.cljs-probe :as probe]
             ;; The covered CLJS-only namespaces. The `:require` forces the
@@ -216,3 +217,96 @@
       (is (contains? live-publics ns-str)
           (str ns-str " is marked :fully-rowed but is not in live-publics "
                "— add its :require + emit-ns-publics entry.")))))
+
+;; ---------------------------------------------------------------------------
+;; re-frame.ui.test HOST-ARITY guard — CLJS (:cljs) lane (rf2-5bcdi).
+;;
+;; The manifest carries name + :kind but NO arity, so a re-frame.ui.test
+;; FUNCTION can reshape a supported arity and stay green — and the contract is
+;; host-specific: `flush!` is 0-arity on the JVM but 0/1-arity on CLJS. This
+;; enumerates the live CLJS analyzer arities of the reader-conditional surface
+;; and reconciles the FUNCTION arities against the `:cljs` half of the sidecar
+;; signature authority. A CLJS-only reshape (e.g. dropping flush!'s 1-arity)
+;; turns this RED. Macros are host-invariant (pinned once on the JVM lane).
+;; ---------------------------------------------------------------------------
+
+(def live-ui-test-signatures
+  "`{var-name (#{arity} | nil)}` for re-frame.ui.test's live CLJS public
+   surface, enumerated off the analyzer at compile time."
+  (emit-ns-signatures re-frame.ui.test))
+
+(def ui-test-signature-contract
+  "The sidecar `:ui-test-signatures` authority, embedded at compile time
+   (no runtime filesystem). `:vars` is the per-var host-aware contract."
+  (emit-ui-test-signature-contract))
+
+(deftest ui-test-cljs-arities-in-sync
+  (testing "the live CLJS function arities of re-frame.ui.test match the :cljs
+            signature contract (the reader-conditional flush! 0/1-arity pinned)"
+    (let [problems (probe/signature-problems (:vars ui-test-signature-contract)
+                                             live-ui-test-signatures)]
+      (is (empty? problems) (probe/signature-report problems)))))
+
+(deftest ui-test-signature-contract-is-non-vacuous
+  (testing "the embedded contract carries the nine blessed ui.test vars and the
+            analyzer surfaced flush!'s live CLJS 0/1-arity (guards against a
+            vacuous green from an unread sidecar or un-analysed namespace)"
+    (is (= "re-frame.ui.test" (:namespace ui-test-signature-contract)))
+    (is (= 9 (count (:vars ui-test-signature-contract))))
+    (is (= #{[0] [1]} (get live-ui-test-signatures "flush!"))
+        "flush! must be observed 0/1-arity on CLJS — the blessed host difference")))
+
+;; Synthetic reconciler contracts — the mutation proof, exercised directly on
+;; the pure `signature-problems` so a reshape goes RED and the in-sync state
+;; stays green regardless of the live analyzer.
+(def ^:private synthetic-contract
+  {"attrs"     {:kind :fn    :cljs #{[1]}}
+   "flush!"    {:kind :fn    :cljs #{[0] [1]}}
+   "render"    {:kind :macro :cljs #{[1] [2]}}
+   "with-root" {:kind :macro :cljs #{[1 :&]}}})
+
+(def ^:private synthetic-live-in-sync
+  {"attrs" #{[1]} "flush!" #{[0] [1]} "render" #{[1] [2]} "with-root" #{[1 :&]}})
+
+(deftest cljs-arities-in-sync-produce-no-problems
+  (testing "the matching live CLJS arities reconcile clean"
+    (is (empty? (probe/signature-problems synthetic-contract synthetic-live-in-sync)))))
+
+(deftest cljs-flush-arity-drop-goes-red
+  (testing "THE BUG (rf2-5bcdi): flush! losing its CLJS 1-arity (thunk) fails
+            against :cljs #{[0] [1]} — a CLJS-only reshape the manifest cannot see"
+    (let [problems (probe/signature-problems
+                    synthetic-contract
+                    (assoc synthetic-live-in-sync "flush!" #{[0]}))]
+      (is (= [:arity-mismatch] (map :kind problems)))
+      (is (= "flush!" (:var (first problems))))
+      (is (= #{[0] [1]} (:expected (first problems))))
+      (is (= #{[0]} (:got (first problems)))))))
+
+(deftest cljs-added-arity-goes-red
+  (testing "ADDING a CLJS-only arity (attrs gains a 2-arity) fails — a superset
+            is drift, not a pass"
+    (let [problems (probe/signature-problems
+                    synthetic-contract
+                    (assoc synthetic-live-in-sync "attrs" #{[1] [2]}))]
+      (is (= [:arity-mismatch] (map :kind problems)))
+      (is (= "attrs" (:var (first problems)))))))
+
+(deftest cljs-unobserved-function-goes-red
+  (testing "a contracted FUNCTION the analyzer surfaces no arity for is
+            :arity-unobserved (never a vacuous pass)"
+    (let [problems (probe/signature-problems
+                    synthetic-contract
+                    (assoc synthetic-live-in-sync "attrs" nil))]
+      (is (= [:arity-unobserved] (map :kind problems)))
+      (is (= "attrs" (:var (first problems)))))))
+
+(deftest cljs-macros-are-not-arity-checked
+  (testing "macros (render / with-root) are host-invariant — the CLJS lane does
+            NOT flag them even when the analyzer surfaces no arity for them
+            (their grammar is pinned on the JVM lane)"
+    (is (empty? (probe/signature-problems
+                 synthetic-contract
+                 (-> synthetic-live-in-sync
+                     (assoc "render" nil)
+                     (dissoc "with-root")))))))

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
@@ -409,6 +409,111 @@
       (conj {:kind :disambiguator-admitted :line line}))
     [{:kind :create-root-row-missing :line nil}]))
 
+;; ---------------------------------------------------------------------------
+;; re-frame.ui.test HOST-ARITY guard (rf2-5bcdi).
+;;
+;; The generated manifest reduces every public var to [namespace var tier
+;; kind]; it carries NO arity facts (gen/kind-of collapses a var to
+;; :macro/:fn/:var). So a re-frame.ui.test fn/macro can keep its public NAME
+;; and its :kind while losing, adding, or reshaping a supported arity, and the
+;; ordinary manifest / projection / `gen --check` gates all stay green — the
+;; exact false-green this guard closes. It matters because the ui.test contract
+;; is HOST-SPECIFIC: `flush!` is 0-arity on the JVM but 0/1-arity on CLJS;
+;; `render` / `with-root` are macros with blessed call grammars.
+;;
+;; This is the JVM (:clj) half. It reads the live Var :arglists of the nine
+;; blessed vars via `ns-publics` (re-frame.ui.test's Tier-1 surface loads
+;; headless on the JVM, so it is on this generator classpath) and reconciles
+;; them against the machine-readable signature authority in the sidecar
+;; (`:ui-test-signatures`). The CLJS (:cljs) half is enforced by the
+;; api-manifest CLJS probe (probe/, run by `npm run test:cljs`).
+;; ---------------------------------------------------------------------------
+
+(def ui-test-namespace
+  "The blessed testing namespace whose public-var ARITIES this guard pins
+   against the sidecar signature authority (rf2-5bcdi)."
+  "re-frame.ui.test")
+
+(defn- strip-implicit-macro-params
+  "Drop a macro's compiler-supplied `&form` / `&env` positional params from an
+   arglist so only PROGRAMMER-VISIBLE params are counted (bead AC: compiler-
+   internal parameters must not leak into the contract). `defmacro` already
+   keeps them out of `:arglists` metadata on the JVM; the strip is defensive
+   and keeps the normalization identical to the CLJS analyzer lane."
+  [arglist]
+  (remove (fn [p] (and (symbol? p) (contains? #{"&form" "&env"} (name p))))
+          arglist))
+
+(defn arglist->arity
+  "Normalize one arglist to a PROGRAMMER-VISIBLE arity vector: `[n]` for a
+   fixed n-arg call, `[n :&]` for a variadic call with n fixed args. A nested
+   destructuring vector counts as ONE positional (e.g. with-root's
+   `[[binding root-form] & body]` → `[1 :&]`). Mirrors the CLJS lane's
+   `re-frame.api-manifest.cljs-publics/arglist->arity`."
+  [arglist]
+  (let [al        (strip-implicit-macro-params arglist)
+        fixed     (count (take-while #(not= '& %) al))
+        variadic? (boolean (some #(= '& %) al))]
+    (if variadic? [fixed :&] [fixed])))
+
+(defn arglists->arities
+  "The set of programmer-visible arity vectors for a var's `:arglists`
+   (nil / empty → `#{}`)."
+  [arglists]
+  (into #{} (map arglist->arity) arglists))
+
+(defn live-ui-test-arities
+  "Live JVM `{var-name-string -> #{arity-vector ...}}` for the public,
+   non-^:no-doc vars of `re-frame.ui.test` (mirrors gen/public-vars-of's
+   `^:no-doc` carve-out, so the nine blessed vars are exactly the set). Arity
+   is derived from each Var's `:arglists`; a macro's `:arglists` already
+   excludes `&form`/`&env`."
+  []
+  (let [ns-sym (symbol ui-test-namespace)]
+    (require ns-sym)
+    (into {}
+          (for [[sym v] (ns-publics ns-sym)
+                :when (not (:no-doc (meta v)))]
+            [(name sym) (arglists->arities (:arglists (meta v)))]))))
+
+(defn read-ui-test-signatures
+  "The sidecar's `:ui-test-signatures` authority `{:namespace :vars {...}}`
+   (rf2-5bcdi) — the ONE machine-readable host-aware signature source for the
+   blessed ui.test surface."
+  []
+  (:ui-test-signatures (gen/read-sidecar)))
+
+(defn ui-test-arity-problems
+  "Pure host-arity reconciler for the JVM (:clj) lane (rf2-5bcdi). Compares the
+   declared `:clj` signature contract against the live JVM arities of the
+   blessed ui.test vars. Returns the seq of problem maps; empty when every var
+   is present with EXACTLY its declared `:clj` arities.
+
+   `signatures` — the `:vars` map `{var {:kind :clj #{arities} :cljs #{..}}}`.
+   `live`       — `{var #{live-jvm-arities}}` (from `live-ui-test-arities`).
+
+   Two directions, mirroring the generator's missing/stale existence guard:
+     - every CONTRACT var must resolve live with matching `:clj` arities (a
+       reshaped arity → `:arity-mismatch`; a var the contract names but that no
+       longer resolves → `:var-absent`);
+     - every LIVE blessed var must be in the contract (a new public var with no
+       arity contract → `:uncontracted-var`), so a fresh export cannot escape
+       arity coverage silently."
+  [signatures live]
+  (sort-by
+   :var
+   (concat
+    (keep (fn [[var {:keys [clj]}]]
+            (if-let [got (get live var)]
+              (when (not= clj got)
+                {:kind :arity-mismatch :var var :expected clj :got got})
+              {:kind :var-absent :var var :expected clj}))
+          signatures)
+    (keep (fn [[var got]]
+            (when-not (contains? signatures var)
+              {:kind :uncontracted-var :var var :got got}))
+          live))))
+
 (defn check!
   "Validate spec/API.md var-rows against the manifest. Returns true when
    every API.md var-row resolves to a manifest row with a MATCHING tier;
@@ -448,7 +553,14 @@
         kind-probs (root-verb-kind-problems {:rows rows :api-rows api-rows})
         ;; Literal-option guard for the create-root row (rf2-e9q33): authored
         ;; :root-id REQUIRED and :disambiguator INVALID must both stay pinned.
-        opt-probs  (create-root-option-problems api-md-lines)]
+        opt-probs  (create-root-option-problems api-md-lines)
+        ;; Host-arity guard for the blessed re-frame.ui.test surface (rf2-5bcdi):
+        ;; the manifest carries name + :kind but NO arity, so a fn/macro can
+        ;; reshape a supported arity and stay green. Pin each var's live JVM
+        ;; (:clj) arities against the sidecar signature authority.
+        arity-probs (ui-test-arity-problems
+                     (:vars (read-ui-test-signatures))
+                     (live-ui-test-arities))]
     (cond
       ;; Vacuity-floor violation: extraction collapsed — refuse a green.
       floor
@@ -499,6 +611,26 @@
                                  (str line)))
                 :create-root-row-missing
                 (println "  create-root var-row not found in spec/API.md"))))
+          false)
+
+      (seq arity-probs)
+      (do (binding [*out* *err*]
+            (println "DRIFT: a re-frame.ui.test public var's JVM arity disagrees with the signature contract.")
+            (println "The nine blessed ui.test vars carry a HOST-AWARE arity contract in")
+            (println "spec/api-manifest-metadata.edn (:ui-test-signatures); the manifest carries")
+            (println "name + :kind but no arity, so a fn/macro can reshape a supported arity and")
+            (println "stay green. Reconcile the source or the contract. Problems:")
+            (doseq [{:keys [kind var expected got]} arity-probs]
+              (case kind
+                :arity-mismatch
+                (println (format "  %-12s ARITY:  live JVM %s; contract :clj %s"
+                                 var (pr-str got) (pr-str expected)))
+                :var-absent
+                (println (format "  %-12s ABSENT: contract expects :clj %s but the var did not resolve"
+                                 var (pr-str expected)))
+                :uncontracted-var
+                (println (format "  %-12s UNCONTRACTED: live JVM %s but no :ui-test-signatures entry"
+                                 var (pr-str got))))))
           false)
 
       (empty? problems)

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
@@ -375,3 +375,142 @@
             (no live option-grammar drift)"
     (is (empty? (c/create-root-option-problems (c/read-api-md-lines)))
         "live drift: create-root row lost :root-id-required or :disambiguator-invalid")))
+
+;; ---------------------------------------------------------------------------
+;; re-frame.ui.test HOST-ARITY guard — JVM (:clj) lane (rf2-5bcdi).
+;;
+;; The generated manifest reduces every var to [namespace var tier kind]; it
+;; carries NO arity. So a re-frame.ui.test fn/macro can keep its name and :kind
+;; while losing / adding / reshaping a supported arity, and every ordinary
+;; manifest / projection / gen --check gate stays green. `ui-test-arity-problems`
+;; reconciles the live JVM :arglists against the sidecar :ui-test-signatures
+;; authority; these fixtures prove a reshaped / removed / uncontracted arity
+;; goes RED and the in-sync state stays green, and that the normalization
+;; strips a macro's compiler-internal &form/&env (bead AC).
+;; ---------------------------------------------------------------------------
+
+;; The :clj projection of the nine blessed vars' signature contract (mirrors
+;; the committed :ui-test-signatures :vars, :clj half).
+(def ^:private ui-test-clj-contract
+  {"attrs"     {:kind :fn    :clj #{[1]}}
+   "text"      {:kind :fn    :clj #{[1]}}
+   "find"      {:kind :fn    :clj #{[2]}}
+   "find-all"  {:kind :fn    :clj #{[2]}}
+   "query"     {:kind :fn    :clj #{[2]}}
+   "dispatch!" {:kind :fn    :clj #{[2]}}
+   "flush!"    {:kind :fn    :clj #{[0]}}
+   "render"    {:kind :macro :clj #{[1] [2]}}
+   "with-root" {:kind :macro :clj #{[1 :&]}}})
+
+;; The matching live-JVM arity map for an in-sync tree.
+(def ^:private ui-test-live-in-sync
+  {"attrs"     #{[1]}
+   "text"      #{[1]}
+   "find"      #{[2]}
+   "find-all"  #{[2]}
+   "query"     #{[2]}
+   "dispatch!" #{[2]}
+   "flush!"    #{[0]}
+   "render"    #{[1] [2]}
+   "with-root" #{[1 :&]}})
+
+(deftest arglist->arity-normalizes-fixed-variadic-and-strips-implicit
+  (testing "a plain arglist yields [n]"
+    (is (= [0] (c/arglist->arity '[])))
+    (is (= [1] (c/arglist->arity '[node])))
+    (is (= [2] (c/arglist->arity '[tree selector]))))
+  (testing "a variadic arglist yields [n :&]; a nested destructuring vector is
+            ONE positional (with-root's [[binding root-form] & body])"
+    (is (= [1 :&] (c/arglist->arity '[[binding root-form :as binding-form] & body])))
+    (is (= [2 :&] (c/arglist->arity '[a b & more]))))
+  (testing "compiler-internal macro params &form/&env do not leak into the
+            programmer-visible arity (bead AC)"
+    (is (= [1] (c/arglist->arity '[&form &env root-or-view])))
+    (is (= [2] (c/arglist->arity '[&form &env root-or-view opts])))
+    (is (= [1 :&] (c/arglist->arity '[&form &env [binding root-form] & body])))))
+
+(deftest ui-test-arities-in-sync-produce-no-problems
+  (testing "the committed :clj contract reconciles clean against the matching
+            live JVM arities"
+    (is (empty? (c/ui-test-arity-problems ui-test-clj-contract ui-test-live-in-sync)))))
+
+(deftest flush-jvm-arity-reshape-goes-red
+  (testing "THE BUG (rf2-5bcdi): flush! reshaped from 0-arity to 1-arity on the
+            JVM fails against the contract's :clj #{[0]}, while its name + :kind
+            (a :fn) are unchanged"
+    (let [problems (c/ui-test-arity-problems
+                    ui-test-clj-contract
+                    (assoc ui-test-live-in-sync "flush!" #{[1]}))]
+      (is (= 1 (count problems)))
+      (is (= :arity-mismatch (:kind (first problems))))
+      (is (= "flush!" (:var (first problems))))
+      (is (= #{[0]} (:expected (first problems))))
+      (is (= #{[1]} (:got (first problems)))))))
+
+(deftest render-macro-arity-drop-goes-red
+  (testing "render (a macro) losing its 2-arity — [1] only — fails against
+            :clj #{[1] [2]} even though the manifest :kind stays :macro"
+    (let [problems (c/ui-test-arity-problems
+                    ui-test-clj-contract
+                    (assoc ui-test-live-in-sync "render" #{[1]}))]
+      (is (= [:arity-mismatch] (map :kind problems)))
+      (is (= "render" (:var (first problems))))
+      (is (= #{[1] [2]} (:expected (first problems)))))))
+
+(deftest with-root-losing-variadic-goes-red
+  (testing "with-root reshaped from variadic [1 :&] to a fixed [1] fails —
+            the '& body' grammar drift the tier/kind reconcile cannot see"
+    (let [problems (c/ui-test-arity-problems
+                    ui-test-clj-contract
+                    (assoc ui-test-live-in-sync "with-root" #{[1]}))]
+      (is (= [:arity-mismatch] (map :kind problems)))
+      (is (= "with-root" (:var (first problems))))
+      (is (= #{[1 :&]} (:expected (first problems))))
+      (is (= #{[1]} (:got (first problems)))))))
+
+(deftest added-jvm-arity-goes-red
+  (testing "ADDING a supported arity (query gains a 3-arity) fails — a superset
+            is drift, not a pass"
+    (let [problems (c/ui-test-arity-problems
+                    ui-test-clj-contract
+                    (assoc ui-test-live-in-sync "query" #{[2] [3]}))]
+      (is (= [:arity-mismatch] (map :kind problems)))
+      (is (= "query" (:var (first problems)))))))
+
+(deftest removed-var-flagged-absent
+  (testing "a contract var whose live var no longer resolves is :var-absent
+            (belt-and-braces alongside the gen --check existence guard)"
+    (let [problems (c/ui-test-arity-problems
+                    ui-test-clj-contract
+                    (dissoc ui-test-live-in-sync "flush!"))]
+      (is (= [:var-absent] (map :kind problems)))
+      (is (= "flush!" (:var (first problems)))))))
+
+(deftest new-uncontracted-var-flagged
+  (testing "a NEW live blessed var with no signature entry is :uncontracted-var
+            — a fresh export cannot escape arity coverage silently"
+    (let [problems (c/ui-test-arity-problems
+                    ui-test-clj-contract
+                    (assoc ui-test-live-in-sync "brand-new!" #{[0]}))]
+      (is (= [:uncontracted-var] (map :kind problems)))
+      (is (= "brand-new!" (:var (first problems)))))))
+
+(deftest live-ui-test-jvm-arities-match-contract
+  (testing "the committed :ui-test-signatures :clj contract reconciles clean
+            against the LIVE re-frame.ui.test JVM :arglists (no live drift), and
+            the enumeration actually covers the nine blessed vars"
+    (let [contract (:vars (c/read-ui-test-signatures))
+          live     (c/live-ui-test-arities)]
+      (is (= 9 (count contract))
+          "the signature authority must carry all nine blessed vars")
+      (is (= (set (keys contract)) (set (keys live)))
+          "live blessed vars and the contract must cover exactly the same names")
+      (is (empty? (c/ui-test-arity-problems contract live))
+          "live drift: a ui.test var's JVM arity disagrees with :ui-test-signatures")
+      ;; The host-specific facts the bead names, pinned against LIVE metadata.
+      (is (= #{[0]} (get live "flush!"))
+          "flush! is 0-arity on the JVM")
+      (is (= #{[1 :&]} (get live "with-root"))
+          "with-root is a variadic macro ([binding] & body)")
+      (is (= #{[1] [2]} (get live "render"))
+          "render is a 1/2-arity macro"))))

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -35,6 +35,58 @@
   :keystone "rf2-3nbl5.2"}
 
  ;; --------------------------------------------------------------------------
+ ;; HOST-AWARE SIGNATURE AUTHORITY for the blessed re-frame.ui.test surface
+ ;; (rf2-5bcdi).
+ ;;
+ ;; The manifest reduces every public var to [namespace var tier kind]; it
+ ;; carries NO arity facts. So a re-frame.ui.test fn/macro can keep its name
+ ;; AND its :kind while losing / adding / reshaping a supported arity, and
+ ;; every ordinary manifest / projection / `gen --check` gate stays green.
+ ;; That is the exact false-green this key closes. It matters here because
+ ;; the public contract is HOST-SPECIFIC: `flush!` is 0-arity on the JVM but
+ ;; 0/1-arity on CLJS; `render` / `with-root` are macros with blessed call
+ ;; grammars. This is the ONE machine-readable signature authority for the
+ ;; nine blessed vars — not a second namespace inventory (the same nine are
+ ;; classified below) and not prose.
+ ;;
+ ;; SHAPE. `:vars` maps each bare var-name to
+ ;;   {:kind :fn|:macro :clj #{arity ...} :cljs #{arity ...}}
+ ;; where an arity is a vector: `[n]` = a fixed n-arg call; `[n :&]` = a
+ ;; variadic call with n fixed args (n-or-more). Arities are the
+ ;; PROGRAMMER-VISIBLE call shapes: a macro's implicit &form/&env are
+ ;; normalized away (they never leak into the contract).
+ ;;
+ ;; ENFORCEMENT (two lanes, one authority):
+ ;;   - JVM (:clj) — api-md-check reads live Var :arglists via ns-publics and
+ ;;     reconciles them against :clj here (re-frame.ui.test's Tier-1 surface
+ ;;     loads headless on the JVM). A reshaped :clj arity turns api-md-check
+ ;;     RED while name + :kind stay put.
+ ;;   - CLJS (:cljs) — the api-manifest CLJS probe (probe/, run by
+ ;;     `npm run test:cljs`) reads the live analyzer arities of the
+ ;;     reader-conditional CLJS surface and reconciles the FUNCTION arities
+ ;;     against :cljs here. A CLJS-only reshape (e.g. dropping `flush!`'s
+ ;;     1-arity) turns the probe RED. Macros are host-invariant (one .cljc
+ ;;     definition expanded on both hosts), so their grammar is pinned once
+ ;;     on the JVM lane; the reader-conditional :clj/:cljs difference for a
+ ;;     function is represented intentionally rather than forced equal.
+ ;; --------------------------------------------------------------------------
+ :ui-test-signatures
+ {:namespace "re-frame.ui.test"
+  :vars
+  {"attrs"     {:kind :fn    :clj #{[1]}     :cljs #{[1]}}
+   "text"      {:kind :fn    :clj #{[1]}     :cljs #{[1]}}
+   "find"      {:kind :fn    :clj #{[2]}     :cljs #{[2]}}
+   "find-all"  {:kind :fn    :clj #{[2]}     :cljs #{[2]}}
+   "query"     {:kind :fn    :clj #{[2]}     :cljs #{[2]}}
+   "dispatch!" {:kind :fn    :clj #{[2]}     :cljs #{[2]}}
+   ;; The blessed reader-conditional difference: 0-arity headless drain on
+   ;; the JVM; 0-arity or 1-arity (thunk) awaited drain on CLJS.
+   "flush!"    {:kind :fn    :clj #{[0]}     :cljs #{[0] [1]}}
+   ;; Macros — host-invariant call grammars (single .cljc definition).
+   "render"    {:kind :macro :clj #{[1] [2]} :cljs #{[1] [2]}}
+   "with-root" {:kind :macro :clj #{[1 :&]}  :cljs #{[1 :&]}}}}
+
+ ;; --------------------------------------------------------------------------
  ;; CLJS-ONLY surfaces — public vars in ClojureScript-only namespaces that
  ;; cannot be `require`d on the JVM, so the generator carries them verbatim.
  ;; Each row is the FULL manifest row, and carries its own


### PR DESCRIPTION
## Problem

The generated API manifest reduces every public var to `[namespace var tier kind]` — it carries **no arity facts** (`gen/kind-of` collapses a var to `:macro`/`:fn`/`:var`). So a `re-frame.ui.test` fn/macro could keep its public **name** *and* its `:kind` while losing, adding, or reshaping a supported arity, and every ordinary manifest / projection / `gen --check` gate stayed **green**. This is the false-green `rf2-vxgfnd.200` left behind (it enrolled the nine blessed `re-frame.ui.test` vars but verified only existence + kind, not signatures).

It matters because the public contract is **host-specific**: `flush!` is 0-arity on the JVM but 0/1-arity on CLJS; `render` / `with-root` are macros with blessed call grammars.

### Enforcement gap (file:line)

- JVM lane derived only `[symbol kind]` — no arity: `implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj:136` (`kind-of`), `:147` (`public-vars-of`).
- The API.md/manifest reconciler compares identity + tier + (post-`rf2-e9q33`) kind only — never signatures: `implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj:230` (`reconcile`).
- CLJS lane reduced live analyzer vars to `[name kind]` and reconciled names only: `implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj:55` (`ns-public-pairs`), `.../cljs_probe.cljc:64` (`reconcile`).

## Fix — one authority, two host lanes

**Authority (arity-capture, not a manifest regeneration).** Added `:ui-test-signatures` to `spec/api-manifest-metadata.edn` — one machine-readable `{var {:kind :clj #{arities} :cljs #{arities}}}` map for the nine blessed vars. Arities are programmer-visible call shapes (`[n]` fixed, `[n :&]` variadic); a macro's `&form`/`&env` are normalized away. This is the **sidecar**, not the generated `spec/api-manifest.edn`: the generator only reads `:classification`/`:cljs-only`, so the manifest is byte-identical and `gen --check` stays green. The sidecar is already read by both lanes and already in the CI trigger, so no new file and no hot-zone workflow edit.

**Why the probe files needed editing.** The CLJS lane can observe live arities *only* from the analyzer (`cljs_publics`) and reconcile them purely (`cljs_probe`) — the JVM `gen` never sees the reader-conditional CLJS surface. Capturing CLJS arities therefore requires a new `emit-ns-signatures` macro + a `signature-problems` reconciler in exactly those two probe files. No ui.test runtime and no manifest generator were touched.

- **JVM (`:clj`) lane** — `api_md_check`: reads live Var `:arglists` via `ns-publics` and reconciles against `:clj`. A reshaped/added/removed JVM arity turns `api-md-check` **RED** while name + `:kind` stay put.
- **CLJS (`:cljs`) lane** — `cljs_publics/emit-ns-signatures` + `cljs_probe/signature-problems`, wired into the probe test: reads live analyzer arities and reconciles the **function** arities against `:cljs`. Dropping `flush!`'s 1-arity turns the probe RED. Macros are host-invariant (one `.cljc` definition), pinned once on the JVM lane; the reader-conditional `:clj`/`:cljs` difference for a function is represented intentionally, never forced equal.

## Quality gates

All run in the foreground to completion from `implementation/scripts/api-manifest/` (and `implementation/` for the CLJS lane):

- `clojure -M -m re-frame.api-manifest.gen --check` → `OK: spec/api-manifest.edn in sync (498 public vars).` (manifest unchanged)
- `clojure -M -m re-frame.api-manifest.api-md-check` (in-sync) → `OK: spec/API.md projection in sync (214 var-rows checked...)` — **exit 0**
- **JVM mutation proof** — temporarily reshaped `ui.test/flush!` JVM arity `[]` → `[_x]`, re-ran `api-md-check`:
  `DRIFT ... flush!  ARITY:  live JVM #{[1]}; contract :clj #{[0]}` — **exit 1**; reverted → exit 0.
- `clojure -M:test` → **Ran 83 tests, 176 assertions, 0 failures, 0 errors** (incl. the new JVM arity reconciler + `arglist->arity` normalization + live-smoke tests, and the CLJS-only-mutation cases).
- `npm run test:cljs` → **Ran 9701 tests, 47739 assertions, 0 failures, 0 errors** (incl. the new probe deftests: live `:cljs` arity in-sync, the non-vacuity check confirming `flush!` is observed 0/1-arity on CLJS, and the CLJS flush!-arity-drop / added-arity / unobserved-function mutation proofs).

Closes rf2-5bcdi.
