### PR TITLE
fix(guard): strengthen parallel :always guide guard against paraphrase + historical-example bypass (rf2-b0vvu)

### DIFF
--- a/implementation/machines/test/re_frame/parallel_states_guide_truth_jvm_test.clj
+++ b/implementation/machines/test/re_frame/parallel_states_guide_truth_jvm_test.clj
@@ -15,7 +15,7 @@
 
   So this namespace guards the prose, in two directions:
 
-  - the superseded claims stay ABSENT, and
+  - the four superseded claims stay ABSENT, and
   - the load-bearing terms (`parent-owned`, the freeze/select/apply ROUND,
     the between-round RE-FREEZE) stay PRESENT.
 
@@ -27,7 +27,26 @@
   itself\"`, frozen per round `not for the whole macrostep`). A guard that
   fired on those would be deleted within a week, so `guard-has-teeth` pins
   both directions: every superseded sentence is caught, every legitimate
-  sentence is not."
+  sentence is not.
+
+  rf2-b0vvu strengthens the superseded half along two axes the first cut
+  (rf2-nqovj) left open, without turning this into a semantic/NLP parser:
+
+  - PARAPHRASE. The retired claims were anchored on their exact removed
+    wording, so a natural editor/AI paraphrase using different surface words
+    slipped through (e.g. `settles independently` → `stabilizes … on its own`;
+    `frozen for the whole macrostep` → `fixed from macrostep entry until
+    macrostep exit`). Each of the four claim FAMILIES now carries a small
+    relationship/token pattern that catches its original AND a paraphrase,
+    while still steering clear of the legitimate near-matches.
+
+  - HISTORICAL / INCORRECT-EXAMPLE POLARITY. A retired claim quoted under an
+    explicit negative-example heading (`### BEFORE — incorrect; do not copy`,
+    `Historical …`, `Superseded …`) is a labelled anti-example, not the guide
+    reasserting the claim — the old cut rejected it. `superseded-hits` now
+    strips such heading-scoped sections before scanning, so a labelled block
+    may quote a retired claim, while the SAME claim in ordinary affirmative
+    prose still fails."
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]))
@@ -45,50 +64,80 @@
   (delay (slurp (io/file (repo-root) "docs/machines/parallel-states.md"))))
 
 ;; ---------------------------------------------------------------------------
-;; The four superseded claims rf2-1rdo4j retired.
+;; The four superseded claim FAMILIES rf2-1rdo4j retired.
 ;;
