### PR TITLE
docs: sweep residual data-loop/dataflow-loop language to event pipeline (rf2-z3juq2)

### DIFF
--- a/docs/api/re-frame.ui.md
+++ b/docs/api/re-frame.ui.md
@@ -411,7 +411,7 @@ from ordinary Clojure code fails loud** (they are not runtime helpers).
 
 - [`re-frame.core`](re-frame.core.md) — events, subs, frames (`make-frame`,
   `capture-frame`), boot (`init!`)
-- [Introduction](../core/introduction.md) — the pure event pipeline this substrate
+- [Introduction](../core/introduction.md) — the event pipeline this substrate
   plugs into
 - Substrate design / UI guide under the synthesis suite (force-tracked findings) when
   reader-facing `docs/ui/` is not yet landed

--- a/examples/core/counter/README.md
+++ b/examples/core/counter/README.md
@@ -6,7 +6,7 @@ The counter is the first example because it shows the shortest path a
 click can take through re-frame2, with nothing else in the way. The
 maths doesn't matter. The path does.
 
-That path is a loop. A click **dispatches** an
+That path is the **event pipeline**. A click **dispatches** an
 [event](../../../docs/core/glossary.md#event) — a plain data vector,
 `[:counter/inc]`, that just says "something happened". The event does
 nothing on its own. The runtime hands it to the registered
@@ -30,7 +30,7 @@ re-derives the count and the
 
 State flows **in** through events and **out** through subscriptions,
 and never the other way. That one-directional shape is the whole idea.
-Every richer example is the same loop with more parts.
+Every richer example is the same pipeline with more parts.
 
 ## What this demonstrates
 
@@ -116,5 +116,5 @@ counter/
 shadow-cljs watch examples/counter
 ```
 
-Then open the served page. The minus and plus buttons drive the loop
+Then open the served page. The minus and plus buttons drive the event pipeline
 described above.

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -541,7 +541,7 @@
    `(rf/replace-frame-state! frame-id {:rf.db/app v})` (Tool-Pair
    §Pair-tool writes; rf2-t3lftq — API-shrink #3 consolidated the former
    `rf/replace-app-db!` into this app-only partial-map form). That
-   surface bypasses the dispatch loop (no event, no cascade) but DOES
+   surface bypasses the event pipeline (no event, no pipeline run) but DOES
    record a synthetic `:rf/epoch-record` with `:event-id
    :rf.epoch/db-replaced` so that `restore-epoch` can rewind past the
    injection. Use sparingly — prefer `dispatch` for any change you want

--- a/spec/Tool-Pair.md
+++ b/spec/Tool-Pair.md
@@ -215,7 +215,7 @@ Under the two-partition frame contract (per [002 §The two-partition frame contr
 | `(rf/replace-frame-state! frame-id {:rf.db/runtime runtime-db})` | **only** the runtime-db partition | privileged runtime / full-frame tool injection of subsystem state (the former `replace-runtime-db!`) |
 | `(rf/replace-frame-state! frame-id {:rf.db/app app-db :rf.db/runtime runtime-db})` | **both** partitions atomically | the full-frame install for tool-driven replay / fixture install |
 
-Every call bypasses the dispatch loop, calls `replace-container!` on the frame-state substrate container, and records a synthetic `:rf/epoch-record` so `restore-epoch!` can rewind past the injection. A present partition key never silently touches the OTHER partition; an ABSENT key is carried forward from the frame's current value, not nilled.
+Every call bypasses the event pipeline, calls `replace-container!` on the frame-state substrate container, and records a synthetic `:rf/epoch-record` so `restore-epoch!` can rewind past the injection. A present partition key never silently touches the OTHER partition; an ABSENT key is carried forward from the frame's current value, not nilled.
 
 **Use cases the surface covers:**
 


### PR DESCRIPTION
Audit-reopen sweep for **rf2-z3juq2** (PR #6023 follow-up). The literal
`data loop` / `dataflow loop` spellings were already clean in tracked
prose; the residue is the retired event-traversal framing under other
spellings. Corrects the four sites the audit named, plus two sibling
uses in the same teaching file.

## What changed

- **examples/core/counter/README.md** — three uses that name the event
  pipeline structure "a loop" ("That path is a loop", "the same loop
  with more parts", "drive the loop") → **event pipeline** / **pipeline**.
  `docs/core/AUTHORING.md` forbids calling the structure "the loop" (a
  pipeline is linear per event, not a free-form cycle). The audit flagged
  "drive the loop"; the other two are the same retired framing in the
  same file.
- **skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs** — the
  `app-db-reset!` docstring "bypasses the dispatch loop (no event, no
  cascade)" → "bypasses the **event pipeline** (no event, no **pipeline
  run**)"; aligns with the same docstring's existing "the event pipeline"
  wording.
- **spec/Tool-Pair.md** — the `replace-frame-state!` contract "Every call
  bypasses the dispatch loop" → "bypasses the **event pipeline**"; aligns
  with the section's existing "pipeline run" usage.
- **docs/api/re-frame.ui.md** — drop the false **pure** adjective from
  "the pure event pipeline". The whole pipeline is not pure: commit /
  perform run impure, best-effort effects after the db write.

## Left intact (verified non-event-traversal sense)

- rAF / poll / watch / agent / control-flow loops; the pair-tool
  **cascade-bundle** / **cascade-summary** trace vocabulary (code
  identifiers, Xray-mirrored per Spec 009); fx / sub / destroy / CSS
  cascades.
- `docs/core/glossary.md` deprecation entry that *defines* the retired
  terms (teaches the retirement — left as-is).
- Historical `event cascade` under `docs/EP/**` (design record).
- `examples/core/counter/README.md` bare "dataflow" (the data flow across
  substrates) — not the retired "dataflow loop" compound.

## Not in this PR (follow-up)

The audit also suggested "add/extend the vocabulary residue gate so
variants cannot recur." That is deferred: the literal retired compounds
are already dead (nothing to recur), a `loop`/`cascade` gate is highly
false-positive-prone against ubiquitous legitimate uses, and CI-wiring a
new gate requires touching `.github/workflows/docs.yml` (hot-zone /
operator-owned), which is out of scope for this prose sweep. Recommend a
separate bead if a gate is still wanted.

## Quality gates

- `python scripts/check_doc_slugs.py` — **PASS** (exit 0)
- `python -m mkdocs build --strict` — **PASS** (exit 0; built in ~22s;
  only pre-existing INFO notes, no warnings)
- `git grep -i` for retired event-traversal compounds (`data loop` /
  `dataflow loop` / `data-flow loop` / `turn of the loop`) across tracked
  prose (excluding `ai/`, generated `docs/site`, `site/`, `.beads/`) —
  **clean**; the sole remaining hit is the sanctioned `glossary.md`
  deprecation entry.
- `npm run test:cljs` — **not run** (not required): the only code-file
  change is docstring prose in a `skills/` preload file, not part of the
  implementation core build and not core-reachable.
