### PR TITLE
fix(adapter): make SSR emitter replay failure-atomic, routed, precedence-safe (rf2-h9szm)

### DIFF
--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_late_bind_publication_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_late_bind_publication_cljs_test.cljs
@@ -12,8 +12,10 @@
         `:adapter/current-frame`, `:adapter/current-component`,
         `:adapter/ratom`, `:adapter/ratom?`,
         `:adapter/make-reaction`, `:adapter/add-on-dispose!`,
-        `:adapter/dispose!`, `:adapter/reactive?`, and
-        `:adapter/after-render`.
+        `:adapter/dispose!`, `:adapter/reactive?`,
+        `:adapter/after-render`, `:adapter/derived-container?`, and
+        `:adapter/arm-hiccup-emitter-if-unarmed!` (rf2-h9szm — the
+        routed, precedence-safe install-replay arm for the SSR emitter).
 
     (2) `late-bind/chain-fn!` - chained hooks where every contributor
         runs (independent of installed-adapter identity). Used for
@@ -43,6 +45,7 @@
     :adapter/reactive?
     :adapter/after-render
     :adapter/derived-container?
+    :adapter/arm-hiccup-emitter-if-unarmed!
     :reagent/set-hiccup-emitter!})
 
 (defn- producers

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -1010,6 +1010,15 @@
     :chained?    true
     :design-bead "rf2-00li"
     :description "Substrate-side source-coord injection on rendered React elements."}
+   {:key         :adapter/arm-hiccup-emitter-if-unarmed!
+    :producer-ns '[re-frame.adapter.reagent
+                   re-frame.adapter.reagent-slim
+                   re-frame.adapter.uix
+                   re-frame.adapter.helix
+                   re-frame.ui.substrate]
+    :chained?    true
+    :design-bead "rf2-h9szm"
+    :description "Precedence-safe, routed install-replay arm for the retained SSR hiccup emitter. `re-frame.substrate.adapter/install-adapter!` calls it (with the durable `:ssr/current-hiccup-emitter`) as part of its failure-atomic install transaction so a destroy → re-init cycle — or an SSR-before-adapter load order — re-arms the freshly-installed generation's `render-to-string` slot. Routed via `route-hook!` so ONLY the installed adapter's slot is re-armed (a loaded inactive adapter's arm never runs, so its throw cannot break the active boot); each adapter's impl arms its per-generation `emitter-cell` ONLY when otherwise unarmed, so a pre-init explicit custom emitter / reset is not silently overwritten by the retained default. Distinct from the broadcast `:reagent/set-hiccup-emitter!` chain the earlier replay used (rf2-h9szm). Not published by plain-atom / test-react, whose emitters are retained across a no-op dispose (no re-arm required)."}
 
    ;; ===========================================================================
    ;; GROUP 4 — HOT-RELOAD / DEV-TOOLING

