### PR TITLE
fix(core): make clear-http-interceptor opts form exact and fail-closed (rf2-s32bf)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -2605,17 +2605,19 @@
 
 (def ^{:doc "Clear an HTTP interceptor by `id` from a frame's
   `:rf.http/managed` middleware chain. EP-0002 context-required
-  frame-local: the single-arity `(clear-http-interceptor id)` resolves
-  the frame through the carried-invariant scope chain; pass the public
-  opts form `(clear-http-interceptor id {:frame target})` to name the
-  frame explicitly (the *override*) — `target` is a frame-id keyword or a
-  live frame value. Per rf2-f28bno the 2-arity is SHAPE-DISCRIMINATED on
-  the second arg (mirroring `reg-http-interceptor`'s `:frame` opt): an
-  opts map ⇒ the public form; a bare frame target ⇒ the internal
-  frame-first plumbing. Under no scope and no explicit frame the call
-  raises `:rf.error/no-frame-context` — it does NOT synthesise a
-  `:rf/default` target. Implementation ships in `day8/re-frame2-http`.
-  Per Spec 014 §Middleware. Late-bound via `:http/clear-http-interceptor`."}
+  frame-local. The public surface is EXACT: `(clear-http-interceptor id)`
+  clears in ambient scope (resolved through the carried-invariant scope
+  chain; under no scope raises `:rf.error/no-frame-context`, never a
+  synthesised `:rf/default`), and `(clear-http-interceptor id {:frame target})`
+  names the frame explicitly (the *override*) — `target` is a frame-id
+  keyword or a live frame value. The opts map is FAIL-CLOSED: it must be
+  EXACTLY `{:frame target}` with a present, non-nil target; a missing
+  `:frame`, a nil target, a misspelled/unknown or extra key, and a non-map
+  second argument all raise the typed `:rf.error/http-bad-interceptor`
+  before any ambient frame is touched (rf2-s32bf). Two-scalar frame-first
+  `(frame id)` is not a public shape. Implementation ships in
+  `day8/re-frame2-http`. Per Spec 014 §Middleware. Late-bound via
+  `:http/clear-http-interceptor`."}
   clear-http-interceptor           rf-http/clear-http-interceptor)
 
 ;; reg-http-interceptor is a macro (per the defreg-macro form above) so

--- a/implementation/core/src/re_frame/core_http.cljc
+++ b/implementation/core/src/re_frame/core_http.cljc
@@ -85,21 +85,28 @@
 
 (defwrapper clear-http-interceptor
   "Spec 014 §Middleware — clear an HTTP interceptor by id from a frame's
-  chain. EP-0002 context-required frame-local: the single-arity
-  `(clear-http-interceptor id)` resolves the frame through the
-  carried-invariant scope chain (a `with-frame` / frame-provider scope).
-  Pass the public opts form `(clear-http-interceptor id {:frame target})`
-  to name the frame explicitly (the *override*); `target` is a frame-id
-  keyword or a live frame value. Per rf2-f28bno the 2-arity is
-  SHAPE-DISCRIMINATED on the second arg (mirroring `reg-http-interceptor`'s
-  `:frame` opt): an opts map ⇒ the public form; a bare frame target ⇒ the
-  internal frame-first plumbing. Under no scope and no explicit frame the
-  call raises `:rf.error/no-frame-context` — it does NOT synthesise a
-  `:rf/default` target. Both arities delegate to the late-bound impl,
-  which performs the frame resolution.
+  chain. EP-0002 context-required frame-local. The public surface is EXACT:
+
+    (clear-http-interceptor id)                  ;; ambient scope
+    (clear-http-interceptor id {:frame target})  ;; explicit frame
+
+  The single-arity `(clear-http-interceptor id)` resolves the frame through
+  the carried-invariant scope chain (a `with-frame` / frame-provider scope);
+  under no scope it raises `:rf.error/no-frame-context` — it does NOT
+  synthesise a `:rf/default` target.
+
+  The two-arity opts form names the frame explicitly (the *override*) —
+  `target` is a frame-id keyword or a live frame value. The opts map is
+  FAIL-CLOSED: it must be EXACTLY `{:frame target}` with a present, non-nil
+  target. A missing `:frame`, a nil target, a misspelled/unknown or extra
+  key, and a non-map second argument all raise the typed
+  `:rf.error/http-bad-interceptor` before any ambient frame is touched
+  (rf2-s32bf). Two-scalar frame-first `(frame id)` is NOT a public shape.
+  Both arities delegate to the late-bound impl, which performs the frame
+  resolution.
 
   Late-bound via `:http/clear-http-interceptor`. When the http artefact
   is absent the call raises `:rf.error/http-artefact-missing`."
   {:hook :http/clear-http-interceptor :artefact http-artefact :on-absent :throw}
-  ([id]          :delegate)
-  ([id-or-frame b] :delegate))
+  ([id]      :delegate)
+  ([id opts] :delegate))

--- a/implementation/http/src/re_frame/http/managed.cljc
+++ b/implementation/http/src/re_frame/http/managed.cljc
@@ -249,19 +249,21 @@
                   interceptor by id as an fx. Args is the map
                   `{:frame <id> :id <kw>}` (NOT positional, matching the
                   fx-convention shape — sibling to `:rf.fx/reg-http-interceptor`
-                  which also takes a map). The fn-form `clear-http-interceptor`
-                  is the call-site surface (public opts form `(id {:frame f})`,
-                  or the internal frame-first plumbing this fx threads through);
-                   this fx is the data-shaped surface for EDN-driven callers.
+                  which also takes a map). The public call-site surface is
+                  the fn-form `clear-http-interceptor`'s opts form
+                  `(id {:frame f})`; this fx is the data-shaped surface for
+                  EDN-driven callers. It already holds a resolved frame, so it
+                  routes through the artefact-internal `clear-http-interceptor*`
+                  seam (frame-first) rather than the public opts form (rf2-s32bf).
 
                   EP-0002 — the carried frame is the fx-context `:frame`
                   (the cascade envelope stamp); the args `:frame` is the
                   per-call *override*. The args frame wins, else the
