### PR TITLE
feat(story): consume flush-presence! for presence-bearing variant playback (rf2-qwzmt, S4-H)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -934,6 +934,8 @@ not every step is legal in both positions:
 | `[:dispatch event-vector]` | settled event dispatch | `:headless` |
 | `[:wait-until predicate-spec]` | settle-on-condition; deterministic if queue/state-based | depends on predicate |
 | `[:wait ms]` | bounded wall-clock sleep; the explicit determinism opt-out | runner-dependent |
+| `[:flush-presence]` | advance the presence clock to quiescence (every retained exit fires) | `:headless` |
+| `[:flush-presence ms]` | advance the presence clock by `ms` (only the exits due fire) | `:headless` |
 | `[:assert assertion-vector]` | checkpoint assertion at this point in the script; illegal in `:setup` | depends on assertion |
 | `[:click selector]` | DOM click | `:dom` / `:browser` |
 | `[:type selector text]` | DOM text input | `:dom` / `:browser` |
@@ -1000,6 +1002,10 @@ on caller.
   REFUSES a program containing a bare `[:wait ms]` with `:cannot-run`
   rather than running it flakily. `[:wait-until pred]` is the
   deterministic alternative and SHOULD be preferred.
+- **`[:flush-presence]` / `[:flush-presence ms]`** advances the
+  compiled-view PRESENCE clock (Spec 004 §Presence) — the fake-clock twin
+  of `[:wait ms]`, and the reason a presence-bearing variant needs no
+  determinism opt-out. See §Presence-bearing variants below.
 - **`[:assert assertion-vector]`** evaluates a `:rf.assert/*` assertion
   atom at THIS exact point in the script — the in-script checkpoint
   position of the one assertion atom (§Inline script assertions vs
@@ -1044,6 +1050,62 @@ checkpoint) or to the terminal `:assertions` slot. The reject runs on the
 fully-resolved setup (inherited ⧺ composed ⧺ own), so a misplaced verdict
 surfaces before any run — the same way the other `:rf.error/story-*` plan
 errors do.
+
+#### Presence-bearing variants
+
+A variant whose view renders a `(ui/presence {:timeout-ms n} …)` boundary
+(Spec 004 §Presence) RETAINS a removed keyed child in the `:unmounting`
+phase until the `:timeout-ms` safety bound fires. That retention is a
+CLOCK, not a queue, so no rung of the settled-boundary ladder can settle
+it: draining the router (`:headless`), flushing reactions
+(`:cljs-reactive`) and awaiting a React commit (`:dom`) all leave the
+retained child exactly where it is, and the next step races the timeout.
+The only wall-clock answer would be `[:wait ms]` — which the determinism
+gate REFUSES (§The bare-`[:wait ms]` opt-out).
+
+`[:flush-presence]` is the deterministic answer. It advances the presence
+FAKE CLOCK through the framework's own verb
+(`re-frame.ui.test/flush-presence!`), firing due exits with no wall-clock
+sleep:
+
+- `[:flush-presence]` advances to quiescence — every pending exit fires,
+  so every retained child reaches its terminal removal;
+- `[:flush-presence ms]` advances the logical clock by `ms` — only the
+  exits that come due fire, so a script can observe a child still RETAINED
+  in `:unmounting` and only THEN drive its removal.
+
+Phases are asserted the ordinary way. `(ui/presence-phase)` is a
+render-time read, so a presence-aware view renders its phase (typically as
+an attribute — `{:data-phase (name (ui/presence-phase))}`) and the script
+asserts on what was rendered:
+
+```clojure
+:script [[:dispatch [:toasts/dismiss 2]]
+         ;; the dismissed toast is RETAINED, still mounted, :unmounting
+         [:assert-dom "[data-msg=b]" :text "b"]
+         [:flush-presence 100]                    ; below :timeout-ms
+         [:assert-dom "[data-msg=b]" :visible]    ; still retained
+         [:flush-presence]                        ; to quiescence
+         [:assert-dom "[data-msg=b]" :hidden]]    ; terminal removal
+```
+
+Story does NOT model presence, own a clock, or reimplement the three-phase
+machine — `re-frame.story.play.presence` is a thin seam that CALLS the
+framework verb. Because Story's shipped jar must not depend on the
+pre-publication `day8/re-frame2-ui`, the verb is INSTALLED by a
+`re-frame.ui`-hosted shell
+(`re-frame.story.play.presence/install-presence-flush!`, registering the
+`:flush-presence!` late-bind hook) rather than `:require`d.
+
+`[:flush-presence]` requires NO capability token and does not lift
+`:required-runner` to `:dom` — the presence clock is a process-global
+fake-clock registry, and a host with no presence runtime advances a
+no-op. That mirrors the framework's own JVM arm of `flush-presence!`,
+which is a documented no-op for host parity so a `.cljc` body reads the
+same on either host. It is deliberately NOT a `:cannot-run` refusal: a
+refusal exists to stop a step passing FALSELY, and there is no false pass
+here — the DOM assertion that FOLLOWS the advance carries the `:dom`
+requirement, as it always did.
 
 **Source metadata is preserved for narrative projection.** The runner
 keeps the script step on every step-result and trace record, and the
@@ -1783,7 +1845,9 @@ tokens it requires:
 
 - `[:dispatch …]` / `[:dispatch-sync …]` → `#{:app-db}` (the headless
   floor drains the queue to a fixed point); `[:wait …]` / `[:wait-until
-  …]` → `#{}` (the boundary ladder governs flush, not the capability set);
+  …]` / `[:flush-presence …]` → `#{}` (the boundary ladder governs flush,
+  not the capability set; the presence clock is a process-global registry
+  and a host without one advances a no-op — §Presence-bearing variants);
   `[:click …]` / `[:type …]` / `[:focus …]` / `[:assert-dom …]` →
   `#{:dom}`.
 - An in-script `[:assert <atom>]` checkpoint folds the WRAPPED atom's
@@ -3216,6 +3280,14 @@ running it flakily. The refusal is a **pure pre-flight** — computed before
 any replay — and carries `:reason :determinism-wall-clock-wait` and the
 offending `:wait-steps`. (A virtual clock that would make `[:wait ms]`
 deterministic remains a non-goal, §P1 non-goals.)
+
+`[:flush-presence]` is NOT a wall-clock step and is never refused: it
+advances the compiled-view presence FAKE clock (§Presence-bearing
+variants), so a variant that would otherwise reach for `[:wait ms]` to
+outlast a `:timeout-ms` retention keeps its deterministic verdict. This is
+not the general virtual clock the non-goal rules out — it advances exactly
+one bounded framework registry (the presence exit scheduler), through the
+framework's own verb.
 
 ### Pure / JVM-testable
 

--- a/tools/story/spec/API.md
+++ b/tools/story/spec/API.md
@@ -227,6 +227,8 @@ transitional dual-acceptance. See [`001-Authoring.md`](001-Authoring.md)
 | `[:dispatch event-vec]`              | `rf/dispatch` (async) into the variant's frame             |
 | `[:dispatch-sync event-vec]`         | `rf/dispatch-sync` (synchronous) into the variant's frame  |
 | `[:wait ms]`                         | Sleep N ms                                                 |
