### PR TITLE
spec(views): finish and guard the per-host AST contract (rf2-vxcl7)

### DIFF
--- a/ai/findings/new-substrate-synthesis/drafts/spec-004-rewrite-draft.md
+++ b/ai/findings/new-substrate-synthesis/drafts/spec-004-rewrite-draft.md
@@ -73,10 +73,12 @@ pattern-level commitments: ⟨01 invariants⟩
    frame and no cross-frame read spelling. Frames are created at **host preflight**
    ([002](002-Frames.md)); the view layer only *scopes* live frames. ⟨I-10, 03 §8⟩
 3. **The portability law.** A portable view has one deterministic, serialisable
-   **template representation** consumed by each host emitter. Emitted host values may be
-   host-native and need not themselves be serialisable. One normalized template AST
-   controls every emitter; parity between emitters is **normalized structural
-   equivalence** (fingerprinted), not byte-identical output. ⟨R-1, I-13⟩
+   **template representation**, produced by the shared analyzer and consumed by that
+   build's host emitter. Emitted host values may be host-native and need not themselves
+   be serialisable. Analysis is host-parameterized, so each build lowers its own AST and
+   hands it to exactly one emitter — the hosts never meet as ASTs. Parity between the
+   two emitter implementations is **normalized structural equivalence**
+   (fingerprinted), not byte-identical output. ⟨R-1, I-13⟩
 4. **Client markup is compiled, never interpreted.** Literal templates lower to
    `jsx`/`jsxs` calls; conversion is compile-time; static subtrees hoist. No hiccup
    walker, tag parser, camelizer, or component-shape detector ships in a browser

