### PR TITLE
fix(ui): preserve record type in the build fingerprint (rf2-59car)

### DIFF
--- a/implementation/ui/src/re_frame/ui/fingerprint.cljc
+++ b/implementation/ui/src/re_frame/ui/fingerprint.cljc
@@ -57,13 +57,16 @@
   `canonical-string` is a TYPE-PRESERVING, INJECTIVE canonical string (not
   EDN). Every node is one self-delimiting token — a type-tag char, the
   char length of its body, a `:`, then the body — so a set / vector / list /
-  map carry DISTINCT tags and a set never collides with a vector (or map) of
-  the same flattened elements. Sets and map keys are order-normalized;
+  map / record carry DISTINCT tags and a set never collides with a vector (or
+  map) of the same flattened elements. A RECORD additionally carries its
+  fully-qualified type name inside its token, so it collides neither with the
+  plain map of the same entries nor with a record of a different type
+  (rf2-59car). Sets, map keys, and record entries are order-normalized;
   vectors and lists stay order-sensitive; scalars carry their host-identical
   `pr-str`. Two `=`-equal plans (up to map-key / set authoring order) always
   digest identically (no spurious plan-conflict); a genuine config change —
-  including a set↔vector↔list type flip — always digests differently.
-  Cross-host equality of the hex output is pinned by
+  including a set↔vector↔list type flip, or a record type swap — always
+  digests differently. Cross-host equality of the hex output is pinned by
   `re-frame.ui.fingerprint-cljs-test`."
   (:require [clojure.string :as str]))
 
@@ -83,22 +86,39 @@
 ;; parses back unambiguously).
 ;;
 ;; The TYPE TAG is what makes the encoding type-preserving. A set (`s`),
-;; vector (`v`), list/seq (`l`), and map (`m`) carry DISTINCT tags, so a set
-;; never collides with a vector — or a map — of the same flattened elements.
-;; That was the pre-#5745 hazard: a set was flattened to a bare vector of its
-;; elements' `pr-str` STRINGS, so the distinct configs `#{:a}` and `[":a"]`
-;; shared one canonical form (`[":a"]`). That is a GUARANTEED pre-hash
-;; collision — a real config change reads as an idempotent no-op — closed here
-;; because `#{:a}` -> "s.." and `[":a"]` -> "v.." can never coincide, and the
-;; inner keyword `:a` -> "t..:a" and string `":a"` -> "t..\":a\"" differ too.
+;; vector (`v`), list/seq (`l`), map (`m`), and record (`r`) carry DISTINCT
+;; tags, so a set never collides with a vector — or a map — of the same
+;; flattened elements. That was the pre-#5745 hazard: a set was flattened to a
+;; bare vector of its elements' `pr-str` STRINGS, so the distinct configs
+;; `#{:a}` and `[":a"]` shared one canonical form (`[":a"]`). That is a
+;; GUARANTEED pre-hash collision — a real config change reads as an idempotent
+;; no-op — closed here because `#{:a}` -> "s.." and `[":a"]` -> "v.." can never
+;; coincide, and the inner keyword `:a` -> "t..:a" and string `":a"` ->
+;; "t..\":a\"" differ too.
 ;;
