### PR TITLE
docs(http): align managed-request stub docs with the stable load-time target (rf2-bchy1)

### DIFF
--- a/docs/api/re-frame.http.md
+++ b/docs/api/re-frame.http.md
@@ -345,7 +345,7 @@ Test-support surface for driving the pipeline without the network: canned-reply 
   ```
 - **Description**: Lexical-scope stubbing.
   - `route-map` is `{[<method> <url>] {:reply {:ok <value>}}}` (success) or `{[<method> <url>] {:reply {:failure <failure-map>}}}` (failure).
-  - Inside the body, requests matching a stubbed route bypass the real client. The helper registers a per-scope stub fx with a process-unique `:rf.test/managed-http-stub-<n>` id, under the test-runner-internal `:rf.test/*` fx-stub family, so nested scopes compose. It then installs the matching `:rf.http/managed` override for the body's dynamic extent.
+  - Inside the body, requests matching a stubbed route bypass the real client. The helper binds one stable override target — `:rf.test/managed-http-scope-stub`, in the test-runner-internal `:rf.test/*` fx-stub family, registered once when `re-frame.http.test-support` loads — as the `:rf.http/managed` override for the body's dynamic extent, and carries the scope's route map on a dynamic var. It mints **no** per-scope fx and performs no registrar write; nested scopes compose because an inner scope's route-map binding shadows the outer's and restores it on exit. Because the target is registered at load time rather than minted per scope, it resolves through the sealed image generation of a frame created before the scope was entered — a `dispatch-sync` in a pre-created frame still routes through the stub.
   - Plain `dispatch-sync` calls auto-route by method + URL with no manual `:fx-overrides`. A per-call `:fx-overrides` still wins.
   - Routes match against the post-`:before` request (the method + URL the pipeline would actually issue). A request with no matching route receives a synthesised `:rf.http/transport` failure reply.
   - The façade macro needs `re-frame.http.test-support` in the require closure. Without it, the call raises `:rf.error/http-artefact-missing`.
@@ -357,7 +357,7 @@ Test-support surface for driving the pipeline without the network: canned-reply 
   ```clojure
   (with-managed-request-stubs* route-map body-fn)
   ```
-- **Description**: Plain-fn surface beneath the macro, for computed route-maps or non-literal bodies. Like the macro, it installs the `:rf.http/managed` override for `body-fn`'s dynamic extent, so dispatches inside auto-route with no manual `:fx-overrides`.
+- **Description**: Plain-fn surface beneath the macro, for computed route-maps or non-literal bodies. Like the macro, it binds the `:rf.http/managed` override (to the stable `:rf.test/managed-http-scope-stub` target) plus the scope's route map for `body-fn`'s dynamic extent, so dispatches inside auto-route with no manual `:fx-overrides`.
 - **Example**:
   ```clojure
   ;; Computed route-map / non-literal body — use the fn form.
@@ -376,7 +376,7 @@ Test-support surface for driving the pipeline without the network: canned-reply 
   (install-managed-request-stubs! route-map)
   ```
 - **Description**: Lower-level than `with-managed-request-stubs`. Use it when stubs span multiple `deftest`s. It registers the `:rf.http/managed-test-stub` fx — the stable, documented `:fx-overrides` target — which persists until `uninstall-managed-request-stubs!`. Returns the stub fx-id.
-  - Unlike the wrapper, this does **not** install the `:rf.http/managed` override. Dispatch with `{:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}}` (or wrap dispatches in `with-fx-overrides`) to route through it.
+  - Unlike the wrapper, this does **not** bind the `:rf.http/managed` override. Dispatch with `{:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}}` (or wrap dispatches in `with-fx-overrides`) to route through it.
   - Nested installs snapshot the prior handler and restore it on uninstall (LIFO).
   - Not a `re-frame.core` façade export — call it through its home namespace `re-frame.http.test-support`.
 - **Example**:

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1439,9 +1439,11 @@
 
 #?(:clj
    (defmacro with-managed-request-stubs
-     "Install stubs, run body, uninstall. `stubs` is
-     `{[method url] {:reply <:ok|:failure>}}`. Implementation ships in
-     `day8/re-frame2-http` (rf2-5kpd). Per Spec 014 §Testing."
+     "Bind the `:rf.http/managed` stub override plus the scope's route map for
+     the body's dynamic extent, run body (bindings unwind on exit; no registrar
+     mutation). `stubs` is `{[method url] {:reply <:ok|:failure>}}`.
+     Implementation ships in `day8/re-frame2-http` (rf2-5kpd). Per Spec 014
+     §Testing."
      [stubs & body]
      `(re-frame.core/with-managed-request-stubs* ~stubs (fn [] ~@body))))
 
@@ -2539,11 +2541,12 @@
 ;; home namespace `re-frame.http.test-support` (require it from your test ns).
 ;; The ergonomic `with-managed-request-stubs` macro stays on the façade.
 
-(def ^{:doc "Fn-form: install stubs, run `thunk`, uninstall. The plumbing
-  the `with-managed-request-stubs` macro routes through. Implementation
-  ships in `day8/re-frame2-http` under `re-frame.http.test-support`
-  (rf2-lwmgw). Per Spec 014 §Testing. Late-bound via
-  `:http/with-managed-request-stubs*`."}
+(def ^{:doc "Fn-form: bind the `:rf.http/managed` stub override plus the scope's
+  route map for `thunk`'s dynamic extent, run `thunk` (bindings unwind on exit;
+  no registrar mutation). The plumbing the `with-managed-request-stubs` macro
+  routes through. Implementation ships in `day8/re-frame2-http` under
+  `re-frame.http.test-support` (rf2-lwmgw). Per Spec 014 §Testing. Late-bound
+  via `:http/with-managed-request-stubs*`."}
   with-managed-request-stubs*      rf-http/with-managed-request-stubs*)
 
 (def ^{:doc "Clear an HTTP interceptor by `id` from a frame's

--- a/implementation/core/src/re_frame/core_http.cljc
+++ b/implementation/core/src/re_frame/core_http.cljc
@@ -36,7 +36,10 @@
 ;; stubs` macro keeps its `with-managed-request-stubs*` façade plumbing below.
 
 (defwrapper with-managed-request-stubs*
-  "Function form: install stubs, run thunk, uninstall. Late-bound via
+  "Function form: bind the `:rf.http/managed → :rf.test/managed-http-scope-stub`
+  stub override plus the scope's route map (on a dynamic var) for the thunk's
+  dynamic extent, then run thunk. Both bindings unwind on exit; the wrapper
+  performs no registrar mutation. Late-bound via
   `:http/with-managed-request-stubs*` (published from
   `re-frame.http.test-support` per rf2-lwmgw)."
   {:hook :http/with-managed-request-stubs* :artefact http-test-support-artefact :on-absent :throw}

--- a/implementation/http/src/re_frame/http/test_support.cljc
+++ b/implementation/http/src/re_frame/http/test_support.cljc
@@ -462,10 +462,12 @@
   `:rf.http/managed` through it. To route, either dispatch with
   `:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}`, or — far
   more usually — wrap the test body via `with-managed-request-stubs` /
-  `with-managed-request-stubs*`, which install a per-scope stub fx AND the
-  matching `:rf.http/managed → <scope-stub>` override for the body's
-  dynamic extent, so plain `dispatch-sync` calls auto-route with no manual
-  `:fx-overrides`.
+  `with-managed-request-stubs*`, which bind the
+  `:rf.http/managed → :rf.test/managed-http-scope-stub` override (a stable
+  target registered at ns-load, NOT a per-scope fx) plus the scope's route
+  map on a dynamic var, for the body's dynamic extent — so plain
+  `dispatch-sync` calls auto-route with no manual `:fx-overrides`. Unlike
+  this fn, that wrapper performs NO registrar mutation.
 
   rf2-vn8qjv — stack/token discipline: install snapshots any prior
   `:rf.http/managed-test-stub` handler before overwriting it, so a nested


### PR DESCRIPTION
## What

PR #6057 replaced the per-invocation, process-unique `:rf.test/managed-http-stub-<n>` registration with **one** namespace-load `:rf.test/managed-http-scope-stub` override target plus a dynamically-shadowed route map (`*scope-stubs*`), so a pre-created sealed frame can resolve the override. Behaviour and precedence were already correct; three descriptions still promised the deleted mechanism. This aligns the stale prose/docstrings with the shipped model (docs/docstring-only, no runtime change).

## Fixes

- **`docs/api/re-frame.http.md`** — the `with-managed-request-stubs` macro bullet dropped the per-scope process-unique `:rf.test/managed-http-stub-<n>` claim; it now states the stable load-time `:rf.test/managed-http-scope-stub` target + dynamic-var route map, **no** per-scope registrar write, nested-scope restoration via shadowing, and sealed-frame visibility (`dispatch-sync` in a pre-created frame still routes through the stub). The `with-managed-request-stubs*` and `install-managed-request-stubs!` bullets align terminology (bind vs install) with the wrapper's no-registrar-mutation contract.
- **`re-frame.http.test-support/install-managed-request-stubs!` docstring** — corrects the "wrapper installs a per-scope stub fx" clause to the shipped bind-override + dynamic-var-route-map model, and adds the explicit distinction that the wrapper performs **no** registrar mutation while this lower-level fn's separate stable `:rf.http/managed-test-stub` registrar write is the distinguishing behaviour.
- **`re-frame.core` façade** — `core.cljc` macro `with-managed-request-stubs`, `core.cljc` fn-form def `with-managed-request-stubs*`, and `core_http.cljc` defwrapper `with-managed-request-stubs*` all replaced "install stubs, run, uninstall" with the shipped "bind the `:rf.http/managed` override + the scope's route map for the dynamic extent (bindings unwind on exit; no registrar mutation)".

Nested-scope restoration, `dispatch-sync` scope, sealed-frame visibility, and per-call-over-lexical-over-frame precedence remain stated consistently with runtime behaviour. Runtime verified against `re-frame.http.test-support` (the load-time `scope-stub-fx-id` registration + `with-managed-request-stubs*` binding `*scope-stubs*` and `router/*fx-overrides*`, no registrar write).

## Quality gates

- `python -m mkdocs build --strict` — **pass** (exit 0)
- api-manifest doc/manifest drift gate (`implementation/scripts/api-manifest`, `clojure -M:test`) — **83 tests, 176 assertions, 0 failures, 0 errors** (incl. `docs/api/` projection + page/member coverage in sync)
- http artefact (`implementation/http`, `clojure -M:test`) — **491 tests, 3762 assertions, 0 failures, 0 errors**

Core changes are prose-only docstrings; no core test pins the changed prose, and the manifest gate (api-manifest) is green. No runtime or public-API change.

Closes rf2-bchy1.
