### PR TITLE
fix(ci): bind the G-13 UI dependency control to the resolved coordinate (rf2-han0r)

### DIFF
--- a/implementation/scripts/_ui-deps-edn-boundary.test.cjs
+++ b/implementation/scripts/_ui-deps-edn-boundary.test.cjs
@@ -18,6 +18,19 @@
  * and that the real ui/deps.edn stays green with its :test-only extra-deps
  * (which legitimately include day8/re-frame2-resources) permitted.
  *
+ * rf2-han0r extends it to the gate's POSITIVE control, which had the mirror-image
+ * weakness one level up. The structural EDN parse above is genuine, so the
+ * boundary's FORBIDDEN half reads real map keys — but the positive half asked
+ * only `mapHasSymbolKey(deps, 'day8/re-frame2')`. Key presence: the coordinate
+ * the key names was never inspected, so `{:local/root "../nowhere"}`,
+ * `{:mvn/version "0.0.0-BOGUS"}` and a `:git/url` all satisfied it, and this
+ * suite pinned that same weak assertion. A positive control that passes whatever
+ * the coordinate says cannot fail. It is now bound to the local root ui/deps.edn
+ * configures — the same binding G-12's Arm 2 uses (rf2-5e3ic), sharing that
+ * gate's expected root and path comparator rather than answering the same
+ * question a second way — and the teeth below drive every rejected shape on both
+ * the Windows and POSIX path shapes the gate runs on.
+ *
  * Standalone node-runnable suite (no external framework), matching the sibling
  * _*.test.cjs convention.
  */
@@ -31,6 +44,18 @@ const {
   productionDepsMap,
   mapHasSymbolKey,
 } = require('./lib/edn.cjs');
+// The REAL gate rule, imported from the runner rather than restated here
+// (rf2-han0r). `run-ui-g13.cjs` requires Playwright lazily, inside `main()`,
+// precisely so this node-only suite can pin the shipped predicate: a hand-copied
+// restatement can drift from the gate silently, which is the whole failure class
+// this file exists to catch.
+const {
+  coreCoordinateResolvesTo,
+  declaredCoreLocalRoot,
+  CORE_COORDINATE,
+  CORE_LOCAL_ROOT,
+  UI_DIR,
+} = require('./run-ui-g13.cjs');
 
 // A faithful copy of the retired brace-counting extractor + its two regexes,
 // kept ONLY here to demonstrate, per shape, exactly what the old proof did.