-;; ORDER handling: sets sort their child tokens (order-INSENSITIVE), map
-;; entries sort by their canonical KEY token (authoring-order-insensitive,
-;; #5745), and vectors/lists preserve producer order (order-SENSITIVE).
-;; Emitting map entries as a length-delimited token stream — rather than
-;; reducing them into an intermediate `sorted-map-by` — means two DISTINCT
-;; keys that share a comparator rank can never overwrite one another; both
-;; entries survive into the digest.
+;; RECORDS ARE MATCHED FIRST (rf2-59car), because a record also satisfies
+;; `map?`. A leading `map?` branch discarded the record's TYPE, so `(->RecA 1)`,
+;; `(->RecB 1)`, and `{:x 1}` — three pairwise-UNEQUAL values — all encoded as
+;; the plain map `{:x 1}` and digested identically. That is the same class of
+;; GUARANTEED pre-hash collision as the pre-#5745 set flattening, and it lands
+;; on the same failure mode: `config-fingerprint` / `build-digest` plan-conflict
+;; detection reads a false digest MATCH as "nothing changed", so a genuine plan
+;; conflict is silently treated as an idempotent no-op. The `r` token therefore
+;; carries the record's fully-qualified type name as its own leading `t` token,
+;; ahead of the entries, and the distinct `r` tag keeps a record clear of the
+;; plain map of the same entries.
+;;
+;; ORDER handling: sets sort their child tokens (order-INSENSITIVE), map and
+;; record entries sort by their canonical KEY token (authoring-order-
+;; insensitive, #5745), and vectors/lists preserve producer order
+;; (order-SENSITIVE). Records share the map's entry canonicalization exactly,
+;; which matters because a record's EXTENSION entries (its `__extmap`) preserve
+;; INSERTION order in the small-map representation: `(assoc (->RecA 1) :b 2 :c 3)`
+;; and `(assoc (->RecA 1) :c 3 :b 2)` are `=`, and must digest identically.
+;; Emitting entries as a length-delimited token stream — rather than reducing
+;; them into an intermediate `sorted-map-by` — means two DISTINCT keys that
+;; share a comparator rank can never overwrite one another; both entries survive
+;; into the digest.
 ;;
 ;; SCALARS (`t`) carry their `pr-str`, which is host-identical for the
 ;; supported terminal types and already type-distinct: a keyword `:a`, the
@@ -122,22 +142,65 @@
   [tag body]
   (str tag (count body) ":" body))
 
+(defn- canonical-entries
+  "The entry-token stream of an associative value: each entry's key and value
+  tokens, with the entries SORTED by their canonical KEY token, concatenated.
+  Shared by the map and the record branch of `-write`, so a record's entries —
+  its declared fields AND its insertion-ordered `__extmap` extensions —
+  canonicalize exactly like a plain map's. A token stream (not a sorted-map)
+  means two distinct keys that share a comparator rank can never overwrite one
+  another."
+  [x]
+  (->> x
+       (map (fn [[k v]] [(-write k) (-write v)]))
+       (sort-by first)
+       (mapcat (fn [[k v]] [k v]))
+       (apply str)))
+
+(defn- record-type-name
+  "The fully-qualified `my.ns/MyRec` name of a record's type, rendered
+  IDENTICALLY on both hosts so tagging a record cannot break the cross-host
+  equality of the hex output.
+
+  On CLJS this is `(pr-str (type x))`: `defrecord` sets the type's
+  `cljs$lang$ctorPrWriter` to write that name as a COMPILE-TIME literal, so it
+  is stable, unique per record type, and survives `:advanced` renaming.
+  `cljs.core/type->str` would NOT do — it reads `cljs$lang$ctorStr`, which
+  `deftype` sets but `defrecord` does not, so it silently degrades to the
+  constructor's JS source text — and neither would `(.-name (type x))`, which
+  `:advanced` munges.
+
+  On the JVM the record's class name carries the same information in host form
+  (the MUNGED namespace, a `.`, then the verbatim record name), so demunging
+  the namespace segment and rejoining it with `/` lands on the very same
+  string."
+  [x]
+  #?(:clj  (let [^String n (.getName (class x))
+                 i         (.lastIndexOf n ".")]
+             (str (clojure.lang.Compiler/demunge (subs n 0 i))
+                  "/"
+                  (subs n (inc i))))
+     :cljs (pr-str (type x))))
+
 (defn- -write
   "Emit the injective, type-preserving canonical token for `x`. Collections
-  carry a distinct type tag (`m`/`s`/`v`/`l`) so a map, set, vector, and
-  list never collide; sets and map keys are order-normalized while vectors
-  and lists keep producer order; scalars (`t`) carry their host-identical,
-  type-distinct `pr-str`."
+  carry a distinct type tag (`m`/`s`/`v`/`l`/`r`) so a map, set, vector, list,
+  and record never collide; sets, map keys, and record entries are
+  order-normalized while vectors and lists keep producer order; scalars (`t`)
+  carry their host-identical, type-distinct `pr-str`."
   [x]
   (cond
+    ;; Record — matched BEFORE `map?`, which a record ALSO satisfies
+    ;; (rf2-59car). The body is the record's fully-qualified type name as a
+    ;; leading `t` token, then its entries canonicalized exactly as a map's, so
+    ;; two record types with the same entries — and a record vs the plain map of
+    ;; those entries — always digest differently.
+    (record? x) (token "r" (str (token "t" (record-type-name x))
+                                (canonical-entries x)))
     ;; Map — sort ENTRIES by their canonical KEY token, then emit key and
     ;; value tokens in that order. A token stream (not a sorted-map) means
     ;; two distinct keys can never overwrite one another.
-    (map? x)    (token "m" (->> x
-                                (map (fn [[k v]] [(-write k) (-write v)]))
-                                (sort-by first)
-                                (mapcat (fn [[k v]] [k v]))
-                                (apply str)))
+    (map? x)    (token "m" (canonical-entries x))
     ;; Set — order-INSENSITIVE: sort the child tokens. The `s` tag keeps a
     ;; set distinct from a vector/list of the same elements.
     (set? x)    (token "s" (apply str (sort (map -write x))))
@@ -153,9 +216,10 @@
 (defn canonical-string
   "One deterministic, type-preserving canonical string per value, identical
   on both hosts (see the section comment above for the token grammar).
-  Equal values — up to map-key / set authoring order — produce the same
-  string; distinct values, including a set vs a vector vs a list of the same
-  elements, produce different strings."
+  Equal values — up to map-key / set / record-extension authoring order —
+  produce the same string; distinct values, including a set vs a vector vs a
+  list of the same elements, and a record vs another record type vs the plain
+  map of the same entries, produce different strings."
   [x]
   (str canonical-version (-write x)))
 

--- a/implementation/ui/test/re_frame/ui/fingerprint_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/fingerprint_cljs_test.cljc
@@ -90,6 +90,120 @@
             (fp/config-fingerprint :frame/f {:routes {{:a 1 :b 2} :right}}))
       "a real config difference still fingerprints differently"))
 
