### PR TITLE
fix(ui-compiler): host-exact ui/slot arity + transitive ui/render-fn purity fence (rf2-ckviw, rf2-vtfzn)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -2091,7 +2091,14 @@
   remaining args are the library's runtime values, walked in the ambient
   (library-view) scope — a slot ARGUMENT is not deferred, so a `(sub …)` there
   is the library's own render-time read. The slot's output participates in the
-  surrounding children exactly like any other child (child-like memo cost)."
+  surrounding children exactly like any other child (child-like memo cost).
+
+  A render-fn is a FIXED-arity callback (Spec 004 §render slots), so the slot
+  boundary owns ONE host-independent arity contract: an INLINE render-fn's
+  parameter count is compared with the slot's argument count HERE and a mismatch
+  is a compile error; a PROP-carried render-fn carries its arity into the runtime
+  carrier and `check-slot-arity!` enforces it before invocation on both hosts —
+  neither leans on a native fixed/variadic call quirk (rf2-ckviw)."
   [e form]
   (when (< (count form) 2)
     (env/fail! e :rf.ui.compile/bad-slot
@@ -2100,27 +2107,45 @@
                {:form form}))
   (let [slotval (nth form 1)
         args    (drop 2 form)
+        argc    (count args)
+        inline? (render-fn-form? e slotval)
         sid     (lexical-site-id e :slot form (:path e))
         args*   (into []
                       (map-indexed (fn [i a] (walk-expr e [:slot :arg i] a)))
                       args)
-        node    (cond-> {:op :slot
-                         :args args*
-                         :sid sid
-                         :static? false
-                         :path (:path e)}
-                  (render-fn-form? e slotval)
-                  (assoc :render-fn (analyze-render-fn
-                                     (update e :path conj :slot-fn) slotval))
-                  (not (render-fn-form? e slotval))
-                  (assoc :slot-value (if (literal-scalar? slotval)
-                                       slotval
-                                       (walk-expr e [:slot :value] slotval))))]
-    (env/add-site! e :slots {:sid sid
-                             :path (:path e)
-                             :source-coord (event-source-coord e form)
-                             :inline? (contains? node :render-fn)})
-    node))
+        ;; Analyze the inline body FIRST (so an impure body throws
+        ;; impure-slot-body before the arity check), then compare arity.
+        rf-node (when inline?
+                  (analyze-render-fn (update e :path conj :slot-fn) slotval))]
+    (when inline?
+      (let [pc (count (:params rf-node))]
+        (when (not= pc argc)
+          (env/fail! e :rf.ui.compile/slot-arity
+                     (str "(ui/slot render-fn arg…) passes " argc " argument"
+                          (when (not= 1 argc) "s") " to an inline (ui/render-fn "
+                          (pr-str (:params rf-node)) " …) that declares " pc
+                          " parameter" (when (not= 1 pc) "s")
+                          " — a render-fn is a FIXED-arity callback, so the slot must "
+                          "pass exactly its declared parameters (host-identically, "
+                          "before invocation). "
+                          (if (< argc pc)
+                            "Pass the missing argument(s), or drop the unused parameter(s)"
+                            "Drop the surplus argument(s), or declare the extra parameter(s)"))
+                     {:form form :expected pc :actual argc}))))
+    (let [node (cond-> {:op :slot
+                        :args args*
+                        :sid sid
+                        :static? false
+                        :path (:path e)}
+                 inline?       (assoc :render-fn rf-node)
+                 (not inline?) (assoc :slot-value (if (literal-scalar? slotval)
+                                                    slotval
+                                                    (walk-expr e [:slot :value] slotval))))]
+      (env/add-site! e :slots {:sid sid
+                               :path (:path e)
+                               :source-coord (event-source-coord e form)
+                               :inline? inline?})
+      node)))
 
 ;; ---------------------------------------------------------------------------
 ;; ui/error-boundary + ui/client-only (S3) — the interop recovery/boundary forms

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -1015,12 +1015,14 @@
                     ;; argument, a branch) — misplaced.
                     (and (symbol? head) (not (contains? locals head))
                          (env/resolves-to? e* head effect-fqns))
