### PR TITLE
fix(trace): serialize each trace listener across concurrent JVM emits (rf2-uw7hg)

### DIFF
--- a/docs/api/re-frame.core.md
+++ b/docs/api/re-frame.core.md
@@ -954,7 +954,7 @@ Two surfaces stacked. The first is **dev-only**: a trace bus that emits one rich
   ```clojure
   (register-listener! stream id callback-fn)
   ```
-- **Description**: Register `callback-fn` under `id` to receive every record the runtime emits on `stream`. Delivery is synchronous: the callback returns before the next record. Re-registering the same id on a stream replaces.
+- **Description**: Register `callback-fn` under `id` to receive every record the runtime emits on `stream`. Delivery is synchronous: the callback returns before the next record. On the JVM, where emits can race across threads, each listener is invoked serially — a callback is never entered concurrently with itself, so tool appenders and stateful folds need no locking of their own. Re-registering the same id on a stream replaces.
   - Streams:
     - `:trace` — dev-only, DCE'd in production.
     - `:events` and `:errors` — **always-on**; they survive CLJS `:advanced` + `goog.DEBUG=false`.

--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -707,11 +707,39 @@
 ;;
 ;; The queue is a plain vector consumed by an advancing index (never mutated
 ;; mid-drain except by append), so appends made by a draining callback extend
-;; it and are picked up in FIFO order. Thread-local by dynamic binding: a
-;; concurrent JVM emit on another thread has its own outermost fan-out and
-;; queue. Composes with rf2-eaxnai: the deferred item carries its OWN
-;; `continue?`, and the listener body already ran under the neutral
-;; continuation scope `re-frame.trace/deliver!` established.
+;; it and are picked up in FIFO order. Composes with rf2-eaxnai: the deferred
+;; item carries its OWN `continue?`, and the listener body already ran under the
+;; neutral continuation scope `re-frame.trace/deliver!` established.
+;;
+;; ---- cross-thread fan-out serialization (rf2-uw7hg) -----------------------
+;;
+;; The deferral queue above is thread-local (a dynamic binding), so it only
+;; orders SAME-thread reentrant emits. It says nothing about two emits racing on
+;; two JVM threads: each opens its OWN outermost fan-out and each would invoke
+;; the SAME registered listener callback CONCURRENTLY. That violates the public
+;; listener contract (`docs/api/re-frame.core.md`: "Delivery is synchronous: the
+;; callback returns before the next record") and Spec 009 §The listener contract,
+;; which require synchronous, in-order, event-at-a-time delivery PER listener —
+;; a callback the tool author was told can never re-enter itself would be run on
+;; two threads at once, and B could reach a listener before A even when A's emit
+;; began first.
+;;
+;; A single process-global monitor (`fanout-monitor`) serializes each OUTERMOST
+;; fan-out — its transitive drain included. Concurrent emits therefore linearize
+;; on monitor-acquisition order: the second thread cannot begin its fan-out until
+;; the first thread's outermost fan-out and every reentrant deferral it drained
+;; have completed. No listener callback ever overlaps itself, records reach each
+;; listener in a single defined order, and an emit still returns only after its
+;; record's callback has run (the monitor is held for the whole synchronous
+;; fan-out and released before `emit!` returns).
+;;
+;; Same-thread reentrancy does NOT re-acquire the monitor: a nested emit sees
+;; `*listener-fanout-queue*` already bound and takes the enqueue branch below, so
+;; it never reaches the lock — no self-deadlock, and the rf2-1zxlsm reentrant
+;; ordering is preserved verbatim. `locking` is a reentrant monitor regardless,
+;; so even a hypothetical re-entry could not deadlock on itself. CLJS is
+;; single-threaded (no concurrent emits): the `:cljs` arm runs the fan-out inline
+;; with no monitor, preserving production elision.
 
 (def ^:private ^:dynamic *listener-fanout-queue*
   "When bound (an outermost listener fan-out is in progress on this thread), a
@@ -720,6 +748,16 @@
   fanning out immediately, so every listener observes the outer event before
   the reentrant one. nil at the top of the stack."
   nil)
