### PR TITLE
docs(mayor-method): retire the decisions.md index from the method docs (rf2-9xj86)

### DIFF
--- a/docs/the-mayor-method/README.md
+++ b/docs/the-mayor-method/README.md
@@ -24,7 +24,7 @@ Prompt engineering and context management are still the keys.
 - [Beads](https://github.com/gastownhall/beads) are used to work.
 - Prompts are treated very seriously.
 - Git worktrees isolate workers.
-- `/ai/decisions.md` tracks the calls waiting on me.
+- Chat and Beads hold the calls waiting on me.
 - I make the important calls.
 
 The rest is good discipline.
@@ -110,7 +110,10 @@ Keep AI working material out of the product tree:
   spec, or docs.
 - `/ai/extended-context/` — durable project context not obvious from code.
   The mayor consults it on bootstrap and contributes on retrospectives.
-- `/ai/decisions.md` — the index of holds awaiting the operator (review gates, operator-run actions, held beads).
+- `/ai/decisions/` — one file per decision, written only when the operator
+  asks for a durable record of a specific call. Ordinary holds awaiting the
+  operator (review gates, operator-run actions, held beads) live in chat and
+  on their beads, not in an index file.
 
 ## Beads are the work queue
 

--- a/docs/the-mayor-method/bootstrap.md
+++ b/docs/the-mayor-method/bootstrap.md
@@ -18,10 +18,11 @@ git-history record.
 prompts; paste the worktree-boundary block verbatim into every editing
 dispatch), then `README.md` (the longer "why"; refer back to sections as needed).
 
-**Decisions.** Keep `ai/decisions.md` current: every hold awaiting the
-operator — review gates, operator-run actions, held beads — goes in it the
-moment it arises, and comes out when resolved. Everything else operator-facing
-goes in chat; there is no dashboard to maintain.
+**Decisions.** Every hold awaiting the operator — review gates, operator-run
+actions, held beads — surfaces in chat and on its bead the moment it arises,
+and clears the same way when resolved. There is no decisions index or dashboard
+to maintain. When the operator asks for a written record of a particular
+decision, capture it as one file per decision under `ai/decisions/`.
 
 **Findings vs extended-context.** `ai/findings/` is gitignored exploratory work
 (audits, drafts, alternatives); always write the finding doc BEFORE filing the
@@ -81,8 +82,8 @@ of a drain; the binding rule is hot-zone parallelism, not strict same-surface.
   project's stance deliberately excludes (e.g. egress the threat model doesn't
   cover). Hold it as an operator decision; surface, don't auto-fix. Don't gold-plate.
 - *Quiescent is a valid state.* At the tail of a drain, dispatch is
-  one-unblocks-the-next (gated on merges/decisions), not fan-out. Hold, keep
-  `ai/decisions.md` honest, surface what needs the operator — don't manufacture work.
+  one-unblocks-the-next (gated on merges/decisions), not fan-out. Hold,
+  surface what needs the operator in chat and on the beads — don't manufacture work.
 - *Checkpoint tracker state on the heartbeat.* Many trackers auto-stage but never
   commit; commit + push the tracker file each cycle so a long session's state
   isn't stranded locally.


### PR DESCRIPTION
## What

PR #6092 retired the `ai/decisions.md` index in `CLAUDE.md` — holds awaiting the operator now surface in chat and on their beads, with per-decision dossiers under `ai/decisions/` only when the operator explicitly asks. The Mayor Method docs that `CLAUDE.md` points readers to still instructed the opposite, so a fresh mayor following the copy-paste bootstrap would recreate exactly the retired maintenance loop.

This reconciles the two authoritative method docs to the current ruling (truth-only, prose-only).

### Sites retired (before → after)

- **`bootstrap.md:21` Decisions paragraph** — "Keep `ai/decisions.md` current: every hold … goes in it" → holds surface in chat and on their bead; no index/dashboard to maintain; operator-requested records go one-file-per-decision under `ai/decisions/`.
- **`bootstrap.md:85` quiescent-state bullet** — "keep `ai/decisions.md` honest, surface what needs the operator" → "surface what needs the operator in chat and on the beads".
- **`README.md:27` TLDR** — "`/ai/decisions.md` tracks the calls waiting on me." → "Chat and Beads hold the calls waiting on me."
- **`README.md:113` `/ai` directory inventory** — "`/ai/decisions.md` — the index of holds …" → "`/ai/decisions/` — one file per decision, written only when the operator asks … Ordinary holds … live in chat and on their beads, not in an index file."

### Scope

- No new tracker/index/dashboard/scanner and no compatibility layer introduced.
- No other Mayor Method guidance changed (worktrees, PRs, loops, stance, findings/extended-context all untouched); no restructuring.
- Explicitly requested per-decision dossiers in `ai/decisions/` remain supported and are now clearly distinguished from the retired index.
- `dispatch-prompt-template.md` has no decisions.md references (confirmed by grep); left untouched.

## Quality gates

- `python -m mkdocs build --strict` — passed (exit 0); the-mayor-method README/bootstrap/dispatch-prompt-template remain in the built nav. The residual INFO lines are pre-existing and unrelated to this diff.
- `git grep -n 'decisions\.md' docs/the-mayor-method/` — now empty (literal index string fully gone). The only remaining `decisions index` match is the negation "There is no decisions index or dashboard"; the two `ai/decisions/` matches intentionally reference the on-request dossier directory.
- Full spine not run (docs-only change, per bead scope).

Closes rf2-9xj86.