--- a/implementation/core/src/re_frame/substrate/adapter.cljc
+++ b/implementation/core/src/re_frame/substrate/adapter.cljc
@@ -75,28 +75,46 @@
   (atom {:installed nil :disposed? false}))
 
 (defn- rearm-hiccup-emitter!
-  "Replay the retained SSR hiccup emitter (rf2-vxgfnd.204) into the freshly-
-  installed adapter generation. `re-frame.ssr.emit` publishes the current
-  emitter durably under `:ssr/current-hiccup-emitter` at ns-load; the React-
-  shaped adapters (re-frame.ui, UIx, Helix) clear their per-generation
-  `emitter-cell` on `dispose-adapter!`, so a public destroy → re-init cycle —
-  or an SSR-before-adapter load order — would otherwise leave `render-to-string`
+  "Re-arm the retained SSR hiccup emitter (rf2-vxgfnd.204) into the freshly-
+  installed adapter generation — ROUTED to that generation ALONE and
+  PRECEDENCE-SAFE (rf2-h9szm). `re-frame.ssr.emit` retains the current emitter
+  durably under `:ssr/current-hiccup-emitter` at ns-load; the React-shaped
+  adapters (re-frame.ui, UIx, Helix) and the ratom family (Reagent /
+  reagent-slim) clear their per-generation `emitter-cell` on
+  `dispose-adapter!`, so a public destroy → re-init cycle — or an
+  SSR-before-adapter load order — would otherwise leave `render-to-string`
   unarmed (`:rf.error/no-hiccup-emitter-bound`).
 
-  Re-applies through the adapter-agnostic `:reagent/set-hiccup-emitter!` chain
-  (the same mechanism a single `(require 're-frame.ssr)` uses to auto-wire every
-  loaded adapter's slot), so the installed adapter's slot is re-armed from the
-  single authoritative source rather than from any adapter-retained state.
-  Idempotent and stale-safe: it always applies the SAME current emitter and
-  never clears, so it cannot overwrite a replacement generation's slot with a
-  disposed generation's emitter. A no-op when re-frame.ssr is not loaded (the
-  durable slot is unset) — `render-to-string` then throws the honest
-  `:rf.error/no-hiccup-emitter-bound` — and on hosts whose adapters do not chain
-  the hook (the JVM/plain-atom emitter is retained across its no-op dispose)."
+  Applies through the `:adapter/arm-hiccup-emitter-if-unarmed!` late-bind hook
+  each React/ratom adapter publishes via `route-hook!` — NOT the adapter-
+  agnostic `:reagent/set-hiccup-emitter!` broadcast the earlier shape used
+  (rf2-h9szm). Two consequences:
+
+    1. ROUTED — the hook dispatches to the (rf/init!)-installed adapter ALONE
+       (per `route-hook!` stable-token routing). A loaded-but-inactive adapter's
+       setter never runs, so its throw cannot break the ACTIVE adapter's boot.
+       The earlier broadcast re-armed EVERY loaded adapter and let any one
+       adapter's throwing setter propagate through the whole install.
+    2. PRECEDENCE-SAFE — the hook arms the slot ONLY when it is otherwise
+       unarmed. A pre-init explicit custom emitter (or reset) is therefore NOT
+       silently overwritten by the retained default; the explicit direct
+       override remains authoritative (per Spec 006 §`set-hiccup-emitter!`
+       last-call-wins), and the default is supplied only to an otherwise-unarmed
+       fresh generation.
+
+  Stale-safe: it always applies the SAME current emitter and never clears, so it
+  cannot overwrite a replacement generation's slot with a disposed generation's
+  emitter. A no-op when re-frame.ssr is not loaded (the durable slot is unset) —
+  `render-to-string` then throws the honest `:rf.error/no-hiccup-emitter-bound`
+  — and on hosts whose adapters do not publish the hook (the JVM/plain-atom and
+  test-react emitters are retained across their no-op dispose, so no re-arm is
+  required). Raising is the caller's contract: `install-adapter!` runs this
+  inside its failure-atomic transaction, so a throwing arm rolls the install
+  back rather than half-installing."
   []
   (when-let [emitter (late-bind/get-fn :ssr/current-hiccup-emitter)]
-    (when-let [apply-emitter! (late-bind/get-fn :reagent/set-hiccup-emitter!)]
-      (apply-emitter! emitter))))
+    (when-let [arm-if-unarmed! (late-bind/get-fn :adapter/arm-hiccup-emitter-if-unarmed!)]
+      (arm-if-unarmed! emitter))))
 
 (defn install-adapter!
   "Install the adapter for this process. Once. A second call without an
@@ -108,7 +126,19 @@
   Re-arms the retained SSR hiccup emitter for the fresh generation
   (`rearm-hiccup-emitter!`, rf2-vxgfnd.204) so a destroy → re-init cycle — or an
   SSR-before-adapter load order — leaves `render-to-string` correctly armed
-  after disposal cleared the previous generation's emitter slot."
+  after disposal cleared the previous generation's emitter slot.
+
+  FAILURE-ATOMIC (rf2-h9szm). Seating the generation and re-arming its retained
+  SSR emitter is ONE transaction. If the re-arm throws (an inactive or the
+  active adapter's setter, or the retained emitter fn), the just-seated
+  generation is rolled back — bounded EXACT-generation cleanup (`identical?` on
+  the generation token, so a concurrent replacement install is never clobbered),
+  the re-arm exception preserved as PRIMARY, the process left in a clean
+  never-installed state so an immediate retry installs fresh. Boot is therefore
+  all-or-nothing: fully installed, or cleanly failed with a consistent adapter
+  state — never the half-installed / partial-armed boot the earlier
+  seat-then-replay order left when the replay's `:reagent/set-hiccup-emitter!`
+  broadcast propagated a step throw AFTER the generation was already seated."
   [adapter]
   (let [entry {:adapter adapter :generation (fresh-adapter-generation)}]
     (swap! adapter-lifecycle-state
@@ -120,9 +150,27 @@
                 "A second install-adapter! was called without an intervening (rf/destroy-adapter!); the existing adapter remains installed (per Spec 006 §Single adapter per process)."
                 {:extra {:installed (:adapter installed)
                          :attempted adapter}}))
-             (assoc state :installed entry :disposed? false))))
-  (rearm-hiccup-emitter!)
-  adapter)
+             (assoc state :installed entry :disposed? false)))
+    ;; The generation is now seated. Re-arm the SSR emitter as part of the SAME
+    ;; install transaction: on failure roll the EXACT generation back so a
+    ;; throwing re-arm cannot leave a half-installed / partial-armed boot
+    ;; (rf2-h9szm). The `identical?` guard bounds the cleanup to the generation
+    ;; THIS call seated — a concurrent replacement install (a different token)
+    ;; is never erased by this rollback, symmetric with `dispose-adapter!`'s
+    ;; finally. `:disposed? false` restores the never-installed diagnosis (a
+    ;; failed install disposed nothing), so a retry surfaces
+    ;; `:rf.error/no-adapter-installed`, not `:rf.error/adapter-disposed`.
+    (try
+      (rearm-hiccup-emitter!)
+      (catch #?(:clj Throwable :cljs :default) e
+        (swap! adapter-lifecycle-state
+               (fn [state]
+                 (if (identical? (:generation entry)
+                                 (get-in state [:installed :generation]))
+                   (assoc state :installed nil :disposed? false)
+                   state)))
+        (throw e)))
+    adapter))
 
 (defn current-adapter
   "Return the discriminator keyword identifying the installed adapter, or

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -2070,6 +2070,16 @@
      :dispose-adapter!            dispose-fn
      :set-hiccup-emitter!         (fn set-it! [f]
                                     (set-hiccup-emitter! emitter-cell f))
+     ;; rf2-h9szm — precedence-safe install-replay arm. Arms this generation's
+     ;; `emitter-cell` with the retained SSR default ONLY when the cell is
+     ;; otherwise unarmed, so a pre-init explicit custom emitter (or reset) is
+     ;; never silently overwritten by `install-adapter!`'s replay. Routed by the
+     ;; installed-adapter identity onto `:adapter/arm-hiccup-emitter-if-unarmed!`
+     ;; by `make-react-adapter` (below), so the replay re-arms ONLY the installed
+     ;; adapter's slot — an inactive adapter's arm never runs.
+     :arm-hiccup-emitter-if-unarmed! (fn arm-if-unarmed! [f]
+                                       (when (nil? @emitter-cell)
+                                         (set-hiccup-emitter! emitter-cell f)))
      :use-current-frame           use-current-frame
      :use-subscribe               use-subscribe
      :flush-views!                flush-views!
@@ -2216,6 +2226,14 @@
     ;; rf2-uo7v); behaviour is adapter-agnostic.
     (late-bind/chain-fn! :reagent/set-hiccup-emitter!
                          (:set-hiccup-emitter! spine-fns))
