### PR TITLE
feat(ui): ship the ruled DEV-only bare-view-alias diagnostic (rf2-vxgfnd.95.15)

### DIFF
--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -888,6 +888,32 @@
 (defn ^:export touch-ui-hmr-shell! []
   (react/createElement hmr-shell-elision-probe nil))
 
+;; ---- rf2-vxgfnd.95.15: DEV bare-view-alias diagnostic DCE ------------------
+;;
+;; A bare `(def alias other/view)` var copy does NOT carry the view's
+;; `:rf.ui/view` metadata (def never copies var meta), so the compiler
+;; classifies `[alias …]` as a FOREIGN head even though the runtime value is the
+;; registered view SHELL. The emitter wraps EVERY foreign head in
+;; `(if goog.DEBUG (re-frame.ui.runtime/warn-bare-view-alias! head) head)`; the
+;; DEV guard consults the shell marker `register-view!` stamps and warns once.
+;; Under :advanced + goog.DEBUG=false the wrapper folds to the bare head,
+;; `warn-bare-view-alias!` becomes unreferenced, and its message string, the
+;; `view-shell-mark` marker, and the dedup set all DCE.
+;;
+;; This touch roots a REAL bare-alias foreign head (a defview consuming a plain
+;; `(def …)` copy of another defview) so the control build (DEBUG=true) contains
+;; the `bare var alias of a registered view` message sentinel and the production
+;; build (DEBUG=false) must NOT — giving the elision assertion teeth. The
+;; element is never host-rendered here (createElement roots the compiled render
+;; fn's foreign-head wrapper without a frame), same idiom as touch-ui-hmr-shell!.
+
+(defview bare-view-alias-canonical-probe [{:keys [x]}] [:span x])
+(def bare-view-alias-probe-copy bare-view-alias-canonical-probe)
+(defview bare-view-alias-consumer-probe [] [bare-view-alias-probe-copy {:x "probe"}])
+
+(defn ^:export touch-bare-view-alias! []
+  (react/createElement bare-view-alias-consumer-probe nil))
+
 ;; ---- rf2-fagk6: cross-frame carried-op honesty warning DCE ----------------
 ;;
 ;; A `(frame)` operation bundle captured under frame A can be CARRIED across a
@@ -935,6 +961,7 @@
   (touch-drain-depth!)
   (touch-ui-sub-overrides!)
   (touch-ui-hmr-shell!)
+  (touch-bare-view-alias!)
   (touch-trace!)
   (touch-schemas!)
   (touch-registrar!)

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -641,6 +641,21 @@ const DEV_ONLY_SENTINELS = [
     sentinel: 'hmr-descriptor' },
   { source: 're-frame.ui Fast Refresh slot (stable inner extra Fiber)',
     sentinel: 'hmr-inner' },
+  // re-frame.ui.runtime — the DEV bare-view-alias diagnostic (rf2-vxgfnd.95.15,
+  // EP-0035 / rf2-ho1iba). A bare `(def alias other/view)` var copy used as a
+  // component head resolves at runtime to the registered view shell;
+  // `warn-bare-view-alias!` consults the DEV shell marker and warns once. The
+  // emitter wraps EVERY foreign head in
+  // `(if goog.DEBUG (re-frame.ui.runtime/warn-bare-view-alias! head) head)`, so
+  // under :advanced + goog.DEBUG=false the wrapper folds to the bare head,
+  // `warn-bare-view-alias!` is unreferenced, and its message string, the
+  // `view-shell-mark` marker, and the dedup set all DCE. The elision-probe's
+  // `touch-bare-view-alias!` roots a real bare-alias foreign head so the control
+  // build (DEBUG=true) contains this message fragment and the production build
+  // (DEBUG=false) must not. (Compile-tier `:rf.ui.compile/*` diagnostic — no
+  // Spec 009 catalogue row, delivered by console.warn not error/throw-error!.)
+  { source: 're-frame.ui.runtime/warn-bare-view-alias! (bare-view-alias diagnostic)',
+    sentinel: 'bare var alias of a registered view' },
   // re-frame.ui.frames — :rf.warning/cross-frame-carried-op DEV-ONLY honesty
   // warning (rf2-vxgfnd.231 shipped the warning in #5960; rf2-fagk6 pins its
   // production elision). A CARRIED `(frame)` operation bundle's `:subscribe`

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -451,9 +451,22 @@
         ;; is not undeclared. Unrelated foreign/view heads keep their spelling.
         self-fqn (:self-fqn @st)
         self?    (and (some? self-fqn) (= (:fqn node) self-fqn))
-        head-sym (if self? (:fqn node) (:sym node))]
+        head-sym (if self? (:fqn node) (:sym node))
+        ;; DEV bare-view-alias diagnostic (rf2-vxgfnd.95.15): a foreign-
+        ;; classified head whose runtime VALUE is a registered view shell is a
+        ;; bare `(def alias other/view)` var copy — the compiler saw a foreign
+        ;; React component and dropped the view's closed-props/children checks +
+        ;; manifest identity. `warn-bare-view-alias!` consults the DEV shell
+        ;; marker and warns once (deduped) at render. goog.DEBUG-gated so
+        ;; `:advanced` folds straight to the bare head — no residue, no cost.
+        ;; View heads resolve the stamped var (classified :view) and stay quiet.
+        head-form (if (= :foreign (:op node))
+                    `(if ~(with-meta 'js/goog.DEBUG {:tag 'boolean})
+                       (re-frame.ui.runtime/warn-bare-view-alias! ~head-sym)
+                       ~head-sym)
+                    head-sym)]
     (when self? (swap! st assoc :self-ref? true))
-    (jsx-runtime-call multi? head-sym props-form key-info)))
+    (jsx-runtime-call multi? head-form props-form key-info)))
 
 (defn- row-key-expr [body]
   (or (get-in body [:props :key :expr]) (get-in body [:key :expr])))

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -36,6 +36,64 @@
 (def Fragment jsxrt/Fragment)
 
 ;; ---------------------------------------------------------------------------
+;; DEV bare-view-alias diagnostic (rf2-vxgfnd.95.15, EP-0035 / rf2-ho1iba)
+;;
+;; `(def alias other/view)` copies the shell VALUE but not the var's
+;; `:rf.ui/view` metadata (def never copies var meta), so the compiler
+;; classifies the aliased head as a FOREIGN React component and silently drops
+;; the view's closed-props / children compile-time checks and its manifest view
+;; identity (Spec 004 Q5, env docstring §var-copies). The runtime VALUE at that
+;; head is still the registered view SHELL, which `register-view!` stamps with
+;; `view-shell-mark`; a foreign head consults the marker (DEV only, emitter-
+;; gated) and warns ONCE per aliased view.
+;;
+;; This is a `:rf.ui.compile/*` COMPILE-TIER diagnostic (no Spec 009 catalogue
+;; row; delivered by console.warn, never `error/throw-error!`). Every arm below
+;; is referenced only from goog.DEBUG-gated emitted code (the emitter's foreign
+;; head) or the DEV-only `register-view!`, so `:advanced` + goog.DEBUG=false
+;; elides the marker set, the dedup set, and this warning entirely — no
+;; production cost.
+;; ---------------------------------------------------------------------------
+
+(def ^:private view-shell-mark "rf$view_shell")
+
+;; Process-lifetime one-shot dedup keyed by view id (see
+;; `clear-bare-view-alias-warned!`, used by the diagnostic's test fixtures).
+(def ^:private bare-view-alias-warned (js/Set.))
+
+(defn clear-bare-view-alias-warned!
+  "Reset the one-shot bare-view-alias diagnostic cache so a test fixture starts
+  from a clean slate. DEV/test only."
+  []
+  (.clear bare-view-alias-warned))
+
+(defn warn-bare-view-alias!
+  "DEV diagnostic (`:rf.ui.compile/bare-view-alias`) for a foreign-classified
+  component head whose runtime VALUE is a registered re-frame.ui view shell —
+  i.e. a bare `(def alias other/view)` var copy, which drops the view's
+  closed-props / children compile-time checks and its manifest view identity.
+  Warns ONCE per aliased view (deduplicated by view id) and returns `head`
+  unchanged; genuine foreign components, plain function props, and canonical /
+  namespace-aliased view heads (which resolve the stamped var and never reach
+  here) stay quiet. Referenced only from the emitter's goog.DEBUG-gated foreign
+  head, so `:advanced` + goog.DEBUG=false elides it."
+  [head]
+  (when (some? head)
+    (when-some [id (unchecked-get head view-shell-mark)]
+      (when-not (.has bare-view-alias-warned id)
+        (.add bare-view-alias-warned id)
+        (js/console.warn
+         (str "[re-frame.ui] the component head " (pr-str id) " is a bare var "
+              "alias of a registered view. `(def alias other/view)` copies the "
+              "value but NOT the view metadata, so the compiler treated it as a "
+              "foreign React component and dropped this view's closed-props and "
+              "children compile-time checks and its manifest view identity. "
+              "Refer to the view by its canonical name, or alias the NAMESPACE "
+              "(:require [... :as x] / :refer) so the head resolves the stamped "
+              "view var. [:rf.ui.compile/bare-view-alias]")))))
+  head)
+
+;; ---------------------------------------------------------------------------
 ;; Memo + registration
 ;; ---------------------------------------------------------------------------
 
@@ -112,6 +170,11 @@
     (set! (.-displayName render-fn) display-name)
     (set! (.-displayName inner) (str display-name "$Body"))
     (set! (.-displayName outer) display-name)
+    ;; Stamp the DEV shell so a foreign-classified head whose runtime value is
+    ;; this shell (a bare `(def alias other/view)` var copy) is caught by
+    ;; `warn-bare-view-alias!`. register-view! is DEV-only (the emitter's
+    ;; production arm is direct React.memo), so the marker DCEs in production.
+    (unchecked-set outer view-shell-mark id)
     (let [publication
           (reactive/prepare-view-descriptor!
            id (:hook-signature manifest) descriptor)]

--- a/implementation/ui/test/re_frame/ui/emit_cljs_lowering_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/emit_cljs_lowering_cljs_test.cljc
@@ -10,6 +10,8 @@
   (case sym
     child-view {:fqn 'app.views/child-view
                 :meta {:rf.ui/view true :rf.ui/children? true}}
+    ;; a NAMESPACE alias resolving a stamped view var (`:require [app.views :as v]`)
+    v/card     {:fqn 'app.views/card :meta {:rf.ui/view true}}
     ForeignComp {:fqn 'app.interop/ForeignComp :meta {}}
     raw-fn {:fqn 're-frame.ui/raw-fn :meta {}}
     event  {:fqn 're-frame.ui/event :meta {}}
@@ -231,3 +233,41 @@
                '("__proto__" value))
              (drop 2 props-form))
           (str (name surface) " retains the authored own property and value")))))
+
+;; ---------------------------------------------------------------------------
+;; DEV bare-view-alias diagnostic (rf2-vxgfnd.95.15) — the emit-side wiring.
+;; The COMPILE stage cannot tell a bare `(def alias other/view)` copy from a
+;; genuine foreign React component (both resolve without `:rf.ui/view` meta), so
+;; EVERY foreign head carries the DEV-gated runtime guard; the runtime shell-
+;; marker check does the discrimination. View heads (canonical + namespace
+;; alias) resolve the stamped var, classify :view, and stay quiet — zero cost.
+;; ---------------------------------------------------------------------------
+
+(defn- bare-alias-guard [form]
+  (first (filter #(and (seq? %)
+                       (= 'if (first %))
+                       (some #{'re-frame.ui.runtime/warn-bare-view-alias!}
+                             (forms-of %)))
+                 (forms-of form))))
+
+(deftest foreign-head-carries-the-dev-gated-bare-view-alias-guard
+  (let [form  (emitted '[ForeignComp {:x 1}])
+        guard (bare-alias-guard form)]
+    (is (some? guard)
+        "a foreign-classified head is consulted at runtime for a bare view-alias")
+    (is (= 'js/goog.DEBUG (second guard))
+        "the guard is goog.DEBUG-gated so :advanced elides it in production")
+    (is (= '(re-frame.ui.runtime/warn-bare-view-alias! ForeignComp) (nth guard 2))
+        "the dev arm consults the shell marker, passing the authored head")
+    (is (= 'ForeignComp (nth guard 3))
+        "the production arm is the bare head verbatim — no residue")))
+
+(deftest canonical-and-namespace-alias-view-heads-stay-quiet
+  (testing "a canonical defview head emits no guard (compile-time quiet)"
+    (is (nil? (bare-alias-guard (emitted '[child-view {:label label}])))))
+  (testing "a namespace-aliased view head resolves the stamped var and stays quiet"
+    (is (nil? (bare-alias-guard (emitted '[v/card {:x 1}])))))
+  (testing "no view head ever routes through the runtime bare-view-alias guard"
+    (is (not-any? #{'re-frame.ui.runtime/warn-bare-view-alias!}
+                  (forms-of (emitted '[:div [child-view {:label l}]
+                                       [v/card {:x 1}]]))))))

--- a/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
@@ -174,6 +174,18 @@
 (defview proto-view [{:keys [v]}] [proto-child {:__proto__ v}])
 (defview proto-foreign [{:keys [v]}] [plain-fc {:__proto__ v}])
 
+;; DEV bare-view-alias diagnostic fixtures (rf2-vxgfnd.95.15). `alias-source-view`
+;; is a real registered view; `bare-view-alias-copy` is a plain `(def …)` var
+;; copy of it — def does NOT carry `:rf.ui/view` metadata, so the compiler
+;; classifies `[bare-view-alias-copy …]` as a FOREIGN head, whose runtime value
+;; is nonetheless the registered shell. `uses-canonical-alias` references the
+;; view by its canonical name (a :view head — quiet), and `uses-foreign` above
+;; is a genuine foreign component (also quiet).
+(defview alias-source-view [{:keys [x]}] [:span x])
+(def bare-view-alias-copy alias-source-view)
+(defview uses-bare-alias      [] [bare-view-alias-copy {:x "aliased"}])
+(defview uses-canonical-alias [] [alias-source-view {:x "canonical"}])
+
 ;; ---------------------------------------------------------------------------
 ;; Renders
 ;; ---------------------------------------------------------------------------
@@ -316,6 +328,49 @@
 (deftest foreign-component-renders
   (is (= "<div><b>L</b></div>"
          (render (rt/jsx2 uses-foreign (js-obj "l" "L"))))))
+
+;; ---------------------------------------------------------------------------
+;; DEV bare-view-alias diagnostic (rf2-vxgfnd.95.15) — runtime behaviour.
+;; A bare `(def alias other/view)` var copy used as a component head resolves at
+;; runtime to the registered view shell; the DEV foreign-head guard warns once
+;; (deduped by view id), naming the lost checks + the canonical/namespace-alias
+;; recovery. Canonical view heads and genuine foreign components stay quiet.
+;; ---------------------------------------------------------------------------
+
+(defn- alias-warnings [warnings]
+  (filter (fn [call]
+            (some #(str/includes? % "bare var alias of a registered view") call))
+          warnings))
+
+(deftest bare-view-alias-head-warns-once-and-dedupes
+  (rt/clear-bare-view-alias-warned!)
+  (let [{:keys [warnings]}
+        (with-captured-console-warn
+         (fn []
+           ;; renders through the aliased shell — still valid markup
+           (is (= "<span>aliased</span>" (render (rt/jsx2 uses-bare-alias (js-obj)))))
+           ;; a SECOND render must not re-warn (process-lifetime dedup by view id)
+           (render (rt/jsx2 uses-bare-alias (js-obj)))))
+        warns (alias-warnings warnings)]
+    (is (= 1 (count warns))
+        "a bare-alias foreign head warns exactly once, deduped across renders")
+    (let [msg (str/join " " (first warns))]
+      (is (str/includes? msg ":rf.ui.compile/bare-view-alias")
+          "the warning carries the compile-tier diagnostic id (no Spec 009 row)")
+      (is (str/includes? msg "alias-source-view")
+          "the warning names the aliased view")
+      (is (str/includes? msg "canonical")
+          "the warning names the canonical-name / namespace-alias recovery"))))
+
+(deftest canonical-and-genuine-foreign-heads-never-warn
+  (rt/clear-bare-view-alias-warned!)
+  (let [{:keys [warnings]}
+        (with-captured-console-warn
+         (fn []
+           (render (rt/jsx2 uses-canonical-alias (js-obj)))   ; canonical :view head
+           (render (rt/jsx2 uses-foreign (js-obj "l" "L")))))] ; genuine foreign (plain fn)
+    (is (empty? (alias-warnings warnings))
+        "a canonical view head and a genuine foreign component both stay quiet")))
 
 (defn- has-own? [o k]
   (.call (.-hasOwnProperty (.-prototype js/Object)) o k))


### PR DESCRIPTION
## What

Ships the EP-0035 / `rf2-ho1iba`-ruled **DEV-only bare-view-alias diagnostic**. When a head the compiler classified as **foreign** resolves at runtime to a registered `re-frame.ui` view shell — i.e. a bare `(def alias other/view)` var copy — it warns once that the copy silently lost the view's closed-props/children compile-time checks and its manifest view identity.

`def` never copies var metadata, so `alias`'s var carries no `:rf.ui/view`; the compiler (Spec 004 Q5, `env` §var-copies) classifies `[alias ...]` as a foreign React component. The runtime value is nonetheless the registered shell — the exact condition this diagnostic detects.

This ships **only the warning**. The trigger-gated alias *feature* (`rf2-ho1iba`) stays intentionally unapproved.

## How (minimal — one cheap shell-marker check + a deduped DEV warning)

- **`runtime.cljs`** — `register-view!` (DEV-only; the emitter's production arm is direct `React.memo`) stamps the returned view shell with a `view-shell-mark`. New `warn-bare-view-alias!` guard consults the marker, warns once (deduped by view id via a `js/Set`), and returns the head unchanged (React identity preserved).
- **`emit_cljs.cljc`** — `emit-component` wraps **every** foreign head in `(if goog.DEBUG (warn-bare-view-alias! head) head)`. The compile stage can't distinguish a bare alias from a genuine foreign component (both resolve without `:rf.ui/view`), so the runtime shell-marker does the discrimination. View heads (canonical **and** namespace-aliased) classify `:view` and never emit the guard — zero cost, no false warnings.

## Compile-tier id, no Spec 009 row

`:rf.ui.compile/bare-view-alias` is a compile-tier diagnostic delivered by `console.warn`, **not** a catalogued runtime error via `error/throw-error!` — so it gets no Spec 009 catalogue row (per the in-flight `.95.13` ruling). No `spec/004-Views.md` touched. It is not a thrown compile error nor an `env/warn!` warning, so it is not part of the frozen error/warning roster.

## Anti-over-engineering

No `defview-alias`, compiler naming graph, wrapper views, or runtime head-guessing beyond the registered-shell check.

## Quality gates

All run in the worktree, foreground:

| Gate | Result |
| --- | --- |
| `implementation/ui` JVM (`clojure -M:test`) | **740 tests, 13792 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` | **9817 tests, 48253 assertions, 0 failures, 0 errors** |
| `npm run test:elision` | **PASS** — production **60/60 absent**, control **60/60 present** (new sentinel), EP-0023 provenance-survives + assembly-DCE intact |

Fixtures added:
- **Compile golden** (`emit_cljs_lowering_cljs_test.cljc`): a foreign head carries the `goog.DEBUG`-gated guard whose production arm is the bare head; canonical + namespace-alias view heads stay quiet. (Removing the emit-side wrapper fails this — the focused causal fixture.)
- **Runtime behaviour** (`react_render_cljs_test.cljs`): a bare-alias head warns exactly once (deduped across renders), naming the id + `canonical` recovery; canonical view head and genuine foreign component stay quiet.
- **Production elision** (`elision_probe.cljs` `touch-bare-view-alias!` + `check-elision.cjs` sentinel): the warning string, marker, and dedup set are absent from the `:advanced` + `goog.DEBUG=false` bundle and present in the control build.

Closes rf2-vxgfnd.95.15.
