### PR TITLE
fix(machines): fence spawn-all-init join/sentinel writes to exact incarnation + CLJS rejection cardinality proof (rf2-8nxsh, rf2-plahy)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -842,6 +842,31 @@
                    spec {:bootstrap-pending? true}))]
       (spawn-rejected? spec spawned-id snap continue?))))
 
+(defn- write-spawned-slot!
+  "Write `value` into the frame's join slot at
+  `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]`, bound to A's RAW
+  owner token (rf2-8nxsh). `spawn-all-init-fx` reaches this write only AFTER
+  its admission preflight has run application `[:schemas :data]` validators and
+  (on the reject path) fanned callback-bearing reject records — either of which
+  can synchronously destroy owner frame A and publish a same-id successor B on
+  its own stack. A bare-id `frame/swap-runtime-db!` resolves to the CURRENT
+  incarnation, so it would land A's join-state / reject sentinel on B (and bump
+  B's commit epoch), leaving B holding an IMPOSSIBLE join it never spawned.
+
+  With an event owner, route the write through `swap-runtime-db-exact!`: it
+  binds the install to A's own container, so a same-id B can never redirect it,
+  and on mid-write owner loss (a synchronous container watch that destroys A
+  during the physical install) it returns nil WITHOUT bumping B's epoch — B
+  stays byte-identical. Without an owner (a conformance / pure-fn caller with no
+  router event owner), fall back to the historical bare-id write; that path has
+  no incarnation to lose, symmetric with `continue?`'s `(constantly true)`.
+  Returns the new runtime-db slice, or nil on owner loss."
+  [frame-id owner-token parent-id invoke-id value]
+  (let [swap-fn #(assoc-in % (paths/spawned-path parent-id invoke-id) value)]
+    (if owner-token
+      (frame/swap-runtime-db-exact! frame-id owner-token swap-fn)
+      (frame/swap-runtime-db! frame-id swap-fn))))
+
 (defn spawn-all-init-fx
   "fx handler for `:rf.machine/spawn-all-init`. Per Spec 005
   §Spawn-and-join via `:spawn-all`, on entry to a `:spawn-all`-bearing
@@ -899,7 +924,20 @@
   Because the sentinel is childless, no actor is ever spawned to complete:
   a stray / forged `:on-child-done` hits `join.cljc`'s childless-slot
   guard and is a no-op (no deadlock), and `destroy-spawn-all-children!`
-  finds nothing to tear down and clears the sentinel on parent exit."
+  finds nothing to tear down and clears the sentinel on parent exit.
+
+  EXACT-INCARNATION FENCE (rf2-8nxsh). The preflight's `[:schemas :data]`
+  validators are application code, and the reject path fans callback-bearing
+  always-on records + dev traces; either can synchronously destroy owner frame
+  A and publish a same-id successor B on its own stack. Both durable writes —
+  the live join AND the reject sentinel — therefore ride A's raw owner token
+  through `write-spawned-slot!` (`swap-runtime-db-exact!`): a same-id B can
+  never redirect the write, and a mid-write container watch that loses A no-ops
+  it (nil return) without bumping B's epoch, so B stays byte-identical. `continue?`
+  is rechecked after the preflight (before either write) and between reject
+  emissions, and the `:rf.machine.spawn-all/started` trace fires only when the
+  join actually committed into A. A validator / listener that swaps A for B thus
+  lands no A-derived join, sentinel, or started trace on B."
   [{frame-id :frame} args]
   (let [;; EP-0002 carried invariant — the fx context carries the cascade
         ;; envelope frame; a nil stamp is an invariant failure
@@ -931,6 +969,18 @@
                           :cancelled #{}
                           :rf/attempt (next-join-attempt-token))
         continue?  (data-validation/owner-continuation frame-id)
+        ;; rf2-8nxsh — the RAW exact owner token (`continue?` closes over the
+        ;; same authority). The admission preflight below runs application
+        ;; `[:schemas :data]` validators (`schema-rejected-child?`), and the
+        ;; reject path fans callback-bearing always-on reject records + dev
+        ;; traces (`reject-unregistered-spawn!`): each is application / listener
+        ;; code that can synchronously destroy owner frame A and publish same-id
+        ;; successor B. Binding the durable join / reject-sentinel write to A's
+        ;; own token (`write-spawned-slot!` → `swap-runtime-db-exact!`) keeps B
+        ;; byte-identical even under a mid-write container watch; nil for a
+        ;; non-router caller falls back to the bare write, symmetric with
+        ;; `continue?`'s `(constantly true)`.
+        owner-token (frame/current-event-owner-token)
         ;; ---- The invoke-level admission preflight ------------------------
         ;; ONE decision, authoritative for EVERY fail-closed child-admission
         ;; condition, taken BEFORE a live join or ANY child side effect is
@@ -968,11 +1018,24 @@
       ;; already emitted its own `:rf.error/schema-validation-failure
       ;; :phase :spawn` as the preflight decided it. Both axes: exactly one
       ;; error per offending child, and no child effect runs at all.
-      (do (doseq [child unregistered]
-            (reject-unregistered-spawn! frame-id (:machine-id child)))
-          (frame/swap-runtime-db! frame-id assoc-in
-                                  (paths/spawned-path parent-id invoke-id)
-                                  spawn-all-reject-sentinel)
+      ;;
+      ;; rf2-8nxsh — every reject record + dev trace `reject-unregistered-spawn!`
+      ;; fans is callback-bearing (an always-on `:errors` listener can destroy A
+      ;; / publish same-id B), and the preflight's schema validators above may
+      ;; ALREADY have lost A. Fence between emissions on `(continue?)` so a
+      ;; listener that replaces A with B terminates the remaining rejects rather
+      ;; than attributing stale diagnostics to a dead frame / successor B; then
+      ;; seed the childless sentinel ONLY while A still owns, bound to A's raw
+      ;; token so a same-id B stays byte-identical (no A-derived sentinel lands
+      ;; on B). Under a live owner with no destroyer this is the historical
+      ;; behaviour: one reject per unregistered child, one sentinel seeded.
+      (do (loop [remaining unregistered]
+            (when (and (seq remaining) (continue?))
+              (reject-unregistered-spawn! frame-id (:machine-id (first remaining)))
+              (recur (rest remaining))))
+          (when (continue?)
+            (write-spawned-slot! frame-id owner-token parent-id invoke-id
+                                 spawn-all-reject-sentinel))
           nil)
       ;; The all-valid fast path. `join-state` already carries the opaque
       ;; per-attempt token (rf2-nvxehu) minted above: one LIVE seed = one join
@@ -982,14 +1045,26 @@
       ;; completion carrier to this exact attempt.
       ;;
       ;; Machine spawn-registry state is durable runtime-db state.
-      (do (frame/swap-runtime-db! frame-id assoc-in
-                                  (paths/spawned-path parent-id invoke-id) join-state)
-          (trace/emit! :rf.machine :rf.machine.spawn-all/started
-                       {;; The parent's live actor INSTANCE address;
-                        ;; `:invoke-id` is the declarative invocation path.
-                        :actor-id   parent-id
-                        :invoke-id  invoke-id
-                        :child-ids  (set (keys children))
-                        :children   children
-                        :frame      frame-id})
+      ;;
+      ;; rf2-8nxsh — the preflight's `[:schemas :data]` validators are
+      ;; application code that may have destroyed A / published same-id B even
+      ;; when every child CONFORMED (a conforming validator returning true still
+      ;; ran on A's stack). Seed the live join ONLY while A still owns and bind
+      ;; it to A's raw token: `write-spawned-slot!` no-ops (returns nil) when A
+      ;; is already gone AND when a mid-write watch loses A, so A's join-state
+      ;; can never land on B. The `:rf.machine.spawn-all/started` trace is
+      ;; framework-owned tail — fire it ONLY when the join actually committed
+      ;; into A (a nil return means B, or a dead frame, and gets no started
+      ;; trace).
+      (do (when (continue?)
+            (when (some? (write-spawned-slot! frame-id owner-token
+                                              parent-id invoke-id join-state))
+              (trace/emit! :rf.machine :rf.machine.spawn-all/started
+                           {;; The parent's live actor INSTANCE address;
+                            ;; `:invoke-id` is the declarative invocation path.
+                            :actor-id   parent-id
+                            :invoke-id  invoke-id
+                            :child-ids  (set (keys children))
+                            :children   children
+                            :frame      frame-id})))
           nil))))

--- a/implementation/machines/test/re_frame/machines_spawn_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_spawn_cljs_test.cljs
@@ -27,14 +27,24 @@
   `[:rf.runtime/machines :spawned <parent> <invoke-id>]`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.machines.lifecycle-fx.spawn :as spawn]
+            [re-frame.machines.paths :as paths]
+            [re-frame.machines.spawn-order :as spawn-order]
             ;; listener / buffer surface lives in re-frame.trace.tooling.
             [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.machines.test-support :as mtest]))
 
