### PR TITLE
fix(ssr): remove successor-reaping cleanup + scope hydrate! render-tree-fn + emit :style CSS (rf2-c6lp3, rf2-0vk7b, rf2-l6h6a)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -75,8 +75,13 @@
   `frame-target` is the DESTROY target: the frame VALUE `make-frame` returned
   (carrying the EXACT incarnation token, so teardown is incarnation-EXACT and
   never reaps a same-id successor a request drain reseated — rf2-moftbs), or a
-  frame-id keyword (the construction-failure path, where no value exists yet and
-  address-directed cleanup of any partial row is correct). The optional
+  frame-id keyword (address-directed — it destroys whichever incarnation
+  currently holds the id). The per-request handlers always pass the VALUE so
+  teardown is exact. The bare-id form is for callers that genuinely own the id's
+  current incarnation (SSR test teardown, streaming edge paths). It is NOT for
+  the setup-FAILURE path: core construction is the exact-token owner of a failed
+  incarnation's rollback, so an address-directed reap there could destroy a
+  same-id successor (rf2-c6lp3). The optional
   `diag-frame-id` names the frame on the failure trace so the `:frame` slot stays
   a clean keyword even when a value is the destroy target; it defaults to
   `frame-target` for the keyword call shape.

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -162,11 +162,13 @@
   `make-frame` explicitly (`:id frame-id`) — the same lifecycle order,
   through the ONE public constructor.
 
-  On failure mid-drain, the request slot AND any partial frame
-  registration are cleared so neither leaks across requests. The frame
-  may be registered in the `frames` atom (see frame.cljc — `swap!
-  frames` happens before `dispatch-sync`), so the best-effort destroy
-  is required even though `make-frame` threw."
+  On failure mid-drain, the request slot is cleared so it does not leak
+  across requests. The failed incarnation itself is NOT reaped here:
+  core construction is its exact-token owner — `make-frame` tears the
+  partial frame down with its exact installed token before rethrowing
+  (frame.cljc, PR #6072). A bare-id reap in the catch would be address-
+  directed and could destroy a same-id successor B seated in the window
+  after A's exact rollback released the per-id transaction (rf2-c6lp3)."
   [{:keys [initial-events fx-overrides ssr on-error]} request]
   ;; The alphabetic prefix keeps the payload frame id valid for strict EDN
   ;; readers; keyword construction itself does not validate local names.
@@ -188,11 +190,18 @@
                 ssr          (assoc :ssr           ssr)))]
         {:frame-id frame-id :frame frame-value})
       (catch Throwable t
+        ;; Clear only the request side channel. Core construction is the
+        ;; EXACT-TOKEN owner of the failed incarnation's rollback: `make-frame`
+        ;; already tore incarnation A down with its exact installed token before
+        ;; rethrowing (frame.cljc — the setup-runner + WON-install catch both
+        ;; destroy `installed-token`, PR #6072). A redundant bare-id
+        ;; `destroy-frame-quietly! frame-id` here would be ADDRESS-directed: once
+        ;; A's exact rollback releases the per-id transaction, a same-id
+        ;; successor B can be seated before this catch continues, and the keyword
+        ;; target would then pin and destroy B (rf2-c6lp3). So we do NOT reap by
+        ;; bare id — construction rollback owns exactly one incarnation, and the
+        ;; request slot is the only per-request state this catch owns.
         (ssr/clear-request! frame-id)
-        ;; Construction FAILED — no frame value was returned, so clean up any
-        ;; partial row address-directed by the gensym id (construction rollback
-        ;; is already exact internally, PR #5928).
-        (lifecycle/destroy-frame-quietly! frame-id)
         ;; Setup runs outside the handler body's catch, so contain a failing
         ;; caller hook here as well.
         {:short-circuit (lifecycle/safe-on-error on-error request t)}))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -19,6 +19,7 @@
             [re-frame.ssr :as ssr]
             [re-frame.ssr.ring :as ssr-ring]
             [re-frame.ssr.ring.lifecycle :as lifecycle]
+            [re-frame.ssr.ring.pipeline :as pipeline]
             [re-frame.ssr.ring.shell :as shell]
             [re-frame.ssr.ring.test-support :as ts]))
 
