### PR TITLE
docs(guide): make Guide 07 executable snippet self-contained and truth-bound (rf2-qww2o)

### DIFF
--- a/ai/findings/new-substrate-synthesis/guide/07-servers.md
+++ b/ai/findings/new-substrate-synthesis/guide/07-servers.md
@@ -157,11 +157,46 @@ either way: **I/O ends in events, and events are the only writers.**
 
 ## Testing the seam without a network
 
-Headless tests never touch a real HTTP client. Install the shared
-[test namespace fixture](08-testing.md#test-namespace-setup), register the
-resource, override `:rf.http/managed` with a capturing stub, then replay the
-transport's reply envelope yourself. Loading, success, failure, and retry all
-drive the **real** ensure → settle → sub path:
+Headless tests never touch a real HTTP client. The
+[test namespace setup](08-testing.md#test-namespace-setup) installs the JVM
+adapter; a resource test adds two things beside it — the resource and
+managed-HTTP artefacts on the require list, and a **capturing** `:rf.http/managed`
+fixture that records what the runtime lowered into an atom instead of doing I/O.
+The fx-handler is the ordinary binary `(fn [ctx args] …)`, so the capture is one
+line:
+
+```clojure
+(ns metrics.ui-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.fx :as fx]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui.test :as ui.test]
+            ;; load-bearing: register the resource events/subs, the
+            ;; managed-HTTP fx surface, the per-test reset hook, and the
+            ;; param validator — an app that uses resources already has these
+            ;; on its classpath.
+            [re-frame.resources]
+            [re-frame.resources.test-support]
+            [re-frame.http.managed]
+            [re-frame.schemas]))
+
+;; the last args the runtime lowered into :rf.http/managed — no network runs
+(def managed-args (atom nil))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter :ambient-frame nil})
+  (fn [f]                                    ; capture the transport, do no I/O
+    (reset! managed-args nil)
+    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! managed-args args)))
+    (f)))
+```
+
+With `managed-args` defined and the transport captured, the loading → success →
+sub path runs for real. `latency-tile` is the view from §2 above:
 
 ```clojure
 (deftest latency-tile-loads-and-recovers
@@ -184,9 +219,26 @@ drive the **real** ensure → settle → sub path:
                        "42"))))
 ```
 
-`@managed-args` is whatever the capturing `:rf.http/managed` stub recorded (its
+`@managed-args` is now defined: the capturing stub recorded it, and its
 `:on-success` is the runtime-owned `[:rf.resource.internal/succeeded …]` reply
-target). To pin a pure presentation state instead, stub the sub:
+target — so `(conj (:on-success @managed-args) {:status :ok :value …})` appends
+the envelope exactly as the live transport does. Replaying the **failure**
+envelope instead drives the error branch and its real retry; continue the same
+test:
+
+```clojure
+;; failure: replay {:status :error :error …} → the tile offers Retry
+(ui.test/dispatch! frame (conj (:on-failure @managed-args)
+                               {:status :error :error {:kind :rf.http/http-5xx}}))
+;; the retry control carries a real refetch event as data — assert it, then fire it
+(is (= [:rf.resource/refetch {:resource :metrics/latency-feed}]
+       (:on-click (ui.test/attrs
+                    (ui.test/find (ui.test/render [latency-tile] {:frame frame})
+                                  :button)))))
+(ui.test/dispatch! frame [:rf.resource/refetch {:resource :metrics/latency-feed}])
+```
+
+To pin a pure presentation state instead, stub the sub:
 
 ```clojure
 (ui.test/render [latency-tile]

--- a/implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj
@@ -15,7 +15,12 @@
   path, and the app-db counterpart (raw `:rf.http/managed` with
   `:on-success`/`:on-failure` handlers consuming the uniform reply envelope) is
   proven too. A false claim in the chapter reddens a deftest below, so the
-  transport / resource / app-db seams cannot drift apart.
+  transport / resource / app-db seams cannot drift apart. `guide07-chapter-
+  forms-stay-truth-bound` (rf2-qww2o) additionally binds the chapter's
+  load-bearing FORMS — keys, url, envelopes, app-db writes, retry intent, and
+  the self-contained `managed-args` atom + capturing `:rf.http/managed`
+  override the runnable snippet dereferences — so a Markdown-only drift reddens
+  even while these hand-copied deftests stay green.
 
   The managed-HTTP transport is exercised WITHOUT a network: `:rf.http/managed`
   is overridden with a capturing stub and the test replays the transport's
@@ -290,6 +295,59 @@
                                  {:status :ok :value {:p95 42}}))
       (is (str/includes?
             (uit/text (uit/render [latency-plain-tile] {:frame frame})) "42")))))
+
+(deftest guide07-chapter-forms-stay-truth-bound
+  ;; rf2-qww2o — the three deftests above PROVE the server-data behaviour with
+  ;; forms held here in the test. This gate BINDS those forms to the chapter
+  ;; text: every load-bearing key, path, envelope, app-db write, retry intent,
+  ;; and — crucially — the SELF-CONTAINED capturing fixture (the `managed-args`
+  ;; atom + the capturing `:rf.http/managed` override the runnable snippet
+  ;; dereferences) must appear verbatim in `07-servers.md`. A drift in the
+  ;; Markdown (a wrong key/url/envelope/refetch, or a snippet that again omits
+  ;; the atom/override) reddens HERE even while the executable deftests keep
+  ;; their own copies green.
+  (let [servers (slurp-guide "07-servers.md")
+        has?    (fn [needle] (str/includes? servers needle))]
+    (testing "§1 register — the 3-slot grammar, fail-closed scope, url, decode"
+      (is (has? "(rf/reg-resource :metrics/latency-feed"))
+      (is (has? ":scope") "the required scope key is shown")
+      (is (has? ":rf.scope/global") "the explicit global scope value")
+      (is (has? ":params-schema [:map]"))
+      (is (has? "{:method :get :url \"/api/metrics/latency\"}")
+          "the exact request the executable gate lowers verbatim")
+      (is (has? ":decode") "the Spec 014 decode key rides through")
+      (is (has? ":json") "the decode value"))
+    (testing "§2 view — lease liveness + passive [:rf/resource …] read"
+      (is (has? "(lease {:resource :metrics/latency-feed})"))
+      (is (has? "(sub [:rf/resource {:resource :metrics/latency-feed}])")))
+    (testing "the ensure cause the lease drives under the hood"
+      (is (has? "[:rf.resource/ensure")))
+    (testing "retry intent — the control carries a real refetch event as data"
+      (is (has? "[:rf.resource/refetch {:resource :metrics/latency-feed}]")))
+    (testing "the uniform reply envelope — success and failure shapes"
+      (is (has? ":status :ok") "success envelope tag")
+      (is (has? ":value") "success carries the decoded body under :value")
+      (is (has? ":status :error") "failure envelope tag")
+      (is (has? "{:status :ok :value {:p95 42}}")
+          "the exact success envelope the gate replays as the last reply arg"))
+    (testing "§Firing a request without a resource — the app-db seam"
+      (is (has? ":on-success [:metrics/latency-arrived]"))
+      (is (has? ":on-failure [:metrics/latency-failed]"))
+      (is (has? "(assoc db :latency {:status :loaded :p95 (:p95 value)})")
+          "the success handler consumes the envelope's :value into app-db")
+      (is (has? "(sub [:metrics/latency])")
+          "the plain tile reads ordinary app-db"))
+    (testing "the runnable testing snippet is SELF-CONTAINED (rf2-qww2o)"
+      (is (has? "(def managed-args (atom nil))")
+          "the managed-args atom is DEFINED in the chapter, not private to this test")
+      (is (has? "(fx/reg-fx :rf.http/managed")
+          "the capturing :rf.http/managed override is INSTALLED in the chapter")
+      (is (has? "(reset! managed-args args)")
+          "the override CAPTURES the lowered args into managed-args")
+      (is (has? "(conj (:on-success @managed-args)")
+          "success replays the transport's reply-append shape onto the captured target")
+      (is (has? "(conj (:on-failure @managed-args)")
+          "failure replays the transport's reply-append shape onto the captured target"))))
 
 (deftest lifecycle-recipe-is-installed-and-owned
   (let [getting-started (slurp-guide "01-getting-started.md")


### PR DESCRIPTION
## What

The advertised runnable **Guide 07** testing snippet (`ai/findings/new-substrate-synthesis/guide/07-servers.md`, "Testing the seam without a network") dereferenced `@managed-args` without ever defining the atom or installing the capturing `:rf.http/managed` override. The linked Guide 08 fixture only installs the substrate adapter; the missing atom + capturing fixture lived **privately** inside `guide_truth_jvm_test`. So a reader could not copy-run the snippet, and the Markdown could drift back to wrong keys/paths/retry-intent while the 10-test suite stayed green (it string-bound only the generic `with-new-frame` spelling).

### Defects (before → after)

- `07-servers.md` testing snippet dereferenced `@managed-args` — **undefined** in the chapter → the atom `(def managed-args (atom nil))` and the capturing `(fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! managed-args args)))` fixture are now shown **in the snippet**, composed beside the Guide 08 adapter fixture, with the load-bearing requires (`re-frame.resources`, `re-frame.resources.test-support`, `re-frame.http.managed`, `re-frame.schemas`).
- prose claimed "override `:rf.http/managed` with a capturing stub" but **no code showed it** → the override is now the one-line binary `(fn [ctx args] ...)` handler, matching the shipped fx-handler signature.
- truth gate string-bound only `with-new-frame` for Guide 07 → new `guide07-chapter-forms-stay-truth-bound` deftest binds every load-bearing chapter form.

### Self-containment

Every symbol the snippet dereferences is now defined in-snippet or clearly in-context (`latency-tile` is the section-2 view). A failure/retry continuation shows the `:on-failure` envelope replay and the real `[:rf.resource/refetch {:resource :metrics/latency-feed}]` intent, so loading / success-42 / failure / retry / recovery are all readable.

### Truth-binding (with runtime citations)

The new deftest binds the chapter text to the exact forms the executable deftests prove; a Markdown-only drift now reddens the gate. Verified against shipped runtime (runtime unchanged):

- **binary fx-handler** `(fn [ctx args] ...)` — `implementation/core/src/re_frame/fx.cljc:89` (`reg-fx` docstring: "Handler signature: `(fn [ctx args] ...)`").
- **reply-append envelope** `(conj (:on-success args) {:status :ok :value ...})` — `implementation/resources/test/re_frame/resources_managed_http_cljs_test.cljc:104-115` (`reply-success!`/`reply-failure!`) and the transport contract at that file's docstring (§4 "the managed-HTTP transport appends `{:status :ok :value <data>}` / `{:status :error :error <envelope>}` as the LAST arg").
- **`:rf.http/managed` keys** `:request` / `:decode` / `:on-success` / `:on-failure` and runtime-owned `[:rf.resource.internal/succeeded ...]` reply target — `resources_managed_http_cljs_test.cljc:175-210`.
- **per-test reset hook** requiring `re-frame.resources.test-support` — `implementation/resources/src/re_frame/resources/test_support.cljc:99` (`set-fn! :resources/reset-resources!`).
- **`:ambient-frame nil`** option — `implementation/core/src/re_frame/test_support.cljc:769`.

The truth-binding was proven live: mutating the chapter's `managed-args` atom def reddens `guide07-chapter-forms-stay-truth-bound`; reverting restores green.

## Quality gates

- `clojure -M:test -n re-frame.ui.guide-truth-jvm-test` (from `implementation/ui/`): **11 tests, 395 assertions, 0 failures** (was 10/371 — the new binding deftest adds 24 assertions).
- Negative check: mutating `(def managed-args (atom nil))` in the chapter → gate **FAILS** on the self-containment assertion; reverted → green.
- `python scripts/check_doc_slugs.py`: **exit 0** (clean).
- `python -m mkdocs build --strict`: **exit 0** (35s; INFO lines pre-existing, unrelated — the guide lives in `ai/` and is not in the site nav).
- Full spine not run (per brief — light doc surface).

rf2-qww2o
