### PR TITLE
fix(core): make the raw fn* binding and arity boundary host-portable (rf2-wnhbm)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -122,13 +122,22 @@
   (and (seq? f) (contains? #{'fn 'fn* 'clojure.core/fn 'cljs.core/fn} (first f))))
 
 (defn- host-portable-argv?
-  "The raw `fn*` special form binds only simple (unqualified) symbols, with an
-  optional single trailing `& rest`. Applied ONLY to a raw `fn*` initializer:
-  its parameters are what the host compiler binds directly, so destructuring,
-  non-symbol/qualified parameters, and malformed `&` forms are host-illegal
-  (and a map argv otherwise reaches binding-plan as a raw
+  "The raw `fn*` special form binds only DISTINCT simple (unqualified) symbols,
+  with an optional single trailing `& rest`. Applied ONLY to a raw `fn*`
+  initializer: its parameters are what the host compiler binds directly, so
+  destructuring, non-symbol/qualified parameters, and malformed `&` forms are
+  host-illegal (and a map argv otherwise reaches binding-plan as a raw
   IllegalArgumentException). Macro `fn` / source `letfn` legally destructure —
-  their expansion owns that grammar — so they keep the looser argv shape."
+  their expansion owns that grammar — so they keep the looser argv shape.
+
+  Distinctness (`[x x]`, `[x & x]`, `[x y x]`) is the rf2-wnhbm seam. Both
+  hosts *compile* a duplicate parameter, but by different mechanisms — the JVM
+  shadows the earlier binding, ClojureScript gensym-renames the later one to
+  `x__$1` — and this analyzer's own lexical model cannot represent either: it
+  threads scope as a SET (`env/binding-syms`), so `[x x]` collapses to one
+  local and a reactive-escape check on the second `x` silently reads the
+  first's scope. A duplicate parameter is never intentional, so the honest
+  bounded rule is to reject it rather than analyze a form we cannot model."
   [argv]
   (and (vector? argv)
        (let [[fixed tail] (split-with #(not= '& %) argv)]
@@ -136,20 +145,45 @@
               (case (count tail)
                 0 true                            ; no variadic marker
                 2 (simple-symbol? (second tail))  ; `& rest`: exactly one rest sym
-                false)))))                        ; bare `&`, or `& a b`
+                false)                            ; bare `&`, or `& a b`
+              (let [bound (cond-> (vec fixed) (seq tail) (conj (second tail)))]
+                (= (count bound) (count (distinct bound))))))))
 
 (defn- host-arities-compatible?
   "Bounded arity-overload check for a raw `fn*`: the host rejects two overloads
-  of the same fixed arity, or more than one variadic overload. (This is the
-  narrow host-portability seam, NOT a general Clojure arity grammar — the
-  fixed-vs-variadic param-count rule is left to the host compiler.)"
+  of the same fixed arity, more than one variadic overload, or a fixed overload
+  that reaches into the variadic overload's arity range. (This is the narrow
+  host-portability seam, NOT a general Clojure arity grammar.)
+
+  The fixed-vs-variadic boundary (rf2-wnhbm) is where the two hosts stop
+  agreeing, so it cannot be left to \"the host compiler\" — there are two of
+  them. Writing `v` for the variadic overload's REQUIRED count (its parameters
+  before `&`, so its emitted parameter count is `v + 1`) and `f` for a fixed
+  overload's arity:
+
+    f <= v      both hosts compile it, identically — legal.
+    f == v + 1  the JVM rejects (`Can't have fixed arity function with more
+                params than variadic function`); ClojureScript compiles it with
+                BOTH a :variadic-max-arity and an :overload-arity
+                (\"Can't have 2 overloads with same arity\") warning, emitting a
+                dispatch that silently drops the fixed overload.
+    f >  v + 1  the JVM rejects; ClojureScript warns :variadic-max-arity and
+                emits the same broken dispatch.
+
+  So every fixed arity must be strictly less than the variadic overload's
+  parameter count — equivalently `f <= v`. That single rule is exactly where
+  the JVM's hard error and ClojureScript's warnings both begin, which is what
+  makes the accept/reject verdict host-portable."
   [argvs]
   (let [variadic?   (fn [argv] (boolean (some #(= '& %) argv)))
-        fixed-count (fn [argv] (count (take-while #(not= '& %) argv)))
+        required    (fn [argv] (count (take-while #(not= '& %) argv)))
         variadics   (filter variadic? argvs)
-        fixed       (map fixed-count (remove variadic? argvs))]
+        fixed       (map required (remove variadic? argvs))]
     (and (<= (count variadics) 1)
-         (= (count fixed) (count (set fixed))))))
+         (= (count fixed) (count (set fixed)))
+         (or (empty? variadics)
+             (let [v (required (first variadics))]
+               (every? #(<= % v) fixed))))))
 
 (defn- fn-init-shape?
   "True when `init` is a structurally well-formed fn/fn* form — the only legal
@@ -161,16 +195,22 @@
   (one or more arity lists); every argv MUST be a vector.
 
   A RAW `fn*` (the host special form — not the `fn` macro) additionally binds
-  only host-portable parameters (`host-portable-argv?`) with non-duplicate
-  arities (`host-arities-compatible?`): the host compiler requires it, and
-  without it a destructuring/qualified/malformed argv is either silently
-  accepted here only to crash the later host compiler, or reaches binding-plan
-  as a raw IllegalArgumentException. Macro `fn` / source `letfn` legally
-  destructure, so their argv shape is left to their own expansion."
+  only host-portable parameters (`host-portable-argv?`) with host-compatible
+  arities (`host-arities-compatible?`), and its optional internal name must be
+  a SIMPLE symbol: the host compiler requires it, and without these a
+  destructuring/qualified/malformed argv is either silently accepted here only
+  to crash the later host compiler, or reaches binding-plan as a raw
+  IllegalArgumentException. A qualified internal name is the sharpest of these
+  (rf2-wnhbm): the JVM accepts `(fn* foo/bar ([x] x))`, while ClojureScript
+  compiles it to `function cljs$user$foo.bar(x){…}` — not valid JavaScript, a
+  parse-time SyntaxError far downstream of this analyzer. Macro `fn` / source
+  `letfn` legally destructure, so their argv shape is left to their own
+  expansion."
   [init]
   (and (fn-form? init)
        (let [raw?    (= 'fn* (first init))
-             tail    (cond-> (rest init) (symbol? (second init)) rest)
+             fname   (when (symbol? (second init)) (second init))
+             tail    (cond-> (rest init) fname rest)
              arities (cond
                        (vector? (first tail)) (list tail)   ; single arity
                        (and (seq tail)
@@ -181,7 +221,8 @@
           (and arities
                (or (not raw?)
                    (let [argvs (map first arities)]
-                     (and (every? host-portable-argv? argvs)
+                     (and (or (nil? fname) (simple-symbol? fname))
+                          (every? host-portable-argv? argvs)
                           (host-arities-compatible? argvs)))))))))
 
 (defn- raw-form? [e f]  (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) ui-raw-fqns)))

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -445,6 +445,100 @@
     (is (nil? (reject-id '[:div {:title (letfn* [f (fn* ([] 0) ([x] x))] f)}]))
         "legal distinct raw fn* fixed arities — accepted")))
 
+(defn- letfn*-init-id
+  "reject-id for `init` used as the single raw letfn* initializer."
+  [init]
+  (reject-id (list :div {:title (list 'letfn* ['f init] 'f)})))
+
+(deftest letfn*-raw-fn*-binding-and-arity-is-host-portable
+  ;; rf2-wnhbm — rf2-9rqmq's bounded grammar still let three host-NON-portable
+  ;; shapes through the typed bad-let boundary. Verdicts below are the measured
+  ;; behaviour of both host compilers, not inference:
+  ;;
+  ;;   duplicate bindings  `[x x]` / `[x & x]` — BOTH hosts compile, by
+  ;;     different mechanisms (JVM shadows the earlier binding, CLJS
+  ;;     gensym-renames the later to `x__$1`). This analyzer threads lexical
+  ;;     scope as a SET, so it cannot model either: `[x x]` collapses to one
+  ;;     local and a reactive-escape check on the second `x` reads the first's
+  ;;     scope. Unmodellable, never intentional -> reject.
+  ;;
+  ;;   qualified internal name  `(fn* foo/bar ([x] x))` — the JVM ACCEPTS it;
+  ;;     CLJS emits `function cljs$user$foo.bar(x){…}`, which is not valid
+  ;;     JavaScript (`SyntaxError: Unexpected token '.'`). A hard host split.
+  ;;
+  ;;   fixed-vs-variadic arity — writing `v` for the variadic overload's
+  ;;     required (pre-`&`) count, so its emitted parameter count is `v + 1`:
+  ;;       f <= v      both hosts compile it identically — legal.
+  ;;       f == v + 1  JVM REJECTS ("Can't have fixed arity function with more
+  ;;                   params than variadic function"); CLJS compiles with
+  ;;                   :variadic-max-arity + :overload-arity ("Can't have 2
+  ;;                   overloads with same arity") and emits a dispatch that
+  ;;                   silently DROPS the fixed overload.
+  ;;       f >  v + 1  JVM REJECTS; CLJS warns :variadic-max-arity, same broken
+  ;;                   dispatch.
+  ;;     So `f <= v` is exactly where the JVM's hard error and CLJS's warnings
+  ;;     both begin — the one rule that makes the verdict host-portable.
+  ;;
+  ;; The analyzer is pure, so this .cljc file IS the CLJ/CLJS parity fixture:
+  ;; every row below is asserted on BOTH hosts and must agree.
+  (testing "raw fn* argv bindings must be distinct"
+    (is (= :rf.ui.compile/bad-let (letfn*-init-id '(fn* [x x] x)))
+        "a duplicate fixed binding is not modellable by set-shaped scope")
+    (is (= :rf.ui.compile/bad-let (letfn*-init-id '(fn* [x & x] x)))
+        "the rest binding may not duplicate a fixed binding")
+    (is (= :rf.ui.compile/bad-let (letfn*-init-id '(fn* [x y x] x)))
+        "adversarial: non-adjacent duplicates are still duplicates")
+    (is (= :rf.ui.compile/bad-let (letfn*-init-id '(fn* ([a] a) ([b b] b))))
+        "adversarial: a duplicate in a LATER overload of a legal-looking fn*")
+    (is (= :rf.ui.compile/bad-let (letfn*-init-id '(fn* [a b & a] a)))
+        "adversarial: rest duplicating the FIRST of several fixed bindings"))
+  (testing "the raw fn* internal name must be a simple symbol"
+    (is (= :rf.ui.compile/bad-let (letfn*-init-id '(fn* foo/bar ([x] x))))
+        "a qualified internal name compiles on the JVM but emits invalid JS")
+    (is (= :rf.ui.compile/bad-let (letfn*-init-id '(fn* foo/bar [x] x)))
+        "adversarial: same hole via the single-arity spelling"))
+  (testing "every fixed arity must be <= the variadic overload's required count"
+    (is (= :rf.ui.compile/bad-let (letfn*-init-id '(fn* ([x] x) ([& r] r))))
+        "f == v+1 (v=0): JVM rejects, CLJS drops the fixed overload")
+    (is (= :rf.ui.compile/bad-let (letfn*-init-id '(fn* ([a b] a) ([x & r] x))))
+        "f == v+1 (v=1): same boundary one arity up")
+    (is (= :rf.ui.compile/bad-let (letfn*-init-id '(fn* ([a b c] a) ([x & r] x))))
+        "f > v+1: JVM rejects, CLJS emits a broken dispatch")
+    (is (= :rf.ui.compile/bad-let (letfn*-init-id '(fn* ([& r] r) ([a] a))))
+        "adversarial: offending pair with the variadic overload written FIRST")
+    (is (= :rf.ui.compile/bad-let
+           (letfn*-init-id '(fn* ([] 0) ([a b] a) ([c & r] c))))
+        "adversarial: a legal 0-arity prefix does not excuse the f=2 > v=1 pair"))
+  (testing "legal host-portable raw fn* stays accepted"
+    (is (nil? (letfn*-init-id '(fn* ([x] x) ([a b & r] a))))
+        "f < v control (f=1, v=2) — accepted")
+    (is (nil? (letfn*-init-id '(fn* ([a b] a) ([c d & r] c))))
+        "f == v boundary (f=2, v=2) — both hosts compile it cleanly, so ACCEPT")
+    (is (nil? (letfn*-init-id '(fn* ([] 0) ([& r] r))))
+        "f == v == 0 — accepted")
+    (is (nil? (letfn*-init-id '(fn* f [x & ys] x)))
+        "distinct bindings + simple internal name — accepted"))
+  (testing "the boundary is raw fn* ONLY — macro fn keeps its own grammar"
+    (is (nil? (letfn*-init-id '(fn [x x] x)))
+        "macro fn owns its parameter grammar — not the raw fn* boundary")
+    (is (nil? (letfn*-init-id '(fn ([x] x) ([& r] r))))
+        "macro fn arity combinations are its expansion's problem, not ours"))
+  (testing "the accept/reject verdict is identical on both analyzer hosts"
+    ;; A single table asserted on whichever host is running: CLJ and CLJS must
+    ;; produce this same vector, which is what "host-portable" means here.
+    (is (= [:rf.ui.compile/bad-let :rf.ui.compile/bad-let :rf.ui.compile/bad-let
+            :rf.ui.compile/bad-let :rf.ui.compile/bad-let nil nil]
+           (mapv letfn*-init-id
+                 ['(fn* [x x] x)
+                  '(fn* [x & x] x)
+                  '(fn* foo/bar ([x] x))
+                  '(fn* ([x] x) ([& r] r))
+                  '(fn* ([a b c] a) ([x & r] x))
+                  '(fn* ([a b] a) ([c d & r] c))
+                  '(fn* f ([x] x))]))
+        (str "host-portable verdict table, evaluated here on "
+             #?(:clj "the JVM analyzer host" :cljs "the ClojureScript analyzer host")))))
+
 (deftest frame-finite-sites
   (is (= :rf.ui.compile/frame-in-loop
          (reject-id '(for [x xs] [:li {:key x} (:frame (frame))])))


### PR DESCRIPTION
Closes rf2-wnhbm.

PR #6216 bounded the raw `fn*` grammar behind the typed `:rf.ui.compile/bad-let`
boundary, but three host-**non**-portable shapes still escaped it. Every verdict
below was measured against both host compilers (Clojure 1.12.4 / ClojureScript
analyzer + emitter), not inferred.

Surface is `implementation/ui/src/re_frame/ui/compiler/analyze.cljc` — the three
existing predicates extended in place. No new error id, no grammar parser, no
change to the accepted `fn*` surface.

## The three holes

**1. Duplicate argv bindings** — `analyze.cljc:124` `host-portable-argv?`

`[x x]`, `[x & x]`, `[x y x]` were accepted. Both hosts *compile* a duplicate
parameter, but by different mechanisms: the JVM shadows the earlier binding,
ClojureScript gensym-renames the later one to `x__$1`. This analyzer threads
lexical scope as a **set** (`env/binding-syms`), so it can model neither —
`[x x]` collapses to one local, and a reactive-escape check on the second `x`
silently reads the first's scope. Unmodellable and never intentional, so the
argv's bound symbols (fixed plus rest) must now be distinct.

**2. Qualified internal fn name** — `analyze.cljc:190` `fn-init-shape?`

The sharpest split of the three. The JVM compiles `(fn* foo/bar ([x] x))`
happily; ClojureScript emits

```js
(function cljs$user$foo.bar(x){ return x; })
```

which is not valid JavaScript — `SyntaxError: Unexpected token '.'`, raised at
parse time far downstream of this analyzer. The optional internal name must now
be a simple symbol.

**3. Fixed-vs-variadic arity** — `analyze.cljc:151` `host-arities-compatible?`

The old docstring explicitly deferred this rule to "the host compiler". There
are two of them, and they disagree. Writing `v` for the variadic overload's
required (pre-`&`) count — so its emitted parameter count is `v + 1` — and `f`
for a fixed overload's arity:

| | JVM | ClojureScript |
|---|---|---|
| `f <= v` | compiles | compiles, no warning |
| `f == v + 1` | **rejects**: `Can't have fixed arity function with more params than variadic function` | compiles with `:variadic-max-arity` + `:overload-arity` ("Can't have 2 overloads with same arity"); emitted dispatch **silently drops the fixed overload** |
| `f > v + 1` | **rejects** | warns `:variadic-max-arity`, same broken dispatch |

So every fixed arity must be strictly less than the variadic overload's
parameter count (equivalently `f <= v`) — exactly where the JVM's hard error and
CLJS's warnings both begin. Confirmed against `cljs.analyzer` source: the
`:variadic-max-arity` guard is `(not (or (zero? variadic-params) (== variadic-params (+ 1 mfa))))`
and `:overload-arity` fires on duplicate `(count :params)`, where the variadic
method's `:params` includes the rest symbol.

### One note on the bead text

The bead reads *"equality produces a CLJS duplicate-arity build warning even
though JVM accepts it"*. The duplicate-arity warning (`:overload-arity`) does
occur, at `f == v + 1` — but the JVM **rejects** that combination too, so it is
not a case of JVM acceptance. The prescribed rule ("every fixed arity strictly
less than its required parameter count") is unchanged and correct; only the JVM
half of that one sub-claim did not reproduce. Reading it as `f <= v` is also
what keeps `f == v` **accepted** — both hosts compile that cleanly and
identically, and the acceptance criteria require a `fixed < variadic` control to
stay accepted.

## Host portability

The analyzer is pure, so the `.cljc` reject test **is** the CLJ/CLJS parity
fixture: every row is asserted on both hosts. The new test closes with an
explicit verdict-table assertion whose failure message names the host it ran on,
so a future divergence reports which host drifted.

## Quality gates

| Gate | Result |
|---|---|
| `clojure -M:test -n re-frame.ui.analyze-reject-cljs-test` (JVM, focused) | 28 tests / 197 assertions, **0 failures** |
| `clojure -M:test` (JVM, full `implementation/ui`) | 812 tests / 14630 assertions, **0 failures** |
| `npm run test:cljs` (CLJS host, to completion) | 9957 tests / 49092 assertions, **0 failures** |
| `scripts/check-playground-sci-freshness.sh` | **OK** — digest matches; this change is in `ui`, not a playground input, and the gate stays green over the rebase onto rf2-ywwpx's rebuilt bundle |
| Focused JVM test re-run post-rebase | 28 tests / 197 assertions, **0 failures** |

**Red-before / green-after.** With the test file in place and the source reverted
to `HEAD`, the JVM run gives **13 failures** — every named hole returning `nil`
(accepted), including all five adversarial rows. With the fix restored, 0
failures on both hosts. Adversarial coverage per hole: non-adjacent duplicates
`[x y x]`; a duplicate confined to a *later* overload of an otherwise legal
`fn*`; rest duplicating the first of several fixed bindings; the qualified name
via the single-arity spelling; the offending arity pair with the variadic
overload written *first*; and a legal 0-arity prefix that does not excuse a
following `f=2 > v=1` pair.

No false rejects: the full 812-test `ui` suite and the 9957-test CLJS suite pass
unchanged, and explicit controls keep `f < v`, `f == v`, `f == v == 0`, legal
named/variadic raw `fn*`, and macro-`fn`'s own looser grammar accepted.