@@ -61,11 +86,18 @@ function fail(message) {
 // The EDN-aware boundary, exactly as run-ui-g13.cjs now applies it: parse the
 // real top-level :deps map, require the positive control, report the forbidden
 // dependency's presence as a real map-key membership.
+//
+// The positive control is the runner's own BOUND predicate (rf2-han0r). It used
+// to be `mapHasSymbolKey(deps, 'day8/re-frame2')` — KEY PRESENCE, pinned here at
+// the same weakness as the gate: the coordinate the key names was never read, so
+// `{:local/root "../nowhere"}`, `{:mvn/version "0.0.0-BOGUS"}` and a `:git/url`
+// all satisfied it. The structural EDN parse was never the problem; the gap sat
+// one level up, at the VALUE.
 function ednForbiddenPresent(depsEdn) {
   const deps = productionDepsMap(depsEdn, fail);
   assert.ok(
-    mapHasSymbolKey(deps, 'day8/re-frame2'),
-    'positive control day8/re-frame2 must be present',
+    coreCoordinateResolvesTo(deps),
+    `positive control ${CORE_COORDINATE} must resolve to ${CORE_LOCAL_ROOT}`,
   );
   return mapHasSymbolKey(deps, 'day8/re-frame2-resources');
 }
@@ -186,6 +218,119 @@ test('gate mutation tooth — injected production dependency leak stays red', ()
     true,
     'EDN-aware check must catch the injected production dependency leak',
   );
+});
+
+// --- rf2-han0r: the positive control bound to the configured local root ------
+//
+// The gate runs on Windows locally and POSIX in CI, so every case is driven on
+// BOTH path shapes on whichever host is executing. `run-ui-g13.cjs` selects its
+// path resolver from the SHAPE of the artefact dir (not `process.platform`), and
+// the comparator it borrows from G-12 realpath-resolves both sides where they
+// exist, unifies separators, and folds case for drive-lettered paths only — so
+// these fixtures mean the same thing on either runner.
+const HOSTS = {
+  POSIX: { uiDir: '/repo/implementation/ui', coreRoot: '/repo/implementation/core' },
+  Windows: {
+    uiDir: 'C:\\proj\\re-frame2\\implementation\\ui',
+    coreRoot: 'C:\\proj\\re-frame2\\implementation\\core',
+  },
+};
+
+const depsEdnDeclaring = (coordinate) => `{:paths ["src"] :deps {${coordinate}}}`;
+
+// [label, coordinate, expected]. `null` shape = run on BOTH hosts.
+const BOUND_CONTROL_CASES = [
+  // The legitimate configuration — must stay green on both hosts.
+  ['genuinely-resolved local root', 'day8/re-frame2 {:local/root "../core"}', true, null],
+  // The four shapes the bead names. Every one of these was accepted by the
+  // presence-only control (the mutation control below proves it).
+  ['bogus :local/root', 'day8/re-frame2 {:local/root "../nowhere"}', false, null],
+  ['bogus :mvn/version', 'day8/re-frame2 {:mvn/version "0.0.0-BOGUS"}', false, null],
+  [
+    'a :git/url coordinate',
+    'day8/re-frame2 {:git/url "https://example.invalid/x.git" :git/sha "abc1234"}',
+    false,
+    null,
+  ],
+  ['coordinate absent', 'day8/re-frame2-other {:local/root "../core"}', false, null],
+  // Wrong-directory roots of every shape: a real sibling artefact, the parent,
+  // and an absolute root pointing elsewhere.
+  ['sibling artefact root', 'day8/re-frame2 {:local/root "../resources"}', false, null],
+  ['parent of the configured root', 'day8/re-frame2 {:local/root ".."}', false, null],
+  ['absolute root, wrong directory', 'day8/re-frame2 {:local/root "/not/the/repo"}', false, 'POSIX'],
+  ['absolute root, wrong drive path', 'day8/re-frame2 {:local/root "C:\\\\not\\\\the\\\\repo"}', false, 'Windows'],
+  // Benign variations a legitimate root may arrive in — an over-tightened
+  // predicate that reds these breaks G-13 against correct configurations, which
+  // is worse than the false-green it replaced.
+  ['absolute root, correct directory', 'day8/re-frame2 {:local/root "/repo/implementation/core"}', true, 'POSIX'],
+  ['trailing separator', 'day8/re-frame2 {:local/root "../core/"}', true, null],
+  ['redundant same-dir segment', 'day8/re-frame2 {:local/root "./../core"}', true, null],
+  // Windows paths are case-insensitive and take either separator; POSIX is
+  // case-SENSITIVE, so the same fold must NOT be granted there.
+  ['drive root, forward separators', 'day8/re-frame2 {:local/root "C:/proj/re-frame2/implementation/core"}', true, 'Windows'],
+  ['drive root, folded case', 'day8/re-frame2 {:local/root "c:\\\\PROJ\\\\re-frame2\\\\implementation\\\\CORE"}', true, 'Windows'],
+  ['POSIX case mismatch stays rejected', 'day8/re-frame2 {:local/root "../CORE"}', false, 'POSIX'],
+  // Degenerate values: nothing here names a directory.
+  ['empty :local/root', 'day8/re-frame2 {:local/root ""}', false, null],
+  ['whitespace-only :local/root', 'day8/re-frame2 {:local/root "   "}', false, null],
+  ['non-string :local/root', 'day8/re-frame2 {:local/root ../core}', false, null],
+  ['nil :local/root', 'day8/re-frame2 {:local/root nil}', false, null],
+  ['coordinate value is not a map', 'day8/re-frame2 "1.2.3"', false, null],
+];
+
+for (const [label, coordinate, expected, onlyShape] of BOUND_CONTROL_CASES) {
+  for (const [shape, host] of Object.entries(HOSTS)) {
+    if (onlyShape && onlyShape !== shape) continue;
+    test(`bound positive control (${shape}) — ${label} -> ${expected}`, () => {
+      const deps = productionDepsMap(depsEdnDeclaring(coordinate), fail);
+      assert.equal(
+        coreCoordinateResolvesTo(deps, host.coreRoot, host.uiDir),
+        expected,
+        `${label} must ${expected ? 'satisfy' : 'fail'} the bound positive control on ${shape}`,
+      );
+    });
+  }
+}
+
+// MUTATION CONTROL (mirrors rf2-5e3ic). Prove the teeth are REAL by showing the
+// retired predicate — `mapHasSymbolKey`, still live for the forbidden check —
+// ACCEPTS every rejection case above. If a future edit makes these pass under
+// presence-only too, the fixtures have stopped discriminating and the control is
+// no longer mutation-proof.
+test('mutation control — the retired presence-only check accepted every rejected coordinate', () => {
+  const rejected = BOUND_CONTROL_CASES.filter(
+    // `coordinate absent` is the ONE shape presence-only did catch; it is pinned
+    // above so binding the value did not cost the original tooth.
+    ([label, , expected]) => expected === false && label !== 'coordinate absent',
+  );
+  assert.ok(rejected.length >= 10, 'the mutation control must cover a real spread of spoofs');
+  for (const [label, coordinate] of rejected) {
+    const deps = productionDepsMap(depsEdnDeclaring(coordinate), fail);
+    assert.equal(
+      mapHasSymbolKey(deps, CORE_COORDINATE),
+      true,
+      `presence-only should accept "${label}" — it was the false-green this bead closes`,
+    );
+  }
+});
+
+// The real, shipped ui/deps.edn must satisfy the bound control on THIS host,
+// resolving through whatever junctions/symlinks the checkout actually uses.
+test('real ui/deps.edn — core coordinate resolves to the configured local root on this host', () => {
+  const realEdn = fs.readFileSync(path.join(__dirname, '..', 'ui', 'deps.edn'), 'utf8');
+  const deps = productionDepsMap(realEdn, fail);
+  assert.equal(
+    declaredCoreLocalRoot(deps),
+    '../core',
+    'ui/deps.edn must declare the core coordinate as {:local/root "../core"}',
+  );
+  assert.ok(
+    coreCoordinateResolvesTo(deps),
+    `real ui/deps.edn must resolve ${CORE_COORDINATE} to ${CORE_LOCAL_ROOT}`,
+  );
+  // Non-vacuity: the expected root is the real core artefact next to ui/.
+  assert.equal(CORE_LOCAL_ROOT, path.resolve(UI_DIR, '..', 'core'));
+  assert.ok(fs.existsSync(path.join(CORE_LOCAL_ROOT, 'deps.edn')), 'core artefact exists');
 });
 
 let failed = 0;

