### PR TITLE
fix(core): make captured subscribe one exact-incarnation operation across all seams (rf2-7w1im)

### DIFF
--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -492,6 +492,17 @@
    :runtime-db  frame/runtime-db-container
    :frame-state frame/frame-state-container})
 
+(def ^:private single-source-container-slot-for
+  "`input-kind → frame-RECORD slot` for the single-source container. Mirrors
+  `single-source-container-for`, whose fns re-resolve `frame-id` through the
+  registry (`(k (frame id))`) — this reads the slot off an ALREADY-resolved
+  record instead. A CAPTURED build (rf2-7w1im) reads its lone signal source off
+  the exact incarnation record the outer fence validated, never a same-id
+  successor re-resolved by bare id in the post-comparison window."
+  {:db          :app-db
+   :runtime-db  :runtime-db
+   :frame-state :frame-state})
+
 ;; ---- the cache ------------------------------------------------------------
 
 (defn- cache-key
@@ -920,6 +931,35 @@
   (-> (into [] (comp (drop-while #(not= query-v %)) (map first)) building)
       (conj (first query-v))))
 
+(defn- emit-frame-destroyed-recovery!
+  "Fan the always-on + dev-trace `:rf.error/frame-destroyed` recovery signal for a
+  subscribe that resolved a missing/destroyed frame — or, for a CAPTURED read, a
+  same-id successor whose incarnation differs from the pinned
+  `expected-incarnation` (rf2-dlld6 / rf2-7w1im). No exception (an invalid op);
+  recovery is `:replaced-with-default` (nil), `elapsed-ms 0`. Reached via the
+  `:error-emit/emit-error-both` late-bind hook (subs cannot static-require
+  error-emit — load cycle). Shared by BOTH seams of the one exact-incarnation
+  captured subscribe operation — the outer `subscribe-in-frame` fence and the
+  durable `build-and-cache!*` fence — so a stale capture emits identically
+  wherever the supersession is detected."
+  [frame-id query-v]
+  (when-let [emit-error-both!
+             (late-bind/get-fn-cached :error-emit/emit-error-both)]
+    (emit-error-both!
+      :rf.error/frame-destroyed
+      query-v                       ;; attempted query-vector (as :event)
+      (first query-v)               ;; sub-id (as :event-id)
+      frame-id
+      nil                           ;; no exception — invalid op
+      0                             ;; elapsed-ms
+      (interop/now-ms)              ;; time
+      {:frame    frame-id
+       :query-v  query-v
+       :recovery :replaced-with-default}))
+  ;; RECOVER to nil (the `:replaced-with-default` value the subscribe surfaces),
+  ;; independent of the emit hook's own return.
+  nil)
+
 (defn- build-and-cache!*
   "Build the reaction for query-v and cache it. Per Spec 006 §Lookup
   algorithm: recursively resolve the input query-vectors (the literal
@@ -953,8 +993,34 @@
   nil-yielding reaction, but DO NOT store it in the cache. The miss is
   transient — a later registration (boot order, lazy load) must let the
   next subscribe build a fresh reaction against the real body. We
-  achieve this by branching here on nil meta."
-  [frame-id query-v]
+  achieve this by branching here on nil meta.
+
+  `expected-incarnation` (rf2-7w1im) is the EXACT incarnation token a captured
+  subscribe pinned, threaded through from `subscribe-in-frame`. It makes the
+  DURABLE build one exact-incarnation operation: the frame record is resolved
+  ONCE here and, when the token is non-nil, VALIDATED against it up front — a
+  same-id successor installed in the window between the outer `subscribe-in-frame`
+  comparison and this build recover-but-emits `:rf.error/frame-destroyed` and
+  returns nil rather than reading the successor's container, recursively
+  resolving inputs in it, or installing/adopting a reaction in its sub-cache. The
+  validated record then feeds the container read, the recursive input subscribes,
+  and the cache write — so nothing re-resolves the bare id back to the successor.
+  A nil `expected-incarnation` (ambient / address-directed) re-resolves by id
+  exactly as before — unchanged."
+  [frame-id query-v expected-incarnation]
+  (let [frame-record (frame/frame frame-id)]
+   (if (and (some? expected-incarnation)
+            (or (nil? frame-record)
+                (not (identical? expected-incarnation
+                                 (:drain-lock frame-record)))))
+     ;; rf2-7w1im: the captured incarnation was superseded between the outer
+     ;; subscribe-in-frame comparison and this durable build — recover-but-emit
+     ;; and DO NOT read/build/cache into the same-id successor (identical posture
+     ;; to the outer fence; one exact-incarnation operation).
+     (do (emit-frame-destroyed-recovery! frame-id query-v) nil)
+     ;; else — the existing build, against the validated `frame-record` for a
+     ;; captured read (never a bare-id re-resolve), or re-resolved by id for the
+     ;; unchanged ambient/address-directed path.
   (let [query-id      (first query-v)
         sub-meta      (registrar/lookup :sub query-id)
         _             (when (nil? sub-meta)
@@ -1046,7 +1112,14 @@
         ;; `:frame-state` container propagates on a change to EITHER partition.
         ;; Layer-2+ subscribes each realized input.
         inputs        (cond
-                        container-fn [(container-fn frame-id)]
+                        ;; rf2-7w1im: a CAPTURED build reads its lone single-source
+                        ;; signal off the VALIDATED record (never a bare-id
+                        ;; re-resolve that could land on a same-id successor); the
+                        ;; ambient/address-directed build re-resolves by id as before.
+                        container-fn [(if (some? expected-incarnation)
+                                        (get frame-record
+                                             (single-source-container-slot-for input-kind))
+                                        (container-fn frame-id))]
                         input-error? []
                         ;; Push this query-v onto the per-thread build stack for
                         ;; the duration of input resolution ONLY (rf2-x76af2.24):
@@ -1080,8 +1153,17 @@
                                        ;; unchanged.
                                        (let [acquired (volatile! [])]
                                          (try
+                                           ;; rf2-7w1im: fence the recursive input
+                                           ;; subscribes to the SAME captured
+                                           ;; incarnation — a same-id successor
+                                           ;; installed mid-build cannot have this
+                                           ;; layer-2+ sub recursively resolve its
+                                           ;; inputs in it. nil (ambient) is the
+                                           ;; unchanged 2-arity input read.
                                            (mapv (fn [input-q]
-                                                   (let [r (subscribe-in-frame frame-id input-q)]
+                                                   (let [r (subscribe-in-frame
+                                                             frame-id input-q
+                                                             expected-incarnation)]
                                                      (vswap! acquired conj input-q)
                                                      r))
                                                  input-qs)
@@ -1140,7 +1222,14 @@
         ;; re-materializes cleanly on the next subscribe.
         sub-meta      (when-not input-error? sub-meta)
         input-signals input-qs
-        cache         (:sub-cache (frame/frame frame-id))
+        ;; rf2-7w1im: a CAPTURED build installs/adopts into the VALIDATED
+        ;; incarnation's sub-cache (never a bare-id re-resolve that could adopt a
+        ;; same-id successor's cache); the ambient/address-directed build
+        ;; re-resolves by id as before (nil when the frame was torn down mid-build,
+        ;; driving the not-cached symmetric-release branch unchanged).
+        cache         (if (some? expected-incarnation)
+                        (:sub-cache frame-record)
+                        (:sub-cache (frame/frame frame-id)))
         k             (cache-key query-v)]
     ;; EP-0025 — sub-output sensitivity PROPAGATION is removed. A sub no longer
     ;; inherits its inputs' (or its layer-1 app-db's) sensitivity; there is no
@@ -1219,7 +1308,9 @@
                                     m)))]
                 (if (identical? winner-reaction (get-in post [k :reaction]))
                   winner-reaction
-                  (compute-and-cache! frame-id query-v)))))))
+                  ;; rf2-7w1im: the collision-retry rebuild stays fenced to the
+                  ;; SAME captured incarnation.
+                  (compute-and-cache! frame-id query-v expected-incarnation)))))))
       ;; Not cached (frame torn down mid-build, or no-such-sub miss).
       ;; Symmetric input release on the escaped-caching path: a layer-2+ build
       ;; already subscribed each `:<-` input above (bumping their ref-counts),
