### PR TITLE
test(core): make the deferred-dispatch docstring guard prove enclosure (rf2-2sjtw)

### DIFF
--- a/implementation/core/test/re_frame/test_helpers_cljs_test.cljc
+++ b/implementation/core/test/re_frame/test_helpers_cljs_test.cljc
@@ -7,6 +7,7 @@
   helpers walk plain hiccup data — no React, no DOM."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer-macros [deftest is testing]])
+            [clojure.string :as str]
             [re-frame.test-helpers :as h]))
 
 ;; ---------------------------------------------------------------------------
@@ -397,7 +398,7 @@
       (is (fn? (h/extract-handler hit :on-click))))))
 
 ;; ---------------------------------------------------------------------------
-;; Deferred-callback frame-law guard (rf2-1yi8d, rf2-ywwpx)
+;; Deferred-callback frame-law guard (rf2-1yi8d, rf2-ywwpx, rf2-2sjtw)
 ;; ---------------------------------------------------------------------------
 ;; The copyable `testid` example must show the `reg-view`-injected `dispatch`,
 ;; not a bare qualified `rf/dispatch`. A deferred `:on-*` callback runs after
@@ -407,20 +408,72 @@
 ;;
 ;; Showing the injected `dispatch` is only half the contract: the example must
 ;; also show the form that BINDS it, otherwise a reader who copies the snippet
