### PR TITLE
fix(xray): settle the route-graph liveness read deterministically (rf2-ybqse)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
@@ -87,7 +87,26 @@
                   :stale-after-ms 60000 :gc-after-ms 300000
                   :tags (fn [_ _] #{}) :request (fn [_ _] {})}}})
 
-(def live-entries
+;; rf2-ybqse — the freshness horizon is anchored to the moment the fixture is
+;; SEEDED, which is why this is a fn and not a `def`.
+;;
+;; `derive-stale?` is a comparison against the wall clock: an entry is stale
+;; once `(.now js/Date)` AT RENDER TIME has passed its `:stale-at`. A horizon
+;; frozen at namespace-LOAD time therefore decays over the life of the run.
+;; `npm run test:cljs` loads every `*_cljs_test` namespace into one
+;; consolidated bundle up front and only then starts executing, so this
+;; namespace's tests ran ~30s after its own `def`s were evaluated on an idle
+;; box — leaving only ~30s of a 60s horizon. On a loaded machine that gap
+;; exceeded 60s, the entry was *legitimately* past its `:stale-at`, and
+;; `route-graph-shows-live-active-route` read `stale (1 work)` where it
+;; expected `fresh`. The panel was right; the fixture had rotted in place.
+;;
+;; Evaluating per-seed collapses the seed→render gap from "however long the
+;; suite takes to get here" to the microseconds inside one test body, which
+;; removes the coupling between this fixture's freshness and the suite's
+;; wall-clock duration. `stale-live-entries` pins the other side of the same
+;; comparison so the `fresh` assertions cannot pass vacuously.
+(defn- live-entries []
   {[session-scope :article/by-slug {:slug "welcome"}]
    {:resource/id :article/by-slug :status :loaded
     :data {:title "Welcome"} :generation 4
@@ -95,19 +114,26 @@
     :active-owners #{[:route :route/article "nav-1"]}
     :tags #{[:article "welcome"]} :request-id [:w 4]}})
 
+(defn- stale-live-entries []
+  (update-in (live-entries)
+             [[session-scope :article/by-slug {:slug "welcome"}] :stale-at]
+             - 120000))
+
 (def live-ledger
   {[:rf.work/resource [session-scope :article/by-slug {:slug "welcome"}] 4]
    {:work/id [:rf.work/resource [session-scope :article/by-slug {:slug "welcome"}] 4]
     :work/kind :resource :resource/key [session-scope :article/by-slug {:slug "welcome"}]
     :generation 4 :status :running :cancellable? true :deadline-at 5100}})
 
-(defn- seed-overrides! []
-  (rf/dispatch-sync [:rf.xray/set-registered-resources-override-for-test resource-regs]
-                    {:frame :rf/xray})
-  (rf/dispatch-sync [:rf.xray/set-resource-entries-override-for-test live-entries]
-                    {:frame :rf/xray})
-  (rf/dispatch-sync [:rf.xray/set-resource-work-ledger-override-for-test live-ledger]
-                    {:frame :rf/xray}))
+(defn- seed-overrides!
+  ([] (seed-overrides! (live-entries)))
+  ([entries]
+   (rf/dispatch-sync [:rf.xray/set-registered-resources-override-for-test resource-regs]
+                     {:frame :rf/xray})
+   (rf/dispatch-sync [:rf.xray/set-resource-entries-override-for-test entries]
+                     {:frame :rf/xray})
+   (rf/dispatch-sync [:rf.xray/set-resource-work-ledger-override-for-test live-ledger]
+                     {:frame :rf/xray})))
 
 ;; ---- (1) registry wiring ------------------------------------------------
 
@@ -464,6 +490,25 @@
         (is (some? status))
         (is (re-find #"loaded" (node-text status)) "status reads loaded")))))
 
+(defn- seed-live-route!
+  "Register the route declaring `:resources` so the graph has a node, and seed
+  the live routing slice with `:route/article` active under nav-1 with the
+  article scoped key still in the unsettled-blocking set.
+
+  Registration goes via the registrar directly (the routing artefact's
+  `reg-route` macro is not on the xray test classpath); the graph reads the
+  registry map decoupled via `(rf/registrations :route)`."
+  []
+  (registrar/register! :route :route/article
+                       {:path "/articles/:slug"
+                        :resources [{:resource :article/by-slug :blocking? true}]})
+  (rf/dispatch-sync
+    [:rf.xray/set-resource-routing-slice-override-for-test
+     {:current {:route-id :route/article :nav-token "nav-1"}
+      :resource-blocking
+      {"nav-1" #{[session-scope :article/by-slug {:slug "welcome"}]}}}]
+    {:frame :rf/xray}))
+
 (deftest route-graph-shows-live-active-route
   (testing "rf2-m5u3gt — with a live routing slice override, the route/resource
             graph flags the active route (● active) and surfaces the live
@@ -471,21 +516,7 @@
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-overrides!)
-      ;; Register the route declaring :resources so the graph has a node.
-      ;; Via the registrar directly (the routing artefact's reg-route macro
-      ;; is not on the xray test classpath); the graph reads the registry map
-      ;; decoupled via (rf/registrations :route).
-      (registrar/register! :route :route/article
-                           {:path "/articles/:slug"
-                            :resources [{:resource :article/by-slug :blocking? true}]})
-      ;; Seed the live routing slice: :route/article active under nav-1, with
-      ;; the article scoped key still in the unsettled-blocking set.
-      (rf/dispatch-sync
-        [:rf.xray/set-resource-routing-slice-override-for-test
-         {:current {:route-id :route/article :nav-token "nav-1"}
-          :resource-blocking
-          {"nav-1" #{[session-scope :article/by-slug {:slug "welcome"}]}}}]
-        {:frame :rf/xray})
+      (seed-live-route!)
       (let [tree (resources/Panel)
             row  (find-by-testid tree "rf-xray-resources-route-row-route/article")]
         (is (some? row) "the route row renders")
@@ -495,6 +526,28 @@
             "the live unsettled-blocking wait point surfaces")
         (is (re-find #"fresh" (node-text row))
             "the blocking :article/by-slug reads :fresh from its live cache entry")))))
+
+(deftest route-graph-freshness-chip-discriminates-stale
+  (testing "rf2-ybqse — the freshness chip is DISCRIMINATING, not decorative:
+            the SAME route graph over an entry whose `:stale-at` has already
+            passed reads `stale`, never `fresh`. This deterministically forces
+            the state that used to surface only as a flake (the sibling test's
+            load-time-anchored `:stale-at` decayed past its horizon mid-run and
+            read `stale (1 work)`), so both sides of the `derive-stale?`
+            comparison are now pinned by an assertion. Without this, a
+            regression that hard-wired the chip to `:fresh` would leave the
+            sibling green."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-overrides! (stale-live-entries))
+      (seed-live-route!)
+      (let [tree (resources/Panel)
+            row  (find-by-testid tree "rf-xray-resources-route-row-route/article")]
+        (is (some? row) "the route row renders")
+        (is (re-find #"stale" (node-text row))
+            "an entry past its :stale-at reads :stale on the route graph")
+        (is (not (re-find #"fresh" (node-text row)))
+            "and does NOT read :fresh — the two are mutually exclusive")))))
 
 ;; ---- (4) PRIVACY --------------------------------------------------------
 


### PR DESCRIPTION
Closes rf2-ybqse.

## Verdict: (a)-family — but not "samples too early". The fixture rots in place.

The test is not racing an unsettled live-work count. The panel is **correct**; the fixture was a wall-clock time-bomb.

`live-entries` was a top-level `def` whose `:stale-at` was `(+ (.now js/Date) 60000)` — frozen at **namespace load**. The panel derives staleness in the other direction (`resources.cljs:1260` → `derive-stale?`), comparing `:stale-at` against `(.now js/Date)` at **render** time. `npm run test:cljs` loads every `*_cljs_test` namespace into one consolidated bundle *before* executing any of them, so the fixture's 60s horizon decays across the whole prefix of the suite.

The `(1 work)` in the reported value is a red herring: it is the seeded `:status :running` ledger row, present in the passing render too, as `fresh (1 work)`.

### Evidence

| measurement | margin (`:stale-at` − render `now`) | result |
|---|---|---|
| pre-fix, full suite, idle box | **+30461 ms** | green, 29.5s consumed of a 60s horizon |
| horizon shrunk to 20000ms (falsification) | **−13700 ms** | **red — reproduced the reported string verbatim** |
| post-fix, full suite, same suite position | **+60000 ms** | green, horizon no longer decays |

The falsification run reproduced the bead's observed text exactly:

```
actual: (not (re-find #"fresh" ":route/article/articles/:slug● activeSSR wait point
              waiting: :article/by-slug:article/by-slug [blocking]· stale (1 work)"))
```

That is the failure condition being a pure function of `(render_time − ns_load_time)` vs the horizon — nondeterministic across identical trees exactly as the bead reported, because it is governed by machine load, not by any diff.

### The fix, at the cause

`live-entries` becomes a fn evaluated **per-seed**, anchoring the horizon to the moment the fixture is seeded rather than to namespace load. The seed→render gap collapses from "however long the suite takes to reach this namespace" to the microseconds inside one test body — the coupling to suite duration is severed, which is why the post-fix margin is the full 60000ms regardless of suite position.

### No assertion was weakened

The `fresh` assertion is **byte-identical**. Nothing was loosened, retried, widened, or slept on.

Going the other way: `route-graph-freshness-chip-discriminates-stale` is **added** to pin the other side of the same comparison. It deterministically forces the state that previously surfaced only as a flake (an entry already past its `:stale-at`) and asserts the chip reads `stale` and **not** `fresh`. Without it, a regression hard-wiring the chip to `:fresh` would leave the sibling green — so this strengthens what the pair proves rather than blinding it.

The route registration + routing-slice seeding shared by both tests moves into `seed-live-route!`.

## Quality gates

All foreground, run to completion.

| gate | result |
|---|---|
| `npm run test:cljs` (full, from `implementation/`) | **Ran 10034 tests / 49465 assertions — 0 failures, 0 errors** (+1 test, +3 assertions = the new pinning test) |
| `clojure -M:test` (from `tools/xray/`, its own dir) | **Ran 1270 tests / 5908 assertions — 0 failures, 0 errors** |

Counts are non-zero and plausible — not the `Ran 0 tests` false-green.

### Stability

- **20 / 20** consecutive focused runs green (`node out/node-test.js --test=day8.re-frame2-xray.panels.resources-cljs-test`).
- **3 / 3** full-suite runs green post-fix.
- The margin measurement above is the stronger proof: focused runs cannot exercise this flake at all (they have no load→run gap), and the post-fix margin of a constant 60000ms shows the failure condition is now *unreachable* rather than merely unobserved. It would require 60 seconds to elapse between two adjacent forms in one test body.

## Spec currency

**`tools/xray/spec/*` unchanged, because the change is test-only** — no production code, no rendering, no testid, and no sub shape is touched. `024-Resources-Panel.md` documents the `:route-graph` / freshness-rollup contract, which is unaltered; `017-Test-Coverage-Matrix.md` is browser-feature-level and does not enumerate unit tests.

## Siblings

I swept every `*_test.{clj,cljs,cljc}` under `tools/` and `implementation/` for wall-clock captured in a top-level `def`. **No sibling has this shape** — every other `(.now js/Date)` / `(System/currentTimeMillis)` hit is a deadline computed at runtime inside a `let`/`loop`, which does not decay. Nothing to file.

Unrelated observation, not touched here: `implementation/routing/test/re_frame/routing_history_cljs_test.cljs:876` emits a `:redef-in-file` warning — `first-registration-preflight-zero-residue-make-frame-cljs-rf2-ktmto9` is defined twice (859 and 876), so the earlier deftest is silently replaced and never runs.
