### PR TITLE
fix(story): make presence playback installable and fail closed (rf2-36biz)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1092,20 +1092,43 @@ asserts on what was rendered:
 Story does NOT model presence, own a clock, or reimplement the three-phase
 machine — `re-frame.story.play.presence` is a thin seam that CALLS the
 framework verb. Because Story's shipped jar must not depend on the
-pre-publication `day8/re-frame2-ui`, the verb is INSTALLED by a
-`re-frame.ui`-hosted shell
-(`re-frame.story.play.presence/install-presence-flush!`, registering the
-`:flush-presence!` late-bind hook) rather than `:require`d.
+pre-publication `day8/re-frame2-ui`, the verb arrives through the
+`:flush-presence!` late-bind hook rather than a `:require`.
+
+**Installing the presence host is one `:require`.** An app that mounts the
+Story shell and renders `re-frame.ui` compiled views requires the optional
+bridge once at boot:
+
+```clojure
+(ns my-app.story
+  (:require [re-frame.story]
+            [re-frame.story.play.presence-host]))   ; installs the verb
+```
+
+`re-frame.story.play.presence-host` is the ONE canonical integration path. It
+holds the `re-frame.ui` dependency on the *app's* side of the seam — Story's
+jar ships the file but never requires it, so the dependency direction is
+unchanged. It installs at load time; there is nothing else to call.
+(`re-frame.story.play.presence/install-presence-flush!` stays public for a
+host registering a different advance.)
 
 `[:flush-presence]` requires NO capability token and does not lift
 `:required-runner` to `:dom` — the presence clock is a process-global
-fake-clock registry, and a host with no presence runtime advances a
-no-op. That mirrors the framework's own JVM arm of `flush-presence!`,
-which is a documented no-op for host parity so a `.cljc` body reads the
-same on either host. It is deliberately NOT a `:cannot-run` refusal: a
-refusal exists to stop a step passing FALSELY, and there is no false pass
-here — the DOM assertion that FOLLOWS the advance carries the `:dom`
-requirement, as it always did.
+fake-clock registry, so a headless script can advance it and prove the
+consequence through app-db alone.
+
+**With no presence host installed, `[:flush-presence]` REFUSES
+(`:cannot-run`)** — it never skips silently. The step was requested and did
+not happen, so the run reports the distinct third status rather than a clean
+verdict over a clock that never moved. A missing hook does NOT prove a missing
+presence runtime: an app can load `re-frame.ui`, render a real
+`(ui/presence …)` boundary, and merely omit the bridge require. Nor may the
+refusal be delegated to the assertion that follows — the grammar requires no
+following assertion at all, and an `:assert-db` one needs only the headless
+floor, so it would happily prove a state the un-advanced clock produced. (The
+framework's own JVM arm of `flush-presence!` remains a no-op, and correctly
+so: there the structural host provably has no lifecycle to advance. An absent
+hook establishes no such thing.)
 
 **Source metadata is preserved for narrative projection.** The runner
 keeps the script step on every step-result and trace record, and the

--- a/tools/story/src/re_frame/story/late_bind.cljc
+++ b/tools/story/src/re_frame/story/late_bind.cljc
@@ -96,12 +96,17 @@
                                      Story's shipped jar must not depend on
                                      the pre-publication `day8/re-frame2-ui`,
                                      so the verb arrives through this hook
-                                     rather than a `:require`. Absent on a
-                                     host with no presence runtime, where the
-                                     advance is a no-op (host parity with the
-                                     framework's own JVM arm), NOT a refusal.
-                                     Install via
-                                     `re-frame.story.play.presence/install-presence-flush!`.
+                                     rather than a `:require`. Installed by
+                                     ONE `:require` of the optional bridge
+                                     `re-frame.story.play.presence-host`,
+                                     which holds the `re-frame.ui` dependency
+                                     on the app's side of the seam. Unlike
+                                     every other hook here, an ABSENT
+                                     `:flush-presence!` is NOT a no-op: a
+                                     requested `[:flush-presence]` refuses
+                                     `:cannot-run`, because a missing hook
+                                     does not prove a missing presence
+                                     runtime (rf2-36biz).
 
   - `:render-hiccup`               — a host that can render the active view
                                      to a HICCUP TREE (data) → the play

--- a/tools/story/src/re_frame/story/play/presence.cljc
+++ b/tools/story/src/re_frame/story/play/presence.cljc
@@ -30,21 +30,29 @@
   Story's shipped jar must not depend on `re-frame.ui` (`day8/re-frame2-ui`
   is pre-publication — the same isolation `re-frame.story.view-tool` keeps),
   so the verb arrives through the `re-frame.story.late-bind` registry under
