### PR TITLE
fix(ui-compiler): make Shadow compile provenance total and unforgeable (rf2-8nn5k)

### DIFF
--- a/implementation/scripts/check-ui-final-schedule.cjs
+++ b/implementation/scripts/check-ui-final-schedule.cjs
@@ -35,7 +35,7 @@
 // (:ui-final-schedule-seq, :parallel-build false) compile schedules are proven.
 //
 // TEETH (documented mutation/revert; run at development time, NOT committed):
-//   * Replace build-hook/compiled-this-pass?'s marker check with the old
+//   * Replace build-hook/compile-verdict's marker check with the old
 //     `:cached false` + `:js`-identity body (rf2-v7wqk) — a non-scheduling hook
 //     that swaps only a retained output's `:js` for a fresh String is then
 //     misread as a recompile, so a cache-hit sibling's ghost is evicted and the
@@ -49,7 +49,12 @@
 //   * Make reconcile-final-schedule proceed silently when :pass-token is absent
 //     (drop the missing-pass-provenance throw) → the FAIL-LOUD pass SUCCEEDS
 //     instead of failing → this gate goes RED.
-// Both were exercised red-before-green during development.
+//   * Restore the marker-absent + `:cached false` -> compiled classification in
+//     build-hook/compile-verdict (drop the Shadow ::build-info :compiled corroboration,
+//     rf2-8nn5k) → the FORGE pass, whose whole-map replacement Shadow did not
+//     compile, is misclassified as a recompile and either evicts app-a's valid view
+//     or succeeds instead of failing loud → this gate goes RED.
+// All were exercised red-before-green during development.
 
 const fs = require('fs');
 const path = require('path');
@@ -68,6 +73,7 @@ const TRIGGER = path.join(FIX, 'trigger.cljs');
 const TARGET = path.join(IMPL, 'target', 'ui-final-schedule');
 const FORCE_MARKER = path.join(TARGET, 'force-recompile-app-a');
 const BLIND_MARKER = path.join(TARGET, 'blind-provenance');
