### PR TITLE
fix(api-manifest): require exact keyword tokens in create-root option guards (rf2-xdda3)

### DIFF
--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
@@ -451,20 +451,27 @@
   "(?:(?!\\|)(?!\\bnot\\b)(?!n't)(?!\\bno\\b)(?!\\bnever\\b).){0,40}")
 
 (def ^:private root-id-required-re
-  "The create-root row must assert authored `:root-id` is REQUIRED, EXACTLY
-   (rf2-e9q33; tightened rf2-asxo3): the WHOLE `:root-id` token — a trailing
-   `-`/word char (`(?![-\\w])`) rejects a `:root-id-v2` prefix drift — bridged
-   by `option-bridge` (same cell, no negation) to `required`. So `:root-id is
-   not required`, `:root-id-v2 required`, and far-away prose no longer pass."
-  (re-pattern (str ":root-id(?![-\\w])" option-bridge "\\brequired\\b")))
+  "The create-root row must assert authored `` `:root-id` `` is REQUIRED,
+   EXACTLY (rf2-e9q33; tightened rf2-asxo3, made exact rf2-xdda3): the token
+   is pinned by its Markdown CODE-SPAN delimiters — a backtick on BOTH edges —
+   bridged by `option-bridge` (same cell, no negation) to `required`. The
+   asxo3 right-edge lookahead `(?![-\\w])` was not a token boundary: it still
+   admitted `:root-id?`, `:root-id!`, `:root-id*`, `:root-id.v2`,
+   `:root-id/foo` (adjacent keyword chars outside `[-\\w]`) and, having no
+   left edge at all, `::root-id` and `:opts:root-id`. Each is a DIFFERENT
+   option. The backtick delimiters close both edges at once, so only the exact
+   token satisfies the pin."
+  (re-pattern (str "`:root-id`" option-bridge "\\brequired\\b")))
 
 (def ^:private disambiguator-invalid-re
-  "The create-root row must assert `:disambiguator` is INVALID, EXACTLY
-   (rf2-e9q33; tightened rf2-asxo3): the WHOLE `:disambiguator` token (no
-   `:disambiguator-old` prefix drift) bridged by `option-bridge` to `invalid`.
-   A row that drops it, renames the token, or reverses the polarity
-   (`:disambiguator is not invalid`, silently admitting the option) goes red."
-  (re-pattern (str ":disambiguator(?![-\\w])" option-bridge "\\binvalid\\b")))
+  "The create-root row must assert `` `:disambiguator` `` is INVALID, EXACTLY
+   (rf2-e9q33; tightened rf2-asxo3, made exact rf2-xdda3): the same
+   both-edge code-span delimiting as `root-id-required-re`, bridged by
+   `option-bridge` to `invalid`. A row that drops it, renames the token
+   (`:disambiguator-old`, `:disambiguator?`, `:disambiguator/old`,
+   `::disambiguator`), or reverses the polarity (`:disambiguator is not
+   invalid`, silently admitting the option) goes red."
+  (re-pattern (str "`:disambiguator`" option-bridge "\\binvalid\\b")))
 
 (defn read-api-md-lines
   "Read spec/API.md as `[[line-no line-text] ...]` (1-based). Shared by

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
@@ -570,6 +570,66 @@
                        "`:rf.ui.compile/missing-root-id` and `:disambiguator` is invalid"))))))
 
 ;; ---------------------------------------------------------------------------
+;; create-root option grammar — EXACT KEYWORD TOKENS (rf2-xdda3).
+;;
+;; asxo3's `(?![-\w])` guarded only the token's RIGHT edge, and only against
+;; `[-\w]`. So every keyword char OUTSIDE that class still bridged a different
+;; option to the pin (`:root-id?`, `:root-id!`, `:root-id*`, `:root-id.v2`,
+;; `:root-id/foo`), and — with no left edge at all — so did anything that
+;; merely ENDED with the token (`::root-id`, `:opts:root-id`). Each names a
+;; different option yet false-greened the exact `:root-id` REQUIRED /
+;; `:disambiguator` INVALID contract. The repair pins the token by its
+;; Markdown code-span delimiters (a backtick on BOTH edges). These fixtures
+;; pin each enumerated exactness hole RED.
+;; ---------------------------------------------------------------------------
+
+(deftest option-token-punctuation-suffix-fails
+  (testing "adjacent keyword punctuation outside [-\\w] (`?`, `!`, `*`, `.`)
+            names a DIFFERENT option and no longer satisfies either pin"
+    (doseq [suffix ["?" "!" "*" ".v2"]]
+      (is (= [:root-id-not-required]
+             (map :kind (option-probe
+                          (str "`:root-id" suffix "` required and "
+                               "`:disambiguator` is invalid"))))
+          (str ":root-id" suffix " must not satisfy the :root-id pin"))
+      (is (= [:disambiguator-admitted]
+             (map :kind (option-probe
+                          (str "`:root-id` required and "
+                               "`:disambiguator" suffix "` is invalid"))))
+          (str ":disambiguator" suffix " must not satisfy the :disambiguator pin")))))
+
+(deftest option-namespaced-token-fails
+  (testing "a NAMESPACED variant (`:root-id/foo`, `:disambiguator/old`) is a
+            different option — the `/` no longer slips past the right edge"
+    (is (= #{:root-id-not-required :disambiguator-admitted}
+           (set (map :kind (option-probe
+                             (str "`:root-id/foo` required and "
+                                  "`:disambiguator/old` is invalid"))))))))
+
+(deftest option-auto-resolved-token-fails
+  (testing "an AUTO-RESOLVED keyword (`::root-id`, `::disambiguator`) is a
+            different option — the LEFT edge asxo3 never guarded"
+    (is (= #{:root-id-not-required :disambiguator-admitted}
+           (set (map :kind (option-probe
+                             (str "`::root-id` required and "
+                                  "`::disambiguator` is invalid"))))))))
+
+(deftest option-left-edge-token-suffix-fails
+  (testing "a token that merely ENDS with the pinned name (`:opts:root-id`)
+            no longer matches as a SUFFIX — both edges are pinned"
+    (is (= #{:root-id-not-required :disambiguator-admitted}
+           (set (map :kind (option-probe
+                             (str "`:opts:root-id` required and "
+                                  "`:opts:disambiguator` is invalid"))))))))
+
+(deftest option-token-must-be-a-code-span
+  (testing "the pin requires the token as a Markdown CODE SPAN — bare prose
+            mentioning the option (no backticks) is not the exact token"
+    (is (= #{:root-id-not-required :disambiguator-admitted}
+           (set (map :kind (option-probe
+                             "authored :root-id required and :disambiguator is invalid")))))))
+
+;; ---------------------------------------------------------------------------
 ;; re-frame.ui.test HOST-SIGNATURE guard — JVM (:clj) lane (rf2-5bcdi;
 ;; kind-aware + exact rf2-d7sso).
 ;;


