### PR TITLE
fix(observation): version the JVM provenance value-shape upgrade before preserving v2 holders (rf2-b0afn)

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -314,11 +314,31 @@
 ;; desync. CLJS stores the token unchanged.
 #?(:clj (def ^:private provenance-storage-version
           ;; Representation version of the private JVM provenance storage. BUMP when
-          ;; the holder shape changes so a reload over an older root REPLACES it. v2
-          ;; = the weak-identity `HashMap<WeakReference-key>` + `ReferenceQueue`
-          ;; (predecessor v1 was a raw synchronized `WeakHashMap<Throwable>` with NO
-          ;; version tag, so it reads uncurrent and is replaced).
-          2))
+          ;; the holder shape OR its stored VALUE representation changes, so a reload
+          ;; over an older root REPLACES it rather than mis-operating on retained
+          ;; entries.
+          ;;
+          ;; v3 (rf2-b0afn) = the weak-identity `HashMap<WeakReference-key>` +
+          ;; `ReferenceQueue` holder whose stored VALUES are the reload-stable raw
+          ;; channel SETs (`#{:always-on :trace}` / `#{:trace}`) (rf2-kia9st).
+          ;;
+          ;; v2 was the SAME holder shape but stored the `EmissionProvenance` DEFTYPE
+          ;; INSTANCE as each value (pre-rf2-kia9st / #6047). The current set-shaped
+          ;; reader [[source-covered-always-on?]] calls `contains?` DIRECTLY on the
+          ;; stored value, which THROWS `IllegalArgumentException` on a retained
+          ;; deftype instance — so a preserved v2 holder is a MID-READ throw hazard,
+          ;; NOT a compatible predecessor. #6047 changed the value shape but left the
+          ;; version at 2, so an old-v2→new-v2 upgrade read the pre-upgrade holder
+          ;; current and preserved its deftype-valued entries. Bumping 2→3 makes the
+          ;; value-shape upgrade an INCOMPATIBLE-holder transition: a v2 root reads
+          ;; uncurrent and is REPLACED (its deftype-valued entries dropped; any
+          ;; in-flight predecessor throwable reads uncovered so the disposal drain
+          ;; fails LOUD — an extra catalogued `:rf.error/observation-on-change-failed`
+          ;; record), never silently `contains?`-thrown mid-read.
+          ;;
+          ;; v1 (conceptual) was a raw synchronized `WeakHashMap<Throwable>` with NO
+          ;; version tag, so it too reads uncurrent and is replaced.
+          3))
 
 #?(:clj
    (defn- fresh-provenance-storage
@@ -334,8 +354,12 @@
    (defn- current-provenance-storage?
      "True when `s` is a CURRENT-version provenance storage holder — a Clojure map
      tagged with [[provenance-storage-version]]. A predecessor raw `WeakHashMap`
-     (`map?` false) or an older/newer-version holder reads false, so the load-time
-     reconciliation replaces it (rf2-qqvgk1)."
+     (`map?` false) reads false; so does an older-version holder — INCLUDING the
+     immediate-predecessor v2 holder whose stored VALUES are `EmissionProvenance`
+     deftype instances rather than raw channel sets (rf2-b0afn): same holder shape,
+     but its retained values would `contains?`-throw in [[source-covered-always-on?]],
+     so it is treated as INCOMPATIBLE. The load-time reconciliation replaces any such
+     root (rf2-qqvgk1 + rf2-b0afn)."
      [s]
      (and (map? s) (= provenance-storage-version (:version s)))))
 

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -3498,6 +3498,96 @@
            (alter-var-root #'obs/provenance-storage (constantly saved)))))))
 
 ;; ===========================================================================
+;; rf2-b0afn — the JVM provenance value-shape upgrade is VERSIONED, so a
+;; preserved IMMEDIATE-PREDECESSOR v2 holder is reconciled as INCOMPATIBLE,
+;; never `contains?`-thrown mid-read.
+;;
+;; #6047 (rf2-kia9st) changed the stored VALUE from an `EmissionProvenance`
+;; deftype INSTANCE to its reload-stable raw channel SET, but LEFT the storage
+;; version at 2 — the SAME version the immediate predecessor declared. So a
+;; reload over a pre-#6047 v2 holder read it current (`map?` + `:version 2`) and
+;; PRESERVED it, retaining deftype-instance values; the new set-shaped
+;; `source-covered-always-on?` reader then called `contains?` on a retained
+;; deftype instance and threw `IllegalArgumentException` MID-READ — an in-flight
+;; disposal-drain read escaping instead of preserving full-drain/exact-once
+;; coverage. The existing real-reload fixture only attests with the NEW
+;; representation before reloading, so it proves new→new reload, NOT the shipped
+;; old-v2→new-v2 value-shape upgrade. Bumping 2→3 makes the value-shape upgrade an
+;; INCOMPATIBLE-holder transition: a v2 root reads uncurrent and is REPLACED (its
+;; deftype-valued entries dropped; any in-flight predecessor throwable reads
+;; uncovered so the drain fails LOUD), never silently `contains?`-thrown.
+;; JVM-only: CLJS uses `js/WeakMap` (fresh realm per page reload).
+;; ===========================================================================
+
+#?(:clj
+   (deftest jvm-provenance-storage-reload-replaces-an-immediate-predecessor-v2-holder
+     ;; RED-before / GREEN-after: seed the IMMEDIATE PREDECESSOR v2 holder — the
+     ;; SAME holder SHAPE (`map?` + `:version 2` + HashMap + ReferenceQueue), but
+     ;; whose stored VALUES are `EmissionProvenance` deftype INSTANCES (the pre-#6047
+     ;; representation) rather than raw channel sets. Before the version bump this
+     ;; holder read current, was preserved, and `source-covered-always-on?` threw
+     ;; `contains?`-on-`EmissionProvenance` mid-read; after the bump it reads
+     ;; INCOMPATIBLE and is reconciled (replaced) WITHOUT throwing.
+     (let [saved @#'obs/provenance-storage]
+       (try
+         (let [q         (java.lang.ref.ReferenceQueue.)
+               m         (java.util.HashMap.)
+               ;; A throwable held STRONGLY so its entry survives to be read — only
+               ;; the version reconciliation, never GC, decides its fate here.
+               t         (ex-info "predecessor-shaped boom" {})
+               ;; The predecessor VALUE shape: the `EmissionProvenance` deftype
+               ;; INSTANCE (what pre-#6047 attest-provenance! stored), NOT a set.
+               pred-val  @#'obs/provenance-both-channels]
+           ;; The predecessor value is the deftype instance, NOT a set — so the
+           ;; current set-shaped reader's `contains?` throws on it (the bug symptom).
+           (is (not (set? pred-val))
+               "the seeded predecessor value is an EmissionProvenance instance, not a set")
+           (.put m (#'obs/weak-identity-key t q) pred-val)
+           ;; The pre-#6047 v2 holder: identical SHAPE, version 2, deftype values.
+           (alter-var-root #'obs/provenance-storage
+                           (constantly {:version 2 :by-throwable m :queue q}))
+           ;; With the version bumped 2→3 this predecessor v2 holder is recognized
+           ;; as INCOMPATIBLE (its value shape changed); before the bump it read
+           ;; current (`map?` + `:version 2` matched) — so this precondition reddens
+           ;; if the fix is reverted.
+           (is (not (#'obs/current-provenance-storage? @#'obs/provenance-storage))
+               (str "the immediate-predecessor v2 holder is recognized as an "
+                    "INCOMPATIBLE root (its stored VALUE representation changed), "
+                    "not a compatible same-version holder"))
+           ;; The reload's load-time reconciliation REPLACES the incompatible holder
+           ;; with a fresh current-version one — WITHOUT reading (and `contains?`-
+           ;; throwing on) the retained deftype values.
+           (#'obs/ensure-current-provenance-storage!)
+           (let [installed @#'obs/provenance-storage]
+             (is (#'obs/current-provenance-storage? installed)
+                 "a fresh current-version holder is installed after the upgrade reload")
+             (is (= @#'obs/provenance-storage-version (:version installed))
+                 "the installed holder carries the CURRENT storage version")
+             (is (instance? java.util.HashMap (:by-throwable installed))
+                 "the fresh holder's inner map is the current plain HashMap")
+             (is (instance? java.lang.ref.ReferenceQueue (:queue installed))
+                 "the fresh holder carries its own paired ReferenceQueue"))
+           ;; Post-upgrade coverage behavior is EXPLICIT: the dropped predecessor
+           ;; throwable reads UNCOVERED — a total, non-throwing read that lets the
+           ;; disposal drain fail LOUD (its own catalogued
+           ;; :rf.error/observation-on-change-failed record), never a silent
+           ;; `contains?`-on-`EmissionProvenance` throw escaping mid-drain.
+           (is (false? (#'obs/source-covered-always-on? t))
+               (str "the dropped predecessor throwable reads uncovered WITHOUT "
+                    "throwing — the value-shape upgrade reconciles via the "
+                    "incompatible-holder path (fail-loud), not a mid-read throw"))
+           ;; And the port round-trips over the reload-installed storage — a fresh
+           ;; attestation reads covered exactly-once.
+           (let [t2 (ex-info "post-upgrade boom" {})]
+             (#'obs/attest-provenance! t2 @#'obs/provenance-both-channels)
+             (is (true? (#'obs/source-covered-always-on? t2))
+                 "a fresh attestation round-trips over the reconciled storage")
+             (is (false? (#'obs/source-covered-always-on? (ex-info "unbound" {})))
+                 "an unbound throwable still reads uncovered")))
+         (finally
+           (alter-var-root #'obs/provenance-storage (constantly saved)))))))
+
+;; ===========================================================================
 ;; ABI guard
 ;; ===========================================================================
 


### PR DESCRIPTION
## Problem

PR #6047 (rf2-kia9st) changed the JVM provenance holder's stored **value** from an `EmissionProvenance` deftype instance to its reload-stable raw **channel set**, but left `provenance-storage-version` at **2** — the same version its immediate predecessor declared (`observation.cljc:315`).

So `ensure-current-provenance-storage!` treated a pre-#6047 v2 holder as current (`map?` + `:version 2`) and **preserved** its old deftype-valued entries. The new set-shaped `source-covered-always-on?` reader then calls `contains?` **directly** on the retained value (`observation.cljc:506`), which throws `IllegalArgumentException: contains? not supported on type: …EmissionProvenance` on a shipped old-v2→new-v2 upgrade — an in-flight disposal-drain read escaping instead of preserving full-drain / exact-once coverage.

The existing "real-reload" regression only attests with the **new** representation before reloading, so it proves new→new reload, not the old-v2→new-v2 value-shape upgrade.

## Fix

Bump the storage version **2 → 3** so the value-shape upgrade is an **incompatible-holder** transition. A pre-upgrade v2 holder now reads uncurrent and is **replaced** by `ensure-current-provenance-storage!` (its deftype-valued entries dropped). Any in-flight predecessor throwable reads uncovered, so the disposal drain fails **loud** via the already-catalogued `:rf.error/observation-on-change-failed` record — never a silent `contains?`-on-`EmissionProvenance` throw mid-read. This is exactly the documented incompatible-holder path the reconciler was designed for; the bug was simply the un-bumped version.

Models the merged rf2-1hob1 v2→v3 storage-tag pattern. Minimal, no store redesign, no new error-id (reuses the existing drain record path).

## Tests

New JVM fixture `jvm-provenance-storage-reload-replaces-an-immediate-predecessor-v2-holder` seeds a **true predecessor-shaped** v2 holder — same holder shape, `:version 2`, but stored **`EmissionProvenance` deftype instances** as values:

- **Red-before** (version un-bumped): the v2 holder reads current, is preserved, and `source-covered-always-on?` throws `IllegalArgumentException: contains? not supported on type: …EmissionProvenance`.
- **Green-after** (version 3): the v2 holder reads incompatible, is reconciled (replaced) **without throwing**; the dropped predecessor throwable reads **uncovered** (fail-loud path); a fresh attestation round-trips over the reconciled storage.

The adjacent `jvm-provenance-survives-a-real-namespace-reload-covered-exactly-once` (new→new reload, exact-once, weak-lifecycle) stays green.

## Quality gates

All run in foreground, unpiped, from the worktree:

- `implementation/core` JVM (`clojure -M:test`): **2037 tests, 9504 assertions, 0 failures, 0 errors**.
- Full observation-port namespace (`-n re-frame.observation-port-cljs-test`): **94 tests, 661 assertions, 0 failures, 0 errors**.
- New fixture red-before: **1 failure + 1 error** (the `contains?`-on-`EmissionProvenance` throw); green-after (with the 3 adjacent reload tests): **4 tests, 30 assertions, 0 failures, 0 errors**.
- `npm run test:cljs`: **9794 tests, 48118 assertions, 0 failures, 0 errors**. (A single load-induced flake appeared on the first run in an unrelated namespace; a clean re-run was fully green. The change is strictly `#?(:clj …)` and does not compile into CLJS, so it cannot affect the CLJS suite.)