@@ -3137,6 +3138,67 @@
       (is (= "Internal error" (:body response))
           "locked generic body — the secondary throw's internals never
            reach the wire (rf2-kzvwq topology-leak contract held)"))))
+
+;; ===========================================================================
+;; rf2-c6lp3 — the setup-failure catch must NOT reap by bare id
+;;
+;; Core construction is the exact-token owner of a failed incarnation's
+;; rollback: `make-frame` tears incarnation A down with its exact installed
+;; token before rethrowing (frame.cljc, PR #6072). Once that exact rollback
+;; releases the per-id transaction, a same-id successor B can be seated before
+;; the SSR setup-failure catch continues. The old catch did a redundant
+;; ADDRESS-directed `destroy-frame-quietly! frame-id`; the bare keyword pins
+;; whichever incarnation currently holds the id — i.e. B — and destroys it.
+;; The fix removes that bare-id reap; the catch owns only the request slot.
+;; ===========================================================================
+
+(deftest setup-failure-catch-does-not-reap-same-id-successor
+  (testing "rf2-c6lp3: a same-id successor B seated during the setup-failure
+            window survives the catch. `setup-request-frame!` gensyms a frame
+            id, seeds the request slot, then calls `make-frame`. We model the
+            reproduced interleaving with `with-redefs`: `make-frame` seats a
+            live successor B at the SAME id (standing in for the incarnation
+            reseated after core's exact rollback of failed A) and then throws
+            as A's constructor would. The catch must clear the request slot and
+            short-circuit WITHOUT reaping B — before the fix the bare-id
+            `destroy-frame-quietly! frame-id` destroyed B."
+    (let [captured-id (atom nil)
+          b-token     (atom nil)
+          real-make   rf/make-frame]
+      (try
+        (with-redefs
+          [rf/make-frame
+           (fn [{:keys [id] :as _opts}]
+             ;; Incarnation A failed and core already rolled it back exactly; a
+             ;; same-id successor B is seated at the gensym id during the window,
+             ;; THEN A's constructor rethrows into `setup-request-frame!`.
+             (reset! captured-id id)
+             (real-make {:id id :doc "successor B" :platform :server})
+             (reset! b-token (frame/frame-incarnation-token id))
+             (throw (ex-info "incarnation A setup failed (already rolled back by core)"
+                             {:simulated true})))]
+          (let [result (pipeline/setup-request-frame!
+                         {;; A valid (empty) :initial-events so setup reaches the
+                          ;; `make-frame` call (our stub); the throw models A's
+                          ;; construction failing, not a bad-opt rejection.
+                          :initial-events []
+                          :on-error (fn [_req _t]
+                                      {:status 500 :headers {} :body "err"})}
+                         {:uri "/x" :request-method :get})]
+            (is (contains? result :short-circuit)
+                "setup failure short-circuits to the on-error 500 response")
+            (is (= 500 (get-in result [:short-circuit :status]))
+                "the configured on-error 500 is returned")))
+
+        ;; The load-bearing assertion: B's EXACT incarnation is still live after
+        ;; the catch. With the removed bare-id reap present it would be destroyed.
+        (is (frame/frame-incarnation-live? @captured-id @b-token)
+            "same-id successor B survives the setup-failure catch (no bare-id reap)")
+        (is (some? (frame/frame @captured-id))
+            "the id still resolves to a live frame (B), not a reaped/absent slot")
+        (finally
+          (when-let [id @captured-id]
+            (rf/destroy-frame! id)))))))
 
 ;; ===========================================================================
 ;; EP-0008 (rf2-hhutya) — HTTP-WIRE acceptance: the promoted SSR error

--- a/implementation/ssr/src/re_frame/ssr/boot.cljc
+++ b/implementation/ssr/src/re_frame/ssr/boot.cljc
@@ -168,8 +168,12 @@
                  `:render-tree-fn` the host supplies: a 0-arity fn
                  returning the CLIENT render-tree to hash (typically
                  `#((rf/view :app/root))`). `hydrate!` calls it
-                 SYNCHRONOUSLY, immediately after `:rf/hydrate` and BEFORE
-                 the host's own render — see the ns docstring §The verify
+                 SYNCHRONOUSLY, immediately after `:rf/hydrate`, BEFORE
+                 the host's own render, and UNDER the target frame's scope —
+                 so the documented `((rf/view :app/root))` idiom, whose view
+                 derefs a frame-scoped `subscribe`, resolves the frame the
+                 same way the server render does inside `(with-frame f …)`.
+                 See the ns docstring §The verify
                  contract for why hashing the pure client tree pre-mount is
                  equivalent to hashing the mounted tree (a re-frame2 view is
                  a pure fn of the just-hydrated app-db). The helper does not
@@ -202,9 +206,12 @@
                       on the JVM it is required (no DOM to read from).
     :render-tree-fn — (optional) a 0-arity fn returning the client
                       render-tree to hash for mismatch detection. Called
-                      ONCE, SYNCHRONOUSLY, immediately after `:rf/hydrate`
-                      and before the host's own render (a pure client-tree
-                      computation — see step 3). Omit to skip verification.
+                      ONCE, SYNCHRONOUSLY, immediately after `:rf/hydrate`,
+                      before the host's own render, and UNDER the `:frame`
+                      scope (so a fn that calls a frame-scoped subscribing
+                      view — the `((rf/view :app/root))` idiom — resolves;
+                      a pure client-tree computation — see step 3). Omit to
+                      skip verification.
     :element-id     — (CLJS, optional) override the payload `<script>` id
                       to read when `:payload` is omitted. Default the
                       pinned `__rf_payload`.
@@ -220,7 +227,9 @@
            (rf/init! reagent-adapter/adapter)
            ;; hydrate! seeds app-db AND verifies synchronously (computing
            ;; the client tree via render-tree-fn) BEFORE the host mounts.
-           ;; The hydration target is supplied explicitly via `:frame`.
+           ;; The hydration target is supplied explicitly via `:frame`, and
+           ;; hydrate! calls render-tree-fn UNDER that frame's scope — so the
+           ;; view's `subscribe` resolves without a manual `with-frame` wrap.
            (let [payload (ssr/hydrate! {:frame          :app/main
                                         :render-tree-fn #((rf/view :app/root))})]
              (rdc/render react-root
@@ -269,6 +278,18 @@
       (router/dispatch-sync! [:rf/hydrate payload] {:frame frame})
       ;; HOT PATH — post-render hash-mismatch detection. Symmetric with
       ;; the server's `:emit-hash?`-stamped `data-rf-render-hash` marker.
+      ;;
+      ;; Call `render-tree-fn` UNDER the target frame's scope (rf2-0vk7b). The
+      ;; documented idiom `(fn [] ((rf/view :app/root)))` computes the client
+      ;; tree by CALLING a registered view, whose reg-view-injected `subscribe`
+      ;; resolves the ambient frame via the carried invariant. `hydrate!` already
+      ;; resolved `frame` and dispatched `:rf/hydrate` into it, so — mirroring
+      ;; the server render, which wraps `((rf/view :app/root))` in
+      ;; `(with-frame f …)` — it pins that same frame here. Without the pin the
+      ;; view's `subscribe` runs under no scope and raises
+      ;; `:rf.error/no-frame-context`, aborting client boot. `bind-fn` re-binds
+      ;; `*current-frame*` for the one call; a `render-tree-fn` that establishes
+      ;; its own scope (or ignores it — a plain-hiccup fn) is unaffected.
       (when render-tree-fn
-        (hydrate/verify-hydration! frame (render-tree-fn))))
+        (hydrate/verify-hydration! frame ((frame/bind-fn frame render-tree-fn)))))
     payload))

--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -389,6 +389,102 @@
         (contains? reserved-prop-keys (str/lower-case nm))
         (contains? jsx-source-prop-names nm))))
 
