### PR TITLE
fix(epoch): make restore one exact-incarnation transaction end to end (rf2-qfrh4)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -368,10 +368,15 @@
     :rf.error/no-such-handler          (kind :frame) — frame not registered,
                                          OR the resolved incarnation was
                                          destroyed / replaced by a same-id
-                                         successor between validation and the
-                                         write (the restore is fenced to the
-                                         EXACT incarnation it resolved — a
-                                         successor is left untouched; rf2-bjh6y)
+                                         successor at ANY point in the restore
+                                         transaction — during precondition
+                                         sampling, between validation and the
+                                         write, or across the post-write
+                                         anchoring/telemetry tail (the whole
+                                         restore is one EXACT-incarnation
+                                         transaction — a successor is left
+                                         byte-for-byte untouched; rf2-bjh6y,
+                                         rf2-qfrh4)
     :rf.epoch/restore-during-drain     — called while drain is in flight
     :rf.epoch/restore-unknown-epoch    — epoch-id not in current history
     :rf.epoch/restore-non-ok-record    — target epoch's :outcome is not :ok

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -374,20 +374,26 @@
   See `restore-epoch!` for the refusal catalogue."
   [frame-id epoch-id]
   (let [frame-result      (frame-exists-or-fail frame-id)
-        ;; The EXACT incarnation identity token (the live record's
-        ;; `:drain-lock`, per `frame-incarnation-token`) of the frame these
-        ;; checks are resolving against. Carried out on the `:ok` result so the
-        ;; write boundary can reject a stale install after a destroy + same-id
-        ;; reconstruction (rf2-bjh6y). nil when the frame is absent — the (1)
-        ;; frame-registered branch fails first in that case.
-        incarnation-token (frame/frame-incarnation-token frame-id)]
+        frame-record      (:frame-record frame-result)
+        ;; The EXACT incarnation identity token (the record's `:drain-lock`, per
+        ;; `frame-incarnation-token`) DERIVED FROM THE SAME captured record — NOT
+        ;; an independent bare-id re-resolve. A same-id successor B seated between
+        ;; the record capture above and here can therefore never supply the
+        ;; token: the ticket pairs THIS record's resolved epoch/history with THIS
+        ;; record's own incarnation, closing seam 1 (rf2-qfrh4 — the prior
+        ;; independent `frame-incarnation-token` re-resolve could pair A's
+        ;; retained epoch/history with B's live token). Carried out on the `:ok`
+        ;; result so the write boundary can reject a stale install after a
+        ;; destroy + same-id reconstruction (rf2-bjh6y). nil when the frame is
+        ;; absent — the (1) frame-registered branch fails first in that case.
+        incarnation-token (some-> frame-record :drain-lock)]
     (cond
       ;; (1) Frame registered?
       (= :fail (:outcome frame-result))
       frame-result
 
       ;; (2) In-flight drain?
-      (drain-in-flight? (:frame-record frame-result))
+      (drain-in-flight? frame-record)
       {:outcome :fail
        :op      :rf.epoch/restore-during-drain
        :tags    {:frame       frame-id
@@ -397,6 +403,22 @@
       (let [history (state/history-for frame-id)
             epoch   (find-epoch-in history epoch-id)]
         (cond
+          ;; Exact-owner gate on the history/validation snapshot (rf2-qfrh4
+          ;; seam 1). `state/history-for` above (and every validator below)
+          ;; resolves by BARE frame-id; a same-id successor seated DURING this
+          ;; precondition sampling means the captured incarnation is no longer
+          ;; live, so the history/validation snapshot may belong to — or would
+          ;; be paired against — the successor. Refuse with the SAME canonical
+          ;; no-such-handler failure the write boundary uses rather than resolve
+          ;; or validate against a stale incarnation. (Belt-and-braces with the
+          ;; record-derived token above: even if a race slips past here the
+          ;; ticket still carries A's token, so the exact write rejects B.)
+          (not (frame/event-continuation-live? frame-id incarnation-token))
+          {:outcome :fail
+           :op      :rf.error/no-such-handler
+           :tags    {:kind  :frame
+                     :frame frame-id}}
+
           ;; (3) Epoch present in current history?
           (nil? epoch)
           {:outcome :fail
@@ -617,15 +639,30 @@
   (`now-ms`). A durable frame-state field MUST come from a causal input, never
   an ambient world read at install (EP-0010 §Restore/Replay). The 2-arity
   passes a nil causal time (a frame-state with no mutation instances to stamp;
-  the reconcile then falls back to its own clock for the no-token case)."
-  ([frame-id frame-state] (reconcile-runtime-db-on-restore frame-id frame-state nil))
+  the reconcile then falls back to its own clock for the no-token case).
+
+  The EXACT incarnation `owner-token` (the captured record's `:drain-lock`) is
+  threaded through `:owner-token` so the reconcile fences its non-deferred host-
+  table clearing (stale/GC timer + work-ledger host handles) to the exact
+  incarnation the restore resolved against (rf2-qfrh4 seam 2). The reconcile
+  runs BEFORE the atomic write and addresses the frame by BARE id; without the
+  token, a callback that churns A to B mid-reconcile would let the bare-id clear
+  touch same-id successor B. Passing the token lets the reconcile skip the clear
+  once the exact incarnation is lost, so no B host handle is released — B's
+  transients belong to B and, if A was destroyed to seat B, `destroy-frame!`
+  already released A's. nil owner-token (the 2-/3-arity pure-unit path) has no
+  incarnation to fence and clears unconditionally, as before."
+  ([frame-id frame-state] (reconcile-runtime-db-on-restore frame-id frame-state nil nil))
   ([frame-id frame-state restore-time-ms]
+   (reconcile-runtime-db-on-restore frame-id frame-state restore-time-ms nil))
+  ([frame-id frame-state restore-time-ms owner-token]
    (if-let [reconcile (late-bind/get-fn :resources/reconcile-on-restore)]
      (if (contains? frame-state frame/runtime-partition-key)
        (update frame-state frame/runtime-partition-key
                (fn [rdb] (when (some? rdb)
                            (reconcile rdb frame-id {:defer-traces?   true
-                                                    :restore-time-ms restore-time-ms}))))
+                                                    :restore-time-ms restore-time-ms
+                                                    :owner-token     owner-token}))))
        frame-state)
      frame-state)))
 
@@ -723,25 +760,34 @@
   current host state before install, deferring success traces until the write
   lands.
 
-  The write boundary is fenced to the EXACT incarnation, not the bare id
-  (rf2-bjh6y). A same-id SUCCESSOR frame reseated between the precondition pass
-  and this write must not receive the resolved epoch's state. Two guards, both
-  keyed on `incarnation-token`:
+  The WHOLE restore is one EXACT-incarnation transaction, keyed on
+  `incarnation-token`, not the bare id (rf2-bjh6y + rf2-qfrh4). A same-id
+  SUCCESSOR frame reseated at ANY seam must not receive the resolved epoch's
+  state, touch host tables, or be anchored. Four fences, all on the token:
 
     - an early `event-continuation-live?` gate refuses BEFORE running the
       subsystem reconcile, so nothing is reconciled against a stale incarnation;
+    - the reconcile carries `incarnation-token` (seam 2) so its non-deferred
+      pre-write host-table clear is fenced — a callback that churns A to B
+      mid-reconcile cannot make the bare-id clear release B's host handles;
     - the physical install goes through the EXACT-INCARNATION
       `replace-frame-state!` arity, which returns nil unless the token still
       names the live record — so even the write itself can never redirect into a
-      same-id successor.
+      same-id successor;
+    - each post-write bare-id tail op (last-settled anchor, deferred subsystem
+      trace commit, host-work quiesce) re-checks `event-continuation-live?`
+      (seam 3) — the `:rf.epoch/restored` emit and the commit/quiesce fan-outs
+      are callback boundaries that can churn A to B, so a lost incarnation STOPS
+      the remaining A-only tail work rather than RETARGETING it onto B.
 
-  Both losses resolve to ONE coherent typed failure — `:rf.error/no-such-handler`
-  (kind `:frame`), the same shape a destroyed-frame write race produces — and
-  leave any successor frame byte-for-byte untouched with no success telemetry.
-  The write's non-nil return (a changed-key set, possibly empty) is success;
-  only the success branch emits restore telemetry, re-anchors post-settle
-  attribution, commits deferred subsystem traces, and cancels host-transient
-  work from the abandoned timeline.
+  Every incarnation loss resolves to ONE coherent typed failure —
+  `:rf.error/no-such-handler` (kind `:frame`), the same shape a destroyed-frame
+  write race produces — and leaves any successor frame byte-for-byte untouched
+  with no success telemetry. The write's non-nil return (a changed-key set,
+  possibly empty) is success; the public result then stays TRUE even if a tail
+  callback churns the incarnation. Only the success branch emits restore
+  telemetry, re-anchors post-settle attribution, commits deferred subsystem
+  traces, and cancels host-transient work from the abandoned timeline.
 
   The whole gate → reconcile → write → bookkeeping runs under the
   frame's `:drain-lock` (`serialize-tool-write!`), so no event transition can