+
+#?(:clj
+   (def ^:private ^Object fanout-monitor
+     "Process-global JVM monitor serializing every OUTERMOST trace-listener
+     fan-out across concurrent emits (rf2-uw7hg), so no registered listener
+     callback is ever invoked on two threads at once and records reach each
+     listener in one defined order. Held for the whole synchronous fan-out +
+     drain. Reentrant same-thread emits never acquire it (they enqueue on
+     `*listener-fanout-queue*`). CLJS is single-threaded and has no counterpart."
+     (Object.)))
 
 (defn- fan-out-to-listeners!
   "Deliver `event` to every registered listener in registration order, isolating
@@ -736,6 +774,25 @@
           (catch #?(:clj Throwable :cljs :default) _ nil))
         (when (continue?)
           (recur (next entries)))))))
+
+(defn- run-outermost-fanout!
+  "Deliver `event` to every registered listener, then drain — FIFO, transitively
+  — every reentrant fan-out a listener deferred while it ran (rf2-1zxlsm). Binds
+  `*listener-fanout-queue*` so a nested emit from a listener body enqueues rather
+  than recursing; the index re-reads `(count @q)` each step so appends made
+  mid-drain are picked up in FIFO emission order.
+
+  On the JVM the caller runs this under `fanout-monitor` so concurrent emits
+  serialize (rf2-uw7hg); the binding + drain are the whole critical section."
+  [event continue?]
+  (let [q (volatile! [])]
+    (binding [*listener-fanout-queue* q]
+      (fan-out-to-listeners! event continue?)
+      (loop [i 0]
+        (when (< i (count @q))
+          (let [[ev cont] (nth @q i)]
+            (fan-out-to-listeners! ev cont))
+          (recur (inc i)))))))
 
 (defn- deliver-to-tooling!
   "Push `event` onto its in-flight frame's run-keyed ring (when the
@@ -774,20 +831,17 @@
    (if-let [q *listener-fanout-queue*]
      ;; Reentrant emit from inside a listener body: defer so every listener
      ;; observes the outer event before this one. The outermost fan-out (below)
-     ;; drains us. Ring retention already ran above, in emission order.
+     ;; drains us. Ring retention already ran above, in emission order. Bound
+     ;; only on THIS thread, so this branch is what keeps a reentrant emit off
+     ;; the `fanout-monitor` — no self-deadlock.
      (do (vswap! q conj [event continue?]) nil)
-     ;; Outermost fan-out: deliver this event, then drain every fan-out that
-     ;; listeners deferred while it ran — and, transitively, any THEY defer —
-     ;; in FIFO emission order. The index re-reads `(count @q)` each step so
-     ;; appends made mid-drain are picked up.
-     (let [q (volatile! [])]
-       (binding [*listener-fanout-queue* q]
-         (fan-out-to-listeners! event continue?)
-         (loop [i 0]
-           (when (< i (count @q))
-             (let [[ev cont] (nth @q i)]
-               (fan-out-to-listeners! ev cont))
-             (recur (inc i)))))))))
+     ;; Outermost fan-out. On the JVM `fanout-monitor` serializes it across
+     ;; concurrent emits (rf2-uw7hg) so no listener callback overlaps itself and
+     ;; records reach each listener in monitor-acquisition order; the monitor is
+     ;; held for the whole synchronous fan-out + drain. CLJS is single-threaded,
+     ;; so it runs inline with no monitor.
+     #?(:clj  (locking fanout-monitor (run-outermost-fanout! event continue?))
+        :cljs (run-outermost-fanout! event continue?)))))
 
 (late-bind/set-fn! :trace.tooling/deliver! deliver-to-tooling!)
 

