### PR TITLE
docs(spec-004): reconcile S3 diagnostic-ownership + local/fn-prop contracts (rf2-vxgfnd.95.13, rf2-vxgfnd.95.14)

### DIFF
--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -927,16 +927,21 @@ path + generation, released/remounted on ambiguity.
   resource / hmr / hydration-correction / reconnect-correction / epoch-restore /
   foreign-or-react) — attribution is emitted at the cause site, never reconstructed.
   Every bounded buffer reports loss accounting (`total`/`retained`/`dropped`).
-- **One catalogue.** The evidence schemas, trace ops, and every error/warning id this
+- **One catalogue (runtime tier).** The evidence schemas, trace ops, and every
+  **runtime** error/warning id this
   Spec names (`:rf.error/dispatch-disconnected`, `:rf.error/view-not-found`,
   `:rf.error/frame-payload-invalid` and its shipped sibling
   `:rf.error/frame-payload-conflict`, `:rf.error/flush-in-open-epoch`,
   `:rf.error/ui-test-overlapping-act`,
   `:rf.error/jvm-host-op`, `:rf.warning/unregistered-event-id`,
   `:rf.warning/placeholder-in-dynamic-vector`, `:rf.warning/cross-frame-carried-op`,
-  `:rf.warning/render-phase-dispatch` / `-set!`, and the compile-error roster) get
+  `:rf.warning/render-phase-dispatch` / `-set!`) get
   (or, per stage, will get) catalogue rows in [009](009-Instrumentation.md) (the
-  one-catalogue rule, rf2-cs0kd1).
+  one-catalogue rule, rf2-cs0kd1). The compile-tier `:rf.ui.compile/*` roster is
+  **exempt**: those ids are maintained in the compiler roster/prose here and carry
+  **no Spec 009 rows** — only runtime-tier ids are catalogued (per the position law
+  above). Spec 009 catalogues the runtime diagnostic surface; the compiler owns its
+  own compile-error roster.
 - **Source ↔ DOM navigation.** Compile-time `data-rf2-source-coord` + render-key
   (+ occurrence-path) annotation on compiler-owned host roots — today's attribute
   vocabulary, so existing Xray click-to-source works day one. Dev-gated; production

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -298,12 +298,18 @@ built on it is not v1).
 | bare fn at a **foreign-component** boundary | unknown | unknown | unknown | no | **compile error** — choose `ui/event`/`ui/handler`/`ui/render-fn`/`ui/raw-fn` |
 | `(ui/raw-fn f)` | foreign, identity-as-protocol | passed through | its closure | no | APIs that treat callback identity as data; also the callback-ref form |
 
-**The narrow bare-fn law (R-4).** Bare fns are legal **only** in known native
-event properties, where the invoker and phase are known. One callback never serves both
-phases. A day-one **strict lint** — `{:re-frame.ui/bare-handlers :warn}` (or `:error`) —
-lets a team adopt explicit-everywhere as policy without a language change; the language
-itself stays permissive (flipping it later would break source; the lint is the honest
-lever).
+**The narrow bare-fn law (R-4).** As an *invoked callback*, a bare fn is legal **only**
+in known native event properties, where the invoker and phase are known. One callback
+never serves both phases. A day-one **strict lint** — `{:re-frame.ui/bare-handlers :warn}`
+(or `:error`) — lets a team adopt explicit-everywhere as policy without a language change;
+the language itself stays permissive (flipping it later would break source; the lint is
+the honest lever). **An ordinary fn prop between INTERNAL views** (compile-resolved Vars)
+is **not** a callback position: it is a **legal opaque value** — identity-compared like
+any other prop, never invoked by the framework, promising **no** invocation phase; the
+receiving view's own contract decides its use (C-13a). To opt a fn into a *phase*, use
+`ui/handler` (the per-site stable identity a fresh closure lacks) or `ui/render-fn`. Bare
+fns at a **foreign-component** boundary and in non-event native positions stay rejected —
+the narrow law governs the callback case, not opaque data props.
 
 **Refs.** `:ref` is a reserved React slot, never an event property — the bare-fn
 shorthand does NOT apply. Object refs are preferred. A callback ref MUST be explicit
