### PR TITLE
fix(trace): route by drain-lock ownership so serial delivery survives without the AB-BA deadlock (rf2-rakqk)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1665,6 +1665,41 @@
     (when-let [frame-record (frame frame-id)]
       (current-thread-is-drainer? frame-record))))
 
+(defn thread-owns-drain-serialization?
+  "True when the CALLING thread currently holds `frame-id`'s single-drainer
+  serialization — via EITHER path that takes the frame's `:drain-lock`: it is the
+  frame's active event DRAINER (`:in-drain?`, stamped around `run-one-pass!`), OR
+  the holder of a cold `call-serialized-with-drain!` critical section
+  (`:serialized-holder`). The both-axis sibling of `in-drain?` (which reports the
+  drainer axis alone).
+
+  This is the REAL lock-ownership evidence the trace tooling consults (via the
+  `:frame/thread-owns-drain-serialization?` late-bind hook) to decide whether an
+  outermost trace emit must drive its listener fan-out INLINE — a thread that
+  owns a frame's drain-lock must never block acquiring the trace `fanout-monitor`,
+  or a listener already holding the monitor that `dispatch-sync`es into that frame
+  closes the rf2-jl75r AB-BA cycle — versus serialize on the monitor like every
+  other clean emit (rf2-uw7hg). Unlike a `:frame`-tag / ambient-frame shape guess
+  (rf2-rakqk), this reports what the thread ACTUALLY holds right now, so a
+  frame-shaped emit issued OUTSIDE any held drain-lock (a public / manual / stale
+  `:frame` tag, an ambient-frame tool emit) correctly reports false and stays
+  serialized.
+
+  Returns false for an absent frame (nothing can be draining it, so no drain-lock
+  is held and no cycle can form)."
+  [frame-id]
+  (boolean
+    (when-let [frame-record (frame frame-id)]
+      (current-thread-owns-drain-serialization? frame-record))))
+
+;; Publish the drain-lock ownership probe so `re-frame.trace.tooling` can route
+;; an outermost emit inline-vs-monitor on REAL lock ownership (rf2-rakqk) rather
+;; than event-shape inference. Late-bound (not a static require) so a production
+;; CLJS bundle that never loads the tooling sibling still DCEs this edge, exactly
+;; like the sibling `:frame/current-frame-id` publication above.
+(late-bind/set-fn! :frame/thread-owns-drain-serialization?
+                   thread-owns-drain-serialization?)
+
 (defn call-serialized-with-drain!
   "Run thunk `f` serialized against `frame-id`'s event drain, returning its
   value. Used by per-frame lifecycle mutations that must not interleave with a

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -1116,6 +1116,10 @@
     :producer-ns 're-frame.frame
     :design-bead "rf2-g1b2m"
     :description "Read the currently-bound frame id from `re-frame.frame/*current-frame*`. Consulted by `re-frame.trace.tooling/push-to-ring!` as the routing fallback when the trace event itself does not carry a `:frame` tag (e.g. sub recompute / view render emits inside an in-flight cascade)."}
+   {:key         :frame/thread-owns-drain-serialization?
+    :producer-ns 're-frame.frame
+    :design-bead "rf2-rakqk"
+    :description "Return true when the CALLING thread currently holds `frame-id`'s single-drainer serialization — the frame's active event drainer (`:in-drain?`, stamped around `run-one-pass!`) OR the holder of a cold `call-serialized-with-drain!` critical section (`:serialized-holder`); the both-axis sibling of the drainer-only `in-drain?`. Consulted by `re-frame.trace.tooling/emit-under-owned-drain-lock?` as the REAL lock-ownership discriminator (not event-shape inference) that routes an outermost trace emit inline-vs-monitor: a thread that owns the target frame's `:drain-lock` must drive its listener fan-out INLINE (a listener already holding `fanout-monitor` may `dispatch-sync` into that frame and spin on its `:drain-lock` — the rf2-jl75r AB-BA seam), while a frame-shaped emit issued outside any held drain-lock serializes on the monitor like every clean emit (rf2-uw7hg). Returns false for an absent frame (nothing can be draining it). Dev-only: late-bound so a production CLJS bundle that never loads the tooling sibling DCEs the edge."}
 
    ;; ---- re-frame.trace.cascade (focused-event-only cascade-DAG aggregator) ----
    ;;

