### PR TITLE
fix(ui-compiler): derive the Shadow compile set causally, not from timestamps (rf2-suz5b)

### DIFF
--- a/implementation/scripts/check-ui-final-schedule.cjs
+++ b/implementation/scripts/check-ui-final-schedule.cjs
@@ -50,10 +50,20 @@
 //     (drop the missing-pass-provenance throw) → the FAIL-LOUD pass SUCCEEDS
 //     instead of failing → this gate goes RED.
 //   * Restore the marker-absent + `:cached false` -> compiled classification in
-//     build-hook/compile-verdict (drop the Shadow ::build-info :compiled corroboration,
-//     rf2-8nn5k) → the FORGE pass, whose whole-map replacement Shadow did not
-//     compile, is misclassified as a recompile and either evicts app-a's valid view
-//     or succeeds instead of failing loud → this gate goes RED.
+//     build-hook/compile-verdict (drop the per-pass compile-witness corroboration,
+//     rf2-8nn5k / rf2-suz5b) → the FORGE pass, whose whole-map replacement Shadow's
+//     compiler never analyzed, is misclassified as a recompile and either evicts
+//     app-a's valid view or succeeds instead of failing loud → this gate goes RED.
+//   * Swap that corroboration back to Shadow's ::build-info :compiled record
+//     (rf2-suz5b) → correct only while the clock cooperates: pinned Shadow derives
+//     that set from `(> compiled-at compile-start)`, so a FORCED-EVICT recompile
+//     landing inside the compile phase's own millisecond tick vanishes from it and
+//     the pass fails loud instead of evicting. The deterministic form of that
+//     misclassification — both same- and backwards-millisecond stamps, and the
+//     future-stamp forgery the timestamp record would have ACCEPTED — is proven
+//     unconditionally by the digest-carrier JVM arms
+//     same-and-backwards-millisecond-recompile-is-witnessed-not-timestamped and
+//     forged-future-stamp-cannot-buy-a-compile.
 // All were exercised red-before-green during development.
 
 const fs = require('fs');