+    ;; rf2-h9szm — routed precedence-safe install-replay arm. Unlike the
+    ;; broadcast `:reagent/set-hiccup-emitter!` chain above (which every loaded
+    ;; adapter contributes to, and which `install-adapter!`'s replay must NOT
+    ;; use — one throwing setter would break the active boot), this hook is
+    ;; ROUTED via `route-hook!` so `install-adapter!`'s replay re-arms ONLY the
+    ;; installed adapter's slot, and only when it is otherwise unarmed.
+    (substrate-adapter/route-hook! adapter :adapter/arm-hiccup-emitter-if-unarmed!
+                                   (:arm-hiccup-emitter-if-unarmed! spine-fns))
     adapter))
 
 ;; ---- ratom-family spine (Reagent + reagent-slim) --------------------------
@@ -2468,7 +2486,14 @@
      ;; surface the SAME `flush-views!` Var with the SAME nil-return shape.
      :flush-views!               flush-views!
      :set-hiccup-emitter!        (fn set-it! [f]
-                                   (set-hiccup-emitter! emitter-cell f))}))
+                                   (set-hiccup-emitter! emitter-cell f))
+     ;; rf2-h9szm — precedence-safe install-replay arm (see the twin in
+     ;; `make-react-spine`). Arms this generation's `emitter-cell` with the
+     ;; retained SSR default ONLY when otherwise unarmed; routed onto
+     ;; `:adapter/arm-hiccup-emitter-if-unarmed!` by `make-ratom-adapter`.
+     :arm-hiccup-emitter-if-unarmed! (fn arm-if-unarmed! [f]
+                                       (when (nil? @emitter-cell)
+                                         (set-hiccup-emitter! emitter-cell f)))}))
 ;; rf2-6id3el: the ratom return map exposes ONLY the surfaces the adapter
 ;; assembler consumes. `make-ratom-adapter` reads none of the internal
 ;; cells; the `:active-roots-cell` / `:emitter-cell` cells stay INTERNAL to
