### PR TITLE
fix(router): carry capture-frame incarnation authority through target consumption (rf2-dlld6)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1232,7 +1232,20 @@
   (if (capture-target-superseded? frame-target captured-incarnation)
     (router/emit-captured-frame-superseded!
       event (frame/frame-target->id frame-target) opts)
-    (dispatch-fn event opts)))
+    ;; rf2-dlld6: the `capture-target-superseded?` pre-check above and the
+    ;; ordinary address-directed dispatch below are SEPARATE operations. On the
+    ;; concurrent JVM host frame A can be destroyed AND a same-id successor B
+    ;; installed in the window between them, so a capture that just validated A
+    ;; would enqueue into B — a bare-id resolve, violating the exact-incarnation
+    ;; promise. Carry the EXACT captured incarnation through as
+    ;; `:rf.frame/expected-incarnation` so `dispatch!` / `dispatch-sync!`
+    ;; validate it against the SAME record they resolve for enqueue (one
+    ;; exact-incarnation operation) and recover-but-emit rather than leak into B.
+    ;; nil `captured-incarnation` (an unpinned capture made while its target was
+    ;; ABSENT) carries nothing and stays deliberately address-directed.
+    (dispatch-fn event (cond-> opts
+                         (some? captured-incarnation)
+                         (assoc :rf.frame/expected-incarnation captured-incarnation)))))
 
 (defn- capture-subscribe!
   "Route a captured `:subscribe` op through the SAME incarnation fence as
@@ -1319,13 +1332,22 @@
      ;; caching a reaction in B's sub-cache); it recover-but-emits and returns nil.
      (fn subscribe-fn
        [query-v]
-       (capture-subscribe!
-         (fn []
-           (if (and subscribe-call-site interop/debug-enabled?)
-             (trace/with-call-site subscribe-call-site
-               (subscribe-impl query-v {:frame frame}))
-             (subscribe-impl query-v {:frame frame})))
-         frame captured-incarnation query-v subscribe-call-site))}))
+       ;; rf2-dlld6: carry the EXACT captured incarnation into the read so
+       ;; `subscribe-in-frame` validates it against the SAME record it resolves
+       ;; from the sub-cache (one exact-incarnation operation) — closing the
+       ;; identical check-then-use window the dispatch arm has: a same-id
+       ;; successor B installed between the `capture-subscribe!` pre-check and
+       ;; the resolve cannot be read (nor a reaction cached in B's sub-cache).
+       (let [sub-opts (cond-> {:frame frame}
+                        (some? captured-incarnation)
+                        (assoc :rf.frame/expected-incarnation captured-incarnation))]
+         (capture-subscribe!
+           (fn []
+             (if (and subscribe-call-site interop/debug-enabled?)
+               (trace/with-call-site subscribe-call-site
+                 (subscribe-impl query-v sub-opts))
+               (subscribe-impl query-v sub-opts)))
+           frame captured-incarnation query-v subscribe-call-site)))}))
 
 (defn capture-frame
   "Return a frame api — the keystone affordance for

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -380,7 +380,15 @@
         ;; the dispatched trace under `:rf.frame/init-step-index`
         ;; (`emit-dispatched-trace`). It is a debug/trace provenance lever, not a
         ;; correctness one — the trace stamp itself is debug-gated there.
-        step-index         (:step-index opts)]
+        step-index         (:step-index opts)
+        ;; rf2-dlld6: the EXACT incarnation a `capture-frame` op pinned at
+        ;; capture (its `:drain-lock`), threaded by
+        ;; `re-frame.core/capture-dispatch!`. A CORRECTNESS lever (it gates
+        ;; whether the enqueue may target the resolved incarnation), so it rides
+        ;; the envelope unconditionally when present — like `:rf.machine/internal?`
+        ;; — never a debug diagnostic. nil for every ordinary / address-directed
+        ;; dispatch; the key is then omitted so the hot path stays lean.
+        expected-incarnation (:rf.frame/expected-incarnation opts)]
     (when (trace/continuation-live?)
       (cond-> {:event                  event
              :frame                  frame
@@ -439,7 +447,11 @@
       ;; envelope only when present (frame-init dispatches), so
       ;; `emit-dispatched-trace` can stamp it on the dispatched trace as the
       ;; second half of the EP-0027 §Provenance contract.
-      step-index         (assoc :step-index step-index))))))
+      step-index         (assoc :step-index step-index)
+      ;; rf2-dlld6: carry the captured incarnation token onto the envelope only
+      ;; when a `capture-frame` op supplied it, so `dispatch!` / `dispatch-sync!`
+      ;; can fence the enqueue to the EXACT incarnation the resolve returns.
+      expected-incarnation (assoc :rf.frame/expected-incarnation expected-incarnation))))))
 
 (defn- resolve-handler [event-id]
   (registrar/lookup :event event-id))
