### PR TITLE
fix(ui): preserve falsy failures across the four UI teardown boundaries (rf2-s2cfv)

### DIFF
--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -1348,6 +1348,14 @@
         (throw e))))
   nil)
 
+;; PRESENCE, not JS truthiness, decides whether a container-reclaim step failed
+;; (rf2-s2cfv). A reclaim step can throw a legitimately falsy value (false/nil);
+;; the failure slot holds this identity sentinel until a throw records into it, so
+;; the FIRST failure is preserved by presence — a later step never overwrites a
+;; falsy first failure, and a falsy failure is still rethrown rather than silently
+;; swallowed.
+(defonce ^:private no-reclaim-failure #js {})
+
 (defn- reclaim-consumed-container!
   "Adapter-disposal fallback after a public Root's host unmount threw.
 
@@ -1356,10 +1364,13 @@
   supported retry through the consumed handle. The adapter owns the terminal
   process teardown, so it clears both pieces against the PINNED React host;
   this makes DOM-empty + same-container re-init deterministic. Any fallback
-  failure propagates as secondary cleanup evidence, never over the host error."
+  failure propagates as secondary cleanup evidence, never over the host error.
+  The FIRST reclaim failure is preserved BY PRESENCE (not truthiness), so a
+  legitimately falsy thrown value (false/nil) is neither overwritten by a later
+  step nor silently swallowed at the rethrow (rf2-s2cfv)."
   [^Root root]
   (let [container (.-container root)
-        failure   (volatile! nil)]
+        failure   (volatile! no-reclaim-failure)]
     (when container
       (try
         (if (fn? (.-replaceChildren container))
@@ -1372,8 +1383,11 @@
           (when (str/starts-with? k "__reactContainer$")
             (js/Reflect.deleteProperty container k)))
         (catch :default e
-          (when-not @failure (vreset! failure e)))))
-    (when @failure (throw @failure))
+          ;; keep the FIRST failure by PRESENCE — never let this secondary step
+          ;; overwrite a falsy (false/nil) first failure.
+          (when (identical? @failure no-reclaim-failure) (vreset! failure e)))))
+    ;; rethrow by PRESENCE so a falsy first failure still propagates.
+    (when-not (identical? @failure no-reclaim-failure) (throw @failure))
     nil))
 
 (defn with-root-admission-closed!
@@ -1469,14 +1483,27 @@
                   (release-root! root-id root)
                   (catch :default recovery-error
                     (vswap! errors conj recovery-error)))))))))
-    (when-let [primary (first @errors)]
-      (when (< 1 (count @errors))
-        (try
-          (js/Object.defineProperty
-           primary "rfUiAdapterCleanupErrors"
-           #js {:value (to-array (rest @errors)) :configurable true})
-          (catch :default _ nil)))
-      (throw primary)))
+    ;; PRESENCE (seq/count), not truthiness: a non-empty error vector whose FIRST
+    ;; payload is falsy (false/nil) must still rethrow — `when-let` on `(first …)`
+    ;; would suppress the whole set (rf2-s2cfv).
+    (when (seq @errors)
+      (let [primary (first @errors)]
+        (when (< 1 (count @errors))
+          (try
+            (js/Object.defineProperty
+             primary "rfUiAdapterCleanupErrors"
+             #js {:value (to-array (rest @errors)) :configurable true})
+            (catch :default _
+              ;; a primitive primary (nil/false/number) cannot carry a diagnostic
+              ;; property; keep the later failures observable via console instead,
+              ;; and rethrow the primary unchanged.
+              (when (exists? js/console)
+                (.warn js/console
+                       (str "[re-frame.ui] adapter cleanup errors could not ride "
+                            "the primitive primary rejection; the primary is "
+                            "rethrown unchanged. Later cleanup errors:")
+                       (to-array (rest @errors)))))))
+        (throw primary))))
   nil)
 
 (defn dispose-live-roots!

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -3200,6 +3200,16 @@
     #?(:cljs (queue-microtask! settle)
        :clj  (settle))))
 
