### PR TITLE
test(ui): finish registry-axis precision in the active HMR fixture (rf2-1g5rt)

### DIFF
--- a/implementation/ui/test/re_frame/ui/reactive_hmr_authority_fence_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_hmr_authority_fence_cljs_test.cljc
@@ -424,7 +424,8 @@
                 "the accepted desired plan is unchanged — capture-2 never overwrote it")))))))
 
 ;; ===========================================================================
-;; rf2-77pb08 — LINEARIZE the final body-authority validation WITH publication.
+;; rf2-77pb08 — SETTLE the final body-authority validation WITH publication
+;; across TWO axes of DIFFERING STRENGTH.
 ;;
 ;; PR #5938 (.214/.260) proved the fence catches an authority change landing at
 ;; or before the final SAMPLE. But that fence sampled the authority and then
@@ -433,27 +434,41 @@
 ;; re-registration (registry axis) landing AFTER the sample but BEFORE the swap
 ;; published a stale generation-0 capture that connected and owned leases.
 ;;
-;; `publish-commit!` fuses validation and publication into ONE compare-and-set!
-;; transition (cell-local axis) gated on the registered-slot identity token
-;; (registry axis). The `:pre-publish` seam fires ONCE, in EXACTLY that former
-;; gap — between an attempt's authority sample and its publish CAS — so these
-;; fixtures land the advance where nothing could catch it before, on BOTH the
-;; cell-local and registry authority axes, and prove nothing publishes.
+;; `publish-commit!` closes that gap ASYMMETRICALLY — each axis carries the
+;; strength it can on re-frame2's single-threaded CLJS host:
+;;   - CELL-LOCAL axis — a GENUINE single-atom CAS linearization: the capture
+;;     generation is validated against the SAME cell-state snapshot the publish
+;;     `compare-and-set!` commits, so validation and publication are ONE atomic
+;;     transition.
+;;   - REGISTRY axis — a BEST-EFFORT slot-identity check, NOT fused into the CAS:
+;;     the registered slot is sampled once as a token and rechecked `identical?`
+;;     IMMEDIATELY BEFORE the CAS. Sound on the single-threaded host (nothing
+;;     preempts between the recheck and the CAS), but it is not a single-atom
+;;     linearization.
+;; The `:pre-publish` seam fires ONCE, in EXACTLY that former gap — between an
+;; attempt's authority sample and its publish CAS — so these fixtures land the
+;; advance where nothing could catch it before, on BOTH axes, and prove nothing
+;; publishes.
 ;;
 ;; MUTATION TOOTH: revert `publish-commit!` to a sample-then-independent-swap
 ;; (so the `:pre-publish` advance lands between the two) and every assertion
 ;; below flips red — the interposed advance then publishes and connects.
 ;; `.cljc` ending `-cljs-test` runs on node (`test:cljs`) AND JVM
-;; (`clojure -M:test`); the accompanying `-race-jvm-test` exercises the same CAS
-;; under GENUINE two-thread concurrency.
+;; (`clojure -M:test`); the accompanying `-race-jvm-test` exercises the same
+;; publish path — both axes — under GENUINE two-thread concurrency.
 ;; ===========================================================================
 
-;; ---- Registry axis: a re-registration in the sample→publish window ----------
-;; The view's HMR slot is the token; a mid-window `register-view-generation!`
-;; swaps `view-generations` to a fresh slot object, failing the `identical?`
-;; gate so the loop re-reads a MOVED revision and rejects.
+;; ---- Registry axis: a re-registration before the final slot-identity check --
+;; The registry axis is a BEST-EFFORT identity check, NOT a single-atom
+;; linearization. The view's HMR slot is sampled once as a token; a
+;; `register-view-generation!` landing at `:pre-publish` (BEFORE the final
+;; `identical?` recheck) swaps `view-generations` to a fresh slot object, so the
+;; recheck fails and the loop re-reads a MOVED revision and rejects. This
+;; exercises the recheck→re-validate path only — it does NOT interpose in the
+;; residual token-recheck→cell-CAS window (a single-fire barrier cannot, and that
+;; window is unreachable on the single-threaded CLJS host anyway).
 
