### PR TITLE
fix(ui-compiler): canonicalize spread-safe caller props to their emitted slot (rf2-xdvob)

### DIFF
--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -1218,101 +1218,150 @@
   per call."
   #{:key :ref :value :checked})
 
-(def ^:private spread-safe-denied-structural-names
-  "The CANONICAL emitted names of the denied structural keys — the form both
-  host converters reduce a caller key to via `(name k)`. The deny law compares
-  canonical NAMES, so `:key`/`:ref`/`:value`/`:checked` AND every alternate
-  spelling that canonicalizes to one of them (`:caller/ref`, `\"ref\"`, `'ref`)
-  are denied uniformly (rf2-izep3)."
-  (into #{} (map name) spread-safe-denied-structural))
-
 (defn caller-key-name
-  "The CANONICAL emitted name of a `ui/spread-safe` caller key — `(name k)`,
+  "The CANONICAL author NAME of a `ui/spread-safe` caller key — `(name k)`,
   the SAME canonicalization both host converters apply (namespace dropped, so
   `:caller/ref` -> \"ref\", `\"ref\"` -> \"ref\", `'ref` -> \"ref\"). Returns
   nil when `k` is NOT a nameable attribute key (a keyword, string, or symbol);
   a non-nameable key is malformed — rejected by `assert-safe-caller!` — not
-  merely 'not denied'."
+  merely 'not denied'. The author NAME drives BOTH the emitted-slot the deny law
+  compares (`caller-key-slot`) and the canonical keyword an accepted key is
+  rewritten to (`(keyword (name k))`), so denial and conversion never diverge."
   [k]
   (when (or (keyword? k) (string? k) (symbol? k))
     (name k)))
 
+(defn caller-key-slot
+  "The React/DOM prop-name SLOT the host converters actually emit a
+  `ui/spread-safe` caller key into — the ONE canonicalization the owned-key deny
+  law compares (against the structural slots and the owned handler families),
+  driven by `(name k)` EXACTLY as the converters classify: an author `on-*` name
+  camelizes to its React handler slot (`:on-change` / `\"on-change\"` ->
+  `onChange`); everything else — already-camel handler spellings like
+  `\"onChange\"` / `\"onChangeCapture\"` included — resolves through the
+  react-dom attr table (`react-prop-name`, so `:class` -> `className`). Returns
+  nil for a NON-nameable key (rejected as malformed upstream), never nil for a
+  nameable one. NOT the property-camel slot for a custom-element `:properties`
+  name (that camelization is tag-scoped and irrelevant to the deny, which never
+  targets properties) — this is the deny/structural/handler classification."
+  [k]
+  (when-some [n (caller-key-name k)]
+    (if (str/starts-with? n "on-")
+      (react-event-name n false)
+      (react-prop-name n))))
+
+(def ^:private spread-safe-denied-structural-slots
+  "The canonical emitted SLOTS of the denied structural/controlled keys — the
+  form both host converters reduce a caller key to via `caller-key-slot`. The
+  deny law compares canonical slots, so `:key`/`:ref`/`:value`/`:checked` AND
+  every alternate spelling that resolves to one of those slots (`:caller/ref`,
+  `\"ref\"`, `'ref`) are denied uniformly (rf2-izep3/rf2-xdvob)."
+  (into #{} (keep caller-key-slot) spread-safe-denied-structural))
+
+(defn- owned-handler-slots
+  "The React handler SLOTS an owned `:on-*` family occupies — BOTH the bubble
+  (`onChange`) and capture (`onChangeCapture`) phases, whichever phase the owned
+  handler itself uses. A caller may install NEITHER phase on an owned event, so
+  the deny law reduces every owned handler key to its two-slot family: an
+  already-camel `\"onChange\"`, a capture `\"onChangeCapture\"`, a kebab
+  `on-change-capture`, and every namespaced/string/symbol alias all resolve to a
+  slot in this set (rf2-xdvob)."
+  [owned-handler-keys]
+  (into #{}
+        (mapcat (fn [h]
+                  (when-some [n (caller-key-name h)]
+                    (when (str/starts-with? n "on-")
+                      [(react-event-name n false)
+                       (react-event-name n true)]))))
+        owned-handler-keys))
+
 (defn spread-safe-denied-key?
   "Is caller key `k` denied to a `ui/spread-safe` caller map, given the
   component's `owned-handler-keys` (the literal `:on-*` keys of its owned map)?
-  Compares the CANONICAL emitted name (`(name k)`) against the denied
-  structural/controlled names and the canonical owned-handler names, so
-  alternate spellings — a namespaced keyword, string, or symbol — that
-  canonicalize to the same React/DOM name cannot bypass the law. A non-nameable
-  key is not 'denied' here (it is rejected as malformed by
+  Compares the caller key's canonical emitted SLOT (`caller-key-slot`) against
+  the denied structural/controlled slots and the owned handler FAMILY slots
+  (bubble + capture), so an alternate spelling — kebab, already-camel
+  (`\"onChange\"` / `\"onChangeCapture\"`), string, symbol, or namespaced — that
+  emits into an owned/structural slot cannot bypass the law (rf2-xdvob). A
+  non-nameable key is not 'denied' here (it is rejected as malformed by
   `assert-safe-caller!`); returns false so the literal/compile-time path reports
   it through its own channel."
   [k owned-handler-keys]
   (boolean
-   (when-some [n (caller-key-name k)]
-     (or (contains? spread-safe-denied-structural-names n)
-         (some (fn [h] (= n (name h))) owned-handler-keys)))))
+   (when-some [slot (caller-key-slot k)]
+     (or (contains? spread-safe-denied-structural-slots slot)
+         (contains? (owned-handler-slots owned-handler-keys) slot)))))
 
-(defn- spread-safe-denial-reason [n owned-names]
+(defn- spread-safe-denial-reason [slot owned-slots]
   (cond
-    (= "key" n)                        "a structural identity slot (keys are literal at the site)"
-    (= "ref" n)                        "a reserved React ref slot"
-    (contains? #{"value" "checked"} n) "the controlled-input contract the sync door proves"
-    (contains? owned-names n)          "an owned event handler the component controls"
-    :else                              "owned by the component"))
+    (= "key" slot)                        "a structural identity slot (keys are literal at the site)"
+    (= "ref" slot)                        "a reserved React ref slot"
+    (contains? #{"value" "checked"} slot) "the controlled-input contract the sync door proves"
+    (contains? owned-slots slot)          "an owned event handler the component controls"
+    :else                                 "owned by the component"))
 
 (defn assert-safe-caller!
-  "EVERY-BUILD guard for `(ui/spread-safe owned caller)`. CANONICALIZES and
-  VALIDATES the caller BEFORE the deny (rf2-izep3): the `caller` must be an
-  author-space attr MAP (or nil = empty); each key must be a nameable attribute
-  key; then its CANONICAL emitted name (`(name k)`) is compared against the
-  denied structural/controlled names and the canonical `owned-handler-keys`
-  names. Alternate spellings — a namespaced keyword, string, or symbol that
-  canonicalizes to the same React/DOM name — therefore cannot bypass the law,
-  and a non-map caller (e.g. a sequence of pairs) or a non-nameable key can no
-  longer slip through the old map-only / raw-key guard. A non-map caller, a
-  non-nameable key, or a denied key throws `:rf.error/ui-tree-malformed`,
-  consistently on BOTH hosts. NOT `goog.DEBUG`-gated — the denial is a
-  production invariant a component library relies on, so it survives an advanced
-  build exactly like the compiled lease-descriptor grammar guard. Returns
-  `caller`."
-  [caller owned-handler-keys]
-  (when (some? caller)
-    (when-not (map? caller)
-      (error/throw-error!
-       :rf.error/ui-tree-malformed 're-frame.ui/spread-safe
-       (str "(ui/spread-safe owned caller) — the caller must be an author-space "
-            "attr MAP (or nil), not a " (name (:type (error/diag-value-summary caller)))
-            ". A non-map caller (e.g. a sequence of pairs) cannot be canonicalized "
-            "and checked against the owned-key deny law; pass a map literal or a "
-            "map-valued expression")
-       {:extra {:caller (error/diag-value-summary caller)}}))
-    (let [owned-names (into #{} (map name) owned-handler-keys)]
-      (reduce-kv
-       (fn [_ k _]
-         (let [n (caller-key-name k)]
-           (cond
-             (nil? n)
-             (error/throw-error!
-              :rf.error/ui-tree-malformed 're-frame.ui/spread-safe
-              (str "(ui/spread-safe owned caller) — the caller attr key " (pr-str k)
-                   " is not a nameable attribute key (a keyword, string, or symbol), "
-                   "so it has no canonical DOM/React name to check against the "
-                   "owned-key deny law. Use a keyword attr key")
-              {:extra {:key k}})
+  "EVERY-BUILD guard + canonicalizer for `(ui/spread-safe owned caller)`. The
+  `caller` must be an author-space attr MAP (or nil = empty); each key must be a
+  nameable attribute key; then its canonical emitted SLOT (`caller-key-slot`) is
+  compared against the denied structural/controlled slots and the owned handler
+  FAMILY slots (bubble + capture). Alternate spellings — kebab, already-camel
+  (`\"onChange\"` / `\"onChangeCapture\"`), a namespaced keyword, string, or
+  symbol — that resolve to an owned/structural slot are therefore denied
+  uniformly, and a non-map caller (e.g. a sequence of pairs) or a non-nameable
+  key can no longer slip through. A non-map caller, a non-nameable key, or a
+  denied key throws `:rf.error/ui-tree-malformed`, consistently on BOTH hosts.
+  NOT `goog.DEBUG`-gated — the denial is a production invariant a component
+  library relies on, so it survives an advanced build exactly like the compiled
+  lease-descriptor grammar guard.
 
-             (or (contains? spread-safe-denied-structural-names n)
-                 (contains? owned-names n))
-             (error/throw-error!
-              :rf.error/ui-tree-malformed 're-frame.ui/spread-safe
-              (str "(ui/spread-safe owned caller) — the caller attr map may not "
-                   "carry " (pr-str k) ": it is "
-                   (spread-safe-denial-reason n owned-names)
-                   ", denied in every build so it can never clobber an owned prop "
-                   "(an alternate spelling — a namespaced keyword, string, or symbol "
-                   "— canonicalizes to the same name and is denied too). Forward it "
-                   "through the visible-cost (ui/spread base overrides) instead, or "
-                   "drop it from the caller map")
-              {:extra {:key k}}))))
-       nil caller)))
-  caller)
+  Returns the CANONICALIZED caller map: every ACCEPTED key is rewritten to its
+  author-canonical keyword (`(keyword (name k))`), so an alternate spelling lands
+  in the SAME emitted slot as the literal author keyword and the emitted prop set
+  matches the classification on BOTH hosts — a caller `:ns/class`/`\"class\"`
+  routes through `:class` composition, and a caller ordinary key dedupes against
+  an owned collision by the same identity (rf2-xdvob). A nil caller returns nil."
+  [caller owned-handler-keys]
+  (if (nil? caller)
+    nil
+    (do
+      (when-not (map? caller)
+        (error/throw-error!
+         :rf.error/ui-tree-malformed 're-frame.ui/spread-safe
+         (str "(ui/spread-safe owned caller) — the caller must be an author-space "
+              "attr MAP (or nil), not a " (name (:type (error/diag-value-summary caller)))
+              ". A non-map caller (e.g. a sequence of pairs) cannot be canonicalized "
+              "and checked against the owned-key deny law; pass a map literal or a "
+              "map-valued expression")
+         {:extra {:caller (error/diag-value-summary caller)}}))
+      (let [owned-slots (owned-handler-slots owned-handler-keys)]
+        (reduce-kv
+         (fn [acc k v]
+           (let [slot (caller-key-slot k)]
+             (cond
+               (nil? slot)
+               (error/throw-error!
+                :rf.error/ui-tree-malformed 're-frame.ui/spread-safe
+                (str "(ui/spread-safe owned caller) — the caller attr key " (pr-str k)
+                     " is not a nameable attribute key (a keyword, string, or symbol), "
+                     "so it has no canonical DOM/React name to check against the "
+                     "owned-key deny law. Use a keyword attr key")
+                {:extra {:key k}})
+
+               (or (contains? spread-safe-denied-structural-slots slot)
+                   (contains? owned-slots slot))
+               (error/throw-error!
+                :rf.error/ui-tree-malformed 're-frame.ui/spread-safe
+                (str "(ui/spread-safe owned caller) — the caller attr map may not "
+                     "carry " (pr-str k) ": it is "
+                     (spread-safe-denial-reason slot owned-slots)
+                     ", denied in every build so it can never clobber an owned prop "
+                     "(an alternate spelling — kebab, already-camel, a namespaced "
+                     "keyword, string, or symbol — canonicalizes to the same slot and "
+                     "is denied too). Forward it through the visible-cost (ui/spread "
+                     "base overrides) instead, or drop it from the caller map")
+                {:extra {:key k}})
+
+               :else
+               (assoc acc (keyword (caller-key-name k)) v))))
+         {} caller)))))

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -488,8 +488,12 @@
   own compiled object and are layered on top by `spread-safe-props`, so this
   object carries NO sugar; :class here is the caller's alone."
   [tag caller owned-handler-keys event-site-key debug-site]
-  (rules/assert-safe-caller! caller owned-handler-keys)
-  (convert-prop-map! (js-obj) tag nil caller event-site-key debug-site))
+  ;; assert-safe-caller! DENIES by canonical emitted slot AND returns the
+  ;; canonicalized caller (each accepted key rewritten to its author keyword), so
+  ;; convert lands every alternate spelling in the SAME slot as the literal
+  ;; author keyword — the emitted prop set matches the classification (rf2-xdvob).
+  (let [caller (rules/assert-safe-caller! caller owned-handler-keys)]
+    (convert-prop-map! (js-obj) tag nil caller event-site-key debug-site)))
 
 (defn spread-safe-props
   "Merge a `ui/spread-safe` element's CALLER object (`caller-obj`) and its

--- a/implementation/ui/src/re_frame/ui/tree.cljc
+++ b/implementation/ui/src/re_frame/ui/tree.cljc
@@ -243,18 +243,22 @@
         ;; owned/structural key); :class composes owned-classes-first.
         [attrs evts prop-props]
         (if-let [{:keys [caller owned-handler-keys]} spread-safe]
-          (do
-            (rules/assert-safe-caller! caller owned-handler-keys)
-            (let [[c-attrs c-evts c-pp]
-                  (reduce-kv (partial fold-dyn-entry properties)
-                             [{} {} #{}]
-                             (or caller {}))
-                  merged (merge c-attrs attrs)
-                  merged (if (and (:class c-attrs) (:class attrs))
-                           (assoc merged :class
-                                  (rules/classes-str [(:class attrs) (:class c-attrs)]))
-                           merged)]
-              [merged (merge c-evts evts) (into prop-props c-pp)]))
+          ;; assert-safe-caller! DENIES by canonical emitted slot AND returns the
+          ;; canonicalized caller (each accepted key rewritten to its author
+          ;; keyword), so an alternate spelling folds through the SAME slot as
+          ;; the literal author keyword — `:ns/class` composes, an ordinary key
+          ;; dedupes against an owned collision, host-parity with CLJS (rf2-xdvob).
+          (let [caller (rules/assert-safe-caller! caller owned-handler-keys)
+                [c-attrs c-evts c-pp]
+                (reduce-kv (partial fold-dyn-entry properties)
+                           [{} {} #{}]
+                           (or caller {}))
+                merged (merge c-attrs attrs)
+                merged (if (and (:class c-attrs) (:class attrs))
+                         (assoc merged :class
+                                (rules/classes-str [(:class attrs) (:class c-attrs)]))
+                         merged)]
+            [merged (merge c-evts evts) (into prop-props c-pp)])
           [attrs evts prop-props])
         evts    (events* events (merge evts dyn-events))
         ctx     *ns-context*

--- a/implementation/ui/test/re_frame/ui/parity_corpus_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/parity_corpus_jvm_test.clj
@@ -383,3 +383,39 @@
            (:rf.error/id (try (tree/render nil-owned-probe
                                            {:oc nil :ot nil :caller [[:aria-label "x"]]})
                               nil (catch clojure.lang.ExceptionInfo e (ex-data e))))))))
+
+;; rf2-xdvob — the deny + canonicalization key on the EMITTED SLOT, so an owned
+;; handler family is denied for EVERY caller spelling that lands in that slot, and
+;; accepted caller keys canonicalize to the slot the conversion emits — the JVM
+;; half of the dual-host correction (the CLJS render half is the sibling suite;
+;; the host-agnostic grammar lives in spread-safe-grammar-cljs-test).
+(defview handler-owner [{:keys [attr]}]
+  [:input (ui/spread-safe {:on-change [:set :rf.ui/value]} attr)])
+
+(deftest safe-spread-owned-handler-family-denied-jvm
+  (doseq [attr [{"onChange" [:hijack]} {:onChange [:hijack]}
+                {"onChangeCapture" [:hijack]} {:on-change-capture [:hijack]}
+                {:x/on-change [:hijack]}]]
+    (is (= :rf.error/ui-tree-malformed
+           (:rf.error/id (try (tree/render handler-owner {:attr attr})
+                              nil (catch clojure.lang.ExceptionInfo e (ex-data e)))))
+        (str "JVM owned handler family denies: " (pr-str attr))))
+  (testing "an unrelated event family passes"
+    (is (map? (tree/render handler-owner {:attr {:on-focus [:ok]}})))))
+
+(deftest safe-spread-caller-canonicalization-host-parity-jvm
+  ;; rf2-xdvob — an alternate :class spelling composes owned-first (not a bypassing
+  ;; divergent key), and an ordinary-owned collision by an alternate caller
+  ;; spelling is won by the owned prop (deduped by ONE canonical identity),
+  ;; matching the CLJS host.
+  (testing "namespaced/string :class spelling composes owned-first"
+    (doseq [caller [{:ns/class "cc"} {"class" "cc"}]]
+      (is (= "oc cc" (get (probe-input-attrs "oc" nil caller) "class"))
+          (str "class spelling composes owned-first: " (pr-str caller)))))
+  (testing "ordinary owned prop wins an alternate caller spelling of the same slot"
+    ;; owned :title (non-nil) vs caller "title" (string) — canonicalized to :title,
+    ;; deduped, owned wins; NO divergent second title identity.
+    (let [attrs (probe-input-attrs nil "ot" {"title" "ct"})]
+      (is (= "ot" (get attrs "title")) "owned :title wins the string-spelled caller")
+      (is (= 1 (count (filter #{"title"} (keys attrs))))
+          "one title identity, not a divergent double"))))

--- a/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
@@ -377,6 +377,35 @@
     (is (string? (render (rt/jsx2 safe-spread-view
                                   (js-obj "attr" {:aria-label "n" "data-x" "d"})))))))
 
+(deftest safe-spread-owned-handler-family-denied-through-render
+  ;; rf2-xdvob — the ADVERSARIAL slot-divergence case. safe-spread-view owns
+  ;; :on-change (React slot onChange). A caller spelling the SAME emitted family —
+  ;; already-camel onChange, capture onChangeCapture, kebab-capture, namespaced —
+  ;; must be denied through the real render/convert path. Pre-fix these bypassed
+  ;; the name-only deny and installed a handler in the owned event slot.
+  (doseq [attr [{"onChange" [:hijack]} {:onChange [:hijack]}
+                {"onChangeCapture" [:hijack]} {:on-change-capture [:hijack]}
+                {:x/on-change [:hijack]}]]
+    (let [data (try (render (rt/jsx2 safe-spread-view (js-obj "attr" attr)))
+                    nil (catch :default e (ex-data e)))]
+      (is (= :rf.error/ui-tree-malformed (:rf.error/id data))
+          (str "owned handler family denied through render: " (pr-str attr)))
+      (is (= 're-frame.ui/spread-safe (:where data)))))
+  (testing "an unrelated event family passes (safe-spread-view owns only on-change)"
+    (is (str/includes? (render (rt/jsx2 safe-spread-view (js-obj "attr" {:on-focus [:ok]})))
+                       "value=\"owned\"")
+        "a different event family is allowed")))
+
+(deftest safe-spread-caller-class-spelling-canonicalizes-to-slot
+  ;; rf2-xdvob — an alternate :class spelling (namespaced / string) routes through
+  ;; :class COMPOSITION (owned classes first), NOT a bypassing raw-name attr set.
+  ;; Pre-fix a namespaced/string spelling missed the identity-based :class branch
+  ;; and emitted className WITHOUT composing (and diverged from the JVM key).
+  (doseq [attr [{:ns/class "extra"} {"class" "extra"}]]
+    (is (str/includes? (render (rt/jsx2 safe-spread-view (js-obj "attr" attr)))
+                       "class=\"form-control extra\"")
+        (str "caller class spelling composes owned-first: " (pr-str attr)))))
+
 (deftest safe-spread-authored-owned-then-caller-eval-order
   ;; rf2-m5h0f — the authored (spread-safe owned caller) order is owned-then-
   ;; caller on CLJS (matching the JVM). Each expression runs EXACTLY once.

--- a/implementation/ui/test/re_frame/ui/spread_safe_grammar_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/spread_safe_grammar_cljs_test.cljc
@@ -78,3 +78,70 @@
     (is (= {} (rules/assert-safe-caller! {} #{:on-change}))))
   (testing "a caller may name an owned handler that is NOT among owned-handler-keys"
     (is (= {:on-click [:e]} (rules/assert-safe-caller! {:on-click [:e]} #{:on-change})))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-xdvob — the deny + canonicalization now key on the EMITTED SLOT, not the
+;; raw author name, so a spelling that lands in an owned/structural slot cannot
+;; bypass the law, and every accepted key is normalized to the slot conversion
+;; actually emits (host-identical, proven here on JVM + CLJS).
+;; ---------------------------------------------------------------------------
+
+(deftest caller-key-slot-is-the-emitted-slot
+  (testing "handler spellings all resolve to the React handler slot"
+    (is (= "onChange" (rules/caller-key-slot :on-change)))
+    (is (= "onChange" (rules/caller-key-slot "on-change")))
+    (is (= "onChange" (rules/caller-key-slot 'on-change)))
+    (is (= "onChange" (rules/caller-key-slot :x/on-change)))
+    (is (= "onChange" (rules/caller-key-slot "onChange")))
+    (is (= "onChange" (rules/caller-key-slot :onChange)))
+    (is (= "onChangeCapture" (rules/caller-key-slot "onChangeCapture")))
+    (is (= "onChangeCapture" (rules/caller-key-slot :on-change-capture))))
+  (testing "class / style / structural slots via the react-dom table"
+    (is (= "className" (rules/caller-key-slot :class)))
+    (is (= "className" (rules/caller-key-slot "class")))
+    (is (= "className" (rules/caller-key-slot :ns/class)))
+    (is (= "style" (rules/caller-key-slot :style)))
+    (is (= "value" (rules/caller-key-slot :value)))
+    (is (= "ref"   (rules/caller-key-slot :ref)))
+    (is (= "aria-label" (rules/caller-key-slot :aria-label))))
+  (testing "non-nameable keys have no slot"
+    (is (nil? (rules/caller-key-slot nil)))
+    (is (nil? (rules/caller-key-slot 5)))))
+
+(deftest spread-safe-denied-key?-denies-the-whole-owned-handler-family
+  ;; The adversarial slot-divergence case: owned :on-change emits React slot
+  ;; onChange, so a caller spelling the SAME family — already-camel, capture,
+  ;; kebab-capture, namespaced — is denied. Pre-fix the name-only compare denied
+  ;; only the exact kebab, so `"onChange"`/`"onChangeCapture"` slipped in and
+  ;; occupied the owned event slot.
+  (testing "kebab, already-camel, capture, string, symbol, namespaced aliases denied"
+    (doseq [k [:on-change "on-change" 'on-change :x/on-change
+               :onChange "onChange" :onChangeCapture "onChangeCapture"
+               :on-change-capture "on-change-capture"]]
+      (is (rules/spread-safe-denied-key? k #{:on-change})
+          (str "owned handler family denies: " (pr-str k)))))
+  (testing "a DIFFERENT event family is not denied"
+    (doseq [k [:on-focus "onFocus" :on-input "onInputCapture" :x/on-blur]]
+      (is (not (rules/spread-safe-denied-key? k #{:on-change}))
+          (str "unrelated event allowed: " (pr-str k))))))
+
+(deftest assert-safe-caller!-denies-owned-handler-family-and-canonicalizes
+  (testing "an already-camel / capture / namespaced owned-family key throws"
+    (doseq [k [:onChange "onChange" :onChangeCapture "onChangeCapture"
+               :on-change-capture :x/on-change]]
+      (is (denied? {k [:hijack]} #{:on-change})
+          (str "owned handler family rejected: " (pr-str k)))
+      (is (= k (:key (deny-data {k [:hijack]} #{:on-change})))
+          "the offending author key is carried through")))
+  (testing "accepted keys are rewritten to their author-canonical keyword"
+    (is (= {:class "c"}    (rules/assert-safe-caller! {:ns/class "c"} #{})))
+    (is (= {:class "c"}    (rules/assert-safe-caller! {"class" "c"} #{})))
+    (is (= {:class "c"}    (rules/assert-safe-caller! {'class "c"} #{})))
+    (is (= {:disabled true} (rules/assert-safe-caller! {"disabled" true} #{})))
+    (is (= {:aria-label "n" :data-x "d" :title "t"}
+           (rules/assert-safe-caller! {:aria-label "n" "data-x" "d" 'title "t"} #{})))
+    (is (= {:on-click [:e]} (rules/assert-safe-caller! {:x/on-click [:e]} #{:on-change}))
+        "an accepted (non-owned) handler canonicalizes too"))
+  (testing "nil / empty unchanged"
+    (is (nil? (rules/assert-safe-caller! nil #{})))
+    (is (= {} (rules/assert-safe-caller! {} #{})))))


### PR DESCRIPTION
## What & why (rf2-xdvob, P1)

PR #6209 (izep3/j4len/m5h0f spread-safe cluster) validates `ui/spread-safe` caller keys **by name** (`caller-key-name` = `(name k)` in `rules.cljc`) but does **not** canonicalize them to the actual emitted/classified **slot** the converters produce. So a caller key that is valid-by-name but maps to a *different* emitted slot than written bypassed the deny and could diverge CLJS-vs-JVM.

**Confirmed red-before (JVM eval):** with owned `#{:on-change}`, `spread-safe-denied-key?` returned `false` for `"onChange"`, `:onChange`, `"onChangeCapture"`, `:on-change-capture` — all of which emit into the owned `onChange`/`onChangeCapture` family. Only the exact kebab `:on-change` was denied. A caller could therefore install a handler in an owned event family (worse under nil owned handlers, where the layering lets the caller's value survive).

## The seam (validation without canonicalization)

- `rules.cljc` `assert-safe-caller!` / `spread-safe-denied-key?` compared `(name k)` against owned/structural **names**, while `runtime/convert-prop-map!` and `tree/fold-dyn-entry` emit **slots** (`react-event-name`, `react-prop-name`, class composition). Names ≠ slots for handlers (kebab vs camel) and for alternate class/style/property spellings.

## Fix (canonicalize to the emitted slot; minimal, no redesign)

- **`caller-key-slot`** (new, public) — the ONE canonical emitted slot a caller key lands in: `on-*` camelizes to its React handler slot; everything else (already-camel spellings included) resolves through the react-dom attr table. Reuses the existing `react-event-name`/`react-prop-name`.
- **`owned-handler-slots`** (new, private) — reduces each owned `:on-*` key to its **two-slot family** (bubble `onChange` + capture `onChangeCapture`).
- **`spread-safe-denied-key?` / `assert-safe-caller!`** now deny by **slot**: already-camel `onChange`/`onChangeCapture`, kebab-capture, namespaced, string and symbol aliases that resolve to an owned/structural slot are all denied — at compile time and in the CLJS/JVM production paths (not `goog.DEBUG`-gated).
- **`assert-safe-caller!` returns the canonicalized caller map** (each accepted key rewritten to `(keyword (name k))`); both conversion seams — `runtime/spread-safe->props` and `tree/element` — now consume the returned map. An alternate `:ns/class`/`"class"` routes through `:class` composition, and an ordinary owned collision dedupes by one canonical identity, giving **identical CLJS==JVM semantics**.

No spread-safe grammar / conversion / classification redesign, no general prop parser or compatibility layer. Does **not** touch `build.cljc`/`build_hook.clj` (8nn5k), `analyze.cljc`, core, spec, or tools.

## Tests (red-before / green-after)

- `spread_safe_grammar_cljs_test.cljc` (host-agnostic, runs on **both** JVM + CLJS): `caller-key-slot` slot table; the whole owned-handler **family** deny incl. the adversarial slot-divergence case (`"onChange"`, `"onChangeCapture"`, `:on-change-capture`, namespaced); canonicalization of accepted keys.
- `react_render_cljs_test.cljs`: owned handler family denied **through the render path**; `:ns/class`/`"class"` compose owned-first.
- `parity_corpus_jvm_test.clj`: JVM half — owned handler family deny + `:ns/class` composition parity + ordinary-owned-collision dedupe (owned wins, one identity).

## Quality gates

- **`implementation/ui` JVM (`clojure -M:test`) — PASS, run to completion**: 791 tests / 14470 assertions, 0 failures/0 errors (was 786/14409 on main; +5 new adversarial tests). G-13/G-14/G-17 and defview parity green.
- **`npm run test:cljs`** — was **backgrounded/incomplete at hand-off** (cold shadow-cljs compile exceeded the foreground window); killed rather than block the PR. **Relying on CI for the authoritative full matrix** (`test:cljs`, `test:adapter-smokes`, elision-prod, bundle-isolation). The host-agnostic `.cljc` grammar suite passed on the JVM half already, and the CLJS render assertions mirror it.
- Playground SCI freshness: reports STALE locally, but the digest roster excludes `implementation/ui/` (this diff touches zero roster paths) — **pre-existing at base / Windows line-ending artefact, not caused by this change**; no rebuild.

Host parity (CLJS==JVM) is the explicit intent: the deny and the canonicalization both derive from `(name k)` through the same `react-event-name`/`react-prop-name` classification, and the `.cljc` grammar suite proves them identical on both hosts.

Do not merge — leaving CI to run the authoritative gate matrix.