### PR TITLE
refactor(machines): finish exact-attempt vocabulary beyond the auth-helper cleanup (rf2-zeeyk)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -381,7 +381,7 @@
   cancellation and atomically closes the attempt by adding its logical child
   id to the live join state's private `:cancelled` set BEFORE exit callbacks,
   snapshot removal, or the terminal destroyed trace. Consequently an already
-  queued/delayed exact-auth completion observes a closed attempt and cannot
+  queued/delayed exact-attempt completion observes a closed attempt and cannot
   fold a contradictory terminal. A new join attempt seeds a new join-state, so
   no tombstone crosses re-entry.
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
@@ -612,7 +612,7 @@
 ;; public shape) PLUS the additive `:rf.reply/*` reply-envelope facts. This is a
 ;; PROJECTION table (op + stale-reason -> row): the ordered exact-attempt
 ;; classification itself is proven producer-backed in the machines suite
-;; (`join_exact_auth_cljs_test`) and, for the Xray arc, in
+;; (`join_exact_attempt_cljs_test`) and, for the Xray arc, in
 ;; `machine_work_identity_cljs_test`'s
 ;; `post-resolution-superseded-straggler-is-stale-completion-not-late`.
 ;;


### PR DESCRIPTION
Finishes the two residual `exact_auth` -> `exact_attempt` abbreviation sites that the narrow rf2-mlk4e auth-helper cleanup left, per rf2-zeeyk. Both are comment/docstring text only.

## What changed

- **`implementation/machines/.../lifecycle_fx/destroy.cljc:384`** — the `prepare-join-child-teardown!` docstring called a queued/delayed completion an **"exact-auth completion"**. That labels the exact-attempt fold fence (the replayable correlation-record mechanism) with stale authentication framing. Renamed to **"exact-attempt completion"**, matching the runtime `:attempt-*` keyword family and the exact-attempt naming mlk4e established.
- **`tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc:615`** — a prose comment still pointed at the pre-rename machines suite **`join_exact_auth_cljs_test`**; updated to the current **`join_exact_attempt_cljs_test`** (mlk4e renamed the file; the xray tree was blocked until rf2-16y3x merged).

## Scope / what was deliberately NOT swept

Narrow terminology cleanup, no runtime behaviour change — no runtime keyword, var, or file rename; no `.beads` edit.

- **Preserved (bead AC3):** `destroy.cljc`'s live-state membership authentication — every `authenticate(s/d)` there describes verifying membership/reap against the CURRENT durable join state, which the bead explicitly names as a legitimate non-coordinate use ("live-state-verified membership/reap classification remains precise rather than being mechanically swept"). Left intact.
- **Out of this slice:** the `exact-authority` / "exact authority" full-word sweep (bead AC2 authority-named fixtures) and the Spec 005 `Exact-authority fold gate` heading/anchor rename (bead AC1, `spec/005-StateMachines.md` is a hot-zone file). The pervasive `forged`/`mint`/`provenance` vocabulary was also left untouched (sweeping it would be the mechanical change both the bead and the minimal-scope brief guard against).

## Quality gates

All green on this branch (no behaviour change expected — comment/docstring only):

- `implementation/machines` JVM (`clojure -M:test`): **1174 tests, 4048 assertions, 0 failures, 0 errors**
- `tools/xray` JVM (`clojure -M:test`, touched the xray comment): **1270 tests, 5908 assertions, 0 failures, 0 errors**
- `implementation` `npm run test:cljs`: **9866 tests, 48504 assertions, 0 failures, 0 errors**

Closes rf2-zeeyk's residual `exact-auth` abbreviation sites; AC1 (Spec 005 hot-zone heading) and AC2 (authority-fixture sweep) remain for their separate sequenced passes.