@@ -462,9 +468,13 @@ most views need only `sub` and bare event vectors.
 (let [[text set-text] (local "")] …)
 ```
 
-`(local init)` → `[value set!]` — **host component-local state, deliberately outside
-re-frame2 epochs**: not observed by subs, not revertible by epoch restore, re-renders
-this view only. `set!` during render is a dev error
+`(local init)` → `[value set! update!]` — **host component-local state, deliberately
+outside re-frame2 epochs**: not observed by subs, not revertible by epoch restore,
+re-renders this view only. `set!` stores its argument **exactly** — a stored function is
+a value, never a React-style updater (no `useState` fn-overload); `update!` applies
+`(f current & args)` to the **latest** host state (not the committed render's value), so
+several same-turn host writers compose instead of last-write-wins. Two-element
+destructuring `[value set!]` stays valid. `set!`/`update!` during render is a dev error
 (`:rf.warning/render-phase-set!`). There is no frame-resident variant and none is
 reserved — if frame-resident ephemera is ever built it will be a new name with its own
 semantics.


### PR DESCRIPTION
Two prose-only reconciliations to `spec/004-Views.md` that align the normative Spec 004 with shipped S3 behaviour. These gate S3 completion (the leaf chain toward mgy7pz → S4). No doc restructure, no new sections, no second rulebook.

## rf2-vxgfnd.95.13 — compile-tier diagnostics vs. the runtime-only Spec 009 catalogue

**Contradiction (before):** The React-interop position law (§React interoperability) states `:rf.ui.compile/*` compile-time ids join the compiler roster and carry **no Spec 009 catalogue rows** — only runtime-tier ids are catalogued. But §"One catalogue" listed "the compile-error roster" among the ids that get (or will get) Spec 009 rows. An implementer could not tell whether S3 must add forbidden 009 rows or violate the one-catalogue statement.

**Reconciled (after):** Narrowed §"One catalogue" to the **runtime tier** — removed "and the compile-error roster" from the catalogued-id list and added an explicit exemption: the compile-tier `:rf.ui.compile/*` roster is maintained in the compiler roster/prose and carries no Spec 009 rows (only runtime-tier ids are catalogued). §One-catalogue now agrees with the position law.

**No Spec 009 rows added** (the bead is precisely about *not* adding compile-tier rows). This matches the shipped `.95.3` implementation, whose commit records "New compile-error ids (all `:rf.ui.compile/*`, prose-only — no Spec 009 rows)".

## rf2-vxgfnd.95.14 — shipped `local` three-tuple + internal fn-prop opacity

**Contradiction 1 (before):** `local` ships `[value set! update!]` (per `implementation/ui/src/re_frame/ui.cljc` + `hooks.cljc`), but Spec 004 still specified `[value set!]`.
**Reconciled (after):** `(local init)` → `[value set! update!]`; `set!` stores its argument **exactly** (a stored fn is a value, never a React-style updater); `update!` applies `(f current & args)` to the **latest** host state so same-turn writers compose instead of last-write-wins. Two-element `[value set!]` destructuring stays valid.

**Contradiction 2 (before):** C-13a + merged `.95.3` make an ordinary fn prop between INTERNAL views a legal opaque identity-compared value, but the narrow bare-fn law (R-4) read as if all non-native-event bare fns were illegal.
**Reconciled (after):** Stated the exception in R-4: an ordinary fn prop between INTERNAL views is a legal **opaque value** (identity-compared, never invoked, no promised phase); `ui/handler` / `ui/render-fn` opt a fn into a phase; foreign bare fns and non-event native positions stay rejected.

**Migrator table (MIG-27) untouched** — `rf2-vxgfnd.188` owns that reconciliation separately; this PR references, does not duplicate, it. **Synthesis-skill reconciliation N/A** — no skill under `skills/` references the fn-prop law (it lives in the operator's gitignored `ai/findings/new-substrate-synthesis/` artifact, out of committed scope).

## Quality gates

- `python -m mkdocs build --strict` — **PASS** (exit 0); my edits introduce zero broken links/anchors.
- `python scripts/check_doc_slugs.py` — **PASS for this PR's surface** (zero broken targets in `spec/004-Views.md`). The checker reports **one pre-existing broken link unrelated to this PR**: `tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md:2562 -> ../../NAMING.md` (missing `tools/NAMING.md`), shipped by the merged `.95.8` PR (#6148, commit 531eedc36e) and pulled in when this branch rebased onto current `origin/main`. It is on the `tools/re-frame2-pair-mcp` surface, not touched here — needs a separate bead/fix on that surface.
- No code gates (prose-only). No `emit_cljs.cljc`, no `spec/009`, no migrator-table changes.

Diff: `spec/004-Views.md` only (27 insertions, 12 deletions).
