### PR TITLE
fix(routing): attach runtime :schema to the four standard nav fx registrations (rf2-sqams)

### DIFF
--- a/implementation/routing/src/re_frame/routing/nav_fx.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_fx.cljc
@@ -17,6 +17,7 @@
   facade owns the two `fx/reg-fx` calls so a `:reload` re-wires them on
   a fresh registrar."
   (:require [re-frame.frame :as frame]
+            [re-frame.routing.nav-fx-schemas :as nav-fx-schemas]
             [re-frame.routing.strategy :as strategy]
             [re-frame.trace :as trace]))
 
@@ -282,8 +283,16 @@
   a carrier) AND break that behavioural surface. The carrier-bearing URL
   classes EP-0015 actually targets — the route-MISS / malformed / blocked
   URLs — are scrubbed at their diagnostic emit sites via
-  `re-frame.routing.egress/redact-url-carriers` (rf2-n1f4rh / rf2-jfaucw)."
+  `re-frame.routing.egress/redact-url-carriers` (rf2-n1f4rh / rf2-jfaucw).
+
+  rf2-sqams: carries the `:rf.fx.nav/push-url-args` `:schema` per
+  [Spec-Schemas §Standard fx args schemas] ('the standard fx ship with
+  `:schema` set to the corresponding schema above'). A non-string arg is
+  now rejected at the Spec 010 §step-5 `:fx-args` boundary — the fx is
+  skipped BEFORE `window.history` is touched — instead of reaching
+  `pushState`."
   {:platforms #{:client}
+   :schema    nav-fx-schemas/push-url-args
    :doc       "Push the URL to the browser history (HTML5 pushState).
 Honours the calling frame's `:url-bound?` metadata: non-URL-bound frames
 no-op the fx so they don't race with the URL-owning frame (per Spec 012
@@ -316,8 +325,14 @@ no-op the fx so they don't race with the URL-owning frame (per Spec 012
   reason (the `:effects-routed` contract asserts the real routed URL, the
   open-redirect gate already cleared it, and a blanket redaction over-reaches
   bare paths). Carrier-bearing route-miss / blocked URLs are scrubbed at
-  their diagnostic emit sites (`egress/redact-url-carriers`)."
+  their diagnostic emit sites (`egress/redact-url-carriers`).
+
+  rf2-sqams: carries the `:rf.fx.nav/replace-url-args` `:schema`, the
+  same `:string` gate its `:rf.nav/push-url` sibling now carries — the
+  two history fxs must not have asymmetric args-validation any more than
+  they have asymmetric drain-survival (rf2-u8qe7y finding 2)."
   {:platforms #{:client}
+   :schema    nav-fx-schemas/replace-url-args
    :doc       "Replace the URL in the browser history (HTML5 replaceState).
 Honours the calling frame's `:url-bound?` metadata: non-URL-bound frames
 no-op the fx so they don't race with the URL-owning frame (per Spec 012

--- a/implementation/routing/src/re_frame/routing/nav_fx_schemas.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_fx_schemas.cljc
@@ -1,0 +1,123 @@
+(ns re-frame.routing.nav-fx-schemas
+  "Malli args schemas for the four standard `:rf.nav/*` navigation fx.
+  Per Spec 012 §Multi-frame routing §Scroll restoration and
+  [Spec-Schemas §Standard fx args schemas], which states normatively
+  that 'the standard fx ship with `:schema` set to the corresponding
+  schema above'. These are the `:rf.fx.nav/*-args` schemas the spec
+  names as registered.
+
+  The schemas here are **plain Malli forms** — vectors, keywords, and
+  `clojure.core` predicates; no Malli code dependency. The routing
+  artefact does NOT depend on Malli / the schemas artefact in
+  production (Spec 006 §Adapter shipping convention — schemas is an
+  optional sibling). The `:schema` value a `reg-fx` carries is consumed
+  by whatever validator the (optional) schemas artefact has installed —
+  `re-frame.fx` resolves the `:schemas/validate-fx!` late-bind hook and
+  calls it only when the registration meta actually carries a
+  `:schema`, per Spec 010 §Validation order step 5. With schemas /
+  Malli absent the hook is unbound and fx-args validation soft-passes;
+  these vars are inert data that still travels with the registration so
+  the `:schema` boundary EXISTS the moment a validator is present.
+
+  Attaching these to the registrations makes malformed navigation args
+  surface at the `:fx-args` boundary — and, per Spec 010 §Per-step
+  recovery row 5, skip the offending fx — while the dispatching event
+  is still in scope, BEFORE the handler mutates browser history, the
+  scroll position, or the host-side scroll-position cache.
+
+  Spec ↔ var map (per [Spec-Schemas §Standard fx args schemas]):
+
+    :rf.fx.nav/push-url-args       — `push-url-args`
+    :rf.fx.nav/replace-url-args    — `replace-url-args`
+    :rf.fx.nav/scroll-args         — `scroll-args`
+    :rf.fx.nav/capture-scroll-args — `capture-scroll-args`
+
+  These are SHAPE checks — the structural contract on the fx args. The
+  same-origin / open-redirect gate (`re-frame.routing.url/safe-in-app-url?`
+  at the nav-event sinks) and the CLJS `run-history-mutation!` try/catch
+  are SEPARATE, complementary defence layers an args schema cannot
+  express (a cross-origin URL is still a `:string`).
+
+  Internal namespace; the public facade is `re-frame.routing`, which
+  owns the `fx/reg-fx` calls these schemas ride on.")
+
+;; ---- :rf.nav/push-url / :rf.nav/replace-url -------------------------------
+
+(def push-url-args
+  "Args of `:rf.nav/push-url` — `:rf.fx.nav/push-url-args`.
+  The PATH-FORM app URL to push onto the browser history. Every emit
+  site (`navigate/…`, `can-leave/…`, `url-change/…`) threads a
+  `registry/route-url` reconstruction or the requested URL string, so a
+  bare `:string` is the exact shape. The strategy `:encode` that maps
+  path-form → final href runs INSIDE the handler, after this gate."
+  :string)
+
+(def replace-url-args
+  "Args of `:rf.nav/replace-url` — `:rf.fx.nav/replace-url-args`.
+  Same path-form app URL string as `:rf.nav/push-url`; the fx differs
+  only in driving `replaceState` rather than `pushState`."
+  :string)
+
+;; ---- :rf.nav/scroll -------------------------------------------------------
+
+(def scroll-args
+  "Args of `:rf.nav/scroll` — `:rf.fx.nav/scroll-args`. Per Spec 012
+  §Scroll restoration §`:rf.nav/scroll` integration the shape is
+  `{:strategy :from :to :saved-pos :fragment}`, which is exactly what
+  `re-frame.routing.scroll/scroll-fx-entry` assembles.
+
+  `:strategy` is REQUIRED — `scroll-fx-entry` always seeds it, and a
+  strategy-less scroll has no defensible interpretation. It is either
+  one of the three standard keywords or a MAP (the host-extensible
+  form, which the handler passes to its default no-op branch). A bare
+  non-standard KEYWORD is deliberately NOT admitted: Spec 012 offers
+  the map form for host extension, and the handler's `nil` default is
+  defence-in-depth rather than a documented extension point.
+
+  `:saved-pos` members are `number?`, not `:int`. The position is read
+  straight off `window.scrollX` / `window.scrollY`, which are
+  FRACTIONAL at non-100% browser zoom and on HiDPI displays — an
+  integer-only tuple would reject valid captured positions. `number?`
+  also admits the plain integer pairs the JVM-side planning tests
+  thread.
+
+  `:from` / `:to` are the `{:id :params :query}` route descriptors
+  `scroll/route-descriptor*` builds — purely DIAGNOSTIC carriers the
+  handler ignores (hence their EP-0015 `:sensitive` path-marks on the
+  registration). Both are optional: the initial navigation has no
+  `:from`, and `scroll-fx-entry` omits either when nil."
+  [:map
+   [:strategy  [:or
+                [:enum :top :restore :preserve]
+                :map]]                                                  ;; map form is host-extensible (post-v1)
+   [:from      {:optional true} [:map
+                                 [:id     :keyword]
+                                 [:params {:optional true} :map]
+                                 [:query  {:optional true} :map]]]
+   [:to        {:optional true} [:map
+                                 [:id     :keyword]
+                                 [:params {:optional true} :map]
+                                 [:query  {:optional true} :map]]]
+   [:saved-pos {:optional true} [:tuple number? number?]]               ;; fractional at non-100% zoom / HiDPI
+   [:fragment  {:optional true} :string]])                              ;; `#fragment` of the target URL
+
+;; ---- :rf.nav/capture-scroll ----------------------------------------------
+
+(def capture-scroll-args
+  "Args of `:rf.nav/capture-scroll` — `:rf.fx.nav/capture-scroll-args`.
+  Save the leaving route's scroll position into the host-side per-frame
+  transient scroll-position cache, keyed by that route's reconstructed
+  URL. `re-frame.routing.scroll/capture-scroll-fx-entry` emits exactly
+  `{:url <leaving-url>}`, so `:url` is REQUIRED — it is the cache key,
+  and a capture without one saves nothing. (The handler's `when url`
+  nil-guard is defence-in-depth, not a documented graceful-degradation
+  path of the kind `:rf.server/redirect`'s target-less case is.)
+
+  The handler also honours an optional `:position` override in place of
+  reading `window.scrollX/Y`. That slot is an INTERNAL / TEST INJECTION
+  SEAM, not public API: no framework path emits it and Spec 012 does
+  not offer it, so it is deliberately absent from this public args
+  shape. Malli maps are open by default, so a test that injects
+  `:position` still validates — it just is not a promise."
+  [:map
+   [:url :string]])                                                     ;; the leaving route's reconstructed URL (cache key)

--- a/implementation/routing/src/re_frame/routing/scroll.cljc
+++ b/implementation/routing/src/re_frame/routing/scroll.cljc
@@ -32,6 +32,7 @@
   facade owns the two `fx/reg-fx` calls so a `:reload` re-wires them on
   a fresh registrar."
   (:require [re-frame.frame :as frame]
+            [re-frame.routing.nav-fx-schemas :as nav-fx-schemas]
             [re-frame.routing.registry :as registry]
             [re-frame.trace :as trace]))
 
@@ -223,9 +224,18 @@
   (`re-frame.classification/project-trace-event` via `re-frame.trace/build-event`)
   redacts it to `:rf/redacted` on the EGRESS copy — the handler still
   receives the real URL in-process (the projection touches only the trace
-  tags, never the handler input), so scroll capture keeps working."
+  tags, never the handler input), so scroll capture keeps working.
+
+  rf2-sqams: carries the `:rf.fx.nav/capture-scroll-args` `:schema`
+  (`[:map [:url :string]]`) per [Spec-Schemas §Standard fx args
+  schemas]. `:url` is the cache KEY, so a missing / non-string one now
+  fails at the Spec 010 §step-5 `:fx-args` boundary rather than
+  silently writing nothing (or a garbage key) into the host-side
+  scroll-position cache. Malli maps are open, so the handler's internal
+  `:position` test-injection seam still validates."
   {:platforms #{:client}
    :sensitive [[:url]]
+   :schema    nav-fx-schemas/capture-scroll-args
    :doc       "Capture the current browser scroll position into the
 host-side per-frame transient scroll-position cache (keyed by url)
 before leaving a route. The cache is NOT runtime-db state and does not
@@ -278,11 +288,21 @@ egress to trace / epochs / SSR (rf2-1hncp2)."})
   mechanism) — route params/query/fragment are always carrier-shaped, so a
   blanket trace scrub of those slots is the correct posture rather than a
   per-route schema decision (which the fx layer cannot make — it does not
-  carry the matched route's schema)."
+  carry the matched route's schema).
+
+  rf2-sqams: carries the `:rf.fx.nav/scroll-args` `:schema` per
+  [Spec-Schemas §Standard fx args schemas]. The gate is orthogonal to
+  the `:sensitive` marks above — `:schema` runs on the handler's INPUT
+  (Spec 010 §step 5, before the handler), the marks run on the trace
+  EGRESS copy (after). `:saved-pos` members are `number?` rather than
+  `:int` because `window.scrollX/Y` are fractional at non-100% zoom and
+  on HiDPI displays; the `:fragment` slot is optional. See
+  `nav-fx-schemas/scroll-args` for the full rationale."
   {:platforms #{:client}
    :sensitive [[:from :params] [:from :query]
                [:to :params]   [:to :query]
                [:fragment]]
+   :schema    nav-fx-schemas/scroll-args
    :doc       "Per Spec 012 §Scroll restoration. Args: {:strategy :from
 :to :saved-pos :fragment}. Standard strategies are :top, :restore,
 :preserve. Map-form strategies are host-extensible; the runtime treats

--- a/implementation/routing/test/re_frame/routing_nav_fx_schemas_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_nav_fx_schemas_cljs_test.cljs
@@ -1,0 +1,339 @@
+(ns re-frame.routing-nav-fx-schemas-cljs-test
+  "rf2-sqams — END-TO-END proof that the runtime `:schema` on the four
+  standard `:rf.nav/*` fx actually gates the handlers.
+
+  The JVM sibling (`routing_nav_fx_schemas_test.clj`) adjudicates the
+  schema shapes and the wired `:schemas/validate-fx!` hook. It CANNOT
+  prove the skip: all four nav fx are `:platforms #{:client}`, so on the
+  JVM `re-frame.fx/handle-one-fx` short-circuits to
+  `:rf.fx/skipped-on-platform` BEFORE reaching the Spec 010 §step-5
+  validation branch. The client host is the only place the gate fires,
+  so the behavioural assertions live here.
+
+  Each test drives a real `dispatch-sync` whose `:fx` vector carries a
+  malformed nav effect plus a well-formed sibling, then asserts:
+
+  - the malformed fx's OBSERVABLE side effect did not happen (no history
+    entry pushed, no scroll performed, nothing written to the host-side
+    scroll-position cache) — the handler never ran;
+  - the sibling fx in the same `:fx` vector still ran (Spec 010 §Per-step
+    recovery row 5: `:recovery :skipped` drops the offending fx only, it
+    does not halt the cascade);
+  - a `:rf.error/schema-validation-failure :where :fx-args` trace fired.
+
+  And, as the POSITIVE controls that matter most, that every shape the
+  runtime legitimately emits still drives its handler — including a
+  FRACTIONAL `:saved-pos` (`window.scrollX/Y` are fractional at non-100%
+  zoom and on HiDPI displays) and the optional `:fragment` slot.
+
+  `re-frame.schemas` is required explicitly: the fx-args gate exists
+  only when the optional schemas artefact has published
+  `:schemas/validate-fx!` (absent it, validation soft-passes per Spec
+  010 §Recommended soft-pass).
+
+  Window / history / scroll stubs come from the shared
+  `re-frame.routing-browser-test-support` fixture (Node has no DOM); its
+  `scrollTo` mirrors browser state onto the `scrollX` / `scrollY` fields
+  `:rf.nav/capture-scroll` reads."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
+            [re-frame.routing :as routing]
+            [re-frame.routing.scroll :as scroll]
+            ;; The optional schemas artefact — publishes :schemas/validate-fx!.
+            [re-frame.schemas]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.routing-browser-test-support
+             :refer [*history-state* current-url with-window-stub-fixture]])
+  (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
+
+(use-fixtures :each
+  with-window-stub-fixture
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter
+     :init-fn (fn []
+                (routing/reset-counters!)
+                (routing/reset-scroll-cache!))}))
+
+;; ---- helpers -------------------------------------------------------------
+
+(defn- own-the-url!
+  "Declare `:rf/default` the URL owner. EP-0002 (rf2-9o48ih): URL
+  ownership is an EXPLICIT declaration — without this the history fxs
+  no-op for a reason unrelated to schema validation, which would make a
+  'nothing was pushed' assertion vacuous."
+  []
+  (rf/make-frame {:id :rf/default :url-bound? true}))
+
+(defn- sibling-calls
+  "Register a plain user fx that records its invocations. Used as the
+  cascade-continues witness in every skip test: the malformed nav fx must
+  be the ONLY casualty."
+  []
+  (let [calls (atom 0)]
+    (rf/reg-fx :test/witness
+               {:platforms #{:server :client}}
+               (fn [_ _] (swap! calls inc)))
+    calls))
+
+(defn- violations
+  "The `:rf.error/schema-validation-failure` events in a trace recording."
+  [traces]
+  (filterv #(= :rf.error/schema-validation-failure (:operation %)) traces))
+
+(defn- scroll-xy []
+  [(.-scrollX js/window) (.-scrollY js/window)])
+
+(defn- set-scroll! [x y]
+  (set! (.-scrollX js/window) x)
+  (set! (.-scrollY js/window) y))
+
+;; =========================================================================
+;; 0. Precondition — the gate is actually installed on this host
+;; =========================================================================
+
+(deftest nav-fx-registrations-carry-schema-on-cljs
+  (testing "rf2-sqams: the four standard nav fx carry a :schema on the CLJS
+            host too — the .cljc registrations are shared, but the gate only
+            ever FIRES here, so the precondition is worth pinning where it
+            matters"
+    (doseq [fx-id [:rf.nav/push-url :rf.nav/replace-url
+                   :rf.nav/scroll :rf.nav/capture-scroll]]
+      (is (some? (:schema (registrar/lookup :fx fx-id)))
+          (str fx-id " carries a runtime :schema")))))
+
+;; =========================================================================
+;; 1. :rf.nav/push-url + :rf.nav/replace-url — history is not touched
+;; =========================================================================
+
+(deftest push-url-with-malformed-args-never-reaches-pushstate
+  (testing "rf2-sqams: a non-string :rf.nav/push-url arg is rejected at the
+            fx-args boundary — window.history.pushState is NOT called, and
+            the sibling fx in the same :fx vector still runs"
+    (own-the-url!)
+    (let [witness (sibling-calls)
+          before  (:entries @*history-state*)]
+      (rf/reg-event :test/bad-push
+                    (fn [_ _]
+                      {:fx [[:rf.nav/push-url :route/cart]   ;; bad: a route-id
+                            [:test/witness    nil]]}))
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [:test/bad-push])
+        (is (= before (:entries @*history-state*))
+            "no history entry was pushed — the handler never ran")
+        (is (= 1 @witness)
+            "the sibling fx still ran (Spec 010 row 5: :skipped, not halted)")
+        (is (= 1 (count (violations @traces)))
+            "exactly one :rf.error/schema-validation-failure fired")
+        (let [v (first (violations @traces))]
+          (is (= :fx-args (-> v :tags :where)))
+          (is (= :rf.nav/push-url (-> v :tags :rf.fx/id)))
+          (is (= :skipped (:recovery v))))))))
+
+(deftest push-url-with-a-well-formed-url-still-pushes
+  (testing "POSITIVE control: the schema does not break working navigation —
+            a path-form URL string drives pushState exactly as before"
+    (own-the-url!)
+    (rf/reg-event :test/good-push
+                  (fn [_ _] {:fx [[:rf.nav/push-url "/cart"]]}))
+    (with-trace-recorder! [traces]
+      (rf/dispatch-sync [:test/good-push])
+      (is (= "/cart" (current-url *history-state*))
+          "the URL was pushed onto the history stack")
+      (is (empty? (violations @traces))
+          "no schema-validation-failure for a conforming URL"))))
+
+(deftest replace-url-with-malformed-args-never-reaches-replacestate
+  (testing "rf2-sqams: :rf.nav/replace-url carries the SAME gate as its
+            push sibling — the two history fxs must not have asymmetric
+            args validation any more than asymmetric drain survival"
+    (own-the-url!)
+    (rf/reg-event :test/good-push
+                  (fn [_ _] {:fx [[:rf.nav/push-url "/cart"]]}))
+    (rf/dispatch-sync [:test/good-push])
+    (let [witness (sibling-calls)]
+      (rf/reg-event :test/bad-replace
+                    (fn [_ _]
+                      {:fx [[:rf.nav/replace-url 42]         ;; bad: not a string
+                            [:test/witness       nil]]}))
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [:test/bad-replace])
+        (is (= "/cart" (current-url *history-state*))
+            "replaceState was NOT called — the URL is unchanged")
+        (is (= 1 @witness) "the sibling fx still ran")
+        (is (= 1 (count (violations @traces))))
+        (is (= :rf.nav/replace-url
+               (-> (violations @traces) first :tags :rf.fx/id)))))))
+
+(deftest replace-url-with-a-well-formed-url-still-replaces
+  (testing "POSITIVE control: a conforming URL still drives replaceState"
+    (own-the-url!)
+    (rf/reg-event :test/good-replace
+                  (fn [_ _] {:fx [[:rf.nav/replace-url "/checkout"]]}))
+    (with-trace-recorder! [traces]
+      (rf/dispatch-sync [:test/good-replace])
+      (is (= "/checkout" (current-url *history-state*)))
+      (is (empty? (violations @traces))))))
+
+;; =========================================================================
+;; 2. :rf.nav/capture-scroll — the host-side cache is not written
+;; =========================================================================
+
+(deftest capture-scroll-with-malformed-args-never-writes-the-cache
+  (testing "rf2-sqams: :url is the cache KEY, so a capture without one (or
+            with a non-string one) must fail BEFORE the handler writes the
+            host-side per-frame scroll-position cache"
+    (set-scroll! 0 640)
+    (let [witness (sibling-calls)]
+      (rf/reg-event :test/bad-capture
+                    (fn [_ _]
+                      {:fx [[:rf.nav/capture-scroll {:position [1 2]}] ;; bad: no :url
+                            [:test/witness          nil]]}))
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [:test/bad-capture])
+        (is (nil? (scroll/frame-scroll-cache :rf/default))
+            "nothing was written to the scroll-position cache")
+        (is (= 1 @witness) "the sibling fx still ran")
+        (is (= 1 (count (violations @traces))))
+        (is (= :rf.nav/capture-scroll
+               (-> (violations @traces) first :tags :rf.fx/id)))))))
+
+(deftest capture-scroll-with-a-non-string-url-never-writes-the-cache
+  (testing "rf2-sqams: a keyword :url would key the LRU cache with a value
+            the symmetric restore lookup can never reconstruct"
+    (rf/reg-event :test/kw-capture
+                  (fn [_ _]
+                    {:fx [[:rf.nav/capture-scroll {:url :route/cart}]]}))
+    (with-trace-recorder! [traces]
+      (rf/dispatch-sync [:test/kw-capture])
+      (is (nil? (scroll/frame-scroll-cache :rf/default))
+          "a keyword :url never reached the cache")
+      (is (= 1 (count (violations @traces)))))))
+
+(deftest capture-scroll-with-a-well-formed-url-still-captures
+  (testing "POSITIVE control: {:url <string>} still captures — and the
+            FRACTIONAL window.scrollX/Y a HiDPI / zoomed browser reports is
+            stored verbatim, which is exactly why rf2-cmdpj relaxed the
+            spec's :saved-pos members from :int to number?"
+    (set-scroll! 0.5 1234.75)
+    (rf/reg-event :test/good-capture
+                  (fn [_ _] {:fx [[:rf.nav/capture-scroll {:url "/cart"}]]}))
+    (with-trace-recorder! [traces]
+      (rf/dispatch-sync [:test/good-capture])
+      (is (= [0.5 1234.75]
+             (scroll/lookup-scroll-position
+               (scroll/frame-scroll-cache :rf/default) "/cart"))
+          "the fractional captured position round-tripped into the cache")
+      (is (empty? (violations @traces))
+          "a fractional scroll position is NOT a schema violation"))))
+
+;; =========================================================================
+;; 3. :rf.nav/scroll — the window is not scrolled
+;; =========================================================================
+
+(deftest scroll-with-a-non-standard-keyword-strategy-never-scrolls
+  (testing "rf2-sqams: Spec 012 offers the MAP form for host extension; a
+            bare non-standard keyword is a typo, and the handler's nil
+            default branch silently swallowed it. It is now rejected at
+            the args boundary and surfaced as a violation"
+    (set-scroll! 0 500)
+    (let [witness (sibling-calls)]
+      (rf/reg-event :test/bad-scroll
+                    (fn [_ _]
+                      {:fx [[:rf.nav/scroll {:strategy :smooth}] ;; bad: not :top/:restore/:preserve
+                            [:test/witness  nil]]}))
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [:test/bad-scroll])
+        (is (= [0 500] (scroll-xy))
+            "the window was not scrolled")
+        (is (= 1 @witness) "the sibling fx still ran")
+        (is (= 1 (count (violations @traces))))
+        (is (= :rf.nav/scroll
+               (-> (violations @traces) first :tags :rf.fx/id)))))))
+
+(deftest scroll-with-a-malformed-saved-pos-never-scrolls
+  (testing "rf2-sqams: a :restore whose :saved-pos is not a two-number tuple
+            would previously reach `.scrollTo` with garbage coordinates
+            (the handler's `sequential?` guard admits [\"0\" \"0\"])"
+    (set-scroll! 0 500)
+    (rf/reg-event :test/bad-saved-pos
+                  (fn [_ _]
+                    {:fx [[:rf.nav/scroll {:strategy :restore
+                                           :saved-pos ["0" "0"]}]]}))
+    (with-trace-recorder! [traces]
+      (rf/dispatch-sync [:test/bad-saved-pos])
+      (is (= [0 500] (scroll-xy))
+          "the window was not scrolled to the string coordinates")
+      (is (= 1 (count (violations @traces)))))))
+
+(deftest scroll-restore-with-a-fractional-saved-pos-still-scrolls
+  (testing "POSITIVE control (the one that matters most): a FRACTIONAL
+            :saved-pos — the shape a non-100%-zoom / HiDPI browser actually
+            captures — still drives `.scrollTo`. The pre-rf2-cmdpj spec
+            shape [:tuple :int :int] would have rejected this and silently
+            broken Back-button scroll restoration for every zoomed user"
+    (set-scroll! 0 0)
+    (rf/reg-event :test/restore
+                  (fn [_ _]
+                    {:fx [[:rf.nav/scroll {:strategy  :restore
+                                           :saved-pos [0.5 1234.75]}]]}))
+    (with-trace-recorder! [traces]
+      (rf/dispatch-sync [:test/restore])
+      (is (= [0.5 1234.75] (scroll-xy))
+          "the window was scrolled to the fractional saved position")
+      (is (empty? (violations @traces))))))
+
+(deftest scroll-with-the-full-planner-args-still-scrolls
+  (testing "POSITIVE control: the FULL five-slot args plan/scroll-plan
+            assembles — :strategy + :from + :to + :saved-pos + the optional
+            :fragment — pass the gate and drive the handler"
+    (set-scroll! 0 0)
+    (rf/reg-event :test/full-scroll
+                  (fn [_ _]
+                    {:fx [[:rf.nav/scroll
+                           {:strategy  :restore
+                            :from      {:id :route/cart
+                                        :params {:id "7"}
+                                        :query  {:q "shoes"}}
+                            :to        {:id :route/checkout}
+                            :saved-pos [12 3400.5]
+                            :fragment  "section-3"}]]}))
+    (with-trace-recorder! [traces]
+      (rf/dispatch-sync [:test/full-scroll])
+      (is (= [12 3400.5] (scroll-xy))
+          "the full planner args drove the restore")
+      (is (empty? (violations @traces))
+          "no violation for the canonical planner output"))))
+
+(deftest scroll-top-with-an-optional-fragment-still-scrolls
+  (testing "POSITIVE control: the optional :fragment slot rf2-cmdpj added to
+            the spec shape validates. The stub's getElementById returns nil,
+            so the handler falls through to `.scrollTo 0 0` — the point is
+            that the ARGS passed the gate, not which branch ran"
+    (set-scroll! 0 900)
+    (rf/reg-event :test/top-fragment
+                  (fn [_ _]
+                    {:fx [[:rf.nav/scroll {:strategy :top
+                                           :fragment "install"}]]}))
+    (with-trace-recorder! [traces]
+      (rf/dispatch-sync [:test/top-fragment])
+      (is (= [0 0] (scroll-xy))
+          "the :top branch ran — args carrying :fragment were not rejected")
+      (is (empty? (violations @traces))))))
+
+(deftest scroll-with-a-map-form-strategy-still-passes
+  (testing "POSITIVE control: the host-extensible MAP strategy form (pinned
+            by routing_scroll_test as flowing through verbatim) validates —
+            the handler's default no-op branch is reached, not the gate"
+    (set-scroll! 0 700)
+    (rf/reg-event :test/map-strategy
+                  (fn [_ _]
+                    {:fx [[:rf.nav/scroll
+                           {:strategy {:behavior :smooth :block :center}}]]}))
+    (with-trace-recorder! [traces]
+      (rf/dispatch-sync [:test/map-strategy])
+      (is (= [0 700] (scroll-xy))
+          "unknown map strategy → handler no-op, window untouched")
+      (is (empty? (violations @traces))
+          "a map-form strategy is NOT a schema violation"))))