-  `:flush-presence!`. A `re-frame.ui`-hosted shell installs it once at boot:
+  `:flush-presence!`. The canonical installation is ONE `:require` of the
+  optional bridge `re-frame.story.play.presence-host`, which holds the
+  `re-frame.ui` dependency on the app's side of the seam and installs the
+  verb at its load time. `install-presence-flush!` below stays public for a
+  host that wants to register a different advance.
 
-      (require '[re-frame.ui.test :as uit])
+  ## No host installed → `:cannot-run`, never a silent skip
 
-      (story-presence/install-presence-flush!
-        (fn [ms] (if ms (uit/flush-presence! ms) (uit/flush-presence!))))
+  With NO host installed the advance DID NOT HAPPEN, and a requested
+  `[:flush-presence]` therefore REFUSES (`:cannot-run`) at the executor
+  (rf2-36biz). The earlier reading — that this should be a no-op mirroring
+  the framework's JVM arm of `flush-presence!` — conflated two different
+  facts. The JVM arm is a no-op because the structural host provably has no
+  lifecycle to advance; an ABSENT HOOK proves nothing of the kind, because an
+  app can load `re-frame.ui`, render a real `(ui/presence …)` boundary, and
+  simply omit the bridge call. Its playback would then advance nothing while
+  Story reported a clean verdict.
 
-  With NO host installed the advance is a no-op — deliberately, and for the
-  same reason the framework's own JVM arm of `flush-presence!` is a no-op:
-  a host with no presence runtime has no retention to advance, and
-  `.cljc` playback must read the same on either host (`ui.test` §host
-  parity). It is NOT a `:cannot-run` refusal: a refusal is for a step that
-  would otherwise pass FALSELY, and there is no false pass here — the
-  assertion that follows carries its own capability gate (a `:assert-dom`
-  step still refuses `:cannot-run` under a headless runner).
+  Nor does the following assertion carry the refusal: the grammar requires no
+  following assertion at all, and an `:assert-db` one needs only the headless
+  floor, so it happily proves a state the un-advanced clock produced. Host
+  parity is preserved where it is real — this namespace is `.cljc` and the
+  bridge installs on both hosts, the JVM verb being the framework's own no-op.
 
   Pure data → data apart from the hook call itself, so both the JVM
   `clojure -M:test` gate and the node `npm run test:cljs` gate exercise it."
@@ -78,11 +86,15 @@
   installed host verb. Returns a small result map:
 
     {:status :advanced :ms <ms|nil>}   — the host verb ran
-    {:status :no-host  :ms <ms|nil>}   — no host installed; a no-op advance
-                                         (host parity — see the ns docstring)
+    {:status :no-host  :ms <ms|nil>}   — no host installed; NOTHING advanced
+                                         (the executor projects this into a
+                                         `:cannot-run` refusal — see the ns
+                                         docstring)
     {:status :error    :ms … :error s} — the host verb threw
 
-  Never throws: the executor projects the map into a step-result."
+  Never throws, and never judges: this is pure data → data reporting of what
+  happened. The executor (`runner-events/exec-flush-presence!`) projects the
+  map into a step-result."
   [ms]
   (if-let [f (presence-flush-fn)]
     (try

--- a/tools/story/src/re_frame/story/play/presence_host.cljc
+++ b/tools/story/src/re_frame/story/play/presence_host.cljc
@@ -1,0 +1,78 @@
+(ns re-frame.story.play.presence-host
+  "OPTIONAL host bridge — the ONE canonical way to make `[:flush-presence]`
+  reach the framework's presence clock (rf2-36biz; Spec 017 §Presence-bearing
+  variants).
+
+  ## Why a separate namespace exists
+
+  `re-frame.story.play.presence` is the SEAM: it holds the `:flush-presence!`
+  late-bind hook and calls whatever the host registered there. It deliberately
+  does NOT `:require` `re-frame.ui` — Story's published jar must not depend on
+  the pre-publication `day8/re-frame2-ui` (the same isolation the view-tool
+  consumer keeps). But a seam nothing installs is a seam nothing reaches: the
+  hook shipped with no production installer at all, so a presence-bearing
+  script could never advance the real clock.
+
+  This namespace is the missing half — the small bridge that DOES require
+  `re-frame.ui.test` and wires its verb into the hook. It is opt-in and never
+  loaded by Story itself, so the dependency direction is unchanged: Story's
+  jar carries this file but never requires it, and the require only resolves
+  in an app that already has `re-frame.ui` on its classpath. Exactly the shape
+  of `re-frame.story.generate.test-check` (an optional adapter whose dependency
+  lives on the `:test` alias only), differing only in that CLJS cannot
+  `requiring-resolve`, so an app without `re-frame.ui` gets a compile-time
+  \"namespace not found\" naming the missing dep rather than a runtime throw.
+
+  ## Integration — one `:require`
+
+  An app that mounts the Story shell AND renders `re-frame.ui` compiled views
+  requires this namespace once at boot:
+
+      (ns my-app.story
+        (:require [re-frame.story]
+                  [re-frame.story.play.presence-host]))
+
+  Loading it installs the verb; there is nothing else to call. `install!` is
+  public and idempotent for the one case that needs it — a test fixture that
+  wiped the hook registry (`late-bind/clear!`) and wants it back.
+
+  ## What it deliberately does NOT do
+
+  It installs the flush verb and nothing else. In particular it leaves the
+  presence WALL CLOCK armed (`presence-runtime/set-wall-clock!` stays true):
+  disabling it process-wide would freeze every retained child in a variant a
+  human is merely clicking through in the canvas, which no `[:flush-presence]`
+  step is there to release. Playback stays deterministic regardless — the
+  clock's `fire-timer!` is id-keyed and exactly-once, so a logical advance
+  fires a due exit early and the real `setTimeout` that lands later is a no-op.
+
+  With this bridge absent, `[:flush-presence]` REFUSES (`:cannot-run`) rather
+  than skipping silently — see `re-frame.story.play.presence`."
+  (:require [re-frame.story.play.presence :as presence]
+            [re-frame.ui.test             :as ui-test]))
+
+(defn install!
+  "Register `re-frame.ui.test/flush-presence!` under the `:flush-presence!`
+  late-bind hook, so a `[:flush-presence]` / `[:flush-presence ms]` script
+  step advances the real presence clock.
+
+  Story adds no clock, no phase model and no scheduler of its own — the two
+  script arities map 1:1 onto the framework verb's two arities: `nil` ms means
+  advance to quiescence, a number advances the logical clock by that many
+  milliseconds. `0` is a legal advance, so the arity is chosen on `some?`, not
+  on truthiness.
+
+  Runs at this namespace's LOAD time (a bare `:require` is the whole
+  integration). Idempotent — re-registration replaces the slot, per Spec 001
+  hot-reload semantics."
+  []
+  (presence/install-presence-flush!
+    (fn [ms]
+      (if (some? ms)
+        (ui-test/flush-presence! ms)
+        (ui-test/flush-presence!))))
+  nil)
+
+;; Load-time install, mirroring how `re-frame.story.canonical` registers its
+;; auto-install hook at ns load: requiring the bridge IS the integration.
+(install!)

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -13,7 +13,9 @@
   - `:wait` ms → JS `setTimeout` (CLJS) or `Thread/sleep` (JVM).
   - `:flush-presence` → the presence-clock advance
     (`re-frame.story.play.presence/advance!` → the host's
-    `re-frame.ui.test/flush-presence!`); a no-op with no presence host.
+    `re-frame.ui.test/flush-presence!`); `:cannot-run` with no presence
+    host installed (rf2-36biz — an advance that did not happen never
+    reports a clean verdict).
   - `:assert-db` path value → read from `rf/app-db-value` and compare.
   - `:assert-db` path :pred fn-or-sym → invoke the predicate. A FN
     handed in directly is called as-is (advanced-CLJS-safe); a SYMBOL