@@ -779,8 +825,13 @@
               ;; `:rf/time-ms`) so the reconcile stamps a dangled-on-restore
               ;; mutation instance's durable `:settled-at` from a replay-stable
               ;; causal input, not the live install clock (EP-0010 §Restore/Replay).
+              ;; Thread the EXACT incarnation token too, so the reconcile's
+              ;; pre-write host-table clear is fenced to this incarnation — a
+              ;; callback that churns A to B mid-reconcile cannot make the bare-id
+              ;; clear release B's host handles (rf2-qfrh4 seam 2).
               frame-state-target (reconcile-runtime-db-on-restore
-                                   frame-id frame-state-target (:committed-at epoch))
+                                   frame-id frame-state-target
+                                   (:committed-at epoch) incarnation-token)
               ;; Write both partitions through the one physical frame container,
               ;; via the EXACT-INCARNATION arity: it resolves through the
               ;; validated incarnation's own record and returns nil if a same-id
@@ -798,14 +849,31 @@
             (do (trace/emit! :rf.epoch :rf.epoch/restored
                              {:frame       frame-id
                               :rf.epoch/id (:epoch-id epoch)})
-                ;; Restore triggers no ordinary event, so explicitly anchor its
-                ;; repaint/subscription/unmount back-fill to the restored epoch.
-                (state/set-last-settled-epoch! frame-id (:epoch-id epoch))
-                ;; Deferred subsystem success traces are valid only after install.
-                (commit-resources-restore-traces! frame-state-target)
-                ;; Host timers and HTTP handles are not frame state; cancel the
-                ;; abandoned timeline only after the new state is installed.
-                (quiesce-orphaned-async-host-work! frame-id)
+                ;; The exact-incarnation install committed, so the public result
+                ;; is TRUE and stays truthful regardless of what follows. But the
+                ;; `:rf.epoch/restored` emit above is a synchronous callback
+                ;; boundary: a trace listener can destroy A and seat a same-id
+                ;; successor B. Every framework-owned tail op below addresses the
+                ;; frame by BARE id (`set-last-settled-epoch!`, the resources
+                ;; trace commit, the machines/http host-work quiesce chain), so
+                ;; each is fenced to the EXACT incarnation the restore installed
+                ;; (rf2-qfrh4 seam 3). Re-check liveness before each — the trace
+                ;; commit and the quiesce chain themselves fan out to
+                ;; listeners/hooks that may churn — so once A is lost the
+                ;; remaining A-only tail work is STOPPED rather than RETARGETED
+                ;; onto B: no B anchor is stamped, no B resource trace committed,
+                ;; no B host handle released or aborted.
+                (when (frame/event-continuation-live? frame-id incarnation-token)
+                  ;; Restore triggers no ordinary event, so explicitly anchor its
+                  ;; repaint/subscription/unmount back-fill to the restored epoch.
+                  (state/set-last-settled-epoch! frame-id (:epoch-id epoch)))
+                (when (frame/event-continuation-live? frame-id incarnation-token)
+                  ;; Deferred subsystem success traces are valid only after install.
+                  (commit-resources-restore-traces! frame-state-target))
+                (when (frame/event-continuation-live? frame-id incarnation-token)
+                  ;; Host timers and HTTP handles are not frame state; cancel the
+                  ;; abandoned timeline only after the new state is installed.
+                  (quiesce-orphaned-async-host-work! frame-id))
                 true)))))))
 
 ;; ---- replace-frame-state! preconditions ------------------------------------

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -962,8 +962,8 @@
           (is (= {:rf.runtime/resources {:entries {}}} (:rdb @seen))
               "the hook receives the runtime-db PARTITION value")
           (is (= :test/x (:frame-id @seen)) "the hook receives the carried frame-id")
