### PR TITLE
fix(xray): make unchanged-sub row selectors injective for concrete queries (rf2-bk2c6)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -689,7 +689,17 @@ the registration id) — so `:subs-skipped` stays cleanly distinct from
 `:subs-ran`, and Xray never claims no concrete instance was skipped when one
 was. Rows display + key by the full query vector (documented fallback to the
 registered id only when the skip evidence genuinely lacks a query-v);
-source-coordinate lookup keeps the registered id. It is NOT reconstructed by
+source-coordinate lookup keeps the registered id. Each row's `data-testid`
+(`rf-xray-reactive-unchanged-row-<selector>`) is minted through an INJECTIVE
+concrete-query selector (rf2-bk2c6) — the readable `id-slug` stem plus a
+stable content-hash of the full identity. `id-slug` alone is LOSSY: it
+flattens every non-alnum char to `_`, so distinct valid queries
+(`[:item/derived :a-b]` and `[:item/derived :a/b]` both slug to
+`__item_derived__a_b_`) would collapse onto one selector the DOM can no longer
+address independently. The hash suffix restores distinction while the SAME
+concrete query always hashes the same — so repeated evidence keeps ONE stable
+selector, matching the dedup contract; the React key, the visible label, and
+`data-query-v` still carry the full query vector unchanged. It is NOT reconstructed by
 filtering `:sub-runs` on `(complement :recomputed?)`, which is structurally
 always empty. The
 graph's `unchanged` (dashed, short-circuited) nodes are subs that RAN with

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
@@ -137,6 +137,22 @@
   [id]
   (when id (string/replace (str id) #"[^a-zA-Z0-9_]" "_")))
 
+(defn- concrete-query-selector
+  "Injective `data-testid` suffix for an unchanged-sub row's concrete-query
+  identity (rf2-bk2c6). `id-slug` alone is LOSSY — it flattens every
+  non-alnum/non-`_` char to `_`, so DISTINCT valid queries collapse to one
+  selector (`[:item/derived :a-b]` and `[:item/derived :a/b]` both slug to
+  `__item_derived__a_b_`), colliding two surviving rows onto one `data-testid`
+  the DOM can no longer address independently. Appending a stable content
+  hash of the FULL identity restores distinction while retaining the readable
+  slug stem: distinct concrete queries get distinct selectors, and the SAME
+  concrete query always hashes the same — so repeated evidence keeps ONE
+  stable selector (the dedup contract). Projection, React keys, the visible
+  label, and `data-query-v` are untouched; only this testid encoding changes."
+  [ident]
+  (str (id-slug ident) "-"
+       (.toString (unsigned-bit-shift-right (hash ident) 0) 36)))
+
 (defn- elapsed-label
   "Format a render's `:elapsed-ms` for the view-node sub-label. Sub-ms
   rounds to one decimal; ≥1ms rounds to whole ms. nil → nil."
@@ -545,7 +561,7 @@
                      :let [ident (unchanged-row-identity row)]]
                  ^{:key (str ident)}
                  [:div {:data-testid (str "rf-xray-reactive-unchanged-row-"
-                                          (id-slug ident))
+                                          (concrete-query-selector ident))
                         :data-query-v (str query-v)
                         :style       unchanged-row-style}
                   [:span {:style {:flex 1}} (unchanged-row-label row)]

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_disclosure_dispatch_routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_disclosure_dispatch_routing_cljs_test.cljs
@@ -142,9 +142,9 @@
                      (let [tree2 (render-panel :rf/xray)]
                        (is (some? (th/find-by-testid tree2 "rf-xray-reactive-unchanged-list"))
                            "the dim memo-hit row list now renders")
-                       (is (some? (th/find-by-testid
-                                    tree2 "rf-xray-reactive-unchanged-row-__user_name_"))
-                           "a memo-hit row renders after expand"))
+                       (is (seq (th/find-by-testid-prefix
+                                  tree2 "rf-xray-reactive-unchanged-row-__user_name_"))
+                           "a memo-hit row renders after expand (readable slug stem, injective suffix)"))
                      (done)))
             (.catch (fn [e] (is false (.-message e)) (done))))))))
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
@@ -12,6 +12,7 @@
   reactive-flow-graph-test; the projection logic by
   reactive-panel-subs-cljs-test."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -28,6 +29,12 @@
   "Concatenated text content under the node matching `testid`."
   [tree testid]
   (some-> (th/find-by-testid tree testid) th/text-content))
