### PR TITLE
fix(xray): retryable fresh-install + changed-handler schema-delta in registry (rf2-g2jf3, rf2-sa8j3)

### DIFF
--- a/tools/xray/spec/014-Registry-Catalogue.md
+++ b/tools/xray/spec/014-Registry-Catalogue.md
@@ -125,20 +125,57 @@ The fix is a SECOND axis alongside the boolean gate — a
   (e.g. the evidence ownership listener).
 
 Bump `schema-version` and pair it with a `migrate-schema!` clause
-whenever a change adds a handler an already-registered older process
-would otherwise never install. Version `1` is the ViewCell evidence
-reactivity bridge; version `2` (rf2-vxgfnd.95.7) adds the S3 view-evidence
-consumption subs `:rf.xray/viewcell-evidence-version` +
+whenever a gated registration change would otherwise strand an
+already-registered older process behind a page reload — an ADD (a handler
+newer code registers that the old install never ran) **or** a REPLACE (a
+gated registration whose body/topology newer code changes; the umbrella
+no-ops it because the id is unchanged, and the name-set snapshots don't see
+it because the id is unchanged — rf2-sa8j3). A migration clause is idempotent
+because re-frame's registrar replaces each handler in place, and replacing a
+sub also **evicts its stale cache** via the registrar replacement-hook, so a
+held subscription rebuilds against the new body without a reload. Version `1`
+is the ViewCell evidence reactivity bridge; version `2` (rf2-vxgfnd.95.7) adds
+the S3 view-evidence consumption subs `:rf.xray/viewcell-evidence-version` +
 `:rf.xray/view-evidence-sites` to that same bridge (see
 [spec/021 §3.4.1–§3.4.2](./021-Dynamic-Panel-Designs.md)), both installed via
 `reactive-panel/install-viewcell-evidence-bridge!` so the bridge stays
-panel-owned; `migrate-schema!` reaches it through the `reactive-panel` facade
-the orchestrator already requires (the idempotent re-install adds only the
-missing delta of subs). Tests drive
-the upgrade via `registry/simulate-legacy-registration!` (test-only:
-poses the umbrella-set / no-schema-stamp sentinels of a pre-#5915
-process); `reset-for-test!` clears both the boolean gate and the schema
-stamp.
+panel-owned; version `3` (rf2-sa8j3) is the first REPLACEMENT delta — the
+`:rf.xray/reactive-data` sub grew from two inputs to four (the panel-local
+`:rf.xray/reactive-show-unchanged?` quick-toggle + the Settings
+show-unchanged pin), so the clause re-runs the owning `reactive-panel`
+facade's `install!` to re-register it (evicting the stale two-input
+reaction). `migrate-schema!` reaches each delta through the `reactive-panel`
+facade the orchestrator already requires (the idempotent re-install applies
+only the missing/changed delta).
+
+Tests drive the upgrade via `registry/simulate-legacy-registration!`
+(test-only: poses the umbrella-set / no-schema-stamp sentinels of a pre-#5915
+process, i.e. schema 0) or `registry/simulate-registration-at-schema!`
+(test-only: poses an INTERMEDIATE installed schema so a fixture can isolate
+the newest migration clause); `reset-for-test!` clears both the boolean gate
+and the schema stamp. `schema-version` is a **public read-only** contract
+number: the governance pin
+`schema-version-is-pinned-so-changed-registrations-name-a-migration` in
+`registry_cljs_test.cljs` reads it and the shipped reactive-data topology, so
+any gated registration edit — add or replace — must consciously bump
+`schema-version` (or record an explicit no-migration rationale) and update
+the pin.
+
+#### Fresh-install atomicity (rf2-g2jf3)
+
+The umbrella flips to `true` BEFORE the bulk leaf install and stamps
+`installed-schema` only AFTER the last installer. So the bulk block is
+wrapped: if any registrar / leaf installer throws mid-install, the guard
+rolls the umbrella back to `false` and rethrows, leaving the fresh install
+**retryable** (the next `register-xray-handlers!` replays every installer;
+partial registrar writes are replaced in place) and `installed-schema`
+**unstamped** — the migration seam can never mistake a failed fresh install
+for a live-upgrade delta and stamp the registry "current" over a partial
+install. `registered?`/`installed-schema` are published current only after
+every installer succeeds. Regression:
+`fresh-install-retryable-after-partial-failure-rf2-g2jf3` (a throw-once
+mid-list leaf; a second call must replay the whole bulk, not run a
+bridge-only migration).
 
 ### Production registration carries no test seams (rf2-e8330v / xxo3zz F3)
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
@@ -790,3 +790,39 @@
     (fn [[_history] _query]
       (viewcell-evidence/rows)))
   nil)
