### PR TITLE
fix(trace): remove the fanout-monitor ↔ frame drain-lock deadlock (rf2-jl75r)

### DIFF
--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -750,13 +750,49 @@
 ;; first.
 ;;
 ;; A single process-global monitor (`fanout-monitor`) serializes each OUTERMOST
-;; fan-out — its whole `drive-fanout!` (outer advance + reentrant deliveries)
-;; included. Concurrent emits therefore linearize on monitor-acquisition order:
-;; the second thread cannot begin its fan-out until the first thread's outermost
-;; drive has fully drained. No listener callback ever overlaps itself, records
-;; reach each listener in a single defined order, and an emit still returns only
-;; after its record's callback has run (the monitor is held for the whole
-;; synchronous drive and released before `emit!` returns).
+;; EXTERNAL/clean fan-out — its whole `drive-fanout!` (outer advance + reentrant
+;; deliveries) included. Concurrent clean emits therefore linearize on
+;; monitor-acquisition order: the second thread cannot begin its fan-out until the
+;; first thread's outermost drive has fully drained. No listener callback ever
+;; overlaps itself, records reach each listener in a single defined order, and an
+;; emit still returns only after its record's callback has run (the monitor is
+;; held for the whole synchronous drive and released before `emit!` returns).
+;;
+;; ---- the frame-drain-emit deadlock seam (rf2-jl75r) -----------------------
+;;
+;; Holding `fanout-monitor` across arbitrary listener bodies is NOT safe for an
+;; emit issued while the emitting thread holds a frame's `:drain-lock`. Public
+;; trace listeners are allowed to call `dispatch-sync`, which forms a hard AB-BA
+;; cycle:
+;;   - T1 acquires `fanout-monitor` (a clean emit), enters a listener, calls
+;;     `dispatch-sync` into frame F, and spin-waits on F's `:drain-lock`;
+;;   - T2 already holds F's `:drain-lock` through `run-one-pass!`, reaches an
+;;     ordinary in-run emit (e.g. `:rf.event/run-start`), and would block
+;;     acquiring `fanout-monitor`.
+;; Neither can progress. `drain-block!`'s bounded-wait assumption is false because
+;; the active drainer (T2) is itself waiting on the caller (T1).
+;;
+;; The fix keeps the whole synchronous, ordered, serialized fan-out for clean
+;; emits but takes the monitor OUT of the cycle: a FRAME-DRAIN emit
+;; (`frame-drain-emit?` — one that ROUTES TO A FRAME the way `push-to-ring!` does,
+;; or a retentionless structural terminal fact) NEVER acquires the monitor. It
+;; drives its fan-out inline (exactly as CLJS always does), so the "drain-lock
+;; holder waits on the monitor" edge is removed and no cycle can form. A thread
+;; that holds a `:drain-lock` only ever emits frame-routed emits, so it never
+;; blocks on the monitor; a thread holding the monitor emitted a frameless
+;; external `emit!` and holds no `:drain-lock`, so nothing waits on it through one.
+;; Frame ROUTABILITY (not merely a `:rf.trace/dispatch-id`) is the load-bearing
+;; discriminator: the epoch cascade trailers (`:rf.epoch/snapshotted` /
+;; `:rf.epoch/outcome`) fire AFTER the buffer is harvested, `outside any cascade`
+;; (nil dispatch-id), yet still on the drainer thread holding the `:drain-lock` —
+;; a dispatch-id-only test misclassifies them and re-opens the deadlock, so the
+;; predicate keys on the frame the emit routes to. Same-thread reentrant delivery
+;; of the drain's own nested emits is unaffected — those take the `*fanout-ctx*`
+;; append+drive branch, never the monitor. The remaining relaxation is bounded and
+;; JVM-only: a frame-scoped clean emit, and two genuinely concurrent frame drains
+;; (never a thing on the single-threaded CLJS target), may drive inline and
+;; overlap a listener; frameless concurrent clean emits — the case rf2-uw7hg's
+;; suite exercises — still serialize on the monitor, unchanged.
 ;;
 ;; Same-thread reentrancy does NOT re-acquire the monitor: a nested emit sees
 ;; `*fanout-ctx*` already bound and takes the append+drive branch below, so it
