### PR TITLE
docs(adapters): fix bare capture-frame in UIx/Helix README escape-hatch examples (rf2-5rcy4)

### DIFF
--- a/implementation/adapters/helix/README.md
+++ b/implementation/adapters/helix/README.md
@@ -9,6 +9,7 @@ See [`../README.md`](../README.md) for the wider adapter tier and the substrate 
 ## Adapter-specific surface
 
 - `re-frame.adapter.helix/use-subscribe` — Helix hook returning the current value of a subscription; re-renders the calling component when the value changes. Resolves the frame from the surrounding `frame-provider` via React context. Override via the 2-arg form to pin to an explicit frame-id.
+- `re-frame.adapter.helix/use-frame` — Helix hook returning the frame api for the ambient frame — the frame-locked ops map `{:frame :dispatch :dispatch-sync :subscribe}`, exactly what `(rf/capture-frame)` returns, in hook position. Resolves the surrounding `frame-provider` / `frame-root` via React context; a bare no-arg `(rf/capture-frame)` reads only the dynamic-var tier and raises `:rf.error/no-frame-context` under a context-provided frame. Pull `:dispatch` off it during render and close over it in callbacks. The returned map is reference-stable across re-renders for the same resolved frame (safe in effect deps).
 - `re-frame.adapter.helix/frame-provider` — the **SCOPE-only** component (rf2-nyea0r split — *roots ensure; providers scope*). `{:frame existing-id}` provides an already-created frame's id to descendants via React context, creating / refreshing / destroying nothing (the scope-into-React counterpart to `rf/with-frame`); fails loud if the frame is absent; given an `:id` (the ENSURE key) it fails loud naming `frame-root`.
 - `re-frame.adapter.helix/frame-root` — the **ENSURE** component, a commit-owned two-pass boundary. `{:id the-id}` (plus `:images` / `:initial-events` / record-config) creates the frame if absent in a client `useLayoutEffect` (a render React discards creates nothing), reuses it without re-seeding if present, and provides its id to descendants. No destroy-on-unmount.
 - `re-frame.adapter.helix/flush-views!` — test helper; wraps React's `act()` to flush pending renders synchronously.
@@ -42,11 +43,12 @@ Helix's `use-effect` is a macro whose first argument is the deps vector and whos
 
 ### Outer / inner pattern
 
-Compose `use-effect` with the standard outer/inner split: the **outer** `defnc` reads subs via `use-subscribe` and produces props; the **inner** `defnc` owns the library lifecycle via `use-effect`. Capture `(:dispatch (rf/capture-frame))` in a `let` above the `use-effect` call so the dispatcher carries the surrounding frame into the effect body.
+Compose `use-effect` with the standard outer/inner split: the **outer** `defnc` reads subs via `use-subscribe` and produces props; the **inner** `defnc` owns the library lifecycle via `use-effect`. Pull `dispatch` from the **`use-frame` hook** in a `let` above the `use-effect` call so it carries the surrounding frame into the effect body.
 
 ```clojure
 (ns my-app.tiles
   (:require [re-frame.core :as rf]
+            [re-frame.adapter.helix :as helix-adapter]
             [helix.core :as hx :refer [defnc $]]
             [helix.hooks :as hooks]
             [helix.dom :as d]))
@@ -54,7 +56,7 @@ Compose `use-effect` with the standard outer/inner split: the **outer** `defnc` 
 ;; Inner — owns the imperative lifecycle. Plain Helix defnc.
 (defnc tile-inner [{:keys [tile-id]}]
   (let [ref      (hooks/use-ref nil)
-        dispatch (:dispatch (rf/capture-frame))]   ;; captured at render — carries the frame
+        {:keys [dispatch]} (helix-adapter/use-frame)]   ;; frame api via hook — reads the surrounding provider
     (hooks/use-effect
       [tile-id]
       (let [el       (.-current ref)
@@ -66,13 +68,13 @@ Compose `use-effect` with the standard outer/inner split: the **outer** `defnc` 
 
 ;; Outer — reads subs, hands props to the inner. Registered via reg-view.
 (rf/reg-view board-panel []
-  (let [active-tile-id (re-frame.adapter.helix/use-subscribe [:board/active-tile])]
+  (let [active-tile-id (helix-adapter/use-subscribe [:board/active-tile])]
     ($ tile-inner {:tile-id active-tile-id})))
 ```
 
 Four things matter:
 
