### PR TITLE
fix(epoch): reconcile silencing schema + source authority to the comparable-ID design (rf2-4go8s)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -1005,13 +1005,22 @@
 ;; paused inside its swap can never block a fan-out re-arm (which takes only
 ;; silence-lock).
 ;;
-;; The generation-authority-through-emission guarantee (rf2-9bhne6) is unchanged:
-;; the claim (`eligible-and-reserve!` under `claim-and-publish-delayed-silence!`)
-;; holds BOTH locks across its eligibility recheck AND the external emit, so a
-;; concurrent `put-listener!` blocks on the registry lock and a concurrent
-;; `record-observation!` blocks on silence-lock — neither can make a fresh
-;; generation current, nor re-arm the observation, in the reserve→emit window.
-;; Ordinary fan-out never contends on either: the registry/observation atoms keep
+;; The generation-authority guarantee (rf2-9bhne6, as CORRECTED by rf2-8b9twg):
+;; `eligible-and-reserve!` (under `claim-and-publish-delayed-silence!`) holds BOTH
+;; locks across its eligibility recheck AND the mark RESERVATION — so a concurrent
+;; `put-listener!` (registry lock) and a concurrent `record-observation!`
+;; (silence-lock) are excluded from THAT window and can neither corrupt the three
+;; eligibility reads nor let two publishers both reserve. The external emit then
+;; runs OUTSIDE both locks (see `claim-and-publish-delayed-silence!` for why: the
+;; foreign trace fan-out can reach a frame's `:drain-lock`, and holding a ledger
+;; lock across it is an AB-BA deadlock). Generation authority survives the
+;; lock-free emit through a DATA QUALIFIER, not a lock: a replacement, an
+;; `unregister-epoch-listener!` drop, a fresh frame destroy, or a
+;; `record-observation!` re-arm MAY all land BETWEEN the reservation and the
+;; publication and make a fresh generation current — but the emit carries
+;; `:observed-gen` (the reserved generation), so a superseded late emit
+;; self-filters at the receiver rather than depending on a held lock. Ordinary
+;; fan-out never contends on either lock: the registry/observation atoms keep
 ;; their own lock-free swaps for the common path.
 #?(:clj
    (defonce ^:private listener-registry-lock (Object.)))
@@ -1032,9 +1041,10 @@
   delayed-silence claim and the registry+observation wipes (`drop-listener!` /
   `reset-listeners!`). The claim reads the `listeners` generation AND the
   observation/mark ledger and must exclude both `put-listener!` and
