### PR TITLE
feat(ui): presence + presence-phase runtime with flush-presence! (rf2-uckeg, S4-A)

### DIFF
--- a/docs/api/re-frame.ui.md
+++ b/docs/api/re-frame.ui.md
@@ -349,6 +349,30 @@ from ordinary Clojure code fails loud** (they are not runtime helpers).
   `:rf.error/routing-artefact-missing` (naming the artefact, its Maven coord, and the
   link site). A plain `[:a]` stays available for intentional browser-native navigation.
 
+### `presence`
+
+- **Kind**: function (compile-time authoring form)
+- **Signature**: `(presence {:timeout-ms n} keyed-children)`
+- **Description**: Declarative **enter/exit retention**, deliberately bounded — **not** an
+  animation system. Keyed children pass `:mounting` → `:present` → `:unmounting`; an
+  exiting child stays **mounted** until its exit completes **or** the **mandatory**
+  `:timeout-ms` safety bound fires, whichever is first, then removal is **terminal and
+  exactly-once** (all ownership released). Removing then re-inserting a key **interrupts**
+  the exit and re-enters. A child reads its phase with `presence-phase`. On the JVM / SSR
+  the structural render yields `:present` (there is no lifecycle to retain).
+- **Errors**: missing / non-positive `:timeout-ms` → `:rf.ui.compile/bad-presence`; an
+  unkeyed child under the boundary → `:rf.ui.compile/presence-unkeyed-child`; direct call →
+  `:rf.error/ui-tree-malformed`.
+
+### `presence-phase`
+
+- **Kind**: function (render-time read)
+- **Signature**: `(presence-phase)` → `:mounting` / `:present` / `:unmounting`
+- **Description**: The single presence-phase read. Inside a `(presence …)` boundary it
+  returns the child's live phase; **outside** one it returns `:present` (so presence-aware
+  children stay reusable anywhere). A render-time read (a React context read on CLJS); the
+  JVM structural render always yields `:present`.
+
 ## Roots and mounting
 
 ### `mount`

--- a/docs/api/re-frame.ui.test.md
+++ b/docs/api/re-frame.ui.test.md
@@ -193,6 +193,29 @@ must be `.cljc` (the standard re-frame discipline) so the JVM render can resolve
   spinning. Calling it inside an open event drain throws `:rf.error/flush-in-open-epoch`
   (CLJS) / fails the shared open-drain guard.
 
