### PR TITLE
fix(bundle-isolation): identify Node's actual script, not a preload (rf2-n36v6)

### DIFF
--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -951,11 +951,13 @@ const NON_BROWSER_OPTIONAL = new Set(['core', 'ssr-ring']);
 // filenames under scripts/, and `command` is the package.json script that
 // invokes them. validateDedicatedGate() binds it to the EXACT runtime AND the
 // EXACT executable (rf2-kfn9q):
-//   - every checker file EXISTS under scripts/;
+//   - every checker is a REGULAR FILE under scripts/;
 //   - `command` is a real package script whose body RUNS each checker as a
-//     directly-invoked, reachable `node <checker>` step (echo, comment,
-//     argument-only, name-substring, and unreachable `false &&` mentions do NOT
-//     count as running it); and
+//     directly-invoked, reachable `node scripts/<checker>` step — the checker
+//     being the script operand Node ACTUALLY executes, immediately after `node`
+//     (echo, comment, argument-only, name-substring, wrong-directory same-name,
+//     `--require`/`-r` preload and other pre-script option positions, and
+//     unreachable `false &&` mentions do NOT count as running it); and
 //   - the runtime being covered (the map KEY / relPath) is OWNED by one of the
 //     checkers — it appears in that checker's exported COVERS_RUNTIMES — so an
 //     unrelated existing checker can NOT be reused for a new runtime it never
@@ -1000,17 +1002,46 @@ function readPackageScripts(root = ROOT) {
   }
 }
 
+// Normalise a script operand as WRITTEN in a package script (whose cwd is the
+// package root) to a comparable posix-relative path, so `scripts/x.cjs`,
+// `./scripts/x.cjs` and `scripts\x.cjs` are one path and not three.
+function normaliseScriptOperand(operand) {
+  return path.posix.normalize(String(operand).replace(/\\/g, '/'));
+}
+
 // True iff `body` (a package.json script body, in this repo's bounded
-// `&&`-chained grammar) RUNS `checker` as a DIRECTLY-INVOKED, REACHABLE step: a
-// `node <path>` command whose script argument's basename is EXACTLY the checker.
-// Substring / echo / comment / argument-only mentions, and any step guarded
-// behind a statically-failing `false &&` short-circuit, do NOT count — so a
-// checker's mere textual presence in the body can not launder coverage (rf2-kfn9q).
+// `&&`-chained grammar) RUNS `checker` as a DIRECTLY-INVOKED, REACHABLE step:
+// a `node <path>` command whose script operand is EXACTLY the checker's
+// package-root-relative path (`scripts/<checker>`). Substring / echo / comment /
+// argument-only mentions, and any step guarded behind a statically-failing
+// `false &&` short-circuit, do NOT count — so a checker's mere textual presence
+// in the body can not launder coverage (rf2-kfn9q).
 //
