### PR TITLE
fix(guard): expand retired-operation guard roots to every active synthesis authority (rf2-d9v3n)

### DIFF
--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_retired_op_prep/ai/findings/new-substrate-synthesis/prep/w9-ci-matrix-disposition.md
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_retired_op_prep/ai/findings/new-substrate-synthesis/prep/w9-ci-matrix-disposition.md
@@ -1,0 +1,3 @@
+# W9 CI matrix disposition
+
+Copy this rule table into the worktree from the mayor checkout before editing.

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_retired_op_prep/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_retired_op_prep/mkdocs.yml
@@ -1,0 +1,1 @@
+site_name: synthesis-retired-op-prep

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_retired_op_toplevel/ai/findings/new-substrate-synthesis/11-adoption-workstreams.md
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_retired_op_toplevel/ai/findings/new-substrate-synthesis/11-adoption-workstreams.md
@@ -1,0 +1,3 @@
+# Adoption workstreams
+
+This workstream plan is mayor checkout only.

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_retired_op_toplevel/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_retired_op_toplevel/mkdocs.yml
@@ -1,0 +1,1 @@
+site_name: synthesis-retired-op-toplevel

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/01-goals-and-invariants.md
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/01-goals-and-invariants.md
@@ -1,0 +1,5 @@
+# Goals and invariants
+
+NEGATIVE CONTROL: this top-level narrative chapter is NOT an operational
+authority, so it must stay out of the inventory even though it carries a retired
+directive. This narrative chapter is mayor checkout only.

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/11-adoption-workstreams.md
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/11-adoption-workstreams.md
@@ -1,0 +1,3 @@
+# Adoption workstreams
+
+The active adoption plan; read it in your own worktree at the audited revision.

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/12-implementation-plan.md
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/12-implementation-plan.md
@@ -1,0 +1,3 @@
+# Implementation plan
+
+Sequenced workstreams; read at the audited revision in your own worktree.

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/README.md
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/README.md
@@ -1,0 +1,5 @@
+# Synthesis README
+
+NEGATIVE CONTROL: the README is not an operational authority. Copy these pages
+into the worktree from the mayor checkout — a retired directive that must stay
+out of scope.

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/prep/w1-migrator-rule-table.md
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/prep/w1-migrator-rule-table.md
@@ -1,0 +1,3 @@
+# W1 migrator rule table
+
+Read this table in your own worktree at the revision being implemented.

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/reviews/codex1.md
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/reviews/codex1.md
@@ -1,0 +1,5 @@
+# Review codex1
+
+NEGATIVE CONTROL: reviews/ is historical review prose, not an active operation.
+The dispatcher copies the plan into the worktree from the mayor checkout — must
+stay out of scope.

