### PR TITLE
docs(adapters): correct reg-view outer to defui/defnc in UIx/Helix README escape-hatch (rf2-otnxq)

### DIFF
--- a/implementation/adapters/helix/README.md
+++ b/implementation/adapters/helix/README.md
@@ -66,8 +66,8 @@ Compose `use-effect` with the standard outer/inner split: the **outer** `defnc` 
           (.removeEventListener el "animationend" listener))))
     (d/div {:ref ref :class "tile merging"})))
 
-;; Outer — reads subs, hands props to the inner. Registered via reg-view.
-(rf/reg-view board-panel []
+;; Outer — reads subs, hands props to the inner. Plain Helix defnc.
+(defnc board-panel []
   (let [active-tile-id (helix-adapter/use-subscribe [:board/active-tile])]
     ($ tile-inner {:tile-id active-tile-id})))
 ```

--- a/implementation/adapters/uix/README.md
+++ b/implementation/adapters/uix/README.md
@@ -66,8 +66,8 @@ Compose `use-effect` with the standard outer/inner split: the **outer** `defui` 
       [tile-id])
     ($ :div {:ref ref :class "tile merging"})))
 
-;; Outer — reads subs, hands props to the inner. Registered via reg-view.
-(rf/reg-view board-panel []
+;; Outer — reads subs, hands props to the inner. Plain UIx defui.
+(defui board-panel []
   (let [active-tile-id (uix-adapter/use-subscribe [:board/active-tile])]
     ($ tile-inner {:tile-id active-tile-id})))
 ```


### PR DESCRIPTION
## What

The "Imperative escape hatch" outer/inner examples in the UIx and Helix adapter READMEs wrote the **outer** component as `(rf/reg-view board-panel [] …)`. But `reg-view` is Reagent-only sugar — hooks adapters have no such macro.

Correct the outer to a plain `defui` (UIx) / `defnc` (Helix), and update the accompanying comment to match the inner-comment style already used in each block ("Plain UIx defui." / "Plain Helix defnc.").

```
-;; Outer — reads subs, hands props to the inner. Registered via reg-view.
-(rf/reg-view board-panel []
+;; Outer — reads subs, hands props to the inner. Plain UIx defui.   (Helix: Plain Helix defnc.)
+(defui board-panel []                                               (Helix: (defnc board-panel [])
```

## Why

Per the merged adm10 guidance at `docs/core/how-to/use-uix-helix-or-slim.md:114`:

> There is no `reg-view` macro here. That sugar is Reagent-only. UIx components are plain `defui`, Helix components plain `defnc`.

The inner is referenced directly as `($ tile-inner …)`, so no registry id is needed for the outer (`reg-view*` is only for the rare component that must be addressable by id). This is the sibling correction to **rf2-5rcy4** (PR #6117, merged), which fixed the inner bare-`capture-frame`→`use-frame` defect in these same two examples but deliberately left the outer `reg-view` out of its surgical scope. Closes rf2-otnxq.

Helix is under S7 retirement — it received the identical minimal `defnc` fix (not gold-plated).

## Quality gates

- `python scripts/check_doc_slugs.py` — pass (exit 0).
- `mkdocs build --strict` — **not applicable**: `mkdocs.yml` sets `docs_dir: docs`, and the adapter READMEs live under `implementation/adapters/`, outside the docs site (same finding as rf2-5rcy4). Cross-verified the `defui`/`defnc` spelling instead against the merged how-to (`use-uix-helix-or-slim.md:101,114`, `(defui counter-buttons [] …)`) and against each block's own ns `:refer [defui $]` / `:refer [defnc $]` and inner components.
- No adapter smoke embeds this example (the only `board-panel` hits elsewhere are `dashboard-panel` in the unrelated `tenant_switcher` testbed), so nothing to compile-check.

Docs-only; two-line change per README.