### PR TITLE
fix(error): make frame-destroyed source-coord operation-realm aware (rf2-xgkgx)

### DIFF
--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -99,11 +99,24 @@
 ;; reserved-fx / no-such-handler) carry an EVENT id under `[:event …]`.
 ;;
 ;; `:rf.error/frame-destroyed` is the one shared category — fired with an
-;; EVENT id from `router.cljc` (a dispatch into a destroyed frame) AND with
-;; a SUB id from `subs.cljc` (a subscribe into a destroyed frame). We can't
-;; disambiguate on the kw alone, so for it we try `:sub` then `:event`
-;; (a sub-id never collides with an event-id under the same registry, so
-;; the first hit is unambiguous; a miss falls through to nil → slot absent).
+;; EVENT id (a dispatch / dispatch-sync into a destroyed frame) AND with a
+;; SUB id (a subscribe into a destroyed frame), and also from the UI
+;; frame-bundle's stale-op seam (`re-frame.ui.frames`) for a `:dispatch` /
+;; `:dispatch-sync` / `:subscribe` / `:capture` op against a dead
+;; incarnation. The category keyword ALONE CANNOT name the realm: an
+;; event-id and a sub-id may legitimately SHARE a keyword — they live in
+;; SEPARATE registries (`[:event id]` vs `[:sub id]`), so a bare
+;; `[:sub]`-then-`[:event]` probe attributes a same-keyword collision to the
+;; WRONG realm (rf2-xgkgx — the earlier comment here wrongly claimed sub-ids
+;; and event-ids never collide). Resolution therefore pivots on the exact
+;; operation realm the record already carries in `:op`: `:dispatch` /
+;; `:dispatch-sync` → `[:event]`, `:subscribe` → `[:sub]`, `:capture` →
+;; NEITHER (a `(frame)` read that resolved a dead incarnation before any op
+;; ran — no component source). The core router / subs emitters carry no
+;; `:op`; for them the lookup falls back to `[:sub]`-then-`[:event]`, which
+;; keeps them correct (the subs sub-id hits `[:sub]`; the router event-id
+;; misses `[:sub]` then hits `[:event]`). A miss on the resolved realm falls
+;; through to nil → the `:source-coord` slot is absent.
 
 (def ^:private sub-error-categories
   "Categories whose `:event-id` slot carries a SUB id — their source
@@ -132,18 +145,37 @@
   the `:source-coord` slot is ABSENT from the record rather than nil.
 
     - `:rf.error/sub-*` categories → look under `[:sub id]`.
-    - `:rf.error/frame-destroyed` is fired with both an event-id (router)
-      and a sub-id (subs), so try `[:sub id]` first then `[:event id]`.
+    - `:rf.error/frame-destroyed` is realm-AMBIGUOUS on the id alone (an
+      event-id and a sub-id may legitimately SHARE a keyword — they live in
+      SEPARATE registries), so it pivots on the exact operation realm the
+      record already carries in `op` (rf2-xgkgx — the PRIVATE steering input;
+      it is NOT read from any public schema slot, just the attribution `op`
+      the frame-bundle stale-op seam already stamps):
+        - `:dispatch` / `:dispatch-sync` → the failing op is a DISPATCH, so
+          the coord lives under `[:event id]`.
+        - `:subscribe`                   → a SUBSCRIBE, coord under `[:sub id]`.
+        - `:capture`                     → a `(frame)` read that resolved a
+          dead incarnation BEFORE any op ran — no component source, so
+          fabricate NEITHER coord (nil), even were an id somehow present.
+        - `op` absent (the core router / subs emitters do not carry it) →
+          fall back to `[:sub]`-then-`[:event]`, which keeps those callers
+          correct (the subs sub-id hits `[:sub]`; the router event-id misses
+          `[:sub]` then hits `[:event]`).
     - every other category → look under `[:event id]`."
-  [error-kw id]
+  [error-kw id op]
   (when id
     (cond
       (contains? sub-error-categories error-kw)
       (source-coords/error-coords-for :sub id)
 
       (= :rf.error/frame-destroyed error-kw)
-      (or (source-coords/error-coords-for :sub id)
-          (source-coords/error-coords-for :event id))
+      (case op
+        (:dispatch :dispatch-sync) (source-coords/error-coords-for :event id)
+        :subscribe                 (source-coords/error-coords-for :sub id)
+        :capture                   nil
+        ;; `op` absent — the realm-ambiguous core router / subs emitters.
+        (or (source-coords/error-coords-for :sub id)
+            (source-coords/error-coords-for :event id)))
 
       :else
       (source-coords/error-coords-for :event id))))
