### PR TITLE
test(conformance): bind the S3 profile route-link and wrapper rows to the executable catalogue (rf2-pd0dh)

### DIFF
--- a/implementation/ui/test/re_frame/ui/s3_conformance_profile_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/s3_conformance_profile_jvm_test.clj
@@ -23,11 +23,15 @@
   catalogued surface (S3 entries + explicitly-listed non-S3 publics), so ANY
   addition / removal / rename of a public var fails the test until the catalogue
   is updated in lockstep. The human profile
-  (spec/conformance/S3-view-conformance-profile.md) is validated ROW BY ROW —
-  each frozen verb's §1 table row must name its direct-call error AND its gate,
-  and the §6 gate roster must name exactly the certified S3 arms — rather than by
-  whole-document token presence, so moving a name into unrelated prose or
-  swapping a gate is caught."
+  (spec/conformance/S3-view-conformance-profile.md) is validated ROW BY ROW for
+  ALL THREE rosters — each frozen verb's §1.1 row must name its direct-call error
+  AND its gate; the §1.2 `route-link` row its view-id, absent-artefact error,
+  contract fragments AND both proof homes; each §1.3 wrapper row its host
+  primitive, kind, direct-call behaviour AND contract fragments (with §1.3 naming
+  the shared JVM/CLJS proof homes); and the §6 gate roster exactly the certified
+  S3 arms — rather than by whole-document token presence, so deleting a row,
+  moving a name into unrelated prose, or swapping a contract, proof home or gate
+  between rows is caught."
   (:require [clojure.java.io :as io]
             [clojure.set :as set]
             [clojure.string :as str]
@@ -78,7 +82,14 @@
                 :absent-error :rf.error/routing-artefact-missing
                 :jvm-proof    "re-frame.ui.route-link-jvm-test"
                 :cljs-proof   "re-frame.ui.route-link-dom-cljs-test"
-                :contract     "ordinary compiled defview; real <a href>; plain left-click dispatches :source :router; native/modifier clicks defer to the browser"}})
+                :contract     "ordinary compiled defview; real <a href>; plain left-click dispatches :source :router; native/modifier clicks defer to the browser"
+                ;; The small EXACT fragments the §1.2 row must carry, so swapping
+                ;; the contract out of the row (or into another row) is red.
+                :row-fragments ["ordinary compiled `defview`"
+                                "not a fail-loud stub"
+                                "real `<a href>`"
+                                "`:source :router`"
+                                "native/modifier clicks defer to the browser"]}})
 
 ;; ---------------------------------------------------------------------------
 ;; (3) The frozen `re-frame.ui.react` INTEROP TIER — seven wrappers (Spec 004
@@ -89,14 +100,56 @@
 ;; re-frame.ui.react-interop-jvm-test; real React client behaviour ->
 ;; re-frame.ui.react-interop-dom-cljs-test.
 ;; ---------------------------------------------------------------------------
+;; `:host` is the wrapped React primitive the row must name; `:row-fragments`
+;; are the small EXACT contract fragments the §1.3 row must carry (so swapping
+;; two wrappers' contracts, or hollowing one out, is red). All seven share the
+;; two proof homes, but each entry names its own so dropping or swapping a proof
+;; association is red per wrapper rather than tier-wide.
 (def frozen-react-wrappers
-  {'use-ref           {:kind :hook :error :rf.error/ui-tree-malformed}
-   'use-effect        {:kind :hook :error :rf.error/ui-tree-malformed}
-   'use-layout-effect {:kind :hook :error :rf.error/ui-tree-malformed}
-   'use-effect-event  {:kind :hook :error :rf.error/ui-tree-malformed}
-   'use-context       {:kind :hook :error :rf.error/ui-tree-malformed}
-   'use-id            {:kind :hook :error :rf.error/ui-tree-malformed}
-   'lazy              {:kind :macro}})
+  {'use-ref           {:kind :hook :error :rf.error/ui-tree-malformed :host "useRef"
+                       :jvm-proof "re-frame.ui.react-interop-jvm-test"
+                       :cljs-proof "re-frame.ui.react-interop-dom-cljs-test"
+                       :row-fragments ["host ref object"
+                                       "read/write via `.current`"
+                                       "assignment never re-renders"]}
+   'use-effect        {:kind :hook :error :rf.error/ui-tree-malformed :host "useEffect"
+                       :jvm-proof "re-frame.ui.react-interop-jvm-test"
+                       :cljs-proof "re-frame.ui.react-interop-dom-cljs-test"
+                       :row-fragments ["passive after-paint effect"
+                                       "setup returns a cleanup"
+                                       "`[]` = connect-only"]}
+   'use-layout-effect {:kind :hook :error :rf.error/ui-tree-malformed :host "useLayoutEffect"
+                       :jvm-proof "re-frame.ui.react-interop-jvm-test"
+                       :cljs-proof "re-frame.ui.react-interop-dom-cljs-test"
+                       :row-fragments ["after DOM mutation"
+                                       "the measure-before-paint door"]}
+   ;; React 19.2 `useEffectEvent` — latest committed values, UNSTABLE identity
+   ;; (a fresh fn each render), no deps array, never in a deps vector, never
+   ;; called during render. Shipped native with no shim (hooks.cljc), proven in
+   ;; re-frame.ui.react-interop-dom-cljs-test.
+   'use-effect-event  {:kind :hook :error :rf.error/ui-tree-malformed :host "useEffectEvent"
+                       :jvm-proof "re-frame.ui.react-interop-jvm-test"
+                       :cljs-proof "re-frame.ui.react-interop-dom-cljs-test"
+                       :row-fragments ["latest render's committed values"
+                                       "identity is **not** stable"
+                                       "a fresh fn each render"
+                                       "takes no deps"
+                                       "must never appear in a deps vector nor be called during render"]}
+   'use-context       {:kind :hook :error :rf.error/ui-tree-malformed :host "useContext"
+                       :jvm-proof "re-frame.ui.react-interop-jvm-test"
+                       :cljs-proof "re-frame.ui.react-interop-dom-cljs-test"
+                       :row-fragments ["**foreign** Context object"
+                                       "never React context"]}
+   'use-id            {:kind :hook :error :rf.error/ui-tree-malformed :host "useId"
+                       :jvm-proof "re-frame.ui.react-interop-jvm-test"
+                       :cljs-proof "re-frame.ui.react-interop-dom-cljs-test"
+                       :row-fragments ["host-generated tree-positional id token"
+                                       "SSR determinism rides the root contract"]}
+   'lazy              {:kind :macro :host "React.lazy"
+                       :jvm-proof "re-frame.ui.react-interop-jvm-test"
+                       :cljs-proof "re-frame.ui.react-interop-dom-cljs-test"
+                       :row-fragments ["code-splitting over a foreign `load-thunk`"
+                                       "not a loading-orchestration surface"]}})
 
 ;; Public vars of `re-frame.ui` that are NOT part of the S3 surface — the boot
 ;; adapter + the S1/S1b/S1c/S2 forms, catalogued in the Spec 004 family. Listed