+const FORGE_MARKER = path.join(TARGET, 'forge-app-a-output');
 const TIMEOUT = 120000;
 
 const BUILDS = [
@@ -201,6 +207,7 @@ async function driveBuild({ id, mode }) {
   fs.rmSync(observeFile(id), { force: true });
   fs.rmSync(FORCE_MARKER, { force: true });
   fs.rmSync(BLIND_MARKER, { force: true });
+  fs.rmSync(FORGE_MARKER, { force: true });
 
   const w = watch(id);
   try {
@@ -237,6 +244,31 @@ async function driveBuild({ id, mode }) {
       fail(`${id}: viewless trigger edit moved the digest (${str(ctlFin, 'digest')} != ${digest0})`);
     }
     console.log('  control warm pass: both views survive, digest stable, app-a not pre-touched');
+
+    // 2.5 FORGE pass — a build-local :compile-prepare hook REPLACES app-a's whole
+    // retained output map (rebuilt from Shadow's public fields, dropping
+    // re-frame.ui's private marker, copying sticky :cached false) WITHOUT removing
+    // it, so Shadow does NOT recompile app-a and it is absent from Shadow's own
+    // ::build-info :compiled. Pre-fix, finish trusted :cached false and evicted
+    // app-a's valid accepted view on a pass that compiled nothing. Now it must FAIL
+    // LOUD (`marker-dropped-without-compile`) before any candidate is finalized, so
+    // the both-views accepted state survives for the FORCED-EVICT arm below.
+    fs.writeFileSync(FORGE_MARKER, 'x');
+    let forgeFail = w.failureCount();
+    let forgeFin = countStage(id, 'finish');
+    editTrigger('forge');
+    await w.waitFailure(forgeFail);
+    await sleep(300);
+    const forgeTx = w.transcript();
+    if (!/marker-dropped-without-compile/.test(forgeTx) &&
+        !/non-scheduling whole-map replacement cannot count as compilation/.test(forgeTx)) {
+      fail(`${id}: forge — build failed but not with the whole-map-replacement diagnostic\n${forgeTx.slice(-1500)}`);
+    }
+    if (countStage(id, 'finish') !== forgeFin) {
+      fail(`${id}: forge — a candidate was finalized despite an unforgeable output-map replacement`);
+    }
+    console.log('  forge pass: a non-scheduling whole-map replacement failed the build before publication');
+    fs.rmSync(FORGE_MARKER, { force: true });
 
     // 3. FORCED-EVICT warm pass — build-local hook forces a viewless recompile.
     fs.writeFileSync(FORCE_MARKER, 'x');
@@ -295,6 +327,7 @@ async function driveBuild({ id, mode }) {
     fs.writeFileSync(TRIGGER, triggerOriginal);
     fs.rmSync(FORCE_MARKER, { force: true });
     fs.rmSync(BLIND_MARKER, { force: true });
+    fs.rmSync(FORGE_MARKER, { force: true });
     await terminateProcessTree(w.child, { timeoutMs: 5000 });
   }
 }

--- a/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
@@ -12,32 +12,44 @@
 
   0. reconcile against Shadow's FINAL authoritative compile schedule — every
      CLJS source actually compiled THIS pass is pre-touched too. Membership is
-     read from re-frame.ui's OWN per-pass provenance marker, never output-map
-     identity, never Shadow's `:js` object identity, and never a wall-clock stamp
-     relationship. At `:compile-prepare` re-frame.ui stamps an opaque per-pass
-     token onto every retained output MAP Shadow handed it. Shadow's compile
-     path (`do-compile-cljs-resource`) builds a FRESH output map for a
-     (re)compiled source, dropping the marker; a later non-scheduling hook that
-     merely annotates or transforms a retained output (assoc/update-in —
-     INCLUDING replacing only `[:output rid :js]` with a fresh equal-byte
-     string) PRESERVES the marker. So a source was (re)compiled THIS pass iff its
-     finish output LACKS the current pass token; `:cached true` then distinguishes
-     a disk-cache load (no macro rerun) from a fresh compile. Keying on
-     re-frame.ui's own marker — not on the identity of Shadow's `:js` artifact —
-     is immune to the ordinary output-transforming shape (a retained output whose
+     TOTAL (every CLJS graph member is reconciled; a missing/nil/non-map final
+     output fails loud, never silently skipped) and UNFORGEABLE by an output-map
+     replacement. It is decided by re-frame.ui's OWN per-pass provenance marker
+     corroborated, for a marker-absent replaced map, by Shadow's OWN causal
+     compile record — never output-map identity, never Shadow's `:js` object
+     identity, and never a wall-clock stamp relationship of re-frame.ui's own. At
+     `:compile-prepare` re-frame.ui stamps an opaque per-pass token onto every
+     retained output MAP Shadow handed it. Shadow's compile path
+     (`do-compile-cljs-resource`) builds a FRESH output map for a (re)compiled
+     source, dropping the marker; a later non-scheduling hook that merely
+     annotates or transforms a retained output (assoc/update-in — INCLUDING
+     replacing only `[:output rid :js]` with a fresh equal-byte string) PRESERVES
+     the marker. So a source that still carries the current pass token is
+     unforgeably RETAINED (a replacement cannot forge the private token). A
+     marker-ABSENT output means the whole map was replaced: re-frame.ui then reads
+     Shadow's own `[:shadow.build/build-info :compiled]` record — populated after
+     the compile phase, outside the `[:output rid]` map a replacement controls —
+     to tell a genuine COMPILER replacement (a real compile) from a non-scheduling
+     HOOK replacement. When Shadow did NOT compile it, `:cached true` is a
+     legitimate disk-cache load and `:cached false` is a whole-map replacement
+     that dropped the marker without any compile — the latter CANNOT masquerade as
+     compilation and fails loud rather than evict a valid accepted view. Keying on
+     re-frame.ui's own marker plus Shadow's compile record — not on the identity of
+     Shadow's `:js` artifact and not on the forgeable `:cached` field alone — is
+     immune to the ordinary output-transforming shape (a retained output whose
      `:js` is swapped for a fresh, even byte-identical, String by a non-scheduling
      hook) that a raw `:js`-identity test misreads as a recompile and so evicts an
-     untouched accepted view; and — reading provenance rather than comparing
-     `:compiled-at` milliseconds — immune to the same-/backwards-millisecond stamp
-     a `>` test misreads as untouched (leaving a ghost accepted view). A later
-     `:compile-prepare` hook (Shadow deep-merges build-local hooks after
-     `:build-defaults` and lets them mutate build state) can force a source to
-     recompile AFTER re-frame.ui observed the schedule; reading the finish-time
-     marker, not the intermediate prepare schedule, closes that hook-order gap so
-     a forced recompile that removed a source's final `ui/defview` evicts its
-     accepted row instead of leaving a ghost view. Missing, malformed, or
-     contradictory per-source provenance fails loudly before any candidate is
-     published, never silently treated as untouched;
+     untouched accepted view; and — never comparing `:compiled-at` milliseconds
+     itself — immune to the same-/backwards-millisecond stamp a `>` test misreads
+     as untouched (leaving a ghost accepted view). A later `:compile-prepare` hook
+     (Shadow deep-merges build-local hooks after `:build-defaults` and lets them
+     mutate build state) can force a source to recompile AFTER re-frame.ui observed
+     the schedule; reading the finish-time marker and Shadow's compile record, not
+     the intermediate prepare schedule, closes that hook-order gap so a forced
+     recompile that removed a source's final `ui/defview` evicts its accepted row
+     instead of leaving a ghost view. Missing, malformed, or contradictory
+     per-source provenance fails loudly before any candidate is published, never
+     silently treated as untouched;
   1. derive the candidate finalized slice (commit staged sources, evict sources
      absent from authoritative membership) and its whole-build digest;
   2. purely validate and project that digest into exactly one compiled
@@ -92,6 +104,22 @@
   output MAP only and is never emitted into any bundle."
   ::pass-marker)
 
+(def ^:private shadow-compiled-path
+  "Shadow's OWN causal per-pass compile record. `shadow.build/compile` populates
+  `[:shadow.build/build-info :compiled]` (a set of resource-ids) via
+  `update-build-info-after-compile` AFTER the compile phase and BEFORE the
+  `:compile-finish` hooks run, so it is authoritative and present when this hook
+  reads it. It is the causal fact re-frame.ui consults to decide, for a
+  marker-ABSENT output, whether Shadow's COMPILER replaced the whole output map
+  (a genuine compile) or a non-scheduling HOOK did (a replacement that must not
+  masquerade as compilation). Reading Shadow's record — not the forgeable
+  `:cached` field carried by the output map re-frame.ui is classifying, and not
+  any `:compiled-at` wall-clock relationship of re-frame.ui's own — is what makes
+  the marker-absent verdict unforgeable by an output-map replacement: the record
+  lives outside the `[:output rid]` map, so reconstructing that map cannot reach
+  or set it."
+  [:shadow.build/build-info :compiled])
+
 (defn- member-nss
   "Authoritative declaring namespaces from Shadow's resolved build graph."
   [{:keys [build-sources sources]}]
@@ -131,66 +159,58 @@
      #{}
      build-sources)))
 
