### PR TITLE
fix(test): correct dangling late-bind clear call in resources revalidation test (rf2-vx62u)

### DIFF
--- a/implementation/resources/test/re_frame/resources_revalidation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_revalidation_cljs_test.cljc
@@ -470,7 +470,7 @@
                  (finally
                    (if prior
                      (late-bind/set-fn! :router/dispatch! prior)
-                     (late-bind/clear-fn! :router/dispatch!)))))
+                     (late-bind/set-fn! :router/dispatch! nil)))))
              (finally
                (uninstall-dom-stub!))))))))
 


### PR DESCRIPTION
## What

Fixes a **flaky MAIN-RED**. The finally-block teardown in `resources_revalidation_cljs_test.cljc:473` called `(late-bind/clear-fn! :router/dispatch!)`, but `re-frame.late-bind` has **no `clear-fn!` var**. The dangling reference emitted an `:undeclared-var` warning that intermittently failed the node `test:cljs` gate (0 failures on one run, 5 on another). Because it lives on `main`, it affected **every branch off main** — the intermittent "unrelated flake on first run, clean on rerun" many workers reported.

## The fix

The teardown means to restore the prior `:router/dispatch!` late-bound fn, or clear it when there was no prior. Corrected the nil-prior branch to the established clear idiom:

```clojure
;; before
(if prior
  (late-bind/set-fn! :router/dispatch! prior)
  (late-bind/clear-fn! :router/dispatch!))
;; after
(if prior
  (late-bind/set-fn! :router/dispatch! prior)
  (late-bind/set-fn! :router/dispatch! nil))
```

`(late-bind/set-fn! <key> nil)` is the codebase-wide clear idiom (see `schemas_cljs_test.cljs:145`, `routing_url_strategy_test.clj:430`, `flows/late_bind_missing_test.clj:38`); `set-fn!` also invalidates the sticky resolution cache, so the hook resolves back to nil on the next dispatch. **No `re-frame.late-bind` runtime change** — `clear-fn!` was never a real API (confirmed: it appears nowhere else in the tree; the `register-warn-once-clear-fn!` matches are a different symbol).

Test-file only, one-line change.

## Quality gates

- `npm run test:cljs` — run **3 times**, all green: `9915 tests, 48841 assertions, 0 failures, 0 errors` each run.
- Full captured logs of runs 2 and 3 grepped for `undeclared-var` / `clear-fn` — **no matches** (warning is gone).
- Confirmed no change to `re-frame.late-bind` runtime.
