### PR TITLE
fix(gate): auto-enroll future UI and adapter artefacts in bundle-isolation (rf2-klyw5)

### DIFF
--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -873,7 +873,7 @@ function assertPositiveControlComplete(artefacts = ARTEFACTS, controls = POSITIV
   };
 }
 
-// ----- canonical publishable-artefact coverage (rf2-sh0sp4) ------------------
+// ----- canonical publishable-runtime coverage (rf2-sh0sp4 / rf2-klyw5) -------
 
 // assertPositiveControlComplete only cross-checks this script's own two local
 // tables (ARTEFACTS <-> POSITIVE_CONTROL): an artefact absent from BOTH is
@@ -881,64 +881,157 @@ function assertPositiveControlComplete(artefacts = ARTEFACTS, controls = POSITIV
 // the gate — a separately published, browser-reachable optional runtime omitted
 // from every internal table stayed green. This check closes that hole by
 // deriving the REQUIRED set from the SAME canonical authority the release
-// lockstep uses (.github/scripts/verify-version-lockstep.sh): every
-// implementation/*/deps.edn carrying a `:clein/build` alias is a published
-// artefact. The browser-optional runtimes among them MUST each carry a primary
-// isolation entry here. It is filesystem-derived, so adding a new browser-
-// optional artefact (a new implementation/<name>/deps.edn with :clein/build,
-// not in the exclusion set below) without an ARTEFACTS entry fails
-// automatically — the check does NOT compare two copies of its own local table.
+// lockstep uses (.github/scripts/verify-version-lockstep.sh): every publishable
+// artefact deps.edn carrying a `:clein/build` alias is a published artefact.
+// Each browser-optional runtime among them MUST map either to a primary generic
+// ARTEFACTS entry here OR to a real dedicated isolation gate
+// (DEDICATED_ISOLATION_GATES below). It is filesystem-derived, so a NEW
+// browser-optional artefact — a new implementation/<name>/deps.edn OR a new
+// implementation/adapters/<name>/deps.edn with :clein/build, not in the
+// exclusion set — that is neither generic-gated nor dedicated-gated fails
+// automatically (FAIL-CLOSED). The check does NOT compare two copies of its own
+// local table.
 //
-// Excluded (published, but NOT a browser-optional runtime — each with reason):
+// Traversal mirrors the release lockstep's bounded FLAT-plus-ADAPTERS shape:
+// per-feature + core-tier artefacts live at implementation/<name>/; substrate
+// adapters live one directory deeper at implementation/adapters/<name>/. The
+// pre-rf2-klyw5 scan read only the top level, so a newly publishable adapter was
+// never enrolled (rf2-klyw5 NOTES — a second counterexample to rf2-sh0sp4 AC6).
+//
+// Excluded from the REQUIRED set (published, but NOT a browser-optional client
+// runtime — each with reason):
 //   core     — always present (the lockstep root; every app loads it, so it is
 //              never isolated from the counter bundle).
-//   ui       — always present (the compiled-view substrate; every adapter loads
-//              it, so it is never isolated from the counter bundle).
 //   ssr-ring — JVM-only ring server adapter (all .clj; no CLJS runtime body can
 //              reach a production client bundle).
-// Substrate adapters (implementation/adapters/*) are always present with their
-// substrate and live one directory deeper, so the top-level scan skips them.
-const NON_BROWSER_OPTIONAL = new Set(['core', 'ui', 'ssr-ring']);
+// `ui` is deliberately NOT excluded (rf2-klyw5): day8/re-frame2-ui is a separate
+// browser-capable substrate artefact that the adapters do NOT depend on, so the
+// old "always present, every adapter loads it" premise was false and let a
+// future publishable UI stay unguarded. Because implementation/ui/deps.edn
+// carries no real :clein/build today (only a comment mentioning the alias), UI
+// is not discovered and pre-publication stays green NATURALLY; when
+// rf2-vxgfnd.99.2 makes UI publishable, it must land a UI isolation entry/gate
+// in that same slice or this coverage check fails and names `ui`.
+const NON_BROWSER_OPTIONAL = new Set(['core', 'ssr-ring']);
+
+// Nested substrate-adapter tier, relative to implementation/ (matches the
+// lockstep authority's implementation/adapters/<name>/ layout).
+const ADAPTERS_DIR = 'adapters';
+
+// Browser-optional runtimes covered by a REAL dedicated isolation gate rather
+// than a generic ARTEFACTS entry. Each substrate adapter ships in the counter/
+// login example matrix and is proven isolated by an adapter-specific gate (the
+// per-feature artefacts, by contrast, must be ABSENT from the no-feature counter
+// bundle, which the generic ARTEFACTS sentinels prove). A discovered runtime
+// mapped here is accounted for; a discovered runtime mapped NOWHERE fails closed.
+// Keep this to the set of EXISTING dedicated gates only — do not add a runtime
+// here without a real gate script proving its isolation.
+const DEDICATED_ISOLATION_GATES = {
+  reagent:
+    'check-uix-helix-reagent-free.cjs + check-login-bundle-isolation.cjs ' +
+    '(reagent is the counter/login reference substrate; its fingerprints are ' +
+    'the positive control both gates assert present, and absent from uix/helix)',
+  uix:
+    'check-uix-helix-reagent-free.cjs + check-login-bundle-isolation.cjs ' +
+    '(uix bundles must be reagent- and helix-free)',
+  helix:
+    'check-uix-helix-reagent-free.cjs + check-login-bundle-isolation.cjs ' +
+    '(helix bundles must be reagent- and uix-free)',
+  'reagent-slim':
+    'check-reagent-slim-bundle-isolation.cjs (test:reagent-slim:bundle-isolation ' +
+    '— slim bundle free of stock reagent + react-dom/server; classic bundle ' +
+    'free of the reagent2.* rewrite)',
+};
 
 // Strip deps.edn line comments (`;` to EOL) so a header comment MENTIONING
-// `:clein/build` (several artefact deps.edn headers do) is not mistaken for a
-// real build alias.
+// `:clein/build` (several artefact deps.edn headers do — implementation/ui's is
+// exactly such a comment) is not mistaken for a real build alias.
 function stripEdnComments(edn) {
   return edn.replace(/;[^\n]*/g, '');
 }
 
-function canonicalBrowserOptionalArtefacts() {
-  const out = [];
-  let entries;
+// True when <root>/<relPath>/deps.edn declares a REAL (non-comment) :clein/build
+// alias — i.e. the directory is a separately publishable artefact.
+function hasRealBuildAlias(root, relPath) {
+  let deps;
   try {
-    entries = fs.readdirSync(ROOT, { withFileTypes: true });
+    deps = fs.readFileSync(path.join(root, relPath, 'deps.edn'), 'utf8');
+  } catch (_e) {
+    return false; // no deps.edn — not a publishable artefact directory
+  }
+  return /:clein\/build/.test(stripEdnComments(deps));
+}
+
+// Discover every publishable browser-optional runtime under implementation/,
+// using the lockstep authority's bounded flat-plus-adapters traversal. Returns
+// `{ name, relPath }` records; `name` is the directory leaf (unique across both
+// tiers) and `relPath` is the implementation/-relative path for diagnostics.
+function discoverBrowserOptionalRuntimes(root = ROOT) {
+  const out = [];
+
+  // Flat per-feature + core-tier artefacts: implementation/<name>/deps.edn.
+  let flat;
+  try {
+    flat = fs.readdirSync(root, { withFileTypes: true });
   } catch (_e) {
     return out; // implementation/ unreadable — nothing to require (fails safe elsewhere)
   }
-  for (const ent of entries) {
-    if (!ent.isDirectory() || NON_BROWSER_OPTIONAL.has(ent.name)) continue;
-    let deps;
-    try {
-      deps = fs.readFileSync(path.join(ROOT, ent.name, 'deps.edn'), 'utf8');
-    } catch (_e) {
-      continue; // no deps.edn — not a publishable artefact directory
+  for (const ent of flat) {
+    if (!ent.isDirectory()) continue;
+    if (ent.name === ADAPTERS_DIR) continue;         // descended into below
+    if (NON_BROWSER_OPTIONAL.has(ent.name)) continue;
+    if (hasRealBuildAlias(root, ent.name)) {
+      out.push({ name: ent.name, relPath: ent.name });
     }
-    if (/:clein\/build/.test(stripEdnComments(deps))) {
-      out.push(ent.name);
+  }
+
+  // Nested substrate adapters: implementation/adapters/<name>/deps.edn. The
+  // pre-rf2-klyw5 top-level-only scan skipped these; the lockstep authority
+  // scans them, so a newly publishable adapter must be enrolled here too.
+  let adapters;
+  try {
+    adapters = fs.readdirSync(path.join(root, ADAPTERS_DIR), { withFileTypes: true });
+  } catch (_e) {
+    adapters = []; // no adapters/ dir — nothing nested to require
+  }
+  for (const ent of adapters) {
+    if (!ent.isDirectory()) continue;
+    const relPath = `${ADAPTERS_DIR}/${ent.name}`;
+    if (hasRealBuildAlias(root, relPath)) {
+      out.push({ name: ent.name, relPath });
     }
   }
   return out;
 }
 
-// Every browser-optional publishable runtime must carry a primary ARTEFACTS
-// entry. A member of the canonical inventory with no isolation entry means a
-// separately published optional runtime could leak into a production bundle
-// with nothing to catch it.
-function assertCanonicalInventoryCovered() {
-  const required = canonicalBrowserOptionalArtefacts();
-  const have = new Set(ARTEFACTS.map((a) => a.name));
-  const missing = required.filter((n) => !have.has(n));
-  return { required, missing, ok: missing.length === 0 };
+// Every discovered browser-optional publishable runtime must map to a real
+// isolation gate — either a generic ARTEFACTS entry (per-feature runtimes, which
+// must be ABSENT from the no-feature counter bundle) or an explicit existing
+// dedicated gate (substrate adapters, proven isolated by adapter-specific gates).
+// A discovered runtime mapped to NEITHER means a separately published optional
+// runtime could leak into a production bundle with nothing to catch it — so the
+// gate fails closed and names it.
+function assertCanonicalInventoryCovered(required = discoverBrowserOptionalRuntimes()) {
+  const generic = new Set(ARTEFACTS.map((a) => a.name));
+  const covered = [];
+  const missing = [];
+  for (const rt of required) {
+    if (generic.has(rt.name)) {
+      covered.push({ ...rt, via: 'generic' });
+    } else if (DEDICATED_ISOLATION_GATES[rt.name]) {
+      covered.push({ ...rt, via: 'dedicated', gate: DEDICATED_ISOLATION_GATES[rt.name] });
+    } else {
+      missing.push(rt);
+    }
+  }
+  return {
+    required,
+    covered,
+    missing,
+    genericCount: covered.filter((c) => c.via === 'generic').length,
+    dedicatedCount: covered.filter((c) => c.via === 'dedicated').length,
+    ok: missing.length === 0,
+  };
 }
 
 // ----- main ------------------------------------------------------------------
@@ -1017,7 +1110,8 @@ function main() {
         `${ARTEFACTS.length} artefact entries; ${internalChecked} internal sentinels absent; ` +
         `${allowListChecked} allow-list budgets ok; ` +
         `${positiveChecked} emitted positive-control sentinels present; ` +
-        `${coverage.required.length} canonical browser-optional runtimes covered; ` +
+        `${coverage.required.length} canonical browser-optional runtimes covered ` +
+        `(${coverage.genericCount} generic, ${coverage.dedicatedCount} dedicated); ` +
         `bundle=${bundleDir} (${blob.length} chars)`
     );
     process.exit(0);
@@ -1069,14 +1163,16 @@ function main() {
       console.error('');
     }
     if (!coverage.ok) {
-      console.error('Canonical inventory coverage (rf2-sh0sp4):');
-      console.error(`  Browser-optional publishable runtime(s) with NO isolation entry: ${coverage.missing.join(', ')}`);
+      console.error('Canonical inventory coverage (rf2-sh0sp4 / rf2-klyw5):');
+      console.error(`  Browser-optional publishable runtime(s) with NO isolation gate: ${coverage.missing.map((rt) => rt.relPath).join(', ')}`);
       console.error('  Each is a separately published day8/re-frame2-<name> artefact');
-      console.error('  (implementation/<name>/deps.edn carries :clein/build) with a CLJS');
-      console.error('  runtime that could leak into a production bundle unguarded. Add a');
-      console.error('  primary ARTEFACTS entry with live runtime sentinels + a positive');
-      console.error('  control. If it is genuinely not a browser-optional runtime (always-');
-      console.error('  present or JVM-only), add it to NON_BROWSER_OPTIONAL with a reason.');
+      console.error('  (implementation/<path>/deps.edn carries :clein/build) with a CLJS');
+      console.error('  runtime that could leak into a production bundle unguarded. Either');
+      console.error('  add a primary ARTEFACTS entry with live runtime sentinels + a');
+      console.error('  positive control, or — for a substrate adapter proven by an adapter-');
+      console.error('  specific gate — map it in DEDICATED_ISOLATION_GATES. If it is');
+      console.error('  genuinely not a browser-optional runtime (always-present or JVM-');
+      console.error('  only), add it to NON_BROWSER_OPTIONAL with a reason.');
       console.error('');
     }
     if (positiveFailures.length) {
@@ -1113,6 +1209,13 @@ if (require.main === module) {
 module.exports = {
   ARTEFACTS,
   POSITIVE_CONTROL,
+  NON_BROWSER_OPTIONAL,
+  DEDICATED_ISOLATION_GATES,
+  ADAPTERS_DIR,
   assertPositiveControlComplete,
   checkArtefact,
+  stripEdnComments,
+  hasRealBuildAlias,
+  discoverBrowserOptionalRuntimes,
+  assertCanonicalInventoryCovered,
 };

--- a/implementation/scripts/check-bundle-isolation.test.cjs
+++ b/implementation/scripts/check-bundle-isolation.test.cjs
@@ -2,11 +2,17 @@
 'use strict';
 
 const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const {
   ARTEFACTS,
   POSITIVE_CONTROL,
+  DEDICATED_ISOLATION_GATES,
   assertPositiveControlComplete,
   checkArtefact,
+  discoverBrowserOptionalRuntimes,
+  assertCanonicalInventoryCovered,
 } = require('./check-bundle-isolation.cjs');
 const { assertSentinelSet } = require('./lib/sentinel-scan.cjs');
 
@@ -83,10 +89,111 @@ const duplicated = assertPositiveControlComplete(confusedArtefacts, POSITIVE_CON
 assert(!duplicated.ok, 'one sentinel attributed to two owners must fail completeness');
 assert.strictEqual(duplicated.sharedSentinels.length, 1);
 
+// ----- coverage enrollment mutations (rf2-klyw5) -----------------------------
+// The sentinel + positive-control mutations above prove per-feature artefacts
+// don't LEAK. This section proves the ENROLLMENT is FAIL-CLOSED: a newly
+// publishable UI or adapter artefact mapped to no isolation gate turns the gate
+// RED rather than being silently skipped. Executable + permanent, exercising the
+// real filesystem discovery path (not injected list membership) so a regression
+// in either the flat-plus-adapters traversal or the ui exclusion is caught.
+
+let coverageMutations = 0;
+
+// A real deps.edn declaring a genuine :clein/build alias.
+const PUBLISHABLE_DEPS =
+  '{:paths ["src"]\n :aliases {:clein/build {:lib day8/re-frame2-fixture}}}\n';
+// A deps.edn that only MENTIONS :clein/build inside a comment — the exact shape
+// of implementation/ui/deps.edn today. Must NOT be discovered as publishable.
+const COMMENT_ONLY_DEPS =
+  ';; NO :clein deploy aliases yet — deliberate; mentions :clein/build in prose.\n' +
+  '{:paths ["src"] :deps {day8/re-frame2 {:local/root "../core"}}}\n';
+
+function writeArtefact(root, relPath, contents) {
+  const dir = path.join(root, relPath);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'deps.edn'), contents);
+}
+
+// Minimal implementation/-shaped fixture: an excluded core + ssr-ring, a
+// generic-gated per-feature artefact (schemas), a comment-only pre-publication
+// ui, and a dedicated-gated adapter (reagent) — all correctly accounted for —
+// plus whatever `extra` mutation the caller injects.
+function withFixture(extra, body) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bundle-iso-cov-'));
+  try {
+    writeArtefact(root, 'core', PUBLISHABLE_DEPS);            // excluded (lockstep root)
+    writeArtefact(root, 'ssr-ring', PUBLISHABLE_DEPS);        // excluded (JVM-only)
+    writeArtefact(root, 'schemas', PUBLISHABLE_DEPS);         // generic (in ARTEFACTS)
+    writeArtefact(root, 'ui', COMMENT_ONLY_DEPS);             // pre-publication: not discovered
+    writeArtefact(root, 'adapters/reagent', PUBLISHABLE_DEPS); // dedicated gate
+    extra(root);
+    body(root);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+// Baseline: core/ssr-ring excluded, comment-only ui NOT discovered, the nested
+// adapter IS descended into, and everything discovered maps to a gate.
+withFixture(() => {}, (root) => {
+  const required = discoverBrowserOptionalRuntimes(root);
+  assert.deepStrictEqual(required.map((r) => r.name).sort(), ['reagent', 'schemas'],
+    'baseline fixture: excluded core/ssr-ring, comment-only ui skipped, adapter descended into');
+  const cov = assertCanonicalInventoryCovered(required);
+  assert(cov.ok, 'baseline fixture must be fully covered');
+  assert.strictEqual(cov.genericCount, 1, 'schemas covered by generic ARTEFACTS gate');
+  assert.strictEqual(cov.dedicatedCount, 1, 'reagent covered by dedicated gate');
+});
+
+// Mutation 1 — hypothetical PUBLISHABLE UI (real :clein/build added to
+// implementation/ui/deps.edn) while no UI isolation entry/gate exists: coverage
+// must fail and NAME ui. Proves ui is no longer permanently defined away.
+coverageMutations += 1;
+withFixture((root) => writeArtefact(root, 'ui', PUBLISHABLE_DEPS), (root) => {
+  const required = discoverBrowserOptionalRuntimes(root);
+  assert(required.some((rt) => rt.name === 'ui'),
+    'publishable ui must now be DISCOVERED (not permanently excluded)');
+  const cov = assertCanonicalInventoryCovered(required);
+  assert(!cov.ok, 'publishable ui with no isolation gate must FAIL coverage');
+  assert(cov.missing.some((rt) => rt.name === 'ui' && rt.relPath === 'ui'),
+    'coverage failure must NAME ui');
+});
+
+// Mutation 2 — hypothetical NEW PUBLISHABLE ADAPTER under
+// implementation/adapters/ while no generic entry or dedicated gate exists:
+// coverage must fail and NAME it. Proves nested adapter paths are not silently
+// skipped and a new adapter fails closed.
+coverageMutations += 1;
+withFixture((root) => writeArtefact(root, 'adapters/newfangled', PUBLISHABLE_DEPS), (root) => {
+  const required = discoverBrowserOptionalRuntimes(root);
+  assert(required.some((rt) => rt.relPath === 'adapters/newfangled'),
+    'new nested adapter must be DISCOVERED (not silently skipped)');
+  const cov = assertCanonicalInventoryCovered(required);
+  assert(!cov.ok, 'new publishable adapter with no isolation gate must FAIL coverage');
+  assert(cov.missing.some((rt) => rt.name === 'newfangled' && rt.relPath === 'adapters/newfangled'),
+    'coverage failure must NAME the new adapter');
+});
+
+// Real-tree floor: the current implementation/ tree must be fully covered, every
+// publishable adapter discovered under adapters/ and resolved by its real
+// dedicated gate, and pre-publication ui NOT required (it has no real
+// :clein/build today, so it stays green naturally).
+const realCoverage = assertCanonicalInventoryCovered();
+assert(realCoverage.ok,
+  `real implementation/ tree must be fully covered; missing: ${realCoverage.missing.map((rt) => rt.relPath).join(', ')}`);
+for (const adapter of Object.keys(DEDICATED_ISOLATION_GATES)) {
+  const rt = realCoverage.covered.find((c) => c.name === adapter);
+  assert(rt && rt.via === 'dedicated' && rt.relPath.startsWith('adapters/'),
+    `${adapter}: must be discovered under adapters/ and covered by its dedicated gate`);
+}
+assert(!realCoverage.required.some((rt) => rt.name === 'ui'),
+  'pre-publication ui must not be in the required set (no real :clein/build yet)');
+
 console.log(
   `PASS check-bundle-isolation self-test: ${ARTEFACTS.length} artefacts; ` +
   `${sentinelMutations} sentinel-removal mutations; ` +
   `${sentinelMutations} deliberate production leaks; ` +
   `${thirdParty.size} emitted third-party owners; ` +
+  `${coverageMutations} coverage enrollment mutations (publishable ui + new adapter fail closed); ` +
   'module-ownership and sentinel-ownership confusion rejected'
 );


### PR DESCRIPTION
Closes rf2-klyw5.

## The enrollment gap

`implementation/scripts/check-bundle-isolation.cjs` derived its REQUIRED set of browser-optional publishable runtimes from a top-level-only filesystem scan and a permanent exclusion list. Two silent gaps (both direct counterexamples to rf2-sh0sp4 AC6):

- **UI permanently excluded** — `NON_BROWSER_OPTIONAL = new Set(['core', 'ui', 'ssr-ring'])` (old line 901). The scan skipped `ui` *before* reading its `deps.edn` (old lines 919 → 922), on the false premise that UI is "always present because every adapter loads it". `day8/re-frame2-ui` is a separate browser-capable substrate the adapters do **not** depend on. A future real `:clein/build` on `implementation/ui/deps.edn` (the planned rf2-vxgfnd.99.2 publication) would have stayed green — missing production-bundle isolation.
- **Adapters never scanned** — `canonicalBrowserOptionalArtefacts()` (old lines 910–931) did `fs.readdirSync(ROOT)` on `implementation/` top-level only and explicitly ignored `implementation/adapters/*`. The release lockstep authority (`.github/scripts/verify-version-lockstep.sh`) scans both flat artefacts and nested adapters; a newly publishable adapter escaped enrollment.

## The fix (fail-closed, discover-by-convention)

- Remove `ui` from `NON_BROWSER_OPTIONAL` (keep `core`, `ssr-ring`). UI carries no real `:clein/build` today (only a comment mentioning the alias, correctly stripped by `stripEdnComments`), so pre-publication stays green **naturally**.
- New `discoverBrowserOptionalRuntimes(root)` uses the lockstep's bounded **flat-plus-adapters** traversal: `implementation/<name>/` + `implementation/adapters/<name>/`.
- `assertCanonicalInventoryCovered()` now requires every discovered runtime to map to a **real** gate: a generic `ARTEFACTS` entry (per-feature runtimes, proven ABSENT from the counter bundle) **or** an explicit existing dedicated gate (`DEDICATED_ISOLATION_GATES` — the four substrate adapters: reagent/uix/helix → `check-uix-helix-reagent-free.cjs` + `check-login-bundle-isolation.cjs`; reagent-slim → `check-reagent-slim-bundle-isolation.cjs`). A runtime mapped to **neither** fails closed and is named.

## Mutation turns red (proof)

- **Executable + permanent** in `check-bundle-isolation.test.cjs`: two coverage-enrollment mutations build minimal temp `implementation/`-shaped fixtures and exercise the real discovery path. A hypothetical publishable UI (real `:clein/build` on `ui/deps.edn`) and a hypothetical new publishable adapter under `adapters/` each make coverage **fail and name** the runtime; the baseline fixture + real tree stay green. A comment-only `:clein/build` is not discovered (mirrors UI today).
- **Live gate demonstration** (temporary, reverted, not committed): injecting a real `:clein/build` into `implementation/ui/deps.edn` and running `node scripts/check-bundle-isolation.cjs` → exit 1, `Browser-optional publishable runtime(s) with NO isolation gate: ui`. Reverting → green again.

## Hot-zone wiring flagged for operator

No hot-zone files edited. When rf2-vxgfnd.99.2 makes UI publishable it must, in that same slice, add UI's real isolation entry/gate (live browser-runtime sentinels + emitted positive control + a UI-free negative bundle) — otherwise this coverage check will (correctly) go red and name `ui`. No `shadow-cljs.edn` / `.github/workflows/*` change was required for this fix.

## Quality gates

- `npm run test:bundle-isolation` — **PASS**. 8 example release builds + positive-control built clean (0 warnings). Self-test PASS (22 artefacts; 38 sentinel-removal mutations; 38 deliberate leaks; 4 emitted third-party owners; **2 coverage enrollment mutations**). Main gate PASS: 22 artefact entries; 38 internal sentinels absent; 3 allow-list budgets ok; 38 positive-control sentinels present; **12 canonical browser-optional runtimes covered (8 generic, 4 dedicated)**. uix-helix-reagent-free PASS (6 checks); login-bundle-isolation PASS (18 checks).
- `npm run test:reagent-slim:bundle-isolation` — **PASS** (6 contracts, 25 sentinel checks).
- Live red-gate demonstration — **PASS** (publishable UI → gate red naming `ui`, exit 1; reverted → green).

Gate summary: 3 gate invocations run, 3 pass, 0 fail.
