### PR TITLE
docs(frames): make caller-owned frame teaching lifecycle-safe (mint+release) (rf2-5l1ro)

### DIFF
--- a/ai/findings/new-substrate-synthesis/prep/w2-migration-skill-extension.md
+++ b/ai/findings/new-substrate-synthesis/prep/w2-migration-skill-extension.md
@@ -231,8 +231,10 @@ errors** — read them, fix the shape they name, never wrap around them. The res
 runtime class is frame scoping at boundaries and interaction-time behaviour, so the
 done-bar per subtree is still live, not "compiles":
 
-1. **Tier-1 structural tests** (`re-frame.ui.test`; JVM, no DOM): `(uit/render view
-   {:frame (rf/make-frame {:initial-events [[:rf/set-db seed]]})})`, structural
+1. **Tier-1 structural tests** (`re-frame.ui.test`; JVM, no DOM): mint a
+   **caller-owned** frame and release it on exit —
+   `(rf/with-new-frame [f (rf/make-frame {:initial-events [[:rf/set-db seed]]})]
+   (uit/render view {:frame f}) …)` — then structural
    `find`/`text`/`attrs`, and **event-intent assertions**
    — assert the button *carries* `[:cart/add id]` as data; no DOM click needed.
    `uit/dispatch!` drives Tier-1 state — real dispatch + drain to fixed point,

--- a/ai/findings/new-substrate-synthesis/skill/SKILL.md
+++ b/ai/findings/new-substrate-synthesis/skill/SKILL.md
@@ -396,16 +396,18 @@ Props compare by value (`rf=`, per slot) to decide re-renders:
 
 ```clojure
 (deftest add-button-carries-intent
-  (let [frame (rf/make-frame {:initial-events [[:rf/set-db {:cart #{}}]]})
-        tree  (uit/render [product-card {:product {:id 42 :name "Hat" :price 9.5}}]
-                          {:frame frame})]
-    (is (= "Hat"          (uit/text (uit/find tree :h3))))
-    (is (= [:cart/add 42] (:on-click (uit/attrs (uit/find tree :button)))))))
+  (rf/with-new-frame [frame (rf/make-frame {:initial-events [[:rf/set-db {:cart #{}}]]})]
+    (let [tree (uit/render [product-card {:product {:id 42 :name "Hat" :price 9.5}}]
+                           {:frame frame})]
+      (is (= "Hat"          (uit/text (uit/find tree :h3))))
+      (is (= [:cart/add 42] (:on-click (uit/attrs (uit/find tree :button))))))))
 ```
 
 - **Tier-1 (default): real view + real frame on the JVM, no DOM.** `render`
-  opts are CLOSED: `{:frame f}` (a frame minted with `rf/make-frame` +
-  `:initial-events`), `:props` (bare-view form only),
+  opts are CLOSED: `{:frame f}` (a **caller-owned** frame minted with
+  `rf/make-frame` + `:initial-events` — `render` binds it but never destroys it,
+  so wrap it in `rf/with-new-frame` as above, or release it with
+  `rf/destroy-frame!`), `:props` (bare-view form only),
   `:sub-overrides {query value}` (the explicit JVM override door). Unknown
   keys throw didactically.
 - `render` also takes a **literal root form** — the same top-region root

--- a/spec/004C-Roots-and-Mount.md
+++ b/spec/004C-Roots-and-Mount.md
@@ -492,9 +492,13 @@ server in sight (guide 01):
 `(ui.test/render root-or-view opts)` accepts exactly two forms:
 
 1. **A view reference** (compile-resolved Var/symbol of a `defview`). Props ride
-   `{:props p}`. A frame rides `{:frame f}` — mint it with `rf/make-frame` +
-   `:initial-events`; with no frame, structural rendering proceeds and any `sub`
-   raises `:rf.error/no-frame-context` — honest, not defaulted.
+   `{:props p}`. A frame rides `{:frame f}`, minted with `rf/make-frame` +
+   `:initial-events` and **caller-owned** — `render` binds it for the render but
+   never creates or destroys it, so release it with `rf/with-new-frame`
+   (eval-bind-run-destroy) or an explicit `rf/destroy-frame!` teardown per
+   [Spec 008 §`with-frame` and `with-new-frame`](008-Testing.md#with-frame-and-with-new-frame),
+   or the `make-frame` value leaks. With no frame, structural rendering proceeds
+   and any `sub` raises `:rf.error/no-frame-context` — honest, not defaulted.
 2. **A literal root form** — the same literal top-region grammar `mount` takes,
    wrappers included, tightened to exactly **one mounted view** per test root
    (§1.1's authored-`:root-id` multi-view allowance does not apply here; two views →


### PR DESCRIPTION
## What

Finishes the lifecycle-safe caller-owned frame teaching (rf2-5l1ro) on the three active surfaces that still taught minting a `{:frame f}` via `rf/make-frame` + `:initial-events` **without ever releasing it** — the exact resource leak the teaching should model, not commit. Canonical `re-frame.ui.test` reference docs and Spec 008 already state the rule (externally supplied frames stay caller-owned; use `rf/with-new-frame` / explicit `destroy-frame!` teardown); these three copyable/prose sources were the residue.

### Sites fixed

- **`spec/004C-Roots-and-Mount.md` §9** (`ui.test/render` view-reference clause) — states the explicit `{:frame f}` is **caller-owned** (`render` binds it but never creates or destroys it) and links the canonical recipe [Spec 008 §`with-frame` and `with-new-frame`](../blob/main/spec/008-Testing.md), instead of implying `render` owns it.
- **`ai/findings/new-substrate-synthesis/skill/SKILL.md` §10** — the copyable Tier-1 `deftest` now wraps mint→use in `rf/with-new-frame` (eval-bind-run-destroy — releases the exact frame on success **and** throw); the `render`-opts bullet names the frame caller-owned and points at `with-new-frame` / `destroy-frame!`.
- **`ai/findings/new-substrate-synthesis/prep/w2-migration-skill-extension.md`** — the Tier-1 verification recipe keeps a named frame `f` for dispatch/assertion under `rf/with-new-frame` and releases it; no longer embeds an unowned `make-frame` call in the render opts (which had discarded the handle needed for cleanup and for the following `uit/dispatch!`).

Truth-only, matches the shipped `with-new-frame` / `destroy-frame!` idiom exactly. **No runtime change** (the frame lifecycle is shipped and correct — this teaches it, doesn't change it), no new public helper or cleanup framework, no broad rewrite. The already-shipped normal/throw cleanup fixtures are unaffected.

## Quality gates

- `python scripts/check_doc_slugs.py` (full intra-repo link + anchor validation, incl. the new 004C→008 anchor) — **PASS** (exit 0)
- `python scripts/check_doc_slugs.py --synthesis-only` (synthesis authority inventory, incl. both edited `ai/findings/` files) — **PASS** (exit 0)
- `python -m mkdocs build --strict` — **PASS** (exit 0, built in 43.9s; spec files are INFO-level "not in nav" as expected — spec is AI-targeted; the synthesis skill lives outside the mkdocs `docs/` dir)

None of the three sites are executable test namespaces (all markdown prose/snippets), so there is no focused ns to run; full spine intentionally not run (CI owns it).
