### PR TITLE
fix(routing): fail auth guard closed for the reserved :rf.route/self target (rf2-yp3ip)

### DIFF
--- a/docs/core/how-to/add-auth.md
+++ b/docs/core/how-to/add-auth.md
@@ -230,13 +230,19 @@ The fix is to normalise all three to one target, then redirect identically:
 ;; Adapted from examples/real-apps/realworld_http/routing.cljs
 (defn- nav-target
   "Normalise a navigation event to {:id <route-id> :params <map>}; nil for
-   non-navigation events (the guard short-circuits)."
-  [[ev-id a b]]
+   non-navigation events (the guard short-circuits). `current` is the current
+   route slice ([:rf.runtime/routing :current]) — the reserved :rf.route/self
+   target resolves against it, exactly as the runtime resolves it."
+  [[ev-id a b] current]
   (case ev-id
-    :rf.route/navigate          (if (map? a)                             ;; {:url ...} escape-hatch target
+    :rf.route/navigate          (cond
+                                  (= :rf.route/self a)                   ;; reserved "stay here" target
+                                  {:id (:route-id current) :params (or (:params current) {})}
+                                  (map? a)                               ;; {:url ...} escape-hatch target
                                   (when-let [{:keys [route-id params]} (routing/match-url (:url a))]
                                     {:id route-id :params (or params {})})
-                                  {:id a :params (or b {})})              ;; route-id target
+                                  :else                                  ;; route-id target
+                                  {:id a :params (or b {})})
     :rf.route/url-requested           (let [{:keys [to params url]} a]     ;; route-link click
                                   (cond
                                     to  {:id to :params (or params {})}
@@ -254,7 +260,12 @@ Now the guard itself. An *event* interceptor's `ctx` splits into two halves: `:c
   {:doc "Redirect logged-out users away from :requires-auth routes; stash the target."}
   {:before
    (fn [ctx]
-     (if-let [{:keys [id params]} (nav-target (get-in ctx [:coeffects :event]))]
+     ;; The current route slice is framework runtime-db state — read it from the
+     ;; :rf.db/runtime coeffect so the reserved :rf.route/self target resolves to
+     ;; the protected route the user is already on.
+     (if-let [{:keys [id params]} (nav-target (get-in ctx [:coeffects :event])
+                                              (get-in ctx [:coeffects :rf.db/runtime
+                                                           :rf.runtime/routing :current]))]
        (let [needs-auth? (contains? (:tags (rf/handler-meta :route id)) :requires-auth)
              logged-in?  (some? (get-in ctx [:coeffects :db :auth :user]))]
          (if (and needs-auth? (not logged-in?))
@@ -272,6 +283,7 @@ Now the guard itself. An *event* interceptor's `ctx` splits into two halves: `:c
 Two helpers do the reading, and both are *pure* — they compute from their arguments without touching app-db, which is exactly why the guard can call them inline:
 
 - **`routing/match-url`** parses a URL string into a map — `{:route-id :params :query :fragment :validation-failed?}` — or `nil` when nothing matches. (Its inverse, `routing/route-url`, builds a URL from a route id and params.) Note the namespace: it lives in `re-frame.routing`, **not** on the `rf/` facade. `nav-target` reaches for it in **three** places: the link-click and URL-bar events carry a raw URL, and `:rf.route/navigate` accepts a `{:url "/settings"}` **escape-hatch target** (deep links, redirects) that is a URL, not a route id — resolve it the same way the runtime does, or a logged-out `[:rf.route/navigate {:url "/settings"}]` slips past the tag check.
+- **The reserved `:rf.route/self` target** is the *third* form `:rf.route/navigate` accepts — *stay on the current route, change only the query* (search, pagination, tabs). It is not a route id; the runtime resolves it from the current route slice, so the guard resolves it the same way, off `current`. Miss it and the guard fails **open** exactly where it hurts: a session that expires *while the user sits on a protected route* can self-navigate (`?page=2`, a tab switch) and — because the raw keyword carries no `:requires-auth` tag — slip past the check. That is why the guard reads the current slice from the `:rf.db/runtime` coeffect and threads it into `nav-target`: resolved to `:app/settings`, the self-nav is gated and the expired session is bounced to login.
 - **`rf/handler-meta`** reads back the metadata you stamped at registration. `(rf/handler-meta :route id)` returns that route's registration map; the guard pulls its `:tags` and checks for `:requires-auth`.
 
 The redirect works by *skip-and-dispatch*. `:rf/skip-handler?` — the public short-circuit primitive an interceptor's `:before` sets on its ctx — stops the original handler, so the protected slice never commits and its `:on-match` loads never fire. The guard then dispatches the login navigation itself.

--- a/docs/resources/tutorial/03-auth-and-forms.md
+++ b/docs/resources/tutorial/03-auth-and-forms.md
@@ -493,18 +493,26 @@ There's one trap here, and it's the kind that passes every casual test. Navigati
 
     If you gate only the programmatic `:rf.route/navigate`, the guard *fails open* the moment someone types `/settings` into the address bar — the protected route loads with no user. The fix is to normalise all three navigation events to one shape, then gate once.
 
-That normaliser is `nav-target` below. The link-click and URL-bar cases carry a raw URL string rather than a route id — and so can `:rf.route/navigate`, whose `{:url "/settings"}` *escape-hatch* target (deep links, redirects) is a URL, not a route id. All three lean on `routing/match-url` to turn that URL back into a route before the guard reads its `:tags`; skip it on the navigate branch and a logged-out `[:rf.route/navigate {:url "/settings"}]` walks in:
+That normaliser is `nav-target` below. The link-click and URL-bar cases carry a raw URL string rather than a route id — and so can `:rf.route/navigate`, whose `{:url "/settings"}` *escape-hatch* target (deep links, redirects) is a URL, not a route id. All three lean on `routing/match-url` to turn that URL back into a route before the guard reads its `:tags`; skip it on the navigate branch and a logged-out `[:rf.route/navigate {:url "/settings"}]` walks in.
+
+`:rf.route/navigate` has a **third** target form too: the reserved `:rf.route/self` — *stay on the current route, change only the query* (search, pagination, tabs). It is not a route id; the runtime resolves it from the current route slice, so `nav-target` takes that slice (`current`) and resolves self the same way. This closes the trap's nastiest corner: a session that *expires while the user is already on `/settings`* would otherwise self-navigate (a filter toggle, `?page=2`) straight past a guard that only knows how to read route ids and URLs — the raw keyword carries no `:requires-auth` tag. Resolved to `:conduit.user/settings`, the self-nav is gated and the stale session is bounced to login:
 
 ```clojure
 (defn- nav-target
   "Normalise any navigation event to {:id route-id :params m};
-   nil for non-navigation events (the guard stands aside)."
-  [[event-id a b]]
+   nil for non-navigation events (the guard stands aside). `current` is the
+   current route slice ([:rf.runtime/routing :current]) — the reserved
+   :rf.route/self target resolves against it, as the runtime resolves it."
+  [[event-id a b] current]
   (case event-id
-    :rf.route/navigate          (if (map? a)                          ;; {:url ...} escape-hatch target
+    :rf.route/navigate          (cond
+                                  (= :rf.route/self a)                ;; reserved "stay here" target
+                                  {:id (:route-id current) :params (or (:params current) {})}
+                                  (map? a)                            ;; {:url ...} escape-hatch target
                                   (when-let [m (routing/match-url (:url a))]
                                     {:id (:route-id m) :params (or (:params m) {})})
-                                  {:id a :params (or b {})})            ;; route-id target
+                                  :else                               ;; route-id target
+                                  {:id a :params (or b {})})
     :rf.route/url-requested           (if-let [to (:to a)]
                                   {:id to :params (or (:params a) {})}
                                   (when-let [m (routing/match-url (:url a))]
@@ -517,7 +525,12 @@ That normaliser is `nav-target` below. The link-click and URL-bar cases carry a 
   {:doc "Bounce signed-out users away from :requires-auth routes; stash the target."}
   {:before
    (fn [ctx]
-     (let [{:keys [id params]} (nav-target (get-in ctx [:coeffects :event]))
+     ;; The route slice is framework runtime-db state — read it from the
+     ;; :rf.db/runtime coeffect so the reserved :rf.route/self target resolves
+     ;; to the protected route the user is already on.
+     (let [{:keys [id params]} (nav-target (get-in ctx [:coeffects :event])
+                                           (get-in ctx [:coeffects :rf.db/runtime
+                                                        :rf.runtime/routing :current]))
            needs-auth? (when id
                          (contains? (:tags (rf/handler-meta :route id)) :requires-auth))
            signed-in?  (some? (get-in ctx [:coeffects :db :auth :user]))]
@@ -535,6 +548,7 @@ That normaliser is `nav-target` below. The link-click and URL-bar cases carry a 
 You register the guard once, under the id `:conduit/auth-guard` — exactly like registering an event or a sub — and then the frame's chain *references* that id. A few pieces are doing precise work:
 
 - **`routing/match-url`** is the URL codec from `re-frame.routing` (`(:require [re-frame.routing :as routing])`) — **not** the `rf/` front porch. It's a pure function, `url → {:route-id :params :query :fragment :validation-failed?}` (or `nil` for a URL that matches nothing), and it runs on both hosts. `nav-target` uses it for the two cases that arrive as a raw URL string.
+- **The current route slice** (`current`, read from the `:rf.db/runtime` coeffect at `[:rf.runtime/routing :current]`) is what resolves the reserved `:rf.route/self` target — a self-nav means "the route I'm already on," so the guard reads that route's id from the slice, exactly as the runtime does, and then checks its `:tags`.
 - **`rf/handler-meta :route id`** reads the route's [registration](../../core/glossary.md#registration) metadata — including its `:tags` — without activating it. It's the introspection seam pair tools use too, so the guard asks the registry the same question Xray would.
 - **`:rf/skip-handler? true`** tells the runtime to skip the event's own handler. For a navigation that means the protected route never commits and its `:on-match` loads (`[:settings/load]`) never fire — a signed-out user can't even trigger the route's data fetch.
 - **The stash** lands the destination at `[:auth :return-to]` — the same spot `submit-success` read earlier — and the guard dispatches the login navigation instead.

--- a/docs/routing/how-to/require-sign-in-on-a-route.md
+++ b/docs/routing/how-to/require-sign-in-on-a-route.md
@@ -48,14 +48,23 @@ Guard `:rf.route/navigate` alone and the third row defeats you: a logged-out rea
 (:require [re-frame.routing :as routing])   ;; match-url lives here, not on rf/
 
 (defn- nav-target
-  "Normalise any navigation event to {:id <route-id> :params <map>}, or nil."
-  [[ev-id a b]]
+  "Normalise any navigation event to {:id <route-id> :params <map>}, or nil.
+  `current` is the current route slice ([:rf.runtime/routing :current]) — the
+  reserved :rf.route/self target resolves to the route you are already on, so
+  pass it in and the guard resolves self exactly as the runtime does."
+  [[ev-id a b] current]
   (case ev-id
     :rf.route/navigate
-    (if (map? a)                                       ;; {:url ...} escape-hatch target
+    (cond
+      (= :rf.route/self a)                               ;; reserved "stay here" target
+      {:id (:route-id current) :params (or (:params current) {})}
+
+      (map? a)                                           ;; {:url ...} escape-hatch target
       (when-let [{:keys [route-id params]} (routing/match-url (:url a))]
         {:id route-id :params (or params {})})
-      {:id a :params (or b {})})                        ;; route-id target — unchanged
+
+      :else                                              ;; route-id target — unchanged
+      {:id a :params (or b {})})
 
     :rf.route/url-requested
     (let [{:keys [to params url]} a]
@@ -79,6 +88,17 @@ route id — so the guard resolves it through `match-url` exactly as the runtime
 reading the route's `:tags`. Guard only the route-id form and a logged-out
 `[:rf.route/navigate {:url "/settings"}]` walks straight in.
 
+`:rf.route/navigate` carries a **third** target form: the reserved `:rf.route/self`,
+which means *stay on the current route; change only the query* (search, pagination, tab
+switches). It is not a registered route id — the runtime resolves it from the current route
+slice, so the guard must too. Miss it and the check fails **open** in the one place it
+matters most: a reader whose session has expired *while sitting on a protected route* can
+self-navigate (a `?page=2`, a tab switch) and the guard, seeing the literal keyword rather
+than the route they're on, waves it through. Resolving `:rf.route/self` against the current
+slice — `(:route-id current)` — makes the guard see `:app/settings`'s `:requires-auth` tag
+and fail **closed**, bouncing the expired session to login. That's why the interceptor reads
+the current slice out of the `:rf.db/runtime` coeffect and threads it into `nav-target`.
+
 ## 3. Redirect with skip-and-dispatch
 
 Now the guard itself: one interceptor, registered once, that runs `:before` every event. For a navigation toward a `:requires-auth` route with no signed-in user, it **skips** the original handler (so the protected route never commits and its loaders never fire) and dispatches the login navigation instead:
@@ -88,7 +108,12 @@ Now the guard itself: one interceptor, registered once, that runs `:before` ever
   {:doc "Redirect logged-out readers away from :requires-auth routes."}
   {:before
    (fn [ctx]
-     (if-let [{:keys [id]} (nav-target (get-in ctx [:coeffects :event]))]
+     ;; The current route slice is framework runtime-db state — read it from
+     ;; the :rf.db/runtime coeffect so the reserved :rf.route/self target
+     ;; resolves to the protected route the reader is already on.
+     (if-let [{:keys [id]} (nav-target (get-in ctx [:coeffects :event])
+                                       (get-in ctx [:coeffects :rf.db/runtime
+                                                    :rf.runtime/routing :current]))]
        (let [needs-auth? (contains? (:tags (rf/handler-meta :route id)) :requires-auth)
              signed-in?  (some? (get-in ctx [:coeffects :db :auth :user]))]
          (if (and needs-auth? (not signed-in?))

--- a/examples/real-apps/realworld_resources/routing.cljs
+++ b/examples/real-apps/realworld_resources/routing.cljs
@@ -211,12 +211,21 @@
 ;; back door: a protected route is unreachable while logged out, by any path. See
 ;; route guard: ../../../docs/routing/glossary.md#route-guard.
 
-(defn- resolve-nav-target [[ev-id a _b]]
+;; `current` is the current route slice ([:rf.runtime/routing :current]) — needed
+;; to resolve the reserved `:rf.route/self` target (stay on the current route,
+;; change only the query) the same way the runtime does. Without it a session
+;; that expires WHILE on a `:requires-auth` route could self-navigate straight
+;; past the guard: the raw `:rf.route/self` keyword carries no `:tags`.
+(defn- resolve-nav-target [[ev-id a _b] current]
   (case ev-id
-    :rf.route/navigate (if (map? a)                        ;; {:url ...} escape-hatch target
+    :rf.route/navigate (cond
+                         (= :rf.route/self a)              ;; reserved "stay here" target
+                         {:id (:route-id current) :params (or (:params current) {})}
+                         (map? a)                          ;; {:url ...} escape-hatch target
                          (when-let [{:keys [route-id params]} (routing/match-url (:url a))]
                            {:id route-id :params (or params {})})
-                         {:id a :params (or _b {})})        ;; route-id target
+                         :else                             ;; route-id target
+                         {:id a :params (or _b {})})
     :rf.route/url-requested  (let [{:keys [to params url]} a]
                          (cond
                            to  {:id to :params (or params {})}
@@ -238,7 +247,13 @@
          `:requires-auth`-tagged routes to login, stashing where they were going
          for a post-login bounce-back."}
   {:before (fn auth-guard-before [ctx]
-             (if-let [{:keys [id params]} (resolve-nav-target (get-in ctx [:coeffects :event]))]
+             ;; The route slice is framework runtime-db state — read it from the
+             ;; :rf.db/runtime coeffect so `:rf.route/self` resolves to the
+             ;; protected route the user is already on.
+             (if-let [{:keys [id params]} (resolve-nav-target
+                                            (get-in ctx [:coeffects :event])
+                                            (get-in ctx [:coeffects :rf.db/runtime
+                                                         :rf.runtime/routing :current]))]
                (let [route-meta  (rf/handler-meta :route id)
                      needs-auth? (boolean (some #{:requires-auth} (:tags route-meta)))
                      logged-in?  (some? (get-in ctx [:coeffects :db :auth :user]))]

--- a/implementation/routing/test/re_frame/routing_auth_guard_matrix_test.clj
+++ b/implementation/routing/test/re_frame/routing_auth_guard_matrix_test.clj
@@ -1,22 +1,43 @@
 (ns re-frame.routing-auth-guard-matrix-test
-  "Executable matrix pinning the canonical auth-guard recipe
-  (docs/routing/how-to/require-sign-in-on-a-route.md, docs/core/how-to/add-auth.md,
-  spec/012-Routing.md §Cross-cutting guards) across ALL FOUR navigation entry
-  points: route-id `:rf.route/navigate`, the raw-URL `{:url ...}` navigate
-  escape hatch, a `route-link` click (`:rf.route/url-requested`), and a URL-bar /
-  popstate / deep-link (`:rf.route/handle-url-change`).
+  "Executable integration matrix pinning the canonical cross-cutting auth-guard
+  recipe (docs/routing/how-to/require-sign-in-on-a-route.md,
+  docs/core/how-to/add-auth.md, docs/resources/tutorial/03-auth-and-forms.md,
+  examples/real-apps/realworld_resources/routing.cljs, spec/012-Routing.md
+  §Cross-cutting guards) across ALL FOUR navigation entry doors — route-id
+  `:rf.route/navigate`, the raw-URL `{:url ...}` navigate escape hatch, a
+  `route-link` click (`:rf.route/url-requested`), and a URL-bar / popstate /
+  deep-link (`:rf.route/handle-url-change`) — AND all THREE navigate target
+  forms: a route-id, the `{:url ...}` escape hatch, and the reserved
+  `:rf.route/self`.
 
-  rf2-e9k3dr — the recipe's `:rf.route/navigate` branch normalised its target as a
-  route id UNCONDITIONALLY. But `:rf.route/navigate` also accepts a `{:url \"/settings\"}`
-  target (the runtime resolves it through `match-url` — see
-  re_frame/routing/navigate.cljc:294), so a map target fell through as a route id:
-  `handler-meta` on a MAP returns nil, `:requires-auth` is missed, and the protected
-  route is entered — a fail-OPEN security hole on the most common escape-hatch path.
+  The guard body below is the SINGLE executable seam the suite drives — it is
+  registered as `:app/auth-guard` and the test runs THAT interceptor (its
+  `:before`, and end-to-end through the frame), not a divorced boolean copy.
+  It is kept byte-faithful to the shipped recipe, so a drift between the doc
+  recipe and this pin trips a test.
 
-  The recipe now mirrors the runtime — map targets normalise through `match-url`
-  before the tag read. This suite is the failing-before / passing-after guard: revert
-  the `:rf.route/navigate` branch to `{:id a :params (or b {})}` and the raw-URL rows
-  below flip from `true`/gated to `false`/open."
+  rf2-e9k3dr — the recipe's `:rf.route/navigate` branch first normalised a
+  `{:url ...}` target as a route id UNCONDITIONALLY; a map target fell through
+  as a route id, `handler-meta` on a MAP returned nil, `:requires-auth` was
+  missed, and the protected route was entered — a fail-OPEN hole on the raw-URL
+  escape hatch.
+
+  rf2-yp3ip — the same branch treated EVERY non-map target as a registered
+  route id, so the reserved `:rf.route/self` target (stay on the current route,
+  change only the query) resolved to the literal keyword `:rf.route/self`. That
+  keyword is not a registered route, so `handler-meta` found no `:requires-auth`
+  tag and the guard stood aside — a fail-OPEN hole exactly where it is most
+  dangerous: a session that expires WHILE the user sits on a `:requires-auth`
+  route can self-navigate (a query change, a tab switch, `?page=2`) straight
+  past the guard. The fix mirrors the runtime (navigate.cljc:262): resolve
+  `:rf.route/self` from the CURRENT route slice
+  (`[:rf.runtime/routing :current]`, carried in the `:rf.db/runtime` coeffect)
+  before reading the tags, so the guard sees the protected destination and fails
+  CLOSED.
+
+  This suite is the failing-before / passing-after guard for BOTH holes:
+  reverting the `:rf.route/navigate` branch to `{:id a :params (or b {})}` flips
+  the raw-URL rows AND the `:rf.route/self` rows from gated to open."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
@@ -26,18 +47,26 @@
 
 (use-fixtures :each rts/reset-runtime)
 
-;; The canonical recipe's normaliser — the FIXED form (rf2-e9k3dr). Kept
-;; byte-faithful to the shipped docs so a drift between the doc recipe and this
-;; pin trips a test. `:rf.route/navigate` now branches on the target shape: a
-;; `{:url ...}` map is resolved through `match-url` exactly as the runtime does;
-;; a keyword is a route id, unchanged.
-(defn- nav-target [[ev-id a b]]
+;; ---------------------------------------------------------------------------
+;; The canonical guard — byte-faithful to the shipped recipe. Registered as
+;; `:app/auth-guard` below and driven directly (its `:before`) AND end-to-end
+;; through the frame. `nav-target` normalises ANY navigation event to
+;; {:id <route-id> :params <map>} (or nil); `current` is the current route
+;; slice, so the reserved `:rf.route/self` target resolves against it exactly
+;; as the runtime does.
+;; ---------------------------------------------------------------------------
+
+(defn- nav-target [[ev-id a b] current]
   (case ev-id
     :rf.route/navigate
-    (if (map? a)                                       ;; {:url ...} escape-hatch target
+    (cond
+      (= :rf.route/self a)                                ;; reserved "stay here" target
+      {:id (:route-id current) :params (or (:params current) {})}
+      (map? a)                                            ;; {:url ...} escape-hatch target
       (when-let [{:keys [route-id params]} (routing/match-url (:url a))]
         {:id route-id :params (or params {})})
-      {:id a :params (or b {})})                        ;; route-id target — unchanged
+      :else                                               ;; route-id target
+      {:id a :params (or b {})})
 
     :rf.route/url-requested
     (let [{:keys [to params url]} a]
@@ -52,72 +81,174 @@
 
     nil))
 
-(defn- guard-decision
-  "The guard's protected-path decision for `event`, signed out:
-   nil   — not a resolvable navigation (guard stands aside),
-   true  — a `:requires-auth` route was targeted (guard redirects — fail CLOSED),
-   false — a public route was targeted (guard allows)."
-  [event]
-  (when-let [{:keys [id]} (nav-target event)]
-    (contains? (:tags (rf/handler-meta :route id)) :requires-auth)))
+(defn- auth-guard-before
+  "The canonical guard `:before`. Reads the current route slice from the
+  `:rf.db/runtime` coeffect so `:rf.route/self` resolves to the route the user
+  is already on. Signed-out navigation toward a `:requires-auth` route is
+  skipped (so the protected route never commits and its `:on-match` loaders
+  never fire) and redirected to login."
+  [ctx]
+  (if-let [{:keys [id]} (nav-target (get-in ctx [:coeffects :event])
+                                    (get-in ctx [:coeffects :rf.db/runtime
+                                                 :rf.runtime/routing :current]))]
+    (let [needs-auth? (contains? (:tags (rf/handler-meta :route id)) :requires-auth)
+          signed-in?  (some? (get-in ctx [:coeffects :db :auth :user]))]
+      (if (and needs-auth? (not signed-in?))
+        (-> ctx
+            (assoc :rf/skip-handler? true)                ;; protected route never commits
+            (assoc-in [:effects :fx]
+                      [[:dispatch [:rf.route/navigate :app/login]]]))
+        ctx))
+    ctx))                                                 ;; not a navigation ⇒ pass through
 
-(defn- register-routes! []
+(defn- register! []
   (rf/reg-route :app/home     {} "/")
   (rf/reg-route :app/login    {} "/login")
   (rf/reg-route :app/settings {:tags #{:requires-auth}} "/settings")
-  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
-  (fx/reg-fx :rf.nav/replace-url {:platforms #{:server :client}} (fn [_ _] nil)))
+  (fx/reg-fx :rf.nav/push-url    {:platforms #{:server :client}} (fn [_ _] nil))
+  (fx/reg-fx :rf.nav/replace-url {:platforms #{:server :client}} (fn [_ _] nil))
+  (rf/reg-interceptor :app/auth-guard
+    {:doc "Redirect signed-out users away from :requires-auth routes."}
+    {:before auth-guard-before}))
 
-;; ---- The matrix: protected fails CLOSED on every door ---------------------
+;; ---- Helpers: drive the REGISTERED guard's :before over a real ctx ---------
+
+(defn- ctx-for
+  "The `:before` ctx the runtime hands the guard for `event`: signed out unless
+  `user` is supplied, carrying `slice` as the current route slice in the
+  reserved `:rf.db/runtime` coeffect (the exact seam navigate-handler reads)."
+  ([event]            (ctx-for event nil nil))
+  ([event slice]      (ctx-for event slice nil))
+  ([event slice user] {:coeffects {:event         event
+                                   :db            (if user {:auth {:user user}} {})
+                                   :rf.db/runtime {:rf.runtime/routing {:current slice}}}}))
+
+(defn- skipped? [ctx] (true? (:rf/skip-handler? (auth-guard-before ctx))))
+(defn- redirect [ctx] (get-in (auth-guard-before ctx) [:effects :fx]))
+
+(def ^:private login-redirect [[:dispatch [:rf.route/navigate :app/login]]])
+
+(defn- real-slice-on
+  "Run a real (guard-free) navigation and return the resulting runtime-db route
+  slice — the exact shape the runtime hands the guard as `:rf.db/runtime`. Used
+  to feed `:rf.route/self` rows a slice the RUNTIME produced, not a hand-rolled
+  one, so the pin proves the guard resolves self the same way the runtime does."
+  [event]
+  (rf/dispatch-sync event)
+  (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+          [:rf.runtime/routing :current]))
+
+;; ---------------------------------------------------------------------------
+;; The matrix: protected fails CLOSED (skip + redirect) on every door + target
+;; form; public is delivered normally (ctx untouched).
+;; ---------------------------------------------------------------------------
 
 (deftest auth-guard-matrix-fails-closed-across-all-doors
-  (register-routes!)
+  (register!)
+  (let [settings-slice (real-slice-on [:rf.route/navigate :app/settings])
+        home-slice     (real-slice-on [:rf.route/navigate :app/home])]
 
-  (testing "route-id :rf.route/navigate — protected gated, public allowed"
-    (is (true?  (guard-decision [:rf.route/navigate :app/settings]))
-        "route-id navigate to a :requires-auth route is gated")
-    (is (false? (guard-decision [:rf.route/navigate :app/home]))
-        "route-id navigate to a public route is allowed"))
+    (testing "route-id :rf.route/navigate"
+      (is (skipped? (ctx-for [:rf.route/navigate :app/settings]))
+          "route-id navigate to a :requires-auth route is skipped")
+      (is (= login-redirect (redirect (ctx-for [:rf.route/navigate :app/settings])))
+          "and redirected to login")
+      (let [ctx (ctx-for [:rf.route/navigate :app/home])]
+        (is (= ctx (auth-guard-before ctx))
+            "public route-id navigate passes through untouched (normal delivery)")))
 
-  (testing "raw-URL {:url ...} :rf.route/navigate — the rf2-e9k3dr fix"
-    (is (true?  (guard-decision [:rf.route/navigate {:url "/settings"}]))
-        "FAILING-BEFORE: a {:url ...} navigate to a protected route MUST be gated
-         — the old branch read handler-meta on the URL map, saw no tags, opened")
-    (is (false? (guard-decision [:rf.route/navigate {:url "/"}]))
-        "a {:url ...} navigate to a public route is allowed")
-    (is (true?  (guard-decision [:rf.route/navigate {:url "/settings?tab=x"}]))
-        "query string on the raw-URL target still resolves + gates"))
+    (testing "raw-URL {:url ...} :rf.route/navigate — the rf2-e9k3dr fix"
+      (is (skipped? (ctx-for [:rf.route/navigate {:url "/settings"}]))
+          "a {:url ...} navigate to a protected route is skipped")
+      (is (skipped? (ctx-for [:rf.route/navigate {:url "/settings?tab=x"}]))
+          "a query string on the raw-URL target still resolves + gates")
+      (let [ctx (ctx-for [:rf.route/navigate {:url "/"}])]
+        (is (= ctx (auth-guard-before ctx))
+            "a {:url ...} navigate to a public route is delivered normally")))
 
-  (testing "route-link click (:rf.route/url-requested) — both :to and :url forms"
-    (is (true?  (guard-decision [:rf.route/url-requested {:url "/settings"}]))
-        "a link click whose href resolves to a protected route is gated")
-    (is (true?  (guard-decision [:rf.route/url-requested {:to :app/settings}]))
-        "a :to link click to a protected route is gated")
-    (is (false? (guard-decision [:rf.route/url-requested {:url "/"}]))
-        "a link click to a public route is allowed"))
+    (testing "reserved :rf.route/self :rf.route/navigate — the rf2-yp3ip fix"
+      (is (skipped? (ctx-for [:rf.route/navigate :rf.route/self {} {:query-merge {:tab "x"}}]
+                             settings-slice))
+          "FAILING-BEFORE: a signed-out self-nav from a protected route MUST be
+           gated — the old branch read handler-meta on the bare :rf.route/self
+           keyword, saw no tags, and opened")
+      (is (= login-redirect
+             (redirect (ctx-for [:rf.route/navigate :rf.route/self {} {:query-merge {:tab "x"}}]
+                                settings-slice)))
+          "and redirected to login")
+      (let [ctx (ctx-for [:rf.route/navigate :rf.route/self {} {:query-merge {:page 2}}]
+                         home-slice)]
+        (is (= ctx (auth-guard-before ctx))
+            "a self-nav from a PUBLIC route is delivered normally"))
+      (is (let [ctx (ctx-for [:rf.route/navigate :rf.route/self {} {:query-merge {:tab "x"}}]
+                             settings-slice {:id 1})]
+            (= ctx (auth-guard-before ctx)))
+          "a self-nav from a protected route while SIGNED IN is delivered normally"))
 
-  (testing "URL-bar / popstate / deep-link (:rf.route/handle-url-change)"
-    (is (true?  (guard-decision [:rf.route/handle-url-change "/settings"]))
-        "pasting / reloading a protected URL is gated")
-    (is (false? (guard-decision [:rf.route/handle-url-change "/"]))
-        "the home URL is allowed"))
+    (testing "route-link click (:rf.route/url-requested) — both :to and :url"
+      (is (skipped? (ctx-for [:rf.route/url-requested {:url "/settings"}]))
+          "a link click whose href resolves to a protected route is gated")
+      (is (skipped? (ctx-for [:rf.route/url-requested {:to :app/settings}]))
+          "a :to link click to a protected route is gated")
+      (let [ctx (ctx-for [:rf.route/url-requested {:url "/"}])]
+        (is (= ctx (auth-guard-before ctx))
+            "a link click to a public route is delivered normally")))
 
-  (testing "unresolvable + non-navigation events short-circuit the guard"
-    (is (nil? (guard-decision [:rf.route/navigate {:url "/no/such/path"}]))
-        "a garbage raw-URL navigate is a non-match — the runtime routes it to
-         :rf.route/not-found, which is not a protected route")
-    (is (nil? (guard-decision [:rf.route/handle-url-change "/no/such/path"]))
-        "a garbage URL-bar entry is a non-match")
-    (is (nil? (guard-decision [:some/other-event 1 2]))
-        "an ordinary event is not a navigation — the guard stands aside")))
+    (testing "URL-bar / popstate / deep-link (:rf.route/handle-url-change)"
+      (is (skipped? (ctx-for [:rf.route/handle-url-change "/settings"]))
+          "pasting / reloading a protected URL is gated")
+      (let [ctx (ctx-for [:rf.route/handle-url-change "/"])]
+        (is (= ctx (auth-guard-before ctx))
+            "the home URL is delivered normally")))
+
+    (testing "unresolvable + non-navigation events stand aside"
+      (is (not (skipped? (ctx-for [:rf.route/navigate {:url "/no/such/path"}])))
+          "a garbage raw-URL navigate is a non-match — the runtime routes it to
+           :rf.route/not-found, which is not protected")
+      (is (not (skipped? (ctx-for [:rf.route/handle-url-change "/no/such/path"])))
+          "a garbage URL-bar entry is a non-match")
+      (let [ctx (ctx-for [:some/other-event 1 2])]
+        (is (= ctx (auth-guard-before ctx))
+            "an ordinary event is not a navigation — the guard stands aside")))))
+
+;; ---- End-to-end: guard on the frame; the protected route does NOT commit ---
+
+(deftest end-to-end-protected-self-nav-does-not-commit
+  (testing "rf2-yp3ip end-to-end — guard attached to the URL-owning frame: a
+            signed-out self-nav from a protected route is SKIPPED, so its query
+            change never commits to the route slice (the protected route and its
+            loaders do not commit)"
+    (register!)
+    (rf/reg-event :test/sign-in  (fn [{:keys [db]} _] {:db (assoc-in db [:auth :user] {:id 1})}))
+    (rf/reg-event :test/sign-out (fn [{:keys [db]} _] {:db (update db :auth dissoc :user)}))
+    ;; Attach the canonical guard to the URL-owning frame — it now runs :before
+    ;; every navigation entry event.
+    (rf/make-frame {:id :rf/default :url-bound? true :interceptors [:app/auth-guard]})
+
+    ;; Signed in, land on the protected route (guard lets us through).
+    (rf/dispatch-sync [:test/sign-in])
+    (rf/dispatch-sync [:rf.route/navigate :app/settings])
+    (is (= :app/settings (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+                                 [:rf.runtime/routing :current :route-id]))
+        "signed in, the guard admits the protected route")
+
+    ;; Session expires; a self-nav (query change) must NOT commit.
+    (rf/dispatch-sync [:test/sign-out])
+    (rf/dispatch-sync [:rf.route/navigate :rf.route/self {} {:query-merge {:tab "secret"}}])
+    (let [cur (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+                      [:rf.runtime/routing :current])]
+      (is (not= "secret" (get-in cur [:query :tab]))
+          "signed out, the guard skips the self-nav handler — the query change
+           never commits (fail CLOSED); the runtime would otherwise have applied
+           it in place on the protected route"))))
 
 ;; ---- The recipe mirrors the SHIPPED runtime (verify against navigate.cljc) --
 
 (deftest runtime-resolves-raw-url-navigate-to-the-protected-route
   (testing "the shipped :rf.route/navigate resolves a {:url ...} target through
-            match-url onto the real route-id — which is exactly WHY the recipe
-            must normalise the same way rather than trust the target to be a keyword"
-    (register-routes!)
+            match-url onto the real route-id — WHY the recipe must normalise the
+            same way rather than trust the target to be a keyword"
+    (register!)
     (rf/dispatch-sync [:rf.route/navigate {:url "/settings"}])
     (is (= :app/settings
            (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
@@ -125,3 +256,28 @@
         "raw-URL navigate lands the slice on the protected route-id")
     (is (= :app/settings (:route-id (routing/match-url "/settings")))
         "match-url hands the recipe the same route-id the runtime used")))
+
+(deftest runtime-resolves-self-to-the-current-protected-route
+  (testing "the shipped :rf.route/navigate resolves :rf.route/self against the
+            CURRENT route slice (navigate.cljc:262) — WHY the guard must read the
+            current slice the same way, or it fails open on the escape hatch"
+    (register!)
+    ;; :rf.route/self is NOT a registered route: the bare keyword carries no tags,
+    ;; which is exactly the fail-open the old {:id :rf.route/self} guard hit.
+    (is (nil? (rf/handler-meta :route :rf.route/self))
+        "the bare :rf.route/self keyword resolves to no route metadata")
+    (is (empty? (:tags (rf/handler-meta :route :rf.route/self)))
+        "so the old {:id :rf.route/self} normalisation carried no :requires-auth")
+    ;; The runtime holds the route-id fixed at the current (protected) route and
+    ;; applies only the query change — the operation the guard must recognise.
+    (rf/dispatch-sync [:rf.route/navigate :app/settings])
+    (rf/dispatch-sync [:rf.route/navigate :rf.route/self {} {:query-merge {:tab "x"}}])
+    (let [cur (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+                      [:rf.runtime/routing :current])]
+      (is (= :app/settings (:route-id cur))
+          "self-nav holds the route-id fixed at the protected route")
+      (is (= "x" (get-in cur [:query :tab]))
+          "and applies only the query change")
+      (is (contains? (:tags (rf/handler-meta :route (:route-id cur))) :requires-auth)
+          "resolving :rf.route/self to the current route-id surfaces the
+           :requires-auth tag the guard reads to fail closed"))))

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -1407,13 +1407,20 @@ A cross-cutting guard interceptor **must cover all three entry doors**, or it fa
 
 ;; Resolve the target route + params from ANY of the three navigation
 ;; events (fail-closed coverage — do not guard only :rf.route/navigate).
-(defn- nav-target [event]
+;; `current` is the current route slice ([:rf.runtime/routing :current]) — the
+;; reserved :rf.route/self target resolves against it, exactly as the runtime
+;; resolves it (§:rf.route/self — navigate-in-place).
+(defn- nav-target [event current]
   (let [[ev-id a b] event]
     (case ev-id
-      :rf.route/navigate          (if (map? a)                  ;; {:url ...} escape-hatch target
+      :rf.route/navigate          (cond
+                                    (= :rf.route/self a)          ;; reserved "stay here" target
+                                    {:id (:route-id current) :params (or (:params current) {})}
+                                    (map? a)                      ;; {:url ...} escape-hatch target
                                     (when-let [{:keys [route-id params]} (routing/match-url (:url a))]
                                       {:id route-id :params (or params {})})
-                                    {:id a :params (or b {})})  ;; a = route-id
+                                    :else                         ;; a = route-id
+                                    {:id a :params (or b {})})
       :rf.route/url-requested           (let [{:keys [to params url]} a]
                                     (cond
                                       to  {:id to :params (or params {})}
@@ -1428,7 +1435,11 @@ A cross-cutting guard interceptor **must cover all three entry doors**, or it fa
          cross-cutting rule spanning many routes, so an interceptor not :can-enter."}
   {:before
    (fn before [ctx]
-     (if-let [{:keys [id]} (nav-target (get-in ctx [:coeffects :event]))]
+     ;; The route slice is framework runtime-db state — read it from the
+     ;; :rf.db/runtime coeffect so `:rf.route/self` resolves to the current route.
+     (if-let [{:keys [id]} (nav-target (get-in ctx [:coeffects :event])
+                                       (get-in ctx [:coeffects :rf.db/runtime
+                                                    :rf.runtime/routing :current]))]
        (let [route-meta (rf/handler-meta :route id)
              gated?     (boolean (some #{:beta-section} (:tags route-meta)))
              enabled?   (get-in ctx [:coeffects :db :flags :beta])]
@@ -1449,7 +1460,7 @@ A cross-cutting guard interceptor **must cover all three entry doors**, or it fa
                 :interceptors [:app/section-lockout]})
 ```
 
-The `:rf.route/navigate` door itself carries **two target forms** (per [§Target form](#target-form--route-id-url-string-or-reserved)): a route-id, and the `{:url …}` escape hatch (deep links, redirects). A raw URL is not a route id, so the normaliser routes the `{:url …}` form through `match-url` exactly as the runtime does before the guard reads `handler-meta` — otherwise `[:rf.route/navigate {:url "/admin"}]` resolves `handler-meta` on a map, sees no tags, and slips past the gate. This is the target-union mirror of the three-door rule: cover both forms of the door too.
+The `:rf.route/navigate` door itself carries **three target forms** (per [§Target form](#target-form--route-id-url-string-or-reserved)): a route-id, the `{:url …}` escape hatch (deep links, redirects), and the reserved `:rf.route/self`. A raw URL is not a route id, so the normaliser routes the `{:url …}` form through `match-url` exactly as the runtime does before the guard reads `handler-meta` — otherwise `[:rf.route/navigate {:url "/admin"}]` resolves `handler-meta` on a map, sees no tags, and slips past the gate. `:rf.route/self` is not a route id either: it means *stay on the current route, change only the query*, and the runtime resolves its id from the current route slice ([§`:rf.route/self` — navigate-in-place](#rfrouteself--navigate-in-place)). The guard must resolve it the same way — from `[:rf.runtime/routing :current]` in the `:rf.db/runtime` coeffect — or it fails **open** exactly where it is most dangerous: a session that expires *while already on a `:requires-auth` route* self-navigates (a query change, a tab switch) and the guard, reading the bare `:rf.route/self` keyword, sees no tags and waves it through. This is the target-union mirror of the three-door rule: cover all three forms of the door too.
 
 Guards are interceptors, not a special routing mechanism. They are registered once and referenced by id; they compose — list multiple refs in the `:interceptors` chain and they layer in order. Prefer `:can-enter` when the policy belongs to one route; reach for a frame-`:interceptors` guard when it spans many routes uniformly, and cover all three doors when you do.
 


### PR DESCRIPTION
## What / why

PR #6058 closed the cross-cutting auth guard's raw-`{:url ...}` fail-open hole, but its synchronized copies still treated **every non-map** `:rf.route/navigate` target as a registered route id. `:rf.route/self` is a reserved **third** target form: the runtime resolves it from the current route slice (`navigate.cljc:262`), while the guard's normaliser resolved it to the literal keyword `:rf.route/self`. That keyword is not a registered route, so `handler-meta` found no `:requires-auth` tag and the guard **stood aside** — a fail-**open** hole exactly where it hurts most: a signed-out / expired session already sitting on a protected route (e.g. `:app/settings`) could **self-navigate** (a query change, a tab switch, `?page=2`) straight past the policy, and the route's loaders could proceed.

## Fix

Every guard copy now resolves `:rf.route/self` from the **current route slice** — read from the `:rf.db/runtime` coeffect at `[:rf.runtime/routing :current]`, exactly as the runtime does — **before** the `:requires-auth` check, so the guard sees the protected destination and fails **closed** (skip + redirect to login). Route-id and raw-URL targets are unchanged. Minimal and consistent across the copies; no new public routing API, no redesign of the guard/router.

**The five synchronized copies** (all now agree navigate has three target forms — route-id, raw-URL, reserved-self):
- `docs/routing/how-to/require-sign-in-on-a-route.md`
- `docs/core/how-to/add-auth.md`
- `docs/resources/tutorial/03-auth-and-forms.md`
- `examples/real-apps/realworld_resources/routing.cljs`
- `spec/012-Routing.md` — guard recipe + corrected the **"two target forms"** claim to **three** (it already documented all three in its own §Target form / `resolve-target` sections).

The canonical guard itself lives in the recipe copies; `navigate.cljc` already resolves `:rf.route/self` correctly (it is the reference the fix mirrors) and is unchanged.

## Closing the "false tooth" matrix

`routing_auth_guard_matrix_test` was a free-standing boolean duplicate — it computed `nav-target` + `handler-meta` in isolation and never executed the interceptor or proved redirect/non-commit (reverting an example copy left it green). It now **registers the canonical guard** and drives its `:before` (plus one end-to-end frame-wired dispatch) across the route-id, raw-URL, route-link, URL-change, and **reserved-self** doors: protected rows prove **skip + redirect** and that the protected route/loaders **do not commit**; public rows prove **normal delivery**. The `:rf.route/self` rows are fed a slice the **runtime produced**, so the pin proves the guard resolves self the same way the runtime does.

**Red-before / green-after (verified):** reverting the guard's `:rf.route/self` branch to the pre-fix "every non-map target is a route id" form flips the self rows (both the `:before` matrix rows and the end-to-end non-commit test) from gated to open — the signed-out self-nav commits `?tab=secret` on the protected route. With the fix, it is skipped and redirected to login.

## Quality gates

- `implementation/routing` JVM (`clojure -M:test`): **429 tests, 2133 assertions, 0 failures, 0 errors** (incl. the rewritten matrix: 4 tests / 27 assertions).
- `npm run test:cljs` (node-runtime CLJS, routing coverage): **9829 tests, 48333 assertions, 0 failures, 0 errors**.
- `python -m mkdocs build --strict`: **built clean** (the edited docs + spec build).
- `npx shadow-cljs compile :examples/realworld-resources` (touched example): **0 warnings**.
- Red-before confirmed by temporarily reverting the self branch (3 self-row failures, incl. the end-to-end query-commit leak), then restored.

Closes rf2-yp3ip.