### PR TITLE
test(s3): make the conformance profile an exact surface catalogue (rf2-2bjw6)

### DIFF
--- a/implementation/ui/test/re_frame/ui/s3_conformance_profile_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/s3_conformance_profile_jvm_test.clj
@@ -2,25 +2,46 @@
   "The S3 view-substrate CONFORMANCE PROFILE, executable (07 §5; EP-0035;
   rf2-vxgfnd.95.10).
 
-  This is the single authoritative catalogue of the FROZEN S3 verb surface. For
-  each verb it pins the direct-call contract (the `(defn …)` facade stub exists
-  for symbol resolution only and fails loud when called outside compiler
-  lowering) and names the gate that proves the verb's real runtime behaviour.
-  The test asserts the CODE honours each direct-call contract on the JVM, and a
-  drift guard asserts the human profile
-  (spec/conformance/S3-view-conformance-profile.md) catalogues every frozen verb
-  and every S3 gate — so the profile cannot silently omit one.
+  This is the single authoritative, EXACT catalogue of the FROZEN S3 surface.
+  It pins THREE runtime homes precisely:
 
-  Runtime behaviour itself is proven by the named gates (browser/JVM/elision
-  suites), not re-asserted here; this profile fixes the SURFACE and keeps the
-  catalogue honest against the shipped facade and its documentation."
+    1. the ten compiler-owned VERBS of the `re-frame.ui` facade — each a
+       `(defn …)` stub that exists for symbol resolution only and FAILS LOUD
+       when called outside compiler lowering;
+    2. `ui/route-link` — the ONE framework-authored S3 VIEW (an ordinary
+       compiled `defview`, NOT a fail-loud stub and NOT a compiler intrinsic);
+    3. the seven `re-frame.ui.react` interop-tier WRAPPERS (six host-hook
+       fail-loud stubs + the def-level `lazy` macro).
+
+  For each entry it names the direct-call/kind contract the CODE must honour on
+  the JVM and the gate/proof home that proves the entry's real runtime
+  behaviour (runtime behaviour itself is proven by those gates — browser / JVM /
+  elision suites — not re-asserted here).
+
+  The catalogue is EXACT, not a superset: exact-set guards assert that the
+  public vars of `re-frame.ui` and `re-frame.ui.react` are EXACTLY the
+  catalogued surface (S3 entries + explicitly-listed non-S3 publics), so ANY
+  addition / removal / rename of a public var fails the test until the catalogue
+  is updated in lockstep. The human profile
+  (spec/conformance/S3-view-conformance-profile.md) is validated ROW BY ROW —
+  each frozen verb's §1 table row must name its direct-call error AND its gate,
+  and the §6 gate roster must name exactly the certified S3 arms — rather than by
+  whole-document token presence, so moving a name into unrelated prose or
+  swapping a gate is caught."
   (:require [clojure.java.io :as io]
+            [clojure.set :as set]
+            [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.ui :as ui]))
+            [re-frame.ui :as ui]
+            [re-frame.ui.react :as react]))
 
-;; The frozen S3 verb surface. verb-symbol -> the direct-call error id, the gate
-;; that proves its runtime behaviour, and the one-line contract. This map is the
-;; source of truth the profile document restates.
+;; ---------------------------------------------------------------------------
+;; (1) The ten compiler-owned S3 VERBS of the re-frame.ui facade. verb-symbol ->
+;; the direct-call error id, the gate that proves its runtime behaviour, and the
+;; one-line contract. Each facade entry is a fail-loud `(defn …)` stub (NO
+;; `:rf.ui/view` metadata — that is what distinguishes a verb from route-link).
+;; This map is the source of truth the profile document's §1 table restates.
+;; ---------------------------------------------------------------------------
 (def frozen-s3-verbs
   {'local          {:error :rf.error/ui-tree-malformed :gate "G-15"
                     :contract "[value set! update!] three-tuple; update! composes over the latest host state"}
@@ -43,6 +64,59 @@
    'client-only    {:error :rf.error/ui-tree-malformed :gate "G-7"
                     :contract "browser-only subtree with a mandatory capability-free fallback"}})
 