--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -758,7 +758,7 @@
 ;; emit still returns only after its record's callback has run (the monitor is
 ;; held for the whole synchronous drive and released before `emit!` returns).
 ;;
-;; ---- the frame-drain-emit deadlock seam (rf2-jl75r) -----------------------
+;; ---- the drain-lock ownership seam (rf2-jl75r + rf2-rakqk) -----------------
 ;;
 ;; Holding `fanout-monitor` across arbitrary listener bodies is NOT safe for an
 ;; emit issued while the emitting thread holds a frame's `:drain-lock`. Public
@@ -772,27 +772,42 @@
 ;; Neither can progress. `drain-block!`'s bounded-wait assumption is false because
 ;; the active drainer (T2) is itself waiting on the caller (T1).
 ;;
-;; The fix keeps the whole synchronous, ordered, serialized fan-out for clean
-;; emits but takes the monitor OUT of the cycle: a FRAME-DRAIN emit
-;; (`frame-drain-emit?` — one that ROUTES TO A FRAME the way `push-to-ring!` does,
-;; or a retentionless structural terminal fact) NEVER acquires the monitor. It
-;; drives its fan-out inline (exactly as CLJS always does), so the "drain-lock
-;; holder waits on the monitor" edge is removed and no cycle can form. A thread
-;; that holds a `:drain-lock` only ever emits frame-routed emits, so it never
-;; blocks on the monitor; a thread holding the monitor emitted a frameless
-;; external `emit!` and holds no `:drain-lock`, so nothing waits on it through one.
-;; Frame ROUTABILITY (not merely a `:rf.trace/dispatch-id`) is the load-bearing
-;; discriminator: the epoch cascade trailers (`:rf.epoch/snapshotted` /
-;; `:rf.epoch/outcome`) fire AFTER the buffer is harvested, `outside any cascade`
-;; (nil dispatch-id), yet still on the drainer thread holding the `:drain-lock` —
-;; a dispatch-id-only test misclassifies them and re-opens the deadlock, so the
-;; predicate keys on the frame the emit routes to. Same-thread reentrant delivery
-;; of the drain's own nested emits is unaffected — those take the `*fanout-ctx*`
-;; append+drive branch, never the monitor. The remaining relaxation is bounded and
-;; JVM-only: a frame-scoped clean emit, and two genuinely concurrent frame drains
-;; (never a thing on the single-threaded CLJS target), may drive inline and
-;; overlap a listener; frameless concurrent clean emits — the case rf2-uw7hg's
-;; suite exercises — still serialize on the monitor, unchanged.
+;; The fix keeps the whole synchronous, ordered, serialized fan-out but takes the
+;; monitor OUT of the cycle for exactly the emits that can close it: an emit whose
+;; thread ACTUALLY holds the target frame's `:drain-lock`
+;; (`emit-under-owned-drain-lock?`) NEVER acquires the monitor — it drives its
+;; fan-out inline (exactly as CLJS always does), so the "drain-lock holder waits
+;; on the monitor" edge is removed and no cycle can form.
+;;
+;; The discriminator is REAL LOCK-OWNERSHIP EVIDENCE, not event-shape inference
+;; (rf2-rakqk). jl75r's first cut keyed on frame ROUTABILITY — any `:frame` tag,
+;; caller-supplied dispatch-id, ambient frame, or `retain? false` bypassed the
+;; monitor — but a frame-SHAPED emit is not proof of lock ownership: a public /
+;; manual / stale `:frame` tag, an ambient-frame tool emit, or a retained
+;; frame-shaped `trace/emit!` issued OUTSIDE any drain owns no lock, yet was
+;; routed inline and so LOST the rf2-uw7hg whole-fanout serial law. The fix asks
+;; the frame engine (`:frame/thread-owns-drain-serialization?`) whether THIS
+;; thread holds that frame's single-drainer serialization right now — the active
+;; drainer (`:in-drain?`, stamped around `run-one-pass!`) OR the holder of a cold
+;; `call-serialized-with-drain!` section (`:serialized-holder`). Only then does it
+;; drive inline; otherwise it serializes on the monitor like every other emit.
+;;
+;; This is EXACT for every genuine drain / settle / teardown emit and no longer
+;; over-broad. The epoch cascade trailers (`:rf.epoch/snapshotted` /
+;; `:rf.epoch/outcome`) fire AFTER the buffer is harvested with a nil dispatch-id,
+;; yet carry a top-level `:frame` and run inside `settle-event-epoch!` while
+;; `:in-drain?` is still stamped — so ownership reports true and they stay inline
+;; (a dispatch-id-only test misclassified them). The retentionless structural
+;; terminals (`:rf.frame/destroyed` / `:rf.frame/drain-interrupted`) carry `:frame`
+;; and are emitted while the drain / destroy path owns the serialization — also
+;; inline, without a blanket `retain? false` bypass. Same-thread reentrant
+;; delivery of the drain's own nested emits is unaffected — those take the
+;; `*fanout-ctx*` append+drive branch, never the monitor. Because the evidence is
+;; exact, deadlock-freedom is unconditional: a false result PROVES no drain-lock is
+;; held (no AB-BA edge through the monitor); a true result acquires no monitor. The
+;; residual JVM-only relaxation is now the exact, minimal one — two genuinely
+;; concurrent frame drains of the SAME frame (never a thing on the single-threaded
+;; CLJS target) each own their drain-lock and drive inline.
 ;;
 ;; Same-thread reentrancy does NOT re-acquire the monitor: a nested emit sees
 ;; `*fanout-ctx*` already bound and takes the append+drive branch below, so it