+
+(defn install-legacy-reactive-data-sub-for-test!
+  "TEST-ONLY (rf2-sa8j3): register the PREDECESSOR two-input
+  `:rf.xray/reactive-data` sub — the shape before f012c70e6f added the
+  panel-local `:rf.xray/reactive-show-unchanged?` quick-toggle + the
+  `[:rf.xray/setting :general :show-unchanged-subs?]` pin. The two-input body
+  reads only `:rf.xray/focus` + `:rf.xray/epoch-history` and hard-codes
+  `:show-unchanged? false`, so it CANNOT respond to either disclosure axis —
+  the observable that distinguishes it from the current four-input sub.
+
+  The changed-handler live-upgrade fixture installs this to model an
+  already-registered process that installed reactive-data under OLD code; the
+  schema-3 migration must REPLACE it with the four-input sub (and evict the
+  stale cache). Registered from THIS ns so its image-assembly source
+  coordinate matches the production sub the migration re-registers — a
+  different source ns would trip the duplicate-id image guard, exactly as the
+  sibling `install-legacy-viewcell-evidence-sub-for-test!` documents. Never
+  call from production. Returns nil."
+  []
+  (rf/reg-sub :rf.xray/reactive-data
+    :<- [:rf.xray/focus]
+    :<- [:rf.xray/epoch-history]
+    (fn [[focus history] _query]
+      (let [record   (focused-epoch-record history (:epoch-id focus))
+            topology (try (subs-tooling/sub-topology) (catch :default _ nil))
+            proj     (project-record record topology)]
+        (merge proj
+               {:focus             focus
+                :frame             (:frame focus)
+                :dispatch-id       (:dispatch-id focus)
+                :triggered-by      (when record (triggered-by record))
+                :seed-paths        (when record (seed-paths record))
+                ;; The predecessor had no disclosure axes — hard-false.
+                :show-unchanged?   false
+                :has-event-bundle? (some? record)}))))
+  nil)

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -119,11 +119,16 @@
 ;; registration schema the process last installed, so a live-upgraded
 ;; process runs the bounded migration for each version it is behind.
 
