### PR TITLE
test(ui-compiler): finish the real and advanced CLJS binding-plan proof (rf2-4xpah)

### DIFF
--- a/implementation/ui/test/re_frame/ui/binding_plan_advanced_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/binding_plan_advanced_elision_prod_test.cljs
@@ -1,0 +1,126 @@
+(ns re-frame.ui.binding-plan-advanced-elision-prod-test
+  "rf2-4xpah — the ADVANCED-CLJS half of the defview binding-plan proof.
+
+  The two companions stop short of the mode the proof actually needs:
+
+  - `binding_plan_host_faithful_jvm_test` pins that an authored `^js` group-local
+    hint survives the canonical plan by INSPECTING the emitted form
+    (`(meta (emit-local …)) => {:tag js}`). A form is not a build.
+  - `binding_plan_host_faithful_cljs_test` executes REAL `defview`s, but on the
+    `:node-test` lane — `:none`, `:infer-externs false`. Nothing is renamed
+    there, so a lost `^js` hint is INVISIBLE: both a hinted and an unhinted
+    property read work.
+
+  `^js` exists for exactly one reason — to survive `:advanced`. This namespace
+  runs ONLY in `:browser-test-prod-elision` (`shadow-cljs release` ⇒
+  `:optimizations :advanced`, shadow's default `:infer-externs :auto`,
+  goog.DEBUG=false), so the binding plan is finally observed in the mode it is
+  written for.
+
+  The causal chain under proof:
+
+    authored `{:keys [^js probe/node]}`
+      → `bp/assoc-binding-units` reconstructs the name-stripped group local as
+        `(with-meta (symbol nil (name bb)) (meta bb))`
+      → the emitted `let` binds `^js node`
+      → shadow's externs inference CLAIMS `.bpAdvancedHinted` (it only claims
+        reads whose target it can type)
+      → Closure leaves that read alone under `:advanced`.
+
+  Drop the `with-meta` and the chain breaks at step 2: the local is bare, no
+  extern claims the read, Closure renames it, and the read misses the object's
+  string key — which `js-obj` (a `goog.object.create` call, not an object
+  literal) makes unrenamable. The fixture below goes RED. Verified by mutation.
+
+  `advanced-build-really-renames-unexterned-property-reads` is the NON-VACUITY
+  control and must be read first: it asserts an UNHINTED read of an equivalent
+  property IS renamed away in this exact bundle. Without it, a build that had
+  quietly stopped renaming would let the hinted fixture pass while proving
+  nothing."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            ["react-dom/server" :as rds]
+            [re-frame.ui :refer [defview]]
+            [re-frame.ui.runtime :as rt]))
+
+;; `js-obj` sets its properties by STRING through `goog.object.create`, so these
+;; keys are dynamic: Closure can neither rename them nor read them as an object
+;; literal. Whether a read below finds its value therefore depends on ONE thing
+;; — whether the READ was renamed.
+(def ^:private probe
+  (js-obj "bpAdvancedHinted"   "kept"
+          "bpAdvancedUnhinted" "kept"))
+
+(defn- markup [view props] (rds/renderToStaticMarkup (rt/jsx2 view props)))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures — REAL defviews, compiled by the production header lowering into an
+;; :advanced release bundle
+;; ---------------------------------------------------------------------------
+
+;; The fixture under proof. The group local is QUALIFIED (`probe/node`) as well
+;; as `^js`-hinted, so it exercises the name-strip and the metadata carriage in
+;; one shape — the host binds `node`, reading slot "probe/node".
+(defview js-hint-view
+  [{:keys [^js probe/node]}]
+  [:span {:data-role "bp-hinted"} (str "[" (.-bpAdvancedHinted node) "]")])
+
+;; The non-vacuity control: the same shape with NO `^js`. Nothing externs
+;; `.bpAdvancedUnhinted`, so `:advanced` renames the read.
+;;
+;; This view is the sole source of the ONE `:infer-warning` this build emits
+;; ("Cannot infer target type in expression (. node -bpAdvancedUnhinted)"). It is
+;; DELIBERATE and load-bearing — it is the compiler stating, at build time, that
+;; it will not extern this read. Do not "fix" it by adding a hint: that silences
+;; the warning and destroys the control. The corresponding evidence for the
+;; fixture above is the ABSENCE of a second such warning; drop the `with-meta` in
+;; `bp/assoc-binding-units` and a second one appears for `.bpAdvancedHinted`.
+(defview js-unhinted-control-view
+  [{:keys [probe/node]}]
+  [:span {:data-role "bp-unhinted"} (str "[" (.-bpAdvancedUnhinted node) "]")])
+
+;; PR #6228's collapse shape, compiled `:advanced`. Slot reads are
+;; `(unchecked-get props "ns/x")` — STRING-keyed, so munging cannot touch them —
+;; and the host's `let` last-wins still picks `:ns/x` over the dead
+;; `[x] <- :other` unit after Closure has renamed everything it may.
+(defview nested-shadow-view
+  [{[x] :other :keys [ns/x]}]
+  [:span {:data-role "bp-nested"} (str "[" x "]")])
+
+;; ---------------------------------------------------------------------------
+;; The control — this bundle really is renaming unexterned reads
+;; ---------------------------------------------------------------------------
+
+(deftest advanced-build-really-renames-unexterned-property-reads
+  (testing "the probe object's string keys are intact (js-obj keys are unrenamable)"
+    (is (= "kept" (unchecked-get probe "bpAdvancedUnhinted")))
+    (is (= "kept" (unchecked-get probe "bpAdvancedHinted"))))
+  (testing "yet an UNHINTED dotted read of one of them finds nothing"
+    (is (= "<span data-role=\"bp-unhinted\">[]</span>"
+           (markup js-unhinted-control-view (js-obj "probe/node" probe)))
+        (str "rf-bp-advanced-renaming-live-v1: :advanced renamed the unexterned "
+             "read — so the hinted fixture below is a real proof, not a "
+             "build that stopped optimizing"))))
+
+;; ---------------------------------------------------------------------------
+;; The proof — the authored ^js reaches the advanced Closure build
+;; ---------------------------------------------------------------------------
+
+(deftest authored-js-hint-survives-the-canonical-plan-into-the-advanced-build
+  (is (= "<span data-role=\"bp-hinted\">[kept]</span>"
+         (markup js-hint-view (js-obj "probe/node" probe)))
+      (str "rf-bp-advanced-js-hint-v1: the authored ^js reached the emitted let "
+           "binding through bp/assoc-binding-units' with-meta, so shadow "
+           "externed the read and Closure left it alone. Drop that with-meta "
+           "and this renders [] like the control above.")))
+
+;; ---------------------------------------------------------------------------
+;; The #6228 collapse shape holds under advanced too
+;; ---------------------------------------------------------------------------
+
+(deftest quoted-slot-reads-and-host-last-wins-survive-advanced
+  (testing "present :ns/x wins over the shadowed [x] <- :other read"
+    (is (= "<span data-role=\"bp-nested\">[1]</span>"
+           (markup nested-shadow-view (js-obj "ns/x" 1 "other" [9])))))
+  (testing "absent :ns/x -> nil; the dead :other value never surfaces, minified or not"
+    (is (= "<span data-role=\"bp-nested\">[]</span>"
+           (markup nested-shadow-view (js-obj "other" [9]))))))

