### PR TITLE
fix(core): truthful frame-boundary guidance after SCOPE/ENSURE split (rf2-7kfzj)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -574,13 +574,14 @@
            :recovery    :supply-frame
            :reason      (str "a frame-scoped " (name operation) " ran with no frame "
                              "context — no carried frame stamp and no established "
-                             "scope. Frame identity is carried, not found: declare "
-                             "your root frame (rf/make-frame) and run the operation "
-                             "inside that scope (with-frame, or an enclosing frame "
-                             "boundary — a frame-provider that scopes an existing "
-                             "frame, or a frame-root that ensures one), or pass an "
-                             "explicit {:frame <id>}. Per Spec 002 §The error and "
-                             "its ladder.")}
+                             "scope. Frame identity is carried, not found. Establish a "
+                             "scope one of three distinct ways (do not combine 1 and 2): "
+                             "(1) create a frame with rf/make-frame, then scope the "
+                             "operation inside it with with-frame or a frame-provider "
+                             "(which SCOPES an existing frame); (2) let a frame-root "
+                             "ENSURE the frame (create-if-absent) without pre-creating "
+                             "it; or (3) pass an explicit {:frame <id>}. Per Spec 002 "
+                             "§The error and its ladder.")}
           ;; Capture-site ancestry off the in-scope handler scope: the
           ;; cascade's dispatch-id correlates a stampless continuation back
           ;; to the cascade that captured the callback. nil outside any
@@ -2770,7 +2771,7 @@
                 ;; A `:frame-init` `:initial-events` step that classifies a path
                 ;; runs (below) at creation, so init-cascade trace stays redacted.
                 ;; EP-0027 §Construction — FORBID handler-time frame construction.
-                ;; Frames are created by the VIEW (frame-provider) or at TOP LEVEL
+                ;; Frames are created by the VIEW (frame-root, ENSURE) or at TOP LEVEL
                 ;; (tests, boot, SSR per request); constructing a frame INSIDE an
                 ;; event handler is not supported. The signal for "inside a
                 ;; handler" is `trace/*handler-scope*` being bound — the router
@@ -2787,10 +2788,11 @@
                     'rf/make-frame
                     (str "constructing a frame inside an event handler is not supported "
                          "(EP-0027) — got a frame construction for " (pr-str id) " while a cascade is in "
-                         "flight. Frames are created by the VIEW (frame-provider) or at "
-                         "TOP LEVEL; a handler changes app-db, and the view materializes "
-                         "frames from it. Move the frame creation to a frame-provider in "
-                         "the view tree, or to top-level boot.")
+                         "flight. Frames are created by the VIEW (a frame-root, which "
+                         "ENSUREs the frame — create-if-absent) or at TOP LEVEL; a handler "
+                         "changes app-db, and the view materializes frames from it. Move "
+                         "the frame creation to a frame-root in the view tree, or to "
+                         "top-level boot (rf/make-frame).")
                     {:recovery :construct-frames-in-view-or-top-level
                      :extra    {:frame id}}))
                 ;; rf2-umsyo9: apply the winning config's frame-scoped trace


### PR DESCRIPTION
## What

Two developer-facing guidance strings in `implementation/core/src/re_frame/frame.cljc` still described the pre-split frame model after PR #6097 repaired the named frame-resolution sites. This reconciles them with the shipped **SCOPE** (`frame-provider`) / **ENSURE** (`frame-root`) behaviour. Text-only — no control flow, throw condition, or recovery-keyword changes.

### `:rf.error/no-frame-context` reason (frame.cljc:575-583)

The old reason told the caller to `rf/make-frame` and then grouped `frame-provider` (SCOPE an already-live frame) with `frame-root` (ENSURE / create-if-absent) as ways to "run inside that scope". Following that literally pre-creates a frame and then hands it to a `frame-root`: a configless root silently adopts the external frame, while a config-bearing root fails `:rf.error/frame-payload-conflict`.

New reason presents three distinct alternatives and tells the reader not to combine (1) and (2):
1. create a frame with `rf/make-frame`, then scope with `with-frame` / a `frame-provider` (which SCOPES an existing frame);
2. let a `frame-root` ENSURE the frame (create-if-absent) **without** pre-creating it;
3. pass an explicit `{:frame <id>}`.

### `:rf.error/frame-construction-in-handler` message (frame.cljc:2773, 2788-2793)

Old message said the scope-only `frame-provider` creates frames in the view. After the split, the VIEW creates a frame via a `frame-root` (ENSURE); `frame-provider` only SCOPEs an existing one. Updated the comment and recovery message to name `frame-root` (view) / `rf/make-frame` (top level) accurately.

## Behaviour

No behaviour change. Both messages are diagnostic strings; the throw conditions, control flow, and the `:construct-frames-in-view-or-top-level` recovery keyword are unchanged.

## Out of fence (noted for follow-up)

The same stale forms are mirrored outside this file's guidance surface: the `subscribe` docstring in `subs.cljc`, comments in `frame_lifecycle_test.clj` / `template_test.clj`, and the Spec 009 / 013 + docs/api inventories. Not touched here per the bead's scope split.

## Quality gates

- `implementation/core` JVM (`clojure -M:test`): **2051 tests, 9663 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **9876 tests, 48548 assertions, 0 failures, 0 errors**

No test asserts the changed message strings, so both suites stay green (text-only change).

Closes rf2-7kfzj.