@@ -2577,6 +2602,12 @@
     ;; string slot. `chain-fn!` (not `set-fn!`) is load-order-independent.
     (late-bind/chain-fn! :reagent/set-hiccup-emitter!
                          (:set-hiccup-emitter! spine-fns))
+    ;; rf2-h9szm — routed precedence-safe install-replay arm (twin of the
+    ;; `make-react-adapter` publication). ROUTED so `install-adapter!`'s replay
+    ;; re-arms ONLY the installed adapter's slot, and only when otherwise
+    ;; unarmed — NOT the broadcast `:reagent/set-hiccup-emitter!` chain above.
+    (substrate-adapter/route-hook! adapter :adapter/arm-hiccup-emitter-if-unarmed!
+                                   (:arm-hiccup-emitter-if-unarmed! spine-fns))
     ;; Each hook routes through `(substrate-adapter/current-adapter)` per
     ;; rf2-0d35 via `route-hook!`: this adapter's impl runs ONLY when it is
     ;; the (rf/init!)-installed one; otherwise it chains to the previously-

--- a/implementation/core/test/re_frame/adapter/ssr_emitter_replay_atomic_cljs_test.cljc
+++ b/implementation/core/test/re_frame/adapter/ssr_emitter_replay_atomic_cljs_test.cljc
@@ -1,0 +1,175 @@
+(ns re-frame.adapter.ssr-emitter-replay-atomic-cljs-test
+  "rf2-h9szm — the `install-adapter!` SSR-emitter replay is FAILURE-ATOMIC,
+  ROUTED, and PRECEDENCE-SAFE.
+
+  PR #6028 (rf2-vxgfnd.204) added install-time replay of the retained SSR
+  hiccup emitter, but the lifecycle transaction was neither failure-atomic nor
+  cleanly routed:
+
+    * `install-adapter!` SEATED the new generation, THEN called
+      `rearm-hiccup-emitter!`, whose `:reagent/set-hiccup-emitter!` BROADCAST
+      re-armed every loaded adapter. A throwing setter (for the active adapter,
+      OR any loaded inactive adapter) propagated out of the broadcast and made
+      the install throw AFTER the target generation was already seated — a
+      failed boot that nonetheless left the process installed / partial-armed.
+    * The broadcast re-armed the retained default over an already-armed slot,
+      silently clobbering a pre-init explicit custom emitter / reset.
+
+  The fix makes seat + re-arm ONE failure-atomic transaction (a throwing re-arm
+  rolls the exact generation back and rethrows the re-arm exception as primary,
+  leaving a clean never-installed state for an immediate retry), routes the
+  re-arm through the `:adapter/arm-hiccup-emitter-if-unarmed!` hook (installed
+  adapter ALONE, so an inactive adapter's throwing setter cannot break the
+  active boot), and arms only an otherwise-unarmed slot (explicit override
+  wins).
+
+  Substrate-agnostic (JVM + the :node-test CLJS gate, via .cljc). It injects the
+  durable emitter slot and the arm hook directly, so it pins the
+  `install-adapter!` lifecycle seam independently of any one substrate's real
+  emitter wiring; the real-adapter end-to-end coverage (custom override survives
+  a real ui-adapter install) lives in
+  `re-frame.ui.ssr-reinit-lifecycle-cljs-test`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.late-bind :as late-bind]
+            [re-frame.substrate.adapter :as adapter]))
+
+;; ---- fixture --------------------------------------------------------------
+;; These tests overwrite the durable SSR-emitter slot and the two emitter hooks
+;; to drive the `install-adapter!` transaction under fault injection. Snapshot
+;; and restore them (and the adapter lifecycle slot) so a real adapter's
+;; publications elsewhere in the bundle survive.
+
+(def ^:private touched-hooks
+  [:ssr/current-hiccup-emitter
+   :adapter/arm-hiccup-emitter-if-unarmed!
+   :reagent/set-hiccup-emitter!])
+
+(defn- restore-hook! [k orig]
+  (if (some? orig)
+    (late-bind/set-fn! k orig)
+    (do (swap! late-bind/hooks dissoc k)
+        (late-bind/invalidate-cache! k))))
+
+(defn- isolate-emitter-hooks [test-fn]
+  (let [saved (into {} (map (fn [k] [k (late-bind/get-fn k)])) touched-hooks)]
+    (adapter/reset-lifecycle-state-for-tests!)
+    (try
+      (test-fn)
+      (finally
+        (adapter/reset-lifecycle-state-for-tests!)
+        (doseq [k touched-hooks]
+          (restore-hook! k (get saved k)))))))
+
+(use-fixtures :each isolate-emitter-hooks)
+
+(def ^:private fake-adapter {:kind :rf.test/atomic-adapter})
+
+(defn- err-id [e]
+  #?(:clj  (:rf.error/id (ex-data e))
+     :cljs (:rf.error/id (ex-data e))))
+
+;; ---- 1. failure-atomicity: throwing re-arm cannot leave a partial boot ----
+
+(deftest a-throwing-replay-rolls-the-install-back-atomically
+  ;; Durable emitter present + the (active) arm throws → install is a no-op on
+  ;; the process slot: it rethrows the arm exception as PRIMARY and leaves no
+  ;; generation seated. Before rf2-h9szm the generation stayed seated and
+  ;; `current-adapter` reported the "failed" install as installed.
+  (late-bind/set-fn! :ssr/current-hiccup-emitter (fn [_ _] "<html/>"))
+  (late-bind/set-fn! :adapter/arm-hiccup-emitter-if-unarmed!
+                     (fn [_] (throw (ex-info "replay boom" {:marker ::boom}))))
+
+  (let [thrown (atom nil)]
+    (try
+      (adapter/install-adapter! fake-adapter)
+      (catch #?(:clj Throwable :cljs :default) e
+        (reset! thrown e)))
+
+    (testing "the re-arm exception is preserved as the primary throw"
+      (is (some? @thrown) "install-adapter! rethrew rather than swallowing")
+      (is (= ::boom (:marker (ex-data @thrown)))
+          "the ORIGINAL re-arm exception surfaced, not a masking rollback error"))
+
+    (testing "no generation is seated — the failed boot is not installed"
+      (is (nil? (adapter/current-adapter))
+          "current-adapter is nil: the seated generation was rolled back")
+      (is (nil? (adapter/current-adapter-spec)))
+      (is (false? (adapter/adapter-disposed?))
+          "a failed install disposed nothing — the never-installed diagnosis stands"))
+
+    (testing "delegation surfaces the never-installed throw, not a half-armed state"
+      (let [de (try (adapter/render-to-string [:div] {}) nil
+                    (catch #?(:clj Throwable :cljs :default) e e))]
+        (is (= :rf.error/no-adapter-installed (err-id de)))))
+
+    (testing "an immediate clean retry installs fresh"
+      (late-bind/set-fn! :adapter/arm-hiccup-emitter-if-unarmed! (fn [_] nil))
+      (is (= fake-adapter (adapter/install-adapter! fake-adapter)))
+      (is (= :rf.test/atomic-adapter (adapter/current-adapter))
+          "the rollback left a clean slot, so the retry seats normally"))))
+
+(deftest exact-generation-rollback-does-not-erase-a-replacement
+  ;; The rollback is bounded to the EXACT generation the failing install seated.
+  ;; Simulate a re-entrant install that lands a REPLACEMENT generation from
+  ;; inside the throwing arm (the arm runs while the failing generation is
+  ;; seated); the failing install's rollback must NOT clear the replacement.
+  (late-bind/set-fn! :ssr/current-hiccup-emitter (fn [_ _] "<html/>"))
+  (let [replacement {:kind :rf.test/replacement-adapter}]
+    (late-bind/set-fn! :adapter/arm-hiccup-emitter-if-unarmed!
+                       (fn [_]
+                         ;; Land a DIFFERENT generation, then fail the outer install.
+                         (adapter/reset-lifecycle-state-for-tests!)
+                         (late-bind/set-fn! :adapter/arm-hiccup-emitter-if-unarmed! (fn [_] nil))
+                         (adapter/install-adapter! replacement)
+                         (throw (ex-info "outer boom" {}))))
+    (is (thrown? #?(:clj Throwable :cljs :default)
+                 (adapter/install-adapter! fake-adapter)))
+    (is (identical? replacement (adapter/current-adapter-spec))
+        "the replacement generation survived — the stale install's rollback is exact-generation-scoped")))
+
+;; ---- 2. routing: an inactive throwing setter cannot break the active boot -
+
+(deftest inactive-throwing-broadcast-setter-cannot-break-the-active-boot
+  ;; The replay routes through `:adapter/arm-hiccup-emitter-if-unarmed!`, NOT the
+  ;; `:reagent/set-hiccup-emitter!` broadcast a loaded inactive adapter also
+  ;; contributes to. So a throwing broadcast setter never runs during install and
+  ;; the active adapter boots cleanly. Before rf2-h9szm the replay used the
+  ;; broadcast and this throw broke the install.
+  (late-bind/set-fn! :ssr/current-hiccup-emitter (fn [_ _] "<html/>"))
+  (let [broadcast-ran (atom false)
+        arm-ran       (atom false)]
+    ;; Stand in for a loaded inactive adapter whose set-hiccup-emitter! throws.
+    (late-bind/set-fn! :reagent/set-hiccup-emitter!
+                       (fn [_] (reset! broadcast-ran true) (throw (ex-info "inactive setter boom" {}))))
+    ;; The installed adapter's routed arm is benign.
+    (late-bind/set-fn! :adapter/arm-hiccup-emitter-if-unarmed!
+                       (fn [_] (reset! arm-ran true)))
+
+    (is (= fake-adapter (adapter/install-adapter! fake-adapter))
+        "install succeeds — the throwing broadcast setter is not on the replay path")
+    (is (= :rf.test/atomic-adapter (adapter/current-adapter)))
+    (is (true? @arm-ran) "the routed install-replay arm ran")
+    (is (false? @broadcast-ran)
+        "the :reagent/set-hiccup-emitter! broadcast was NOT invoked by install-replay")))
+
+;; ---- 3. precedence: replay arms only an otherwise-unarmed slot ------------
+
+(deftest replay-arms-an-unarmed-slot-but-never-overwrites-an-armed-one
+  (late-bind/set-fn! :ssr/current-hiccup-emitter ::retained-default)
+  (let [slot (atom nil)]
+    ;; The arm hook mirrors the real spine impl: arm the slot ONLY when unarmed.
+    (late-bind/set-fn! :adapter/arm-hiccup-emitter-if-unarmed!
+                       (fn [f] (when (nil? @slot) (reset! slot f))))
+
+    (testing "an otherwise-unarmed fresh generation receives the retained default"
+      (is (= fake-adapter (adapter/install-adapter! fake-adapter)))
+      (is (= ::retained-default @slot)
+          "the freshly installed, unarmed slot was armed from the durable emitter"))
+
+    (testing "an explicit pre-init override is NOT clobbered by the replay"
+      (adapter/reset-lifecycle-state-for-tests!)
+      (reset! slot ::explicit-custom)          ;; app set a custom emitter pre-init
+      (is (= fake-adapter (adapter/install-adapter! fake-adapter)))
+      (is (= ::explicit-custom @slot)
+          "install-replay left the explicit override authoritative — the default did not win"))))

--- a/implementation/ssr/test/re_frame/ssr_emitter_reinit_lifecycle_jvm_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_emitter_reinit_lifecycle_jvm_test.clj
@@ -12,9 +12,11 @@
   bound across destroy → re-init on the JVM.
 
   The rf2-vxgfnd.204 install-time replay (`install-adapter!` →
-  `rearm-hiccup-emitter!`) is a harmless idempotent no-op here: plain-atom does
-  not chain `:reagent/set-hiccup-emitter!`, so the durable `:ssr/current-hiccup-
-  emitter` slot has no chained applier to run — retention alone keeps the JVM
+  `rearm-hiccup-emitter!`) is a harmless no-op here: plain-atom publishes no
+  `:adapter/arm-hiccup-emitter-if-unarmed!` routed arm (rf2-h9szm — the replay is
+  routed to the installed adapter's own arm hook, not the broadcast
+  `:reagent/set-hiccup-emitter!` chain), so the durable `:ssr/current-hiccup-
+  emitter` slot has no per-adapter arm to run — retention alone keeps the JVM
   path armed."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]

--- a/implementation/ui/test/re_frame/ui/ssr_reinit_lifecycle_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/ssr_reinit_lifecycle_cljs_test.cljs
@@ -88,3 +88,26 @@
   (is (nil? (rf/init! ui/adapter)))
   (is (re-find #"<div>ok</div>" (render!))
       "gen2 renders — the replacement generation's emitter is armed, not stranded by gen1's dispose"))
+
+(deftest a-pre-init-explicit-custom-emitter-survives-the-install-replay
+  ;; rf2-h9szm PRECEDENCE — under the real ui adapter on an SSR-loaded classpath,
+  ;; an EXPLICIT custom emitter armed before init is NOT silently overwritten by
+  ;; install-replay of the retained default. The replay arms only an otherwise-
+  ;; unarmed slot, so the explicit direct override remains authoritative. Before
+  ;; the fix the replay's unconditional broadcast clobbered the custom emitter
+  ;; with the retained default.
+  ;;
+  ;; The public last-call-wins setter chain (`:reagent/set-hiccup-emitter!`) arms
+  ;; every loaded adapter's cell, so the finally restores them all to the retained
+  ;; default — no sibling adapter test observes the custom emitter.
+  (let [default   (late-bind/get-fn :ssr/current-hiccup-emitter)
+        set-chain (late-bind/get-fn :reagent/set-hiccup-emitter!)
+        custom    (fn [_tree _opts] "CUSTOM-EMITTER-MARKER")]
+    (try
+      (set-chain custom)                        ;; explicit override, pre-init
+      (is (nil? (rf/init! ui/adapter)))
+      (is (= "CUSTOM-EMITTER-MARKER" (render!))
+          "install-replay left the explicit custom emitter authoritative — the retained default did not win")
+      (finally
+        ;; Restore the retained default into every loaded adapter's slot.
+        (set-chain default)))))


### PR DESCRIPTION
## What

PR #6028 (rf2-vxgfnd.204) added install-time replay of the retained SSR hiccup emitter, but `install-adapter!` SEATED the new generation and only THEN called `rearm-hiccup-emitter!`, whose `:reagent/set-hiccup-emitter!` **broadcast** re-armed every loaded adapter. A throwing setter — the active adapter's, or **any loaded inactive adapter's** — propagated out of the broadcast and made the install throw *after* the target generation was already seated: a reported-failed boot that nonetheless behaved as installed / partial-armed (reproduced on main: first `init!` threw, `current-adapter` still non-nil, second `init!` "succeeded" by skipping the seated install). The broadcast also clobbered a pre-init explicit custom emitter with the retained default.

## The non-atomic seam

`implementation/core/src/re_frame/substrate/adapter.cljc` — `install-adapter!` seated the generation (`swap!`), then `(rearm-hiccup-emitter!)` ran as a *separate* top-level form with no rollback; `rearm-hiccup-emitter!` re-applied through the global `:reagent/set-hiccup-emitter!` chain (`chain-fn!` steps propagate a step throw and stop later steps).

## Fix

- **Failure-atomic.** `install-adapter!` seats + re-arms as ONE transaction: a throwing re-arm rolls the **exact** generation back (`identical?` on the token, so a concurrent replacement install is never clobbered), rethrows the re-arm exception as **primary**, and leaves a clean never-installed state for an immediate retry. Boot is all-or-nothing.
- **Routed.** The replay applies through a new routed `:adapter/arm-hiccup-emitter-if-unarmed!` late-bind hook each React/ratom adapter publishes via `route-hook!`, so it re-arms **only the installed adapter's** slot. A loaded inactive adapter's throwing setter can no longer break the active boot. The `:reagent/set-hiccup-emitter!` broadcast is unchanged (still auto-wires every adapter at SSR ns-load) — it is just off the install-replay path.
- **Precedence-safe.** Each adapter's arm impl arms its `emitter-cell` only when otherwise unarmed, so a pre-init explicit custom emitter / reset is not silently overwritten by the retained default.

The adapter contract stays **closed** (ten fns + `:kind`) — the arm lives in the late-bind table, not the adapter spec map. `plain-atom` / `test-react` publish no arm hook (they retain their emitter across a no-op dispose), so the replay is a harmless no-op there.

### Files
- `implementation/core/src/re_frame/substrate/adapter.cljc` — atomic `install-adapter!` + routed/precedence-safe `rearm-hiccup-emitter!`
- `implementation/core/src/re_frame/substrate/spine.cljs` — per-adapter `arm-hiccup-emitter-if-unarmed!` (react + ratom spines) + `route-hook!` publication
- `implementation/core/src/re_frame/late_bind/directory.cljc` — directory entry for the new routed hook
- Tests: new `ssr_emitter_replay_atomic_cljs_test.cljc` (atomicity/routing/precedence, JVM+node); real-adapter precedence pin in `ssr_reinit_lifecycle_cljs_test.cljs`; updated reagent-slim published-hook pin + JVM reinit docstring

## Quality gates

- **Red-before / green-after (partial-armed boot):** restored the pre-fix `install-adapter!` and ran the new suite — all four deftests FAIL (seated-after-throw / no rollback / broadcast breaks boot / no precedence). With the fix they pass (4 tests, 18 assertions, 0 failures).
- **`implementation/core` JVM (full):** `Ran 2036 tests containing 9495 assertions. 0 failures, 0 errors.`
- **`implementation/ssr` JVM (full):** `Ran 398 tests containing 1693 assertions. 0 failures, 0 errors.`
- **`npm run test:cljs` (node-test, full):** `Ran 9768 tests containing 47985 assertions. 0 failures, 0 errors.`

Do not merge.
