### PR TITLE
fix(machines): bind timer cancellation batches + reschedules to the exact frame incarnation (rf2-ijlhj)

### DIFF
--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -333,46 +333,78 @@
       (fn [] (not (frame/frame-incarnation-live? frame-id captured)))
       (constantly false))))
 
+(defn- claim-emit-release!
+  "The ONE durable cancel step: claim the `[frame-id k]` slot by EXACTLY `token`,
+  and only if that claim wins, emit the single owed `:rf.machine.timer/cancelled`
+  trace and release the claimed entry's resources. Shared by the current-occupant
+  cancel (`cancel-after-timer-entry!`) and the incarnation-exact batch cancel
+  (`cancel-snapshotted-entry!`).
+
+  Because the claim is scoped to the exact attempt `token` (an atomic
+  token-guarded CAS, `claim-entry!`), a same-id successor B that re-armed key `k`
+  under a FRESH globally-unique token is never claimed — the CAS fails and B's
+  entry + host handle survive byte-identical (rf2-ijlhj / rf2-j538f7.7).
+  `owner-gone?` fences the shared `(frame,query-v)` subscription decrement inside
+  `release-entry-resources!` (rf2-i4aj9c) so A's release cannot dispose a
+  reaction same-id B re-armed for the SAME query."
+  [frame-id k reason token owner-gone?]
+  (when-let [claimed (claim-entry! frame-id k token)]
+    (emit-cancelled! frame-id k claimed reason)
+    (release-entry-resources! frame-id claimed (:delay k) owner-gone?)))
+
 (defn- cancel-after-timer-entry!
-  "Cancel and clear a single :after timer-table entry under `frame-id`,
+  "Cancel the CURRENT occupant of a single :after timer-table slot `[frame-id k]`,
   emitting one `:rf.machine.timer/cancelled` trace stamped with
   `reason` (closed set: `:on-exit / :on-destroy / :on-resolution /
   :on-supersede / :on-frame-destroy / :on-restore`). Idempotent —
   a second call against the same `[frame-id k]` is a no-op (the entry
   is gone so no trace fires).
 
-  Cancels the exact attempt observed: it reads the current occupant's
-  `:token` and atomically CLAIMS the slot only while that token is still
-  current (`claim-entry!`). If a concurrent re-arm published a SUCCESSOR under
-  the same key between the read and the claim, this cancellation leaves the
-  successor untouched and emits nothing — the successor's own arrival already
-  released the observed attempt, so the cancellation fires exactly once and
-  never deletes a successor it did not release (rf2-j538f7.7). A cancellation
-  that claims an ARMING sentinel (`:handle nil`, host clock not yet armed)
-  still emits the owed trace and releases the held subscription; the arming
-  thread's publish phase then finds its token gone and cancels the returned
-  host handle.
+  Reads the current occupant's `:token` and atomically CLAIMS the slot only while
+  that token is still current (`claim-entry!`), so if a concurrent re-arm
+  published a SUCCESSOR under the same key between the read and the claim, this
+  cancellation leaves the successor untouched and emits nothing (rf2-j538f7.7). A
+  cancellation that claims an ARMING sentinel (`:handle nil`, host clock not yet
+  armed) still emits the owed trace and releases the held subscription; the
+  arming thread's publish phase then finds its token gone and cancels the
+  returned host handle.
 
-  rf2-i4aj9c — `emit-cancelled!` is CALLBACK-BEARING (the synchronous
-  `:rf.machine.timer/cancelled` trace). A listener can destroy the owning frame
-  incarnation A and re-arm the SAME subscription-vector query in same-id B on
-  that trace's own stack. The optional `owner-gone?` predicate is threaded into
-  `release-entry-resources!` so the shared `subs/unsubscribe` decrement is
-  skipped once A is lost — A's release cannot dispose B's fresh reaction.
+  Used by the reschedule single-cancels — `schedule-after-timer!`'s leading
+  `:on-supersede` and `on-sub-changed!`'s `:on-resolution` — which DELIBERATELY
+  cancel whatever attempt currently holds the key before installing / rescheduling
+  over it. BATCH cancellations (`after-cancel-fx`, actor / frame destroy, restore)
+  must NOT re-read the current occupant — a same-id successor B could have re-armed
+  the key on a prior cancellation's callback stack, and re-reading would claim B —
+  so they use `cancel-snapshotted-entry!` instead, binding the claim to the
+  incarnation's OWN attempt token captured at batch entry (rf2-ijlhj).
 
-  rf2-rbxdxa — the 3-arity is NO LONGER unfenced: it captures its own
-  same-id-successor predicate (`successor-published?-fn`) BEFORE `emit-cancelled!`,
-  so EVERY non-destroy cancellation reason (`:on-exit` / `:on-resolution` /
-  `:on-supersede` / `:on-frame-destroy` / `:on-restore`) also skips the shared
-  decrement when a cancellation listener republishes same-id B, while an ordinary
-  cancellation (no successor) still releases fully. The 4-arity carries the
-  stronger destroy-tail `owner-gone?` its callers captured at the effect entry."
+  rf2-i4aj9c / rf2-rbxdxa — `emit-cancelled!` is CALLBACK-BEARING; `owner-gone?`
+  (defaulting to a same-id-successor predicate captured BEFORE the trace) is
+  threaded into `release-entry-resources!` so the shared `subs/unsubscribe`
+  decrement is skipped once A is lost, while an ordinary cancellation with no
+  successor still releases fully."
   ([frame-id k reason] (cancel-after-timer-entry! frame-id k reason (successor-published?-fn frame-id)))
   ([frame-id k reason owner-gone?]
    (when-let [entry (get-in @after-timers [frame-id k])]
-     (when-let [claimed (claim-entry! frame-id k (:token entry))]
-       (emit-cancelled! frame-id k claimed reason)
-       (release-entry-resources! frame-id claimed (:delay k) owner-gone?)))))
+     (claim-emit-release! frame-id k reason (:token entry) owner-gone?))))
+
+(defn- cancel-snapshotted-entry!
+  "Cancel a batch-SNAPSHOTTED `[k entry]` pair, binding the claim to the EXACT
+  attempt token the batch OBSERVED — not the slot's current occupant (rf2-ijlhj).
+
+  A batch (`after-cancel-fx`, `cancel-actor-timers!`, `cancel-all-timers!`,
+  `cancel-frame-timers-on-restore!`) snapshots the incarnation A's entries, then
+  cancels them one by one. Each cancellation's `:rf.machine.timer/cancelled` trace
+  is CALLBACK-BEARING: a listener can destroy A and publish same-id B, re-arming a
+  reused `{:parent :spawn :delay}` key under a FRESH token, on that trace's own
+  stack (deterministic) — or a JVM thread can do the same between snapshot and
+  claim. Re-reading the current occupant to source the claim token (the old
+  `cancel-after-timer-entry!` shape) would then claim/remove B. Sourcing the token
+  from the SNAPSHOT `entry` instead makes the claim incarnation-exact: B's
+  fresh-token entry fails the atomic CAS and survives untouched. `owner-gone?` is
+  the batch's ONE captured incarnation predicate, threaded into the release."
+  [frame-id k entry reason owner-gone?]
+  (claim-emit-release! frame-id k reason (:token entry) owner-gone?))
 
 (defn- on-sub-changed!
   "Watch callback invoked when a subscription-vector delay's value
@@ -385,10 +417,22 @@
   caught by the epoch invariant when the new timer fires."
   [frame-id parent-id invoke-id delay-key state old-v new-v]
   (when-not (= old-v new-v)
-    (let [k (after-timer-key parent-id invoke-id delay-key)]
-      (cancel-after-timer-entry! frame-id k :on-resolution)
-      ;; Machine snapshots are durable runtime-db state.
-      (when-let [rt (frame/frame-runtime-db-value frame-id)]
+    (let [k (after-timer-key parent-id invoke-id delay-key)
+          ;; rf2-ijlhj — capture the owning incarnation BEFORE the callback-bearing
+          ;; `:on-resolution` cancel. `cancel-after-timer-entry!` fires the
+          ;; `:rf.machine.timer/cancelled` trace, whose listener can destroy A and
+          ;; publish same-id B on this stack; the bare-ID runtime read + reschedule
+          ;; below would otherwise resolve `still-here?` against B's snapshot and
+          ;; install A-derived timer work into B. This ONE predicate fences both the
+          ;; cancel's shared-subscription release and the reschedule continuation.
+          owner-gone? (successor-published?-fn frame-id)]
+      (cancel-after-timer-entry! frame-id k :on-resolution owner-gone?)
+      ;; Machine snapshots are durable runtime-db state. The post-cancel read +
+      ;; reschedule run ONLY while the captured incarnation still owns the frame;
+      ;; once a cancellation listener has replaced A with B, nothing A-derived is
+      ;; read from or installed into the successor.
+      (when-let [rt (and (not (owner-gone?))
+                         (frame/frame-runtime-db-value frame-id))]
         (let [snap (get-in rt (paths/snapshot-path parent-id))
               ;; Per Spec 005 §Per-region :after scoping: for parallel-region
               ;; machines the snapshot's :state is a map
@@ -433,11 +477,24 @@
   `:rf.machine.timer/cancelled` trace with `:reason :on-supersede` —
   the only path that hits this branch with a live prior entry is
   `cancel-and-reschedule` (initial schedule against an empty slot is a
-  no-op cancel)."
+  no-op cancel).
+
+  rf2-ijlhj — the leading `:on-supersede` cancel is CALLBACK-BEARING when it
+  supersedes a LIVE prior entry (the reschedule path): its
+  `:rf.machine.timer/cancelled` listener can destroy owning incarnation A and
+  publish same-id B on this stack. The incarnation captured at entry
+  (`owner-gone?`) is rechecked AFTER that cancel and BEFORE any delay
+  resolution / slot reservation / host arm, so a superseding reschedule installs
+  NO A-derived host work (or subscription ref-count) into successor B. An INITIAL
+  schedule supersedes an empty slot (no trace, no callback), so the recheck is a
+  no-op pass-through and the arm proceeds normally."
   [frame-id parent-id invoke-id state delay-key epoch server? snapshot
    {:keys [emit-scheduled-trace?]}]
   (let [delay-source (transition/classify-delay-source delay-key)
         k            (after-timer-key parent-id invoke-id delay-key)
+        ;; rf2-ijlhj — the owning incarnation, captured BEFORE the callback-bearing
+        ;; `:on-supersede` cancel and rechecked before the durable arm below.
+        owner-gone?  (successor-published?-fn frame-id)
         ;; A region `:after`'s `invoke-id` is region-PREFIXED
         ;; (`prefix-region-invoke-id` prepends the region name). Record that
         ;; region name in the entry so `emit-cancelled!` can strip it before
@@ -453,8 +510,14 @@
                                  (map? (:state snapshot))
                                  (seq invoke-id))
                        (first invoke-id))]
-    (cancel-after-timer-entry! frame-id k :on-supersede)
-    (cond
+    (cancel-after-timer-entry! frame-id k :on-supersede owner-gone?)
+    ;; rf2-ijlhj — a superseding cancellation's listener may have replaced A with
+    ;; same-id B on the stack above; gate every durable step (delay resolution,
+    ;; subscription hold, slot reservation, host arm, publish) on the captured
+    ;; incarnation so no A-derived timer work lands on B. Initial schedules keep
+    ;; the live owner (empty-slot supersede fires no callback), so this passes.
+    (when-not (owner-gone?)
+     (cond
       server?
       ;; Pure-side already emitted :skipped-on-server; no-op here.
       nil
@@ -619,7 +682,7 @@
                 ;; released the reaction and emitted the single owed `:cancelled`
                 ;; trace (or, for a self-fire, dispatched + released silently).
                 (do (managed-timer/cancel! handle)
-                    nil)))))))))
+                    nil))))))))))
 
 (defn after-schedule-fx
   "fx handler for `:rf.machine/after-schedule`. Per Spec 005 §Delayed
@@ -698,11 +761,26 @@
                     {:where 'rf.machine/after-cancel
                      :event-id (:rf/parent-id args)})
         parent-id (:rf/parent-id args)