+;; ---- inline-style map serialisation (rf2-l6h6a) ---------------------------
+;;
+;; A hiccup `:style` whose value is a MAP must serialise to a CSS declaration
+;; string (`{:margin "0 1em"}` → `margin:0 1em`), NOT the EDN print of the map
+;; (`{:margin &quot;0 1em&quot;}`). The server HTML must match what the client
+;; React path emits from the same style object, or React 19 logs a hydration
+;; attribute mismatch on first load (rf2-l6h6a — surfaced by the generated SSR
+;; scaffold's counter-value span).
+;;
+;; The rules mirror `react-dom/server`'s `pushStyleAttribute` — the same
+;; contract the reagent-slim static-markup emitter pins in its IMPL-SPEC §8.3.
+;; It is duplicated here by intent: bundle isolation forbids `re-frame.ssr`
+;; requiring the adapter, exactly as `void-elements` is duplicated in
+;; `emit.cljc`.
+
+(defn- style-name->css
+  "camelCase style-property name → kebab CSS name, matching React's
+  `pushStyleAttribute` conversion: insert `-` before each upper-case char,
+  lower-case, then `^ms- → -ms-` (so `msFlex` → `-ms-flex`). An already-kebab
+  name (`margin-top`) has no upper-case chars and is returned unchanged."
+  [raw]
+  (-> raw
+      (str/replace #"([A-Z])" "-$1")
+      (str/lower-case)
+      (str/replace #"^ms-" "-ms-")))
+
+;; React 19.2.0's `unitlessNumber` set, mirrored verbatim from the authoritative
+;; `reagent2.dom.server/unitless-style-props` (camelCase keys), then reprojected
+;; ONCE to the kebab CSS names `style-name->css` produces so a numeric value can
+;; be classified without re-deriving the camelCase form. Deriving the kebab set
+;; from the camelCase source (rather than hand-transcribing) preserves React's
+;; own quirks — e.g. the capital-K typo `WebKitBoxFlexGroup` reprojects to
+;; `-web-kit-box-flex-group`, which a real `:-webkit-box-flex-group`/
+;; `:WebkitBoxFlexGroup` prop never matches, so it gets `px` exactly as React
+;; does (byte-parity with `react-dom/server`).
+(def ^:private unitless-style-props-camel
+  #{"animationIterationCount" "aspectRatio" "borderImageOutset"
+    "borderImageSlice" "borderImageWidth" "boxFlex" "boxFlexGroup"
+    "boxOrdinalGroup" "columnCount" "columns" "flex" "flexGrow"
+    "flexPositive" "flexShrink" "flexNegative" "flexOrder" "gridArea"
+    "gridRow" "gridRowEnd" "gridRowSpan" "gridRowStart" "gridColumn"
+    "gridColumnEnd" "gridColumnSpan" "gridColumnStart" "fontWeight"
+    "lineClamp" "lineHeight" "opacity" "order" "orphans" "scale"
+    "tabSize" "widows" "zIndex" "zoom" "fillOpacity" "floodOpacity"
+    "stopOpacity" "strokeDasharray" "strokeDashoffset" "strokeMiterlimit"
+    "strokeOpacity" "strokeWidth" "MozAnimationIterationCount" "MozBoxFlex"
+    "MozBoxFlexGroup" "MozLineClamp" "msAnimationIterationCount" "msFlex"
+    "msZoom" "msFlexGrow" "msFlexNegative" "msFlexOrder" "msFlexPositive"
+    "msFlexShrink" "msGridColumn" "msGridColumnSpan" "msGridRow"
+    "msGridRowSpan" "WebkitAnimationIterationCount" "WebkitBoxFlex"
+    "WebKitBoxFlexGroup" "WebkitBoxOrdinalGroup" "WebkitColumnCount"
+    "WebkitColumns" "WebkitFlex" "WebkitFlexGrow" "WebkitFlexPositive"
+    "WebkitFlexShrink" "WebkitLineClamp"})
+
+(def ^:private unitless-style-css-names
+  (into #{} (map style-name->css) unitless-style-props-camel))
+
+(defn- style-token->str
+  "Serialise a scalar style value to its string form: keyword/symbol → name
+  (so `:red` / `:flex` render bare), everything else `str`-ed."
+  [v]
+  (if (or (keyword? v) (symbol? v)) (name v) (str v)))
+
+(defn style-map->css
+  "Serialise a hiccup `:style` MAP to an HTML inline-style declaration string,
+  matching `react-dom/server`'s `pushStyleAttribute` so the server HTML agrees
+  with the client React render (rf2-l6h6a):
+
+    - camelCase property names → kebab CSS names (`:marginTop` → `margin-top`);
+    - a NUMERIC value gets a `px` suffix unless it is `0` or the property is
+      unitless (`:flex-grow`, `:z-index`, `:opacity`, …); numbers are
+      canonicalised cross-runtime (`hash/canonical-number`) so a JVM `1.0`
+      and a CLJS `1` emit the same `1px`;
+    - an entry whose value is nil / boolean / \"\" is omitted entirely (no
+      empty `prop:` declaration);
+    - CSS custom properties (`--foo`) pass through name + value verbatim (no
+      `px` logic)."
+  [m]
+  (->> m
+       (keep (fn [[k v]]
+               (when (and (some? v) (not (boolean? v)) (not= "" v))
+                 (let [raw (name k)]
+                   (if (str/starts-with? raw "--")
+                     ;; CSS custom property: name + value verbatim.
+                     (str raw ":" (style-token->str v))
+                     (let [css-name (style-name->css raw)]
+                       (str css-name ":"
+                            (if (number? v)
+                              (let [n (hash/canonical-number v)]
+                                (if (or (zero? v)
+                                        (contains? unitless-style-css-names css-name))
+                                  n
+                                  (str n "px")))
+                              (style-token->str v)))))))))
+       (str/join ";")))
+
 (defn attr-string
   "Render an attribute map as ` k1=\"v1\" k2=\"v2\"` (leading space when
   non-empty; empty string when the map is empty). Boolean `true` emits
@@ -424,25 +520,31 @@
                            (true? v)  (validate-attr-name! k)
                            (false? v) nil
                            (nil? v)   nil
-                           :else      (str (validate-attr-name! k)
-                                           "=\""
-                                           ;; A numeric attribute VALUE is
-                                           ;; canonicalised the same way the
-                                           ;; render-tree hash serialises it
-                                           ;; (rf2-0ypnnk) so a whole-valued
-                                           ;; double renders `value="0"` (not
-                                           ;; the JVM `value="0.0"`) and the
-                                           ;; emitted HTML matches the hash
-                                           ;; byte-for-byte cross-runtime.
-                                           ;; Without this the hash would
-                                           ;; AGREE while the server/client
-                                           ;; attribute strings diverged — a
-                                           ;; silent hydration inconsistency.
-                                           (escape-attr
-                                             (if (number? v)
-                                               (hash/canonical-number v)
-                                               v))
-                                           "\"")))
+                           :else
+                           (let [rendered-val
+                                 (cond
+                                   ;; A map-valued `:style` serialises to a CSS
+                                   ;; declaration string, matching react-dom/
+                                   ;; server's `pushStyleAttribute` so the server
+                                   ;; HTML agrees with the client React render
+                                   ;; (rf2-l6h6a). A string `:style` value is
+                                   ;; already CSS and rides the default branch
+                                   ;; verbatim.
+                                   (and (map? v) (= "style" (name k)))
+                                   (style-map->css v)
+                                   ;; A numeric attribute VALUE is canonicalised
+                                   ;; the same way the render-tree hash serialises
+                                   ;; it (rf2-0ypnnk) so a whole-valued double
+                                   ;; renders `value="0"` (not the JVM
+                                   ;; `value="0.0"`) and the emitted HTML matches
+                                   ;; the hash byte-for-byte cross-runtime.
+                                   ;; Without this the hash would AGREE while the
+                                   ;; server/client attribute strings diverged — a
+                                   ;; silent hydration inconsistency.
+                                   (number? v) (hash/canonical-number v)
+                                   :else       v)]
+                             (str (validate-attr-name! k)
+                                  "=\"" (escape-attr rendered-val) "\""))))
                        attrs)]
     (if (seq rendered)
       (str " " (str/join " " rendered))

--- a/implementation/ssr/test/re_frame/ssr_attr_filter_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_attr_filter_test.clj
@@ -127,6 +127,77 @@
            (html/attr-string {(keyword "onClick=alert(1) data-x") "v"
                               :id "x"})))))
 
