### PR TITLE
docs(http): reconcile clear-http-interceptor api doc to the exact fail-closed contract (rf2-7sdlc)

### DIFF
--- a/docs/api/re-frame.http.md
+++ b/docs/api/re-frame.http.md
@@ -248,11 +248,11 @@ A middleware surface that mirrors the rest of the `reg-*` family. Use it to inje
   (clear-http-interceptor id)
   (clear-http-interceptor id {:frame target})
   ```
-- **Description**: Unregister an interceptor by id.
-  - `(clear-http-interceptor id)` resolves the frame from the carried scope it runs under.
-  - `(clear-http-interceptor id {:frame target})` names the frame explicitly via the trailing opts map, mirroring `reg-http-interceptor`'s `:frame` and the family's public-frame-targeting law (never a positional frame arg on a public surface).
-  - Either form raises `:rf.error/no-frame-context` when the frame is absent (single-arity under no scope, or opts `{:frame nil}`). It never clears against a synthesised `:rf/default`.
-  - The 2-arity is shape-discriminated: an opts map as the second arg is the public form, while a bare frame target in the first position is the internal frame-first `(frame id)` plumbing.
+- **Description**: Unregister an interceptor by id. The public surface is **exact** — the two shapes above, nothing else.
+  - `(clear-http-interceptor id)` resolves the frame through the ambient (carried-scope) chain it runs under. Under no scope it raises the always-on `:rf.error/no-frame-context` rather than clearing against a synthesised `:rf/default`.
+  - `(clear-http-interceptor id {:frame target})` names the frame explicitly via the trailing opts map, mirroring `reg-http-interceptor`'s `:frame` and the family's public-frame-targeting law (never a positional frame arg on a public surface). `target` is a present, non-nil frame-id keyword or a live frame value.
+  - The two-arity opts map is **fail-closed**: it MUST be exactly `{:frame target}`. A `{}`, a `{:frame nil}`, a typo'd or extra key (`{:fram f}`), and a non-map second arg all raise `:rf.error/http-bad-interceptor` BEFORE any ambient frame is resolved or touched — never reinterpreted as a positional frame nor silently cleared against the ambient scope (rf2-s32bf). This is distinct from the single-arity no-scope `:rf.error/no-frame-context`.
+  - The frame-first `(frame id)` spelling is a separate artefact-internal seam (`clear-http-interceptor*`), reached directly by internal cleanup that already holds a resolved frame — e.g. the `:rf.fx/clear-http-interceptor` fx — **not** a public arity of `clear-http-interceptor`.
 - **Example**:
   ```clojure
   (rf/clear-http-interceptor :auth-header)


### PR DESCRIPTION
Closes rf2-7sdlc.

## Problem

PR #6257 (rf2-i5t3h) reconciled `spec/014-HTTPRequests.md` and the migration guide to the exact fail-closed `clear-http-interceptor` facade shipped by rf2-s32bf (#6247), and rf2-hf4ts fixed `docs/api/re-frame.core.md`. The **dedicated** HTTP API page — the feature's primary programmer-facing reference — was missed and still taught the retired contract.

`docs/api/re-frame.http.md` under `### clear-http-interceptor` claimed:

- **"Either form raises `:rf.error/no-frame-context` when the frame is absent (single-arity under no scope, or opts `{:frame nil}`)"** — wrong. `{:frame nil}` raises `:rf.error/http-bad-interceptor`.
- **"The 2-arity is shape-discriminated: an opts map as the second arg is the public form, while a bare frame target in the first position is the internal frame-first `(frame id)` plumbing."** — wrong. The public fn is not shape-discriminated and has no frame-first arm.

A programmer following the page got a fail-loud surprise and the wrong error/recovery model.

## Shipped contract (the source of truth)

Per `implementation/http/src/re_frame/http/middleware.cljc` (`valid-clear-opts?` + `clear-http-interceptor`), the public surface is exact:

- `(clear-http-interceptor id)` — ambient carried scope; no scope raises `:rf.error/no-frame-context`.
- `(clear-http-interceptor id {:frame target})` — opts map must be **exactly** `{:frame target}` with a present, non-nil target. `{}`, `{:frame nil}`, a typo'd/extra key, and a non-map second arg all raise `:rf.error/http-bad-interceptor` **before** any ambient frame is resolved or touched.
- Frame-first `(frame id)` is the separately named artefact-internal `clear-http-interceptor*` seam (used by the `:rf.fx/clear-http-interceptor` fx), not a public arity.

## Change

Rewrote only the four description bullets of that one entry, mirroring the wording already landed in `spec/014-HTTPRequests.md` (§ interceptor clearing) and `docs/api/re-frame.core.md`. The signature block was already correct and is unchanged.

**Documentation-only** — no runtime change, no compatibility layer, public alias, or new validation mechanism. Diff is 5 insertions / 5 deletions in a single file.

The page is **hand-authored**, not generated (no generation marker or gen script targets it; `docs/api/` is consumed by the api-manifest projection check, which validates coverage/drift rather than emitting the file), so it is edited directly.

## Quality gates

| Gate | Result |
| --- | --- |
| `mkdocs build --strict` | **green** (exit 0; INFO-only, no strict warnings) |
| `clojure -M:test` in `implementation/scripts/api-manifest` (doc-api coverage + projection drift) | **green** — 99 tests, 217 assertions, 0 failures, 0 errors |

The api-manifest run confirms `docs/api` page+member coverage in sync (200 eligible manifest vars) and the `spec/Privacy.md + docs/api/ + docs/story/api/` projection in sync (311 public-var references).

Full spine not run — documentation-only diff with no runtime surface.