-  `record-observation!` across its eligibility recheck and emit; the wipes mutate
-  both domains. Encoding the order here keeps every both-locks caller consistent
-  so the registry→silence DAG can never invert."
+  `record-observation!` across its eligibility recheck and mark RESERVATION (NOT
+  the external emit, which the claim runs after releasing both locks — rf2-8b9twg);
+  the wipes mutate both domains. Encoding the order here keeps every both-locks
+  caller consistent so the registry→silence DAG can never invert."
   [f]
   (with-listener-registry-lock #(with-silence-lock f)))
 
@@ -1151,15 +1161,17 @@
   cannot both reserve: the first writes the mark, the second sees it above
   baseline and returns nil.
 
-  NOTE the reserve-then-emit-later split leaves a claim→emit window: a
-  replacement landing after this returns but before the caller's external emit
-  makes a fresh generation current at the emission point. This reserve-only
-  primitive emits an UNQUALIFIED signal, so it remains only for staged tests and
-  any caller whose emit provably cannot race a registry mutation. Callers whose
-  emit CAN race a registry mutation use `claim-and-publish-delayed-silence!`,
-  which reserves here (under both locks), then emits a GENERATION-QUALIFIED
-  signal OUTSIDE the locks so a superseded generation's late emit self-filters at
-  the receiver (rf2-8b9twg)."
+  NOTE this primitive RESERVES ONLY — it EMITS NOTHING. It returns the reserved
+  seq; the CALLER performs the external emit later, which leaves a claim→emit
+  window: a replacement / drop / re-arm landing after this returns but before the
+  caller's emit makes a fresh generation current at the emission point. Because
+  this path does NOT hand the caller the reserved generation to qualify that emit
+  with, a caller wiring it to a bare `{:frame :cb-id}` emit produces an UNQUALIFIED
+  signal — so this primitive remains only for staged tests and any caller whose
+  emit provably cannot race a registry mutation. Callers whose emit CAN race a
+  registry mutation use `claim-and-publish-delayed-silence!`, which reserves here
+  (under both locks), then emits a GENERATION-QUALIFIED signal OUTSIDE the locks so
+  a superseded generation's late emit self-filters at the receiver (rf2-8b9twg)."
   [frame-id cb-id observed-gen baseline]
   (with-claim-locks
     #(eligible-and-reserve! frame-id cb-id observed-gen baseline)))
@@ -1171,9 +1183,12 @@
 
   `publish!` is a 0-arg thunk that performs the external
   `:rf.epoch.cb/silenced-on-frame-destroy` emit. It runs with NO ledger lock
-  held, so a same-id replacement CAN make a fresh generation H current in the
-  reserve→emit window. `publish!` MUST therefore qualify its emit with
-  `observed-gen` (the caller bakes it into the payload): the resulting
+  held, so any registry/observation mutation MAY land BETWEEN the reservation and
+  the emit — a same-id replacement (making a fresh generation H current), an
+  `unregister-epoch-listener!` drop, a fresh same-id frame destroy, or a
+  `record-observation!` re-arm on a live successor. That window is intended and
+  race-coherent: `publish!` MUST qualify its emit with `observed-gen` (the caller
+  bakes it into the payload): the resulting
   GENERATION-QUALIFIED signal SELF-FILTERS at the receiver — an observer whose
   current generation for `cb-id` no longer equals the carried `observed-gen`
   discards it. The receiver reads that current generation through the supported
@@ -1280,16 +1295,20 @@
   new callback could be erased by a lagging second swap (rf2-j538f7.5), and its
   mirror in which a stale old callback could re-arm the new registration.
 
-  Participates in `listener-registry-lock` (rf2-9bhne6): installing a fresh
-  generation is a `listeners`-atom mutation that `claim-and-publish-delayed-silence!`
-  reads (under the same registry lock) while deciding+emitting a delayed silence,
-  so it is serialized against that critical section. A replacement therefore
-  cannot make a fresh generation current between a silence's reservation and its
-  emission — it blocks on the registry lock until publication completes, closing
-  the claim→emit window. It holds ONLY the registry lock, NOT silence-lock, so a
-  watcher parked inside the `(swap! listeners …)` below can never block a
-  concurrent `record-observation!` fan-out re-arm (the single-monitor deadlock,
-  rf2-9bhne6 follow-up).
+  Participates in `listener-registry-lock` (rf2-9bhne6, as corrected by
+  rf2-8b9twg): installing a fresh generation is a `listeners`-atom mutation that
+  `claim-and-publish-delayed-silence!` reads (under the same registry lock) while
+  RESERVING a delayed silence, so it is serialized against that reservation's
+  eligibility recheck — a replacement cannot make a fresh generation current
+  DURING the reservation; it blocks on the registry lock until the reservation
+  completes. It does NOT block the silence's external EMIT: that emit runs OUTSIDE
+  the ledger locks (rf2-8b9twg), so a replacement MAY land between the reservation
+  and the emit and make a fresh generation current. That is sound because the emit
+  is generation-qualified (`:observed-gen`): a superseded late emit self-filters at
+  the receiver rather than depending on a held lock. It holds ONLY the registry
+  lock, NOT silence-lock, so a watcher parked inside the `(swap! listeners …)`
+  below can never block a concurrent `record-observation!` fan-out re-arm (the
+  single-monitor deadlock, rf2-9bhne6 follow-up).
 
   Returns the id."
   [id f]
@@ -1304,9 +1323,13 @@
   bookkeeping it carried. Takes BOTH ledger locks (`with-claim-locks`,
   rf2-9bhne6): it mutates the `listeners` registry (registry lock) AND the
   observation ledger + terminal-silence marks (silence-lock). Holding both means
-  a drop in a delayed-silence claim's reserve→emit window blocks until
-  publication completes rather than making a stale generation current — or
-  clearing an observation the claim is deciding against — mid-signal."
+  a drop is serialized against a delayed-silence claim's RESERVATION — it cannot
+  retire a generation, or clear an observation the claim is deciding against,
+  WHILE the claim's eligibility recheck+reserve runs under those locks. It does
+  NOT block the claim's external EMIT (that runs after the locks are released,
+  rf2-8b9twg): a drop MAY land between the reservation and the emit, and the
+  generation-qualified signal stays correct because a receiver self-filters an
+  `:observed-gen` that no longer names a live registration."
   [id]
   (with-claim-locks
     (fn []
@@ -1386,11 +1409,14 @@
   A genuine re-arm (the outer guard passed) runs under `silence-lock`
   (rf2-9bhne6): it mutates the observation ledger AND prunes the terminal-silence
   mark, both of which `claim-and-publish-delayed-silence!` reads (under
-  silence-lock, the inner of its two claim locks) while deciding a delayed
+  silence-lock, the inner of its two claim locks) while RESERVING a delayed
   silence. Participating in that lock makes the claim's eligibility reads coherent
   against a concurrent re-arm — a re-arm cannot land between the claim's
-  individual reads (or between its reservation and emit) and yield a stale-state
-  grant. Crucially it takes ONLY silence-lock, NOT the registry lock
+  individual reads (they run under the lock) and yield a stale-state grant. A
+  re-arm MAY still land between the reservation and the claim's external emit
+  (which runs lock-free, rf2-8b9twg); that window is race-coherent because the
+  emit is generation-qualified, so a re-armed successor's live callback is never
+  mistaken for the reserved generation's silence. Crucially it takes ONLY silence-lock, NOT the registry lock
   `put-listener!` holds, so a re-arm is never blocked behind a registration
   paused inside the `listeners` swap (the single-monitor deadlock this split
   fixed, rf2-9bhne6 follow-up). The lock-free fast no-op above keeps the fan-out

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -861,3 +861,51 @@
           ;; owner ledger, then unregister cb.
           (epoch.listeners/on-frame-destroyed! id token-b nil)
           (rf/unregister-listener! :epoch cb))))))
