### PR TITLE
fix(ui): close ViewCell evidence weak-cell v2→v3 migration/exactness/admission gaps (rf2-1hob1)

### DIFF
--- a/implementation/ui/src/re_frame/ui/tool/evidence.cljc
+++ b/implementation/ui/src/re_frame/ui/tool/evidence.cljc
@@ -101,6 +101,28 @@
 (def ^:private dynamic-marker {:rf.ui.evidence/opaque :dynamic})
 (def ^:private bounded-marker {:rf.ui.evidence/opaque :bounded})
 
+#?(:clj
+   (def ^:private exact-number-classes
+     "The closed set of immutable platform numeric classes admitted VERBATIM.
+     Each is a value-typed leaf that is NOT `IObj`, so an admitted number can
+     carry no hidden ViewCell — unlike an arbitrary `Number` subclass, which may
+     ALSO implement `IObj` and hold a cell in metadata or a field. Membership is
+     by EXACT class, so any subclass (a `proxy [Number IObj]` included) is
+     excluded and takes the opaque/inexact path (rf2-1hob1)."
+     #{java.lang.Long    java.lang.Integer    java.lang.Short   java.lang.Byte
+       java.lang.Double  java.lang.Float
+       java.math.BigInteger java.math.BigDecimal
+       clojure.lang.BigInt  clojure.lang.Ratio}))
+
+(defn- exact-number?
+  "True for a number safe to admit verbatim: a JS primitive number on CLJS
+  (never `IMeta`), or one of the closed set of immutable platform numeric
+  classes on the JVM (`exact-number-classes`), matched by exact class so no
+  `Number`/`IObj` subclass can root a ViewCell through metadata or a field."
+  [x]
+  #?(:clj  (contains? exact-number-classes (class x))
+     :cljs (number? x)))
+
 (defn- project-target-value
   "Copy one target value into bounded plain EDN, returning `[copy exact?]`.
 
@@ -109,17 +131,26 @@
   identity-bearing object or query→cell back-edge can enter the long-lived
   weak-registry value. Ordinary bounded EDN remains exact.
 
-  METADATA is the subtle leak (rf2-vxgfnd.94.17). Among the scalar leaves only
-  the SYMBOL is metadata-capable — `(with-meta 'q {:cell cell})` is a legal
-  target value whose metadata can hold the very ViewCell the entry is
-  weak-keyed by, so returning the symbol verbatim roots the key. (nil, boolean,
-  number, char and string are not `IMeta`; a keyword is interned and rejects
-  metadata on both hosts; a record is already opaque.) A metadata-bearing
-  symbol is REBUILT from its ns/name — value-equal, provably free of any hidden
-  field — and marked inexact, because dropping the metadata changed what the
-  original carried. Collection metadata needs no special case: every collection
-  branch reconstructs a fresh value, so container-level metadata never
-  survives; a metadata-bearing symbol NESTED in one is stripped by the same leaf
+  METADATA is the subtle leak (rf2-vxgfnd.94.17). The metadata-capable scalar
+  leaf is the SYMBOL — `(with-meta 'q {:cell cell})` is a legal target value
+  whose metadata can hold the very ViewCell the entry is weak-keyed by, so
+  returning the symbol verbatim roots the key. (nil, boolean, char and string
+  are not `IMeta`; a keyword is interned and rejects metadata on both hosts; a
+  record is already opaque.) A metadata-bearing symbol is REBUILT from its
+  ns/name — value-equal, provably free of any hidden field — and marked inexact,
+  because dropping the metadata changed what the original carried.
+
+  NUMBERS are admitted verbatim ONLY from a closed set of immutable platform
+  numeric classes (`exact-number?`). On the JVM `number?` alone is not enough: a
+  `Number` subclass can ALSO be `IObj`, so a `proxy [Number IObj]` holding a
+  ViewCell in metadata or a field is `number?` and would slip through as exact
+  and root the key (rf2-1hob1). Any class outside the set takes the opaque path.
+
+  COLLECTION metadata does not LEAK — every collection branch reconstructs a
+  fresh, metadata-free value — but dropping it is still information loss, so a
+  reconstructed vector/list/map/set whose original carried metadata is marked
+  INEXACT, the same honesty the symbol rule applies (rf2-1hob1). A
+  metadata-bearing symbol NESTED in a collection is stripped by the same leaf
   rule on the recursion."
   ([x] (project-target-value x 0 (volatile! target-node-cap)))
   ([x depth budget]
@@ -131,7 +162,7 @@
          (> depth target-depth-cap)
          [bounded-marker false]
 
-         (or (nil? x) (boolean? x) (number? x) (char? x))
+         (or (nil? x) (boolean? x) (char? x) (exact-number? x))
          [x true]
 
          (string? x)
@@ -166,13 +197,17 @@
          (if (> (count x) target-value-cap)
            [bounded-marker false]
            (let [parts (mapv #(project-target-value % (inc depth) budget) x)]
-             [(mapv first parts) (every? second parts)]))
+             ;; A reconstructed container drops its own metadata (no back-edge);
+             ;; that dropped metadata is loss, so it lowers exactness too.
+             [(mapv first parts)
+              (and (every? second parts) (nil? (meta x)))]))
 
          (list? x)
          (if (> (count x) target-value-cap)
            [bounded-marker false]
            (let [parts (mapv #(project-target-value % (inc depth) budget) x)]
-             [(apply list (map first parts)) (every? second parts)]))
+             [(apply list (map first parts))
+              (and (every? second parts) (nil? (meta x)))]))
 
          (map? x)
          (if (> (count x) target-value-cap)
@@ -182,11 +217,13 @@
                                 (project-target-value v (inc depth) budget)])
                              x)]
              ;; A partial map could misstate which value belonged to which key.
