### PR TITLE
fix(ui): retire the captured failed-root reporter across re-entrant reclaim (rf2-j7225)

### DIFF
--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -1404,6 +1404,33 @@
       (finally
         (reset! disposing-live-roots? false)))))
 
+(defn- reclaim-and-retire-quarantine!
+  "Terminal recovery for one exact cleanup-failure quarantine whose host handle
+  React consumed: adapter-reclaim its exact container, retire that spent reporter
+  authority, then release the identity-fenced claim. The `reclaim → retire →
+  release` order is fixed — retirement runs only once the reclaim PROVES the
+  surface free, and a FAILED reclaim throws above it, skipping BOTH retirement
+  and release so the claim stays quarantined AND reporter-authoritative
+  fail-closed (rf2-nd7z9h).
+
+  Retirement targets the EXACT `incarnation` CAPTURED before the reclaim — never
+  a fresh registry read. `reclaim-consumed-container!` runs synchronous host code
+  (`replaceChildren`), during which a custom-element callback or a low-level/test
+  seam can install a same-id SUCCESSOR into `live-roots`. A bare-id lookup after
+  the reclaim would then resolve to that innocent successor: it would retire the
+  successor's reporter while `release-root!`'s identity fence correctly preserves
+  the successor's claim — leaving it live WITHOUT reporter authority (its teardown
+  could settle before React's cleanup) and strongly retaining the failed
+  predecessor's dead token. Passing the captured predecessor `incarnation` keeps
+  retirement bound to the predecessor, so a bypass-installed successor is never
+  disturbed and the stale snapshot never owns a replacement it did not admit
+  (rf2-j7225). Returns nil."
+  [root-id ^Root root incarnation]
+  (reclaim-consumed-container! root)
+  (reactive/retire-root-reporter! incarnation)
+  (release-root! root-id root)
+  nil)
+
 (defn drain-live-roots!
   "Drain one exact snapshot of every public compiled client Root.
 
@@ -1441,16 +1468,13 @@
           ;; handle consumed. Adapter destruction owns terminal container reclaim.
           quarantined?
           (try
-            (reclaim-consumed-container! root)
-            ;; rf2-nd7z9h — the terminal reclaim proved this consumed surface
-            ;; free, so this exact incarnation's reporter authority is spent:
-            ;; retire it BEFORE releasing the claim so `live-reporters` cannot
-            ;; strongly retain a dead incarnation across recovery cycles (nor
-            ;; leave stale reporter-deferred teardown authority for its old
-            ;; token). A FAILED reclaim throws above and skips both retirement and
-            ;; release, keeping quarantine AND reporter authority fail-closed.
-            (reactive/retire-root-reporter! (:root-incarnation current))
-            (release-root! root-id root)
+            ;; rf2-nd7z9h / rf2-j7225 — reclaim the consumed surface, then retire
+            ;; THIS captured incarnation's spent reporter authority BEFORE releasing
+            ;; the claim (never re-read the registry: a successor installed during
+            ;; the synchronous reclaim keeps its own reporter + claim). A FAILED
+            ;; reclaim throws and skips both, keeping quarantine AND reporter
+            ;; authority fail-closed.
+            (reclaim-and-retire-quarantine! root-id root (:root-incarnation current))
             (catch :default recovery-error
               (vswap! errors conj recovery-error)))
 
@@ -1471,16 +1495,20 @@
               (mark-cleanup-failure-quarantine! root-id root)
               (when (exact-cleanup-failure-quarantine? root-id root)
                 (try
-                  (reclaim-consumed-container! root)
                   ;; `unmount!*` just classified this exact root as cleanup-failed.
-                  ;; Successful adapter reclaim proves the surface free; the
-                  ;; identity fence prevents a stale snapshot releasing a successor.
+                  ;; Successful adapter reclaim proves the surface free; the identity
+                  ;; fence prevents a stale snapshot releasing a successor.
                   ;; rf2-nd7z9h — retire this incarnation's reporter authority too,
                   ;; between the successful reclaim and the claim release, so the
                   ;; reporter ledger returns to baseline (a failed reclaim throws
                   ;; above and retains both quarantine and reporter authority).
-                  (reactive/retire-root-reporter! (root-incarnation-of root-id))
-                  (release-root! root-id root)
+                  ;; rf2-j7225 — retire the EXACT incarnation CAPTURED in `current`,
+                  ;; NOT a fresh `root-incarnation-of` read: the synchronous reclaim
+                  ;; can install a same-id successor, and a bare-id lookup would then
+                  ;; retire the successor's reporter while the identity fence keeps
+                  ;; its claim — the very stale-snapshot ownership `current` fences.
+                  (reclaim-and-retire-quarantine!
+                   root-id root (:root-incarnation current))
                   (catch :default recovery-error
                     (vswap! errors conj recovery-error)))))))))
     ;; PRESENCE (seq/count), not truthiness: a non-empty error vector whose FIRST