-(defn- compiled-this-pass?
-  "Whether Shadow (re)compiled `final-output`'s source THIS pass, decided by
-  re-frame.ui's OWN per-pass provenance marker — never Shadow's `:js` object
-  identity and never a wall-clock stamp.
+(defn- compile-verdict
+  "Classify one CLJS `final-output`'s per-pass provenance. A PURE classifier
+  returning a keyword; the caller (`actually-recompiled-member-nss`) turns a
+  fail-loud verdict into a typed error carrying full per-resource context.
 
-  At `:compile-prepare` re-frame.ui stamped `pass-token` onto every retained
-  output MAP (see `stamp-retained-outputs`). Shadow's compile path
-  (`do-compile-cljs-resource`, the sole producer of a freshly compiled output)
-  builds a FRESH output map, so a real recompile's finish output LACKS the
-  marker. A warm cache HIT keeps its stamped map. A later non-scheduling
-  `:compile-prepare` hook that annotates or transforms a retained output
-  (assoc/update-in — INCLUDING replacing only `[:output rid :js]` with a fresh,
-  even byte-identical, String) PRESERVES the marker, because assoc keeps every
-  other key. A disk-cache load also lacks the marker but is `:cached true`.
+    :compiled  — Shadow (re)compiled this source THIS pass;
+    :retained  — a warm hit / marker-preserving metadata-or-`:js` transform /
+                 disk-cache load; NOT compiled this pass;
 
-  So, checking the marker FIRST (it is authoritative over `:cached`, which is
-  sticky on retained outputs):
+  or a fail-loud reason keyword (`:stale-provenance-marker`,
+  `:marker-dropped-without-compile`, `:unmarked-output-missing-cached-flag`).
 
-  - marker == the current pass token  -> RETAINED (warm hit / metadata
-    annotation / a non-scheduling `:js` transform); NOT compiled this pass;
-  - marker absent + `:cached false`   -> a fresh compile this pass;
-  - marker absent + `:cached true`    -> a disk-cache load; NOT compiled;
-  - marker absent + `:cached` neither `true` nor `false`, OR a marker that is
-    PRESENT but is NOT the current pass token -> missing/contradictory
-    per-source provenance: fails loudly rather than being silently classified
-    as untouched (rf2-ialoij's missing/ambiguous-evidence criterion).
+  Two facts decide it, in order, and NEITHER is a `:js` object identity or a
+  `:compiled-at` wall-clock relationship:
 
-  No branch is `>`, `>=`, `!=`, or any relationship on the `:compiled-at` wall
-  clock, so a genuine EQUAL-stamp or BACKWARDS-stamp recompile (same-millisecond
-  `System/currentTimeMillis`, clock skew, a non-monotonic clock) is still
-  classified as a recompile, while an ordinary output transform and a warm cache
-  hit are never misread as one."
-  [final-output pass-token]
+  1. re-frame.ui's OWN per-pass MARKER. At `:compile-prepare` re-frame.ui stamped
+     `pass-token` onto every retained output MAP (see `stamp-retained-outputs`).
+     A warm hit keeps it; a non-scheduling assoc/update-in on a retained output
+     (INCLUDING replacing only `[:output rid :js]` with a fresh, even
+     byte-identical, String) PRESERVES it; Shadow's compile path AND an
+     uncooperative whole-map replacement both DROP it. So marker present and
+     equal to `pass-token` is unforgeably RETAINED (a replacement cannot forge
+     the private token). A marker present but NOT equal to the token is a stale
+     cross-pass artefact and fails loud.
+
+  2. For a marker-ABSENT output — where the whole map was replaced — Shadow's OWN
+     causal compile record `shadow-compiled?` (this resource's membership in
+     `[:shadow.build/build-info :compiled]`, computed by Shadow after the compile
+     phase). It distinguishes a genuine COMPILER replacement (`:compiled`) from a
+     non-scheduling HOOK replacement, WITHOUT trusting the output map's forgeable
+     `:cached` field to conclude compilation. When Shadow did NOT compile it:
+     `:cached true` is a legitimate disk-cache load (RETAINED); `:cached false`
+     is a whole-map replacement that dropped the marker without any Shadow
+     compile — it cannot be silently treated as a compile and fails loud
+     (`:marker-dropped-without-compile`); any other `:cached` value is
+     unusable evidence and fails loud.
+
+  Because the marker gate is checked before the compile record, a genuine
+  EQUAL-stamp or BACKWARDS-stamp recompile is still classified `:compiled` (it
+  dropped the marker AND is in Shadow's record); re-frame.ui itself never
+  compares `:compiled-at`."
+  [final-output pass-token shadow-compiled?]
   (let [marker (get final-output compile-marker-key ::unmarked)]
     (cond
-      (= marker pass-token) false
-
-      (= marker ::unmarked)
-      (case (:cached final-output)
-        false true
-        true  false
-        (throw
-         (ex-info
-          (str "re-frame.ui compile-finish found a CLJS output with no per-pass "
-               "provenance marker and no usable Shadow :cached flag; refusing to "
-               "guess whether it was compiled this pass")
-          {::error ::ambiguous-compile-evidence
-           :reason :unmarked-output-missing-cached-flag
-           :cached (:cached final-output)
-           :recovery :configure-ui-build-hook-once})))
-
+      (= marker pass-token)    :retained
+      (not= marker ::unmarked) :stale-provenance-marker
+      shadow-compiled?         :compiled
       :else
-      (throw
-       (ex-info
-        (str "re-frame.ui compile-finish found a CLJS output carrying a STALE "
-             "per-pass provenance marker (not this pass's token); refusing to "
-             "guess whether it was compiled this pass")
-        {::error ::ambiguous-compile-evidence
-         :reason :stale-provenance-marker
-         :recovery :configure-ui-build-hook-once})))))
+      (case (:cached final-output)
+        true  :retained                        ; disk-cache load: replaced map, not compiled
+        false :marker-dropped-without-compile   ; non-scheduling whole-map replacement
+        :unmarked-output-missing-cached-flag))))
 
 (defn- stamp-retained-outputs
   "Stamp re-frame.ui's opaque per-pass provenance `pass-token` onto every
@@ -214,32 +234,98 @@
 (defn- actually-recompiled-member-nss
   "Declaring namespaces of every CLJS source Shadow ACTUALLY (re)compiled in
   THIS pass, read from the FINAL build-state at `:compile-finish` — after every
-  schedule-mutating `:compile-prepare` hook and after compilation ran —
-  distinguished by re-frame.ui's OWN per-pass provenance marker, never output-map
-  identity, never Shadow's `:js` object identity, and never a wall-clock stamp.
+  schedule-mutating `:compile-prepare` hook and after compilation ran.
 
-  `pass-token` is the opaque token re-frame.ui stamped onto every retained output
-  map at `:compile-prepare` (see `stamp-retained-outputs`). See
-  `compiled-this-pass?`: a source counts as recompiled iff its finish output
-  LACKS that token (Shadow replaced the whole map) and is not a `:cached true`
-  disk load. This is immune to a later hook annotating or transforming a retained
-  output's map — INCLUDING replacing only its `:js` with a fresh equal-byte
-  string — which a raw `:js`-identity test misread as a recompile and so evicted
-  an untouched accepted view; to a same- or backwards-millisecond compile stamp
-  (which a `>`/`>=` stamp test misreads as untouched, leaving a ghost accepted
-  view); and to the build-local hook merge order re-frame.ui cannot control."
-  [{:keys [build-sources sources output]} pass-token]
-  (reduce
-   (fn [acc resource-id]
-     (let [{:keys [type ns provides]} (get sources resource-id)
-           final-output (get output resource-id)]
-       (if (and (= :cljs type)
-                (some? final-output)
-                (compiled-this-pass? final-output pass-token))
-         (into acc (or provides (when ns #{ns})))
-         acc)))
-   #{}
-   build-sources))
+  Provenance is TOTAL: EVERY CLJS member of the authoritative build graph is
+  reconciled. A missing, nil, non-map, or otherwise unusable final output is
+  never silently skipped (which would let an accepted row survive with no
+  per-resource evidence); it throws a typed compiler error naming the build id,
+  resource id, declaring namespace/provides, reason, and recovery before any
+  candidate is derived.
+
+  Provenance is UNFORGEABLE by an output-map replacement: a member counts as
+  recompiled per `compile-verdict`, which gates FIRST on re-frame.ui's own
+  per-pass marker (unforgeable RETAINED) and, only for a marker-absent replaced
+  map, on Shadow's OWN causal compile record (`shadow-compiled-path`) rather than
+  the output map's forgeable `:cached` field. A whole-map replacement that drops
+  the marker without a corresponding Shadow compile cannot masquerade as
+  compilation — it fails loud. This remains immune to a `:js`-object-identity
+  misread and to same-/backwards-millisecond compile stamps (re-frame.ui compares
+  no `:compiled-at`)."
+  [{:keys [build-sources sources output] :as build-state} pass-token]
+  (let [build-id (:shadow.build/build-id build-state)
+        compiled (set (get-in build-state shadow-compiled-path))]
+    (reduce
+     (fn [acc resource-id]
+       (let [{:keys [type ns provides]} (get sources resource-id)]
+         (if (not= :cljs type)
+           acc
+           (let [final-output (get output resource-id)]
+             (if-not (map? final-output)
+               (throw
+                (ex-info
+                 (str "re-frame.ui compile-finish found CLJS build member "
+                      resource-id " (" (or ns provides) ") with no usable final "
+                      "output map; refusing to publish an accepted candidate while "
+                      "a graph member's per-resource compile evidence is absent")
+                 {::error ::missing-compile-output
+                  :build-id build-id
+                  :resource-id resource-id
+                  :ns ns
+                  :provides provides
+                  :reason :absent-or-non-map-final-output
+                  :final-output final-output
+                  :recovery :ensure-shadow-output-for-cljs-member}))
+               (case (compile-verdict final-output pass-token
+                                      (contains? compiled resource-id))
+                 :compiled (into acc (or provides (when ns #{ns})))
+                 :retained acc
+                 :stale-provenance-marker
+                 (throw
+                  (ex-info
+                   (str "re-frame.ui compile-finish found CLJS build member "
+                        resource-id " carrying a STALE per-pass provenance marker "
+                        "(not this pass's token); refusing to guess whether it was "
+                        "compiled this pass")
+                   {::error ::ambiguous-compile-evidence
+                    :build-id build-id
+                    :resource-id resource-id
+                    :ns ns
+                    :provides provides
+                    :reason :stale-provenance-marker
+                    :recovery :preserve-ui-pass-marker-or-remove-output-to-schedule}))
+                 :marker-dropped-without-compile
+                 (throw
+                  (ex-info
+                   (str "re-frame.ui compile-finish found CLJS build member "
+                        resource-id " whose retained output map was REPLACED "
+                        "(re-frame.ui's per-pass marker was dropped) although "
+                        "Shadow did not compile it this pass; a non-scheduling "
+                        "whole-map replacement cannot count as compilation")
+                   {::error ::ambiguous-compile-evidence
+                    :build-id build-id
+                    :resource-id resource-id
+                    :ns ns
+                    :provides provides
+                    :reason :marker-dropped-without-compile
+                    :recovery :preserve-ui-pass-marker-or-remove-output-to-schedule}))
+                 :unmarked-output-missing-cached-flag
+                 (throw
+                  (ex-info
+                   (str "re-frame.ui compile-finish found CLJS build member "
+                        resource-id " with no per-pass provenance marker and no "
+                        "usable Shadow :cached flag; refusing to guess whether it "
+                        "was compiled this pass")
+                   {::error ::ambiguous-compile-evidence
+                    :build-id build-id
+                    :resource-id resource-id
+                    :ns ns
+                    :provides provides
+                    :reason :unmarked-output-missing-cached-flag
+                    :cached (:cached final-output)
+                    :recovery :preserve-ui-pass-marker-or-remove-output-to-schedule}))))))))
+     #{}
+     build-sources)))
 
 (defn- reconcile-final-schedule
   "Before deriving the finish candidate, pre-touch every source Shadow actually

--- a/implementation/ui/test/re_frame/ui/compiler_build_hook_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_hook_jvm_test.clj
@@ -81,8 +81,24 @@
        (with-meta (list 'defview vname {:id view-id} [] template) {:line 1})
        {} vname (list {:id view-id} [] template)))))
 
-(defn- finish [state member-nss]
-  (build-hook/hook (at-stage state :compile-finish member-nss)))
+(defn- finish
+  ([state member-nss] (finish state member-nss (set member-nss)))
+  ([state member-nss recompiled-nss]
+   ;; Model Shadow's real compile phase: every source Shadow (re)compiled this
+   ;; pass gets a FRESH output map (marker-absent, `:cached false`) and is
+   ;; recorded in Shadow's OWN `[:shadow.build/build-info :compiled]` set. Warm
+   ;; cache-hit members keep the marker-stamped output prepare left them. This is
+   ;; what a real build hands `:compile-finish`; the prior helper unrealistically
+   ;; left recompiled members with NO output at finish.
+   (let [recompiled-nss (set recompiled-nss)
+         with-outputs (reduce (fn [s n]
+                                (assoc-in s [:output n]
+                                          {:resource-id n :js "compiled"
+                                           :cached false}))
+                              state recompiled-nss)]
+     (build-hook/hook
+      (-> (at-stage with-outputs :compile-finish member-nss)
+          (assoc-in [:shadow.build/build-info :compiled] recompiled-nss))))))
 
 (defn- pass
   ([state member-nss declarations]
@@ -92,7 +108,7 @@
         compiled (reduce (fn [s [source id fp]]
                            (declare-view s source id fp))
                          prepared declarations)]
-    (finish compiled member-nss))))
+    (finish compiled member-nss recompiled-nss))))
 
 (defn- views [state]
   (build/accepted-aggregate build/views state))

