### PR TITLE
ci: make Clojure toolchain install resilient to transient network flake (rf2-9sgj8)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -180,10 +180,22 @@ jobs:
           node-version: '24'
 
       - name: Set up Clojure CLI (SCI bundle build)
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs (playground SCI bundle deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -22,10 +22,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -104,10 +116,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -153,10 +177,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -249,10 +285,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -264,10 +264,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (below) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -337,10 +349,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (below) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/post-merge-playground-freshness.yml
+++ b/.github/workflows/post-merge-playground-freshness.yml
@@ -131,10 +131,22 @@ jobs:
           node-version: '24'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs (playground SCI bundle deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/release-xray.yml
+++ b/.github/workflows/release-xray.yml
@@ -122,10 +122,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -166,10 +178,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,10 +165,22 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -304,10 +316,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -443,10 +467,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/template-release.yml
+++ b/.github/workflows/template-release.yml
@@ -154,10 +154,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       # rf2-ek857f F1 — Node.js is required for the emitted-app smoke in
       # `emitted_test_run_test.clj` (compiles + runs the emitted

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -556,10 +556,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -604,10 +616,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -649,10 +673,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -874,10 +910,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -922,10 +970,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -968,10 +1028,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1016,10 +1088,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1065,10 +1149,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1111,10 +1207,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1159,10 +1267,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1197,10 +1317,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1235,10 +1367,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1273,10 +1417,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1322,10 +1478,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1375,10 +1543,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1431,10 +1611,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1480,10 +1672,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1525,10 +1729,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1570,10 +1786,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1616,10 +1844,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1683,10 +1923,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1732,10 +1984,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -1848,10 +2112,22 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1948,10 +2224,22 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2019,10 +2307,22 @@ jobs:
           node-version: '24'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs (framework + shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2071,10 +2371,22 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2138,10 +2450,22 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2207,10 +2531,22 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2261,10 +2597,22 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2323,10 +2671,22 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2399,10 +2759,22 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs (Story/Xray shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2553,10 +2925,22 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2670,10 +3054,22 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2752,10 +3148,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2797,10 +3205,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2843,10 +3263,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2897,10 +3329,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       # rf2-80y2h: mcp-base now carries a CLJS test target (shadow-cljs
       # :node-test build) covering the `.cljc` `:cljs` reader-conditional
@@ -2967,10 +3411,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       # rf2-ir6a0 — Node.js is required for the
       # `emitted_test_run_test.clj` slice (compiles + runs the emitted
@@ -3066,10 +3522,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -3149,10 +3617,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -3245,10 +3725,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -3408,10 +3900,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -3489,10 +3993,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -3518,10 +4034,21 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Babashka
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          bb: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Babashka install (same setup-clojure curl-35 /
+        # socket-hang-up flake class as the Clojure CLI installs above).
+        # Reuses the repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff
+        # loop; the bb installer pulls from raw.githubusercontent.com, which
+        # 429s under rate limiting — hence --retry-all-errors (lint.yml note).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/bb-install \
+              https://raw.githubusercontent.com/babashka/babashka/master/install \
+              && sudo bash /tmp/bb-install && break
+            echo "Babashka install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          bb --version
 
       - name: Run re-frame2-pair structural tests
         working-directory: skills/re-frame2-pair
@@ -3602,10 +4129,22 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -3687,10 +4226,22 @@ jobs:
           node-version: '24'
 
       - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
+        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
+        # hang-up reds the JVM job in setup before any test runs. Reuses the
+        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
+        # the whole download+install (no github-token needed — the
+        # releases/latest/download redirect hits no GitHub API).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+              && sudo bash /tmp/linux-install.sh && break
+            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+            sleep "$((attempt * 10))"
+          done
+          clojure --version
 
       - name: Cache Maven / gitlibs (playground SCI bundle deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -777,7 +777,17 @@ test('cljs job provisions Clojure CLI before the G-12 isolation gate (rf2-3kewru
   assert.notEqual(setup, -1, 'cljs job must install Clojure CLI for G-12 Arm 2');
   assert.notEqual(gate, -1, 'cljs job must run the UI isolation gate');
   assert.ok(setup < gate, 'Clojure CLI setup must precede the G-12 isolation gate');
-  assert.match(block, /DeLaGuardo\/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2/);
+  // rf2-9sgj8 — the install now runs the official linux-install.sh directly
+  // with retry (resilient against the transient curl-35 / socket-hang-up that
+  // reds setup) instead of DeLaGuardo/setup-clojure. It is still a real Clojure
+  // CLI provision, which is all Arm 2's `clojure -Stree` needs — assert the
+  // install actually downloads+installs the CLI rather than pinning the
+  // (now-removed) action SHA.
+  assert.match(
+    block,
+    /brew-install\/releases\/latest\/download\/linux-install\.sh/,
+    'cljs job must install the Clojure CLI for Arm 2 `clojure -Stree` (rf2-9sgj8 resilient install)',
+  );
 });
 
 // rf2-vxgfnd.135 — the tracked synthesis guide/drafts are authoritative


### PR DESCRIPTION
Fixes the recurring **CI false-red** where a JVM job dies in *setup* with
`curl: (35) Recv failure: Connection reset by peer` / `socket hang up`
during the Clojure toolchain download — a transient network drop, **not** a
test failure. The tests never run; the job reds before any of them start.
Observed 6+ times (qxgve derivation-conformance, leeqp story-mcp, 1g5rt JVM
ssr, fnkmi JVM core), each forcing a manual re-run and risking a wrong
`--admin` merge.

## Root cause

Every JVM job installs the toolchain via `DeLaGuardo/setup-clojure`, whose
internal `linux-install.sh` curl has **no retry**. A single reset during the
CLI/tools-zip download fails the whole step.

## Fix

Replace each `setup-clojure` install step with a direct, **retrying** install
that reuses the repo's own blessed resilient-curl idiom — the exact
`curl --retry 5 --retry-all-errors --retry-delay 3` pattern already used for
the clj-kondo install in `lint.yml` — wrapped in a 3× backoff loop so a
mid-install tools-zip drop retries the whole download+install, not just the
script fetch:

```yaml
run: |
  set -euo pipefail
  for attempt in 1 2 3; do
    curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
      https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
      && sudo bash /tmp/linux-install.sh && break
    echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
    sleep "$((attempt * 10))"
  done
  clojure --version
```

The `releases/latest/download` redirect hits no GitHub API, so `github-token`
is no longer needed. Behaviour is otherwise unchanged — `latest` still
resolves to the latest stable CLI, exactly as `cli: latest` did.

### Why retry (not a new action or a composite)

The repo uses **no** retry action, so per the bead's prescription this is a
`run:` retry loop around a manual install — reusing the pattern already in
`lint.yml` rather than introducing a new third-party dependency. Caching alone
would not cure a transient drop (a cache miss still downloads and can still
reset); retry is the direct cure.

## Scope

Applied **consistently** to all **60** install sites — 59 Clojure CLI + 1
Babashka (the `skills-structural` job's `bb` install, same flake class) —
across `docs.yml`, `expensive-tests.yml`, `lint.yml`,
`post-merge-playground-freshness.yml`, `release-xray.yml`, `release.yml`,
`template-release.yml`, and `test.yml`. **No test logic changed** — pure
CI-infra resilience. Only `.github/workflows/*.yml` touched.

## Quality gates

- **YAML parse**: all 8 edited workflows parse under `yaml.safe_load` ✅
- **Bash syntax**: both install scripts (CLI + bb) pass `bash -n` ✅
- **Retry control flow**: simulated fail-twice-then-succeed under
  `set -euo pipefail` — errexit correctly survives failed attempts (the `&&`
  chain suppresses it for non-final commands), retries with backoff, and
  breaks cleanly on success ✅
- **Consistency**: zero `uses: DeLaGuardo/setup-clojure` references remain;
  60 resilient installs in place (59 CLI + 1 bb) ✅
- **Full validation is CI-side** (sanctioned for this infra change): the
  retry/backoff only exercises under a real network blip, which can't be
  reproduced locally. Because a `test.yml` change trips the changed-surface
  classifier's `mark_all`, this PR's CI runs **every** JVM job, exercising the
  new install path across all of `test.yml`'s install steps. The tag-triggered
  release workflows (`release*.yml`, `template-release.yml`) don't run on a PR;
  their install block is identical to the validated ones.

## Note for reviewer

The 60 install steps are near-duplicates because GitHub Actions has no native
step-level retry for a `uses:` action and offers no YAML-anchor DRY. A tiny
composite action (`.github/actions/…`) could collapse this to one place if you
prefer — deliberately **not** done here per the bead's "don't build a composite
action from scratch" guidance and the workflows-only surface fence. Easy
fast-follow if desired.

Closes rf2-9sgj8.