@@ -1239,7 +1330,7 @@
                    (seq input-signals))
           (doseq [input-q input-signals]
             (release-input-ref! frame-id input-q :not-cached-release)))
-        reaction))))
+        reaction))))))
 
 (defn- compute-and-cache!
   "Cycle-guarding entry to the reactive sub build (rf2-x76af2.24). Detects a
@@ -1248,39 +1339,45 @@
   recovers it to a structured `:rf.error/sub-cycle` + nil-yielding reaction
   instead of a raw host StackOverflowError. Delegates the actual
   materialisation to `build-and-cache!*`, which pushes the per-thread marker
-  across its input resolution."
-  [frame-id query-v]
-  (let [construction-key [frame-id (cache-key query-v)]
-        stack            *subs-under-construction*]
-    (when (some #(= construction-key %) stack)
-      ;; This query-v is already resolving its inputs higher on the stack — a
-      ;; `:<-` cycle. Throw the sentinel to unwind the WHOLE partial build so no
-      ;; half-wired cyclic reaction is cached; the outermost build (below)
-      ;; catches it, emits the diagnostic error and recovers to nil.
-      (throw (sub-cycle-ex frame-id query-v
-               (sub-cycle-path stack construction-key query-v))))
-    (if (empty? stack)
-      ;; Outermost build: a cycle thrown anywhere in the input recursion unwinds
-      ;; to here. Emit the structured error (diagnostic, mirroring flow-cycle)
-      ;; and recover to a nil-yielding reaction — NOT cached, mirroring the
-      ;; no-such-sub miss so a later registration fix rebuilds cleanly.
-      (try
-        (build-and-cache!* frame-id query-v)
-        (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
-          (if (= :rf.error/sub-cycle (:rf.error/id (ex-data e)))
-            (do
-              (emit-sub-cycle! frame-id query-v (:cycle (ex-data e)) :subscribe)
-              ;; Observation-port acquire path only (rf2-vxgfnd.27): record the
-              ;; cycle so `acquire!` throws typed `:rf.error/sub-cycle`
-              ;; (fail-loud → the ViewCell error boundary) rather than lease
-              ;; this never-cached nil reaction. sub-cycle stays DIAGNOSTIC (009
-              ;; catalogue) — the port throws the typed carrier but does NOT
-              ;; promote it to the always-on axis. No-op on the subscribe path.
-              (record-acquire-recovery! :cycle {:cycle   (:cycle (ex-data e))
-                                                :query-v query-v})
-              (adapter/make-derived-value [] (constantly nil)))
-            (throw e))))
-      (build-and-cache!* frame-id query-v))))
+  across its input resolution.
+
+  `expected-incarnation` (rf2-7w1im, 3-arity) is the captured incarnation token
+  threaded straight through to `build-and-cache!*`'s exact-incarnation fence; nil
+  (the observation-port acquire path + the ambient/address-directed miss) is the
+  unchanged bare-id build."
+  ([frame-id query-v] (compute-and-cache! frame-id query-v nil))
+  ([frame-id query-v expected-incarnation]
+   (let [construction-key [frame-id (cache-key query-v)]
+         stack            *subs-under-construction*]
+     (when (some #(= construction-key %) stack)
+       ;; This query-v is already resolving its inputs higher on the stack — a
+       ;; `:<-` cycle. Throw the sentinel to unwind the WHOLE partial build so no
+       ;; half-wired cyclic reaction is cached; the outermost build (below)
+       ;; catches it, emits the diagnostic error and recovers to nil.
+       (throw (sub-cycle-ex frame-id query-v
+                (sub-cycle-path stack construction-key query-v))))
+     (if (empty? stack)
+       ;; Outermost build: a cycle thrown anywhere in the input recursion unwinds
+       ;; to here. Emit the structured error (diagnostic, mirroring flow-cycle)
+       ;; and recover to a nil-yielding reaction — NOT cached, mirroring the
+       ;; no-such-sub miss so a later registration fix rebuilds cleanly.
+       (try
+         (build-and-cache!* frame-id query-v expected-incarnation)
+         (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+           (if (= :rf.error/sub-cycle (:rf.error/id (ex-data e)))
+             (do
+               (emit-sub-cycle! frame-id query-v (:cycle (ex-data e)) :subscribe)
+               ;; Observation-port acquire path only (rf2-vxgfnd.27): record the
+               ;; cycle so `acquire!` throws typed `:rf.error/sub-cycle`
+               ;; (fail-loud → the ViewCell error boundary) rather than lease
+               ;; this never-cached nil reaction. sub-cycle stays DIAGNOSTIC (009
+               ;; catalogue) — the port throws the typed carrier but does NOT
+               ;; promote it to the always-on axis. No-op on the subscribe path.
+               (record-acquire-recovery! :cycle {:cycle   (:cycle (ex-data e))
+                                                 :query-v query-v})
+               (adapter/make-derived-value [] (constantly nil)))
+             (throw e))))
+       (build-and-cache!* frame-id query-v expected-incarnation)))))
 
 ;; ---- the sub-override subscribe seam (CLJS, dev-only) --------------------
 ;;
@@ -1436,59 +1533,51 @@
    (live-frame/call-with-frame-resolution
      (live-frame/frame-resolution-target frame-id)
      (fn []
-   (or
-     #?(:cljs
-        (when interop/debug-enabled?
-          (resolve-sub-override frame-id query-v)))
-     (let [frame-record (frame/frame frame-id)]
+   (let [frame-record (frame/frame frame-id)
+         ;; rf2-7w1im: resolve the record ONCE and decide supersession up front,
+         ;; so a CAPTURED read consumes EXACTLY the validated incarnation across
+         ;; the override, hit, and miss seams — one exact-incarnation operation.
+         ;; `expected-incarnation` nil (the ambient / explicit address-directed
+         ;; read, and every layer-2+ recursive input resolution) → never
+         ;; superseded, so every clause below stays byte-identical to the
+         ;; pre-fence behaviour.
+         superseded? (and (some? expected-incarnation)
+                          (not (identical? expected-incarnation
+                                           (:drain-lock frame-record))))]
+     (or
+       ;; rf2-7w1im: the CLJS dev sub-override seam now sits INSIDE the
+       ;; incarnation fence — a stale captured subscribe must NOT surface an
+       ;; override for a superseded incarnation (the override short-circuits
+       ;; build-and-cache, so consulted ahead of the fence it would escape it
+       ;; entirely). An UNFENCED read (`superseded?` is false whenever
+       ;; `expected-incarnation` is nil) still consults it exactly as before —
+       ;; INCLUDING ahead of the missing-frame branch — and a LIVE captured read
+       ;; (incarnation still valid) keeps its override too.
+       #?(:cljs
+          (when (and interop/debug-enabled? (not superseded?))
+            (resolve-sub-override frame-id query-v)))
        (cond
-         ;; Missing or destroyed frame: emit + return nil rather than
-         ;; deref-ing nil and exploding. Subscribe RECOVERS (returns nil)
-         ;; AND emits a
-         ;; production-survivable `:rf.error/frame-destroyed` through the
-         ;; always-on error-emit listener (surface #4) so a subscribe
-         ;; during a teardown / hot-reload race recovers safely while a
-         ;; real use-after-destroy bug stays observable on the
-         ;; production-watched stream. Reached via the
-         ;; `:error-emit/dispatch-on-error` late-bind hook (subs cannot
-         ;; static-require `re-frame.error-emit` — load cycle). The
-         ;; `:frame`-stampable record carries `frame-id` + the attempted
-         ;; `query-v` (as `:event`) for frame + shipper attribution.
+         ;; Missing or destroyed frame, OR a superseded captured read (rf2-dlld6 /
+         ;; rf2-7w1im): recover-but-emit `:rf.error/frame-destroyed` and return
+         ;; nil rather than deref-ing nil, reading a same-id successor's app-db,
+         ;; or caching a reaction in its sub-cache. Production-survivable
+         ;; (surface #4) so a subscribe during a teardown / hot-reload race
+         ;; recovers safely while a real use-after-destroy bug stays observable on
+         ;; the production-watched stream.
          ;;
-         ;; rf2-dlld6: the SAME recover-but-emit also covers a superseded
-         ;; captured read — `frame-record` resolved a same-id successor B whose
-         ;; `:drain-lock` differs from the `expected-incarnation` a
-         ;; `capture-frame` op pinned (A destroyed + B installed after the
-         ;; capture's liveness pre-check). The token is compared against the
-         ;; record we just resolved for the read, so a stale capture can neither
-         ;; read B's app-db nor cache a reaction in B's sub-cache. A nil
-         ;; `expected-incarnation` (ambient / address-directed / layer-2+ input)
-         ;; leaves the clause a pure `(nil? frame-record)` test.
-         (or (nil? frame-record)
-             (and (some? expected-incarnation)
-                  (not (identical? expected-incarnation
-                                   (:drain-lock frame-record)))))
-         (do
-           ;; Both channels via the shared helper: axis 1 the
-           ;; always-on listener (survives prod elision), axis 2 the dev trace
-           ;; (DCEs under `:advanced` + `goog.DEBUG=false`). No exception —
-           ;; invalid op; `elapsed-ms 0`. Reached via the
-           ;; `:error-emit/emit-error-both` hook (subs cannot static-require
-           ;; error-emit — load cycle).
-           (when-let [emit-error-both!
-                      (late-bind/get-fn-cached :error-emit/emit-error-both)]
-             (emit-error-both!
-               :rf.error/frame-destroyed
-               query-v                       ;; attempted query-vector (as :event)
-               (first query-v)               ;; sub-id (as :event-id)
-               frame-id
-               nil                           ;; no exception — invalid op
-               0                             ;; elapsed-ms
-               (interop/now-ms)             ;; time
-               {:frame    frame-id
-                :query-v  query-v
-                :recovery :replaced-with-default}))
-           nil)
+         ;; rf2-dlld6: the `expected-incarnation` comparison (folded into
+         ;; `superseded?`) is made against the record we JUST resolved for the
+         ;; read — A destroyed + a same-id successor B installed after the
+         ;; capture's liveness pre-check resolves B here, whose `:drain-lock`
+         ;; differs from the pinned token — so validation and consumption are one
+         ;; exact-incarnation operation. rf2-7w1im: the DURABLE build/read past
+         ;; this cond (a miss, or a hit's concurrent-eviction rebuild) carries the
+         ;; SAME token into `build-and-cache!*`, which re-fences it, so a
+         ;; supersession in the post-comparison window cannot retarget B either. A
+         ;; nil `expected-incarnation` leaves the clause a pure
+         ;; `(nil? frame-record)` test.
+         (or (nil? frame-record) superseded?)
+         (emit-frame-destroyed-recovery! frame-id query-v)   ;; emits, returns nil
 
          :else
          (let [cache (:sub-cache frame-record)
@@ -1517,8 +1606,12 @@
                                    m)))]
                (if (identical? reaction (get-in new [k :reaction]))
                  reaction
-                 (compute-and-cache! frame-id query-v)))
-             (compute-and-cache! frame-id query-v))))))))))) ;; close fn + call-with-frame-resolution + normalize-target let + 3-arity + subscribe-in-frame
+                 ;; rf2-7w1im: the hit's concurrent-eviction rebuild carries the
+                 ;; captured token so the rebuild is fenced to the SAME
+                 ;; incarnation (never a bare-id retarget to a same-id successor).
+                 (compute-and-cache! frame-id query-v expected-incarnation)))
+             ;; Miss: the durable build carries the captured token (rf2-7w1im).
+             (compute-and-cache! frame-id query-v expected-incarnation))))))))))) ;; close or + let[frame-record superseded?] + fn + call-with-frame-resolution + normalize-target let + 3-arity + subscribe-in-frame
 
 (defn subscribe
   "Per Spec 006 §Lookup algorithm. Returns the reaction for query-v;

--- a/implementation/core/test/re_frame/capture_frame_test.clj
+++ b/implementation/core/test/re_frame/capture_frame_test.clj
@@ -21,6 +21,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
+            [re-frame.subs :as subs]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
 
@@ -290,6 +291,123 @@
           "no reaction/cache entry was installed in same-id successor B's sub-cache")
       (is (some #(= :rf.error/frame-destroyed (:operation %)) @errs)
           "the superseded subscribe recover-but-emits :rf.error/frame-destroyed"))))
