### PR TITLE
fix(machines): resolve join completion overrides once under the exact-owner fence (rf2-5g6qq)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -501,49 +501,68 @@
     :rf.fx/clear-flow
     :rf.route/with-nav-token})
 
+(defn classify-fx-override
+  "Resolve `overrides`[`fx-id`] into ONE structured disposition, performing the
+  registrar + protected-target lookup EXACTLY ONCE. This is THE single override
+  policy — `real-override?`, `override-applies?`, and `resolve-fx-with-overrides`
+  all express themselves over it, and the machines join-completion transport
+  (`:rf.machine/join-dispatch`) consumes the SAME disposition under its
+  exact-owner fence (rf2-5g6qq). Because the classification is taken once and
+  wholly determines the caller's branch, a concurrent register / unregister can
+  never flip an applies-preflight into a different EXECUTION disposition.
+
+  Returns a map `{:disposition <kw> …}`:
+
+    {:disposition :noop}
+      No override, or the documented nil/false placeholder — the original fx runs.
+    {:disposition :applied-fn :override <fn>}
+      A fn-value override runs IN PLACE OF the fx (CLJS-reference convenience).
+    {:disposition :applied-redirect :target <fx-id>}
+      A keyword redirect to a REGISTERED, NON-PROTECTED fx runs in place.
+    {:disposition :fallthrough :reason :unregistered :target <fx-id>}
+    {:disposition :fallthrough :reason :malformed :value <v>}
+      A real but non-applying override — surface `:rf.error/override-fallthrough`
+      (`emit-override-fallthrough!`), then run the original fx.
+    {:disposition :protected-rejection :target <fx-id>}
+      A keyword redirect whose TARGET is a protected internal id
+      (`rejected-reserved-fx-ids`) — refused, same fallthrough diagnostic.
+
+  Pure and non-emitting (mirrors the value-inspecting predicate family); callers
+  own any diagnostic / execution."
+  [overrides fx-id]
+  (let [v (get overrides fx-id)]
+    (cond
+      (or (nil? v) (false? v)) {:disposition :noop}
+      (fn? v)                  {:disposition :applied-fn :override v}
+      (keyword? v)
+      (cond
+        (contains? rejected-reserved-fx-ids v) {:disposition :protected-rejection :target v}
+        (registrar/lookup :fx v)               {:disposition :applied-redirect :target v}
+        :else                                  {:disposition :fallthrough :reason :unregistered :target v})
+      :else                    {:disposition :fallthrough :reason :malformed :value v})))
+
 (defn real-override?
   "True iff `overrides` carries a GENUINE override for `fx-id` — a fn body, a
   keyword redirect, or any other non-noop value (which `resolve-fx-with-
   overrides` then reports) — as opposed to the documented nil/false no-op
   placeholder (spec/002 §`:fx-overrides`: \"nil/false → no override, fall
   through\"). The single definition of \"is this fx actually overridden\",
-  shared by the reject-tier gate (`real-reject-override?`) and the machines
-  `:rf.machine/join-dispatch` transport's override-first resolution (rf2-ulsbgr
-  — a `:spawn-all` child completion whose canonical `:dispatch` / `:dispatch-
-  later` is overridden must route through that override, NOT be lowered to the
-  private recordable transport). Public so the machines transport reuses this
-  one definition rather than forking a second override engine."
+  shared by the reject-tier gate (`real-reject-override?`). A thin predicate over
+  the ONE `classify-fx-override` policy (any non-`:noop` disposition)."
   [overrides fx-id]
-  (let [v (get overrides fx-id)]
-    (and (some? v) (not (false? v)))))
+  (not= :noop (:disposition (classify-fx-override overrides fx-id))))
 
 (defn override-applies?
   "True iff `overrides` carries an override for `fx-id` that will ACTUALLY run
   an application-controlled handler IN PLACE OF the fx — a fn-value, or a
-  keyword redirect to a REGISTERED, NON-PROTECTED fx. This is the STRICTER
-  companion to `real-override?`: an override value that `real-override?` counts
-  as genuine but that does NOT run an app handler returns false here — a
-  nil/false noop, an UNREGISTERED-keyword or MALFORMED value (both fall through
-  to the original fx via `:rf.error/override-fallthrough`), and a redirect whose
-  TARGET is a PROTECTED internal id (`rejected-reserved-fx-ids`).
-
-  The machines join-completion transport (`:rf.machine/join-dispatch`, rf2-t154jx)
-  uses this to decide whether a public `{:dispatch …}` / `{:dispatch-later …}`
-  override GENUINELY pre-empts a `:spawn-all` child's completion — routed through
-  the shared override engine `handle-one-fx`, minting no private authority
-  (rf2-ulsbgr) — or merely falls through, in which case the authenticated
-  recordable transport must still run so the join folds (rf2-2lzk8a). It shares
-  `resolve-fx-with-overrides`'s registrar lookup + protected-target rule and is
-  the NON-EMITTING pre-flight predicate for that ONE engine (mirrors the
-  existing `real-override?` / `real-reject-override?` value-inspecting
-  predicates), not a second resolver."
+  keyword redirect to a REGISTERED, NON-PROTECTED fx. The STRICTER companion to
+  `real-override?`: a nil/false noop, an UNREGISTERED-keyword or MALFORMED value,
+  and a redirect whose TARGET is a PROTECTED internal id all return false. A thin
+  predicate over the ONE `classify-fx-override` policy (an `:applied-fn` /
+  `:applied-redirect` disposition)."
   [overrides fx-id]
-  (let [v (get overrides fx-id)]
-    (cond
-      (fn? v)      true
-      (keyword? v) (and (not (contains? rejected-reserved-fx-ids v))
-                        (some? (registrar/lookup :fx v)))
-      :else        false)))
+  (contains? #{:applied-fn :applied-redirect}
+             (:disposition (classify-fx-override overrides fx-id))))
 
 (defn- real-reject-override?
   "True iff `overrides` carries a GENUINE reject-tier override attempt for
@@ -932,8 +951,71 @@
          overrides))
      overrides)))
 