@@ -248,13 +301,25 @@
         rows       (filter #(= token (first-cell %)) lines)]
     (when (= 1 (count rows)) (first rows))))
 
+(defn- section-between
+  "The region of `text` from header `from` up to header `to`, so a claim is read
+  from the section that owns it rather than from incidental prose elsewhere."
+  [text from to]
+  (let [start (str/index-of text from)
+        end   (str/index-of text to)]
+    (when (and start end (< start end)) (subs text start end))))
+
 (defn- roster-section
   "The §6 gate-roster region of `text` (from the `## 6.` header to `## 7.`), so a
   gate is read from a real roster row, not from incidental prose elsewhere."
   [text]
-  (let [start (str/index-of text "## 6.")
-        end   (str/index-of text "## 7.")]
-    (when (and start end) (subs text start end))))
+  (section-between text "## 6." "## 7."))
+
+(defn- interop-section
+  "The §1.3 React-interop-tier region — the section that owns the shared wrapper
+  proof homes (they are stated once for the tier, not per row)."
+  [text]
+  (section-between text "### 1.3" "## 2."))
 
 (deftest profile-catalogues-every-verb-row-exactly
   (testing "each frozen S3 verb has one §1 table row naming its direct-call error AND its gate"
@@ -272,6 +337,66 @@
                   (str token "'s row must name its direct-call error " error))
               (is (str/includes? row (str "**" gate "**"))
                   (str token "'s row must name its proving gate " gate)))))))))
