### PR TITLE
feat(ui): S3 frozen re-frame.ui.react interop tier (rf2-vxgfnd.95.4)

### DIFF
--- a/docs/api/re-frame.ui.react.md
+++ b/docs/api/re-frame.ui.react.md
@@ -1,0 +1,99 @@
+# re-frame.ui.react
+
+`re-frame.ui.react` is the **frozen React-interop tier** of the compiled-view
+substrate (Maven coordinate `day8/re-frame2-ui`) — a deliberately tiny, closed set of
+seven wrappers for views that must participate in a *foreign* React world: an exported
+`defview` living inside a legacy parent, or a foreign widget embedded inside a `defview`
+whose API demands refs, contexts, ids, or code-splitting.
+
+It is **not** a second state or reactivity model. `use-state` is `local`;
+`use-memo`/`use-callback` are the compiler's job (per-site identity is owned for you);
+`use-reducer`/`use-sync-external-store`/`use-transition`/`use-deferred-value` and
+Suspense-as-authoring do not exist. Full call shapes and host behaviour live in
+Spec 004 §The React interop tier.
+
+```clojure
+(:require [re-frame.ui :as ui :refer [defview local]]
+          [re-frame.ui.react :as react])
+```
+
+**The position law.** The six host hooks (`use-ref` … `use-id`) are recognised and
+lowered by the compiler exactly like `sub`/`local`/`effect`, and are legal **only where
+they evaluate unconditionally, exactly once per render** — the straight-line top of a
+view body (an outer `let` binding), never inside a branch, a loop, or a callback.
+React's hook order must be static; a misplaced hook is a compile error. Adding, removing,
+or reordering any wrapper changes the view's hook signature (a clean remount); editing a
+deps vector or an effect body preserves state.
+
+## Host hooks
+
+### `use-ref`
+
+`(react/use-ref)` / `(react/use-ref initial)` → the host ref object (`useRef`).
+Read/write via `(.-current ref)`; assignment **never re-renders** — its reason to exist
+beside `local` — and it is the preferred object ref for `:ref` positions. No deps. On a
+JVM structural render it is an inert ref (`current` nil, stays nil).
+
+### `use-effect`
+
+`(react/use-effect setup)` / `(react/use-effect setup deps)` → nil (`useEffect`, passive,
+after paint). `setup` is a zero-arg fn returning a cleanup fn or nil, honoured on dep
+change, disconnect, and unmount; StrictMode dev replay is expected and must be
+idempotent-safe. The one-arg form runs after every commit; a `deps` vector is compared
+per authored slot by **`Object.is`** — React's own effect-dependency rule (a distinct
+value-equal host value *is* a change; `rf=` stays the memo/prop comparator). `[]` deps ⇒
+connect-only. Effects do not run on the JVM (capability metadata only).
+
+### `use-layout-effect`
+
+`(react/use-layout-effect setup)` / `(… setup deps)` → nil (`useLayoutEffect`, after DOM
+mutation, **before paint**) for measure-then-mutate work that would flicker under passive
+timing — the native component-library measure-before-paint door
+([recipe](../core/how-to/measure-before-paint.md)). Same setup/cleanup/`Object.is`-deps
+contract as `use-effect`.
+
+### `use-effect-event`
+
+`(react/use-effect-event f)` → fn (`useEffectEvent`, React 19.2). The returned fn's body
+always sees the **latest** render's values; its identity is **not stable** (React
+allocates a fresh function every render — do not rely on stability, and do not put it in a
+deps vector). It must not be called during render (host throws). App intent still goes
+through event vectors / `ui/event`; this is for the foreign pattern of a latest-values
+callback invoked from an effect. On the JVM the returned fn raises `:rf.error/jvm-host-op`
+if invoked.
+
+### `use-context`
+
+`(react/use-context ctx)` → the context's current value (`useContext`). `ctx` is a
+**foreign** Context object (`React.createContext` in foreign code); the value is handed
+through uncoerced. Internal state never rides React context — frames have
+`frame-root`/`frame-provider`, app state has `sub`. On the JVM it resolves a
+test-provided value or fails loud.
+
+### `use-id`
+
+`(react/use-id)` → string (`useId`): a host-generated tree-positional token prefixed by
+the root's `identifierPrefix`. Determinism under SSR rides the root contract. On the JVM
+it is a deterministic inert string — safe for static roots; a hydrating root is a mismatch
+risk.
+
+## Code-splitting
+
+### `lazy`
+
+`(react/lazy load-thunk)` / `(react/lazy load-thunk {:fallback tpl})` — **def-level only**.
+`React.lazy` over a foreign component-loading `load-thunk` (a zero-arg fn returning a
+Promise of a foreign component). The result is a foreign component reference, legal
+exactly where foreign heads are: `[HeavyChart {…}]`. A `{:fallback tpl}` declares
+capability-free per-site loading content the emitter renders inside a minimal host
+Suspense boundary. Code-splitting interop for *foreign* components — **not** a
+loading-orchestration surface (loading state is explicit application state via `sub`).
+Calling `react/lazy` inside a view body is a compile error. On the JVM it renders its
+declared fallback (else nothing) and never invokes the thunk.
+
+## See also
+
+- [Measure before paint](../core/how-to/measure-before-paint.md) — the sanctioned
+  `use-ref` + `use-layout-effect` recipe for component-library geometry.
+- [`re-frame.ui`](re-frame.ui.md) — the compiled-view surface these wrappers live inside.
+- Spec 004 §The React interop tier — the full normative contract.

