### PR TITLE
fix(examples): reconcile remaining deferred-callback frame-law authorities to shipped law (rf2-1yi8d)

### DIFF
--- a/implementation/core/src/re_frame/test_helpers.cljc
+++ b/implementation/core/src/re_frame/test_helpers.cljc
@@ -95,7 +95,7 @@
   outer attrs map. The [[testid]] helper standardises the attrs
   fragment so the convention reads at every call site:
 
-      [:button (testid \"counter-inc\" {:on-click #(rf/dispatch [:counter/inc])})
+      [:button (testid \"counter-inc\" {:on-click #(dispatch [:counter/inc])})
        \"+\"]
 
   Equivalent to writing `{:data-testid \"counter-inc\" :on-click ...}`
@@ -465,7 +465,7 @@
 
   Use at the view call site:
 
-      [:button (testid \"counter-inc\" {:on-click #(rf/dispatch [:counter/inc])})
+      [:button (testid \"counter-inc\" {:on-click #(dispatch [:counter/inc])})
        \"+\"]
 
   Reads as one assertion-friendly fragment instead of inline

--- a/implementation/core/test/re_frame/test_helpers_cljs_test.cljc
+++ b/implementation/core/test/re_frame/test_helpers_cljs_test.cljc
@@ -395,3 +395,21 @@
           hit  (h/find-by-testid tree "go")]
       (is (some? hit))
       (is (fn? (h/extract-handler hit :on-click))))))
+
+;; ---------------------------------------------------------------------------
+;; Deferred-callback frame-law guard (rf2-1yi8d)
+;; ---------------------------------------------------------------------------
+;; The copyable `testid` example in the docstring must show the
+;; `reg-view`-injected `dispatch`, not a bare qualified `rf/dispatch`. A
+;; deferred `:on-*` callback runs after the render scope unwinds and the
+;; `frame-provider`'s React context has been popped, so a bare `rf/dispatch`
+;; there resolves no frame and raises `:rf.error/no-frame-context` (EP-0002,
+;; no `:rf/default` floor). This fixture pins the docstring so the positive
+;; example cannot revert to the unlawful bare form.
+(deftest testid-docstring-teaches-injected-dispatch-not-bare
+  (let [doc (:doc (meta #'h/testid))]
+    (is (some? doc) "testid must carry a docstring")
+    (is (re-find #"#\(dispatch " doc)
+        "the testid example must dispatch through the reg-view-injected `dispatch`")
+    (is (nil? (re-find #"#\(rf/dispatch " doc))
+        "the testid example must NOT use a bare deferred `rf/dispatch` (raises :rf.error/no-frame-context)")))

--- a/migration/from-re-frame-v1/re-frame-query-to-resources.md
+++ b/migration/from-re-frame-v1/re-frame-query-to-resources.md
@@ -131,9 +131,9 @@ A typical `re-frame-query`-style article fetch: a query keyed by slug, ensured o
 
 ;; The view reads it passively — no fetching, no observer registration.
 (rf/reg-view article-page []
-  (let [slug  (:slug @(rf/subscribe [:rf.route/params]))
-        state @(rf/subscribe [:rf/resource
-                              {:resource :article/by-slug :params {:slug slug}}])]
+  (let [slug  (:slug @(subscribe [:rf.route/params]))
+        state @(subscribe [:rf/resource
+                           {:resource :article/by-slug :params {:slug slug}}])]
     (cond
       (:loading? state)                              [article-skeleton]
       (and (:error state) (not (:has-data? state)))  [article-error (:error state)]
@@ -183,13 +183,13 @@ A typical `re-frame-query`-style article fetch: a query keyed by slug, ensured o
 
 ;; The form fires the write and watches it through instance-keyed subs.
 (rf/reg-view article-form [article]
-  (let [{:keys [pending? error?]} @(rf/subscribe [:rf/mutation {:instance :form/article-save}])]
+  (let [{:keys [pending? error?]} @(subscribe [:rf/mutation {:instance :form/article-save}])]
     [:button {:disabled pending?
-              :on-click #(rf/dispatch [:rf.mutation/execute
-                                       {:mutation :article/save
-                                        :params   article
-                                        :instance :form/article-save
-                                        :cause    [:form-submit :article/save]}])}
+              :on-click #(dispatch [:rf.mutation/execute
+                                    {:mutation :article/save
+                                     :params   article
+                                     :instance :form/article-save
+                                     :cause    [:form-submit :article/save]}])}
      (if pending? "Saving…" "Save")]))
 ```
 

--- a/skills/re-frame2/references/cross-cutting/testing.md
+++ b/skills/re-frame2/references/cross-cutting/testing.md
@@ -261,7 +261,7 @@ When a fixture didn't stash the tree, or you need the `:on-click`-fires-the-righ
 - `testid` — the **authoring** helper that standardises the attrs fragment at view call sites; use it whenever you write a new view that wants a test handle:
 
 ```clojure
-[:button (h/testid "counter-inc" {:on-click #(rf/dispatch [:counter/inc])}) "+"]
+[:button (h/testid "counter-inc" {:on-click #(dispatch [:counter/inc])}) "+"]
 ```
 
 **Why walk the view, not just assert state?** State-only assertions (`(is (= 2 (:n db)))`) catch handler bugs but miss two classes the hiccup-walk catches — *state-correct, view-broken* (handler updated db, view reads the wrong path / forgets a branch) and *wrong-frame dispatch* (`:on-click` dispatches into the wrong frame; host-frame state never changes). Both surface on JVM and Node-CLJS with no browser.


### PR DESCRIPTION
## Summary

PR #6215 corrected most deferred-callback examples, but a few **active copyable authorities** still contradicted the shipped frame-law. This finishes that bounded sweep (rf2-1yi8d).

**The law.** A bare, fully-qualified `rf/dispatch` in a deferred `:on-*` callback carries no frame: by the time the callback fires the dynamic `*current-frame*` scope has unwound and the `frame-provider`'s React context has been popped, so it raises `:rf.error/no-frame-context` (EP-0002, no `:rf/default` floor). What survives the render boundary is a frame captured at render time — the `reg-view`-injected `dispatch` / `subscribe` (a `capture-frame` op bundle), or an explicit `(rf/capture-frame)`.

## Reconciled authorities (truth-only, no runtime change)

- **`implementation/core/src/re_frame/test_helpers.cljc`** (ns docstring L98, `testid` docstring L468) — bare `#(rf/dispatch [:counter/inc])` → injected `#(dispatch [:counter/inc])`. This makes the **source docstrings** match the already-corrected generated `docs/api/re-frame.test-helpers.md` (fixed by #6215), closing the source↔generated drift the bead flags. Only docstring text changed; the `defn testid` body is untouched.
- **`migration/from-re-frame-v1/re-frame-query-to-resources.md`** (reg-view recipe) — the deferred `#(rf/dispatch [:rf.mutation/execute …])` now uses the injected `dispatch`; the needlessly-qualified render-phase `@(rf/subscribe …)` in both `article-page` and `article-form` reg-view bodies now uses the injected `subscribe`.
- **`skills/re-frame2/references/cross-cutting/testing.md`** (L264) — the `testid` skill twin of the docstring authority gets the same injected-dispatch fix, so the two copyable authorities stay consistent.
- **`implementation/core/test/re_frame/test_helpers_cljs_test.cljc`** — narrow **focused fixture** (`testid-docstring-teaches-injected-dispatch-not-bare`) pins the `testid` docstring so the positive example cannot revert to the bare deferred form. Not a prose parser: it asserts on one var's `:doc` metadata.

## Confirmed NOT contradictory (left untouched)

- `implementation/adapters/reagent-slim/test/.../reagent_slim_synthetic_event_frame_dom_cljs_test.cljs` — a #6215 proof that already teaches the correct law.
- `implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc` — tests compiler handler-shape analysis (event vectors / fns / interop macros); no bare `rf/dispatch` copyable, not a frame-law authority.
- Labelled `;; before` / SEARCH migration examples (`skills/re-frame-migration/...`, `migration/.../README.md` O-2 before block), explicit-`{:frame …}` callbacks, and EP design-history docs — preserved per acceptance.

No runtime src, ui-compiler src, presence, core-spine, or machine source touched.

## Quality gates

- `npm run test:cljs` — **9924 tests, 48875 assertions, 0 failures, 0 errors** (green). The new docstring guard + the corrected authorities ride this suite; the guard would have been red against the pre-fix bare-`rf/dispatch` docstring.
- `mkdocs build --strict` — **exit 0** (spec/ + migration/ staged as CI does; only code-identifier text inside existing code blocks changed, no links touched).