### PR TITLE
fix(views): make deferred-callback frame law consistent across examples and adapters (rf2-leeqp)

### DIFF
--- a/docs/api/re-frame.core.md
+++ b/docs/api/re-frame.core.md
@@ -212,7 +212,8 @@ On CLJS, `dispatch`, `dispatch-sync`, and `subscribe` are macros in call positio
 - **Description**: Async dispatch: drops the event onto the frame's queue and returns immediately. This is the default.
 - **Example**:
   ```clojure
-  [:button {:on-click #(rf/dispatch [:counter/inc])} "+"]
+  ;; inside a reg-view: the injected `dispatch` captured the frame at render
+  [:button {:on-click #(dispatch [:counter/inc])} "+"]
   ```
 
 - **Fn form**: In VALUE position — passed rather than called, e.g. `(run! rf/dispatch events)` — `dispatch` resolves to the plain-fn value instead of expanding as a macro. It skips call-site stamping, so it composes through `map` / `comp` / `partial`. `opts` may carry `:frame` (a frame-id keyword or a live frame value). Returns `nil`. (A JVM programmatic caller reaches `re-frame.router/dispatch!` directly.)

--- a/docs/api/re-frame.test-helpers.md
+++ b/docs/api/re-frame.test-helpers.md
@@ -204,7 +204,7 @@ This namespace pairs with `render-to-string` in [re-frame.ssr.md](re-frame.ssr.m
 - **Description**: Build an attrs map carrying `:data-testid id`. The 2-arity merges `extra` into that map, and `:data-testid` always wins on collision. Use it at the view call site. Pair it with `find-by-testid` at the assertion site.
 - **Example**:
   ```clojure
-  [:button (th/testid "counter-inc" {:on-click #(rf/dispatch [:counter/inc])})
+  [:button (th/testid "counter-inc" {:on-click #(dispatch [:counter/inc])})
    "+"]
   ;; => [:button {:data-testid "counter-inc" :on-click ...} "+"]
   ```

--- a/docs/core/how-to/validate-with-schemas.md
+++ b/docs/core/how-to/validate-with-schemas.md
@@ -46,13 +46,12 @@ Now, what the registration buys you. From this point on, after every event handl
 
 ## Watch one catch a bug
 
-Theory's cheap. Here's a schema doing its job — live. In Conduit, an article's favorite count must never go below zero (you can't un-favorite past nobody). The rule appears **twice**, on purpose. The handler *guards* (`pos?` — real behaviour that ships to production). The schema *declares* (`[:int {:min 0}]` — the dev tripwire). The cell runs in the playground's frame, so no `with-frame` is needed. Click in and press **`Ctrl-Enter`** (**`Cmd-Enter`** on macOS) to evaluate, then drive it with the buttons.
+Theory's cheap. Here's a schema doing its job — live. In Conduit, an article's favorite count must never go below zero (you can't un-favorite past nobody). The rule appears **twice**, on purpose. The handler *guards* (`pos?` — real behaviour that ships to production). The schema *declares* (`[:int {:min 0}]` — the dev tripwire). The cell mounts under a `frame-root` that seeds a `:demo` [frame](../glossary.md#frame), so the buttons dispatch into a real frame — the same shape a production app uses. Click in and press **`Ctrl-Enter`** (**`Cmd-Enter`** on macOS) to evaluate, then drive it with the buttons.
 
 The piece to watch is the `[:int {:min 0}]` on the `[:howto.schema/article]` slice — that's the app-db schema from the last section. (Each `reg-event` *also* carries a small `{:schema [:cat ...]}` map describing its event vector; ignore those for now — they're event schemas, a few sections down.)
 
 ```cljs-rf2
-(require '[reagent2.core :as r]
-         '[re-frame.core :as rf])
+(require '[re-frame.core :as rf])
 
 ;; The slice's shape: a non-negative favorite count, and a favorited? flag.
 (rf/reg-app-schema [:howto.schema/article]
@@ -89,17 +88,17 @@ The piece to watch is the `[:int {:min 0}]` on the `[:howto.schema/article]` sli
 (rf/reg-sub :howto.schema/favorited?
   (fn [db _] (get-in db [:howto.schema/article :favorited?])))
 
-(defn favorite-button []
+(rf/reg-view favorite-button []
   [:div
-   [:button {:on-click #(rf/dispatch [:howto.schema/unfavorite])} "♥ unfavorite"]
+   [:button {:on-click #(dispatch [:howto.schema/unfavorite])} "♥ unfavorite"]
    [:span {:style {:margin "0 1em" :font-size "1.4em"}}
-    @(rf/subscribe [:howto.schema/favorites-count])]
-   [:button {:on-click #(rf/dispatch [:howto.schema/favorite])} "♥ favorite"]
+    @(subscribe [:howto.schema/favorites-count])]
+   [:button {:on-click #(dispatch [:howto.schema/favorite])} "♥ favorite"]
    [:div {:style {:margin-top "0.75em" :color "#666" :font-size "0.85em"}}
-    "favorited?: " (str @(rf/subscribe [:howto.schema/favorited?]))]])
+    "favorited?: " (str @(subscribe [:howto.schema/favorited?]))]])
 
-(rf/dispatch-sync [:howto.schema/initialise])
-[favorite-button]
+[rf/frame-root {:id :demo :initial-events [[:howto.schema/initialise]]}
+ [favorite-button]]
 ```
 
 Click `unfavorite` down to `0` and keep clicking: nothing happens, because the `pos?` guard stands. Now simulate the bug the schema exists to catch. **Delete the guard** — replace `(if (pos? n) (-> db …) db)` with just the `(-> db …)` threading — re-evaluate, and click `unfavorite` past zero. The handler writes `-1`, and `[:int {:min 0}]` rejects it. The browser console shows the `:rf.error/schema-validation-failure`, and the count on screen stays `0`: the candidate write was rejected before it installed, so app-db never held the bad value. Put the guard back when you're done.