-                  fx-context frame, threaded explicitly into the fn-form's
-                   internal frame-first arity so it never repairs
-                   to a synthesised `:rf/default`."}
+                  fx-context frame, threaded explicitly into the internal
+                  frame-first seam so it never repairs to a synthesised
+                  `:rf/default`."}
            (fn [{ctx-frame :frame} {:keys [frame id]}]
-             (middleware/clear-http-interceptor (or frame ctx-frame) id)))
+             (middleware/clear-http-interceptor* (or frame ctx-frame) id)))
 
 ;; The canned effects and stub helpers are registered only when
 ;; `re-frame.http.test-support` is explicitly required. The namespace boundary,

--- a/implementation/http/src/re_frame/http/middleware.cljc
+++ b/implementation/http/src/re_frame/http/middleware.cljc
@@ -200,14 +200,20 @@
                     :id    id}))
     id))
 
-(defn- clear-http-interceptor*
-  "Core clear: drop the slot named `id` from `frame`'s chain and emit the
-  `:rf.http.interceptor/cleared` trace when a slot actually existed. `frame`
-  is a resolved frame TARGET (a frame-id keyword or a live frame value) —
-  normalized to its frame-id before keying the per-frame registry, so both
-  spellings land on the same chain. The single clear mechanic both public
-  arities (ambient / opts / internal frame-first) funnel through. Returns
-  `id`."
+(defn clear-http-interceptor*
+  "Internal frame-first clear seam: drop the slot named `id` from `frame`'s
+  chain and emit the `:rf.http.interceptor/cleared` trace when a slot actually
+  existed. `frame` is a RESOLVED frame TARGET (a frame-id keyword or a live
+  frame value) — normalized to its frame-id before keying the per-frame
+  registry, so both spellings land on the same chain.
+
+  This is the artefact-internal `(frame id)` seam — NOT part of the public
+  `re-frame.core` surface (only `clear-http-interceptor` is late-bound to
+  core). Internal cleanup that already holds a resolved frame — the
+  `:rf.fx/clear-http-interceptor` fx (which carries the fx-context frame) —
+  routes through here directly rather than the public opts form (rf2-s32bf).
+  Both public arities also funnel through it once they have resolved a frame.
+  Returns `id`."
   [frame id]
   (let [frame-id (frame/frame-target->id frame)
         existed? (some? (some (fn [v] (when (= (:id v) id) v))
@@ -221,60 +227,67 @@
                     :id    id}))
     id))
 
+(defn- valid-clear-opts?
+  "The public two-arity opts map must be EXACTLY `{:frame target}` — the sole
+  key is `:frame` and its value is a PRESENT, non-nil frame TARGET (a frame-id
+  keyword or a live frame value). Rejects a missing `:frame`, a nil target, a
+  misspelled/unknown key, an extra key, and any non-map second argument. A
+  frame VALUE is itself a map (carries `:rf.frame/object`); `frame-value?`
+  distinguishes it from a bare-keyword target."
+  [opts]
+  (and (map? opts)
+       (= #{:frame} (set (keys opts)))
+       (let [target (:frame opts)]
+         (or (keyword? target)
+             (frame/frame-value? target)))))
+
 (defn clear-http-interceptor
   "Unregister an HTTP interceptor by id from a frame's chain.
 
-  EP-0002 — context-required frame-local. The single-arity
-  `(clear-http-interceptor id)` resolves the frame through the
-  carried-invariant scope chain (a `with-frame` / frame-provider scope).
-  Pass the public opts form `(clear-http-interceptor id {:frame target})`
-  to name the frame explicitly (the *override*) — `target` is a frame-id
-  keyword or a live frame value. When the resolved frame is absent
-  (single-arity under no scope, or opts `{:frame nil}`), raises the
-  always-on `:rf.error/no-frame-context` rather than clearing against a
-  synthesised `:rf/default`. No-arg form not supported — explicit ids only.
+  EP-0002 — context-required frame-local. The public surface is EXACT:
 
-  Per rf2-f28bno the 2-arity is SHAPE-DISCRIMINATED on the second arg,
-  mirroring `reg-http-interceptor`'s `:frame` opt (and the family's
-  rf2-bfadc6 / EP-0024 disposition — public frame targeting is a trailing
-  `{:frame …}` opts map, never positional): an OPTS MAP (a non-frame-value
-  map) ⇒ the public `(clear-http-interceptor id {:frame target})` form;
-  anything else ⇒ the INTERNAL frame-first `(clear-http-interceptor frame
-  id)` plumbing (a frame-id keyword or frame value first, id second),
-  retained for implementation / test / tooling reach. This closes the
-  silent-no-op misbind the old public frame-first arity carried: an author
-  who learned `(reg-http-interceptor id {… :frame f})` and wrote the
-  natural `(clear-http-interceptor id {:frame f})` used to bind `id` as the
-  frame and `{:frame f}` as the interceptor-id — a clear of an interceptor
-  that never existed, no-op with nothing to name the mistake — and now
-  binds the frame correctly."
-  ([id] (clear-http-interceptor*
-          (frame/require-current-frame!
-            :clear-http-interceptor
-            {:where 'rf/clear-http-interceptor :event-id id})
-          id))
-  ([a b]
-   ;; rf2-f28bno: an OPTS MAP (non-frame-value map) is the PUBLIC
-   ;; `(clear-http-interceptor id {:frame target})` form — `a` is the id,
-   ;; `(:frame b)` the explicit frame target (`nil`/absent ⇒ resolve the
-   ;; ambient frame, which raises `:rf.error/no-frame-context` under no
-   ;; scope, never a `:rf/default` floor). Anything else is the INTERNAL
-   ;; frame-first plumbing: `a` is the frame target, `b` the id. A frame
-   ;; VALUE is itself a map (carries `:rf.frame/object`), so the opts
-   ;; discriminator is `map? AND NOT frame-value?`.
-   (if (and (map? b) (not (frame/frame-value? b)))
-     (clear-http-interceptor*
-       (or (:frame b)
-           (frame/require-current-frame!
-             :clear-http-interceptor
-             {:where 'rf/clear-http-interceptor :event-id a}))
-       a)
-     (clear-http-interceptor*
-       (or a
-           (frame/require-current-frame!
-             :clear-http-interceptor
-             {:where 'rf/clear-http-interceptor :event-id b}))
-       b))))
+    (clear-http-interceptor id)                  ;; ambient scope
+    (clear-http-interceptor id {:frame target})  ;; explicit frame
+
+  The single-arity `(clear-http-interceptor id)` resolves the frame through
+  the carried-invariant scope chain (a `with-frame` / frame-provider scope);
+  under no scope it raises the always-on `:rf.error/no-frame-context` rather
+  than clearing against a synthesised `:rf/default`.
+
+  The two-arity opts form names the frame explicitly (the *override*) —
+  `target` is a frame-id keyword or a live frame value. The opts map is
+  FAIL-CLOSED: it must be EXACTLY `{:frame target}` with a present, non-nil
+  target. A missing `:frame`, a nil target, a misspelled/unknown or extra
+  key, and a non-map second argument all raise the typed
+  `:rf.error/http-bad-interceptor` (mirroring `reg-http-interceptor`'s arg
+  validation) BEFORE any ambient frame is resolved or touched. This closes
+  the silent mis-clear the old `(or (:frame opts) ambient-frame)` resolution
+  carried (rf2-s32bf): `(clear-http-interceptor id {})` or a typo'd
+  `{:fram f}` used to silently clear the AMBIENT frame instead of failing.
+
+  Two-scalar frame-first `(clear-http-interceptor frame id)` is NOT a public
+  shape. Artefact-internal cleanup that already holds a resolved frame — the
+  `:rf.fx/clear-http-interceptor` fx — routes through the `clear-http-interceptor*`
+  seam instead. No-arg form is not supported — explicit ids only."
+  ([id]
+   (clear-http-interceptor*
+     (frame/require-current-frame!
+       :clear-http-interceptor
+       {:where 'rf/clear-http-interceptor :event-id id})
+     id))
+  ([id opts]
+   ;; rf2-s32bf — the PUBLIC two-arity is ONLY `(id {:frame target})`.
+   ;; Fail-closed: reject anything that is not exactly `{:frame target}`
+   ;; (present, non-nil) BEFORE resolving or touching the ambient frame. This
+   ;; also rejects the old two-scalar frame-first shape — a keyword or other
+   ;; scalar second arg is not a valid opts map. The explicit target names the
+   ;; frame; the opts form never falls back to the ambient scope.
+   (when-not (valid-clear-opts? opts)
+     (error/throw-error!
+       :rf.error/http-bad-interceptor 'rf/clear-http-interceptor
+       "expected (clear-http-interceptor id {:frame target}): the two-arity opts map must be exactly {:frame target} with a present, non-nil frame target (a frame-id keyword or a live frame value). Two-scalar frame-first (frame id) is not a public shape."
+       {:extra {:received {:id id :opts opts}}}))
+   (clear-http-interceptor* (:frame opts) id)))
 
 (defn clear-all-http-interceptors!
   "Test-time helper: drop the per-frame interceptor registry."

--- a/implementation/http/test/re_frame/http_interceptors_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_interceptors_cljs_test.cljs
@@ -21,7 +21,8 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
-            [re-frame.http.managed :as http-managed]))
+            [re-frame.http.managed :as http-managed]
+            [re-frame.http.middleware :as http-mw]))
 
 ;; EP-0002 (rf2-nn0jqa): the no-`:frame` `reg-http-interceptor` /
 ;; `clear-http-interceptor` calls below resolve the frame through the
@@ -147,18 +148,19 @@
     (is (zero? (count (http-managed/interceptors-snapshot :rf/default))))
     (is (= [:on-other] (mapv :id (http-managed/interceptors-snapshot :other))))))
 
-;; ---- 4a. rf2-f28bno — frame-arg spelling: the public {:frame} opts form ----
+;; ---- 4a. rf2-f28bno / rf2-s32bf — the public {:frame} opts form ------------
 ;;
-;; `clear-http-interceptor`'s public 2-arity is now the trailing `{:frame …}`
-;; opts map (mirroring `reg-http-interceptor`'s `:frame`), shape-discriminated
-;; against the retained internal frame-first plumbing. This closes the
-;; silent-no-op misbind the old public frame-first arity carried.
+;; `clear-http-interceptor`'s public 2-arity is EXACTLY the trailing
+;; `{:frame …}` opts map (mirroring `reg-http-interceptor`'s `:frame`).
+;; Two-scalar frame-first is not a public shape; artefact-internal cleanup
+;; routes through the `clear-http-interceptor*` seam. This closes the silent
+;; mis-clear the old `(or (:frame opts) ambient-frame)` resolution carried.
 
 (deftest clear-http-interceptor-frame-arg-spelling-rf2-f28bno
   (testing "rf2-f28bno — `(clear-http-interceptor id {:frame f})` targets frame
-            `f` from an ambient `:rf/default` scope; the internal frame-first
-            `(clear-http-interceptor f id)` plumbing is retained; and the old
-            misbind guess now binds the frame correctly instead of no-op'ing."
+            `f` from an ambient `:rf/default` scope; the internal
+            `clear-http-interceptor*` seam (frame-first) still clears; and the
+            old misbind guess now binds the frame correctly instead of no-op'ing."
     ;; The ambient scope is :rf/default (fixture). Register on the OTHER frame.
     (rf/reg-http-interceptor :fa/on-other {:frame :fa/other :before (fn [c] c)})
     (rf/reg-http-interceptor :fa/on-default {:before (fn [c] c)})
@@ -173,12 +175,50 @@
         "opts {:frame :fa/other} cleared the named frame's slot (misbind closed)")
     (is (= [:fa/on-default] (mapv :id (http-managed/interceptors-snapshot :rf/default)))
         "the :rf/default chain is untouched by the explicit-frame clear")
-    ;; (2) INTERNAL frame-first plumbing still clears a named frame's slot.
+    ;; (2) INTERNAL frame-first seam still clears a named frame's slot.
     (rf/reg-http-interceptor :fa/again {:frame :fa/other :before (fn [c] c)})
     (is (= [:fa/again] (mapv :id (http-managed/interceptors-snapshot :fa/other))))
-    (rf/clear-http-interceptor :fa/other :fa/again)   ;; frame-first: (frame id)
+    (http-mw/clear-http-interceptor* :fa/other :fa/again)   ;; private seam: (frame id)
     (is (zero? (count (http-managed/interceptors-snapshot :fa/other)))
-        "internal frame-first (frame id) plumbing cleared the slot")))
+        "internal frame-first seam (clear-http-interceptor*) cleared the slot")))
+
+;; ---- 4b. rf2-s32bf — the public opts form is EXACT + FAIL-CLOSED -----------
+
+(deftest clear-http-interceptor-opts-form-fail-closed-rf2-s32bf
+  (testing "rf2-s32bf — the public 2-arity opts map must be EXACTLY
+            {:frame target}; malformed opts, a non-map second arg, and the old
+            two-scalar frame-first shape fail closed with
+            :rf.error/http-bad-interceptor and leave the ambient interceptor
+            untouched; the exact {:frame target} form still clears."
+    (letfn [(threw-bad? [thunk]
+              (let [ex (try (thunk) nil (catch :default e e))]
+                (and (some? ex)
+                     (= :rf.error/http-bad-interceptor
+                        (:rf.error/id (ex-data ex))))))]
+      ;; ambient scope is :rf/default (fixture) — seed a slot there.
+      (rf/reg-http-interceptor :s32bf/ambient {:before (fn [c] c)})
+      (is (= [:s32bf/ambient]
+             (mapv :id (http-managed/interceptors-snapshot :rf/default))))
+      (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient {}))
+          "empty opts map (no :frame) fails closed")
+      (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient {:frame nil}))
+          "nil :frame fails closed")
+      (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient {:fram :rf/default}))
+          "misspelled opts key fails closed")
+      (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient {:frame :rf/default :extra 1}))
+          "extra opts key fails closed (map must be exactly {:frame target})")
+      (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient "not-a-map"))
+          "non-map second arg fails closed")
+      (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient 42))
+          "non-map scalar second arg fails closed")
+      (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient :some-frame))
+          "old two-scalar frame-first is not a public shape — fails closed")
+      (is (= [:s32bf/ambient]
+             (mapv :id (http-managed/interceptors-snapshot :rf/default)))
+          "no malformed clear touched the ambient :rf/default interceptor")
+      (rf/clear-http-interceptor :s32bf/ambient {:frame :rf/default})
+      (is (zero? (count (http-managed/interceptors-snapshot :rf/default)))
+          "the exact {:frame target} form clears the named frame"))))
 
 ;; ---- 5. invalid shape raises ----------------------------------------------
 