--- a/implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj
@@ -405,6 +405,18 @@
    ;; marker between "one" and "AST" must not buy the retired wording a pass.
    ["one AST consumed by the emitters"
     #"(?is)\bAST\**\s+consumed\s+by\s+(?:two|both|each\s+host|the\s+(?:two|host))\s+emitter"]
+   ;; A fourth formulation of the same retired model, which reached Spec 004's
+   ;; Abstract untouched by the three above (rf2-vxcl7): the cross-host noun is
+   ;; "template representation" rather than "AST", so no /AST/ pattern sees it.
+   ;; "consumed by THAT BUILD'S host emitter" is the current law and must NOT
+   ;; match — only a cross-host quantifier does.
+   ["one template representation consumed by the host emitters"
+    #"(?is)\b(?:one|a\s+single)\b.{0,80}?\btemplate\s+representation\**\s+consumed\s+by\s+(?:two|both|each|every|the)(?:\s+(?:two|host))?\s+emitters?\b"]
+   ;; …and its second half, whose quantifier ("every") the "one parse/AST →
+   ;; per-host emitters" row does not carry, and whose verb is governance rather
+   ;; than handing-off.
+   ["one AST governs every emitter"
+    #"(?is)\b(?:one|a\s+single)\s+(?:normalized\s+|normalised\s+|template\s+)*AST\b[^.]{0,60}?\b(?:controls|governs|drives|feeds|serves)\s+(?:every|each|both|all|the)\s+(?:host\s+)?emitters?\b"]
    ["one emitter implements both hosts"
     #"(?i)(?:(?:one|same)\s+emitter[^\n]{0,120}(?:both\s+hosts|client[^\n]*server|browser[^\n]*jvm)|(?:both\s+hosts|client[^\n]*server|browser[^\n]*jvm)[^\n]{0,120}(?:one|same)\s+emitter)"]
    ["host output is identical"
@@ -465,6 +477,45 @@
         (doseq [[claim pattern] retired-claim-patterns]
           (is (not (re-find pattern text))
               (str path " reintroduced retired claim: " claim)))))))
+
+(defn- section-text
+  "The text of `heading` up to the next same-level heading, or nil if absent.
+
+  Region scoping is load-bearing: the document-wide census above cannot see
+  WHERE a claim sits, so one correct sentence in Spec 004's body kept the file
+  green while its Abstract still taught the retired cross-host model. Binding a
+  region means a second occurrence of the same phrase elsewhere in the document
+  cannot satisfy the row (the false-green shape rf2-yho9j found).
+
+  Line endings are normalized first so the slice behaves identically on a CRLF
+  checkout (Windows) and an LF one (CI)."
+  [text heading]
+  (let [text (str/replace text "\r\n" "\n")]
+    (when-let [from (str/index-of text heading)]
+      (let [to (str/index-of text "\n## " (+ from (count heading)))]
+        (subs text from (or to (count text)))))))
+
+(deftest spec-004-abstract-teaches-per-host-analysis
+  (let [abstract (section-text (slurp (root-file "spec/004-Views.md"))
+                               "\n## Abstract\n")]
+    (when (is (some? abstract) "spec/004-Views.md lost its '## Abstract' heading")
+      (testing "the Abstract states host-parameterized analysis, one emitter per build"
+        (doseq [pattern [#"(?is)analysis\s+is\s+host-parameterized"
+                         #"(?is)hands\s+it\s+to\s+exactly\s+one\s+emitter"
+                         #"(?is)hosts\s+never\s+meet\s+as\s+ASTs"]]
+          (is (re-find pattern abstract)
+              (str "spec/004-Views.md Abstract lost its per-host statement: "
+                   pattern))))
+      (testing "the Abstract keeps the two-emitter and normalized-parity facts"
+        (doseq [pattern [#"(?is)two\s+emitter\s+implementations"
+                         #"(?is)normalized\s+structural\s+equivalence"]]
+          (is (re-find pattern abstract)
+              (str "spec/004-Views.md Abstract lost a legitimate fact: " pattern))))
+      (testing "retired cross-host claims stay absent from the Abstract"
+        (doseq [[claim pattern] retired-claim-patterns]
+          (is (not (re-find pattern abstract))
+              (str "spec/004-Views.md Abstract reintroduced retired claim: "
+                   claim)))))))
 
 (deftest pipeline-and-stage-claims-stay-truthful
   (let [chapters (into {} (map (juxt identity slurp-guide) chapter-files))

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -24,10 +24,12 @@ pattern-level commitments:
    frame and no cross-frame read spelling. Frames are created at **host preflight**
    ([002](002-Frames.md)); the view layer only *scopes* live frames.
 3. **The portability law.** A portable view has one deterministic, serialisable
-   **template representation** consumed by each host emitter. Emitted host values may be
-   host-native and need not themselves be serialisable. One normalized template AST
-   controls every emitter; parity between emitters is **normalized structural
-   equivalence** (fingerprinted), not byte-identical output.
+   **template representation**, produced by the shared analyzer and consumed by that
+   build's host emitter. Emitted host values may be host-native and need not themselves
+   be serialisable. Analysis is host-parameterized, so each build lowers its own AST and
+   hands it to exactly one emitter — the hosts never meet as ASTs. Parity between the
+   two emitter implementations is **normalized structural equivalence**
+   (fingerprinted), not byte-identical output.
 4. **Client markup is compiled, never interpreted.** Literal templates lower to
    `jsx`/`jsxs` calls; conversion is compile-time; static subtrees hoist. No hiccup
    walker, tag parser, camelizer, or component-shape detector ships in a browser


### PR DESCRIPTION
Closes rf2-vxcl7.

## What the Abstract claimed vs what ships

Spec 004's numbered Abstract (commitment 3) still taught the **retired cross-host-one-AST model**:

> A portable view has one deterministic, serialisable **template representation** consumed by **each host emitter**. … **One normalized template AST controls every emitter**.

What ships (`compiler.cljc`: `(if cljs? (emit-cljs/emit-defview args) (emit-jvm/emit-defview args))`) and what §The portability law and the template AST says a few lines below is the opposite: **One AST per build**, analysis is host-parameterized, "the hosts never meet as ASTs". The premise held — this was the last of the four formulations, and the one the existing guard could not see.

## Completed wording

```
3. **The portability law.** A portable view has one deterministic, serialisable
   **template representation**, produced by the shared analyzer and consumed by that
   build's host emitter. Emitted host values may be host-native and need not themselves
   be serialisable. Analysis is host-parameterized, so each build lowers its own AST and
   hands it to exactly one emitter — the hosts never meet as ASTs. Parity between the
   two emitter implementations is **normalized structural equivalence**
   (fingerprinted), not byte-identical output.
```

Legitimate facts preserved: **two emitter implementations**, and parity as **normalized structural equivalence** (not byte-identical).

The identical paragraph was the source wording in the tracked `spec-004-rewrite-draft.md`, which the authority census already covers — the new patterns red on it, so it is reconciled identically. (That subtree is force-added to git by documented exception.)

## The guard

Extends the already-CI-wired compiler-model authority census in `implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj`. It **composes with** the existing S3/S4-style census rather than duplicating it — the new region test reuses the shared `retired-claim-patterns` vector.

1. **Two new census rows.** The three existing rows all key on the noun `AST`; this formulation's cross-host noun was `template representation`, and its quantifier `every` sat outside the emitter alternation `(two|both|per-host|each host)`. Both rows deliberately do **not** match the current law's `consumed by that build's host emitter`.
2. **Abstract bound as a region** (`section-text`). The document-wide census cannot see *where* a claim sits, so one correct sentence in 004's body kept the file green while the Abstract taught the retired model — exactly the false-green shape rf2-yho9j found (a second occurrence of the same phrase elsewhere satisfying the row). Region scoping means a body occurrence cannot satisfy an Abstract row. Line endings are normalized so the slice behaves the same on a CRLF checkout and an LF CI runner.

No general spec-prose framework, no mirror-sync mechanism, no new normative rules, no restructuring. **No edits or guards target gitignored/generated `docs/spec/`** — strict MkDocs remains the projection mechanism.

## Mutation proof — 4 mutations, 4 red, restore green

| # | Mutation | Result |
|---|---|---|
| 1 | Reintroduce `One normalized template AST controls every emitter.` | **RED** ×2 — census + Abstract region |
| 2 | Reintroduce `template representation consumed by each host emitter` | **RED** ×2 — census + Abstract region |
| 3 | Delete only the per-host sentence from the Abstract, body left correct | **RED** ×3 Abstract rows — and the **document-wide test stayed GREEN**, proving the region binding is load-bearing |
| 4 | Weaken `two emitter implementations` → `emitters` | **RED** ×1 legitimate-fact row |

Each new census row fires **independently** (1 and 2 red on one pattern each). Restored: green.

A fifth, unplanned proof: the first full run after adding the rows red on the untouched draft authority, catching the same retired wording there.

## Quality gates

| Gate | Result |
|---|---|
| `implementation/ui` → `clojure -M:test` | **902 tests / 15851 assertions, 0 failures, 0 errors** (baseline ~901/15787; delta is the new deftest + new census rows) |
| `implementation` → `npm run test:cljs` | **10053 tests / 49566 assertions, 0 failures, 0 errors** |
| `python -m mkdocs build --strict` | **green** (built in 31.84s) |
| `python scripts/check_doc_slugs.py` | **green** (exit 0) |

All run in the foreground to completion, unpiped counts confirmed non-zero.

Today's merged 004 changes are intact: rf2-yjhrt (S4-D), rf2-0ufty (§Presence retraction), rf2-74vlo (S4-C), rf2-6u4cw (raw portals), rf2-3i7tr (head-policy ownership split), rf2-29s75, rf2-xoz1s. The diff touches only Abstract commitment 3.
