### PR TITLE
test(g13): make the cold-first control causal to the timed dispatch (rf2-6k4cm)

### DIFF
--- a/implementation/scripts/_g13-timing-evidence.test.cjs
+++ b/implementation/scripts/_g13-timing-evidence.test.cjs
@@ -29,6 +29,7 @@ const {
   validateWarmSamples,
   summarizeWarm,
   assertColdIsFirstDrain,
+  assertColdOrderControl,
   buildSummary,
 } = require('./lib/g13-timing-evidence.cjs');
 
@@ -213,6 +214,65 @@ test('assertColdIsFirstDrain rejects any nonzero pre-hot (a later warmed drain)'
 test('assertColdIsFirstDrain rejects a missing pre-hot witness', () => {
   assert.throws(() => assertColdIsFirstDrain({ label: 'cold' }), /first post-mount dispatch/);
   assert.throws(() => assertColdIsFirstDrain(null, 'V=500'), /cold sample is missing/);
+});
+
+// ----- assertColdOrderControl: the CAUSAL cold-first control (rf2-6k4cm) ------
+//
+// The fixture runs both cycle orders on fresh frames and reports each TIMED
+// cycle's own pre-hot witness. This control asserts the two orders DIVERGE — the
+// only evidence that the witness is sourced from the timed dispatch, not from a
+// point (sample! entry) that stays 0 regardless of which cycle the timer measures.
+
+const QUEUED_WRITES = 8;
+
+test('assertColdOrderControl accepts the causal 0 / queued-writes divergence', () => {
+  // Real inverted execution advances :hot by queued-writes before the timer, so a
+  // causal witness reports 0 (timing-first) vs 8 (correctness-first).
+  const order = { 'timing-first': 0, 'correctness-first': QUEUED_WRITES };
+  assert.equal(assertColdOrderControl(order, QUEUED_WRITES), order);
+});
+
+test('assertColdOrderControl REJECTS a correctness-first witness that stayed 0 (the vacuous, non-causal control)', () => {
+  // THE TEETH. A witness captured before the timed dispatch stays 0 in BOTH
+  // orders — the exact false-green this bead repairs. It must be rejected even
+  // though the per-sample cold-first assertion (0 === 0) would still pass.
+  const collapsed = { 'timing-first': 0, 'correctness-first': 0 };
+  assert.throws(
+    () => assertColdOrderControl(collapsed, QUEUED_WRITES, 'V=100 cold-first order control'),
+    /non-causal, vacuous cold-first control/,
+  );
+  assert.throws(
+    () => assertColdOrderControl(collapsed, QUEUED_WRITES, 'V=100 cold-first order control'),
+    /V=100 cold-first order control/,
+  );
+});
+
+test('assertColdOrderControl rejects a correctness-first witness that advanced by the wrong amount', () => {
+  assert.throws(
+    () => assertColdOrderControl({ 'timing-first': 0, 'correctness-first': 16 }, QUEUED_WRITES),
+    /did not advance to queued-writes/,
+  );
+});
+
+test('assertColdOrderControl rejects a timing-first witness that left the mount seed', () => {
+  // If the timed cycle did NOT run first, its witness is nonzero and the reported
+  // "cold" span is a warmed drain — the control must reject it.
+  assert.throws(
+    () => assertColdOrderControl({ 'timing-first': 8, 'correctness-first': QUEUED_WRITES }, QUEUED_WRITES),
+    /timing-first witness is not the mount seed/,
+  );
+});
+
+test('assertColdOrderControl rejects a missing order control', () => {
+  assert.throws(() => assertColdOrderControl(null, QUEUED_WRITES), /order control is missing/);
+  assert.throws(() => assertColdOrderControl(undefined, QUEUED_WRITES, 'V=500'), /V=500/);
+});
+
+test('assertColdOrderControl rejects a non-positive queued-writes basis', () => {
+  assert.throws(
+    () => assertColdOrderControl({ 'timing-first': 0, 'correctness-first': 8 }, 0),
+    /queued-writes must be a positive finite number/,
+  );
 });
 
 // ----- runner ----------------------------------------------------------------

--- a/implementation/scripts/lib/g13-timing-evidence.cjs
+++ b/implementation/scripts/lib/g13-timing-evidence.cjs
@@ -108,6 +108,66 @@ function assertColdIsFirstDrain(cold, where = 'cold timing evidence') {
   return cold;
 }
 
+// rf2-6k4cm — the CAUSAL cold-first order control. `assertColdIsFirstDrain`
+// above proves ONE reported witness is 0, but a witness read at `sample!` entry
+// (before either cycle) stays 0 no matter which cycle the timer actually
+// measures — so that assertion can pass while the "cold" span is a warmed second
+// drain. This closes the gap: the fixture runs the two cycles in BOTH orders on
+// fresh frames and reports each TIMED cycle's OWN pre-hot witness. With the
+// witness sourced from the timed dispatch, the orders MUST diverge —
+// `timing-first` (the real cold order) sees the mount seed 0; `correctness-first`
+// (a correctness drain BEFORE the timer) sees `queuedWrites`. This asserts the
+// divergence: timing-first passes the cold-first assertion, correctness-first
+// fails it, and a non-causal witness that stays 0 in BOTH orders is rejected.
+// `queuedWrites` is the fixture's per-drain :hot advance (8). Returns the order
+// control on success.
+function assertColdOrderControl(order, queuedWrites, where = 'cold-first order control') {
+  if (!order || typeof order !== 'object') {
+    throw evidenceFail(`${where}: order control is missing (got ${JSON.stringify(order)})`);
+  }
+  if (typeof queuedWrites !== 'number' || !Number.isFinite(queuedWrites) || queuedWrites <= 0) {
+    throw evidenceFail(
+      `${where}: queued-writes must be a positive finite number; got ${JSON.stringify(queuedWrites)}`,
+    );
+  }
+  const timingFirst = order['timing-first'];
+  const correctnessFirst = order['correctness-first'];
+  // The real cold order: the timed cycle ran before any drain, so its witness is
+  // the mount seed and the cold-first assertion must ACCEPT it.
+  if (timingFirst !== COLD_FIRST_DRAIN_PRE_HOT) {
+    throw evidenceFail(
+      `${where}: timing-first witness is not the mount seed ${COLD_FIRST_DRAIN_PRE_HOT} ` +
+        `(got ${JSON.stringify(timingFirst)}); the timed cycle did not measure the first drain`,
+    );
+  }
+  assertColdIsFirstDrain({ 'timing-pre-hot': timingFirst }, `${where} (timing-first)`);
+  // The inverted order: a correctness drain committed `queuedWrites` before the
+  // timed cycle, so a CAUSAL witness MUST advance to it. A witness still equal to
+  // the mount seed here proves the value was captured before the timed dispatch —
+  // exactly the vacuous, non-causal control this check exists to reject.
+  if (correctnessFirst !== queuedWrites) {
+    throw evidenceFail(
+      `${where}: correctness-first witness did not advance to queued-writes ` +
+        `(got ${JSON.stringify(correctnessFirst)}, expected ${queuedWrites}); the pre-hot witness ` +
+        'is not sourced from the timed dispatch — a non-causal, vacuous cold-first control',
+    );
+  }
+  // ...and the cold-first assertion MUST REJECT that inverted-order witness.
+  let rejected = false;
+  try {
+    assertColdIsFirstDrain({ 'timing-pre-hot': correctnessFirst }, `${where} (correctness-first)`);
+  } catch (_) {
+    rejected = true;
+  }
+  if (!rejected) {
+    throw evidenceFail(
+      `${where}: the cold-first assertion accepted the correctness-first witness ` +
+        `(${JSON.stringify(correctnessFirst)}) — the control does not depend on the timed dispatch order`,
+    );
+  }
+  return order;
+}
+
 function fmt(x) {
   return Number(x).toFixed(3);
 }
@@ -158,5 +218,6 @@ module.exports = {
   validateWarmSamples,
   summarizeWarm,
   assertColdIsFirstDrain,
+  assertColdOrderControl,
   buildSummary,
 };

--- a/implementation/scripts/run-ui-g13.cjs
+++ b/implementation/scripts/run-ui-g13.cjs
@@ -22,6 +22,7 @@ const {
   validateWarmSamples,
   summarizeWarm,
   assertColdIsFirstDrain,
+  assertColdOrderControl,
   buildSummary,
 } = require('./lib/g13-timing-evidence.cjs');
 
@@ -286,6 +287,15 @@ function assertDevResult(result) {
   if (!sameJson(roster, [100, 500])) {
     fail(`workload roster is not exactly one V=100 then one V=500: ${JSON.stringify(roster)}`);
   }
+  // rf2-6k4cm — the CAUSAL cold-first order control. The fixture ran the timing
+  // and correctness cycles in BOTH orders on fresh frames and reported each timed
+  // cycle's OWN pre-hot witness. Because the witness rides the timed dispatch (not
+  // sample! entry), the orders diverge — timing-first sees the mount seed 0 and
+  // passes assertColdIsFirstDrain; correctness-first sees queued-writes and fails
+  // it. This asserts the divergence, so the earlier per-size cold-first checks can
+  // no longer pass vacuously: a witness that stayed 0 in both orders (captured
+  // before the timed dispatch) is rejected here.
+  assertColdOrderControl(result['cold-first-order-control'], result['queued-writes']);
   const expected = expectedProjection();
   const projections = [];
   for (const size of result.results || []) {
@@ -375,6 +385,19 @@ function assertMutationTeeth(result) {
     ['correctness ran before the cold timer', (r) => {
       r.results[0].cold['timing-pre-hot'] = 8;
     }],
+    // rf2-6k4cm — the CAUSAL order-control teeth. Unlike the forged-field tooth
+    // above (which only asserts the assertion rejects a nonzero value), these pin
+    // the SOURCE-order evidence the fixture actually produced. If the pre-hot
+    // witness were captured before the timed dispatch (the non-causal regression),
+    // the correctness-first witness would collapse to the mount seed and the gate
+    // must go red; timing-first must stay the mount seed; the control cannot vanish.
+    ['order control correctness-first collapsed to the mount seed (non-causal witness)', (r) => {
+      r['cold-first-order-control']['correctness-first'] = 0;
+    }],
+    ['order control timing-first advanced off the mount seed', (r) => {
+      r['cold-first-order-control']['timing-first'] = 8;
+    }],
+    ['order control absent', (r) => { delete r['cold-first-order-control']; }],
     // rf2-vxgfnd.212 — workload-roster teeth. Each must fail validation, proving
     // the exact one-to-one V=100/V=500 roster before projections are compared.
     // 'duplicate V=100' is the bead's exact false-green: the V=500 row silently

--- a/implementation/ui/g13/re_frame/ui/g13/dev.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/dev.cljs
@@ -76,15 +76,26 @@
   timestamp is taken the instant the post-commit Promise resolves — before any
   delta scan, counter comparison, or DOM query — so the sample is the true
   dispatch-to-commit span and is independent of the V-scaled audit work done by
-  the correctness cycle. Returns the elapsed milliseconds."
+  the correctness cycle.
+
+  rf2-6k4cm — the `:pre-hot` witness (app-db `:hot` immediately before THIS
+  timed dispatch) is read here, adjacent to the dispatch it guards, and returned
+  WITH this exact timed cycle. It is read before `started`, so it sits OUTSIDE
+  the measured interval and leaves the dispatch-to-commit span unchanged. Being
+  sourced from the timed cycle's own dispatch — not from `sample!` entry — makes
+  it causal to the measurement: any drain that preceded this cycle shows up as a
+  nonzero witness, so a warmed cycle can never masquerade as the cold first
+  drain. Returns `{:elapsed-ms <ms> :pre-hot <app-db :hot at dispatch>}`."
   [frame]
-  (let [started (js/performance.now)]
+  (let [pre-hot (:hot (rf/app-db-value frame))
+        started (js/performance.now)]
     (-> (uit/flush!
          (fn []
            ;; dispatch! completes all eight write epochs synchronously; the
            ;; render phase runs when flush!'s Promise advances to the commit.
            (uit/dispatch! frame [::fixture/step fixture/queued-writes])))
-        (.then (fn [_] (- (js/performance.now) started))))))
+        (.then (fn [_] {:elapsed-ms (- (js/performance.now) started)
+                        :pre-hot pre-hot})))))
 
 (defn- correctness-cycle!
   "Exact push-work accounting for ONE drain — UNTIMED. Owns the O(V) live-cell
@@ -207,19 +218,72 @@
   correctness so the reported `:elapsed-ms` is a true first-drain
   dispatch-to-commit span — never the second dispatch after this sample's own
   O(V) audit, DOM read, and cache/React warm-up. `:timing-pre-hot` is the
-  app-db `:hot` value captured immediately BEFORE the timing dispatch (outside
-  the measured interval): the mount seed leaves it 0 and every drain adds
-  `queued-writes`, so for the `cold` sample it is 0 — the causal proof that the
-  timer measured the FIRST post-mount dispatch, before any correctness-cycle
-  dispatch or audit. The exact counts still come from a cycle never on the clock."
+  witness `timing-cycle!` read of app-db `:hot` immediately BEFORE its own timed
+  dispatch (outside the measured interval) and returned WITH that cycle
+  (rf2-6k4cm): the mount seed leaves it 0 and every drain adds `queued-writes`,
+  so for the `cold` sample it is 0 — the CAUSAL proof that the timer measured the
+  FIRST post-mount dispatch. Because it rides the timed cycle rather than being
+  read at `sample!` entry, running correctness before timing advances it to
+  `queued-writes` and the cold-first control fails; it cannot pass vacuously.
+  The exact counts still come from a cycle never on the clock."
   [root frame v label]
-  (let [timing-pre-hot (:hot (rf/app-db-value frame))]
-    (-> (timing-cycle! frame)
-        (.then (fn [elapsed]
-                 (-> (correctness-cycle! root frame v label)
-                     (.then (fn [c]
-                              (assoc c :elapsed-ms elapsed
-                                     :timing-pre-hot timing-pre-hot)))))))))
+  ;; rf2-6k4cm — the timed cycle runs FIRST and reports its OWN pre-hot witness;
+  ;; `:timing-pre-hot` is that witness, so it is causal to the measured dispatch.
+  ;; Inverting these two stages (correctness before timing) would advance the
+  ;; witness off the mount seed and redden the cold-first control — it can no
+  ;; longer stay 0 while the timer measures a warmed second drain.
+  (-> (timing-cycle! frame)
+      (.then (fn [{:keys [elapsed-ms pre-hot]}]
+               (-> (correctness-cycle! root frame v label)
+                   (.then (fn [c]
+                            (assoc c :elapsed-ms elapsed-ms
+                                   :timing-pre-hot pre-hot))))))))
+
+;; rf2-6k4cm — the CAUSAL cold-first order control. The gate's `assertColdIsFirstDrain`
+;; rests on `:timing-pre-hot` being 0 for the cold sample. Forging that field, or
+;; asserting a value read before either cycle, does NOT prove the witness tracks the
+;; timed dispatch — it can stay 0 while the timer secretly measures a warmed second
+;; drain. This control runs the two cycles in BOTH orders on FRESH frames and returns
+;; each timed cycle's OWN witness. Because the witness now rides `timing-cycle!`'s
+;; dispatch, the two orders DIVERGE: timing-first witnesses the mount seed 0,
+;; correctness-first witnesses `queued-writes`. The runner asserts the divergence, so
+;; a non-causal witness (0 in both) is rejected. This is source/order evidence — it
+;; runs correctness before timing for real, not a JSON mutation.
+(defn- timed-witness!
+  "Mount a FRESH v-sized fixture, run the two cycles in `order` (`:timing-first`
+  or `:correctness-first`), and return the TIMED cycle's own `:pre-hot` witness.
+  Tears the frame down on every exit."
+  [v order]
+  (let [frame (rf/make-frame {:initial-events [[:rf/set-db (fixture/seed v)]]})]
+    (-> (uit/with-root [root [ui/frame-provider {:frame frame}
+                              [fixture/app {:v v}]]]
+          (if (= order :correctness-first)
+            ;; A correctness drain advances app-db :hot off the mount seed BEFORE
+            ;; the timed cycle runs; the timed cycle must then witness that advance.
+            (-> (correctness-cycle! root frame v "order-control")
+                (.then (fn [_] (timing-cycle! frame)))
+                (.then (fn [timed] (:pre-hot timed))))
+            ;; The true cold order: the timed cycle runs first, so it witnesses 0.
+            (-> (timing-cycle! frame)
+                (.then (fn [timed] (:pre-hot timed))))))
+        (.then (fn [pre-hot]
+                 (rf/destroy-frame! frame)
+                 pre-hot)
+               (fn [e]
+                 (rf/destroy-frame! frame)
+                 (throw e))))))
+
+(defn- order-control!
+  "Report each order's timed-cycle witness for the runner's causal cold-first
+  control: `:timing-first` (expected 0, passes) and `:correctness-first`
+  (expected `queued-writes`, fails)."
+  [v]
+  (-> (timed-witness! v :timing-first)
+      (.then (fn [timing-first]
+               (-> (timed-witness! v :correctness-first)
+                   (.then (fn [correctness-first]
+                            {:timing-first timing-first
+                             :correctness-first correctness-first})))))))
 
 (defn- run-size! [v]
   (let [frame (rf/make-frame {:initial-events [[:rf/set-db (fixture/seed v)]]})
@@ -283,32 +347,42 @@
               sizes)
       (.then
        (fn [results]
-         (let [projections (mapv #(get-in % [:cold :projection]) results)]
-           (ensure! (apply = projections)
-                    "candidate-work projection depends on V"
-                    {:projections projections})
-           {:gate "G-13"
-            :status "pass"
-            :sizes sizes
-            :queued-writes fixture/queued-writes
-            :affected-viewcells fixture/hot-count
-            :fixed-shell-idle-cells fixture/idle-shell-count
-            :timing-posture "evidence-only; no threshold"
-            ;; rf2-vxgfnd.210 — the explicit candidate-work axis plus the HONEST
-            ;; scope of what the counts prove. `port-fan-out` (C*Q, summed over
-            ;; all V live cells with the V−C non-affected cells contributing
-            ;; zero) is the named V-independent candidate-work projection. The
-            ;; counts prove V-independent DELIVERED push work (fan-out
-            ;; occurrences + sub recomputes + renders + one commit). A pure
-            ;; membership SCAN that inspects V candidates but delivers to only C
-            ;; is observable only by a production-side counter at the port's
-            ;; candidate-iteration choke point — out of this gate's reach — and
-            ;; is tracked by timing evidence alone, never asserted by a count
-            ;; nor by a wall-clock threshold.
-            :candidate-work-projection "port-fan-out"
-            :proof-scope
-            "v-independent delivered push work; pure candidate scan is timing-evidence-only"
-            :results results})))))
+         ;; rf2-6k4cm — run the causal cold-first order control on a fresh frame
+         ;; (both orders), then fold its witnesses into the result the runner asserts.
+         (-> (order-control! (first sizes))
+             (.then
+              (fn [order]
+                (let [projections (mapv #(get-in % [:cold :projection]) results)]
+                  (ensure! (apply = projections)
+                           "candidate-work projection depends on V"
+                           {:projections projections})
+                  {:gate "G-13"
+                   :status "pass"
+                   :sizes sizes
+                   :queued-writes fixture/queued-writes
+                   :affected-viewcells fixture/hot-count
+                   :fixed-shell-idle-cells fixture/idle-shell-count
+                   ;; rf2-6k4cm — the timed-cycle witness under both cycle orders.
+                   ;; `:timing-first` is the real cold order (0); `:correctness-first`
+                   ;; is a drain before the timer (queued-writes). The runner proves
+                   ;; the cold-first control accepts the former and rejects the latter.
+                   :cold-first-order-control order
+                   :timing-posture "evidence-only; no threshold"
+                   ;; rf2-vxgfnd.210 — the explicit candidate-work axis plus the HONEST
+                   ;; scope of what the counts prove. `port-fan-out` (C*Q, summed over
+                   ;; all V live cells with the V−C non-affected cells contributing
+                   ;; zero) is the named V-independent candidate-work projection. The
+                   ;; counts prove V-independent DELIVERED push work (fan-out
+                   ;; occurrences + sub recomputes + renders + one commit). A pure
+                   ;; membership SCAN that inspects V candidates but delivers to only C
+                   ;; is observable only by a production-side counter at the port's
+                   ;; candidate-iteration choke point — out of this gate's reach — and
+                   ;; is tracked by timing evidence alone, never asserted by a count
+                   ;; nor by a wall-clock threshold.
+                   :candidate-work-projection "port-fan-out"
+                   :proof-scope
+                   "v-independent delivered push work; pure candidate scan is timing-evidence-only"
+                   :results results}))))))))
 
 (defn -main []
   (-> (execute!)


### PR DESCRIPTION
## What

G-13's cold-first control (`assertColdIsFirstDrain`) rested on the cold sample's `:timing-pre-hot` being 0, but the witness was captured at `sample!` entry — before either the timing or correctness cycle ran — rather than at the timed dispatch itself. That made it **non-causal**: swapping the two cycles so correctness runs before timing leaves the reported "cold" span a warmed second drain, yet the entry-captured witness stays 0 and the control passes vacuously (a false-green in the gate's control arm, closing rf2-52isf's acceptance gap).

This tightens the **control** so it is causally tied to the actual timed dispatch. **The runtime dispatch order is unchanged** (#6100 got that right) — the timed cycle still runs first.

## How

- `timing-cycle!` (`dev.cljs`) now reads the pre-hot witness immediately before its **own** dispatch — before `started`, so it sits outside the measured interval and the dispatch-to-commit span is unchanged — and returns it with that exact timed cycle (`{:elapsed-ms .. :pre-hot ..}`). `sample!` consumes that witness for `:timing-pre-hot`. Any drain that preceded the timer now surfaces as a nonzero witness; a warmed cycle can no longer masquerade as the cold first drain.
- New in-fixture **order control** (`order-control!` / `timed-witness!`) runs the two cycles in **both** orders on fresh frames and reports each timed cycle's own witness — `:timing-first` (mount seed 0) and `:correctness-first` (queued-writes). This runs correctness before timing *for real*, not by mutating JSON.
- `assertColdOrderControl` (pure, unit-tested in `g13-timing-evidence.cjs`) asserts the divergence — the cold-first assertion accepts timing-first and rejects correctness-first — so a non-causal witness that stays 0 in both orders is rejected. Wired into `assertDevResult`; three mutation teeth pin it.

## The teeth (vacuous-pass-now-fails)

| State | cold `timing-pre-hot` | gate |
|---|---|---|
| **pre-fix** control, order inverted | 0 (entry capture, decoupled) | **GREEN — vacuous** |
| **fixed** control, order inverted | 8 (causal to timed dispatch) | **RED — caught** |
| fixed control, correct order | 0 | GREEN |

Live order control on the green run reports `{timing-first: 0, correctness-first: 8}` — real inverted execution advances the witness, proving the dependency.

## Quality gates

- `npm run test:ui-g13` (full browser gate: shadow-cljs compile + release + Playwright) — **PASS**. Report carries `cold-first-order-control {timing-first: 0, correctness-first: 8}` and 29 red mutation teeth (incl. the three new order-control teeth).
- Red-before/green-after proven at the source level: inverting `sample!` order turned the fixed gate RED (`timing-pre-hot=8, expected 0; correctness ran before the cold timer`); the pre-fix control stayed GREEN under the same inversion.
- `node scripts/_g13-timing-evidence.test.cjs` — **31 passed** (6 new `assertColdOrderControl` tests, incl. the collapsed-witness teeth: a witness that stays 0 in both orders is rejected).

The clean dispatch-to-commit interval, two-cycle separation, raw samples, quantiles, exact-work projection, and evidence-only/no-threshold posture are unchanged. No benchmark framework, production instrumentation, or timing threshold added. No workflow yaml change (gate command unchanged).

Closes rf2-6k4cm.