@@ -818,53 +833,68 @@
      trace-listener fan-out across concurrent emits (rf2-uw7hg), so no registered
      listener callback is ever invoked on two threads at once and records reach
      each listener in one defined order. Held for the whole synchronous drive of
-     such an emit. A frame-drain emit (`frame-drain-emit?`) NEVER acquires it —
-     see the deadlock note below — and reentrant same-thread emits never acquire
-     it (they advance the bound `*fanout-ctx*` schedule). CLJS is single-threaded
-     and has no counterpart."
+     such an emit. An emit whose thread actually owns the target frame's
+     `:drain-lock` (`emit-under-owned-drain-lock?`) NEVER acquires it — see the
+     deadlock note below — and reentrant same-thread emits never acquire it (they
+     advance the bound `*fanout-ctx*` schedule). CLJS is single-threaded and has no
+     counterpart."
      (Object.)))
 
 #?(:clj
-   (defn- frame-drain-emit?
-     "True when this outermost emit originates from INSIDE a frame's runtime
-     activity — i.e. the emitting thread may hold that frame's `:drain-lock`. Such
-     an emit MUST NOT block acquiring `fanout-monitor`: a listener already holding
+   (defn- emit-under-owned-drain-lock?
+     "True when this outermost emit is issued by a thread that ACTUALLY holds the
+     target frame's `:drain-lock` right now — the ONLY condition under which
+     acquiring `fanout-monitor` could close the rf2-jl75r AB-BA cycle. Such an emit
+     MUST drive its fan-out INLINE (off the monitor): a listener already holding
      the monitor is allowed to `dispatch-sync` into that same frame and would spin
-     on its `:drain-lock` — a hard AB-BA cycle (rf2-jl75r, `deliver-to-tooling!`).
-     It drives its fan-out INLINE instead, so no process-global lock is ever held
-     by, or awaited by, a frame-drain emit.
+     on its `:drain-lock`, and if the emitting drainer thread then blocked
+     acquiring the monitor neither could progress. Driving inline removes the
+     drain-lock↔monitor edge entirely.
 
-     The discriminator is FRAME ROUTABILITY, computed exactly as `push-to-ring!`
-     routes an emit to a per-frame ring: an emit that resolves to a frame — via an
-     explicit `[:tags :frame]`, a top-level `:frame`, or the in-flight run's
-     `frame/*current-frame*` (the late-bound `:frame/current-frame-id` hook) —
-     originates from within that frame's drain / settle / lifecycle activity. This
-     is the ONLY signal that covers EVERY drain emit, including ones the drain's
-     `:rf.trace/dispatch-id` scope does not reach: the epoch cascade trailers
-     (`:rf.epoch/snapshotted` / `:rf.epoch/outcome`) fire AFTER the buffer is
-     harvested, `outside any cascade` (nil dispatch-id), yet still on the drainer
-     thread holding the `:drain-lock` — a dispatch-id-only test would misclassify
-     them and re-open the deadlock. A retentionless structural terminal fact
-     (`retain?` false: `:rf.frame/destroyed` / `:rf.frame/drain-interrupted`,
-     emitted while `destroy-frame!` holds the frame's drain serialization) is
-     included for the same reason even if it were ever frameless.
+     The discriminator is REAL LOCK-OWNERSHIP EVIDENCE, not event-shape inference
+     (rf2-rakqk). The emit's target frame is resolved exactly as `push-to-ring!`
+     routes to a per-frame ring — an explicit `[:tags :frame]`, a top-level
+     `:frame`, or the in-flight run's `frame/*current-frame*` (the
+     `:frame/current-frame-id` hook) — and we then ask the frame engine whether
+     THIS thread owns that frame's single-drainer serialization (the
+     `:frame/thread-owns-drain-serialization?` hook: true iff the thread is the
+     frame's active event drainer `:in-drain?`, OR the holder of a cold
+     `call-serialized-with-drain!` critical section `:serialized-holder` — the two
+     paths that take the frame's `:drain-lock`). Every genuine drain / settle /
+     teardown emit — including the epoch cascade trailers (`:rf.epoch/snapshotted`
+     / `:rf.epoch/outcome`, which fire AFTER the buffer is harvested with a nil
+     dispatch-id yet carry a top-level `:frame` and run on the drainer thread while
+     `:in-drain?` is stamped) and the retentionless structural terminals
+     (`:rf.frame/destroyed` / `:rf.frame/drain-interrupted`, carrying `:frame` and
+     emitted while the drain / destroy path owns the serialization) — resolves its
+     frame and reports true, so it stays off the monitor and the deadlock cannot
+     form.
 
-     An external/clean emit — a tool or REPL `emit!` with NO frame in scope (no
-     `:frame` tag, no ambient `*current-frame*`), the shape rf2-uw7hg's suite
-     exercises — resolves no frame and returns false, so concurrent clean emits
-     still serialize on the monitor (no listener callback overlaps itself). The
-     residual relaxation is bounded and JVM-only: a frame-scoped clean emit, and
-     two genuinely concurrent frame drains (never a thing on the single-threaded
-     CLJS target), may drive inline and overlap a listener.
+     A frame-SHAPED emit that is NOT under a held drain-lock — a public / manual /
+     stale / malformed `:frame` tag, an ambient-frame tool emit, a retained-frame
+     `trace/emit!` outside any drain — owns NO lock, so it reports false and
+     serializes on the monitor like every other clean emit. This RESTORES the
+     rf2-uw7hg whole-fanout serial law the prior event-shape heuristic lost for
+     those emits: event payload shape can no longer opt an emit out of
+     serialization. A frameless clean emit resolves no frame and likewise
+     serializes.
+
+     Because the evidence is exact, deadlock-freedom holds unconditionally: a
+     false result PROVES the thread holds no drain-lock (so no AB-BA edge through
+     the monitor), and a true result drives inline (so no monitor is acquired at
+     all).
 
      JVM-only: the `:cljs` outermost arm has no monitor, so it needs no predicate."
-     [event retain?]
-     (or (not retain?)
-         (some? (get-in event [:tags :frame]))
-         (some? (:frame event))
-         (some? (get-in event [:tags :rf.trace/dispatch-id]))
-         (when-let [current-frame (late-bind/get-fn-cached :frame/current-frame-id)]
-           (some? (current-frame))))))
+     [event]
+     (when-let [frame-id (or (get-in event [:tags :frame])
+                             (:frame event)
+                             (when-let [current-frame
+                                        (late-bind/get-fn-cached :frame/current-frame-id)]
+                               (current-frame)))]
+       (boolean
+         (when-let [owns? (late-bind/get-fn-cached
+                            :frame/thread-owns-drain-serialization?)]
+           (owns? frame-id))))))
 
 (defn- drive-fanout!
   "Drive the shared fan-out schedule `ctx` to completion: deliver every queued
@@ -908,11 +938,12 @@
 (defn- run-outermost-fanout!
   "Seed a fresh fan-out schedule for `event`, bind it as `*fanout-ctx*` so
   reentrant emits from listener bodies advance the SAME schedule, and drive it to
-  completion. On the JVM a CLEAN outermost emit runs this under `fanout-monitor`
-  so concurrent emits serialize (rf2-uw7hg); a frame-drain emit runs it inline,
-  off the monitor, to break the drain-lock↔monitor cycle (rf2-jl75r — see the
-  `deliver-to-tooling!` outermost branch). Either way the binding + drive are the
-  whole critical section."
+  completion. On the JVM an emit whose thread does NOT own the target frame's
+  drain-lock runs this under `fanout-monitor` so concurrent emits serialize
+  (rf2-uw7hg); an emit that DOES own it (`emit-under-owned-drain-lock?`) runs it
+  inline, off the monitor, to break the drain-lock↔monitor cycle (rf2-jl75r /
+  rf2-rakqk — see the `deliver-to-tooling!` outermost branch). Either way the
+  binding + drive are the whole critical section."
   [event continue?]
   (let [ctx {:q       (volatile! [[event continue?]])
              :head    (volatile! 0)
@@ -967,25 +998,27 @@
          nil)
      ;; Outermost fan-out.
      ;;
-     ;; A FRAME-DRAIN emit (`frame-drain-emit?`: one that ROUTES TO A FRAME the way
-     ;; `push-to-ring!` does, or a retentionless structural terminal fact) runs on
-     ;; a thread that may hold a frame's `:drain-lock`. It MUST NOT block acquiring
-     ;; `fanout-monitor`: a listener already holding the monitor is free to
-     ;; `dispatch-sync` into that same frame and spin on its `:drain-lock`, closing
-     ;; a hard AB-BA cycle (rf2-jl75r). Such an emit drives its fan-out inline —
-     ;; exactly as the single-threaded CLJS host always does — so no process-global
-     ;; lock is ever held by, or awaited by, a frame-drain emit. This is the "no
-     ;; fan-out lock across arbitrary listener code that may dispatch-sync into the
-     ;; draining frame" seam.
+     ;; An emit issued by a thread that ACTUALLY holds the target frame's
+     ;; `:drain-lock` (`emit-under-owned-drain-lock?` — resolved from REAL
+     ;; lock-ownership evidence, not event-shape inference; rf2-rakqk) MUST NOT
+     ;; block acquiring `fanout-monitor`: a listener already holding the monitor is
+     ;; free to `dispatch-sync` into that same frame and spin on its `:drain-lock`,
+     ;; closing a hard AB-BA cycle (rf2-jl75r). Such an emit drives its fan-out
+     ;; inline — exactly as the single-threaded CLJS host always does — so no
+     ;; process-global lock is ever held by, or awaited by, a drain-lock-owning
+     ;; emit. This is the "no fan-out lock across arbitrary listener code that may
+     ;; dispatch-sync into the draining frame" seam.
      ;;
-     ;; An EXTERNAL/clean emit (a tool or REPL `emit!` with NO frame in scope) still
-     ;; serializes on `fanout-monitor` across concurrent emits (rf2-uw7hg) so no
-     ;; listener callback overlaps itself and records reach each listener in
-     ;; monitor-acquisition order — the monitor is held for that whole drive. Such
-     ;; a thread holds no `:drain-lock`, so nothing waits on it through one; the
+     ;; Every OTHER outermost emit — a frameless external/clean emit, AND a
+     ;; frame-shaped emit whose thread does NOT hold that frame's drain-lock (a
+     ;; public/manual/stale `:frame` tag, an ambient-frame tool emit) — serializes
+     ;; on `fanout-monitor` across concurrent emits (rf2-uw7hg) so no listener
+     ;; callback overlaps itself and records reach each listener in
+     ;; monitor-acquisition order; the monitor is held for that whole drive. Such a
+     ;; thread holds no `:drain-lock`, so nothing waits on it through one and the
      ;; drain-lock↔monitor cycle cannot form. CLJS is single-threaded and runs
      ;; every outermost emit inline with no monitor.
-     #?(:clj  (if (frame-drain-emit? event retain?)
+     #?(:clj  (if (emit-under-owned-drain-lock? event)
                 (run-outermost-fanout! event continue?)
                 (locking fanout-monitor (run-outermost-fanout! event continue?)))
         :cljs (run-outermost-fanout! event continue?)))))

