### PR TITLE
fix(api-manifest): make root API drift checks exact-row and polarity-safe (rf2-asxo3)

### DIFF
--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
@@ -171,6 +171,54 @@
   [cells]
   (first (keep-indexed (fn [i c] (when (= "Tier" (str/trim c)) i)) cells)))
 
+(defn parse-var-rows
+  "Pure var-row parser over `[[line-no line-text] ...]` indexed API.md lines
+   (rf2-asxo3 — extracted from `parse-api-md-var-rows` so parser DISAPPEARANCE
+   is unit-testable with synthetic lines, mirroring the reconcile /
+   option-guard pure cores). Returns the `[{:var :qualifier :tier :doc-kind
+   :line :raw} ...]` vector.
+
+   A row whose `M/Fn` cell is NOT a recognised var-kind marker (`var-kind-
+   marker?` — e.g. the marker drifted to an unknown spelling like `Macro`) is
+   SKIPPED: it never becomes a var-row. That is the disappearance the two-sided
+   root-verb kind guard must not silently pass — it turns a dropped root-verb
+   row into a caught `:kind-row-missing`, not a green (rf2-asxo3)."
+  [indexed-lines]
+  (loop [lines    indexed-lines
+         tier-idx nil
+         acc      (transient [])]
+    (if-let [[[n line] & more] (seq lines)]
+      (let [cells (table-row-cells line)]
+        (cond
+          (nil? cells)
+          ;; A non-table line ends the current table's column context.
+          (recur more nil acc)
+
+          (header-row? cells)
+          (recur more (tier-col-index cells) acc)
+
+          (separator-row? cells)
+          (recur more tier-idx acc)
+
+          :else
+          (let [first-cell (first cells)
+                kind-cell  (second cells)
+                m          (re-matches #"`([^`]+)`" (str/trim first-cell))]
+            (if (and tier-idx m (var-kind-marker? kind-cell)
+                     (< tier-idx (count cells)))
+              (if-let [tier (first-tier-token (nth cells tier-idx))]
+                (let [[qualifier bare] (parse-first-cell-ident (second m))]
+                  (recur more tier-idx
+                         (conj! acc {:var       bare
+                                     :qualifier qualifier
+                                     :tier      tier
+                                     :doc-kind  (documented-kind kind-cell)
+                                     :line      n
+                                     :raw       (second m)})))
+                (recur more tier-idx acc))
+              (recur more tier-idx acc)))))
+      (persistent! acc))))
+
 (defn parse-api-md-var-rows
   "Parse spec/API.md and return `[{:var <bare-name> :qualifier <ns-or-alias
    or nil> :tier <kw> :doc-kind <:macro/:fn/:var or nil> :line <n> :raw
@@ -189,43 +237,16 @@
    which would pick up tier words that appear in prose Notes cells. A
    var-row is a row whose first cell is one back-tick identifier and whose
    second cell is a var-kind marker; a table with no `Tier` column
-   contributes no rows (its surface is keyword-registrations / schemas)."
+   contributes no rows (its surface is keyword-registrations / schemas).
+
+   The pure loop is extracted as `parse-var-rows` (rf2-asxo3) so parser
+   DISAPPEARANCE — a deleted row, or a row whose M/Fn marker drifted to an
+   unknown spelling and is therefore SKIPPED — is unit-testable against
+   synthetic lines; the two-sided root-verb kind guard turns that
+   disappearance into a caught problem rather than a silent green."
   []
   (with-open [r (io/reader @api-md-file)]
-    (loop [lines (map-indexed (fn [i line] [(inc i) line]) (line-seq r))
-           tier-idx nil
-           acc (transient [])]
-      (if-let [[[n line] & more] (seq lines)]
-        (let [cells (table-row-cells line)]
-          (cond
-            (nil? cells)
-            ;; A non-table line ends the current table's column context.
-            (recur more nil acc)
-
-            (header-row? cells)
-            (recur more (tier-col-index cells) acc)
-
-            (separator-row? cells)
-            (recur more tier-idx acc)
-
-            :else
-            (let [first-cell (first cells)
-                  kind-cell  (second cells)
-                  m          (re-matches #"`([^`]+)`" (str/trim first-cell))]
-              (if (and tier-idx m (var-kind-marker? kind-cell)
-                       (< tier-idx (count cells)))
-                (if-let [tier (first-tier-token (nth cells tier-idx))]
-                  (let [[qualifier bare] (parse-first-cell-ident (second m))]
-                    (recur more tier-idx
-                           (conj! acc {:var       bare
-                                       :qualifier qualifier
-                                       :tier      tier
-                                       :doc-kind  (documented-kind kind-cell)
-                                       :line      n
-                                       :raw       (second m)})))
-                  (recur more tier-idx acc))
-                (recur more tier-idx acc)))))
-        (persistent! acc)))))
+    (parse-var-rows (map-indexed (fn [i line] [(inc i) line]) (line-seq r)))))
 
 (defn reconcile
   "Pure reconciler (rf2-41j0a — extracted so the qualifier-resolution
@@ -303,6 +324,18 @@
 ;; flip M -> Fn (or unmount! Fn -> M) and stay GREEN. This guard restores the
 ;; comparison for the Spec-004C root verbs: each documented kind must equal
 ;; the manifest `:kind` for the `re-frame.ui` row of that name.
+;;
+;; Made EXACT-ROW + POLARITY-SAFE (rf2-asxo3). The first cut compared BARE var
+;; names over whatever rows survived in `api-rows`, which left two holes: a
+;; foreign same-name qualified row (`other.ui/render!`) matched a root verb by
+;; bare name and could falsely prove OR contradict it; and a DELETED row — or a
+;; row whose `M/Fn` marker drifted to an unknown spelling and was therefore
+;; dropped by the parser — vanished from `api-rows`, so the one-way
+;; keep-over-present-rows stayed green. The guard now (1) resolves the qualifier
+;; exactly (`root-ui-row?`), and (2) reconciles the REQUIRED SET of four verbs,
+;; requiring EXACTLY ONE `re-frame.ui` row each — so deletion, duplication, an
+;; unknown kind marker, or a foreign qualifier can no longer false-green or
+;; false-red the check.
 ;; ---------------------------------------------------------------------------
 
 (def root-verb-namespace
@@ -318,37 +351,76 @@
    pinned is an intentional one-line addition here."
   #{"create-root" "render!" "hydrate-root" "unmount!"})
 
+(defn- root-ui-row?
+  "True when an API.md var-row denotes a `re-frame.ui` root-lifecycle verb
+   (rf2-asxo3): its bare var is one of `root-verb-kinds` AND its qualifier
+   resolves EXACTLY to `re-frame.ui` — a BARE row (the documented convention
+   for the root verbs) or a qualifier that maps through `aliases` (else
+   verbatim) to `re-frame.ui`. A foreign same-name qualified row
+   (`other.ui/render!`) resolves to `other.ui`, is NOT a root-verb row, and so
+   can neither falsely PROVE nor falsely CONTRADICT the real `re-frame.ui`
+   row — the exactness hole the bare-name comparison had."
+  [aliases {:keys [var qualifier]}]
+  (and (boolean (root-verb-kinds var))
+       (or (nil? qualifier)
+           (= root-verb-namespace (get aliases qualifier qualifier)))))
+
 (defn root-verb-kind-problems
-  "Pure documented-kind reconciler for the Spec-004C root verbs (rf2-e9q33).
-   For every API.md var-row naming one of `root-verb-kinds`, the DOCUMENTED
-   kind (its `M/Fn` marker mapped to `:macro` / `:fn` / `:var`) must equal
-   the manifest `:kind` for the `re-frame.ui` row of that name. Returns the
-   seq of problem maps; empty when every root verb's documented kind matches.
+  "Two-sided documented-kind reconciler for the Spec-004C root verbs
+   (rf2-e9q33; made EXACT-ROW + POLARITY-SAFE — rf2-asxo3). For EACH of the
+   four `root-verb-kinds` verbs there must be EXACTLY ONE `re-frame.ui` API.md
+   var-row whose DOCUMENTED kind (its `M/Fn` marker mapped to `:macro` / `:fn`
+   / `:var`) equals the manifest `:kind` of the `re-frame.ui` row of that name.
+   Returns the seq of problem maps; empty when all four verbs reconcile.
 
    `rows`     — manifest rows (each `{:namespace :var :kind ...}`).
-   `api-rows` — parsed API.md var-rows `{:var :doc-kind :line :raw ...}`.
+   `api-rows` — parsed API.md var-rows `{:var :qualifier :doc-kind :line :raw}`.
+   `aliases`  — `{alias -> namespace}` adapter `:as` aliases (defaults to
+                `adapter-aliases`) for EXACT qualifier resolution.
 
-   Row ABSENCE (a root verb dropped from API.md or the manifest) is the
-   `reconcile` / `gen --check` existence guard's job, not this kind guard's:
-   this fires only when a row is PRESENT on both sides with a disagreeing
-   kind — the wrong-Var-kind drift the tier reconcile could not see."
-  [{:keys [rows api-rows]}]
+   EXACT-ROW: `root-ui-row?` honours the preserved qualifier, so a foreign
+   same-name row (`other.ui/render!`) is not counted as the root verb — it can
+   neither prove nor contradict the real row (the bare-name comparison could).
+
+   POLARITY-SAFE: the reconcile is driven by the REQUIRED SET, not by whatever
+   rows survive in `api-rows`. So a DELETED row, a row the parser DROPPED for an
+   unknown `M/Fn` marker, or a DUPLICATED row is CAUGHT (`:kind-row-missing` /
+   `:kind-row-duplicated`) instead of silently disappearing. A verb absent from
+   the manifest — no `re-frame.ui` row to resolve against — is
+   `:kind-manifest-absent`. Present-on-both-sides disagreements stay
+   `:kind-mismatch` / `:kind-unmarked`."
+  [{:keys [rows api-rows aliases] :or {aliases adapter-aliases}}]
   (let [manifest-kind (into {}
                             (for [{:keys [namespace var kind]} rows
                                   :when (and (= namespace root-verb-namespace)
                                              (root-verb-kinds var))]
-                              [var kind]))]
-    (keep (fn [{:keys [var doc-kind line raw]}]
-            (when-let [mkind (and (root-verb-kinds var)
-                                  (get manifest-kind var))]
-              (cond
-                (nil? doc-kind)
-                {:kind :kind-unmarked :var var :raw raw :line line
-                 :manifest-kind mkind}
-                (not= doc-kind mkind)
-                {:kind :kind-mismatch :var var :raw raw :line line
-                 :doc-kind doc-kind :manifest-kind mkind})))
-          api-rows)))
+                              [var kind]))
+        rows-by-var   (group-by :var (filter #(root-ui-row? aliases %) api-rows))]
+    (mapcat
+     (fn [v]
+       (let [mkind (get manifest-kind v)
+             vrows (get rows-by-var v)]
+         (cond
+           (nil? mkind)
+           [{:kind :kind-manifest-absent :var v}]
+
+           (empty? vrows)
+           [{:kind :kind-row-missing :var v :manifest-kind mkind}]
+
+           (next vrows)
+           [{:kind :kind-row-duplicated :var v :manifest-kind mkind
+             :lines (mapv :line vrows)}]
+
+           :else
+           (let [{:keys [doc-kind line raw]} (first vrows)]
+             (cond
+               (nil? doc-kind)
+               [{:kind :kind-unmarked :var v :raw raw :line line
+                 :manifest-kind mkind}]
+               (not= doc-kind mkind)
+               [{:kind :kind-mismatch :var v :raw raw :line line
+                 :doc-kind doc-kind :manifest-kind mkind}])))))
+     (sort root-verb-kinds))))
 
 ;; ---------------------------------------------------------------------------
 ;; create-root LITERAL-OPTION guard (rf2-e9q33).
@@ -370,18 +442,29 @@
    option-grammar the gate pins (rf2-e9q33)."
   #"^\s*\|\s*`create-root`\s*\|")
 
+(def ^:private option-bridge
+  "The connective allowed between an option token and its polarity word: up to
+   40 chars that stay in the SAME table cell (`(?!\\|)`) and carry NO negation
+   (`not` / `n't` / `no` / `never`) (rf2-asxo3). A tempered dot — each step
+   asserts the forbidden forms do not START here, then consumes one char — so a
+   negated or far-prose clause cannot bridge the token to the polarity word."
+  "(?:(?!\\|)(?!\\bnot\\b)(?!n't)(?!\\bno\\b)(?!\\bnever\\b).){0,40}")
+
 (def ^:private root-id-required-re
-  "The create-root row must assert authored `:root-id` is REQUIRED — the
-   `:root-id` token followed, within the SAME table cell (`[^|]`), by
-   `required` (rf2-e9q33)."
-  #":root-id[^|]{0,60}\brequired\b")
+  "The create-root row must assert authored `:root-id` is REQUIRED, EXACTLY
+   (rf2-e9q33; tightened rf2-asxo3): the WHOLE `:root-id` token — a trailing
+   `-`/word char (`(?![-\\w])`) rejects a `:root-id-v2` prefix drift — bridged
+   by `option-bridge` (same cell, no negation) to `required`. So `:root-id is
+   not required`, `:root-id-v2 required`, and far-away prose no longer pass."
+  (re-pattern (str ":root-id(?![-\\w])" option-bridge "\\brequired\\b")))
 
 (def ^:private disambiguator-invalid-re
-  "The create-root row must assert `:disambiguator` is INVALID — the
-   `:disambiguator` token followed, within the SAME table cell (`[^|]`), by
-   `invalid` (rf2-e9q33). A row that drops this — or renames it to admit the
-   option — goes red."
-  #":disambiguator[^|]{0,60}\binvalid\b")
+  "The create-root row must assert `:disambiguator` is INVALID, EXACTLY
+   (rf2-e9q33; tightened rf2-asxo3): the WHOLE `:disambiguator` token (no
+   `:disambiguator-old` prefix drift) bridged by `option-bridge` to `invalid`.
+   A row that drops it, renames the token, or reverses the polarity
+   (`:disambiguator is not invalid`, silently admitting the option) goes red."
+  (re-pattern (str ":disambiguator(?![-\\w])" option-bridge "\\binvalid\\b")))
 
 (defn read-api-md-lines
   "Read spec/API.md as `[[line-no line-text] ...]` (1-based). Shared by
@@ -584,10 +667,13 @@
                      (projection/ep0017-keyword-drift-problems "spec/API.md" api-md-lines)
                      (projection/ep0011-reply-vocab-drift-problems "spec/API.md" api-md-lines)
                      (projection/ep0015-privacy-vocab-drift-problems "spec/API.md" api-md-lines))
-        ;; Documented-kind guard for the Spec-004C root verbs (rf2-e9q33):
-        ;; each root verb's M/Fn marker must match the manifest :kind — the
-        ;; wrong-Var-kind drift the tier reconcile could not see.
-        kind-probs (root-verb-kind-problems {:rows rows :api-rows api-rows})
+        ;; Documented-kind guard for the Spec-004C root verbs (rf2-e9q33;
+        ;; exact-row + polarity-safe rf2-asxo3): EXACTLY ONE `re-frame.ui` row
+        ;; per verb, its M/Fn marker matching the manifest :kind — deletion,
+        ;; duplication, an unknown kind marker, or a foreign same-name row are
+        ;; all caught, not silently dropped.
+        kind-probs (root-verb-kind-problems {:rows rows :api-rows api-rows
+                                             :aliases adapter-aliases})
         ;; Literal-option guard for the create-root row (rf2-e9q33): authored
         ;; :root-id REQUIRED and :disambiguator INVALID must both stay pinned.
         opt-probs  (create-root-option-problems api-md-lines)
@@ -620,17 +706,27 @@
 
       (seq kind-probs)
       (do (binding [*out* *err*]
-            (println "DRIFT: spec/API.md documents a Spec-004C root verb with the wrong Var kind.")
+            (println "DRIFT: spec/API.md root-verb KIND guard failed (exact-row + polarity-safe).")
             (println "create-root / render! / hydrate-root are MACROS; unmount! is a FUNCTION.")
-            (println "Each root-verb row's M/Fn marker must match the manifest :kind. Problems:")
-            (doseq [{:keys [kind raw line doc-kind manifest-kind]} kind-probs]
+            (println "EXACTLY ONE re-frame.ui var-row per verb, its M/Fn marker matching the")
+            (println "manifest :kind. Problems:")
+            (doseq [{:keys [kind var raw line doc-kind manifest-kind lines]} kind-probs]
               (case kind
                 :kind-mismatch
-                (println (format "  L%-4d KIND:    `%s` API.md marks %s; manifest :kind is %s"
+                (println (format "  L%-4d KIND:       `%s` API.md marks %s; manifest :kind is %s"
                                  line raw doc-kind manifest-kind))
                 :kind-unmarked
-                (println (format "  L%-4d KIND:    `%s` carries no var-kind marker; manifest :kind is %s"
-                                 line raw manifest-kind)))))
+                (println (format "  L%-4d KIND:       `%s` carries no var-kind marker; manifest :kind is %s"
+                                 line raw manifest-kind))
+                :kind-row-missing
+                (println (format "  %-13s MISSING:    no re-frame.ui var-row (deleted, or an unknown M/Fn marker dropped it); manifest :kind is %s"
+                                 var manifest-kind))
+                :kind-row-duplicated
+                (println (format "  %-13s DUPLICATED: %d re-frame.ui var-rows at lines %s; exactly one required"
+                                 var (count lines) (pr-str lines)))
+                :kind-manifest-absent
+                (println (format "  %-13s NO-MANIFEST: the manifest carries no re-frame.ui :kind for this verb"
+                                 var)))))
           false)
 
       (seq opt-probs)

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
@@ -221,43 +221,58 @@
    {:namespace "re-frame.ui"   :var "unmount!"     :kind :fn}
    {:namespace "re-frame.core" :var "reg-event"    :kind :fn}])
 