--- a/implementation/scripts/run-ui-g13.cjs
+++ b/implementation/scripts/run-ui-g13.cjs
@@ -10,14 +10,30 @@ const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const { isDeepStrictEqual } = require('util');
-const { chromium } = require('playwright');
 const {
   createHarnessCleanup,
   resolveServePort,
   startLocalHttpServer,
 } = require('./lib/local-browser-harness.cjs');
 const { classifyReleaseBundle } = require('./lib/read-release-bundle.cjs');
-const { productionDepsMap, mapHasSymbolKey } = require('./lib/edn.cjs');
+const {
+  productionDepsMap,
+  mapHasSymbolKey,
+  mapGetKeyword,
+  isMap,
+  isSymbol,
+} = require('./lib/edn.cjs');
+// The SAME binding G-12 Arm 2 uses (rf2-5e3ic, PR #6332). Both gates read the
+// same `implementation/ui/deps.edn` and ask the same question — "did the core
+// coordinate resolve to the root this artefact configures?" — so they share one
+// expected root and one path comparator rather than answering it twice. That
+// module is require-cheap (fs/path/child_process only; `main` runs solely under
+// `require.main === module`).
+const {
+  isConfiguredLocalRoot,
+  requiredCoordinate: CORE_COORDINATE,
+  requiredCoordinateLocalRoot: CORE_LOCAL_ROOT,
+} = require('./check-ui-adapter-isolation.cjs');
 const {
   validateWarmSamples,
   summarizeWarm,
@@ -27,6 +43,7 @@ const {
 } = require('./lib/g13-timing-evidence.cjs');
 
 const IMPL = path.resolve(__dirname, '..');
+const UI_DIR = path.join(IMPL, 'ui');
 const OUT = path.join(IMPL, 'out');
 const DEV = path.join(OUT, 'ui-g13');
 const PROD = path.join(OUT, 'ui-g13-prod');
@@ -141,7 +158,8 @@ function assertBundleElision() {
     optionalResourcesSentinelAbsent: OPTIONAL_RESOURCES_SENTINEL,
     optionalResourcesManifestAbsent: 're_frame/resources.cljc and re_frame/resources/**',
     uiDependencyBoundary:
-      'production :deps: day8/re-frame2 present; day8/re-frame2-resources absent',
+      `production :deps: ${CORE_COORDINATE} resolved to its configured local root ` +
+      `${CORE_LOCAL_ROOT}; day8/re-frame2-resources absent`,
   };
 }
 