--- a/implementation/ui/test/re_frame/ui/root_registry_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_registry_cljs_test.cljs
@@ -10,6 +10,7 @@
             [re-frame.error :as error]
             [re-frame.registrar :as registrar]
             [re-frame.ui.client :as client]
+            [re-frame.ui.reactive :as reactive]
             [re-frame.ui.runtime :as runtime]))
 
 (use-fixtures :each
@@ -585,6 +586,69 @@
         "the consumed handle's .unmount returns without effect")
     (is (= 1 @calls)
         "the re-called .unmount is a NO-OP — it never re-drives a real teardown")))
+
+(deftest reclaim-installed-successor-keeps-reporter-authority-and-claim
+  ;; rf2-j7225 — `reclaim-consumed-container!` runs SYNCHRONOUS host code
+  ;; (`replaceChildren`), and a custom-element callback or a low-level/test seam
+  ;; can install a same-id SUCCESSOR (B) into `live-roots` DURING that reclaim.
+  ;; Recovery must retire the reporter authority of the EXACT captured predecessor
+  ;; (A) — never a fresh `(root-incarnation-of root-id)` read, which now resolves
+  ;; to B: retiring B leaves it LIVE WITHOUT reporter authority (its teardown could
+  ;; settle before React's cleanup) while `release-root!`'s identity fence
+  ;; correctly PRESERVES B's claim, and A's dead token stays strongly retained.
+  ;; A bypass-installed replacement is not owned by the stale disposal snapshot.
+  (let [rid       :reg/reclaim-successor
+        container (js-obj)
+        a-inc     (reactive/make-root-incarnation)
+        a-boom    (js/Error. "predecessor host unmount boom")
+        a-root    (client/->Root #js {:unmount (fn [] (throw a-boom))} container rid)
+        succ-root (volatile! nil)
+        succ-inc  (volatile! nil)]
+    ;; Predecessor A: a committed root (reporter-live), NOT tearing-down, so the
+    ;; drain visits it on the `:else`/unmount!* recovery arm.
+    (client/register-live-root!
+     {:root-id rid :provenance :authored} container a-root a-inc)
+    (reactive/report-root-commit! a-inc)
+    (is (true? (reactive/live-reporter? a-inc))
+        "the committed predecessor holds live reporter authority")
+    ;; The reclaim seam installs + commits a same-id successor B synchronously,
+    ;; the moment `reclaim-consumed-container!` calls `replaceChildren`.
+    (unchecked-set
+     container "replaceChildren"
+     (fn []
+       (let [b-inc  (reactive/make-root-incarnation)
+             b-root (client/->Root #js {:unmount (fn [] nil)} container rid)]
+         (vreset! succ-root b-root)
+         (vreset! succ-inc b-inc)
+         (client/register-live-root!
+          {:root-id rid :provenance :authored} container b-root b-inc)
+         (reactive/report-root-commit! b-inc))))
+    ;; Drain: A is not pre-quarantined, so unmount!* A throws (its host `.unmount`),
+    ;; the `:else` recovery reclaims (installing B), then retires + releases.
+    (is (identical? a-boom
+                    (try (client/dispose-live-roots!) nil (catch :default e e)))
+        "the predecessor host teardown error still propagates as primary")
+    ;; B was installed DURING the reclaim — a DISTINCT incarnation…
+    (is (some? @succ-inc))
+    (is (not (identical? a-inc @succ-inc))
+        "the same-id successor is a distinct incarnation")
+    ;; …and its claim survives release-root!'s identity fence (true both before and
+    ;; after the fix — the fence was never the bug).
+    (is (contains? (client/live-root-ids) rid)
+        "the bypass-installed successor's live claim survives")
+    (is (identical? @succ-root (:root (client/live-root-entry rid)))
+        "the surviving claim is the successor B, not the failed predecessor A")
+    ;; The DISCRIMINATING assertions — RED before rf2-j7225 (the bare-id lookup
+    ;; retired B and stranded A), GREEN after (the captured token retires A only):
+    (is (false? (reactive/live-reporter? a-inc))
+        "the failed predecessor's reporter is retired via the CAPTURED incarnation")
+    (is (true? (reactive/live-reporter? @succ-inc))
+        "the same-id successor keeps reporter authority — recovery never re-read the
+         mutable registry after the synchronous reclaim")
+    ;; Restore the reporter ledger to baseline regardless of outcome (idempotent).
+    (reactive/retire-root-reporter! a-inc)
+    (reactive/retire-root-reporter! @succ-inc)
+    (client/release-root! rid @succ-root)))
 
 ;; ---------------------------------------------------------------------------
 ;; React root options


### PR DESCRIPTION
## What

`drain-live-roots!`'s same-drain recovery branch (the `:else`/`unmount!*` arm)
retired reporter authority by re-reading the mutable live-roots registry with
`(root-incarnation-of root-id)` **after** the synchronous
`reclaim-consumed-container!` (`replaceChildren`). Because that host call is
synchronous, a custom-element callback or a low-level/test seam can replace
failed root **A** with a same-id successor **B** *during* the reclaim. The bare-id
lookup then resolved to **B**:

- `retire-root-reporter!` removed **B** from `live-reporters` (B left live but
  WITHOUT reporter authority — its teardown could settle before React's cleanup);
- `release-root! root-id A` correctly identity-fenced and preserved **B**'s claim;
- **A**'s dead reporter token stayed strongly retained.

This contradicted the drain's own stated stale-snapshot rule: a bypass-installed
replacement is not owned by the stale disposal snapshot.

## Fix

Retire the **exact incarnation captured in `current`** (`(:root-incarnation current)`)
— exactly as the sibling pre-existing-quarantine branch already did — never a
fresh `root-incarnation-of` read after the reclaim. The
`reclaim → captured-token retirement → identity-fenced release` sequence is now
shared across both recovery branches via a single private
`reclaim-and-retire-quarantine!` helper. A failed reclaim still throws above the
retirement/release, keeping quarantine AND reporter authority fail-closed
(rf2-nd7z9h). Minimal, matching the sibling branch's correct pattern.

## Test

New deterministic node-runtime fixture in `root_registry_cljs_test.cljs`
(`reclaim-installed-successor-keeps-reporter-authority-and-claim`): a
`replaceChildren` callback installs + commits a same-id successor **B** during the
reclaim.

- **Red before** (faithful pre-fix inline re-read after reclaim): exactly the two
  discriminating assertions fail — "the failed predecessor's reporter is retired
  via the CAPTURED incarnation" and "the same-id successor keeps reporter
  authority" (2 failures / 0 errors; all other tests green).
- **Green after**: predecessor **A** retired, successor **B** stays reporter-live,
  and B's identity-fenced claim survives.

## Quality gates

| Gate | Result |
| --- | --- |
| `npm run test:cljs` (full node-test) | ✅ 9797 tests, 48156 assertions, 0 failures, 0 errors |
| `implementation/ui` JVM (`clojure -M:test`) | ✅ 732 tests, 13764 assertions, 0 failures, 0 errors |
| Focused `:node-test-ui` red-before / green-after | ✅ 2 failures with the bug reintroduced → 0 after the fix |

Rebased on `origin/main` including rf2-s2cfv (falsy-failure presence tracking).
Touches only `implementation/ui/src/re_frame/ui/client.cljs` and its
`root_registry_cljs_test.cljs`; no ui compiler / evidence substrate /
`observation.cljc` / machines surfaces touched.

Closes rf2-j7225.