@@ -224,9 +256,14 @@
            ;; The lookup is KIND-AWARE: the registry is keyed
            ;; by `[registry-kind id]`, so a sub-id (`:rf.error/sub-*`
            ;; categories) must resolve under `[:sub …]`, not the hardcoded
-           ;; `[:event …]`. See [[error-source-coord]] / [[sub-error-categories]].
+           ;; `[:event …]`. For the realm-ambiguous `:rf.error/frame-destroyed`
+           ;; category the resolution ALSO pivots on the operation realm the
+           ;; record carries in its `:op` attribution — the private steering
+           ;; input (rf2-xgkgx), so a same-keyword event vs subscription is
+           ;; attributed to the correct realm. See [[error-source-coord]] /
+           ;; [[sub-error-categories]].
            source-coord (try
-                          (error-source-coord error-kw event-id)
+                          (error-source-coord error-kw event-id (:op attrs))
                           (catch #?(:clj Throwable :cljs :default) e
                             (when (trace/continuation-live?)
                               (throw e))))]

--- a/implementation/core/test/re_frame/on_error_cljs_test.cljc
+++ b/implementation/core/test/re_frame/on_error_cljs_test.cljc
@@ -21,6 +21,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.error-emit :as error-emit]
+            [re-frame.source-coords :as source-coords]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
 
@@ -617,6 +618,121 @@
           (is (symbol?  (:ns   sc)))
           (is (integer? (:line sc)))
           (is (string?  (:file sc))))))))
