### PR TITLE
fix(router): carry the operation realm through capture-frame-superseded error emission (rf2-7xlvt)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1227,11 +1227,15 @@
   `dispatch-fn` (the `dispatch-impl` / `dispatch-sync-impl` alias, preserving the
   single `with-redefs` interception seam). `frame-target` is a keyword id OR a
   frame VALUE; the recover-but-emit stamps the normalized frame id (identity for
-  a keyword) so the diagnostic carries an id, never a value map (rf2-vclh63)."
-  [dispatch-fn frame-target captured-incarnation event opts]
+  a keyword) so the diagnostic carries an id, never a value map (rf2-vclh63).
+  `op` (rf2-7xlvt) is the ALREADY-KNOWN operation realm — `:dispatch` or
+  `:dispatch-sync` — carried through the recover-but-emit so the frame-destroyed
+  source-coord resolves under `[:event id]` exactly, never the realm-ambiguous
+  fallback that could steal a same-keyword subscription's coord."
+  [dispatch-fn op frame-target captured-incarnation event opts]
   (if (capture-target-superseded? frame-target captured-incarnation)
     (router/emit-captured-frame-superseded!
-      event (frame/frame-target->id frame-target) opts)
+      event (frame/frame-target->id frame-target) op opts)
     ;; rf2-dlld6: the `capture-target-superseded?` pre-check above and the
     ;; ordinary address-directed dispatch below are SEPARATE operations. On the
     ;; concurrent JVM host frame A can be destroyed AND a same-id successor B
@@ -1257,11 +1261,13 @@
   wrapper). The async-safe, recover-but-emit sibling of the SYNCHRONOUS throwing
   `re-frame.ui.frames/fence-subscribe`; reuses the dispatch fence's emit seam,
   passing `subscribe-call-site` as the `:rf.trace/call-site` so the drop is
-  attributed to the subscribe coord."
+  attributed to the subscribe coord, and the `:subscribe` operation realm
+  (rf2-7xlvt) so the frame-destroyed source-coord resolves under `[:sub id]`
+  exactly — never a same-keyword event's coord."
   [subscribe-thunk frame-target captured-incarnation query-v subscribe-call-site]
   (if (capture-target-superseded? frame-target captured-incarnation)
     (router/emit-captured-frame-superseded!
-      query-v (frame/frame-target->id frame-target)
+      query-v (frame/frame-target->id frame-target) :subscribe
       {:rf.trace/call-site subscribe-call-site})
     (subscribe-thunk)))
 
