### PR TITLE
test(flows): remove the vacuous registrar-hook test and stale teardown assertions (rf2-y678a)

### DIFF
--- a/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
+++ b/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
@@ -22,10 +22,10 @@
       same-frame multi-thread `dispatch-sync` would hit
       `:rf.error/dispatch-sync-in-handler` via the `:in-sync-drain?`
       guard, so we deliberately partition by frame. Per-frame `flows`
-      / `last-inputs` slots are independent; the global registrar
-      `:flow` slot IS shared (flow-id is global) but reg-flow stamps
-      the most-recently-registered frame onto its metadata per Spec
-      013 §Frame-scoping line 105.
+      / `last-inputs` slots are independent, and under the single store
+      (rf2-en00bk) they are the SOLE store — the `:flow` registrar slot
+      is RESERVED-but-empty, so no frame-blind slot is shared between
+      threads (Spec 013 §Frame-scoping).
     - **Per iter**, the thread runs the reg-flow → dispatch-drain →
       clear-flow cycle against a per-thread namespaced flow id
       (`:ztw5p.stress/double-f<i>`) whose `:derive` action increments a
@@ -33,17 +33,17 @@
       both bumping exactly once per dirty evaluation.
         1. `(rf/reg-flow ...)` against the per-thread frame —
            per-thread namespaced `:id` keeps each thread's `:derive`
-           closure binding independent (registrar is GLOBAL; one
-           shared `:id` would only bind the last closure).
+           closure and its per-thread assertions independently
+           attributable.
         2. `(rf/dispatch-sync [:bump-input] {:frame F})` — drives one
            dirty evaluation. The `:derive` fn bumps the global atomic
            AND the per-thread counter atom. Both bump exactly once
            per dirty evaluation (the dirty-check guarantees `:derive`
            runs once per input change).
         3. `(rf/clear-flow ...)` against the per-thread frame — must
-           dissoc both the per-frame registry slot AND (since this is
-           the LAST frame holding the id) the global registrar `:flow`
-           slot. Cleanup is the leak-invariant test surface.
+           dissoc the flow's per-frame registry slot, pruning the
+           frame-id key once its last flow is cleared. Cleanup is the
+           leak-invariant test surface.
 
   Invariants asserted:
 
@@ -74,10 +74,10 @@
        (read via `flows/flows-snapshot`) holds zero entries for every
        test frame, the dirty-check `last-inputs` map (read via
        `flows/last-inputs-snapshot`) holds zero entries for every
-       per-thread flow id, and the global `:flow` registrar slot is
-       unregistered for every per-thread flow id (the LAST frame
-       holding it released the id, so per Spec 013 §Frame-scoping
-       the registrar slot must be vacated).
+       per-thread flow id, and the reserved `:flow` registrar slot
+       reads `nil` for every per-thread flow id (it is never written
+       under the single store, so per Spec 013 §Frame-scoping there is
+       nothing to vacate).
 
   Threads start in lockstep via `CountDownLatch.countDown` — the same
   shape rf2-35rgj / rf2-1gpx8 use to maximise contention. Per-thread
@@ -138,9 +138,9 @@
   ;; cycle-detection-under-contention (every prospective cyclic
   ;; registration must throw, even when topo-sort is reading from a
   ;; concurrently-mutating per-frame slot) and clean-registry-
-  ;; teardown (the per-frame registry, the dirty-check `last-inputs`
-  ;; map, and the global `:flow` registrar slot all clear after the
-  ;; matching `clear-flow`).
+  ;; teardown (the per-frame registry and the dirty-check `last-inputs`
+  ;; map both clear after the matching `clear-flow`, and the reserved
+  ;; `:flow` registrar slot stays empty throughout).
   (testing (str n-threads " threads × " stress-iters
                 " iters reg-flow / dirty-eval / clear-flow — "
                 "no drops, no doubles, cycles still detected, no leaks")
@@ -152,8 +152,9 @@
           ;; §Rules rule 1 — frames are independent state machines,
           ;; their drain-locks don't share). Per-thread flow-ids let
           ;; each thread's `:derive` fn close over THIS thread's
-          ;; per-thread counter atom — `reg-flow` writes the GLOBAL
-          ;; registrar; each id binds independently in the registrar.
+          ;; per-thread counter atom — `reg-flow` writes the per-frame
+          ;; store, keyed `[frame-id flow-id]`, so each thread's frame
+          ;; and id bind independently.
           per-thread
           (vec
             (for [i (range n-threads)]
@@ -239,9 +240,9 @@
                           ;; if a future hangs.
                           idx)))]
         ;; Release all threads simultaneously — maximises lock-step