-             ;; Preserve it only when every copied association is exact.
+             ;; Preserve it only when every copied association is exact — and
+             ;; even then, dropping the map's own metadata lowers exactness.
              (if (every? (fn [[[_ k-exact?] [_ v-exact?]]]
                            (and k-exact? v-exact?))
                          parts)
-               [(into {} (map (fn [[[k _] [v _]]] [k v])) parts) true]
+               [(into {} (map (fn [[[k _] [v _]]] [k v])) parts)
+                (nil? (meta x))]
                [dynamic-marker false])))
 
          (set? x)
@@ -195,7 +232,7 @@
            (let [parts (mapv #(project-target-value % (inc depth) budget) x)
                  copy  (into #{} (map first) parts)]
              (if (and (every? second parts) (= (count copy) (count x)))
-               [copy true]
+               [copy (nil? (meta x))]
                [dynamic-marker false])))
 
          :else
@@ -333,8 +370,13 @@
   ;; earlier heads — is LEGACY, and its entries are re-projected on migration
   ;; (rf2-vxgfnd.94.18). BUMP THIS whenever the copier changes what a retained
   ;; value may hold: v1 admitted metadata-bearing symbols, whose metadata could
-  ;; hold the very ViewCell the entry is weak-keyed by (rf2-vxgfnd.94.17).
-  ::weak-cell-entries-v2)
+  ;; hold the very ViewCell the entry is weak-keyed by (rf2-vxgfnd.94.17). v2 was
+  ;; minted at an intermediate head whose copier ALSO returned those symbols
+  ;; verbatim, and the copier was then FIXED under the same v2 tag — so a store
+  ;; HMR-migrated at that head carries a v2 tag over metadata-bearing values and
+  ;; would be trusted forever. v3 rejects every pre-final store and re-projects
+  ;; it (rf2-1hob1).
+  ::weak-cell-entries-v3)
 
 (def ^:private ^:const weak-store-tag-key ::weak-cell-entries)
 

--- a/implementation/ui/test/re_frame/ui/tool_evidence_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/tool_evidence_cljs_test.cljc
@@ -368,7 +368,10 @@
             q   (get tk 2)]
         (is (= [::q 1] q) "the collection value is preserved")
         (is (nil? (meta q)) "…without its metadata")
-        (is (nil? (meta tk)) "nor does the target vector keep metadata")))
+        (is (nil? (meta tk)) "nor does the target vector keep metadata")
+        (is (false? (:targets-exact? ev))
+            "dropped container metadata is loss, so exactness is lowered (rf2-1hob1)")
+        (is (false? (:dropped-exact? ev)))))
 
     (testing "an ordinary metadata-free symbol remains exact"
       (let [ev (:evidence (entry-for ::sym-ordinary))]
@@ -377,6 +380,71 @@
         (is (nil? (meta (get-in ev [:targets 0 2 1]))))
         (is (true? (:targets-exact? ev)) "…and honestly exact")
         (is (true? (:dropped-exact? ev)))))))
