### PR TITLE
fix(ui-compiler): bind fragment key-presence to an actual :key (rf2-xoz1s)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -2448,7 +2448,13 @@
   (`analyze-fragment`), while `:element` (`analyze-element-props`) and
   `:view`/`:foreign` (`analyze-component-props`) carry it inside their analyzed
   props map. Reading `[:key :present?]` off an `:element` finds nil and rejects
-  every keyed literal host child (rf2-vxgfnd.96.1)."
+  every keyed literal host child (rf2-vxgfnd.96.1).
+
+  Both locations now answer the SAME question — does this node carry a `:key`?
+  A `:fragment` used to report its PROPS MAP's presence there, so `[:<> {} …]`
+  passed as keyed while offering the boundary no identity to retain; the probe
+  is truthful at its source now (rf2-xoz1s), which is why this predicate needs
+  no fragment-specific translation."
   [ast]
   (case (:op ast)
     :for true
@@ -2708,14 +2714,30 @@
                                    (str "fragments take only {:key ...}; got "
                                         (str/join ", " (map pr-str (keys extra))))
                                    {:form form}))))
-        key-form  (when has-props (get second* :key))
-        key-form* (if (and has-props (not (literal-scalar? key-form)))
+        ;; Key PRESENCE is `:key`'s own presence, never the props map's
+        ;; (rf2-xoz1s). `[:<> {} …]` carries a props map and no key; reporting
+        ;; `:present? true` for it claims an identity the fragment does not
+        ;; have, and every downstream key consumer believes the claim — the
+        ;; presence boundary admits it as keyed and then has nothing to track,
+        ;; `analyze-for` mis-reports the empty map as a CONSTANT key, and the
+        ;; JVM structural tree gains a `:key nil` entry. `contains?` is exactly
+        ;; how `:element`/`:view` probe their own props (`analyze-element-props`
+        ;; / `analyze-component-props`), so the three node kinds now answer the
+        ;; same question the same way and `presence-keyed-child?` reads a true
+        ;; `[:key :present?]` off a `:fragment` without further translation.
+        key?      (and has-props (contains? second* :key))
+        key-form  (when key? (get second* :key))
+        key-form* (if (and key? (not (literal-scalar? key-form)))
                     (walk-expr e [:fragment :key] key-form)
                     key-form)
         children  (analyze-children e (vec (if has-props (drop 2 form) (drop 1 form))))]
     {:op :fragment
-     :key {:present? has-props :expr key-form* :literal? (literal-scalar? key-form)}
+     :key {:present? key? :expr key-form* :literal? (literal-scalar? key-form)}
      :children children
+     ;; Deliberately still `has-props`, not `key?`: hoisting is a separate
+     ;; question from identity, and `[:<> {} …]` staying un-hoisted is a missed
+     ;; optimisation rather than a wrong answer. Narrowing it would change
+     ;; emitted code for a shape this bead is not about.
      :static? (and (not has-props) (every? node-static? children))
      :path (:path e)}))
 

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -133,7 +133,17 @@
 (deftest fragments-lower
   (is (= :fragment (:op (ana* [:<> [:p "a"] [:p "b"]]))))
   (is (true? (get-in (ana* [:<> {:key 'k} [:p "a"]]) [:key :present?]))
-      "fragments accept exactly {:key ...}"))
+      "fragments accept exactly {:key ...}")
+  ;; rf2-xoz1s — `:present?` is the KEY's presence, not the props map's. An
+  ;; empty props map is legal (only `:key` is admissible, and it is optional)
+  ;; and supplies no identity, so it must not report one.
+  (is (= :fragment (:op (ana* [:<> {} [:p "a"]])))
+      "an empty fragment props map is still a legal fragment")
+  (is (false? (get-in (ana* [:<> {} [:p "a"]]) [:key :present?]))
+      "[:<> {} …] has a props map and NO key — reporting a key there hands
+       every downstream consumer an identity that was never written")
+  (is (false? (get-in (ana* [:<> [:p "a"]]) [:key :present?]))
+      "and a fragment with no props map at all is likewise keyless"))
 
 ;; ---------------------------------------------------------------------------
 ;; Control forms normalize INTO the AST

--- a/implementation/ui/test/re_frame/ui/presence_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/presence_jvm_test.clj
@@ -20,6 +20,7 @@
             [re-frame.ui :as ui :refer [defview]]
             [re-frame.ui.compiler.analyze :as ana]
             [re-frame.ui.compiler.emit-cljs :as emit-cljs]
+            [re-frame.ui.compiler.emit-jvm :as emit-jvm]
             [re-frame.ui.compiler.env :as env]
             [re-frame.ui.semantic :as semantic]
             [re-frame.ui.test :as uit]))
@@ -163,6 +164,57 @@
       (is (nil? (get-in fr [:props :key :present?]))
           "a :fragment has no analyzed props map"))))
 