@@ -1072,15 +1074,33 @@
   only the exits that come due — the arity that lets a script observe the
   retained `:unmounting` phase before its terminal removal.
 
-  A no-host advance is a step-skip, NOT a `:cannot-run` refusal: with no
-  presence runtime there is no retention to advance and nothing to pass
-  falsely (the framework's own JVM arm is a no-op for the same host-parity
-  reason). A host verb that THROWS is a step-exception — never swallowed."
+  A no-host advance FAILS CLOSED to `:cannot-run` (rf2-36biz). The step was
+  REQUESTED, and with no host installed it did not happen — so the run reports
+  the distinct THIRD status rather than a clean verdict over a clock that
+  never moved. \"No hook installed\" does not prove \"no presence runtime
+  exists\": an app can load `re-frame.ui` and simply omit the bridge call.
+  Nor can a following assertion be relied on to carry the refusal — the
+  grammar requires no following assertion, and an `:assert-db` one needs only
+  the headless floor. The refusal NAMES its install path so it is actionable.
+
+  A host verb that THROWS is a step-exception — never swallowed."
   [_frame-id idx step]
   (let [ms  (runner/step-presence-ms step)
         res (presence/advance! ms)]
-    (if (= :error (:status res))
-      (runner/step-exception idx step (:error res))
+    (case (:status res)
+      :error   (runner/step-exception idx step (:error res))
+      :no-host (runner/step-fail
+                 idx step
+                 {:cannot-run? true
+                  :reason      :no-presence-host
+                  :message     (str "cannot run " (pr-str step)
+                                    " — no presence host is installed, so the "
+                                    "presence clock did not advance. An app "
+                                    "that renders re-frame.ui compiled views "
+                                    "installs the verb by requiring "
+                                    "re-frame.story.play.presence-host (or by "
+                                    "calling re-frame.story.play.presence/"
+                                    "install-presence-flush! directly)")})
       (runner/step-skip idx step))))
 
 (defn exec-step!

--- a/tools/story/src/re_frame/story/requirements.cljc
+++ b/tools/story/src/re_frame/story/requirements.cljc
@@ -235,9 +235,13 @@
   settlement, and the boundary ladder (`settled-boundary`) governs flush,
   not the capability set. `:flush-presence` in particular does NOT require
   `:dom`: the presence clock is a process-global fake-clock registry, and a
-  host with no presence runtime advances a no-op (host parity — see
-  `re-frame.story.play.presence`). The DOM assertion that FOLLOWS the
-  advance carries the `:dom` requirement, as it always did."
+  headless script can advance it and prove the consequence through app-db
+  alone. Its fail-closed gate is not a capability token but the RUNTIME
+  presence-host check in `runner-events/exec-flush-presence!` — whether the
+  `:flush-presence!` hook is installed is a property of the process, not of
+  the runner tier, so it is unknowable to this static registry. An
+  uninstalled host refuses `:cannot-run` there (rf2-36biz); it is emphatically
+  NOT left to whatever assertion happens to follow."
   {:dispatch       #{:app-db}
    :dispatch-sync  #{:app-db}
    :wait           #{}

--- a/tools/story/test/re_frame/story/play/presence_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/presence_cljs_test.cljc
@@ -50,6 +50,12 @@
             [re-frame.story.late-bind             :as late-bind]
             [re-frame.story.plan                  :as plan]
             [re-frame.story.play.presence         :as story-presence]
+            ;; The OPTIONAL bridge under test (rf2-36biz) — the one canonical
+            ;; installation path. Requiring it is what an app does; it holds
+            ;; the `re-frame.ui` dependency on the app's side of the seam, so
+            ;; Story's own namespaces never require it (and its jar stays
+            ;; free of the pre-publication artefact).
+            [re-frame.story.play.presence-host    :as presence-host]
             [re-frame.story.play.runner           :as runner]
             [re-frame.story.play.runner-events    :as re]
             [re-frame.story.requirements          :as requirements]
@@ -160,11 +166,11 @@
         (is (= [100 nil] @calls)))
       (finally (swap! late-bind/hooks dissoc :flush-presence!)))))
 
