### PR TITLE
fix(api-manifest): make ui.test host-signature reconciliation kind-aware and exact (rf2-d7sso)

### DIFF
--- a/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_probe.cljc
+++ b/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_probe.cljc
@@ -44,6 +44,15 @@
   the JVM side; for CLJS-only value-defs the sidecar's curated `:kind`
   stands.
 
+  This EXISTENCE-only rule is the `reconcile` fn's — it covers the
+  `:cljs-only` ADAPTER/Xray surfaces, which bind fn-valued value-defs the
+  analyzer cannot tell from a plain `:var`. The re-frame.ui.test host-signature
+  reconciler below (`signature-problems`) DOES reconcile `:kind` (rf2-d7sso):
+  that surface is real `defn`s + `defmacro`s (no value-defs), so the analyzer
+  classifies it reliably, and the sidecar's declared kind is VALIDATED against
+  the live analyzer kind rather than trusted — closing the seam where the JVM
+  lane once ignored the sidecar kind while this lane trusted it to select checks.
+
   ## Why the adapters are `:fully-rowed` but the Xray mount surface is not
 
   spec/API.md tiers the Xray `mount-*!` family `internal-public` (the
@@ -117,51 +126,89 @@
 ;; ---------------------------------------------------------------------------
 
 (defn signature-problems
-  "Pure host-arity reconciler for the CLJS (:cljs) lane (rf2-5bcdi). Compares
-   the declared `:cljs` signature contract against the live CLJS analyzer
-   arities. Returns a sorted problems vector; empty ⇒ in sync.
+  "Pure host-signature reconciler for the CLJS (:cljs) lane (rf2-5bcdi; made
+   KIND-AWARE + EXACT — rf2-d7sso). Reconciles the sidecar signature contract
+   against the live CLJS analyzer surface. Returns a sorted problems vector;
+   empty ⇒ in sync.
 
-   `contract` — the `:vars` map `{var {:kind :fn|:macro :clj #{..} :cljs #{..}}}`.
-   `live`     — `{var (#{arity} | nil)}` from `cljs-publics/emit-ns-signatures`.
+   `contract` — the sidecar `:vars` map
+                `{var {:kind :fn|:macro :clj #{..} :cljs #{..}}}`.
+   `surface`  — `{var {:kind kw :arities (#{arity} | nil)}}` from
+                `cljs-publics/emit-ns-surface` — the live CLJS classification
+                (`:kind`) + host arities.
 
-   Only FUNCTION vars are reconciled: a re-frame.ui.test function can carry a
-   host-specific runtime arity, so the CLJS surface is where a CLJS-only arity
-   reshape must go RED (the reader-conditional `:clj`/`:cljs` difference is
-   represented intentionally, never forced equal). MACROS are host-invariant
-   (one `.cljc` definition expanded on both hosts), so their programmer-visible
-   call grammar is pinned once on the JVM lane, and the analyzer does not
-   reliably surface their arglists anyway. A FUNCTION the analyzer surfaces no
-   arity for is itself drift (`:arity-unobserved`)."
-  [contract live]
-  (->> contract
-       (keep (fn [[var {:keys [kind cljs]}]]
-               (when (= kind :fn)
-                 (let [got (get live var)]
-                   (cond
-                     (nil? got)      {:kind :arity-unobserved :var var :expected cljs}
-                     (not= cljs got) {:kind :arity-mismatch   :var var :expected cljs :got got})))))
-       (sort-by :var)
-       vec))
+   The sidecar's declared `:kind` is NOT trusted to SELECT checks (the
+   rf2-d7sso seam): it is RECONCILED against the live analyzer kind and a
+   disagreement is REJECTED (`:kind-mismatch`) — so a sidecar kind flipped
+   `:fn`→`:macro` reddens this lane instead of silently skipping the entry.
+   Arity checks are then selected by the AUTHORITATIVE live kind:
+
+     - FUNCTIONS are arity-checked against `:cljs` (a re-frame.ui.test function
+       can carry a host-specific runtime arity, so a CLJS-only reshape goes RED
+       here; the reader-conditional `:clj`/`:cljs` difference is represented
+       intentionally, never forced equal). A function the analyzer surfaces no
+       arity for is itself drift (`:arity-unobserved`).
+     - MACROS are host-invariant (one `.cljc` definition expanded on both
+       hosts) — their call grammar is pinned once on the JVM lane and the
+       analyzer does not reliably surface their arglists, so they are not
+       arity-checked here.
+
+   Names are reconciled exactly: a contract var the live surface does not
+   expose → `:var-absent`; a live blessed var with no contract entry →
+   `:uncontracted-var` (so a classified CLJS-only function with no host-arity
+   contract, or an omitted entry, goes RED)."
+  [contract surface]
+  (->>
+   (concat
+    (mapcat
+     (fn [[var {:keys [kind cljs]}]]
+       (if-let [{live-kind :kind live-arities :arities} (get surface var)]
+         (concat
+          (when (not= kind live-kind)
+            [{:kind :kind-mismatch :var var :declared kind :live-kind live-kind}])
+          (when (= live-kind :fn)
+            (cond
+              (nil? live-arities)      [{:kind :arity-unobserved :var var :expected cljs}]
+              (not= cljs live-arities) [{:kind :arity-mismatch :var var :expected cljs :got live-arities}])))
+         [{:kind :var-absent :var var :expected cljs}]))
+     contract)
+    (keep (fn [[var _]]
+            (when-not (contains? contract var)
+              {:kind :uncontracted-var :var var}))
+          surface))
+   (sort-by :var)
+   vec))
 
 (defn signature-report
   "Render a `signature-problems` seq to an actionable multi-line string — the
-   message the probe's failing arity assertion prints."
+   message the probe's failing signature assertion prints."
   [problems]
   (str/join
    "\n"
    (concat
-    ["CLJS ui.test host-arity DRIFT (rf2-5bcdi): a re-frame.ui.test FUNCTION's"
-     "live CLJS arity no longer matches the :cljs signature contract in"
-     "spec/api-manifest-metadata.edn (:ui-test-signatures). Reshape the source"
-     "or reconcile the contract until this is green. Problems:"]
-    (map (fn [{:keys [kind var expected got]}]
+    ["CLJS ui.test host-signature DRIFT (rf2-5bcdi/rf2-d7sso): a re-frame.ui.test"
+     "public var's live CLJS classification/arity no longer matches the signature"
+     "contract in spec/api-manifest-metadata.edn (:ui-test-signatures). The"
+     "sidecar's declared :kind is reconciled against the live analyzer kind, so a"
+     "stale/flipped kind is rejected here. Reshape the source or reconcile the"
+     "contract until this is green. Problems:"]
+    (map (fn [{:keys [kind var expected got declared live-kind]}]
            (case kind
+             :kind-mismatch
+             (str "    " var ": sidecar declares " (pr-str declared)
+                  " ; live CLJS analyzer is " (pr-str live-kind))
              :arity-mismatch
              (str "    " var ": live CLJS " (pr-str got)
                   " ; contract :cljs " (pr-str expected))
              :arity-unobserved
              (str "    " var ": the analyzer surfaced NO arity (expected :cljs "
-                  (pr-str expected) ") — a function must be observable")))
+                  (pr-str expected) ") — a function must be observable")
+             :var-absent
+             (str "    " var ": the contract names it but the live CLJS surface "
+                  "does not expose it")
+             :uncontracted-var
+             (str "    " var ": live CLJS public var with no :ui-test-signatures "
+                  "entry")))
          problems))))
 
 (defn report

--- a/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj
+++ b/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj
@@ -77,22 +77,25 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- strip-implicit-macro-params
-  "Drop a macro's compiler-supplied `&form` / `&env` positional params so only
-   PROGRAMMER-VISIBLE params are counted (bead AC: compiler-internal
-   parameters must not leak). Mirrors the JVM lane's
-   `re-frame.api-manifest.api-md-check/strip-implicit-macro-params`."
+  "Drop a MACRO's compiler-supplied `&form` / `&env` positional params so only
+   PROGRAMMER-VISIBLE params are counted (bead AC: compiler-internal parameters
+   must not leak). Applied ONLY to macros (rf2-d7sso) — for an ordinary function
+   `&form`/`&env` are legal programmer parameter names and are counted. Mirrors
+   the JVM lane's `re-frame.api-manifest.api-md-check/strip-implicit-macro-params`."
   [arglist]
   (remove (fn [p] (and (symbol? p) (contains? #{"&form" "&env"} (name p))))
           arglist))
 
 (defn arglist->arity
-  "Normalize one arglist to a PROGRAMMER-VISIBLE arity vector: `[n]` for a
-   fixed n-arg call, `[n :&]` for a variadic call with n fixed args. A nested
+  "Normalize one arglist to a PROGRAMMER-VISIBLE arity vector, KIND-AWARE
+   (rf2-d7sso): `[n]` for a fixed n-arg call, `[n :&]` for a variadic call with
+   n fixed args. For a `:macro` the compiler-supplied `&form` / `&env` slots are
+   stripped; for a `:fn` they are ordinary parameters and COUNTED. A nested
    destructuring vector counts as ONE positional. Mirrors the JVM lane's
-   `re-frame.api-manifest.api-md-check/arglist->arity` exactly so the two
-   hosts normalize identically."
-  [arglist]
-  (let [al        (strip-implicit-macro-params arglist)
+   `re-frame.api-manifest.api-md-check/arglist->arity` exactly so the two hosts
+   normalize identically."
+  [kind arglist]
+  (let [al        (if (= kind :macro) (strip-implicit-macro-params arglist) arglist)
         fixed     (count (take-while #(not= '& %) al))
         variadic? (boolean (some #(= '& %) al))]
     (if variadic? [fixed :&] [fixed])))
@@ -108,24 +111,36 @@
 
 (defn info->arities
   "The set of programmer-visible arity vectors for a CLJS analyzer var-info
-   map, or nil when the analyzer surfaces no `:arglists` for it (a plain
-   value `:var`, or a macro whose arglists the analyzer erases — the probe
-   treats an unobserved FUNCTION as drift, but never a macro, whose grammar
-   is host-invariant and pinned on the JVM lane)."
+   map, normalized for its live `kind-of` (rf2-d7sso — a function's `&form`/
+   `&env` params are counted, a macro's are stripped), or nil when the analyzer
+   surfaces no `:arglists` for it (a plain value `:var`, or a macro whose
+   arglists the analyzer erases — the probe treats an unobserved FUNCTION as
+   drift, but never a macro, whose grammar is host-invariant and pinned on the
+   JVM lane)."
   [info]
   (when-let [arglists (or (unwrap-arglists (:arglists info))
                           (unwrap-arglists (:arglists (:meta info))))]
-    (into #{} (map arglist->arity) arglists)))
+    (let [kind (kind-of info)]
+      (into #{} (map #(arglist->arity kind %)) arglists))))
 
-(defn ns-public-signatures
-  "Return `{var-name-string (#{arity-vector ...} | nil)}` for every public
-   var of `ns-sym` in the analyzer compilation env `state`, minus the
-   `^:no-doc` carve-outs. The driver behind `emit-ns-signatures`; exposed as
-   a plain fn so it can be unit-tested off a synthetic compiler-state atom."
+(defn ns-public-surface
+  "Return `{var-name-string {:kind kw :arities (#{arity-vector ...} | nil)}}`
+   for every public var of `ns-sym` in the analyzer compilation env `state`,
+   minus the `^:no-doc` carve-outs — the live CLJS classification (`:kind`) and
+   host arities in ONE map (rf2-d7sso). The driver behind `emit-ns-surface`;
+   exposed as a plain fn so it can be unit-tested off a synthetic compiler-state
+   atom.
+
+   `:kind` is the AUTHORITATIVE live classification the sidecar's declared kind
+   is reconciled against on the CLJS lane. For the ui.test surface the analyzer
+   classifies its real `defn`s (`:fn`) and `defmacro`s (`:macro`) reliably —
+   there are no fn-valued value-defs here (the analyzer limitation the
+   `:cljs-only` kind carve-out documents does not reach this surface)."
   [state ns-sym]
   (->> (ana-api/ns-publics state ns-sym)
        (remove (fn [[_ info]] (:no-doc (:meta info))))
-       (map (fn [[sym info]] [(name sym) (info->arities info)]))
+       (map (fn [[sym info]] [(name sym) {:kind    (kind-of info)
+                                          :arities (info->arities info)}]))
        (into {})))
 
 ;; ---------------------------------------------------------------------------
@@ -206,22 +221,24 @@
         pairs (ns-public-pairs env/*compiler* sym)]
     `[~@(map (fn [[v k]] [v k]) pairs)]))
 
-(defmacro emit-ns-signatures
-  "Expand to a literal `{var-name #{arity-vector ...}}` map for the public
-   vars of `ns-sym` (a quoted symbol), read from the CLJS analyzer's
-   compilation environment at macro-expansion time (rf2-5bcdi). A var the
-   analyzer surfaces no arglists for maps to `nil`. The target namespace must
-   already be analysed — `:require` it from the calling namespace first.
+(defmacro emit-ns-surface
+  "Expand to a literal `{var-name {:kind kw :arities #{arity-vector ...}|nil}}`
+   map for the public vars of `ns-sym` (a quoted symbol), read from the CLJS
+   analyzer's compilation environment at macro-expansion time (rf2-5bcdi;
+   kind-aware rf2-d7sso). A var the analyzer surfaces no arglists for maps to
+   `:arities nil`. The target namespace must already be analysed — `:require`
+   it from the calling namespace first.
 
-   The emitted map is self-evaluating data (strings → sets of vectors of
-   numbers / the `:&` keyword), so — like `emit-cljs-only-rows` — the value
-   is returned directly. It is the live CLJS arity surface the probe
-   reconciles against the `:cljs` signature contract."
+   The emitted map is self-evaluating data (strings → `{:kind <keyword>
+   :arities <set of vectors of numbers / the :& keyword>}`), so — like
+   `emit-cljs-only-rows` — the value is returned directly. It is the live CLJS
+   classification + arity surface the probe reconciles the sidecar signature
+   contract against."
   [ns-sym]
   (let [sym (if (and (seq? ns-sym) (= 'quote (first ns-sym)))
               (second ns-sym)
               ns-sym)]
-    (ns-public-signatures env/*compiler* sym)))
+    (ns-public-surface env/*compiler* sym)))
 
 (defmacro emit-ui-test-signature-contract
   "Expand to the sidecar's `:ui-test-signatures` authority map

--- a/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
+++ b/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
@@ -64,7 +64,7 @@
   mechanism for it (see rf2-2mtte PR notes)."
   (:require-macros [re-frame.api-manifest.cljs-publics
                     :refer [emit-ns-publics emit-cljs-only-rows
-                            emit-classification-rows emit-ns-signatures
+                            emit-classification-rows emit-ns-surface
                             emit-ui-test-signature-contract]])
   (:require [cljs.test :refer-macros [deftest is testing]]
             [re-frame.api-manifest.cljs-probe :as probe]
@@ -230,46 +230,55 @@
 ;; turns this RED. Macros are host-invariant (pinned once on the JVM lane).
 ;; ---------------------------------------------------------------------------
 
-(def live-ui-test-signatures
-  "`{var-name (#{arity} | nil)}` for re-frame.ui.test's live CLJS public
-   surface, enumerated off the analyzer at compile time."
-  (emit-ns-signatures re-frame.ui.test))
+(def live-ui-test-surface
+  "`{var-name {:kind kw :arities (#{arity} | nil)}}` for re-frame.ui.test's live
+   CLJS public surface, enumerated off the analyzer at compile time — the live
+   classification (kind) + host arities the sidecar signature contract is
+   reconciled against (rf2-d7sso)."
+  (emit-ns-surface re-frame.ui.test))
 
 (def ui-test-signature-contract
   "The sidecar `:ui-test-signatures` authority, embedded at compile time
    (no runtime filesystem). `:vars` is the per-var host-aware contract."
   (emit-ui-test-signature-contract))
 
-(deftest ui-test-cljs-arities-in-sync
-  (testing "the live CLJS function arities of re-frame.ui.test match the :cljs
-            signature contract (the reader-conditional flush! 0/1-arity pinned)"
+(deftest ui-test-cljs-signatures-in-sync
+  (testing "the live CLJS classification + function arities of re-frame.ui.test
+            match the signature contract (kind reconciled; flush! 0/1-arity pinned)"
     (let [problems (probe/signature-problems (:vars ui-test-signature-contract)
-                                             live-ui-test-signatures)]
+                                             live-ui-test-surface)]
       (is (empty? problems) (probe/signature-report problems)))))
 
 (deftest ui-test-signature-contract-is-non-vacuous
   (testing "the embedded contract carries the nine blessed ui.test vars and the
-            analyzer surfaced flush!'s live CLJS 0/1-arity (guards against a
+            analyzer surfaced flush!'s live CLJS :fn 0/1-arity (guards against a
             vacuous green from an unread sidecar or un-analysed namespace)"
     (is (= "re-frame.ui.test" (:namespace ui-test-signature-contract)))
     (is (= 9 (count (:vars ui-test-signature-contract))))
-    (is (= #{[0] [1]} (get live-ui-test-signatures "flush!"))
+    (is (= :fn (get-in live-ui-test-surface ["flush!" :kind]))
+        "flush! must be classified :fn by the live analyzer — the kind authority")
+    (is (= #{[0] [1]} (get-in live-ui-test-surface ["flush!" :arities]))
         "flush! must be observed 0/1-arity on CLJS — the blessed host difference")))
 
 ;; Synthetic reconciler contracts — the mutation proof, exercised directly on
-;; the pure `signature-problems` so a reshape goes RED and the in-sync state
-;; stays green regardless of the live analyzer.
+;; the pure `signature-problems` so a reshape / kind flip goes RED and the
+;; in-sync state stays green regardless of the live analyzer.
 (def ^:private synthetic-contract
   {"attrs"     {:kind :fn    :cljs #{[1]}}
    "flush!"    {:kind :fn    :cljs #{[0] [1]}}
    "render"    {:kind :macro :cljs #{[1] [2]}}
    "with-root" {:kind :macro :cljs #{[1 :&]}}})
 
+;; The live SURFACE fixture: {var {:kind :arities}}. A macro's analyzer arities
+;; may be nil (host-invariant, never arity-checked here).
 (def ^:private synthetic-live-in-sync
-  {"attrs" #{[1]} "flush!" #{[0] [1]} "render" #{[1] [2]} "with-root" #{[1 :&]}})
+  {"attrs"     {:kind :fn    :arities #{[1]}}
+   "flush!"    {:kind :fn    :arities #{[0] [1]}}
+   "render"    {:kind :macro :arities #{[1] [2]}}
+   "with-root" {:kind :macro :arities #{[1 :&]}}})
 
 (deftest cljs-arities-in-sync-produce-no-problems
-  (testing "the matching live CLJS arities reconcile clean"
+  (testing "the matching live CLJS surface reconciles clean"
     (is (empty? (probe/signature-problems synthetic-contract synthetic-live-in-sync)))))
 
 (deftest cljs-flush-arity-drop-goes-red
@@ -277,7 +286,7 @@
             against :cljs #{[0] [1]} — a CLJS-only reshape the manifest cannot see"
     (let [problems (probe/signature-problems
                     synthetic-contract
-                    (assoc synthetic-live-in-sync "flush!" #{[0]}))]
+                    (assoc-in synthetic-live-in-sync ["flush!" :arities] #{[0]}))]
       (is (= [:arity-mismatch] (map :kind problems)))
       (is (= "flush!" (:var (first problems))))
       (is (= #{[0] [1]} (:expected (first problems))))
@@ -288,7 +297,7 @@
             is drift, not a pass"
     (let [problems (probe/signature-problems
                     synthetic-contract
-                    (assoc synthetic-live-in-sync "attrs" #{[1] [2]}))]
+                    (assoc-in synthetic-live-in-sync ["attrs" :arities] #{[1] [2]}))]
       (is (= [:arity-mismatch] (map :kind problems)))
       (is (= "attrs" (:var (first problems)))))))
 
@@ -297,16 +306,48 @@
             :arity-unobserved (never a vacuous pass)"
     (let [problems (probe/signature-problems
                     synthetic-contract
-                    (assoc synthetic-live-in-sync "attrs" nil))]
+                    (assoc-in synthetic-live-in-sync ["attrs" :arities] nil))]
       (is (= [:arity-unobserved] (map :kind problems)))
+      (is (= "attrs" (:var (first problems)))))))
+
+(deftest cljs-sidecar-kind-flip-goes-red
+  (testing "THE rf2-d7sso BUG: a sidecar entry whose :kind was flipped :fn→:macro
+            is REJECTED against the live analyzer kind (:fn) — the CLJS lane no
+            longer silently SKIPS the entry on the unvalidated sidecar kind (its
+            arities still match, so ONLY the kind mismatch fires)"
+    (let [problems (probe/signature-problems
+                    (assoc-in synthetic-contract ["flush!" :kind] :macro)
+                    synthetic-live-in-sync)]
+      (is (= [:kind-mismatch] (map :kind problems)))
+      (is (= "flush!" (:var (first problems))))
+      (is (= :macro (:declared (first problems))))
+      (is (= :fn (:live-kind (first problems)))))))
+
+(deftest cljs-classified-var-without-signature-goes-red
+  (testing "a live blessed var with no :ui-test-signatures entry (an omitted
+            contract entry, or a classified CLJS-only function added without a
+            host-arity contract) is :uncontracted-var — cannot escape coverage"
+    (let [problems (probe/signature-problems
+                    (dissoc synthetic-contract "attrs")
+                    synthetic-live-in-sync)]
+      (is (= [:uncontracted-var] (map :kind problems)))
+      (is (= "attrs" (:var (first problems)))))))
+
+(deftest cljs-contract-var-not-live-goes-red
+  (testing "a contract var the live CLJS surface no longer exposes is :var-absent"
+    (let [problems (probe/signature-problems
+                    synthetic-contract
+                    (dissoc synthetic-live-in-sync "attrs"))]
+      (is (= [:var-absent] (map :kind problems)))
       (is (= "attrs" (:var (first problems)))))))
 
 (deftest cljs-macros-are-not-arity-checked
   (testing "macros (render / with-root) are host-invariant — the CLJS lane does
-            NOT flag them even when the analyzer surfaces no arity for them
-            (their grammar is pinned on the JVM lane)"
+            NOT arity-flag them even when the analyzer surfaces no arity for them
+            (their grammar is pinned on the JVM lane), as long as they are
+            present with the :macro classification"
     (is (empty? (probe/signature-problems
                  synthetic-contract
                  (-> synthetic-live-in-sync
-                     (assoc "render" nil)
-                     (dissoc "with-root")))))))
+                     (assoc-in ["render" :arities] nil)
+                     (assoc-in ["with-root" :arities] nil)))))))

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
@@ -410,7 +410,7 @@
     [{:kind :create-root-row-missing :line nil}]))
 
 ;; ---------------------------------------------------------------------------
-;; re-frame.ui.test HOST-ARITY guard (rf2-5bcdi).
+;; re-frame.ui.test HOST-SIGNATURE guard (rf2-5bcdi; kind-aware + exact rf2-d7sso).
 ;;
 ;; The generated manifest reduces every public var to [namespace var tier
 ;; kind]; it carries NO arity facts (gen/kind-of collapses a var to
@@ -421,12 +421,17 @@
 ;; is HOST-SPECIFIC: `flush!` is 0-arity on the JVM but 0/1-arity on CLJS;
 ;; `render` / `with-root` are macros with blessed call grammars.
 ;;
-;; This is the JVM (:clj) half. It reads the live Var :arglists of the nine
-;; blessed vars via `ns-publics` (re-frame.ui.test's Tier-1 surface loads
+;; This is the JVM (:clj) half. It reads the live Var :kind + :arglists of the
+;; nine blessed vars via `ns-publics` (re-frame.ui.test's Tier-1 surface loads
 ;; headless on the JVM, so it is on this generator classpath) and reconciles
 ;; them against the machine-readable signature authority in the sidecar
-;; (`:ui-test-signatures`). The CLJS (:cljs) half is enforced by the
-;; api-manifest CLJS probe (probe/, run by `npm run test:cljs`).
+;; (`:ui-test-signatures`). The sidecar DUPLICATES each var's `:kind`; rather
+;; than trust it (the JVM lane once IGNORED it while the CLJS lane TRUSTED it —
+;; the rf2-d7sso seam), the declared kind is RECONCILED against the live Var
+;; kind and a disagreement is REJECTED. The CLJS (:cljs) half is enforced by the
+;; api-manifest CLJS probe (probe/, run by `npm run test:cljs`), which
+;; reconciles the same sidecar kind against the live ANALYZER kind — so a
+;; stale/flipped sidecar kind reddens BOTH hosts, never one silently.
 ;; ---------------------------------------------------------------------------
 
 (def ui-test-namespace
@@ -435,46 +440,69 @@
   "re-frame.ui.test")
 
 (defn- strip-implicit-macro-params
-  "Drop a macro's compiler-supplied `&form` / `&env` positional params from an
+  "Drop a MACRO's compiler-supplied `&form` / `&env` positional params from an
    arglist so only PROGRAMMER-VISIBLE params are counted (bead AC: compiler-
    internal parameters must not leak into the contract). `defmacro` already
    keeps them out of `:arglists` metadata on the JVM; the strip is defensive
-   and keeps the normalization identical to the CLJS analyzer lane."
+   and keeps the normalization identical to the CLJS analyzer lane.
+
+   Applied ONLY to macros (rf2-d7sso): for an ORDINARY FUNCTION `&form` /
+   `&env` are legal programmer parameter names and must be COUNTED — the old
+   unconditional strip collapsed `[x]`, `[&env x]` and `[&form &env x]` to the
+   same visible arity, hiding a real function arity change."
   [arglist]
   (remove (fn [p] (and (symbol? p) (contains? #{"&form" "&env"} (name p))))
           arglist))
 
 (defn arglist->arity
-  "Normalize one arglist to a PROGRAMMER-VISIBLE arity vector: `[n]` for a
-   fixed n-arg call, `[n :&]` for a variadic call with n fixed args. A nested
-   destructuring vector counts as ONE positional (e.g. with-root's
-   `[[binding root-form] & body]` → `[1 :&]`). Mirrors the CLJS lane's
-   `re-frame.api-manifest.cljs-publics/arglist->arity`."
-  [arglist]
-  (let [al        (strip-implicit-macro-params arglist)
+  "Normalize one arglist to a PROGRAMMER-VISIBLE arity vector, KIND-AWARE
+   (rf2-d7sso): `[n]` for a fixed n-arg call, `[n :&]` for a variadic call with
+   n fixed args. For a `:macro` the compiler-supplied `&form` / `&env` slots are
+   stripped (they never leak into the public grammar); for a `:fn` they are
+   ordinary parameters and COUNTED. A nested destructuring vector counts as ONE
+   positional (e.g. with-root's `[[binding root-form] & body]` → `[1 :&]`).
+   Mirrors the CLJS lane's `re-frame.api-manifest.cljs-publics/arglist->arity`."
+  [kind arglist]
+  (let [al        (if (= kind :macro) (strip-implicit-macro-params arglist) arglist)
         fixed     (count (take-while #(not= '& %) al))
         variadic? (boolean (some #(= '& %) al))]
     (if variadic? [fixed :&] [fixed])))
 
 (defn arglists->arities
-  "The set of programmer-visible arity vectors for a var's `:arglists`
-   (nil / empty → `#{}`)."
-  [arglists]
-  (into #{} (map arglist->arity) arglists))
+  "The set of programmer-visible arity vectors for a var's `:arglists`,
+   normalized for `kind` (rf2-d7sso — a function's `&form`/`&env` params are
+   counted, a macro's are stripped). nil / empty `:arglists` → `#{}`."
+  [kind arglists]
+  (into #{} (map #(arglist->arity kind %)) arglists))
 
-(defn live-ui-test-arities
-  "Live JVM `{var-name-string -> #{arity-vector ...}}` for the public,
-   non-^:no-doc vars of `re-frame.ui.test` (mirrors gen/public-vars-of's
-   `^:no-doc` carve-out, so the nine blessed vars are exactly the set). Arity
-   is derived from each Var's `:arglists`; a macro's `:arglists` already
-   excludes `&form`/`&env`."
+(defn- live-kind-of
+  "The manifest `:kind` (`:macro` / `:fn` / `:var`) of a live JVM Var — the
+   AUTHORITATIVE live classification (mirrors gen/kind-of) the sidecar's
+   declared `:kind` is reconciled against (rf2-d7sso)."
+  [v]
+  (let [m (meta v)]
+    (cond
+      (:macro m)                  :macro
+      (or (:arglists m) (fn? @v)) :fn
+      :else                       :var)))
+
+(defn live-ui-test-surface
+  "Live JVM `{var-name-string {:kind kw :arities #{arity-vector ...}}}` for the
+   public, non-^:no-doc vars of `re-frame.ui.test` (mirrors gen/public-vars-of's
+   `^:no-doc` carve-out, so the nine blessed vars are exactly the set). `:kind`
+   is the live-Var classification — the authority the sidecar's declared kind is
+   reconciled against; `:arities` is derived KIND-AWARELY from each Var's
+   `:arglists` (a function's `&form`/`&env` params are counted; a macro's are
+   stripped — rf2-d7sso)."
   []
   (let [ns-sym (symbol ui-test-namespace)]
     (require ns-sym)
     (into {}
           (for [[sym v] (ns-publics ns-sym)
-                :when (not (:no-doc (meta v)))]
-            [(name sym) (arglists->arities (:arglists (meta v)))]))))
+                :when (not (:no-doc (meta v)))
+                :let  [kind (live-kind-of v)]]
+            [(name sym) {:kind    kind
+                         :arities (arglists->arities kind (:arglists (meta v)))}]))))
 
 (defn read-ui-test-signatures
   "The sidecar's `:ui-test-signatures` authority `{:namespace :vars {...}}`
@@ -484,35 +512,44 @@
   (:ui-test-signatures (gen/read-sidecar)))
 
 (defn ui-test-arity-problems
-  "Pure host-arity reconciler for the JVM (:clj) lane (rf2-5bcdi). Compares the
-   declared `:clj` signature contract against the live JVM arities of the
-   blessed ui.test vars. Returns the seq of problem maps; empty when every var
-   is present with EXACTLY its declared `:clj` arities.
+  "Pure host-signature reconciler for the JVM (:clj) lane (rf2-5bcdi; made
+   KIND-AWARE + EXACT — rf2-d7sso). Reconciles the sidecar signature contract
+   against the LIVE JVM public surface of the blessed ui.test vars — the
+   authoritative live classification. Returns the sorted problem seq; empty when
+   every var reconciles EXACTLY on name, authoritative `:kind`, and `:clj` arity.
 
-   `signatures` — the `:vars` map `{var {:kind :clj #{arities} :cljs #{..}}}`.
-   `live`       — `{var #{live-jvm-arities}}` (from `live-ui-test-arities`).
+   `signatures` — the sidecar `:vars` map
+                  `{var {:kind :fn|:macro :clj #{arities} :cljs #{..}}}`.
+   `surface`    — `{var {:kind kw :arities #{arity ...}}}` from the live JVM
+                  Vars (`live-ui-test-surface`).
 
-   Two directions, mirroring the generator's missing/stale existence guard:
-     - every CONTRACT var must resolve live with matching `:clj` arities (a
-       reshaped arity → `:arity-mismatch`; a var the contract names but that no
-       longer resolves → `:var-absent`);
-     - every LIVE blessed var must be in the contract (a new public var with no
-       arity contract → `:uncontracted-var`), so a fresh export cannot escape
-       arity coverage silently."
-  [signatures live]
+   The sidecar's declared `:kind` is NOT trusted: it is RECONCILED against the
+   live kind and a disagreement is REJECTED (`:kind-mismatch`) — so a sidecar
+   kind flipped `:fn`→`:macro` reddens THIS lane instead of being silently
+   ignored, closing the JVM half of the rf2-d7sso seam. Three directions:
+     - every CONTRACT var must resolve live with a matching kind AND matching
+       `:clj` arities (`:kind-mismatch` / `:arity-mismatch`; a contract var that
+       no longer resolves → `:var-absent`);
+     - every LIVE blessed var must be in the contract (a fresh export with no
+       signature → `:uncontracted-var`)."
+  [signatures surface]
   (sort-by
    :var
    (concat
-    (keep (fn [[var {:keys [clj]}]]
-            (if-let [got (get live var)]
-              (when (not= clj got)
-                {:kind :arity-mismatch :var var :expected clj :got got})
-              {:kind :var-absent :var var :expected clj}))
-          signatures)
-    (keep (fn [[var got]]
+    (mapcat
+     (fn [[var {:keys [kind clj]}]]
+       (if-let [{live-kind :kind live-arities :arities} (get surface var)]
+         (concat
+          (when (not= kind live-kind)
+            [{:kind :kind-mismatch :var var :declared kind :live-kind live-kind}])
+          (when (not= clj live-arities)
+            [{:kind :arity-mismatch :var var :expected clj :got live-arities}]))
+         [{:kind :var-absent :var var :expected clj}]))
+     signatures)
+    (keep (fn [[var {live-arities :arities}]]
             (when-not (contains? signatures var)
-              {:kind :uncontracted-var :var var :got got}))
-          live))))
+              {:kind :uncontracted-var :var var :got live-arities}))
+          surface))))
 
 (defn check!
   "Validate spec/API.md var-rows against the manifest. Returns true when
@@ -560,7 +597,7 @@
         ;; (:clj) arities against the sidecar signature authority.
         arity-probs (ui-test-arity-problems
                      (:vars (read-ui-test-signatures))
-                     (live-ui-test-arities))]
+                     (live-ui-test-surface))]
     (cond
       ;; Vacuity-floor violation: extraction collapsed — refuse a green.
       floor
@@ -615,13 +652,18 @@
 
       (seq arity-probs)
       (do (binding [*out* *err*]
-            (println "DRIFT: a re-frame.ui.test public var's JVM arity disagrees with the signature contract.")
-            (println "The nine blessed ui.test vars carry a HOST-AWARE arity contract in")
+            (println "DRIFT: a re-frame.ui.test public var's JVM signature disagrees with the contract.")
+            (println "The nine blessed ui.test vars carry a HOST-AWARE signature contract in")
             (println "spec/api-manifest-metadata.edn (:ui-test-signatures); the manifest carries")
-            (println "name + :kind but no arity, so a fn/macro can reshape a supported arity and")
-            (println "stay green. Reconcile the source or the contract. Problems:")
-            (doseq [{:keys [kind var expected got]} arity-probs]
+            (println "name + :kind but no arity, so a fn/macro can reshape a supported arity — and")
+            (println "the sidecar's declared :kind is reconciled against the LIVE Var kind, so a")
+            (println "stale/flipped kind is rejected here (rf2-d7sso). Reconcile the source or the")
+            (println "contract. Problems:")
+            (doseq [{:keys [kind var expected got declared live-kind]} arity-probs]
               (case kind
+                :kind-mismatch
+                (println (format "  %-12s KIND:   sidecar declares %s; live JVM Var is %s"
+                                 var (pr-str declared) (pr-str live-kind)))
                 :arity-mismatch
                 (println (format "  %-12s ARITY:  live JVM %s; contract :clj %s"
                                  var (pr-str got) (pr-str expected)))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
@@ -377,16 +377,19 @@
         "live drift: create-root row lost :root-id-required or :disambiguator-invalid")))
 
 ;; ---------------------------------------------------------------------------
-;; re-frame.ui.test HOST-ARITY guard — JVM (:clj) lane (rf2-5bcdi).
+;; re-frame.ui.test HOST-SIGNATURE guard — JVM (:clj) lane (rf2-5bcdi;
+;; kind-aware + exact rf2-d7sso).
 ;;
 ;; The generated manifest reduces every var to [namespace var tier kind]; it
 ;; carries NO arity. So a re-frame.ui.test fn/macro can keep its name and :kind
 ;; while losing / adding / reshaping a supported arity, and every ordinary
 ;; manifest / projection / gen --check gate stays green. `ui-test-arity-problems`
-;; reconciles the live JVM :arglists against the sidecar :ui-test-signatures
-;; authority; these fixtures prove a reshaped / removed / uncontracted arity
-;; goes RED and the in-sync state stays green, and that the normalization
-;; strips a macro's compiler-internal &form/&env (bead AC).
+;; reconciles the live JVM surface (kind + :arglists) against the sidecar
+;; :ui-test-signatures authority; these fixtures prove a reshaped / removed /
+;; uncontracted arity — AND a sidecar :kind flipped :fn→:macro (the rf2-d7sso
+;; seam the JVM lane once IGNORED) — go RED while the in-sync state stays green,
+;; and that the normalization strips a MACRO's compiler-internal &form/&env but
+;; COUNTS an ordinary function's &form/&env params (bead AC).
 ;; ---------------------------------------------------------------------------
 
 ;; The :clj projection of the nine blessed vars' signature contract (mirrors
@@ -402,32 +405,45 @@
    "render"    {:kind :macro :clj #{[1] [2]}}
    "with-root" {:kind :macro :clj #{[1 :&]}}})
 
-;; The matching live-JVM arity map for an in-sync tree.
+;; The matching live-JVM SURFACE for an in-sync tree: {var {:kind :arities}}.
 (def ^:private ui-test-live-in-sync
-  {"attrs"     #{[1]}
-   "text"      #{[1]}
-   "find"      #{[2]}
-   "find-all"  #{[2]}
-   "query"     #{[2]}
-   "dispatch!" #{[2]}
-   "flush!"    #{[0]}
-   "render"    #{[1] [2]}
-   "with-root" #{[1 :&]}})
+  {"attrs"     {:kind :fn    :arities #{[1]}}
+   "text"      {:kind :fn    :arities #{[1]}}
+   "find"      {:kind :fn    :arities #{[2]}}
+   "find-all"  {:kind :fn    :arities #{[2]}}
+   "query"     {:kind :fn    :arities #{[2]}}
+   "dispatch!" {:kind :fn    :arities #{[2]}}
+   "flush!"    {:kind :fn    :arities #{[0]}}
+   "render"    {:kind :macro :arities #{[1] [2]}}
+   "with-root" {:kind :macro :arities #{[1 :&]}}})
 
 (deftest arglist->arity-normalizes-fixed-variadic-and-strips-implicit
-  (testing "a plain arglist yields [n]"
-    (is (= [0] (c/arglist->arity '[])))
-    (is (= [1] (c/arglist->arity '[node])))
-    (is (= [2] (c/arglist->arity '[tree selector]))))
+  (testing "a plain arglist yields [n] (kind-agnostic when no &form/&env present)"
+    (is (= [0] (c/arglist->arity :fn '[])))
+    (is (= [1] (c/arglist->arity :fn '[node])))
+    (is (= [2] (c/arglist->arity :macro '[tree selector]))))
   (testing "a variadic arglist yields [n :&]; a nested destructuring vector is
             ONE positional (with-root's [[binding root-form] & body])"
-    (is (= [1 :&] (c/arglist->arity '[[binding root-form :as binding-form] & body])))
-    (is (= [2 :&] (c/arglist->arity '[a b & more]))))
-  (testing "compiler-internal macro params &form/&env do not leak into the
+    (is (= [1 :&] (c/arglist->arity :macro '[[binding root-form :as binding-form] & body])))
+    (is (= [2 :&] (c/arglist->arity :fn '[a b & more]))))
+  (testing "a MACRO's compiler-internal &form/&env do not leak into the
             programmer-visible arity (bead AC)"
-    (is (= [1] (c/arglist->arity '[&form &env root-or-view])))
-    (is (= [2] (c/arglist->arity '[&form &env root-or-view opts])))
-    (is (= [1 :&] (c/arglist->arity '[&form &env [binding root-form] & body])))))
+    (is (= [1] (c/arglist->arity :macro '[&form &env root-or-view])))
+    (is (= [2] (c/arglist->arity :macro '[&form &env root-or-view opts])))
+    (is (= [1 :&] (c/arglist->arity :macro '[&form &env [binding root-form] & body]))))
+  (testing "an ORDINARY FUNCTION's &form/&env are legal programmer parameters and
+            are COUNTED, never stripped (rf2-d7sso) — [x], [&env x] and
+            [&form &env x] are three DISTINCT function arities"
+    (is (= [1] (c/arglist->arity :fn '[x])))
+    (is (= [2] (c/arglist->arity :fn '[&env x])))
+    (is (= [3] (c/arglist->arity :fn '[&form &env x])))
+    (is (= [2 :&] (c/arglist->arity :fn '[&env x & more])))))
+
+(deftest arglists->arities-is-kind-aware
+  (testing "arglists->arities threads the kind: a function counts &env/&form,
+            a macro strips them (rf2-d7sso)"
+    (is (= #{[2]} (c/arglists->arities :fn '([&env x]))))
+    (is (= #{[1]} (c/arglists->arities :macro '([&form &env x]))))))
 
 (deftest ui-test-arities-in-sync-produce-no-problems
   (testing "the committed :clj contract reconciles clean against the matching
@@ -440,7 +456,7 @@
             (a :fn) are unchanged"
     (let [problems (c/ui-test-arity-problems
                     ui-test-clj-contract
-                    (assoc ui-test-live-in-sync "flush!" #{[1]}))]
+                    (assoc-in ui-test-live-in-sync ["flush!" :arities] #{[1]}))]
       (is (= 1 (count problems)))
       (is (= :arity-mismatch (:kind (first problems))))
       (is (= "flush!" (:var (first problems))))
@@ -452,7 +468,7 @@
             :clj #{[1] [2]} even though the manifest :kind stays :macro"
     (let [problems (c/ui-test-arity-problems
                     ui-test-clj-contract
-                    (assoc ui-test-live-in-sync "render" #{[1]}))]
+                    (assoc-in ui-test-live-in-sync ["render" :arities] #{[1]}))]
       (is (= [:arity-mismatch] (map :kind problems)))
       (is (= "render" (:var (first problems))))
       (is (= #{[1] [2]} (:expected (first problems)))))))
@@ -462,7 +478,7 @@
             the '& body' grammar drift the tier/kind reconcile cannot see"
     (let [problems (c/ui-test-arity-problems
                     ui-test-clj-contract
-                    (assoc ui-test-live-in-sync "with-root" #{[1]}))]
+                    (assoc-in ui-test-live-in-sync ["with-root" :arities] #{[1]}))]
       (is (= [:arity-mismatch] (map :kind problems)))
       (is (= "with-root" (:var (first problems))))
       (is (= #{[1 :&]} (:expected (first problems))))
@@ -473,9 +489,22 @@
             is drift, not a pass"
     (let [problems (c/ui-test-arity-problems
                     ui-test-clj-contract
-                    (assoc ui-test-live-in-sync "query" #{[2] [3]}))]
+                    (assoc-in ui-test-live-in-sync ["query" :arities] #{[2] [3]}))]
       (is (= [:arity-mismatch] (map :kind problems)))
       (is (= "query" (:var (first problems)))))))
+
+(deftest jvm-sidecar-kind-flip-goes-red
+  (testing "THE rf2-d7sso BUG: a sidecar entry whose :kind was flipped :fn→:macro
+            is REJECTED against the live JVM Var kind (:fn) — the JVM lane no
+            longer IGNORES the sidecar :kind (its arities still match, so ONLY the
+            kind mismatch fires)"
+    (let [problems (c/ui-test-arity-problems
+                    (assoc-in ui-test-clj-contract ["flush!" :kind] :macro)
+                    ui-test-live-in-sync)]
+      (is (= [:kind-mismatch] (map :kind problems)))
+      (is (= "flush!" (:var (first problems))))
+      (is (= :macro (:declared (first problems))))
+      (is (= :fn (:live-kind (first problems)))))))
 
 (deftest removed-var-flagged-absent
   (testing "a contract var whose live var no longer resolves is :var-absent
@@ -491,26 +520,30 @@
             — a fresh export cannot escape arity coverage silently"
     (let [problems (c/ui-test-arity-problems
                     ui-test-clj-contract
-                    (assoc ui-test-live-in-sync "brand-new!" #{[0]}))]
+                    (assoc ui-test-live-in-sync "brand-new!" {:kind :fn :arities #{[0]}}))]
       (is (= [:uncontracted-var] (map :kind problems)))
       (is (= "brand-new!" (:var (first problems)))))))
 
-(deftest live-ui-test-jvm-arities-match-contract
-  (testing "the committed :ui-test-signatures :clj contract reconciles clean
-            against the LIVE re-frame.ui.test JVM :arglists (no live drift), and
-            the enumeration actually covers the nine blessed vars"
+(deftest live-ui-test-jvm-signature-matches-contract
+  (testing "the committed :ui-test-signatures contract reconciles clean against
+            the LIVE re-frame.ui.test JVM surface (kind + :clj arities; no live
+            drift), and the enumeration actually covers the nine blessed vars"
     (let [contract (:vars (c/read-ui-test-signatures))
-          live     (c/live-ui-test-arities)]
+          surface  (c/live-ui-test-surface)]
       (is (= 9 (count contract))
           "the signature authority must carry all nine blessed vars")
-      (is (= (set (keys contract)) (set (keys live)))
+      (is (= (set (keys contract)) (set (keys surface)))
           "live blessed vars and the contract must cover exactly the same names")
-      (is (empty? (c/ui-test-arity-problems contract live))
-          "live drift: a ui.test var's JVM arity disagrees with :ui-test-signatures")
+      (is (empty? (c/ui-test-arity-problems contract surface))
+          "live drift: a ui.test var's JVM signature disagrees with :ui-test-signatures")
       ;; The host-specific facts the bead names, pinned against LIVE metadata.
-      (is (= #{[0]} (get live "flush!"))
+      (is (= :fn (get-in surface ["flush!" :kind]))
+          "flush! is classified :fn by the live JVM Var — the kind authority")
+      (is (= #{[0]} (get-in surface ["flush!" :arities]))
           "flush! is 0-arity on the JVM")
-      (is (= #{[1 :&]} (get live "with-root"))
+      (is (= :macro (get-in surface ["with-root" :kind])))
+      (is (= #{[1 :&]} (get-in surface ["with-root" :arities]))
           "with-root is a variadic macro ([binding] & body)")
-      (is (= #{[1] [2]} (get live "render"))
+      (is (= :macro (get-in surface ["render" :kind])))
+      (is (= #{[1] [2]} (get-in surface ["render" :arities]))
           "render is a 1/2-arity macro"))))


### PR DESCRIPTION
## Problem

PR #6108 added a host-aware arity SIDECAR (`:ui-test-signatures`) for the nine blessed `re-frame.ui.test` vars, but the sidecar's DUPLICATED `:kind` was not reconciled as an exact contract. The two host lanes disagreed on the authority:

- **JVM lane** (`api_md_check.clj` `ui-test-arity-problems`): destructured only `:clj`, **IGNORING** the sidecar's `:kind`.
- **CLJS lane** (`cljs_probe.cljc` `signature-problems`): `(when (= kind :fn) ...)` — **TRUSTED** the sidecar's `:kind` to select whether to arity-check.

So flipping a var's sidecar `:kind` from `:fn` to `:macro` left the JVM lane green (still arity-checks) and made the CLJS lane silently **skip** the entry — a wrong/stale sidecar kind went uncaught, and a later CLJS-only arity reshape could escape.

Secondary: `arglist->arity` stripped `&form`/`&env` from **every** arglist, so `[x]`, `[&env x]` and `[&form &env x]` all normalized alike — a real function arity change using those legal parameter names stayed green.

### Reproduced drift (before)
On the unmodified tree, the OLD JVM reconciler returns `()` (no problems) for a flipped `flush!` kind:
```
OLD JVM reconciler on a WRONG :kind (flush! flipped :fn -> :macro):
  problems = ()   ; the JVM lane IGNORES the sidecar :kind
```
The OLD CLJS lane's `(when (= kind :fn) ...)` skips the `:macro`-flipped entry entirely.

## Fix (both-validate, symmetric across hosts)

Both reconcilers treat the **live public classification** as the authority for `:kind` and reconcile the sidecar's declared kind against it exactly, **REJECTING** a disagreement rather than trusting/ignoring it. The sidecar format is unchanged (kept `:kind`, now validated).

- **JVM** — `live-ui-test-surface` reads each Var's live `:kind` (mirrors `gen/kind-of`) + `:arglists`; `ui-test-arity-problems` validates the sidecar kind against the live Var kind → `:kind-mismatch` when they disagree.
- **CLJS** — `emit-ns-surface` reads the live analyzer `:kind` + arities; `signature-problems` validates the sidecar kind against it and **selects the arity check by the authoritative live kind**, never the unvalidated sidecar kind. Names are reconciled both directions (`:var-absent` / `:uncontracted-var`), so an omitted entry or a classified function with no host-arity contract goes red.
- **Kind-aware normalization** — `&form`/`&env` are stripped only for `:macro`; for a `:fn` they are counted, so `[x]`, `[&env x]`, `[&form &env x]` are three distinct function arities.

For the ui.test surface the analyzer classifies its real `defn`s (`:fn`) and `defmacro`s (`:macro`) reliably (no fn-valued value-defs — the analyzer limitation the `:cljs-only` kind carve-out documents does not reach this surface), so validating the sidecar kind against the live analyzer kind is sound.

Surface: `implementation/scripts/api-manifest/**` only. The `:ui-test-signatures` sidecar shape and the `re-frame.ui.test` runtime are **untouched**.

### After
- Flipped `flush!` kind now → `{:kind :kind-mismatch, :var "flush!", :declared :macro, :live-kind :fn}` on the JVM; the correct sidecar still returns `()`.
- The CLJS lane rejects the same flip (`cljs-sidecar-kind-flip-goes-red`).
- A function arglist with `&env`/`&form` params now counts them (`arglist->arity-normalizes-fixed-variadic-and-strips-implicit`).

## Quality gates

All run in the worktree, foreground:

- `clojure -M:test` (api-manifest JVM suite) — **85 tests, 189 assertions, 0 failures, 0 errors** (was 83/176; +2 tests: JVM kind-flip proof + kind-aware `arglists->arities`).
- `clojure -M -m re-frame.api-manifest.gen --check` — **OK: spec/api-manifest.edn in sync (514 public vars). EXIT=0**
- `clojure -M -m re-frame.api-manifest.api-md-check` — **OK: spec/API.md projection in sync (217 var-rows). EXIT=0**
- `npm run test:cljs` (exercises the CLJS reconcile path / probe) — **9889 tests, 48668 assertions, 0 failures, 0 errors**.

Red-before / green-after: a sidecar entry with a wrong `:kind` currently passes one host / is ignored by the other → after, both hosts reject the mismatch; the correct sidecar still passes. New self-tests: `jvm-sidecar-kind-flip-goes-red`, `cljs-sidecar-kind-flip-goes-red`, plus function `&env`/`&form` counting.