+### `flush-presence!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  ;; JVM (Tier 1): synchronous no-op
+  (flush-presence!) → nil
+  (flush-presence! ms) → nil
+  ;; CLJS (Tier 3): Promise-backed
+  (flush-presence!) → js/Promise
+  (flush-presence! ms) → js/Promise
+  ```
+- **Description**: Advance **presence** enter/exit transitions on a fake clock — the S4
+  twin of `flush!` — so retained (`:unmounting`) children reach their `:timeout-ms`
+  removal **without** wall-clock sleeps. `(flush-presence!)` advances to quiescence (every
+  pending exit fires); `(flush-presence! ms)` advances the logical clock by `ms`, firing
+  only the exits that come due. On **CLJS** the advance and its removal commits run inside
+  awaited React `act` and the returned Promise settles at the framework/React fixed point —
+  await it before asserting an enter/exit. On the **JVM** the structural render has no
+  lifecycle (presence renders `:present`, no retention timers), so both arities are a
+  synchronous no-op returning `nil`, present for host-parity. The open-event-drain guard
+  runs synchronously first.
+
 ## See also
 
 - [`re-frame.ui`](re-frame.ui.md) — the compiled-view substrate under test (`defview`,

--- a/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
+++ b/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
@@ -250,11 +250,12 @@
       (is (empty? problems) (probe/signature-report problems)))))
 
 (deftest ui-test-signature-contract-is-non-vacuous
-  (testing "the embedded contract carries the nine blessed ui.test vars and the
-            analyzer surfaced flush!'s live CLJS :fn 0/1-arity (guards against a
-            vacuous green from an unread sidecar or un-analysed namespace)"
+  (testing "the embedded contract carries the ten blessed ui.test vars (the nine
+            S1–S2 vars plus S4's flush-presence!) and the analyzer surfaced
+            flush!'s live CLJS :fn 0/1-arity (guards against a vacuous green from
+            an unread sidecar or un-analysed namespace)"
     (is (= "re-frame.ui.test" (:namespace ui-test-signature-contract)))
-    (is (= 9 (count (:vars ui-test-signature-contract))))
+    (is (= 10 (count (:vars ui-test-signature-contract))))
     (is (= :fn (get-in live-ui-test-surface ["flush!" :kind]))
         "flush! must be classified :fn by the live analyzer — the kind authority")
     (is (= #{[0] [1]} (get-in live-ui-test-surface ["flush!" :arities]))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
@@ -527,11 +527,11 @@
 (deftest live-ui-test-jvm-signature-matches-contract
   (testing "the committed :ui-test-signatures contract reconciles clean against
             the LIVE re-frame.ui.test JVM surface (kind + :clj arities; no live
-            drift), and the enumeration actually covers the nine blessed vars"
+            drift), and the enumeration actually covers the ten blessed vars"
     (let [contract (:vars (c/read-ui-test-signatures))
           surface  (c/live-ui-test-surface)]
-      (is (= 9 (count contract))
-          "the signature authority must carry all nine blessed vars")
+      (is (= 10 (count contract))
+          "the signature authority must carry all ten blessed vars")
       (is (= (set (keys contract)) (set (keys surface)))
           "live blessed vars and the contract must cover exactly the same names")
       (is (empty? (c/ui-test-arity-problems contract surface))

--- a/implementation/ui/src/re_frame/ui.cljc
+++ b/implementation/ui/src/re_frame/ui.cljc
@@ -58,6 +58,7 @@
   (:require [re-frame.error :as error]
             [re-frame.ui.hooks]
             [re-frame.ui.lease-descriptor]
+            [re-frame.ui.presence-runtime :as presence-rt]
             [re-frame.ui.reactive :as reactive]
             [re-frame.ui.route-link-seam :as rl]
             #?@(:clj  [[re-frame.ui.compiler :as compiler]
@@ -604,6 +605,34 @@
         "compiler renders the client subtree in the browser and the "
         "capability-free fallback on the JVM/SSR; it is never called directly")
    nil))
+
+(defn presence
+  "(ui/presence {:timeout-ms n} keyed-children) — declarative enter/exit
+  retention, deliberately bounded (NOT an animation system). Keyed children
+  pass :mounting → :present → :unmounting; an exiting child stays mounted until
+  its exit completes OR the MANDATORY :timeout-ms safety bound fires, whichever
+  first, then removal is terminal and exactly-once (all ownership released).
+  Removal-then-reinsertion of a key interrupts the exit and re-enters. Unkeyed
+  children under a presence boundary are a build failure. Read a child's phase
+  with (ui/presence-phase).
+
+  A template form — the compiler wires it into the runtime retention boundary;
+  a direct call fails loud by design."
+  [& _]
+  (error/throw-error!
+   :rf.error/ui-tree-malformed 're-frame.ui/presence
+   (str "(ui/presence {:timeout-ms n} children) is a template form — the "
+        "compiler wires it into the runtime enter/exit retention boundary; it "
+        "is never called directly")
+   nil))
+
+(defn presence-phase
+  "(ui/presence-phase) — the single presence-phase read: :mounting / :present /
+  :unmounting inside a (ui/presence …) boundary, :present outside one (so
+  presence-aware children stay reusable anywhere). A render-time read (a React
+  context read on CLJS); the JVM structural render always yields :present."
+  []
+  (presence-rt/presence-phase))
 
 ;; ---------------------------------------------------------------------------
 ;; Compiled render slots (S3) — the internal library-seam callback + invocation

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -27,7 +27,7 @@
   scoping a subtree to an already-live frame."
   #{:text :nothing :expr :element :fragment :view :foreign
     :if :let :letfn :case :for :raw :html :frame-root :frame-provider :slot
-    :error-boundary :client-only
+    :error-boundary :client-only :presence
     :hook-prefix})
 
 (defn literal-scalar? [x]
@@ -44,6 +44,7 @@
 (def ^:private ui-slot-fqns   #{'re-frame.ui/slot})
 (def ^:private error-boundary-fqns #{'re-frame.ui/error-boundary})
 (def ^:private client-only-fqns #{'re-frame.ui/client-only})
+(def ^:private presence-fqns #{'re-frame.ui/presence})
 (def ^:private sub-fqns       #{'re-frame.ui/sub})
 (def ^:private lease-fqns     #{'re-frame.ui/lease})
 (def ^:private frame-fqns     #{'re-frame.ui/frame})
@@ -194,6 +195,7 @@
 (defn- slot-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) ui-slot-fqns)))
 (defn- error-boundary-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) error-boundary-fqns)))
 (defn- client-only-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) client-only-fqns)))
+(defn- presence-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) presence-fqns)))
 
 ;; ---------------------------------------------------------------------------
 ;; Expression rewriting — lexical site indexing + loop finiteness
@@ -2377,6 +2379,88 @@
      :path (:path e)}))
 
 ;; ---------------------------------------------------------------------------
+;; ui/presence (S4, rf2-uckeg) — declarative enter/exit retention
+;; ---------------------------------------------------------------------------
+
+(def ^:private presence-opt-keys #{:timeout-ms})
+
+(defn- presence-keyed-child?
+  "A presence child must be STATICALLY keyed — the identity the runtime tracks
+  across renders. A `(for …)` is keyed by construction (analyze-for enforces
+  every row's `:key`); a literal element/view/foreign/fragment must carry a
+  `:key`. A branch (if/let/case) is keyed when each rendered arm is."
+  [ast]
+  (case (:op ast)
+    :for true
+    (:element :fragment) (boolean (get-in ast [:key :present?]))
+    (:view :foreign) (boolean (get-in ast [:props :key :present?]))
+    :if (and (presence-keyed-child? (:then ast)) (presence-keyed-child? (:else ast)))
+    :let (presence-keyed-child? (:body ast))
+    :letfn (presence-keyed-child? (:body ast))
+    :case (and (every? presence-keyed-child? (map second (:clauses ast)))
+               (or (= ::none (:default ast)) (presence-keyed-child? (:default ast))))
+    :nothing true                       ; a statically-absent arm is fine
+    false))
+
+(defn- analyze-presence
+  "(ui/presence {:timeout-ms n} keyed-children) — the three-phase enter/exit
+  retention boundary. `:timeout-ms` is MANDATORY (the terminal safety bound —
+  unit suffixed on the key) and a positive number literal. Children must be
+  statically KEYED (a `(for …)` with `:key`, or keyed element/view rows) —
+  unkeyed presence children are a build failure (§Presence)."
+  [e form]
+  (let [opts  (nth form 1 nil)
+        body  (drop 2 form)]
+    (when-not (map? opts)
+      (env/fail! e :rf.ui.compile/bad-presence
+                 (str "(ui/presence {:timeout-ms n} children) needs a literal opts "
+                      "map with a mandatory :timeout-ms (the terminal safety bound)")
+                 {:form form}))
+    (let [bad (remove presence-opt-keys (keys opts))]
+      (when (seq bad)
+        (env/fail! e :rf.ui.compile/bad-presence
+                   (str "unknown presence option" (when (next bad) "s") " "
+                        (str/join ", " (map pr-str bad))
+                        " — the only option is :timeout-ms")
+                   {:form form})))
+    (when-not (contains? opts :timeout-ms)
+      (env/fail! e :rf.ui.compile/bad-presence
+                 (str ":timeout-ms is MANDATORY on (ui/presence …) — the terminal "
+                      "safety bound: a retained exiting child is removed when its "
+                      "exit completes OR :timeout-ms fires, whichever first")
+                 {:form form}))
+    (let [t (:timeout-ms opts)]
+      (when-not (and (number? t) (pos? t))
+        (env/fail! e :rf.ui.compile/bad-presence
+                   (str ":timeout-ms must be a positive number of milliseconds; got "
+                        (pr-str t))
+                   {:form form})))
+    (when (empty? body)
+      (env/fail! e :rf.ui.compile/bad-presence
+                 "(ui/presence {:timeout-ms n} children) needs at least one keyed child"
+                 {:form form}))
+    (let [child-asts (into []
+                           (map-indexed
+                            (fn [i c]
+                              (analyze (-> e (update :path conj :presence i)
+                                           (assoc :hooks-region? false))
+                                       c)))
+                           body)]
+      (doseq [ast child-asts]
+        (when-not (presence-keyed-child? ast)
+          (env/fail! e :rf.ui.compile/presence-unkeyed-child
+                     (str "children under (ui/presence …) must be KEYED — a "
+                          "(for [x xs] [row {:key (:id x)} …]) or keyed element/view "
+                          "rows. Presence tracks children by key across renders, so "
+                          "unkeyed presence children are a build failure")
+                     {:form form})))
+      {:op :presence
+       :timeout-ms (:timeout-ms opts)
+       :children child-asts
+       :static? false
+       :path (:path e)})))
+
+;; ---------------------------------------------------------------------------
 ;; Reactive authoring verbs in head position (rf2-vxgfnd.266)
 ;; ---------------------------------------------------------------------------
 ;;
@@ -2930,6 +3014,9 @@
 
         (client-only-form? e form)
         (analyze-client-only e form)
+
+        (presence-form? e form)
+        (analyze-presence e form)
 
         (render-fn-form? e form)
         (env/fail! e :rf.ui.compile/render-fn-misplaced

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -522,6 +522,16 @@
            (.push ~arr ~row)))
        ~arr)))
 
+(defn- emit-presence
+  "`ui/presence` → the runtime retention boundary. The compiled keyed children
+  (a `for` emits a JS array) are handed as one array; the boundary tracks them
+  by React key across renders, driving the :mounting/:present/:unmounting phase
+  each child reads with `(presence-phase)`."
+  [node st]
+  `(re-frame.ui.presence-runtime/presence-boundary
+    ~(:timeout-ms node)
+    (cljs.core/array ~@(children-forms st (:children node) false))))
+
 (defn- emit-frame-root
   "A top-region `frame-root` SCOPES its preflight-ensured frame to its
   children through the shared React frame context (rf2-vxgfnd.25 —
@@ -620,6 +630,7 @@
     :foreign  (emit-component node st inline?)
     :slot     (emit-slot node st)
     :error-boundary (emit-error-boundary node st)
+    :presence (emit-presence node st)
     ;; S3: the browser renders the client subtree directly (activation). The
     ;; capability-free fallback is the JVM/SSR path only; the single-update SSR
     ;; phase-flip (fallback→client per root) completes S5.

--- a/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
@@ -314,6 +314,12 @@
     ;; under the server failure policy (per 011); it never renders the fallback
     ;; (that is client recovery). A throw below it is the server's to project.
     :error-boundary (emit-node (:child node))
+    ;; presence: the JVM has no lifecycle, so it renders the children :present,
+    ;; wrapped in the `:rf.ui/presence {:phase :present :timeout-ms n}` fragment
+    ;; (§004B — presence metadata exposed structurally).
+    :presence `(re-frame.ui.tree/presence
+                ~(:timeout-ms node)
+                ~@(keep emit-node (:children node)))
     ;; client-only: the JVM/SSR renders the deterministic capability-free
     ;; FALLBACK, wrapped in the `:rf.ui/boundary :client-only` fragment (§004B);
     ;; the browser-only client subtree never appears on the JVM tree.

--- a/implementation/ui/src/re_frame/ui/presence_runtime.cljc
+++ b/implementation/ui/src/re_frame/ui/presence_runtime.cljc
@@ -1,0 +1,313 @@
+(ns re-frame.ui.presence-runtime
+  "Presence — declarative enter/exit retention (Spec 004 §Presence, S4).
+  (Named `-runtime` to avoid the CLJS var↔namespace munging clash with the
+  public `re-frame.ui/presence` var — the same split as `lease` ↔
+  `re-frame.ui.lease-descriptor`.)
+  DELIBERATELY BOUNDED: not an animation system. The three-phase keyed
+  retention machine plus the `:timeout-ms` terminal safety bound, and nothing
+  more (no easing, no curves, no presence-event bus).
+
+  A `(ui/presence {:timeout-ms n} keyed-children)` boundary tracks its children
+  BY KEY across renders. A key passes `:mounting → :present`; when a key leaves
+  the incoming set the child is RETAINED in `:unmounting` (its exit transition
+  runs against that phase) until the `:timeout-ms` safety bound fires, then the
+  removal is terminal and EXACTLY-ONCE (React unmounts the retained subtree, so
+  every lease / effect it owns is released). Removal-then-reinsertion of a key
+  interrupts the exit and re-enters at `:present`.
+
+  `(presence-phase)` is the single phase read — `react/useContext` on CLJS,
+  `:present` on the JVM structural subset. Outside a boundary it returns
+  `:present`, so presence-aware children stay reusable anywhere.
+
+  The runtime split:
+
+    reconcile          PURE next-entry derivation (both hosts, unit-testable)
+    the presence clock a fake-advanceable exit scheduler; `flush-presence!`
+                       (re-frame.ui.test) drives it deterministically without
+                       wall-clock sleeps, production arms `js/setTimeout`
+    presence-boundary  the React function component that wires the two together
+
+  The JVM structural node lives in `re-frame.ui.tree/presence` (a fragment
+  carrying the `:rf.ui/presence {:phase :present :timeout-ms n}` diagnostic
+  marker, §004B); this namespace's JVM arm is `presence-phase` only."
+  #?(:cljs (:require ["react" :as react])))
+
+;; ---------------------------------------------------------------------------
+;; reconcile — the PURE three-phase entry derivation (both hosts)
+;; ---------------------------------------------------------------------------
+
+(defn reconcile
+  "Derive the next ordered entry vector from the COMMITTED entries and the
+  incoming key vector. Pure and idempotent — the same inputs always give the
+  same output, so a StrictMode double-render is harmless.
+
+    committed    ordered [{:key k :phase :mounting|:present|:unmounting} …]
+    incoming     ordered [k …] (the keys present in this render)
+
+  Rules, in committed order then appended new keys:
+    - a committed key still incoming keeps its phase, EXCEPT `:unmounting`
+      flips back to `:present` (removal-then-reinsertion re-entry);
+    - a committed key no longer incoming becomes `:unmounting` (retained —
+      it is dropped from the set only by its removal callback, never here);
+    - a brand-new incoming key is appended as `:mounting`.
+
+  Retained (`:unmounting`) keys hold their slot; new keys append at the end."
+  [committed incoming]
+  (let [incoming-set (set incoming)
+        committed-keys (into #{} (map :key) committed)
+        kept (mapv (fn [{:keys [key phase] :as e}]
+                     (cond
+                       (and (incoming-set key) (= :unmounting phase))
+                       (assoc e :phase :present)          ; re-entry
+                       (incoming-set key) e               ; still here
+                       :else (assoc e :phase :unmounting))) ; retained for exit
+                   committed)
+        added (into [] (comp (remove committed-keys)
+                             (map (fn [k] {:key k :phase :mounting})))
+                    incoming)]
+    (into kept added)))
+
+;; ---------------------------------------------------------------------------
+;; The presence clock — a fake-advanceable exit scheduler
+;;
+;; ONE registry of pending exits owns every retention timer. Production arms a
+;; real `js/setTimeout` per exit; tests advance the logical clock through
+;; `ui.test/flush-presence!` (→ `advance-clock!`), firing due timers with no
+;; wall-clock sleep. `fire-timer!` is id-keyed and idempotent, so a real
+;; setTimeout that lands after a test already flushed its timer is a no-op —
+;; the terminal removal runs EXACTLY ONCE regardless of which path wins.
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (do
+
+(defonce ^:private clock
+  ;; :now      logical milliseconds
+  ;; :next-id  monotonic timer id
+  ;; :pending  {id {:fire-at ms :remove! fn :handle js-timeout-handle}}
+  (atom {:now 0 :next-id 0 :pending {}}))
+
+(defonce ^:private wall-clock?
+  ;; Production arms a real js/setTimeout; a deterministic test disables it so
+  ;; the logical clock (advance-clock!) is the SOLE removal driver.
+  (atom true))
+
+(defn set-wall-clock!
+  "Enable/disable the real-`setTimeout` removal arm. Tests that drive removal
+  purely through `flush-presence!` disable it for determinism; production
+  leaves it on. Returns the new value."
+  [on?]
+  (reset! wall-clock? (boolean on?)))
+
+(defn pending-count
+  "How many exits are currently retained (awaiting removal)?"
+  []
+  (count (:pending @clock)))
+
+(defn fire-timer!
+  "Fire the pending timer `id` EXACTLY ONCE: atomically claim + remove it, then
+  run its `:remove!`. A second call (real setTimeout after a test flush, a
+  double advance) finds nothing and is a no-op — the exactly-once guard."
+  [id]
+  (let [entry (get-in @clock [:pending id])]
+    (when entry
+      (let [claimed (volatile! nil)]
+        (swap! clock update :pending
+               (fn [p] (when-let [e (get p id)]
+                         (vreset! claimed e))
+                       (dissoc p id)))
+        (when-let [{:keys [remove! handle]} @claimed]
+          (when handle (js/clearTimeout handle))
+          (remove!))))))
+
+(defn cancel-timer!
+  "Cancel pending timer `id` WITHOUT firing its removal (re-entry / unmount)."
+  [id]
+  (let [entry (get-in @clock [:pending id])]
+    (when-let [handle (:handle entry)] (js/clearTimeout handle))
+    (swap! clock update :pending dissoc id)
+    nil))
+
+(defn schedule-exit!
+  "Register an exit removal to fire after `timeout-ms` of clock time. Returns
+  the timer id (pass to `cancel-timer!` on re-entry / unmount). Production also
+  arms a real `js/setTimeout`; both routes funnel through the id-keyed
+  `fire-timer!`, so the removal is exactly-once."
+  [timeout-ms remove!]
+  (let [id (:next-id @clock)
+        fire-at (+ (:now @clock) timeout-ms)
+        handle (when @wall-clock?
+                 (js/setTimeout #(fire-timer! id) timeout-ms))]
+    (swap! clock (fn [c]
+                   (-> c
+                       (assoc :next-id (inc (:next-id c)))
+                       (assoc-in [:pending id]
+                                 {:fire-at fire-at :remove! remove! :handle handle}))))
+    id))
+
+(defn- due-ids
+  "Pending ids whose fire-at ≤ `t`, in fire-at then id order (deterministic)."
+  [t]
+  (->> (:pending @clock)
+       (filter (fn [[_ {:keys [fire-at]}]] (<= fire-at t)))
+       (sort-by (fn [[id {:keys [fire-at]}]] [fire-at id]))
+       (mapv first)))
+
+(defn advance-clock!
+  "Advance the logical clock by `ms` (or, with no arg, to quiescence — past the
+  last pending fire-at) and fire every timer that comes due, in deterministic
+  order. The deterministic, wall-clock-free driver behind
+  `ui.test/flush-presence!`. Returns the number of exits removed."
+  ([]
+   (let [pend (:pending @clock)]
+     (if (empty? pend)
+       0
+       (let [maxf (apply max (map :fire-at (vals pend)))]
+         (advance-clock! (- (inc maxf) (:now @clock)))))))
+  ([ms]
+   (let [target (+ (:now @clock) ms)]
+     (swap! clock assoc :now target)
+     (let [ids (due-ids target)]
+       (doseq [id ids] (fire-timer! id))
+       (count ids)))))
+
+(defn reset-clock!
+  "Drop every pending exit and reset logical time — a test-isolation hook."
+  []
+  (doseq [[_ {:keys [handle]}] (:pending @clock)]
+    (when handle (js/clearTimeout handle)))
+  (reset! clock {:now 0 :next-id 0 :pending {}})
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; presence-context + the boundary component
+;; ---------------------------------------------------------------------------
+
+(defonce ^js presence-context
+  ;; Default `:present` — a presence-aware child rendered OUTSIDE any boundary
+  ;; reads `:present`, so it stays reusable anywhere.
+  (react/createContext :present))
+
+(defn- react-element? [x]
+  (and (some? x) (react/isValidElement x)))
+
+(defn- collect-elements
+  "Flatten the incoming children (a compiled `for` emits nested JS arrays) into
+  an ordered [key element] vector. Keys come from React's own `.-key` (already
+  string-coerced), the identity `reconcile` tracks. The analyzer guarantees
+  every presence child is keyed, so an element without a key is defensive-only."
+  [acc x]
+  (cond
+    (nil? x)              acc
+    (js/Array.isArray x)  (reduce collect-elements acc x)
+    (react-element? x)    (if-some [k (.-key x)] (conj acc [k x]) acc)
+    :else                 acc))
+
+(defn- render-entries
+  "Render each entry as its element wrapped in a phase-carrying context Provider
+  (so `(presence-phase)` in the child reads its phase). The Provider is keyed by
+  the entry key; the wrapped element keeps its own key too."
+  [entries elements]
+  (into-array
+   (keep (fn [{:keys [key phase]}]
+           (when-some [el (get elements key)]
+             (react/createElement (.-Provider presence-context)
+                                  #js {:value phase :key key}
+                                  el)))
+         entries)))
+
+(defn- entries-signature [entries]
+  ;; phase-sensitive identity so the commit effect only re-renders on a real
+  ;; change (avoids an infinite setState loop).
+  (mapv (juxt :key :phase) entries))
+
+(defn ^:private PresenceComponent [^js props]
+  (let [timeout-ms (.-timeoutMs props)
+        incoming   (.-incoming props)
+        ;; forceUpdate cell — the setter identity is stable across renders.
+        tick       (react/useState 0)
+        force!     (fn [] ((aget tick 1) inc))
+        ;; committed state (source of truth) — mutated ONLY in the effect /
+        ;; removal callbacks, never during render, so `reconcile` reads a stable
+        ;; snapshot and a StrictMode double-render is idempotent.
+        st         (react/useRef nil)]
+    (when (nil? (.-current st))
+      (set! (.-current st) #js {:entries [] :elements {} :timers {}}))
+    (let [state    (.-current st)
+          incoming-pairs (collect-elements [] incoming)
+          incoming-keys  (mapv first incoming-pairs)
+          ;; keep the latest element for every incoming key; retained keys keep
+          ;; their last-seen element.
+          elements (merge (.-elements state) (into {} incoming-pairs))
+          desired  (reconcile (.-entries state) incoming-keys)]
+      (set! (.-elements state) elements)
+      ;; Commit + phase transitions run AFTER paint (a side-effect, never during
+      ;; render). Runs every commit; idempotent via signature guards.
+      (react/useEffect
+       (fn []
+         (let [state   (.-current st)
+               desired (reconcile (.-entries state) (mapv first (collect-elements [] incoming)))
+               timers  (.-timers state)
+               ;; 1. schedule a removal timer for each newly-:unmounting key
+               ;; 2. cancel the timer for each re-entered key
+               timers* (reduce
+                        (fn [tm {:keys [key phase]}]
+                          (cond
+                            (and (= :unmounting phase) (not (contains? tm key)))
+                            (assoc tm key
+                                   (schedule-exit!
+                                    timeout-ms
+                                    (fn remove-key! []
+                                      (let [s (.-current st)]
+                                        (set! (.-entries s)
+                                              (filterv #(not= key (:key %)) (.-entries s)))
+                                        (set! (.-elements s) (dissoc (.-elements s) key))
+                                        (set! (.-timers s) (dissoc (.-timers s) key)))
+                                      (force!))))
+                            (and (not= :unmounting phase) (contains? tm key))
+                            (do (cancel-timer! (get tm key)) (dissoc tm key))
+                            :else tm))
+                        timers
+                        desired)
+               ;; 3. flip every :mounting entry to :present (enter transition)
+               next    (mapv (fn [e] (if (= :mounting (:phase e))
+                                       (assoc e :phase :present) e))
+                             desired)]
+           (set! (.-timers state) timers*)
+           (when (not= (entries-signature next) (entries-signature (.-entries state)))
+             (set! (.-entries state) next)
+             (force!)))
+         js/undefined))
+      ;; teardown: cancel every pending timer (React unmounts the retained
+      ;; subtrees itself — the terminal ownership release).
+      (react/useEffect
+       (fn [] (fn []
+                (let [state (.-current st)]
+                  (doseq [[_ id] (.-timers state)] (cancel-timer! id))
+                  (set! (.-timers state) {}))))
+       #js [])
+      (render-entries desired elements))))
+
+(defn presence-boundary
+  "Build a `(ui/presence {:timeout-ms n} children)` element (the CLJS emitter's
+  lowering target). `timeout-ms` is the compile-time literal safety bound;
+  `children` is the compiled keyed children (a JS array, possibly nesting the
+  arrays a `for` emits)."
+  [timeout-ms children]
+  (react/createElement PresenceComponent
+                       #js {:timeoutMs timeout-ms :incoming children}))
+
+   ))
+
+;; ---------------------------------------------------------------------------
+;; presence-phase — the single phase read (both hosts)
+;; ---------------------------------------------------------------------------
+
+(defn presence-phase
+  "Read the current presence phase — `:mounting` / `:present` / `:unmounting`
+  inside a `(ui/presence …)` boundary, `:present` outside one. A render-time
+  read (CLJS `react/useContext`); on the JVM structural subset it is always
+  `:present`."
+  []
+  #?(:cljs (react/useContext presence-context)
+     :clj  :present))

--- a/implementation/ui/src/re_frame/ui/test.cljc
+++ b/implementation/ui/src/re_frame/ui/test.cljc
@@ -71,6 +71,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.router :as router]
             [re-frame.ui.eq :as eq]
+            [re-frame.ui.presence-runtime :as presence]
             [re-frame.ui.reactive :as reactive]
             #?@(:clj [[re-frame.ui.compiler.emit-jvm :as emit-jvm]
                       [re-frame.ui.compiler.env :as env]
@@ -829,6 +830,36 @@
                           (pr-str thunk))
                      {:got thunk}))
         (flush-async! thunk)))))
+
+;; ---------------------------------------------------------------------------
+;; flush-presence! — the S4 fake-clock transition advance (rf2-uckeg)
+;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (defn flush-presence!
+     "`(flush-presence!)` — advance presence transitions on the JVM Tier-1 host.
+     The JVM structural render has no lifecycle (presence renders :present, no
+     retention timers), so this is a synchronous no-op returning nil. Present
+     for host-parity: a `.cljc` test body can call it on either host."
+     ([] nil)
+     ([_ms] nil))
+   :cljs
+   (do
+     (defn flush-presence!
+       "Advance the presence fake clock so retained (:unmounting) children reach
+       their :timeout-ms removal WITHOUT wall-clock sleeps — the S4 twin of
+       `flush!`. `(flush-presence!)` advances to quiescence (every pending exit
+       fires); `(flush-presence! ms)` advances the logical clock by `ms`, firing
+       only the exits that come due. The advance + its removal commits run inside
+       awaited React `act`; the returned Promise settles at the framework/React
+       fixed point (drive an enter/exit assertion after awaiting it). The
+       open-event-drain guard runs synchronously first."
+       ([]
+        (guard-open-drain!)
+        (flush-async! (fn [] (presence/advance-clock!) nil)))
+       ([ms]
+        (guard-open-drain!)
+        (flush-async! (fn [] (presence/advance-clock! ms) nil))))))
 
 ;; ---------------------------------------------------------------------------
 ;; render (S1: JVM structural render — root-identity-and-mount §9)

--- a/implementation/ui/src/re_frame/ui/tree.cljc
+++ b/implementation/ui/src/re_frame/ui/tree.cljc
@@ -295,6 +295,18 @@
       (seq chs)       (assoc :children chs)
       (not (seq chs)) (assoc :children []))))
 
+(defn presence
+  "The JVM/SSR structural node for `(ui/presence {:timeout-ms n} …)`: a fragment
+  carrying the `:rf.ui/presence {:phase :present :timeout-ms n}` diagnostic
+  marker (§004B — the \"presence metadata exposed structurally\"; a droppable
+  reserved key, stripped by semantic normalization). The JVM has no lifecycle,
+  so every retained child renders `:present`."
+  [timeout-ms & xs]
+  (let [chs (apply children xs)]
+    (cond-> {:rf.ui/presence {:phase :present :timeout-ms timeout-ms}}
+      (seq chs)       (assoc :children chs)
+      (not (seq chs)) (assoc :children []))))
+
 (defn view-boundary
   "Wrap one internal-view expansion (Q12: view-boundary nodes are real
   nodes, nesting recursively). `props` is the props map the view fn
@@ -309,12 +321,14 @@
         chs (cond
               (nil? body) nil
               ;; fragment-rooted view: boundary adopts the fragment's children.
-              ;; A boundary-marked fragment (`:rf.ui/boundary`, e.g. a root-level
-              ;; ui/client-only fallback) is NOT adopted — its marker is a
+              ;; A marker-bearing fragment (`:rf.ui/boundary`, e.g. a root-level
+              ;; ui/client-only fallback; or `:rf.ui/presence`, a root-level
+              ;; ui/presence boundary) is NOT adopted — its marker is a
               ;; load-bearing child node that must survive as its own node.
               (and (map? body) (not (contains? body :tag))
                    (not (contains? body :view-id)) (not (contains? body :html))
                    (not (contains? body :rf.ui/boundary))
+                   (not (contains? body :rf.ui/presence))
                    (contains? body :children)
                    (not (contains? body :key)))
               (let [c (:children body)] (when (seq c) c))

--- a/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
@@ -371,7 +371,10 @@
             ;; S3 route-link (rf2-vxgfnd.95.5): an ORDINARY compiled defview over
             ;; the routing-owned late-bound link seam — the FIRST framework-
             ;; provided compiled view, not a compiler intrinsic
-            route-link}
+            route-link
+            ;; S4 presence (rf2-uckeg): declarative enter/exit retention — the
+            ;; template form + its single phase read
+            presence presence-phase}
          (set (keys (ns-publics 're-frame.ui))))
       "no reg-view family, no Form-1/2/3 helpers, no h macro, no view
        lookup, no ratom/cursor/reaction — Spec 004 §Removed forms"))

--- a/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
@@ -68,6 +68,9 @@
     :rf.ui.compile/bad-error-boundary
     :rf.ui.compile/bad-client-only
     :rf.ui.compile/capability-in-fallback
+    ;; presence — declarative enter/exit retention (S4, rf2-uckeg)
+    :rf.ui.compile/bad-presence
+    :rf.ui.compile/presence-unkeyed-child
     ;; compiled render slots (S3, rf2-ri0k6n)
     :rf.ui.compile/bad-render-fn
     :rf.ui.compile/bad-slot
@@ -217,6 +220,7 @@
       slot        {:fqn 're-frame.ui/slot :meta {}}
       error-boundary {:fqn 're-frame.ui/error-boundary :meta {}}
       client-only    {:fqn 're-frame.ui/client-only :meta {}}
+      presence       {:fqn 're-frame.ui/presence :meta {}}
       frame-provider {:fqn 're-frame.ui/frame-provider :meta {}}
       child-view  {:fqn 'app.views/child-view
                    :meta {:rf.ui/view true :rf.ui/children? true}}
@@ -344,6 +348,25 @@
    [:rf.ui.compile/capability-in-fallback
     '(client-only {:fallback [:p (sub [:q])]} [:div "live"])
     ["CAPABILITY-FREE" "client subtree"]]
+   ;; presence — declarative enter/exit retention (S4, rf2-uckeg)
+   [:rf.ui.compile/bad-presence
+    '(presence [:li {:key 1} "x"])
+    ["literal opts map" ":timeout-ms"]]
+   [:rf.ui.compile/bad-presence
+    '(presence {:timeout-ms 300 :easing :ease} (for [x xs] [:li {:key x} x]))
+    ["unknown presence option" ":timeout-ms"]]
+   [:rf.ui.compile/bad-presence
+    '(presence {} (for [x xs] [:li {:key x} x]))
+    [":timeout-ms is MANDATORY" "safety bound"]]
+   [:rf.ui.compile/bad-presence
+    '(presence {:timeout-ms 0} (for [x xs] [:li {:key x} x]))
+    ["positive number of milliseconds"]]
+   [:rf.ui.compile/presence-unkeyed-child
+    '(presence {:timeout-ms 300} [:li "x"])
+    ["KEYED" "build failure"]]
+   [:rf.ui.compile/presence-unkeyed-child
+    '(presence {:timeout-ms 300} [child-view {:toast 1}])
+    ["KEYED"]]
    ;; compiled render slots (S3, rf2-ri0k6n)
    [:rf.ui.compile/bad-render-fn
     '[child-view {:row (render-fn [a] [:p "a"] [:p "b"])}]

--- a/implementation/ui/test/re_frame/ui/presence_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/presence_dom_cljs_test.cljs
@@ -17,6 +17,16 @@
 
 (defn- browser? [] (exists? js/document))
 
+;; The mounted machine's app surface. Registered at ns-load BEFORE the
+;; `use-fixtures` form below so `make-reset-runtime-fixture` captures them in its
+;; ns-load baseline (test_support.cljc §Stable ns-load baseline — the snapshot is
+;; taken eagerly at fixture-build time). The per-test reset then folds that
+;; baseline back over a fresh registrar, so `::toasts` is registered again at
+;; every mount — otherwise the strict mounted-React observation port throws
+;; `:rf.error/no-such-sub` on the unknown ENTRY sub.
+(rf/reg-event ::set-toasts (fn [{:keys [db]} [_ ts]] {:db (assoc db :toasts ts)}))
+(rf/reg-sub ::toasts (fn [db _] (:toasts db)))
+
 ;; ---------------------------------------------------------------------------
 ;; Fixtures — the async runtime reset PLUS a deterministic presence clock
 ;; (reset + wall-clock disabled, so advance-clock! is the SOLE removal driver).
@@ -72,9 +82,6 @@
 ;; ---------------------------------------------------------------------------
 ;; Mounted three-phase machine (jsdom / browser)
 ;; ---------------------------------------------------------------------------
-
-(rf/reg-event ::set-toasts (fn [{:keys [db]} [_ ts]] {:db (assoc db :toasts ts)}))
-(rf/reg-sub ::toasts (fn [db _] (:toasts db)))
 
 (defview toast-card [{:keys [msg]}]
   [:li {:data-testid "toast" :data-msg msg

--- a/implementation/ui/test/re_frame/ui/presence_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/presence_dom_cljs_test.cljs
@@ -1,0 +1,169 @@
+(ns re-frame.ui.presence-dom-cljs-test
+  "S4 presence (rf2-uckeg) client behaviour: the fake-clock exit scheduler and
+  the mounted three-phase machine (Spec 004 §Presence).
+
+    - the presence clock: advance-clock! fires DUE timers deterministically, in
+      order, EXACTLY ONCE (the double-cleanup guard); a partial advance leaves a
+      not-yet-due exit retained (the timeout-fires-before-exit adversarial case);
+    - mounted: a keyed child enters :mounting → :present; a removed key is
+      RETAINED :unmounting until flush-presence! reaches :timeout-ms, then it is
+      removed and its ownership released exactly once; reinsertion re-enters."
+  (:require [cljs.test :refer [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.presence-runtime :as presence]
+            [re-frame.ui.test :as uit]))
+
+(defn- browser? [] (exists? js/document))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures — the async runtime reset PLUS a deterministic presence clock
+;; (reset + wall-clock disabled, so advance-clock! is the SOLE removal driver).
+;; ---------------------------------------------------------------------------
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter ui/adapter :ambient-frame nil :async? true})
+  {:before #(do (presence/reset-clock!) (presence/set-wall-clock! false))
+   :after  #(do (presence/reset-clock!) (presence/set-wall-clock! true))})
+
+(deftest advance-clock-fires-due-timers-in-order
+  (let [fired (atom [])]
+    (presence/schedule-exit! 300 #(swap! fired conj :a))
+    (presence/schedule-exit! 100 #(swap! fired conj :b))
+    (presence/schedule-exit! 200 #(swap! fired conj :c))
+    (testing "a partial advance fires only the due timers, in fire-at order"
+      (is (= 1 (presence/advance-clock! 100)) "one exit due at t=100")
+      (is (= [:b] @fired))
+      (is (= 2 (presence/pending-count)) "two exits still retained"))
+    (testing "advancing the rest fires the remainder in order"
+      (is (= 2 (presence/advance-clock! 250)) "c (200) then a (300) come due")
+      (is (= [:b :c :a] @fired))
+      (is (= 0 (presence/pending-count))))))
+
+(deftest advance-to-quiescence-fires-everything
+  (let [fired (atom 0)]
+    (presence/schedule-exit! 300 #(swap! fired inc))
+    (presence/schedule-exit! 999 #(swap! fired inc))
+    (is (= 2 (presence/advance-clock!)) "no-arg advance drains to quiescence")
+    (is (= 2 @fired))
+    (is (zero? (presence/pending-count)))))
+
+(deftest removal-is-exactly-once
+  ;; the double-cleanup guard: firing a timer twice (a real setTimeout landing
+  ;; after a test flush; a double advance) runs the removal ONCE.
+  (let [runs (atom 0)
+        id   (presence/schedule-exit! 100 #(swap! runs inc))]
+    (presence/fire-timer! id)
+    (presence/fire-timer! id)                 ; second fire: no-op
+    (presence/advance-clock! 10000)           ; nothing left to fire
+    (is (= 1 @runs) "terminal removal runs exactly once")))
+
+(deftest cancel-does-not-fire
+  ;; re-entry / unmount cancels a pending exit WITHOUT running its removal.
+  (let [runs (atom 0)
+        id   (presence/schedule-exit! 100 #(swap! runs inc))]
+    (presence/cancel-timer! id)
+    (presence/advance-clock! 10000)
+    (is (= 0 @runs) "a cancelled exit never removes")
+    (is (zero? (presence/pending-count)))))
+
+;; ---------------------------------------------------------------------------
+;; Mounted three-phase machine (jsdom / browser)
+;; ---------------------------------------------------------------------------
+
+(rf/reg-event ::set-toasts (fn [{:keys [db]} [_ ts]] {:db (assoc db :toasts ts)}))
+(rf/reg-sub ::toasts (fn [db _] (:toasts db)))
+
+(defview toast-card [{:keys [msg]}]
+  [:li {:data-testid "toast" :data-msg msg
+        :data-phase (name (ui/presence-phase))}
+   msg])
+
+(defview toast-list []
+  (ui/presence {:timeout-ms 300}
+    (for [t (ui/sub [::toasts])]
+      [toast-card {:key (:id t) :msg (:msg t)}])))
+
+(defn- toasts [root]
+  (vec (.querySelectorAll (.-container root) "[data-testid='toast']")))
+
+(defn- phase-of [root msg]
+  (some #(when (= msg (.getAttribute % "data-msg"))
+           (.getAttribute % "data-phase"))
+        (toasts root)))
+
+(defn- reject-unexpectedly! [done label e]
+  (is false (str label ": " (some-> e ex-message)))
+  (done))
+
+(deftest mounted-presence-machine
+  (if-not (browser?)
+    (is true "mounted presence needs a DOM host — covered in the browser job")
+    (async done
+      (let [f (rf/make-frame {:initial-events
+                              [[::set-toasts [{:id 1 :msg "a"} {:id 2 :msg "b"}]]]})]
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [toast-list]]]
+              (-> (uit/flush!)     ; settle the enter flip (:mounting → :present)
+                  (.then (fn [_]
+                           (testing "enter: both keyed children present"
+                             (is (= 2 (count (toasts root))))
+                             (is (= "present" (phase-of root "a")))
+                             (is (= "present" (phase-of root "b"))))
+                           ;; remove toast "b" from the source list
+                           (uit/dispatch! f [::set-toasts [{:id 1 :msg "a"}]])
+                           (uit/flush!)))
+                  (.then (fn [_]
+                           (testing "exit: the removed child is RETAINED :unmounting"
+                             (is (= 2 (count (toasts root)))
+                                 "b stays mounted while exiting")
+                             (is (= "present" (phase-of root "a")))
+                             (is (= "unmounting" (phase-of root "b"))))
+                           ;; advance the clock by LESS than :timeout-ms — still retained
+                           (uit/flush-presence! 100)))
+                  (.then (fn [_]
+                           (testing "timeout-fires-before-exit: below :timeout-ms, still retained"
+                             (is (= 2 (count (toasts root))))
+                             (is (= "unmounting" (phase-of root "b"))))
+                           ;; advance past :timeout-ms — the safety bound removes it
+                           (uit/flush-presence! 300)))
+                  (.then (fn [_]
+                           (testing "removal: the timeout removes the retained child"
+                             (is (= 1 (count (toasts root))) "b is gone")
+                             (is (= "a" (.-textContent (first (toasts root)))))
+                             (is (zero? (presence/pending-count))
+                                 "no retention timer left — cleanup ran"))))))
+            (.then (fn [_] (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f)
+                     (reject-unexpectedly! done "mounted presence rejected" e))))))))
+
+(deftest reinsertion-interrupts-exit
+  (if-not (browser?)
+    (is true "mounted presence needs a DOM host — covered in the browser job")
+    (async done
+      (let [f (rf/make-frame {:initial-events [[::set-toasts [{:id 1 :msg "a"}]]]})]
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [toast-list]]]
+              (-> (uit/flush!)
+                  (.then (fn [_]
+                           ;; remove, then re-insert BEFORE the timeout fires
+                           (uit/dispatch! f [::set-toasts []])
+                           (uit/flush!)))
+                  (.then (fn [_]
+                           (is (= "unmounting" (phase-of root "a")) "a is exiting")
+                           (uit/dispatch! f [::set-toasts [{:id 1 :msg "a"}]])
+                           (uit/flush!)))
+                  (.then (fn [_]
+                           (testing "re-entry: the exit is interrupted, a is :present again"
+                             (is (= 1 (count (toasts root))))
+                             (is (= "present" (phase-of root "a")))
+                             (is (zero? (presence/pending-count))
+                                 "the pending exit timer was cancelled"))
+                           ;; and a later flush-presence! does not remove it
+                           (uit/flush-presence!)))
+                  (.then (fn [_]
+                           (is (= 1 (count (toasts root)))
+                               "a survives — its exit was interrupted")))))
+            (.then (fn [_] (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f)
+                     (reject-unexpectedly! done "reinsertion rejected" e))))))))

--- a/implementation/ui/test/re_frame/ui/presence_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/presence_jvm_test.clj
@@ -1,0 +1,134 @@
+(ns re-frame.ui.presence-jvm-test
+  "S4 presence (rf2-uckeg) on the JVM Tier-1 structural host (Spec 004
+  §Presence + §The JVM structural subset; §004B reserved `:rf.ui/presence`):
+
+    - a (ui/presence {:timeout-ms n} …) boundary renders a FRAGMENT carrying
+      `:rf.ui/presence {:phase :present :timeout-ms n}` — the JVM has no
+      lifecycle, so every keyed child renders `:present` (no retention timers);
+    - `(ui/presence-phase)` reads `:present` on the JVM structural subset AND
+      `:present` outside any boundary;
+    - the `:rf.ui/presence` diagnostic marker is stripped by semantic
+      normalization N (it never changes markup / a fingerprint).
+
+  The client three-phase machine (enter/exit retention, `:timeout-ms` removal,
+  exactly-once cleanup, `flush-presence!`) rides the DOM suite
+  `presence_dom_cljs_test`; the pure reconcile rides `presence_reconcile_cljs_test`."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.compiler.analyze :as ana]
+            [re-frame.ui.compiler.emit-cljs :as emit-cljs]
+            [re-frame.ui.compiler.env :as env]
+            [re-frame.ui.semantic :as semantic]
+            [re-frame.ui.test :as uit]))
+
+(use-fixtures :each (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- all-nodes [t]
+  (tree-seq map? (fn [n] (filter map? (:children n))) t))
+
+(defn- presence-node [t]
+  (some #(when (contains? % :rf.ui/presence) %) (all-nodes t)))
+
+(defn- all-strings [t]
+  (mapcat (fn [n] (filter string? (:children n))) (all-nodes t)))
+
+;; ---------------------------------------------------------------------------
+;; Views
+;; ---------------------------------------------------------------------------
+
+(defview toast-card [{:keys [msg]}]
+  ;; a presence-aware child: it reads its phase (always :present on the JVM).
+  [:li {:data-phase (name (ui/presence-phase))} msg])
+
+(defview toast-list [{:keys [toasts]}]
+  (ui/presence {:timeout-ms 300}
+    (for [t toasts]
+      [toast-card {:key (:id t) :msg (:msg t)}])))
+
+(defview reusable-outside-boundary []
+  ;; presence-phase OUTSIDE any boundary must still resolve to :present, so the
+  ;; child stays reusable anywhere.
+  [:span {:data-phase (name (ui/presence-phase))} "reusable"])
+
+;; ---------------------------------------------------------------------------
+;; JVM :present — the fragment marker + every child present
+;; ---------------------------------------------------------------------------
+
+(deftest presence-renders-the-present-marker-fragment
+  (let [t (uit/render toast-list {:props {:toasts [{:id 1 :msg "a"} {:id 2 :msg "b"}]}})
+        p (presence-node t)]
+    (is (some? p) "the JVM emits a `:rf.ui/presence` fragment node")
+    (is (= {:phase :present :timeout-ms 300} (:rf.ui/presence p))
+        "the marker carries :phase :present and the compile-time :timeout-ms")
+    (is (not (contains? p :tag)) "the presence node is a FRAGMENT, not an element")
+    (testing "every keyed child renders (no retention on the JVM)"
+      (is (= #{"a" "b"} (set (all-strings t)))))))
+
+(deftest presence-phase-is-present-on-the-jvm
+  (let [t (uit/render toast-list {:props {:toasts [{:id 1 :msg "a"}]}})]
+    (is (= "present" (:data-phase (uit/attrs (uit/find t :li))))
+        "a presence-aware child reads :present on the JVM structural subset"))
+  (testing "presence-phase OUTSIDE a boundary is also :present (reusable anywhere)"
+    (let [t (uit/render reusable-outside-boundary)]
+      (is (= "present" (:data-phase (uit/attrs (uit/find t :span))))))))
+
+;; ---------------------------------------------------------------------------
+;; §004B — the marker is a droppable diagnostic (stripped by N)
+;; ---------------------------------------------------------------------------
+
+(deftest presence-marker-is-stripped-by-semantic-normalization
+  (let [t (uit/render toast-list {:props {:toasts [{:id 1 :msg "a"}]}})
+        n (semantic/normalize t)]
+    (is (not-any? #(and (map? %) (contains? % :rf.ui/presence))
+                  (tree-seq coll? seq n))
+        "the :rf.ui/presence diagnostic never reaches the semantic projection")
+    (is (contains? (set (mapcat :children (filter map? (tree-seq coll? seq n)))) "a")
+        "the keyed child content survives normalization")))
+
+;; ---------------------------------------------------------------------------
+;; Empty presence still renders the marker (discriminable fragment)
+;; ---------------------------------------------------------------------------
+
+(deftest empty-presence-still-carries-the-marker
+  (let [t (uit/render toast-list {:props {:toasts []}})
+        p (presence-node t)]
+    (is (some? p) "an empty presence boundary still emits its marker fragment")
+    (is (= {:phase :present :timeout-ms 300} (:rf.ui/presence p)))))
+
+;; ---------------------------------------------------------------------------
+;; Analyzer + CLJS emission — recognition and the browser lowering target
+;; (the analyzer/emitter are .cljc, so both are inspectable on this JVM host;
+;; locks the codegen without a React mount)
+;; ---------------------------------------------------------------------------
+
+(defn- resolver [sym]
+  (case sym
+    presence {:fqn 're-frame.ui/presence :meta {}}
+    nil))
+
+(defn- mk-env []
+  (env/make-env {:host :clj :ns-sym 'app.probe
+                 :self 'self-view :self-id :app.probe/self-view
+                 :resolver resolver}))
+
+(deftest analyzer-lowers-presence-to-the-presence-op
+  (let [ast (ana/analyze (mk-env)
+                         '(presence {:timeout-ms 300}
+                            (for [t ts] [:li {:key (:id t)} (:msg t)])))]
+    (is (= :presence (:op ast)) "a valid presence form lowers to the :presence op")
+    (is (= 300 (:timeout-ms ast)) "the compile-time :timeout-ms literal is carried")
+    (is (= [:for] (mapv :op (:children ast)))
+        "the keyed (for …) child is analyzed under the boundary")))
+
+(deftest cljs-emission-wires-the-presence-boundary
+  (let [ast  (ana/analyze (mk-env)
+                          '(presence {:timeout-ms 300}
+                             (for [t ts] [:li {:key (:id t)} (:msg t)])))
+        text (pr-str (emit-cljs/emit-standalone ast))]
+    (is (str/includes? text "re-frame.ui.presence-runtime/presence-boundary")
+        "the CLJS emitter lowers ui/presence to the runtime retention boundary")
+    (is (str/includes? text "(re-frame.ui.presence-runtime/presence-boundary 300")
+        "the compile-time :timeout-ms literal is threaded to the boundary")))

--- a/implementation/ui/test/re_frame/ui/presence_reconcile_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/presence_reconcile_cljs_test.cljc
@@ -1,0 +1,84 @@
+(ns re-frame.ui.presence-reconcile-cljs-test
+  "The PURE three-phase entry derivation behind the presence boundary
+  (re-frame.ui.presence/reconcile). Host-agnostic (`.cljc`), so the enter →
+  present → exit → re-entry state machine is pinned without React on either
+  host (Spec 004 §Presence)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ui.presence-runtime :as presence]))
+
+(defn- phases [entries] (mapv (juxt :key :phase) entries))
+
+;; ---------------------------------------------------------------------------
+;; Enter — a brand-new key mounts
+;; ---------------------------------------------------------------------------
+
+(deftest new-key-enters-mounting
+  (testing "a key present for the first time is appended as :mounting"
+    (is (= [["a" :mounting]] (phases (presence/reconcile [] ["a"]))))
+    (is (= [["a" :mounting] ["b" :mounting]]
+           (phases (presence/reconcile [] ["a" "b"]))))))
+
+(deftest committed-mounting-stays-mounting-until-flipped
+  ;; reconcile does not flip :mounting → :present (that is the boundary effect's
+  ;; job); it preserves a still-incoming key's committed phase.
+  (is (= [["a" :mounting]]
+         (phases (presence/reconcile [{:key "a" :phase :mounting}] ["a"]))))
+  (is (= [["a" :present]]
+         (phases (presence/reconcile [{:key "a" :phase :present}] ["a"])))))
+
+;; ---------------------------------------------------------------------------
+;; Exit — a removed key is RETAINED :unmounting (not dropped)
+;; ---------------------------------------------------------------------------
+
+(deftest removed-key-is-retained-unmounting
+  (testing "a present key no longer incoming becomes :unmounting, held in slot"
+    (is (= [["a" :unmounting]]
+           (phases (presence/reconcile [{:key "a" :phase :present}] [])))))
+  (testing "an already-:unmounting key stays :unmounting while retained"
+    (is (= [["a" :unmounting]]
+           (phases (presence/reconcile [{:key "a" :phase :unmounting}] [])))))
+  (testing "reconcile NEVER drops a key — removal is the timer's job, not here"
+    (is (= 1 (count (presence/reconcile [{:key "a" :phase :unmounting}] []))))))
+
+;; ---------------------------------------------------------------------------
+;; Re-entry — removal-then-reinsertion interrupts the exit
+;; ---------------------------------------------------------------------------
+
+(deftest reinserted-key-reenters-present
+  (testing "an :unmounting key that reappears flips back to :present (re-entry)"
+    (is (= [["a" :present]]
+           (phases (presence/reconcile [{:key "a" :phase :unmounting}] ["a"]))))))
+
+;; ---------------------------------------------------------------------------
+;; Order — retained exiting keys hold their slot; new keys append
+;; ---------------------------------------------------------------------------
+
+(deftest retained-keys-hold-slot-new-keys-append
+  (let [committed [{:key "a" :phase :present}
+                   {:key "b" :phase :present}
+                   {:key "c" :phase :present}]
+        ;; b leaves, d arrives
+        next (presence/reconcile committed ["a" "c" "d"])]
+    (is (= [["a" :present] ["b" :unmounting] ["c" :present] ["d" :mounting]]
+           (phases next))
+        "b holds its slot as :unmounting; d appends at the end")))
+
+;; ---------------------------------------------------------------------------
+;; Idempotence — a StrictMode double-render is harmless
+;; ---------------------------------------------------------------------------
+
+(deftest reconcile-is-idempotent-for-fixed-incoming
+  (let [committed [{:key "a" :phase :present} {:key "b" :phase :mounting}]
+        once  (presence/reconcile committed ["a" "b"])
+        twice (presence/reconcile once ["a" "b"])]
+    (is (= (phases once) (phases twice))
+        "re-running reconcile with the same incoming keys is stable")))
+
+;; ---------------------------------------------------------------------------
+;; presence-phase — :present outside a boundary (host-agnostic default)
+;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (deftest presence-phase-is-present-on-jvm
+     (is (= :present (presence/presence-phase))
+         "the JVM structural subset always reads :present")))

--- a/implementation/ui/test/re_frame/ui/s3_conformance_profile_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/s3_conformance_profile_jvm_test.clj
@@ -104,7 +104,10 @@
 ;; classified (S3 verb, S3 view, or here) before the surface can silently drift.
 (def non-s3-facade-publics
   '#{adapter defview custom-element mount create-root render! hydrate-root
-     unmount! frame-root frame-provider sub lease frame raw html raw-fn spread})
+     unmount! frame-root frame-provider sub lease frame raw html raw-fn spread
+     ;; S4 presence (rf2-uckeg): the enter/exit retention template form + its
+     ;; single phase read — not part of the S3 surface
+     presence presence-phase})
 
 ;; The S3-specific gate arms this profile certifies (07 §5 / EP-0034 §4): every
 ;; verb gate PLUS the two non-verb S3 arms — G-11 (HMR shell + view-evidence /

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -82,6 +82,10 @@
    ;; The blessed reader-conditional difference: 0-arity headless drain on
    ;; the JVM; 0-arity or 1-arity (thunk) awaited drain on CLJS.
    "flush!"    {:kind :fn    :clj #{[0]}     :cljs #{[0] [1]}}
+   ;; flush-presence! (rf2-uckeg, S4) — the fake-clock transition advance.
+   ;; Host-uniform 0/1-arity on BOTH hosts: `(flush-presence!)` advances to
+   ;; quiescence, `(flush-presence! ms)` by ms (JVM both no-op nil; CLJS awaited).
+   "flush-presence!" {:kind :fn :clj #{[0] [1]} :cljs #{[0] [1]}}
    ;; Macros — host-invariant call grammars (single .cljc definition).
    "render"    {:kind :macro :clj #{[1] [2]} :cljs #{[1] [2]}}
    "with-root" {:kind :macro :clj #{[1 :&]}  :cljs #{[1 :&]}}}}
@@ -375,6 +379,19 @@
   ;; blessed-set` JVM row landed with this feature. Owner 012 — routing owns the
   ;; link law + full conformance matrix; the ui table LINKS to 012.
   {:namespace "re-frame.ui" :var "route-link"     :kind :fn    :facade? false :tier :advanced    :owner "012" :status "Spec-004 S3" :runtime-verified? true}
+  ;; presence / presence-phase (rf2-uckeg — the FIRST S4 feature) — the ruled
+  ;; §Presence contract: declarative keyed enter/exit retention, deliberately
+  ;; bounded (NOT an animation system). `presence` is a resolution-only template
+  ;; `defn` (the compiler lowers `(ui/presence …)` into the runtime retention
+  ;; boundary; a direct call throws) with a MANDATORY :timeout-ms terminal bound;
+  ;; `presence-phase` is a render-time `defn` reading a child's
+  ;; :mounting/:present/:unmounting phase (:present outside a boundary / on the
+  ;; JVM). Both are advanced-tier authoring verbs (kin to slot / error-boundary /
+  ;; client-only). Their live public vars are reconciled by the CLJS probe
+  ;; (re-frame.ui is fully-rowed, both directions); the spec/API.md §Compiled
+  ;; views rows are the projection reconciliation.
+  {:namespace "re-frame.ui" :var "presence"       :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S4" :runtime-verified? true}
+  {:namespace "re-frame.ui" :var "presence-phase" :kind :fn    :facade? false :tier :advanced    :owner "004" :status "Spec-004 S4" :runtime-verified? true}
   ;; re-frame.ui.react (rf2-vxgfnd.95.4) — the frozen seven-wrapper React interop
   ;; tier (Spec 004 §The React interop tier). Six host hooks (use-ref /
   ;; use-effect / use-layout-effect / use-effect-event / use-context / use-id)
@@ -1173,8 +1190,8 @@
   ;; owner + `with-root-outcome` (^:no-doc) are internal by classification.
   ;; Tier 1 (S1): render / find / find-all / text / attrs / dispatch!.
   ;; Tier 3 (S2): with-root / native-CSS query / (flush!)/(flush! thunk).
-  ;; S4's `flush-presence!` is NOT defined yet — it stays absent (no row)
-  ;; until its stage lands, then takes an ordinary manifest update.
+  ;; S4 (rf2-uckeg): `flush-presence!` — the fake-clock enter/exit transition
+  ;; advance (the S4 twin of `flush!`; JVM synchronous no-op, CLJS awaited).
   ;; =========================================================================
   ["re-frame.ui.test" "render"]    {:tier :testing :owner "008" :status "Spec-004 S1"}
   ["re-frame.ui.test" "find"]      {:tier :testing :owner "008" :status "Spec-004 S1"}
@@ -1185,6 +1202,7 @@
   ["re-frame.ui.test" "with-root"] {:tier :testing :owner "008" :status "Spec-004 S2"}
   ["re-frame.ui.test" "query"]     {:tier :testing :owner "008" :status "Spec-004 S2"}
   ["re-frame.ui.test" "flush!"]    {:tier :testing :owner "008" :status "Spec-004 S2"}
+  ["re-frame.ui.test" "flush-presence!"] {:tier :testing :owner "008" :status "Spec-004 S4"}
 
   ;; =========================================================================
   ;; re-frame.schemas — optional artefact (day8/re-frame2-schemas), §010.

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 514,
+ :var-count 517,
  :tier-vocab
  [:front-porch
   :advanced
@@ -505,6 +505,8 @@
   {:namespace "re-frame.ui", :var "lease", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui", :var "local", :tier :front-porch, :kind :fn, :owner "004", :status "Spec-004 S3", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui", :var "mount", :tier :front-porch, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui", :var "presence", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S4", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui", :var "presence-phase", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S4", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui", :var "raw", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui", :var "raw-fn", :tier :advanced, :kind :fn, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui", :var "render!", :tier :advanced, :kind :macro, :owner "004", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
@@ -527,6 +529,7 @@
   {:namespace "re-frame.ui.test", :var "find", :tier :testing, :kind :fn, :owner "008", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui.test", :var "find-all", :tier :testing, :kind :fn, :owner "008", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui.test", :var "flush!", :tier :testing, :kind :fn, :owner "008", :status "Spec-004 S2", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ui.test", :var "flush-presence!", :tier :testing, :kind :fn, :owner "008", :status "Spec-004 S4", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui.test", :var "query", :tier :testing, :kind :fn, :owner "008", :status "Spec-004 S2", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui.test", :var "render", :tier :testing, :kind :macro, :owner "008", :status "Spec-004 S1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ui.test", :var "text", :tier :testing, :kind :fn, :owner "008", :status "Spec-004 S1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
Implements **S4-A** (`rf2-uckeg`), the first feature of re-frame.ui Stage 4 — the ruled **presence** contract (`spec/004-Views.md §Presence` + `spec/API.md §2b` + `spec/004B §Reserved keys`).

## What landed

- **3-phase keyed retention** `:mounting → :present → :unmounting`, driven by a **pure `reconcile`** (host-agnostic) plus a thin React boundary.
- **Mandatory `:timeout-ms`** terminal safety bound — the retained exiting child is removed when the timeout fires; a missing/non-positive `:timeout-ms` is a **build failure**.
- **Terminal cleanup exactly-once** — the exit scheduler is id-keyed and idempotent (`fire-timer!`), so a double-advance / late real-`setTimeout` never double-removes; React unmounts the retained subtree (releasing its leases/effects).
- **Unkeyed presence child = build-fail** (`:rf.ui.compile/presence-unkeyed-child`, compile-tier).
- **JVM `:present`** — the JVM emitter renders a fragment carrying `:rf.ui/presence {:phase :present :timeout-ms n}` (a droppable §004B diagnostic, stripped by semantic normalization N).
- **`ui.test/flush-presence!`** — a deterministic fake-clock advance (no wall-clock sleeps); `(flush-presence!)` drains to quiescence, `(flush-presence! ms)` advances by `ms`.
- **`(ui/presence-phase)`** — the single phase read; `:present` outside a boundary and on the JVM subset.

## Seam

- Runtime: `implementation/ui/src/re_frame/ui/presence_runtime.cljc` (`reconcile` + the presence clock + `PresenceComponent`/`presence-boundary` + `presence-phase`). Named `-runtime` to avoid the CLJS var↔namespace munging clash with the public `re-frame.ui/presence` var (same split as `lease` ↔ `lease-descriptor`).
- Compiler: analyzer recognition + the unkeyed/`:timeout-ms` build checks (`analyze.cljc`, a new `:presence` op), CLJS lowering to `presence-boundary` (`emit_cljs.cljc`), JVM lowering to `tree/presence` (`emit_jvm.cljc` + `tree.cljc`). **`build.cljc` untouched — no collision with the in-flight qbjdu.**
- Facade/test: `re-frame.ui/presence` (fail-loud template form) + `re-frame.ui/presence-phase`; `re-frame.ui.test/flush-presence!`.

## Spec 009 / OPERATOR-FLAG #2

Presence mints **only compile-tier `:rf.ui.compile/*` ids** (`bad-presence`, `presence-unkeyed-child`) — roster-only per rf2-kvtn97, **no Spec 009 / Spec-Schemas rows** (added to the frozen `error_roster` roster instead). No runtime error/trace ids minted. `check_keyword_catalogue_drift.py` green.

## Scope discipline (anti-over-engineering)

Implemented the bead's deliverables and nothing beyond §Presence. **Deliberately deferred** (need a per-child DOM wrapper/clone the ruled surface — only `presence-phase` is public — does not sanction; genuinely inventive, so flagged rather than invented): the *early DOM-`transitionend` completion before the timeout*, `inert`/`aria-hidden` on exiting children, and the reduced-motion immediate path. These are §Presence refinements, not bead-A deliverables — recommend a follow-up bead. `:timeout-ms` is the removal mechanism (author sizes it to the exit animation, matching the toast example).

## Quality gates

Rebased on current `main` and all four CI gates now run to completion locally, **green** (a Shape-5 CI-fix — the earlier hand-off backgrounded `test:cljs` so CI caught what local runs missed):

- **Public-API manifest drift-check** — `clojure -M -m re-frame.api-manifest.gen --check` green (**517 vars in sync**); `clojure -M:test` projection suite green (**85 tests, 0 failures**). The feature's three public verbs are now rowed: `re-frame.ui/presence` + `presence-phase` (`:cljs-only`, `:advanced`), `re-frame.ui.test/flush-presence!` (`:classification` `:testing` + a `:ui-test-signatures` `:fn` `#{[0] [1]}` entry). Added the docs/api member headings the coverage check requires; regenerated `spec/api-manifest.edn`.
- **Lint required** — `clj-kondo --fail-level error` **0 errors** (45 informational warnings, the defview-DSL unresolved symbols) + Splint `--fail-on-errors` **0 errors**. The aggregator was red only because its `api-manifest` dependency (above) was failing; both linters were already clean.
- **CLJS (`:node-test`)** — `npm run test:cljs` ran to completion: **9940 tests / 48989 assertions, 0 failures, 0 errors** (was red only via the CLJS manifest probe reconciliation; the rebased `emit_cljs.cljc` is clean — no test broke).
- **CLJS (`:browser-test`, headless Chromium)** — `npm run test:browser` ran to completion: **456 tests / 2533 assertions, 0 failures, 0 errors**. Fixed a real test bug: the mounted presence tests registered their subs *after* the `use-fixtures` form, so the fixture's eager ns-load baseline never captured them and the strict mounted-React observation port threw `:rf.error/no-such-sub` at mount (JVM/node recover-to-nil, so only this gate reddened). Moved the reg-event/reg-sub above the fixture form.

## Rebase note (done)

Rebased onto current `main` (past rf2-xdvob / #6260). `emit_cljs.cljc` auto-merged cleanly — both intents preserved: xdvob's spread-safe caller-prop canonicalization (`spread-safe->props` / `spread-safe-props`, lines ~347–405) and uckeg's additive `emit-presence` fn + `:presence` dispatch arm (~522/630) live in different functions, so there was no overlap to reconcile. `analyze.cljc` / `build.cljc` unaffected.