--- a/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_cljs_test.cljs
@@ -17,7 +17,21 @@
   CLOSED-`:props` set. `collapse-entries` compared whole `:pattern` values, so a
   vector `[x]` shadowed by a symbol `x` slipped through. The fix sweeps by the
   LOCALS each pattern binds (`bp/pattern-locals`); the executable plan
-  (`:binding-units`) is untouched, so every initializer still runs."
+  (`:binding-units`) is untouched, so every initializer still runs.
+
+  rf2-4xpah completes the real-host acceptance this suite promised: qualified
+  slot spellings and the didactic bare-slot miss now render VISIBLE values here
+  (the JVM companion pins them at macro level only); the collision defaults
+  carry SEQUENCED markers, so the visible winner is attributable to the second
+  evaluation rather than merely counted; a three-marker fixture makes the host
+  `bes` ORDER distinguishable from written source order; and a throwing default
+  proves it escapes the render even when the slot is present.
+
+  What this lane still cannot see is `:advanced`. It runs `:none` with
+  `:infer-externs false`, so an authored `^js` group-local hint is
+  indistinguishable from a lost one. That half lives in
+  `binding_plan_advanced_elision_prod_test`, which runs the same shapes through
+  a real Closure `:advanced` release build."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             ["react-dom/server" :as rds]
@@ -36,7 +50,15 @@
 (defonce ^:private evals (atom []))
 (defn- mark! [tag] (swap! evals conj tag) tag)
 
