### PR TITLE
fix(epoch): fence restore to the exact frame incarnation it resolved (rf2-bjh6y)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1435,9 +1435,20 @@
   recognized partition keys before delegating. Callers wanting the former
   single-partition helpers compose a one-key map:
   `(replace-frame-state! id {app-partition-key new-app-db})` /
-  `(replace-frame-state! id {runtime-partition-key new-runtime-db})`."
-  [id frame-state]
-  (commit-frame-transition! id (select-keys frame-state [app-partition-key runtime-partition-key])))
+  `(replace-frame-state! id {runtime-partition-key new-runtime-db})`.
+
+  The 3-arity is the EXACT-INCARNATION variant (mirrors
+  `commit-frame-transition!`'s own 2/3-arity split): it resolves the write
+  through `owner-token`'s own frame record and installs nothing — returning
+  `nil` — unless `owner-token` still names the live incarnation, so a same-id
+  successor reseated under `id` after the caller captured its token can never
+  receive the write. Epoch restore (`perform-restore!`) threads the token it
+  validated preconditions against so a time-travel install lands only on the
+  exact frame incarnation it resolved (rf2-bjh6y)."
+  ([id frame-state]
+   (commit-frame-transition! id (select-keys frame-state [app-partition-key runtime-partition-key])))
+  ([id owner-token frame-state]
+   (commit-frame-transition! id owner-token (select-keys frame-state [app-partition-key runtime-partition-key]))))
 
 (defn- swap-partition!
   "Mutate ONE partition `pk` of `id`'s physical frame-state container in place:

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -345,7 +345,13 @@
   Failure modes (each is a no-op on the frame-state and emits a
   structured error trace):
 
-    :rf.error/no-such-handler          (kind :frame) — frame not registered
+    :rf.error/no-such-handler          (kind :frame) — frame not registered,
+                                         OR the resolved incarnation was
+                                         destroyed / replaced by a same-id
+                                         successor between validation and the
+                                         write (the restore is fenced to the
+                                         EXACT incarnation it resolved — a
+                                         successor is left untouched; rf2-bjh6y)
     :rf.epoch/restore-during-drain     — called while drain is in flight
     :rf.epoch/restore-unknown-epoch    — epoch-id not in current history
     :rf.epoch/restore-non-ok-record    — target epoch's :outcome is not :ok
@@ -359,9 +365,13 @@
   [frame-id epoch-id]
   (if-not interop/debug-enabled?
     false
-    (let [{:keys [outcome epoch op tags]} (tool-pair/check-restore-preconditions! frame-id epoch-id)]
+    (let [{:keys [outcome epoch op tags incarnation-token]}
+          (tool-pair/check-restore-preconditions! frame-id epoch-id)]
       (case outcome
-        :ok   (tool-pair/perform-restore! frame-id epoch)
+        ;; Carry the EXACT incarnation token the preconditions resolved against
+        ;; to the write boundary, so a same-id successor seated in between never
+        ;; receives this epoch's state (rf2-bjh6y).
+        :ok   (tool-pair/perform-restore! frame-id incarnation-token epoch)
         :fail (do (tool-pair/emit-precondition-failure! op tags)
                   false)))))
 

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -355,9 +355,15 @@
   "Validate the documented preconditions for restoring `frame-id`
   to `epoch-id`. Returns a result map:
 
-    {:outcome :ok :epoch <epoch>}
+    {:outcome :ok :epoch <epoch> :incarnation-token <token>}
                  — all checks passed; `:epoch` is the resolved history
-                   record whose `:frame-state-after` is the restore target.
+                   record whose `:frame-state-after` is the restore target,
+                   and `:incarnation-token` is the EXACT identity token of
+                   the frame incarnation these checks resolved against.
+                   `restore-epoch!` carries it to the write boundary so
+                   `perform-restore!` refuses to install into a same-id
+                   SUCCESSOR frame seated between this pass and the physical
+                   write (rf2-bjh6y).
     {:outcome :fail :op <kw> :tags <map>}
                  — first failing check; `:op` is the trace operation
                    the caller must emit, `:tags` are its tags. No
@@ -367,7 +373,14 @@
 
   See `restore-epoch!` for the refusal catalogue."
   [frame-id epoch-id]
-  (let [frame-result (frame-exists-or-fail frame-id)]
+  (let [frame-result      (frame-exists-or-fail frame-id)
+        ;; The EXACT incarnation identity token (the live record's
+        ;; `:drain-lock`, per `frame-incarnation-token`) of the frame these
+        ;; checks are resolving against. Carried out on the `:ok` result so the
+        ;; write boundary can reject a stale install after a destroy + same-id
+        ;; reconstruction (rf2-bjh6y). nil when the frame is absent — the (1)
+        ;; frame-registered branch fails first in that case.
+        incarnation-token (frame/frame-incarnation-token frame-id)]
     (cond
       ;; (1) Frame registered?
       (= :fail (:outcome frame-result))
@@ -461,7 +474,7 @@
                                      :version-current  current}
                               (some? machine-type) (assoc :machine-type machine-type))}
 
-                  {:outcome :ok :epoch epoch})))))))))
+                  {:outcome :ok :epoch epoch :incarnation-token incarnation-token})))))))))
 
 ;; ---- write-boundary liveness guard ----------------------------------------
 ;;
