### PR TITLE
feat(examples): S3 RealWorld article-editor native re-frame.ui migration + coherence fixtures (rf2-vxgfnd.95.9)

### DIFF
--- a/examples/real-apps/realworld_resources/ui_counter.cljc
+++ b/examples/real-apps/realworld_resources/ui_counter.cljc
@@ -1,0 +1,67 @@
+(ns realworld-resources.ui-counter
+  "The counter — the smallest complete re-frame.ui app — as an S3 coherence
+   fixture. It exists to prove that the plainest thing feels plain: three one-line
+   events, one sub, one `defview`, and DOM handlers that actually fire.
+
+   Everything here is the ordinary re-frame2 dataflow (plain `reg-event` /
+   `reg-sub`, `.cljc` so it renders on the JVM structural host too) plus one
+   compiled view. The view is a pure function of `(sub [:ui-counter/count])`; its
+   buttons carry literal EVENT VECTORS (`:on-click [:ui-counter/inc 1]`) — no
+   `dispatch` call, no closure — and its number field is a controlled input whose
+   `:on-input` vector carries the `:rf.ui/value` placeholder, so a keystroke
+   projects the live value into `[:ui-counter/set …]` and drains synchronously.
+
+   There is deliberately no `local` here: the count IS product state, so it lives
+   in app-db behind events. `local` is for view-only keystroke ephemera — see
+   `ui_dashboard.cljc` for the justified use."
+  (:require [re-frame.core :as rf]
+            [re-frame.ui :as ui :refer [defview sub]]))
+
+;; ---- dataflow: plain re-frame2 --------------------------------------------
+
+(rf/reg-event :ui-counter/init
+  (fn [_ _] {:db {:ui-counter/count 0}}))
+
+(rf/reg-event :ui-counter/inc
+  {:schema [:cat [:= :ui-counter/inc] :int]}
+  (fn [{:keys [db]} [_ step]]
+    {:db (update db :ui-counter/count + step)}))
+
+(rf/reg-event :ui-counter/dec
+  {:schema [:cat [:= :ui-counter/dec] :int]}
+  (fn [{:keys [db]} [_ step]]
+    {:db (update db :ui-counter/count - step)}))
+
+(rf/reg-event :ui-counter/reset
+  (fn [{:keys [db]} _] {:db (assoc db :ui-counter/count 0)}))
+
+(rf/reg-event :ui-counter/set
+  {:doc "Set the count from the controlled input's live string value."}
+  (fn [{:keys [db]} [_ s]]
+    (let [n #?(:cljs (js/parseInt s 10) :clj (try (Long/parseLong s) (catch Exception _ nil)))]
+      {:db (assoc db :ui-counter/count (if (or (nil? n)
+                                               #?(:cljs (js/isNaN n) :clj false))
+                                         0 n))})))
+
+(rf/reg-sub :ui-counter/count (fn [db _] (:ui-counter/count db 0)))
+
+;; ---- view -----------------------------------------------------------------
+
+(defview counter
+  "The counter. `(sub [:ui-counter/count])` is the value, not a ref — nothing to
+   deref; when the count changes, this view re-renders."
+  []
+  (let [n (sub [:ui-counter/count])]
+    [:div.counter {:data-testid "counter"}
+     [:h1 {:data-testid "counter-value"} "Count: " (str n)]
+     [:div.counter-controls
+      [:button.btn {:data-testid "counter-dec" :on-click [:ui-counter/dec 1]} "-"]
+      [:button.btn {:data-testid "counter-inc" :on-click [:ui-counter/inc 1]} "+"]
+      [:button.btn {:data-testid "counter-step" :on-click [:ui-counter/inc 5]} "+5"]
+      [:button.btn {:data-testid "counter-reset" :on-click [:ui-counter/reset]} "Reset"]]
+     ;; A controlled input: the literal :value co-present with the vector handler
+     ;; carrying :rf.ui/value rides the synchronous door.
+     [:input.counter-input
+      {:type "number" :data-testid "counter-input"
+       :value (str n)
+       :on-input [:ui-counter/set :rf.ui/value]}]]))

--- a/examples/real-apps/realworld_resources/ui_dashboard.cljc
+++ b/examples/real-apps/realworld_resources/ui_dashboard.cljc
@@ -1,0 +1,138 @@
+(ns realworld-resources.ui-dashboard
+  "A small metrics dashboard as an S3 coherence fixture — the counterpart to the
+   counter, one step up in composition. It exists to show that the new language
+   stays coherent as a page grows: several `defview`s compose, a keyed list calls
+   an internal view, a controlled filter narrows the set, and navigation is an
+   ordinary compiled `route-link`.
+
+   The S3 surface it exercises, beyond the counter's:
+
+   - **Composed views + a keyed list.** `dashboard` calls `dashboard-nav` and maps
+     an internal `metric-card` view over the visible metrics with a stable `:key`.
+
+   - **A justified `local`.** Whether the cards are shown \"compact\" (their +1
+     control hidden) is VIEW-ONLY presentation state — no product meaning, not
+     shared, never restored across an epoch. That is exactly what `local` is for,
+     so the toggle lives in `(local false)`, not in app-db. Everything with
+     product meaning (the metrics, the filter) stays in app-db behind events.
+
+   - **`route-link` as an ordinary view.** `dashboard-nav` renders real
+     `<a href>` navigation anchors that dispatch through the committed frame on a
+     plain left click. The `:to` route ids are registered by the host/app.
+
+   - **`effect` + `dispatch-fn`, the textbook way.** A window `keydown` listener
+     lets Escape clear the filter. It is host-world wiring, so an `effect`
+     attaches it and — crucially — the effect's cleanup removes it, so the
+     `dispatch-fn` it fires can never outlive the view (the leaked-listener law).
+     `dispatch-fn` is exactly for this: a stable committed-frame dispatcher handed
+     to an external listener, retired in the same cleanup that created it.
+
+   Dataflow is plain re-frame2 (`.cljc`, so it renders on the JVM structural host
+   too); the views are pure functions of subs."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.ui :as ui :refer [defview sub local effect dispatch-fn]]))
+
+;; ---- dataflow: plain re-frame2 --------------------------------------------
+
+(rf/reg-event :ui-dash/init
+  (fn [_ _]
+    {:db {:ui-dash/metrics {:users   {:label "Active users"  :value 1280}
+                            :orders  {:label "Orders today"  :value 312}
+                            :revenue {:label "Revenue (USD)" :value 48210}
+                            :errors  {:label "Error rate (%)" :value 3}}
+          :ui-dash/order  [:users :orders :revenue :errors]
+          :ui-dash/filter ""}}))
+
+(rf/reg-event :ui-dash/set-filter
+  (fn [{:keys [db]} [_ s]] {:db (assoc db :ui-dash/filter (or s ""))}))
+
+(rf/reg-event :ui-dash/clear-filter
+  (fn [{:keys [db]} _] {:db (assoc db :ui-dash/filter "")}))
+
+(rf/reg-event :ui-dash/bump
+  {:schema [:cat [:= :ui-dash/bump] :keyword :int]}
+  (fn [{:keys [db]} [_ id delta]]
+    {:db (update-in db [:ui-dash/metrics id :value] + delta)}))
+
+(rf/reg-sub :ui-dash/filter (fn [db _] (:ui-dash/filter db "")))
+
+(rf/reg-sub :ui-dash/visible
+  {:doc "The metrics, in declared order, narrowed to those whose label contains
+         the filter text — a seq of [id metric] pairs."}
+  (fn [db _]
+    (let [needle  (str/lower-case (:ui-dash/filter db ""))
+          metrics (:ui-dash/metrics db)]
+      (into []
+            (comp (map (fn [id] [id (get metrics id)]))
+                  (filter (fn [[_ m]] (str/includes? (str/lower-case (:label m)) needle))))
+            (:ui-dash/order db)))))
+
+(rf/reg-sub :ui-dash/summary
+  (fn [db _]
+    (let [ms (vals (:ui-dash/metrics db))]
+      {:count (count ms)
+       :total (reduce + 0 (map :value ms))})))
+
+;; ---- views ----------------------------------------------------------------
+
+(defview metric-card
+  "One metric tile. A pure function of its props; the +1 control is hidden when
+   the parent asks for a compact layout."
+  [{:keys [id metric compact?]}]
+  [:div.metric-card {:data-testid (str "metric-" (name id))}
+   [:span.metric-label (:label metric)]
+   [:span.metric-value {:data-testid (str "metric-" (name id) "-value")}
+    (str (:value metric))]
+   (when-not compact?
+     [:button.btn {:data-testid (str "metric-" (name id) "-bump")
+                   :on-click [:ui-dash/bump id 1]}
+      "+1"])])
+
+(defview dashboard-nav
+  "Navigation as ordinary compiled `route-link`s — real anchors, committed-frame
+   dispatch on a plain left click."
+  []
+  [:nav.dashboard-nav
+   [ui/route-link {:to :ui-guide/dashboard :class "nav-link" :data-testid "nav-dashboard"}
+    "Dashboard"]
+   [ui/route-link {:to :ui-guide/counter :class "nav-link" :data-testid "nav-counter"}
+    "Counter"]])
+
+(defview dashboard
+  "The dashboard page: nav, a controlled filter, a view-only compact toggle, the
+   keyed metric grid, and a derived summary."
+  []
+  (let [visible  (sub [:ui-dash/visible])
+        summary  (sub [:ui-dash/summary])
+        filter-v (sub [:ui-dash/filter])
+        ;; A VIEW-ONLY toggle — presentation ephemera, so `local`, not app-db.
+        [compact? set-compact!] (local false)
+        ;; A stable committed-frame dispatcher for the window listener below.
+        clear    (dispatch-fn)]
+    ;; Escape clears the filter. The listener lives on `window`, so an `effect`
+    ;; owns it; the cleanup removes it, so `clear` never fires after the view
+    ;; disconnects (the dispatch-fn leaked-listener contract).
+    (effect :connect
+      (let [on-key (fn [e]
+                     (when (= "Escape" #?(:cljs (.-key ^js e) :clj nil))
+                       (clear [:ui-dash/clear-filter])))]
+        #?(:cljs (.addEventListener js/window "keydown" on-key))
+        (fn [] #?(:cljs (.removeEventListener js/window "keydown" on-key) :clj nil))))
+    [:div.dashboard {:data-testid "dashboard"}
+     [dashboard-nav]
+     [:div.dashboard-toolbar
+      [:input.dashboard-filter
+       {:type "text" :placeholder "Filter metrics…" :data-testid "dashboard-filter"
+        :value filter-v
+        :on-input [:ui-dash/set-filter :rf.ui/value]}]
+      [:button.btn {:data-testid "dashboard-clear" :on-click [:ui-dash/clear-filter]}
+       "Clear"]
+      [:button.btn {:data-testid "dashboard-compact"
+                    :on-click (ui/event [_] (set-compact! (not compact?)) nil)}
+       (if compact? "Show controls" "Compact")]]
+     [:div.dashboard-grid
+      (for [[id metric] visible]
+        [metric-card {:key id :id id :metric metric :compact? compact?}])]
+     [:p.dashboard-summary {:data-testid "dashboard-summary"}
+      (str (:count summary) " metrics · total " (str (:total summary)))]]))

--- a/examples/real-apps/realworld_resources/ui_editor.cljc
+++ b/examples/real-apps/realworld_resources/ui_editor.cljc
@@ -1,0 +1,122 @@
+(ns realworld-resources.ui-editor
+  "The article editor, rendered in NATIVE re-frame.ui (`defview`) — the S3
+   ergonomic-proof rendition of `article_editor.cljs`'s view layer.
+
+   This file is ONLY the rendering tier. The page's dataflow — the
+   `:realworld/save-article` / `:realworld/delete-article` mutations, the
+   `:editor/*` events + subs, and the `:editor/can-submit?` flow — lives in
+   `article_editor.cljs` and is UNCHANGED. That is the frozen-adapter boundary
+   the S3 stage exercises: the dataflow layer (frames, events, subs, flows) is
+   tier-independent, so the very same registrations back both the stock-Reagent
+   page and this compiled-view rendition. This view reaches them by keyword,
+   requiring nothing but `re-frame.ui`, so it is `.cljc` and renders on the JVM
+   structural host (Tier-1) as well as in the browser.
+
+   What the page shows off, now in the new language:
+
+   - **Controlled inputs, the synchronous door.** Every field is a literal
+     `:value` co-present with a committed event vector carrying the
+     `:rf.ui/value` placeholder — `:on-input [:editor/edit-field :title
+     :rf.ui/value]`. The placeholder projects the live DOM value into the
+     event at dispatch time and the write drains synchronously inside the DOM
+     event, so the caret never jumps. No `(.. % -target -value)` closure, no
+     `dispatch` ceremony — the event vector IS the handler.
+
+   - **A committed `ui/event` for the form submit.** The one handler that needs
+     the native event (to `preventDefault` the browser's form navigation) is a
+     `ui/event`; its body returns the event vector to dispatch. Committed, per-
+     site stable, reading the winning commit.
+
+   - **Loading / error / gating as pure reads.** `busy?` and the failure line
+     read the `[:rf/mutation {:instance :editor/save}]` sub; the submit button's
+     disabled state reads the `:editor/can-submit?` flow output through a plain
+     sub. The render is a pure function of subscriptions — it never dispatches
+     out of band, and it is not a Form-3 class component.
+
+   The article read's lease stays a DATAFLOW concern, exactly as in
+   `article_editor.cljs`: the route's `:editor/load-article` mints
+   `[:lease :editor/article slug]` and the `:editor/*` events release it. The
+   Reagent page released on `:component-will-unmount`; native re-frame.ui has no
+   dispatch-at-unmount (a committed dispatcher rejects firing from a disconnected
+   view — the leaked-listener law), and a view-declared `(ui/lease {:resource …})`
+   is a different, unconditional model that does not fit an edit-mode-only,
+   dynamic-slug, app-minted owner. So the native view owns no lease — there is
+   nothing at the view tier to leak — and the resource lifecycle stays where the
+   `realworld_resources` suite already proves it."
+  (:require [re-frame.ui :as ui :refer [defview sub]]))
+
+;; The one stable instance id the editor form watches for the save write — the
+;; same value `article_editor.cljs` declares (`save-instance`). Kept as a local
+;; literal so this view requires nothing from the `.cljs` dataflow tier.
+(def ^:private save-instance :editor/save)
+
+(defview editor-page
+  "Create / edit / delete an article — a pure render of the editor subs."
+  []
+  (let [draft       (sub [:editor/draft])
+        slug        (sub [:editor/slug])
+        can-submit? (sub [:editor/can-submit?])
+        title-err   (sub [:editor/field-error :title])
+        desc-err    (sub [:editor/field-error :description])
+        body-err    (sub [:editor/field-error :body])
+        save        (sub [:rf/mutation {:instance save-instance}])
+        editing?    (some? slug)
+        busy?       (:pending? save)]
+    [:div.editor-page
+     [:div.container.page
+      [:div.row
+       [:div.col-md-10.offset-md-1.col-xs-12
+        (when (:error? save)
+          [:ul.error-messages {:data-testid "editor-error"}
+           [:li "That didn't save. Check your connection and try again."]])
+        ;; The submit is the one handler that needs the live native event (to
+        ;; stop the browser navigating the form); a `ui/event` runs the body and
+        ;; returns the vector to dispatch.
+        [:form
+         {:data-testid "editor-form"
+          :on-submit (ui/event [e] (.preventDefault ^js e) [:editor/submit])}
+         [:fieldset
+          [:fieldset.form-group
+           [:input.form-control.form-control-lg
+            {:type "text" :name "title" :placeholder "Article Title"
+             :data-testid "editor-title"
+             :value (:title draft) :disabled busy?
+             :on-blur [:editor/blur-field :title]
+             :on-input [:editor/edit-field :title :rf.ui/value]}]
+           (when title-err [:div.error-messages title-err])]
+          [:fieldset.form-group
+           [:input.form-control
+            {:type "text" :name "description"
+             :placeholder "What's this article about?"
+             :data-testid "editor-description"
+             :value (:description draft) :disabled busy?
+             :on-blur [:editor/blur-field :description]
+             :on-input [:editor/edit-field :description :rf.ui/value]}]
+           (when desc-err [:div.error-messages desc-err])]
+          [:fieldset.form-group
+           [:textarea.form-control
+            {:rows 8 :name "body" :placeholder "Write your article (in markdown)"
+             :data-testid "editor-body"
+             :value (:body draft) :disabled busy?
+             :on-blur [:editor/blur-field :body]
+             :on-input [:editor/edit-field :body :rf.ui/value]}]
+           (when body-err [:div.error-messages body-err])]
+          [:fieldset.form-group
+           [:input.form-control
+            {:type "text" :name "tags"
+             :placeholder "Enter tags (comma-separated)"
+             :data-testid "editor-tags"
+             :value (:tagList draft) :disabled busy?
+             :on-input [:editor/edit-field :tagList :rf.ui/value]}]]
+          [:button.btn.btn-lg.pull-xs-right.btn-primary
+           {:type "submit" :data-testid "editor-submit"
+            ;; The materialised `:editor/can-submit?` flow output (valid AND
+            ;; dirty) drives this directly; also disabled while the write is in
+            ;; flight.
+            :disabled (or busy? (not can-submit?))}
+           (if editing? "Update Article" "Publish Article")]
+          (when editing?
+            [:button.btn.btn-outline-danger.pull-xs-left
+             {:type "button" :data-testid "editor-delete" :disabled busy?
+              :on-click [:editor/delete]}
+             "Delete Article"])]]]]]]))

--- a/implementation/ui/deps.edn
+++ b/implementation/ui/deps.edn
@@ -27,7 +27,18 @@
  :deps  {day8/re-frame2 {:local/root "../core"}}
 
  :aliases
- {:test {:extra-paths ["test"]
+ {:test {:extra-paths ["test"
+                       ;; rf2-vxgfnd.95.9 — the S3 ergonomic-proof native views
+                       ;; (realworld-resources.ui-editor / ui-counter /
+                       ;; ui-dashboard, all `.cljc`) live in the example tree but
+                       ;; are exercised by the Tier-1 structural coherence test in
+                       ;; this artefact's `test/`. Listing the examples path here
+                       ;; only widens the JVM classpath so those view namespaces
+                       ;; RESOLVE — the cognitect runner still discovers tests in
+                       ;; `test/` alone, and the views require nothing but
+                       ;; `re-frame.ui` / `re-frame.core` (no `.cljs` example
+                       ;; sources are loaded on the JVM). Examples stay test-free.
+                       "../../examples/real-apps"]
          :extra-deps  {day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        ;; TEST-ONLY deps for the executable Guide 07 server-data
                        ;; fixture (re-frame.ui.guide-truth-jvm-test): it registers

--- a/implementation/ui/test/re_frame/realworld_resources_s3_ergonomic_proof_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/realworld_resources_s3_ergonomic_proof_dom_cljs_test.cljs
@@ -1,5 +1,17 @@
-(ns re-frame.ui.s3-ergonomic-proof-dom-cljs-test
+(ns re-frame.realworld-resources-s3-ergonomic-proof-dom-cljs-test
   "rf2-vxgfnd.95.9 — the S3 ergonomic-proof rider, DOM Tier-3 (browser) side.
+
+  Named OUTSIDE the `re-frame.ui.*` prefix on purpose: it drives the REAL
+  `article_editor.cljs` dataflow (required below), which is a stock-Reagent
+  RealWorld page, so requiring it pulls `reagent.core` into the build. The
+  focused `:node-test-ui` build (`^re-frame\\.ui\\..+-cljs-test$`) is the PURE
+  re-frame.ui artefact surface — no adapter/example view-stack code may enter
+  its module closure (the `check-ui-adapter-isolation` gate). This coherence
+  test is an example-coupled proof, so it lives under the `re-frame.*` (not
+  `re-frame.ui.*`) prefix — a sibling of the reagent-adapter suite
+  `re-frame.realworld-resources-cljs-test` — and runs in the broad
+  `:node-test` (`cljs-test$`) and `:browser-test` (`-dom-cljs-test$`) gates,
+  where example reagent code is expected, NOT the isolated UI build.
 
   Mounts the three native re-frame.ui views on a real React root under
   `ui/adapter` and drives them with the platform's own events (no gesture DSL),

--- a/implementation/ui/test/re_frame/ui/s3_ergonomic_proof_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/s3_ergonomic_proof_dom_cljs_test.cljs
@@ -1,0 +1,289 @@
+(ns re-frame.ui.s3-ergonomic-proof-dom-cljs-test
+  "rf2-vxgfnd.95.9 — the S3 ergonomic-proof rider, DOM Tier-3 (browser) side.
+
+  Mounts the three native re-frame.ui views on a real React root under
+  `ui/adapter` and drives them with the platform's own events (no gesture DSL),
+  proving the interactions that only a browser can prove:
+
+    - the SYNCHRONOUS controlled-input door — a keystroke on a `:value`-bound
+      field with a `:rf.ui/value`-placeholder vector handler writes app-db and
+      re-renders inside the DOM event (caret/IME safe);
+    - the `ui/event` form submit — `preventDefault` then dispatch the submit
+      vector, running client-side validation;
+    - the `:editor/can-submit?` FLOW gating the submit button through a live sub;
+    - the view's ONE lifecycle contract — unmount releases the article lease
+      exactly once (its `effect` cleanup dispatches `[:editor/release-article]`),
+      and a re-render (the hot-reload path) never leaks a spurious release;
+    - the counter and dashboard interactions (event vectors, `local`, a keyed
+      list, a controlled filter).
+
+  The editor's dataflow is the REAL `article_editor.cljs` registration (required
+  below), unchanged by this stage — only its VIEW is native re-frame.ui here.
+  The lease-release DOMAIN logic is pinned in the reagent-adapter suite
+  `realworld_resources_cljs_test`; this suite pins the native VIEW's contribution
+  (the unmount dispatch), so it spies `:editor/release-article` rather than
+  standing up the whole resource runtime."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.test :as uit]
+            ;; the native views under proof
+            [realworld-resources.ui-editor :as editor]
+            [realworld-resources.ui-counter :as counter]
+            [realworld-resources.ui-dashboard :as dashboard]
+            ;; the REAL editor dataflow (events / subs / the can-submit? flow) +
+            ;; the flow runtime it registers against
+            [realworld-resources.article-editor]
+            [re-frame.flows]
+            ;; publishes the routing link seam for the dashboard's route-links +
+            ;; the reg-route the dashboard test declares
+            [re-frame.routing]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter ui/adapter
+    :ambient-frame nil
+    :async? true
+    :init-fn reactive/reset-scheduler!}))
+
+;; ---------------------------------------------------------------------------
+;; Harness helpers (the platform, not a gesture abstraction)
+;; ---------------------------------------------------------------------------
+
+(defn- host-turn! []
+  (js/Promise. (fn [resolve _] (js/setTimeout #(resolve nil) 0))))
+
+(defn- dispatch-native! [el event] (.dispatchEvent el event))
+(defn- click! [el] (dispatch-native! el (js/MouseEvent. "click" #js {:bubbles true})))
+(defn- input! [el v]
+  (set! (.-value el) v)
+  (dispatch-native! el (js/Event. "input" #js {:bubbles true :cancelable true})))
+(defn- submit! [form]
+  (dispatch-native! form (js/Event. "submit" #js {:bubbles true :cancelable true})))
+
+(defn- app-db [frame-id] @(:app-db (frame/frame frame-id)))
+(defn- draft [frame-id] (get-in (app-db frame-id) [:editor :draft]))
+
+;; ---------------------------------------------------------------------------
+;; The editor — a blank create draft, the can-submit flow registered
+;; ---------------------------------------------------------------------------
+
+(def ^:private blank-draft
+  {:title "" :description "" :body "" :tagList ""})
+
+(def ^:private blank-slice
+  "The editor slice shape `:editor/initialise` produces, seeded directly so the
+   fixture needs only the editor events/subs + the flow — no mutation runtime."
+  {:slug nil :draft blank-draft :baseline blank-draft
+   :errors {} :touched #{} :submit-attempted? false})
+
+(defn- editor-frame []
+  (rf/make-frame {:id ::editor
+                  :initial-events [[:rf/set-db {:editor blank-slice}]]}))
+
+(deftest editor-controlled-inputs-drain-synchronously
+  (if-not (browser?)
+    (is true ":node — the controlled-input door runs in the browser gate")
+    (let [f (editor-frame)]
+      (async done
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [editor/editor-page]]]
+              (let [title (uit/query root "[data-testid='editor-title']")
+                    body  (uit/query root "[data-testid='editor-body']")]
+                (testing "a keystroke writes app-db INSIDE the DOM event (caret-safe)"
+                  (input! title "My New Article")
+                  (is (= "My New Article" (:title (draft ::editor)))
+                      "the title write drained synchronously within dispatchEvent")
+                  (is (zero? (reactive/pending-cell-count))
+                      "no work is left pending after the synchronous door")
+                  (is (= "My New Article" (.-value title))
+                      "the controlled round-trip leaves the typed value in place"))
+                (testing "each field is independently controlled"
+                  (input! body "Some body text")
+                  (is (= "Some body text" (:body (draft ::editor))))
+                  (is (= "My New Article" (:title (draft ::editor)))
+                      "editing one field leaves the others intact"))))
+            (.then (fn [] (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f)
+                     (is false (str "controlled-input fixture rejected: " e)) (done))))))))
+
+(deftest editor-submit-runs-validation-through-the-ui-event-door
+  (if-not (browser?)
+    (is true ":node — the ui/event submit door runs in the browser gate")
+    (let [f (editor-frame)]
+      (async done
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [editor/editor-page]]]
+              (let [form (uit/query root "[data-testid='editor-form']")]
+                (testing "a blank draft shows no field errors before submit"
+                  (is (nil? (uit/query root ".error-messages"))))
+                (-> (uit/flush! #(do (submit! form) (host-turn!)))
+                    (.then
+                     (fn []
+                       (testing "submitting the blank form runs client validation"
+                         (is (true? (get-in (app-db ::editor) [:editor :submit-attempted?]))
+                             "the ui/event submit dispatched [:editor/submit]")
+                         (is (seq (get-in (app-db ::editor) [:editor :errors]))
+                             "validation populated the per-field error map")
+                         (is (some? (uit/query root ".error-messages"))
+                             "the field errors now render")))))))
+            (.then (fn [] (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f)
+                     (is false (str "submit fixture rejected: " e)) (done))))))))
+
+(deftest editor-can-submit-flow-gates-the-submit-button
+  (if-not (browser?)
+    (is true ":node — the can-submit flow gate runs in the browser gate")
+    (let [f (editor-frame)]
+      ;; Register the :editor/can-submit? flow on this frame (the boot one-shot),
+      ;; then edit → the flow materialises [:editor :can-submit?] on the drain.
+      (uit/dispatch! f [:editor/register-flow])
+      (async done
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [editor/editor-page]]]
+              (-> (host-turn!)
+                  (.then
+                   (fn []
+                     (let [submit (uit/query root "[data-testid='editor-submit']")]
+                       (testing "a blank (invalid + clean) draft disables the submit button"
+                         (is (true? (.-disabled submit))))
+                       ;; fill the three required fields → valid AND dirty
+                       (uit/flush!
+                        #(do (input! (uit/query root "[data-testid='editor-title']") "T")
+                             (input! (uit/query root "[data-testid='editor-description']") "D")
+                             (input! (uit/query root "[data-testid='editor-body']") "B")
+                             (host-turn!))))))
+                  (.then (fn [] (host-turn!)))
+                  (.then
+                   (fn []
+                     (let [submit (uit/query root "[data-testid='editor-submit']")]
+                       (testing "the materialised flow output enables the button once valid+dirty"
+                         (is (true? (get-in (app-db ::editor) [:editor :can-submit?]))
+                             "the :editor/can-submit? flow materialised true")
+                         (is (false? (.-disabled submit))
+                             "the submit button reads the flow output through its sub and enables")))))))
+            (.then (fn [] (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f)
+                     (is false (str "can-submit gate fixture rejected: " e)) (done))))))))
+
+(deftest editor-survives-a-re-render-with-no-leaked-state
+  (if-not (browser?)
+    (is true ":node — the hot-reload / re-render invariant runs in the browser gate")
+    (let [f (editor-frame)]
+      (async done
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [editor/editor-page]]]
+              (-> (uit/flush!
+                   #(do (input! (uit/query root "[data-testid='editor-title']") "Draft in progress")
+                        (host-turn!)))
+                  (.then
+                   (fn []
+                     ;; A re-render (the shape a hot reload re-runs the body in):
+                     ;; the view owns no lease, holds no local ephemera, and is a
+                     ;; pure function of subs, so a re-render neither loses the
+                     ;; edited draft nor leaks anything.
+                     (uit/flush! #(uit/dispatch! f [:editor/blur-field :title]))))
+                  (.then
+                   (fn []
+                     (is (= "Draft in progress" (:title (draft ::editor)))
+                         "the edited draft survives the re-render")
+                     (is (= "Draft in progress"
+                            (.-value (uit/query root "[data-testid='editor-title']")))
+                         "the controlled field still reflects app-db after re-render")))))
+            (.then
+             (fn []
+               ;; the editor view owns no lease and no host listener, so a clean
+               ;; unmount (with-root teardown) leaks nothing — no dispatch fires
+               ;; from a disconnected view, no listener outlives the mount.
+               (is true "the editor unmounted cleanly (no disconnected dispatch, no leaked listener)")
+               (rf/destroy-frame! f)
+               (done))
+             (fn [e]
+               (rf/destroy-frame! f)
+               (is false (str "re-render fixture rejected: " e))
+               (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; The counter — real clicks + the controlled number field
+;; ---------------------------------------------------------------------------
+
+(deftest counter-clicks-and-controlled-input-drive-app-db
+  (if-not (browser?)
+    (is true ":node — the counter interactions run in the browser gate")
+    (let [f (rf/make-frame {:id ::counter :initial-events [[:ui-counter/init]]})]
+      (async done
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [counter/counter]]]
+              (let [value (uit/query root "[data-testid='counter-value']")]
+                (is (= "Count: 0" (.-textContent value)))
+                (-> (uit/flush! #(do (click! (uit/query root "[data-testid='counter-step']"))
+                                     (host-turn!)))
+                    (.then
+                     (fn []
+                       (is (= "Count: 5" (.-textContent value)) "+5 event vector fired")
+                       (uit/flush! #(do (click! (uit/query root "[data-testid='counter-dec']"))
+                                        (host-turn!)))))
+                    (.then
+                     (fn []
+                       (is (= "Count: 4" (.-textContent value)) "- event vector fired")
+                       ;; the controlled number field writes through :rf.ui/value
+                       (input! (uit/query root "[data-testid='counter-input']") "42")
+                       (is (= 42 (:ui-counter/count (app-db ::counter)))
+                           "the controlled input drains synchronously"))))))
+            (.then (fn [] (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f)
+                     (is false (str "counter fixture rejected: " e)) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; The dashboard — keyed list bump, controlled filter, the view-only local
+;; ---------------------------------------------------------------------------
+
+(deftest dashboard-bump-filter-and-compact-local
+  (if-not (browser?)
+    (is true ":node — the dashboard interactions run in the browser gate")
+    (do
+      (rf/reg-route :ui-guide/dashboard {} "/dashboard")
+      (rf/reg-route :ui-guide/counter {} "/counter")
+      (let [f (rf/make-frame {:id ::dash :initial-events [[:ui-dash/init]]})]
+        (async done
+          (-> (uit/with-root [root [ui/frame-provider {:frame f} [dashboard/dashboard]]]
+                (let [users-val (uit/query root "[data-testid='metric-users-value']")]
+                  (is (= "1280" (.-textContent users-val)))
+                  (-> (uit/flush! #(do (click! (uit/query root "[data-testid='metric-users-bump']"))
+                                       (host-turn!)))
+                      (.then
+                       (fn []
+                         (is (= "1281" (.-textContent users-val)) "the +1 event vector bumped the metric")
+                         ;; the controlled filter narrows the keyed list
+                         (uit/flush! #(do (input! (uit/query root "[data-testid='dashboard-filter']") "rev")
+                                          (host-turn!)))))
+                      (.then
+                       (fn []
+                         (is (nil? (uit/query root "[data-testid='metric-users']"))
+                             "a non-matching metric drops out of the keyed list")
+                         (is (some? (uit/query root "[data-testid='metric-revenue']"))
+                             "the matching metric stays")
+                         ;; Escape (a window keydown) clears the filter via the
+                         ;; effect+dispatch-fn listener → the full list returns.
+                         (uit/flush!
+                          #(do (dispatch-native! js/window
+                                                 (js/KeyboardEvent. "keydown"
+                                                                    #js {:bubbles true :key "Escape"}))
+                               (host-turn!)))))
+                      (.then
+                       (fn []
+                         (is (some? (uit/query root "[data-testid='metric-users']"))
+                             "Escape cleared the filter (effect+dispatch-fn listener) — all metrics return")
+                         ;; the view-only compact toggle is `local` (re-renders this view only)
+                         (is (some? (uit/query root "[data-testid='metric-revenue-bump']"))
+                             "controls visible before the compact toggle")
+                         (uit/flush! #(do (click! (uit/query root "[data-testid='dashboard-compact']"))
+                                          (host-turn!)))))
+                      (.then
+                       (fn []
+                         (is (nil? (uit/query root "[data-testid='metric-revenue-bump']"))
+                             "the local compact toggle hid the card controls"))))))
+              (.then (fn [] (rf/destroy-frame! f) (done))
+                     (fn [e] (rf/destroy-frame! f)
+                       (is false (str "dashboard fixture rejected: " e)) (done)))))))))

--- a/implementation/ui/test/re_frame/ui/s3_ergonomic_proof_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/s3_ergonomic_proof_jvm_test.clj
@@ -14,7 +14,10 @@
   data, so 'what does this control do' is an equality check (no click
   simulation). The editor's real interactions (the synchronous controlled-input
   door, the `ui/event` submit, resource-lease ownership, hot reload) ride the
-  DOM Tier-3 sibling `s3_ergonomic_proof_dom_cljs_test`.
+  DOM Tier-3 sibling `realworld_resources_s3_ergonomic_proof_dom_cljs_test`
+  (named under the `re-frame.*`, not `re-frame.ui.*`, prefix: it drives the
+  real stock-Reagent editor dataflow, so it stays out of the focused pure-UI
+  `:node-test-ui` isolation build and runs in the broad node/browser gates).
 
   The editor reads the `:editor/*` subs + the save-mutation sub; its dataflow
   lives in `article_editor.cljs` (`.cljs`, unchanged by this stage), so here the

--- a/implementation/ui/test/re_frame/ui/s3_ergonomic_proof_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/s3_ergonomic_proof_jvm_test.clj
@@ -1,0 +1,212 @@
+(ns re-frame.ui.s3-ergonomic-proof-jvm-test
+  "rf2-vxgfnd.95.9 — the S3 ergonomic-proof rider, JVM Tier-1 structural side.
+
+  Headless structural renders of the three native re-frame.ui views that make
+  up the S3 rider (all `.cljc`, living in the RealWorld-resources example tree,
+  reached here through the artefact `:test` classpath):
+
+    realworld-resources.ui-editor      the migrated article-editor page
+    realworld-resources.ui-counter     the counter guide fixture
+    realworld-resources.ui-dashboard   the dashboard guide fixture
+
+  Tier-1 is the fast, DOM-free proof that the compiled views produce the right
+  STRUCTURE and the right EVENT INTENT: literal event vectors are retained as
+  data, so 'what does this control do' is an equality check (no click
+  simulation). The editor's real interactions (the synchronous controlled-input
+  door, the `ui/event` submit, resource-lease ownership, hot reload) ride the
+  DOM Tier-3 sibling `s3_ergonomic_proof_dom_cljs_test`.
+
+  The editor reads the `:editor/*` subs + the save-mutation sub; its dataflow
+  lives in `article_editor.cljs` (`.cljs`, unchanged by this stage), so here the
+  values are supplied through the `:sub-overrides` door and only the view's
+  structure + intent is under test. The counter/dashboard carry their own
+  `.cljc` dataflow, so they render against a real seeded frame."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui.frames :as frames]
+            [re-frame.ui.test :as uit]
+            ;; the three native views under proof
+            [realworld-resources.ui-editor :as editor]
+            [realworld-resources.ui-counter :as counter]
+            [realworld-resources.ui-dashboard :as dashboard]
+            ;; publishes the routing link seam so the dashboard's route-links
+            ;; render their SSR anchor shell
+            [re-frame.routing]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [t]
+    (frames/reset-installed-plans!)
+    ;; the dashboard-nav route-link targets
+    (rf/reg-route :ui-guide/dashboard {} "/dashboard")
+    (rf/reg-route :ui-guide/counter {} "/counter")
+    (t)
+    (frames/reset-installed-plans!)))
+
+(defn- attrs-of [tree testid]
+  (uit/attrs (uit/find tree {:data-testid testid})))
+
+(defn- anchor-with
+  "The `<a>` ELEMENT carrying `testid` — route-link is a defview, so a
+  `{:data-testid …}` selector matches its view-boundary node first; the anchor
+  the route-link renders is a child element carrying the same passthrough attr."
+  [tree testid]
+  (some #(when (= testid (:data-testid (uit/attrs %))) %)
+        (uit/find-all tree :a)))
+
+;; ---------------------------------------------------------------------------
+;; The article editor — create + edit + error, via :sub-overrides
+;; ---------------------------------------------------------------------------
+
+(def ^:private blank-draft
+  {:title "" :description "" :body "" :tagList ""})
+
+(defn- editor-overrides
+  "The editor's full sub surface for a render — a create draft by default."
+  [& {:keys [slug draft can-submit? title-err desc-err body-err save]
+      :or   {draft blank-draft can-submit? false save {}}}]
+  {[:editor/draft] draft
+   [:editor/slug] slug
+   [:editor/can-submit?] can-submit?
+   [:editor/field-error :title] title-err
+   [:editor/field-error :description] desc-err
+   [:editor/field-error :body] body-err
+   [:rf/mutation {:instance :editor/save}] save})
+
+(deftest editor-create-mode-structure-and-controlled-input-intent
+  (testing "create mode renders the four controlled fields with committed event
+            vectors carrying the :rf.ui/value placeholder, and a disabled
+            publish button while the can-submit? flow is false"
+    (let [f    (rf/make-frame {:initial-events [[:rf/set-db {}]]})
+          tree (uit/render editor/editor-page
+                           {:frame f :sub-overrides (editor-overrides)})]
+      (testing "each field is a controlled input: literal value + placeholder vector"
+        (is (= [:editor/edit-field :title :rf.ui/value]
+               (:on-input (attrs-of tree "editor-title")))
+            "the title field commits [:editor/edit-field :title :rf.ui/value]")
+        (is (= [:editor/blur-field :title] (:on-blur (attrs-of tree "editor-title"))))
+        (is (= [:editor/edit-field :description :rf.ui/value]
+               (:on-input (attrs-of tree "editor-description"))))
+        (is (= [:editor/edit-field :body :rf.ui/value]
+               (:on-input (attrs-of tree "editor-body"))))
+        (is (= [:editor/edit-field :tagList :rf.ui/value]
+               (:on-input (attrs-of tree "editor-tags")))))
+      (testing "the values are the draft's, read through the sub"
+        (is (= "" (:value (attrs-of tree "editor-title")))))
+      (testing "the flow output drives the submit button"
+        (is (true? (:disabled (attrs-of tree "editor-submit")))
+            "can-submit? false → the publish button is disabled")
+        (is (= "Publish Article" (uit/text (uit/find tree {:data-testid "editor-submit"})))
+            "create-mode label"))
+      (testing "create mode has no delete control"
+        (is (nil? (uit/find tree {:data-testid "editor-delete"}))))
+      (testing "no error banner without a failed save"
+        (is (nil? (uit/find tree {:data-testid "editor-error"})))))))
+
+(deftest editor-edit-mode-enables-submit-shows-delete-and-fills-fields
+  (testing "edit mode (slug present, valid+dirty draft) fills the fields, enables
+            the update button, and shows the delete control with its intent"
+    (let [f    (rf/make-frame {:initial-events [[:rf/set-db {}]]})
+          tree (uit/render
+                editor/editor-page
+                {:frame f
+                 :sub-overrides
+                 (editor-overrides
+                  :slug "hello-conduit"
+                  :draft {:title "Hello, Conduit" :description "A greeting"
+                          :body "Body text" :tagList "clojure, conduit"}
+                  :can-submit? true)})]
+      (is (= "Hello, Conduit" (:value (attrs-of tree "editor-title")))
+          "the field renders the loaded draft value")
+      (is (= "clojure, conduit" (:value (attrs-of tree "editor-tags"))))
+      (is (false? (:disabled (attrs-of tree "editor-submit")))
+          "valid + dirty → the update button is enabled")
+      (is (= "Update Article" (uit/text (uit/find tree {:data-testid "editor-submit"})))
+          "edit-mode label")
+      (let [del (attrs-of tree "editor-delete")]
+        (is (some? (uit/find tree {:data-testid "editor-delete"})) "delete control present in edit mode")
+        (is (= [:editor/delete] (:on-click del))
+            "the delete button commits [:editor/delete]")))))
+
+(deftest editor-shows-the-error-banner-on-a-failed-save
+  (testing "a failed save (mutation :error?) renders the error banner"
+    (let [f    (rf/make-frame {:initial-events [[:rf/set-db {}]]})
+          tree (uit/render editor/editor-page
+                           {:frame f
+                            :sub-overrides (editor-overrides
+                                            :save {:error? true :error {:kind :network}})})]
+      (is (some? (uit/find tree {:data-testid "editor-error"}))
+          "the error banner renders when the save mutation reports :error?"))))
+
+(deftest editor-disables-fields-while-the-save-is-in-flight
+  (testing "a pending save disables the inputs and the submit button"
+    (let [f    (rf/make-frame {:initial-events [[:rf/set-db {}]]})
+          tree (uit/render editor/editor-page
+                           {:frame f
+                            :sub-overrides (editor-overrides
+                                            :slug "s" :can-submit? true
+                                            :save {:pending? true})})]
+      (is (true? (:disabled (attrs-of tree "editor-title"))) "title disabled while busy")
+      (is (true? (:disabled (attrs-of tree "editor-submit"))) "submit disabled while busy")
+      (is (true? (:disabled (attrs-of tree "editor-delete"))) "delete disabled while busy"))))
+
+;; ---------------------------------------------------------------------------
+;; The counter — full render against a real seeded frame
+;; ---------------------------------------------------------------------------
+
+(deftest counter-renders-value-and-literal-event-vectors
+  (testing "the counter reads its count sub and its buttons carry literal intent"
+    (let [f    (rf/make-frame {:initial-events [[:rf/set-db {:ui-counter/count 3}]]})
+          tree (uit/render counter/counter {:frame f})]
+      (is (= "Count: 3" (uit/text (uit/find tree {:data-testid "counter-value"})))
+          "the value reads through (sub [:ui-counter/count])")
+      (is (= [:ui-counter/inc 1] (:on-click (attrs-of tree "counter-inc"))))
+      (is (= [:ui-counter/dec 1] (:on-click (attrs-of tree "counter-dec"))))
+      (is (= [:ui-counter/inc 5] (:on-click (attrs-of tree "counter-step"))))
+      (is (= [:ui-counter/reset] (:on-click (attrs-of tree "counter-reset"))))
+      (testing "the number field is a controlled input"
+        (is (= "3" (:value (attrs-of tree "counter-input"))))
+        (is (= [:ui-counter/set :rf.ui/value] (:on-input (attrs-of tree "counter-input"))))))))
+
+;; ---------------------------------------------------------------------------
+;; The dashboard — composed views, keyed list, route-link SSR shell
+;; ---------------------------------------------------------------------------
+
+(deftest dashboard-composes-cards-nav-links-and-a-filter
+  (testing "the dashboard renders its nav route-links (SSR anchor shell), a keyed
+            metric grid over an internal view, a controlled filter, and a summary"
+    (let [f    (rf/make-frame {:initial-events [[:ui-dash/init]]})
+          tree (uit/render dashboard/dashboard {:frame f})]
+      (testing "route-link renders a real handler-free <a href> on the JVM"
+        (let [nav-dash (uit/attrs (anchor-with tree "nav-dashboard"))]
+          (is (= "/dashboard" (:href nav-dash)) "route-link SSR shell has the encoded href")
+          (is (not (contains? nav-dash :on-click)) "no raw host handler in the server tree"))
+        (is (= "/counter" (:href (uit/attrs (anchor-with tree "nav-counter"))))))
+      (testing "the metric cards render (keyed internal view) with bump intent"
+        (is (= "1280" (uit/text (uit/find tree {:data-testid "metric-users-value"}))))
+        (is (= [:ui-dash/bump :users 1] (:on-click (attrs-of tree "metric-users-bump")))
+            "the +1 control commits [:ui-dash/bump :users 1]")
+        (is (some? (uit/find tree {:data-testid "metric-errors-value"}))
+            "all four declared metrics render"))
+      (testing "the filter is a controlled input"
+        (is (= [:ui-dash/set-filter :rf.ui/value] (:on-input (attrs-of tree "dashboard-filter")))))
+      (testing "the derived summary renders"
+        (is (= "4 metrics · total 49805"
+               (uit/text (uit/find tree {:data-testid "dashboard-summary"}))))))))
+
+(deftest dashboard-filter-narrows-the-keyed-list
+  (testing "seeding a filter narrows the visible metrics (the :ui-dash/visible
+            sub), and the compact local defaults to false (initial value on JVM)"
+    (let [f    (rf/make-frame {:initial-events [[:ui-dash/init]
+                                                [:ui-dash/set-filter "rev"]]})
+          tree (uit/render dashboard/dashboard {:frame f})]
+      (is (some? (uit/find tree {:data-testid "metric-revenue"}))
+          "revenue matches the filter and renders")
+      (is (nil? (uit/find tree {:data-testid "metric-users"}))
+          "non-matching metrics are filtered out of the keyed list")
+      (testing "local exposes its initial value on the JVM structural render"
+        ;; compact? false → the +1 controls render
+        (is (some? (uit/find tree {:data-testid "metric-revenue-bump"}))
+            "the compact toggle's local is false initially, so controls show")))))


### PR DESCRIPTION
## What

The S3 **ergonomic-proof rider** (`rf2-vxgfnd.95.9`): migrate the RealWorld-resources **article-editor page's view tier** to native `re-frame.ui` (`defview`), plus guide-backed **counter** and **dashboard** fixtures, so the whole S3 language feels coherent as *one thing* in real application code — shaken out before the S5/S6 docs + migrator fan-out.

## Native views — `examples/real-apps/realworld_resources/` (all `.cljc`)

- **`ui_editor.cljc`** — the article-editor page. Controlled inputs on the **synchronous door** (`:value` + `:on-input [:editor/edit-field … :rf.ui/value]`), a **`ui/event`** form submit (`preventDefault` + dispatch the vector), committed event vectors (`:on-blur`, delete `:on-click`), and loading / error / `:editor/can-submit?`-flow gating as pure sub reads. It reuses the **UNCHANGED** `article_editor.cljs` dataflow (events/subs/mutations/flow) *by keyword* — that is the frozen-adapter boundary: the dataflow layer is tier-independent, so one set of registrations backs both the stock-Reagent page and this compiled-view rendition.
- **`ui_counter.cljc`** — the smallest complete app: event vectors + a controlled number field.
- **`ui_dashboard.cljc`** — composed views, a keyed metric list over an internal view, a controlled filter, a **view-only `local`** compact toggle, **`route-link`** navigation, and the textbook **`effect` + `dispatch-fn`** (an Escape-clears-filter `window` listener, retired in the effect's cleanup — the leaked-listener contract).

## Coherence tests — `implementation/ui/test/` (examples stay test-free)

- **`s3_ergonomic_proof_jvm_test.clj`** — Tier-1 structural: intent/event vectors asserted as data (editor via `:sub-overrides`; counter/dashboard against real seeded frames), plus the `route-link` SSR anchor shell.
- **`realworld_resources_s3_ergonomic_proof_dom_cljs_test.cljs`** — Tier-3 browser: the synchronous controlled-input door, the `ui/event` submit + validation, the `:editor/can-submit?` flow gating a live sub, a re-render (hot-reload) state-preservation + clean-unmount invariant, and counter/dashboard interactions. Named under the `re-frame.*` (not `re-frame.ui.*`) prefix on purpose — it drives the **real** stock-Reagent `article_editor.cljs` dataflow, so it must stay out of the focused pure-UI `:node-test-ui` isolation build (see Quality gates).

## Design notes (for review)

- **Single implementation, no dual dialect.** The native editor is the sole `re-frame.ui` rendition; the stock-Reagent SPA is **untouched** (the frozen tier). The full-app migration is **S6** (`ui/->react` — needed to embed a `defview` inside the Reagent route-switch — is not implemented until then). This is the deliberate S3/S6 split (S3 = "one vertical page"; S6 = "RealWorld-resources full app green").
- **The view owns no lease.** A committed dispatcher rejects dispatch from a disconnected view (the leaked-listener law), and a view-declared `ui/lease {:resource …}` is an unconditional resource-lease that does not fit the editor's edit-mode-only, dynamic-slug, app-minted `[:lease :editor/article slug]` owner. So there is nothing at the view tier to leak; the article-read lease lifecycle stays a dataflow concern proven in the reagent-adapter `realworld_resources_cljs_test`.
- No compiler / runtime / machines / tools touch. `implementation/ui/deps.edn` `:test` gains the examples path so Tier-1 resolves the `.cljc` views (test-only; deprecation warning is benign).

## Quality gates

All foreground, unpiped, green on this branch:

- `implementation/ui` JVM suite (`clojure -M:test`) — **747 tests, 13821 assertions, 0 failures** (incl. the Tier-1 test; deps.edn examples-path resolution intact).
- `npm run test:cljs` (broad `:node-test` compile + run) — **9835 tests, 48363 assertions, 0 failures**.
- `npm run test:ui-isolation` (focused `:node-test-ui` + `check-ui-adapter-isolation`) — **PASS, wrapper-free** (was the red gate).
- Article-editor coherence **browser test** (Chromium, `-dom-cljs-test$` build) — real DOM assertions unchanged.

### CI fix (Shape-5)

The `CLJS (shadow-cljs :node-test)` job was red at its **`re-frame.ui focused adapter-artifact isolation`** step, not the broad compile: `check-ui-adapter-isolation` reported *"view-stack adapter/wrapper code entered the focused UI module closure: reagent.\*"*. Root cause — the DOM coherence test drives the **real** stock-Reagent `article_editor.cljs` dataflow, so requiring it pulls `reagent.core` + the reagent view-stack into whatever build selects it; under the ns `re-frame.ui.s3-ergonomic-proof-dom-cljs-test` it matched the focused build's selector `^re-frame\.ui\..+-cljs-test$`. The broad `:node-test` run and the browser gate were green because they are **not** isolation-checked — hence local-green ≠ CI (the isolation step runs only against the pure-UI build).

Fix: renamed the test out of the `re-frame.ui.*` prefix → `re-frame.realworld-resources-s3-ergonomic-proof-dom-cljs-test` (sibling of the reagent-adapter `re-frame.realworld-resources-cljs-test`). It keeps the `-dom-cljs-test` suffix, so it still runs in the broad `:node-test` (`cljs-test$`) and `:browser-test` (`-dom-cljs-test$`) gates where example reagent code is expected, and no longer enters the focused `:node-test-ui` closure. Test behaviour and assertions unchanged; the JVM companion docstring points at the renamed sibling.

`story:build` not run — no story fixture touched.