--- a/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/spikes/s1-codegen-report.md
+++ b/scripts/_test_fixtures/check_doc_slugs/synthesis_valid_narrow_scope/ai/findings/new-substrate-synthesis/spikes/s1-codegen-report.md
@@ -1,0 +1,5 @@
+# Spike s1 codegen report
+
+NEGATIVE CONTROL: spikes/ is historical spike prose, not an active operation.
+This report is mayor checkout only and absent from worker worktrees — must stay
+out of scope.

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -77,9 +77,34 @@ DEFAULT_ROOTS = (
 # explicit opt-in scope: it must not widen the default docs/MkDocs corpus or
 # sweep unrelated ai/ scratch. S6 owns publication; this gate owns only links
 # and anchors while the source remains here.
+#
+# The scope is ALSO the retired-operation guard's inventory (see
+# _scan_retired_synthesis_ops): every active runnable/dispatch authority a
+# worker executes directly must be covered, so a stale copy-from-mayor /
+# local-only directive cannot hide in a live authority. rf2-d9v3n expanded the
+# inventory from guide/ + drafts/ (which only covered publication-track pages)
+# to the operational authorities as well:
+#
+#   * prep/ — the per-workstream prep tables (w1/w2/w3/w9) workers run against.
+#   * the two top-level operational authorities named in SYNTHESIS_FILES.
+#
+# The inventory stays narrow and reviewable on purpose: the sibling 01-10
+# narrative chapters, README, and the reviews/ + spikes/ subtrees are
+# historical review/spike prose, NOT active operations, and stay out.
 SYNTHESIS_ROOTS = (
     "ai/findings/new-substrate-synthesis/guide",
     "ai/findings/new-substrate-synthesis/drafts",
+    "ai/findings/new-substrate-synthesis/prep",
+)
+
+# Individual top-level operational authorities. These two files live directly in
+# ai/findings/new-substrate-synthesis/ alongside the 01-10 narrative chapters and
+# README, so the whole directory is NOT a root — only these named files are
+# active authorities a worker dispatches/executes and must be guarded. Naming
+# them explicitly keeps the inventory an auditable list, not a directory sweep.
+SYNTHESIS_FILES = (
+    "ai/findings/new-substrate-synthesis/11-adoption-workstreams.md",
+    "ai/findings/new-substrate-synthesis/12-implementation-plan.md",
 )
 
 # Diff-ready spec drafts author their links for the file's eventual `spec/`
@@ -323,11 +348,16 @@ def _iter_markdown(
 ) -> Iterable[Path]:
     """Yield absolute paths to every in-scope .md file."""
     roots: list[tuple[Path, bool]] = []
+    explicit_files: list[Path] = []
     if synthesis_only:
         for d in SYNTHESIS_ROOTS:
             p = repo_root / d
             if p.is_dir():
                 roots.append((p, True))
+        for f in SYNTHESIS_FILES:
+            p = repo_root / f
+            if p.is_file():
+                explicit_files.append(p)
     else:
         for d in DEFAULT_ROOTS:
             p = repo_root / d
@@ -354,6 +384,17 @@ def _iter_markdown(
                 continue
             seen.add(ap)
             yield path
+    # Individually-named authority files (SYNTHESIS_FILES). Run through the same
+    # exclusion + dedup path; allow_ai_findings is True because these are the
+    # exact tracked synthesis authorities, never an arbitrary ai/ path.
+    for path in explicit_files:
+        if _is_excluded(path, repo_root, allow_ai_findings=True):
+            continue
+        ap = path.resolve()
+        if ap in seen:
+            continue
+        seen.add(ap)
+        yield path
 
 
 def _strip_fences(lines: list[str]) -> list[tuple[int, str]]:
@@ -898,8 +939,10 @@ def main(argv: list[str]) -> int:
         "--synthesis-only",
         action="store_true",
         help=(
-            "Scan only the tracked re-frame.ui synthesis guide and active "
-            "drafts. Enumerates every matched file and fails if the scope is empty."
+            "Scan only the tracked re-frame.ui synthesis authority inventory: "
+            "the guide + active drafts, the prep/ workstream tables, and the "
+            "top-level adoption/implementation plans. Enumerates every matched "
+            "file and fails if the scope is empty."
         ),
     )
     args = parser.parse_args(argv)
@@ -1002,6 +1045,13 @@ def _run_self_tests(verbose: bool = False) -> int:
         # quotes of the old model.
         ("synthesis_retired_op", 1),
         ("synthesis_retired_op_allowed", 0),
+        # rf2-d9v3n — the inventory now covers the operational authorities too,
+        # so a retired copy-from-mayor / mayor-checkout-only directive can no
+        # longer hide in a prep/ workstream table (COPY_FROM_MAYOR) or a
+        # top-level plan named in SYNTHESIS_FILES (MAYOR_CHECKOUT_ONLY). Both
+        # trip under the synthesis scope and stay invisible to the default corpus.
+        ("synthesis_retired_op_prep", 1),
+        ("synthesis_retired_op_toplevel", 1),
     ]
     for fixture, expected in synthesis_cases:
         root = _SELF_TEST_FIXTURE_ROOT / fixture
@@ -1039,6 +1089,14 @@ def _run_self_tests(verbose: bool = False) -> int:
             )
             failures += 1
 
