### PR TITLE
docs(spec): complete the standard navigation fx schema authority (rf2-cmdpj)

### DIFF
--- a/spec/API.md
+++ b/spec/API.md
@@ -498,6 +498,7 @@ Standard route-related fx (canonical detail in [012-Routing.md](012-Routing.md))
 | `:rf.nav/push-url` | URL string | `:client` |
 | `:rf.nav/replace-url` | URL string | `:client` |
 | `:rf.nav/scroll` | scroll-spec map | `:client` |
+| `:rf.nav/capture-scroll` | `{:url <leaving-route-url>}` | `:client` |
 | `:rf.route/with-nav-token` | `{:rf/reply-to <reply-target> :value <v> :nav-token <token> :route-id <route-id>}` (per [012 §Threading the nav-token](012-Routing.md#navigation-tokens--stale-result-suppression)) | universal |
 
 Standard route-related cofx (canonical detail in [012-Routing.md](012-Routing.md)):
@@ -942,6 +943,7 @@ Per [Spec-Schemas.md](Spec-Schemas.md), the spec's own runtime shapes are descri
 | `:rf.fx.nav/push-url-args` | Args of `:rf.nav/push-url` fx | 012 |
 | `:rf.fx.nav/replace-url-args` | Args of `:rf.nav/replace-url` fx | 012 |
 | `:rf.fx.nav/scroll-args` | Args of `:rf.nav/scroll` fx | 012 |
+| `:rf.fx.nav/capture-scroll-args` | Args of `:rf.nav/capture-scroll` fx | 012 |
 | `:rf.fx/with-nav-token-args` | Args of `:rf.route/with-nav-token` fx wrapper | 012 |
 | `:rf.fx/spawn-args` | Args of `:rf.machine/spawn` fx (the canonical actor-lifecycle fx-id; emitted from any event handler's `:fx`) | 005 |
 | `:rf.fx/managed-args` | Args of `:rf.http/managed` fx (request envelope, decode, accept, retry, timeout-ms, on-success/on-failure, request-id, abort-signal) | 014 |

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -3759,6 +3759,10 @@ The `:rf/effect-map`'s `:fx` is `[[fx-id args] ...]`. Each *standard* `fx-id` (t
 (def NavReplaceUrlFxArgs :string)
 
 ;; :rf.nav/scroll — scroll-on-navigate. Client only. Per [012 §Scroll restoration].
+;; Every slot the navigation planner actually emits is described here: the planner builds
+;; `{:strategy :from :to :saved-pos :fragment}` (per [012 §`:rf.nav/scroll` integration]),
+;; and the handler reads `:strategy` / `:saved-pos` / `:fragment` (`:from` / `:to` are
+;; purely diagnostic carriers it ignores — hence their EP-0015 `:sensitive` path-marks).
 (def NavScrollFxArgs
   [:map
    [:strategy  [:or
@@ -3766,7 +3770,31 @@ The `:rf/effect-map`'s `:fx` is `[[fx-id args] ...]`. Each *standard* `fx-id` (t
                 :map]]                                                       ;; map form is host-extensible (post-v1)
    [:from      {:optional true} [:map [:id :keyword] [:params {:optional true} :map] [:query {:optional true} :map]]]
    [:to        {:optional true} [:map [:id :keyword] [:params {:optional true} :map] [:query {:optional true} :map]]]
-   [:saved-pos {:optional true} [:tuple :int :int]]])                        ;; runtime-captured saved position (for :restore)
+   ;; Runtime-captured saved position (for :restore), read straight off the browser's
+   ;; `window.scrollX` / `window.scrollY`. Those are FRACTIONAL at non-100% zoom and on
+   ;; HiDPI displays, so the members are `number?` rather than `:int` — an integer-only
+   ;; tuple would reject valid captured positions. (JVM-side planning tests thread plain
+   ;; integer pairs, which `number?` also admits.)
+   [:saved-pos {:optional true} [:tuple number? number?]]
+   ;; The `#fragment` of the URL being navigated to, when present. `:top` scrolls this
+   ;; element into view instead of scrolling to the top of the page.
+   [:fragment  {:optional true} :string]])
+
+;; :rf.nav/capture-scroll — save the leaving route's scroll position into the host-side
+;; per-frame transient scroll-position cache, keyed by that route's reconstructed URL.
+;; Client only. Per [012 §Scroll restoration]. The navigation planner emits exactly
+;; `{:url <leaving-url>}`, so `:url` is REQUIRED — it is the cache key, and a capture
+;; without one saves nothing (the handler's nil-guard is defence-in-depth, not a
+;; documented graceful-degradation path of the kind :rf.server/redirect has).
+;;
+;; The handler also honours an optional `:position` override in place of reading
+;; `window.scrollX/Y`. That slot is an INTERNAL / TEST INJECTION SEAM, not public API:
+;; no framework path emits it and [012](012-Routing.md) does not offer it, so it is
+;; deliberately absent from this public args shape. Schemas here are open by default,
+;; so a test that injects `:position` still validates — it just is not a promise.
+(def NavCaptureScrollFxArgs
+  [:map
+   [:url :string]])                                                          ;; the leaving route's reconstructed URL (cache key)
 
 ;; :rf.machine/spawn — canonical actor-lifecycle fx-id (registered globally by
 ;; re-frame.machines); usable inside any event handler's :fx (machine actions
@@ -3882,6 +3910,7 @@ These are registered under spec ids:
 | `:rf.fx.nav/push-url-args` | `:rf.nav/push-url` (per [012](012-Routing.md)) |
 | `:rf.fx.nav/replace-url-args` | `:rf.nav/replace-url` |
 | `:rf.fx.nav/scroll-args` | `:rf.nav/scroll` |
+| `:rf.fx.nav/capture-scroll-args` | `:rf.nav/capture-scroll` |
 | `:rf.fx/spawn-args` | `:rf.machine/spawn` (the canonical actor-lifecycle fx-id; emitted from any event handler's `:fx` and from machine actions; per [005](005-StateMachines.md)) |
 | `:rf.fx/destroy-machine-args` | `:rf.machine/destroy` (the canonical actor-destroy fx-id; per [005](005-StateMachines.md) and — accepts either a bare actor-id keyword or a `{:rf/parent-id :rf/invoke-id}` map) |
 | `:rf.fx/dispatch-to-system-args` | `:rf.machine/dispatch-to-system` (the action→named-actor messaging fx-id; args are the 2-element pair `[<system-id> <event-vector>]` — a `[:tuple :keyword [:ref :rf/event]]` (per [§`:rf/event`](#rfevent-the-event-vector)); per [005 §Cross-machine messaging by name](005-StateMachines.md#cross-machine-messaging-by-name)) |


### PR DESCRIPTION
Closes rf2-cmdpj (partial — see **Scope** below).

PR #6242 / rf2-weo9xx corrected three malformed navigation schema-id spellings to `:rf.fx.nav/*`. The resulting authority was still incomplete: it described three of the four canonical standard navigation effects, and the one it described most fully did not match what the runtime emits.

Every shape below was read off the shipped runtime first.

## Gaps closed

| Gap | Evidence in shipped runtime |
|---|---|
| `NavScrollFxArgs` omitted `:fragment` | `scroll/scroll-fx-entry` emits `{:strategy :from :to :saved-pos :fragment}`; `scroll/scroll-fx-handler` destructures `:fragment` and uses it for `.getElementById` → `.scrollIntoView`. 012 §`:rf.nav/scroll` integration shows `:fragment "section-2"` in the emitted args. |
| `NavScrollFxArgs`'s `:saved-pos` was `[:tuple :int :int]` | `scroll/capture-scroll-handler` captures `[(.-scrollX js/window) (.-scrollY js/window)]`. Those are fractional at non-100% zoom / on HiDPI, so an integer-only tuple rejects valid captured positions. Relaxed to `[:tuple number? number?]`, which still admits the integer pairs `routing_plan_test.clj` threads on the JVM. |
| `NavCaptureScrollFxArgs` did not exist | `scroll/capture-scroll-fx-entry` emits exactly `[:rf.nav/capture-scroll {:url url}]`; the handler saves under that url as the cache key. Schema is `[:map [:url :string]]`, `:url` **required**. |
| `:rf.fx.nav/capture-scroll-args` absent from both schema-id lists | Added to `spec/Spec-Schemas.md` and `spec/API.md`. |
| `:rf.nav/capture-scroll` absent from API's Standard route-related fx roster | Added. It is a canonical standard effect per 012 §Effects, Conventions §Reserved fx-ids, and `routing.cljc`'s `fx/reg-fx`. |

### Ruling: `capture-scroll`'s optional `:position`

The bead asks for an explicit disposition. `capture-scroll-handler` accepts `{:keys [url position]}` and falls back to `window.scrollX/Y` when `:position` is absent. **No framework path emits `:position`** — `capture-scroll-fx-entry` builds `{:url url}` only — and 012 does not offer it. Ruled an **internal / test injection seam, not public API**, so it stays out of the public args shape. Schemas are open by default, so a test injecting it still validates; it just is not a promise.

## Scope — what this PR does *not* do

The bead's acceptance also asks that the four `:rf.nav/*` registrations carry runtime `:schema` metadata so args actually validate (the `implementation/ssr` precedent: local schema vars attached at `reg-fx`). **That half is not here** — this dispatch was fenced to the spec surface, and the routing runtime is explicitly off-limits. This PR makes the normative authority complete and truthful; a follow-up makes the runtime conform to it.

Nothing in `implementation/` changed, no effects were invented, and the two hot-zone files took surgical diffs (+2 lines in `API.md`, +31/-1 in `Spec-Schemas.md`).

## Quality gates

All run in the foreground on this worktree. All green.

| Gate | Result |
|---|---|
| `python -m mkdocs build --strict` | exit 0 — built in 37.78s |
| `python scripts/check_keyword_catalogue_drift.py --self-test` | exit 0 |
| `python scripts/check_keyword_catalogue_drift.py` | exit 0 — the new `:rf.fx.nav/capture-scroll-args` reconciles against the Conventions reserved table alongside its three siblings |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `implementation/scripts/api-manifest` `clojure -M:test` (API.md touched) | exit 0 — 104 tests, 229 assertions, 0 failures; API.md projection in sync (217 var-rows) |

Red-before / green-after: `capture-scroll` appeared **0** times in `spec/API.md` and `spec/Spec-Schemas.md` on `origin/main`; **2** times in each after.
