### PR TITLE
docs(pair-mcp): fix broken NAMING.md link target in Tool-Catalogue (rf2-q75nc)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -2559,7 +2559,7 @@ lease, or React object crosses the wire.
 | `read-mounted-views`      | `mounted-views`               | —          |
 | `explain-render`          | `explain-render`              | `view-id?` |
 
-The wire names carry a [`NAMING.md`](../../NAMING.md)-conformant verb
+The wire names carry a [`NAMING.md`](../../mcp-conformance/NAMING.md)-conformant verb
 prefix (`read-` / `explain-`); the framework fn names (`view-manifest`,
 …) do not, so the four manifest reads take the `read-<thing>` idiom
 `read-ui` / `read-dom` / `read-sub` already use.


### PR DESCRIPTION
## What

Fix the broken markdown link at `tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md:2562`.

PR #6148 (.95.8) added `[`NAMING.md`](../../NAMING.md)`. From `tools/re-frame2-pair-mcp/spec/`, `../../NAMING.md` resolves to `tools/NAMING.md`, which does not exist. The only tracked `NAMING.md` is `tools/mcp-conformance/NAMING.md`. This turned the `docs` / `check_doc_slugs` gate RED on `main` HEAD, failing every rebasing PR.

## The fix (one link, minimal)

Line 2562: `[`NAMING.md`](../../NAMING.md)` → `[`NAMING.md`](../../mcp-conformance/NAMING.md)`.

From `tools/re-frame2-pair-mcp/spec/`, `../../mcp-conformance/NAMING.md` resolves to `tools/mcp-conformance/NAMING.md` (exists).

The prose mentions of `NAMING.md` elsewhere in the file (lines 20, 2371, 2481, 2741, 2841, 3708) are **not** markdown links and are left untouched. This was the only `](../../NAMING.md)` link occurrence in the file.

## Quality gates

- `python scripts/check_doc_slugs.py --self-test --verbose` → all 22 self-tests passed
- `python scripts/check_doc_slugs.py --verbose` → **no broken links** (527 markdown files scanned) — this is the exact CI `docs` job step that was red
- `python -m mkdocs build --strict` → exit 0 (no warnings escalated)
- Corrected relative path verified to resolve to the real file on disk

Closes rf2-q75nc.