### PR TITLE
fix(bundle-isolation): make publishable-runtime enrolment structural and causal (rf2-zef0e)

### DIFF
--- a/.github/scripts/verify-version-lockstep.sh
+++ b/.github/scripts/verify-version-lockstep.sh
@@ -239,24 +239,32 @@ for artefact in "${ARTEFACTS[@]}"; do
   KNOWN_IMPL_PATHS["${ARTEFACT_PATHS[$artefact]}"]=1
 done
 # Adapters live under implementation/adapters/<name>/; their subpaths are
-# already registered (adapters/reagent, …). Walk both the flat
-# per-feature dirs and the adapters/ dir for :clein/build.
-while IFS= read -r deps_file; do
-  [[ -f "${deps_file}" ]] || continue
-  # Strip `;;` line comments before matching so a deps.edn that only
-  # MENTIONS :clein/build in prose (e.g. implementation/adapters/test-react/
-  # whose header documents that it deliberately carries NO :clein/build) is
-  # not mis-detected as publishable.
-  sed 's/;;.*$//' "${deps_file}" | grep -qF ':clein/build' || continue
-  # Derive the subpath relative to implementation/ (e.g. "resources" or
-  # "adapters/reagent").
-  subpath="${deps_file#"${REPO_ROOT}/implementation/"}"
-  subpath="${subpath%/deps.edn}"
+# already registered (adapters/reagent, …).
+#
+# rf2-zef0e — publishability is discovered via the shared EDN-AWARE authority
+# (implementation/scripts/lib/publishable-runtimes.cjs), the SAME structural
+# result the bundle-isolation gate consumes, instead of a duplicated textual
+# grep that could drift. The authority reads each deps.edn's real
+# :aliases/:clein/build KEY: a genuine alias survives `;` inside EDN strings,
+# and a :clein/build token inside a string, a `;` comment, or a `#_` discard
+# form (e.g. implementation/ui/ and implementation/adapters/test-react/ each
+# only MENTION the alias in prose) is correctly NOT treated as publishable. It
+# emits one implementation/-relative subpath per line for every publishable
+# artefact under implementation/ (bounded flat-plus-nested, same reach as the
+# previous `find -mindepth 2 -maxdepth 3`). If it cannot run we FAIL CLOSED
+# (exit) rather than skip the inventory guard.
+PUBLISHABLE_AUTHORITY="${REPO_ROOT}/implementation/scripts/lib/publishable-runtimes.cjs"
+if ! publishable_subpaths="$(node "${PUBLISHABLE_AUTHORITY}" "${REPO_ROOT}/implementation")"; then
+  echo "::error file=implementation/scripts/lib/publishable-runtimes.cjs::failed to enumerate publishable artefacts via the structural EDN authority (is node available on PATH?)"
+  exit 2
+fi
+while IFS= read -r subpath; do
+  [[ -z "${subpath}" ]] && continue
   if [[ -z "${KNOWN_IMPL_PATHS[$subpath]:-}" ]]; then
     echo "::error file=implementation/${subpath}/deps.edn::implementation/${subpath} declares a :clein/build (publishable) artefact but is NOT in the lockstep ARTEFACTS inventory — add it to ARTEFACT_PATHS / ARTEFACTS / NON_CORE in this script AND to the release.yml deploy matrix + release notes (rf2-qmhysc)"
     errors=$((errors + 1))
   fi
-done < <(find "${REPO_ROOT}/implementation" -mindepth 2 -maxdepth 3 -name deps.edn)
+done <<< "${publishable_subpaths}"
 
 # Tools/* deployable jars (rf2-lwtke). Each tools/<name>/deps.edn that
 # carries a :clein/build alias publishes to Clojars at the same lockstep

--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -62,8 +62,10 @@ const {
   countSubstring,
 } = require('./lib/read-release-bundle.cjs');
 const { assertSentinelSet } = require('./lib/sentinel-scan.cjs');