-;; Each pattern is anchored on the phrasing that carries the CLAIM, never on a
-;; bare keyword, so the corrected guide's legitimate uses of the same words
-;; stay clear of it. `guard-has-teeth` proves both halves of that.
+;; One entry per family, not per removed sentence: each family's pattern is an
+;; alternation over the original removed phrasing PLUS a small
+;; relationship/token paraphrase form. Collapsing to families keeps the return
+;; of `superseded-hits` one label per reverted idea, so an original and its
+;; paraphrase both report the same family rather than double-counting.
+;;
+;; Every alternative is anchored on the phrasing that carries the CLAIM (a
+;; relationship between tokens — `region` + a settling verb + `on its own`;
+;; a `frozen`/`fixed` word + `whole`/`entire` + `macrostep`), never on a bare
+;; keyword, so the corrected guide's legitimate uses of the same words stay
+;; clear of it. `guard-has-teeth` proves both halves for each family.
+
+(def ^:private claim-per-region-settle
+  "region `:always` settles independently (not one parent round)")
+(def ^:private claim-loop-per-region
+  "the `:always` loop runs per region (not one parent round over all regions)")
+(def ^:private claim-converges-next-event
+  "a guarded `:always` waits for a later event (not the same macrostep)")
+(def ^:private claim-frozen-whole-macrostep
+  "sibling keys frozen for the whole macrostep (not per selection round)")
 
 (def ^:private superseded-claims
-  [;; 1. Birth / per-region settling: "each region's birth `:always` settles
-   ;;    independently as part of the initial step". The parent runs birth
-   ;;    rounds across the whole configuration.
-   ["a region's `:always` settles independently"
-    #"(?i)settles?\s+independently"]
+  [;; 1. Per-region settling: "each region's birth `:always` settles
+   ;;    independently". The parent runs birth rounds across the whole
+   ;;    configuration. Paraphrase caught: a region stabilizes/settles
+   ;;    "on its own" / "by itself" / "independently".
+   ;;
+   ;;    The paraphrase alternative deliberately does NOT list `itself` /
+   ;;    `themselves`, so the guide's explicit negation of the old framing —
+   ;;    `not "each region settles itself"` — is not caught.
+   [claim-per-region-settle
+    #"(?i)(?:settles?\s+independently|\bregions?\b[^.\n]{0,40}?\b(?:settl|stabili[sz])[a-z]*\b[^.\n]{0,40}?\b(?:on\s+its\s+own|on\s+their\s+own|by\s+itself|by\s+themselves|independently|in\s+isolation|separately)\b)"]
 
    ;; 2. "per region" applied to the `:always` LOOP (not to the apply phase):
    ;;    "the microstep loop runs *per region*", settling to "*that region's*
-   ;;    fixed point", with "siblings aren't re-evaluated".
-   ["the `:always` loop runs per region"
-    #"(?i)loop\s+runs\s+\*{0,2}per[-\s]region"]
-   ["`:always` settles to a per-region fixed point"
-    #"(?i)(?:that\s+region's|its\s+own)\*{0,2}\s+\*{0,2}fixed\s+point"]
-   ["siblings are not re-evaluated during the `:always` loop"
-    #"(?i)siblings\s+are(?:n't|\s+not)\s+re-evaluated"]
+   ;;    fixed point", with "siblings aren't re-evaluated". Paraphrase caught:
+   ;;    an eventless/microstep LOOP that runs "region by region", or SIBLINGS
+   ;;    "held aside" / "left untouched" / "not revisited".
+   ;;
+   ;;    Both paraphrase alternatives are anchored so the correct guide stays
+   ;;    clear: the loop form needs an actual loop word (`the loop is not …`
+   ;;    has none of `microstep`/`eventless`/`:always` before `loop`), and the
+   ;;    sibling form keys on `sibling(s)`, so the root-`:on` suppression prose
+   ;;    "regions … are left untouched" (about REGIONS, not SIBLINGS) is clear.
+   [claim-loop-per-region
+    #"(?i)(?:loop\s+runs\s+\*{0,2}per[-\s]region|(?:that\s+region'?s|its\s+own)\*{0,2}\s+\*{0,2}fixed\s+point|siblings?\s+are(?:n'?t|\s+not)\s+re-?evaluated|\b(?:microstep|eventless|:?always)\s+loop\b[^.\n]{0,40}?\b(?:per[-\s]region|region[-\s]by[-\s]region|in\s+each\s+region|within\s+each\s+region|region-local|region\s+at\s+a\s+time)\b|\bsiblings?\b[^.\n]{0,40}?\b(?:left\s+untouched|held\s+(?:aside|untouched|fixed|out)|not\s+revisited|not\s+reconsidered|not\s+re-?examined|not\s+re-?checked)\b)"]
 
    ;; 3. A guarded `:always` reading a sibling "converges on the NEXT EVENT" —
    ;;    it converges inside the SAME macrostep, on the parent's first
-   ;;    eventless round.
-   ["a guarded `:always` converges on the next event"
-    #"(?i)converges?\s+on\s+the\s+\*{0,2}next\s+event"]
-   ["a guarded `:always` re-selects on the next event delivered"
-    #"(?i)on\s+the\s+next\s+event\s+delivered"]
-   ["a guarded `:always` fires one event later"
-    #"(?i)just\s+one\s+event\s+later"]
+   ;;    eventless round. Paraphrase caught: a guard/transition that
+   ;;    waits/defers/"only fires" UNTIL/FOR a later/next/another EVENT.
+   ;;
+   ;;    The paraphrase needs a wait/defer verb, so the correct guide's
+   ;;    "re-broadcasts … on the next microstep" and "before it dequeues the
+   ;;    next raise" (no wait verb; not an EVENT) stay clear.
+   [claim-converges-next-event
+    #"(?i)(?:converges?\s+on\s+the\s+\*{0,2}next\s+event|on\s+the\s+next\s+event\s+delivered|just\s+one\s+event\s+later|\b(?:waits?|waited|defers?|deferred|delays?|delayed|postpones?|postponed|held\s+back|won'?t\s+fire|does\s+not\s+fire|only\s+(?:fires?|moves?|re-?selects?))\b[^.\n]{0,45}?\b(?:until|for|till|on)\b[^.\n]{0,30}?\b(?:another|the\s+next|a\s+later|a\s+future|a\s+subsequent|the\s+following|subsequent|later)\b[^.\n]{0,25}?\bevent\b)"]
 
    ;; 4. `:tags` / `:all-state` frozen for the WHOLE macrostep — they are
-   ;;    frozen per SELECTION ROUND and re-frozen between rounds.
+   ;;    frozen per SELECTION ROUND and re-frozen between rounds. Paraphrase
+   ;;    caught: keys "fixed"/"frozen"/"constant" for the WHOLE/ENTIRE
+   ;;    macrostep, or "from macrostep entry … until macrostep exit".
    ;;
-   ;;    NOTE: the corrected guide contains the substring "not for the whole
-   ;;    macrostep". These patterns require the ASSERTION ("frozen FOR the
-   ;;    whole macrostep", "as of the START of the macrostep"), so the negated
-   ;;    teaching does not trip them.
-   ["sibling keys are frozen for the whole macrostep"
-    #"(?i)frozen\s+for\s+the\s+\*{0,2}whole\s+macrostep"]
-   ["sibling keys reflect the configuration at macrostep start"
-    #"(?i)as\s+of\s+the\s+\*{0,2}start\*{0,2}\s+of\s+the\s+macrostep"]])
+   ;;    NOTE: the corrected guide contains "not for the whole macrostep" and
+   ;;    "frozen for the **selection round**". The original alternatives
+   ;;    require the contiguous ASSERTION ("frozen FOR the whole macrostep"),
+   ;;    and the paraphrase alternatives require a `whole`/`entire`/`macrostep`
+   ;;    token within a short window of the `fixed`/`frozen` word — which the
+   ;;    negated teaching (`frozen for the selection round … not for the whole
+   ;;    macrostep`, `whole` ~80 chars away) never satisfies.
+   [claim-frozen-whole-macrostep
+    #"(?i)(?:frozen\s+for\s+the\s+\*{0,2}whole\s+macrostep|as\s+of\s+the\s+\*{0,2}start\*{0,2}\s+of\s+the\s+macrostep|\b(?:frozen|fixed|constant|unchanged|stable|pinned|immutable|unchanging)\b[^.\n]{0,45}?\b(?:whole|entire|throughout|across|for\s+the\s+(?:duration|life)\s+of|until\s+the\s+end\s+of|macrostep\s+entry)\b[^.\n]{0,30}?\bmacrostep\b|\bfrom\s+macrostep\s+(?:entry|start|begin(?:ning)?)\b[^.\n]{0,45}?\b(?:until|to|through|up\s+to)\b[^.\n]{0,30}?\bmacrostep\s+(?:exit|end|finish|completion)\b)"]])
 
 ;; ---------------------------------------------------------------------------
 ;; The load-bearing terms the rewrite installed. Absence = the guide lost the
@@ -108,12 +157,61 @@
    ["birth runs the same parent-owned round process"
     #"(?i)same\s+process\s+runs\s+at\s+\*{0,2}birth"]])
 
-(defn- superseded-hits
-  "Every superseded claim `text` reacquired."
+;; ---------------------------------------------------------------------------
+;; Historical / incorrect-example polarity.
+;;
+;; A retired claim quoted under a heading that explicitly frames its section as
+;; a NEGATIVE example (BEFORE — incorrect; do not copy / Historical … /
+;; Superseded …) is a labelled anti-example, not the guide reasserting the
+;; claim. Strip those heading-scoped sections before scanning, so a labelled
+;; block may quote a retired claim while the SAME claim in ordinary affirmative
+;; prose still trips the guard.
+;;
+;; This is a light ATX-heading scan, not a Markdown parser: a section runs from
+;; a negative-example heading to the next heading of equal-or-higher level.
+
+(def ^:private atx-heading
+  #"^(#{1,6})\s")
+
+(def ^:private historical-heading
+  #"(?i)^#{1,6}\s.*\b(?:incorrect|do[-\s]*not[-\s]*copy|superseded|deprecated|anti-?patterns?|the\s+old\s+(?:model|framing|way)|what\s+not\s+to|historical)\b")
+
+(defn- strip-historical-sections
+  "Drop the body of any section whose ATX heading explicitly frames it as a
+  negative example. Everything else — ordinary, affirmative teaching prose — is
+  retained and scanned."
   [text]
-  (->> superseded-claims
-       (filter (fn [[_ pattern]] (re-find pattern text)))
-       (mapv first)))
+  (loop [lines (str/split-lines text)
+         drop-level nil       ;; nil = keeping; int = dropping until heading <= this level
+         kept (transient [])]
+    (if (empty? lines)
+      (str/join "\n" (persistent! kept))
+      (let [line  (first lines)
+            m     (re-find atx-heading line)
+            level (when m (count (second m)))]
+        (cond
+          ;; inside a historical section: keep dropping until a heading of
+          ;; equal-or-higher level closes it (that heading is re-examined).
+          drop-level
+          (if (and level (<= level drop-level))
+            (recur lines nil kept)
+            (recur (rest lines) drop-level kept))
+
+          ;; a heading that opens a historical section
+          (and level (re-find historical-heading line))
+          (recur (rest lines) level kept)
+
+          :else
+          (recur (rest lines) nil (conj! kept line)))))))
+
+(defn- superseded-hits
+  "Every superseded claim FAMILY the affirmative prose reacquired. Sections
+  under an explicit historical/incorrect-example heading are exempt."
+  [text]
+  (let [affirmative (strip-historical-sections text)]
+    (->> superseded-claims
+         (filter (fn [[_ pattern]] (re-find pattern affirmative)))
+         (mapv first))))
 
 (defn- missing-terms
   "Every load-bearing term `text` no longer carries."
@@ -138,29 +236,54 @@
              "the parent-owned round law."))))
 
 (deftest guard-has-teeth
-  (testing "every superseded sentence is caught"
-    ;; Verbatim from the prose rf2-1rdo4j removed (git show cbaa8192cb^).
-    (doseq [[claim sentence]
-            [["a region's `:always` settles independently"
+  (testing "every superseded claim is caught — original wording AND a paraphrase"
+    ;; Originals are verbatim from the prose rf2-1rdo4j removed
+    ;; (git show cbaa8192cb^); each `paraphrase` restates the SAME claim with
+    ;; different surface words. Both must report the claim's family.
+    (doseq [[family sentence]
+            [;; family 1 — per-region settling
+             [claim-per-region-settle
               "each region's birth `:always` settles independently as part of the initial step."]
-             ["the `:always` loop runs per region"
+             [claim-per-region-settle          ; paraphrase (rf2-b0vvu mutation)
+              "Each region stabilizes its eventless transitions on its own before its siblings are revisited."]
+
+             ;; family 2 — the `:always` loop runs per region
+             [claim-loop-per-region
               "**`:always`** — the microstep loop runs *per region*."]
-             ["`:always` settles to a per-region fixed point"
+             [claim-loop-per-region
               "that region's new state's `:always` entries are checked and settle to *that region's* fixed point;"]
-             ["siblings are not re-evaluated during the `:always` loop"
+             [claim-loop-per-region
               "siblings aren't re-evaluated for `:always` on this region's microstep."]
-             ["a guarded `:always` converges on the next event"
+             [claim-loop-per-region             ; paraphrase
+              "The eventless loop is run region by region, and the siblings are held aside until the next round."]
+
+             ;; family 3 — a guarded `:always` waits for a later event
+             [claim-converges-next-event
               "- **A guarded `:always` reading the sibling — converges on the NEXT EVENT.**"]
-             ["a guarded `:always` re-selects on the next event delivered"
+             [claim-converges-next-event
               "so this re-selects against the committed `:form/valid` on the next event delivered"]
-             ["a guarded `:always` fires one event later"
+             [claim-converges-next-event
               "it fires, just one event later."]
-             ["sibling keys are frozen for the whole macrostep"
+             [claim-converges-next-event        ; paraphrase (rf2-b0vvu mutation)
+              "A sibling-dependent guard waits until another event arrives."]
+
+             ;; family 4 — sibling keys frozen for the whole macrostep
+             [claim-frozen-whole-macrostep
               "`:tags` and `:all-state` are frozen for the whole macrostep."]
-             ["sibling keys reflect the configuration at macrostep start"
-              "the sibling configuration as of the *start* of the macrostep."]]]
-      (is (= [claim] (superseded-hits sentence))
-            (str "the guard failed to catch a reverted claim: " claim))))
+             [claim-frozen-whole-macrostep
+              "the sibling configuration as of the *start* of the macrostep."]
+             [claim-frozen-whole-macrostep      ; paraphrase (rf2-b0vvu mutation)
+              "Sibling keys remain fixed from macrostep entry until macrostep exit."]]]
+      (is (= [family] (superseded-hits sentence))
+          (str "the guard failed to catch (exactly) the claim: " family
+               "\n  in: " sentence))))
+
+  (testing "the three exact paraphrase mutations reproduced in rf2-b0vvu fail the guard"
+    (doseq [mutation ["Each region stabilizes its eventless transitions on its own before its siblings are revisited."
+                      "Sibling keys remain fixed from macrostep entry until macrostep exit."
+                      "A sibling-dependent guard waits until another event arrives."]]
+      (is (seq (superseded-hits mutation))
+          (str "a reproduced paraphrase mutation slipped through: " mutation))))
 
   (testing "the corrected guide's legitimate uses of the same words are not caught"
     ;; Verbatim from the SHIPPED guide. Each sits within a word or two of a
@@ -175,9 +298,39 @@
              "So the loop is not *\"each region settles itself\"* — it is *\"the machine settles, one whole-configuration round at a time\"*."
              "`:tags` and `:all-state` are frozen for the **selection round** that is currently choosing transitions, not for the whole macrostep."
              ;; per-region timers/spawn remain correct region-local claims
-             "A sibling region transitioning does **not** cancel this region's in-flight `:after` timer; each region keeps its own timer epoch."]]
+             "A sibling region transitioning does **not** cancel this region's in-flight `:after` timer; each region keeps its own timer epoch."
+             ;; root-`:on` suppression: REGIONS (not siblings) are left untouched
+             "Region `:a` declares `:reset` locally, so on `:reset` the root transition is dropped wholesale, and regions the root *would* have moved are left untouched:"
+             ;; the orthogonal AXES each move on their own — not the `:always` loop
+             "Those three axes are **orthogonal**: each moves on its own, and any combination is legal."
+             ;; a raised event re-broadcasts on the next MICROSTEP (not event), no wait
+             "that internal event re-broadcasts across every region on the next microstep"
+             ;; eventless work drains before the next RAISE (not event), no wait
+             "the parent settles `:always` to a fixed point before it dequeues the next raise."]]
       (is (= [] (superseded-hits sentence))
           (str "the guard fired on legitimate shipped prose: " sentence))))
+
+  (testing "an explicitly labelled historical / do-not-copy section may quote a retired claim"
+    ;; A BEFORE/incorrect block is a labelled anti-example, not a revert.
+    (let [before-block
+          (str "### BEFORE — incorrect; do not copy\n"
+               "\n"
+               "Each region's `:always` settles independently, and its sibling\n"
+               "keys stay frozen for the whole macrostep until the next event.\n"
+               "\n"
+               "## `:always` stabilization is parent-owned\n"
+               "\n"
+               "The parent settles `:always` in freeze/select/apply rounds.\n")]
+      (is (= [] (superseded-hits before-block))
+          (str "a retired claim quoted under an explicit BEFORE/incorrect/"
+               "do-not-copy heading must be treated as a labelled anti-example, "
+               "not as the guide reasserting the claim.")))
+    ;; POLARITY: the SAME claims in ordinary affirmative prose still fail —
+    ;; the exemption is heading-scoped, not a blanket pass on the phrasing.
+    (is (seq (superseded-hits "Each region's `:always` settles independently."))
+        "the same claim in affirmative prose (no historical heading) must still trip the guard")
+    (is (seq (superseded-hits "Sibling keys stay frozen for the whole macrostep."))
+        "the same claim in affirmative prose (no historical heading) must still trip the guard"))
 
   (testing "a guide stripped of the law is caught by the required-term half"
     (is (seq (missing-terms "Parallel regions are orthogonal axes of one machine."))))


### PR DESCRIPTION
## What

Closes two bypass paths in the parent-owned parallel-`:always` GUIDE guard
(`implementation/machines/test/re_frame/parallel_states_guide_truth_jvm_test.clj`,
added by rf2-nqovj / #6119). The guard anchored each retired claim on its exact
removed wording, so:

1. **Paraphrase bypass.** A natural editor/AI restatement using different
   surface words left `superseded-hits` empty. Confirmed against the shipped
   guard — all three returned `[]`:
   - `settles independently` → *"Each region stabilizes its eventless transitions on its own before its siblings are revisited."*
   - `frozen for the whole macrostep` → *"Sibling keys remain fixed from macrostep entry until macrostep exit."*
   - `converges on the NEXT EVENT` → *"A sibling-dependent guard waits until another event arrives."*
2. **Historical-example false-positive.** A retired claim quoted under an
   explicit `### BEFORE — incorrect; do not copy` heading was rejected, so the
   guide could not teach the old model as a labelled negative example.

## How

A small deterministic text check — **not** a semantic/NLP or Markdown parser:

- The superseded half is collapsed to **one entry per claim family**; each
  family's pattern is an alternation over the original phrasing plus a small
  relationship/token paraphrase form (`region` + settle verb + `on its own`;
  a wait/defer verb + `until`/`for` + a later/next/another `event`; a
  `frozen`/`fixed` word + `whole`/`entire` + `macrostep`, or `from macrostep
  entry … until macrostep exit`). Every alternative stays anchored on the
  relationship that carries the claim, clear of the legitimate near-matches.
- `superseded-hits` strips **heading-scoped negative-example sections**
  (`BEFORE`/`incorrect`/`do-not-copy`/`superseded`/`historical`) before
  scanning, so a labelled block may quote a retired claim while the **same
  claim in ordinary affirmative prose still fails** — the exemption is
  heading-scoped, not a blanket pass on the phrasing.

The required-term half and its legitimate near-match controls are unchanged.
The guide (`docs/machines/parallel-states.md`) is untouched.

## Anti-over-engineering

No general prose validation. Patterns are keyed on the specific
relationship each family expresses and verified to stay clean on the shipped
guide's near-matches: `each moves on its own` (orthogonal axes, not the loop),
`regions … left untouched` (root-`:on` suppression, keyed on *sibling* not
*region*), `on the next microstep` / `next raise` (no wait verb; not an
event), and the negated `not "each region settles itself"` / `frozen for the
selection round … not for the whole macrostep`.

## Quality gates

- `clojure -M:test -n re-frame.parallel-states-guide-truth-jvm-test` (machines JVM gate):
  **2 tests, 34 assertions, 0 failures, 0 errors** (was 20 assertions).
- Self-test proves both directions:
  - every family caught in original wording **and** a paraphrase, including the three reproduced mutations (RED);
  - a labelled historical block passes while the same claim affirmatively fails (polarity);
  - the shipped guide and all legitimate near-matches stay clean (GREEN, no false-fire).
- `mkdocs build --strict` / `check_doc_slugs.py`: **N/A** — this PR is
  test-only; the guide corpus is byte-identical.
