### PR TITLE
docs(ui): two-axis publish-commit precision + escape the @view docstring warning (rf2-ce8cj)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -3527,8 +3527,10 @@
     (:hmr-body-revision slot)))
 
 (defn- publish-commit!
-  "Linearize the FINAL HMR body-authority validation WITH the state publication
-  as ONE operation (rf2-77pb08). Publishes `new-committed` (optionally
+  "Settle the FINAL HMR body-authority validation together with the state
+  publication (rf2-77pb08) across two axes of differing strength — a cell-state
+  CAS linearization and a best-effort registered-slot identity check taken
+  immediately before it (detailed below). Publishes `new-committed` (optionally
   transformed by `accept-capture`) onto `cell` and returns `:published`, or
   returns `:stale` having published NOTHING when the body authority moved.
 
@@ -3558,7 +3560,7 @@
     - REGISTRY axis — a BEST-EFFORT slot-IDENTITY gate, NOT a single-atom
       linearization. The view's HMR slot is sampled ONCE per attempt as an
       authority TOKEN; the publish gate is `(and (identical? token (get
-      @view-generations view-id)) (compare-and-set! st s published))` — TWO reads
+      (deref view-generations) view-id)) (compare-and-set! st s published))` — TWO reads
       of TWO different atoms (`view-generations` for the token, `st` for the
       CAS). The token is checked IMMEDIATELY BEFORE the CAS, not fused atomically
       WITH it. A same-view re-registration swaps `view-generations` to a fresh
@@ -3777,7 +3779,7 @@
           ;; joins this commit to the acquired incarnation's teardown, not the
           ;; replacement id (rf2-vxgfnd.88).
           (when-some [barrier *commit-barrier*] (barrier :post-acquire cell))
-          ;; FINAL HMR-authority fence + publication as ONE linearized operation
+          ;; FINAL HMR-authority fence + publication — two axes of differing strength
           ;; (rf2-77pb08, completing rf2-vxgfnd.214). Step 1 samples the body
           ;; authority ONCE — before the :pre-acquire barrier, the acquire/cache
           ;; callbacks, and the :post-acquire barrier, EVERY one of which can
@@ -3787,10 +3789,11 @@
           ;; to publish — a check-to-use gap in which an `advance-generation!`
           ;; (cell-local axis) or a same-view re-registration (registry axis) could
           ;; land and let a stale-generation capture publish and connect. A third
-          ;; read only MOVES that gap. `publish-commit!` instead FUSES the final
-          ;; validation and the step-6 publication into ONE compare-and-set!
-          ;; transition (cell-local axis) gated on the registered-slot identity
-          ;; token (registry axis), so no pause interposed before the CAS can
+          ;; read only MOVES that gap. `publish-commit!` instead CAS-linearizes
+          ;; the final cell-state validation with the step-6 publication
+          ;; (cell-local axis), and checks the registered-slot identity token
+          ;; IMMEDIATELY BEFORE that CAS (registry axis — best-effort under the
+          ;; single-threaded CLJS host), so no pause interposed before the CAS can
           ;; publish a stale capture. On rejection it publishes NOTHING; we release
           ;; ONLY the newly staged leases in reverse acquisition order, leaving the
           ;; prior committed set / values / lifecycle untouched, and return :stale

--- a/implementation/ui/test/re_frame/ui/reactive_publication_linearize_race_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/reactive_publication_linearize_race_jvm_test.clj
@@ -1,6 +1,9 @@
 (ns re-frame.ui.reactive-publication-linearize-race-jvm-test
-  "rf2-77pb08 — the final ViewCell body-authority validation and the state
-  publication are ONE linearized compare-and-set! transition.
+  "rf2-77pb08 — the final ViewCell body-authority validation settles with the
+  state publication across two axes of differing strength: the cell-state publish
+  is a genuine single-atom compare-and-set! linearization; the registered-slot
+  identity is a best-effort check taken immediately before that CAS, sound on
+  re-frame2's single-threaded CLJS host.
 
   THE RACE (JVM-only; CLJS is single-threaded). PR #5938 fenced the final
   publication against an HMR body-authority change, but the fence SAMPLED the
@@ -12,12 +15,24 @@
 
   These fixtures reproduce the window with a deterministic `CountDownLatch`
   handoff (NO sleeps): the commit PARKS at the `:pre-publish` seam — fired inside
-  `publish-commit!` between an attempt's authority sample and its publish CAS — a
-  racing thread advances the authority, then the commit resumes. With the
-  linearization the publish CAS over the now-stale snapshot FAILS (cell-local
-  axis) or the registered-slot identity token has moved (registry axis), so the
-  loop re-validates and returns `:stale` having published/connected NOTHING.
-  Pre-fix (sample-then-independent-swap) the racing commit publishes and connects.
+  `publish-commit!` after an attempt's authority sample, before its publish CAS —
+  a racing thread advances the authority, then the commit resumes.
+
+  CELL-LOCAL axis (genuine single-atom linearization): the racing
+  `advance-generation!` moves the cell-state atom, so the publish
+  `compare-and-set!` over the now-stale snapshot FAILS; the loop re-validates and
+  returns `:stale`.
+
+  REGISTRY axis (best-effort slot-identity gate, NOT one fused CAS): the racing
+  re-registration swaps the slot object BEFORE the `identical?` token recheck that
+  immediately precedes the CAS, so that recheck fails, the loop re-reads a moved
+  revision and returns `:stale`. This fixture exercises the recheck→re-validate
+  path — NOT the residual token-read→CAS window; a single-fire barrier cannot
+  interpose there, and that window is unreachable on the single-threaded CLJS host
+  anyway.
+
+  Both publish/connect NOTHING. Pre-fix (sample-then-independent-swap) the racing
+  commit publishes and connects.
 
   `.clj` (JVM-only) — a genuine two-thread interleaving; the barrier handoff means
   only one thread mutates the substrate at a time, so this is a controlled


### PR DESCRIPTION
Closes rf2-ce8cj. Finishes the `publish-commit!` registry-axis precision sweep started by rf2-lbvkqy and makes the emitted docstring Closure-clean. Prose/comment-only — **no runtime logic, no linearization-behaviour change**.

## What changed

**Two-axis wording** (honest, per rf2-lbvkqy's detailed model: cell-local generation is a genuine single-atom CAS linearization; registry authority is a best-effort slot-identity check immediately before the cell CAS, sound on the single-threaded CLJS host):

- `reactive.cljc:3529` `publish-commit!` function lead — "Linearize … as **ONE operation**" → "Settle … **across two axes of differing strength** — a cell-state CAS linearization and a best-effort registered-slot identity check taken immediately before it".
- `reactive.cljc:3780` step-6 `commit*` comment — "publication as **ONE linearized operation**" → "publication — two axes of differing strength"; and "**FUSES** … into **ONE compare-and-set! transition** gated on the registered-slot identity token" → "CAS-linearizes the cell-state validation with the publication (cell-local axis), and checks the registered-slot identity token IMMEDIATELY BEFORE that CAS (registry axis — best-effort under the single-threaded host)".
- `reactive_publication_linearize_race_jvm_test.clj:2` ns docstring — "the final … validation and the state publication are **ONE linearized compare-and-set! transition**" → two axes, two strengths. The registry fixture description now states it interposes the re-registration **BEFORE** the `identical?` token recheck (recheck→re-validate path), **not** inside the residual token-read→CAS window — proving the registry axis is best-effort, not one fused CAS.

**`@view` docstring escape** — the detailed repair had embedded a raw `@view-generations` in the emitted docstring code-sample, so Closure parsed `@view` as an unknown JSDoc tag at `publish-commit!` (the recurring "pre-existing" `@view` warning). Rewritten as `(deref view-generations)` — same meaning, no leading `@` sigil. The remaining eight `@view-generations` occurrences are all real code derefs (function bodies + the runtime token sample/recheck) and are untouched.

## Quality gates

All foreground, unpiped, from the worktree.

- `implementation/ui` JVM (`clojure -M:test`): **758 tests / 13952 assertions, 0 failures, 0 errors**.
- `npm run test:cljs`: **9866 tests / 48504 assertions, 0 failures, 0 errors**.
- `npm run test:elision`: **0** `unknown JSDoc tag "view"` occurrences (both builds `0 warnings`); `PASS elision: production 60/60 absent … control 60/60 present`.
  - Red-before/green-after: origin/main carried raw `@view-generations` in the `publish-commit!` docstring (line ~3561) → the `@view` warning; after this change the advanced build emits 0 JSDoc warnings.

No change to `publish-commit!` runtime forms; no `analyze.cljc`/`emit_cljs.cljc`/`header.cljc`/`binding_plan.cljc`, `events.cljs`, or `frames.cljc` touched.