-1. **`(:dispatch (rf/capture-frame))` is captured in the `let` above `use-effect`**, not inside the effect body. The dispatcher closes over the frame at render-time; the effect body fires after commit but the closure is already established. Inside the effect body, `dispatch` carries the right frame.
+1. **The frame api comes from the `use-frame` hook**, called at the top of the component body — never a bare `(rf/capture-frame)`. `use-frame` reads the surrounding `frame-provider` / `frame-root` through React context; a no-arg `(rf/capture-frame)` in a plain hooks component reads only the dynamic-var tier and raises `:rf.error/no-frame-context` under a context-provided frame. The `dispatch` you pull off it closes over the resolved frame at render-time, so the effect body — which fires after commit on a frameless stack — still routes to the right frame.
 2. **The cleanup fn is mandatory.** Without it, the listener leaks across re-mounts and across hot-reloads. The cleanup runs on unmount and before each re-run when deps change.
 3. **The deps vector matters.** Include every prop the effect reads so React re-runs the effect when those props change. An empty deps vector means "run once on mount, clean up on unmount."
 4. **Don't call `use-subscribe` inside the effect body.** Hooks must be called at the top of the component body, not inside another hook's callback. Subscribe in the outer (or in the inner's top-level `let`) and pass the value as a dep.
@@ -80,6 +82,6 @@ Four things matter:
 ### Cross-references
 
 - [Spec 004 §Views MUST NOT attach native DOM event listeners from render bodies](../../../spec/004-Views.md#effects-and-leases--the-view-side-surface) and [§Views MUST NOT own imperative library lifecycles directly](../../../spec/004-Views.md#effects-and-leases--the-view-side-surface) — bare `addEventListener` in a render body leaks listeners and silently routes dispatches to `:rf/default`; library lifecycles belong in `use-effect`.
-- [Spec 002 §Dispatches issued from inside a handler body](../../../spec/002-Frames.md#dispatches-issued-from-inside-a-handler-body) — async callbacks escape the dynamic frame binding; capture `(:dispatch (rf/capture-frame))` at render-time to carry the frame.
+- [Spec 002 §Dispatches issued from inside a handler body](../../../spec/002-Frames.md#dispatches-issued-from-inside-a-handler-body) — async callbacks escape the dynamic frame binding; call the `use-frame` hook at render-time (capture-frame in hook position) to carry the frame into the callback.
 - **Outer/inner Pattern (Pattern-OuterInner)** — the canonical home for wrapping stateful JS components (D3, Mapbox, animation libraries); the worked example above is one instance.
 - [Helix 0.2.x docs — `use-effect`](https://github.com/lilactown/helix/blob/master/docs/creating-components.md) — the underlying hook's signature, deps-vector semantics, and stale-closure considerations.

--- a/implementation/adapters/uix/README.md
+++ b/implementation/adapters/uix/README.md
@@ -11,6 +11,7 @@ See [`../README.md`](../README.md) for the wider adapter tier and the substrate 
 ## Adapter-specific surface
 
 - `re-frame.adapter.uix/use-subscribe` — UIx hook returning the current value of a subscription; re-renders the calling component when the value changes. Resolves the frame from the surrounding `frame-provider` via React context. Override via the 2-arg form to pin to an explicit frame-id.
+- `re-frame.adapter.uix/use-frame` — UIx hook returning the frame api for the ambient frame — the frame-locked ops map `{:frame :dispatch :dispatch-sync :subscribe}`, exactly what `(rf/capture-frame)` returns, in hook position. Resolves the surrounding `frame-provider` / `frame-root` via React context; a bare no-arg `(rf/capture-frame)` reads only the dynamic-var tier and raises `:rf.error/no-frame-context` under a context-provided frame. Pull `:dispatch` off it during render and close over it in callbacks. The returned map is reference-stable across re-renders for the same resolved frame (safe in effect deps).
 - `re-frame.adapter.uix/frame-provider` — the **SCOPE-only** component (rf2-nyea0r split — *roots ensure; providers scope*). `{:frame existing-id}` provides an already-created frame's id to descendants via React context, creating / refreshing / destroying nothing (the scope-into-React counterpart to `rf/with-frame`); fails loud if the frame is absent; given an `:id` (the ENSURE key) it fails loud naming `frame-root`.
 - `re-frame.adapter.uix/frame-root` — the **ENSURE** component, a commit-owned two-pass boundary. `{:id the-id}` (plus `:images` / `:initial-events` / record-config) creates the frame if absent in a client `useLayoutEffect` (a render React discards creates nothing), reuses it without re-seeding if present, and provides its id to descendants. No destroy-on-unmount.
 - `re-frame.adapter.uix/flush-views!` — test helper; wraps React's `act()` to flush pending renders synchronously.
@@ -43,17 +44,18 @@ The escape hatch is **`uix.core/use-effect`** — UIx's React `useEffect` wrappe
 
 ### Outer / inner pattern
 
-Compose `use-effect` with the standard outer/inner split: the **outer** `defui` reads subs via `use-subscribe` and produces props; the **inner** `defui` owns the library lifecycle via `use-effect`. Capture `(:dispatch (rf/capture-frame))` in a `let` above the `use-effect` call so the dispatcher carries the surrounding frame into the effect body.
+Compose `use-effect` with the standard outer/inner split: the **outer** `defui` reads subs via `use-subscribe` and produces props; the **inner** `defui` owns the library lifecycle via `use-effect`. Pull `dispatch` from the **`use-frame` hook** in a `let` above the `use-effect` call so it carries the surrounding frame into the effect body.
 
 ```clojure
 (ns my-app.tiles
   (:require [re-frame.core :as rf]
+            [re-frame.adapter.uix :as uix-adapter]
             [uix.core :as uix :refer [defui $]]))
 
 ;; Inner — owns the imperative lifecycle. Plain UIx defui.
 (defui tile-inner [{:keys [tile-id]}]
   (let [ref      (uix/use-ref)
-        dispatch (:dispatch (rf/capture-frame))]   ;; captured at render — carries the frame
+        {:keys [dispatch]} (uix-adapter/use-frame)]   ;; frame api via hook — reads the surrounding provider
     (uix/use-effect
       (fn []
         (let [el       (.-current ref)
@@ -66,13 +68,13 @@ Compose `use-effect` with the standard outer/inner split: the **outer** `defui` 
 
 ;; Outer — reads subs, hands props to the inner. Registered via reg-view.
 (rf/reg-view board-panel []
-  (let [active-tile-id (re-frame.adapter.uix/use-subscribe [:board/active-tile])]
+  (let [active-tile-id (uix-adapter/use-subscribe [:board/active-tile])]
     ($ tile-inner {:tile-id active-tile-id})))
 ```
 
 Four things matter:
 
-1. **`(:dispatch (rf/capture-frame))` is captured in the `let` above `use-effect`**, not inside the effect body. The dispatcher closes over the frame at render-time; the effect body fires after commit but the closure is already established. Inside the effect body, `dispatch` carries the right frame.
+1. **The frame api comes from the `use-frame` hook**, called at the top of the component body — never a bare `(rf/capture-frame)`. `use-frame` reads the surrounding `frame-provider` / `frame-root` through React context; a no-arg `(rf/capture-frame)` in a plain hooks component reads only the dynamic-var tier and raises `:rf.error/no-frame-context` under a context-provided frame. The `dispatch` you pull off it closes over the resolved frame at render-time, so the effect body — which fires after commit on a frameless stack — still routes to the right frame.
 2. **The cleanup fn is mandatory.** Without it, the listener leaks across re-mounts and across hot-reloads. The cleanup runs on unmount and before each re-run when deps change.
 3. **The deps vector matters.** Include every prop the effect reads so React re-runs the effect when those props change. An empty deps vector means "run once on mount, clean up on unmount."
 4. **Don't call `use-subscribe` inside the effect body.** Hooks must be called at the top of the component body, not inside another hook's callback. Subscribe in the outer (or in the inner's top-level `let`) and pass the value as a dep.
@@ -80,6 +82,6 @@ Four things matter:
 ### Cross-references
 
 - [Spec 004 §Views MUST NOT attach native DOM event listeners from render bodies](../../../spec/004-Views.md#effects-and-leases--the-view-side-surface) and [§Views MUST NOT own imperative library lifecycles directly](../../../spec/004-Views.md#effects-and-leases--the-view-side-surface) — bare `addEventListener` in a render body leaks listeners and silently routes dispatches to `:rf/default`; library lifecycles belong in `use-effect`.
-- [Spec 002 §Dispatches issued from inside a handler body](../../../spec/002-Frames.md#dispatches-issued-from-inside-a-handler-body) — async callbacks escape the dynamic frame binding; capture `(:dispatch (rf/capture-frame))` at render-time to carry the frame.
+- [Spec 002 §Dispatches issued from inside a handler body](../../../spec/002-Frames.md#dispatches-issued-from-inside-a-handler-body) — async callbacks escape the dynamic frame binding; call the `use-frame` hook at render-time (capture-frame in hook position) to carry the frame into the callback.
 - **Outer/inner Pattern (Pattern-OuterInner)** — the canonical home for wrapping stateful JS components (D3, Mapbox, animation libraries); the worked example above is one instance.
 - [UIx 2.x docs — `use-effect`](https://github.com/pitch-io/uix) — the underlying hook's signature, deps-vector semantics, and stale-closure considerations.


### PR DESCRIPTION
Follow-up from rf2-adm10 (PR #6112), which corrected this exact pattern in the guidance docs. Fixes `rf2-5rcy4`.

## The defect

Both adapter READMEs' "Imperative escape hatch" examples carried a bare `(:dispatch (rf/capture-frame))` in the inner hooks component:

- `implementation/adapters/uix/README.md:56` (before) — `dispatch (:dispatch (rf/capture-frame))`
- `implementation/adapters/helix/README.md:57` (before) — `dispatch (:dispatch (rf/capture-frame))`

A no-arg `(rf/capture-frame)` in a hooks-adapter component reads **only the dynamic-var tier**. Under a context-provided frame (`frame-provider` / `frame-root`) that tier is unbound during render, so the call raises `:rf.error/no-frame-context` — the example as written is broken.

## The fix

Carry the frame via the **`use-frame` hook** — capture-frame in hook position — exactly as adm10 established for the guidance leaves. After (both files): `{:keys [dispatch]} (uix-adapter/use-frame)` / `(helix-adapter/use-frame)`.

`use-frame` hook citation (`re-frame.adapter.uix` / `re-frame.adapter.helix`, verified against source):

> UIx/Helix hook returning the frame api for the ambient frame — EXACTLY what `(rf/capture-frame)` returns (the frame-locked ops map `{:frame :dispatch :dispatch-sync :subscribe}`), captured in hook position. … Resolution matches the ambient `use-subscribe`: dynamic-var tier first, then the surrounding `frame-provider` / `frame-root` via React context; no scope raises `:rf.error/no-frame-context`. The returned map is reference-stable across re-renders for the same resolved frame (safe in effect deps).

Per edit, each README also gains a one-line `use-frame` entry in its "Adapter-specific surface" list, and the example's ns require + outer `use-subscribe` reference are switched to the aliased adapter (`uix-adapter` / `helix-adapter`) so the example references a documented, resolvable symbol.

**Helix** (slated for S7 retirement) received the *identical* trivially-parallel fix — the same `use-frame` hook exists in `re-frame.adapter.helix` — with no extra investment beyond the mirror.

## Out of scope (follow-up filed)

The **outer** component in the same block is `(rf/reg-view board-panel …)`, but the merged guidance (how-to line 114, Pattern-StatefulComponents table) says `reg-view` is Reagent-only — hooks-adapter outers should be plain `defui`/`defnc`. That is a *distinct* defect from this bead's bare-capture-frame scope; filed as **rf2-otnxq** rather than expanding this surgical fix.

## Quality gates

- `scripts/check_doc_slugs.py` → **exit 0** (green). Note: its corpus is `docs`/`spec`/`skills`/`migration` + `tools/*/spec`; the adapter READMEs under `implementation/adapters/` are not in scope, so no covered link changed.
- `mkdocs build --strict` → **N/A**: `docs_dir: docs`, so these `implementation/` READMEs are not part of the mkdocs site (the bead's "if the READMEs are in the docs build" condition is not met).
- No adapter smoke/testbed embeds this illustrative example; the `use-frame` spelling is verified against the shipped counter view (`docs/core/how-to/use-uix-helix-or-slim.md`) and the adapter docstrings.
- Docs-only change; no runtime source touched.
