### PR TITLE
fix(readme-links): slugify full heading titles; drop the inert explicit-id assumption (rf2-w6ltl)

### DIFF
--- a/scripts/_test_fixtures/check_readme_links/README.md
+++ b/scripts/_test_fixtures/check_readme_links/README.md
@@ -24,6 +24,8 @@ Fixtures:
 | `underscore_disambig_ok`             | 0        | Duplicate `## Errors` headings → MkDocs slug `errors_1` (underscore), not GitHub's `errors-1`.       |
 | `inline_code_link_ignored`           | 0        | Broken-looking links inside fenced code blocks AND inline code spans — skipped.                      |
 | `external_link_skipped_by_default`   | 0        | External `https://` URL — skipped without `--check-external` (the default + `--ci` mode).            |
+| `explicit_id_full_title_ok`          | 0        | `## One {#dup}` is heading TEXT — the id is the full-title slug `one-dup`, so that link resolves.    |
+| `explicit_id_brace_not_a_target`     | 1        | Negative control: a link to the brace id `#dup` targets nothing → flagged.                           |
 
 The MkDocs-vs-GitHub slug fixtures (`mkdocs_slug_anchor_ok` +
 `github_slug_anchor_broken`) are the load-bearing pair that locks in

--- a/scripts/_test_fixtures/check_readme_links/explicit_id_brace_not_a_target/README.md
+++ b/scripts/_test_fixtures/check_readme_links/explicit_id_brace_not_a_target/README.md
@@ -1,0 +1,7 @@
+# Brace text is not a fragment target
+
+## One {#dup}
+
+Negative control (rf2-w6ltl): the brace suffix mints no fragment target on a
+GitHub-rendered README, so a link to [the brace id](#dup) must be reported
+BROKEN. The rendered id is `one-dup`, not `dup`.

--- a/scripts/_test_fixtures/check_readme_links/explicit_id_brace_not_a_target/mkdocs.yml
+++ b/scripts/_test_fixtures/check_readme_links/explicit_id_brace_not_a_target/mkdocs.yml
@@ -1,0 +1,4 @@
+# Self-test fixture marker (rf2-w6ltl).  Empty config is fine — the validator
+# only checks for this file's existence as the repo-root guard.  Negative control
+# for the renderer-parity tooth: the brace suffix itself is NOT a fragment target,
+# so a link aimed at it must be reported BROKEN.

--- a/scripts/_test_fixtures/check_readme_links/explicit_id_full_title_ok/README.md
+++ b/scripts/_test_fixtures/check_readme_links/explicit_id_full_title_ok/README.md
@@ -1,0 +1,7 @@
+# Explicit id renders as the full-title slug
+
+## One {#dup}
+
+GitHub does not honour the `{#id}` custom-heading-id syntax, so `{#dup}` renders
+as literal heading text and the fragment id is the slugified FULL visible title.
+A link to [the rendered id](#one-dup) therefore resolves (rf2-w6ltl).

--- a/scripts/_test_fixtures/check_readme_links/explicit_id_full_title_ok/mkdocs.yml
+++ b/scripts/_test_fixtures/check_readme_links/explicit_id_full_title_ok/mkdocs.yml
@@ -1,0 +1,5 @@
+# Self-test fixture marker (rf2-w6ltl).  Empty config is fine — the validator
+# only checks for this file's existence as the repo-root guard.  Renderer-parity
+# tooth for the README gate: a `{#id}` suffix is NOT honoured as a custom heading
+# id (GitHub ignores the syntax outright, and the project's MkDocs config leaves
+# attr_list disabled), so the fragment id is the slugified FULL visible title.

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -203,21 +203,6 @@ EXCLUDE_DIR_REL = frozenset({Path("docs/spec"), Path("docs/migration")})
 # treats as code, not headings.
 _HEADING_RE = re.compile(r"^(?:[ \t]*>[ \t]?)*(#{1,6})[ \t]+(.+?)[ \t]*#*[ \t]*$")
 
-# Custom heading id syntax: "## Title {#explicit-id}".  python-markdown honours
-# this ONLY when the attr_list extension is enabled, and mkdocs.yml does NOT
-# enable it (see `markdown_extensions`: meta, admonition, footnotes, toc,
-# pymdownx.*).  Under the real configuration the brace suffix is therefore
-# ordinary heading TEXT: "## One {#dup}" renders the visible title "One {#dup}"
-# with id "one-dup", not "dup".  `_scan_rendered_ids` consequently slugifies the
-# full visible title and has no explicit-id special case — the predecessor's
-# special case recorded "dup" and so certified fragments the site never mints
-# (rf2-ru0wg).
-#
-# The pattern is retained only because scripts/check_readme_links.py imports it
-# (it validates the GitHub-rendered READMEs, a different renderer with its own
-# heading-id rules).  Nothing in THIS module uses it.
-_EXPLICIT_ID_RE = re.compile(r"\{#([A-Za-z0-9_\-:.]+)\}\s*$")
-
 # Inline HTML anchor — authors use `<a name="foo"></a>` / `<a id="foo"></a>`
 # to mint a stable target slug that is independent of (and often shorter than)
 # the heading's auto-derived slug.  Browsers and the rendered MkDocs site

--- a/scripts/check_readme_links.py
+++ b/scripts/check_readme_links.py
@@ -69,7 +69,6 @@ try:
     from check_doc_slugs import (
         SLUGIFY,
         SLUG_SEP,
-        _EXPLICIT_ID_RE,
         _HEADING_RE,
         _HTML_ANCHOR_RE,
         _LINK_RE,
@@ -84,7 +83,6 @@ except ImportError as exc:  # pragma: no cover - dev-env path
         from check_doc_slugs import (  # type: ignore  # noqa: F401
             SLUGIFY,
             SLUG_SEP,
-            _EXPLICIT_ID_RE,
             _HEADING_RE,
             _HTML_ANCHOR_RE,
             _LINK_RE,
@@ -205,11 +203,14 @@ def _slug_index(path: Path) -> set[str]:
         if not m:
             continue
         title = m.group(2).strip()
-        explicit = _EXPLICIT_ID_RE.search(title)
-        if explicit:
-            slug = explicit.group(1)
-        else:
-            slug = SLUGIFY(title, SLUG_SEP)
+        # A trailing `{#id}` is NOT a custom heading id here.  GitHub — which
+        # renders these READMEs — does not support the syntax at all, and the
+        # project's mkdocs.yml leaves `attr_list` disabled, so under BOTH
+        # renderers the brace suffix is ordinary heading TEXT: "## One {#dup}"
+        # shows the visible title "One {#dup}" and mints the id "one-dup", not
+        # "dup".  Slugify the full visible title; no explicit-id special case
+        # (rf2-w6ltl, mirroring rf2-ru0wg in check_doc_slugs.py).
+        slug = SLUGIFY(title, SLUG_SEP)
         if not slug:
             continue
         n = seen_counts.get(slug, 0)
@@ -447,6 +448,8 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("underscore_disambig_ok",           0),  # MkDocs _N suffix
         ("inline_code_link_ignored",         0),  # fence + inline-code guard
         ("external_link_skipped_by_default", 0),  # off without --check-external
+        ("explicit_id_full_title_ok",        0),  # `{#id}` is heading TEXT (rf2-w6ltl)
+        ("explicit_id_brace_not_a_target",   1),  # ...so the brace id resolves nowhere
     ]
 
     failures = 0


### PR DESCRIPTION
Closes rf2-w6ltl. Mirrors the merged rf2-ru0wg / #6281 fix into its twin checker.

## The bug

`scripts/check_readme_links.py:208` treated a heading suffix `{#id}` as the rendered fragment id — the identical assumption ru0wg removed from `check_doc_slugs.py`. It is wrong for the GitHub-rendered READMEs too: **GitHub does not support the custom-heading-id syntax at all**, so the brace suffix is ordinary heading TEXT and `## One {#dup}` mints the id `one-dup`, not `dup`. The checker consequently certified fragments no renderer ever mints.

**Latent, not live.** No tracked README uses the syntax today (`git grep -E '^\s*#{1,6}\s+.*\{#[A-Za-z0-9_.:-]+\}\s*$' -- '*README.md'` is empty), so no link is broken — but the gate would have blessed one the moment someone wrote it. **No README content changed.**

## The fix

`_slug_index` drops the special case and slugifies the full visible title with the shared `SLUGIFY`, matching `check_doc_slugs.py`'s `_scan_rendered_ids`.

## Dead-regex cleanup (ru0wg's tail, sanctioned by this bead)

`_EXPLICIT_ID_RE` was kept alive in `check_doc_slugs.py` — defined but unused — solely because this script hard-imported it (two import blocks). With the import gone the regex is dead in both files, so it is removed from both along with the comment explaining why it was being retained. `git grep _EXPLICIT_ID_RE` now matches nothing outside this bead's own JSONL description; no other importer existed.

## Quality gates

Run in the worktree, foreground, unpiped.

| Gate | Result |
| --- | --- |
| `python scripts/check_readme_links.py --self-test --verbose` | **10 passed** (was 8) |
| `python scripts/check_readme_links.py` (real scan) | exit 0 |
| `python scripts/check_doc_slugs.py --self-test --verbose` | **44 passed** — unchanged after the regex removal |
| `python scripts/check_doc_slugs.py` (real scan) | exit 0 |
| `python scripts/check_doc_slugs.py --synthesis-only` | exit 0, 41 files |

### Red-before / green-after

Two fixtures added, mirroring ru0wg's pair. Registered with post-fix expectations and run against the unfixed checker first — both failed, in exactly the inverted shape the bug predicts:

```
self-test FAIL: explicit_id_full_title_ok expected broken=0, got 1
self-test FAIL: explicit_id_brace_not_a_target expected broken=1, got 0
```

That is the bug stated precisely: the real id `#one-dup` was reported BROKEN, while the phantom `#dup` was blessed. After the fix both pass. The fixture index README table gains the two matching rows.

Full spine not run — checker-only change, per the bead's gate.