+    # rf2-d9v3n — prove the expanded inventory enumerates exactly the active
+    # authorities (guide + drafts + prep/ + the two top-level SYNTHESIS_FILES)
+    # and NOTHING else: the fixture also carries a top-level narrative chapter, a
+    # README, a reviews/ page, a spikes/ page (each with a retired directive), and
+    # unrelated ai/ scratch — none of which may enter the inventory. The parallel
+    # synthesis_valid_narrow_scope run above (expected synthesis broken=0) is the
+    # belt-and-suspenders proof that those retired-directive landmines are never
+    # scanned; this set-equality is the direct proof.
     narrow_root = _SELF_TEST_FIXTURE_ROOT / "synthesis_valid_narrow_scope"
     narrow_files = {
         path.relative_to(narrow_root).as_posix()
@@ -1047,6 +1105,9 @@ def _run_self_tests(verbose: bool = False) -> int:
     expected_narrow_files = {
         "ai/findings/new-substrate-synthesis/guide/index.md",
         "ai/findings/new-substrate-synthesis/drafts/design.md",
+        "ai/findings/new-substrate-synthesis/prep/w1-migrator-rule-table.md",
+        "ai/findings/new-substrate-synthesis/11-adoption-workstreams.md",
+        "ai/findings/new-substrate-synthesis/12-implementation-plan.md",
     }
     if narrow_files != expected_narrow_files:
         sys.stderr.write(
@@ -1056,7 +1117,8 @@ def _run_self_tests(verbose: bool = False) -> int:
         failures += 1
     elif verbose:
         sys.stderr.write(
-            "self-test PASS: synthesis scope enumerates guide + drafts only\n"
+            "self-test PASS: synthesis scope enumerates guide + drafts + prep + "
+            "top-level authorities only (narrative/README/reviews/spikes excluded)\n"
         )
 
     empty_root = _SELF_TEST_FIXTURE_ROOT / "valid_link"


### PR DESCRIPTION
## What

The retired copy-from-mayor / mayor-checkout-only guard in `scripts/check_doc_slugs.py` (rf2-vxgfnd.136) ran only over `SYNTHESIS_ROOTS = guide/ + drafts/` — the publication-track pages. The **live operational authorities a worker actually executes** were outside the inventory, so a stale copy-from-mayor / local-only directive named in one of them slipped past the guard.

### The gap (file:line)

`scripts/check_doc_slugs.py` on `origin/main`, `SYNTHESIS_ROOTS` (was lines 80-83):

```python
SYNTHESIS_ROOTS = (
    "ai/findings/new-substrate-synthesis/guide",
    "ai/findings/new-substrate-synthesis/drafts",
)
```

Excluded from the guard: `prep/w1-migrator-rule-table.md`, `prep/w2-migration-skill-extension.md`, `prep/w3-docs-disposition.md`, `prep/w9-ci-matrix-disposition.md`, and the top-level `11-adoption-workstreams.md` + `12-implementation-plan.md`.

### The fix

- Add `ai/findings/new-substrate-synthesis/prep` to `SYNTHESIS_ROOTS` (the four `w*` workstream tables).
- Add a new explicit `SYNTHESIS_FILES` list for the two top-level operational plans (`11-adoption-workstreams.md`, `12-implementation-plan.md`) — only those two files are authorities, so the whole top-level directory (which also holds the 01-10 narrative chapters, `README.md`, and the `reviews/` + `spikes/` historical prose) is deliberately **not** a root. The inventory stays a narrow, auditable list, not a directory sweep.

The retired-op scanner already runs on every file `_iter_markdown` yields under `--synthesis-only`, so widening the inventory extends the guard with **no scanner change**.

### Authorities are clean

The six newly-covered authorities carry no retired-operation directive on current main (verified with the guard's own classifier and a raw text probe — the only near-matches are a benign "tool tier absent from production bundles" phrase and a "LOCAL-ONLY" CI-gate classification, neither of which is a retired directive). The expansion closes the hole prophylactically; no authority-doc fix was needed.

### Fail-before proof (self-test)

Two new fixtures prove a retired directive in a newly-covered authority now trips (RED under `--synthesis-only`, invisible to the default corpus):
- `synthesis_retired_op_prep` — `COPY_FROM_MAYOR` in a `prep/` workstream table.
- `synthesis_retired_op_toplevel` — `MAYOR_CHECKOUT_ONLY` in a top-level plan.

`synthesis_valid_narrow_scope` is extended with `prep/` + both top-level authorities plus negative-control landmine siblings (narrative chapter, README, `reviews/`, `spikes/` — each carrying a retired directive) that must stay excluded. The inventory set-equality assertion proves exactly the active authorities are enumerated and nothing else.

## Quality gates

All run in the worktree, foreground, unpiped:

- `python scripts/check_doc_slugs.py --self-test --verbose` → **22/22 pass** (incl. the two new fail-before fixtures; was 20).
- `python scripts/check_doc_slugs.py --synthesis-only` → **exit 0**; now enumerates **41** authority files (was 35) including all 4 `prep/` tables + `11`/`12`.
- `python scripts/check_doc_slugs.py` (default docs corpus) → **exit 0**.
- **RED/GREEN proof:** a live retired-op appended to the real `prep/w9-ci-matrix-disposition.md` → guard flags `RETIRED_SYNTHESIS_OP [COPY_FROM_MAYOR]` (exit 1); reverted → exit 0, file clean.
- `python scripts/check_readme_links.py` + `--self-test` → **exit 0** (companion gate imports unchanged symbols from this module; unaffected).
- `mkdocs build --strict` → **exit 0** (built in ~41s).

## Follow-up (not in this PR — operator/CI surface)

The CI change-classifier `.github/scripts/report-changed-surfaces.sh` sets `synthesis_docs=true` only for `guide/*`, `drafts/*`, `check_doc_slugs.py`, its fixtures, and (separately) `12-implementation-plan.md`. A PR touching **only** `prep/*` or `11-adoption-workstreams.md` would not fire the synthesis-docs job that runs `--synthesis-only`, so the newly-covered guard would not run for that PR. That file + `.github/workflows/test.yml` are outside this bead's scoped surface; flagging for a follow-up to align the CI trigger paths with the expanded inventory.

Closes rf2-d9v3n.