### PR TITLE
fix(machines): retain authoritative spawn-all preflight verdict and prepared children (rf2-ek435)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -449,6 +449,64 @@
           :skipped))
       :skipped)))
 
+;; ---- authoritative :spawn-all prepared-children handoff -------------------
+
+(def ^:private prepared-children-key
+  "The reserved join-state slot under which `spawn-all-init-fx`'s admission
+  preflight retains the AUTHORITATIVE prepared per-child result on the accept
+  path (rf2-ek435): a `{<spawned-id> {:spec <stamped-spec> :snap <initial-snap>}}`
+  map, one entry per admitted child. Each child's own `:rf.machine/spawn` fx —
+  a SEPARATE entry later in the same entry vector — consumes its entry
+  (`spawn-all-prepared-child`) rather than re-resolving the type, rebuilding the
+  snapshot, or re-running its `[:schemas :data]` validator. Consuming rather than
+  recomputing is what makes the preflight's verdict authoritative: a type
+  re-registration or a second validator pass between the preflight and the
+  install can no longer flip an admitted child into a rejected one (which would
+  strand an impossible half-live join), and each child is resolved / prepared /
+  validated EXACTLY ONCE per attempt.
+
+  The slot is EPHEMERAL install-time scratch, not durable join state: each
+  consuming child drops its own entry inside the SAME runtime-db swap that
+  installs its snapshot (`drop-prepared-entry`), and the key vanishes once the
+  last child has installed — so the join state the `join.cljc` interceptor and
+  epoch capture see carries no scratch. It rides under a reserved `:rf/*` key,
+  is never application-facing, and — unlike the retired public boolean verdict —
+  cannot be forged: the value the install lands is the framework-built snapshot,
+  not a re-derivation a public flag could bypass."
+  :rf/prepared)
+
+(defn- spawn-all-prepared-child
+  "The framework-owned prepared result `spawn-all-init-fx` retained for THIS
+  `:spawn-all` child (rf2-ek435), read from the join slot's `:rf/prepared`
+  scratch by the child's own spawned-id. Returns `{:spec <stamped-spec>
+  :snap <initial-snap>}` for an admitted `:spawn-all` child, or nil when there
+  is no invoke (`:rf/spawn-all-id` absent — a plain single `:spawn`) or no
+  prepared entry (a hand-emitted `:spawn-all` child fx with no preceding init
+  fx, which falls back to the resolve/build/validate path). `spawn-all-init-fx`
+  is the FIRST fx in the entry vector, so on the normal declarative path the
+  entry is always present by the time this child's spawn fx runs."
+  [runtime-db args spawned-id]
+  (when-let [invoke-id (:rf/spawn-all-id args)]
+    (get-in runtime-db (conj (paths/spawned-path (:rf/parent-id args) invoke-id)
+                             prepared-children-key spawned-id))))
+
+(defn- drop-prepared-entry
+  "Remove THIS child's consumed `:rf/prepared` entry from the join slot, and
+  drop the `:rf/prepared` key entirely once the last admitted child has
+  consumed its entry — so the durable join state carries no install-time
+  scratch (rf2-ek435). Applied to the install's `rt-after-alloc` base so the
+  drop rides the SAME runtime-db swap that lands the snapshot; a no-op if the
+  join slot is not a live join (belt-and-braces)."
+  [runtime-db args spawned-id]
+  (update-in runtime-db (paths/spawned-path (:rf/parent-id args) (:rf/spawn-all-id args))
+             (fn [join-state]
+               (if (map? join-state)
+                 (let [remaining (dissoc (get join-state prepared-children-key) spawned-id)]
+                   (if (seq remaining)
+                     (assoc join-state prepared-children-key remaining)
+                     (dissoc join-state prepared-children-key)))
+                 join-state))))
+
 ;; ---- :rf.machine/spawn -----------------------------------------------------
 
 (defn spawn-fx
@@ -602,24 +660,48 @@
         ;; Machine snapshots are durable runtime-db state.
         old-rt     (frame/frame-runtime-db-value frame-id)
         machine-id-for-alloc (or (:id-prefix args) (:machine-id args))
-        [rt-after-alloc spawned-id]
+        [rt-after-alloc-raw spawned-id]
         (cond
           pre-id        [old-rt pre-id]
           (and old-rt machine-id-for-alloc)
                         (allocate-actor-id-in-runtime-db old-rt machine-id-for-alloc)
           :else         [old-rt nil])
-        ;; The stamped spec this install would land — built through the SAME
-        ;; `candidate-spawn-spec` path `spawn-all-init-fx`'s preflight uses, so
-        ;; a `:spawn-all` child's invoke-level verdict and its install-time
-        ;; verdict are decided over an identical value (rf2-7u8gen).
-        spec''     (candidate-spawn-spec args spawned-id
-                                         (join-child-record old-rt args spawned-id))
-        ;; Build the initial snapshot ONCE here so the schema-rejection
-        ;; decision can gate every side effect below; `install-spawn!`
-        ;; threads the same value rather than re-building it.
-        initial-snap (when spec''
-                       (parallel/build-initial-snapshot
-                         spec'' {:bootstrap-pending? true}))
+        ;; A `:spawn-all` child consumes the AUTHORITATIVE prepared result its
+        ;; invoke's `spawn-all-init-fx` preflight resolved, stamped, built, and
+        ;; validated ONCE (rf2-ek435) — never re-resolving the type, rebuilding
+        ;; the snapshot, or re-running its `[:schemas :data]` validator here. So
+        ;; a type re-registration or a second validator pass BETWEEN the
+        ;; preflight and this install can no longer flip an admitted child into
+        ;; a rejected one (which stranded an impossible half-live join naming a
+        ;; child whose snapshot a second verdict omitted), and the validator
+        ;; runs exactly once per attempt. nil for a plain single `:spawn` or a
+        ;; hand-emitted child with no preceding init fx — those keep the
+        ;; resolve/build/validate path below.
+        prepared   (spawn-all-prepared-child old-rt args spawned-id)
+        ;; Consuming the entry drops it from the join slot's `:rf/prepared`
+        ;; scratch in the SAME runtime-db swap that installs the snapshot, so
+        ;; the durable join state carries none once every child has installed.
+        rt-after-alloc (if prepared
+                         (drop-prepared-entry rt-after-alloc-raw args spawned-id)
+                         rt-after-alloc-raw)
+        ;; The stamped spec this install lands. For a `:spawn-all` child it is
+        ;; the framework-owned spec the preflight already resolved + stamped
+        ;; (consumed, not recomputed); otherwise it is built through the SAME
+        ;; `candidate-spawn-spec` path the preflight uses, so the fallback
+        ;; per-child verdict is still decided over an identical value.
+        spec''     (if prepared
+                     (:spec prepared)
+                     (candidate-spawn-spec args spawned-id
+                                           (join-child-record old-rt args spawned-id)))
+        ;; The initial snapshot the install lands. Consumed verbatim from the
+        ;; preflight for a `:spawn-all` child (built ONCE there); built ONCE
+        ;; here otherwise, so the schema-rejection decision can gate every side
+        ;; effect below and `install-spawn!` threads the same value.
+        initial-snap (if prepared
+                       (:snap prepared)
+                       (when spec''
+                         (parallel/build-initial-snapshot
+                           spec'' {:bootstrap-pending? true})))
         ;; Decide schema rejection BEFORE the trace and the
         ;; install. Gating both on `(not rejected?)` makes a rejected spawn
         ;; FULLY atomic — it installs no snapshot, records no spawn-order
@@ -631,7 +713,14 @@
         ;; nothing to runtime-db, so no liveness exists for the rejected actor
         ;; (the strongest form of atomicity: an actor's liveness IS its
         ;; snapshot, and the snapshot was never installed).
-        rejected?  (spawn-rejected? spec'' spawned-id initial-snap continue?)]
+        ;;
+        ;; A `:spawn-all` child that reached here was ADMITTED by the
+        ;; authoritative preflight (a rejected invoke is suppressed upstream by
+        ;; `spawn-all-invoke-rejected?` before `spawn-fx*` runs), and its
+        ;; validator ALREADY ran once there — so it is never re-validated here.
+        rejected?  (if prepared
+                     false
+                     (spawn-rejected? spec'' spawned-id initial-snap continue?))]
     ;; Gate the ENTIRE accepted-spawn cascade — the
     ;; `:rf.machine.spawn/spawned` trace, the snapshot/system-id/spawn-slot
     ;; install, AND the `:start` (or synthetic) dispatch — on THREE conditions:
@@ -809,38 +898,63 @@
 (defn- next-join-attempt-token []
   (swap! join-attempt-counter inc))
 
-(defn- schema-rejected-child?
-  "True iff `args` — ONE prepared per-child spawn of the `:spawn-all` whose
-  join-state is `join-state` — would be REJECTED by spawn-time
-  `[:schemas :data]` validation. Emits that child's
-  `:rf.error/schema-validation-failure :phase :spawn` exactly once, as it
-  decides (rf2-7u8gen).
+(defn- prepare-spawn-all-child
+  "The AUTHORITATIVE single preparation of ONE `:spawn-all` per-child spawn for
+  an attempt (rf2-ek435 / rf2-7u8gen). Resolves the child's TYPE, stamps its
+  framework `:data`, builds its initial snapshot, and runs its `[:schemas :data]`
+  validator EXACTLY ONCE — against the join-state about to be seeded — and
+  returns the prepared result the per-child install then consumes verbatim:
 
-  Builds the candidate snapshot through the SAME `candidate-spawn-spec` /
-  `build-initial-snapshot` path the per-child install runs, against the
-  join-state about to be seeded — so this IS the verdict the install would
-  reach, not an approximation of it.
+    {:args <spawn-args> :spawned-id <id> :spec <stamped-spec> :snap <initial-snap>
+     :unregistered? <bool> :schema-reject? <bool> :rejected? <bool>}
 
-  An unregistered TYPE resolves to no spec and is NOT a schema reject
-  (`spawn-rejected?` is false for a nil spec): `unregistered-spawn-type?` owns
-  that child, and the two invoke-level reject reasons stay disjoint — each
-  offending child is counted, and reported, under exactly one of them.
+  The child is resolved ONCE: `candidate-spawn-spec` returns nil exactly when
+  the TYPE is unregistered (an inline `:definition` always resolves to itself),
+  so `:unregistered?` is derived from that one resolution rather than a second
+  registry read. `:schema-reject?` runs the application `[:schemas :data]`
+  validator (via `spawn-rejected?`), emitting that child's
+  `:rf.error/schema-validation-failure :phase :spawn` exactly once as it
+  decides. The two reject reasons are DISJOINT — an unregistered TYPE resolves
+  to no spec, so it can never also be a schema reject — so each offending child
+  is reported under exactly one of them.
 
-  Returns nil (not a reject) for a child with no pre-allocated id: its
-  `:rf/self-id` stamp — and therefore its `:data` — is unknowable until the
-  install allocates one, so there is nothing faithful to validate. The
-  transition reducer pre-allocates every declarative `:spawn-all` child; the
-  runtime-db fallback allocator serves only hand-emitted `:rf.machine/spawn`
-  fxs, which belong to no invoke and so have no invoke to reject."
+  The validator is application code fenced to A's exact incarnation via
+  `continue?`; the invoke-level caller rechecks `(continue?)` after the whole
+  preflight before any durable write.
+
+  `:spawned-id` is nil (nothing prepared) for a child with no pre-allocated id:
+  its `:rf/self-id` stamp — and therefore its `:data` — is unknowable until an
+  install allocates one, so there is nothing faithful to prepare. The transition
+  reducer pre-allocates every declarative `:spawn-all` child; the runtime-db
+  fallback allocator serves only hand-emitted `:rf.machine/spawn` fxs, which
+  belong to no invoke."
   [args join-state continue?]
-  (when-let [spawned-id (pre-allocated-actor-id args)]
-    (let [spec (candidate-spawn-spec
-                 args spawned-id
-                 (join-child-record-from-state join-state args spawned-id))
-          snap (when spec
-                 (parallel/build-initial-snapshot
-                   spec {:bootstrap-pending? true}))]
-      (spawn-rejected? spec spawned-id snap continue?))))
+  (let [spawned-id (pre-allocated-actor-id args)
+        ;; ONE resolution + framework-stamp, shared by the verdict AND the
+        ;; snapshot the install consumes — through the SAME `candidate-spawn-spec`
+        ;; path the fallback per-child install would run, so the two can never
+        ;; disagree about the value that gets validated.
+        spec       (when spawned-id
+                     (candidate-spawn-spec
+                       args spawned-id
+                       (join-child-record-from-state join-state args spawned-id)))
+        ;; Unregistered ⟺ a `:machine-id` (no inline `:definition`) that resolved
+        ;; to no spec — read off the SAME resolution above, not a second lookup.
+        unregistered? (boolean (and (some? spawned-id)
+                                    (some? (:machine-id args))
+                                    (nil? (:definition args))
+                                    (nil? spec)))
+        snap       (when spec
+                     (parallel/build-initial-snapshot spec {:bootstrap-pending? true}))
+        schema-reject? (boolean (and spec (some? spawned-id)
+                                     (spawn-rejected? spec spawned-id snap continue?)))]
+    {:args           args
+     :spawned-id     spawned-id
+     :spec           spec
+     :snap           snap
+     :unregistered?  unregistered?
+     :schema-reject? schema-reject?
+     :rejected?      (or unregistered? schema-reject?)}))
 
 (defn- write-spawned-slot!
   "Write `value` into the frame's join slot at
@@ -880,7 +994,10 @@
      :cancelled  #{}   ;; authenticated explicit-teardown tombstones for THIS attempt
      :resolved?  false
      :spec       <invoke-all-spec>
-     :rf/attempt <opaque-attempt-token>}   ;; minted HERE per live seed (rf2-nvxehu)
+     :rf/attempt <opaque-attempt-token>   ;; minted HERE per live seed (rf2-nvxehu)
+     :rf/prepared {<spawned-id> {:spec <stamped-spec> :snap <initial-snap>}, ...}}
+       ;; EPHEMERAL — the authoritative prepared children each per-child install
+       ;; CONSUMES then drops (rf2-ek435); gone once every child has installed.
 
   Subsequent `:on-child-done` / `:on-child-error` events arrive at the
   parent's `make-machine-handler` boundary and are intercepted by
@@ -957,7 +1074,24 @@
         ;; everything a per-child effect would: the materialised `:data`, the
         ;; pre-allocated id, and hence the child's real `[:schemas :data]`
         ;; verdict (rf2-7u8gen).
-        child-args (:child-args args)
+        ;;
+        ;; rf2-ek435 — re-stamp each child-arg's `:rf/spawn-all-id` (and
+        ;; `:rf/parent-id`) to THIS fx's own `invoke-id` / `parent-id`. For a
+        ;; PARALLEL-region invoke, `parallel/prefix-region-invoke-id` region-
+        ;; prefixes the init-fx's top-level `:rf/invoke-id` AND every per-child
+        ;; `:rf.machine/spawn` fx's top-level `:rf/spawn-all-id`, but NOT the
+        ;; `:child-args` nested here — so their `:rf/spawn-all-id` is the
+        ;; UN-prefixed path. The preflight now RETAINS the `:rf/join-child`
+        ;; membership record built from these args (rf2-nvxehu `:invoke-id`), and
+        ;; the per-child install consumes it, so that record must carry the SAME
+        ;; region-prefixed invoke-id the per-child spawn fxs (and hence the join
+        ;; slot) use — else a parallel child's completion coordinate names a slot
+        ;; the region never seeded and its join never folds. `invoke-id` here IS
+        ;; the region-prefixed value (the fx's own top-level `:rf/invoke-id`); in
+        ;; the flat case this is a no-op (they already match).
+        child-args (mapv #(assoc % :rf/parent-id parent-id
+                                   :rf/spawn-all-id invoke-id)
+                         (:child-args args))
         ;; Mint the attempt token BEFORE the preflight so the candidate
         ;; snapshots validated below carry the very `:rf/join-child` record the
         ;; per-child installs will stamp — identical values, identical
@@ -971,7 +1105,7 @@
         continue?  (data-validation/owner-continuation frame-id)
         ;; rf2-8nxsh — the RAW exact owner token (`continue?` closes over the
         ;; same authority). The admission preflight below runs application
-        ;; `[:schemas :data]` validators (`schema-rejected-child?`), and the
+        ;; `[:schemas :data]` validators (`prepare-spawn-all-child`), and the
         ;; reject path fans callback-bearing always-on reject records + dev
         ;; traces (`reject-unregistered-spawn!`): each is application / listener
         ;; code that can synchronously destroy owner frame A and publish same-id
@@ -982,17 +1116,24 @@
         ;; `continue?`'s `(constantly true)`.
         owner-token (frame/current-event-owner-token)
         ;; ---- The invoke-level admission preflight ------------------------
-        ;; ONE decision, authoritative for EVERY fail-closed child-admission
-        ;; condition, taken BEFORE a live join or ANY child side effect is
-        ;; published (rf2-qb1j5z for unregistered types, rf2-7u8gen for
-        ;; spawn-time schema validity). The two conditions are DISJOINT — an
-        ;; unregistered type resolves to no spec, so it can never also be a
-        ;; schema reject — hence each offending child is reported exactly once
-        ;; under exactly one of them. Registration-time SHAPE rejection stays
-        ;; where it already belongs (`reg-machine`).
-        unregistered   (filterv unregistered-spawn-type? child-args)
-        schema-invalid (filterv #(schema-rejected-child? % join-state continue?)
-                                child-args)]
+        ;; ONE authoritative preparation per child, then ONE decision — both
+        ;; taken BEFORE a live join or ANY child side effect is published
+        ;; (rf2-qb1j5z for unregistered types, rf2-7u8gen for spawn-time schema
+        ;; validity, rf2-ek435 for retaining the result). `prepare-spawn-all-child`
+        ;; resolves each child's type, stamps its `:data`, builds its snapshot,
+        ;; and runs its `[:schemas :data]` validator EXACTLY ONCE, returning the
+        ;; prepared result. The accept path retains those prepared children so
+        ;; each per-child install CONSUMES its resolved spec + built snapshot
+        ;; rather than recomputing them — the preflight's verdict AND its
+        ;; prepared set are authoritative, not re-derived downstream. The two
+        ;; reject reasons are DISJOINT — an unregistered type resolves to no
+        ;; spec, so it can never also be a schema reject — hence each offending
+        ;; child is reported exactly once under exactly one of them.
+        ;; Registration-time SHAPE rejection stays where it belongs
+        ;; (`reg-machine`).
+        prepared       (mapv #(prepare-spawn-all-child % join-state continue?) child-args)
+        unregistered   (mapv :args (filterv :unregistered? prepared))
+        schema-invalid (filterv :schema-reject? prepared)]
     (if (or (seq unregistered) (seq schema-invalid))
       ;; Fail-closed: reject the join so the never-running spec-less child
       ;; cannot hang the `:all` join forever. Emit EXACTLY one reject per
@@ -1056,9 +1197,23 @@
       ;; framework-owned tail — fire it ONLY when the join actually committed
       ;; into A (a nil return means B, or a dead frame, and gets no started
       ;; trace).
+      ;;
+      ;; rf2-ek435 — retain the AUTHORITATIVE prepared children on the seeded
+      ;; join under `:rf/prepared` (`{<spawned-id> {:spec … :snap …}}`, one
+      ;; entry per admitted child). Every child was admitted here, so each has a
+      ;; resolved spec + built snapshot; each per-child install then CONSUMES its
+      ;; entry (`spawn-all-prepared-child`) instead of re-resolving / rebuilding /
+      ;; re-validating, and drops it in the same swap that lands its snapshot —
+      ;; so the scratch never outlives the drain.
       (do (when (continue?)
-            (when (some? (write-spawned-slot! frame-id owner-token
-                                              parent-id invoke-id join-state))
+            (when (some? (write-spawned-slot!
+                           frame-id owner-token parent-id invoke-id
+                           (assoc join-state prepared-children-key
+                                  (into {}
+                                        (comp (filter :spawned-id)
+                                              (map (juxt :spawned-id
+                                                         #(select-keys % [:spec :snap]))))
+                                        prepared))))
               (trace/emit! :rf.machine :rf.machine.spawn-all/started
                            {;; The parent's live actor INSTANCE address;
                             ;; `:invoke-id` is the declarative invocation path.

--- a/implementation/machines/test/re_frame/spawn_all_authoritative_preflight_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/spawn_all_authoritative_preflight_cljs_test.cljc
@@ -1,0 +1,241 @@
+(ns re-frame.spawn-all-authoritative-preflight-cljs-test
+  "The `:spawn-all` admission preflight's VERDICT and its PREPARED CHILDREN are
+  AUTHORITATIVE (rf2-ek435).
+
+  `spawn-all-init-fx` (the FIRST fx in the entry vector) resolves, stamps,
+  builds, and `[:schemas :data]`-validates every declarative `:spawn-all` child
+  EXACTLY ONCE for an attempt, then RETAINS the prepared result — the resolved
+  spec + built snapshot per admitted child — under the join slot's reserved
+  `:rf/prepared` scratch. Each child's own `:rf.machine/spawn` fx (a SEPARATE
+  entry later in the same vector) then CONSUMES its prepared entry rather than
+  re-resolving the type, rebuilding the snapshot, or re-running the validator.
+
+  Before this fix `spawn-all-init-fx` retained only a BOOLEAN verdict, so every
+  accepted per-child spawn re-resolved / rebuilt / re-validated the same child:
+
+   - a direct all-valid invoke observed TWO validator calls per child, and
+   - a `:rf.machine.spawn-all/started` listener could re-register the child TYPE
+     between the two passes, so the preflight accepted v1 and published a live
+     child-bearing join while the per-child install resolved a now-rejecting v2
+     and installed NO snapshot — leaving an impossible half-live join naming a
+     child whose snapshot a SECOND verdict omitted.
+
+  Pinned here (JVM + CLJS):
+
+   1. An all-valid child's `[:schemas :data]` validator runs EXACTLY ONCE per
+      attempt (the install consumes the prepared result, it does not re-validate).
+   2. A type re-registration between the preflight and the install cannot omit
+      the child's snapshot — the install consumes the prepared v1, never the
+      re-registered v2 — so the join is never child-bearing-but-snapshotless.
+   3. An all-valid invoke still seeds a live join, and the ephemeral prepared
+      scratch is consumed + dropped: the durable join state retains none.
+   4. A partial-reject batch (one schema-invalid child among valid siblings)
+      still rejects atomically — one childless sentinel, no sibling installed,
+      exactly one spawn-phase failure, and no prepared scratch."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   ;; Loading the machines facade registers `rf/reg-machine` + the reserved
+   ;; machine fxs when this ns runs alone.
+   [re-frame.machines]
+   [re-frame.machines.test-support :as mtest]
+   ;; The schemas artefact ships the registered-validator hot path the
+   ;; `:where :machine-data` boundary routes through; the `.malli` adapter
+   ;; publishes Malli's validate/explain into the late-bind table.
+   [re-frame.schemas]
+   [re-frame.schemas.malli]
+   [re-frame.trace :as trace]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter}))
+  mtest/trace-capture-fixture)
+
+;; ---------------------------------------------------------------------------
+;; Fixtures under test.
+;; ---------------------------------------------------------------------------
+
+(def ^:private strict-child
+  "A child TYPE whose initial `:data` is schema-checked at spawn time. Its
+  registered default `{:n 1}` conforms to `pos-int?`."
+  {:initial :running
+   :data    {:n 1}
+   :schemas {:data [:map [:n pos-int?]]}
+   :states  {:running {:on {:finish {:target :done}}}
+             :done    {:final? true}}})
+
+(def ^:private plain-child
+  "An unconstrained sibling — a real live actor if anything installs."
+  {:initial :running
+   :data    {}
+   :states  {:running {}}})
+
+(defn- parent-over
+  "A `:spawn-all` parent over `children` with join mode `:all`."
+  [children]
+  {:initial :idle
+   :states
+   {:idle    {:on {:start :forking}}
+    :forking {:spawn-all {:children         children
+                          :join             :all
+                          :on-child-done    :sa/done
+                          :on-child-error   :sa/failed
+                          :on-all-complete  [:all/done]}
+              :on {:all/done :ready}}
+    :ready   {}}})
+
+(defn- join-slot [parent-id]
+  (get-in (mtest/runtime-db) [:rf.runtime/machines :spawned parent-id [:forking]]))
+
+(defn- snap-of [actor-id]
+  (get-in (mtest/runtime-db) [:rf.runtime/machines :snapshots actor-id]))
+
+(defn- spawn-phase-failures []
+  (filterv #(= :spawn (get-in % [:tags :phase]))
+           (mtest/events-of :rf.error/schema-validation-failure)))
+
+;; ===========================================================================
+;; (1) Validator cardinality — the accepted per-child install does NOT
+;;     re-validate; each child is validated EXACTLY ONCE per attempt.
+;; ===========================================================================
+
+(deftest each-spawn-all-child-is-validated-exactly-once-per-attempt
+  (testing "an all-valid :spawn-all child's [:schemas :data] validator runs
+            EXACTLY once for the attempt — the preflight prepares + validates it
+            and the per-child install CONSUMES that prepared snapshot rather than
+            re-validating (the pre-fix all-valid path observed TWO calls). The
+            count is sampled at the child's :rf.machine.lifecycle/spawned trace —
+            after the install, before any later macrostep re-validation."
+    (let [calls       (atom 0)
+          at-install  (atom nil)
+          listener-id ::count-at-install]
+      ;; A conforming schema that COUNTS every validate call. It passes
+      ;; ({:n 1} is a pos-int?), so the child installs on both the fixed and the
+      ;; pre-fix path — the DISCRIMINATOR is how many times it was validated by
+      ;; install time, not whether it installed.
+      (rf/reg-machine :sa/counted
+                      {:initial :running
+                       :data    {:n 1}
+                       :schemas {:data [:fn (fn [v] (swap! calls inc) (pos-int? (:n v)))]}
+                       :states  {:running {}}})
+      (rf/reg-machine :sup/count (parent-over [{:id :c :machine-id :sa/counted}]))
+      (trace/register-listener!
+        listener-id
+        (fn [ev]
+          (when (and (= :rf.machine.lifecycle/spawned (:operation ev))
+                     (= :sa/counted#1 (get-in ev [:tags :spawned-id]))
+                     (nil? @at-install))
+            (reset! at-install @calls))))
+      (try
+        (rf/dispatch-sync [:sup/count [:start]])
+        (finally (trace/unregister-listener! listener-id)))
+      (is (some? (snap-of :sa/counted#1))
+          "(precondition) the conforming child installed a live snapshot")
+      (is (= 1 @at-install)
+          "validated EXACTLY once by install time — the preflight prepared it and
+           the install consumed that result (the pre-fix path re-validated → 2)"))))
+
+;; ===========================================================================
+;; (2) Type re-registration between the preflight and the install cannot omit
+;;     the child's snapshot — the authoritative repro of the half-live join.
+;; ===========================================================================
+
+(deftest type-reregistration-between-preflight-and-install-cannot-omit-a-snapshot
+  (testing "a :rf.machine.spawn-all/started listener that RE-REGISTERS a child
+            TYPE to a now-rejecting spec cannot flip the admitted child into a
+            rejected one: the per-child install consumes the preflight's prepared
+            v1 snapshot rather than re-resolving + re-validating the v2 the
+            listener installed, so the child installs and the join is FULLY live
+            — never a child-bearing join whose snapshot a SECOND verdict omitted."
+    (rf/reg-machine :sa/strict strict-child)         ; v1 — pos-int?, data {:n 1}, conforms
+    (rf/reg-machine :sup/rereg (parent-over [{:id :c :machine-id :sa/strict}]))
+    (let [listener-id ::rereg
+          fired       (atom false)]
+      (trace/register-listener!
+        listener-id
+        (fn [ev]
+          (when (and (= :rf.machine.spawn-all/started (:operation ev))
+                     (not @fired))
+            (reset! fired true)
+            ;; v2 — the SAME states but a schema that REJECTS the very {:n 1}
+            ;; data the preflight already admitted. A pre-fix install re-resolves
+            ;; this and rejects the child, installing no snapshot.
+            (rf/reg-machine :sa/strict
+                            (assoc strict-child :schemas {:data [:map [:n neg-int?]]})))))
+      (try
+        (rf/dispatch-sync [:sup/rereg [:start]])
+        (finally (trace/unregister-listener! listener-id)))
+      (is (true? @fired)
+          "(precondition) the started listener fired and re-registered the type"))
+    (let [slot (join-slot :sup/rereg)]
+      (is (contains? slot :children)
+          "a LIVE child-bearing join was seeded")
+      (is (= {:c :sa/strict#1} (:children slot))
+          "the join names the admitted child at its allocated id"))
+    ;; The install fired its lifecycle trace AND landed the snapshot — proof it
+    ;; consumed the prepared v1 rather than re-resolving/re-validating v2 (which
+    ;; would have omitted the snapshot, stranding an impossible half-live join).
+    (is (seq (filterv #(= :sa/strict#1 (get-in % [:tags :spawned-id]))
+                      (mtest/events-of :rf.machine.lifecycle/spawned)))
+        "the child's install COMMITTED (a lifecycle/spawned trace fired) — a second verdict did not omit it")
+    (is (some? (snap-of :sa/strict#1))
+        "the child's snapshot INSTALLED — the install consumed the preflight's prepared v1")
+    (is (= :running (mtest/machine-state :sa/strict#1))
+        "the installed snapshot is v1's (state :running) — the prepared result was consumed verbatim, not re-derived from v2")))
+
+;; ===========================================================================
+;; (3) All-valid keeps the live join AND retains no prepared scratch.
+;; ===========================================================================
+
+(deftest all-valid-seeds-a-live-join-and-retains-no-prepared-scratch
+  (testing "an all-valid :spawn-all seeds a LIVE child-bearing join and every
+            child installs; the authoritative :rf/prepared scratch the preflight
+            retained is CONSUMED and dropped by the installs, so the durable
+            join state carries none once the drain completes."
+    (rf/reg-machine :sa/plain plain-child)
+    (rf/reg-machine :sup/clean (parent-over [{:id :a :machine-id :sa/plain}
+                                             {:id :b :machine-id :sa/plain}]))
+    (rf/dispatch-sync [:sup/clean [:start]])
+    (let [slot (join-slot :sup/clean)
+          ids  (vals (:children slot))]
+      (is (contains? slot :children)
+          "a live child-bearing join — no false reject")
+      (is (= 2 (count ids))
+          "the join names both children")
+      (is (not (contains? slot :rf/prepared))
+          "the ephemeral prepared scratch was consumed + dropped — the durable join retains none")
+      (doseq [id ids]
+        (is (some? (snap-of id))
+            (str "child " id " installed its snapshot"))))))
+
+;; ===========================================================================
+;; (4) Adversarial: a partial-reject batch still rejects atomically and retains
+;;     no prepared scratch.
+;; ===========================================================================
+
+(deftest partial-reject-batch-rejects-atomically-with-no-prepared-scratch
+  (testing "a batch with ONE schema-invalid child among valid siblings rejects
+            the WHOLE invoke: one childless reject sentinel (never a prepared
+            join), no sibling installed, and exactly one spawn-phase schema
+            failure — the invalid child validated ONCE, its siblings suppressed."
+    (rf/reg-machine :sa/strict strict-child)
+    (rf/reg-machine :sa/plain plain-child)
+    (rf/reg-machine :sup/partial
+                    (parent-over [{:id :ok  :machine-id :sa/plain}
+                                  {:id :bad :machine-id :sa/strict :data {:n -1}}
+                                  {:id :ok2 :machine-id :sa/plain}]))
+    (rf/dispatch-sync [:sup/partial [:start]])
+    (is (= {:rf/spawn-all-rejected? true} (join-slot :sup/partial))
+        "one childless reject sentinel — exactly this map, so NO :rf/prepared scratch leaked onto the reject path")
+    (is (nil? (snap-of :sa/strict#1))
+        "the schema-invalid child installed nothing")
+    (is (nil? (snap-of :sa/plain#1))
+        "no valid sibling installed — the reject is ATOMIC")
+    (is (nil? (snap-of :sa/plain#2))
+        "no valid sibling installed — the reject is ATOMIC")
+    (is (= 1 (count (spawn-phase-failures)))
+        "exactly ONE :phase :spawn failure — the invalid child validated once, never re-validated under a suppressed per-child spawn")))


### PR DESCRIPTION
Closes rf2-ek435 (P1, bug).

## Problem

`spawn-all-init-fx` (the first fx in the entry vector) is the authoritative batch-admission preflight, but PR #6010 retained only a **boolean** verdict. Every accepted per-child `spawn-fx*` then re-resolved the type, rebuilt the snapshot, and re-ran the `[:schemas :data]` validator. Two concrete defects on current `main`:

- **Double validation.** A direct all-valid invoke ran each child's validator **twice** (preflight + per-child install).
- **Divergent verdict / half-live join.** A `:rf.machine.spawn-all/started` listener that re-registers a child TYPE between the two passes made the preflight admit v1 and publish a live child-bearing join, while the per-child install resolved a now-rejecting v2 and installed **no snapshot** — a child-bearing join whose snapshot a second verdict omitted (the exact dead-join/orphan class rf2-7u8gen removed via the schema path).

## Fix

The preflight now prepares each child **once** (`prepare-spawn-all-child`: resolve + framework-stamp + build snapshot + validate) and **retains** the result — the resolved spec and built snapshot per admitted child — under the join slot's reserved, ephemeral `:rf/prepared` scratch. Each per-child install **consumes** its entry (`spawn-all-prepared-child`) rather than recomputing, and **drops** it in the same runtime-db swap that lands its snapshot, so the durable join state carries no scratch (verified).

Result: the admit/reject **verdict** and the **prepared child set** are authoritative — no type re-registration or second validator pass between the preflight and the install can flip an admitted child into a rejected one, and each child is resolved / prepared / validated **exactly once** per attempt. The prepared value is the framework-built snapshot, not a re-derivation a public boolean could bypass.

Also re-stamps each nested child-arg's `:rf/spawn-all-id` to the init-fx's own (region-prefixed) `invoke-id`: `parallel/prefix-region-invoke-id` prefixes the per-child spawn fxs but **not** the init-fx's nested `:child-args`, so the retained `:rf/join-child` coordinate must be normalized or a parallel-region child's completion names a slot its region never seeded and its join never folds. (Regression caught by the existing parallel-routing test and fixed before merge.)

Minimal, at the existing seam: no new fx/event, no batch-admission redesign, no result-envelope framework — the data already computed at preflight time is carried through to the consumer.

## Scope / fences

- Touches only `implementation/machines/src/.../lifecycle_fx/spawn.cljc` + a new test.
- **Spec 005 not touched** (leeqp is live on it). `:rf/prepared` is ephemeral, never-observable install-time scratch (seeded and fully dropped within the entry-fx drain — gone before any completion, epoch capture, or tool reads the join-state), so it is **not** part of the durable join-state contract Spec 005 catalogues. No spec change required; a one-line doc note is optional at most.

## Quality gates

Red-before/green-after was demonstrated by running the new test against the pre-fix `spawn.cljc` from `origin/main`: **4 failures** (cardinality observed 2 not 1; re-registration stranded a snapshotless half-live join — no lifecycle/spawned trace, nil snapshot), then **0 failures** after the fix.

| Gate | Result |
|---|---|
| `implementation/machines` JVM (`clojure -M:test`) — full suite | **1178 tests / 4066 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` (node-test, all artefacts) | **9880 tests / 48566 assertions, 0 failures, 0 errors** |
| New `spawn-all-authoritative-preflight-cljs-test` (JVM + CLJS) | green both hosts |

### New test coverage (`spawn_all_authoritative_preflight_cljs_test.cljc`, `.cljc` → JVM + CLJS)

1. **Validator cardinality** — an all-valid child's `[:schemas :data]` validator runs **exactly once** per attempt (sampled at the child's `:rf.machine.lifecycle/spawned` trace, before later macrostep re-validation). Pre-fix: 2.
2. **Type re-registration seam** — a `:rf.machine.spawn-all/started` listener re-registers the child TYPE to a rejecting spec; the install consumes the prepared v1, so the child installs and the join is fully live (never child-bearing-but-snapshotless). Pre-fix: nil snapshot / no lifecycle trace.
3. **All-valid** — still seeds a live join; the `:rf/prepared` scratch is consumed + dropped (durable join retains none).
4. **Adversarial partial-reject batch** — one schema-invalid child among valid siblings still rejects atomically: one childless sentinel (no `:rf/prepared`), no sibling installed, exactly one spawn-phase failure.
