### PR TITLE
fix(ui): carry event/query head on frame-destroyed stale-op exception, redaction intact (rf2-r79gr)

### DIFF
--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -1098,6 +1098,13 @@
   an off-box shipper attributes the failure. `payload` is nil for the `:capture`
   arm (the read failed before any op was invoked).
 
+  The THROWN exception mirrors the same STRUCTURAL attribution in its `:extra`
+  ex-data — `:frame`, `:op`, and the event/query `:event-id` HEAD (rf2-r79gr) —
+  so a synchronous `try/catch` around a stale op attributes it from the caught
+  exception alone, without correlating the async always-on record. Head only:
+  the raw payload BODY never rides the exception (same fail-closed policy as the
+  record — see below).
+
   Emitted EXACTLY ONCE, at this UI source: the incarnation fence emits and throws
   HERE — before delegating to core's dispatch/subscribe — so the same failure is
   never ALSO fanned by core's router/subs frame-destroyed path (source-level
@@ -1128,21 +1135,30 @@
   (let [;; Body redacted at source (rf2-01ihi) — a dead incarnation has no
         ;; trustworthy policy for its captured payload on EITHER channel. nil
         ;; for the `:capture` arm (no op was invoked, so no payload to redact).
-        redacted-event (when (some? payload) privacy/redacted-sentinel)]
+        redacted-event (when (some? payload) privacy/redacted-sentinel)
+        ;; The STRUCTURAL event/query HEAD — the attempted vector's first
+        ;; element (the event-id / sub-id keyword), NEVER the raw payload body
+        ;; (rf2-01ihi redacts the body; only the head survives). nil for the
+        ;; `:capture` arm. Rides BOTH the always-on record's `:event-id` slot
+        ;; AND the thrown exception's `:extra :event-id` (rf2-r79gr), so a
+        ;; synchronous catcher attributes the stale op from the exception alone,
+        ;; without correlating the async record stream — head only, so no
+        ;; successor elision policy can be borrowed to egress the body.
+        event-id       (when payload (first payload))]
     (error-emit/emit-error-both!
      :rf.error/frame-destroyed
      redacted-event                  ;; attempted event/query body, redacted at source (elided as :event); nil for :capture
-     (when payload (first payload))  ;; :event-id / sub-id — the structural vector head (survives)
+     event-id                        ;; :event-id / sub-id — the structural vector head (survives)
      frame-id
      nil                             ;; no exception — a dead-incarnation op, not a caught throw
      0                               ;; elapsed-ms — not a timed path
      (interop/now-ms)                ;; time
      {:frame frame-id :op op :event redacted-event :reason :frame-destroyed} ;; dev-trace tags (axis 2)
-     {:op op}))                      ;; category-specific attribution for the always-on record (axis 1)
-  (error/throw-error!
-   :rf.error/frame-destroyed 're-frame.ui/frame
-   reason
-   {:extra {:frame frame-id :op op}}))
+     {:op op})                       ;; category-specific attribution for the always-on record (axis 1)
+    (error/throw-error!
+     :rf.error/frame-destroyed 're-frame.ui/frame
+     reason
+     {:extra {:frame frame-id :op op :event-id event-id}})))
 
 (defn- throw-frame-ops-destroyed!
   "The ambient frame a `(frame)` read resolved has no live incarnation to

--- a/implementation/ui/test/re_frame/ui/frame_ops_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/frame_ops_cljs_test.cljc
@@ -262,6 +262,69 @@
       (is (= :rf.error/frame-destroyed (:error (first @recs)))))))
 
 ;; ===========================================================================