-        ;; contention on the GLOBAL registrar's `:flow` slot (each
-        ;; thread is writing/reading the same registrar kind during
-        ;; reg/clear).
+        ;; contention on the shared per-frame `flows` / `last-inputs`
+        ;; atoms (every thread is swapping the same two atoms during
+        ;; reg/clear, each under its own frame-id key).
         (.countDown latch)
         ;; Bounded join — if a cycle ever hangs (e.g. a clear-flow
         ;; that doesn't fire under contention), we want a visible
@@ -295,9 +296,9 @@
         ;;     thread cleared its flow, the per-frame registry must
         ;;     have the frame-id key fully PRUNED for every test frame,
         ;;     the `last-inputs` map must hold no entries for any
-        ;;     per-thread flow id, and the global `:flow` registrar slot
-        ;;     must be gone for every per-thread flow id (the LAST frame
-        ;;     holding it released the id per Spec 013 §Frame-scoping).
+        ;;     per-thread flow id, and the reserved `:flow` registrar slot
+        ;;     must read `nil` for every per-thread flow id (never written
+        ;;     under the single store, per Spec 013 §Frame-scoping).
         ;;
         ;; Each per-thread frame had ALL its flows cleared, so clearing the
         ;; last one prunes the frame-id key entirely — the slot is strictly

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -1294,7 +1294,7 @@
         "re-registration after reset works without raising")))
 
 ;; ---------------------------------------------------------------------------
-;; 7. clear-flow :frame opt routing — multi-frame registrar-slot retention
+;; 7. clear-flow :frame opt routing — multi-frame sibling isolation
 ;;
 ;; This deftest pins `clear-flow`'s `:frame` opt routing within the flows
 ;; artefact's own test alias — three branches in registry.cljc:
@@ -1302,11 +1302,13 @@
 ;; 1. Frame opt routing: `(clear-flow :foo {:frame :left})` removes the
 ;;    flow from `:left`'s per-frame map only; sibling frame `:right`'s
 ;;    identically-named flow stays intact.
-;; 2. "Last frame holding id" registrar-slot retention (registry.cljc
-;;    line ~254 `not-any?`): when the same flow id is registered against
-;;    two frames, clearing it from one frame must NOT unregister the
-;;    `:flow` registrar slot — the other frame still needs it for
-;;    hot-reload tracking. Clearing from the second frame then unregisters.
+;; 2. Sibling isolation across the whole clear sequence: when the same flow
+;;    id is registered against two frames, clearing it from one frame leaves
+;;    the other frame's per-frame entry authoritative in place, and clearing
+;;    the second frame drops the final entry. Under the single store
+;;    (rf2-en00bk) the `:flow` registrar slot is RESERVED-but-empty — never
+;;    written, so there is nothing to retain or unregister; the assertions
+;;    below pin it `nil` throughout.
 ;; 3. app-db `dissoc-in` is frame-local: clearing on `:left` only
 ;;    dissoc-in's `:left`'s app-db; `:right`'s app-db is untouched.
 ;;
@@ -1440,45 +1442,33 @@
             "the per-frame store slot is gone after the value-keyed clear")))))
 
 ;; ---------------------------------------------------------------------------
-;; 8. `_hot-reload-hook` defonce-idempotency on namespace reload
+;; 8. (removed) `_hot-reload-hook` defonce-idempotency on namespace reload
 ;;
