### PR TITLE
fix(xray): preserve record type in concrete-query selectors (rf2-5h9td)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -691,8 +691,10 @@ was. Rows display + key by the full query vector (documented fallback to the
 registered id only when the skip evidence genuinely lacks a query-v);
 source-coordinate lookup keeps the registered id. Each row's `data-testid`
 (`rf-xray-reactive-unchanged-row-<selector>`) is minted through a GENUINELY
-INJECTIVE concrete-query selector (rf2-bk2c6, hardened rf2-haoip) — the
-readable `id-slug` stem plus a lossless, order-canonical encoding of the full
+INJECTIVE concrete-query selector (rf2-bk2c6, hardened rf2-haoip and
+rf2-5h9td) — the
+readable `id-slug` stem plus a lossless, order-canonical, TYPE-PRESERVING
+encoding of the full
 identity (a small local `canonical-str` rendering, made DOM-safe via
 `encodeURIComponent`). `id-slug` alone is LOSSY: it flattens every non-alnum
 char to `_`, so distinct valid queries (`[:item/derived :a-b]` and
@@ -700,12 +702,34 @@ char to `_`, so distinct valid queries (`[:item/derived :a-b]` and
 one selector the DOM can no longer address independently. A 32-bit `hash`
 suffix did NOT close this: a 32-bit hash COLLIDES, so distinct queries
 (`[:item/derived " @"]` and `[:item/derived "!!"]` share hash `1127258382`)
-still minted the identical selector. The lossless suffix is collision-free —
-distinct concrete queries always receive distinct selectors — while
-value-equal identities (maps built in any insertion order included) canonicalize
+still minted the identical selector. Nor was a lossless encoding alone
+sufficient: ClojureScript RECORDS satisfy `map?`, so an encoder whose first
+branch is `map?` discards the record's type tag and renders `(->A 1)`,
+`(->B 1)` and `{:x 1}` all as `{:x 1}` — three pairwise-UNEQUAL concrete
+queries back onto one selector. Records are legal concrete-query arguments
+(the fresh-object cache diagnostic names them explicitly: `map / collection /
+record built inline`), so the encoding matches records FIRST and tags them
+`#my.ns/MyRec` — a compile-time, `:advanced`-safe name read off the type's
+`cljs$lang$ctorPrWriter` — before canonicalizing their entries; a record's
+extension entries stay order-canonical exactly like a plain map's, and the
+tag can collide with neither a set (`#{`) nor a map. The lossless suffix is
+collision-free —
+distinct concrete queries always receive distinct selectors, at every nesting
+depth — while
+value-equal identities (maps built in any insertion order included, and equal
+records whose extension maps were built in different insertion orders)
+canonicalize
 to ONE stable selector, so repeated evidence keeps a single row matching the
 dedup contract; the React key, the visible label, and `data-query-v` still
-carry the full query vector unchanged. It is NOT reconstructed by
+carry the full query vector unchanged. The SUPPORTED DOMAIN is stated
+honestly: injectivity holds for the EDN value space a concrete query is built
+from — the collections above plus scalars whose `pr-str` is faithful and
+type-distinct (keyword, symbol, string, number, boolean, nil, char, uuid,
+inst, regex). It does NOT hold for values `pr-str` cannot separate — raw JS
+objects/arrays and functions, which are `=`-distinct by identity — nor for
+deliberately reader-hostile symbols that print as structure; those are not
+concrete-query identities in practice and the selector makes no claim about
+them. It is NOT reconstructed by
 filtering `:sub-runs` on `(complement :recomputed?)`, which is structurally
 always empty. The
 graph's `unchanged` (dashed, short-circuited) nodes are subs that RAN with

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
@@ -137,23 +137,61 @@
   [id]
   (when id (string/replace (str id) #"[^a-zA-Z0-9_]" "_")))
 
+(declare canonical-str)
+
+(defn- canonical-entries
+  "Entries of an associative value rendered `<k> <v>` and SORTED, so
+  insertion order cannot leak into the encoding. Shared by the map and the
+  record branch of `canonical-str` — a record's extension entries (its
+  `__extmap`) are canonicalized exactly like a plain map's."
+  [x]
+  (->> x
+       (map (fn [[k v]] (str (canonical-str k) " " (canonical-str v))))
+       sort
+       (string/join ", ")))
+
+(defn- record-tag
+  "The fully-qualified `my.ns/MyRec` name of a defrecord instance's type.
+  `defrecord` sets the type's `cljs$lang$ctorPrWriter` to write that name as
+  a COMPILE-TIME literal, so `pr-str` on the type is stable, unique per
+  record type, and survives `:advanced` renaming. (`cljs.core/type->str`
+  would NOT do: it reads `cljs$lang$ctorStr`, which `deftype` sets but
+  `defrecord` does not, so it degrades to the constructor's JS source text.)"
+  [x]
+  (pr-str (type x)))
+
 (defn- canonical-str
   "Lossless, order-canonical string rendering of a concrete-query identity.
   Distinct EDN values render to distinct strings (injective); value-equal
-  identities render identically — maps and sets emit their elements in
-  canonical (sorted) order, so an identity built in ANY map/set insertion
+  identities render identically — maps, records, and sets emit their elements
+  in canonical (sorted) order, so an identity built in ANY map/set insertion
   order yields ONE stable string. Vectors and lists keep their significant
   order; scalars defer to `pr-str` (faithful + reader-quoted, so a string can
   never masquerade as structure). Small + local to the selector below — NOT a
-  general serializer."
+  general serializer.
+
+  RECORDS ARE TYPE-PRESERVING (rf2-5h9td). CLJS records satisfy `map?`, so a
+  bare `map?` branch would discard the record's type and render `(->A 1)`,
+  `(->B 1)` and `{:x 1}` all as `{:x 1}` — three UNEQUAL concrete queries
+  collapsed onto one selector. Records are matched FIRST and carry an explicit
+  `#my.ns/MyRec` type tag; they can never collide with a set (`#{`, and a
+  record tag is non-empty and never starts with `{`) nor with a plain map.
+  Records are legal concrete-query arguments — the fresh-object cache
+  diagnostic already names them (`map / collection / record built inline`).
+
+  SUPPORTED DOMAIN, honestly stated. Injectivity holds for the EDN value
+  space a concrete query is built from: collections (above), and scalars whose
+  `pr-str` is faithful and type-distinct — keyword, symbol, string, number,
+  boolean, nil, char, uuid, inst, regex. It does NOT hold for values `pr-str`
+  cannot distinguish: raw JS objects/arrays (`#js {…}` renders by content, but
+  two such objects are `=`-distinct by identity) and functions. Nor for
+  deliberately degenerate reader-hostile symbols (`(symbol \"#a/B{:x 1}\")`
+  prints as structure). Those are not concrete-query identities in practice;
+  the selector does not claim to separate them."
   [x]
   (cond
-    (map? x)    (str "{" (->> x
-                              (map (fn [[k v]]
-                                     (str (canonical-str k) " " (canonical-str v))))
-                              sort
-                              (string/join ", "))
-                     "}")
+    (record? x) (str "#" (record-tag x) "{" (canonical-entries x) "}")
+    (map? x)    (str "{" (canonical-entries x) "}")
     (set? x)    (str "#{" (->> x (map canonical-str) sort (string/join " ")) "}")
     (vector? x) (str "[" (->> x (map canonical-str) (string/join " ")) "]")
     (seq? x)    (str "(" (->> x (map canonical-str) (string/join " ")) ")")
@@ -161,8 +199,8 @@
 
 (defn- concrete-query-selector
   "GENUINELY INJECTIVE `data-testid` suffix for an unchanged-sub row's
-  concrete-query identity (rf2-bk2c6 / rf2-haoip). `id-slug` alone is LOSSY —
-  it flattens every non-alnum/non-`_` char to `_`, so DISTINCT valid queries
+  concrete-query identity (rf2-bk2c6 / rf2-haoip / rf2-5h9td). `id-slug` alone
+  is LOSSY — it flattens every non-alnum/non-`_` char to `_`, so DISTINCT queries
   collapse to one slug (`[:item/derived :a-b]` and `[:item/derived :a/b]` both
   slug to `__item_derived__a_b_`). Appending a 32-bit `hash` did NOT fix this:
   a 32-bit hash COLLIDES, so distinct queries (`[:item/derived \" @\"]` and
@@ -172,8 +210,14 @@
   encoding of the full identity, made DOM-safe via `encodeURIComponent`:
   distinct concrete queries get distinct selectors (collision-free), and
   value-equal identities — maps in any insertion order included — get ONE
-  stable selector (the dedup contract). The readable `id-slug` stem survives;
-  projection, React keys, the visible label, and `data-query-v` are untouched;
+  stable selector (the dedup contract). That encoding is TYPE-PRESERVING for
+  records (rf2-5h9td): since CLJS records satisfy `map?`, a bare map branch
+  would have rendered `(->A 1)`, `(->B 1)` and `{:x 1}` identically and
+  re-collapsed three distinct queries onto one selector — see `canonical-str`
+  for the record tag and the honestly-stated supported domain.
+
+  The readable `id-slug` stem survives; projection, React keys, the visible
+  label, and `data-query-v` are untouched;
   only this testid encoding changes. BOTH the readable stem and the
   discriminator derive from `canonical-str`, so the WHOLE selector is a function
   of VALUE — the `id-slug` stem cannot re-leak map insertion order."

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
@@ -608,6 +608,114 @@
           "the two value-equal map orders collapse to ONE selector; the
            genuinely-different map keeps its own — 2 distinct selectors total"))))
 
+;; rf2-5h9td — REAL ClojureScript records for the type-preservation tests
+;; below. `RecA` and `RecB` are structurally identical (one field `x`) and
+;; differ ONLY by record type, which is exactly the pair the pre-fix `map?`
+;; branch could not separate.
+
+(defrecord RecA [x])
+(defrecord RecB [x])
+
+(deftest unchanged-row-selectors-preserve-record-type
+  (testing "rf2-5h9td — CLJS records satisfy `map?`, so the rf2-haoip encoder's
+            leading `(map? x)` branch discarded the record TAG and rendered
+            `(->RecA 1)`, `(->RecB 1)` and `{:x 1}` all as `{:x 1}`. Those three
+            concrete queries are pairwise UNEQUAL (`(= (->RecA 1) (->RecB 1))`
+            and `(= (->RecA 1) {:x 1})` are both false), so collapsing them onto
+            one `data-testid` was false identity — rows the DOM cannot address
+            independently, violating rf2-haoip's every-distinct-valid-query AC.
+            Each must now mint its OWN selector. (Red before this fix: distinct
+            testid count was 1, and that shared testid addressed 3 nodes.)"
+    (facade/install!)
+    (rf/make-frame {:id :rf/xray})
+    (is (map? (->RecA 1)) "premise — a CLJS record IS `map?`, hence the bug")
+    (is (not= (->RecA 1) (->RecB 1)) "premise — the two record types are unequal")
+    (is (not= (->RecA 1) {:x 1}) "premise — record and plain map are unequal")
+    (seed-reactive-data!
+      {:has-event-bundle? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :show-unchanged? true
+       :subs-skipped [{:sub-id :cfg/derived :query-v [:cfg/derived (->RecA 1)]
+                       :reason :input-value-equal :input-paths-unchanged []}
+                      {:sub-id :cfg/derived :query-v [:cfg/derived (->RecB 1)]
+                       :reason :input-value-equal :input-paths-unchanged []}
+                      {:sub-id :cfg/derived :query-v [:cfg/derived {:x 1}]
+                       :reason :input-value-equal :input-paths-unchanged []}]})
+    (let [tree    (view/reactive-panel)
+          testids (unchanged-row-testids tree)]
+      (is (= 3 (count testids)) "all three seeded rows render")
+      (is (= 3 (count (distinct testids)))
+          "RecA, RecB and the plain map each mint a DISTINCT selector — the
+           record TYPE is preserved, not flattened into the entries")
+      (doseq [id (distinct testids)]
+        (is (= 1 (count (th/find-all-by-testid tree id)))
+            "each concrete query's test-id addresses exactly one row")))))
+
+(deftest unchanged-row-selector-canonical-across-record-extension-order
+  (testing "rf2-5h9td ADVERSARIAL — type preservation must not cost
+            order-canonicality. A record's EXTENSION entries (assoc'd beyond its
+            declared fields) live in `__extmap`, whose small-map representation
+            preserves INSERTION order, so `(assoc (->RecA 1) :b 2 :c 3)` and
+            `(assoc (->RecA 1) :c 3 :b 2)` iterate differently while being `=`.
+            They must mint ONE stable selector, while a genuinely different
+            extension value (`:c 4`) keeps its own — order-invariance is not
+            value-collapse."
+    (facade/install!)
+    (rf/make-frame {:id :rf/xray})
+    (is (= (assoc (->RecA 1) :b 2 :c 3) (assoc (->RecA 1) :c 3 :b 2))
+        "premise — the two extension orders are value-equal")
+    (seed-reactive-data!
+      {:has-event-bundle? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :show-unchanged? true
+       :subs-skipped [{:sub-id  :cfg/derived
+                       :query-v [:cfg/derived (assoc (->RecA 1) :b 2 :c 3)]
+                       :reason :input-value-equal :input-paths-unchanged []}
+                      {:sub-id  :cfg/derived
+                       :query-v [:cfg/derived (assoc (->RecA 1) :c 3 :b 2)]
+                       :reason :input-value-equal :input-paths-unchanged []}
+                      {:sub-id  :cfg/derived
+                       :query-v [:cfg/derived (assoc (->RecA 1) :b 2 :c 4)]
+                       :reason :input-value-equal :input-paths-unchanged []}]})
+    (let [tree    (view/reactive-panel)
+          testids (unchanged-row-testids tree)]
+      (is (= 3 (count testids)) "all three seeded rows render")
+      (is (= 2 (count (distinct testids)))
+          "the two extension-insertion orders collapse to ONE selector; the
+           genuinely-different extension keeps its own — 2 distinct total"))))
+
+(deftest unchanged-row-selectors-preserve-record-type-at-depth
+  (testing "rf2-5h9td ADVERSARIAL — the record tag must survive RECURSION, not
+            just a top-level query argument. A record nested as a map VALUE
+            (`{:k (->RecA 1)}`) and a plain map in the same slot
+            (`{:k {:x 1}}`) are unequal queries and must stay individually
+            addressable; a second record TYPE at that same depth must differ
+            again. (Red before the fix: all three collapsed to one testid.)"
+    (facade/install!)
+    (rf/make-frame {:id :rf/xray})
+    (seed-reactive-data!
+      {:has-event-bundle? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :show-unchanged? true
+       :subs-skipped [{:sub-id  :cfg/derived
+                       :query-v [:cfg/derived {:k (->RecA 1)}]
+                       :reason :input-value-equal :input-paths-unchanged []}
+                      {:sub-id  :cfg/derived
+                       :query-v [:cfg/derived {:k (->RecB 1)}]
+                       :reason :input-value-equal :input-paths-unchanged []}
+                      {:sub-id  :cfg/derived
+                       :query-v [:cfg/derived {:k {:x 1}}]
+                       :reason :input-value-equal :input-paths-unchanged []}]})
+    (let [tree    (view/reactive-panel)
+          testids (unchanged-row-testids tree)]
+      (is (= 3 (count testids)) "all three seeded rows render")
+      (is (= 3 (count (distinct testids)))
+          "nested RecA, nested RecB and the nested plain map each mint a
+           DISTINCT selector — the encoder is type-preserving at every depth")
+      (doseq [id (distinct testids)]
+        (is (= 1 (count (th/find-all-by-testid tree id)))
+            "each nested-record query's test-id addresses exactly one row")))))
+
 (deftest unchanged-row-unparameterized-shows-plain-sub-id
   (testing "rf2-cj2yx / rf2-bk2c6 — a bare unparameterized skip (query-v
             `[:sub/id]`) renders the plain sub-id label (the common case is


### PR DESCRIPTION
Closes rf2-5h9td. Follow-up to rf2-haoip (#6274).

## The lossy site

`tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs:151` — `canonical-str`'s first branch was `(map? x)`. ClojureScript records satisfy `map?`, so the encoder discarded the record tag and rendered `(->A 1)`, `(->B 1)` and `{:x 1}` all as `{:x 1}`. Those three concrete queries are pairwise **unequal**, so haoip's "lossless" selector still minted **one** `data-testid` for all three — false identity, rows the DOM cannot address independently, and haoip's every-distinct-valid-query AC still unmet.

Records are legal concrete-query arguments; the fresh-object cache diagnostic already names them (`map / collection / record built inline`).

## The fix

Minimal, at haoip's seam — no new serializer, no runtime registry, no change to the query model.

- Match `(record? x)` **first** and tag it `#my.ns/MyRec`.
- The tag is `(pr-str (type x))`. `defrecord` sets the type's `cljs$lang$ctorPrWriter` to write that name as a **compile-time literal**, so it is stable, unique per record type, and survives `:advanced` renaming. `cljs.core/type->str` would *not* do: it reads `cljs$lang$ctorStr`, which `deftype` sets but `defrecord` does not, so it degrades to the constructor's JS source text.
- The tag can collide with neither a set (`#{` — a record tag is non-empty and never starts with `{`) nor a map.
- Entry rendering factored into `canonical-entries`, shared by both branches, so a record's extension entries (`__extmap`, which preserves insertion order in its small-map representation) stay order-canonical exactly like a plain map's.

Per the bead's "audit the other supported types", the **supported domain is now stated honestly** in the `canonical-str` docstring and in spec/021: injectivity holds for the EDN value space a concrete query is built from (collections, plus scalars whose `pr-str` is faithful and type-distinct). It does **not** hold for raw JS objects/arrays and functions (`=`-distinct by identity, indistinguishable by `pr-str`), nor for deliberately reader-hostile symbols that print as structure. Those are not concrete-query identities in practice and the selector makes no claim about them.

Projection, React keys, labels, `data-query-v`, ordering, and unparameterized rows are unchanged — only the testid encoding moves.

## Tests

Three new tests using **real ClojureScript records** (`defrecord RecA [x]` / `RecB [x]` — structurally identical, differing only by type), each proving the selector addresses exactly one row:

1. `unchanged-row-selectors-preserve-record-type` — RecA / RecB / plain map mint 3 distinct selectors; premises asserted inline (`map?` is true for a record; all three are pairwise unequal).
2. `unchanged-row-selector-canonical-across-record-extension-order` (**adversarial**) — `(assoc (->RecA 1) :b 2 :c 3)` and `(assoc (->RecA 1) :c 3 :b 2)` are `=` but iterate differently; they must collapse to ONE selector while `:c 4` keeps its own. Type preservation must not cost order-canonicality.
3. `unchanged-row-selectors-preserve-record-type-at-depth` (**adversarial**) — the tag must survive recursion: `{:k (->RecA 1)}` / `{:k (->RecB 1)}` / `{:k {:x 1}}` nested as a map value must stay individually addressable.

haoip's existing map-insertion-order and hash-collision tests are untouched and still pass.

## Quality gates

`npm run test:cljs` (from `implementation/`) — the suite that owns the xray CLJS tests. Foreground, run to completion.

**Red before** (fix reverted, tests present):

```
Ran 10005 tests containing 49262 assertions.
5 failures, 0 errors.
```

4 of those 5 were the new tests — both type tests reported `(not (= 3 1))` for the distinct-selector count, and both `find-all-by-testid` assertions reported `(not (= 1 3))`: one shared testid addressing three rows, exactly the bead's repro. (The 5th, `route-graph-shows-live-active-route` in `resources_cljs_test`, is an unrelated load-sensitive flake — it passed in every subsequent run and is not reachable from this diff.)

**Green after:**

```
[:node-test] Build completed. (1712 files, 50 compiled, 1 warnings, 62.80s)
Ran 10005 tests containing 49266 assertions.
0 failures, 0 errors.
```

The +4 assertion delta is exactly the two `doseq` blocks going from 1 iteration (one collapsed testid) to 3.

`npm run test:xray-feature-gate` was **not** run: the selector is not feature-gated, and the gate script contains no reference to `rf-xray-reactive-unchanged-row` or to the selector encoding.

## Spec

`tools/xray/spec/021-Dynamic-Panel-Designs.md` §3.4 updated in this PR (the Xray spec rule). The normative selector claim now reads TYPE-PRESERVING, documents the record branch and its compile-time tag source, extends the value-equal clause to cover records with differently-ordered extension maps, and carries the honestly-stated supported domain.