+(def ^:private root-rows-in-sync
+  "The four Spec-004C root verbs documented IN SYNC — bare re-frame.ui rows
+   with the committed kinds (create-root/render!/hydrate-root = macro,
+   unmount! = fn). The two-sided guard (rf2-asxo3) requires all four, so each
+   adversarial fixture MUTATES one row and keeps the other three in sync, which
+   isolates a single problem instead of tripping three missing-row false
+   positives."
+  [{:var "create-root"  :qualifier nil :doc-kind :macro :line 254 :raw "create-root"}
+   {:var "render!"      :qualifier nil :doc-kind :macro :line 255 :raw "render!"}
+   {:var "hydrate-root" :qualifier nil :doc-kind :macro :line 256 :raw "hydrate-root"}
+   {:var "unmount!"     :qualifier nil :doc-kind :fn    :line 257 :raw "unmount!"}])
+
 (defn- kind-problems-for [api-rows]
   (c/root-verb-kind-problems {:rows root-manifest-rows :api-rows api-rows}))
 
+(defn- mutate-row
+  "`root-rows-in-sync` with the row for `v` merged with `changes`."
+  [v changes]
+  (mapv #(if (= v (:var %)) (merge % changes) %) root-rows-in-sync))
+
+(defn- drop-row
+  "`root-rows-in-sync` with the row for `v` removed (simulates a deletion)."
+  [v]
+  (vec (remove #(= v (:var %)) root-rows-in-sync)))
+
 (deftest root-verbs-in-sync-produce-no-kind-problems
-  (testing "the committed documented kinds (create-root/render!/hydrate-root
-            = macro, unmount! = fn) reconcile clean against the manifest"
-    (is (empty? (kind-problems-for
-                  [{:var "create-root"  :doc-kind :macro :line 252 :raw "create-root"}
-                   {:var "render!"      :doc-kind :macro :line 253 :raw "render!"}
-                   {:var "hydrate-root" :doc-kind :macro :line 254 :raw "hydrate-root"}
-                   {:var "unmount!"     :doc-kind :fn    :line 255 :raw "unmount!"}])))))
+  (testing "the four in-sync root rows (create-root/render!/hydrate-root =
+            macro, unmount! = fn) reconcile clean against the manifest"
+    (is (empty? (kind-problems-for root-rows-in-sync)))))
 
 (deftest create-root-flipped-macro-to-fn-goes-red
   (testing "THE BUG (rf2-e9q33): a create-root row whose M/Fn marker flipped
-            M -> Fn (documented :fn) fails against the manifest :macro"
-    (let [problems (kind-problems-for
-                     [{:var "create-root" :doc-kind :fn :line 252 :raw "create-root"}])]
+            M -> Fn (documented :fn) fails against the manifest :macro; the
+            other three rows stay in sync so exactly one problem is isolated"
+    (let [problems (kind-problems-for (mutate-row "create-root" {:doc-kind :fn}))]
       (is (= 1 (count problems)))
       (is (= :kind-mismatch (:kind (first problems))))
       (is (= :fn    (:doc-kind (first problems))))
       (is (= :macro (:manifest-kind (first problems))))
-      (is (= 252 (:line (first problems)))))))
+      (is (= 254 (:line (first problems)))))))
 
 (deftest render-and-hydrate-flipped-to-fn-go-red
   (testing "render! and hydrate-root flipped M -> Fn each fail on kind"
     (is (= [:kind-mismatch]
-           (map :kind (kind-problems-for
-                        [{:var "render!" :doc-kind :fn :line 253 :raw "render!"}]))))
+           (map :kind (kind-problems-for (mutate-row "render!" {:doc-kind :fn})))))
     (is (= [:kind-mismatch]
-           (map :kind (kind-problems-for
-                        [{:var "hydrate-root" :doc-kind :fn :line 254 :raw "hydrate-root"}]))))))
+           (map :kind (kind-problems-for (mutate-row "hydrate-root" {:doc-kind :fn})))))))
 
 (deftest unmount-documented-as-anything-but-fn-goes-red
   (testing "unmount! documented as a macro (Fn -> M) fails — the acceptance
             criterion 'unmount! documented as anything other than a function'"
-    (let [problems (kind-problems-for
-                     [{:var "unmount!" :doc-kind :macro :line 255 :raw "unmount!"}])]
+    (let [problems (kind-problems-for (mutate-row "unmount!" {:doc-kind :macro}))]
       (is (= 1 (count problems)))
       (is (= :kind-mismatch (:kind (first problems))))
       (is (= :macro (:doc-kind (first problems))))
@@ -267,19 +282,134 @@
   (testing "a root verb whose marker pins no kind (e.g. a `Component` cell,
             doc-kind nil) is flagged :kind-unmarked rather than silently
             passing"
-    (let [problems (kind-problems-for
-                     [{:var "create-root" :doc-kind nil :line 252 :raw "create-root"}])]
+    (let [problems (kind-problems-for (mutate-row "create-root" {:doc-kind nil}))]
       (is (= 1 (count problems)))
       (is (= :kind-unmarked (:kind (first problems))))
       (is (= :macro (:manifest-kind (first problems)))))))
 
 (deftest non-root-var-rows-are-not-kind-checked
-  (testing "the guard fires ONLY for the named root verbs — an unrelated
-            var-row (even one carried in the manifest) contributes no kind
-            problem regardless of its documented kind"
+  (testing "the guard fires ONLY for the named root verbs — unrelated var-rows
+            alongside the in-sync root rows contribute no kind problem
+            regardless of their documented kind"
     (is (empty? (kind-problems-for
-                  [{:var "reg-event" :doc-kind :macro :line 1 :raw "reg-event"}
-                   {:var "some-tooling-fn" :doc-kind :var :line 2 :raw "some-tooling-fn"}])))))
+                  (into root-rows-in-sync
+                        [{:var "reg-event" :qualifier nil :doc-kind :macro :line 1 :raw "reg-event"}
+                         {:var "some-tooling-fn" :qualifier nil :doc-kind :var :line 2 :raw "some-tooling-fn"}]))))))
+
+;; ---------------------------------------------------------------------------
+;; Root-verb KIND guard — EXACT-ROW + POLARITY-SAFE (rf2-asxo3).
+;;
+;; The first cut compared BARE var names over whatever rows survived in
+;; api-rows. Two holes: a foreign same-name qualified row (other.ui/render!)
+;; matched a root verb by bare name (false prove/contradict), and a DELETED
+;; row — or a row the parser dropped for an unknown M/Fn marker — vanished from
+;; api-rows, leaving the one-way keep silently green. These fixtures pin the
+;; exact-qualifier resolution and the two-sided required-set reconcile.
+;; ---------------------------------------------------------------------------
+
+(deftest foreign-qualified-row-does-not-false-red
+  (testing "THE EXACTNESS BUG, false-RED half (rf2-asxo3): a foreign same-name
+            qualified row (other.ui/render!) with a WRONG kind, ALONGSIDE the
+            real bare render! row, is NOT counted as the root verb — the real
+            row keeps the check green"
+    (is (empty? (kind-problems-for
+                  (conj root-rows-in-sync
+                        {:var "render!" :qualifier "other.ui" :doc-kind :fn
+                         :line 400 :raw "other.ui/render!"}))))))
+
+(deftest foreign-qualified-row-cannot-false-green-a-deleted-row
+  (testing "THE EXACTNESS BUG, false-GREEN half (rf2-asxo3): with the real bare
+            render! deleted, a foreign other.ui/render! — even with the CORRECT
+            kind — does not satisfy the requirement; render! is flagged missing"
+    (let [problems (kind-problems-for
+                     (conj (drop-row "render!")
+                           {:var "render!" :qualifier "other.ui" :doc-kind :macro
+                            :line 400 :raw "other.ui/render!"}))]
+      (is (= 1 (count problems)))
+      (is (= :kind-row-missing (:kind (first problems))))
+      (is (= "render!" (:var (first problems)))))))
+
+(deftest re-frame-ui-qualified-row-is-accepted
+  (testing "an EXPLICITLY re-frame.ui-qualified row resolves as the root verb
+            (bare is the documented convention, but the exact qualifier counts)"
+    (is (empty? (kind-problems-for
+                  (conj (drop-row "render!")
+                        {:var "render!" :qualifier "re-frame.ui" :doc-kind :macro
+                         :line 255 :raw "re-frame.ui/render!"}))))))
+
+(deftest deleted-root-row-is-caught
+  (testing "THE POLARITY BUG (rf2-asxo3): a root verb DELETED from API.md — no
+            longer in api-rows — is caught :kind-row-missing, not silently green"
+    (let [problems (kind-problems-for (drop-row "unmount!"))]
+      (is (= 1 (count problems)))
+      (is (= :kind-row-missing (:kind (first problems))))
+      (is (= "unmount!" (:var (first problems))))
+      (is (= :fn (:manifest-kind (first problems)))))))
+
+(deftest duplicated-root-row-is-caught
+  (testing "two re-frame.ui rows for the same verb (a stray duplicate) is
+            caught :kind-row-duplicated — exactly one is required"
+    (let [problems (kind-problems-for
+                     (conj root-rows-in-sync
+                           {:var "render!" :qualifier nil :doc-kind :macro
+                            :line 260 :raw "render!"}))]
+      (is (= 1 (count problems)))
+      (is (= :kind-row-duplicated (:kind (first problems))))
+      (is (= "render!" (:var (first problems))))
+      (is (= [255 260] (:lines (first problems)))))))
+
+(deftest manifest-missing-root-verb-is-caught
+  (testing "a verb absent from the MANIFEST (no re-frame.ui :kind to resolve
+            against) is :kind-manifest-absent — the comparison cannot silently
+            skip a verb it cannot resolve"
+    (let [problems (c/root-verb-kind-problems
+                     {:rows     (remove #(= "unmount!" (:var %)) root-manifest-rows)
+                      :api-rows root-rows-in-sync})]
+      (is (= 1 (count problems)))
+      (is (= :kind-manifest-absent (:kind (first problems))))
+      (is (= "unmount!" (:var (first problems)))))))
+
+;; ---------------------------------------------------------------------------
+;; END-TO-END parser disappearance (rf2-asxo3).
+;;
+;; The pure `parse-var-rows` core lets us feed synthetic indexed API.md lines.
+;; A root verb whose M/Fn marker drifted to an UNKNOWN spelling (`Macro`, not
+;; the blessed `M`) is SKIPPED by the real parser — proving the disappearance
+;; is real, and that the two-sided guard turns it into a caught missing row.
+;; ---------------------------------------------------------------------------
+
+(def ^:private synthetic-api-md-lines
+  "A minimal API.md table (with a Tier column) documenting the four root verbs;
+   render! carries an UNKNOWN M/Fn marker (`Macro`) so the parser drops it."
+  [[1 "| Name | M/Fn | Signature | Stage | Tier | Notes |"]
+   [2 "|------|------|-----------|-------|------|-------|"]
+   [3 "| `create-root`  | M     | sig | S1 | advanced | n |"]
+   [4 "| `render!`      | Macro | sig | S1 | advanced | n |"]
+   [5 "| `hydrate-root` | M     | sig | S1 | advanced | n |"]
+   [6 "| `unmount!`     | Fn    | sig | S1 | advanced | n |"]])
+
+(deftest unknown-kind-marker-disappears-then-is-caught
+  (testing "END-TO-END (rf2-asxo3): a root verb whose M/Fn marker is an unknown
+            spelling (`Macro`) is DROPPED by the real parser"
+    (let [parsed (c/parse-var-rows synthetic-api-md-lines)]
+      (is (= #{"create-root" "hydrate-root" "unmount!"} (set (map :var parsed)))
+          "render! must have DISAPPEARED from the parse (unknown marker skipped)")
+      (testing "and the two-sided kind guard turns that disappearance into a
+                caught :kind-row-missing rather than a silent green"
+        (let [problems (c/root-verb-kind-problems
+                         {:rows root-manifest-rows :api-rows parsed})]
+          (is (= 1 (count problems)))
+          (is (= :kind-row-missing (:kind (first problems))))
+          (is (= "render!" (:var (first problems)))))))))
+
+(deftest parse-var-rows-recovers-blessed-markers
+  (testing "control: with all four markers the blessed M/Fn spellings, the pure
+            parser recovers all four verbs and the guard is clean"
+    (let [ok-lines (assoc-in synthetic-api-md-lines [3 1]
+                             "| `render!` | M | sig | S1 | advanced | n |")
+          parsed   (c/parse-var-rows ok-lines)]
+      (is (= #{"create-root" "render!" "hydrate-root" "unmount!"} (set (map :var parsed))))
+      (is (empty? (c/root-verb-kind-problems {:rows root-manifest-rows :api-rows parsed}))))))
 
 (deftest live-root-verb-kinds-match-the-manifest
   (testing "the committed spec/API.md documents each Spec-004C root verb with
@@ -375,6 +505,69 @@
             (no live option-grammar drift)"
     (is (empty? (c/create-root-option-problems (c/read-api-md-lines)))
         "live drift: create-root row lost :root-id-required or :disambiguator-invalid")))
+
+;; ---------------------------------------------------------------------------
+;; create-root option grammar — EXACT + POLARITY-SAFE (rf2-asxo3).
+;;
+;; The first regexes matched `:root-id[^|]{0,60}required` (and the disambiguator
+;; analogue), so `:root-id is not required`, `:root-id-v2 required`,
+;; `:disambiguator is not invalid`, and `:disambiguator-old invalid` all
+;; false-greened: negation, a token prefix/suffix, or reversed polarity slipped
+;; through. The tightened regexes pin the WHOLE token (a trailing `-`/word char
+;; rejects the prefix drift) and forbid an intervening negation, close to the
+;; token. These fixtures pin each enumerated failure form goes RED.
+;; ---------------------------------------------------------------------------
+
+(defn- option-probe
+  "Run the option guard over a single create-root row whose Notes cell is
+   `notes`."
+  [notes]
+  (c/create-root-option-problems
+    [[254 (str "| `create-root` | M | opts | S1 | advanced | " notes " |")]]))
+
+(deftest option-negation-fails-root-id-required
+  (testing "a NEGATED :root-id assertion (`is not required`) no longer
+            false-greens — the option is admitted, so the pin fails"
+    (is (= [:root-id-not-required]
+           (map :kind (option-probe
+                        "`:root-id` is not required and `:disambiguator` is invalid"))))))
+
+(deftest option-reversed-polarity-fails-disambiguator-invalid
+  (testing "a REVERSED-polarity :disambiguator assertion (`is not invalid`,
+            silently admitting the option) is caught :disambiguator-admitted"
+    (is (= [:disambiguator-admitted]
+           (map :kind (option-probe
+                        "`:root-id` required and `:disambiguator` is not invalid"))))))
+
+(deftest option-token-prefix-fails-root-id
+  (testing "a DIFFERENT token (`:root-id-v2`) does not satisfy the :root-id pin
+            — the whole-token boundary rejects the prefix drift"
+    (is (= [:root-id-not-required]
+           (map :kind (option-probe
+                        "`:root-id-v2` required and `:disambiguator` is invalid"))))))
+
+(deftest option-token-prefix-fails-disambiguator
+  (testing "a DIFFERENT token (`:disambiguator-old`) does not satisfy the
+            :disambiguator pin"
+    (is (= [:disambiguator-admitted]
+           (map :kind (option-probe
+                        "`:root-id` required and `:disambiguator-old` invalid"))))))
+
+(deftest option-far-prose-fails
+  (testing "the polarity word must sit CLOSE to the token; far-away unrelated
+            prose between them no longer bridges the pin"
+    (is (= [:root-id-not-required]
+           (map :kind (option-probe
+                        (str "`:root-id` is one of several options that may or may not "
+                             "eventually be required and `:disambiguator` is invalid")))))))
+
+(deftest option-in-sync-committed-clause-passes
+  (testing "the committed create-root clause (authored :root-id **required**;
+            :disambiguator is invalid) still reconciles clean under the
+            tightened regexes"
+    (is (empty? (option-probe
+                  (str "authored `:root-id` **required** — a missing id is "
+                       "`:rf.ui.compile/missing-root-id` and `:disambiguator` is invalid"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; re-frame.ui.test HOST-SIGNATURE guard — JVM (:clj) lane (rf2-5bcdi;


### PR DESCRIPTION
## What

Harden the Spec-004C root-API drift checks in
`implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj`
so they are exact-row and polarity-safe. Checker-only — no API-row data changed,
no redesign (no schema layer, no general Markdown parser).

Closes rf2-asxo3.

## Defects (reproduced before fix)

1. **Qualifier exactness** — `root-verb-kind-problems` compared BARE var names
   and ignored the parser's preserved `:qualifier`. A foreign `other.ui/render!`
   masqueraded as the root verb: with a wrong kind it false-**red** (spurious
   `:kind-mismatch`); with the right kind it false-**greened** a deleted real row.

2. **Polarity** — the guard iterated only surviving `api-rows`. A DELETED row, or
   a row whose `M/Fn` marker drifted to an unknown spelling (so the parser skips
   it), simply disappeared from `api-rows` — the one-way keep + coarse floor
   stayed green.

3. **Option regexes** (same bead, acceptance criterion 3) — `:root-id ...required`
   / `:disambiguator ...invalid` accepted negation and token drift:
   `:root-id is not required`, `:root-id-v2 required`,
   `:disambiguator is not invalid`, `:disambiguator-old invalid` all false-greened.

## Fix

- `root-verb-kind-problems` is now a **two-sided reconcile over the required set**
  of four verbs. `root-ui-row?` resolves the preserved qualifier exactly
  (bare = the documented convention, else alias→verbatim to `re-frame.ui`), so a
  foreign qualifier is excluded. Each verb must have **exactly one** `re-frame.ui`
  row: deletion / unknown-marker → `:kind-row-missing`, duplication →
  `:kind-row-duplicated`, manifest gap → `:kind-manifest-absent`; a present-on-both
  wrong kind stays `:kind-mismatch` / `:kind-unmarked`.
- Extracted the pure `parse-var-rows` core (mirroring the existing reconcile /
  option-guard pure cores) so parser disappearance is testable end-to-end.
- Option regexes now pin the **whole token** (`(?![-\w])` rejects a `-v2` /
  `-old` prefix) and forbid an intervening negation close to the token, so
  negation, token prefix/suffix, reversed polarity, and far-away prose all go red.

## Scope note

The dispatch brief named two defect sites (qualifier exactness + polarity); the
bead's acceptance also names the option-regex hole (criterion 3) and bounds
itself to "the four Spec-004C root rows and two create-root option facts." All
three fixes live in the one checker file, are minimal per-site tightenings, and
are required by the bead's acceptance, so they ship together. The committed
`spec/API.md` create-root row already states the complete option contract
(`:root-id` required, the `:rf.ui.compile/missing-root-id` error, `:disambiguator`
invalid, Spec-004C reference) and the tightened checker now enforces it exactly —
no docs/data change was needed (criterion 5).

## Quality gates

`cd implementation/scripts/api-manifest && clojure -M:test` (foreground):

```
OK: spec/API.md projection in sync (217 var-rows checked against the manifest).
...
Ran 99 tests containing 217 assertions.
0 failures, 0 errors.
```

Red-before/green-after adversarial cases added, one per defect:
- exactness: foreign-qualifier masquerade — false-red half (foreign row beside
  real rows stays green) and false-green half (foreign-only cannot satisfy a
  deleted real row), plus an explicitly `re-frame.ui`-qualified row is accepted.
- polarity: deletion → `:kind-row-missing`, duplication → `:kind-row-duplicated`,
  manifest-absence → `:kind-manifest-absent`, and an **end-to-end** unknown-kind
  marker (`Macro`) proven to disappear via the real `parse-var-rows` then caught.
- option grammar: negation, reversed polarity, token prefix (×2), and far-away
  prose all flagged; the committed in-sync clause still passes.