### PR TITLE
test(core): resurrect the silently-replaced editor-URI test (rf2-9e4lf)

### DIFF
--- a/implementation/core/test/re_frame/source_coords_editor_uri_test.clj
+++ b/implementation/core/test/re_frame/source_coords_editor_uri_test.clj
@@ -194,8 +194,10 @@
             (str editor " produced a URI that trips the forbidden-scheme gate: "
                  uri))))))
 
-(deftest forbidden-scheme-substring-is-not-rejected
-  (testing "the gate matches the LEADING scheme only — substrings elsewhere are fine"
+(deftest editor-uri-does-not-reject-forbidden-scheme-substring
+  (testing "the gate matches the LEADING scheme only, so `editor-uri` still
+            returns a URI when a substring elsewhere in the path looks like a
+            forbidden scheme"
     ;; A path that contains "javascript:" deep inside is not the scheme.
     (is (some? (eu/editor-uri
                  :custom-fallback ; unknown -> vscode default
@@ -213,6 +215,14 @@
 ;; not an allowlist (Security.md / Tool-Pair.md §Editor URI scheme
 ;; allowlist). `forbidden-scheme?` is now PUBLIC so the tool `open!` seams
 ;; can re-apply the cheap denylist at the pre-resolved `{:uri ...}` handoff.
+;;
+;; Each test here has a twin in the rf2-vwcsq block above: that block drives
+;; the `editor-uri` BUILDER, this one drives the `forbidden-scheme?` PREDICATE
+;; directly. rf2-9e4lf: the substring pair was the one that collided — both
+;; deftests were named `forbidden-scheme-substring-is-not-rejected`, so when
+;; this block landed (f2b24e146f) its test silently replaced the builder-level
+;; one, which had not run since. The axis is which surface is under test, so
+;; that is what the two names now say.
 
 (deftest forbidden-scheme-rejects-the-three-known-bad
   (testing "forbidden-scheme? is true for javascript: / data: / vbscript:"
@@ -264,7 +274,7 @@
     (is (not (eu/forbidden-scheme? "no-scheme-here")))
     (is (not (eu/forbidden-scheme? 42)))))
 
-(deftest forbidden-scheme-substring-is-not-rejected
+(deftest forbidden-scheme-predicate-does-not-flag-substring
   (testing "the gate matches the LEADING scheme only — a 'javascript:'
             substring deep in the URI is not the scheme"
     (is (not (eu/forbidden-scheme? "vscode://file/src/has-javascript:x.cljs:1:1")))


### PR DESCRIPTION
`implementation/core/test/re_frame/source_coords_editor_uri_test.clj` defined `forbidden-scheme-substring-is-not-rejected` twice. The second `deftest` silently replaced the first, so the first body had **never executed**.

## Archaeology — same defect class as rf2-qo5xk, different cause

The bead's stated cause (the `rf2-h1vqa4` rename sweep, copied from rf2-qo5xk) does **not** hold here. `git log -L` on both bodies gives:

| Body | Born | Bead | Asserts on |
|---|---|---|---|
| line 197 | `067ef5c3c9` (2026-05-14) | rf2-vwcsq | `eu/editor-uri` — the **builder** |
| line 267 | `f2b24e146f` (2026-06-17) | rf2-ox357n | `eu/forbidden-scheme?` — the **predicate** |

No rename sweep was involved. `f2b24e146f` is the allowlist → denylist migration: it deleted three `allowed-uri?` tests and added a parallel block driving the newly-public `forbidden-scheme?` predicate, reusing the existing symbol verbatim. Every other test in that block was disambiguated from its builder-level twin by a singular/plural or verb-form tweak (`forbidden-schemes-case-insensitive` vs `forbidden-scheme-is-case-insensitive`, and so on) — the substring pair alone collided exactly.

## Disposition — (a) genuinely distinct

The two bodies assert on **different functions**, so both are renamed to express that axis rather than suffixed:

- `forbidden-scheme-substring-is-not-rejected` → **`editor-uri-does-not-reject-forbidden-scheme-substring`** (builder)
- `forbidden-scheme-substring-is-not-rejected` → **`forbidden-scheme-predicate-does-not-flag-substring`** (predicate)

A block comment records why the pair exists and how it collided, so the next author extending the parallel block sees the trap.

## The resurrected body PASSES — no latent bug

It found nothing broken. `forbidden-scheme?` correctly matches the leading scheme only, so a benign `vscode:` / `myeditor:` URI carrying a `javascript:` substring deeper in the path is not rejected. Reported plainly because a failure here would have been the more valuable finding.

## Quality gates

`cd implementation/core && clojure -M:test` — foreground, unpiped, run to completion.

| | tests | assertions | result |
|---|---|---|---|
| baseline (branch point) | 2072 | 9912 | 0 failures, 0 errors |
| this branch | 2073 | 9914 | 0 failures, 0 errors |
| **this branch, rebased on current main** | **2073** | **9917** | **0 failures, 0 errors** |

Exactly **+1 test and +2 assertions** against both baselines — matching the resurrected body's two `is` forms.

### Duplicate-definition signal: the JVM emits none

Verified with a standalone probe — a namespace defining the same `deftest` twice, the first body deliberately failing:

```
Ran 1 tests containing 1 assertions.
0 failures, 0 errors.
```

The failing body vanished with **zero diagnostic output** and the suite reported green. There is no JVM equivalent of the shadow-cljs `:redef-in-file` warning that rf2-qo5xk relied on (Clojure's `already refers to` warning only fires when a def shadows a var referred from a *different* namespace), so the count is the available signal.

### Independent falsification

Since a green suite alone proves nothing, one assertion in the resurrected body was temporarily inverted. The suite went red **at the new symbol name**:

```
FAIL in (editor-uri-does-not-reject-forbidden-scheme-substring) (source_coords_editor_uri_test.clj:202)
  actual: (not (nil? "vscode://file/src/has-javascript:keyword.cljs:1:1"))
Ran 2073 tests containing 9914 assertions.
1 failures, 0 errors.
```

That failure was impossible while the body was being replaced. The probe was reverted; the final gate above is the reverted tree.

## Scope

One file, two renames, one comment. Per the bead, no lint rule or duplicate-name checker — 1454 test files were scanned under rf2-qo5xk and this was the last instance. The CLJS twin (`source_coords_editor_uri_cljs_test`) was checked and carries no such test, so it needed no change.

Closes rf2-9e4lf.
