### PR TITLE
fix(ui-compiler): defview binding-plan (parse) correctness + real compiled-CLJS proof (rf2-iiacq)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/binding_plan.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/binding_plan.cljc
@@ -123,3 +123,50 @@
   dependent `:or` default resolves to the same symbol on every host."
   [pattern]
   (mapv :local-pattern (assoc-binding-units pattern)))
+
+(defn pattern-locals
+  "The set of local symbols a destructuring binding PATTERN introduces, exactly
+  as host `destructure` binds them. This is the host-faithful primitive a
+  DERIVED-slot consumer uses to judge which binding units survive host `let`
+  last-wins shadowing: a unit whose every local a LATER unit rebinds contributes
+  no final visible local, so its lookup key is a dead slot even though its
+  initializer still runs (`assoc-binding-units` keeps it in the executable plan).
+
+  A simple symbol binds itself. A sequential `[a b & more :as all]` binds each
+  element pattern (recursively), the rest pattern and `:as`. An associative
+  `{:keys [...] p key :as s :or {...}}` binds each group local NAME-STRIPPED
+  (`:keys [ns/x]` binds `x`, exactly as the plan's group locals arrive), each
+  explicit sub-pattern (recursively), and `:as`. Directives (`:or`, the group
+  keyword) and lookup keys are not locals; the `&` marker is dropped.
+
+  Comparing the LOCALS a pattern binds — not whole `:pattern` values — is what
+  lets a nested or partially overlapping pattern collapse faithfully: a symbol
+  `x <- :ns/x` shadows the `x` a sibling `[x] <- :other` binds (whole-pattern
+  equality would miss it, leaking `:other`), while `[a b] <- :other` survives
+  beside `a <- :ns/a` because `b` is still a final visible local."
+  [pattern]
+  (cond
+    (symbol? pattern)
+    (if (= '& pattern) #{} #{pattern})
+
+    (vector? pattern)
+    (loop [ps (seq pattern), acc #{}]
+      (if (nil? ps)
+        acc
+        (let [p (first ps)]
+          (if (or (= :as p) (= '& p))
+            (recur (nnext ps) (into acc (pattern-locals (second ps))))
+            (recur (next ps)  (into acc (pattern-locals p)))))))
+
+    (map? pattern)
+    (reduce-kv
+     (fn [acc k v]
+       (cond
+         (= k :as)         (into acc (pattern-locals v))
+         (= k :or)         acc
+         (key-group-kw? k) (into acc (map (fn [s] (symbol nil (name s)))) v)
+         :else             (into acc (pattern-locals k))))
+     #{}
+     pattern)
+
+    :else #{}))

--- a/implementation/ui/src/re_frame/ui/compiler/header.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/header.cljc
@@ -114,27 +114,43 @@
   nil)
 
 (defn- collapse-entries
-  "Keep exactly ONE entry per bound local (`:pattern`) — the host `bes`-order
-  WINNER, i.e. the LAST occurrence, the binding the host's `let` last-wins
-  actually establishes. `bp/assoc-binding-units` already collapses two units
-  that share a `bes` KEY (`{:keys [x] x :foo}` → the group's `assoc` overwrites
-  the explicit entry, one `x <- :x`). But a QUALIFIED group local whose bare
-  name collides an explicit local (`{:keys [ns/x] x :other}`) keeps two DISTINCT
-  `bes` keys (`ns/x`, `x`) that both name-strip to the same local `x`; those
-  arrive as two units binding one local via host last-wins. Left uncollapsed
-  they leave a DEAD slot (`:other` here) in the derived `:slots` — over-comparing
-  in the memo comparator (spurious re-renders), over-declaring in the manifest
-  `:prop-slots`, and silently accepting a never-bound key under CLOSED `:props`.
-  De-duping by `:pattern` here — keeping the last, host-winning entry — restores
-  the 'never two entries for one local' invariant so the derived slots carry no
-  key the view never binds. The winning entry stays in its `bes` position; a
-  same-key collision across DISTINCT locals (`{:keys [x] y :x}` — two locals,
-  one slot) is untouched (both patterns differ, so both survive; the slot
-  `distinct` folds the shared key)."
+  "Project the full host binding-unit plan to its FINAL visible-local slots: keep
+  an entry only where it binds a local NO LATER entry rebinds — the bindings the
+  host's `let` last-wins actually leaves visible. `bp/assoc-binding-units` already
+  collapses two units that share a `bes` KEY (`{:keys [x] x :foo}` → the group's
+  `assoc` overwrites the explicit entry, one `x <- :x`). The residual shadows it
+  does NOT catch arrive as DISTINCT units binding one local via host last-wins:
+    - a QUALIFIED group local whose bare name collides an explicit local
+      (`{:keys [ns/x] x :other}` — `ns/x` ≠ `x` as `bes` keys, both name-strip to
+      the local `x`);
+    - a NESTED or partially overlapping pattern (`{[x] :other :keys [ns/x]}` —
+      `[x]` and `x` are unequal `:pattern` values, but `[x]`'s only local `x` is
+      reclaimed by the group's `x <- :ns/x`).
+  Left uncollapsed these leave a DEAD slot (`:other` here) in the derived `:slots`
+  — over-comparing in the memo comparator (spurious re-renders), over-declaring in
+  the manifest `:prop-slots`, and silently accepting a never-bound key under
+  CLOSED `:props`.
+
+  A reverse sweep restores the 'no dead slot' invariant: walk entries LAST→first,
+  keeping the set of locals a later entry already claimed; retain an entry only
+  where it binds at least one local NOT yet claimed (a final visible local), then
+  add its locals to the claimed set. Comparing the LOCALS each pattern binds
+  (`bp/pattern-locals`) rather than whole `:pattern` values is what catches the
+  nested case a whole-pattern equality misses. The winning entries stay in their
+  `bes` positions, and the FULL executable plan (`:binding-units`) is untouched —
+  every host initializer still runs. Two DISTINCT locals sharing one slot
+  (`{:keys [x] y :x}`) both survive; a partial overlap (`{[a b] :other :keys
+  [ns/a]}`) keeps `:other` because `b` is still a final visible local; the slot
+  `distinct` folds any shared key."
   [entries]
-  (let [last-idx (into {} (map-indexed (fn [i e] [(:pattern e) i])) entries)]
-    (into [] (keep-indexed (fn [i e] (when (= i (last-idx (:pattern e))) e)))
-          entries)))
+  (let [v (vec entries)]
+    (loop [i (dec (count v)), claimed #{}, keep #{}]
+      (if (neg? i)
+        (into [] (keep-indexed (fn [idx e] (when (contains? keep idx) e))) v)
+        (let [locals (bp/pattern-locals (:pattern (nth v i)))]
+          (if (some (complement claimed) locals)
+            (recur (dec i) (into claimed locals) (conj keep i))
+            (recur (dec i) claimed keep)))))))
 
 (defn parse-header
   "argv -> {:mode :none|:named|:as, :as-sym, :entries [{:key :slot :pattern

--- a/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_cljs_test.cljs
@@ -1,0 +1,161 @@
+(ns re-frame.ui.binding-plan-host-faithful-cljs-test
+  "rf2-iiacq — REAL compiled-CLJS evidence for the defview header binding plan.
+
+  The `*_jvm_test` companion pins the plan against `clojure.core/destructure` and
+  models the CLJS primitives (`unchecked-get`/`undefined?`) on the JVM. This suite
+  does NOT model: it defines REAL `defview`s — so the actual `parse-header` →
+  `emit-cljs` header lowering, comparator and manifest all run through the CLJS
+  compiler — then COMPILES and EXECUTES them under node (`react-dom/server`). What
+  it observes is the host itself: the visible bound value, the generated memo
+  comparator's slot set, the published manifest `:prop-slots`, and `:or` default
+  side effects firing per host binding unit.
+
+  The correctness defect it locks (origin/main b0e20ccd): a NESTED or partially
+  overlapping header pattern (`{[x] :other :keys [ns/x]}`) whose earlier unit's
+  every local is reclaimed by a later unit left a DEAD `:other` slot in the
+  DERIVED projection — the memo comparator, the manifest `:prop-slots`, the
+  CLOSED-`:props` set. `collapse-entries` compared whole `:pattern` values, so a
+  vector `[x]` shadowed by a symbol `x` slipped through. The fix sweeps by the
+  LOCALS each pattern binds (`bp/pattern-locals`); the executable plan
+  (`:binding-units`) is untouched, so every initializer still runs."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            ["react-dom/server" :as rds]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.runtime :as rt]))
+
+(defn- render [el] (rds/renderToStaticMarkup el))
+(defn- descriptor [id] (reactive/view-descriptor id))
+(defn- compare-fn [id] (:compare-fn (descriptor id)))
+(defn- prop-slot-keys [id]
+  (mapv :key (get-in (descriptor id) [:manifest :prop-slots])))
+
+;; `:or` default side-effect log — proves each HOST binding unit's initializer
+;; runs, in authored order, on the real host (not a JVM model).
+(defonce ^:private evals (atom []))
+(defn- mark! [tag] (swap! evals conj tag) tag)
+
+(use-fixtures :each {:before (fn [] (reset! evals []))})
+
+;; ---------------------------------------------------------------------------
+;; Fixtures — REAL defviews compiled through the production header lowering
+;; ---------------------------------------------------------------------------
+
+;; The bead's exact defect shape: the nested explicit `[x] <- :other` binds a
+;; local `x` that the qualified group local `x <- :ns/x` fully reclaims. `:other`
+;; contributes NO final visible local → it is a dead derived slot.
+(defview nested-shadow-view
+  [{[x] :other :keys [ns/x]}]
+  [:div.x (str x)])
+
+;; Partial overlap: `[a b] <- :other` and `a <- :ns/a`. The group reclaims `a`,
+;; but `b` is STILL a final visible local reading `:other` — so `:other` must
+;; SURVIVE as a live slot, and the `[a b] <- :other` initializer must run.
+(defview partial-overlap-view
+  [{[a b] :other :keys [ns/a]}]
+  [:div [:span.a (str a)] [:span.b (str b)]])
+
+;; Qualified-group-name collision carrying an `:or` default. Derived slots
+;; collapse to the winner `:ns/x`, but BOTH host units bind the local `x`, so the
+;; default's eager get-arg runs ONCE PER UNIT — executable plan is retained.
+(defview collision-default-view
+  [{:keys [ns/x] x :other :or {x (mark! "D")}}]
+  [:div.x (str x)])
+
+;; Plain defaulted slot: the `:or` default is `get`'s eager third argument, so it
+;; evaluates whether or not the slot is present — the host-faithful count.
+(defview eager-default-view
+  [{:keys [x] :or {x (mark! "E")}}]
+  [:div.x (str x)])
+
+;; ---------------------------------------------------------------------------
+;; The derived-slot defect — comparator + manifest, on the real host
+;; ---------------------------------------------------------------------------
+
+(deftest nested-shadow-drops-the-dead-slot-from-the-real-comparator
+  (testing "the compiled memo comparator ignores the fully-shadowed :other slot"
+    (let [cmp (compare-fn ::nested-shadow-view)]
+      (is (fn? cmp))
+      ;; :ns/x is the ONLY declared slot: props differing only in :other compare
+      ;; EQUAL (no repaint). On origin/main :other was a dead declared slot, so
+      ;; this returned false — a spurious re-render — and this assertion was RED.
+      (is (true? (cmp (js-obj "ns/x" 1 "other" 1)
+                      (js-obj "ns/x" 1 "other" 2)))
+          ":other is not a declared slot — differing :other does not repaint")
+      ;; the live slot still drives the comparator
+      (is (false? (cmp (js-obj "ns/x" 1) (js-obj "ns/x" 2)))
+          ":ns/x is the live slot — a change repaints")))
+  (testing "the published manifest declares only the final visible-local slot"
+    (is (= [:ns/x] (prop-slot-keys ::nested-shadow-view))
+        "manifest :prop-slots carries no dead :other")))
+
+(deftest partial-overlap-keeps-the-slot-a-visible-local-still-reads
+  (testing "the comparator DOES compare :other — b is a final visible local"
+    (let [cmp (compare-fn ::partial-overlap-view)]
+      (is (false? (cmp (js-obj "ns/a" 1 "other" [7 8])
+                       (js-obj "ns/a" 1 "other" [7 9])))
+          ":other stays live because b <- :other survives the collapse")
+      (is (false? (cmp (js-obj "ns/a" 1 "other" [7 8])
+                       (js-obj "ns/a" 2 "other" [7 8])))
+          ":ns/a is live too")))
+  (testing "manifest keeps both live slots"
+    (is (= [:other :ns/a] (prop-slot-keys ::partial-overlap-view))
+        "a partially overlapping pattern keeps the slot its surviving local reads")))
+
+;; ---------------------------------------------------------------------------
+;; Host-faithful bound VALUE — the shadowed initializer is dead, the later wins
+;; ---------------------------------------------------------------------------
+
+(deftest nested-shadow-binds-the-host-winning-value
+  (testing "present :ns/x wins over the shadowed [x] <- :other read"
+    (is (= "<div class=\"x\">1</div>"
+           (render (rt/jsx2 nested-shadow-view (js-obj "ns/x" 1 "other" [9]))))
+        "x resolves to :ns/x (1), never the destructured :other (9)"))
+  (testing "absent :ns/x -> nil, never the dead :other value"
+    (let [html (render (rt/jsx2 nested-shadow-view (js-obj "other" [9])))]
+      (is (= "<div class=\"x\"></div>" html))
+      (is (not (str/includes? html "9"))
+          "the shadowed [x] <- :other binding is dead — its 9 never surfaces"))))
+
+(deftest partial-overlap-binds-both-live-locals-host-faithfully
+  ;; a <- :ns/a (group reclaims it); b <- (second :other). Both initializers run.
+  (is (= "<div><span class=\"a\">1</span><span class=\"b\">8</span></div>"
+         (render (rt/jsx2 partial-overlap-view
+                          (js-obj "ns/a" 1 "other" [7 8]))))
+      "a is the group's :ns/a; b reads the executed [a b] <- :other second slot"))
+
+;; ---------------------------------------------------------------------------
+;; Executable plan retained — every host initializer runs (real CLJS side effects)
+;; ---------------------------------------------------------------------------
+
+(deftest collision-runs-both-unit-defaults-though-slots-collapse
+  (testing "the derived projection collapses to the single winning slot"
+    (is (= [:ns/x] (prop-slot-keys ::collision-default-view))
+        "manifest declares only :ns/x — the dead :other is dropped"))
+  (testing "yet BOTH host binding units execute the eager default, in order"
+    (reset! evals [])
+    (is (= "<div class=\"x\">1</div>"
+           (render (rt/jsx2 collision-default-view (js-obj "ns/x" 1 "other" 2))))
+        "present: :ns/x wins")
+    (is (= ["D" "D"] @evals)
+        "the default's eager get-arg runs once per unit (x<-:other, x<-:ns/x)")
+    (reset! evals [])
+    (is (= "<div class=\"x\">D</div>"
+           (render (rt/jsx2 collision-default-view (js-obj))))
+        "absent: the winning unit falls to its default")
+    (is (= ["D" "D"] @evals)
+        "both units still evaluate their default — executable plan is retained")))
+
+(deftest eager-default-runs-once-present-and-absent
+  (testing "present slot: the eager get-arg default STILL evaluates once"
+    (reset! evals [])
+    (is (= "<div class=\"x\">5</div>"
+           (render (rt/jsx2 eager-default-view (js-obj "x" 5)))))
+    (is (= ["E"] @evals)
+        "the default is get's eager third arg — evaluated even when present"))
+  (testing "absent slot: the default evaluates once and becomes the value"
+    (reset! evals [])
+    (is (= "<div class=\"x\">E</div>"
+           (render (rt/jsx2 eager-default-view (js-obj)))))
+    (is (= ["E"] @evals))))


### PR DESCRIPTION
Closes rf2-iiacq.

## The defect (`parse-header` → `collapse-entries`, `implementation/ui/src/re_frame/ui/compiler/header.cljc`)

On origin/main, `parse-header` mis-derived the effective slots for a **nested or partially overlapping** header pattern. `collapse-entries` de-duped the collapsed projection by whole `:pattern` values, so a vector pattern `[x]` shadowed by a symbol group local `x <- :ns/x` slipped through uncollapsed:

```
(parse-header '[{[x] :other :keys [ns/x]}])
;; origin/main :slots => [:other :ns/x]   ← :other is DEAD
;; fixed       :slots => [:ns/x]
```

Native destructuring runs both initializers but the later `x <- :ns/x` is the only visible local; the `[x] <- :other` unit binds no final visible local. The dead `:other` leaked into the **memo comparator** (spurious re-renders), the **manifest `:prop-slots`** (over-declared), and the **CLOSED-`:props`** set (silently accepts a never-bound key).

## The fix (minimal)

- Added `bp/pattern-locals` to the owned seam `implementation/ui/src/re_frame/ui/compiler/binding_plan.cljc` — the host-faithful set of local symbols a destructuring pattern introduces (name-stripping group locals exactly as `clojure.core/destructure` does).
- Rewrote `collapse-entries` as a **reverse winner sweep**: walk entries last→first, keep an entry only where it binds a local no later entry rebinds. Comparing the **locals** each pattern binds (not whole `:pattern` values) catches the nested `[x]`-shadowed-by-`x` case.

The full executable plan (`:binding-units`) is **untouched** — every host initializer still runs; only the derived slots collapse. A partial overlap `{[a b] :other :keys [ns/a]}` correctly **keeps** `:other` because `b` is still a visible local. No emitter redesign, no new error-id, no new public API.

## Real compiled-CLJS proof

New `implementation/ui/test/re_frame/ui/binding_plan_host_faithful_cljs_test.cljs` — prior binding-plan proofs were all JVM-side emitter/form modelling. This suite defines **real `defview`s**, compiles them through the production header lowering, and **executes them under node** (`react-dom/server`), observing the host itself:

- the generated **memo comparator's** slot set (dead `:other` ignored),
- the published **manifest `:prop-slots`** (`[:ns/x]`, no dead key),
- the **visible bound value** (`:ns/x` wins; absent `:ns/x` → nil, never the shadowed `[x] <- :other` value),
- `:or` default **side effects** firing once per host binding unit (executable plan retained),
- the partial-overlap fixture proving `:other` stays live when a visible local reads it.

**Red-before / green-after** (same test, source reverted to origin/main vs. fixed), on the real compiled-CLJS node lane:

```
origin/main source:  FAIL (nested-shadow-drops-the-dead-slot-from-the-real-comparator)
  expected: (true? (cmp (js-obj "ns/x" 1 "other" 1) (js-obj "ns/x" 1 "other" 2)))
    actual: (not (true? false))               ← comparator repaints on the dead :other
  expected: (= [:ns/x] (prop-slot-keys ...))
    actual: (not (= [:ns/x] [:other :ns/x]))  ← manifest declares the dead :other
  → 2 failures
fixed source:  0 failures
```

## Quality gates

- `cd implementation/ui && clojure -M:test` (ui JVM) — **Ran 774 tests, 14309 assertions, 0 failures, 0 errors** (post-rebase).
- `npm run test:cljs` (consolidated compiled-CLJS node lane; the new proof runs here) — **Ran 9907 tests, 48773 assertions, 0 failures, 0 errors** (post-rebase). One flaky failure on the unrelated Xray resources-panel freshness test `resources_cljs_test.cljs:496` on the first run — not on this diff's surface — passed clean on re-run.

Existing defview parity, the qualified-group-name collision fixture, and G-13/G-14 remain green.
