### PR TITLE
docs(ui): retract the automatic presence DOM promises; timeout-only per ruling (rf2-0ufty)

### DIFF
--- a/docs/api/re-frame.ui.md
+++ b/docs/api/re-frame.ui.md
@@ -355,11 +355,15 @@ from ordinary Clojure code fails loud** (they are not runtime helpers).
 - **Signature**: `(presence {:timeout-ms n} keyed-children)`
 - **Description**: Declarative **enter/exit retention**, deliberately bounded — **not** an
   animation system. Keyed children pass `:mounting` → `:present` → `:unmounting`; an
-  exiting child stays **mounted** until its exit completes **or** the **mandatory**
-  `:timeout-ms` safety bound fires, whichever is first, then removal is **terminal and
-  exactly-once** (all ownership released). Removing then re-inserting a key **interrupts**
-  the exit and re-enters. A child reads its phase with `presence-phase`. On the JVM / SSR
-  the structural render yields `:present` (there is no lifecycle to retain).
+  exiting child is **retained** for exactly the **mandatory** `:timeout-ms` — the exit
+  retention duration *and* terminal bound — then removal is **terminal and exactly-once**
+  (all ownership released). Removing then re-inserting a key **interrupts** the exit and
+  re-enters. A child reads its phase with `presence-phase`. On the JVM / SSR the
+  structural render yields `:present` (there is no lifecycle to retain). The boundary is
+  **DOM-agnostic**: no wrapper node, no stamped attributes, no observed DOM events — a
+  presence-aware child owns its own exit styling and accessibility (stamp `inert` /
+  `aria-hidden` and the exit class against `presence-phase` = `:unmounting`; the child's
+  stylesheet owns `prefers-reduced-motion`).
 - **Errors**: missing / non-positive `:timeout-ms` → `:rf.ui.compile/bad-presence`; an
   unkeyed child under the boundary → `:rf.ui.compile/presence-unkeyed-child`; direct call →
   `:rf.error/ui-tree-malformed`.

