### PR TITLE
docs(views): reconcile hooks adapter recipe table to the single causally-guarded rule (rf2-05kex)

### DIFF
--- a/scripts/check_skill_re_frame2_drift.py
+++ b/scripts/check_skill_re_frame2_drift.py
@@ -100,7 +100,9 @@ existing automated guards did not catch (the no-bead-id guard was scoped to
      SENTENCE-scoped (a bounded recipe-sentence carve, NOT a general prose
      parser — a mixed Reagent+hooks line is checked per sentence): (6a) each
      authoritative leaf (`patterns/stateful-components.md`, `references/
-     fundamentals/frames.md`) MUST carry a COHERENT recipe sentence naming an
+     fundamentals/frames.md`, and — rf2-05kex — `references/fundamentals/
+     views.md`, whose per-adapter recipe table had drifted while its own
+     paragraph stayed lawful) MUST carry a COHERENT recipe sentence naming an
      ordinary `defui`/`defnc`, `use-subscribe`, AND `use-frame` together; (6b)
      no hooks-recipe sentence may carry a residue shape — a `:contextType`
      ATTRIBUTED to a hooks adapter (fires even under a stray far "not"; a
@@ -385,7 +387,9 @@ def managed_http_recipe_problems(text: str) -> list[tuple[int, str]]:
 #     real attribution.
 #
 #     6a — COHERENCE FLOOR. Each authoritative hooks-guidance leaf (patterns/
-#          stateful-components.md, references/fundamentals/frames.md) MUST carry
+#          stateful-components.md, references/fundamentals/frames.md, and
+#          references/fundamentals/views.md — the per-adapter recipe table leaf,
+#          anchored under rf2-05kex after its table row drifted) MUST carry
 #          at least one COHERENT recipe sentence naming an ordinary `defui` /
 #          `defnc`, `use-subscribe`, AND `use-frame` together — proving the
 #          relationship, not just the scattered presence of two tokens.
@@ -407,6 +411,12 @@ def managed_http_recipe_problems(text: str) -> list[tuple[int, str]]:
 HOOKS_LEAF_REQUIRED = (
     ("patterns", "stateful-components.md"),
     ("references", "fundamentals", "frames.md"),
+    # rf2-05kex — the views leaf carries the per-adapter recipe table. Its table
+    # row had drifted (an ordinary hooks view classified as `reg-view*` on a
+    # `defui` / `defnc`) while its own paragraph taught the lawful ordinary
+    # `defui`/`defnc` + `use-subscribe` + `use-frame` recipe — a contradiction the
+    # coherence floor missed because it did not anchor this leaf. Anchor it.
+    ("references", "fundamentals", "views.md"),
 )
 HOOKS_ADAPTER_RE = re.compile(r"\b(?:UIx|Helix)\b")
 # A "hooks-recipe sentence" names a hooks adapter OR one of the two hooks — so a
@@ -723,7 +733,7 @@ def find_drift(files: list[Path]) -> tuple[list[str], int]:
             for label in hooks_sentence_problems(sent):
                 problems.append(f"{rel}:{lineno}: {label}\n    {sent.strip()}")
 
-    # Rule 6a — COHERENCE FLOOR. The two authoritative hooks-guidance leaves must
+    # Rule 6a — COHERENCE FLOOR. The authoritative hooks-guidance leaves must
     # each carry a single COHERENT recipe sentence (ordinary `defui`/`defnc` +
     # `use-subscribe` + `use-frame` together), proving the relationship — not just
     # the scattered presence of two tokens (which a semantic reversal that names

--- a/skills/re-frame2/references/fundamentals/views.md
+++ b/skills/re-frame2/references/fundamentals/views.md
@@ -85,8 +85,8 @@ The shape is identical; the registration surface differs by adapter (cross-ref t
 | Adapter | Ordinary (Form-1) view | Lifecycle-bearing view |
 |---|---|---|
 | **Reagent** / **Reagent-slim** | `reg-view` (defn-shape, Form-1) | `reg-view*` + `create-class` (Form-3) |
-| **UIx** | `reg-view*` on a `defui` component | same + `use-effect` (deps vector) |
-| **Helix** | `reg-view*` on a `defnc` component | same + `use-effect` (deps vector first) |
+| **UIx** | ordinary `defui`; subs via `use-subscribe`, frame via `use-frame`; `reg-view*` optional (registry addressing only) | same + `use-effect` (deps vector) |
+| **Helix** | ordinary `defnc`; subs via `use-subscribe`, frame via `use-frame`; `reg-view*` optional (registry addressing only) | same + `use-effect` (deps vector first) |
 
 The `reg-view` macro (and its injected locals) is **Reagent-only** — it does not cover UIx / Helix (spec 004, Decision 4). On the hooks adapters a UIx / Helix component is an ordinary `defui` / `defnc`: it reads subs through the adapter's `use-subscribe` hook (no injected `subscribe`) and carries the frame — for dispatch, and for any async callback that fires after render — through the **`use-frame`** hook (the hook-position spelling of `capture-frame`, reading the surrounding `frame-provider` / `frame-root` from React context). `reg-view*` on these adapters is optional, only when a component needs registry-keyed view addressing — never the source of the frame wiring.
 


### PR DESCRIPTION
Closes rf2-05kex.

PR #6225 corrected the paragraph immediately **below** the per-adapter table in `skills/re-frame2/references/fundamentals/views.md`, but the **table itself** still gave the opposite copyable rule for the hooks adapters. Rule 6's coherence floor stayed green because it anchored only `patterns/stateful-components.md` and `references/fundamentals/frames.md`, not this leaf, and `reg-view*` is a lawful token, so nothing caught the drift.

## The contradiction (reproduced before editing)

`skills/re-frame2/references/fundamentals/views.md`, "Per-adapter spelling" table (line 88-89 before):

| Adapter | Ordinary (Form-1) view |
|---|---|
| **UIx** | `reg-view*` on a `defui` component |
| **Helix** | `reg-view*` on a `defnc` component |

The paragraph directly under it (unchanged, already lawful after #6225): *"On the hooks adapters a UIx / Helix component is an ordinary `defui` / `defnc`: it reads subs through the adapter's `use-subscribe` hook … and carries the frame … through the **`use-frame`** hook … `reg-view*` on these adapters is optional, only when a component needs registry-keyed view addressing — never the source of the frame wiring."*

The shipped recipe agrees with the paragraph, not the table — `examples/substrates/helix/counter/core.cljs` is a plain `defnc` using `use-subscribe` + `use-frame` and **no** `reg-view*`. So the table taught unnecessary registration and contradicted both the paragraph and the shipped example.

## The fix (truth-only, minimal)

Reconcile the two table cells to the lawful ordinary hooks recipe, using the exact wording of the already-anchored sibling table in `patterns/stateful-components.md` so the two per-adapter tables now agree:

- **UIx** → `ordinary `defui`; subs via `use-subscribe`, frame via `use-frame`; `reg-view*` optional (registry addressing only)`
- **Helix** → `ordinary `defnc`; subs via `use-subscribe`, frame via `use-frame`; `reg-view*` optional (registry addressing only)`

`reg-view*` remains accurately documented as optional registry-keyed addressing, never the frame wiring. No example runtime change (the helix `core.cljs` recipe was already correct); no example `spec.cjs` added (examples are test-free, rf2-8cevm); no spec files touched.

## Guard: anchor the drifted leaf

Rule 6a (`scripts/check_skill_re_frame2_drift.py`) missed this because its coherence floor never anchored `views.md` — the very leaf that carries the per-adapter recipe table. Added `references/fundamentals/views.md` to `HOOKS_LEAF_REQUIRED` so the leaf must always carry a coherent `defui`/`defnc` + `use-subscribe` + `use-frame` recipe sentence. The `--self-test` loop already iterates that tuple, so the four residue mutations (reg-view-macro, bare-capture, semantic-reversal, `:contextType`-attribution) and the coherence-floor load-bearing check now run against `views.md` automatically — no new test code.

### Scope note

The bead's file surface is `skills/re-frame2/references/fundamentals/views.md`, not `examples/` (the dispatch brief's candidate files were the wrong tree), so the PR scope is `docs(views)`. The broader acceptance items that fall outside this leaf/guard — anchoring the `skills/re-frame2-setup/references/first-counter.md` warning in its own setup guard, anchoring the `spec/006-ReactiveSubstrate.md` hooks paragraph (a hot-zone spec file, off-limits for this bead), and a table-cell-specific 6a predicate (a coherence floor can't force the *table* right if the paragraph stays right) — are deliberately deferred as out-of-surface / over-engineering; flagged in the worker report for the mayor.

## Quality gates

- `python scripts/check_skill_re_frame2_drift.py --verbose` — **green** (50 leaves / 7413 lines; exit 0).
- `python scripts/check_skill_re_frame2_drift.py --self-test` — **all cases passed** (now including the four residue mutations + coherence-floor load-bearing check against `views.md`; exit 0).
- `python -m mkdocs build --strict` — **exit 0** (change is under `skills/`, excluded from the mkdocs nav; no cross-link breakage).
