### PR TITLE
docs(core): reconcile app-db counter seed with the rewritten introduction (rf2-gstf3)

### DIFF
--- a/docs/core/app-db.md
+++ b/docs/core/app-db.md
@@ -19,11 +19,11 @@ Almost everything else in re-frame2 stays simple *because* of that.
 
 ## A complete live counter
 
-The intro counter already seeded `:value 0` through its `:initialise` event; the
+The intro counter seeded `:value` explicitly through its `:initialise` event; the
 `(:value db 0)` in its subscription was a defensive display fallback, not the
-initializer. Here we extend that same initial map with a second fact — `:step-size` —
-so both begin explicit in one store. Click the buttons (edit the cell and press
-**`Ctrl-Enter`** / **`Cmd-Enter`** if you change the code):
+initializer. Here we reuse that same initialization pattern and add a second fact —
+`:step-size` — so both begin explicit in one store. Click the buttons (edit the cell
+and press **`Ctrl-Enter`** / **`Cmd-Enter`** if you change the code):
 
 ```cljs-rf2
 (require '[re-frame.core :as rf])

--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -149,8 +149,8 @@ speak them: timers, HTTP replies, route loaders. The next page,
 ## One map of state: app-db
 
 Each running instance holds application state as one immutable Clojure map —
-**app-db**. In the counter it starts `{}`, then becomes `{:value 0}` after
-`:initialise`, then `{:value 1}` after the first `:inc`.
+**app-db**. In the counter it starts `{}`, then becomes `{:value 3}` after
+`:initialise`, then `{:value 4}` after the first `:inc`.
 
 Handlers never "set state" as a side effect. They return the next map inside an
 effect description. [app-db](app-db.md) is the dedicated page for that doctrine.


### PR DESCRIPTION
## What

Commit `f4e39519a9` rewrote the introduction's live counter example to seed at **3**, but two dependent prose sites still narrated the old zero seed. This reconciles them (docs-consistency only, no runtime change). The introduction's live example is the source of truth and is left unchanged.

### Reconciled sites (file:line before → after)

- `docs/core/introduction.md:152-153` — the "One map of state: app-db" section narrated `{}` → `{:value 0}` → `{:value 1}`; now `{}` → `{:value 3}` → `{:value 4}`, agreeing with the live example (`[:initialise 3]`) and the earlier "isolated execution context" prose (line 91, already `{:value 3}`/`{:value 4}`).
- `docs/core/app-db.md:22-24` — dropped the stale claim that the intro seeded `:value 0`; now distinguishes the intro's explicit `:initialise` seed from the `(:value db 0)` subscription fallback, and says it **reuses the same initialization pattern** (adding `:step-size`) rather than extending "that same initial map." This decouples the app-db page's own teaching number (`{:value 0 :step-size 1}`) from the intro's, per the bead's lowest-drift guidance.

The app-db stepping-counter example and its own transition sequence are intentionally left seeded at `0` — a self-contained teaching number, no longer falsely claimed to be the intro's literal map.

## Acceptance criteria

- [x] The introduction's stated starting value, `:initialise` handler, app-db transition sequence, and first-increment value all agree numerically (all 3 → 4).
- [x] The app-db guide truthfully distinguishes the introduction's explicit seed from the subscription fallback.
- [x] The app-db transition says it reuses the same initialization pattern while adding `:step-size`; no false "same initial map" claim.
- [x] Introduction live example unchanged; no runtime change.

## Quality gates

- `python -m mkdocs build --strict` — exit 0 (docs/core builds, 0 new broken links). Remaining INFO lines are pre-existing (excluded/external links), not from this change.
- `scripts/check_doc_slugs.py` — n/a: edits touch only literal `:value` numbers in prose, no anchors or cross-links.

Closes rf2-gstf3
