### PR TITLE
docs(reactive): reconcile slice-memo lifetime per host with CLJS microtask window + strengthen census (rf2-er64a)

### DIFF
--- a/ai/findings/new-substrate-synthesis/03-reactivity-and-ownership.md
+++ b/ai/findings/new-substrate-synthesis/03-reactivity-and-ownership.md
@@ -164,17 +164,26 @@ Probes are ownership-free: no ref-count, no watch, no zero-owner cache node.
 **First-mount fan-out mitigation:** probes share a **slice-scoped pure memo table** —
 the `?slice-memo` argument — so N sibling rows probing `[:orders/by-id id]` compute
 shared derivation parents once per slice, not once per row. There is no public React
-render-pass token; the table is scoped to the **current synchronous execution slice**,
-created lazily on first probe and bounded **per-host**. On the **JVM** the slice is a
-thread-local render scope (`*slice*` / `with-slice-memo`, opened around every public
-Tier-1 render entry — `re-frame.ui.tree/render`, the `ui.test/render` routes, and each
-ViewCell capture) whose table is **discarded synchronously when the render thunk
-returns** — there is no microtask on the JVM. On **CLJS** a single-threaded module holder
-shares the pass and is **released at the host microtask checkpoint** (`queueMicrotask`,
-under a CAS guard, aligned with the port's own table clear). Both hosts belt-and-braces
-tag the table with `(frame, frame-epoch, registry-epoch)`, invalidate on any mismatch,
-and enforce the one law: sharing is allowed within a slice, but no table or handle
-survives into a later render slice. A time-sliced
+render-pass token, so how far a table's sharing reaches — the *slice* it belongs to — is
+bounded **per-host**, created lazily on first probe. On the **JVM** sharing ends with its
+synchronous render thunk: the slice is a thread-local render scope (`*slice*` /
+`with-slice-memo`, opened around every public Tier-1 render entry —
+`re-frame.ui.tree/render`, the `ui.test/render` routes, and each ViewCell capture) whose
+table is **discarded synchronously when the render thunk returns** — there is no microtask
+on the JVM. On **CLJS** sharing MAY span later callbacks within the bounded host-microtask
+window: a single-threaded module holder shares the pass and is **released at the host
+microtask checkpoint** (`queueMicrotask`, under a CAS guard, aligned with the port's own
+table clear). The whole host-microtask window is therefore one CLJS slice — because
+`queueMicrotask` is FIFO, a genuinely-later render interposed before that checkpoint finds
+the holder still installed and reuses it, a bounded within-window economy — and no holder
+or table survives past the checkpoint into the next window (rf2-2g7pxq pins the
+inverse-FIFO ordering). Both hosts belt-and-braces tag the table with
+`(frame, frame-epoch, registry-epoch)` plus the frame incarnation, invalidate on any
+mismatch, and enforce the same law: probes may share within one slice — the JVM's
+synchronous render thunk, the CLJS host-microtask window — but no holder or table survives
+past that boundary into the next slice. Bounded reuse is never stale-value authority: an
+interposed later render at a moved epoch fails the tag check and mints a fresh table rather
+than the stale memoized value. A time-sliced
 pass spanning k slices builds k tables (fixture 1b: 3 tables across an interrupted
 3,000-row transition) — the economy is **once-per-slice, not once-per-pass**; bounded,
 allocation-trivial, zero React internals. An interrupted or abandoned slice's table

--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -1417,25 +1417,34 @@
 
 (defn make-slice-memo
   "Return a fresh slice-memo HANDLE for [[probe]]'s optional second argument.
-  Within one synchronous execution slice, cold probes threading the same
-  handle share computed derivation parents (N sibling rows probing
-  `[:orders/by-id id]` compute shared parents once per slice, not once per
-  row). The table inside is created lazily on first cold probe, tagged with
-  `(frame, frame-epoch, registry-epoch)` PLUS the exact frame-incarnation
-  token, and invalidated on any mismatch — the token by identity, because the
-  epoch triple can tie across a same-id destroy+recreate (rf2-vxgfnd.160). The
-  handle dies with its slice under ONE law — probes may share within a slice,
-  but no table or handle survives into a later render slice — which each host
-  reaches by its own mechanism, because their scheduling models differ: on the
-  JVM a thread-local render scope discards the table when the render thunk
-  returns (there is no microtask there), while on CLJS a module holder is
-  cleared at the `queueMicrotask` checkpoint so an abandoned slice's table is
-  released. `re-frame.ui.reactive` owns both. The memo is an ECONOMY, never an
-  authority — for a COMMITTING reader the commit evidence comparison
-  (invariant 5) corrects any staleness before paint; the
-  incarnation-complete tag additionally keeps a COMMIT-FREE
-  reader (a Tier-1 probe outside a ViewCell, which has no commit step 5)
-  correct on its own. Per Spec 006 §The slice-scoped probe memo."
+  Cold probes threading the same handle share computed derivation parents (N
+  sibling rows probing `[:orders/by-id id]` compute shared parents once per
+  slice, not once per row). The table inside is created lazily on first cold
+  probe, tagged with `(frame, frame-epoch, registry-epoch)` PLUS the exact
+  frame-incarnation token, and invalidated on any mismatch — the token by
+  identity, because the epoch triple can tie across a same-id destroy+recreate
+  (rf2-vxgfnd.160).
+
+  How far the sharing reaches — the SLICE — is bounded PER HOST, because the
+  hosts' scheduling models genuinely differ, yet both reach the same law:
+  probes may share within one slice, but no holder or table survives past that
+  boundary into the next slice. On the JVM sharing ends with its synchronous
+  render thunk — a thread-local render scope discards the table when the thunk
+  returns (there is no microtask there). On CLJS sharing MAY span later
+  callbacks within the bounded host-microtask window: one module holder lives
+  until the `queueMicrotask` checkpoint, so a genuinely-later render interposed
+  before that checkpoint (queueMicrotask is FIFO) reuses the still-installed
+  holder — a bounded within-window economy — while no holder survives past the
+  checkpoint into the next window (rf2-2g7pxq). `re-frame.ui.reactive` owns
+  both.
+
+  Bounded reuse is never stale-value authority: an interposed later render at a
+  moved epoch fails the tag check and mints a fresh table rather than serving
+  the stale value. The memo is an ECONOMY, never an authority — for a
+  COMMITTING reader the commit evidence comparison (invariant 5) corrects any
+  staleness before paint; the incarnation-complete tag additionally keeps a
+  COMMIT-FREE reader (a Tier-1 probe outside a ViewCell, which has no commit
+  step 5) correct on its own. Per Spec 006 §The slice-scoped probe memo."
   []
   (atom {:tag nil :memo nil}))
 
@@ -1478,8 +1487,8 @@
              (when (exists? js/queueMicrotask)
                (js/queueMicrotask
                  (fn []
-                   ;; Release only OUR table — a later slice may have
-                   ;; installed a fresh one already.
+                   ;; Release only OUR table — a later probe in this window may
+                   ;; have re-tagged and installed a fresh one already.
                    (when (identical? fresh (:memo @handle))
                      (reset! handle {:tag nil :token nil :memo nil}))))))
           fresh)))))