-(def ^:private schema-version
-  "Current registration-schema version. Bump when a code change adds a
-  handler that an ALREADY-registered older process would otherwise never
-  install (the umbrella `registered?` gate no-ops its whole leaf install
-  on `:after-load`); pair each bump with a `migrate-schema!` clause below.
+(def schema-version
+  "Current registration-schema version. Bump when a code change ADDS a
+  handler an ALREADY-registered older process would otherwise never install,
+  OR CHANGES (replaces) a gated registration's body/topology the umbrella
+  `registered?` gate would otherwise leave at its old shape — on
+  `:after-load` the umbrella no-ops the whole leaf install, so BOTH a new id
+  and a changed body stay behind until a full page reload. Pair each bump
+  with a `migrate-schema!` clause below. Public (a read-only contract number):
+  the governance pin in `registry_cljs_test.cljs` reads it so any gated
+  registration edit — add OR replace — must name a schema bump (rf2-sa8j3).
 
   Version history:
     1 — ViewCell evidence REACTIVITY BRIDGE (rf2-vxgfnd.286 / rf2-ykaq4u):
@@ -139,8 +144,22 @@
         version honesty) and `:rf.xray/view-evidence-sites` (static per-view
         manifest sites). A schema-1 process has the bridge but not these two,
         so the migration re-runs the bridge install (idempotent — reg-sub
-        replaces in place) to add exactly the missing delta."
-  2)
+        replaces in place) to add exactly the missing delta.
+    3 — Reactive-data topology REPLACEMENT (rf2-sa8j3): a CHANGED handler
+        body, not a new id. `:rf.xray/reactive-data` went from two inputs to
+        four (adding the panel-local `:rf.xray/reactive-show-unchanged?`
+        quick-toggle + the `[:rf.xray/setting :general :show-unchanged-subs?]`
+        pin) inside `reactive-panel/install!` — the umbrella + the name-set
+        snapshot both no-op a REPLACEMENT (same id, changed body), so a
+        schema-2 process re-running `register-xray-handlers!` retained the OLD
+        two-input body until a page reload. The migration re-runs the owning
+        `reactive-panel` facade's `install!`: re-frame's registrar replaces
+        each handler in place AND the sub-cache replacement-hook evicts the
+        stale reactive-data reaction, so a live-upgraded process reaches the
+        four-input topology (held Views subscriptions invalidated) with no
+        reload. Generalises the seam — a gated registration REPLACEMENT is a
+        schema delta exactly as an ADDITION is."
+  3)
 
 (defonce ^:private installed-schema
   ;; The registration-schema version this process has installed, or nil
@@ -154,13 +173,16 @@
 
 (defn- migrate-schema!
   "Bring an already-registered older-schema process up to `schema-version`
-  by installing EXACTLY the handlers newer schema versions add — the
-  bounded live-upgrade seam (rf2-ykaq4u). `from` is the process's installed
-  schema (0 ⇒ pre-schema-versioning, i.e. a pre-#5915 process). Each clause
-  is additive, idempotent (re-frame's registrar replaces in place), and
-  gated on `from` predating the version that introduced its handler — so
-  this is NOT an unconditional whole-registry re-registration; only the
-  missing delta is installed, and only for a process that is behind."
+  by installing EXACTLY the bounded delta newer schema versions introduce —
+  a handler newer versions ADD, or a gated registration whose BODY/topology
+  newer versions CHANGE (replace) — the live-upgrade seam (rf2-ykaq4u /
+  rf2-sa8j3). `from` is the process's installed schema (0 ⇒
+  pre-schema-versioning, i.e. a pre-#5915 process). Each clause is idempotent
+  (re-frame's registrar replaces in place; replacing a sub also evicts its
+  stale cache via the registrar replacement-hook), and gated on `from`
+  predating the version that introduced its delta — so this is NOT an
+  unconditional whole-registry re-registration; only the missing/changed
+  delta is installed, and only for a process that is behind."
   [from]
   (when (< from 1)
     ;; schema 1 — the ViewCell evidence REACTIVITY BRIDGE. A pre-#5915
@@ -179,7 +201,23 @@
     ;; bridge without them; re-running the (idempotent) bridge install adds
     ;; exactly the missing two subs — reg-sub replaces in place, so the
     ;; already-present bridge handlers are untouched.
-    (reactive-panel/install-viewcell-evidence-bridge!)))
+    (reactive-panel/install-viewcell-evidence-bridge!))
+  (when (< from 3)
+    ;; schema 3 — the Reactive-data topology REPLACEMENT (rf2-sa8j3). The
+    ;; `:rf.xray/reactive-data` sub changed from two inputs to four inside
+    ;; `reactive-panel/install!` (adding the `:rf.xray/reactive-show-
+    ;; unchanged?` quick-toggle + the Settings show-unchanged pin). That is a
+    ;; CHANGED body, not a new id, so neither the umbrella nor an
+    ;; addition-only migration would replace the OLD two-input sub a schema-2
+    ;; process cached. Re-run the owning `reactive-panel` facade's `install!`:
+    ;; re-frame's registrar replaces each handler in place and the sub-cache
+    ;; replacement-hook evicts the stale `:rf.xray/reactive-data` reaction, so
+    ;; a held Views subscription rebuilds against the current four-input body
+    ;; — no page reload. Idempotent, and reached only for a behind process:
+    ;; a fresh boot stamps `installed-schema` current inside the umbrella
+    ;; block, so the seam's `(< schema-version schema-version)` guard is false
+    ;; there and this clause never double-registers on a fresh boot.
+    (reactive-panel/install!)))
 
 (defn register-xray-handlers!
   "Idempotent registration of Xray's :rf.xray/* events, subs, fxs.
@@ -1152,4 +1190,21 @@
   []
   (reset! registered? true)
   (reset! installed-schema nil)
+  nil)
+
+(defn simulate-registration-at-schema!
+  "TEST-ONLY (rf2-sa8j3): pose the sentinels to model an ALREADY-registered
+  process that installed schema `n` under OLDER code and is now running NEWER
+  code whose `schema-version` is ahead of `n`. The umbrella gate is SET (its
+  full install ran) and `installed-schema` is stamped `n`, so a subsequent
+  `register-xray-handlers!` no-ops the umbrella and reaches ONLY the migration
+  seam — running exactly the `(< n …)` clauses that post-date the posed
+  schema. Complements `simulate-legacy-registration!` (which poses the
+  pre-schema-versioning nil stamp, i.e. schema 0): this poses an INTERMEDIATE
+  schema so a fixture can isolate the newest migration clause. Poses only the
+  sentinels; the fixture registers whatever predecessor handler shape it
+  needs. Never call from production. Returns nil."
+  [n]
+  (reset! registered? true)
+  (reset! installed-schema n)
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -198,6 +198,19 @@
        no-ops too — no handler-replaced flood on repeat reloads."
   []
   (when (compare-and-set! registered? false true)
+    ;; rf2-g2jf3 — fresh-install ATOMICITY. `compare-and-set!` flips the
+    ;; umbrella to true BEFORE the ~900-line bulk install below, but the
+    ;; schema is stamped only AFTER the last installer. If any registrar /
+    ;; leaf installer throws mid-block, an unguarded exit would leave
+    ;; `{registered? true, installed-schema nil}` — the next reload's umbrella
+    ;; permanently skips the unfinished bulk install and the migration seam
+    ;; mis-reads the nil stamp as schema 0, stamping the registry "current"
+    ;; over a PARTIAL install. Wrap the whole bulk block so a throw ROLLS the
+    ;; umbrella back to false and rethrows: the registration stays RETRYABLE
+    ;; (a second call replays every installer; partial registrar writes are
+    ;; replaced in place) and the schema is NEVER stamped past a failure.
+    ;; Publish registered/current only after every installer succeeds.
+    (try
     ;; ---- cross-panel primitives ---------------------------------
 
     ;; Xray's trace-buffer sub returns a flat snapshot of every
@@ -1089,8 +1102,21 @@
     (static-interceptors-panel/install!)
     ;; Fresh boot ran the whole leaf install (the current bridge included),
     ;; so stamp the schema CURRENT — the migration seam below then no-ops
-    ;; on this process and on its own `:after-load` reloads.
-    (reset! installed-schema schema-version))
+    ;; on this process and on its own `:after-load` reloads. Reached ONLY when
+    ;; every installer above succeeded (rf2-g2jf3): the stamp is the last act
+    ;; inside the guarded block, so a partial install never advances the schema.
+    (reset! installed-schema schema-version)
+    (catch :default e
+      ;; A registrar / leaf installer threw mid bulk-install (rf2-g2jf3). Roll
+      ;; the umbrella back so the NEXT `register-xray-handlers!` replays the
+      ;; whole leaf install (re-frame's registrar replaces partial writes in
+      ;; place) instead of permanently skipping it, and leave `installed-schema`
+      ;; UNSTAMPED (nil) so the migration seam below cannot mistake a failed
+      ;; fresh install for a live-upgrade delta. Rethrow so the failure stays
+      ;; loud — a transient/programming failure surfaces immediately rather
+      ;; than silently degrading into a partial registry.
+      (reset! registered? false)
+      (throw e))))
   ;; ---- live-upgrade migration seam (rf2-ykaq4u) ----------------------
   ;;
   ;; INDEPENDENT of the umbrella gate above. An already-registered process

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -56,9 +56,12 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.subs.tooling :as subs-tooling]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.focus :as focus]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.panels.reactive-panel-subs :as reactive-panel-subs]
+            [day8.re-frame2-xray.panels.routing :as routing]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.self-noise :as self-noise]
             [day8.re-frame2-xray.test-support :as xray-test-support]