@@ -2087,9 +2099,20 @@
 
   `opts` carries the dev-only `:rf.trace/call-site` (the capture's dispatch coord),
   bound around the emit so the trace attributes the drop to the dispatch site.
-  Called from `make-capture-frame`'s incarnation-fenced dispatch / dispatch-sync
-  ops; the bare-id `frame-destroyed` emit `dispatch!` / `dispatch-sync!` already
-  raise for a fully-unclaimed id is unchanged (an unpinned 1-arity capture stays
+  Called UNIFORMLY from `make-capture-frame`'s incarnation-fenced `:dispatch`,
+  `:dispatch-sync` (rf2-9pyles) AND `:subscribe` (rf2-tdjv7p, #6084) ops when the
+  synchronous `capture-target-superseded?` pre-check already sees the pin gone;
+  a superseded `:subscribe` additionally returns nil rather than a reaction.
+
+  rf2-dlld6 closes the concurrent-JVM window BETWEEN that pre-check and the
+  ordinary bare-id target consumption: `capture-dispatch!` / the `:subscribe`
+  thunk carry the pinned incarnation through as `:rf.frame/expected-incarnation`,
+  so `dispatch!` / `dispatch-sync!` (and `subscribe-in-frame`) validate it
+  against the SAME record they resolve for enqueue/read and emit the SAME
+  production-survivable `:rf.error/frame-destroyed` exactly once — never a
+  liveness-check-to-bare-id-use window, never a leak into a same-id successor.
+  The bare-id `frame-destroyed` emit `dispatch!` / `dispatch-sync!` already raise
+  for a fully-unclaimed id is unchanged (an unpinned 1-arity capture stays
   address-directed)."
   [event frame-id opts]
   (trace/with-call-site (when interop/debug-enabled? (:rf.trace/call-site opts))
@@ -3810,6 +3833,11 @@
              frame-id       (:frame envelope)
              frame-record   (when (owner-live?) (frame/frame frame-id))
              target-token   (:drain-lock frame-record)
+             ;; rf2-dlld6: the EXACT incarnation a `capture-frame` op pinned at
+             ;; capture (its `:drain-lock`), carried onto the envelope by
+             ;; `build-envelope`. nil for every ordinary / address-directed
+             ;; dispatch — the fence below is inert then.
+             expected-incarnation (:rf.frame/expected-incarnation envelope)
              target-live?   #(and (owner-live?)
                                   (frame/frame-incarnation-live?
                                     frame-id target-token))
@@ -3827,6 +3855,21 @@
        ;; `emit-frame-destroyed!` carries it; the always-on record reads
        ;; its coords off the parallel error-coord registry, not the
        ;; dynamic call-site.
+       (trace/with-call-site (:call-site envelope)
+         (emit-frame-destroyed! (first event) event (:frame envelope)))
+
+       ;; rf2-dlld6: a captured op pinned to incarnation A resolved a same-id
+       ;; successor B here — A was destroyed and B installed in the window
+       ;; between `capture-frame`'s liveness pre-check and this bare-id resolve.
+       ;; `target-token` is B's `:drain-lock`, read off the SAME record we would
+       ;; enqueue into, so this mismatch IS the exact-incarnation check fused
+       ;; with target consumption (no second liveness-check-to-bare-id-use
+       ;; window). Recover-but-emit `:rf.error/frame-destroyed` and enqueue
+       ;; NOTHING — A's authority never leaks into B. Identical recover-but-emit
+       ;; to the nil-record clause above; the address-directed path (nil
+       ;; `expected-incarnation`) is untouched.
+       (and (some? expected-incarnation)
+            (not (identical? expected-incarnation target-token)))
        (trace/with-call-site (:call-site envelope)
          (emit-frame-destroyed! (first event) event (:frame envelope)))
 
@@ -3895,6 +3938,11 @@
          ;; build-envelope) so the synchronous error emits below can
          ;; carry it without referencing the keyword a second time.
          call-site    (:call-site envelope)
+         ;; rf2-dlld6: the EXACT incarnation a `capture-frame` op pinned at
+         ;; capture (its `:drain-lock`), carried onto the envelope by
+         ;; `build-envelope`. nil for every ordinary / address-directed
+         ;; dispatch-sync — the fence below is inert then.
+         expected-incarnation (:rf.frame/expected-incarnation envelope)
          ;; Nested-sync detection, hoisted out of the cond TEST position so
          ;; the cond reads as flat test→result pairs. True when this call is
          ;; reentering the SAME frame's running drain — either an explicit
@@ -3946,6 +3994,20 @@
        ;; destroyed / unknown frame RECOVERS (no-op) AND emits the
        ;; production-survivable `:rf.error/frame-destroyed` through the
        ;; always-on listener.
+       (trace/with-call-site call-site
+         (emit-frame-destroyed! (first event) event (:frame envelope)))
+
+       ;; rf2-dlld6: a captured op pinned to incarnation A resolved a same-id
+       ;; successor B here — A destroyed + B installed between `capture-frame`'s
+       ;; liveness pre-check and this bare-id resolve. `target-token` is B's
+       ;; `:drain-lock`, read off the SAME record we would seed the drain from,
+       ;; so this mismatch fuses the exact-incarnation check with target
+       ;; consumption (no liveness-check-to-bare-id-use window). Recover-but-emit
+       ;; and process NOTHING, so A's authority never leaks into B. Placed before
+       ;; the `nested-sync?` / drain clauses so a superseded capture never enters
+       ;; B's drain. Address-directed dispatch-sync (nil expected) is untouched.
+       (and (some? expected-incarnation)
+            (not (identical? expected-incarnation target-token)))
        (trace/with-call-site call-site
          (emit-frame-destroyed! (first event) event (:frame envelope)))
 

--- a/implementation/core/src/re_frame/router/diagnostics.cljc
+++ b/implementation/core/src/re_frame/router/diagnostics.cljc
@@ -130,10 +130,19 @@
                             `frame.cljc`'s `run-setup-events!` onto each
                             `:initial-events` dispatch (EP-0027); read by
                             `build-envelope` and carried onto the dispatched
-                            trace as `:rf.frame/init-step-index`"
+                            trace as `:rf.frame/init-step-index`
+    :rf.frame/expected-incarnation
+                            rf2-dlld6 — the EXACT incarnation token
+                            (`:drain-lock`) a `capture-frame` op pinned at
+                            capture, threaded by `re-frame.core/capture-dispatch!`.
+                            `build-envelope` reads it and carries it onto the
+                            envelope so `dispatch!` / `dispatch-sync!` refuse to
+                            enqueue into a same-id successor resolved after the
+                            capture's liveness pre-check. INTERNAL (reserved
+                            `:rf.frame/` namespace) — not an app-facing opt."
   #{:frame :fx-overrides :interceptor-overrides :trace-id :source
     :source-detail :origin :rf.cofx :rf.cofx/mint-policy :rf.trace/call-site
-    :rf.machine/internal? :step-index})
+    :rf.machine/internal? :step-index :rf.frame/expected-incarnation})
 
 (def ^:const retired-draft-opt-hints
   "Dispatch-opt keys that named a fact only ever spelled in the spec's own

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -1347,8 +1347,20 @@
   `interop/debug-enabled?` so it DCEs in production, and the override
   feeds ONLY the derefed reaction the view sees — never app-db, never
   `compute-sub` — so `:rf.assert/sub-equals` stays unsatisfiable by an
-  override."
-  [target query-v]
+  override.
+
+  `expected-incarnation` (rf2-dlld6, 3-arity) is the EXACT incarnation token a
+  `capture-frame` `:subscribe` op pinned at capture. When non-nil the read is
+  FENCED to that incarnation: a same-id successor resolved here (the capture's
+  frame was destroyed and a successor reseated under the id after the capture's
+  liveness pre-check) recover-but-emits `:rf.error/frame-destroyed` and returns
+  nil rather than reading the successor's app-db or caching a reaction in its
+  sub-cache. The token is compared against the SAME record resolved for the read
+  (`:drain-lock`), so validation and consumption are one exact-incarnation
+  operation. nil `expected-incarnation` — the ambient / explicit address-directed
+  read, and every layer-2+ recursive input resolution — is unfenced."
+  ([target query-v] (subscribe-in-frame target query-v nil))
+  ([target query-v expected-incarnation]
    (let [frame-id (frame/frame-target->id target)]
    ;; (CLJS, dev-only): record the view→sub edge — push this
    ;; query-v into the in-flight render's deref sink so `:rf.view/rendered`
@@ -1442,7 +1454,20 @@
          ;; static-require `re-frame.error-emit` — load cycle). The
          ;; `:frame`-stampable record carries `frame-id` + the attempted
          ;; `query-v` (as `:event`) for frame + shipper attribution.
-         (nil? frame-record)
+         ;;
+         ;; rf2-dlld6: the SAME recover-but-emit also covers a superseded
+         ;; captured read — `frame-record` resolved a same-id successor B whose
+         ;; `:drain-lock` differs from the `expected-incarnation` a
+         ;; `capture-frame` op pinned (A destroyed + B installed after the
+         ;; capture's liveness pre-check). The token is compared against the
+         ;; record we just resolved for the read, so a stale capture can neither
+         ;; read B's app-db nor cache a reaction in B's sub-cache. A nil
+         ;; `expected-incarnation` (ambient / address-directed / layer-2+ input)
+         ;; leaves the clause a pure `(nil? frame-record)` test.
+         (or (nil? frame-record)
+             (and (some? expected-incarnation)
+                  (not (identical? expected-incarnation
+                                   (:drain-lock frame-record)))))
          (do
            ;; Both channels via the shared helper: axis 1 the
            ;; always-on listener (survives prod elision), axis 2 the dev trace
@@ -1493,7 +1518,7 @@
                (if (identical? reaction (get-in new [k :reaction]))
                  reaction
                  (compute-and-cache! frame-id query-v)))
-             (compute-and-cache! frame-id query-v)))))))))) ;; close fn + call-with-frame-resolution + normalize-target let + subscribe-in-frame
+             (compute-and-cache! frame-id query-v))))))))))) ;; close fn + call-with-frame-resolution + normalize-target let + 3-arity + subscribe-in-frame
 
 (defn subscribe
   "Per Spec 006 §Lookup algorithm. Returns the reaction for query-v;
@@ -1557,8 +1582,13 @@
    ;; reach. `opts` may carry `{:frame target}` (a frame-id keyword or a live
    ;; frame value) — the explicit OVERRIDE intent; ambient (the carried
    ;; scope/hold stamp) when absent.
+   ;;
+   ;; rf2-dlld6: `:rf.frame/expected-incarnation` (a `capture-frame`
+   ;; `:subscribe` op's pinned token — INTERNAL, reserved `:rf.frame/` ns)
+   ;; rides alongside `:frame` so the read is fenced to the exact captured
+   ;; incarnation. nil for every ordinary explicit-frame read.
    (if-some [target (:frame opts)]
-     (subscribe-in-frame target query-v)
+     (subscribe-in-frame target query-v (:rf.frame/expected-incarnation opts))
      (subscribe query-v))))
 
 (defn- subscribe-once-in-frame

--- a/implementation/core/test/re_frame/capture_frame_test.clj
+++ b/implementation/core/test/re_frame/capture_frame_test.clj
@@ -182,6 +182,115 @@
           (is (some #(= :rf.error/frame-destroyed (:operation %)) @errs)
               "the superseded value-capture dispatch recover-but-emits :rf.error/frame-destroyed"))))))
 