--- a/docs/machines/concepts.md
+++ b/docs/machines/concepts.md
@@ -108,17 +108,18 @@ Click into the cell and press **`Ctrl-Enter`** (**`Cmd-Enter`** on macOS):
     :unlocked {:on {:push {:target :locked}
                     :coin {:target :unlocked :action :take-coin}}}}})
 
-(defn turnstile-view []
-  (let [{:keys [state data]} (or @(rf/subscribe [:rf/machine :turnstile/flow])
+(rf/reg-view turnstile-view []
+  (let [{:keys [state data]} (or @(subscribe [:rf/machine :turnstile/flow])
                                  {:state :locked :data {:coins 0 :pushes 0}})
         open? (= state :unlocked)]
     [:div {:style {:font-family "sans-serif"}}
      [:p "state: " [:strong {:style {:color (if open? "green" "crimson")}} (str state)]]
      [:p "coins: " (:coins data) " · pushes: " (:pushes data)]
-     [:button {:on-click #(rf/dispatch [:turnstile/flow [:coin]])} "insert coin"]
-     [:button {:on-click #(rf/dispatch [:turnstile/flow [:push]])} "push"]]))
+     [:button {:on-click #(dispatch [:turnstile/flow [:coin]])} "insert coin"]
+     [:button {:on-click #(dispatch [:turnstile/flow [:push]])} "push"]]))
 
-[turnstile-view]
+[rf/frame-root {:id :demo}
+ [turnstile-view]]
 ```
 
 !!! tip "Try it"

--- a/docs/tools/playground/README.md
+++ b/docs/tools/playground/README.md
@@ -48,17 +48,16 @@ evaluated at the SCI **top level** (NOT wrapped in `(do ...)`) so a leading
 `(require ...)`'s aliases reach its sibling top-level forms.
 
 ```cljs-rf2
-(require '[reagent2.core :as r]
-         '[re-frame.core :as rf])
+(require '[re-frame.core :as rf])
 (rf/reg-event :init (fn [_ _] {:db {:n 0}}))
 (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
 (rf/reg-sub      :n    (fn [db _] (:n db)))
-(rf/dispatch-sync [:init])
-(defn counter []
+(rf/reg-view counter []
   [:div
-   [:span "count: " @(rf/subscribe [:n])]
-   [:button {:on-click #(rf/dispatch [:inc])} "inc"]])
-[counter]
+   [:span "count: " @(subscribe [:n])]
+   [:button {:on-click #(dispatch [:inc])} "inc"]])
+[rf/frame-root {:id :demo :initial-events [[:init]]}
+ [counter]]
 ```
 
 **Why this is NOT a Scittle plugin.** Scittle's `scittle.reagent.js` /
@@ -80,8 +79,12 @@ How re-frame2's API reaches a cell:
 - `dispatch` / `dispatch-sync` / `subscribe` are macro-in-call-position /
   fn-in-value-position on CLJS (Convention A), so `sci/copy-ns` already
   brings the plain-fn form in under their own names; the SCI config still
-  overrides those three entries with playground-local wrappers so every
-  cell dispatch/subscribe defaults to the playground's single frame.
+  overrides those three entries with playground-local wrappers so a
+  **frame-less** cell's dispatch/subscribe still resolve to the playground's
+  single frame. That is a fallback, not the shape to copy: a cell that
+  establishes its own frame (`frame-root` + `reg-view`, as the docs' cells do)
+  routes through it unchanged, exactly as a real app would — its `:on-*`
+  callbacks fire against the frame captured at render, not the harness default.
 
 **React 19 is bundled, not global.** reagent2 targets React 19, which **dropped
 its UMD build** — so the Phase-2 global-`React`-from-CDN trick is unavailable.

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_synthetic_event_frame_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_synthetic_event_frame_dom_cljs_test.cljs
@@ -1,54 +1,49 @@
-(ns re-frame.views-synthetic-event-frame-dom-cljs-test
-  "Real-DOM proof for the Core Views guide's synthetic-event frame advice
-  (rf2-xzgs3j).
+(ns re-frame.adapter.reagent-slim-synthetic-event-frame-dom-cljs-test
+  "reagent-slim half of the deferred-callback frame-law real-DOM matrix
+  (rf2-leeqp; completes the stock-Reagent proof rf2-xzgs3j /
+  `views-synthetic-event-frame-dom-cljs-test`).
 
-  The `docs/core/views.md` §\"imperative listeners lose the frame\" section
-  previously claimed that Hiccup `:on-*` attrs are 'wrapped so a `dispatch`
-  inside them carries the frame', and marked a bare
-  `#(rf/dispatch [:tile/finished])` in an `:on-animation-end` prop as the
-  RIGHT pattern. That is FALSE of the shipped adapters. Neither the Reagent
-  adapter (`re-frame.adapter.reagent`) nor reagent-slim wraps `:on-*`
-  callbacks to re-establish a frame binding: the handler is a plain closure
-  React invokes LATER, on a fresh JS stack, with no render in progress. At
-  that point:
+  WHAT THIS PINS. A view's `:on-*` handler runs LATER — on the user's
+  click, on a fresh JS stack, after the render that built it has
+  committed. By then the dynamic `re-frame.frame/*current-frame*` scope
+  has unwound and the `frame-provider`'s React context has been popped
+  back to the no-provider sentinel. So a bare, fully-qualified
+  `rf/dispatch` from an `:on-click` resolves NO frame and — EP-0002, no
+  `:rf/default` floor — raises `:rf.error/no-frame-context`; NOTHING
+  lands. What survives that boundary is the frame captured at RENDER
+  time: the `reg-view` macro's injected `dispatch` is exactly a
+  `(rf/capture-frame)` op bundle bound to the render frame, so the
+  UNqualified injected `dispatch` dispatches correctly after the render
+  boundary.
 
-    * the dynamic `re-frame.frame/*current-frame*` scope has unwound, and
-    * the frame-provider's React context value has been popped back to the
-      no-provider sentinel (context is a render-phase concept).
+  The stock-Reagent twin (`re-frame.views-synthetic-event-frame-dom-cljs-test`,
+  rf2-xzgs3j) proves this under `reagent.dom.client`. The existing
+  reagent-slim client-runtime smoke
+  (`adapters/reagent-slim/testbed/smoke.cjs`) proves only the
+  captured/injected HAPPY path. This suite closes the gap the bead flags:
+  the BARE-dispatch FAILURE under the day8/reagent-slim substrate
+  (`reagent2.dom.client` + `re-frame.adapter.reagent-slim`), with a real
+  synthetic click.
 
-  So a bare, fully-qualified `rf/dispatch` from an `:on-*` handler resolves
-  NO frame and — EP-0002, no `:rf/default` floor — raises
-  `:rf.error/no-frame-context` (see `re-frame.core/current-frame-id`,
-  implementation/core/src/re_frame/core.cljc:1118-1132, and
-  `frame/require-current-frame!`).
+  RIGOUR (rf2-leeqp acceptance). The working half settles on a CAUSAL
+  signal — `test-support/poll-until` waits for the frame's app-db to
+  actually advance, NOT a fixed sleep. A SINGLE idempotent finalizer
+  (`finalize!`) unmounts the root, removes the DOM node, destroys the
+  frame, and completes the async test on EVERY path — success,
+  poll timeout, or a throw from mount/setup.
 
-  What actually carries the frame into a deferred callback is capturing it
-  at RENDER time. The `reg-view` macro injects `dispatch` / `subscribe`
-  locals that are exactly a `(rf/capture-frame)` op bundle
-  (core_reg_view_macro.cljc:185-192), so the UNqualified injected `dispatch`
-  closes over the render frame and dispatches correctly after the render
-  boundary. The same is true of an explicit `(:dispatch (rf/capture-frame))`
-  or an explicit `{:frame …}` on the dispatch.
-
-  This suite fires a REAL synthetic click on a mounted `reg-view` and pins
-  both halves of the corrected advice:
-
-    1. bare `#(rf/dispatch [:evt])`     → raises :rf.error/no-frame-context
-                                          and nothing lands.
-    2. injected `#(dispatch [:evt])`    → dispatches successfully; the
-                                          frame's app-db advances.
-
-  Browser-only — a genuine synthetic event needs a real React root + real
-  DOM the Node runner can't fake. The `-dom-cljs-test$` suffix (rf2-2hrj8)
-  opts this file into the `:browser-test` build; `:node-test` still loads it
-  (matches `cljs-test$`) and the DOM branch self-gates on `(browser?)`,
-  exiting early under :node-test where `js/document` is absent."
+  Browser-only — a genuine synthetic event needs a real React root the
+  Node runner can't fake. The `-dom-cljs-test$` suffix opts this file
+  into the `:browser-test` build; `:node-test` still loads it (matches
+  `cljs-test$`) and the DOM branch self-gates on `(browser?)`, exiting
+  early where `js/document` is absent."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
-            [reagent.dom.client :as rdc]
+            [reagent2.dom.client :as rdc]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support])
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; `:ambient-frame nil` OPTS OUT of the fixture's default ambient
@@ -61,7 +56,7 @@
 ;; half awaits the async dispatch drain.
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter :async? true :ambient-frame nil}))
+    {:adapter reagent-slim-adapter/adapter :async? true :ambient-frame nil}))
 
 ;; ---- browser gate ----------------------------------------------------------
 
@@ -76,13 +71,14 @@
 
 ;; The proof view. Defined with the `reg-view` MACRO (not `reg-view*`) so the
 ;; UNqualified `dispatch` / `subscribe` below are the macro's render-time
-;; frame-captured injections — the exact surface the guide documents.
+;; frame-captured injections — the exact surface the guide documents — under
+;; the reagent-slim substrate (the `reg-view` carries the `:contextType`
+;; wiring slim needs to read the frame-provider's frame from React context).
 ;;
 ;;   * `syn-bare`     uses fully-qualified `rf/dispatch` — the ambient form.
 ;;                    It bypasses the injection and resolves the frame at
 ;;                    CLICK time, when there is none. Wrapped in try/catch to
-;;                    capture the raised error id (mirrors the setTimeout
-;;                    regression in dispatch_frame_capture_cljs_test).
+;;                    capture the raised error id.
 ;;   * `syn-captured` uses the injected `dispatch` — captured at render.
 (reg-view proof-view []
   (let [n @(subscribe [:syn/n])]
@@ -102,18 +98,20 @@
 (defn- query [mount-node testid]
   (.querySelector mount-node (str "[data-testid='" testid "']")))
 
-(deftest synthetic-event-frame-advice-real-dom-proof
-  "rf2-xzgs3j — real synthetic click proves the corrected guide advice.
+(deftest synthetic-event-frame-advice-real-dom-proof-reagent-slim
+  "rf2-leeqp — real synthetic click proves the deferred-callback frame law
+   under reagent-slim.
 
-   A `reg-view` mounted under a `frame-provider` carries two buttons. A real
-   DOM click on the bare `#(rf/dispatch …)` button raises
-   :rf.error/no-frame-context and lands nothing; a real DOM click on the
-   injected `#(dispatch …)` button dispatches successfully and the frame's
-   app-db advances after the render boundary."
+   A `reg-view` mounted under a `frame-provider` on a real `reagent2`
+   root carries two buttons. A real DOM click on the bare
+   `#(rf/dispatch …)` button raises :rf.error/no-frame-context and lands
+   nothing; a real DOM click on the injected `#(dispatch …)` button
+   dispatches successfully and the frame's app-db advances after the
+   render boundary. Settles on the causal app-db signal via poll-until."
   (if-not (browser?)
     (is true ":node-test: no DOM — the :browser-test runner exercises the assertions")
     (async done
-      (let [target     :syn/frame
+      (let [target     :syn.slim/frame
             done?      (atom false)
             ;; Resources are held in atoms so THE single finalizer can clean up
             ;; whatever was allocated, even if setup (createElement / mount /
@@ -126,8 +124,8 @@
             ;; completes the async test. No fixed sleeps anywhere.
             finalize!  (fn []
                          (when (compare-and-set! done? false true)
-                           (when-let [r @root-atom] (try (rdc/unmount r) (catch :default _ nil)))
-                           (when-let [n @node-atom] (try (.remove n)     (catch :default _ nil)))
+                           (when-let [r @root-atom] (try (.unmount r)  (catch :default _ nil)))
+                           (when-let [n @node-atom] (try (.remove n)   (catch :default _ nil)))
                            (try (rf/destroy-frame! target) (catch :default _ nil))
                            (done)))]
         (try
@@ -135,7 +133,7 @@
           (let [mount-node (.createElement js/document "div")]
             (reset! node-atom mount-node)
             (.appendChild (.-body js/document) mount-node)
-            (rf/make-frame {:id target :doc "rf2-xzgs3j synthetic-event proof frame"})
+            (rf/make-frame {:id target :doc "rf2-leeqp reagent-slim synthetic-event proof frame"})
             (rf/reg-event :syn/init (fn [{:keys [db]} _] {:db (assoc db :n 0)}))
             (rf/reg-event :syn/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
             (rf/reg-sub :syn/n (fn [db _] (:n db)))
@@ -168,7 +166,7 @@
                 (.click captured)
                 (-> (test-support/poll-until
                       #(= 1 (:n (rf/app-db-value target)))
-                      {:label      "injected dispatch advances the render frame to {:n 1}"
+                      {:label      "reagent-slim injected dispatch advances the render frame to {:n 1}"
                        :timeout-ms 1000})
                     (.then (fn [_]
                              (is (= 1 (:n (rf/app-db-value target)))
@@ -182,5 +180,5 @@
                                        (pr-str (ex-message e))))
                               (finalize!)))))))
           (catch :default e
-            (is false (str "synthetic-event proof threw: " (pr-str e)))
+            (is false (str "reagent-slim synthetic-event proof threw: " (pr-str e)))
             (finalize!)))))))

--- a/migration/from-re-frame-v1/README.md
+++ b/migration/from-re-frame-v1/README.md
@@ -459,10 +459,13 @@ re-frame2's frame-routing for views relies on `reg-view`. A plain `(defn my-view
 
 The footgun bites a plain fn that depends on the surrounding frame. A plain fn is **safe** when it establishes its own frame scope (a `with-frame`, or a captured `capture-frame`); a single-frame app's plain fns are safe *inside* the one root `frame-provider` only when registered as views — a bare `rf/subscribe` in an unregistered plain fn under the root will still raise, because the plain fn can't read the context.
 
+The `frame-provider` is a **render-phase** scope, though — it does **not** preserve dynamic scope into a *later* callback. Even inside a registered `reg-view`, a bare fully-qualified `rf/dispatch` / `rf/subscribe` placed in an `:on-*` handler (or any deferred callback: a timer, a socket message, an imperative listener) fires *after* render has unwound the dynamic frame and popped the provider's React context, so it raises `:rf.error/no-frame-context` all the same. What survives the render boundary is a frame captured *at render time* — the `reg-view`-injected `dispatch` / `subscribe`, or an explicit `(rf/capture-frame)` — never a fresh `rf/dispatch`.
+
 **What to look for** in the codebase:
 
 1. Every Reagent fn referenced by a Var (or anonymous lambda) that is **not** registered via `rf/reg-view` and calls `rf/subscribe` / `rf/dispatch` (the ambient 1-arity forms), where it renders under a `frame-provider`.
 2. The hiccup subtree under each `(rf/frame-provider {:frame <id>} ...)` (or ENSURE `(rf/frame-root {:id <id>} ...)`).
+3. Bare fully-qualified `rf/dispatch` / `rf/subscribe` inside an `:on-*` (or other deferred) callback — **even in a `reg-view`**. The fix is the injected `dispatch` / `subscribe` captured at render, or an explicit `(rf/capture-frame)`, not a fresh `rf/dispatch`.
 
 The agent doesn't need to render the tree — a static walk over the hiccup forms inside the provider is enough. Cross-reference the registered set via `(rf/registrations :view)` to determine which Vars are `reg-view`-backed.
 

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -4307,31 +4307,31 @@ The 7GUIs circle-drawer in this style. The modal-edit flow is a registered machi
         can-redo?              @(rf/subscribe [:drawer/can-redo?])]
     [:div.drawer
      [:div.row
-      [:button {:on-click #(rf/dispatch [:drawer/undo]) :disabled (not can-undo?)} "Undo"]
-      [:button {:on-click #(rf/dispatch [:drawer/redo]) :disabled (not can-redo?)} "Redo"]]
+      [:button {:on-click #(dispatch [:drawer/undo]) :disabled (not can-undo?)} "Undo"]
+      [:button {:on-click #(dispatch [:drawer/redo]) :disabled (not can-redo?)} "Redo"]]
      [:svg {:width 600 :height 400 :style {:border "1px solid #999"}
             :on-click (fn [e]
                         (when-not editing?
                           (let [r (.. e -currentTarget getBoundingClientRect)
                                 x (- (.. e -clientX) (.-left r))
                                 y (- (.. e -clientY) (.-top r))]
-                            (rf/dispatch [:drawer/add-circle x y]))))}
+                            (dispatch [:drawer/add-circle x y]))))}
       (for [{:keys [id x y radius]} circles]
         ^{:key id}
         [:circle {:cx x :cy y :r radius :fill "transparent" :stroke "black"
                   :on-context-menu (fn [e] (.preventDefault e)
                                      ;; pass radius in the event payload — machine cannot read :db
-                                     (rf/dispatch [:drawer/editor [:right-click-circle id radius]]))}])]
+                                     (dispatch [:drawer/editor [:right-click-circle id radius]]))}])]
      (when editing?
        [:div.dialog {:style {:border "1px solid #999" :padding "10px" :margin-top "5px"}}
         [:p (str "Adjust diameter of circle " (:circle-id ed))]
         [:input {:type "range" :min 5 :max 100 :step 1
                  :value (:preview-radius ed)
-                 :on-change #(rf/dispatch [:drawer/editor [:drag-slider
-                                                           (js/parseInt (.. % -target -value))]])}]
+                 :on-change #(dispatch [:drawer/editor [:drag-slider
+                                                        (js/parseInt (.. % -target -value))]])}]
         [:div.row
-         [:button {:on-click #(rf/dispatch [:drawer/editor [:close-dialog]])}  "Commit"]
-         [:button {:on-click #(rf/dispatch [:drawer/editor [:cancel-dialog]])} "Cancel"]]])]))
+         [:button {:on-click #(dispatch [:drawer/editor [:close-dialog]])}  "Commit"]
+         [:button {:on-click #(dispatch [:drawer/editor [:cancel-dialog]])} "Cancel"]]])]))
 ```
 
 **Modeling rule the example illustrates:** preview is *display* state, not domain state. The drag never persists into `:circles`; instead the `:drawer/circles-with-preview` sub merges `:preview-radius` from the editor's `:data` into the rendered circles at read time. Cancel is therefore a no-op on domain state — there is nothing to revert because nothing was persisted.

--- a/spec/008-Testing.md
+++ b/spec/008-Testing.md
@@ -594,9 +594,9 @@ Assert rendered text after dispatching:
 Authoring side — emit a testid at the view call site:
 
 ```clojure
-(defn counter-button [label dispatch-ev]
+(defn counter-button [label on-click]
   [:button (th/testid (str "counter-" label)
-                      {:on-click #(rf/dispatch dispatch-ev)})
+                      {:on-click on-click})
    label])
 ```
 

--- a/spec/Construction-Prompts.md
+++ b/spec/Construction-Prompts.md
@@ -577,7 +577,7 @@ The framework-registered `:rf/machine` sub returns the snapshot for any machine;
        :submitting  [spinner]
        :error-shown [:<>
                      [:p (str "Error: " (:error data))]
-                     [:button {:on-click #(rf/dispatch [:auth.login/flow [:dismiss]])}
+                     [:button {:on-click #(dispatch [:auth.login/flow [:dismiss]])}
                       "Try again"]]
        :authed      [:p "Welcome!"]
        :locked-out  [:p "Account locked."]

--- a/spec/Pattern-ReusableComponents.md
+++ b/spec/Pattern-ReusableComponents.md
@@ -56,7 +56,7 @@ The view is an ordinary function. The id is a positional argument:
     [:div.customer-card
      [:h3 (:name customer)]
      [:p  (:email customer)]
-     [:button {:on-click #(rf/dispatch [:customer/edit id])}
+     [:button {:on-click #(dispatch [:customer/edit id])}
       "Edit"]]))
 ```
 
@@ -103,7 +103,7 @@ Two positional args, two subs, two dispatch-scope ids:
     [:div.transfer
      [:div.from [:h3 (:name source)] [:p (:balance source)]]
      [:div.to   [:h3 (:name dest)]   [:p (:balance dest)]]
-     [:button {:on-click #(rf/dispatch [:account/transfer source-id dest-id 100])}
+     [:button {:on-click #(dispatch [:account/transfer source-id dest-id 100])}
       "Transfer $100"]]))
 ```
 

--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -1193,11 +1193,12 @@ renders against the variant's frame) or assertions (which read through
 ```clojure
 (rf/reg-view :app.ui/counter
   (fn [_]
-    (let [n @(rf/subscribe [:counter/value])]
+    (let [n        @(rf/subscribe [:counter/value])
+          dispatch (:dispatch (rf/capture-frame))]   ;; frame captured at render — survives the deferred click
       [:div
-       [:button {:on-click #(rf/dispatch [:counter/decrement])} "−"]
+       [:button {:on-click #(dispatch [:counter/decrement])} "−"]
        [:span.value n]
-       [:button {:on-click #(rf/dispatch [:counter/increment])} "+"]])))
+       [:button {:on-click #(dispatch [:counter/increment])} "+"]])))
 
 (story/reg-story :story.counter
   {:component :app.ui/counter

--- a/tools/story/spec/Tutorial-Playwright.md
+++ b/tools/story/spec/Tutorial-Playwright.md
@@ -185,12 +185,13 @@ canonical pattern:
 ```clojure
 (rf/reg-view :app.ui/counter
   (fn [_]
-    (let [n @(rf/subscribe [:counter/value])]
+    (let [n        @(rf/subscribe [:counter/value])
+          dispatch (:dispatch (rf/capture-frame))]   ;; frame captured at render — survives the deferred click
       [:div
-       [:button {:on-click  #(rf/dispatch [:counter/decrement])
+       [:button {:on-click  #(dispatch [:counter/decrement])
                  :data-test "counter-decrement"} "−"]
        [:span {:data-test "counter-value"} n]
-       [:button {:on-click  #(rf/dispatch [:counter/increment])
+       [:button {:on-click  #(dispatch [:counter/increment])
                  :data-test "counter-increment"} "+"]])))
 ```
 


### PR DESCRIPTION
## Summary

A bare, fully-qualified `rf/dispatch` inside a deferred `:on-*` callback carries **no** frame context in a real build: by the time the callback fires, the dynamic `*current-frame*` scope has unwound and the `frame-provider`'s React context has been popped, so it raises `:rf.error/no-frame-context` (EP-0002, no `:rf/default` floor). What survives the render boundary is a frame captured **at render time** — the `reg-view`-injected `dispatch` / `subscribe` (a `capture-frame` op bundle), or an explicit `(rf/capture-frame)`.

PR #6062 fixed `docs/core/views.md` and added a stock-Reagent real-DOM proof. This PR finishes the same law across the remaining first-party teaching surfaces (`rf2-leeqp`) and completes the adapter proof so **both** shipped Reagent substrates are pinned.

## Lawful shape confirmed

- `reg-view` macro (`core_reg_view_macro.cljc`) injects `dispatch` / `subscribe` bound to `(make-capture-frame (current-frame-id) …)` — render-time capture. So the injected **unqualified** `dispatch` dispatches correctly after the render boundary; a fresh `rf/dispatch` does not.
- Render-phase `rf/subscribe` (in a `reg-view` body) is lawful (scope active during render) and is left as-is — only the **deferred callbacks** were unlawful.

## Corrected sites

Live cells → `frame-root` + `reg-view` (browser-clickable without relying on the SCI playground's frame injection):
- `docs/core/how-to/validate-with-schemas.md` — `defn favorite-button` + top-level `dispatch-sync` → `reg-view` + `frame-root {:id :demo :initial-events …}`; prose "runs in the playground's frame, so no `with-frame`" corrected.
- `docs/machines/concepts.md` — `defn turnstile-view` → `reg-view` + `frame-root`.
- `docs/tools/playground/README.md` — `defn counter` → `reg-view` + `frame-root`; the harness "wrappers" note now says the frame-less fallback is *not* the shape to copy.

`reg-view` reference examples → deferred-callback `#(rf/dispatch …)` → injected `#(dispatch …)`:
- `spec/005-StateMachines.md` (drawer `reg-view main`: undo/redo, svg add-circle, context-menu, drag-slider, commit/cancel).
- `spec/Construction-Prompts.md` (`login-form`), `spec/Pattern-ReusableComponents.md` (`customer-card`, `account-transfer`).
- `docs/api/re-frame.core.md` (`dispatch` example), `docs/api/re-frame.test-helpers.md` (`testid` example).
- `tools/story/spec/001-Authoring.md`, `tools/story/spec/Tutorial-Playwright.md` — story keyword-id `(reg-view :id (fn …))` form (which doesn't inject) uses a render-captured `(:dispatch (rf/capture-frame))`.

Prose:
- `migration/from-re-frame-v1/README.md` M-11 — new caveat: `frame-provider` is a render-phase scope that does **not** preserve dynamic scope into a later callback; even inside a `reg-view`, a bare `rf/dispatch` in an `:on-*` handler raises `:rf.error/no-frame-context`. New flag item 3.
- `spec/008-Testing.md` — `counter-button` becomes a pure presentational helper taking an `on-click` callback (house rule: helpers take data + callbacks only).

Explicitly-labelled WRONG examples and explicit-`{:frame …}` callbacks were left untouched.

## Adapter proof — real-DOM matrix (both substrates)

A real synthetic click, on a `reg-view` mounted under a `frame-provider` in a real React root, pins **both** halves of the law: bare `#(rf/dispatch …)` raises `:rf.error/no-frame-context` and lands nothing; injected `#(dispatch …)` reaches the render frame and app-db advances after the render boundary.

- **New**: `implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_synthetic_event_frame_dom_cljs_test.cljs` — the reagent-slim half (the gap #6062 left; the slim smoke only proved the happy path).
- **Hardened**: `views_synthetic_event_frame_dom_cljs_test.cljs` (stock Reagent) — replaced the two fixed 10 ms timers and the setup outside the guaranteed cleanup path.

Both now use a **causal settle** (`test-support/poll-until` on the frame's app-db, no fixed sleeps) and **one guaranteed finalizer** (idempotent; unmounts the root, removes the DOM node, destroys the frame, completes the async test on every path — success, poll timeout, or a throw anywhere in setup/mount).

No core runtime change. Still exactly **3** adapter smokes (Reagent/UIx/Helix). No new `*.spec.cjs` under `examples/`.

## Quality gates

- `python scripts/check_doc_slugs.py` → **exit 0**.
- `python -m mkdocs build --strict` → **exit 0** (only pre-existing spec/migration INFO notes).
- `npm run test:cljs` → **Ran 9877 tests containing 48549 assertions. 0 failures, 0 errors.** (a clean re-run; a single first-run failure was a load-induced flake — no compiled CLJS source is touched.)
- `npm run test:adapter-smokes` → **Ran 3 adapter-smoke specs. 0 failures.**
- Focused `:browser-test` under real Chromium, both synthetic-event proofs (`ns-regexp "synthetic-event-frame-dom-cljs-test$"`) → **Ran 2 tests containing 12 assertions. 0 failures, 0 errors.** — the bare-fail / injected-lands assertions actually fire on both stock Reagent and reagent-slim.
