### PR TITLE
fix(test-support): make sequester-app-registration! a true no-op on absent provenance row (rf2-22vzb)

### DIFF
--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -180,11 +180,41 @@
   captured after the second app loads then fails default-image assembly
   loud (`:rf.error/image-duplicate-id`) on every `make-frame`. Each
   consuming test ns calls this at NS LOAD (right after requiring its app
-  ns) so no other suite's baseline ever sees more than one row."
+  ns) so no other suite's baseline ever sees more than one row.
+
+  PROVENANCE-SAFE + TRUE NO-OP (rf2-22vzb). Two guards keep a co-loaded
+  suite's removal from ever touching a SIBLING namespace's live
+  registration:
+
+    - ABSENT ROW => TRUE NO-OP. When `[kind id provenance-ns]` has no
+      source-store row, neither the live registrar nor the source store is
+      touched and nil is returned. A requested namespace that never
+      registered `(kind, id)` therefore cannot clobber whichever namespace
+      DID (the reported bug: sequestering `missing.app`'s absent row was
+      wiping `app.b`'s live `(kind, id)` and leaving its source row behind).
+    - REGISTRAR LEG IS OWNERSHIP-GUARDED. The registrar's single
+      `(kind, id)` slot is the LAST writer's — for an id BOTH apps register
+      that may be a SIBLING's. Remove it ONLY when its current writer IS
+      `provenance-ns`; otherwise leave it standing so the sibling's live
+      registration survives (mirrors the registrar guard in
+      [[sequester-app-namespaces!]]). This suite's own source row is
+      forgotten either way — sibling source rows survive — so registrar and
+      source-store authority stay coherent."
   [kind id provenance-ns]
-  (let [row (get-in @source-store/kind->id->ns->descriptor
-                    [kind id provenance-ns])]
-    (swap! registrar/kind->id->metadata update kind dissoc id)
+  (when-let [row (get-in @source-store/kind->id->ns->descriptor
+                         [kind id provenance-ns])]
+    ;; Registrar leg — remove the shared (kind, id) resolver slot ONLY when
+    ;; this provenance-ns is its CURRENT writer, so an id both apps register
+    ;; does not have a sibling's live registration clobbered.
+    (swap! registrar/kind->id->metadata update kind
+           (fn [m]
+             (let [cur    (get m id)
+                   cur-ns (or (get cur source-store/provenance-ns-key)
+                              (some-> (:ns cur) str))]
+               (if (and cur (= cur-ns (str provenance-ns)))
+                 (dissoc m id)
+                 m))))
+    ;; Source leg — forget THIS provenance-ns's own row; sibling rows survive.
     (source-store/forget-descriptor! kind id provenance-ns)
     row))
 

--- a/implementation/core/test/re_frame/sequester_app_registration_cljs_test.cljc
+++ b/implementation/core/test/re_frame/sequester_app_registration_cljs_test.cljc
@@ -1,0 +1,168 @@
+(ns re-frame.sequester-app-registration-cljs-test
+  "Provenance safety + true-no-op contract for
+  `re-frame.test-support/sequester-app-registration!` (rf2-22vzb).
+
+  BUNDLE CO-LOAD HYGIENE (rf2-h1vqa4) sequesters one app's `(kind, id)`
+  registration from the live registrar AND the provenance source store so a
+  co-loaded example app cannot fail another suite's default-image assembly.
+  Auditing the documented no-op contract (PR #6056) exposed the singular helper
+  removing `(kind, id)` from the live registrar UNCONDITIONALLY — even when the
+  requested `[kind id provenance-ns]` source row was absent, or when the live
+  registrar slot belonged to a SIBLING provenance namespace. Either way it
+  returned nil yet clobbered another namespace's live registration and left a
+  registrar/source-store divergence behind.
+
+  These rows pin the repaired contract, cross-platform (JVM + CLJS), against a
+  snapshot/restore of both stores so the shared `:node-test` bundle is
+  undisturbed:
+
+    - correct `:route` capture / removal / reinstatement,
+    - a mismatched kind is a true no-op,
+    - an absent provenance row is a true no-op (the reported bug),
+    - a same-id sibling provenance row cannot clobber the sibling's live
+      registrar slot.
+
+  See [Spec 008 §Built-in test-runner namespace] and the
+  `sequester-app-registration!` docstring."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.registrar :as registrar]
+            [re-frame.source-store :as source-store]
+            [re-frame.test-support :as test-support]))
+
+;; ---- isolation: snapshot/restore BOTH stores ------------------------------
+;;
+;; The helper mutates the process-default registrar + source store directly, so
+;; the fixture snapshots both atoms and restores them in a `finally`. That scopes
+;; every registration these rows make to the case, leaving the shared node-test
+;; bundle's ns-load registrations (sibling suites' reg-view'd components, routing
+;; standards, …) exactly as they were.
+
+(use-fixtures :each
+  (fn [test-fn]
+    (let [reg-snap @registrar/kind->id->metadata
+          src-snap @source-store/kind->id->ns->descriptor]
+      (try
+        (test-fn)
+        (finally
+          (reset! registrar/kind->id->metadata reg-snap)
+          (reset! source-store/kind->id->ns->descriptor src-snap))))))
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- reg-slot
+  "The live registrar metadata for (kind, id), or nil."
+  [kind id]
+  (get-in @registrar/kind->id->metadata [kind id]))
+
+(defn- src-row
+  "The source-store descriptor for the exact (kind, id, provenance-ns) slot,
+  or nil."
+  [kind id provenance-ns]
+  (get-in @source-store/kind->id->ns->descriptor [kind id provenance-ns]))
+
+(defn- reg!
+  "Register (kind, id) authored in `provenance-ns` through the real
+  `registrar/register!` path — registrar resolver map + provenance source store
+  in lockstep, exactly as a `reg-*` macro would in dev. `provenance-ns` is a
+  string; it is stamped into the descriptor's macro-captured `:ns` symbol so the
+  source store keys the row under it. Returns the stored source descriptor."
+  [kind id provenance-ns]
+  (registrar/register! kind id
+                       {:ns         (symbol provenance-ns)
+                        :handler-fn (fn [& _] [kind id provenance-ns])})
+  (src-row kind id provenance-ns))
+
+;; ---- 1. correct :route capture / removal / reinstatement ------------------
+
+(deftest matching-route-row-captured-removed-and-reinstated
+  (testing "a present matching (kind, id, provenance-ns) :route row is captured,
+            removed from BOTH stores, returned, and reinstated exactly once by
+            reinstate-app-registration! (rf2-22vzb acceptance 3)"
+    (reg! :route :rf2-22vzb/not-found-route "rf2-22vzb.app-a")
+    (let [captured (test-support/sequester-app-registration!
+                     :route :rf2-22vzb/not-found-route "rf2-22vzb.app-a")]
+      (is (some? captured)
+          "the captured source descriptor is returned")
+      (is (= "rf2-22vzb.app-a" (get captured source-store/provenance-ns-key))
+          "the captured row carries app-a's provenance")
+      (is (nil? (reg-slot :route :rf2-22vzb/not-found-route))
+          "removed from the live registrar")
+      (is (nil? (src-row :route :rf2-22vzb/not-found-route "rf2-22vzb.app-a"))
+          "removed from the source store")
+      ;; Reinstate — registrar + source store back in lockstep.
+      (test-support/reinstate-app-registration! captured)
+      (is (some? (reg-slot :route :rf2-22vzb/not-found-route))
+          "reinstated into the live registrar")
+      (is (= captured (src-row :route :rf2-22vzb/not-found-route "rf2-22vzb.app-a"))
+          "reinstated into the source store, byte-for-byte the captured row"))))
+
+;; ---- 2. mismatched kind is a true no-op -----------------------------------
+
+(deftest mismatched-kind-is-true-no-op
+  (testing "sequestering under a KIND the id was never registered under returns
+            nil and leaves the real (kind, id) registration untouched — no slot
+            is fabricated or clobbered (rf2-22vzb acceptance 4)"
+    (reg! :route :rf2-22vzb/mismatch-probe "rf2-22vzb.app-a")
+    (let [reg-before (reg-slot :route :rf2-22vzb/mismatch-probe)
+          src-before (src-row :route :rf2-22vzb/mismatch-probe "rf2-22vzb.app-a")
+          returned   (test-support/sequester-app-registration!
+                       :sub :rf2-22vzb/mismatch-probe "rf2-22vzb.app-a")]
+      (is (nil? returned)
+          "no :sub source row for the id → returns nil")
+      (is (= reg-before (reg-slot :route :rf2-22vzb/mismatch-probe))
+          "the real :route registrar slot is untouched")
+      (is (= src-before (src-row :route :rf2-22vzb/mismatch-probe "rf2-22vzb.app-a"))
+          "the real :route source row is untouched")
+      (is (nil? (reg-slot :sub :rf2-22vzb/mismatch-probe))
+          "no :sub slot was fabricated"))))
+
+;; ---- 3. absent provenance row is a true no-op (the reported bug) ----------
+
+(deftest absent-provenance-row-is-true-no-op
+  (testing "sequestering a (kind, id) under a provenance-ns that never registered
+            it changes NEITHER store and returns nil — the reported clobber where
+            `missing.app` wiped `app.b`'s live registration while leaving its
+            source row behind (rf2-22vzb acceptance 1)"
+    (reg! :route :rf2-22vzb/audit-same "rf2-22vzb.app-b")
+    (let [reg-before (reg-slot :route :rf2-22vzb/audit-same)
+          src-before (src-row :route :rf2-22vzb/audit-same "rf2-22vzb.app-b")
+          returned   (test-support/sequester-app-registration!
+                       :route :rf2-22vzb/audit-same "rf2-22vzb.missing-app")]
+      (is (nil? returned)
+          "absent provenance row → returns nil")
+      (is (some? reg-before)
+          "precondition: app-b's registration is live before the no-op call")
+      (is (= reg-before (reg-slot :route :rf2-22vzb/audit-same))
+          "the live registrar still holds app-b's registration — NOT clobbered")
+      (is (= src-before (src-row :route :rf2-22vzb/audit-same "rf2-22vzb.app-b"))
+          "app-b's source-store row survives — no registrar/source divergence"))))
+
+;; ---- 4. same-id sibling provenance cannot clobber the sibling -------------
+
+(deftest sibling-provenance-registration-not-clobbered
+  (testing "when two namespaces register the SAME (kind, id), sequestering one
+            provenance-ns forgets ONLY its own source row and never removes the
+            live registrar slot owned by the SIBLING — registrar and source-store
+            authority remain coherent (rf2-22vzb acceptance 2)"
+    ;; app-a registers first, app-b second → the registrar's single
+    ;; (kind, id) resolver slot is app-b's (last writer); the source store keeps
+    ;; BOTH provenance rows.
+    (reg! :route :rf2-22vzb/shared-id "rf2-22vzb.app-a")
+    (reg! :route :rf2-22vzb/shared-id "rf2-22vzb.app-b")
+    (is (some? (src-row :route :rf2-22vzb/shared-id "rf2-22vzb.app-a"))
+        "precondition: app-a's source row present")
+    (is (some? (src-row :route :rf2-22vzb/shared-id "rf2-22vzb.app-b"))
+        "precondition: app-b's source row present (sibling)")
+    (let [captured (test-support/sequester-app-registration!
+                     :route :rf2-22vzb/shared-id "rf2-22vzb.app-a")]
+      (is (some? captured)
+          "app-a's own present row is captured + returned")
+      (is (= "rf2-22vzb.app-a" (get captured source-store/provenance-ns-key))
+          "the captured row is app-a's, not the sibling's")
+      (is (some? (reg-slot :route :rf2-22vzb/shared-id))
+          "app-b's live registrar slot is NOT clobbered by app-a's sequester")
+      (is (nil? (src-row :route :rf2-22vzb/shared-id "rf2-22vzb.app-a"))
+          "app-a's own source row is forgotten")
+      (is (some? (src-row :route :rf2-22vzb/shared-id "rf2-22vzb.app-b"))
+          "app-b's source row survives — registrar/source authority coherent"))))