@@ -778,13 +814,57 @@
 
 #?(:clj
    (def ^:private ^Object fanout-monitor
-     "Process-global JVM monitor serializing every OUTERMOST trace-listener
-     fan-out across concurrent emits (rf2-uw7hg), so no registered listener
-     callback is ever invoked on two threads at once and records reach each
-     listener in one defined order. Held for the whole synchronous drive.
-     Reentrant same-thread emits never acquire it (they advance the bound
-     `*fanout-ctx*` schedule). CLJS is single-threaded and has no counterpart."
+     "Process-global JVM monitor serializing every EXTERNAL/clean OUTERMOST
+     trace-listener fan-out across concurrent emits (rf2-uw7hg), so no registered
+     listener callback is ever invoked on two threads at once and records reach
+     each listener in one defined order. Held for the whole synchronous drive of
+     such an emit. A frame-drain emit (`frame-drain-emit?`) NEVER acquires it —
+     see the deadlock note below — and reentrant same-thread emits never acquire
+     it (they advance the bound `*fanout-ctx*` schedule). CLJS is single-threaded
+     and has no counterpart."
      (Object.)))
+
+#?(:clj
+   (defn- frame-drain-emit?
+     "True when this outermost emit originates from INSIDE a frame's runtime
+     activity — i.e. the emitting thread may hold that frame's `:drain-lock`. Such
+     an emit MUST NOT block acquiring `fanout-monitor`: a listener already holding
+     the monitor is allowed to `dispatch-sync` into that same frame and would spin
+     on its `:drain-lock` — a hard AB-BA cycle (rf2-jl75r, `deliver-to-tooling!`).
+     It drives its fan-out INLINE instead, so no process-global lock is ever held
+     by, or awaited by, a frame-drain emit.
+
+     The discriminator is FRAME ROUTABILITY, computed exactly as `push-to-ring!`
+     routes an emit to a per-frame ring: an emit that resolves to a frame — via an
+     explicit `[:tags :frame]`, a top-level `:frame`, or the in-flight run's
+     `frame/*current-frame*` (the late-bound `:frame/current-frame-id` hook) —
+     originates from within that frame's drain / settle / lifecycle activity. This
+     is the ONLY signal that covers EVERY drain emit, including ones the drain's
+     `:rf.trace/dispatch-id` scope does not reach: the epoch cascade trailers
+     (`:rf.epoch/snapshotted` / `:rf.epoch/outcome`) fire AFTER the buffer is
+     harvested, `outside any cascade` (nil dispatch-id), yet still on the drainer
+     thread holding the `:drain-lock` — a dispatch-id-only test would misclassify
+     them and re-open the deadlock. A retentionless structural terminal fact
+     (`retain?` false: `:rf.frame/destroyed` / `:rf.frame/drain-interrupted`,
+     emitted while `destroy-frame!` holds the frame's drain serialization) is
+     included for the same reason even if it were ever frameless.
+
+     An external/clean emit — a tool or REPL `emit!` with NO frame in scope (no
+     `:frame` tag, no ambient `*current-frame*`), the shape rf2-uw7hg's suite
+     exercises — resolves no frame and returns false, so concurrent clean emits
+     still serialize on the monitor (no listener callback overlaps itself). The
+     residual relaxation is bounded and JVM-only: a frame-scoped clean emit, and
+     two genuinely concurrent frame drains (never a thing on the single-threaded
+     CLJS target), may drive inline and overlap a listener.
+
+     JVM-only: the `:cljs` outermost arm has no monitor, so it needs no predicate."
+     [event retain?]
+     (or (not retain?)
+         (some? (get-in event [:tags :frame]))
+         (some? (:frame event))
+         (some? (get-in event [:tags :rf.trace/dispatch-id]))
+         (when-let [current-frame (late-bind/get-fn-cached :frame/current-frame-id)]
+           (some? (current-frame))))))
 
 (defn- drive-fanout!
   "Drive the shared fan-out schedule `ctx` to completion: deliver every queued
@@ -828,8 +908,11 @@
 (defn- run-outermost-fanout!
   "Seed a fresh fan-out schedule for `event`, bind it as `*fanout-ctx*` so
   reentrant emits from listener bodies advance the SAME schedule, and drive it to
-  completion. On the JVM the caller runs this under `fanout-monitor` so concurrent
-  emits serialize (rf2-uw7hg); the binding + drive are the whole critical section."
+  completion. On the JVM a CLEAN outermost emit runs this under `fanout-monitor`
+  so concurrent emits serialize (rf2-uw7hg); a frame-drain emit runs it inline,
+  off the monitor, to break the drain-lock↔monitor cycle (rf2-jl75r — see the
+  `deliver-to-tooling!` outermost branch). Either way the binding + drive are the
+  whole critical section."
   [event continue?]
   (let [ctx {:q       (volatile! [[event continue?]])
              :head    (volatile! 0)
@@ -882,12 +965,29 @@
      (do (vswap! (:q ctx) conj [event continue?])
          (drive-fanout! ctx)
          nil)
-     ;; Outermost fan-out. On the JVM `fanout-monitor` serializes it across
-     ;; concurrent emits (rf2-uw7hg) so no listener callback overlaps itself and
-     ;; records reach each listener in monitor-acquisition order; the monitor is
-     ;; held for the whole synchronous drive. CLJS is single-threaded, so it runs
-     ;; inline with no monitor.
-     #?(:clj  (locking fanout-monitor (run-outermost-fanout! event continue?))
+     ;; Outermost fan-out.
+     ;;
+     ;; A FRAME-DRAIN emit (`frame-drain-emit?`: one that ROUTES TO A FRAME the way
+     ;; `push-to-ring!` does, or a retentionless structural terminal fact) runs on
+     ;; a thread that may hold a frame's `:drain-lock`. It MUST NOT block acquiring
+     ;; `fanout-monitor`: a listener already holding the monitor is free to
+     ;; `dispatch-sync` into that same frame and spin on its `:drain-lock`, closing
+     ;; a hard AB-BA cycle (rf2-jl75r). Such an emit drives its fan-out inline —
+     ;; exactly as the single-threaded CLJS host always does — so no process-global
+     ;; lock is ever held by, or awaited by, a frame-drain emit. This is the "no
+     ;; fan-out lock across arbitrary listener code that may dispatch-sync into the
+     ;; draining frame" seam.
+     ;;
+     ;; An EXTERNAL/clean emit (a tool or REPL `emit!` with NO frame in scope) still
+     ;; serializes on `fanout-monitor` across concurrent emits (rf2-uw7hg) so no
+     ;; listener callback overlaps itself and records reach each listener in
+     ;; monitor-acquisition order — the monitor is held for that whole drive. Such
+     ;; a thread holds no `:drain-lock`, so nothing waits on it through one; the
+     ;; drain-lock↔monitor cycle cannot form. CLJS is single-threaded and runs
+     ;; every outermost emit inline with no monitor.
+     #?(:clj  (if (frame-drain-emit? event retain?)
+                (run-outermost-fanout! event continue?)
+                (locking fanout-monitor (run-outermost-fanout! event continue?)))
         :cljs (run-outermost-fanout! event continue?)))))
 
 (late-bind/set-fn! :trace.tooling/deliver! deliver-to-tooling!)