+;; ---------------------------------------------------------------------------
+;; Key PRESENCE means the key, not the props map (rf2-xoz1s)
+;;
+;; A fragment's props map may hold exactly one entry — `:key` — so `has a props
+;; map` reads like `has a key` right up until the map is EMPTY. `[:<> {} …]`
+;; used to report `:present? true` with `:expr nil`: a key claimed and not
+;; supplied. Every consumer believed it, and the presence boundary — whose whole
+;; job is retaining a child BY its identity — admitted a child with none.
+;; ---------------------------------------------------------------------------
+
+(deftest fragment-key-presence-tracks-the-key-not-the-props-map
+  (testing "an EMPTY props map is not a key"
+    (let [fr (ana/analyze (mk-env) '[:<> {} [:p "a"]])]
+      (is (false? (get-in fr [:key :present?]))
+          "[:<> {} …] carries a props map and no identity — saying otherwise
+           promises downstream a key that was never written")
+      (is (nil? (get-in fr [:key :expr]))
+          "and there is no key expression to promise")))
+  (testing "a supplied key is still present, and still carries its expression"
+    (let [fr (ana/analyze (mk-env) '[:<> {:key "x"} [:p "a"]])]
+      (is (true? (get-in fr [:key :present?])))
+      (is (= "x" (get-in fr [:key :expr])))))
+  (testing "an explicitly nil key IS written, so it stays present"
+    ;; `:element` answers `contains?` the same way — the two node kinds agree
+    ;; rather than the fragment inventing a nil-specific rule of its own.
+    (is (true? (get-in (ana/analyze (mk-env) '[:<> {:key nil} [:p "a"]])
+                       [:key :present?])))
+    (is (true? (get-in (ana/analyze (mk-env) '[:div {:key nil} "hi"])
+                       [:props :key :present?]))))
+  (testing "no props map at all remains keyless"
+    (is (false? (get-in (ana/analyze (mk-env) '[:<> [:p "a"]]) [:key :present?])))))
+
+(deftest fragment-key-presence-reaches-its-consumers
+  (testing "the JVM structural tree no longer gains a :key nil entry"
+    ;; emit-jvm splices `:present?` straight into `(tree/fragment key? expr …)`,
+    ;; and `tree/fragment` assocs `:key` on a truthy flag — so the old claim put
+    ;; a `:key nil` on the structural node for a fragment with no key.
+    (let [node (emit-jvm/emit-node (ana/analyze (mk-env) '[:<> {} [:p "a"]]))]
+      (is (= 'false (nth node 1)) "the fragment is emitted as UNkeyed")
+      (is (nil? (nth node 2)) "with no key expression")))
+  (testing "a for row spelling an empty props map fails as UNKEYED"
+    ;; analyze-for reads the same `:present?`. It used to pass the missing-key
+    ;; check and trip on `:literal?` instead, reporting a CONSTANT key for a row
+    ;; that had no key at all — the right rejection for the wrong reason.
+    (is (= :rf.ui.compile/unkeyed-list-item
+           (presence-error '(for [t ts] [:<> {} [:p "a"]]))))
+    (is (= :rf.ui.compile/unkeyed-list-item
+           (presence-error '(for [t ts] [:<> [:p "a"]]))))
+    (is (nil? (presence-error '(for [t ts] [:<> {:key (:id t)} [:p "a"]])))
+        "a genuinely keyed row is untouched")))
+
 (deftest keyed-literal-children-are-accepted
   (testing "a keyed literal host child"
     (let [ast (ana/analyze (mk-env) '(presence {:timeout-ms 300} [:li {:key "x"} "hi"]))]
@@ -190,6 +242,11 @@
   (testing "an unkeyed fragment child"
     (is (= :rf.ui.compile/presence-unkeyed-child
            (presence-error '(presence {:timeout-ms 300} [:<> [:li "hi"]])))))
+  (testing "a fragment whose props map holds NO key (rf2-xoz1s)"
+    ;; the wrong-answer path this bead closes: accepted as keyed, leaving the
+    ;; boundary with nothing to retain the child by.
+    (is (= :rf.ui.compile/presence-unkeyed-child
+           (presence-error '(presence {:timeout-ms 300} [:<> {} [:li "hi"]])))))
   (testing "ADVERSARIAL: one unkeyed sibling among keyed ones still fails"
     (is (= :rf.ui.compile/presence-unkeyed-child
            (presence-error '(presence {:timeout-ms 300}


### PR DESCRIPTION
Closes rf2-xoz1s. Sibling to rf2-vxgfnd.96.1 (#6331), which fixed the same class
of defect — a key-presence probe reading the wrong thing — on the `:element`
branch and deliberately left this one to its own bead.

## The defect

`analyze-fragment` wrote `:key {:present? has-props …}`: the presence of a props
map, not of a key. A fragment's props map admits exactly one entry (`:key`), so
the two read alike right up until the map is EMPTY.

Reproduced before any change:

```
[:<> {} [:p "a"]]  =>  {:key {:present? true, :expr nil, :literal? true}}
(presence {:timeout-ms 300} [:<> {} [:p "a"]])  =>  :ACCEPTED
```

A key claimed, `nil` behind the claim, and the presence boundary — whose whole
job is retaining a child BY its identity — admitting a child with none.

Direction matters: 96.1 wrongly REJECTED valid code; this wrongly ACCEPTS
invalid code.

## Consumers of fragment `:key`, and how each is affected

| Consumer | Before | After |
|---|---|---|
| `presence-keyed-child?` (`analyze.cljc`) | admits `[:<> {} …]` as keyed | rejects it — `:rf.ui.compile/presence-unkeyed-child` |
| `analyze-for` row-key check | passes the missing-key check, then trips `:literal?` → `:rf.ui.compile/constant-list-key` ("constant :key nil") | `:rf.ui.compile/unkeyed-list-item` — the honest id. Right rejection, right reason |
| `emit-jvm` `:fragment` → `(tree/fragment key? expr …)` | emits `(fragment true nil …)`; `tree/fragment` assocs `:key` on a truthy flag, so the structural tree gained a `:key nil` entry | `(fragment false nil …)` — no phantom `:key` |
| `emit-cljs` `emit-fragment` → `jsx-call` key-info | selects React's 3-argument jsx API to pass a nil key | 2-argument call; React-equivalent output (key `nil` ≡ no key) |
| `emit-cljs/replace-row-key-expr` | writes `[:key :expr]` only, for `for` bodies | unaffected — `analyze-for` guarantees `:present?` by the time it runs |
| `a11y.cljc` / `root.cljc` fragment walks | read `:children` | unaffected |

## The fix

`:present?` becomes `(contains? props :key)` — exactly how `analyze-element-props`
and `analyze-component-props` probe their own props. The three node kinds now
answer the same question the same way, which is why `presence-keyed-child?`
needs no change beyond its docstring: 96.1 established that a `:fragment` carries
its key at the node, and that path is simply truthful now.

Scope held deliberately narrow — no new namespace (the change is ~5 lines, well
short of the rf2-74vlo `a11y.cljc` precedent), no AST redesign, no new node type,
no extension to other node kinds.

`:static?` keeps `has-props` as its basis on purpose. Hoisting is a separate
question from identity, and `[:<> {} …]` staying un-hoisted is a missed
optimisation, not a wrong answer; narrowing it would change emitted code for a
shape this bead is not about.

`[:<> {:key nil} …]` stays PRESENT — the key was written. `:element` answers
`contains?` identically, so the fragment invents no nil-specific rule of its own.

## Blast radius: empty

`git grep` over all tracked sources finds **zero** occurrences of `[:<> {}` and
**zero** of `[:<> {:key nil}`. Every fragment in the repo that carries a props
map carries a real `:key`. Nothing in testbeds, examples, guide fixtures, or
tests is newly rejected — no latent bugs surfaced, no must-accept cases found.

## Red-before / green-after

| Form | Before | After |
|---|---|---|
| `(presence {:timeout-ms 300} [:<> {} [:li "hi"]])` | ACCEPTED | `presence-unkeyed-child` |
| `(presence {:timeout-ms 300} [:<> {:key "x"} [:p "a"]])` | ACCEPTED | ACCEPTED |
| `(presence {:timeout-ms 300} [:li {:key "x"} "hi"])` (96.1 control) | ACCEPTED | ACCEPTED |
| `(for [t ts] [:<> {:key (:id t)} …])` | ACCEPTED | ACCEPTED |

## Quality gates

All foreground, run to completion. Green before and after.

| Gate | Result |
|---|---|
| `implementation/ui` JVM (`clojure -M:test`) | **901 tests / 15787 assertions, 0 failures** (baseline on this branch pre-change: 899 / 15772 — +2 tests, +15 assertions, all added here) |
| `npm run test:cljs` | **10042 tests / 49506 assertions, 0 failures** |
| `npm run test:browser` | **462 tests / 2589 assertions, 0 failures** |
| `npm run test:adapter-smokes` | **3 adapter-smoke specs, 0 failures** |
| S4 conformance guard (`s4-conformance-profile-jvm-test`, run by name) | **29 tests / 332 assertions, 0 failures** — `spec/conformance/**` UNMODIFIED |

`test:browser` was run because the mounted presence tests self-skip under node
(no `js/document`) — a node-only result would have been vacuous, as #6331 found.

## Tests added

- `presence_jvm_test.clj` — `fragment-key-presence-tracks-the-key-not-the-props-map`
  (empty map ≠ key; supplied key still present with its expr; explicit `nil` key
  present, cross-checked against `:element`; no props map keyless) and
  `fragment-key-presence-reaches-its-consumers` (JVM emit is UNkeyed; `for` rows
  fail as unkeyed rather than constant-keyed; keyed rows untouched). Plus the
  `[:<> {} …]` case in `unkeyed-children-remain-a-build-failure`.
- `analyze_accept_cljs_test.cljc` — `fragments-lower` gains the empty-props-map
  pins (runs on both hosts).
