### PR TITLE
fix(ui): authenticate the superseding receipt envelope before silent settlement (rf2-x2vrh)

### DIFF
--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -542,30 +542,42 @@
 
 (defn- superseding-index
   "Index a superseding attempt's receipt writes by `frame-id →
-  {:root-id :rev}` for the benign-supersession check. A nil receipt / no
-  writes yields `{}`. Only the render-supersession abort path (a later
-  `render!*` seating a new attempt for the SAME root) supplies one; every
+  {:root-id :rev :receipt-root-id}` for the benign-supersession check. Each
+  entry carries the receipt's OUTER `:root-id` — the controller that presents
+  the write — alongside the write's own root/rev, so `benign-supersession?`
+  can AUTHENTICATE the envelope: a legitimate receipt's outer controller equals
+  the root of every write it minted (execute-frame-plans* stamps both from the
+  same arriving root), so an entry whose outer controller was swapped for a
+  foreign root can never silently settle another attempt's write. A nil
+  receipt / no writes yields `{}`. Only the render-supersession abort path (a
+  later `render!*` seating a new attempt for the SAME root) supplies one; every
   other abort/finalize path passes none, so out-of-band stale settlements stay
   dev-loud."
-  [superseding-receipt]
+  [{receipt-root-id :root-id :as superseding-receipt}]
   (into {}
         (map (fn [{:keys [frame-id root-id rev]}]
-               [frame-id {:root-id root-id :rev rev}]))
+               [frame-id {:root-id root-id :rev rev
+                          :receipt-root-id receipt-root-id}]))
         (:writes superseding-receipt)))
 
 (defn- benign-supersession?
   "True when an aborted write was LEGITIMATELY overtaken by the superseding
   same-root attempt, so its revision mismatch is EXPECTED SETTLEMENT rather than
-  an authority failure. Suppression is precise: the superseding attempt must own
-  this exact frame-id, under the SAME root as the aborted write, and the CURRENT
-  record must BE that superseding write (its rev, its root). Anything else — a
-  foreign-root receipt, a pruned/missing record, a reincarnation, or a divergence
-  the superseding attempt does not account for — is NOT benign and stays
-  dev-loud. `superseding` is the `superseding-index` map (empty for the
-  non-supersession settlement paths, so those never suppress)."
+  an authority failure. Suppression is precise: the superseding receipt's
+  ENVELOPE must be AUTHENTIC — its outer controller root must match the write it
+  presents — that write must own this exact frame-id, under the SAME root as the
+  aborted write, and the CURRENT record must BE that superseding write (its rev,
+  its root). Anything else — a split envelope (a foreign outer controller
+  presenting the owner's intact inner write), a foreign-root write, a
+  pruned/missing record, a reincarnation, or a divergence the superseding attempt
+  does not account for — is NOT benign and stays dev-loud. `superseding` is the
+  `superseding-index` map (empty for the non-supersession settlement paths, so
+  those never suppress)."
   [superseding receipt-root-id {:keys [frame-id root-id]} record]
-  (when-some [{sup-root :root-id sup-rev :rev} (get superseding frame-id)]
+  (when-some [{sup-root :root-id sup-rev :rev sup-receipt-root :receipt-root-id}
+              (get superseding frame-id)]
     (and (= receipt-root-id root-id)            ; the aborted write names its own root
+         (= sup-receipt-root sup-root)          ; the superseding ENVELOPE vouches for its own write
          (= sup-root root-id)                   ; the superseding write is the SAME root
          (some? record)
          (= sup-rev (:rev record))              ; current authority IS that attempt

--- a/implementation/ui/test/re_frame/ui/preflight_authority_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/preflight_authority_cljs_test.cljc
@@ -420,6 +420,59 @@
         (is (nil? (:mount-incomplete (frames/installed-plan-entry fid)))
             "the foreign controller never mutates the owner's record")))))
 
+(deftest split-envelope-superseder-with-foreign-outer-root-stays-loud
+  (testing "a superseding receipt whose INNER writes are the legitimate owner's
+            but whose OUTER :root-id was swapped for a foreign controller is a
+            SPLIT ENVELOPE: authenticating only the inner write fields would let
+            it silently settle the overtaken write (rf2-x2vrh). The envelope must
+            be authenticated — outer controller = the write it presents — so the
+            abort emits exactly one evidence-mismatch and never mutates the
+            current owner-authoritative record."
+    (let [fid    :sup/split-envelope
+          rcpt-a (frames/execute-frame-plans! :root/owner [(plan fid "cfa-aaaaaaaaaaaaaa")])
+          rcpt-b (frames/execute-frame-plans! :root/owner [(plan fid "cfb-bbbbbbbbbbbbbb")])]
+      (is (= [:root/owner] (mapv :root-id (:writes rcpt-b)))
+          "sanity: B's inner writes legitimately name the owner root")
+      (is (= "cfb-bbbbbbbbbbbbbb" (:config-fingerprint (frames/installed-plan-entry fid)))
+          "sanity: B is the live owner-authoritative record before the OLD abort")
+      ;; Tamper ONLY B's OUTER controller identity; the inner writes stay
+      ;; :root/owner — the exact split the inner-only guard misses.
+      (let [tampered-b (assoc rcpt-b :root-id :root/foreign)
+            mismatches (capture-mismatches
+                        #(frames/abort-preflight-attempt! rcpt-a tampered-b))]
+        (is (= 1 (count mismatches))
+            "the un-authenticated split envelope cannot suppress the mismatch")
+        (is (= :record-revision-mismatch (:reason (first mismatches)))
+            "…the overtaken write is surfaced, not silently settled")
+        (is (= fid (:frame (first mismatches))))
+        (let [entry (frames/installed-plan-entry fid)]
+          (is (= :root/owner (owner-root entry))
+              "B remains the owner-authoritative record")
+          (is (= "cfb-bbbbbbbbbbbbbb" (:config-fingerprint entry))
+              "…at B's config, unmutated by the rejected settlement")
+          (is (nil? (:mount-incomplete entry))
+              "the split-envelope abort never mutates the current record"))))))
+
+(deftest same-root-superseder-with-authentic-envelope-still-settles-silently
+  (testing "the envelope authentication does NOT over-tighten the benign path:
+            an ordinary same-root A→B receipt whose outer controller matches its
+            inner writes still settles the overtaken write silently, B stays
+            authoritative (rf2-x2vrh control)"
+    (let [fid    :sup/authentic-envelope
+          rcpt-a (frames/execute-frame-plans! :root/owner [(plan fid "cfa-aaaaaaaaaaaaaa")])
+          rcpt-b (frames/execute-frame-plans! :root/owner [(plan fid "cfb-bbbbbbbbbbbbbb")])]
+      (is (= :root/owner (:root-id rcpt-b))
+          "sanity: B's outer envelope legitimately names the owner root")
+      (let [mismatches (capture-mismatches
+                        #(frames/abort-preflight-attempt! rcpt-a rcpt-b))]
+        (is (empty? mismatches)
+            "an authentic same-root envelope settles the overtaken write silently")
+        (let [entry (frames/installed-plan-entry fid)]
+          (is (= :root/owner (owner-root entry)) "B still owns the record")
+          (is (= "cfb-bbbbbbbbbbbbbb" (:config-fingerprint entry)) "…at B's config")
+          (is (nil? (:mount-incomplete entry))
+              "the authentic abort did not clobber B's live record"))))))
+
 (deftest reincarnation-not-suppressed-even-under-a-superseding-receipt
   (testing "if the frame is destroyed after the superseding attempt refreshed it,
             the OLD receipt's abort finds no record for it and stays dev-loud —


### PR DESCRIPTION
## What

PR #6060 suppresses an old preflight receipt's revision mismatch when a later same-root receipt owns the exact current write. The suppression authenticated only the superseding receipt's **inner** write fields: `superseding-index` discarded the receipt's outer `:root-id`, and `benign-supersession?` compared the write root/rev with the old write and current record.

That left a **split-envelope** authority gap: a *foreign outer controller* presenting the legitimate owner's *intact inner write* settled silently. A deterministic probe ran attempts A + B for `:root/owner`, changed **only** B's outer `:root-id` to `:root/foreign` (inner write untouched), and aborted A with that tampered superseder → **zero** `:rf.error/frame-preflight-evidence-mismatch` records while B stayed owner-authoritative. Closed `rf2-5ep117`'s fixture changes *both* the outer controller and inner write, so it missed this split case.

## Fix

Authenticate the envelope at the `superseding-index` / `benign-supersession?` seam (`implementation/ui/src/re_frame/ui/frames.cljc`):

- `superseding-index` now carries each entry's **outer** receipt `:root-id` alongside the write's own root/rev.
- `benign-supersession?` adds one check — `(= sup-receipt-root sup-root)` — requiring the superseding envelope's outer controller to match the inner write it presents. Combined with the pre-existing `sup-root = aborted-write root = current record root` chain, the envelope is transitively tied to the write it presents **and** the current owner.

A legitimate receipt always stamps outer and inner roots from the same arriving root (`execute-frame-plans*`), so this never over-tightens the ordinary same-root benign path; a swapped outer controller can no longer vouch for a write it did not mint.

Reuses the existing `:rf.error/frame-preflight-evidence-mismatch` id — **no new error-id, no Spec 009 catalogue row**. No touch to `analyze.cljc` / `emit_cljs.cljc` / tooling / tools; the change is entirely in `frames.cljc`'s runtime preflight seam plus its cross-host test.

## Test

Adds to `preflight_authority_cljs_test.cljc` (cross-host `.cljc`):

- `split-envelope-superseder-with-foreign-outer-root-stays-loud` — the exact tamper (B's outer `:root-id` → `:root/foreign`, inner write intact); asserts **exactly one** `:record-revision-mismatch` and the current record unmutated (B stays owner-authoritative at B's config).
- `same-root-superseder-with-authentic-envelope-still-settles-silently` — control: an authentic same-root A→B envelope still settles silently, B stays authoritative.

**Red before / green after** (target namespace, unfixed → fixed source):

- Unfixed: 3 failures, all in the split-envelope test (`(= 1 (count mismatches))` → `0`). The authentic-envelope control passed.
- Fixed: 0 failures.

## Quality gates

- `implementation/ui` JVM (`clojure -M:test`): **742 tests, 13801 assertions, 0 failures, 0 errors**.
- `npm run test:cljs` (node CLJS): **9839 tests, 48380 assertions, 0 failures, 0 errors**.
- Per-namespace red-before / green-after confirmed for `re-frame.ui.preflight-authority-cljs-test` (15 tests, 84 assertions).
- Not run (per brief): `test:browser`, full spine. `rf2-9kj98` (supersession browser proof) is queued behind this runtime fix.

Closes rf2-x2vrh.