### PR DESCRIPTION
Direct follow-up to rf2-asxo3 (#6265). That PR tightened the create-root option regexes with a `(?![-\w])` negative lookahead; the lookahead is **not** a keyword-token boundary.

## The remaining exactness holes

`implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj:459` and `:467` matched `:root-id(?![-\w])` / `:disambiguator(?![-\w])`. That guards only the **right** edge, and only against `[-\w]`:

- every keyword char *outside* `[-\w]` still passed the lookahead — `:root-id?`, `:root-id!`, `:root-id*`, `:root-id.v2`, `:root-id/foo` (and the `:disambiguator` analogues);
- there was **no left edge at all**, so any token merely *ending* with the pinned name matched as a suffix — `::root-id`, `:opts:root-id`.

Each names a different option, yet all of them false-greened the exact `:root-id` REQUIRED / `:disambiguator` INVALID contract Spec 004C fixes.

## The fix

Pin the token by its Markdown **code-span delimiters** — a backtick on both edges:

```clojure
(re-pattern (str "`:root-id`"       option-bridge "\brequired\b"))
(re-pattern (str "`:disambiguator`" option-bridge "\binvalid\b"))
```

One delimiter closes both edges at once. asxo3's `option-bridge` (same cell, no negation) is reused unchanged, and the one-row guard keeps its shape — no keyword parser, no Markdown grammar, per the bead's explicit anti-over-engineering fence.

**Checker-only.** The committed `spec/API.md` create-root row already writes both tokens as code spans, so no API-row data changed and `live-create-root-options-are-pinned` stays green.

## Red-before / green-after

Probe over the guard, before vs after (`[]` = false-green):

| row fragment | before | after |
|---|---|---|
| committed clause (baseline) | `[]` | `[]` |
| `` `:root-id-v2` `` / `` `:disambiguator-old` `` (asxo3) | red | red |
| `` `:root-id?` `` / `` `:disambiguator?` `` | `[]` | red |
| `` `:root-id!` `` / `` `:disambiguator!` `` | `[]` | red |
| `` `:root-id*` `` / `` `:disambiguator*` `` | `[]` | red |
| `` `:root-id.v2` `` / `` `:disambiguator.old` `` | `[]` | red |
| `` `:root-id/foo` `` / `` `:disambiguator/old` `` | `[]` | red |
| `` `::root-id` `` / `` `::disambiguator` `` | `[]` | red |
| `` `:opts:root-id` `` / `` `:opts:disambiguator` `` | `[]` | red |
| unbackticked bare prose | `[]` | red |

Five new adversarial deftests cover these families: `option-token-punctuation-suffix-fails`, `option-namespaced-token-fails`, `option-auto-resolved-token-fails`, `option-left-edge-token-suffix-fails`, `option-token-must-be-a-code-span`. asxo3's existing negation / reversed-polarity / token-prefix / far-prose / cross-cell / deletion / committed-row cases are untouched and still green.

## Quality gates

`cd implementation/scripts/api-manifest && clojure -M:test` — foreground, unpiped:

```
OK: spec/API.md projection in sync (217 var-rows checked against the manifest).
OK: docs/api page+member coverage in sync (200 eligible manifest vars each have a page + member entry).
OK: spec/Privacy.md + docs/api/ + docs/story/api/ projection in sync (311 public-var references checked).
OK: docs/core/ + docs/*/concepts.md projection in sync (655 public-var references checked).
OK: skills/ projection in sync (505 public-var references checked).

Ran 104 tests containing 229 assertions.
0 failures, 0 errors.
```

Grown from asxo3's 99 tests / 217 assertions to 104 / 229, still 0 fail. Not a roster path — no bundle rebuild.

Closes rf2-xdda3.