+;; ---- rf2-dlld6: carry the captured incarnation THROUGH target consumption ---
+;;
+;; rf2-9pyles/tdjv7p/vclh63 (above) pinned the exact incarnation and had
+;; `capture-target-superseded?` VALIDATE it — but that check and the ordinary
+;; address-directed dispatch/subscribe it then delegated to were SEPARATE
+;; operations. On the concurrent JVM host frame A can be destroyed AND a same-id
+;; successor B installed in the window between the check returning "A live" and
+;; the ordinary implementation resolving the bare id — so a check-passing stale
+;; capture leaked into B (`{:successor-db {:owner :B :marked-by :stale-capture}}`
+;; in the reproduction). The fix carries the captured incarnation through into
+;; the router/sub resolve so validation and target consumption are ONE
+;; exact-incarnation operation.
+;;
+;; These fixtures interpose ONE-SHOT on `frame/frame-incarnation-live?` — the
+;; predicate `capture-target-superseded?` consults — and, at the moment the
+;; pre-check validates incarnation A as live, destroy A and reseat a same-id
+;; successor B BEFORE returning A's (true) liveness. That is exactly the JVM
+;; interleaving: the stale capture validated A, another actor swapped A for B,
+;; then the op resumed and resolved the bare id → B. Deterministic + single-
+;; threaded (the swap runs inside the interposed call), so no latch is needed.
+
+(defn- run-supersede-during-precheck
+  "Run `op` with a ONE-SHOT interposition on `frame/frame-incarnation-live?`:
+  when the capture's pre-check validates incarnation `a-token` of `frame-id` as
+  live, destroy A and reseat a fresh same-id successor B BEFORE handing back A's
+  (true) liveness — reproducing the destroy-A/create-B window between
+  `capture-frame`'s liveness pre-check and the ordinary bare-id target resolve.
+  The interposition fires exactly once (the pre-check); every later call —
+  including the destroy/create machinery's own — delegates to the real fn."
+  [frame-id a-token op]
+  (let [real  frame/frame-incarnation-live?
+        fired (atom false)]
+    (with-redefs [frame/frame-incarnation-live?
+                  (fn [id token]
+                    (let [live? (real id token)]
+                      (when (and (not @fired)
+                                 (= id frame-id)
+                                 (identical? token a-token)
+                                 live?)
+                        (reset! fired true)     ;; set BEFORE the swap so the
+                        ;; destroy/create's own liveness reads take the real path
+                        (rf/destroy-frame! frame-id)
+                        (rf/make-frame {:id frame-id :doc "incarnation B (successor)"}))
+                      live?))]
+      (op))))
+
+(deftest stale-capture-dispatch-sync-does-not-retarget-same-id-successor
+  (testing "rf2-dlld6 (dispatch-sync arm) — a capture whose pre-check validated
+            incarnation A, superseded by same-id B before the bare-id resolve,
+            MUST NOT dispatch-sync into B. It recover-but-emits
+            :rf.error/frame-destroyed and leaves B byte-for-byte unchanged."
+    (rf/reg-event :fh/mark (fn [{:keys [db]} _] {:db (assoc db :marked-by :stale-capture)}))
+    (rf/make-frame {:id :fh/race :doc "incarnation A"})
+    (let [a-token (frame/frame-incarnation-token :fh/race)
+          {:keys [dispatch-sync]} (rf/capture-frame :fh/race) ;; pins A
+          errs    (atom [])]
+      (rf/register-listener! :trace ::race (fn [ev] (swap! errs conj ev)))
+      (run-supersede-during-precheck
+        :fh/race a-token #(dispatch-sync [:fh/mark]))
+      (rf/unregister-listener! :trace ::race)
+      (is (nil? (:marked-by (rf/app-db-value :fh/race)))
+          "the stale capture did NOT mutate same-id successor B")
+      (is (some #(= :rf.error/frame-destroyed (:operation %)) @errs)
+          "the superseded dispatch-sync recover-but-emits :rf.error/frame-destroyed"))))
+
+(deftest stale-capture-async-dispatch-does-not-enqueue-into-same-id-successor
+  (testing "rf2-dlld6 (async dispatch arm) — a superseded capture's async
+            dispatch enqueues NOTHING into same-id successor B; it recover-but-
+            emits and B stays byte-for-byte unchanged."
+    (rf/reg-event :fh/mark (fn [{:keys [db]} _] {:db (assoc db :marked-by :stale-capture)}))
+    (rf/make-frame {:id :fh/race :doc "incarnation A"})
+    (let [a-token (frame/frame-incarnation-token :fh/race)
+          {:keys [dispatch]} (rf/capture-frame :fh/race) ;; pins A
+          errs    (atom [])]
+      (rf/register-listener! :trace ::race (fn [ev] (swap! errs conj ev)))
+      (run-supersede-during-precheck
+        :fh/race a-token #(dispatch [:fh/mark]))
+      ;; The fence short-circuits BEFORE enqueue/schedule, so nothing can drain
+      ;; into B; poll to confirm the emit lands rather than asserting a single
+      ;; instant.
+      (test-support/poll-until (fn [] (some (fn [ev] (= :rf.error/frame-destroyed (:operation ev))) @errs))
+                               {:label "async fence emits frame-destroyed"})
+      (rf/unregister-listener! :trace ::race)
+      (is (nil? (:marked-by (rf/app-db-value :fh/race)))
+          "the stale async dispatch enqueued nothing into successor B")
+      (is (some #(= :rf.error/frame-destroyed (:operation %)) @errs)
+          "the superseded async dispatch recover-but-emits :rf.error/frame-destroyed"))))
+
+(deftest stale-capture-subscribe-race-does-not-read-or-cache-in-same-id-successor
+  (testing "rf2-dlld6 (subscribe arm) — a capture whose pre-check validated A,
+            superseded by same-id B before the sub-cache resolve, neither reads
+            B's app-db nor installs a reaction/cache entry in B; it returns nil
+            and recover-but-emits."
+    (rf/reg-sub :fh/value (fn [db _] (:value db)))
+    (rf/make-frame {:id :fh/race :doc "incarnation A"})
+    (let [a-token (frame/frame-incarnation-token :fh/race)
+          {:keys [subscribe]} (rf/capture-frame :fh/race) ;; pins A
+          errs    (atom [])
+          result  (do (rf/register-listener! :trace ::race (fn [ev] (swap! errs conj ev)))
+                      (run-supersede-during-precheck
+                        :fh/race a-token #(subscribe [:fh/value])))]
+      (rf/unregister-listener! :trace ::race)
+      (is (nil? result)
+          "the superseded subscribe returns nil — it did NOT resolve a reaction into B")
+      (is (empty? @(:sub-cache (frame/frame :fh/race)))
+          "no reaction/cache entry was installed in same-id successor B's sub-cache")
+      (is (some #(= :rf.error/frame-destroyed (:operation %)) @errs)
+          "the superseded subscribe recover-but-emits :rf.error/frame-destroyed"))))
+
 ;; ---- contract: (capture-frame) outside any scope RAISES (EP-0002) ---------
 ;;
 ;; rf2-jue6sp: the no-arg capture form captures ONLY when a real scope

--- a/implementation/core/test/re_frame/unknown_dispatch_opts_warn_test.clj
+++ b/implementation/core/test/re_frame/unknown_dispatch_opts_warn_test.clj
@@ -163,7 +163,12 @@
     ;; (The `:realm` opt was removed under the realm-substrate collapse —
     ;; rf2-9w37t2 / rf2-afdlyr — every dispatch is the single default realm,
     ;; so build-envelope no longer reads a realm dimension.)
+    ;; `:rf.frame/expected-incarnation` (rf2-dlld6) is the INTERNAL captured-
+    ;; incarnation token a `capture-frame` op threads through; build-envelope
+    ;; reads it and carries it onto the envelope so `dispatch!` / `dispatch-sync!`
+    ;; fence the enqueue to the exact captured incarnation.
     (is (= #{:frame :fx-overrides :interceptor-overrides :trace-id :source
              :source-detail :origin :rf.cofx :rf.cofx/mint-policy
-             :rf.trace/call-site :rf.machine/internal? :step-index}
+             :rf.trace/call-site :rf.machine/internal? :step-index
+             :rf.frame/expected-incarnation}
            diag/known-dispatch-opts))))

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -470,15 +470,23 @@ close this window; either is individually sufficient for its axis, and together 
 2. **Incarnation-keyed frame-capture fence.** A frame api (`capture-frame`, and the `reg-view`
    render-time injection) captured against a **live** frame pins that frame's exact incarnation (its
    `:drain-lock`, per [002 §capture-frame](002-Frames.md)). If the captured incarnation is later
-   destroyed — the id unclaimed, **or** a same-id successor incarnation reseated under it — a dispatch
-   through the stale api RECOVERS (the event is never enqueued into the successor) and emits the
-   production-survivable `:rf.error/frame-destroyed`, exactly as a dispatch into a destroyed frame
-   does. This is the async-safe, recover-but-emit sibling of the synchronous **throwing** incarnation
-   fence the `(frame)` accessor bundle already applies; it is the last-line guard for a predecessor
-   cleanup — including a throwing-host quarantine React later self-completes — that fires after both
-   the successor adapter and a same-id successor frame are live. A capture whose id was **not** live
-   at capture (the `capture-frame` 1-arity lock-to-id form used from outside any scope) pins nothing
-   and stays address-directed.
+   destroyed — the id unclaimed, **or** a same-id successor incarnation reseated under it — **every**
+   op the stale api exposes behaves uniformly: `:dispatch` and `:dispatch-sync` RECOVER (the event is
+   never enqueued into the successor), and `:subscribe` RECOVERS by reading nothing and returning
+   **nil** (it never resolves a reaction against the successor's app-db nor caches an entry in the
+   successor's sub-cache). Each emits the production-survivable `:rf.error/frame-destroyed`
+   **exactly once**, exactly as an op into a destroyed frame does. The captured incarnation is carried
+   through into target selection / enqueue / read, so validation and target consumption are **one
+   exact-incarnation operation** — the pinned token is compared against the same record the router / sub
+   resolves for the enqueue or read. There is therefore **no liveness-check-to-bare-id-use window**: on
+   the concurrent JVM host, an actor that destroys the captured incarnation and reseats a same-id
+   successor between the capture's liveness pre-check and its ordinary address-directed consumption can
+   never redirect the stale op into that successor (rf2-dlld6). This is the async-safe, recover-but-emit
+   sibling of the synchronous **throwing** incarnation fence the `(frame)` accessor bundle already
+   applies; it is the last-line guard for a predecessor cleanup — including a throwing-host quarantine
+   React later self-completes — that fires after both the successor adapter and a same-id successor
+   frame are live. A capture whose id was **not** live at capture (the `capture-frame` 1-arity
+   lock-to-id form used from outside any scope) pins nothing and stays address-directed.
 
 This is consistent with **"Disposal is total"** and **"no state survives"** (the adapter-revertibility
 contract above): the surviving `:tearing-down` claim is a **host-ownership quarantine** tracking a


### PR DESCRIPTION
## Summary

`capture-frame` checked its pinned incarnation in `capture-target-superseded?`, then delegated to the ordinary address-directed dispatch/subscribe implementation. On the supported concurrent JVM host those are **separate** operations: frame A can be destroyed and a same-id successor B installed **after** the check returns "A live" but **before** the ordinary implementation resolves the bare id. The stale capture then targeted B, violating the exact-incarnation promise. Router target-local locking begins only *after* the ordinary resolve, so it could not recover the lost authority. The subscribe/value repair (#6084) and async dispatch shared the same check-then-use shape.

This carries the **exact captured incarnation** (`:drain-lock`) through into target selection/enqueue/read so validation and target consumption are **one exact-incarnation operation** across all three arms.

## The fix

- **`capture-dispatch!`** (core) and the **`:subscribe`** thunk thread the pinned token as the internal `:rf.frame/expected-incarnation` opt (reserved `:rf.frame/` ns; `nil` for an unpinned capture made while the target was absent — that stays deliberately address-directed).
- **`build-envelope`** carries it onto the envelope (same treatment as `:rf.machine/internal?` / `:step-index`). **`dispatch!` / `dispatch-sync!`** compare it against `target-token` — the `:drain-lock` read off the **same record** they would enqueue into — and recover-but-emit `:rf.error/frame-destroyed` on a mismatch, before entering B's drain.
- **`subscribe-in-frame`**'s new 3-arity folds the same compare into its nil-record clause: a superseded read returns `nil` and installs no reaction/cache entry in B's sub-cache.

Reuses the merged fence-family mechanism (exact `:drain-lock` identity comparison against the resolved record; `nil` falls back to the historical bare-id path). **No** new error-id, **no** public token, **no** global locking, **no** `frame.cljc` change, **no** router redesign. `known-dispatch-opts` gains the internal key (drift-guard test updated). Contract reconciled in Spec 006 §Successor-generation settlement fence and the `emit-captured-frame-superseded!` docstring (uniform dispatch/dispatch-sync/subscribe, `nil` subscribe return, exactly-once emission, exact-incarnation consumption).

## Reproduction (red-before / green-after)

A deterministic one-shot interposition around `frame-incarnation-live?` destroys A and reseats a same-id successor B **during** the capture's liveness pre-check — exactly the JVM interleaving. Before the fix all three arms leak into B:

- dispatch-sync writes `:marked-by :stale-capture` into B,
- async dispatch enqueues into B (poll times out with no recover-emit),
- subscribe caches a reaction reading B in B's sub-cache.

After the fix each recover-but-emits `:rf.error/frame-destroyed` exactly once and B stays byte-for-byte unchanged; the capture-while-absent address-directed behaviour is preserved.

## Quality gates

- **Core JVM** (`clojure -M:test`): **2046 tests, 9647 assertions, 0 failures, 0 errors**.
- **CLJS** (`npm run test:cljs`): **9852 tests, 48465 assertions, 0 failures, 0 errors**.
- New JVM adversarial tests for all three arms in `capture_frame_test.clj`; `unknown-dispatch-opts-warn-test` drift-guard updated for the new internal opt.

Not run (per brief): `test:browser`, full spine.