--- a/implementation/ui/test/re_frame/ui/slice_memo_lifetime_census_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/slice_memo_lifetime_census_jvm_test.clj
@@ -9,19 +9,28 @@
   thunk returns. The prose was reconciled per-host in 718a8dea16; this census is
   the regression pin that commit did not carry.
 
-  The law, and why the mechanisms legitimately differ: the table dies with its
-  slice, so probes may share WITHIN one slice but no table or handle survives
-  into a LATER render slice. How a slice is BOUNDED is per-host because the
-  hosts' scheduling models genuinely differ — the JVM has no microtask queue, and
-  the single-threaded CLJS host needs no thread-local. Both reach the same law.
+  The law, and why the mechanisms legitimately differ: probes may share WITHIN
+  one slice, but no holder or table survives PAST that host boundary into the
+  next slice. What BOUNDS a slice is per-host because the hosts' scheduling
+  models genuinely differ. On the JVM sharing ends with the synchronous render
+  thunk (no microtask queue, a thread-local scope). On CLJS the whole
+  host-microtask window is ONE slice: because `queueMicrotask` is FIFO, a
+  genuinely-later render interposed before the checkpoint REUSES the still-
+  installed holder — a bounded within-window economy the inverse-FIFO fixture
+  proves (rf2-2g7pxq) — so the obsolete framing of the CLJS slice as one
+  'synchronous execution slice' (nothing surviving into a 'later render slice')
+  is false and this census now REJECTS it. Both reach the same law.
 
   This census pins, in BOTH authoritative documents:
 
