### PR TITLE
ci: extract the resilient Clojure installer into one shared script (rf2-e7ja9)

### DIFF
--- a/.github/scripts/install-clojure-cli.sh
+++ b/.github/scripts/install-clojure-cli.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Resilient Clojure CLI install for GitHub Actions (rf2-9sgj8, extracted rf2-e7ja9).
+#
+# # Why this is not `DeLaGuardo/setup-clojure`
+#
+# setup-clojure's internal linux-install.sh curl has no retry, so a transient
+# curl-35 / socket-hang-up reds a JVM job in *setup*, before any test runs.
+# Under load that flaked repeatedly across the matrix. This runs the official
+# linux-install.sh directly, wrapping it in the repo's clj-kondo curl-retry
+# idiom (lint.yml) plus a 3x backoff loop over the whole download+install.
+# No github-token is needed — the releases/latest/download redirect hits no
+# GitHub API, so this does not consume the job's API budget.
+#
+# # Why one script instead of 59 copies
+#
+# rf2-9sgj8 hardened ~59 call sites by copying this body into each one. That
+# put the download URL, curl policy, backoff, privilege, and the post-install
+# validation boundary in 59 places where they could silently drift apart.
+# This file is the single owner of that policy (rf2-e7ja9).
+#
+# # Calling it
+#
+# Every job that installs the CLI checks out the repository first, so:
+#
+#     - name: Set up Clojure CLI
+#       run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
+#
+# Use the $GITHUB_WORKSPACE-absolute form, not a relative path: several jobs
+# set a `defaults.run.working-directory` (e.g. `implementation`), under which
+# a relative `./.github/scripts/...` would not resolve.
+#
+# # Failure boundary
+#
+# Three whole download+install attempts with bounded linear backoff. If all
+# three fail the loop falls through to `clojure --version`, which fails the
+# step — the caller never proceeds with a half-installed toolchain.
+#
+set -euo pipefail
+
+for attempt in 1 2 3; do
+  curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
+    https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
+    && sudo bash /tmp/linux-install.sh && break
+  echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
+  sleep "$((attempt * 10))"
+done
+clojure --version

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -180,22 +180,7 @@ jobs:
           node-version: '24'
 
       - name: Set up Clojure CLI (SCI bundle build)
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs (playground SCI bundle deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -22,22 +22,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -116,22 +101,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -177,22 +147,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -285,22 +240,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -264,22 +264,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (below) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -349,22 +334,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (below) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/post-merge-playground-freshness.yml
+++ b/.github/workflows/post-merge-playground-freshness.yml
@@ -131,22 +131,7 @@ jobs:
           node-version: '24'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs (playground SCI bundle deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/release-xray.yml
+++ b/.github/workflows/release-xray.yml
@@ -122,22 +122,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -178,22 +163,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,22 +165,7 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -316,22 +301,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -467,22 +437,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/template-release.yml
+++ b/.github/workflows/template-release.yml
@@ -154,22 +154,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       # rf2-ek857f F1 — Node.js is required for the emitted-app smoke in
       # `emitted_test_run_test.clj` (compiles + runs the emitted

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -556,22 +556,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -616,22 +601,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -673,22 +643,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -910,22 +865,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -970,22 +910,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1028,22 +953,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1088,22 +998,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1149,22 +1044,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1207,22 +1087,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1267,22 +1132,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1317,22 +1167,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1367,22 +1202,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1417,22 +1237,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1478,22 +1283,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1543,22 +1333,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1611,22 +1386,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1672,22 +1432,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1729,22 +1474,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1786,22 +1516,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1844,22 +1559,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1923,22 +1623,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1984,22 +1669,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -2112,22 +1782,7 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2224,22 +1879,7 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2307,22 +1947,7 @@ jobs:
           node-version: '24'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs (framework + shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2371,22 +1996,7 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2450,22 +2060,7 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2531,22 +2126,7 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2597,22 +2177,7 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2671,22 +2236,7 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2759,22 +2309,7 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs (Story/Xray shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -2925,22 +2460,7 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -3054,22 +2574,7 @@ jobs:
           cache-dependency-path: implementation/package-lock.json
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -3148,22 +2653,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -3205,22 +2695,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -3263,22 +2738,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -3329,22 +2789,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       # rf2-80y2h: mcp-base now carries a CLJS test target (shadow-cljs
       # :node-test build) covering the `.cljc` `:cljs` reader-conditional
@@ -3411,22 +2856,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       # rf2-ir6a0 — Node.js is required for the
       # `emitted_test_run_test.clj` slice (compiles + runs the emitted
@@ -3522,22 +2952,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -3617,22 +3032,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -3725,22 +3125,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -3900,22 +3285,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -3993,22 +3363,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -4129,22 +3484,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -4226,22 +3566,7 @@ jobs:
           node-version: '24'
 
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
       - name: Cache Maven / gitlibs (playground SCI bundle deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -491,7 +491,7 @@ jobs:
       - name: Self-test the README link validator
         run: python scripts/check_readme_links.py --self-test --verbose
 
-      - name: Validate README links (targets + MkDocs-rule anchor slugs)
+      - name: Validate README links (targets + GitHub-rule anchor slugs)
         run: python scripts/check_readme_links.py --ci
 
       # README inventory drift-ratchet gate (rf2-fvv9c, follows rf2-198k3).

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -777,16 +777,118 @@ test('cljs job provisions Clojure CLI before the G-12 isolation gate (rf2-3kewru
   assert.notEqual(setup, -1, 'cljs job must install Clojure CLI for G-12 Arm 2');
   assert.notEqual(gate, -1, 'cljs job must run the UI isolation gate');
   assert.ok(setup < gate, 'Clojure CLI setup must precede the G-12 isolation gate');
-  // rf2-9sgj8 — the install now runs the official linux-install.sh directly
-  // with retry (resilient against the transient curl-35 / socket-hang-up that
-  // reds setup) instead of DeLaGuardo/setup-clojure. It is still a real Clojure
-  // CLI provision, which is all Arm 2's `clojure -Stree` needs — assert the
-  // install actually downloads+installs the CLI rather than pinning the
-  // (now-removed) action SHA.
+  // rf2-9sgj8 — the install runs the official linux-install.sh with retry
+  // (resilient against the transient curl-35 / socket-hang-up that reds setup)
+  // instead of DeLaGuardo/setup-clojure. rf2-e7ja9 — that body now lives in the
+  // one shared script rather than inline here. It is still a real Clojure CLI
+  // provision, which is all Arm 2's `clojure -Stree` needs — assert the step
+  // calls the shared installer rather than pinning the (now-removed) action SHA
+  // or a copied installer body.
   assert.match(
     block,
+    /\.github\/scripts\/install-clojure-cli\.sh/,
+    'cljs job must install the Clojure CLI for Arm 2 `clojure -Stree` (rf2-e7ja9 shared installer)',
+  );
+});
+
+// rf2-e7ja9 — the resilient Clojure CLI install (rf2-9sgj8) was copied into 59
+// jobs across eight workflows. It now lives in ONE script,
+// `.github/scripts/install-clojure-cli.sh`, which every one of those jobs
+// calls. These assertions are the structural proof that it STAYS that way: a
+// reintroduced inline installer body, a resurrected setup-clojure action, or a
+// relative call path all fail here rather than silently re-forking the policy.
+const CLOJURE_INSTALLER = path.join(REPO_ROOT, '.github', 'scripts', 'install-clojure-cli.sh');
+const WORKFLOW_DIR = path.join(REPO_ROOT, '.github', 'workflows');
+const allWorkflows = () =>
+  fs
+    .readdirSync(WORKFLOW_DIR)
+    .filter((f) => f.endsWith('.yml'))
+    .map((f) => ({ name: f, text: fs.readFileSync(path.join(WORKFLOW_DIR, f), 'utf8') }));
+
+test('the shared Clojure CLI installer exists and keeps its failure boundary (rf2-e7ja9)', () => {
+  assert.ok(fs.existsSync(CLOJURE_INSTALLER), '.github/scripts/install-clojure-cli.sh must exist');
+  // The workflows execute it directly (`run: "$GITHUB_WORKSPACE/..."`), so the
+  // mode recorded in the index must be 100755 — a 100644 would fail all 59
+  // jobs with "Permission denied". A Windows checkout has core.filemode=false
+  // and will happily stage 100644, so assert git's mode rather than the
+  // filesystem's (which is meaningless there).
+  const mode = execFileSync('git', ['ls-files', '-s', '--', '.github/scripts/install-clojure-cli.sh'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  }).trim();
+  assert.match(
+    mode,
+    /^100755\s/,
+    'install-clojure-cli.sh must be committed executable (100755) — the workflows run it directly',
+  );
+  const src = fs.readFileSync(CLOJURE_INSTALLER, 'utf8');
+  // The semantics rf2-9sgj8 established, now owned in exactly one place:
+  // three whole download+install attempts, curl retry, bounded backoff, sudo
+  // install, and a final `clojure --version` failure boundary.
+  assert.match(src, /^set -euo pipefail$/m, 'installer must run under set -euo pipefail');
+  assert.match(src, /for attempt in 1 2 3; do/, 'installer must make three whole attempts');
+  assert.match(
+    src,
+    /curl -fsSL --retry 5 --retry-all-errors --retry-delay 3/,
+    'installer must keep the curl retry policy',
+  );
+  assert.match(
+    src,
     /brew-install\/releases\/latest\/download\/linux-install\.sh/,
-    'cljs job must install the Clojure CLI for Arm 2 `clojure -Stree` (rf2-9sgj8 resilient install)',
+    'installer must fetch the official linux-install.sh',
+  );
+  assert.match(src, /sudo bash \/tmp\/linux-install\.sh/, 'installer must install with sudo');
+  assert.match(src, /sleep "\$\(\(attempt \* 10\)\)"/, 'installer must keep the bounded backoff');
+  assert.match(
+    src,
+    /clojure --version\s*$/,
+    'installer must end on `clojure --version` — the failure boundary that stops a caller ' +
+      'proceeding with a half-installed toolchain',
+  );
+});
+
+test('no workflow carries an inline Clojure installer body or setup-clojure (rf2-e7ja9)', () => {
+  for (const { name, text } of allWorkflows()) {
+    assert.doesNotMatch(
+      text,
+      /brew-install\/releases\/latest\/download\/linux-install\.sh/,
+      `${name} must call .github/scripts/install-clojure-cli.sh, not copy the installer body ` +
+        '(rf2-e7ja9 — 59 copies of this policy is what the extraction deleted)',
+    );
+    assert.doesNotMatch(
+      text,
+      /uses:\s*\S*setup-clojure@/,
+      `${name} must not use the setup-clojure action — its un-retried curl is the ` +
+        'transient curl-35 / socket-hang-up flake rf2-9sgj8 removed',
+    );
+  }
+});
+
+test('every Clojure CLI step calls the shared installer by absolute path (rf2-e7ja9)', () => {
+  let callSites = 0;
+  for (const { name, text } of allWorkflows()) {
+    const lines = text.split(/\r?\n/);
+    lines.forEach((line, i) => {
+      if (!/^\s*-\s+name:.*Set up Clojure CLI/.test(line)) return;
+      callSites++;
+      // The step's `run:` is the next non-blank line — the extraction leaves a
+      // two-line step, so anything else means a body crept back in.
+      const next = lines[i + 1] ?? '';
+      assert.match(
+        next,
+        /^\s*run: "\$GITHUB_WORKSPACE\/\.github\/scripts\/install-clojure-cli\.sh"$/,
+        `${name}:${i + 2} — a "Set up Clojure CLI" step must be exactly a call to the shared ` +
+          'installer. Use the $GITHUB_WORKSPACE-absolute form: several jobs set a ' +
+          '`defaults.run.working-directory` (e.g. `implementation`) under which a relative ' +
+          './.github/scripts/... would not resolve.',
+      );
+    });
+  }
+  // Non-vacuity: if the steps were renamed away wholesale this test would
+  // otherwise pass by iterating nothing.
+  assert.ok(
+    callSites >= 50,
+    `expected the ~59 Clojure CLI call sites to still be present, found ${callSites}`,
   );
 });
 


### PR DESCRIPTION
Closes rf2-e7ja9.

## What

rf2-9sgj8 hardened the Clojure CLI install against the transient `curl (35)` /
`socket hang up` that was redding JVM jobs in *setup*, before any test ran. The
hardening was right, but it landed as a copy of the same installer body plus a
six-line rationale in **59 jobs across eight workflows** — putting the download
URL, curl policy, backoff, privilege, and the post-install validation boundary
in 59 places where they could silently drift apart.

This extracts that policy into one owner, `.github/scripts/install-clojure-cli.sh`,
and replaces all 59 sites with a call to it.

**944 lines of workflow deleted, 59 added.** The diff is "59 copies of a block →
59 calls to one thing" — nothing else.

Before → after, per file (`git grep -c`):

| workflow | inline bodies before | shared calls after |
|---|---|---|
| `test.yml` | 45 | 45 |
| `expensive-tests.yml` | 4 | 4 |
| `release.yml` | 3 | 3 |
| `lint.yml` | 2 | 2 |
| `release-xray.yml` | 2 | 2 |
| `docs.yml` | 1 | 1 |
| `post-merge-playground-freshness.yml` | 1 | 1 |
| `template-release.yml` | 1 | 1 |
| **total** | **59** | **59** |

Inline installer bodies remaining: **0**. `setup-clojure` uses remaining: **0**.

One representative call site:

```diff
       - name: Set up Clojure CLI
-        # rf2-9sgj8 — resilient Clojure CLI install. setup-clojure's internal
-        # linux-install.sh curl has no retry, so a transient curl-35 / socket-
-        # hang-up reds the JVM job in setup before any test runs. Reuses the
-        # repo's clj-kondo curl-retry idiom (lint.yml) + a 3x backoff loop over
-        # the whole download+install (no github-token needed — the
-        # releases/latest/download redirect hits no GitHub API).
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o /tmp/linux-install.sh \
-              https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh \
-              && sudo bash /tmp/linux-install.sh && break
-            echo "Clojure CLI install attempt ${attempt}/3 failed; retrying in $((attempt * 10))s"
-            sleep "$((attempt * 10))"
-          done
-          clojure --version
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
```

## Behaviour preservation

The extracted body is **byte-identical** to the one it replaces: three whole
download+install attempts, the same `--retry 5 --retry-all-errors --retry-delay 3`,
the same bounded linear backoff, `sudo` install, and the same final
`clojure --version` failure boundary. Nothing about the hardening was
"improved" while extracting it.

All 59 sites were verified identical before the change — 3 textual variants
existed, differing only in the step *name* (`(SCI bundle build)`) and one
comment word (`(below)` vs `(lint.yml)`); the executable `run:` body was the
same at all 59.

A **semantic YAML diff** of all ten workflows before and after confirms the
change is inert everywhere else: exactly 59 steps changed, and every change is
confined to the `run:` key of a step named "Set up Clojure CLI". No step
counts, step names, cache keys, tool versions, `runs-on`, `defaults`, `needs`,
`if`, or triggers moved.

Two things worth flagging for review:

- **Call sites use the `$GITHUB_WORKSPACE`-absolute form, not a relative path.**
  Several jobs set a `defaults.run.working-directory` (e.g.
  `expensive-tests.yml` → `implementation`), under which
  `./.github/scripts/...` would not resolve. This follows the existing
  convention in `release.yml`. All 59 sites were confirmed to run after an
  `actions/checkout` in their own job.
- **The script is committed `100755`.** The workflows execute it directly, so a
  `100644` would fail all 59 jobs with "Permission denied". A Windows checkout
  (`core.filemode=false`) will happily stage `100644`, so this is pinned by a
  test rather than left to chance.

The one-off Babashka installer stays inline and separate, per the bead.

## Structural proof

The pre-existing rf2-3kewru assertion in `_changed-surfaces.test.cjs` pinned
the inline body in the `cljs` job; it now pins the shared call. Four new
assertions catch a regression in either direction:

1. the shared script exists, is committed `100755`, and still carries each
   element of the rf2-9sgj8 semantics (attempts, curl flags, URL, sudo,
   backoff, `clojure --version` boundary);
2. no workflow carries an inline installer body;
3. no workflow resurrects a `setup-clojure` action;
4. every "Set up Clojure CLI" step is exactly a call to the shared script by
   absolute path — with a non-vacuity floor on the call-site count, so the test
   cannot pass by iterating nothing.

All four were **mutation-tested** (relative path, dropped `clojure --version`,
reintroduced inline body, `100644` mode) — each mutation fails the suite; each
restore returns it to green.

## Second commit — unrelated one-line fix

`ci: correct the README-links step name after the GitHub-slug switch` folds in
a stale string a sibling worker found in a file this PR already touches
(rf2-zzt2r / #6314, now merged). That PR taught `check_readme_links.py` to
model **GitHub's** duplicate-heading slugs (`-1`/`-2`) instead of MkDocs'
(`_1`/`_2`) — a deliberate divergence, since these READMEs are rendered by
GitHub. The CI step name still advertised "MkDocs-rule anchor slugs". Reworded
to "GitHub-rule"; the step's `run:` is untouched, and nothing outside the
workflow pins the string. Kept as a separate commit so the main diff reads as
pure extraction.

## Quality gates

Run in the worktree, foreground:

| gate | result |
|---|---|
| `node scripts/_changed-surfaces.test.cjs` | **168 passed** |
| `node scripts/_lint-workflow-policy.test.cjs` | **4 passed** |
| YAML parse, all 10 workflows (`yaml.safe_load`) | **all parse** |
| `bash -n .github/scripts/install-clojure-cli.sh` | **OK** |
| `python scripts/check_readme_links.py --self-test` | **exit 0** |
| `python scripts/check_readme_links.py --ci` | **exit 0** |
| semantic YAML before/after diff | **59 steps changed, 0 unexpected** |
| mutation tests on the 4 new assertions | **4/4 caught** |

`shellcheck` and `actionlint` are not installed locally, so neither ran.

**CI is the real verification here.** GitHub Actions cannot be executed
locally, so everything above is structural proof over the committed YAML — it
establishes that the call shape is uniform and the semantics are byte-equal,
not that the runners are happy. The first real signal is this PR's own run,
which exercises the new script across the whole matrix. **A red workflow gate
on this PR must be fixed on-branch — never admin-merged.**