-          (is (= {:defer-traces? true :restore-time-ms nil} (:opts @seen))
-              "rf2-obi8rr — the hook is consulted with :defer-traces? true so it does not emit success rows before the install; rf2-wshzsp — and a :restore-time-ms slot (nil here, the 2-arity no-token path)")
+          (is (= {:defer-traces? true :restore-time-ms nil :owner-token nil} (:opts @seen))
+              "rf2-obi8rr — the hook is consulted with :defer-traces? true so it does not emit success rows before the install; rf2-wshzsp — and a :restore-time-ms slot (nil here, the 2-arity no-token path); rf2-qfrh4 — and an :owner-token slot (nil here, the 2-arity no-incarnation path) so the reconcile can fence its bare-id host-table clear to the exact incarnation")
           (is (true? (get-in out [:rf.db/runtime :rf.runtime/reconciled?]))
               "the hook's reconciled runtime-db is installed back into the frame-state")
           (is (= {:n 1} (:rf.db/app out)) "the app-db partition is untouched"))
@@ -5175,6 +5175,199 @@
         (is (= {:n 1} (rf/app-db-value :test/ctl)) "app-db rewound to the target epoch")
         (is (some #(= :rf.epoch/restored (:operation %)) @recorded)
             ":rf.epoch/restored success trace fired for the live-incarnation restore")))))
