### PR TITLE
fix(xray): concrete-query skipped-sub identity + operator-effective unchanged-sub disclosure (rf2-cj2yx, rf2-16y3x)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -678,10 +678,20 @@ substrate's `sub-run-row` hardcodes `:recomputed? true`) but rides
 tags `:rf.sub/id` / `:rf.sub/query-v` / `:rf.sub/reason` `:input-value-equal`
 / `:rf.sub/input-paths-unchanged`). `reactive-panel-subs/project-record`
 reads those ops off `:trace-events` into a distinct `:subs-skipped` slice
-(`skipped-subs`), de-duplicated by sub-id and EXCLUDING any sub that also
-recomputed this epoch — so `:subs-skipped` stays cleanly distinct from
-`:subs-ran`. It is NOT reconstructed by filtering `:sub-runs` on
-`(complement :recomputed?)`, which is structurally always empty. The
+(`skipped-subs`), de-duplicated + cross-excluded by CONCRETE query-v
+identity (rf2-cj2yx) — NOT the registered `:rf.sub/id`, which would
+collapse distinct parameterizations of one sub. The cache and trace
+identify a short-circuited reaction by its full query vector, so
+`[:item/derived 1]` and `[:item/derived 2]` stay two distinct rows, a burst
+that memo-hits one concrete query collapses to a single row, and a
+recomputed query excludes ONLY its EXACT skip (never every instance sharing
+the registration id) — so `:subs-skipped` stays cleanly distinct from
+`:subs-ran`, and Xray never claims no concrete instance was skipped when one
+was. Rows display + key by the full query vector (documented fallback to the
+registered id only when the skip evidence genuinely lacks a query-v);
+source-coordinate lookup keeps the registered id. It is NOT reconstructed by
+filtering `:sub-runs` on `(complement :recomputed?)`, which is structurally
+always empty. The
 graph's `unchanged` (dashed, short-circuited) nodes are subs that RAN with
 `:value-changed? false` (a recompute that produced the same value) — a
 DIFFERENT category from a memo-hit skip, and the panel never conflates the

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel.cljs
@@ -51,9 +51,17 @@
 (rf/reg-view Panel
   "The Reactive panel's root view. Plain function-call delegation to
   the body so the React-context frame tier resolves through the
-  facade reg-view wrapper to leaf subscribes."
+  facade reg-view wrapper to leaf subscribes.
+
+  The reg-view-injected `dispatch` (the frame-aware dispatcher captured
+  at render time, closing over the surrounding instance frame) is threaded
+  into `reactive-panel` so the panel-local disclosure toggle's deferred
+  `:on-click` lands on THIS Xray instance's frame after render scope
+  unwinds — not a bare global `rf/dispatch` that leaks to `:rf/default`
+  / emits `:rf.error/no-frame-context` (rf2-16y3x). Same contract as the
+  Settings `Modal` threading `dispatch` into `popup-view`."
   []
-  (view/reactive-panel))
+  (view/reactive-panel dispatch))
 
 (def install-viewcell-evidence-bridge!
   "See `reactive-panel-subs/install-viewcell-evidence-bridge!`. Re-exported

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
@@ -22,10 +22,13 @@
     (NOT a `:sub-runs` row) when a reaction was reactively considered but
     its input was value-equal to last-seen, so the user body did NOT
     recompute (`re-frame.subs.memo/emit-sub-skip!`). `project-record`
-    reads those ops off `:trace-events` — de-duplicated by sub-id and
-    excluding any sub that ALSO recomputed this epoch (a sub that ran DID
-    fire; it is a `:subs-ran` row, not an unchanged/short-circuited one),
-    so `:subs-skipped` stays cleanly distinct from `:subs-ran`. This is the
+    reads those ops off `:trace-events` — de-duplicated + cross-excluded
+    by CONCRETE query-v identity (rf2-cj2yx), NOT the registered sub-id, so
+    two parameterizations of one registered sub (`[:item/derived 1]` /
+    `[:item/derived 2]`) stay distinct rows and a recomputed query excludes
+    only its EXACT skip (a sub that ran DID fire; it is a `:subs-ran` row,
+    not an unchanged/short-circuited one), so `:subs-skipped` stays cleanly
+    distinct from `:subs-ran`. This is the
     'what DIDN'T fire' coverage the panel's collapsed unchanged-subs
     disclosure surfaces. It is NOT reconstructed by filtering `:sub-runs`
     on `(complement :recomputed?)` — that shape is structurally empty.
@@ -483,6 +486,20 @@
 
 ;; ---- memo-hit skip evidence (spec/021 §3.4) -------------------------------
 
+(defn- skip-query-v
+  "Concrete-query identity for a `:rf.sub/skip` op (rf2-cj2yx). The
+  canonical `:rf.sub/query-v` tag names the EXACT parameterized instance
+  the cache/trace short-circuited (`[:item/derived 1]` distinct from
+  `[:item/derived 2]`), so it — not the registered `:rf.sub/id` — is the
+  dedup + cross-exclusion key. Documented fallback: when the skip evidence
+  genuinely lacks a query-v, the bare unparameterized query shape
+  `[sub-id]` (so an id-only skip still collapses/excludes against a
+  `[sub-id]`-shaped run). nil only when neither a query-v nor a sub-id is
+  present."
+  [tags sub-id]
+  (or (:rf.sub/query-v tags)
+      (when sub-id [sub-id])))
+
 (defn skipped-subs
   "Project the epoch's memo-hit `:rf.sub/skip` evidence into distinct
   'unchanged sub' rows for the §3.4 disclosure.
@@ -496,31 +513,38 @@
   `:<-` query-vectors for a layer-n sub).
 
   Each projected row `{:sub-id _ :query-v _ :reason _ :input-paths-unchanged
-  [...]}`. De-duplicated by sub-id (first-seen — a post-settle deref burst
-  can memo-hit the same sub repeatedly) and EXCLUDING any sub-id present in
-  `ran-ids` (a sub that recomputed this epoch DID fire — it is a
-  `:subs-ran` row, so it must not ALSO appear in the 'what DIDN'T fire'
-  coverage; this keeps `:subs-skipped` cleanly distinct from `:subs-ran`,
-  the two categories the panel must never conflate).
+  [...]}`. De-duplicated + cross-excluded by CONCRETE QUERY-V identity
+  (rf2-cj2yx), NOT the registered sub-id: the cache and trace identify a
+  short-circuited reaction by its full query vector, so a burst that
+  memo-hits `[:item/derived 2]` twice collapses to one row while
+  `[:item/derived 1]` and `[:item/derived 2]` stay two distinct rows.
+  `ran-query-vs` is the set of concrete query-vectors that RECOMPUTED this
+  epoch; a skip is excluded ONLY when its exact query recomputed (a sub
+  that ran DID fire — it is a `:subs-ran` row, not an unchanged one), so
+  `[:item/derived 1]` recomputing no longer suppresses a `[:item/derived 2]`
+  skip. This keeps `:subs-skipped` cleanly distinct from `:subs-ran`, the
+  two categories the panel must never conflate.
 
-  `ran-ids` is the set of `:sub-id`s in `:subs-ran`. nil-safe on both args."
-  [trace-events ran-ids]
-  (let [ran (or ran-ids #{})]
+  `ran-query-vs` is the set of concrete `:query-v`s in `:subs-ran`.
+  nil-safe on both args."
+  [trace-events ran-query-vs]
+  (let [ran (or ran-query-vs #{})]
     (:rows
      (reduce
       (fn [{:keys [seen] :as acc} ev]
         (if (= :rf.sub/skip (op-kw ev))
-          (let [tags   (:tags ev)
-                sub-id (or (:rf.sub/id tags) (:sub-id tags))]
-            (if (or (nil? sub-id)
-                    (contains? seen sub-id)
-                    (contains? ran sub-id))
+          (let [tags    (:tags ev)
+                sub-id  (or (:rf.sub/id tags) (:sub-id tags))
+                query-v (skip-query-v tags sub-id)]
+            (if (or (nil? query-v)
+                    (contains? seen query-v)
+                    (contains? ran query-v))
               acc
               (-> acc
-                  (update :seen conj sub-id)
+                  (update :seen conj query-v)
                   (update :rows conj
                           {:sub-id                sub-id
-                           :query-v               (:rf.sub/query-v tags)
+                           :query-v               query-v
                            :reason                (:rf.sub/reason tags)
                            :input-paths-unchanged (or (:rf.sub/input-paths-unchanged tags)
                                                       [])}))))
@@ -566,8 +590,16 @@
          flows-comp    (count (get grouped :rf.flow/computed []))
          flows-skipped (count (get grouped :rf.flow/skip []))
          changed-set   (changed-sub-id-set ran)
-         ran-ids       (into #{} (map :sub-id) ran)
-         skipped       (skipped-subs trace-events ran-ids)
+         ;; rf2-cj2yx — cross-exclude skipped subs by CONCRETE query-v, not
+         ;; the registered sub-id: a recomputed `[:item/derived 1]` must
+         ;; exclude only its own skip, never a `[:item/derived 2]` memo-hit.
+         ;; Documented fallback to `[sub-id]` when a run row lacks its query-v.
+         ran-query-vs  (into #{}
+                             (map (fn [row]
+                                    (or (:query-v row)
+                                        (when-let [sid (:sub-id row)] [sid]))))
+                             ran)
+         skipped       (skipped-subs trace-events ran-query-vs)
          readers       (sub-readers trace-events)
          {:keys [level-1 level-2]} (partition-subs-by-level ran topology readers)
          v-rows        (view-rows trace-events changed-set)

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
@@ -516,8 +516,14 @@
   `:rf.xray/reactive-toggle-unchanged` quick-toggle.
 
   Rows key + test-id + label by CONCRETE query-v (rf2-cj2yx), so distinct
-  parameterizations of one registered sub stay individually visible."
-  [data]
+  parameterizations of one registered sub stay individually visible.
+
+  `dispatch` (rf2-16y3x) is the facade-injected frame-aware dispatcher: the
+  toggle's deferred `:on-click` calls IT, not a bare global `rf/dispatch`,
+  so the flip lands on the surrounding Xray instance's frame after render
+  scope unwinds (a bare dispatch would leak to `:rf/default` / emit
+  `:rf.error/no-frame-context` and leave the disclosure state untouched)."
+  [dispatch data]
   (let [rows  (:subs-skipped data)
         n     (count rows)
         open? (boolean (:show-unchanged? data))]
@@ -528,7 +534,7 @@
                  :data-open   (str open?)
                  :aria-expanded (str open?)
                  :on-click    (fn [_e]
-                                (rf/dispatch [:rf.xray/reactive-toggle-unchanged]))
+                                (dispatch [:rf.xray/reactive-toggle-unchanged]))
                  :style       unchanged-toggle-style}
         (str (if open? "Hide" "Show") " " n " unchanged sub" (when (not= 1 n) "s")
              " " (if open? "▴" "▾"))]
@@ -820,9 +826,17 @@
 
   Renders the left → right REACTIVE FLOW graph (rf2-ad7zx.6) followed by
   the UNMOUNTED VIEWS + DESTROYED SUBSCRIPTIONS sections and the closing
-  legend."
-  []
-  (let [data @(rf/subscribe [:rf.xray/reactive-data])]
+  legend.
+
+  `dispatch` (rf2-16y3x) is the frame-aware dispatcher the facade `Panel`
+  reg-view injects and threads down — the panel-local unchanged-subs
+  disclosure toggle's deferred `:on-click` calls it (never a bare global
+  `rf/dispatch`) so the click lands on the surrounding instance frame after
+  render scope unwinds. The 0-arity is a test convenience (plain-fn mounts
+  that never click the toggle); production always threads a real dispatcher."
+  ([] (reactive-panel nil))
+  ([dispatch]
+   (let [data @(rf/subscribe [:rf.xray/reactive-data])]
     [:section {:data-testid "rf-xray-reactive"
                :style {:height "100%"
                        :display "flex"
@@ -848,9 +862,9 @@
          [:section {:data-testid "rf-xray-reactive-flow-section"}
           (section-label "flow" "Reactive Flow" {:title-case? true})
           (flow-graph data)]
-         (unchanged-subs-section data)
+         (unchanged-subs-section dispatch data)
          (unmounted-views-section data)
          (destroyed-subs-section data)
          (viewcell-evidence-section)
          (view-sites-section)
-         (legend)])]]))
+         (legend)])]])))

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
@@ -483,6 +483,29 @@
    ;; §3.4 — rendered at 60% opacity (:text-tertiary): coverage, dimmed.
    :color (:text-tertiary tokens)})
 
+(defn- unchanged-row-identity
+  "Concrete-query identity a skipped-sub row keys + test-ids by (rf2-cj2yx).
+  The full `:query-v` when the skip evidence carried it — so distinct
+  parameterizations of one registered sub (`[:item/derived 1]` /
+  `[:item/derived 2]`) render as distinct, individually-addressable rows;
+  the documented fallback to the registered `:sub-id` only when the
+  evidence genuinely lacked a query-v."
+  [{:keys [sub-id query-v]}]
+  (if (some? query-v) query-v sub-id))
+
+(defn- unchanged-row-label
+  "Display label for a skipped-sub row (rf2-cj2yx). A bare single-element
+  query `[:sub/id]` renders as the plain sub-id (the common unparameterized
+  case — unchanged); a parameterized query renders the FULL vector so
+  `[:item/derived 1]` and `[:item/derived 2]` read distinctly. Falls back
+  to the registered id when the row carries no query-v."
+  [{:keys [sub-id query-v]}]
+  (cond
+    (and (vector? query-v) (= 1 (count query-v))) (format-id (first query-v))
+    (vector? query-v)                             (pr-str query-v)
+    (some? query-v)                               (format-id query-v)
+    :else                                         (format-id sub-id)))
+
 (defn- unchanged-subs-section
   "The 'Show N unchanged subs' footer disclosure (spec/021 §3.4).
 
@@ -490,7 +513,10 @@
   toggle button; collapsed by default, expanded (per-panel toggle OR the
   `:show-unchanged-subs?` Settings pin — both fold into `:show-unchanged?`)
   it lists the memo-hit subs dim. The button dispatches the panel-local
-  `:rf.xray/reactive-toggle-unchanged` quick-toggle."
+  `:rf.xray/reactive-toggle-unchanged` quick-toggle.
+
+  Rows key + test-id + label by CONCRETE query-v (rf2-cj2yx), so distinct
+  parameterizations of one registered sub stay individually visible."
   [data]
   (let [rows  (:subs-skipped data)
         n     (count rows)
@@ -509,12 +535,14 @@
        (when open?
          (into [:div {:data-testid "rf-xray-reactive-unchanged-list"
                       :style       list-card-style}]
-               (for [{:keys [sub-id]} rows]
-                 ^{:key (str sub-id)}
+               (for [{:keys [query-v] :as row} rows
+                     :let [ident (unchanged-row-identity row)]]
+                 ^{:key (str ident)}
                  [:div {:data-testid (str "rf-xray-reactive-unchanged-row-"
-                                          (id-slug sub-id))
+                                          (id-slug ident))
+                        :data-query-v (str query-v)
                         :style       unchanged-row-style}
-                  [:span {:style {:flex 1}} (format-id sub-id)]
+                  [:span {:style {:flex 1}} (unchanged-row-label row)]
                   [:span {:style {:font-family sans-stack :font-size "10px"}}
                    "input unchanged · memo hit"]])))])))
 

--- a/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
@@ -456,6 +456,7 @@
         auto-open?      @(rf/subscribe [:rf.xray/setting :general :auto-open-on-error?])
         epoch-history   @(rf/subscribe [:rf.xray/setting :general :epoch-history])
         show-ungrouped? @(rf/subscribe [:rf.xray/show-ungrouped?])
+        show-unchanged-subs? @(rf/subscribe [:rf.xray/setting :general :show-unchanged-subs?])
         editor-override @(rf/subscribe [:rf.xray/setting :general :editor-override])
         host-editor     @(rf/subscribe [:rf.xray/editor-host-default])]
     [:div {:data-testid "rf-xray-settings-section-general"}
@@ -642,11 +643,45 @@
        "Default OFF — Xray is silent-by-default. Useful when "
        "debugging SSR / REPL flows."]]
 
-     ;; Removed 2026-05-27 — "Always show unchanged subs in the
-     ;; Reactive panel" toggle. The `:show-unchanged-subs?` setting
-     ;; slot stays; default OFF keeps the per-event-bundle footer
-     ;; disclosure pattern (spec/021 §3.4) — unchanged subs are
-     ;; coverage signal, not signal-of-the-moment.
+     ;; ── Always show unchanged subs (spec/021 §3.4 pin) ──────────
+     ;;
+     ;; Restored rf2-16y3x. The `:show-unchanged-subs?` `:general` slot
+     ;; is the always-expand pin for the Views panel's memo-hit "Show N
+     ;; unchanged subs" disclosure. Default OFF keeps the per-event-bundle
+     ;; footer-collapsed pattern (unchanged subs are coverage signal, not
+     ;; signal-of-the-moment); flipping ON expands the disclosure for
+     ;; every event-bundle. Composes with the panel-local quick-toggle —
+     ;; either axis (this pin OR the panel toggle) opens the disclosure
+     ;; (`reactive-panel-subs/:rf.xray/reactive-data` folds the two into
+     ;; `:show-unchanged?`). The slot had been kept while its control was
+     ;; removed on 2026-05-27, leaving spec/021 + the source acceptance
+     ;; promising a pin with no UI; this restores the operator-facing
+     ;; control.
+     [:div {:style (field-style)}
+      [:label {:style {:display "flex" :align-items "center" :gap "8px"
+                       :cursor "pointer"
+                       :font-size (:body type-scale)
+                       :color (:text-primary tokens)}}
+       [:input {:data-testid "rf-xray-settings-show-unchanged-subs"
+                :type        "checkbox"
+                :checked     (boolean show-unchanged-subs?)
+                :on-change   #(dispatch
+                                [:rf.xray/settings-update
+                                 :general :show-unchanged-subs?
+                                 (boolean (.. % -target -checked))])}]
+       "Always show unchanged subs in the Views panel"]
+      [:p {:style (hint-style)}
+       "Pins the Views panel's "
+       [:code {:style {:font-family mono-stack
+                       :color (:text-tertiary tokens)}}
+        "Show N unchanged subs"]
+       " disclosure open for every event-bundle (memo-hit subs that "
+       "short-circuited without recomputing). Default OFF — the footer "
+       "disclosure stays collapsed until you expand it per event-bundle. "
+       "Setting: "
+       [:code {:style {:font-family mono-stack
+                       :color (:text-tertiary tokens)}}
+        ":general :show-unchanged-subs?"] "."]]
 
      ;; Removed 2026-05-27 — "Use system colors" toggle (the manual
      ;; HCM-mode activator). The OS-level `@media (forced-colors:

--- a/tools/xray/test/day8/re_frame2_xray/frame_singleton_guard_test.clj
+++ b/tools/xray/test/day8/re_frame2_xray/frame_singleton_guard_test.clj
@@ -69,6 +69,29 @@
   captured frame-aware dispatcher."
   #":on-[a-z-]+\s+#?\(rf/dispatch(-sync)?\b")
 
+(def ^:private deferred-fn-bare-dispatch-pattern
+  "Matches the DEFERRED-MULTILINE bare-dispatch leak the adjacency-only
+  `on-handler-global-dispatch-pattern` above misses (rf2-16y3x): an
+  `:on-<event>` wired to a multi-line `(fn [args] …)` whose FIRST body
+  form is a single-arg bare `(rf/dispatch [ev])` / `(rf/dispatch-sync
+  [ev])` carrying NO `{:frame …}` opt —
+
+      :on-click    (fn [_e]
+                     (rf/dispatch [:some/event]))
+
+  This is exactly the reactive-panel unchanged-subs toggle bug: after
+  render scope unwinds the ambient frame is gone, so the bare dispatch
+  leaks to `:rf/default` / emits `:rf.error/no-frame-context`, leaving
+  the instance's state untouched. `\\s` spans newlines (Java regex), so
+  the callback body need not be single-line. NARROW by design: it does
+  NOT trip a dispatch carrying an explicit `{:frame frame}` opt (the
+  `\\]\\s*\\)` tail requires the event vector to close the dispatch call)
+  nor a callback whose first form is a guard like `(.stopPropagation e)`
+  — those are the correct/pre-existing shapes. The fix is to call a
+  captured frame-aware dispatcher (the reg-view-injected `dispatch`
+  threaded down, a `dispatch-fn`, or `(:dispatch (rf/capture-frame))`)."
+  #":on-[a-z-]+\s+#?\(fn\s+\[[^\]]*\]\s*\(rf/dispatch(-sync)?\s+\[[^\]]*\]\s*\)")
+
 ;; ---- allowlist ----------------------------------------------------------
 
 (def ^:private pending-migration
@@ -156,9 +179,35 @@
                                    :pattern pattern-kw
                                    :line    (str/trim line)})))))))))
 
