### PR TITLE
test(conformance): S4 view conformance profile + dual-emitter parity (rf2-yho9j, S4-E)

### DIFF
--- a/implementation/ui/test/re_frame/ui/parity_fixtures.cljc
+++ b/implementation/ui/test/re_frame/ui/parity_fixtures.cljc
@@ -29,10 +29,22 @@
   prefixes, keyword values); :class (string/vector/flag-map orders,
   sugar-first merge).
 
-  OUT OF SCOPE at S1 (documented, not silently skipped): foreign
-  components and `ui/raw` (JVM host-op — no JVM execution by contract),
-  `ui/client-only` + `ui/presence` (land S2/S3), `sub`/`lease` reads
-  (S2). Their compile grammar is pinned by the S1b suites."
+  S4 additions (W14; rf2-yho9j — the view-shape sweep): `ui/presence`
+  (the retention boundary's STRUCTURAL contribution — it renders no node
+  of its own and every incoming keyed child renders exactly once), the
+  RULED custom-element adversarial row (a DECLARED name that is also a
+  standard HTML attribute spelling stays a PROPERTY on both emitters),
+  and the `ui/html` no-sanitisation row (a hostile `javascript:` scheme
+  crosses verbatim — `re-frame.ui` gates nothing).
+
+  OUT OF SCOPE for the corpus (documented, not silently skipped):
+  foreign components and `ui/raw` (JVM host-op — no JVM execution by
+  contract, so there is no JVM side to compare; their boundary corpus is
+  raw_foreign_boundary_{jvm,dom_cljs}_test); `ui/client-only` (the SSR
+  phase flip lands S5); presence's THREE-PHASE machine and any
+  `(ui/presence-phase)` read (host-bearing — retention timers and the
+  first-render phase a server render reports are mounted/S5 questions,
+  proven in presence_dom_cljs_test and presence_jvm_test)."
   (:require [re-frame.ui :as ui :refer [defview]]))
 
 ;; ---------------------------------------------------------------------------
@@ -40,6 +52,12 @@
 ;; ---------------------------------------------------------------------------
 
 (ui/custom-element :parity-widget {:properties #{:accent-color}})
+
+;; S4-B adversarial declaration (rf2-yho9j): `:tab-index` is a standard HTML
+;; attribute spelling, but DECLARING it makes it a PROPERTY — the declaration is
+;; the sole classifier, never an attribute-name heuristic. Both emitters must
+;; therefore keep it OUT of markup.
+(ui/custom-element :parity-attrish {:properties #{:tab-index}})
 
 ;; ---------------------------------------------------------------------------
 ;; Views
@@ -410,6 +428,56 @@
    (when hint [:small.pp-hint hint])])
 
 ;; ---------------------------------------------------------------------------
+;; S4 corpus additions (W14; rf2-yho9j) — the S4 surfaces that HAVE two
+;; emitter sides to compare. Presence's retention machine, `ui/raw` and the
+;; foreign head do not (see the ns docstring); what IS dual-emitter is the
+;; STRUCTURAL contribution each S4 form makes to the rendered output.
+;; ---------------------------------------------------------------------------
+
+(defview toast-row
+  "A presence child as a compiled VIEW — the shape S4-C's a11y roster blesses
+  (a keyed child view can read its own phase and stamp its own exit a11y). It
+  deliberately does NOT read (ui/presence-phase): the phase a FIRST render
+  reports is host-specific (the JVM structural subset says :present; a client
+  render enters through :mounting), so it is not a corpus claim."
+  [{:keys [toast]}]
+  [:li.toast [:span.msg (:msg toast)]])
+
+(defview presence-toasts
+  "ui/presence over keyed compiled child views. The corpus claim is that the
+  boundary contributes NO NODE OF ITS OWN and passes every incoming keyed child
+  through exactly once: on the JVM it is a fragment carrying the `:rf.ui/presence`
+  diagnostic marker, which normalization N strips; on the client it is a
+  component whose per-child phase Provider is invisible in markup. Both sides
+  must therefore land on the same children in the same order."
+  [{:keys [toasts]}]
+  (ui/presence {:timeout-ms 300}
+    (for [t toasts]
+      [toast-row {:key (:id t) :toast t}])))
+
+(defview presence-inline
+  "Presence nested MID-TREE over inline keyed literal markup (the second legal
+  child shape). Non-focusable content, so the S4-C `a11y-presence-exit-interactive`
+  check stays silent — the corpus is not the place to exercise a diagnostic."
+  [{:keys [items]}]
+  [:section.presence-host
+   [:h4 "notes"]
+   [:ul.notes
+    (ui/presence {:timeout-ms 120}
+      (for [i items]
+        [:li.note {:key (:id i) :data-note (:id i)} (:label i)]))]
+   [:p.after "after"]])
+
+(defview custom-element-attrish
+  "S4-B adversarial classification: `:tab-index` is DECLARED on
+  `:parity-attrish`, so it is a PROPERTY (lowered to the camelCase JS property
+  name) and neither emitter writes it into markup; the undeclared `:role` and
+  `:data-k` stay ordinary attributes on both hosts."
+  [{:keys [idx]}]
+  [:div.attrish
+   [:parity-attrish {:tab-index idx :role "note" :data-k "keep"}]])
+
+;; ---------------------------------------------------------------------------
 ;; Cases — pure data; the SINGLE corpus both hosts consume
 ;; ---------------------------------------------------------------------------
 
@@ -443,6 +511,10 @@
    :pp-list-cell          pp-list-cell
    :pp-safe-form-control  pp-safe-form-control
    :pp-schema-described   pp-schema-described
+   ;; S4 (W14, rf2-yho9j)
+   :presence-toasts       presence-toasts
+   :presence-inline       presence-inline
+   :ce-attrish            custom-element-attrish
    :page            page})
 
 (def cases
@@ -495,4 +567,12 @@
                                                                           :data-testid "pp"
                                                                           :class "extra"}}}
    {:id :pp-schema-described  :view :pp-schema-described :props {:label "Name" :hint "your full name"}}
+   ;; --- S4 (W14; rf2-yho9j) — the dual-emitter S4 rows -------------------
+   {:id :presence-two         :view :presence-toasts :props {:toasts [{:id 1 :msg "a & <b>"}
+                                                                      {:id 2 :msg "second"}]}}
+   {:id :presence-empty       :view :presence-toasts :props {:toasts []}}
+   {:id :presence-inline      :view :presence-inline :props {:items [{:id "n1" :label "one"}
+                                                                     {:id "n2" :label "two & <three>"}]}}
+   {:id :ce-declared-attr-name :view :ce-attrish     :props {:idx "3"}}
+   {:id :trusted-hostile      :view :trusted         :props {:markup "<a href=\"javascript:alert(1)\" target=\"_blank\">click</a><b>bold & raw</b>"}}
    {:id :page                 :view :page            :props {:items items-3 :on? true}}])

--- a/implementation/ui/test/re_frame/ui/s3_conformance_profile_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/s3_conformance_profile_jvm_test.clj
@@ -277,7 +277,10 @@
 ;; validated row by row rather than by whole-document token presence.
 ;; ===========================================================================
 