--- a/implementation/core/test/re_frame/trace_listener_drain_deadlock_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_drain_deadlock_test.clj
@@ -24,12 +24,13 @@
   is false and T1's listener `dispatch-sync` really does spin on the lock.
 
   The fix keeps the whole synchronous, ordered, serialized clean-emit fan-out
-  (rf2-uw7hg) but takes the monitor OUT of the cycle: a frame-drain emit
-  (`frame-drain-emit?`) never acquires the monitor — it drives its fan-out inline,
-  exactly as the single-threaded CLJS host always does. This suite is the
-  deterministic barrier/latch proof that the exact AB-BA interleaving now
-  completes within a bounded timeout and the listener-dispatched event settles
-  EXACTLY once.
+  (rf2-uw7hg) but takes the monitor OUT of the cycle: an emit whose thread
+  ACTUALLY holds the target frame's `:drain-lock` (`emit-under-owned-drain-lock?`,
+  keyed on real lock ownership per rf2-rakqk, not event-shape inference) never
+  acquires the monitor — it drives its fan-out inline, exactly as the
+  single-threaded CLJS host always does. This suite is the deterministic
+  barrier/latch proof that the exact AB-BA interleaving now completes within a
+  bounded timeout and the listener-dispatched event settles EXACTLY once.
 
   JVM-only (`.clj`): CLJS is single-threaded, has no monitor, and cannot race two
   drains — the deadlock cannot manifest there."