-(deftest advance-with-no-host-is-a-no-op-not-a-refusal
-  (testing "host parity: the framework's own JVM arm of flush-presence! is a
-            no-op, so a Story host with no presence runtime advances a no-op
-            too — there is no retention to advance and nothing to pass
-            falsely (the DOM assertion that follows carries the refusal)"
+(deftest advance-with-no-host-reports-no-host
+  (testing "with no host installed the advance DID NOT HAPPEN, and `advance!`
+            says so faithfully — the executor projects `:no-host` into a
+            `:cannot-run` refusal (rf2-36biz). `advance!` itself stays pure
+            data → data: it reports, the executor judges"
     (is (nil? (story-presence/presence-flush-fn)))
     (is (= {:status :no-host :ms nil} (story-presence/advance! nil)))
     (is (= {:status :no-host :ms 250} (story-presence/advance! 250)))))
@@ -197,6 +203,12 @@
   (story/clear-all!)
   (registrar/clear-all!)
   (reset! frame/frames {})
+  ;; Start every test HOOK-FREE, symmetrically with `teardown!`. The hook
+  ;; registry is process-global, and merely REQUIRING the optional bridge
+  ;; (`presence-host`, whose load-time install is the whole point of it)
+  ;; arms it for the rest of the process — so the no-host tests must not
+  ;; depend on ns-load order to see an empty slot.
+  (swap! late-bind/hooks dissoc :flush-presence!)
   (try (rf/init! plain-atom/adapter)
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
   (reset! re/run-state {})
@@ -276,12 +288,56 @@
     (testing "both arities reached the host verb, ms threaded through"
       (is (= [100 nil] (:advances @state))))))
 
-(deftest presence-step-with-no-host-skips-cleanly
-  (testing "with no presence host the step is a SKIP, not a refusal and not
-            an exception — the same no-op the framework's JVM arm is"
+(deftest presence-step-with-no-host-refuses-cannot-run
+  (testing "rf2-36biz — with NO presence host installed the advance did not
+            happen, so the step REFUSES (`:cannot-run`) rather than skipping
+            silently. `no hook installed` does not prove `no presence runtime
+            exists`: an app can load re-frame.ui and simply omit the bridge
+            call, and its presence-bearing playback would then report a clean
+            verdict over a clock that never moved"
     (let [res (exec-step! presence-frame 0 [:flush-presence])]
-      (is (nil? (:passed? res)))
-      (is (nil? (:exception res))))))
+      (is (true? (:cannot-run? res)) "the distinct THIRD status, not a skip")
+      (is (false? (:passed? res)))
+      (is (nil? (:exception res)) "an absent host is a refusal, not a throw")
+      (is (string? (:message res)))
+      (is (re-find #"install-presence-flush!|presence-host" (:message res))
+          "the refusal NAMES the install path — an actionable refusal"))))
+
+;; The bridge's INSTALLATION is host-agnostic, but DRIVING the installed verb
+;; repeatedly is not: on CLJS `flush-presence!` is Promise-backed and holds a
+;; single in-flight act token, so back-to-back synchronous advances are the
+;; framework's own `:rf.error/ui-test-overlapping-act` misuse. This arm is
+;; therefore JVM-only, where the verb is a documented synchronous no-op. The
+;; CLJS end-to-end proof — the shipped bridge driving the REAL clock, with the
+;; act yields the run loop gives — is the real-clock `.cljs` companion, which
+;; installs through this same `presence-host/install!`.
+#?(:clj
+   (deftest presence-host-bridge-installs-the-framework-verb
+     (testing "rf2-36biz — the hook shipped with NO production installer: only
+               tests and docstrings called `install-presence-flush!`, so a
+               presence-bearing script could never reach the real clock. The
+               optional bridge is that missing installer, and it is REAL —
+               this drives the SHIPPED `install!`, not a copy of it"
+       (is (nil? (story-presence/presence-flush-fn))
+           "the fixture cleared the process-global hook")
+       (presence-host/install!)
+       (is (some? (story-presence/presence-flush-fn))
+           "one call — and a bare :require does it at load time")
+       (is (identical? (story-presence/presence-flush-fn)
+                       (late-bind/get-fn :flush-presence!))
+           "installed into the SAME late-bind slot the executor reads")
+       (testing "the installed verb runs — the framework's JVM arm of
+                 flush-presence! is its own documented no-op"
+         (is (= {:status :advanced :ms nil} (story-presence/advance! nil)))
+         (is (= {:status :advanced :ms 0}   (story-presence/advance! 0))
+             "0 is a legal advance — the arity is chosen on some?, not truth"))
+       (testing "idempotent: re-installing replaces the slot, never doubles it"
+         (presence-host/install!)
+         (is (= {:status :advanced :ms nil} (story-presence/advance! nil))))
+       (testing "and the step the bead is about now RUNS instead of refusing"
+         (let [res (exec-step! presence-frame 0 [:flush-presence])]
+           (is (nil? (:cannot-run? res)))
+           (is (nil? (:exception res))))))))
 
 (deftest presence-step-surfaces-a-throwing-host-as-an-exception
   (story-presence/install-presence-flush! (fn [_] (throw (ex-info "boom" {}))))
@@ -331,6 +387,58 @@
          (is (= :pass (:status state))
              "both the retained-phase assertion and the removal assertion held")
          (is (= :removed (:toast (db))))))))