+| `[:flush-presence]`                  | Advance the compiled-view presence clock to quiescence — every retained (`:unmounting`) child reaches its terminal removal (spec/017 §Presence-bearing variants) |
+| `[:flush-presence ms]`               | Advance the presence clock by N ms — only the exits that come due fire, so a script can observe a child still retained |
 | `[:assert assertion-atom]`           | Evaluate a canonical `[:rf.assert/…]` atom at this point — the primary assertion form (see [Canonical assertion events](#canonical-assertion-events--the-one-assertion-vocabulary)) |
 | `[:assert-db path value]`            | **Sugar** → folds to `[:assert [:rf.assert/path-equals path value]]` |
 | `[:assert-db path :pred fn-or-sym]`  | **Sugar** → folds to `[:assert [:rf.assert/path-matches path [:fn …]]]` |

--- a/tools/story/src/re_frame/story/late_bind.cljc
+++ b/tools/story/src/re_frame/story/late_bind.cljc
@@ -81,6 +81,28 @@
                                      JVM (no DOM / substrate), so
                                      `render-variant` returns `:cannot-run`.
 
+  - `:flush-presence!`             — a `re-frame.ui`-hosted shell →
+                                     `re-frame.story.play.presence` (consumed
+                                     by the `[:flush-presence]` script step).
+                                     Advances the compiled-view PRESENCE fake
+                                     clock so a variant rendering a
+                                     `(ui/presence …)` boundary settles its
+                                     retained (`:unmounting`) children
+                                     deterministically, with no wall-clock
+                                     sleep. Signature: `(f ms-or-nil) → any`
+                                     — nil means 'to quiescence', mirroring
+                                     the two arities of the framework verb
+                                     `re-frame.ui.test/flush-presence!`.
+                                     Story's shipped jar must not depend on
+                                     the pre-publication `day8/re-frame2-ui`,
+                                     so the verb arrives through this hook
+                                     rather than a `:require`. Absent on a
+                                     host with no presence runtime, where the
+                                     advance is a no-op (host parity with the
+                                     framework's own JVM arm), NOT a refusal.
+                                     Install via
+                                     `re-frame.story.play.presence/install-presence-flush!`.
+
   - `:render-hiccup`               — a host that can render the active view
                                      to a HICCUP TREE (data) → the play
                                      runner's browser-tier executor

--- a/tools/story/src/re_frame/story/play/evidence.cljc
+++ b/tools/story/src/re_frame/story/play/evidence.cljc
@@ -426,8 +426,9 @@
   open a narrative span over the epochs they settle. `:dispatch` and
   `:dispatch-sync` both commit at least one epoch; DOM-driving steps
   (`:click` / `:type` / `:focus`) commit epochs through the synthetic
-  event they fire. Pure assertion / wait steps (`:assert` / `:assert-db`
-  / `:assert-dom` / `:wait` / `:wait-until`) commit no epoch of their own
+  event they fire. Pure assertion / settle steps (`:assert` / `:assert-db`
+  / `:assert-dom` / `:wait` / `:wait-until` / `:flush-presence`) commit no
+  epoch of their own
   — their beats (if any) belong to the preceding dispatch — so they are
   NOT span-openers. (An `[:assert …]` checkpoint DOES dispatch its wrapped
   `:rf.assert/*` atom, but that is a verdict, not behaviour-under-test, so

--- a/tools/story/src/re_frame/story/play/presence.cljc
+++ b/tools/story/src/re_frame/story/play/presence.cljc
@@ -1,0 +1,95 @@
+(ns re-frame.story.play.presence
+  "The presence rung of Story playback — the seam a `[:flush-presence]`
+  script step reaches for (rf2-qwzmt, S4-H; Spec 004 §Presence).
+
+  ## Why a rung exists
+
+  A variant whose view renders a `(ui/presence {:timeout-ms n} …)` boundary
+  RETAINS a removed keyed child in `:unmounting` until the `:timeout-ms`
+  safety bound fires. Playback then has a settlement problem the
+  `settled-boundary` ladder cannot solve: the retention is a CLOCK, not a
+  queue. Draining the router to a fixed point (`:headless`), flushing
+  reactions (`:cljs-reactive`) or awaiting a React commit (`:dom`) all leave
+  the retained child exactly where it is — the next step races the timeout.
+  The only wall-clock answer is `[:wait ms]`, which the determinism gate
+  REFUSES (`re-frame.story.determinism` §The bare-`[:wait ms]` opt-out).
+
+  `re-frame.ui.test/flush-presence!` is the framework's own answer: it
+  advances the presence FAKE CLOCK, firing due exits with no wall-clock
+  sleep. `(flush-presence!)` advances to quiescence (every pending exit
+  fires); `(flush-presence! ms)` advances the logical clock by `ms`, firing
+  only the exits that come due — so a script can observe the retained
+  `:unmounting` phase and THEN its terminal removal, deterministically.
+
+  This namespace is the (thin) seam, nothing more. Story does NOT model
+  presence, own a clock, or reimplement the three-phase machine — it CALLS
+  the framework verb and lets the framework own the semantics.
+
+  ## The host hook
+
+  Story's shipped jar must not depend on `re-frame.ui` (`day8/re-frame2-ui`
+  is pre-publication — the same isolation `re-frame.story.view-tool` keeps),
+  so the verb arrives through the `re-frame.story.late-bind` registry under
+  `:flush-presence!`. A `re-frame.ui`-hosted shell installs it once at boot:
+
+      (require '[re-frame.ui.test :as uit])
+
+      (story-presence/install-presence-flush!
+        (fn [ms] (if ms (uit/flush-presence! ms) (uit/flush-presence!))))
+
+  With NO host installed the advance is a no-op — deliberately, and for the
+  same reason the framework's own JVM arm of `flush-presence!` is a no-op:
+  a host with no presence runtime has no retention to advance, and
+  `.cljc` playback must read the same on either host (`ui.test` §host
+  parity). It is NOT a `:cannot-run` refusal: a refusal is for a step that
+  would otherwise pass FALSELY, and there is no false pass here — the
+  assertion that follows carries its own capability gate (a `:assert-dom`
+  step still refuses `:cannot-run` under a headless runner).
+
+  Pure data → data apart from the hook call itself, so both the JVM
+  `clojure -M:test` gate and the node `npm run test:cljs` gate exercise it."
+  (:require [re-frame.story.late-bind :as late-bind]))
+
+(def presence-flush-hook-key
+  "The `re-frame.story.late-bind` hook key a `re-frame.ui`-hosted shell
+  registers its presence-clock advance under. The fn signature is
+  `(f ms-or-nil) → any` — `nil` means advance to quiescence, a number means
+  advance the logical clock by that many milliseconds. Both map 1:1 onto the
+  two arities of `re-frame.ui.test/flush-presence!`."
+  :flush-presence!)
+
+(defn install-presence-flush!
+  "Register the host's presence-clock advance under the `:flush-presence!`
+  late-bind hook. `flush-fn` takes ONE argument — the ms to advance by, or
+  `nil` for 'to quiescence' — mirroring `flush-presence!`'s two arities.
+  Idempotent (re-registration replaces, per Spec 001 hot-reload semantics)."
+  [flush-fn]
+  (late-bind/set-fn! presence-flush-hook-key flush-fn)
+  nil)
+
+(defn presence-flush-fn
+  "The installed presence-advance fn, or nil when no host registered one
+  (the bare JVM / a Story app with no compiled-view presence boundaries)."
+  []
+  (late-bind/get-fn presence-flush-hook-key))
+
+(defn advance!
+  "Advance the presence clock by `ms` (nil → to quiescence) through the
+  installed host verb. Returns a small result map:
+
+    {:status :advanced :ms <ms|nil>}   — the host verb ran
+    {:status :no-host  :ms <ms|nil>}   — no host installed; a no-op advance
+                                         (host parity — see the ns docstring)
+    {:status :error    :ms … :error s} — the host verb threw
+
+  Never throws: the executor projects the map into a step-result."
+  [ms]
+  (if-let [f (presence-flush-fn)]
+    (try
+      (f ms)
+      {:status :advanced :ms ms}
+      (catch #?(:clj Throwable :cljs :default) e
+        {:status :error
+         :ms     ms
+         :error  #?(:clj (.getMessage ^Throwable e) :cljs (str e))}))
+    {:status :no-host :ms ms}))

--- a/tools/story/src/re_frame/story/play/runner.cljc
+++ b/tools/story/src/re_frame/story/play/runner.cljc
@@ -55,12 +55,24 @@
   with `:cannot-run` (the capability registry requires `:dom`), and they
   run under a `:dom` / `:browser` runner.
 
+  `[:flush-presence]` / `[:flush-presence ms]` advances the compiled-view
+  PRESENCE clock (Spec 004 §Presence) so a variant whose view renders a
+  `(ui/presence {:timeout-ms n} …)` boundary settles its retained
+  (`:unmounting`) children DETERMINISTICALLY — the fake-clock twin of
+  `[:wait ms]`, and the reason a presence-bearing variant does not need the
+  determinism opt-out. It routes through
+  `re-frame.story.play.presence` to the framework's own
+  `re-frame.ui.test/flush-presence!`; with no presence host installed it is
+  a no-op (host parity, exactly as the framework's JVM arm is).
+
   | Step                               | Semantics                                                     |
   |------------------------------------|---------------------------------------------------------------|
   | `[:dispatch event-vec]`            | settled dispatch — drain through `settled-boundary`           |
   | `[:dispatch-sync event-vec]`       | low-level synchronous dispatch escape (not the author form)   |
   | `[:wait-until predicate-spec]`     | deterministic settle-on-condition (queue/state)               |
   | `[:wait ms]`                       | bounded wall-clock sleep — the explicit determinism opt-out   |
+  | `[:flush-presence]`                | advance the presence clock to quiescence (fires every exit)   |
+  | `[:flush-presence ms]`             | advance the presence clock by `ms` (fires the exits due)      |
   | `[:assert assertion-vector]`       | in-script checkpoint assertion (illegal in `:setup`)          |
   | `[:assert-db path value]`          | Assert `(= (get-in @app-db path) value)`                      |
   | `[:assert-db path :pred fn-or-sym]`| Assert custom predicate — `fn` is preferred (works under advanced CLJS); `symbol` is the JVM/dev escape hatch (resolved at run time, fragile under advanced CLJS munging) |
@@ -103,8 +115,10 @@
   step grammar across `:setup` and `:script` (spec/017 §Script step
   grammar). `:assert` is the in-script checkpoint atom
   (the wrapped `:rf.assert/*` assertion); `:wait-until` is the
-  deterministic settle-on-condition; `:focus` is the DOM focus step."
-  #{:dispatch :dispatch-sync :wait :wait-until
+  deterministic settle-on-condition; `:focus` is the DOM focus step;
+  `:flush-presence` is the deterministic presence-clock advance (the
+  fake-clock twin of `:wait`)."
+  #{:dispatch :dispatch-sync :wait :wait-until :flush-presence
     :assert :assert-db :assert-dom
     :click :type :focus})
 
@@ -117,9 +131,18 @@
 (def async-yield-step-types
   "Steps that put work on an async queue the runner cannot directly
   flush — `:click` / `:type` / `:focus` (synthetic DOM events whose
-  handlers re-enter the dispatch chain) and `:wait` (the runner sleeps
-  explicitly). The driver yields one tick AFTER these steps so the
-  queued effects drain before the next step runs.
+  handlers re-enter the dispatch chain), `:wait` (the runner sleeps
+  explicitly) and `:flush-presence`. The driver yields one tick AFTER
+  these steps so the queued effects drain before the next step runs.
+
+  `:flush-presence` is here because the framework verb it calls
+  (`re-frame.ui.test/flush-presence!`) is Promise-backed on CLJS: the
+  clock advance and its removal callbacks run SYNCHRONOUSLY inside the
+  awaited `act`, but the React commits that unmount the retained subtree
+  settle on the microtask queue. A `setTimeout` 0 yield runs after the
+  microtask queue has drained to empty, so the next step observes the
+  committed removal rather than racing it. On the JVM the verb is a
+  synchronous no-op and the run loop recurs in tail position regardless.
 
   `:dispatch` is not in this set: a `[:dispatch …]` step settles through
   `settled-boundary` (spec/017) — in headless the `dispatch-sync!`
@@ -136,7 +159,7 @@
 
   Steps NOT in this set (`:dispatch`, `:dispatch-sync`, `:wait-until`,
   `:assert`, `:assert-db`, `:assert-dom`) recur synchronously on CLJS."
-  #{:click :type :focus :wait})
+  #{:click :type :focus :wait :flush-presence})
 
 (declare step-type)
 
@@ -189,6 +212,14 @@
                       (and (= 2 (count step))
                            (number? (nth step 1))
                            (not (neg? (nth step 1)))))
+    ;; `[:flush-presence]` (to quiescence) / `[:flush-presence ms]` (advance
+    ;; the logical clock by ms) — the two arities of the framework verb
+    ;; `re-frame.ui.test/flush-presence!`, no more.
+    :flush-presence (boolean
+                      (or (= 1 (count step))
+                          (and (= 2 (count step))
+                               (number? (nth step 1))
+                               (not (neg? (nth step 1))))))
     ;; `[:wait-until predicate-spec]` — deterministic settle-on-condition.
     ;; The predicate-spec is `[:db path expected]`, `[:db path :pred fn]`,
     ;; or `[:queue-empty]`. A 2-arity vector whose payload is itself a
@@ -665,6 +696,9 @@
     :dispatch-sync  (str "dispatch-sync " (pr-str (second step)))
     :wait           (str "wait " (second step) "ms")
     :wait-until     (str "wait-until " (pr-str (second step)))
+    :flush-presence (if (= 1 (count step))
+                      "flush-presence"
+                      (str "flush-presence " (second step) "ms"))
     :assert         (str "assert " (pr-str (second step)))
     :assert-db      (cond
                       (and (= 4 (count step)) (= :pred (nth step 2)))
@@ -770,6 +804,17 @@
   "Return the ms duration from a `:wait` step, or nil."
   [step]
   (when (= :wait (step-type step))
+    (nth step 1 nil)))
+
+(defn step-presence-ms
+  "Return the ms to advance the presence clock by from a
+  `[:flush-presence ms]` step, or nil — for the bare `[:flush-presence]`
+  (advance to quiescence) AND for any non-`:flush-presence` step. The two
+  cases are distinguished by the step TAG, never by this nil: nil here
+  means exactly what nil means to `re-frame.ui.test/flush-presence!` — the
+  no-arg arity."
+  [step]
+  (when (= :flush-presence (step-type step))
     (nth step 1 nil)))
 
 (defn step-assertion

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -11,6 +11,9 @@
     (richer runners supply reactive / DOM flushes through flush-hooks).
     `:dispatch-sync` → the low-level `re-frame.router/dispatch-sync!` escape.
   - `:wait` ms → JS `setTimeout` (CLJS) or `Thread/sleep` (JVM).
+  - `:flush-presence` → the presence-clock advance
+    (`re-frame.story.play.presence/advance!` → the host's
+    `re-frame.ui.test/flush-presence!`); a no-op with no presence host.
   - `:assert-db` path value → read from `rf/app-db-value` and compare.
   - `:assert-db` path :pred fn-or-sym → invoke the predicate. A FN
     handed in directly is called as-is (advanced-CLJS-safe); a SYMBOL
@@ -48,6 +51,7 @@
             [re-frame.story.play.browser :as browser]
             [re-frame.story.play.dom    :as dom]
             [re-frame.story.play.evidence :as evidence]
+            [re-frame.story.play.presence :as presence]
             [re-frame.story.play.runner :as runner]
             [re-frame.story.play.settled-boundary :as boundary]
             [re-frame.story.predicates  :as pred]
@@ -1055,6 +1059,30 @@
                                         "queue/state predicate did not hold "
                                         "after the preceding dispatch settled)")}))))
 