--- a/implementation/core/test/re_frame/trace_listener_drain_deadlock_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_drain_deadlock_test.clj
@@ -1,0 +1,153 @@
+(ns re-frame.trace-listener-drain-deadlock-test
+  "rf2-jl75r — the JVM trace `fanout-monitor` must NOT be held (or awaited) across
+  a frame-drain emit. Public trace listeners are allowed to call `dispatch-sync`,
+  and the drain path emits ordinary traces (`:rf.event/run-start`, …) while
+  holding a frame's `:drain-lock`. Before the fix these two facts closed a hard
+  AB-BA deadlock (`re-frame.trace.tooling/deliver-to-tooling!`):
+
+    - **T1** does a clean `emit!`, acquires `fanout-monitor`, enters a listener
+      that calls `dispatch-sync` into frame F, and spin-waits on F's `:drain-lock`
+      (`re-frame.router/drain-block!`).
+    - **the drainer** (here the JVM async-drain executor thread) already holds F's
+      `:drain-lock` through `run-one-pass!`, reaches an ordinary in-run
+      `:rf.event/run-start` emit, and blocks acquiring `fanout-monitor`.
+
+  Neither can progress: `drain-block!`'s bounded-wait assumption is false because
+  the active drainer is itself waiting on the caller (T1).
+
+  Why an ASYNC drain drives the drainer side: a `dispatch-sync` seeds
+  `:in-sync-drain? true` on the frame router, which makes a concurrent
+  cross-thread `dispatch-sync` to that same frame a rejected nested-sync — it
+  never reaches `drain-block!`, so it never spins. The genuine cycle needs the
+  drainer holding the lock through the ASYNC path (`drain-try!` /
+  `re-frame.interop/next-tick`'s single-thread executor), where `:in-sync-drain?`
+  is false and T1's listener `dispatch-sync` really does spin on the lock.
+
+  The fix keeps the whole synchronous, ordered, serialized clean-emit fan-out
+  (rf2-uw7hg) but takes the monitor OUT of the cycle: a frame-drain emit
+  (`frame-drain-emit?`) never acquires the monitor — it drives its fan-out inline,
+  exactly as the single-threaded CLJS host always does. This suite is the
+  deterministic barrier/latch proof that the exact AB-BA interleaving now
+  completes within a bounded timeout and the listener-dispatched event settles
+  EXACTLY once.
+
+  JVM-only (`.clj`): CLJS is single-threaded, has no monitor, and cannot race two
+  drains — the deadlock cannot manifest there."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            ;; Load-bearing require (rf2-jl75r): with the epoch artefact on the
+            ;; classpath the per-event settle emits the cascade trailers
+            ;; (`:rf.epoch/snapshotted` / `:rf.epoch/outcome`) `outside any cascade`
+            ;; — nil `:rf.trace/dispatch-id` — yet STILL on the drainer thread
+            ;; holding the `:drain-lock`. That is the exact emit a dispatch-id-only
+            ;; frame-drain test misclassifies (re-opening the deadlock), so the
+            ;; suite must load epoch to exercise the frame-routability discriminator
+            ;; rather than only the dispatch-id fast path. The FULL JVM suite always
+            ;; loads epoch; this require makes the guard hold in isolation too.
+            [re-frame.epoch]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace :as trace])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; Loop the deterministic proof so a green run is determinism, not a lucky
+;; interleaving. Env-overridable for a heavier local soak.
+(def ^:private iters
+  (or (some-> (System/getenv "RF2_JL75R_ITERS") Long/parseLong)
+      25))
+
+;; Bounded waits: a correct run completes in milliseconds. A deadlocked run
+;; leaves the threads alive forever, so the timeout is what converts the hang
+;; into a red assertion instead of hanging the whole suite.
+(def ^:private join-timeout-ms 10000)
+(def ^:private latch-timeout-s 10)
+
+(deftest fanout-monitor-drain-lock-ab-ba-does-not-deadlock
+  (testing (str "T1 (fanout-monitor -> listener -> dispatch-sync F) against the "
+                "async drainer (F.:drain-lock -> run-start emit) completes "
+                "bounded and the dispatched event settles exactly once ("
+                iters " iterations)")
+    (dotimes [iter iters]
+      (let [t1-event-runs  (atom 0)
+            drain-first    (atom 0)
+            drain-second   (atom 0)
+            l-fired?       (atom false)
+            ;; The drainer signals it is inside the drain, holding F's drain-lock.
+            drainer-in     (CountDownLatch. 1)
+            ;; T1's listener (holding fanout-monitor) signals the drainer to
+            ;; proceed to its next in-run emit, which pre-fix blocks acquiring
+            ;; that same monitor.
+            drainer-go     (CountDownLatch. 1)]
+
+        ;; --- handlers, re-registered each iter so they close over this iter's
+        ;; latches/counters. All target the fixture-ensured :rf/default frame.
+        (rf/reg-event :jl75r/drain-first
+          (fn [{:keys [db]} _]
+            (swap! drain-first inc)
+            ;; This handler runs on the async-drain executor thread, INSIDE
+            ;; :rf/default's drain — the active drainer holds the frame's
+            ;; :drain-lock right now and `:in-sync-drain?` is false.
+            (.countDown drainer-in)
+            ;; Block mid-drain, STILL holding the drain-lock, until T1 has
+            ;; acquired fanout-monitor inside its listener and started
+            ;; dispatch-sync-spinning on our drain-lock.
+            (.await drainer-go latch-timeout-s TimeUnit/SECONDS)
+            ;; Queue a SECOND event. Its `:rf.event/run-start` — an ordinary
+            ;; in-run (drain-nested) emit fanned out while we still hold the
+            ;; drain-lock — is precisely what pre-fix blocked acquiring the
+            ;; monitor (the run-end/db-changed emits of THIS event contend too).
+            {:db (assoc db :jl75r/drain-first true)
+             :fx [[:dispatch [:jl75r/drain-second]]]}))
+
+        (rf/reg-event :jl75r/drain-second
+          (fn [{:keys [db]} _]
+            (swap! drain-second inc)
+            {:db (assoc db :jl75r/drain-second true)}))
+
+        (rf/reg-event :jl75r/t1-event
+          (fn [{:keys [db]} _]
+            (swap! t1-event-runs inc)
+            {:db (assoc db :jl75r/t1-event true)}))
+
+        (trace/register-listener! ::jl75r
+          (fn [ev]
+            ;; React ONLY to T1's clean trigger emit (never to the drain's own
+            ;; run-start/run-end/db-changed emits), and exactly once.
+            (when (and (= :jl75r/t1-trigger (:operation ev))
+                       (compare-and-set! l-fired? false true))
+              ;; We are on T1, HOLDING fanout-monitor (a clean emit's outermost
+              ;; drive holds it across this callback). Release the drainer, then
+              ;; dispatch-sync into :rf/default — which the executor is draining
+              ;; — so this spins on the drain-lock (`drain-block!`). Pre-fix, the
+              ;; drainer's next in-run emit blocks on the monitor we hold: the
+              ;; AB-BA cycle.
+              (.countDown drainer-go)
+              (rf/dispatch-sync [:jl75r/t1-event] {:frame :rf/default}))))
+
+        ;; Kick the ASYNC drain (runs on `re-frame.interop/next-tick`'s
+        ;; single-thread executor, `:in-sync-drain?` false), then wait until it
+        ;; is genuinely inside the drain holding :rf/default's drain-lock.
+        (rf/dispatch [:jl75r/drain-first] {:frame :rf/default})
+        (.await drainer-in latch-timeout-s TimeUnit/SECONDS)
+
+        (let [t1 (Thread. ^Runnable
+                          (fn [] (trace/emit! :info :jl75r/t1-trigger {}))
+                          "jl75r-t1-listener")]
+          (.start t1)
+          (.join t1 join-timeout-ms)
+          (trace/unregister-listener! ::jl75r)
+
+          (is (not (.isAlive t1))
+              (str "iter " iter ": T1 (fanout-monitor -> listener -> "
+                   "dispatch-sync F) never finished within " join-timeout-ms
+                   "ms — the fanout-monitor/drain-lock AB-BA deadlock is present"))
+          (is (= 1 @t1-event-runs)
+              (str "iter " iter ": the listener-dispatched event must settle "
+                   "EXACTLY once; it ran " @t1-event-runs " time(s)"))
+          (is (= 1 @drain-second)
+              (str "iter " iter ": the frame-drain's second event (whose "
+                   "run-start is the contended emit) must settle exactly once; "
+                   "it ran " @drain-second " time(s)")))))))


