### PR TITLE
docs(nav): align Flows nav label with current pipeline vocabulary (rf2-w40po)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -174,7 +174,7 @@ nav:
       - "Coeffects: the way in": core/coeffects.md
     - "Structure":
       - "Frames: isolated worlds": core/frames.md
-      - "Flows: write-side derivations": core/flows.md
+      - "Flows: derived values your handlers can read": core/flows.md
       - "Interceptors: cross-cutting (rare)": core/interceptors.md
     - "Operations":
       - "Errors: dossiers": core/errors.md


### PR DESCRIPTION
## What

`mkdocs.yml` labeled the Core `core/flows.md` nav row as **"Flows: write-side derivations"**, still teaching the pipeline-sense "write side" vocabulary the terminology ruling retired in favor of update/commit/render. The page itself is titled **"Flows: derived values your handlers can read"**.

This aligns the one nav label with the page title / reader promise:

- Before: `- "Flows: write-side derivations": core/flows.md`
- After:  `- "Flows: derived values your handlers can read": core/flows.md`

Closed `rf2-isdag` cleared the string/routing/bundle residues but missed this MkDocs nav row. Scope is exactly one line; no other nav rows renamed, no `docs/core/flows.md` content touched. Resources' deliberately retained read-path/write-path terminology exception is unrelated and left untouched.

## Quality gates

- `python scripts/check_doc_slugs.py` — pass (exit 0)
- `python -m mkdocs build --strict` — pass (exit 0, built in 22.64s; nav resolves)
- Label verified to match `docs/core/flows.md`'s `# Flows: derived values your handlers can read` title

Closes rf2-w40po