+;; rf2-r79gr — the THROWN stale-op exception carries the structural event/query
+;; HEAD in its `:extra` ex-data, so a synchronous catcher attributes the failing
+;; op from the exception ALONE (without correlating the async always-on record).
+;; The record already exposes the head as `:event-id` (rf2-01ihi's surviving
+;; evidence); this leg pins the SAME head onto the thrown exception's ex-data.
+;; Head ONLY: rf2-01ihi's fail-closed policy stays intact — the raw payload BODY
+;; NEVER rides the exception. Reverting `:event-id` out of `:extra` goes red.
+;; ===========================================================================
+
+(defn- ex-data-of
+  "Run `thunk` (expected to throw the canonical ExceptionInfo) and return the
+  caught exception's ex-data, or nil if it did not throw."
+  [thunk]
+  (try (thunk) nil
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+         (ex-data e))))
+
+(defn- deep-contains?
+  "True when `target` appears anywhere in `x` (key, value, or leaf) — the
+  redaction proof walks the WHOLE ex-data so a re-keyed payload leak cannot hide."
+  [x target]
+  (cond
+    (= x target)    true
+    (map? x)        (boolean (some (fn [[k v]] (or (deep-contains? k target)
+                                                   (deep-contains? v target))) x))
+    (sequential? x) (boolean (some #(deep-contains? % target) x))
+    (set? x)        (boolean (some #(deep-contains? % target) x))
+    :else           false))
+
+(deftest thrown-stale-op-exception-carries-the-head-body-redacted
+  (testing "Per rf2-r79gr: the THROWN :rf.error/frame-destroyed exception carries
+            the structural event/query HEAD as :extra :event-id (dispatch /
+            dispatch-sync / subscribe), so a try/catch attributes the stale op
+            from the exception alone. Head ONLY — rf2-01ihi keeps the raw payload
+            BODY off the exception entirely."
+    (rf/reg-event :ops/secret   (fn [_ _] {:db {}}))
+    (rf/reg-sub   :ops/secret-q (fn [db _] db))
+    ;; A sensitive body the exception must NEVER carry; only the head survives.
+    (let [secret-body  {:password :TOP-SECRET}
+          secret-value :TOP-SECRET]
+      (doseq [[op invoke head]
+              [[:dispatch      (fn [b] ((:dispatch b) [:ops/secret secret-body]))      :ops/secret]
+               [:dispatch-sync (fn [b] ((:dispatch-sync b) [:ops/secret secret-body])) :ops/secret]
+               [:subscribe     (fn [b] ((:subscribe b) [:ops/secret-q secret-body]))   :ops/secret-q]]]
+        (testing (str "stale " op)
+          (make-frame! :ops/doomed {})
+          (let [b (rf/with-frame :ops/doomed (frames/frame-ops))]
+            (frame/destroy-frame! :ops/doomed)
+            (let [data (ex-data-of #(invoke b))]
+              (is (= :rf.error/frame-destroyed (:rf.error/id data))
+                  "the stale op fails loud with the canonical typed error")
+              (is (= :ops/doomed (:frame data)) ":extra carries the captured frame id")
+              (is (= op (:op data))             ":extra carries the failing op")
+              ;; THE FIX (red before rf2-r79gr — :event-id absent from :extra):
+              (is (= head (:event-id data))
+                  ":extra carries the STRUCTURAL event/query head (rf2-r79gr)")
+              ;; rf2-01ihi INTACT: only the head rides the exception, never the body.
+              (is (not (deep-contains? data secret-body))
+                  "the raw payload BODY never rides the thrown exception")
+              (is (not (deep-contains? data secret-value))
+                  "no sensitive leaf from the payload reaches the exception ex-data"))))))))
+
+;; ===========================================================================
 ;; rf2-vxgfnd.231 — the cross-frame carried-subscribe HONESTY warning.
 ;;
 ;; A `(frame)` operation bundle captured under frame A can be CARRIED across a


### PR DESCRIPTION
## What

Follow-up from **rf2-xgkgx** (PR #6131, merged). The typed stale-op exception thrown by `re-frame.ui.frames/emit-and-throw-frame-destroyed!` now carries the structural event/query **HEAD** as `:extra :event-id`, completing the xgkgx acceptance.

### Evaluation (not verified-redundant)

The bead asked to evaluate first whether 01ihi already carries the head. It does — but only on the **always-on record** (`emit-error-both!`'s `:event-id` positional arg). The **thrown exception**'s `:extra` carried only `{:frame :op}` — no head. These are distinct surfaces with distinct consumers: a synchronous `try/catch` around a stale `(frame)` op sees only the exception's ex-data, not the async record stream. Adding the head to `:extra` brings the exception into parity with the record, so a catcher can attribute the failing event/query from the exception alone.

### Change

`emit-and-throw-frame-destroyed!` binds the head once (the attempted vector's first element) and rides it on **both** surfaces — the record's `:event-id` slot and the thrown exception's `:extra :event-id`.

### rf2-01ihi fail-closed policy — INTACT

Head only, never the body. The raw payload BODY is still redacted to `:rf/redacted` at source and never rides the exception. No successor elision policy can be borrowed to egress a dead incarnation's payload. The new test proves the raw payload body (and any sensitive leaf) reaches the exception ex-data **nowhere**, across dispatch / dispatch-sync / subscribe.

## Quality gates

All foreground, unpiped.

- **Red-before/green-after** (`re-frame.ui.frame-ops-cljs-test`, JVM): with `:event-id` removed from `:extra`, the new test goes **red** — 3 failures (`(:event-id data)` is nil for dispatch / dispatch-sync / subscribe) while the redaction assertions stay green; with the head restored, **green**.
- **`implementation/ui` JVM** (`clojure -M:test`): 712 tests / 13569 assertions — 0 failures, 0 errors. Includes the rf2-01ihi reincarnation-elision redaction proof.
- **`implementation/core` JVM** (`clojure -M:test`, error-catalogue conformance): 2032 tests / 9474 assertions — 0 failures, 0 errors. No new error-id, so no catalogue change.
- **`npm run test:cljs`**: 9764 tests / 47980 assertions — 0 failures, 0 errors. Exercises the `.cljc` test on the CLJS host too.

Did not run `test:browser` or the full spine per brief.
