### PR TITLE
fix(ui-compiler): enforce carrier identity at every read/write/finish boundary (rf2-qbjdu)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -135,7 +135,13 @@
          (when (instance? clojure.lang.IAtom v) v)))))
 
 #?(:clj
-   (defn- ui-owned-compiler-state []
+   (defn- owned-compiler-state
+     "Raw recognizer: the bound compiler-env state iff re-frame.ui-owned (a
+     private carrier key or Shadow's still-recognized outer bridge marker), else
+     nil. Does NOT validate build identity — every ambient read/write that
+     observes or mutates the carrier goes through `validated-compiler-state`,
+     which additionally fails closed on a malformed or contradictory identity."
+     []
      (when-let [a (compiler-env-atom)]
        (let [s @a]
          (when (ui-owned-compiler-state? s) s)))))
@@ -174,75 +180,96 @@
 ;; Ambient build identity
 ;; ---------------------------------------------------------------------------
 
-(defn- any-pass-open?
-  "Whether a lifecycle hook has an open compiler pass in this JVM. Used only
-  with a Shadow-shaped compiler env to reject an unresolved per-thread build
-  id while retaining the documented session fallback for plain CLJS compiler
-  and REPL contexts."
-  []
-  (boolean (some (comp true? :pass-open?) (vals @state))))
+#?(:clj
+   (defn- carrier-build-id
+     "THE single validated re-frame.ui build-identity resolver — private-carrier
+     presence, build-id extraction, and private-versus-Shadow agreement in ONE
+     place, resolved from re-frame.ui's OWN authority rather than Shadow's outer
+     marker. Every ambient read/write/finish boundary traverses it, so a
+     malformed or contradictory carrier is rejected fail-closed everywhere, not
+     just where `current-build-id` happens to be consulted.
+
+     When `compiler-state` carries re-frame.ui's private accepted carrier, that
+     carrier is authoritative: its `:build-id` is the answer. A private carrier
+     with a MISSING build id, or with an id that DISAGREES with a still-present
+     Shadow bridge id, fails loudly — downgrading to the process session
+     fallback could route this compilation into a different parallel build.
+
+     With no private carrier yet (the pre-hook window / legacy path) the state is
+     re-frame.ui-recognized ONLY through Shadow's outer bridge marker, so that
+     recognized bridge MUST supply the id: a bridge present without its leaf id
+     fails loudly rather than downgrade to the session fallback, which the
+     contract reserves for a genuinely plain CLJS/REPL environment carrying
+     NEITHER recognized marker NOR private carrier. Callers pass a state already
+     known re-frame.ui-owned (see `owned-compiler-state`); the fail-closed throw
+     is the gate."
+     [compiler-state]
+     (let [private?   (some #(contains? compiler-state %) private-carrier-keys)
+           private-id (get-in compiler-state [accepted-snapshot-key :build-id])
+           shadow-id  (get-in compiler-state
+                              [shadow-bridge-key :shadow.build/build-id])]
+       (if private?
+         (cond
+           (nil? private-id)
+           (throw
+            (ex-info
+             (str "re-frame.ui compiler found its private build carrier but no "
+                  "build id in the accepted snapshot; refusing the session-build "
+                  "fallback because it can route this compilation into a "
+                  "different parallel build")
+             {::error ::private-build-id-unresolved
+              :recovery :check-ui-build-carrier
+              :expected-path [accepted-snapshot-key :build-id]}))
+
+           (and (some? shadow-id) (not= shadow-id private-id))
+           (throw
+            (ex-info
+             (str "re-frame.ui compiler private build carrier id " private-id
+                  " disagrees with Shadow's still-present build id " shadow-id
+                  "; refusing to guess which build this compilation belongs to")
+             {::error ::private-build-id-shadow-disagreement
+              :recovery :check-ui-build-carrier
+              :private-build-id private-id
+              :shadow-build-id shadow-id}))
+
+           :else private-id)
+
+         ;; No private carrier yet: the state is re-frame.ui-recognized only
+         ;; through Shadow's outer bridge, which must therefore carry the id.
+         (do
+           (when (nil? shadow-id)
+             (throw
+              (ex-info
+               (str "re-frame.ui compiler could not resolve shadow's build id "
+                    "from a recognized build bridge; refusing the session-build "
+                    "fallback because it can route this compilation into a "
+                    "different parallel build")
+               {::error ::shadow-build-id-unresolved
+                :recovery :check-shadow-compiler-env
+                :expected-path [shadow-bridge-key :shadow.build/build-id]})))
+           shadow-id)))))
+
+#?(:clj
+   (defn- validated-compiler-state
+     "The ONE resolver every ambient accepted/scratch/overlay read and every
+     ambient write traverses: the bound owned compiler-state with its build
+     identity validated by `carrier-build-id`, which throws fail-closed on a
+     malformed or contradictory carrier BEFORE it can be observed or mutated.
+     nil when no owned carrier is bound (the genuinely plain / REPL fallback)."
+     []
+     (when-let [s (owned-compiler-state)]
+       (carrier-build-id s)                 ; fail-closed identity gate
+       s)))
 
 #?(:clj
    (defn- ambient-build-id
-     "The build id the current compilation belongs to, resolved from
-     re-frame.ui's OWN authority rather than Shadow's outer marker.
-
-     When the bound compiler-env carries re-frame.ui's private accepted carrier,
-     that carrier is authoritative: its `:build-id` is the answer. A private
-     carrier present with a MISSING build id, or with an id that DISAGREES with a
-     still-present Shadow bridge id, fails loudly — downgrading to the process
-     session fallback could route this compilation into a different parallel
-     build.
-
-     With no private carrier yet (the pre-hook window / legacy path) a
-     recognized Shadow bridge supplies the id; a recognized bridge missing its
-     leaf id while a pass is open still fails loudly. A plain/no-marker compiler
-     env returns nil and uses the documented session fallback."
+     "The build id the current compilation belongs to, resolved and validated
+     through `carrier-build-id` from re-frame.ui's OWN authority rather than
+     Shadow's outer marker. nil for a genuinely plain / REPL env (no owned
+     carrier), where `current-build-id` uses the session fallback."
      []