-                    (env/fail! e :rf.ui.compile/hook-misplaced
-                               (str "(effect …) is a host-effect STATEMENT — place it in a "
-                                    "defview's UNCONDITIONAL top region (or a top-region "
-                                    "let/do body) BEFORE the final template, never as an "
-                                    "expression, branch, or deferred callback")
-                               {:form f})
+                    (if (:in-render-fn? e)
+                      (impure-slot-fail! e "effect" f)
+                      (env/fail! e :rf.ui.compile/hook-misplaced
+                                 (str "(effect …) is a host-effect STATEMENT — place it in a "
+                                      "defview's UNCONDITIONAL top region (or a top-region "
+                                      "let/do body) BEFORE the final template, never as an "
+                                      "expression, branch, or deferred callback")
+                                 {:form f}))
 
                    (fn-form? f) (rw-fn f locals p)
                    (contains? #{'let 'let* 'loop 'loop*} head) (rw-let f locals p)
@@ -1890,6 +1892,21 @@
   [e head-info k kind form]
   (let [[_ bindings & body] form
         verb (if (= kind :ui-event) "ui/event" "ui/handler")]
+    ;; A committed callback authored as a component prop inside a render-fn slot
+    ;; body is the correctness-critical escape: a repeated slot reuses ONE lexical
+    ;; event-site key, so later rows overwrite the descriptor and every row's
+    ;; callback reads the last row's closure. The purity fence rejects it — the
+    ;; callback belongs to the owning view or a mounted defview (rf2-vtfzn).
+    (when (:in-render-fn? e)
+      (env/fail! e :rf.ui.compile/impure-slot-body
+                 (str "(" verb " …) at prop " k " inside a ui/render-fn slot body "
+                      "— a slot body is a PURE render fragment; a committed callback "
+                      "DISPATCHES / runs imperative work, which a slot body may not "
+                      "own (a repeated slot shares ONE lexical callback site, so "
+                      "every row would alias the last row's closure). Own the "
+                      "callback in the OWNING view, or MOUNT a defview that owns its "
+                      "handlers")
+                 {:prop k :form form}))
     (when-not (and (vector? bindings) (not (some #{'&} bindings))
                    (if (= kind :ui-event)
                      (= 1 (count bindings))
@@ -2191,6 +2208,19 @@
                         (pr-str fallback))
                    {:form form}))
       (let [on-error (:on-error opts)]
+        ;; :on-error DISPATCHES after the failing commit — a committed-callback
+        ;; dispatch surface. Inside a render-fn slot body it escapes the purity
+        ;; fence exactly like a component-prop callback, so reject it (the
+        ;; error-boundary and its :on-error belong to the owning view or a mounted
+        ;; defview; rf2-vtfzn). A fallback-only boundary stays legal in a slot.
+        (when (and (some? on-error) (:in-render-fn? e))
+          (env/fail! e :rf.ui.compile/impure-slot-body
+                     (str ":on-error inside a ui/render-fn slot body — a slot body "
+                          "is a PURE render fragment, and :on-error DISPATCHES after "
+                          "the failing commit, which a slot body may not own. Place "
+                          "the error-boundary (with its :on-error) in the OWNING "
+                          "view, or MOUNT a defview that owns the boundary")
+                     {:form form}))
         (when (and (some? on-error)
                    (not (and (vector? on-error) (keyword? (first on-error)))))
           (env/fail! e :rf.ui.compile/bad-error-boundary
@@ -2521,6 +2551,18 @@
   body…)` runs at each connect. The body is a DEFERRED callback (sub/lease/frame
   inside are rejected); it is spliced before the template by `analyze-hooks-body`."
   [e index form]
+  ;; The purity fence is TRANSITIVE: a render-fn slot body inherits the enclosing
+  ;; hooks region, so a leading (effect …) would otherwise reach this seam and be
+  ;; emitted as a React lifecycle hook INSIDE the deferred callback. A slot body
+  ;; is a PURE render fragment — its effects belong to the owning view or a
+  ;; mounted defview (rf2-vtfzn).
+  (when (:in-render-fn? e)
+    (env/fail! e :rf.ui.compile/impure-slot-body
+               (str "(effect …) inside a ui/render-fn slot body — a slot body is a "
+                    "PURE render fragment; a host effect is a lifecycle hook, which "
+                    "a slot body may not own. Run the effect in the OWNING view, or "
+                    "MOUNT a defview that owns its own effects")
+               {:form form}))
   (when (or (nil? (:self-id e)) (not (:hooks-region? e)))
     (env/fail! e :rf.ui.compile/hook-misplaced
                (str "(effect …) is a host-effect statement — legal ONLY in a "

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -410,7 +410,8 @@
   (case marker
     :render-fn
     [slot `(re-frame.ui.runtime/render-fn
-            (fn [~@(:params render-fn)] ~(emit-node (:body render-fn) st false)))]
+            (fn [~@(:params render-fn)] ~(emit-node (:body render-fn) st false))
+            ~(count (:params render-fn)))]
 
     :ui-event
     ;; foreign/view committed event callback — flags 0 (the controlled-input
@@ -534,10 +535,12 @@
   (let [rf      (gensym "rf-ui-slot")
         slotval (if-let [{:keys [params body]} (:render-fn node)]
                   `(re-frame.ui.runtime/render-fn
-                    (fn [~@params] ~(emit-node body st false)))
+                    (fn [~@params] ~(emit-node body st false))
+                    ~(count params))
                   (:slot-value node))]
     `(let [~rf ~slotval]
        (when (re-frame.ui.runtime/slot-ready? ~rf)
+         (re-frame.ui.runtime/check-slot-arity! ~rf ~(count (:args node)))
          (~rf ~@(:args node))))))
 
 (defn- emit-error-boundary

--- a/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
@@ -206,7 +206,8 @@
     ;; carrier the seam invokes via ui/slot. On the JVM its rendered output is
     ;; a structural tree node.
     :render-fn  `(re-frame.ui.tree/render-fn
-                  (fn [~@(:params render-fn)] ~(emit-node (:body render-fn))))
+                  (fn [~@(:params render-fn)] ~(emit-node (:body render-fn)))
+                  ~(count (:params render-fn)))
     value))
 
 (defn- emit-view [node]
@@ -254,10 +255,12 @@
   [node]
   (let [rf      (gensym "rf-ui-slot")
         slotval (if-let [{:keys [params body]} (:render-fn node)]
-                  `(re-frame.ui.tree/render-fn (fn [~@params] ~(emit-node body)))
+                  `(re-frame.ui.tree/render-fn (fn [~@params] ~(emit-node body))
+                                               ~(count params))
                   (:slot-value node))]
     `(let [~rf ~slotval]
        (when (re-frame.ui.tree/slot-ready? ~rf)
+         (re-frame.ui.tree/check-slot-arity! ~rf ~(count (:args node)))
          ((:f ~rf) ~@(:args node))))))
 
 (defn emit-node

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -256,12 +256,16 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private render-fn-mark "rf$render_fn")
+(def ^:private render-fn-arity-mark "rf$render_fn_arity")
 
 (defn render-fn
-  "Mark a compiled callback closure as a `ui/render-fn` value and return it.
-  The value is directly invocable; `slot` gates every invocation."
-  [f]
+  "Mark a compiled callback closure as a `ui/render-fn` value, recording its
+  fixed `arity` (the declared parameter count), and return it. The value is
+  directly invocable; `slot` gates every invocation and `check-slot-arity!`
+  enforces the arity host-identically before it fires."
+  [f arity]
   (unchecked-set f render-fn-mark true)
+  (unchecked-set f render-fn-arity-mark arity)
   f)
 
 (defn render-fn?
@@ -291,6 +295,25 @@
     (nil? x)        false
     (render-fn? x)  true
     :else           (invalid-slot! x)))
+
+(defn check-slot-arity!
+  "Enforce the host-independent ui/slot ↔ ui/render-fn arity contract BEFORE
+  invocation: a slot passing `argc` runtime args to a render-fn compiled with a
+  different fixed arity is the didactic `:rf.error/ui-tree-malformed` (the arity
+  twin of `invalid-slot!`) on BOTH hosts — neither leans on the native call
+  quirk (JS silently drops surplus args; the JVM throws a raw ArityException)."
+  [rf argc]
+  (let [arity (unchecked-get rf render-fn-arity-mark)]
+    (when (not= arity argc)
+      (error/throw-error!
+       :rf.error/ui-tree-malformed 're-frame.ui/slot
+       (str "a ui/slot passed " argc " argument" (when (not= 1 argc) "s")
+            " to a ui/render-fn that declares " arity " parameter"
+            (when (not= 1 arity) "s")
+            " — a render-fn is a fixed-arity callback; the slot must pass exactly "
+            "its declared parameters. Match the slot's argument count to the "
+            "render-fn's parameter vector")
+       {:extra {:expected arity :actual argc}}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Props ABI helpers (Q2/Q3)

--- a/implementation/ui/src/re_frame/ui/tree.cljc
+++ b/implementation/ui/src/re_frame/ui/tree.cljc
@@ -354,12 +354,14 @@
 ;; masquerade as tree content nor be sanitized as an ordinary opaque fn.
 ;; ---------------------------------------------------------------------------
 
-(defrecord RenderFn [f])
+(defrecord RenderFn [f arity])
 
 (defn render-fn
-  "Wrap a compiled pure-render closure as a `ui/render-fn` value."
-  [f]
-  (->RenderFn f))
+  "Wrap a compiled pure-render closure as a `ui/render-fn` value, recording its
+  fixed `arity` (the declared parameter count) so `check-slot-arity!` can enforce
+  the arity host-identically."
+  [f arity]
+  (->RenderFn f arity))
 
 (defn render-fn?
   "True when `x` is a compiled `ui/render-fn` value."
@@ -385,6 +387,25 @@
     (nil? x)       false
     (render-fn? x) true
     :else          (invalid-slot! x)))
+
+(defn check-slot-arity!
+  "Enforce the host-independent ui/slot ↔ ui/render-fn arity contract BEFORE
+  invocation: a slot passing `argc` runtime args to a render-fn compiled with a
+  different fixed arity is the didactic `:rf.error/ui-tree-malformed` (the arity
+  twin of `invalid-slot!`) on BOTH hosts — neither leans on the native call
+  quirk (JS silently drops surplus args; the JVM throws a raw ArityException)."
+  [rf argc]
+  (let [arity (:arity rf)]
+    (when (not= arity argc)
+      (error/throw-error!
+       :rf.error/ui-tree-malformed 're-frame.ui/slot
+       (str "a ui/slot passed " argc " argument" (when (not= 1 argc) "s")
+            " to a ui/render-fn that declares " arity " parameter"
+            (when (not= 1 arity) "s")
+            " — a render-fn is a fixed-arity callback; the slot must pass exactly "
+            "its declared parameters. Match the slot's argument count to the "
+            "render-fn's parameter vector")
+       {:extra {:expected arity :actual argc}}))))
 
 (defn sanitize-prop
   "View-boundary :props sanitization (top-level values only): render-fn

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -920,7 +920,10 @@
   ;; statically-referenced internal view head — a stateful replacement part is
   ;; a PURE slot body mounting a static defview that owns its own state. If this
   ;; regressed, the wave-2 registered-ui/view gate analysis would have to redo.
-  (let [ast (ana* '[:ul (slot (render-fn [x] [child-view {:v x} [:em "kid"]]))])
+  ;; NOTE the matched slot arity: each inline render-fn declares exactly the
+  ;; parameters the slot supplies (1 arg → 1 param), the fixed-arity contract
+  ;; (rf2-ckviw).
+  (let [ast (ana* '[:ul (slot (render-fn [x] [child-view {:v x} [:em "kid"]]) item)])
         slot (first (:children ast))
         body (get-in slot [:render-fn :body])]
     (is (= :slot (:op slot)))
@@ -928,7 +931,8 @@
     (is (= :app.views/child-view (:view-id body)))
     (testing "a slot body may also mount a static view under control flow / for"
       (let [ast2 (ana* '[:ul (slot (render-fn [xs]
-                                     (for [x xs] [child-view {:key (:id x) :v x}])))])
+                                     (for [x xs] [child-view {:key (:id x) :v x}]))
+                                   items)])
             body2 (get-in ast2 [:children 0 :render-fn :body])]
         (is (= :for (:op body2)))
         (is (= :view (get-in body2 [:body :op])) "the keyed for row is an internal view")))))

--- a/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
@@ -73,6 +73,8 @@
     :rf.ui.compile/bad-slot
     :rf.ui.compile/render-fn-misplaced
     :rf.ui.compile/impure-slot-body
+    ;; host-exact slot ↔ render-fn arity (rf2-ckviw)
+    :rf.ui.compile/slot-arity
     ;; props
     :rf.ui.compile/bad-class
     :rf.ui.compile/bad-style
@@ -354,6 +356,16 @@
     ["FIXED arg list"]]
    [:rf.ui.compile/bad-slot '(slot) ["render-fn value"]]
    [:rf.ui.compile/bad-slot '[:div {:title (slot r 1)}] ["child position"]]
+   ;; host-exact slot ↔ render-fn arity (rf2-ckviw): an INLINE render-fn's
+   ;; parameter count must match the slot's argument count — too-few and too-many
+   ;; are host-independent compile errors (JS silently drops surplus args; the
+   ;; JVM throws ArityException — the compiler owns ONE contract instead).
+   [:rf.ui.compile/slot-arity
+    '(slot (render-fn [a b] [:p a b]) x)
+    ["FIXED-arity" "declares 2 parameter"]]
+   [:rf.ui.compile/slot-arity
+    '(slot (render-fn [a] [:p a]) x y)
+    ["FIXED-arity" "Drop the surplus"]]
    [:rf.ui.compile/render-fn-misplaced
     '(render-fn [a] [:p a]) ["ui/slot" "prop value"]]
    [:rf.ui.compile/render-fn-misplaced

--- a/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
@@ -382,6 +382,22 @@
    [:rf.ui.compile/impure-slot-body
     '(slot (render-fn [a] [:div {:ref r} "x"]))
     ["commit-phase" "Mount a defview"]]
+   ;; transitive purity fence (rf2-vtfzn): a COMMITTED-CALLBACK / dispatch surface
+   ;; authored inside a render-fn body escapes the fence unless rejected. A
+   ;; component-prop ui/event / ui/handler is the correctness-critical one — a
+   ;; repeated slot shares ONE lexical callback site, aliasing every row's
+   ;; closure to the last row. (The leading (effect …) statement needs a hooks
+   ;; region and is exercised in effect-inside-render-fn-is-impure below.)
+   [:rf.ui.compile/impure-slot-body
+    '(slot (render-fn [row] [child-view {:on-pick (event [e] [:pick (:id row)])}]) item)
+    ["DISPATCHES" "alias the last row"]]
+   [:rf.ui.compile/impure-slot-body
+    '(slot (render-fn [row] [child-view {:on-pick (handler [e] (do-it (:id row)))}]) item)
+    ["DISPATCHES" "alias the last row"]]
+   [:rf.ui.compile/impure-slot-body
+    '(slot (render-fn [a] (error-boundary {:fallback child-view :on-error [:oops a]}
+                                          [:p "x"])) item)
+    [":on-error" "DISPATCHES"]]
    ;; props
    [:rf.ui.compile/bad-class '[:div {:class {(kw) true}} "x"] ["literal names"]]
    [:rf.ui.compile/bad-style '[:div {:style {(kw) 1}} "x"] ["dynamic expression"]]
@@ -437,6 +453,32 @@
   (doseq [[id form names] analyzer-roster]
     (testing (str id " <- " (pr-str form))
       (assert-row! (reject form) id form names))))
+
+(deftest effect-inside-render-fn-is-impure
+  ;; rf2-vtfzn — the primary escape: a render-fn slot body INHERITS the enclosing
+  ;; hooks region, so a leading (effect …) in a top-region let inside the body was
+  ;; accepted and emitted as a React lifecycle hook INSIDE the deferred callback.
+  ;; This needs a hooks-region env (a slot authored in a defview's top region), so
+  ;; it cannot ride the mk-env roster table above.
+  (let [e (assoc (mk-env) :hooks-region? true :top-region? true)
+        ex (try (ana/analyze e '(slot (render-fn [a]
+                                        (let [x 1] (effect [] (side-effect! x a)) [:div]))
+                                      item))
+                nil
+                (catch #?(:clj clojure.lang.ExceptionInfo
+                          :cljs cljs.core/ExceptionInfo) ex ex))]
+    (assert-row! ex :rf.ui.compile/impure-slot-body
+                 '(slot (render-fn [a] (let [x 1] (effect [] (side-effect! x a)) [:div])) item)
+                 ["lifecycle hook" "MOUNT a defview"]))
+  (testing "mutation control — the SAME effect in a real defview top region is LEGAL"
+    ;; the fence must fire ONLY inside :in-render-fn?, not on a legitimate
+    ;; top-region effect: a leading (effect …) in a genuine hooks region (no
+    ;; render-fn wrapper) still lowers to a :hook-prefix, so the fence is not
+    ;; over-firing on ordinary top-region effects.
+    (let [e   (assoc (mk-env) :hooks-region? true :top-region? true)
+          ast (ana/analyze e '(let [x 1] (effect [] (side-effect! x)) [:div "ok"]))]
+      (is (= :hook-prefix (get-in ast [:body :op]))
+          "a leading (effect …) in a genuine defview top region stays legal"))))
 
 (deftest dynamic-props-map-diagnostic
   ;; hiccup structure makes a non-map/non-spread props position a CHILD,

--- a/implementation/ui/test/re_frame/ui/parity_fixtures.cljc
+++ b/implementation/ui/test/re_frame/ui/parity_fixtures.cljc
@@ -340,6 +340,18 @@
   [{:keys [rows]}]
   [slot-table {:rows rows :render nil}])
 
+(defview slot-bad-arity-consumer
+  "rf2-ckviw end-to-end fixture: the consumer supplies a ONE-parameter renderer,
+  but slot-table invokes `(ui/slot render i r)` with TWO args. The mismatch is not
+  statically visible here (a prop-carried render-fn), so the carrier records arity
+  1 and the slot seam's `check-slot-arity!` fails didactically BEFORE invocation on
+  both hosts — never the native quirk (JS drops the surplus arg; the JVM throws
+  ArityException). NOT a member of `views`/`cases` — it throws on render by design."
+  [{:keys [rows]}]
+  [slot-table {:rows rows
+               :render (ui/render-fn [only-row]
+                         [:span.cell (:name only-row)])}])
+
 ;; ---------------------------------------------------------------------------
 ;; Cases — pure data; the SINGLE corpus both hosts consume
 ;; ---------------------------------------------------------------------------

--- a/implementation/ui/test/re_frame/ui/slot_render_fn_arity_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/slot_render_fn_arity_cljs_test.cljc
@@ -1,0 +1,89 @@
+(ns re-frame.ui.slot-render-fn-arity-cljs-test
+  "rf2-ckviw — the RUNTIME half of the host-exact ui/slot ↔ ui/render-fn arity
+  contract (the INLINE compile-time half is the `:rf.ui.compile/slot-arity`
+  roster rows in error_roster_cljs_test). A prop-carried render-fn cannot be
+  arity-checked at the slot call site (the value arrives at a library seam), so
+  the compiled carrier RECORDS its fixed arity and the slot seam's
+  `check-slot-arity!` enforces it BEFORE invocation — identically on both hosts,
+  leaning on neither native call quirk (JS silently drops surplus args; the JVM
+  throws a raw ArityException). One `.cljc` source runs the carrier seam on both
+  hosts; the JVM half additionally proves the emitter wires the check ahead of
+  the invocation end to end."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            ;; the render-slot CARRIER vocabulary — the CLJS runtime twin and the
+            ;; JVM tree twin expose the same render-fn / check-slot-arity! surface.
+            #?(:clj  [re-frame.ui.tree :as carrier]
+               :cljs [re-frame.ui.runtime :as carrier])
+            #?(:clj [re-frame.ui.parity-fixtures :as fx])))
+
+(defn- caught
+  "Run `thunk`; -> the thrown ExceptionInfo, or nil when it returns."
+  [thunk]
+  (try (thunk) nil
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) ex
+         ex)))
+
+;; ---------------------------------------------------------------------------
+;; The carrier seam — host-identical arity enforcement (both hosts)
+;; ---------------------------------------------------------------------------
+
+(deftest exact-arity-passes-the-seam
+  ;; a render-fn compiled with arity N, invoked with N slot args, never fires.
+  (let [rf0 (carrier/render-fn (fn [] :zero) 0)
+        rf2 (carrier/render-fn (fn [a b] [a b]) 2)]
+    (is (nil? (caught #(carrier/check-slot-arity! rf0 0)))
+        "a zero-arg slot over a zero-param render-fn is legal")
+    (is (nil? (caught #(carrier/check-slot-arity! rf2 2)))
+        "a two-arg slot over a two-param render-fn is legal")))
+
+(deftest too-few-and-too-many-fail-didactically-with-identical-shape
+  ;; the SAME code path on each host: the carrier records arity, the seam throws
+  ;; the canonical :rf.error/ui-tree-malformed BEFORE any invocation. This is the
+  ;; parity proof — identical category + message data on CLJS and JVM.
+  (let [rf2 (carrier/render-fn (fn [a b] [a b]) 2)]
+    (doseq [[argc dir] [[1 :too-few] [3 :too-many]]]
+      (testing (str dir " (" argc " args, arity 2)")
+        (let [ex (caught #(carrier/check-slot-arity! rf2 argc))]
+          (is (some? ex) "a mismatched arity throws before invocation")
+          (is (= :rf.error/ui-tree-malformed (:rf.error/id (ex-data ex)))
+              "the arity twin reuses the slot-malformed runtime id")
+          (is (= 're-frame.ui/slot (:where (ex-data ex))) "thrown as ui/slot")
+          (is (= 2 (:expected (ex-data ex))) "carries the render-fn's declared arity")
+          (is (= argc (:actual (ex-data ex))) "carries the passed argument count")
+          (let [m (ex-message ex)]
+            (is (str/includes? m "fixed-arity callback")
+                "names the fixed-arity contract")
+            (is (str/includes? m "declares 2 parameter")
+                "names the declared parameter count")
+            (is (str/includes? m (str "passed " argc " argument"))
+                "names the passed argument count")))))))
+
+;; ---------------------------------------------------------------------------
+;; End-to-end (JVM): the emitter wires check-slot-arity! AHEAD of invocation
+;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (deftest prop-carried-arity-mismatch-throws-on-render-before-invocation
+     ;; slot-table invokes `(ui/slot render i r)` (2 args); the bad consumer
+     ;; supplies a ONE-param render-fn. The mismatch is invisible at each call
+     ;; site (a prop-carried value crossing the library seam), so ONLY the
+     ;; carrier-recorded arity + the emitted check can catch it — and it must,
+     ;; before the render-fn body runs (a raw ArityException would be host-only).
+     (let [rows [{:id 1 :name "alpha"} {:id 2 :name "beta"}]
+           ex   (caught #(re-frame.ui.tree/render fx/slot-bad-arity-consumer
+                                                  {:rows rows}))]
+       (is (some? ex) "rendering a wrong-arity prop-carried slot throws")
+       (is (= :rf.error/ui-tree-malformed (:rf.error/id (ex-data ex)))
+           "the didactic slot-malformed id, NOT a raw ArityException")
+       (is (str/includes? (ex-message ex) "fixed-arity callback")
+           "the message names the arity contract")
+       (is (= 1 (:expected (ex-data ex))) "the render-fn declared arity 1")
+       (is (= 2 (:actual (ex-data ex))) "the slot passed 2 args"))
+     (testing "mutation control — the correct-arity consumer renders cleanly"
+       ;; slot-consumer supplies a two-param render-fn and slot-table passes two
+       ;; args: the fence must NOT fire on a matching arity.
+       (let [rows [{:id 1 :name "alpha"}]
+             out  (caught #(re-frame.ui.tree/render fx/slot-consumer {:rows rows}))]
+         (is (nil? out)
+             "a matched-arity prop-carried slot renders without throwing")))))


### PR DESCRIPTION
Coupled compiler-lane cluster on `implementation/ui/src/re_frame/ui/compiler/analyze.cljc` (one serial surface, one worker). Both bugs were the S3→S4 critical path, blocking the final S3 conformance bead `rf2-vxgfnd.95.10`. Two commits, one per bead.

## rf2-ckviw (P2) — host-exact `ui/slot` ↔ `ui/render-fn` arity

`#6032` declared `ui/render-fn` a fixed-arity callback, but `analyze-slot` never compared the slot's arg count with the render-fn's parameter vector and no carrier recorded arity, so `(ui/slot (ui/render-fn [x] …) 1 2)` diverged by host — JS dropped the surplus arg; the JVM threw a raw `ArityException`. The slot boundary now owns ONE host-independent contract:

- **Inline** render-fn/arg mismatch (too-few and too-many) is a compile error, the new compile-tier `:rf.ui.compile/slot-arity` — rejected didactically on both hosts. The inline body is analyzed first, so an impure body still fails with `impure-slot-body` ahead of the arity check.
- **Prop-carried** render-fns: the compiled carrier (`re-frame.ui.runtime` + `re-frame.ui.tree`) records its fixed arity; the slot seam's new `check-slot-arity!` enforces it BEFORE invocation on both hosts, reusing the existing `:rf.error/ui-tree-malformed` runtime id (the arity twin of `invalid-slot!`).

## rf2-vtfzn (P1) — transitive `ui/render-fn` purity fence

`analyze-render-fn` set `:in-render-fn?` while inheriting the enclosing `:hooks-region?`, so a leading `(ui/effect …)` in a render-fn top-region `let` was emitted as a React hook inside the deferred callback; component-prop `ui/event`/`ui/handler` and error-boundary `:on-error` likewise did not reject `:in-render-fn?`. Correctness-critical for repeated slots (one lexical event-site key → later rows overwrite the descriptor → every row callback reads the last row's closure). Closed the ONE boundary — every effect / committed-callback / `:on-error` surface under `:in-render-fn?` now fails with `:rf.ui.compile/impure-slot-body` (`analyze-effect-statement`, the `rewrite-expr` effect-as-expression branch, `analyze-component-callback`, `analyze-error-boundary`). The intended pattern stays legal: a slot body may MOUNT a static defview that owns its own hooks/handlers.

## Compile-tier / Spec 009

Both fixes stay within existing catalogue surface — no Spec 009 change (rf2-s522m is live there):
- `:rf.ui.compile/slot-arity` is a COMPILE-tier id (per the rf2-vxgfnd.95.13 ruling, compile-tier ids carry no Spec 009 rows); added to the frozen S1e roster.
- `check-slot-arity!` reuses the already-catalogued runtime id `:rf.error/ui-tree-malformed` (009 already lists `re-frame.ui.runtime` / `re-frame.ui.tree` as emitters; `invalid-slot!` already reuses it for slot misuse). No new runtime id, no 009 touch.

`events.cljs` (rf2-677rf) and `emit_cljs.cljc`'s defview path (rf2-eukmp) were not touched; the only emit change is the arity carrier arg + the `check-slot-arity!` call the arity contract requires.

## Quality gates

Foreground, unpiped, run after both commits:

- `implementation/ui` JVM (`clojure -M:test`): **744 tests, 13836 assertions, 0 failures, 0 errors**.
- `npm run test:cljs` (node runtime, both hosts of the `.cljc` suites): **9832 tests, 48376 assertions, 0 failures, 0 errors**.

Red-before/green-after:
- ckviw — `(ui/slot (ui/render-fn [x] …) 1 2)` diverged JS/JVM; now `:rf.ui.compile/slot-arity` on both hosts (inline, compile-time) + `check-slot-arity!` before invocation for prop-carried (new `slot_render_fn_arity` test: carrier seam on both hosts + JVM end-to-end mismatch throwing the didactic id, not `ArityException`, with a matched-arity control).
- vtfzn — a leading `(ui/effect …)` / prop `ui/event`/`ui/handler` / `:on-error` inside a render-fn is now rejected with `impure-slot-body`; the mount-a-defview accept fixtures stay green; a top-region-effect mutation control proves the fence fires only under `:in-render-fn?`.
