### PR TITLE
fix(observation): make current? total across throwing opaque equality (rf2-sbfqy)

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -2125,36 +2125,55 @@
   query. An unchanged live lease is retained untouched by the caller; a
   disposed node (HMR), a destroyed/swapped frame, a restabilized query, or a
   moved/removed override fails the check and classifies the site as
-  retargeted. Pure read; never throws.
+  retargeted. TOTAL, pure read; never throws.
 
   Static (override) leases compare the consumer's OPAQUE slot identity by
   `=` and its OPAQUE movement token by the core-local spelling of the frozen
   `rf=` law. Thus an `rf=`-equal provider replacement (including NaN→NaN)
   retains, while any value/schema movement retargets, without this port
-  interpreting either token."
+  interpreting either token. Those slot/movement tokens (and a subscription
+  query's app args) are APP-SUPPLIED, so their host equality implementation
+  MAY THROW: a comparison that cannot ESTABLISH sameness classifies the site
+  as NOT current — the conservative kept-check result, since a site that
+  cannot be proven kept is retargeted through the normal staged commit path,
+  never painted stale — so the throw never propagates out of the predicate
+  (rf2-sbfqy)."
   [lease target]
-  ;; Pure no-throw predicate (rf2-vxgfnd.183): a non-lease reads FALSE rather
-  ;; than field-accessing lease-state and leaking a host error — current? is the
-  ;; commit kept-check, and a malformed value is simply "not current". `and`
-  ;; short-circuits before `@(lease-state lease)` so no raw NPE/TypeError escapes.
+  ;; TOTAL no-throw predicate (rf2-vxgfnd.183 + rf2-sbfqy): a non-lease reads
+  ;; FALSE rather than field-accessing lease-state and leaking a host error, and
+  ;; a THROWING opaque-token equality (the app-supplied :override-id/:version, or
+  ;; a subscription query's app args) is caught and read as NOT current. current?
+  ;; is the commit kept-check, and a value that cannot be PROVEN kept is simply
+  ;; "not current". `and` short-circuits before `@(lease-state lease)` so a
+  ;; non-lease never derefs; the `try` guards the ONE kept-check-comparison seam
+  ;; so no raw equality throw escapes. The catch is LOCAL to this predicate — the
+  ;; port's non-predicate ops (probe/acquire!/read/release!) keep their typed
+  ;; fail-loud contracts, never blanket-swallowing equality failures.
   (when interop/debug-enabled? (note-candidate-inspection! :current?))
   (and (lease? lease)
-       (let [st @(lease-state lease)]
-         (case (:lease-kind st)
-           :static
-           (let [lt (:target st)]
-             (and (= :story-override (:kind target))
-                  (= (:override-id lt) (:override-id target))
-                  (node-value= (:version lt) (:version target))
-                  (= (:query lt) (:query target))))
+       (try
+         (let [st @(lease-state lease)]
+           (case (:lease-kind st)
+             :static
+             (let [lt (:target st)]
+               (and (= :story-override (:kind target))
+                    (= (:override-id lt) (:override-id target))
+                    (node-value= (:version lt) (:version target))
+                    (= (:query lt) (:query target))))
 
-           :node
-           (and (= :live (:status st))
-                (= :subscription (:kind target))
-                (= (:frame-id st) (:frame-id target))
-                (= (:query-v st) (:query target))
-                (node-still-canonical? st))
+             :node
+             (and (= :live (:status st))
+                  (= :subscription (:kind target))
+                  (= (:frame-id st) (:frame-id target))
+                  (= (:query-v st) (:query target))
+                  (node-still-canonical? st))
 
+             false))
+         (catch #?(:clj Throwable :cljs :default) _
+           ;; A throwing opaque-token equality cannot ESTABLISH sameness →
+           ;; conservatively NOT current, so the site retargets through the
+           ;; normal staged commit path rather than escaping the predicate
+           ;; (rf2-sbfqy).
            false))))
 
 ;; ---- read -----------------------------------------------------------------------

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -2001,6 +2001,60 @@
       (is (nil? (:node-version ev))))))
 
 ;; ===========================================================================