@@ -248,8 +258,8 @@ async function driveBuild({ id, mode }) {
     // 2.5 FORGE pass — a build-local :compile-prepare hook REPLACES app-a's whole
     // retained output map (rebuilt from Shadow's public fields, dropping
     // re-frame.ui's private marker, copying sticky :cached false) WITHOUT removing
-    // it, so Shadow does NOT recompile app-a and it is absent from Shadow's own
-    // ::build-info :compiled. Pre-fix, finish trusted :cached false and evicted
+    // it, so Shadow does NOT recompile app-a and re-frame.ui's per-pass compile
+    // witness never fires for it. Pre-fix, finish trusted :cached false and evicted
     // app-a's valid accepted view on a pass that compiled nothing. Now it must FAIL
     // LOUD (`marker-dropped-without-compile`) before any candidate is finalized, so
     // the both-views accepted state survives for the FORCED-EVICT arm below.

--- a/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
@@ -15,11 +15,11 @@
      TOTAL (every CLJS graph member is reconciled; a missing/nil/non-map final
      output fails loud, never silently skipped) and UNFORGEABLE by an output-map
      replacement. It is decided by re-frame.ui's OWN per-pass provenance marker
-     corroborated, for a marker-absent replaced map, by Shadow's OWN causal
-     compile record — never output-map identity, never Shadow's `:js` object
-     identity, and never a wall-clock stamp relationship of re-frame.ui's own. At
-     `:compile-prepare` re-frame.ui stamps an opaque per-pass token onto every
-     retained output MAP Shadow handed it. Shadow's compile path
+     corroborated, for a marker-absent replaced map, by re-frame.ui's OWN per-pass
+     COMPILE WITNESS — never output-map identity, never Shadow's `:js` object
+     identity, and never a wall-clock stamp relationship (re-frame.ui's own or
+     Shadow's). At `:compile-prepare` re-frame.ui stamps an opaque per-pass token
+     onto every retained output MAP Shadow handed it. Shadow's compile path
      (`do-compile-cljs-resource`) builds a FRESH output map for a (re)compiled
      source, dropping the marker; a later non-scheduling hook that merely
      annotates or transforms a retained output (assoc/update-in — INCLUDING
@@ -27,21 +27,29 @@
      the marker. So a source that still carries the current pass token is
      unforgeably RETAINED (a replacement cannot forge the private token). A
      marker-ABSENT output means the whole map was replaced: re-frame.ui then reads
-     Shadow's own `[:shadow.build/build-info :compiled]` record — populated after
-     the compile phase, outside the `[:output rid]` map a replacement controls —
-     to tell a genuine COMPILER replacement (a real compile) from a non-scheduling
-     HOOK replacement. When Shadow did NOT compile it, `:cached true` is a
-     legitimate disk-cache load and `:cached false` is a whole-map replacement
-     that dropped the marker without any compile — the latter CANNOT masquerade as
-     compilation and fails loud rather than evict a valid accepted view. Keying on
-     re-frame.ui's own marker plus Shadow's compile record — not on the identity of
-     Shadow's `:js` artifact and not on the forgeable `:cached` field alone — is
-     immune to the ordinary output-transforming shape (a retained output whose
-     `:js` is swapped for a fresh, even byte-identical, String by a non-scheduling
-     hook) that a raw `:js`-identity test misreads as a recompile and so evicts an
-     untouched accepted view; and — never comparing `:compiled-at` milliseconds
-     itself — immune to the same-/backwards-millisecond stamp a `>` test misreads
-     as untouched (leaving a ghost accepted view). A later `:compile-prepare` hook
+     its own compile witness — a `cljs.analyzer` pass installed at
+     `:compile-prepare` which fires only while Shadow's COMPILER is analyzing a
+     source, and whose record lives outside the `[:output rid]` map a replacement
+     controls — to tell a genuine COMPILER replacement (a real compile) from a
+     non-scheduling HOOK replacement. When the compiler did NOT analyze it,
+     `:cached true` is a legitimate disk-cache load and `:cached false` is a
+     whole-map replacement that dropped the marker without any compile — the
+     latter CANNOT masquerade as compilation and fails loud rather than evict a
+     valid accepted view. Keying on re-frame.ui's own marker plus its own compile
+     witness — not on the identity of Shadow's `:js` artifact and not on the
+     forgeable `:cached` field alone — is immune to the ordinary
+     output-transforming shape (a retained output whose `:js` is swapped for a
+     fresh, even byte-identical, String by a non-scheduling hook) that a raw
+     `:js`-identity test misreads as a recompile and so evicts an untouched
+     accepted view; and — no `:compiled-at` millisecond is compared anywhere on
+     this path, by re-frame.ui or on its behalf — immune to the
+     same-/backwards-millisecond stamp a `>` test misreads as untouched (leaving a
+     ghost accepted view). Deliberately NOT Shadow's own
+     `[:shadow.build/build-info :compiled]` record: pinned Shadow computes it in
+     `shadow.build/resources-compiled-recently` as
+     `(and (not cached) (> compiled-at compile-start))`, so it is that very
+     wall-clock ordering authority under another name and DROPS a genuine
+     same-/backwards-millisecond recompile (rf2-suz5b). A later `:compile-prepare` hook
      (Shadow deep-merges build-local hooks after `:build-defaults` and lets them
      mutate build state) can force a source to recompile AFTER re-frame.ui observed
      the schedule; reading the finish-time marker and Shadow's compile record, not
@@ -104,21 +112,84 @@
   output MAP only and is never emitted into any bundle."
   ::pass-marker)
 
-(def ^:private shadow-compiled-path
-  "Shadow's OWN causal per-pass compile record. `shadow.build/compile` populates
-  `[:shadow.build/build-info :compiled]` (a set of resource-ids) via
-  `update-build-info-after-compile` AFTER the compile phase and BEFORE the
-  `:compile-finish` hooks run, so it is authoritative and present when this hook
-  reads it. It is the causal fact re-frame.ui consults to decide, for a
-  marker-ABSENT output, whether Shadow's COMPILER replaced the whole output map
-  (a genuine compile) or a non-scheduling HOOK did (a replacement that must not
-  masquerade as compilation). Reading Shadow's record — not the forgeable
-  `:cached` field carried by the output map re-frame.ui is classifying, and not
-  any `:compiled-at` wall-clock relationship of re-frame.ui's own — is what makes
-  the marker-absent verdict unforgeable by an output-map replacement: the record
-  lives outside the `[:output rid]` map, so reconstructing that map cannot reach
-  or set it."
-  [:shadow.build/build-info :compiled])
+(def ^:private compile-witness-pass-key
+  "Metadata marker identifying re-frame.ui's own analyzer pass, so a warm daemon
+  re-installs exactly ONE witness per pass instead of accumulating one per
+  compile."
+  ::compile-witness-pass)
+
+(defn- analyzed-ns
+  "The declaring namespace an analyzer node belongs to.
+
+  Shadow analyzes a source's leading `(ns …)` form while its compile state still
+  reads `cljs.user` (`do-analyze-cljs-string` only advances the ns in
+  `post-analyze`, AFTER `cljs.analyzer/analyze*` has run the passes), so an `:ns`
+  node's OWN `:name` is authoritative for that first form. Every later node
+  carries the resolved namespace in its analyzer env. Reading the ns node is what
+  makes a viewless source — one whose only remaining form IS its `ns` form,
+  precisely the zero-declaration recompile that must evict — witnessed."
+  [env ast]
+  (if (= :ns (:op ast))
+    (:name ast)
+    (let [ns (:ns env)]
+      (if (symbol? ns) ns (:name ns)))))
+
+(defn- compile-witness-pass
+  "re-frame.ui's OWN per-pass CAUSAL compile witness: a `cljs.analyzer` pass
+  (`cljs.analyzer/*passes*`, which Shadow binds from `[:analyzer-passes]` on
+  every `shadow.build.compiler/analyze` call) recording the declaring namespace
+  of every source Shadow's COMPILER actually analyzed this pass.
+
+  It is causal, not corroborative: the pass runs if and only if
+  `do-compile-cljs-resource` is analyzing that source's forms. A disk-cache load
+  (`load-cached-cljs-resource`) restores analysis data without analyzing and is
+  therefore NOT witnessed; a warm hit runs nothing; a hook that replaces
+  `[:output rid]` executes no analyzer pass at all. And the record lives in a
+  closed-over atom re-frame.ui created this pass — outside the `[:output rid]`
+  map — so an output-map replacement can neither reach nor forge it.
+
+  Deliberately NOT Shadow's `[:shadow.build/build-info :compiled]` set: pinned
+  Shadow derives that from `(> compiled-at compile-start)`
+  (`shadow.build/resources-compiled-recently`), which silently omits a genuine
+  recompile whose `System/currentTimeMillis` stamp lands on or before the compile
+  start — the same wall-clock ordering authority this path exists to avoid
+  (rf2-suz5b, rf2-ialoij). Nothing here reads a millisecond."
+  [witnessed]
+  (with-meta
+    (fn compile-witness [env ast _opts]
+      (when-let [ns (analyzed-ns env ast)]
+        ;; Read-mostly: only the first node of each namespace writes, so the
+        ;; parallel-compile threads contend once per source, not per AST node.
+        (when-not (contains? @witnessed ns)
+          (swap! witnessed conj ns)))
+      ast)
+    {compile-witness-pass-key true}))
+
+(defn- install-compile-witness
+  "Install this pass's compile witness as the last `[:analyzer-passes]` entry,
+  first removing any witness a previous pass of a warm watch daemon left behind
+  (they are identified by `compile-witness-pass-key` metadata, never by position)
+  so passes cannot accumulate.
+
+  When the build-state carries no `:analyzer-passes` key at all — a plain-JVM
+  finish, never a Shadow build, where `shadow.build.api/init` always seeds it —
+  this is a no-op rather than a guess at Shadow's defaults. That fails SAFE: an
+  unwitnessed marker-absent output is refused loudly at `:compile-finish`, never
+  quietly trusted as compiled."
+  [build-state witnessed]
+  (if-not (contains? build-state :analyzer-passes)
+    build-state
+    (update build-state :analyzer-passes
+            (fn [passes]
+              (-> (into [] (remove #(get (meta %) compile-witness-pass-key)) passes)
+                  (conj (compile-witness-pass witnessed)))))))
+
+(defn- witnessed-compile?
+  "Did re-frame.ui's compile witness see Shadow's compiler analyze this
+  resource's declaring namespace (or any namespace it provides) this pass?"
+  [witnessed ns provides]
+  (boolean (or (and ns (contains? witnessed ns))
+               (some #(contains? witnessed %) provides))))
 
 (defn- member-nss
   "Authoritative declaring namespaces from Shadow's resolved build graph."
@@ -184,28 +255,29 @@
      the private token). A marker present but NOT equal to the token is a stale
      cross-pass artefact and fails loud.
 
-  2. For a marker-ABSENT output — where the whole map was replaced — Shadow's OWN
-     causal compile record `shadow-compiled?` (this resource's membership in
-     `[:shadow.build/build-info :compiled]`, computed by Shadow after the compile
-     phase). It distinguishes a genuine COMPILER replacement (`:compiled`) from a
-     non-scheduling HOOK replacement, WITHOUT trusting the output map's forgeable
-     `:cached` field to conclude compilation. When Shadow did NOT compile it:
-     `:cached true` is a legitimate disk-cache load (RETAINED); `:cached false`
-     is a whole-map replacement that dropped the marker without any Shadow
-     compile — it cannot be silently treated as a compile and fails loud
-     (`:marker-dropped-without-compile`); any other `:cached` value is
+  2. For a marker-ABSENT output — where the whole map was replaced —
+     re-frame.ui's OWN per-pass compile witness `compile-witnessed?` (this
+     resource's namespace was analyzed by Shadow's compiler this pass, recorded
+     by `compile-witness-pass`). It distinguishes a genuine COMPILER replacement
+     (`:compiled`) from a non-scheduling HOOK replacement, WITHOUT trusting the
+     output map's forgeable `:cached` field to conclude compilation. When the
+     compiler did NOT analyze it: `:cached true` is a legitimate disk-cache load
+     (RETAINED); `:cached false` is a whole-map replacement that dropped the
+     marker without any compile — it cannot be silently treated as a compile and
+     fails loud (`:marker-dropped-without-compile`); any other `:cached` value is
      unusable evidence and fails loud.
 
-  Because the marker gate is checked before the compile record, a genuine
-  EQUAL-stamp or BACKWARDS-stamp recompile is still classified `:compiled` (it
-  dropped the marker AND is in Shadow's record); re-frame.ui itself never
-  compares `:compiled-at`."
-  [final-output pass-token shadow-compiled?]
+  Because the marker gate is checked before the witness, a genuine EQUAL-stamp or
+  BACKWARDS-stamp recompile is still classified `:compiled` (it dropped the marker
+  AND its namespace was analyzed). No `:compiled-at` millisecond is compared here
+  or in the witness — unlike Shadow's own `[:shadow.build/build-info :compiled]`
+  set, which is exactly such a comparison and would drop that recompile."
+  [final-output pass-token compile-witnessed?]
   (let [marker (get final-output compile-marker-key ::unmarked)]
     (cond
       (= marker pass-token)    :retained
       (not= marker ::unmarked) :stale-provenance-marker
-      shadow-compiled?         :compiled
+      compile-witnessed?       :compiled
       :else
       (case (:cached final-output)
         true  :retained                        ; disk-cache load: replaced map, not compiled
@@ -246,15 +318,14 @@
   Provenance is UNFORGEABLE by an output-map replacement: a member counts as
   recompiled per `compile-verdict`, which gates FIRST on re-frame.ui's own
   per-pass marker (unforgeable RETAINED) and, only for a marker-absent replaced
-  map, on Shadow's OWN causal compile record (`shadow-compiled-path`) rather than
-  the output map's forgeable `:cached` field. A whole-map replacement that drops
-  the marker without a corresponding Shadow compile cannot masquerade as
-  compilation — it fails loud. This remains immune to a `:js`-object-identity
-  misread and to same-/backwards-millisecond compile stamps (re-frame.ui compares
-  no `:compiled-at`)."
-  [{:keys [build-sources sources output] :as build-state} pass-token]
-  (let [build-id (:shadow.build/build-id build-state)
-        compiled (set (get-in build-state shadow-compiled-path))]
+  map, on re-frame.ui's own per-pass compile witness (`compile-witness-pass`)
+  rather than the output map's forgeable `:cached` field. A whole-map replacement
+  that drops the marker without the compiler having analyzed the source cannot
+  masquerade as compilation — it fails loud. This remains immune to a
+  `:js`-object-identity misread and to same-/backwards-millisecond compile stamps
+  — neither re-frame.ui nor anything it consults compares a `:compiled-at`."
+  [{:keys [build-sources sources output] :as build-state} pass-token witnessed]
+  (let [build-id (:shadow.build/build-id build-state)]
     (reduce
      (fn [acc resource-id]
        (let [{:keys [type ns provides]} (get sources resource-id)]
@@ -277,7 +348,7 @@
                   :final-output final-output
                   :recovery :ensure-shadow-output-for-cljs-member}))
                (case (compile-verdict final-output pass-token
-                                      (contains? compiled resource-id))
+                                      (witnessed-compile? witnessed ns provides))
                  :compiled (into acc (or provides (when ns #{ns})))
                  :retained acc
                  :stale-provenance-marker
@@ -300,8 +371,9 @@
                    (str "re-frame.ui compile-finish found CLJS build member "
                         resource-id " whose retained output map was REPLACED "
                         "(re-frame.ui's per-pass marker was dropped) although "
-                        "Shadow did not compile it this pass; a non-scheduling "
-                        "whole-map replacement cannot count as compilation")
+                        "Shadow's compiler never analyzed it this pass; a "
+                        "non-scheduling whole-map replacement cannot count as "
+                        "compilation")
                    {::error ::ambiguous-compile-evidence
                     :build-id build-id
                     :resource-id resource-id
@@ -340,25 +412,29 @@
 
   When no re-frame.ui pass is open (a non-Shadow / plain-JVM finish with no
   scratch) this is a no-op — the prepare-time pre-touch is the sole reconciler.
-  When a pass IS open the prepare-time `:pass-token` provenance MUST be present;
-  its absence is unobservable provenance and fails loudly rather than silently
-  reconciling against an assumed-empty compile schedule. Pure build-state
-  transform (apart from that guard)."
+  When a pass IS open BOTH prepare-time provenance facts MUST be present — the
+  `:pass-token` stamped onto retained outputs and the `:compile-witness` the
+  analyzer pass writes into; either one missing is unobservable provenance and
+  fails loudly rather than silently reconciling against an assumed-empty compile
+  schedule. Pure build-state transform (apart from that guard)."
   [build-state]
   (let [scratch (get-in build-state [:compiler-env build/scratch-key])]
     (if-not scratch
       build-state
       (do
-        (when-not (contains? scratch :pass-token)
-          (throw
-           (ex-info
-            (str "re-frame.ui compile-finish observed no per-pass compile "
-                 "provenance (missing prepare-time :pass-token); refusing to "
-                 "reconcile against an assumed-empty compile schedule")
-            {::error ::missing-pass-provenance
-             :recovery :configure-ui-build-hook-once})))
+        (doseq [k [:pass-token :compile-witness]]
+          (when-not (contains? scratch k)
+            (throw
+             (ex-info
+              (str "re-frame.ui compile-finish observed no per-pass compile "
+                   "provenance (missing prepare-time " k "); refusing to "
+                   "reconcile against an assumed-empty compile schedule")
+              {::error ::missing-pass-provenance
+               :reason k
+               :recovery :configure-ui-build-hook-once}))))
         (let [extra (actually-recompiled-member-nss build-state
-                                                    (:pass-token scratch))]
+                                                    (:pass-token scratch)
+                                                    @(:compile-witness scratch))]
           (if (seq extra)
             (update-in build-state
                        [:compiler-env build/scratch-key :touched]
@@ -569,24 +645,32 @@
       (validate-ui-cache-blocker! build-state)
       (let [build-state (reset-cold-ui-consumer-output build-state)
             pass-token  (str (java.util.UUID/randomUUID))
-            stamped     (stamp-retained-outputs build-state pass-token)]
+            witnessed   (atom #{})
+            stamped     (-> build-state
+                            (stamp-retained-outputs pass-token)
+                            (install-compile-witness witnessed))]
         ;; Stamp an opaque per-pass provenance token onto every retained `:output`
-        ;; map Shadow handed us BEFORE any compilation, and remember it in scratch,
-        ;; so `:compile-finish` can identify the sources Shadow actually
-        ;; (re)compiled this pass: a compiled source's fresh output map LOSES the
-        ;; token, while a later non-scheduling hook's assoc/update-in on a retained
-        ;; output — INCLUDING replacing only `[:output rid :js]` with a fresh
-        ;; equal-byte string — PRESERVES it. Robust to that output-transforming
-        ;; shape (which a raw `:js`-identity test misread as a recompile) and free
-        ;; of any `:compiled-at` wall-clock comparison so same-/backwards-
-        ;; millisecond recompiles are still caught (rf2-v7wqk, rf2-vxgfnd.194,
-        ;; rf2-vxgfnd.255, rf2-vxgfnd.282, rf2-ialoij).
+        ;; map Shadow handed us BEFORE any compilation, install this pass's causal
+        ;; compile witness, and remember both in scratch, so `:compile-finish` can
+        ;; identify the sources Shadow actually (re)compiled this pass: a compiled
+        ;; source's fresh output map LOSES the token, while a later non-scheduling
+        ;; hook's assoc/update-in on a retained output — INCLUDING replacing only
+        ;; `[:output rid :js]` with a fresh equal-byte string — PRESERVES it. For
+        ;; the marker-absent remainder the witness says whether Shadow's compiler
+        ;; actually analyzed the source. Robust to that output-transforming shape
+        ;; (which a raw `:js`-identity test misread as a recompile) and free of any
+        ;; `:compiled-at` wall-clock comparison — including Shadow's own
+        ;; `(> compiled-at compile-start)` `::build-info :compiled` set — so
+        ;; same-/backwards-millisecond recompiles are still caught (rf2-v7wqk,
+        ;; rf2-vxgfnd.194, rf2-vxgfnd.255, rf2-vxgfnd.282, rf2-ialoij, rf2-suz5b).
         (-> (build/prepare-shadow-build stamped
                                         build-id
                                         (member-nss stamped)
                                         (recompiled-member-nss stamped))
             (assoc-in [:compiler-env build/scratch-key :pass-token]
-                      pass-token))))
+                      pass-token)
+            (assoc-in [:compiler-env build/scratch-key :compile-witness]
+                      witnessed))))
 
     :compile-finish
     ;; Reconcile against Shadow's final compile schedule, then project. All are

--- a/implementation/ui/test/re_frame/ui/compiler_build_hook_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_hook_jvm_test.clj
@@ -10,7 +10,8 @@
             [re-frame.ui.compiler :as compiler]
             [re-frame.ui.compiler.build :as build]
             [re-frame.ui.compiler.build-hook :as build-hook]
-            [re-frame.ui.compiler.root :as root]))
+            [re-frame.ui.compiler.root :as root]
+            [re-frame.ui.shadow-compile-model :as shadow]))
 
 (use-fixtures :each
   (fn [f] (build/reset-build!) (try (f) (finally (build/reset-build!)))))
@@ -22,6 +23,9 @@
    ;; Truthy executor + default parallel-build mirrors Shadow watch. In that
    ;; branch output presence is the exact cache-hit / compile-schedule signal.
    :executor (Object.)
+   ;; As `shadow.build.api/init` seeds it: the seam re-frame.ui installs its
+   ;; per-pass compile witness into.
+   :analyzer-passes []
    :build-sources (vec member-nss)
    :sources (into {} (map (fn [n] [n {:ns n :provides #{n} :type :cljs}]))
                   member-nss)})
@@ -85,20 +89,21 @@
   ([state member-nss] (finish state member-nss (set member-nss)))
   ([state member-nss recompiled-nss]
    ;; Model Shadow's real compile phase: every source Shadow (re)compiled this
-   ;; pass gets a FRESH output map (marker-absent, `:cached false`) and is
-   ;; recorded in Shadow's OWN `[:shadow.build/build-info :compiled]` set. Warm
+   ;; pass gets a FRESH output map (marker-absent, `:cached false`) AND has its
+   ;; forms analyzed — the causal event re-frame.ui's per-pass compile witness
+   ;; records (rf2-suz5b; never a `(> compiled-at compile-start)` set). Warm
    ;; cache-hit members keep the marker-stamped output prepare left them. This is
-   ;; what a real build hands `:compile-finish`; the prior helper unrealistically
-   ;; left recompiled members with NO output at finish.
+   ;; what a real build hands `:compile-finish`.
    (let [recompiled-nss (set recompiled-nss)
          with-outputs (reduce (fn [s n]
                                 (assoc-in s [:output n]
                                           {:resource-id n :js "compiled"
                                            :cached false}))
-                              state recompiled-nss)]
-     (build-hook/hook
-      (-> (at-stage with-outputs :compile-finish member-nss)
-          (assoc-in [:shadow.build/build-info :compiled] recompiled-nss))))))
+                              state recompiled-nss)
+         finishing (at-stage with-outputs :compile-finish member-nss)]
+     (doseq [n recompiled-nss]
+       (shadow/compile-ns! finishing (get-in finishing [:sources n :ns])))
+     (build-hook/hook finishing))))
 
 (defn- pass
   ([state member-nss declarations]

--- a/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
@@ -1,10 +1,12 @@
 (ns re-frame.ui.compiler-digest-carrier-jvm-test
   "Pure carrier projection plus functional accepted-snapshot transaction tests."
-  (:require [cljs.env :as cljs-env]
+  (:require [cljs.analyzer :as ana]
+            [cljs.env :as cljs-env]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [re-frame.ui.compiler.build :as build]
-            [re-frame.ui.compiler.build-hook :as build-hook]))
+            [re-frame.ui.compiler.build-hook :as build-hook]
+            [re-frame.ui.shadow-compile-model :as shadow]))
 
 (def ^:private carrier-rid [:cljs "re_frame/ui/digest_carrier.cljs"])
 (def ^:private client-rid [:cljs "re_frame/ui/client.cljs"])
@@ -35,6 +37,10 @@
    :compiler-env {}
    :executor (Object.)
    :build-options {:cache-blockers '#{re-frame.ui}}
+   ;; `shadow.build.api/init` always seeds `:analyzer-passes`; carrying it here
+   ;; is what lets re-frame.ui install its per-pass compile witness, exactly as
+   ;; in a real build.
+   :analyzer-passes []
    :build-sources [carrier-rid app-rid]
    :sources {carrier-rid {:ns 're-frame.ui.digest-carrier
                           :provides #{'re-frame.ui.digest-carrier}
@@ -58,6 +64,7 @@
            :shadow.build/stage :compile-prepare
            :compiler-env {}
            :build-options {:cache-blockers '#{re-frame.ui}}
+           :analyzer-passes []
            :build-sources [carrier-rid app-a-rid app-b-rid]
            :sources {carrier-rid {:ns 're-frame.ui.digest-carrier
                                   :provides #{'re-frame.ui.digest-carrier}
@@ -95,12 +102,18 @@
   "Drive `:compile-finish`. Models Shadow's real compile phase: every CLJS build
   member whose output is ABSENT (Shadow scheduled it — e.g. a version-0 UI
   consumer whose retained output prepare invalidated) is given a FRESH compiled
-  output map and recorded in Shadow's OWN `[:shadow.build/build-info :compiled]`
-  set. Members that already carry an output keep it (a warm hit's marker-stamped
-  map, or a map the test set to model a recompile / a hook replacement); such a
-  test names its own recompiled members via `extra-compiled`. The prior helper
-  left version-0-invalidated consumers with NO finish output, which real Shadow
-  never does."
+  output map AND has its forms analyzed, which is what re-frame.ui's per-pass
+  compile witness observes. Members that already carry an output keep it (a warm
+  hit's marker-stamped map, or a map the test set to model a recompile / a hook
+  replacement); such a test names its own recompiled members via
+  `extra-compiled`.
+
+  rf2-suz5b: the compiled set is derived by DRIVING the build-state's installed
+  `:analyzer-passes` through pinned ClojureScript's own calling convention (see
+  `re-frame.ui.shadow-compile-model`), never by asserting membership in Shadow's
+  `[:shadow.build/build-info :compiled]` — that set is
+  `(> compiled-at compile-start)` and omits a same-millisecond recompile, so
+  writing it here would assume the disputed fact."
   ([state] (finish state #{}))
   ([state extra-compiled]
    (let [cljs-members (filter #(= :cljs (get-in state [:sources % :type]))
@@ -113,10 +126,9 @@
                            (not (map? (get-in s [:output rid])))
                            (assoc-in [:output rid]
                                      (compiled-output rid "compiled"))))
-                       state scheduled)
-         ;; Shadow RESETS `:compiled` every pass (extract-build-info recomputes
-         ;; it), so set — never accumulate — this pass's compiled set.
-         state (assoc-in state [:shadow.build/build-info :compiled] scheduled)]
+                       state scheduled)]
+     (doseq [rid scheduled]
+       (shadow/compile-ns! state (get-in state [:sources rid :ns])))
      (build-hook/hook (assoc state :shadow.build/stage :compile-finish)))))
 
 (deftest ui-build-requires-the-load-bearing-cache-blocker
@@ -388,6 +400,163 @@
               "app.b's accepted row is digest-stable across the warm pass")
           (is (not (contains? views-after :app/a-view))
               "the genuinely recompiled zero-declaration source is evicted despite its backwards stamp"))))))
+
+(deftest same-and-backwards-millisecond-recompile-is-witnessed-not-timestamped
+  ;; rf2-suz5b — the P1 the compile WITNESS fixes (red-before / green-after).
+  ;;
+  ;; rf2-8nn5k corroborated a marker-absent output against Shadow's
+  ;; `[:shadow.build/build-info :compiled]` record, believing it independent of
+  ;; wall-clock. Pinned Shadow computes it in `resources-compiled-recently` as
+  ;; `(and (not cached) (> compiled-at compile-start))` — the very ordering
+  ;; authority rf2-ialoij removed, under another name. `System/currentTimeMillis`
+  ;; ticks at ~15.6ms on Windows, so a small incremental watch recompile
+  ;; routinely finishes inside the tick the compile phase started in, and a
+  ;; non-monotonic clock can send the stamp backwards outright.
+  ;;
+  ;; Both rows of the bead's pinned probe are exercised here (compiled-at 1000 and
+  ;; 999 against compile-start 1000). `assert-no-timestamp-corroboration!` proves
+  ;; from Shadow's OWN verbatim derivation that the record is EMPTY for app.a, so
+  ;; no correct verdict can come from it. RED-BEFORE: `compile-verdict` saw marker
+  ;; absent + not-compiled + `:cached false` and threw
+  ;; `:marker-dropped-without-compile`, failing the whole build on an ordinary
+  ;; same-tick recompile. GREEN-AFTER: re-frame.ui's own witness saw the compiler
+  ;; analyze app.a, so it is `:compiled`, its zero-declaration recompile evicts
+  ;; its accepted row, and the cache-hit sibling survives.
+  (doseq [parallel? [true false]
+          [stamp-label stamp] [[:equal-millisecond 1000] [:backwards-millisecond 999]]]
+    (testing (str (if parallel? "parallel" "sequential") " / " (name stamp-label))
+      (let [build-id (keyword "same-ms" (str (name stamp-label)
+                                             (if parallel? "-p" "-s")))
+            good (-> (two-source-state build-id parallel?)
+                     prepare
+                     (declare 'app.a :app/a-view ["tfa-1" "hsa-1"])
+                     (declare 'app.b :app/b-view ["tfb-1" "hsb-1"])
+                     finish)
+            digest-before (build/accepted-build-digest good)
+            ;; A warm accepted generation: both sources retain a compiled output,
+            ;; so re-frame.ui pre-touches neither at prepare.
+            warm-input (-> good
+                           (assoc-in [:output carrier-rid :js]
+                                     build-hook/digest-sentinel)
+                           (assoc-in [:output app-a-rid]
+                                     {:resource-id app-a-rid
+                                      :js (fresh-js "app.a = {};")
+                                      :compiled-at 1000 :cached false})
+                           (assoc-in [:output app-b-rid]
+                                     {:resource-id app-b-rid
+                                      :js (fresh-js "app.b = {};")
+                                      :compiled-at 1000 :cached false}))
+            prepared (prepare warm-input)
+            ;; A later prepare hook removed app.a's output; Shadow recompiled it
+            ;; after re-frame.ui observed the schedule, and its final ui/defview
+            ;; is gone. Shadow stamped the fresh output inside — or behind — the
+            ;; millisecond `compile-all` recorded as `:compile-start`.
+            recompiled (-> prepared
+                           (assoc :compile-start 1000)
+                           (assoc-in [:output app-a-rid]
+                                     {:resource-id app-a-rid
+                                      :js (fresh-js "app.a = {};")
+                                      :compiled-at stamp :cached false}))]
+        (shadow/assert-no-timestamp-corroboration!
+         recompiled app-a-rid (name stamp-label))
+        (is (not (contains?
+                  (get-in prepared [:compiler-env build/scratch-key :touched])
+                  'app.a))
+            "re-frame.ui does not pre-touch an output-present source at prepare")
+        (let [finished (finish recompiled #{app-a-rid})
+              views-after (build/accepted-aggregate build/views finished)]
+          (is (= {:app/b-view ["tfb-1" "hsb-1"]} views-after)
+              "the witnessed recompile evicts its ghost; the cache hit survives")
+          (is (not (contains? views-after :app/a-view))
+              "no ghost view survives a same-/backwards-millisecond recompile")
+          (is (not= digest-before (build/accepted-build-digest finished))
+              "evicting the ghost changes the accepted whole-build digest"))))))
+
+(deftest forged-future-stamp-cannot-buy-a-compile
+  ;; rf2-suz5b adversary — the mirror of the same-millisecond miss. A
+  ;; non-scheduling whole-map replacement that copies Shadow's public fields and
+  ;; sets `:compiled-at` in the FUTURE satisfies `(> compiled-at compile-start)`,
+  ;; so pinned Shadow's `[:shadow.build/build-info :compiled]` record WOULD have
+  ;; contained it — asserted below from Shadow's own verbatim derivation. Under
+  ;; rf2-8nn5k that corroboration classified the forgery `:compiled`, pre-touched
+  ;; app.b, saw no registry macro and SILENTLY EVICTED a valid accepted view; a
+  ;; forger only had to pick a large enough number. re-frame.ui's own witness
+  ;; cannot be reached by rebuilding an output map — no analyzer pass ran for
+  ;; app.b — so the replacement fails loud BEFORE publication and app.b's
+  ;; accepted view and the whole-build digest survive.
+  (doseq [parallel? [true false]]
+    (testing (str (if parallel? "parallel" "sequential") " compilation")
+      (let [build-id (keyword "future-forge" (if parallel? "p" "s"))
+            good (-> (two-source-state build-id parallel?)
+                     prepare
+                     (declare 'app.a :app/a-view ["tfa-1" "hsa-1"])
+                     (declare 'app.b :app/b-view ["tfb-1" "hsb-1"])
+                     finish)
+            digest-before (build/accepted-build-digest good)
+            views-before (build/accepted-aggregate build/views good)
+            warm-input (-> good
+                           (assoc-in [:output carrier-rid :js]
+                                     build-hook/digest-sentinel)
+                           (assoc-in [:output app-a-rid]
+                                     {:resource-id app-a-rid
+                                      :js (fresh-js "app.a = {};")
+                                      :compiled-at 1000 :cached false})
+                           (assoc-in [:output app-b-rid]
+                                     {:resource-id app-b-rid
+                                      :js (fresh-js "app.b = {};")
+                                      :compiled-at 1000 :cached false}))
+            prepared (prepare warm-input)
+            ;; The forgery: every visible field Shadow publishes, a sticky
+            ;; `:cached false`, and a stamp far past `:compile-start`. No
+            ;; compilation is scheduled and no analyzer pass runs.
+            forged-b {:resource-id app-b-rid :js (fresh-js "app.b = {};")
+                      :compiled-at Long/MAX_VALUE :cached false}
+            forged (-> prepared
+                       (assoc :compile-start 1000)
+                       (assoc-in [:output app-b-rid] forged-b))]
+        (is (contains? (shadow/resources-compiled-recently forged) app-b-rid)
+            "the forgery satisfies pinned Shadow's (> compiled-at compile-start) record")
+        (is (nil? (get forged-b :re-frame.ui.compiler.build-hook/pass-marker))
+            "and drops re-frame.ui's private per-pass marker, as a real compile does")
+        (let [ex (try (finish forged) nil
+                      (catch clojure.lang.ExceptionInfo e e))]
+          (is (= :re-frame.ui.compiler.build-hook/ambiguous-compile-evidence
+                 (:re-frame.ui.compiler.build-hook/error (ex-data ex)))
+              "an unwitnessed whole-map replacement cannot masquerade as compilation")
+          (is (= :marker-dropped-without-compile (:reason (ex-data ex))))
+          (is (= app-b-rid (:resource-id (ex-data ex))))
+          (is (= views-before (build/accepted-aggregate build/views good))
+              "the forged replacement never evicted app.b's valid accepted view")
+          (is (= digest-before (build/accepted-build-digest good))))))))
+
+(deftest witness-pass-is-driven-by-pinned-clojurescript
+  ;; rf2-suz5b / AC3: the corroborating fact must be derived through the real
+  ;; machinery, not inserted. The other fixtures drive re-frame.ui's installed
+  ;; analyzer pass through `cljs.analyzer/analyze*`'s reduction
+  ;; (`re-frame.ui.shadow-compile-model`); this one pins that model against
+  ;; PINNED ClojureScript itself — a real `(ns …)` form through the real
+  ;; `analyze*`, which is exactly how Shadow's `do-compile-cljs-resource` reaches
+  ;; the passes it binds from `[:analyzer-passes]`. It also proves the case the
+  ;; witness exists for: a VIEWLESS source, whose only remaining form is its `ns`
+  ;; form, is still attributed to its own namespace even though Shadow's compile
+  ;; state still reads `cljs.user` while that form is analyzed.
+  (let [prepared (prepare (two-source-state :real-analyzer true))
+        witness (get-in prepared [:compiler-env build/scratch-key :compile-witness])]
+    (is (some? witness) "prepare installs this pass's compile witness in scratch")
+    (is (= 1 (count (filter #(get (meta %) :re-frame.ui.compiler.build-hook/compile-witness-pass)
+                            (:analyzer-passes prepared))))
+        "exactly one witness pass is installed, never one per warm pass")
+    (is (not (contains? @witness 'app.a))
+        "nothing is witnessed before the compiler analyzes anything")
+    (cljs-env/with-compiler-env (cljs-env/default-compiler-env)
+      (binding [ana/*passes* (:analyzer-passes prepared)
+                ana/*cljs-ns* 'cljs.user
+                ana/*analyze-deps* false
+                ana/*load-macros* false]
+        (ana/analyze* (assoc (ana/empty-env) :ns {:name 'cljs.user})
+                      '(ns app.a) nil {})))
+    (is (contains? @witness 'app.a)
+        "pinned ClojureScript's own analyze* drives re-frame.ui's witness")))
 
 (deftest metadata-only-output-mutation-is-not-a-recompile
   ;; rf2-vxgfnd.282 / rf2-ialoij / rf2-v7wqk: a fresh output MAP is NOT compile

--- a/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/hook.clj
+++ b/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/hook.clj
@@ -93,10 +93,13 @@
         ;; A later NON-scheduling hook that REPLACES app-a's whole retained output
         ;; map, rebuilt from Shadow's PUBLIC fields (dropping re-frame.ui's private
         ;; marker) and copying the sticky :cached false, WITHOUT removing it — so
-        ;; Shadow does not reschedule it and app-a is absent from Shadow's OWN
-        ;; ::build-info :compiled record. This is the "unforgeable by output-map
-        ;; replacement" adversary: :compile-finish must FAIL LOUD rather than trust
-        ;; the forged :cached false and evict app-a's valid accepted view.
+        ;; Shadow does not reschedule it, no analyzer pass runs for app-a and
+        ;; re-frame.ui's per-pass compile witness never records it. This is the
+        ;; "unforgeable by output-map replacement" adversary: :compile-finish must
+        ;; FAIL LOUD rather than trust the forged :cached false and evict app-a's
+        ;; valid accepted view. Note the forgery copies `:compiled-at` too, so it
+        ;; is exactly the shape a wall-clock record could not have rejected
+        ;; (rf2-suz5b).
         (and rid forge?)
         (assoc-in [:output rid]
                   (-> (get-in build-state [:output rid])

--- a/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/shadow-cljs.edn
+++ b/implementation/ui/test/re_frame/ui/digest_probe/final_schedule/shadow-cljs.edn
@@ -38,9 +38,9 @@
 
   ;; SEQUENTIAL compile schedule (:parallel-build false). re-frame.ui's prepare
   ;; pre-touch takes its (nil? prior-output)/warnings branch here. The
-  ;; final-schedule reconciliation, keyed on Shadow's causal per-source compile
-  ;; evidence (a :cached false finish output whose fresh :js artifact differs from
-  ;; the prepare snapshot), must evict identically in both modes.
+  ;; final-schedule reconciliation, keyed on re-frame.ui's own per-pass provenance
+  ;; marker plus its per-pass compile witness (never a `:js` artifact and never a
+  ;; `:compiled-at` stamp), must evict identically in both modes.
   :ui-final-schedule-seq
   {:target :browser
    :output-dir "../../../../../../out/ui-final-schedule-seq"

--- a/implementation/ui/test/re_frame/ui/shadow_compile_model.clj
+++ b/implementation/ui/test/re_frame/ui/shadow_compile_model.clj
@@ -1,0 +1,97 @@
+(ns re-frame.ui.shadow-compile-model
+  "Test-only model of Shadow 3.4.10's compile phase for the build-hook
+  provenance fixtures (rf2-suz5b).
+
+  A real compile does exactly two things to build state that re-frame.ui can
+  observe. It REPLACES the source's whole `[:output rid]` map with a fresh
+  compiler-shaped map — dropping re-frame.ui's per-pass marker — and it drives
+  the build-state's installed `[:analyzer-passes]` over that source's forms. The
+  second is what re-frame.ui's per-pass compile witness records, and these
+  fixtures drive it through pinned ClojureScript's OWN calling convention rather
+  than by inserting an expected id into a corroborating set:
+
+    ;; cljs.analyzer/analyze*, ClojureScript 1.12.145
+    (reduce (fn [ast pass] (pass env ast opts)) ast passes)
+
+  `analyze!` below is that reduction verbatim. `compile-ns!` applies it to the
+  `:ns` AST node `cljs.analyzer`'s `parse 'ns` produces — the ONLY form a
+  viewless zero-declaration recompile still has, and therefore the strictest
+  case. `witness-pass-is-driven-by-pinned-clojurescript` in
+  `re-frame.ui.compiler-digest-carrier-jvm-test` pins this model against the REAL
+  `cljs.analyzer/analyze*` on a REAL `(ns …)` form, so the shortcut cannot drift
+  from the machinery it stands in for.
+
+  Modelling the analyzer instead of Shadow's `[:shadow.build/build-info
+  :compiled]` set is the whole point of rf2-suz5b: pinned Shadow derives that set
+  in `shadow.build/resources-compiled-recently` as
+
+    (and (not cached) (number? compiled-at) (> compiled-at compile-start))
+
+  so a fixture that hands `:compiled` the resource id it expects assumes exactly
+  the wall-clock fact under dispute — and hides that a genuine same-millisecond
+  recompile is missing from it."
+  (:require [clojure.test :refer [is]]))
+
+(defn ns-node
+  "The shape `cljs.analyzer`'s `parse 'ns` returns for `(ns <ns-sym> …)`.
+
+  Shadow analyzes a source's leading `ns` form while its compile state still
+  reads `cljs.user` (`do-analyze-cljs-string` advances the ns only in
+  `post-analyze`, AFTER the passes have run), so the node's own `:name` — not the
+  analyzer env — carries the declaring namespace here."
+  [ns-sym]
+  {:op :ns
+   :name ns-sym
+   :form (list 'ns ns-sym)
+   :env {:ns {:name 'cljs.user}}
+   :children []})
+
+(defn analyze!
+  "Run `build-state`'s installed analyzer passes over `ast` exactly as
+  `cljs.analyzer/analyze*` does. Returns the (possibly rewritten) ast."
+  [build-state env ast]
+  (reduce (fn [ast pass] (pass env ast {}))
+          ast
+          (:analyzer-passes build-state)))
+
+(defn compile-ns!
+  "Model Shadow's compiler ANALYZING the source that declares `ns-sym` — the
+  causal event re-frame.ui's compile witness observes. Side-effecting on the
+  witness only; returns `build-state` unchanged so it composes in a `reduce`."
+  [build-state ns-sym]
+  (analyze! build-state {:ns {:name 'cljs.user}} (ns-node ns-sym))
+  build-state)
+
+(defn resources-compiled-recently
+  "`shadow.build/resources-compiled-recently`, verbatim from pinned Shadow
+  3.4.10 (`shadow/build.clj` L72-83) — the derivation behind
+  `[:shadow.build/build-info :compiled]`:
+
+    (filter (fn [src-id]
+              (let [{:keys [cached compiled-at]} (get-in state [:output src-id])]
+                (and (not cached) (number? compiled-at)
+                     (> compiled-at compile-start)))))
+
+  Reproduced here ONLY to prove what that set does NOT contain — that a genuine
+  recompile stamped on or before `compile-start` is absent from it, so the
+  corroboration rf2-8nn5k built on it silently disappears. Nothing in
+  `re-frame.ui` calls it or anything like it."
+  [{:keys [build-sources compile-start] :as state}]
+  (into #{}
+        (filter (fn [src-id]
+                  (let [{:keys [cached compiled-at]} (get-in state [:output src-id])]
+                    (and (not cached)
+                         (number? compiled-at)
+                         (> compiled-at compile-start)))))
+        build-sources))
+
+(defn assert-no-timestamp-corroboration!
+  "Assert that pinned Shadow's timestamp-derived compile record is EMPTY for
+  `rid` in `state` — i.e. that this fixture's genuine recompile would have been
+  invisible to rf2-8nn5k's corroboration, so any correct verdict it reaches must
+  come from the causal witness instead."
+  [state rid label]
+  (is (not (contains? (resources-compiled-recently state) rid))
+      (str label
+           ": pinned Shadow's (> compiled-at compile-start) record omits this "
+           "genuine recompile — the verdict cannot come from a timestamp")))


### PR DESCRIPTION
Closes rf2-suz5b (P1, follow-up to rf2-8nn5k / #6270).

## The bug

rf2-8nn5k made finish-time provenance total and unforgeable by corroborating a
marker-absent output map against Shadow's `[:shadow.build/build-info :compiled]`
record, on the understanding that it was an independent causal compile fact.
It is not. Pinned Shadow 3.4.10 computes it in
`shadow.build/resources-compiled-recently` (`shadow/build.clj` L72-83):

```clj
(and (not cached) (number? compiled-at) (> compiled-at compile-start))
```

with `compiled-at` from `do-compile-cljs-resource` and `compile-start` from
`compiler/compile-all` — both `System/currentTimeMillis`. It is the same
wall-clock ordering authority rf2-ialoij removed, under another name, and it
misleads in both directions:

* **False negative (the P1).** `System/currentTimeMillis` ticks at ~15.6ms on
  Windows, so a small incremental watch recompile routinely finishes inside the
  tick the compile phase started in. `compile-verdict`
  (`build_hook.clj:203-213` pre-fix) then saw marker absent + not compiled +
  `:cached false` and threw `:marker-dropped-without-compile` — failing the
  whole build on an ordinary recompile, and violating rf2-8nn5k's own
  equal/backwards-stamp AC.
* **False positive.** A non-scheduling whole-map replacement that copies
  Shadow's public fields satisfies `(> compiled-at compile-start)` for any
  post-start stamp, so it is classified `:compiled`, pre-touched, and its valid
  accepted view is silently evicted.

The JVM fixtures hid both because they wrote `:compiled` from their own
`scheduled` argument — asserting the disputed fact instead of deriving it.

## The fix

Replace the corroboration at the same seam with re-frame.ui's OWN per-pass
**compile witness**: a `cljs.analyzer` pass installed at `:compile-prepare` and
recorded in scratch beside the pass token. Shadow binds `cljs.analyzer/*passes*`
from `[:analyzer-passes]` on every `shadow.build.compiler/analyze` call, so the
witness fires if and only if the compiler is analyzing that source's forms — a
disk-cache load restores analysis data without analyzing, a warm hit runs
nothing, and a hook that replaces `[:output rid]` runs no pass at all. The
record lives in a closed-over atom outside `[:output rid]`, which is what keeps
the marker-absent verdict unforgeable. Nothing on this path reads a millisecond
any more, directly or on re-frame.ui's behalf.

rf2-8nn5k's marker/warm-hit split is preserved exactly: the marker gate is still
checked first and is still authoritative for retained outputs; only the
marker-ABSENT corroboration changed. No new error ids — the fail-loud arms keep
`::ambiguous-compile-evidence` / `:marker-dropped-without-compile`, and a
missing `:compile-witness` reuses `::missing-pass-provenance` with a `:reason`.

Scope: `build_hook.clj` + its JVM fixtures + the final-schedule probe/gate
comments. No new marker or token type, no tolerance window, no build-graph
analyzer, no `build.cljc` change.

## Red-before / green-after

Restoring the timestamp corroboration and deriving `:compiled` through pinned
Shadow's verbatim rule (instead of hand-inserting ids):

| arm | red-before | green-after |
|---|---|---|
| `same-and-backwards-millisecond-recompile-is-witnessed-not-timestamped` (new) | ERROR — throws `:marker-dropped-without-compile` on a genuine same-ms recompile | evicts the ghost, cache-hit sibling survives, digest moves |
| `forged-future-stamp-cannot-buy-a-compile` (new, adversarial) | 6 FAIL — the forgery is accepted as a compile | fails loud, accepted view + digest survive |
| `whole-map-replacement-cannot-forge-compilation` (rf2-8nn5k's own forge arm) | 24 FAIL — passed only because its `:compiled` set was hand-authored | unchanged, green |

Totals: 30 failures + 1 error red-before → 0 failures + 0 errors after.

Both new arms run in parallel and sequential compile modes and both bead probe
rows (`compiled-at` 1000 and 999 against `compile-start` 1000);
`assert-no-timestamp-corroboration!` proves from Shadow's own derivation that
its record is EMPTY for the recompile, so no correct verdict can come from it.

Per the bead's AC3 the corroborating fact is derived through the real
machinery, never inserted: `re-frame.ui.shadow-compile-model` drives the
installed passes through `cljs.analyzer/analyze*`'s own reduction, and
`witness-pass-is-driven-by-pinned-clojurescript` pins that model against the
REAL `cljs.analyzer/analyze*` on a real `(ns …)` form — including the case the
witness exists for, a viewless source whose only remaining form is its `ns`
form, analyzed while Shadow's compile state still reads `cljs.user`.

## Quality gates

| gate | result |
|---|---|
| `implementation/ui` JVM (`clojure -M:test`) | **821 tests, 14677 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` | **9961 tests, 49096 assertions, 0 failures, 0 errors** |
| `npm run test:ui-final-schedule` (real Shadow) | **PASS (parallel + sequential)** — cold accept, control warm pass, forge, forced-evict, fail-loud |
| `npm run test:ui-digest-carrier` | **PASS** (exit 0; it also re-runs final-schedule) |
| `scripts/check-playground-sci-freshness.sh` | **OK** — `implementation/ui` is not a playground input, no rebuild needed |

The real-Shadow gate is the load-bearing one for a provenance change and it
exercises every arm end-to-end: `control warm pass: both views survive, digest
stable, app-a not pre-touched` (warm-hit split intact), `forge pass: a
non-scheduling whole-map replacement failed the build before publication`,
`forced-evict pass: app-a evicted via reconcile, app-b byte-identical, digest
bd1-22b86317872965c7 -> bd1-63e33690e5bc260c`, and `fail-loud pass: unavailable
schedule evidence failed the build before publication`.
