### PR TITLE
fix(doc-slugs): align heading-id + compatibility-anchor recognition with MkDocs render (rf2-ru0wg, rf2-ehxs8)

### DIFF
--- a/docs/core/how-to/report-errors-in-production.md
+++ b/docs/core/how-to/report-errors-in-production.md
@@ -16,7 +16,7 @@ This guide builds a production bridge to Sentry, one step at a time: register th
 
     You'd reach for `Sentry.init` plus the global `window.onerror` hook. That gives you the exception and its stack — genuinely useful — but it can't tell you what the app was actually *doing* when things went sideways. re-frame2's record carries the in-flight event alongside the throwable, so your issue tracker shows the *cause*, not just the crash site. The slogan: **production keeps the dossiers, not the firehose.**
 
-## 1. Register a listener {#register-a-listener}
+## 1. Register a listener
 
 Here is the smallest possible bridge. It catches every production failure and ships the throwable to Sentry:
 
@@ -46,7 +46,7 @@ One trap to disarm before you go further. There's a *different* stream, `registe
 
     The closest analogue is a logging / crash-reporting middleware you `applyMiddleware` once at store creation. The difference: this listener sits *outside* the data path entirely. It observes failures; it never sits in the reducer chain; it has no power to swallow, retry, or rewrite the action. It's a read-only seat by design — more on that in §5.
 
-## 2. Gate it so it can't fire in dev {#gate-it}
+## 2. Gate it so it can't fire in dev
 
 The substrate is always on, in dev *and* production, so the bare listener from §1 fires against your real Sentry project every time something throws while you're developing. Not what you want. The fix is to register it only in an actual production build — gate it behind your own build flag:
 
@@ -82,7 +82,7 @@ Two more properties fall out of the substrate's design for free:
 
 To take the bridge back down — a feature flag flipping off, say — call `(rf/unregister-listener! :errors ::sentry-bridge)`.
 
-## 3. Branch on the category, never the prose {#branch-on-the-category}
+## 3. Branch on the category, never the prose
 
 Now the second naive assumption. The `record` your listener receives isn't one fixed shape — it's one of several related shapes (a *union*), and not all of them carry an `:exception`. So your bridge has to look at a record and decide *which* kind it's holding before it reads fields off it.
 
@@ -124,7 +124,7 @@ Because these have no throwable, your bridge falls through to `captureMessage` �
 
     When the failing handler or subscription was registered through a `reg-*` macro, the record carries a `:source-coord` of `{:ns … :file … :line …}` — the definition site of the *broken* component. It's the production analogue of the jump-to-source chip [Xray](../glossary.md#xray) shows in dev, and it survives elision on purpose: the coord rides a separate always-on registry, *not* the public registration metadata (which is stripped of coord keys under `goog.DEBUG=false`). Ship it as `:extra` (above) and your Sentry issue links straight back to the line; it also makes a stabler fingerprint than a stack trace whose frames shift between builds. The slot is simply **absent** when the component was registered programmatically (no macro to capture the coord) — so read it defensively, never assume it's there.
 
-### Name the *failing* component, not just the event {#name-the-failing-component}
+### Name the *failing* component, not just the event
 
 Here's the subtlety that's the difference between a useful Sentry issue and a useless one. For most categories the failing id *is* the event id — `:rf.error/handler-exception` fails the handler, and the handler *is* the event; the `:rf.error/sub-*` categories carry the sub-id under `:event-id`. But two categories fail a component **distinct** from the dispatched event:
 