+(deftest attr-string-serialises-style-map
+  (testing "rf2-l6h6a — a map-valued `:style` serialises to a CSS declaration
+            string (matching react-dom/server's `pushStyleAttribute`), NOT the
+            EDN print of the map. Before the fix `{:margin \"0 1em\"}` rendered
+            the literal `style=\"{:margin &quot;0 1em&quot;}\"`, and React 19
+            logged a hydration attribute mismatch on every SSR app's first load."
+    (testing "the reported repro: a single string-valued declaration"
+      (is (= " style=\"margin:0 1em\""
+             (html/attr-string {:style {:margin "0 1em"}})))
+      (is (not (str/includes? (html/attr-string {:style {:margin "0 1em"}})
+                              "{:margin"))
+          "the raw EDN map text must never reach the wire"))
+
+    (testing "camelCase property names → kebab CSS names (React's rule)"
+      (is (= " style=\"margin-top:4px\""
+             (html/attr-string {:style {:marginTop "4px"}}))))
+
+    (testing "an already-kebab property name is unchanged"
+      (is (= " style=\"background-color:red\""
+             (html/attr-string {:style {:background-color "red"}}))))
+
+    (testing "a keyword value renders bare (its name)"
+      (is (= " style=\"display:flex\""
+             (html/attr-string {:style {:display :flex}}))))
+
+    (testing "a numeric value on a non-unitless property gets a px suffix"
+      (is (= " style=\"width:10px\""
+             (html/attr-string {:style {:width 10}}))))
+
+    (testing "a numeric value of 0 is bare (no px)"
+      (is (= " style=\"margin:0\""
+             (html/attr-string {:style {:margin 0}}))))
+
+    (testing "a numeric value on a unitless property is bare (no px)"
+      (is (= " style=\"flex-grow:1\""
+             (html/attr-string {:style {:flex-grow 1}})))
+      (is (= " style=\"z-index:100\""
+             (html/attr-string {:style {:z-index 100}}))))
+
+    (testing "nil / boolean / empty-string entries are omitted entirely"
+      (is (= " style=\"color:red\""
+             (html/attr-string {:style {:color "red" :top nil
+                                        :bottom false :left ""}}))))
+
+    (testing "CSS custom properties (--foo) pass through verbatim, no px"
+      (is (= " style=\"--gap:8\""
+             (html/attr-string {:style {:--gap 8}}))))
+
+    (testing "the CSS string is attribute-escaped (double-quote in a value)"
+      (is (= " style=\"font-family:&quot;My Font&quot;, sans-serif\""
+             (html/attr-string {:style {:font-family "\"My Font\", sans-serif"}}))))
+
+    (testing "a STRING :style value is already CSS and rides through untouched"
+      (is (= " style=\"margin:0 1em\""
+             (html/attr-string {:style "margin:0 1em"}))))
+
+    (testing "multiple declarations join with `;` in map order"
+      (is (= " style=\"margin:0;padding:4px\""
+             (html/attr-string {:style (array-map :margin 0 :padding "4px")}))))))
+
+(deftest render-to-string-serialises-style-map-through-full-emit
+  (testing "rf2-l6h6a — the style-map → CSS serialisation survives the FULL
+            `render-to-string` emit composition (not just `attr-string` in
+            isolation), so the wire markup for a `:style` map is CSS and the
+            server/client render agree (no hydration attribute mismatch)."
+    (let [html-out (emit/render-to-string
+                     [:div {:style {:margin "0 1em" :color :red}} "hi"] {})]
+      (is (= "<div style=\"margin:0 1em;color:red\">hi</div>" html-out))
+      (is (not (str/includes? html-out "{:margin"))
+          "no raw EDN map text on the wire — the hydration-mismatch defect is gone"))))
+
 (deftest render-to-string-strips-lowercase-handlers-end-to-end
   (testing "rf2-1uex4 — the canonical lowercase `on*` payload an attacker
             splats into `:custom-attrs` does NOT survive through the public

--- a/implementation/ssr/test/re_frame/ssr_hydration_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_test.clj
@@ -710,6 +710,55 @@
         (is (= 7 (rf/subscribe-once [:count] {:frame client-frame}))
             ":rf/hydrate still applied the seeded slice")))))
 