--- a/implementation/ui/src/re_frame/ui.cljc
+++ b/implementation/ui/src/re_frame/ui.cljc
@@ -609,12 +609,18 @@
 (defn presence
   "(ui/presence {:timeout-ms n} keyed-children) — declarative enter/exit
   retention, deliberately bounded (NOT an animation system). Keyed children
-  pass :mounting → :present → :unmounting; an exiting child stays mounted until
-  its exit completes OR the MANDATORY :timeout-ms safety bound fires, whichever
-  first, then removal is terminal and exactly-once (all ownership released).
+  pass :mounting → :present → :unmounting; an exiting child is retained for
+  exactly the MANDATORY :timeout-ms — the exit retention duration AND terminal
+  bound — then removal is terminal and exactly-once (all ownership released).
   Removal-then-reinsertion of a key interrupts the exit and re-enters. Unkeyed
   children under a presence boundary are a build failure. Read a child's phase
   with (ui/presence-phase).
+
+  DOM-agnostic: the boundary inserts no wrapper node, stamps no attributes, and
+  observes no DOM events. A presence-aware child owns its own exit styling and
+  accessibility — stamp inert / aria-hidden and the exit class against
+  (ui/presence-phase) = :unmounting; the child's stylesheet owns
+  prefers-reduced-motion.
 
   A template form — the compiler wires it into the runtime retention boundary;
   a direct call fails loud by design."

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -2467,8 +2467,8 @@
     (when-not (contains? opts :timeout-ms)
       (env/fail! e :rf.ui.compile/bad-presence
                  (str ":timeout-ms is MANDATORY on (ui/presence …) — the terminal "
-                      "safety bound: a retained exiting child is removed when its "
-                      "exit completes OR :timeout-ms fires, whichever first")
+                      "safety bound AND the exit retention duration: a retained "
+                      "exiting child is removed when :timeout-ms fires")
                  {:form form}))
     (let [t (:timeout-ms opts)]
       (when-not (and (number? t) (pos? t))

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -550,17 +550,20 @@ enter/exit retention is out of scope):
     [toast-card {:key (:id t) :toast t}]))
 ```
 
-- Keyed children pass `:mounting → :present → :unmounting`; an exiting child stays
-  mounted until its transition/animation completes, with `:timeout-ms` as the
-  **mandatory** safety bound (unit-suffixed); then cleanup is terminal and exactly-once
-  (all ownership released). Unkeyed children under a presence boundary are a build
-  failure.
+- Keyed children pass `:mounting → :present → :unmounting`; an exiting child is retained
+  for exactly `:timeout-ms` — the **mandatory** (unit-suffixed) exit retention duration
+  *and* terminal bound, not a cap over some other completion signal — then cleanup is
+  terminal and exactly-once (all ownership released). Unkeyed children under a presence
+  boundary are a build failure.
 - `(presence-phase)` is the single phase read. Outside a presence boundary it returns
   `:present`, so presence-aware children stay reusable anywhere.
-- Removal-then-reinsertion of a key has deterministic interruption/re-entry; exiting
-  children are `inert`/`aria-hidden` by default; reduced-motion takes the immediate
-  path; hydration does not fabricate enter transitions; tests advance transitions via
-  `ui.test/flush-presence!` (no wall-clock sleeps).
+- Removal-then-reinsertion of a key has deterministic interruption/re-entry; hydration
+  does not fabricate enter transitions; tests advance transitions via
+  `ui.test/flush-presence!` (no wall-clock sleeps). The boundary is **DOM-agnostic**: it
+  inserts no wrapper node, stamps no attributes, and observes no DOM events. A
+  presence-aware child owns its own exit styling and accessibility — stamp `inert` /
+  `aria-hidden` and the exit class against `(presence-phase)` = `:unmounting`, and let
+  the child's stylesheet honour `prefers-reduced-motion`.
 - The JVM emitter renders `:present` and exposes presence metadata structurally.
   Occurrence-paths (§View identity) identify retained exiting rows in tooling.
 
@@ -1292,7 +1295,8 @@ stages in small batches, 011 → S5).
   `re-frame.ui.test` / `.react` / (if earned) `.data`. Separate artifact on a lockstep
   release train initially (R-6).
 - **R-4 — the narrow bare-fn law + strict lint** (§Handlers).
-- **Presence ruling** — wrapper form, no reserved nodes; `:timeout-ms` mandatory;
+- **Presence ruling** — wrapper form, no reserved nodes; `:timeout-ms` mandatory (it *is*
+  the exit retention duration, and the boundary stays DOM-agnostic — rf2-0ufty);
   `presence-phase` returns `:present` outside a boundary (§Presence).
 - **Refs policy** — `:ref` reserved; object refs preferred; callback refs explicit
   `ui/raw-fn` (§Handlers).


### PR DESCRIPTION
Closes rf2-0ufty.

`spec/004-Views.md` §Presence promised three **automatic DOM behaviours** that the shipped presence runtime does not implement. This retracts them and reconciles `:timeout-ms` wording so spec prose, the public docstring, the human API reference, the compiler diagnostic, and the runtime all agree on **timeout-only**.

Per the delegated ruling recorded on the bead (2026-07-18 14:57 AUSEST): **D1** stay minimal / DOM-agnostic, **D3** `:timeout-ms` stays mandatory as *the* exit retention duration and terminal bound (not a safety cap over a completion mechanism that does not exist), **D2** the prose follow-through happens now.

## The three retracted promises, with runtime evidence

Verified against `implementation/ui/src/re_frame/ui/presence_runtime.cljc` (merged in #6261). The runtime is three phases with a `:timeout-ms`-driven exit through `schedule-exit!` → `fire-timer!` (id-keyed, exactly-once). It registers **no** DOM listener, stamps **no** attribute, and reads **no** media query — `render-entries` wraps each child in a phase-carrying context `Provider` and nothing else.

| # | Promise (before) | After | Runtime evidence it was unkept |
|---|---|---|---|
| 1 | `spec/004-Views.md:553` — "stays mounted until its **transition/animation completes**, with `:timeout-ms` as the mandatory **safety bound**" | "is retained for exactly `:timeout-ms` — the mandatory (unit-suffixed) exit retention duration *and* terminal bound, not a cap over some other completion signal" | No `transitionend` / `transitioncancel` / `addEventListener` anywhere in the presence runtime. `schedule-exit!` is the only exit route and it fires on `timeout-ms` alone. |
| 2 | `spec/004-Views.md:560` — "exiting children are `inert`/`aria-hidden` **by default**" | replaced with author-facing guidance: the child stamps `inert` / `aria-hidden` and the exit class against `(presence-phase)` = `:unmounting` | `render-entries` adds only `#js {:value phase :key key}` on the context Provider — no attribute is ever stamped on any child. |
| 3 | `spec/004-Views.md:561` — "**reduced-motion takes the immediate path**" | replaced with: the child's stylesheet honours `prefers-reduced-motion` | No `matchMedia` and no `prefers-reduced-motion` read in `implementation/ui/src` at all; there is no alternate immediate-removal path in the code. |