+(defn- exec-flush-presence!
+  "Execute a `[:flush-presence]` / `[:flush-presence ms]` step — advance the
+  compiled-view PRESENCE clock through the installed host verb
+  (`re-frame.story.play.presence/advance!` → the framework's
+  `re-frame.ui.test/flush-presence!`), so a variant rendering a
+  `(ui/presence {:timeout-ms n} …)` boundary settles its retained
+  (`:unmounting`) children WITHOUT a wall-clock sleep.
+
+  Bare `[:flush-presence]` advances to quiescence (every pending exit
+  fires); `[:flush-presence ms]` advances the logical clock by `ms`, firing
+  only the exits that come due — the arity that lets a script observe the
+  retained `:unmounting` phase before its terminal removal.
+
+  A no-host advance is a step-skip, NOT a `:cannot-run` refusal: with no
+  presence runtime there is no retention to advance and nothing to pass
+  falsely (the framework's own JVM arm is a no-op for the same host-parity
+  reason). A host verb that THROWS is a step-exception — never swallowed."
+  [_frame-id idx step]
+  (let [ms  (runner/step-presence-ms step)
+        res (presence/advance! ms)]
+    (if (= :error (:status res))
+      (runner/step-exception idx step (:error res))
+      (runner/step-skip idx step))))
+
 (defn exec-step!
   "Execute ONE step against `frame-id`. Returns a step-result record
   (per `runner/step-pass` / `step-fail` / `step-skip` / `step-exception`).
@@ -1083,6 +1111,7 @@
       (:assert-db
        :assert-dom)   (exec-assert! frame-id idx (assertions/fold-assert-step step))
       :wait-until     (exec-wait-until!    frame-id idx step)
+      :flush-presence (exec-flush-presence! frame-id idx step)
       :click          (exec-click!         frame-id idx step)
       :type           (exec-type!          frame-id idx step)
       :focus          (exec-focus!         frame-id idx step)

--- a/tools/story/src/re_frame/story/requirements.cljc
+++ b/tools/story/src/re_frame/story/requirements.cljc
@@ -230,13 +230,19 @@
   "Capability tokens each SCRIPT/SETUP step tag requires (spec/017 §Script
   step grammar + §Runner requirements). `:dispatch` needs only `:app-db`
   (the headless floor drains the queue to fixed point); DOM-driving steps