### PR DESCRIPTION
## What

`re-frame.test-support/sequester-app-registration!` (BUNDLE CO-LOAD HYGIENE, rf2-h1vqa4) looked up `[kind id provenance-ns]` in the provenance source store but then removed `(kind, id)` from the live registrar **and** the source store *unconditionally*:

```clojure
(let [row (get-in @source-store/kind->id->ns->descriptor [kind id provenance-ns])]
  (swap! registrar/kind->id->metadata update kind dissoc id)   ; <- always ran
  (source-store/forget-descriptor! kind id provenance-ns)
  row)
```

Two failure modes fell out of that:

- **Absent row → not a no-op.** Registering `:audit/same` for `"app.b"` then sequestering the same kind/id for `"missing.app"` returned `nil` yet still wiped `app.b`'s live `(kind, id)` registration and left its source-store row behind (`{:returned nil, :registrar-after nil, :source-after <app.b descriptor>}`).
- **Sibling clobber.** When two namespaces register the same `(kind, id)`, the registrar's single resolver slot is the *last* writer's. Sequestering one provenance's (present) row still removed that shared slot even when a **sibling** owned it, leaving a registrar/source-store divergence a co-loaded suite could observe as a missing handler.

## Fix

Guard the removal at the seam, mirroring the sibling-safe discipline already in `sequester-app-namespaces!`:

- **Absent `[kind id provenance-ns]` source row ⇒ true no-op** — touch neither store, return `nil` (`when-let` on the lookup).
- **Registrar leg is ownership-guarded** — remove the shared `(kind, id)` slot only when *this* `provenance-ns` is its current writer; otherwise leave it standing so the sibling's live registration survives. This provenance-ns's own source row is forgotten either way (sibling source rows survive), so registrar and source-store authority stay coherent.

No registrar/sequester machinery redesign — a guard at the specific seam. The tools/xray registry is a different registration system and is untouched.

## Tests

New cross-platform (JVM + CLJS) `sequester_app_registration_cljs_test.cljc` with the four focused rows the bead calls for: correct `:route` capture/removal/reinstatement, mismatched kind, absent provenance, and same-id sibling provenance. Each runs against a snapshot/restore of both stores so the shared node-test bundle is undisturbed.

Red-before / green-after (running the new ns against the pre-fix helper): the `absent-provenance-row-is-true-no-op` and `sibling-provenance-registration-not-clobbered` rows fail on the old code (`reg-slot` clobbered to `nil`, matching the reported `{:registrar-after nil}` symptom) and pass after the guard; the capture/removal and mismatched-kind rows pass throughout.

## Quality gates

- `implementation/core` JVM (`clojure -M:test`): **2041 tests, 9535 assertions, 0 failures, 0 errors**.
- `npm run test:cljs` (node-runtime CLJS, includes the new ns + every example suite that calls `sequester-app-registration!`/`reinstate-app-registration!` at ns-load): **9824 tests, 48314 assertions, 0 failures, 0 errors**.
- Red-before/green-after demonstrated on the new namespace (2 bug-manifestation assertions fail on the pre-fix helper, all pass after).

Not run (per scope): `test:browser`, full spine. Ignore any pre-existing docs-gate red (unrelated NAMING.md link, fixed separately).

Closes rf2-22vzb.