@@ -222,12 +240,89 @@ function assertLeaseFreeAdvanced(blob, uiDepsOverride = null, mintControlBlob = 
   // reader-discarded form; the parser sees EDN structure, so those variants
   // cannot slip a forbidden dependency past the boundary.
   const uiProdDeps = productionDepsMap(uiDeps, fail);
-  if (!mapHasSymbolKey(uiProdDeps, 'day8/re-frame2')) {
-    fail('UI dependency positive control omitted day8/re-frame2');
-  }
+  assertCoreCoordinateBound(uiProdDeps);
   if (mapHasSymbolKey(uiProdDeps, 'day8/re-frame2-resources')) {
     fail('UI artefact dependency boundary retained day8/re-frame2-resources');
   }
+}
+
+// POSITIVE CONTROL, BOUND TO THE CONFIGURED ROOT (rf2-han0r) — the G-13 twin of
+// the G-12 Arm-2 binding shipped in rf2-5e3ic. Both gates read this same
+// `ui/deps.edn` asking the same question, so they are bound the same way.
+//
+// The structural EDN parse above is genuine — the reader sees real map
+// structure, never a byte slice — and that is exactly what made this gap easy
+// to miss, because the weakness sat one level UP, at the VALUE. The control
+// asked only `mapHasSymbolKey(deps, 'day8/re-frame2')`: KEY PRESENCE. The
+// coordinate it names was never inspected, so `{:local/root "../nowhere"}`,
+// `{:mvn/version "0.0.0-BOGUS"}` and a `{:git/url ...}` coordinate all satisfied
+// it. A control that passes whatever the coordinate says cannot fail, and a
+// positive control that cannot fail is not evidence that the artefact under
+// measurement is the one wired into the graph.
+//
+// Bind it to the root `ui/deps.edn` configures: `day8/re-frame2` must be a
+// `{:local/root ...}` coordinate whose root, resolved relative to the artefact
+// dir, IS `implementation/core`. Rejecting the Maven and git forms is
+// deliberate, matching rf2-5e3ic: re-declaring core as either is a change of
+// coordinate KIND, and must be made intentionally here rather than absorbed by
+// a permissive check.
+//
+// `CORE_LOCAL_ROOT` and `isConfiguredLocalRoot` are G-12's, imported above. That
+// comparator carries the hard-won cross-platform detail — the gate runs on
+// Windows locally and POSIX in CI, so both sides are realpath-resolved where
+// they exist (junctions/symlinks), separators unified, and drive-lettered paths
+// case-folded while POSIX stays case-SENSITIVE.
+function declaredCoreLocalRoot(depsMap) {
+  const entry = depsMap.entries.find(([k]) => isSymbol(k, CORE_COORDINATE));
+  if (!entry) return null; // coordinate absent entirely
+  const coordinate = entry[1];
+  if (!isMap(coordinate)) return null; // not a coordinate map at all
+  const localRoot = mapGetKeyword(coordinate, 'local/root');
+  // Absent for `:mvn/version` / `:git/url` coordinates; non-string values
+  // (a symbol, a vector, nil) are not a root either.
+  if (localRoot === null || typeof localRoot !== 'object') return null;
+  if (localRoot.edn !== 'string') return null;
+  return localRoot.value;
+}
+
+// Join a declared `:local/root` onto the artefact dir. The ONE place this gate
+// diverges from rf2-5e3ic, and only because the two gates read different data:
+// G-12 receives an already-canonicalized ABSOLUTE root from tools.deps, whereas
+// `ui/deps.edn` declares a RELATIVE one (`"../core"`), so G-13 must perform the
+// join itself. `path.resolve` is bound to the HOST — on Windows it would rewrite
+// a POSIX `/repo/...` root to `C:\repo\...` — so pick the resolver from the
+// SHAPE of the path rather than from `process.platform`. On the two hosts the
+// gate actually runs on this is identical to native `path.resolve` (Windows dir
+// -> win32, POSIX dir -> posix); it additionally lets the self-test drive both
+// path shapes on either host, which is what makes the cross-platform teeth real
+// rather than a re-run of whichever host happens to be executing.
+function resolveDeclaredRoot(uiDir, declared) {
+  const impl = /^[A-Za-z]:[\\/]|^\\\\/.test(uiDir) ? path.win32 : path.posix;
+  return impl.resolve(uiDir, declared);
+}
+
+// Does production `:deps` resolve the core coordinate to `expectedRoot`?
+// `expectedRoot`/`uiDir` are injectable so the self-test can drive Windows- and
+// POSIX-shaped fixtures on either host.
+function coreCoordinateResolvesTo(depsMap, expectedRoot = CORE_LOCAL_ROOT, uiDir = UI_DIR) {
+  const declared = declaredCoreLocalRoot(depsMap);
+  if (declared === null || declared.trim() === '') return false;
+  // `:local/root` is relative to the artefact dir (an absolute root resolves to
+  // itself, and still has to name the configured directory to pass).
+  return isConfiguredLocalRoot(resolveDeclaredRoot(uiDir, declared), expectedRoot);
+}
+
+function assertCoreCoordinateBound(depsMap, expectedRoot = CORE_LOCAL_ROOT, uiDir = UI_DIR) {
+  if (coreCoordinateResolvesTo(depsMap, expectedRoot, uiDir)) return;
+  const declared = declaredCoreLocalRoot(depsMap);
+  fail(
+    `UI dependency positive control: production :deps does not resolve ${CORE_COORDINATE} to its ` +
+      `configured local root ${expectedRoot} (declared :local/root ` +
+      `${declared === null ? '<absent — not a {:local/root ...} coordinate>' : JSON.stringify(declared)}` +
+      `, resolved against ${uiDir}). The coordinate must be present AND point at the core artefact ` +
+      'this gate measures — a key-presence check accepted a bogus root, an :mvn/version, or a ' +
+      ':git/url, none of which describe the graph the measured builds compile.',
+  );
 }
 
 function expectedProjection() {
@@ -456,6 +551,34 @@ function assertMutationTeeth(result) {
       mintControl.blob,
     );
   }));