-  need `:dom`. `:wait` / `:wait-until` require nothing of their own — the
-  predicate / wall-clock dictates the settlement, and the boundary ladder
-  (`settled-boundary`) governs flush, not the capability set."
+  need `:dom`. `:wait` / `:wait-until` / `:flush-presence` require nothing
+  of their own — the predicate / wall-clock / presence clock dictates the
+  settlement, and the boundary ladder (`settled-boundary`) governs flush,
+  not the capability set. `:flush-presence` in particular does NOT require
+  `:dom`: the presence clock is a process-global fake-clock registry, and a
+  host with no presence runtime advances a no-op (host parity — see
+  `re-frame.story.play.presence`). The DOM assertion that FOLLOWS the
+  advance carries the `:dom` requirement, as it always did."
   {:dispatch       #{:app-db}
    :dispatch-sync  #{:app-db}
    :wait           #{}
    :wait-until     #{}
+   :flush-presence #{}
    :assert-db      #{:app-db}
    :assert         #{:app-db}   ; in-script checkpoint — tokens come from its assertion atom
    :assert-dom     #{:dom}

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -160,11 +160,11 @@
   This returns the wrapped event vector for those, plus a bare event
   vector that bypassed coercion (an out-of-band path).
 
-  A NON-dispatch step (`[:wait …]`, `[:wait-until …]`, `[:click …]`,
-  `[:type …]`, `[:focus …]`) is legal in `:setup` per the grammar table
-  and contributes its capability token to `:required-runner` — but it
-  needs `>= :dom` / `:cljs-reactive`, which the headless phase-2 path
-  cannot honour. Such a step returns `nil` here; `plan-setup-events`
+  A NON-dispatch step (`[:wait …]`, `[:wait-until …]`,
+  `[:flush-presence …]`, `[:click …]`, `[:type …]`, `[:focus …]`) is legal
+  in `:setup` per the grammar table, but the headless phase-2 path can only
+  `dispatch-sync` — it cannot sleep, settle on a predicate, advance the
+  presence clock or drive the DOM. Such a step returns `nil` here; `plan-setup-events`
   turns that into a loud `:cannot-run`-shaped refusal rather than a
   silent drop (spec/017 §Script and settled-boundary — a step a runner
   cannot honour FAILS CLOSED, never under-runs and passes falsely)."
@@ -208,10 +208,10 @@
 
   REFUSES (throws `:rf.error/story-setup-step-unrunnable`) when a setup
   step is a non-dispatch step (`[:wait …]` / `[:click …]` / `[:type …]`
-  / `[:focus …]` / `[:wait-until …]`). Such a step is legal in `:setup`
-  and lifts `:required-runner` to `:dom` / `:cljs-reactive`, but the
-  headless phase-2 path can only `dispatch-sync` — it cannot honour a
-  DOM/reactive boundary. Per spec/017 §Script and settled-boundary a
+  / `[:focus …]` / `[:wait-until …]` / `[:flush-presence …]`). Such a step
+  is legal in `:setup`, but the headless phase-2 path can only
+  `dispatch-sync` — it cannot honour a DOM/reactive boundary or advance
+  the presence clock. Per spec/017 §Script and settled-boundary a
   step a runner cannot honour FAILS CLOSED (`:cannot-run`); silently
   dropping it is the forbidden under-run that vanishes a precondition the
   author wrote. The throw is caught by the orchestrator and projected as
@@ -229,10 +229,10 @@
              " — :setup carries a non-dispatch step "
              (pr-str (vec offenders))
              " that the headless runner cannot execute. A "
-             ":wait / :wait-until / :click / :type / :focus step is "
-             "legal in :setup but requires a :dom / :cljs-reactive "
-             "runner; run this variant under a richer runner, or move "
-             "the step to :script.")
+             ":wait / :wait-until / :flush-presence / :click / :type / "
+             ":focus step is legal in :setup but the headless phase-2 "
+             "path can only dispatch-sync; run this variant under a "
+             "richer runner, or move the step to :script.")
         {:recovery :use-a-richer-runner-or-move-to-script
          :extra    {:variant/id      variant-id
                     :offending-steps (vec offenders)}}))

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -492,6 +492,8 @@
   - `[:dispatch-sync event-vec]`         — synchronous dispatch escape
   - `[:wait-until predicate-spec]`       — deterministic settle-on-condition
   - `[:wait ms]`                         — sleep N ms (determinism opt-out)