--- a/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
@@ -85,8 +85,39 @@
     (assoc state :compiler-env
            (dissoc @compiler :shadow.build.cljs-bridge/state))))
 
-(defn- finish [state]
-  (build-hook/hook (assoc state :shadow.build/stage :compile-finish)))
+(defn- compiled-output
+  "A FRESH Shadow-shaped compiled output map: marker-absent, `:cached false`.
+  Modelling `do-compile-cljs-resource`, which replaces the whole output map."
+  [rid js]
+  {:resource-id rid :js js :cached false})
+
+(defn- finish
+  "Drive `:compile-finish`. Models Shadow's real compile phase: every CLJS build
+  member whose output is ABSENT (Shadow scheduled it — e.g. a version-0 UI
+  consumer whose retained output prepare invalidated) is given a FRESH compiled
+  output map and recorded in Shadow's OWN `[:shadow.build/build-info :compiled]`
+  set. Members that already carry an output keep it (a warm hit's marker-stamped
+  map, or a map the test set to model a recompile / a hook replacement); such a
+  test names its own recompiled members via `extra-compiled`. The prior helper
+  left version-0-invalidated consumers with NO finish output, which real Shadow
+  never does."
+  ([state] (finish state #{}))
+  ([state extra-compiled]
+   (let [cljs-members (filter #(= :cljs (get-in state [:sources % :type]))
+                              (:build-sources state))
+         scheduled (into (set extra-compiled)
+                         (remove #(map? (get-in state [:output %])))
+                         cljs-members)
+         state (reduce (fn [s rid]
+                         (cond-> s
+                           (not (map? (get-in s [:output rid])))
+                           (assoc-in [:output rid]
+                                     (compiled-output rid "compiled"))))
+                       state scheduled)
+         ;; Shadow RESETS `:compiled` every pass (extract-build-info recomputes
+         ;; it), so set — never accumulate — this pass's compiled set.
+         state (assoc-in state [:shadow.build/build-info :compiled] scheduled)]
+     (build-hook/hook (assoc state :shadow.build/stage :compile-finish)))))
 
 (deftest ui-build-requires-the-load-bearing-cache-blocker
   (doseq [configured [nil [] '#{other.library}]]
@@ -140,8 +171,8 @@
     (is (= (count sentinel) (count digest)))
     (is (not (str/includes? js sentinel)))
     (is (= 1 (count (re-seq (re-pattern digest) js))))
-    (is (nil? (get-in out [:output app-rid]))
-        "version-zero prepare invalidates retained UI-consumer output before Shadow recompiles it")
+    (is (false? (:cached (get-in out [:output app-rid])))
+        "version-zero prepare invalidated the retained UI-consumer output; Shadow recompiled it fresh (:cached false), not a warm-cache hit")
     (is (= (:build-modules input) (:build-modules out)))
     (is (= {:app/view ["tf1-a" "hs1-a"]}
            (build/accepted-aggregate build/views out)))
@@ -275,7 +306,9 @@
                                      {:resource-id app-a-rid
                                       :js (fresh-js "app.a = {};")
                                       :compiled-at 1000 :cached false})
-                           finish)]
+                           ;; Shadow genuinely recompiled app-a this pass, so it is
+                           ;; in Shadow's causal `::build-info :compiled` record.
+                           (finish #{app-a-rid}))]
           (is (not (contains?
                     (get-in prepared [:compiler-env build/scratch-key :touched])
                     'app.a))
@@ -337,7 +370,10 @@
                                      {:resource-id app-a-rid
                                       :js (fresh-js "app.a = {};")
                                       :compiled-at 1 :cached false})
-                           finish)
+                           ;; app-a genuinely recompiled (backwards stamp) — in
+                           ;; Shadow's causal `::build-info :compiled` record; app-b
+                           ;; is a warm hit (marker preserved), never in it.
+                           (finish #{app-a-rid}))
               views-after (build/accepted-aggregate build/views finished)]
           (is (not (contains?
                     (get-in prepared [:compiler-env build/scratch-key :touched])
@@ -425,19 +461,19 @@
 
       (testing (str mode " — companion: app.b output removed and recompiled")
         ;; Same stamp (1000), opposite verdict: the later hook instead REMOVES
-        ;; app.b's output and app.b genuinely recompiles — a FRESH `:js` object at
+        ;; app.b's output and app.b genuinely recompiles — a FRESH output map at
         ;; the SAME `:compiled-at` — after its final defview was removed,
-        ;; contributing nothing. app.b is evicted; app.a stays a cache hit. Whole-
-        ;; map identity would have flagged BOTH arms' app.b as recompiled and a
-        ;; stamp test would have missed this same-ms recompile; the fresh-`:js`
-        ;; evidence distinguishes them.
+        ;; contributing nothing. app.b is evicted; app.a stays a cache hit. The
+        ;; marker (dropped by the whole-map replacement) plus Shadow's causal
+        ;; `::build-info :compiled` record distinguish this genuine recompile from
+        ;; arm 1's marker-preserving annotation — with no `:compiled-at` compare.
         (let [prepared (prepare warm-input)
               finished (-> prepared
                            (assoc-in [:output app-b-rid]
                                      {:resource-id app-b-rid
                                       :js (fresh-js "app.b = {};")
                                       :compiled-at 1000 :cached false})
-                           finish)]
+                           (finish #{app-b-rid}))]
           (is (= {:app/a-view ["tfa-1" "hsa-1"]}
                  (build/accepted-aggregate build/views finished))
               "the genuinely recompiled zero-declaration source is evicted")
@@ -564,6 +600,109 @@
         (is (= :re-frame.ui.compiler.build-hook/ambiguous-compile-evidence
                (:re-frame.ui.compiler.build-hook/error (ex-data ex))))
         (is (= :stale-provenance-marker (:reason (ex-data ex))))))))
+
+(deftest whole-map-replacement-cannot-forge-compilation
+  ;; rf2-8nn5k (violation 2 — UNFORGEABLE): a later NON-scheduling hook replaces an
+  ;; ENTIRE retained output map, copying Shadow's sticky `:cached false` and output
+  ;; data into a fresh map while dropping re-frame.ui's unknown private marker — and
+  ;; schedules NO compilation, so the source is NOT in Shadow's own
+  ;; `[:shadow.build/build-info :compiled]` record. Pre-fix, finish trusted the
+  ;; output map's forgeable `:cached false` and classified the replacement a compile,
+  ;; pre-touched the warm source, and EVICTED its valid accepted view (changing the
+  ;; whole-build digest) on a pass that compiled nothing. Now the marker-absent
+  ;; verdict consults Shadow's causal compile record rather than `:cached`, so the
+  ;; forged whole-map replacement fails loud BEFORE publication and the accepted
+  ;; view/digest survive. Both equal-byte and changed-byte forgeries; both schedules.
+  (doseq [parallel? [true false]
+          [byte-label forged-js] [[:equal-bytes "app.b = {};"]
+                                  [:changed-bytes "app.b = {/* forged */};"]]]
+    (testing (str (if parallel? "parallel" "sequential") " / " (name byte-label))
+      (let [build-id (keyword "forge" (str (name byte-label) (if parallel? "-p" "-s")))
+            good (-> (two-source-state build-id parallel?)
+                     prepare
+                     (declare 'app.a :app/a-view ["tfa-1" "hsa-1"])
+                     (declare 'app.b :app/b-view ["tfb-1" "hsb-1"])
+                     finish)
+            digest-before (build/accepted-build-digest good)
+            views-before  (build/accepted-aggregate build/views good)
+            warm-a {:resource-id app-a-rid :js (fresh-js "app.a = {};")
+                    :compiled-at 1000 :cached false}
+            warm-b {:resource-id app-b-rid :js (fresh-js "app.b = {};")
+                    :compiled-at 1000 :cached false}
+            warm-input (-> good
+                           (assoc-in [:output carrier-rid :js]
+                                     build-hook/digest-sentinel)
+                           (assoc-in [:output app-a-rid] warm-a)
+                           (assoc-in [:output app-b-rid] warm-b))
+            prepared (prepare warm-input)
+            ;; The forgery: a fresh output MAP built from Shadow's public fields
+            ;; (no re-frame.ui marker), copying the sticky :cached false. `finish`
+            ;; is NOT told app.b compiled (it is not in ::build-info :compiled).
+            forged-b {:resource-id app-b-rid :js (fresh-js forged-js)
+                      :compiled-at 1000 :cached false}
+            ex (try (-> prepared (assoc-in [:output app-b-rid] forged-b) finish)
+                    nil
+                    (catch clojure.lang.ExceptionInfo e e))]
+        (is (false? (:cached forged-b))
+            "the forgery copies Shadow's sticky :cached false")
+        (is (nil? (get forged-b :re-frame.ui.compiler.build-hook/pass-marker))
+            "and drops re-frame.ui's private per-pass marker")
+        (is (some? ex)
+            "a whole-map replacement Shadow did not compile cannot be silently classified as a compile")
+        (is (= :re-frame.ui.compiler.build-hook/ambiguous-compile-evidence
+               (:re-frame.ui.compiler.build-hook/error (ex-data ex))))
+        (is (= :marker-dropped-without-compile (:reason (ex-data ex))))
+        (is (= app-b-rid (:resource-id (ex-data ex)))
+            "the diagnostic names the offending resource, not just the hook")
+        (is (= 'app.b (:ns (ex-data ex))))
+        (is (= build-id (:build-id (ex-data ex))))
+        (is (not= :configure-ui-build-hook-once (:recovery (ex-data ex)))
+            "a later-hook evidence loss reports an accurate recovery, not hook-config boilerplate")
+        (is (= views-before (build/accepted-aggregate build/views warm-input))
+            "the forged replacement never evicted app.b's valid accepted view")
+        (is (= digest-before (build/accepted-build-digest warm-input))
+            "the whole-build digest is unchanged")))))
+
+(deftest absent-cljs-member-output-fails-loud-not-silent
+  ;; rf2-8nn5k (violation 1 — TOTAL): a CLJS graph member with a missing/nil/non-map
+  ;; final output must fail loud, naming the resource, rather than be silently
+  ;; skipped — pre-fix, a missing `[:output rid]` was skipped, so an accepted
+  ;; row/digest could publish with the member's per-resource compile evidence absent.
+  ;; Bypasses the realistic `finish` helper (which would repopulate an absent output)
+  ;; to drive the guard directly, modelling a hook that drops/corrupts an output.
+  (doseq [parallel? [true false]
+          [label bad] [[:absent ::absent] [:non-map "not-a-map"]]]
+    (testing (str (if parallel? "parallel" "sequential") " / " (name label))
+      (let [good (-> (two-source-state (keyword "total" (name label)) parallel?)
+                     prepare
+                     (declare 'app.a :app/a-view ["tfa-1" "hsa-1"])
+                     (declare 'app.b :app/b-view ["tfb-1" "hsb-1"])
+                     finish)
+            views-before (build/accepted-aggregate build/views good)
+            warm-a {:resource-id app-a-rid :js (fresh-js "app.a = {};")
+                    :compiled-at 1000 :cached false}
+            warm-b {:resource-id app-b-rid :js (fresh-js "app.b = {};")
+                    :compiled-at 1000 :cached false}
+            warm-input (-> good
+                           (assoc-in [:output carrier-rid :js]
+                                     build-hook/digest-sentinel)
+                           (assoc-in [:output app-a-rid] warm-a)
+                           (assoc-in [:output app-b-rid] warm-b))
+            prepared (prepare warm-input)
+            broken (cond-> (assoc prepared :shadow.build/stage :compile-finish)
+                     (= bad ::absent) (update :output dissoc app-b-rid)
+                     (not= bad ::absent) (assoc-in [:output app-b-rid] bad))
+            ex (try (build-hook/hook broken) nil
+                    (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? ex)
+            "a missing/non-map CLJS member output must fail loud, never be skipped")
+        (is (= :re-frame.ui.compiler.build-hook/missing-compile-output
+               (:re-frame.ui.compiler.build-hook/error (ex-data ex))))
+        (is (= app-b-rid (:resource-id (ex-data ex))))
+        (is (= 'app.b (:ns (ex-data ex))))
+        (is (= :absent-or-non-map-final-output (:reason (ex-data ex))))
+        (is (= views-before (build/accepted-aggregate build/views warm-input))
+            "the accepted view aggregate is left last-known-good on the fail-loud path")))))
 
 (deftest interleaved-build-values-carry-isolated-digests
   (let [a (-> (shadow-state :a build-hook/digest-sentinel)

--- a/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/hook.clj
+++ b/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/hook.clj
@@ -42,6 +42,7 @@
   (io/file "../../../../../../target" "ui-final-schedule"))
 (def ^:private force-marker (io/file out-dir "force-recompile-app-a"))
 (def ^:private blind-marker (io/file out-dir "blind-provenance"))
+(def ^:private forge-marker (io/file out-dir "forge-app-a-output"))
 
 (def ^:private app-a-ns 're-frame.ui.digest-probe.final-schedule.app-a)
 (def ^:private a-view-id :re-frame.ui.digest-probe.final-schedule.app-a/a-view)
@@ -70,13 +71,15 @@
           scratch (get-in build-state [:compiler-env build/scratch-key])
           touched (:touched scratch)
           force?  (.exists force-marker)
-          blind?  (.exists blind-marker)]
+          blind?  (.exists blind-marker)
+          forge?  (.exists forge-marker)]
       (record! build-id
                {:stage :prepare
                 :app-a-output-present (some? (get-in build-state [:output rid]))
                 :app-a-pretouched (boolean (contains? (set touched) app-a-ns))
                 :force force?
-                :blind blind?})
+                :blind blind?
+                :forge forge?})
       (cond-> build-state
         ;; A later prepare hook forcing a viewless recompile of an output-present
         ;; cache-hit source: remove its output AND remove its final ui/defview.
@@ -86,6 +89,20 @@
                       (str "(ns " app-a-ns
                            " (:require [re-frame.ui :as ui]))\n"
                            ";; final-schedule fixture: viewless forced recompile\n")))
+
+        ;; A later NON-scheduling hook that REPLACES app-a's whole retained output
+        ;; map, rebuilt from Shadow's PUBLIC fields (dropping re-frame.ui's private
+        ;; marker) and copying the sticky :cached false, WITHOUT removing it — so
+        ;; Shadow does not reschedule it and app-a is absent from Shadow's OWN
+        ;; ::build-info :compiled record. This is the "unforgeable by output-map
+        ;; replacement" adversary: :compile-finish must FAIL LOUD rather than trust
+        ;; the forged :cached false and evict app-a's valid accepted view.
+        (and rid forge?)
+        (assoc-in [:output rid]
+                  (-> (get-in build-state [:output rid])
+                      (select-keys [:resource-id :js :source-map-compact
+                                    :compiled-at :warnings :cached])
+                      (assoc :cached false)))
 
         ;; A later hook that destroys the per-pass provenance re-frame.ui needs to
         ;; reconcile: drop the :pass-token from the open scratch.


### PR DESCRIPTION
## What & why

PR #6198 replaced Shadow `:js` object identity with a private per-pass compile marker, but the post-merge audit (rf2-mlymc) found **two finish-time states still violating the closed-provenance invariant**. This closes both at the existing marker seam — no provenance redesign.

### Violation 1 — provenance was not TOTAL
`actually-recompiled-member-nss` invoked the classifier only when a CLJS build member had a non-nil final output; a missing/nil/non-map `[:output resource-id]` was **silently skipped**, so an accepted row/digest could publish even though that member's per-resource compile evidence was absent.

**Fix:** every CLJS member of the authoritative graph is reconciled. A missing/nil/non-map final output throws a typed `::missing-compile-output` error — naming build id, resource id, declaring ns/provides, reason, and recovery — before candidate derivation.

### Violation 2 — provenance was FORGEABLE by an output-map replacement
For a marker-absent (whole-map-replaced) output, the classifier trusted the output map's own sticky `:cached false` to conclude "compiled". A later non-scheduling hook that rebuilds a retained output map from Shadow's public fields (dropping re-frame.ui's unknown private marker, copying `:cached false`, scheduling **no** compilation) was misclassified as a compile → it pre-touched the warm source and **evicted a valid accepted view**, moving the digest on a pass that compiled nothing.

**Fix:** a marker-absent output now consults Shadow's OWN causal compile record `[:shadow.build/build-info :compiled]` (populated by `update-build-info-after-compile` after the compile phase and before `:compile-finish` hooks, and living **outside** the `[:output rid]` map a replacement controls) to distinguish a genuine COMPILER replacement from a HOOK replacement. A whole-map replacement Shadow did not compile fails loud (`:marker-dropped-without-compile`) instead of evicting. re-frame.ui itself compares no `:compiled-at` wall clock — the marker gate stays authoritative for warm hits, so equal-/backwards-millisecond genuine recompiles are still evicted.

`compiled-this-pass?` becomes the pure `compile-verdict` classifier; the caller raises the typed, context-rich errors (a later-hook evidence loss no longer reports only `:configure-ui-build-hook-once`).

### Scope / coordination
Confined to `build.cljc`'s consumer `build_hook.clj` (+ its tests) and the final-schedule real-Shadow fixture. **No** touch to `emit_cljs.cljc` / `rules.cljc` / `analyze.cljc` (xdvob's live files), the presence runtime, core, spec, or tools. Provenance is JVM build-time only (`.clj`) — no host-parity surface.

## Quality gates

- **`implementation/ui` JVM (`clojure -M:test`)** — 788 tests, 14482 assertions, 0 failures. Includes the two updated provenance suites + two new adversarial deftests.
- **`npm run test:cljs`** — 9923 tests, 48872 assertions, 0 failures.
- **`npm run test:ui-final-schedule`** (real Shadow 3.4.10 watch, parallel + sequential) — **PASS**. New `forge` arm proves the fix end-to-end: a non-scheduling whole-map replacement of a retained output fails the build before publication; the existing forced-evict (genuine recompile still in Shadow's real `::build-info :compiled` → evicted) and blind-provenance fail-loud arms remain green.
- **`npm run test:ui-digest-carrier`** — environmental timeout: the browser-test build hung during shadow startup/dev-http binding (before any `Compiling`) under concurrent-worker machine load, so the `:compile-finish` path this PR changes was never reached. Not a regression (the diff only touches `:compile-finish`; `test:ui-final-schedule` is the direct real-Shadow proof of that path).

### Red-before / green-after
- Direct probe on current main: `actually-recompiled-member-nss` returned `#{}` for a missing member output and `#{app.b}` (forged "compiled") for a reconstructed unmarked `{:cached false}` map. After the fix both fail loud with typed errors (`::missing-compile-output`, `:marker-dropped-without-compile`).
- Adversarial forge case added at both the synthetic (equal-byte + changed-byte, both schedules) and real-Shadow layers; both fail closed with the accepted view/digest left last-known-good.

rf2-8nn5k