-;; gets an unresolved `dispatch` symbol (rf2-ywwpx). So this fixture pins the
-;; binding context — the enclosing `rf/reg-view` must appear ahead of the
-;; injected use — not merely the presence of `#(dispatch`.
-;; `[\s\S]*?` rather than `(?s).*?` — the inline `(?s)` flag is a Java-only
-;; regex construct and CLJS compiles patterns to JS RegExp.
-(def ^:private reg-view-binds-injected-dispatch
-  #"\(rf/reg-view [\s\S]*?#\(dispatch ")
+;; gets an unresolved `dispatch` symbol (rf2-ywwpx).
+;;
+;; Two regex generations failed to prove that. The previous fixture,
+;; `#"\(rf/reg-view [\s\S]*?#\(dispatch "`, only required a `reg-view` to occur
+;; somewhere *earlier* in the docstring: `[\s\S]*?` is lazy but unbounded, so it
+;; spans a closing paren happily and matched
+;; `(rf/reg-view already-closed [] [:div])\n[:button #(dispatch [:x])]` — a view
+;; that has already closed followed by a detached fragment whose `dispatch` is
+;; unresolved (rf2-2sjtw). Textual ordering is not enclosure.
+;;
+;; So the guard no longer infers structure from a pattern; it pins the canonical
+;; example as one exact form. `canonical-testid-example` is a single balanced
+;; `rf/reg-view` carrying its own closing `])`, with the deferred `#(dispatch
+;; ...)` strictly interior — enclosure holds by construction of the literal
+;; rather than by a match that could straddle two forms. Comparison is on
+;; whitespace-collapsed text, so re-indenting the docstring stays green while
+;; token order and paren structure stay pinned.
+;;
+;; Deliberately NOT reader- or balance-based: `cljs.reader/read-string` is
+;; EDN-only and throws on `#(...)` fn literals, so a reader walk could not run on
+;; both hosts without a new dependency, and a paren-depth scanner would be wrong
+;; in general (parens nest inside string and character literals). Both are more
+;; machinery than a docstring guard warrants.
+(def ^:private canonical-testid-example
+  "(rf/reg-view counter-inc-button [] [:button (testid \"counter-inc\" {:on-click #(dispatch [:counter/inc])}) \"+\"])")
+
+(defn- collapse-ws
+  "Trim and squeeze runs of whitespace to a single space, so the pin is
+  indentation-insensitive but structure-exact."
+  [s]
+  (str/replace (str/trim s) #"\s+" " "))
+
+(defn- shows-enclosed-injected-dispatch?
+  "True when `doc` contains the canonical `rf/reg-view` example whole —
+  opening form, deferred `#(dispatch ...)`, and closing paren."
+  [doc]
+  (str/includes? (collapse-ws doc) canonical-testid-example))
 
 (deftest testid-docstring-shows-the-binding-context-for-injected-dispatch
   (let [doc (:doc (meta #'h/testid))]
     (is (some? doc) "testid must carry a docstring")
-    (is (re-find reg-view-binds-injected-dispatch doc)
-        (str "the testid example must show the `rf/reg-view` form that BINDS `dispatch` "
-             "ahead of the deferred `#(dispatch ...)` that uses it — otherwise a reader "
-             "copying the snippet gets an unresolved `dispatch` symbol"))
+    (is (shows-enclosed-injected-dispatch? doc)
+        (str "the testid example must show the whole `rf/reg-view` form that BINDS `dispatch` "
+             "— up to and including its closing paren — around the deferred `#(dispatch ...)` "
+             "that uses it, otherwise a reader copying the snippet gets an unresolved "
+             "`dispatch` symbol"))
     (is (nil? (re-find #"#\(rf/dispatch " doc))
         "the testid example must NOT use a bare deferred `rf/dispatch` (raises :rf.error/no-frame-context)")))
+
+;; Negative controls are load-bearing in both directions: they pin the shapes the
+;; guard must reject, and they trip if a future edit loosens the pin back toward
+;; a bare `#(dispatch ` substring.
+(deftest enclosure-guard-discriminates-binding-context
+  (testing "re-indented canonical example still passes — the pin must not over-tighten"
+    (is (shows-enclosed-injected-dispatch?
+         (str "  (rf/reg-view counter-inc-button []\n"
+              "      [:button (testid \"counter-inc\"\n"
+              "                       {:on-click #(dispatch [:counter/inc])})\n"
+              "       \"+\"])"))))
+  (testing "a `reg-view` that has already closed does not bind a later detached fragment (rf2-2sjtw)"
+    (is (not (shows-enclosed-injected-dispatch?
+              "(rf/reg-view already-closed [] [:div])\n[:button #(dispatch [:x])]"))))
+  (testing "a detached fragment with no binding form at all"
+    (is (not (shows-enclosed-injected-dispatch?
+              "[:button (testid \"counter-inc\" {:on-click #(dispatch [:counter/inc])}) \"+\"]"))))
+  (testing "an otherwise-canonical example that reverts to a bare qualified `rf/dispatch`"
+    (is (not (shows-enclosed-injected-dispatch?
+              (str "(rf/reg-view counter-inc-button [] [:button "
+                   "(testid \"counter-inc\" {:on-click #(rf/dispatch [:counter/inc])}) \"+\"])"))))))


### PR DESCRIPTION
Third and final pass on the `testid` deferred-dispatch docstring guard (rf2-1yi8d → rf2-ywwpx → rf2-2sjtw).

## The weakness

The guard claimed to prove that the canonical example's deferred `#(dispatch ...)` sits inside the `rf/reg-view` form that BINDS it. It proved only textual ordering.

`#"\(rf/reg-view [\s\S]*?#\(dispatch "` requires a `reg-view` somewhere *earlier* in the docstring and nothing more — `[\s\S]*?` is lazy but unbounded, so it spans a closing paren happily. Reproduced on the JVM:

```
detached  = "(rf/reg-view already-closed [] [:div])\n[:button #(dispatch [:x])]"
re-find   => "(rf/reg-view already-closed [] [:div])\n[:button #(dispatch "
MATCHES (should not) => true
```

The match text visibly spans the `)` that closes the view. The fragment that follows is detached and its `dispatch` unresolved — the exact regression rf2-ywwpx was meant to turn red.

## The fix

The guard no longer infers structure from a pattern; it pins the canonical example as one exact form. `canonical-testid-example` is a single balanced `rf/reg-view` carrying its own closing `])`, with the deferred `#(dispatch ...)` strictly interior — **enclosure holds by construction of the literal** rather than by a match that could straddle two forms. Comparison runs on whitespace-collapsed text, so the pin is indentation-insensitive but structure-exact.

Deliberately **not** reader- or balance-based, per the bead's "no balanced-form parser":
- `cljs.reader/read-string` is EDN-only and throws on `#(...)` fn literals, so a reader walk could not satisfy the both-hosts criterion without a new dependency.
- A paren-depth scanner is wrong in general — parens nest inside string and character literals — which would invite a fourth pass.

Negative controls are load-bearing in both directions: they pin the rejected shapes, and they trip if a future edit loosens the pin back toward a bare `#(dispatch ` substring.

## Red-before / green-after

Both predicates against every fixture:

| Fixture | OLD guard | NEW guard |
| --- | --- | --- |
| **POSITIVE** real shipped `testid` docstring | true ok | **true ok** |
| **POSITIVE** re-indented canonical example | true ok | **true ok** |
| **NEGATIVE** already-closed `reg-view` + detached fragment | true ← **WRONG** | **false ok** |
| **NEGATIVE** detached fragment, no binding form | false ok | false ok |
| **NEGATIVE** canonical shape but bare qualified `rf/dispatch` | false ok | false ok |

Exactly one row flips, and it is precisely the defect the bead reports. The positive control on the real shipped docstring still passes — the guard is not over-tightened.

## Quality gates

- **JVM** — `cd implementation/core && clojure -M:test -n re-frame.test-helpers-cljs-test` → `Ran 42 tests containing 73 assertions. 0 failures, 0 errors.`
- **CLJS/node** — same namespace compiled and run via `cljs.main -t node` → `Ran 45 tests containing 82 assertions. 0 failures, 0 errors.`
- **Counts reconcile** — 42 top-level `deftest`s = the JVM count; 42 + 3 `:cljs`-only = 45 = the CLJS count. Every test executed on both hosts, including the new one (no silent skip / no "Ran 0 tests" false-green).
- **clj-kondo** — `errors: 0, warnings: 0` on the changed file.

`node_modules` was absent in this worktree, so the CLJS host was verified with `cljs.main` on node rather than the shadow-cljs `npm run test:cljs` suite. That exercises the exact portability question this change introduces (`str/replace` with a regex, `str/includes?`, `str/trim` under JS RegExp) on the exact namespace; CI's node suite still covers the shadow path.

## Scope

Test-only — one file, `implementation/core/test/re_frame/test_helpers_cljs_test.cljc`. The `test_helpers.cljc` docstring is **unchanged**, so the baked playground input's digest is untouched and this stays clear of the bundle-conflict queue (rf2-tzy13). No runtime change, no parser, no doc framework.

Closes rf2-2sjtw.