+;; PRESENCE, not JS truthiness, decides whether the host `.unmount` thunk threw
+;; (rf2-s2cfv). On CLJS a thunk can throw a legitimately falsy value (false/nil);
+;; `host-error` holds this identity sentinel until a throw records into it, so
+;; such a failure is a REAL, preserved host error — reaped fail-closed over the
+;; exact generation and rethrown — never reclassified as a success/deferred
+;; teardown that settles and releases ownership. Cross-host: a bare Object on the
+;; JVM, a fresh JS object on CLJS; compared only by `identical?`.
+(def ^:private no-host-error
+  #?(:clj (Object.) :cljs #js {}))
+
 (defn teardown-root!
   "Explicit host/ROOT teardown driver (03 §4) — the root-path counterpart to
   the frame-destroy sweep, driven from `re-frame.ui.client/unmount!*` at the
@@ -3307,7 +3317,7 @@
    (let [prev       @teardown-collector
          prev-sig   @teardown-settle-signal
          fired      (volatile! false)
-         host-error (volatile! nil)
+         host-error (volatile! no-host-error)
          captured   (volatile! #{})
          _          (do
                       (reset! teardown-collector #{})
@@ -3327,6 +3337,9 @@
                           (reset! teardown-collector prev)
                           (reset! teardown-settle-signal prev-sig))))
          collected  @captured
+         ;; PRESENCE, not truthiness: a throw of a falsy value (false/nil) still
+         ;; counts as a host failure (rf2-s2cfv).
+         host-threw? (not (identical? @host-error no-host-error))
          explicit?  (some? root-incarnation)
          ;; When an explicit root incarnation is named it is AUTHORITATIVE: this
          ;; teardown owns EXACTLY the cells of that generation (rf2-vxgfnd.156).
@@ -3364,7 +3377,7 @@
                          (comp (mapcat #(weak-live (get @root-cells %) %))
                                (filter #(= :disconnected (lifecycle %))))
                          incs)
-         victims   (if (and @host-error explicit?)
+         victims   (if (and host-threw? explicit?)
                      ;; The host handle is consumed/released even on this path.
                      ;; Fail closed over the EXACT root generation, including
                      ;; cells still connected because React ran no cleanup.
@@ -3382,12 +3395,12 @@
          ;; layout effect) is not a member, so it has no pending host teardown to
          ;; await and settles synchronously. `collected` no longer classifies — it
          ;; only drives the reap (`owned`/`hidden`/`victims`).
-         deferred? (and explicit? (not @host-error) (not @fired)
+         deferred? (and explicit? (not host-threw?) (not @fired)
                         (contains? @live-reporters root-incarnation))]
      (doseq [cell victims]
        (teardown! cell))
      (cond
-       @host-error
+       host-threw?
        ;; rf2-vxgfnd.275 — the exact generation is force-dead (victims) above;
        ;; on-settled is NOT fired. The host teardown threw, so the container is
        ;; NOT proven free: the client FAILS CLOSED in its own catch, leaving the

--- a/implementation/ui/src/re_frame/ui/substrate.cljs
+++ b/implementation/ui/src/re_frame/ui/substrate.cljs
@@ -106,15 +106,54 @@
    spine-fns
    {:kind :rf.adapter/ui :frame-provider frame-provider-component}))
 
+;; PRESENCE, not JS truthiness, decides whether the public-root drain and the
+;; generic spine dispose failed (rf2-s2cfv). Either can throw a legitimately falsy
+;; value (false/nil); each slot holds this identity sentinel until a throw records
+;; into it, so a falsy failure is preserved — thrown in primary order, never lost
+;; to a truthy `cond`. Compared only by `identical?`.
+(defonce ^:private no-dispose-error #js {})
+
 (defn- attach-secondary-cleanup!
-  [primary secondary]
-  (when (and primary secondary)
-    (try
-      (js/Object.defineProperty
-       primary "rfUiAdapterCleanupError"
-       #js {:value secondary :configurable true})
-      (catch :default _ nil)))
+  "Preserve `primary` as the thrown value; when a secondary cleanup failure is
+  PRESENT (not merely truthy), retain it on the primary as
+  `rfUiAdapterCleanupError` for diagnostics. Presence — not truthiness — gates the
+  attach, so a falsy secondary is real. A primitive primary (nil/false/number)
+  cannot carry a property, so the secondary rides the always-on console diagnostic
+  instead and stays observable. `primary` is returned UNCHANGED either way — never
+  coerced or replaced (rf2-s2cfv)."
+  [primary secondary-present? secondary]
+  (when secondary-present?
+    (let [attached?
+          (try
+            (js/Object.defineProperty
+             primary "rfUiAdapterCleanupError"
+             #js {:value secondary :configurable true})
+            true
+            (catch :default _ false))]
+      (when (and (not attached?) (exists? js/console))
+        (.warn js/console
+               (str "[re-frame.ui] an adapter spine cleanup failure could not "
+                    "ride the primary rejection (a primitive reason cannot carry "
+                    "a diagnostic property); the primary is rethrown unchanged. "
+                    "Secondary cleanup error:")
+               secondary))))
   primary)
+
+(defn ^:no-doc dispose-outcome
+  "The disposal outcome policy, decided by failure PRESENCE (never JS truthiness):
+  a public-root drain failure is PRIMARY (a present spine failure rides it as a
+  diagnostic), else a spine-only failure is thrown, else disposal is clean.
+  `root-present?`/`spine-present?` are decided by presence at the call site, so a
+  legitimately falsy drain/spine failure (false/nil) is preserved and correctly
+  ordered. Returns `[:throw reason]` or `[:ok]`. Extracted as the ONE place the
+  presence decision lives, so it is unit-checkable off the DOM (rf2-s2cfv)."
+  [root-present? root-error spine-present? spine-error]
+  (cond
+    root-present?
+    [:throw (attach-secondary-cleanup! root-error spine-present? spine-error)]
+
+    spine-present? [:throw spine-error]
+    :else          [:ok]))
 
 (defn- dispose-adapter!
   "Dispose public compiled roots first, then the generic React spine. Both
@@ -125,8 +164,8 @@
   [with-root-admission-closed! drain-live-roots!]
   (with-root-admission-closed!
    (fn []
-     (let [root-error  (volatile! nil)
-           spine-error (volatile! nil)]
+     (let [root-error  (volatile! no-dispose-error)
+           spine-error (volatile! no-dispose-error)]
        (try
          (drain-live-roots!)
          (catch :default e
@@ -135,12 +174,13 @@
          ((:dispose-adapter! spine-adapter))
          (catch :default e
            (vreset! spine-error e)))
-       (cond
-         @root-error
-         (throw (attach-secondary-cleanup! @root-error @spine-error))
-
-         @spine-error (throw @spine-error)
-         :else nil)))))
+       ;; PRESENCE-decided (rf2-s2cfv): a falsy drain/spine failure (false/nil) is
+       ;; preserved, thrown in primary order, and never lost to a truthy `cond`.
+       (let [[outcome reason]
+             (dispose-outcome
+              (not (identical? @root-error no-dispose-error))  @root-error
+              (not (identical? @spine-error no-dispose-error)) @spine-error)]
+         (when (= :throw outcome) (throw reason)))))))
 
 (defn- ui-flush-render!
   "The first-party adapter's `:flush-render!` — the ViewCell-settling override of

--- a/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc
@@ -458,6 +458,61 @@
         "the consumed incarnation is removed from root ownership")))
 
 ;; ===========================================================================
+;; rf2-s2cfv — a host `.unmount` that throws a FALSY value (false/nil) is a REAL
+;; host failure, tracked by PRESENCE not JS truthiness: the exact generation is
+;; force-dead (fail-closed), the identical falsy value is rethrown, and it is
+;; never taken for a success/deferred teardown. CLJS-only — the JVM cannot
+;; `throw` a non-Throwable, so a falsy host error is a JS-runtime concern.
+;; ===========================================================================
+
+#?(:cljs
+   (deftest throwing-a-false-host-unmount-force-deads-the-generation-and-rethrows
+     (rf/reg-sub :rt/a (fn [db _] (:a db)))
+     (let [fid     (make-frame! :rt/frame {:a 1})
+           inc     (reactive/make-root-incarnation)
+           cell    (doto (render+commit! (reactive/make-cell ::v) fid [[:rt/a]])
+                     (reactive/attach-root! inc))
+           outcome (try (reactive/teardown-root! inc (fn [] (throw false)))
+                        [::settled]
+                        (catch :default e [::threw e]))]
+       (is (= [::threw false] outcome)
+           "the falsy host error is rethrown, never swallowed by truthiness")
+       (is (= :dead (reactive/lifecycle cell))
+           "the exact consumed generation is force-dead — the fail-closed sweep ran")
+       (is (nil? (ref-count fid [:rt/a])) "force-dead released the observation owner")
+       (is (zero? (reactive/root-cell-count inc)) "the consumed incarnation is dropped"))))
+
+#?(:cljs
+   (deftest throwing-a-nil-host-unmount-force-deads-the-generation-and-rethrows
+     (rf/reg-sub :rt/a (fn [db _] (:a db)))
+     (let [fid     (make-frame! :rt/frame {:a 1})
+           inc     (reactive/make-root-incarnation)
+           cell    (doto (render+commit! (reactive/make-cell ::v) fid [[:rt/a]])
+                     (reactive/attach-root! inc))
+           outcome (try (reactive/teardown-root! inc (fn [] (throw nil)))
+                        [::settled]
+                        (catch :default e [::threw e]))]
+       (is (= [::threw nil] outcome)
+           "a nil host error is rethrown, never taken for a clean/deferred teardown")
+       (is (= :dead (reactive/lifecycle cell)) "the exact generation is force-dead")
+       (is (nil? (ref-count fid [:rt/a])))
+       (is (zero? (reactive/root-cell-count inc))))))
+
+#?(:cljs
+   (deftest throwing-a-false-host-unmount-without-generation-rethrows-without-guessing
+     (rf/reg-sub :rt/a (fn [db _] (:a db)))
+     (let [fid     (make-frame! :rt/frame {:a 1})
+           cell    (render+commit! (reactive/make-cell ::v) fid [[:rt/a]])
+           outcome (try (reactive/teardown-root! (fn [] (throw false)))
+                        [::settled]
+                        (catch :default e [::threw e]))]
+       (is (= [::threw false] outcome)
+           "the original falsy host error propagates, never masked")
+       (is (= :connected (reactive/lifecycle cell))
+           "no generation evidence → the orphaned cell is not falsely killed")
+       (is (= 1 (ref-count fid [:rt/a]))))))
+
+;; ===========================================================================
 ;; rf2-vxgfnd.182 — the DEFERRED-vs-SYNCHRONOUS host-teardown discriminator
 ;;
 ;; react-dom 19.2 refuses a SYNCHRONOUS unmount from inside render/commit: the

--- a/implementation/ui/test/re_frame/ui/teardown_falsy_failure_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/teardown_falsy_failure_cljs_test.cljs
@@ -1,0 +1,202 @@
+(ns re-frame.ui.teardown-falsy-failure-cljs-test
+  "rf2-s2cfv — falsy failure preservation across the UI teardown boundaries.
+
+  On CLJS a thrown value need not be a truthy Error: JS lets code `throw false`
+  or `throw nil`. PR #5965 taught `re-frame.ui.test/with-root` to track cleanup
+  failures by PRESENCE (an identity sentinel) rather than JS truthiness; this
+  fixture pins the same presence discipline at the four production teardown
+  boundaries so a falsy failure is never swallowed, overwritten, or misrouted:
+
+    - `client/reclaim-consumed-container!` — a falsy FIRST reclaim failure is not
+      overwritten by a later step and is still rethrown.
+    - `client/drain-live-roots!` — a non-empty error set whose PRIMARY is falsy
+      still rethrows (never suppressed by `when-let`), and later failures stay
+      observable even for a primitive primary.
+    - `substrate/dispose-outcome` — the extracted presence decision for
+      `dispose-adapter!`: a falsy public-root/spine failure is preserved and
+      correctly ordered (public-root primary over spine).
+    - `substrate/attach-secondary-cleanup!` — a falsy secondary is attached by
+      presence; a primitive primary keeps it observable via console.
+
+  Runs off the DOM under `npm run test:cljs` (node): the boundaries are exercised
+  with fake Root/container objects and the extracted pure deciders."
+  (:require [cljs.test :refer [deftest is testing use-fixtures]]
+            [re-frame.ui.client :as client]
+            [re-frame.ui.substrate :as substrate]))
+
+(use-fixtures :each
+  (fn [f]
+    (client/reset-live-roots!)
+    (try (f) (finally (client/reset-live-roots!)))))
+
+(defn- catch-throw
+  "Run `thunk`, returning `[::threw v]` for the thrown value `v` (including a
+  falsy one) or `[::no-throw ret]` when it returns — so a swallowed falsy failure
+  is distinguishable from a rethrown one."
+  [thunk]
+  (try [::no-throw (thunk)] (catch :default e [::threw e])))
+
+(defn- with-warn-spy
+  "Run `f` with `js/console.warn` captured; returns the vector of `[msg detail]`
+  arg pairs it was called with."
+  [f]
+  (let [calls (atom [])
+        orig  (.-warn js/console)]
+    (set! (.-warn js/console) (fn [msg detail] (swap! calls conj [msg detail])))
+    (try (f) (finally (set! (.-warn js/console) orig)))
+    @calls))
+
+(defn- reclaim! [root]
+  (#'client/reclaim-consumed-container! root))
+
+;; ===========================================================================
+;; client/reclaim-consumed-container! — a falsy first reclaim failure is neither
+;; swallowed at the rethrow nor overwritten by a later step.
+;; ===========================================================================
+
+(deftest reclaim-rethrows-a-falsy-first-cleanup-failure
+  (testing "a FALSE first-step failure is rethrown, not swallowed by truthiness"
+    (let [container #js {}
+          _         (set! (.-replaceChildren container) (fn [] (throw false)))
+          root      (client/->Root nil container nil)]
+      (is (= [::threw false] (catch-throw #(reclaim! root))))))
+  (testing "a NIL first-step failure is rethrown"
+    (let [container #js {}
+          _         (set! (.-replaceChildren container) (fn [] (throw nil)))
+          root      (client/->Root nil container nil)]
+      (is (= [::threw nil] (catch-throw #(reclaim! root)))))))
+
+(deftest reclaim-keeps-the-falsy-first-failure-over-a-later-truthy-one
+  ;; First step throws FALSE; the marker-deletion step then throws an Error. The
+  ;; falsy first failure must be preserved by presence — a later truthy failure
+  ;; must not overwrite it.
+  (let [second-boom (js/Error. "marker deletion failed")
+        base        #js {}
+        _           (set! (.-replaceChildren base) (fn [] (throw false)))
+        _           (js/Object.defineProperty
+                     base "__reactContainer$1"
+                     #js {:value 1 :enumerable true :configurable true})
+        container   (js/Proxy. base
+                               #js {:deleteProperty (fn [_ _] (throw second-boom))})
+        root        (client/->Root nil container nil)]
+    (is (= [::threw false] (catch-throw #(reclaim! root)))
+        "the falsy FIRST failure wins — never overwritten by the later Error")))
+
+(deftest reclaim-is-clean-when-both-steps-succeed
+  (let [container #js {}
+        _         (set! (.-replaceChildren container) (fn [] nil))
+        root      (client/->Root nil container nil)]
+    (is (= [::no-throw nil] (catch-throw #(reclaim! root)))
+        "a repaired container reclaims cleanly and returns nil")))
+
+;; ===========================================================================
+;; client/drain-live-roots! — a non-empty error set with a FALSY primary still
+;; rethrows, and later failures stay observable for a primitive primary.
+;; ===========================================================================
+
+(defn- quarantined-entry
+  "A live-root registry entry already `:cleanup-failure?` quarantined, whose
+  terminal container reclaim throws `boom` (drain takes the `quarantined?` branch
+  → `reclaim-consumed-container!`)."
+  [root-id boom]
+  (let [container #js {}
+        _         (set! (.-replaceChildren container) (fn [] (throw boom)))
+        root      (client/->Root nil container root-id)]
+    {:root root
+     :root-id root-id
+     :tearing-down? true
+     :cleanup-failure? true
+     :root-incarnation (js/Object.)}))
+
+(defn- seed-live-roots! [entries-map]
+  (reset! @#'client/live-roots entries-map))
+
+(deftest drain-rethrows-a-falsy-primary-cleanup-failure
+  (testing "a single reclaim failure of FALSE still rethrows — not suppressed"
+    (seed-live-roots! (array-map :falsy-drain/one (quarantined-entry :falsy-drain/one false)))
+    (is (= [::threw false] (catch-throw client/drain-live-roots!))))
+  (testing "a single reclaim failure of NIL still rethrows"
+    (seed-live-roots! (array-map :falsy-drain/one (quarantined-entry :falsy-drain/one nil)))
+    (is (= [::threw nil] (catch-throw client/drain-live-roots!)))))
+
+(deftest drain-keeps-a-falsy-primary-and-keeps-later-errors-observable
+  ;; Two quarantined roots: the FIRST reclaim throws FALSE, the second throws an
+  ;; Error. The falsy primary must be rethrown (ordering preserved), and because a
+  ;; primitive primary cannot carry the `rfUiAdapterCleanupErrors` diagnostic
+  ;; array, the later error rides a console warning so it stays observable.
+  (let [second-boom (js/Error. "second root cleanup failed")]
+    (seed-live-roots!
+     (array-map
+      :falsy-drain/primary   (quarantined-entry :falsy-drain/primary false)
+      :falsy-drain/secondary (quarantined-entry :falsy-drain/secondary second-boom)))
+    (let [thrown (atom nil)
+          warns  (with-warn-spy
+                   #(reset! thrown (catch-throw client/drain-live-roots!)))]
+      (is (= [::threw false] @thrown)
+          "the falsy PRIMARY is rethrown ahead of the later Error")
+      (is (= 1 (count warns)) "the primitive-primary fallback logged exactly one warning")
+      (is (= second-boom (aget (second (first warns)) 0))
+          "…the later error rides the console warning so it stays observable"))))
+
+;; ===========================================================================
+;; substrate/dispose-outcome — the extracted presence decision for
+;; dispose-adapter!: a falsy public-root/spine failure is preserved and ordered.
+;; ===========================================================================
+
+(def ^:private absent-marker (js/Object.))
+
+(defn- outcome [root-present? root-error spine-present? spine-error]
+  (#'substrate/dispose-outcome root-present? root-error spine-present? spine-error))
+
+(deftest dispose-outcome-preserves-a-falsy-public-root-failure
+  (testing "a FALSE public-root drain failure is thrown, never taken for clean"
+    (is (= [:throw false] (outcome true false false absent-marker))))
+  (testing "a NIL public-root drain failure is thrown"
+    (is (= [:throw nil] (outcome true nil false absent-marker)))))
+
+(deftest dispose-outcome-preserves-a-falsy-spine-only-failure
+  (testing "a FALSE spine-only failure is thrown, never taken for clean"
+    (is (= [:throw false] (outcome false absent-marker true false))))
+  (testing "a NIL spine-only failure is thrown"
+    (is (= [:throw nil] (outcome false absent-marker true nil)))))
+
+(deftest dispose-outcome-orders-a-falsy-public-root-ahead-of-the-spine
+  ;; Both halves failed and the public-root failure is FALSE: it must remain
+  ;; primary (a truthiness cond would let the truthy spine error win the throw).
+  (let [spine-boom (js/Error. "spine dispose failed")
+        [tag reason] (outcome true false true spine-boom)]
+    (is (= :throw tag))
+    (is (= false reason) "the falsy public-root failure stays primary over the spine error")))
+
+(deftest dispose-outcome-is-clean-when-neither-half-failed
+  (is (= [:ok] (outcome false absent-marker false absent-marker))
+      "no present failure → clean disposal, never a spurious throw"))
+
+;; ===========================================================================
+;; substrate/attach-secondary-cleanup! — a falsy secondary is attached by
+;; presence; a primitive primary keeps it observable via console.
+;; ===========================================================================
+
+(defn- attach [primary secondary-present? secondary]
+  (#'substrate/attach-secondary-cleanup! primary secondary-present? secondary))
+
+(deftest attach-secondary-attaches-a-present-falsy-secondary
+  (let [primary (js/Error. "public root failed")]
+    (is (identical? primary (attach primary true false)) "the primary is returned unchanged")
+    (is (= false (.-rfUiAdapterCleanupError primary))
+        "a PRESENT but falsy secondary is attached by presence, not truthiness")))
+
+(deftest attach-secondary-skips-an-absent-secondary
+  (let [primary (js/Error. "public root failed")]
+    (is (identical? primary (attach primary false nil)))
+    (is (undefined? (.-rfUiAdapterCleanupError primary))
+        "no secondary present → nothing attached")))
+
+(deftest attach-secondary-keeps-a-secondary-observable-for-a-primitive-primary
+  ;; A primitive primary (false) cannot carry a defineProperty diagnostic, so the
+  ;; secondary must ride a console warning instead — the primary is unchanged.
+  (let [secondary (js/Error. "spine failed")
+        warns     (with-warn-spy #(is (= false (attach false true secondary))))]
+    (is (= 1 (count warns)) "exactly one fallback warning was logged")
+    (is (= secondary (second (first warns)))
+        "…carrying the secondary so it stays observable")))


### PR DESCRIPTION
## Summary

PR #5965 taught `re-frame.ui.test/with-root` to track cleanup failures by **presence** (an identity sentinel) rather than JS truthiness, but four production teardown boundaries stayed truthiness-based. On CLJS a thunk can `throw false`/`throw nil`, so a legitimately falsy failure was swallowed, overwritten, or misrouted — taking the success/deferred path, missing the fail-closed sweep, and never rethrowing.

This applies the same presence convention (a captured-none sentinel) to all four sites — no new error-handling framework.

### The four truthiness sites (file:line before → after)

- **`reactive/teardown-root!`** (`implementation/ui/src/re_frame/ui/reactive.cljc`): `host-error` was `(volatile! nil)` with truthy branches, so a `throw false`/`nil` took the success/deferred victim path, missed the exact-root fail-closed sweep, settled/released ownership, and never rethrew. Now a `no-host-error` sentinel + a `host-threw?` presence check drive `victims`, `deferred?`, and the rethrow.
- **`client/reclaim-consumed-container!`** (`implementation/ui/src/re_frame/ui/client.cljs`): a falsy first cleanup failure could be overwritten by the marker-deletion step and was never rethrown. Now a `no-reclaim-failure` sentinel preserves the first failure by presence and rethrows it.
- **`client/drain-live-roots!`** (`implementation/ui/src/re_frame/ui/client.cljs`): `when-let` on `(first @errors)` suppressed a non-empty error vector whose primary is `false`/`nil`. Now `seq`/`count` decides the rethrow, and a primitive primary keeps later errors observable via a console fallback.
- **`substrate/dispose-adapter!`** (`implementation/ui/src/re_frame/ui/substrate.cljs`): nil slots + a truthy `cond` lost failures and primary ordering. Extracted `dispose-outcome` — the ONE presence decision, unit-checkable off the DOM (mirroring `with-root-outcome`) — plus a `no-dispose-error` sentinel; `attach-secondary-cleanup!` now gates on secondary **presence** with a primitive-safe console fallback.

No compiler (`analyze`/`emit`/`route-link`) or `frames.cljc` code was touched (coupled-lane fence respected).

## Tests

Focused node/JVM tests cover nil, false, Error, and mixed primary/secondary order at every boundary:

- `implementation/ui/test/re_frame/ui/reactive_root_teardown_cljs_test.cljc` — CLJS-only falsy `teardown-root!` tests (explicit-generation false/nil fail-closed + rethrow; one-arity false rethrow-without-guessing). The JVM cannot `throw` a non-Throwable, so falsy host errors are a JS-runtime concern.
- `implementation/ui/test/re_frame/ui/teardown_falsy_failure_cljs_test.cljs` (new, node) — `reclaim-consumed-container!` (falsy swallow + falsy-first-over-later-truthy ordering + clean path), `drain-live-roots!` (falsy primary rethrow + primitive-primary observability), `dispose-outcome` (falsy public-root/spine preservation + ordering + clean), `attach-secondary-cleanup!` (present-falsy attach + primitive-primary console fallback).

## Quality gates

Run in foreground, unpiped, from `implementation/`:

- **`implementation/ui` JVM** (`clojure -M:test`): **711 tests, 13541 assertions, 0 failures, 0 errors** (green-after).
- **`npm run test:cljs`** (full node-test): **9778 tests, 47996 assertions, 0 failures, 0 errors** (green-after). Focused `npm run test:ui`: **732 tests, 3694 assertions, 0 failures**.

**Red-before / green-after** per site (bug re-introduced surgically, presence → truthiness):

| Site | Red-before (buggy) | Green-after (fix) |
|---|---|---|
| `teardown-root!` | 9 failures — `throw false`/`nil` returns `[::settled]`, cell `:connected`, ref-count retained, not rethrown | pass |
| `reclaim-consumed-container!` + `drain-live-roots!` | 7 failures — falsy failures swallowed / suppressed by `when-let` | pass |
| `dispose-outcome` + `attach-secondary-cleanup!` | 7 failures — falsy public-root/spine failures lost / misordered; falsy secondary not attached | pass |

`test:browser` and the full spine were not run (per scope).
