### PR TITLE
fix(ui-compiler): spread-safe emit order, nil-absence, caller-key validation (rf2-m5h0f, rf2-j4len, rf2-izep3)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -369,6 +369,19 @@
       ;; are a runtime-built object layered UNDER them — owned props win any
       ;; collision, :class composes (owned classes first), and the owned-key
       ;; deny law is enforced at runtime by spread-safe->props in EVERY build.
+      ;;
+      ;; EVALUATION ORDER (rf2-m5h0f): the AUTHORED argument order is
+      ;; `(ui/spread-safe owned caller)`, so BOTH hosts evaluate the OWNED prop
+      ;; expressions BEFORE the CALLER ones. The JVM emitter already forces this
+      ;; — its `tree/element` opts-map literal lists the owned `:norm`/`:dyn`/
+      ;; `:dyn-events` slots ahead of the `:spread-safe :caller` slot, and a
+      ;; Clojure map literal evaluates its value expressions left-to-right, once
+      ;; each. CLJS matches it here with single-evaluation `let` temporaries:
+      ;; the owned object is bound first, then the caller object; each authored
+      ;; expression runs exactly once, in owned-then-caller order (a bare
+      ;; `(spread-safe-props caller-obj owned-obj)` would evaluate the caller
+      ;; argument first — the pre-fix CLJS-vs-JVM divergence). Under :advanced
+      ;; the temporaries fold away.
       (let [ss          (get-in node [:props :safe-spread])
             owned-pairs (element-prop-pairs st node inner-inline?)
             owned-obj   (ordered-literal-object
@@ -379,7 +392,11 @@
                           ~(:owned-handler-keys ss)
                           ~(site-key-form ss)
                           ~(debug-site-form (assoc ss :classification :spread)))
-            props-form  `(re-frame.ui.runtime/spread-safe-props ~caller-obj ~owned-obj)
+            owned-sym   (gensym "rf-ui-owned")
+            caller-sym  (gensym "rf-ui-caller")
+            props-form  `(let [~owned-sym ~owned-obj
+                               ~caller-sym ~caller-obj]
+                           (re-frame.ui.runtime/spread-safe-props ~caller-sym ~owned-sym))
             chs         (children-forms st (:children node) inner-inline?)]
         (if (:present? key-info)
           `(re-frame.ui.runtime/jsx-spread3 ~tag-str ~props-form

--- a/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
@@ -134,6 +134,14 @@
       ;; (from the same analysed props); the CALLER map rides a `:spread-safe`
       ;; opt that `tree/element` guards (owned-key deny in EVERY build) and
       ;; folds UNDER the owned attrs (owned wins, :class composes).
+      ;;
+      ;; EVALUATION ORDER (rf2-m5h0f) is LOAD-BEARING: the opts-map literal below
+      ;; lists the owned `:norm`/`:dyn`/`:dyn-events` slots BEFORE the
+      ;; `:spread-safe :caller` slot, so — a Clojure map literal evaluating its
+      ;; value expressions left-to-right, once each — the owned prop expressions
+      ;; run BEFORE the caller's, matching the authored `(spread-safe owned
+      ;; caller)` order. The CLJS emitter forces the same owned-then-caller order
+      ;; with `let` temporaries. Do NOT reorder these keys.
       (:safe-spread props)
       (let [ss      (:safe-spread props)
             [stat-ev dyn-ev] (event-entries (:events props))

--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -1218,41 +1218,101 @@
   per call."
   #{:key :ref :value :checked})
 
-(defn spread-safe-denied-key?
-  "Is `k` denied to a `ui/spread-safe` caller map, given the component's
-  `owned-handler-keys` (the literal `:on-*` keys of its owned map)?"
-  [k owned-handler-keys]
-  (or (contains? spread-safe-denied-structural k)
-      (contains? owned-handler-keys k)))
+(def ^:private spread-safe-denied-structural-names
+  "The CANONICAL emitted names of the denied structural keys — the form both
+  host converters reduce a caller key to via `(name k)`. The deny law compares
+  canonical NAMES, so `:key`/`:ref`/`:value`/`:checked` AND every alternate
+  spelling that canonicalizes to one of them (`:caller/ref`, `\"ref\"`, `'ref`)
+  are denied uniformly (rf2-izep3)."
+  (into #{} (map name) spread-safe-denied-structural))
 
-(defn- spread-safe-denial-reason [k owned-handler-keys]
+(defn caller-key-name
+  "The CANONICAL emitted name of a `ui/spread-safe` caller key — `(name k)`,
+  the SAME canonicalization both host converters apply (namespace dropped, so
+  `:caller/ref` -> \"ref\", `\"ref\"` -> \"ref\", `'ref` -> \"ref\"). Returns
+  nil when `k` is NOT a nameable attribute key (a keyword, string, or symbol);
+  a non-nameable key is malformed — rejected by `assert-safe-caller!` — not
+  merely 'not denied'."
+  [k]
+  (when (or (keyword? k) (string? k) (symbol? k))
+    (name k)))
+
+(defn spread-safe-denied-key?
+  "Is caller key `k` denied to a `ui/spread-safe` caller map, given the
+  component's `owned-handler-keys` (the literal `:on-*` keys of its owned map)?
+  Compares the CANONICAL emitted name (`(name k)`) against the denied
+  structural/controlled names and the canonical owned-handler names, so
+  alternate spellings — a namespaced keyword, string, or symbol — that
+  canonicalize to the same React/DOM name cannot bypass the law. A non-nameable
+  key is not 'denied' here (it is rejected as malformed by
+  `assert-safe-caller!`); returns false so the literal/compile-time path reports
+  it through its own channel."
+  [k owned-handler-keys]
+  (boolean
+   (when-some [n (caller-key-name k)]
+     (or (contains? spread-safe-denied-structural-names n)
+         (some (fn [h] (= n (name h))) owned-handler-keys)))))
+
+(defn- spread-safe-denial-reason [n owned-names]
   (cond
-    (= :key k)                       "a structural identity slot (keys are literal at the site)"
-    (= :ref k)                       "a reserved React ref slot"
-    (contains? #{:value :checked} k) "the controlled-input contract the sync door proves"
-    (contains? owned-handler-keys k) "an owned event handler the component controls"
-    :else                            "owned by the component"))
+    (= "key" n)                        "a structural identity slot (keys are literal at the site)"
+    (= "ref" n)                        "a reserved React ref slot"
+    (contains? #{"value" "checked"} n) "the controlled-input contract the sync door proves"
+    (contains? owned-names n)          "an owned event handler the component controls"
+    :else                              "owned by the component"))
 
 (defn assert-safe-caller!
-  "EVERY-BUILD guard for `(ui/spread-safe owned caller)`: throw
-  `:rf.error/ui-tree-malformed` if the runtime `caller` map names a denied key
-  (the structural/controlled/identity set plus the component's
-  `owned-handler-keys`). NOT `goog.DEBUG`-gated — the denial is a production
-  invariant a component library relies on, so it survives an advanced build
-  exactly like the compiled lease-descriptor grammar guard. Returns `caller`."
+  "EVERY-BUILD guard for `(ui/spread-safe owned caller)`. CANONICALIZES and
+  VALIDATES the caller BEFORE the deny (rf2-izep3): the `caller` must be an
+  author-space attr MAP (or nil = empty); each key must be a nameable attribute
+  key; then its CANONICAL emitted name (`(name k)`) is compared against the
+  denied structural/controlled names and the canonical `owned-handler-keys`
+  names. Alternate spellings — a namespaced keyword, string, or symbol that
+  canonicalizes to the same React/DOM name — therefore cannot bypass the law,
+  and a non-map caller (e.g. a sequence of pairs) or a non-nameable key can no
+  longer slip through the old map-only / raw-key guard. A non-map caller, a
+  non-nameable key, or a denied key throws `:rf.error/ui-tree-malformed`,
+  consistently on BOTH hosts. NOT `goog.DEBUG`-gated — the denial is a
+  production invariant a component library relies on, so it survives an advanced
+  build exactly like the compiled lease-descriptor grammar guard. Returns
+  `caller`."
   [caller owned-handler-keys]
-  (when (map? caller)
-    (reduce-kv
-     (fn [_ k _]
-       (when (spread-safe-denied-key? k owned-handler-keys)
-         (error/throw-error!
-          :rf.error/ui-tree-malformed 're-frame.ui/spread-safe
-          (str "(ui/spread-safe owned caller) — the caller attr map may not "
-               "carry " (pr-str k) ": it is "
-               (spread-safe-denial-reason k owned-handler-keys)
-               ", denied in every build so it can never clobber an owned prop. "
-               "Forward it through the visible-cost (ui/spread base overrides) "
-               "instead, or drop it from the caller map")
-          {:extra {:key k}})))
-     nil caller))
+  (when (some? caller)
+    (when-not (map? caller)
+      (error/throw-error!
+       :rf.error/ui-tree-malformed 're-frame.ui/spread-safe
+       (str "(ui/spread-safe owned caller) — the caller must be an author-space "
+            "attr MAP (or nil), not a " (name (:type (error/diag-value-summary caller)))
+            ". A non-map caller (e.g. a sequence of pairs) cannot be canonicalized "
+            "and checked against the owned-key deny law; pass a map literal or a "
+            "map-valued expression")
+       {:extra {:caller (error/diag-value-summary caller)}}))
+    (let [owned-names (into #{} (map name) owned-handler-keys)]
+      (reduce-kv
+       (fn [_ k _]
+         (let [n (caller-key-name k)]
+           (cond
+             (nil? n)
+             (error/throw-error!
+              :rf.error/ui-tree-malformed 're-frame.ui/spread-safe
+              (str "(ui/spread-safe owned caller) — the caller attr key " (pr-str k)
+                   " is not a nameable attribute key (a keyword, string, or symbol), "
+                   "so it has no canonical DOM/React name to check against the "
+                   "owned-key deny law. Use a keyword attr key")
+              {:extra {:key k}})
+
+             (or (contains? spread-safe-denied-structural-names n)
+                 (contains? owned-names n))
+             (error/throw-error!
+              :rf.error/ui-tree-malformed 're-frame.ui/spread-safe
+              (str "(ui/spread-safe owned caller) — the caller attr map may not "
+                   "carry " (pr-str k) ": it is "
+                   (spread-safe-denial-reason n owned-names)
+                   ", denied in every build so it can never clobber an owned prop "
+                   "(an alternate spelling — a namespaced keyword, string, or symbol "
+                   "— canonicalizes to the same name and is denied too). Forward it "
+                   "through the visible-cost (ui/spread base overrides) instead, or "
+                   "drop it from the caller map")
+              {:extra {:key k}}))))
+       nil caller)))
   caller)

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -496,13 +496,26 @@
   compiled OWNED object (`owned-obj`) into the final props object: owned props
   WIN every collision (the caller can carry no owned/structural key — the guard
   denied them), and `className` composes with the owned classes first. Returns
-  the merged object."
+  the merged object.
+
+  NIL-MEANS-ABSENT (rf2-j4len): a compiled owned DYNAMIC prop whose value
+  normalizes to nil sits in `owned-obj` as an explicit null (the owned object
+  is a literal built once, so a nil `attr-val`/`class-val` still materializes
+  the key). Layer owned OVER caller KEY-BY-KEY, skipping any nil owned value, so
+  a nil owned prop stays ABSENT and the caller's value survives — matching the
+  JVM `tree/element`, which drops nil owned :norm/:dyn before layering the
+  caller attrs. `js/Object.assign` would copy the explicit null and erase the
+  caller's value (the divergence). General for every dynamic owned prop, not a
+  class-only patch; class then composes owned-first when both are non-nil."
   [caller-obj owned-obj]
-  (let [caller-class (unchecked-get caller-obj "className")
-        owned-class  (unchecked-get owned-obj "className")]
-    (js/Object.assign caller-obj owned-obj)
-    (when (and (some? caller-class) (some? owned-class))
-      (unchecked-set caller-obj "className" (str owned-class " " caller-class)))
+  (let [caller-class (unchecked-get caller-obj "className")]
+    (doseq [k (js/Object.keys owned-obj)]
+      (let [v (unchecked-get owned-obj k)]
+        (when (some? v)
+          (unchecked-set caller-obj k v))))
+    (let [owned-class (unchecked-get owned-obj "className")]
+      (when (and (some? caller-class) (some? owned-class))
+        (unchecked-set caller-obj "className" (str owned-class " " caller-class))))
     caller-obj))
 
 (defn jsx-spread2

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -819,6 +819,22 @@
     (is (= #{} (get-in el [:props :safe-spread :owned-handler-keys])))
     (is (false? (:static? el)))))
 
+(deftest spread-safe-literal-caller-denies-alternate-spellings
+  ;; rf2-izep3 — the COMPILE-TIME literal-caller denial shares the canonicalized
+  ;; grammar (`rules/spread-safe-denied-key?`), so a namespaced/string/symbol
+  ;; alias of a denied key is rejected at compile time, not only the exact
+  ;; keyword. Owned :on-change makes on-change aliases denied too.
+  (doseq [caller '[{:x/ref "r"} {"ref" "r"} {:some/value "v"} {"checked" "c"}
+                   {:evil/on-change [:hijack]}]]
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+                 (ana* [:input (list 'spread-safe
+                                     {:value 'v :on-change [:set :rf.ui/value]}
+                                     caller)]))
+        (str "literal alternate spelling denied at compile: " (pr-str caller))))
+  (testing "an exact allowed literal caller (incl. a string spelling) still analyzes"
+    (is (some? (ana* '[:div.card (spread-safe {:role "region"}
+                                              {:aria-label "x" "data-y" "y"})])))))
+
 (deftest raw-and-raw-fn-props-mark
   (let [v (ana* '[ForeignComp {:el (raw host-el) :cb (raw-fn f)}])]
     (is (= [:foreign :ui/raw-fn]

--- a/implementation/ui/test/re_frame/ui/parity_corpus_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/parity_corpus_jvm_test.clj
@@ -8,6 +8,7 @@
   node suite — react-dom/server needs a JS host)."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
+            [re-frame.ui :as ui :refer [defview]]
             [re-frame.ui.compiler.emit-jvm :as emit-jvm]
             [re-frame.ui.compiler.env :as env]
             [re-frame.ui.compiler.root :as root]
@@ -283,3 +284,56 @@
       (is (= [:chat/frame] (mapv :frame-id (:plans (analyze-mount-form wrapped)))))
       (is (= {:history 10}
              (:config (first (:plans (analyze-mount-form nested)))))))))
+
+;; ---------------------------------------------------------------------------
+;; ui/spread-safe — JVM half of the dual-host spread-safe corrections
+;; (rf2-m5h0f authored eval order; rf2-j4len nil-owned absence + host parity).
+;; The CLJS half lives in react-render-cljs-test; both hosts must AGREE.
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private eval-order (atom []))
+(defn- omark! [v] (swap! eval-order conj [:owned v]) v)
+(defn- cmark! [v] (swap! eval-order conj [:caller v]) v)
+(defn- oboom! [] (swap! eval-order conj [:owned :boom]) (throw (ex-info "owned boom" {})))
+(defn- cboom! [] (swap! eval-order conj [:caller :boom]) (throw (ex-info "caller boom" {})))
+
+;; owned + caller both literal-at-site so their value expressions ride the
+;; compiled spread-safe path.
+(defview order-probe []
+  [:input.op (ui/spread-safe {:title (omark! "t")} {:data-x (cmark! "c")})])
+(defview order-owned-throws []
+  [:input.op (ui/spread-safe {:title (omark! "t") :lang (oboom!)}
+                             {:data-x (cmark! "c")})])
+(defview order-caller-throws []
+  [:input.op (ui/spread-safe {:title (omark! "t")} {:data-x (cboom!)})])
+(defview order-denial [{:keys [attr]}]
+  [:input.op (ui/spread-safe {:title (omark! "t") :value "owned"
+                              :on-change [:set :rf.ui/value]}
+                             attr)])
+
+(deftest safe-spread-authored-owned-then-caller-eval-order
+  ;; rf2-m5h0f — the JVM already forces the authored owned-then-caller order via
+  ;; its opts-map literal; pin it (and single-eval) so it stays that way and
+  ;; agrees with the CLJS host.
+  (testing "success: owned before caller, once each"
+    (reset! eval-order [])
+    (is (map? (tree/render order-probe {})))
+    (is (= [[:owned "t"] [:caller "c"]] @eval-order)
+        "owned evaluates before caller, each exactly once"))
+  (testing "owned throws: the caller is never reached"
+    (reset! eval-order [])
+    (try (tree/render order-owned-throws {}) (catch Exception _))
+    (is (= [[:owned "t"] [:owned :boom]] @eval-order)
+        "owned ran (and threw) before any caller expression"))
+  (testing "caller throws: owned already ran"
+    (reset! eval-order [])
+    (try (tree/render order-caller-throws {}) (catch Exception _))
+    (is (= [[:owned "t"] [:caller :boom]] @eval-order)
+        "owned evaluated first, then the caller expression threw"))
+  (testing "caller denial throws: owned already ran"
+    (reset! eval-order [])
+    (let [data (try (tree/render order-denial {:attr {:ref "r"}})
+                    nil (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+      (is (= :rf.error/ui-tree-malformed (:rf.error/id data)) "the deny fired")
+      (is (= [[:owned "t"]] @eval-order)
+          "owned evaluated before the every-build caller deny threw"))))

--- a/implementation/ui/test/re_frame/ui/parity_corpus_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/parity_corpus_jvm_test.clj
@@ -337,3 +337,32 @@
       (is (= :rf.error/ui-tree-malformed (:rf.error/id data)) "the deny fired")
       (is (= [[:owned "t"]] @eval-order)
           "owned evaluated before the every-build caller deny threw"))))
+
+;; rf2-j4len — a nil-normalized owned dynamic prop is ABSENT before layering, so
+;; the caller's value survives; a non-nil owned value wins; classes compose
+;; owned-first. Owned :class/:title are dynamic (from props) so they can be nil.
+;; The JVM tree already drops nil owned :norm/:dyn — this pins it and the CLJS
+;; host must AGREE.
+(defview nil-owned-probe [{:keys [oc ot caller]}]
+  [:input (ui/spread-safe {:class oc :title ot} caller)])
+
+(defn- probe-input-attrs [oc ot caller]
+  (:attrs (find-sem (semantic/normalize
+                     (assoc (nil-owned-probe {:oc oc :ot ot :caller caller})
+                            :rf.ui/tree-version tree/tree-version))
+                    (by-tag :input))))
+
+(deftest safe-spread-nil-owned-prop-absent-and-host-parity
+  (let [caller {:class "cc" :title "ct"}]
+    (testing "nil owned dynamic prop is absent: the caller value survives"
+      (let [attrs (probe-input-attrs nil nil caller)]
+        (is (= "cc" (get attrs "class")) "nil owned :class -> caller :class survives")
+        (is (= "ct" (get attrs "title")) "nil owned :title -> caller :title survives")))
+    (testing "non-nil owned wins; class composes owned-first"
+      (let [attrs (probe-input-attrs "oc" "ot" caller)]
+        (is (= "oc cc" (get attrs "class")) "class composes owned-first")
+        (is (= "ot" (get attrs "title")) "non-nil owned :title wins")))
+    (testing "owned present, caller absent: owned renders"
+      (let [attrs (probe-input-attrs "ocls" "otitle" {})]
+        (is (= "ocls" (get attrs "class")))
+        (is (= "otitle" (get attrs "title")))))))

--- a/implementation/ui/test/re_frame/ui/parity_corpus_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/parity_corpus_jvm_test.clj
@@ -366,3 +366,20 @@
       (let [attrs (probe-input-attrs "ocls" "otitle" {})]
         (is (= "ocls" (get attrs "class")))
         (is (= "otitle" (get attrs "title")))))))
+
+;; rf2-izep3 — the JVM tree conversion shares the canonicalized caller-key
+;; grammar: an alternate spelling of a denied structural key in the RUNTIME
+;; caller is rejected too (the exhaustive grammar lives in the .cljc grammar
+;; test that runs on both hosts; this pins the JVM tree/element integration).
+(deftest safe-spread-jvm-tree-denies-alternate-spelling-caller-keys
+  (doseq [k [:caller/ref "ref" :some/value "checked" :ns/key]]
+    (is (= :rf.error/ui-tree-malformed
+           (:rf.error/id (try (tree/render nil-owned-probe
+                                           {:oc nil :ot nil :caller {k "x"}})
+                              nil (catch clojure.lang.ExceptionInfo e (ex-data e)))))
+        (str "JVM tree denies alternate spelling: " (pr-str k))))
+  (testing "a non-map runtime caller is rejected by the JVM tree"
+    (is (= :rf.error/ui-tree-malformed
+           (:rf.error/id (try (tree/render nil-owned-probe
+                                           {:oc nil :ot nil :caller [[:aria-label "x"]]})
+                              nil (catch clojure.lang.ExceptionInfo e (ex-data e))))))))

--- a/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
@@ -351,6 +351,32 @@
   (is (string? (render (rt/jsx2 spread-view (js-obj "extra" {:value "ok"}))))
       "general ui/spread accepts any key — it is the visible-cost escape"))
 
+(deftest safe-spread-caller-key-canonicalization-deny
+  ;; rf2-izep3 — the every-build deny compares the CANONICAL emitted name, so
+  ;; alternate spellings (namespaced keyword / string / symbol), a non-map
+  ;; caller, and a non-nameable key are all rejected through the actual CLJS
+  ;; render/convert path — not only the exact keyword keys.
+  (testing "namespaced/string/symbol aliases of a denied key are rejected"
+    (doseq [attr [{:caller/ref "r"} {"ref" "r"} {:some/value "v"}
+                  {"checked" "c"} {:x/on-change [:hijack]}]]
+      (let [data (try (render (rt/jsx2 safe-spread-view (js-obj "attr" attr)))
+                      nil (catch :default e (ex-data e)))]
+        (is (= :rf.error/ui-tree-malformed (:rf.error/id data))
+            (str "alias denied: " (pr-str attr)))
+        (is (= 're-frame.ui/spread-safe (:where data))))))
+  (testing "a non-map caller (a sequence of pairs) is rejected"
+    (is (= :rf.error/ui-tree-malformed
+           (:rf.error/id (try (render (rt/jsx2 safe-spread-view
+                                               (js-obj "attr" [[:aria-label "x"]])))
+                              nil (catch :default e (ex-data e)))))))
+  (testing "a non-nameable key is rejected"
+    (is (= :rf.error/ui-tree-malformed
+           (:rf.error/id (try (render (rt/jsx2 safe-spread-view (js-obj "attr" {5 "x"})))
+                              nil (catch :default e (ex-data e)))))))
+  (testing "exact allowed keys (incl. a string spelling) still pass"
+    (is (string? (render (rt/jsx2 safe-spread-view
+                                  (js-obj "attr" {:aria-label "n" "data-x" "d"})))))))
+
 (deftest safe-spread-authored-owned-then-caller-eval-order
   ;; rf2-m5h0f — the authored (spread-safe owned caller) order is owned-then-
   ;; caller on CLJS (matching the JVM). Each expression runs EXACTLY once.

--- a/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
@@ -9,7 +9,7 @@
   tests publish an ownership-free candidate through the internal EventOwner
   test seam, then invoke the same stable committed callback a DOM node gets."
   (:require [clojure.string :as str]
-            [clojure.test :refer [deftest is use-fixtures]]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             ["react-dom/server" :as rds]
             [re-frame.registrar :as registrar]
             [re-frame.trace :as trace]
@@ -152,6 +152,32 @@
   [:input.form-control
    (ui/spread-safe {:value "owned" :on-change [:set :rf.ui/value] :type "text"}
                    attr)])
+
+;; rf2-m5h0f — evaluation-order probes. The mark helpers append to `eval-order`
+;; and return an ordinary attr value, so a rendered `ui/spread-safe` records the
+;; ACTUAL order (and count) its owned + caller expressions ran in. The authored
+;; order is owned-then-caller; both hosts must observe exactly that.
+(defonce ^:private eval-order (atom []))
+(defn- omark! [v] (swap! eval-order conj [:owned v]) v)
+(defn- cmark! [v] (swap! eval-order conj [:caller v]) v)
+(defn- oboom! [] (swap! eval-order conj [:owned :boom]) (throw (ex-info "owned boom" {})))
+(defn- cboom! [] (swap! eval-order conj [:caller :boom]) (throw (ex-info "caller boom" {})))
+
+;; owned + caller both literal-at-site so their value expressions ride the
+;; compiled spread-safe path (not the caller's construction site).
+(defview order-probe []
+  [:input.op (ui/spread-safe {:title (omark! "t")} {:data-x (cmark! "c")})])
+(defview order-owned-throws []
+  [:input.op (ui/spread-safe {:title (omark! "t") :lang (oboom!)}
+                             {:data-x (cmark! "c")})])
+(defview order-caller-throws []
+  [:input.op (ui/spread-safe {:title (omark! "t")} {:data-x (cboom!)})])
+;; a runtime caller carrying a denied key: the owned expr must have already run
+;; when the every-build deny throws.
+(defview order-denial [{:keys [attr]}]
+  [:input.op (ui/spread-safe {:title (omark! "t") :value "owned"
+                              :on-change [:set :rf.ui/value]}
+                             attr)])
 
 (defview trusted
   []
@@ -319,6 +345,32 @@
   ;; the same site through general ui/spread does NOT throw (visible-cost escape)
   (is (string? (render (rt/jsx2 spread-view (js-obj "extra" {:value "ok"}))))
       "general ui/spread accepts any key — it is the visible-cost escape"))
+
+(deftest safe-spread-authored-owned-then-caller-eval-order
+  ;; rf2-m5h0f — the authored (spread-safe owned caller) order is owned-then-
+  ;; caller on CLJS (matching the JVM). Each expression runs EXACTLY once.
+  (testing "success: owned before caller, once each"
+    (reset! eval-order [])
+    (is (string? (render (rt/jsx2 order-probe (js-obj)))))
+    (is (= [[:owned "t"] [:caller "c"]] @eval-order)
+        "owned evaluates before caller, each exactly once"))
+  (testing "owned throws: the caller is never reached"
+    (reset! eval-order [])
+    (try (render (rt/jsx2 order-owned-throws (js-obj))) (catch :default _))
+    (is (= [[:owned "t"] [:owned :boom]] @eval-order)
+        "owned ran (and threw) before any caller expression"))
+  (testing "caller throws: owned already ran"
+    (reset! eval-order [])
+    (try (render (rt/jsx2 order-caller-throws (js-obj))) (catch :default _))
+    (is (= [[:owned "t"] [:caller :boom]] @eval-order)
+        "owned evaluated first, then the caller expression threw"))
+  (testing "caller denial throws: owned already ran"
+    (reset! eval-order [])
+    (let [data (try (render (rt/jsx2 order-denial (js-obj "attr" {:ref "r"})))
+                    nil (catch :default e (ex-data e)))]
+      (is (= :rf.error/ui-tree-malformed (:rf.error/id data)) "the deny fired")
+      (is (= [[:owned "t"]] @eval-order)
+          "owned evaluated before the every-build caller deny threw"))))
 
 (deftest trusted-html-single-bypass
   (is (= "<div class=\"content\"><b>bold & raw</b></div>"

--- a/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
@@ -179,6 +179,11 @@
                               :on-change [:set :rf.ui/value]}
                              attr)])
 
+;; rf2-j4len — owned :class + :title are DYNAMIC (from props) so they can be nil.
+(defview nil-owned-probe
+  [{:keys [oc ot caller]}]
+  [:input (ui/spread-safe {:class oc :title ot} caller)])
+
 (defview trusted
   []
   [:div.content (ui/html "<b>bold & raw</b>")])
@@ -371,6 +376,28 @@
       (is (= :rf.error/ui-tree-malformed (:rf.error/id data)) "the deny fired")
       (is (= [[:owned "t"]] @eval-order)
           "owned evaluated before the every-build caller deny threw"))))
+
+(deftest safe-spread-nil-owned-prop-absent-and-host-parity
+  ;; rf2-j4len — a nil-normalized owned DYNAMIC prop is ABSENT before layering,
+  ;; so the caller value survives; a non-nil owned value wins; class composes
+  ;; owned-first. General for dynamic owned props (:class AND :title). This is
+  ;; the CLJS half; the JVM half (already correct) pins the same result.
+  (let [caller {:class "cc" :title "ct"}]
+    (testing "nil owned dynamic prop is absent: the caller value survives"
+      (let [html (render (rt/jsx2 nil-owned-probe
+                                  (js-obj "oc" nil "ot" nil "caller" caller)))]
+        (is (str/includes? html "class=\"cc\"") "nil owned :class -> caller :class survives")
+        (is (str/includes? html "title=\"ct\"") "nil owned :title -> caller :title survives")))
+    (testing "non-nil owned wins; class composes owned-first"
+      (let [html (render (rt/jsx2 nil-owned-probe
+                                  (js-obj "oc" "oc" "ot" "ot" "caller" caller)))]
+        (is (str/includes? html "class=\"oc cc\"") "class composes owned-first")
+        (is (str/includes? html "title=\"ot\"") "non-nil owned :title wins")))
+    (testing "owned present, caller absent: owned renders"
+      (let [html (render (rt/jsx2 nil-owned-probe
+                                  (js-obj "oc" "ocls" "ot" "otitle" "caller" {})))]
+        (is (str/includes? html "class=\"ocls\""))
+        (is (str/includes? html "title=\"otitle\""))))))
 
 (deftest trusted-html-single-bypass
   (is (= "<div class=\"content\"><b>bold & raw</b></div>"

--- a/implementation/ui/test/re_frame/ui/spread_safe_deny_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/spread_safe_deny_elision_prod_test.cljs
@@ -47,6 +47,24 @@
                  (catch :default e (ex-data e)))]
       (is (= :rf.error/ui-tree-malformed (:rf.error/id data)))
       (is (= :on-change (:key data)))))
+  (testing "an ALTERNATE SPELLING of a denied key is denied in production too
+            (rf2-izep3 — the canonicalized grammar survives :advanced)"
+    (doseq [k [:caller/ref "value" 'checked]]
+      (let [data (try
+                   (rules/assert-safe-caller! {k "x"} @runtime-owned-handlers)
+                   nil
+                   (catch :default e (ex-data e)))]
+        (is (= :rf.error/ui-tree-malformed (:rf.error/id data))
+            (str "alternate spelling denied in the elided build: " (pr-str k)))
+        (is (= 're-frame.ui/spread-safe (:where data))))))
+  (testing "a non-map / non-nameable caller is rejected in production too"
+    (is (= :rf.error/ui-tree-malformed
+           (:rf.error/id (try (rules/assert-safe-caller! [[:aria-label "x"]]
+                                                         @runtime-owned-handlers)
+                              nil (catch :default e (ex-data e))))))
+    (is (= :rf.error/ui-tree-malformed
+           (:rf.error/id (try (rules/assert-safe-caller! {5 "x"} @runtime-owned-handlers)
+                              nil (catch :default e (ex-data e)))))))
   (testing "an allowed caller passes in production (no false-positive throw)"
     (is (= {:aria-label "x"}
            (rules/assert-safe-caller! {:aria-label "x"} @runtime-owned-handlers)))))

--- a/implementation/ui/test/re_frame/ui/spread_safe_grammar_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/spread_safe_grammar_cljs_test.cljc
@@ -1,0 +1,80 @@
+(ns re-frame.ui.spread-safe-grammar-cljs-test
+  "rf2-izep3 — the ONE validated author-space caller-key grammar for
+  `ui/spread-safe`, exercised DIRECTLY (host-agnostic). `assert-safe-caller!`,
+  `spread-safe-denied-key?`, and `caller-key-name` are pure `.cljc`, so the
+  canonicalization + validation + deny law are proven IDENTICAL on the JVM and
+  CLJS hosts: this suite runs under both `clojure -M:test` and the node
+  `-cljs-test` build. The render-level integration (the deny reached through the
+  actual host converters) lives in react-render-cljs-test / parity-corpus-jvm-
+  test; the advanced-production reachability rides the -deny-elision-prod-test."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ui.rules :as rules]))
+
+(defn- deny-data [caller owned]
+  (try (rules/assert-safe-caller! caller owned)
+       nil
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e))))
+
+(defn- denied? [caller owned]
+  (= :rf.error/ui-tree-malformed (:rf.error/id (deny-data caller owned))))
+
+(deftest caller-key-name-canonicalizes
+  (testing "nameable keys canonicalize to (name k); namespace dropped"
+    (is (= "ref" (rules/caller-key-name :ref)))
+    (is (= "ref" (rules/caller-key-name :caller/ref)))
+    (is (= "ref" (rules/caller-key-name "ref")))
+    (is (= "ref" (rules/caller-key-name 'ref)))
+    (is (= "on-change" (rules/caller-key-name :x/on-change))))
+  (testing "non-nameable keys have no canonical name"
+    (is (nil? (rules/caller-key-name nil)))
+    (is (nil? (rules/caller-key-name false)))
+    (is (nil? (rules/caller-key-name 5)))))
+
+(deftest spread-safe-denied-key?-compares-canonical-names
+  (testing "structural/controlled aliases are denied by canonical name"
+    (doseq [k [:key :ref :value :checked
+               :caller/ref "ref" 'ref :some/value "value" "checked" :ns/key]]
+      (is (rules/spread-safe-denied-key? k #{})
+          (str "denied by canonical name: " (pr-str k)))))
+  (testing "owned-handler aliases are denied by canonical name"
+    (doseq [k [:on-change "on-change" :x/on-change]]
+      (is (rules/spread-safe-denied-key? k #{:on-change})
+          (str "owned-handler alias denied: " (pr-str k)))))
+  (testing "allowed + non-nameable keys are not 'denied' here"
+    (doseq [k [:aria-label "data-x" :title :class :style nil false 5]]
+      (is (not (rules/spread-safe-denied-key? k #{:on-change}))))))
+
+(deftest assert-safe-caller!-rejects-alternate-spellings
+  (testing "structural/controlled aliases (namespaced/string/symbol) are rejected"
+    (doseq [k [:key :ref :value :checked
+               :caller/ref "ref" 'ref :some/value "value" "checked" :ns/key 'checked]]
+      (let [data (deny-data {k "x"} #{})]
+        (is (= :rf.error/ui-tree-malformed (:rf.error/id data))
+            (str "alias rejected: " (pr-str k)))
+        (is (= 're-frame.ui/spread-safe (:where data)))
+        (is (= k (:key data)) "the offending author key is carried through"))))
+  (testing "owned-handler aliases are rejected against canonical owned names"
+    (doseq [k [:on-change "on-change" :x/on-change]]
+      (is (denied? {k [:e]} #{:on-change}) (str "owned alias rejected: " (pr-str k))))))
+
+(deftest assert-safe-caller!-rejects-non-map-and-non-nameable
+  (testing "a non-map caller (a pair sequence / vector / string) is rejected"
+    (is (denied? [[:aria-label "x"]] #{}))
+    (is (denied? '([:aria-label "x"]) #{}))
+    (is (denied? "not-a-map" #{})))
+  (testing "non-nameable keys are rejected"
+    (doseq [k [nil false 5 3.0]]
+      (is (denied? {k "x"} #{}) (str "non-nameable key rejected: " (pr-str k))))))
+
+(deftest assert-safe-caller!-passes-allowed-callers
+  (testing "exact allowed keys pass; the caller is returned unchanged"
+    (is (= {:aria-label "n" :data-x "d" :title "t" :class "c" :style {:color "red"}}
+           (rules/assert-safe-caller!
+            {:aria-label "n" :data-x "d" :title "t" :class "c" :style {:color "red"}}
+            #{:on-change}))))
+  (testing "nil caller = the empty caller (returns nil, no throw)"
+    (is (nil? (rules/assert-safe-caller! nil #{:on-change}))))
+  (testing "an empty map passes"
+    (is (= {} (rules/assert-safe-caller! {} #{:on-change}))))
+  (testing "a caller may name an owned handler that is NOT among owned-handler-keys"
+    (is (= {:on-click [:e]} (rules/assert-safe-caller! {:on-click [:e]} #{:on-change})))))


### PR DESCRIPTION
Fixes three tightly-coupled defects on the `ui/spread-safe` emit + runtime seam (all discovered by the rf2-30n0x audit of PRs 6043/6044/6045). One coupled compiler lane, committed smallest-cleanup → biggest-correctness.

## rf2-m5h0f — authored owned-then-caller evaluation order (both hosts)
The CLJS emitter passed the caller object as the FIRST argument to `spread-safe-props`, so a `(ui/spread-safe owned caller)` site evaluated CALLER expressions before OWNED ones — the opposite of the authored order and divergent from the JVM emitter (whose `tree/element` opts-map literal already evaluates owned `:norm`/`:dyn`/`:dyn-events` before `:spread-safe :caller`). Chose and documented ONE order (authored owned-then-caller); CLJS now binds owned then caller in single-evaluation `let` temporaries (folded away under `:advanced`). A note pins the JVM opts-map order as load-bearing.

## rf2-j4len — nil owned props stay absent, preserving host parity
CLJS `spread-safe-props` used `js/Object.assign`, so an owned DYNAMIC prop normalized to nil (still a key in the literal owned object, as an explicit null) erased the caller's value — a nil owned `:class`/`:title` dropped the caller's. The JVM `tree/element` already drops nil owned `:norm`/`:dyn` before layering, so the hosts diverged. CLJS now layers owned over caller key-by-key, skipping nil owned values (general for every dynamic owned prop, not class-only); className still composes owned-first.

## rf2-izep3 — canonicalize + validate caller keys before the every-build deny
The owned-key deny compared RAW caller keys, while both host converters canonicalize via `(name k)`. Namespaced-keyword / string / symbol aliases of a denied structural/controlled key (`:caller/ref` → "ref", `"checked"` → "checked") bypassed the guard and were installed under their canonical name; a non-map sequence of pairs bypassed the map-only guard entirely. Defined ONE validated author-space grammar in `re-frame.ui.rules` (shared by the compile-time literal denial, CLJS conversion, and JVM tree conversion): `caller-key-name` canonicalizes; `spread-safe-denied-key?` compares canonical names; `assert-safe-caller!` rejects non-map callers and non-nameable keys with the typed `:rf.error/ui-tree-malformed` boundary error BEFORE the deny, consistently on both hosts in every build.

## Surface
`emit_cljs.cljc` (order), `runtime.cljs` (nil-absence), `rules.cljc` (shared grammar), plus a one-line load-bearing-order note in `emit_jvm.cljc`. No touch to `build_hook.clj`, `analyze.cljc` (source), `ui/test.cljc`, or any hot-zone.

## Quality gates
- `implementation/ui` JVM (`clojure -M:test`): 772 tests, 0 failures / 0 errors
- `npm run test:cljs` (full node-test): 9885 tests, 0 failures / 0 errors (2 pre-existing warnings in unrelated resources/routing tests)
- focused `node-test-ui`: 774 tests, 0 failures, 0 warnings
- `npm run test:adapter-smokes`: 3 adapter smokes (Reagent / UIx / Helix), 0 failures
- Red-before / green-after honored per bead (m5h0f + j4len reproduced on CLJS; izep3 reproduced across the grammar, JVM-tree, and literal compile-time tests). Host parity (CLJS == JVM) verified by paired react-render (CLJS) + parity-corpus (JVM) tests for m5h0f and j4len.
- G-17 advanced-production elision proof extended with an alternate spelling (runs in CI's `test:browser-prod-elision`).
