### PR TITLE
fix(examples): resolve keyword view-refs in the streaming SSR example (rf2-o4rbh)

### DIFF
--- a/docs/ssr/streaming.md
+++ b/docs/ssr/streaming.md
@@ -25,12 +25,28 @@ Runnable tree:
    [:div.article-body @(rf/subscribe [:article/body])]
    [:section.article-extras
     [:rf/suspense-boundary
-     {:id :region.comments :fallback [:article/comments-skeleton]}
-     [:article/comments]]
+     {:id :region.comments :fallback [comments-skeleton]}
+     [comments]]
     [:rf/suspense-boundary
-     {:id :region.author-feed :fallback [:article/author-feed-skeleton]}
-     [:article/author-feed]]]])
+     {:id :region.author-feed :fallback [author-feed-skeleton]}
+     [author-feed]]]])
 ```
+
+Two things about the heads inside a boundary. Reference views by **Var**
+(`comments`, which `rf/reg-view` defs for you) or by `(rf/view :id)` lookup — a
+bare `[:article/comments]` head is an *HTML element*, never a view, so it paints
+`<comments>` in the browser. The JVM SSR emitter *does* resolve keyword heads
+through the view registry, which makes this a particularly quiet mistake: the
+server renders it correctly and only the client goes wrong.
+
+And `:rf/suspense-boundary` itself is **server-only** — it means something to the
+streaming shell walker and to nothing else. Your client render tree carries the
+resolved subtree directly (a view that reads its own app-db slice and falls back
+to its skeleton when that slice is absent renders correctly in both runtimes; see
+`card-slot` in
+[the worked example](../../examples/capabilities/ssr/ssr_streaming/core.cljc)).
+Left in a client render tree, the marker's name passes the DOM tag grammar and
+React paints a phantom `<suspense-boundary>` element.
 
 The streaming walker emits the shell on the first byte, with each boundary's
 `:fallback` markup carried inside an **inert** `<template data-rf2-suspense-fallback>`

--- a/examples/capabilities/ssr/ssr_streaming/README.md
+++ b/examples/capabilities/ssr/ssr_streaming/README.md
@@ -19,9 +19,19 @@ and name a `:fallback` to show in the meantime:
 
 ```clojure
 [:rf/suspense-boundary
- {:id :card.revenue :fallback [:dashboard/card-skeleton :revenue]}
- [:dashboard/card :revenue]]
+ {:id :card.revenue :fallback [card-skeleton :revenue]}
+ [card-view :revenue]]
 ```
+
+Note the children are **Var references**, not keywords. A bare
+`[:dashboard/card :revenue]` head is an HTML element, never a view — the
+runtime doesn't intercept the keyword case to dispatch through the view
+registry (see
+[Conventions §Render-tree shape vs runtime lookup](../../../../spec/Conventions.md)),
+so it would paint `<card>revenue</card>` in the browser. The JVM SSR
+emitter *does* resolve keyword heads through the registry, which is what
+makes that mistake so easy to ship: the server renders it correctly and
+only the client goes wrong.
 
 One caveat up front: this demo runs **offline**, with no Clojure server.
 Instead of fetching from three real services, `:rf/server-init` seeds all
@@ -95,6 +105,23 @@ against *each* with a `{:frame …}` override, because that's where the
 `:cards` commit actually validates on either side. The server then drops
 its per-request frame-id from the payload, so the client's explicit
 `:frame` stands rather than tripping a frame-id mismatch.
+
+The other subtlety is that `:rf/suspense-boundary` is a **server-only**
+marker. It means something to the streaming shell walker and to nothing
+else — there is no client-side rendering for it. So the browser's render
+tree carries the resolved card directly, and `card-slot` in
+[`core.cljc`](core.cljc) is the single reader-conditional where the two
+runtimes part company. Leaving the marker in a client render tree is a
+quiet failure rather than a loud one: its name passes the DOM tag grammar,
+so React paints a phantom `<suspense-boundary>` element instead of raising
+anything.
+
+Which cards the client can actually render falls out of app-db, not out of
+the boundary structure. `card-view` renders the skeleton when its card
+isn't in app-db yet — which is the true state for a chunk still in flight,
+and the permanent state for `:card.flaky`, whose boundary failed and
+therefore shipped no delta. That's why the client's render agrees with the
+DOM the stream painted without having to know which boundaries succeeded.
 
 The `.cljc` shape mirrors [`examples/capabilities/ssr/ssr/core.cljc`](../ssr/core.cljc):
 the server branch lives in `:clj`, the browser branch in `:cljs`. The

--- a/examples/capabilities/ssr/ssr_streaming/core.cljc
+++ b/examples/capabilities/ssr/ssr_streaming/core.cljc
@@ -8,9 +8,13 @@
   until the slowest one answers. This offline example preserves that wire
   shape as collected data; it does not simulate network timings.
 
-  Five ideas earn their keep here:
+  Six ideas earn their keep here:
    - `:rf/suspense-boundary` — one hiccup marker that says \"this region
      may arrive late.\" That marker IS the whole streaming API.
+   - The marker is **server-only**. It has meaning to the streaming shell
+     walker and to nothing else, so the browser's render tree carries the
+     resolved card instead — see `card-slot`, the one place this example
+     is genuinely two programs.
    - A `:fallback` to show in the meantime — here a skeleton card.
    - Failure isolation — one card throws on purpose, to prove a blown
      boundary stays on its fallback instead of taking the page down with
@@ -76,16 +80,28 @@
 (rf/reg-sub :cards/slice (fn [db _] (:cards db)))
 (rf/reg-sub :card/by-id   (fn [db [_ id]] (get-in db [:cards id])))
 
-(rf/reg-view ^{:rf/id :dashboard/card} card-view [card-id]
-  (let [card @(subscribe [:card/by-id card-id])]
-    [:div.card
-     [:h3 (:title card)]
-     [:p.value (str (:value card))]]))
-
 (rf/reg-view ^{:rf/id :dashboard/card-skeleton} card-skeleton [card-id]
   [:div.card.skeleton
    [:h3 (str "Loading " (name card-id) " …")]
    [:p.value "—"]])
+
+(rf/reg-view ^{:rf/id :dashboard/card} card-view [card-id]
+  ;; Reads its own slice of app-db and nothing else, which is what lets the
+  ;; same view render correctly in both runtimes: on the server inside a
+  ;; continuation, where `:rf/server-init` has already seeded the data, and
+  ;; in the browser against whatever the streamed delta or the final payload
+  ;; put there.
+  ;;
+  ;; The nil branch isn't defensive padding — it's the client's honest state
+  ;; for a card whose chunk hasn't landed yet, or (see `:card.flaky` below)
+  ;; never will, because a failed boundary ships no delta. Falling back to
+  ;; the skeleton is what keeps the client's render agreeing with the DOM
+  ;; the stream actually painted.
+  (if-let [card @(subscribe [:card/by-id card-id])]
+    [:div.card
+     [:h3 (:title card)]
+     [:p.value (str (:value card))]]
+    [card-skeleton card-id]))
 
 (rf/reg-view ^{:rf/id :dashboard/throwing-card} throwing-card []
   ;; The card that fails on purpose, standing in for that one flaky
@@ -99,36 +115,62 @@
   ;; [SSR guide — Streaming](../../../../docs/ssr/concepts.md#streaming-rfsuspense-boundary).
   (throw (ex-info "flaky third-party metric service" {})))
 
+(defn- card-slot
+  "One card's slot in the dashboard — and the one place this example is
+  genuinely two programs.
+
+  SERVER — a `:rf/suspense-boundary`, the whole streaming trick in one
+  marker. It wraps a region that's allowed to arrive late: the `:fallback`
+  ships inline in the shell right now, and `body` renders separately and
+  streams in as its own chunk once it resolves. The `:id` is how the client
+  pairs an arriving chunk with its placeholder — you pick it, and it has to
+  be unique.
+
+  CLIENT — just the card. `:rf/suspense-boundary` is a **server-only**
+  marker: per [Spec 011 §Streaming SSR](../../../../spec/011-SSR.md#streaming-ssr)
+  it is recognised only by the streaming shell walker, and a browser render
+  tree is not somewhere it means anything. Leave one in a client render tree
+  and its name sails straight through the DOM tag grammar — React paints a
+  phantom `<suspense-boundary>` element with `:id` and `:fallback` mangled
+  into attributes.
+
+  The same trap sits one level down, and it's the more tempting one: a bare
+  `[:dashboard/card :revenue]` head is an **HTML element**, never a view.
+  The runtime does not intercept the keyword case to dispatch through the
+  view registry (Conventions §Render-tree shape vs runtime lookup), so that
+  head paints `<card>revenue</card>` — tag from the keyword's name, argument
+  as a text node. Render trees reference views by **Var** (`card-view`, which
+  `reg-view` defs for you) or by `(rf/view :id)` lookup. The JVM SSR emitter
+  does resolve a keyword head through the registry, which is exactly why the
+  mistake survives a server-side test and only shows up in the browser.
+
+  By the time the browser renders, every boundary has already resolved — the
+  streaming runtime swapped each chunk into the DOM and merged its delta, and
+  the final payload seeded the rest — so the client renders the resolved card
+  and `hydrate-root` adopts the DOM the stream painted."
+  [boundary-id card-id body]
+  #?(:clj  [:rf/suspense-boundary
+            {:id boundary-id :fallback [card-skeleton card-id]}
+            body]
+     :cljs [card-view card-id]))
+
 (rf/reg-view ^{:rf/id :dashboard/root} root-view []
   [:main.dashboard
    [:header
     [:h1 "Dashboard"]
     [:p "Streamed SSR demo — shell renders first, cards stream in."]]
    [:section.cards
-    ;; Here's the whole trick, four times over. `:rf/suspense-boundary`
-    ;; wraps a region that's allowed to arrive late. The `:fallback` ships
-    ;; inline in the shell right now; the real child renders separately and
-    ;; streams in as its own chunk once it resolves. The `:id` is how the
-    ;; client pairs an arriving chunk with its placeholder — you pick it,
-    ;; and it has to be unique.
-    [:rf/suspense-boundary
-     {:id :card.revenue :fallback [:dashboard/card-skeleton :revenue]}
-     [:dashboard/card :revenue]]
-    [:rf/suspense-boundary
-     {:id :card.signups :fallback [:dashboard/card-skeleton :signups]}
-     [:dashboard/card :signups]]
-    [:rf/suspense-boundary
-     {:id :card.latency :fallback [:dashboard/card-skeleton :latency]}
-     [:dashboard/card :latency]]
-    ;; The failure-path card — same marker, same shape as the three above.
-    ;; The only difference shows up on the wire: its chunk carries the
-    ;; fallback HTML stamped `data-rf2-suspense-failed="1"` and no
-    ;; hydrate-delta script. A failure is just another way for a boundary to
-    ;; resolve.
-    [:rf/suspense-boundary
-     {:id :card.flaky
-      :fallback [:dashboard/card-skeleton :flaky]}
-     [:dashboard/throwing-card]]]
+    (card-slot :card.revenue :revenue [card-view :revenue])
+    (card-slot :card.signups :signups [card-view :signups])
+    (card-slot :card.latency :latency [card-view :latency])
+    ;; The failure-path card — same slot, same shape as the three above. It
+    ;; differs only in its deferred body, and only on the wire: its chunk
+    ;; carries the fallback HTML stamped `data-rf2-suspense-failed="1"` and
+    ;; no hydrate-delta script. A failure is just another way for a boundary
+    ;; to resolve. Client-side that missing delta is the whole story — no
+    ;; `:flaky` entry ever reaches app-db, so `card-view` renders its
+    ;; skeleton, matching the fallback the failed chunk left in the DOM.
+    (card-slot :card.flaky :flaky [throwing-card])]
    [:footer
     [:p "Each card above is a `:rf/suspense-boundary`."]]])
 

--- a/implementation/adapters/reagent/test/re_frame/ssr_streaming_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/ssr_streaming_example_cljs_test.cljs
@@ -1,0 +1,149 @@
+(ns re-frame.ssr-streaming-example-cljs-test
+  "Client-side render contract for the streaming SSR example
+   (`examples/capabilities/ssr/ssr_streaming/`).
+
+   Closes the isomorphism gap rf2-o4rbh found: the example's `:clj` branch
+   was covered end-to-end by `re-frame.examples-test/ssr-streaming-example-
+   runs-end-to-end` (JVM), but NOTHING exercised the `:cljs` branch's render
+   tree. The example composed its cards as keyword view-refs
+   (`[:dashboard/card :revenue]`) inside `:rf/suspense-boundary` markers —
+   both of which resolve on the JVM SSR emitter and NEITHER of which has any
+   client-side meaning:
+
+     - Per [Conventions §Render-tree shape vs runtime lookup] a bare
+       `[:keyword args]` head in a render tree is an **HTML element**; the
+       runtime does not intercept the keyword case to dispatch via the views
+       registry. Reagent's `parse-tag` runs `(name tag)`, so
+       `:dashboard/card` became the literal DOM tag `<card>`.
+     - Per [Spec 011 §Streaming SSR] `:rf/suspense-boundary` is recognised
+       ONLY by the streaming shell walker; its name passes the DOM tag
+       grammar, so on the client it became a phantom `<suspense-boundary>`
+       element with `{:id … :fallback …}` serialised as bogus attributes.
+
+   Server and client therefore disagreed STRUCTURALLY on the flagship
+   streaming example: the server streamed `<div class=\"card\">`s, the
+   browser painted `<suspense-boundary><card>…`.
+
+   The example tree itself stays test-free (rf2-8cevm), so this substrate-
+   side suite carries the cover — the same split as the JVM half, which lives
+   in `re-frame.examples-test`. Sibling shape:
+   `re-frame.infinite-feed-example-cljs-test`.
+
+   `render-to-static-markup` is stock Reagent's react-dom/server serializer —
+   the same hiccup→React-element mapping the browser's `hydrate-root` runs,
+   so the markup below is what the client actually paints.
+
+   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
+            [clojure.string :as str]
+            [reagent.dom.server :as rds]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            ;; the example's production source — registers :dashboard/root,
+            ;; :dashboard/card, :dashboard/card-skeleton and the two subs at
+            ;; ns-load.
+            [ssr-streaming.core :as example]))
+
+;; ---- fixture ---------------------------------------------------------------
+
+(def ^:private test-frame :ssr-streaming-example-cljs-test/frame)
+
+(defn- init!
+  "Per-test setup (adapter installed, registrar baseline reinstated). Stands
+  up a `:client`-platform frame — the same platform the example's `run`
+  makes — and registers the example's `:cards` contract against it, mirroring
+  the `run` wiring."
+  []
+  (rf/make-frame {:id       test-frame
+                  :doc      "ssr-streaming example client-render test frame"
+                  :platform :client})
+  (rf/reg-app-schema [:cards] {:frame test-frame} example/CardsSchema))
+
+;; `make-reset-runtime-fixture` is load-bearing here, not boilerplate: the
+;; CLJS node runner loads every test ns into ONE bundle, and a sibling suite's
+;; `:each` fixture can restore the registrar to a snapshot that predates this
+;; ns's load — which strands `ssr-streaming.core`'s ns-load views and subs and
+;; leaves `(rf/view :dashboard/root)` nil. The fixture folds this ns's stable
+;; ns-load baseline back over the live registrar before each test.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter
+     :init-fn init!}))
+
+(defn- render-client-tree
+  "Render the example's client render tree — byte-for-byte the `tree` its
+  `run` hands to `hydrate-root` — to static markup."
+  []
+  ;; `with-frame` as well as the provider: `render-to-static-markup` runs
+  ;; outside React's DOM renderer, where the provider's context bridge does
+  ;; not reach the views' injected `subscribe`. The provider is here because
+  ;; it is what the example's `run` actually mounts; `with-frame` is what
+  ;; makes the subs resolve under a static render.
+  (rf/with-frame test-frame
+    (rds/render-to-static-markup
+      [rf/frame-provider {:frame test-frame}
+       [(rf/view :dashboard/root)]])))
+
+(defn- seed-cards!
+  "Stand in for the streamed deltas + the final `__rf_payload` hydrate: the
+  three cards whose boundaries RESOLVED land in app-db; `:flaky` (whose
+  continuation threw server-side, shipping no delta) stays absent."
+  []
+  (rf/reg-event ::seed
+    (fn [{:keys [db]} _]
+      {:db (assoc db :cards
+                  {:revenue {:title "Revenue (last 7 days)"     :value 42375}
+                   :signups {:title "New signups (last 7 days)" :value 318}
+                   :latency {:title "P50 latency (ms)"          :value 24}})}))
+  (rf/dispatch-sync [::seed] {:frame test-frame}))
+
+;; ---- (1) no server-only marker leaks into the client DOM -------------------
+
+(deftest client-render-emits-no-server-only-markers
+  (testing "rf2-o4rbh: the client render tree contains neither a phantom
+            <suspense-boundary> element (Spec 011 — streaming-shell-walker-only
+            marker) nor a keyword view-ref rendered as a literal DOM tag
+            (Conventions — keyword heads are HTML elements, never views)"
+    (seed-cards!)
+    (let [html (render-client-tree)]
+      (is (not (str/includes? html "<suspense-boundary"))
+          (str ":rf/suspense-boundary is a server-only marker; it must not "
+               "reach a client render tree. Got: " html))
+      (is (not (str/includes? html "<card"))
+          (str "A keyword view-ref head renders as a literal DOM tag on the "
+               "client. Got: " html))
+      (is (not (str/includes? html "<card-skeleton"))
+          (str "A keyword view-ref head renders as a literal DOM tag on the "
+               "client. Got: " html)))))
+
+;; ---- (2) the client paints the same structure the server streamed ----------
+
+(deftest client-render-matches-the-streamed-dom
+  (testing "rf2-o4rbh: with the resolved cards hydrated, the client renders
+            the same .card structure the streaming server painted — this is
+            what `hydrate-root` has to adopt without a mismatch"
+    (seed-cards!)
+    (let [html (render-client-tree)]
+      ;; `<main …>` also carries the adapter's dev-only source-coord /
+      ;; view-id attributes, so match the class rather than the whole tag.
+      (is (str/includes? html "class=\"dashboard\"") html)
+      (is (str/includes? html "42375") html)
+      (is (str/includes? html "Revenue (last 7 days)") html)
+      (is (str/includes? html "New signups (last 7 days)") html)
+      (is (str/includes? html "P50 latency (ms)") html)
+      (is (= 4 (count (re-seq #"class=\"card[\" ]" html)))
+          (str "expected four rendered cards (three resolved + the flaky "
+               "one's skeleton). Got: " html)))))
+
+;; ---- (3) a boundary that never resolved stays on its skeleton --------------
+
+(deftest unresolved-card-renders-its-skeleton
+  (testing "rf2-o4rbh: the `:flaky` card's continuation threw server-side, so
+            no delta ever seeded it. Its client render must degrade to the
+            skeleton rather than paint an empty card — that is the DOM the
+            failed chunk's fallback left in place"
+    (seed-cards!)
+    (let [html (render-client-tree)]
+      (is (str/includes? html "class=\"card skeleton\"") html)
+      (is (str/includes? html "Loading flaky") html))))

--- a/implementation/core/test/re_frame/examples_test.clj
+++ b/implementation/core/test/re_frame/examples_test.clj
@@ -511,7 +511,14 @@
         (is (= 3 (count ok-chunks)))
         (doseq [c ok-chunks]
           (is (clojure.string/includes? (:template c)
-                                         "data-rf2-suspense-resolved=\"1\""))))
+                                         "data-rf2-suspense-resolved=\"1\""))
+          ;; rf2-o4rbh: the deferred body is a Var-headed hiccup vector
+          ;; (`[card-view :revenue]`), not a keyword view-ref. Pin that the
+          ;; emitter still resolves it to the rendered card — a regression
+          ;; here would emit an unresolved head instead of the card markup.
+          (is (clojure.string/includes? (:template c) "class=\"card\"")
+              (str "resolved chunk must carry the rendered card body; got "
+                   (:template c)))))
       ;; Final payload carries the canonical :rf/* keys.
       (is (= 1 (:rf/version (:final-payload result))))
       (is (some? (:rf/render-hash (:final-payload result))))


### PR DESCRIPTION
Closes rf2-o4rbh.

## The defect, reproduced

The streaming SSR example composed its cards as keyword view-refs inside `:rf/suspense-boundary` markers. Rendering the example's own client tree — the exact `tree` its `run` hands to `hydrate-root` — through stock Reagent + `react-dom/server` produced:

```html
<main class="dashboard">
  <header><h1>Dashboard</h1><p>Streamed SSR demo — shell renders first, cards stream in.</p></header>
  <section class="cards">
    <suspense-boundary id="card.revenue"><card>revenue</card></suspense-boundary>
    <suspense-boundary id="card.signups"><card>signups</card></suspense-boundary>
    <suspense-boundary id="card.latency"><card>latency</card></suspense-boundary>
    <suspense-boundary id="card.flaky"><throwing-card></throwing-card></suspense-boundary>
  </section>
  <footer>…</footer>
</main>
```

The card-id keyword rendered as literal text inside a phantom `<card>` tag, wrapped in a phantom `<suspense-boundary>` whose `:fallback` React discarded. The same tree rendered by the JVM streaming emitter produces four correct `<div class="card">` subtrees. Server and client disagreed structurally on the flagship streaming example.

## Verdict: example misuse, not a framework bug

Both behaviours are exactly as specified, and the client is the one following the spec:

- **Keyword heads.** `spec/Conventions.md` §Render-tree shape vs runtime lookup and `spec/Cross-Spec-Interactions.md` §237 both state that a bare `[:keyword args]` head in a render tree is an HTML element and that the runtime does not intercept the keyword case to dispatch through the view registry. Reagent's `parse-tag` runs `(name tag)`, so `:dashboard/card` → tag `card`.
- **`:rf/suspense-boundary`.** `spec/011-SSR.md` §277 pins it as recognised *only* by the streaming shell walker — the non-streaming JVM emitter fails loud on it (`:rf.error/ssr-suspense-boundary-outside-stream`) precisely because its name passes the DOM tag grammar. There is no client-side rendering for it; `re-frame.ssr.streaming.client` is DOM-swap machinery only.

Nothing was papered over: the framework question this exposed is filed separately as **rf2-j81hs** (P2) — the JVM emitter resolves keyword heads via `(registrar/lookup :view head)` while every client substrate treats them as DOM tags, and the client has no counterpart to the server's loud `:rf/suspense-boundary` guard. That bead carries the measured evidence, three ruling options, and the related open question of what a client render tree should contain at a boundary on a genuinely streamed page (`streaming-install!` materialises `<rf-suspense>` mounts the render tree has no way to express). Fixing it properly means changing normative claims in `spec/011-SSR.md` / `spec/Conventions.md` — hot-zone, so reported rather than edited.

## The fix

- **`card-slot`** is the single reader-conditional where the two runtimes part company: the boundary marker stays server-side, the client renders the resolved card. It carries the explanation of both traps.
- **`card-view`** falls back to its skeleton when its app-db slice is absent. That's the honest client state for a chunk still in flight, and the permanent state for `:card.flaky` — whose boundary failed and therefore shipped no delta. This is what lets the client's render agree with the DOM the stream painted without needing to know which boundaries succeeded, and it makes the render match the example's `index.html` exactly.
- Deferred bodies are Var-headed (`[card-view :revenue]`); the flaky slot differs only in its body (`[throwing-card]`), which the client never invokes.
- The example README and `docs/ssr/streaming.md` shipped the same keyword-head snippet. Both corrected, and both now name the trap — the SSR guide page is where a reader meets this feature first.

## Regression cover

The example tree stays test-free (rf2-8cevm) — **no `*.spec.cjs` was added under `examples/`**. Cover lands substrate-side, mirroring how the JVM half already lives in `re-frame.examples-test`:

- **New:** `implementation/adapters/reagent/test/re_frame/ssr_streaming_example_cljs_test.cljs` — renders the example's client tree through `react-dom/server` and pins that no server-only marker reaches it, that the resolved cards match the streamed DOM, and that an unresolved boundary degrades to its skeleton. Proven non-vacuous: it failed against the unmodified example with the literal-text output quoted above.
- **Extended:** `re-frame.examples-test/ssr-streaming-example-runs-end-to-end` now asserts each resolved chunk carries `class="card"`, pinning that the emitter still resolves the Var-headed deferred body.

## Sibling examples

Swept `examples/` for render-tree keyword heads. The three in `ssr_streaming/core.cljc` (plus the README snippet) were the only ones — every other hit is an event vector, not hiccup. The two sibling SSR examples (`ssr/core.cljc`, `resources_ssr/core.cljc`) already use the idiomatic `[(rf/view :pages/articles)]` lookup form. Nothing else to fix.

## Quality gates

All foreground, run to completion, non-zero counts confirmed.

| Gate | Result |
| --- | --- |
| `npm run test:cljs` | **Ran 10036 tests / 49485 assertions — 0 failures, 0 errors** |
| `implementation/core` `clojure -M:test` (loads the example; owns the JVM half) | **Ran 2071 tests / 9913 assertions — 0 failures, 0 errors** (9910 before; +3 confirms the new assertion executed) |
| `npm run test:examples-compile` | **all 44 example builds compiled with zero warnings**, `[:examples/ssr-streaming] Build completed. (203 files, 202 compiled, 0 warnings)` |
| `python -m mkdocs build --strict` | exit 0, no warnings |