-    - each distinguishes the JVM thread-local render scope from the CLJS module
-      holder released at the microtask checkpoint;
+    - each distinguishes the JVM thread-local render scope (sharing ends with
+      the synchronous render thunk) from the CLJS module holder whose sharing
+      MAY span later callbacks within the bounded host-microtask window;
     - neither applies microtask lifetime to the JVM — the JVM span may name a
       microtask ONLY to deny it;
-    - each states the shared law, attributed to BOTH hosts.
+    - neither carries the obsolete synchronous-slice / later-render-slice claim,
+      and CLJS AFFIRMS the within-window reuse;
+    - each states the shared host-boundary law, attributed to BOTH hosts.
 
   The census is a pure predicate over document text
   (`slice-memo-lifetime-violations`), so the negative arm can prove it has teeth:
@@ -102,15 +111,36 @@
 (def ^:private jvm-synchronous-discard
   "synchronously when the render thunk returns")
 
-(def ^:private later-slice-law
-  "no table or handle survives into a later render slice")
-
 (def ^:private both-hosts-law-re
   "The reconciliation's substance: ONE law, attributed to BOTH hosts."
   #"(?i)both hosts[\s\S]{0,240}?enforce the (?:same|one) law")
 
 (def ^:private within-slice-sharing-re
   #"(?i)(?:shar\w+[^.]{0,48}within (?:one|a) slice|within (?:one|a) slice[^.]{0,48}shar\w+)")
+
+(def ^:private next-slice-boundary-re
+  "The CORRECTED boundary law: sharing ends at the HOST boundary — the JVM
+  thunk's return, the CLJS microtask checkpoint — with nothing surviving into
+  the NEXT slice. This REPLACES the obsolete unconditional 'no ... survives
+  into a later render slice' claim, which a bounded within-window reuse
+  (the inverse-FIFO fixture, rf2-2g7pxq) contradicts."
+  #"(?i)no (?:holder|table)[^.]{0,80}?survives? past[^.]{0,80}?into the next slice")
+
+(def ^:private obsolete-synchronous-slice-re
+  "The obsolete claim this bead retires: the CLJS memo scoped to the 'current
+  synchronous execution slice', or the universal 'no ... survives into a later
+  render slice'. Both frame the CLJS slice as one SYNCHRONOUS call and so deny
+  the within-window reuse the inverse-FIFO fixture proves (rf2-2g7pxq) — a
+  genuinely-later render interposed before the checkpoint reuses the holder.
+  Its PRESENCE (not absence) is the violation."
+  #"(?i)synchronous execution slice|into a later render slice")
+
+(def ^:private cljs-window-reuse-re
+  "CLJS must AFFIRM the bounded within-window later-render reuse — the substance
+  the inverse-FIFO fixture proves, not merely the checkpoint marker: the whole
+  host-microtask window is one slice, so a genuinely-later render interposed
+  before the checkpoint REUSES the still-installed holder."
+  #"(?i)host-microtask window[\s\S]{0,240}?reuse")
 
 (def ^:private microtask-re #"(?i)microtask")
 
@@ -155,6 +185,13 @@
       (and cljs (not (str/includes? cljs "queueMicrotask")))
       (conj :cljs/microtask-checkpoint-missing)
 
+      ;; CLJS must AFFIRM the bounded within-window later-render reuse — the
+      ;; substance the inverse-FIFO fixture proves (rf2-2g7pxq), not merely the
+      ;; presence of the checkpoint marker. The old census false-greened by
+      ;; requiring the checkpoint word while its LAW still denied the reuse.
+      (and cljs (not (re-find cljs-window-reuse-re cljs)))
+      (conj :cljs/window-reuse-missing)
+
       ;; The shared law, in both halves, attributed to both hosts.
       (not (re-find both-hosts-law-re section))
       (conj :law/not-attributed-to-both-hosts)
@@ -162,8 +199,15 @@
       (not (re-find within-slice-sharing-re section))
       (conj :law/within-slice-sharing-missing)
 
-      (not (str/includes? section later-slice-law))
-      (conj :law/later-slice-reuse-missing))))
+      ;; THE claim this bead retires: the obsolete synchronous-slice / later-
+      ;; render-slice framing. Its PRESENCE is the violation — it contradicts
+      ;; the executable within-window reuse proof.
+      (re-find obsolete-synchronous-slice-re section)
+      (conj :law/obsolete-synchronous-slice-claim)
+
+      ;; The corrected host-boundary law, in place of the old universal.
+      (not (re-find next-slice-boundary-re section))
+      (conj :law/next-slice-boundary-missing))))
 
 ;; ---------------------------------------------------------------------------
 ;; Positive arm — the live documents