+
+;; ---------------------------------------------------------------------------
+;; FAIL CLOSED: an uninstalled host is a refusal, never a silent green
+;; (rf2-36biz)
+;; ---------------------------------------------------------------------------
+;;
+;; The retired justification for the silent skip was "the DOM assertion that
+;; FOLLOWS carries the `:dom` requirement, so an incapable runner refuses
+;; there". The grammar never required a following assertion, never required it
+;; to be `:assert-dom`, and — more fundamentally — "no hook installed" does
+;; not prove "no presence runtime exists". These two tests drive the SAME
+;; script under the SAME headless runner with the ONLY following assertion an
+;; `:assert-db`, so that premise cannot come back: the pair differs in exactly
+;; one thing, whether the host was installed, and the verdicts must differ.
+
+#?(:clj
+   (deftest playback-with-no-presence-host-refuses-rather-than-passing-falsely
+     (testing "RED-the-bug: no host installed. `[:flush-presence 100]` never
+               advanced anything, yet `[:assert-db [:toast] :retained]` holds
+               anyway — the toast is retained because NOTHING moved the clock,
+               not because the advance stayed below :timeout-ms. The
+               assertion cannot tell those two worlds apart, so the STEP must:
+               the run is `:cannot-run`, never `:pass`"
+       (let [done  (atom nil)
+             _     (re/run! presence-frame "no-host"
+                            {:name   "no-host"
+                             :script [[:dispatch [:presence/tick]]
+                                      [:flush-presence 100]
+                                      [:assert-db [:toast] :retained]]}
+                            #(reset! done %))
+             state @done]
+         (is (= :cannot-run (:status state))
+             "an uninstalled presence host fails CLOSED")
+         (is (not= :pass (:status state))
+             "the silent false green rf2-36biz names is gone")))))
+
+#?(:clj
+   (deftest playback-with-an-installed-host-still-passes-the-same-script
+     (install-stub-presence-host! 300)
+     (testing "the other direction — over-tightening would be worse than the
+               bug. The IDENTICAL script, `:assert-db` its only assertion,
+               still passes once a host is properly installed"
+       (let [done  (atom nil)
+             _     (re/run! presence-frame "with-host"
+                            {:name   "with-host"
+                             :script [[:dispatch [:presence/tick]]
+                                      [:flush-presence 100]
+                                      [:assert-db [:toast] :retained]]}
+                            #(reset! done %))
+             state @done]
+         (is (= :pass (:status state))
+             "a valid setup is never refused")))))
 
 ;; The REAL framework verb driven against the REAL presence clock is the
 ;; pure-`.cljs` companion `presence_real_clock_cljs_test.cljs` — that arm is

