### PR TITLE
docs(api): fix clear-http-interceptor stale frame-first signature (rf2-hf4ts)

### DIFF
--- a/docs/api/re-frame.core.md
+++ b/docs/api/re-frame.core.md
@@ -1520,9 +1520,9 @@ Managed HTTP is an optional capability: one fx-id (`[:rf.http/managed …]`), on
 - **Signature**:
   ```clojure
   (clear-http-interceptor id)
-  (clear-http-interceptor frame id)
+  (clear-http-interceptor id {:frame target})
   ```
-- Unregister an HTTP interceptor by id (single-arity resolves the frame from carried scope; two-arity names it). Full contract in [re-frame.http.md](re-frame.http.md).
+- Unregister an HTTP interceptor by id (single-arity resolves the frame from carried scope; the opts form names it explicitly via a trailing `{:frame target}` map, mirroring `reg-http-interceptor`). The frame-first `(frame id)` spelling is internal plumbing, not a public call. Full contract in [re-frame.http.md](re-frame.http.md).
 
 #### `with-managed-request-stubs`
 


### PR DESCRIPTION
## Summary

The `re-frame.core` API landing page (`docs/api/re-frame.core.md`) advertised the two-arity public signature of `clear-http-interceptor` as `(clear-http-interceptor frame id)` — a stale **frame-first** positional spelling that no longer matches the shipped runtime and contradicted the feature API page.

The shipped public contract (confirmed in `implementation/core/src/re_frame/core_http.cljc:86-105`) is:

```clojure
([id]          :delegate)   ; single-arity — resolves frame from carried scope
([id-or-frame b] :delegate) ; two-arity — SHAPE-DISCRIMINATED (rf2-f28bno)
```

The public two-arity form is `(clear-http-interceptor id {:frame target})` (opts map). The frame-first `(frame id)` shape survives **only** as internal plumbing behind the shape discrimination — it is not a public call.

This reconciles the core landing page to the shipped signature, matching the already-correct `core_http.cljc` docstring, Spec 014, and `docs/api/re-frame.http.md:243-255`.

## Change

`docs/api/re-frame.core.md` (clear-http-interceptor entry, ~line 1523):

- before: `(clear-http-interceptor frame id)`
- after: `(clear-http-interceptor id {:frame target})` + prose clarifying the frame-first spelling is internal plumbing, not a public call.

**No runtime change** — docs-only. The `core_http.cljc` docstring was already correct (no edit needed); `docs/api/re-frame.http.md` was already correct (no edit needed).

## Quality gates

- `python -m mkdocs build --strict` → exit 0 (docs built, no new broken links)
- `clojure -M -m re-frame.api-manifest.gen --check` → OK: `spec/api-manifest.edn` in sync (514 public vars)
- `clojure -M -m re-frame.api-manifest.doc-api-check` → OK: `docs/api/` projection in sync (313 references), page+member coverage in sync (197 eligible vars)

Closes rf2-hf4ts.