+  // rf2-han0r TEETH — the positive control must be able to FAIL. Each of these
+  // rewrites the core coordinate's VALUE while leaving the `day8/re-frame2` KEY
+  // exactly where it is, so every one of them was green under the presence-only
+  // check: the gate confirmed the coordinate was mentioned, never that it named
+  // the artefact being measured.
+  for (const [label, coordinate] of [
+    ['core coordinate re-pointed at a non-existent root', '{:local/root "../nowhere"}'],
+    ['core coordinate re-pointed at a sibling artefact', '{:local/root "../resources"}'],
+    ['core coordinate downgraded to a maven version', '{:mvn/version "0.0.0-BOGUS"}'],
+    ['core coordinate swapped to a git url', '{:git/url "https://example.invalid/x.git" :git/sha "abc1234"}'],
+  ]) {
+    red.push(expectMutationFailure(label, () => {
+      assertLeaseFreeAdvanced(
+        release.blob,
+        uiDeps.replace('day8/re-frame2 {:local/root "../core"}', `day8/re-frame2 ${coordinate}`),
+        mintControl.blob,
+      );
+    }));
+  }
+  // The coordinate absent altogether — the shape the presence check DID catch,
+  // pinned here so binding the value did not cost the original tooth.
+  red.push(expectMutationFailure('core coordinate absent from production :deps', () => {
+    assertLeaseFreeAdvanced(
+      release.blob,
+      uiDeps.replace('day8/re-frame2 {:local/root "../core"}', ''),
+      mintControl.blob,
+    );
+  }));
   red.push(expectMutationFailure('optional Resources source-graph leak', () => {
     assertOptionalResourcesManifest(
       `${prodManifest}\n"re_frame/resources/internal/runtime.cljs"`,
@@ -486,6 +609,11 @@ function appendSummary(report) {
 }
 
 async function main() {
+  // Required here, not at module load, so the boundary predicate above can be
+  // require()'d by `_ui-deps-edn-boundary.test.cjs` — a node-only suite that
+  // must pin the REAL gate rule rather than a hand-copied restatement of it —
+  // without dragging Playwright into that suite. `chromium` is used only below.
+  const { chromium } = require('playwright');
   const cleanup = createHarnessCleanup();
   cleanup.installSignalHandlers();
   let browser;
@@ -581,6 +709,14 @@ module.exports = {
   attachWarmSummary,
   appendSummary,
   expectedProjection,
+  // The bound dependency-boundary rule, exported so `_ui-deps-edn-boundary.test.cjs`
+  // pins THIS predicate rather than a hand-copied restatement that can drift.
+  declaredCoreLocalRoot,
+  coreCoordinateResolvesTo,
+  assertCoreCoordinateBound,
+  CORE_COORDINATE,
+  CORE_LOCAL_ROOT,
+  UI_DIR,
 };
 
 // CLI entry-point (skipped when require()'d by the test suite).


### PR DESCRIPTION
Closes rf2-han0r.

## The defect

`implementation/scripts/run-ui-g13.cjs` proved its UI dependency **positive** control with key presence:

```js
const uiProdDeps = productionDepsMap(uiDeps, fail);
if (!mapHasSymbolKey(uiProdDeps, 'day8/re-frame2')) {
  fail('UI dependency positive control omitted day8/re-frame2');
}
```

The coordinate that key names was never inspected. `{:local/root "../nowhere"}`, `{:mvn/version "0.0.0-BOGUS"}` and a `{:git/url ...}` coordinate all satisfied it. A positive control that passes whatever the coordinate says cannot fail, so it was never evidence that the artefact under measurement is the one wired into the graph. `_ui-deps-edn-boundary.test.cjs` pinned the same weak assertion.

The header comment above the site stresses that the parse is structural — a real EDN reader, not a byte scan. That is true, and is exactly what made this easy to miss: the weakness sat one level **up**, at the value.

## The fix — mirrored from #6332, not reinvented

`rf2-5e3ic` (#6332) fixed precisely this defect for G-12's Arm 2, reading the same `implementation/ui/deps.edn` and asking the same question. This binds G-13 the same way: `day8/re-frame2` must be a `{:local/root ...}` coordinate resolving to `implementation/core`.

G-12's `requiredCoordinateLocalRoot` and `isConfiguredLocalRoot` are **imported directly**, so the two gates share one expected root and one path comparator rather than answering the same question twice — including that comparator's hard-won cross-platform handling (realpath-resolved where the directory exists, separators unified, drive-lettered paths case-folded, POSIX case-**sensitive**). Rejecting the Maven and git forms is deliberate and matches #6332: re-declaring core as either is a change of coordinate *kind*, to be made intentionally in the predicate.

**One deliberate divergence.** `ui/deps.edn` declares a *relative* root (`"../core"`), where tools.deps hands G-12 an already-canonicalized absolute one — so G-13 must perform the join itself. `path.resolve` is bound to the host (on Windows it rewrites a POSIX `/repo/...` root to `C:\repo\...`), so the resolver is chosen from the **shape** of the artefact dir rather than `process.platform`. On the two hosts the gate runs on this is identical to native `path.resolve`; it additionally lets the teeth drive both path shapes on either runner instead of re-testing whichever host is executing.

## Teeth — input → result

Every rejection flips `true` → `false`; every legitimate case stays `true`. Driven on both path shapes (`before` = the retired presence-only check, still live in the suite as a mutation control).

| input | shape | before | after |
|---|---|---|---|
| genuinely-resolved local root | POSIX | true | **true** |
| genuinely-resolved local root | Windows | true | **true** |
| bogus `:local/root` (`../nowhere`) | POSIX | true | **false** |
| bogus `:local/root` (`../nowhere`) | Windows | true | **false** |
| bogus `:mvn/version` | POSIX | true | **false** |
| bogus `:mvn/version` | Windows | true | **false** |
| a `:git/url` coordinate | POSIX | true | **false** |
| a `:git/url` coordinate | Windows | true | **false** |
| coordinate absent | both | false | **false** |
| sibling artefact root (`../resources`) | both | true | **false** |
| parent of the configured root | both | true | **false** |
| absolute root, wrong directory | POSIX | true | **false** |
| absolute root, wrong drive path | Windows | true | **false** |
| absolute root, correct directory | POSIX | true | **true** |
| trailing separator | both | true | **true** |
| redundant same-dir segment | both | true | **true** |
| drive root, forward separators | Windows | true | **true** |
| drive root, folded case | Windows | true | **true** |
| POSIX case mismatch stays rejected | POSIX | true | **false** |
| empty / whitespace-only `:local/root` | both | true | **false** |
| non-string / nil `:local/root` | both | true | **false** |
| coordinate value is not a map | both | true | **false** |

Five gate-level mutation teeth were added to `assertMutationTeeth` (bogus root, sibling artefact, maven version, git url, plus *coordinate absent* — the one shape the old check did catch, pinned so binding the value did not cost the original tooth). Each was verified to bite against the real `ui/deps.edn`, with no vacuous no-op replacements.

The unit suite now imports the runner's **real** predicate instead of restating it — a hand-copied restatement can drift from the gate silently, which is the failure class that file exists to catch. To allow that, `run-ui-g13.cjs` requires Playwright lazily inside `main()` (`chromium` is referenced only there), so the node-only suite pins the shipped rule without pulling a browser dependency into it.

## Quality gates

Run in the worktree, foreground, to completion:

- `node scripts/_ui-deps-edn-boundary.test.cjs` — **49 passed** (13 before; +36 bound-control teeth). Green.
- `node scripts/_changed-surfaces.test.cjs` — **168 passed**, exactly the stated baseline. Green.
- `node scripts/check-ui-adapter-isolation.cjs --self-test` — **PASS**. Run because this PR imports G-12's binding; confirms the shared comparator and expected root are undisturbed.
- Runner mutation teeth verified directly against the real `ui/deps.edn`: all five red, no no-op replaces, unmutated deps.edn stays green.
- `node --check` on both changed files.

Not run locally: the full `npm run test:ui-g13` browser gate (two shadow-cljs release builds + Chromium; the worktree has no `node_modules`, and no junction was created). CI owns it — the diff is confined to a pure predicate plus teeth, and every changed code path was exercised above. If CI reds, it will be fixed on-branch.