+(defn- strip-comment-lines
+  "Drop `;;`-leading comment lines so a whole-file (multiline) scan does
+  not match a pattern that appears only in a line comment. Docstrings are
+  left intact — the deferred-dispatch pattern is code-shaped and does not
+  occur in prose, and stripping them would need a reader."
+  [^String text]
+  (->> (str/split-lines text)
+       (remove #(re-find #"^\s*;;" %))
+       (str/join "\n")))
+
+(defn- multiline-offenders
+  "Return a seq of `{:file rel :pattern <kw>}` for every non-allowlisted
+  file whose WHOLE SOURCE TEXT (comment lines stripped) matches `pattern`
+  — the multiline scan the line-by-line `offenders` can't do (rf2-16y3x).
+  No reader / parser: one DOTALL-free `re-find` over the file text, where
+  `\\s` already spans newlines."
+  [pattern pattern-kw]
+  (let [root (src-root)]
+    (->> (cljs-source-files root)
+         (remove #(pending-migration (rel-path root %)))
+         (keep (fn [^java.io.File f]
+                 (when (re-find pattern (strip-comment-lines (slurp f)))
+                   {:file (rel-path root f) :pattern pattern-kw}))))))
+
 (defn- report [offs]
   (str/join "\n  "
-            (map (fn [{:keys [file line]}] (str file " — " line)) offs)))
+            (map (fn [{:keys [file line]}]
+                   (if line (str file " — " line) (str file)))
+                 offs)))
 
 ;; ---- tests --------------------------------------------------------------
 
