### PR TITLE
fix(ui-compiler): host-faithful defview binding plan — qualified :keys, symbol metadata, header eval semantics (rf2-wix0o, rf2-gvuoo, rf2-nedxb)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/binding_plan.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/binding_plan.cljc
@@ -108,7 +108,14 @@
     (for [[bb bk] bes]
       (if (contains? explicit bb)
         {:local-pattern bb :key bk :explicit? true}
-        {:local-pattern (symbol (name bb)) :key bk :explicit? false}))))
+        ;; Reconstruct the group local exactly as the host does — name-stripped
+        ;; (`{:keys [acct/id]}` binds `id`), but carrying the AUTHORED symbol's
+        ;; metadata (`(with-meta (symbol nil (name bb)) (meta bb))`), so a `^js`
+        ;; or other portable type hint survives to the CLJS `let` binding and its
+        ;; Closure interop inference. Only the host's existing metadata is kept;
+        ;; nothing is invented, matching `clojure.core/destructure` verbatim.
+        {:local-pattern (with-meta (symbol nil (name bb)) (meta bb))
+         :key bk :explicit? false}))))
 
 (defn binding-order
   "The local-patterns of map `pattern`, in host `destructure` `bes` order

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -647,32 +647,38 @@
 
 (defn- slot-read [slot default]
   (if (some? default)
-    `(let [v# (cljs.core/unchecked-get ~props-sym ~slot)]
-       (if (cljs.core/undefined? v#) ~default v#))
+    ;; Host-faithful: native destructure lowers a defaulted slot to
+    ;; `(get props :slot default)` — `get` is a function, so the default operand
+    ;; is EVALUATED as part of the lookup even when the slot is present (it is an
+    ;; eager third argument). Evaluate `d#` unconditionally (once), then select
+    ;; it only when the slot is absent — matching the host's eval count/effects,
+    ;; not just its final value.
+    `(let [d# ~default
+           v# (cljs.core/unchecked-get ~props-sym ~slot)]
+       (if (cljs.core/undefined? v#) d# v#))
     `(cljs.core/unchecked-get ~props-sym ~slot)))
 
 (defn header-bindings
   "The CLJS header `let` bindings, in canonical host `destructure` order
   (rf2-vxgfnd.283): `:as` binds the whole props map FIRST — matching the JVM
-  native destructuring the JVM emitter uses — then ONE property-read per
-  collapsed binding unit. The entries are already the host `bes` order with
-  winning lookup slots (`parse-header` routed them through the ONE canonical
-  binding plan, `bp/assoc-binding-units`, then `header/collapse-entries`), so
-  there is NOTHING left to sort or de-collide here: two header entries binding
-  the same local — whether they collided in the `bes` map or only after a
-  qualified group local name-strips onto an explicit local — already collapsed
-  in `parse-header` to one entry, so this emits exactly one read of the host's
-  winning slot (never two, never a silent last-wins), and a qualified `:keys`
-  local reads its qualified slot. Emitting `:as` last, or the
-  entries in parse order, could resolve a dependent `:or` default to a different
-  symbol on CLJS than on the JVM — including a public reactive authoring var."
+  native destructuring the JVM emitter uses — then ONE property-read per host
+  binding UNIT. These consume `parse-header`'s `:binding-units` — the FULL host
+  plan, not the collapsed derived projection — so the emission reproduces the
+  host's executable semantics exactly (rf2-nedxb): every host initializer runs,
+  and a qualified-group-name collision (`{:keys [ns/x] x :other}`) emits BOTH
+  units binding one local, the later `:ns/x` winning by host `let` last-wins.
+  The units are already the host `bes` order with winning lookup slots (a
+  qualified `:keys` local reads its qualified slot), so there is nothing to sort
+  or de-collide here. Emitting `:as` last, or the units in parse order, could
+  resolve a dependent `:or` default to a different symbol on CLJS than on the
+  JVM — including a public reactive authoring var."
   [header]
   (concat
    (when (:as-sym header)
      [(:as-sym header) `(re-frame.ui.runtime/props->map ~props-sym)])
    (mapcat (fn [{:keys [slot pattern default]}]
              [pattern (slot-read slot default)])
-           (:entries header))))
+           (:binding-units header))))
 
 (defn comparator-form
   "The generated straight-line rf= comparator (RULED: Object.is OR = per

--- a/implementation/ui/src/re_frame/ui/compiler/header.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/header.cljc
@@ -137,21 +137,33 @@
           entries)))
 
 (defn parse-header
-  "argv -> {:mode :none|:named|:as, :as-sym, :entries [{:key :slot
-  :pattern :default}...], :slots [kw...], :children? bool, :binding-form}
+  "argv -> {:mode :none|:named|:as, :as-sym, :entries [{:key :slot :pattern
+  :default}...], :binding-units [...same shape...], :slots [kw...], :children?
+  bool, :binding-form}
 
-  The binding `:entries` and `:slots` are the CANONICAL, host-faithful binding
-  units (`bp/assoc-binding-units`, then `collapse-entries`): one entry per bound
-  local, in host `destructure` `bes` order, carrying the WINNING lookup key after
-  collapse. Two header entries that bind the same local COLLAPSE to a single
-  entry — never two, never a silent last-wins — whether they collide in the host
-  `bes` map (`{:keys [x] x :foo}` → `x <- :x`) or only after the qualified group
-  local name-strips onto an explicit local (`{:keys [ns/x] x :other}` → the host
-  last-wins `x <- :ns/x`, the explicit `:other` dropped). A qualified group local
-  (`{:keys [acct/id]}`) keeps its qualified slot `:acct/id`. Both emitters, the
-  schema slot order, the memo comparator and the manifest metadata read these
-  same collapsed entries, so no downstream path can re-collide, strip a qualified
-  key, or inherit a dead slot."
+  TWO views of the ONE canonical, host-faithful binding plan
+  (`bp/assoc-binding-units`), split by what the host actually does:
+
+  - `:binding-units` — the FULL host binding-unit plan, one unit per `bes`
+    entry, in host `destructure` order, carrying its winning lookup key and any
+    `:or` default. The EXECUTABLE emission (the CLJS `header-bindings` lowering)
+    and the analyzer's scope walk consume this, so every host initializer runs
+    and the host `let` last-wins is reproduced exactly — including the two units
+    a qualified-group-name collision (`{:keys [ns/x] x :other}`) establishes for
+    one local (rf2-nedxb).
+
+  - `:entries` + `:slots` — the COLLAPSED effective-slot projection (`:entries`
+    run through `collapse-entries`): one entry per bound local, the host-winning
+    last occurrence. DERIVED metadata — the memo comparator, the manifest
+    `:prop-slots`, the closed-`:props` slot set and the schema slot order — reads
+    these, so it never over-declares a dead slot (`{:keys [ns/x] x :other}` drops
+    `:other`), re-collides, or strips a qualified key (`{:keys [acct/id]}` keeps
+    `:acct/id`).
+
+  For every header WITHOUT a qualified-group-name collision the two views are
+  identical; they differ only where the host binds one local through two `bes`
+  keys. The JVM emitter uses `:binding-form` (native destructuring) and needs
+  neither view."
   [argv]
   (when-not (vector? argv)
     (fail :rf.ui.compile/bad-defview-args
@@ -163,33 +175,37 @@
                "positional args. Got " (count argv))
           {:argv argv}))
   (if (empty? argv)
-    {:mode :none :as-sym nil :entries [] :slots [] :children? false
-     :binding-form nil}
+    {:mode :none :as-sym nil :entries [] :binding-units [] :slots []
+     :children? false :binding-form nil}
     (let [b (first argv)]
       (cond
         (symbol? b)
-        {:mode :as :as-sym b :entries [] :slots [] :children? true
-         :binding-form b}
+        {:mode :as :as-sym b :entries [] :binding-units [] :slots []
+         :children? true :binding-form b}
 
         (map? b)
         (let [as-sym  (get b :as)
               or-map  (get b :or {})
               _       (validate-header-map! b or-map)
-              ;; ONE canonical, de-collided binding plan — the host `bes` order
-              ;; with winning lookup keys. `collapse-entries` folds any two units
-              ;; that bind the SAME local (including the qualified-group-name
-              ;; collision `bp/assoc-binding-units` leaves as two) to the single
-              ;; host-winning entry, so no downstream consumer inherits a dead
-              ;; slot, re-collides, or strips a qualified key.
-              entries (collapse-entries
-                       (mapv (fn [{:keys [local-pattern key]}]
-                               (cond-> {:key key
-                                        :slot (slot-name key)
-                                        :pattern local-pattern}
-                                 (and (symbol? local-pattern)
-                                      (contains? or-map local-pattern))
-                                 (assoc :default (get or-map local-pattern))))
-                             (bp/assoc-binding-units b)))
+              ;; The FULL host binding-unit plan — the host `bes` order with
+              ;; winning lookup keys, EVERY unit the host `let` establishes. A
+              ;; qualified-group-name collision (`{:keys [ns/x] x :other}`) is two
+              ;; units binding one local via host last-wins; both stay here so
+              ;; executable emission runs every host initializer (rf2-nedxb).
+              binding-units
+              (mapv (fn [{:keys [local-pattern key]}]
+                      (cond-> {:key key
+                               :slot (slot-name key)
+                               :pattern local-pattern}
+                        (and (symbol? local-pattern)
+                             (contains? or-map local-pattern))
+                        (assoc :default (get or-map local-pattern))))
+                    (bp/assoc-binding-units b))
+              ;; The COLLAPSED effective-slot projection — one entry per bound
+              ;; local (the host-winning last occurrence). `collapse-entries` folds
+              ;; the qualified-group-name collision to its single winner, so the
+              ;; comparator, manifest and schema slots carry no dead key.
+              entries (collapse-entries binding-units)
               _ (doseq [s (keys or-map)]
                   (when-not (some #(= s (:pattern %)) entries)
                     (fail :rf.ui.compile/bad-defview-args
@@ -199,6 +215,7 @@
           {:mode (if as-sym :as :named)
            :as-sym as-sym
            :entries entries
+           :binding-units binding-units
            :slots slots
            :children? (boolean (or as-sym (some #(= :children %) slots)))
            :binding-form b})

--- a/implementation/ui/src/re_frame/ui/compiler/header.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/header.cljc
@@ -84,10 +84,15 @@
        (do (when-not (and (vector? v) (every? symbol? v))
              (fail :rf.ui.compile/bad-defview-args
                    (str k " needs a vector of symbols") {:form v}))
-           (doseq [s v]
-             (reserved-slot-check! (if-let [ns* (namespace k)]
-                                     (keyword ns* (name s))
-                                     (keyword (name s))))))
+           ;; Derive each group key with the CANONICAL transform the binding plan
+           ;; uses (`bp/key-group-directive-fn`), so `{:keys [acct/key]}` derives
+           ;; the qualified `:acct/key` — NOT a bare `:key` from `(keyword (name
+           ;; s))` — while a genuinely bare `:keys [key]`/`:keys [ref]` still
+           ;; derives the reserved `:key`/`:ref` and fails. One namespace rule for
+           ;; the diagnostic and the plan, so equivalent host spellings agree.
+           (let [group-key (bp/key-group-directive-fn k)]
+             (doseq [s v]
+               (reserved-slot-check! (group-key s)))))
 
        (keyword? k)
        (fail :rf.ui.compile/bad-defview-args

--- a/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_jvm_test.clj
@@ -41,6 +41,33 @@
        (map first)
        vec))
 
+(defn- native-local
+  "The user local `clojure.core/destructure` binds for name `nm` in map `pat` —
+  WITH the metadata the host preserves via `with-meta` (the ground truth)."
+  [pat nm]
+  (->> (destructure [pat 'the-map])
+       (partition 2)
+       (map first)
+       (some #(when (and (symbol? %) (= (name nm) (name %))) %))))
+
+(defn- plan-local
+  "The canonical binding plan's `:local-pattern` for local name `nm` in map
+  `pat` — WITH its metadata (the plan must retain what the host preserves)."
+  [pat nm]
+  (some #(when (and (symbol? %) (= (name nm) (name %)))
+           %)
+        (ana/header-binding-order pat)))
+
+(defn- emit-local
+  "The symbol the CLJS header emitter binds for local name `nm` — WITH its
+  metadata, so a lost `^js`/type hint on the emitted `let` binding is visible."
+  [argv nm]
+  (->> (header/parse-header argv)
+       emit-cljs/header-bindings
+       (partition 2)
+       (map first)
+       (some #(when (and (symbol? %) (= (name nm) (name %))) %))))
+
 ;; ---------------------------------------------------------------------------
 ;; The plan reproduces the host bes order
 ;; ---------------------------------------------------------------------------
@@ -258,3 +285,45 @@
           f   (eval (list 'fn [pat] 'x))]
       (is (= :a (f {:x :a :foo :b})) "reads :x")
       (is (nil? (f {:foo :b}))       "absent :x, no default → nil, never :foo"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-gvuoo — group-symbol METADATA survives the canonical plan
+;;
+;; `assoc-binding-units` reconstructed a group local with `(symbol (name bb))`,
+;; discarding authored symbol metadata. Real `clojure.core/destructure`
+;; preserves it via `(with-meta (symbol nil (name bb)) (meta bb))`. Symbol
+;; equality ignores metadata, so the plan-order tests above false-green; losing
+;; `^js` and other portable type hints changes Closure interop inference,
+;; warnings and advanced-build codegen. These fixtures compare the metadata
+;; DIRECTLY against the host's, so a `(symbol (name …))` regression fails.
+;; ---------------------------------------------------------------------------
+
+(deftest group-symbol-metadata-survives-the-canonical-plan
+  (testing "native clojure.core/destructure preserves ^js on the group local (ground truth)"
+    (is (= {:tag 'js} (meta (native-local '{:keys [^js node]} 'node)))
+        "the host binds `node` carrying its authored {:tag js}"))
+  (testing "the canonical binding plan retains the SAME metadata as the host"
+    (let [host (meta (native-local '{:keys [^js node]} 'node))
+          plan (meta (plan-local   '{:keys [^js node]} 'node))]
+      (is (= {:tag 'js} plan)
+          "^js survives on the plan's :local-pattern, not a bare (symbol (name bb))")
+      (is (= host plan)
+          "plan metadata equals the host's preserved metadata")))
+  (testing "the emitted CLJS header binding carries the hint (advanced interop)"
+    (is (= {:tag 'js} (meta (emit-local ['{:keys [^js node]}] 'node)))
+        "^js reaches the emitted `let` binding so Closure interop inference holds"))
+  (testing "a QUALIFIED group local keeps its hint through the name-strip"
+    ;; {:keys [^js acct/node]} binds the name-only local `node`, still ^js-tagged
+    (is (= {:tag 'js} (meta (native-local '{:keys [^js acct/node]} 'node)))
+        "host name-strips acct/node → node, keeping the hint")
+    (is (= {:tag 'js} (meta (plan-local   '{:keys [^js acct/node]} 'node)))
+        "the plan name-strips the same way and keeps the hint")
+    (is (= [:acct/node] (:slots (header/parse-header ['{:keys [^js acct/node]}])))
+        "the qualified lookup key is unchanged by metadata preservation"))
+  (testing "unhinted group symbols + explicit locals retain current behavior"
+    (is (nil? (meta (native-local '{:keys [plain]} 'plain))) "host: no meta invented")
+    (is (nil? (meta (plan-local   '{:keys [plain]} 'plain))) "plan: no meta invented")
+    (is (nil? (meta (emit-local ['{:keys [plain]}] 'plain)))  "emit: no meta invented")
+    ;; an explicit {^js ex :e1} local was never rewritten, so it already kept meta
+    (is (= {:tag 'js} (meta (native-local '{^js ex :e1} 'ex)))  "host keeps explicit ^js")
+    (is (= {:tag 'js} (meta (plan-local   '{^js ex :e1} 'ex)))  "plan keeps explicit ^js")))

--- a/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_jvm_test.clj
@@ -238,10 +238,13 @@
           {:keys [locals slot-of]} (emitted [pat])]
       (is (= {'x :ns/x} host)
           "host last-wins binds x <- :ns/x; the explicit :other is dead")
-      (is (= '[x] locals)
-          "x is emitted EXACTLY ONCE — no duplicate read")
+      ;; rf2-nedxb — the EXECUTABLE emission runs every host binding unit, so both
+      ;; the shadowed `:other` read and the winning `:ns/x` read are emitted (host
+      ;; `let` last-wins). Only the DERIVED slots (below) collapse to the winner.
+      (is (= '[x x] locals)
+          "x is emitted for BOTH host units — the later :ns/x is the visible winner")
       (is (= "ns/x" (slot-of 'x))
-          "CLJS reads the host's winning slot \"ns/x\", never dead \"other\"")
+          "CLJS's winning read is the host's slot \"ns/x\", never dead \"other\"")
       (is (= (header/slot-name (host 'x)) (slot-of 'x)))))
   (testing "the collapsed slot is the ONLY declared slot — no dead :other"
     (let [h (header/parse-header '[{:keys [ns/x] x :other}])]
@@ -327,3 +330,127 @@
     ;; an explicit {^js ex :e1} local was never rewritten, so it already kept meta
     (is (= {:tag 'js} (meta (native-local '{^js ex :e1} 'ex)))  "host keeps explicit ^js")
     (is (= {:tag 'js} (meta (plan-local   '{^js ex :e1} 'ex)))  "plan keeps explicit ^js")))
+
+;; ---------------------------------------------------------------------------
+;; rf2-nedxb — executable HOST EVAL SEMANTICS survive header collapse
+;;
+;; Two host-visible losses in the CLJS header lowering (the JVM emitter uses
+;; native destructuring, so it is already faithful):
+;;
+;;   1. A `:or` default is `get`'s third argument — a function arg, so the host
+;;      evaluates it as part of the lookup even when the slot is PRESENT. The old
+;;      `slot-read` only evaluated it when the slot was absent.
+;;   2. A qualified-group/explicit same-local collision (`{:keys [ns/x] x :other}`)
+;;      is TWO host binding units (both name-strip to `x`, host `let` last-wins);
+;;      native evaluates BOTH initializers before the later wins. The collapsed
+;;      projection (comparator/manifest/slots) keeps only the winner, but the
+;;      EXECUTABLE emission must run every host unit.
+;;
+;; The emitter is `.cljc` and runs on the JVM for both hosts. These fixtures
+;; evaluate the REAL emitter output on the JVM, modeling only the two cljs
+;; primitives it uses — `unchecked-get` (absent slot -> a sentinel; present-nil
+;; stays nil) and `undefined?` (tests that sentinel) — and compare effect COUNT,
+;; order, throws and final value against real `clojure.core/destructure`.
+;; ---------------------------------------------------------------------------
+
+(def ^:private UNDEF (Object.))            ; models JS `undefined` for an absent slot
+(defn- uget [m k] (if (contains? m k) (get m k) UNDEF))
+(defn- undef? [x] (identical? x UNDEF))
+(def calls (atom 0))                        ; :or default side-effect counter
+(def marks (atom []))                       ; :or default evaluation-order log
+(defn- mk [tag] (swap! marks conj tag) tag)
+
+(defn- header-locals [binds]
+  (->> binds (partition 2) (map first) (filter symbol?) distinct vec))
+
+(defn- run-native
+  "Evaluate the JVM emitter path — native `let` destructuring of the raw pattern
+  — on keyword-keyed `props`. Returns {local -> final value}; the ground truth."
+  [pat props]
+  (binding [*ns* (find-ns 're-frame.ui.binding-plan-host-faithful-jvm-test)]
+    (let [locals (->> (destructure [pat 'the-map]) (partition 2) (map first)
+                      (remove #(re-find #"^(map__|vec__|seq__|first__|p__|the-map)"
+                                        (name %)))
+                      distinct vec)
+          f (eval `(fn [m#] (let [~pat m#]
+                              ~(into {} (map (fn [s] [(list 'quote s) s])) locals))))]
+      (f props))))
+
+(defn- run-emitted
+  "Evaluate the REAL CLJS `header-bindings` emitter output on the JVM, modeling
+  `unchecked-get`/`undefined?` with faithful JS-object semantics. `props` is
+  keyword-keyed and converted to the slot STRINGS the emitter reads. Returns
+  {local -> final value}; `:or` default side effects run for real."
+  [argv props]
+  (binding [*ns* (find-ns 're-frame.ui.binding-plan-host-faithful-jvm-test)]
+    (let [binds  (vec (emit-cljs/header-bindings (header/parse-header argv)))
+          subbed (walk/postwalk-replace
+                  {'cljs.core/unchecked-get `uget
+                   'cljs.core/undefined?    `undef?}
+                  binds)
+          locals (header-locals binds)
+          strp   (into {} (map (fn [[k v]] [(header/slot-name k) v])) props)
+          f      (eval `(fn [~'rf-ui-props]
+                          (let [~@subbed]
+                            ~(into {} (map (fn [s] [(list 'quote s) s])) locals))))]
+      ;; A final binding left as the sentinel is `js/undefined` on real CLJS,
+      ;; which `nil?`/`=` treat as nil (an absent no-default read) — model that.
+      (into {} (map (fn [[k v]] [k (if (undef? v) nil v)])) (f strp)))))
+
+(deftest or-default-evaluates-once-present-and-absent-like-the-host
+  (let [pat  '{:keys [x] :or {x (swap! calls inc)}}
+        argv [pat]]
+    (testing "native: the :or default is an eager get-arg — evaluated once whether present or absent"
+      (reset! calls 0)
+      (is (= {'x 5} (run-native pat {:x 5})))
+      (is (= 1 @calls) "present -> default STILL evaluated once (get's 3rd arg is eager)")
+      (reset! calls 0)
+      (is (= {'x 1} (run-native pat {})))
+      (is (= 1 @calls) "absent -> default evaluated once, becomes the value"))
+    (testing "emitted CLJS agrees on COUNT and value (present + absent)"
+      (reset! calls 0)
+      (is (= {'x 5} (run-emitted argv {:x 5})))
+      (is (= 1 @calls) "emitted evaluates the default even when the slot is PRESENT, like the host")
+      (reset! calls 0)
+      (is (= {'x 1} (run-emitted argv {})))
+      (is (= 1 @calls))))
+  (testing "a throwing default is evaluated even when the slot is PRESENT (both targets)"
+    (let [pat  '{:keys [x] :or {x (throw (ex-info "boom" {}))}}
+          argv [pat]]
+      (is (thrown? clojure.lang.ExceptionInfo (run-native pat {:x 5}))
+          "native: the eager get-arg throws even though :x is present")
+      (is (thrown? clojure.lang.ExceptionInfo (run-emitted argv {:x 5}))
+          "emitted: host-faithful — the default throws even though :x is present"))))
+
+(deftest shadowed-initializers-all-execute-with-the-later-winning
+  (let [pat  '{:keys [ns/x] x :other :or {x (mk :d)}}
+        argv [pat]]
+    (testing "the split: executable plan keeps BOTH host units; derived slots keep only the winner"
+      (let [h (header/parse-header argv)]
+        (is (= 2 (count (:binding-units h)))
+            "the uncollapsed executable plan carries both host binding units")
+        (is (= [:ns/x] (:slots h))
+            "the collapsed projection keeps only the host-winning slot")
+        (is (= [{:key :ns/x :slot "ns/x" :pattern 'x :default '(mk :d)}] (:entries h))
+            "derived `:entries` remain the single collapsed winner")))
+    (testing "native evaluates BOTH initializers (default per unit); :ns/x wins"
+      (reset! marks [])
+      (is (= {'x 1} (run-native pat {:ns/x 1 :other 2})))
+      (is (= [:d :d] @marks) "two get-calls each evaluate the :or default -> 2, in host order")
+      (reset! marks [])
+      (is (= {'x :d} (run-native pat {})))
+      (is (= [:d :d] @marks) "both defaults evaluated; the winner :ns/x is absent -> its default value"))
+    (testing "emitted CLJS emits both host binding units -> same count, order and winner"
+      (reset! marks [])
+      (is (= {'x 1} (run-emitted argv {:ns/x 1 :other 2})))
+      (is (= [:d :d] @marks)
+          "both shadowed initializers execute — not just the collapsed winner")
+      (reset! marks [])
+      (is (= {'x :d} (run-emitted argv {})))
+      (is (= [:d :d] @marks))))
+  (testing "without a default, the dead :other read still happens but :ns/x is the visible winner"
+    (let [pat '{:keys [ns/x] x :other}]
+      (is (= {'x nil} (run-native  pat {:other 2}))  "native: :other read is shadowed by absent :ns/x")
+      (is (= {'x nil} (run-emitted [pat] {:other 2}))
+          "emitted: same — :ns/x (absent) wins over the shadowed :other read")
+      (is (= {'x 1}   (run-emitted [pat] {:ns/x 1 :other 2})) "present :ns/x wins"))))

--- a/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
@@ -231,6 +231,44 @@
          (expand-error '(re-frame.ui/defview v [{:keys [a] :or {b 1}}] [:div a])))
       ":or keys must match bound slot symbols"))
 
+(deftest qualified-key-ref-props-accepted-in-every-keys-spelling
+  ;; rf2-wix0o — the raw reserved-slot `:keys` arm derived each group key with
+  ;; `(keyword (name s))`, DROPPING a qualified symbol's namespace: the legal
+  ;; `{:keys [acct/key]}` was wrongly rejected as reserved React `:key` and
+  ;; `{:keys [acct/ref]}` as bare `:ref`, while the EQUIVALENT `{:acct/keys …}`
+  ;; and explicit `{p :acct/key}` spellings preserved the namespace and
+  ;; compiled. Raw diagnostics now reuse the canonical group-key transform
+  ;; (`bp/key-group-directive-fn`) — the SAME one the binding plan uses — so
+  ;; every equivalent host spelling derives the same qualified slots, while a
+  ;; genuinely bare `:key`/`:ref` group symbol still fails before collapse.
+  (testing "all equivalent host spellings derive the SAME qualified slots"
+    (let [group  (:slots (header/parse-header '[{:keys [acct/key acct/ref]}]))
+          nsgrp  (:slots (header/parse-header '[{:acct/keys [key ref]}]))
+          explct (:slots (header/parse-header '[{k :acct/key r :acct/ref}]))]
+      (is (= [:acct/key :acct/ref] group)
+          "bare :keys keeps each qualified symbol's namespace, not bare :key/:ref")
+      (is (= group nsgrp)   ":acct/keys spelling derives the same slots")
+      (is (= group explct)  "explicit qualified-lookup spelling derives the same slots")))
+  (testing "the qualified slots match REAL clojure.core/destructure lookup keys"
+    ;; native destructure binds local `key` via `(get m :acct/key)` — ground truth
+    (let [f (eval (list 'fn '[{:keys [acct/key acct/ref]}] '[key ref]))]
+      (is (= [1 2] (f {:acct/key 1 :acct/ref 2}))
+          "native destructure reads the QUALIFIED slots into locals key/ref")))
+  (testing "all three spellings COMPILE as real defviews (not emitter-form inspection)"
+    (is (nil? (expand-error '(re-frame.ui/defview v [{:keys [acct/key acct/ref]}] [:div "x"])))
+        "the bare :keys spelling with qualified symbols compiles")
+    (is (nil? (expand-error '(re-frame.ui/defview v [{:acct/keys [key ref]}] [:div "x"])))
+        "the :acct/keys spelling compiles")
+    (is (nil? (expand-error '(re-frame.ui/defview v [{k :acct/key r :acct/ref}] [:div "x"])))
+        "the explicit qualified-lookup spelling compiles"))
+  (testing "genuinely BARE :key / :ref group symbols stay rejected before collapse"
+    (is (= :rf.ui.compile/key-prop-declared
+           (expand-error '(re-frame.ui/defview v [{:keys [key]}] [:div "x"])))
+        "a bare `:keys [key]` still feeds the reserved React key slot")
+    (is (= :rf.ui.compile/ref-prop-declared-s1
+           (expand-error '(re-frame.ui/defview v [{:keys [ref]}] [:div "x"])))
+        "a bare `:keys [ref]` is still the S3 forwarding spelling — rejected at S1")))
+
 (deftest q3-slot-encoding-table
   ;; the encode function E — the props-ABI freeze's normative core
   (is (= "product"    (header/slot-name :product)))


### PR DESCRIPTION
## Summary

A false-green family in the `defview` binding-plan lowering: literal-value fixtures passed while native `clojure.core/destructure` semantics diverged. Three host-faithfulness fixes on the coupled compiler lane, each proved against real `clojure.core/destructure` (not literal values).

### rf2-wix0o — accept qualified key/ref props in every `:keys` spelling
The raw reserved-slot validation's bare `:keys` arm derived each group key with `(keyword (name s))`, **dropping a qualified symbol's namespace** — legal `{:keys [acct/key]}` was rejected as reserved React `:key` and `{:keys [acct/ref]}` as bare `:ref`, while the equivalent `{:acct/keys [key]}` / `{p :acct/key}` spellings compiled. Fixed by deriving the group key with the canonical `bp/key-group-directive-fn` (the transform the binding plan already uses), so equivalent host spellings agree while genuinely bare `:key`/`:ref` still fail.
Seam: `header.cljc` `validate-header-map!` `:keys` arm.

### rf2-gvuoo — preserve group-symbol metadata through the canonical plan
`assoc-binding-units` reconstructed a group local with `(symbol (name bb))`, discarding authored symbol metadata. Native `clojure.core/destructure` preserves it via `(with-meta (symbol nil (name bb)) (meta bb))`; the canonical plan and the emitted CLJS `let` binding dropped it — losing `^js`/portable type hints changes Closure interop inference, warnings and advanced codegen. Fixed by reconstructing with `with-meta`, carrying only the host's existing metadata (nothing invented).
Seam: `binding_plan.cljc` `assoc-binding-units` group-local reconstruction.

### rf2-nedxb — preserve executable host semantics when header entries collapse
Two host-visible eval-semantics losses in the CLJS lowering (the JVM emitter uses native destructuring, already faithful):
1. `slot-read` evaluated an `:or` default only when the slot was absent, but native lowers a defaulted slot to `(get props :slot default)` — `get`'s third arg is eager, so the default evaluates even when the slot is PRESENT. Now `d#` is evaluated once unconditionally, selected only on absence.
2. `collapse-entries` correctly folds a qualified-group-name collision (`{:keys [ns/x] x :other}`) for DERIVED slots, but the CLJS emission consumed only that winner — native evaluates BOTH host initializers before the later wins. `parse-header` now exposes `:binding-units` (the FULL host plan) for executable emission + the analyzer scope walk, while `:entries`/`:slots` stay collapsed for the comparator/manifest/schema; `header-bindings` consumes `:binding-units`.
Seams: `emit_cljs.cljc` `slot-read` + `header-bindings`; `header.cljc` `parse-header` split.

## Host-faithfulness proofs (not literal values)
- **wix0o** (`defview-grammar-jvm-test`): all three spellings derive `[:acct/key :acct/ref]` and compile as real defviews; native destructure reads the same qualified slots; bare `:key`/`:ref` retain their typed diagnostics.
- **gvuoo** (`binding-plan-host-faithful-jvm-test`): a `^js` hint survives on the plan's `:local-pattern` AND the emitted CLJS binding, compared DIRECTLY against native metadata (symbol equality ignores metadata, so a `(symbol (name …))` regression fails).
- **nedxb** (`binding-plan-host-faithful-jvm-test`): the REAL emitter output is evaluated on the JVM (modeling only `unchecked-get`/`undefined?`) and compared against native `clojure.core/destructure` on eval COUNT, order, throws and final value — present slots still evaluate their default once, a throwing default throws even when present, and both shadowed initializers run with the later `:ns/x` winning. The existing `[x]`-emit-once assertion (which pinned the old host-infaithful behavior) is corrected to `[x x]`.

## Quality gates
- `implementation/ui` JVM (`clojure -M:test`): **758 tests / 13953 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (real CLJS emission path): **9850 tests / 48463 assertions, 0 failures, 0 errors**
- `npm run test:elision`: **PASS** — production 60/60 absent, control 60/60 present (emit changes leave production clean)
- Per-bead red-before / green-after proving host-faithfulness (qualified `:keys` / metadata / eval count+order), not literal values.
- No touch to `events.cljs`, `frames.cljc`, `tooling.cljc`, or the `.95.10` hot-zones; changes confined to `header.cljc`, `binding_plan.cljc`, `emit_cljs.cljc` + the two JVM test files.