--- a/implementation/core/test/re_frame/trace_listener_concurrent_serialization_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_concurrent_serialization_test.clj
@@ -1,0 +1,185 @@
+(ns re-frame.trace-listener-concurrent-serialization-test
+  "rf2-uw7hg — each registered trace listener must be invoked SERIALLY across
+  concurrent JVM emits. Spec 009 §The listener contract (and
+  `docs/api/re-frame.core.md`: \"Delivery is synchronous: the callback returns
+  before the next record\") promise synchronous, in-order, event-at-a-time
+  delivery PER listener — a tool callback / appender was told it can never
+  re-enter itself.
+
+  ## The defect
+
+  `re-frame.trace.tooling/deliver-to-tooling!` defers reentrant fan-outs onto
+  `*listener-fanout-queue*`, a THREAD-LOCAL dynamic binding. That orders
+  same-thread nested emits (rf2-1zxlsm) but says nothing about two emits racing
+  on two JVM threads: each opens its OWN outermost fan-out and each invokes the
+  SAME registered listener callback CONCURRENTLY. A latch probe that blocks
+  listener L while it handles event A on one thread, then emits B on another,
+  observed B enter L before A's callback returned — the callback overlapped
+  itself, and B could overtake A even when A's emit began first.
+
+  ## The fix
+
+  A single process-global JVM monitor (`fanout-monitor`) serializes each
+  OUTERMOST fan-out — its transitive reentrant drain included. Concurrent emits
+  linearize on monitor-acquisition order; no listener callback ever overlaps
+  itself; an emit still returns only after its record's callback completes.
+  Same-thread reentrancy never re-acquires the monitor (it enqueues on the
+  thread-local queue), so the rf2-1zxlsm ordering is preserved and there is no
+  self-deadlock. CLJS is single-threaded, so these races cannot manifest there
+  and there is no monitor — hence this suite is JVM-only (`.clj`)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace :as trace])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private probe-a :trace.serialize/a)
+(def ^:private probe-b :trace.serialize/b)
+
+;; Loop the deterministic latch proof so a green run is determinism, not a lucky
+;; interleaving. Env-overridable for a heavier local soak.
+(def ^:private latch-iters
+  (or (some-> (System/getenv "RF2_UW7HG_LATCH_ITERS") Long/parseLong)
+      50))
+
+(def ^:private stress-iters
+  (or (some-> (System/getenv "RF2_UW7HG_STRESS_ITERS") Long/parseLong)
+      2000))
+
+;; ---- 1. Deterministic two-thread latch proof -----------------------------
+
+(deftest per-listener-callback-never-overlaps-across-concurrent-emits
+  ;; A single listener L blocks INSIDE its callback while handling event A
+  ;; (emitted on thread t1). While A is blocked, event B is emitted to the SAME
+  ;; L on thread t2. Pre-fix, t2's outermost fan-out was a distinct thread-local
+  ;; queue and ran concurrently, so L(B) entered while L(A) was still in flight
+  ;; (max concurrent invocations 2, and B recorded before A returned). With
+  ;; `fanout-monitor`, t2's fan-out blocks until t1's A callback returns, so L
+  ;; never re-enters itself and B is delivered strictly after A.
+  (testing (str "one listener cannot enter B until its A callback has returned "
+                "(" latch-iters " iterations)")
+    (dotimes [iter latch-iters]
+      (let [log       (atom [])
+            in-flight (atom 0)
+            max-conc  (atom 0)
+            a-entered (CountDownLatch. 1)
+            b-entered (CountDownLatch. 1)
+            release-a (CountDownLatch. 1)]
+        (trace/register-listener! ::probe
+          (fn [ev]
+            (let [op (:operation ev)]
+              (when (or (= op probe-a) (= op probe-b))
+                ;; Overlap detector: record the max simultaneous invocations.
+                (let [n (swap! in-flight inc)]
+                  (swap! max-conc max n))
+                (swap! log conj [:enter op])
+                (if (= op probe-a)
+                  (do (.countDown a-entered)
+                      ;; Block A mid-callback, holding the fan-out monitor, until
+                      ;; the harness releases it — never released by B's delivery,
+                      ;; so a serialized B cannot deadlock A.
+                      (.await release-a 5 TimeUnit/SECONDS))
+                  (.countDown b-entered))
+                (swap! log conj [:exit op])
+                (swap! in-flight dec)))))
+        (let [t1 (Thread. ^Runnable (fn [] (trace/emit! :info probe-a {})))
+              t2 (Thread. ^Runnable (fn [] (trace/emit! :info probe-b {})))]
+          (.start t1)
+          ;; A is now inside L, blocked on release-a (holding fanout-monitor).
+          (.await a-entered 5 TimeUnit/SECONDS)
+          (.start t2)
+          ;; Wait until t2 has reached the fan-out seam: pre-fix it enters L(B)
+          ;; (b-entered fires, overlap already recorded); fixed, it is BLOCKED
+          ;; contending for fanout-monitor. late-bind + the emit path use only
+          ;; lock-free atoms, so a BLOCKED state here means monitor contention.
+          ;; Deadline-bounded so a mis-started thread cannot hang the suite.
+          (let [deadline (+ (System/currentTimeMillis) 5000)]
+            (loop []
+              (when (and (< (System/currentTimeMillis) deadline)
+                         (pos? (.getCount b-entered))
+                         (not= java.lang.Thread$State/BLOCKED (.getState t2)))
+                (Thread/yield)
+                (recur))))
+          (.countDown release-a)
+          (.join t1 5000)
+          (.join t2 5000))
+        (trace/unregister-listener! ::probe)
+        (is (= 1 @max-conc)
+            (str "iter " iter ": the listener callback was invoked concurrently "
+                 "with itself across two emits (max concurrent invocations "
+                 @max-conc "); per-listener delivery must never overlap"))
+        (is (= [[:enter probe-a] [:exit probe-a] [:enter probe-b] [:exit probe-b]]
+               @log)
+            (str "iter " iter ": B reached the listener before A's callback "
+                 "returned; expected strict A-before-B ordering, got "
+                 (pr-str @log)))))))
+
+;; ---- 2. Stress + registration churn (no overlap, no deadlock) ------------
+
+(deftest ^:stress concurrent-emits-serialize-under-registration-churn
+  ;; Many threads emit concurrently while a churn thread registers /
+  ;; unregisters a second listener. A continuously-registered always-on
+  ;; listener runs an overlap detector. Invariants:
+  ;;   - it NEVER observes a concurrent self-invocation (max-conc == 1) — the
+  ;;     monitor serializes every fan-out;
+  ;;   - it receives EVERY emitted event exactly once (delivered == total) —
+  ;;     registration churn on a sibling id neither drops nor double-delivers;
+  ;;   - the run COMPLETES — no emitter thread is left alive (no deadlock,
+  ;;     no retroactive stall) after joining.
+  (testing (str "concurrent emits never overlap a listener and never deadlock "
+                "under registration churn (" stress-iters " emits)")
+    (let [in-flight  (atom 0)
+          max-conc   (atom 0)
+          delivered  (atom 0)
+          n-threads  6
+          per-thread (quot stress-iters n-threads)
+          total      (* n-threads per-thread)]
+      (trace/register-listener! ::always-on
+        (fn [_ev]
+          (let [n (swap! in-flight inc)]
+            (swap! max-conc max n))
+          (swap! delivered inc)
+          (swap! in-flight dec)))
+      (let [start (CountDownLatch. 1)
+            stop  (atom false)
+            churn (Thread.
+                    ^Runnable
+                    (fn []
+                      (.await start)
+                      (let [toggle (atom false)]
+                        (while (not @stop)
+                          (if (swap! toggle not)
+                            (trace/register-listener! ::churned (fn [_ev] nil))
+                            (trace/unregister-listener! ::churned))
+                          (Thread/yield)))))
+            emitters (mapv (fn [t]
+                             (Thread.
+                               ^Runnable
+                               (fn []
+                                 (.await start)
+                                 (dotimes [i per-thread]
+                                   (trace/emit! :info :trace.serialize/stress
+                                                {:t t :i i})))))
+                           (range n-threads))]
+        (.start churn)
+        (doseq [^Thread e emitters] (.start e))
+        (.countDown start)
+        (doseq [^Thread e emitters] (.join e 30000))
+        (reset! stop true)
+        (.join churn 5000)
+        (let [stragglers (filterv (fn [^Thread e] (.isAlive e)) emitters)]
+          (trace/unregister-listener! ::always-on)
+          (trace/unregister-listener! ::churned)
+          (is (empty? stragglers)
+              (str "an emitter thread did not finish within the deadline — "
+                   "possible deadlock; " (count stragglers) " still alive"))
+          (is (= 1 @max-conc)
+              (str "the always-on listener overlapped itself under concurrent "
+                   "emits (max concurrent invocations " @max-conc ")"))
+          (is (= total @delivered)
+              (str "every concurrently-emitted event must reach the always-on "
+                   "listener exactly once; expected " total ", got "
+                   @delivered)))))))