-(use-fixtures :each {:before (fn [] (reset! evals []))})
+;; rf2-4xpah — a SEQUENCED marker. Two host units that collide on one local
+;; share ONE authored `:or` form, so the host evaluates the same expression
+;; twice and identical tags (`["D" "D"]`) prove a COUNT but not an ORDER. The
+;; sequence number makes the two evaluations distinguishable, so the visible
+;; winner can be attributed to a specific one.
+(defonce ^:private eval-seq (atom 0))
+(defn- mark-seq! [tag] (mark! (str tag (swap! eval-seq inc))))
+
+(use-fixtures :each {:before (fn [] (reset! evals []) (reset! eval-seq 0))})
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures — REAL defviews compiled through the production header lowering
@@ -60,7 +82,7 @@
 ;; collapse to the winner `:ns/x`, but BOTH host units bind the local `x`, so the
 ;; default's eager get-arg runs ONCE PER UNIT — executable plan is retained.
 (defview collision-default-view
-  [{:keys [ns/x] x :other :or {x (mark! "D")}}]
+  [{:keys [ns/x] x :other :or {x (mark-seq! "D")}}]
   [:div.x (str x)])
 
 ;; Plain defaulted slot: the `:or` default is `get`'s eager third argument, so it
@@ -68,6 +90,40 @@
 (defview eager-default-view
   [{:keys [x] :or {x (mark! "E")}}]
   [:div.x (str x)])
+
+;; rf2-4xpah — DISTINGUISHABLE evaluation order. Written source order is a, b,
+;; c, but the host `bes` transformation `dissoc`s the group directive and
+;; re-`assoc`s its locals AFTER the surviving explicit entries, so the host binds
+;; a, c, b. Three DISTINCT markers make that visible on the real host: an
+;; emitter that kept parse order would log ["a" "b" "c"].
+(defview interleaved-order-view
+  [{a :aa :keys [b] c :cc :or {a (mark! "a") b (mark! "b") c (mark! "c")}}]
+  [:div.o (str a b c)])
+
+;; rf2-4xpah — THROW propagation. The `:or` default is `get`'s eager third
+;; argument, so a throwing default must escape the render even when the slot is
+;; PRESENT. A lazy (absent-only) lowering would swallow it on the present arm.
+(defview throwing-default-view
+  [{:keys [x] :or {x (throw (ex-info "rf-bp-throwing-default" {}))}}]
+  [:div.x (str x)])
+
+;; ---------------------------------------------------------------------------
+;; Qualified slot spellings — the REAL-HOST half of the JVM parity
+;;
+;; `defview_grammar_jvm_test/qualified-key-ref-props-accepted-in-every-keys-
+;; spelling` proves all three spellings derive the same qualified slots, but
+;; entirely at macro level on the JVM. These are the same three spellings as
+;; REAL defviews, rendering VISIBLE values on the real host.
+;; ---------------------------------------------------------------------------
+
+(defview qualified-keys-view      [{:keys [acct/key acct/ref]}] [:div.q (str "[" key "|" ref "]")])
+(defview qualified-group-view     [{:acct/keys [key ref]}]      [:div.q (str "[" key "|" ref "]")])
+(defview qualified-explicit-view  [{k :acct/key r :acct/ref}]   [:div.q (str "[" k "|" r "]")])
+
+;; The didactic bare-slot shape: the local is name-stripped to `id`, but the
+;; slot READ is the qualified "acct/id" verbatim — a bare "id" prop is a
+;; DIFFERENT slot and binds nothing.
+(defview qualified-id-view [{:keys [acct/id]}] [:div.id (str "[" id "]")])
 
 ;; ---------------------------------------------------------------------------
 ;; The derived-slot defect — comparator + manifest, on the real host