--- a/implementation/http/test/re_frame/http_interceptors_test.clj
+++ b/implementation/http/test/re_frame/http_interceptors_test.clj
@@ -27,6 +27,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.http.managed :as http-managed]
+            [re-frame.http.middleware :as http-mw]
             [re-frame.test-support :as test-support]
             [re-frame.trace :as trace])
   (:import [com.sun.net.httpserver HttpServer HttpHandler HttpExchange]
@@ -433,20 +434,20 @@
                (:rf.error/id (ex-data thrown)))
             "the throw is the always-on :rf.error/no-frame-context — no :rf/default floor")))))
 
-;; ---- 5b. rf2-f28bno — frame-arg spelling: the public {:frame} opts form ---
+;; ---- 5b. rf2-f28bno / rf2-s32bf — the public {:frame} opts form -----------
 ;;
-;; `clear-http-interceptor`'s public 2-arity is now the trailing `{:frame …}`
-;; opts map (mirroring `reg-http-interceptor`'s `:frame`), shape-discriminated
-;; against the retained internal frame-first plumbing. Registry-level (no
+;; `clear-http-interceptor`'s public 2-arity is EXACTLY the trailing
+;; `{:frame …}` opts map (mirroring `reg-http-interceptor`'s `:frame`).
+;; Two-scalar frame-first is not a public shape; artefact-internal cleanup
+;; routes through the `clear-http-interceptor*` seam. Registry-level (no
 ;; server): assert the opts form targets the named frame from an ambient
-;; :rf/default scope, the misbind is closed, and the internal frame-first
-;; plumbing still clears.
+;; :rf/default scope, the misbind is closed, and the internal seam still clears.
 
 (deftest clear-http-interceptor-frame-arg-spelling-rf2-f28bno
   (testing "rf2-f28bno — `(clear-http-interceptor id {:frame f})` targets frame
             `f` from the ambient :rf/default scope (the old-shape misbind that
             silently no-op'd now binds the frame correctly); the internal
-            frame-first `(clear-http-interceptor f id)` plumbing is retained."
+            `clear-http-interceptor*` seam (frame-first) still clears."
     ;; The ambient scope is :rf/default (fixture). Register on BOTH frames —
     ;; the interceptor registry is a per-frame-id atom independent of the
     ;; `frames` registry, so a named frame needs no separate registration (the
@@ -464,12 +465,61 @@
         "opts {:frame :fa/other} cleared the named frame's slot (misbind closed)")
     (is (= [:fa/on-default] (mapv :id (http-managed/interceptors-snapshot :rf/default)))
         "the :rf/default chain is untouched by the explicit-frame clear")
-    ;; (2) INTERNAL frame-first plumbing still clears a named frame's slot.
+    ;; (2) INTERNAL frame-first seam still clears a named frame's slot.
     (rf/reg-http-interceptor :fa/again {:frame :fa/other :before (fn [c] c)})
     (is (= [:fa/again] (mapv :id (http-managed/interceptors-snapshot :fa/other))))
-    (rf/clear-http-interceptor :fa/other :fa/again)   ;; frame-first: (frame id)
+    (http-mw/clear-http-interceptor* :fa/other :fa/again)   ;; private seam: (frame id)
     (is (zero? (count (http-managed/interceptors-snapshot :fa/other)))
-        "internal frame-first (frame id) plumbing cleared the slot")))
+        "internal frame-first seam (clear-http-interceptor*) cleared the slot")))
+
+;; ---- 5c. rf2-s32bf — the public opts form is EXACT + FAIL-CLOSED ----------
+;;
+;; The public 2-arity is ONLY `(clear-http-interceptor id {:frame target})`.
+;; A malformed opts map (empty, nil :frame, misspelled/unknown key, extra
+;; key), a non-map second arg, and the old two-scalar frame-first spelling
+;; all fail closed with the typed `:rf.error/http-bad-interceptor` BEFORE any
+;; ambient state is touched — the old `(or (:frame opts) ambient-frame)`
+;; resolution silently mis-cleared the ambient frame on any of these.
+
+(deftest clear-http-interceptor-opts-form-fail-closed-rf2-s32bf
+  (testing "rf2-s32bf — the public 2-arity opts map must be EXACTLY
+            {:frame target}; malformed opts, a non-map second arg, and the old
+            two-scalar frame-first shape fail closed with
+            :rf.error/http-bad-interceptor and leave the ambient interceptor
+            untouched; the exact {:frame target} form still clears."
+    (letfn [(threw-bad? [thunk]
+              (let [ex (try (thunk) nil
+                            (catch clojure.lang.ExceptionInfo e e))]
+                (and (some? ex)
+                     (= :rf.error/http-bad-interceptor
+                        (:rf.error/id (ex-data ex))))))]
+      ;; ambient scope is :rf/default (fixture) — seed a slot there.
+      (rf/reg-http-interceptor :s32bf/ambient {:before (fn [c] c)})
+      (is (= [:s32bf/ambient]
+             (mapv :id (http-managed/interceptors-snapshot :rf/default))))
+      ;; every malformed 2-arg form fails closed
+      (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient {}))
+          "empty opts map (no :frame) fails closed")
+      (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient {:frame nil}))
+          "nil :frame fails closed")
+      (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient {:fram :rf/default}))
+          "misspelled opts key fails closed")
+      (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient {:frame :rf/default :extra 1}))
+          "extra opts key fails closed (map must be exactly {:frame target})")
+      (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient "not-a-map"))
+          "non-map second arg fails closed")
+      (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient 42))
+          "non-map scalar second arg fails closed")
+      (is (threw-bad? #(rf/clear-http-interceptor :s32bf/ambient :some-frame))
+          "old two-scalar frame-first is not a public shape — fails closed")
+      ;; NO rejected call touched the ambient chain
+      (is (= [:s32bf/ambient]
+             (mapv :id (http-managed/interceptors-snapshot :rf/default)))
+          "no malformed clear touched the ambient :rf/default interceptor")
+      ;; the exact opts form still clears the ambient frame
+      (rf/clear-http-interceptor :s32bf/ambient {:frame :rf/default})
+      (is (zero? (count (http-managed/interceptors-snapshot :rf/default)))
+          "the exact {:frame target} form clears the named frame"))))
 
 ;; ---- 6. re-registering an id replaces in place ---------------------------
 


