### PR TITLE
fix(ui-compiler): per-pass provenance for compile membership, not :js identity (rf2-v7wqk)

### DIFF
--- a/implementation/scripts/check-ui-final-schedule.cjs
+++ b/implementation/scripts/check-ui-final-schedule.cjs
@@ -1,15 +1,16 @@
 #!/usr/bin/env node
 'use strict';
 
-// rf2-vxgfnd.195 / rf2-ialoij — the FIFTH real-Shadow arm for final-schedule
-// reconciliation, complementing the synthetic JVM fixtures that fabricate build
-// state and outputs (compiler_digest_carrier_jvm_test.clj's
+// rf2-vxgfnd.195 / rf2-ialoij / rf2-v7wqk — the FIFTH real-Shadow arm for
+// final-schedule reconciliation, complementing the synthetic JVM fixtures that
+// fabricate build state and outputs (compiler_digest_carrier_jvm_test.clj's
 // later-prepare-hook-forced-recompile / colliding-and-backwards-stamps /
-// metadata-only / missing-provenance arms). Those cannot prove Shadow hook
-// deep-merge/order, an actual build-local :compile-prepare hook, real
-// sequential/parallel scheduling, output-marker retention, or fail-loud
-// behaviour — but here the FRESH `:js` object Shadow's real compile path
-// allocates is genuine, not a hand-built stand-in.
+// metadata-only / non-scheduling-js-transform / missing- and
+// ambiguous-provenance arms). Those cannot prove Shadow hook deep-merge/order,
+// an actual build-local :compile-prepare hook, real sequential/parallel
+// scheduling, per-pass marker retention, or fail-loud behaviour — but here the
+// FRESH output map Shadow's real compile path allocates (dropping re-frame.ui's
+// per-pass marker) is genuine, not a hand-built stand-in.
 //
 // This gate drives ONE real Shadow 3.4.10 warm watch daemon per compile mode
 // through:
@@ -22,29 +23,30 @@
 //      retained output and rewrites its source viewless, forcing Shadow to
 //      recompile app-a AFTER re-frame.ui observed the schedule. app-a was NOT
 //      pre-touched at prepare, so ONLY reconcile-final-schedule at :compile-
-//      finish (reading Shadow's causal per-source compile evidence — app-a's
-//      fresh, :cached false output carrying a new :js artifact object) can evict
-//      it. The accepted row is evicted, the digest moves, and app-b (a true
-//      cache hit) stays byte-identical;
+//      finish (reading re-frame.ui's per-pass marker — app-a's fresh compiled
+//      output map LACKS the token :compile-prepare stamped) can evict it. The
+//      accepted row is evicted, the digest moves, and app-b (a true cache hit,
+//      its stamped output retained) stays byte-identical;
 //   4. a FAIL-LOUD pass — a build-local hook drops re-frame.ui's per-pass
-//      :pass-output provenance from the open scratch; reconciliation must FAIL
+//      :pass-token provenance from the open scratch; reconciliation must FAIL
 //      the build rather than silently reconcile against an assumed-empty
 //      schedule.
 // Both the PARALLEL (:ui-final-schedule) and SEQUENTIAL
 // (:ui-final-schedule-seq, :parallel-build false) compile schedules are proven.
 //
 // TEETH (documented mutation/revert; run at development time, NOT committed):
-//   * Restore build-hook/compiled-this-pass?'s old wall-clock body (a
-//     `(> now then)` on :compiled-at, rf2-ialoij) — a real-host recompile whose
-//     fresh output lands in the SAME millisecond as its prepare snapshot is then
-//     misread as untouched, so app-a's ghost can survive the FORCED-EVICT pass.
-//     The deterministic same-/backwards-stamp misclassification is proven
-//     unconditionally by the digest-carrier JVM arms.
+//   * Replace build-hook/compiled-this-pass?'s marker check with the old
+//     `:cached false` + `:js`-identity body (rf2-v7wqk) — a non-scheduling hook
+//     that swaps only a retained output's `:js` for a fresh String is then
+//     misread as a recompile, so a cache-hit sibling's ghost is evicted and the
+//     digest moves on a pass that compiled nothing. The deterministic
+//     output-transforming misclassification is proven unconditionally by the
+//     digest-carrier JVM arm non-scheduling-js-transform-is-not-a-recompile.
 //   * Delete the `(reconcile-final-schedule build-state)` call in
 //     re-frame.ui.compiler.build-hook/hook's :compile-finish branch → the
 //     FORCED-EVICT pass keeps app-a's ghost row (a-present stays true,
 //     view-count stays 2, digest unchanged) → this gate goes RED.
-//   * Make reconcile-final-schedule proceed silently when :pass-output is absent
+//   * Make reconcile-final-schedule proceed silently when :pass-token is absent
 //     (drop the missing-pass-provenance throw) → the FAIL-LOUD pass SUCCEEDS
 //     instead of failing → this gate goes RED.
 // Both were exercised red-before-green during development.

--- a/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
@@ -12,26 +12,32 @@
 
   0. reconcile against Shadow's FINAL authoritative compile schedule — every
      CLJS source actually compiled THIS pass is pre-touched too. Membership is
