### PR TITLE
fix(machines): close the post-selection registrar race for prepared spawn-all children (rf2-zo5n9)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -443,18 +443,22 @@
   merge is applied on top of `rt-after-alloc` so the caller's counter bump
   survives. Under Spec 002's single-drainer invariant the discarded
   re-read is value-equal to the snapshot the caller already had. Machine
-  snapshots are durable runtime-db state (EP-0001)."
+  snapshots are durable runtime-db state (EP-0001).
+
+  `type-ref-fn` is a THUNK, not a value (rf2-zo5n9). The revertible TYPE
+  reference a PREPARED `:spawn-all` child stamps is registrar-DERIVED —
+  `prepared-type-ref` compares the prepared definition against what the
+  registrar currently holds — so the moment it is chosen is a correctness
+  property, not a scheduling detail. Forcing it here, inside the `(continue?)`
+  fence and immediately before the physical write, is the LAST point ahead of
+  the swap; every callback-bearing pre-install emission (the caller's
+  `:rf.machine.spawn/spawned` trace and this fn's own
+  `:rf.error/system-id-collision` trace, both of which fan synchronously to
+  application listeners that can unregister or replace the child's TYPE) has
+  already run and is therefore already reflected in the reference this stamps."
   [frame-id rt-after-alloc spec spawned-id initial-snap
-   {:keys [system-id parent-id invoke-id track? type-ref continue? owner-token]}]
-  (let [existing (when system-id (get-in rt-after-alloc (paths/system-id-path system-id)))
-        ;; Stamp the revertible TYPE reference onto the snapshot root so the
-        ;; lazy resolver can re-materialise the handler from runtime-db alone. The
-        ;; spawn is known-accepted by the time `install-spawn!` runs (an
-        ;; unregistered `:machine-id` was rejected fail-closed upstream), so
-        ;; `spec` is always present; the `spec`/`type-ref` guards are
-        ;; belt-and-braces.
-        initial-snap (cond-> initial-snap
-                       (and spec type-ref) (assoc :rf/machine-type type-ref))]
+   {:keys [system-id parent-id invoke-id track? type-ref-fn continue? owner-token]}]
+  (let [existing (when system-id (get-in rt-after-alloc (paths/system-id-path system-id)))]
     (when (and system-id existing (not= existing spawned-id))
       (trace/emit-error! :rf.error/system-id-collision
                          {:frame             frame-id
@@ -489,7 +493,41 @@
     ;; trace. Without an owner (conformance / pure-fn), fall back to the bare
     ;; write (its non-nil return marks `:committed`).
     (if (or (nil? continue?) (continue?))
-      (let [install-fn (fn [_rt]
+      (let [;; rf2-zo5n9 — CHOOSE the revertible TYPE reference HERE, at the last
+            ;; point before the write, and stamp it onto the snapshot root so the
+            ;; lazy resolver can re-materialise the handler from runtime-db alone.
+            ;;
+            ;; THE WINDOW THIS CLOSES. rf2-rxjy3 made a prepared `:spawn-all`
+            ;; child's reference follow the definition-lifetime rule — keep the
+            ;; `:machine-id` keyword while the registrar still holds the prepared
+            ;; definition, pin that definition once the registrar has diverged —
+            ;; but the CHOICE was taken in `spawn-fx*`'s `let` bindings, ahead of
+            ;; two callback-bearing emissions that still run before this write:
+            ;; the caller's `:rf.machine.spawn/spawned` trace and the
+            ;; `:rf.error/system-id-collision` trace above. Both fan synchronously
+            ;; to application listeners. A listener that UNREGISTERED or REPLACED
+            ;; the admitted child's TYPE therefore diverged the registrar AFTER
+            ;; `prepared-type-ref` had observed it intact and returned the
+            ;; keyword — so the install stamped a now-STALE keyword and the child
+            ;; came up INERT (nothing resolves; it never leaves `:initial`, and
+            ;; every event raises `:rf.error/no-such-handler`) or SPLIT (a
+            ;; prepared-v1 snapshot driven by an unrelated current-v2 handler).
+            ;; The very failure modes rxjy3 removed, reached through a later door.
+            ;;
+            ;; Deferring the CHOICE — rather than re-checking anything — is the
+            ;; whole fix: `type-ref-fn` reads the registrar as it stands at
+            ;; commit, so whatever the last pre-install callback did to it is
+            ;; what the definition-lifetime rule decides against. It is NOT a
+            ;; re-verdict: an admitted child ALWAYS installs (rf2-v4oqd), and
+            ;; this can only select the FORM of its reference.
+            type-ref     (type-ref-fn)
+            ;; The spawn is known-accepted by the time `install-spawn!` runs (an
+            ;; unregistered `:machine-id` was rejected fail-closed upstream), so
+            ;; `spec` is always present; the `spec`/`type-ref` guards are
+            ;; belt-and-braces.
+            initial-snap (cond-> initial-snap
+                           (and spec type-ref) (assoc :rf/machine-type type-ref))
+            install-fn (fn [_rt]
                          (cond-> rt-after-alloc
                            spec      (assoc-in (paths/snapshot-path spawned-id) initial-snap)
                            system-id (assoc-in (paths/system-id-path system-id) spawned-id)
@@ -646,7 +684,17 @@
   admission. An admitted child ALWAYS installs — that is exactly what v4oqd
   established, and re-instating a fail-closed recheck here would restore the
   impossible half-live join it removed. The divergent case simply stops
-  depending on a registrar entry the preflight's verdict no longer speaks for."
+  depending on a registrar entry the preflight's verdict no longer speaks for.
+
+  WHEN this runs is part of the contract (rf2-zo5n9). Because the rule is
+  decided by comparing the prepared definition against the registrar's CURRENT
+  contents, a divergence that happens after the comparison is a divergence the
+  installed snapshot does not reflect — and the callbacks between the child's
+  admission and its install (the `:rf.machine.spawn/spawned` trace, and
+  `install-spawn!`'s `:rf.error/system-id-collision` trace) are exactly where a
+  listener can cause one. `spawn-fx*` therefore passes this as a THUNK and
+  `install-spawn!` forces it at the last point before the runtime-db swap, so
+  the comparison is made against the registrar as it stands at COMMIT."
   [args prepared]
   (let [type-spec  (:type-spec prepared)
         machine-id (:machine-id args)]
@@ -872,9 +920,21 @@
         ;; from (rf2-rxjy3 — see `prepared-type-ref` for the definition-lifetime
         ;; rule; the undisturbed case still stamps the plain `:machine-id`
         ;; keyword, so hot-reload semantics are unchanged).
-        type-ref   (if prepared
-                     (prepared-type-ref args prepared)
-                     (machine-type-ref args))
+        ;;
+        ;; rf2-zo5n9 — a THUNK, deliberately unforced here. `prepared-type-ref`
+        ;; is the one registrar-DERIVED input the install still needs, and
+        ;; everything between this binding and the write is callback-bearing:
+        ;; the `:rf.machine.spawn/spawned` trace below and `install-spawn!`'s
+        ;; `:rf.error/system-id-collision` trace both fan synchronously to
+        ;; application listeners that can unregister or replace the child's TYPE.
+        ;; Choosing here would read a registrar those callbacks then invalidate,
+        ;; stamping a stale keyword onto the snapshot (inert child / split
+        ;; authority). `install-spawn!` forces it at the last point before the
+        ;; swap instead. `machine-type-ref` is pure over `args` and reads no
+        ;; registrar, so the non-prepared path is timing-independent either way.
+        type-ref-fn (if prepared
+                      #(prepared-type-ref args prepared)
+                      (constantly (machine-type-ref args)))
         ;; The initial snapshot the install lands. Consumed verbatim from the
         ;; preflight for a `:spawn-all` child (built ONCE there); built ONCE
         ;; here otherwise, so the schema-rejection decision can gate every side
@@ -964,7 +1024,7 @@
                                          :parent-id   parent-id
                                          :invoke-id   invoke-id
                                          :track?      track?
-                                         :type-ref    type-ref
+                                         :type-ref-fn type-ref-fn
                                          :continue?   continue?
                                          :owner-token owner-token})]
         ;; rf2-hloj0g — `install-spawn!`'s `:rf.error/system-id-collision`

--- a/implementation/machines/test/re_frame/spawn_all_prepared_unregister_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/spawn_all_prepared_unregister_cljs_test.cljc
@@ -23,6 +23,7 @@
   note called out as NOT covered — the recheck's fail-closed branch — on JVM +
   CLJS."
   (:require
+   [clojure.string :as str]
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
@@ -147,6 +148,36 @@
           (reset! fired true)
           (f))))
     #(trace/unregister-listener! listener-id)))
+
+(defn- on-operation-once
+  "Register a synchronous trace listener that runs `f` exactly once, on the first
+  `operation` emit. Returns an unregister thunk.
+
+  The generalisation of `on-started-once` to the LATER callback-bearing seams
+  rf2-zo5n9 covers — the per-child `:rf.machine.spawn/spawned` trace and
+  `install-spawn!`'s `:rf.error/system-id-collision` trace — both of which run
+  AFTER the prepared entry has been selected and BEFORE the snapshot's
+  `:rf/machine-type` is written."
+  [listener-id operation f]
+  (let [fired (atom false)]
+    (trace/register-listener!
+      listener-id
+      (fn [ev]
+        (when (and (= operation (:operation ev)) (not @fired))
+          (reset! fired true)
+          (f))))
+    #(trace/unregister-listener! listener-id)))
+
+(defn- on-every-spawned
+  "Register a synchronous listener that runs `(f <spawned-id>)` on EVERY per-child
+  `:rf.machine.spawn/spawned` emit. Returns an unregister thunk."
+  [listener-id f]
+  (trace/register-listener!
+    listener-id
+    (fn [ev]
+      (when (= :rf.machine.spawn/spawned (:operation ev))
+        (f (get-in ev [:tags :spawned-id])))))
+  #(trace/unregister-listener! listener-id))
 
 ;; ===========================================================================
 ;; (1) THE BUG — a started-listener UNREGISTERS an admitted child TYPE between
@@ -417,3 +448,169 @@
           "the live child picked up the hot-reloaded definition — hot-reload semantics preserved"))
     (is (empty? (no-such-handler-errors))
         "no :rf.error/no-such-handler fired")))
+
+;; ===========================================================================
+;; rf2-zo5n9 — the POST-SELECTION seam. rf2-rxjy3 (tests 4-7 above) made the
+;; prepared child's definition-lifetime choice correct, but `spawn-fx*` took
+;; that choice in its `let` bindings — BEFORE the two callback-bearing
+;; emissions that still run ahead of the install:
+;;
+;;   (a) the per-child `:rf.machine.spawn/spawned` trace, and
+;;   (b) `install-spawn!`'s `:rf.error/system-id-collision` trace.
+;;
+;; Both fan synchronously to application listeners, and both complete BEFORE
+;; the runtime-db swap that writes `:rf/machine-type`. A listener on either
+;; that unregistered or replaced the admitted child's TYPE therefore diverged
+;; the registrar AFTER `prepared-type-ref` had already observed it intact and
+;; returned the revertible `:machine-id` KEYWORD. The install then stamped that
+;; now-stale keyword, and the lazy resolver re-materialised NOTHING (inert
+;; actor) or an unrelated successor definition (split authority) — exactly the
+;; two failure modes rxjy3 eliminated, reached through a later door.
+;;
+;; The suites above mutate the registrar from `:rf.machine.spawn-all/started`,
+;; which fires BEFORE the per-child spawn fx runs at all, so they cannot see
+;; either seam. These tests pin the later ones: the reference is now selected
+;; at the LAST safe point, after every callback-bearing pre-install emission
+;; and immediately before the physical write.
+;; ===========================================================================
+
+;; ===========================================================================
+;; (8) THE BUG — a per-child `:rf.machine.spawn/spawned` listener UNREGISTERS
+;;     the admitted child TYPE. The child must still be a LIVE actor.
+;; ===========================================================================
+
+(deftest unregister-from-the-spawned-trace-listener-keeps-the-child-live
+  (testing "a :rf.machine.spawn/spawned listener that UNREGISTERS the admitted
+            child TYPE — after the prepared entry was selected, before the
+            snapshot's :rf/machine-type is written — cannot leave the child
+            inert: the reference is chosen at the last safe point, so the
+            diverged registrar is seen and the prepared definition is pinned.
+            The child bootstraps :idle → :ready and a later ordinary event runs."
+    (rf/reg-machine :sa/late-unreg booting-child)
+    (rf/reg-machine :sup/late-unreg (parent-over [{:id :c :machine-id :sa/late-unreg}]))
+    (let [off (on-operation-once ::late-unreg :rf.machine.spawn/spawned
+                #(registrar/unregister! :event :sa/late-unreg))]
+      (try
+        (rf/dispatch-sync [:sup/late-unreg [:start]])
+        (finally (off))))
+    (let [child (get (:children (join-slot :sup/late-unreg)) :c)]
+      (is (some? (snap-of child))
+          "the admitted child installed its prepared snapshot")
+      (is (map? (type-ref-of child))
+          "the prepared definition is PINNED — the registrar diverged on the spawned-trace callback, after the keyword would have been chosen")
+      (is (= :ready (mtest/machine-state child))
+          "the child COMPLETED its synthetic bootstrap — a stale keyword would have resolved nothing and left it at :idle")
+      (is (not (:rf/bootstrap-pending? (snap-of child)))
+          "the :rf/bootstrap-pending? marker cleared — the initial-entry cascade actually ran")
+      (rf/dispatch-sync [child [:go]])
+      (is (= :working (mtest/machine-state child))
+          "a later ordinary event ran against the prepared definition too")
+      (is (empty? (no-such-handler-errors))
+          "NO :rf.error/no-such-handler fired"))
+    (is (empty? (unregistered-rejects))
+        "rf2-v4oqd preserved — no registry recheck re-ran for the prepared child")))
+
+;; ===========================================================================
+;; (9) THE BUG, other leg — a per-child `:rf.machine.spawn/spawned` listener
+;;     RE-REGISTERS the admitted child TYPE to an UNRELATED v2.
+;; ===========================================================================
+
+(deftest reregister-from-the-spawned-trace-listener-keeps-one-coherent-authority
+  (testing "a :rf.machine.spawn/spawned listener that RE-REGISTERS the admitted
+            child TYPE to an UNRELATED definition cannot split the child's
+            authority: the snapshot AND the handler both come from the prepared
+            v1, so the child bootstraps into v1's :ready — never v2's :v2-boot."
+    (rf/reg-machine :sa/late-swap booting-child)
+    (rf/reg-machine :sup/late-swap (parent-over [{:id :c :machine-id :sa/late-swap}]))
+    (let [off (on-operation-once ::late-swap :rf.machine.spawn/spawned
+                #(rf/reg-machine :sa/late-swap unrelated-v2))]
+      (try
+        (rf/dispatch-sync [:sup/late-swap [:start]])
+        (finally (off))))
+    (let [child (get (:children (join-slot :sup/late-swap)) :c)]
+      (is (= booting-child (type-ref-of child))
+          "the prepared v1 definition is pinned — the registrar diverged after the keyword would have been chosen")
+      (is (= :ready (mtest/machine-state child))
+          "the child bootstrapped through the PREPARED v1 definition (:idle → :ready)")
+      (is (not= :v2-boot (mtest/machine-state child))
+          "the child did NOT resolve its handler from the unrelated current v2")
+      (rf/dispatch-sync [child [:go]])
+      (is (= :working (mtest/machine-state child))
+          "a later ordinary event ran against v1 too — one coherent authority"))
+    (is (empty? (no-such-handler-errors))
+        "no :rf.error/no-such-handler fired")))
+
+;; ===========================================================================
+;; (10) Adversarial — EVERY child's TYPE unregistered from its OWN
+;;      `:rf.machine.spawn/spawned` emit. Each child's reference must be chosen
+;;      against the registrar as it stands at ITS OWN install, so every child
+;;      stays live and the join still folds to completion.
+;; ===========================================================================
+
+(deftest every-child-unregistered-from-its-own-spawned-trace-stays-live
+  (testing "when each admitted child's TYPE is unregistered from that child's OWN
+            :rf.machine.spawn/spawned emit, every child pins its prepared
+            definition, bootstraps to :ready, and the :all join still folds —
+            no inert child, no :rf.error/no-such-handler, no reject."
+    (rf/reg-machine :sa/late-a booting-child)
+    (rf/reg-machine :sa/late-b booting-child)
+    (rf/reg-machine :sup/late-all (parent-over [{:id :a :machine-id :sa/late-a}
+                                                {:id :b :machine-id :sa/late-b}]))
+    (let [off (on-every-spawned ::late-all
+                (fn [spawned-id]
+                  ;; `<type>#n` — unregister the TYPE this very child was
+                  ;; prepared from, on its own pre-install callback.
+                  (when-let [t (some #(when (= (name %)
+                                               (first (str/split (name spawned-id) #"#")))
+                                        %)
+                                     [:sa/late-a :sa/late-b])]
+                    (registrar/unregister! :event t))))]
+      (try
+        (rf/dispatch-sync [:sup/late-all [:start]])
+        (finally (off))))
+    (let [slot (join-slot :sup/late-all)]
+      (is (= 2 (count (:children slot))) "the join names both admitted children")
+      (doseq [id (vals (:children slot))]
+        (is (map? (type-ref-of id))
+            (str "child " id " pinned its prepared definition"))
+        (is (= :ready (mtest/machine-state id))
+            (str "child " id " bootstrapped — it is a live actor, not an inert snapshot"))))
+    (is (empty? (no-such-handler-errors))
+        "no :rf.error/no-such-handler fired for either child")
+    (is (empty? (unregistered-rejects))
+        "no unregistered-type reject fired for either child")))
+
+;; ===========================================================================
+;; (11) Adversarial — the OTHER pre-install callback: `install-spawn!`'s
+;;      `:rf.error/system-id-collision` trace. Two admitted children sharing a
+;;      `:system-id` make the second child's install fan that trace; a listener
+;;      on it unregisters that child's TYPE. This seam is INSIDE
+;;      `install-spawn!`, later even than the spawned trace, so it is the
+;;      tightest window the fix must still cover.
+;; ===========================================================================
+
+(deftest unregister-from-the-system-id-collision-listener-keeps-the-child-live
+  (testing "a :rf.error/system-id-collision listener that UNREGISTERS the
+            colliding child's TYPE — the LAST callback before the runtime-db
+            swap — still cannot install a stale keyword: the rebound child pins
+            its prepared definition and bootstraps to :ready."
+    (rf/reg-machine :sa/sys-a booting-child)
+    (rf/reg-machine :sa/sys-b booting-child)
+    (rf/reg-machine :sup/sys (parent-over
+                               [{:id :a :machine-id :sa/sys-a :system-id :sys/shared}
+                                {:id :b :machine-id :sa/sys-b :system-id :sys/shared}]))
+    (let [off (on-operation-once ::sys :rf.error/system-id-collision
+                #(registrar/unregister! :event :sa/sys-b))]
+      (try
+        (rf/dispatch-sync [:sup/sys [:start]])
+        (finally (off))))
+    (let [slot  (join-slot :sup/sys)
+          child (get (:children slot) :b)]
+      (is (= 1 (count (mtest/events-of :rf.error/system-id-collision)))
+          "the shared :system-id fanned exactly one collision trace (the second child's install)")
+      (is (map? (type-ref-of child))
+          "the rebound child pinned its prepared definition — the registrar diverged on the collision callback, INSIDE install-spawn!")
+      (is (= :ready (mtest/machine-state child))
+          "the rebound child bootstrapped — it is live, not inert")
+      (is (empty? (no-such-handler-errors))
+          "no :rf.error/no-such-handler fired"))))


### PR DESCRIPTION
Closes rf2-zo5n9.

## The window

`implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc` — `spawn-fx*` computed `type-ref` in its `let` bindings (pre-fix line 875), but the value is only *used* by `install-spawn!`'s snapshot stamp (pre-fix line 456). Two callback-bearing emissions run in between, both synchronous and both ahead of the runtime-db swap:

1. the per-child `:rf.machine.spawn/spawned` trace (`spawn-fx*`, pre-fix line 922);
2. `install-spawn!`'s `:rf.error/system-id-collision` trace (pre-fix line 459).

`prepared-type-ref` (rf2-rxjy3) decides the child's reference by comparing its prepared `:type-spec` against what the registrar *currently* holds. A listener on either trace that unregistered or replaced the admitted child's TYPE diverged the registrar **after** that comparison had already been made and returned the revertible `:machine-id` keyword. The install then stamped a stale keyword, and the lazy resolver re-materialised:

- **nothing** — the child sat at `:initial` with `:rf/bootstrap-pending? true` and every event raised `:rf.error/no-such-handler` (inert actor); or
- **an unrelated successor definition** — a prepared-v1 snapshot driven by a current-v2 handler (split authority).

Exactly the two failure modes rf2-rxjy3 eliminated, reached through a later door. The existing suites mutate the registrar from `:rf.machine.spawn-all/started`, which fires before the per-child spawn fx runs at all, so neither seam was covered.

## Repro technique

Same barrier shape the family's prior beads used — a synchronous `trace/register-listener!` that fires once on a chosen operation and mutates the registrar on the emitting stack. Widened from the suite's `on-started-once` to a general `on-operation-once` so the later operations (`:rf.machine.spawn/spawned`, `:rf.error/system-id-collision`) can be targeted, plus an `on-every-spawned` variant for the per-child adversarial case. No timing, no sleeps — the listener runs inside the emit, so the interleaving is deterministic on JVM and CLJS alike.

## The fix

Defer the *choice*, don't re-check anything. `spawn-fx*` passes `:type-ref-fn` as a thunk instead of `:type-ref` as a value; `install-spawn!` forces it inside the `(continue?)` fence, immediately before building `install-fn` — the last point ahead of the swap, after every callback-bearing pre-install emission. The definition-lifetime comparison is therefore made against the registrar as it stands at commit.

`machine-type-ref` (the non-prepared path) reads no registrar, so it is wrapped in `constantly` and stays timing-independent either way.

**Error id: none minted.** Like rf2-rxjy3, the fix *removes* a bad outcome rather than adding a boundary condition, so there is no new Spec 009 / `Spec-Schemas.md` row to co-edit.

## Red-before / green-after

Pre-fix, the four new tests failed **18 assertions** across the suite's 11 tests (62 assertions). Post-fix, 0 failures.

| # | Test | Seam |
|---|---|---|
| 8 | `unregister-from-the-spawned-trace-listener-keeps-the-child-live` | `:rf.machine.spawn/spawned` listener unregisters the TYPE |
| 9 | `reregister-from-the-spawned-trace-listener-keeps-one-coherent-authority` | same listener re-registers to an unrelated v2 |
| 10 | *(adversarial)* `every-child-unregistered-from-its-own-spawned-trace-stays-live` | every child's TYPE unregistered from that child's own emit; join must still fold |
| 11 | *(adversarial)* `unregister-from-the-system-id-collision-listener-keeps-the-child-live` | the tightest window — two children share a `:system-id`, and the collision listener unregisters the rebound child's TYPE from *inside* `install-spawn!` |

## Family intents preserved

- **rf2-ek435** (`:rf/prepared` preflight) — untouched; each child still prepared exactly once, and the scratch is still consumed + dropped in the install's own swap (tests 1-3 green).
- **rf2-v4oqd** (prepared verdict consumed, no registry recheck) — **no recheck reinstated**. `prepared-type-ref` selects only the *form* of the reference and can never reject or suppress a child; an admitted child always installs. Tests 8-11 all assert `(empty? (unregistered-rejects))`.
- **rf2-qlzh9** (atomic collision reject via the childless sentinel, `:rf.error/machine-spawn-all-duplicate-id`) — what counts as a collision is unchanged; the address-collision suite is green.
- **rf2-rxjy3** (handler-resolvable prepared child; dual `:spec` / `:type-spec` retention) — strengthened, not altered. The definition-lifetime rule is verbatim; only its evaluation point moved. Both legs still pinned: divergence pins the prepared definition (tests 4-6), and an undisturbed install still keeps the revertible keyword so hot-reload reaches live children (test 7).
- **rf2-ri19s** (alias rejection hoisted ahead of schema callbacks) — untouched; the fix lives entirely downstream of admission, in the per-child install. `spawn-all-init-fx`'s preflight ordering is unmodified, and the collision suite's zero-validator assertions are green.

## Quality gates

All foreground, run to completion, on the rebased tree.

- `cd implementation/machines && clojure -M:test` — **Ran 1196 tests containing 4166 assertions. 0 failures, 0 errors.**
- Targeted family suites (`spawn-all-prepared-unregister` + `spawn-all-authoritative-preflight` + `spawn-all-address-collision`) — **Ran 21 tests containing 112 assertions. 0 failures, 0 errors.**
- `npm run test:cljs` — **Ran 10024 tests containing 49410 assertions. 0 failures, 0 errors.**
- `sh scripts/check-playground-sci-freshness.sh` — **OK**, input-digest `315ebe42…` matches current inputs.

machines is a baked playground input, so the gate went STALE on the fix; `docs/cljs/playground-rf2.js` was rebuilt via `docs/tools/playground/sci` and committed as a separate, regenerable commit. Rebased onto `origin/main` (`42f7574`) — the rebase was clean, no conflict on the generated bundle — and the machines JVM suite plus the freshness gate were re-run green against the new base.