+const { pathDeclaresBuildAlias } = require('./lib/publishable-runtimes.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
+const SCRIPTS_DIR = __dirname;
 const report = createGateReporter();
 
 // ----- the bundle-isolation contract ----------------------------------------
@@ -89,6 +91,9 @@ const report = createGateReporter();
 const ARTEFACTS = [
   {
     name: 'schemas',
+    // Publishable per-feature runtime at implementation/schemas/. `relPath` is
+    // what canonical coverage keys on (exact path, never leaf name).
+    relPath: 'schemas',
     internalSentinels: [
       // schemas.cljc — `reg-app-schemas` validates its arg is a map.
       { source: 're-frame.schemas/reg-app-schemas (app-schemas-bad-arg)',
@@ -100,6 +105,7 @@ const ARTEFACTS = [
 
   {
     name: 'machines',
+    relPath: 'machines',
     internalSentinels: [
       // machines.cljc — `resolve-guard` ex-info on unresolved keyword.
       { source: 're-frame.machines/resolve-guard (machine-unresolved-guard)',
@@ -117,6 +123,7 @@ const ARTEFACTS = [
 
   {
     name: 'routing',
+    relPath: 'routing',
     internalSentinels: [
       // routing.cljc — `route` lookup ex-info.
       { source: 're-frame.routing route-by-id (no-such-route)',
@@ -131,6 +138,7 @@ const ARTEFACTS = [
 
   {
     name: 'flows',
+    relPath: 'flows',
     internalSentinels: [
       // flows.cljc — topological-sort cycle detection.
       { source: 're-frame.flows topo-sort (flow-cycle)',
@@ -156,6 +164,7 @@ const ARTEFACTS = [
 
   {
     name: 'http',
+    relPath: 'http',
     internalSentinels: [
       // http/managed.cljc — managed-abort fx (registered only when the
       // ns is loaded; the keyword string survives :advanced).
@@ -211,6 +220,7 @@ const ARTEFACTS = [
   // assembly remain reachable while the debug-only restore trace ids DCE.
   {
     name: 'epoch',
+    relPath: 'epoch',
     internalSentinels: [
       { source: 're-frame.epoch.listeners listener failure diagnostic',
         sentinel: 'rf.epoch.cb/listener-exception' },
@@ -231,6 +241,7 @@ const ARTEFACTS = [
 
   {
     name: 'ssr',
+    relPath: 'ssr',
     internalSentinels: [
       // ssr.cljc — namespace-prefix on every server-only fx and trace
       // op (`:rf.server/respond`, `:rf.server/redirect`, ...). The
@@ -273,6 +284,7 @@ const ARTEFACTS = [
   // resources artefact's own src tree (verified repo-wide).
   {
     name: 'resources',
+    relPath: 'resources',
     internalSentinels: [
       // registry.cljc — `reg-resource` spec validator ex-info reason.
       { source: 're-frame.resources.registry reg-resource (resource-bad-spec)',
@@ -873,30 +885,40 @@ function assertPositiveControlComplete(artefacts = ARTEFACTS, controls = POSITIV
   };
 }
 
-// ----- canonical publishable-runtime coverage (rf2-sh0sp4 / rf2-klyw5) -------
+// ----- canonical publishable-runtime coverage (rf2-sh0sp4 / rf2-klyw5 / rf2-zef0e) -------
 
 // assertPositiveControlComplete only cross-checks this script's own two local
 // tables (ARTEFACTS <-> POSITIVE_CONTROL): an artefact absent from BOTH is
 // defined away, not detected. That is exactly how the resources runtime slipped
 // the gate — a separately published, browser-reachable optional runtime omitted
 // from every internal table stayed green. This check closes that hole by
-// deriving the REQUIRED set from the SAME canonical authority the release
-// lockstep uses (.github/scripts/verify-version-lockstep.sh): every publishable
-// artefact deps.edn carrying a `:clein/build` alias is a published artefact.
-// Each browser-optional runtime among them MUST map either to a primary generic
-// ARTEFACTS entry here OR to a real dedicated isolation gate
-// (DEDICATED_ISOLATION_GATES below). It is filesystem-derived, so a NEW
-// browser-optional artefact — a new implementation/<name>/deps.edn OR a new
-// implementation/adapters/<name>/deps.edn with :clein/build, not in the
-// exclusion set — that is neither generic-gated nor dedicated-gated fails
-// automatically (FAIL-CLOSED). The check does NOT compare two copies of its own
-// local table.
+// deriving the REQUIRED set STRUCTURALLY from the real publishable surface: the
+// shared EDN-aware authority (scripts/lib/publishable-runtimes.cjs) that reads
+// each deps.edn's real `:aliases/:clein/build` KEY — the SAME parsed fact the
+// release lockstep (.github/scripts/verify-version-lockstep.sh) consumes. Each
+// browser-optional runtime among them MUST map — BY EXACT implementation-
+// relative PATH — either to a generic ARTEFACTS entry (whose `relPath` equals
+// the runtime's path) OR to a dedicated isolation gate whose descriptor
+// VALIDATES (real checker file + invoked package command). A runtime mapped to
+// NEITHER fails automatically (FAIL-CLOSED). The check does NOT compare two
+// copies of its own local table.
+//
+// rf2-zef0e makes the enrolment causal — the fail-closed claim can no longer be
+// discharged by text or names:
+//   - Discovery is EDN-structural (via publishable-runtimes.cjs): a genuine
+//     `:clein/build` survives `;` inside strings (so a real runtime is never
+//     silently omitted), and a token inside a string / comment / `#_` discard is
+//     NOT invented as an alias.
+//   - Coverage is keyed by EXACT relative path, so a future
+//     implementation/adapters/schemas can NOT inherit the flat
+//     implementation/schemas generic gate via a colliding directory leaf.
+//   - Dedicated coverage is a MACHINE-READABLE descriptor validated against real
+//     wiring (validateDedicatedGate), so a fictional prose entry, a removed
+//     checker, or an uninvoked command can NOT enrol a runtime.
 //
 // Traversal mirrors the release lockstep's bounded FLAT-plus-ADAPTERS shape:
 // per-feature + core-tier artefacts live at implementation/<name>/; substrate
-// adapters live one directory deeper at implementation/adapters/<name>/. The
-// pre-rf2-klyw5 scan read only the top level, so a newly publishable adapter was
-// never enrolled (rf2-klyw5 NOTES — a second counterexample to rf2-sh0sp4 AC6).
+// adapters live one directory deeper at implementation/adapters/<name>/.
 //
 // Excluded from the REQUIRED set (published, but NOT a browser-optional client
 // runtime — each with reason):
@@ -908,10 +930,11 @@ function assertPositiveControlComplete(artefacts = ARTEFACTS, controls = POSITIV
 // browser-capable substrate artefact that the adapters do NOT depend on, so the
 // old "always present, every adapter loads it" premise was false and let a
 // future publishable UI stay unguarded. Because implementation/ui/deps.edn
-// carries no real :clein/build today (only a comment mentioning the alias), UI
-// is not discovered and pre-publication stays green NATURALLY; when
-// rf2-vxgfnd.99.2 makes UI publishable, it must land a UI isolation entry/gate
-// in that same slice or this coverage check fails and names `ui`.
+// carries no real :clein/build today (only a comment mentioning the alias, which
+// the EDN-aware authority correctly ignores), UI is not discovered and
+// pre-publication stays green NATURALLY; when rf2-vxgfnd.99.2 makes UI
+// publishable, it must land a UI isolation entry/gate in that same slice or this
+// coverage check fails and names `ui`.
 const NON_BROWSER_OPTIONAL = new Set(['core', 'ssr-ring']);
 
 // Nested substrate-adapter tier, relative to implementation/ (matches the
@@ -919,53 +942,95 @@ const NON_BROWSER_OPTIONAL = new Set(['core', 'ssr-ring']);
 const ADAPTERS_DIR = 'adapters';
 
 // Browser-optional runtimes covered by a REAL dedicated isolation gate rather
-// than a generic ARTEFACTS entry. Each substrate adapter ships in the counter/
-// login example matrix and is proven isolated by an adapter-specific gate (the
-// per-feature artefacts, by contrast, must be ABSENT from the no-feature counter
-// bundle, which the generic ARTEFACTS sentinels prove). A discovered runtime
-// mapped here is accounted for; a discovered runtime mapped NOWHERE fails closed.
+// than a generic ARTEFACTS entry. KEYED BY EXACT implementation-relative PATH
+// (never leaf name) so a future implementation/adapters/<x> can not inherit a
+// flat implementation/<x> generic gate through a colliding directory leaf. Each
+// value is a MACHINE-READABLE descriptor: `checkers` are the real gate-script
+// filenames under scripts/, and `command` is the package.json script that
+// invokes them. validateDedicatedGate() confirms every checker file EXISTS and
+// that `command` is a real package script whose body INVOKES each checker — so a
+// truthy prose string, a removed checker, or an uninvoked command fails closed.
 // Keep this to the set of EXISTING dedicated gates only — do not add a runtime
-// here without a real gate script proving its isolation.
+// here without a real, invoked gate script proving its isolation.
 const DEDICATED_ISOLATION_GATES = {
-  reagent:
-    'check-uix-helix-reagent-free.cjs + check-login-bundle-isolation.cjs ' +
-    '(reagent is the counter/login reference substrate; its fingerprints are ' +
-    'the positive control both gates assert present, and absent from uix/helix)',
-  uix:
-    'check-uix-helix-reagent-free.cjs + check-login-bundle-isolation.cjs ' +
-    '(uix bundles must be reagent- and helix-free)',
-  helix:
-    'check-uix-helix-reagent-free.cjs + check-login-bundle-isolation.cjs ' +
-    '(helix bundles must be reagent- and uix-free)',
-  'reagent-slim':
-    'check-reagent-slim-bundle-isolation.cjs (test:reagent-slim:bundle-isolation ' +
-    '— slim bundle free of stock reagent + react-dom/server; classic bundle ' +
-    'free of the reagent2.* rewrite)',
+  'adapters/reagent': {
+    checkers: ['check-uix-helix-reagent-free.cjs', 'check-login-bundle-isolation.cjs'],
+    command: 'test:bundle-isolation',
+    note: 'reagent is the counter/login reference substrate; its fingerprints are ' +
+      'the positive control both gates assert present, and absent from uix/helix',
+  },
+  'adapters/uix': {
+    checkers: ['check-uix-helix-reagent-free.cjs', 'check-login-bundle-isolation.cjs'],
+    command: 'test:bundle-isolation',
+    note: 'uix bundles must be reagent- and helix-free',
+  },
+  'adapters/helix': {
+    checkers: ['check-uix-helix-reagent-free.cjs', 'check-login-bundle-isolation.cjs'],
+    command: 'test:bundle-isolation',
+    note: 'helix bundles must be reagent- and uix-free',
+  },
+  'adapters/reagent-slim': {
+    checkers: ['check-reagent-slim-bundle-isolation.cjs'],
+    command: 'test:reagent-slim:bundle-isolation',
+    note: 'slim bundle free of stock reagent + react-dom/server; classic bundle ' +
+      'free of the reagent2.* rewrite',
+  },
 };
 
-// Strip deps.edn line comments (`;` to EOL) so a header comment MENTIONING
-// `:clein/build` (several artefact deps.edn headers do — implementation/ui's is
-// exactly such a comment) is not mistaken for a real build alias.
-function stripEdnComments(edn) {
-  return edn.replace(/;[^\n]*/g, '');
+// Package.json scripts map, read once. Used to prove a dedicated gate's declared
+// command is a REAL invoked package script (not just a name in prose).
+function readPackageScripts(root = ROOT) {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+    return pkg.scripts || {};
+  } catch (_e) {
+    return {};
+  }
 }
 
-// True when <root>/<relPath>/deps.edn declares a REAL (non-comment) :clein/build
-// alias — i.e. the directory is a separately publishable artefact.
-function hasRealBuildAlias(root, relPath) {
-  let deps;
-  try {
-    deps = fs.readFileSync(path.join(root, relPath, 'deps.edn'), 'utf8');
-  } catch (_e) {
-    return false; // no deps.edn — not a publishable artefact directory
+// A dedicated-gate descriptor is CAUSAL only when it is wired to real, invoked
+// machinery. Returns `{ ok, reasons }`: ok iff `gate` is a
+// `{ checkers: [...], command }` map whose every checker file EXISTS in
+// scriptsDir AND whose command is a package.json script whose body INVOKES every
+// checker. A truthy prose string, a nonexistent checker, or an uninvoked/absent
+// command all fail — so enrolment can not be discharged by editing this table.
+function validateDedicatedGate(gate, { scriptsDir = SCRIPTS_DIR, scripts = readPackageScripts() } = {}) {
+  if (!gate || typeof gate !== 'object' || Array.isArray(gate)) {
+    return { ok: false, reasons: ['descriptor is not a { checkers, command } map (a prose string does not enrol a runtime)'] };
   }
-  return /:clein\/build/.test(stripEdnComments(deps));
+  const reasons = [];
+  const checkers = Array.isArray(gate.checkers) ? gate.checkers : [];
+  const command = typeof gate.command === 'string' ? gate.command : null;
+  if (checkers.length === 0) reasons.push('no checker script(s) declared');
+  for (const checker of checkers) {
+    if (!fs.existsSync(path.join(scriptsDir, checker))) {
+      reasons.push(`checker script does not exist: ${checker}`);
+    }
+  }
+  if (!command) {
+    reasons.push('no package/CI command declared');
+  } else {
+    const body = scripts[command];
+    if (body === undefined) {
+      reasons.push(`declared command is not an invoked package.json script: ${command}`);
+    } else {
+      for (const checker of checkers) {
+        if (!body.includes(checker)) {
+          reasons.push(`package command '${command}' does not invoke checker: ${checker}`);
+        }
+      }
+    }
+  }
+  return { ok: reasons.length === 0, reasons };
 }
 
 // Discover every publishable browser-optional runtime under implementation/,
-// using the lockstep authority's bounded flat-plus-adapters traversal. Returns
-// `{ name, relPath }` records; `name` is the directory leaf (unique across both
-// tiers) and `relPath` is the implementation/-relative path for diagnostics.
+// using the shared EDN-aware authority (`pathDeclaresBuildAlias`, the SAME
+// parsed `:aliases/:clein/build` fact the release lockstep consumes) over the
+// lockstep's bounded flat-plus-adapters traversal. Returns `{ name, relPath }`
+// records; `name` is the directory leaf and `relPath` is the implementation/-
+// relative path — coverage keys on `relPath` so leaf collisions can't launder a
+// runtime through the wrong gate.
 function discoverBrowserOptionalRuntimes(root = ROOT) {
   const out = [];
 
@@ -980,7 +1045,7 @@ function discoverBrowserOptionalRuntimes(root = ROOT) {
     if (!ent.isDirectory()) continue;
     if (ent.name === ADAPTERS_DIR) continue;         // descended into below
     if (NON_BROWSER_OPTIONAL.has(ent.name)) continue;
-    if (hasRealBuildAlias(root, ent.name)) {
+    if (pathDeclaresBuildAlias(root, ent.name)) {
       out.push({ name: ent.name, relPath: ent.name });
     }
   }
@@ -997,31 +1062,52 @@ function discoverBrowserOptionalRuntimes(root = ROOT) {
   for (const ent of adapters) {
     if (!ent.isDirectory()) continue;
     const relPath = `${ADAPTERS_DIR}/${ent.name}`;
-    if (hasRealBuildAlias(root, relPath)) {
+    if (pathDeclaresBuildAlias(root, relPath)) {
       out.push({ name: ent.name, relPath });
     }
   }
   return out;
 }
 
-// Every discovered browser-optional publishable runtime must map to a real
-// isolation gate — either a generic ARTEFACTS entry (per-feature runtimes, which
-// must be ABSENT from the no-feature counter bundle) or an explicit existing
-// dedicated gate (substrate adapters, proven isolated by adapter-specific gates).
-// A discovered runtime mapped to NEITHER means a separately published optional
-// runtime could leak into a production bundle with nothing to catch it — so the
-// gate fails closed and names it.
-function assertCanonicalInventoryCovered(required = discoverBrowserOptionalRuntimes()) {
-  const generic = new Set(ARTEFACTS.map((a) => a.name));
+// The exact implementation-relative PATHS a generic ARTEFACTS entry proves
+// isolated — the per-feature publishable runtimes, each declaring `relPath`.
+// Keyed by path, never leaf name: a generic entry covers exactly the path it
+// declares, so a nested adapter with a colliding leaf is not silently absorbed.
+function genericCoveragePaths(artefacts = ARTEFACTS) {
+  return new Set(artefacts.filter((a) => a.relPath).map((a) => a.relPath));
+}
+
+// Every discovered browser-optional publishable runtime must map — BY EXACT
+// implementation-relative PATH — to a real isolation gate: a generic ARTEFACTS
+// entry whose `relPath` equals the runtime's path (per-feature runtimes, which
+// must be ABSENT from the no-feature counter bundle) OR a dedicated gate whose
+// descriptor VALIDATES (real checker file + invoked package command). A runtime
+// mapped to NEITHER means a separately published optional runtime could leak
+// into a production bundle with nothing to catch it — so the gate fails closed
+// and names it (with the reason its would-be gate was rejected).
+function assertCanonicalInventoryCovered(required = discoverBrowserOptionalRuntimes(), opts = {}) {
+  const {
+    dedicatedGates = DEDICATED_ISOLATION_GATES,
+    scriptsDir = SCRIPTS_DIR,
+    scripts = readPackageScripts(),
+  } = opts;
+  const generic = genericCoveragePaths();
   const covered = [];
   const missing = [];
   for (const rt of required) {
-    if (generic.has(rt.name)) {
+    if (generic.has(rt.relPath)) {
       covered.push({ ...rt, via: 'generic' });
-    } else if (DEDICATED_ISOLATION_GATES[rt.name]) {
-      covered.push({ ...rt, via: 'dedicated', gate: DEDICATED_ISOLATION_GATES[rt.name] });
+      continue;
+    }
+    const gate = dedicatedGates[rt.relPath];
+    const validation = validateDedicatedGate(gate, { scriptsDir, scripts });
+    if (gate && validation.ok) {
+      covered.push({ ...rt, via: 'dedicated', gate });
     } else {
-      missing.push(rt);
+      missing.push({
+        ...rt,
+        reasons: gate ? validation.reasons : ['no isolation gate mapped for this exact path'],
+      });
     }
   }
   return {
@@ -1163,16 +1249,23 @@ function main() {
       console.error('');
     }
     if (!coverage.ok) {
-      console.error('Canonical inventory coverage (rf2-sh0sp4 / rf2-klyw5):');
-      console.error(`  Browser-optional publishable runtime(s) with NO isolation gate: ${coverage.missing.map((rt) => rt.relPath).join(', ')}`);
+      console.error('Canonical inventory coverage (rf2-sh0sp4 / rf2-klyw5 / rf2-zef0e):');
+      console.error('  Browser-optional publishable runtime(s) with NO valid isolation gate:');
+      for (const rt of coverage.missing) {
+        console.error(`    - ${rt.relPath}: ${(rt.reasons || []).join('; ')}`);
+      }
       console.error('  Each is a separately published day8/re-frame2-<name> artefact');
-      console.error('  (implementation/<path>/deps.edn carries :clein/build) with a CLJS');
-      console.error('  runtime that could leak into a production bundle unguarded. Either');
-      console.error('  add a primary ARTEFACTS entry with live runtime sentinels + a');
-      console.error('  positive control, or — for a substrate adapter proven by an adapter-');
-      console.error('  specific gate — map it in DEDICATED_ISOLATION_GATES. If it is');
-      console.error('  genuinely not a browser-optional runtime (always-present or JVM-');
-      console.error('  only), add it to NON_BROWSER_OPTIONAL with a reason.');
+      console.error('  (implementation/<path>/deps.edn carries a real :aliases/:clein/build)');
+      console.error('  with a CLJS runtime that could leak into a production bundle');
+      console.error('  unguarded. Either add a primary ARTEFACTS entry keyed by its exact');
+      console.error('  `relPath` (with live runtime sentinels + a positive control), or —');
+      console.error('  for a substrate adapter proven by an adapter-specific gate — map its');
+      console.error('  exact path in DEDICATED_ISOLATION_GATES with a REAL descriptor');
+      console.error('  ({ checkers: [<existing gate script>], command: <invoked package');
+      console.error('  script> }); a prose string, a nonexistent checker, or an uninvoked');
+      console.error('  command is rejected. If it is genuinely not a browser-optional');
+      console.error('  runtime (always-present or JVM-only), add it to NON_BROWSER_OPTIONAL');
+      console.error('  with a reason.');
       console.error('');
     }
     if (positiveFailures.length) {
@@ -1214,8 +1307,10 @@ module.exports = {
   ADAPTERS_DIR,
   assertPositiveControlComplete,
   checkArtefact,
-  stripEdnComments,
-  hasRealBuildAlias,
+  pathDeclaresBuildAlias,
   discoverBrowserOptionalRuntimes,
+  genericCoveragePaths,
+  validateDedicatedGate,
+  readPackageScripts,
   assertCanonicalInventoryCovered,
 };

--- a/implementation/scripts/check-bundle-isolation.test.cjs
+++ b/implementation/scripts/check-bundle-isolation.test.cjs
@@ -11,10 +11,16 @@ const {
   DEDICATED_ISOLATION_GATES,
   assertPositiveControlComplete,
   checkArtefact,
+  pathDeclaresBuildAlias,
   discoverBrowserOptionalRuntimes,
+  genericCoveragePaths,
+  validateDedicatedGate,
   assertCanonicalInventoryCovered,
 } = require('./check-bundle-isolation.cjs');
 const { assertSentinelSet } = require('./lib/sentinel-scan.cjs');
+
+// Repo root, for cross-checking the lockstep script + real implementation/ tree.
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
 
 const thirdParty = new Set(['xyflow', 'elkjs', 'zprint', 'editscript']);
 let sentinelMutations = 0;
@@ -89,17 +95,19 @@ const duplicated = assertPositiveControlComplete(confusedArtefacts, POSITIVE_CON
 assert(!duplicated.ok, 'one sentinel attributed to two owners must fail completeness');
 assert.strictEqual(duplicated.sharedSentinels.length, 1);
 
-// ----- coverage enrollment mutations (rf2-klyw5) -----------------------------
+// ----- structural + causal enrollment mutations (rf2-klyw5 / rf2-zef0e) ------
 // The sentinel + positive-control mutations above prove per-feature artefacts
-// don't LEAK. This section proves the ENROLLMENT is FAIL-CLOSED: a newly
-// publishable UI or adapter artefact mapped to no isolation gate turns the gate
-// RED rather than being silently skipped. Executable + permanent, exercising the
-// real filesystem discovery path (not injected list membership) so a regression
-// in either the flat-plus-adapters traversal or the ui exclusion is caught.
+// don't LEAK. This section proves the ENROLLMENT is FAIL-CLOSED and can no
+// longer be DISCHARGED by text or names: a newly publishable runtime mapped to
+// no valid isolation gate turns the gate RED. Executable + permanent, exercising
+// the real EDN-aware discovery + gate-validation path (not injected list
+// membership) so a regression in the flat-plus-adapters traversal, the EDN
+// structural predicate, the path-keyed coverage, or the dedicated-gate
+// validation is caught.
 
 let coverageMutations = 0;
 
-// A real deps.edn declaring a genuine :clein/build alias.
+// A real deps.edn declaring a genuine :aliases/:clein/build alias.
 const PUBLISHABLE_DEPS =
   '{:paths ["src"]\n :aliases {:clein/build {:lib day8/re-frame2-fixture}}}\n';
 // A deps.edn that only MENTIONS :clein/build inside a comment — the exact shape
@@ -107,6 +115,24 @@ const PUBLISHABLE_DEPS =
 const COMMENT_ONLY_DEPS =
   ';; NO :clein deploy aliases yet — deliberate; mentions :clein/build in prose.\n' +
   '{:paths ["src"] :deps {day8/re-frame2 {:local/root "../core"}}}\n';
+// Genuine :aliases/:clein/build, but with a `;` inside an EDN STRING before it.
+// The old stripEdnComments regex truncated the line at the first `;`, dropping
+// the real alias — a publishable runtime silently escaped the gate. The
+// EDN-aware authority must still discover it.
+const SEMICOLON_IN_STRING_DEPS =
+  '{:note "a ; semicolon inside a string"\n' +
+  ' :aliases {:clein/build {:lib day8/re-frame2-fixture}}}\n';
+// :clein/build appears only as a STRING VALUE — not a build alias. Must NOT be
+// discovered (the old `/:clein\\/build/` search invented an alias from prose).
+const TOKEN_IN_STRING_DEPS =
+  '{:note ":clein/build is a deploy alias, described here"\n' +
+  ' :aliases {:test {}}}\n';
+// :clein/build appears only inside a `#_` reader-discarded top-level form — not
+// a live alias. The live form's :aliases has no :clein/build. Must NOT be
+// discovered (the reader skips the discard; a naive grep would false-match).
+const DISCARD_FORM_DEPS =
+  '#_{:aliases {:clein/build {:lib day8/x}}}\n' +
+  '{:paths ["src"] :aliases {:test {}}}\n';
 
 function writeArtefact(root, relPath, contents) {
   const dir = path.join(root, relPath);
@@ -117,7 +143,10 @@ function writeArtefact(root, relPath, contents) {
 // Minimal implementation/-shaped fixture: an excluded core + ssr-ring, a
 // generic-gated per-feature artefact (schemas), a comment-only pre-publication
 // ui, and a dedicated-gated adapter (reagent) — all correctly accounted for —
-// plus whatever `extra` mutation the caller injects.
+// plus whatever `extra` mutation the caller injects. Gate VALIDATION resolves
+// against the REAL scripts/ + package.json (the four dedicated gates are a
+// property of this repo, not the temp fixture), so the temp fixture drives only
+// DISCOVERY while coverage validation stays authentic.
 function withFixture(extra, body) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bundle-iso-cov-'));
   try {
@@ -137,12 +166,12 @@ function withFixture(extra, body) {
 // adapter IS descended into, and everything discovered maps to a gate.
 withFixture(() => {}, (root) => {
   const required = discoverBrowserOptionalRuntimes(root);
-  assert.deepStrictEqual(required.map((r) => r.name).sort(), ['reagent', 'schemas'],
+  assert.deepStrictEqual(required.map((r) => r.relPath).sort(), ['adapters/reagent', 'schemas'],
     'baseline fixture: excluded core/ssr-ring, comment-only ui skipped, adapter descended into');
   const cov = assertCanonicalInventoryCovered(required);
   assert(cov.ok, 'baseline fixture must be fully covered');
-  assert.strictEqual(cov.genericCount, 1, 'schemas covered by generic ARTEFACTS gate');
-  assert.strictEqual(cov.dedicatedCount, 1, 'reagent covered by dedicated gate');
+  assert.strictEqual(cov.genericCount, 1, 'schemas covered by generic ARTEFACTS gate (by relPath)');
+  assert.strictEqual(cov.dedicatedCount, 1, 'adapters/reagent covered by its validated dedicated gate');
 });
 
 // Mutation 1 — hypothetical PUBLISHABLE UI (real :clein/build added to
@@ -151,11 +180,11 @@ withFixture(() => {}, (root) => {
 coverageMutations += 1;
 withFixture((root) => writeArtefact(root, 'ui', PUBLISHABLE_DEPS), (root) => {
   const required = discoverBrowserOptionalRuntimes(root);
-  assert(required.some((rt) => rt.name === 'ui'),
+  assert(required.some((rt) => rt.relPath === 'ui'),
     'publishable ui must now be DISCOVERED (not permanently excluded)');
   const cov = assertCanonicalInventoryCovered(required);
   assert(!cov.ok, 'publishable ui with no isolation gate must FAIL coverage');
-  assert(cov.missing.some((rt) => rt.name === 'ui' && rt.relPath === 'ui'),
+  assert(cov.missing.some((rt) => rt.relPath === 'ui'),
     'coverage failure must NAME ui');
 });
 
@@ -170,30 +199,142 @@ withFixture((root) => writeArtefact(root, 'adapters/newfangled', PUBLISHABLE_DEP
     'new nested adapter must be DISCOVERED (not silently skipped)');
   const cov = assertCanonicalInventoryCovered(required);
   assert(!cov.ok, 'new publishable adapter with no isolation gate must FAIL coverage');
-  assert(cov.missing.some((rt) => rt.name === 'newfangled' && rt.relPath === 'adapters/newfangled'),
+  assert(cov.missing.some((rt) => rt.relPath === 'adapters/newfangled'),
     'coverage failure must NAME the new adapter');
 });
 
+// Mutation 3 — COLLIDING LEAF NAMES: a publishable implementation/adapters/schemas
+// must NOT inherit the flat implementation/schemas generic gate through the
+// shared leaf `schemas`. Coverage is keyed by exact relPath, so adapters/schemas
+// fails closed even though the flat `schemas` generic gate is present.
+coverageMutations += 1;
+withFixture((root) => writeArtefact(root, 'adapters/schemas', PUBLISHABLE_DEPS), (root) => {
+  const required = discoverBrowserOptionalRuntimes(root);
+  assert(required.some((rt) => rt.relPath === 'schemas'),
+    'flat schemas still discovered');
+  assert(required.some((rt) => rt.relPath === 'adapters/schemas'),
+    'nested adapters/schemas discovered as its own runtime');
+  const cov = assertCanonicalInventoryCovered(required);
+  assert(!cov.ok, 'adapters/schemas must NOT ride the flat schemas gate — coverage fails closed');
+  assert(cov.missing.some((rt) => rt.relPath === 'adapters/schemas'),
+    'coverage failure must NAME adapters/schemas');
+  // The flat schemas is still covered generically (by its own relPath).
+  assert(cov.covered.some((c) => c.relPath === 'schemas' && c.via === 'generic'),
+    'flat schemas still covered by the generic gate keyed on its exact relPath');
+});
+
+// Mutation 4 — DISCOVERY is EDN-STRUCTURAL: a genuine alias survives a `;`
+// inside an EDN string, and a token inside a string / comment / discard form is
+// NOT invented as an alias.
+coverageMutations += 1;
+withFixture((root) => {
+  writeArtefact(root, 'semicolonpub', SEMICOLON_IN_STRING_DEPS);
+  writeArtefact(root, 'strmention', TOKEN_IN_STRING_DEPS);
+  writeArtefact(root, 'discardform', DISCARD_FORM_DEPS);
+}, (root) => {
+  assert(pathDeclaresBuildAlias(root, 'semicolonpub'),
+    'a genuine :aliases/:clein/build must survive a `;` inside an EDN string');
+  assert(!pathDeclaresBuildAlias(root, 'strmention'),
+    'a :clein/build token inside a STRING must NOT be treated as a build alias');
+  assert(!pathDeclaresBuildAlias(root, 'discardform'),
+    'a :clein/build inside a `#_` discard form must NOT be treated as a build alias');
+  const required = discoverBrowserOptionalRuntimes(root);
+  assert(required.some((rt) => rt.relPath === 'semicolonpub'),
+    'the semicolon-in-string runtime is enrolled (not silently omitted)');
+  assert(!required.some((rt) => rt.relPath === 'strmention' || rt.relPath === 'discardform'),
+    'string / discard mentions are not enrolled');
+});
+
+// Mutation 5 — DEDICATED GATES ARE CAUSAL: a dedicated descriptor enrols a
+// runtime only when its checker script EXISTS and its command is an INVOKED
+// package script. A prose string, a nonexistent checker, or an uninvoked/absent
+// command all fail closed. A well-formed descriptor pointing at a real, invoked
+// gate passes.
+coverageMutations += 1;
+{
+  // Unit-level: validateDedicatedGate directly.
+  assert(!validateDedicatedGate('isolated by the vibes').ok,
+    'a truthy prose string is not a valid dedicated gate');
+  assert(!validateDedicatedGate({ checkers: ['check-does-not-exist.cjs'], command: 'test:bundle-isolation' }).ok,
+    'a nonexistent checker script fails validation');
+  assert(!validateDedicatedGate({ checkers: ['check-login-bundle-isolation.cjs'], command: 'test:no-such-script' }).ok,
+    'a command that is not a package.json script fails validation');
+  assert(!validateDedicatedGate({ checkers: ['check-login-bundle-isolation.cjs'], command: 'test:reagent-slim:bundle-isolation' }).ok,
+    'a real command that does NOT invoke the declared checker fails validation');
+  assert(validateDedicatedGate({ checkers: ['check-login-bundle-isolation.cjs'], command: 'test:bundle-isolation' }).ok,
+    'a real checker invoked by its real package command validates');
+
+  // Integration: a discovered adapter routed through each bad descriptor fails
+  // coverage; the valid descriptor covers it. Each override keeps the real
+  // dedicated gates (so the fixture's adapters/reagent stays covered) and varies
+  // only adapters/newpub.
+  withFixture((root) => writeArtefact(root, 'adapters/newpub', PUBLISHABLE_DEPS), (root) => {
+    const required = discoverBrowserOptionalRuntimes(root);
+    const withNewpub = (descriptor) => assertCanonicalInventoryCovered(required, {
+      dedicatedGates: { ...DEDICATED_ISOLATION_GATES, 'adapters/newpub': descriptor },
+    });
+
+    const prose = withNewpub('isolated, trust me');
+    assert(!prose.ok && prose.missing.some((rt) => rt.relPath === 'adapters/newpub'),
+      'a prose dedicated entry must NOT enrol a runtime');
+
+    const ghostChecker = withNewpub({ checkers: ['check-ghost.cjs'], command: 'test:bundle-isolation' });
+    assert(!ghostChecker.ok && ghostChecker.missing.some((rt) => rt.relPath === 'adapters/newpub'),
+      'a dedicated entry whose checker script does not exist must fail closed');
+
+    const uninvoked = withNewpub({ checkers: ['check-login-bundle-isolation.cjs'], command: 'test:phantom' });
+    assert(!uninvoked.ok && uninvoked.missing.some((rt) => rt.relPath === 'adapters/newpub'),
+      'a dedicated entry whose command is not an invoked package script must fail closed');
+
+    const valid = withNewpub({ checkers: ['check-login-bundle-isolation.cjs'], command: 'test:bundle-isolation' });
+    assert(valid.ok, 'a real checker invoked by a real package command enrols the runtime');
+    assert(valid.covered.some((c) => c.relPath === 'adapters/newpub' && c.via === 'dedicated'),
+      'the validly-gated adapter is covered via its dedicated gate');
+  });
+}
+
 // Real-tree floor: the current implementation/ tree must be fully covered, every
-// publishable adapter discovered under adapters/ and resolved by its real
-// dedicated gate, and pre-publication ui NOT required (it has no real
+// publishable adapter discovered under adapters/ and resolved by its real,
+// validated dedicated gate, and pre-publication ui NOT required (it has no real
 // :clein/build today, so it stays green naturally).
 const realCoverage = assertCanonicalInventoryCovered();
 assert(realCoverage.ok,
-  `real implementation/ tree must be fully covered; missing: ${realCoverage.missing.map((rt) => rt.relPath).join(', ')}`);
-for (const adapter of Object.keys(DEDICATED_ISOLATION_GATES)) {
-  const rt = realCoverage.covered.find((c) => c.name === adapter);
+  `real implementation/ tree must be fully covered; missing: ${realCoverage.missing.map((rt) => `${rt.relPath} (${(rt.reasons || []).join('; ')})`).join(', ')}`);
+for (const relPath of Object.keys(DEDICATED_ISOLATION_GATES)) {
+  const rt = realCoverage.covered.find((c) => c.relPath === relPath);
   assert(rt && rt.via === 'dedicated' && rt.relPath.startsWith('adapters/'),
-    `${adapter}: must be discovered under adapters/ and covered by its dedicated gate`);
+    `${relPath}: must be discovered under adapters/ and covered by its validated dedicated gate`);
 }
-assert(!realCoverage.required.some((rt) => rt.name === 'ui'),
+assert(!realCoverage.required.some((rt) => rt.relPath === 'ui'),
   'pre-publication ui must not be in the required set (no real :clein/build yet)');
+
+// Every generic-coverage path must correspond to a real publishable per-feature
+// runtime on disk (so a stale relPath can't paper over a missing runtime).
+for (const relPath of genericCoveragePaths()) {
+  assert(pathDeclaresBuildAlias(path.join(REPO_ROOT, 'implementation'), relPath),
+    `generic-coverage relPath '${relPath}' must be a real publishable implementation/ artefact`);
+}
+
+// ----- lockstep consumes the SAME structural authority (rf2-zef0e) -----------
+// The release lockstep (.github/scripts/verify-version-lockstep.sh) must derive
+// its publishable-artefact inventory from the shared EDN-aware authority, NOT a
+// duplicated textual grep — so bundle-isolation and lockstep prove the identical
+// parsed :aliases/:clein/build fact and cannot drift.
+const LOCKSTEP = fs.readFileSync(
+  path.join(REPO_ROOT, '.github', 'scripts', 'verify-version-lockstep.sh'), 'utf8');
+assert(/publishable-runtimes\.cjs/.test(LOCKSTEP),
+  'lockstep must consume the shared publishable-runtimes.cjs authority for inventory discovery');
+assert(!/grep\s+-qF\s+':clein\/build'/.test(LOCKSTEP),
+  'lockstep must NOT rediscover publishability via a textual grep for the clein/build token (duplicated grep removed)');
 
 console.log(
   `PASS check-bundle-isolation self-test: ${ARTEFACTS.length} artefacts; ` +
   `${sentinelMutations} sentinel-removal mutations; ` +
   `${sentinelMutations} deliberate production leaks; ` +
   `${thirdParty.size} emitted third-party owners; ` +
-  `${coverageMutations} coverage enrollment mutations (publishable ui + new adapter fail closed); ` +
+  `${coverageMutations} structural+causal enrollment mutations ` +
+  '(publishable ui + new adapter fail closed; leaf-collision, EDN string/comment/discard, ' +
+  'prose/absent/uninvoked dedicated gate all rejected); ' +
+  'lockstep consumes the shared EDN authority; ' +
   'module-ownership and sentinel-ownership confusion rejected'
 );

--- a/implementation/scripts/lib/publishable-runtimes.cjs
+++ b/implementation/scripts/lib/publishable-runtimes.cjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+'use strict';
+
+/*
+ * Bounded, EDN-aware publishable-artefact discovery authority (rf2-zef0e).
+ *
+ * The single STRUCTURAL source of truth for "is implementation/<path> a
+ * separately publishable artefact?" — a deps.edn whose real `:aliases` map
+ * carries a `:clein/build` key. It reads EDN STRUCTURE (via scripts/lib/edn.cjs)
+ * rather than grepping text, so the fail-closed enrolment claim actually holds:
+ *
+ *   - a genuine `:aliases/:clein/build` survives `;` inside EDN strings
+ *     (the old `stripEdnComments` regex truncated the line at the first `;`,
+ *     silently dropping a real alias — a publishable runtime slipped the gate);
+ *   - a `:clein/build` token inside a string, a `;` comment, or a `#_`
+ *     reader-discarded form is NOT mistaken for a build alias (the old
+ *     `/:clein\/build/` search invented aliases from prose).
+ *
+ * Consumed by:
+ *   - check-bundle-isolation.cjs — via `pathDeclaresBuildAlias`, to enrol every
+ *     browser-optional publishable runtime in the isolation gate; and
+ *   - .github/scripts/verify-version-lockstep.sh — via the CLI below, as its
+ *     release-inventory authority,
+ * so BOTH gates prove the identical parsed `:aliases/:clein/build` fact instead
+ * of maintaining two drifting textual greps.
+ *
+ * This is not a general EDN / discovery framework: it is a thin predicate over
+ * the existing edn.cjs reader plus one bounded flat-plus-nested traversal.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { readEdn, isMap, mapGetKeyword, isKeyword } = require('./edn.cjs');
+
+// True iff `depsText` declares a REAL `:aliases/:clein/build` alias.
+//
+// Reads EDN structure: the top-level form must be a map, its `:aliases` value
+// must be a map, and that map must carry a `:clein/build` KEY. Occurrences of
+// the token inside strings, `;` comments, or `#_` discard forms are structure
+// the reader skips, so they never satisfy the check.
+//
+// On UNPARSEABLE EDN the reader throws; we then fail CLOSED — if the raw text
+// mentions `:clein/build` at all, treat the directory as publishable (forcing
+// enrolment) rather than silently omitting it. A well-formed deps.edn never
+// reaches this fallback, so the structure-aware rejection of string / comment /
+// discard mentions above is not weakened for any real artefact.
+function depsDeclaresBuildAlias(depsText) {
+  let top;
+  try {
+    top = readEdn(depsText);
+  } catch (_e) {
+    return /:clein\/build/.test(depsText); // fail-closed on unreadable EDN
+  }
+  if (!isMap(top)) return false;
+  const aliases = mapGetKeyword(top, 'aliases');
+  if (aliases === undefined || aliases === null || !isMap(aliases)) return false;
+  return aliases.entries.some(([k]) => isKeyword(k, 'clein/build'));
+}
+
+// True iff <root>/<relPath>/deps.edn declares a real `:clein/build` alias. A
+// missing/unreadable deps.edn file is not a publishable artefact directory.
+function pathDeclaresBuildAlias(root, relPath) {
+  let depsText;
+  try {
+    depsText = fs.readFileSync(path.join(root, relPath, 'deps.edn'), 'utf8');
+  } catch (_e) {
+    return false;
+  }
+  return depsDeclaresBuildAlias(depsText);
+}
+
+// Every publishable artefact under `implRoot`, mirroring the release lockstep's
+// bounded `find -mindepth 2 -maxdepth 3 -name deps.edn` reach: every
+// implementation/<name>/deps.edn (depth 2) and implementation/<name>/<sub>/deps.edn
+// (depth 3 — the adapters live here). Returns `{ relPath }` records sorted by
+// relPath. No exclusions: callers filter for their own surface (the lockstep
+// keeps them all; the bundle-isolation gate drops the always-present / JVM-only
+// runtimes and re-groups adapters).
+function listPublishableRuntimes(implRoot) {
+  const out = [];
+  let top;
+  try {
+    top = fs.readdirSync(implRoot, { withFileTypes: true });
+  } catch (_e) {
+    return out;
+  }
+  for (const ent of top) {
+    if (!ent.isDirectory()) continue;
+    if (pathDeclaresBuildAlias(implRoot, ent.name)) out.push({ relPath: ent.name });
+    let subs;
+    try {
+      subs = fs.readdirSync(path.join(implRoot, ent.name), { withFileTypes: true });
+    } catch (_e) {
+      subs = [];
+    }
+    for (const sub of subs) {
+      if (!sub.isDirectory()) continue;
+      const relPath = `${ent.name}/${sub.name}`;
+      if (pathDeclaresBuildAlias(implRoot, relPath)) out.push({ relPath });
+    }
+  }
+  out.sort((a, b) => a.relPath.localeCompare(b.relPath));
+  return out;
+}
+
+module.exports = {
+  depsDeclaresBuildAlias,
+  pathDeclaresBuildAlias,
+  listPublishableRuntimes,
+};
+
+// CLI: `node publishable-runtimes.cjs <implementation-root>` prints each
+// publishable artefact's implementation-relative subpath, one per line. The
+// release lockstep (verify-version-lockstep.sh) consumes this as its inventory
+// authority, so it proves the same parsed EDN fact the bundle-isolation gate
+// consumes in-process. Exit 0 on success; non-zero (fail-closed) on error, so
+// the lockstep hard-fails rather than skipping the inventory guard.
+if (require.main === module) {
+  const implRoot = process.argv[2];
+  if (!implRoot) {
+    process.stderr.write('usage: publishable-runtimes.cjs <implementation-root>\n');
+    process.exit(2);
+  }
+  try {
+    for (const rt of listPublishableRuntimes(implRoot)) {
+      process.stdout.write(`${rt.relPath}\n`);
+    }
+  } catch (err) {
+    process.stderr.write(`publishable-runtimes: ${err.message}\n`);
+    process.exit(2);
+  }
+}


### PR DESCRIPTION
Closes rf2-zef0e.

## The discharge

PR #6109 makes bundle-isolation auto-enrol future publishable UI/adapter runtimes, but its FAIL-CLOSED claim could be discharged (defeated) four ways — an un-enrolled publishable runtime could stay green while a real leak path existed:

1. **Leaf-name coverage collision.** Coverage keyed on the directory leaf, so a future `implementation/adapters/schemas` inherited the flat `implementation/schemas` generic gate — a real leak path stayed green.
2. **Prose dedicated gate.** `DEDICATED_ISOLATION_GATES` values were truthy strings; adding a descriptive map entry enrolled a runtime with **no** checker script and **no** invoked command.
3. **Semicolon-in-string.** `stripEdnComments` stripped `;`→EOL with a regex that ignored EDN string boundaries, truncating a `deps.edn` line at a semicolon inside a string and dropping a genuine `:aliases/:clein/build` after it — the runtime was silently omitted (fail-open).
4. **Token-in-string / discard.** A `/:clein\/build/` search invented an alias from a string mention or a `#_`-discarded form.

Reproduced against the pre-fix code (temp `implementation/`-shaped fixtures): `adapters/schemas` rode the flat `schemas` gate (coverage green); a prose entry enrolled `adapters/ghost`; a genuine `:clein/build` behind a semicolon-in-string was not discovered; a string/discard mention was invented as an alias.

## The fix — enrolment derives from the real publishable surface

- **`implementation/scripts/lib/publishable-runtimes.cjs`** (new): one bounded, **EDN-aware** discovery authority built on the existing `scripts/lib/edn.cjs` reader. It inspects each `deps.edn`'s real `:aliases/:clein/build` KEY — a genuine alias survives `;` inside strings, and a token inside a string / `;` comment / `#_` discard is not treated as an alias. Consumed by the bundle-isolation gate in-process **and** by the release lockstep via its CLI, so both prove the *same parsed EDN fact*; the lockstep's duplicated `grep -qF ':clein/build'` textual scan is removed (it fails closed if node can't run).
- **Coverage keyed by exact implementation-relative path** (`check-bundle-isolation.cjs`): `ARTEFACTS` per-feature runtimes carry `relPath`; `DEDICATED_ISOLATION_GATES` keyed by `adapters/<name>`. A nested adapter can never inherit a flat gate through a colliding leaf.
- **Machine-readable dedicated descriptors** `{ checkers, command }` validated by `validateDedicatedGate()`: every checker file must EXIST and the declared package command must INVOKE it. A prose string, a removed checker, or an uninvoked/absent command fails closed.

Red-before / green-after (temp fixtures): the four discharges above now — (1) name `adapters/schemas` as missing, (2) reject the prose entry, (3) discover the semicolon-in-string alias, (4) reject the string/discard mention. The genuinely-isolated real tree still passes: 12 browser-optional runtimes covered (8 generic + 4 dedicated), `ui` not required, four dedicated gates green.

## Scope

Scripts only — the bundle-isolation gate + its self-test, one small `scripts/lib/` EDN-aware helper, and the (non-hot-zone) `.github/scripts/verify-version-lockstep.sh` inventory discovery. No runtime CLJS/CLJC, no `re-frame.core` facade export, no `deps.edn`/`shadow-cljs.edn`/workflow change, no new artefact hierarchy.

## Quality gates

- `npm run test:bundle-isolation` — **PASS**. 8 example releases + positive control built clean (0 warnings). Self-test PASS (22 artefacts; 38 sentinel-removal mutations; 38 deliberate leaks; 4 emitted third-party owners; **5 structural+causal enrolment mutations** — publishable-ui/new-adapter fail closed; leaf collision; EDN string/comment/discard; prose/absent/uninvoked dedicated gate all rejected; lockstep consumes the shared EDN authority). Main gate PASS: 22 artefact entries; 38 internal sentinels absent; 3 allow-list budgets ok; 38 positive-control sentinels present; **12 canonical browser-optional runtimes covered (8 generic, 4 dedicated)**. uix-helix-reagent-free PASS (6 checks); login-bundle-isolation PASS (18 checks).
- `npm run test:reagent-slim:bundle-isolation` — **PASS** (6 contracts, 25 sentinel checks).
- `npm run test:script-policy` — **PASS** (full policy suite, unaffected).
- `verify-version-lockstep.sh` — **PASS** locally (14 implementation/ + 4 tools/ = 18 artefacts). Fail-closed direction verified: an un-enrolled publishable adapter turns it red and names the path (exit 1).

Gate summary: 4 gate invocations run, 4 pass, 0 fail.