+  - `[:flush-presence]`                  — advance the presence clock to quiescence
+  - `[:flush-presence ms]`               — advance the presence clock by N ms
   - `[:assert assertion-vec]`            — in-script `:rf.assert/*` checkpoint
   - `[:assert-db path value]`            — equality assertion
   - `[:assert-db path :pred fn-sym]`     — predicate assertion

--- a/tools/story/test/re_frame/story/play/presence_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/presence_cljs_test.cljc
@@ -1,0 +1,338 @@
+(ns re-frame.story.play.presence-cljs-test
+  "S4-H (rf2-qwzmt) — Story's presence rung: the `[:flush-presence]` script
+  step consumes the framework's own `re-frame.ui.test/flush-presence!` so a
+  presence-bearing variant settles DETERMINISTICALLY during playback.
+
+  The problem the rung solves: a variant whose view renders a
+  `(ui/presence {:timeout-ms n} …)` boundary RETAINS a removed keyed child
+  in `:unmounting` until the timeout fires. That retention is a CLOCK, not a
+  queue, so no rung of the `settled-boundary` ladder settles it — playback
+  races the timeout, and the only wall-clock answer (`[:wait ms]`) is the
+  determinism opt-out the gate refuses.
+
+  Three layers:
+
+  - PURE grammar (both hosts) — `[:flush-presence]` / `[:flush-presence ms]`
+    are known steps with the framework verb's two arities, require NO
+    capability token, do not lift `:required-runner` to `:dom`, and are NOT
+    wall-clock steps (the determinism gate accepts a script carrying them).
+  - The SEAM against a stub presence host (both hosts) — the step routes the
+    ms through `re-frame.story.play.presence/advance!`; a script WITHOUT the
+    step leaves the retained exit pending and its assertion FAILS, the same
+    script WITH it passes. This is the red-before/green-after, proven
+    host-agnostically through the real `run!` playback loop.
+  - The REAL framework verb — the same script driven against the ACTUAL
+    `re-frame.ui.test/flush-presence!` and the ACTUAL presence exit
+    scheduler. That arm is ASYNC (the verb is Promise-backed on CLJS) and
+    lives in the pure-`.cljs` companion
+    `presence_real_clock_cljs_test.cljs`, which reuses this ns's harness.
+    The JVM arm of `flush-presence!` is a documented no-op (there is no
+    lifecycle to advance on the structural host), so the real-clock arm is
+    CLJS-only — exactly the host split the framework verb declares.
+
+  Mounted three-phase behaviour (`:mounting` → `:present` → `:unmounting`
+  against real DOM) belongs to the framework and is pinned there
+  (`re-frame.ui.presence-dom-cljs-test`); Story does not re-prove it. What
+  Story owns — and what these tests pin — is that its PLAYBACK LOOP can
+  reach the verb at the right point.
+
+  `.cljc` ending `-cljs-test` rides `npm run test:cljs` (node) AND
+  `clojure -M:test` (JVM), so the rung is graft-checked on both hosts."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core                        :as rf]
+            [re-frame.frame                       :as frame]
+            [re-frame.router                      :as router]
+            [re-frame.registrar                   :as registrar]
+            [re-frame.substrate.plain-atom        :as plain-atom]
+            [re-frame.story                       :as story]
+            [re-frame.story.determinism           :as determinism]
+            [re-frame.story.late-bind             :as late-bind]
+            [re-frame.story.plan                  :as plan]
+            [re-frame.story.play.presence         :as story-presence]
+            [re-frame.story.play.runner           :as runner]
+            [re-frame.story.play.runner-events    :as re]
+            [re-frame.story.requirements          :as requirements]
+            ;; The framework's presence exit scheduler — reached ONLY to reset
+            ;; it between tests (the CLOCK is a CLJS-only surface: the JVM
+            ;; structural host has no lifecycle, so the call is reader-gated).
+            ;; `day8/re-frame2-ui` is pinned on the `:test` alias only — Story's
+            ;; shipped jar must not depend on the pre-publication artefact,
+            ;; which is precisely why the rung takes the verb through a
+            ;; late-bind hook instead of a `:require`.
+            [re-frame.ui.presence-runtime         :as presence-rt]))
+
+;; ===========================================================================
+;; PURE: the step grammar (both hosts, no runtime)
+;; ===========================================================================
+
+(deftest flush-presence-is-a-known-step
+  (testing "the one tagged grammar recognises :flush-presence"
+    (is (contains? runner/step-types :flush-presence))
+    (is (= :flush-presence (runner/step-type [:flush-presence])))
+    (is (= :flush-presence (runner/step-type [:flush-presence 300])))
+    (is (true? (runner/known-step? [:flush-presence])))
+    (is (true? (runner/known-step? [:flush-presence 300])))))
+
+(deftest flush-presence-arity-mirrors-the-framework-verb
+  (testing "the two arities are exactly flush-presence!'s: bare (to
+            quiescence) and a non-negative ms (partial advance)"
+    (is (true?  (runner/step-arity-ok? [:flush-presence])))
+    (is (true?  (runner/step-arity-ok? [:flush-presence 0])))
+    (is (true?  (runner/step-arity-ok? [:flush-presence 300])))
+    (is (false? (runner/step-arity-ok? [:flush-presence -1])))
+    (is (false? (runner/step-arity-ok? [:flush-presence "300"])))
+    (is (false? (runner/step-arity-ok? [:flush-presence 100 200])))))
+
+(deftest step-presence-ms-reads-the-advance
+  (testing "nil means the no-arg arity (to quiescence), NOT 'absent'"
+    (is (nil? (runner/step-presence-ms [:flush-presence])))
+    (is (= 300 (runner/step-presence-ms [:flush-presence 300])))
+    (is (nil? (runner/step-presence-ms [:wait 300]))
+        "the tag, never the nil, distinguishes the step")))
+
+(deftest flush-presence-summary
+  (is (= "flush-presence" (runner/step-summary [:flush-presence])))
+  (is (= "flush-presence 300ms" (runner/step-summary [:flush-presence 300]))))
+
+(deftest flush-presence-yields-a-tick
+  (testing "the framework verb is Promise-backed on CLJS — the driver yields
+            one tick so the retained subtree's removal COMMIT lands before
+            the next step reads it"
+    (is (contains? runner/async-yield-step-types :flush-presence))
+    (is (true? (runner/async-yield? [:flush-presence])))))
+
+(deftest flush-presence-round-trips-through-coercion
+  (testing "a tagged step is never mistaken for a bare event vector"
+    (let [tagged [[:dispatch [:e]] [:flush-presence 100] [:flush-presence]]]
+      (is (= tagged (runner/coerce-script tagged))))))
+
+;; ===========================================================================
+;; PURE: capabilities + determinism (both hosts)
+;; ===========================================================================
+
+(deftest flush-presence-requires-no-capability
+  (testing "the presence clock is a process-global registry — advancing it
+            needs no :dom (the ASSERTION that follows carries that)"
+    (is (= #{} (get requirements/step-capabilities :flush-presence)))
+    (is (= #{} (requirements/step-tokens [:flush-presence])))
+    (is (= #{} (requirements/step-tokens [:flush-presence 300]))))
+  (testing "a presence-bearing script does not lift :required-runner to :dom"
+    (let [p (plan/variant-plan
+              {:variant/id :story.presence/headless
+               :script [[:dispatch [:e]]
+                        [:flush-presence 100]
+                        [:flush-presence]]}
+              {})]
+      (is (not (contains? (:required-runner p) :dom))))))
+
+(deftest flush-presence-is-deterministic
+  (testing "[:flush-presence] is NOT a wall-clock step — the determinism gate
+            refuses [:wait ms] but accepts the fake-clock advance, so a
+            presence-bearing variant keeps its stable verdict"
+    (let [presence-art {:event-program [[:dispatch [:e]]
+                                        [:flush-presence 100]
+                                        [:flush-presence]]}
+          wait-art     {:event-program [[:dispatch [:e]] [:wait 300]]}]
+      (is (= [] (determinism/wait-steps presence-art)))
+      (is (false? (determinism/has-wall-clock-wait? presence-art)))
+      (is (true?  (determinism/has-wall-clock-wait? wait-art))
+          "the wall-clock opt-out is still refused — this rung is its
+           deterministic alternative, not a loophole"))))
+
+;; ===========================================================================
+;; The host hook (both hosts)
+;; ===========================================================================
+
+(deftest install-presence-flush-registers-the-hook
+  (let [calls (atom [])]
+    (try
+      (is (nil? (story-presence/presence-flush-fn))
+          "no host installed by default")
+      (story-presence/install-presence-flush! #(swap! calls conj %))
+      (is (some? (story-presence/presence-flush-fn)))
+      (is (identical? (story-presence/presence-flush-fn)
+                      (late-bind/get-fn :flush-presence!))
+          "the hook lives in the shared late-bind registry")
+      (testing "advance! threads the ms through, nil meaning 'to quiescence'"
+        (is (= {:status :advanced :ms 100} (story-presence/advance! 100)))
+        (is (= {:status :advanced :ms nil} (story-presence/advance! nil)))
+        (is (= [100 nil] @calls)))
+      (finally (swap! late-bind/hooks dissoc :flush-presence!)))))
+
+(deftest advance-with-no-host-is-a-no-op-not-a-refusal
+  (testing "host parity: the framework's own JVM arm of flush-presence! is a
+            no-op, so a Story host with no presence runtime advances a no-op
+            too — there is no retention to advance and nothing to pass
+            falsely (the DOM assertion that follows carries the refusal)"
+    (is (nil? (story-presence/presence-flush-fn)))
+    (is (= {:status :no-host :ms nil} (story-presence/advance! nil)))
+    (is (= {:status :no-host :ms 250} (story-presence/advance! 250)))))
+
+(deftest advance-surfaces-a-throwing-host
+  (let [boom (ex-info "presence host exploded" {})]
+    (try
+      (story-presence/install-presence-flush! (fn [_] (throw boom)))
+      (let [res (story-presence/advance! nil)]
+        (is (= :error (:status res)) "a throwing host is never swallowed")
+        (is (string? (:error res))))
+      (finally (swap! late-bind/hooks dissoc :flush-presence!)))))
+
+;; ===========================================================================
+;; PLAYBACK against a live frame
+;; ===========================================================================
+
+(def exec-step!
+  "The private single-step executor, reached via var-quote — the established
+  Story-test seam. Public here so the pure-`.cljs` real-clock companion
+  (`presence-real-clock-cljs-test`) drives the SAME executor."
+  @#'re/exec-step!)
+
+(def presence-frame :story.presence/frame)
+
+(defn setup!
+  "Fresh registrar + runtime + variant frame. Shared with the real-clock
+  companion so both halves of the rung test the same harness."
+  []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
+  (reset! re/run-state {})
+  ;; The canonical `:rf.assert/*` handlers must be installed so the
+  ;; `[:assert-db …]` steps below record onto the assertion slot.
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (rf/make-frame {:id presence-frame :doc "presence rung test frame"})
+  ;; `:presence/tick` stands in for "the toast is on screen and has just been
+  ;; dismissed" — the source list dropped the key, so the boundary RETAINS the
+  ;; child; `:presence/exited` is the app-visible consequence of its terminal
+  ;; removal once the retention timeout fires.
+  (rf/reg-event :presence/tick   (fn [{:keys [db]} _] {:db (assoc db :toast :retained)}))
+  (rf/reg-event :presence/exited (fn [{:keys [db]} _] {:db (assoc db :toast :removed)}))
+  nil)
+
+(defn teardown!
+  "Drop the process-global presence host + reset the framework clock."
+  []
+  ;; The late-bind hook registry is process-global — a leaked presence host
+  ;; would silently arm every LATER test's `[:flush-presence]` step.
+  (swap! late-bind/hooks dissoc :flush-presence!)
+  #?(:cljs (do (presence-rt/reset-clock!)
+               (presence-rt/set-wall-clock! true)))
+  nil)
+
+;; The cross-platform FN form (`meta-fixtures-test`): the map form silently
+;; skips every deftest on the JVM half of a `.cljc`. Everything in THIS ns is
+;; synchronous, so the fn form is honoured on both hosts. The async arm — which
+;; cljs.test requires a MAP fixture for — lives in the pure-`.cljs` companion
+;; `presence_real_clock_cljs_test.cljs`, where the map form is legitimate.
+(use-fixtures :each (fn [f] (setup!) (try (f) (finally (teardown!)))))
+
+(defn db [] (rf/app-db-value presence-frame))
+
+;; ---------------------------------------------------------------------------
+;; The seam, against a STUB presence host (both hosts)
+;; ---------------------------------------------------------------------------
+;;
+;; A stub host stands in for the framework's exit scheduler: it holds ONE
+;; pending exit with a `:timeout-ms` bound and fires it (dispatching the
+;; app-visible consequence into the variant frame) only once the advanced
+;; logical clock reaches that bound. That is the retention shape the real
+;; presence clock has — enough to prove the PLAYBACK seam on both hosts,
+;; without re-proving the framework's three-phase machine.
+
+(defn- install-stub-presence-host!
+  "Install a stub presence host holding one exit due at `timeout-ms`.
+  Returns the atom holding its logical state."
+  [timeout-ms]
+  (let [state (atom {:now 0 :pending? true :advances []})]
+    (story-presence/install-presence-flush!
+      (fn [ms]
+        (swap! state update :advances conj ms)
+        (let [now (if (nil? ms)
+                    ;; nil = advance to quiescence: past every pending exit
+                    (inc timeout-ms)
+                    (+ (:now @state) ms))]
+          (swap! state assoc :now now)
+          (when (and (:pending? @state) (>= now timeout-ms))
+            (swap! state assoc :pending? false)
+            (router/dispatch-sync! [:presence/exited] {:frame presence-frame})))))
+    state))
+
+(deftest presence-step-drives-the-host-verb
+  (let [state (install-stub-presence-host! 300)]
+    (testing "a partial advance below :timeout-ms leaves the exit RETAINED"
+      (let [res (exec-step! presence-frame 0 [:flush-presence 100])]
+        (is (nil? (:passed? res)) "an advance contributes no pass/fail of its own")
+        (is (nil? (:exception res)))
+        (is (true? (:pending? @state)) "still retained — the timeout has not come due")
+        (is (nil? (:toast (db))))))
+    (testing "an advance to quiescence fires the retained exit"
+      (exec-step! presence-frame 1 [:flush-presence])
+      (is (false? (:pending? @state)))
+      (is (= :removed (:toast (db)))))
+    (testing "both arities reached the host verb, ms threaded through"
+      (is (= [100 nil] (:advances @state))))))
+
+(deftest presence-step-with-no-host-skips-cleanly
+  (testing "with no presence host the step is a SKIP, not a refusal and not
+            an exception — the same no-op the framework's JVM arm is"
+    (let [res (exec-step! presence-frame 0 [:flush-presence])]
+      (is (nil? (:passed? res)))
+      (is (nil? (:exception res))))))
+
+(deftest presence-step-surfaces-a-throwing-host-as-an-exception
+  (story-presence/install-presence-flush! (fn [_] (throw (ex-info "boom" {}))))
+  (let [res (exec-step! presence-frame 0 [:flush-presence])]
+    (is (some? (:exception res)) "a throwing host fails the step loudly")
+    (is (false? (:passed? res)))))
+
+;; ---------------------------------------------------------------------------
+;; RED / GREEN through the real playback loop (JVM — synchronous run!)
+;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (deftest playback-without-the-presence-step-cannot-settle-the-retention
+     (install-stub-presence-host! 300)
+     (testing "RED — ordinary settlement does not touch the presence clock:
+               dispatching and draining to a fixed point leaves the retained
+               exit pending, so the assertion on its terminal removal FAILS.
+               This is the race the rung exists to close"
+       (let [done  (atom nil)
+             _     (re/run! presence-frame "no-presence"
+                            {:name   "no-presence"
+                             :script [[:dispatch [:presence/tick]]
+                                      [:assert-db [:toast] :removed]]}
+                            #(reset! done %))
+             state @done]
+         (is (= :fail (:status state))
+             "the retained exit never fired — playback raced the timeout")
+         (is (= :retained (:toast (db)))
+             "the child is still retained, exactly as the failing assertion said")))))
+
+#?(:clj
+   (deftest playback-with-the-presence-step-settles-deterministically
+     (install-stub-presence-host! 300)
+     (testing "GREEN — the same script with [:flush-presence] steps observes
+               the child still RETAINED below :timeout-ms and then its
+               terminal removal, with no wall-clock sleep anywhere"
+       (let [done  (atom nil)
+             _     (re/run! presence-frame "presence"
+                            {:name   "presence"
+                             :script [[:dispatch [:presence/tick]]
+                                      [:flush-presence 100]
+                                      [:assert-db [:toast] :retained]
+                                      [:flush-presence]
+                                      [:assert-db [:toast] :removed]]}
+                            #(reset! done %))
+             state @done]
+         (is (= :pass (:status state))
+             "both the retained-phase assertion and the removal assertion held")
+         (is (= :removed (:toast (db))))))))
+
+;; The REAL framework verb driven against the REAL presence clock is the
+;; pure-`.cljs` companion `presence_real_clock_cljs_test.cljs` — that arm is
+;; ASYNC (the verb is Promise-backed on CLJS), and cljs.test requires a MAP
+;; fixture once a ns carries async tests, which a `.cljc` may not use.

--- a/tools/story/test/re_frame/story/play/presence_real_clock_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/play/presence_real_clock_cljs_test.cljs
@@ -1,0 +1,147 @@
+(ns re-frame.story.play.presence-real-clock-cljs-test
+  "S4-H (rf2-qwzmt) — the Story presence rung driven against the REAL
+  framework verb and the REAL presence clock.
+
+  `re-frame.ui.test/flush-presence!` advances
+  `re-frame.ui.presence-runtime`'s exit scheduler — the SAME registry a
+  mounted `(ui/presence {:timeout-ms n} …)` boundary arms its retention
+  timers in. Scheduling a real exit and driving it through Story's
+  `[:flush-presence]` step proves the rung reaches the framework verb FOR
+  REAL, no stub, with no DOM required: mounted three-phase behaviour
+  (`:mounting` → `:present` → `:unmounting`) is the framework's own test
+  (`re-frame.ui.presence-dom-cljs-test`) and Story does not re-prove it.
+
+  Pure `.cljs`, not `.cljc`, for two reasons that point the same way:
+
+  - the verb is PROMISE-backed on CLJS, so these tests are `async`, and
+    cljs.test then requires MAP fixtures — which a `.cljc` may not use
+    (`re-frame.story.meta-fixtures-test`: the map form silently skips every
+    deftest on the JVM half);
+  - the presence CLOCK is a CLJS-only surface. The JVM arm of
+    `flush-presence!` is a documented no-op — the structural host has no
+    lifecycle to advance — so there is nothing here for the JVM to run.
+
+  The host-agnostic half of the rung (the grammar, the capability +
+  determinism classification, the hook, and the red/green playback proof
+  against a stub presence host) lives in the `.cljc` sibling
+  `presence-cljs-test`, whose harness this ns reuses.
+
+  The wall clock is DISABLED throughout, so the logical advance is the sole
+  removal driver — the determinism the whole rung exists for."
+  (:require [cljs.test :refer [async deftest is testing use-fixtures]]
+            [re-frame.core                     :as rf]
+            [re-frame.router                   :as router]
+            [re-frame.story.play.presence      :as story-presence]
+            [re-frame.story.play.runner-events :as re]
+            [re-frame.ui.presence-runtime      :as presence-rt]
+            [re-frame.ui.test                  :as uit]
+            ;; The shared harness (fresh registrar + runtime + variant frame,
+            ;; and the same private step executor) — one harness across both
+            ;; halves of the rung's coverage.
+            [re-frame.story.play.presence-cljs-test :as shared]))
+
+;; cljs.test honours the MAP fixture form, and REQUIRES it once a ns carries
+;; `async` tests: a fn fixture would return before the async body settles, so
+;; its teardown could never be honoured. Legitimate here precisely because
+;; this file is pure `.cljs` (see the ns docstring).
+(use-fixtures :each {:before shared/setup! :after shared/teardown!})
+
+(defn- install-real-presence-host! []
+  (presence-rt/reset-clock!)
+  (presence-rt/set-wall-clock! false)
+  (story-presence/install-presence-flush!
+    ;; The rung reuses the framework verb's two arities EXACTLY — Story adds
+    ;; no clock, no phase model, no scheduler of its own.
+    (fn [ms] (if ms (uit/flush-presence! ms) (uit/flush-presence!)))))
+
+(defn- schedule-real-exit!
+  "Arm a REAL retained exit due at 300ms of logical time. Its removal
+  callback stands in for the app-visible consequence of the terminal
+  unmount — a mounted boundary's removal releases the retained subtree's
+  leases; headless, a dispatched event is the observable."
+  []
+  (presence-rt/schedule-exit!
+    300 #(router/dispatch-sync! [:presence/exited] {:frame shared/presence-frame})))
+
+(defn- after-tick
+  "Yield one macrotask — exactly what the run loop does after an async-yield
+  step (`runner/async-yield-step-types`). The framework verb holds a SINGLE
+  in-flight act token, so calling it again before the previous act settles is
+  the framework's own `:rf.error/ui-test-overlapping-act` misuse error. A
+  `setTimeout` 0 runs only after the microtask queue has drained to empty, so
+  the act has settled. A test driving `exec-step!` DIRECTLY owes the same
+  yield the loop gives — including after the LAST advance, or the still-active
+  act leaks into the next test."
+  [f]
+  (js/setTimeout f 0))
+
+(deftest real-flush-presence-advances-the-framework-clock
+  (async done
+    (install-real-presence-host!)
+    (schedule-real-exit!)
+    (is (= 1 (presence-rt/pending-count)) "one exit retained")
+    (shared/exec-step! shared/presence-frame 0 [:flush-presence 100])
+    ;; The advance + its removal callbacks run synchronously inside the awaited
+    ;; act; only the React commits settle on the microtask queue.
+    (is (= 1 (presence-rt/pending-count))
+        "below :timeout-ms the exit is STILL retained — the partial-advance
+         arity is what lets a script observe the :unmounting phase")
+    (is (nil? (:toast (shared/db))))
+    (after-tick
+      (fn []
+        (shared/exec-step! shared/presence-frame 1 [:flush-presence])
+        (is (zero? (presence-rt/pending-count))
+            "advancing to quiescence fired the retained exit")
+        (is (= :removed (:toast (shared/db)))
+            "the terminal removal is observable to the next script step")
+        (after-tick
+          (fn []
+            ;; exactly-once: a further advance re-fires nothing.
+            (shared/exec-step! shared/presence-frame 2 [:flush-presence])
+            (is (zero? (presence-rt/pending-count)))
+            (is (= :removed (:toast (shared/db))))
+            ;; Yield once more so THIS act settles before the test ends — an
+            ;; act still in flight would collide with the next test's advance.
+            (after-tick done)))))))
+
+(deftest real-playback-settles-a-presence-bearing-script
+  (async done
+    (install-real-presence-host!)
+    (schedule-real-exit!)
+    ;; The whole point: ONE play, driven by the real run loop, against the real
+    ;; framework clock — the retained child is asserted still present below
+    ;; :timeout-ms and removed after quiescence, with no [:wait ms] anywhere.
+    (re/run! shared/presence-frame "real-presence"
+             {:name   "real-presence"
+              :script [[:dispatch [:presence/tick]]
+                       [:flush-presence 100]
+                       [:assert-db [:toast] :retained]
+                       [:flush-presence]
+                       [:assert-db [:toast] :removed]]}
+             (fn [state]
+               (is (= :pass (:status state))
+                   "a presence-bearing variant plays back deterministically")
+               (is (= :removed (:toast (shared/db))))
+               (is (zero? (presence-rt/pending-count)))
+               (done)))))
+
+(deftest real-playback-without-the-step-cannot-settle-the-retention
+  (async done
+    (install-real-presence-host!)
+    (schedule-real-exit!)
+    ;; RED — the same script with the rung REMOVED. Ordinary settlement drains
+    ;; the router to a fixed point and still cannot touch the presence clock,
+    ;; so the retained exit never fires and the removal assertion FAILS. This
+    ;; is the race `[:flush-presence]` exists to close.
+    (re/run! shared/presence-frame "no-presence"
+             {:name   "no-presence"
+              :script [[:dispatch [:presence/tick]]
+                       [:assert-db [:toast] :removed]]}
+             (fn [state]
+               (is (= :fail (:status state))
+                   "playback alone raced the presence timeout")
+               (is (= :retained (:toast (shared/db)))
+                   "the child is still retained, exactly as the failure said")
+               (is (= 1 (presence-rt/pending-count))
+                   "the real exit is still pending — nothing advanced the clock")
+               (done)))))


### PR DESCRIPTION
Closes rf2-qwzmt (S4-H, epic rf2-vxgfnd.96). Consumes S4-A's merged presence API; nothing under `implementation/` is touched.

## The problem

A variant whose view renders a `(ui/presence {:timeout-ms n} …)` boundary RETAINS a removed keyed child in `:unmounting` until the timeout fires. That retention is a **clock, not a queue**, so no rung of the `settled-boundary` ladder settles it — draining the router (`:headless`), flushing reactions (`:cljs-reactive`) and awaiting a React commit (`:dom`) all leave the retained child exactly where it is, and the next script step races the timeout. The only wall-clock answer, `[:wait ms]`, is the determinism opt-out the gate refuses.

## The rung

`[:flush-presence]` / `[:flush-presence ms]` — the deterministic fake-clock twin of `[:wait ms]`. It advances the presence clock through the framework's own `re-frame.ui.test/flush-presence!`, reusing that verb's two arities exactly: bare = to quiescence, `ms` = partial advance, so a script can observe a child still retained and only then drive its terminal removal.

```clojure
:script [[:dispatch [:toasts/dismiss 2]]
         [:flush-presence 100]                    ; below :timeout-ms
         [:assert-dom "[data-msg=b]" :visible]    ; still retained
         [:flush-presence]                        ; to quiescence
         [:assert-dom "[data-msg=b]" :hidden]]    ; terminal removal
```

Phases are asserted the ordinary way — `(ui/presence-phase)` is a render-time read, so the view renders it (`{:data-phase (name (ui/presence-phase))}`) and the existing `:assert-dom` / `:assert-db` steps read what was rendered. No new assertion atom.

## Design notes

- **Story models no presence of its own** — no clock, no phase machine, no scheduler. `re-frame.story.play.presence` (new, ~95 lines) is a thin seam that CALLS the framework verb.
- **The verb arrives by hook, not `:require`.** Story's shipped jar must not depend on the pre-publication `day8/re-frame2-ui` — the same isolation `re-frame.story.view-tool` keeps — so a `re-frame.ui`-hosted shell installs it via `install-presence-flush!` under the `:flush-presence!` late-bind key.
- **No host installed → no-op, not `:cannot-run`.** This matches the framework's own JVM arm, a documented no-op for host parity. There is no false pass to guard: the DOM assertion that FOLLOWS carries the `:dom` requirement, as it always did. A host verb that throws is a step-exception, never swallowed.
- **`async-yield` step.** The verb is Promise-backed on CLJS: the advance and its removal callbacks run synchronously inside the awaited `act`, but the React commits settle on the microtask queue. The existing setTimeout-0 yield runs after that queue drains, so the next step observes the committed removal.
- **Deterministic.** `determinism/wait-steps` filters on `:wait`, so a presence-bearing script keeps its stable verdict rather than reaching for the opt-out.

## Red before / green after

Both proven as live tests, against the REAL presence clock (`presence_real_clock_cljs_test.cljs`):

- RED — `real-playback-without-the-step-cannot-settle-the-retention`: the script without the rung ends `:fail`, the child is still `:retained`, and the real exit is still pending. Ordinary settlement cannot touch the presence clock.
- GREEN — `real-playback-settles-a-presence-bearing-script`: the same script with `[:flush-presence 100]` / `[:flush-presence]` ends `:pass`, having asserted the retained phase and then the terminal removal, with no wall-clock sleep anywhere.

Tests are CLJS unit tests (no Playwright spec added). The `.cljc` half covers grammar, capabilities, determinism and the hook on both hosts; the async real-clock arm is pure `.cljs` because cljs.test requires map fixtures once a ns carries `async` tests, which `meta-fixtures-test` forbids in `.cljc` (map fixtures silently skip every deftest on the JVM).

Mounted three-phase behaviour stays the framework's own test (`re-frame.ui.presence-dom-cljs-test`) — Story does not re-prove it.

## Quality gates

| Gate | Result |
|---|---|
| `tools/story` `clojure -M:test` (JVM) | **green** — 1833 tests, 6778 assertions, 0 failures, 0 errors |
| `tools/story` `clojure -M:test -n …presence-cljs-test` | **green** — 16 tests, 52 assertions |
| `npm run test:cljs` (node) | **green** — 9968 tests, 49096 assertions, 0 failures, 0 errors |
| `npm run story:build` | **green** — 685 files, 624 compiled, 0 warnings |

Two transient reds appeared mid-session on untouched surfaces and did not reproduce across three subsequent full runs: `xray/panels/resources-cljs-test` and `test-quiet-shadow-node` (the latter spawns a subprocess over a fixed fixture ns this diff is not part of). Both are the known under-load flakes.

Spec kept current: `tools/story/spec/017-Testing-Story.md` gains §Presence-bearing variants plus grammar/capability/determinism rows; `spec/API.md` gains the two step rows.
