### PR TITLE
test(ui): custom-element property-vs-attribute classification + conformance (rf2-vea1f, S4-B)

### DIFF
--- a/implementation/ui/test/re_frame/ui/custom_element_classification_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/custom_element_classification_dom_cljs_test.cljs
@@ -1,0 +1,74 @@
+(ns re-frame.ui.custom-element-classification-dom-cljs-test
+  "S4-B (rf2-vea1f) — the CLIENT half of the RULED custom-element
+  classification (Spec 004 §Template grammar / 004B §Custom elements): a
+  DECLARED `:properties` name is applied to a mounted custom element as a JS
+  PROPERTY under its kebab -> camelCase spelling, while undeclared names ride
+  as ATTRIBUTES (the all-attributes default).
+
+  This is the `props applied at hydration` side the server emitter cannot
+  render: the JVM emits attributes only (property-classified names omitted by
+  `N`) and the properties apply here, on a real `react-dom/client` mount. The
+  structural classification + the `N` markup-omission are proven on the JVM in
+  custom_element_classification_jvm_test; the compile-time emit name
+  (`helpText`) rides react_render_cljs_test. This file closes the loop on the
+  actual DOM node in a real browser."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.test :as uit]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+;; A real custom element whose `accentColor` PROPERTY is a plain accessor with
+;; NO attribute reflection. React 19's client renderer assigns a prop as a JS
+;; property when a matching property exists on the element instance, else as an
+;; attribute — so this gives the declared property a home, while undeclared
+;; names (no matching property) fall to attributes. Defined once at ns-load and
+;; guarded off the non-DOM node host (the browser job runs the assertions).
+(when (and (exists? js/customElements)
+           (not (js/customElements.get "ce-accent")))
+  (js/customElements.define
+   "ce-accent"
+   (js* "(class extends HTMLElement { get accentColor(){ return this.__ac; } set accentColor(v){ this.__ac = v; } })")))
+
+(ui/custom-element :ce-accent {:properties #{:accent-color}})
+
+(defview accent-host []
+  ;; :accent-color is DECLARED  -> property (camelCase accentColor)
+  ;; :data-x / :label are NOT   -> attributes (verbatim / all-attributes)
+  [:ce-accent {:accent-color "blue" :data-x "d" :label "wide & <deep>"}])
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter ui/adapter :ambient-frame nil :async? true}))
+
+(defn- accent-el [root]
+  (.querySelector (.-container root) "ce-accent"))
+
+(deftest declared-property-applies-as-a-js-property-on-the-client
+  (if-not (browser?)
+    (is true "custom-element client property-setting needs a DOM host — the browser job runs it")
+    (async done
+      (-> (uit/with-root [root [accent-host]]
+            (-> (uit/flush!)
+                (.then
+                 (fn [_]
+                   (let [el (accent-el root)]
+                     (is (some? el) "the custom element mounted")
+                     (testing "declared :accent-color -> camelCase JS PROPERTY, applied at client render"
+                       (is (= "blue" (.-accentColor el))
+                           "set as a JS property under the kebab -> camelCase name")
+                       (is (nil? (.getAttribute el "accent-color"))
+                           "a declared property is NOT reflected as the kebab attribute")
+                       (is (nil? (.getAttribute el "accentcolor"))
+                           "nor as any attribute spelling — it is a PROPERTY, not markup"))
+                     (testing "undeclared names ride as ATTRIBUTES (the all-attributes default)"
+                       (is (= "d" (.getAttribute el "data-x")))
+                       (is (= "wide & <deep>" (.getAttribute el "label")))
+                       (is (nil? (.-label el))
+                           "an undeclared name is NOT set as a JS property")))))) )
+          (.then (fn [_] (done))
+                 (fn [e]
+                   (is false (str "mount rejected: " (some-> e ex-message)))
+                   (done)))))))

