### PR TITLE
docs(machines): reconcile tutorial + executable companion into one program (rf2-k7fzd)

### DIFF
--- a/docs/machines/inspecting-machines.md
+++ b/docs/machines/inspecting-machines.md
@@ -121,9 +121,9 @@ Because a machine is an event handler, every guard evaluation, action run, and t
 {:operation :rf.machine/guard-evaluated
  :tags {:actor-id :auth.login/flow             ;; the LIVE instance (a singleton's id == its type)
         :guard-id :under-retry-limit
-        :input    {:data {:attempts 3} :event [:auth.login/failure {…}]}
+        :input    {:data {:attempts 2} :event [:auth.login/failure {…}]}
         :state    :submitting                  ;; the active state the guard ran against
-        :outcome  :fail}}                       ;; :pass | :fail | :threw
+        :outcome  :fail}}                       ;; :pass | :fail | :threw  (rejects on the third failure)
 
 ;; one trace record per user-declared action invocation
 {:operation :rf.machine/action-ran
@@ -162,7 +162,7 @@ When you've found the guard that blocked a transition and want to *read it*, ask
 (rf/handler-meta :machine-guard [:auth.login/flow :under-retry-limit])
 ;; => {:rf/guard-id        :under-retry-limit
 ;;     :rf/machine-id      :auth.login/flow
-;;     :rf.handler/source  "(fn [{data :data}] (< (:attempts data) 3))"
+;;     :rf.handler/source  "(fn [{data :data}] (< (:attempts data) 2))"
 ;;     :handler-fn         #<fn>
 ;;     :ns … :line … :file …}
 
@@ -206,12 +206,14 @@ Use the same `login-flow` value from the [tutorial](tutorial.md#the-complete-mac
     (is (= :submitting (:state (result/snap r))))
     (is (= :rf.http/managed (ffirst (result/fx r)))))
 
-  ;; at the retry limit the first failure candidate is skipped → :locked-out
+  ;; at the retry limit (two failures already recorded) the first failure
+  ;; candidate is skipped → the third failure records its error and locks out
   (let [r (machines/machine-transition
             login-flow
-            {:state :submitting :data {:attempts 3 :error nil}}
+            {:state :submitting :data {:attempts 2 :error nil}}
             [:auth.login/failure {:error {:message "bad creds"}}])]
-    (is (= :locked-out (:state (result/snap r))))))
+    (is (= :locked-out (:state (result/snap r))))
+    (is (= 3 (get-in (result/snap r) [:data :attempts])))))
 ```
 
 The return value is a **Result map**. Discriminate with `result/ok?` / `result/fail?`;

--- a/docs/machines/tutorial.md
+++ b/docs/machines/tutorial.md
@@ -209,13 +209,20 @@ Project the snapshot; ask **tags** for shared intent:
   :<- [:rf/machine :auth.login/flow]
   (fn [m _] (get-in m [:data :error])))
 
+;; The credential draft is ordinary app-db form state — read through a plain
+;; sub, never reached out of the view. The inputs that WRITE it are a form-slice
+;; concern; build one in [Build a form](../core/how-to/build-a-form.md).
+(rf/reg-sub :auth.login/draft
+  (fn [db _] (get-in db [:auth :login-form :draft])))
+
 (rf/reg-view login-view []
   (let [state @(subscribe [:auth.login/state])
         error @(subscribe [:auth.login/error])
+        draft @(subscribe [:auth.login/draft])
         busy? @(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])]
     (case state
       :idle        [:button {:disabled busy?
-                             :on-click #(dispatch [:login/submit @draft-creds])}
+                             :on-click #(dispatch [:login/submit draft])}
                     "Sign in"]
       :submitting  [:p "Signing in…"]
       :error-shown [:div [:p error]

--- a/examples/capabilities/machines/state_machine_walkthrough/README.md
+++ b/examples/capabilities/machines/state_machine_walkthrough/README.md
@@ -3,7 +3,7 @@
 This example puts a login form in your browser — an email field, a password
 field, a **Sign in** button. Fill it in and submit. The attempt fails, and an
 error message appears with a **Dismiss** button. It fails *every* time, on
-purpose. After three rejections, a fourth submit locks the account: the form
+purpose. After two rejections, a third submit locks the account: the form
 disappears and an "Account locked" panel takes its place. Across the top, a
 banner names the machine's current state the whole way through, so you watch it
 step `:idle → :submitting → :error-shown` and back, then finally settle in
@@ -53,8 +53,8 @@ at it, poke here.
   while a request is in flight; `:auth/locked` swaps the form for a lockout
   panel. That is *ask, don't tell*: the view never names a state keyword, so
   adding a sixth busy state wouldn't touch it. The demo wires the request to
-  always fail (more below), so what you watch is the lockout path — three
-  rejected attempts, then a fourth that the retry guard rejects, parking the
+  always fail (more below), so what you watch is the lockout path — two
+  rejected attempts, then a third that the retry guard rejects, parking the
   machine in `:locked-out`.
 
 - **The same flow tested as pure function calls.** Feed a starting
@@ -127,7 +127,7 @@ shadow-cljs watch examples/state-machine-walkthrough
 ```
 
 Then open the served [`index.html`](index.html) and watch the lockout path:
-three rejected attempts, then a fourth that parks the machine in `:locked-out`.
+two rejected attempts, then a third that parks the machine in `:locked-out`.
 
 ## Cross-references
 

--- a/examples/capabilities/machines/state_machine_walkthrough/core.cljc
+++ b/examples/capabilities/machines/state_machine_walkthrough/core.cljc
@@ -62,9 +62,11 @@
     ;; A guard is a pure yes/no question asked of one map: {:data ... :event ...}.
     ;; `data` is the snapshot's :data slot, handed to you directly. Say yes here
     ;; and the transition fires; say no and the machine looks at the next option.
+    ;; The guard checks the PRE-action :attempts, so it passes for the first two
+    ;; failures and rejects on the third — three attempts total.
     ;; See docs/machines/glossary.md#guard.
     (fn [{data :data}]
-      (< (:attempts data) 3))}
+      (< (:attempts data) 2))}
 
    :actions
    {:clear-error
@@ -87,22 +89,14 @@
               :on-failure [:walkthrough.login/flow [:walkthrough.login/failure]]}]]})
 
     :record-error
-    ;; The classified failure map rides under :error.
+    ;; The classified failure map rides under :error. This is the action the
+    ;; terminal failure runs too — so the third, locking-out failure is counted
+    ;; (attempts → 3) and its message retained, not discarded on the way to
+    ;; :locked-out.
     (fn [{data :data [_ {:keys [error]}] :event}]
       {:data (-> data
                  (update :attempts inc)
                  (assoc :error (or (:message error) "Login failed.")))})
