### PR TITLE
fix(core-scheduler): complete exception contract across depth-zero and with-epoch drains (rf2-2u4rw)

### DIFF
--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -97,24 +97,47 @@
 ;; single-threaded JS event loop and never escape the adapter closure —
 ;; `volatile!` is the right primitive, no CAS cost.
 
+(def ^:private capture-none
+  "Presence sentinel shared by the failure seams — the derived fan-out's
+  first-thrown capture (`notify`) and the scheduler's earliest-escape cell
+  (`:escaped`, read/written by `drain-scheduler!` + `with-epoch`). A distinct
+  object identity so a subscriber / recompute that throws `nil`/`false` (both
+  legal CLJS throws) is still recorded and re-raised by PRESENCE — never masked
+  by a truthiness test (rf2-vxgfnd.203, rf2-qcmzc, rf2-2u4rw)."
+  (js-obj))
+
+(defn- pick-third
+  "Reducing fn that returns the map value, discarding accumulator + key.
+  Hoisted (top-level, allocated once) so `sole-val` pays no per-call closure."
+  [_ _ v]
+  v)
+
+(defn- sole-val
+  "The single value of a one-entry map, WITHOUT the map-seq + `MapEntry`
+  `(val (first m))` allocates (rf2-2u4rw common-path preservation). `reduce-kv`
+  walks the backing array directly and returns the sole value; `nil`/`false`
+  values survive (it returns whatever `pick-third` yields). Caller guarantees
+  exactly one entry (the `(case (count ws) 1 …)` fast path)."
+  [m]
+  (reduce-kv pick-third nil m))
+
 (defn make-scheduler
   "Return a fresh per-adapter epoch scheduler cell. Each adapter owns its
   own so multiple React-shaped adapters can coexist in a test bundle
-  without sharing an epoch queue."
+  without sharing an epoch queue.
+
+  `:escaped` is the scheduler-lifetime EARLIEST-ESCAPE cell (rf2-2u4rw):
+  the first thunk failure a drain contains, held by PRESENCE across the
+  sequential sibling-watch drains of a single direct source mutation and
+  across the `with-epoch` body/finally boundary, so the earliest primary
+  failure surfaces once (E1 over any later E2) after all owned work is
+  attempted. One volatile per scheduler — no per-drain capture allocation."
   []
   {:depth     (volatile! 0)   ;; open-epoch nesting depth
    :flushing? (volatile! false)
    :queue     (volatile! [])  ;; ordered queue of pending flush thunks
-   :queued    (volatile! #{})}) ;; identity set guarding double-enqueue
-
-(def ^:private capture-none
-  "Presence sentinel shared by the two failure seams — the derived fan-out's
-  first-thrown capture (`notify`) and the scheduler drain's first-escape
-  capture (`drain-scheduler!`). A distinct object identity so a subscriber /
-  recompute that throws `nil`/`false` (both legal CLJS throws) is still
-  recorded and re-raised by PRESENCE — never masked by a truthiness test
-  (rf2-vxgfnd.203, rf2-qcmzc)."
-  (js-obj))
+   :queued    (volatile! #{}) ;; identity set guarding double-enqueue
+   :escaped   (volatile! capture-none)}) ;; earliest-escape cell (rf2-2u4rw)
 
 (defn- drain-scheduler!
   "Drain the scheduler's pending flush thunks in enqueue order until the
@@ -124,14 +147,14 @@
   notifies its watchers — which may enqueue downstream thunks that the
   same loop then drains, preserving topological order.
 
-  Per-thunk isolation WITH first-escape surfacing (rf2-l3lelt + rf2-qcmzc).
-  On the production sub graph a flush thunk never throws: the spine
-  compute-fn is `subs.memo/validate-and-trace`, which brackets the user sub
-  body in `try/catch`, emits `:rf.error/sub-exception`, and recovers to nil.
-  A non-catching compute-fn (a RAW derived value built by tooling/tests),
+  Per-thunk isolation WITH earliest-escape surfacing (rf2-l3lelt + rf2-qcmzc
+  + rf2-2u4rw). On the production sub graph a flush thunk never throws: the
+  spine compute-fn is `subs.memo/validate-and-trace`, which brackets the user
+  sub body in `try/catch`, emits `:rf.error/sub-exception`, and recovers to
+  nil. A non-catching compute-fn (a RAW derived value built by tooling/tests),
   or a throwing derived SUBSCRIBER (whose escape the fan-out `notify`
   re-raises after delivering every sibling), CAN throw though — and this
-  seam owes TWO disciplines at once:
+  seam owes THREE disciplines at once:
 
     1. Don't STRAND the tail (rf2-l3lelt). A throw propagating out of a bare
        drain loop stranded every downstream thunk still queued behind it:
@@ -144,65 +167,90 @@
     2. Don't SWALLOW the failure (rf2-qcmzc). The earlier per-thunk guard
        DISCARDED every escape (`(catch :default _ nil)`), so a programmer
        error in a raw derived value / subscriber vanished silently and the
-       fan-out's careful re-raise reached a dead end — the source bead's
-       observability criterion unmet. Instead the loop CAPTURES the FIRST
-       escape by PRESENCE (`capture-none`, not truthiness — `nil`/`false`
-       are legal CLJS throws whose identity must survive), keeps draining
-       the tail, restores scheduler state in the `finally`, and THEN
-       re-raises the retained value to the caller (`replace-container!` / a
-       direct source mutation) — the established caller/error channel. The
-       primary failure surfaces WITH identity preserved, AFTER every sibling
-       has been delivered.
+       fan-out's careful re-raise reached a dead end. Instead the loop
+       CAPTURES the escape by PRESENCE into the scheduler's `:escaped` cell
+       (`capture-none`, not truthiness — `nil`/`false` are legal CLJS throws
+       whose identity must survive), keeps draining the tail, restores queue/
+       flushing state in the `finally`, and surfaces the escape through the
+       caller/error channel — identity preserved, AFTER every sibling.
 
-  The throwing thunk's own `dirty?` was already cleared by `flush!` before
-  `recompute`, so it leaves no stuck guard either. Queued / re-entrant
-  writes a subscriber triggers mid-drain are a later pass; the FIRST escape
-  is the one surfaced."
-  [{:keys [flushing? queue queued] :as _scheduler}]
+    3. Preserve the EARLIEST across the depth-zero source-atom entry
+       (rf2-2u4rw). A direct `reset!` fires its source's watches ONE AT A
+       TIME through the atom's own (uncontained) notify loop; each derived
+       dependent's watch marks-dirty and, at depth zero, drains here. Were
+       this drain to re-raise the FIRST dependent's failure, that throw would
+       escape the atom's notify loop and the LATER dependents' watches would
+       never mark/enqueue — a supported direct mutation suppressing sibling
+       derived work. So the capture lives on the SCHEDULER (`:escaped`),
+       surviving across those sequential per-watch drains, and a drain
+       re-raises ONLY a STALE escape — one already present at its entry,
+       deferred by an EARLIER sibling drain. A FRESH escape (captured in THIS
+       drain) is left in `:escaped` so the atom's notify loop continues to the
+       later sibling; that sibling's drain (or the terminal `with-epoch`
+       close) then surfaces the earliest primary. Net: the later sibling
+       marks/drains, THEN the original first failure surfaces once.
+
+  `:escaped` is a scheduler-lifetime volatile (allocated once by
+  `make-scheduler`), so an ordinary empty/one-subscriber drain allocates
+  NOTHING here — the cursor is a loop binding, not a per-drain volatile
+  (rf2-2u4rw common-path preservation). The throwing thunk's own `dirty?`
+  was already cleared by `flush!` before `recompute`, so it leaves no stuck
+  guard either."
+  [{:keys [flushing? queue queued escaped] :as _scheduler}]
   (when-not @flushing?
     (vreset! flushing? true)
-    ;; Walk the live `@queue` by index rather than re-slicing the head: a
-    ;; thunk may `schedule-flush!` downstream thunks, which `conj` onto the
-    ;; same vector, so re-reading `(count @queue)` each step keeps the
-    ;; running loop observing newly-enqueued thunks in enqueue order. The
-    ;; cursor advances and the entry leaves `queued` BEFORE the thunk runs,
-    ;; so a thunk that throws is already considered consumed (matching the
-    ;; old head-pop-before-call ordering). The per-thunk `try/catch` (see the
-    ;; docstring) BOTH isolates a throwing thunk so the loop drains the
-    ;; downstream tail to completion AND retains its escape for surfacing;
-    ;; the `finally` then restores scheduler state for the next epoch.
-    (let [cursor   (volatile! 0)
-          captured (volatile! capture-none)]
+    ;; A STALE escape present at entry was deferred by a preceding sibling
+    ;; drain (a direct depth-zero mutation whose earlier dependent threw);
+    ;; this drain drains the later sibling's owned work, then re-raises it.
+    (let [stale-at-entry? (not (identical? capture-none @escaped))]
       (try
-        (loop []
-          (when (< @cursor (count @queue))
-            (let [thunk (nth @queue @cursor)]
+        ;; Walk the live `@queue` by index rather than re-slicing the head: a
+        ;; thunk may `schedule-flush!` downstream thunks, which `conj` onto the
+        ;; same vector, so re-reading `(count @queue)` each step keeps the
+        ;; running loop observing newly-enqueued thunks in enqueue order. The
+        ;; entry leaves `queued` and the cursor advances BEFORE the thunk runs,
+        ;; so a thunk that throws is already considered consumed (matching the
+        ;; old head-pop-before-call ordering). The per-thunk `try/catch`
+        ;; isolates a throwing thunk (drains the tail) AND retains its escape.
+        (loop [cursor 0]
+          (when (< cursor (count @queue))
+            (let [thunk (nth @queue cursor)]
               (vswap! queued disj thunk)
-              (vswap! cursor inc)
-              ;; Per-thunk isolation + first-escape capture (rf2-l3lelt +
-              ;; rf2-qcmzc): retain the FIRST escape by presence so it can be
-              ;; surfaced after the drain, while the loop still drains the
-              ;; not-yet-run tail. `capture-none`/`nil`/`false` safe.
               (try (thunk)
                    (catch :default e
-                     (when (identical? capture-none @captured)
-                       (vreset! captured e)))))
-            (recur)))
+                     (when (identical? capture-none @escaped)
+                       (vreset! escaped e)))))
+            (recur (inc cursor))))
         (finally
           ;; The loop consumes `@queue` to empty on every non-re-entrant exit
-          ;; (per-thunk capture means no throw escapes the loop), so the
-          ;; cursor reaches the end and this releases the backing vector for
-          ;; the next epoch. Re-entrant drains short-circuit on `@flushing?`
-          ;; above and never reach here.
+          ;; (per-thunk capture means no throw escapes the loop), so this
+          ;; releases the backing vector for the next epoch. Re-entrant drains
+          ;; short-circuit on `@flushing?` above and never reach here.
           (vreset! queue [])
           (vreset! flushing? false)))
-      ;; Scheduler state is restored; NOW surface the FIRST retained escape
-      ;; through the caller/error channel (rf2-qcmzc). Re-raised OUTSIDE the
-      ;; try/finally so scheduler state is clean for the next epoch even on
-      ;; this path, and so the `finally`'s own resets can never mask the
-      ;; primary failure.
-      (when-not (identical? capture-none @captured)
-        (throw @captured)))))
+      ;; Queue/flushing state is restored. Surface ONLY a stale escape — one
+      ;; present at entry (a deferred earlier-sibling failure). A fresh escape
+      ;; captured in THIS drain is left in `:escaped` so the atom's own notify
+      ;; loop can still fire the later sibling watches; the following sibling
+      ;; drain (stale-at-entry) or the terminal `with-epoch` close surfaces it.
+      ;; Re-raised OUTSIDE the try/finally so the `finally`'s resets can never
+      ;; mask the primary failure (rf2-qcmzc + rf2-2u4rw).
+      (when stale-at-entry?
+        (let [e @escaped]
+          (vreset! escaped capture-none)
+          (throw e))))))
+
+(defn- surface-escaped!
+  "If the scheduler holds a retained earliest escape, clear it and re-raise it
+  (by presence — `nil`/`false` survive). The terminal surfacing helper for
+  `with-epoch`'s outermost close (rf2-2u4rw): after the drain has attempted
+  every owned thunk and restored state, any escape a FRESH-capture drain
+  deferred surfaces here, once."
+  [{:keys [escaped] :as _scheduler}]
+  (when-not (identical? capture-none @escaped)
+    (let [e @escaped]
+      (vreset! escaped capture-none)
+      (throw e))))
 
 (defn- schedule-flush!
   "Enqueue `thunk` on the scheduler (dedup by identity within the current
@@ -216,18 +264,50 @@
     (drain-scheduler! scheduler)))
 
 (defn- with-epoch
-  "Run `body-thunk` inside an open epoch on `scheduler`; the outermost
-  close drains the pending flush queue. Nested epochs (a re-entrant
-  `replace-container!` during a flush) only drain at the outermost
-  boundary so coalescing spans the whole synchronous cascade."
-  [{:keys [depth] :as scheduler} body-thunk]
+  "Run `body-thunk` inside an open epoch on `scheduler`; the outermost close
+  drains the pending flush queue. Nested epochs (a re-entrant
+  `replace-container!` during a flush) only drain at the outermost boundary so
+  coalescing spans the whole synchronous cascade.
+
+  Body/finally failure ordering (rf2-2u4rw). `body-thunk` (the bracketed
+  `reset!`) can queue work and THEN throw E1 — e.g. a `replace-container!`
+  whose reset fires a watch that itself throws after other watches already
+  enqueued flushes. The outermost close must still drain that queued tail, but
+  the drain can throw its own E2. A bare `try/finally` would let JavaScript's
+  finally-replaces-try semantics surface E2 and LOSE E1 — the caller-visible
+  primary would no longer be the earliest escape. So the body's escape is
+  caught, recorded as the earliest (`:escaped`) BEFORE the drain runs so a
+  drain E2 cannot displace it, the drain attempts every owned thunk and
+  restores scheduler state, and the EARLIEST (E1 over E2) surfaces once via
+  `surface-escaped!`. `depth` is decremented on both the success and throw
+  paths so nested-epoch accounting stays correct. `capture-none` presence
+  (not truthiness) keeps a `false`/`nil` body throw representable."
+  [{:keys [depth escaped] :as scheduler} body-thunk]
   (vswap! depth inc)
-  (try
-    (body-thunk)
-    (finally
-      (vswap! depth dec)
-      (when (zero? @depth)
-        (drain-scheduler! scheduler)))))
+  (let [body-escaped (try
+                       (body-thunk)
+                       capture-none
+                       (catch :default e e))]
+    (vswap! depth dec)
+    (if (zero? @depth)
+      (do
+        ;; Body threw E1 → it escaped earliest, so it is the PRIMARY. Seed
+        ;; `:escaped` before draining so the drain's own escape can't displace
+        ;; it (rf2-2u4rw with-epoch entry). A clean body leaves `:escaped`
+        ;; untouched; the drain then owns any flush escape.
+        (when-not (identical? capture-none body-escaped)
+          (when (identical? capture-none @escaped)
+            (vreset! escaped body-escaped)))
+        ;; Always attempt the queued tail. `drain-scheduler!` re-raises a
+        ;; stale escape (the seeded E1) itself; `surface-escaped!` covers the
+        ;; clean-body / drain-only escape the drain deferred (this outermost
+        ;; close is terminal — no later sibling drain follows).
+        (drain-scheduler! scheduler)
+        (surface-escaped! scheduler))
+      ;; Nested epoch close: the outer epoch owns the drain + surfacing;
+      ;; propagate a body escape upward so it reaches that boundary.
+      (when-not (identical? capture-none body-escaped)
+        (throw body-escaped)))))
 
 ;; ---- container ------------------------------------------------------------
 ;;
