### PR TITLE
test(epoch): pin nil-evidence cleanup across all five exact-owner stores and hosts (rf2-oh1y8)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -703,3 +703,161 @@
               "the superseded signal no longer matches the current generation — DISCARD")))
       (rf/unregister-listener! :trace ::recorder6)
       (rf/unregister-listener! :epoch ::watcher6))))
+
+;; ---- rf2-oh1y8 — nil-evidence cleanup across every owned store, CLJS host ---
+;;
+;; The JVM peer `destroy-cleans-exact-owner-stores-when-snapshot-evidence-is-nil`
+;; (`re-frame.epoch-test`) directly seeds and asserts each of the FIVE exact-owner
+;; stores `on-frame-destroyed!`'s cleanup-fn drops. `re-frame.epoch.state` is a
+;; host-shared `.cljc`, but owner serialization differs by host (`locking` on JVM
+;; vs synchronous direct execution on CLJS), and rf2-hclxos called for BOTH hosts.
+;; These two synchronous CLJS fixtures close that gap:
+;;
+;;   1. the #5939 nil-evidence path drops all five stores AND fabricates nothing —
+;;      re-nesting cleanup under the evidence guard fails causally;
+;;   2. a stale predecessor A resuming with nil evidence CANNOT erase a claimed
+;;      same-id B's stores (the compare-owned no-op). The equivalent JVM invariant
+;;      lives in `frame-destroy-incarnation-jvm-test`.
+
+(deftest destroy-cleans-exact-owner-stores-when-snapshot-evidence-is-nil-cljs
+  (testing "rf2-oh1y8 (synchronous CLJS) — a throwing :epoch/snapshot-frame-
+            destroyed hook yields nil terminal-evidence (#5939), but the destroyed
+            incarnation's FIVE id-keyed epoch stores are STILL dropped, and the
+            nil bundle publishes/fabricates nothing. Each store is seeded and
+            asserted directly, so re-nesting cleanup under the evidence guard — or
+            removing any single drop — fails exactly its assertion."
+    (let [id            :rf2-oh1y8/nil-evidence
+          cb            ::rf2-oh1y8-nil-evidence-cb
+          render-key    ::rf2-oh1y8-nil-evidence-view
+          records       (atom [])
+          traces        (atom [])
+          original-snap (late-bind/get-fn :epoch/snapshot-frame-destroyed)]
+      (rf/make-frame {:id id})
+      (rf/reg-event :rf2-oh1y8/seed (fn [_ _] {:db {:audit/seed :from-A}}))
+      ;; cb OBSERVES A: fanning the settled record stamps its observation, so a
+      ;; fabricating publish would have a real observer to (wrongly) silence.
+      (rf/register-listener! :epoch cb (fn [r] (swap! records conj r)))
+      (rf/register-listener! :trace ::rf2-oh1y8-nil-evidence-trace
+        (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:rf2-oh1y8/seed] {:frame id})
+      (reset! records [])                          ; drop the :seed :ok record
+      (let [a-epoch-id (:epoch-id (first (rf/epoch-history id)))]
+        ;; The cascade seeds history + last-settled + cb's observation. Seed the two
+        ;; the synchronous cascade cannot: the harvested-empty capture buffer and
+        ;; the render mount-attribution (no React commit).
+        (state/buffer-event! id {:operation :rf.event/run-start
+                                 :tags {:rf.trace/dispatch-id ::seed-dispatch}})
+        (state/record-mount-epoch! id render-key a-epoch-id)
+        (state/record-render-deps! id render-key ::a-sub)
+
+        ;; PRE-DESTROY: all five exact-owner stores hold A's state.
+        (is (contains? (set (state/cbs-observing-frame id)) cb)
+            "observation stamp seeded — cb observed A")
+        (is (= 1 (count (state/history-for id)))
+            "history seeded — A settled one epoch")
+        (is (seq (state/buffer-for id))
+            "capture buffer seeded")
+        (is (some? (state/last-settled-epoch-id id))
+            "last-settled epoch seeded")
+        (is (some? (state/mount-epoch-for id render-key))
+            "mount attribution seeded")
+        (try
+          (late-bind/set-fn! :epoch/snapshot-frame-destroyed
+            (fn [& args]
+              (if (= id (first args))
+                (throw (ex-info "snapshot blew" {:why :test}))
+                (when original-snap (apply original-snap args)))))
+          (rf/destroy-frame! id)
+
+          ;; (1) All five id-keyed stores are dropped despite the nil bundle.
+          (is (empty? (state/cbs-observing-frame id))
+              "observation stamps dropped (drop-frame-observation!)")
+          (is (= [] (state/history-for id))
+              "history dropped (drop-frame-history!)")
+          (is (empty? (state/buffer-for id))
+              "capture buffer dropped (drop-frame-buffer!)")
+          (is (nil? (state/last-settled-epoch-id id))
+              "last-settled epoch dropped (drop-last-settled-epoch!)")
+          (is (nil? (state/mount-epoch-for id render-key))
+              "mount attribution dropped (drop-frame-mount-attribution!)")
+          (is (nil? (state/render-deps-for id render-key))
+              "mount attribution read-set dropped with the frame's entry")
+          (is (= [] (rf/epoch-history id))
+              "public epoch-history is [] even though the snapshot threw")
+          (is (nil? (frame/frame-incarnation-token id))
+              "A is fully destroyed — no live incarnation owns the id")
+
+          ;; (2) #5939 NON-FABRICATION: the nil bundle publishes/opens nothing.
+          (is (empty? (filter #(= :halted-destroy (:outcome %)) @records))
+              "no :halted-destroy record is fabricated from the nil bundle")
+          (is (empty? (filter #(= :rf.epoch.cb/silenced-on-frame-destroy
+                                  (:operation %))
+                              @traces))
+              "no silencing fires — the nil bundle owed none")
+          (is (zero? (reduce + 0 (map count
+                                      (vals (state/terminal-silence-marks-snapshot)))))
+              "a nil bundle opens no deferred-silence window — no mark accreted")
+          (finally
+            (late-bind/set-fn! :epoch/snapshot-frame-destroyed original-snap)
+            (when (frame/frame id) (rf/destroy-frame! id))
+            (rf/unregister-listener! :epoch cb)
+            (rf/unregister-listener! :trace ::rf2-oh1y8-nil-evidence-trace)))))))
+
+(deftest stale-a-nil-evidence-cleanup-cannot-erase-claimed-same-id-b-cljs
+  (testing "rf2-oh1y8 (synchronous CLJS) — a stale predecessor A resuming with NIL
+            terminal-evidence runs its exact-owner cleanup, but a same-id successor
+            B already CLAIMED the id-keyed stores. A LOSES the compare-owned
+            comparison, so its cleanup no-ops and cannot erase ANY of B's five
+            exact-owner stores. The equivalent JVM invariant lives in
+            frame-destroy-incarnation-jvm-test."
+    (let [id         :rf2-oh1y8-stale/frame
+          cb         ::rf2-oh1y8-stale-cb
+          render-key ::rf2-oh1y8-stale-view
+          token-a    #js {}
+          token-b    #js {}
+          b-record   {:frame id :epoch-id 2 :outcome :ok :db-after {:audit/seed :from-B}}]
+      (rf/register-listener! :epoch cb (fn [_] nil))
+      (try
+        ;; A claims + cb observes A (the state a live incarnation holds before its
+        ;; nil-evidence destroy is deferred past a same-id successor).
+        (state/claim-frame-owner! id token-a)
+        (epoch.listeners/notify-listeners! {:frame id :epoch-id 1})
+        ;; Same-id B claims the id-keyed stores (dropping A's), then seeds ALL FIVE
+        ;; of its own.
+        (state/claim-frame-owner! id token-b)
+        (epoch.listeners/notify-listeners! b-record)   ; cb re-observes under B
+        (state/record! b-record)                       ; history
+        (state/set-last-settled-epoch! id 2)           ; last-settled
+        (state/buffer-event! id {:operation :rf.event/run-start
+                                 :tags {:rf.trace/dispatch-id ::b-dispatch}}) ; buffer
+        (state/record-mount-epoch! id render-key 2)    ; mount attribution
+        (state/record-render-deps! id render-key ::b-sub)
+
+        ;; PRE-RESUME: B's five stores are populated.
+        (is (contains? (set (state/cbs-observing-frame id)) cb))
+        (is (= [b-record] (state/history-for id)))
+        (is (seq (state/buffer-for id)))
+        (is (= 2 (state/last-settled-epoch-id id)))
+        (is (= 2 (state/mount-epoch-for id render-key)))
+
+        ;; Stale A resumes with NIL evidence: cleanup loses the comparison to B.
+        (epoch.listeners/on-frame-destroyed! id token-a nil)
+
+        ;; B's FIVE stores are byte-identical — A's stale cleanup no-op'd.
+        (is (contains? (set (state/cbs-observing-frame id)) cb)
+            "B's observation survives A's stale nil-evidence cleanup")
+        (is (= [b-record] (state/history-for id))
+            "B's history survives")
+        (is (seq (state/buffer-for id))
+            "B's capture buffer survives")
+        (is (= 2 (state/last-settled-epoch-id id))
+            "B's last-settled anchor survives")
+        (is (= 2 (state/mount-epoch-for id render-key))
+            "B's mount attribution survives")
+        (is (= #{::b-sub} (state/render-deps-for id render-key))
+            "B's mount read-set survives")
+        (finally
+          ;; B tears itself down (token-b owns → cleanup runs) and releases the
+          ;; owner ledger, then unregister cb.
+          (epoch.listeners/on-frame-destroyed! id token-b nil)
+          (rf/unregister-listener! :epoch cb))))))

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -4034,9 +4034,14 @@
   (testing "a throwing :epoch/snapshot-frame-destroyed hook yields nil terminal-
             evidence (#5939), but the destroyed incarnation's id-keyed epoch stores
             are STILL dropped — cleanup authority is the frame-id + owner-token, not
-            the snapshot bundle — so a same-id successor B inherits nothing (rf2-hclxos)"
+            the snapshot bundle — so a same-id successor B inherits nothing (rf2-hclxos).
+            Directly SEEDS and ASSERTS each of the FIVE exact-owner stores the
+            cleanup-fn drops — observation stamps, history, capture buffer,
+            last-settled epoch, mount attribution — so neutering ANY single drop
+            fails exactly its assertion (rf2-oh1y8)."
     (let [id            :test/nil-evidence-cleanup
           cb            ::nil-evidence-cb
+          render-key    ::nil-evidence-view   ; mount-attribution key for store #5
           records       (atom [])
           traces        (record-trace!)
           original-snap (late-bind/get-fn :epoch/snapshot-frame-destroyed)]
@@ -4048,10 +4053,31 @@
       (rf/register-listener! :epoch cb (fn [r] (swap! records conj r)))
       (rf/dispatch-sync [:seed] {:frame id})
       (reset! records [])                          ; drop the :seed :ok record
-      (let [a-token (frame/frame-incarnation-token id)]
-        ;; A settled one epoch: its id-keyed history holds the [:audit/seed] record.
-        (is (= 1 (count (rf/epoch-history id)))
-            "A settled one epoch before destroy")
+      (let [a-token   (frame/frame-incarnation-token id)
+            a-epoch-id (:epoch-id (first (rf/epoch-history id)))]
+        ;; A settled one epoch: the cascade already seeded three of the five stores
+        ;; — history (the [:audit/seed] record), last-settled-epoch (the settle
+        ;; anchor), and cb's observation stamp (fanning the settled record to the
+        ;; :epoch listener). The synchronous JVM cascade cannot populate the other
+        ;; two: the in-flight capture buffer is harvested empty at settle, and there
+        ;; is no React commit to record mount attribution. SEED those two directly so
+        ;; every one of the five exact-owner stores holds A's state before destroy.
+        (state/buffer-event! id {:operation :rf.event/run-start
+                                 :tags {:rf.trace/dispatch-id ::seed-dispatch}})
+        (state/record-mount-epoch! id render-key a-epoch-id)
+        (state/record-render-deps! id render-key ::a-sub)
+
+        ;; PRE-DESTROY: all five exact-owner stores are non-empty for A's id.
+        (is (contains? (set (state/cbs-observing-frame id)) cb)
+            "observation stamp seeded — cb observed A's settled record")
+        (is (= 1 (count (state/history-for id)))
+            "history seeded — A settled one epoch")
+        (is (seq (state/buffer-for id))
+            "capture buffer seeded — an in-flight event is buffered")
+        (is (some? (state/last-settled-epoch-id id))
+            "last-settled epoch seeded — A's settle anchored it")
+        (is (some? (state/mount-epoch-for id render-key))
+            "mount attribution seeded — render-key anchored to A's epoch")
         (is (= :from-A (get-in (first (rf/epoch-history id)) [:db-after :audit/seed]))
             "A's settled record carries [:audit/seed] :from-A")
         (try
@@ -4066,8 +4092,24 @@
                 (when original-snap (apply original-snap args)))))
           (rf/destroy-frame! id)
 
-          ;; (1) EXACT-OWNER STORE CLEANUP ran despite the nil bundle — the destroyed
-          ;;     id's history is [] (it still equalled A's [:audit/seed] before fix).
+          ;; (1) EXACT-OWNER STORE CLEANUP ran despite the nil bundle. Each of the
+          ;;     FIVE id-keyed stores the cleanup-fn drops is asserted directly, so
+          ;;     re-nesting cleanup under the evidence guard — or removing ANY single
+          ;;     drop call — fails exactly the matching assertion (rf2-oh1y8).
+          (is (empty? (state/cbs-observing-frame id))
+              "observation stamps dropped (drop-frame-observation!)")
+          (is (= [] (state/history-for id))
+              "history dropped (drop-frame-history!)")
+          (is (empty? (state/buffer-for id))
+              "capture buffer dropped (drop-frame-buffer!)")
+          (is (nil? (state/last-settled-epoch-id id))
+              "last-settled epoch dropped (drop-last-settled-epoch!)")
+          (is (nil? (state/mount-epoch-for id render-key))
+              "mount attribution dropped (drop-frame-mount-attribution!)")
+          (is (nil? (state/render-deps-for id render-key))
+              "mount attribution read-set dropped with the frame's entry")
+          ;; The public projection agrees with the raw store, and the incarnation
+          ;; is gone.
           (is (= [] (rf/epoch-history id))
               "destroyed id's epoch-history is [] even though the snapshot threw")
           (is (nil? (frame/frame-incarnation-token id))


### PR DESCRIPTION
## Summary

PR #6091 (rf2-hclxos) made `on-frame-destroyed!`'s exact-owner store cleanup run
independently of optional terminal evidence. That runtime is correct — this PR
**proves** it with real teeth, test-only, **no runtime change**.

The gap the audit (rf2-qf479) found: the nil-evidence regression asserted only
**history** (via public `epoch-history`) and only on **JVM**. Removing any of the
four *other* drop calls left the fixture green, and there was no synchronous CLJS
nil-evidence cleanup fixture nor a CLJS stale-A / claimed-B comparison.

## The five exact-owner stores

`on-frame-destroyed!`'s cleanup-fn (`implementation/epoch/src/re_frame/epoch/listeners.cljc`) drops:

1. **observation stamps** — `state/drop-frame-observation!`
2. **history** — `state/drop-frame-history!`
3. **capture buffer** — `state/drop-frame-buffer!`
4. **last-settled epoch** — `state/drop-last-settled-epoch!`
5. **mount attribution** — `state/drop-frame-mount-attribution!`

## Changes (test-only)

- **JVM** `destroy-cleans-exact-owner-stores-when-snapshot-evidence-is-nil`
  (`epoch_test.clj`) now directly **seeds** each of the five stores for the
  destroyed id (cascade seeds history + last-settled + observation; the buffer
  and mount attribution are seeded directly since the synchronous cascade can't
  populate them) and **asserts each is dropped** after a throwing
  `:epoch/snapshot-frame-destroyed` hook yields nil evidence (#5939).
- **CLJS** `destroy-cleans-exact-owner-stores-when-snapshot-evidence-is-nil-cljs`
  (`epoch_cljs_test.cljs`) mirrors that synchronously and additionally pins
  non-fabrication (no terminal record / silencing / accreted deferred-silence
  mark).
- **CLJS** `stale-a-nil-evidence-cleanup-cannot-erase-claimed-same-id-b-cljs`
  proves a stale predecessor A resuming with nil evidence loses the compare-owned
  comparison to a claimed same-id B and cannot erase any of B's five stores. The
  equivalent JVM invariant already lives in `frame-destroy-incarnation-jvm-test`.

## Quality gates

Runtime (`listeners.cljc`, `state.cljc`) is **unchanged** — verified `git status`
clean after every red-before probe.

- **JVM** `clojure -M:test -n re-frame.epoch-test`: 162 tests, 734 assertions, 0 failures, 0 errors.
- **CLJS** `npm run test:cljs` (across-hosts gate): 9903 tests, 48780 assertions, 0 failures, 0 errors.
- **Red-before / green-after, per store (JVM):** neutering each single drop call fails exactly that store's assertion —
  observation (1 fail), history (4 — the history-reading asserts), capture buffer (1), last-settled epoch (1), mount attribution (2 — mount-epoch + read-set). Restoring the drop → 21/21 pass.
- **Red-before (CLJS):** re-nesting the cleanup under `(when terminal-evidence …)` (the exact pre-#6091 regression) fails all five store-cleared assertions in the synchronous CLJS fixture causally. Restoring → green.

Closes rf2-oh1y8.