+;; ---------------------------------------------------------------------------
+;; (2) route-link — the ONE framework-authored S3 VIEW. An ORDINARY compiled
+;; `defview` over the routing-owned late-bound link seam (`:routing/link-model` /
+;; `:routing/activate-link!`), NOT a compiler intrinsic and NOT a fail-loud stub:
+;; its var carries `:rf.ui/view` metadata + a registered view-id, and rendering
+;; it without the routing artefact fails loud with :rf.error/routing-artefact-
+;; missing. The click/href law + conformance matrix live in Spec 012 (routing
+;; owns the law); the JVM/SSR shell + client render homes are named here.
+;; ---------------------------------------------------------------------------
+(def frozen-s3-view
+  {'route-link {:view-id      :re-frame.ui/route-link
+                :absent-error :rf.error/routing-artefact-missing
+                :jvm-proof    "re-frame.ui.route-link-jvm-test"
+                :cljs-proof   "re-frame.ui.route-link-dom-cljs-test"
+                :contract     "ordinary compiled defview; real <a href>; plain left-click dispatches :source :router; native/modifier clicks defer to the browser"}})
+
+;; ---------------------------------------------------------------------------
+;; (3) The frozen `re-frame.ui.react` INTEROP TIER — seven wrappers (Spec 004
+;; §The React interop tier). NOT a second state/reactivity model. Six are HOST
+;; HOOKS: `(defn …)` stubs the compiler recognises by resolved head and lowers,
+;; and which fail loud on a direct call. `lazy` is a DEF-LEVEL macro. Proof
+;; homes: JVM structural subset + compile-time position law + HMR-signature ->
+;; re-frame.ui.react-interop-jvm-test; real React client behaviour ->
+;; re-frame.ui.react-interop-dom-cljs-test.
+;; ---------------------------------------------------------------------------
+(def frozen-react-wrappers
+  {'use-ref           {:kind :hook :error :rf.error/ui-tree-malformed}
+   'use-effect        {:kind :hook :error :rf.error/ui-tree-malformed}
+   'use-layout-effect {:kind :hook :error :rf.error/ui-tree-malformed}
+   'use-effect-event  {:kind :hook :error :rf.error/ui-tree-malformed}
+   'use-context       {:kind :hook :error :rf.error/ui-tree-malformed}
+   'use-id            {:kind :hook :error :rf.error/ui-tree-malformed}
+   'lazy              {:kind :macro}})
+
+;; Public vars of `re-frame.ui` that are NOT part of the S3 surface — the boot
+;; adapter + the S1/S1b/S1c/S2 forms, catalogued in the Spec 004 family. Listed
+;; explicitly so the facade exact-set guard forces every NEW public var to be
+;; classified (S3 verb, S3 view, or here) before the surface can silently drift.
+(def non-s3-facade-publics
+  '#{adapter defview custom-element mount create-root render! hydrate-root
+     unmount! frame-root frame-provider sub lease frame raw html raw-fn spread})
+
+;; The S3-specific gate arms this profile certifies (07 §5 / EP-0034 §4): every
+;; verb gate PLUS the two non-verb S3 arms — G-11 (HMR shell + view-evidence /
+;; manifest production absence) and G-18 (library-façade isolation). The §6
+;; roster must name exactly this set.
+(def s3-arm-gates
+  #{"G-6" "G-7" "G-8" "G-11" "G-15" "G-16" "G-17" "G-18"})
+
+;; ===========================================================================
+;; Executable surface pins — the shipped code honours each catalogued contract.
+;; ===========================================================================
+
 (defn- direct-call!
   "Invoke the facade stub for `verb` directly (outside compiler lowering) so it
   fails loud, and return the thrown `:rf.error/id`, or ::no-throw."
@@ -62,17 +136,90 @@
     ::no-throw
     (catch clojure.lang.ExceptionInfo e (:rf.error/id (ex-data e)))))
 
-(deftest every-frozen-s3-verb-resolves-in-the-facade
-  (testing "each frozen S3 verb is a public var of re-frame.ui"
-    (doseq [verb (keys frozen-s3-verbs)]
-      (is (some? (ns-resolve 're-frame.ui verb))
-          (str verb " must resolve in the re-frame.ui facade")))))
-
-(deftest every-frozen-s3-verb-direct-call-fails-loud
-  (testing "the facade stub exists for symbol resolution only and throws its documented id"
+(deftest s3-verbs-resolve-as-fail-loud-facade-stubs
+  (testing "each frozen S3 verb is a public fail-loud facade stub (not a view)"
     (doseq [[verb {:keys [error]}] frozen-s3-verbs]
-      (is (= error (direct-call! verb))
-          (str "(" verb " …) called directly must throw " error)))))
+      (let [v (ns-resolve 're-frame.ui verb)]
+        (is (some? v) (str "ui/" verb " must resolve in the re-frame.ui facade"))
+        (is (not (:rf.ui/view (meta v)))
+            (str "ui/" verb " is a compiler-verb stub, not a compiled view"))
+        (is (= error (direct-call! verb))
+            (str "(" verb " …) called directly must fail loud with " error))))))
+
+(deftest route-link-is-a-compiled-view-not-a-stub
+  (testing "route-link is an ordinary compiled defview, not a fail-loud stub"
+    (doseq [[view {:keys [view-id]}] frozen-s3-view]
+      (let [v (ns-resolve 're-frame.ui view)]
+        (is (some? v) (str "ui/" view " must resolve in the re-frame.ui facade"))
+        (is (true? (:rf.ui/view (meta v)))
+            (str "ui/" view " must be a compiled view (carry :rf.ui/view)"))
+        (is (= view-id (:rf.ui/view-id (meta v)))
+            (str "ui/" view " must register view-id " view-id))
+        (is (not (contains? frozen-s3-verbs view))
+            (str "ui/" view " must not be double-classified as a fail-loud verb"))))))
+
+(defn- react-direct-call!
+  "Invoke a `re-frame.ui.react` HOOK wrapper directly (at a supported arity) so
+  it fails loud, and return the thrown `:rf.error/id`, or ::no-throw."
+  [wrapper]
+  (try
+    (case wrapper
+      use-ref           (react/use-ref)
+      use-effect        (react/use-effect nil)
+      use-layout-effect (react/use-layout-effect nil)
+      use-effect-event  (react/use-effect-event nil)
+      use-context       (react/use-context nil)
+      use-id            (react/use-id))
+    ::no-throw
+    (catch clojure.lang.ExceptionInfo e (:rf.error/id (ex-data e)))))
+
+(deftest react-wrappers-resolve-with-frozen-kinds
+  (testing "the seven interop wrappers resolve; the six hooks fail loud, lazy is a macro"
+    (doseq [[wrapper {:keys [kind error]}] frozen-react-wrappers]
+      (let [v (ns-resolve 're-frame.ui.react wrapper)]
+        (is (some? v) (str "react/" wrapper " must resolve in re-frame.ui.react"))
+        (case kind
+          :hook  (do (is (not (:macro (meta v)))
+                         (str "react/" wrapper " is a host-hook fn, not a macro"))
+                     (is (= error (react-direct-call! wrapper))
+                         (str "(react/" wrapper " …) called directly must fail loud with " error)))
+          :macro (is (true? (:macro (meta v)))
+                     (str "react/" wrapper " must be a def-level macro")))))))
+
+;; ===========================================================================
+;; Exact-set guards — the add / remove / rename teeth on the runtime surface.
+;; ===========================================================================
+
+(deftest facade-surface-is-exactly-the-catalogue
+  (testing "re-frame.ui publics are EXACTLY the catalogued surface — a new / removed / renamed public var fails until the catalogue is updated in lockstep"
+    (let [publics    (set (keys (ns-publics 're-frame.ui)))
+          catalogued (set/union (set (keys frozen-s3-verbs))
+                                (set (keys frozen-s3-view))
+                                non-s3-facade-publics)]
+      (is (= catalogued publics)
+          (str "re-frame.ui surface drift — "
+               "uncatalogued new publics: " (sort (set/difference publics catalogued))
+               "; catalogued-but-absent: " (sort (set/difference catalogued publics)))))))
+
+(deftest react-tier-is-exactly-the-catalogue
+  (testing "re-frame.ui.react publics are EXACTLY the seven frozen wrappers"
+    (let [publics    (set (keys (ns-publics 're-frame.ui.react)))
+          catalogued (set (keys frozen-react-wrappers))]
+      (is (= catalogued publics)
+          (str "re-frame.ui.react surface drift — "
+               "uncatalogued new publics: " (sort (set/difference publics catalogued))
+               "; catalogued-but-absent: " (sort (set/difference catalogued publics)))))))
+
+(deftest verb-gates-are-certified-s3-arms
+  (testing "every S3 verb names a gate in the certified S3-arm roster (no phantom verb gate)"
+    (doseq [[verb {:keys [gate]}] frozen-s3-verbs]
+      (is (contains? s3-arm-gates gate)
+          (str "ui/" verb " names gate " gate " which is not a certified S3 arm")))))
+
+;; ===========================================================================
+;; Document drift guard — the human profile stays EXACT against this surface,
+;; validated row by row rather than by whole-document token presence.
+;; ===========================================================================
 
 (defn- repo-root []
   (loop [d (io/file (System/getProperty "user.dir"))]
@@ -81,20 +228,61 @@
       (.exists (io/file d "spec" "conformance")) d
       :else (recur (.getParentFile d)))))
 
-(deftest profile-document-catalogues-every-verb-and-gate
-  (testing "the human S3 conformance profile stays in sync with this executable surface"
-    (let [root (repo-root)]
-      (is (some? root) "must locate the repo root (spec/conformance)")
-      (let [doc (io/file root "spec" "conformance" "S3-view-conformance-profile.md")]
-        (is (.exists doc) (str "the profile document must exist at " doc))
-        (let [text (slurp doc)]
-          (doseq [verb (keys frozen-s3-verbs)]
-            (is (.contains text (str "`ui/" verb "`"))
-                (str "the profile must catalogue ui/" verb)))
-          ;; Every S3 gate must be named — these prove the profile's runtime rows.
-          (doseq [gate ["G-7" "G-8" "G-11" "G-15" "G-16" "G-17" "G-18"]]
-            (is (.contains text gate)
-                (str "the profile must name gate " gate)))
-          (testing "explicit non-surfaces (the wall) are documented"
-            (is (.contains text "Non-surfaces")
-                "the profile must enumerate explicit S3 non-surfaces")))))))
+(defn- profile-doc []
+  (io/file (repo-root) "spec" "conformance" "S3-view-conformance-profile.md"))
+
+(defn- table-row-for
+  "The single Markdown table row whose FIRST cell is exactly `token`, or nil when
+  there is not exactly one. Keying on the first cell (not mere occurrence) binds
+  a verb to its OWN §1 catalogue row: prose mentions, roster rows that name a
+  bare token without the `ui/` qualifier, and rows that merely reference the verb
+  mid-contract (e.g. the `ui/slot` row naming `ui/render-fn`) do not match."
+  [lines token]
+  (let [first-cell (fn [line]
+                     (let [t (str/triml line)]
+                       (when (str/starts-with? t "|")
+                         (-> t (subs 1) (str/split #"\|") first str/trim))))
+        rows       (filter #(= token (first-cell %)) lines)]
+    (when (= 1 (count rows)) (first rows))))
+
+(defn- roster-section
+  "The §6 gate-roster region of `text` (from the `## 6.` header to `## 7.`), so a
+  gate is read from a real roster row, not from incidental prose elsewhere."
+  [text]
+  (let [start (str/index-of text "## 6.")
+        end   (str/index-of text "## 7.")]
+    (when (and start end) (subs text start end))))
+
+(deftest profile-catalogues-every-verb-row-exactly
+  (testing "each frozen S3 verb has one §1 table row naming its direct-call error AND its gate"
+    (let [doc (profile-doc)]
+      (is (some? (repo-root)) "must locate the repo root (spec/conformance)")
+      (is (.exists doc) (str "the profile document must exist at " doc))
+      (let [lines (str/split-lines (slurp doc))]
+        (doseq [[verb {:keys [error gate]}] frozen-s3-verbs]
+          (let [token (str "`ui/" verb "`")
+                row   (table-row-for lines token)]
+            (is (some? row)
+                (str "the profile must catalogue " token " in exactly one table row"))
+            (when row
+              (is (str/includes? row (str error))
+                  (str token "'s row must name its direct-call error " error))
+              (is (str/includes? row (str "**" gate "**"))
+                  (str token "'s row must name its proving gate " gate)))))))))
+
+(deftest profile-gate-roster-is-exactly-the-arm-set
+  (testing "the §6 gate roster names EXACTLY the certified S3 arms — dropping / adding / renaming a roster gate is red"
+    (let [text   (slurp (profile-doc))
+          roster (roster-section text)]
+      (is (some? roster) "the profile must have a §6 gate roster and a §7 header")
+      (when roster
+        (let [named (set (map second (re-seq #"\*\*(G-\d+)\*\*" roster)))]
+          (is (= s3-arm-gates named)
+              (str "§6 gate-roster drift — "
+                   "extra: " (sort (set/difference named s3-arm-gates))
+                   "; missing: " (sort (set/difference s3-arm-gates named)))))))))
+
+(deftest profile-documents-the-non-surface-wall
+  (testing "the profile enumerates the explicit S3 non-surfaces (the wall)"
+    (is (str/includes? (slurp (profile-doc)) "Non-surfaces")
+        "the profile must enumerate explicit S3 non-surfaces")))


### PR DESCRIPTION
## What

`implementation/ui/test/re_frame/ui/s3_conformance_profile_jvm_test.clj` — called the single authoritative catalogue of the frozen S3 surface — was **not exact**. This makes it an exact-set / exact-row catalogue. **Test-only: no runtime or spec change.**

### The inexactness (rf2-2bjw6)

- **Subset, not exact-set.** It checked only that the ten facade verbs *resolved* (`every-frozen-s3-verb-resolves-in-the-facade`). A new / removed / renamed public var in `re-frame.ui` or `re-frame.ui.react` slipped through.
- **Omitted frozen surface.** The structured map held only the ten `re-frame.ui` verbs — it omitted `ui/route-link` and all seven `re-frame.ui.react` interop wrappers.
- **Loose whole-document doc match** (old lines 91–100). It asserted each verb token and each gate name occurred *somewhere* in the Markdown, and the gate list was a hand-hardcoded set (`["G-7" "G-8" "G-11" "G-15" "G-16" "G-17" "G-18"]`) **disjoint from the catalogue — it omitted G-6 entirely** and never proved a verb→gate row association.

### The fix (exact-set / exact-row, bounded)

- Catalogue all three frozen S3 runtime homes and pin each against the shipped code: the ten fail-loud verb stubs (resolve + direct-call error + no `:rf.ui/view` meta); `route-link` as an ordinary compiled `defview` (`:rf.ui/view` + registered view-id, **not** a fail-loud stub); the seven interop wrappers (six host hooks fail loud, `lazy` is a macro), naming their JVM/CLJS proof homes.
- **Exact-set guards**: `ns-publics` of `re-frame.ui` and `re-frame.ui.react` must equal the catalogued surface (S3 entries + explicit non-S3 publics), so any add/remove/rename fails until the catalogue is updated in lockstep.
- **Row-by-row doc validation**: each verb's §1 table row (keyed on its first cell) must name its direct-call error AND its gate; the §6 roster must name exactly the certified S3 arms (restores G-6).

Bounded inventory/drift check — no documentation generator or general Markdown parser.

## Quality gates

Focused ns `re-frame.ui.s3-conformance-profile-jvm-test`, foreground, on the rebased tree:

```
Ran 9 tests containing 101 assertions.
0 failures, 0 errors.
```

**Red-before / green-after teeth** (each mutation reverted after):

| Mutation (temporary) | Old test | New test |
|---|---|---|
| `ui/local` §1 row gate `G-15`→`G-99` | **green** (loose `.contains` matched G-15 in §6) | **RED** — `` `ui/local`'s row must name its proving gate G-15`` |
| §6 roster gate `G-11`→`G-12` | n/a | **RED** — `§6 gate-roster drift — extra: (G-12); missing: (G-11)` |
| Add public `surface-drift-probe` to `re-frame.ui` | green (subset check) | **RED** — `uncatalogued new publics: (surface-drift-probe)` |

Real frozen surface + real profile document: **green**.

## Scope / fence

Test file only (`git diff --stat` = 1 file). No runtime source, spec, ui-compiler, epoch, machines, or gate files touched. Public var sets were verified live via `ns-publics` on the JVM.

### Out-of-fence follow-up (not in this PR)

The wider bead also asks the S3 profile **document** to cross-list `route-link` + the react wrappers and to reconcile Spec 004's `use-effect-event` prose with native React 19.2 semantics. Those require spec-file + `react.cljc` + browser-fixture edits outside this test-only fence — the executable catalogue here pins them against the runtime and names their proof homes; the doc-side additions and prose reconciliation should ride a separate bead.

rf2-2bjw6