### PR TITLE
test(ssr): execute the canonical startup recipe in the DOM-adoption regression (rf2-drq8s)

### DIFF
--- a/examples/capabilities/ssr/ssr/core.cljc
+++ b/examples/capabilities/ssr/ssr/core.cljc
@@ -75,7 +75,12 @@
             ;; byte-for-byte on the client.
             #?(:clj [re-frame.ssr.html-helpers :as html])
             #?(:cljs [reagent.dom.client :as rdc])
-            #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])))
+            #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])
+            ;; The client mount step — the payload-vs-client-only React-root
+            ;; branch — factored into a registration-free helper so the browser
+            ;; DOM-adoption regression can execute the EXACT branch this recipe
+            ;; ships, not a copy of it. See the ns docstring there.
+            #?(:cljs [ssr.mount :as mount])))
 
 ;; ============================================================================
 ;; SCHEMA
@@ -446,20 +451,20 @@
                                   :render-tree-fn (fn [] ((rf/view :app/root)))})
            tree    [rf/frame-provider {:frame app-frame} [(rf/view :app/root)]]]
        (when el
-         (if payload
-           ;; Server-rendered: ADOPT the painted DOM. `hydrate-root` reconciles
-           ;; React against the server markup — same nodes, listeners attached,
-           ;; no re-paint — and returns the retained root. `create-root` +
-           ;; `render` would throw the server HTML away and mount fresh, which is
-           ;; the bug this branch avoids.
-           (reset! react-root (rdc/hydrate-root el tree))
-           ;; No payload means no server render — a plain first load. Run the
-           ;; app's own bootstrap against the frame, then mount a fresh root; the
-           ;; page comes up showing the empty-articles fallback.
-           (do
-             (rf/dispatch-sync [:ssr/client-bootstrap] {:frame app-frame})
-             (reset! react-root (rdc/create-root el))
-             (rdc/render @react-root tree)))))))
+         ;; No payload means no server render — a plain first load. Run the
+         ;; app's own bootstrap against the frame before the fresh mount; a
+         ;; hydrating load skips it, because the server already booted this
+         ;; frame's state. (This is app logic, so it stays here in `run` rather
+         ;; than inside the shared mount helper.)
+         (when-not payload
+           (rf/dispatch-sync [:ssr/client-bootstrap] {:frame app-frame}))
+         ;; The adopt-vs-fresh React-root decision lives in ONE place —
+         ;; `ssr.mount/mount!` — so the DOM-adoption regression executes the
+         ;; exact branch this recipe ships instead of a copy: payload present ⇒
+         ;; `hydrate-root` ADOPTS the server DOM; absent ⇒ a fresh `create-root`
+         ;; + `render`. The retained root is stashed for `render!`'s hot-reload
+         ;; re-renders.
+         (reset! react-root (mount/mount! el tree payload))))))
 
 ;; No tests in this file — and that's deliberate. The example tree stays
 ;; test-free so the source reads as pure demonstration; the headless tests that

--- a/examples/capabilities/ssr/ssr/mount.cljs
+++ b/examples/capabilities/ssr/ssr/mount.cljs
@@ -1,0 +1,39 @@
+(ns ssr.mount
+  "The client mount step of the SSR startup recipe, factored into a single
+  registration-free helper so a test can drive the EXACT adopt-vs-fresh React
+  root branch `ssr.core/run` ships — not a hand-kept copy of it.
+
+  `mount!` is the payload-vs-client-only decision, and this is the one place it
+  lives. `ssr.core/run` calls it after it has READ+HYDRATE+VERIFIED state via
+  `re-frame.ssr/hydrate!`; the browser DOM-adoption regression
+  (`re-frame.ssr.ssr-startup-recipe-dom-cljs-test`) calls the SAME helper, so a
+  regression here — swapping `hydrate-root` for `create-root` — turns that proof
+  red.
+
+  Why its own namespace, and not a private `defn-` inside `ssr.core`: the
+  regression has to reach the helper WITHOUT `:require`-ing `ssr.core`, whose app
+  registrations (`:auth.session/store`, `:articles/loaded`, …) collide at image
+  assembly with the login + realworld examples already sharing the consolidated
+  test bundle (`:rf.error/image-duplicate-id`). This namespace registers nothing,
+  so a test loads only the mount logic and no example ids enter the bundle."
+  (:require [reagent.dom.client :as rdc]))
+
+(defn mount!
+  "Mount `tree` into the container `el`, adopting the server-rendered DOM when a
+  hydration `payload` is present.
+
+  - payload present ⇒ `hydrate-root`: React reconciles against the server markup
+    (same nodes, listeners attached, no re-paint) and the retained root is
+    returned. `create-root` + `render` here would throw the server HTML away and
+    mount fresh — the adopt-vs-replace bug this branch exists to avoid.
+  - payload absent ⇒ a fresh `create-root` + `render`.
+
+  Returns the retained React root, or nil when `el` is absent (no container to
+  mount into)."
+  [el tree payload]
+  (when el
+    (if payload
+      (rdc/hydrate-root el tree)
+      (let [root (rdc/create-root el)]
+        (rdc/render root tree)
+        root))))

