### PR TITLE
fix(ui-compiler): define recursive defviews on their canonical current-namespace Var (rf2-eukmp)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -17,7 +17,13 @@
   (:require [clojure.string :as str]
             [clojure.walk :as walk]
             [re-frame.ui.compiler.analyze :as ana]
-            [re-frame.ui.rules :as rules]))
+            [re-frame.ui.rules :as rules]
+            ;; JVM-only: a self-recursive view completes the same-named `:refer`
+            ;; shadowing in the LIVE CLJS analyzer state so its def/declare
+            ;; resolve to the current-ns Var (see `emit-defview`). Never loaded on
+            ;; the CLJS host — the emitter only mutates analyzer state on the JVM
+            ;; macro-expansion path.
+            #?(:clj [cljs.env])))
 
 (def ^:private props-sym 'rf-ui-props)
 
@@ -771,6 +777,25 @@
                             :rf.ui/children? children?}
                      docstring   (assoc :doc docstring)
                      closed-keys (assoc :rf.ui/closed-prop-keys (vec closed-keys)))]
+    ;; A self-recursive view whose name collides with a same-named `:refer`
+    ;; (e.g. `(defview sub …)` where the ns refers re-frame.ui/sub) must resolve
+    ;; its OWN declare/def/head to the current-namespace Var, not the refer. The
+    ;; CLJS analyzer already signals this shadowing on the def (its `:redef`
+    ;; warning: "sub … replaced by <ns>/sub", and it adds sub to `:excludes`) —
+    ;; but cljs.analyzer/resolve-var ranks `:uses` (refers) ABOVE `:defs` and
+    ;; ignores `:excludes`, so a bare def name still resolves through the refer
+    ;; and BOTH clobbers the public authoring Var (`re_frame.ui.sub = …`) and
+    ;; leaves the qualified self head (`<ns>.sub`) undefined — the split identity.
+    ;; Completing the shadowing the analyzer already intends — dropping the view's
+    ;; own name from the live ns `:uses` — makes the declare, the def, and the
+    ;; recursive head share the one canonical current-ns Var. JVM-only: this is
+    ;; the macro-expansion path with the live compiler env; non-recursive views
+    ;; and the CLJS-host golden path are untouched.
+    #?(:clj
+       (when (and (:self-ref? @st) self-fqn (some? cljs.env/*compiler*))
+         (swap! cljs.env/*compiler* update-in
+                [:cljs.analyzer/namespaces (symbol (namespace self-fqn)) :uses]
+                dissoc vname)))
     `(do
        ;; A self-recursive view forward-declares its Var so the `$render` fn
        ;; (emitted before the view's own `(def …)`) may reference the

--- a/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
@@ -361,6 +361,76 @@
                (emit-var-js aenv (symbol "cljs.user" (name verb))))
             (str "the qualified " verb " head resolves to the current-namespace Var"))))))
 
+;; ---------------------------------------------------------------------------
+;; rf2-eukmp — the WHOLE production do-form, not isolated symbols
+;; ---------------------------------------------------------------------------
+;;
+;; PR #6053 fixed the recursive JSX HEAD (self-fqn) but left the view's own
+;; declare/def on the raw bare name. The focused rows above compile EXTRACTED
+;; reference symbols in isolation and check the raw def is bare — a FALSE GREEN:
+;; a bare `(def sub …)` in a ns referring re-frame.ui/sub resolves the def NAME
+;; through the same-named `:refer` (cljs.analyzer/resolve-var ranks `:uses` above
+;; `:defs` and IGNORES `:excludes`), so the WHOLE form both clobbers the public
+;; authoring Var (`re_frame.ui.sub = …`) and leaves the qualified self head
+;; (`cljs.user.sub`) undefined — the split identity. The row below analyzes AND
+;; compiles the ENTIRE emitted `(declare/defn/def)` do-form as one unit through
+;; real cljs.analyzer + cljs.compiler. Against pre-fix output every assertion is
+;; RED (the def targets re-frame.ui/<verb>, the JS assigns re_frame.ui.<verb>).
+
+(defn- analyze-whole-form
+  "Analyze the COMPLETE production do-form in the referred cljs.user ns (warnings
+  silenced) and compile it to JS as ONE unit — never extracted symbols in
+  isolation. `emit-defview` has already run for `do-form`, so any same-named
+  refer shadowing it completes is live in the analyzer state this reads."
+  [aenv do-form]
+  (binding [cljs-analyzer/*cljs-warnings*
+            (zipmap (keys cljs-analyzer/*cljs-warnings*) (repeat false))]
+    (let [ast       (cljs-analyzer/analyze (assoc aenv :context :statement) do-form)
+          def-names (atom [])]
+      (walk/postwalk
+       (fn [x]
+         (when (and (map? x) (= :def (:op x))) (swap! def-names conj (:name x)))
+         x)
+       ast)
+      {:def-names @def-names :js (cljs-comp/emit-str ast)})))
+
+(defn- munged-ref?
+  "True iff `js` references the exact munged Var `pre.<verb>` at an identifier
+  boundary (so `re_frame.ui.frame` does not spuriously match
+  `re_frame.ui.frames`, nor `cljs.user.sub` match `cljs.user.sub$render`)."
+  [js pre verb]
+  (boolean (re-find (re-pattern (str (java.util.regex.Pattern/quote (str pre "." (name verb)))
+                                     "(?![A-Za-z0-9_$])"))
+                    js)))
+
+(deftest real-cljs-recursive-defview-whole-form-defines-current-ns-var
+  ;; rf2-eukmp acceptance. Reverting the emitter's canonical-Var alignment
+  ;; (leaving the def/declare to resolve through the refer) fails every row.
+  (with-referred-cljs-env
+    (fn [aenv]
+      (doseq [verb '[sub lease frame]]
+        (let [self-fqn      (symbol "cljs.user" (name verb))
+              authoring-fqn (symbol "re-frame.ui" (name verb))
+              args          (self-emit-args aenv verb)
+              do-form       (emit-cljs/emit-defview args)
+              {:keys [def-names js]} (analyze-whole-form aenv do-form)]
+          (testing (str "whole form: the view def defines the current-ns Var (" verb ")")
+            (is (some #(= self-fqn %) def-names)
+                (str "a def in the whole form targets cljs.user/" verb))
+            (is (not-any? #(= authoring-fqn %) def-names)
+                (str "no def targets the authoring Var re-frame.ui/" verb)))
+          (testing (str "whole form: emitted JS assigns the current-ns Var, never the authoring Var (" verb ")")
+            (is (str/includes? js (str "cljs.user." (name verb) " ="))
+                (str "the emitted JS assigns cljs.user." (name verb)))
+            (is (not (str/includes? js (str "re_frame.ui." (name verb) " =")))
+                (str "the emitted JS never assigns (clobbers) re_frame.ui." (name verb))))
+          (testing (str "whole form: def + recursive head share ONE current-ns Var, authoring Var untouched (" verb ")")
+            (is (munged-ref? js "cljs.user" verb)
+                (str "the recursive head references cljs.user." (name verb)))
+            (is (not (munged-ref? js "re_frame.ui" verb))
+                (str "zero re_frame.ui." (name verb)
+                     " reference anywhere in the whole emitted form"))))))))
+
 (deftest a-non-recursive-defview-emits-no-self-declaration
   ;; Preserve unrelated behavior: a view that does NOT reference itself emits no
   ;; forward declaration and no fqn rewrite — the self-head machinery is inert.


### PR DESCRIPTION
## What

PR #6053 fixed the recursive JSX **head** (self-fqn) but left the view's own
`declare`/`def` on the raw bare name. In a namespace that refers
`re-frame.ui/{sub,lease,frame}`, a bare `(def sub …)` resolves its **name**
through the same-named `:refer` — `cljs.analyzer/resolve-var` ranks `:uses`
(refers) **above** `:defs` and **ignores** `:excludes`. So the complete
generated `(declare/defn/def)` form was a **split identity**:

- the `def` clobbered the public authoring Var, emitting `re_frame.ui.sub = …`
  (overwriting `re-frame.ui/sub`), and
- the qualified self head `cljs.user.sub` was **never defined**, so
  `cljs.user.sub$render` recursed through an undefined Var.

The prior focused suite stayed green because it checked the raw def was bare and
compiled **extracted reference symbols in isolation** — never the whole form.

## The fix (`emit_cljs.cljc` → `emit-defview`)

The CLJS analyzer already **signals** this shadowing on the def (its `:redef`
warning "sub … replaced by `<ns>/sub`", plus adding `sub` to `:excludes`), but the
resolve-var ordering means a bare def name still captures the refer. `emit-defview`
now **completes the shadowing the analyzer intends**: for a self-recursive view it
drops the view's own name from the live ns `:uses` in the JVM macro-expansion
compiler env, so the `declare`, the `def`, and the recursive head all resolve to
the **one canonical current-namespace Var**.

- JVM-only (`#?(:clj …)`), guarded on `:self-ref?` + a live compiler env.
- Non-recursive views and the CLJS golden path are untouched.
- **No runtime code is added** — production elision stays clean.

## Regression (whole production form, not isolated symbols)

`real-cljs-recursive-defview-whole-form-defines-current-ns-var` analyzes **and**
compiles the ENTIRE emitted `(declare/defn/def)` do-form as one unit through real
`cljs.analyzer` + `cljs.compiler`, proving across `sub`/`lease`/`frame`:

- the `def` defines `cljs.user.<verb>` (never `re-frame.ui/<verb>`),
- the emitted JS assigns `cljs.user.<verb>`, never `re_frame.ui.<verb>`,
- the recursive head references the **same** current-ns Var, and
- the authoring Var is not clobbered.

Verified **red-before / green-after**: the new test fails **15/18** assertions
against pre-fix output and passes fully with the fix.

## Quality gates

- `implementation/ui` JVM (`clojure -M:test`): **752 tests / 13888 assertions, 0 failures**
- `npm run test:cljs`: **9846 tests / 48440 assertions, 0 failures**
- `npm run test:elision`: **PASS** — production 60/60 absent, control 60/60 present, 0 warnings
- Scope: only `emit_cljs.cljc` + its test; `analyze.cljc` untouched.

Closes rf2-eukmp.