-
-    :lock-account
-    (fn [_]
-      {:fx [[:rf.http/managed
-             ;; Fire-and-forget: the account is already locked in the UI, so
-             ;; both reply branches are silenced (`nil`). Every managed request
-             ;; must address its reply (Spec 014 §Reply addressing) — silencing
-             ;; is the explicit choice, not an omission.
-             {:request    {:method :post :url "/api/auth/lock"}
-              :on-success nil
-              :on-failure nil}]]})
 
     :store-session
     (fn [{[_ {:keys [value]}] :event}]
@@ -127,7 +121,7 @@
                                    :guard  :under-retry-limit
                                    :action :record-error}
                                   {:target :locked-out
-                                   :action :lock-account}]}}
+                                   :action :record-error}]}}
 
     :error-shown
     {:on {:walkthrough.login/dismiss {:target :idle}

--- a/examples/capabilities/machines/state_machine_walkthrough/views.cljs
+++ b/examples/capabilities/machines/state_machine_walkthrough/views.cljs
@@ -6,11 +6,11 @@
   the views, the Reagent mount, and a `run` fn that points `:rf.http/managed` at
   the canned-failure stub through per-frame :fx-overrides.
 
-  The demo tells one story — the lockout. Three failed attempts walk the machine
-  round the loop :submitting -> :error-shown -> :idle, and then a fourth submit
-  trips the `:under-retry-limit` guard and the machine settles into :locked-out.
-  For that to play out, every request has to fail, which is exactly why we wire
-  in the canned-FAILURE stub here."
+  The demo tells one story — the lockout. Two failed attempts walk the machine
+  round the loop :submitting -> :error-shown -> :idle, and then a third submit
+  trips the `:under-retry-limit` guard and the machine settles into :locked-out
+  (three attempts total). For that to play out, every request has to fail, which
+  is exactly why we wire in the canned-FAILURE stub here."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -127,8 +127,8 @@
   ;; views all resolve to this frame.
   ;;
   ;; `:fx-overrides` redirects `:rf.http/managed` to the canned-FAILURE stub, so
-  ;; every login attempt fails on purpose — the lockout demo can't lock anyone
-  ;; out without three failures to work with.
+  ;; every login attempt fails on purpose — the lockout demo reaches
+  ;; `:locked-out` when the third failing attempt trips the retry guard.
   ;;
   ;; One subtlety worth pausing on: the machine seeds itself on its first event,
   ;; but the DRAFT slice does not. So `:initial-events` seeds the draft before

--- a/implementation/core/test/re_frame/examples_test.clj
+++ b/implementation/core/test/re_frame/examples_test.clj
@@ -845,19 +845,21 @@
                                                         [:walkthrough.login/success {:value {:token "t"}}])]
           (is (= :authed (:state s2))))))
 
-    (testing "pure lockout — at the retry limit the second :failure clause's :locked-out target wins"
-      ;; Once :data :attempts reaches the retry limit, the
-      ;; :under-retry-limit guard fails and the :locked-out target wins.
-      ;; The guard checks the snapshot BEFORE the action runs;
-      ;; :record-error then bumps the counter on hits, so attempts=3 is
-      ;; the first counter value at which the guard rejects.
-      (let [snapshot {:state :submitting :data {:attempts 3 :error nil}}
+    (testing "pure lockout — the third failure fails the retry guard, records the terminal error, and locks out (three attempts total)"
+      ;; Two failures already recorded (:attempts 2); the third is terminal.
+      ;; The :under-retry-limit guard checks the snapshot BEFORE :record-error
+      ;; runs, so attempts=2 is the first counter value at which the guard
+      ;; rejects — the fallback candidate then runs :record-error too, so the
+      ;; locking-out failure is counted (attempts → 3) and its message stored.
+      (let [snapshot {:state :submitting :data {:attempts 2 :error nil}}
             {s ::result/snap}
             (machines/machine-transition login-flow snapshot
                                    [:walkthrough.login/failure
-                                    {:failure {:kind :rf.http/http-4xx
-                                               :message "bad creds"}}])]
-        (is (= :locked-out (:state s)) "expected :locked-out at attempts=3")))
+                                    {:error {:message "bad creds"}}])]
+        (is (= :locked-out (:state s)) "expected :locked-out on the third failure")
+        ;; the terminal failure is still counted — attempts bumped, message stored
+        (is (= 3 (get-in s [:data :attempts])) "the third failure records count 3")
+        (is (= "bad creds" (get-in s [:data :error])) "the terminal error is retained")))
 
     (testing "drain happy path — full drain lands the app-db at :authed via the canned-success stub"
       ;; Full drain: registers the machine, dispatches into it, asserts the
@@ -871,14 +873,14 @@
         (is (= :authed (rf/compute-sub [:walkthrough.login/state] (rf/frame-state-value f)))
             "expected :authed after canned success")))
 