+
+(defn- unchanged-row-testids
+  "Every unchanged-sub row's `data-testid`, in depth-first order."
+  [tree]
+  (mapv #(:data-testid (th/attrs %))
+        (th/find-by-testid-prefix tree "rf-xray-reactive-unchanged-row-")))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
@@ -474,10 +481,12 @@
 ;; ---- unchanged-subs disclosure keys by concrete query-v (rf2-cj2yx) ----
 
 (deftest unchanged-rows-key-and-label-by-concrete-query-v
-  (testing "rf2-cj2yx — two skipped memo-hits sharing a registered sub-id but
-            DISTINCT concrete query-vs render as two individually-addressable
-            rows: distinct test-ids AND distinct labels (the full query
-            vector), not one row collapsed by sub-id."
+  (testing "rf2-cj2yx / rf2-bk2c6 — two skipped memo-hits sharing a registered
+            sub-id but DISTINCT concrete query-vs render as two
+            individually-addressable rows: distinct test-ids AND distinct
+            labels (the full query vector), not one row collapsed by sub-id.
+            The injective selector keeps the readable slug stem and only
+            appends a stable disambiguator."
     (facade/install!)
     (rf/make-frame {:id :rf/xray})
     (seed-reactive-data!
@@ -488,22 +497,63 @@
                        :reason :input-value-equal :input-paths-unchanged []}
                       {:sub-id :item/derived :query-v [:item/derived 2]
                        :reason :input-value-equal :input-paths-unchanged []}]})