+
+;; ============================================================================
+;; rf2-xgkgx — frame-destroyed source-coord is OPERATION-REALM AWARE.
+;; ----------------------------------------------------------------------------
+;; `:rf.error/frame-destroyed` is the one realm-AMBIGUOUS category: an event-id
+;; and a sub-id may legitimately SHARE a keyword because they live in SEPARATE
+;; registries (`[:event id]` vs `[:sub id]`). The pre-fix resolution probed
+;; `[:sub]` then `[:event]`, so a `:dispatch` frame-destroyed whose id ALSO
+;; named a subscription was attributed to the WRONG realm (the subscription's
+;; coord). The UI frame-bundle stale-op seam (`re-frame.ui.frames`) stamps the
+;; exact failing `:op` onto the always-on record; `error-emit/error-source-coord`
+;; now pivots on it — `:dispatch` / `:dispatch-sync` → the EVENT coord,
+;; `:subscribe` → the SUBSCRIPTION coord, `:capture` → NEITHER. The `:op` is a
+;; PRIVATE steering input (read from the record's attribution, never promoted to
+;; a public schema slot).
+;;
+;; These drive the exact seam the frame-bundle uses (`emit-error-both!` with the
+;; `:op` in the trailing record-attrs) against `[:event id]` / `[:sub id]` coords
+;; seeded directly into the always-on `error-coords-by-id` registry, and assert
+;; the delivered record's resolved `:source-coord` names the correct realm. Both
+;; collision directions plus the no-coordinate (programmatic) case are covered.
+;; ============================================================================
+
+(def ^:private xgkgx-event-coord
+  {:ns 're-frame.on-error-cljs-test.collide-events :file "collide_events.cljc" :line 11})
+
+(def ^:private xgkgx-sub-coord
+  {:ns 're-frame.on-error-cljs-test.collide-subs :file "collide_subs.cljc" :line 22})
+
+(defn- xgkgx-frame-destroyed-records
+  "Fire a frame-destroyed record shaped EXACTLY like the UI frame-bundle's
+  stale-op seam (`re-frame.ui.frames/emit-and-throw-frame-destroyed!` →
+  `emit-error-both!` with `{:op op}` in the trailing record-attrs) and return
+  the vector of always-on records the listener saw. Exactly ONE record per emit
+  pins the one-record-per-runtime-error law across the arms."
+  [op id]
+  (let [seen (atom [])]
+    (rf/register-listener! :errors :xgkgx/recorder
+                           (fn [record] (swap! seen conj record)))
+    (error-emit/emit-error-both!
+      :rf.error/frame-destroyed
+      (when id [id])   ;; attempted event/query vector (nil for :capture)
+      id               ;; event-id / sub-id — the vector head (nil for :capture)
+      :rf/default      ;; a live frame — no fail-closed :event noise
+      nil              ;; no exception — an invalid op, not a caught throw
+      0                ;; elapsed-ms — not a timed path
+      0                ;; time
+      {:frame :rf/default :op op :reason :frame-destroyed} ;; dev-trace tags (axis 2)
+      {:op op})        ;; category-specific attribution for the always-on record (axis 1)
+    @seen))
+
+(deftest frame-destroyed-dispatch-resolves-the-event-coord-on-same-keyword-collision
+  (testing "rf2-xgkgx — a `:dispatch` frame-destroyed record whose id is
+            registered as BOTH an event AND a same-keyword subscription
+            resolves the EVENT coord. The pre-fix `[:sub]`-first probe picked
+            the subscription's coord (the WRONG realm)."
+    (source-coords/forget-error-coords!)
+    (source-coords/remember-error-coords! :event :xgkgx.collide/a xgkgx-event-coord)
+    (source-coords/remember-error-coords! :sub   :xgkgx.collide/a xgkgx-sub-coord)
+    (let [records (xgkgx-frame-destroyed-records :dispatch :xgkgx.collide/a)]
+      (is (= 1 (count records)) "exactly one always-on record per frame-destroyed emit")
+      (let [r (first records)]
+        (is (= :rf.error/frame-destroyed (:error r)))
+        (is (= xgkgx-event-coord (:source-coord r))
+            ":dispatch resolves the EVENT coord, not the same-keyword sub's")))))
+
+(deftest frame-destroyed-dispatch-sync-shares-the-dispatch-event-realm
+  (testing "rf2-xgkgx — `:dispatch-sync` shares the dispatch realm: it resolves
+            the EVENT coord, never the same-keyword subscription's."
+    (source-coords/forget-error-coords!)
+    (source-coords/remember-error-coords! :event :xgkgx.collide/b xgkgx-event-coord)
+    (source-coords/remember-error-coords! :sub   :xgkgx.collide/b xgkgx-sub-coord)
+    (let [records (xgkgx-frame-destroyed-records :dispatch-sync :xgkgx.collide/b)]
+      (is (= 1 (count records)))
+      (is (= xgkgx-event-coord (:source-coord (first records)))
+          ":dispatch-sync resolves the EVENT coord"))))
+
+(deftest frame-destroyed-subscribe-resolves-the-sub-coord-on-same-keyword-collision
+  (testing "rf2-xgkgx — the INVERSE collision direction: a `:subscribe`
+            frame-destroyed record whose id is registered as BOTH resolves the
+            SUBSCRIPTION coord, never the same-keyword event's."
+    (source-coords/forget-error-coords!)
+    (source-coords/remember-error-coords! :event :xgkgx.collide/c xgkgx-event-coord)
+    (source-coords/remember-error-coords! :sub   :xgkgx.collide/c xgkgx-sub-coord)
+    (let [records (xgkgx-frame-destroyed-records :subscribe :xgkgx.collide/c)]
+      (is (= 1 (count records)))
+      (is (= xgkgx-sub-coord (:source-coord (first records)))
+          ":subscribe resolves the SUB coord, not the same-keyword event's"))))
+
+(deftest frame-destroyed-capture-fabricates-no-coord
+  (testing "rf2-xgkgx — the `:capture` arm (a `(frame)` read that resolved a
+            dead incarnation BEFORE any op ran) fabricates NEITHER coord: no id
+            rides the record, and no `:source-coord` slot appears even with
+            same-keyword registrations present."
+    (source-coords/forget-error-coords!)
+    (source-coords/remember-error-coords! :event :xgkgx.collide/d xgkgx-event-coord)
+    (source-coords/remember-error-coords! :sub   :xgkgx.collide/d xgkgx-sub-coord)
+    (let [records (xgkgx-frame-destroyed-records :capture nil)]
+      (is (= 1 (count records)))
+      (let [r (first records)]
+        (is (= :rf.error/frame-destroyed (:error r)))
+        (is (not (contains? r :source-coord))
+            ":capture never fabricates a source-coord")))))
+
+(deftest frame-destroyed-programmatic-registration-omits-the-coord
+  (testing "rf2-xgkgx — a `:dispatch` frame-destroyed for an id with NO captured
+            coords (a programmatic registration that bypassed the macro path)
+            omits the `:source-coord` slot rather than niling it."
+    (source-coords/forget-error-coords!)
+    (let [records (xgkgx-frame-destroyed-records :dispatch :xgkgx.no-coord/e)]
+      (is (= 1 (count records)))
+      (let [r (first records)]
+        (is (= :rf.error/frame-destroyed (:error r)))
+        (is (not (contains? r :source-coord))
+            "no captured coords ⇒ the :source-coord slot is ABSENT, not nil")))))
 
 (deftest non-recovery-categories-fan-out-to-listener
   (testing "Per rf2-2hvga (= B / widen): every catalogued production-


### PR DESCRIPTION
## What

`:rf.error/frame-destroyed` is the one realm-ambiguous error category: an
event-id and a sub-id may legitimately **share** a keyword because they live in
**separate** always-on registries (`[:event id]` vs `[:sub id]`). PR #5954
already stamps the exact failing `:op` onto the compiled UI frame-bundle's
frame-destroyed record, but `error_emit/error-source-coord` ignored it and
probed `[:sub]`-then-`[:event]` for **every** frame-destroyed record
(`error_emit.cljc` old lines 144-147). So a stale `:dispatch` / `:dispatch-sync`
of `[:x …]` was attributed to an unrelated subscription `:x` whenever both
existed — off-box tooling (Sentry, IDE jump-to-source, AI) pointed at the wrong
definition. The old comments even asserted, incorrectly, that a sub-id never
collides with an event-id.

## Fix

`error-source-coord` now pivots on the operation realm the record already
carries in its `:op` attribution (a **private** steering input — not a new
public schema slot):

| `:op`                          | realm resolved              |
| ------------------------------ | --------------------------- |
| `:dispatch` / `:dispatch-sync` | EVENT coord `[:event id]`    |
| `:subscribe`                   | SUBSCRIPTION coord `[:sub id]` |
| `:capture`                     | **neither** (dead-incarnation `(frame)` read, no component source) |
| absent (core router/subs)      | legacy `[:sub]`-then-`[:event]` fallback |

The `:op` is threaded from the record's attribution (`(:op attrs)`) into
`error-source-coord`. The always-on-record + dev-trace fan-out is unchanged
(this only changes **which registry** the `:source-coord` is read from), the
existing core router/subs frame-destroyed emitters keep working via the
no-`:op` fallback, and rf2-01ihi's fail-closed payload policy is untouched
(no changes outside `error_emit.cljc`).

Scope: `error_emit.cljc` + its test only. No ui-compiler / error_emit-caller
touch; no core registry change; reuses `:rf.error/frame-destroyed` (no new
error-id, no Spec 009 catalogue row).

## Quality gates

- **Core JVM** (`clojure -M:test`, from `implementation/core`): `Ran 2032 tests
  containing 9474 assertions. 0 failures, 0 errors.`
- **CLJS node-test** (`npm run test:cljs`): `Ran 9753 tests containing 47951
  assertions. 0 failures, 0 errors.`
- **Red-before / green-after** (5 new tests in `on_error_cljs_test`): with the
  fix reverted to the old `[:sub]`-first probe, the two dispatch-realm
  collision tests FAIL (resolve `collide_subs.cljc:22` instead of
  `collide_events.cljc:11`); with the fix they pass. Both collision directions
  (dispatch → event, subscribe → sub), `:dispatch-sync`, the `:capture`
  no-coord case, and the no-coordinate programmatic case are covered.