--- a/implementation/ui/test/re_frame/ui/custom_element_classification_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/custom_element_classification_jvm_test.clj
@@ -1,0 +1,110 @@
+(ns re-frame.ui.custom-element-classification-jvm-test
+  "S4-B (rf2-vea1f) — the RULED custom-element property-vs-attribute
+  classification, proven on the JVM structural surface (Spec 004
+  §Template grammar / 004B §Custom elements).
+
+  A DECLARED `:properties` name is a PROPERTY: it stays in the single
+  `:attrs` author map, is named by the `:rf.ui/property-props` reserved
+  marker, and lowers to the kebab -> camelCase JS property name. Every
+  other name is an ATTRIBUTE. An UNDECLARED element is all-attributes.
+  The JVM emitter carries ATTRIBUTES ONLY into markup — property-classified
+  names are OMITTED by semantic normalization `N` (the server cannot set
+  properties) and applied at hydration on the client (the client half is
+  proven in custom_element_classification_dom_cljs_test).
+
+  The closed `{:properties #{…}}` grammar, the macro shape, and the
+  cross-source declaration law are proven in compiler_build_jvm_test /
+  custom_element_conflict_jvm_test; this file proves the CLASSIFICATION
+  behaviour end-to-end through the real `defview` -> tree -> N path,
+  including the adversarial cases the S4 contract calls out."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.rules :as rules]
+            [re-frame.ui.semantic :as semantic]
+            [re-frame.ui.tree :as tree]))
+
+;; Declared custom elements — distinct tags per source (the cross-source
+;; conflict law forbids two SOURCES declaring one tag with different sets).
+(ui/custom-element :ce-fancy   {:properties #{:accent-color :help-text}})
+
+;; A declared name that is ALSO a standard HTML attribute spelling: the
+;; DECLARATION is the sole classifier, so `:tab-index` is a PROPERTY here,
+;; not the `tabindex` attribute it would be on a plain element.
+(ui/custom-element :ce-attrish {:properties #{:tab-index}})
+
+(defview declared-props-view []
+  [:ce-fancy {:accent-color "blue" :help-text "h" :data-x "d" :label "lab"}])
+
+(defview attr-override-view []
+  [:ce-attrish {:tab-index "3" :role "note"}])
+
+;; `:ce-plain` is never declared — the all-attributes default.
+(defview undeclared-element-view []
+  [:ce-plain {:accent-color "x" :data-y "y"}])
+
+(defn- element [view] (first (:children (tree/render view {}))))
+
+(deftest declared-name-is-a-property-undeclared-is-an-attribute
+  (let [el (element declared-props-view)]
+    (is (= :ce-fancy (:tag el)))
+    (testing "every author-space key lives in the single :attrs map"
+      (is (= {:accent-color "blue" :help-text "h" :data-x "d" :label "lab"}
+             (:attrs el))))
+    (testing "ONLY the declared names are classified as properties (the marker)"
+      (is (= #{:accent-color :help-text} (:rf.ui/property-props el))))
+    (testing "undeclared names are attributes — never in the property marker"
+      (is (not (contains? (:rf.ui/property-props el) :data-x)))
+      (is (not (contains? (:rf.ui/property-props el) :label))))))
+
+(deftest kebab-property-name-lowers-to-camelcase
+  ;; The JVM structural tree keeps the AUTHOR kebab key (the marker names
+  ;; :accent-color); the RULED kebab -> camelCase JS property NAME is the
+  ;; lowered spelling both emitters use (the client sets `el.accentColor`).
+  (is (= "accentColor" (rules/custom-element-property-name "accent-color")))
+  (is (= "helpText" (rules/custom-element-property-name "help-text")))
+  (is (= "tabIndex" (rules/custom-element-property-name "tab-index"))
+      "a standard-attribute spelling still camelizes when declared a property"))
+
+(deftest declaration-overrides-default-attribute-classification
+  ;; Adversarial: a DECLARED name that is a standard HTML attribute spelling
+  ;; is forced to a PROPERTY — the declaration is the sole classifier, never
+  ;; an attribute-name heuristic.
+  (let [el (element attr-override-view)]
+    (is (= #{:tab-index} (:rf.ui/property-props el))
+        ":tab-index is a PROPERTY here because it is DECLARED — not the tabindex attribute")
+    (is (not (contains? (:rf.ui/property-props el) :role))
+        "the undeclared :role stays an attribute alongside the property")))
+
+(deftest undeclared-element-is-all-attributes
+  (let [el (element undeclared-element-view)]
+    (is (= :ce-plain (:tag el)))
+    (is (= {:accent-color "x" :data-y "y"} (:attrs el)))
+    (is (nil? (:rf.ui/property-props el))
+        "no declaration -> no property classification (all-attributes default)")))
+
+(deftest jvm-markup-is-attributes-only-properties-apply-at-hydration
+  ;; `N` (the semantic/serialiser half) OMITS property-classified names from
+  ;; markup — the server cannot set properties, so they apply on the client at
+  ;; hydration. The plain attributes survive.
+  (testing "ce-fancy: declared properties omitted, undeclared attributes kept"
+    (let [[node] (semantic/normalize (tree/render declared-props-view {}))]
+      (is (= :ce-fancy (:tag node)))
+      (is (not (contains? node :rf.ui/property-props))
+          "the marker itself never reaches the semantic output")
+      (let [attrs (:attrs node)]
+        (is (= "d" (get attrs "data-x")) "the plain attribute survives as markup")
+        (is (not (contains? attrs "accent-color")) "kebab property name absent from markup")
+        (is (not (contains? attrs "accentColor"))  "camelCase property name absent from markup")
+        (is (not (contains? attrs "help-text")))
+        (is (not (contains? attrs "helpText"))))))
+  (testing "ce-attrish: the DECLARED tab-index property is omitted from markup"
+    (let [[node] (semantic/normalize (tree/render attr-override-view {}))
+          attrs  (:attrs node)]
+      (is (not (contains? attrs "tabindex")) "declared -> property -> omitted, not a tabindex attribute")
+      (is (not (contains? attrs "tabIndex")))
+      (is (contains? attrs "role") "the undeclared :role remains an attribute")))
+  (testing "undeclared element: everything is markup (no property omission)"
+    (let [[node] (semantic/normalize (tree/render undeclared-element-view {}))
+          attrs  (:attrs node)]
+      (is (= "x" (get attrs "accent-color")) "undeclared element -> the name is a plain attribute")
+      (is (= "y" (get attrs "data-y"))))))


### PR DESCRIPTION
## Summary

S4-B (rf2-vea1f) of the re-frame.ui S4 epic (rf2-vxgfnd.96). **Scope verdict: conformance/test-only.** The custom-element property-vs-attribute classification, kebab→camelCase mapping, and the JVM attributes-only + props-at-hydration split all **shipped with the S1b compiler core** (rf2-vxgfnd.2); dyudz classified the `:rf.ui/property-props` conversion-table rows. This leaf adds the S4-stage **conformance proof** the epic obligates — including the adversarial cases the RULED contract (Spec 004 §Template grammar / 004B §Custom elements) calls out. No source or spec change.

### Where the classification behaviour already lives (proven, not added here)
- `implementation/ui/src/re_frame/ui/compiler/analyze.cljc:1648,1671-1675,1702` — `property?` classification, camelCase `:react-name`, `:kind`, `:property-props`.
- `implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc:232` — property value passthrough under the camelCase name.
- `implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc:36-57,158,186` — property-props → `tree/element :props`.
- `implementation/ui/src/re_frame/ui/tree.cljc:196,231-274` — property classification + `:rf.ui/property-props` marker.
- `implementation/ui/src/re_frame/ui/semantic.cljc:124-162` — `N` omits property-props from markup (attributes-only).
- `implementation/ui/src/re_frame/ui/rules.cljc:387-391` — `custom-element-property-name` (kebab→camel).

### What this PR adds (2 test files)
- `custom_element_classification_jvm_test.clj` — the structural surface via the real `defview → tree → N` path: declared name → property (in `:attrs` + marker), undeclared → attribute, undeclared element → all-attributes, a **declared standard-attribute spelling (`:tab-index`) forced to a property** (declaration is the sole classifier), and `N` attributes-only markup omission with property names absent.
- `custom_element_classification_dom_cljs_test.cljs` — the **client half** on a real `react-dom/client` mount (browser job): declared `:accent-color` applied as the camelCase JS property `accentColor` and NOT reflected as an attribute; undeclared `:data-x`/`:label` ride as attributes with no matching JS property. This is the props-at-hydration side the server emitter cannot render. (No `reg-event`/`reg-sub` in the mounted test — avoids S4-A's eager-registrar-snapshot pitfall.)

### Red-before / green-after
Mutating the REAL classifier — `property?` in `analyze.cljc:1648` forced to `false` — turns the JVM test RED on the property marker, the attribute-override case, and the attributes-only markup-omission (property names leak into markup). Restored → green. The tests exercise the shipped classification, not a mock.

### Spec 009 / roster
Zero new error/trace/compile ids minted (tier: n/a). No Spec 009 or roster rows; no catalogue-drift check needed. No spec prose touched (the contract already fully describes the behaviour) → no mkdocs.

## Quality gates — all ran to completion, foreground
- **`implementation/ui` JVM** (`clojure -M:test`) — **809 tests / 14547 assertions, 0 failures, 0 errors** (includes the 5 new JVM conformance deftests).
- **`npm run test:cljs`** (node) — **9949 tests / 49027 assertions, 0 failures, 0 errors** (compiles + no-ops the DOM file on the non-DOM host).
- **`npm run test:browser`** (Chromium) — **457 tests / 2540 assertions, 0 failures, 0 errors** (the DOM conformance deftest's real client property-setting assertions run here — confirms React 19 sets the declared property as the camelCase JS property on the client).
- **`npm run test:adapter-smokes`** — **3 adapter-smoke specs (Reagent/UIx/Helix), 0 failures** (host parity).

Do NOT merge until CI confirms (it is authoritative).