@@ -701,71 +714,99 @@
   nil)
 
 (defn perform-restore!
-  "Install the target epoch's whole `:frame-state-after` after validation.
+  "Install the target epoch's whole `:frame-state-after` after validation,
+  FENCED to the exact frame incarnation the preconditions resolved against
+  (`incarnation-token`, from `check-restore-preconditions!`).
 
   App-db and runtime-db are restored atomically; `:db-after` is only a tool
   projection. Optional subsystems reconcile captured durable state against
   current host state before install, deferring success traces until the write
   lands.
 
-  Frame liveness is checked again at the write boundary, and the write's return
-  closes the remaining teardown race: nil means no write, while a non-nil set,
-  including empty, is success. Only the success branch emits restore telemetry,
-  re-anchors post-settle attribution, commits deferred subsystem traces, and
-  cancels host-transient work from the abandoned timeline.
+  The write boundary is fenced to the EXACT incarnation, not the bare id
+  (rf2-bjh6y). A same-id SUCCESSOR frame reseated between the precondition pass
+  and this write must not receive the resolved epoch's state. Two guards, both
+  keyed on `incarnation-token`:
 
-  The whole liveness-check → reconcile → write → bookkeeping runs under the
+    - an early `event-continuation-live?` gate refuses BEFORE running the
+      subsystem reconcile, so nothing is reconciled against a stale incarnation;
+    - the physical install goes through the EXACT-INCARNATION
+      `replace-frame-state!` arity, which returns nil unless the token still
+      names the live record — so even the write itself can never redirect into a
+      same-id successor.
+
+  Both losses resolve to ONE coherent typed failure — `:rf.error/no-such-handler`
+  (kind `:frame`), the same shape a destroyed-frame write race produces — and
+  leave any successor frame byte-for-byte untouched with no success telemetry.
+  The write's non-nil return (a changed-key set, possibly empty) is success;
+  only the success branch emits restore telemetry, re-anchors post-settle
+  attribution, commits deferred subsystem traces, and cancels host-transient
+  work from the abandoned timeline.
+
+  The whole gate → reconcile → write → bookkeeping runs under the
   frame's `:drain-lock` (`serialize-tool-write!`), so no event transition can
   interleave between the reconcile's read and the physical install — the
   restore holds one serial position relative to any drain (rf2-3fc89f.4). A
   restore invoked reentrantly from the active drainer refuses with
   `:rf.epoch/restore-during-drain` rather than deadlocking or splicing."
-  [frame-id epoch]
+  [frame-id incarnation-token epoch]
   (serialize-tool-write!
     frame-id
     :rf.epoch/restore-during-drain
     {:frame frame-id :rf.epoch/id (:epoch-id epoch)}
     (fn []
-      (let [{:keys [outcome op tags]} (live-container-or-fail frame-id)]
-        (if (= :fail outcome)
-          (do (emit-precondition-failure! op tags)
-              false)
-          (let [;; Whole `:frame-state-after` is the only restore source.
-                frame-state-target (:frame-state-after epoch)
-                ;; Reconcile runtime subsystems before the atomic install,
-                ;; the same way SSR hydration reconciles its installed slice — so a
-                ;; mid-flight captured snapshot does not install stranded
-                ;; `:loading` / `:fetching` entries pointing at vanished attempts,
-                ;; and a pre-restore reply cannot write stale data into a restored
-                ;; entry.
-                ;; Thread the restored epoch's causal time
-                ;; (`:committed-at` = the committing token's `:rf.cofx`
-                ;; `:rf/time-ms`) so the reconcile stamps a dangled-on-restore
-                ;; mutation instance's durable `:settled-at` from a replay-stable
-                ;; causal input, not the live install clock (EP-0010 §Restore/Replay).
-                frame-state-target (reconcile-runtime-db-on-restore
-                                     frame-id frame-state-target (:committed-at epoch))
-                ;; Write both partitions through the one physical frame container.
-                ;; Under the drain lock the container's re-read matches the value
-                ;; installed. Nil means the frame was destroyed after the liveness
-                ;; check; a non-nil changed-key-set (even empty) means it landed.
-                changed (frame/replace-frame-state! frame-id frame-state-target)]
-            (if (nil? changed)
-              (do (emit-precondition-failure! :rf.error/no-such-handler
-                                              {:kind :frame :frame frame-id})
-                  false)
-              (do (trace/emit! :rf.epoch :rf.epoch/restored
-                               {:frame       frame-id
-                                :rf.epoch/id (:epoch-id epoch)})
-                  ;; Restore triggers no ordinary event, so explicitly anchor its
-                  ;; repaint/subscription/unmount back-fill to the restored epoch.
-                  (state/set-last-settled-epoch! frame-id (:epoch-id epoch))
-                  ;; Deferred subsystem success traces are valid only after install.
-                  (commit-resources-restore-traces! frame-state-target)
-                  ;; Host timers and HTTP handles are not frame state; cancel the
-                  ;; abandoned timeline only after the new state is installed.
-                  (quiesce-orphaned-async-host-work! frame-id)
-                  true))))))))
+      (if-not (frame/event-continuation-live? frame-id incarnation-token)
+        ;; The incarnation these preconditions resolved against is no longer
+        ;; live — a same-id SUCCESSOR was seated (or the frame was destroyed /
+        ;; is being torn down) between validation and this write. Refuse BEFORE
+        ;; the reconcile so no subsystem state is reconciled against a stale
+        ;; incarnation, and route to the SAME canonical no-such-handler failure a
+        ;; destroyed-frame write race uses (rf2-bjh6y). The successor stays
+        ;; byte-for-byte untouched; no success telemetry fires.
+        (do (emit-precondition-failure! :rf.error/no-such-handler
+                                        {:kind :frame :frame frame-id})
+            false)
+        (let [;; Whole `:frame-state-after` is the only restore source.
+              frame-state-target (:frame-state-after epoch)
+              ;; Reconcile runtime subsystems before the atomic install,
+              ;; the same way SSR hydration reconciles its installed slice — so a
+              ;; mid-flight captured snapshot does not install stranded
+              ;; `:loading` / `:fetching` entries pointing at vanished attempts,
+              ;; and a pre-restore reply cannot write stale data into a restored
+              ;; entry.
+              ;; Thread the restored epoch's causal time
+              ;; (`:committed-at` = the committing token's `:rf.cofx`
+              ;; `:rf/time-ms`) so the reconcile stamps a dangled-on-restore
+              ;; mutation instance's durable `:settled-at` from a replay-stable
+              ;; causal input, not the live install clock (EP-0010 §Restore/Replay).
+              frame-state-target (reconcile-runtime-db-on-restore
+                                   frame-id frame-state-target (:committed-at epoch))
+              ;; Write both partitions through the one physical frame container,
+              ;; via the EXACT-INCARNATION arity: it resolves through the
+              ;; validated incarnation's own record and returns nil if a same-id
+              ;; successor has reseated `frame-id`, so the install can never
+              ;; redirect into that successor. Under the drain lock the
+              ;; container's re-read matches the value installed. Nil means the
+              ;; incarnation was lost after the gate (destroyed, or reseated); a
+              ;; non-nil changed-key-set (even empty) means it landed on the
+              ;; exact incarnation.
+              changed (frame/replace-frame-state! frame-id incarnation-token frame-state-target)]
+          (if (nil? changed)
+            (do (emit-precondition-failure! :rf.error/no-such-handler
+                                            {:kind :frame :frame frame-id})
+                false)
+            (do (trace/emit! :rf.epoch :rf.epoch/restored
+                             {:frame       frame-id
+                              :rf.epoch/id (:epoch-id epoch)})
+                ;; Restore triggers no ordinary event, so explicitly anchor its
+                ;; repaint/subscription/unmount back-fill to the restored epoch.
+                (state/set-last-settled-epoch! frame-id (:epoch-id epoch))
+                ;; Deferred subsystem success traces are valid only after install.
+                (commit-resources-restore-traces! frame-state-target)
+                ;; Host timers and HTTP handles are not frame state; cancel the
+                ;; abandoned timeline only after the new state is installed.
+                (quiesce-orphaned-async-host-work! frame-id)
+                true)))))))
 
 ;; ---- replace-frame-state! preconditions ------------------------------------
 ;;

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -1180,12 +1180,15 @@
         (late-bind/set-fn! machines-key (fn [_frame-id] (reset! fired? true)))
         (rf/dispatch-sync [:step] {:frame :test/main})
         (let [target-record (last (rf/epoch-history :test/main))
-              ;; drive perform-restore! directly against a frame whose container
-              ;; is gone (the validate-then-destroy / destroyed-frame branch):
-              ;; live-container-or-fail returns :fail and perform-restore! bails
-              ;; with false BEFORE the success telemetry / quiesce chain.
+              ;; Capture the incarnation token while the frame is still live (as
+              ;; restore-epoch! does at precondition time), then destroy it and
+              ;; drive perform-restore! directly against the now-gone incarnation
+              ;; (the validate-then-destroy / destroyed-frame branch): the
+              ;; write-boundary incarnation gate refuses and perform-restore!
+              ;; bails with false BEFORE the success telemetry / quiesce chain.
+              token (frame/frame-incarnation-token :test/main)
               _ (rf/destroy-frame! :test/main)
-              result (tool-pair/perform-restore! :test/main target-record)]
+              result (tool-pair/perform-restore! :test/main token target-record)]
           (is (false? result) "perform-restore! returns false for the destroyed frame")
           (is (false? @fired?)
               "the quiesce chain did NOT fire for a restore that wrote nothing"))