+;; rf2-59car — REAL records for the type-preservation tests below. `RecA` and
+;; `RecB` are structurally identical (one field `x`) and differ ONLY by record
+;; type, which is exactly the pair the pre-fix leading `map?` branch could not
+;; separate.
+
+(defrecord RecA [x])
+(defrecord RecB [x])
+
+(deftest canonical-string-preserves-record-type
+  ;; rf2-59car: a record ALSO satisfies `map?`, so `-write`'s leading `(map? x)`
+  ;; branch discarded the record's TYPE and encoded `(->RecA 1)`, `(->RecB 1)`,
+  ;; and `{:x 1}` all as the plain map `cfp2:m9:t2::xt1:1`. Those three values
+  ;; are pairwise UNEQUAL, so collapsing them was a GUARANTEED pre-hash
+  ;; collision of the same class as the pre-#5745 set flattening — and it lands
+  ;; on the worse failure mode: `config-fingerprint` / `build-digest`
+  ;; plan-conflict detection reads a false digest MATCH as "nothing changed", so
+  ;; a genuine plan conflict is silently treated as an idempotent no-op.
+  (is (map? (->RecA 1)) "premise — a record IS `map?`, which is why it collapsed")
+  (is (record? (->RecA 1)) "premise — and it is a record")
+  (is (not= (->RecA 1) (->RecB 1)) "premise — the two record types are unequal")
+  (is (not= (->RecA 1) {:x 1}) "premise — record and plain map are unequal")
+  (is (apply distinct? [(fp/canonical-string (->RecA 1))
+                        (fp/canonical-string (->RecB 1))
+                        (fp/canonical-string {:x 1})])
+      "RecA, RecB, and the plain map of the same entries all canonicalize
+       DISTINCTLY — the record type is preserved, not flattened into entries")
+  ;; the digests that actually feed plan-conflict detection must separate too.
+  (is (apply distinct? [(fp/config-fingerprint :frame/f (->RecA 1))
+                        (fp/config-fingerprint :frame/f (->RecB 1))
+                        (fp/config-fingerprint :frame/f {:x 1})])
+      "and so must their config fingerprints — a record type swap is a REAL
+       plan change, never an idempotent no-op")
+  ;; the record tag can collide with no other token type.
+  (is (apply distinct? [(fp/canonical-string (->RecA 1))
+                        (fp/canonical-string #{[:x 1]})
+                        (fp/canonical-string [[:x 1]])
+                        (fp/canonical-string (list [:x 1]))])
+      "a record stays distinct from a set/vector/list of its flattened entries"))
+
+(deftest canonical-string-record-extension-order-is-canonical
+  ;; rf2-59car ADVERSARIAL — type preservation must not cost order-canonicality.
+  ;; A record's EXTENSION entries (assoc'd beyond its declared fields) live in
+  ;; `__extmap`, whose small-map representation preserves INSERTION order, so
+  ;; the two values below iterate differently while being `=`. They must digest
+  ;; identically or preflight raises a SPURIOUS plan conflict.
+  (is (= (assoc (->RecA 1) :b 2 :c 3) (assoc (->RecA 1) :c 3 :b 2))
+      "premise — the two extension orders are value-equal")
+  (is (= (fp/canonical-string (assoc (->RecA 1) :b 2 :c 3))
+         (fp/canonical-string (assoc (->RecA 1) :c 3 :b 2)))
+      "a record's extension entries are order-normalized exactly like a map's")
+  (is (= (fp/config-fingerprint :frame/f (assoc (->RecA 1) :b 2 :c 3))
+         (fp/config-fingerprint :frame/f (assoc (->RecA 1) :c 3 :b 2)))
+      "so two plans identical up to extension authoring order fingerprint EQUAL")
+  ;; order-invariance is not value-collapse: a genuinely different extension
+  ;; value still separates.
+  (is (not= (fp/canonical-string (assoc (->RecA 1) :b 2 :c 3))
+            (fp/canonical-string (assoc (->RecA 1) :b 2 :c 4)))
+      "a real extension difference still canonicalizes differently")
+  ;; nor may an extension entry be confusable with a declared field.
+  (is (not= (fp/canonical-string (assoc (->RecA 1) :y 2))
+            (fp/canonical-string (assoc (->RecA 2) :y 1)))
+      "declared field and extension entry are not interchangeable"))
+
+(deftest canonical-string-preserves-record-type-at-depth
+  ;; rf2-59car ADVERSARIAL — the record tag must survive RECURSION, not just a
+  ;; top-level value. `-write` recurses through map values, set elements, and
+  ;; vector slots, and every one of those paths must keep the type.
+  (is (apply distinct? [(fp/canonical-string {:k (->RecA 1)})
+                        (fp/canonical-string {:k (->RecB 1)})
+                        (fp/canonical-string {:k {:x 1}})])
+      "nested as a map VALUE, RecA / RecB / plain map stay distinct")
+  (is (apply distinct? [(fp/canonical-string {(->RecA 1) :v})
+                        (fp/canonical-string {(->RecB 1) :v})
+                        (fp/canonical-string {{:x 1} :v})])
+      "and as a map KEY")
+  (is (apply distinct? [(fp/canonical-string [(->RecA 1)])
+                        (fp/canonical-string [(->RecB 1)])
+                        (fp/canonical-string [{:x 1}])])
+      "and inside a vector")
+  (is (apply distinct? [(fp/canonical-string #{(->RecA 1)})
+                        (fp/canonical-string #{(->RecB 1)})
+                        (fp/canonical-string #{{:x 1}})])
+      "and inside a set")
+  (is (not= (fp/config-fingerprint :frame/f {:routes {:home (->RecA 1)}})
+            (fp/config-fingerprint :frame/f {:routes {:home {:x 1}}}))
+      "a nested record vs plain map is a REAL plan difference at any depth")
+  ;; order-canonicality still holds around a nested record.
+  (is (= (fp/canonical-string {:k (assoc (->RecA 1) :b 2 :c 3) :j 1})
+         (fp/canonical-string {:j 1 :k (assoc (->RecA 1) :c 3 :b 2)}))
+      "nesting composes: outer map order and inner extension order both
+       normalize"))
+
+(deftest record-tag-cross-host-golden
+  ;; The record TAG is the one part of the encoding whose natural host
+  ;; renderings DIVERGE — the JVM has a munged, dotted class name
+  ;; (`re_frame.ui.fingerprint_cljs_test.RecA`) where CLJS has the
+  ;; `cljs$lang$ctorPrWriter` literal (`re-frame.ui.fingerprint-cljs-test/RecA`).
+  ;; `record-type-name` normalizes the JVM side onto the CLJS form, so these
+  ;; JVM-computed literals must reproduce EXACTLY under the CLJS run. Without
+  ;; that normalization a build-time (JVM) digest and a client (CLJS) digest of
+  ;; the SAME plan would differ — a spurious plan conflict, the mirror-image
+  ;; failure of the collapse this bead fixed.
+  (is (= "cf1-b812168c861e3c0c" (fp/config-fingerprint :frame/f (->RecA 1)))
+      "cross-host golden — JVM-computed literal; the CLJS run must match")
+  (is (= "cf1-d5f464cf44df9810" (fp/config-fingerprint :frame/f {:k (->RecA 1)}))
+      "cross-host golden — record nested as a map value")
+  ;; The record branch is CONSERVATIVE: it changes the encoding of nothing but
+  ;; records, so no fingerprint over the record-free value space moves and the
+  ;; `cfp2` version marker does not need to rotate. The two pre-existing goldens
+  ;; in `fnv1a-64-cross-host-golden` are unchanged by this bead, which is the
+  ;; standing proof of that.
+  (is (= "tf1-c783a8a97ba1ec42" (fp/digest "tf1-" "a"))
+      "the record branch perturbs no record-free digest — `cfp2` still applies"))
+
 (deftest fnv1a-64-cross-host-golden
   ;; The digest input is (canonical-string "a") = "cfp2:t3:\"a\"", so pin OUR
   ;; pipeline's value — a JVM-computed literal the CLJS run must reproduce.


### PR DESCRIPTION
Closes rf2-59car.

## The defect

`implementation/ui/src/re_frame/ui/fingerprint.cljc:136` — `-write` matched
`(map? x)` FIRST, and a record also satisfies `map?`, so the record's TYPE was
discarded before hashing. Confirmed on the JVM against the pre-fix code:

```
record? / map?  =>  true true
(= (->RecA 1) (->RecB 1))  =>  false      ; pairwise UNEQUAL values …
(= (->RecA 1) {:x 1})      =>  false

canon (->RecA 1)  =>  cfp2:m9:t2::xt1:1   ; … one identical encoding
canon (->RecB 1)  =>  cfp2:m9:t2::xt1:1
canon {:x 1}      =>  cfp2:m9:t2::xt1:1

(config-fingerprint :f (->RecA 1))  =>  cf1-41a67ff176862acb   ; one digest
(config-fingerprint :f (->RecB 1))  =>  cf1-41a67ff176862acb
(config-fingerprint :f {:x 1})      =>  cf1-41a67ff176862acb
```

The namespace docstring claims TYPE-PRESERVING, so the code contradicted its own
contract. This is the same class of GUARANTEED pre-hash collision as the
pre-#5745 set flattening, on a worse surface: `config-fingerprint` /
`build-digest` feed plan-conflict detection, where a false digest MATCH reads as
"nothing changed" — a genuine plan conflict silently treated as an idempotent
no-op.

## The fix — mirrors #6318 (rf2-5h9td)

Records are matched BEFORE `map?` and carry an `r` token whose body is the
record's fully-qualified type name (as its own leading `t` token) followed by
its entries. Entry rendering is factored into `canonical-entries`, shared with
the map branch — exactly #6318's seam — so a record's insertion-ordered
`__extmap` extensions stay order-canonical like a plain map's.

The type name is host-normalized, because this is a `.cljc` whose namespace
claims cross-host equality of the hex output (a divergent tag would trade the
false MATCH for a false MISMATCH — a spurious plan conflict between a build-time
JVM digest and a client CLJS digest). On CLJS it is `(pr-str (type x))`:
`defrecord` sets `cljs$lang$ctorPrWriter` to a compile-time literal, so it is
`:advanced`-safe. Per #6318, and re-verified here against the ClojureScript
1.12.145 jar, `cljs.core/type->str` would NOT do — it reads
`cljs$lang$ctorStr`, which `deftype` sets (core.cljc:1849) but `defrecord` does
not (core.cljc:2038), so it degrades to the constructor's JS source text:

```
pr-str type  =>  probe.core/RecA
type->str    =>  function (x,__meta,__extmap,__hash){ this.x = x; … }
```

On the JVM the class name is demunged and rejoined with `/`, landing on the
identical string — verified at source level: the CLJS bundle's `ctorPrWriter`
literals are exactly `re-frame.ui.fingerprint-cljs-test/RecA` / `RecB`, which is
precisely what the JVM branch emits.

`(.-name (type x))` is not used anywhere — it is munged under `:advanced`.

### The `cfp2` version marker deliberately does NOT rotate

The record branch changes the encoding of records alone, so no digest over the
record-free value space moves and no rebuild/remount wave is provoked. The two
pre-existing cross-host goldens are byte-identical after the fix
(`tf1-c783a8a97ba1ec42`, `cf1-012724d9085f1a27`) — that is the standing proof,
and a test asserts it.

## No existing test was passing because of the collapse

Explicitly checked, and the answer is **no**. `fingerprint_cljs_test.cljc` was
the only fingerprint test and contained no records; no record type in
`implementation/ui` (`InertRef`, `LazyJvmComponent`, `RenderFn`) is fed to a
digest — every digest input is reader forms, AST projections, keywords and
strings. Empirically both full suites stayed green after the fix, and the
pre-existing goldens did not move.

## Quality gates

Red-before / green-after, run from the artefact directory with non-zero counts.

**Red before** (record branch disabled, tests present) — 9 failures, all
record-type assertions, showing the collapsed values:

```
Ran 11 tests containing 52 assertions.
{:test 11, :pass 43, :fail 9, :error 0}

actual: (not (apply distinct? ["cfp2:m9:t2::xt1:1" "cfp2:m9:t2::xt1:1" "cfp2:m9:t2::xt1:1"]))
actual: (not (apply distinct? ["cf1-41a67ff176862acb" "cf1-41a67ff176862acb" "cf1-41a67ff176862acb"]))
```

**Green after**:

```
Ran 11 tests containing 52 assertions.
{:test 11, :pass 52, :fail 0, :error 0}
```

**`implementation/ui` JVM** (`cd implementation/ui && clojure -M:test`):

```
Ran 858 tests containing 15104 assertions.
0 failures, 0 errors.
```

854 tests on main → 858, exactly the 4 new deftests. (Assertion totals vary
run-to-run in this suite — a second identical run gave 15102 — because of its
`doseq`/race/perf-budget tests; test count is stable.)

**`npm run test:cljs`** (exit 0):

```
Ran 10027 tests containing 49424 assertions.
0 failures, 0 errors.
```

Verified this gate genuinely covers the change rather than reading as a false
green: `.shadow-cljs/builds/node-test/.../re_frame.ui.fingerprint_cljs_test.js`
contains both JVM-computed record goldens and `re_frame.ui.fingerprint.js`
contains `record_type_name`. The CLJS run reproducing the JVM-computed goldens
is what proves host-identity.

**clj-kondo**: 0 errors; the 2 warnings on the file (unused `clojure.string`
require, `-write` shadowing `cljs.core/-write`) are both pre-existing on main.

**No bundle rebuild**: `implementation/ui` is not a baked playground input;
`scripts/check-playground-sci-freshness.sh` reports OK/fresh (digest
`d645396499736545ab4b6be335d10061642431928ecda29308ab9adbbbd15ea9` matches).

## Tests added

Four deftests in `fingerprint_cljs_test.cljc`, mirroring #6318's shapes:
two record types differing only by TYPE; record vs plain map with identical
entries; extension-map insertion order invariance (`:b 2 :c 3` vs `:c 3 :b 2`)
without collapsing a real extension difference; type preservation AT DEPTH as
map value, map key, vector element and set element; and the cross-host record
goldens.