@@ -1315,15 +1321,15 @@
     {:frame frame
      :dispatch
      (fn dispatch-fn
-       ([event]      (capture-dispatch! dispatch-impl frame captured-incarnation
+       ([event]      (capture-dispatch! dispatch-impl :dispatch frame captured-incarnation
                                         event (merge dispatch-opts {:frame frame})))
-       ([event opts] (capture-dispatch! dispatch-impl frame captured-incarnation
+       ([event opts] (capture-dispatch! dispatch-impl :dispatch frame captured-incarnation
                                         event (merge dispatch-opts opts {:frame frame}))))
      :dispatch-sync
      (fn dispatch-sync-fn
-       ([event]      (capture-dispatch! dispatch-sync-impl frame captured-incarnation
+       ([event]      (capture-dispatch! dispatch-sync-impl :dispatch-sync frame captured-incarnation
                                         event (merge dispatch-opts {:frame frame})))
-       ([event opts] (capture-dispatch! dispatch-sync-impl frame captured-incarnation
+       ([event opts] (capture-dispatch! dispatch-sync-impl :dispatch-sync frame captured-incarnation
                                         event (merge dispatch-opts opts {:frame frame}))))
      :subscribe
      ;; rf2-tdjv7p: fence subscribe on the SAME incarnation pin as dispatch — a

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -2066,16 +2066,34 @@
   Reached via the `:error-emit/dispatch-on-error` late-bind hook — the
   drain helper is on the same facade as the dispatch entry points and
   router already static-requires `error-emit`, but routing all the
-  non-recovery sites through one helper keeps the gating uniform."
-  [event-id event frame-id]
-  ;; Fan out along BOTH channels (rf2-c4oycd shared helper). Axis 1 — the
-  ;; always-on listener (survives prod elision); axis 2 — the dev trace (DCE'd
-  ;; under `:advanced` + `goog.DEBUG=false`). No exception — invalid op, not a
-  ;; throw; `elapsed-ms 0` (not a timed path).
-  (error-emit/emit-error-both!
-    :rf.error/frame-destroyed
-    event event-id frame-id nil 0 (interop/now-ms)
-    {:frame frame-id :event event :reason :frame-destroyed}))
+  non-recovery sites through one helper keeps the gating uniform.
+
+  `op` (rf2-7xlvt) is the ALREADY-KNOWN operation realm of the failing op
+  — `:dispatch` / `:dispatch-sync` / `:subscribe` — carried onto the
+  always-on record's private `:op` steering slot so
+  `error-emit/error-source-coord` resolves the source-coord under the EXACT
+  realm (`[:event id]` for a dispatch, `[:sub id]` for a subscribe) rather
+  than the realm-ambiguous `[:sub]`-then-`[:event]` fallback. The bare
+  router drain / no-such-frame emitters carry NO realm (the 3-arity), so
+  they keep that fallback — unchanged. The `capture-frame` stale-op seam
+  (`emit-captured-frame-superseded!`) is the one caller that KNOWS the
+  realm and passes it."
+  ([event-id event frame-id]
+   (emit-frame-destroyed! event-id event frame-id nil))
+  ([event-id event frame-id op]
+   ;; Fan out along BOTH channels (rf2-c4oycd shared helper). Axis 1 — the
+   ;; always-on listener (survives prod elision); axis 2 — the dev trace (DCE'd
+   ;; under `:advanced` + `goog.DEBUG=false`). No exception — invalid op, not a
+   ;; throw; `elapsed-ms 0` (not a timed path). When `op` is present it rides
+   ;; BOTH the dev-trace tags (axis 2) and the always-on record-attrs (axis 1
+   ;; — the private `:op` source-coord steering); nil `op` leaves the record
+   ;; shape exactly as the bare-drain callers have always emitted it.
+   (error-emit/emit-error-both!
+     :rf.error/frame-destroyed
+     event event-id frame-id nil 0 (interop/now-ms)
+     (cond-> {:frame frame-id :event event :reason :frame-destroyed}
+       op (assoc :op op))
+     (when op {:op op}))))
 
 (defn- handle-frame-destroyed!
   "Per Spec 002 §Run-to-completion: a frame disposed between enqueue and
@@ -2104,6 +2122,18 @@
   synchronous `capture-target-superseded?` pre-check already sees the pin gone;
   a superseded `:subscribe` additionally returns nil rather than a reaction.
 
+  `op` (rf2-7xlvt) is the ALREADY-KNOWN operation realm of the failing captured
+  op — `:dispatch` / `:dispatch-sync` (from `capture-dispatch!`) or `:subscribe`
+  (from `capture-subscribe!`). It is carried through `emit-frame-destroyed!` onto
+  the always-on record's private `:op` steering slot so `error-emit/error-source-
+  coord` resolves the source-coord under the EXACT realm — `[:event id]` for a
+  dispatch, `[:sub id]` for a subscribe — never the realm-ambiguous
+  `[:sub]`-then-`[:event]` fallback that (before rf2-7xlvt) misattributed a stale
+  captured dispatch to a same-keyword subscription's coord and a stale captured
+  subscribe to an unrelated event's coord instead of OMITTING it. This seam KNOWS
+  the realm; the bare router drain emitters (which genuinely do not) keep the
+  fallback.
+
   rf2-dlld6 closes the concurrent-JVM window BETWEEN that pre-check and the
   ordinary bare-id target consumption: `capture-dispatch!` / the `:subscribe`
   thunk carry the pinned incarnation through as `:rf.frame/expected-incarnation`,
@@ -2114,9 +2144,9 @@
   The bare-id `frame-destroyed` emit `dispatch!` / `dispatch-sync!` already raise
   for a fully-unclaimed id is unchanged (an unpinned 1-arity capture stays
   address-directed)."
-  [event frame-id opts]
+  [event frame-id op opts]
   (trace/with-call-site (when interop/debug-enabled? (:rf.trace/call-site opts))
-    (emit-frame-destroyed! (first event) event frame-id))
+    (emit-frame-destroyed! (first event) event frame-id op))
   nil)
 
 ;; EP-0015 §8 (rf2-d2r3um): the former per-dispatch

--- a/implementation/core/test/re_frame/on_error_cljs_test.cljc
+++ b/implementation/core/test/re_frame/on_error_cljs_test.cljc
@@ -734,6 +734,129 @@
         (is (not (contains? r :source-coord))
             "no captured coords ⇒ the :source-coord slot is ABSENT, not nil")))))
 
+;; ============================================================================
+;; rf2-7xlvt — CORE capture-frame stale-op source-coord is OPERATION-REALM EXACT
+;; ----------------------------------------------------------------------------
+;; The synchronous capture pre-check seam — `router/emit-captured-frame-
+;; superseded!`, reached from `core/capture-dispatch!` + `core/capture-
+;; subscribe!` — recover-but-emits `:rf.error/frame-destroyed` when a
+;; `capture-frame` op finds its pinned incarnation superseded. Before rf2-7xlvt
+;; it DROPPED the already-known operation realm, so `error-emit/error-source-
+;; coord` fell back to the legacy `[:sub]`-then-`[:event]` probe (the correct
+;; fallback for the realm-ambiguous bare router / subs emitters, UNSOUND here
+;; where the realm IS known). That misattributed a stale captured DISPATCH to a
+;; same-keyword SUBSCRIPTION's coord, and a stale captured SUBSCRIBE to an
+;; unrelated EVENT's coord (instead of OMITTING `:source-coord`). This seam
+;; KNOWS the realm (`:dispatch` / `:dispatch-sync` / `:subscribe`); it now
+;; carries it through the shared frame-destroyed emit boundary so the resolved
+;; coord names the correct definition (dispatch → `[:event]`, subscribe →
+;; `[:sub]`) — or is omitted when the realm's own coord is genuinely absent.
+;;
+;; These drive the REAL capture seam (a `capture-frame` api pinned to a live
+;; frame, then destroyed + reseated as a same-id successor) against distinct
+;; sentinel `[:event id]` / `[:sub id]` coords seeded into the always-on
+;; `error-coords-by-id` registry — the same registry the runtime resolves —
+;; and assert the delivered record's `:source-coord` names the correct realm.
+;; ============================================================================
+
+(def ^:private xlvt-event-coord
+  {:ns 're-frame.on-error-cljs-test.xlvt-events :file "xlvt_events.cljc" :line 7})
+
+(def ^:private xlvt-sub-coord
+  {:ns 're-frame.on-error-cljs-test.xlvt-subs :file "xlvt_subs.cljc" :line 13})
+
+(defn- capture-superseded-record
+  "Pin a `capture-frame` api to a LIVE frame, destroy that frame and reseat a
+  same-id successor B (superseding the pin exactly like the bead's repro), run
+  `seed` to populate the always-on `error-coords-by-id` registry, then invoke
+  the captured `op-key` op (`:dispatch` / `:dispatch-sync` / `:subscribe`) with
+  the vector `[id]`. The synchronous `capture-target-superseded?` pre-check sees
+  the pin gone, so the op recover-but-emits through `emit-captured-frame-
+  superseded!` (never leaking into B). Returns the vector of always-on records
+  the listener saw — exactly one per stale op."
+  [op-key id seed]
+  (let [fid  :xlvt/target]
+    (rf/make-frame {:id fid :doc "capture target A"})
+    (let [h (rf/capture-frame fid)]
+      (rf/destroy-frame! fid)
+      (rf/make-frame {:id fid :doc "same-id successor B"})
+      (let [seen (atom [])]
+        (source-coords/forget-error-coords!)
+        (seed)
+        (rf/register-listener! :errors :xlvt/recorder
+                               (fn [record] (swap! seen conj record)))
+        (case op-key
+          :dispatch      ((:dispatch h) [id])
+          :dispatch-sync ((:dispatch-sync h) [id])
+          :subscribe     ((:subscribe h) [id]))
+        @seen))))
+
+(defn- seed-both [id]
+  (fn []
+    (source-coords/remember-error-coords! :event id xlvt-event-coord)
+    (source-coords/remember-error-coords! :sub   id xlvt-sub-coord)))
+
+(deftest stale-captured-dispatch-resolves-the-event-coord-not-the-collision-sub
+  (testing "rf2-7xlvt — a stale captured `:dispatch` whose id is BOTH an event
+            AND a same-keyword sub resolves the EVENT coord. Pre-fix the realm
+            was dropped and the `[:sub]`-first fallback stole the sub's coord."
+    (let [records (capture-superseded-record :dispatch :audit/collide
+                                             (seed-both :audit/collide))]
+      (is (= 1 (count records)) "exactly one always-on record per stale op")
+      (let [r (first records)]
+        (is (= :rf.error/frame-destroyed (:error r)))
+        (is (= xlvt-event-coord (:source-coord r))
+            "stale captured dispatch resolves the EVENT coord, never the collision sub's")))))
+
+(deftest stale-captured-dispatch-sync-shares-the-event-realm
+  (testing "rf2-7xlvt — a stale captured `:dispatch-sync` shares the dispatch
+            realm: the EVENT coord, never the same-keyword sub's."
+    (let [records (capture-superseded-record :dispatch-sync :audit/collide
+                                             (seed-both :audit/collide))]
+      (is (= 1 (count records)))
+      (is (= xlvt-event-coord (:source-coord (first records)))
+          "stale captured dispatch-sync resolves the EVENT coord"))))
+
+(deftest stale-captured-subscribe-resolves-the-sub-coord-not-the-collision-event
+  (testing "rf2-7xlvt — the inverse collision direction: a stale captured
+            `:subscribe` whose id is BOTH resolves the SUB coord, never the
+            same-keyword event's."
+    (let [records (capture-superseded-record :subscribe :audit/collide
+                                             (seed-both :audit/collide))]
+      (is (= 1 (count records)))
+      (is (= xlvt-sub-coord (:source-coord (first records)))
+          "stale captured subscribe resolves the SUB coord"))))
+
+(deftest stale-captured-subscribe-omits-coord-when-only-event-registered
+  (testing "rf2-7xlvt — a stale captured `:subscribe` for an id that is ONLY an
+            EVENT (no sub coord) OMITS `:source-coord` rather than stealing the
+            unrelated event's. Pre-fix the `[:sub]`-then-`[:event]` fallback
+            returned the EVENT coord — the wrong realm."
+    (let [records (capture-superseded-record
+                    :subscribe :audit/collide
+                    (fn [] (source-coords/remember-error-coords!
+                             :event :audit/collide xlvt-event-coord)))]
+      (is (= 1 (count records)))
+      (let [r (first records)]
+        (is (= :rf.error/frame-destroyed (:error r)))
+        (is (not (contains? r :source-coord))
+            "no sub coord ⇒ :source-coord is ABSENT, never the unrelated event's")))))
+
+(deftest stale-captured-dispatch-omits-coord-when-only-sub-registered
+  (testing "rf2-7xlvt — the inverse omit: a stale captured `:dispatch` for an id
+            that is ONLY a SUB (no event coord) OMITS `:source-coord` rather than
+            stealing the unrelated sub's. Pre-fix the `[:sub]`-first fallback
+            returned the SUB coord — the wrong realm."
+    (let [records (capture-superseded-record
+                    :dispatch :audit/collide
+                    (fn [] (source-coords/remember-error-coords!
+                             :sub :audit/collide xlvt-sub-coord)))]
+      (is (= 1 (count records)))
+      (let [r (first records)]
+        (is (= :rf.error/frame-destroyed (:error r)))
+        (is (not (contains? r :source-coord))
+            "no event coord ⇒ :source-coord is ABSENT, never the unrelated sub's")))))
+
 (deftest non-recovery-categories-fan-out-to-listener
   (testing "Per rf2-2hvga (= B / widen): every catalogued production-
             reachable runtime `:rf.error/*` — frame-destroyed,


### PR DESCRIPTION
## Summary

The synchronous `capture-frame` stale-op seam — `router/emit-captured-frame-superseded!`, reached from `core/capture-dispatch!` and `core/capture-subscribe!` — recover-but-emits `:rf.error/frame-destroyed` when a captured op finds its pinned incarnation superseded. It **dropped the already-known operation realm** on the way to `emit-frame-destroyed!`, so `error-emit/error-source-coord` fell back to the realm-ambiguous `[:sub]`-then-`[:event]` probe.

That probe is the *correct* fallback for the bare router / subs emitters (which genuinely do not know the realm), but **unsound here** — this seam knows whether the attempted op was dispatch, dispatch-sync, or subscribe. On a capture pinned to a destroyed incarnation A (same-id successor B reseated):

- with both `[:event id]` and `[:sub id]` present, a stale captured **dispatch** was attributed to the **SUB** coord;
- with only the event coord present, a stale captured **subscribe** stole the unrelated **EVENT** coord instead of omitting `:source-coord`.

Either way the always-on record misdirected Xray / off-box tooling and the programmer/AI to the wrong definition.

## Fix

Carry the known realm through the shared frame-destroyed emit boundary onto the record's private `:op` steering slot — the exact slot the UI frame-bundle stale-op seam already stamps (rf2-xgkgx):

- `core/capture-dispatch!` gains an `op` param; the `:dispatch` / `:dispatch-sync` arms pass their realm.
- `core/capture-subscribe!` passes `:subscribe`.
- `router/emit-captured-frame-superseded!` threads `op` into `router/emit-frame-destroyed!`.
- `emit-frame-destroyed!` gains an `op`-carrying 4-arity that rides `{:op op}` on both the dev-trace tags and the always-on record-attrs. The **bare-drain 3-arity is unchanged** (nil op → existing fallback), so `handle-frame-destroyed!` and the ordinary bare router dispatch / no-such-frame emitters keep their behavior.

`error-emit/error-source-coord` was already realm-aware from rf2-xgkgx — this PR just feeds it the realm the seam already knew. No error-substrate redesign, no public incarnation token, no new error id (`:rf.error/frame-destroyed` reused), no recovery-behavior change. Orthogonal to rf2-dlld6's exact-incarnation consumption race — its bare-id emitters are untouched. Rebased on merged rf2-dlld6 (#6186).

## Tests

New `rf2-7xlvt` section in `on_error_cljs_test.cljc` drives the **real** capture seam (a `capture-frame` api pinned to a live frame, destroyed + reseated as a same-id successor) against distinct sentinel `[:event id]` / `[:sub id]` coords seeded into the always-on `error-coords-by-id` registry:

- stale captured dispatch + dispatch-sync resolve the EVENT coord on a same-keyword collision (red before: picked the SUB coord);
- stale captured subscribe resolves the SUB coord on the inverse collision;
- stale captured subscribe with only an event coord OMITS `:source-coord` (red before: stole the EVENT coord);
- stale captured dispatch with only a sub coord OMITS `:source-coord` (red before: stole the SUB coord);
- each stale op emits exactly one always-on record.

Red-before / green-after confirmed: 4 wrong-realm arms failed on main, all pass after the fix.

## Quality gates

- `clojure -M:test` (core JVM): **2051 tests, 9660 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **9872 tests, 48522 assertions, 0 failures, 0 errors**
- Reused `:rf.error/frame-destroyed` — no Spec 009 catalogue row needed.
