### PR TITLE
feat(ui): S3 versioned view evidence + re-frame.ui.tool projections (rf2-vxgfnd.95.6)

### DIFF
--- a/implementation/scripts/check-ui-mounted-prod-elision.cjs
+++ b/implementation/scripts/check-ui-mounted-prod-elision.cjs
@@ -122,6 +122,42 @@ for (const forbidden of ['dropped-exact', 'invalidation-evidence projection']) {
 }
 
 /*
+ * rf2-vxgfnd.95.6 — the DEV-ONLY re-frame.ui.tool projection tier (the five
+ * frozen projections: view-manifest / mounted-views / explain-render /
+ * view-dependencies / view-event-sites).
+ *
+ * The elision companion (tool_view_elision_prod_test) requires re-frame.ui.tool
+ * into this SAME bundle and CALLS every projection, so these are positive proofs
+ * of BODY-erasure: the facade vars survive (they are called) while their
+ * debug-gated projection SHAPES do not. Source positive controls first — the
+ * projection-shape keyword strings still name the gated bodies in source.
+ */
+const TOOL_FACADE_SOURCE = path.join(ROOT, 'ui', 'src', 're_frame', 'ui',
+                                     'tool.cljc');
+const toolFacadeSource = fs.readFileSync(TOOL_FACADE_SOURCE, 'utf8');
+for (const expected of ['identity-exact', 'site-counts']) {
+  if (!toolFacadeSource.includes(expected)) {
+    fail(`tool-facade source positive-control sentinel is absent: ${expected}`);
+  }
+}
+
+const TOOL_VIEW_PROD_TEST = path.join(ROOT, 'ui', 'test', 're_frame', 'ui',
+                                      'tool_view_elision_prod_test.cljs');
+const toolViewProdTest = fs.readFileSync(TOOL_VIEW_PROD_TEST, 'utf8');
+const TOOL_PROJECTIONS_CONTROL = 'rf-ui-tool-projections-inert-v1';
+if (!toolViewProdTest.includes(TOOL_PROJECTIONS_CONTROL)) {
+  fail(`tool-facade inert-projection control is absent from its test: ${TOOL_PROJECTIONS_CONTROL}`);
+}
+if (!bundle.includes(TOOL_PROJECTIONS_CONTROL)) {
+  fail('tool-facade inert-projection assertion was omitted from advanced bundle');
+}
+for (const forbidden of ['identity-exact', 'site-counts']) {
+  if (bundle.includes(forbidden)) {
+    fail(`re-frame.ui.tool projection shape survived advanced output: ${forbidden}`);
+  }
+}
+
+/*
  * rf2-vxgfnd.94.8 — REAL compiled mutation control. A second advanced build
  * flips a private goog-define which roots an unrelatedly named atom/reset path
  * inside re-frame.ui.tool.evidence. The same production test must turn red on

--- a/implementation/ui/src/re_frame/ui/tool.cljc
+++ b/implementation/ui/src/re_frame/ui/tool.cljc
@@ -1,0 +1,293 @@
+(ns re-frame.ui.tool
+  "The DEV-ONLY public projection tier over the compiled-view evidence model
+  (rf2-vxgfnd.95.6; Spec 004 §View identity and the instrumentation surface;
+  04-debugging §1/§5). Five frozen read-only projections a debugging consumer
+  (Xray, Story, Pair) reads WITHOUT touching private React state, leases, or the
+  reactive scheduler:
+
+    `view-manifest`     — the versioned public projection of a view's compiler
+                          MANIFEST (what CAN happen): source, per-prop docs/
+                          defaults, prop slots + schema, render-slot + interop
+                          sites, capability bits, fingerprints, site counts.
+    `mounted-views`     — the committed CONNECTED-INSTANCE records (what DID
+                          happen): occurrence identity, owning root, live
+                          connection state, honest hide-vs-unmount lifecycle
+                          labels, and the bounded render evidence per incarnation.
+    `explain-render`    — the render CAUSES for a view's live incarnations: the
+                          bounded cause set, occurrence/epoch counters, the moving
+                          observation targets, and explicit loss accounting.
+    `view-dependencies` — the reactive dependency SITES a view declares
+                          (subscriptions + leases) with literal-vs-`:dynamic`
+                          query-shape honesty.
+    `view-event-sites`  — the event-handler SITES a view declares, distinguishing
+                          LITERAL (`:vector`) and NORMALIZED (`:options`) event
+                          vectors from opaque `:dynamic` handlers — never claiming
+                          a raw callback's internals are inspectable.
+
+  THE SHAPES ARE VERSIONED. Every projection stamps `:rf.ui.tool/version`
+  (`schema-version`) so a consumer built against an older head reads the version
+  and degrades rather than mis-parsing. The projections are DETERMINISTIC,
+  SERIALIZABLE, and READ-ONLY: they mint no evidence, retain nothing, and egress
+  no ViewCell / lease / React object — only bounded plain data.
+
+  DEV-ONLY. Every entry point is compile-time gated on `interop/debug-enabled?`
+  and returns nil (or an empty envelope) under `:advanced` + goog.DEBUG=false;
+  the whole tier DCEs out of production (05 §4; G-7/G-11). Manifests live in the
+  process-global `:view` registry both hosts populate (`re-frame.ui.runtime`/
+  `re-frame.ui.tree`); the connected-instance evidence lives in the
+  `re-frame.ui.tool.evidence` retention engine this tier extends."
+  (:require [re-frame.interop          :as interop]
+            [re-frame.registrar        :as registrar]
+            [re-frame.ui.tool.evidence :as evidence]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(def schema-version
+  "The versioned tool-evidence public-shape contract version. Bumped whenever a
+  projection's shape changes incompatibly, so a consumer reads `:rf.ui.tool/version`
+  and reconciles rather than mis-parsing an evolved shape."
+  1)
+
+;; ---- manifest access (both hosts register `:view` into the registrar) --------
+
+(defn- manifest-of
+  "The compiler manifest registered for `view-id` (dev), or nil. Both the CLJS
+  runtime and the JVM tree register the manifest under the process-global `:view`
+  registry key `:rf.ui/manifest`."
+  [view-id]
+  (:rf.ui/manifest (registrar/lookup :view view-id)))
+
+;; ---- literal/dynamic query honesty -------------------------------------------
+
+(defn- literal-form?
+  "True when `x` is pure literal DATA — a scalar, or a collection built wholly of
+  literals, or a `(quote …)` — with NO free symbol and NO call. A sub query or
+  lease descriptor that satisfies this is exactly the authored runtime shape and
+  is safe to project verbatim; anything with a free symbol (a captured local) or
+  a call is `:dynamic` and must NOT be presented as the literal value."
+  [x]
+  (cond
+    (or (nil? x) (boolean? x) (number? x) (char? x) (string? x) (keyword? x)) true
+    (symbol? x) false
+    (vector? x) (every? literal-form? x)
+    (set? x)    (every? literal-form? x)
+    (map? x)    (every? (fn [[k v]] (and (literal-form? k) (literal-form? v))) x)
+    (seq? x)    (= 'quote (first x))
+    :else       false))
+
+;; ---- 1. view-manifest --------------------------------------------------------
+
+(defn- literal-map-schema-entries
+  "When `schema` is a literal Malli `[:map …]`, return `{prop-key {…}}` carrying
+  each child entry's `:doc`/`:default`/`:optional?`/`:schema`. nil for a registry
+  reference keyword, an `[:and …]`/`[:or …]` wrapper, or a runtime schema object —
+  those are left to the raw `:props-schema`. A bounded walk over one literal map,
+  not a general schema interpreter."
+  [schema]
+  (when (and (vector? schema) (= :map (first schema)))
+    (into {}
+          (keep (fn [entry]
+                  (when (and (vector? entry) (keyword? (first entry)))
+                    (let [[k a b] entry
+                          props   (when (map? a) a)
+                          child   (if props b a)]
+                      [k (cond-> {}
+                           (:doc props)               (assoc :doc (:doc props))
+                           (contains? props :default) (assoc :default (:default props))
+                           (some? props)              (assoc :optional? (boolean (:optional props)))
+                           (some? child)              (assoc :schema child))]))))
+          ;; a `[:map {map-props} …]` puts an optional properties map first
+          (drop-while map? (rest schema)))))
+
+(defn- project-props
+  "One source of truth for a view's props: each declared prop slot merged with the
+  per-prop docs/defaults/schema derivable from a literal `[:map …]` props schema
+  (readiness P1-5 — component libraries consume THIS instead of a parallel
+  args-description system). Slots with no literal schema entry carry key/slot/index
+  alone (honest — no fabricated doc)."
+  [prop-slots props-schema]
+  (let [by-key (literal-map-schema-entries props-schema)]
+    (mapv (fn [{:keys [key slot index]}]
+            (merge {:key key :slot slot :index index}
+                   (get by-key key)))
+          prop-slots)))
+
+(defn- project-manifest
+  [m]
+  (let [sites (:sites m)]
+    {:rf.ui.tool/version   schema-version
+     :view-id              (:view-id m)
+     :display-name         (:display-name m)
+     :doc                  (:doc m)
+     :source               (:source m)
+     :props                (project-props (:prop-slots m) (:props-schema m))
+     :props-schema         (:props-schema m)
+     :open-props?          (boolean (:open-props? m))
+     :children?            (boolean (:children? m))
+     :as?                  (boolean (:as? m))
+     :capabilities         (:capabilities m)
+     :render-slots         (mapv #(select-keys % [:sid :source-coord :inline?])
+                                 (:slots sites))
+     :interop-sites        (mapv #(select-keys % [:sid :kind :order])
+                                 (:react sites))
+     :template-fingerprint (:template-fingerprint m)
+     :hook-signature       (:hook-signature m)
+     :site-counts          {:subs         (count (:subs sites))
+                            :events       (count (:events sites))
+                            :leases       (count (:leases sites))
+                            :effects      (count (:effects sites))
+                            :dispatch-fns (count (:dispatch-fns sites))
+                            :frame-ops    (count (:frame-ops sites))
+                            :render-slots (count (:slots sites))
+                            :interop      (count (:react sites))
+                            :locals       (count (:locals sites))
+                            :htmls        (count (:htmls sites))}}))
+
+(defn view-manifest
+  "The versioned public projection of the compiled view `view-id`'s manifest —
+  what CAN happen, useful BEFORE mount. Carries the view's source coord, per-prop
+  docs/defaults/schema (the single source of truth replacing parallel
+  args-description systems), declared render-slot + interop sites, capability bits,
+  fingerprints, and site counts. Returns nil when `view-id` is not a registered
+  compiled view, or in a production build."
+  [view-id]
+  (when interop/debug-enabled?
+    (when-some [m (manifest-of view-id)]
+      (project-manifest m))))
+
+;; ---- 2. mounted-views --------------------------------------------------------
+
+(defn mounted-views
+  "The committed CONNECTED-INSTANCE records for every incarnation the evidence
+  tier currently retains — occurrence identity, owning root, live connection
+  state, honest hide-vs-unmount lifecycle labels, and the bounded render evidence.
+  A currently-connected cell reads `:connection :connected`; an Activity-hidden
+  cell the tool deliberately retains reads `:connection :disconnected` with the
+  qualified retroactive labels (never a fabricated `:unmounted`). Speculative
+  renders publish nothing. An empty (but versioned) envelope when no evidence tool
+  is installed; nil in a production build."
+  []
+  (when interop/debug-enabled?
+    {:rf.ui.tool/version schema-version
+     :views              (or (evidence/instance-records) [])}))
+
+;; ---- 3. explain-render -------------------------------------------------------
+
+(defn- explain-occurrence
+  [{:keys [occurrence view-id root-id connection lifecycle evidence]}]
+  (let [ev evidence]
+    {:occurrence   occurrence
+     :view-id      view-id
+     :root-id      root-id
+     :connection   connection
+     :lifecycle    lifecycle
+     :causes       (or (:causes ev) #{})
+     :render-count (or (:count ev) 0)
+     :batches      (or (:batches ev) 0)
+     :first-epoch  (:first-epoch ev)
+     :latest-epoch (:latest-epoch ev)
+     ;; two DISTINCT honesty axes over the moving targets: `:identity-exact?`
+     ;; says the SHOWN targets kept their exact identity (no opaque/bounded
+     ;; marker), while `:loss` says how many DISTINCT targets were omitted past
+     ;; the shown cap. The shown sample is complete exactly when `:loss :dropped`
+     ;; is 0; neither field ever presents a lower bound as completeness (04 §2).
+     :observations {:targets         (or (:targets ev) [])
+                    :identity-exact? (if (nil? ev) true (boolean (:targets-exact? ev)))}
+     :loss         {:dropped (count (:dropped ev))
+                    :exact?  (if (nil? ev) true (boolean (:dropped-exact? ev)))}}))
+
+(defn explain-render
+  "Why did view `view-id`'s live incarnations render? Each occurrence projects the
+  bounded render CAUSES (the `:value`/`:hmr`/`:disposed` cause set), the occurrence
+  and batch counters, the first/latest movement epochs, the moving observation
+  targets, and EXPLICIT loss accounting (`:dropped` with an `:exact?` flag — a
+  count is a completeness claim only when exact). With no arg, every retained
+  incarnation. Occurrences are keyed by stable occurrence identity, so two
+  instances of one view are distinguishable. An empty (but versioned) envelope
+  with no evidence; nil in a production build."
+  ([] (explain-render nil))
+  ([view-id]
+   (when interop/debug-enabled?
+     {:rf.ui.tool/version schema-version
+      :view-id            view-id
+      :occurrences        (into []
+                                (comp (filter #(or (nil? view-id)
+                                                   (= view-id (:view-id %))))
+                                      (map explain-occurrence))
+                                (or (evidence/instance-records) []))})))
+
+;; ---- 4. view-dependencies ----------------------------------------------------
+
+(defn- project-sub-site
+  [{:keys [sid query path]}]
+  (if (literal-form? query)
+    {:sid sid :path path :dynamic? false :query query}
+    {:sid sid :path path :dynamic? true
+     :query-id (when (and (vector? query) (keyword? (first query))) (first query))}))
+
+(defn- project-lease-site
+  [{:keys [sid descriptor path]}]
+  (if (literal-form? descriptor)
+    {:sid sid :path path :dynamic? false :descriptor descriptor}
+    {:sid sid :path path :dynamic? true}))
+
+(defn view-dependencies
+  "The reactive dependency SITES the compiled view `view-id` declares — its
+  `sub` and `lease` sites — with query-shape honesty: a fully-literal query is
+  projected verbatim (`:dynamic? false`), a query carrying a captured local is
+  `:dynamic? true` (its literal `:query-id`, when present, is still shown — the
+  runtime argument is not fabricated). Read from the compiler manifest, so it is
+  available before mount. nil for an unregistered view or in production."
+  [view-id]
+  (when interop/debug-enabled?
+    (when-some [m (manifest-of view-id)]
+      (let [sites (:sites m)]
+        {:rf.ui.tool/version schema-version
+         :view-id            view-id
+         :subscriptions      (mapv project-sub-site (:subs sites))
+         :leases             (mapv project-lease-site (:leases sites))}))))
+
+;; ---- 5. view-event-sites -----------------------------------------------------
+
+(defn- site-kind
+  "The coarse honesty grouping over the fine compiler classification: a LITERAL
+  event vector, a NORMALIZED options-map event vector, or an opaque DYNAMIC
+  handler (`ui/event`/`ui/handler`/bare-fn/dynamic-expr — never inspectable)."
+  [classification]
+  (case classification
+    :vector  :literal
+    :options :normalized
+    :dynamic))
+
+(defn- project-event-site
+  [{:keys [sid prop source-coord path classification serializable? sync? handler]}]
+  (let [serial? (boolean serializable?)]
+    (cond-> {:sid             sid
+             :prop            prop
+             :source-coord    source-coord
+             :occurrence-path path
+             :classification  classification
+             :site-kind       (site-kind classification)
+             :serializable?   serial?
+             :sync?           (boolean sync?)}
+      ;; A serializable site's authored event vector IS its inspectable shape
+      ;; (04 §3 — literal + normalized-branch); an opaque handler shows a marker
+      ;; and nothing more, never a claim about the callback's internals.
+      (and serial? (not= :opaque handler)) (assoc :handler handler)
+      (or (not serial?) (= :opaque handler)) (assoc :handler :opaque))))
+
+(defn view-event-sites
+  "The event-handler SITES the compiled view `view-id` declares (its `:on-*`
+  handlers), each classified for HONESTY: `:site-kind :literal` for a literal
+  event vector and `:normalized` for an options-map event vector — both carry
+  their inspectable `:handler` event vector; `:dynamic` for a `ui/event`,
+  `ui/handler`, bare fn, or dynamic expression — shown as `:handler :opaque`, the
+  tier never claiming a raw callback's internals are inspectable. `:serializable?`
+  and `:sync?` (the controlled-input synchronous door) ride each site. Read from
+  the compiler manifest. nil for an unregistered view or in production."
+  [view-id]
+  (when interop/debug-enabled?
+    (when-some [m (manifest-of view-id)]
+      {:rf.ui.tool/version schema-version
+       :view-id            view-id
+       :handlers           (mapv project-event-site (:events (:sites m)))})))

--- a/implementation/ui/src/re_frame/ui/tool/evidence.cljc
+++ b/implementation/ui/src/re_frame/ui/tool/evidence.cljc
@@ -90,6 +90,14 @@
 (def ^:private ^:const target-node-cap 128)
 (def ^:private ^:const target-string-cap 256)
 
+(def ^:private ^:const interval-cap
+  ;; Most-recent lifecycle intervals projected per incarnation (rf2-vxgfnd.95.6).
+  ;; A hide/reveal or teardown cycle appends one interval; a long-lived Activity
+  ;; cell could accrete many, so the connected-instance record projects a bounded
+  ;; TAIL and reports older ones as a `:dropped` count — the lifecycle axis of the
+  ;; same honest-loss discipline the per-cell target account uses.
+  16)
+
 (def ^:private dynamic-marker {:rf.ui.evidence/opaque :dynamic})
 (def ^:private bounded-marker {:rf.ui.evidence/opaque :bounded})
 
@@ -893,4 +901,78 @@
                    :root-id  (get roots (reactive/cell-root cell))
                    :evidence evidence}))
            (sort-by :cell-id)
+           (into [])))))
+
+;; ---- connected-instance records (S3 — lifecycle-aware) -----------------------
+;;
+;; The S3 tool tier (`re-frame.ui.tool`) needs the SAME retained incarnations the
+;; `projection` read exposes, plus the cell's live CONNECTION state and its
+;; lifecycle-fact log. Those live on the ViewCell (03 §4). Projecting them HERE —
+;; where the engine already holds the cell behind its non-owning weak key — keeps
+;; the public facade handle-free: only the ordinal, the authoring view id, and
+;; bounded serializable data ever egress. No ViewCell, lease, or React object.
+
+(def ^:private lifecycle-interval-keys
+  ;; The serializable lifecycle-fact keys (03 §4). `:state` is the EMITTED runtime
+  ;; fact; `:reason`/`:proof` are the qualified RETROACTIVE annotation — an
+  ;; explicit INFERENCE label (`:unknown` until the runtime PROVES `:activity-hidden`
+  ;; via a settled reconnect or `:unmounted` via host/root teardown). This tier
+  ;; passes them through VERBATIM and never fabricates a hide/unmount claim the
+  ;; runtime did not record.
+  [:state :reason :proof])
+
+(defn- project-lifecycle
+  "Project a cell's interval log into a BOUNDED, serializable lifecycle
+  annotation: the most-recent `interval-cap` intervals (each reduced to the
+  `:state`/`:reason`/`:proof` label keys — all keywords, never a handle) plus an
+  honest `:dropped` count of older intervals omitted and an `:exact?` flag. The
+  hide-vs-unmount labels are copied through as the runtime recorded them; the
+  projection never upgrades an `:unknown` disconnect to a fabricated hide/unmount."
+  [ivs]
+  (let [ivs     (vec ivs)
+        n       (count ivs)
+        dropped (max 0 (- n interval-cap))
+        shown   (if (pos? dropped) (subvec ivs dropped) ivs)]
+    {:intervals (mapv #(select-keys % lifecycle-interval-keys) shown)
+     :dropped   dropped
+     :exact?    (zero? dropped)}))
+
+(defn instance-records
+  "Per-incarnation CONNECTED-INSTANCE records (tool read) — the S3
+  lifecycle-aware sibling of `projection`. Each retained committed incarnation
+  projects to
+
+    {:occurrence ord      ; stable per-incarnation ordinal (occurrence identity)
+     :view-id    vid       ; the authoring view (defview identity)
+     :root-id    rid|nil   ; the owning LIVE client root (nil under no live root)
+     :connection state     ; the cell's LIVE runtime lifecycle keyword
+                           ;   (:connected / :disconnected — dead cells are pruned)
+     :lifecycle  {:intervals [...] :dropped n :exact? b}
+                           ; bounded serializable lifecycle-fact log + honest
+                           ;   hide-vs-unmount labels (never fabricated)
+     :evidence   accrual}  ; the bounded cumulative render evidence (`projection`)
+
+  Records represent COMMITTED CONNECTED incarnations only — a speculative render
+  never enrols, so nothing here is fabricated. A currently-connected cell reads
+  `:connection :connected`; an Activity-hidden cell the tool deliberately retains
+  reads `:connection :disconnected` and carries the honest hide-vs-unmount
+  interval labels (rf2-un54gv / 03 §4). No ViewCell, lease, or React object
+  egresses — only the ordinal, the view id, and bounded serializable data. nil in
+  a production build, where the debug evidence plane is elided."
+  []
+  (when interop/debug-enabled?
+    (let [entries (transition!
+                   (fn []
+                     (let [s (swap! state* normalize-state)]
+                       (store-live-entries! (:entries s)))))
+          roots   (root-id-index)]
+      (->> entries
+           (map (fn [[cell {:keys [cell-id view-id evidence]}]]
+                  {:occurrence cell-id
+                   :view-id    view-id
+                   :root-id    (get roots (reactive/cell-root cell))
+                   :connection (reactive/lifecycle cell)
+                   :lifecycle  (project-lifecycle (reactive/intervals cell))
+                   :evidence   evidence}))
+           (sort-by :occurrence)
            (into [])))))

--- a/implementation/ui/test/re_frame/ui/tool_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/tool_cljs_test.cljc
@@ -1,0 +1,363 @@
+(ns re-frame.ui.tool-cljs-test
+  "rf2-vxgfnd.95.6 — the five frozen `re-frame.ui.tool` dev-only projections over
+  the compiled-view evidence model.
+
+  The rows:
+
+    - VERSIONED PUBLIC SHAPE — every projection stamps `:rf.ui.tool/version`
+      (`schema-version`) so a consumer degrades on an evolved shape;
+    - `view-manifest` — the manifest projection (what CAN happen): per-prop
+      docs/defaults/schema, render-slot + interop sites, capability bits, source,
+      site counts; nil for an unregistered view;
+    - `view-event-sites` — literal (`:vector`) vs normalized (`:options`) vs
+      opaque `:dynamic` handler honesty; a raw callback is `:opaque`, never
+      claimed inspectable;
+    - `view-dependencies` — literal-vs-`:dynamic` sub/lease query-shape honesty;
+    - `mounted-views` — committed CONNECTED-INSTANCE records: occurrence identity
+      distinguishes two instances of one view; connection state; the honest
+      hide-vs-unmount lifecycle labels (INFERENCE, never fabricated runtime truth);
+    - `explain-render` — the render causes + explicit loss accounting;
+    - SERIALIZABLE, not handles — no ViewCell / lease / React object egresses.
+
+  `.cljc` ending `-cljs-test` rides `npm run test:cljs` / `test:ui` (node) AND
+  `clojure -M:test` (JVM), so the projections are graft-checked on both hosts."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            #?(:cljs [cljs.reader])
+            [re-frame.registrar             :as registrar]
+            [re-frame.substrate.plain-atom  :as plain-atom]
+            [re-frame.test-support          :as test-support]
+            [re-frame.ui.reactive           :as reactive]
+            [re-frame.ui.tool               :as tool]
+            [re-frame.ui.tool.evidence      :as evidence]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (evidence/force-release!)
+    (try (f) (finally
+               (reactive/reset-scheduler!)
+               (evidence/force-release!)))))
+
+;; ---------------------------------------------------------------------------
+;; A hand-built manifest mirroring the compiler's emitted shape (compiler.cljc
+;; `manifest` + analyze.cljc `add-site!`). The projection tier is a pure function
+;; of this contract; the compiler's emission of it is proven by the compiler
+;; suites, and the JVM `defview` companion (tool_defview_jvm_test) proves a REAL
+;; emitted manifest projects the same.
+;; ---------------------------------------------------------------------------
+
+(defn- register-view! [view-id manifest]
+  (registrar/register! :view view-id {:rf/id view-id
+                                       :rf.ui/compiled? true
+                                       :rf.ui/manifest manifest}))
+
+(def ^:private demo-manifest
+  {:view-id      :demo/widget
+   :display-name "demo/widget"
+   :doc          "A demo widget."
+   :source       {:file "demo.cljc" :line 10 :column 1}
+   :prop-slots   [{:key :label :slot "label" :index 0}
+                  {:key :count :slot "count" :index 1}
+                  {:key :children :slot "children" :index 2}]
+   :props-schema [:map
+                  [:label {:doc "The button label."} :string]
+                  [:count {:default 0 :optional true} :int]]
+   :open-props?  false
+   :children?    true
+   :as?          false
+   :template-fingerprint "tf1-abc"
+   :hook-signature       "hs1-def"
+   :capabilities #{:cell :local}
+   :sites
+   {:subs   [{:sid "sid1-a" :query [:demo/total] :path [] :expr-path [0]}
+             {:sid "sid1-b" :query '[:demo/item id] :path [1] :expr-path [1]}]
+    :leases [{:sid "sid1-c" :descriptor [:demo/res 7] :path [] :expr-path [0]}
+             {:sid "sid1-d" :descriptor '[:demo/res n] :path [1] :expr-path [1]}]
+    :events [{:sid "sid1-e" :site-index 0 :view-id :demo/widget
+              :source-coord {:file "demo.cljc" :line 11} :path [:button 0]
+              :prop :on-click :handler '[:demo/inc n]
+              :classification :vector :serializable? true}
+             {:sid "sid1-f" :site-index 1 :view-id :demo/widget
+              :source-coord {:file "demo.cljc" :line 12} :path [:input 0]
+              :prop :on-change
+              :handler {:event '[:demo/set v] :prevent-default true}
+              :classification :options :serializable? true}
+             {:sid "sid1-g" :site-index 2 :view-id :demo/widget
+              :source-coord {:file "demo.cljc" :line 13} :path [:input 1]
+              :prop :on-input :handler :opaque
+              :classification :ui-event :serializable? false :sync? true}
+             {:sid "sid1-h" :site-index 3 :view-id :demo/widget
+              :source-coord {:file "demo.cljc" :line 14} :path [:a 0]
+              :prop :on-mouse-over :handler :opaque
+              :classification :fn :serializable? false}
+             {:sid "sid1-i" :site-index 4 :view-id :demo/widget
+              :source-coord {:file "demo.cljc" :line 15} :path [:a 1]
+              :prop :on-key-down :handler :opaque
+              :classification :dynamic :serializable? false}]
+    :slots  [{:sid "sid1-s" :source-coord {:file "demo.cljc" :line 16} :inline? true}]
+    :react  [{:sid "sid1-r" :kind :ref :order 0 :path [] :expr-path [0]}
+             {:sid "sid1-t" :kind :effect :order 1 :path [] :expr-path [1]}]
+    :effects      []
+    :dispatch-fns []
+    :frame-ops    []
+    :locals       [{:sid "sid1-l"}]
+    :htmls        []}})
+
+;; ---------------------------------------------------------------------------
+;; helpers for connected-instance evidence (driven through the reactive seam,
+;; no DOM — the same technique the S2 tool-evidence suite uses)
+;; ---------------------------------------------------------------------------
+
+(defn- connect! [cell]
+  (let [[_ capture] (reactive/with-capture cell (fn [] nil))]
+    (reactive/commit! cell capture))
+  cell)
+
+(defn- enrol! [cell epoch]
+  (reactive/mark-dirty! cell epoch)
+  (reactive/flush-pending!)
+  cell)
+
+(defn- view-of [view-id]
+  (filter #(= view-id (:view-id %)) (:views (tool/mounted-views))))
+
+(defn- no-cell-anywhere?
+  "Deep-walk `x`: true when NO ViewCell is reachable (the handle-egress proof)."
+  [x]
+  (cond
+    (reactive/cell? x) false
+    (map? x)  (every? no-cell-anywhere? (concat (keys x) (vals x)))
+    (coll? x) (every? no-cell-anywhere? x)
+    :else     true))
+
+;; ===========================================================================
+;; view-manifest — the versioned public shape (what CAN happen)
+;; ===========================================================================
+
+(deftest view-manifest-projects-the-versioned-public-shape
+  (register-view! :demo/widget demo-manifest)
+  (let [vm (tool/view-manifest :demo/widget)]
+    (is (= tool/schema-version (:rf.ui.tool/version vm)) "stamped with the schema version")
+    (is (= :demo/widget (:view-id vm)))
+    (is (= "A demo widget." (:doc vm)))
+    (is (= {:file "demo.cljc" :line 10 :column 1} (:source vm)))
+    (is (= #{:cell :local} (:capabilities vm)))
+    (is (false? (:open-props? vm)))
+    (is (true? (:children? vm)))
+
+    (testing "per-prop docs/defaults are the single source of truth (readiness P1-5)"
+      (let [by-key (into {} (map (juxt :key identity)) (:props vm))]
+        (is (= 3 (count (:props vm))))
+        (is (= {:key :label :slot "label" :index 0
+                :doc "The button label." :optional? false :schema :string}
+               (:label by-key))
+            "label carries its doc + schema + not-optional")
+        (is (= {:key :count :slot "count" :index 1
+                :default 0 :optional? true :schema :int}
+               (:count by-key))
+            "count carries its default + optional flag + schema")
+        (is (= {:key :children :slot "children" :index 2} (:children by-key))
+            "a slot with no literal schema entry carries key/slot/index alone — no fabrication")))
+
+    (testing "render-slot + interop sites + site counts"
+      (is (= [{:sid "sid1-s" :source-coord {:file "demo.cljc" :line 16} :inline? true}]
+             (:render-slots vm)))
+      (is (= [{:sid "sid1-r" :kind :ref :order 0}
+              {:sid "sid1-t" :kind :effect :order 1}]
+             (:interop-sites vm))
+          "the frozen re-frame.ui.react interop sites are surfaced")
+      (is (= {:subs 2 :events 5 :leases 2 :effects 0 :dispatch-fns 0 :frame-ops 0
+              :render-slots 1 :interop 2 :locals 1 :htmls 0}
+             (:site-counts vm))))
+
+    (testing "the raw props schema rides alongside the derived per-prop view"
+      (is (= (:props-schema demo-manifest) (:props-schema vm))))))
+
+(deftest view-manifest-tolerates-a-missing-view
+  (is (nil? (tool/view-manifest :nope/absent)) "an unregistered view projects nil"))
+
+;; ===========================================================================
+;; view-event-sites — literal / normalized / dynamic handler honesty (AC3)
+;; ===========================================================================
+
+(deftest view-event-sites-distinguish-literal-normalized-and-dynamic
+  (register-view! :demo/widget demo-manifest)
+  (let [res    (tool/view-event-sites :demo/widget)
+        by-sid (into {} (map (juxt :sid identity)) (:handlers res))]
+    (is (= tool/schema-version (:rf.ui.tool/version res)))
+    (is (= 5 (count (:handlers res))))
+
+    (testing "a LITERAL event vector is site-kind :literal and shows its vector"
+      (let [h (by-sid "sid1-e")]
+        (is (= :literal (:site-kind h)))
+        (is (= :vector (:classification h)))
+        (is (true? (:serializable? h)))
+        (is (= '[:demo/inc n] (:handler h)) "the authored event vector is inspectable")
+        (is (= :on-click (:prop h)))))
+
+    (testing "a NORMALIZED options-map handler is site-kind :normalized"
+      (let [h (by-sid "sid1-f")]
+        (is (= :normalized (:site-kind h)))
+        (is (= :options (:classification h)))
+        (is (true? (:serializable? h)))
+        (is (= {:event '[:demo/set v] :prevent-default true} (:handler h)))))
+
+    (testing "a ui/event is opaque :dynamic — never claims callback internals"
+      (let [h (by-sid "sid1-g")]
+        (is (= :dynamic (:site-kind h)))
+        (is (= :ui-event (:classification h)))
+        (is (false? (:serializable? h)))
+        (is (= :opaque (:handler h)) "the raw callback body is NOT projected")
+        (is (true? (:sync? h)) "the controlled-input synchronous door is surfaced")))
+
+    (testing "a bare fn and a dynamic expression are both opaque :dynamic"
+      (doseq [sid ["sid1-h" "sid1-i"]]
+        (let [h (by-sid sid)]
+          (is (= :dynamic (:site-kind h)))
+          (is (= :opaque (:handler h)))
+          (is (false? (:serializable? h)))
+          (is (false? (:sync? h)) "no sync door on a non-controlled site"))))))
+
+(deftest view-event-sites-tolerates-a-missing-view
+  (is (nil? (tool/view-event-sites :nope/absent))))
+
+;; ===========================================================================
+;; view-dependencies — literal vs dynamic query honesty
+;; ===========================================================================
+
+(deftest view-dependencies-are-honest-about-dynamic-queries
+  (register-view! :demo/widget demo-manifest)
+  (let [res    (tool/view-dependencies :demo/widget)
+        by-sid (into {} (map (juxt :sid identity)) (:subscriptions res))]
+    (is (= tool/schema-version (:rf.ui.tool/version res)))
+
+    (testing "a fully-literal sub query is projected verbatim"
+      (let [s (by-sid "sid1-a")]
+        (is (false? (:dynamic? s)))
+        (is (= [:demo/total] (:query s)))))
+
+    (testing "a sub query carrying a captured local is :dynamic, with only its id"
+      (let [s (by-sid "sid1-b")]
+        (is (true? (:dynamic? s)))
+        (is (= :demo/item (:query-id s)) "the literal query-id is honest")
+        (is (not (contains? s :query)) "the dynamic runtime argument is NOT fabricated")))
+
+    (testing "leases split literal vs dynamic the same way"
+      (let [by-sid (into {} (map (juxt :sid identity)) (:leases res))]
+        (is (= [:demo/res 7] (:descriptor (by-sid "sid1-c"))))
+        (is (false? (:dynamic? (by-sid "sid1-c"))))
+        (is (true? (:dynamic? (by-sid "sid1-d"))))
+        (is (not (contains? (by-sid "sid1-d") :descriptor)))))))
+
+(deftest view-dependencies-tolerates-a-missing-view
+  (is (nil? (tool/view-dependencies :nope/absent))))
+
+;; ===========================================================================
+;; mounted-views — committed connected-instance records + occurrence identity
+;; ===========================================================================
+
+(deftest mounted-views-are-committed-connected-instance-records
+  (is (true? (evidence/install! ::xray)))
+  (let [a (enrol! (connect! (reactive/make-cell :demo/row)) 1)
+        b (enrol! (connect! (reactive/make-cell :demo/row)) 2)]
+    (let [res  (tool/mounted-views)
+          rows (view-of :demo/row)]
+      (is (= tool/schema-version (:rf.ui.tool/version res)))
+      (is (= 2 (count rows)) "two committed incarnations of ONE view")
+      (is (= [:connected :connected] (mapv :connection rows)))
+      (is (= 2 (count (into #{} (map :occurrence) rows)))
+          "occurrence identity distinguishes two instances of one view (render-key alone insufficient)")
+      (is (every? #(contains? % :evidence) rows) "each carries its bounded render evidence")
+      (is (every? #(= {:intervals [] :dropped 0 :exact? true} (:lifecycle %)) rows)
+          "a never-disconnected instance has an empty (exact) lifecycle log"))))
+
+(deftest mounted-views-label-hide-vs-unmount-as-inference-not-runtime-truth
+  ;; The core honesty row (rf2-un54gv / 03 §4). React gives no hide-vs-unmount
+  ;; signal at cleanup, so a disconnect is `:disconnected {:reason :unknown}`; a
+  ;; settled reconnect PROVES an Activity hide (a retroactive INFERENCE label); an
+  ;; explicit teardown PROVES an unmount. The tier copies these through and never
+  ;; fabricates the distinction.
+  (is (true? (evidence/install! ::xray)))
+  (let [cell (enrol! (connect! (reactive/make-cell :demo/hidden)) 1)]
+
+    (testing "a bare disconnect stays honestly :unknown — no fabricated :unmounted"
+      (reactive/disconnect! cell)
+      (let [row (first (view-of :demo/hidden))]
+        (is (= :disconnected (:connection row)) "runtime state is the observed fact")
+        (is (= [{:state :disconnected :reason :unknown}]
+               (:intervals (:lifecycle row)))
+            "the reason stays :unknown until the runtime proves otherwise")))
+
+    (testing "a settled reconnect retro-labels the PRIOR interval an Activity hide"
+      (reactive/settle-disconnect! cell)
+      (connect! cell)
+      (let [row (first (view-of :demo/hidden))]
+        (is (= :connected (:connection row)) "the live runtime state is :connected again")
+        (is (= [{:state :disconnected :reason :activity-hidden :proof :reconnect}]
+               (:intervals (:lifecycle row)))
+            "the hide is a QUALIFIED retroactive inference, tagged with its proof")))
+
+    (testing "explicit teardown proves an unmount and prunes the dead incarnation"
+      (reactive/teardown! cell)
+      (is (empty? (view-of :demo/hidden)) "a proven-dead incarnation leaves mounted-views"))))
+
+(deftest mounted-views-are-empty-without-an-installed-tool
+  (is (= {:rf.ui.tool/version tool/schema-version :views []} (tool/mounted-views))
+      "no evidence tool installed → an empty but versioned envelope"))
+
+;; ===========================================================================
+;; explain-render — causes + explicit loss accounting
+;; ===========================================================================
+
+(deftest explain-render-projects-causes-and-loss-accounting
+  (is (true? (evidence/install! ::xray)))
+  (let [cell (connect! (reactive/make-cell :demo/why))
+        sink (evidence/installed-sink)]
+    ;; drive real evidence: 8 shown + 2 dropped distinct targets in one window
+    (doseq [i (range 10)]
+      (sink cell {:first-epoch 1 :latest-epoch 1 :count 1 :causes #{:value}
+                  :targets [[:sub :rf/default [:demo/q i]]]
+                  :dropped #{} :dropped-exact? true}))
+    (let [res (tool/explain-render :demo/why)
+          occ (first (:occurrences res))]
+      (is (= tool/schema-version (:rf.ui.tool/version res)))
+      (is (= :demo/why (:view-id res)))
+      (is (= 1 (count (:occurrences res))))
+      (is (= #{:value} (:causes occ)) "the projected render cause")
+      (is (= 10 (:render-count occ)) "every occurrence counted")
+      (is (= 8 (count (:targets (:observations occ)))) "shown sample capped at 8")
+      (is (true? (:identity-exact? (:observations occ)))
+          "the shown targets kept exact identity (plain EDN, no opaque marker)")
+      (is (= 2 (:dropped (:loss occ)))
+          "two DISTINCT omissions past the shown cap — the completeness axis")
+      (is (true? (:exact? (:loss occ))) "the loss account itself is exact")
+      (is (= :connected (:connection occ)))))
+
+  (testing "explain-render with no arg spans every incarnation"
+    (is (= tool/schema-version (:rf.ui.tool/version (tool/explain-render))))
+    (is (<= 1 (count (:occurrences (tool/explain-render)))))))
+
+;; ===========================================================================
+;; Serializable, versioned, read-only — no handles egress
+;; ===========================================================================
+
+(deftest projections-are-serializable-not-handles
+  (register-view! :demo/widget demo-manifest)
+  (is (true? (evidence/install! ::xray)))
+  (let [cell (enrol! (connect! (reactive/make-cell :demo/row)) 1)
+        outputs [(tool/view-manifest :demo/widget)
+                 (tool/view-event-sites :demo/widget)
+                 (tool/view-dependencies :demo/widget)
+                 (tool/mounted-views)
+                 (tool/explain-render :demo/row)]]
+    (doseq [o outputs]
+      (is (no-cell-anywhere? o) "no ViewCell reaches a projection result")
+      (is (string? (pr-str o)) "the projection is printable")
+      (is (= o (#?(:clj read-string :cljs cljs.reader/read-string) (pr-str o)))
+          "…and round-trips through EDN unchanged — pure serializable data"))
+    ;; read-only: a second read after no mutation is identical (deterministic)
+    (is (= (tool/mounted-views) (tool/mounted-views)) "deterministic + read-only")
+    ;; keep `cell` reachable so it is not collected mid-assertion
+    (is (reactive/cell? cell))))

--- a/implementation/ui/test/re_frame/ui/tool_defview_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/tool_defview_jvm_test.clj
@@ -1,0 +1,100 @@
+(ns re-frame.ui.tool-defview-jvm-test
+  "rf2-vxgfnd.95.6 — end-to-end proof that the five `re-frame.ui.tool` projections
+  read a REAL compiler-emitted manifest, not just the hand-built contract the
+  `-cljs-test` companion pins. A JVM `defview` registers its manifest into the
+  process-global `:view` registry (`re-frame.ui.tree/register-view!`); the
+  projections read it back. The macro is host-shared, so the manifest the JVM
+  emitter registers here is the same shape the CLJS emitter registers."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.registrar :as registrar]
+            [re-frame.ui :as ui :refer [defview sub]]
+            [re-frame.ui.tool :as tool]))
+
+;; Real compiled views. Each registers its manifest at namespace load.
+
+(defview literal-view
+  "A static view with no sites."
+  []
+  [:div "static"])
+
+(defview doc-view
+  "A view whose props schema carries per-prop docs/defaults."
+  {:props [:map
+           [:label {:doc "The visible label."} :string]
+           [:size {:default :md :optional true} :keyword]]}
+  [{:keys [label]}]
+  [:div label])
+
+(defview reactive-view
+  "A view with a literal sub, a dynamic sub, and event handlers."
+  [{:keys [id]}]
+  (let [total (sub [:demo/total])
+        item  (sub [:demo/item id])]
+    [:button {:on-click [:demo/inc id]
+              :on-mouse-over (fn [_] nil)}
+     (str total item)]))
+
+(defn- view-id-of [v] (:rf.ui/view-id (meta v)))
+(defn- manifest-of [id] (:rf.ui/manifest (registrar/lookup :view id)))
+
+(def ^:private ids
+  {:literal  (view-id-of #'literal-view)
+   :doc      (view-id-of #'doc-view)
+   :reactive (view-id-of #'reactive-view)})
+
+;; The REAL emitted manifests, captured at load; a per-test fixture re-registers
+;; them so a sibling namespace's registrar-clearing fixture cannot strand them.
+(def ^:private captured
+  (into {} (map (fn [[k id]] [id (manifest-of id)])) ids))
+
+(use-fixtures :each
+  (fn [f]
+    (doseq [[id m] captured]
+      (registrar/register! :view id {:rf/id id :rf.ui/compiled? true
+                                     :rf.ui/manifest m}))
+    (f)))
+
+(deftest view-manifest-reads-a-real-emitted-manifest
+  (let [vm (tool/view-manifest (:literal ids))]
+    (is (= tool/schema-version (:rf.ui.tool/version vm)))
+    (is (= (:literal ids) (:view-id vm)))
+    (is (= "A static view with no sites." (:doc vm)))
+    (is (map? (:source vm)) "the real source coord rides through")
+    (is (= 0 (:subs (:site-counts vm)))
+        "a static view declares no reactive sites")))
+
+(deftest real-props-schema-yields-per-prop-docs-and-defaults
+  (let [vm     (tool/view-manifest (:doc ids))
+        by-key (into {} (map (juxt :key identity)) (:props vm))]
+    (is (= "The visible label." (:doc (:label by-key)))
+        "the per-prop doc is derived from the REAL emitted props schema")
+    (is (= :md (:default (:size by-key))) "…and the per-prop default")
+    (is (true? (:optional? (:size by-key))))))
+
+(deftest real-sub-lease-and-event-sites-project-with-honesty
+  (let [rid (:reactive ids)]
+    (testing "site counts reflect the real emission"
+      (let [vm (tool/view-manifest rid)]
+        (is (set? (:capabilities vm)) "capabilities is a (possibly empty) set")
+        (is (<= 2 (:subs (:site-counts vm))) "both subs counted")
+        (is (<= 2 (:events (:site-counts vm))) "both handlers counted")))
+
+    (testing "view-dependencies distinguishes the literal sub from the dynamic one"
+      (let [deps    (tool/view-dependencies rid)
+            queries (into #{} (map :query) (:subscriptions deps))
+            dyn     (filter :dynamic? (:subscriptions deps))]
+        (is (contains? queries [:demo/total]) "the literal sub is projected verbatim")
+        (is (some #(= :demo/item (:query-id %)) dyn)
+            "the sub with a captured local is :dynamic with only its query-id")))
+
+    (testing "view-event-sites is honest about the literal vector and the opaque fn"
+      (let [sites   (:handlers (tool/view-event-sites rid))
+            by-prop (group-by :prop sites)]
+        (is (= :literal (:site-kind (first (by-prop :on-click))))
+            "the literal event vector is inspectable")
+        (is (= [:demo/inc] (take 1 (:handler (first (by-prop :on-click)))))
+            "…and its authored event-id is shown")
+        (let [over (first (by-prop :on-mouse-over))]
+          (is (= :dynamic (:site-kind over)))
+          (is (= :opaque (:handler over)) "the raw callback is opaque, never inspected")
+          (is (false? (:serializable? over))))))))

--- a/implementation/ui/test/re_frame/ui/tool_view_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/tool_view_elision_prod_test.cljs
@@ -1,0 +1,36 @@
+(ns re-frame.ui.tool-view-elision-prod-test
+  "Advanced-production control for the DEV-ONLY `re-frame.ui.tool` projection tier
+  (rf2-vxgfnd.95.6; G-7/G-11).
+
+  This namespace runs ONLY in `:browser-test-prod-elision` (`:advanced`,
+  goog.DEBUG=false). Requiring `re-frame.ui.tool` here pulls the facade into the
+  exact release bundle the companion gate (scripts/check-ui-mounted-prod-elision.cjs)
+  greps, so the assertion — no projection-shape strings survive while the facade
+  vars are still present and CALLED — is a positive proof of erasure, not
+  absence-by-omission.
+
+  Behaviourally: in production the debug evidence plane does not exist, so every
+  projection is a gated no-op returning nil. The only surviving public var is the
+  plain-value `schema-version` (data, not machinery)."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.ui.tool :as tool]))
+
+(def ^:private ^:const projections-inert-control
+  ;; The companion bundle gate requires this marker to SURVIVE, proving the
+  ;; assertions below are actually compiled into the advanced artefact whose
+  ;; debug-only projection bodies must disappear.
+  "rf-ui-tool-projections-inert-v1")
+
+(deftest advanced-production-elides-the-tool-projection-tier
+  (testing "every manifest-backed projection is a gated nil no-op"
+    (is (nil? (tool/view-manifest ::probe)) projections-inert-control)
+    (is (nil? (tool/view-dependencies ::probe)))
+    (is (nil? (tool/view-event-sites ::probe))))
+
+  (testing "the instance-record projections are gated nil no-ops too"
+    (is (nil? (tool/mounted-views)))
+    (is (nil? (tool/explain-render)))
+    (is (nil? (tool/explain-render ::probe))))
+
+  (testing "only the plain-value schema-version survives — data, not machinery"
+    (is (= 1 tool/schema-version))))


### PR DESCRIPTION
Extends the S2 `re-frame.ui.tool.evidence` retention engine with lifecycle-aware
connected-instance records and adds the DEV-ONLY public `re-frame.ui.tool` tier —
the five frozen read-only projections a debugging consumer (Xray/Story/Pair)
reads without touching private React state, leases, or the scheduler. Realises
Spec 004 §View identity + EP-0033; the S2 evidence engine is extended, not rebuilt.

## What ships

**Evidence engine** (`tool/evidence.cljc`) — one new public read plus a bounded
lifecycle projector:
- `instance-records` — the lifecycle-aware sibling of `projection`. Each retained
  committed incarnation → occurrence identity (the stable `cell-id` ordinal),
  view-id, root-id, the LIVE `:connection` state, a bounded serializable
  lifecycle-interval log with the honest hide-vs-unmount labels, and the bounded
  render evidence. No ViewCell / lease / React object egresses.
- The hide-vs-unmount labels are copied through VERBATIM: `:disconnected {:reason
  :unknown}` stays unknown until the runtime proves `:activity-hidden` (a settled
  reconnect) or `:unmounted` (host/root teardown) — never fabricated runtime truth.

**Public tier** (`tool.cljc`, new): `view-manifest` / `mounted-views` /
`explain-render` / `view-dependencies` / `view-event-sites`. Every projection
stamps `:rf.ui.tool/version` (`schema-version`), is deterministic + serializable +
read-only, tolerates missing/older evidence, and is gated on
`interop/debug-enabled?` so the whole tier DCEs out of advanced production.
- `view-manifest` is the versioned public shape (readiness P1-5): per-prop
  docs/defaults **derived** from the existing Malli props schema (no compiler
  emission change), declared render-slot + interop sites, capability bits, site
  counts, source, fingerprints.
- `view-event-sites` distinguishes literal (`:vector`) / normalized (`:options`)
  event vectors from opaque `:dynamic` handlers — a raw callback is `:opaque`,
  never claimed inspectable; `:serializable?` + `:sync?` ride each site.
- `view-dependencies` is honest about dynamic sub/lease queries (`:dynamic?` +
  `:query-id`, never a fabricated runtime argument).
- `explain-render` separates identity fidelity (`:identity-exact?`) from sample
  completeness (`:loss`).

## Scope discipline

- **No compiler / analyze / emit / route-link touch** (`.95.5`'s lane) — the tier
  is a pure read over the compiler-emitted manifest (registrar `:view`), the
  existing evidence accrual, and reactive cell lifecycle.
- **Anti-over-engineering held**: no new authoring API, no production registry, no
  query engine, no new Xray panel; built entirely on existing evidence /
  weak-retention / manifest / lifecycle mechanisms (no failing fixture proved a
  missing primitive).
- **No hot-zone edits required**: no new runtime error ids, warning families, or
  trace ops → no Spec 009 / Spec-Schemas rows. The dev-only tier follows the
  `re-frame.ui.tool.evidence` sibling precedent (not rowed in api-manifest/API.md);
  `gen --check` stays green at 511 vars. Flagged for the reviewer: if a future
  consumer wants these rowed as a blessed public surface, that is a separate
  api-manifest classification decision.

## Quality gates (all foreground, green)

- `implementation/ui` JVM — full suite **725 tests / 13663 assertions, 0 fail**
  (incl. the new `tool_cljs_test` on JVM + `tool_defview_jvm_test` end-to-end over
  a REAL emitted manifest).
- `implementation/core` JVM conformance — **13 tests / 33 assertions, 0 fail**
  (unaffected — no new ids).
- `npm run test:cljs` — **9774 tests / 48059 assertions, 0 fail**.
- `npm run test:ui` — **728 tests / 3757 assertions, 0 fail**.
- `npm run test:elision` — **PASS** (framework 55/55 absent).
- Tool-tier production absence: `shadow-cljs release browser-test-prod-elision` +
  `check-ui-mounted-prod-elision.cjs` — **PASS** (incl. renamed-state mutant); the
  advanced bundle keeps the called facade vars but erases the projection SHAPES
  (`identity-exact` / `site-counts` sentinels absent; inert-marker present). The
  bundle browser run is **96 tests / 362 assertions, 0 fail**.

## Acceptance proofs (fixtures)

- Versioned public manifest, per-prop docs/defaults, render-slot/interop sites,
  site counts — `view-manifest-projects-the-versioned-public-shape` (+ real
  emission: `real-props-schema-yields-per-prop-docs-and-defaults`).
- Occurrence identity distinguishes two instances of one view —
  `mounted-views-are-committed-connected-instance-records`.
- Hide-vs-unmount = inference, not runtime truth —
  `mounted-views-label-hide-vs-unmount-as-inference-not-runtime-truth`.
- Literal/normalized/`:dynamic` handler honesty + opaque callbacks —
  `view-event-sites-distinguish-literal-normalized-and-dynamic`.
- Render causes + explicit loss accounting —
  `explain-render-projects-causes-and-loss-accounting`.
- Serializable, not handles (deep no-ViewCell walk + EDN round-trip) —
  `projections-are-serializable-not-handles`.
- Production absence — `tool_view_elision_prod_test` + the extended bundle gate.