-(defn- repo-root []
+;; `repo-root`, `table-row-for` and `section-between` are PUBLIC so the sibling
+;; stage profiles compose with this guard instead of duplicating its row-binding
+;; machinery (rf2-yho9j: the S4 guard reuses all three). Behaviour unchanged.
+(defn repo-root []
   (loop [d (io/file (System/getProperty "user.dir"))]
     (cond
       (nil? d) nil
@@ -287,7 +290,7 @@
 (defn- profile-doc []
   (io/file (repo-root) "spec" "conformance" "S3-view-conformance-profile.md"))
 
-(defn- table-row-for
+(defn table-row-for
   "The single Markdown table row whose FIRST cell is exactly `token`, or nil when
   there is not exactly one. Keying on the first cell (not mere occurrence) binds
   a verb to its OWN §1 catalogue row: prose mentions, roster rows that name a
@@ -301,7 +304,7 @@
         rows       (filter #(= token (first-cell %)) lines)]
     (when (= 1 (count rows)) (first rows))))
 
-(defn- section-between
+(defn section-between
   "The region of `text` from header `from` up to header `to`, so a claim is read
   from the section that owns it rather than from incidental prose elsewhere."
   [text from to]

--- a/implementation/ui/test/re_frame/ui/s4_conformance_profile_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/s4_conformance_profile_jvm_test.clj
@@ -44,6 +44,11 @@
             [re-frame.ui.compiler.env :as env]
             [re-frame.ui.parity-fixtures :as fx]
             [re-frame.ui.rules :as rules]
+            ;; COMPOSITION, not duplication: the S3 guard owns the frozen S1-S3
+            ;; rosters AND the row-binding machinery (repo-root / table-row-for /
+            ;; section-between). This profile reuses both rather than restating
+            ;; the S3 surface or re-implementing its helpers.
+            [re-frame.ui.s3-conformance-profile-jvm-test :as s3]
             [re-frame.ui.test :as uit]))
 
 ;; ---------------------------------------------------------------------------
@@ -246,19 +251,44 @@
 
 (def s4-arm-gates #{"G-7" "G-11"})
 
+;; ---------------------------------------------------------------------------
+;; (5) INHERITANCE. This profile is CUMULATIVE: S1-S3 ride the frozen S3 profile
+;; by exact reference. The facade publics the S3 guard classifies as "not S3"
+;; (`non-s3-facade-publics`) split into exactly two buckets — the S4 delta this
+;; profile rows, and the S1/S2 carry-over forms the Spec 004 family catalogues.
+;; Asserting that partition is EXACT is what makes a NEW PUBLIC SURFACE fail
+;; loudly: a new facade var lands in `non-s3-facade-publics` (the S3 guard's own
+;; exact-set check) and must then be classified here or listed below.
+;; ---------------------------------------------------------------------------
+
+(def s1-s2-carryover-publics
+  "Facade publics that are neither S3 nor the S4 delta — the S1/S1b/S1c/S2 forms
+  and the boot adapter, catalogued in the Spec 004 family. Listed explicitly so
+  every NEW public var must be classified (S3 verb/view, S4 delta, or here)."
+  '#{adapter defview mount create-root render! hydrate-root unmount!
+     frame-root frame-provider sub lease frame spread})
+
+(def s4-inherits-profile
+  "The frozen profile this one inherits by exact reference. A broken inheritance
+  link — the file gone, or the reference dropped from §0 — is red."
+  "S3-view-conformance-profile.md")
+
 ;; ===========================================================================
 ;; Executable surface pins — the shipped code honours each catalogued contract.
 ;; ===========================================================================
 
-(defn- repo-root []
-  (loop [d (io/file (System/getProperty "user.dir"))]
-    (cond
-      (nil? d) nil
-      (.exists (io/file d "spec" "conformance")) d
-      :else (recur (.getParentFile d)))))
+;; Shared with the S3 guard — see the :require note above.
+(def ^:private repo-root s3/repo-root)
+(def ^:private table-row-for s3/table-row-for)
+(def ^:private section-between s3/section-between)
 
 (defn- profile-doc []
   (io/file (repo-root) "spec" "conformance" "S4-view-conformance-profile.md"))
+
+(defn- s3-profile-doc []
+  (io/file (repo-root) "spec" "conformance" "S3-view-conformance-profile.md"))
+
+(defn- doc-lines [] (str/split-lines (slurp (profile-doc))))
 
 (defn- err-id
   "Run `f`; -> the thrown `:rf.error/id`, or ::no-throw."
@@ -268,6 +298,66 @@
 
 (defn- ex-data-of [f]
   (try (f) nil (catch clojure.lang.ExceptionInfo e (ex-data e))))
+
+;; ===========================================================================
+;; Inheritance — composes with the S3 guard (the ruled S4-E obligation):
+;; a new public surface, a broken inheritance link, or a moved/deleted proof row
+;; must fail loudly.
+;; ===========================================================================
+
+(defn- s4-facade-forms
+  "The S4-delta forms that live on the `re-frame.ui` facade (flush-presence! is
+  `re-frame.ui.test`'s, so it is not a facade public)."
+  []
+  (set (keys (into {} (remove (fn [[_ v]] (= 're-frame.ui.test (:ns v)))
+                              frozen-s4-forms)))))
+
+(deftest new-public-surface-fails-loudly
+  (testing "the non-S3 facade publics partition EXACTLY into the S4 delta + the S1/S2 carry-over — a NEW public var is red until it is classified"
+    (let [non-s3     s3/non-s3-facade-publics
+          classified (set/union (s4-facade-forms) s1-s2-carryover-publics)]
+      (is (= non-s3 classified)
+          (str "facade classification drift — "
+               "unclassified (new?) publics: " (sort (set/difference non-s3 classified))
+               "; classified-but-absent: " (sort (set/difference classified non-s3))))))
+  (testing "the live facade agrees — every classified name actually resolves"
+    (doseq [sym (set/union (s4-facade-forms) s1-s2-carryover-publics)]
+      (is (some? (ns-resolve 're-frame.ui sym))
+          (str "ui/" sym " is classified but does not resolve")))))
+
+(deftest s4-does-not-double-classify-any-s3-surface
+  (testing "no S4-delta form is also catalogued as an S3 verb, the S3 view, or a React wrapper"
+    (doseq [sym (keys frozen-s4-forms)]
+      (is (not (contains? s3/frozen-s3-verbs sym))
+          (str sym " must not be double-classified as an S3 verb"))
+      (is (not (contains? s3/frozen-s3-view sym))
+          (str sym " must not be double-classified as the S3 framework view"))
+      (is (not (contains? s3/frozen-react-wrappers sym))
+          (str sym " must not be double-classified as a React interop wrapper")))))
+
+(deftest inheritance-link-is-intact
+  (testing "the frozen S3 profile this one inherits still exists"
+    (is (.exists (s3-profile-doc))
+        (str "broken inheritance link — " s4-inherits-profile " is missing")))
+  (testing "§0 inherits S1-S3 by EXACT reference to the frozen S3 profile"
+    (let [section (section-between (slurp (profile-doc)) "## 0." "## 1.")]
+      (is (some? section) "the profile must have a §0 inheritance section and a §1 header")
+      (when section
+        (doseq [claim [s4-inherits-profile
+                       "cumulative"
+                       "by exact reference"
+                       "does not restate"]]
+          (is (str/includes? section claim)
+              (str "§0 must state: " claim))))))
+  (testing "the S4 profile does NOT restate the frozen S3 rosters (duplication IS drift)"
+    (let [lines (doc-lines)]
+      (doseq [sym (concat (keys s3/frozen-s3-verbs) (keys s3/frozen-s3-view))]
+        (is (nil? (table-row-for lines (str "`ui/" sym "`")))
+            (str "the S4 profile must not restate the S3 row for ui/" sym
+                 " — S1-S3 are inherited by reference (§0)")))
+      (doseq [sym (keys s3/frozen-react-wrappers)]
+        (is (nil? (table-row-for lines (str "`react/" sym "`")))
+            (str "the S4 profile must not restate the S3 row for react/" sym))))))
 
 (deftest s4-forms-resolve-with-their-frozen-kinds
   (testing "every catalogued S4 form resolves in its namespace with the frozen kind"
@@ -444,29 +534,6 @@
 ;; validated row by row rather than by whole-document token presence.
 ;; ===========================================================================
 
-(defn- table-row-for
-  "The single Markdown table row whose FIRST cell is exactly `token`, or nil when
-  there is not exactly one. Keying on the first cell (not mere occurrence) binds
-  a form to its OWN §1 catalogue row: prose mentions, wall bullets, and rows that
-  merely reference the form mid-contract do not match."
-  [lines token]
-  (let [first-cell (fn [line]
-                     (let [t (str/triml line)]
-                       (when (str/starts-with? t "|")
-                         (-> t (subs 1) (str/split #"\|") first str/trim))))
-        rows       (filter #(= token (first-cell %)) lines)]
-    (when (= 1 (count rows)) (first rows))))
-
-(defn- section-between
-  "The region of `text` from header `from` up to header `to`, so a claim is read
-  from the section that owns it rather than from incidental prose elsewhere."
-  [text from to]
-  (let [start (str/index-of text from)
-        end   (str/index-of text to)]
-    (when (and start end (< start end)) (subs text start end))))
-
-(defn- doc-lines [] (str/split-lines (slurp (profile-doc))))
-
 (defn- check-row!
   "Assert the profile row keyed by `token` exists exactly once and carries every
   fragment + every id in `musts`."
@@ -559,6 +626,112 @@
           (str "the profile names proof home " home
                ", which is not a test namespace under implementation/ui/test")))))
 
+;; --- the ruled sequencing, non-parity, S5-wall and hand-off obligations ------
+
+(def open-presence-grammar-bugs
+  "The two OPEN S4-epic bugs that change the ACCEPTED presence grammar. The
+  profile's presence rows state the post-fix grammar and must say so, and §8
+  must make closing both part of the S4-conforming declaration."
+  ["rf2-vxgfnd.96.1" "rf2-vxgfnd.96.2"])
+
+(deftest profile-sequences-presence-behind-the-open-grammar-bugs
+  (testing "§1.1 states that the presence rows track the POST-FIX grammar, naming both open bugs"
+    (let [section (section-between (slurp (profile-doc)) "### 1.1" "### 1.2")]
+      (is (some? section) "the profile must have a §1.1 presence section and a §1.2 header")
+      (when section
+        (doseq [claim (concat open-presence-grammar-bugs
+                              ["POST-FIX presence grammar"
+                               "part of the S4-conforming"])]
+          (is (str/includes? section claim)
+              (str "§1.1 must state: " claim))))))
+  (testing "§8 makes closing both bugs part of the S4-conforming declaration"
+    (let [text (slurp (profile-doc))
+          tail (subs text (str/index-of text "## 8."))]
+      (doseq [claim (concat open-presence-grammar-bugs
+                            ["S4 is not yet declarable conforming"
+                             "Closing both is part of the S4-conforming declaration"])]
+        (is (str/includes? tail claim)
+            (str "§8 must state: " claim))))))
+
+(deftest profile-rows-the-intentional-non-parity-facts
+  (testing "§4.1 rows each non-parity S4 fact against its real proof home — never the structural comparator"
+    (let [lines (doc-lines)]
+      (doseq [[token proof] {"`ui/raw` / foreign component head" "re-frame.ui.raw-foreign-boundary-jvm-test"
+                             "the document head"                 "absence of surface"
+                             "the a11y roster"                   a11y-proof-home
+                             "presence's three-phase machine"    "re-frame.ui.presence-dom-cljs-test"}]
+        (let [row (table-row-for lines token)]
+          (is (some? row)
+              (str "§4.1 must row the non-parity fact " token " in exactly one table row"))
+          (when row
+            (is (str/includes? row proof)
+                (str token "'s non-parity row must name its real proof home: " proof))))))))
+
+(deftest profile-defers-the-s5-surfaces-explicitly
+  (testing "§5 lists the deliberate S5 non-surfaces — S4 claims conformance for none of them"
+    (let [section (section-between (slurp (profile-doc)) "## 5." "## 6.")]
+      (is (some? section) "the profile must have a §5 wall and a §6 header")
+      (when section
+        (doseq [claim ["rf2-vxgfnd.97"
+                       "Root Manifest"
+                       "hydration"
+                       "`render-static`"
+                       "phase"
+                       "failed-root isolation"
+                       "root-hydration half of W14"]]
+          (is (str/includes? section claim)
+              (str "§5 must defer to S5: " claim)))))))
+
+(deftest profile-bounds-the-g7-growth
+  (testing "the §6 G-7 ROW itself carries the S4-shapes-only bound"
+    ;; Row-keyed, not section-keyed: the same phrase also appears in the §6
+    ;; prose, so a section-wide substring check would stay green when the ROW
+    ;; is hollowed out (the exact under-binding class rf2-pd0dh fixed for S3).
+    (let [row (table-row-for (doc-lines) "**G-7**")]
+      (is (some? row) "§6 must carry exactly one G-7 roster row")
+      (when row
+        (is (str/includes? row "**S4 shapes only**")
+            "the G-7 row must bound its arm to S4 shapes only"))))
+  (testing "§6 bounds G-7 to S4 shapes and disclaims the broader S1-S3 equivalence debt"
+    (let [section (section-between (slurp (profile-doc)) "## 6." "## 7.")]
+      (when section
+        (doseq [claim ["**S4 shapes only**"
+                       "first"
+                       "in scope here"
+                       "named-open owner"
+                       "existing"]]
+          (is (str/includes? section claim)
+              (str "§6 must bound the G-7 growth: " claim)))))))
+
+(deftest profile-carries-the-s5-handoff-row
+  (testing "§7 CITES the obligations already recorded on rf2-vxgfnd.97 and creates no parallel ones"
+    (let [section (section-between (slurp (profile-doc)) "## 7." "## 8.")]
+      (is (some? section) "the profile must have a §7 hand-off section and a §8 header")
+      (when section
+        (doseq [claim ["rf2-vxgfnd.97"
+                       "no parallel obligation"
+                       "root-manifest hydration + failed-root isolation fixtures"
+                       "rf2-d9yq3"
+                       "hydrated presence starts `:present`"
+                       "rf2-aozoi"
+                       "SSR-adoption custom-element"
+                       "semantic normalizer"
+                       "render-fingerprint vocabulary"]]
+          (is (str/includes? section claim)
+              (str "§7 hand-off must cite: " claim)))))))
+
+(deftest profile-cites-the-ruled-head-ownership
+  (testing "§3 cites the rf2-3i7tr ruling and the ui/raw portal qualification — S4 adds no head machinery"
+    (let [section (section-between (slurp (profile-doc)) "## 3." "## 4.")]
+      (when section
+        (doseq [claim ["rf2-3i7tr"
+                       "normatively owns"
+                       "Spec 011 normatively owns"
+                       "**`ui/raw` does widen it, and that is deliberate.**"
+                       "no head machinery"]]
+          (is (str/includes? section claim)
+              (str "§3 must cite the ruled ownership: " claim)))))))
+
 (deftest profile-gate-roster-is-exactly-the-arm-set
   (testing "the §6 gate roster names EXACTLY the certified S4 arms — S4 adds NO new named gate"
     (let [roster (section-between (slurp (profile-doc)) "## 6." "## 7.")]
@@ -578,8 +751,8 @@
       (let [section (section-between text "## 3." "## 4.")]
         (is (some? section) "the profile must have a §3 head section and a §4 header")
         (when section
-          (doseq [claim ["No compiled-view form renders into `<head>`"
-                         "no `ui/head`"
+          (doseq [claim ["No compiled *structural* form renders into `<head>`"
+                         "no `ui/head`, and no head channel"
                          "**absence of surface**"
                          "`reg-head`"]]
             (is (str/includes? section claim)

--- a/implementation/ui/test/re_frame/ui/s4_conformance_profile_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/s4_conformance_profile_jvm_test.clj
@@ -1,0 +1,600 @@
+(ns re-frame.ui.s4-conformance-profile-jvm-test
+  "The S4 view-substrate CONFORMANCE PROFILE, executable (07 §5; EP-0035;
+  rf2-yho9j — the S4-E leaf of epic rf2-vxgfnd.96).
+
+  This is the single authoritative, EXACT catalogue of the FROZEN S4 surface —
+  the compiled-view substrate's presence + web-boundaries stage. S4 adds NO new
+  verb to the facade: its forms were EXPORTED at S1 for symbol resolution and
+  ASSERT at S4, so this profile pins BEHAVIOUR over an already-blessed surface.
+  It fixes FOUR rosters:
+
+    1. PRESENCE — the `ui/presence` retention boundary, the `ui/presence-phase`
+       read, and the `ui.test/flush-presence!` fake-clock driver;
+    2. CUSTOM ELEMENTS — the RULED property-vs-attribute classification
+       (declaration is the sole classifier; kebab -> camelCase);
+    3. the compile-tier A11Y roster — four `:rf.ui.compile/*` warnings with NO
+       Spec 009 row and no runtime emission, plus the suppression round trip;
+    4. the FOREIGN BOUNDARY — `ui/raw` / `ui/raw-fn` / a foreign component head
+       (host-bearing, typed `:rf.error/jvm-host-op`) and `ui/html` (the single
+       escaping bypass, which sanitises NOTHING).
+
+  Plus two absences and one corpus: the document HEAD is host-owned (§3 — an
+  absence of SURFACE, bound here as an absence), the S4 WALL (§5), and the W14
+  dual-emitter PARITY rows S4 contributes to the compiled-view corpus (§4).
+
+  Runtime behaviour itself is proven by the named proof homes (browser / JVM /
+  corpus suites), not re-asserted here. What this guard adds is BINDING: every
+  human row in spec/conformance/S4-view-conformance-profile.md is validated
+  ROW BY ROW against these maps — keyed on the row's FIRST table cell, so prose
+  mentions and cross-references elsewhere do not satisfy a row — and every
+  named proof home must be a REAL test namespace on disk. Deleting a row,
+  hollowing one out, or swapping a contract, error id or proof home between
+  rows is red.
+
+  Mirrors the shape rf2-pd0dh left on the S3 profile guard
+  (`s3_conformance_profile_jvm_test`); the S3 surface is that file's and is not
+  restated here."
+  (:require [clojure.java.io :as io]
+            [clojure.set :as set]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.ui :as ui]
+            [re-frame.ui.compiler.a11y :as a11y]
+            [re-frame.ui.compiler.analyze :as ana]
+            [re-frame.ui.compiler.env :as env]
+            [re-frame.ui.parity-fixtures :as fx]
+            [re-frame.ui.rules :as rules]
+            [re-frame.ui.test :as uit]))
+
+;; ---------------------------------------------------------------------------
+;; (1) The frozen S4 FORMS — presence, custom elements, the foreign boundary.
+;; Each entry names the namespace the form lives in, its kind, the loud-failure
+;; ids the CODE must honour, the small EXACT contract fragments its human row
+;; must carry, and BOTH proof homes. This map is the source of truth §1 of the
+;; profile document restates.
+;;
+;; `:token` is the profile row's FIRST CELL (rows are keyed on it, so a mention
+;; in prose or in another row's contract cell does not satisfy the row).
+;; `:row-fragments` are deliberately SMALL exact fragments: enough that swapping
+;; two rows' contracts, or hollowing one out, is red; not so many that ordinary
+;; editorial rewording is.
+;; ---------------------------------------------------------------------------
+
+(def frozen-s4-forms
+  {;; --- §1.1 presence -----------------------------------------------------
+   'presence
+   {:section       "### 1.1"
+    :token         "`ui/presence`"
+    :ns            're-frame.ui
+    :kind          :template-form
+    :direct-error  :rf.error/ui-tree-malformed
+    :compile-errors [:rf.ui.compile/bad-presence
+                     :rf.ui.compile/presence-unkeyed-child]
+    :jvm-proof     "re-frame.ui.presence-jvm-test"
+    :cljs-proof    "re-frame.ui.presence-dom-cljs-test"
+    :row-fragments ["`:timeout-ms` is **mandatory**"
+                    "the exit retention duration and the terminal bound"
+                    "terminal removal is **exactly-once**"
+                    "re-insertion interrupts the exit"
+                    "**no node of its own**"
+                    "unkeyed child is a build failure"]}
+
+   'presence-phase
+   {:section       "### 1.1"
+    :token         "`ui/presence-phase`"
+    :ns            're-frame.ui
+    :kind          :fn
+    :direct-error  nil                      ; a direct call is LEGAL
+    :jvm-value     :present
+    :jvm-proof     "re-frame.ui.presence-jvm-test"
+    :cljs-proof    "re-frame.ui.presence-dom-cljs-test"
+    :row-fragments ["**`:present` outside one**"
+                    "reusable anywhere"
+                    "JVM structural subset always yields `:present`"]}
+
+   'flush-presence!
+   {:section       "### 1.1"
+    :token         "`ui.test/flush-presence!`"
+    :ns            're-frame.ui.test
+    :kind          :fn
+    :direct-error  nil
+    :jvm-value     nil                      ; synchronous no-op on the JVM
+    :arities       #{0 1}
+    :jvm-proof     "re-frame.ui.presence-jvm-test"
+    :cljs-proof    "re-frame.ui.presence-dom-cljs-test"
+    :row-fragments ["fake clock"
+                    "no wall-clock sleep"
+                    "drains to quiescence"
+                    "synchronous `nil` no-op on the JVM"]}
+
+   ;; --- §1.2 custom elements ----------------------------------------------
+   'custom-element
+   {:section       "### 1.2"
+    :token         "`ui/custom-element`"
+    :ns            're-frame.ui
+    :kind          :macro
+    :compile-errors [:rf.ui.compile/bad-custom-element
+                     :rf.ui.compile/custom-element-conflict]
+    :jvm-proof     "re-frame.ui.custom-element-classification-jvm-test"
+    :cljs-proof    "re-frame.ui.custom-element-classification-dom-cljs-test"
+    :row-fragments ["closed `{:properties #{…}}` grammar"
+                    "**kebab → camelCase**"
+                    "`:accent-color` → `accentColor`"
+                    "**undeclared element is all-attributes**"
+                    "declaration is the **sole classifier**"]}
+
+   ;; --- §1.4 the foreign boundary ------------------------------------------
+   'raw
+   {:section       "### 1.4"
+    :token         "`ui/raw`"
+    :ns            're-frame.ui
+    :kind          :fn
+    :host-op       :ui/raw
+    :direct-error  :rf.error/jvm-host-op
+    :compile-errors [:rf.ui.compile/bad-raw]
+    :jvm-proof     "re-frame.ui.raw-foreign-boundary-jvm-test"
+    :cljs-proof    "re-frame.ui.raw-foreign-boundary-dom-cljs-test"
+    :row-fragments ["cannot render on the JVM"
+                    "the raise is **lazy**"
+                    "compiled siblings render normally"]}
+
+   'raw-fn
+   {:section       "### 1.4"
+    :token         "`ui/raw-fn`"
+    :ns            're-frame.ui
+    :kind          :fn
+    :direct-error  nil                      ; identity — it passes through
+    :opaque-marker {:rf.ui/opaque :ui/raw-fn}
+    :compile-errors [:rf.ui.compile/raw-fn-child]
+    :jvm-proof     "re-frame.ui.raw-foreign-boundary-jvm-test"
+    :cljs-proof    "re-frame.ui.raw-foreign-boundary-dom-cljs-test"
+    :row-fragments ["foreign callback in prop position"
+                    "`{:rf.ui/opaque :ui/raw-fn}` marker"]}
+
+   'html
+   {:section       "### 1.4"
+    :token         "`ui/html`"
+    :ns            're-frame.ui
+    :kind          :fn
+    :direct-error  nil                      ; the JVM arm BUILDS the node
+    :shape-error   :rf.error/ui-tree-malformed
+    :compile-errors [:rf.ui.compile/bad-html
+                     :rf.ui.compile/html-not-sole-child]
+    :jvm-proof     "re-frame.ui.raw-foreign-boundary-jvm-test"
+    :cljs-proof    "re-frame.ui.raw-foreign-boundary-dom-cljs-test"
+    :row-fragments ["**`re-frame.ui` sanitises nothing**"
+                    "no `javascript:`-scheme gate"
+                    "`string?` **shape** check"
+                    "never a content check"
+                    "empty string is a legal inert bypass"]}})
+
+;; The foreign COMPONENT HEAD is a boundary without a facade var — it is any
+;; resolvable non-view head. It still owns a §1.4 row, and its distinctness from
+;; `ui/raw` (a different `:op` in the same typed error) is the load-bearing fact.
+(def frozen-foreign-head
+  {:section       "### 1.4"
+   :token         "foreign component head"
+   :host-op       :foreign-component
+   :error         :rf.error/jvm-host-op
+   :jvm-proof     "re-frame.ui.raw-foreign-boundary-jvm-test"
+   :cljs-proof    "re-frame.ui.raw-foreign-boundary-dom-cljs-test"
+   :row-fragments ["resolvable var without view metadata"
+                   "**distinct** boundary from `ui/raw`"]})
+
+;; ---------------------------------------------------------------------------
+;; (2) The compile-tier A11Y roster (S4-C, rf2-74vlo). FOUR ids, closed. They
+;; are `:rf.ui.compile/*` — COMPILE tier: no Spec 009 catalogue row, no runtime
+;; emission, no production egress. `:rf.ui.compile/bad-suppress` is the loud
+;; failure of the suppression grammar itself and is NOT a suppressible finding.
+;; ---------------------------------------------------------------------------
+
+(def frozen-a11y-roster
+  {:rf.ui.compile/a11y-missing-accessible-name
+   {:row-fragments ["no discernible accessible name"
+                    "`aria-labelledby`"]}
+   :rf.ui.compile/a11y-invalid-literal-aria
+   {:row-fragments ["**literal** `aria-*` value"
+                    "runtime-computed value is never flagged"]}
+   :rf.ui.compile/a11y-click-non-interactive
+   {:row-fragments ["non-interactive element"
+                    "no keyboard path"]}
+   :rf.ui.compile/a11y-presence-exit-interactive
+   {:row-fragments ["**inline literal** markup under a presence boundary"
+                    "outside the per-child phase Provider"
+                    "keyed child view"
+                    "`(ui/presence-phase) = :unmounting`"]}})
+
+(def a11y-suppress-error :rf.ui.compile/bad-suppress)
+(def a11y-proof-home "re-frame.ui.a11y-diagnostics-cljs-test")
+
+;; ---------------------------------------------------------------------------
+;; (3) The W14 dual-emitter PARITY rows S4 contributes to the compiled-view
+;; corpus (§4). Each names the corpus case id it pins and the small exact
+;; fragments the §4 row must carry, so a row cannot be hollowed out and a case
+;; cannot be deleted from the corpus while the profile still advertises it.
+;; ---------------------------------------------------------------------------
+
+(def frozen-s4-parity-cases
+  {:presence-two
+   {:view :presence-toasts
+    :row-fragments ["**no node of its own**"
+                    "marker fragment is stripped by `N`"
+                    "phase Provider is invisible in markup"]}
+   :presence-empty
+   {:view :presence-toasts
+    :row-fragments ["structurally inert on both hosts"]}
+   :presence-inline
+   {:view :presence-inline
+    :row-fragments ["**mid-tree**"
+                    "inline keyed literal markup"
+                    "siblings are undisturbed"]}
+   :ce-declared-attr-name
+   {:view :ce-attrish
+    :row-fragments ["standard HTML attribute spelling"
+                    "`:tab-index`"
+                    "stays a **PROPERTY** on both emitters"]}
+   :trusted-hostile
+   {:view :trusted
+    :row-fragments ["crosses **verbatim** on both hosts"
+                    "`javascript:` scheme is not gated"]}})
+
+;; ---------------------------------------------------------------------------
+;; (4) The S4-specific gate arms this profile certifies (07 §5 / EP-0034 §4).
+;; S4 introduces NO new named gate — it GROWS two existing ones. The §6 roster
+;; must name exactly this set.
+;; ---------------------------------------------------------------------------
+
+(def s4-arm-gates #{"G-7" "G-11"})
+
+;; ===========================================================================
+;; Executable surface pins — the shipped code honours each catalogued contract.
+;; ===========================================================================
+
+(defn- repo-root []
+  (loop [d (io/file (System/getProperty "user.dir"))]
+    (cond
+      (nil? d) nil
+      (.exists (io/file d "spec" "conformance")) d
+      :else (recur (.getParentFile d)))))
+
+(defn- profile-doc []
+  (io/file (repo-root) "spec" "conformance" "S4-view-conformance-profile.md"))
+
+(defn- err-id
+  "Run `f`; -> the thrown `:rf.error/id`, or ::no-throw."
+  [f]
+  (try (f) ::no-throw
+       (catch clojure.lang.ExceptionInfo e (:rf.error/id (ex-data e)))))
+
+(defn- ex-data-of [f]
+  (try (f) nil (catch clojure.lang.ExceptionInfo e (ex-data e))))
+
+(deftest s4-forms-resolve-with-their-frozen-kinds
+  (testing "every catalogued S4 form resolves in its namespace with the frozen kind"
+    (doseq [[sym {:keys [ns kind]}] frozen-s4-forms]
+      (let [v (ns-resolve ns sym)]
+        (is (some? v) (str sym " must resolve in " ns))
+        (case kind
+          :macro (is (true? (:macro (meta v)))
+                     (str sym " must be a def-level macro"))
+          (is (not (:macro (meta v)))
+              (str sym " must be a fn, not a macro")))
+        (is (not (:rf.ui/view (meta v)))
+            (str sym " is an S4 form, not a compiled view"))))))
+
+(deftest presence-is-a-fail-loud-template-form
+  (testing "a direct (ui/presence …) call fails loud — the compiler owns the form"
+    (is (= :rf.error/ui-tree-malformed (err-id #(ui/presence {:timeout-ms 300})))))
+  (testing "the catalogued direct-call error is the one the code raises"
+    (is (= (:direct-error (frozen-s4-forms 'presence))
+           (err-id #(ui/presence {:timeout-ms 300}))))))
+
+(deftest presence-phase-reads-present-outside-a-boundary
+  ;; The reusability law: a presence-aware child rendered ANYWHERE reads
+  ;; :present, so it never needs a boundary to be legal.
+  (is (= (:jvm-value (frozen-s4-forms 'presence-phase)) (ui/presence-phase)))
+  (is (= :present (ui/presence-phase))
+      "presence-phase outside a boundary (and on the JVM) is :present"))
+
+(deftest flush-presence-is-a-jvm-no-op-at-both-arities
+  (let [{:keys [arities jvm-value]} (frozen-s4-forms 'flush-presence!)]
+    (is (= #{0 1} arities))
+    (is (= jvm-value (uit/flush-presence!)) "zero-arity JVM flush is a nil no-op")
+    (is (= jvm-value (uit/flush-presence! 500)) "ms-arity JVM flush is a nil no-op")))
+
+(deftest raw-and-html-honour-their-catalogued-jvm-behaviour
+  (testing "ui/raw is host-bearing: a JVM call raises the typed host-op error naming its op"
+    (let [d (ex-data-of #(ui/raw ::anything))]
+      (is (= (:direct-error (frozen-s4-forms 'raw)) (:rf.error/id d)))
+      (is (= (:host-op (frozen-s4-forms 'raw)) (:op d))
+          "the ex-data names WHICH host-bearing form was hit")))
+  (testing "ui/raw-fn passes the fn through verbatim (identity-as-protocol)"
+    (let [f (fn [_] :ok)]
+      (is (identical? f (ui/raw-fn f)))))
+  (testing "ui/html sanitises nothing — the JVM arm builds the verbatim leaf"
+    (let [hostile "<a href=\"javascript:alert(1)\">x</a><b>a & b</b>"]
+      (is (= {:html hostile} (ui/html hostile))
+          "no escaping, no tag/attribute filter, no scheme gate")))
+  (testing "the ONLY runtime guard on trusted markup is a `string?` SHAPE check"
+    (is (= (:shape-error (frozen-s4-forms 'html)) (err-id #(ui/html 42))))
+    (is (= {:html ""} (ui/html ""))
+        "an empty string is a legal inert bypass — emptiness is not a content rule")))
+
+;; --- presence compile-tier pins --------------------------------------------
+
+(defn- presence-env []
+  (env/make-env {:host :clj :ns-sym 'app.s4probe
+                 :self 'self-view :self-id :app.s4probe/self-view
+                 :resolver (fn [sym]
+                             (case sym
+                               presence {:fqn 're-frame.ui/presence :meta {}}
+                               nil))}))
+
+(defn- compile-err-id [form]
+  (:rf.ui.compile/error (ex-data-of #(ana/analyze (presence-env) form))))
+
+(deftest presence-compile-errors-are-the-catalogued-ids
+  (let [{:keys [compile-errors]} (frozen-s4-forms 'presence)
+        [bad-presence unkeyed] compile-errors]
+    (testing "a MISSING :timeout-ms is a build failure — it is mandatory, not defaulted"
+      (is (= bad-presence
+             (compile-err-id '(presence {} (for [t ts] [:li {:key (:id t)} "a"]))))))
+    (testing "a non-positive :timeout-ms is the same build failure"
+      (is (= bad-presence
+             (compile-err-id '(presence {:timeout-ms 0} (for [t ts] [:li {:key (:id t)} "a"]))))))
+    (testing "an UNKEYED child under a presence boundary is a build failure"
+      (is (= unkeyed
+             (compile-err-id '(presence {:timeout-ms 300} [:li "no key"])))))
+    (testing "the well-formed shape compiles (the checks are not blanket rejections)"
+      ;; The keyed `(for …)` — keyed by construction. NOTE: a keyed LITERAL
+      ;; element is currently still rejected here; that is the open bug
+      ;; rf2-vxgfnd.96.1, deliberately not asserted either way by this profile.
+      (is (= :presence (:op (ana/analyze (presence-env)
+                                         '(presence {:timeout-ms 300}
+                                            (for [t ts] [:li {:key (:id t)} "a"])))))))))
+
+;; --- custom-element pins ----------------------------------------------------
+
+(deftest custom-element-property-names-lower-kebab-to-camelcase
+  ;; The RULED name mapping the §1.2 row states — the declaration is the sole
+  ;; classifier, so even a standard-attribute spelling camelizes when declared.
+  (is (= "accentColor" (rules/custom-element-property-name "accent-color")))
+  (is (= "helpText" (rules/custom-element-property-name "help-text")))
+  (is (= "tabIndex" (rules/custom-element-property-name "tab-index"))))
+
+;; --- a11y roster pins -------------------------------------------------------
+
+(deftest a11y-roster-is-exactly-the-catalogue
+  (testing "the compile-tier a11y roster is EXACTLY the four catalogued ids — an addition is a roster change"
+    (is (= (set (keys frozen-a11y-roster)) a11y/a11y-warning-ids)
+        (str "a11y roster drift — "
+             "uncatalogued: " (sort (set/difference a11y/a11y-warning-ids
+                                                    (set (keys frozen-a11y-roster))))
+             "; catalogued-but-absent: " (sort (set/difference (set (keys frozen-a11y-roster))
+                                                               a11y/a11y-warning-ids))))))
+
+(deftest a11y-ids-are-compile-tier-with-no-spec-009-row
+  (testing "every a11y id is a COMPILE-tier id (rf.ui.compile), not a runtime error/trace id"
+    (doseq [id (keys frozen-a11y-roster)]
+      (is (= "rf.ui.compile" (namespace id))
+          (str id " must be a compile-tier id"))))
+  (testing "no a11y id has a Spec 009 catalogue row — the compile tier has no runtime emission"
+    (let [spec-009 (slurp (io/file (repo-root) "spec" "009-Instrumentation.md"))]
+      (doseq [id (cons a11y-suppress-error (keys frozen-a11y-roster))]
+        (is (not (str/includes? spec-009 (str id)))
+            (str id " must NOT have a Spec 009 row — it is compile-tier only"))))))
+
+(deftest malformed-a11y-suppression-is-a-loud-compile-error
+  ;; The suppression round trip's loud half: an unknown id, or a blank / non-string
+  ;; reason, is a build failure — never a silent no-op that hides a real finding.
+  (let [env-fn #(-> (env/make-env {:host :clj :ns-sym 'app.s4suppress
+                                   :self 'self-view :self-id :app.s4suppress/self-view
+                                   :resolver (constantly nil)})
+                    (assoc :self-children? false :self-closed-keys nil))
+        reject (fn [form]
+                 (:rf.ui.compile/error
+                  (ex-data-of #(ana/analyze (env-fn) form))))]
+    (testing "an unknown suppression id"
+      (is (= a11y-suppress-error
+             (reject '^{:rf.ui/suppress {:rf.ui.compile/a11y-nonsense "r"}}
+                     [:p "fine"]))))
+    (testing "a blank reason"
+      (is (= a11y-suppress-error
+             (reject '^{:rf.ui/suppress {:rf.ui.compile/a11y-click-non-interactive "  "}}
+                     [:p "fine"]))))
+    (testing "a non-string reason"
+      (is (= a11y-suppress-error
+             (reject '^{:rf.ui/suppress {:rf.ui.compile/a11y-click-non-interactive true}}
+                     [:p "fine"]))))))
+
+;; --- §3 the document head is host-owned: bound as an ABSENCE ----------------
+
+(deftest no-head-targeting-surface-exists
+  (testing "the re-frame.ui facade exposes no head-targeting public"
+    (let [publics (set (map name (keys (ns-publics 're-frame.ui))))]
+      (is (not (contains? publics "head")) "there is no ui/head")
+      (is (empty? (filter #(str/includes? % "head") publics))
+          (str "a head-targeting facade public appeared: "
+               (sort (filter #(str/includes? % "head") publics))
+               " — §3 of the profile says the document head is host-owned"))))
+  (testing "the compiler's CLOSED op set carries no head channel"
+    (is (not (contains? ana/node-ops :head)))
+    (is (empty? (filter #(str/includes? (name %) "head") ana/node-ops))
+        "no AST op may target the document head")))
+
+;; --- §4 the W14 parity rows exist in the shipped corpus ---------------------
+
+(deftest s4-parity-cases-are-in-the-shipped-corpus
+  (testing "every catalogued S4 parity row is exactly one live corpus case over the view it names"
+    (let [by-id (group-by :id fx/cases)]
+      (doseq [[id {:keys [view]}] frozen-s4-parity-cases]
+        (let [matches (get by-id id)]
+          (is (= 1 (count matches))
+              (str "corpus case " id " must exist exactly once in parity-fixtures/cases"))
+          (when (= 1 (count matches))
+            (is (= view (:view (first matches)))
+                (str "corpus case " id " must render the catalogued view " view)))))))
+  (testing "every view an S4 parity row names is a real compiled corpus view"
+    (doseq [[id {:keys [view]}] frozen-s4-parity-cases]
+      (is (some? (get fx/views view))
+          (str "the view " view " named by S4 parity row " id " is not in parity-fixtures/views")))))
+
+;; ===========================================================================
+;; Document drift guard — the human profile stays EXACT against this surface,
+;; validated row by row rather than by whole-document token presence.
+;; ===========================================================================
+
+(defn- table-row-for
+  "The single Markdown table row whose FIRST cell is exactly `token`, or nil when
+  there is not exactly one. Keying on the first cell (not mere occurrence) binds
+  a form to its OWN §1 catalogue row: prose mentions, wall bullets, and rows that
+  merely reference the form mid-contract do not match."
+  [lines token]
+  (let [first-cell (fn [line]
+                     (let [t (str/triml line)]
+                       (when (str/starts-with? t "|")
+                         (-> t (subs 1) (str/split #"\|") first str/trim))))
+        rows       (filter #(= token (first-cell %)) lines)]
+    (when (= 1 (count rows)) (first rows))))
+
+(defn- section-between
+  "The region of `text` from header `from` up to header `to`, so a claim is read
+  from the section that owns it rather than from incidental prose elsewhere."
+  [text from to]
+  (let [start (str/index-of text from)
+        end   (str/index-of text to)]
+    (when (and start end (< start end)) (subs text start end))))
+
+(defn- doc-lines [] (str/split-lines (slurp (profile-doc))))
+
+(defn- check-row!
+  "Assert the profile row keyed by `token` exists exactly once and carries every
+  fragment + every id in `musts`."
+  [lines token musts fragments]
+  (let [row (table-row-for lines token)]
+    (is (some? row)
+        (str "the profile must catalogue " token " in exactly one table row"))
+    (when row
+      (doseq [m musts]
+        (is (str/includes? row (str m))
+            (str token "'s row must name " m)))
+      (doseq [f fragments]
+        (is (str/includes? row f)
+            (str token "'s row must carry its contract fragment: " f))))
+    row))
+
+(deftest profile-document-exists
+  (is (some? (repo-root)) "must locate the repo root (spec/conformance)")
+  (is (.exists (profile-doc))
+      (str "the S4 profile document must exist at " (profile-doc))))
+
+(deftest profile-catalogues-every-s4-form-row-exactly
+  (testing "each frozen S4 form has one §1 row naming its errors, proof homes and contract"
+    (let [lines (doc-lines)]
+      (doseq [[sym {:keys [token direct-error compile-errors shape-error host-op
+                           jvm-proof cljs-proof row-fragments]}] frozen-s4-forms]
+        (testing (str sym)
+          (check-row! lines token
+                      (concat (when direct-error [direct-error])
+                              (when shape-error [shape-error])
+                              (when host-op [host-op])
+                              compile-errors
+                              [jvm-proof cljs-proof])
+                      row-fragments))))))
+
+(deftest profile-catalogues-the-foreign-head-row-exactly
+  (testing "the foreign component head owns its own §1.4 row, distinct from ui/raw"
+    (let [{:keys [token error host-op jvm-proof cljs-proof row-fragments]} frozen-foreign-head]
+      (check-row! (doc-lines) token
+                  [error host-op jvm-proof cljs-proof]
+                  row-fragments))))
+
+(deftest profile-catalogues-every-a11y-row-exactly
+  (testing "each a11y id has one §1.3 row naming what it fires on and the author remedy"
+    (let [lines (doc-lines)]
+      (doseq [[id {:keys [row-fragments]}] frozen-a11y-roster]
+        (check-row! lines (str "`" id "`") [] row-fragments))))
+  (testing "§1.3 pins the compile-tier posture, the closed roster, the suppression grammar, and its proof home"
+    (let [section (section-between (slurp (profile-doc)) "### 1.3" "### 1.4")]
+      (is (some? section) "the profile must have a §1.3 a11y section and a §1.4 header")
+      (when section
+        (doseq [claim ["no Spec 009 catalogue row"
+                       "no runtime emission"
+                       "closed"
+                       "`^{:rf.ui/suppress {<id> \"reason\"}}`"
+                       (str a11y-suppress-error)
+                       a11y-proof-home]]
+          (is (str/includes? section claim)
+              (str "§1.3 must state: " claim)))))))
+
+(deftest profile-catalogues-every-s4-parity-row-exactly
+  (testing "each W14 S4 corpus row is one §4 table row naming the claim it pins"
+    (let [lines (doc-lines)]
+      (doseq [[id {:keys [row-fragments]}] frozen-s4-parity-cases]
+        (check-row! lines (str "`" id "`") [] row-fragments))))
+  (testing "§4 states the parity contract and names what is deliberately OUT of the corpus"
+    (let [section (section-between (slurp (profile-doc)) "## 4." "## 5.")]
+      (is (some? section) "the profile must have a §4 parity section and a §5 header")
+      (when section
+        (doseq [claim ["normalized structural equivalence"
+                       "byte-identical HTML is *not* the contract"
+                       "no JVM side to compare"
+                       ":rf.error/jvm-host-op"]]
+          (is (str/includes? section claim)
+              (str "§4 must state: " claim)))))))
+
+(deftest profile-names-real-proof-homes
+  ;; A proof home that is not a real test namespace is a lie the row-binding
+  ;; checks above cannot see — they only prove the STRING is in the row.
+  (let [test-root (io/file (repo-root) "implementation" "ui" "test")
+        exists?   (fn [ns-name]
+                    (let [base (-> ns-name (str/replace "-" "_") (str/replace "." "/"))]
+                      (some #(.exists (io/file test-root (str base %)))
+                            [".clj" ".cljs" ".cljc"])))]
+    (doseq [home (concat (mapcat (juxt :jvm-proof :cljs-proof) (vals frozen-s4-forms))
+                         [(:jvm-proof frozen-foreign-head)
+                          (:cljs-proof frozen-foreign-head)
+                          a11y-proof-home])]
+      (is (exists? home)
+          (str "the profile names proof home " home
+               ", which is not a test namespace under implementation/ui/test")))))
+
+(deftest profile-gate-roster-is-exactly-the-arm-set
+  (testing "the §6 gate roster names EXACTLY the certified S4 arms — S4 adds NO new named gate"
+    (let [roster (section-between (slurp (profile-doc)) "## 6." "## 7.")]
+      (is (some? roster) "the profile must have a §6 gate roster and a §7 header")
+      (when roster
+        (let [named (set (map second (re-seq #"\*\*(G-\d+)\*\*" roster)))]
+          (is (= s4-arm-gates named)
+              (str "§6 gate-roster drift — "
+                   "extra: " (sort (set/difference named s4-arm-gates))
+                   "; missing: " (sort (set/difference s4-arm-gates named)))))
+        (is (str/includes? roster "no new named gate")
+            "§6 must state that S4 introduces no new named gate")))))
+
+(deftest profile-documents-the-head-policy-and-the-non-surface-wall
+  (let [text (slurp (profile-doc))]
+    (testing "§3 records the host-owned head policy as an ABSENCE of surface"
+      (let [section (section-between text "## 3." "## 4.")]
+        (is (some? section) "the profile must have a §3 head section and a §4 header")
+        (when section
+          (doseq [claim ["No compiled-view form renders into `<head>`"
+                         "no `ui/head`"
+                         "**absence of surface**"
+                         "`reg-head`"]]
+            (is (str/includes? section claim)
+                (str "§3 must state: " claim))))))
+    (testing "§5 enumerates the explicit S4 non-surfaces (the wall)"
+      (let [section (section-between text "## 5." "## 6.")]
+        (is (some? section) "the profile must have a §5 wall and a §6 header")
+        (when section
+          (doseq [claim ["not an animation system"
+                         "wrapper node"
+                         "**retracted**"
+                         "no optional `:timeout-ms`"
+                         "sole classifier"
+                         "**sanitisation**"
+                         "head-targeting"
+                         "compile-tier only"]]
+            (is (str/includes? section claim)
+                (str "the §5 wall must enumerate: " claim))))))))

--- a/spec/conformance/S4-view-conformance-profile.md
+++ b/spec/conformance/S4-view-conformance-profile.md
@@ -10,12 +10,29 @@ boundary, and the explicit non-surfaces) and names, for each row, the suite or
 gate that proves it. The runtime behaviour is proven by those homes (browser /
 JVM / corpus suites), not re-asserted in prose here.
 
+## 0. Inheritance — this profile is cumulative and rows only the S4 delta
+
+**"S4-conforming" means S3-conforming plus everything below.** S1–S3 are
+inherited **by exact reference** to the frozen S3 profile,
+[`spec/conformance/S3-view-conformance-profile.md`](S3-view-conformance-profile.md),
+which remains the sole authority for the ten compiler-owned verbs, the
+`route-link` view, and the seven-wrapper React interop tier. This document
+**does not restate any of it** — restating a frozen roster is how the two
+profiles drift apart. It rows only the S4 **delta**:
+
+- presence (`ui/presence`, `ui/presence-phase`, `ui.test/flush-presence!`);
+- the ruled custom-element property-vs-attribute classification;
+- the completed `ui/raw` foreign boundary (and `ui/html`'s no-sanitisation
+  contract);
+- the ruled compile-tier a11y roster;
+- the no-compiled-head structural policy, **by reference** to its ruling.
+
 S4 adds no new verb to the `re-frame.ui` facade. Its forms were **exported at
 S1** for symbol resolution and **assert at S4** — the stage froze *behaviour*
-over an already-blessed surface. The S3 verbs, the `route-link` view, and the
-React interop tier are catalogued in
-[S3-view-conformance-profile.md](S3-view-conformance-profile.md) and are
-unchanged here.
+over an already-blessed surface. The drift guard composes with the S3 guard
+rather than duplicating it: it reuses that guard's row-binding machinery and its
+published rosters, and fails loudly on a **new public surface**, a **broken
+inheritance link**, or a **moved or deleted proof row**.
 
 The frozen surface and the proof references are kept honest by an executable
 drift guard,
@@ -50,6 +67,16 @@ Presence is **DOM-agnostic and timeout-only** (ruled, `rf2-0ufty`): the boundary
 inserts no wrapper node, stamps no attributes, and observes no DOM events. A
 presence-aware child owns its own exit styling and accessibility by reading
 `(ui/presence-phase)`.
+
+> **Sequencing — these rows track the POST-FIX presence grammar.** Two S4-epic
+> bugs are **open** and both change the *accepted* presence grammar:
+> `rf2-vxgfnd.96.1` (**P1** — keyed literal children are wrongly rejected) and
+> `rf2-vxgfnd.96.2` (**P2** — duplicate ownership identities are wrongly
+> accepted). The rows below state the grammar as ruled, which is the grammar
+> that will ship once both close; today's compiler rejects a keyed *literal*
+> child that these rows admit. **Closing both is part of the S4-conforming
+> declaration** — S4 cannot honestly be declared conforming over a known P1
+> presence grammar bug (see §8).
 
 | Form | Kind | Contract | Loud failure | Proven by |
 |---|---|---|---|---|
@@ -146,19 +173,38 @@ catalogued in §4.
 
 ## 3. The document head is host-owned
 
-**No compiled-view form renders into `<head>`.** There is no head-targeting form,
-no `ui/head`, and no head channel in the view AST or the JVM tree; `re-frame.ui`
-mounts into a root element inside `<body>`. `ui/html` does not widen this — it is
-the sole child of a **DOM element**, and `<head>` is neither a mount target nor
-reachable from a template. The document head belongs to the **host**: the HTML
-shell the app serves and, for server-rendered apps, Spec 011's structured
-`reg-head` / `active-head` channel.
+**No compiled *structural* form renders into `<head>`.** There is no
+head-targeting form, no `ui/head`, and no head channel in the view AST or the
+JVM tree; `re-frame.ui` mounts into a root element inside `<body>`. `ui/html`
+does not widen this — it is the sole child of a **DOM element**, and `<head>` is
+neither a mount target nor reachable from a template. The document head belongs
+to the **host**: the HTML shell the app serves and, for server-rendered apps,
+Spec 011's structured `reg-head` / `active-head` channel.
 
-This row states an **absence of surface**, not a behaviour, so it has no
+**`ui/raw` does widen it, and that is deliberate.** A foreign value handed to
+React verbatim may be a **portal**, and a portal renders into whatever container
+the caller names, `document.head` included. Nodes placed that way are host
+behaviour the **caller owns** — outside head ordering, de-duplication,
+precedence, and every hydration guarantee, `:rf/head-hash` mismatch detection
+included. What survives is **enumerability**: every site declares the `:raw`
+capability and is recorded in the manifest, so the set of such escapes is finite
+and listable. The **JVM tree has no such route** — `:raw` raises
+`:rf.error/jvm-host-op` — so a server-rendered head still comes only from
+`reg-head` / `active-head`.
+
+**Normative ownership (ruled, `rf2-3i7tr`) — do not reopen.** Spec 004
+normatively owns the compiled-view *structural absence* (no `ui/head`, no head
+target, no portable head channel, qualified at the `ui/raw` foreign boundary).
+Spec 011 normatively owns the *structured document-head mechanism* (`reg-head` /
+`render-head` / `active-head`, head-model shape, escaping, shell emission,
+ordering, `:rf/head-hash`, mismatch behaviour). Spec 009 owns only the
+trace/error projection. S4 adds **no head machinery** and takes no position
+beyond citing that ruling.
+
+This section states an **absence of surface**, not a behaviour, so it has no
 behavioural fixture. What the drift guard binds is exactly the absence: the
 `re-frame.ui` facade exposes no head-targeting public, and the compiler's closed
-form set contains no head op. Spec 004 records the standing policy and the open
-question of which Spec normatively *owns* it — that ruling is not S4's.
+form set contains no head op.
 
 ## 4. W14 dual-emitter parity — the S4 corpus rows
 
@@ -176,13 +222,33 @@ rows (the view-shape sweep, W14):
 | `:ce-declared-attr-name` | the adversarial classification row: a **declared** name that is also a standard HTML attribute spelling (`:tab-index`) stays a **PROPERTY** on both emitters and is written into markup by neither, while undeclared siblings stay ordinary attributes |
 | `:trusted-hostile` | `ui/html` crosses **verbatim** on both hosts — a `javascript:` scheme is not gated, and nothing about the string is inspected |
 
-**Deliberately out of the corpus** (documented, not silently skipped): `ui/raw`
-and the foreign component head have **no JVM side to compare** — rendering them
-on the JVM is `:rf.error/jvm-host-op` by contract, so their boundary corpus is
-the `raw_foreign_boundary_*` pair; presence's **three-phase machine** and any
-`(ui/presence-phase)` read are host-bearing — retention timers and the phase a
-*first* render reports are mounted (and, for the server, S5) questions, proven in
-`presence_dom_cljs_test` and `presence_jvm_test`.
+### 4.1 The intentional NON-parity facts
+
+Some S4 facts are **not** structural-equivalence facts and must never be forced
+through the comparator — a fixture that pretends otherwise is a false green.
+Each is rowed here against the paired or compile-time proof home that really
+owns it:
+
+| S4 fact | Why it is not a parity fact | Real proof home |
+|---|---|---|
+| `ui/raw` / foreign component head | a **host escape** — rendering it on the JVM raises `:rf.error/jvm-host-op` by contract, so there is **no JVM side to compare** | paired: `re-frame.ui.raw-foreign-boundary-jvm-test` + `re-frame.ui.raw-foreign-boundary-dom-cljs-test` |
+| the document head | an **absence of surface** (§3), not an emitted shape — there is nothing for either emitter to produce | the facade/op-set absence guards in this profile's drift guard |
+| the a11y roster | **compile-time analyzer facts** — findings are produced during analysis and never reach either emitter's output | `re-frame.ui.a11y-diagnostics-cljs-test` (host-shared, pure analyzer) |
+| presence's three-phase machine | **host-bearing** — retention timers, and the phase a *first* render reports, are mounted questions (and, for the server, S5's) | `re-frame.ui.presence-dom-cljs-test` (mounted) + `re-frame.ui.presence-jvm-test` (structural) |
+
+The corpus rows above carry only the **portable** half of each S4 surface — the
+structural output both emitters must agree on.
+
+For presence the portable half is precisely this: the JVM emits its `:present`
+marker fragment and `N` strips it; the client wraps each child in a phase
+Provider, which is invisible in markup. Both therefore emit **exactly the
+children** — the boundary's own contribution to the output is zero nodes on both
+hosts. The **phase value itself is not portable at first render**: the JVM
+structural subset reports `:present`, while an ordinary first *client* render
+necessarily enters `:mounting` (the component starts with no committed entries),
+which is correct pre-hydration. Reconciling those — so a server-adopted child
+starts `:present` without fabricating an enter transition — is S5's obligation,
+recorded as the `rf2-d9yq3` rider in §7. No corpus row may assert a phase value.
 
 ## 5. Non-surfaces (the S4 wall)
 
@@ -208,6 +274,15 @@ an API redesign or a named interop boundary, never a substrate exception:
 - no silent a11y suppression — an unknown id or a blank reason is a loud compile
   error.
 
+**Deliberately deferred to S5 (`rf2-vxgfnd.97`) — S4 claims no conformance for
+any of it:** the **Root Manifest** (v1 extension keys, wire/discovery) and
+**hydration** (preflight, idempotent payload install, locator/registry conflicts,
+fingerprint/digest validation); **`render-static`**; the **`client-only` phase
+flip**; **multi-root hydration** and **failed-root isolation**; and the
+root-hydration half of W14. `hydrate-root` remains deliberately fail-loud until
+that stage. A fixture here that appeared to prove any of them would be stage
+collapse, not coverage.
+
 ## 6. The gate roster (S4 arms)
 
 The full G-1..G-18 roster lives in `docs/EP/EP-0034` §4 and the 07 §5 gate
@@ -216,13 +291,38 @@ ones:
 
 | Gate | S4 arm |
 |---|---|
-| **G-7** | dev/prod equivalence extended to the S4 surfaces — committed DOM, presence retention/removal, and custom-element property application agree with debug off; the a11y roster is compile-tier and emits nothing at runtime in either build |
-| **G-11** | exact production absence extended to the S4 test surface — `re-frame.ui.test` (now including `flush-presence!`) and every compile-tier diagnostic string stay out of advanced production bundles |
+| **G-7** | dev↔prod equivalence for **S4 shapes only** — committed DOM, presence retention/removal, and custom-element property application agree with debug off; the a11y roster is compile-tier and emits nothing at runtime in either build |
+| **G-11** | S4 diagnostic / site / reload / test machinery absent from advanced production output — `re-frame.ui.test` (now including `flush-presence!`) and every compile-tier diagnostic string stay out of advanced production bundles |
+
+**The G-7 growth is bounded, deliberately.** G-7 today has no equivalence test
+beyond its production-absence arm, so S4 writes G-7's **first** equivalence arms
+— and writes them for **S4 shapes only**. The broader retroactive S1–S3
+equivalence-matrix debt is **not** in scope here and keeps its existing
+named-open owner; S4 does not discharge it, and no row in this profile should be
+read as claiming it. Both arms wire into the **existing** required
+JVM / CLJS / DOM / parity / production-elision jobs — no new job, no new named
+gate, and no S5 SSR build in the S4 matrix.
 
 Everything else S4 froze is proven by the named suites in §1 and the parity
 corpus in §4, not by a gate arm.
 
-## 7. Conformance grading
+## 7. Hand-off to S5
+
+S5 (`rf2-vxgfnd.97`) already carries the obligations that S4's surfaces create.
+This row **cites** them; it creates **no parallel obligation**:
+
+| Obligation (recorded on `rf2-vxgfnd.97`) | Origin |
+|---|---|
+| S5-obligation (1) — **root-manifest hydration + failed-root isolation fixtures** | the residual named gate from the stage plan |
+| **AUDIT RIDER** — a multi-root fixture proving **hydrated presence starts `:present`** (while a client-only mount still observes `:mounting → :present`), with sibling-root isolation | `rf2-d9yq3` / PR #6261 |
+| **AUDIT RIDER** — one real **SSR-adoption custom-element** fixture: server markup carries declared attributes only and omits the declared property under both spellings; hydrate without replacement; the declared property applies under camelCase | `rf2-aozoi` / PR #6276 |
+
+S4 leaves the canonical **semantic normalizer** (Spec 004B's `N`) and the
+**render-fingerprint vocabulary** as the contract S5 consumes — unchanged by this
+stage, and the reason a hydration fixture can be written at S5 without
+re-deriving the comparison space.
+
+## 8. Conformance grading
 
 An S4-conforming host emits, for the frozen surface above: the presence
 retention contract with its mandatory `:timeout-ms`, exactly-once terminal
@@ -231,6 +331,14 @@ classification with its JVM attributes-only / client properties-at-hydration
 split (§1.2); the four compile-tier a11y diagnostics with their suppression round
 trip (§1.3); the foreign-boundary laws and `ui/html`'s no-sanitisation contract
 (§1.4); the host behaviour of §2; a host-owned document head (§3); the parity
-rows of §4; and none of the non-surfaces (§5). The gate arms in §6 and the suites
-named throughout are the executable acceptance; `scripts/test-fast-pr.sh` plus
-the S4 CI matrix run them.
+rows of §4; and none of the non-surfaces (§5). It must also be **S3-conforming**
+— §0 inherits S1–S3 by reference, and a host that fails the S3 profile fails
+this one. The gate arms in §6 and the suites named throughout are the executable
+acceptance; `scripts/test-fast-pr.sh` plus the S4 CI matrix run them.
+
+**S4 is not yet declarable conforming.** Two presence grammar bugs are open —
+`rf2-vxgfnd.96.1` (**P1**, keyed literal children wrongly rejected) and
+`rf2-vxgfnd.96.2` (**P2**, duplicate ownership identities wrongly accepted) —
+and both change the accepted presence grammar this profile's §1.1 rows state.
+**Closing both is part of the S4-conforming declaration**; the stage cannot
+honestly be declared conforming over a known P1 presence grammar bug.

--- a/spec/conformance/S4-view-conformance-profile.md
+++ b/spec/conformance/S4-view-conformance-profile.md
@@ -1,0 +1,236 @@
+# S4 view-substrate conformance profile
+
+**Status:** Reference · owned by `rf2-yho9j` (the S4 conformance gate).
+
+This is the single authoritative catalogue of the frozen S4 surface of
+`re-frame.ui` — the compiled-view substrate's **presence and web-boundaries**
+stage. It fixes *what* S4 froze (the presence retention boundary, the ruled
+custom-element classification, the compile-tier a11y roster, the foreign
+boundary, and the explicit non-surfaces) and names, for each row, the suite or
+gate that proves it. The runtime behaviour is proven by those homes (browser /
+JVM / corpus suites), not re-asserted in prose here.
+
+S4 adds no new verb to the `re-frame.ui` facade. Its forms were **exported at
+S1** for symbol resolution and **assert at S4** — the stage froze *behaviour*
+over an already-blessed surface. The S3 verbs, the `route-link` view, and the
+React interop tier are catalogued in
+[S3-view-conformance-profile.md](S3-view-conformance-profile.md) and are
+unchanged here.
+
+The frozen surface and the proof references are kept honest by an executable
+drift guard,
+`implementation/ui/test/re_frame/ui/s4_conformance_profile_jvm_test.clj`: its
+`frozen-s4-forms`, `frozen-a11y-roster`, `frozen-s4-parity-cases` and
+`s4-arm-gates` maps are the source of truth this document restates. Every
+roster is bound row by row — the guard fails if a §1 row is missing or
+duplicated, if a row stops naming the error, kind, contract fragments or proof
+homes its map entry fixes, if a named proof home is not a real test namespace,
+if the §4 corpus row set drifts from the shipped parity cases, or if the §6
+roster stops naming exactly the certified S4 arms. Deleting a row, hollowing
+one out, or swapping a contract or proof home between rows is red.
+
+## 1. Frozen S4 surface
+
+Four closed rosters: the **presence** boundary and its phase read, the ruled
+**custom-element** classification, the compile-tier **a11y** diagnostics, and
+the **foreign boundary**.
+
+### 1.1 Presence — declarative enter/exit retention
+
+`ui/presence` is a bounded retention boundary, **not an animation system**. A
+`(ui/presence {:timeout-ms n} keyed-children)` boundary tracks its children by
+key: a key passes `:mounting → :present`; a key that leaves the incoming set is
+**retained** in `:unmounting` for exactly `:timeout-ms` — the mandatory exit
+retention duration *and* terminal bound — after which removal is terminal and
+**exactly-once** (React unmounts the retained subtree, releasing every lease and
+effect it owns). Removal-then-reinsertion interrupts the exit and re-enters at
+`:present`.
+
+Presence is **DOM-agnostic and timeout-only** (ruled, `rf2-0ufty`): the boundary
+inserts no wrapper node, stamps no attributes, and observes no DOM events. A
+presence-aware child owns its own exit styling and accessibility by reading
+`(ui/presence-phase)`.
+
+| Form | Kind | Contract | Loud failure | Proven by |
+|---|---|---|---|---|
+| `ui/presence` | template form (compiler-owned); direct call fails loud | keyed enter/exit retention; `:timeout-ms` is **mandatory** — the exit retention duration and the terminal bound; terminal removal is **exactly-once**; re-insertion interrupts the exit; the boundary contributes **no node of its own** | direct call `:rf.error/ui-tree-malformed`; a missing/non-positive `:timeout-ms` or a bad opts map is `:rf.ui.compile/bad-presence`; an **unkeyed child is a build failure**, `:rf.ui.compile/presence-unkeyed-child` | JVM `re-frame.ui.presence-jvm-test`; CLJS `re-frame.ui.presence-dom-cljs-test` |
+| `ui/presence-phase` | ordinary fn — the single phase read | `:mounting` / `:present` / `:unmounting` inside a boundary; **`:present` outside one**, so presence-aware children stay reusable anywhere; the JVM structural subset always yields `:present` | none — a direct call is legal and returns `:present` | JVM `re-frame.ui.presence-jvm-test`; CLJS `re-frame.ui.presence-dom-cljs-test` |
+| `ui.test/flush-presence!` | test-surface driver | advances the presence **fake clock** so retained children reach their `:timeout-ms` removal with **no wall-clock sleep**: `(flush-presence!)` drains to quiescence, `(flush-presence! ms)` advances by `ms`; the sole and complete exit driver in tests; a synchronous `nil` no-op on the JVM (host parity for `.cljc` bodies) | none | JVM `re-frame.ui.presence-jvm-test`; CLJS `re-frame.ui.presence-dom-cljs-test` |
+
+The pure three-phase entry derivation (`reconcile`) is host-shared and unit-tested
+in `re-frame.ui.presence-reconcile-cljs-test`.
+
+### 1.2 Custom elements — the ruled property-vs-attribute classification
+
+`ui/custom-element` **exports at S1**; its classification behaviour **asserts at
+S4**. The declaration is the **sole classifier** — never an attribute-name
+heuristic:
+
+| Form | Kind | Contract | Loud failure | Proven by |
+|---|---|---|---|---|
+| `ui/custom-element` | def-level declaration macro | closed `{:properties #{…}}` grammar; the declaration is the **sole classifier** — a **declared** name is a PROPERTY under the ruled **kebab → camelCase** JS property name (`:accent-color` → `accentColor`), every other name is an ATTRIBUTE, an **undeclared element is all-attributes**, and a declared name that is also a standard HTML attribute spelling is still a PROPERTY | `:rf.ui.compile/bad-custom-element`; two sources declaring one tag with different sets is `:rf.ui.compile/custom-element-conflict` | JVM `re-frame.ui.custom-element-classification-jvm-test`; CLJS `re-frame.ui.custom-element-classification-dom-cljs-test` |
+
+**Host split.** The JVM emitter carries **attributes only** into markup —
+property-classified names are omitted by normalization `N`, because a server
+cannot set a property — and the properties **apply at hydration** on the client,
+where React assigns them to the mounted element under the camelCase name. The
+`:rf.ui/property-props` marker that names the classification is a reserved
+diagnostic and never reaches the semantic space.
+
+### 1.3 The a11y compile-tier diagnostic roster
+
+Four **compile-tier** warnings, minted by `re-frame.ui.compiler.a11y`. They are
+`:rf.ui.compile/*` ids, which means: **no Spec 009 catalogue row**, no runtime emission,
+and no production egress. A compile-roster finding is printed by the compiler
+and recorded as a manifest `:diagnostics` fact. The roster is **closed**; an
+addition is a roster change.
+
+The charter is **high confidence**: a false positive is worse than a miss, so
+each check is proven in *both* directions and the silent direction is the
+load-bearing one.
+
+| Diagnostic | Fires on | Author remedy |
+|---|---|---|
+| `:rf.ui.compile/a11y-missing-accessible-name` | an interactive element with no discernible accessible name | give it text content, `aria-label`, or `aria-labelledby` |
+| `:rf.ui.compile/a11y-invalid-literal-aria` | a **literal** `aria-*` value outside the pinned WAI-ARIA vocabulary | correct the literal; a runtime-computed value is never flagged |
+| `:rf.ui.compile/a11y-click-non-interactive` | a click handler on a non-interactive element with no keyboard path | use a real control, or add role + keyboard handling |
+| `:rf.ui.compile/a11y-presence-exit-interactive` | **inline literal** markup under a presence boundary carrying focusable content — the one shape where the author remedy is *structurally* unavailable, because inline props evaluate in the parent's render, outside the per-child phase Provider | extract a **keyed child view** that reads `(ui/presence-phase) = :unmounting` and stamps its own `inert` / `aria-hidden` |
+
+**Suppression.** `^{:rf.ui/suppress {<id> "reason"}}` silences the *printed*
+warning while the finding remains a manifest `:diagnostics` fact carrying its
+reason. A malformed suppression — an unknown id, a blank or non-string reason —
+is the loud compile error `:rf.ui.compile/bad-suppress`, never a silent no-op.
+
+Proven by `re-frame.ui.a11y-diagnostics-cljs-test` (host-shared, pure analyzer);
+the diagnostics reach tooling through the Xray diagnostics channel.
+
+### 1.4 The foreign boundary
+
+The boundary has two sides and one law each; `ui/html` is the third foreign edge.
+
+| Form | Kind | Contract | Loud failure | Proven by |
+|---|---|---|---|---|
+| `ui/raw` | host-bearing template form | a foreign element that cannot render on the JVM; the raise is **lazy** — an untaken branch never evaluates its argument, and compiled siblings render normally around the absent boundary | rendered on the JVM: `:rf.error/jvm-host-op` naming `:op :ui/raw`; bad compile form `:rf.ui.compile/bad-raw` | JVM `re-frame.ui.raw-foreign-boundary-jvm-test`; CLJS `re-frame.ui.raw-foreign-boundary-dom-cljs-test` |
+| `ui/raw-fn` | host-bearing callback-ref form | a foreign callback in prop position; becomes the opaque `{:rf.ui/opaque :ui/raw-fn}` marker | in child position `:rf.ui.compile/raw-fn-child` | JVM `re-frame.ui.raw-foreign-boundary-jvm-test`; CLJS `re-frame.ui.raw-foreign-boundary-dom-cljs-test` |
+| foreign component head | host-bearing call head | a resolvable var without view metadata; a **distinct** boundary from `ui/raw` and the error says so | rendered on the JVM: `:rf.error/jvm-host-op` naming `:op :foreign-component` | JVM `re-frame.ui.raw-foreign-boundary-jvm-test`; CLJS `re-frame.ui.raw-foreign-boundary-dom-cljs-test` |
+| `ui/html` | trusted-markup leaf | the single escaping bypass. **`re-frame.ui` sanitises nothing** — no escaping, no tag filter, no attribute filter, no `javascript:`-scheme gate; the only runtime guard is a `string?` **shape** check (a non-string is `:rf.error/ui-tree-malformed`), never a content check; an empty string is a legal inert bypass | non-string value `:rf.error/ui-tree-malformed`; bad compile form `:rf.ui.compile/bad-html`; not the sole child `:rf.ui.compile/html-not-sole-child` | JVM `re-frame.ui.raw-foreign-boundary-jvm-test`; CLJS `re-frame.ui.raw-foreign-boundary-dom-cljs-test` |
+
+**A foreign value in prop position is opaque.** It becomes the
+`{:rf.ui/opaque :foreign}` (or `{:rf.ui/opaque :ui/raw-fn}`) marker and the value
+itself is **never evaluated and never enters the tree** — so no host object can
+leak into a structural tree, a fingerprint, or a serialised payload, and no prop
+silently degrades to `nil`.
+
+## 2. Host behaviour
+
+**JVM structural render (Tier 1).** A presence boundary renders a **fragment**
+carrying the reserved `:rf.ui/presence {:phase :present :timeout-ms n}`
+diagnostic marker; the JVM has no lifecycle, so every keyed child renders and no
+retention timer exists. An empty boundary still emits its marker fragment. The
+marker is a droppable diagnostic — normalization `N` strips it, so it never
+changes markup or a fingerprint. `(ui/presence-phase)` is `:present`.
+Custom-element markup is **attributes only**. `ui/raw` and a foreign head raise
+`:rf.error/jvm-host-op`; `ui/html` renders as an opaque verbatim leaf.
+
+**CLJS mounted render (Tier 3).** The three-phase machine runs against a real
+`react-dom/client` mount: a keyed child enters `:mounting → :present`; a removed
+key is retained `:unmounting` until `flush-presence!` reaches `:timeout-ms`, then
+it is removed and its ownership released **exactly once**; a partial advance
+leaves a not-yet-due exit retained; re-insertion cancels the pending exit without
+running its removal. Declared custom-element properties are applied to the
+mounted element as JS properties under the camelCase name and are **not**
+reflected as any attribute spelling; undeclared names ride as attributes.
+
+**Cross-host parity.** The S4 rows the compiled-view parity corpus carries are
+catalogued in §4.
+
+## 3. The document head is host-owned
+
+**No compiled-view form renders into `<head>`.** There is no head-targeting form,
+no `ui/head`, and no head channel in the view AST or the JVM tree; `re-frame.ui`
+mounts into a root element inside `<body>`. `ui/html` does not widen this — it is
+the sole child of a **DOM element**, and `<head>` is neither a mount target nor
+reachable from a template. The document head belongs to the **host**: the HTML
+shell the app serves and, for server-rendered apps, Spec 011's structured
+`reg-head` / `active-head` channel.
+
+This row states an **absence of surface**, not a behaviour, so it has no
+behavioural fixture. What the drift guard binds is exactly the absence: the
+`re-frame.ui` facade exposes no head-targeting public, and the compiler's closed
+form set contains no head op. Spec 004 records the standing policy and the open
+question of which Spec normatively *owns* it — that ruling is not S4's.
+
+## 4. W14 dual-emitter parity — the S4 corpus rows
+
+The compiled-view parity corpus (`parity_fixtures.cljc` + the JVM/CLJS corpus
+tests) proves **normalized structural equivalence** across the JVM tree and the
+CLJS `react-dom/server` emitter. Parity is equivalence in normalization `N`'s
+semantic space — byte-identical HTML is *not* the contract. S4 contributes these
+rows (the view-shape sweep, W14):
+
+| Corpus case | The S4 claim it pins |
+|---|---|
+| `:presence-two` | a presence boundary contributes **no node of its own** and passes every incoming keyed child view through exactly once — the JVM marker fragment is stripped by `N`, the client's per-child phase Provider is invisible in markup, and both sides land on the same children in the same order |
+| `:presence-empty` | an empty boundary is structurally inert on both hosts |
+| `:presence-inline` | presence **mid-tree** over inline keyed literal markup — the second legal child shape — splices identically, and its siblings are undisturbed |
+| `:ce-declared-attr-name` | the adversarial classification row: a **declared** name that is also a standard HTML attribute spelling (`:tab-index`) stays a **PROPERTY** on both emitters and is written into markup by neither, while undeclared siblings stay ordinary attributes |
+| `:trusted-hostile` | `ui/html` crosses **verbatim** on both hosts — a `javascript:` scheme is not gated, and nothing about the string is inspected |
+
+**Deliberately out of the corpus** (documented, not silently skipped): `ui/raw`
+and the foreign component head have **no JVM side to compare** — rendering them
+on the JVM is `:rf.error/jvm-host-op` by contract, so their boundary corpus is
+the `raw_foreign_boundary_*` pair; presence's **three-phase machine** and any
+`(ui/presence-phase)` read are host-bearing — retention timers and the phase a
+*first* render reports are mounted (and, for the server, S5) questions, proven in
+`presence_dom_cljs_test` and `presence_jvm_test`.
+
+## 5. Non-surfaces (the S4 wall)
+
+S4 deliberately does **not** ship, and a consumer that appears to need one gets
+an API redesign or a named interop boundary, never a substrate exception:
+
+- **presence is not an animation system** — no easing, no curves, no presence
+  event bus; anything beyond enter/exit retention is out of scope;
+- no presence **wrapper node**, clone/ref contract, or reserved DOM node; the
+  boundary is DOM-agnostic;
+- no automatic `transitionend` early completion, no automatic `inert`/
+  `aria-hidden` on exit, no framework-owned reduced-motion path — all three were
+  **retracted** (`rf2-0ufty`); the presence-aware child owns them;
+- no optional `:timeout-ms` — it is mandatory, and it is the exit duration, not a
+  cap over a completion mechanism that does not exist;
+- no attribute-name **heuristic** for custom elements — the declaration is the
+  sole classifier; no open/runtime property set;
+- no **sanitisation** in `ui/html` — no escaping, tag filter, attribute filter, or
+  scheme gate; provenance is the author's obligation;
+- no **head-targeting** form, `ui/head`, or head channel in the AST or JVM tree;
+- no Spec 009 **runtime** rows for the a11y roster, and no production egress of
+  any diagnostic string; the a11y ids are compile-tier only;
+- no silent a11y suppression — an unknown id or a blank reason is a loud compile
+  error.
+
+## 6. The gate roster (S4 arms)
+
+The full G-1..G-18 roster lives in `docs/EP/EP-0034` §4 and the 07 §5 gate
+roster. S4 introduces **no new named gate**; it grows the arms of two existing
+ones:
+
+| Gate | S4 arm |
+|---|---|
+| **G-7** | dev/prod equivalence extended to the S4 surfaces — committed DOM, presence retention/removal, and custom-element property application agree with debug off; the a11y roster is compile-tier and emits nothing at runtime in either build |
+| **G-11** | exact production absence extended to the S4 test surface — `re-frame.ui.test` (now including `flush-presence!`) and every compile-tier diagnostic string stay out of advanced production bundles |
+
+Everything else S4 froze is proven by the named suites in §1 and the parity
+corpus in §4, not by a gate arm.
+
+## 7. Conformance grading
+
+An S4-conforming host emits, for the frozen surface above: the presence
+retention contract with its mandatory `:timeout-ms`, exactly-once terminal
+removal, and unkeyed-child build failure (§1.1); the ruled custom-element
+classification with its JVM attributes-only / client properties-at-hydration
+split (§1.2); the four compile-tier a11y diagnostics with their suppression round
+trip (§1.3); the foreign-boundary laws and `ui/html`'s no-sanitisation contract
+(§1.4); the host behaviour of §2; a host-owned document head (§3); the parity
+rows of §4; and none of the non-surfaces (§5). The gate arms in §6 and the suites
+named throughout are the executable acceptance; `scripts/test-fast-pr.sh` plus
+the S4 CI matrix run them.


### PR DESCRIPTION
The **final S4 leaf** (`rf2-yho9j`, epic `rf2-vxgfnd.96`). All six other leaves have merged; this one profiles what they built, binds every claim to an executable assertion, and extends the W14 parity corpus with the S4 surfaces that actually have two emitter sides to compare.

## What landed

**`spec/conformance/S4-view-conformance-profile.md`** (new) — four closed rosters plus two absences:

| § | Roster | Leaf |
|---|---|---|
| 1.1 | `ui/presence`, `ui/presence-phase`, `ui.test/flush-presence!` | A (#6261) |
| 1.2 | `ui/custom-element` — the ruled property-vs-attribute classification | B (#6276) |
| 1.3 | the four `:rf.ui.compile/a11y-*` warnings + the suppression grammar | C (#6312) |
| 1.4 | `ui/raw` / `ui/raw-fn` / foreign head / `ui/html` | D (#6289) |
| 3 | the document head is host-owned — an **absence of surface** | D |
| 4 | the W14 dual-emitter parity rows | W14 |
| 5 | the S4 wall (incl. the three promises `rf2-0ufty` **retracted**) | 0ufty (#6294) |
| 6 | gate roster: exactly **{G-7, G-11}** — no new named gate | — |

S4 adds **no verb** to the facade: its forms exported at S1 and assert here. The S3 surface is untouched — `S3-view-conformance-profile.md` and its guard are left exactly as `rf2-pd0dh` (#6309) landed them.

**`implementation/ui/test/re_frame/ui/s4_conformance_profile_jvm_test.clj`** (new) — the executable drift guard, mirroring pd0dh's shape (`table-row-for` keyed on the row's **first cell**, `section-between`). Beyond restating rows it adds teeth pd0dh's S3 guard does not have:

- **proof homes must be real** — every `:jvm-proof` / `:cljs-proof` string must resolve to an actual test namespace under `implementation/ui/test/`, so a row cannot name a fictional home;
- **the two absences are bound as absences** — no head-targeting public in the `re-frame.ui` facade and no `:head` op in the compiler's closed `node-ops`; **no Spec 009 catalogue row** for any a11y id (asserted by reading `spec/009-Instrumentation.md`);
- **shipped behaviour is pinned, not just restated** — presence's fail-loud direct call, the mandatory-`:timeout-ms` and unkeyed-child build failures, `rules/custom-element-property-name` kebab→camelCase, `ui/html`'s `string?`-shape-check-only guard (and that it gates no `javascript:` scheme), and the loud `:rf.ui.compile/bad-suppress` grammar.

**`parity_fixtures.cljc`** — the W14 S4 rows and the **view-shape sweep**:

| Case | Claim |
|---|---|
| `:presence-two` | the boundary contributes **no node of its own**; the JVM marker fragment is stripped by `N`, the client's phase Provider is invisible in markup |
| `:presence-empty` | an empty boundary is structurally inert on both hosts |
| `:presence-inline` | presence **mid-tree** over inline keyed literal markup splices identically |
| `:ce-declared-attr-name` | a **declared** name that is also a standard HTML attribute spelling (`:tab-index`) stays a **PROPERTY** on both emitters |
| `:trusted-hostile` | `ui/html` crosses verbatim — the `javascript:` scheme is not gated |

The sweep also replaces the stale *"presence lands S2/S3"* scope note with what is now deliberately **out** of the corpus and why: `ui/raw` and a foreign head have **no JVM side to compare** (`:rf.error/jvm-host-op` by contract), and presence's retention machine plus any `(ui/presence-phase)` read are host-bearing.

## Mutation proof

Every row must redden the guard when corrupted — the exact defect pd0dh found in the S3 profile. One mutation per S4 leaf, plus the parity/gate/head rows, each applied to the shipped document and reverted byte-for-byte:

| Mutation | Result |
|---|---|
| **A** drop the mandatory-`:timeout-ms` fragment from the `ui/presence` row | RED |
| **B** swap the ruled `:accent-color` → `accentColor` mapping | RED |
| **C** delete the `a11y-presence-exit-interactive` roster row | RED |
| **D** hollow out `ui/html`'s "sanitises nothing" claim | RED |
| **W14** delete the `:ce-declared-attr-name` corpus row | RED |
| **§6** rename the G-11 arm | RED |
| **§3** drop the "no `ui/head`" claim | RED |

7/7 red; profile restored byte-for-byte afterwards.

## Scope

**Operator flag #5 — no conflict.** The epic bundles "dual-emitter parity + root-hydration", but the **bead's own acceptance** names only *parity fixtures + the view-shape sweep* — it does not mention root-hydration. That matches the decomposition audit's recommendation, so this PR scopes to parity + sweep and leaves root-manifest hydration to S5. Nothing here touches it.

**No workflow edit needed** (`rf2-e7ja9` is live in `.github/workflows/`): the new JVM guard runs under `implementation/ui`'s existing `clojure -M:test`, and the parity additions ride the existing corpus tests. No CI wiring changed.

**No new named G-gate.** §6 grows the arms of G-7 (dev/prod equivalence extended to the S4 surfaces) and G-11 (production absence extended to `flush-presence!` and the compile-tier diagnostic strings), and the guard binds the roster to exactly `{"G-7" "G-11"}`.

## Note for the epic

`rf2-vxgfnd.96.1` (*"Accept keyed literal elements inside `ui/presence`"*, P1, open) reproduces on current main: `(presence {:timeout-ms 300} [:li {:key 1} "a"])` still fails `:rf.ui.compile/presence-unkeyed-child`. The guard uses the keyed `(for …)` shape that ships today and explicitly does **not** assert the literal-element case either way, with a comment pointing at that bead — so fixing it will not fight this profile.

## Quality gates

All foreground, run to completion.

| Gate | Result |
|---|---|
| `implementation/ui` JVM (`clojure -M:test`) | **874 tests / 15479 assertions — 0 failures, 0 errors** |
| S4 drift guard (focused) | **20 tests / 220 assertions — 0 failures, 0 errors** |
| `npm run test:cljs` | **10020 tests / 49392 assertions — 0 failures, 0 errors** |
| `npm run test:adapter-smokes` | **3 adapter-smoke specs — 0 failures** |
| `mkdocs build --strict` | **exit 0** (spec staged into `docs/spec/`; the new profile builds with no link warnings) |
| `scripts/check_doc_slugs.py` | **exit 0** |
| Mutation proof | **7/7 RED** |

The CLJS suite is the one that matters for the corpus: it runs the live cross-emitter parity gate, so the new S4 fixtures — including the adversarial `tab-index` property row — are proven equivalent across the JVM tree and `react-dom/server`.

**This is the last S4 leaf — when it lands the stage is complete.**

Refs: `rf2-yho9j`, `rf2-vxgfnd.96`

---

# Reconciled to the ruling (2026-07-18)

Rebased onto current main and reconciled to the ruling recorded on the bead after this PR was raised (**Option A — split W14 at the S4/S5 contract boundary**). Point by point:

| Ruling requirement | What the PR did before | Change made |
|---|---|---|
| **1.** Cumulative; inherit S1–S3 **by exact reference** to the frozen S3 profile | one prose cross-reference, no inheritance contract | new **§0**: cumulative, inherits by exact reference, "does not restate any of it"; the guard binds the reference, the S3 file's existence, **and** that no S3 row is restated here |
| **2.** Guard **composes with**, does not duplicate, the S3 guard | duplicated `repo-root` / `table-row-for` / `section-between`; no use of S3's rosters | requires the S3 guard and reuses its machinery + rosters; three helpers promoted `defn-`→`defn` there (no behaviour change, its 12/176 still pass). Binds the three ruled failure modes: **new public surface**, **broken inheritance link**, **moved/deleted proof row** |
| **3.** Parity in the existing compiler-owned corpus; row the intentional NON-parity facts against real proof homes | fixtures correct; non-parity facts were prose only | new **§4.1** rows `ui/raw` / head / a11y / presence-machine against their paired or compile-time proof homes; §4 now states exactly what *is* portable about presence (zero own-nodes on both hosts) and what is *not* (first-render phase: JVM `:present` vs client `:mounting`) |
| **4.** G-7 growth **bounded** to S4-shape arms only | said "extended to the S4 surfaces" — unbounded | §6 states S4 writes G-7's **first** equivalence arms, **S4 shapes only**, and disclaims the retroactive S1–S3 equivalence-matrix debt (keeps its existing named-open owner); bound row-specifically |
| **5.** Presence sequences **behind** `rf2-vxgfnd.96.1` / `.96.2` | rows shipped with no sequencing statement | the ruling is **either/or** — land the bugs first *or* state the rows track the post-fix grammar. Took the second branch **literally: nothing removed.** §1.1 states the rows track the post-fix grammar and names both open bugs; **§8 declares S4 not yet conforming** until both close |
| **6.** S5 surfaces stay S5 | none leaked, but none were listed either | §5 now explicitly defers Root Manifest/hydration, `render-static`, `client-only` phase flip, failed-root isolation, and the root-hydration half of W14 |
| **7.** Hand-off row citing obligations **already recorded** on `rf2-vxgfnd.97` | absent | new **§7** cites S5-obligation (1), the `rf2-d9yq3` hydrated-presence rider and the `rf2-aozoi` SSR-adoption rider, states **no parallel obligation**, and leaves Spec 004B's `N` + the render-fingerprint vocabulary as S5's contract |

## Deferred / removed for the presence sequencing

**Nothing.** The ruling's second branch is explicit, so the presence rows and presence parity fixtures stay and are **annotated** instead: §1.1 marks them as tracking the post-fix grammar, and §8 blocks the conforming declaration on `rf2-vxgfnd.96.1` + `.96.2`. The guard already used the keyed-`(for …)` shape that ships today and asserts nothing about the keyed-literal case, so closing `.96.1` will not fight this profile.

## Head policy — corrected, not just re-cited

Two things changed here. `rf2-3i7tr` has since **ruled** the normative home (Spec 004 owns the structural absence; Spec 011 the structured SSR head mechanism; Spec 009 only the diagnostic projection) — §3 previously called it an open question and now cites the ruling. Separately, the rebase surfaced that **#6321 landed the `ui/raw` portal caveat**: the absence is scoped to compiled **structural** forms, and `ui/raw` deliberately widens it (a portal may target `document.head` — caller-owned, outside head ordering/dedupe/hydration guarantees, enumerable via the `:raw` capability; the JVM tree has no such route). **My §3 overstated the absence and is corrected.** `spec/004-Views.md` is untouched — those edits belong to `rf2-3i7tr`'s implementation.

## Rebase

Clean onto current main (`dd2659f71d`), no conflicts. **`docs/cljs/playground-rf2.js` untouched** — not in the diff (verified), so `rf2-tzy13`'s removal is unaffected. No `.github/workflows/` edit was needed at any point, so `rf2-e7ja9` is unaffected.

## Mutation proof — now 16/16 RED

Extended to cover every ruled obligation. The proof **found two real under-binding defects in my own guard**: `"no `ui/head`"` and `"S4 shapes only"` each appear twice in the document, so corrupting one site was satisfied by the other occurrence and stayed GREEN. Both now bind row-specifically or on a single-occurrence phrase — the same defect class `rf2-pd0dh` fixed for S3, caught here by the proof rather than by review.

| Mutation | Result |
|---|---|
| A `:timeout-ms` mandatory · B kebab→camel mapping · C a11y row · D `ui/html` no-sanitisation | RED ×4 |
| W14 corpus row · §6 G-11 rename · §3 no-`ui/head` | RED ×3 |
| §0 inheritance reference · §0 "does not restate" | RED ×2 |
| §1.1 `rf2-vxgfnd.96.1` · §8 not-yet-conforming | RED ×2 |
| §4.1 `ui/raw` non-parity proof home · §5 failed-root isolation | RED ×2 |
| §6 G-7 "S4 shapes only" bound | RED |
| §7 `rf2-d9yq3` rider · §7 no-parallel-obligations | RED ×2 |

Profile restored byte-for-byte afterwards.

## Quality gates (re-run after reconciliation, foreground, from the artefact directory)

| Gate | Result |
|---|---|
| `implementation/ui` JVM (`clojure -M:test` **from `implementation/ui`**) | **883 tests / 15634 assertions — 0 failures, 0 errors** |
| S4 drift guard (focused) | **29 tests / 332 assertions — 0 failures** |
| S3 drift guard (focused — unchanged by the helper promotion) | **12 tests / 176 assertions — 0 failures** |
| `npm run test:cljs` | **10023 tests / 49408 assertions — 0 failures, 0 errors** |
| `mkdocs build --strict` | **exit 0** |
| `scripts/check_doc_slugs.py` | **exit 0** |
| Mutation proof | **16/16 RED** |