-(deftest pre-publish-registration-is-linearized-registry-axis
+(deftest pre-publish-registration-is-identity-checked-registry-axis
   (rf/reg-sub :r/a (fn [db _] (:a db)))
   (seed! {:a 1})
   (let [vid  ::linz-registry-view
@@ -466,7 +481,7 @@
                            (reregister-barrier vid :pre-publish hs0)]
                    (reactive/commit! cell cap))]
       (is (= :stale result)
-          "a re-registration interposed between the sample and the publish CAS is fenced")
+          "a re-registration before the final slot-identity check is rejected — the moved token fails the recheck")
       (is (= :fresh (reactive/lifecycle cell)) "a fenced candidate never connects")
       (is (empty? (reactive/committed-sites cell)) "no dependency set published")
       (is (nil? (entry [:r/a])) "the staged lease was released — zero-owner node")


### PR DESCRIPTION
## Summary

Finishes the registry-axis precision sweep in the active HMR fixture
`reactive_hmr_authority_fence_cljs_test.cljc`, following the two-axis
`publish-commit!` contract that PR #6188 (rf2-ce8cj) established in the
runtime docstring, the step-6 comment, and the companion race JVM test.

The rf2-77pb08 section still carried the pre-repair vocabulary that treats
both commit-authority axes as one CAS linearization. The actual contract is
deliberately **asymmetric**:

- **Cell-local axis** — a genuine single-atom CAS linearization (validation
  and publication are one atomic `compare-and-set!` transition).
- **Registry axis** — a best-effort slot-identity check taken *immediately
  before* that CAS, sound only under the single-threaded CLJS host; **not**
  fused into the CAS and **not** a single-atom linearization.

### Precised spots (text/name only)

| Location | Before | After |
|---|---|---|
| Section heading | `LINEARIZE the final body-authority validation WITH publication` | `SETTLE the final body-authority validation WITH publication across TWO axes of DIFFERING STRENGTH` |
| Summary | `publish-commit! fuses validation and publication into ONE compare-and-set! transition (cell-local axis) gated on the registered-slot identity token (registry axis)` | two-bullet split: cell-local = genuine single-atom CAS linearization; registry = best-effort slot-identity check, NOT fused into the CAS, immediate `identical?` recheck before it |
| Race-test pointer | `exercises the same CAS under GENUINE two-thread concurrency` | `exercises the same publish path — both axes — under GENUINE two-thread concurrency` |
| Registry-axis comment | `a re-registration in the sample→publish window` / `identical? gate` | best-effort identity check; exercises the recheck→re-validate path only; does NOT interpose in the residual token-recheck→cell-CAS window |
| Test name | `pre-publish-registration-is-linearized-registry-axis` | `pre-publish-registration-is-identity-checked-registry-axis` |
| `:stale` assertion msg | `a re-registration interposed between the sample and the publish CAS is fenced` | `a re-registration before the final slot-identity check is rejected — the moved token fails the recheck` |

The cell-local test `pre-publish-generation-advance-is-linearized-cell-local-axis`
retains its genuine linearization wording. No runtime `reactive.cljc` change;
no runtime forms, assertion predicates, test behavior, concurrency seam, lock,
or public surface change — comment/description and one deftest name only. The
czh5k reload-cycle surface was not touched.

## Quality gates

- `npm run test:cljs` (node) — **9901 tests / 48753 assertions, 0 failures, 0 errors**
- `clojure -M:test -n re-frame.ui.reactive-hmr-authority-fence-cljs-test` (focused JVM arm) — **15 tests / 121 assertions, 0 failures, 0 errors**

Both green, as expected for a description/comment-only precision sweep.

Closes rf2-1g5rt.