### PR DESCRIPTION
## What

PR #6051's reentrant listener fan-out queue (`*listener-fanout-queue*` in `implementation/core/src/re_frame/trace/tooling.cljc`) is a **thread-local** dynamic binding, so it only orders **same-thread** nested emits. Two emits racing on two JVM threads each opened their own outermost fan-out and invoked the **same** registered listener callback concurrently.

This violated the public listener contract — `docs/api/re-frame.core.md`: *"Delivery is synchronous: the callback returns before the next record"* — and Spec 009 §The listener contract, which require synchronous, in-order, event-at-a-time delivery **per listener**. It also let B reach a listener before A even when A's emit began first, and exposed ordinary tool callbacks/appenders to concurrent invocation they were told cannot happen.

## The race (file:line)

- `tooling.cljc` outermost fan-out branch of `deliver-to-tooling!` — two threads each entered it concurrently (the queue is bound per-thread), running `fan-out-to-listeners!` at the same time.
- `fan-out-to-listeners!` invokes `(f event)` — the **same** registered callback `f`, overlapped across threads.

## The fix

Serialize the **outermost** fan-out — its transitive reentrant drain included — under a single process-global JVM monitor (`fanout-monitor`). Concurrent emits linearize on monitor-acquisition order; no listener callback ever overlaps itself; an emit still returns only after its record's callback completes (the monitor is held for the whole synchronous fan-out).

