### PR TITLE
docs(ui): head policy, trusted-markup guidance, and raw foreign-boundary corpus (rf2-yjhrt, S4-D)

### DIFF
--- a/implementation/ui/test/re_frame/ui/raw_foreign_boundary_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/raw_foreign_boundary_dom_cljs_test.cljs
@@ -1,0 +1,135 @@
+(ns re-frame.ui.raw-foreign-boundary-dom-cljs-test
+  "S4-D (rf2-yjhrt) — the FOREIGN BOUNDARY corpus, CLIENT half (Spec 004
+  §Interop and boundaries; the stage-profile row `§Interop — ui/raw` =
+  S1 compile form + opaque marker, COMPLETES S4 with this corpus).
+
+  The JVM half proves the boundary FAILS LOUD where it cannot render
+  (raw_foreign_boundary_jvm_test). This half proves what it does where
+  it CAN: the foreign value crosses into the real DOM untouched.
+
+    - `ui/raw` splices an already-created React element into child
+      position among compiled siblings, in document order. `re-frame.ui`
+      never inspects it: the element's props were authored in REACT's
+      own spelling (`className`, `tabIndex`) and arrive that way — the
+      compiler's kebab conversion table is not applied across the
+      boundary, because the compiler never sees the other side of it.
+
+    - `ui/html` bypasses escaping: the string is PARSED as markup (real
+      elements appear in the DOM), and nothing in it is sanitised — a
+      `javascript:` URL and an inline handler attribute survive
+      verbatim. The same characters in an ordinary string child are
+      ESCAPED to text. That contrast is the whole XSS boundary, and it
+      is the behaviour Spec 004 §Trusted markup documents.
+
+  Rendering these assertions needs a real DOM (`ui/raw` is a host React
+  element; `ui/html` lowers to `dangerouslySetInnerHTML`), so the
+  browser job runs them and the node host skips."
+  (:require ["react" :as React]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.test :as uit]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+;; A foreign React element, authored the way a foreign library would: REACT
+;; prop spellings (className / tabIndex), not the compiler's kebab author-space.
+(defn- foreign-element []
+  (React/createElement "em" #js {:className "foreign" :tabIndex 4} "FOREIGN"))
+
+(defview raw-host []
+  [:div.host
+   [:span.before "before"]
+   (ui/raw (foreign-element))
+   [:span.after "after"]])
+
+;; Inert-by-construction hostile markup: the anchor is never clicked and the
+;; handler attribute never fires — the point is that both survive UNFILTERED.
+(def hostile
+  "<a class=\"evil\" href=\"javascript:alert(1)\" onclick=\"window.__rf2_pwned = true\">click</a><b>bold &amp; raw</b>")
+
+(defview trusted-host []
+  [:div.trusted (ui/html hostile)])
+
+(defview escaped-host []
+  ;; The SAME characters as ordinary template text — the always-escaping path.
+  [:div.escaped "<a class=\"evil\">click</a>"])
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter ui/adapter :ambient-frame nil :async? true}))
+
+(defn- q [root sel] (.querySelector (.-container root) sel))
+
+(defn- assert-raw-boundary [root]
+  (let [host (q root ".host")
+        kids (array-seq (.-children host))]
+    (testing "the foreign element reaches the DOM in document order"
+      (is (= 3 (count kids)) "compiled sibling, foreign element, compiled sibling")
+      (is (= ["SPAN" "EM" "SPAN"] (mapv #(.-tagName %) kids)))
+      (is (= ["before" "FOREIGN" "after"] (mapv #(.-textContent %) kids))))
+    (testing "re-frame.ui does not touch the far side of the boundary"
+      (let [em (q root "em")]
+        (is (= "foreign" (.getAttribute em "class"))
+            "React's className arrived as the class attribute")
+        (is (= "4" (.getAttribute em "tabindex"))
+            "React's tabIndex arrived — the compiler's conversion table was never applied")))))
+
+(defn- assert-trusted-boundary [root]
+  (testing "the string is PARSED as markup — real elements, not text"
+    (is (some? (q root ".trusted a")) "the anchor became a real element")
+    (is (some? (q root ".trusted b")) "so did the bold"))
+  (testing "NOTHING is filtered — this is the documented XSS boundary"
+    (let [a (q root ".trusted a")]
+      (is (= "javascript:alert(1)" (.getAttribute a "href"))
+          "the javascript: scheme is not gated")
+      (is (= "window.__rf2_pwned = true" (.getAttribute a "onclick"))
+          "an inline handler attribute is not stripped")))
+  (testing "entities in the trusted string decode as markup, not as data"
+    (is (= "bold & raw" (.-textContent (q root ".trusted b")))))
+  (is (undefined? (.-__rf2_pwned js/window))
+      "sanity: the fixture is inert — nothing was executed"))
+
+(defn- assert-escaped-boundary [root]
+  (let [el (q root ".escaped")]
+    (is (nil? (.querySelector el "a"))
+        "an ordinary string child creates NO element — strings always escape")
+    (is (= "<a class=\"evil\">click</a>" (.-textContent el))
+        "the markup survives as literal TEXT")))
+
+;; `uit/with-root` compiles its template at macro-expansion time, so the view
+;; head must be a literal at each call site — only the promise tail is shared.
+(defn- finish [p done]
+  (-> p
+      (.then (fn [_] (done))
+             (fn [e]
+               (is false (str "mount rejected: " (some-> e ex-message)))
+               (done)))))
+
+(deftest raw-splices-a-foreign-element-verbatim-among-compiled-siblings
+  (if-not (browser?)
+    (is true "ui/raw is a host React element — the browser job runs it")
+    (async done
+      (finish (uit/with-root [root [raw-host]]
+                (-> (uit/flush!)
+                    (.then (fn [_] (assert-raw-boundary root)))))
+              done))))
+
+(deftest trusted-markup-is-parsed-and-never-sanitised
+  (if-not (browser?)
+    (is true "ui/html lowers to dangerouslySetInnerHTML — the browser job runs it")
+    (async done
+      (finish (uit/with-root [root [trusted-host]]
+                (-> (uit/flush!)
+                    (.then (fn [_] (assert-trusted-boundary root)))))
+              done))))
+
+(deftest an-ordinary-string-child-is-escaped-the-bypass-is-the-only-exception
+  (if-not (browser?)
+    (is true "the escaping contrast needs a DOM — the browser job runs it")
+    (async done
+      (finish (uit/with-root [root [escaped-host]]
+                (-> (uit/flush!)
+                    (.then (fn [_] (assert-escaped-boundary root)))))
+              done))))

--- a/implementation/ui/test/re_frame/ui/raw_foreign_boundary_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/raw_foreign_boundary_jvm_test.clj
@@ -1,0 +1,146 @@
+(ns re-frame.ui.raw-foreign-boundary-jvm-test
+  "S4-D (rf2-yjhrt) — the FOREIGN BOUNDARY corpus, JVM half (Spec 004
+  §Interop and boundaries; the stage-profile row `§Interop — ui/raw` =
+  S1 compile form + opaque marker, COMPLETES S4 with this corpus).
+
+  The boundary has two sides and one law each:
+
+  1. `ui/raw` / a foreign component head are HOST-BEARING. They cannot
+     render on the JVM, so a rendered occurrence raises the TYPED
+     `:rf.error/jvm-host-op` naming which form was hit — never a silent
+     nil child, never a half-rendered tree. The raise is LAZY: an
+     untaken branch never evaluates its argument, so a JVM structural
+     test of a view that *can* reach a foreign child still renders every
+     path that avoids it.
+
+  2. A foreign value in PROP position is OPAQUE. It becomes the
+     `{:rf.ui/opaque :foreign}` marker and the value itself is NEVER
+     evaluated and NEVER enters the tree — so no host object can leak
+     into a structural tree, a fingerprint, or a serialised payload.
+
+  The trusted-markup boundary (`ui/html`) is the third foreign edge: the
+  string crosses into the document unescaped and unfiltered. This file
+  pins that `re-frame.ui` applies NO sanitisation — the contract the
+  Spec 004 §Trusted markup guidance documents.
+
+  The compile-form rejections (`:rf.ui.compile/bad-raw`,
+  `.../bad-html`, `.../html-not-sole-child`) ride the analyzer suites;
+  the client half — the foreign element actually reaching the DOM — is
+  raw_foreign_boundary_dom_cljs_test."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.semantic :as semantic]
+            [re-frame.ui.tree :as tree]))
+
+(defn- boom! []
+  (throw (ex-info "a foreign value must never be evaluated on the JVM" {})))
+
+;; A resolvable var WITHOUT view metadata is a foreign React head.
+(def ForeignWidget ::not-a-view)
+
+(defview raw-child-view [{:keys [foreign?]}]
+  [:div.host
+   [:span.before "before"]
+   (when foreign? (ui/raw (boom!)))
+   [:span.after "after"]])
+
+(defview foreign-head-view [{:keys [foreign?]}]
+  [:div.host (when foreign? [ForeignWidget {:x 1}])])
+
+(defview foreign-prop-sink [{:keys [title]}]
+  [:div.sink title])
+
+(defview boundary-props-view []
+  [foreign-prop-sink {:title "plain data"
+                      :el    (ui/raw (boom!))
+                      :cb    (ui/raw-fn boom!)}])
+
+(defview trusted-view [{:keys [markup]}]
+  [:div.content (ui/html markup)])
+
+(defn- err [f]
+  (try (f) nil
+       (catch clojure.lang.ExceptionInfo e (ex-data e))))
+
+(defn- element
+  "The view's root ELEMENT (`tree/render` returns the view-boundary wrapper)."
+  [view props]
+  (first (:children (tree/render view props))))
+
+;; ---------------------------------------------------------------------------
+;; 1. Host-bearing forms raise the TYPED host-op error, lazily
+;; ---------------------------------------------------------------------------
+
+(deftest raw-child-raises-the-typed-host-op-error
+  (let [d (err #(tree/render raw-child-view {:foreign? true}))]
+    (is (= :rf.error/jvm-host-op (:rf.error/id d))
+        "the boundary fails with the typed id, not a bare host exception")
+    (is (= :ui/raw (:op d))
+        "the ex-data names WHICH host-bearing form was hit")
+    (is (= 're-frame.ui/render (:where d))
+        "attributed to the render entry point")))
+
+(deftest foreign-component-head-raises-the-typed-host-op-error
+  (let [d (err #(tree/render foreign-head-view {:foreign? true}))]
+    (is (= :rf.error/jvm-host-op (:rf.error/id d)))
+    (is (= :foreign-component (:op d))
+        "a foreign head is a DISTINCT boundary from ui/raw and says so")))
+
+(deftest the-boundary-is-lazy-and-does-not-poison-the-surrounding-tree
+  ;; The argument of an untaken `ui/raw` is never evaluated (`boom!` would
+  ;; throw a DIFFERENT exception), and every compiled sibling still renders.
+  (let [kids (:children (element raw-child-view {:foreign? false}))]
+    (is (= 2 (count kids)) "the untaken foreign child contributes no node")
+    (is (= ["before" "after"] (mapv #(first (:children %)) kids))
+        "compiled siblings render normally around the absent boundary"))
+  (is (some? (tree/render foreign-head-view {:foreign? false}))
+      "an untaken foreign head is equally inert"))
+
+;; ---------------------------------------------------------------------------
+;; 2. A foreign value in PROP position is opaque — and never evaluated
+;; ---------------------------------------------------------------------------
+
+(deftest foreign-props-become-the-opaque-marker-carrying-no-host-value
+  (let [props (:props (element boundary-props-view {}))]
+    (testing "the boundary is recorded, discriminated by form"
+      (is (= {:rf.ui/opaque :foreign} (:el props))
+          "a (ui/raw …) prop is the opaque :foreign marker")
+      (is (= {:rf.ui/opaque :ui/raw-fn} (:cb props))
+          "a callback-ref prop is the opaque :ui/raw-fn marker"))
+    (testing "the host value itself never enters the tree"
+      ;; `boom!` did not throw, so the foreign expression was never
+      ;; evaluated: no host object can reach a structural tree, a
+      ;; fingerprint, or a serialised payload through a prop.
+      (is (not (contains? (set (vals props)) nil))
+          "no prop degrades to a silent nil")
+      (is (= "plain data" (:title props))
+          "ordinary data props are unaffected by a foreign sibling prop"))))
+
+;; ---------------------------------------------------------------------------
+;; 3. Trusted markup — the boundary re-frame.ui does NOT sanitise
+;; ---------------------------------------------------------------------------
+
+(deftest trusted-markup-crosses-the-boundary-verbatim
+  (let [hostile (str "<img src=x onerror=\"steal()\">"
+                     "<a href=\"javascript:alert(1)\">click</a>"
+                     "<b>bold & raw</b>")
+        node    (first (:children (element trusted-view {:markup hostile})))]
+    (is (= {:html hostile} node)
+        "the trusted-HTML leaf carries the string VERBATIM — no escaping, no tag filter, no attribute filter, no javascript:-scheme gate")
+    (testing "the raw ampersand and angle brackets are NOT entity-escaped"
+      (is (.contains ^String (:html node) "bold & raw"))
+      (is (.contains ^String (:html node) "<img src=x")))
+    (testing "normalization N carries it as an opaque leaf, still verbatim"
+      (let [[sem] (semantic/normalize (tree/render trusted-view {:markup hostile}))]
+        (is (= [{:html hostile}] (:children sem))
+            "N compares raw markup verbatim — it does not parse or sanitise it")))))
+
+(deftest trusted-markup-shape-check-is-the-only-runtime-guard
+  ;; The JVM node builder's ONLY validation is `string?`. It is a shape
+  ;; check, never a content check — nothing about the string is inspected.
+  (let [d (err #(tree/render trusted-view {:markup 42}))]
+    (is (= :rf.error/ui-tree-malformed (:rf.error/id d))
+        "a non-string trusted-markup value fails loud on the JVM")
+    (is (= 're-frame.ui/html (:where d))))
+  (is (= {:html ""} (first (:children (element trusted-view {:markup ""}))))
+      "an empty string is a legal (and inert) bypass — emptiness is not a content rule"))

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -587,6 +587,88 @@ independent demand for platform-scale features). The seven wrappers of the forei
 React-interop tier — `re-frame.ui.react` — carry their own call-shape contract in
 §The React interop tier below.
 
+### Trusted markup — what `ui/html` does not do
+
+`ui/html` is the one place escaping is bypassed, and the bypass is a **naming**
+device rather than a safety device. The call is visible in the template, the
+compiler manifest records every site, and the compiled view declares an `:html`
+capability — so the set of bypasses in a codebase is finite and enumerable by
+construction. That enumerability *is* the mechanism. **`re-frame.ui` does not
+sanitise.**
+
+| Host | What the string becomes | Escaping / filtering applied |
+|---|---|---|
+| Browser | the parent element's React `dangerouslySetInnerHTML` — `{__html: s}` | **none** — React assigns it to `innerHTML` verbatim |
+| JVM | the trusted-HTML node `{:html s}`, carried by normalization `N` as an opaque raw-markup leaf and compared verbatim | **none** — no escape pass runs over it (the tree→HTML serialiser lands S5 and is contracted to write these leaves verbatim, per [004B §Children, text, and escaping](004B-UI-Tree-and-Conversion.md#children-text-and-escaping)) |
+
+There is no allowlist, no tag or attribute filter, no `javascript:`-scheme gate, and
+no DOM-purifier pass on either host. A `<script>` element, an `onerror=` attribute,
+or a `javascript:` href inside the string reaches the document exactly as written.
+
+The checks that *do* exist are **shape** checks, and they are deliberately partial:
+
+- The form takes exactly one argument and must be the **sole child** of a non-void
+  DOM element (`[:div (ui/html s)]`) — violations are the compile errors
+  `:rf.ui.compile/bad-html`, `:rf.ui.compile/html-not-sole-child`, and
+  `:rf.ui.compile/void-children`.
+- A **literal** non-string scalar (`(ui/html 42)`) is rejected at compile time. A
+  **runtime** expression is accepted unvalidated — the compiler cannot know the
+  value, and the site is recorded as non-serialisable.
+- A non-string value reaching the JVM node builder raises
+  `:rf.error/ui-tree-malformed`. The browser has no equivalent runtime guard: the
+  value is handed to React unchecked.
+- The prop spellings (`:dangerouslySetInnerHTML`, `:dangerously-set-inner-html`,
+  `:inner-html`) are compile errors naming `(ui/html …)` as the replacement — there
+  is exactly one spelling, and it is a node variant, not a prop.
+
+**The caller's guarantee.** Every `(ui/html s)` site asserts that `s` is trusted
+markup: an author-controlled literal, or a value that passed a real sanitiser at the
+boundary where it entered the app. "Trusted" is a claim about the string's
+*provenance*, not about its content — the framework cannot check it and does not
+try. Passing user-, tenant-, or CMS-authored markup into `ui/html` without
+sanitising it first is an arbitrary-script-injection XSS vector, and that call is
+the app's to make. This is the same posture the SSR host adapter's shell hooks take
+([011 §Trusted shell hook contract](011-SSR.md#trusted-shell-hook-contract)): the
+framework names the boundary, validates the shape, and points at structured
+alternatives; the content trust itself is caller-owned. See
+[Security §XSS at output boundaries](Security.md#xss-at-output-boundaries).
+
+**Prefer, in order:** ordinary template children (strings everywhere else always
+escape — full 5-char escaping in text and attribute values); a compiled child view
+for structured content; `re-frame.ui.data` for genuinely runtime-authored trees.
+Reach for `ui/html` only when the markup itself is the data *and* its provenance is
+trusted — a build-time Markdown render, a sanitiser's output, a static SVG string.
+
+### The document head is host-owned
+
+**No compiled-view form renders into `<head>`.** `re-frame.ui` mounts into a root
+element inside `<body>` (§Roots and mounting), and every template form in this Spec
+produces nodes beneath that root: there is no head-targeting form, no `ui/head`, and
+no head channel in the view AST or the JVM tree. The document head belongs to the
+**host** — the HTML shell the app serves and, for server-rendered apps, Spec 011's
+structured [`reg-head` / `active-head`](011-SSR.md#headmeta-contract) channel, which
+derives the head model from `app-db` through registered fns and applies
+position-appropriate escaping at every leaf.
+
+`ui/html` does not widen this. It is the sole child of a **DOM element** in the
+rendered tree, and `<head>` is neither a mount target nor reachable from a template,
+so trusted markup cannot be used to reach into it.
+
+The reasoning is that head elements are document-global singletons with
+de-duplication, ordering, and precedence semantics that no part of the compiled
+substrate models today, and the server-rendered head already carries its own
+`:rf/head-hash` channel — deliberately separate from `:rf/render-hash` — with its
+own mismatch-detection path. A view-level head API would have to reconcile with both
+before it could be correct. Head rendering therefore stays host-owned until that
+hardening lands, which is the posture S1–S3 already shipped under.
+
+> **[S4-OPEN — normative home undecided].** This section records the standing
+> policy; the question of *which* Spec normatively owns the head-render policy —
+> this one, [011](011-SSR.md) (which owns the server-side head model), or elsewhere
+> — has not been ruled. The text lives here, next to the §Interop boundary table it
+> constrains, pending that ruling. No S4 conformance fixture asserts it: it states
+> an absence of surface, not a behaviour.
+
 ## `ui/route-link` — a framework-provided compiled view over the routing seam
 
 `ui/route-link` is the compiled counterpart of the stock-Reagent `rf/route-link` — a


### PR DESCRIPTION
S4-D of the re-frame.ui Stage-4 epic (rf2-vxgfnd.96). Discharges the epic's obligations **(3) head policy** and **(4) the raw foreign-boundary corpus (W14)**, plus the sanitization guidance `spec/API.md` already staged for this stage (`html`: *"S1 → S4 hardens head policy + sanitization guidance"*).

Spec prose + tests only. **No runtime change**, no new error/trace/compile ids, no new public vars, no api-manifest / error-roster / conformance-profile churn.

## 1. Trusted markup — `spec/004-Views.md` §Interop

New subsection **§Trusted markup — what `ui/html` does not do**, written against the *shipped* code rather than the aspiration (every claim was verified in this worktree before it was written):

| Host | What the string becomes | Escaping applied |
|---|---|---|
| Browser | the parent element's React `dangerouslySetInnerHTML` `{__html: s}` | **none** — straight to `innerHTML` |
| JVM | the `{:html s}` leaf, carried by `N` as an opaque raw-markup leaf | **none** — no escape pass runs over it |

No allowlist, no tag/attribute filter, no `javascript:`-scheme gate, no purifier on either host. The section documents that the surviving checks are **shape** checks and that they are partial by design: a *literal* non-string scalar is a compile error, a *runtime* expression is accepted unvalidated, and the JVM's `string?` guard has **no browser counterpart**. The caller's guarantee is framed as one about **provenance**, mirroring the established 011 §Trusted shell hook contract posture — the framework names the boundary, the trust call is the app's.

**No sanitiser was implemented.** The whole point of the boundary is that the framework does not sanitise; the deliverable is the documented contract plus the corpus that pins it.

## 2. The document head is host-owned — `spec/004-Views.md` §Interop

New subsection stating that no compiled-view form renders into `<head>`: `re-frame.ui` mounts inside `<body>`, there is no head-targeting form and no head channel in the AST or the JVM tree, and the host owns the head — via its HTML shell and, for SSR, Spec 011's structured `reg-head` / `active-head` channel. `ui/html` does not widen this: it is the sole child of a DOM **element**, and `<head>` is neither a mount target nor reachable from a template.

**No head machinery was added** — this is a decision (an absence of surface), not a feature.

> **OPERATOR FLAG #3 is still open and is marked as such in the prose.** The section carries an explicit `[S4-OPEN — normative home undecided]` note: *which* Spec normatively owns the head-render policy (this one, 011, or elsewhere) has not been ruled. Per the dispatch brief the text was placed in the most obvious existing §Interop location without inventing a new spec file or moving content between specs. Relocating it later is a pure move.

> **OPERATOR FLAG #4 was respected**: the `[S6-CONFIRM]` Activity-hidden / presence-retained compat fixture was **not** implemented here, and `reagent-compat-boundary.md` was not touched.

## 3. The `raw` foreign-boundary corpus (W14)

Completes the stage-profile row **`§Interop — ui/raw`: S1 → completes S4 (foreign-boundary corpus)**, closing the gap `parity_fixtures.cljc` documents as explicitly out of scope at S1 (*"foreign components and `ui/raw` (JVM host-op — no JVM execution by contract)"*). Placement mirrors S4-A/S4-B exactly (a `*_jvm_test.clj` + `*_dom_cljs_test.cljs` pair under `implementation/ui/test/`) — see the note below on why not `spec/conformance/fixtures/`.

**`raw_foreign_boundary_jvm_test.clj`** — the host-bearing forms raise the **typed** `:rf.error/jvm-host-op` naming *which* form was hit (`:ui/raw` vs `:foreign-component`); the raise is lazy and does not poison compiled siblings; a foreign value in prop position becomes `{:rf.ui/opaque :foreign}` and is **never evaluated**, so no host object can reach a tree, fingerprint, or serialised payload; and trusted markup crosses verbatim (hostile markup unescaped and unfiltered through both the raw tree and `N`).

**`raw_foreign_boundary_dom_cljs_test.cljs`** — the client half: a foreign React element splices into document order with **React's own** prop spellings intact (proving the conversion table is never applied across the boundary); trusted markup is *parsed* into real elements with a `javascript:` URL and an inline handler attribute surviving unfiltered; and the same characters as an ordinary string child are escaped to text. That contrast is the XSS boundary the new guidance documents.

### Note on the corpus home

The bead named `spec/conformance/fixtures/`. That corpus is host-agnostic and dispatch/pure-primitive shaped: it has **no `:view/*` capability vocabulary and no view-shape ops**, so an EDN fixture there would land in `classify-capabilities`' `:unknown` bucket and **hard-fail the whole corpus suite** unless the core runner were extended — out of this bead's fence and over-engineered for the goal. S4-A and S4-B both landed their S4 conformance as executable test namespaces under `implementation/ui/test/`; this follows that precedent.

## Pre-existing bug found while verifying (NOT fixed here) — filed as `rf2-29s75` (P1)

`[:div (ui/spread base ovr) (ui/html s)]` — the analyzer accepts it, the **JVM emitter keeps the markup, and the CLJS emitter silently drops it** (`emit-element`'s `:spread` branch never calls `element-prop-pairs`, the only place the html node becomes `dangerouslySetInnerHTML`; the emitted output has no `__html` and an empty children array). Verified by direct analyzer+emitter probe. This is a silent dual-emitter divergence that falsifies the normative sentence *"both emitters treat it identically"*. It is fail-safe security-wise (dropping cannot inject) but it is silent data loss, and no test covers the combination. The ui compiler was out of this bead's fence and the fix needs a ruling (make the emitters agree vs. reject the combination at compile time), so it is filed rather than patched.

## Quality gates

All run in the foreground to completion on this worktree.

| Gate | Result |
|---|---|
| `mkdocs build --strict` | PASS — built clean in 35.89s (no warnings; new §Interop anchors and cross-spec links resolve) |
| `scripts/check_doc_slugs.py` | PASS — clean (`spec/004-Views.md` is in its roster) |
| `implementation/ui` JVM — `clojure -M:test` | PASS — **817 tests / 14628 assertions, 0 failures, 0 errors** (baseline on `origin/main` was 811/14609 — the delta is exactly this corpus) |
| `npm run test:cljs` (node) | PASS — **9954 tests / 49038 assertions, 0 failures, 0 errors** |
| `npm run test:browser` (real Chromium) | PASS — **460 tests / 2553 assertions, 0 failures, 0 errors** — the DOM half genuinely executes, it is not skipped |

### Red-before / green-after

The corpus was proven to actually exercise the boundary, by probing then reverting (source restored via `git checkout`; the probes are **not** in this branch):

- **Regression A — `:raw` silently dropped in *both* emitters.** JVM corpus went to **3 failures** (typed id, `:op` discriminator, and `:where` all bite). Browser corpus failed **by name**: `FAIL in (raw-splices-a-foreign-element-verbatim-among-compiled-siblings)`, including *"the foreign element reaches the DOM in document order"* and *"React's tabIndex arrived — the compiler's conversion table was never applied"*. (The whole browser suite went from 0 to 68 failures / 61 errors, confirming how load-bearing the boundary is.)
- **Regression B — `tree/html` made to escape `&` and `<`.** JVM corpus went to **4 failures**, all in `trusted-markup-crosses-the-boundary-verbatim`, including the `N`-carries-it-verbatim assertion. The "we do not sanitise" claim is therefore pinned, not merely asserted in prose.

Both reverted; the green figures above are post-revert.