@@ -4899,17 +4902,18 @@
     (rf/dispatch-sync [:inc]  {:frame :test/short-lived})
 
     (let [target-id (-> (rf/epoch-history :test/short-lived) first :epoch-id)
-          ;; (1) Validate against the LIVE frame — passes, yields the epoch.
-          {:keys [outcome epoch]} (tool-pair/check-restore-preconditions!
-                                    :test/short-lived target-id)]
+          ;; (1) Validate against the LIVE frame — passes, yields the epoch and
+          ;; the exact incarnation token the checks resolved against.
+          {:keys [outcome epoch incarnation-token]}
+          (tool-pair/check-restore-preconditions! :test/short-lived target-id)]
       (is (= :ok outcome) "precondition validation passed against the live frame")
 
       ;; (2) The race: the frame is destroyed in the validate→write window.
       (rf/destroy-frame! :test/short-lived)
 
-      ;; (3) Perform the write at the boundary — the container is now nil.
+      ;; (3) Perform the write at the boundary — the resolved incarnation is gone.
       (let [recorded (record-trace!)
-            result   (tool-pair/perform-restore! :test/short-lived epoch)]
+            result   (tool-pair/perform-restore! :test/short-lived incarnation-token epoch)]
         (is (false? result)
             "perform-restore! reports HONEST failure (false) — NOT a synthetic
              success — when the frame disappeared between validate and write")
@@ -5059,21 +5063,22 @@
     (rf/dispatch-sync [:inc]  {:frame :test/short-lived})
 
     (let [target-id (-> (rf/epoch-history :test/short-lived) first :epoch-id)
-          {:keys [outcome epoch]} (tool-pair/check-restore-preconditions!
-                                    :test/short-lived target-id)]
+          {:keys [outcome epoch incarnation-token]}
+          (tool-pair/check-restore-preconditions! :test/short-lived target-id)]
       (is (= :ok outcome) "precondition validation passed against the live frame")
 
       (let [real-write frame/replace-frame-state!
             recorded   (record-trace!)
-            ;; The post-liveness window: live-container-or-fail (inside
-            ;; perform-restore!) resolves a LIVE container, THEN this redef'd
-            ;; write destroys the frame and delegates to the real write, which
-            ;; now returns nil against the destroyed frame.
+            ;; The post-liveness window: the write-boundary incarnation gate
+            ;; (inside perform-restore!) passes against the LIVE incarnation, THEN
+            ;; this redef'd exact-incarnation write destroys the frame and
+            ;; delegates to the real 3-arity write, which now returns nil against
+            ;; the destroyed incarnation.
             result     (with-redefs [frame/replace-frame-state!
-                                     (fn [frame-id fs]
+                                     (fn [frame-id token fs]
                                        (rf/destroy-frame! frame-id)
-                                       (real-write frame-id fs))]
-                         (tool-pair/perform-restore! :test/short-lived epoch))]
+                                       (real-write frame-id token fs))]
+                         (tool-pair/perform-restore! :test/short-lived incarnation-token epoch))]
         (is (false? result)
             "perform-restore! reports HONEST failure (false) — the nil write
              return is checked, not ignored")
@@ -5085,6 +5090,91 @@
           (is (= :test/short-lived (:frame (:tags ev))) "tags carry :frame"))
         (is (not-any? #(= :rf.epoch/restored (:operation %)) @recorded)
             "no :rf.epoch/restored success trace for the post-liveness drop")))))