--- a/tools/story/test/re_frame/story/play/presence_real_clock_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/play/presence_real_clock_cljs_test.cljs
@@ -31,10 +31,12 @@
   (:require [cljs.test :refer [async deftest is testing use-fixtures]]
             [re-frame.core                     :as rf]
             [re-frame.router                   :as router]
-            [re-frame.story.play.presence      :as story-presence]
+            ;; The shipped optional bridge — the one canonical installation
+            ;; path (rf2-36biz). Requiring it is exactly what a consuming app
+            ;; does; `install!` re-arms it after the shared fixture's teardown.
+            [re-frame.story.play.presence-host :as presence-host]
             [re-frame.story.play.runner-events :as re]
             [re-frame.ui.presence-runtime      :as presence-rt]
-            [re-frame.ui.test                  :as uit]
             ;; The shared harness (fresh registrar + runtime + variant frame,
             ;; and the same private step executor) — one harness across both
             ;; halves of the rung's coverage.
@@ -48,11 +50,16 @@
 
 (defn- install-real-presence-host! []
   (presence-rt/reset-clock!)
+  ;; Test-only determinism: the logical advance is the SOLE removal driver
+  ;; here. The BRIDGE deliberately leaves the wall clock armed (a variant a
+  ;; human is merely clicking through in the canvas has no [:flush-presence]
+  ;; step to release its retained children) — see `presence-host`.
   (presence-rt/set-wall-clock! false)
-  (story-presence/install-presence-flush!
-    ;; The rung reuses the framework verb's two arities EXACTLY — Story adds
-    ;; no clock, no phase model, no scheduler of its own.
-    (fn [ms] (if ms (uit/flush-presence! ms) (uit/flush-presence!)))))
+  ;; Install through the SHIPPED bridge (rf2-36biz), not a hand-rolled copy of
+  ;; it, so this whole suite is an acceptance test of the one canonical
+  ;; integration path. The bridge reuses the framework verb's two arities
+  ;; EXACTLY — Story adds no clock, no phase model, no scheduler of its own.
+  (presence-host/install!))
 
 (defn- schedule-real-exit!
   "Arm a REAL retained exit due at 300ms of logical time. Its removal


### PR DESCRIPTION
Closes rf2-36biz. Follow-up to rf2-qwzmt (#6295, S4-H).

## The two failures

**Uninstallable.** #6295 added `[:flush-presence]` through a late-bound `:flush-presence!` hook but shipped no production installer. Every caller of `install-presence-flush!` in the repo was a test or a docstring, so a presence-bearing script could never reach `re-frame.ui.test/flush-presence!`.

**Silent false pass.** With no hook, `advance!` returned `{:status :no-host}`, the executor mapped every non-error result to a skipped step, and `requirements` gave the step no capability — so a run reported `:pass` over a presence clock that never moved.

The retired justification was that "the DOM assertion that follows" carries the refusal. The grammar requires no following assertion at all, never requires it to be `:assert-dom`, and — more fundamentally — *"no hook installed" does not prove "no presence runtime exists"*: an app can load `re-frame.ui`, render a real `(ui/presence …)` boundary, and merely omit the bridge call.

## The fix, at qwzmt's seam

`re-frame.story.play.presence-host` — the missing installer, and the one canonical integration path:

```clojure
(ns my-app.story
  (:require [re-frame.story]
            [re-frame.story.play.presence-host]))   ; installs the verb
```

An optional bridge that requires `re-frame.ui.test` and installs at load time, so a bare `:require` is the whole integration. It holds the `re-frame.ui` dependency on the *app's* side of the seam — Story's own namespaces never require it, so the dependency direction is unchanged and the jar stays isolated from the pre-publication `day8/re-frame2-ui`. Same shape as the optional `generate.test-check` adapter, differing only in that CLJS cannot `requiring-resolve`. It deliberately leaves the presence wall clock armed: disabling it process-wide would freeze retained children in a variant a human is merely clicking through in the canvas.

`exec-flush-presence!` projects `:no-host` into a `:cannot-run` refusal naming its install path. `advance!` stays pure data → data — it reports, the executor judges, matching how the settled-boundary refusal is projected.

`step-capabilities` keeps `:flush-presence #{}`: whether the hook is installed is a property of the process, not the runner tier, so it is unknowable to the static registry — the runtime check is the gate. Spec 017, the late-bind hook catalogue and the requirements prose all carried the retired justification normatively and are corrected.

## Red-before / green-after, both directions

Per the bead, the pinned script's ONLY following assertion is `:assert-db`, so the false premise cannot return. The two runs differ in exactly one thing — whether a host was installed:

| | before | after |
|---|---|---|
| host-less run | `:pass` (false green) | `:cannot-run` |
| installed-host run, identical script | `:pass` | `:pass` |

RED (pre-fix): `expected: (= :cannot-run (:status state))` / `actual: (not (= :cannot-run :pass))` — plus the executor-level refusal test. 5 failures, 1 error, all in the two new tests. The second row is the guard against an over-tightened fix that refuses valid setups.

The real-clock CLJS suite now installs through the shipped `presence-host/install!` rather than a hand-rolled copy, making it an acceptance test of the canonical path. The shared fixture also clears the hook on *setup* as well as teardown, so the bridge's load-time install cannot leak across tests by ns-load order.

## Quality gates

| Gate | Result |
|---|---|
| `tools/story` `clojure -M:test` (from artefact dir) | **1836 tests / 6792 assertions, 0 failures, 0 errors** (baseline 1833/6778) |
| `npm run test:cljs` | **10020 tests / 49390 assertions, 0 failures, 0 errors** |
| `npm run story:build` | **Build completed, 0 warnings** |
| Bundle isolation (manual) | `presence_host` and `re_frame.ui.test` both **0 occurrences** in the built story bundle |

No dependency on `day8/re-frame2-ui` added (`tools/story/deps.edn` unchanged — it stays on the `:test` alias where it already was); no `implementation/**` change; no Playwright spec (CLJS unit tests per project convention).