## `:timeout-ms` rewording

Reworded on every surface from a *safety cap over some other completion mechanism* to **the exit retention duration and terminal bound** — which is what the runtime actually implements:

- `spec/004-Views.md` §Presence bullet 1, plus a short clarifier appended to the Resolved-decisions "Presence ruling" line (permitted by the bead; the line was already correct).
- `implementation/ui/src/re_frame/ui.cljc` — `ui/presence` docstring: dropped "exit completes OR … whichever first"; added a DOM-agnostic paragraph.
- `docs/api/re-frame.ui.md` — the `presence` human API reference carried the same "whichever is first" phrasing.
- `implementation/ui/src/re_frame/ui/compiler/analyze.cljc` — the `:rf.ui.compile/bad-presence` message told authors the child "is removed when its **exit completes OR** `:timeout-ms` fires, whichever first". See the note below.

## Scope note — `analyze.cljc`

The bead enumerated surfaces (1) spec, (2) docstring, (3) a `docs/`+`skills/` sweep; its sweep hint grepped for `transitionend`/`inert`/`aria-hidden`/`reduced-motion`, which does not match this message's "exit completes" phrasing, so the compiler diagnostic was missed. The bead's AC is *no automatic-DOM promise remains on any tracked surface*, so it is covered here.

The change is a **string literal only** — no logic, no grammar behaviour, no accept/reject change — and it deliberately preserves both substrings the frozen error roster pins (`":timeout-ms is MANDATORY"` and `"safety bound"`), so **no test changes were required**. Verified by running the roster namespace directly (below).

## Not done, deliberately

- No behaviour added. No runtime or grammar logic touched; `presence_runtime.cljc` is untouched (its docstring was already truthful).
- No wrapper node, clone/ref contract, sanitiser, or attribute stamping introduced.
- §Presence not restructured — still three bullets plus the JVM bullet, kept surgical because **rf2-74vlo (S4-C) lands on this file next**.
- The consumer-gated **future seam** (child-attached, exit-scoped completion signal racing the mandatory timeout — rf2-6ajm6z) is **not** implemented and not written into the spec.
- The S4 conformance row and the JVM parity contract are unchanged.

Couples to **rf2-74vlo (S4-C)**: the `presence-exit-interactive` remedy is author-owned stamping against `(presence-phase)` = `:unmounting`, never a framework `inert`-on-exit — no S4-C check may depend on framework inert-on-exit existing.

## Quality gates

All foreground, run to completion.

| Gate | Result |
|---|---|
| `python -m mkdocs build --strict` | **exit 0**, no WARNING/ERROR |
| `python scripts/check_doc_slugs.py` | **clean** (no output) |
| `implementation/ui` JVM — `clojure -M:test` | **818 tests / 14653 assertions, 0 failures, 0 errors** |
| `implementation/ui` JVM — roster ns alone (`-n re-frame.ui.error-roster-cljs-test`) | **12 tests / 608 assertions, 0 failures** — proves the reworded diagnostic still satisfies both pinned substrings |
| `implementation/scripts/api-manifest` — `clojure -M:test` | **104 tests / 229 assertions, 0 failures**; `docs/api` page+member coverage and projection in sync |
| Playground SCI freshness | **N/A** — `implementation/ui/src` is not on the baked input roster (roster is `core/src`, `adapters/reagent-slim/src`, `machines/src`, `flows/src`, `docs/tools/playground/sci/src`) |

**AC grep — no automatic-DOM promise remains on any tracked surface.** `git grep -iE "transitionend|transition/animation completes|exit completes|whichever first|whichever is first"` over tracked files (excluding `.beads/`, the generated `docs/cljs/` bundle, and the unrelated adapter/SSR event-name rosters) returns **no matches**. The surviving `inert` / `aria-hidden` / `prefers-reduced-motion` mentions in the presence context are exactly the new **author-facing guidance** (the child owns them) — never a framework promise.