--- a/implementation/core/test/re_frame/trace_listener_frame_tagged_serialization_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_frame_tagged_serialization_test.clj
@@ -1,0 +1,131 @@
+(ns re-frame.trace-listener-frame-tagged-serialization-test
+  "rf2-rakqk — a frame-SHAPED trace emit that is NOT issued while the emitting
+  thread actually holds the target frame's `:drain-lock` must STILL serialize
+  through `fanout-monitor` like every other clean emit (rf2-uw7hg). The public
+  trace-listener contract (Spec 009 §The listener contract) promises a single
+  registered listener is never entered concurrently with itself across JVM
+  threads, whatever the event payload looks like.
+
+  ## The defect this pins (rf2-rakqk)
+
+  PR #6200 (rf2-jl75r) broke the fanout-monitor↔drain-lock AB-BA deadlock by
+  routing any FRAME-SHAPED outermost emit inline, off the monitor. But the
+  discriminator was event-shape inference: a `:frame` tag / caller-supplied
+  dispatch-id / ambient frame / `retain? false` opted an emit out of the monitor
+  even when the emitting thread was NOT actually inside a held drain-lock. A
+  public/manual/stale `:frame`-tagged `trace/emit!` — issued from an ordinary
+  thread that owns no drain-lock — was therefore driven inline and LOST the
+  whole-fanout serial law: two such emits could enter the same listener callback
+  concurrently.
+
+  A deterministic latch probe below starts two `{:frame :rf/default}`-tagged
+  emits on two threads while the first listener callback is latched. Pre-fix the
+  second entered the callback while the first was still in flight (max concurrent
+  invocations 2). With the drain-lock OWNERSHIP discriminator
+  (`re-frame.trace.tooling/emit-under-owned-drain-lock?`), neither emitting thread
+  owns `:rf/default`'s drain-lock (no drain is in flight), so both serialize on
+  the monitor: the second is BLOCKED contending for it until the first callback
+  returns. max concurrent invocations 1, strict A-before-B.
+
+  The complementary law — an emit that GENUINELY owns the target drain-lock (an
+  in-run / settle / teardown emit on the drainer thread) still drives inline and
+  never deadlocks against a listener's `dispatch-sync` — is pinned by
+  `re-frame.trace-listener-drain-deadlock-test` (rf2-jl75r) and is deliberately
+  not duplicated here.
+
+  JVM-only (`.clj`): CLJS is single-threaded, has no monitor, and cannot race two
+  emits — the overlap cannot manifest there."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace :as trace])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private probe-a :trace.rakqk/a)
+(def ^:private probe-b :trace.rakqk/b)
+
+;; Loop the deterministic latch proof so a green run is determinism, not a lucky
+;; interleaving. Env-overridable for a heavier local soak.
+(def ^:private latch-iters
+  (or (some-> (System/getenv "RF2_RAKQK_LATCH_ITERS") Long/parseLong)
+      50))
+
+(deftest frame-tagged-public-emits-not-under-a-drain-serialize
+  ;; Two frame-TAGGED emits (`{:frame :rf/default}`) issued from two ordinary
+  ;; threads, NEITHER of which is draining `:rf/default` — so neither holds its
+  ;; `:drain-lock`. A single listener L blocks INSIDE its callback while handling
+  ;; A (thread t1). While A is blocked, B is emitted to the SAME L on t2. Pre-fix
+  ;; the `:frame` tag routed both inline (bypassing `fanout-monitor`), so L(B)
+  ;; entered while L(A) was still in flight (max concurrent invocations 2). With
+  ;; the drain-lock OWNERSHIP discriminator, an unowned frame-tagged emit is NOT
+  ;; treated as a drain emit, so t2's fan-out blocks on the monitor until t1's A
+  ;; callback returns: L never re-enters itself, B delivered strictly after A.
+  (testing (str "a frame-shaped emit that owns no drain-lock cannot enter B until "
+                "its A callback has returned (" latch-iters " iterations)")
+    (dotimes [iter latch-iters]
+      (let [log       (atom [])
+            in-flight (atom 0)
+            max-conc  (atom 0)
+            a-entered (CountDownLatch. 1)
+            b-entered (CountDownLatch. 1)
+            release-a (CountDownLatch. 1)]
+        (trace/register-listener! ::probe
+          (fn [ev]
+            (let [op (:operation ev)]
+              (when (or (= op probe-a) (= op probe-b))
+                ;; Overlap detector: record the max simultaneous invocations.
+                (let [n (swap! in-flight inc)]
+                  (swap! max-conc max n))
+                (swap! log conj [:enter op])
+                (if (= op probe-a)
+                  (do (.countDown a-entered)
+                      ;; Block A mid-callback (holding the fan-out monitor iff the
+                      ;; monitor path is taken) until the harness releases it —
+                      ;; never released by B's delivery, so a serialized B cannot
+                      ;; deadlock A.
+                      (.await release-a 5 TimeUnit/SECONDS))
+                  (.countDown b-entered))
+                (swap! log conj [:exit op])
+                (swap! in-flight dec)))))
+        ;; Both emits carry a `:frame` tag but run on fresh threads that are NOT
+        ;; draining `:rf/default` — so the payload is frame-SHAPED yet the thread
+        ;; owns no drain-lock. This is exactly the emit the shape heuristic
+        ;; mis-routed inline.
+        (let [t1 (Thread. ^Runnable
+                          (fn [] (trace/emit! :info probe-a {:frame :rf/default})))
+              t2 (Thread. ^Runnable
+                          (fn [] (trace/emit! :info probe-b {:frame :rf/default})))]
+          (.start t1)
+          ;; A is now inside L, blocked on release-a.
+          (.await a-entered 5 TimeUnit/SECONDS)
+          (.start t2)
+          ;; Wait until t2 has reached the fan-out seam: pre-fix it enters L(B)
+          ;; (b-entered fires, overlap already recorded); fixed, it is BLOCKED
+          ;; contending for fanout-monitor. The ownership probe + emit path use
+          ;; only lock-free atoms, so a BLOCKED state here means monitor
+          ;; contention. Deadline-bounded so a mis-started thread cannot hang the
+          ;; suite.
+          (let [deadline (+ (System/currentTimeMillis) 5000)]
+            (loop []
+              (when (and (< (System/currentTimeMillis) deadline)
+                         (pos? (.getCount b-entered))
+                         (not= java.lang.Thread$State/BLOCKED (.getState t2)))
+                (Thread/yield)
+                (recur))))
+          (.countDown release-a)
+          (.join t1 5000)
+          (.join t2 5000))
+        (trace/unregister-listener! ::probe)
+        (is (= 1 @max-conc)
+            (str "iter " iter ": a frame-tagged public emit that owns no "
+                 "drain-lock overlapped the listener callback with itself (max "
+                 "concurrent invocations " @max-conc "); event-shape must not opt "
+                 "an emit out of the rf2-uw7hg serial monitor"))
+        (is (= [[:enter probe-a] [:exit probe-a] [:enter probe-b] [:exit probe-b]]
+               @log)
+            (str "iter " iter ": B reached the listener before A's callback "
+                 "returned; expected strict A-before-B ordering, got "
+                 (pr-str @log)))))))


### PR DESCRIPTION
## What & why

PR #6200 (rf2-jl75r) removed the `fanout-monitor` / frame `:drain-lock` AB-BA deadlock by routing any FRAME-SHAPED outermost trace emit inline, off the serial monitor. But `frame-drain-emit?` was **event-shape inference, not lock-ownership evidence**: any `:frame` tag, caller-supplied dispatch-id, ambient frame, or `retain? false` opted an emit out of the monitor even when the emitting thread held no drain-lock. So a public/manual/stale frame-tagged `trace/emit!` lost the **rf2-uw7hg whole-fanout serial law** — two such emits could enter the same registered listener callback concurrently.

## The fix

Replace the shape heuristic with **real lock-ownership evidence** at the same seam:

- `re-frame.frame` publishes `:frame/thread-owns-drain-serialization?` — the both-axis sibling of `in-drain?` (active drainer `:in-drain?` **or** cold `call-serialized-with-drain!` holder `:serialized-holder` — the two paths that take the frame's `:drain-lock`).
- `re-frame.trace.tooling/emit-under-owned-drain-lock?` resolves the emit's target frame exactly as `push-to-ring!` does, then asks whether **THIS thread actually holds that frame's drain-lock right now**. Owns it → drive fan-out inline (no monitor, no AB-BA edge); does not own it → serialize on `fanout-monitor` like every clean emit.

Because the evidence is exact, deadlock-freedom is **unconditional**: a false result *proves* no drain-lock is held (no cycle through the monitor); a true result acquires no monitor. Event payload shape can no longer opt an emit out of serialization.

### Seam
- Event-shape inference (removed): `emit-under-owned-drain-lock?` replaces `frame-drain-emit?` in `implementation/core/src/re_frame/trace/tooling.cljc` (the `deliver-to-tooling!` outermost `#?(:clj (if …))` branch).
- Ownership discriminator (added): `re-frame.frame/thread-owns-drain-serialization?` (wraps the existing private `current-thread-owns-drain-serialization?`), published via the new `:frame/thread-owns-drain-serialization?` late-bind hook (directory entry added; drift test green). No change to frame.cljc's drain-lock mechanism.

## Four laws — all preserved
- **uw7hg** (whole-fanout serial monitor) — RESTORED for the mis-routed frame-tagged/non-drain emits.
- **jl75r** (no monitor across a held drain-lock) — kept: genuine drain / settle / teardown emits own the drain-lock and stay inline, including the epoch cascade trailers (`:rf.epoch/snapshotted` / `:rf.epoch/outcome`, which fire during `settle-event-epoch!` while `:in-drain?` is stamped) and the retentionless structural terminals (`:rf.frame/destroyed` / `:rf.frame/drain-interrupted`).
- **s522m** (reentrant `*fanout-ctx*` scheduler) and **1zxlsm** (ordering) — untouched.

## Quality gates
All foreground, unpiped.

- **`implementation/core` JVM (focused, `clojure -M:test`)** — `re-frame.trace-listener-drain-deadlock-test` (jl75r) + `re-frame.trace-listener-frame-tagged-serialization-test` (new rakqk probe) + `re-frame.trace-listener-concurrent-serialization-test` (uw7hg latch) + `re-frame.trace-listener-test` (s522m/1zxlsm) + `re-frame.late-bind-drift-test`: **23 tests, 984 assertions, 0 failures, 0 errors.**
- **uw7hg stress** (`clojure -M:slow-test -n …concurrent-serialization-test`, 2000-emit / 6-thread): **1 test, 3 assertions, 0 failures** — max concurrent invocations 1, delivered == total, no stragglers.
- **`npm run test:cljs`** (node-runtime CLJS): **9911 tests, 48812 assertions, 0 failures, 0 errors.** (One unrelated flake on the first run went green on rerun; the CLJS delivery path — the `:cljs` arm — is untouched by this change.)
- **Red-before / green-after**: the new probe fails serialization under the shape heuristic (max concurrent invocations 2; log `[:enter a][:enter b][:exit b][:exit a]`) and passes under ownership routing (max 1; strict A-before-B). Verified by temporary revert-and-restore.

Closes rf2-rakqk.
