### PR TITLE
refactor(machines): finish exact-attempt terminology (drop residual auth vocabulary) (rf2-mlk4e)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -266,7 +266,7 @@
   minted into the join state, and the canonical private work generation
   selected from explicit spawn provenance. The child's
   machine-handler boundary reads it to stamp outbound completion carriers
-  with the attempt authentication the parent's join interceptor verifies
+  with the exact-attempt coordinate the parent's join interceptor verifies
   (`join/stamp-join-completion-fx` / `intercept-spawn-all-event`), so a
   stale completion from a PRIOR attempt / prior actor incarnation can
   never fold into a successor join, while fixed-vs-generated work provenance

--- a/implementation/machines/src/re_frame/machines/reply.cljc
+++ b/implementation/machines/src/re_frame/machines/reply.cljc
@@ -361,7 +361,7 @@
   :rf.machine.spawn-all/join-resolved` — the join is latched `:resolved?`);
   the 3-arity threads an explicit `stale-reason` for the other suppression
   classes (rf2-nvxehu): `:rf.machine.spawn-all/attempt-unverified` (a
-  completion carrier with no runtime attempt authentication),
+  completion carrier with no runtime-stamped attempt coordinate),
   `:rf.machine.spawn-all/attempt-superseded` (a carrier bound to a PRIOR
   child attempt / wrong actor after respawn or re-entry), and
   `:rf.machine.spawn-all/duplicate-completion` (an exact re-completion of an

--- a/implementation/machines/test/re_frame/join_exact_attempt_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_exact_attempt_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.join-exact-auth-cljs-test
+(ns re-frame.join-exact-attempt-cljs-test
   "rf2-nvxehu — join folds and reaps are FENCED to the EXACT child attempt and
   resolved join (a fail-closed correlation record, not authentication).
 
@@ -119,10 +119,10 @@
   read (see `exact-current-coordinate-accepted-from-any-source-metadata-slot-not-read`),
   so tests present crafted coordinates on the coeffect, not on the event. A
   MISMATCHED coordinate fails closed; an EXACT-CURRENT one folds regardless of
-  source. nil `auth` dispatches the bare, coordinate-less public carrier."
-  [parent-kw inner auth]
-  (if auth
-    (rf/dispatch-sync [parent-kw inner] {:rf.cofx {:rf.machine/join-attempt auth}})
+  source. nil `coordinate` dispatches the bare, coordinate-less public carrier."
+  [parent-kw inner coordinate]
+  (if coordinate
+    (rf/dispatch-sync [parent-kw inner] {:rf.cofx {:rf.machine/join-attempt coordinate}})
     (rf/dispatch-sync [parent-kw inner])))
 
 ;; ---------------------------------------------------------------------------
@@ -270,7 +270,7 @@
       (is (= [:rf.machine.spawn-all/attempt-superseded] (stale-reasons))))))
 
 (deftest wrong-child-for-correct-actor-is-superseded
-  (testing "rf2-nvxehu — a carrier claiming child :b with an auth record
+  (testing "rf2-nvxehu — a carrier claiming child :b with an attempt coordinate
             minted for child :a (correct actor A, correct token) fails the
             logical-child-id clause"
     (let [j (reg-join-parent! :jea/p5 :jea/p5a :jea/p5b)]

--- a/implementation/machines/test/re_frame/join_parallel_recordable_controls_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_parallel_recordable_controls_cljs_test.cljc
@@ -3,7 +3,7 @@
   `:rf.cofx` transport (`:rf.machine/join-attempt`) in the AMBIGUOUS PARALLEL
   shape.
 
-  `join_exact_auth_cljs_test` covers the wrong-invoke / wrong-actor /
+  `join_exact_attempt_cljs_test` covers the wrong-invoke / wrong-actor /
   unstamped / unknown-child control classes in the FLAT shape via event-vector
   METADATA. This file re-drives the same control classes in the two-region
   parallel shape where both regions reuse the SAME logical child id `:worker`


### PR DESCRIPTION
## Summary

Finishes the exact-attempt terminology repair (rf2-mlk4e) by removing the residual carrier-facing "authentication" vocabulary tail. That wording pulled readers back toward the rejected secret/provenance model even though current behaviour is a caller-suppliable exact-current **correlation fence** (accept-on-exact / fail-closed-on-mismatch). Closed rf2-cpbjfp + rf2-93r7eu did the main rename; this is the residual tail.

**Narrow terminology/file/test cleanup only — no runtime behaviour change.**

## Changes

Three vocabulary sites (before -> after):

- `lifecycle_fx/spawn.cljc` `join-child-record` docstring: "the **attempt authentication** the parent's join interceptor verifies" -> "the **exact-attempt coordinate** the parent's join interceptor verifies".
- `reply.cljc` `stale-join-child-reply` docstring: an `:attempt-unverified` carrier has "no runtime **attempt authentication**" -> "no runtime-stamped **attempt coordinate**".
- Cross-host fixture: one `"auth record"` test description -> `"attempt coordinate"`.

Fixture rename (via `git mv`, history preserved):

- `join_exact_auth_cljs_test.cljc` -> `join_exact_attempt_cljs_test.cljc`
- ns `re-frame.join-exact-auth-cljs-test` -> `re-frame.join-exact-attempt-cljs-test`
- `dispatch-forged!` `auth` helper arg -> `coordinate` (value still flows to the same `:rf.machine/join-attempt` cofx slot)
- Updated the same-artefact cross-reference in `join_parallel_recordable_controls_cljs_test.cljc` to the new filename.

The ns still ends in `-cljs-test`, so both cognitect-style JVM discovery and the shadow `cljs-test$` ns-regexp match. Runtime keywords (`:attempt-unverified` / `-superseded` / `-duplicate-completion`) and all accept-on-exact / fail-closed-on-mismatch behaviour are unchanged. The "genuinely authenticated live membership" language in `destroy.cljc` was deliberately left untouched (off-surface; the bead protects it).

## Quality gates

- Machines JVM (`clojure -M:test`): **1174 tests / 4046 assertions, 0 failures, 0 errors**.
- Renamed ns standalone (`-n re-frame.join-exact-attempt-cljs-test`): **14 tests / 62 assertions, 0 failures, 0 errors** — confirms JVM discovery of the new filename.
- `npm run test:cljs`: **9852 tests / 48465 assertions, 0 failures, 0 errors** — confirms `cljs-test$` discovery of the new ns.

Closes rf2-mlk4e.