### PR DESCRIPTION
## What

The public `clear-http-interceptor` two-arity treated **any** second map as opts and resolved the target with `(or (:frame opts) ambient-frame)`. Under an ambient frame, a malformed opts map — `{}`, `{:frame nil}`, a typo'd `{:fram f}`, an extra key — or a non-map second argument **silently cleared the ambient interceptor** instead of failing. The two-scalar frame-first `(frame id)` spelling also leaked into the public surface.

This makes the public surface **exact** and **fail-closed**.

## Where the fix lives

The unsafe discriminator + `(or (:frame b) ambient-frame)` resolution is in the HTTP artefact's `implementation/http/src/re_frame/http/middleware.cljc` (`clear-http-interceptor` 2-arity, was ~line 265–271), **not** `core_http.cljc` — the facade there is a late-bind `defwrapper` that delegates to it, and the existing typed arg-validation error `:rf.error/http-bad-interceptor` lives in that artefact too. The fix therefore lands in `middleware.cljc` (+ the fx caller in `managed.cljc` + the artefact's JVM/CLJS tests), with the two facade docstrings (`core_http.cljc`, `core.cljc`) tightened to the exact contract.

## Contract (after)

- `(clear-http-interceptor id)` — clears in ambient scope (unchanged; under no scope raises `:rf.error/no-frame-context`).
- `(clear-http-interceptor id {:frame target})` — the opts map must be **exactly** `{:frame target}` with a present, non-nil target (frame-id keyword or live frame value). A missing `:frame`, nil target, misspelled/unknown or extra key, and a non-map second argument all raise the existing typed `:rf.error/http-bad-interceptor` **before any ambient frame is touched**.
- Two-scalar frame-first `(frame id)` is **not** a public shape. Artefact-internal cleanup (the `:rf.fx/clear-http-interceptor` fx, which already holds a resolved frame) routes through the `clear-http-interceptor*` private seam.