--- a/implementation/ssr/test/re_frame/ssr/ssr_startup_recipe_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/ssr_startup_recipe_dom_cljs_test.cljs
@@ -30,21 +30,29 @@
   A `create-root` regression in the copyable recipe could therefore
   replace the server DOM while all of the above stayed green.
 
-  ## Why this drives the seam rather than importing `ssr.core`
+  ## How this executes the canonical recipe (rf2-drq8s)
 
-  The example ns `ssr.core` cannot be `:require`d into a CLJS test: it and
-  `examples/core/login/model.cljs` (ns `login.model`, already in the
+  The load-bearing branch of the recipe — payload present ⇒
+  `reagent.dom.client/hydrate-root` (adopt the server DOM); payload absent ⇒
+  `create-root` + `render` (fresh) — lives in ONE place: the registration-free
+  helper `ssr.mount/mount!`. `ssr.core/run` calls it, and so does `run-recipe!`
+  below, so this proof executes the SAME mount code the copyable recipe ships —
+  not a copy of it. Regress that branch (swap `hydrate-root` for `create-root`)
+  and this proof turns red.
+
+  `ssr.mount` is its own namespace rather than a private `defn-` in `ssr.core`
+  on purpose: this test must reach the helper WITHOUT `:require`-ing `ssr.core`,
+  whose app registrations (`:auth.session/store`, `:articles/loaded`, …) collide
+  at image assembly with `examples/core/login` (`login.model`, already in the
   consolidated `:node-test` bundle via `example_login_success_token_cljs_test`)
-  BOTH register the fx `:auth.session/store`, so co-loading them fails
-  image assembly with `:rf.error/image-duplicate-id` and breaks unrelated
-  tests bundle-wide. Per the bead's own allowance, this proof instead
-  drives the SMALLEST SHARED SEAM the recipe directly executes:
-  `run-recipe!` below is a line-for-line mirror of `ssr.core/run`'s mount
-  branch, exercising the SAME real machinery — `re-frame.ssr/hydrate!`
-  (payload read + state seed), the stock Reagent adapter, and
-  `reagent.dom.client/hydrate-root` / `create-root` / `render` — against
-  real planted server DOM. Keep this mirror in lock-step with
-  `ssr.core/run`.
+  and the realworld example (`realworld-http.*`, via `realworld-cljs-test`) —
+  `:rf.error/image-duplicate-id`, breaking unrelated tests bundle-wide.
+  `ssr.mount` registers nothing, so loading it pulls no example ids into the
+  bundle.
+
+  Everything ABOVE the mount call is exercised the same way `ssr.core/run` does
+  it — `re-frame.ssr/hydrate!` (payload read + state seed) and the stock Reagent
+  adapter — against real planted server DOM.
 
   The view here is a PLAIN component (not `reg-view`) on the `:rf/default`
   frame — deliberately. In a DEV build a registered-view root carries the
@@ -92,7 +100,11 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [reagent.dom.client :as rdc]
+            ;; The canonical mount helper `ssr.core/run` itself calls. Requiring
+            ;; it — NOT `ssr.core` — is what lets this proof execute the real
+            ;; adopt-vs-fresh React-root branch without pulling `ssr.core`'s app
+            ;; registrations (and their bundle-wide id collisions) into the test.
+            [ssr.mount :as mount]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.constants :as constants]
             [re-frame.test-support :as test-support]))
@@ -137,15 +149,24 @@
        "<button class=\"toggle-bodies\" data-testid=\"toggle-bodies\">Hide bodies</button>"
        "</div>"))
 
-;; ---- the recipe under test (mirror of ssr.core/run) ------------------------
+;; ---- the recipe under test: drives the canonical mount helper --------------
 
 (defn- run-recipe!
-  "Line-for-line mirror of `examples/capabilities/ssr/ssr/core.cljc` `run`'s
-  mount branch: install the stock Reagent adapter, stand up the client frame,
-  READ+HYDRATE+VERIFY state via `ssr/hydrate!`, then — payload present ⇒ ADOPT
-  the server DOM with `hydrate-root`; payload absent ⇒ fresh `create-root` +
-  `render`. `root-atom` stands in for the example's retained `react-root`.
-  Returns the payload `hydrate!` applied (nil on a client-only load)."
+  "Drives the client boot the way `ssr.core/run` does and hands the mount to the
+  SHARED `ssr.mount/mount!` — the single home of the adopt-vs-fresh React-root
+  branch `ssr.core/run` itself calls. Install the stock Reagent adapter, stand
+  up the client frame, READ+HYDRATE+VERIFY state via `ssr/hydrate!`, then mount
+  via `mount!`: payload present ⇒ ADOPT the server DOM with `hydrate-root`;
+  payload absent ⇒ fresh `create-root` + `render`. `root-atom` stands in for the
+  example's retained `react-root`. Returns the payload `hydrate!` applied (nil on
+  a client-only load).
+
+  The tree is a PLAIN component (see the ns docstring), not the recipe's own
+  registered `:app/root` view: a registered view's dev-only `data-rf-*`
+  annotations — which no server renderer reproduces — would make React treat
+  hydration as a mismatch and regenerate the tree, masking the adopt-vs-replace
+  signal. Driving `mount!` with a plain, annotation-free tree keeps that signal
+  clean while still executing the canonical mount branch."
   [root-atom]
   (rf/init! reagent-adapter/adapter)
   (rf/make-frame {:id app-frame :platform :client})
