### PR TITLE
fix(bundle-isolation): complete + fail-closed publishable inventory; pin dedicated coverage binding (rf2-o58c2, rf2-kfn9q)

### DIFF
--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -949,11 +949,21 @@ const NON_BROWSER_OPTIONAL = new Set(['core', 'ssr-ring']);
 // flat implementation/<x> generic gate through a colliding directory leaf. Each
 // value is a MACHINE-READABLE descriptor: `checkers` are the real gate-script
 // filenames under scripts/, and `command` is the package.json script that
-// invokes them. validateDedicatedGate() confirms every checker file EXISTS and
-// that `command` is a real package script whose body INVOKES each checker — so a
-// truthy prose string, a removed checker, or an uninvoked command fails closed.
-// Keep this to the set of EXISTING dedicated gates only — do not add a runtime
-// here without a real, invoked gate script proving its isolation.
+// invokes them. validateDedicatedGate() binds it to the EXACT runtime AND the
+// EXACT executable (rf2-kfn9q):
+//   - every checker file EXISTS under scripts/;
+//   - `command` is a real package script whose body RUNS each checker as a
+//     directly-invoked, reachable `node <checker>` step (echo, comment,
+//     argument-only, name-substring, and unreachable `false &&` mentions do NOT
+//     count as running it); and
+//   - the runtime being covered (the map KEY / relPath) is OWNED by one of the
+//     checkers — it appears in that checker's exported COVERS_RUNTIMES — so an
+//     unrelated existing checker can NOT be reused for a new runtime it never
+//     inspects.
+// A truthy prose string, a removed checker, an uninvoked command, or a checker
+// that does not declare the runtime all fail closed. Keep this to the set of
+// EXISTING dedicated gates only — do not add a runtime here without a real,
+// invoked gate script that declares (in COVERS_RUNTIMES) it isolates that path.
 const DEDICATED_ISOLATION_GATES = {
   'adapters/reagent': {
     checkers: ['check-uix-helix-reagent-free.cjs', 'check-login-bundle-isolation.cjs'],
@@ -990,13 +1000,60 @@ function readPackageScripts(root = ROOT) {
   }
 }
 
+// True iff `body` (a package.json script body, in this repo's bounded
+// `&&`-chained grammar) RUNS `checker` as a DIRECTLY-INVOKED, REACHABLE step: a
+// `node <path>` command whose script argument's basename is EXACTLY the checker.
+// Substring / echo / comment / argument-only mentions, and any step guarded
+// behind a statically-failing `false &&` short-circuit, do NOT count — so a
+// checker's mere textual presence in the body can not launder coverage (rf2-kfn9q).
+//
+// This is a BOUNDED recogniser (split on `&&`, drop trailing `#` comments,
+// tokenise on whitespace), not a general shell parser: it recognises exactly the
+// `program arg…` steps the repo's isolation scripts are written in.
+function commandRunsChecker(body, checker) {
+  for (const rawStep of String(body).split('&&')) {
+    const step = rawStep.split('#')[0].trim();  // drop trailing shell comment
+    if (step === '') continue;
+    const tokens = step.split(/\s+/);
+    // A literal `false` step always fails, so nothing AFTER it in the `&&` chain
+    // runs — a checker sitting behind it is unreachable.
+    if (tokens[0] === 'false') break;
+    if (tokens[0] !== 'node') continue;
+    // node's script argument is its first non-flag operand; only THAT running the
+    // checker counts (checker as a later argument to another script does not).
+    const scriptArg = tokens.slice(1).find((t) => !t.startsWith('-'));
+    if (scriptArg && path.basename(scriptArg) === checker) return true;
+  }
+  return false;
+}
+
+// The implementation-relative runtimes a checker OWNS (its exported
+// COVERS_RUNTIMES), or null if it declares none / can't be loaded. The checker
+// is the source of truth for what it isolates, so a descriptor can not bind a
+// checker to a runtime the checker never inspects (rf2-kfn9q). `require` is safe
+// because the checkers guard their `main()` behind `require.main === module`, so
+// loading one for its contract runs no bundle work.
+function checkerCoversRuntimes(scriptsDir, checker) {
+  let mod;
+  try {
+    mod = require(path.join(scriptsDir, checker));
+  } catch (_e) {
+    return null;
+  }
+  return mod && Array.isArray(mod.COVERS_RUNTIMES) ? mod.COVERS_RUNTIMES : null;
+}
+
 // A dedicated-gate descriptor is CAUSAL only when it is wired to real, invoked
-// machinery. Returns `{ ok, reasons }`: ok iff `gate` is a
-// `{ checkers: [...], command }` map whose every checker file EXISTS in
-// scriptsDir AND whose command is a package.json script whose body INVOKES every
-// checker. A truthy prose string, a nonexistent checker, or an uninvoked/absent
-// command all fail — so enrolment can not be discharged by editing this table.
-function validateDedicatedGate(gate, { scriptsDir = SCRIPTS_DIR, scripts = readPackageScripts() } = {}) {
+// machinery AND bound to the exact runtime it claims to isolate. Returns
+// `{ ok, reasons }`: ok iff `gate` is a `{ checkers: [...], command }` map whose
+// every checker file EXISTS in scriptsDir, whose command is a package.json
+// script whose body RUNS every checker as a directly-invoked reachable step,
+// AND — when a `relPath` is supplied (the runtime it is mapped under) — one of
+// its checkers OWNS that runtime in its COVERS_RUNTIMES. A truthy prose string,
+// a nonexistent checker, an uninvoked/echoed/unreachable command, or an
+// unrelated checker reused for a runtime it does not inspect all fail — so
+// enrolment can not be discharged by editing this table.
+function validateDedicatedGate(gate, { scriptsDir = SCRIPTS_DIR, scripts = readPackageScripts(), relPath = null } = {}) {
   if (!gate || typeof gate !== 'object' || Array.isArray(gate)) {
     return { ok: false, reasons: ['descriptor is not a { checkers, command } map (a prose string does not enrol a runtime)'] };
   }
@@ -1017,10 +1074,25 @@ function validateDedicatedGate(gate, { scriptsDir = SCRIPTS_DIR, scripts = readP
       reasons.push(`declared command is not an invoked package.json script: ${command}`);
     } else {
       for (const checker of checkers) {
-        if (!body.includes(checker)) {
-          reasons.push(`package command '${command}' does not invoke checker: ${checker}`);
+        if (!commandRunsChecker(body, checker)) {
+          reasons.push(`package command '${command}' does not RUN checker '${checker}' ` +
+            'as a directly-invoked reachable step (echo / comment / argument-only / ' +
+            'name-substring / unreachable false-and mentions do not count)');
         }
       }
+    }
+  }
+  // Runtime binding: the descriptor is bound to the EXACT runtime it is mapped
+  // under only when a checker declares (owns) that runtime. This is what stops
+  // the login checker being assigned to a hypothetical adapters/newpub.
+  if (relPath) {
+    const owned = checkers.some((checker) => {
+      const covers = checkerCoversRuntimes(scriptsDir, checker);
+      return Array.isArray(covers) && covers.includes(relPath);
+    });
+    if (!owned) {
+      reasons.push(`no declared checker OWNS the exact runtime '${relPath}' ` +
+        '(a checker must list it in COVERS_RUNTIMES; reusing an unrelated checker does not bind coverage)');
     }
   }
   return { ok: reasons.length === 0, reasons };
@@ -1076,7 +1148,7 @@ function assertCanonicalInventoryCovered(required = discoverBrowserOptionalRunti
       continue;
     }
     const gate = dedicatedGates[rt.relPath];
-    const validation = validateDedicatedGate(gate, { scriptsDir, scripts });
+    const validation = validateDedicatedGate(gate, { scriptsDir, scripts, relPath: rt.relPath });
     if (gate && validation.ok) {
       covered.push({ ...rt, via: 'dedicated', gate });
     } else {

--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -62,7 +62,7 @@ const {
   countSubstring,
 } = require('./lib/read-release-bundle.cjs');
 const { assertSentinelSet } = require('./lib/sentinel-scan.cjs');
-const { pathDeclaresBuildAlias } = require('./lib/publishable-runtimes.cjs');
+const { pathDeclaresBuildAlias, listPublishableRuntimes } = require('./lib/publishable-runtimes.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 const SCRIPTS_DIR = __dirname;
@@ -916,9 +916,12 @@ function assertPositiveControlComplete(artefacts = ARTEFACTS, controls = POSITIV
 //     wiring (validateDedicatedGate), so a fictional prose entry, a removed
 //     checker, or an uninvoked command can NOT enrol a runtime.
 //
-// Traversal mirrors the release lockstep's bounded FLAT-plus-ADAPTERS shape:
-// per-feature + core-tier artefacts live at implementation/<name>/; substrate
-// adapters live one directory deeper at implementation/adapters/<name>/.
+// Discovery CONSUMES the shared authority's listPublishableRuntimes directly
+// (rf2-o58c2) rather than maintaining a second, narrower traversal: the
+// authority's bounded flat-plus-nested walk is the SAME inventory the release
+// lockstep enrols, so a publishable runtime nested OUTSIDE adapters/ can no
+// longer reach release inventory while escaping bundle coverage. Bundle
+// isolation then applies only its explicit browser/JVM exclusions below.
 //
 // Excluded from the REQUIRED set (published, but NOT a browser-optional client
 // runtime — each with reason):
@@ -935,11 +938,10 @@ function assertPositiveControlComplete(artefacts = ARTEFACTS, controls = POSITIV
 // pre-publication stays green NATURALLY; when rf2-vxgfnd.99.2 makes UI
 // publishable, it must land a UI isolation entry/gate in that same slice or this
 // coverage check fails and names `ui`.
+//
+// Keyed by exact implementation-relative PATH (both entries are flat, so path
+// == leaf today) so the exclusion is applied against the authority's relPath.
 const NON_BROWSER_OPTIONAL = new Set(['core', 'ssr-ring']);
-
-// Nested substrate-adapter tier, relative to implementation/ (matches the
-// lockstep authority's implementation/adapters/<name>/ layout).
-const ADAPTERS_DIR = 'adapters';
 
 // Browser-optional runtimes covered by a REAL dedicated isolation gate rather
 // than a generic ARTEFACTS entry. KEYED BY EXACT implementation-relative PATH
@@ -1024,49 +1026,23 @@ function validateDedicatedGate(gate, { scriptsDir = SCRIPTS_DIR, scripts = readP
   return { ok: reasons.length === 0, reasons };
 }
 
-// Discover every publishable browser-optional runtime under implementation/,
-// using the shared EDN-aware authority (`pathDeclaresBuildAlias`, the SAME
-// parsed `:aliases/:clein/build` fact the release lockstep consumes) over the
-// lockstep's bounded flat-plus-adapters traversal. Returns `{ name, relPath }`
-// records; `name` is the directory leaf and `relPath` is the implementation/-
-// relative path — coverage keys on `relPath` so leaf collisions can't launder a
-// runtime through the wrong gate.
+// Discover every publishable browser-optional runtime under implementation/ by
+// CONSUMING the shared authority's listPublishableRuntimes (rf2-o58c2) — the
+// SAME parsed `:aliases/:clein/build` inventory, over the SAME bounded
+// flat-plus-nested reach, that the release lockstep enrols — then dropping the
+// runtimes that are not browser-optional client bundles (the always-present
+// core; the JVM-only servers in NON_BROWSER_OPTIONAL). There is no second
+// traversal to drift from the lockstep: a publishable runtime nested outside
+// adapters/ is enrolled here exactly as it is in release inventory. Read faults
+// propagate (the authority throws, fail-closed) rather than yielding a
+// silently-shrunken set. Returns `{ name, relPath }` records; `name` is the
+// directory leaf and `relPath` the implementation/-relative path — coverage
+// keys on `relPath` so leaf collisions can't launder a runtime through the
+// wrong gate.
 function discoverBrowserOptionalRuntimes(root = ROOT) {
-  const out = [];
-
-  // Flat per-feature + core-tier artefacts: implementation/<name>/deps.edn.
-  let flat;
-  try {
-    flat = fs.readdirSync(root, { withFileTypes: true });
-  } catch (_e) {
-    return out; // implementation/ unreadable — nothing to require (fails safe elsewhere)
-  }
-  for (const ent of flat) {
-    if (!ent.isDirectory()) continue;
-    if (ent.name === ADAPTERS_DIR) continue;         // descended into below
-    if (NON_BROWSER_OPTIONAL.has(ent.name)) continue;
-    if (pathDeclaresBuildAlias(root, ent.name)) {
-      out.push({ name: ent.name, relPath: ent.name });
-    }
-  }
-
-  // Nested substrate adapters: implementation/adapters/<name>/deps.edn. The
-  // pre-rf2-klyw5 top-level-only scan skipped these; the lockstep authority
-  // scans them, so a newly publishable adapter must be enrolled here too.
-  let adapters;
-  try {
-    adapters = fs.readdirSync(path.join(root, ADAPTERS_DIR), { withFileTypes: true });
-  } catch (_e) {
-    adapters = []; // no adapters/ dir — nothing nested to require
-  }
-  for (const ent of adapters) {
-    if (!ent.isDirectory()) continue;
-    const relPath = `${ADAPTERS_DIR}/${ent.name}`;
-    if (pathDeclaresBuildAlias(root, relPath)) {
-      out.push({ name: ent.name, relPath });
-    }
-  }
-  return out;
+  return listPublishableRuntimes(root)
+    .filter((rt) => !NON_BROWSER_OPTIONAL.has(rt.relPath))
+    .map((rt) => ({ name: path.basename(rt.relPath), relPath: rt.relPath }));
 }
 
 // The exact implementation-relative PATHS a generic ARTEFACTS entry proves
@@ -1304,7 +1280,6 @@ module.exports = {
   POSITIVE_CONTROL,
   NON_BROWSER_OPTIONAL,
   DEDICATED_ISOLATION_GATES,
-  ADAPTERS_DIR,
   assertPositiveControlComplete,
   checkArtefact,
   pathDeclaresBuildAlias,

--- a/implementation/scripts/check-bundle-isolation.test.cjs
+++ b/implementation/scripts/check-bundle-isolation.test.cjs
@@ -246,14 +246,17 @@ withFixture((root) => {
     'string / discard mentions are not enrolled');
 });
 
-// Mutation 5 — DEDICATED GATES ARE CAUSAL: a dedicated descriptor enrols a
-// runtime only when its checker script EXISTS and its command is an INVOKED
-// package script. A prose string, a nonexistent checker, or an uninvoked/absent
-// command all fail closed. A well-formed descriptor pointing at a real, invoked
-// gate passes.
+// Mutation 5 — DEDICATED GATES ARE CAUSAL, bound to the EXACT runtime AND
+// executable (rf2-klyw5 / rf2-kfn9q): a dedicated descriptor enrols a runtime
+// only when its checker script EXISTS, its command RUNS that checker as a
+// directly-invoked reachable step, AND a checker OWNS the exact runtime in its
+// COVERS_RUNTIMES. A prose string, a nonexistent checker, an uninvoked / echoed /
+// argument-only / substring / unreachable-false-and command, or an unrelated
+// checker reused for a runtime it never inspects all fail closed.
 coverageMutations += 1;
 {
-  // Unit-level: validateDedicatedGate directly.
+  // Unit-level: validateDedicatedGate directly (no relPath → runtime binding
+  // not exercised; exercises descriptor shape + executable binding).
   assert(!validateDedicatedGate('isolated by the vibes').ok,
     'a truthy prose string is not a valid dedicated gate');
   assert(!validateDedicatedGate({ checkers: ['check-does-not-exist.cjs'], command: 'test:bundle-isolation' }).ok,
@@ -261,14 +264,49 @@ coverageMutations += 1;
   assert(!validateDedicatedGate({ checkers: ['check-login-bundle-isolation.cjs'], command: 'test:no-such-script' }).ok,
     'a command that is not a package.json script fails validation');
   assert(!validateDedicatedGate({ checkers: ['check-login-bundle-isolation.cjs'], command: 'test:reagent-slim:bundle-isolation' }).ok,
-    'a real command that does NOT invoke the declared checker fails validation');
+    'a real command that does NOT run the declared checker fails validation');
   assert(validateDedicatedGate({ checkers: ['check-login-bundle-isolation.cjs'], command: 'test:bundle-isolation' }).ok,
-    'a real checker invoked by its real package command validates');
+    'a real checker run by its real package command validates (executable binding)');
+
+  // rf2-kfn9q — EXECUTABLE binding: a checker counts only when a package-script
+  // step DIRECTLY runs it. echo / comment / argument-only / name-substring /
+  // unreachable false-and mentions do NOT. A synthetic scripts map isolates the
+  // grammar from the real package.json.
+  const grammarScripts = {
+    'gate:echo':      'echo check-login-bundle-isolation.cjs',
+    'gate:false-and': 'false && node scripts/check-login-bundle-isolation.cjs',
+    'gate:comment':   'node scripts/check-uix-helix-reagent-free.cjs && # node scripts/check-login-bundle-isolation.cjs',
+    'gate:arg-only':  'node scripts/check-uix-helix-reagent-free.cjs check-login-bundle-isolation.cjs',
+    'gate:substring': 'node scripts/xcheck-login-bundle-isolation.cjs',
+    'gate:real':      'shadow-cljs release x && node scripts/check-login-bundle-isolation.cjs',
+  };
+  const grammarGate = (command) => validateDedicatedGate(
+    { checkers: ['check-login-bundle-isolation.cjs'], command },
+    { scripts: grammarScripts });
+  assert(!grammarGate('gate:echo').ok, 'echo mention does not RUN the checker');
+  assert(!grammarGate('gate:false-and').ok, 'unreachable false-and mention does not RUN the checker');
+  assert(!grammarGate('gate:comment').ok, 'a commented-out mention does not RUN the checker');
+  assert(!grammarGate('gate:arg-only').ok, 'checker as an argument to another script does not RUN it');
+  assert(!grammarGate('gate:substring').ok, 'a longer filename containing the checker name as a substring does not RUN it');
+  assert(grammarGate('gate:real').ok, 'a real `node scripts/<checker>` step RUNS the checker');
+
+  // rf2-kfn9q — RUNTIME binding: with a relPath, a checker must OWN that exact
+  // runtime (COVERS_RUNTIMES). The login checker owns adapters/reagent, not
+  // adapters/newpub.
+  const boundReagent = validateDedicatedGate(
+    { checkers: ['check-login-bundle-isolation.cjs'], command: 'gate:real' },
+    { scripts: grammarScripts, relPath: 'adapters/reagent' });
+  assert(boundReagent.ok, 'the login checker OWNS adapters/reagent → binds');
+  const unboundNewpub = validateDedicatedGate(
+    { checkers: ['check-login-bundle-isolation.cjs'], command: 'gate:real' },
+    { scripts: grammarScripts, relPath: 'adapters/newpub' });
+  assert(!unboundNewpub.ok, 'the login checker does NOT own adapters/newpub → does not bind');
+  assert(unboundNewpub.reasons.some((r) => /adapters\/newpub/.test(r) && /COVERS_RUNTIMES|OWNS/.test(r)),
+    'the runtime-binding failure names the unbound runtime');
 
   // Integration: a discovered adapter routed through each bad descriptor fails
-  // coverage; the valid descriptor covers it. Each override keeps the real
-  // dedicated gates (so the fixture's adapters/reagent stays covered) and varies
-  // only adapters/newpub.
+  // coverage; a genuinely-bound one covers it. Overrides keep the real dedicated
+  // gates (so the fixture's adapters/reagent stays covered) and vary newpub.
   withFixture((root) => writeArtefact(root, 'adapters/newpub', PUBLISHABLE_DEPS), (root) => {
     const required = discoverBrowserOptionalRuntimes(root);
     const withNewpub = (descriptor) => assertCanonicalInventoryCovered(required, {
@@ -287,10 +325,17 @@ coverageMutations += 1;
     assert(!uninvoked.ok && uninvoked.missing.some((rt) => rt.relPath === 'adapters/newpub'),
       'a dedicated entry whose command is not an invoked package script must fail closed');
 
-    const valid = withNewpub({ checkers: ['check-login-bundle-isolation.cjs'], command: 'test:bundle-isolation' });
-    assert(valid.ok, 'a real checker invoked by a real package command enrols the runtime');
-    assert(valid.covered.some((c) => c.relPath === 'adapters/newpub' && c.via === 'dedicated'),
-      'the validly-gated adapter is covered via its dedicated gate');
+    // rf2-kfn9q — reusing an UNRELATED existing checker for a new runtime fails:
+    // the login checker really RUNS under test:bundle-isolation, but it does NOT
+    // own adapters/newpub, so the descriptor is not causally bound to newpub.
+    const unrelated = withNewpub({ checkers: ['check-login-bundle-isolation.cjs'], command: 'test:bundle-isolation' });
+    assert(!unrelated.ok && unrelated.missing.some((rt) => rt.relPath === 'adapters/newpub'),
+      'reusing the login checker for adapters/newpub must fail — checker does not isolate newpub');
+
+    // The genuinely-gated fixture adapter stays covered: adapters/reagent maps to
+    // its real checkers, which DO own adapters/reagent in COVERS_RUNTIMES.
+    assert(unrelated.covered.some((c) => c.relPath === 'adapters/reagent' && c.via === 'dedicated'),
+      'the real adapters/reagent gate (whose checkers own its coverage) still binds');
   });
 }
 
@@ -417,8 +462,11 @@ console.log(
   `${sentinelMutations} deliberate production leaks; ` +
   `${thirdParty.size} emitted third-party owners; ` +
   `${coverageMutations} structural+causal enrollment mutations ` +
-  '(publishable ui + new adapter fail closed; leaf-collision, EDN string/comment/discard, ' +
-  'prose/absent/uninvoked dedicated gate all rejected); ' +
+  '(publishable ui + new adapter + nested non-adapter fail closed; leaf-collision, ' +
+  'EDN string/comment/discard rejected; dedicated gate bound to exact runtime + ' +
+  'executable — prose/absent/uninvoked/echo/false-and/arg-only/substring command + ' +
+  'unrelated-checker-for-new-runtime all rejected; nonexistent-root / subtree-EACCES / ' +
+  'unreadable-deps.edn fail closed, missing-deps.edn is a normal non-candidate); ' +
   'lockstep consumes the shared EDN authority; ' +
   'module-ownership and sentinel-ownership confusion rejected'
 );

--- a/implementation/scripts/check-bundle-isolation.test.cjs
+++ b/implementation/scripts/check-bundle-isolation.test.cjs
@@ -18,6 +18,7 @@ const {
   assertCanonicalInventoryCovered,
 } = require('./check-bundle-isolation.cjs');
 const { assertSentinelSet } = require('./lib/sentinel-scan.cjs');
+const { listPublishableRuntimes } = require('./lib/publishable-runtimes.cjs');
 
 // Repo root, for cross-checking the lockstep script + real implementation/ tree.
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -291,6 +292,89 @@ coverageMutations += 1;
     assert(valid.covered.some((c) => c.relPath === 'adapters/newpub' && c.via === 'dedicated'),
       'the validly-gated adapter is covered via its dedicated gate');
   });
+}
+
+// ----- inventory completeness + fail-closed read faults (rf2-o58c2) ----------
+// Bundle isolation now CONSUMES the shared authority's listPublishableRuntimes
+// (no second, narrower traversal), so a publishable runtime nested OUTSIDE
+// adapters/ — which the release lockstep enrols — is discovered and fails
+// closed if ungated. And an unexpected root / subtree / deps.edn read fault
+// THROWS (naming the path) instead of silently shrinking the inventory, while a
+// MISSING deps.edn stays a normal non-candidate.
+
+// Mutation 6 — NESTED NON-ADAPTER runtime (implementation/<x>/<y>/deps.edn with
+// a real :clein/build, x != adapters). The pre-rf2-o58c2 bundle-isolation walk
+// descended only into adapters/, so this reached release inventory (via the
+// authority) while escaping bundle coverage. Now both consumers enrol it by
+// exact relPath, and — ungated — it fails coverage closed.
+coverageMutations += 1;
+withFixture((root) => writeArtefact(root, 'plugins/widgets', PUBLISHABLE_DEPS), (root) => {
+  assert(listPublishableRuntimes(root).some((r) => r.relPath === 'plugins/widgets'),
+    'the release-lockstep authority enrols the nested non-adapter runtime');
+  const required = discoverBrowserOptionalRuntimes(root);
+  assert(required.some((rt) => rt.relPath === 'plugins/widgets'),
+    'bundle isolation must ALSO discover the nested non-adapter runtime (no narrower second traversal)');
+  const cov = assertCanonicalInventoryCovered(required);
+  assert(!cov.ok && cov.missing.some((rt) => rt.relPath === 'plugins/widgets'),
+    'an ungated nested non-adapter runtime fails coverage closed and is named');
+});
+
+// Mutation 7 — FAIL-CLOSED read faults. A missing deps.edn is a normal
+// non-candidate; a nonexistent root, an unreadable subtree, or an unreadable
+// deps.edn throws and names the path (so the lockstep CLI exits non-zero and the
+// bundle gate fails, rather than proving a shrunken inventory).
+coverageMutations += 1;
+
+// (a) Missing deps.edn: a directory with no deps.edn is NOT an error.
+withFixture((root) => fs.mkdirSync(path.join(root, 'nodeps')), (root) => {
+  assert.strictEqual(pathDeclaresBuildAlias(root, 'nodeps'), false,
+    'a directory with no deps.edn is a normal non-candidate (not an error)');
+});
+
+// (b) Nonexistent implementation root: throws (was a silent empty result → the
+// CLI exited 0 for a torn checkout).
+{
+  const ghostRoot = path.join(os.tmpdir(), `bundle-iso-nonexistent-${process.pid}-${Date.now()}`);
+  assert.throws(() => listPublishableRuntimes(ghostRoot), /cannot read implementation root/,
+    'a nonexistent implementation root must throw, not return an empty inventory');
+}
+
+// (c) Unreadable deps.edn: a deps.edn that is itself a DIRECTORY reproduces an
+// unexpected read fault (EISDIR) deterministically on every platform (POSIX
+// chmod is a no-op on Windows). Not an absence → throws naming the path, and
+// the whole enumeration fails closed.
+withFixture(
+  (root) => fs.mkdirSync(path.join(root, 'baddeps', 'deps.edn'), { recursive: true }),
+  (root) => {
+    assert.throws(() => pathDeclaresBuildAlias(root, 'baddeps'), /cannot read .*deps\.edn/,
+      'an unreadable deps.edn (not ENOENT) must throw, not be silently skipped');
+    assert.throws(() => listPublishableRuntimes(root), /cannot read .*deps\.edn/,
+      'the unreadable deps.edn makes the whole enumeration fail closed');
+  });
+
+// (d) Partial subtree EACCES: a subtree we listed as a directory but then can't
+// read must throw. Simulated with a scoped fs.readdirSync stub (deterministic +
+// cross-platform, since POSIX chmod does not block reads on Windows).
+{
+  const realReaddir = fs.readdirSync;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bundle-iso-eacces-'));
+  try {
+    writeArtefact(root, 'core', PUBLISHABLE_DEPS);
+    fs.mkdirSync(path.join(root, 'locked'), { recursive: true });
+    fs.readdirSync = (p, opts) => {
+      if (typeof p === 'string' && path.basename(p) === 'locked') {
+        const err = new Error('EACCES: permission denied');
+        err.code = 'EACCES';
+        throw err;
+      }
+      return realReaddir(p, opts);
+    };
+    assert.throws(() => listPublishableRuntimes(root), /cannot read subtree .*locked/,
+      'an EACCES on a partial subtree must fail closed and name the path');
+  } finally {
+    fs.readdirSync = realReaddir;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 }
 
 // Real-tree floor: the current implementation/ tree must be fully covered, every

--- a/implementation/scripts/check-login-bundle-isolation.cjs
+++ b/implementation/scripts/check-login-bundle-isolation.cjs
@@ -247,4 +247,19 @@ function main() {
   process.exit(1);
 }
 
-main();
+// Checker-owned target contract (rf2-kfn9q): the exact implementation-relative
+// runtimes this gate actually isolates. The dedicated-gate binding in
+// check-bundle-isolation.cjs requires a runtime's descriptor to name a checker
+// whose COVERS_RUNTIMES includes it, so an unrelated existing checker can NOT be
+// reused for a new runtime it never inspects. This gate proves the shared
+// login.model stays substrate-free across the Reagent / UIx / Helix login
+// bundles, so it isolates all three adapter runtimes.
+const COVERS_RUNTIMES = ['adapters/reagent', 'adapters/uix', 'adapters/helix'];
+
+module.exports = { COVERS_RUNTIMES };
+
+// Run only when invoked directly (`node scripts/check-login-bundle-isolation.cjs`),
+// not when required as the checker-owned target contract above.
+if (require.main === module) {
+  main();
+}

--- a/implementation/scripts/check-reagent-slim-bundle-isolation.cjs
+++ b/implementation/scripts/check-reagent-slim-bundle-isolation.cjs
@@ -460,4 +460,16 @@ function main() {
   }
 }
 
-main();
+// Checker-owned target contract (rf2-kfn9q): the exact implementation-relative
+// runtime this gate isolates — the slim adapter. It proves the slim bundle is
+// free of stock Reagent + react-dom/server (and the classic bundle free of the
+// reagent2.* rewrite), so it is the isolation authority for adapters/reagent-slim.
+// See the binding in check-bundle-isolation.cjs (validateDedicatedGate).
+const COVERS_RUNTIMES = ['adapters/reagent-slim'];
+
+module.exports = { COVERS_RUNTIMES };
+
+// Run only when invoked directly, not when required for its target contract.
+if (require.main === module) {
+  main();
+}

--- a/implementation/scripts/check-uix-helix-reagent-free.cjs
+++ b/implementation/scripts/check-uix-helix-reagent-free.cjs
@@ -171,4 +171,16 @@ function main() {
   }
 }
 
-main();
+// Checker-owned target contract (rf2-kfn9q): the exact implementation-relative
+// runtimes this gate isolates. It proves the UIx-only and Helix-only bundles
+// carry no stock Reagent while the Reagent bundle does (the cross-substrate
+// positive control), so it isolates all three adapter runtimes. See the binding
+// in check-bundle-isolation.cjs (validateDedicatedGate).
+const COVERS_RUNTIMES = ['adapters/reagent', 'adapters/uix', 'adapters/helix'];
+
+module.exports = { COVERS_RUNTIMES };
+
+// Run only when invoked directly, not when required for its target contract.
+if (require.main === module) {
+  main();
+}

--- a/implementation/scripts/lib/publishable-runtimes.cjs
+++ b/implementation/scripts/lib/publishable-runtimes.cjs
@@ -58,13 +58,20 @@ function depsDeclaresBuildAlias(depsText) {
 }
 
 // True iff <root>/<relPath>/deps.edn declares a real `:clein/build` alias. A
-// missing/unreadable deps.edn file is not a publishable artefact directory.
+// MISSING deps.edn (the directory simply is not a publishable artefact) is a
+// normal non-candidate. Any OTHER read fault — an unreadable file (EACCES), a
+// deps.edn that is itself a directory (EISDIR), an I/O error — is NOT "absent":
+// it is a torn / permission-broken checkout, so we fail CLOSED and throw
+// naming the path rather than silently omitting a runtime that may be
+// publishable (which would shrink both the release and bundle proofs).
 function pathDeclaresBuildAlias(root, relPath) {
+  const depsPath = path.join(root, relPath, 'deps.edn');
   let depsText;
   try {
-    depsText = fs.readFileSync(path.join(root, relPath, 'deps.edn'), 'utf8');
-  } catch (_e) {
-    return false;
+    depsText = fs.readFileSync(depsPath, 'utf8');
+  } catch (err) {
+    if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) return false;
+    throw new Error(`cannot read ${depsPath}: ${err.message}`);
   }
   return depsDeclaresBuildAlias(depsText);
 }
@@ -72,26 +79,34 @@ function pathDeclaresBuildAlias(root, relPath) {
 // Every publishable artefact under `implRoot`, mirroring the release lockstep's
 // bounded `find -mindepth 2 -maxdepth 3 -name deps.edn` reach: every
 // implementation/<name>/deps.edn (depth 2) and implementation/<name>/<sub>/deps.edn
-// (depth 3 — the adapters live here). Returns `{ relPath }` records sorted by
-// relPath. No exclusions: callers filter for their own surface (the lockstep
-// keeps them all; the bundle-isolation gate drops the always-present / JVM-only
-// runtimes and re-groups adapters).
+// (depth 3 — the adapters live here, plus any other nested runtime). Returns
+// `{ relPath }` records sorted by relPath. No exclusions: callers filter for
+// their own surface (the lockstep keeps them all; the bundle-isolation gate
+// drops the always-present / JVM-only runtimes).
+//
+// Read faults FAIL CLOSED (rf2-o58c2): a nonexistent / unreadable root, or an
+// unreadable subtree we just listed as a directory, is a torn checkout or
+// permissions fault — NOT "no runtimes". Throwing (naming the path) makes both
+// consumers (release lockstep + bundle isolation) hard-fail instead of silently
+// proving a shrunken inventory. (A missing deps.edn stays a normal
+// non-candidate — see pathDeclaresBuildAlias.)
 function listPublishableRuntimes(implRoot) {
   const out = [];
   let top;
   try {
     top = fs.readdirSync(implRoot, { withFileTypes: true });
-  } catch (_e) {
-    return out;
+  } catch (err) {
+    throw new Error(`cannot read implementation root ${implRoot}: ${err.message}`);
   }
   for (const ent of top) {
     if (!ent.isDirectory()) continue;
     if (pathDeclaresBuildAlias(implRoot, ent.name)) out.push({ relPath: ent.name });
+    const subDir = path.join(implRoot, ent.name);
     let subs;
     try {
-      subs = fs.readdirSync(path.join(implRoot, ent.name), { withFileTypes: true });
-    } catch (_e) {
-      subs = [];
+      subs = fs.readdirSync(subDir, { withFileTypes: true });
+    } catch (err) {
+      throw new Error(`cannot read subtree ${subDir}: ${err.message}`);
     }
     for (const sub of subs) {
       if (!sub.isDirectory()) continue;


### PR DESCRIPTION
Two PR #6214 follow-ups on the shared `implementation/scripts/lib/publishable-runtimes.cjs` authority and the bundle-isolation checkers that consume it. Two commits (smallest -> biggest).

## rf2-o58c2 — complete + fail-closed publishable-runtime inventory
- `check-bundle-isolation.cjs` kept a second, narrower traversal (flat implementation children + `adapters/` only). The release lockstep enrols every flat **and** one-level-nested runtime via `listPublishableRuntimes`, so a publishable runtime nested outside `adapters/` reached release inventory while escaping bundle coverage. `discoverBrowserOptionalRuntimes` now **consumes `listPublishableRuntimes` directly**, then applies only its explicit browser/JVM exclusions — one inventory, keyed by exact relPath.
- The authority turned root / subtree / `deps.edn` read errors into an empty/absent result, so its CLI exited 0 for a nonexistent implementation root. Now `listPublishableRuntimes` / `pathDeclaresBuildAlias` **fail closed**: a missing `deps.edn` stays a normal non-candidate, but a nonexistent/unreadable root, an unreadable subtree, or an unreadable `deps.edn` throws naming the path — so the lockstep CLI exits non-zero and the bundle gate fails.

## rf2-kfn9q — bind dedicated coverage to the exact runtime and executable
- A dedicated descriptor validated when the package-script body merely **contained** each checker filename — `echo check-login-bundle-isolation.cjs` and `false && node scripts/check-login-bundle-isolation.cjs` both passed. `validateDedicatedGate` now requires the checker in a **directly-runnable, reachable step** of the repo's bounded `&&`-chained package-script grammar (`commandRunsChecker`); echo, comment, argument-only, name-substring, and unreachable `false &&` mentions all fail.
- The descriptor was not bound to its runtime, so the login checker could be assigned to a hypothetical `adapters/newpub`. Coverage is now **causally bound to the exact implementation-relative runtime**: it must be owned by one of the checkers' exported `COVERS_RUNTIMES` (a checker-owned target contract). Reusing an unrelated existing checker for a new runtime fails. The dedicated checkers guard `main()` behind `require.main` so the contract can be read without running bundle work.

Minimal, at the existing authority + its consumers: no production-bundle changes, no bundle-isolation redesign, no manifest-schema layer, no general shell/workflow parser. The playground SCI bundle is untouched.

## Red-before / green-after
- **o58c2 (A)**: `discoverBrowserOptionalRuntimes` returned `[]` for a nested non-adapter runtime that `listPublishableRuntimes` found → now both enrol it by exact relPath (ungated → fails closed).
- **o58c2 (B)**: CLI exited 0 for a nonexistent root → now exits 2 naming the path.
- **kfn9q**: `echo` / `false &&` / argument-only / substring commands and login→`adapters/newpub` all validated → now all rejected with a naming reason.
- Adversarial mutations added to `check-bundle-isolation.test.cjs`: nested non-adapter; nonexistent root; partial-subtree EACCES; unreadable `deps.edn`; missing `deps.edn` (normal non-candidate); echo / false-and / arg-only / substring executable-binding; unrelated-checker-for-newpub runtime-binding.

## Quality gates
Run foreground on the final combined state:
- `npm run test:bundle-isolation` — **PASS** (self-test: 22 artefacts / 38 sentinels / 7 enrolment mutations; check-bundle-isolation: 12 canonical browser-optional runtimes covered [8 generic, 4 dedicated]; uix-helix-reagent-free; login-bundle-isolation)
- `npm run test:reagent-slim:bundle-isolation` — **PASS** (6 contracts)
- All four current dedicated gates remain green through their real commands (guarded `main()` preserves direct-invocation behaviour).