-     read from Shadow's CAUSAL per-source compile evidence, never output-map
-     identity and never a wall-clock stamp relationship: a source counts as
-     recompiled iff Shadow marked its finish output freshly compiled (`:cached
-     false`) carrying a `:js` artifact object distinct from the one snapshotted
-     at prepare. Shadow allocates that fresh `:js` string and stamps `:cached
-     false` EXACTLY inside its `do-compile-cljs-resource` compile path, so both
-     facts hold iff Shadow really (re)compiled the source this pass; a warm cache
-     hit keeps its retained output object (same `:js`), and a disk-cache load is
-     `:cached true`. Keying on the fresh `:js` object — not the whole output map
-     — is immune to a later non-scheduling hook that replaces a retained output's
-     MAP (via assoc/update-in) while PRESERVING its nested `:js`, and — because it
-     reads Shadow's own compile provenance rather than comparing `:compiled-at`
-     milliseconds — immune to the same-/backwards-millisecond stamp a `>` test
-     misreads as untouched (leaving a ghost accepted view). A later
+     read from re-frame.ui's OWN per-pass provenance marker, never output-map
+     identity, never Shadow's `:js` object identity, and never a wall-clock stamp
+     relationship. At `:compile-prepare` re-frame.ui stamps an opaque per-pass
+     token onto every retained output MAP Shadow handed it. Shadow's compile
+     path (`do-compile-cljs-resource`) builds a FRESH output map for a
+     (re)compiled source, dropping the marker; a later non-scheduling hook that
+     merely annotates or transforms a retained output (assoc/update-in —
+     INCLUDING replacing only `[:output rid :js]` with a fresh equal-byte
+     string) PRESERVES the marker. So a source was (re)compiled THIS pass iff its
+     finish output LACKS the current pass token; `:cached true` then distinguishes
+     a disk-cache load (no macro rerun) from a fresh compile. Keying on
+     re-frame.ui's own marker — not on the identity of Shadow's `:js` artifact —
+     is immune to the ordinary output-transforming shape (a retained output whose
+     `:js` is swapped for a fresh, even byte-identical, String by a non-scheduling
+     hook) that a raw `:js`-identity test misreads as a recompile and so evicts an
+     untouched accepted view; and — reading provenance rather than comparing
+     `:compiled-at` milliseconds — immune to the same-/backwards-millisecond stamp
+     a `>` test misreads as untouched (leaving a ghost accepted view). A later
      `:compile-prepare` hook (Shadow deep-merges build-local hooks after
      `:build-defaults` and lets them mutate build state) can force a source to
      recompile AFTER re-frame.ui observed the schedule; reading the finish-time
-     compile evidence, not the intermediate prepare schedule, closes that
-     hook-order gap so a forced recompile that removed a source's final
-     `ui/defview` evicts its accepted row instead of leaving a ghost view;
+     marker, not the intermediate prepare schedule, closes that hook-order gap so
+     a forced recompile that removed a source's final `ui/defview` evicts its
+     accepted row instead of leaving a ghost view. Missing, malformed, or
+     contradictory per-source provenance fails loudly before any candidate is
+     published, never silently treated as untouched;
   1. derive the candidate finalized slice (commit staged sources, evict sources
      absent from authoritative membership) and its whole-build digest;
   2. purely validate and project that digest into exactly one compiled
