### PR TITLE
test(reactive): complete the mounted NaN proof through the public Reagent path (rf2-mjpmp)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_cljs_test.cljs
@@ -49,7 +49,25 @@
   AND an integrated ViewCell (`re-frame.ui.reactive` — colocated on the
   consolidated `:node-test` classpath, which carries both `ui/src` and
   `adapters/reagent`), and (c) retain a real-movement positive control so
-  upstream suppression cannot make the assertions vacuous."
+  upstream suppression cannot make the assertions vacuous.
+
+  rf2-mjpmp (mounted arm) — the SAME fact at a REAL React mount, through the
+  PUBLIC compiled path, lives in the sibling namespace
+  `re-frame.observation-port-watchable-host-mounted-dom-cljs-test` (the
+  `-dom-cljs-test` suffix is what enrols it in the `:browser-test` build; this
+  file's `-cljs-test` suffix is `:node-test` only). The two headless arms here
+  drive the ViewCell by hand (`with-capture` / `commit!`, and a
+  `reactive/subscribe` listener standing in for a render), which pins the
+  cell-level contract headlessly but leaves the PUBLIC mount path unexercised.
+  The mounted arm closes that gap: it installs the stock Reagent adapter and
+  mounts a compiled sub-reading `defview` through the public compiled mount
+  path, so a NaN→NaN recompute is judged by the REAL mounted render — the
+  compiled view's own body invocation and the React commit — not by a listener
+  count. Reagent supplies the WATCHABLE host (its Reaction notifies on
+  NaN→NaN); the compiled ViewCell reads that host THROUGH the observation port,
+  which is what makes `make-watch-handler`'s suppression load-bearing at a live
+  mount. The corrected section header below records why that composition is
+  supported."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.ratom :as ratom]
             [re-frame.core :as rf]
@@ -299,43 +317,61 @@
 ;; rf2-r09qj — NaN moves NaN-STABLY through an integrated ViewCell
 ;; ===========================================================================
 ;;
-;; WHY THE "render" IS A HEADLESS `reactive/subscribe` LISTENER, NOT A REACT
-;; MOUNT (rf2-en6qm). An audit (rf2-en6qm) asked to re-establish this fact at a
-;; REAL mounted render (a live React component's render count) rather than a
-;; `useSyncExternalStore` listener. That is architecturally UNREACHABLE for THIS
-;; fact without a runtime change, because the two properties the proof needs are
-;; mutually exclusive across every supported adapter:
+;; WHY THIS ARM'S "render" IS A HEADLESS `reactive/subscribe` LISTENER — and why
+;; that is a COMPLEMENT to, not a substitute for, the mounted arm below.
 ;;
-;;   1. HOST WATCH FIRES ON NaN→NaN. Only the ratom Reaction (Reagent /
-;;      reagent-slim) notifies on NaN→NaN — its notify gate is raw `=`
-;;      (`(= ##NaN ##NaN)` is false). That firing on a NO-move is the whole
-;;      point: it is what makes the observation port's `node-value=` suppression
-;;      (make-watch-handler) LOAD-BEARING. The first-party re-frame.ui / UIx /
-;;      Helix watchable substrate gates notify on `rf=`
-;;      (`Object.is(##NaN,##NaN)` is true — `re_frame/substrate/spine.cljs`
-;;      `rf=`), so its host watch does NOT fire on NaN→NaN and the
-;;      make-watch-handler is never even reached.
-;;   2. DRIVES A ViewCell AT A REAL MOUNT. Only re-frame.ui / UIx / Helix render
-;;      through the observation port → ViewCell → `useSyncExternalStore`. Reagent
-;;      and reagent-slim render NATIVELY through `re-frame.views` /
-;;      `create-class`; a mounted Reagent view never touches the observation port
-;;      or a ViewCell. And `re-frame.ui.client/mount!` refuses a non-`re-frame.ui`
-;;      adapter generation, so "Reagent host + ViewCell real mount" is not a
-;;      supported configuration.
+;; This test drives a real `re-frame.ui.reactive` cell by hand (`with-capture` /
+;; `commit!`) and reads the SAME `useSyncExternalStore` `subscribe` seam React
+;; calls, so it pins the cell-level contract — version, revision, and listener
+;; notification — without a DOM. That is genuinely useful: it runs headlessly in
+;; the `:node-test` build, on every PR, with no browser.
 ;;
-;; So the ONLY host that fires on NaN→NaN (property 1) is exactly the family that
-;; never drives a ViewCell (property 2). At a real mounted render on the ui
-;; adapter a NaN→NaN produces zero renders too — but for the WRONG reason (the
-;; host's own `rf=` gate suppresses at source; the sentinel would NOT fire), so
-;; it would prove the spine's notify gate, not make-watch-handler suppression.
-;; This integrated ViewCell (real `re-frame.ui.reactive` cell, driven by
-;; `with-capture`/`commit!` and observed via the SAME `useSyncExternalStore`
-;; `subscribe` seam React calls) is therefore the HIGHEST-fidelity SUPPORTED
-;; proof of the make-watch-handler NaN suppression over a Reagent watchable host;
-;; the render is the listener-notification count that a mounted React component
-;; would consume. Moving it to a live React mount would require either a runtime
-;; change to the ui substrate notify gate or an unsupported Reagent+ViewCell
-;; bridge — both out of scope for a proof.
+;; It is NOT the whole proof, because a hand-driven commit is a PROXY for a
+;; render: mutating the public compiled mount path would leave this arm green.
+;; The sibling namespace
+;; `re-frame.observation-port-watchable-host-mounted-dom-cljs-test` closes that
+;; gap through the PUBLIC compiled mount path, at a real React mount.
+;;
+;; A PRIOR REVISION OF THIS COMMENT CLAIMED THE MOUNTED ARM WAS ARCHITECTURALLY
+;; UNREACHABLE. That claim was WRONG on two counts, and is corrected here
+;; (rf2-mjpmp) so it does not mislead a future reader:
+;;
+;;   - It said `re-frame.ui.client/mount!` "refuses a non-`re-frame.ui` adapter
+;;     generation". It does not. `mount*` captures the OPAQUE installed-adapter
+;;     generation token (`current-adapter-generation`) before its side-effecting
+;;     frame preflight and re-asserts that the SAME token is still installed
+;;     afterwards (`require-adapter-generation-open!`, rf2-vxgfnd.199). That is a
+;;     generic identity check against destroy / destroy-and-replace during
+;;     preflight — it reads no `:kind`, and there is no adapter-kind gate
+;;     anywhere on the mount path. Compiled roots mount under whatever adapter is
+;;     installed; sibling suites already mount them under `:kind :custom`
+;;     adapters.
+;;   - It said Reagent "never touches the observation port or a ViewCell". That
+;;     conflates WHICH ADAPTER SUPPLIES THE WATCHABLE HOST with WHICH RENDERER
+;;     DRIVES THE VIEW. They are independent. A compiled `defview` always reads
+;;     its subs through the observation port into a ViewCell — that is the
+;;     compiled path, not an adapter feature. The installed adapter supplies the
+;;     sub-cache's derived nodes; under Reagent those nodes ARE
+;;     `reagent.ratom/Reaction`s. So a compiled view mounted while Reagent is
+;;     installed reads a REAGENT watchable through a REAL ViewCell.
+;;
+;; The two properties the proof needs are therefore NOT mutually exclusive:
+;;
+;;   1. HOST WATCH FIRES ON NaN→NaN — supplied by the REAGENT adapter's Reaction,
+;;      whose notify gate is raw `=` (`(= ##NaN ##NaN)` is false). Firing on a
+;;      NO-move is the whole point: it is what makes the port's `node-value=`
+;;      suppression (make-watch-handler) LOAD-BEARING. (The first-party
+;;      re-frame.ui / UIx / Helix substrate gates notify on `rf=` —
+;;      `Object.is(##NaN,##NaN)` is true, `re_frame/substrate/spine.cljs` — so on
+;;      THOSE hosts the watch never fires for NaN→NaN and make-watch-handler is
+;;      never reached. A mounted NaN proof on the ui adapter would produce zero
+;;      renders for the WRONG reason, proving the spine's notify gate instead.)
+;;   2. DRIVES A ViewCell AT A REAL MOUNT — supplied by the COMPILED VIEW, which
+;;      routes every `ui/sub` through the observation port → ViewCell →
+;;      `useSyncExternalStore` regardless of the installed adapter.
+;;
+;; Composing the two needs no bridge, no adapter-kind guard, and no runtime
+;; change — only the already-public composition the mounted arm exercises.
 
 (deftest viewcell-over-watchable-host-nan-to-nan-is-version-revision-render-stable
   (testing "an integrated observation→ViewCell path over a WATCHABLE (Reagent)

--- a/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_mounted_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_mounted_dom_cljs_test.cljs
@@ -1,0 +1,277 @@
+(ns re-frame.observation-port-watchable-host-mounted-dom-cljs-test
+  "rf2-mjpmp — the MOUNTED completion of the observation port's NaN-stability
+  proof: NaN moves NaN-STABLY through a REAL compiled ViewCell at a REAL React
+  mount, on the PUBLIC compiled mount path, over the stock Reagent watchable
+  host.
+
+  WHAT THE HEADLESS SIBLING CANNOT REACH. The sibling namespace
+  `re-frame.observation-port-watchable-host-cljs-test` proves the same fact
+  headlessly, but drives the ViewCell BY HAND — `reactive/with-capture` +
+  `reactive/commit!`, observed through a `reactive/subscribe` listener standing
+  in for a render. That pins the cell-level contract with no browser, and it
+  runs on every PR; but a hand-driven commit is a PROXY for a render, so
+  mutating the public compiled mount path leaves it green. This namespace
+  closes that gap: the NaN control is judged by the MOUNTED RENDER itself.
+
+  WHY THIS COMPOSITION IS SUPPORTED (correcting a prior claim). An earlier
+  revision of the sibling file recorded this arm as \"architecturally
+  unreachable without a runtime change\". That was wrong on two counts:
+
+    - `re-frame.ui.client/mount*` does NOT reject a non-`re-frame.ui` adapter.
+      It captures the OPAQUE installed-adapter generation token
+      (`current-adapter-generation`) before its side-effecting frame preflight
+      and re-asserts the SAME token afterwards
+      (`require-adapter-generation-open!`, rf2-vxgfnd.199) — a generic identity
+      check against destroy / destroy-and-replace during preflight. It reads no
+      `:kind`; there is no adapter-kind gate on the mount path, and sibling
+      suites already mount compiled roots under `:kind :custom` adapters.
+    - Reagent does NOT keep a compiled view away from the observation port.
+      That conflates WHICH ADAPTER SUPPLIES THE WATCHABLE HOST with WHICH
+      RENDERER DRIVES THE VIEW; they are independent. A compiled `defview`
+      always reads its subs through the observation port into a ViewCell —
+      that is the compiled path, not an adapter feature — while the INSTALLED
+      adapter supplies the sub-cache's derived nodes. Under Reagent those nodes
+      ARE `reagent.ratom/Reaction`s.
+
+  So the two properties the proof needs COMPOSE rather than exclude:
+
+    1. HOST WATCH FIRES ON NaN→NaN — from the REAGENT adapter's Reaction, whose
+       notify gate is raw `=` (`(= ##NaN ##NaN)` is false). Firing on a NO-move
+       is the whole point: it is what makes the port's `node-value=`
+       suppression (`make-watch-handler`) LOAD-BEARING. The first-party
+       re-frame.ui / UIx / Helix substrate gates notify on `rf=`
+       (`Object.is(##NaN,##NaN)` is true), so on THOSE hosts the watch never
+       fires for NaN→NaN and `make-watch-handler` is never reached — a mounted
+       NaN proof there would show zero renders for the WRONG reason.
+    2. DRIVES A ViewCell AT A REAL MOUNT — from the COMPILED VIEW, which routes
+       every `ui/sub` through the observation port → ViewCell →
+       `useSyncExternalStore` regardless of the installed adapter.
+
+  Composing them needs no bridge, no adapter-kind guard, no equality
+  abstraction, and NO RUNTIME CHANGE — only the already-public surface below.
+
+  THE RENDER EVIDENCE IS ATTRIBUTABLE AND MOUNTED, not a listener count:
+  `renders` counts the compiled view's own BODY invocations and `commits`
+  counts React Profiler `onRender` commits of the mounted tree. A NaN→NaN that
+  escaped `node-value=` would advance the node, dirty the cell, notify
+  `useSyncExternalStore`, and move BOTH.
+
+  The `-dom-cljs-test` suffix (rf2-2hrj8) enrols this file in the
+  `:browser-test` build; `:node-test`'s `cljs-test$` regex matches it too, and
+  there the body gates on `(browser?)` and no-ops."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            ["react" :as react]
+            [reagent.ratom :as ratom]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.substrate.observation :as obs]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.test :as uit]
+            ;; The CLJS emitter wraps a SUB-BEARING view's body in
+            ;; `re-frame.ui.viewcell/render` (sub-free views are never wrapped),
+            ;; so a consumer of a sub-bearing `defview` must load the viewcell
+            ;; runtime for that emitted reference to resolve.
+            [re-frame.ui.viewcell]
+            [re-frame.test-support :as test-support]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+;; The stock REAGENT adapter is the watchable host under test: its derived sub
+;; reactions are `reagent.ratom/Reaction`, which notify on NaN→NaN.
+;;
+;; `:async? true` — this is an `(async done …)` namespace, and cljs.test
+;; hard-errors on a fn-form fixture there ("Async tests require fixtures to be
+;; specified as maps"). The map form establishes the ambient `:rf/default`
+;; scope with a PERSISTENT `set!` rather than a dynamic `binding`, so a bare
+;; `dispatch-sync` still lands when the mounted body resumes on a later tick.
+;; `:init-fn` resets the ViewCell scheduler per test, so this namespace never
+;; inherits a sibling's pending-cell state on the shared `:browser-test` page.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter
+     :async?  true
+     :init-fn reactive/reset-scheduler!}))
+
+(def ^:private fid :rf/default)
+
+(defn- node-reaction []
+  (:reaction (get @(:sub-cache (frame/frame fid)) [:obs/n])))
+
+(defn- register! []
+  (rf/reg-sub :obs/n (fn [db _] (:n db)))
+  (rf/reg-event :obs/set-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)})))
+
+;; The subscription target-key the ViewCell projects committed leases/values by
+;; (`re-frame.ui.reactive/target-key` of a `[:sub fid query]` target).
+(defn- tk [q] [:sub fid q])
+
+(defn- nan-num? [x] (and (number? x) (js/isNaN x)))
+
+;; An INDEPENDENT watch on the shared node reaction that counts ONLY NaN→NaN
+;; fires. It proves the underlying host callback actually RAN for the no-movement
+;; recompute (the port's `make-watch-handler` is a sibling watch on the same
+;; reaction, fired in the same notify sweep) — so a green "nothing moved"
+;; assertion cannot be vacuously green because the reaction never fired.
+;; Returns the sentinel counter atom and a `remove!` thunk.
+(defn- install-nan-sentinel! [reaction]
+  (let [hits (atom 0)
+        k    (gensym "rf-nan-sentinel")]
+    (add-watch reaction k
+               (fn [_ _ prev nu]
+                 (when (and (nan-num? prev) (nan-num? nu))
+                   (swap! hits inc))))
+    [hits (fn remove! [] (remove-watch reaction k))]))
+
+;; The eager consumer that keeps the (lazy) Reagent reaction on the push path,
+;; exactly as the headless sibling stands one: an auto-running reaction that
+;; derefs the sub so a value movement re-runs the node and fires the port's
+;; watch. It renders NOTHING, so it cannot contribute to the mounted render or
+;; commit counts below — those come solely from the compiled view and React.
+(defn- make-driver [] (ratom/run! (deref (rf/subscribe [:obs/n]))))
+
+(defn- nan-commit-profiler
+  "Plain React Profiler wrapper — `onRender` fires once per COMMIT of the
+  mounted subtree, giving commit-level attribution alongside the compiled
+  view's own body count."
+  [^js props]
+  (react/createElement
+   (.-Profiler react)
+   #js {:id       "watchable-host-nan-mounted"
+        :onRender (fn [& _] (swap! (.-commits props) inc))}
+   (.-children props)))
+
+;; The compiled sub-reading component. Its BODY INVOCATION is the mounted
+;; render, and its `ui/sub` read is the ViewCell → observation-port → Reagent
+;; Reaction path under test. The value is surfaced into the DOM so the mounted
+;; output is independently checkable.
+(defview mounted-nan-view
+  [{:keys [renders]}]
+  (let [_ (swap! renders inc)
+        v (ui/sub [:obs/n])]
+    [:output {:data-nan-site "mounted"} (str v)]))
+
+(defn- mounted-text [root]
+  (some-> (uit/query root "[data-nan-site]") .-textContent))
+
+;; ONE movement at the mount. `dispatch-sync` moves app-db inside React `act`;
+;; `ratom/flush!` then drains Reagent's queue so the WATCHED sub Reaction
+;; re-runs and notifies its watchers (the port's per-lease watch among them).
+;; `uit/flush!` alternates framework notification and React commits to a fixed
+;; point, so any render the movement EARNED has committed by the time the
+;; returned Promise resolves — and a movement that earned none has provably
+;; produced none.
+(defn- move! [v]
+  (uit/flush! (fn []
+                (rf/dispatch-sync [:obs/set-n v])
+                (ratom/flush!))))
+
+(deftest mounted-viewcell-over-watchable-host-nan-to-nan-is-render-stable
+  (if-not (browser?)
+    (is true ":node — no DOM; the :browser-test runner exercises the mounted body")
+    (do
+      (register!)
+      (rf/dispatch-sync [:obs/set-n ##NaN])
+      (let [driver (make-driver)]
+        (ratom/flush!)                       ;; settle: node warm + active at NaN
+        (let [baseline (reactive/current-live-cells)
+              renders  (atom 0)
+              commits  (atom 0)
+              notes    (atom [])
+              probe*   (atom nil)
+              nan-rm*  (atom nil)
+              cleanup! (fn []
+                         (when-let [rm @nan-rm*] (rm))
+                         (when-let [p @probe*] (obs/release! p))
+                         (ratom/dispose! driver))]
+          (async done
+            (->
+             (uit/with-root
+               [root [nan-commit-profiler {:commits commits}
+                      [ui/frame-provider {:frame fid}
+                       [mounted-nan-view {:renders renders}]]]]
+               (let [mounted           (remove baseline (reactive/current-live-cells))
+                     cell              (first mounted)
+                     reaction          (node-reaction)
+                     [nan-hits nan-rm] (install-nan-sentinel! reaction)
+                     ;; An INDEPENDENT probe lease on the SAME node: its
+                     ;; `on-change` is the `{:cause :value}` note channel that
+                     ;; the mounted cell's own (cell-dirtying) `on-change`
+                     ;; cannot surface. Same port, same node, same notify sweep
+                     ;; — the standard public `acquire!`, not a test bridge.
+                     probe             (obs/acquire!
+                                        (obs/resolve-target
+                                         {:frame fid :query-v [:obs/n]})
+                                        (fn [ev] (swap! notes conj ev)))
+                     ver0              (:version (obs/read probe))
+                     rev0              (reactive/revision cell)
+                     renders0          @renders
+                     commits0          @commits]
+                 (reset! nan-rm* nan-rm)
+                 (reset! probe* probe)
+                 (testing "preconditions — a REAL mounted ViewCell over the Reagent host"
+                   (is (= 1 (count mounted))
+                       "the compiled sub-reading view mounted exactly one ViewCell")
+                   (is (satisfies? IWatchable reaction)
+                       "the mounted cell reads a Reagent Reaction — an IWatchable host,
+                        so the port armed its per-lease value-movement watch")
+                   (is (obs/owned? (reactive/committed-lease cell (tk [:obs/n])))
+                       "…through a REAL owned observation lease taken by the mounted commit")
+                   (is (nan-num? (get (reactive/committed-values cell) (tk [:obs/n])))
+                       "the mounted cell committed the host's NaN")
+                   (is (= "NaN" (mounted-text root))
+                       "and the MOUNTED DOM carries it — a real render, not a proxy")
+                   (is (= 1 renders0) "the mount rendered the compiled view exactly once")
+                   (is (= 1 commits0) "…in exactly one React commit")
+                   (is (empty? @notes) "acquire! on a warm NaN node fans nothing"))
+                 (->
+                  (move! ##NaN)
+                  (.then
+                   (fn []
+                     (testing "NaN→NaN fires the host watch yet moves NOTHING at the mount"
+                       (is (pos? @nan-hits)
+                           "the Reagent host watch FIRED for NaN→NaN — make-watch-handler
+                            genuinely ran, so the green assertions below are non-vacuous")
+                       (is (empty? @notes)
+                           "ZERO {:cause :value} notes — node-value= suppressed the fan-out
+                            (a raw not= at the seam would fan a phantom movement)")
+                       (is (= ver0 (:version (obs/read probe)))
+                           "node version UNMOVED — NaN=NaN under the movement law")
+                       (is (= rev0 (reactive/revision cell))
+                           "mounted ViewCell revision UNMOVED — the cell was never dirtied")
+                       (is (= renders0 @renders)
+                           "ZERO further MOUNTED renders — the compiled view's body
+                            did not re-run at the live mount")
+                       (is (= commits0 @commits)
+                           "ZERO further React commits of the mounted tree")
+                       (is (= "NaN" (mounted-text root))
+                           "the mounted DOM is untouched"))
+                     (move! 5)))
+                  (.then
+                   (fn []
+                     (testing "positive control — a REAL move moves all four EXACTLY once"
+                       (is (= 1 (count @notes))
+                           "exactly one {:cause :value} note for the real movement")
+                       (is (= :value (:cause (first @notes))))
+                       (is (= (inc ver0) (:version (obs/read probe)))
+                           "the real move advanced the node version EXACTLY once")
+                       (is (= (inc rev0) (reactive/revision cell))
+                           "…and the mounted cell's revision exactly once")
+                       (is (= (inc renders0) @renders)
+                           "…and drove EXACTLY ONE attributable mounted render")
+                       (is (= (inc commits0) @commits)
+                           "…committed through React exactly once")
+                       (is (= "5" (mounted-text root))
+                           "the mounted DOM shows the moved value")))))))
+             ;; `with-root` unmounts the React root and removes its container as
+             ;; part of this awaited chain, so the mount is EXPLICITLY torn down
+             ;; before the fixture's `:after` restores the adapter.
+             (.then (fn []
+                      (cleanup!)
+                      (done))
+                    (fn [e]
+                      (cleanup!)
+                      (is false (str "mounted NaN proof rejected: " e))
+                      (done))))))))))


### PR DESCRIPTION
## What

PR #6227 correctly tightened the watchable-host NaN controls to exact-`inc`, but closed its mounted-render arm as *"architecturally unreachable without a runtime change"*. That rationale was wrong on two counts, and the mounted proof turns out to be reachable on **already-public surface**.

### The acceptance gap

`implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_cljs_test.cljs:340` — `viewcell-over-watchable-host-nan-to-nan-is-version-revision-render-stable` drives the ViewCell **by hand** (`reactive/with-capture` + `reactive/commit!`) and counts a `reactive/subscribe` listener as the "render". That is a **proxy**: mutating the public compiled mount path leaves it green. The ~40-line comment at `:302-338` recorded the mounted arm as unreachable.

### Why the "unreachable" rationale was wrong

- **`re-frame.ui.client/mount*` does NOT refuse a non-`re-frame.ui` adapter generation.** It captures the *opaque* installed-adapter generation token (`current-adapter-generation`) before its side-effecting frame preflight and re-asserts the **same token** afterwards (`require-adapter-generation-open!`, rf2-vxgfnd.199) — a generic identity check against destroy / destroy-and-replace *during preflight*. It reads no `:kind`; there is no adapter-kind gate anywhere on the mount path, and sibling suites already mount compiled roots under `:kind :custom` adapters.
- **Reagent does not keep a compiled view away from the observation port.** The claim conflated *which adapter supplies the watchable host* with *which renderer drives the view*. A compiled `defview` always reads its subs through the observation port into a ViewCell — that is the **compiled path**, not an adapter feature — while the **installed adapter** supplies the sub-cache's derived nodes. Under Reagent those nodes **are** `reagent.ratom/Reaction`s.

So the two properties **compose** rather than exclude:

1. **Host watch fires on NaN→NaN** — from the Reagent Reaction's raw `=` notify gate (`(= ##NaN ##NaN)` is false). Firing on a NO-move is exactly what makes the port's `node-value=` suppression (`make-watch-handler`) load-bearing.
2. **Drives a ViewCell at a real mount** — from the compiled view, which routes every `ui/sub` through observation port → ViewCell → `useSyncExternalStore` regardless of installed adapter.

## How the proof now goes through the public Reagent path

New sibling namespace `re-frame.observation-port-watchable-host-mounted-dom-cljs-test`:

- the fixture installs the **stock Reagent adapter** (the watchable host);
- `re-frame.ui.test/with-root` mounts a **compiled sub-reading `defview`** through the public compiled mount path and awaits the **real initial commit**;
- so the mounted view's `ui/sub` is a real ViewCell reading a real Reagent watchable **through the observation port**, and the NaN control is judged by the **mounted render itself**.

Assertions for **NaN→NaN**: the independent host-watch sentinel **fired** (non-vacuous), **zero** `{:cause :value}` notes, node version unmoved, mounted ViewCell revision unmoved, **zero** further mounted renders/commits, DOM untouched. **Real movement** positive control moves all four **exactly once** (exact `inc` node version + cell revision, one attributable mounted render, one React commit, DOM shows the moved value).

Render evidence is **attributable and mounted** — the compiled view's own body invocations plus React `Profiler` `onRender` commits — not a listener count. The root is **explicitly unmounted** (awaited `with-root` teardown) before the fixture restores the adapter.

**Why a sibling file:** `:browser-test` selects on `ns-regexp "-dom-cljs-test$"`. A mounted arm added inside the existing `-cljs-test` namespace would **never run in a browser**. `:node-test`'s `cljs-test$` matches both suffixes, so the new file also loads in Node, where the body gates on `(browser?)` and no-ops. The existing namespace's fixture and arms are therefore **untouched**; its diff is **comment/docstring-only** (the inaccurate architecture comment corrected in place, plus a pointer to the mounted arm).

## Proof (red-before / green-after)

The mounted arm is non-vacuous and genuinely executes in the browser. Mutating the **four mounted render/commit counters** — NaN→NaN expectations flipped to require movement (`= renders0` → `= (inc renders0)`, same for commits), and the real-move expectations widened to `+2` — produced **exactly 4 failures**, all in this test, then reverted:

```
Ran 457 tests containing 2555 assertions.
4 failures, 0 errors.
```

Those are precisely the assertions that can only be satisfied by a real mounted render, so the proof now breaks if the public mounted path misbehaves — which the hand-driven arm cannot do.

## Quality gates

Run in the foreground to completion on the exact committed state:

- `npm run test:browser` (**the gate that actually executes the mounted body**): **457 tests, 2555 assertions, 0 failures, 0 errors** — GREEN.
- `npm run test:cljs` (node; loads the new file, compiles it, runs the untouched headless siblings): **9951 tests, 49035 assertions, 0 failures, 0 errors** — GREEN.
- Non-vacuousness mutation (4 mounted counters): **4 failures**, exactly the four mutated assertions, reverted before commit.
- Act-hygiene check: a baseline browser run with the new file temporarily excluded and the final run with it included both show **0 `not wrapped in act` warnings** — the new mounted arm adds no act noise to the shared `:browser-test` page.

## Scope

**Test-only; no runtime change.** No bespoke bridge, no equality abstraction, no adapter-kind guard, no general harness — only already-public surface (`ui.test/with-root`, `ui/frame-provider`, `ui/sub`, `obs/acquire!`, `reactive/current-live-cells` / `revision` / `committed-lease`). Two files: the existing namespace (comment-only) and the new mounted `-dom-cljs-test` sibling.