+
+;; rf2-bjh6y — the write boundary is fenced to the EXACT frame incarnation the
+;; preconditions resolved against, not the bare id. If incarnation A is
+;; destroyed and a same-id SUCCESSOR B is seated BETWEEN precondition resolution
+;; and the physical write, the restore MUST refuse — installing A's captured
+;; state into B (reported as success) is the defect. The reproduction drives the
+;; two phases directly with the successor interposed, exactly as the public
+;; restore-epoch! sequences them: validate (live A) → destroy A + create B →
+;; perform! with A's now-stale token. Before the fence: {:restore-result true,
+;; :b-db-after {:owner :A :n 1}} — A's state overwrote B. After: the stale write
+;; is rejected via the SAME :rf.error/no-such-handler path a destroyed-frame race
+;; uses, and B is left byte-for-byte untouched.
+
+(deftest restore-fenced-to-exact-incarnation-leaves-same-id-successor-untouched
+  (testing "rf2-bjh6y — a restore whose preconditions resolve against incarnation
+            A, then A is destroyed and a same-id SUCCESSOR B is created BEFORE the
+            write, REJECTS the stale install: returns false, leaves B's app-db
+            byte-for-byte unchanged (A's state is NOT installed into B), emits
+            :rf.error/no-such-handler (kind :frame), and emits no
+            :rf.epoch/restored success trace."
+    (rf/make-frame {:id :test/succ})
+    (rf/reg-event :set-owner (fn [_ [_ owner n]] {:db {:owner owner :n n}}))
+
+    ;; Incarnation A records an epoch at {:owner :A :n 1}, then advances so that
+    ;; epoch is a genuine rewind target (distinct from the current state).
+    (rf/dispatch-sync [:set-owner :A 1] {:frame :test/succ})
+    (rf/dispatch-sync [:set-owner :A 2] {:frame :test/succ})
+    (let [a-target-id (some (fn [r] (when (= {:owner :A :n 1} (:db-after r)) (:epoch-id r)))
+                            (rf/epoch-history :test/succ))
+          ;; (1) Resolve preconditions against LIVE incarnation A — yields the
+          ;; target epoch AND A's exact incarnation token.
+          {:keys [outcome epoch incarnation-token]}
+          (tool-pair/check-restore-preconditions! :test/succ a-target-id)]
+      (is (some? a-target-id) "seeded an A epoch whose db-after is {:owner :A :n 1}")
+      (is (= :ok outcome) "preconditions passed against live incarnation A")
+
+      ;; (2) Interpose: destroy A, seat a same-id SUCCESSOR B (a fresh
+      ;; incarnation — distinct :drain-lock), and give B its own app-db.
+      (rf/destroy-frame! :test/succ)
+      (rf/make-frame {:id :test/succ})
+      (rf/dispatch-sync [:set-owner :B 99] {:frame :test/succ})
+      (is (= {:owner :B :n 99} (rf/app-db-value :test/succ))
+          "successor B seeded to {:owner :B :n 99}")
+
+      ;; (3) Drive the write with A's now-stale token + epoch.
+      (let [recorded    (record-trace!)
+            b-db-before (rf/app-db-value :test/succ)
+            result      (tool-pair/perform-restore! :test/succ incarnation-token epoch)
+            b-db-after  (rf/app-db-value :test/succ)]
+        (is (false? result)
+            (str "the stale cross-incarnation restore must be REJECTED; got "
+                 (pr-str result)))
+        (is (= {:owner :B :n 99} b-db-after)
+            (str "successor B must be byte-for-byte unchanged — A's {:owner :A :n 1} "
+                 "must NOT install into B; b-db-before " (pr-str b-db-before)
+                 " b-db-after " (pr-str b-db-after)))
+        (is (has-error-op? @recorded :rf.error/no-such-handler)
+            ":rf.error/no-such-handler fired for the lost incarnation")
+        (let [ev (some #(when (= :rf.error/no-such-handler (:operation %)) %) @recorded)]
+          (is (= :frame (:kind (:tags ev))) "the typed failure carries :kind :frame")
+          (is (= :test/succ (:frame (:tags ev))) "the typed failure carries :frame"))
+        (is (not-any? #(= :rf.epoch/restored (:operation %)) @recorded)
+            "no :rf.epoch/restored success trace for the rejected stale restore")))))
+
+(deftest restore-within-incarnation-through-fence-still-succeeds
+  (testing "rf2-bjh6y control — with the SAME precheck → token → perform seam but
+            NO incarnation churn, the restore installs and returns true: the
+            exact-incarnation fence rejects only a lost incarnation, never an
+            ordinary live one."
+    (rf/make-frame {:id :test/ctl})
+    (rf/reg-event :set-n (fn [_ [_ n]] {:db {:n n}}))
+    (rf/dispatch-sync [:set-n 1] {:frame :test/ctl})
+    (rf/dispatch-sync [:set-n 2] {:frame :test/ctl})
+    (let [target-id (some (fn [r] (when (= {:n 1} (:db-after r)) (:epoch-id r)))
+                          (rf/epoch-history :test/ctl))
+          {:keys [outcome epoch incarnation-token]}
+          (tool-pair/check-restore-preconditions! :test/ctl target-id)]
+      (is (= :ok outcome) "preconditions passed against the live frame")
+      (is (= {:n 2} (rf/app-db-value :test/ctl)) "current state is {:n 2} before restore")
+      (let [recorded (record-trace!)
+            result   (tool-pair/perform-restore! :test/ctl incarnation-token epoch)]
+        (is (true? result) "an ordinary within-incarnation restore still succeeds")
+        (is (= {:n 1} (rf/app-db-value :test/ctl)) "app-db rewound to the target epoch")
+        (is (some #(= :rf.epoch/restored (:operation %)) @recorded)
+            ":rf.epoch/restored success trace fired for the live-incarnation restore")))))
 
 ;; rf2-obi8rr — the resources restore-reconcile success rows
 ;; (:rf.resource/restored / :rf.resource/owner-released) must NOT leak when the
@@ -5156,16 +5246,16 @@
         (rf/dispatch-sync [:seed-res] {:frame :test/obi8rr-fail})
         (let [target-id (-> (rf/epoch-history :test/obi8rr-fail) last :epoch-id)]
           (rf/dispatch-sync [:clear-res] {:frame :test/obi8rr-fail})
-          (let [{:keys [outcome epoch]} (tool-pair/check-restore-preconditions!
-                                          :test/obi8rr-fail target-id)]
+          (let [{:keys [outcome epoch incarnation-token]}
+                (tool-pair/check-restore-preconditions! :test/obi8rr-fail target-id)]
             (is (= :ok outcome) "precondition validation passed against the live frame")
             (let [real-write frame/replace-frame-state!
                   recorded   (record-trace!)
                   result     (with-redefs [frame/replace-frame-state!
-                                           (fn [fid fs]
+                                           (fn [fid token fs]
                                              (rf/destroy-frame! fid)
-                                             (real-write fid fs))]
-                               (tool-pair/perform-restore! :test/obi8rr-fail epoch))]
+                                             (real-write fid token fs))]
+                               (tool-pair/perform-restore! :test/obi8rr-fail incarnation-token epoch))]
               (is (false? result) "perform-restore! reports honest failure for the nil-write teardown")
               (is (not-any? #(= :rf.epoch/restored (:operation %)) @recorded)
                   "no :rf.epoch/restored (the install never landed)")


### PR DESCRIPTION
## Problem (rf2-bjh6y, P1)

`restore-epoch!` resolved the target record from frame incarnation **A** in `check-restore-preconditions!`, then passed only the **bare frame id** and the resolved epoch into `perform-restore!`. `perform-restore!` serialized on the id, checked only that *some* current container existed (`live-container-or-fail`), reconciled A's saved state, and installed it via a **bare-id** `replace-frame-state!`. If A was destroyed and a same-id successor **B** was created between those phases, the restore installed A's state into B and reported success:

```
{:restore-result true :b-db-before {:owner :B :n 99} :b-db-after {:owner :A :n 1}}
```

The merged drain-serialization fix (`rf2-3fc89f.4`) serialized restore against event drains but did **not** retain exact-incarnation identity across the precheck→write split.

## Fix

Carry **A's exact incarnation token** (the live record's `:drain-lock`, per `frame-incarnation-token`) out on the `check-restore-preconditions!` `:ok` result and thread it to `perform-restore!`. The write boundary is now fenced to that exact incarnation two ways:

1. an early `event-continuation-live?` gate refuses **before** the subsystem reconcile runs (nothing is reconciled against a stale incarnation), and
2. the physical install goes through a new **exact-incarnation** `replace-frame-state!` arity — delegating to `commit-frame-transition!`'s existing token-fenced 3-arity (the same mechanism the router's own exact-incarnation commit uses) — which returns `nil` unless the token still names the live record, so the write itself can never redirect into a same-id successor.

Both losses (no frame / incarnation replaced) resolve to the **one** coherent `:rf.error/no-such-handler` (kind `:frame`) failure the destroyed-frame write race already uses — **no new error id**, no spec/009 catalogue row, **no internal token in public API**. The public `restore-epoch!` arity (`[frame-id epoch-id]`) is unchanged.

Scope: the epoch-restore seam (`restore-epoch!` / `check-restore-preconditions!` / `perform-restore!`) plus a symmetric 2-line exact-incarnation arity on `frame/replace-frame-state!`. The epoch listener-registration API (`register-epoch-listener!`, rf2-6ys5n) is untouched.

## Quality gates

- **Epoch artefact JVM** (`clojure -M:test`): `411 tests, 6115 assertions, 0 failures, 0 errors`.
- **Core JVM** (`clojure -M:test`, frame.cljc is core): `2043 tests, 9640 assertions, 0 failures, 0 errors`.
- **CLJS** (`npm run test:cljs`, epoch is core-reachable): `9850 tests, 48463 assertions, 0 failures, 0 errors`.
- **Red-before / green-after**: the new B-interposition regression fails on the reverted (bare-id gate + bare-id write) behavior exactly as reproduced — `got true`, `b-db-after {:owner :A :n 1}`, `:rf.epoch/restored` fired — and passes after the fence, with B left byte-for-byte `{:owner :B :n 99}` and `:rf.error/no-such-handler` (kind `:frame`) emitted. A within-incarnation control confirms an ordinary restore still installs and returns true.