@@ -1075,6 +1078,151 @@
         (is (some? (rf/subscribe [q-v]))
             (str q-v " must resolve through rf/subscribe after
                  register-xray-handlers!"))))))
+
+;; ---- registration-schema seam: fresh-install atomicity (rf2-g2jf3) ------
+;;
+;; `register-xray-handlers!` flips the `registered?` umbrella BEFORE the
+;; ~900-line bulk leaf install and stamps `installed-schema` only AFTER the
+;; last installer. Pre-fix, a throw mid-install exited with
+;; `{registered? true, installed-schema nil}`: the next call's umbrella
+;; permanently skipped the unfinished bulk install, and the migration seam
+;; mis-read the nil stamp as schema 0 — stamping the registry "current" over
+;; a PARTIAL install. The fix wraps the bulk block so a throw rolls the
+;; umbrella back to false and rethrows, leaving the fresh install RETRYABLE
+;; and the schema UNSTAMPED. The observable: a THROW-ONCE mid-list leaf, then
+;; a second call that REPLAYS the whole bulk (not a bridge-only migration).
+
+(deftest fresh-install-retryable-after-partial-failure-rf2-g2jf3
+  (testing "rf2-g2jf3 — a throw mid bulk-install rolls the umbrella back so
+            the fresh install stays retryable and never advances the schema"
+    ;; The `@calls` counter is the snapshot-independent observable: the
+    ;; runtime fixture restores a registrar SNAPSHOT that already carries the
+    ;; xray handlers, so 'handler present/absent' cannot distinguish a
+    ;; completed install from a partial one. What DOES distinguish them is
+    ;; whether the bulk block RE-RUNS — i.e. whether `compare-and-set!`
+    ;; succeeds a second time, which happens only if the umbrella was rolled
+    ;; back to false (the fix) rather than left set with a mis-stamped schema
+    ;; (the bug). `routing/install!` is a THROW-ONCE mid-list leaf.
+    (let [orig-install routing/install!
+          calls        (atom 0)]
+      (with-redefs [routing/install!
+                    (fn []
+                      (swap! calls inc)
+                      (if (= 1 @calls)
+                        (throw (ex-info "rf2-g2jf3 throw-once mid-list leaf" {}))
+                        (orig-install)))]
+        (testing "the mid-list installer throw propagates loudly"
+          (is (thrown-with-msg? js/Error #"rf2-g2jf3 throw-once"
+                (registry/register-xray-handlers!)))
+          (is (= 1 @calls) "the throwing installer ran exactly once"))
+        (testing "a SECOND call REPLAYS the whole bulk install — the umbrella
+                  rolled back to false and the schema was never stamped past
+                  the failure, so this is a fresh re-install (which re-runs
+                  routing AND every installer after it), NOT a bridge-only
+                  migration over a falsely-advanced schema"
+          (registry/register-xray-handlers!)
+          (is (= 2 @calls)
+              "compare-and-set succeeded again → the bulk block re-ran
+               (pre-fix the umbrella stayed set + the schema was mis-stamped
+               current, so the retry no-ops the umbrella and runs only a
+               bridge migration — routing never re-runs and calls stalls at 1)"))
+        (testing "the completed install is now idempotent — schema stamped
+                  current, so a further reload no-ops"
+          (registry/register-xray-handlers!)
+          (is (= 2 @calls)
+              "a third call no-ops — umbrella set + migration at current
+               schema, no re-run"))))))
+
+;; ---- registration-schema seam: changed handlers migrate too (rf2-sa8j3) --
+;;
+;; The `registered?` umbrella + the name-set snapshots above cover ADDED
+;; registrations. They do NOT cover a CHANGED body: a sub that gains inputs
+;; keeps its id, so the umbrella no-ops it and the name set is untouched.
+;; `:rf.xray/reactive-data` went two → four inputs inside
+;; `reactive-panel/install!` (f012c70e6f), so an already-registered process
+;; retained the OLD two-input body until a page reload. The schema-3
+;; migration re-runs the owning `reactive-panel` facade `install!`, replacing
+;; the sub (and evicting its stale cache) so the four-input topology reaches a
+;; live-upgraded process.
+
+(defn- reactive-data-input-ids
+  "The static `:<-` input sub-ids of `:rf.xray/reactive-data`, read off the
+  live `sub-topology` (each `[query-id args]` reduced to its head). `[]` when
+  the sub is unregistered."
+  []
+  (let [inputs (:inputs (get (subs-tooling/sub-topology) :rf.xray/reactive-data))]
+    (mapv #(if (vector? %) (first %) %) (or inputs []))))
+
+(deftest changed-reactive-data-migrates-as-a-schema-delta-rf2-sa8j3
+  (testing "rf2-sa8j3 — a live process holding the PREDECESSOR two-input
+            reactive-data upgrades to the current four-input topology via the
+            schema migration, invalidating the held cache — no page reload"
+    ;; 1. Full current boot: reactive-data is the four-input sub; frame live.
+    (setup-xray-frame!)
+    ;; 2. DOWNGRADE (from the canonical ns, so image assembly sees one source
+    ;;    coord per id) to model a process that cached the OLD two-input sub.
+    (reactive-panel-subs/install-legacy-reactive-data-sub-for-test!)
+    ;; 3. Pose the sentinels: umbrella SET + installed-schema at 2 — the
+    ;;    schema BEFORE the reactive-data replacement bump — so
+    ;;    register-xray-handlers! no-ops the umbrella and runs ONLY the
+    ;;    reactive-data migration clause (`(< 2 3)`).
+    (registry/simulate-registration-at-schema! 2)
+    ;; Turn the disclosure toggle ON — the axis only the four-input sub reads.
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/reactive-set-unchanged true]))
+
+    (testing "PRECONDITION — the cached two-input predecessor ignores the axis"
+      (is (= [:rf.xray/focus :rf.xray/epoch-history]
+             (reactive-data-input-ids))
+          "downgraded to the pre-f012c70e6f two-input topology")
+      (is (false? (rf/with-frame :rf/xray
+                    (:show-unchanged? @(rf/subscribe [:rf.xray/reactive-data]))))
+          "the two-input body hard-codes show-unchanged? false — the toggle is
+           invisible to it"))
+
+    ;; 4. The live upgrade: :after-load re-runs register-xray-handlers!. The
+    ;;    umbrella no-ops; the schema-3 migration re-registers the four-input
+    ;;    reactive-data through the reactive-panel facade.
+    (registry/register-xray-handlers!)
+
+    (testing "the REPLACEMENT migrated — the four-input topology is restored"
+      (is (= [:rf.xray/focus :rf.xray/epoch-history
+              :rf.xray/reactive-show-unchanged? :rf.xray/setting]
+             (reactive-data-input-ids))
+          "reactive-data is back to the four-input topology"))
+    (testing "the held cache was invalidated — a read now honours the toggle
+              the predecessor could not see"
+      (is (true? (rf/with-frame :rf/xray
+                   (:show-unchanged? @(rf/subscribe [:rf.xray/reactive-data]))))
+          "the replaced four-input sub resolves show-unchanged? through the
+           reactive axis — the stale two-input reaction was evicted"))))
+
+;; ---- schema-delta governance pin (rf2-sa8j3) ----------------------------
+;;
+;; The name-set snapshots catch ADDED registrations; this pin catches CHANGED
+;; ones. It ties `schema-version` to the shipped reactive-data topology, so
+;; ANY gated registration edit — add OR replace — must consciously bump
+;; `schema-version` + pair a `migrate-schema!` clause (or record an explicit
+;; no-migration rationale) and update the pins here. Mirrors the drift-guard
+;; discipline of `focus-valid-panels-mirrors-live-dynamic-registry`.
+
+(def ^:private expected-schema-version 3)
+
+(deftest schema-version-is-pinned-so-changed-registrations-name-a-migration
+  (testing "registry/schema-version matches the governance pin"
+    (is (= expected-schema-version registry/schema-version)
+        (str "registration-schema version changed. If you ADDED or CHANGED a "
+             "gated registration, bump schema-version, pair a migrate-schema! "
+             "clause (or document why no migration is needed), then update "
+             "expected-schema-version. rf2-sa8j3.")))
+  (testing "the schema-3 reactive-data topology is the current shipped shape"
+    (setup-xray-frame!)
+    (is (= [:rf.xray/focus :rf.xray/epoch-history
+            :rf.xray/reactive-show-unchanged? :rf.xray/setting]
+           (reactive-data-input-ids))
+        (str "reactive-data topology drifted from the schema-" expected-schema-version
+             " pin. A changed sub topology is a schema delta — bump "
+             "schema-version + add a migrate-schema! clause. rf2-sa8j3."))))
 
 ;; ---- Machine tab fit-on-entry signal (rf2-6tw7t) ------------------------
 ;;


### PR DESCRIPTION
Two-bead cluster on the Xray registration-schema seam (`tools/xray/.../registry.cljs`). Rebased on `origin/main` (post rf2-vxgfnd.95.7, which bumped `schema-version` to **2**).

## rf2-g2jf3 — fresh-install atomicity
`register-xray-handlers!` flips the `registered?` umbrella true BEFORE the ~900-line bulk leaf install but stamps `installed-schema` only AFTER the last installer. A throw mid-install exited `{registered? true, installed-schema nil}`: the next reload's umbrella permanently skipped the unfinished bulk install, and the migration seam mis-read the nil stamp as schema 0 — stamping the registry "current" over a **partial** install (every handler after the failure point absent while the registry claimed current).

**Fix:** wrap the bulk block in try/catch — a throw rolls the umbrella back to `false` and rethrows, leaving the fresh install **retryable** (a second call replays every installer; partial registrar writes are replaced in place) and `installed-schema` **unstamped**. registered/current publish only after every installer succeeds.

**Regression:** `fresh-install-retryable-after-partial-failure-rf2-g2jf3` — a throw-once mid-list leaf (`routing/install!`); the snapshot-independent observable is that a second call must re-run the bulk (the redef counter reaches 2), i.e. NOT a bridge-only migration over a falsely-advanced schema.

## rf2-sa8j3 — changed handlers migrate too
Verified post-.95.7: the changed-handler gap is **still open**. `.95.7`'s schema-2 migration only re-runs `install-viewcell-evidence-bridge!`, which does NOT touch `:rf.xray/reactive-data`. That sub grew from two inputs to four (adding `:rf.xray/reactive-show-unchanged?` + the Settings pin) inside `reactive-panel/install!` — a REPLACEMENT (same id, changed body), which both the umbrella and the name-set snapshots no-op. A schema-2 process retained the old two-input body until a page reload.

**Fix:** bump `schema-version` **2 → 3** and add a `migrate-schema! (< from 3)` clause that re-runs the owning `reactive-panel` facade's `install!`. re-frame's registrar replaces each handler in place and the sub-cache replacement-hook (`invalidate-sub-on-replace!`) evicts the stale reaction, so a live-upgraded process reaches the four-input topology (held Views subscriptions invalidated) with no reload. `schema-version` is now public (read-only contract number), and a governance pin ties it to the shipped reactive-data topology so any gated registration edit — add OR replace — must name a schema bump.

**Regression:** `changed-reactive-data-migrates-as-a-schema-delta-rf2-sa8j3` — a schema-2 process holding the predecessor two-input handler upgrades to the four-input topology; the held cache is invalidated (a read now honours the disclosure toggle the predecessor ignored). Plus the `schema-version-is-pinned-...` governance test.

Spec `014-Registry-Catalogue.md` updated for both the ADD-or-REPLACE schema-delta contract and fresh-install atomicity.

## Quality gates
All foreground, unpiped. Red-before / green-after demonstrated for the cluster (3 new tests failed against unpatched code, pass after the fix).

- `npm run test:cljs` (node-test, runs the xray `.cljs` suites): **9816 tests / 48250 assertions, 0 failures, 0 errors**
- tools/xray JVM `clojure -M:test`: **1268 tests / 5901 assertions, 0 failures, 0 errors**
- `npm run test:xray-feature-gate` (browser, nightly-full sweep): **16 scenarios, 0 failures, 13 matrix rows**

Scope: only `registry.cljs` + its tests + the sa8j3 owning-facade re-registration (via the already-required `reactive-panel/install!`) + one canonical-ns test-only legacy-sub helper in `reactive_panel_subs.cljs` (mirrors the existing `install-legacy-viewcell-evidence-sub-for-test!`; required because the image duplicate-id guard needs canonical-ns registration). No `implementation/` changes.