+
+(deftest profile-catalogues-the-framework-view-row-exactly
+  (testing "the §1.2 route-link row names its view-id, absent-artefact error, contract, and BOTH proof homes"
+    (let [lines (str/split-lines (slurp (profile-doc)))]
+      (doseq [[view {:keys [view-id absent-error jvm-proof cljs-proof row-fragments]}] frozen-s3-view]
+        (let [token (str "`ui/" view "`")
+              row   (table-row-for lines token)]
+          (is (some? row)
+              (str "the profile must catalogue " token " in exactly one table row"))
+          (when row
+            (is (str/includes? row (str view-id))
+                (str token "'s row must name its registered view-id " view-id))
+            (is (str/includes? row (str absent-error))
+                (str token "'s row must name its absent-artefact error " absent-error))
+            (is (str/includes? row jvm-proof)
+                (str token "'s row must name its JVM proof home " jvm-proof))
+            (is (str/includes? row cljs-proof)
+                (str token "'s row must name its CLJS proof home " cljs-proof))
+            (doseq [fragment row-fragments]
+              (is (str/includes? row fragment)
+                  (str token "'s row must carry its contract fragment: " fragment)))))))))
+
+(deftest profile-catalogues-every-react-wrapper-row-exactly
+  (testing "each frozen wrapper has one §1.3 row naming its host primitive, kind, direct-call behaviour, and contract"
+    (let [lines (str/split-lines (slurp (profile-doc)))]
+      (doseq [[wrapper {:keys [kind error host row-fragments]}] frozen-react-wrappers]
+        (let [token (str "`react/" wrapper "`")
+              row   (table-row-for lines token)]
+          (is (some? row)
+              (str "the profile must catalogue " token " in exactly one table row"))
+          (when row
+            (is (str/includes? row (str "`" host "`"))
+                (str token "'s row must name the host primitive it wraps: " host))
+            (case kind
+              :hook  (do (is (str/includes? row "host hook")
+                             (str token "'s row must classify it as a host hook"))
+                         (is (str/includes? row (str error))
+                             (str token "'s row must name its direct-call error " error)))
+              :macro (do (is (str/includes? row "def-level macro")
+                             (str token "'s row must classify it as a def-level macro"))
+                         (is (str/includes? row "compile error")
+                             (str token "'s row must state its compile-error direct-call behaviour"))))
+            (doseq [fragment row-fragments]
+              (is (str/includes? row fragment)
+                  (str token "'s row must carry its contract fragment: " fragment)))))))))
+
+(deftest profile-names-the-react-wrapper-proof-homes
+  (testing "§1.3 names the JVM + CLJS proof homes every wrapper rides — dropping or swapping one is red"
+    (let [section (interop-section (slurp (profile-doc)))]
+      (is (some? section) "the profile must have a §1.3 interop-tier section and a §2 header")
+      (when section
+        (doseq [[wrapper {:keys [jvm-proof cljs-proof]}] frozen-react-wrappers]
+          (is (str/includes? section jvm-proof)
+              (str "§1.3 must name " wrapper "'s JVM proof home " jvm-proof))
+          (is (str/includes? section cljs-proof)
+              (str "§1.3 must name " wrapper "'s CLJS proof home " cljs-proof)))
+        ;; the JVM home proves three distinct things; naming it is not enough
+        (doseq [aspect ["structural subset" "position law" "HMR signature"]]
+          (is (str/includes? section aspect)
+              (str "§1.3 must state the JVM proof home covers the " aspect)))))))
 
 (deftest profile-gate-roster-is-exactly-the-arm-set
   (testing "the §6 gate roster names EXACTLY the certified S3 arms — dropping / adding / renaming a roster gate is red"

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -851,7 +851,7 @@ without touching React's hook order — the property the position law relies on.
 | `use-ref` | `(react/use-ref)` / `(react/use-ref initial)` → ref | `useRef`; the foreign ref object, read/write via `(.-current ref)`. Assignment never re-renders — its reason to exist beside `local` — and it is the preferred object ref for `:ref` positions. No deps. |
 | `use-effect` | `(react/use-effect setup)` / `(react/use-effect setup deps)` → nil | `useEffect` (passive, after paint); `setup` returns a cleanup fn or nil, honored on dep change, disconnect, and unmount; StrictMode dev replay is expected and MUST be idempotent-safe — the `effect` contract in a foreign spelling. |
 | `use-layout-effect` | `(react/use-layout-effect setup)` / `(… setup deps)` → nil | `useLayoutEffect` (after DOM mutation, before paint) for measure-then-mutate work that would flicker under passive timing; observes the committed frame, never a mid-commit state. |
-| `use-effect-event` | `(react/use-effect-event f)` → stable fn | `useEffectEvent`; a fn with stable identity across renders whose body sees the latest render's values. Takes **no** deps; the returned fn MUST NOT appear in any deps vector and MUST NOT be called during render (it is effect-phase machinery). App intent still goes through event vectors / `ui/event`. |
+| `use-effect-event` | `(react/use-effect-event f)` → fn | `useEffectEvent` (React 19.2, native — no shim); a fn whose body always sees the latest render's committed values. Its identity is **not** stable — React allocates a fresh fn every render, so never rely on stability. Takes **no** deps; the returned fn MUST NOT appear in any deps vector and MUST NOT be called during render (it is effect-phase machinery). App intent still goes through event vectors / `ui/event`. |
 | `use-context` | `(react/use-context ctx)` → value | `useContext`; `ctx` is a foreign Context object (`React.createContext` in foreign code, an opaque foreign value). Internal state never rides React context — frames have `frame-root` / `frame-provider`, app state has `sub`; this reads the *foreign* world's providers, and the value is handed through uncoerced. |
 | `use-id` | `(react/use-id)` → string | `useId`; a host-generated tree-positional token prefixed by the root's `identifierPrefix`. Determinism under SSR rides the root contract — a hydrating root takes the server's prefix from the manifest ([004C](004C-Roots-and-Mount.md)). |
 | `lazy` | `(react/lazy load-thunk)` / `(react/lazy load-thunk {:fallback tpl})` | `React.lazy` over a foreign component-loading thunk (a zero-arg fn returning a Promise of a foreign component); the result is a foreign component reference, legal exactly where foreign heads are. Def-level only. |
@@ -921,8 +921,9 @@ six hooks changes the hook signature ⇒ a deliberate clean remount (never a cor
 order); same-signature edits preserve state. Fast Refresh re-runs effects on every refresh
 (cleanup then setup) even when deps are unchanged, so the view generation participates in
 the kernel-internal deps comparison — the `rf=` economy must never out-vote Fast Refresh
-semantics. `use-effect-event` keeps stable identity across same-signature refreshes with
-its latest body swapped in; `use-ref`'s `current` survives same-signature refreshes and
+semantics. `use-effect-event` picks up its latest body across same-signature refreshes —
+its identity is not preserved, and never was stable to begin with (React allocates a
+fresh fn every render); `use-ref`'s `current` survives same-signature refreshes and
 resets on remount. Reloading the module that defines a `react/lazy` mints a new component
 identity, so the foreign subtree below it remounts — the foreign boundary's cost, not a
 `ui` HMR defect.

--- a/spec/conformance/S3-view-conformance-profile.md
+++ b/spec/conformance/S3-view-conformance-profile.md
@@ -12,8 +12,11 @@ those gates (browser / JVM / elision suites), not re-asserted in prose here.
 The frozen surface and the gate references are kept honest by an executable drift
 guard, `implementation/ui/test/re_frame/ui/s3_conformance_profile_jvm_test.clj`:
 its `frozen-s3-verbs`, `frozen-s3-view`, and `frozen-react-wrappers` maps are the
-source of truth this document restates, and it fails if this profile omits a
-frozen verb or an S3 gate.
+source of truth this document restates. All three rosters are bound row by row:
+the guard fails if a §1 row is missing or duplicated, or if a row stops naming
+the error, gate, view-id, host primitive, kind, contract fragments, or proof
+homes its map entry fixes — so deleting a row, or swapping a contract or proof
+home between rows, is red.
 
 ## 1. Frozen S3 surface
 


### PR DESCRIPTION
Closes rf2-pd0dh.

## The gap

rf2-ar0ga (#6277) added the §1.2 `route-link` row and the seven §1.3 `re-frame.ui.react` wrapper rows to the human S3 profile, but the executable drift guard never looped `frozen-s3-view` or `frozen-react-wrappers`. It validated only the ten `frozen-s3-verbs` rows, the §6 gate roster, and a whole-document `"Non-surfaces"` substring — so the new rows could regress freely, while the profile told readers all three maps were the source of truth it restates.

**Proven before the fix** — on `origin/main`, corrupting route-link's view-id, absent-artefact error and JVM proof home *and* deleting the entire `react/use-id` row left the focused suite at **9 tests / 101 assertions, 0 failures**.

## What changed

Extends the existing bounded `table-row-for` helper to all three rosters — no Markdown parser, no generator, no restructuring of the profile.

- `frozen-s3-view` gains `:row-fragments`. New `profile-catalogues-the-framework-view-row-exactly` binds the §1.2 row to its view-id, absent-artefact error, both proof homes, and its contract fragments.
- `frozen-react-wrappers` gains `:host`, `:jvm-proof`, `:cljs-proof`, `:row-fragments` — the contract and proof fields the bead noted it lacked, so it can actually be the source of truth the profile claims. New `profile-catalogues-every-react-wrapper-row-exactly` binds each §1.3 row to its host primitive, kind, direct-call behaviour, and contract fragments; `profile-names-the-react-wrapper-proof-homes` asserts §1.3 names the shared JVM/CLJS proof homes plus the three aspects the JVM home covers (structural subset, position law, HMR signature).
- `roster-section` generalises into a small `section-between`.
- The profile's own header paragraph now states what the guard actually enforces.

Focused suite goes **9 tests / 101 assertions → 12 / 176**.

### Mutation proof (after)

| Mutation | Result |
|---|---|
| route-link row: view-id, absent-error, JVM proof → bogus | **4 failures** (was 0) |
| delete the whole `react/use-id` row | **row-not-found failure** (was 0) |
| swap `use-effect` ↔ `use-layout-effect` contract cells | **5 failures** (was 0) |

## `use-effect-event` authority reconciliation

Spec 004 was the sole outlier and is corrected to the shipped semantics. It claimed `→ stable fn` / "a fn with stable identity across renders" (line 854) and "keeps stable identity across same-signature refreshes" (line 924), against:

- `implementation/ui/src/re_frame/ui/react.cljc` — "its identity is NOT stable (React allocates a fresh function every render — do not rely on stability)";
- `implementation/ui/src/re_frame/ui/hooks.cljc` — native `(react/useEffectEvent f)`, "No shim — the host primitive's deliberate misuse signal is preserved";
- `react_interop_dom_cljs_test` — `use-effect-event-latest-body-and-unstable-identity` asserts two distinct identities;
- the S3 profile §1.3 row, which already stated unstable identity.

**No runtime change** — `implementation/ui/src/**` is untouched (0 diff lines). Documented and proven, not altered.

## Quality gates

| Gate | Result |
|---|---|
| `clojure -M:test -n re-frame.ui.s3-conformance-profile-jvm-test` | green — 12 tests, 176 assertions, 0 failures |
| `implementation/ui` full JVM (`clojure -M:test`) | green — 837 tests, 14822 assertions, 0 failures |
| `python -m mkdocs build --strict` | green |
| `python scripts/check_doc_slugs.py` | green (exit 0) |
| `python scripts/check_skill_re_frame2_drift.py --verbose` | green (exit 0) |

`--self-test` not run: `spec/006-ReactiveSubstrate.md` is untouched.

## Notes

- Left clean for rf2-yho9j (S4-E): `section-between` and the per-roster row tests are the shape an S4 profile can reuse directly.
- Out of scope, worth a follow-up: `ai/findings/new-substrate-synthesis/drafts/ui-react-interop-contract.md` (tracked, lines 120 and 294) still carries the superseded "stable fn" claim. It is a draft working artefact, not normative, so it was left alone rather than widening this bead's surface.
