### PR TITLE
docs(guide): correct false adapter-disposition lines to the 2026-07-17 ruling (rf2-3rlgq)

### DIFF
--- a/ai/findings/new-substrate-synthesis/guide/01-getting-started.md
+++ b/ai/findings/new-substrate-synthesis/guide/01-getting-started.md
@@ -13,9 +13,9 @@ views, state, events, frames, then a real dashboard.
         day8/re-frame2-ui {…}}}
 ```
 
-`package.json` carries `react` and `react-dom` — nothing else. `re-frame.ui` is the
-default and the only view surface this guide teaches. Stock Reagent and UIx remain
-optional, frozen compatibility adapters; Helix and slim are deleted.
+`package.json` carries `react` and `react-dom` — nothing else. `re-frame.ui` is an
+experimental additional substrate, the view surface this guide teaches. Stock Reagent,
+UIx, and reagent-slim remain first-class, actively-supported adapters; only Helix is deleted.
 
 The browser/runtime must provide the standard JavaScript `WeakRef` constructor (all
 current evergreen browsers and supported modern Node runtimes do). re-frame.ui probes

--- a/ai/findings/new-substrate-synthesis/guide/11-ssr.md
+++ b/ai/findings/new-substrate-synthesis/guide/11-ssr.md
@@ -5,7 +5,7 @@ browser and versioned `re-frame.ui.tree` structural data on the JVM. The shared
 conversion contract and parity gates hold those outputs together.
 
 HTML is a separate S5 step: `re-frame.ssr/emit-ui-tree` serialises that structural tree.
-Until S5 lands, `render-to-string` remains the frozen Reagent/hiccup compatibility
+Until S5 lands, `render-to-string` remains the Reagent/hiccup compatibility
 route; it is not the re-frame.ui tree pipeline.
 
 | Mechanism | Delivery stage |
@@ -31,7 +31,7 @@ and keep the shared markup outside.
 
 ## Rendering a page *(re-frame.ui HTML and `ssr-ring` land S5)*
 
-The current compatibility `render-to-string` path is the frozen Reagent/hiccup route.
+The current compatibility `render-to-string` path is the Reagent/hiccup route.
 The S5 re-frame.ui path uses per-request frames: drain `:initial-events`, emit the
 versioned structural tree, serialise it with `re-frame.ssr/emit-ui-tree`, respond, and
 tear down. Request-to-response glue lands with the `ssr-ring` ecosystem adapter; this

--- a/ai/findings/new-substrate-synthesis/guide/12-how-it-works.md
+++ b/ai/findings/new-substrate-synthesis/guide/12-how-it-works.md
@@ -46,7 +46,7 @@ compiles one fixture set through both emitters and compares the results once eac
 is fully lowered and projected into a common semantic space, so divergence is *detected*
 rather than prevented.
 
-Contrast the frozen stock-Reagent path: `reg-view` is registration and frame injection
+Contrast the stock-Reagent path: `reg-view` is registration and frame injection
 only — the body is spliced **verbatim** and still interpreted by Reagent. It is not
 "the same compiler under another name". The migration map is
 [13 — From other worlds](13-from-other-worlds.md).
@@ -302,7 +302,7 @@ and parity gates compare the two outputs so conversion drift fails loudly.
 Neither JVM emission nor that parity gate produces HTML. At S5,
 `re-frame.ssr/emit-ui-tree` is the separate serializer that turns the versioned tree
 into HTML; its conversion/escaping contract and parity gates control drift across that
-boundary. Until then, `render-to-string` remains the frozen Reagent/hiccup compatibility
+boundary. Until then, `render-to-string` remains the Reagent/hiccup compatibility
 route. At S5 a fingerprint in the root manifest lets hydration check the delivered
 structure rather than hope.
 

--- a/ai/findings/new-substrate-synthesis/guide/13-from-other-worlds.md
+++ b/ai/findings/new-substrate-synthesis/guide/13-from-other-worlds.md
@@ -4,9 +4,8 @@ A translation map for people arriving from React, UIx, or Reagent. Nothing
 here is required if you started at [01](01-getting-started.md) with a blank mind —
 use it when a habit from elsewhere misleads.
 
-`re-frame.ui` is the default and the only view surface taught here. Stock Reagent and
-UIx remain frozen compatibility adapters, without a feature-parity programme. Helix
-and slim are deleted.
+`re-frame.ui` is an experimental additional substrate, the view surface taught here. Stock Reagent,
+UIx, and reagent-slim remain first-class, actively-supported adapters. Only Helix is deleted.
 
 ## From React / UIx
 
@@ -38,7 +37,7 @@ and slim are deleted.
 
 1. **Dataflow first** — move events, subs, and a `frame-root` mount to re-frame2 while
    keeping registered Reagent views as they are (stock Reagent remains a supported,
-   frozen compatibility tier). You immediately gain Xray, epochs, Story, schemas,
+   first-class adapter). You immediately gain Xray, epochs, Story, schemas,
    machines, and resources.
 2. **Views per subtree** — migrate to `defview` on your schedule, with the migrator.
    Old and new trees co-mount at explicit boundaries.
@@ -51,7 +50,7 @@ A common confusion if you already know re-frame2: **`reg-view` is not a template
 compiler.** It is a registration macro. It defs the symbol, derives a registry id,
 and injects frame-bound `dispatch` / `subscribe` as lexical locals (with source
 coordinates). The view body is spliced **verbatim** — no code-walking, no hiccup
-lowering. Under the frozen stock-Reagent tier, templates still go through Reagent at
+lowering. Under the first-class stock-Reagent adapter, templates still go through Reagent at
 runtime; handlers are still ordinary closures.
 
 `defview` is different in kind: the template (and data handlers) are **compiled** —

--- a/ai/findings/new-substrate-synthesis/guide/README.md
+++ b/ai/findings/new-substrate-synthesis/guide/README.md
@@ -1,6 +1,6 @@
 # The re-frame2 UI guide
 
-re-frame2 UI is the view layer for re-frame2. You write **hiccup** and **event
+re-frame2 UI is an experimental, additional view layer for re-frame2. You write **hiccup** and **event
 vectors**. The compiler turns them into efficient React at build time — no hiccup
 interpreter in the bundle, no hooks ceremony, no manual memoisation.
 

--- a/implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj
@@ -407,7 +407,7 @@
     (testing "JVM emission is structural data and HTML serialization is S5"
       (doseq [required ["versioned `re-frame.ui.tree` structural data"
                         "`re-frame.ssr/emit-ui-tree`"
-                        "frozen Reagent/hiccup"
+                        "Reagent/hiccup"
                         "conversion contract and parity gates"]]
         (is (or (str/includes? ssr required)
                 (str/includes? how required))


### PR DESCRIPTION
Truth-only correction of the synthesis-tree UI guide (`ai/findings/new-substrate-synthesis/guide/`) to the Mike-ruled **2026-07-17 adapter disposition** (rf2-ukq8qt / PR #6087 / a72bd7e492), which `spec/006-ReactiveSubstrate.md` already carries verbatim (line 13):

> Reagent, reagent-slim, and UIx live on as first-class, actively-supported adapters, `re-frame.ui` is a new experimental substrate offered alongside them, and only Helix is removed.

Closes rf2-3rlgq. Blocks rf2-bbdbs2 (the register/tutorial pass rebases onto this truth baseline).

## What changed

**Commit 1 — guide truth corrections** (enumerated spans only; no voice/structure/register edits, no runtime change):

| File:line | Before (false/stale) → After (matches ruling) |
|---|---|
| `01-getting-started.md:16-18` | "the default and the only view surface… optional, frozen compatibility adapters; Helix and slim are deleted" → "an experimental additional substrate, the view surface this guide teaches. Stock Reagent, UIx, and reagent-slim remain first-class, actively-supported adapters; only Helix is deleted" |
| `13-from-other-worlds.md:7-9` | same false disposition → same correction |
| `13-from-other-worlds.md:41` | "supported, frozen compatibility tier" → "supported, first-class adapter" |
| `13-from-other-worlds.md:54` | "Under the frozen stock-Reagent tier" → "Under the first-class stock-Reagent adapter" |
| `README.md:3` | "the view layer" → "an experimental, additional view layer" |
| `11-ssr.md:8,34` | "frozen Reagent/hiccup" route/path → "Reagent/hiccup" (path is current + supported, not frozen) |
| `12-how-it-works.md:49,305` | drop stale "frozen" from the stock-Reagent / Reagent-hiccup paths |

Technical content (reg-view vs defview, S5/stage claims, conversion-contract/parity phrasing) left untouched.

**Commit 2 — coupled-truth test reconciliation** (`implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj:410`): the `pipeline-and-stage-claims-stay-truthful` gate required the literal `"frozen Reagent/hiccup"` as a "ruled pipeline phrase" — the same superseded claim the ruling retires. Changed to `"Reagent/hiccup"` so the gate moves in lockstep with the guide. Retires a stale-claim expectation only; does not weaken coverage (the phrase still pins the S5 SSR compatibility-route mention). The distinct `"frozen surface matrix"` stage-classifier rows (:497-498) are a different concept — locked API surface — and are left untouched.

## Quality gates

- `scripts/check_doc_slugs.py --synthesis-only` — **PASS** (exit 0).
- `re-frame.ui.guide-truth-jvm-test` (the `synthesis-docs` CI job, `.github/workflows/test.yml:590`) — **PASS: 395/395 assertions, 0 failures, 0 errors** (the previously-red `frozen Reagent/hiccup` assertion now passes with the corrected phrase).
- `mkdocs build --strict` — **N/A**: the synthesis-tree `guide/` is not in the mkdocs nav (`report-changed-surfaces.sh` classifies it `synthesis_docs=true`). Factual correctness verified manually vs the ruling + spec/006 inventory.

Coupled blocker from the initial revision is **resolved** — the one-line test-assertion fix is folded into this PR (commit 2), so the branch is internally consistent and green. Ready for review.