-    (testing "drain retry-then-lockout — three failures cycle, the fourth :submit lands at :locked-out"
-      ;; Three failures cycle :submitting → :error-shown → :idle ×3, then
-      ;; a fourth :submit fails the guard and lands at :locked-out. Uses
+    (testing "drain retry-then-lockout — two failures cycle, the third :submit lands at :locked-out (three attempts total)"
+      ;; Two failures cycle :submitting → :error-shown → :idle ×2, then a
+      ;; third :submit fails the guard and lands at :locked-out. Uses
       ;; `rf/with-fx-overrides` — the lexical-scope counterpart to the
       ;; per-frame `:fx-overrides` opt on `make-frame`.
       (let [f (frame/make-anon-frame-record! {})]
         (rf/with-fx-overrides {:rf.http/managed :walkthrough.login/canned-failure}
-          (dotimes [_ 3]
+          (dotimes [_ 2]
             (rf/dispatch-sync [:walkthrough.login/flow [:walkthrough.login/submit
                                                   {:email "x@y.z" :password "wrong"}]]
                               {:frame f})
@@ -887,4 +889,4 @@
                                                 {:email "x@y.z" :password "wrong"}]]
                             {:frame f}))
         (is (= :locked-out (rf/compute-sub [:walkthrough.login/state] (rf/frame-state-value f)))
-            "expected :locked-out on 4th attempt")))))
+            "expected :locked-out on the third submit")))))


### PR DESCRIPTION
## What & why

`rf2-k7fzd` (P2 bug). PR #6055 corrected the Machines tutorial to a
three-total-attempt lockout policy and advertised it as copy-pasteable, but the
complete teaching program still split into two incompatible copies: the tutorial
prose vs. the tested executable companion. This reconciles them onto **one**
program so a reader can copy-paste the tutorial and get exactly the behaviour the
CI test proves.

## The drift

- **`docs/machines/tutorial.md` Step 5** dereferenced an undefined `draft-creds`
  symbol in the Sign-in callback → `Unable to resolve symbol: draft-creds`, so the
  promised view could not be copied into a real app.
- **`examples/capabilities/machines/state_machine_walkthrough/core.cljc`** still
  guarded with `(< attempts 3)`, locked on the **fourth** submit, and its terminal
  branch ran only `:lock-account` — discarding the final error instead of recording
  it.
- **`examples_test.clj`** and the **README / `views.cljs`** browser prose pinned that
  contradictory four-attempt behaviour, so the green test protected the wrong program.
- **`docs/machines/inspecting-machines.md`** called its `< 3` table "the tutorial value".

## The reconciliation

Source of truth = the corrected tutorial's three-total-attempt policy.

- `tutorial.md` Step 5: read the draft through a plain `:auth.login/draft` sub
  (`draft`), dropping the undefined symbol — the view now compiles and copy-pastes.
- `core.cljc`: guard `(< attempts 3)` → `(< attempts 2)`; terminal failure candidate
  `:lock-account` → `:record-error`; removed the now-unused `:lock-account` action.
  The third failure now records count 3 + its error before `:locked-out`.
- `examples_test.clj`: pure-lockout scenario drives `attempts 2` → `:locked-out`,
  asserting attempts→3 and the retained error; drain scenario is two failing cycles
  then a third submit that locks out.
- `inspecting-machines.md`: `handler-meta` source, the guard-evaluated trace input,
  and the `machine-transition` example all show the `< 2` boundary.
- `README.md` / `views.cljs`: "two rejections, then a third locks" (three attempts total).

Namespacing differs by design (`app.login` in the tutorial vs. `walkthrough.login`
in the companion, which coexists with the sibling `login` example) — the *policy*
is now identical everywhere.

## Quality gates

- `implementation/core` JVM `clojure -M:test` — **2038 tests, 9616 assertions, 0 failures, 0 errors** (includes `state-machine-walkthrough-runs-headless`).
- Focused `clojure -M:test -n re-frame.examples-test` — **15 tests, 91 assertions, 0 failures**.
- `python -m mkdocs build --strict` — **exit 0, no warnings**, 0 new broken links.

## Out of scope (flagged for follow-up)

`docs/machines/concepts.md` line 160 shows the same `:under-retry-limit` guard with
the old `(< (:attempts data) 3)` limit. It is an isolated guard-syntax illustration
(not the lockout candidate list), and it sits outside this bead's surface fence
(tutorial.md + inspecting-machines.md only), so it is left untouched here — worth a
small follow-up bead to align the illustration.
