### PR TITLE
docs(story): reword the recorder no-warnings hint to severity framing (rf2-zqz4w)

### DIFF
--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -371,7 +371,7 @@
                    :type :edn}]}
    {:id          :rf.assert/no-warnings
     :label       "no-warnings"
-    :hint        "Assert no :rf.warning/* events seen during play."
+    :hint        "Assert no warning-severity trace event (:op-type :warning) captured during play — any operation namespace, not only :rf.warning/*."
     :fields      []}
    {:id          :rf.assert/effect-emitted
     :label       "effect-emitted"


### PR DESCRIPTION
Closes rf2-zqz4w.

Final follow-up to rf2-ciys6 (#6287), which reconciled five of the six sites that described Story's `:rf.assert/no-warnings` contract by **keyword namespace** rather than by **severity**. The sixth is a recorder picker hint in `tools/story/src`, which was fenced at the time for rf2-qwzmt (S4-H) — qwzmt merged in #6295, so it is now free.

## The drift

```
- "Assert no :rf.warning/* events seen during play."
+ "Assert no warning-severity trace event (:op-type :warning) captured during play — any operation namespace, not only :rf.warning/*."
```

The old hint promised a namespace-scoped check. The shipped check is severity-scoped, so the hint understated it: a warning-severity trace event in *any* operation namespace fails the assertion, not just `:rf.warning/*` ones.

## Shipped behaviour re-verified

`tools/story/src/re_frame/story/play/evidence.cljc:190-201` — the discriminator is `:op-type`, and the operation namespace is never inspected:

```clojure
(def warning-operation … :warning)

(defn warning-trace? [trace-event]
  (= warning-operation (:op-type trace-event)))
```

`tools/story/src/re_frame/story/assertions.cljc:620-631` (`evaluate-no-warnings`) passes iff that filtered vector is empty. So the assertion is severity-gated end to end — the code is right and the hint was wrong, which is the direction this bead assumed.

## The other five (verified correct, untouched)

Each already carries ciys6's severity framing; this PR does not modify them.

| Site | |
|---|---|
| `tools/story/spec/004-Assertions.md:29` | severity-framed |
| `tools/story/spec/API.md:363` | severity-framed |
| `tools/story/spec/015-Test-Coverage.md:287` | severity-framed |
| `docs/story/api/reference.md:241` | severity-framed |
| `docs/story/api/script.md:47` | severity-framed |

The new hint mirrors their wording, with the `"Assert …"` lead-in the sibling hints in the same vocabulary use. The hint renders into a column-flex picker row with no width cap, `nowrap`, or ellipsis, so the full clause wraps rather than truncating — no need to trade away the corrective for length.

## Quality gates

`tools/story` `clojure -M:test` (full artefact suite, foreground — the recorder ns rides it):

```
Ran 1833 tests containing 6778 assertions.
0 failures, 0 errors.
```

String-only change with no behaviour delta, and no test pinned the old literal (the recorder vocabulary test asserts only `(string? (:hint entry))`), so no pin needed updating. Not a baked input, so no bundle rebuild.