@@ -204,12 +248,14 @@ once-per-pass** — bounded, allocation-trivial, and requiring zero React intern
 interrupted or abandoned slice's table becomes unreachable garbage.")
 
 (deftest census-rejects-the-historical-pre-reconciliation-wording
-  (testing "the pre-718a8dea16 Spec 006 text names no host and generalises the
-            CLJS microtask, so the census must reject it"
+  (testing "the pre-718a8dea16 Spec 006 text names no host, generalises the
+            CLJS microtask, AND carries the obsolete synchronous-slice claim, so
+            the census must reject it"
     (is (= #{:jvm/span-missing
              :cljs/span-missing
              :law/not-attributed-to-both-hosts
-             :law/later-slice-reuse-missing}
+             :law/obsolete-synchronous-slice-claim
+             :law/next-slice-boundary-missing}
            (slice-memo-lifetime-violations (normalize pre-reconciliation-spec-006))))))
 
 (defn- drift
@@ -227,7 +273,24 @@ interrupted or abandoned slice's table becomes unreachable garbage.")
 (def ^:private drifts
   "Single-fact mutations of the LIVE text. Each is one edit away from green, so
   the census is proven to catch MINIMAL drift, not merely wholly-other prose."
-  [{:label   "the JVM span gains microtask lifetime (the historical drift)"
+  [;; THE drift this bead exists for: restore the obsolete synchronous-slice /
+   ;; later-render-slice claim while KEEPING every checkpoint marker
+   ;; (thread-local, queueMicrotask, the discard phrase). The old census could
+   ;; not catch this — it demanded the checkpoint markers but not their
+   ;; compatible meaning, so this exact edit false-greened.
+   {:label   "the obsolete synchronous-execution-slice claim is restored, checkpoint markers retained"
+    :match   "The whole host-microtask window is therefore one CLJS slice"
+    :replace "The table is scoped to the current synchronous execution slice"
+    :expect  :law/obsolete-synchronous-slice-claim}
+   {:label   "the CLJS within-window reuse economy is dropped"
+    :match   "finds the holder still installed and reuses it"
+    :replace "opens a fresh table"
+    :expect  :cljs/window-reuse-missing}
+   {:label   "the corrected host-boundary law is dropped"
+    :match   "no holder or table survives past that boundary into the next slice"
+    :replace "the table stays reusable"
+    :expect  :law/next-slice-boundary-missing}
+   {:label   "the JVM span gains microtask lifetime"
     :match   jvm-microtask-denial
     :replace "the table is cleared by `queueMicrotask` at the microtask checkpoint"
     :expect  :jvm/microtask-lifetime-applied}
@@ -235,10 +298,6 @@ interrupted or abandoned slice's table becomes unreachable garbage.")
     :match   jvm-synchronous-discard
     :replace "eventually"
     :expect  :jvm/synchronous-discard-missing}
-   {:label   "the later-slice reuse law is dropped"
-    :match   later-slice-law
-    :replace "the table stays reusable"
-    :expect  :law/later-slice-reuse-missing}
    {:label   "the law is no longer attributed to both hosts"
     :match   "Both hosts"
     :replace "The CLJS host"

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -1624,32 +1624,44 @@ table** — the optional `?slice-memo` argument to `probe`. Within one slice, pr
 share computed derivation parents; the table dies with the slice. No entry survives
 into cache state, ownership state, or a later slice.
 
-**Lifetime (S-3-settled).** There is no public React render-pass token; the table is
-scoped to the **current synchronous execution slice** and created lazily on first probe.
-How the slice is bounded — and how the table dies with it — is **per-host**, because the
-two runtimes reach the same law by different means:
+**Lifetime (S-3-settled).** There is no public React render-pass token, so how far a
+table's sharing reaches — the *slice* it belongs to — is bounded **per-host**, because the
+two runtimes reach the same law by genuinely different scheduling models. The table is
+created lazily on first probe and belt-and-braces tagged with
+`(frame, frame-epoch, registry-epoch)` plus the exact frame incarnation, invalidated on
+any mismatch.
 
-- **JVM — a thread-local render scope.** A private dynamic binding (`*slice*`, opened by
-  `with-slice-memo`) wraps every public Tier-1 render entry: `re-frame.ui.tree/render`,
-  the `ui.test/render` routes (view-reference / literal / plan-bearing, all converging on
-  `render-with-opts` / `render-plan-bearing`), and the reactive host entry (one scope per
-  ViewCell render). The binding **discards the table synchronously when the render thunk
-  returns** — there is no microtask on the JVM, and no scheduler- or tag-change
-  dependency. The scope is re-entrant, so a Tier-1 render and the ViewCell capture nested
-  inside it share one table, while a bare probe outside any render scope gets a fresh
-  per-call handle; two sequential executor tasks and two concurrent renders on distinct
-  threads never share a table.
-- **CLJS — a module holder cleared at the microtask checkpoint.** The single-threaded
-  host needs no thread-local scope: one module holder shares the handle across every probe
-  of a synchronous render pass, then is **released at the host microtask checkpoint**
-  (`queueMicrotask`, under a CAS guard so a stale clear cannot erase a newer holder,
-  aligned with the port's own table clear — deliberately not the macrotask `next-tick`
-  path, which would leave a dead slice's holder live for one more host turn).
+- **JVM — a thread-local render scope; sharing ends with its synchronous render thunk.** A
+  private dynamic binding (`*slice*`, opened by `with-slice-memo`) wraps every public
+  Tier-1 render entry: `re-frame.ui.tree/render`, the `ui.test/render` routes
+  (view-reference / literal / plan-bearing, all converging on `render-with-opts` /
+  `render-plan-bearing`), and the reactive host entry (one scope per ViewCell render). The
+  binding **discards the table synchronously when the render thunk returns** — there is no
+  microtask on the JVM, and no scheduler- or tag-change dependency. The scope is
+  re-entrant, so a Tier-1 render and the ViewCell capture nested inside it share one table,
+  while a bare probe outside any render scope gets a fresh per-call handle; two sequential
+  executor tasks and two concurrent renders on distinct threads never share a table, and a
+  render that begins after the thunk returns opens a fresh scope.
+- **CLJS — a module holder released at the microtask checkpoint; sharing MAY span later
+  callbacks within the bounded host-microtask window.** The single-threaded host needs no
+  thread-local scope: one module holder shares the handle across every probe until it is
+  **released at the host microtask checkpoint** (`queueMicrotask`, under a CAS guard so a
+  stale clear cannot erase a newer holder, aligned with the port's own table clear —
+  deliberately not the macrotask `next-tick` path, which would leave a dead slice's holder
+  live for one more host turn). The whole host-microtask window is therefore one CLJS
+  slice: because `queueMicrotask` is FIFO, a genuinely-later render in a microtask
+  interposed before that checkpoint finds the holder still installed and reuses it — a
+  bounded within-window economy, never a leak — and a caught-render retry, being
+  synchronous and pre-checkpoint, collapses to the same within-window sharing. No holder or
+  table survives past the checkpoint into the next window (⟨rf2-2g7pxq⟩ pins the
+  inverse-FIFO ordering deterministically).
 
-Both hosts belt-and-braces tag the table with `(frame, frame-epoch, registry-epoch)` and
-invalidate on any mismatch, and both enforce the same law: probes may share within one
-slice, but **no table or handle survives into a later render slice**. A time-sliced pass
-spanning k slices builds k tables, so the economy is **once-per-slice, not
+Both hosts invalidate the table on any tag mismatch, and both enforce the same law: probes
+may share within one slice — the JVM's synchronous render thunk, the CLJS host-microtask
+window — but **no holder or table survives past that boundary into the next slice**.
+Bounded reuse is never stale-value authority: an interposed later render at a moved epoch
+fails the tag check and mints a fresh table rather than serving the stale memoized value. A
+time-sliced pass spanning k slices builds k tables, so the economy is **once-per-slice, not
 once-per-pass** — bounded, allocation-trivial, and requiring zero React internals; an
 interrupted or abandoned slice's table becomes unreachable garbage. ⟨S-3 §5, fixtures
 1b/6⟩


### PR DESCRIPTION
## What & why

The inverse-FIFO CLJS fixture added for closed `rf2-2g7pxq` proves that a
**genuinely-later render** in a microtask interposed *before* the holder clear
**reuses** the existing slice memo — the whole CLJS host-microtask window is
**one slice**. But three live authorities still scoped the memo to the "current
synchronous execution slice" and claimed nothing survives into a "later render
slice", contradicting the executable proof:

| authority | before | after |
| --- | --- | --- |
| `spec/006-ReactiveSubstrate.md` §The slice-scoped probe memo (was ~L1627–1651) | "the table is **scoped to the current synchronous execution slice**"; "both enforce the same law: probes may share within one slice, but **no table or handle survives into a later render slice**" | per-host: **JVM — sharing ends with its synchronous render thunk**; **CLJS — sharing MAY span later callbacks within the bounded host-microtask window** (the whole window is one slice; an interposed later render reuses the still-installed holder); shared law now "**no holder or table survives past that boundary into the next slice**" |
| `ai/findings/new-substrate-synthesis/03-reactivity-and-ownership.md` (was ~L164–185) | "the table is scoped to the **current synchronous execution slice**"; "enforce the one law: sharing is allowed within a slice, but **no table or handle survives into a later render slice**" | same per-host reconciliation; CLJS affirms within-window reuse; corrected host-boundary law |
| `implementation/core/src/re_frame/substrate/observation.cljc` `make-slice-memo` docstring (was ~L1418–1438) | "**Within one synchronous execution slice**…"; "no table or handle survives into a **later render slice**" | per-host statement: JVM ends with the synchronous render thunk; CLJS may span later callbacks within the host-microtask window; bounded reuse is distinguished from stale-value authority |

The exact `(frame, frame-epoch, registry-epoch)` + frame-incarnation tag safety
law is **preserved verbatim**, and bounded within-window reuse is explicitly
distinguished from stale-value authority: an interposed later render at a moved
epoch fails the tag check and mints a fresh table rather than serving the stale
value.

### Census (`slice_memo_lifetime_census_jvm_test.clj`, #6009's census)

The census false-greened — it **required** the contradictory `no table or handle
survives into a later render slice` phrase to pass (it checked for the checkpoint
markers but not their compatible meaning). Strengthened to enforce the reconciled
law:

- **Presence-is-violation** rejection of the obsolete synchronous-slice /
  later-render-slice claim (`:law/obsolete-synchronous-slice-claim`).
- New requirement that the CLJS span **affirm** the within-window later-render
  reuse (`:cljs/window-reuse-missing`).
- Corrected host-boundary law required (`:law/next-slice-boundary-missing`) in
  place of the old universal.
- New negative-arm drift restores the obsolete synchronous-slice claim **while
  retaining every checkpoint marker** — the census now rejects it. The historical
  pre-reconciliation fixture's expected violation set is updated accordingly.

### Runtime unchanged

Only the `make-slice-memo` docstring and one CAS-guard code comment were touched —
no logic. The runtime already implements exactly this within-window reuse
(release-only-our-table at the `queueMicrotask` checkpoint, tag-validated on
reuse), so no mismatch was exposed.

## Quality gates

All foreground, unpiped, from the worker worktree:

- **Lifetime census** (`clojure -M:test -n re-frame.ui.slice-memo-lifetime-census-jvm-test`): `Ran 3 tests containing 17 assertions. 0 failures, 0 errors.`
- **Census has teeth (adversarial proof)**: temporarily reinserting `current synchronous execution slice` into the live Spec 006 turned the positive gate RED (`#{:law/obsolete-synchronous-slice-claim :cljs/window-reuse-missing}`) and tripped the drift-anchor guard; reverted → green again. The strengthened drift arm exercises the same restoration in-test.
- **`python scripts/check_doc_slugs.py --verbose`**: `scanning 525 markdown files... no broken links.`
- **`mkdocs build --strict`**: `Documentation built in 19.25 seconds` (INFO only, no warnings).
- **`npm run test:cljs`**: `Ran 9718 tests containing 47804 assertions. 0 failures, 0 errors.` (includes the inverse-FIFO CLJS fixture that pins the reconciled runtime behaviour; confirms the observation docstring edit broke nothing).

Closes rf2-er64a.
