### PR TITLE
fix(ui-compiler): truthful controlled-input diagnostic + close letfn* raw-fn* grammar (rf2-r0775, rf2-9rqmq)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -120,6 +120,36 @@
 (defn- fn-form? [f]
   (and (seq? f) (contains? #{'fn 'fn* 'clojure.core/fn 'cljs.core/fn} (first f))))
 
+(defn- host-portable-argv?
+  "The raw `fn*` special form binds only simple (unqualified) symbols, with an
+  optional single trailing `& rest`. Applied ONLY to a raw `fn*` initializer:
+  its parameters are what the host compiler binds directly, so destructuring,
+  non-symbol/qualified parameters, and malformed `&` forms are host-illegal
+  (and a map argv otherwise reaches binding-plan as a raw
+  IllegalArgumentException). Macro `fn` / source `letfn` legally destructure —
+  their expansion owns that grammar — so they keep the looser argv shape."
+  [argv]
+  (and (vector? argv)
+       (let [[fixed tail] (split-with #(not= '& %) argv)]
+         (and (every? simple-symbol? fixed)
+              (case (count tail)
+                0 true                            ; no variadic marker
+                2 (simple-symbol? (second tail))  ; `& rest`: exactly one rest sym
+                false)))))                        ; bare `&`, or `& a b`
+
+(defn- host-arities-compatible?
+  "Bounded arity-overload check for a raw `fn*`: the host rejects two overloads
+  of the same fixed arity, or more than one variadic overload. (This is the
+  narrow host-portability seam, NOT a general Clojure arity grammar — the
+  fixed-vs-variadic param-count rule is left to the host compiler.)"
+  [argvs]
+  (let [variadic?   (fn [argv] (boolean (some #(= '& %) argv)))
+        fixed-count (fn [argv] (count (take-while #(not= '& %) argv)))
+        variadics   (filter variadic? argvs)
+        fixed       (map fixed-count (remove variadic? argvs))]
+    (and (<= (count variadics) 1)
+         (= (count fixed) (count (set fixed))))))
+
 (defn- fn-init-shape?
   "True when `init` is a structurally well-formed fn/fn* form — the only legal
   shape for a HOST letfn* binding initializer. Bounded grammar check, not a full
@@ -127,14 +157,31 @@
   otherwise throws a raw host `Don't know how to create ISeq` exception) and
   rejects a non-fn initializer such as a bare `42` up front. Accepted shapes are
   `(fn <name>? [argv] body*)` (single arity) and `(fn <name>? ([argv] body*)+)`
-  (one or more arity lists); every argv MUST be a vector."
+  (one or more arity lists); every argv MUST be a vector.
+
+  A RAW `fn*` (the host special form — not the `fn` macro) additionally binds
+  only host-portable parameters (`host-portable-argv?`) with non-duplicate
+  arities (`host-arities-compatible?`): the host compiler requires it, and
+  without it a destructuring/qualified/malformed argv is either silently
+  accepted here only to crash the later host compiler, or reaches binding-plan
+  as a raw IllegalArgumentException. Macro `fn` / source `letfn` legally
+  destructure, so their argv shape is left to their own expansion."
   [init]
   (and (fn-form? init)
-       (let [tail (cond-> (rest init) (symbol? (second init)) rest)]
-         (cond
-           (vector? (first tail)) true
-           (seq tail)             (every? #(and (seq? %) (vector? (first %))) tail)
-           :else                  false))))
+       (let [raw?    (= 'fn* (first init))
+             tail    (cond-> (rest init) (symbol? (second init)) rest)
+             arities (cond
+                       (vector? (first tail)) (list tail)   ; single arity
+                       (and (seq tail)
+                            (every? #(and (seq? %) (vector? (first %))) tail))
+                       tail                                  ; arity lists
+                       :else nil)]
+         (boolean
+          (and arities
+               (or (not raw?)
+                   (let [argvs (map first arities)]
+                     (and (every? host-portable-argv? argvs)
+                          (host-arities-compatible? argvs)))))))))
 
 (defn- raw-form? [e f]  (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) ui-raw-fqns)))
 (defn- html-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) ui-html-fqns)))

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -1583,11 +1583,13 @@
                                        :msg (str (:k handler)
                                                  " is paired with a controlled "
                                                  ":value/:checked prop, but its "
-                                                 "handler is not a literal data "
-                                                 "event. It stays on the ordinary "
-                                                 "batched path; use a literal event "
-                                                 "vector to open the controlled-"
-                                                 "input sync door")
+                                                 "handler is neither a literal event "
+                                                 "vector nor a (ui/event …) handler, "
+                                                 "so it stays on the ordinary batched "
+                                                 "path. Open the controlled-input sync "
+                                                 "door with a literal event vector, or "
+                                                 "a (ui/event …) handler when the "
+                                                 "native payload must flow")
                                        :form (:form handler)}))
                                    (assoc handler :sync? sync?)))
                                events0)

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -457,7 +457,17 @@
       (is (false? (get-in ast [:props :events 0 :sync?])))
       (is (= [:rf.ui.compile/controlled-input-async-handler]
              (mapv :id warnings))
-          "a fallback site names the exact conditions it failed to prove"))
+          "a fallback site names the exact conditions it failed to prove")
+      ;; rf2-r0775 — the recovery guidance must name BOTH sync-door forms
+      ;; (#{:vector :ui-event} per controlled-event-sync?): a literal event
+      ;; vector OR a (ui/event …) handler. A reusable control that needs the
+      ;; native payload may not be expressible as a literal vector, so the
+      ;; diagnostic must not prescribe only the vector door.
+      (let [msg (:msg (first warnings))]
+        (is (re-find #"literal event vector" msg)
+            "the diagnostic still names the literal-event-vector door")
+        (is (re-find #"ui/event" msg)
+            "the diagnostic ALSO names the (ui/event …) door")))
     (testing "a bare fn at a controlled site still batches with the diagnostic"
       (let [{:keys [ast warnings]}
             (ana-full '[:input {:value value :on-input (fn [e] (js/console.log e))}])]

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -400,6 +400,51 @@
          (reject-id '[:div {:title (letfn* [f (fn* f ([x] (sub [:q])))] (f 7))}]))
       "a reactive read inside a deferred local fn body is not a finite render site"))
 
+(deftest letfn*-raw-fn*-parameter-and-arity-grammar
+  ;; rf2-9rqmq — fn-init-shape? treated any vector as a well-formed argv and any
+  ;; vector-led arity list as valid, so host-illegal RAW `fn*` grammar escaped
+  ;; the UI compiler: a destructuring/qualified parameter or a malformed `&` was
+  ;; ACCEPTED (only to crash the later host compiler), and a malformed directive
+  ;; like `(fn* [{:keys 42}] …)` threw a raw IllegalArgumentException from
+  ;; binding-plan. The raw `fn*` special form binds only simple symbols with an
+  ;; optional single `& rest`, and rejects duplicate/incompatible arities — the
+  ;; UI analyzer must reject the same shapes, on the typed bad-let surface, and
+  ;; on BOTH hosts (the analyzer is pure — this IS the CLJ/CLJS parity fixture).
+  (testing "raw fn* parameters must be host-portable simple symbols"
+    (is (= :rf.ui.compile/bad-let
+           (reject-id '[:div {:title (letfn* [f (fn* [{:keys [x]}] x)] f)}]))
+        "a destructuring parameter is host-illegal in raw fn*")
+    (is (= :rf.ui.compile/bad-let
+           (reject-id '[:div {:title (letfn* [f (fn* [foo/bar] foo/bar)] f)}]))
+        "a qualified parameter is host-illegal in raw fn*")
+    (is (= :rf.ui.compile/bad-let
+           (reject-id '[:div {:title (letfn* [f (fn* [{:keys 42}] 1)] f)}]))
+        "a malformed directive is typed bad-let (never a raw IllegalArgumentException)")
+    (is (= :rf.ui.compile/bad-let
+           (reject-id '[:div {:title (letfn* [f (fn* [a & b c] a)] f)}]))
+        "a malformed & (two rest params) is host-illegal")
+    (is (= :rf.ui.compile/bad-let
+           (reject-id '[:div {:title (letfn* [f (fn* [a &] a)] f)}]))
+        "a bare & (no rest param) is host-illegal"))
+  (testing "raw fn* rejects duplicate / multiple-variadic arities"
+    (is (= :rf.ui.compile/bad-let
+           (reject-id '[:div {:title (letfn* [f (fn* ([x] x) ([y] y))] f)}]))
+        "two overloads of the same fixed arity are host-illegal")
+    (is (= :rf.ui.compile/bad-let
+           (reject-id '[:div {:title (letfn* [f (fn* ([& a] a) ([x & b] x))] f)}]))
+        "more than one variadic overload is host-illegal"))
+  (testing "the boundary is raw fn* ONLY — macro fn / source letfn destructuring stays legal"
+    (is (nil? (reject-id '[:div {:title (letfn* [f (fn [{:keys [x]}] x)] f)}]))
+        "macro fn owns its destructuring expansion — accepted")
+    (is (nil? (reject-id '[:div {:title (letfn* [f (fn [[a b]] a)] f)}]))
+        "macro fn nested/sequential destructuring — accepted")
+    (is (nil? (reject-id '[:div {:title (letfn* [f (fn* f ([x] x))] (f 7))}]))
+        "a legal named raw fn* retains its exact shape")
+    (is (nil? (reject-id '[:div {:title (letfn* [f (fn* [a & b] a)] f)}]))
+        "a legal raw fn* variadic (single trailing & rest) — accepted")
+    (is (nil? (reject-id '[:div {:title (letfn* [f (fn* ([] 0) ([x] x))] f)}]))
+        "legal distinct raw fn* fixed arities — accepted")))
+
 (deftest frame-finite-sites
   (is (= :rf.ui.compile/frame-in-loop
          (reject-id '(for [x xs] [:li {:key x} (:frame (frame))])))


### PR DESCRIPTION
Coupled compiler-lane cluster on `implementation/ui/src/re_frame/ui/compiler/analyze.cljc` (reject/diagnostic family). Two beads, one worker (they would merge-conflict if parallel). Commit order: smallest cleanup → biggest correctness.

## rf2-r0775 — name both sync-door forms in the controlled-input diagnostic
The compile-tier `:rf.ui.compile/controlled-input-async-handler` warning prescribed ONLY "a literal event vector" to open the controlled-input sync door. Since PR #6027 the accepted door is `#{:vector :ui-event}` (`controlled-event-sync?`), so a reusable control needing the native payload — not expressible as a literal vector — was told its only fix was a form it cannot use.

- **Seam:** `analyze.cljc` ~L1582 (the `env/warn!` `:msg` inside the controlled-event branch).
- **Fix:** reword the guidance to name BOTH valid forms — a literal event vector, OR a `(ui/event …)` handler when the native payload must flow. Message-text only; no control-flow change.
- **Reused id (no new id):** `:rf.ui.compile/controlled-input-async-handler` (warning). Compile-tier `:rf.ui.compile/*` — no Spec 009 row.
- **Red→green:** accept-table assertion now requires the message to name both `literal event vector` and `ui/event`; before, the message named only the vector door.

## rf2-9rqmq — close the raw `fn*` parameter and arity grammar at the letfn* boundary
PR #6094's `fn-init-shape?` treated any vector as a well-formed argv and any vector-led arity list as valid, so host-illegal RAW `fn*` grammar escaped the UI compiler.

- **Seam:** `analyze.cljc` `fn-init-shape?` (~L123), reached from `rw-letfn*` (~L704).
- **Fix:** for a RAW `fn*` (head = `fn*`) only, enforce host-portable params (`host-portable-argv?`: simple symbols + optional single `& rest`) and non-duplicate/single-variadic arities (`host-arities-compatible?`). Macro `fn` / source `letfn` keep the looser argv shape — their expansion owns destructuring. Two bounded helpers; no new error id, no broad special-form roster, no general grammar parser.
- **Reused id (no new id):** `:rf.ui.compile/bad-let`.
- **Red→green (cross-host `.cljc`):** `(letfn* [f (fn* [{:keys [x]}] x)] f)`, `(fn* [foo/bar] …)`, `(fn* [a & b c] a)`, `(fn* [a &] a)`, `(fn* ([x] x) ([y] y))`, `(fn* ([& a] a) ([x & b] x))` were ACCEPTED (or, for `(fn* [{:keys 42}] …)`, threw a raw `IllegalArgumentException` from binding-plan); all now reject onto `:rf.ui.compile/bad-let`. Controls stay accepted: macro `fn` destructuring, legal named/single/variadic/multi raw `fn*`.

## Scope
Touches ONLY `analyze.cljc` + its accept/reject tests. No emit_cljs.cljc / rules.cljc / runtime.cljs / build_hook.clj / ui/test.cljc / spec touch. No new error-id. Both fixes reuse existing ids.

## Quality gates
- `implementation/ui` JVM (`clojure -M:test`): **773 tests, 14304 assertions, 0 failures, 0 errors** (both fixes in place; +1 deftest, +19 assertions vs main's 772/14285).
- `npm run test:cljs` (CLJS host): **9887 tests, 48673 assertions, 0 failures, 0 errors**. Confirmed the new `.cljc` fixtures + both src fixes compiled into the node-test bundle — cross-host parity green.
- Did NOT run the full spine (per brief). defview parity + G-13 unaffected (JVM suite green).