@@ -473,9 +553,12 @@
                                  ;; Single subscriber: no sibling to protect →
                                  ;; no capture cell, invoke directly. A throw
                                  ;; propagates through `flush!` into the drain,
-                                 ;; which surfaces it (rf2-qcmzc) — same outcome,
-                                 ;; zero extra allocation on the common path.
-                                 1 ((val (first ws)) prev nu)
+                                 ;; which surfaces it (rf2-qcmzc). `sole-val`
+                                 ;; extracts the lone watcher WITHOUT the map-seq
+                                 ;; + `MapEntry` `(val (first ws))` allocates —
+                                 ;; genuinely allocation-free on the common path
+                                 ;; (rf2-2u4rw).
+                                 1 ((sole-val ws) prev nu)
                                  ;; Two+ subscribers: attempt each independently,
                                  ;; capture the FIRST escape by presence, re-raise
                                  ;; after delivery (surfaced via the drain).

--- a/implementation/core/test/re_frame/substrate/spine_glitch_free_cljs_test.cljs
+++ b/implementation/core/test/re_frame/substrate/spine_glitch_free_cljs_test.cljs
@@ -370,6 +370,159 @@
           "the bare reset! drained immediately (no epoch open) and notified
            once with the recomputed value"))))
 
+;; ---- direct source mutation: earlier dependent throw does NOT suppress -----
+;; ---- the later sibling's derived work (rf2-2u4rw depth-zero entry) ---------
+
+(deftest direct-source-earlier-throw-still-drains-later-sibling
+  (testing "a DIRECT raw source reset (depth zero, bypassing replace-container!)
+            fires the source's watches ONE AT A TIME through the atom's own
+            notify loop. TWO derived dependents watch the source; the EARLIER
+            (first-firing) dependent's recompute throws. Before rf2-2u4rw the
+            depth-zero drain re-raised that failure inline, so it escaped the
+            atom's uncontained notify loop and the LATER dependent's watch never
+            marked/enqueued — a supported direct mutation suppressing sibling
+            derived work. Now the drain captures the escape on the SCHEDULER's
+            :escaped cell and DEFERS it, so the atom loop continues to the later
+            sibling (which marks + drains its own flush); the later sibling's
+            drain then surfaces the earlier failure. Net: the later sibling's
+            derived work runs, THEN the original first failure surfaces once,
+            with identity preserved, and the scheduler recovers cleanly."
+    (let [scheduler    (spine/make-scheduler)
+          make-derived (spine/make-derived-value-fn "rf-b1-" scheduler)
+          src          (atom 1)
+          boom?        (atom false)
+          later-ran    (atom 0)
+          sentinel     (js/Error. "earlier boom")
+          ;; EARLIER dependent — constructed first, so its watch fires first and
+          ;; its flush drains first. Throws the sentinel on demand.
+          earlier      (make-derived [src]
+                         (fn [x] (when @boom? (throw sentinel)) x))
+          ;; LATER dependent — the sibling a re-raising depth-zero drain would
+          ;; have suppressed (its watch never firing because the atom loop
+          ;; aborted). Counts its cascade-time flushes.
+          later        (make-derived [src]
+                         (fn [x] (when @boom? (swap! later-ran inc)) (* x 10)))
+          later-notes  (atom [])]
+      ;; Lazy baselines (the sub-cache reads on subscribe), before arming.
+      (is (= 1 @earlier) "earlier baseline")
+      (is (= 10 @later) "later baseline")
+      (add-watch later :w (fn [_ _ prev nu] (swap! later-notes conj [prev nu])))
+      (reset! boom? true)
+      (let [caught (atom ::none)]
+        (try (reset! src 2)
+             (catch :default e (reset! caught e)))
+        (is (identical? sentinel @caught)
+            "the EARLIER dependent's failure surfaced to the caller with EXACT
+             identity — deferred on :escaped, re-raised after the later sibling")
+        (is (= 1 @later-ran)
+            "the LATER sibling's flush STILL ran (its watch marked/enqueued) —
+             a re-raising depth-zero drain would have suppressed it entirely")
+        (is (= [[10 20]] @later-notes)
+            "the later sibling notified its own watcher with the settled value
+             BEFORE the earlier failure surfaced"))
+      ;; Recovery: disarm and reset AGAIN — both dependents re-mark + flush,
+      ;; proving neither the :escaped cell nor a dirty? guard was left stuck.
+      (reset! boom? false)
+      (reset! later-notes [])
+      (reset! src 3)
+      (is (= 3 @earlier) "earlier recovered — its dirty? guard was cleared")
+      (is (= [[20 30]] @later-notes)
+          "a later clean reset re-marks + flushes the later sibling — scheduler
+           state (:escaped, queue, flushing?) fully recovered"))))
+
+(deftest direct-source-both-dependents-throw-surfaces-earliest
+  (testing "when BOTH direct dependents throw (earlier first), the EARLIEST
+            escape is the one surfaced (presence capture across the sequential
+            per-watch drains) — the later dependent's own throw is dropped in
+            favour of the first. (rf2-2u4rw)"
+    (let [scheduler    (spine/make-scheduler)
+          make-derived (spine/make-derived-value-fn "rf-b1b-" scheduler)
+          src          (atom 1)
+          boom?        (atom false)
+          first-err    (js/Error. "first boom")
+          earlier      (make-derived [src] (fn [x] (when @boom? (throw first-err)) x))
+          later        (make-derived [src] (fn [x] (when @boom? (throw (js/Error. "second boom"))) x))]
+      (is (= 1 @earlier) "earlier baseline")
+      (is (= 1 @later) "later baseline")
+      (reset! boom? true)
+      (let [caught (atom ::none)]
+        (try (reset! src 2)
+             (catch :default e (reset! caught e)))
+        (is (identical? first-err @caught)
+            "the earliest (first-firing dependent's) failure surfaced by
+             identity; the later dependent's throw was superseded")))))
+
+;; ---- with-epoch body/finally failure ordering (rf2-2u4rw epoch entry) ------
+
+(deftest with-epoch-body-throw-wins-over-drain-throw
+  (testing "a `with-epoch` body that QUEUES work and then throws E1, whose
+            queued drain then throws E2, surfaces E1 (the earliest escape) to
+            the caller — NOT E2. A bare try/finally would let JavaScript's
+            finally-replaces-try semantics surface E2 and lose the primary E1.
+            rf2-2u4rw seeds the body escape onto :escaped BEFORE draining so the
+            drain's E2 cannot displace it; the drain still attempts the queued
+            tail, and E1 surfaces once with exact identity, scheduler clean."
+    (let [scheduler    (spine/make-scheduler)
+          make-derived (spine/make-derived-value-fn "rf-b2-" scheduler)
+          replace!     (spine/make-replace-container-fn scheduler)
+          root         (spine/make-state-container {:a 1})
+          boom?        (atom false)
+          e1           (js/Error. "E1 body")
+          ;; A derived whose flush recompute throws E2 during the drain (its
+          ;; :a slice moves, so it recomputes and throws when armed).
+          drain-thrower (make-derived [root]
+                          (fn [db] (when @boom? (throw (js/Error. "E2 drain")))
+                            (:a db)))]
+      (is (= 1 @drain-thrower) "baseline deref")
+      (reset! boom? true)
+      (let [caught (atom ::none)]
+        ;; Body: reset root (queues drain-thrower's flush at depth 1), THEN
+        ;; throw E1. The outermost close drains (flush throws E2) and must
+        ;; surface E1.
+        (try (#'spine/with-epoch scheduler
+               (fn []
+                 (reset! root {:a 2})   ;; queues the flush (no drain yet)
+                 (throw e1)))           ;; E1 escapes the body after queueing
+             (catch :default e (reset! caught e)))
+        (is (identical? e1 @caught)
+            "E1 (the body's earliest escape) surfaced with exact identity — the
+             drain's E2 did not displace it (rf2-2u4rw)"))
+      ;; Scheduler recovered: a normal replace! after the failure flushes
+      ;; cleanly (queue/flushing?/:escaped all clean).
+      (reset! boom? false)
+      (let [notes (atom [])]
+        (add-watch drain-thrower :w (fn [_ _ _ nu] (swap! notes conj nu)))
+        (replace! root {:a 5})
+        (is (= [5] @notes)
+            "a later replace! flushes normally — scheduler state fully restored
+             after the body-throw + drain-throw cascade")
+        (is (= 5 @drain-thrower) "the derived value settled to the new slice"))))
+
+  (testing "the body-over-drain primary is preserved by PRESENCE: a body that
+            throws a FALSEY value (`nil` / `false`, both legal CLJS throws)
+            still wins over a truthy drain E2, with exact identity. (rf2-2u4rw)"
+    (doseq [thrown-val [false nil]]
+      (let [scheduler    (spine/make-scheduler)
+            make-derived (spine/make-derived-value-fn "rf-b2f-" scheduler)
+            root         (spine/make-state-container {:a 1})
+            boom?        (atom false)
+            _drain-thrower (make-derived [root]
+                             (fn [db] (when @boom? (throw (js/Error. "E2 drain")))
+                               (:a db)))]
+        (is (= 1 @_drain-thrower) "baseline deref")
+        (reset! boom? true)
+        (let [caught (atom ::none)
+              threw? (atom false)]
+          (try (#'spine/with-epoch scheduler
+                 (fn [] (reset! root {:a 2}) (throw thrown-val)))
+               (catch :default e (reset! threw? true) (reset! caught e)))
+          (is @threw?
+              (str "with-epoch SURFACED the `" (pr-str thrown-val) "` body throw"))
+          (is (identical? thrown-val @caught)
+              (str "the surfaced value IS the original `" (pr-str thrown-val)
+                   "` body throw — earliest primary preserved by presence, not "
+                   "truthiness, over the truthy drain E2")))))))
+
 ;; ---- native derived fan-out: rf= movement law ----------------------------
 ;; (rf2-vxgfnd.203)
 


### PR DESCRIPTION
Completes the single scheduler exception contract in `core/.../substrate/spine.cljs` at the two entry boundaries #6106 left incomplete. No error bus, no aggregation framework, no container/ratom change, no new public error id.

## The two boundary seams

**Boundary 1 — depth-zero direct source-atom watch** (`drain-scheduler!` via `schedule-flush!`, spine.cljs). A direct `reset!` fires its source's watches one at a time through the atom's own uncontained notify loop; each derived dependent's watch marks-dirty and, at depth zero, drains inline. The old drain re-raised the FIRST dependent's failure inline → it escaped the atom notify loop → the LATER dependents' watches never marked/enqueued (a supported direct mutation suppressing sibling derived work). Capture now lives on the scheduler's `:escaped` cell (by presence), surviving across the sequential per-watch drains. A drain re-raises **only a stale escape** (present at entry, deferred by an earlier sibling drain); a **fresh** escape is left in `:escaped` so the atom loop continues to the later sibling, which marks/drains its own flush, and that sibling's drain surfaces the earliest primary. Net: the later sibling runs, THEN the first failure surfaces once, identity preserved.

**Boundary 2 — `with-epoch` body/finally ordering** (`with-epoch`, spine.cljs). A body that queues work then throws E1, whose queued drain then throws E2, lost E1 to JavaScript's finally-replaces-try semantics. The body escape is now caught, seeded onto `:escaped` as the earliest **before** the drain runs (a drain E2 cannot displace it), the drain attempts the queued tail + restores state, and the **earliest (E1 over E2)** surfaces once via `surface-escaped!`. `depth` is decremented on both paths so nested-epoch accounting stays correct. Presence capture keeps a `false`/`nil` body throw representable.

## Red-before / green-after

Two focused CLJS tests in `spine_glitch_free_cljs_test.cljs`, each reproducing a boundary defect:

- `direct-source-earlier-throw-still-drains-later-sibling` — earlier dependent throws; asserts the later sibling's flush still ran + notified, then the earlier failure surfaces by identity, scheduler recovers.
- `with-epoch-body-throw-wins-over-drain-throw` (+ falsey `false`/`nil` variant) — body E1 wins over drain E2 by exact identity/presence, scheduler recovers.
- `direct-source-both-dependents-throw-surfaces-earliest` — supplementary earliest-wins pin.

Against the pre-fix source (tests kept, source reverted to HEAD): **6 assertion failures** across the two boundary tests. With the fix: **0 failures**.

## Common-path preservation (no hot-path regression)

- `:escaped` is a scheduler-lifetime volatile (allocated once by `make-scheduler`) → no per-drain capture volatile; the drain cursor is now a loop binding, not a volatile. An ordinary empty / one-subscriber drain allocates nothing here.
- Single-subscriber fan-out uses `sole-val` (`reduce-kv` + hoisted `pick-third`) instead of `(val (first ws))`, dropping the singleton map-seq + `MapEntry` allocation. Two-plus subscribers still pay the capture volatile + `run!` closure only.

## Scope note

A bare-`atom` cascade where the *last-firing* sibling itself throws is an inherent limitation of a plain atom's sequential notify loop (can't batch without a container type) and is outside the acceptance ("when the earlier dependent throws") and outside production (production compute-fn is `validate-and-trace`, which never throws). Kept in scope: the two drain entries only — no `make-state-container` type change.

## Quality gates

- `npm run test:cljs` (node-runtime CLJS; the scheduler is CLJS-hosted and the exception ordering is CLJS-observable) — **9879 tests, 48568 assertions, 0 failures, 0 errors** with the fix.
- No JVM arm: the scheduler is `.cljs`-only (requires react), so `test:cljs` is the complete gate for this surface.