Same-thread reentrancy takes the enqueue branch and **never re-acquires** the monitor, so the rf2-1zxlsm reentrant ordering is preserved verbatim and there is no self-deadlock. CLJS is single-threaded — the `:cljs` arm runs the fan-out inline with no monitor, preserving production elision. Listener exception isolation, exact-continuation suppression (rf2-eaxnai), retentionless structural delivery (rf2-vxgfnd.244), and registration-replacement semantics are all untouched.

Scope is confined to `tooling.cljc` (the fan-out seam) + its regression test + a clarifying sentence in `docs/api/re-frame.core.md`. No `observation.cljc` or `spec/009` touch. No new error-id, so no Spec 009 catalogue row.

## Regression coverage

New JVM suite `implementation/core/test/re_frame/trace_listener_concurrent_serialization_test.clj`:

1. **Deterministic two-thread latch proof** (looped 50×): a listener blocks inside its A callback on one thread while B is emitted to the same listener on another. Asserts the callback never overlaps itself (max-concurrent == 1) and B is delivered strictly after A. With the monitor removed the test fails deterministically on every iteration (`max-conc 2`, log `[a-enter, b-enter, b-exit, a-exit]`).
2. **`^:stress` + registration churn**: 6 threads emit concurrently while a churn thread registers/unregisters a sibling listener; asserts no self-overlap, exact-once delivery, and no deadlock (no straggler threads).

## Quality gates

- `implementation/core` JVM (`clojure -M:test`): **2037 tests, 9599 assertions, 0 failures, 0 errors**.
- `implementation/core` `^:stress` (`clojure -M:slow-test -n …`): new stress test green.
- `npm run test:cljs`: **9796 tests, 48148 assertions, 0 failures, 0 errors**.
- Red-before confirmed: with the monitor disabled, the latch test fails deterministically across all 50 iterations; restored to green with the fix.