+
+;; rf2-qfrh4 — bjh6y fenced only the PHYSICAL write. Three further seams could
+;; still cross from incarnation A into a same-id successor B across the rest of
+;; the restore transaction. Each test below interposes a deterministic churn at
+;; ONE seam and asserts the exact-incarnation fence now holds end to end:
+;;
+;;   seam 1 — precondition sampling re-resolves history (and, pre-fix, the token)
+;;            by bare id;
+;;   seam 2 — the pre-write reconcile does a bare-id host-table clear;
+;;   seam 3 — the post-write bare-id tail (anchor / trace commit / quiesce) runs
+;;            after the synchronous :rf.epoch/restored callback boundary.
+;;
+;; The control (`restore-through-all-fences-still-succeeds`) drives the same
+;; token-threaded seams with NO churn and confirms an ordinary restore succeeds.
+
+(deftest restore-preconditions-refuse-successor-seated-during-history-sampling
+  (testing "rf2-qfrh4 seam 1 — a same-id successor B seated DURING precondition
+            sampling (interposed on the bare-id history re-resolve) must NOT
+            yield an :ok ticket that pairs A's retained epoch with a stale
+            incarnation. `check-restore-preconditions!` exact-owner-gates the
+            history/validation snapshot and refuses with :rf.error/no-such-handler
+            (kind :frame); B is byte-for-byte unchanged. Before the fix the
+            checks resolved history / re-resolved the token independently by bare
+            id and returned :ok."
+    (rf/make-frame {:id :test/seam1})
+    (rf/reg-event :set-owner (fn [_ [_ o n]] {:db {:owner o :n n}}))
+    (rf/dispatch-sync [:set-owner :A 1] {:frame :test/seam1})
+    (rf/dispatch-sync [:set-owner :A 2] {:frame :test/seam1})
+    (let [a-target-id (some (fn [r] (when (= {:owner :A :n 1} (:db-after r)) (:epoch-id r)))
+                            (rf/epoch-history :test/seam1))
+          a-token     (frame/frame-incarnation-token :test/seam1)
+          real-hist   state/history-for
+          churned?    (atom false)]
+      (is (some? a-target-id) "seeded an A epoch whose db-after is {:owner :A :n 1}")
+      (let [result (with-redefs [state/history-for
+                                 (fn [fid]
+                                   ;; Interpose the churn on the bare-id history
+                                   ;; re-resolve the checks perform: capture A's
+                                   ;; retained history, destroy A + seat a same-id
+                                   ;; successor B, then hand back A's RETAINED
+                                   ;; history (the documented late-cleanup overlap).
+                                   (if (and (= fid :test/seam1) (not @churned?))
+                                     (let [a-hist (real-hist fid)]
+                                       (reset! churned? true)
+                                       (rf/destroy-frame! :test/seam1)
+                                       (rf/make-frame {:id :test/seam1})
+                                       (rf/dispatch-sync [:set-owner :B 99] {:frame :test/seam1})
+                                       a-hist)
+                                     (real-hist fid)))]
+                     (tool-pair/check-restore-preconditions! :test/seam1 a-target-id))]
+        (is (true? @churned?) "the successor was interposed during sampling")
+        (is (= :fail (:outcome result))
+            "the checks refuse rather than pair A's epoch against the seated successor")
+        (is (= :rf.error/no-such-handler (:op result))
+            "the refusal is the canonical no-such-handler typed failure (reused, not new)")
+        (is (= :frame (:kind (:tags result))) "the typed failure carries :kind :frame")
+        (is (nil? (:incarnation-token result))
+            "no :ok ticket — so no A epoch is ever paired with the successor's token")
+        (is (not (identical? a-token (frame/frame-incarnation-token :test/seam1)))
+            "successor B is a fresh incarnation (distinct token)")
+        (is (= {:owner :B :n 99} (rf/app-db-value :test/seam1))
+            "successor B is byte-for-byte unchanged")))))
+
+(deftest restore-reconcile-fenced-to-exact-incarnation-spares-successor
+  (testing "rf2-qfrh4 seam 2 — perform-restore! threads the EXACT incarnation
+            token into the pre-write reconcile so its bare-id host-table clear is
+            fenced. A reconcile that churns A to B mid-pass then gates its side
+            effect on the threaded token performs NO B-addressed effect; the exact
+            write then rejects the lost incarnation, restore returns false, and B
+            is byte-for-byte unchanged. Before the fix the reconcile received no
+            token and its bare-id clear landed on B."
+    (rf/make-frame {:id :test/seam2})
+    ;; seed a non-nil runtime-db partition so the reconcile hook is consulted
+    ;; (`reconcile-runtime-db-on-restore` skips a nil runtime-db).
+    (rf/reg-event :seed2
+      (fn [{rt :rf.db/runtime} [_ o n]]
+        {:db {:owner o :n n}
+         :rf.db/runtime (assoc (or rt {}) :marker :present)}))
+    (rf/dispatch-sync [:seed2 :A 1] {:frame :test/seam2})
+    (rf/dispatch-sync [:seed2 :A 2] {:frame :test/seam2})
+    (let [a-target-id (some (fn [r] (when (= {:owner :A :n 1} (:db-after r)) (:epoch-id r)))
+                            (rf/epoch-history :test/seam2))
+          {:keys [outcome epoch incarnation-token]}
+          (tool-pair/check-restore-preconditions! :test/seam2 a-target-id)
+          seen-token (atom :unseen)
+          b-effect?  (atom false)
+          rk         :resources/reconcile-on-restore
+          r0         (late-bind/get-fn rk)]
+      (is (= :ok outcome) "preconditions passed against live incarnation A")
+      (is (some? a-target-id) "seeded an A epoch")
+      (try
+        (late-bind/set-fn! rk
+          (fn [rdb frame-id {:keys [owner-token]}]
+            (reset! seen-token owner-token)
+            ;; churn A -> same-id successor B mid-reconcile
+            (rf/destroy-frame! :test/seam2)
+            (rf/make-frame {:id :test/seam2})
+            (rf/dispatch-sync [:seed2 :B 99] {:frame :test/seam2})
+            ;; The real resources host-transient clear addresses the frame by BARE
+            ;; id; fence it on the threaded token exactly as ssr.cljc now does. A
+            ;; true here would mean a bare-id host-table touch landing on B.
+            (when (and frame-id (or (nil? owner-token)
+                                    (frame/frame-incarnation-live? frame-id owner-token)))
+              (reset! b-effect? true))
+            rdb))
+        (let [result (tool-pair/perform-restore! :test/seam2 incarnation-token epoch)]
+          (is (identical? incarnation-token @seen-token)
+              "the reconcile received the EXACT incarnation token (was absent before the fix)")
+          (is (false? @b-effect?)
+              "the token-fenced bare-id host-table effect did NOT fire against successor B")
+          (is (false? result) "the exact write rejects the lost incarnation")
+          (is (= {:owner :B :n 99} (rf/app-db-value :test/seam2))
+              "successor B is byte-for-byte unchanged"))
+        (finally (late-bind/set-fn! rk r0))))))
+
+(deftest restore-tail-anchoring-fenced-to-exact-incarnation
+  (testing "rf2-qfrh4 seam 3 — after the exact install commits, a synchronous
+            :rf.epoch/restored trace listener that destroys A and seats a same-id
+            successor B must not let the bare-id post-write tail (last-settled
+            anchor, resource-trace commit, host-work quiesce) RETARGET onto B.
+            restore returns TRUE (the install committed on A) but B's last-settled
+            anchor is NOT stamped with A's restored epoch-id. Before the fix the
+            tail ran unconditionally by bare id and stamped B."
+    (rf/make-frame {:id :test/seam3})
+    (rf/reg-event :set-owner3 (fn [_ [_ o n]] {:db {:owner o :n n}}))
+    (rf/dispatch-sync [:set-owner3 :A 1] {:frame :test/seam3})
+    (rf/dispatch-sync [:set-owner3 :A 2] {:frame :test/seam3})
+    (let [a-target-id (some (fn [r] (when (= {:owner :A :n 1} (:db-after r)) (:epoch-id r)))
+                            (rf/epoch-history :test/seam3))
+          {:keys [outcome epoch incarnation-token]}
+          (tool-pair/check-restore-preconditions! :test/seam3 a-target-id)
+          fired? (atom false)
+          lk     ::seam3-churn]
+      (is (= :ok outcome) "preconditions passed against live incarnation A")
+      (is (some? a-target-id) "seeded an A epoch")
+      (rf/register-listener! :trace lk
+        (fn [ev]
+          (when (and (not @fired?) (= :rf.epoch/restored (:operation ev)))
+            (reset! fired? true)
+            (rf/destroy-frame! :test/seam3)
+            (rf/make-frame {:id :test/seam3})
+            (rf/dispatch-sync [:set-owner3 :B 99] {:frame :test/seam3}))))
+      (try
+        (let [result (tool-pair/perform-restore! :test/seam3 incarnation-token epoch)]
+          (is (true? @fired?) "the :rf.epoch/restored listener churned A to B")
+          (is (true? result)
+              "the install committed on the exact incarnation A, so the public result stays TRUE")
+          (is (not= a-target-id (state/last-settled-epoch-id :test/seam3))
+              "the post-write anchor was NOT retargeted onto successor B")
+          (is (= {:owner :B :n 99} (rf/app-db-value :test/seam3))
+              "successor B's app-db is untouched by the restore tail"))
+        (finally (rf/unregister-listener! :trace lk))))))
+
+(deftest restore-through-all-fences-still-succeeds
+  (testing "rf2-qfrh4 control — the same token-threaded seams (record-derived
+            token, exact-owner history gate, token-carrying reconcile, fenced
+            post-write tail) with NO incarnation churn install and return true:
+            the fences reject only a lost incarnation, never an ordinary live one.
+            The reconcile receives the exact token and sees it LIVE; the tail
+            anchors last-settled to the restored epoch."
+    (rf/make-frame {:id :test/allfences})
+    (rf/reg-event :seedc
+      (fn [{rt :rf.db/runtime} [_ n]]
+        {:db {:n n}
+         :rf.db/runtime (assoc (or rt {}) :marker :present)}))
+    (rf/dispatch-sync [:seedc 1] {:frame :test/allfences})
+    (rf/dispatch-sync [:seedc 2] {:frame :test/allfences})
+    (let [target-id (some (fn [r] (when (= {:n 1} (:db-after r)) (:epoch-id r)))
+                          (rf/epoch-history :test/allfences))
+          {:keys [outcome epoch incarnation-token]}
+          (tool-pair/check-restore-preconditions! :test/allfences target-id)
+          token-live? (atom nil)
+          rk          :resources/reconcile-on-restore
+          r0          (late-bind/get-fn rk)]
+      (is (= :ok outcome) "preconditions passed against the live frame")
+      (is (identical? incarnation-token (frame/frame-incarnation-token :test/allfences))
+          "the :ok ticket's token is the live incarnation's own drain-lock (record-derived)")
+      (try
+        (late-bind/set-fn! rk
+          (fn [rdb frame-id {:keys [owner-token]}]
+            (reset! token-live? (and (some? owner-token)
+                                     (frame/frame-incarnation-live? frame-id owner-token)))
+            rdb))
+        (let [recorded (record-trace!)
+              result   (tool-pair/perform-restore! :test/allfences incarnation-token epoch)]
+          (is (true? @token-live?) "the reconcile saw the threaded token LIVE (no churn)")
+          (is (true? result) "an ordinary within-incarnation restore still succeeds")
+          (is (= {:n 1} (rf/app-db-value :test/allfences)) "app-db rewound to the target epoch")
+          (is (= target-id (state/last-settled-epoch-id :test/allfences))
+              "the tail anchored last-settled to the restored epoch")
+          (is (some #(= :rf.epoch/restored (:operation %)) @recorded)
+              ":rf.epoch/restored success trace fired"))
+        (finally (late-bind/set-fn! rk r0))))))
 
 ;; rf2-obi8rr — the resources restore-reconcile success rows
 ;; (:rf.resource/restored / :rf.resource/owner-released) must NOT leak when the

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -1341,6 +1341,16 @@
     to emit post-install. The host-side-transient clear runs regardless
     (idempotent; the only failure path is an already-destroyed frame whose
     transients were already released).
