### PR TITLE
fix(ui-compiler): make ui/spread and ui/html compose on both emitters (rf2-29s75)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -345,17 +345,50 @@
         key-info      (get-in node [:props :key])]
     (cond
       (get-in node [:props :spread])
-      (let [spread (get-in node [:props :spread])
-            sugar (get-in node [:props :class :base-str])
-            props-form `(re-frame.ui.runtime/spread->props
+      ;; ui/spread: the props object is runtime-built by `spread->props`;
+      ;; children ride the same call.
+      ;;
+      ;; TRUSTED MARKUP (rf2-29s75): `ui/spread` and `ui/html` COMPOSE — an
+      ;; element may carry a runtime-built prop map AND a trusted-markup sole
+      ;; child, and BOTH take effect. This branch does not go through
+      ;; `element-prop-pairs` (the `:safe-spread` sibling below does, which is
+      ;; why it already composed), so the compiler-owned
+      ;; `dangerouslySetInnerHTML` is attached here explicitly; without it the
+      ;; markup was silently dropped on CLJS while the JVM emitter kept it —
+      ;; a dual-emitter divergence against Spec 004 §Interop.
+      ;;
+      ;; The prop is set AFTER `spread->props` returns, so the visible
+      ;; `(ui/html ...)` site — the trust assertion — WINS any same-key value
+      ;; smuggled through the runtime prop map (see rf2-5pr75).
+      ;;
+      ;; EVALUATION ORDER: `base`/`overrides` are `spread->props` arguments, so
+      ;; they evaluate once each in authored order BEFORE the markup expression,
+      ;; matching source order and the JVM path (whose `:children` thunk runs
+      ;; after the opts map's `:dyn (merge base overrides)`). The
+      ;; single-evaluation `let` temporary mirrors the `:safe-spread` branch and
+      ;; folds away under :advanced.
+      ;;
+      ;; The analyzer sets `:children []` on an html-kid element, so no
+      ;; positional child accompanies the markup and React's
+      ;; children-vs-innerHTML conflict cannot arise.
+      (let [spread     (get-in node [:props :spread])
+            sugar      (get-in node [:props :class :base-str])
+            built      `(re-frame.ui.runtime/spread->props
                          ~tag-str
                          ~(when (seq sugar) sugar)
                          ~(:base spread)
                          ~(:overrides spread)
                          ~(site-key-form spread)
                          ~(debug-site-form (assoc spread :classification :spread)))
-            chs (children-forms st (:children node) inner-inline?)]
-        ;; spread props objects are runtime-built; children ride the same call
+            props-form (if-some [html (:html node)]
+                         (let [props-sym (gensym "rf-ui-spread")]
+                           `(let [~props-sym ~built]
+                              (cljs.core/unchecked-set
+                               ~props-sym "dangerouslySetInnerHTML"
+                               (cljs.core/js-obj "__html" ~(:form html)))
+                              ~props-sym))
+                         built)
+            chs        (children-forms st (:children node) inner-inline?)]
         (if (:present? key-info)
           `(re-frame.ui.runtime/jsx-spread3 ~tag-str ~props-form
                                             ~(:expr key-info)

--- a/implementation/ui/test/re_frame/ui/emit_cljs_lowering_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/emit_cljs_lowering_cljs_test.cljc
@@ -15,6 +15,9 @@
     ForeignComp {:fqn 'app.interop/ForeignComp :meta {}}
     raw-fn {:fqn 're-frame.ui/raw-fn :meta {}}
     event  {:fqn 're-frame.ui/event :meta {}}
+    ui/spread      {:fqn 're-frame.ui/spread :meta {}}
+    ui/spread-safe {:fqn 're-frame.ui/spread-safe :meta {}}
+    ui/html        {:fqn 're-frame.ui/html :meta {}}
     nil))
 
 (defn- emitted [form]
@@ -271,3 +274,112 @@
     (is (not-any? #{'re-frame.ui.runtime/warn-bare-view-alias!}
                   (forms-of (emitted '[:div [child-view {:label l}]
                                        [v/card {:x 1}]]))))))
+
+;; ---------------------------------------------------------------------------
+;; ui/spread + ui/html compose (rf2-29s75)
+;;
+;; The general-spread branch builds its props object at RUNTIME and never goes
+;; through `element-prop-pairs`, so the compiler-owned dangerouslySetInnerHTML
+;; has to be attached at that seam explicitly. Before the fix the CLJS emitter
+;; dropped the markup here (empty children array, no __html) while the JVM
+;; emitter kept the `tree/html` leaf — a silent dual-emitter divergence. The
+;; cross-host proof lives in the parity corpus (:spread-trusted /
+;; :safe-spread-trusted); these are the focused lowering assertions.
+;; ---------------------------------------------------------------------------
+
+(defn- occurrences [sym form]
+  (count (filter #{sym} (forms-of form))))
+
+(defn- html-objs [form]
+  (filter #(and (seq? %)
+                (= 'cljs.core/js-obj (first %))
+                (= "__html" (second %)))
+          (forms-of form)))
+
+(defn- inner-html-sets [form]
+  (filter #(and (seq? %)
+                (= 'cljs.core/unchecked-set (first %))
+                (= "dangerouslySetInnerHTML" (nth % 2 nil)))
+          (forms-of form)))
+
+(deftest general-spread-carries-trusted-markup-to-react
+  (let [form     (emitted '[:div (ui/spread base ovr) (ui/html markup)])
+        sets     (vec (inner-html-sets form))
+        objs     (vec (html-objs form))
+        children (last form)]
+    (is (= 're-frame.ui.runtime/jsx-spread2 (first form))
+        "an unkeyed spread element still routes through the spread jsx helper")
+    (is (= 1 (count sets))
+        "exactly one dangerouslySetInnerHTML is attached to the spread props object")
+    (is (= 1 (count objs))
+        "exactly one __html carrier is built")
+    (is (= '(cljs.core/js-obj "__html" markup) (first objs))
+        "the authored ui/html expression is the __html value, unwrapped and unsanitised")
+    (is (= '(cljs.core/array) children)
+        "the markup takes NO positional child slot — React's children-vs-innerHTML
+         conflict cannot arise")))
+
+(deftest spread-and-markup-expressions-evaluate-once-each-in-source-order
+  (let [form    (emitted '[:div (ui/spread base ovr) (ui/html markup)])
+        props   (nth form 2)
+        [_ bindings & body] props
+        init    (second bindings)]
+    ;; The emitter's syntax-quoted `let` resolves against the CORE OF THE HOST
+    ;; reading this .cljc — clojure.core/let on the JVM (the only host the
+    ;; emitter actually runs on), cljs.core/let when this test is compiled for
+    ;; the node-test build. Assert the binding form, not the core alias.
+    (is (= "let" (name (first props)))
+        "the runtime-built props object is bound to a single-evaluation temporary")
+    (is (= 're-frame.ui.runtime/spread->props (first init))
+        "the temporary is the object spread->props returned")
+    (is (every? #(= 1 (occurrences % form)) '[base ovr markup])
+        "base, overrides and the markup expression each evaluate exactly once")
+    (is (and (= 1 (occurrences 'base init)) (= 1 (occurrences 'ovr init)))
+        "base and overrides are spread->props arguments — evaluated in authored order")
+    (is (zero? (occurrences 'markup init))
+        "the markup expression is NOT part of the spread call")
+    (is (= 1 (occurrences 'markup (vec body)))
+        "the markup evaluates in the let BODY — i.e. AFTER base and overrides,
+         matching source order and the JVM emitter's children thunk")
+    (is (= (last body) (first bindings))
+        "the let returns the same props object it mutated")))
+
+(deftest trusted-markup-wins-over-a-runtime-smuggled-inner-html-key
+  (let [form  (emitted '[:div (ui/spread base ovr) (ui/html markup)])
+        props (nth form 2)
+        [_ _ & body] props]
+    (is (= 'cljs.core/unchecked-set (ffirst body))
+        "the compiler-owned prop is set AFTER spread->props returns, so the
+         visible (ui/html …) site — the trust assertion — wins any same-key
+         value carried in through the runtime prop map (see rf2-5pr75)")))
+
+(deftest spread-without-trusted-markup-is-unchanged
+  (let [plain (emitted '[:div (ui/spread base ovr) [:span "a"] [:span "b"]])]
+    (is (empty? (inner-html-sets plain))
+        "an ordinary spread element gains no innerHTML prop")
+    (is (empty? (html-objs plain)))
+    (is (some #(and (seq? %)
+                    (= 're-frame.ui.runtime/spread->props (first %)))
+              (forms-of plain))
+        "the runtime-built props object is still the bare spread->props call")
+    (is (= 2 (count (rest (last (filter #(and (seq? %)
+                                              (= 'cljs.core/array (first %)))
+                                        (forms-of plain))))))
+        "ordinary children still ride the spread call's children array")))
+
+(deftest safe-spread-composes-with-trusted-markup-in-both-key-shapes
+  (testing "keyless — the sibling spread form already composed; pin it"
+    (let [form (emitted '[:div (ui/spread-safe {:class "owned"} caller)
+                          (ui/html markup)])]
+      (is (= 're-frame.ui.runtime/jsx-spread2 (first form)))
+      (is (= 1 (count (html-objs form))))
+      (is (= '(cljs.core/array) (last form))
+          "no positional child accompanies the markup")))
+  (testing "keyed — the jsx-spread3 arm carries the markup too"
+    (let [form (emitted '[:div (ui/spread-safe {:key k :class "owned"} caller)
+                          (ui/html markup)])]
+      (is (= 're-frame.ui.runtime/jsx-spread3 (first form)))
+      (is (= 1 (count (html-objs form))))
+      (is (= 'k (nth form 3))
+          "the authored key still reaches React's third argument")
+      (is (= '(cljs.core/array) (last form))))))

--- a/implementation/ui/test/re_frame/ui/parity_fixtures.cljc
+++ b/implementation/ui/test/re_frame/ui/parity_fixtures.cljc
@@ -258,6 +258,24 @@
   [{:keys [markup]}]
   [:div.content (ui/html markup)])
 
+(defview spread-trusted
+  "ui/spread + ui/html COMPOSE (rf2-29s75): a runtime-built prop map and a
+  trusted-markup sole child on ONE element — BOTH take effect on BOTH emitters.
+  The overrides deliberately COLLIDE with a base prop (:title) and add to the
+  sugar class, so the spread merge is exercised alongside the raw markup. The
+  CLJS emitter used to drop the markup here while the JVM emitter kept it."
+  [{:keys [extra markup]}]
+  [:div.raw (ui/spread {:title "base title" :data-a "b" :class "base"} extra)
+   (ui/html markup)])
+
+(defview safe-spread-trusted
+  "ui/spread-safe + ui/html — the sibling spread form, which already composed
+  (its branch builds owned props through element-prop-pairs). Pinned here so
+  the two spread forms are proven to agree with each other AND across hosts."
+  [{:keys [attrs markup]}]
+  [:div.safe-raw (ui/spread-safe {:class "owned" :data-owned "o"} attrs)
+   (ui/html markup)])
+
 (defview handlers
   "Handler grammar: literal vectors (+ placeholders), options maps,
   dynamic handler expressions classified by value (vector / nil), a
@@ -433,6 +451,8 @@
    :custom-elements custom-elements
    :spread-view     spread-view
    :trusted         trusted
+   :spread-trusted      spread-trusted
+   :safe-spread-trusted safe-spread-trusted
    :handlers        handlers
    :with-defaults   with-defaults
    :as-props        as-props
@@ -476,6 +496,11 @@
    {:id :spread-override      :view :spread-view     :props {:extra {:class "x" :tab-index 9}}}
    {:id :spread-add           :view :spread-view     :props {:extra {:data-b "c" :title "t & t"}}}
    {:id :trusted              :view :trusted         :props {:markup "<b>bold & raw</b><i>i</i>"}}
+   ;; rf2-29s75 — spread + trusted markup on one element, both emitters
+   {:id :spread-trusted       :view :spread-trusted  :props {:extra {:title "override & <wins>" :class "x" :tab-index 9}
+                                                             :markup "<b>bold & raw</b><i>i</i>"}}
+   {:id :safe-spread-trusted  :view :safe-spread-trusted :props {:attrs {:aria-label "raw region" :data-c "c" :class "caller"}
+                                                                 :markup "<em>em & raw</em>"}}
    {:id :handlers-on          :view :handlers        :props {:id 42 :on? true :ks ["k1" "k2"]}}
    {:id :handlers-off         :view :handlers        :props {:id 7 :on? false :ks []}}
    {:id :defaults-absent      :view :with-defaults   :props {}}


### PR DESCRIPTION
Fixes rf2-29s75 (P1). Implements the operator's **ruling: option (a) — `ui/spread` and `ui/html` COMPOSE.** No compile-time rejection was added.

## The divergence (reproduced on both hosts)

`[:div (ui/spread base ovr) (ui/html s)]` compiles clean, the analyzer accepts it (`:html {:op :html :form s}`, `:children []`, `:props :spread` present) — but the emitters disagreed. Direct analyzer+emitter probe at `origin/main`:

**CLJS — markup silently discarded** (no `__html`, empty children array):

```clojure
(re-frame.ui.runtime/jsx-spread2
 "div"
 (re-frame.ui.runtime/spread->props "div" nil base ovr …)
 (cljs.core/array))          ; <- empty; the trusted markup is GONE
```

**JVM — markup preserved:**

```clojure
(re-frame.ui.tree/element :div
 {:dyn (clojure.core/merge base ovr)
  :children (clojure.core/fn [] (re-frame.ui.tree/children (re-frame.ui.tree/html s)))})
```

Same source: markup on the JVM, nothing in the browser. Fail-safe security-wise (dropping cannot inject) but silent data loss, and it falsified Spec 004 §Interop / `spec/API.md`'s "both emitters treat it identically".

## Root cause and the fix

`emit-element`'s `:spread` branch builds its props object at runtime through `spread->props` and **never calls `element-prop-pairs`** — the only place an `:html` node becomes `dangerouslySetInnerHTML`. The `:safe-spread` sibling *does* call it, which is exactly why that form already composed correctly.

The fix attaches the compiler-owned `dangerouslySetInnerHTML` at that existing seam, **after** `spread->props` returns, so the visible `(ui/html …)` site — the trust assertion — wins any same-key value smuggled through the runtime prop map (rf2-5pr75). One `let` temporary, mirroring the adjacent `:safe-spread` branch; it folds away under `:advanced`.

Pinned semantics:
- `base`/`overrides` are `spread->props` arguments, so they evaluate **once each in authored order, before** the markup expression — matching source order and the JVM path (whose `:children` thunk runs after the opts map's `:dyn (merge base overrides)`).
- The analyzer already sets `:children []` on an html-kid element, so the markup takes **no positional child slot** — React's children-vs-innerHTML conflict cannot arise.
- `ui/html` shape and trust semantics unchanged.

Because the html attach lands on the shared `props-form` binding computed before the key branch, **both** the `jsx-spread2` and `jsx-spread3` arms carry it. (Note: a *keyed* general-spread element is structurally unreachable today — the analyzer hardcodes `:key {:present? false}` for the spread branch — so the keyed shape is pinned through the `spread-safe` sibling, where it is reachable.)

**No change was required in `emit_jvm.cljc`** (its `child-forms` is computed before branch dispatch, so its `:spread` branch already carried the `tree/html` leaf) and **none in `analyze.cljc`** (composition is already the accepted grammar). Three files touched, all in `implementation/ui`.

## Explicitly NOT done (per the ruling)

Option (b) was rejected by the operator, so this PR adds **no** rejection rule, **no** `:rf.ui.compile/*` roster id, and **no** `error_roster_cljs_test` row. Verified: `git diff` introduces no `fail!` call and no new roster id.

## Normative spec

**No amendment required** — the fix makes Spec 004 §Interop line 664 and `spec/API.md` line 246 ("both emitters treat it identically") true again. No hot-zone file touched.

## Tests

- **Parity corpus** (`parity_fixtures.cljc`, the compiler-owned cross-emitter gate): `:spread-trusted` pairs a *colliding* override (`:title` overridden) plus a sugar-class merge with raw markup; `:safe-spread-trusted` pins the already-working `spread-safe` sibling.
- **Focused CLJS lowering** (`emit_cljs_lowering_cljs_test.cljc`), 5 deftests: exactly one `__html` carrier, empty children array, once-each evaluation in source order, attach-after-conversion ordering, the unchanged no-markup spread path, and both jsx-spread2/jsx-spread3 shapes.

### Adjacency
`parity_fixtures.cljc` is also modified by open PR #6320 (rf2-yho9j, S4-E). My addition is deliberately minimal and anchored next to the existing `trusted`/`spread-view` entries, away from #6320's hunks (ns docstring, custom-element decl, and a new trailing S4 section).

## Quality gates

Run **to completion, foreground**:

| Gate | Result |
|---|---|
| `cd implementation/ui && clojure -M:test` | **859 tests / 15175 assertions, 0 failures, 0 errors** (baseline on the unmodified tree: 854 / 15088 — so +5 tests, +87 assertions) |
| `npm run test:cljs` (full, post-fix) | **10028 tests / 49429 assertions, 1 failure** — that single failure was my own over-specific test assertion (`clojure.core/let` vs `cljs.core/let`; the emitter's syntax-quoted `let` resolves against the host reading the `.cljc`). **The parity corpus was GREEN in this run** — `:spread-trusted` / `:safe-spread-trusted` passed. Assertion fixed in the commit. |
| `npm run test:ui` (focused ui CLJS build) | used for the red-before capture — see below |

**Red-before / green-after (cross-host):** with the emitter reverted and the new tests in place, the live cross-emitter parity gate went RED exactly as predicted:

```
parity divergence in case :spread-trusted
  first divergence: {:path [0 :children],
                     :jvm [{:tag :b, :children ["bold & raw"]} {:tag :i, :children ["i"]}],
                     :react nil}
  react html: <div title="override &amp; &lt;wins&gt;" data-a="b" class="raw x" tabindex="9"></div>
```

JVM carries the markup; React renders an empty div. `:safe-spread-trusted` passed even pre-fix, confirming the sibling branch already composed. The focused lowering ns was 17 tests / 86 assertions with 9 failures + 1 error pre-fix (all in the new deftests; pre-existing ones passed). After the fix both go green, as recorded above.

**Incomplete at hand-off — CI is authoritative:**
- The confirmatory `npm run test:cljs` **re-run** (after the one-line test-assertion fix) was backgrounded by the harness at its 600s cap and had **not finished** when I handed off. Its only observed failure so far is `day8/re_frame2_xray/panels/resources_cljs_test` (`route-graph-shows-live-active-route`) — a `tools/xray` panel test outside my surface that **passed in the earlier full run**, so it reads as flaky under load rather than a regression.
- `npm run test:adapter-smokes` was **not run**.

Local-green is not CI-green regardless; please treat the CI matrix on this PR as authoritative.

Do not merge without CI.