+;; current? is TOTAL across a throwing opaque-token equality (rf2-sbfqy)
+;; ===========================================================================
+;;
+;; A :story-override lease's :override-id / :version are OPAQUE app-supplied
+;; tokens — :override-id compared by plain `=`, :version by the core-local
+;; `node-value=` `rf=` spelling (which calls `=`). Their HOST equality is app
+;; code and MAY THROW. current? is the commit kept-check and is documented TOTAL
+;; and never-throw (Spec 006 §Error contract; Ownership; its docstring): a
+;; comparison that cannot ESTABLISH sameness classifies the site as NOT current,
+;; so the throw never escapes the predicate — the site retargets through the
+;; normal staged commit path instead. `BoomEq` throws from its equality on BOTH
+;; hosts (JVM `Object.equals`; CLJS `-equiv`), so the same adversarial fixture
+;; runs under `clojure -M:test` AND `npm run test:cljs`.
+
+(deftype BoomEq []
+  #?@(:clj  [Object
+             (equals [_ _] (throw (ex-info "boom-from-equals" {})))]
+      :cljs [IEquiv
+             (-equiv [_ _] (throw (ex-info "boom-from-equals" {})))]))
+
+(deftest current?-is-total-across-a-throwing-opaque-token-equality
+  ;; The bead's exact repro shape: a SUPPORTED :story-override target whose
+  ;; :version opaque token throws through host equality. It passes the port
+  ;; grammar and acquisition (validate-target! checks only key PRESENCE + the
+  ;; query shape, never a token's equality — acquire! stores the target as-is),
+  ;; so pre-fix the exception escaped LATER through current?'s node-value=
+  ;; version compare.
+  (testing "acquisition of a throwing-token override target succeeds"
+    (let [target {:kind :story-override :query [:obs/items]
+                  :value nil :override-id :slot :version (->BoomEq)}
+          lease  (obs/acquire! target (fn [_] (throw (ex-info "never" {}))))]
+      (is (obs/lease? lease))
+      (testing "current? returns false, never throws, when the VERSION compare throws"
+        (is (false? (obs/current? lease (assoc target :version (->BoomEq))))
+            "a throwing opaque-version equality → conservatively NOT current"))))
+  (testing "current? is total for a throwing OVERRIDE-ID equality too"
+    ;; :override-id is compared by plain `=` before the version compare; a
+    ;; throwing id token is likewise caught and read as not-current.
+    (let [target {:kind :story-override :query [:obs/items]
+                  :value nil :override-id (->BoomEq) :version 1}
+          lease  (obs/acquire! target (fn [_] (throw (ex-info "never" {}))))]
+      (is (false? (obs/current? lease (assoc target :override-id (->BoomEq)))))))
+  (testing "the guard does NOT blanket-swallow — the SAME opaque instance still reads current"
+    ;; node-value='s `identical?` arm short-circuits before `=` is ever called,
+    ;; so a version token IDENTICAL in both the lease and the compared target
+    ;; keeps the well-formed identity path unchanged and the site stays current.
+    (let [tok    (->BoomEq)
+          target {:kind :story-override :query [:obs/items]
+                  :value nil :override-id :slot :version tok}
+          lease  (obs/acquire! target (fn [_] (throw (ex-info "never" {}))))]
+      (is (true? (obs/current? lease target))
+          "an identical opaque version token retains without invoking `=`"))))
+
+;; ===========================================================================
 ;; cold-probe edge set ([S2-CONFIRM] — confirmed/corrected)
 ;; ===========================================================================
 

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -1310,7 +1310,11 @@ commit path with honest ownership reporting ⟨S-3 §5; 09 codex2 F1⟩:
   plain `=`; `:version` is the movement token, compared by the frozen `rf=` law (the
   port's core-local `node-value=` spelling). NaN-to-NaN therefore **retains** — the
   observable counterexample that makes the split load-bearing: a plain-`=` version
-  compare would retarget a NaN-valued override on every commit, forever.
+  compare would retarget a NaN-valued override on every commit, forever. Because those
+  tokens are opaque and app-supplied, either comparison **may throw** through a hostile
+  host `equals`/`-equiv`; `current?` is total, so a throwing token compare reads **not
+  current** and the site retargets through the normal staged path rather than escaping
+  the predicate — never weakening the fail-loud contract of the port's non-predicate ops.
 
 *(Shape ruled and final; the lease semantics are pinned by the port's own fixtures, and
 the Tier-3 mounted Story-context fixture landed with the ViewCell layer.)*
@@ -1414,8 +1418,14 @@ The port and the public read API split deliberately ⟨09 codex2 F1 — binding�
   disposed node, or a value that is not a lease at all, each returns `false` rather than
   field-accessing the lease state and leaking a raw host error (a JVM `NullPointerException`,
   a CLJS `TypeError`) — a value that is not a live node lease is simply not current, and
-  owns no node. They are the commit path's cheap guard, so they answer rather than fail.
-  Every other operation names its typed rejection:
+  owns no node. `current?` is total across its comparisons too: the tokens it weighs —
+  a static override's opaque `:override-id`/`:version`, a subscription query's app args —
+  are **app-supplied, so their host equality may throw**; a comparison that cannot
+  **establish** sameness classifies the site as **not current** (the conservative
+  kept-check result — an unprovable site retargets through the normal staged commit path,
+  never painted stale), so the throw never escapes the predicate. They are the commit
+  path's cheap guard, so they answer rather than fail. Every other operation names its
+  typed rejection:
   - `:rf.error/no-such-sub` — the target's own query names an unregistered sub, at
     `probe` or `acquire!`. This is the **same catalogue id** the public surface records
     ([§What happens when a sub references an unknown sub](#what-happens-when-a-sub-references-an-unknown-sub));


### PR DESCRIPTION
## What & why

The observation port's `current?` is contracted **TOTAL, pure, never-throw** (Spec 006 §Error contract; Ownership; its docstring). PR #6014 (rf2-tuysqw) reconciled the prose to that contract — but a supported `:story-override` lease could still **throw through its opaque version/identity comparison**, violating it.

A `:story-override` lease compares the consumer's OPAQUE, app-supplied tokens: `:override-id` by plain `=`, `:version` by the core-local `node-value=` `rf=` spelling (which calls `=`). Those tokens are app code, so their host equality (`Object.equals` on the JVM, `-equiv` on CLJS) **may throw**. The target passes the port grammar and acquisition (`validate-target!` checks only key presence + query shape; `acquire!` stores the target as-is), so the exception escaped **later** through `current?`'s compare — `implementation/core/src/re_frame/substrate/observation.cljc:2147` (override-id `=`) / `:2148` (version `node-value=`).

## The fix

Guard the **one** kept-check-comparison seam: wrap `current?`'s comparison body in a `try` whose `catch` (`#?(:clj Throwable :cljs :default)`) returns `false` — the conservative kept-check result. A comparison that cannot **establish** sameness classifies the site as **not current**, so it retargets through the normal staged commit path rather than escaping the predicate. The catch is **local** to the predicate; the port's non-predicate ops (`probe`/`acquire!`/`read`/`release!`) keep their typed fail-loud contracts. `node-value=`'s `identical?` arm is untouched, so an identical opaque token still retains without ever invoking `=` (verified by a control assertion — the guard does not blanket-swallow).

No new error id (the predicate swallows the throw), so **no Spec 009 row**.

## Contract consistency (four surfaces)

- `current?` docstring — pins the throwing-token → not-current rule.
- Spec 006 — §Error contract total-predicate statement + the static override lease split-equality note.
- Ownership — already states "two total no-throw predicates `current?` / `owned?`" (unchanged, now truthful).
- Test — new adversarial `.cljc` fixture (`BoomEq`) throwing from host equality on **both** hosts.

## Quality gates

Red-before / green-after with the same adversarial `.cljc` fixture on both hosts (throwing `:story-override` version + override-id compares; identical-instance control stays current):

| Gate | Red-before (source reverted) | Green-after |
| --- | --- | --- |
| JVM `implementation/core` — observation ns (`clojure -M:test -n re-frame.observation-port-cljs-test`) | `2 errors` (`boom-from-equals` escapes `current?` at observation.cljc:2148 / :2147) | `93 tests, 652 assertions, 0 failures, 0 errors` |
| JVM `implementation/core` full (`clojure -M:test`) | — | `2027 tests, 9461 assertions, 0 failures, 0 errors` |
| CLJS focused new var (`node out/node-test.js --test=…`) | `2 errors` (`boom-from-equals` escapes on CLJS too) | `1 test, 4 assertions, 0 failures, 0 errors` |
| CLJS full (`npm run test:cljs`) | — | `9729 tests, 47857 assertions, 0 failures, 0 errors` |

Bead: rf2-sbfqy.