--- a/docs/core/how-to/measure-before-paint.md
+++ b/docs/core/how-to/measure-before-paint.md
@@ -1,0 +1,91 @@
+# Measure before paint (popovers, dropdowns, viewport geometry)
+
+You are building a component-library primitive — a popover, a dropdown, a tooltip, a virtualised table — and it needs to *measure the DOM and place itself before the browser paints*. Read the trigger's rectangle, decide whether the panel opens below or flips above, and apply the position in the same frame, so the user never sees it jump.
+
+This is the one job [`app-db`](../glossary.md#app-db), [subscriptions](../glossary.md#subscription), and events cannot do for you: they are your *application's* state, settled between paints, and geometry is a *host* fact that only exists once the element is in the document. So re-frame.ui gives native component-library code a deliberately small door onto React's own timing — the [`re-frame.ui.react`](../../api/re-frame.ui.md) interop tier — and this recipe is the sanctioned pattern for walking through it.
+
+> **Measure in a layout effect, compute placement with a pure function, apply it, clean up exactly.**
+
+??? info "For JavaScript developers"
+
+    This is the `useRef` + `useLayoutEffect` measure-then-position pattern, unchanged in spirit. The two differences: the *placement maths* lives in a pure `.cljc` function you can unit-test on the JVM with no DOM, and the surface is closed — there is no `useMemo`/`useCallback`/`useState` here, because the compiler already owns per-site identity and [`local`](../../api/re-frame.ui.md) already owns ephemeral state. You reach for `react/use-layout-effect` *only* for measure-before-paint. Listeners and anything deferrable belong in the passive `react/use-effect`.
+
+---
+
+## The three pieces
+
+**1 — A ref for the element.** `react/use-ref` gives you a stable mutable box whose `.current` React points at the DOM node via a `:ref` prop. Writing it never re-renders — that is exactly why it exists next to `local`.
+
+**2 — Pure placement geometry.** Keep the decision — "does this fit below, or flip above?" — in a plain function of numbers. No DOM, no host, no re-frame. It is trivially testable and it reads the same on every host.
+
+```clojure
+(defn place
+  "Pure: given the trigger's bottom edge, the panel's measured height, and the
+  viewport height, decide the panel's side + top. No DOM access."
+  [anchor-bottom panel-height viewport-height]
+  (if (> (+ anchor-bottom panel-height) viewport-height)
+    {:side :above :top (max 0 (- anchor-bottom panel-height))}
+    {:side :below :top anchor-bottom}))
+```
+
+**3 — A layout effect that measures, computes, applies, and cleans up.** `react/use-layout-effect` runs after React has mutated the DOM but *before* the browser paints, so a position you write here is the one the user's eye first sees.
+
+```clojure
+(ns my.lib.popover
+  (:require [re-frame.ui :as ui :refer [defview local]]
+            [re-frame.ui.react :as react]
+            [my.lib.geometry :refer [place]]))
+
+(defview popover
+  "A native measure-before-paint primitive. `anchor-bottom`/`viewport` arrive as
+  ordinary props; the placement is applied before paint, so the panel never
+  flashes in the wrong spot."
+  [{:keys [anchor-bottom viewport]}]
+  (let [el (react/use-ref)
+        _  (react/use-layout-effect
+            (fn []
+              (let [node   (.-current el)
+                    height (.-offsetHeight node)
+                    {:keys [side top]} (place anchor-bottom height viewport)]
+                (set! (.. node -dataset -side) (name side))
+                (set! (.. node -style -top) (str top "px"))
+                ;; clean up EXACTLY what you set — the effect re-runs on every
+                ;; deps change and on unmount, so leave no stale placement.
+                (fn []
+                  (set! (.. node -dataset -side) "")
+                  (set! (.. node -style -top) ""))))
+            [anchor-bottom viewport])]
+    [:div {:ref el :class "popover"}
+     "…panel content…"]))
+```
+
+The deps vector `[anchor-bottom viewport]` is compared per slot by `Object.is` — React's own effect-dependency rule — so the panel re-measures whenever the anchor moves or the viewport resizes, and not otherwise.
+
+---
+
+## The rules that keep this honest
+
+**Layout effects are for measure-before-paint, and nothing else.** They block paint, so they are the wrong home for a scroll listener, a `ResizeObserver`, a network call, or anything the user would not notice a frame late. Put those in the passive `react/use-effect`, which runs *after* paint:
+
+```clojure
+(react/use-effect
+  (fn []
+    (let [on-resize #(recompute!)]
+      (js/window.addEventListener "resize" on-resize)
+      (fn [] (js/window.removeEventListener "resize" on-resize))))
+  [])                                   ; [] deps ⇒ attach once, detach on unmount
+```
+
+**Every wrapper obeys the position law.** `use-ref` and `use-layout-effect` are real host hooks, so they are legal only in the straight-line top of the view body — an outer `let` binding, never inside a branch, a loop, or a callback. React's hook order must be static; the compiler rejects a misplaced hook with a didactic message. Add or remove a hook and the view remounts cleanly (its hook signature changed); edit a deps vector or an effect body and state is preserved.
+
+**Application state still goes through events.** Whether the popover is *open* is application state — a `local`, or `app-db` behind an event if other views care. Geometry is the only thing that belongs in the layout effect. Keep the split and both stay testable: the open/close logic through the [event pipeline](../events.md), the placement through a pure `place` function on the JVM.
+
+**On the server there is no layout.** In a JVM/SSR structural render the layout effect does not run and `use-ref` is inert (`.current` stays nil) — the panel renders its markup, and the real measurement happens once, on the client, after hydration. That is correct: there is nothing to measure until the DOM exists.
+
+---
+
+## See also
+
+- [`re-frame.ui.react` — the interop tier](../../api/re-frame.ui.md) — all seven wrappers and their exact call shapes.
+- [Fix a slow view](fix-a-slow-view.md) — the memoisation story for ordinary reactive views (you will almost never need these hooks there).
+- [Where should this value live?](../where-state-lives.md) — geometry vs. `local` vs. `app-db`.

--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -250,7 +250,10 @@
         ;; `sub` sites stay excluded by design (Spec 004 §Hot reload).
         hs      (fingerprint/hook-signature-hash
                  {:locals (mapv (constantly :local) (:locals sites))
-                  :effects (mapv :kind (:effects sites))})
+                  :effects (mapv :kind (:effects sites))
+                  ;; the frozen re-frame.ui.react interop hooks: kind + source-
+                  ;; order position among all let-body host hooks (S3 shape-2).
+                  :react (mapv #(select-keys % [:kind :order]) (:react sites))})
         manifest {:view-id view-id
                   :display-name display-name
                   :doc docstring
@@ -269,10 +272,21 @@
                   :as? (= :as (:mode hdr))
                   :template-fingerprint tf
                   :hook-signature hs
-                  :capabilities (cond-> (capabilities ast)
-                                  (seq (:locals sites))       (conj :local)
-                                  (seq (:effects sites))      (conj :effect)
-                                  (seq (:dispatch-fns sites)) (conj :dispatch-fn))
+                  :capabilities (into
+                                 (cond-> (capabilities ast)
+                                   (seq (:locals sites))       (conj :local)
+                                   (seq (:effects sites))      (conj :effect)
+                                   (seq (:dispatch-fns sites)) (conj :dispatch-fn))
+                                 ;; re-frame.ui.react hooks fold onto the static-
+                                 ;; root vocabulary: use-ref→:ref; use-effect /
+                                 ;; use-layout-effect / use-effect-event→:effect;
+                                 ;; use-context→:context; use-id is exempt (inert
+                                 ;; deterministic ids are static-safe). lazy folds
+                                 ;; into :foreign via the AST scan.
+                                 (keep {:ref :ref :effect :effect
+                                        :layout-effect :effect :effect-event :effect
+                                        :context :context})
+                                 (map :kind (:react sites)))
                   :sites sites}
         args    {:vname vname
                  ;; The canonical current-namespace Var a self-recursive head
@@ -320,6 +334,69 @@
   [form menv vname forms]
   (anchored (source-coords form (some? (:ns menv)))
             #(defview** form menv vname forms)))
+
+;; ---------------------------------------------------------------------------
+;; re-frame.ui.react/lazy — the def-level code-splitting constructor
+;; ---------------------------------------------------------------------------
+
+(defn- compile-lazy-fallback
+  "Compile a react/lazy `:fallback` template capability-free to a host render
+  thunk `(fn [] element)`. CLJS emits a self-contained React element; JVM emits
+  the deterministic structural tree."
+  [menv cljs? ns-sym fallback-form]
+  (let [e   (env/make-env {:host (if cljs? :cljs :clj)
+                           :cljs-env menv
+                           :ns-sym ns-sym
+                           ;; a synthetic self-id so a reactive read in the
+                           ;; fallback is recognised as a site and rejected with
+                           ;; the didactic :rf.ui.compile/capability-in-fallback
+                           ;; (the client-only-fallback rule), not a bare
+                           ;; self-less misplacement.
+                           :self-id :re-frame.ui.react/lazy-fallback
+                           :template-anchor (fingerprint/digest "sta1-" fallback-form)})
+        ast (ana/analyze-capability-free-template
+             e "a re-frame.ui.react/lazy :fallback" fallback-form)]
+    `(fn [] ~(if cljs?
+               (emit-cljs/emit-standalone ast)
+               (emit-jvm/emit-node ast)))))
+
+(defn expand-lazy
+  "Expand `(re-frame.ui.react/lazy load-thunk {:fallback tpl}?)` — a DEF-LEVEL
+  foreign-component constructor. CLJS wraps `React.lazy` (with a Suspense
+  boundary when a fallback is given); the JVM structural value renders the
+  compiled fallback / nothing and never references the load thunk. `form` =
+  &form, `menv` = &env, `args` = the argument list."
+  [form menv args]
+  (anchored
+   (source-coords form (some? (:ns menv)))
+   (fn []
+     (let [cljs?  (some? (:ns menv))
+           ns-sym (if cljs? (-> menv :ns :name) (ns-name *ns*))
+           n      (count args)]
+       (when (or (< n 1) (> n 2))
+         (fail :rf.ui.compile/bad-lazy
+               (str "(react/lazy load-thunk {:fallback tpl}?) takes the load "
+                    "thunk and an optional literal opts map; got " n " argument(s)")
+               {:form form}))
+       (let [load-thunk (first args)
+             opts       (second args)]
+         (when (and (some? opts) (not (map? opts)))
+           (fail :rf.ui.compile/bad-lazy
+                 "(react/lazy load-thunk {:fallback tpl}) opts must be a literal map"
+                 {:form form}))
+         (let [bad (remove #{:fallback} (keys opts))]
+           (when (seq bad)
+             (fail :rf.ui.compile/bad-lazy
+                   (str "unknown react/lazy option" (when (next bad) "s") " "
+                        (str/join ", " (map pr-str bad))
+                        " — the only option is :fallback")
+                   {:form form})))
+         (let [fallback    (:fallback opts)
+               fallback-fn (when (some? fallback)
+                             (compile-lazy-fallback menv cljs? ns-sym fallback))]
+           (if cljs?
+             `(re-frame.ui.hooks/lazy-component ~load-thunk ~fallback-fn)
+             `(re-frame.ui.hooks/lazy-jvm ~fallback-fn))))))))
 
 (defn- custom-element**
   [coords ns-sym tag opts]

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -50,6 +50,39 @@
 (def ^:private local-fqns     #{'re-frame.ui/local})
 (def ^:private effect-fqns    #{'re-frame.ui/effect})
 (def ^:private dispatch-fn-fqns #{'re-frame.ui/dispatch-fn})
+
+;; The frozen re-frame.ui.react interop tier (Spec 004 §The React interop tier).
+;; The six host hooks are recognised in expression (let-binding value) position
+;; by the same finite-site machinery as `local`, position-checked, and lowered
+;; to `re-frame.ui.hooks/*`. `lazy` is def-level only — recognised in a view
+;; body solely to reject it.
+(def ^:private react-use-ref-fqns          #{'re-frame.ui.react/use-ref})
+(def ^:private react-use-effect-fqns       #{'re-frame.ui.react/use-effect})
+(def ^:private react-use-layout-effect-fqns #{'re-frame.ui.react/use-layout-effect})
+(def ^:private react-use-effect-event-fqns #{'re-frame.ui.react/use-effect-event})
+(def ^:private react-use-context-fqns      #{'re-frame.ui.react/use-context})
+(def ^:private react-use-id-fqns           #{'re-frame.ui.react/use-id})
+(def ^:private react-lazy-fqns             #{'re-frame.ui.react/lazy})
+;; kind keyword + runtime lowering target + call arity, keyed by fqn set.
+(def ^:private react-hook-specs
+  [{:fqns react-use-ref-fqns          :kind :ref          :runtime 're-frame.ui.hooks/use-ref
+    :min-args 0 :max-args 1 :name "use-ref"}
+   {:fqns react-use-effect-fqns       :kind :effect       :runtime 're-frame.ui.hooks/use-effect
+    :min-args 1 :max-args 2 :name "use-effect" :deferred-cb 0 :deps-arg 1}
+   {:fqns react-use-layout-effect-fqns :kind :layout-effect :runtime 're-frame.ui.hooks/use-layout-effect
+    :min-args 1 :max-args 2 :name "use-layout-effect" :deferred-cb 0 :deps-arg 1}
+   {:fqns react-use-effect-event-fqns :kind :effect-event :runtime 're-frame.ui.hooks/use-effect-event
+    :min-args 1 :max-args 1 :name "use-effect-event" :deferred-cb 0}
+   {:fqns react-use-context-fqns      :kind :context      :runtime 're-frame.ui.hooks/use-context
+    :min-args 1 :max-args 1 :name "use-context"}
+   {:fqns react-use-id-fqns           :kind :id           :runtime 're-frame.ui.hooks/use-id
+    :min-args 0 :max-args 0 :name "use-id"}])
+
+(defn- react-hook-spec-for
+  "The react-hook spec `head` (an unshadowed symbol) resolves to, or nil."
+  [e* head]
+  (some (fn [spec] (when (env/resolves-to? e* head (:fqns spec)) spec))
+        react-hook-specs))
 (def ^:private frame-root-fqns #{'re-frame.ui/frame-root})
 (def ^:private frame-provider-fqns #{'re-frame.ui/frame-provider})
 
@@ -865,12 +898,87 @@
                                           "(host hooks run once per render in fixed order)")
                                      {:form f})))
                       (let [sid (lexical-site-id e :local f p)]
+                        (env/next-hook-ordinal! e) ; a local advances the shared body-hook ordinal
                         (env/add-site! e :locals {:sid sid :path (:path e)
                                                   :expr-path (vec p)})
                         (with-same-meta
                           f
                           (list runtime-local-fqn
                                 (rw (second f) locals (conj p 1))))))
+
+                    ;; re-frame.ui.react host hooks (use-ref / use-effect /
+                    ;; use-layout-effect / use-effect-event / use-context /
+                    ;; use-id) — value-position host hooks obeying the SAME
+                    ;; position law as `local`: legal only where they evaluate
+                    ;; unconditionally, once per render (the straight-line top
+                    ;; region — an outer let binding). Lowered to hooks/use-*.
+                    (and (symbol? head) (not (contains? locals head))
+                         (react-hook-spec-for e* head))
+                    (let [{:keys [kind runtime min-args max-args name deps-arg]}
+                          (react-hook-spec-for e* head)
+                          call-args (rest f)
+                          argc      (count call-args)]
+                      (when (or (< argc min-args) (> argc max-args))
+                        (env/fail! e :rf.ui.compile/unsupported-form
+                                   (str "(react/" name " …) takes "
+                                        (if (= min-args max-args)
+                                          (str min-args)
+                                          (str min-args "–" max-args))
+                                        " argument(s); got " argc)
+                                   {:form f}))
+                      (when (or (nil? (:self-id e))
+                                (:in-loop? e)
+                                (contains? locals deferred-scope)
+                                (not (:hooks-region? e)))
+                        (if (:in-render-fn? e)
+                          (impure-slot-fail! e (str "react/" name) f)
+                          (env/fail! e :rf.ui.compile/react-hook-misplaced
+                                     (str "(react/" name " …) is a host hook — legal ONLY "
+                                          "where it evaluates unconditionally, once per "
+                                          "render: the straight-line top region of a "
+                                          "defview body (an outer let binding). It cannot "
+                                          "run in a loop, branch, deferred callback, "
+                                          "render-fn slot, or root expression — React's "
+                                          "hook order must be static. Hoist it to the top "
+                                          "of the view body, or extract a keyed child view")
+                                     {:form f})))
+                      (when (and deps-arg (> argc deps-arg)
+                                 (not (vector? (nth call-args deps-arg))))
+                        (env/fail! e :rf.ui.compile/react-hook-bad-deps
+                                   (str "(react/" name " setup deps): deps must be a "
+                                        "literal vector (compared per slot by Object.is); "
+                                        "got " (pr-str (nth call-args deps-arg)))
+                                   {:form f}))
+                      (let [sid   (lexical-site-id e kind f p)
+                            order (env/next-hook-ordinal! e)
+                            args* (map-indexed
+                                   (fn [i a]
+                                     (if (and deps-arg (= i deps-arg))
+                                       ;; deps vector: walk each slot in ambient
+                                       ;; scope (render-time values).
+                                       (with-same-meta a
+                                         (mapv (fn [j d] (rw d locals (conj p (inc i) j)))
+                                               (range) a))
+                                       ;; setup fn / ctx / initial: ordinary
+                                       ;; expressions (a setup fn is a deferred
+                                       ;; callback — rw-fn rejects reactive sites).
+                                       (rw a locals (conj p (inc i)))))
+                                   call-args)]
+                        (env/add-site! e :react {:sid sid :kind kind :order order
+                                                 :path (:path e) :expr-path (vec p)})
+                        (with-same-meta f (apply list runtime args*))))
+
+                    ;; (react/lazy …) is DEF-LEVEL only — recognised in a body
+                    ;; solely to reject it (per-render construction remount-loops).
+                    (and (symbol? head) (not (contains? locals head))
+                         (env/resolves-to? e* head react-lazy-fqns))
+                    (env/fail! e :rf.ui.compile/react-lazy-misplaced
+                               (str "(react/lazy …) is DEF-LEVEL only — bind it at the top "
+                                    "level: (def HeavyChart (react/lazy load-thunk "
+                                    "{:fallback tpl})), then use the component as a foreign "
+                                    "head [HeavyChart {…}]. Calling it inside a view body "
+                                    "mints a new component type per render and remount-loops")
+                               {:form f})
 
                     ;; (ui/dispatch-fn) — the stable committed-frame dispatcher.
                     ;; A render-time site like (frame): finite, not in a loop or
@@ -1963,14 +2071,17 @@
                               "). Q2 pin: absent :props = open, present :props "
                               "= closed")
                          {:head head :undeclared (vec bad)}))))))
-    {:op (if (= :view (:kind info)) :view :foreign)
-     :sym head
-     :fqn (:fqn info)
-     :view-id (:view-id info)
-     :props props
-     :children children
-     :static? false
-     :path (:path e)}))
+    (cond-> {:op (if (= :view (:kind info)) :view :foreign)
+             :sym head
+             :fqn (:fqn info)
+             :view-id (:view-id info)
+             :props props
+             :children children
+             :static? false
+             :path (:path e)}
+      ;; a re-frame.ui.react/lazy component is a foreign head that IS callable on
+      ;; the JVM structural render (renders its fallback / nothing).
+      (:lazy? info) (assoc :lazy? true))))
 
 (defn- analyze-slot
   "Analyze `(ui/slot render-fn-value arg…)` — the compiler-owned invocation of
@@ -2112,6 +2223,14 @@
                       "event handlers into the client subtree")
                  {:form form :capabilities (vec (sort found))}))
     ast))
+
+(defn analyze-capability-free-template
+  "Analyze `form` as a standalone CAPABILITY-FREE template (deterministic
+  structural markup: no reactive reads, host state/effects, or committed event
+  handlers) — the def-level entry for re-frame.ui.react/lazy's `:fallback`.
+  Returns the AST or fails loud. `context` names the position for diagnostics."
+  [e context form]
+  (analyze-capability-free e context form))
 
 (defn- analyze-client-only
   "(ui/client-only {:fallback tpl} client-tpl) — a browser-only subtree with a

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -550,6 +550,20 @@
     `(re-frame.ui.runtime/error-boundary
       ~fb-sym ~reset-key ~on-error-form ~child)))
 
+(defn emit-standalone
+  "Emit a CAPABILITY-FREE AST as a self-contained CLJS render form (no ViewCell
+  hook skeleton). Used by def-level constructors — re-frame.ui.react/lazy's
+  fallback template. Static elements the emitter would hoist to module-level
+  defs are bound in a local `let` instead (each is an immutable static React
+  element, built once when the enclosing thunk closure is minted)."
+  [ast]
+  (let [st   (new-state 'rf-ui-standalone)
+        body (emit-node ast st false)
+        defs (:defs @st)]
+    (if (seq defs)
+      `(let [~@(mapcat (fn [d] [(nth d 1) (nth d 2)]) defs)] ~body)
+      body)))
+
 (defn emit-node
   "AST node -> CLJS form (nil for a statically-absent child)."
   [node st inline?]

--- a/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
@@ -229,11 +229,17 @@
       call)))
 
 (defn- emit-foreign [node]
-  `(re-frame.ui.tree/jvm-host-op!
-    :foreign-component
-    ~(str "foreign React component " (:sym node) " in a JVM render — "
-          "foreign components never appear in the JVM tree; wrap the "
-          "subtree in ui/client-only (S3)")))
+  (if (:lazy? node)
+    ;; a re-frame.ui.react/lazy component IS callable on the JVM structural
+    ;; render: it renders its declared fallback (or nothing) and NEVER invokes
+    ;; the load thunk (which is not even emitted on the JVM). Props/children are
+    ;; irrelevant — the fallback is capability-free markup baked into the value.
+    `(~(:sym node) {})
+    `(re-frame.ui.tree/jvm-host-op!
+      :foreign-component
+      ~(str "foreign React component " (:sym node) " in a JVM render — "
+            "foreign components never appear in the JVM tree; wrap the "
+            "subtree in ui/client-only (S3)"))))
 
 (defn- emit-for [node]
   `(re-frame.ui.tree/keyed-run

--- a/implementation/ui/src/re_frame/ui/compiler/env.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/env.cljc
@@ -56,8 +56,15 @@
    :hooks-region? false
    :path      []
    :warnings  (atom [])
+   ;; A shared monotonic ordinal over the LET-BODY host hooks (`local` +
+   ;; the six re-frame.ui.react hooks) in source order. Stamped on react-hook
+   ;; sites so the hook signature detects a local↔react reorder (both live in
+   ;; the same top-region let, interleaved in React hook order) — a per-category
+   ;; count vector alone could not. Effects are structurally before (hook-prefix)
+   ;; and do not advance it.
+   :hook-ordinal (atom 0)
    :sites     (atom {:events [] :subs [] :leases [] :htmls [] :frame-ops []
-                     :slots [] :locals [] :effects [] :dispatch-fns []})})
+                     :slots [] :locals [] :effects [] :dispatch-fns [] :react []})})
 
 (defn warn! [env w]
   (swap! (:warnings env) conj w)
@@ -66,6 +73,14 @@
 (defn add-site! [env kind site]
   (swap! (:sites env) update kind conj site)
   nil)
+
+(defn next-hook-ordinal!
+  "Advance and return (0-based) the shared body-hook ordinal — the source-order
+  position of a `local` / re-frame.ui.react hook among the top-region let-body
+  hooks. Locals advance it without storing it; react-hook sites store theirs, so
+  a local↔react reorder shifts a react ordinal and changes the hook signature."
+  [env]
+  (dec (long (swap! (:hook-ordinal env) inc))))
 
 (defn compile-error
   "All analyzer/emitter compile errors carry {:rf.ui.compile/error <id>}
@@ -107,6 +122,20 @@
            (let [m (meta v)]
              {:fqn  (symbol (str (ns-name (:ns m))) (str (:name m)))
               :meta m}))))))
+
+#?(:clj
+   (defn- jvm-lazy-value?
+     "JVM structural compile: `sym` resolves to a bound var whose value is a
+     re-frame.ui.react/lazy component (marked `:rf.ui/lazy` by lazy-jvm). Lets
+     the JVM emitter render a bare `[HeavyChart …]` head's fallback rather than
+     raise the foreign host-op — without any authored var metadata."
+     [env sym]
+     (boolean
+      (when-let [ns* (find-ns (:ns env))]
+        (when-let [v (try (ns-resolve ns* sym) (catch Exception _ nil))]
+          (and (var? v)
+               (bound? v)
+               (:rf.ui/lazy (try (deref v) (catch Exception _ nil)))))))))
 
 (defn resolve-sym
   "Resolve `sym` in the consuming namespace. Returns {:fqn sym :meta m}
@@ -154,8 +183,18 @@
 
     :else
     (if-let [{:keys [fqn meta]} (resolve-sym env sym)]
-      (if (:rf.ui/view meta)
+      (cond
+        (:rf.ui/view meta)
         {:kind :view :sym sym :fqn fqn :view-id (view-id-of fqn meta)}
+        ;; a re-frame.ui.react/lazy component: a foreign head that IS callable on
+        ;; the JVM structural render (it renders its fallback / nothing), so the
+        ;; JVM emitter invokes it instead of raising the foreign host-op. Detected
+        ;; by authored var meta OR (JVM structural compile) the marked value.
+        (or (:rf.ui/lazy meta)
+            #?(:clj (and (= :clj (:host env)) (jvm-lazy-value? env sym))
+               :cljs false))
+        {:kind :foreign :sym sym :fqn fqn :lazy? true}
+        :else
         {:kind :foreign :sym sym :fqn fqn})
       (fail! env :rf.ui.compile/unresolved-head
              (str "unresolved component head " sym " — require/refer it, or "

--- a/implementation/ui/src/re_frame/ui/fingerprint.cljc
+++ b/implementation/ui/src/re_frame/ui/fingerprint.cljc
@@ -18,14 +18,26 @@
       template-fingerprint  \"tf1-\"  input: the view's template AST
                             fingerprint projection (source-location
                             metadata stripped; forms as read)
-      hook-signature-hash   \"hs1-\"  input: [1 {:locals [...] :effects [...]}]
+      hook-signature-hash   \"hs1-\"  input (shape 2, S3):
+                            [2 {:locals [...] :effects [...] :react [...]}]
                             — the ordered host-hook plan. `sub` sites are
                             deliberately EXCLUDED: dev's fixed full hook
                             skeleton makes adding your first sub a
                             same-signature edit (Spec 004 rewrite §Hot
-                            reload). At S1 both vectors are always empty
-                            (no reactivity in this slice); the input shape
-                            is the frozen contract.
+                            reload). `:react` carries the frozen
+                            re-frame.ui.react interop hooks as ordered
+                            {:kind :order} entries (kind + source-order
+                            position among ALL let-body host hooks, so a
+                            local↔react reorder — both live in the top-region
+                            let, interleaved in React hook order — changes the
+                            signature). Adding, removing, or reordering any
+                            wrapper changes the plan; editing a deps vector or
+                            setup body does NOT. The S1→S3 shape bump (integer
+                            1→2, prefix \"hs1-\" unchanged — the prefix versions
+                            the ALGORITHM, the integer the INPUT shape)
+                            re-serialises every hook signature: a deliberate
+                            one-time global remount wave when S3 lands (pre-
+                            alpha, no shim).
       build-digest          \"bd1-\"  input: the SORTED vector of
                             [view-id template-fingerprint hook-signature]
                             triples of every view in the build (sorted by
@@ -201,10 +213,16 @@
 
 (defn hook-signature-hash
   "\"hs1-\" digest of the ordered host-hook plan
-  `{:locals [...] :effects [...]}` (version-1 input shape; `sub` sites
-  excluded by design)."
-  [{:keys [locals effects] :or {locals [] effects []}}]
-  (digest "hs1-" [1 {:locals (vec locals) :effects (vec effects)}]))
+  `{:locals [...] :effects [...] :react [...]}` (shape-version 2, S3; `sub`
+  sites excluded by design). `:react` entries are `{:kind :order}` maps — the
+  wrapper kind plus its source-order position among ALL top-region let-body
+  host hooks (locals included), so a local↔react reorder changes the signature.
+  The leading integer versions the INPUT SHAPE; the \"hs1-\" prefix (unchanged)
+  versions the algorithm."
+  [{:keys [locals effects react] :or {locals [] effects [] react []}}]
+  (digest "hs1-" [2 {:locals  (vec locals)
+                     :effects (vec effects)
+                     :react   (vec react)}]))
 
 (defn build-digest
   "\"bd1-\" digest over `[[view-id template-fingerprint hook-signature] ...]`

--- a/implementation/ui/src/re_frame/ui/hooks.cljc
+++ b/implementation/ui/src/re_frame/ui/hooks.cljc
@@ -139,6 +139,107 @@
   []
   (events/dispatch-fn))
 
+;; ---------------------------------------------------------------------------
+;; re-frame.ui.react interop tier — the frozen seven wrappers' CLJS lowering
+;; targets. The analyzer rewrites (react/use-* …) authored sites to these; the
+;; position law keeps them straight-line and once-per-render, so React's hook
+;; order stays static. Every React-property access is `^js`-hinted so the
+;; advanced build carries zero :infer-warning.
+;; ---------------------------------------------------------------------------
+
+(defn use-ref
+  "react/use-ref lowering target — `useRef`. Returns the host ref object;
+  read/write `(.-current ref)`; assignment never re-renders."
+  ([] (react/useRef nil))
+  ([initial] (react/useRef initial)))
+
+(defn- deps-object-is-equal?
+  "Per-slot `Object.is` comparison of two authored deps vectors — React's
+  effect-dependency equality (a synchronisation input, NOT a repaint value: a
+  distinct value-equal host object IS a change here). An arity change is never
+  equal. `rf=` stays the memo/prop comparator; effects use this."
+  [prev nxt]
+  (let [n (count prev)]
+    (and (== n (count nxt))
+         (loop [i 0]
+           (or (== i n)
+               (and ^boolean (js/Object.is (nth prev i) (nth nxt i))
+                    (recur (inc i))))))))
+
+(defn- effect-deps-token
+  "Render-time pure token for a react effect's authored deps held in the useRef
+  cell `ref`: one internal token whose identity changes iff any slot changed by
+  `Object.is` or the arity changed — so React owns cleanup→setup and the authored
+  deps arity stays compiler-managed behind a fixed one-element React deps array."
+  [^js ref deps]
+  (let [prev ^js (.-current ref)]
+    (if (and (some? prev) (deps-object-is-equal? (.-deps prev) deps))
+      (.-token prev)
+      (let [t #js {}]
+        (set! (.-current ref) #js {:deps deps :token t})
+        t))))
+
+(defn use-effect
+  "react/use-effect lowering target — `useEffect` (passive, after paint). Both
+  arities allocate the same fixed hook shape (a held deps cell + the effect), so
+  editing deps presence is a same-signature edit. No-deps ⇒ a fresh token every
+  render (runs after every commit); deps ⇒ per-slot `Object.is`."
+  ([setup]
+   (let [_ref (react/useRef nil)]
+     (react/useEffect #(run-effect setup) #js [#js {}]))
+   js/undefined)
+  ([setup deps]
+   (let [ref (react/useRef nil)]
+     (react/useEffect #(run-effect setup) #js [(effect-deps-token ref deps)]))
+   js/undefined))
+
+(defn use-layout-effect
+  "react/use-layout-effect lowering target — `useLayoutEffect` (after DOM
+  mutation, before paint): the measure-before-paint door. Same fixed hook shape
+  and `Object.is` deps contract as `use-effect`."
+  ([setup]
+   (let [_ref (react/useRef nil)]
+     (react/useLayoutEffect #(run-effect setup) #js [#js {}]))
+   js/undefined)
+  ([setup deps]
+   (let [ref (react/useRef nil)]
+     (react/useLayoutEffect #(run-effect setup) #js [(effect-deps-token ref deps)]))
+   js/undefined))
+
+(defn use-effect-event
+  "react/use-effect-event lowering target — React 19.2 `useEffectEvent`, native.
+  The returned fn sees the latest render's values; its identity is NOT stable
+  (React allocates a fresh function each render) and it throws if called during
+  render. No shim — the host primitive's deliberate misuse signal is preserved."
+  [f]
+  (react/useEffectEvent f))
+
+(defn use-context
+  "react/use-context lowering target — `useContext`; hands the foreign context
+  value through uncoerced."
+  [ctx]
+  (react/useContext ctx))
+
+(defn use-id
+  "react/use-id lowering target — `useId`; a host tree-positional token prefixed
+  by the root's identifierPrefix."
+  []
+  (react/useId))
+
+(defn lazy-component
+  "Def-level React.lazy wrapper (re-frame.ui.react/lazy). `load-thunk` is a
+  zero-arg fn returning a Promise of a foreign component; `fallback-thunk` is a
+  zero-arg fn returning the compiled fallback React element (rendered inside a
+  Suspense boundary) or nil (the author supplies a Suspense ancestor). Returns a
+  foreign component — legal exactly where foreign heads are."
+  [load-thunk fallback-thunk]
+  (let [lazy-inner (react/lazy load-thunk)]
+    (fn lazy-boundary [props]
+      (let [el (react/createElement lazy-inner props)]
+        (if fallback-thunk
+          (react/createElement react/Suspense #js {:fallback (fallback-thunk)} el)
+          el)))))
+
 )
 
    :clj
@@ -170,5 +271,91 @@
   (fn jvm-dispatch-fn [& _]
     (tree/jvm-host-op! :ui/dispatch-fn
                        "(ui/dispatch-fn) dispatch is a host-only client operation")))
+
+;; ---------------------------------------------------------------------------
+;; re-frame.ui.react interop tier — the JVM structural subset (Spec 004 §Host
+;; behaviour). Refs are inert; passive/layout effects do not run; effect-event
+;; is metadata-only and its returned fn fails loud; use-context resolves a
+;; JVM-provided test value or fails loud; use-id is a deterministic inert string.
+;; ---------------------------------------------------------------------------
+
+(defrecord InertRef [current])
+
+(defn use-ref
+  "JVM react/use-ref: an inert ref (`current` nil, stays nil) — refs never
+  appear in the JVM structural tree."
+  ([] (->InertRef nil))
+  ([_initial] (->InertRef nil)))
+
+(defn use-effect
+  "JVM react/use-effect: does not run (recorded as capability metadata only)."
+  ([_setup] nil)
+  ([_setup _deps] nil))
+
+(defn use-layout-effect
+  "JVM react/use-layout-effect: does not run (capability metadata only)."
+  ([_setup] nil)
+  ([_setup _deps] nil))
+
+(defn use-effect-event
+  "JVM react/use-effect-event: metadata-only; the returned fn raises
+  `:rf.error/jvm-host-op` if invoked."
+  [_f]
+  (fn jvm-use-effect-event [& _]
+    (tree/jvm-host-op! :ui/use-effect-event
+                       "(react/use-effect-event …) is a host-only client operation")))
+
+(def ^:dynamic *jvm-react-context-values*
+  "JVM/SSR structural-render lookup for `(react/use-context ctx)`: a map keyed
+  by the JVM-side context argument (typically a reader-conditional token). Bound
+  by a fixture / the ui.test/render `:react-context-values` option; an absent
+  key fails loud — foreign React context never silently resolves nil."
+  nil)
+
+(defn use-context
+  "JVM react/use-context: the JVM-provided test value, else fails loud."
+  [ctx]
+  (if (and (map? *jvm-react-context-values*)
+           (contains? *jvm-react-context-values* ctx))
+    (get *jvm-react-context-values* ctx)
+    (tree/jvm-host-op!
+     :ui/use-context
+     (str "(react/use-context " (pr-str ctx) ") has no JVM-provided value — "
+          "bind re-frame.ui.hooks/*jvm-react-context-values* (or the "
+          "ui.test/render :react-context-values option) keyed by the JVM-side "
+          "context token; foreign React context never resolves on the JVM"))))
+
+(def ^:dynamic *jvm-use-id-prefix*
+  "JVM `(react/use-id)` identifier prefix (the resolved root prefix stand-in)."
+  "rf2-")
+
+(def ^:dynamic *jvm-use-id-counter*
+  "Optional per-render occurrence counter (a `volatile!`) making repeated
+  `(react/use-id)` calls deterministic and distinct; nil ⇒ a single `-0` id."
+  nil)
+
+(defn use-id
+  "JVM react/use-id: a deterministic inert string (prefix + occurrence counter).
+  Does NOT reproduce React's tree-positional algorithm — safe for static roots;
+  a hydrating root is a mismatch risk."
+  []
+  (let [n (if *jvm-use-id-counter*
+            (let [v @*jvm-use-id-counter*] (vswap! *jvm-use-id-counter* inc) v)
+            0)]
+    (str *jvm-use-id-prefix* "uid-" n)))
+
+;; A re-frame.ui.react/lazy component on the JVM: an INVOKABLE structural
+;; component (renders the declared fallback / nothing, never touching the load
+;; thunk — which is not even emitted on the JVM) that also carries the
+;; `:rf.ui/lazy` marker the analyzer's `classify-head` detects via var deref, so
+;; the JVM emitter calls it instead of raising the foreign host-op.
+(defrecord LazyJvmComponent [render-fallback]
+  clojure.lang.IFn
+  (invoke [_ _props] (when render-fallback (render-fallback))))
+
+(defn lazy-jvm
+  "JVM structural render value of a react/lazy component (see LazyJvmComponent)."
+  [fallback-thunk]
+  (assoc (->LazyJvmComponent fallback-thunk) :rf.ui/lazy true))
 
 ))

--- a/implementation/ui/src/re_frame/ui/react.cljc
+++ b/implementation/ui/src/re_frame/ui/react.cljc
@@ -1,0 +1,146 @@
+(ns re-frame.ui.react
+  "The frozen `re-frame.ui.react` interop tier — seven wrappers (Spec 004
+  §The React interop tier) for compiled views that must participate in a
+  *foreign* React world: an exported `defview` living inside a legacy/foreign
+  parent (`ui/->react`), or a foreign widget embedded inside a `defview` whose
+  API demands refs, contexts, ids, or code-splitting.
+
+  This is NOT a second state or reactivity model. The roster is deliberately
+  tiny and closed: `use-ref`, `use-effect`, `use-layout-effect`,
+  `use-effect-event`, `use-context`, `use-id`, `lazy`. `use-state` (that is
+  `local`), `use-memo`/`use-callback` (per-site stable identity is the
+  compiler's job), `use-reducer`/`use-sync-external-store`/`use-transition`/
+  `use-deferred-value` (a second state model / `startTransition` over app-db)
+  do NOT exist.
+
+  Six of the seven (`use-ref` … `use-id`) are HOST HOOKS: the compiler
+  recognises their call sites by resolved head symbol (the same finite-site
+  machinery as `sub`/`local`/`effect`), lowers them to `re-frame.ui.hooks/*`,
+  and enforces the POSITION LAW — a hook site is legal only where it evaluates
+  unconditionally, exactly once per render (the straight-line top region of a
+  view body: outer `let` bindings and positions reachable without crossing a
+  control form, a fn form, or a loop). React's hook order must be static.
+
+  `lazy` is a DEF-LEVEL constructor (a macro), exempt from the position law but
+  subject to its own: a `react/lazy` call inside a view body/template is a
+  compile error, because calling it per render mints a new component type and
+  remount-loops.
+
+  Second sanctioned audience (readiness C-6): `use-ref` + `use-layout-effect`
+  serve native component-library infrastructure doing measure-before-paint
+  (popover/dropdown placement, table viewport geometry) — measure in the layout
+  effect, compute placement with pure `.cljc` geometry, apply, clean up exactly.
+  Passive `use-effect` stays the home for listeners and deferrable work.
+
+  The six hook vars exist for symbol resolution only; a direct call fails
+  loudly. The compiler rewrites the authored form to the lowered runtime call."
+  (:refer-clojure :exclude [lazy])
+  #?(:cljs (:require-macros [re-frame.ui.react]))
+  (:require [re-frame.error :as error]
+            [re-frame.ui.hooks]
+            #?(:clj [re-frame.ui.compiler :as compiler])))
+
+(defn- lowering-only! [name* shape]
+  (error/throw-error!
+   :rf.error/ui-tree-malformed name*
+   (str "(" name* " …) executed outside compiler lowering — it is a lexical "
+        "re-frame.ui.react interop form recognised inside a compiled view, not "
+        "a callable helper. Author it as " shape " in a defview's unconditional "
+        "top region")
+   nil))
+
+(defn use-ref
+  "(react/use-ref) / (react/use-ref initial) → the host ref object (`useRef`).
+  Read/write via `(.-current ref)`; assignment NEVER re-renders — its reason to
+  exist beside `local` — and it is the preferred object ref for `:ref`
+  positions. No deps. On the JVM structural render it yields an inert ref
+  (`current` nil, stays nil); refs never appear in the JVM tree.
+
+  This var exists for symbol resolution only; a direct call fails loudly."
+  ([] (lowering-only! 're-frame.ui.react/use-ref
+                      "(let [r (react/use-ref)] …)"))
+  ([_initial] (lowering-only! 're-frame.ui.react/use-ref
+                              "(let [r (react/use-ref initial)] …)")))
+
+(defn use-effect
+  "(react/use-effect setup) / (react/use-effect setup deps) → nil (`useEffect`,
+  passive, after paint). `setup` is a zero-arg fn returning a cleanup fn or nil,
+  honoured on dep change, disconnect, and unmount; StrictMode dev replay is
+  expected and MUST be idempotent-safe — the `effect` contract in a foreign
+  spelling. One-arg form runs after every commit; a `deps` vector is compared
+  per authored slot by `Object.is` (React's own effect-dependency equality — a
+  synchronisation input, not a repaint value; `rf=` stays the memo/prop
+  comparator). `[]` deps ⇒ connect-only.
+
+  This var exists for symbol resolution only; a direct call fails loudly."
+  ([_setup] (lowering-only! 're-frame.ui.react/use-effect
+                            "(let [_ (react/use-effect setup)] …)"))
+  ([_setup _deps] (lowering-only! 're-frame.ui.react/use-effect
+                                  "(let [_ (react/use-effect setup deps)] …)")))
+
+(defn use-layout-effect
+  "(react/use-layout-effect setup) / (… setup deps) → nil (`useLayoutEffect`,
+  after DOM mutation, BEFORE paint) for measure-then-mutate work that would
+  flicker under passive timing — the component-library measure-before-paint
+  door (readiness C-6). Observes the committed frame, never a mid-commit state.
+  Same setup/cleanup/`Object.is`-deps contract as `use-effect`.
+
+  This var exists for symbol resolution only; a direct call fails loudly."
+  ([_setup] (lowering-only! 're-frame.ui.react/use-layout-effect
+                            "(let [_ (react/use-layout-effect setup)] …)"))
+  ([_setup _deps] (lowering-only! 're-frame.ui.react/use-layout-effect
+                                  "(let [_ (react/use-layout-effect setup deps)] …)")))
+
+(defn use-effect-event
+  "(react/use-effect-event f) → fn (`useEffectEvent`, React 19.2). The returned
+  fn's body always sees the latest render's values; its identity is NOT stable
+  (React allocates a fresh function every render — do not rely on stability).
+  Takes NO deps. The returned fn MUST NOT appear in any deps vector and MUST NOT
+  be called during render (host throws — it is effect-phase machinery). App
+  intent still goes through event vectors / `ui/event`; this is for the foreign
+  pattern of a latest-values callback invoked from an effect.
+
+  This var exists for symbol resolution only; a direct call fails loudly."
+  [_f] (lowering-only! 're-frame.ui.react/use-effect-event
+                       "(let [on-x (react/use-effect-event f)] …)"))
+
+(defn use-context
+  "(react/use-context ctx) → the context's current value (`useContext`). `ctx`
+  is a FOREIGN Context object (`React.createContext` in foreign code, an opaque
+  foreign value); the value is handed through uncoerced. Internal state never
+  rides React context — frames have `frame-root`/`frame-provider`, app state
+  has `sub`; this reads the foreign world's providers (theme, i18n, router).
+
+  This var exists for symbol resolution only; a direct call fails loudly."
+  [_ctx] (lowering-only! 're-frame.ui.react/use-context
+                         "(let [v (react/use-context ctx)] …)"))
+
+(defn use-id
+  "(react/use-id) → string (`useId`): a host-generated tree-positional token
+  prefixed by the root's `identifierPrefix`. Determinism under SSR rides the
+  root contract (a hydrating root takes the server's prefix from the manifest).
+  On the JVM structural render it yields a deterministic inert string (prefix +
+  per-render occurrence counter) — a value serialised into a *hydrating* root's
+  markup is a mismatch risk; static roots are safe.
+
+  This var exists for symbol resolution only; a direct call fails loudly."
+  [] (lowering-only! 're-frame.ui.react/use-id "(let [id (react/use-id)] …)"))
+
+#?(:clj
+   (defmacro lazy
+     "(react/lazy load-thunk) / (react/lazy load-thunk {:fallback tpl}) — DEF
+     LEVEL only. `React.lazy` over a foreign component-loading `load-thunk` (a
+     zero-arg fn returning a Promise of a foreign component). The result is a
+     foreign component reference, legal exactly where foreign heads are:
+     `[HeavyChart {…}]`. Code-splitting interop for FOREIGN components, not a
+     loading-orchestration surface (loading state in re-frame2 is explicit
+     application state — `sub` over resource state).
+
+     `{:fallback tpl}` declares per-site loading content: a capability-free
+     template the emitter renders inside a minimal host Suspense boundary
+     wrapping that one foreign element. Without a `:fallback`, `React.lazy`'s
+     own rule applies — a Suspense boundary must exist somewhere above.
+
+     A `react/lazy` call inside a view body/template is a compile error."
+     [& args]
+     (compiler/expand-lazy &form &env args)))

--- a/implementation/ui/test/re_frame/ui/react_interop_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_interop_dom_cljs_test.cljs
@@ -1,0 +1,311 @@
+(ns re-frame.ui.react-interop-dom-cljs-test
+  "rf2-vxgfnd.95.4 — the frozen re-frame.ui.react interop tier on a real React
+  root (jsdom/browser): the client behaviour the JVM suite cannot exercise.
+
+    - use-ref: `.current` survives re-renders; a write never re-renders; the
+      ref attaches to a `:ref` position;
+    - use-effect: passive, Object.is deps (a distinct value-equal host value IS
+      a change — the .95.12 correction), cleanup on dep change + unmount;
+    - use-layout-effect: the readiness C-6 measure-before-paint NATIVE consumer
+      (measure in the layout effect, pure geometry, apply, clean up exactly);
+      StrictMode replay is idempotent-safe; unmount (reconnect) runs cleanup;
+    - use-context: reads a FOREIGN React provider's value uncoerced;
+    - use-id: a non-empty host token, stable across re-renders;
+    - use-effect-event: latest render's body, UNSTABLE identity (native React
+      19.2 — a fresh function every render);
+    - lazy: Suspense fallback then foreign activation.
+
+  Compile position law + JVM structural subset + hook-signature HMR law ride the
+  sibling `react_interop_jvm_test`."
+  (:require ["react" :as React]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview local]]
+            [re-frame.ui.react :as react]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.test :as uit]))
+
+(defn- browser? [] (and (exists? js/document) (some? (.-createElement js/document))))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter ui/adapter :ambient-frame nil :async? true
+    :init-fn reactive/reset-scheduler!}))
+
+(defn- host-turn! [] (js/Promise. (fn [resolve _] (js/setTimeout #(resolve nil) 0))))
+(defn- click! [el] (.dispatchEvent el (js/MouseEvent. "click" #js {:bubbles true})))
+(defn- make-frame [id db] (rf/make-frame {:id id :initial-events [[:rf/set-db db]]}))
+
+(defonce ^:private log (atom []))
+(defonce ^:private idents (atom []))
+(defn- reset-log! [] (reset! log []) (reset! idents []))
+
+;; ---------------------------------------------------------------------------
+;; use-ref — survives re-render; a write never re-renders
+;; ---------------------------------------------------------------------------
+
+(defview ref-view []
+  ;; a use-ref cell written from a committed handler (never during render — that
+  ;; would be a render-phase mutation); it survives re-renders and its write
+  ;; does NOT re-render (contrast `local`).
+  (let [[n set-n] (local 0)
+        r         (react/use-ref)]
+    [:div
+     [:span {:data-role "n"} (str n)]
+     [:button {:data-role "stash" :on-click (ui/handler [_] (set! (.-current r) 77))} "stash"]
+     [:button {:data-role "re" :on-click (ui/handler [_] (set-n (inc n)))} "re"]
+     [:button {:data-role "read" :on-click (ui/handler [_] (swap! log conj [:read (.-current r)]))} "read"]]))
+
+(deftest use-ref-current-survives-re-render
+  (if-not (browser?)
+    (is true ":node — browser gate runs use-ref persistence")
+    (async done
+      (reset-log!)
+      (let [f (make-frame ::ref {})]
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [ref-view]]]
+              (-> (host-turn!)
+                  ;; write the ref from a handler — this must NOT re-render.
+                  (.then (fn [] (uit/flush! #(click! (uit/query root "[data-role='stash']")))))
+                  (.then host-turn!)
+                  (.then (fn []
+                           (is (= "0" (.-textContent (uit/query root "[data-role='n']")))
+                               "writing use-ref's current never re-renders")
+                           ;; force an unrelated re-render, then read the ref back.
+                           (uit/flush! #(click! (uit/query root "[data-role='re']")))))
+                  (.then host-turn!)
+                  (.then (fn []
+                           (uit/flush! #(click! (uit/query root "[data-role='read']")))))
+                  (.then host-turn!)
+                  (.then (fn []
+                           (is (some #(= % [:read 77]) @log)
+                               "the ref object survived the re-render (current preserved)")))))
+            (.then (fn [] (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f) (is false (str e)) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; use-effect — Object.is deps, cleanup, and the rf=/Object.is distinction
+;; ---------------------------------------------------------------------------
+
+(defview effect-view []
+  (let [dep   (ui/sub [::dep])
+        other (ui/sub [::other])
+        _     (react/use-effect
+               (fn []
+                 (swap! log conj [:run dep])
+                 (fn [] (swap! log conj [:cleanup dep])))
+               [dep])]
+    [:span {:data-role "e"} (str dep "/" other)]))
+
+(deftest use-effect-object-is-deps-cleanup
+  (if-not (browser?)
+    (is true ":node — browser gate runs use-effect deps/cleanup")
+    (async done
+      (rf/reg-sub ::dep (fn [db _] (:dep db)))
+      (rf/reg-sub ::other (fn [db _] (:other db)))
+      (rf/reg-event ::set-dep (fn [{:keys [db]} [_ v]] {:db (assoc db :dep v)}))
+      (rf/reg-event ::set-other (fn [{:keys [db]} [_ v]] {:db (assoc db :other v)}))
+      (reset-log!)
+      (let [f (make-frame ::eff {:dep 0 :other 0})]
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [effect-view]]]
+              (-> (host-turn!)
+                  (.then (fn [] (is (some #(= % [:run 0]) @log) "runs after mount")
+                           (uit/flush! #(uit/dispatch! f [::set-other 9]))))
+                  (.then host-turn!)
+                  (.then (fn []
+                           (is (= 1 (count (filter #(= (first %) :run) @log)))
+                               "an unchanged (Object.is) dep does NOT re-run")
+                           (uit/flush! #(uit/dispatch! f [::set-dep 1]))))
+                  (.then host-turn!)
+                  (.then (fn []
+                           (is (some #(= % [:cleanup 0]) @log) "dep change cleans up the prior run")
+                           (is (some #(= % [:run 1]) @log) "then re-runs with the new dep")))))
+            (.then (fn []
+                     (is (some #(= % [:cleanup 1]) @log) "unmount runs cleanup")
+                     (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f) (is false (str e)) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; use-layout-effect — the readiness C-6 measure-before-paint NATIVE consumer
+;; ---------------------------------------------------------------------------
+
+;; Pure `.cljc`-style placement geometry: clamp the measured anchor into the
+;; viewport, flipping above when it would overflow below. No host access.
+(defn- placement [anchor-top el-height viewport-h]
+  (if (> (+ anchor-top el-height) viewport-h)
+    {:side :above :top (max 0 (- anchor-top el-height))}
+    {:side :below :top anchor-top}))
+
+(defview popover [{:keys [anchor viewport]}]
+  ;; a NATIVE consumer (no foreign boundary): measure the element in a layout
+  ;; effect (before paint), compute placement with pure geometry, apply it, and
+  ;; clean up exactly on teardown / re-measure.
+  (let [el (react/use-ref)
+        _  (react/use-layout-effect
+            (fn []
+              (let [h  (.-offsetHeight (.-current el))
+                    p  (placement anchor h viewport)]
+                (set! (.. el -current -dataset -side) (name (:side p)))
+                (set! (.. el -current -dataset -top) (str (:top p)))
+                (swap! log conj [:place (:side p) (:top p)])
+                (fn [] (swap! log conj [:place-cleanup]))))
+            [anchor viewport])]
+    [:div {:ref el :data-role "popover"} "menu"]))
+
+(deftest layout-effect-measure-before-paint-and-cleanup
+  (if-not (browser?)
+    (is true ":node — browser gate runs the C-6 measure-before-paint consumer")
+    (async done
+      (reset-log!)
+      (let [f (make-frame ::pop {})]
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [popover {:anchor 10 :viewport 500}]]]
+              (-> (host-turn!)
+                  (.then (fn []
+                           (let [^js el (uit/query root "[data-role='popover']")]
+                             ;; the layout effect measured + applied placement to the DOM.
+                             (is (some #(= (first %) :place) @log)
+                                 "the layout effect measured and computed placement")
+                             (is (= "below" (.. el -dataset -side))
+                                 "pure geometry applied a placement attribute before paint"))))))
+            (.then (fn []
+                     (is (some #(= % [:place-cleanup]) @log)
+                         "teardown ran the layout effect cleanup exactly")
+                     (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f) (is false (str e)) (done))))))))
+
+;; StrictMode replay of the native measure-before-paint consumer is idempotent
+;; (cleanup balances setup — no double-applied placement leaks).
+(defview strict-popover-host []
+  (ui/raw (React/createElement (.-StrictMode React) nil
+                               (React/createElement popover #js {:anchor 10 :viewport 500}))))
+
+(deftest layout-effect-strictmode-is-idempotent
+  (if-not (browser?)
+    (is true ":node — browser gate runs StrictMode layout replay")
+    (async done
+      (reset-log!)
+      (-> (uit/with-root [root [strict-popover-host]]
+            (-> (host-turn!)
+                (.then (fn []
+                         (let [places   (count (filter #(= (first %) :place) @log))
+                               cleanups (count (filter #(= % [:place-cleanup]) @log))]
+                           (is (>= places 1) "the layout effect ran")
+                           ;; StrictMode double-invokes; each setup is balanced by a
+                           ;; cleanup, so no orphaned placement survives (idempotent).
+                           (is (= places (inc cleanups))
+                               "every StrictMode setup but the live one is balanced by a cleanup"))))))
+          (.then (fn [] (done)) (fn [e] (is false (str e)) (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; use-context — reads a FOREIGN provider's value
+;; ---------------------------------------------------------------------------
+
+(def ^:private Theme (React/createContext "default"))
+
+(defview theme-consumer [] (let [v (react/use-context Theme)] [:span {:data-role "theme"} v]))
+
+(defview theme-host []
+  (ui/raw (React/createElement (.-Provider Theme) #js {:value "themed"}
+                               (React/createElement theme-consumer #js {}))))
+
+(deftest use-context-reads-foreign-provider
+  (if-not (browser?)
+    (is true ":node — browser gate runs use-context")
+    (async done
+      (-> (uit/with-root [root [theme-host]]
+            (-> (host-turn!)
+                (.then (fn []
+                         (is (= "themed" (.-textContent (uit/query root "[data-role='theme']")))
+                             "the foreign context value flows through uncoerced")))))
+          (.then (fn [] (done)) (fn [e] (is false (str e)) (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; use-id — a non-empty host token, stable across re-renders
+;; ---------------------------------------------------------------------------
+
+(defview id-view []
+  (let [[n set-n] (local 0)
+        id        (react/use-id)
+        _         (swap! log conj [:id id])]
+    [:div
+     [:label {:data-role "id" :for id} (str n)]
+     [:button {:data-role "re" :on-click (ui/handler [_] (set-n (inc n)))} "re"]]))
+
+(deftest use-id-is-stable-across-renders
+  (if-not (browser?)
+    (is true ":node — browser gate runs use-id")
+    (async done
+      (reset-log!)
+      (let [f (make-frame ::id {})]
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [id-view]]]
+              (-> (host-turn!)
+                  (.then (fn [] (uit/flush! #(click! (uit/query root "[data-role='re']")))))
+                  (.then host-turn!)
+                  (.then (fn []
+                           (let [ids (map second (filter #(= (first %) :id) @log))]
+                             (is (every? #(and (string? %) (seq %)) ids) "a non-empty host token")
+                             (is (apply = ids) "stable across re-renders"))))))
+            (.then (fn [] (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f) (is false (str e)) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; use-effect-event — latest body, UNSTABLE identity (native React 19.2)
+;; ---------------------------------------------------------------------------
+
+(defview effect-event-view []
+  (let [[n set-n] (local 0)
+        on-tick   (react/use-effect-event (fn [] (swap! log conj [:tick n])))
+        _         (react/use-effect (fn [] (on-tick) nil))
+        _         (swap! idents conj on-tick)]
+    [:button {:data-role "inc" :on-click (ui/handler [_] (set-n (inc n)))} (str n)]))
+
+(deftest use-effect-event-latest-body-and-unstable-identity
+  (if-not (browser?)
+    (is true ":node — browser gate runs use-effect-event")
+    (async done
+      (reset-log!)
+      (let [f (make-frame ::ee {})]
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [effect-event-view]]]
+              (-> (host-turn!)
+                  (.then (fn [] (uit/flush! #(click! (uit/query root "[data-role='inc']")))))
+                  (.then host-turn!)
+                  (.then (fn []
+                           ;; the effect (runs every commit) calls the effect-event,
+                           ;; whose body sees the LATEST render's n.
+                           (is (some #(= % [:tick 1]) @log)
+                               "the effect-event body sees the latest render's value")
+                           ;; native React 19.2: a fresh function identity each render.
+                           (is (>= (count @idents) 2))
+                           (is (not= (first @idents) (second @idents))
+                               "identity is UNSTABLE across renders (no shim)")))))
+            (.then (fn [] (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f) (is false (str e)) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; lazy — Suspense fallback then foreign activation
+;; ---------------------------------------------------------------------------
+
+(defn- heavy-thunk []
+  ;; a code-split foreign component, resolved on a later microtask.
+  (js/Promise.resolve
+   #js {:default (fn heavy [_props]
+                   (React/createElement "span" #js {:data-role "heavy"} "heavy!"))}))
+
+(def LazyHeavy (react/lazy heavy-thunk {:fallback [:span.spin "loading"]}))
+
+(defview lazy-page [] [:section [LazyHeavy {}]])
+
+(deftest lazy-shows-fallback-then-activates
+  (if-not (browser?)
+    (is true ":node — browser gate runs lazy activation")
+    (async done
+      (-> (uit/with-root [root [lazy-page]]
+            (-> (host-turn!)
+                (.then host-turn!)
+                (.then host-turn!)
+                (.then (fn []
+                         (is (some? (uit/query root "[data-role='heavy']"))
+                             "the code-split foreign component activated after its Promise resolved")
+                         (is (= "heavy!" (.-textContent (uit/query root "[data-role='heavy']"))))))))
+          (.then (fn [] (done)) (fn [e] (is false (str e)) (done)))))))

--- a/implementation/ui/test/re_frame/ui/react_interop_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/react_interop_jvm_test.clj
@@ -1,0 +1,294 @@
+(ns re-frame.ui.react-interop-jvm-test
+  "rf2-vxgfnd.95.4 — the frozen re-frame.ui.react interop tier on the JVM
+  Tier-1 structural host, plus the COMPILE-TIME position law.
+
+  The seven wrappers (Spec 004 §The React interop tier): use-ref, use-effect,
+  use-layout-effect, use-effect-event, use-context, use-id, lazy. This suite
+  pins:
+    - the position law rejections (`:rf.ui.compile/react-hook-misplaced`,
+      `-bad-deps`, `react-lazy-misplaced`) — compile-time ids in COMPILER PROSE,
+      no Spec 009 catalogue rows;
+    - the hook-signature-hash contribution (kind + interleave order; edit-a-body
+      is same-signature; add/remove/reorder — including local↔react — is not)
+      and the S3 shape-version bump;
+    - the manifest sites + capability-bit folding;
+    - the JVM structural subset: inert ref, effects don't run, use-effect-event
+      returns a fn that fails loud, use-context resolves a JVM-provided value or
+      fails loud, use-id is a deterministic inert string, lazy renders its
+      fallback / nothing and NEVER invokes the load thunk.
+
+  Real React client behaviour (use-ref no-re-render, Object.is deps + cleanup,
+  use-layout-effect measure-before-paint, use-effect-event latest-body + unstable
+  identity, use-context foreign provider, use-id, lazy activation, StrictMode,
+  HMR) rides the DOM suite `react_interop_dom_cljs_test`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.react :as react]
+            [re-frame.ui.fingerprint :as fp]
+            [re-frame.ui.hooks :as hooks]
+            [re-frame.ui.frames :as frames]
+            [re-frame.ui.test :as uit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [t]
+    (frames/reset-frame-ops-cache!)
+    (try (t) (finally (frames/reset-frame-ops-cache!)))))
+
+;; Compile-error probing follows the .95.2 JVM suite: `macroexpand-1` with
+;; FULLY-QUALIFIED symbols, so resolution is independent of the runtime *ns*.
+(defn- compile-error [form]
+  (try (macroexpand-1 form) nil
+       (catch clojure.lang.ExceptionInfo e (:rf.ui.compile/error (ex-data e)))
+       (catch Exception e
+         (let [c (.getCause e)]
+           (when (instance? clojure.lang.ExceptionInfo c)
+             (:rf.ui.compile/error (ex-data c)))))))
+
+(defn- manifest [view-id]
+  (:rf.ui/manifest (registrar/handler-meta :view view-id)))
+
+;; ---------------------------------------------------------------------------
+;; The position law — compile-time rejections (prose ids, no Spec 009 rows)
+;; ---------------------------------------------------------------------------
+
+(deftest position-law-rejects-conditional-loop-and-deferred
+  (testing "a wrapper in a branch is misplaced (React hook order must be static)"
+    (is (= :rf.ui.compile/react-hook-misplaced
+           (compile-error '(re-frame.ui/defview v []
+                             (when true (let [r (re-frame.ui.react/use-ref)] [:div])))))))
+  (testing "a wrapper in a loop is misplaced"
+    (is (= :rf.ui.compile/react-hook-misplaced
+           (compile-error '(re-frame.ui/defview v []
+                             [:ul (for [i [1 2]]
+                                    (let [r (re-frame.ui.react/use-ref)] [:li {:key i} i]))])))))
+  (testing "a wrapper in a deferred fn body is misplaced"
+    (is (= :rf.ui.compile/react-hook-misplaced
+           (compile-error '(re-frame.ui/defview v []
+                             (let [f (fn [] (re-frame.ui.react/use-context :t))] [:div])))))))
+
+(deftest use-effect-deps-must-be-a-literal-vector
+  (is (= :rf.ui.compile/react-hook-bad-deps
+         (compile-error '(re-frame.ui/defview v []
+                           (let [_ (re-frame.ui.react/use-effect (fn [] nil) :nope)] [:div]))))))
+
+(deftest reactive-read-inside-a-setup-fn-is-rejected
+  ;; the setup fn is a DEFERRED callback — a sub/lease/frame inside owns no
+  ;; render-time site (the same law as `effect`).
+  (is (some? (compile-error '(re-frame.ui/defview v []
+                               (let [_ (re-frame.ui.react/use-effect
+                                        (fn [] (re-frame.ui/sub [:x])) [])]
+                                 [:div]))))))
+
+(deftest wrong-arities-are-rejected
+  (is (= :rf.ui.compile/unsupported-form
+         (compile-error '(re-frame.ui/defview v []
+                           (let [id (re-frame.ui.react/use-id :extra)] [:div id])))))
+  (is (= :rf.ui.compile/unsupported-form
+         (compile-error '(re-frame.ui/defview v []
+                           (let [r (re-frame.ui.react/use-ref 1 2)] [:div]))))))
+
+(deftest lazy-in-a-view-body-is-def-level-only
+  (is (= :rf.ui.compile/react-lazy-misplaced
+         (compile-error '(re-frame.ui/defview v []
+                           (let [c (re-frame.ui.react/lazy (fn []))] [:div]))))))
+
+(deftest a-valid-top-region-view-compiles
+  (is (nil? (compile-error
+             '(re-frame.ui/defview v []
+                (let [r  (re-frame.ui.react/use-ref)
+                      id (re-frame.ui.react/use-id)
+                      th (re-frame.ui.react/use-context :theme)
+                      _  (re-frame.ui.react/use-effect (fn [] nil) [th])]
+                  [:div {:ref r :id id} th]))))))
+
+;; ---------------------------------------------------------------------------
+;; Manifest sites + capability folding
+;; ---------------------------------------------------------------------------
+
+(defview manifest-probe []
+  (let [r  (react/use-ref)
+        id (react/use-id)
+        th (react/use-context :theme)
+        _  (react/use-effect (fn [] nil) [th])
+        _  (react/use-layout-effect (fn [] nil))
+        on (react/use-effect-event (fn [x] x))]
+    [:div {:ref r :id id} th]))
+
+(deftest manifest-records-react-sites-and-kinds
+  (let [m     (manifest ::manifest-probe)
+        sites (get-in m [:sites :react])
+        kinds (mapv :kind sites)]
+    (is (= 6 (count sites)) "all six wrapper sites are recorded")
+    (is (= [:ref :id :context :effect :layout-effect :effect-event] kinds)
+        "kinds are recorded in source order")
+    (is (apply distinct? (map :sid sites)) "each site has a distinct lexical id")
+    (is (= (range 6) (mapv :order sites))
+        "shared body-hook ordinals are 0..5 in source order")))
+
+(deftest capability-bits-fold-onto-the-static-root-vocabulary
+  (let [caps (set (:capabilities (manifest ::manifest-probe)))]
+    (is (contains? caps :ref)     "use-ref → :ref")
+    (is (contains? caps :effect)  "use-effect/use-layout-effect/use-effect-event → :effect")
+    (is (contains? caps :context) "use-context → :context")
+    (is (not (contains? caps :id)) "use-id is exempt (inert deterministic ids are static-safe)")))
+
+;; ---------------------------------------------------------------------------
+;; Hook-signature contribution (shape-version 2; interleave-safe)
+;; ---------------------------------------------------------------------------
+
+(deftest hook-signature-shape-is-version-2-with-react
+  (let [hs (:hook-signature (manifest ::manifest-probe))]
+    (is (string? hs))
+    (is (.startsWith ^String hs "hs1-")
+        "the prefix versions the ALGORITHM (unchanged); the integer versions the shape")))
+
+(deftest editing-a-deps-vector-or-setup-body-is-same-signature
+  (let [sig (fn [react] (fp/hook-signature-hash {:react react}))
+        a   (sig [{:kind :effect :order 0}])
+        b   (sig [{:kind :effect :order 0}])]
+    (is (= a b) "kind + order only — deps contents / setup bodies never enter the hash")))
+
+(deftest adding-removing-or-reordering-a-wrapper-changes-the-signature
+  (let [sig (fn [m] (fp/hook-signature-hash m))]
+    (testing "adding a wrapper"
+      (is (not= (sig {:react [{:kind :ref :order 0}]})
+                (sig {:react [{:kind :ref :order 0} {:kind :effect :order 1}]}))))
+    (testing "reordering two react wrappers"
+      (is (not= (sig {:react [{:kind :ref :order 0} {:kind :context :order 1}]})
+                (sig {:react [{:kind :context :order 0} {:kind :ref :order 1}]}))))
+    (testing "a local↔react reorder (both live in the top-region let)"
+      ;; local advances the shared ordinal, so moving it across a use-ref shifts
+      ;; the ref's ordinal — a per-category count vector could not catch this.
+      (is (not= (sig {:locals [:local] :react [{:kind :ref :order 1}]})
+                (sig {:locals [:local] :react [{:kind :ref :order 0}]}))))))
+
+;; A NATIVE (non-foreign-boundary) measure-before-paint consumer (readiness
+;; C-6): use-ref for the element + use-layout-effect to measure and place. Its
+;; real-compiler hook-signature drives the HMR law below (and its client
+;; behaviour rides the DOM suite).
+(defview popover-v1 [{:keys [anchor]}]
+  (let [el (react/use-ref)
+        _  (react/use-layout-effect (fn [] nil) [anchor])]
+    [:div {:ref el :data-role "popover"} "menu"]))
+
+;; same wrappers, same order, edited layout-effect body + deps → SAME signature
+;; (a compatible refresh: state preserved).
+(defview popover-v1-edited [{:keys [anchor]}]
+  (let [el (react/use-ref)
+        _  (react/use-layout-effect (fn [] (identity :edited)) [anchor :extra])]
+    [:div {:ref el :data-role "popover"} "MENU"]))
+
+;; an ADDED passive effect → DIFFERENT signature (a deliberate clean remount).
+(defview popover-v2-added [{:keys [anchor]}]
+  (let [el (react/use-ref)
+        _  (react/use-layout-effect (fn [] nil) [anchor])
+        _  (react/use-effect (fn [] nil) [])]
+    [:div {:ref el :data-role "popover"} "menu"]))
+
+(deftest hmr-law-native-consumer-edit-preserves-add-remounts
+  (let [sig #(:hook-signature (manifest %))]
+    (is (= (sig ::popover-v1) (sig ::popover-v1-edited))
+        "editing a layout-effect body/deps is a SAME-signature edit (state preserved)")
+    (is (not= (sig ::popover-v1) (sig ::popover-v2-added))
+        "adding a wrapper changes the hook signature (a clean remount)")))
+
+;; ---------------------------------------------------------------------------
+;; JVM structural subset
+;; ---------------------------------------------------------------------------
+
+(defview inert-ref-view [] (let [r (react/use-ref 42)] [:div {:ref r} "x"]))
+
+(deftest use-ref-is-inert-on-the-jvm
+  (let [t (uit/render [inert-ref-view {}])]
+    (is (= "x" (uit/text (uit/find t :div))) "the view renders; the ref is inert")))
+
+(deftest jvm-use-ref-current-stays-nil
+  (is (nil? (:current (hooks/use-ref)))    "0-arg inert ref")
+  (is (nil? (:current (hooks/use-ref 99))) "1-arg inert ref ignores the initial"))
+
+(def ^:dynamic *effect-ran* (atom false))
+
+(defview effects-dont-run-view []
+  (let [_ (react/use-effect (fn [] (reset! *effect-ran* true)) [])
+        _ (react/use-layout-effect (fn [] (reset! *effect-ran* true)))]
+    [:div "ok"]))
+
+(deftest effects-do-not-run-on-the-jvm
+  (binding [*effect-ran* (atom false)]
+    (uit/render [effects-dont-run-view {}])
+    (is (false? @*effect-ran*) "passive/layout effects never run in a structural render")))
+
+(deftest use-effect-event-fn-fails-loud-on-jvm-invoke
+  (let [f (hooks/use-effect-event (fn [x] x))]
+    (is (thrown? clojure.lang.ExceptionInfo (f 1))
+        "the returned fn raises :rf.error/jvm-host-op when invoked")))
+
+(defview ctx-view [] (let [v (react/use-context :theme)] [:div v]))
+
+(deftest use-context-resolves-a-jvm-provided-value
+  (binding [hooks/*jvm-react-context-values* {:theme "dark"}]
+    (let [t (uit/render [ctx-view {}])]
+      (is (= "dark" (uit/text (uit/find t :div)))
+          "the JVM-provided test value flows through"))))
+
+(deftest use-context-with-no-provided-value-fails-loud
+  (is (thrown? clojure.lang.ExceptionInfo
+               (uit/render [ctx-view {}]))
+      "an unbound foreign context never silently resolves nil"))
+
+(defview id-view [] (let [id (react/use-id)] [:div {:data-id id} id]))
+
+(deftest use-id-is-a-deterministic-inert-string
+  (let [t (uit/render [id-view {}])]
+    (is (= "rf2-uid-0" (uit/text (uit/find t :div)))
+        "a deterministic prefix + occurrence-counter string; safe for static roots")))
+
+(deftest jvm-use-id-counter-makes-repeats-distinct
+  (binding [hooks/*jvm-use-id-counter* (volatile! 0)]
+    (is (= "rf2-uid-0" (hooks/use-id)))
+    (is (= "rf2-uid-1" (hooks/use-id)) "an occurrence counter distinguishes repeats")))
+
+;; ---------------------------------------------------------------------------
+;; lazy — def-level; JVM renders the fallback / nothing, never the thunk
+;; ---------------------------------------------------------------------------
+
+(def ThrowingThunk (fn [] (throw (ex-info "the load thunk must NEVER run on the JVM" {}))))
+
+(def WithFallback  (react/lazy ThrowingThunk {:fallback [:div.spinner "Loading…"]}))
+(def WithoutFallback (react/lazy ThrowingThunk))
+
+(deftest lazy-value-carries-the-marker
+  (is (true? (:rf.ui/lazy WithFallback)))
+  (is (true? (:rf.ui/lazy WithoutFallback))))
+
+(defview lazy-fallback-page [] [:section [WithFallback {:data 1}]])
+(defview lazy-nothing-page  [] [:section [WithoutFallback {:data 1}]])
+
+(deftest lazy-renders-its-declared-fallback-and-never-the-thunk
+  (let [t (uit/render [lazy-fallback-page {}])]
+    (is (= "Loading…" (uit/text t))
+        "the JVM structural render shows the declared capability-free fallback")))
+
+(deftest lazy-without-a-fallback-renders-nothing
+  (let [t (uit/render [lazy-nothing-page {}])]
+    ;; the section renders; the lazy child contributes nothing (never the thunk).
+    (is (= "" (or (uit/text t) ""))
+        "no fallback ⇒ :nothing (a foreign component that never suspends here)")))
+
+(defn- eval-compile-error [form]
+  (try (eval form) nil
+       (catch Throwable e
+         ;; walk the (possibly multi-level) cause chain for the compile id.
+         (some (fn [t] (:rf.ui.compile/error (ex-data t)))
+               (take 8 (iterate #(some-> % ex-cause) e))))))
+
+(deftest lazy-fallback-must-be-capability-free
+  ;; a reactive read in a lazy fallback is a compile error (the client-only rule).
+  (is (= :rf.ui.compile/capability-in-fallback
+         (eval-compile-error '(re-frame.ui.react/lazy
+                               (fn [])
+                               {:fallback [:div (re-frame.ui/sub [:x])]})))))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -189,6 +189,7 @@ nav:
       - "Build a form": core/how-to/build-a-form.md
       - "Validate with schemas": core/how-to/validate-with-schemas.md
       - "Fix a slow view": core/how-to/fix-a-slow-view.md
+      - "Measure before paint": core/how-to/measure-before-paint.md
       - "Keep secrets out of traces": core/how-to/keep-secrets-out-of-traces.md
       - "Report errors in production": core/how-to/report-errors-in-production.md
       - "Configure dev and prod": core/how-to/configure-dev-and-prod.md
@@ -217,6 +218,7 @@ nav:
     - api/README.md
     - "re-frame.core": api/re-frame.core.md
     - "re-frame.ui": api/re-frame.ui.md
+    - "re-frame.ui.react": api/re-frame.ui.react.md
     - "re-frame.schemas": api/re-frame.schemas.md
     - "re-frame.flows": api/re-frame.flows.md
     - "re-frame.http": api/re-frame.http.md

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -365,7 +365,22 @@
   ;; :api-md-known-unmanifested allowlist below (they now ship).
   {:namespace "re-frame.ui" :var "handler"        :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S3" :runtime-verified? true}
   {:namespace "re-frame.ui" :var "error-boundary" :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S3" :runtime-verified? true}
-  {:namespace "re-frame.ui" :var "client-only"    :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S3" :runtime-verified? true}]
+  {:namespace "re-frame.ui" :var "client-only"    :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S3" :runtime-verified? true}
+  ;; re-frame.ui.react (rf2-vxgfnd.95.4) — the frozen seven-wrapper React interop
+  ;; tier (Spec 004 §The React interop tier). Six host hooks (use-ref /
+  ;; use-effect / use-layout-effect / use-effect-event / use-context / use-id)
+  ;; are resolution-only `defn`s the compiler recognises + lowers inside a
+  ;; compiled view, position-checked by the finite-site machinery; `lazy` is a
+  ;; def-level `defmacro` (React.lazy over a foreign component-loading thunk).
+  ;; Interop surfaces — advanced tier. Their live vars + the DOM/JVM fixtures
+  ;; landed with this feature.
+  {:namespace "re-frame.ui.react" :var "use-ref"           :kind :fn    :facade? false :tier :advanced :owner "004" :status "Spec-004 S3" :runtime-verified? true}
+  {:namespace "re-frame.ui.react" :var "use-effect"        :kind :fn    :facade? false :tier :advanced :owner "004" :status "Spec-004 S3" :runtime-verified? true}
+  {:namespace "re-frame.ui.react" :var "use-layout-effect" :kind :fn    :facade? false :tier :advanced :owner "004" :status "Spec-004 S3" :runtime-verified? true}
+  {:namespace "re-frame.ui.react" :var "use-effect-event"  :kind :fn    :facade? false :tier :advanced :owner "004" :status "Spec-004 S3" :runtime-verified? true}
+  {:namespace "re-frame.ui.react" :var "use-context"       :kind :fn    :facade? false :tier :advanced :owner "004" :status "Spec-004 S3" :runtime-verified? true}
+  {:namespace "re-frame.ui.react" :var "use-id"            :kind :fn    :facade? false :tier :advanced :owner "004" :status "Spec-004 S3" :runtime-verified? true}
+  {:namespace "re-frame.ui.react" :var "lazy"              :kind :macro :facade? false :tier :advanced :owner "004" :status "Spec-004 S3" :runtime-verified? true}]
 
  ;; --------------------------------------------------------------------------
  ;; API.md var-rows that are KNOWINGLY absent from the manifest. The

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 504,
+ :var-count 511,
  :tier-vocab
  [:front-porch
   :advanced
@@ -512,6 +512,13 @@
   {:namespace "re-frame.ui", :var "spread-safe", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S3", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui", :var "sub", :tier :front-porch, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui", :var "unmount!", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui.react", :var "lazy", :tier :advanced, :kind :macro, :owner "004", :status "Spec-004 S3", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui.react", :var "use-context", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S3", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui.react", :var "use-effect", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S3", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui.react", :var "use-effect-event", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S3", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui.react", :var "use-id", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S3", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui.react", :var "use-layout-effect", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S3", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui.react", :var "use-ref", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S3", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui.test", :var "attrs", :tier :testing, :kind :fn, :owner "008", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui.test", :var "dispatch!", :tier :testing, :kind :fn, :owner "008", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui.test", :var "find", :tier :testing, :kind :fn, :owner "008", :status "Spec-004 S1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
Implements `rf2-vxgfnd.95.4` — the frozen seven-wrapper `re-frame.ui.react`
interop tier (Spec 004 §The React interop tier): `use-ref`, `use-effect`,
`use-layout-effect`, `use-effect-event`, `use-context`, `use-id` (six host
hooks) and the def-level `lazy` constructor. Builds on the merged `.95.2`
(hooks.cljc) and `.95.3` (callback boundaries) patterns.

## What landed

- **Facade** `re-frame.ui.react` (`implementation/ui/src/re_frame/ui/react.cljc`):
  six resolution-only host-hook stubs the compiler recognises + lowers inside a
  compiled view, plus the `lazy` macro (React.lazy over a foreign
  component-loading thunk; a compiler-checked capability-free `:fallback`
  rendered inside a Suspense boundary).
- **Analyzer** (`analyze.cljc`): react-hook FQN recognition in the finite-site
  expression walk; the **position law** (legal only in the straight-line top
  region — an outer `let` binding); lowering to `re-frame.ui.hooks/*`; a
  `:react` manifest site per wrapper with kind + shared body-hook ordinal.
- **Runtime** (`hooks.cljc`): CLJS wraps real React (every property access
  `^js`-hinted for a 0-infer-warning advanced build); JVM structural subset.
- **Hook-signature** (`fingerprint.cljc`): shape-version 1→2 with a `:react`
  vector of `{:kind :order}` entries — the order is a shared body-hook ordinal
  counting locals too, so a `local↔react` reorder (both interleave in the
  top-region `let`) changes the signature; a per-category count vector could
  not catch it.
- **Capability bits**, manifest evidence, guide recipe + docs/api page.

## Corrections absorbed (from the blocking P1 audits `.95.11` / `.95.12`)

- `use-effect-event` is **native React 19.2** — unstable identity, latest body,
  no identity shim (`.95.11`).
- `use-effect` / `use-layout-effect` deps compare per authored slot by
  **`Object.is`** (React's effect-dependency rule), not `rf=`; `rf=` stays the
  memo/prop comparator (`.95.12`).

## Position-law diagnostics (compiler prose, NO Spec 009 rows)

`:rf.ui.compile/react-hook-misplaced` (branch/loop/deferred/render-fn/root),
`:rf.ui.compile/react-hook-bad-deps` (non-literal deps vector),
`:rf.ui.compile/react-lazy-misplaced` (lazy in a view body),
`:rf.ui.compile/bad-lazy` / `capability-in-fallback` (lazy grammar/fallback).
All compile-time ids — no runtime `:rf.error/*` id was introduced, so no
Spec 009 catalogue row is needed.

## Readiness C-6 (measure-before-paint)

`use-ref` + `use-layout-effect` gain the native component-library
measure-before-paint audience. Ships a guide recipe
(`docs/core/how-to/measure-before-paint.md`) and StrictMode / reconnect / HMR /
JVM-metadata conformance fixtures through a **native** (non-foreign-boundary)
consumer.

## Quality gates

| Gate | Result |
|---|---|
| `implementation/ui` JVM (`clojure -M:test`) | **711 tests, 0 failures** |
| `implementation/core` JVM error-catalogue conformance | **9 tests, 0 failures** (no new runtime ids) |
| `npm run test:cljs` (node-test) | **9756 tests, 0 failures** |
| `npm run test:ui` (node-test-ui) | **717 tests, 0 failures** |
| `npm run test:browser` (Playwright) | **431 tests, 0 failures** |
| `shadow-cljs compile ui-digest-probe-lazy` (advanced) | **0 warnings** |
| `react_interop_jvm_test` (new) | **24 tests, 0 failures** |
| `api-manifest gen --check` | **in sync (511 vars)** |
| `mkdocs build --strict` | **pass** |

## Notes / sequenced follow-ups

- The hot-zone spec prose (`spec/004-Views.md`, `spec/API.md`) still states the
  pre-audit semantics (`rf=` deps, stable `use-effect-event`); those normative
  corrections are owned by the blocking beads `.95.11` / `.95.12` / `.95.13`
  and ride their hot-zone transfer. The implementation here already follows the
  corrected contract, and `spec/API.md` already lists the seven names so the
  manifest↔API.md projection passes.
- Did NOT touch `error_emit.cljc` (parallel bead `xgkgx`); position-law compile
  diagnostics use `env/fail!` in compiler prose.
- Anti-over-engineering confirmed: exactly the seven names, no extra hook
  wrappers, no generic `use-hook`, no UIx-parity layer, no runtime hook-ordering
  repair, no debug registry.