+
+;; ---- rf2-7w1im: the POST-comparison boundary (not only the pre-check) -------
+;;
+;; rf2-dlld6 (above) made the OUTER subscribe-in-frame comparison validate the
+;; captured incarnation — but that comparison and the DURABLE build it delegates
+;; a miss / hit-eviction rebuild to were still separate operations. On the
+;; concurrent JVM host frame A can be destroyed AND a same-id successor B
+;; installed in the window between the comparison returning "A" and
+;; `compute-and-cache!` re-resolving the bare id — so a comparison-passing
+;; capture leaked its read / cache-write / recursive-input resolution into B.
+;; rf2-7w1im carries the pinned incarnation THROUGH the build (compute-and-cache!
+;; → build-and-cache!*), which re-fences it and reads the container / writes the
+;; sub-cache / subscribes inputs off the validated record, so the whole captured
+;; subscribe is ONE exact-incarnation operation.
+;;
+;; These fixtures interpose ONE-SHOT on `subs/compute-and-cache!` — entered only
+;; AFTER the outer comparison validated A and delegated the miss/rebuild — and,
+;; at that boundary, destroy A and reseat a same-id successor B (seeded with
+;; :B-value) BEFORE the real build runs. That is exactly the JVM interleaving the
+;; earlier `frame-incarnation-live?` pre-check interposition (rf2-dlld6) CANNOT
+;; reach: it fires at the pre-check, before the outer comparison. Deterministic +
+;; single-threaded (the swap runs inside the interposed call), so no latch.
+
+(defn- run-supersede-at-build
+  "Interpose ONE-SHOT on `subs/compute-and-cache!`: the first time it is entered
+  for `trigger-qv` (the post-comparison durable-build boundary — the outer
+  `subscribe-in-frame` has already validated incarnation A and delegated the miss
+  / hit-eviction rebuild here), destroy A and reseat a same-id successor B seeded
+  with :B-value, THEN delegate to the real build. Reproduces A destroyed + B
+  installed AFTER the outer comparison but before the durable read/cache-write.
+  Fires exactly once; every later call (incl. the destroy/create machinery's own,
+  and the entry sub's build when `trigger-qv` is an INPUT query) takes the real
+  path."
+  [frame-id trigger-qv op]
+  (let [real  @#'subs/compute-and-cache!
+        fired (atom false)]
+    (with-redefs [subs/compute-and-cache!
+                  (fn [& args]
+                    (when (and (= trigger-qv (second args))
+                               (compare-and-set! fired false true))
+                      (rf/destroy-frame! frame-id)
+                      (rf/make-frame {:id frame-id :doc "incarnation B (successor)"})
+                      (rf/dispatch-sync [:fh/seed :B-value] {:frame frame-id}))
+                    (apply real args))]
+      (op))))
+
+(deftest stale-capture-subscribe-post-comparison-miss-does-not-retarget-successor
+  (testing "rf2-7w1im (miss arm) — a captured subscribe whose OUTER incarnation
+            comparison validated A, then superseded by same-id B AFTER that
+            comparison but BEFORE the durable build (compute-and-cache!), must not
+            read B, install a reaction in B, or return B's value. It returns nil,
+            emits exactly one :rf.error/frame-destroyed, and leaves B's db +
+            sub-cache untouched. MUTATION TOOTH: if the build falls back to a bare
+            frame id (drops the token / re-resolves), it reads and caches B and
+            this fails."
+    (rf/reg-event :fh/seed (fn [{:keys [db]} [_ v]] {:db {:value v}}))
+    (rf/reg-sub :fh/value (fn [db _] (:value db)))
+    (rf/make-frame {:id :fh/race :doc "incarnation A"})
+    (rf/dispatch-sync [:fh/seed :A-value] {:frame :fh/race})
+    (let [{:keys [subscribe]} (rf/capture-frame :fh/race)   ;; pins A
+          errs   (atom [])
+          _      (rf/register-listener! :trace ::pcb-miss (fn [ev] (swap! errs conj ev)))
+          result (run-supersede-at-build :fh/race [:fh/value]
+                   #(subscribe [:fh/value]))]
+      (rf/unregister-listener! :trace ::pcb-miss)
+      (is (nil? result)
+          "the post-comparison-superseded subscribe returns nil — it did NOT resolve into B")
+      (is (= :B-value (:value (rf/app-db-value :fh/race)))
+          "successor B's app-db is intact (untouched by the stale build)")
+      (is (empty? @(:sub-cache (frame/frame :fh/race)))
+          "no reaction/cache entry was installed in successor B's sub-cache")
+      (is (= 1 (count (filter #(= :rf.error/frame-destroyed (:operation %)) @errs)))
+          "exactly one :rf.error/frame-destroyed emit"))))
+
+(deftest live-capture-subscribe-miss-still-reads-its-own-incarnation
+  (testing "rf2-7w1im (genuine-subscribe control) — with NO interposition a
+            captured subscribe that misses builds against its OWN incarnation,
+            caches in its OWN sub-cache, and reads its value; the fence rejects
+            ONLY a superseded read, never a genuine same-incarnation one."
+    (rf/reg-event :fh/seed (fn [{:keys [db]} [_ v]] {:db {:value v}}))
+    (rf/reg-sub :fh/value (fn [db _] (:value db)))
+    (rf/make-frame {:id :fh/live :doc "incarnation A"})
+    (rf/dispatch-sync [:fh/seed :A-value] {:frame :fh/live})
+    (let [{:keys [subscribe]} (rf/capture-frame :fh/live)
+          reaction (subscribe [:fh/value])]
+      (is (some? reaction) "a live captured subscribe on a miss builds a reaction")
+      (is (= :A-value @reaction) "and reads its own incarnation's value")
+      (is (contains? @(:sub-cache (frame/frame :fh/live)) [:fh/value])
+          "the reaction is cached in its own frame's sub-cache"))))
+
+(deftest stale-capture-subscribe-recursive-input-not-resolved-in-successor
+  (testing "rf2-7w1im (recursive-input arm) — a captured layer-2 subscribe whose
+            ENTRY build validated A, then superseded by same-id B before the
+            layer-1 INPUT build, must not recursively resolve the input in B. The
+            input build's fence rejects; neither the entry nor its input installs
+            a reaction in successor B's sub-cache. MUTATION TOOTH: if the input
+            subscribe drops the token it resolves in B and B's sub-cache gains
+            [:fh/value]."
+    (rf/reg-event :fh/seed (fn [{:keys [db]} [_ v]] {:db {:value v}}))
+    (rf/reg-sub :fh/value (fn [db _] (:value db)))
+    (rf/reg-sub :fh/derived :<- [:fh/value] (fn [v _] [:derived v]))
+    (rf/make-frame {:id :fh/race :doc "incarnation A"})
+    (rf/dispatch-sync [:fh/seed :A-value] {:frame :fh/race})
+    (let [{:keys [subscribe]} (rf/capture-frame :fh/race)   ;; pins A
+          errs   (atom [])
+          _      (rf/register-listener! :trace ::pcb-rec (fn [ev] (swap! errs conj ev)))
+          ;; Fire at the INPUT build ([:fh/value]) — AFTER the entry [:fh/derived]
+          ;; build validated A and began resolving its inputs.
+          _      (run-supersede-at-build :fh/race [:fh/value]
+                   #(subscribe [:fh/derived]))]
+      (rf/unregister-listener! :trace ::pcb-rec)
+      (is (= :B-value (:value (rf/app-db-value :fh/race)))
+          "successor B's app-db is intact")
+      (is (empty? @(:sub-cache (frame/frame :fh/race)))
+          "neither :fh/derived nor its input :fh/value is installed in successor B's sub-cache")
+      (is (some #(= :rf.error/frame-destroyed (:operation %)) @errs)
+          "the recursive input's build fence emits :rf.error/frame-destroyed"))))
 
 ;; ---- contract: (capture-frame) outside any scope RAISES (EP-0002) ---------
 ;;

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -1667,14 +1667,23 @@
         raced?  (atom false)]
     (with-redefs
       [subs/compute-and-cache!
-       (fn [frame-id query-v]
-         (let [reaction (real-cc frame-id query-v)]
-           ;; Displace the just-built canonical node ONCE, in the
-           ;; build→canonical-check window, with the frame left LIVE.
-           (when (and (= query-v [:obs/items])
-                      (compare-and-set! raced? false true))
-             (displace-node! [:obs/items] reaction))
-           reaction))]
+       ;; rf2-7w1im: `compute-and-cache!` is now 2/3-arity — the captured-
+       ;; incarnation token rides the optional 3rd arg. Mirror BOTH fixed arities
+       ;; (the acquire path calls the 2-arity via static dispatch; the internal
+       ;; token-carrying self-call / recursive input calls the 3-arity). The
+       ;; displacer acts ONLY on the 2-arity ENTRY; the 3-arity is a pure
+       ;; pass-through, so it never re-triggers.
+       (fn
+         ([frame-id query-v]
+          (let [reaction (real-cc frame-id query-v nil)]
+            ;; Displace the just-built canonical node ONCE, in the
+            ;; build→canonical-check window, with the frame left LIVE.
+            (when (and (= query-v [:obs/items])
+                       (compare-and-set! raced? false true))
+              (displace-node! [:obs/items] reaction))
+            reaction))
+         ([frame-id query-v expected-incarnation]
+          (real-cc frame-id query-v expected-incarnation)))]
       (let [[[outcome lease] records] (with-error-records #(obs/acquire! target (fn [_])))]
         (is (true? @raced?) "the displacement fired in the build→check window")
         (testing "acquire! did NOT throw or fan a false frame-destroyed while the frame is live"
@@ -1708,13 +1717,18 @@
         builds  (atom 0)]
     (with-redefs
       [subs/compute-and-cache!
-       (fn [frame-id query-v]
-         (let [reaction (real-cc frame-id query-v)]
-           (when (= query-v [:obs/items])
-             ;; Evict the first K builds in-window; the (K+1)th settles.
-             (when (<= (swap! builds inc) k)
-               (evict-node! [:obs/items])))
-           reaction))]
+       ;; rf2-7w1im: 2/3-arity shim (see acquire-live-cache-displacement) — act
+       ;; only on the 2-arity entry; the 3-arity is a pass-through.
+       (fn
+         ([frame-id query-v]
+          (let [reaction (real-cc frame-id query-v nil)]
+            (when (= query-v [:obs/items])
+              ;; Evict the first K builds in-window; the (K+1)th settles.
+              (when (<= (swap! builds inc) k)
+                (evict-node! [:obs/items])))
+            reaction))
+         ([frame-id query-v expected-incarnation]
+          (real-cc frame-id query-v expected-incarnation)))]
       (let [[[outcome lease] records] (with-error-records #(obs/acquire! target (fn [_])))]
         (is (= (inc k) @builds) "converged on the very next build after K displacements")
         (is (= :ok outcome) "acquire! converged on a lease — it did not spin or throw")
@@ -1739,13 +1753,18 @@
           raced?  (atom false)]
       (with-redefs
         [subs/compute-and-cache!
-         (fn [frame-id query-v]
-           (let [reaction (real-cc frame-id query-v)]
-             (when (and (= query-v [:obs/items63])
-                        (compare-and-set! raced? false true))
-               ;; Destroy the targeted incarnation in the window — token → nil.
-               (frame/destroy-frame! race-fid))
-             reaction))]
+         ;; rf2-7w1im: 2/3-arity shim (see acquire-live-cache-displacement) — act
+         ;; only on the 2-arity entry; the 3-arity is a pass-through.
+         (fn
+           ([frame-id query-v]
+            (let [reaction (real-cc frame-id query-v nil)]
+              (when (and (= query-v [:obs/items63])
+                         (compare-and-set! raced? false true))
+                ;; Destroy the targeted incarnation in the window — token → nil.
+                (frame/destroy-frame! race-fid))
+              reaction))
+           ([frame-id query-v expected-incarnation]
+            (real-cc frame-id query-v expected-incarnation)))]
         (let [[[outcome e] records] (with-error-records #(obs/acquire! target (fn [_])))]
           (is (true? @raced?) "the destruction fired in the build→check window")
           (is (= :threw outcome) "a real teardown still throws — it is not retargeted")
@@ -1779,15 +1798,20 @@
         builds  (atom 0)]
     (with-redefs
       [subs/compute-and-cache!
-       (fn [frame-id query-v]
-         (let [reaction (real-cc frame-id query-v)]
-           (when (= query-v [:obs/items])
-             ;; Displace EVERY build in-window, leaving the frame (and its
-             ;; incarnation token) LIVE — the storm never settles, so the bounded
-             ;; retry exhausts its budget with the incarnation demonstrably alive.
-             (swap! builds inc)
-             (evict-node! [:obs/items]))
-           reaction))]
+       ;; rf2-7w1im: 2/3-arity shim (see acquire-live-cache-displacement) — act
+       ;; only on the 2-arity entry; the 3-arity is a pass-through.
+       (fn
+         ([frame-id query-v]
+          (let [reaction (real-cc frame-id query-v nil)]
+            (when (= query-v [:obs/items])
+              ;; Displace EVERY build in-window, leaving the frame (and its
+              ;; incarnation token) LIVE — the storm never settles, so the bounded
+              ;; retry exhausts its budget with the incarnation demonstrably alive.
+              (swap! builds inc)
+              (evict-node! [:obs/items]))
+            reaction))
+         ([frame-id query-v expected-incarnation]
+          (real-cc frame-id query-v expected-incarnation)))]
       (let [[[outcome e] records] (with-error-records #(obs/acquire! target (fn [_])))]
         (is (= :threw outcome) "the exhausted retry is fail-loud")
         (is (some? (frame/frame fid))

--- a/implementation/core/test/re_frame/subs_override_seam_cljs_test.cljs
+++ b/implementation/core/test/re_frame/subs_override_seam_cljs_test.cljs
@@ -22,6 +22,7 @@
        failure trace."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.subs :as subs]
             [re-frame.late-bind :as late-bind]
             [re-frame.schemas.malli]                ;; install the default Malli validator
@@ -178,3 +179,57 @@
                              "any value surfaces when the sub declares no schema")))))]
       (is (not-any? #{:rf.error/schema-validation-failure} errors)
           "no validation runs when the sub has no :schema"))))
+
+;; ---- 4 · rf2-7w1im — the override seam sits INSIDE the incarnation fence ---
+;;
+;; The resolve-sub-override consult is CLJS-dev-specific and, pre-fix, ran BEFORE
+;; the frame-record / expected-incarnation fence — so a HIT short-circuited
+;; build-and-cache and ESCAPED the fence entirely. A stale captured subscribe
+;; (its pinned `:rf.frame/expected-incarnation` superseded by a same-id
+;; successor) would therefore surface an override value for a torn-down
+;; incarnation. rf2-7w1im gates the consult on `(not superseded?)`, so a
+;; superseded captured read recover-but-emits before the override can return.
+
+(deftest stale-captured-subscribe-is-fenced-before-override-resolution
+  (testing "rf2-7w1im — a stale captured subscribe (pinned
+            :rf.frame/expected-incarnation superseded by a same-id successor) is
+            FENCED before resolve-sub-override can return a value: it recovers to
+            nil and emits :rf.error/frame-destroyed, and the pinned override is
+            NOT surfaced for the superseded incarnation. A LIVE captured subscribe
+            (matching incarnation) still surfaces the override — existing
+            behaviour retained. MUTATION TOOTH: with the pre-fix ordering (override
+            ahead of the fence) the stale subscribe returns :override-value and
+            the nil assertion fails."
+    (rf/reg-sub :fh/ovr (fn [db _] (:v db)))
+    (rf/make-frame {:id :fh/ovr-frame :doc "incarnation A"})
+    (let [a-token (frame/frame-incarnation-token :fh/ovr-frame)]
+      ;; Supersede A with a same-id successor B.
+      (rf/destroy-frame! :fh/ovr-frame)
+      (rf/make-frame {:id :fh/ovr-frame :doc "incarnation B (successor)"})
+      (let [b-token (frame/frame-incarnation-token :fh/ovr-frame)]
+        (is (and (some? a-token) (some? b-token) (not (identical? a-token b-token)))
+            "B is a distinct incarnation from A")
+        (with-overrides* {[:fh/ovr] :override-value}
+          (fn []
+            ;; STALE captured subscribe (pinned to A): the fence must win over the
+            ;; override.
+            (let [errors (collect-errors
+                           (fn []
+                             (let [r (subs/subscribe
+                                       [:fh/ovr]
+                                       {:frame :fh/ovr-frame
+                                        :rf.frame/expected-incarnation a-token})]
+                               (is (nil? r)
+                                   "stale captured subscribe returns nil — the override is NOT surfaced")
+                               (when (some? r)
+                                 (is (not= :override-value @r)
+                                     "the superseded incarnation's override must never surface")))))]
+              (is (some #{:rf.error/frame-destroyed} errors)
+                  "the fenced stale subscribe emits :rf.error/frame-destroyed"))
+            ;; LIVE captured subscribe (pinned to B): override behaviour retained.
+            (let [r (subs/subscribe
+                      [:fh/ovr]
+                      {:frame :fh/ovr-frame
+                       :rf.frame/expected-incarnation b-token})]
+              (is (= :override-value @r)
+                  "a LIVE captured subscribe still surfaces the override (existing behaviour retained)"))))))))


### PR DESCRIPTION
## What

Extends dlld6's `expected-incarnation` fence (PR #6186) so a **captured subscribe consumes exactly the validated incarnation across every seam**, not just the outer `subscribe-in-frame` comparison. dlld6 validated the captured token against the record the outer comparison resolved, but that comparison and the durable build it delegated to were separate operations — on the concurrent JVM host frame A could be destroyed and a same-id successor B installed in the window between them, so a comparison-passing capture leaked its read / cache-write / recursive-input resolution into B (the classic check-then-use race, same family as dlld6/bjh6y/qfrh4). There was also a CLJS-dev-specific bypass: `resolve-sub-override` ran *before* the fence, so a stale override escaped it.

Reuses dlld6's `:rf.frame/expected-incarnation` mechanism and its `:rf.error/frame-destroyed` error-id. **No new error-id, no public token surface, no new abstraction, no retry, no global lock.**

## The seams (all in `implementation/core/src/re_frame/subs.cljc`)

| Seam | Before | After |
|---|---|---|
| **override** (`subscribe-in-frame`, CLJS `resolve-sub-override`) | consulted *ahead* of the fence → a stale capture's override escaped it | consult gated on `(not superseded?)` — inside the fence; unfenced/live reads unchanged |
| **hit** (`subscribe-in-frame`) | reads the validated `frame-record`'s sub-cache | unchanged (already fenced by dlld6) |
| **miss + hit-eviction rebuild** (`subscribe-in-frame` → `compute-and-cache!` → `build-and-cache!*`) | `compute-and-cache! frame-id query-v` re-resolved the bare id → container read + cache write could retarget B | carry the token; `build-and-cache!*` resolves the record **once**, re-fences it, and reads the container / writes the sub-cache off *that validated record* |
| **recursive input** (`build-and-cache!*`) | layer-2+ input `subscribe-in-frame` unfenced → could resolve inputs in B | input subscribes thread the token so they self-fence to A |

The recover-but-emit is factored into a shared `emit-frame-destroyed-recovery!` used by both the outer and durable-build fences, so a stale capture emits identically wherever the supersession is detected. The unfenced (ambient / address-directed / `nil` token) path is byte-identical to before — every record-vs-id and gate decision keys on `(some? expected-incarnation)`.

## Quality gates

- **Core JVM (focused):** `clojure -M:test -n re-frame.capture-frame-test -n re-frame.frame-destroy-incarnation-jvm-test` → **49 tests, 270 assertions, 0 failures, 0 errors.**
- **CLJS (full node-test):** `npm run test:cljs` → **9902 tests, 48757 assertions, 0 failures, 0 errors** (the resolve-sub-override bypass is CLJS-dev-specific, so this is the essential proof).

### Red-before / green-after per seam

Deterministic, single-threaded, no latches.

- **miss** (JVM `stale-capture-subscribe-post-comparison-miss-does-not-retarget-successor`) — a one-shot interposition on `subs/compute-and-cache!` destroys A and reseats B *after* the outer comparison validated A but *before* the durable build. **Red-before:** returned a Reaction reading `:B-value`, B's sub-cache gained `[:fh/value]`, zero `:rf.error/frame-destroyed`. **Green-after:** returns nil, exactly one emit, B's db + sub-cache untouched.
- **recursive input** (JVM `stale-capture-subscribe-recursive-input-not-resolved-in-successor`) — a layer-2 `[:fh/derived] :<- [:fh/value]` superseded at the *input* build. **Red-before:** B's sub-cache held BOTH `[:fh/value]` and `[:fh/derived]` (literally "recursively resolve inputs in B"). **Green-after:** neither installs in B; the input fence emits.
- **override** (CLJS `stale-captured-subscribe-is-fenced-before-override-resolution`) — a stale captured subscribe with an active override. **Red-before** (override let escape the fence): returns `:override-value`, no emit. **Green-after:** returns nil + emits; a live captured subscribe (matching incarnation) still surfaces the override.
- **genuine-subscribe control** (JVM `live-capture-subscribe-miss-still-reads-its-own-incarnation`) — green in both: a same-incarnation captured miss builds against and reads its own incarnation.

Mutation teeth: the miss/recursive tests fail if post-validation build/install falls back to a bare frame id; the override test fails if the override consult precedes the fence.

`observation_port_cljs_test.cljc`'s `compute-and-cache!` mock shims were updated to mirror the new 2/3-arity signature (they mock an internal fn whose arity this PR extends; a fixed 2-arity shim can't provide the static `arity$3` dispatch the recursive path now emits).

Do not merge — leaving for review.
