### PR TITLE
fix(ui): reconcile frame-cost, reload-ledger elision and build-hook authority (rf2-cj5js, rf2-k9yuy, rf2-fm8bf)

### DIFF
--- a/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
+++ b/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
@@ -43,17 +43,17 @@
       - `day8.re-frame2-xray.runtime` — the discovery sentinel + safe-egress
         entry points.
   - `re-frame.ui` (rf2-qz1h5d; rf2-vxgfnd.83 + rf2-vxgfnd.103) — the Spec-004
-    compiled-view substrate. FULLY-ROWED (both directions): the entire blessed
-    export set is rowed — the S1 set, the namespace-specific `frame-root` row
-    (rf2-vxgfnd.71), `frame-provider`, the S2 SCOPE form (rf2-vxgfnd.83,
-    rowed once rf2-vxgfnd.24 blessed it as the native SCOPE grammar),
-    `adapter`, the first-party `:rf.adapter/ui` boot adapter Var
-    (rf2-vxgfnd.103 / PR #5809), `frame`, the S2 ops-bundle body form
-    (rf2-vxgfnd.184), and the S3 additions `event`, `render-fn`, `slot`, and
-    `spread-safe`. A row
-    removed / renamed in source → RED (direction 1); a NEW public Var added to
-    this closed compiler grammar without a row → RED (direction 2), so an
-    accidental public export cannot accumulate silently.
+    compiled-view substrate. FULLY-ROWED (both directions): the ENTIRE blessed
+    export set is rowed. That set is NOT re-listed here — it grows every stage
+    and a second hand-maintained inventory would drift silently. The ONE
+    authoritative enumeration is the JVM assertion
+    `re-frame.ui.defview-grammar-jvm-test/export-surface-is-exactly-the-blessed-set`
+    (`implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj`), which
+    pins `(ns-publics 're-frame.ui)` to an exact literal set; the manifest's
+    `:cljs-only` `re-frame.ui` rows are its projection. A row removed / renamed
+    in source → RED (direction 1); a NEW public Var added to this closed
+    compiler grammar without a row → RED (direction 2), so an accidental
+    public export cannot accumulate silently.
 
   The pair-MCP server (`re-frame2-pair-mcp.server`) is the third
   CLJS-only surface the keystone names. It compiles under the pair-MCP
@@ -137,13 +137,11 @@
    "day8.re-frame2-xray.open-in-editor"              (emit-ns-publics day8.re-frame2-xray.open-in-editor)
    "day8.re-frame2-xray.runtime"                     (emit-ns-publics day8.re-frame2-xray.runtime)
    ;; rf2-qz1h5d + rf2-vxgfnd.83 + rf2-vxgfnd.103 — re-frame.ui compiled-view
-   ;; substrate. FULLY-ROWED now: the entire blessed export set is rowed (the
-   ;; S1 set, the namespace-specific `frame-root` row rf2-vxgfnd.71, the S2
-   ;; SCOPE form `frame-provider` rf2-vxgfnd.83 — rowed once rf2-vxgfnd.24
-   ;; blessed it — the first-party `adapter` Var rf2-vxgfnd.103, the `frame`
-   ;; ops-bundle body form rf2-vxgfnd.184, and the S3 additions `event`,
-   ;; `render-fn`, `slot`, and `spread-safe`), so
-   ;; re-frame.ui is in `fully-rowed` below (both directions checked).
+   ;; substrate. FULLY-ROWED: the entire blessed export set is rowed, so
+   ;; re-frame.ui is in `fully-rowed` below (both directions checked). The
+   ;; blessed set itself is enumerated ONCE, in
+   ;; `export-surface-is-exactly-the-blessed-set` (see the ns docstring) —
+   ;; never re-listed here.
    "re-frame.ui"                                     (emit-ns-publics re-frame.ui)
    ;; rf2-vxgfnd.200 — re-frame.ui.test testing surface. JVM-introspected for
    ;; its manifest rows (the generator owns tier/kind); the probe reconciles
@@ -153,12 +151,10 @@
 (def fully-rowed
   "Namespaces whose ENTIRE public surface must be rowed (direction 2).
    The three adapter namespaces — their public surface IS the documented
-   adapter API — and `re-frame.ui`, the Spec-004 compiled-view substrate:
-   with `frame-provider` rowed (rf2-vxgfnd.83, once rf2-vxgfnd.24 blessed it
-   as the native SCOPE form) and the first-party `adapter` Var rowed
-   (rf2-vxgfnd.103), `frame` (rf2-vxgfnd.184), and the S3 additions `event` /
-   `render-fn` / `slot` / `spread-safe`, the entire blessed export set is rowed, so a NEW
-   accidental public Var added to this first-party closed compiler grammar
+   adapter API — and `re-frame.ui`, the Spec-004 compiled-view substrate,
+   whose entire blessed export set is rowed (that set is enumerated ONCE, in
+   `export-surface-is-exactly-the-blessed-set` — see the ns docstring), so a
+   NEW accidental public Var added to this first-party closed compiler grammar
    fails direction-2 completeness. The Xray mount surface stays a curated
    subset (direction 1 only), so it is deliberately absent here."
   #{"re-frame.adapter.reagent"

--- a/implementation/scripts/check-ui-mounted-prod-elision.cjs
+++ b/implementation/scripts/check-ui-mounted-prod-elision.cjs
@@ -158,6 +158,58 @@ for (const forbidden of ['identity-exact', 'site-counts']) {
 }
 
 /*
+ * rf2-k9yuy — the custom-element hot-reload LEDGER must not reach production.
+ *
+ * `re-frame.ui.rules` keeps a source/cycle ledger so a hot reload can stage,
+ * reconcile and evict custom-element declarations. Production can never open a
+ * reload cycle (`notify-reload!` is a ^:dev/before-load hook shadow does not
+ * install in a release build), so that state is pure dead weight there — yet it
+ * used to ship: the atom was an unconditional `defonce` and every production
+ * registration `swap-vals!`'d against it. The `reload-ledger?` compile-time gate
+ * now folds it out.
+ *
+ * The ledger's root keys are NAMESPACE-QUALIFIED (`::sources` / `::cycles`)
+ * precisely so this grep has teeth: `re-frame.ui.rules/sources` and
+ * `re-frame.ui.rules/cycles` are minted by that ledger and nothing else, whereas
+ * bare `sources` / `cycles` would collide across the corpus. Closure renames
+ * symbols under :advanced but never rewrites string literals, and a CLJS keyword
+ * carries its fully-qualified name as one — so if either appears here, the
+ * ledger compiled in.
+ *
+ * Source positive control first: the keys must still BE namespace-qualified in
+ * rules.cljc, so a rename cannot turn this into a vacuous pass. The dev-positive
+ * control is `re-frame.ui.rules-cljs-test` (node, goog.DEBUG=true), which stages,
+ * reconciles and commits real reload cycles through those same keys — deleting
+ * the dev branch to satisfy this grep reddens there instead.
+ */
+const RULES_SOURCE = path.join(ROOT, 'ui', 'src', 're_frame', 'ui', 'rules.cljc');
+const rulesSource = fs.readFileSync(RULES_SOURCE, 'utf8');
+for (const expected of ['::sources', '::cycles', 'reload-ledger?']) {
+  if (!rulesSource.includes(expected)) {
+    fail(`reload-ledger source positive-control sentinel is absent: ${expected}`);
+  }
+}
+
+const LEDGER_PROD_TEST = path.join(ROOT, 'ui', 'test', 're_frame', 'ui',
+                                   'custom_element_reload_elision_prod_test.cljs');
+const ledgerProdTest = fs.readFileSync(LEDGER_PROD_TEST, 'utf8');
+const LEDGER_CONTROL = 'rf-ui-custom-element-reload-ledger-absent-v1';
+for (const expected of ["@#'rules/ledger-state", LEDGER_CONTROL]) {
+  if (!ledgerProdTest.includes(expected)) {
+    fail(`reload-ledger causal-oracle control is absent from its test: ${expected}`);
+  }
+}
+if (!bundle.includes(LEDGER_CONTROL)) {
+  fail('reload-ledger private-state assertion was omitted from advanced bundle');
+}
+
+for (const forbidden of ['re-frame.ui.rules/sources', 're-frame.ui.rules/cycles']) {
+  if (bundle.includes(forbidden)) {
+    fail(`custom-element reload ledger survived advanced output: ${forbidden}`);
+  }
+}
+
+/*
  * rf2-vxgfnd.94.8 — REAL compiled mutation control. A second advanced build
  * flips a private goog-define which roots an unrelatedly named atom/reset path
  * inside re-frame.ui.tool.evidence. The same production test must turn red on

--- a/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
@@ -52,10 +52,15 @@
      same-/backwards-millisecond recompile (rf2-suz5b). A later `:compile-prepare` hook
      (Shadow deep-merges build-local hooks after `:build-defaults` and lets them
      mutate build state) can force a source to recompile AFTER re-frame.ui observed
-     the schedule; reading the finish-time marker and Shadow's compile record, not
-     the intermediate prepare schedule, closes that hook-order gap so a forced
+     the schedule; reading the finish-time marker — and, where the marker is
+     absent, re-frame.ui's OWN analyzer-pass compile witness — rather than the
+     intermediate prepare schedule closes that hook-order gap, so a forced
      recompile that removed a source's final `ui/defview` evicts its accepted row
-     instead of leaving a ghost view. Missing, malformed, or contradictory
+     instead of leaving a ghost view. The witness is what makes this work without
+     re-admitting the retired wall-clock authority: it records the fact that
+     Shadow's compiler ANALYZED the source, outside the `[:output rid]` map any
+     replacement controls, so no `:compiled-at` comparison and no
+     `::build-info :compiled` membership is consulted anywhere on this path. Missing, malformed, or contradictory
      per-source provenance fails loudly before any candidate is published, never
      silently treated as untouched;
   1. derive the candidate finalized slice (commit staged sources, evict sources

--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -1052,8 +1052,15 @@
 ;;   - STABLE IDENTITY per live incarnation: the bundle is cached keyed by
 ;;     the frame's incarnation token (`frame/frame-incarnation-token`), so
 ;;     repeated `(frame)` reads across renders return the IDENTICAL bundle
-;;     (rf= memo-friendly) and a render performs no registry construction —
-;;     one map lookup. A destroyed/replaced frame mints a fresh bundle.
+;;     (rf= memo-friendly) and a render CONSTRUCTS nothing — no bundle mint,
+;;     no closure allocation, no registry walk. A cache HIT is a BOUNDED,
+;;     allocation-free lifecycle+cache read: the incarnation token, the
+;;     incarnation-scoped closing check, the cache entry, and the token
+;;     identity compare that proves the entry belongs to THIS incarnation
+;;     (`frame-ops-for` below is the whole path). Bounded, not free — the
+;;     liveness reads are what make the stale-bundle fence sound, so they
+;;     are load-bearing rather than overhead. A destroyed/replaced frame
+;;     mints a fresh bundle.
 ;;   - INCARNATION-FENCED ops: each op checks the captured incarnation is
 ;;     still live (`frame/frame-incarnation-live?`) before delegating, so a
 ;;     bundle that outlives its frame fails loud with the canonical

--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -748,9 +748,9 @@
 ;;                                known-good manifest survives.
 ;;
 ;; The whole protocol reads and writes ONE authoritative value (`ledger-state`:
-;; live `:sources` + in-flight `:cycles`), so the reload cycle is a LINEARIZABLE
-;; state transition (rf2-vxgfnd.144). The public `custom-elements` aggregate is a
-;; pure projection published AFTER each transition, never interleaved with it —
+;; live `::sources` + in-flight `::cycles`), so the reload cycle is a
+;; LINEARIZABLE state transition (rf2-vxgfnd.144). The public `custom-elements`
+;; aggregate is a pure projection published AFTER each transition, never interleaved with it —
 ;; so a watch that reentrantly registers during publication observes an already-
 ;; closed cycle and write-through's into the next generation instead of staging
 ;; into a cycle the commit is about to discard.
@@ -770,9 +770,28 @@
 ;; and the cycle that reconciles it cannot key a row differently. The explicit
 ;; build-scoped arities remain the seam for multi-build reconciliation and tests.
 ;;
-;; Production never opens a cycle (`notify-reload!` is a dev-only hook), so every
-;; registration writes through directly and classification stays a plain lookup —
-;; all reconciliation machinery is reload-only.
+;; ## Production carries none of this (rf2-k9yuy)
+;;
+;; Production never opens a cycle: `notify-reload!` is a `^:dev/before-load` hook
+;; shadow does not install in a release build. So a production registration was
+;; always a plain write-through and classification always a plain lookup — but
+;; until rf2-k9yuy the ledger atom was still ALLOCATED and every production
+;; registration still `swap-vals!`'d against it, shipping unused bookkeeping to
+;; consumers. The `reload-ledger?` compile-time gate now folds the whole ledger
+;; out of `:advanced` + `goog.DEBUG=false`: no ledger atom, no staging branch, no
+;; reload-hook body, and `register-custom-element!` emits the ONE direct
+;; `custom-elements` update it actually needs — still once per declaration at
+;; load, never per render. Dev and the JVM keep the full protocol unchanged.
+;;
+;; The elision is pinned BOTH ways. LEXICALLY: the ledger's namespace-qualified
+;; root keys (`::sources` / `::cycles`) are minted nowhere else, so
+;; `scripts/check-ui-mounted-prod-elision.cjs` greps the real `:advanced` browser
+;; bundle for them — present ⇒ the ledger compiled in. CAUSALLY:
+;; `custom_element_reload_elision_prod_test.cljs` runs IN that bundle and asserts
+;; the private `ledger-state` var holds no atom while registration still
+;; classifies. The dev side is the positive control — `rules_cljs_test` (node,
+;; `goog.DEBUG=true`) stages, reconciles and commits real cycles, so removing the
+;; dev branch reddens there rather than silently satisfying the bundle grep.
 ;;
 ;; ## Bounded by shadow's reload surface (the honest edge)
 ;;
@@ -796,34 +815,71 @@
   custom-elements
   (atom {}))
 
+(def ^:private ^boolean reload-ledger?
+  "COMPILE-TIME gate for the ENTIRE hot-reload ledger (rf2-k9yuy).
+
+  Only a host that can OPEN a reload cycle needs the source/cycle ledger below.
+  Development (`goog.DEBUG`) can; `:advanced` production cannot — `notify-reload!`
+  is a `^:dev/before-load` hook shadow never installs in a release build — so in
+  production every registration was already a plain write-through and the whole
+  ledger was unused bookkeeping a consumer shipped for nothing.
+
+  Under `:advanced` + `goog.DEBUG=false` Closure constant-folds this to `false`,
+  which DCEs the ledger atom's construction, every staging/reconcile branch and
+  every reload-hook body — so no source/cycle state is allocated, rooted, read or
+  mutated in production. What survives is the ONE direct `custom-elements` update
+  a production registration actually needs.
+
+  The JVM arm is unconditionally `true` (NOT `interop/debug-enabled?`, which
+  `-Dre-frame.debug=false` can flip): the compiler and the JVM tree-builder
+  fixtures drive the reload protocol headless, so the ledger must always be
+  present there."
+  #?(:cljs ^boolean js/goog.DEBUG
+     :clj  true))
+
+(def ^:private empty-ledger
+  "The quiescent ledger value — no committed sources, no in-flight cycles."
+  {::sources {} ::cycles {}})
+
 (defonce ^{:private true
-           :doc "The ONE authoritative ledger value (rf2-vxgfnd.144). A single
-  atom so cycle open/close, staged-row ownership and the ledger transition are a
-  LINEARIZABLE state change — check-then-act on the reload cycle can never be
-  split across two atoms and interleaved:
+           :doc "The ONE authoritative ledger value (rf2-vxgfnd.144), or `nil`
+  in `:advanced` production (rf2-k9yuy — see `reload-ledger?`; a host that can
+  never open a reload cycle allocates no ledger). A single atom so cycle
+  open/close, staged-row ownership and the ledger transition are a LINEARIZABLE
+  state change — check-then-act on the reload cycle can never be split across two
+  atoms and interleaved:
 
-    {:sources {[build-id ns-sym] {tag decl}}   ; the per-source committed ledger
-     :cycles  {build-id {:staged {[b ns] {tag decl}} :touched #{[b ns]}}}}
+    {::sources {[build-id ns-sym] {tag decl}}   ; the per-source committed ledger
+     ::cycles  {build-id {:staged {[b ns] {tag decl}} :touched #{[b ns]}}}}
 
-  `:sources` is the runtime mirror of the compile-side build ledger — a source
+  `::sources` is the runtime mirror of the compile-side build ledger — a source
   whose file is deleted, or whose last declaration is dropped, vanishes the
-  moment its row is reconciled away, no surviving declaration required. `:cycles`
-  holds each build's IN-FLIGHT reload (absent = no cycle → direct write-through):
-  `:staged` accumulates the cycle's re-registrations, held back from the live
-  aggregate until commit; `:touched` is the reloaded/removed source set
-  `note-reloaded-sources!` records — the sources to reconcile even when they
+  moment its row is reconciled away, no surviving declaration required.
+  `::cycles` holds each build's IN-FLIGHT reload (absent = no cycle → direct
+  write-through): `:staged` accumulates the cycle's re-registrations, held back
+  from the live aggregate until commit; `:touched` is the reloaded/removed source
+  set `note-reloaded-sources!` records — the sources to reconcile even when they
   staged nothing (zero-declaration / deletion).
 
-  The public `custom-elements` aggregate is a pure PROJECTION of `:sources`,
+  Both keys are NAMESPACE-QUALIFIED (`::sources` / `::cycles`) so the advanced-
+  bundle elision scan has an unambiguous lexical sentinel — this ledger is their
+  only minter, whereas the bare-keyword spellings collide with unrelated corpus
+  keywords and would make the grep meaningless. The scan itself lives in
+  scripts/check-ui-mounted-prod-elision.cjs; it deliberately owns the fully-
+  qualified grep strings, because the elision companion reifies THIS var and so
+  carries this doc into the very bundle being scanned.
+
+  The public `custom-elements` aggregate is a pure PROJECTION of `::sources`,
   published (one `reset!`) AFTER each authoritative transition completes — never
   interleaved with it."}
   ledger-state
-  (atom {:sources {} :cycles {}}))
+  (when reload-ledger? (atom empty-ledger)))
 
 (def ^:private default-build
   "The owner token for a source registering outside any real Shadow build: the
   JVM tree builder, a plain-JVM/REPL host, a `:node-test` bundle, and every
-  `:advanced` production bundle (which never reloads, so its ledger key is inert)."
+  `:advanced` production bundle (which never reloads and — rf2-k9yuy — carries no
+  ledger at all, so this token names only the write-through owner)."
   ::default)
 
 #?(:cljs
@@ -869,7 +925,7 @@
 
 (defn- aggregate
   "The public aggregate as the merge of every ledger source's map — the live
-  registry is a PURE FUNCTION of `:sources`. Sources merged in a stable order so
+  registry is a PURE FUNCTION of `::sources`. Sources merged in a stable order so
   the projection is deterministic regardless of ledger insertion order."
   [sources]
   (reduce (fn [agg src] (merge agg (get sources src)))
@@ -878,20 +934,22 @@
 
 (defn- publish!
   "Republish the public aggregate as a pure projection of the CURRENT ledger
-  `:sources`. Called AFTER an authoritative `ledger-state` transition, never
+  `::sources`. Called AFTER an authoritative `ledger-state` transition, never
   interleaved with it, so a reentrant `register-custom-element!` a watch fires
   during this publish sees the already-transitioned ledger.
 
   Uses `swap!` reading the LIVE ledger (not a captured snapshot) so that under JVM
-  contention the projection retries and recomputes from the latest `:sources` —
+  contention the projection retries and recomputes from the latest `::sources` —
   it can never overwrite a concurrent write-through's row with a stale aggregate.
-  On CLJS it is a single uncontended recompute."
+  On CLJS it is a single uncontended recompute.
+
+  Reached only from `commit-reload!`, so it is ledger-only by construction."
   []
-  (swap! custom-elements (fn [_] (aggregate (:sources @ledger-state))))
+  (swap! custom-elements (fn [_] (aggregate (::sources @ledger-state))))
   nil)
 
 (defn- reconcile-sources
-  "Fold one build's committed cycle into `:sources`: every STAGED source replaces
+  "Fold one build's committed cycle into `::sources`: every STAGED source replaces
   its whole prior contribution; every reconciled source that staged NOTHING (a
   zero-declaration edit or a removed/deleted file flagged via `:touched`) is
   evicted; untouched sources are kept."
@@ -917,24 +975,32 @@
   removed. A write-through additionally publishes its one row; because it decided
   against staging atomically, a commit that closed the cycle first cannot delete
   this row (the closed cycle no longer names it), and a commit still open cannot
-  see it as staged (it went to `:sources`, not `:staged`) — the generation rule
-  the reentrancy fix relies on."
+  see it as staged (it went to `::sources`, not `:staged`) — the generation rule
+  the reentrancy fix relies on.
+
+  In `:advanced` production (`reload-ledger?` false) there is no ledger and no
+  cycle can ever be open, so the whole stage-vs-write-through transition folds
+  away and what remains is the single direct aggregate update — the same row the
+  dev write-through publishes, reached without touching any ledger state
+  (rf2-k9yuy)."
   ([tag decl ns-sym] (register-custom-element! tag decl ns-sym (current-build-id)))
   ([tag decl ns-sym build-id]
-   (let [source [build-id ns-sym]
-         [old _new]
-         (swap-vals! ledger-state
-                     (fn [{:keys [cycles] :as st}]
-                       (if (contains? cycles build-id)
-                         (update-in st [:cycles build-id :staged source]
-                                    (fnil assoc {}) tag decl)
-                         (update-in st [:sources source]
-                                    (fnil assoc {}) tag decl))))]
-     ;; The winning transition saw `old`; if `old` had no open cycle it was a
-     ;; write-through, so publish this row incrementally. (Staged registrations
-     ;; stay invisible until commit.)
-     (when-not (contains? (:cycles old) build-id)
-       (swap! custom-elements assoc tag decl)))
+   (if reload-ledger?
+     (let [source [build-id ns-sym]
+           [old _new]
+           (swap-vals! ledger-state
+                       (fn [st]
+                         (if (contains? (::cycles st) build-id)
+                           (update-in st [::cycles build-id :staged source]
+                                      (fnil assoc {}) tag decl)
+                           (update-in st [::sources source]
+                                      (fnil assoc {}) tag decl))))]
+       ;; The winning transition saw `old`; if `old` had no open cycle it was a
+       ;; write-through, so publish this row incrementally. (Staged registrations
+       ;; stay invisible until commit.)
+       (when-not (contains? (::cycles old) build-id)
+         (swap! custom-elements assoc tag decl)))
+     (swap! custom-elements assoc tag decl))
    tag))
 
 (defn ^:dev/before-load notify-reload!
@@ -942,10 +1008,12 @@
   (the runtime analogue of the compile-side `begin-build!`). Re-registrations
   from here stage instead of mutating the live aggregate; opening a fresh cycle
   discards any staging left by a previously ABORTED reload. Production never hot-
-  reloads, so this never fires there."
+  reloads (shadow installs no `^:dev/before-load` hook in a release build), so
+  this never fires there and its body folds away with the ledger (rf2-k9yuy)."
   ([] (notify-reload! (current-build-id)))
   ([build-id]
-   (swap! ledger-state assoc-in [:cycles build-id] {:staged {} :touched #{}})
+   (when reload-ledger?
+     (swap! ledger-state assoc-in [::cycles build-id] {:staged {} :touched #{}}))
    nil))
 
 (defn note-reloaded-sources!
@@ -953,22 +1021,24 @@
   the signal a zero-declaration source cannot emit for itself, fed in the shipped
   browser reload path by `reload-source-reset!` (the SHADOW_NS_RESET producer;
   rf2-vxgfnd.77). `sources` is a coll of ns-syms (paired with `build-id`) or
-  ready-made [build ns] pairs. A no-op when no cycle is open; unions into the
-  cycle so it can be called repeatedly."
+  ready-made [build ns] pairs. A no-op when no cycle is open (and, in `:advanced`
+  production, when there is no ledger at all — rf2-k9yuy); unions into the cycle
+  so it can be called repeatedly."
   ([sources] (note-reloaded-sources! sources (current-build-id)))
   ([sources build-id]
-   (swap! ledger-state
-          (fn [{:keys [cycles] :as st}]
-            (if (contains? cycles build-id)
-              (let [pairs (map (fn [s] (if (vector? s) s [build-id s])) sources)]
-                (update-in st [:cycles build-id :touched] (fnil into #{}) pairs))
-              st)))
+   (when reload-ledger?
+     (swap! ledger-state
+            (fn [st]
+              (if (contains? (::cycles st) build-id)
+                (let [pairs (map (fn [s] (if (vector? s) s [build-id s])) sources)]
+                  (update-in st [::cycles build-id :touched] (fnil into #{}) pairs))
+                st))))
    nil))
 
 (defn ^:dev/after-load commit-reload!
   "shadow-cljs hot-reload hook (dev only): COMMIT the open reload cycle for
   `build-id`. The reconciliation AND the cycle close are ONE atomic transition on
-  `ledger-state`: `:sources` is reconciled (staged sources replace their whole
+  `ledger-state`: `::sources` is reconciled (staged sources replace their whole
   contribution; touched-but-unstaged sources are evicted; untouched sources are
   kept) and the cycle is removed in the SAME swap. Only then is the aggregate
   published.
@@ -986,22 +1056,23 @@
   cycle is open."
   ([] (commit-reload! (current-build-id)))
   ([build-id]
-   (let [[old _new]
-         (swap-vals! ledger-state
-                     (fn [{:keys [sources cycles] :as st}]
-                       (if-let [{:keys [staged touched]} (get cycles build-id)]
-                         (-> st
-                             (assoc :sources
-                                    (reconcile-sources sources staged touched))
-                             (update :cycles dissoc build-id))
-                         st)))]
-     ;; Publish only when THIS commit closed a cycle (the winning transition saw
-     ;; one in `old`). The cycle is gone from the ledger, so a reentrant
-     ;; registration during the publish takes the write-through path — it cannot
-     ;; be recaptured or dropped by this commit. `publish!` recomputes from the
-     ;; LIVE ledger, so a concurrent write-through's row is never clobbered.
-     (when (contains? (:cycles old) build-id)
-       (publish!)))
+   (when reload-ledger?
+     (let [[old _new]
+           (swap-vals! ledger-state
+                       (fn [st]
+                         (if-let [{:keys [staged touched]} (get (::cycles st) build-id)]
+                           (-> st
+                               (assoc ::sources
+                                      (reconcile-sources (::sources st) staged touched))
+                               (update ::cycles dissoc build-id))
+                           st)))]
+       ;; Publish only when THIS commit closed a cycle (the winning transition saw
+       ;; one in `old`). The cycle is gone from the ledger, so a reentrant
+       ;; registration during the publish takes the write-through path — it cannot
+       ;; be recaptured or dropped by this commit. `publish!` recomputes from the
+       ;; LIVE ledger, so a concurrent write-through's row is never clobbered.
+       (when (contains? (::cycles old) build-id)
+         (publish!))))
    nil))
 
 ;; ---------------------------------------------------------------------------
@@ -1144,27 +1215,35 @@
 
 (defn reset-custom-elements!
   "Test support: clear the runtime custom-element registry, the per-source
-  ledger, and any in-flight reload cycles."
+  ledger, and any in-flight reload cycles. In `:advanced` production there is no
+  ledger to clear, so only the aggregate is reset (rf2-k9yuy)."
   []
   (reset! custom-elements {})
-  (reset! ledger-state {:sources {} :cycles {}})
+  (when reload-ledger?
+    (reset! ledger-state empty-ledger))
   nil)
 
 (defn in-flight-cycles
   "Test support: the set of build-ids with a reload cycle currently OPEN. A
   quiescent ledger has none; a lingering entry after a commit settles is an
-  orphan cycle. Observability only — not a consumer API (classification reads
-  `custom-element-properties`)."
+  orphan cycle. Always empty where there is no ledger (`:advanced` production
+  can never open a cycle). Observability only — not a consumer API
+  (classification reads `custom-element-properties`)."
   []
-  (set (keys (:cycles @ledger-state))))
+  (if reload-ledger?
+    (set (keys (::cycles @ledger-state)))
+    #{}))
 
 (defn projected-aggregate
   "Test support: the aggregate the public `custom-elements` atom MUST equal — the
-  pure projection of the current ledger `:sources`. A settled ledger's published
+  pure projection of the current ledger `::sources`. A settled ledger's published
   aggregate always equals this; a divergence is a torn or clobbered projection.
-  Observability only."
+  Where there is no ledger (`:advanced` production) registrations write straight
+  through, so the live aggregate IS the projection. Observability only."
   []
-  (aggregate (:sources @ledger-state)))
+  (if reload-ledger?
+    (aggregate (::sources @ledger-state))
+    @custom-elements))
 
 (defn custom-element-properties [tag]
   (get-in @custom-elements [tag :properties] #{}))

--- a/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_digest_carrier_jvm_test.clj
@@ -277,15 +277,18 @@
   ;; forcing Shadow to recompile it after re-frame.ui observed the schedule. If
   ;; that source removed its final ui/defview it contributes nothing, and —
   ;; pre-fix — its accepted row survived as a ghost view because it was never
-  ;; pre-touched. The :compile-finish reconcile against Shadow's CAUSAL per-source
-  ;; compile evidence (a `:cached false` finish output whose `:js` artifact is a
-  ;; fresh object) evicts it.
+  ;; pre-touched. The :compile-finish reconcile evicts it: the whole-map
+  ;; replacement dropped re-frame.ui's per-pass MARKER, and re-frame.ui's own
+  ;; analyzer-pass COMPILE WITNESS saw Shadow's compiler analyze the source.
   ;;
   ;; The forced recompile here carries a `:compiled-at` stamp EQUAL to the prepare
   ;; snapshot (a same-millisecond `System/currentTimeMillis`) and byte-identical
-  ;; `:js`, so nothing but Shadow's fresh-object provenance distinguishes it from a
-  ;; warm hit. A `(> now then)` stamp test would read it as untouched and leave the
-  ;; ghost; the causal test evicts it.
+  ;; `:js`, so no wall-clock or `:js`-identity test can tell it from a warm hit:
+  ;; a `(> now then)` stamp test reads it as untouched and leaves the ghost. Only
+  ;; the marker-plus-witness pair — neither of which is a timestamp, and neither
+  ;; of which a replacement controls — evicts it. `finish`'s `extra-compiled`
+  ;; drives the installed analyzer pass (see the helper), which is exactly how the
+  ;; witness observes the compile.
   (doseq [parallel? [true false]]
     (testing (str (if parallel? "parallel" "sequential") " compilation")
       (let [good (-> (two-source-state :ghost parallel?)
@@ -318,8 +321,10 @@
                                      {:resource-id app-a-rid
                                       :js (fresh-js "app.a = {};")
                                       :compiled-at 1000 :cached false})
-                           ;; Shadow genuinely recompiled app-a this pass, so it is
-                           ;; in Shadow's causal `::build-info :compiled` record.
+                           ;; Shadow genuinely recompiled app-a this pass, so
+                           ;; `finish` runs its forms through the installed
+                           ;; analyzer pass — that is what re-frame.ui's own
+                           ;; compile witness records.
                            (finish #{app-a-rid}))]
           (is (not (contains?
                     (get-in prepared [:compiler-env build/scratch-key :touched])
@@ -382,9 +387,10 @@
                                      {:resource-id app-a-rid
                                       :js (fresh-js "app.a = {};")
                                       :compiled-at 1 :cached false})
-                           ;; app-a genuinely recompiled (backwards stamp) — in
-                           ;; Shadow's causal `::build-info :compiled` record; app-b
-                           ;; is a warm hit (marker preserved), never in it.
+                           ;; app-a genuinely recompiled (backwards stamp), so
+                           ;; `finish` analyzes it and the compile witness records
+                           ;; it; app-b is a warm hit (marker preserved), never
+                           ;; analyzed and never witnessed.
                            (finish #{app-a-rid}))
               views-after (build/accepted-aggregate build/views finished)]
           (is (not (contains?
@@ -633,8 +639,8 @@
         ;; app.b's output and app.b genuinely recompiles — a FRESH output map at
         ;; the SAME `:compiled-at` — after its final defview was removed,
         ;; contributing nothing. app.b is evicted; app.a stays a cache hit. The
-        ;; marker (dropped by the whole-map replacement) plus Shadow's causal
-        ;; `::build-info :compiled` record distinguish this genuine recompile from
+        ;; marker (dropped by the whole-map replacement) plus re-frame.ui's own
+        ;; analyzer-pass compile witness distinguish this genuine recompile from
         ;; arm 1's marker-preserving annotation — with no `:compiled-at` compare.
         (let [prepared (prepare warm-input)
               finished (-> prepared
@@ -774,14 +780,16 @@
   ;; rf2-8nn5k (violation 2 — UNFORGEABLE): a later NON-scheduling hook replaces an
   ;; ENTIRE retained output map, copying Shadow's sticky `:cached false` and output
   ;; data into a fresh map while dropping re-frame.ui's unknown private marker — and
-  ;; schedules NO compilation, so the source is NOT in Shadow's own
-  ;; `[:shadow.build/build-info :compiled]` record. Pre-fix, finish trusted the
+  ;; schedules NO compilation, so Shadow's compiler never analyzes the source and
+  ;; re-frame.ui's compile witness never records it. Pre-fix, finish trusted the
   ;; output map's forgeable `:cached false` and classified the replacement a compile,
   ;; pre-touched the warm source, and EVICTED its valid accepted view (changing the
   ;; whole-build digest) on a pass that compiled nothing. Now the marker-absent
-  ;; verdict consults Shadow's causal compile record rather than `:cached`, so the
+  ;; verdict consults that witness rather than `:cached`, so the
   ;; forged whole-map replacement fails loud BEFORE publication and the accepted
-  ;; view/digest survive. Both equal-byte and changed-byte forgeries; both schedules.
+  ;; view/digest survive. The witness lives OUTSIDE `[:output rid]`, which is the
+  ;; whole reason a replacement cannot forge it.
+  ;; Both equal-byte and changed-byte forgeries; both schedules.
   (doseq [parallel? [true false]
           [byte-label forged-js] [[:equal-bytes "app.b = {};"]
                                   [:changed-bytes "app.b = {/* forged */};"]]]
@@ -806,7 +814,8 @@
             prepared (prepare warm-input)
             ;; The forgery: a fresh output MAP built from Shadow's public fields
             ;; (no re-frame.ui marker), copying the sticky :cached false. `finish`
-            ;; is NOT told app.b compiled (it is not in ::build-info :compiled).
+            ;; is NOT told app.b compiled, so it never runs app.b's forms through
+            ;; the installed analyzer pass and the compile witness stays silent.
             forged-b {:resource-id app-b-rid :js (fresh-js forged-js)
                       :compiled-at 1000 :cached false}
             ex (try (-> prepared (assoc-in [:output app-b-rid] forged-b) finish)

--- a/implementation/ui/test/re_frame/ui/custom_element_reload_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/custom_element_reload_elision_prod_test.cljs
@@ -52,3 +52,35 @@
   (is (= #{:p} (rules/custom-element-properties :prod-el))
       "production registration is a direct write-through, immediately live")
   (rules/reset-custom-elements!))
+
+(deftest no-reload-ledger-state-exists-in-advanced-production
+  ;; rf2-k9yuy — the CAUSAL half of the ledger-elision proof (the lexical half is
+  ;; the `re-frame.ui.rules/sources` + `re-frame.ui.rules/cycles` bundle grep in
+  ;; scripts/check-ui-mounted-prod-elision.cjs).
+  ;;
+  ;; Before rf2-k9yuy `ledger-state` was an unconditional `defonce (atom
+  ;; {:sources {} :cycles {}})` and EVERY production registration `swap-vals!`'d
+  ;; against it before updating the aggregate — hidden bookkeeping a consumer
+  ;; shipped and paid for, invisible to the visible-classification assertions
+  ;; above. The gate now folds the ledger out of `:advanced`, so the private var
+  ;; holds NO atom at all.
+  ;;
+  ;; Reading the PRIVATE var directly is the point: a renamed-but-still-rooted
+  ;; successor atom would satisfy every public assertion in this namespace, so the
+  ;; oracle has to look where the residue would actually live. The marker string
+  ;; below is asserted PRESENT in the release bundle by the same scanner, proving
+  ;; this deftest was really compiled into the artefact rather than dropped.
+  (let [marker "rf-ui-custom-element-reload-ledger-absent-v1"]
+    (rules/reset-custom-elements!)
+    (is (nil? @#'rules/ledger-state)
+        (str marker " — the reload ledger var holds no atom in advanced production"))
+    (rules/register-custom-element! :ledger-probe-el {:properties #{:q}} 'app.ledger-probe)
+    (is (nil? @#'rules/ledger-state)
+        (str marker " — registration allocated no ledger on the way to the aggregate"))
+    (is (= #{:q} (rules/custom-element-properties :ledger-probe-el))
+        "and the one direct aggregate update still classified the element")
+    (is (= #{} (rules/in-flight-cycles))
+        "no cycle can be open where there is no ledger")
+    (is (= @rules/custom-elements (rules/projected-aggregate))
+        "with no ledger the live aggregate IS the projection")
+    (rules/reset-custom-elements!)))

--- a/implementation/ui/test/re_frame/ui/frame_ops_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/frame_ops_cljs_test.cljc
@@ -95,8 +95,10 @@
   (let [b1 (rf/with-frame :ops/stable (frames/frame-ops))
         b2 (rf/with-frame :ops/stable (frames/frame-ops))]
     (is (identical? b1 b2)
-        "repeated reads return the IDENTICAL bundle — one map lookup, no
-         per-render construction")
+        "repeated reads return the IDENTICAL bundle — a cache HIT constructs
+         nothing (no bundle mint, no closure allocation); it is a bounded
+         lifecycle+cache read: incarnation token, closing check, cache entry,
+         token identity compare")
     (is (identical? (:dispatch b1) (:dispatch b2)))
     (is (identical? (:subscribe b1) (:subscribe b2)))))
 

--- a/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
@@ -384,7 +384,7 @@
   (rules/register-custom-element! :seed-el {:properties #{:s3}} 'app.seed)
   (rules/commit-reload!)
   (is (= #{:r} (rules/custom-element-properties :reentrant-el))
-      "the reentrant row is in :sources, so a subsequent unrelated reload keeps it"))
+      "the reentrant row is in ::sources, so a subsequent unrelated reload keeps it"))
 
 (deftest reentrant-registration-applies-exactly-once-never-doubled
   ;; The reentrant registration must not be applied twice (once as a stray

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -288,10 +288,13 @@
   ;;     AND direction-2 completeness (a NEW public Var added without a row → RED,
   ;;     so an accidental future public export cannot accumulate silently). It
   ;;     joins the three adapter namespaces in the probe's `:fully-rowed` set.
-  ;;     Hence :runtime-verified? true. The later-stage verbs (local / effect /
-  ;;     dispatch-fn / presence / presence-phase / ->react / error-boundary /
-  ;;     client-only) are NOT yet defined and stay on the
-  ;;     :api-md-known-unmanifested allowlist below until they ship. Tiers are
+  ;;     Hence :runtime-verified? true. The later-stage verbs named here when
+  ;;     this note was written have since SHIPPED and are rowed below —
+  ;;     local / effect / dispatch-fn (S3), error-boundary / client-only (S3),
+  ;;     presence / presence-phase (S4). `->react` (S6) is the ONE remaining
+  ;;     spec/API.md §Compiled views verb with no live Var, so it is the only
+  ;;     re-frame.ui entry left on the :api-md-known-unmanifested allowlist
+  ;;     below. Tiers are
   ;;     verbatim from spec/API.md §Compiled views; :kind is the source form
   ;;     (html is a `defn`, not a macro).
   ;;     `frame` (rf2-vxgfnd.184) is the S2 compiled ops-bundle body form —
@@ -427,8 +430,9 @@
    ;; move it into a :cljs-only row (and delete its entry here) when it lands.
    ;; local / effect / dispatch-fn shipped S3 (rf2-vxgfnd.95.2) — now rowed
    ;; under :cljs-only above.
-   "presence"               ; spec/API.md §Compiled views — S4 enter/exit retention, unshipped
-   "presence-phase"         ; spec/API.md §Compiled views — S4 presence-phase read, unshipped
+   ;; presence / presence-phase shipped S4 (rf2-uckeg) — now rowed under
+   ;; :cljs-only above, so they left this allowlist and their API.md tier is
+   ;; reconciled against the manifest like every other shipped verb.
    "->react"}               ; spec/API.md §Compiled views — S6 React-component export bridge, unshipped
    ;; error-boundary / client-only shipped S3 (rf2-vxgfnd.95.3) — now rowed
    ;; under :cljs-only above (alongside handler).


### PR DESCRIPTION
Three small `implementation/ui` accuracy fixes, one commit each. Two are
comment-only; the middle one changes production emission.

## rf2-cj5js — frame-cost and manifest-probe commentary

**Claimed vs actual.** The `(frame)` overview and the stable-identity test
said a cached frame-ops read is "one map lookup". The shipped path
(`frame-ops-for`) reads the incarnation token, rejects a nil/closing
incarnation, reads the cache entry, and compares token identity. Both now
say a cache HIT constructs nothing but performs a bounded lifecycle+cache
read — and that those liveness reads are load-bearing for the stale-bundle
fence, not overhead.

The manifest metadata called seven verbs "NOT yet defined" and allowlisted
while every one of them is rowed below it. `->react` (S6) is the only verb
still unshipped, so it is now the only `re-frame.ui` entry on
`:api-md-known-unmanifested`; `presence` / `presence-phase` leave the
allowlist and their API.md tier is reconciled like every other shipped verb.

The CLJS fully-rowed probe's three inventories of the blessed export set
stopped at the first four S3 additions. They now reference the ONE
authoritative enumeration (`export-surface-is-exactly-the-blessed-set`)
rather than maintaining a second hand-written list that drifts each stage.

## rf2-k9yuy — reload-ledger elision (the one with teeth)

**Premise verified first.** On origin/main, the `:advanced` +
`goog.DEBUG=false` browser-test bundle contained the ledger's `:sources`,
`:cycles`, `:staged` and `:touched` keyword literals. The ledger shipped.
(The producer and build-id lookup were already gated by #6018 —
`reFrameUiReloadSourceReset` and `shadow.cljs.devtools.client.env.build_id`
measured absent.)

A private compile-time `reload-ledger?` gate folds the ledger out of
production: no atom allocated, no staging branch, no reload-hook body. What
remains is the one direct `custom-elements` update the registration needs.
Dev keeps the ledger unchanged; the JVM arm is unconditionally `true` (not
`interop/debug-enabled?`, which `-Dre-frame.debug=false` can flip) so
compiler and tree-builder fixtures keep working.

The ledger's root keys become namespace-qualified (`::sources` / `::cycles`)
so the elision has an unambiguous grep — bare `:sources` / `:cycles` collide
across the corpus.

**Elision proof.** Artefact greppped:
`implementation/out/browser-test-prod-elision/js/test.js` (the real
`:advanced` release bundle, 2.26 MB — not the `out/node-test.js` loader).

| build | `re-frame.ui.rules/sources` | `re-frame.ui.rules/cycles` |
|---|---|---|
| after this change (`goog.DEBUG=false`) | 0 | 0 |
| same build, `goog.DEBUG=true` (ledger reintroduced) | 1 | 1 |

So the grep reds when the ledger comes back. `re-frame.ui.rules/default`
still survives in the production bundle, proving the namespace IS compiled
in and the absence is real elision, not namespace-absence.

`scripts/check-ui-mounted-prod-elision.cjs` now carries that grep, plus
source positive controls (the qualified keys and the gate must still exist
in `rules.cljc`). The causal oracle in the production companion reads the
PRIVATE `ledger-state` var and asserts it holds no atom before and after a
registration that still classifies — a renamed-but-rooted successor would
satisfy every public assertion, so the oracle looks where residue lives. Its
marker is asserted PRESENT in the bundle so the deftest cannot be silently
dropped. The dev-positive control is `rules-cljs-test` (node,
`goog.DEBUG=true`), which stages, reconciles and commits real reload cycles
through those same keys.

Incidental finding: the causal oracle reifies `#'rules/ledger-state`, which
carries that var's `:doc` into the release bundle. The first sentinel draft
spelled the fully-qualified grep strings in that docstring and defeated its
own grep (measured 2 hits, all docstring). The docstring now delegates them
to the scanner.

## rf2-fm8bf — build-hook authority comments

`rf2-suz5b` replaced Shadow's timestamp-derived
`[:shadow.build/build-info :compiled]` set with re-frame.ui's `cljs.analyzer`
pass witness, recorded outside the `[:output rid]` map a replacement
controls. The runtime and the `finish` helper's docstring already said so;
six surrounding comments still taught the retired mechanism, sitting exactly
where the mechanism is learned.

The namespace overview no longer closes the later-hook gap with "Shadow's
compile record" two paragraphs after declaring that record deliberately
unused; the fixtures no longer call a `:cached false` output with a fresh
`:js` object "Shadow's causal compile evidence", and no longer claim a
manually driven source is in a set the helper never writes (it drives the
installed analyzer pass instead). Red-before statements stay clearly
historical.

## Quality gates

All foreground, run to completion, non-zero counts confirmed.

| gate | result |
|---|---|
| `implementation/ui` `clojure -M:test` | **901 tests / 15785 assertions**, 0 failures, 0 errors |
| `npm run test:cljs` | **10053 tests / 49566 assertions**, 0 failures, 0 errors |
| `npm run test:elision` | PASS — production 60/60 absent, control 60/60 present |
| `npm run test:bundle-isolation` | PASS — 22 artefacts, 38 sentinels absent, 38 positive controls present |
| `npm run test:adapter-smokes` | PASS — 3 adapter-smoke specs, 0 failures |
| api-manifest `gen --check` | OK — 517 public vars in sync |
| api-manifest `api-md-check` | OK — 217 var-rows checked |
| api-manifest `clojure -M:test` | 104 tests / 229 assertions, 0 failures |
| `shadow-cljs release browser-test-prod-elision` + ledger grep | 0/0 absent; 1/1 present in the DEBUG=true mutation control |

The full `test:browser-prod-elision` gate (Playwright + the renamed-state
mutant build) is CI-owned; the release build and bundle grep it depends on
were run here directly.

## Adjacent, named not fixed

- `presence` is documented `M` (macro) in `spec/API.md` §Compiled views but
  rowed `:kind :fn` in the manifest, matching the source (a resolution-only
  `defn`). The documented-kind guard covers only the four root-lifecycle
  verbs, so nothing is red — but the marker looks wrong. `spec/API.md` and
  the S4 profile are fenced to rf2-vxcl7 this round.
- A `defonce` var whose `:doc` metadata is reified by a `#'` read ships that
  docstring into `:advanced` bundles. Only observed for the two vars read
  this way (`ledger-state`, and by the same shape `tool.evidence/state*`);
  ordinary `defn` docstrings strip normally. Small, but it means prose on a
  reified var is production bytes.