-;; The flows registry installs a registrar replacement-hook
-;; (`invalidate-flow-on-replace!`) once at namespace load via
-;; `(defonce ^:private _hot-reload-hook
-;; (registrar/add-replacement-hook! ...))`. A plain `def` would push a
-;; duplicate hook into `re-frame.registrar/replacement-hooks` on every
-;; namespace reload — and every subsequent flow re-registration would
-;; invalidate `last-inputs` twice (functionally harmless because `dissoc` is
-;; idempotent, but a silent bookkeeping leak that would compound across many
-;; hot-reload cycles in long dev sessions).
-;;
-;; Pin the idempotency: `(require 're-frame.flows.registry :reload)`
-;; MUST NOT push a duplicate hook.
+;; This section formerly pinned `defonce` idempotency of a registrar
+;; replacement-hook that the flows registry installed at namespace load. No
+;; such hook exists under the single store (rf2-en00bk): `reg-flow` drops the
+;; re-registered `[frame-id flow-id]` last-inputs row directly. The hook-count
+;; check therefore asserted nothing about flows — reloading a namespace that
+;; installs no hook trivially leaves the unrelated hook vector unchanged — so
+;; it was removed (rf2-y678a). The re-registration behaviour it nominally
+;; guarded is proved causally by section 9a below: a same-frame replacement
+;; invalidates only that frame's last-inputs row, and the sibling's survives.
 ;; ---------------------------------------------------------------------------