@@ -137,13 +137,13 @@ For exactly these two, the record **also** carries `:failing-id` (the broken int
 
     The error payload is a *tagged union* (a sum type) keyed by `(:error record)`, with `:exception` an *optional* field rather than a guaranteed one — so a correct consumer is a fold over the discriminant with a presence-check on the optional. The substrate guarantees the tag is a stable closed vocabulary while leaving the `:reason` prose free to vary: the classic move of pinning the machine-readable variant tag and treating the human string as a non-contractual rendering. Branch on the tag, project the optional, ignore the prose.
 
-### Don't scrub the `:event` yourself {#dont-scrub-the-event}
+### Don't scrub the `:event` yourself
 
 You don't have to redact the event vector by hand to keep secrets out of Sentry. The substrate runs it through `re-frame.elision/elide-wire-value` once before fan-out, with the off-box defaults. Paths your app classified as sensitive arrive as `:rf/redacted`, and oversized payloads arrive as the `:rf.size/large-elided` marker rather than the full thing. That's [data classification](../glossary.md#data-classification) doing its job at the egress boundary ([Keep secrets out of traces](keep-secrets-out-of-traces.md)).
 
 Now the flip side, out loud: the raw `:exception` is **not** scrubbed. The `:event` vector is wire-elided, but the host throwable rides raw — deliberately, because a post-mortem shipper needs the stack to be useful. The consequence: a value that landed in an exception message or `ex-data` is *not* redacted on this surface. This is the documented exception to the always-on substrate's "structured data only" rule. If that worries you for a given frame, the projected frame sink (§8) drops the `:exception` for you under its `:rf.egress/public-error` profile.
 
-## 4. Handle the frame-teardown report {#handle-the-frame-teardown-report}
+## 4. Handle the frame-teardown report
 
 One record shape breaks bridges written for "an error is an event with an exception," and it deserves its own branch. When a frame is destroyed it runs a batch of best-effort cleanup hooks — [flow](../glossary.md#flow) teardown, [resource](../../resources/glossary.md#resource) cleanup, [schema](../glossary.md#schema) deregistration, trace-ring release. Any of those may throw, and the runtime reports *all the ones that threw together*, in one bounded record with **no `:event` and no top-level `:exception`**:
 
@@ -197,7 +197,7 @@ Notice where the throwables live: **inside** the `:hook-failures` vector, one pe
 
     On the [server-side-rendering](../../ssr/glossary.md#ssr) tier, a handful of non-event categories arrive on this stream: `:rf.error/ssr-render-failed`, `:rf.error/ssr-streaming-writer-failed`, `:rf.error/malformed-hydration-payload`, `:rf.error/ssr-head-resolution-failed`, `:rf.error/sanitised-on-projection`, `:rf.error/ssr-ring-error-view-failed`, and `:rf.error/hydration-frame-id-mismatch`. They carry no `:event` / `:event-id`, each has its own flat keys, and some carry an `:exception` while others don't — one more reason the structural branch checks `:exception` presence rather than assuming it.
 
-## 5. Know what survives elision {#what-survives-elision}
+## 5. Know what survives elision
 
 It's worth being precise about what's still running in production, because the line isn't obvious from outside. ([Observability](../observability.md) is the full account of what [elision](../glossary.md#elide) removes and spares; here's the short version a monitor needs.)
 
@@ -213,7 +213,7 @@ It's worth being precise about what's still running in production, because the l
 
     On the JVM the diagnostic gate defaults **on**, the opposite of what you want in production. A production SSR host must set `-Dre-frame.debug=false` explicitly to shed the dev-verbose overhead (otherwise it retains user input in trace rings, per request). The good news: the error substrate fires under *both* settings, so this bridge keeps working there regardless — flipping the gate is purely about cost, not coverage.
 
-## 6. Verify it in dev {#verify-it-in-dev}
+## 6. Verify it in dev
 
 The substrate is live in dev too — only your gates keep the bridge *off* — which is convenient, because you can eyeball the branch before you ship. Register the listener body **without the gates**, dropping a `println` where the Sentry calls go:
 
@@ -235,7 +235,7 @@ Now exercise a few failing paths and watch the records print **synchronously**:
 
 That same handler failure also lands on Xray's trace surface as the full dev dossier — the firehose you have in dev, sitting right next to the tight record production will actually keep. Seeing both side by side is the fastest way to build the right intuition for what gets dropped at the elision boundary.
 
-## 7. Pair `:errors` with its `:events` sibling {#pair-errors-with-events}
+## 7. Pair `:errors` with its `:events` sibling
 
 Crash reporting is the `:errors` stream's job. Its sibling, the `:events` stream, answers the *other* production-observability question: how many events am I processing, how fast, and how many aborted? It fires one tight record per processed event after the run settles:
 
@@ -261,7 +261,7 @@ The two streams pair naturally: `:events` tells you *something is wrong* (a spik
 
     Think of `:events` as the per-query lifecycle telemetry you'd feed a metrics dashboard, and `:errors` as the crash channel you'd feed an issue tracker — except here they're two streams of one verb, differentiated by data, not two separate libraries you bolt on.
 
-## 8. Prefer the frame sink for metrics and privacy-bound egress {#prefer-the-frame-sink}
+## 8. Prefer the frame sink for metrics and privacy-bound egress
 
 So far every listener has been **corpus-wide** — one fan-out covering every frame in the app, carrying the raw `:exception` deliberately, because a post-mortem monitor needs the host throwable and its stack to be useful. That's the right tool for crash reporting. It is *not* the right tool for everything.
 

--- a/scripts/_test_fixtures/check_doc_slugs/compat_anchor_teeth/docs/machines/commented_heading.md
+++ b/scripts/_test_fixtures/check_doc_slugs/compat_anchor_teeth/docs/machines/commented_heading.md
@@ -1,0 +1,14 @@
+# Page
+
+<!--
+## Keep Me
+
+This heading lives entirely inside a multi-line HTML comment, so MkDocs renders
+no `keep-me` fragment target for it. A render-faithful checker must recognise
+headings on the comment-masked line, not the raw line (rf2-ehxs8) — otherwise
+the commented heading silently satisfies the compat manifest.
+-->
+
+Body text. The only source of a `keep-me` slug on this page is the commented
+heading above, which the browser never turns into a fragment target. No markdown
+links here.

--- a/scripts/_test_fixtures/check_doc_slugs/compat_anchor_teeth/docs/routing/loader_fake_before.md
+++ b/scripts/_test_fixtures/check_doc_slugs/compat_anchor_teeth/docs/routing/loader_fake_before.md
@@ -1,0 +1,17 @@
+# Loaders
+
+<!-- <a id="when-a-loader-fails"></a> -->
+
+A backticked example anchor `<a id="when-a-loader-fails"></a>` also appears before
+the passage, but inline code mints no fragment target either.
+
+On loader failure, the transition moves to the error state.
+
+<a id="when-a-loader-fails"></a>
+
+## Declaring resources instead
+
+The two anchors before the passage are non-rendered (one HTML-commented, one
+inline code); the sole RENDERED `when-a-loader-fails` anchor sits AFTER the
+loader-failure passage. Render-faithful placement must ignore both fakes and
+fail (rf2-ehxs8). No markdown links here.

--- a/scripts/_test_fixtures/check_doc_slugs/explicit_id_brace_not_a_target/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/explicit_id_brace_not_a_target/docs/index.md
@@ -1,0 +1,7 @@
+# Brace text is not a fragment target
+
+## One {#dup}
+
+Negative control (rf2-ru0wg): with `attr_list` disabled the brace suffix mints no
+fragment target, so a link to [the brace id](#dup) must be reported BROKEN. The
+rendered id is `one-dup`, not `dup`.

--- a/scripts/_test_fixtures/check_doc_slugs/explicit_id_brace_not_a_target/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/explicit_id_brace_not_a_target/mkdocs.yml
@@ -1,0 +1,4 @@
+# Self-test fixture marker (rf2-ru0wg).  Empty config is fine — the validator
+# only checks for this file's existence as the repo-root guard.  Negative control
+# for the renderer-parity tooth: the brace suffix itself is NOT a fragment target
+# under the real (attr_list-disabled) configuration.

--- a/scripts/_test_fixtures/check_doc_slugs/explicit_id_duplicate/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/explicit_id_duplicate/docs/index.md
@@ -1,0 +1,13 @@
+# Duplicate explicit-id headings disambiguate on the full-title slug
+
+## One {#dup}
+
+First occurrence — [the first rendered id](#one-dup).
+
+## One {#dup}
+
+Two headings carrying the SAME brace suffix slugify to the same full-title slug,
+so pymdownx.toc disambiguates the second with its `_N` suffix.
+
+The second heading's target is [the disambiguated id](#one-dup_1). The
+predecessor collapsed both headings onto the brace id `dup` (rf2-ru0wg).

--- a/scripts/_test_fixtures/check_doc_slugs/explicit_id_duplicate/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/explicit_id_duplicate/mkdocs.yml
@@ -1,0 +1,5 @@
+# Self-test fixture marker (rf2-ru0wg).  Empty config is fine — the validator
+# only checks for this file's existence as the repo-root guard.  Duplicate case
+# for the renderer-parity tooth: two headings carrying the same brace suffix
+# slugify to the same full-title slug and are disambiguated with pymdownx.toc's
+# _N suffix, rather than collapsing onto the brace id.

--- a/scripts/_test_fixtures/check_doc_slugs/explicit_id_full_title_ok/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/explicit_id_full_title_ok/docs/index.md
@@ -1,0 +1,8 @@
+# Explicit id renders as the full-title slug
+
+## One {#dup}
+
+The `attr_list` extension is NOT enabled in mkdocs.yml, so `{#dup}` is not an
+attribute list — it renders as literal heading text and the fragment id is the
+slugified FULL visible title. A link to [the rendered id](#one-dup) therefore
+resolves (rf2-ru0wg).

--- a/scripts/_test_fixtures/check_doc_slugs/explicit_id_full_title_ok/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/explicit_id_full_title_ok/mkdocs.yml
@@ -1,0 +1,5 @@
+# Self-test fixture marker (rf2-ru0wg).  Empty config is fine — the validator
+# only checks for this file's existence as the repo-root guard.  This fixture is
+# the renderer-parity tooth: with attr_list DISABLED (as in the real mkdocs.yml)
+# a `{#id}` suffix is literal heading text, so the fragment id is the slugified
+# FULL visible title.

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -587,16 +587,18 @@ def _scan_rendered_ids(path: Path) -> dict[str, int]:
     by `_strip_fences`, HTML comments are masked by `_mask_html_comments`, and
     inline-code spans are masked by `_strip_inline_code` before the anchor regex
     runs — anchor-shaped text that the browser never turns into a fragment target
-    therefore contributes nothing. Heading slugs are still derived from the
-    fence-stripped line (inline code inside a heading title is part of the
-    rendered slug, so it must NOT be masked away there).
+    therefore contributes nothing. Heading slugs are derived from the SAME
+    comment-masked line (rf2-ehxs8 — the predecessor matched headings on the raw
+    line, so a heading buried in a multiline HTML comment still minted a slug),
+    but inline code is deliberately NOT masked away there: inline code inside a
+    heading title is part of the rendered slug.
     """
     text = path.read_text(encoding="utf-8", errors="replace")
     counts: dict[str, int] = {}
     seen_counts: dict[str, int] = {}
     fence_stripped = _strip_fences(text.splitlines())
     comment_masked = _mask_html_comments(fence_stripped)
-    for (_, raw_line), (_, masked_line) in zip(fence_stripped, comment_masked):
+    for _, masked_line in comment_masked:
         # HTML anchor elements can appear on any line (heading or not). Only a
         # RENDERED anchor counts, so recognise them on the comment- and
         # inline-code-masked line.
@@ -605,7 +607,11 @@ def _scan_rendered_ids(path: Path) -> dict[str, int]:
             aid = am.group(1)
             counts[aid] = counts.get(aid, 0) + 1
 
-        m = _HEADING_RE.match(raw_line)
+        # Headings are recognised on the comment-masked line (rf2-ehxs8): a
+        # heading that lives entirely inside a multiline HTML comment renders no
+        # fragment target and must not be indexed. Inline code is NOT masked
+        # here — a heading title's inline code IS part of the rendered slug.
+        m = _HEADING_RE.match(masked_line)
         if not m:
             continue
         title = m.group(2).strip()
@@ -656,7 +662,9 @@ def _anchor_precedes_passage(
 ) -> bool:
     """True iff an explicit `<a id=anchor_id>` appears before the named passage.
 
-    `lines` are fence-stripped content lines. Returns False if the anchor is
+    `lines` are content lines the CALLER has already reduced to rendered source —
+    fence-stripped, and (from `_check_compat_anchor_placement`) HTML-comment- and
+    inline-code-masked, so only a real fragment target matches. Returns False if the anchor is
     absent, the passage is absent, or the anchor appears at/after the passage —
     each is a placement defect the caller reports (rf2-zq5i6). Kept a pure
     function so the placement teeth can drive it with a correct and a mutated
@@ -882,11 +890,17 @@ def _check_compat_anchor_placement(
         if not page.is_file():
             misplaced.append((page_rel, anchor, "page missing from working tree"))
             continue
+        # Placement must locate the RENDERED anchor (rf2-ehxs8): mask HTML
+        # comments and inline code as well as fenced code, so anchor-shaped text
+        # the browser never turns into a fragment target cannot stand in for the
+        # real anchor. Without this a commented/backticked fake anchor before the
+        # passage passes placement while the sole rendered anchor sits after it.
+        fence_stripped = _strip_fences(
+            page.read_text(encoding="utf-8", errors="replace").splitlines()
+        )
         lines = [
-            content
-            for _, content in _strip_fences(
-                page.read_text(encoding="utf-8", errors="replace").splitlines()
-            )
+            _strip_inline_code(content)
+            for _, content in _mask_html_comments(fence_stripped)
         ]
         if not _anchor_precedes_passage(lines, anchor, passage_re):
             misplaced.append(
@@ -1595,6 +1609,20 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("placement drifted — anchor after passage",
          dict(compat_anchors={}, source_files=(),
               placement={("docs/routing/loader_drifted.md", "when-a-loader-fails"):
+                         re.compile(r"On loader failure")}), 1),
+        # rf2-ehxs8 — both remaining raw/fence-only source paths made
+        # render-faithful. (1) A heading that exists ONLY inside a multiline HTML
+        # comment mints no fragment target, so it must not satisfy the manifest
+        # (the predecessor matched headings on the raw line). (2) Placement must
+        # locate the RENDERED anchor: commented and backticked anchor-shaped text
+        # before the passage must not stand in for the sole real anchor, which
+        # sits after it.
+        ("commented-only heading mints no rendered slug",
+         dict(compat_anchors={"docs/machines/commented_heading.md": ("keep-me",)},
+              source_files=(), placement={}), 1),
+        ("placement ignores commented/backticked fake anchor before passage",
+         dict(compat_anchors={}, source_files=(),
+              placement={("docs/routing/loader_fake_before.md", "when-a-loader-fails"):
                          re.compile(r"On loader failure")}), 1),
         # rf2-57k74 source-comment mechanism (Machines).
         ("source-comment link valid",

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -203,9 +203,19 @@ EXCLUDE_DIR_REL = frozenset({Path("docs/spec"), Path("docs/migration")})
 # treats as code, not headings.
 _HEADING_RE = re.compile(r"^(?:[ \t]*>[ \t]?)*(#{1,6})[ \t]+(.+?)[ \t]*#*[ \t]*$")
 
-# Custom heading id syntax: "## Title {#explicit-id}" — pymdownx.toc honours
-# this when the attr_list extension is enabled.  We're conservative and accept
-# any {#id} suffix on H1-H3 headings.
+# Custom heading id syntax: "## Title {#explicit-id}".  python-markdown honours
+# this ONLY when the attr_list extension is enabled, and mkdocs.yml does NOT
+# enable it (see `markdown_extensions`: meta, admonition, footnotes, toc,
+# pymdownx.*).  Under the real configuration the brace suffix is therefore
+# ordinary heading TEXT: "## One {#dup}" renders the visible title "One {#dup}"
+# with id "one-dup", not "dup".  `_scan_rendered_ids` consequently slugifies the
+# full visible title and has no explicit-id special case — the predecessor's
+# special case recorded "dup" and so certified fragments the site never mints
+# (rf2-ru0wg).
+#
+# The pattern is retained only because scripts/check_readme_links.py imports it
+# (it validates the GitHub-rendered READMEs, a different renderer with its own
+# heading-id rules).  Nothing in THIS module uses it.
 _EXPLICIT_ID_RE = re.compile(r"\{#([A-Za-z0-9_\-:.]+)\}\s*$")
 
 # Inline HTML anchor — authors use `<a name="foo"></a>` / `<a id="foo"></a>`
@@ -615,11 +625,11 @@ def _scan_rendered_ids(path: Path) -> dict[str, int]:
         if not m:
             continue
         title = m.group(2).strip()
-        explicit = _EXPLICIT_ID_RE.search(title)
-        if explicit:
-            slug = explicit.group(1)
-        else:
-            slug = SLUGIFY(title, SLUG_SEP)
+        # attr_list is NOT enabled in mkdocs.yml, so a trailing `{#id}` is not an
+        # attribute list — it is literal heading text and the rendered fragment id
+        # is the slugified FULL visible title (rf2-ru0wg).  Slugify the title
+        # exactly as authored; no explicit-id special case.
+        slug = SLUGIFY(title, SLUG_SEP)
         if not slug:
             continue
         # pymdownx.toc disambiguates duplicate HEADING slugs by appending _N
@@ -1403,6 +1413,13 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("ai_findings_dir_link_flagged",     1),  # rf2-l7yj8
         ("blockquoted_heading_ok",           0),  # rf2-869k9m
         ("indented_heading_not_indexed",     1),  # rf2-869k9m (negative control)
+        # rf2-ru0wg — renderer parity for `## Title {#id}` headings. attr_list is
+        # NOT enabled in mkdocs.yml, so the brace suffix is literal heading text
+        # and the fragment id is the slugified FULL visible title. The parity
+        # tooth, its negative control, and the duplicate case:
+        ("explicit_id_full_title_ok",        0),  # `{#dup}` -> id `one-dup`
+        ("explicit_id_brace_not_a_target",   1),  # `#dup` is NOT a target
+        ("explicit_id_duplicate",            0),  # -> `one-dup`, `one-dup_1`
     ]
 
     failures = 0

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1588,7 +1588,7 @@ UI already reads.
 [:rf.assert/schema-error {:where :event :event :checkout/submit}]
 ```
 
-### The schema-violation invariant {#schema-violation-invariant}
+### The schema-violation invariant
 
 The invariant is implemented as a **refinement of the agreement floor**, not
 an opt-in (rf2-5x1wt.21). It rests on three pieces, all pure data → data:
@@ -2032,7 +2032,7 @@ rather than maintaining independent result schemas. This unification
 fixes the documented "false GREEN," where run-state and the assertions
 slot disagreed.
 
-### Run-result evidence projection {#run-result-evidence-projection}
+### Run-result evidence projection
 
 The evidential run-result slots are **projections from one retained epoch
 tape**, not a second capture path. The boundary lives in
@@ -2116,7 +2116,7 @@ already hashes `:epoch-tape` alongside the projected `:schema-violations` /
 `:warnings` / `:effects`, so a divergent projection perturbs the
 run-equivalence hash.
 
-### Unified run result {#unified-run-result}
+### Unified run result
 
 There is **one run-result shape**, assembled by **one boundary** —
 `re-frame.story.result/run-result` (re-exported as `story/run-result`).
@@ -3374,7 +3374,7 @@ run-results (`strip-noise` — the volatile / per-run-stamp / `:rf.story/*`
 strip without the map-flattening ordering pass `canonicalize` applies), so
 they read named slots while seeing none of the per-run noise.
 
-## Golden slices {#golden-slices}
+## Golden slices
 
 A **golden slice** is a curated canonicalized run regression artifact — the
 deferred P1.5 surface (§Shared primitive lock), unblocked now that


### PR DESCRIPTION
Two P2 render-faithfulness bugs on the doc-slug/anchor checker. Both fixes are
checker-side; the only doc change is the heading reconciliation rf2-ru0wg's
acceptance explicitly calls for. `mkdocs.yml` is untouched.

## rf2-ru0wg — explicit heading ids assumed an extension that isn't enabled

`scripts/check_doc_slugs.py:209` treated a trailing `{#id}` as the rendered
fragment id, but python-markdown only honours that with `attr_list`, and
`mkdocs.yml` does not enable it (`markdown_extensions`: meta, admonition,
footnotes, toc, pymdownx.*). Under the real config the suffix is ordinary heading
TEXT: `## One {#dup}` renders the visible title `One {#dup}` with id `one-dup`,
while the checker recorded `dup`.

That let the gate certify fragments the site never mints, and leaked literal
brace text onto the page. Both live cases were real — `## Golden slices
{#golden-slices}` rendered as id `golden-slices-golden-slices`, so the two
in-page links to `#golden-slices` and one to `#run-result-evidence-projection`
passed the gate but would not resolve in a browser.

Taking the branch of the acceptance that needs no config change: the explicit-id
special case is dropped and the full visible title is slugified, then the 14
authored headings are reconciled by removing the inert `{#id}` suffixes. Their
natural slugs are exactly what the existing in-page links already target, so
those links now resolve for real. No other in-repo link referenced any removed id
(verified across `docs/ spec/ skills/ migration/ tools/*/spec/ implementation/
examples/`).

`_EXPLICIT_ID_RE` is retained but unused here: `scripts/check_readme_links.py`
hard-imports it for the GitHub-rendered READMEs — a different renderer and
outside this bead's surface. No README in the repo uses the syntax, so that path
is latent; flagged below rather than widened into.

## rf2-ehxs8 — two paths still read raw/fence-only source

PR #6236 (rf2-zq5i6) made anchor recognition render-faithful; two paths still
accepted markup the browser never turns into a fragment target. Both now reuse
zq5i6's own `_mask_html_comments` + `_strip_inline_code` helpers — no new
machinery.

* `_scan_rendered_ids` masked comments for the anchor scan but matched headings
  on the raw line, so a heading buried in a multiline HTML comment still minted a
  slug. Headings now match the comment-masked line. Inline code is deliberately
  still not masked for the title — a heading's inline code is part of its
  rendered slug — so ordinary heading slug semantics are preserved.
* `_check_compat_anchor_placement` built its lines with `_strip_fences` alone, so
  a commented or backticked anchor-shaped string before the passage satisfied
  placement while the sole rendered anchor sat after it. It now reduces the page
  to rendered source first.

The manifest, count-based uniqueness, source walk, and bounded-checker shape are
unchanged. No MkDocs rendering and no general Markdown parser is introduced.

## Quality gates

Run in the worktree at the committed tree; `main`'s gates were green beforehand
and the same commands were run as a baseline.

| Gate | Before | After |
| --- | --- | --- |
| `python scripts/check_doc_slugs.py` | exit 0, 528 files | **exit 0, 528 files** |
| `python scripts/check_doc_slugs.py --self-test` | 39 passed | **44 passed** (+5 new teeth) |
| `python scripts/check_doc_slugs.py --synthesis-only` | exit 0 | **exit 0** |
| `mkdocs build --strict` | exit 0 | **exit 0** (48.8s) |
| `python scripts/check_readme_links.py` (+ `--self-test`) | exit 0 | **exit 0** (import of the changed module intact) |

Red-before / green-after — every new tooth was added first and observed failing
against the unfixed checker:

| Tooth | Before | After |
| --- | --- | --- |
| `explicit_id_full_title_ok` — `{#dup}` resolves as `one-dup` | FAIL got 1 | PASS 0 |
| `explicit_id_brace_not_a_target` — `#dup` is NOT a target (adversarial) | FAIL got 0 | PASS 1 |
| `explicit_id_duplicate` — duplicates give `one-dup` / `one-dup_1` | FAIL got 2 | PASS 0 |
| `commented-only heading mints no rendered slug` (adversarial) | FAIL got 0 | PASS 1 |
| `placement ignores commented/backticked fake anchor before passage` (adversarial) | FAIL got 0 | PASS 1 |

Renderer parity was verified directly rather than assumed: the reconciled page
was built and its rendered `<h*>` ids compared against the checker's index —
**no missed and no invented ids**, and zero `{#` text remains in the rendered
HTML. The three previously-uncertifiable 017 anchors (`golden-slices`,
`run-result-evidence-projection`, `unified-run-result`) now resolve.

## Follow-up (not actioned — outside surface)

`scripts/check_readme_links.py:208` carries the same explicit-id assumption for
the GitHub-rendered READMEs. GitHub does not honour `{#id}` either, so the branch
is wrong there too, but it is currently latent: no tracked `README.md` uses the
syntax. Worth a small bead; deliberately not widened into here.