### PR DESCRIPTION
## The deadlock (AB-BA)

The JVM trace fan-out held the process-global `fanout-monitor` across the whole `run-outermost-fanout!` — **including each arbitrary registered listener body** (`implementation/core/src/re_frame/trace/tooling.cljc`, the outermost branch of `deliver-to-tooling!`). Public trace listeners are allowed to call `dispatch-sync`, which closes a hard AB-BA cycle with a frame's `:drain-lock`:

- **T1** does a clean `emit!`, acquires `fanout-monitor`, enters a listener that calls `dispatch-sync` into frame F, and spin-waits on F's `:drain-lock` (`re-frame.router/drain-block!`).
- **the drainer of F** (e.g. the async-drain executor) already holds F's `:drain-lock` through `run-one-pass!`, reaches an ordinary in-run emit (`:rf.event/run-start` …), and blocks acquiring `fanout-monitor`.

Neither can progress — `drain-block!`'s bounded-wait assumption is false because the active drainer is itself waiting on the caller. (A `dispatch-sync` from T2 would instead be rejected as nested-sync via the router's `:in-sync-drain?` flag; the genuine cycle needs the drainer holding the lock through the **async** path, where that flag is false.)

## The fix

Keep the whole synchronous, ordered, serialized fan-out for **clean concurrent emits** (rf2-uw7hg), but take the monitor **out of the cycle**: a **frame-drain emit** never acquires the monitor — it drives its fan-out **inline**, exactly as the single-threaded CLJS host always does. The "drain-lock holder waits on the monitor" edge is removed, so no cycle can form.

