### PR TITLE
fix(xray): preserve event edges on self/internal→:always + browser proof for parallel :always-round (rf2-v528f, rf2-gy9ln)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -845,9 +845,13 @@ region-qualified grammar) is projected carrying `:parallel-root-on? true`
 TOO (plus `:parallel-root-after? true` + `:after <delay>`), so this same
 arm 3 resolves a fired root-`:after` move without a separate arm — a fired
 root `:after` lights its region-qualified edge exactly as a root `:on`
-does. Separately, a region **HANDLED but UNCHANGED**
-(`before == after` with a non-empty `:cascade` for the region) lights its
-self / internal edge through an ordered, mutually-exclusive pair:
+does. Separately, a region **HANDLED but UNCHANGED** — its EVENT target is
+the resting state (`before == the event target`) with a non-empty
+**non-microstep** `:cascade` for the region, EVEN when a later `:always`
+round then moves the region on so the settled `after` differs (rf2-v528f;
+see [§Parallel parent-owned `:always` round](#parallel-parent-owned-always-round-fired-edge-highlight-rf2-bvwv4q))
+— lights its self / internal edge through an ordered, mutually-exclusive
+pair:
 (a) a **leaf** self / internal edge (region-scoped in-region `:source`,
 `:from-path == :to-path`, rf2-l8ls6w); else (b) a region-**ROOT
 targetless / action-only `:on`** fallback — a region-level `:on`
@@ -906,9 +910,28 @@ the round loop advanced — the parallel analog of `direct-event-target`), so
 the event edge matches `:idle → :staged` (never the phantom `:idle → :done`);
 and each round's own regional hop is matched with `event*` `:always`
 (region-scoped, `region-local-fired-ids`), so an **ACTIONLESS** round still
-lights. A region that **DECLINED** the external event but later took an
-`:always` round has its first round's `:from` equal to its pre-event state,
-so it gains **no phantom event-labelled edge** — only its round edges light.
+lights.
+
+**Handled self/internal EVENT then a round (rf2-v528f).** A region can HANDLE
+the event with a real **self / internal** transition (`before == the event
+target` — the region rests on the event) and THEN take an `:always` round
+that moves it on. Because the discriminator is `before` vs the **event
+target** (the first round's `:from`), NOT `before` vs the settled `after`,
+the region's self / internal EVENT edge still lights alongside its round
+edge. The earlier derivation additionally required the region to have **no**
+rounds and diffed the settled before/after, so an internal-then-round region
+lost its event edge (e.g. `:idle --:go[/:arm]--> :idle` then a guarded
+`:idle --:always--> :done` lit only the `:always` edge, dropping
+`region__a__idle__idle__go__a_arm`). The event-handled-region set
+(`handled-regions-from-cascade`) is derived from the **non-`:microstep`**
+cascade steps (`:exit` / `:action` / `:entry`) alone: a parallel macrostep's
+`:cascade` interleaves the event-handling steps with one `:kind :microstep`
+step per round, so a region that **DECLINED** the event but participated in
+stabilization contributes ONLY microstep steps and is correctly excluded —
+counting them would mint a **phantom** event edge. A declined-then-round
+region's first round `:from` equals its pre-event state, so it gains **no
+phantom event-labelled edge** — only its round edges light.
+
 Region-tagging keeps this scoped to parallel: single-active `:always`
 microsteps carry no `:region` and continue to ride the transition's
 structured `:cascade` (above). The returned ids are the EXACT canonical

--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -937,6 +937,14 @@ microsteps carry no `:region` and continue to ride the transition's
 structured `:cascade` (above). The returned ids are the EXACT canonical
 machines-viz edge-ids the live chart mints (agreement by construction).
 
+**Browser proof (rf2-gy9ln).** The round RENDER — the `[ALWAYS]` round rows
+(`data-cascade-round-index`, actionless-round visibility) AND the four regional
+`data-fired-edge-ids` this section derives — is pinned by a real-Chromium
+`-dom-cljs-test` mount driven off real parallel-round trace evidence
+(`panels.epoch.machine-epochs-always-round-dom-cljs-test`); see
+[`017-Test-Coverage-Matrix.md`](017-Test-Coverage-Matrix.md) §Parallel
+`:always`-round BROWSER proof.
+
 ### Guard-blocked edge highlight on the topology chart (rf2-fzrzlw)
 
 A guard-blocked no-op (above) emits NO `:rf.machine/transition`, so the chart's

--- a/tools/xray/spec/017-Test-Coverage-Matrix.md
+++ b/tools/xray/spec/017-Test-Coverage-Matrix.md
@@ -242,6 +242,28 @@ only. The CLJS render-fidelity harness
 (`panels.epoch.machine-epochs-harness-cljs-test`) drives the substrate
 directly and is decoupled from this view.
 
+**Parallel `:always`-round BROWSER proof (rf2-gy9ln).** The render-fidelity
+harness above is Node-only, while browser selection runs `-dom-cljs-test`
+namespaces; the nightly `runMachineEpochs` asserts per-frame snapshots and
+explicitly delegates deep microstep render fidelity to the CLJS unit. So
+removing the projection/view clause for parent-owned parallel `:always` rounds
+(rf2-bvwv4q) could leave every browser check green. The focused browser proof
+`panels.epoch.machine-epochs-always-round-dom-cljs-test` closes that gap: it
+drives the REAL co-selected parallel-round machine (`:go` moves both regions
+`:idle → :staged`, then a parent round co-selects both `:staged → :done`),
+captures the emitted `:rf.machine/transition` + `:rf.machine.microstep/
+transition` traces, and mounts the REAL render layers into a real Chromium DOM
+(Reagent adapter → `reagent.dom.client` → `flushSync`). It asserts (1) the
+SHARED machine-cascade mini-pipeline renders TWO first-class `[ALWAYS]` round
+rows (regions `:a` then `:b`, shared `data-cascade-round-index` 0) with NO
+`[ACTION]` row — the round is ACTIONLESS yet the rows are visible — and (2) the
+focused-event section's chart wrapper renders `data-fired-edge-ids` carrying the
+FOUR real regional edges (`:a`/`:b` direct `:go` events + `:a`/`:b` `:always`
+rounds), computed from the real trace via `extract-fired-edge-ids`. Filtering
+`:rf.machine.microstep/transition` out of the projection drops the round rows;
+filtering it out of the fired-edge derivation drops the two `:always` edges —
+either reddens the proof.
+
 ## Cross-references
 
 - [`000-Vision.md`](./000-Vision.md) - panel inventory and the five canonical questions.

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
@@ -363,17 +363,31 @@
 
 (defn- handled-regions-from-cascade
   "rf2-l8ls6w — the SET of region names a parallel macrostep actually HANDLED
-  this transition, read off the trace's structured `:cascade`. Each cascade
+  the EXTERNAL event, read off the trace's structured `:cascade`. Each cascade
   step carries `:region <region-name>` (stamped by the single-machine engine
   from the synthetic region-spec's `:rf/region` — `transition.cljc` §structured
   cascade steps); a region that handled the event contributes at least one
-  step (`:exit` / `:action` / `:entry`), a RESTING region (declined the event)
-  contributes none. This is the discriminator that distinguishes a HANDLED-
-  unchanged region (a real self/internal transition with `before == after` +
-  a non-empty cascade) from a region that simply did not move. Returns the set
-  of non-nil `:region`s present in the cascade."
+  EVENT step (`:exit` / `:action` / `:entry`), a RESTING region (declined the
+  event) contributes none. This is the discriminator that distinguishes a
+  HANDLED-unchanged region (a real self/internal transition whose EVENT target
+  is the resting state + a non-empty event cascade) from a region that simply
+  did not move.
+
+  rf2-v528f — `:kind :microstep` steps are EXCLUDED. A parallel macrostep's
+  `:cascade` interleaves the event-handling steps with one `:kind :microstep`
+  step per parent-owned `:always` ROUND (`parallel.cljc` — each carries the
+  round's `:region`). A region that DECLINED the event but participated in
+  stabilization (took an `:always` round) contributes ONLY microstep steps, so
+  counting them would mark it event-handled and mint a PHANTOM event edge. Event
+  handling is derived from the non-microstep (`:exit` / `:action` / `:entry`)
+  steps alone; the round edges light off the standalone round evidence
+  (`microstep-region-rounds`), not this set. Returns the set of non-nil
+  `:region`s present in the non-microstep cascade steps."
   [cascade]
-  (into #{} (keep :region) cascade))
+  (into #{}
+        (comp (remove #(= :microstep (:kind %)))
+              (keep :region))
+        cascade))
 
 (defn- region-local-fired-ids
   "rf2-8ncxrf — fired-edge ids for ONE region that CHANGED state (its
@@ -583,15 +597,17 @@
       region-local/region-level edge ALSO matches cannot happen — the root
       `:on` is suppressed ENTIRELY when any region handles the event, Spec
       005; so the three are mutually exclusive per region.)
-    - **rf2-l8ls6w / rf2-pdvtxt — region HANDLED but UNCHANGED.** `before ==
-      after` yet the region appears in the `:cascade` (a real self/internal
-      transition fired with a non-empty cascade). Two self/internal edge
-      shapes are lit, in order: a LEAF self/internal edge (`region-self-
-      internal-fired-ids`, region-scoped in-region source), else a region-ROOT
-      targetless/action-only `:on` fallback (`region-machine-internal-fired-
-      ids`, `:machine-level? true` `:internal? true` sourced from the region
-      CONTAINER — rf2-pdvtxt). A region that simply DECLINED the event
-      (RESTING — absent from the cascade) lights nothing.
+    - **rf2-l8ls6w / rf2-pdvtxt / rf2-v528f — region HANDLED but UNCHANGED.**
+      `before == the EVENT target` (the event left the region resting) yet the
+      region appears in the `:cascade` (a real self/internal transition fired
+      with a non-empty event cascade) — EVEN when a later `:always` round then
+      moves the region on, so the settled `after` differs (rf2-v528f). Two
+      self/internal edge shapes are lit, in order: a LEAF self/internal edge
+      (`region-self-internal-fired-ids`, region-scoped in-region source), else a
+      region-ROOT targetless/action-only `:on` fallback (`region-machine-
+      internal-fired-ids`, `:machine-level? true` `:internal? true` sourced from
+      the region CONTAINER — rf2-pdvtxt). A region that simply DECLINED the
+      event (RESTING — absent from the event cascade) lights nothing.
 
   `handled-regions` is the set of region names the cascade recorded (from
   `handled-regions-from-cascade`). Per-region `from` / `to` are coerced
@@ -606,10 +622,17 @@
   does not exist. When a region has rounds, this lights the DIRECT event edge
   against the FIRST round's `:from` (the state the event committed, not the
   settled state — the parallel analog of the single-active `direct-event-
-  target`), PLUS each round's own regional `:always` edge. A region that
-  DECLINED the event but later took an `:always` round (its first round's
-  `:from` equals its pre-event state) gains NO phantom event edge — only its
-  round edges light. Returns a seq of ids."
+  target`), PLUS each round's own regional `:always` edge.
+
+  rf2-v528f — the event edge is derived from `before` vs the EVENT target (the
+  first round's `:from`), NOT `before` vs the settled `after`. So a region that
+  handled the event with a SELF/INTERNAL transition (`before == event-target`)
+  and THEN took an `:always` round still lights its self/internal event edge —
+  the round moving the region on no longer suppresses it. Conversely a region
+  that DECLINED the event but later took an `:always` round (its first round's
+  `:from` equals its pre-event state, and it is ABSENT from the non-microstep
+  event cascade) gains NO phantom event edge — only its round edges light.
+  Returns a seq of ids."
   [edges before-map after-map event* handled-regions region->rounds]
   (when event*
     (mapcat
@@ -647,17 +670,21 @@
                   (seq (region-machine-on-fired-ids edges region ev-to* event*))
                   (region-root-on-fired-ids edges region ev-to* event*))
 
-              ;; HANDLED-but-UNCHANGED with NO round: a real self/internal
-              ;; transition (before == after + a non-empty cascade). A LEAF
-              ;; self/internal edge wins; else a region-ROOT targetless/action-
-              ;; only `:on` fallback (rf2-pdvtxt). A RESTING region (= but
-              ;; absent from the cascade) lights nothing. A region that DECLINED
-              ;; the event but later took a round has `rounds`, so it never
-              ;; reaches here (rf2-bvwv4q — no phantom event edge); only its
-              ;; `always-ids` light.
+              ;; HANDLED-but-UNCHANGED on the EVENT: a real self/internal
+              ;; transition whose EVENT target is the resting state
+              ;; (`region-before == event-target`) with a non-empty event
+              ;; cascade — EVEN when a later `:always` round then moves the
+              ;; region on, so the settled `region-after` differs (rf2-v528f).
+              ;; The discriminator is the EVENT target, not the settled state.
+              ;; A LEAF self/internal edge wins; else a region-ROOT targetless/
+              ;; action-only `:on` fallback (rf2-pdvtxt). `handled-regions` is
+              ;; derived from the NON-microstep cascade steps (rf2-v528f), so a
+              ;; region that DECLINED the event but took a round is ABSENT and
+              ;; lights no phantom event edge — only its `always-ids` light. A
+              ;; RESTING region (unchanged + absent from the event cascade)
+              ;; lights nothing.
               (and from*
-                   (empty? rounds)
-                   (= region-before region-after)
+                   (= region-before event-target)
                    (contains? handled-regions region))
               (or (seq (region-self-internal-fired-ids edges region from* event*))
                   (region-machine-internal-fired-ids edges region event*))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_always_round_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_always_round_dom_cljs_test.cljs
@@ -1,0 +1,225 @@
+(ns day8.re-frame2-xray.panels.epoch.machine-epochs-always-round-dom-cljs-test
+  "Browser (real-DOM) proof for parallel `:always`-round RENDERING (rf2-gy9ln).
+
+  ## The gap this closes
+
+  PR #5978 delivered the parent-owned parallel `:always`-round evidence + its
+  Node/JVM projection + trace-state coverage, but NO browser (`-dom-cljs-test`)
+  fixture asserts the RENDER. The real-runtime `machine_epochs_harness_cljs_test`
+  is Node-only; browser selection runs `-dom-cljs-test` namespaces. The nightly
+  `runMachineEpochs` asserts per-frame snapshots and EXPLICITLY delegates deep
+  microstep render fidelity to the CLJS unit, and PR smoke does not stage
+  machine-epochs. So removing the projection/view clause for parallel `:always`
+  rounds could leave every browser check green — no DOM test pinned
+  `data-cascade-round-index`, the `[ALWAYS]` round presentation, actionless-round
+  visibility, or the four regional topology edges.
+
+  ## What it drives + asserts (real evidence, not hand-built view-models)
+
+  It drives the REAL parallel-round machine through the LIVE substrate
+  (`dispatch-sync [:go]`), captures the trace stream Xray's ring buffer recorded
+  (the aggregate `:rf.machine/transition` + the two standalone
+  `:rf.machine.microstep/transition` round traces — `machines/parallel.cljc`),
+  and feeds it through the REAL render layers into a REAL DOM mount (Reagent
+  adapter → `reagent.dom.client/create-root` → `react-dom/flushSync`):
+
+    1. `machine-epochs-always-round-renders-round-rows-in-browser` mounts the
+       SHARED `epoch-view/machine-cascade-mini-pipeline` (the SAME renderer the
+       Epoch panel + Machine tab use), projecting `proj/machine-cascade-rows`,
+       and asserts the DOM carries TWO first-class `[ALWAYS]` round rows (regions
+       `:a` then `:b`, shared `data-cascade-round-index` 0), with NO `[ACTION]`
+       row (the round is ACTIONLESS — the round trace is its only evidence).
+       Reddens if `proj/machine-cascade-rows` stops harvesting
+       `:rf.machine.microstep/transition` OR the view drops the `:microstep` row
+       clause (`cascade-microstep-round-clause`).
+
+    2. `machine-epochs-always-round-renders-four-fired-topology-edges-in-browser`
+       mounts the REAL `machine-inspector/focused-event-section` (the focused
+       Machine tab surface — the shared mini-pipeline above its topology chart)
+       with the record's `:fired-edge-ids` computed from the REAL trace via
+       `trace-state/extract-fired-edge-ids`, and asserts the chart wrapper's
+       `data-fired-edge-ids` RENDERS exactly the four real regional edges (`:a`/
+       `:b` direct `:go` events + `:a`/`:b` `:always` rounds). Reddens if the
+       round `:rf.machine.microstep/transition` evidence is filtered from the
+       fired-edge derivation (the two `:always` edges drop).
+
+  ## Test target
+
+  The ns ends in `_dom_cljs_test.cljs` so it runs under the `:browser-test`
+  build (real DOM / React via Chromium) — the ordinary browser selector/CI lane
+  for Xray changed surfaces. The `:node-test` build's `cljs-test$` regex also
+  matches the suffix, so the ns loads under Node too, where the body
+  short-circuits via `(browser?)` (no `js/document` mount)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as string]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.preload :as preload]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]
+            [day8.re-frame2-xray.panels.epoch.projection :as proj]
+            [day8.re-frame2-xray.panels.epoch.view :as epoch-view]
+            [day8.re-frame2-xray.panels.machines.trace-state :as trace-state]
+            [day8.re-frame2-xray.panels.machine-inspector :as machine-inspector]
+            [day8.re-frame2-machines-viz.chart.layout :as chart-layout]))
+
+;; Reagent adapter — a real React mount is the whole point of this file.
+(use-fixtures :each
+  (xray-test-support/make-xray-runtime-fixture {:adapter reagent-adapter/adapter}))
+
+(def ^:private machine-id :xray-test.always-round/par)
+
+;; The SAME co-selected parallel-round machine the Node harness drives
+;; (`machine_epochs_harness_cljs_test` / `re-frame.parallel-always-round-cljs-test`
+;; `co-selected-machine`): each region `:idle --:go--> :staged` then a parent
+;; round co-selects both `:staged --:always--> :done`. ACTIONLESS — the round
+;; trace is its ONLY first-class evidence.
+(def ^:private parallel-round-machine
+  {:type         :parallel
+   :region-order [:a :b]
+   :regions {:a {:initial :idle
+                 :states  {:idle   {:on {:go :staged}}
+                           :staged {:always :done}
+                           :done   {}}}
+             :b {:initial :idle
+                 :states  {:idle   {:on {:go :staged}}
+                           :staged {:always :done}
+                           :done   {}}}}})
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test` build
+  loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- drive-real-round!
+  "Drive the REAL runtime: register + start the machine, dispatch `:go`, and
+  return the trace stream Xray's ring buffer recorded — the aggregate
+  `:rf.machine/transition` (settled region-map) PLUS the two standalone
+  `:rf.machine.microstep/transition` round traces. Real evidence, NOT a
+  hand-built view-model."
+  []
+  (registry/register-xray-handlers!)
+  (preload/register-trace-collector!)
+  (rf/reg-machine machine-id parallel-round-machine)
+  (rf/dispatch-sync [machine-id [:rf.machine/start]])
+  (trace-collector/reset-for-test!)
+  (rf/dispatch-sync [machine-id [:go]])
+  (vec (trace-collector/buffer-for-test)))
+
+(defn- mount!
+  "Mount `component` into a fresh, sized DOM container, committed synchronously
+  via `flushSync` (React 19 `root.render` is otherwise async). Returns
+  `{:container :root}`; the caller `cleanup!`s."
+  [component]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)]
+    (set! (.. container -style -width) "720px")
+    (set! (.. container -style -height) "520px")
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync (fn [] (rdc/render root component)))
+    {:container container :root root}))
+
+(defn- cleanup! [{:keys [container root]}]
+  (try (.unmount root) (catch :default _ nil))
+  (.remove container))
+
+(defn- q-all [container sel] (vec (js/Array.from (.querySelectorAll container sel))))
+
+(defn- region-edge-id
+  "The canonical machines-viz edge id for `region`'s `from → to` on `event`,
+  disambiguated by the region-scoped `:source` — the SAME id the live chart
+  mints (agreement by construction)."
+  [projected region from to event]
+  (some (fn [e]
+          (when (and (= from  (:from-path e))
+                     (= to    (:to-path e))
+                     (= event (:event e))
+                     (= (chart-layout/region-scoped-id region from) (:source e)))
+            (:id e)))
+        projected))
+
+(deftest machine-epochs-always-round-renders-round-rows-in-browser
+  (testing "rf2-gy9ln — driving the REAL parallel-round runtime, the SHARED
+            machine-cascade mini-pipeline RENDERS two first-class [ALWAYS] round
+            rows (regions :a then :b, shared round-index 0), each carrying
+            data-cascade-round-index + data-cascade-region, with NO [ACTION] row
+            (the round is ACTIONLESS but still visible). Reddens if the
+            projection stops harvesting :rf.machine.microstep/transition OR the
+            view drops the :microstep row clause."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real DOM mount")
+      (let [trace-events (drive-real-round!)
+            cascade      (proj/machine-cascade-rows trace-events)
+            mounted      (mount! [epoch-view/machine-cascade-mini-pipeline cascade machine-id])
+            container    (:container mounted)]
+        (try
+          (let [micro-rows    (q-all container
+                                (str "[data-testid^=\"rf-xray-epoch-machine-cascade-row-\""
+                                     "][data-cascade-kind=\"microstep\"]"))
+                round-clauses (q-all container
+                                "[data-testid^=\"rf-xray-epoch-machine-cascade-microstep-round-\"]")
+                always-pills  (q-all container
+                                "[data-testid=\"rf-xray-epoch-machine-cascade-kind-microstep\"]")
+                action-rows   (q-all container "[data-cascade-kind=\"action\"]")]
+            (is (= 2 (count micro-rows))
+                "two first-class :microstep round rows render in the real DOM")
+            (is (= ["a" "b"] (mapv #(.getAttribute % "data-cascade-region") round-clauses))
+                "the two round rows render regions :a then :b in deterministic order")
+            (is (= ["0" "0"] (mapv #(.getAttribute % "data-cascade-round-index") round-clauses))
+                "co-selected rounds share data-cascade-round-index 0 — ONE parent-owned round")
+            (is (and (= 2 (count always-pills))
+                     (every? #(= "ALWAYS" (string/trim (.-textContent %))) always-pills))
+                "each round row renders the [ALWAYS] kind badge")
+            (is (empty? action-rows)
+                "the round is ACTIONLESS — NO [ACTION] row renders, yet the round rows are visible"))
+          (finally (cleanup! mounted)))))))
+
+(deftest machine-epochs-always-round-renders-four-fired-topology-edges-in-browser
+  (testing "rf2-gy9ln — the focused-event Machine section RENDERS
+            data-fired-edge-ids carrying the four real regional topology edges
+            (:a/:b direct :go events + :a/:b :always rounds), computed from the
+            REAL trace via extract-fired-edge-ids. Reddens if the round
+            :rf.machine.microstep/transition evidence is filtered from the
+            fired-edge derivation (the two :always edges drop)."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real DOM mount")
+      (let [trace-events (drive-real-round!)
+            cascade      (proj/machine-cascade-rows trace-events)
+            projected    (:edges (chart-layout/project-definition parallel-round-machine))
+            a-go         (region-edge-id projected :a [:idle]   [:staged] :go)
+            b-go         (region-edge-id projected :b [:idle]   [:staged] :go)
+            a-always     (region-edge-id projected :a [:staged] [:done]   :always)
+            b-always     (region-edge-id projected :b [:staged] [:done]   :always)
+            fired        (trace-state/extract-fired-edge-ids
+                           parallel-round-machine trace-events machine-id)
+            ;; The focused-event record the Machine tab renders: real cascade +
+            ;; the real fired-edge-ids computed above (the same values the panel's
+            ;; sub computes off extract-fired-edge-ids).
+            record       {:machine-id     machine-id
+                          :from-state     {:a :idle :b :idle}
+                          :to-state       {:a :done :b :done}
+                          :definition     parallel-round-machine
+                          :fired-edge-ids fired
+                          :no-op?         false}
+            mounted      (mount! [rf/frame-provider {:frame :rf/default}
+                                  [(fn [] (#'machine-inspector/focused-event-section
+                                            cascade record))]])
+            container    (:container mounted)]
+        (try
+          (is (every? string? [a-go b-go a-always b-always])
+              "all four real regional edges exist in the projection")
+          (let [chart    (.querySelector container
+                           "[data-testid=\"rf-xray-machine-focused-event-chart\"]")
+                rendered (some-> chart (.getAttribute "data-fired-edge-ids"))
+                ids      (set (when rendered
+                                (remove string/blank? (string/split rendered #"\s+"))))]
+            (is (some? chart) "the focused-event chart wrapper rendered")
+            (is (= #{a-go b-go a-always b-always} ids)
+                (str "data-fired-edge-ids RENDERS exactly the four real regional edges "
+                     "(two direct :go + two :always rounds); rendered=" (pr-str rendered))))
+          (finally (cleanup! mounted)))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
@@ -1105,6 +1105,126 @@
       (is (= #{a-go a-always b-always} fired)
           "b lights ONLY its :always round edge — no phantom :go edge for the
            region that declined the event"))))
+
+;; ---- extract-fired-edge-ids: HANDLED self/internal EVENT then an :always ----
+;; ROUND (rf2-v528f)
+;;
+;; A parallel region can HANDLE the external event with a real SELF/INTERNAL
+;; transition (before == the EVENT target — the region rests) and THEN take a
+;; parent-owned `:always` round that moves it on. The runtime commits ONE
+;; aggregate `:rf.machine/transition` whose SETTLED `:after` is the round's
+;; target, PLUS a standalone `:rf.machine.microstep/transition` per round, AND
+;; stamps the event-handling action step + a `:kind :microstep` round step into
+;; the aggregate `:cascade`. Before rf2-v528f the handled-unchanged branch
+;; required `(empty? rounds)` and diffed the SETTLED before/after, so the
+;; region's self/internal EVENT edge was DROPPED and only the round edge lit.
+;; The fix keys handled-unchanged off `(region-before == event-target)` and
+;; derives the event-handled-region set from the NON-microstep cascade steps.
+
+(deftest extract-fired-edge-ids-parallel-internal-then-round-keeps-event-edge
+  (testing "rf2-v528f — region :a HANDLES :go with a targetless/INTERNAL
+            transition (:arm action, stays :idle) and THEN a round moves
+            :idle→:done; BOTH the :go internal event edge AND the :always round
+            edge light — the settled :idle→:done no longer swallows the event
+            edge. region :b co-selects :idle→:staged (event) then :staged→:done."
+    (let [def       {:type    :parallel
+                     :regions {:a {:initial :idle
+                                   :states  {:idle {:on     {:go {:action :arm}}
+                                                    :always {:target :done :guard :armed?}}
+                                             :done {}}}
+                               :b {:initial :idle
+                                   :states  {:idle   {:on {:go :staged}}
+                                             :staged {:always :done}
+                                             :done   {}}}}}
+          projected (:edges (chart-layout/project-definition def))
+          a-go      (region-edge-id projected :a [:idle]   [:idle]   :go)   ;; internal self
+          a-always  (region-edge-id projected :a [:idle]   [:done]   :always)
+          b-go      (region-edge-id projected :b [:idle]   [:staged] :go)
+          b-always  (region-edge-id projected :b [:staged] [:done]   :always)
+          ;; LIVE runtime shape: ONE aggregate transition whose :cascade carries
+          ;; :a's event action step + :b's event exit/entry steps + one
+          ;; `:kind :microstep` round step per region, PLUS one standalone
+          ;; `:rf.machine.microstep/transition` per co-selected round.
+          events    [{:operation :rf.machine/transition
+                      :tags {:actor-id :par/arm
+                             :before {:state {:a :idle :b :idle}}
+                             :after  {:state {:a :done :b :done}}
+                             :event  [:go]
+                             :cascade [{:kind :action    :region :a :state []       :action :arm}
+                                       {:kind :exit      :region :b :state [:idle]}
+                                       {:kind :entry     :region :b :state [:staged]}
+                                       {:kind :microstep :region :a :microstep-index 0
+                                        :from :idle   :to :done}
+                                       {:kind :microstep :region :b :microstep-index 0
+                                        :from :staged :to :done}]}}
+                     {:operation :rf.machine.microstep/transition
+                      :tags {:actor-id :par/arm :region :a
+                             :from :idle :to :done :microstep-index 0}}
+                     {:operation :rf.machine.microstep/transition
+                      :tags {:actor-id :par/arm :region :b
+                             :from :staged :to :done :microstep-index 0}}]
+          fired     (trace-state/extract-fired-edge-ids def events :par/arm)]
+      (is (every? string? [a-go a-always b-go b-always])
+          "all four real edges exist in the projection (:a's :go is an internal self edge)")
+      (is (contains? fired a-go)
+          "the HANDLED self/internal :go EVENT edge for :a lights (rf2-v528f — was dropped
+           because a later :always round set the handled-unchanged (empty? rounds) guard false)")
+      (is (= #{a-go a-always b-go b-always} fired)
+          "exactly the four real edges light — the event edge survives the later round"))))
+
+(deftest extract-fired-edge-ids-parallel-microstep-only-region-not-event-handled
+  (testing "rf2-v528f — a region present in the aggregate :cascade ONLY via a
+            `:kind :microstep` round step is NOT treated as event-handled: no
+            phantom event edge is minted even though the projection has a
+            matchable :go internal self edge for it. Kills the 'count microsteps
+            as event handling' mutation."
+    ;; :a moves on :go (:idle→:staged) then rounds :staged→:done — event-handled
+    ;; via :exit/:entry. :b's ONLY structured presence is its `:kind :microstep`
+    ;; round step (:idle→:ready) — the trace omits any :b event step, modelling a
+    ;; region that did NOT handle :go yet took an :always round. :b's def carries
+    ;; a :go internal self edge PRECISELY so a microstep-counting derivation would
+    ;; have a phantom to (wrongly) light; the fix leaves it dark.
+    (let [def       {:type    :parallel
+                     :regions {:a {:initial :idle
+                                   :states  {:idle   {:on {:go :staged}}
+                                             :staged {:always :done}
+                                             :done   {}}}
+                               :b {:initial :idle
+                                   :states  {:idle  {:on     {:go {:action :note}} ;; internal self
+                                                     :always :ready}
+                                             :ready {}}}}}
+          projected (:edges (chart-layout/project-definition def))
+          a-go      (region-edge-id projected :a [:idle]   [:staged] :go)
+          a-always  (region-edge-id projected :a [:staged] [:done]   :always)
+          b-go      (region-edge-id projected :b [:idle]   [:idle]   :go)   ;; the phantom candidate
+          b-always  (region-edge-id projected :b [:idle]   [:ready]  :always)
+          events    [{:operation :rf.machine/transition
+                      :tags {:actor-id :par/mstep
+                             :before {:state {:a :idle :b :idle}}
+                             :after  {:state {:a :done :b :ready}}
+                             :event  [:go]
+                             ;; :a handled :go (exit/entry); :b appears ONLY as a
+                             ;; :kind :microstep round step — never an event step.
+                             :cascade [{:kind :exit      :region :a :state [:idle]}
+                                       {:kind :entry     :region :a :state [:staged]}
+                                       {:kind :microstep :region :a :microstep-index 0
+                                        :from :staged :to :done}
+                                       {:kind :microstep :region :b :microstep-index 0
+                                        :from :idle :to :ready}]}}
+                     {:operation :rf.machine.microstep/transition
+                      :tags {:actor-id :par/mstep :region :a
+                             :from :staged :to :done :microstep-index 0}}
+                     {:operation :rf.machine.microstep/transition
+                      :tags {:actor-id :par/mstep :region :b
+                             :from :idle :to :ready :microstep-index 0}}]
+          fired     (trace-state/extract-fired-edge-ids def events :par/mstep)]
+      (is (every? string? [a-go a-always b-go b-always])
+          "the projection HAS a :b :go internal self edge — a microstep-counting
+           derivation would light it as a phantom")
+      (is (not (contains? fired b-go))
+          "no phantom :go event edge for :b (present only via a :kind :microstep step)")
+      (is (= #{a-go a-always b-always} fired)
+          ":b lights ONLY its :always round edge; microstep presence is not event handling"))))
 ;; REGION-QUALIFIED targets. The before/after region-map shows the move, but
 ;; the moved region's edge is sourced from the synthetic MACHINE-ROOT chip
 ;; (region-qualified :to-path), NOT a region-local edge — so the region-local


### PR DESCRIPTION
Two-commit, same-surface cluster on `tools/xray/` — both about parallel `:always`-round rendering. Commit 1 fixes the fired-edge derivation; commit 2 adds the browser proof that passes against the fixed logic.

## rf2-v528f (P2, bug) — preserve event edges on handled self/internal → `:always` rounds

A `:type :parallel` region that HANDLES the external event with a real self/internal transition (`before == the event target` — the region rests on the event) and THEN takes a parent-owned `:always` round lost its event edge in Xray's fired-edge derivation.

- **Cause** (`tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs`): the handled-but-unchanged branch (was line ~658) required `(empty? rounds)` and diffed the settled `before`/`after`, so a later round set the guard false and only the `:always` round edge lit — dropping `region__a__idle__idle__go__a_arm`.
- **Fix**: key handled-unchanged off `(region-before == event-target)` (the event target is the first round's `:from`), not the settled `after`; and derive the event-handled-region set (`handled-regions-from-cascade`) from the **non-`:microstep`** cascade steps (`:exit`/`:action`/`:entry`) so a region that declined the event but only participated in stabilization (microstep-only) gains no phantom edge.
- **Tests**: two focused regressions added to `trace_state_cljs_test.cljs` — internal-then-round keeps the event edge (kills the `(empty? rounds)` mutation); microstep-only region is not event-handled (kills the count-microsteps mutation).
- **Red-before / green-after**: against the original source the new internal-then-round test fails, fired set omitting `region__a__idle__idle__go__a_arm` (the exact edge the bead cites); with the fix it lights alongside the `:always` edge.

## rf2-gy9ln (P2) — browser proof for parallel `:always`-round rendering

Adds `tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_always_round_dom_cljs_test.cljs`, the missing `-dom-cljs-test` browser fixture. It drives the REAL co-selected parallel-round machine, captures the emitted `:rf.machine/transition` + `:rf.machine.microstep/transition` traces, and mounts the REAL render layers into a real Chromium DOM (Reagent adapter → `reagent.dom.client` → `flushSync`). It asserts:

- the shared machine-cascade mini-pipeline renders TWO first-class `[ALWAYS]` round rows (regions `:a` then `:b`, shared `data-cascade-round-index` 0) with NO `[ACTION]` row — actionless yet visible; and
- the focused-event section's chart wrapper renders `data-fired-edge-ids` carrying the FOUR real regional edges (`:a`/`:b` direct `:go` + `:a`/`:b` `:always` rounds), computed from the real trace via `extract-fired-edge-ids`.

Mutation-verified: filtering `:rf.machine.microstep/transition` out of the projection reddens the round-row assertions (4 failures in Chromium), confirming the fixture is load-bearing.

## Spec (tools/xray/spec)

- `003-Machine-Inspector.md` — updated the handled-unchanged + parent-owned `:always`-round derivation prose for rf2-v528f, plus a cross-ref to the browser proof.
- `017-Test-Coverage-Matrix.md` — new "Parallel `:always`-round BROWSER proof (rf2-gy9ln)" note under the machine-epochs stepper section.

No `implementation/shadow-cljs.edn` change (no new testbed build-id — the fixture is a `-dom-cljs-test` namespace, wired into the browser lane by suffix convention).

## Quality gates

All foreground, unpiped, in the worker worktree.

| Gate | Result |
| --- | --- |
| `trace-state-cljs-test` (node, focused) | 65 tests / 141 assertions, 0 failures |
| Surrounding node suites (trace-state, machine-epochs harness, epoch projection, machine-inspector, topology, canvas, new dom test) | 420 tests / 1759 assertions, 0 failures |
| `tools/xray` JVM suite (`clojure -M:test`) | 1265 tests / 5899 assertions, 0 failures |
| Browser proof (`machine-epochs-always-round-dom-cljs-test`, real Chromium) | 2 tests / 8 assertions, 0 failures |
| rf2-v528f red-before / green-after | confirmed (edge dropped before, preserved after) |
| rf2-gy9ln mutation-proof (projection microstep filter) | confirmed red (4 failures), reverted |

Do NOT merge — leaving for review/merge sweep.