+(defn emit-override-fallthrough!
+  "Surface the canonical `:rf.error/override-fallthrough` diagnostic for a
+  non-applying override `disposition` (a `:fallthrough` or `:protected-rejection`
+  from `classify-fx-override`) on BOTH error substrates — the always-on error-emit
+  fan-out (rf2-goum9x: override misconfiguration is production-reachable) and the
+  dev trace. A no-op for `:noop` / `:applied-*` dispositions.
+
+  The ONE emit path shared by `resolve-fx-with-overrides` and the machines
+  join-completion transport (`:rf.machine/join-dispatch`, rf2-5g6qq), so a
+  misconfigured override on a join completion reads identically to one on any
+  other dispatch. `frame-id` / `origin-event` / `origin-event-id` (rf2-goum9x)
+  frame-attribute the emit; the recovery is the framework's own
+  `:replaced-with-default` (use the registered `original-fx-id`)."
+  [{:keys [disposition reason target value]}
+   original-fx-id overrides frame-id origin-event origin-event-id]
+  (case disposition
+    ;; rf2-2lzk8a — a redirect whose TARGET is a protected internal id: refused,
+    ;; fail safely exactly like an unregistered target.
+    :protected-rejection
+    (emit-fx-error! :rf.error/override-fallthrough
+                    origin-event origin-event-id frame-id nil
+                    {:failing-id    original-fx-id
+                     :overrides-map overrides
+                     :looked-up-id  target
+                     :frame         frame-id
+                     :reason        (str "Override redirected `" original-fx-id
+                                         "` to `" target
+                                         "`, a PROTECTED internal fx-id that "
+                                         "may not be an override target. Using "
+                                         "the registered `" original-fx-id "` instead.")
+                     :recovery      :replaced-with-default})
+
+    :fallthrough
+    (if (= reason :unregistered)
+      (emit-fx-error! :rf.error/override-fallthrough
+                      origin-event origin-event-id frame-id nil
+                      {:failing-id    original-fx-id
+                       :overrides-map overrides
+                       :looked-up-id  target
+                       :frame         frame-id
+                       :reason        (str "Override redirected `" original-fx-id
+                                           "` to `" target
+                                           "`, which is not registered. Using the registered `"
+                                           original-fx-id "` instead.")
+                       :recovery      :replaced-with-default})
+      ;; :malformed — any value that is not a keyword / fn / nil / false.
+      (emit-fx-error! :rf.error/override-fallthrough
+                      origin-event origin-event-id frame-id nil
+                      {:failing-id    original-fx-id
+                       :overrides-map overrides
+                       :override      value
+                       :frame         frame-id
+                       :reason        (str "Override for `" original-fx-id
+                                           "` is `" (pr-str value)
+                                           "`, which is not a valid `:fx-overrides` "
+                                           "value — it must be an fx-id keyword "
+                                           "(id-redirect), a function (override body), "
+                                           "or nil/false (noop). Using the registered `"
+                                           original-fx-id "` instead.")
+                       :recovery      :replaced-with-default}))
+    nil))
+
 (defn resolve-fx-with-overrides
-  "Apply fx-id overrides per Spec 002 §Per-frame and per-call overrides.
+  "Apply fx-id overrides per Spec 002 §Per-frame and per-call overrides, over the
+  ONE `classify-fx-override` policy.
 
   Three override-value shapes are honoured (per [002 §`:fx-overrides`](spec/002-Frames.md#fx-overrides--replace-fx-handlers)):
 
@@ -968,128 +1050,33 @@
   frame-attributed and fanned out through the always-on error-emit
   substrate (not just the dev trace) — they are otherwise read-only here."
   [original-fx-id overrides frame-id origin-event origin-event-id]
-  (if (contains? overrides original-fx-id)
-    (let [override-target (get overrides original-fx-id)]
-      (cond
-        ;; (3) function value — CLJS-reference convenience. The
-        ;; `:rf.fx/override-applied` trace is emitted by `handle-one-fx`
-        ;; when the override fn actually fires (not here), because a
-        ;; fn-value override of a *reserved* fx-id must pre-empt the
-        ;; reserved body — emitting the trace here would fire it even on
-        ;; paths that (counterfactually) declined the override. Returns
-        ;; the original-fx-id unchanged; `resolved-fx-meta` synthesises
-        ;; the meta carrying the user's fn.
-        (fn? override-target)
-        original-fx-id
+  (let [disposition (classify-fx-override overrides original-fx-id)]
+    (case (:disposition disposition)
+      ;; (3) function value — CLJS-reference convenience. Returns the
+      ;; original-fx-id unchanged; the `:rf.fx/override-applied` trace is
+      ;; emitted by `handle-one-fx` when the override fn actually fires (a
+      ;; fn-value override of a *reserved* fx-id must pre-empt the reserved
+      ;; body — emitting here would fire even on paths that declined it).
+      :applied-fn       original-fx-id
 
-        ;; (2) id-redirect to a registered fx.
-        (keyword? override-target)
-        (cond
-          ;; rf2-2lzk8a — REFUSE a redirect whose TARGET is a protected internal
-          ;; id (`rejected-reserved-fx-ids`: the state-installing lifecycle fxs,
-          ;; the nav-token threader, and the private `:rf.machine/join-dispatch`
-          ;; join-completion transport). An app must not reach a framework-
-          ;; internal transport by redirecting a canonical effect — it would
-          ;; bypass the reserved-key reject (an app can already not OVERRIDE
-          ;; these ids), escalate privilege, and for the self-recursive
-          ;; `:rf.machine/join-dispatch` re-enter override resolution unboundedly
-          ;; to a StackOverflowError. Fail safely exactly like an unregistered
-          ;; target: emit the canonical override-fallthrough and use the
-          ;; original fx.
-          (contains? rejected-reserved-fx-ids override-target)
-          (do
-            (emit-fx-error! :rf.error/override-fallthrough
-                            origin-event
-                            origin-event-id
-                            frame-id
-                            nil
-                            {:failing-id     original-fx-id
-                             :overrides-map  overrides
-                             :looked-up-id   override-target
-                             :frame          frame-id
-                             :reason         (str "Override redirected `"
-                                                  original-fx-id
-                                                  "` to `"
-                                                  override-target
-                                                  "`, a PROTECTED internal fx-id that "
-                                                  "may not be an override target. Using "
-                                                  "the registered `"
-                                                  original-fx-id
-                                                  "` instead.")
-                             :recovery       :replaced-with-default})
-            original-fx-id)
+      ;; (2) id-redirect to a registered fx.
+      :applied-redirect (do
+                          (trace/emit! :rf.fx :rf.fx/override-applied
+                                       {:rf.fx/from original-fx-id
+                                        :rf.fx/to   (:target disposition)})
+                          (:target disposition))
 
-          (registrar/lookup :fx override-target)
-          (do
-            (trace/emit! :rf.fx :rf.fx/override-applied
-                         {:rf.fx/from original-fx-id :rf.fx/to override-target})
-            override-target)
-          :else
-          (do
-            ;; rf2-goum9x: override misconfiguration is a production-
-            ;; reachable runtime error (Spec 009 §Error event catalogue) —
-            ;; fan it out through the always-on listener so override-map
-            ;; mistakes are visible in production, not only under dev
-            ;; traces. The recovery is the framework's own
-            ;; `:replaced-with-default` (use the registered fx).
-            (emit-fx-error! :rf.error/override-fallthrough
-                            origin-event
-                            origin-event-id
-                            frame-id
-                            nil
-                            {:failing-id     original-fx-id
-                             :overrides-map  overrides
-                             :looked-up-id   override-target
-                             :frame          frame-id
-                             :reason         (str "Override redirected `"
-                                                  original-fx-id
-                                                  "` to `"
-                                                  override-target
-                                                  "`, which is not registered. Using the registered `"
-                                                  original-fx-id
-                                                  "` instead.")
-                             :recovery       :replaced-with-default})
-            original-fx-id))
+      ;; A real but non-applying override — surface the canonical fallthrough
+      ;; (protected-target redirect, unregistered keyword, or malformed value)
+      ;; through the shared emit path, then fall back to the original fx.
+      (:fallthrough :protected-rejection)
+      (do
+        (emit-override-fallthrough! disposition original-fx-id overrides
+                                    frame-id origin-event origin-event-id)
+        original-fx-id)
 
-        ;; `nil` / `false` — the documented noop-style placeholder
-        ;; (spec/002 §`:fx-overrides`): "no override", silently fall
-        ;; through to the original fx. KEPT silent on purpose.
-        (or (nil? override-target) (false? override-target))
-        original-fx-id
-
-        :else
-        ;; Any OTHER value (a number / string / map / vector / …) is a
-        ;; malformed `:fx-overrides` entry — an `:fx-overrides` value must
-        ;; be an fx-id keyword (id-redirect), a fn (override body), or
-        ;; nil/false (noop). Fail LOUD, matching the sibling
-        ;; unregistered-keyword branch (rf2-3az1vn P2 + spec/002 §`:fx-overrides`
-        ;; :else throw): emit `:rf.error/override-fallthrough` through BOTH
-        ;; error substrates so a silently-swallowed bad override surfaces in
-        ;; dev AND production observability, then fall through to the original
-        ;; fx (recovery `:replaced-with-default`).
-        (do
-          (emit-fx-error! :rf.error/override-fallthrough
-                          origin-event
-                          origin-event-id
-                          frame-id
-                          nil
-                          {:failing-id    original-fx-id
-                           :overrides-map overrides
-                           :override      override-target
-                           :frame         frame-id
-                           :reason        (str "Override for `"
-                                               original-fx-id
-                                               "` is `"
-                                               (pr-str override-target)
-                                               "`, which is not a valid `:fx-overrides` "
-                                               "value — it must be an fx-id keyword "
-                                               "(id-redirect), a function (override body), "
-                                               "or nil/false (noop). Using the registered `"
-                                               original-fx-id
-                                               "` instead.")
-                           :recovery      :replaced-with-default})
-          original-fx-id)))
-    original-fx-id))
+      ;; `:noop` — missing key / nil / false. KEPT silent on purpose.
+      original-fx-id)))
 
 (defn- resolved-fx-meta
   "Return the fx-handler meta to invoke for `original-fx-id` under

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -64,6 +64,7 @@
   lookup."
   (:require [re-frame.frame :as frame]
             [re-frame.fx :as fx]
+            [re-frame.machines.data-validation :as data-validation]
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.path-walk :as path-walk]
             [re-frame.machines.paths :as paths]
@@ -190,27 +191,47 @@
   `:dispatch-later` completion to this PRIVATE id BEFORE core override
   resolution, so `do-fx` looked up `:fx-overrides` under the private id and a
   `{:fx-overrides {:dispatch capture-fn}}` never intercepted the completion.
-  Here we resolve the CANONICAL override FIRST: when the completion's authored
-  id (`:dispatch-later` for a numeric `:ms`, else `:dispatch`) has an override
-  that GENUINELY APPLIES — a fn-value or a keyword redirect to a REGISTERED,
-  NON-PROTECTED fx, per `re-frame.fx/override-applies?` — in the SAME effective
-  override map `do-fx` used (per-frame ⋈ per-call, per-call winning), we route
-  the canonical `[fx-id args]` back through the shared core seam
-  `re-frame.fx/handle-one-fx` (the identical resolution a normal dispatch flows
-  through). The override captures / redirects the completion, queues nothing,
-  and folds nothing — the framework-produced path never runs, so no coordinate
-  is stamped onto the normal transport.
+  Here we take ONE structured resolution of the CANONICAL override
+  (`:dispatch-later` for a numeric `:ms`, else `:dispatch`) from the SHARED
+  policy `re-frame.fx/classify-fx-override`, against the SAME effective override
+  map `do-fx` used (per-frame ⋈ per-call, per-call winning), then consume THAT
+  ONE disposition (rf2-5g6qq):
 
-  Every OTHER disposition — no override, a nil/false noop, an UNREGISTERED
-  keyword, a MALFORMED value, or a redirect to a PROTECTED internal id — is NOT
-  an applied override: it falls through to the recordable transport below, so
-  the join still folds EXACTLY ONCE on the framework-produced coordinate (the
-  pre-fix `real-override?` gate routed these to `handle-one-fx`, where the
-  fall-through re-dispatched a coordinate-less `:dispatch` that the parent's
-  fence suppressed `:attempt-unverified`, hanging the join). The canonical
-  `:rf.error/override-fallthrough` diagnostic for a real-but-non-applying
-  override is still surfaced through the ONE override engine
-  (`re-frame.fx/resolve-fx-with-overrides`) before the transport runs.
+    - `:applied-fn` / `:applied-redirect` — a fn-value or a keyword redirect to a
+      REGISTERED, NON-PROTECTED fx GENUINELY pre-empts the completion. We route
+      the PRE-RESOLVED effect through the shared core seam
+      `re-frame.fx/handle-one-fx` (empty overrides for a redirect target, the
+      captured fn for a fn-value) so execution CANNOT re-decide applies-vs-
+      fallthrough — a concurrent register / unregister can never flip the
+      single disposition into a coordinate-less transport. The override captures
+      / redirects the completion, queues nothing, and folds nothing — the
+      framework-produced path never runs, so no coordinate is stamped.
+
+    - `:noop` / `:fallthrough` / `:protected-rejection` — no override, a nil/false
+      noop, an UNREGISTERED keyword, a MALFORMED value, or a redirect to a
+      PROTECTED internal id is NOT an applied override: it falls through to the
+      recordable transport below, so the join still folds EXACTLY ONCE on the
+      framework-produced coordinate (the pre-fix `real-override?` gate routed
+      these to `handle-one-fx`, where the fall-through re-dispatched a
+      coordinate-less `:dispatch` that the parent's fence suppressed
+      `:attempt-unverified`, hanging the join). The canonical
+      `:rf.error/override-fallthrough` diagnostic for a real-but-non-applying
+      override is surfaced through the ONE shared emit path
+      (`re-frame.fx/emit-override-fallthrough!`) before the transport runs.
+
+  EXACT-OWNER FENCE (rf2-5g6qq, modelled on rf2-8nxsh). Both the fallthrough
+  diagnostic emit AND the transport fan synchronous callbacks: an always-on
+  `:errors` listener can destroy owner frame A (and publish same-id successor B)
+  DURING the diagnostic emit. The pre-fix seam then UNCONDITIONALLY called
+  `child-dispatch!` afterward — immediate router dispatch fired the completion
+  after A was gone, and a delayed completion reserved a `dispatch-later-timers`
+  slot AFTER destroy had already released that table (a post-cleanup timer that
+  fires dead-on-arrival). So we recheck exact-owner continuation
+  (`data-validation/owner-continuation`, bound to A's raw owner token) AFTER the
+  emit and BEFORE the router dispatch / numeric-ms timer reservation: if A is
+  gone, neither lands on A nor on an unrelated same-id B. The `:applied-*`
+  branch's `handle-one-fx` is itself exact-owner-fenced by core, so it needs no
+  extra guard.
 
   RESERVED / NON-OVERRIDABLE / NON-REDIRECTABLE (rf2-2lzk8a). It re-dispatches
   ONLY the pre-built completion carrier it was handed (never traverses arbitrary
@@ -245,62 +266,85 @@
         ;; ⋈ per-call, per-call winning (mirrors `router/apply-overrides`). The
         ;; per-call tier rides the emitting child's dispatch envelope.
         overrides    (merge (:fx-overrides (:config frame-record))
-                            (:fx-overrides envelope))]
-    (if (fx/override-applies? overrides canonical-id)
-      ;; OVERRIDE GENUINELY APPLIES (rf2-ulsbgr / rf2-2lzk8a): a fn-value or a
-      ;; keyword redirect to a REGISTERED, NON-PROTECTED fx pre-empts the
-      ;; completion. Route the canonical `:dispatch` / `:dispatch-later` back
-      ;; through the shared core override-resolution seam so the override
-      ;; intercepts the completion exactly as it would a normal dispatch.
-      ;; `handle-one-fx` (not `do-fx`) keeps the single `:event/do-fx` boundary
-      ;; marker on the outer walk (the nav-token wrapper precedent). No
-      ;; `child-dispatch!` → no fold, no queue, and no coordinate stamped onto
-      ;; the normal transport. `override-applies?` (NOT the coarser
-      ;; `real-override?`) is the gate: a nil/false noop, an UNREGISTERED-keyword
-      ;; / MALFORMED value, and a redirect to a PROTECTED internal id all fall
-      ;; through to the recordable transport below — so the join still folds on
-      ;; the framework-produced coordinate (rf2-2lzk8a).
+                            (:fx-overrides envelope))
+        origin-event-id (when (vector? origin-event) (first origin-event))
+        ;; ONE structured override resolution from the shared policy
+        ;; (rf2-5g6qq). Consumed below WITHOUT re-consulting the registrar /
+        ;; protected-target rule, so a concurrent register / unregister cannot
+        ;; flip an applies-preflight into a coordinate-less transport. This is
+        ;; the SAME policy `resolve-fx-with-overrides` consumes — join
+        ;; duplicates no registrar / protected-target lookup.
+        disposition  (fx/classify-fx-override overrides canonical-id)
+        ;; Exact-owner continuation predicate, captured ONCE against A's raw
+        ;; owner token (rf2-5g6qq / rf2-8nxsh): true while the incarnation that
+        ;; owns the in-flight event may still run framework continuation, false
+        ;; once a synchronous callback (a fallthrough `:errors` listener) has
+        ;; destroyed A / published same-id B.
+        continue?    (data-validation/owner-continuation frame-id)]
+    (case (:disposition disposition)
+      ;; OVERRIDE GENUINELY APPLIES (rf2-ulsbgr / rf2-2lzk8a): route the
+      ;; PRE-RESOLVED effect through the shared core seam. `handle-one-fx` (not
+      ;; `do-fx`) keeps the single `:event/do-fx` boundary marker on the outer
+      ;; walk (the nav-token wrapper precedent) and is itself exact-owner-fenced
+      ;; by core. No `child-dispatch!` → no fold, no queue, no coordinate stamped.
+      ;;
+      ;; A fn-value override is churn-immune (no registrar dependency); pass it
+      ;; as the sole override so execution resolves to the SAME fn.
+      :applied-fn
+      (fx/handle-one-fx
+        frame-id
+        (if (number? ms) [canonical-id {:ms ms :event event}] [canonical-id event])
+        (fx/platform-for-frame-record frame-record)
+        {canonical-id (:override disposition)}
+        origin-event
+        envelope)
+
+      ;; A keyword redirect to a REGISTERED, NON-PROTECTED fx: invoke the
+      ;; PRE-RESOLVED target directly with EMPTY overrides, so `handle-one-fx`
+      ;; cannot re-resolve the canonical id to a fallthrough transport under
+      ;; mid-flight churn (rf2-5g6qq). If the target was unregistered since
+      ;; classification, this is an honest `:rf.error/no-such-fx` — never a
+      ;; coordinate-less completion.
+      :applied-redirect
       (fx/handle-one-fx
         frame-id
         (if (number? ms)
-          [:dispatch-later {:ms ms :event event}]
-          [:dispatch event])
+          [(:target disposition) {:ms ms :event event}]
+          [(:target disposition) event])
         (fx/platform-for-frame-record frame-record)
-        overrides
+        {}
         origin-event
         envelope)
-      ;; NON-APPLYING / UNOVERRIDDEN: the normal recordable transport. A REAL
-      ;; but non-applying override on the canonical id (an unregistered keyword,
-      ;; a malformed value, or a redirect to a protected internal id) must still
-      ;; surface its canonical `:rf.error/override-fallthrough` through the ONE
-      ;; override engine — but it does NOT strip the completion of its coordinate.
-      ;; Drive the engine purely for that diagnostic (its resolved id, the
-      ;; canonical id, is discarded — the coordinate rides the transport below),
-      ;; so a misconfigured override on a join completion is as visible as on any
-      ;; other dispatch, then the recordable transport runs EXACTLY ONCE and the
-      ;; join folds (rf2-2lzk8a). nil/false noop emits nothing.
+
+      ;; :noop / :fallthrough / :protected-rejection — the normal recordable
+      ;; transport. A REAL but non-applying override surfaces its canonical
+      ;; `:rf.error/override-fallthrough` through the ONE shared emit path FIRST
+      ;; (a `:noop` emits nothing); it does NOT strip the completion of its
+      ;; coordinate. That emit fans synchronous listeners, so recheck exact-owner
+      ;; continuation before the transport: if a fallthrough listener destroyed
+      ;; A, neither the immediate router dispatch nor the numeric-ms timer
+      ;; reservation runs (rf2-5g6qq).
+      ;;
+      ;; The recordable causal-envelope fact rides `:rf.cofx`; `:source
+      ;; :machine-action` matches the child's original `:dispatch` stamp; the
+      ;; `:rf.machine/internal?` front-of-queue ordering + override / lineage /
+      ;; mint-policy inheritance are lifted from `envelope` by `child-dispatch!`.
+      ;; A `:dispatch-later` completion carries its numeric `:ms` + `:source-detail`
+      ;; for EVERY delay INCLUDING ZERO (rf2-21hsb1) — the canonical
+      ;; `child-dispatch!` path treats every numeric `:ms` as host-clock-delayed,
+      ;; so a `:dispatch-later {:ms 0}` yields through the frame-owned timer (a
+      ;; render/scheduling boundary, Spec 002 §long-running work) rather than
+      ;; folding synchronously. A direct `:dispatch` completion (nil `:ms`)
+      ;; enqueues immediately in the current drain.
       (do
-        (when (fx/real-override? overrides canonical-id)
-          (fx/resolve-fx-with-overrides
-            canonical-id overrides frame-id origin-event
-            (when (vector? origin-event) (first origin-event))))
-        ;; The normal recordable transport. The recordable causal-
-      ;; envelope fact rides `:rf.cofx`; `:source :machine-action` matches the
-      ;; child's original `:dispatch` stamp; the `:rf.machine/internal?`
-      ;; front-of-queue ordering + override / lineage / mint-policy inheritance
-      ;; are lifted from `envelope` by `child-dispatch!`. A `:dispatch-later`
-      ;; completion carries its numeric `:ms` + `:source-detail` for EVERY delay
-      ;; INCLUDING ZERO (rf2-21hsb1) — the canonical `child-dispatch!` path treats
-      ;; every numeric `:ms` as host-clock-delayed, so a `:dispatch-later {:ms 0}`
-      ;; yields through the frame-owned timer (a render/scheduling boundary,
-      ;; Spec 002 §long-running work) rather than folding synchronously. A direct
-      ;; `:dispatch` completion (nil `:ms`) enqueues immediately in the current
-      ;; drain — it alone carries no numeric `:ms` and no synthetic delayed detail.
-      (fx/child-dispatch!
-        frame-id envelope event
-        (cond-> {:source  :machine-action
-                 :rf.cofx {:rf.machine/join-attempt attempt}}
-          (number? ms) (assoc :ms ms :source-detail {:ms ms}))))))
+        (fx/emit-override-fallthrough!
+          disposition canonical-id overrides frame-id origin-event origin-event-id)
+        (when (continue?)
+          (fx/child-dispatch!
+            frame-id envelope event
+            (cond-> {:source  :machine-action
+                     :rf.cofx {:rf.machine/join-attempt attempt}}
+              (number? ms) (assoc :ms ms :source-detail {:ms ms})))))))
   nil)
 
 (defn- stamp-fx-entry

--- a/implementation/machines/test/re_frame/join_completion_fence_test.clj
+++ b/implementation/machines/test/re_frame/join_completion_fence_test.clj
@@ -1,0 +1,322 @@
+(ns re-frame.join-completion-fence-test
+  "rf2-5g6qq — the `:spawn-all` join-completion transport
+  (`:rf.machine/join-dispatch`) resolves the canonical override ONCE and consumes
+  that single disposition under the originating event's EXACT FRAME OWNER.
+
+  Two current-main defects the fix closes (each has a mutation tooth here):
+
+    A. INCARNATION LEAK. For a REAL but non-applying override on the canonical
+       `:dispatch` / `:dispatch-later` id, `join-dispatch-fx` drove
+       `resolve-fx-with-overrides` only to emit the synchronous
+       `:rf.error/override-fallthrough` diagnostic, then UNCONDITIONALLY called
+       `child-dispatch!`. An always-on `:errors` listener can destroy the owner
+       frame A DURING that emit; the outer `handle-one-fx` fence notices only
+       AFTER the handler returns — too late to undo the inner side effect. The
+       immediate path then re-dispatched the completion into the gone frame; a
+       delayed completion reserved a `dispatch-later-timers` slot AFTER destroy
+       had already released that table (a post-cleanup timer that fires
+       dead-on-arrival, and — keyed by frame-id — leaks onto a same-id successor
+       B). The fix rechecks exact-owner continuation after the emit and before
+       the router dispatch / numeric-ms timer reservation.
+
+    B. CHURN FLIP. `override-applies?` (preflight) and `handle-one-fx` →
+       `resolve-fx-with-overrides` (execution) each independently re-looked-up the
+       registrar + protected-target rule, so a concurrent register / unregister
+       between them could flip an applies-preflight into a fallthrough that
+       re-dispatched a COORDINATE-LESS `:dispatch` (parent-suppressed
+       `:attempt-unverified`, hanging the join). The fix classifies ONCE
+       (`re-frame.fx/classify-fx-override`) and executes the PRE-RESOLVED
+       disposition, so no second registrar read can change it.
+
+  MUTATION TEETH: dropping the `(when (continue?) …)` transport guard makes the
+  destroy tests re-dispatch / re-arm into the gone frame; restoring the two-phase
+  `override-applies?` + full-overrides `handle-one-fx` makes the churn test flip
+  to `:attempt-unverified`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.fx :as fx]
+            [re-frame.interop :as interop]
+            [re-frame.machines]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  mtest/trace-capture-fixture)
+
+;; ---------------------------------------------------------------------------
+;; helpers (mirroring the sibling join transport tests)
+;; ---------------------------------------------------------------------------
+
+(defn- join-state
+  ([parent-id] (join-state :rf/default parent-id))
+  ([frame-id parent-id]
+   (get-in (mtest/runtime-db frame-id)
+           [:rf.runtime/machines :spawned parent-id [:racing]])))
+
+(defn- stale-reasons []
+  (mapv (comp :rf.reply/stale-reason :tags)
+        (mtest/events-of :rf.machine.spawn-all/stale-completion)))
+
+(defn- mk-child
+  "A dispatching child: on `:go` transitions to a plain terminal and dispatches
+  its completion back to `parent-id` via `:dispatch` (through its OWN handler
+  boundary, so the runtime attaches the recordable `:rf.machine/join-attempt`)."
+  [parent-id]
+  {:initial :running
+   :data    {:id nil}
+   :actions {:record-id     (fn [{data :data ev :event}] {:data (assoc data :id (second ev))})
+             :dispatch-done (fn [{data :data}]
+                              {:fx [[:dispatch [parent-id [:child/done (:id data)]]]]})}
+   :states  {:running {:on {:set-id {:action :record-id}
+                            :go     {:target :done :action :dispatch-done}}}
+             :done {}}})
+
+(defn- mk-child-delayed
+  "Like `mk-child` but completes through a `:dispatch-later` with delay `ms`."
+  [parent-id ms]
+  {:initial :running
+   :data    {:id nil}
+   :actions {:record-id     (fn [{data :data ev :event}] {:data (assoc data :id (second ev))})
+             :dispatch-done (fn [{data :data}]
+                              {:fx [[:dispatch-later {:ms    ms
+                                                      :event [parent-id [:child/done (:id data)]]}]]})}
+   :states  {:running {:on {:set-id {:action :record-id}
+                            :go     {:target :done :action :dispatch-done}}}
+             :done {}}})
+
+(defn- reg-parent!
+  "A two-child `:all` join parent (children `child-a-kw` / `child-b-kw`)."
+  [parent-kw child-a-kw child-b-kw]
+  (rf/reg-machine parent-kw
+    {:initial :idle
+     :states  {:idle   {:on {:start :racing}}
+               :racing {:spawn-all
+                        {:children        [{:id :a :machine-id child-a-kw :start [:set-id :a]}
+                                           {:id :b :machine-id child-b-kw :start [:set-id :b]}]
+                         :join            :all
+                         :on-child-done   :child/done
+                         :on-child-error  :child/failed
+                         :on-all-complete [:all/done]}
+                        :on {:abort :idle}}}}))
+
+(defn- with-dispatch-stub
+  "Run `body-fn` with `:router/dispatch!` replaced by a RECORDING stub that
+  captures each `[event opts]` into `sink` WITHOUT draining. Restores the real
+  hook in a finally."
+  [sink body-fn]
+  (let [real (late-bind/get-fn :router/dispatch!)]
+    (try
+      (late-bind/set-fn! :router/dispatch! (fn [event opts] (swap! sink conj [event opts])))
+      (body-fn)
+      (finally
+        (late-bind/set-fn! :router/dispatch! real)))))
+
+(defn- completion-dispatched?
+  "True iff the completion carrier `[parent-id [:child/done child-id]]` was
+  observed on the router-dispatch stub `sink`."
+  [sink parent-id child-id]
+  (some (fn [[event _opts]] (= [parent-id [:child/done child-id]] event)) @sink))
+
+(defn- with-destroying-error-listener
+  "Register an `:errors` listener that records every error kind into `sink` and,
+  on the FIRST `:rf.error/override-fallthrough`, SYNCHRONOUSLY destroys
+  `frame-id` — the owner-frame-destroyed-during-emit hazard (rf2-5g6qq). Destroys
+  at most once (guards its own re-entry). Unregisters in a finally."
+  [sink frame-id body-fn]
+  (let [fired? (atom false)]
+    (rf/register-listener! :errors ::fence
+      (fn [r]
+        (swap! sink conj (:error r))
+        (when (and (= :rf.error/override-fallthrough (:error r))
+                   (not @fired?))
+          (reset! fired? true)
+          (rf/destroy-frame! frame-id))))
+    (try (body-fn) (finally (rf/unregister-listener! :errors ::fence)))))
+
+(defn- timers-for-frame [frame-id]
+  (->> @@(resolve 're-frame.fx/dispatch-later-timers)
+       (filter (fn [[[fid _tid] _handle]] (= fid frame-id)))))
+
+;; ---------------------------------------------------------------------------
+;; (A) INCARNATION — a fallthrough `:errors` listener that destroys the owner
+;;     frame during the override-fallthrough emit leaks NO afterward side effect.
+;; ---------------------------------------------------------------------------
+
+(deftest immediate-completion-fallthrough-listener-destroy-does-not-dispatch
+  (testing "rf2-5g6qq — an IMMEDIATE completion whose real-but-non-applying
+            `:dispatch` override falls through surfaces the canonical
+            override-fallthrough; an `:errors` listener destroys the owner frame
+            DURING that emit. After the fix the exact-owner recheck skips the
+            transport, so the completion is NEVER re-dispatched into the gone
+            frame (nor onto a same-id successor B). Pre-fix `child-dispatch!` ran
+            unconditionally and dispatched the completion after destroy."
+    (rf/make-frame {:id :fence/imm :doc "rf2-5g6qq immediate destroy frame"})
+    (rf/reg-machine :fence.imm/ca (mk-child :fence.imm/rp))
+    (rf/reg-machine :fence.imm/cb (mk-child :fence.imm/rp))
+    (reg-parent! :fence.imm/rp :fence.imm/ca :fence.imm/cb)
+    (rf/dispatch-sync [:fence.imm/rp [:start]] {:frame :fence/imm})
+    (let [a    (get-in (join-state :fence/imm :fence.imm/rp) [:children :a])
+          errs (atom [])
+          sink (atom [])]
+      (with-dispatch-stub sink
+        (fn []
+          (with-destroying-error-listener errs :fence/imm
+            (fn []
+              (rf/dispatch-sync [a [:go]]
+                                {:frame        :fence/imm
+                                 :fx-overrides {:dispatch :fence.imm/nonexistent}})))))
+      (is (some #{:rf.error/override-fallthrough} @errs)
+          "the fallthrough diagnostic fired (the destroy trigger)")
+      (is (not (completion-dispatched? sink :fence.imm/rp :a))
+          "the completion was NOT re-dispatched after the listener destroyed A")
+      ;; A same-id successor B carries no A-derived completion.
+      (rf/make-frame {:id :fence/imm :doc "rf2-5g6qq successor B"})
+      (is (nil? (join-state :fence/imm :fence.imm/rp))
+          "same-id successor B holds no folded join from A's completion"))))
+
+(deftest positive-delay-completion-fallthrough-listener-destroy-arms-no-timer
+  (testing "rf2-5g6qq — a POSITIVE-delay (60s) completion whose `:dispatch-later`
+            override falls through: the listener destroys A during the emit, which
+            releases A's `dispatch-later-timers`. After the fix the exact-owner
+            recheck skips the timer reservation, so NO post-cleanup timer is armed
+            (and none leaks onto a recreated same-id B). Pre-fix the unconditional
+            `child-dispatch!` armed `[frame-id tid]` AFTER destroy — a
+            fires-dead-on-arrival timer."
+    (fx/reset-dispatch-later-timers!)
+    (rf/make-frame {:id :fence/pos :doc "rf2-5g6qq positive-delay destroy frame"})
+    (rf/reg-machine :fence.pos/ca (mk-child-delayed :fence.pos/rp 600000))
+    (rf/reg-machine :fence.pos/cb (mk-child-delayed :fence.pos/rp 600000))
+    (reg-parent! :fence.pos/rp :fence.pos/ca :fence.pos/cb)
+    (rf/dispatch-sync [:fence.pos/rp [:start]] {:frame :fence/pos})
+    (let [a    (get-in (join-state :fence/pos :fence.pos/rp) [:children :a])
+          errs (atom [])]
+      (with-destroying-error-listener errs :fence/pos
+        (fn []
+          (rf/dispatch-sync [a [:go]]
+                            {:frame        :fence/pos
+                             :fx-overrides {:dispatch-later :fence.pos/nonexistent}})))
+      (is (some #{:rf.error/override-fallthrough} @errs)
+          "the fallthrough diagnostic fired (the destroy trigger)")
+      (is (zero? (count (timers-for-frame :fence/pos)))
+          "no post-cleanup timer was armed after the listener destroyed A")
+      ;; A recreated same-id B inherits no leaked timer.
+      (rf/make-frame {:id :fence/pos :doc "rf2-5g6qq successor B"})
+      (is (zero? (count (timers-for-frame :fence/pos)))
+          "same-id successor B carries no timer leaked from A's transport"))
+    (fx/reset-dispatch-later-timers!)))
+
+(deftest zero-delay-completion-fallthrough-listener-destroy-arms-no-timer
+  (testing "rf2-5g6qq — the zero-ms boundary: a `:dispatch-later {:ms 0}`
+            completion is host-clock-deferred (a numeric `:ms`, rf2-21hsb1), so it
+            too rides the timer reservation the exact-owner recheck now guards. The
+            host clock is captured (never fired), so the observable is whether the
+            transport armed a timer AT ALL: with the fallthrough listener
+            destroying A during the emit, `interop/set-timeout!` is NEVER reached.
+            Pre-fix the unconditional transport armed it — a dead-on-arrival ms-0
+            re-dispatch into the gone frame."
+    (fx/reset-dispatch-later-timers!)
+    (rf/make-frame {:id :fence/zero :doc "rf2-5g6qq zero-delay destroy frame"})
+    (rf/reg-machine :fence.zero/ca (mk-child-delayed :fence.zero/rp 0))
+    (rf/reg-machine :fence.zero/cb (mk-child-delayed :fence.zero/rp 0))
+    (reg-parent! :fence.zero/rp :fence.zero/ca :fence.zero/cb)
+    (rf/dispatch-sync [:fence.zero/rp [:start]] {:frame :fence/zero})
+    (let [a     (get-in (join-state :fence/zero :fence.zero/rp) [:children :a])
+          errs  (atom [])
+          armed (atom [])]
+      (with-redefs [interop/set-timeout!   (fn [f _ms] (swap! armed conj f) ::handle)
+                    interop/clear-timeout! (fn [_] nil)]
+        (with-destroying-error-listener errs :fence/zero
+          (fn []
+            (rf/dispatch-sync [a [:go]]
+                              {:frame        :fence/zero
+                               :fx-overrides {:dispatch-later :fence.zero/nonexistent}}))))
+      (is (some #{:rf.error/override-fallthrough} @errs)
+          "the fallthrough diagnostic fired (the destroy trigger)")
+      (is (empty? @armed)
+          "no :ms 0 host timer was armed after the listener destroyed A"))
+    (fx/reset-dispatch-later-timers!)))
+
+;; ---------------------------------------------------------------------------
+;; (B) CHURN — a register/unregister between the single classification and its
+;;     execution cannot flip an applies-preflight into a coordinate-less transport.
+;; ---------------------------------------------------------------------------
+
+(deftest churn-between-classify-and-execute-produces-no-coordinateless-completion
+  (testing "rf2-5g6qq — an `:applied-redirect` override to a REGISTERED target is
+            classified ONCE; its execution consumes that pre-resolved disposition
+            with EMPTY overrides. A concurrent unregistration of the target
+            AFTER the single classification (modelled by a registrar lookup that
+            returns registered on the first read and nil thereafter) therefore
+            CANNOT flip the disposition into a fallthrough transport: the
+            completion is applied-then-missing (`:rf.error/no-such-fx`), NEVER a
+            coordinate-less `:dispatch` the parent would suppress
+            `:attempt-unverified`. Pre-fix the two independent registrar reads
+            flipped and hung the join."
+    (rf/reg-fx :churn/target (fn [_ _] nil))
+    (rf/reg-machine :churn/ca (mk-child :churn/rp))
+    (rf/reg-machine :churn/cb (mk-child :churn/rp))
+    (reg-parent! :churn/rp :churn/ca :churn/cb)
+    (rf/dispatch-sync [:churn/rp [:start]])
+    (let [a     (get-in (join-state :churn/rp) [:children :a])
+          errs  (atom [])
+          calls (atom 0)
+          real  registrar/lookup]
+      (rf/register-listener! :errors ::churn (fn [r] (swap! errs conj (:error r))))
+      (try
+        ;; The target is REGISTERED at the single classification (lookup #1) and
+        ;; UNREGISTERED for every later read (lookup #2, the execution meta) —
+        ;; the exact preflight→execution churn window.
+        (with-redefs [registrar/lookup
+                      (fn [kind id]
+                        (if (and (= kind :fx) (= id :churn/target))
+                          (when (= 1 (swap! calls inc)) (real kind id))
+                          (real kind id)))]
+          (rf/dispatch-sync [a [:go]] {:fx-overrides {:dispatch :churn/target}}))
+        (finally (rf/unregister-listener! :errors ::churn)))
+      (is (empty? (stale-reasons))
+          "NO :attempt-unverified — the single disposition did not flip to a
+           coordinate-less transport")
+      (is (= #{} (:done (join-state :churn/rp)))
+          "the applied override pre-empted the fold (nothing folded), NOT a hung join")
+      (is (some #{:rf.error/no-such-fx} @errs)
+          "the churned-away target surfaced :no-such-fx — applied-then-missing,
+           not a fallthrough transport"))))
+
+;; ---------------------------------------------------------------------------
+;; (B') CONTROL — a still-registered redirect target folds nothing but captures;
+;;      an applied fn-value override is churn-immune (no registrar dependency).
+;; ---------------------------------------------------------------------------
+
+(deftest applied-redirect-and-fn-controls-consume-the-single-disposition
+  (testing "rf2-5g6qq — the applies controls under the single-resolution model: a
+            registered keyword redirect runs the PRE-RESOLVED target (capturing
+            the completion, folding nothing); a fn-value override runs the
+            captured fn. Neither stamps a coordinate nor folds."
+    ;; keyword redirect
+    (let [captured (atom [])]
+      (rf/reg-fx :ctl/capture (fn [_ args] (swap! captured conj args)))
+      (rf/reg-machine :ctl.kw/ca (mk-child :ctl.kw/rp))
+      (rf/reg-machine :ctl.kw/cb (mk-child :ctl.kw/rp))
+      (reg-parent! :ctl.kw/rp :ctl.kw/ca :ctl.kw/cb)
+      (rf/dispatch-sync [:ctl.kw/rp [:start]])
+      (let [a (get-in (join-state :ctl.kw/rp) [:children :a])]
+        (rf/dispatch-sync [a [:go]] {:fx-overrides {:dispatch :ctl/capture}})
+        (is (= [[:ctl.kw/rp [:child/done :a]]] @captured)
+            "the pre-resolved redirect target captured the completion")
+        (is (= #{} (:done (join-state :ctl.kw/rp))) "nothing folded under the redirect")
+        (is (empty? (stale-reasons)) "no coordinate-less suppression")))
+    ;; fn-value
+    (let [captured (atom [])]
+      (rf/reg-machine :ctl.fn/ca (mk-child :ctl.fn/rp))
+      (rf/reg-machine :ctl.fn/cb (mk-child :ctl.fn/rp))
+      (reg-parent! :ctl.fn/rp :ctl.fn/ca :ctl.fn/cb)
+      (rf/dispatch-sync [:ctl.fn/rp [:start]])
+      (let [a (get-in (join-state :ctl.fn/rp) [:children :a])]
+        (rf/dispatch-sync [a [:go]]
+                          {:fx-overrides {:dispatch (fn [_ args] (swap! captured conj args))}})
+        (is (= [[:ctl.fn/rp [:child/done :a]]] @captured)
+            "the fn-value override captured the completion")
+        (is (= #{} (:done (join-state :ctl.fn/rp))) "nothing folded under the fn override")))))


### PR DESCRIPTION
Closes rf2-5g6qq (P1, gh-6043).

## Problem

`join-dispatch-fx` (the `:rf.machine/join-dispatch` join-completion transport) resolved the canonical override **twice** and ran its non-applying transport **unfenced**:

1. **Incarnation leak.** For a real-but-non-applying override on the canonical `:dispatch` / `:dispatch-later` id, it drove `resolve-fx-with-overrides` only to emit the synchronous `:rf.error/override-fallthrough`, then **unconditionally** called `child-dispatch!`. An always-on `:errors` listener can destroy owner frame A *during* that emit; the outer `handle-one-fx` fence notices only after the handler returns. The immediate path then re-dispatched the completion into the gone frame; a delayed (e.g. 60s) completion reserved a `dispatch-later-timers` slot **after** destroy had already released that table — a post-cleanup timer that fires dead-on-arrival and, keyed by frame-id, leaks onto a same-id successor B.

2. **Churn flip.** `override-applies?` (preflight) and `handle-one-fx` → `resolve-fx-with-overrides` (execution) each independently re-looked-up the registrar + protected-target rule, so a concurrent register/unregister between them could flip an applies-preflight into a fallthrough that re-dispatched a **coordinate-less** `:dispatch` the parent suppressed `:attempt-unverified`, hanging the join.

## Fix

One structured resolution consumed under the exact frame owner:

- **Shared policy.** New `re-frame.fx/classify-fx-override` returns a single structured disposition (`:noop` / `:fallthrough` / `:applied-fn` / `:applied-redirect` / `:protected-rejection`) with the registrar + protected-target lookup taken **exactly once**. `real-override?`, `override-applies?`, and `resolve-fx-with-overrides` now express themselves over it; the fallthrough diagnostic is factored into the shared `emit-override-fallthrough!` the join reuses. Join duplicates no registrar/protected-target policy.
- **Exact-owner fence** (modelled on rf2-8nxsh). The join classifies once, emits the fallthrough diagnostic through the shared path, then rechecks exact-owner continuation (`data-validation/owner-continuation`, bound to A's raw owner token) **before** the router dispatch / numeric-ms timer reservation. After a destroy-during-emit neither lands on A nor on a same-id B. The `:applied-*` branch's `handle-one-fx` is itself exact-owner-fenced by core.
- **Churn-safe execution.** The applied branches execute the **pre-resolved** disposition (empty overrides for a redirect target, the captured fn for a fn-value), so a mid-flight registrar change cannot flip an applies-preflight into a coordinate-less transport — a churned-away target surfaces an honest `:rf.error/no-such-fx`.

No new error-id (reuses `:rf.error/override-fallthrough` / `:rf.error/no-such-fx` / `:rf.error/reserved-fx-override`).

## Quality gates

All foreground, unpiped.

- `implementation/machines` JVM (`clojure -M:test`): **1167 tests / 4016 assertions, 0 failures, 0 errors**.
- `implementation/core` JVM (`clojure -M:test`): **2036 tests / 9495 assertions, 0 failures, 0 errors**.
- `npm run test:cljs`: **9794 tests / 48118 assertions, 0 failures, 0 errors** (one earlier single-test flake did not reproduce on a clean re-run).
- New `join_completion_fence_test.clj` (5 tests / 16 assertions) — **red-before/green-after teeth verified**:
  - unconditional transport → immediate re-dispatch after destroy + positive-delay/zero-delay timer armed post-cleanup (and leaked onto B);
  - two-phase re-resolution → churn flips to `:attempt-unverified` / `:rf.error/override-fallthrough` instead of `:no-such-fx`.

Existing disposition coverage (unregistered / malformed / protected-redirect / applied fn+redirect controls, immediate + zero/positive delay, hand-authored fence) stays green in `join_authority_effect_path_test.cljc`, `join_dispatch_override_intercept_cljs_test.cljc`, and `join_reserved_dispatch_semantics_test.clj`.

Not run per brief: `test:browser`, full spine.