-
-(deftest hot-reload-hook-is-defonce-idempotent
-  (testing "reloading re-frame.flows.registry does NOT install a duplicate replacement-hook"
-    (let [hooks-var (resolve 're-frame.registrar/replacement-hooks)
-          before    (count @(deref hooks-var))]
-      (require 're-frame.flows.registry :reload)
-      (let [after (count @(deref hooks-var))]
-        (is (= before after)
-            "the hook count is unchanged across a namespace reload — `defonce` guards the install")))))
 
 ;; ---------------------------------------------------------------------------
 ;; 9. Frame-scoping coverage lives in `clear-flow-routes-via-frame-opt`
-;; above (registration routing, app-db dissoc, registrar-slot retention,
+;; above (registration routing, app-db dissoc, per-frame sibling isolation,
 ;; AND the post-clear re-drain check).
 ;; ---------------------------------------------------------------------------
 
 ;; ---------------------------------------------------------------------------
-;; 9a. invalidate-flow-on-replace! is frame-scoped
+;; 9a. Re-registration invalidation is frame-scoped
 ;;
 ;; Spec 013 §Re-registration scopes the invalidation to `[frame-id flow-id]`.
-;; A replacement hook that wiped every frame's row under the flow id would
-;; have a re-registration on frame `:left` clear `:right`'s last-inputs row
-;; too, causing unnecessary recompute on `:right`'s next drain and weakening
-;; frame isolation.
+;; `reg-flow` invalidates that one row directly. An invalidation that wiped
+;; every frame's row under the flow id would have a re-registration on frame
+;; `:left` clear `:right`'s last-inputs row too, causing unnecessary recompute
+;; on `:right`'s next drain and weakening frame isolation.
 ;; ---------------------------------------------------------------------------
 
 (deftest hot-reload-on-one-frame-does-not-invalidate-sibling-frames-last-inputs

--- a/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
+++ b/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
@@ -77,11 +77,10 @@
 
 (deftest reg-flow-emits-no-registered-trace-under-prod
   (testing "Per Spec 009 §Production-elision (rf2-xxd6z): `reg-flow`
-            installs the flow via the registrar but emits NO
+            installs the flow into the per-frame flow store but emits NO
             `:rf.flow/registered` trace under `:advanced` +
-            `goog.DEBUG=false`. The registrar's own
-            `:rf.registry/handler-registered` would also elide (its
-            gate is symmetric); the assertion below is total."
+            `goog.DEBUG=false`. The listener records EVERY event, so the
+            assertion below is total — no trace of any kind is delivered."
     (let [seen (listener-fixture
                  (fn []
                    (rf/reg-flow :prod-elision/area
@@ -90,7 +89,7 @@
                      (fn [w h] (* (or w 0) (or h 0))))))]
       (is (empty? seen)
           "no trace events delivered under :advanced + goog.DEBUG=false"))
-    ;; Cross-check: the flow IS registered — the registrar mutation
+    ;; Cross-check: the flow IS registered — the per-frame store write
     ;; happened, only the trace surface elided. The per-frame flow
     ;; registry (read via `flows/flows-snapshot`) is keyed
     ;; `{frame-id {flow-id flow}}`; the flow registers under


### PR DESCRIPTION
Closes rf2-y678a.

PR #6255 fixed rf2-3neiv's destroy-conformance matcher but left 3neiv's explicit acceptance arm incomplete: the obsolete hot-reload hook test and the retired flow-registrar language in test authority both survived. This completes that arm. Test-only.

## The vacuous test

`implementation/flows/test/re_frame/flows_test.clj:1459` — `hot-reload-hook-is-defonce-idempotent`:

```clojure
(let [hooks-var (resolve 're-frame.registrar/replacement-hooks)
      before    (count @(deref hooks-var))]
  (require 're-frame.flows.registry :reload)
  (let [after (count @(deref hooks-var))]
    (is (= before after) ...)))
```

It claimed `re-frame.flows.registry` installs `_hot-reload-hook` via `registrar/add-replacement-hook!` and that a namespace reload must not duplicate it. **No such var or installer exists in flows.** `grep` over `implementation/flows/src` for `_hot-reload-hook|add-replacement-hook!|invalidate-flow-on-replace!|replacement-hooks` returns nothing; those symbols live in core and are used only by `subs/cache.cljc` and `substrate/observation.cljc`. Under the single store (rf2-en00bk) `reg-flow` performs same-frame last-input invalidation directly — a fact `flows_lifecycle_drain_race_test.clj:26` already records ("the former `registrar/register!` → `invalidate-flow-on-replace!` indirection is gone").

Reloading a namespace that installs no hook cannot change the count, so the assertion was trivially true. Measured on the flows test classpath:

```
hooks before: 0 | after 3 reloads of flows.registry: 0 | (= before after) => true
```

The vector is *empty* — the assertion was literally `(= 0 0)`, green regardless of flows' behaviour, and unable to detect any regression.

## Removed, not replaced

Per the bead's acceptance (replace "only if a current user-visible behavior is otherwise unproved"), deletion is correct: defonce-idempotence of a hook that does not exist is not a property of the system. The real re-registration behaviour is already proved causally by `hot-reload-on-one-frame-does-not-invalidate-sibling-frames-last-inputs` — a same-frame replacement drops only that frame's `last-inputs` row while the sibling frame's row survives. Section 8 now records the removal and points at that proof.

## Stale test contracts reconciled

Comments/docstrings only — every runtime assertion is unchanged, and each was already correct:

- **`flows_test.clj`** — section 7 no longer describes retaining/unregistering a global `:flow` registrar slot (its body already pins `(nil? (registrar/lookup :flow …))` throughout); section 9a no longer attributes the invalidation to the removed `invalidate-flow-on-replace!` hook.
- **`flows_concurrency_stress_test.clj`** — seven spots no longer say `reg-flow` writes a shared global registrar slot or that `clear-flow` releases it on last-frame; the end assertions already expected the reserved slot to stay `nil`.
- **`flows_trace_emit_elision_prod_test.cljs`** — no longer says `reg-flow` installs through a registrar or that a registrar mutation occurred; the cross-check reads the per-frame flow store.

Past-tense historical contrast is preserved per the bead's narrow-sweep instruction: 9b's double-store explanation, `flows_trace_test.clj`'s "pre-fix … gated on the GLOBAL registrar", and the drain-race test's "the former indirection is gone". Core-src comment work remains with rf2-qowmk and is not duplicated here.

## Quality gates

- `clojure -M:test` in `implementation/flows` (JVM, foreground): **240 tests, 6037 assertions, 0 failures, 0 errors.** The `:stress` ns is excluded from the default gate by the alias but still loads, so its comment edits are compile-checked.
- Vacuousness verified empirically before deletion (hook-count probe above).
- No runtime source changed — diff is 3 files, all under `implementation/flows/test/`. Test-only, so no bundle rebuild (`test/` is not a roster path).
- `test:elision` / `test:cljs` not run locally: the `.cljs` edit is a `testing` label string plus a comment, behaviour-neutral. CI owns those lanes.
