### PR TITLE
fix(ui-compiler): pure-annotate emitted view def for facade-isolation DCE (rf2-edpam)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -828,7 +828,10 @@
               ~view-id ~render-sym compare# ~display-name (quote ~manifest))
              ;; The production arm is deliberately direct React.memo. Closure
              ;; folds away the sibling registration arm and with it every HMR
-             ;; slot/listener/dynamic-lookup/extra-Fiber helper.
+             ;; slot/listener/dynamic-lookup/extra-Fiber helper. `memo-view`
+             ;; carries an `@nosideeffects` JSDoc annotation, so Closure DCEs
+             ;; this call whole when the view def is UNREFERENCED (G-18 facade
+             ;; isolation, rf2-edpam).
              (re-frame.ui.runtime/memo-view
               ~(if host-render host-render-sym render-sym)
               compare# ~display-name))))

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -97,10 +97,23 @@
 ;; Memo + registration
 ;; ---------------------------------------------------------------------------
 
-(defn memo-view
+(defn ^{:jsdoc ["@nosideeffects"]} memo-view
   "React.memo over the compiled render fn with the generated `rf=`
   comparator. This is the direct production path: no shell, slot, listener,
-  dynamic render lookup, or extra Fiber."
+  dynamic render lookup, or extra Fiber.
+
+  The `@nosideeffects` JSDoc annotation (Closure-native, always honoured — it
+  rides the type-info JSDoc channel Closure preserves) promises that building a
+  memoized component is side-effect-free. Under `:advanced` + goog.DEBUG=false a
+  production view def folds to exactly this call (the emitter's direct-React.memo
+  arm; the DEV `displayName` writes below are goog.DEBUG-stripped), so the
+  annotation lets Closure dead-code-eliminate an UNREFERENCED view def whole —
+  render fn and sentinel strings included. Without it Closure keeps the call as a
+  retained expression statement and a single-view import of a multi-view library
+  namespace drags in every unimported sibling (G-18 facade isolation, rf2-edpam).
+  The promise is honest where it matters: `memo-view` is reached ONLY on the
+  goog.DEBUG=false production arm, so no build both runs the `displayName` writes
+  and trusts this annotation."
   [render-fn compare-fn display-name]
   (let [c (react/memo render-fn compare-fn)]
     (when ^boolean js/goog.DEBUG


### PR DESCRIPTION
## What

The G-18 library facade-isolation gap (rf2-edpam). An `:advanced` build importing EXACTLY ONE view from a multi-view library namespace RETAINED all unimported siblings (their render fns + sentinel strings), so a single-view consumer dragged in the whole library.

**Root cause.** The production `defview` arm emits `(def vname (memo-view render cmp name))`, and `memo-view` calls `React.memo(renderFn, cmp)`. Closure does not treat that call as side-effect-free, so an unreferenced view def survived `:advanced` as a retained `memo-view(…)` expression statement (Closure dropped the unused `var` binding but kept the call). The compiled single-view bundle showed the imported view as `var dL=OK(render,cmp)` (kept) but each sibling as a bare `OK(render,cmp);` statement (`OK` = `memo-view`).

**Fix (minimum, readiness §4).** Annotate `memo-view` with `@nosideeffects` JSDoc — the Closure-native annotation that rides the type-info JSDoc channel Closure always preserves. A raw `/*#__PURE__*/` block comment did NOT survive shadow-cljs → Closure in this setup (verified: siblings stayed retained), whereas `@nosideeffects` on the function makes Closure DCE every unused-result call to it. Building a memoized component is side-effect-free, so an unreferenced view def now elides whole (render fn + sentinels included).

The `displayName` writes in `memo-view` are goog.DEBUG-stripped, and `memo-view` is reached only on the goog.DEBUG=false production arm (DEV uses the `register-view!` arm), so no build both runs those writes and trusts the annotation. The emitter's production/registration arms are unchanged (the emit_cljs.cljc hunk is a comment documenting the coupling); a referenced view behaves exactly as before. No second elision mode, no registration redesign.

## Quality gates

Run in the worker worktree (`:advanced` proof-pack + Closure), foreground:

- `npm run test:ui-facade-isolation` — **GREEN** (was RED). Before: `siblings retained in single-view: 5/5`. After: `0/5`; positive control 6/6 sentinels present; imported `controlled-input` sentinel present. **G-18 PASS.**
- `npm run test:elision` — **PASS** (G-13 HMR-slot elision + production DCE not regressed): production 60/60 absent, control 60/60 present, EP-0023 1/1 provenance-survives + 2/2 assembly-DCE.
- `implementation/ui` JVM (`clojure -M:test`) — **761 tests, 14151 assertions, 0 failures, 0 errors.**
- `npm run test:cljs` — **9867 tests, 48509 assertions, 0 failures, 0 errors.**
- `npm run test:adapter-smokes` — **3 specs, 0 failures** (exit 0; Reagent/UIx/Helix mount+dispatch+assert).

No `analyze.cljc` / `events.cljs` / `frames.cljc` / hot-zone (`.github/workflows`, `shadow-cljs.edn`, `deps.edn`) touched. Diff is 2 files: `runtime.cljs` (the annotation) + `emit_cljs.cljc` (comment-only).