Reuses `:rf.error/http-bad-interceptor` — **no new error vocabulary, no new public arity/alias, no opts-schema framework, no facade redesign.**

## Red-before / green-after

New adversarial test (`clear-http-interceptor-opts-form-fail-closed-rf2-s32bf`, JVM + CLJS). Against the old code, **8 assertions failed** — every malformed form (`{}`, `{:frame nil}`, `{:fram …}`, `{:frame … :extra 1}`, `"not-a-map"`, `42`, `:some-frame`) silently succeeded, and the seeded ambient `:rf/default` interceptor was mis-cleared (`[:s32bf/ambient]` → `[]`). After the fix, each rejected call throws `:rf.error/http-bad-interceptor`, the ambient interceptor is proven untouched, and the exact `{:frame target}` form plus the single-arity ambient form still clear.

## Quality gates

- `clojure -M:test -n re-frame.http-interceptors-test` (focused JVM ns) — **34 tests, 114 assertions, 0 failures, 0 errors** (was 8 failures pre-fix).
- `npm run test:cljs` (full node-runtime CLJS suite, incl. the conformance fixture that drives clear via the data-shaped fx) — **9913 tests, 48822 assertions, 0 failures, 0 errors**.
- No facade metadata changed (manifest carries no docstring/arglist for this var); `docs/api/re-frame.core.md` already teaches the exact shapes (from #6199) — no doc/gen change needed.

## Out of fence — follow-up

Two consumer docs still teach the old frame-first form as public and are outside this fence (hot-zone/spec): `migration/from-re-frame-v1/README.md:1721` lists `(rf/clear-http-interceptor frame id)` under **Public API**, and `spec/014-HTTPRequests.md:869` describes it as "retained as internal plumbing". Both should be reconciled to the exact shapes (foldable into the spec keyword-drift sweep / a migration-guide bead).