--- a/implementation/routing/test/re_frame/routing_nav_fx_schemas_test.clj
+++ b/implementation/routing/test/re_frame/routing_nav_fx_schemas_test.clj
@@ -1,0 +1,380 @@
+(ns re-frame.routing-nav-fx-schemas-test
+  "rf2-sqams — runtime `:schema` on the four standard `:rf.nav/*` fx.
+
+  [Spec-Schemas §Standard fx args schemas] states normatively that 'the
+  standard fx ship with `:schema` set to the corresponding schema
+  above'. The four navigation registrations carried `:platforms` /
+  `:doc` / `:sensitive` but no `:schema`, so — since
+  `re-frame.fx/handle-one-fx` consults the `:schemas/validate-fx!` hook
+  ONLY when the registration meta actually carries a `:schema` (Spec 010
+  §Validation order step 5) — malformed navigation args bypassed the
+  promised structural boundary entirely. rf2-cmdpj (#6296) landed the
+  spec half; this suite pins the runtime half.
+
+  Two layers are asserted here:
+
+  1. WIRING — each registration's meta carries the `:schema` value, and
+     it is the corresponding `nav-fx-schemas` var (not a copy that could
+     drift).
+  2. ADJUDICATION — the real registered schema, run through Malli,
+     accepts every shape the runtime legitimately emits and rejects
+     adversarial ones. The POSITIVE controls matter as much as the
+     negatives: a schema that broke working navigation would be worse
+     than no schema at all. In particular `:saved-pos` must admit
+     FRACTIONAL members (`window.scrollX/Y` are fractional at non-100%
+     zoom and on HiDPI displays — the pre-#6296 `[:tuple :int :int]`
+     spec shape rejected valid captures) and the five-slot scroll args
+     including `:fragment` must validate.
+  3. BOUNDARY — the real `:schemas/validate-fx!` late-bind hook (the
+     exact fn `re-frame.fx` calls) returns false for malformed args and
+     emits `:rf.error/schema-validation-failure :where :fx-args` with
+     `:recovery :skipped`.
+
+  The END-TO-END skip proof lives in the CLJS sibling
+  (`routing_nav_fx_schemas_cljs_test.cljs`): all four fx are
+  `:platforms #{:client}`, so on the JVM `handle-one-fx` short-circuits
+  to `:rf.fx/skipped-on-platform` BEFORE the validation branch — the
+  args gate can only actually fire on the client host."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [malli.core :as m]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.registrar :as registrar]
+            [re-frame.routing.nav-fx :as nav-fx]
+            [re-frame.routing.nav-fx-schemas :as nav-fx-schemas]
+            [re-frame.routing.scroll :as scroll]
+            [re-frame.test-support :refer [with-trace-recorder!]]
+            [re-frame.routing-test-support :as rts]))
+
+(use-fixtures :each rts/reset-runtime)
+
+(def ^:private fx-id->schema-var
+  "The four standard navigation fx and the `nav-fx-schemas` var each
+  MUST carry, per [Spec-Schemas §Standard fx args schemas]."
+  {:rf.nav/push-url       #'nav-fx-schemas/push-url-args
+   :rf.nav/replace-url    #'nav-fx-schemas/replace-url-args
+   :rf.nav/scroll         #'nav-fx-schemas/scroll-args
+   :rf.nav/capture-scroll #'nav-fx-schemas/capture-scroll-args})
+
+(defn- registered-schema
+  "The `:schema` on the LIVE `:rf.nav/*` fx registration — read through
+  the registrar, so every assertion below adjudicates what the runtime
+  would actually validate against rather than a var the registration
+  might not reference."
+  [fx-id]
+  (:schema (registrar/lookup :fx fx-id)))
+
+;; =========================================================================
+;; 1. Wiring — every standard nav fx registration carries its :schema
+;; =========================================================================
+
+(deftest standard-nav-fx-registrations-carry-schema
+  (testing "rf2-sqams: each of the four standard :rf.nav/* fx registrations
+            carries a :schema, and it is the corresponding nav-fx-schemas
+            var — the drift tooth that keeps the four-member set aligned"
+    (doseq [[fx-id schema-var] fx-id->schema-var]
+      (let [meta* (registrar/lookup :fx fx-id)]
+        (is (some? meta*)
+            (str fx-id " is registered by the routing facade"))
+        (is (contains? meta* :schema)
+            (str fx-id " registration carries a :schema — without it "
+                 "re-frame.fx skips the Spec 010 step-5 fx-args gate entirely"))
+        (is (= @schema-var (:schema meta*))
+            (str fx-id "'s registered :schema IS " (symbol schema-var)
+                 " — not a drifting copy"))))))
+
+(deftest nav-fx-meta-vars-carry-schema
+  (testing "the :schema rides on the exported meta vars themselves, so a
+            facade `:reload` (which re-reads these vars) re-wires the gate"
+    (is (= nav-fx-schemas/push-url-args       (:schema nav-fx/push-url-meta)))
+    (is (= nav-fx-schemas/replace-url-args    (:schema nav-fx/replace-url-meta)))
+    (is (= nav-fx-schemas/scroll-args         (:schema scroll/scroll-fx-meta)))
+    (is (= nav-fx-schemas/capture-scroll-args (:schema scroll/capture-scroll-meta))))
+
+  (testing "the pre-existing EP-0015 :sensitive marks and :platforms survive —
+            :schema is additive, it does not displace the other meta"
+    (is (= #{:client} (:platforms scroll/scroll-fx-meta)))
+    (is (= [[:from :params] [:from :query]
+            [:to :params]   [:to :query]
+            [:fragment]]
+           (:sensitive scroll/scroll-fx-meta)))
+    (is (= [[:url]] (:sensitive scroll/capture-scroll-meta)))))
+
+(deftest nav-fx-schemas-are-valid-malli-schemas
+  (testing "every registered nav-fx schema compiles under Malli — an
+            uncompilable schema would throw inside validate-fx! and the
+            fail-closed catch would silently skip real navigation"
+    (doseq [[fx-id _] fx-id->schema-var]
+      (is (some? (m/schema (registered-schema fx-id)))
+          (str fx-id "'s :schema is a well-formed Malli schema")))))
+
+;; =========================================================================
+;; 2. Adjudication — :rf.nav/push-url + :rf.nav/replace-url (:string)
+;; =========================================================================
+
+(deftest history-fx-schemas-accept-the-urls-the-runtime-emits
+  (testing "POSITIVE control: every path-form URL shape the emit sites
+            (navigate / can-leave / url-change) thread through validates"
+    (doseq [fx-id [:rf.nav/push-url :rf.nav/replace-url]
+            url   ["/"
+                   "/cart"
+                   "/articles/42"
+                   "/search?q=shoes&page=2"
+                   "/docs/intro#install"
+                   "#/hash-app-route"          ;; hash strategy, encoded downstream
+                   "/demos#/based-hash"        ;; base OUTSIDE the fragment
+                   ""]]                        ;; degenerate but structurally a string
+      (is (m/validate (registered-schema fx-id) url)
+          (str fx-id " accepts the legitimately-emitted URL " (pr-str url))))))
+
+(deftest history-fx-schemas-reject-non-string-urls
+  (testing "ADVERSARIAL: a non-string URL is rejected BEFORE window.history
+            is touched — previously these reached pushState/replaceState"
+    (doseq [fx-id [:rf.nav/push-url :rf.nav/replace-url]
+            bad   [nil
+                   42
+                   :route/cart                       ;; a route-id, not a URL
+                   {:url "/cart"}                    ;; the capture-scroll shape
+                   ["/cart"]
+                   ['(:rf.nav/push-url "/cart")]]]   ;; a whole fx entry
+      (is (not (m/validate (registered-schema fx-id) bad))
+          (str fx-id " rejects " (pr-str bad))))))
+
+;; =========================================================================
+;; 3. Adjudication — :rf.nav/scroll
+;; =========================================================================
+
+(deftest scroll-fx-schema-accepts-every-planner-output
+  (let [schema (registered-schema :rf.nav/scroll)]
+    (testing "POSITIVE control: the three standard strategies validate"
+      (doseq [strategy [:top :restore :preserve]]
+        (is (m/validate schema {:strategy strategy})
+            (str "bare :strategy " strategy " validates"))))
+
+    (testing "POSITIVE control: a map-form (host-extensible) strategy validates
+              — routing_scroll_test pins that {:behavior :smooth :block :center}
+              flows into the fx args verbatim"
+      (is (m/validate schema {:strategy {:behavior :smooth :block :center}}))
+      (is (m/validate schema {:strategy {}})))
+
+    (testing "POSITIVE control: the FULL five-slot planner output — the exact
+              shape plan/scroll-plan assembles — validates, :fragment included"
+      (is (m/validate schema
+                      {:strategy  :restore
+                       :from      {:id :route/cart :params {:id "7"} :query {:q "x"}}
+                       :to        {:id :route/checkout}
+                       :saved-pos [120 3400]
+                       :fragment  "section-3"})
+          "full :strategy/:from/:to/:saved-pos/:fragment args validate"))
+
+    (testing "POSITIVE control (rf2-cmdpj): FRACTIONAL :saved-pos members
+              validate. window.scrollX/Y are fractional at non-100% browser
+              zoom and on HiDPI displays; the pre-#6296 [:tuple :int :int]
+              shape rejected genuinely-captured positions, which is why the
+              spec relaxed both members to number?"
+      (is (m/validate schema {:strategy :restore :saved-pos [0.5 1234.75]})
+          "both members fractional")
+      (is (m/validate schema {:strategy :restore :saved-pos [0 1234.75]})
+          "mixed integer / fractional — the HiDPI y-only case")
+      (is (m/validate schema {:strategy :restore :saved-pos [120 3400]})
+          "plain integer pairs (what the JVM planning tests thread) still pass")
+      (is (m/validate schema {:strategy :restore :saved-pos [-0.5 0.0]})
+          "negative / zero doubles — elastic-scroll overscroll positions"))
+
+    (testing "POSITIVE control: :fragment alone (the :top + fragment branch —
+              scroll-fx-handler scrolls the element into view)"
+      (is (m/validate schema {:strategy :top :fragment "install"})))
+
+    (testing "POSITIVE control: :from omitted on the initial navigation
+              (scroll-fx-entry drops nil slots via cond->)"
+      (is (m/validate schema {:strategy :top :to {:id :route/home}})))
+
+    (testing "POSITIVE control: a descriptor with neither :params nor :query —
+              route-descriptor* includes them only when non-empty"
+      (is (m/validate schema {:strategy :top
+                              :from     {:id :route/home}
+                              :to       {:id :route/cart}})))))
+
+(deftest scroll-fx-schema-rejects-malformed-args
+  (let [schema (registered-schema :rf.nav/scroll)]
+    (testing "ADVERSARIAL: :strategy is REQUIRED — scroll-fx-entry always
+              seeds it, and a strategy-less scroll has no interpretation"
+      (is (not (m/validate schema {})))
+      (is (not (m/validate schema {:saved-pos [0 0]})))
+      (is (not (m/validate schema {:fragment "x"}))))
+
+    (testing "ADVERSARIAL: a bare non-standard KEYWORD strategy is rejected.
+              Spec 012 offers the MAP form for host extension; the handler's
+              nil default branch is defence-in-depth, not an extension point"
+      (is (not (m/validate schema {:strategy :smooth})))
+      (is (not (m/validate schema {:strategy :Top})))
+      (is (not (m/validate schema {:strategy "top"})))
+      (is (not (m/validate schema {:strategy nil}))))
+
+    (testing "ADVERSARIAL: `false` never reaches the fx — resolve-scroll-strategy
+              maps it to ::suppress and scroll-fx-entry returns nil, so a
+              `false` strategy arriving here is a planner bug worth catching"
+      (is (not (m/validate schema {:strategy false}))))
+
+    (testing "ADVERSARIAL: malformed :saved-pos"
+      (is (not (m/validate schema {:strategy :restore :saved-pos [0]}))
+          "one-member tuple")
+      (is (not (m/validate schema {:strategy :restore :saved-pos [0 0 0]}))
+          "three-member tuple")
+      (is (not (m/validate schema {:strategy :restore :saved-pos ["0" "0"]}))
+          "string members — a serialised position that never round-tripped")
+      (is (not (m/validate schema {:strategy :restore :saved-pos {:x 0 :y 0}}))
+          "map instead of a tuple")
+      (is (not (m/validate schema {:strategy :restore :saved-pos nil}))
+          "explicit nil — cond-> omits the slot rather than niling it"))
+
+    (testing "ADVERSARIAL: malformed :from / :to descriptors"
+      (is (not (m/validate schema {:strategy :top :from {}}))
+          ":id is required on a descriptor")
+      (is (not (m/validate schema {:strategy :top :to {:id "route/cart"}}))
+          ":id must be a keyword, not the stringified route name")
+      (is (not (m/validate schema {:strategy :top :from {:id :route/cart
+                                                         :params [[:id "7"]]}}))
+          ":params must be a map, not a seq of pairs")
+      (is (not (m/validate schema {:strategy :top :to :route/cart}))
+          "a bare route-id instead of a descriptor map"))
+
+    (testing "ADVERSARIAL: :fragment must be a string"
+      (is (not (m/validate schema {:strategy :top :fragment :install})))
+      (is (not (m/validate schema {:strategy :top :fragment 3}))))
+
+    (testing "ADVERSARIAL: args must be a map at all"
+      (is (not (m/validate schema :top)))
+      (is (not (m/validate schema [:top])))
+      (is (not (m/validate schema nil))))))
+
+;; =========================================================================
+;; 4. Adjudication — :rf.nav/capture-scroll
+;; =========================================================================
+
+(deftest capture-scroll-fx-schema-accepts-what-the-planner-emits
+  (let [schema (registered-schema :rf.nav/capture-scroll)]
+    (testing "POSITIVE control: capture-scroll-fx-entry emits exactly
+              {:url <leaving-url>} — every reconstructable URL validates"
+      (doseq [url ["/" "/cart" "/articles/42?ref=email" "/docs#install"]]
+        (is (m/validate schema {:url url})
+            (str "{:url " (pr-str url) "} validates"))))
+
+    (testing "POSITIVE control: the internal `:position` TEST INJECTION SEAM
+              still validates. Malli maps are OPEN, so the handler's
+              `(or position <window.scrollX/Y>)` override is tolerated
+              without being promised in the public shape"
+      (is (m/validate schema {:url "/cart" :position [10 20]}))
+      (is (m/validate schema {:url "/cart" :position [10.5 20.25]})))))
+
+(deftest capture-scroll-fx-schema-rejects-malformed-args
+  (let [schema (registered-schema :rf.nav/capture-scroll)]
+    (testing "ADVERSARIAL: :url is REQUIRED — it is the cache KEY, and a
+              capture without one writes nothing. The handler's `when url`
+              nil-guard is defence-in-depth, not a graceful-degradation
+              contract of the kind :rf.server/redirect's no-target case is"
+      (is (not (m/validate schema {})))
+      (is (not (m/validate schema {:position [0 0]})))
+      (is (not (m/validate schema {:url nil}))))
+
+    (testing "ADVERSARIAL: a non-string :url would key the LRU cache with a
+              value the symmetric restore lookup can never reconstruct"
+      (is (not (m/validate schema {:url :route/cart})))
+      (is (not (m/validate schema {:url 42})))
+      (is (not (m/validate schema {:url {:route-id :route/cart}}))))
+
+    (testing "ADVERSARIAL: args must be a map — the bare-URL-string shape
+              (the push-url args shape) is a real mix-up worth catching"
+      (is (not (m/validate schema "/cart")))
+      (is (not (m/validate schema nil))))))
+
+;; =========================================================================
+;; 5. Boundary — the real :schemas/validate-fx! hook re-frame.fx calls
+;; =========================================================================
+;;
+;; `re-frame.fx/handle-one-fx` resolves `:schemas/validate-fx!` through
+;; late-bind and calls it with `[fx-id event-id args meta frame continue?]`,
+;; skipping the fx when it returns false. These tests drive that exact fn
+;; with the exact registration meta, so they adjudicate the wired path
+;; rather than a reconstruction of it.
+
+(defn- validate-through-hook
+  "Call the live `:schemas/validate-fx!` hook with the LIVE registration
+  meta for `fx-id`. Returns the boolean `handle-one-fx` honours."
+  [fx-id args]
+  (let [validate-fx! (late-bind/get-fn :schemas/validate-fx!)]
+    (validate-fx! fx-id :test/originating-event args
+                  (registrar/lookup :fx fx-id))))
+
+(deftest validate-fx-hook-is-wired-for-the-nav-fx
+  (testing "the schemas artefact is on the routing test classpath and has
+            published :schemas/validate-fx! — the hook re-frame.fx consults"
+    (is (fn? (late-bind/get-fn :schemas/validate-fx!)))))
+
+(deftest nav-fx-args-pass-the-real-validation-hook-when-conforming
+  (testing "POSITIVE control through the WIRED path: everything the runtime
+            legitimately emits passes, fractional :saved-pos included"
+    (with-trace-recorder! [traces]
+      (is (true? (validate-through-hook :rf.nav/push-url "/cart")))
+      (is (true? (validate-through-hook :rf.nav/replace-url "/checkout")))
+      (is (true? (validate-through-hook :rf.nav/capture-scroll {:url "/cart"})))
+      (is (true? (validate-through-hook
+                   :rf.nav/scroll
+                   {:strategy  :restore
+                    :from      {:id :route/cart}
+                    :to        {:id :route/checkout}
+                    :saved-pos [0.5 1234.75]
+                    :fragment  "section-3"}))
+          "the full five-slot args with a FRACTIONAL :saved-pos pass")
+      (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
+                          @traces))
+          "no schema-validation-failure trace fires for conforming nav args"))))
+
+(deftest schema-less-nav-fx-meta-adjudicates-nothing
+  (testing "rf2-sqams RED-BEFORE control: the pre-sqams registration meta —
+            :platforms / :doc / :sensitive but NO :schema — passes args that
+            the live registration now rejects. This is the whole defect: an
+            fx-args gate exists only where a :schema does, so before this
+            change every malformed navigation arg reached its handler
+            unvalidated. Kept as a permanent control so a future edit that
+            drops a :schema cannot quietly reopen the hole while the
+            positive tests above still pass."
+    (doseq [[fx-id bad-args] {:rf.nav/push-url       :route/cart
+                              :rf.nav/replace-url    42
+                              :rf.nav/scroll         {:strategy :smooth}
+                              :rf.nav/capture-scroll {:position [0 0]}}]
+      (let [validate-fx!    (late-bind/get-fn :schemas/validate-fx!)
+            pre-sqams-meta  (dissoc (registrar/lookup :fx fx-id) :schema)]
+        (is (true? (validate-fx! fx-id :test/originating-event
+                                 bad-args pre-sqams-meta))
+            (str fx-id " with a schema-less meta soft-passes " (pr-str bad-args)
+                 " — the pre-sqams behaviour"))
+        (is (false? (validate-through-hook fx-id bad-args))
+            (str fx-id " with the LIVE (schema-bearing) meta rejects the same "
+                 "args — the boundary the spec promises now exists"))))))
+
+(deftest nav-fx-args-fail-the-real-validation-hook-when-malformed
+  (testing "ADVERSARIAL through the WIRED path: at least one malformed shape
+            per fx returns false, so handle-one-fx skips the fx (Spec 010
+            §Per-step recovery row 5) BEFORE the handler mutates history,
+            scroll position, or the capture cache"
+    (doseq [[fx-id bad-args] {:rf.nav/push-url       :route/cart
+                              :rf.nav/replace-url    42
+                              :rf.nav/scroll         {:strategy :smooth}
+                              :rf.nav/capture-scroll {:position [0 0]}}]
+      (with-trace-recorder! [traces]
+        (is (false? (validate-through-hook fx-id bad-args))
+            (str fx-id " with " (pr-str bad-args) " fails the wired gate"))
+        (let [violations (filter #(= :rf.error/schema-validation-failure
+                                     (:operation %))
+                                 @traces)]
+          (is (= 1 (count violations))
+              (str fx-id " emitted exactly one schema-validation-failure"))
+          (let [v (first violations)]
+            (is (= :fx-args (-> v :tags :where))
+                "the violation is tagged :where :fx-args (Spec 010 step 5)")
+            (is (= fx-id (-> v :tags :rf.fx/id)))
+            (is (= fx-id (-> v :tags :failing-id)))
+            (is (= :test/originating-event (-> v :tags :event-id))
+                "the originating event-id threads through")
+            (is (= :skipped (:recovery v))
+                "recovery is :skipped — the offending fx alone is dropped")))))))


### PR DESCRIPTION
Closes rf2-sqams. Runtime half of rf2-cmdpj (#6296, **merged** — this branch is rebased on it).

## The defect

[`spec/Spec-Schemas.md`](../blob/main/spec/Spec-Schemas.md) states normatively that *"the standard fx ship with `:schema` set to the corresponding schema above"*. The four `:rf.nav/*` registrations carried `:platforms` / `:doc` / `:sensitive` but **no `:schema`** — and `re-frame.fx/handle-one-fx` consults the `:schemas/validate-fx!` hook *only* when the registration meta actually carries a `:schema` (Spec 010 §Validation order step 5). So the promised structural boundary did not exist: every malformed navigation arg reached its handler unvalidated.

The spec was right and the runtime was the non-conforming side. #6296 deliberately did not soften the prose; this makes the runtime conform to it.

## What changed

New `implementation/routing/src/re_frame/routing/nav_fx_schemas.cljc` holds the four args schemas, then each is attached at its registration meta:

| fx | registration | schema |
|---|---|---|
| `:rf.nav/push-url` | `nav_fx.cljc:286` (`push-url-meta`) | `push-url-args` — `:string` |
| `:rf.nav/replace-url` | `nav_fx.cljc:326` (`replace-url-meta`) | `replace-url-args` — `:string` |
| `:rf.nav/scroll` | `scroll.cljc:289` (`scroll-fx-meta`) | `scroll-args` — the five-slot map |
| `:rf.nav/capture-scroll` | `scroll.cljc:238` (`capture-scroll-meta`) | `capture-scroll-args` — `[:map [:url :string]]` |

All four ride the `fx/reg-fx` calls the facade already makes at `routing.cljc:288-294`.

**Mechanism mirrored: `re-frame.ssr.server-fx-schemas`.** Explicit local schema vars in a dedicated ns, attached directly at the registration meta — exactly how the seven `:rf.server/*` fx do it (`ssr.cljc:235`, `:243`, `:251`, …). No global Malli registry, no schema-plugin layer, no cross-doc parser, and no Malli dependency in the routing artefact: the vars are plain data (vectors, keywords, `clojure.core` predicates) that stay inert when the optional schemas artefact is absent, per Spec 010 §Recommended soft-pass.

Shapes are #6296's **verbatim** — verified against merged `spec/Spec-Schemas.md:3756`, `:3759`, `NavScrollFxArgs`, `NavCaptureScrollFxArgs`.

### The two shapes worth calling out

- **`:saved-pos` is `[:tuple number? number?]`, not `[:tuple :int :int]`.** `window.scrollX/Y` are fractional at non-100% zoom and on HiDPI displays. An integer-only tuple would reject genuinely-captured positions and silently break Back-button scroll restoration for every zoomed user — the reason #6296 relaxed it.
- **`:position` on capture-scroll stays an internal test-injection seam.** Malli maps are open, so a test injecting it still validates; it is deliberately absent from the public shape rather than blessed.

## Verification of what the effects actually accept

Each schema was checked against the real emitters before attaching, per the "do not ship a schema that breaks working code" bar: `scroll/capture-scroll-fx-entry:211` emits exactly `{:url url}`; `capture-scroll-handler:253` reads `[(.-scrollX js/window) (.-scrollY js/window)]`; `scroll-fx-entry:169` assembles `{:strategy :from :to :saved-pos :fragment}` via `cond->` (nil slots omitted, never nil'd); `plan/scroll-plan:130` is the single assembly point; every `:rf.nav/push-url` / `:rf.nav/replace-url` emit site (`navigate.cljc:167`/`:619`, `can_leave.cljc:405`/`:526`/`:557`) threads a URL string.

The one judgement call: **`:strategy` admits the three standard keywords or a MAP, not an arbitrary keyword.** Spec 012 offers the map form for host extension; the handler's `nil` default branch is defence-in-depth, not a documented extension point. A repo-wide sweep found no emitter of a bare non-standard keyword strategy, and `routing_scroll_test`'s map-form case (`{:behavior :smooth :block :center}`) is covered by the `:map` arm.

## Red-before / green-after

**Red-before is pinned permanently in the suite** (`schema-less-nav-fx-meta-adjudicates-nothing`) rather than only demonstrated once: it calls the live `:schemas/validate-fx!` hook with the pre-sqams meta (the live registration `dissoc`'d of `:schema`) and asserts it **soft-passes** the very args the schema-bearing meta now rejects — for all four fx. That is the defect, and it means a future edit dropping a `:schema` cannot quietly reopen the hole while the positive tests still pass.

**Green-after is proven end-to-end on the client host.** The JVM cannot prove the skip: all four fx are `:platforms #{:client}`, so `handle-one-fx` short-circuits to `:rf.fx/skipped-on-platform` *before* the validation branch. Hence the split:

- `routing_nav_fx_schemas_test.clj` (13 tests / 158 assertions) — wiring (each registration's `:schema` **is** the corresponding var, not a drifting copy), adjudication (≥1 adversarial case per fx, plus the red-before control), and the wired hook emitting `:rf.error/schema-validation-failure :where :fx-args` with `:recovery :skipped`.
- `routing_nav_fx_schemas_cljs_test.cljs` (14 tests) — behavioural: **no history entry pushed**, **no scroll performed**, **nothing written to the scroll-position cache** for malformed args; the sibling fx in the same `:fx` vector **still runs** (Spec 010 §Per-step recovery row 5).

### Positive controls (the ones that matter most)

A schema that broke working navigation would be worse than no schema, so these are asserted behaviourally, not just structurally:

- **Fractional `:saved-pos`** — `{:strategy :restore :saved-pos [0.5 1234.75]}` still drives `.scrollTo`; the canary run reported `actual: [0.5 1234.75]`, i.e. the fractional pair genuinely round-tripped through the gate into the window.
- **Fractional capture** — a HiDPI `window.scrollX/Y` of `[0.5 1234.75]` still lands in the LRU cache verbatim.
- **Optional `:fragment`** — both alone (`{:strategy :top :fragment "install"}`) and in the full five-slot planner output.
- Full planner args, map-form strategy, all three standard strategies, `:from` omitted on initial nav, descriptors without `:params`/`:query`, and eight real URL shapes (path-form, hash-form, based-hash, query, fragment).

The CLJS suite was verified to actually execute via a deliberate canary failure (it failed as expected, then was reverted and re-run green) — the new ns is loaded through `SHADOW_IMPORT` and matches the `cljs-test$` ns-regexp.

## Scope

No spec edit (`spec/Spec-Schemas.md` / `spec/API.md` are #6296's surface and hot-zone — untouched). No behaviour change: no handler, arg shape, or registration was altered beyond adding the `:schema` key; the pre-existing EP-0015 `:sensitive` marks and `:platforms` are asserted intact. No validation framework, no new effects, no compatibility aliases. `implementation/routing` + `implementation/ssr` are not baked playground inputs, and the freshness gate confirms no rebuild was needed.

## Quality gates

| Gate | Result |
|---|---|
| `implementation/routing` JVM — `clojure -M:test` | **442 tests / 2275 assertions, 0 failures, 0 errors** |
| `implementation/ssr` JVM — `clojure -M:test` (routing is its test dep) | **401 tests / 1711 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` | **10000 tests / 49236 assertions, 0 failures, 0 errors** |
| `scripts/check-playground-sci-freshness.sh` | **OK** — digest matches; no rebuild needed (routing/ssr are not baked inputs) |
| CLJS suite executes (canary) | deliberate failure surfaced, reverted, re-run green |

All gates run in the foreground to completion, post-rebase onto `origin/main` (`b9b5e4a8d0`). No `spec/` file touched. Not merging — leaving that to the mayor.