@@ -153,14 +174,7 @@
         payload (ssr/hydrate! {:frame app-frame :render-tree-fn (fn [] [recipe-view])})
         tree    [rf/frame-provider {:frame app-frame} [recipe-view]]]
     (when el
-      (if payload
-        ;; Server-rendered: ADOPT the painted DOM (same nodes, listeners
-        ;; attached, no re-paint).
-        (reset! root-atom (rdc/hydrate-root el tree))
-        ;; No payload: fresh root, mounted from scratch.
-        (do
-          (reset! root-atom (rdc/create-root el))
-          (rdc/render @root-atom tree))))
+      (reset! root-atom (mount/mount! el tree payload)))
     payload))
 
 ;; Async tests need the map-form fixture (a fn-form fixture's teardown races


### PR DESCRIPTION
Closes rf2-drq8s.

## The false-green

PR #6250 (rf2-byio7) added a real-browser DOM-adoption proof, but it drove a
**line-for-line mirror** of the recipe rather than the recipe itself. The mirror's
mount conditional lived at `ssr_startup_recipe_dom_cljs_test.cljs:157-163`
(private `run-recipe!`), and the test namespace never required `ssr.core`.

The dependency was not merely weak — it was *structurally absent*: with no browser
test requiring `ssr.core`, the canonical recipe was never even compiled into the
`:browser-test` bundle. Regressing the real payload branch at
`examples/capabilities/ssr/ssr/core.cljc:449-462` could not affect the proof at
all. Verified on main: with `hydrate-root` swapped for `create-root` + `render` in
the canonical recipe, the DOM-adoption test still passed.

## The fix

The load-bearing payload-vs-client-only React-root branch now lives in exactly one
place — `ssr.mount/mount!` (new, `examples/capabilities/ssr/ssr/mount.cljs`).
`ssr.core/run` calls it, and the regression calls the same helper, so the proof
executes the mount code the copyable recipe ships. The test no longer contains any
mount conditional.

**Why a separate namespace, not a `defn-` in `ssr.core`:** the test must reach the
helper without `:require`-ing `ssr.core`. Requiring it would pull its app
registrations into the consolidated test bundle, where they collide at image
assembly (`:rf.error/image-duplicate-id`) with examples already present — on
`:auth.session/store` (`login.model`, via `example_login_success_token_cljs_test`)
**and** on `:articles/loaded` (`realworld-http.articles`, via
`realworld-cljs-test`). So this is not a one-rename problem, as the original
investigation supposed. `ssr.mount` registers nothing, which resolves the
collision by avoiding it entirely — no example id had to be renamed, and the
canonical example remains runnable and copyable.

The test keeps its own plain-component tree (a registered view's dev-only
`data-rf-*` annotations would trigger a hydration mismatch and mask the
adopt-vs-replace signal) — but that tree is now mounted *through* the canonical
branch.

Semantics preserved: the client-only `:ssr/client-bootstrap` dispatch and the
retained root are intact in `run`; the JVM path is untouched, since the new
require is `#?(:cljs ...)`-guarded (confirmed: the JVM ns form elides it, so
`handle-request` and the JVM example tests are unaffected).

## Quality gates

Run to completion in the foreground.

| Gate | Result |
| --- | --- |
| `npm run test:browser` (after fix) | **456 tests / 2533 assertions, 0 failures, 0 errors** — exit 0 |
| `npm run test:cljs` (after fix) | **9948 tests / 49026 assertions, 0 failures, 0 errors** |

**Causal proof the false-green is closed** — regress `ssr.mount/mount!`'s payload
branch to `create-root` + `render` and the browser suite goes
**456 tests / 2533 assertions, 4 failures**, all in
`payload-backed-startup-adopts-server-dom-and-activates-handlers`:

```
FAIL in (payload-backed-startup-adopts-server-dom-and-activates-handlers)
  (ssr_startup_recipe_dom_cljs_test.cljs:277:21)
expected: (identical? server-btn after-btn)
  actual: (not (identical? #object[HTMLButtonElement] #object[HTMLButtonElement]))
```

plus the retained-node `isConnected`, the live-handler click, and the in-place
re-render assertions (lines 282, 291, 295). Reverted before commit; no probe
residue. The same mutation applied to the canonical recipe **before** this change
left the suite green — that is the boundary this PR closes.

Baseline note: an earlier run showed 1 failure in an unrelated act-env-sensitive
test; a clean re-run was green (456/2533, 0 failures), confirming it as a known
flake rather than a regression.