+;; The always-on error-listener registry (a `defonce` atom) is cleared per test
+;; so an `:errors` listener from one test cannot leak into the next (the
+;; unregistered-rejection cardinality + incarnation-fence tests register them).
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+    {:adapter reagent-adapter/adapter
+     :init-fn (fn [] (error-emit/clear-error-listeners!))}))
 
 ;; snapshot lookup via the shared machines test-support — no hardcoded
 ;; `[:rf.runtime/machines :snapshots …]` path. The per-section
@@ -290,3 +300,258 @@
       (is (thrown-with-msg? js/Error
                             #"spawn-timeout-ms-removed"
                             (rf/reg-machine :rmv/bad-invoke-all bad))))))
+
+;; ===========================================================================
+;; rf2-plahy — CLJS exact-cardinality proof for UNREGISTERED spawn rejection.
+;;
+;; The production path is `.cljc`, but until now the exact N/order/sentinel
+;; coverage lived ONLY in the JVM `machine_spawn_unregistered_type_test.clj`;
+;; the CLJS surface merely mentioned the error in a setup comment. Host-specific
+;; error/trace wiring (the always-on `:errors` fan-out + the dev trace) could
+;; regress on the CLJS runtime while CI stayed green. These pin it on CLJS.
+;;
+;; Mutation tooth: restoring the OLD per-child gate order (the child-local
+;; `unregistered-spawn-type?` gate ahead of the invoke `spawn-all-invoke-rejected?`
+;; sentinel gate in `spawn-fx`) makes each offending child fan a SECOND reject
+;; from its own per-child fx — the cardinality doubles and these tests fail.
+;; ===========================================================================
+
+(defn- with-error-records
+  "Run `thunk` while a corpus-wide always-on `:errors` listener records every
+  fanned-out record; return the records filtered to the unregistered-type
+  category (the production-survivable axis). Always unregisters in a `finally`."
+  [thunk]
+  (let [seen (atom [])]
+    (rf/register-listener! :errors ::recorder (fn [r] (swap! seen conj r)))
+    (try
+      (thunk)
+      (filterv #(= :rf.error/machine-spawn-unregistered-type (:error %)) @seen)
+      (finally (rf/unregister-listener! :errors ::recorder)))))
+
+(defn- reject-trace-machine-ids
+  "The `:machine-id` of every unregistered-type reject the dev TRACE axis fanned
+  (DCE'd in production; the always-on axis is captured separately)."
+  [traces]
+  (mapv #(get-in % [:tags :machine-id])
+        (filterv #(= :rf.error/machine-spawn-unregistered-type (:operation %)) @traces)))
+
+(defn- spawn-all-parent
+  "A `:spawn-all :all` parent over `children`, for cardinality fixtures."
+  [children]
+  {:initial :idle
+   :states
+   {:idle    {:on {:start :forking}}
+    :forking {:spawn-all {:children        children
+                          :join            :all
+                          :on-child-done   :gc/done
+                          :on-child-error  :gc/failed
+                          :on-all-complete [:all/done]}
+              :on {:all/done :ready}}
+    :ready   {}}})
+
+(defn- runtime-db-value []
+  (:rf.db/runtime (rf/frame-state-value :rf/default)))
+
+(deftest spawn-all-multi-unregistered-exact-cardinality-cljs
+  (testing "a rejected :spawn-all with MULTIPLE missing child types + a registered
+            sibling fans EXACTLY ONE always-on record AND one dev trace per
+            offending id, seeds the childless sentinel, and runs NO child effect
+            (no snapshot / spawn-order / spawn trace for any child)"
+    (let [ok-child {:initial :running :data {} :states {:running {}}}
+          traces   (atom [])]
+      (rf/reg-machine :card/ok ok-child)
+      ;; :card/missing-a and :card/missing-b are NEVER reg-machine'd.
+      (rf/reg-machine :sup/card
+                      (spawn-all-parent [{:id :a  :machine-id :card/missing-a}
+                                         {:id :ok :machine-id :card/ok}
+                                         {:id :b  :machine-id :card/missing-b}]))
+      (trace-tooling/register-listener! ::card (fn [ev] (swap! traces conj ev)))
+      (let [records (with-error-records
+                      #(rf/dispatch-sync [:sup/card [:start]]))]
+        (trace-tooling/unregister-listener! ::card)
+        ;; TWO offending children ⇒ TWO always-on records — the OLD gate order
+        ;; produced FOUR (each offending child re-emitting from its per-child fx).
+        (is (= 2 (count records))
+            "exactly TWO always-on records — one per offending child, not four")
+        (is (= [:card/missing-a :card/missing-b]
+               (sort (mapv :machine-id records)))
+            "one record per offending machine-id — no duplicates, no sibling")
+        ;; The dev-trace axis carries the SAME cardinality (both channels fire).
+        (is (= [:card/missing-a :card/missing-b]
+               (sort (reject-trace-machine-ids traces)))
+            "exactly TWO dev traces — one per offending machine-id")
+        ;; A childless reject SENTINEL was seeded — no live join.
+        (is (= {:rf/spawn-all-rejected? true}
+               (get-in (runtime-db-value)
+                       [:rf.runtime/machines :spawned :sup/card [:forking]]))
+            "one childless reject sentinel (no :children) for the invoke")
+        ;; The registered sibling was SUPPRESSED — no child effect ran.
+        (is (nil? (get-in (runtime-db-value)
+                          [:rf.runtime/machines :snapshots :card/ok#1]))
+            "the registered sibling installs no snapshot under the rejected invoke")
+        (is (not (some #{:card/ok#1} (spawn-order/frame-order :rf/default)))
+            "the registered sibling records no spawn-order entry")
+        (is (not (some (fn [ev] (= :rf.machine.spawn/spawned (:operation ev)))
+                       @traces))
+            "no :rf.machine.spawn/spawned trace for ANY child of a rejected invoke")))))
+
+(deftest single-unregistered-spawn-exact-one-cljs
+  (testing "a standalone single :spawn of an UNREGISTERED :machine-id (no invoke
+            sentinel to hide behind) fans EXACTLY ONE always-on record + one dev
+            trace and installs nothing — the per-child gate still fails closed"
+    (let [parent {:initial :idle
+                  :states
+                  {:idle    {:on {:start :working}}
+                   :working {:spawn {:machine-id :ghost/worker
+                                     :system-id  :ghost-actor
+                                     :start      [:go]}}}}
+          traces (atom [])]
+      ;; :ghost/worker is NEVER reg-machine'd.
+      (rf/reg-machine :sup/ghost parent)
+      (trace-tooling/register-listener! ::ghost (fn [ev] (swap! traces conj ev)))
+      (let [records (with-error-records
+                      #(rf/dispatch-sync [:sup/ghost [:start]]))]
+        (trace-tooling/unregister-listener! ::ghost)
+        (is (= 1 (count records))
+            "exactly ONE always-on record for the standalone unregistered spawn")
+        (is (= :ghost/worker (:machine-id (first records)))
+            "the record names the unregistered TYPE")
+        (is (= [:ghost/worker] (reject-trace-machine-ids traces))
+            "exactly ONE dev trace for the standalone unregistered spawn")
+        ;; Nothing installed — no snapshot, no slot, no system-id, no spawn-order.
+        (is (nil? (get-in (runtime-db-value)
+                          [:rf.runtime/machines :snapshots :ghost/worker#1]))
+            "no snapshot installed for the rejected actor")
+        (is (nil? (get-in (runtime-db-value)
+                          [:rf.runtime/machines :spawned :sup/ghost [:working]]))
+            "no [:rf.runtime/machines :spawned …] slot for the rejected spawn")
+        (is (nil? (get-in (runtime-db-value)
+                          [:rf.runtime/machines :system-ids :ghost-actor]))
+            "no :system-id binding for the rejected spawn")
+        (is (not (some #{:ghost/worker#1} (spawn-order/frame-order :rf/default)))
+            "no spawn-order entry for the rejected actor")))))
+
+;; ===========================================================================
+;; rf2-8nxsh — CLJS incarnation fence for `spawn-all-init-fx`'s join / sentinel
+;; writes. Cross-host companion to the JVM
+;; `spawn_all_init_incarnation_fence_test.clj`: the production path is `.cljc`,
+;; so the fence logic is shared, but the schema-validator / trace / frame wiring
+;; is host-specific and must be pinned on the CLJS runtime too.
+;;
+;; `spawn-all-init-fx` is driven DIRECTLY under a bound event owner (A's token);
+;; the destroyer publishes same-id successor B on the callback's own stack.
+;; ===========================================================================
+
+(def ^:private fence-child-schema ::fence-child-schema)
+
+(defn- fence-init-args
+  "A faithful `[:rf.machine/spawn-all-init args]` payload over `children` (each
+  `{:child-id :machine-id :spawned-id :data?}`) — the join-state seed plus the
+  prepared per-child `:child-args` the admission preflight decides over."
+  [parent-id invoke-id children]
+  (let [child-arg (fn [{:keys [machine-id spawned-id child-id data]}]
+                    (cond-> {:machine-id            machine-id
+                             :id-prefix             machine-id
+                             :rf/spawned-id         spawned-id
+                             :rf/parent-id          parent-id
+                             :rf/spawn-all-id       invoke-id
+                             :rf/spawn-all-child-id child-id}
+                      (some? data) (assoc :data data)))]
+    {:rf/parent-id parent-id
+     :rf/invoke-id invoke-id
+     :join-state   {:children  (into {} (map (juxt :child-id :spawned-id)) children)
+                    :done      #{} :failed #{} :resolved? false
+                    :spec      {:join :all :on-child-done :sa/done
+                                :on-child-error :sa/failed :on-all-complete [:all/done]}
+                    :invoke-id invoke-id}
+     :child-args   (mapv child-arg children)}))
+
+(deftest spawn-all-init-conforming-validator-loss-fences-live-join-cljs
+  (testing "a CONFORMING [:schemas :data] validator that destroys A + publishes
+            same-id B during the preflight: the all-valid join write no-ops
+            (bound to A's raw token), so B holds no A-derived live join and gets
+            no started trace"
+    (rf/reg-machine :fence/strict {:initial :running :data {:n 1}
+                                   :schemas {:data fence-child-schema}
+                                   :states  {:running {}}})
+    (let [frame-a   :rf2-8nxsh/accept-cljs
+          parent-id :par/a
+          invoke-id [:forking]
+          fired?    (atom false)
+          b-birth   (atom nil)
+          orig      (late-bind/get-fn :schemas/validate-with-registered-fn)]
+      (rf/make-frame {:id frame-a})
+      (let [token-a (frame/frame-incarnation-token frame-a)
+            started (atom [])]
+        (trace-tooling/register-listener!
+          ::accept (fn [ev] (when (= :rf.machine.spawn-all/started (:operation ev))
+                              (swap! started conj ev))))
+        (try
+          (late-bind/set-fn! :schemas/validate-with-registered-fn
+            (fn [schema _data]
+              (when (= schema fence-child-schema)
+                (when (compare-and-set! fired? false true)
+                  (frame/destroy-frame! frame-a)   ;; destroy A
+                  (rf/make-frame {:id frame-a})      ;; publish same-id B
+                  (reset! b-birth (mtest/runtime-db frame-a))))
+              true))                                  ;; conform verdict
+          (frame/call-with-event-owner-token frame-a token-a
+            (fn [] (spawn/spawn-all-init-fx
+                     {:frame frame-a}
+                     (fence-init-args parent-id invoke-id
+                                      [{:child-id :bad :machine-id :fence/strict
+                                        :spawned-id :fence/strict#1 :data {:n 1}}]))))
+          (is (true? @fired?) "the conforming validator ran (fence exercised)")
+          (is (nil? (get-in (mtest/runtime-db frame-a)
+                            (paths/spawned-path parent-id invoke-id)))
+              "no A-derived live join landed on same-id successor B")
+          (is (= @b-birth (mtest/runtime-db frame-a))
+              "B's runtime-db is byte-identical to its birth value")
+          (is (empty? @started)
+              "no :rf.machine.spawn-all/started trace fired against B")
+          (finally
+            (trace-tooling/unregister-listener! ::accept)
+            (late-bind/set-fn! :schemas/validate-with-registered-fn orig)))))))
+
+(deftest spawn-all-init-reject-listener-loss-fences-sentinel-cljs
+  (testing "an unregistered child fans a reject record; an :errors LISTENER on
+            that record destroys A + publishes same-id B. Ownership is rechecked
+            and the sentinel write rides A's raw token, so no reject sentinel
+            lands on B"
+    (rf/reg-machine :fence/ok {:initial :running :data {} :states {:running {}}})
+    ;; :fence/missing is NEVER reg-machine'd.
+    (let [frame-a   :rf2-8nxsh/reject-cljs
+          parent-id :par/a
+          invoke-id [:forking]
+          fired?    (atom false)
+          records   (atom [])
+          b-birth   (atom nil)]
+      (rf/make-frame {:id frame-a})
+      (let [token-a (frame/frame-incarnation-token frame-a)]
+        (rf/register-listener! :errors ::rej
+          (fn [r]
+            (when (= :rf.error/machine-spawn-unregistered-type (:error r))
+              (swap! records conj r)
+              (when (compare-and-set! fired? false true)
+                (frame/destroy-frame! frame-a)   ;; destroy A on the record's stack
+                (rf/make-frame {:id frame-a})      ;; publish same-id B
+                (reset! b-birth (mtest/runtime-db frame-a))))))
+        (try
+          (frame/call-with-event-owner-token frame-a token-a
+            (fn [] (spawn/spawn-all-init-fx
+                     {:frame frame-a}
+                     (fence-init-args parent-id invoke-id
+                                      [{:child-id :ok      :machine-id :fence/ok
+                                        :spawned-id :fence/ok#1}
+                                       {:child-id :missing :machine-id :fence/missing
+                                        :spawned-id :fence/missing#1}]))))
+          (is (true? @fired?) "the reject-record listener ran (fence exercised)")
+          (is (= 1 (count @records))
+              "the reject record fired once (it precedes the loss)")
+          (is (nil? (get-in (mtest/runtime-db frame-a)
+                            (paths/spawned-path parent-id invoke-id)))
+              "no reject sentinel landed on same-id successor B")
+          (is (= @b-birth (mtest/runtime-db frame-a))
+              "B's runtime-db is byte-identical to its birth value")
+          (finally
+            (rf/unregister-listener! :errors ::rej)))))))

--- a/implementation/machines/test/re_frame/spawn_all_init_incarnation_fence_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_init_incarnation_fence_test.clj
@@ -1,0 +1,272 @@
+(ns re-frame.spawn-all-init-incarnation-fence-test
+  "rf2-8nxsh — fence `spawn-all-init-fx`'s admission preflight AND its durable
+  join / reject-sentinel writes to the EXACT frame incarnation.
+
+  `spawn-all-init-fx` captures an exact-incarnation `continue?` before the
+  admission preflight, but on current main it wrote the reject sentinel and the
+  live join through a bare-id `frame/swap-runtime-db!` WITHOUT rechecking
+  ownership after:
+
+    - the preflight's `[:schemas :data]` validators (application code that can
+      synchronously destroy owner frame A and publish a same-id successor B),
+      and
+    - the reject path's `reject-unregistered-spawn!` emissions (callback-bearing
+      always-on records + dev traces).
+
+  A validator (or a reject-record listener) that swapped A for B therefore let
+  A-derived join-state / the reject sentinel install into B via the bare-id
+  write, leaving B holding an IMPOSSIBLE join it never spawned — and the
+  `:rf.machine.spawn-all/started` trace fired against B under A's authority.
+
+  These fixtures drive `spawn-all-init-fx` DIRECTLY under a bound event owner
+  (A's dequeue-time token), with a destroyer that publishes same-id B on the
+  callback's / listener's own stack, and assert B stays byte-identical: no
+  A-derived join, no reject sentinel, no started trace, no child side effect
+  lands on B. Deterministic + single-threaded — the destroyer runs INSIDE the
+  callback, so no latch coordination is needed.
+
+  The ruled policy (mirrored from the completion / spawn-tail fence,
+  rf2-3evq0x): already-entered authored callbacks may unwind, but loss of
+  exact-incarnation ownership is a TERMINAL fence for every subsequent
+  framework-owned write / tail. Cover conforming, failing, AND throwing schema
+  validators plus unregistered-child rejection with a reject-record listener;
+  ordinary all-valid and rejection behaviour stays unchanged (the fence is
+  scoped to owner-loss only — the two live-owner controls)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            ;; Loading the machines facade registers `rf/reg-machine` + the
+            ;; reserved machine fxs when this ns runs alone.
+            [re-frame.machines]
+            [re-frame.machines.lifecycle-fx.spawn :as spawn]
+            [re-frame.machines.paths :as paths]
+            [re-frame.machines.spawn-order :as spawn-order]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+;; Fresh registrar + plain-atom adapter per test; the always-on error-listener
+;; registry (a `defonce` atom) cleared so an `:errors` listener from one test
+;; cannot leak into the next.
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn [] (error-emit/clear-error-listeners!))})
+  mtest/trace-capture-fixture)
+
+;; The opaque schema marker the strict child declares; the destroyer validator
+;; keys on it. The schemas artefact is NOT loaded — the test provides the
+;; `:schemas/validate-with-registered-fn` hook directly (as the completion-fence
+;; test does), so the child's spawn-time `[:schemas :data]` gate routes through
+;; our destroyer.
+(def ^:private child-schema ::child-schema)
+
+(def ^:private strict-child
+  {:initial :running :data {:n 1} :schemas {:data child-schema}
+   :states  {:running {}}})
+
+(def ^:private ok-child
+  {:initial :running :data {} :states {:running {}}})
+
+;; ---- faithful spawn-all-init args -----------------------------------------
+
+(defn- init-args
+  "A faithful `[:rf.machine/spawn-all-init args]` payload (transition.cljc
+  §build-spawn-all-init) for `parent-id`'s invoke at slot key `invoke-id` over
+  `children` — each `{:child-id :machine-id :spawned-id :data?}`. Carries the
+  join-state seed and the PREPARED per-child `:child-args` the invoke-level
+  admission preflight decides over."
+  [parent-id invoke-id children]
+  (let [children-map (into {} (map (juxt :child-id :spawned-id)) children)
+        child-arg    (fn [{:keys [machine-id spawned-id child-id data]}]
+                       (cond-> {:machine-id            machine-id
+                                :id-prefix             machine-id
+                                :rf/spawned-id         spawned-id
+                                :rf/parent-id          parent-id
+                                :rf/spawn-all-id       invoke-id
+                                :rf/spawn-all-child-id child-id}
+                         (some? data) (assoc :data data)))]
+    {:rf/parent-id parent-id
+     :rf/invoke-id invoke-id
+     :join-state   {:children  children-map
+                    :done      #{}
+                    :failed    #{}
+                    :resolved? false
+                    :spec      {:join            :all
+                                :on-child-done   :sa/done
+                                :on-child-error  :sa/failed
+                                :on-all-complete [:all/done]}
+                    :invoke-id invoke-id}
+     :child-args   (mapv child-arg children)}))
+
+(defn- join-slot [frame-a parent-id invoke-id]
+  (get-in (mtest/runtime-db frame-a) (paths/spawned-path parent-id invoke-id)))
+
+;; ---- direct-invocation runner ---------------------------------------------
+
+(defn- run-init
+  "Make frame A, capture A's token, register a destroyer keyed on `trigger`,
+  then call `spawn-all-init-fx` DIRECTLY under A's bound event owner over
+  `children`. When `destroy?`, the trigger destroys A + publishes same-id B on
+  the callback's own stack. `trigger`:
+    {:kind :validator :verdict <:true|:false|:throw>} — a
+       `:schemas/validate-with-registered-fn` override that (optionally)
+       destroys A then returns / throws the verdict;
+    {:kind :reject-listener} — an `:errors` listener that (optionally) destroys
+       A on the first `:rf.error/machine-spawn-unregistered-type` record.
+  Returns observables read off B."
+  [frame-a parent-id invoke-id children {:keys [trigger destroy?]}]
+  (spawn-order/reset-all!)
+  (rf/make-frame {:id frame-a})
+  (let [token-a       (frame/frame-incarnation-token frame-a)
+        fired?        (atom false)
+        records       (atom [])
+        b-birth       (atom nil)
+        orig-validate (late-bind/get-fn :schemas/validate-with-registered-fn)
+        destroy+B!    (fn []
+                        (when (and destroy? (compare-and-set! fired? false true))
+                          (frame/destroy-frame! frame-a)  ;; destroy A
+                          (rf/make-frame {:id frame-a})    ;; publish same-id B
+                          (reset! b-birth (mtest/runtime-db frame-a))))]
+    (rf/register-listener! :errors ::recorder
+                           (fn [r]
+                             (when (= :rf.error/machine-spawn-unregistered-type (:error r))
+                               (swap! records conj r)
+                               (when (= :reject-listener (:kind trigger))
+                                 (destroy+B!)))))
+    (try
+      (when (= :validator (:kind trigger))
+        (late-bind/set-fn! :schemas/validate-with-registered-fn
+          (fn [schema _data]
+            (when (= schema child-schema)
+              (destroy+B!)
+              (case (:verdict trigger)
+                :throw (throw (ex-info "validator boom" {}))
+                :false false
+                true)))))
+      (frame/call-with-event-owner-token frame-a token-a
+        (fn [] (spawn/spawn-all-init-fx
+                 {:frame frame-a}
+                 (init-args parent-id invoke-id children))))
+      {:fired?     @fired?
+       :records    @records
+       :b-birth    @b-birth
+       :b-runtime  (mtest/runtime-db frame-a)
+       :join-slot  (join-slot frame-a parent-id invoke-id)
+       :started    (mtest/events-of :rf.machine.spawn-all/started)}
+      (finally
+        (rf/unregister-listener! :errors ::recorder)
+        (late-bind/set-fn! :schemas/validate-with-registered-fn orig-validate)))))
+
+(defn- assert-b-inert
+  "The successor B carries NONE of A's derived spawn-all state: no join slot,
+  runtime-db byte-identical to B's birth value, no started trace."
+  [{:keys [fired? join-slot b-runtime b-birth started]}]
+  (is (true? fired?) "the destroyer ran (the incarnation fence was exercised)")
+  (is (nil? join-slot)
+      "no A-derived join / reject sentinel landed on same-id successor B")
+  (is (= b-birth b-runtime)
+      "B's runtime-db is byte-identical to its birth value")
+  (is (empty? started)
+      "no :rf.machine.spawn-all/started trace fired against B"))
+
+;; ===========================================================================
+;; (1) Accept-path fence — a preflight schema validator destroys A.
+;;     Mutation tooth: reverting the live-join write to a bare-id
+;;     `swap-runtime-db!` lands A's join-state on B.
+;; ===========================================================================
+
+(deftest conforming-validator-loss-fences-live-join
+  (testing "a CONFORMING `[:schemas :data]` validator that destroys A + publishes
+            same-id B (a validator returning true still ran on A's stack): the
+            all-valid path recomputes to the exact write, which no-ops — B holds
+            no A-derived live join and gets no started trace"
+    (rf/reg-machine :fence/strict strict-child)
+    (assert-b-inert
+      (run-init :rf2-8nxsh/accept-conform :par/a [:forking]
+                [{:child-id :bad :machine-id :fence/strict :spawned-id :fence/strict#1
+                  :data {:n 1}}]
+                {:trigger {:kind :validator :verdict :true} :destroy? true}))))
+
+(deftest failing-validator-loss-fences-live-join
+  (testing "a FAILING validator that destroys A: the verdict is
+            :rf/stale-incarnation (owner-loss short-circuits the schema verdict),
+            so no sentinel OR join lands on B — a failing-yet-destroying validator
+            leaks nothing"
+    (rf/reg-machine :fence/strict strict-child)
+    (assert-b-inert
+      (run-init :rf2-8nxsh/accept-fail :par/a [:forking]
+                [{:child-id :bad :machine-id :fence/strict :spawned-id :fence/strict#1
+                  :data {:n 1}}]
+                {:trigger {:kind :validator :verdict :false} :destroy? true}))))
+
+(deftest throwing-validator-loss-fences-live-join
+  (testing "a THROWING validator that destroys A then throws: the throw is caught
+            and (A gone) swallowed to :rf/stale-incarnation, so the durable write
+            no-ops and B stays byte-identical"
+    (rf/reg-machine :fence/strict strict-child)
+    (assert-b-inert
+      (run-init :rf2-8nxsh/accept-throw :par/a [:forking]
+                [{:child-id :bad :machine-id :fence/strict :spawned-id :fence/strict#1
+                  :data {:n 1}}]
+                {:trigger {:kind :validator :verdict :throw} :destroy? true}))))
+
+;; ===========================================================================
+;; (2) Reject-path fence — a reject-record listener destroys A.
+;;     Mutation tooth: reverting the sentinel write to an unguarded bare-id
+;;     `swap-runtime-db!` lands the reject sentinel on B.
+;; ===========================================================================
+
+(deftest reject-record-listener-loss-fences-sentinel
+  (testing "an unregistered child fans one always-on reject record; a LISTENER on
+            that record destroys A + publishes same-id B. Ownership is rechecked
+            before the sentinel write and the write rides A's raw token, so no
+            reject sentinel lands on B"
+    (rf/reg-machine :fence/ok ok-child)
+    ;; :fence/missing is NEVER reg-machine'd — the unregistered child.
+    (let [result (run-init :rf2-8nxsh/reject-listener :par/a [:forking]
+                           [{:child-id :ok      :machine-id :fence/ok      :spawned-id :fence/ok#1}
+                            {:child-id :missing :machine-id :fence/missing :spawned-id :fence/missing#1}]
+                           {:trigger {:kind :reject-listener} :destroy? true})]
+      (is (= 1 (count (:records result)))
+          "the reject record fired once (it precedes the loss) — the fence is not a suppression bug")
+      (assert-b-inert result))))
+
+;; ===========================================================================
+;; (3) Live-owner controls — the fence is scoped to owner-loss only.
+;; ===========================================================================
+
+(deftest live-owner-accept-seeds-a-live-join
+  (testing "control: an all-valid invoke whose validator does NOT destroy A seeds
+            a LIVE child-bearing join and fires the started trace — unchanged"
+    (rf/reg-machine :fence/strict strict-child)
+    (let [{:keys [join-slot started]}
+          (run-init :rf2-8nxsh/live-accept :par/a [:forking]
+                    [{:child-id :good :machine-id :fence/strict :spawned-id :fence/strict#1
+                      :data {:n 7}}]
+                    {:trigger {:kind :validator :verdict :true} :destroy? false})]
+      (is (contains? join-slot :children)
+          "a LIVE child-bearing join is seeded (no false reject)")
+      (is (= {:good :fence/strict#1} (:children join-slot))
+          "the join names the child at its allocated id")
+      (is (some? (:rf/attempt join-slot))
+          "the live seed minted its per-attempt token")
+      (is (= 1 (count started))
+          "the :rf.machine.spawn-all/started trace fired for the live join"))))
+
+(deftest live-owner-reject-seeds-the-sentinel
+  (testing "control: an unregistered child with NO destroyer seeds the childless
+            reject sentinel and fans exactly one reject record — unchanged"
+    (rf/reg-machine :fence/ok ok-child)
+    (let [{:keys [join-slot records started]}
+          (run-init :rf2-8nxsh/live-reject :par/a [:forking]
+                    [{:child-id :ok      :machine-id :fence/ok      :spawned-id :fence/ok#1}
+                     {:child-id :missing :machine-id :fence/missing :spawned-id :fence/missing#1}]
+                    {:trigger {:kind :reject-listener} :destroy? false})]
+      (is (= {:rf/spawn-all-rejected? true} join-slot)
+          "the childless reject sentinel is seeded (no live join)")
+      (is (= 1 (count records))
+          "exactly one always-on reject record for the one unregistered child")
+      (is (empty? started)
+          "a rejected invoke fires no started trace"))))


### PR DESCRIPTION
## What

`spawn-all-init-fx` captured an exact-incarnation `continue?` before its admission preflight, but then wrote the reject sentinel and the live join through a **bare-id** `frame/swap-runtime-db!` **without rechecking ownership** after:

- the preflight's `[:schemas :data]` validators (application code), and
- the reject path's `reject-unregistered-spawn!` emissions (callback-bearing always-on records + dev traces).

A validator or reject-record listener that synchronously destroyed owner frame **A** and published a same-id successor **B** therefore let A-derived join-state / the reject sentinel install into B via the bare-id write (which resolves to the *current* incarnation) — **B held an IMPOSSIBLE join it never spawned** — and the `:rf.machine.spawn-all/started` trace fired against B under A's authority.

### Unchecked write sites (before)
- `lifecycle_fx/spawn.cljc` reject sentinel write (was line ~973) — after `schema-rejected-child?` preflight **and** `reject-unregistered-spawn!` emissions.
- `lifecycle_fx/spawn.cljc` live-join write + `:rf.machine.spawn-all/started` trace (was lines ~985/987) — after the preflight validators.

## Fix (rf2-8nxsh)

Both durable writes now ride A's **raw owner token** through a new `write-spawned-slot!` helper (`frame/swap-runtime-db-exact!`), so a same-id B can never redirect the write and a mid-write container watch that loses A no-ops it without bumping B's epoch — B stays byte-identical. `continue?` is rechecked **after the preflight** (before either write) and **between reject emissions**, and the started trace fires only when the join actually committed into A. Non-router callers (nil owner-token) fall back to the historical bare-id write, symmetric with `continue?`'s `(constantly true)`.

**No new error-id** — reuses `:rf.error/machine-spawn-unregistered-type` + `:rf/stale-incarnation` semantics, so no Spec-009 catalogue row / core conformance gate is implicated. No core-frame or spec/005 edits.

## Tests

- **`spawn_all_init_incarnation_fence_test.clj` (JVM, new):** conforming, failing, and throwing schema-validator loss (accept-path live-join fence) + reject-record listener loss (reject-path sentinel fence) + two live-owner controls. Drives `spawn-all-init-fx` directly under A's bound event owner with a destroyer that publishes same-id B on the callback's own stack; asserts B byte-identical (no A-derived join, no sentinel, no started trace). **Red-before:** reverting the two writes to bare-id `swap-runtime-db!` lands A's join `{:children {:bad :fence/strict#1}}` on B and fires the started trace against B (11 assertions fail); **green-after** with the fence.
- **`machines_spawn_cljs_test.cljs` (rf2-plahy):** exact unregistered-rejection cardinality on CLJS — multi-missing + registered sibling fan exactly N always-on records + N dev traces, seed the childless sentinel, run no child effect; plus standalone single-spawn exact-one. Plus the 8nxsh CLJS incarnation fence (accept + reject paths). **Mutation tooth confirmed:** reversing the per-child gate order doubles the cardinality and fails the CLJS test (3 assertions).

## Quality gates

- `implementation/machines` JVM full suite (`clojure -M:test`): **1158 tests, 3957 assertions, 0 failures, 0 errors** (includes new fence test + all existing spawn tests).
- `npm run test:cljs` (node-test, covers the new CLJS spawn tests): **9722 tests, 47826 assertions, 0 failures, 0 errors**.
- Incarnation repro red-before / green-after verified for both write sites (JVM).
- plahy per-child gate-order mutation verified to fail the CLJS test.
- Core JVM conformance gate: not run — **no error-id added or touched**.