+
+(deftest container-metadata-is-dropped-and-lowers-exactness
+  ;; rf2-1hob1 gap 2. Every collection branch reconstructs a fresh, metadata-free
+  ;; value (no leak), but derived `exact?` from its CHILDREN alone — so a
+  ;; container that DROPPED its own metadata still reported exact, making
+  ;; `:targets-exact?`/`:dropped-exact?` lie. Dropping container metadata is
+  ;; information loss exactly like dropping a symbol's, and must lower exactness.
+  (let [project #'evidence/project-target-value]
+    (testing "a metadata-bearing vector keeps its value but is marked inexact"
+      (let [[copy exact?] (project (with-meta [:q 1] {:hidden :lost}))]
+        (is (= [:q 1] copy) "the value is reconstructed")
+        (is (nil? (meta copy)) "…without its metadata (no back-edge)")
+        (is (false? exact?) "…and is no longer claimed exact")))
+    (testing "a metadata-bearing list is marked inexact"
+      (let [[copy exact?] (project (with-meta (list :q 1) {:hidden :lost}))]
+        (is (= (list :q 1) copy))
+        (is (nil? (meta copy)))
+        (is (false? exact?))))
+    (testing "a metadata-bearing map is marked inexact"
+      (let [[copy exact?] (project (with-meta {:q 1} {:hidden :lost}))]
+        (is (= {:q 1} copy))
+        (is (nil? (meta copy)))
+        (is (false? exact?))))
+    (testing "a metadata-bearing set is marked inexact"
+      (let [[copy exact?] (project (with-meta #{:q 1} {:hidden :lost}))]
+        (is (= #{:q 1} copy))
+        (is (nil? (meta copy)))
+        (is (false? exact?))))
+    (testing "a metadata-FREE container of exact leaves stays exact (control)"
+      (is (= [[:q 1] true] (project [:q 1])))
+      (is (= [(list :q 1) true] (project (list :q 1))))
+      (is (= [{:q 1} true] (project {:q 1})))
+      (is (= [#{:q 1} true] (project #{:q 1}))))
+    (testing "nested container metadata lowers the outer projection's exactness"
+      (let [[copy exact?] (project [::q (with-meta [1 2] {:hidden :lost})])]
+        (is (= [::q [1 2]] copy) "the values reconstruct")
+        (is (false? exact?)
+            "the outer vector is exact only if every child projected exact")))))
+
+#?(:clj
+   (deftest jvm-number-subclass-holding-a-cell-is-projected-opaque
+     ;; rf2-1hob1 gap 3. `(number? x)` admits ANY `Number`, but on the JVM a
+     ;; `Number` subclass can ALSO be `IObj`: a `proxy [Number IObj]` holding a
+     ;; ViewCell in its metadata is `number?`, so the leaf rule returned it
+     ;; verbatim as EXACT and rooted the weak key. Admission must be a closed set
+     ;; of immutable platform numeric classes; a subclass takes the opaque path.
+     (let [cell   (reactive/make-cell ::rogue-number)
+           rogue  (proxy [java.lang.Number clojure.lang.IObj] []
+                    (intValue    [] 0)
+                    (longValue   [] 0)
+                    (floatValue  [] (float 0))
+                    (doubleValue [] 0.0)
+                    (meta        [] {:cell cell})
+                    (withMeta    [_] this))
+           [copy exact?] (#'evidence/project-target-value rogue)]
+       (is (number? rogue) "the rogue really IS a Number (it defeats `number?`)")
+       (is (false? exact?) "a Number subclass is never claimed exact")
+       (is (= {:rf.ui.evidence/opaque :dynamic} copy)
+           "…and is projected opaque, retaining no reference to the cell")
+       (testing "the ordinary immutable numeric leaves still project exact"
+         (doseq [n [0 -3 (long 7) (int 7) (short 7) (byte 7)
+                    1.5 (float 1.5) 1N 1/2 3.14M
+                    (bigint 9) (biginteger 9)]]
+           (is (= [n true] (#'evidence/project-target-value n))
+               (str n " (" (class n) ") is an admitted platform number")))))))
 
 #?(:clj
    (deftest metadata-bearing-symbol-does-not-defeat-weak-keys
@@ -421,6 +489,30 @@
                                 (nil? (.get ref)))
                               refs)))
            "neither a direct nor nested query→cell path owns the weak key")
+       (is (= [] (evidence/projection))))))
+
+#?(:clj
+   (deftest rogue-number-target-does-not-defeat-weak-keys
+     ;; The retention proof for rf2-1hob1 gap 3. The rogue Number holds the
+     ;; ViewCell the entry is weak-keyed by; before the closed-set admission the
+     ;; copier returned it verbatim as exact, so the store VALUE reached its own
+     ;; KEY and a WeakHashMap never collects such an entry — the row pinned
+     ;; forever. RED before the fix; the projected opaque marker holds nothing.
+     (is (true? (evidence/install! ::xray)))
+     (let [ref (let [cell  (connect-empty! (reactive/make-cell ::rogue-weak))
+                     rogue (proxy [java.lang.Number clojure.lang.IObj] []
+                             (intValue    [] 0)
+                             (longValue   [] 0)
+                             (floatValue  [] (float 0))
+                             (doubleValue [] 0.0)
+                             (meta        [] {:cell cell})
+                             (withMeta    [_] this))
+                     sink  (evidence/installed-sink)]
+                 (publish-target! sink cell [:sub fid rogue])
+                 (reactive/disconnect! cell)
+                 (java.lang.ref.WeakReference. cell))]
+       (is (true? (gc-until #(nil? (.get ^java.lang.ref.WeakReference ref))))
+           "a rogue Number target roots no weak key once projected opaque")
        (is (= [] (evidence/projection))))))
 
 #?(:cljs
@@ -479,6 +571,13 @@
 (defn- legacy-entry
   [ord vid evidence]
   {:cell-id ord :view-id vid :evidence evidence})
+
+(def ^:private tag-key @#'evidence/weak-store-tag-key)
+
+;; The intermediate contract tag (`::weak-cell-entries-v2`) — minted while the
+;; copier still returned metadata-bearing symbols verbatim, then kept over the
+;; copier fix. A store stamped with it must be treated as legacy (rf2-1hob1).
+(def ^:private v2-tag :re-frame.ui.tool.evidence/weak-cell-entries-v2)
 
 (deftest compatible-hmr-sanitizes-a-legacy-strong-map-store
   ;; The pre-weak head kept `:entries` as a STRONG persistent map keyed by
@@ -626,6 +725,66 @@
                                 (nil? (.get ref)))
                               refs)))
            "no migrated raw query→cell path survives to own its own weak key")
+       (is (= [] (evidence/projection))))))
+
+(deftest compatible-hmr-reprojects-a-v2-tagged-store
+  ;; rf2-1hob1 gap 1 [the P1]. `::weak-cell-entries-v2` was minted at an
+  ;; intermediate head whose copier still returned metadata-bearing symbols
+  ;; verbatim; the copier was FIXED under the same v2 tag. So a store
+  ;; HMR-migrated at that head carries the v2 tag over a symbol whose metadata
+  ;; holds a ViewCell — and `weak-store-current?` trusted ANY v2 store, skipping
+  ;; sanitization forever. The current tag must reject v2 and re-project it.
+  (is (true? (evidence/install! ::tool-a)))
+  (let [state* @#'evidence/state*
+        cell   (connect-empty! (reactive/make-cell ::v2-legacy))
+        store  (:entries @state*)]
+    (#'evidence/store-seed-entry!
+     store cell
+     (legacy-entry 5 ::v2-legacy
+                   (legacy-accrual [[:sub fid (with-meta 'q {:cell cell})]] [])))
+    ;; stamp the intermediate v2 tag over the seeded (metadata-bearing) store
+    (swap! state* assoc-in [:entries tag-key] v2-tag)
+
+    (is (true? (evidence/install! ::tool-a)) "the reload re-arms the same owner")
+
+    (testing "the v2 store is treated as legacy and re-projected"
+      (let [ev  (:evidence (entry-for ::v2-legacy))
+            sym (get-in ev [:targets 0 2])]
+        (is (= 'q sym) "value semantics preserved")
+        (is (nil? (meta sym)) "…but the metadata/back-reference is gone")
+        (is (false? (:targets-exact? ev)) "the dropped metadata is marked loss")
+        (is (false? (:dropped-exact? ev)))
+        (is (= 5 (:cell-id (entry-for ::v2-legacy))) "the ordinal survives")))
+
+    (testing "the store is now re-tagged current, so repeat HMR is idempotent"
+      (let [before (evidence/projection)]
+        (is (true? (evidence/install! ::tool-a)))
+        (is (true? (evidence/install! ::tool-a)))
+        (is (= before (evidence/projection))
+            "re-projecting an already-current row changes nothing")))))
+
+#?(:clj
+   (deftest v2-tagged-store-migration-releases-the-metadata-symbol-weak-key
+     ;; The retention proof for rf2-1hob1 gap 1. A v2-tagged store's
+     ;; metadata-bearing symbol is a back-edge from the entry VALUE, through the
+     ;; symbol's metadata, to its own weak KEY — and a WeakHashMap entry whose
+     ;; value reaches its key never collects. Trusting the v2 tag skipped
+     ;; re-projection, so the row pinned forever. RED before the tag bump.
+     (is (true? (evidence/install! ::tool-a)))
+     (let [state* @#'evidence/state*
+           ref    (let [cell  (connect-empty! (reactive/make-cell ::v2-weak))
+                        store (:entries @state*)]
+                    (#'evidence/store-seed-entry!
+                     store cell
+                     (legacy-entry 5 ::v2-weak
+                                   (legacy-accrual
+                                    [[:sub fid (with-meta 'q {:cell cell})]] [])))
+                    (swap! state* assoc-in [:entries tag-key] v2-tag)
+                    (reactive/disconnect! cell)
+                    (java.lang.ref.WeakReference. cell))]
+       (is (true? (evidence/install! ::tool-a)) "the compatible reload migrates")
+       (is (true? (gc-until #(nil? (.get ^java.lang.ref.WeakReference ref))))
+           "the re-projected v2 store no longer roots its own weak key")
        (is (= [] (evidence/projection))))))
 
 ;; ===========================================================================


### PR DESCRIPTION
Closes **rf2-1hob1** (P1). Bumps the `re-frame.ui.tool.evidence` retained-value
contract to v3 and closes three ownership/exactness gaps confirmed on current
main after rf2-vxgfnd.95.6. Surface is entirely `implementation/ui/src/re_frame/ui/tool/evidence.cljc`
(the store internals — copier, tag, exactness derivation); no `tools/` consumer
(.95.7/.95.8) or other surface is touched.

## The three gaps (confirmed on main, then fixed)

1. **Migration hole [the P1]** — `::weak-cell-entries-v2` was minted at an
   intermediate head whose copier still returned metadata-bearing symbols
   verbatim, then the copier was fixed under the *same* v2 tag.
   `weak-store-current?` trusted any v2 store, so `migrate-weak-store!` skipped
   re-projection forever and a `symbol-meta → ViewCell` back-edge rooted the weak
   key. **Fix:** bump the tag to `::weak-cell-entries-v3` so every pre-final store
   is re-projected/re-sanitized on migration.

2. **Container-metadata exactness lie** — the vector/list/map/set branches derived
   `exact?` from children only, so `(with-meta [:q 1] {:hidden :lost})` dropped its
   container metadata (no leak) but still reported exact, making
   `:targets-exact?`/`:dropped-exact?` lie. **Fix:** lower exactness whenever a
   reconstructed container carried `(meta x)`, the same honesty the symbol rule
   already applies.

3. **JVM Number admission hole** — `(number? x)` admitted arbitrary `Number`
   subclasses; a `proxy [Number IObj]` holding a ViewCell in metadata returned
   exact and rooted its weak key. **Fix:** restrict verbatim admission to a closed
   set of immutable platform numeric classes (matched by *exact* class); any
   subclass takes the opaque/inexact path. CLJS keeps `number?` (JS primitive
   numbers are never `IMeta`).

## Quality gates

Red-before / green-after was demonstrated per gap by reverting only the source
(keeping the new tests) — 16 assertions failed across all three gaps, then all
pass with the fix.

- `implementation/ui` JVM (`clojure -M:test`): **731 tests, 13740 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node): **9796 tests, 48148 assertions, 0 failures, 0 errors**
- Evidence namespace focused (`-n re-frame.ui.tool-evidence-cljs-test`): **21 tests, 218 assertions, 0 failures** (was 16 failures before the fix)

New / extended coverage:
- `container-metadata-is-dropped-and-lowers-exactness` — vector/list/map/set + nested (Gap 2, unit)
- `metadata-bearing-symbol-targets-are-stripped-and-marked-inexact` — added the missing `::meta-coll` exactness assertion (Gap 2, delivery path)
- `jvm-number-subclass-holding-a-cell-is-projected-opaque` + `rogue-number-target-does-not-defeat-weak-keys` (Gap 3, unit + weak-GC)
- `compatible-hmr-reprojects-a-v2-tagged-store` + `v2-tagged-store-migration-releases-the-metadata-symbol-weak-key` (Gap 1, migration value + weak-GC)

Rebased on rf2-vxgfnd.95.6 (#6139) and current origin/main.