+
+;; ---- rf2-4go8s — a NON-KEYWORD comparable listener id round-trips -----------
+
+(deftest non-keyword-comparable-cb-id-round-trips-through-silencing-cljs
+  (testing "rf2-4go8s (CLJS) — `register-epoch-listener!` accepts ANY comparable
+            value as the listener id, not only keyword|string. A NON-KEYWORD id
+            (a vector) registers, answers the generation query, and is emitted
+            VERBATIM as the silencing signal's `:cb-id` — raw-ID preservation —
+            and the generation self-filter works identically on it. This is the
+            end-to-end proof the emitted `:cb-id` domain is the same comparable-ID
+            domain the public register/query API accepts (Spec-Schemas
+            EpochCbSilencedOnFrameDestroyTags :cb-id :any, widened from the stale
+            keyword|string narrowing)."
+    (let [cb-id [:my-app/epoch-log 7]]         ; a vector — NOT a keyword|string
+      (is (nil? (rf/epoch-listener-generation cb-id))
+          "an unregistered non-keyword id has no generation")
+      (rf/make-frame {:id :test/non-kw-cljs})
+      (rf/reg-event :seed-nonkw (fn [{:keys [db]} _] {:db {:n 0}}))
+      (let [recorded (atom [])]
+        (rf/register-listener! :trace ::recorder-nonkw (fn [ev] (swap! recorded conj ev)))
+        (rf/register-listener! :epoch cb-id (fn [_] nil))
+        (is (some? (rf/epoch-listener-generation cb-id))
+            "the non-keyword id answers the generation query once registered")
+        ;; Observe the frame under the live generation, then destroy it.
+        (rf/dispatch-sync [:seed-nonkw] {:frame :test/non-kw-cljs})
+        (let [g-observed (rf/epoch-listener-generation cb-id)]
+          (rf/destroy-frame! :test/non-kw-cljs)
+          (let [tags (->> @recorded
+                          (filter #(= :rf.epoch.cb/silenced-on-frame-destroy
+                                      (:operation %)))
+                          first
+                          :tags)]
+            (is (some? tags) "a silence fired for the destroyed frame")
+            ;; RAW-ID PRESERVATION: the emitted :cb-id is the vector VERBATIM.
+            (is (= cb-id (:cb-id tags))
+                "the emitted :cb-id is the raw non-keyword id, not narrowed/coerced")
+            (is (vector? (:cb-id tags))
+                "and it is genuinely a non-keyword comparable value")
+            (is (= g-observed (:observed-gen tags))
+                "the silence names the generation that observed the frame")
+            ;; GENERATION-QUALIFIED SELF-FILTER on the non-keyword id.
+            (is (= (:observed-gen tags) (rf/epoch-listener-generation cb-id))
+                "live signal matches the current generation — APPLY")
+            (rf/register-listener! :epoch cb-id (fn [_] nil))  ; supersede G→H
+            (is (not= (:observed-gen tags) (rf/epoch-listener-generation cb-id))
+                "a superseded signal no longer matches — DISCARD")))
+        (rf/unregister-listener! :trace ::recorder-nonkw)
+        (rf/unregister-listener! :epoch cb-id)))))