The discriminator is **frame routability**, computed the way `push-to-ring!` routes an emit to a per-frame ring (explicit `[:tags :frame]` / top-level `:frame` / the in-flight run's `*current-frame*`). An emit that resolves to a frame originates from within that frame's drain / settle / lifecycle activity. This is the **only** signal that covers *every* drain emit — including the epoch cascade trailers (`:rf.epoch/snapshotted` / `:rf.epoch/outcome`) that fire `outside any cascade` (nil `:rf.trace/dispatch-id`) yet **still on the drainer thread holding the `:drain-lock`**; a dispatch-id-only test misclassifies them and re-opens the deadlock. A frameless external `emit!` (the shape rf2-uw7hg's suite exercises) resolves no frame and still serializes on the monitor.

Scope: `implementation/core/src/re_frame/trace/tooling.cljc` only (+ its test). `frame.cljc`'s drain-lock, `events.cljs`, and `observation.cljc` are untouched — the fix is entirely on the trace side.

### Preserved delivery laws
- **rf2-uw7hg** — frameless concurrent clean emits still serialize on `fanout-monitor`; no listener callback overlaps itself.
- **rf2-s522m** / **rf2-1zxlsm** — same-thread reentrant delivery still takes the `*fanout-ctx*` append+drive branch (never the monitor); nested emits complete synchronously and in emission order.
- CLJS unchanged (single-threaded, no monitor). The `:cljs` outermost arm is untouched.

## Red-before / green-after

A new deterministic JVM barrier/latch test (`trace_listener_drain_deadlock_test.clj`) forces the exact interleaving — T1 `fanout-monitor → listener → dispatch-sync(F)` against the async drainer `F.:drain-lock → run-start emit` — and requires both to complete bounded and the dispatched event to settle **exactly once**. It **loads the epoch artefact** so the nil-dispatch-id `:rf.epoch/snapshotted` trailer fires (the precise emit that defeats a dispatch-id-only fix).

- **Pre-fix** (unconditional `locking`, and also the dispatch-id-only predicate + epoch): T1 never finishes, neither event settles — deadlock.
- **Post-fix**: 25/25 iterations settle bounded-and-once.

## Quality gates

All run in the foreground, unpiped:

- **core JVM** (`cd implementation/core && clojure -M:test`): **2052 tests, 9738 assertions, 0 failures, 0 errors**. Includes the new deadlock test + rf2-uw7hg concurrent-serialization + rf2-s522m/rf2-1zxlsm nested-emission suites.
- **rf2-uw7hg stress** (`:slow-test`, `concurrent-emits-serialize-under-registration-churn`, 2000 emits × 6 threads + churn): 0 failures — `max-conc == 1`, `delivered == total`, no deadlock.
- **CLJS** (`npm run test:cljs`): **9876 tests, 48548 assertions, 0 failures, 0 errors**.

Do not merge.