@@ -134,18 +190,90 @@
     (is (= [:ns/x] (prop-slot-keys ::collision-default-view))
         "manifest declares only :ns/x — the dead :other is dropped"))
   (testing "yet BOTH host binding units execute the eager default, in order"
-    (reset! evals [])
+    (reset! evals []) (reset! eval-seq 0)
     (is (= "<div class=\"x\">1</div>"
            (render (rt/jsx2 collision-default-view (js-obj "ns/x" 1 "other" 2))))
         "present: :ns/x wins")
-    (is (= ["D" "D"] @evals)
+    (is (= ["D1" "D2"] @evals)
         "the default's eager get-arg runs once per unit (x<-:other, x<-:ns/x)")
-    (reset! evals [])
-    (is (= "<div class=\"x\">D</div>"
+    (reset! evals []) (reset! eval-seq 0)
+    (is (= "<div class=\"x\">D2</div>"
            (render (rt/jsx2 collision-default-view (js-obj))))
-        "absent: the winning unit falls to its default")
-    (is (= ["D" "D"] @evals)
+        (str "absent: the winner is the SECOND evaluation — the later "
+             "x <- :ns/x unit — not the first. Identical markers could not "
+             "tell these apart; had the units been emitted in the reverse "
+             "order the visible value would read D1"))
+    (is (= ["D1" "D2"] @evals)
         "both units still evaluate their default — executable plan is retained")))
+
+;; ---------------------------------------------------------------------------
+;; rf2-4xpah — the remaining real-host `:or` semantics: distinguishable ORDER
+;; and THROW propagation
+;; ---------------------------------------------------------------------------
+
+(deftest defaults-evaluate-in-host-bes-order-not-source-order
+  (testing "all slots present: every eager default still runs, in host bes order"
+    (reset! evals [])
+    (is (= "<div class=\"o\">ABC</div>"
+           (render (rt/jsx2 interleaved-order-view
+                            (js-obj "aa" "A" "b" "B" "cc" "C")))))
+    (is (= ["a" "c" "b"] @evals)
+        "host order: explicit entries keep their places, the group's local is re-assoc'd last")
+    (is (not= ["a" "b" "c"] @evals)
+        "written source order a,b,c would be the regression"))
+  (testing "all slots absent: the same order, and each default becomes its value"
+    (reset! evals [])
+    (is (= "<div class=\"o\">abc</div>"
+           (render (rt/jsx2 interleaved-order-view (js-obj)))))
+    (is (= ["a" "c" "b"] @evals))))
+
+(deftest throwing-default-propagates-even-when-the-slot-is-present
+  ;; React logs a render error before rethrowing; silence it so the throw under
+  ;; test is the only signal on a green run.
+  (let [orig js/console.error]
+    (set! js/console.error (fn [& _] nil))
+    (try
+      (testing "present slot: the eager get-arg default throws anyway"
+        (is (thrown-with-msg?
+             ExceptionInfo #"rf-bp-throwing-default"
+             (render (rt/jsx2 throwing-default-view (js-obj "x" 5))))
+            "a lazy absent-only lowering would render 5 and swallow this"))
+      (testing "absent slot: the default throws as it is selected"
+        (is (thrown-with-msg?
+             ExceptionInfo #"rf-bp-throwing-default"
+             (render (rt/jsx2 throwing-default-view (js-obj))))))
+      (finally (set! js/console.error orig)))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-4xpah — qualified slot spellings + the didactic bare-slot failure, on the
+;; REAL host (the JVM half is macro-level only)
+;; ---------------------------------------------------------------------------
+
+(deftest every-qualified-spelling-reads-the-same-qualified-slots-on-the-real-host
+  (let [props (js-obj "acct/key" "K" "acct/ref" "R")]
+    (doseq [[label view] [["bare :keys with qualified symbols" qualified-keys-view]
+                          [":acct/keys group"                  qualified-group-view]
+                          ["explicit {local :acct/key} entry"  qualified-explicit-view]]]
+      (is (= "<div class=\"q\">[K|R]</div>" (render (rt/jsx2 view props)))
+          (str label
+               " reads slots \"acct/key\"/\"acct/ref\" verbatim — the qualified "
+               "names are legal precisely because they are NOT the reserved "
+               "bare :key/:ref React slots"))))
+  (testing "the qualified spellings declare the qualified slots, never bare ones"
+    (is (= [:acct/key :acct/ref] (prop-slot-keys ::qualified-keys-view)))
+    (is (= [:acct/key :acct/ref] (prop-slot-keys ::qualified-group-view)))
+    (is (= [:acct/key :acct/ref] (prop-slot-keys ::qualified-explicit-view)))))
+
+(deftest a-bare-prop-is-a-different-slot-and-binds-nothing
+  (testing "the qualified slot binds the name-stripped local"
+    (is (= "<div class=\"id\">[7]</div>"
+           (render (rt/jsx2 qualified-id-view (js-obj "acct/id" 7))))))
+  (testing "a BARE \"id\" prop is a different slot — didactically, nothing binds"
+    (is (= "<div class=\"id\">[]</div>"
+           (render (rt/jsx2 qualified-id-view (js-obj "id" 7))))
+        "the name-strip renames the LOCAL, never the lookup slot")
+    (is (= [:acct/id] (prop-slot-keys ::qualified-id-view))
+        "and the manifest declares the qualified slot, so a bare :id is undeclared")))
 
 (deftest eager-default-runs-once-present-and-absent
   (testing "present slot: the eager get-arg default STILL evaluates once"

--- a/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_jvm_test.clj
@@ -13,6 +13,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.walk :as walk]
             [re-frame.ui.compiler.analyze :as ana]
+            [re-frame.ui.compiler.binding-plan :as bp]
             [re-frame.ui.compiler.emit-cljs :as emit-cljs]
             [re-frame.ui.compiler.header :as header]))
 
@@ -86,6 +87,20 @@
           "syms-first source order, not keys<strs<syms rank")
       (is (not= '[k1 k2 s1 s2 y1 y2] (plan-order pat))
           "the invented rank order would silently regress this")))
+  (testing "a group directive is re-assoc'd AFTER the surviving explicit entries"
+    ;; rf2-4xpah — the JVM half of the CLJS suite's distinguishable-order
+    ;; fixture (`interleaved-order-view`). Written source order is a, b, c; the
+    ;; host `dissoc`s the `:keys` directive and re-`assoc`s its local, so the
+    ;; binding order is a, c, b. The CLJS suite asserts that same order from
+    ;; three DISTINCT `:or` markers on the real host; this pins the expected
+    ;; literal against REAL `clojure.core/destructure`, so neither side can
+    ;; drift into agreeing on a wrong order.
+    (let [pat '{a :aa :keys [b] c :cc}]
+      (is (= (real-local-order pat) (plan-order pat)))
+      (is (= '[a c b] (plan-order pat))
+          "the group's local lands last, not in its written position")
+      (is (not= '[a b c] (plan-order pat))
+          "written source order would be the regression")))
   (testing "the 8→9 entry map-representation threshold"
     (is (= '[a b c d e f g h] (plan-order '{:keys [a b c d e f g h]}))
         "8 entries stay a PersistentArrayMap in source order")
@@ -288,6 +303,69 @@
           f   (eval (list 'fn [pat] 'x))]
       (is (= :a (f {:x :a :foo :b})) "reads :x")
       (is (nil? (f {:foo :b}))       "absent :x, no default → nil, never :foo"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-4xpah — the NESTED / partially overlapping collapse, JVM half
+;;
+;; PR #6228 repaired the nested shadow (`{[x] :other :keys [ns/x]}`) and added
+;; `bp/pattern-locals`, but pinned both ONLY on the compiled-CLJS lane. These
+;; fixtures pair that suite: the new primitive gets direct unit coverage, and
+;; the two collapse shapes are checked against REAL JVM native destructuring —
+;; the exact code the JVM emitter emits — so the two hosts cannot agree on a
+;; value neither host actually binds.
+;; ---------------------------------------------------------------------------
+
+(deftest pattern-locals-are-the-locals-the-host-binds
+  (testing "simple + sequential patterns"
+    (is (= '#{x} (bp/pattern-locals 'x)))
+    (is (= #{}   (bp/pattern-locals '&)) "the rest MARKER is not a local")
+    (is (= '#{x} (bp/pattern-locals '[x])))
+    (is (= '#{a b more all} (bp/pattern-locals '[a b & more :as all]))
+        "element patterns, the rest pattern and :as all bind")
+    (is (= '#{a b c} (bp/pattern-locals '[a [b [c]]])) "nesting recurses"))
+  (testing "associative patterns — group locals arrive NAME-STRIPPED"
+    (is (= '#{x} (bp/pattern-locals '{:keys [ns/x]}))
+        ":keys [ns/x] binds x, exactly as the plan's group locals arrive")
+    (is (= '#{x p whole}
+           (bp/pattern-locals '{:keys [ns/x] p :other :as whole :or {x 1}}))
+        "group locals, explicit sub-patterns and :as bind; :or and lookup keys do not")
+    (is (= '#{u v} (bp/pattern-locals '{[u v] :other}))
+        "an explicit entry's nested pattern recurses")))
+
+(deftest nested-and-partial-overlap-collapse-agrees-with-native-destructuring
+  (testing "NESTED: [x] <- :other is fully reclaimed, so :other is a dead slot"
+    (let [argv '[{[x] :other :keys [ns/x]}]
+          h    (header/parse-header argv)]
+      (is (= [:ns/x] (:slots h))
+          "the dead :other does not reach the comparator / manifest / schema slots")
+      (is (= 2 (count (:binding-units h)))
+          "yet the EXECUTABLE plan keeps both units — every initializer still runs")
+      (is (= '[[x] x] (:locals (emitted argv)))
+          (str "so the CLJS emitter emits the nested [x] <- :other unit AND the "
+               "winning x <- :ns/x, in that order — the later symbol shadows "
+               "the nested pattern's x by host let last-wins")))
+    ;; ground truth — what the JVM emitter's native `let` destructuring binds
+    (let [f (eval (list 'fn '[{[x] :other :keys [ns/x]}] 'x))]
+      (is (= 1 (f {:ns/x 1 :other [9]}))
+          "present :ns/x wins; the nested [x] <- :other read is dead")
+      (is (nil? (f {:other [9]}))
+          "absent :ns/x -> nil, never the shadowed 9 — matches the compiled-CLJS render")))
+  (testing "PARTIAL overlap: b still reads :other, so :other stays a live slot"
+    (let [h (header/parse-header '[{[a b] :other :keys [ns/a]}])]
+      (is (= [:other :ns/a] (:slots h))
+          ":other survives because b is still a final visible local"))
+    (let [f (eval (list 'fn '[{[a b] :other :keys [ns/a]}] '[a b]))]
+      (is (= [1 8] (f {:ns/a 1 :other [7 8]}))
+          "a is the group's :ns/a; b is the executed [a b] <- :other second slot")))
+  (testing "SCHEMA + CLOSED :props follow the collapsed slots for these shapes too"
+    (is (= [:ns/x :extra]
+           (header/declared-slots (header/parse-header '[{[x] :other :keys [ns/x]}])
+                                  (header/props-schema-keys [:map [:extra :any]])))
+        "the dead :other is absent from the declared-slot order the schema extends")
+    (is (= [:other :ns/a]
+           (header/declared-slots (header/parse-header '[{[a b] :other :keys [ns/a]}])
+                                  nil))
+        "a partial overlap keeps the slot its surviving local reads")))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-gvuoo — group-symbol METADATA survives the canonical plan

--- a/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
@@ -321,6 +321,33 @@
                   [{:keys [ns/x] x :other}] [v {:other 1}])))
         "an open map accepts undeclared props, dead-shadowed or not")))
 
+(deftest nested-and-partial-overlap-drive-the-closed-props-set-too
+  ;; rf2-4xpah — PR #6228 extended the collapse to NESTED and partially
+  ;; overlapping patterns, but pinned the consequence only on the comparator and
+  ;; the manifest (compiled-CLJS lane). The declared-slot set also gates CLOSED
+  ;; `:props`, so the same two shapes belong here beside their sibling case.
+  (testing "NESTED: [x] <- :other is fully reclaimed, so :other is undeclared"
+    (let [hdr (header/parse-header '[{[x] :other :keys [ns/x]}])]
+      (is (= [:ns/x] (:slots hdr)))
+      (is (= [:ns/x] (header/declared-slots hdr nil))))
+    (is (nil? (expand-error
+               '(re-frame.ui/defview v {:props [:map [:ns/x :any]]}
+                  [{[x] :other :keys [ns/x]}] [v {:ns/x 1}])))
+        "the host-winning :ns/x prop is accepted")
+    (is (= :rf.ui.compile/undeclared-prop
+           (expand-error
+            '(re-frame.ui/defview v {:props [:map [:ns/x :any]]}
+               [{[x] :other :keys [ns/x]}] [v {:other [1]}])))
+        "the dead :other binds nothing, so a closed map must reject it"))
+  (testing "PARTIAL overlap: b still reads :other, so :other STAYS declared"
+    (let [hdr (header/parse-header '[{[a b] :other :keys [ns/a]}])]
+      (is (= [:other :ns/a] (:slots hdr)))
+      (is (= [:other :ns/a] (header/declared-slots hdr nil))))
+    (is (nil? (expand-error
+               '(re-frame.ui/defview v {:props [:map [:other :any] [:ns/a :any]]}
+                  [{[a b] :other :keys [ns/a]}] [v {:other [1 2]}])))
+        "a surviving visible local keeps its slot legal at a closed call site")))
+
 ;; ---------------------------------------------------------------------------
 ;; custom-element (RULED grammar, closed)
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes rf2-4xpah.

PR #6228 repaired the nested / partially-overlapping `defview` slot collapse and added a real compiled-CLJS proof. The algorithm is sound — this finishes the promised causal host proof without redesigning it. **Test-only: the runtime is unchanged.**

## The advanced-CLJS gap

`^js` on a group local exists for exactly one reason — to survive `:advanced`. Both existing proofs are blind to it:

| proof | what it observes | why it cannot see a lost `^js` |
|---|---|---|
| `binding_plan_host_faithful_jvm_test.clj:304` | `(meta (emit-local '[{:keys [^js node]}] 'node)) => {:tag js}` | a FORM, not a build |
| `binding_plan_host_faithful_cljs_test.cljs` | real `defview`s under `:node-test` | `:none` + `:infer-externs false` — nothing is renamed, so hinted and unhinted reads behave identically |

New `implementation/ui/test/re_frame/ui/binding_plan_advanced_elision_prod_test.cljs` closes it. It runs in the **existing** `:browser-test-prod-elision` build (`shadow-cljs release` ⇒ `:advanced`, shadow's default `:infer-externs :auto`, `goog.DEBUG=false`) — **no new harness, no new build id, no `shadow-cljs.edn` change**. The build's `:ns-regexp "-elision-prod-test$"` picks the file up by name; verified it actually runs (see the mutation below, which names it in the failure).

It mounts real `defview`s and proves the whole chain:

```
authored {:keys [^js probe/node]}
  -> bp/assoc-binding-units reconstructs the name-stripped group local as
     (with-meta (symbol nil (name bb)) (meta bb))
  -> the emitted `let` binds ^js node
  -> shadow's externs inference CLAIMS .bpAdvancedHinted
  -> Closure leaves that read alone under :advanced
```

The probe object is built with `js-obj` (a `goog.object.create` call, not an object literal), so its keys are **unrenamable** — only the READ can break.

`advanced-build-really-renames-unexterned-property-reads` is the **non-vacuity control**: an UNHINTED read of an equivalent property IS renamed away in the same bundle. Without it, a build that had quietly stopped renaming would let the fixture pass while proving nothing.

> The one `:infer-warning` this build emits is that control (`Cannot infer target type in expression (. node -bpAdvancedUnhinted)`). It is deliberate and load-bearing — the compiler stating at build time that it will not extern the read — and is documented in-file so it is not "fixed". The evidence for the fixture is the **absence** of a second such warning.

## Real-host semantics the CLJS fixture could not previously prove

The bead's diagnosis: *"the CLJS default fixture cannot prove initializer order or throwing-default parity because both markers are identical and no default throws."*

- **ORDER is now distinguishable.** `interleaved-order-view` puts three DISTINCT `:or` markers on `{a :aa :keys [b] c :cc}`. The host `dissoc`s the group directive and re-`assoc`s its local **after** the surviving explicit entries, so the real-host log is `["a" "c" "b"]`; a parse-order emitter would log `["a" "b" "c"]`. The JVM companion pins the same pattern against real `clojure.core/destructure`, so neither side can drift into agreeing on a wrong order.
- **The collision defaults carry SEQUENCED markers** (`["D1" "D2"]`, not `["D" "D"]`), so the absent-slot winner is *attributable* to the SECOND evaluation — the later `x <- :ns/x` unit — rather than merely counted. Had the units been emitted in reverse the view would render `D1`.
- **THROW propagation**: a throwing `:or` default escapes the render even when the slot is PRESENT (the default is `get`'s eager third argument; a lazy absent-only lowering would render `5` and swallow it).
- **Qualified key/ref parity is no longer JVM-only.** All three spellings — `{:keys [acct/key acct/ref]}`, `{:acct/keys [key ref]}`, `{k :acct/key r :acct/ref}` — now render the same VISIBLE values through real `defview`s, and a bare `"id"` prop is shown to be a different slot binding nothing (the didactic bare-slot miss: the name-strip renames the LOCAL, never the lookup slot).

## Retained / completed collapse checks

The nested and partial-overlap shapes were pinned only on the comparator and manifest. They now also carry, on the JVM:

- direct unit coverage for `bp/pattern-locals` — the primitive #6228 introduced had **none**;
- agreement with REAL native destructuring (`(eval (fn [{[x] :other :keys [ns/x]}] x))`);
- `declared-slots`, and the **CLOSED-`:props`** consequence beside its sibling case in `defview_grammar_jvm_test.clj`: the dead `:other` is rejected at a literal call site, while a partial overlap keeps its slot legal because a visible local still reads it.

## Mutation proof (teeth)

Reverting `bp/assoc-binding-units` to `(symbol nil (name bb))` — dropping the `with-meta` — and rebuilding the advanced bundle:

```
Build completed. (329 files, 9 compiled, 2 warnings, 61.46s)
  WARNING #1 :infer-warning — Cannot infer target type in (. node -bpAdvancedHinted)   <- NEW
  WARNING #2 :infer-warning — Cannot infer target type in (. node -bpAdvancedUnhinted)

FAIL in (authored-js-hint-survives-the-canonical-plan-into-the-advanced-build)
  expected: "<span data-role=\"bp-hinted\">[kept]</span>"
    actual: "<span data-role=\"bp-hinted\">[]</span>"
Ran 99 tests containing 376 assertions. 1 failures, 0 errors.
```

Exactly the predicted symptom, and the control + nested-shadow tests stayed GREEN — so the failure is precisely attributable to the lost hint. The runtime mutation was reverted; the diff touches test files only.

## Quality gates

All run in the foreground to completion on the final tree.

- `cd implementation/ui && clojure -M:test` (ui JVM) — **Ran 814 tests containing 14639 assertions, 0 failures, 0 errors.**
- `npm run test:cljs` (consolidated compiled-CLJS node lane) — **Ran 9960 tests containing 49089 assertions, 0 failures, 0 errors.**
- `npm run test:browser-prod-elision` (the `:advanced` gate this PR extends; includes the scanner's own mutant sub-build + mutant browser run) — build completed with the 1 deliberate control warning, `ui mounted production elision: PASS`, **Ran 99 tests containing 376 assertions. 0 failures, 0 errors.**

No general macroexpander, metadata framework, compatibility layer or public API was added; the canonical binding-plan helper and the reverse sweep are untouched.