-     (when-let [compiler-state (ui-owned-compiler-state)]
-       (let [private?   (some #(contains? compiler-state %) private-carrier-keys)
-             private-id (get-in compiler-state [accepted-snapshot-key :build-id])
-             shadow-id  (get-in compiler-state
-                                [shadow-bridge-key :shadow.build/build-id])]
-         (if private?
-           (cond
-             (nil? private-id)
-             (throw
-              (ex-info
-               (str "re-frame.ui compiler found its private build carrier but no "
-                    "build id in the accepted snapshot; refusing the session-build "
-                    "fallback because it can route this compilation into a "
-                    "different parallel build")
-               {::error ::private-build-id-unresolved
-                :recovery :check-ui-build-carrier
-                :expected-path [accepted-snapshot-key :build-id]}))
-
-             (and (some? shadow-id) (not= shadow-id private-id))
-             (throw
-              (ex-info
-               (str "re-frame.ui compiler private build carrier id " private-id
-                    " disagrees with Shadow's still-present build id " shadow-id
-                    "; refusing to guess which build this compilation belongs to")
-               {::error ::private-build-id-shadow-disagreement
-                :recovery :check-ui-build-carrier
-                :private-build-id private-id
-                :shadow-build-id shadow-id}))
-
-             :else private-id)
-
-           ;; No private carrier yet: a recognized Shadow bridge supplies the id.
-           (do
-             (when (and (nil? shadow-id) (any-pass-open?))
-               (throw
-                (ex-info
-                 (str "re-frame.ui compiler could not resolve shadow's build id "
-                      "while a build pass is open; refusing the session-build "
-                      "fallback because it can route this compilation into a "
-                      "different parallel build")
-                 {::error ::shadow-build-id-unresolved
-                  :recovery :check-shadow-compiler-env
-                  :expected-path [shadow-bridge-key :shadow.build/build-id]})))
-             shadow-id))))))
+     (when-let [s (owned-compiler-state)]
+       (carrier-build-id s))))
 
 (defn current-build-id
   "The build id a contribution belongs to: the explicit `*build-id*`
@@ -279,9 +306,10 @@
      "Effective disposable slice for the currently bound Shadow compiler.
      During a file/watch pass this is `scratch`; during no-pass REPL work it is
      an isolated overlay seeded from the accepted snapshot. Neither is an
-     accepted successful-build authority."
+     accepted successful-build authority. The carrier's build identity is
+     validated (`validated-compiler-state`) before any slice is observed."
      []
-     (when-let [compiler-state (ui-owned-compiler-state)]
+     (when-let [compiler-state (validated-compiler-state)]
        (or (get compiler-state scratch-key)
            (get compiler-state repl-overlay-key)
            (assoc empty-slice
@@ -289,7 +317,7 @@
 
 #?(:clj
    (defn- ambient-accepted-slice []
-     (when-let [compiler-state (ui-owned-compiler-state)]
+     (when-let [compiler-state (validated-compiler-state)]
        (assoc empty-slice
               :committed (:registries (accepted-snapshot compiler-state))))))
 
@@ -374,6 +402,12 @@
          (let [updated (atom nil)]
            (swap! compiler-atom
                   (fn [compiler-state]
+                    ;; Fail-closed identity gate BEFORE any scratch/overlay
+                    ;; mutation: a carrier whose build identity is missing or
+                    ;; disagrees with a still-present Shadow bridge id must not
+                    ;; be written (the same authority `validated-compiler-state`
+                    ;; enforces on the read side).
+                    (carrier-build-id compiler-state)
                     (let [k (if (contains? compiler-state scratch-key)
                               scratch-key
                               repl-overlay-key)
@@ -682,7 +716,7 @@
   plain-JVM fallback build's committed digest. Real Shadow tooling should use
   `accepted-build-digest` with an explicit retained build-state."
   ([]
-   (if-let [compiler-state #?(:clj (ui-owned-compiler-state) :cljs nil)]
+   (if-let [compiler-state #?(:clj (validated-compiler-state) :cljs nil)]
      (:digest (accepted-snapshot compiler-state))
      (finalized-build-digest (current-build-id))))
   ([build-id]
@@ -714,8 +748,32 @@
 (defn shadow-finish-candidate
   "Derive, but do not externally publish, the successful compiler candidate
   from `build-state`'s disposable scratch. The snapshot version advances once
-  per finalized pass and its digest is computed exactly once."
+  per finalized pass and its digest is computed exactly once.
+
+  Before deriving anything, the supplied `build-id` is validated against
+  re-frame.ui's OWN accepted private carrier and any still-present Shadow bridge
+  id via `carrier-build-id` — the same fail-closed identity every ambient
+  read/write traverses. A carrier for build :A whose id disagrees with a
+  supplied :B (or with a still-present Shadow bridge :B) therefore cannot
+  finalize into a :B-stamped snapshot carrying A's registry rows: it fails
+  before a candidate is derived."
   [build-state build-id members]
+  ;; Fail-closed identity gate (JVM build-time only): the supplied build-id must
+  ;; agree with the accepted private carrier and any still-present Shadow bridge
+  ;; id before a candidate is derived.
+  #?(:clj
+     (when (ui-owned-compiler-state? (:compiler-env build-state))
+       (let [resolved (carrier-build-id (:compiler-env build-state))]
+         (when (and (some? resolved) (not= resolved build-id))
+           (throw
+            (ex-info
+             (str "re-frame.ui compile-finish supplied build id " build-id
+                  " disagrees with its accepted private build carrier id "
+                  resolved "; refusing to finalize a cross-build candidate")
+             {::error ::private-build-id-shadow-disagreement
+              :recovery :check-ui-build-carrier
+              :private-build-id resolved
+              :shadow-build-id build-id}))))))
   (let [accepted (accepted-snapshot build-state)
         scratch (get-in build-state [:compiler-env scratch-key])]
     (when-not (and scratch (:pass-open? scratch))

--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -189,22 +189,28 @@
      malformed or contradictory carrier is rejected fail-closed everywhere, not
      just where `current-build-id` happens to be consulted.
 
-     When `compiler-state` carries re-frame.ui's private accepted carrier, that
-     carrier is authoritative: its `:build-id` is the answer. A private carrier
-     with a MISSING build id, or with an id that DISAGREES with a still-present
-     Shadow bridge id, fails loudly — downgrading to the process session
-     fallback could route this compilation into a different parallel build.
+     Identity lives ONLY in the accepted-snapshot carrier (its `:build-id`); the
+     disposable scratch/overlay slices carry no identity. When `compiler-state`
+     carries that accepted carrier it is authoritative: its `:build-id` is the
+     answer. An accepted carrier with a MISSING build id, or with an id that
+     DISAGREES with a still-present Shadow bridge id, fails loudly — downgrading
+     to the process session fallback could route this compilation into a
+     different parallel build.
 
-     With no private carrier yet (the pre-hook window / legacy path) the state is
-     re-frame.ui-recognized ONLY through Shadow's outer bridge marker, so that
-     recognized bridge MUST supply the id: a bridge present without its leaf id
-     fails loudly rather than downgrade to the session fallback, which the
-     contract reserves for a genuinely plain CLJS/REPL environment carrying
-     NEITHER recognized marker NOR private carrier. Callers pass a state already
-     known re-frame.ui-owned (see `owned-compiler-state`); the fail-closed throw
-     is the gate."
+     With no accepted carrier yet (the pre-hook window / legacy path, or a
+     no-hook REPL/watch overlay) identity comes from Shadow's outer bridge
+     marker: a recognized bridge supplies the id. A recognized bridge present
+     without its leaf id fails loudly rather than downgrade to the session
+     fallback, which the contract reserves for a genuinely plain CLJS/REPL
+     environment carrying NEITHER recognized marker NOR carrier. Callers pass a
+     state already known re-frame.ui-owned (see `owned-compiler-state`); the
+     fail-closed throw is the gate."
      [compiler-state]
-     (let [private?   (some #(contains? compiler-state %) private-carrier-keys)
+     ;; `private?` is the ACCEPTED-SNAPSHOT identity carrier specifically — not
+     ;; the disposable scratch/overlay (which a no-hook REPL/watch write creates
+     ;; with no accepted snapshot and whose identity legitimately resolves from
+     ;; the Shadow bridge below).
+     (let [private?   (contains? compiler-state accepted-snapshot-key)
            private-id (get-in compiler-state [accepted-snapshot-key :build-id])
            shadow-id  (get-in compiler-state
                               [shadow-bridge-key :shadow.build/build-id])]

--- a/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
@@ -348,6 +348,151 @@
   (is (= #{:fallback/row} (set (keys (build/aggregate build/views :app))))
       "the same-keyed session slice is untouched by the private-carrier writes"))
 
+;; ---------------------------------------------------------------------------
+;; Carrier identity is enforced at EVERY read, write and finish boundary
+;; (rf2-qbjdu). #5970 made `current-build-id` fail-closed on a private carrier
+;; that is missing its id or disagrees with a still-present Shadow bridge, but
+;; the registry paths did not traverse that check: ambient reads, `contribute!`,
+;; and `shadow-finish-candidate` accepted a mismatched carrier. A carrier for
+;; build :A carrying a still-present Shadow bridge id :B must now be rejected
+;; fail-closed at each boundary — never observed, mutated, or finalized — while
+;; a genuinely agreeing carrier still passes.
+;; ---------------------------------------------------------------------------
+
+(defn- ab-carrier
+  "A compiler-env atom carrying re-frame.ui's PRIVATE accepted+scratch carrier
+  for `private-build` AND a still-present Shadow outer bridge naming a DIFFERENT
+  `shadow-build` — the exact A/B contradiction the boundary guards reject."
+  [private-build shadow-build members]
+  (atom (assoc (:compiler-env (build/prepare-shadow-build {} private-build
+                                                          (set members)
+                                                          (set members)))
+               :shadow.build.cljs-bridge/state
+               {:shadow.build/build-id shadow-build})))
+
+(deftest read-through-an-a-carrier-with-a-b-bridge-is-rejected
+  ;; Pre-seed an :a/view row in the private accepted carrier for :app-a and
+  ;; attach a still-present Shadow bridge naming :app-b. Pre-fix, every ambient
+  ;; read EXPOSED the row (the ui-owned recognizer skipped identity); now each
+  ;; read fails closed before observing the malformed carrier.
+  (binding [cljs-env/*compiler*
+            (atom {build/accepted-snapshot-key
+                   {:build-id :app-a
+                    :registries {'app.a {build/views {:a/view ["tfa" "hsa"]}}}
+                    :digest "d" :version 1}
+                   :shadow.build.cljs-bridge/state {:shadow.build/build-id :app-b}})]
+    (doseq [[label read-fn]
+            [[:aggregate          #(build/aggregate build/views)]
+             [:committed-aggregate #(build/committed-aggregate build/views)]
+             [:element-properties #(build/element-properties :x-el)]
+             [:pass-open?         #(build/pass-open?)]
+             [:finalized-digest   #(build/finalized-build-digest)]]]
+      (testing (name label)
+        (let [ex (try (read-fn) nil (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? ex)
+              (str (name label) " must reject the A-carrier + B-bridge read"))
+          (is (= :re-frame.ui.compiler.build/private-build-id-shadow-disagreement
+                 (:re-frame.ui.compiler.build/error (ex-data ex)))))))))
+
+(deftest write-through-an-a-carrier-with-a-b-bridge-is-rejected-before-mutation
+  ;; contribute! (the sole write boundary) must reject the mismatched carrier
+  ;; before it stages/upserts anything — pre-fix it created an overlay row and
+  ;; aggregate exposed it.
+  (let [carrier (ab-carrier :app-a :app-b '#{app.a})]
+    (binding [cljs-env/*compiler* carrier]
+      (let [ex (try (build/contribute! build/views 'app.a :a/view ["tfa" "hsa"])
+                    nil
+                    (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? ex)
+            "contribute! must reject a private-A / shadow-B carrier")
+        (is (= :re-frame.ui.compiler.build/private-build-id-shadow-disagreement
+               (:re-frame.ui.compiler.build/error (ex-data ex))))))
+    (is (nil? (get-in @carrier [build/scratch-key :staged 'app.a]))
+        "the rejected write staged nothing — fail BEFORE mutation")))
+
+(deftest read-and-write-through-a-private-carrier-missing-its-id-are-rejected
+  ;; A private carrier present but with NO build id in its accepted snapshot must
+  ;; reject reads and writes too, not only `current-build-id`.
+  (binding [cljs-env/*compiler*
+            (atom {build/accepted-snapshot-key
+                   {:registries {'app.a {build/views {:a/view ["tfa" "hsa"]}}}
+                    :digest "d" :version 0}})]        ; NO :build-id
+    (let [read-ex (try (build/aggregate build/views) nil
+                       (catch clojure.lang.ExceptionInfo e e))]
+      (is (= :re-frame.ui.compiler.build/private-build-id-unresolved
+             (:re-frame.ui.compiler.build/error (ex-data read-ex)))
+          "aggregate must reject a private carrier missing its build id"))
+    (let [write-ex (try (build/contribute! build/views 'app.a :b/view ["tfb" "hsb"])
+                        nil
+                        (catch clojure.lang.ExceptionInfo e e))]
+      (is (= :re-frame.ui.compiler.build/private-build-id-unresolved
+             (:re-frame.ui.compiler.build/error (ex-data write-ex)))
+          "contribute! must reject the same carrier before mutation"))))
+
+(deftest recognized-bridge-without-build-id-fails-loud-even-with-no-pass-open
+  ;; The bead's third case: a recognized Shadow bridge carrying no leaf id must
+  ;; NOT downgrade to the session fallback merely because no pass is marked open
+  ;; — the fallback is reserved for a genuinely plain env with NEITHER marker NOR
+  ;; carrier. (`hook-open-shadow-compile-without-build-id-fails-loud` covers the
+  ;; pass-open variant; this covers the no-pass variant that pre-fix downgraded.)
+  (binding [cljs-env/*compiler* (atom {:shadow.build.cljs-bridge/state {}})]
+    (let [ex (try (build/current-build-id) nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex)
+          "a recognized bridge with no id must fail even with no pass open")
+      (is (= :re-frame.ui.compiler.build/shadow-build-id-unresolved
+             (:re-frame.ui.compiler.build/error (ex-data ex)))))
+    (is (thrown? clojure.lang.ExceptionInfo (build/aggregate build/views))
+        "and the ambient read fails closed the same way")))
+
+(deftest finish-with-supplied-id-contradicting-the-carrier-is-rejected
+  ;; The finish boundary: pre-fix `shadow-finish-candidate` trusted its explicit
+  ;; build-id argument and would stamp a :B snapshot from an :A carrier's scratch.
+  ;; Both a still-present disagreeing Shadow bridge and a bare supplied-id
+  ;; mismatch must now fail before a candidate is derived.
+  (doseq [{:keys [label attach-bridge?]}
+          [{:label "A-carrier + still-present B-bridge" :attach-bridge? true}
+           {:label "A-carrier, no bridge, supplied B"    :attach-bridge? false}]]
+    (testing label
+      (let [prepared (build/prepare-shadow-build {} :app-a '#{app.a} '#{app.a})
+            build-state (cond-> prepared
+                          attach-bridge?
+                          (assoc-in [:compiler-env
+                                     :shadow.build.cljs-bridge/state]
+                                    {:shadow.build/build-id :app-b}))
+            ex (try (build/shadow-finish-candidate build-state :app-b '#{app.a})
+                    nil
+                    (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? ex)
+            "finish must reject a supplied id contradicting the accepted carrier")
+        (is (= :re-frame.ui.compiler.build/private-build-id-shadow-disagreement
+               (:re-frame.ui.compiler.build/error (ex-data ex))))
+        (is (= :app-a (:private-build-id (ex-data ex))))
+        (is (= :app-b (:shadow-build-id (ex-data ex))))))))
+
+(deftest matched-carrier-passes-reads-writes-and-finish
+  ;; The control: a genuinely agreeing carrier (private :app == bridge :app) must
+  ;; still pass at EVERY boundary — the guards reject only contradictions.
+  (let [carrier (atom (assoc (:compiler-env
+                              (build/prepare-shadow-build {} :app '#{app.a}
+                                                          '#{app.a}))
+                             :shadow.build.cljs-bridge/state
+                             {:shadow.build/build-id :app}))]
+    (binding [cljs-env/*compiler* carrier]
+      (is (nil? (build/contribute! build/views 'app.a :a/view ["tfa" "hsa"]))
+          "a matched carrier accepts the write")
+      (is (= {:a/view ["tfa" "hsa"]} (build/aggregate build/views))
+          "and the read exposes the staged row")
+      (is (string? (build/finalized-build-digest))
+          "and the digest read resolves"))
+    (let [finished (build/shadow-finish-candidate {:compiler-env @carrier}
+                                                  :app '#{app.a})]
+      (is (= :app (get-in finished [:snapshot :build-id]))
+          "finish with the agreeing supplied id publishes an :app-stamped snapshot")
+      (is (= {:a/view ["tfa" "hsa"]}
+             (get-in finished [:snapshot :registries 'app.a build/views]))
+          "carrying app.a's own committed row"))))
+
 (deftest explicit-view-id-collision-fails-in-either-compile-order
   (doseq [[first-ns second-ns] [['app.alpha 'app.beta]
                                 ['app.beta 'app.alpha]]]


### PR DESCRIPTION
Closes rf2-qbjdu.

## Problem

PR #5970 (rf2-vxgfnd.192) introduced ambient-build-id to make the re-frame.ui
private carrier authoritative and fail-closed, but the identity check only ran
where `current-build-id` was consulted — not on the actual registry paths.
`ambient-shadow-slice` / `ambient-accepted-slice` read the compiler state
directly; `update-current-slice!` gated only on `ui-owned-compiler-state?`
before mutating scratch/overlay; `shadow-finish-candidate` trusted its explicit
build-id argument. So a carrier prepared for build `:A` carrying a still-present
Shadow bridge id `:B` was accepted at reads, at `contribute!`, and at finish —
`shadow-finish-candidate` would even stamp a `:B` snapshot from `:A`'s scratch,
cross-publishing registries/digests under contradictory build authority.

## Fix

One validated resolver owns presence + extraction + agreement, and every
boundary traverses it:

- **`carrier-build-id`** — the single validated identity resolver (private
  presence, build-id extraction, private-vs-Shadow agreement), extracted from
  the old `ambient-build-id` body. Reuses the existing error-ids
  `::private-build-id-unresolved`, `::private-build-id-shadow-disagreement`,
  `::shadow-build-id-unresolved`.
- **`validated-compiler-state`** — owned compiler-state with its identity
  validated fail-closed. Every ambient **read** (`aggregate`,
  `committed-aggregate`, `element-properties`, `pass-open?`,
  `finalized-build-digest`) now goes through it.
- **`update-current-slice!`** — validates identity inside the swap, before any
  scratch/overlay **write**.
- **`shadow-finish-candidate`** — validates its supplied build-id against the
  accepted private carrier and any still-present Shadow bridge before deriving a
  candidate (JVM-only reader conditional).

A recognized Shadow bridge with **no leaf id** now fails closed
unconditionally (previously only when a pass was open); the session fallback is
reserved for a genuinely plain CLJS/REPL env with neither marker nor carrier.

No new error-id, no carrier/build-hook redesign — the boundary gaps are closed
by routing the existing #5970 mechanism through one resolver.

## Boundaries closed (build.cljc)

| Boundary | Site | Before | After |
| --- | --- | --- | --- |
| read | `ambient-shadow-slice`, `ambient-accepted-slice`, `finalized-build-digest` | direct `ui-owned-compiler-state` read | `validated-compiler-state` (fail-closed) |
| write | `update-current-slice!` swap | gated only on `ui-owned-compiler-state?` | `carrier-build-id` before mutation |
| finish | `shadow-finish-candidate` | trusts explicit `build-id` arg | validates arg vs carrier + bridge |

## Quality gates

- `implementation/ui` JVM (`clojure -M:test`): **786 tests, 14411 assertions, 0 failures, 0 errors** (includes the build-hook + digest-carrier + G-13/G-14 suites).
- `npm run test:cljs`: **9910 tests, 48804 assertions, 0 failures, 0 errors** (confirms build.cljc still compiles clean under CLJS after the reader-conditional guard).
- **Red-before / green-after:** with the source reverted to `origin/main` and the new tests in place, the 6 new adversarial tests produced **26 failures** across the read (5 read fns), write, finish (bridge + no-bridge variants), missing-private-id, and recognized-bridge-no-id boundaries; the `matched-carrier-passes-reads-writes-and-finish` control passed in both. With the fix, all green.

Adversarial coverage added (per boundary, plus the matched-carrier control):
`read-through-an-a-carrier-with-a-b-bridge-is-rejected`,
`write-through-an-a-carrier-with-a-b-bridge-is-rejected-before-mutation`,
`read-and-write-through-a-private-carrier-missing-its-id-are-rejected`,
`recognized-bridge-without-build-id-fails-loud-even-with-no-pass-open`,
`finish-with-supplied-id-contradicting-the-carrier-is-rejected`,
`matched-carrier-passes-reads-writes-and-finish`.