-// This is a BOUNDED recogniser (split on `&&`, drop trailing `#` comments,
-// tokenise on whitespace), not a general shell parser: it recognises exactly the
-// `program arg…` steps the repo's isolation scripts are written in.
-function commandRunsChecker(body, checker) {
+// Two identity rules make the operand the ACTUAL executed script (rf2-n36v6):
+//
+//   - POSITION. Node's script operand is the token IMMEDIATELY after `node`.
+//     Matching "the first token that does not start with `-`" instead is wrong
+//     for Node's real CLI grammar, because several options CONSUME the next
+//     token (`--require <preload>`, `-r <preload>`, `--import <x>`, …): in
+//     `node --require scripts/<checker> other.cjs` the checker is a PRELOAD,
+//     whose `require.main === module` guard deliberately runs no bundle work,
+//     and `other.cjs` is what Node executes. Rather than carry a Node option
+//     table (this is not a Node CLI parser), any `node` step with a pre-script
+//     option is rejected outright: the repo writes its gates as plain
+//     `node scripts/<checker>`, and an unrecognised shape fails CLOSED.
+//
+//   - PATH. The operand is compared as a whole normalised path, not by
+//     `basename`, so `node elsewhere/<checker>` — a different file that merely
+//     shares the descriptor's filename — does not bind coverage.
+//
+// This stays a BOUNDED recogniser (split on `&&`, drop trailing `#` comments,
+// tokenise on whitespace), not a general shell or Node parser: it recognises
+// exactly the `program arg…` steps the repo's isolation scripts are written in.
+function commandRunsChecker(body, checker, { scriptsDir = SCRIPTS_DIR } = {}) {
+  // The package root is the scripts dir's parent, so the operand a package
+  // script must name is `scripts/<checker>` relative to it.
+  const expected = normaliseScriptOperand(
+    path.relative(path.dirname(scriptsDir), path.join(scriptsDir, checker)));
   for (const rawStep of String(body).split('&&')) {
     const step = rawStep.split('#')[0].trim();  // drop trailing shell comment
     if (step === '') continue;
@@ -1019,12 +1050,25 @@ function commandRunsChecker(body, checker) {
     // runs — a checker sitting behind it is unreachable.
     if (tokens[0] === 'false') break;
     if (tokens[0] !== 'node') continue;
-    // node's script argument is its first non-flag operand; only THAT running the
-    // checker counts (checker as a later argument to another script does not).
-    const scriptArg = tokens.slice(1).find((t) => !t.startsWith('-'));
-    if (scriptArg && path.basename(scriptArg) === checker) return true;
+    const scriptArg = tokens[1];
+    // A pre-script option (recognised or not) may consume the operand after it;
+    // this step's executed script is not statically known, so it counts for
+    // nothing.
+    if (!scriptArg || scriptArg.startsWith('-')) continue;
+    if (normaliseScriptOperand(scriptArg) === expected) return true;
   }
   return false;
+}
+
+// True iff `p` is a REGULAR file. Descriptors name checker SCRIPTS, so mere path
+// existence is too weak — a directory (or any non-file entry) sharing a
+// checker's name must not discharge enrolment (rf2-n36v6).
+function isRegularFile(p) {
+  try {
+    return fs.statSync(p).isFile();
+  } catch (_e) {
+    return false;
+  }
 }
 
 // The implementation-relative runtimes a checker OWNS (its exported
@@ -1062,8 +1106,8 @@ function validateDedicatedGate(gate, { scriptsDir = SCRIPTS_DIR, scripts = readP
   const command = typeof gate.command === 'string' ? gate.command : null;
   if (checkers.length === 0) reasons.push('no checker script(s) declared');
   for (const checker of checkers) {
-    if (!fs.existsSync(path.join(scriptsDir, checker))) {
-      reasons.push(`checker script does not exist: ${checker}`);
+    if (!isRegularFile(path.join(scriptsDir, checker))) {
+      reasons.push(`checker script is not a regular file: ${checker}`);
     }
   }
   if (!command) {
@@ -1074,10 +1118,11 @@ function validateDedicatedGate(gate, { scriptsDir = SCRIPTS_DIR, scripts = readP
       reasons.push(`declared command is not an invoked package.json script: ${command}`);
     } else {
       for (const checker of checkers) {
-        if (!commandRunsChecker(body, checker)) {
+        if (!commandRunsChecker(body, checker, { scriptsDir })) {
           reasons.push(`package command '${command}' does not RUN checker '${checker}' ` +
             'as a directly-invoked reachable step (echo / comment / argument-only / ' +
-            'name-substring / unreachable false-and mentions do not count)');
+            'name-substring / wrong-directory / pre-script-option (e.g. --require ' +
+            'preload) / unreachable false-and mentions do not count)');
         }
       }
     }

--- a/implementation/scripts/check-bundle-isolation.test.cjs
+++ b/implementation/scripts/check-bundle-isolation.test.cjs
@@ -290,6 +290,73 @@ coverageMutations += 1;
   assert(!grammarGate('gate:substring').ok, 'a longer filename containing the checker name as a substring does not RUN it');
   assert(grammarGate('gate:real').ok, 'a real `node scripts/<checker>` step RUNS the checker');
 
+  // rf2-n36v6 — SCRIPT IDENTITY: the operand that counts is the one Node
+  // ACTUALLY executes. Two families of false-green are closed here.
+  //
+  // (a) PRE-SCRIPT OPTIONS. Several Node options consume the following token, so
+  //     "first token not starting with `-`" credits a PRELOAD as the script: in
+  //     `node --require scripts/<checker> other.cjs`, the checker is preloaded
+  //     (its `require.main === module` guard runs no bundle work) and other.cjs
+  //     is what executes. Every pre-script option position — value-taking,
+  //     bare, or unrecognised — fails CLOSED rather than being guessed at.
+  const identityScripts = {
+    'gate:require-preload':  'node --require scripts/check-login-bundle-isolation.cjs scripts/check-bundle-isolation.test.cjs',
+    'gate:r-preload':        'node -r scripts/check-login-bundle-isolation.cjs scripts/check-bundle-isolation.test.cjs',
+    'gate:import-preload':   'node --import scripts/check-login-bundle-isolation.cjs scripts/check-bundle-isolation.test.cjs',
+    'gate:loader-preload':   'node --experimental-loader scripts/check-login-bundle-isolation.cjs scripts/check-bundle-isolation.test.cjs',
+    'gate:env-file':         'node --env-file scripts/check-login-bundle-isolation.cjs scripts/check-bundle-isolation.test.cjs',
+    'gate:unlisted-option':  'node --frobnicate scripts/check-login-bundle-isolation.cjs scripts/check-bundle-isolation.test.cjs',
+    'gate:bare-flag':        'node --enable-source-maps scripts/check-login-bundle-isolation.cjs',
+    'gate:wrong-dir':        'node elsewhere/check-login-bundle-isolation.cjs',
+    'gate:parent-escape':    'node ../scripts/check-login-bundle-isolation.cjs',
+    'gate:dot-slash':        'node ./scripts/check-login-bundle-isolation.cjs',
+    'gate:win-sep':          'node scripts\\check-login-bundle-isolation.cjs',
+    'gate:trailing-args':    'node scripts/check-login-bundle-isolation.cjs --verbose',
+  };
+  const identityGate = (command) => validateDedicatedGate(
+    { checkers: ['check-login-bundle-isolation.cjs'], command },
+    { scripts: identityScripts });
+  for (const option of ['require', 'r', 'import', 'loader']) {
+    assert(!identityGate(`gate:${option}-preload`).ok,
+      `a --${option} PRELOAD operand is not the executed script and does not RUN the checker`);
+  }
+  assert(!identityGate('gate:env-file').ok,
+    'an --env-file option operand is not the executed script and does not RUN the checker');
+  assert(!identityGate('gate:unlisted-option').ok,
+    'an UNLISTED pre-script option fails closed (no Node option table is guessed at)');
+  assert(!identityGate('gate:bare-flag').ok,
+    'a pre-script option position fails closed even when the checker would be the real script');
+
+  // (b) PATH IDENTITY. The operand is compared whole, not by basename, so a
+  //     different file sharing the checker's filename can not bind coverage.
+  assert(!identityGate('gate:wrong-dir').ok,
+    'a same-basename script in another directory does not RUN the declared checker');
+  assert(!identityGate('gate:parent-escape').ok,
+    'a path escaping the package root does not RUN the declared checker');
+
+  // The real written forms still bind (separator- and argument-insensitive).
+  assert(identityGate('gate:dot-slash').ok, '`./scripts/<checker>` RUNS the checker');
+  assert(identityGate('gate:win-sep').ok, 'a Windows-separator operand RUNS the checker');
+  assert(identityGate('gate:trailing-args').ok, 'trailing arguments after the script operand are fine');
+
+  // rf2-n36v6 — a descriptor names a checker SCRIPT: a non-regular file (here a
+  // DIRECTORY sharing a checker's name) must not discharge enrolment, which mere
+  // existsSync path existence would have allowed.
+  {
+    const fakeScripts = fs.mkdtempSync(path.join(os.tmpdir(), 'bundle-iso-scripts-'));
+    try {
+      fs.mkdirSync(path.join(fakeScripts, 'check-login-bundle-isolation.cjs'));
+      const dirShaped = validateDedicatedGate(
+        { checkers: ['check-login-bundle-isolation.cjs'], command: 'gate:real' },
+        { scriptsDir: fakeScripts, scripts: grammarScripts });
+      assert(!dirShaped.ok, 'a directory sharing a checker name is not a checker script');
+      assert(dirShaped.reasons.some((r) => /regular file/.test(r)),
+        'the non-regular-file failure says so');
+    } finally {
+      fs.rmSync(fakeScripts, { recursive: true, force: true });
+    }
+  }
+
   // rf2-kfn9q — RUNTIME binding: with a relPath, a checker must OWN that exact
   // runtime (COVERS_RUNTIMES). The login checker owns adapters/reagent, not
   // adapters/newpub.


### PR DESCRIPTION
Closes rf2-n36v6. Follow-up to the merged rf2-o58c2 / rf2-kfn9q cluster (#6272).

## The mis-parse

`commandRunsChecker` (`implementation/scripts/check-bundle-isolation.cjs:1024` on main) took **the first non-flag token** after `node` as the executed script:

```js
const scriptArg = tokens.slice(1).find((t) => !t.startsWith('-'));
if (scriptArg && path.basename(scriptArg) === checker) return true;
```

That is wrong for Node's CLI grammar. Options like `--require`/`-r`/`--import`/`--experimental-loader`/`--env-file` **consume the following token**, so in

```
node --require scripts/check-login-bundle-isolation.cjs scripts/check-bundle-isolation.test.cjs
```

the checker is a **preload** — its `require.main === module` guard deliberately runs no bundle work — and `check-bundle-isolation.test.cjs` is what Node actually executes. The recognizer credited the preload, recreating the exact inert/argument-only false-green rf2-kfn9q was meant to close.

The same function compared only `path.basename`, so `node elsewhere/check-login-bundle-isolation.cjs` also bound coverage — a *different file* that merely shared the descriptor's filename. Separately, checker files were probed with `existsSync`, which a directory of the same name satisfies.

## The fix

Per the bead's ruling the repo grammar stays deliberately small — **no Node option table, no shell parser**:

- **Position** — the script operand is the token *immediately* after `node`. Any pre-script option (value-taking, bare, or unrecognised) fails **closed** rather than being guessed at. The repo writes its gates as plain `node scripts/<checker>`.
- **Path** — the operand is compared as a whole normalised package-root-relative path (`scripts/<checker>`), not by basename. `./` prefixes, Windows and POSIX separators, and trailing arguments are all still accepted.
- **Regular file** — descriptor checkers are verified with `statSync().isFile()`, so a directory sharing a checker's name cannot discharge enrolment.

Still a bounded token check (split on `&&`, drop `#` comments, tokenise on whitespace). No checker is executed during descriptor validation.

## Quality gates

| Gate | Result |
| --- | --- |
| `npm run test:bundle-isolation` | PASS — 22 artefacts; 38 sentinels absent; **12 canonical runtimes covered (8 generic, 4 dedicated)** |
| `npm run test:reagent-slim:bundle-isolation` | PASS — 6 contracts; 25 sentinel checks |
| `node scripts/check-bundle-isolation.test.cjs` | PASS — self-test, all mutation families |

All 4 dedicated gates still bind under the tightened recognizer, so the real commands are unaffected.

### Red before / green after

Against unmodified `origin/main`, all three false forms were **ACCEPTED**; they are now rejected:

| Command | main | now |
| --- | --- | --- |
| `node --require scripts/<checker> other.cjs` | ACCEPTED | rejected |
| `node -r scripts/<checker> other.cjs` | ACCEPTED | rejected |
| `node elsewhere/<checker>` | ACCEPTED | rejected |
| `node scripts/<checker>` (real form) | accepted | accepted |

### Adversarial cases added to the self-test

Rejected: `--require`, `-r`, `--import`, `--experimental-loader`, `--env-file` preloads; an **unlisted** option (`--frobnicate`) — fails closed, not guessed; a bare flag (`--enable-source-maps`) even where the checker *would* be the real script; wrong-directory same-basename; parent-escape (`../scripts/<checker>`); a directory shaped like a checker file.

Still accepted: `node scripts/<checker>`, `./scripts/<checker>`, `scripts\<checker>` (Windows separator), trailing args, and `&&`-chained real steps.

### Mutation-tested

Each rule was individually reverted on the real file and the self-test caught it:

- restore `slice(1).find(...)` → fails at *"a `--require` PRELOAD operand is not the executed script"*
- restore `basename` comparison (keeping the position fix) → fails at *"a same-basename script in another directory does not RUN the declared checker"*
- restore `existsSync` → fails at *"the non-regular-file failure says so"*

kfn9q's echo / `false &&` / comment / argument-only / name-substring / unrelated-checker cases and o58c2's fail-closed inventory mutations all remain green.