--- a/implementation/epoch/test/re_frame/epoch_silence_contract_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_silence_contract_test.clj
@@ -1,0 +1,188 @@
+(ns re-frame.epoch-silence-contract-test
+  "rf2-4go8s — the epoch silencing SCHEMA and the state.cljc source authority
+  agree with the shipped comparable-ID / opaque-generation / outside-lock design.
+
+  Three teeth, no runtime change:
+
+    * AC1 / AC3 (JVM) — a NON-KEYWORD comparable listener id round-trips through
+      registration → generation query → the emitted `:cb-id` VERBATIM (raw-ID
+      preservation) → the generation self-filter, AND the emitted tags validate
+      against the CANONICAL `EpochCbSilencedOnFrameDestroyTags` schema EXTRACTED
+      from `spec/Spec-Schemas.md`. Before this bead the schema narrowed `:cb-id`
+      to keyword|string, so a valid non-keyword id the runtime accepts (and emits
+      raw) FAILED the canonical schema — the drift this proves is closed.
+
+    * AC6 — a focused SOURCE-CONTRACT tooth over the exact `epoch/state.cljc`
+      docstrings + module comment that used to carry the stale authority. It
+      catches a regression to EMIT-UNDER-LOCK language (a claim that a ledger lock
+      spans the external emit, or that a replacement/drop blocks until publication)
+      or to RESERVE-ONLY-EMITS language (describing the reserve-only primitive as
+      emitting a signal though it emits nothing). It reads only these named
+      surfaces — it is NOT a general comment linter.
+
+  The runtime is UNCHANGED: reservation happens under both ledger locks and the
+  generation-qualified emit runs after they are released (rf2-8b9twg). These teeth
+  pin the doc/schema surfaces to that shipped protocol."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [malli.core :as m]
+            [re-frame.core :as rf]
+            ;; Side-effect: publishes the `:epoch/*` late-bind hooks.
+            [re-frame.epoch]
+            [re-frame.epoch.state :as state]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- canonical schema extraction (no drift: read the markdown) --------------
+
+(def ^:private spec-schemas-candidates
+  ;; `clojure -M:test` runs from implementation/epoch; keep a couple of fallbacks
+  ;; so the extraction is CWD-robust (mirrors observation-schema-extract).
+  ["../../spec/Spec-Schemas.md" "../spec/Spec-Schemas.md" "spec/Spec-Schemas.md"])
+
+(defn- canonical-silencing-schema
+  "Extract the `EpochCbSilencedOnFrameDestroyTags` `[:map …]` form from
+  `spec/Spec-Schemas.md`. The `;;` comments in the def are dropped by the EDN
+  reader, so the result is the pure canonical schema — validating the runtime's
+  emitted tags against THIS proves the markdown schema (not a hand-copy) accepts
+  the id domain the runtime emits."
+  []
+  (let [f    (or (some (fn [p] (let [f (io/file p)] (when (.exists f) f)))
+                       spec-schemas-candidates)
+                 (throw (ex-info "rf2-4go8s: cannot locate spec/Spec-Schemas.md"
+                                 {:candidates spec-schemas-candidates})))
+        text (slurp f)
+        start (str/index-of text "(def EpochCbSilencedOnFrameDestroyTags")
+        _    (when (nil? start)
+               (throw (ex-info "rf2-4go8s: EpochCbSilencedOnFrameDestroyTags not found"
+                               {:file (str f)})))
+        form (edn/read-string (subs text start))
+        schema (nth form 2 nil)]
+    (when-not (and (vector? schema) (= :map (first schema)))
+      (throw (ex-info "rf2-4go8s: schema is not a [:map …] form" {:read schema})))
+    schema))
+
+;; ---- AC1 / AC3 — a non-keyword comparable id round-trips + schema-validates -
+
+(deftest non-keyword-comparable-cb-id-round-trips-and-schema-validates
+  (testing "a non-keyword comparable listener id (a vector) registers, answers the
+            generation query, is emitted VERBATIM as :cb-id, self-filters by
+            generation, and validates against the canonical markdown schema"
+    (let [cb-id   [:my-app/epoch-log 7]         ; a vector — NOT keyword|string
+          schema  (canonical-silencing-schema)
+          entries (into {} (map (fn [e] [(first e) (second e)])) (rest schema))]
+      ;; The canonical schema must ACCEPT the non-keyword id (widened from the
+      ;; stale keyword|string narrowing) and treat :observed-gen as opaque.
+      (is (= :any (:cb-id entries))
+          "the canonical :cb-id domain is :any (the open comparable-ID domain)")
+      (is (= :any (:observed-gen entries))
+          "the canonical :observed-gen is an opaque :any token, not :int")
+
+      (is (nil? (rf/epoch-listener-generation cb-id))
+          "an unregistered non-keyword id has no generation")
+
+      (rf/make-frame {:id :test/non-kw})
+      (rf/reg-event :seed-nonkw (fn [{:keys [db]} _] {:db {:n 0}}))
+
+      (let [recorded (atom [])]
+        (rf/register-listener! :trace ::recorder-nonkw (fn [ev] (swap! recorded conj ev)))
+        (rf/register-listener! :epoch cb-id (fn [_] nil))
+        (is (some? (rf/epoch-listener-generation cb-id))
+            "the non-keyword id answers the generation query once registered")
+
+        ;; Observe the frame under the live generation, then destroy it.
+        (rf/dispatch-sync [:seed-nonkw] {:frame :test/non-kw})
+        (let [g-observed (rf/epoch-listener-generation cb-id)]
+          (rf/destroy-frame! :test/non-kw)
+          (let [tags (->> @recorded
+                          (filter #(= :rf.epoch.cb/silenced-on-frame-destroy
+                                      (:operation %)))
+                          first
+                          :tags)]
+            (is (some? tags) "a silence fired for the destroyed frame")
+
+            ;; RAW-ID PRESERVATION — the emitted :cb-id is the vector VERBATIM.
+            (is (= cb-id (:cb-id tags))
+                "the emitted :cb-id is the raw non-keyword id, not narrowed/coerced")
+            (is (vector? (:cb-id tags))
+                "and it is genuinely a non-keyword comparable value")
+            (is (= g-observed (:observed-gen tags))
+                "the silence names the generation that observed the frame")
+
+            ;; SCHEMA VALIDATION — the emitted tags satisfy the CANONICAL schema
+            ;; from the markdown (would FAIL the old keyword|string :cb-id).
+            (is (m/validate schema tags)
+                (str "emitted tags must validate against the canonical "
+                     "EpochCbSilencedOnFrameDestroyTags schema: "
+                     (pr-str (m/explain schema tags))))
+
+            ;; GENERATION-QUALIFIED SELF-FILTER on the non-keyword id.
+            (is (= (:observed-gen tags) (rf/epoch-listener-generation cb-id))
+                "live signal matches the current generation — APPLY")
+            (rf/register-listener! :epoch cb-id (fn [_] nil)) ; supersede G→H
+            (is (not= (:observed-gen tags) (rf/epoch-listener-generation cb-id))
+                "a superseded signal no longer matches — DISCARD")))
+
+        (rf/unregister-listener! :trace ::recorder-nonkw)
+        (rf/unregister-listener! :epoch cb-id)))))
+
+;; ---- AC6 — source-contract tooth over the state.cljc silencing authority ----
+
+(defn- squish
+  "Collapse runs of whitespace to single spaces so a multi-line docstring/comment
+  is searchable as one line."
+  [s]
+  (some-> s (str/replace #"\s+" " ") str/trim))
+
+(defn- var-doc [v] (squish (:doc (meta v))))
+
+(defn- state-source
+  "The `re-frame.epoch.state` source text, read off the classpath (its `src` dir
+  is a classpath root), squished — the module comment is a top-level `;;` block,
+  not reachable through var metadata."
+  []
+  (squish (slurp (io/resource "re_frame/epoch/state.cljc"))))
+
+(deftest source-authority-states-the-outside-lock-generation-qualified-protocol
+  (testing "AC6 — the state.cljc silencing docstrings + module comment describe the
+            shipped protocol (reserve/recheck under both locks, RELEASE, then emit
+            a generation-qualified signal OUTSIDE the locks) and carry NO stale
+            emit-under-lock or reserve-only-emits authority. A regression to that
+            language flips these assertions RED."
+    (let [src        (state-source)
+          put-doc    (var-doc #'state/put-listener!)
+          drop-doc   (var-doc #'state/drop-listener!)
+          rec-doc    (var-doc #'state/record-observation!)
+          reserve    (var-doc #'state/claim-delayed-silence!)
+          publish    (var-doc #'state/claim-and-publish-delayed-silence!)]
+
+      ;; --- NO emit-under-lock authority (a lock spanning the external emit) ---
+      (is (not (str/includes? src "across its eligibility recheck AND the external emit"))
+          "module comment must NOT claim a lock spans the external emit")
+      (is (not (str/includes? put-doc "blocks on the registry lock until publication completes"))
+          "put-listener! must NOT claim a replacement blocks until publication")
+      (is (not (str/includes? drop-doc "blocks until publication completes"))
+          "drop-listener! must NOT claim a drop blocks until publication")
+      (is (not (str/includes? rec-doc "between its reservation and emit"))
+          "record-observation! must NOT exclude a re-arm from the reservation→emit window")
+
+      ;; --- NO reserve-only-emits authority (the reserve-only helper emits none) ---
+      (is (not (str/includes? reserve "primitive emits an UNQUALIFIED signal"))
+          "claim-delayed-silence! must NOT describe the reserve-only primitive as emitting")
+      (is (str/includes? reserve "RESERVES ONLY")
+          "claim-delayed-silence! states it reserves only")
+      (is (str/includes? reserve "EMITS NOTHING")
+          "claim-delayed-silence! states it emits nothing")
+
+      ;; --- the CORRECT protocol is stated positively ---
+      (is (str/includes? src "runs OUTSIDE both locks")
+          "module comment states the emit runs OUTSIDE both locks")
+      (is (str/includes? publish "OUTSIDE")
+          "claim-and-publish-delayed-silence! states the emit runs outside the locks")
+      (is (str/includes? put-doc "OUTSIDE the ledger locks")
+          "put-listener! states the emit runs outside the ledger locks"))))

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -1908,18 +1908,30 @@ Common keys (`:category`, `:failing-id`, `:reason`, `:frame`) are inherited from
   ;; the consumer's call. Per Tool-Pair §Surface behaviour against
   ;; destroyed frames.
   ;;
-  ;; :observed-gen is the reserved callback generation the silence is
-  ;; attributed to (a process-monotonic int token). The emit runs OUTSIDE the
-  ;; ledger locks, so this qualifier — not a lock — preserves generation
-  ;; authority: a receiver whose current generation for cb-id no longer equals
-  ;; the carried :observed-gen self-filters the superseded signal (rf2-8b9twg).
-  ;; The receiver reads that current generation through the supported
-  ;; re-frame.epoch/epoch-listener-generation query (rf2-6ys5n), not the private
-  ;; registry. Per 009 §The delayed-silence emission linearization law.
+  ;; :cb-id is the listener id VERBATIM — the SAME open comparable-ID domain the
+  ;; public register-epoch-listener! / register-listener! :epoch and the
+  ;; epoch-listener-generation query accept: ANY comparable value (a keyword,
+  ;; string, number, vector, …). The runtime emits the raw registered id, so this
+  ;; schema MUST NOT narrow it below what registration accepts — :any is the
+  ;; open-identifier domain (as for :rf.epoch/id / :rf.reply/work-id), NOT a
+  ;; keyword|string restriction.
+  ;;
+  ;; :observed-gen is the callback GENERATION the silence is attributed to — an
+  ;; OPAQUE, EQUALITY-ONLY token, NOT a public integer or ordering contract. Its
+  ;; internal representation is a process-monotonic counter, but that is an
+  ;; implementation detail consumers must never depend on (no arithmetic, no
+  ;; ordering); the schema is :any so no int/order contract leaks. A consumer
+  ;; compares it for EQUALITY only, against the current generation read through
+  ;; the supported re-frame.epoch/epoch-listener-generation query (rf2-6ys5n),
+  ;; never the private registry. The emit runs OUTSIDE the ledger locks, so this
+  ;; qualifier — not a lock — preserves generation authority: a receiver whose
+  ;; current generation for cb-id no longer equals the carried :observed-gen
+  ;; self-filters the superseded signal (rf2-8b9twg). Per 009 §The delayed-silence
+  ;; emission linearization law.
   [:map
    [:frame :keyword]
-   [:cb-id [:or :keyword :string]]
-   [:observed-gen :int]])
+   [:cb-id :any]
+   [:observed-gen :any]])
 
 ;; --- warnings: SSR / authoring-time advisories ---
 


### PR DESCRIPTION
## What

Reconciles the epoch silencing **schema** and **`epoch/state.cljc` source authority** to the already-shipped comparable-ID / opaque-generation / outside-lock design (rf2-8b9twg). **No runtime change** — the runtime is correct; the schema and several docstrings/comments lagged it. Closes rf2-4go8s.

## Why

PR #6191 exposed listener generation so generation-qualified silencing is publicly implementable. But `register-epoch-listener!` accepts **any comparable id** and the runtime emits that raw id as `:cb-id`, while `Spec-Schemas.md` narrowed the silencing-event `:cb-id` to `keyword|string` and declared `:observed-gen :int` — even though the public contract makes generations opaque/equality-only. Meanwhile several `state.cljc` docstrings/comments still claimed a ledger lock spans the external emit, or that a replacement/drop blocks until publication, and described the reserve-only helper as emitting an unqualified signal (it emits nothing).

## Changes

**`spec/Spec-Schemas.md` — `EpochCbSilencedOnFrameDestroyTags`**
- `:cb-id` `[:or :keyword :string]` → `:any` (the same open comparable-ID domain the public register/query API accepts; runtime emits the raw id verbatim).
- `:observed-gen` `:int` → `:any`, re-specified as an **opaque, equality-only** token (internal rep is a process-monotonic counter, but that is not a public int/order contract).

**`implementation/epoch/src/re_frame/epoch/state.cljc` (prose only — no logic)**
- Module comment + `with-claim-locks` + `put-listener!` / `drop-listener!` / `record-observation!` / `claim-delayed-silence!` / `claim-and-publish-delayed-silence!` docstrings reconciled to the real protocol: reserve/recheck under both locks, **release**, then emit a generation-qualified signal **OUTSIDE** the locks.
- Removed the stale emit-under-lock claims and the "reserve-only helper emits an unqualified signal" description (it emits nothing).
- Source authority now **explicitly allows** a replacement / unregister-drop / destroy / re-arm to land **between reservation and publication**, and explains `:observed-gen` makes that window race-coherent.

**Tests**
- `epoch_silence_contract_test.clj` (new, JVM): a non-keyword comparable id (a vector) round-trips through registration → generation query → emitted `:cb-id` verbatim → generation self-filter, and the emitted tags validate against the canonical schema **extracted from `Spec-Schemas.md`**. Plus a focused **source-contract tooth** over the named state.cljc docstrings/comment catching regression to emit-under-lock / reserve-only-emits language (not a general comment linter).
- `epoch_cljs_test.cljs`: CLJS peer proving non-keyword raw-ID preservation + generation-qualified self-filter.

## Quality gates

All green (run from the worker worktree):

- JVM epoch silencing suite incl. new contract test (`clojure -M:test -n …`): **21 tests, 3679 assertions, 0 failures/errors**
- New contract test focused: **2 tests, 21 assertions, 0 failures**
- `npm run test:cljs` (incl. new non-keyword CLJS test): **9902 tests, 48761 assertions, 0 failures/errors**
- `python -m mkdocs build --strict`: **exit 0**
- `python scripts/check_keyword_catalogue_drift.py`: **clean (0 findings)**

Red-before/green-after: the old schema rejected a valid non-keyword id the runtime accepts (and the AC6 tooth's forbidden-phrase assertions were present in the old prose); after, the schema accepts it and the tooth is green. Runtime tests stay green because there is no runtime change.