-    (let [tree (view/reactive-panel)
-          row1 (th/find-by-testid tree "rf-xray-reactive-unchanged-row-__item_derived_1_")
-          row2 (th/find-by-testid tree "rf-xray-reactive-unchanged-row-__item_derived_2_")]
-      (is (some? row1) "the [:item/derived 1] parameterization has its own row")
-      (is (some? row2) "the [:item/derived 2] parameterization has its own row")
-      (is (re-find #"\[:item/derived 1\]"
-                   (text-of tree "rf-xray-reactive-unchanged-row-__item_derived_1_"))
+    (let [tree    (view/reactive-panel)
+          testids (unchanged-row-testids tree)
+          id-for  (fn [stem]
+                    (some #(when (str/starts-with?
+                                   % (str "rf-xray-reactive-unchanged-row-" stem))
+                             %)
+                          testids))
+          id1     (id-for "__item_derived_1_")
+          id2     (id-for "__item_derived_2_")]
+      (is (= 2 (count testids)) "each parameterization renders its own row")
+      (is (some? id1) "the [:item/derived 1] parameterization keeps its slug stem")
+      (is (some? id2) "the [:item/derived 2] parameterization keeps its slug stem")
+      (is (not= id1 id2) "the two rows carry DISTINCT test-ids")
+      (is (= 1 (count (th/find-all-by-testid tree id1)))
+          "row 1's test-id addresses exactly one node")
+      (is (= 1 (count (th/find-all-by-testid tree id2)))
+          "row 2's test-id addresses exactly one node")
+      (is (re-find #"\[:item/derived 1\]" (text-of tree id1))
           "row 1 labels with its full concrete query vector")
-      (is (re-find #"\[:item/derived 2\]"
-                   (text-of tree "rf-xray-reactive-unchanged-row-__item_derived_2_"))
+      (is (re-find #"\[:item/derived 2\]" (text-of tree id2))
           "row 2 labels with its full concrete query vector"))))
 
+(deftest unchanged-row-selectors-injective-for-colliding-queries
+  (testing "rf2-bk2c6 — two DISTINCT concrete queries whose `id-slug` forms
+            COLLIDE (`[:item/derived :a-b]` and `[:item/derived :a/b]` both
+            slug to `__item_derived__a_b_`) must still receive distinct,
+            individually-addressable row test-ids. Before the injective
+            selector both rows shared one `data-testid` (find-all returned 2,
+            distinct count was 1); after, each is uniquely addressable while
+            the labels stay distinct."
+    (facade/install!)
+    (rf/make-frame {:id :rf/xray})
+    (seed-reactive-data!
+      {:has-event-bundle? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :show-unchanged? true
+       :subs-skipped [{:sub-id :item/derived :query-v [:item/derived :a-b]
+                       :reason :input-value-equal :input-paths-unchanged []}
+                      {:sub-id :item/derived :query-v [:item/derived :a/b]
+                       :reason :input-value-equal :input-paths-unchanged []}]})
+    (let [tree    (view/reactive-panel)
+          testids (unchanged-row-testids tree)]
+      (is (= 2 (count testids)) "both colliding parameterizations render a row")
+      (is (= 2 (count (distinct testids)))
+          "the injective selector gives the two rows DISTINCT test-ids")
+      (doseq [id (distinct testids)]
+        (is (= 1 (count (th/find-all-by-testid tree id)))
+            "each concrete query's test-id addresses exactly one node"))
+      (let [joined (str/join " " (map #(text-of tree %) (distinct testids)))]
+        (is (re-find #":a-b" joined) "the :a-b parameterization is labelled")
+        (is (re-find #":a/b" joined) "the :a/b parameterization is labelled")))))
+
 (deftest unchanged-row-unparameterized-shows-plain-sub-id
-  (testing "rf2-cj2yx — a bare unparameterized skip (query-v `[:sub/id]`)
-            renders the plain sub-id label (the common case is unchanged),
-            not a bracketed one-element vector."
+  (testing "rf2-cj2yx / rf2-bk2c6 — a bare unparameterized skip (query-v
+            `[:sub/id]`) renders the plain sub-id label (the common case is
+            unchanged), not a bracketed one-element vector; its readable slug
+            stem survives the injective encoding."
     (facade/install!)
     (rf/make-frame {:id :rf/xray})
     (seed-reactive-data!
@@ -512,9 +562,13 @@
        :show-unchanged? true
        :subs-skipped [{:sub-id :user/name :query-v [:user/name]
                        :reason :input-value-equal :input-paths-unchanged []}]})
-    (let [tree (view/reactive-panel)
-          row  (text-of tree "rf-xray-reactive-unchanged-row-__user_name_")]
-      (is (some? row) "the unparameterized row renders")
+    (let [tree    (view/reactive-panel)
+          testids (unchanged-row-testids tree)
+          id      (first testids)
+          row     (text-of tree id)]
+      (is (= 1 (count testids)) "exactly one unparameterized row renders")
+      (is (str/starts-with? id "rf-xray-reactive-unchanged-row-__user_name_")
+          "the common-case row keeps its readable :user/name slug stem")
       (is (re-find #":user/name" row) "labels with the plain sub-id")
       (is (not (re-find #"\[:user/name\]" row))
           "no bracketed one-element vector for the bare query"))))


### PR DESCRIPTION
## What

The unchanged-sub disclosure rows (Reactive panel, spec/021 §3.4) built each
row's `data-testid` via `id-slug`, which replaces every non-alnum/non-`_`
char with `_`. Distinct valid concrete queries therefore collapsed to the
**same** selector, so two surviving rows shared one `data-testid` the DOM
could not address independently.

Counterexample (the bead's): `[:item/derived :a-b]` and `[:item/derived :a/b]`
both slug to `__item_derived__a_b_`. The React key (`(str ident)`), the visible
label, and `data-query-v` already carried the full query-v faithfully — only
the row **selector** was lossy.

## Fix

`concrete-query-selector` (`reactive_panel_view.cljs`) appends a stable
content hash of the full identity to the readable `id-slug` stem:

- Distinct concrete queries get distinct, individually-addressable selectors.
- The **same** concrete query always hashes the same → one stable selector
  (the existing dedup contract holds).
- Projection, React keys, visible labels, `data-query-v`, ordering, and the
  unparameterized common case are untouched — only this testid encoding changes.

No general EDN/DOM serialization framework; a single small helper at the one
call site. spec/021 §3.4 updated to document the injective selector encoding
(mandatory tools/xray spec-in-same-PR rule).

## Quality gates

CLJS node-test lane (the focused Xray Reactive panel lane rides this build):

- **Red-before** (call site reverted to `id-slug`): the new
  `unchanged-row-selectors-injective-for-colliding-queries` fails exactly as
  designed — `(count (distinct testids))` is `1` not `2` (collision), the
  shared testid addresses `2` nodes, and the `:a/b` row is unaddressable.
  **3 failures, 0 errors — only the new test; every other test still green**
  (projection-unchanged control: the non-colliding parameterized +
  unparameterized cases pass under both old and new code).
- **Green-after** (fix in place): `Ran 9887 tests containing 48670 assertions.
  0 failures, 0 errors.`

Also demonstrated the raw `id-slug` collision at the string level:
`"[:item/derived :a-b]"` and `"[:item/derived :a/b]"` both → `__item_derived__a_b_`.

JVM lanes untouched (change is CLJS-only: one view namespace + CLJS test files).

Closes rf2-bk2c6.
