### PR TITLE
docs(ui): correct re-frame.ui conditional lease guidance (rf2-c21ucg)

### DIFF
--- a/ai/findings/new-substrate-synthesis/guide/03-state.md
+++ b/ai/findings/new-substrate-synthesis/guide/03-state.md
@@ -127,9 +127,12 @@ Deps are values — a rebuilt-but-equal vector is the same dep. No identity trap
 alive. First lease in → the resource is ensured; last lease out → it can wind down.
 
 **Lease never returns data and never fetches during render.** Reading is always the
-passive `(sub [:rf/resource …])`. Conditional leases follow the same rule as
-conditional reads: `(when live? (lease …))` is legal; a `lease` inside a loop is a
-compile error (extract a keyed child view).
+passive `(sub [:rf/resource …])`. Unlike a conditional read, a `lease` is a *leading
+declaration*, not an expression — so you make liveness conditional inside the
+descriptor: `(lease (when live? descriptor))`, where the descriptor evaluates to `nil`
+(lease nothing) or a map (lease that resource). A `lease` in expression position —
+inside a `when`, a prop, or a template — is a compile error, and a `lease` inside a
+loop is too (extract a keyed child view).
 
 Rule of thumb: loading that belongs to navigation or workflow rides route/event
 resource plans; `lease` is for liveness that genuinely follows visible UI — dashboard

--- a/ai/findings/new-substrate-synthesis/guide/14-compile-time-limits.md
+++ b/ai/findings/new-substrate-synthesis/guide/14-compile-time-limits.md
@@ -62,8 +62,12 @@ single linear template.
 ## Reactive sites must be finite
 
 Every `(sub …)` and `(lease …)` is a **compile-indexed site** on the view's single
-React bridge ([12](12-how-it-works.md)). Sites may sit in branches — `sub` is not a
-hook — but they may not appear inside an unbounded loop body.
+React bridge ([12](12-how-it-works.md)). A `(sub …)` may sit in a branch — `sub` is not
+a hook — but no site may appear inside an unbounded loop body. A `(lease …)` is
+stricter still: it is a *leading declaration*, never an expression, so it may not sit in
+a branch at all. Conditional liveness moves into the descriptor —
+`(lease (when live? descriptor))` (see [03](03-state.md#resource-liveness-lease)); a
+`lease` in expression position is `:rf.ui.compile/unsupported-form`.
 
 | You cannot | Why | Do this instead |
 |---|---|---|
@@ -85,10 +89,12 @@ hook — but they may not appear inside an unbounded loop body.
          [order-row {:key id :id id}])])
 ```
 
-Conditional reads remain legal:
+Conditional reads remain legal — and a conditional *lease* keeps the `lease` as a
+leading declaration, moving the condition into its descriptor:
 
 ```clojure
-(let [details (when expanded? (sub [:orders/details id]))] …)   ; ✓
+(let [details (when expanded? (sub [:orders/details id]))] …)   ; ✓ conditional read
+(lease (when expanded? {:resource :orders/details :params {:id id}}))   ; ✓ conditional lease
 ```
 
 ---


### PR DESCRIPTION
## What

Guide 03 (`Resource liveness: lease`) and Guide 14 (`Reactive sites must be finite` / `Conditional reads remain legal`) taught `(when live? (lease …))` — a `lease` in **expression position** — as a legal conditional lease. The shipped compiler rejects that spelling. This corrects both to the shipped contract: `lease` is a **leading declaration**, so conditional liveness moves into the descriptor — `(lease (when live? descriptor))`.

## Shipped-behaviour citations (read-only; no runtime touched)

- `implementation/ui/src/re_frame/ui/compiler/analyze.cljc:793-797` — a `lease` used as an expression fails `:rf.ui.compile/unsupported-form` with the message *"(lease ...) is a declaration, not an expression … conditional liveness is (lease (when p descriptor))"*.
- `implementation/ui/test/re_frame/ui/lease_compiler_jvm_test.clj:56-77` (`body-grammar-is-a-closed-prefix`) — `(when active? (lease {…}))` + template → `:rf.ui.compile/multi-form-body`; `[:div (lease {…})]` → `:rf.ui.compile/unsupported-form`. The expression-position conditional lease is a **compile error**.
- `implementation/ui/test/re_frame/ui/resource_lease_lifecycle_dom_cljs_test.cljs:238-245` — the passing lifecycle fixture uses exactly the legal form: `(ui/lease (when (ui/sub [::activate?]) {:resource ::feed :params {…}}))`.
- `implementation/ui/src/re_frame/ui/compiler/analyze.cljc:196-234, 236-255` — the leading `(lease descriptor)` analysis accepts a descriptor that evaluates to `nil` (inactive) or a closed map, which is what makes `(lease (when p descriptor))` legal.

The acceptance criterion — a fixture proving expression-position lease is rejected while the direct conditional-descriptor form compiles — is already satisfied by the two existing fixtures above, so no new test was added (change kept scoped to the doc-truth defect).

## Changes

- **Guide 03** (`ai/findings/new-substrate-synthesis/guide/03-state.md`): replaced the false *"conditional leases follow the same rule as conditional reads: `(when live? (lease …))` is legal"* with the descriptor form `(lease (when live? descriptor))` and the note that a `lease` in expression position (or a loop) is a compile error.
- **Guide 14** (`ai/findings/new-substrate-synthesis/guide/14-compile-time-limits.md`): stated the lease-declaration exception wherever the page discusses branch-sensitive sites — `sub` may sit in a branch, `lease` may not; added the conditional-lease line to the *Conditional reads remain legal* example.

## Quality gates

- `python scripts/check_doc_slugs.py` — exit 0 (validates the new `03-state.md#resource-liveness-lease` anchor).
- `python -m mkdocs build --strict` — exit 0 (Documentation built; only pre-existing INFO notes on unrelated core/migration/spec links).
- Test suites not run (doc-only change; brief scoped to the guidance docs, runtime read-only).

Closes rf2-c21ucg.