+  - `:owner-token` (rf2-qfrh4 seam 2) — the EXACT incarnation token (the
+    captured frame record's `:drain-lock`) the restore resolved against. The
+    host-side-transient clear addresses the frame by BARE id and runs BEFORE the
+    atomic install, so a callback that churns incarnation A to a same-id
+    successor B mid-reconcile could otherwise make it release B's live host
+    handles. When present, the clear fires ONLY while that exact incarnation is
+    still live (`frame/frame-incarnation-live?`); once it is lost the clear is
+    skipped — B is untouched, and A's transients were already released by
+    `destroy-frame!`. nil (the pure-unit 1-/2-arity) has no incarnation to fence
+    and clears unconditionally, as before.
   - `:restore-time-ms` (rf2-wshzsp) — the restore's CAUSAL time: the restored
     epoch's `:committed-at` (the committing token's `:rf.cofx`
     `:rf/time-ms`, replay-stable per EP-0010 §Time). It is the source of the
@@ -1357,7 +1367,7 @@
   touches it."
   ([runtime-db] (reconcile-on-restore runtime-db nil nil))
   ([runtime-db frame-id] (reconcile-on-restore runtime-db frame-id nil))
-  ([runtime-db frame-id {:keys [defer-traces? restore-time-ms]}]
+  ([runtime-db frame-id {:keys [defer-traces? restore-time-ms owner-token]}]
    (let [resources (get runtime-db state/resources-key)
          entries   (:entries resources)
          ledger    (get runtime-db state/work-ledger-key)
@@ -1523,7 +1533,20 @@
          ;; pure-unit 1-arity passes nil and has no live host tables to clear).
          ;; NOT deferred (rf2-obi8rr): idempotent, and the only failed-install
          ;; path is an already-destroyed frame whose transients were released.
-         (when frame-id
+         ;;
+         ;; FENCED to the exact incarnation (rf2-qfrh4 seam 2). This clear
+         ;; addresses the frame by BARE id and runs BEFORE `perform-restore!`'s
+         ;; atomic write; a callback that churns incarnation A to a same-id
+         ;; successor B mid-reconcile would otherwise make it release B's live
+         ;; host handles. When epoch passes the captured `:owner-token` we clear
+         ;; ONLY while that exact incarnation is still live — once it is lost the
+         ;; clear is skipped, so B is untouched (and if A was destroyed to seat
+         ;; B, `destroy-frame!` already released A's transients). nil owner-token
+         ;; (the pure-unit 1-/2-arity) has no incarnation to fence and clears
+         ;; unconditionally, as before.
+         (when (and frame-id
+                    (or (nil? owner-token)
+                        (frame/frame-incarnation-live? frame-id owner-token)))
            (clear-host-transients-on-restore! frame-id))
          (if defer-traces?
            ;; rf2-obi8rr — ride the intents back as metadata; the epoch

--- a/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
@@ -796,6 +796,50 @@
             handles but is a no-op on an unarmed frame (idempotent)"
     (is (nil? (ssr/clear-host-transients-on-restore! :restore/unarmed)))))
 
+(deftest reconcile-host-transient-clear-fenced-to-exact-incarnation
+  (testing "rf2-qfrh4 seam 2 — the pre-write host-transient clear fires only when
+            the threaded :owner-token still names the live incarnation. A STALE
+            token (a churned / destroyed incarnation) SKIPS the clear so a same-id
+            successor's armed host handles are spared — the reconcile runs BEFORE
+            the atomic write and addresses the frame by bare id, so without this
+            fence a callback that churned A to B mid-reconcile would release B's
+            live handles. A LIVE token clears as before; a nil token (the
+            pure-unit path) clears unconditionally."
+    (let [fid  :restore/fence
+          rkey gkey
+          wid  [:rf.work/resource gkey 7]
+          arm! (fn []
+                 (timers/schedule! fid rkey timers/stale-kind 600000)
+                 (work-ledger/put-handle! fid wid {:transport :rf.http/managed :request-id wid}))
+          e    (entry {:resource-id :article/by-slug :status :fetching :data {:x 1}
+                       :loaded-at 1 :stale-at 9.0e15 :current-work wid})]
+      (rf/make-frame {:id fid})
+      (let [live-token  (frame/frame-incarnation-token fid)
+            ;; a unique reference that never names fid's live incarnation — an
+            ;; incarnation token is a `:drain-lock` atom, so a fresh atom stands
+            ;; in for a destroyed / successor incarnation's token (cross-host:
+            ;; `(Object.)` is not a CLJS constructor).
+            stale-token (atom :stale-incarnation)]
+        ;; STALE token — the clear is fenced out; armed handles survive.
+        (arm!)
+        (is (seq (frame-timer-keys fid)) "armed a stale timer for the frame")
+        (is (seq (work-handle-keys fid)) "recorded a work handle for the frame")
+        (ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid {:owner-token stale-token})
+        (is (seq (frame-timer-keys fid))
+            "a stale incarnation token SKIPS the timer clear (successor's handle spared)")
+        (is (seq (work-handle-keys fid))
+            "a stale incarnation token SKIPS the work-handle clear")
+        ;; LIVE token — clears as before.
+        (ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid {:owner-token live-token})
+        (is (empty? (frame-timer-keys fid)) "the live incarnation token clears the timer")
+        (is (empty? (work-handle-keys fid)) "the live incarnation token clears the work handle")
+        ;; nil token (pure-unit path) — clears unconditionally, as before.
+        (arm!)
+        (ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid {:owner-token nil})
+        (is (empty? (frame-timer-keys fid)) "nil token clears the timer unconditionally")
+        (is (empty? (work-handle-keys fid)) "nil token clears the work handle unconditionally")
+        (timers/cancel-for-key! fid rkey)))))
+
 ;; ===========================================================================
 ;; 5. The generation allocator is monotonic across restore (part 1)
 ;; ===========================================================================


### PR DESCRIPTION
## What & why

`rf2-bjh6y` (#6179) promised epoch restore would be fenced to the exact frame incarnation it resolved, but it fenced only the **physical** `replace-frame-state!` write. Three further seams could still cross from incarnation **A** into a same-id successor **B** across the rest of the restore transaction (found by the #6179 post-merge audit `rf2-cvh7j`):

1. **Precondition sampling (seam 1)** — `check-restore-preconditions!` captured a frame record, then **independently** re-resolved the incarnation token *and* history by bare id. In the late-cleanup overlap a staged read could pair A's retained epoch/history with B's live token, and `perform-restore!` installed A's db into B.
2. **Pre-write reconcile (seam 2)** — the resources `reconcile-on-restore` hook runs before the exact write and clears host transients (stale/GC timer + work-ledger handles) by **bare id**. A callback that churned A→B mid-reconcile made that clear release **B's** live handles; the exact write then correctly failed, but B had already been touched.
3. **Post-write tail (seam 3)** — the synchronous `:rf.epoch/restored` telemetry ran **before** the bare-id last-settled anchor, resource-trace commit, and host-work quiesce. A trace listener could destroy A and seat B, and the tail then stamped/quiesced **B** while restore still returned `true`.

## The fix

Extend bjh6y's fence to the **whole transaction** by threading the one exact incarnation token (the captured record's `:drain-lock`) through every seam. No new error-id (reuses `:rf.error/no-such-handler`, kind `:frame`), no public token exposure, no retry, no locking framework.

- **seam 1** (`check-restore-preconditions!`): derive the token from the **same** captured record instead of a second bare-id lookup, and exact-owner-gate the history/validation snapshot — a successor seated during sampling refuses with `:rf.error/no-such-handler`.
- **seam 2** (`reconcile-runtime-db-on-restore` → `:resources/reconcile-on-restore`): thread `:owner-token` into the reconcile so its bare-id host-transient clear fires **only** while the exact incarnation is still live (`frame/frame-incarnation-live?`); once lost it is skipped (and if A was destroyed to seat B, `destroy-frame!` already released A's transients). nil token (pure-unit path) clears unconditionally, as before.
- **seam 3** (`perform-restore!` tail): re-check `event-continuation-live?` before each post-write bare-id tail op. A lost incarnation **stops** the remaining A-only work rather than retargeting it onto B; the committed install keeps the public result truthful (`true`).

The `restore-epoch!` / `perform-restore!` failure-mode docs are updated to describe the end-to-end transaction. Files touched: `epoch/tool_pair.cljc` (the transaction), `epoch.cljc` (doc), `resources/ssr.cljc` (the reconcile's token-fenced clear) + their tests.

## Quality gates

All foreground, unpiped.

- **epoch JVM** (`clojure -M:test`): `Ran 417 tests containing 6155 assertions. 0 failures, 0 errors.`
- **resources JVM** restore ns (`clojure -M:test -n re-frame.resources-restore-cljs-test`): `Ran 36 tests containing 127 assertions. 0 failures, 0 errors.`
- **`npm run test:cljs`**: `Ran 9887 tests containing 48667 assertions. 0 failures, 0 errors.`

### Adversarial coverage (one per seam + no-churn control), red-before / green-after verified

- `restore-preconditions-refuse-successor-seated-during-history-sampling` (seam 1) — RED: returns `:ok` with a token; GREEN: `:fail` / `:rf.error/no-such-handler`, B unchanged.
- `restore-reconcile-fenced-to-exact-incarnation-spares-successor` (seam 2, epoch) + `reconcile-host-transient-clear-fenced-to-exact-incarnation` (seam 2, resources) — RED: stale token clears B's handles; GREEN: skipped, B spared.
- `restore-tail-anchoring-fenced-to-exact-incarnation` (seam 3) — RED: anchor retargets onto B; GREEN: `true` returned, anchor not retargeted.
- `restore-through-all-fences-still-succeeds` (control) — an ordinary within-incarnation restore installs and returns `true`.

Extends `rf2-bjh6y`. Does not merge.
