### PR TITLE
docs(ui): finish the per-host AST reconciliation in Spec 004 and the compiler header (rf2-kxkag)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -1,9 +1,10 @@
 (ns re-frame.ui.compiler
   "defview / custom-element expansion pipeline: arity + options parsing,
   header (Q2) analysis, template analysis, manifest + fingerprint
-  assembly, and per-host emission. One template parse -> one normalized
-  AST -> per-host emitter (the portability law: no emitter consumes raw
-  source or another emitter's output).
+  assembly, and per-host emission. Each host build runs the shared
+  analyzer over its own source and hands that build's own AST to exactly
+  one emitter (the portability law: no emitter consumes raw source or
+  another emitter's output).
 
   Runs on the JVM only (macro expansion for both hosts); .cljc so the
   namespace stays loadable everywhere."

--- a/implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj
@@ -400,6 +400,11 @@
    ;; law and must NOT match, so the emitter side requires two/both/per-host.
    ["one parse/AST → per-host emitters"
     #"(?i)(?:one|a\s+single)\s+(?:normalized\s+|normalised\s+|template\s+)*(?:parse|AST)\b[^\n]{0,80}(?:two|both|per-host|each\s+host)\s+emitter"]
+   ;; The same claim spread over a line/prefix break, which the single-line
+   ;; pattern above cannot see: an intervening comma or a Markdown blockquote
+   ;; marker between "one" and "AST" must not buy the retired wording a pass.
+   ["one AST consumed by the emitters"
+    #"(?is)\bAST\**\s+consumed\s+by\s+(?:two|both|each\s+host|the\s+(?:two|host))\s+emitter"]
    ["one emitter implements both hosts"
     #"(?i)(?:(?:one|same)\s+emitter[^\n]{0,120}(?:both\s+hosts|client[^\n]*server|browser[^\n]*jvm)|(?:both\s+hosts|client[^\n]*server|browser[^\n]*jvm)[^\n]{0,120}(?:one|same)\s+emitter)"]
    ["host output is identical"
@@ -438,7 +443,16 @@
     #"(?is)hosts\s+never\s+meet\s+as\s+ASTs"]
 
    "docs/EP/EP-0030-the-compiled-view-substrate-program.md"
-   [#"(?is)each\s+host\s+build\s+emits\s+from\s+its\s+own"]})
+   [#"(?is)each\s+host\s+build\s+emits\s+from\s+its\s+own"]
+
+   "spec/004-Views.md"
+   [#"(?i)\*\*One\s+AST\s+per\s+build\.\*\*"
+    #"(?is)hosts'?\s+ASTs\s+are\s+not\s+guaranteed\s+equal\s+values"
+    #"(?is)hosts\s+never\s+meet\s+as\s+ASTs"]
+
+   "implementation/ui/src/re_frame/ui/compiler.cljc"
+   [#"(?is)each\s+host\s+build\s+runs\s+the\s+shared\s+analyzer"
+    #"(?is)hands\s+that\s+build's\s+own\s+AST\s+to\s+exactly\s+one\s+emitter"]})
 
 (deftest compiler-authorities-teach-per-host-analysis
   (doseq [[path required] compiler-model-authorities]

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -2,9 +2,10 @@
 
 > Status: Drafting. **v1-required.** A view is `ui/defview` — a pure function of **one
 > props map** to a **template**. Templates are Reagent-familiar hiccup with the
-> ambiguities removed; a compiler lowers every view to **one normalized, serialisable
-> template AST** consumed by two emitters — direct React code for the browser, a
-> structural render tree for the JVM. No interpreter ships. Event handlers are **data**
+> ambiguities removed; a shared analyzer lowers every view to a **normalized,
+> serialisable template AST**, and each host build hands its own AST to exactly one
+> emitter — direct React code for the browser, a structural render tree for the JVM.
+> No interpreter ships. Event handlers are **data**
 > (event vectors) by default. Every view is memoized by default. The CLJS realisation is
 > **`re-frame.ui`** (artifact `day8/re-frame2-ui`, alias `ui/`); frames are created at
 > host preflight (per [002](002-Frames.md)), never from render. SSR
@@ -46,14 +47,18 @@ for readability.
 
 ## The portability law and the template AST
 
-**A portable view has one deterministic, serialisable template representation consumed
-by each host emitter. Emitted host values may be host-native and need not themselves be
-serialisable.**
+**A portable view has one deterministic, serialisable template representation, produced
+by a shared analyzer and consumed by that build's host emitter. Emitted host values may
+be host-native and need not themselves be serialisable.**
 
-- **One AST.** `defview` is `.cljc`. The compiler normalizes the template — including
-  the control forms (§Template grammar) — into one closed-node-set AST. Every analyzer
-  and every emitter consumes that AST; no emitter consumes raw source or another
-  emitter's output.
+- **One AST per build.** `defview` is `.cljc`. A build runs the shared analyzer, which
+  normalizes the template — including the control forms (§Template grammar) — into one
+  closed-node-set AST, and hands it to exactly one emitter; no emitter consumes raw
+  source or another emitter's output. That discipline is about *one* compilation and
+  does not reach across hosts: analysis is host-parameterized (a symbol resolving to
+  `cljs.core/map` here and `clojure.core/map` there lands differently), so the two
+  hosts' ASTs are not guaranteed equal values, let alone one value, and the hosts never
+  meet as ASTs.
 - **Two emitters.** The browser emitter generates direct React code (`jsx`/`jsxs`
   calls, hoisted static subtrees, compile-time prop conversion). The JVM emitter
   generates the canonical serialisable structural render tree consumed by the existing
@@ -1305,7 +1310,7 @@ order and is a defect in this table.
 
 | Normative section (this Spec) | Stage | What that stage's fixtures assert |
 |---|---|---|
-| §The portability law and the template AST | **S1** | one AST → two emitters; normalized structural equivalence (parity corpus v0); serialisation boundary; closed node set; AST-shape gate |
+| §The portability law and the template AST | **S1** | shared analyzer → one AST and one emitter per host build; normalized structural equivalence (parity corpus v0); serialisation boundary; closed node set; AST-shape gate |
 | §`ui/defview` — grammar, props ABI, options map, registration, `rf=` comparator | **S1** | declaration arities + diagnostics; props ABI encoding + `:key` reservation; registrar `:view` entries; the ruled `rf=` comparator emitted and asserted against prop-driven re-render (subscription/local interplay asserts S2/S3; stable-shell identity is S2 HMR work) |
 | §Template grammar — forms, control forms, rejection roster | **S1** | table forms lower; compile-error roster with didactic messages |
 | §Template grammar — expression positions (the closed macro grammar) | **S2** | audited transparent set lowers with sites indexed below it; unaudited core/user macros rejected with the didactic escape (real-host-analyzer macro authority); bare `sub`/`lease` reference below a transparent macro rejected; binding-pattern/`:or` fences — the rf2-vxgfnd.100 hidden-sub/helper/binder-macro fixtures |


### PR DESCRIPTION
Closes rf2-kxkag.

PR #6310 reconciled the reachable compiler authorities to shipped reality and landed the retired-claim guard, but two named sites stayed fenced — `spec/004-Views.md` behind rf2-74vlo (S4-C), and `implementation/ui/src/**` behind the off-limits rule. Both fences have lifted (#6312 merged), so this finishes the bead.

## Shipped reality

`implementation/ui/src/re_frame/ui/compiler.cljc` runs `ana/analyze-view-body` per expansion, and emission is `(if cljs? (emit-cljs/emit-defview args) (emit-jvm/emit-defview args))`. The analyzer is **shared**, each host build produces **its own AST**, and exactly **one emitter** runs per build. The retired formulation is "one AST, two emitters" / "one normalized AST → per-host emitters". Wording matches what #6310 established, so every authority now reads identically.

## The sites

| File | Before | After |
|---|---|---|
| `spec/004-Views.md` status blurb | "a compiler lowers every view to **one normalized, serialisable template AST** consumed by two emitters" | "a shared analyzer lowers every view to a **normalized, serialisable template AST**, and each host build hands its own AST to exactly one emitter" |
| `spec/004-Views.md` portability law + bullet | "representation consumed by each host emitter" / "**One AST.**" | "representation, produced by a shared analyzer and consumed by that build's host emitter" / "**One AST per build.**" + the host-parameterized-analysis explanation |
| `spec/004-Views.md` S1 stage table | "one AST → two emitters" | "shared analyzer → one AST and one emitter per host build" |
| `implementation/ui/src/re_frame/ui/compiler.cljc` ns docstring | "One template parse -> one normalized AST -> per-host emitter" | "Each host build runs the shared analyzer over its own source and hands that build's own AST to exactly one emitter" |

The bead named the `**One AST.**` bullet and the stage-table row. The status blurb is the third instance of the same claim in the same file — and it is the one the bead *description* names verbatim ("Spec 004 says one normalized AST is consumed by two emitters"), so it is in scope; fixing two of three would have left the file contradicting itself within fifty lines. The portability-law sentence is the lead-in to the bullet it introduces and moves with it.

`compiler.cljc` is a **comment-only** edit — no logic touched. Nothing #6310 already fixed was re-touched.

## The guard

`spec/004-Views.md` and `implementation/ui/src/re_frame/ui/compiler.cljc` join `compiler-model-authorities`, so each carries positive per-host re-analysis assertions (a wording-only deletion cannot false-green) and is censused against every retired claim.

One census row is added alongside those two entries. The existing `one parse/AST → per-host emitters` pattern is single-line and requires whitespace straight after the adjective; the comma in "one normalized, serialisable" plus the blockquote marker before "template AST" meant the status-blurb wording passed **untouched** — verified empirically before adding the row. That is precisely the wording-only false-green the acceptance criteria forbid, so a newline-tolerant `AST consumed by two emitters` row closes it. Adding it raised the suite from 15070 to 15088 assertions with zero new failures, so it produces no false positives anywhere in the guide corpus or the authority set.

## Quality gates

All foreground, unpiped.

- `cd implementation/ui && clojure -M:test` — **854 tests, 15088 assertions, 0 failures, 0 errors**
- `python -m mkdocs build --strict` — exit 0 (built in 53.40s)
- `python scripts/check_doc_slugs.py` — exit 0
- `sh scripts/check-playground-sci-freshness.sh` — **OK**, digest matches; `implementation/ui` is not a baked playground input, so no bundle rebuild was expected or performed

**Mutation proof — four sites, each restored individually and re-run:**

| Restored | Result |
|---|---|
| `**One AST.**` bullet | 3 failures — all three `spec/004-Views.md` positive assertions lost |
| S1 stage-table row | 1 failure — `reintroduced retired claim: one parse/AST → per-host emitters` |
| `compiler.cljc` docstring | 3 failures — both positive assertions lost **plus** the retired-claim census |
| status blurb | 1 failure — `reintroduced retired claim: one AST consumed by the emitters` (green before the new row; reddens after) |