+(deftest boot-hydrate-scopes-render-tree-fn-to-target-frame
+  (testing "rf2-0vk7b: hydrate! calls :render-tree-fn UNDER the target frame's
+            scope. The documented client-boot idiom
+            `(fn [] ((rf/view :app/root)))` computes the tree by CALLING a
+            registered view whose reg-view-injected `subscribe` resolves the
+            ambient frame via the carried invariant (EP-0002). Here the
+            render-tree-fn reads an AMBIENT frame-scoped subscription directly
+            (`subscribe-once`, the same require-current-frame! resolution path).
+
+            Before the fix hydrate! ran render-tree-fn OUTSIDE any with-frame, so
+            the ambient read raised :rf.error/no-frame-context and client boot
+            aborted (mirroring the example/docstring symptom). After the fix
+            hydrate! pins the resolved frame around the call, the read resolves,
+            and the verify step runs — a divergent server hash fires
+            :rf.ssr/hydration-mismatch, proving the subscribing tree actually
+            computed under scope."
+    (register-baseline-handlers!)
+    (let [client-frame (frame/make-anon-frame-record! {:doc "0vk7b scope frame"
+                                       :platform :client
+                                       :ssr {:detect-mismatch? true}})
+          ;; Divergent server hash so a successful verify FIRES the mismatch —
+          ;; the trace is the proof the subscribing tree computed under scope.
+          payload      (materialise-response
+                         (assoc baseline-payload :rf/render-hash "server00"))
+          ;; The unwrapped idiom, distilled: reads an AMBIENT frame-scoped
+          ;; subscription (exactly what a reg-view's injected `subscribe` does),
+          ;; so it can ONLY succeed if hydrate! provides the frame scope.
+          render-tree-fn (fn [] [:div.app [:span (rf/subscribe-once [:count])]])]
+      (with-trace-recorder! [traces]
+        ;; Simulate the BROWSER's client-boot condition: no ambient frame. The
+        ;; ssr test fixture otherwise pins `*current-frame*` to `:rf/default`
+        ;; (`test_fixture.clj` — the carried-invariant equivalent of wrapping
+        ;; every test in `(with-frame :rf/default …)`), which would MASK this bug
+        ;; by resolving the subscribe to `:rf/default`. `run`/`^:export run` in a
+        ;; browser has no such scope, so unbind it here — only then does the
+        ;; unwrapped render-tree-fn face the real no-frame-context condition.
+        (binding [frame/*current-frame* nil]
+          (let [returned (ssr/hydrate! {:frame          client-frame
+                                        :payload        payload
+                                        :render-tree-fn render-tree-fn})]
+            (is (some? returned)
+                "hydrate! completed — the subscribing render-tree-fn did NOT
+                 raise :rf.error/no-frame-context (it ran under the target frame
+                 scope hydrate! established)")
+            (is (some #(= :rf.ssr/hydration-mismatch (:operation %)) @traces)
+                (str "verify ran the subscribing render-tree-fn under frame scope "
+                     "(server hash 'server00' != client render-tree hash); saw: "
+                     (pr-str (mapv :operation @traces))))))))))
+
 ;; ===========================================================================
 ;; rf2-acjknb — EP-0002: hydrate! requires :frame; payload :rf/frame-id is
 ;; VALIDATED against the explicit target (no :rf/default-from-absence, no


### PR DESCRIPTION
Three targeted fixes in the coupled `re-frame.ssr` runtime module (one worker owns the module this round). Each is a minimal, self-contained correctness fix — no pipeline/emitter/hydration redesign. Commits are per-bead in `l6h6a → 0vk7b → c6lp3` order.

## rf2-l6h6a (P2) — SSR emitter renders map-valued `:style` as raw EDN

**Seam:** `html_helpers.cljc` `attr-string` (re-exported at `emit/attr-string`) — the shared per-attribute serializer. A map-valued `:style` fell through the `:else` branch and was `str`-ed as EDN.

**Fix:** `attr-string` now serializes a map-valued `:style` to a CSS declaration string matching react-dom/server's `pushStyleAttribute`, so server HTML agrees with the client React render (no hydration attribute mismatch): camelCase→kebab property names, `px` for non-`0`/non-unitless numbers (React 19.2.0's `unitlessNumber` set, reprojected to kebab names), nil/boolean/`""` omitted, `--foo` custom props verbatim, cross-runtime numeric canonicalisation. String `:style` values still ride through untouched. The unitless set is duplicated by intent from reagent-slim (bundle isolation forbids `re-frame.ssr` requiring the adapter — same rationale as `void-elements`).

**Red→green:** before, `{:style {:margin "0 1em"}}` emitted `style="{:margin &quot;0 1em&quot;}"`; after, `style="margin:0 1em"`. New `attr-string` + full-emit fixtures.

## rf2-0vk7b (P2) — unwrapped render-tree-fn raises `no-frame-context`

**Seam:** `boot.cljc` `hydrate!` — it called `:render-tree-fn` during verify OUTSIDE any frame scope, so the documented `(fn [] ((rf/view :app/root)))` idiom's injected `subscribe` raised `:rf.error/no-frame-context` and client boot aborted.

**Approach chosen — Option B (scope inside `hydrate!`), not per-callsite wrapping.** `hydrate!` already resolves `frame` and dispatch-syncs `:rf/hydrate` into it, so — mirroring the server render, which wraps `((rf/view :app/root))` in `(with-frame f …)` — it now pins that frame around the render-tree-fn call via `frame/bind-fn`. This validates the idiom used across the examples, the docstring, and `docs/ssr/*` in one place, rather than sprinkling `with-frame` wraps through teaching artefacts (which would also have to be repeated for every future host). The examples/docstring are left as the idiomatic unwrapped form and now work. Verified safe against the bead's double-scope caveat: the framework's own hydration tests use non-subscribing render-tree-fns and never wrap `hydrate!`, so nothing double-scopes; `bind-fn` is a plain re-entrant `*current-frame*` rebind that any self-established inner scope wins over.

**Red→green:** before, an unwrapped subscribing render-tree-fn raised `:rf.error/no-frame-context`; after, it resolves under the target-frame scope and verify runs. New regression unbinds the ssr fixture's ambient `:rf/default` to face the real browser frameless condition (otherwise the fixture masks the bug).

## rf2-c6lp3 (P1) — remove SSR's successor-reaping setup-failure cleanup

**Seam:** `pipeline.clj` `setup-request-frame!` catch — a redundant address-directed `(destroy-frame-quietly! frame-id)` by bare id.

**Fix:** removed. Core construction is already the exact-token owner of a failed incarnation's rollback (`make-frame` destroys `installed-token` before rethrowing, PR #6072). Once that rollback releases the per-id transaction a same-id successor B can be seated before the catch continues, and the bare-keyword target then pins and destroys B. The catch now owns only the request slot. `setup-request-frame!` and `destroy-frame-quietly!` docstrings corrected to state the real ownership boundary. Both streaming and non-streaming setup-failure paths inherit the fix through the shared helper.

**Red→green:** a deterministic JVM seam seats a live same-id successor B during the setup-failure window; before, the bare-id reap destroyed B (not live / absent); after, B survives.

## Quality gates

All run in the foreground, unpiped. Per-bead red-before/green-after captured (revert-to-HEAD → red → restore → green).

| Gate | Result |
| --- | --- |
| `implementation/ssr` JVM (`clojure -M:test`) | **401 tests, 1711 assertions, 0 failures, 0 errors** |
| `implementation/ssr-ring` JVM (`clojure -M:test`) | **199 tests, 978 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` (node CLJS) | **9846 tests, 48440 assertions, 0 failures, 0 errors** |
| `python -m mkdocs build --strict` | **exit 0, no warnings** |

Red-before confirmed for each: l6h6a emitted `style="{:margin &quot;0 1em&quot;}"`; 0vk7b raised `:rf.error/no-frame-context`; c6lp3 reaped successor B (`frame-incarnation-live?` false, `frame` absent).

## Scope / fence

Touches only `implementation/ssr/src/re_frame/ssr/{emit path via html_helpers, boot}`, the `setup-request-frame!` catch + `destroy-frame-quietly!` in `implementation/ssr-ring`, and the corresponding SSR tests. No `tools/template` (scaffold — rf2-w1k3i's tree), no ui compiler, no `frames.cljc`/`tooling.cljc`/`tools/xray`, no `.github/workflows`/`shadow-cljs.edn`/`deps.edn` hot-zones. Examples under `examples/capabilities/ssr/*` are unchanged (Option B fixes them without edits).