-        invoke-id (vec (:rf/invoke-id args))]
-    (doseq [[k _entry] (get @after-timers frame-id)
-            :when (and (= parent-id (:parent k))
-                       (= invoke-id (:spawn k)))]
-      (cancel-after-timer-entry! frame-id k :on-exit))
+        invoke-id (vec (:rf/invoke-id args))
+        ;; rf2-ijlhj — bind the whole batch to ONE captured incarnation. Every
+        ;; `:rf.machine.timer/cancelled` trace is callback-bearing; a listener can
+        ;; destroy A and re-arm a same-key successor B on the FIRST cancellation's
+        ;; own stack. Two protections, both keyed off the entries SNAPSHOTTED here:
+        ;;   (1) cancel by the snapshotted attempt token (`cancel-snapshotted-entry!`),
+        ;;       never re-reading the current occupant — B's fresh-token re-arm fails
+        ;;       the atomic claim, so a within-key A→B swap can't remove B;
+        ;;   (2) short-circuit the loop the instant ownership is lost, so the
+        ;;       remaining keys (which B may have re-armed) are never even visited.
+        owner-gone? (successor-published?-fn frame-id)
+        snap        (into []
+                          (filter (fn [[k _]] (and (= parent-id (:parent k))
+                                                   (= invoke-id (:spawn k)))))
+                          (get @after-timers frame-id))]
+    (loop [pairs snap]
+      (when (and (seq pairs) (not (owner-gone?)))
+        (let [[k entry] (first pairs)]
+          (cancel-snapshotted-entry! frame-id k entry :on-exit owner-gone?))
+        (recur (rest pairs))))
     nil))
 
 (defn cancel-actor-timers!
@@ -719,34 +797,33 @@
   so the Xray Handler section can attribute the cancel to the actor's
   destroy event.
 
-  rf2-4ipqe4 — each `:rf.machine.timer/cancelled` emit is CALLBACK-BEARING:
-  a listener can synchronously destroy the finishing actor's owning frame
-  incarnation A and publish a same-id successor B ON THE FIRST CANCELLATION's
-  own stack. The cancellation loop reads each key's LIVE entry (so a stale
-  snapshot key whose slot B re-armed under a new token would be cancelled
-  against B) and the destroy tail that follows this call (classification /
-  spawn-order / system-id release) resolves bare frame/actor ids to the
-  CURRENT incarnation B. The optional `owner-gone?` predicate (the finalize
-  cascade's exact-incarnation gate) is rechecked BEFORE each snapshotted
-  cancellation, so once the first cancellation loses A the loop short-circuits
-  and never cancels B's timer. `owner-gone?` is MONOTONIC (once A→B it stays
-  gone). The 2-arity (the imperative `destroy` tail, which carries no event
-  owner) passes `(constantly false)` — unfenced, its historical behaviour."
+  rf2-4ipqe4 / rf2-ijlhj — each `:rf.machine.timer/cancelled` emit is
+  CALLBACK-BEARING: a listener can synchronously destroy the finishing actor's
+  owning frame incarnation A and publish a same-id successor B ON THE FIRST
+  CANCELLATION's own stack, re-arming a reused key under a fresh token. The loop
+  SNAPSHOTS A's `[k entry]` pairs up front and cancels each by its snapshotted
+  attempt token (`cancel-snapshotted-entry!`), so a re-read can never claim B's
+  fresh-token entry; the destroy tail that follows this call (classification /
+  spawn-order / system-id release) resolves bare frame/actor ids to the CURRENT
+  incarnation B. The optional `owner-gone?` predicate (the finalize cascade's
+  exact-incarnation gate) is rechecked BEFORE each cancellation, so once the first
+  cancellation loses A the loop short-circuits and never touches B's timer, and it
+  is threaded into the release so A's `subs/unsubscribe` cannot decrement a
+  reaction B re-armed for the same query. `owner-gone?` is MONOTONIC (once A→B it
+  stays gone). The 2-arity (the imperative `destroy` tail, which carries no event
+  owner) passes `(constantly false)` — its historical behaviour, now still safe
+  because the snapshot-token claim alone fences B's entry."
   ([frame-id parent-id]
    (cancel-actor-timers! frame-id parent-id (constantly false)))
   ([frame-id parent-id owner-gone?]
    (when (and frame-id parent-id)
-     (loop [ks (->> (vec (get @after-timers frame-id))
-                    (into [] (comp (filter (fn [[k _]] (= parent-id (:parent k))))
-                                   (map first))))]
-       (when (and (seq ks) (not (owner-gone?)))
-         ;; rf2-i4aj9c — thread `owner-gone?` into the single-entry cancel so
-         ;; the WITHIN-entry `emit-cancelled!` → subscription-release step is
-         ;; fenced too: a `:rf.machine.timer/cancelled` listener that re-arms the
-         ;; same query in same-id B cannot have A's release decrement B's ref.
-         ;; The loop-level guard short-circuits the REMAINING keys after the loss.
-         (cancel-after-timer-entry! frame-id (first ks) :on-destroy owner-gone?)
-         (recur (subvec ks 1)))))))
+     (loop [pairs (into []
+                        (filter (fn [[k _]] (= parent-id (:parent k))))
+                        (vec (get @after-timers frame-id)))]
+       (when (and (seq pairs) (not (owner-gone?)))
+         (let [[k entry] (first pairs)]
+           (cancel-snapshotted-entry! frame-id k entry :on-destroy owner-gone?))
+         (recur (subvec pairs 1)))))))
 
 (defn cancel-all-timers!
   "Cancel every in-flight :after timer the runtime is currently tracking
@@ -764,20 +841,27 @@
 
   The timer table is partitioned per frame; the 1-arity variant releases
   the destroyed frame's host-clock handles and subscription watchers
-  without touching sibling frames' state."
+  without touching sibling frames' state.
+
+  rf2-ijlhj — the 1-arity is a BATCH: each `:rf.machine.timer/cancelled` trace is
+  callback-bearing, so a listener could re-arm a same-key successor B on the first
+  cancellation's stack. It snapshots the `[k entry]` pairs, cancels each by its
+  snapshotted attempt token (`cancel-snapshotted-entry!`, never re-reading — a
+  re-read would claim B), and short-circuits once the captured incarnation is
+  lost. The 0-arity fixture-reset stays a SILENT bulk release (no traces, no
+  successor semantics — test-isolation cleanup)."
   ([]
    (doseq [[frame-id inner] @after-timers
            [k entry] inner]
      (release-entry-resources! frame-id entry (:delay k)))
    (reset! after-timers {}))
   ([frame-id]
-   (doseq [[k _entry] (vec (get @after-timers frame-id))]
-     ;; Use the single-entry helper so each cancellation emits the
-     ;; unified `:rf.machine.timer/cancelled` trace with the right
-     ;; `:reason`. `vec`-snapshot the iteration so the swap inside
-     ;; `cancel-after-timer-entry!` cannot trip a concurrent-
-     ;; modification surprise on the JVM target.
-     (cancel-after-timer-entry! frame-id k :on-frame-destroy))))
+   (let [owner-gone? (successor-published?-fn frame-id)]
+     (loop [pairs (vec (get @after-timers frame-id))]
+       (when (and (seq pairs) (not (owner-gone?)))
+         (let [[k entry] (first pairs)]
+           (cancel-snapshotted-entry! frame-id k entry :on-frame-destroy owner-gone?))
+         (recur (subvec pairs 1)))))))
 
 (defn cancel-frame-timers-on-restore!
   "Cancel every in-flight `:after` timer the given `frame-id` currently holds,
@@ -797,11 +881,20 @@
   (Managed-Effects §restore: \"epoch restore MUST NOT revive host work\").
 
   Published as the `:machines/on-frame-restored!` late-bind hook, consulted by
-  the epoch restore boundary (`perform-restore!`) AFTER a successful install.
-  No-op when the frame holds no in-flight timers. `vec`-snapshots the iteration
-  so the swap inside `cancel-after-timer-entry!` cannot trip a concurrent-
-  modification surprise on the JVM target."
+  the epoch restore boundary (`perform-restore!`) AFTER a successful install (the
+  frame stays LIVE across a restore — it is a wholesale runtime-db swap, not a
+  destroy). No-op when the frame holds no in-flight timers.
+
+  rf2-ijlhj — a BATCH like `cancel-all-timers!`: it snapshots the `[k entry]`
+  pairs, cancels each by its snapshotted attempt token (`cancel-snapshotted-entry!`,
+  never re-reading), and short-circuits once a callback-published same-id
+  successor B has replaced the incarnation captured at entry — so no `:on-restore`
+  cancel lands on B."
   [frame-id]
-  (doseq [[k _entry] (vec (get @after-timers frame-id))]
-    (cancel-after-timer-entry! frame-id k :on-restore))
+  (let [owner-gone? (successor-published?-fn frame-id)]
+    (loop [pairs (vec (get @after-timers frame-id))]
+      (when (and (seq pairs) (not (owner-gone?)))
+        (let [[k entry] (first pairs)]
+          (cancel-snapshotted-entry! frame-id k entry :on-restore owner-gone?))
+        (recur (subvec pairs 1)))))
   nil)

--- a/implementation/machines/test/re_frame/machine_timer_incarnation_fence_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_timer_incarnation_fence_cljs_test.cljc
@@ -1,0 +1,284 @@
+(ns re-frame.machine-timer-incarnation-fence-cljs-test
+  "rf2-ijlhj — bind machine `:after` timer CANCELLATION BATCHES and the
+  cancel→reschedule continuation to ONE captured frame incarnation.
+
+  PR #6049 (rf2-rbxdxa) made single-entry resource RELEASE successor-aware, but
+  the cancellation CLAIM still re-read the slot's current occupant, and the batch
+  loops / reschedule paths recaptured the incarnation per key. Three residual
+  seams let a cancellation land on a same-id successor B:
+
+    1. CAPTURE→READ — a batch snapshots A's entries, but each single-entry cancel
+       re-read `@after-timers[frame-id k]` for its claim token. If A was replaced
+       by same-id B at the same key between snapshot and claim (a JVM thread race,
+       or a callback on a prior cancellation's `:rf.machine.timer/cancelled`
+       trace), the cancel claimed/removed B by B's OWN token.
+
+    2. TWO-KEY CALLBACK REPLACEMENT — cancelling A/k1 fires the callback-bearing
+       `:cancelled` trace; a listener can destroy A, publish same-id B, and re-arm
+       B/k2. The batch then advanced to k2, recaptured B, and cancelled B's host
+       work.
+
+    3. ON-RESOLUTION / SUPERSEDE — `on-sub-changed!` cancels then bare-ID reads +
+       reschedules; a listener that replaced A with B on the `:on-resolution`
+       trace's stack got A-derived timer work installed into B (and B's re-arm
+       superseded).
+
+  The fix cancels every BATCH entry by the SNAPSHOTTED attempt token (never the
+  re-read occupant — B's fresh token fails the atomic claim), binds the batch to
+  ONE incarnation predicate captured at entry (loop short-circuit + release
+  fence), and fences the `on-sub-changed!` reschedule + `schedule-after-timer!`
+  supersede-continuation on the same recheck.
+
+  Deterministic + single-threaded on BOTH runtimes: the successor B is published
+  on the cancellation callback's own stack (CLJS `set-timeout!` cannot fire before
+  the caller yields, so the synchronous-callback shape is the supported CLJS path)
+  or installed directly as the deterministic stand-in for the JVM thread race.
+  Per Spec 005 §Delayed `:after` transitions."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            [re-frame.machines :as machines]
+            [re-frame.machines.paths :as paths]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.machines.timer :as timer]
+            [re-frame.subs :as subs]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+;; Touch the artefact so the machines registration hooks (incl. the
+;; `:machines/on-frame-destroyed!` timer cleanup) are wired even in isolation.
+(def ^:private _artefact machines/machine-transition)
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- fresh-handle
+  "A process-unique opaque host handle, distinguishable by `identical?`."
+  []
+  #?(:clj (Object.) :cljs #js {}))
+
+(def ^:private parent-id :rf2-ijlhj/actor)
+
+(defn- literal-entry
+  "A hand-built literal-delay timer-table entry — the fields `emit-cancelled!` /
+  `release-entry-resources!` read, with nil sub slots (literal delays carry no
+  reaction / watcher)."
+  [token handle]
+  {:handle          handle
+   :reaction        nil
+   :sub-watcher-key nil
+   :resolved-ms     3600000
+   :epoch           0
+   :state           :waiting
+   :region          nil
+   :delay-source    :literal
+   :token           token})
+
+(defn- k-for [delay] {:parent parent-id :spawn [] :delay delay})
+
+(defn- install-entry! [frame-id k entry]
+  (swap! timer/after-timers assoc-in [frame-id k] entry))
+
+(defn- inner [frame-id] (get @timer/after-timers frame-id {}))
+
+;; ===========================================================================
+;; TEST 1 — CAPTURE→READ: the batch cancels by the SNAPSHOTTED attempt token, so
+;; a same-id successor B re-armed at a batch key (BEFORE that key's claim, while
+;; the frame stays live so no incarnation short-circuit fires) survives — its
+;; fresh token fails the atomic claim. The deterministic single-threaded
+;; stand-in for the JVM race "A replaced by B between snapshot and claim".
+;; ===========================================================================
+
+(deftest capture-read-batch-claims-only-the-snapshotted-attempt
+  (rf/make-frame {:id :rf2-ijlhj/cr-frame})
+  (let [frame-id  :rf2-ijlhj/cr-frame
+        k1        (k-for 1000)
+        k2        (k-for 2000)
+        hA1       (fresh-handle)
+        hA2       (fresh-handle)
+        hB2       (fresh-handle)
+        b-entry   (literal-entry ::successor-token hB2)
+        cancelled (atom [])
+        fired?    (atom false)]
+    (install-entry! frame-id k1 (literal-entry ::a1-token hA1))
+    (install-entry! frame-id k2 (literal-entry ::a2-token hA2))
+    (trace-tooling/register-listener!
+      ::cr
+      (fn [ev]
+        (when (and (= :rf.machine.timer/cancelled (:operation ev))
+                   (compare-and-set! fired? false true))
+          ;; The frame stays LIVE (no destroy) — so owner-gone? never flips and
+          ;; the loop does NOT short-circuit; k2 IS visited. B lands at k2 under a
+          ;; FRESH token, exactly as a concurrent re-arm would between the batch
+          ;; snapshot and k2's claim.
+          (install-entry! frame-id k2 b-entry))))
+    (try
+      (with-redefs [interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)]
+        (timer/after-cancel-fx {:frame frame-id}
+                               {:rf/parent-id parent-id :rf/invoke-id []}))
+      (finally (trace-tooling/unregister-listener! ::cr)))
+    (is (true? @fired?) "the first cancellation's trace listener ran (seam exercised)")
+    (is (= b-entry (get-in @timer/after-timers [frame-id k2]))
+        "successor B at k2 SURVIVES — the batch claimed only its snapshotted a2-token, never B's fresh token")
+    (is (identical? hB2 (:handle (get-in @timer/after-timers [frame-id k2])))
+        "B's host handle at k2 is intact")
+    (is (not (some #(identical? hB2 %) @cancelled))
+        "B's handle was NOT cancelled by the A-scoped batch")
+    (is (some #(identical? hA1 %) @cancelled)
+        "A/k1's own handle was cancelled (ordinary live-owner cancellation preserved)")))
+
+;; ===========================================================================
+;; TEST 2 — TWO-KEY CALLBACK REPLACEMENT + real incarnation swap: cancelling A/k1
+;; destroys A and publishes same-id B (re-arming B/k2) on the trace's own stack;
+;; the batch, bound to A's incarnation, short-circuits and never touches B/k2.
+;; ===========================================================================
+
+(deftest two-key-batch-destroy-during-cancel-spares-successor
+  (rf/make-frame {:id :rf2-ijlhj/tk-frame})
+  (let [frame-id  :rf2-ijlhj/tk-frame
+        token-a   (frame/frame-incarnation-token frame-id)
+        k1        (k-for 1000)
+        k2        (k-for 2000)
+        hA1       (fresh-handle)
+        hA2       (fresh-handle)
+        hB2       (fresh-handle)
+        b-entry   (literal-entry ::b2-token hB2)
+        cancelled (atom [])
+        reasons   (atom [])
+        fired?    (atom false)
+        b-token   (atom nil)]
+    (install-entry! frame-id k1 (literal-entry ::a1-token hA1))
+    (install-entry! frame-id k2 (literal-entry ::a2-token hA2))
+    (trace-tooling/register-listener!
+      ::tk
+      (fn [ev]
+        (when (= :rf.machine.timer/cancelled (:operation ev))
+          (swap! reasons conj (:reason (:tags ev)))
+          (when (compare-and-set! fired? false true)
+            ;; Destroy A (its on-frame-destroyed hook releases A's remaining k2),
+            ;; then publish same-id B and re-arm B/k2 on this trace's own stack.
+            (frame/destroy-frame! frame-id)
+            (rf/make-frame {:id frame-id})
+            (reset! b-token (frame/frame-incarnation-token frame-id))
+            (install-entry! frame-id k2 b-entry)))))
+    (try
+      (with-redefs [interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)]
+        (timer/after-cancel-fx {:frame frame-id}
+                               {:rf/parent-id parent-id :rf/invoke-id []}))
+      (finally (trace-tooling/unregister-listener! ::tk)))
+    (is (true? @fired?) "a cancellation fired and destroyed A / published B (seam exercised)")
+    (is (some? @b-token) "same-id successor B is live after the swap")
+    (is (not (identical? token-a @b-token)) "B is a DISTINCT incarnation from A")
+    (is (= b-entry (get-in @timer/after-timers [frame-id k2]))
+        "B's re-armed k2 SURVIVES — the A-bound batch short-circuited and never reached it")
+    (is (not (some #(identical? hB2 %) @cancelled))
+        "B's host handle was NOT cancelled by A's batch")
+    (is (not (some #{:on-exit} (rest @reasons)))
+        "no :on-exit (batch) cancellation landed after the incarnation was lost")))
+
+;; ===========================================================================
+;; TEST 3 — ON-RESOLUTION / SUPERSEDE: a sub-value change fires `on-sub-changed!`;
+;; its `:on-resolution` cancel destroys A + publishes same-id B (re-arming B/k) on
+;; the trace's stack. The reschedule continuation (bare-ID read + supersede +
+;; install) must NOT run against B — B's entry/handle survive and no A-derived
+;; timer is installed / superseded. Real add-watch path; deterministic on both
+;; runtimes.
+;; ===========================================================================
+
+(deftest on-resolution-reschedule-is-fenced-to-the-owning-incarnation
+  (rf/make-frame {:id :rf2-ijlhj/res-frame})
+  (let [frame-id   :rf2-ijlhj/res-frame
+        delay-key  [:rf2-ijlhj/dyn]
+        k          (k-for delay-key)
+        reaction   (atom 5000)
+        hB         (fresh-handle)
+        b-entry    {:handle          hB
+                    :reaction        nil
+                    :sub-watcher-key nil
+                    :resolved-ms     7000
+                    :epoch           0
+                    :state           :waiting
+                    :region          nil
+                    :delay-source    :sub
+                    :token           ::b-token}
+        cancelled  (atom [])
+        reasons    (atom [])
+        unsub      (atom 0)
+        fired?     (atom false)]
+    (trace-tooling/register-listener!
+      ::res
+      (fn [ev]
+        (when (= :rf.machine.timer/cancelled (:operation ev))
+          (swap! reasons conj (:reason (:tags ev)))
+          (when (compare-and-set! fired? false true)
+            ;; The :on-resolution cancel already claimed + removed A's entry;
+            ;; destroy A, publish same-id B, re-arm B/k, and seed B's snapshot so
+            ;; the (unfenced) reschedule's `still-here?` would be TRUE — the
+            ;; mutation tooth that supersedes B if the fence is absent.
+            (frame/destroy-frame! frame-id)
+            (rf/make-frame {:id frame-id})
+            (frame/swap-runtime-db!
+              frame-id
+              (fn [rt] (assoc-in rt (paths/snapshot-path parent-id)
+                                 {:state :waiting :data {}})))
+            (install-entry! frame-id k b-entry)))))
+    (try
+      (with-redefs [subs/subscribe   (fn ([_] reaction) ([_ _] reaction))
+                    subs/unsubscribe (fn ([_] (swap! unsub inc) nil)
+                                       ([_ _] (swap! unsub inc) nil))
+                    interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)
+                    interop/schedule-after!   (fn [_thunk _ms] (fresh-handle))]
+        ;; Arm a real sub-vec `:after` timer — installs A's entry + attaches the
+        ;; `on-sub-changed!` watcher to `reaction`.
+        (timer/after-schedule-fx
+          {:frame frame-id}
+          {:rf/parent-id parent-id :rf/invoke-id [] :state :waiting
+           :delay-key delay-key :epoch 0 :server? false})
+        (is (= 1 (count (inner frame-id))) "precondition: A's sub-vec timer is armed")
+        ;; A sub-value change fires on-sub-changed! via the real add-watch.
+        (reset! reaction 6000))
+      (finally (trace-tooling/unregister-listener! ::res)))
+    (is (true? @fired?) "the :on-resolution cancel fired and swapped A→B (seam exercised)")
+    (is (= b-entry (get-in @timer/after-timers [frame-id k]))
+        "B's re-armed entry SURVIVES — no A-derived reschedule / supersede touched it")
+    (is (identical? hB (:handle (get-in @timer/after-timers [frame-id k])))
+        "B's host handle is intact (not cancelled by a supersede)")
+    (is (not (some #(identical? hB %) @cancelled))
+        "B's handle was NOT cancelled — the reschedule continuation was fenced off")
+    (is (not (some #{:on-supersede} @reasons))
+        "no :on-supersede cancellation fired — the reschedule never ran against B")
+    (is (= [:on-resolution] @reasons)
+        "exactly the single :on-resolution cancel fired; nothing A-derived reached B")))
+
+;; ===========================================================================
+;; TEST 4 — CONTROL: an ordinary live-owner batch (no successor) still cancels
+;; every snapshotted entry fully — the fence is scoped strictly to owner loss.
+;; ===========================================================================
+
+(deftest live-owner-batch-cancels-every-entry
+  (rf/make-frame {:id :rf2-ijlhj/live-frame})
+  (let [frame-id  :rf2-ijlhj/live-frame
+        k1        (k-for 1000)
+        k2        (k-for 2000)
+        hA1       (fresh-handle)
+        hA2       (fresh-handle)
+        cancelled (atom [])
+        reasons   (atom [])]
+    (install-entry! frame-id k1 (literal-entry ::a1-token hA1))
+    (install-entry! frame-id k2 (literal-entry ::a2-token hA2))
+    (trace-tooling/register-listener!
+      ::live
+      (fn [ev] (when (= :rf.machine.timer/cancelled (:operation ev))
+                 (swap! reasons conj (:reason (:tags ev))))))
+    (try
+      (with-redefs [interop/cancel-scheduled! (fn [h] (swap! cancelled conj h) nil)]
+        (timer/after-cancel-fx {:frame frame-id}
+                               {:rf/parent-id parent-id :rf/invoke-id []}))
+      (finally (trace-tooling/unregister-listener! ::live)))
+    (is (empty? (inner frame-id))
+        "both entries cancelled + cleared for the live owner (no fence wrongly skipped)")
+    (is (some #(identical? hA1 %) @cancelled) "k1 handle cancelled")
+    (is (some #(identical? hA2 %) @cancelled) "k2 handle cancelled")
+    (is (= [:on-exit :on-exit] @reasons) "two :on-exit cancellations, one per entry")))


### PR DESCRIPTION
## What

Binds the machine `:after` timer **cancellation batches** and the **cancel→reschedule continuation** to the exact frame incarnation observed by their caller, so a cancel/reschedule can no longer land on a same-id successor `B` after the originating incarnation `A` was destroyed. Fixes `rf2-ijlhj` (P1, discovered from the #6049–#6051 audit `rf2-h8jhr`).

PR #6049 (`rf2-rbxdxa`) made single-entry resource **release** successor-aware, but the cancellation **claim** still re-read the slot's current occupant and the batch loops / reschedule paths recaptured the incarnation per key. Three residual seams let a cancellation touch `B`:

1. **Capture→read.** Batches snapshotted `A`'s entries, but each single-entry cancel re-read `@after-timers[frame-id k]` for its claim token. If `A` was replaced by same-id `B` at that key between snapshot and claim (JVM thread race, or a callback on a prior `:rf.machine.timer/cancelled` trace), the cancel claimed/removed `B` by `B`'s own fresh token. New `cancel-snapshotted-entry!` claims by the **snapshotted** attempt token — `B`'s fresh-token entry fails the atomic `claim-entry!` CAS and survives byte-identical.
2. **Two-key callback replacement.** `after-cancel-fx`, frame-destroy (`cancel-all-timers!` 1-arity) and restore (`cancel-frame-timers-on-restore!`) now capture **one** incarnation predicate at batch entry and short-circuit the loop once ownership is lost — mirroring `cancel-actor-timers!` (which is likewise upgraded to snapshot-token claims).
3. **On-resolution / supersede reschedule.** `on-sub-changed!` captures the owner before its callback-bearing `:on-resolution` cancel and fences the bare-ID runtime read + reschedule; `schedule-after-timer!` rechecks the incarnation after its leading `:on-supersede` cancel and before any delay resolution / slot reservation / host arm — a superseding reschedule installs no `A`-derived work (or subscription ref-count) into `B`.

Reuses the existing exact-incarnation machinery (`successor-published?-fn`, `claim-entry!`'s token CAS). No new timer framework, no new error-id, no `spec/009` row. `machines/lifecycle_fx/join.cljc` (the coupled `rf2-5g6qq` lane) is untouched.

## Quality gates

All run in the worktree, foreground, unpiped.

- **Red-before / green-after** (`machine_timer_incarnation_fence_cljs_test.cljc`): against the pre-fix source the 3 leak tests fail on **11** assertions (B's entry removed, B's handle cancelled, `:on-supersede` reschedule fires); after the fix all pass, control still green.
- **Machines JVM** (`clojure -M:test`): **1169 tests, 4030 assertions, 0 failures, 0 errors** (full suite; includes the 4 new tests).
- **CLJS node** (`npm run test:cljs`): **9800 tests, 48170 assertions, 0 failures, 0 errors** — the new cljc test runs on the CLJS runtime too (renamed `*-cljs-test` so the `cljs-test$` node-test build picks it up; +4 tests / +22 assertions vs. baseline).

Per the brief, `test:browser` and the full spine were not run (CI owns those).

## Regression coverage

`machine_timer_incarnation_fence_cljs_test.cljc` (cljc, JVM + CLJS), deterministic single-threaded (successor `B` published on the cancellation callback's own stack — the supported CLJS path):

- **capture→read** — batch cancels only its snapshotted attempt; a fresh-token `B` re-armed at a batch key while the frame stays live survives.
- **two-key destroy-during-batch** — cancelling `A/k1` destroys `A` + publishes same-id `B` re-arming `B/k2`; the A-bound batch short-circuits, `B/k2` + its handle survive.
- **on-resolution / supersede** — `on-sub-changed!`'s `:on-resolution` cancel destroys `A` + re-arms `B`; the reschedule is fenced off (no `:on-supersede`, `B` intact, no A-derived install).
- **live-owner control** — an ordinary batch with no successor still cancels + clears every entry.
