### PR TITLE
docs(ui): qualify the host-owned head policy for raw portals (rf2-6u4cw)

### DIFF
--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -725,18 +725,39 @@ trusted — a build-time Markdown render, a sanitiser's output, a static SVG str
 
 ### The document head is host-owned
 
-**No compiled-view form renders into `<head>`.** `re-frame.ui` mounts into a root
-element inside `<body>` (§Roots and mounting), and every template form in this Spec
-produces nodes beneath that root: there is no head-targeting form, no `ui/head`, and
-no head channel in the view AST or the JVM tree. The document head belongs to the
-**host** — the HTML shell the app serves and, for server-rendered apps, Spec 011's
-structured [`reg-head` / `active-head`](011-SSR.md#headmeta-contract) channel, which
-derives the head model from `app-db` through registered fns and applies
-position-appropriate escaping at every leaf.
+**No compiled structural form renders into `<head>`.** `re-frame.ui` mounts into a
+root element inside `<body>` (§Roots and mounting), and every structural template
+form in this Spec — elements, fragments, compiled views, `ui/html` — produces nodes
+beneath that root: there is no head-targeting form, no `ui/head`, and no head
+channel in the view AST or the JVM tree. The document head belongs to the **host** —
+the HTML shell the app serves and, for server-rendered apps, Spec 011's structured
+[`reg-head` / `active-head`](011-SSR.md#headmeta-contract) channel, which derives the
+head model from `app-db` through registered fns and applies position-appropriate
+escaping at every leaf.
 
 `ui/html` does not widen this. It is the sole child of a **DOM element** in the
 rendered tree, and `<head>` is neither a mount target nor reachable from a template,
 so trusted markup cannot be used to reach into it.
+
+**`ui/raw` does widen it, and that is deliberate.** `(ui/raw x)` is an opaque
+foreign-value hatch: the browser emitter lowers the analysed node to `x` unchanged
+and hands it to React verbatim, and the compiler checks the call's *shape* — one
+argument, child position — never the value. A React element can be a **portal**, and
+a portal renders into whatever container the caller names, `document.head` included.
+An app that has explicitly entered host React can therefore reach the head through
+`ui/raw`, exactly as it can through any other host React it runs. Nodes placed that
+way are host behaviour the caller owns: they sit outside head ordering,
+de-duplication, precedence, and every hydration guarantee this Spec and
+[011](011-SSR.md) make, `:rf/head-hash` mismatch detection included. The posture is
+trusted markup's — the framework names the boundary and does not inspect what crosses
+it — and the containment that survives is enumerability: every site declares the
+`:raw` capability and is recorded in the manifest, so the set of such escapes is
+finite and listable. The **JVM tree has no such route**: `:raw` raises
+`:rf.error/jvm-host-op` (§The JVM structural subset), so a server-rendered head still
+comes only from `reg-head` / `active-head` — which remains the path to reach for when
+the head is app state, rather than a portal no part of the substrate can see. The
+Wave-2 `ui/portal` row in §Interop would inherit the same caveat, its target being a
+caller-supplied node.
 
 The reasoning is that head elements are document-global singletons with
 de-duplication, ordering, and precedence semantics that no part of the compiled


### PR DESCRIPTION
Closes rf2-6u4cw.

## The gap

S4-D (#6289) correctly established that `re-frame.ui` has no structural head API and that `ui/html` cannot escape its DOM element. But it stated the containment absolutely — *"No compiled-view form renders into `<head>`… every template form in this Spec produces nodes beneath that root"* — and that is not true across the `ui/raw` boundary.

Shipped-source evidence:

- `implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc:623` — `:raw (:form node)`. The analysed node lowers to the caller's form **unchanged**. Note the contrast with `:expr` on the line above, which is wrapped in `re-frame.ui.runtime/child`; `:raw` gets no wrapper and no normalisation, so the value reaches React verbatim.
- `implementation/ui/src/re_frame/ui/compiler/analyze.cljc:3050-3056` — the only checks are the call's **shape**: exactly one argument, non-nil (`:rf.ui.compile/bad-raw`), in child position. `walk-expr` is a capability/scope walk over the expression, not a constraint on the value.
- Nothing downstream narrows it to non-portal nodes. `React.createPortal` returns a valid React node whose container is caller-supplied — `document.head` included.

So a portal wrapped in `ui/raw` crosses the compiler by design and can render into the head, escaping the policy S4-D had just documented as absolute.

## The qualification

`spec/004-Views.md` §Interop, "The document head is host-owned":

- The opening claim is scoped from *"No compiled-view form"* to **"No compiled structural form"**, and the enumeration is made explicit (elements, fragments, compiled views, `ui/html`).
- A new paragraph names the escape: `ui/raw` **does** widen it, deliberately. Portals placed that way are caller-owned host behaviour, outside head ordering, de-duplication, precedence, and every hydration guarantee this Spec and 011 make — `:rf/head-hash` mismatch detection included.
- It records the containment that *does* survive: every site declares the `:raw` capability and is manifest-recorded, so the set of escapes is finite and listable — the same enumerability posture `ui/html` already carries.
- It records that the **JVM tree has no such route**: `:raw` raises `:rf.error/jvm-host-op` (`emit_jvm.cljc:281` → `tree.cljc:456`), so a server-rendered head still comes only from Spec 011 `reg-head` / `active-head`, which stays the preferred structured path.
- One closing sentence notes the Wave-2 `ui/portal` row would inherit the same caveat, its target being a caller-supplied node.

## Scope discipline

Documentation-only; `spec/004-Views.md` is the sole file touched.

- **No enforcement added.** No portal check, no compile diagnostic, no restriction on what `raw` accepts, no head-guarding machinery, no sanitiser, no conformance promise for portals. S4-D's ruled posture is that head is host-owned and `raw` is a trusted-markup-grade escape hatch whose guarantees are the caller's; the honest fix is to say so about portals too.
- **The `[S4-OPEN]` normative-home question is untouched.** Which Spec owns the head-render policy is rf2-3i7tr's to rule; the blockquote is left exactly as shipped.
- **Consistent with the S4 conformance profile (#6320) §3.** That assertion is that no `ui/head` surface exists. This change adds no API and asserts no new behaviour — it says an existing opaque foreign-value hatch is opaque, which leaves the head-absence assertion intact. (#6320 is not yet on `main`; only the S3 profile is present, so this is reasoned from the assertion's stated shape rather than its merged text.)
- Existing trusted-markup and raw foreign-boundary contracts are unchanged.

## Quality gates

Run in the worktree, foreground, unpiped:

| Gate | Result |
|---|---|
| `python -m mkdocs build --strict` | **PASS** — `Documentation built in 43.57 seconds`, no warnings escalated |
| `python scripts/check_doc_slugs.py` | **PASS** — exit 0 |

`implementation/ui` JVM suite **not applicable**: the diff touches zero implementation files, and no test pins the head-policy prose — `grep -rniE "host-owned|document\.head|<head>|head-policy" implementation/ui/test/` returns no matches, and a repo-wide grep for the policy sentences finds them only in `spec/004-Views.md`.
