### PR TITLE
fix(xray): make concrete-query row selectors genuinely injective (rf2-haoip)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -690,16 +690,22 @@ the registration id) — so `:subs-skipped` stays cleanly distinct from
 was. Rows display + key by the full query vector (documented fallback to the
 registered id only when the skip evidence genuinely lacks a query-v);
 source-coordinate lookup keeps the registered id. Each row's `data-testid`
-(`rf-xray-reactive-unchanged-row-<selector>`) is minted through an INJECTIVE
-concrete-query selector (rf2-bk2c6) — the readable `id-slug` stem plus a
-stable content-hash of the full identity. `id-slug` alone is LOSSY: it
-flattens every non-alnum char to `_`, so distinct valid queries
-(`[:item/derived :a-b]` and `[:item/derived :a/b]` both slug to
-`__item_derived__a_b_`) would collapse onto one selector the DOM can no longer
-address independently. The hash suffix restores distinction while the SAME
-concrete query always hashes the same — so repeated evidence keeps ONE stable
-selector, matching the dedup contract; the React key, the visible label, and
-`data-query-v` still carry the full query vector unchanged. It is NOT reconstructed by
+(`rf-xray-reactive-unchanged-row-<selector>`) is minted through a GENUINELY
+INJECTIVE concrete-query selector (rf2-bk2c6, hardened rf2-haoip) — the
+readable `id-slug` stem plus a lossless, order-canonical encoding of the full
+identity (a small local `canonical-str` rendering, made DOM-safe via
+`encodeURIComponent`). `id-slug` alone is LOSSY: it flattens every non-alnum
+char to `_`, so distinct valid queries (`[:item/derived :a-b]` and
+`[:item/derived :a/b]` both slug to `__item_derived__a_b_`) would collapse onto
+one selector the DOM can no longer address independently. A 32-bit `hash`
+suffix did NOT close this: a 32-bit hash COLLIDES, so distinct queries
+(`[:item/derived " @"]` and `[:item/derived "!!"]` share hash `1127258382`)
+still minted the identical selector. The lossless suffix is collision-free —
+distinct concrete queries always receive distinct selectors — while
+value-equal identities (maps built in any insertion order included) canonicalize
+to ONE stable selector, so repeated evidence keeps a single row matching the
+dedup contract; the React key, the visible label, and `data-query-v` still
+carry the full query vector unchanged. It is NOT reconstructed by
 filtering `:sub-runs` on `(complement :recomputed?)`, which is structurally
 always empty. The
 graph's `unchanged` (dashed, short-circuited) nodes are subs that RAN with

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
@@ -137,21 +137,49 @@
   [id]
   (when id (string/replace (str id) #"[^a-zA-Z0-9_]" "_")))
 
+(defn- canonical-str
+  "Lossless, order-canonical string rendering of a concrete-query identity.
+  Distinct EDN values render to distinct strings (injective); value-equal
+  identities render identically — maps and sets emit their elements in
+  canonical (sorted) order, so an identity built in ANY map/set insertion
+  order yields ONE stable string. Vectors and lists keep their significant
+  order; scalars defer to `pr-str` (faithful + reader-quoted, so a string can
+  never masquerade as structure). Small + local to the selector below — NOT a
+  general serializer."
+  [x]
+  (cond
+    (map? x)    (str "{" (->> x
+                              (map (fn [[k v]]
+                                     (str (canonical-str k) " " (canonical-str v))))
+                              sort
+                              (string/join ", "))
+                     "}")
+    (set? x)    (str "#{" (->> x (map canonical-str) sort (string/join " ")) "}")
+    (vector? x) (str "[" (->> x (map canonical-str) (string/join " ")) "]")
+    (seq? x)    (str "(" (->> x (map canonical-str) (string/join " ")) ")")
+    :else       (pr-str x)))
+
 (defn- concrete-query-selector
-  "Injective `data-testid` suffix for an unchanged-sub row's concrete-query
-  identity (rf2-bk2c6). `id-slug` alone is LOSSY — it flattens every
-  non-alnum/non-`_` char to `_`, so DISTINCT valid queries collapse to one
-  selector (`[:item/derived :a-b]` and `[:item/derived :a/b]` both slug to
-  `__item_derived__a_b_`), colliding two surviving rows onto one `data-testid`
-  the DOM can no longer address independently. Appending a stable content
-  hash of the FULL identity restores distinction while retaining the readable
-  slug stem: distinct concrete queries get distinct selectors, and the SAME
-  concrete query always hashes the same — so repeated evidence keeps ONE
-  stable selector (the dedup contract). Projection, React keys, the visible
-  label, and `data-query-v` are untouched; only this testid encoding changes."
+  "GENUINELY INJECTIVE `data-testid` suffix for an unchanged-sub row's
+  concrete-query identity (rf2-bk2c6 / rf2-haoip). `id-slug` alone is LOSSY —
+  it flattens every non-alnum/non-`_` char to `_`, so DISTINCT valid queries
+  collapse to one slug (`[:item/derived :a-b]` and `[:item/derived :a/b]` both
+  slug to `__item_derived__a_b_`). Appending a 32-bit `hash` did NOT fix this:
+  a 32-bit hash COLLIDES, so distinct queries (`[:item/derived \" @\"]` and
+  `[:item/derived \"!!\"]` share hash `1127258382`) still minted the identical
+  selector — false identity, two rows onto one `data-testid` the DOM cannot
+  address independently. The discriminator is now a LOSSLESS, order-canonical
+  encoding of the full identity, made DOM-safe via `encodeURIComponent`:
+  distinct concrete queries get distinct selectors (collision-free), and
+  value-equal identities — maps in any insertion order included — get ONE
+  stable selector (the dedup contract). The readable `id-slug` stem survives;
+  projection, React keys, the visible label, and `data-query-v` are untouched;
+  only this testid encoding changes. BOTH the readable stem and the
+  discriminator derive from `canonical-str`, so the WHOLE selector is a function
+  of VALUE — the `id-slug` stem cannot re-leak map insertion order."
   [ident]
-  (str (id-slug ident) "-"
-       (.toString (unsigned-bit-shift-right (hash ident) 0) 36)))
+  (let [canon (canonical-str ident)]
+    (str (id-slug canon) "-" (js/encodeURIComponent canon))))
 
 (defn- elapsed-label
   "Format a render's `:elapsed-ms` for the view-node sub-label. Sub-ms

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
@@ -549,6 +549,65 @@
         (is (re-find #":a-b" joined) "the :a-b parameterization is labelled")
         (is (re-find #":a/b" joined) "the :a/b parameterization is labelled")))))
 
+(deftest unchanged-row-selectors-injective-for-hash-colliding-queries
+  (testing "rf2-haoip — the ADVERSARIAL pair the 32-bit-hash suffix could not
+            separate: `[:item/derived \" @\"]` and `[:item/derived \"!!\"]`
+            collide on BOTH the `id-slug` form AND the ClojureScript vector
+            hash (`1127258382` → base-36 `in524u`), so the prior hash-suffixed
+            selector minted ONE `data-testid` for two distinct concrete queries
+            (false identity). The lossless order-canonical selector must give
+            them DISTINCT, individually-addressable test-ids while the labels
+            stay distinct. (Red before the injective fix: distinct testid count
+            was 1, the shared testid addressed 2 nodes.)"
+    (facade/install!)
+    (rf/make-frame {:id :rf/xray})
+    (seed-reactive-data!
+      {:has-event-bundle? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :show-unchanged? true
+       :subs-skipped [{:sub-id :item/derived :query-v [:item/derived " @"]
+                       :reason :input-value-equal :input-paths-unchanged []}
+                      {:sub-id :item/derived :query-v [:item/derived "!!"]
+                       :reason :input-value-equal :input-paths-unchanged []}]})
+    (let [tree    (view/reactive-panel)
+          testids (unchanged-row-testids tree)]
+      (is (= 2 (count testids)) "both hash-colliding parameterizations render a row")
+      (is (= 2 (count (distinct testids)))
+          "the injective selector gives the two rows DISTINCT test-ids (not the
+           single shared hash suffix)")
+      (doseq [id (distinct testids)]
+        (is (= 1 (count (th/find-all-by-testid tree id)))
+            "each concrete query's test-id addresses exactly one node"))
+      (let [joined (str/join " " (map #(text-of tree %) (distinct testids)))]
+        (is (re-find #" @" joined) "the \" @\" parameterization is labelled")
+        (is (re-find #"!!" joined) "the \"!!\" parameterization is labelled")))))
+
+(deftest unchanged-row-selector-canonical-across-map-insertion-order
+  (testing "rf2-haoip — VALUE-EQUAL concrete queries retain ONE stable selector
+            matching the dedup semantics: a map arg built in different insertion
+            orders (`{:a 1 :b 2}` vs `{:b 2 :a 1}`) is `=` and must mint the
+            SAME row test-id, while a genuinely different map (`{:a 1 :b 3}`)
+            mints a DISTINCT one (still injective — order-invariance is not
+            value-collapse)."
+    (facade/install!)
+    (rf/make-frame {:id :rf/xray})
+    (seed-reactive-data!
+      {:has-event-bundle? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :show-unchanged? true
+       :subs-skipped [{:sub-id :cfg/derived :query-v [:cfg/derived {:a 1 :b 2}]
+                       :reason :input-value-equal :input-paths-unchanged []}
+                      {:sub-id :cfg/derived :query-v [:cfg/derived {:b 2 :a 1}]
+                       :reason :input-value-equal :input-paths-unchanged []}
+                      {:sub-id :cfg/derived :query-v [:cfg/derived {:a 1 :b 3}]
+                       :reason :input-value-equal :input-paths-unchanged []}]})
+    (let [tree    (view/reactive-panel)
+          testids (unchanged-row-testids tree)]
+      (is (= 3 (count testids)) "all three seeded rows render")
+      (is (= 2 (count (distinct testids)))
+          "the two value-equal map orders collapse to ONE selector; the
+           genuinely-different map keeps its own — 2 distinct selectors total"))))
+
 (deftest unchanged-row-unparameterized-shows-plain-sub-id
   (testing "rf2-cj2yx / rf2-bk2c6 — a bare unparameterized skip (query-v
             `[:sub/id]`) renders the plain sub-id label (the common case is


### PR DESCRIPTION
## What

The unchanged-sub disclosure rows (Reactive/Views panel, `tools/xray/spec/021`
§3.4) mint each row's `data-testid` through `concrete-query-selector`. PR #6220
called that selector "injective" but the discriminator was only a **32-bit
ClojureScript `hash`** appended to the lossy `id-slug` stem. A 32-bit hash
**collides**, so distinct concrete queries could still map to one selector —
false identity. The bead's proven pair `[:item/derived " @"]` and
`[:item/derived "!!"]` share slug `__item_derived_ _`, share vector hash
`1127258382` (base-36 `in524u`), and therefore minted the **identical**
`data-testid` — two surviving rows the DOM could not address independently.

## Fix

`concrete-query-selector` (`reactive_panel_view.cljs`) now derives its
discriminator from a small, local **`canonical-str`** helper — a lossless,
order-canonical rendering of the full identity — made DOM-safe with
`encodeURIComponent`:

- **Genuinely injective**: distinct concrete queries always get distinct
  selectors (a collision-free encoding of the full structural key, not a lossy
  hash).
- **Canonical**: value-equal identities — including maps built in different
  insertion orders — canonicalize to ONE stable selector, matching the upstream
  dedup-by-value semantics. Both the readable `id-slug` stem AND the
  discriminator derive from `canonical-str`, so the stem cannot re-leak map
  insertion order.
- `canonical-str` special-cases only maps/sets (sorted) and structural
  collections; scalars defer to `pr-str`. It is small and local to this one
  call site — **not** a general EDN/DOM serialization framework.

React keys, the visible label, `data-query-v`, projection, ordering, and the
unparameterized common case are untouched — only this testid encoding changes.
`tools/xray/spec/021` §3.4 updated to document the lossless injective encoding
(mandatory tools/xray spec-in-same-PR rule).

## Quality gates

CLJS node-test lane — `npm run test:cljs` from `implementation/` (the focused
Xray Reactive-panel suite rides this build):

- **Green-after (fix in place):** `Ran 9938 tests containing 48982 assertions.
  0 failures, 0 errors.`
- Two adversarial tests added to `reactive_panel_view_cljs_test.cljs`:
  - `unchanged-row-selectors-injective-for-hash-colliding-queries` — the true
    red-before pair `[:item/derived " @"]` / `[:item/derived "!!"]` that
    collide on BOTH `id-slug` and the 32-bit hash (the prior `:a-b`/`:a/b`
    test slug-collides but hash-DIFFERS, so it never exercised a real hash
    collision).
  - `unchanged-row-selector-canonical-across-map-insertion-order` — pins
    value-equal maps in different insertion orders to one selector while a
    genuinely different map keeps its own.
- **Red-before (call site reverted to the 32-bit hash):** both new tests fail
  as designed — the collision pair collapses to one shared `data-testid`
  (`distinct` count 1, not 2), and the map-insertion-order pair splits into 3
  selectors instead of 2. (An intermediate run also caught a subtler leak: a
  canonical discriminator alone was insufficient while the readable `id-slug`
  stem still used `(str ident)` — the stem leaked map insertion order, yielding
  3 selectors. Deriving the stem from `canonical-str` too closed it; that is the
  committed fix.)

Change is CLJS-only (one view namespace + one CLJS test file + one spec doc);
JVM lanes untouched.

Closes rf2-haoip.