@@ -76,6 +82,16 @@
 
 (def ^:private carrier-ns 're-frame.ui.digest-carrier)
 
+(def ^:private compile-marker-key
+  "re-frame.ui's OWN private per-pass provenance marker key, stamped onto every
+  retained output map at `:compile-prepare` (see `stamp-retained-outputs`). It
+  is the per-pass fact that decides compile membership at `:compile-finish` —
+  Shadow's compile path drops it by replacing the whole output map, an ordinary
+  non-scheduling assoc/update-in on a retained output preserves it. Opaque and
+  namespaced so no Shadow or hook code collides with it; it is a key on the JVM
+  output MAP only and is never emitted into any bundle."
+  ::pass-marker)
+
 (defn- member-nss
   "Authoritative declaring namespaces from Shadow's resolved build graph."
   [{:keys [build-sources sources]}]
@@ -116,65 +132,110 @@
      build-sources)))
 
 (defn- compiled-this-pass?
-  "Shadow's CAUSAL fresh-compile evidence for one source, free of any wall-clock
-  stamp comparison.
+  "Whether Shadow (re)compiled `final-output`'s source THIS pass, decided by
+  re-frame.ui's OWN per-pass provenance marker — never Shadow's `:js` object
+  identity and never a wall-clock stamp.
 
-  Shadow's compile path — `do-compile-cljs-resource`, reached ONLY through
-  `maybe-compile-cljs` — is the sole producer of a freshly compiled output: it
-  allocates a brand-new `:js` artifact string (its own `StringWriter`) and stamps
-  `:cached false` on it. A disk-cache load stamps `:cached true` with a distinct
-  deserialized `:js`. A warm cache HIT keeps the prior output object untouched
-  (`generate-output-for-source` returns it; par-compile's `already-compiled`
-  skips it), so the SAME `:js` object survives the pass. A later non-scheduling
-  `:compile-prepare` hook that only annotates or normalizes a retained output
-  (assoc/update-in) yields a NEW output MAP but — assoc preserving nested values —
-  PRESERVES the identical `:js` object.
+  At `:compile-prepare` re-frame.ui stamped `pass-token` onto every retained
+  output MAP (see `stamp-retained-outputs`). Shadow's compile path
+  (`do-compile-cljs-resource`, the sole producer of a freshly compiled output)
+  builds a FRESH output map, so a real recompile's finish output LACKS the
+  marker. A warm cache HIT keeps its stamped map. A later non-scheduling
+  `:compile-prepare` hook that annotates or transforms a retained output
+  (assoc/update-in — INCLUDING replacing only `[:output rid :js]` with a fresh,
+  even byte-identical, String) PRESERVES the marker, because assoc keeps every
+  other key. A disk-cache load also lacks the marker but is `:cached true`.
 
-  So a source was (re)compiled THIS pass iff Shadow marked its finish output
-  freshly compiled (`:cached` is `false` — never a cache load, never a retained
-  annotation of one) AND that output carries a DIFFERENT `:js` artifact object
-  than the one re-frame.ui snapshotted at `:compile-prepare`:
+  So, checking the marker FIRST (it is authoritative over `:cached`, which is
+  sticky on retained outputs):
 
-  - `:cached false` rejects a disk-cache load (fresh `:js`, but no macro rerun);
-  - a fresh `:js` object rejects both a warm cache hit (same output object, same
-    `:js`) and a metadata-only mutation (new map, but the nested `:js` is the
-    same object) — the two false positives raw whole-output `identical?` produced.
+  - marker == the current pass token  -> RETAINED (warm hit / metadata
+    annotation / a non-scheduling `:js` transform); NOT compiled this pass;
+  - marker absent + `:cached false`   -> a fresh compile this pass;
+  - marker absent + `:cached true`    -> a disk-cache load; NOT compiled;
+  - marker absent + `:cached` neither `true` nor `false`, OR a marker that is
+    PRESENT but is NOT the current pass token -> missing/contradictory
+    per-source provenance: fails loudly rather than being silently classified
+    as untouched (rf2-ialoij's missing/ambiguous-evidence criterion).
 
-  Neither test is `>`, `>=`, `!=`, `not=`, or any other relationship on the
-  `:compiled-at` wall clock, so a genuine EQUAL-stamp or BACKWARDS-stamp recompile
-  (same-millisecond `System/currentTimeMillis`, clock skew, a non-monotonic clock)
-  is still classified as a recompile, while a metadata annotation and a warm cache
+  No branch is `>`, `>=`, `!=`, or any relationship on the `:compiled-at` wall
+  clock, so a genuine EQUAL-stamp or BACKWARDS-stamp recompile (same-millisecond
+  `System/currentTimeMillis`, clock skew, a non-monotonic clock) is still
+  classified as a recompile, while an ordinary output transform and a warm cache
   hit are never misread as one."
-  [final-output snapshot-output]
-  (and (false? (:cached final-output))
-       (not (identical? (:js final-output) (:js snapshot-output)))))
+  [final-output pass-token]
+  (let [marker (get final-output compile-marker-key ::unmarked)]
+    (cond
+      (= marker pass-token) false
+
+      (= marker ::unmarked)
+      (case (:cached final-output)
+        false true
+        true  false
+        (throw
+         (ex-info
+          (str "re-frame.ui compile-finish found a CLJS output with no per-pass "
+               "provenance marker and no usable Shadow :cached flag; refusing to "
+               "guess whether it was compiled this pass")
+          {::error ::ambiguous-compile-evidence
+           :reason :unmarked-output-missing-cached-flag
+           :cached (:cached final-output)
+           :recovery :configure-ui-build-hook-once})))
+
+      :else
+      (throw
+       (ex-info
+        (str "re-frame.ui compile-finish found a CLJS output carrying a STALE "
+             "per-pass provenance marker (not this pass's token); refusing to "
+             "guess whether it was compiled this pass")
+        {::error ::ambiguous-compile-evidence
+         :reason :stale-provenance-marker
+         :recovery :configure-ui-build-hook-once})))))
+
+(defn- stamp-retained-outputs
+  "Stamp re-frame.ui's opaque per-pass provenance `pass-token` onto every
+  retained output MAP present at `:compile-prepare`. Purely additive — it adds
+  one private namespaced key and changes no Shadow-visible output byte (in
+  particular no `:js`), so it is inert to Shadow's flush and to the emitted
+  bundle. Shadow's compile path REPLACES a (re)compiled source's whole output
+  map, dropping the marker; a later non-scheduling hook's assoc/update-in on a
+  retained output preserves it. The token is regenerated every prepare, so a
+  retained output is re-stamped and no stale marker survives from a prior pass.
+  Pure build-state transform."
+  [build-state pass-token]
+  (reduce-kv
+   (fn [bs rid output]
+     (if (map? output)
+       (assoc-in bs [:output rid compile-marker-key] pass-token)
+       bs))
+   build-state
+   (:output build-state)))
 
 (defn- actually-recompiled-member-nss
   "Declaring namespaces of every CLJS source Shadow ACTUALLY (re)compiled in
   THIS pass, read from the FINAL build-state at `:compile-finish` — after every
   schedule-mutating `:compile-prepare` hook and after compilation ran —
-  distinguished by Shadow's CAUSAL per-source compile evidence, never output-map
-  identity and never a wall-clock stamp relationship.
+  distinguished by re-frame.ui's OWN per-pass provenance marker, never output-map
+  identity, never Shadow's `:js` object identity, and never a wall-clock stamp.
 
-  `pass-output` is the `:output` map re-frame.ui snapshotted at
-  `:compile-prepare` (the outputs Shadow was about to compile from). See
-  `compiled-this-pass?`: a source counts as recompiled iff Shadow marked its
-  finish output freshly compiled (`:cached false`) with a `:js` artifact object
-  distinct from its snapshot — the evidence Shadow's own compile path carries.
-  This is immune to a later hook replacing a retained output's whole MAP while
-  preserving its nested `:js` (raw whole-output `identical?` misread the fresh
-  map as a recompile and evicted an untouched accepted view), to a same- or
-  backwards-millisecond compile stamp (which a `>`/`>=` stamp test misreads as
-  untouched, leaving a ghost accepted view), and to the build-local hook merge
-  order re-frame.ui cannot control."
-  [{:keys [build-sources sources output]} pass-output]
+  `pass-token` is the opaque token re-frame.ui stamped onto every retained output
+  map at `:compile-prepare` (see `stamp-retained-outputs`). See
+  `compiled-this-pass?`: a source counts as recompiled iff its finish output
+  LACKS that token (Shadow replaced the whole map) and is not a `:cached true`
+  disk load. This is immune to a later hook annotating or transforming a retained
+  output's map — INCLUDING replacing only its `:js` with a fresh equal-byte
+  string — which a raw `:js`-identity test misread as a recompile and so evicted
+  an untouched accepted view; to a same- or backwards-millisecond compile stamp
+  (which a `>`/`>=` stamp test misreads as untouched, leaving a ghost accepted
+  view); and to the build-local hook merge order re-frame.ui cannot control."
+  [{:keys [build-sources sources output]} pass-token]
   (reduce
    (fn [acc resource-id]
      (let [{:keys [type ns provides]} (get sources resource-id)
            final-output (get output resource-id)]
        (if (and (= :cljs type)
                 (some? final-output)
-                (compiled-this-pass? final-output (get pass-output resource-id)))
+                (compiled-this-pass? final-output pass-token))
          (into acc (or provides (when ns #{ns})))
          acc)))
    #{}
@@ -193,25 +254,25 @@
 
   When no re-frame.ui pass is open (a non-Shadow / plain-JVM finish with no
   scratch) this is a no-op — the prepare-time pre-touch is the sole reconciler.
-  When a pass IS open the prepare-time `:pass-output` provenance snapshot MUST
-  be present; its absence is unobservable provenance and fails loudly rather
-  than silently reconciling against an assumed-empty compile schedule. Pure
-  build-state transform (apart from that guard)."
+  When a pass IS open the prepare-time `:pass-token` provenance MUST be present;
+  its absence is unobservable provenance and fails loudly rather than silently
+  reconciling against an assumed-empty compile schedule. Pure build-state
+  transform (apart from that guard)."
   [build-state]
   (let [scratch (get-in build-state [:compiler-env build/scratch-key])]
     (if-not scratch
       build-state
       (do
-        (when-not (contains? scratch :pass-output)
+        (when-not (contains? scratch :pass-token)
           (throw
            (ex-info
             (str "re-frame.ui compile-finish observed no per-pass compile "
-                 "provenance (missing prepare-time :pass-output snapshot); "
-                 "refusing to reconcile against an assumed-empty compile schedule")
+                 "provenance (missing prepare-time :pass-token); refusing to "
+                 "reconcile against an assumed-empty compile schedule")
             {::error ::missing-pass-provenance
              :recovery :configure-ui-build-hook-once})))
         (let [extra (actually-recompiled-member-nss build-state
-                                                    (:pass-output scratch))]
+                                                    (:pass-token scratch))]
           (if (seq extra)
             (update-in build-state
                        [:compiler-env build/scratch-key :touched]
@@ -420,22 +481,26 @@
     :compile-prepare
     (do
       (validate-ui-cache-blocker! build-state)
-      (let [build-state (reset-cold-ui-consumer-output build-state)]
-        ;; Snapshot the `:output` map Shadow handed us BEFORE any compilation, so
-        ;; `:compile-finish` can identify the sources Shadow actually recompiled
-        ;; this pass by Shadow's own causal compile evidence — a `:cached false`
-        ;; finish output whose `:js` artifact object differs from this snapshot —
-        ;; robust to a later prepare hook mutating a retained output's whole MAP
-        ;; while preserving its nested `:js`, and free of any `:compiled-at`
-        ;; wall-clock comparison so same-/backwards-millisecond recompiles are
-        ;; still caught (rf2-vxgfnd.194, rf2-vxgfnd.255, rf2-vxgfnd.282,
-        ;; rf2-ialoij).
-        (-> (build/prepare-shadow-build build-state
+      (let [build-state (reset-cold-ui-consumer-output build-state)
+            pass-token  (str (java.util.UUID/randomUUID))
+            stamped     (stamp-retained-outputs build-state pass-token)]
+        ;; Stamp an opaque per-pass provenance token onto every retained `:output`
+        ;; map Shadow handed us BEFORE any compilation, and remember it in scratch,
+        ;; so `:compile-finish` can identify the sources Shadow actually
+        ;; (re)compiled this pass: a compiled source's fresh output map LOSES the
+        ;; token, while a later non-scheduling hook's assoc/update-in on a retained
+        ;; output — INCLUDING replacing only `[:output rid :js]` with a fresh
+        ;; equal-byte string — PRESERVES it. Robust to that output-transforming
+        ;; shape (which a raw `:js`-identity test misread as a recompile) and free
+        ;; of any `:compiled-at` wall-clock comparison so same-/backwards-
+        ;; millisecond recompiles are still caught (rf2-v7wqk, rf2-vxgfnd.194,
+        ;; rf2-vxgfnd.255, rf2-vxgfnd.282, rf2-ialoij).
+        (-> (build/prepare-shadow-build stamped
                                         build-id
-                                        (member-nss build-state)
-                                        (recompiled-member-nss build-state))
-            (assoc-in [:compiler-env build/scratch-key :pass-output]
-                      (:output build-state)))))
+                                        (member-nss stamped)
+                                        (recompiled-member-nss stamped))
+            (assoc-in [:compiler-env build/scratch-key :pass-token]
+                      pass-token))))
 
     :compile-finish
     ;; Reconcile against Shadow's final compile schedule, then project. All are

--- a/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
@@ -16,10 +16,16 @@
   "A DISTINCT String instance carrying `s`, modelling Shadow's
   `(.toString StringWriter)`: every real `do-compile-cljs-resource` allocates a
   brand-new `:js` object — never an interned literal — even when the emitted
-  bytes are byte-identical to a prior compile. `identical?` on that object is
-  precisely the causal recompile signal `compiled-this-pass?` keys on, so a test
-  literal (interned, shared across every occurrence) would falsely read as a warm
-  cache hit. Use this for the `:js` of any output that models a fresh compile."
+  bytes are byte-identical to a prior compile. Use this for the `:js` of any
+  output that models a fresh compile.
+
+  NOTE: `:js` object identity is deliberately NOT the recompile signal any more
+  (rf2-v7wqk) — a non-scheduling hook can swap `:js` for a fresh String without
+  scheduling compilation, so a `:js`-identity test misclassifies. Compile
+  membership is now re-frame.ui's per-pass provenance MARKER: Shadow's compile
+  path replaces the whole output MAP (dropping the marker `:compile-prepare`
+  stamped), while an assoc/update-in on a retained output preserves it. `fresh-js`
+  here only makes a modelled compile carry a realistic distinct `:js`."
   ^String [^String s]
   (String. s))
 
@@ -285,21 +291,21 @@
               "evicting the ghost changes the accepted whole-build digest"))))))
 
 (deftest causal-membership-survives-colliding-and-backwards-stamps
-  ;; rf2-vxgfnd.255 / rf2-ialoij: final-schedule membership is decided by Shadow's
-  ;; CAUSAL compile evidence — a `:cached false` finish output whose `:js` artifact
-  ;; is a fresh object — never a `:compiled-at` wall-clock relationship. Shadow
+  ;; rf2-vxgfnd.255 / rf2-ialoij / rf2-v7wqk: final-schedule membership is decided
+  ;; by re-frame.ui's per-pass provenance MARKER — never a `:compiled-at`
+  ;; wall-clock relationship and never Shadow's `:js` object identity. Shadow
   ;; stamps `:compiled-at` with `System/currentTimeMillis`, which can EQUAL or
   ;; DECREASE across genuine compiles (same-ms, clock skew, a non-monotonic clock),
   ;; so any `>`/`>=`/`!=` stamp test misclassifies. In ONE warm pass, under the
   ;; SAME optimizer/compile controls (sequential + parallel):
-  ;;   * app.b is a genuine cache hit whose retained output object (same `:js`) is
-  ;;     unchanged, yet carries the maximal `:compiled-at` — it must stay accepted
-  ;;     and digest-stable;
-  ;;   * app.a is genuinely recompiled (a fresh `:js` object) and removed its final
-  ;;     view, but its stamp went BACKWARDS (Long/MAX_VALUE snapshot -> 1 finish) —
-  ;;     it must still be evicted.
+  ;;   * app.b is a genuine cache hit whose stamped retained output flows through
+  ;;     prepare -> finish unchanged, yet carries the maximal `:compiled-at` — it
+  ;;     must stay accepted and digest-stable;
+  ;;   * app.a is genuinely recompiled (Shadow replaces its whole output map,
+  ;;     dropping the marker) and removed its final view, but its stamp went
+  ;;     BACKWARDS (Long/MAX_VALUE snapshot -> 1 finish) — it must still be evicted.
   ;; A `(> now then)` test reads app.a's backwards stamp as untouched (ghost
-  ;; survives) and would evict the max-stamp app.b; the causal test does neither.
+  ;; survives) and would evict the max-stamp app.b; the marker test does neither.
   (doseq [parallel? [true false]]
     (testing (str (if parallel? "parallel" "sequential") " compilation")
       (let [good (-> (two-source-state :collide parallel?)
@@ -311,9 +317,10 @@
         (is (= {:app/a-view ["tfa-1" "hsa-1"] :app/b-view ["tfb-1" "hsb-1"]}
                (build/accepted-aggregate build/views good))
             "the accepted build declares both sources' views")
-        ;; The EXACT same retained object stands in for app.b across prepare and
-        ;; finish (a true cache hit at the maximal stamp). app.a is replaced with a
-        ;; fresh output object whose stamp is LOWER than its snapshot.
+        ;; app.b's stamped retained output flows through prepare -> finish (a true
+        ;; cache hit at the maximal stamp): it is NOT re-set at finish, so it keeps
+        ;; the marker prepare stamped. app.a is replaced with a fresh output map
+        ;; (no marker) whose stamp is LOWER than its snapshot.
         (let [warm-b-output {:resource-id app-b-rid :js (fresh-js "app.b = {};")
                              :compiled-at Long/MAX_VALUE :cached false}
               warm-input (-> good
@@ -330,7 +337,6 @@
                                      {:resource-id app-a-rid
                                       :js (fresh-js "app.a = {};")
                                       :compiled-at 1 :cached false})
-                           (assoc-in [:output app-b-rid] warm-b-output)
                            finish)
               views-after (build/accepted-aggregate build/views finished)]
           (is (not (contains?
@@ -348,20 +354,19 @@
               "the genuinely recompiled zero-declaration source is evicted despite its backwards stamp"))))))
 
 (deftest metadata-only-output-mutation-is-not-a-recompile
-  ;; rf2-vxgfnd.282 / rf2-ialoij: a fresh output MAP is NOT compile provenance.
-  ;; Shadow deep-merges build-local hooks after the inherited re-frame.ui hook, so
-  ;; a later :compile-prepare hook can annotate or normalize a source's STILL-VALID
-  ;; retained output with assoc/update-in — producing a NEW output MAP (but, assoc
-  ;; preserving nested values, the SAME `:js` object) WITHOUT scheduling any
-  ;; compilation. Under raw whole-output `identical?` provenance re-frame.ui
-  ;; misread that fresh map as a recompile, pre-touched the source, saw no registry
-  ;; macro, and silently EVICTED its accepted view. Shadow's causal fresh-compile
-  ;; evidence is the fresh `:js` artifact object its compile path allocates: a
-  ;; metadata-only mutation preserves the SAME `:js` object, a real recompile
-  ;; allocates a new one. Membership keys on `:cached false` plus that `:js` object,
-  ;; NOT the whole-map reference and NOT the `:compiled-at` stamp — so the survival
-  ;; and eviction arms below are distinguished with the stamp held EQUAL. Both arms
-  ;; run in sequential and parallel compile modes.
+  ;; rf2-vxgfnd.282 / rf2-ialoij / rf2-v7wqk: a fresh output MAP is NOT compile
+  ;; provenance. Shadow deep-merges build-local hooks after the inherited
+  ;; re-frame.ui hook, so a later :compile-prepare hook can annotate or normalize a
+  ;; source's STILL-VALID retained output with assoc/update-in — producing a NEW
+  ;; output MAP WITHOUT scheduling any compilation. Under raw whole-output
+  ;; `identical?` provenance re-frame.ui misread that fresh map as a recompile,
+  ;; pre-touched the source, saw no registry macro, and silently EVICTED its
+  ;; accepted view. The per-pass MARKER is preserved by any assoc/update-in on a
+  ;; retained output (a real recompile instead REPLACES the whole map, dropping
+  ;; it), so a metadata annotation survives and a real recompile evicts — the two
+  ;; arms below are distinguished with the `:compiled-at` stamp held EQUAL and,
+  ;; deliberately, WITHOUT relying on `:js` identity. Both arms run in sequential
+  ;; and parallel compile modes.
   (doseq [parallel? [true false]]
     (let [mode (if parallel? "parallel" "sequential")
           good (-> (two-source-state :meta parallel?)
@@ -389,18 +394,23 @@
 
       (testing (str mode " — later hook only annotates app.b's retained output")
         ;; No source is scheduled this warm pass. A later build-local prepare hook
-        ;; replaces app.b's still-valid output with a NEW map that ONLY adds
-        ;; metadata; assoc preserves the SAME `:js` object, so Shadow skips app.b.
-        ;; app.b must survive byte-identical and the digest must not move.
-        (let [prepared  (prepare warm-input)
-              mutated-b (assoc warm-b :shadow.build/annotation :normalized)
-              finished  (-> prepared
-                            (assoc-in [:output app-b-rid] mutated-b)
-                            finish)]
-          (is (not (identical? mutated-b warm-b))
+        ;; receives the build-state AFTER re-frame.ui's prepare (its output already
+        ;; marker-stamped) and replaces app.b's still-valid output with a NEW map
+        ;; that ONLY adds metadata; assoc preserves the marker, so Shadow skips
+        ;; app.b. app.b must survive byte-identical and the digest must not move.
+        (let [prepared    (prepare warm-input)
+              prepared-b  (get-in prepared [:output app-b-rid])
+              mutated-b   (assoc prepared-b :shadow.build/annotation :normalized)
+              finished    (-> prepared
+                              (assoc-in [:output app-b-rid] mutated-b)
+                              finish)]
+          (is (not (identical? mutated-b prepared-b))
               "the later hook produced a fresh output MAP for app.b")
+          (is (= (get prepared-b :re-frame.ui.compiler.build-hook/pass-marker)
+                 (get mutated-b :re-frame.ui.compiler.build-hook/pass-marker))
+              "but the metadata-only mutation preserved re-frame.ui's per-pass marker")
           (is (identical? (:js warm-b) (:js mutated-b))
-              "but the metadata-only mutation preserved Shadow's `:js` artifact object")
+              "and (incidentally) still the SAME `:js` object — but that is no longer the signal")
           (is (not (contains?
                     (get-in prepared [:compiler-env build/scratch-key :touched])
                     'app.b))
@@ -435,22 +445,125 @@
               "evicting the recompiled ghost changes the whole-build digest"))))))
 
 (deftest missing-per-pass-provenance-fails-loud-not-empty-schedule
-  ;; rf2-vxgfnd.255: an open pass whose prepare-time provenance snapshot is
-  ;; unobservable must fail loudly at finish rather than silently reconcile
+  ;; rf2-vxgfnd.255 / rf2-v7wqk: an open pass whose prepare-time provenance token
+  ;; is unobservable must fail loudly at finish rather than silently reconcile
   ;; against an assumed-empty compile schedule (which would leak ghost rows).
   (let [prepared (-> (two-source-state :no-prov false)
                      prepare
                      (declare 'app.a :app/a-view ["tfa-1" "hsa-1"])
                      (declare 'app.b :app/b-view ["tfb-1" "hsb-1"]))
         blinded (update-in prepared [:compiler-env build/scratch-key]
-                           dissoc :pass-output)
+                           dissoc :pass-token)
         ex (try (finish blinded) nil
                 (catch clojure.lang.ExceptionInfo e e))]
-    (is (some? (get-in prepared [:compiler-env build/scratch-key :pass-output]))
-        "an ordinary open pass records the provenance snapshot")
-    (is (some? ex) "finish with open scratch but no :pass-output must throw")
+    (is (some? (get-in prepared [:compiler-env build/scratch-key :pass-token]))
+        "an ordinary open pass records the per-pass provenance token")
+    (is (some? ex) "finish with open scratch but no :pass-token must throw")
     (is (= :re-frame.ui.compiler.build-hook/missing-pass-provenance
            (:re-frame.ui.compiler.build-hook/error (ex-data ex))))))
+
+(deftest non-scheduling-js-transform-is-not-a-recompile
+  ;; rf2-v7wqk — the P1 the per-pass marker fixes (red-before / green-after).
+  ;; `:cached` is STICKY on retained outputs, so a later non-scheduling
+  ;; :compile-prepare hook that replaces ONLY `[:output rid :js]` with a fresh
+  ;; String (equal bytes OR changed bytes) — scheduling NO compilation — leaves
+  ;; `:cached false` and a DIFFERENT `:js` object. The pre-fix `:cached false` +
+  ;; `:js`-identity test misread that as a recompile, pre-touched app.b, saw no
+  ;; registry macro, and EVICTED its valid accepted view — changing the whole-
+  ;; build digest. assoc preserves re-frame.ui's per-pass marker, so the marker
+  ;; test sees no compilation: the view and digest are retained. The metadata test
+  ;; above cannot catch this ordinary output-transforming shape because it
+  ;; deliberately preserves the nested `:js` object. Both equal-byte and
+  ;; changed-byte transforms; both compile schedules.
+  (doseq [parallel? [true false]
+          [byte-label new-js] [[:equal-bytes "app.b = {};"]
+                               [:changed-bytes "app.b = {/* transformed */};"]]]
+    (testing (str (if parallel? "parallel" "sequential") " / " (name byte-label))
+      (let [good (-> (two-source-state (keyword "jsx" (name byte-label)) parallel?)
+                     prepare
+                     (declare 'app.a :app/a-view ["tfa-1" "hsa-1"])
+                     (declare 'app.b :app/b-view ["tfb-1" "hsb-1"])
+                     finish)
+            digest-before (build/accepted-build-digest good)
+            views-before  (build/accepted-aggregate build/views good)
+            warm-a {:resource-id app-a-rid :js (fresh-js "app.a = {};")
+                    :compiled-at 1000 :cached false}
+            warm-b {:resource-id app-b-rid :js (fresh-js "app.b = {};")
+                    :compiled-at 1000 :cached false}
+            warm-input (-> good
+                           (assoc-in [:output carrier-rid :js]
+                                     build-hook/digest-sentinel)
+                           (assoc-in [:output app-a-rid] warm-a)
+                           (assoc-in [:output app-b-rid] warm-b))
+            prepared (prepare warm-input)
+            ;; A later non-scheduling hook swaps ONLY app.b's :js for a fresh
+            ;; String — no compilation. :cached stays false (sticky). assoc keeps
+            ;; every other key, including re-frame.ui's per-pass marker.
+            transformed-b (assoc (get-in prepared [:output app-b-rid])
+                                 :js (fresh-js new-js))
+            finished (-> prepared
+                         (assoc-in [:output app-b-rid] transformed-b)
+                         finish)]
+        (is (= {:app/a-view ["tfa-1" "hsa-1"] :app/b-view ["tfb-1" "hsb-1"]}
+               views-before)
+            "the accepted build declares both sources' views")
+        (is (false? (:cached transformed-b))
+            "a non-scheduling :js transform leaves :cached false (sticky)")
+        (is (not (identical? (:js transformed-b) (:js warm-b)))
+            "and yields a DIFFERENT :js object — the shape a :js-identity test misreads")
+        (is (not (contains?
+                  (get-in prepared [:compiler-env build/scratch-key :touched])
+                  'app.b))
+            "re-frame.ui does not pre-touch an output-present source at prepare")
+        (is (= views-before (build/accepted-aggregate build/views finished))
+            "an output :js transform is NOT a recompile; both accepted views survive")
+        (is (contains? (build/accepted-aggregate build/views finished) :app/b-view)
+            "app.b's accepted view is retained, not evicted as a ghost")
+        (is (= digest-before (build/accepted-build-digest finished))
+            "the whole-build digest is unchanged")))))
+
+(deftest ambiguous-per-source-provenance-fails-loud
+  ;; rf2-v7wqk / rf2-ialoij: per-source provenance that is MISSING/malformed (an
+  ;; unmarked output with no usable `:cached` flag) or CONTRADICTORY (an output
+  ;; carrying a STALE marker that is not this pass's token) must fail with a typed
+  ;; compiler error BEFORE any accepted candidate is published — never silently
+  ;; classified as untouched.
+  (let [marker-key :re-frame.ui.compiler.build-hook/pass-marker
+        warm-b {:resource-id app-b-rid :js (fresh-js "app.b = {};")
+                :compiled-at 1000 :cached false}
+        open (fn [build-id]
+               (let [good (-> (two-source-state build-id false)
+                              prepare
+                              (declare 'app.a :app/a-view ["tfa-1" "hsa-1"])
+                              (declare 'app.b :app/b-view ["tfb-1" "hsb-1"])
+                              finish)]
+                 (-> good
+                     (assoc-in [:output carrier-rid :js] build-hook/digest-sentinel)
+                     (assoc-in [:output app-a-rid]
+                               {:resource-id app-a-rid :js (fresh-js "app.a = {};")
+                                :compiled-at 1000 :cached false})
+                     (assoc-in [:output app-b-rid] warm-b)
+                     prepare)))
+        finish-ex (fn [prepared bad-b]
+                    (try (-> prepared (assoc-in [:output app-b-rid] bad-b) finish)
+                         nil
+                         (catch clojure.lang.ExceptionInfo e e)))]
+    (testing "unmarked output with no usable :cached flag"
+      (let [prepared (open :ambig-unmarked)
+            ex (finish-ex prepared {:resource-id app-b-rid :js (fresh-js "x")})]
+        (is (some? ex) "an unmarked output with no :cached must throw")
+        (is (= :re-frame.ui.compiler.build-hook/ambiguous-compile-evidence
+               (:re-frame.ui.compiler.build-hook/error (ex-data ex))))
+        (is (= :unmarked-output-missing-cached-flag (:reason (ex-data ex))))))
+    (testing "output carrying a stale (wrong-token) marker"
+      (let [prepared (open :ambig-stale)
+            stale-b (assoc (get-in prepared [:output app-b-rid])
+                           marker-key "not-this-pass-token")
+            ex (finish-ex prepared stale-b)]
+        (is (some? ex) "a stale provenance marker must throw")
+        (is (= :re-frame.ui.compiler.build-hook/ambiguous-compile-evidence
+               (:re-frame.ui.compiler.build-hook/error (ex-data ex))))
+        (is (= :stale-provenance-marker (:reason (ex-data ex))))))))
 
 (deftest interleaved-build-values-carry-isolated-digests
   (let [a (-> (shadow-state :a build-hook/digest-sentinel)

--- a/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/hook.clj
+++ b/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/hook.clj
@@ -17,13 +17,13 @@
       re-frame.ui already observed the schedule) and rewrite its in-memory source
       to a VIEWLESS namespace (its final ui/defview removed). re-frame.ui saw
       app-a as an output-present cache hit and did NOT pre-touch it; only
-      `reconcile-final-schedule` at :compile-finish — reading Shadow's causal
-      per-source compile evidence (app-a's fresh, `:cached false` recompiled
-      output carries a new `:js` artifact object) — can evict its now-absent
-      accepted view.
+      `reconcile-final-schedule` at :compile-finish — reading re-frame.ui's OWN
+      per-pass provenance marker (app-a's fresh compiled output map LACKS the
+      token :compile-prepare stamped onto retained outputs) — can evict its
+      now-absent accepted view.
 
     blind-provenance — model a hook that destroys the per-pass compile-schedule
-      evidence: drop re-frame.ui's :pass-output snapshot from the open scratch.
+      evidence: drop re-frame.ui's :pass-token from the open scratch.
       `reconcile-final-schedule` must then FAIL LOUD at :compile-finish rather
       than silently reconcile against an assumed-empty schedule.
 
@@ -88,9 +88,9 @@
                            ";; final-schedule fixture: viewless forced recompile\n")))
 
         ;; A later hook that destroys the per-pass provenance re-frame.ui needs to
-        ;; reconcile: drop the :pass-output snapshot from the open scratch.
+        ;; reconcile: drop the :pass-token from the open scratch.
         (and blind? scratch)
-        (update-in [:compiler-env build/scratch-key] dissoc :pass-output)))
+        (update-in [:compiler-env build/scratch-key] dissoc :pass-token)))
 
     :compile-finish
     (let [snap  (build/accepted-snapshot build-state)


### PR DESCRIPTION
## What / why (rf2-v7wqk, P1 correctness)

`re-frame.ui.compiler.build-hook/compiled-this-pass?` decided Shadow compile
membership from `:cached false` **plus a non-identical `:js` object**
(build_hook.clj:149-150 on origin/main). But `:cached` is **sticky** on retained
outputs, and Shadow deep-merges build-local hooks after `:build-defaults`, so a
later **non-scheduling** `:compile-prepare` hook can transform a retained output's
JS — replacing only `[:output rid :js]` with a fresh String (even byte-identical) —
**without scheduling any compilation**. That leaves `:cached false` with a fresh
`:js` object, so `:compile-finish` misclassified the untouched source as
recompiled, pre-touched it, saw no registry macro, and **evicted its valid
accepted view** — changing the whole-build digest on a pass that compiled nothing.

The pre-existing metadata-only test could not catch this: it deliberately
preserves the nested `:js` object, so it never exercises the ordinary
output-transforming shape (`same-bytes=true, same-object=false`).

## The seam and the fix

- **Buggy seam:** `compiled-this-pass?` — `(and (false? (:cached final-output)) (not (identical? (:js final-output) (:js snapshot-output))))`.
- **Fix — per-pass provenance marker.** At `:compile-prepare`, `stamp-retained-outputs`
  stamps an opaque per-pass token (`::pass-marker`, a fresh UUID stored in scratch
  as `:pass-token`) onto every retained `:output` map. Shadow's compile path
  **replaces** a (re)compiled source's whole output map, dropping the marker; a
  non-scheduling `assoc`/`update-in` on a retained output (including a bare `:js`
  swap) **preserves** it. Membership now reads the marker, not `:cached`/`:js`
  identity; `:cached true` still distinguishes a disk-cache load from a fresh
  compile. Missing / malformed / contradictory per-source provenance fails loud
  (`::ambiguous-compile-evidence`) **before publication**, never silently
  classified as untouched. `:pass-output` snapshot → `:pass-token`.
- Scope: `build_hook.clj` only (the compile-membership detection). No touch to
  `analyze.cljc` / `emit_cljs.cljc` (rf2-edpam's surface). G-13 HMR-slot elision
  not regressed (marker is a JVM output-map key; never enters any bundle).

## Red-before / green-after

New JVM arm `non-scheduling-js-transform-is-not-a-recompile` (both `equal-bytes`
and `changed-bytes`; parallel + sequential):

- **Red before** (origin/main `build_hook.clj`, my test): **12 failures** — the
  `:js` transform is misread as a recompile, app.b's view `{a,b}`→`{a}` is evicted,
  digest moves `bd1-365a7385ed4a5aa2`→`bd1-0043927395c49e7a`.
- **Green after** (this fix): 28 assertions, 0 failures — the marker sees no
  compilation, the view and digest are retained.
- **Genuine-recompile control** still evicts: `later-prepare-hook-forced-recompile-evicts-removed-view`,
  `causal-membership-survives-colliding-and-backwards-stamps`, and the
  companion arm all keep evicting a real (map-replacing) recompile — including
  the real-Shadow FORCED-EVICT pass (app-a evicted via reconcile, app-b
  byte-identical).
- New `ambiguous-per-source-provenance-fails-loud` covers the fail-loud shapes.

## Quality gates

All run in the foreground, unpiped:

- `implementation/ui` JVM `clojure -M:test`: **763 tests, 14194 assertions, 0 failures, 0 errors**.
- `npm run test:cljs`: **9876 tests, 48548 assertions, 0 failures, 0 errors**.
- `npm run test:ui-final-schedule` (real-Shadow build-hook gate): **PASS (parallel + sequential)** — FORCED-EVICT via marker + FAIL-LOUD on dropped `:pass-token`.
- `npm run test:ui-digest-carrier` (digest-carrier lifecycle + final-schedule): **PASS, exit 0** — fail-loud diagnostic now reads `missing prepare-time :pass-token`.
- Red-before/green-after proven as above.
