### PR TITLE
docs(resources): correct landing lease cleanup + mutation invalidation guidance (rf2-l6yfs)

### DIFF
--- a/docs/resources/concepts.md
+++ b/docs/resources/concepts.md
@@ -296,8 +296,10 @@ remembered in `onSuccess`:
 Success plan arms (fixed order): `:patches` → `:populates` → `:removes` →
 `:invalidates`. Patches run *before* populates, so when the same key is both
 patched and populated the **populate wins** — it is applied last, overwriting the
-patch. Invalidation runs last of all, over the tags the patch/populate did not
-already freshen.
+patch. Invalidation runs last of all. Only keys this same mutation **populated**
+are spared from its immediate refetch — a populate is an authoritative load, so
+the value it just wrote stays fresh. A **patched** key is *not* exempt: the same
+pass may still mark it stale and refetch it.
 
 Execute and watch (instance id is app-chosen — reuse it for the sub):
 

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -29,10 +29,11 @@ leak boundary. Views *read* — they never fetch.
 @(rf/subscribe [:rf/resource {:resource :article :params {:slug "hello"}}])
 ;; => {:status :idle …}  — registered, but nothing has caused a load yet
 
-;; a route or an event is the cause; here, an explicit ensure
+;; a route or an event is the cause; here, a one-shot ownerless ensure
+;; (supply a :cause, not an :owner — nothing pins the entry alive)
 (rf/dispatch [:rf.resource/ensure {:resource :article
                                    :params   {:slug "hello"}
-                                   :owner    [:lease :article "hello"]}])
+                                   :cause    [:event :article/opened]}])
 
 ;; now the same passive read progresses
 @(rf/subscribe [:rf/resource {:resource :article :params {:slug "hello"}}])


### PR DESCRIPTION
## What

Two targeted, docs-only corrections on the Resources pages. PR #6050 (closed rf2-5gj77s) fixed these pages but introduced two copyable contract errors still on main. Verified against runtime + spec before rewording.

### 1. `docs/resources/index.md` — landing ensure taught a pinned cache entry

The first `:rf.resource/ensure` example minted `:owner [:lease :article "hello"]` but never dispatched the matching `:rf.resource/release-owner`. An event-minted owner is a **durable liveness lease**: the entry keeps that owner in `:active-owners` and the reverse owner index, so normal stale/GC collection cannot reclaim it — the landing snippet taught a permanently pinned entry (the orphaned-owner leak the tutorial itself later warns against, and Xray lints for).

Fix: switch to a **one-shot ownerless ensure** carrying a `:cause`, not an `:owner`. This is the idiomatic minimal form for "an event caused this load, and nothing intends to keep it alive" (Spec 016 §Active owners and causes: *"If an event only wants to refresh data and does not intend to keep it active, it omits `:owner` and supplies only `:cause`."*). The passive read still progresses; nothing pins the entry. Lifecycle/owner+release is taught properly in the tutorial (Part 2).

### 2. `docs/resources/concepts.md` — overstated patch exemption from invalidation

The fixed-arm-order prose said invalidation runs *"over the tags the patch/populate did not already freshen."* Runtime truth: `mutation_events.cljc` `plan->fx` passes **only `populated-ks`** as the same-mutation exemption set (call site line 1710 passes `populated-ks`, never `patched-ks`), matching Spec 016 §Populate is an authoritative load and the populate-only `:refetch-populated?` rule. A **patched** key is *not* exempt — the same mutation's invalidation pass may immediately mark it stale and refetch it.

Fix: reword to a **populate-only** exemption, stating explicitly that patched keys are not exempt.

## Quality gates

- `python -m mkdocs build --strict` — **exit 0** (documentation built; only pre-existing INFO lines, no new warnings/errors).
- `python scripts/check_doc_slugs.py` — **exit 0**. Its one reported finding is a pre-existing broken link in `tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md` (outside this PR's surface; unrelated to these edits, which add/change no links or anchors).
- No code gates — docs-only.

Closes rf2-l6yfs.
