### PR TITLE
docs(synthesis): finish the G-14 residual and retire the stable-fn interop claim (rf2-3plx7, rf2-58l6v)

### DIFF
--- a/ai/findings/new-substrate-synthesis/12-implementation-plan.md
+++ b/ai/findings/new-substrate-synthesis/12-implementation-plan.md
@@ -50,7 +50,9 @@ Epic `EPIC: re-frame.ui program` with per-stage children. Sequencing constraints
   08 §2 wins); (3) compile-error roster + didactic messages; (4) `ui.test`
   render/find/text over JVM trees; (5) parity corpus v0; (6) **interim Spec-004
   amendment merges here**, full 004 rewrite merges **atomically with the slice's
-  conformance fixtures**; (7) G-1/G-14 gates wired. *Contracts in place:* the public
+  conformance fixtures**; (7) G-1 wired, and G-14 only in its `defview` expansion-p95
+  arm — the other two arms (watch-loop rebuild delta, guide-fixtures CI cost) stay named
+  open, so G-14 is **not** complete at S1 ⟨07 §5⟩. *Contracts in place:* the public
   JVM-tree schema, conversion table, fingerprint/normalization inputs, and SSR consumption
   boundary are frozen in `spec/004B-UI-Tree-and-Conversion.md`, and the mount grammar,
   root identity, and locator rules in `spec/004C-Roots-and-Mount.md` (both promoted from

--- a/ai/findings/new-substrate-synthesis/drafts/ui-react-interop-contract.md
+++ b/ai/findings/new-substrate-synthesis/drafts/ui-react-interop-contract.md
@@ -117,16 +117,17 @@ observes the committed frame, never a mid-commit state.
 ### 2.4 `use-effect-event`
 
 ```clojure
-(react/use-effect-event f)  ;; => stable fn
+(react/use-effect-event f)  ;; => fn (identity NOT stable)
 ```
 
-Wraps `useEffectEvent` (stabilised in React 19.2 — the spike's release line). Returns a
-fn with **stable identity across renders** whose body always sees the latest render's
-values. **The no-deps contract:** `use-effect-event` takes *no* deps vector — that is
-the point of the primitive — and the returned fn **MUST NOT appear in any deps vector**
-(its stability makes it a lie there) and **MUST NOT be called during render** (host
-throws; it is effect-phase machinery). The compiler emits a dev diagnostic where a
-returned effect-event binding is statically visible inside a deps vector
+Wraps `useEffectEvent` (native in React 19.2 — the spike's release line; no shim).
+Returns a fn whose body always sees the latest render's values. Its identity is **not**
+stable — React allocates a fresh fn every render, so never rely on stability.
+**The no-deps contract:** `use-effect-event` takes *no* deps vector — that is the point
+of the primitive — and the returned fn **MUST NOT appear in any deps vector** (a fresh
+identity every render would defeat the comparison) and **MUST NOT be called during
+render** (host throws; it is effect-phase machinery). The compiler emits a dev
+diagnostic where a returned effect-event binding is statically visible inside a deps vector
 **[S3-CONFIRM — best-effort static detection scope]**. Boundary note: this wrapper does
 not change the event-boundary law — app intent still goes through event vectors /
 `ui/event`; `use-effect-event` is for the *foreign* pattern of "latest-values callback
@@ -291,8 +292,9 @@ The 03 §10 contract applies unmodified; this section states only what the tier 
   that re-run ("deps `rf=`-equal ⇒ skip"); therefore the **view generation participates
   in the internal comparison** — a generation bump forces cleanup + re-run regardless of
   deps. The `rf=` economy must never out-vote Fast Refresh semantics.
-- `use-effect-event`: identity stays stable across same-signature refreshes; the
-  latest-body slot is swapped, so the stable fn sees the edited body immediately.
+- `use-effect-event`: picks up its latest body across same-signature refreshes, so the
+  returned fn sees the edited body immediately. Its identity is not preserved across a
+  refresh — and never was stable to begin with (§2.4), so nothing is lost there.
 - `use-ref`: `current` survives same-signature refreshes (host state preservation);
   reset on remount.
 - `use-context`: host-managed; re-reads the provider on the refresh render.


### PR DESCRIPTION
Two small honesty corrections in the force-tracked synthesis tree, each the
last residual of a sweep another PR already completed elsewhere. Draft and
stage-roster prose only — no normative surface, code, test, gate, workflow,
or threshold changes.

## rf2-3plx7 — the G-14 residual

`12-implementation-plan.md`'s S1 epic roster listed item (7) as "G-1/G-14
gates wired". That is the overstatement rf2-1nd4q (#6316) corrected in
`07-testing.md` and EP-0034; this file was off-limits in that dispatch, so
it was left as the known last copy.

G-14 has three arms and one is wired. Verified from the wiring, not the docs:

| Arm | State | Evidence |
|---|---|---|
| `defview` expansion p95 | **wired** | `implementation/ui/test/re_frame/ui/g14_compile_budget_jvm_test.clj`, three fixture sizes, `50000.0`us bar, CI job `jvm-ui` |
| watch-loop rebuild delta | open | needs the S2+ dashboard fixture; no assertion repo-wide; owner `rf2-gv8gr` |
| guide-fixtures CI cost | open | needs the guide-examples corpus; owner is the `[S3-CONFIRM]` item in `drafts/guide-fixture-pipeline.md` 6/7 |

The roster now states G-1 wired and G-14 wired only in its expansion-p95 arm,
names the two open arms, and points at `07 §5` for the breakdown #6316 put
there. A stage roster should not carry a second copy of the gate's detail.

## rf2-58l6v — the stable-fn interop claim

`drafts/ui-react-interop-contract.md` still promised `use-effect-event`
returns a "stable fn". React 19.2's `useEffectEvent` has **unstable** identity
— a fresh function every render. rf2-pd0dh (#6309) reconciled the last
normative outlier; the shipped code and tests already agreed, so this draft
was the only remaining stale copy:

- `implementation/ui/src/re_frame/ui/react.cljc:96` — "its identity is NOT stable (React allocates a fresh function every render)"
- `implementation/ui/src/re_frame/ui/hooks.cljc:211` — native `useEffectEvent`, "No shim"
- `react_interop_dom_cljs_test.cljs:263` — `use-effect-event-latest-body-and-unstable-identity` asserts two distinct identities
- `spec/004-Views.md:935`, `:1005` — the reconciled normative wording this edit matches

Two sites fixed. In §2.4, the call-shape comment and its prose; "stabilised in
React 19.2" also becomes "native in React 19.2 … no shim", since that phrase
was itself feeding the confusion (the API stabilised, the identity did not).
The deps-vector prohibition stands, but its stated rationale was derived from
the stale premise — "its stability makes it a lie there" becomes "a fresh
identity every render would defeat the comparison". In the HMR section, the
bullet claiming identity "stays stable across same-signature refreshes" now
says the latest body is picked up and that identity was never stable to begin
with.

Two other "stable" mentions in that file are correct and untouched: the
`use-memo`/`use-callback` row and the stable-shell HMR machinery.

## The `ai/` tracking boundary (rf2-58l6v part 2 — reported, not actioned)

The bead asked whether this tracked file under a gitignored tree is legitimate.
**It is.** `git ls-files ai/` returns 85 files in exactly two trees —
`new-substrate-synthesis/` (61) and `new-substrate-codex/` (24) — and
`.gitignore` lines 39-48 document that force-tracked exception explicitly,
including the `git add -f` mechanism. No accidental force-add.

The real gap is that **CLAUDE.md contradicts it**: "The whole tree is
local-only (`/ai/` is in `.gitignore`); never `git add` anything under it" —
which is why workers keep re-deriving the boundary. Proposed wording is in the
report to the mayor; **deliberately not applied here**, since CLAUDE.md is the
agent-instruction file and should not change inside a docs-correction PR.

## Quality gates

All foreground, unpiped, on the final tree. Main was green.

| Gate | Result |
|---|---|
| `python scripts/check_synthesis_plan_authority.py` | exit 0 |
| `python scripts/check_synthesis_plan_authority.py --self-test` | exit 0 |
| `python scripts/check_doc_slugs.py --synthesis-only` | exit 0 (41 files) |
| `python -m mkdocs build --strict` | exit 0, built in 39.50s |

The authority guard's tightened bead-token matching (rf2-eipo0 / #6315) passes
clean on both edits; nothing was loosened.