@@ -193,6 +242,58 @@
              "reg-view-injected `dispatch`, a threaded `dispatch-fn`, or "
              "`(:dispatch (rf/capture-frame))`). Offenders:\n  "
              (report offs)))))
+
+(deftest no-deferred-fn-bare-dispatch-in-migrated-files
+  ;; rf2-16y3x — the reactive-panel unchanged-subs toggle installed a
+  ;; DEFERRED `(fn [_e] (rf/dispatch [ev]))` on-click. The bare dispatch
+  ;; fired after render scope unwound (ambient frame gone) → leaked to
+  ;; `:rf/default` / `:rf.error/no-frame-context`, leaving Xray state
+  ;; untouched. The adjacency-only guard above missed the multiline
+  ;; callback; this whole-file scan catches it so it cannot regress.
+  (let [offs (multiline-offenders deferred-fn-bare-dispatch-pattern
+                                  :deferred-fn-bare-dispatch)]
+    (is (empty? offs)
+        (str "rf2-16y3x — a DEFERRED multiline bare `(fn [args] (rf/dispatch "
+             "[ev]))` (no `{:frame …}` opt, dispatch as the callback's first "
+             "form) is wired to an `:on-*` handler in a de-singletoned (or "
+             "new) file. After render unwinds the ambient frame is gone, so "
+             "the bare dispatch leaks to `:rf/default` and the instance's "
+             "state never changes. Call a captured frame-aware dispatcher "
+             "(the reg-view-injected `dispatch` threaded down, a "
+             "`dispatch-fn`, or `(:dispatch (rf/capture-frame))`). "
+             "Offenders:\n  "
+             (report offs)))))
+
+(deftest deferred-fn-bare-dispatch-pattern-catches-multiline-callback
+  ;; Causal red/green for the guard (rf2-16y3x): the pattern MUST match the
+  ;; deferred multiline bug shape (which the old adjacency-only pattern
+  ;; missed) and MUST NOT match the fixed shape (a threaded `dispatch`) nor
+  ;; a dispatch carrying an explicit `{:frame …}` opt nor a guard-first
+  ;; callback. Proves the strengthened guard is causally sound without a
+  ;; parser.
+  (let [bug     (str ":on-click    (fn [_e]\n"
+                     "               (rf/dispatch [:rf.xray/reactive-toggle-unchanged]))")
+        bug-1ln ":on-click (fn [_e] (rf/dispatch [:x/y]))"
+        fixed   (str ":on-click    (fn [_e]\n"
+                     "               (dispatch [:rf.xray/reactive-toggle-unchanged]))")
+        framed  (str ":on-click (fn [^js e]\n"
+                     "            (rf/dispatch [:x/y] {:frame frame}))")
+        guarded (str ":on-click (fn [e]\n"
+                     "            (.stopPropagation e)\n"
+                     "            (rf/dispatch [:x/y] {:frame frame}))")]
+    (is (re-find deferred-fn-bare-dispatch-pattern bug)
+        "catches the multiline deferred bare-dispatch bug shape")
+    (is (re-find deferred-fn-bare-dispatch-pattern bug-1ln)
+        "also catches the single-line form")
+    ;; The OLD adjacency-only pattern demonstrably MISSED the multiline shape.
+    (is (not (re-find on-handler-global-dispatch-pattern bug))
+        "the pre-existing adjacency-only guard missed this multiline callback")
+    (is (not (re-find deferred-fn-bare-dispatch-pattern fixed))
+        "does NOT flag a threaded frame-aware `dispatch` (the fix)")
+    (is (not (re-find deferred-fn-bare-dispatch-pattern framed))
+        "does NOT flag a dispatch carrying an explicit {:frame …} opt")
+    (is (not (re-find deferred-fn-bare-dispatch-pattern guarded))
+        "does NOT flag a guard-first callback with an explicit frame opt")))
 
 (deftest pending-migration-allowlist-stays-honest
   ;; The allowlist must only name files that ACTUALLY still carry a

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_disclosure_dispatch_routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_disclosure_dispatch_routing_cljs_test.cljs
@@ -1,0 +1,196 @@
+(ns day8.re-frame2-xray.panels.reactive-panel-disclosure-dispatch-routing-cljs-test
+  "MOUNTED click-time regression for the Views panel's unchanged-subs
+  disclosure controls (rf2-16y3x).
+
+  Sibling in shape to `settings/popup_dispatch_routing_cljs_test.cljs`:
+  it mounts the REAL facade `reg-view` (not the plain `reactive-panel`
+  fn), plucks a deferred `:on-click` off the rendered hiccup, and invokes
+  it OUTSIDE any `with-frame` binding — reproducing the browser reality
+  that a React click fires AFTER render commits and the ambient frame
+  scope has unwound.
+
+  ## The two bugs these mounted tests defend against
+
+  1. **Panel-local toggle leaked to `:rf/default`.** The unchanged-subs
+     footer button installed a deferred `(fn [_e] (rf/dispatch …))` —
+     a BARE global dispatch. After render scope unwinds the 3-tier frame
+     resolution falls through to `:rf/default` (or emits
+     `:rf.error/no-frame-context`), so the click never flipped Xray's
+     `:reactive/show-unchanged?` and the disclosure stayed collapsed.
+     The fix threads the facade `reg-view`-injected frame-aware
+     `dispatch` down through `reactive-panel` → `unchanged-subs-section`,
+     so the deferred click lands on the surrounding instance frame.
+
+  2. **Settings pin had no UI.** The `:general :show-unchanged-subs?`
+     pin (spec/021 §3.4) lost its control on 2026-05-27 while the slot
+     stayed. Restored; the pin alone opens the disclosure.
+
+  The earlier registry tests dispatched inside a manually-bound
+  `:rf/xray` frame, which MASKED the click failure (they proved plumbing,
+  not the deferred-click path). These tests render the actual `Panel` and
+  fire its real deferred handler frameless, so the leak reproduces."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.core :as rf]
+            [re-frame.test-helpers :as th]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.panels.reactive-panel :as facade]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+;; A test-only event that writes the `:epoch-history` db slot the REAL
+;; `:rf.xray/epoch-history` sub reads. Registered in `:post-reset` (a NEW
+;; id, so no duplicate-image guard). Seeding the slot — rather than
+;; re-registering the production composite (rejected by the duplicate-id
+;; image guard once `register-xray-handlers!` has assembled the registry
+;; image) — drives the FULLY-REAL composite + `project-record` + skip
+;; projection, so these mounted tests exercise the real disclosure data
+;; path end to end.
+(defn- register-seed-event! []
+  (rf/reg-event :rf2-16y3x.test/seed-epoch-history
+    (fn [{:keys [db]} [_ history]]
+      {:db (assoc db :epoch-history history)})))
+
+(use-fixtures :each
+  (xray-test-support/make-xray-runtime-fixture
+    {:tier       :runtime
+     :async?     true
+     :post-reset (fn []
+                   (registry/register-xray-handlers!)
+                   (register-seed-event!)
+                   (rf/make-frame {:id :rf/xray}))}))
+
+;; ---- seeding -----------------------------------------------------------
+
+(defn- skip-ev
+  "A canonical `:rf.sub/skip` memo-hit trace event (the real substrate
+  shape) so the production `project-record` projects a genuine
+  `:subs-skipped` row."
+  [sub-id]
+  {:operation :rf.sub/skip
+   :tags      {:rf.sub/id                    sub-id
+               :rf.sub/query-v               [sub-id]
+               :rf.sub/reason                :input-value-equal
+               :rf.sub/input-paths-unchanged []}})
+
+(defn- seed-memo-hits!
+  "Seed the given frame's `:epoch-history` slot with ONE focused epoch
+  record carrying two memo-hit `:rf.sub/skip` trace events, so the REAL
+  `:rf.xray/reactive-data` composite head-falls-back onto it (nil focus →
+  HEAD record) and `project-record` projects two `:subs-skipped` rows. The
+  `:show-unchanged?` open-state stays the real OR of the two live disclosure
+  axes off the frame's db (panel-local toggle slot + Settings pin slot)."
+  [frame-id]
+  (rf/with-frame frame-id
+    (rf/dispatch-sync
+      [:rf2-16y3x.test/seed-epoch-history
+       [{:epoch-id     :ep-1
+         :trace-events [(skip-ev :user/name) (skip-ev :cart/total)]}]])))
+
+(defn- render-panel [frame-id]
+  (rf/with-frame frame-id (facade/Panel)))
+
+(defn- toggle-on-click [tree]
+  (:on-click (second (th/find-by-testid tree "rf-xray-reactive-unchanged-toggle"))))
+
+(defn- fake-event []
+  #js {:preventDefault (fn []) :stopPropagation (fn [])})
+
+(defn- await-xray-db [frame-id pred label]
+  (test-support/poll-until
+    #(pred (rf/app-db-value frame-id))
+    {:label label :timeout-ms 1000}))
+
+;; ---- default collapsed -------------------------------------------------
+
+(deftest disclosure-default-collapsed
+  (testing "rf2-16y3x — with neither the panel-local toggle nor the
+            Settings pin set, the disclosure is collapsed: the footer
+            toggle renders (2 memo-hit subs) but the dim row list does not."
+    (seed-memo-hits! :rf/xray)
+    (let [tree (render-panel :rf/xray)]
+      (is (some? (th/find-by-testid tree "rf-xray-reactive-unchanged-toggle"))
+          "the footer toggle renders")
+      (is (re-find #"Show 2 unchanged subs"
+                   (th/text-content (th/find-by-testid tree "rf-xray-reactive-unchanged-toggle")))
+          "collapsed label counts the memo-hit subs")
+      (is (nil? (th/find-by-testid tree "rf-xray-reactive-unchanged-list"))
+          "the dim row list is hidden while collapsed"))))
+
+;; ---- local click expands (through the frame-bound dispatcher) ----------
+
+(deftest local-toggle-click-expands-through-frame-bound-dispatch
+  (testing "rf2-16y3x — a REAL deferred click on the panel-local toggle,
+            fired OUTSIDE the render frame scope, flips :rf/xray's
+            :reactive/show-unchanged? (no leak to :rf/default, no
+            no-frame-context) and a re-render then shows the dim rows."
+    (seed-memo-hits! :rf/xray)
+    (let [tree    (render-panel :rf/xray)
+          handler (toggle-on-click tree)]
+      (is (fn? handler) "the toggle exposes an :on-click handler")
+      ;; Fire outside any with-frame — exactly a browser click after render.
+      (handler (fake-event))
+      (async done
+        (-> (await-xray-db :rf/xray
+                           #(true? (boolean (:reactive/show-unchanged? %)))
+                           ":reactive/show-unchanged? flips true after the click")
+            (.then (fn [_]
+                     (is (true? (boolean (:reactive/show-unchanged? (rf/app-db-value :rf/xray))))
+                         "the deferred click landed on :rf/xray's frame")
+                     (is (nil? (:reactive/show-unchanged? (rf/app-db-value :rf/default)))
+                         ":rf/default's db was NOT polluted (no bare-dispatch leak)")
+                     ;; Re-render: the composite now folds in the flipped axis.
+                     (let [tree2 (render-panel :rf/xray)]
+                       (is (some? (th/find-by-testid tree2 "rf-xray-reactive-unchanged-list"))
+                           "the dim memo-hit row list now renders")
+                       (is (some? (th/find-by-testid
+                                    tree2 "rf-xray-reactive-unchanged-row-__user_name_"))
+                           "a memo-hit row renders after expand"))
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))
+
+;; ---- Settings pin expands (the configured axis, alone) -----------------
+
+(deftest settings-pin-expands-disclosure
+  (testing "rf2-16y3x — the `:general :show-unchanged-subs?` Settings pin
+            alone (panel-local toggle still OFF) expands the disclosure per
+            spec/021 §3.4 — the local + configured axes compose."
+    (seed-memo-hits! :rf/xray)
+    ;; Flip ONLY the Settings pin (the panel-local toggle stays default OFF).
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/settings-update :general :show-unchanged-subs? true]))
+    (let [tree (render-panel :rf/xray)]
+      (is (false? (boolean (:reactive/show-unchanged? (rf/app-db-value :rf/xray))))
+          "the panel-local quick-toggle is still OFF")
+      (is (some? (th/find-by-testid tree "rf-xray-reactive-unchanged-list"))
+          "the Settings pin alone opens the disclosure")
+      (is (= "true"
+             (get (second (th/find-by-testid tree "rf-xray-reactive-unchanged-toggle"))
+                  :aria-expanded))
+          "the toggle reports expanded"))))
+
+;; ---- frame isolation ---------------------------------------------------
+
+(deftest local-click-changes-only-that-instance
+  (testing "rf2-16y3x — with two frame-scoped panels mounted, a click on
+            instance A's toggle changes ONLY A's disclosure state; instance
+            B's :reactive/show-unchanged? is untouched (per-instance frame,
+            not a shared singleton)."
+    (rf/make-frame {:id :xray-cell-2})
+    (seed-memo-hits! :rf/xray)
+    (seed-memo-hits! :xray-cell-2)
+    (let [tree-a  (render-panel :rf/xray)
+          ;; mount B too (its own frame-bound dispatcher captured)
+          _tree-b (render-panel :xray-cell-2)
+          handler (toggle-on-click tree-a)]
+      (handler (fake-event))
+      (async done
+        (-> (await-xray-db :rf/xray
+                           #(true? (boolean (:reactive/show-unchanged? %)))
+                           "instance A flips true")
+            (.then (fn [_]
+                     (is (true? (boolean (:reactive/show-unchanged? (rf/app-db-value :rf/xray))))
+                         "instance A's disclosure expanded")
+                     (is (false? (boolean (:reactive/show-unchanged? (rf/app-db-value :xray-cell-2))))
+                         "instance B is untouched — driving A did not move B")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_subs_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_subs_cljs_test.cljs
@@ -45,7 +45,7 @@
 (defn- skip-ev
   "A `:rf.sub/skip` memo-hit trace event as the substrate emits it
   (`re-frame.subs.memo/emit-sub-skip!`) — rides `:trace-events`, NOT
-  `:sub-runs`."
+  `:sub-runs`. The query-v is the bare unparameterized shape `[sub-id]`."
   ([sub-id] (skip-ev sub-id []))
   ([sub-id input-paths-unchanged]
    {:operation :rf.sub/skip
@@ -53,6 +53,19 @@
                 :rf.sub/query-v               [sub-id]
                 :rf.sub/reason                :input-value-equal
                 :rf.sub/input-paths-unchanged input-paths-unchanged}}))
+
+(defn- skip-qv
+  "A `:rf.sub/skip` op for a CONCRETE parameterized query (rf2-cj2yx) —
+  the registered `sub-id` plus the EXACT `query-v` the cache/trace
+  short-circuited (e.g. `[:item/derived 1]`), the two carried separately
+  so the projection can dedup/exclude by the concrete query while keeping
+  the id for source-coordinate lookup."
+  [sub-id query-v]
+  {:operation :rf.sub/skip
+   :tags      {:rf.sub/id                    sub-id
+               :rf.sub/query-v               query-v
+               :rf.sub/reason                :input-value-equal
+               :rf.sub/input-paths-unchanged []}})
 
 ;; ---- focused-epoch-record ---------------------------------------------
 
@@ -138,14 +151,80 @@
           "layer-2 skip names its upstream query-vectors"))))
 
 (deftest skipped-subs-excludes-subs-that-also-ran
-  (testing "rf2-ty5r5o — a sub that RECOMPUTED this epoch DID fire, so it is
-            a :subs-ran row and MUST NOT also appear in :subs-skipped (the
-            two categories stay distinct); a pure memo-hit survives."
+  (testing "rf2-ty5r5o / rf2-cj2yx — a sub that RECOMPUTED this epoch DID
+            fire, so it is a :subs-ran row and MUST NOT also appear in
+            :subs-skipped (the two categories stay distinct); a pure memo-hit
+            survives. Exclusion keys on the CONCRETE query-v run-set."
     (let [events [(skip-ev :read-a)     ; also ran (below) → excluded
                   (skip-ev :derived-a)] ; pure skip → kept
-          rows   (subs/skipped-subs events #{:read-a})]
+          ;; ran-set is now concrete query-vs (rf2-cj2yx), not bare sub-ids.
+          rows   (subs/skipped-subs events #{[:read-a]})]
       (is (= [:derived-a] (mapv :sub-id rows))
           ":read-a is excluded (it ran); :derived-a survives"))))
+
+;; ---- concrete-query identity (rf2-cj2yx) -------------------------------
+;;
+;; The cache/trace identify a short-circuited reaction by its full query
+;; vector, so the disclosure must dedup + cross-exclude by concrete query-v
+;; — NOT the registered sub-id, which collapses distinct parameterizations.
+
+(deftest skipped-subs-preserves-distinct-parameterizations
+  (testing "rf2-cj2yx — two memo-hit skips sharing a registered sub-id but
+            with DISTINCT concrete query-vs BOTH survive (dedup is by
+            concrete query-v, not the registered id)."
+    (let [events [(skip-qv :item/derived [:item/derived 1])
+                  (skip-qv :item/derived [:item/derived 2])]
+          rows   (subs/skipped-subs events #{})]
+      (is (= 2 (count rows)) "both parameterizations survive")
+      (is (= [[:item/derived 1] [:item/derived 2]] (mapv :query-v rows))
+          "each row carries its own concrete query-v")
+      (is (= [:item/derived :item/derived] (mapv :sub-id rows))
+          "the registered id rides both rows for source-coord lookup"))))
+
+(deftest skipped-subs-dedups-repeated-same-concrete-query
+  (testing "rf2-cj2yx — repeated evidence for the SAME concrete query (a
+            post-settle deref burst) collapses to one row."
+    (let [events [(skip-qv :item/derived [:item/derived 2])
+                  (skip-qv :item/derived [:item/derived 2])]
+          rows   (subs/skipped-subs events #{})]
+      (is (= [[:item/derived 2]] (mapv :query-v rows))
+          "the same concrete query collapses to a single row"))))
+
+(deftest skipped-subs-recompute-excludes-only-exact-query
+  (testing "rf2-cj2yx — the focused counterexample: `[:item/derived 1]`
+            recomputes while `[:item/derived 2]` memo-hits. The recompute
+            excludes ONLY its exact query; the different same-id memo-hit is
+            preserved + disambiguated, not suppressed."
+    (let [events       [(skip-qv :item/derived [:item/derived 1])  ; ran below → excluded
+                        (skip-qv :item/derived [:item/derived 2])] ; memo-hit → kept
+          ran-query-vs #{[:item/derived 1]}
+          rows         (subs/skipped-subs events ran-query-vs)]
+      (is (= [[:item/derived 2]] (mapv :query-v rows))
+          "only the exact recomputed query is excluded; the sibling survives"))))
+
+(deftest skipped-subs-unparameterized-behavior-unchanged
+  (testing "rf2-cj2yx — an ordinary unparameterized skip (query-v `[sub-id]`)
+            still projects one row and still excludes when that exact query
+            recomputed: the common-case behavior is unchanged."
+    (is (= [:user/name]
+           (mapv :sub-id (subs/skipped-subs [(skip-ev :user/name)] #{})))
+        "a lone unparameterized skip survives")
+    (is (= []
+           (subs/skipped-subs [(skip-ev :user/name)] #{[:user/name]}))
+        "the `[sub-id]` run-set excludes the matching `[sub-id]` skip")))
+
+(deftest skipped-subs-falls-back-to-sub-id-when-query-v-absent
+  (testing "rf2-cj2yx — documented fallback: a skip op lacking a query-v
+            uses the registered `[sub-id]` shape as its identity, so it
+            still projects a row and still excludes against a `[sub-id]` run."
+    (let [ev {:operation :rf.sub/skip
+              :tags {:rf.sub/id :legacy/sub :rf.sub/reason :input-value-equal}}]
+      (is (= [{:sub-id :legacy/sub :query-v [:legacy/sub]}]
+             (mapv #(select-keys % [:sub-id :query-v])
+                   (subs/skipped-subs [ev] #{})))
+          "query-v falls back to the bare [sub-id] shape")
+      (is (= [] (subs/skipped-subs [ev] #{[:legacy/sub]}))
+          "the fallback identity still cross-excludes against a [sub-id] run"))))
 
 (deftest skipped-subs-nil-safe
   (is (= [] (subs/skipped-subs nil nil)))
@@ -180,6 +259,36 @@
       (let [p (subs/project-record r)]
         (is (= [] (:subs-skipped p)))
         (is (= 0 (-> p :counts :subs-skipped)))))))
+
+(deftest project-record-preserves-parameterized-skip-past-same-id-recompute
+  (testing "rf2-cj2yx — end to end: `[:item/derived 1]` recomputes (a
+            :sub-runs row) while `[:item/derived 2]` memo-hits. project-record
+            builds the run-set from CONCRETE query-vs, so it excludes only the
+            exact recomputed query and keeps the `[:item/derived 2]` skip —
+            Xray no longer claims no concrete instance was skipped when one
+            was."
+    (let [record {:sub-runs     [{:sub-id :item/derived :query-v [:item/derived 1]
+                                  :recomputed? true :value-changed? true}]
+                  :trace-events [(skip-qv :item/derived [:item/derived 2])]}
+          p      (subs/project-record record)]
+      (is (= [[:item/derived 1]] (mapv :query-v (:subs-ran p)))
+          ":item/derived 1 recomputed → a subs-ran row")
+      (is (= [[:item/derived 2]] (mapv :query-v (:subs-skipped p)))
+          ":item/derived 2 memo-hit survives (NOT suppressed by the same-id recompute)")
+      (is (= [:item/derived] (mapv :sub-id (:subs-skipped p)))
+          "the registered id still rides the skip row")
+      (is (= 1 (-> p :counts :subs-skipped))))))
+
+(deftest project-record-both-parameterizations-skipped-survive
+  (testing "rf2-cj2yx — two same-id skipped queries with no recompute BOTH
+            survive through project-record (distinct concrete rows)."
+    (let [record {:sub-runs     []
+                  :trace-events [(skip-qv :item/derived [:item/derived 1])
+                                 (skip-qv :item/derived [:item/derived 2])]}
+          p      (subs/project-record record)]
+      (is (= [[:item/derived 1] [:item/derived 2]] (mapv :query-v (:subs-skipped p)))
+          "both concrete parameterizations survive as distinct rows")
+      (is (= 2 (-> p :counts :subs-skipped))))))
 
 ;; ---- project-record: views rendered -----------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
@@ -471,3 +471,51 @@
       (is (re-find #"no change \(short-circuits" legend-text) "no-change swatch labelled")
       (is (re-find #"unmounted / destroyed" legend-text) "teardown swatch labelled"))))
 
+;; ---- unchanged-subs disclosure keys by concrete query-v (rf2-cj2yx) ----
+
+(deftest unchanged-rows-key-and-label-by-concrete-query-v
+  (testing "rf2-cj2yx — two skipped memo-hits sharing a registered sub-id but
+            DISTINCT concrete query-vs render as two individually-addressable
+            rows: distinct test-ids AND distinct labels (the full query
+            vector), not one row collapsed by sub-id."
+    (facade/install!)
+    (rf/make-frame {:id :rf/xray})
+    (seed-reactive-data!
+      {:has-event-bundle? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :show-unchanged? true
+       :subs-skipped [{:sub-id :item/derived :query-v [:item/derived 1]
+                       :reason :input-value-equal :input-paths-unchanged []}
+                      {:sub-id :item/derived :query-v [:item/derived 2]
+                       :reason :input-value-equal :input-paths-unchanged []}]})
+    (let [tree (view/reactive-panel)
+          row1 (th/find-by-testid tree "rf-xray-reactive-unchanged-row-__item_derived_1_")
+          row2 (th/find-by-testid tree "rf-xray-reactive-unchanged-row-__item_derived_2_")]
+      (is (some? row1) "the [:item/derived 1] parameterization has its own row")
+      (is (some? row2) "the [:item/derived 2] parameterization has its own row")
+      (is (re-find #"\[:item/derived 1\]"
+                   (text-of tree "rf-xray-reactive-unchanged-row-__item_derived_1_"))
+          "row 1 labels with its full concrete query vector")
+      (is (re-find #"\[:item/derived 2\]"
+                   (text-of tree "rf-xray-reactive-unchanged-row-__item_derived_2_"))
+          "row 2 labels with its full concrete query vector"))))
+
+(deftest unchanged-row-unparameterized-shows-plain-sub-id
+  (testing "rf2-cj2yx — a bare unparameterized skip (query-v `[:sub/id]`)
+            renders the plain sub-id label (the common case is unchanged),
+            not a bracketed one-element vector."
+    (facade/install!)
+    (rf/make-frame {:id :rf/xray})
+    (seed-reactive-data!
+      {:has-event-bundle? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :show-unchanged? true
+       :subs-skipped [{:sub-id :user/name :query-v [:user/name]
+                       :reason :input-value-equal :input-paths-unchanged []}]})
+    (let [tree (view/reactive-panel)
+          row  (text-of tree "rf-xray-reactive-unchanged-row-__user_name_")]
+      (is (some? row) "the unparameterized row renders")
+      (is (re-find #":user/name" row) "labels with the plain sub-id")
+      (is (not (re-find #"\[:user/name\]" row))
+          "no bracketed one-element vector for the bare query"))))
+

--- a/tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs
@@ -116,6 +116,33 @@
       (is (find-by-testid rendered "rf-xray-settings-epoch-history-value")
           "Epoch history numeric readout renders alongside the slider"))))
 
+(deftest general-section-restores-show-unchanged-subs-pin
+  (testing "rf2-16y3x — the General tab re-exposes the 'Always show
+            unchanged subs' pin (spec/021 §3.4). The control had been
+            removed while its `:general :show-unchanged-subs?` slot stayed,
+            so the spec/source promised a pin with no UI. The controlled
+            checkbox reflects the slot and writes via :rf.xray/settings-update."
+    (setup!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/settings-open])
+      (rf/dispatch-sync [:rf.xray/settings-select-tab :general]))
+    (rf/with-frame :rf/xray
+      (let [rendered (popup/Modal)
+            box      (find-by-testid rendered "rf-xray-settings-show-unchanged-subs")]
+        (is (some? box) "the restored show-unchanged-subs checkbox renders")
+        (is (= false (:checked (second box)))
+            "unchecked by default (slot default OFF)")
+        (is (fn? (:on-change (second box)))
+            "the checkbox carries an :on-change writer")))
+    ;; Flip the pin ON; the controlled checkbox reflects the slot on re-render.
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/settings-update :general :show-unchanged-subs? true]))
+    (rf/with-frame :rf/xray
+      (let [rendered (popup/Modal)
+            box      (find-by-testid rendered "rf-xray-settings-show-unchanged-subs")]
+        (is (= true (:checked (second box)))
+            "the checkbox reflects the flipped-on pin")))))
+
 ;; rf2-pu9sb moved the Epoch history slider from General to Buffer;
 ;; that move was reverted 2026-05-27 per Mike. The slot stays
 ;; `:general :epoch-history`; only the visual home moved. The


### PR DESCRIPTION
Fixes the Xray Reactive-panel unchanged-sub (memo-hit) disclosure surface — a 2-bead cluster.

## rf2-cj2yx — preserve concrete query identity in skipped-sub disclosure

The skipped-subs projection deduplicated and cross-excluded by the registered `sub-id` while the cache/trace identify concrete instances by full query-v. So a recomputed `[:item/derived 1]` suppressed a `[:item/derived 2]` memo-hit, and multiple skipped parameterizations collapsed to the first — Xray could claim no concrete instance was skipped when one was.

- `skipped-subs` / `project-record` now dedup + cross-exclude by **concrete query-v** (documented fallback to `[sub-id]` only when the skip evidence lacks a query-v). A recompute excludes only its exact query.
- The `unchanged-subs-section` view keys, test-ids, and labels each row by its full query vector, so distinct parameterizations stay individually visible; a bare `[sub-id]` query still renders the plain sub-id label.
- Seam: `tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs` (`skipped-subs`, `project-record`) + `reactive_panel_view.cljs` (`unchanged-subs-section`).
- `spec/021` §3.4 documents the concrete-query identity.

## rf2-16y3x — make both unchanged-sub disclosure controls operator-effective

Neither disclosure control was effective. The panel-local toggle installed a deferred `(fn [_e] (rf/dispatch …))` — a bare global dispatch that, after render scope unwinds, leaked to `:rf/default` / emitted `rf.error/no-frame-context` and left Xray state untouched. The Settings view had removed the promised "Always show unchanged subs" control while keeping its state slot.

- The facade `Panel` reg-view now threads its injected frame-aware `dispatch` through `reactive-panel` → `unchanged-subs-section`, so the toggle's deferred click lands on the surrounding instance frame. Seam: `reactive_panel.cljs:56` (`(view/reactive-panel dispatch)`) → `reactive_panel_view.cljs` (`reactive-panel` arity + `unchanged-subs-section` on-click).
- Settings General re-exposes the `:general :show-unchanged-subs?` pin; the pin alone opens the disclosure (composes with the panel-local toggle). Seam: `settings/view.cljs` `general-section`.
- A **mounted regression** (`reactive_panel_disclosure_dispatch_routing_cljs_test.cljs`) renders the real `Panel` reg-view, fires its real deferred toggle click frameless, and proves default-collapsed / local-click-expanded / Settings-pin-expanded / frame-isolation using real memo-hit rows (the fully-real composite + `project-record` + skip path). Red-before verified: with a bare dispatch the click never flips `:rf/xray`'s `:reactive/show-unchanged?` (poll times out).
- The frame-singleton guard gains a narrow multiline pattern (+ a causal unit test) that catches a deferred `(fn [args] (rf/dispatch [ev]))` the adjacency-only guard missed — no parser, no new state machinery. It does not trip the pre-existing `.stopPropagation`/`{:frame frame}` shapes.
- `spec/021` §3.4 already specifies both the panel-local toggle and the Settings pin; the source had drifted (control removed) and is restored to match — no additional spec change needed.

No `registry.cljs` or `implementation/`/core touch (the dispatcher is threaded via the existing reg-view injection). Rebased-clean on origin/main (no file overlap with the 27 intervening commits).

## Quality gates

- **tools/xray JVM** (`clojure -M:test`): `Ran 1270 tests … 0 failures, 0 errors` — includes the strengthened frame-singleton guard + its causal pattern test.
- **CLJS node** (`npm run test:cljs`): `Ran 9851 tests containing 48406 assertions. 0 failures, 0 errors` — includes the mounted disclosure regression + the restored-Settings-control test + the cj2yx concrete-query tests.
- **Red-before / green-after** (per bead):
  - cj2yx: the same-id recompute + different same-id memo-hit counterexample and two-same-id-skips-survive tests fail under sub-id identity, pass under concrete query-v.
  - 16y3x: the mounted deferred-click tests (`local-toggle-click-expands…`, `local-click-changes-only…`) fail with the bare dispatch (poll times out — state never flips), pass with the threaded dispatcher.
- **Browser feature gate** (`npm run test:xray-feature-gate`): 15/16 scenarios pass. The 1 failure is a **non-deterministic 5000ms Playwright locator timeout** unrelated to this diff — a **different** scenario failed on each of two runs ("static mode chrome and chord", then "source coordinates and launch-mode availability"), both outside the Dynamic-mode reactive-panel / settings surfaces this PR touches, with an accompanying `http-server exited unexpectedly` under compile/browser load. Every scenario exercising the changed surfaces ("feature matrix shell and panel handoff", "multi-frame isolation substrate", "two-frame isolation") passed green on both runs.
