### PR TITLE
fix(ui): close the runtime spread prop-smuggling path (rf2-5pr75)

### DIFF
--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -1365,3 +1365,82 @@
                :else
                (assoc acc (keyword (caller-key-name k)) v))))
          {} caller)))))
+
+;; ---------------------------------------------------------------------------
+;; ui/spread + ui/spread-safe — the RUNTIME rejected-spelling deny (EVERY build)
+;;
+;; `rejected-prop-spellings` ("one spelling per name, and it is a node variant")
+;; is enforced on LITERAL props by the analyzer (`check-rejected-spelling!`),
+;; which cannot see a prop map assembled at RUNTIME. A `(ui/spread base
+;; overrides)` map therefore reached the host converters unchecked, and
+;; `react-prop-name` passes an unrecognized name VERBATIM — so
+;; `{:dangerouslySetInnerHTML #js {:__html s}}` landed in React's raw-markup
+;; slot with NO visible `(ui/html …)` trust assertion anywhere in the source
+;; (rf2-5pr75). The deny below closes that at the ONE runtime seam both hosts
+;; fold a spread map through (`runtime/convert-prop-map!` on CLJS,
+;; `tree/fold-dyn-entry` on the JVM), so `ui/spread` and the `ui/spread-safe`
+;; caller map are covered together.
+;; ---------------------------------------------------------------------------
+
+(def ^:private rejected-prop-slots
+  "`rejected-prop-spellings` reduced to the canonical emitted SLOTS the host
+  converters actually write into (`caller-key-slot` — the same rf2-xdvob
+  canonicalization the spread-safe owned-key deny compares), each mapped to the
+  didactic replacement its compile error names.
+
+  Comparing SLOTS rather than literal keywords is what makes the deny TOTAL for
+  the one spelling that carries a trust boundary: every alias of React's
+  raw-markup prop — `\"dangerouslySetInnerHTML\"`, `'dangerouslySetInnerHTML`,
+  the namespaced `:x/dangerouslySetInnerHTML` — reduces to the SAME slot and is
+  denied, while a spelling that reduces to any OTHER slot (`:dangerouslysetinnerhtml`)
+  cannot reach React's slot at all and needs no deny. No legitimate prop
+  collides: `:class` slots to `className` and `:for` to `htmlFor`, distinct from
+  the rejected `:class-name` / `:html-for`."
+  (into {}
+        (keep (fn [[k replacement]]
+                (when-some [slot (caller-key-slot k)] [slot replacement])))
+        rejected-prop-spellings))
+
+(defn spread-rejected-key?
+  "Is runtime prop key `k` a rejected spelling — the runtime twin of the
+  analyzer's literal `check-rejected-spelling!`? Compares `k`'s canonical
+  emitted slot, so every alias reaches the same verdict on both hosts. A
+  non-nameable key has no slot and is not 'rejected' here (the converters
+  report it through their own channel)."
+  [k]
+  (contains? rejected-prop-slots (caller-key-slot k)))
+
+(defn assert-spread-prop-key!
+  "EVERY-BUILD deny for ONE prop key arriving through a RUNTIME prop map — a
+  `(ui/spread base overrides)` map or a `(ui/spread-safe owned caller)` caller
+  map. A rejected spelling throws `:rf.error/ui-tree-malformed`, NOT
+  `goog.DEBUG`-gated, so an `:advanced` production build is exactly as safe as
+  dev — the same production-reachability the sibling `assert-safe-caller!`
+  owned-key deny has, and the only defensible choice for a key whose whole
+  meaning is 'bypass HTML escaping'.
+
+  The key is denied on PRESENCE, value irrelevant: `rejected-prop-spellings`
+  rejects the NAME, so a nil value is still an illegal spelling, and a
+  value-dependent guard would be a trust check with a hole in it.
+
+  DENY, not silently drop. Dropping would be fail-safe against injection but
+  invisible twice over: an author who MEANT raw markup would ship a silently
+  empty element, and an author who did NOT would never learn their forwarded
+  prop map carries a smuggled key. The message names the escape — `(ui/html …)`,
+  the visible trust assertion — exactly as the compile error does.
+
+  `re-frame.ui` sanitises NOTHING: the fix is not to clean the markup but to
+  require it be asserted at a visible site."
+  [k]
+  (when-some [replacement (get rejected-prop-slots (caller-key-slot k))]
+    (error/throw-error!
+     :rf.error/ui-tree-malformed 're-frame.ui/spread
+     (str "a runtime spread prop map may not carry " (pr-str k)
+          ": it is not a prop — one spelling per name, ambiguities removed — and "
+          "the rule holds for a map assembled at RUNTIME exactly as it does for "
+          "literal props, which the compiler checks and this map it cannot see. "
+          "Use " replacement ". An alternate spelling (kebab, already-camel, a "
+          "namespaced keyword, string, or symbol) canonicalizes to the same "
+          "emitted slot and is denied too, so raw markup can never reach the DOM "
+          "without the visible (ui/html ...) trust assertion at the site")
+     {:extra {:key k}})))

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -410,12 +410,19 @@
   rule table (shared by `spread->props` and `spread-safe->props`): :class
   composes (`sugar-classes` first when supplied), :style px/name rules, on-*
   runtime handler classification, custom-element property classification by
-  `tag`, all other names through the attr conversion table. Returns `o`."
+  `tag`, all other names through the attr conversion table. Returns `o`.
+
+  Every key is FIRST put through `rules/assert-spread-prop-key!` — the runtime
+  half of the analyzer's literal rejected-spelling deny, which cannot see a map
+  built at runtime (rf2-5pr75). It runs BEFORE the cond (so no later branch —
+  including the custom-element property branch — can route around it) and in
+  EVERY build (so production is never less safe than dev)."
   [o tag sugar-classes m event-site-key debug-site]
   (let [property? (rules/custom-element-properties (keyword tag))]
     (when (and (some? sugar-classes) (not (contains? m :class)))
       (unchecked-set o "className" sugar-classes))
     (doseq [[k v] m]
+      (rules/assert-spread-prop-key! k)
       (let [n (name k)]
         (cond
           (= k :key)

--- a/implementation/ui/src/re_frame/ui/tree.cljc
+++ b/implementation/ui/src/re_frame/ui/tree.cljc
@@ -172,8 +172,16 @@
   accumulator via the rule table shared by `ui/spread`, `ui/spread-safe`, and
   the JVM tree builder: on-* -> events, :class merges, :style normalizes,
   :key/:ref skipped, custom-element `properties` classified. `properties` is
-  the tag's property set (nil for plain DOM)."
+  the tag's property set (nil for plain DOM).
+
+  Every key is FIRST put through `rules/assert-spread-prop-key!` — the JVM twin
+  of the CLJS `runtime/convert-prop-map!` guard, the runtime half of the
+  analyzer's literal rejected-spelling deny (rf2-5pr75). A LITERAL element's
+  per-prop dynamic values also fold through here, but their keys are literal and
+  the analyzer already rejected those spellings, so the guard can only fire on a
+  key that arrived inside a runtime map."
   [properties [m es pp] k v]
+  (rules/assert-spread-prop-key! k)
   (let [n (name k)]
     (cond
       (nil? v)                   [m es pp]

--- a/implementation/ui/test/re_frame/ui/spread_rejected_prop_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/spread_rejected_prop_cljs_test.cljc
@@ -1,0 +1,290 @@
+(ns re-frame.ui.spread-rejected-prop-cljs-test
+  "rf2-5pr75 — the RUNTIME half of the rejected-prop-spelling deny.
+
+  `rules/rejected-prop-spellings` (\"one spelling per name, and it is a node
+  variant\") was enforced only on LITERAL props, by the analyzer. A
+  `(ui/spread base overrides)` map is assembled at RUNTIME, so the compiler
+  cannot see it, and `react-prop-name` passes an unrecognized name VERBATIM —
+  which meant `{:dangerouslySetInnerHTML #js {:__html s}}` reached React's
+  raw-markup slot with NO `(ui/html …)` trust assertion anywhere in the source.
+  That is an injection path in any app that forwards a user-influenced attr map.
+
+  The deny now lives at the ONE runtime seam both hosts fold a spread map
+  through, so this suite runs UNDER BOTH `clojure -M:test` (JVM) and the node
+  `-cljs-test` build, and pins:
+
+    1. the LAW (`rules/spread-rejected-key?` / `assert-spread-prop-key!`) —
+       canonical-SLOT comparison, so every alias of React's raw-markup prop is
+       denied and no legitimate prop collides;
+    2. the SEAM per host — `runtime/spread->props` (CLJS) and `tree/element`'s
+       `:dyn` fold (JVM), reached via `base` AND via `overrides`, plus the
+       `ui/spread-safe` caller map, which shares the seam;
+    3. the END-TO-END injection proof — a compiled view rendered through real
+       react-dom/server must not emit the hostile markup (CLJS only: the JVM
+       emitter has no React);
+    4. the POSITIVE CONTROLS — `(ui/html …)` still renders raw markup, both
+       alone and alongside a `ui/spread` on the same element (the rf2-29s75
+       composition), on both hosts.
+
+  Advanced-build reachability (the deny is NOT `goog.DEBUG`-gated) rides
+  spread_rejected_prop_elision_prod_test."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.rules :as rules]
+            #?@(:clj  [[re-frame.ui.tree :as tree]]
+                :cljs [["react-dom/server" :as rds]
+                       [re-frame.ui.runtime :as rt]])))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures — compiled views (both emitters compile this file)
+;; ---------------------------------------------------------------------------
+
+(defview spread-only
+  "A spread element with NO positional children — the shape where a smuggled
+  \"children\" slot is not overwritten by the jsx child attach either."
+  [{:keys [extra]}]
+  [:div.card (ui/spread {:data-a "b"} extra)])
+
+(defview spread-base-only
+  "The same element with the hostile map arriving as `base` rather than
+  `overrides` — both spread arguments merge into the one runtime map."
+  [{:keys [hostile]}]
+  [:div.card (ui/spread hostile {:data-a "b"})])
+
+(defview spread-trusted-control
+  "POSITIVE CONTROL — `ui/spread` and `ui/html` COMPOSE (rf2-29s75). The deny
+  must not touch the compiler-owned raw-markup prop, which is attached at the
+  visible `(ui/html …)` site, outside the runtime prop map."
+  [{:keys [extra markup]}]
+  [:div.raw (ui/spread {:data-a "b"} extra) (ui/html markup)])
+
+(defview trusted-control
+  "POSITIVE CONTROL — `ui/html` alone, the sanctioned escaping bypass."
+  [{:keys [markup]}]
+  [:div.content (ui/html markup)])
+
+(def hostile-markup "<img src=x onerror=alert(1)>")
+
+(def rejected-spellings
+  "The literal author keywords the analyzer rejects — every one must be denied
+  in a runtime map too."
+  [:class-name :html-for :dangerously-set-inner-html :dangerouslySetInnerHTML
+   :inner-html :children])
+
+(def dangerous-aliases
+  "Alternate spellings that all canonicalize to React's ACTUAL raw-markup slot.
+  These are the security-load-bearing rows: the slot is what reaches the DOM."
+  [:dangerouslySetInnerHTML
+   "dangerouslySetInnerHTML"
+   'dangerouslySetInnerHTML
+   :caller/dangerouslySetInnerHTML])
+
+;; ---------------------------------------------------------------------------
+;; 1. The law
+;; ---------------------------------------------------------------------------
+
+(defn- denied-data [f]
+  (try (f) nil
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e (ex-data e))))
+
+(defn- denied? [k]
+  (= :rf.error/ui-tree-malformed
+     (:rf.error/id (denied-data #(rules/assert-spread-prop-key! k)))))
+
+(deftest every-rejected-spelling-is-denied-in-a-runtime-map
+  (testing "the analyzer's literal deny set is denied at runtime too"
+    (doseq [k rejected-spellings]
+      (is (rules/spread-rejected-key? k) (str "rejected: " (pr-str k)))
+      (is (denied? k) (str "throws: " (pr-str k))))))
+
+(deftest the-deny-compares-canonical-emitted-slots
+  (testing "every alias of React's raw-markup SLOT is denied"
+    (doseq [k dangerous-aliases]
+      (is (= "dangerouslySetInnerHTML" (rules/caller-key-slot k))
+          (str "canonical slot of " (pr-str k)))
+      (is (denied? k) (str "denied: " (pr-str k)))))
+  (testing "every alias of the children slot is denied"
+    (doseq [k [:children "children" 'children :x/children]]
+      (is (denied? k) (str "denied: " (pr-str k)))))
+  (testing "a spelling that canonicalizes ELSEWHERE cannot reach React's slot"
+    ;; React prop names are case-sensitive, so these are inert attributes, not
+    ;; the raw-markup slot — denying them would be theatre, not safety.
+    (doseq [k [:dangerouslysetinnerhtml :DangerouslySetInnerHTML]]
+      (is (not= "dangerouslySetInnerHTML" (rules/caller-key-slot k)))
+      (is (not (denied? k))))))
+
+(deftest legitimate-props-are-untouched
+  (testing "no legitimate prop collides with a rejected slot"
+    ;; :class slots to className and :for to htmlFor — distinct from the
+    ;; rejected :class-name / :html-for, so the deny cannot false-positive.
+    (doseq [k [:class :for :style :title :key :ref :value :checked
+               :on-click :on-change :data-x :aria-label :tab-index :href :id]]
+      (is (not (rules/spread-rejected-key? k)) (str "allowed: " (pr-str k)))
+      (is (not (denied? k)) (str "allowed: " (pr-str k)))))
+  (testing "a non-nameable key has no slot and is not denied HERE"
+    (doseq [k [nil false 5]]
+      (is (not (rules/spread-rejected-key? k)))
+      (is (not (denied? k))))))
+
+(deftest the-deny-is-on-key-presence-not-value
+  (testing "a nil value does not excuse an illegal spelling"
+    (is (denied? :dangerouslySetInnerHTML))
+    (is (= :rf.error/ui-tree-malformed
+           (:rf.error/id (denied-data
+                          #(rules/assert-spread-prop-key! :dangerouslySetInnerHTML)))))))
+
+(deftest the-message-names-the-escape
+  (let [d (denied-data #(rules/assert-spread-prop-key! :dangerouslySetInnerHTML))]
+    (is (= :rf.error/ui-tree-malformed (:rf.error/id d)))
+    (is (= 're-frame.ui/spread (:where d)))
+    (is (str/includes? (:reason d) "(ui/html ...)"))
+    (is (= :dangerouslySetInnerHTML (:key d))))
+  (testing ":children names positional children"
+    (is (str/includes? (:reason
+                        (denied-data #(rules/assert-spread-prop-key! :children)))
+                       "positional children")))
+  (testing ":class-name names :class"
+    (is (str/includes? (:reason
+                        (denied-data #(rules/assert-spread-prop-key! :class-name)))
+                       ":class"))))
+
+;; ---------------------------------------------------------------------------
+;; 2. The host seams
+;; ---------------------------------------------------------------------------
+
+(defn- convert
+  "Fold a runtime prop map through THIS host's spread seam, exactly as the
+  emitted code does. Returns nil on success (we only assert deny/allow here)."
+  [m]
+  #?(:clj  (do (tree/element :div {:static {:class "card"} :dyn m}) nil)
+     :cljs (do (rt/spread->props "div" nil m nil [:site "p"] nil) nil)))
+
+(defn- convert-safe
+  "Fold a `ui/spread-safe` CALLER map through this host's seam — the sibling
+  spread form shares `convert-prop-map!` / `fold-dyn-entry`."
+  [caller]
+  #?(:clj  (do (tree/element :div {:static {:class "card"}
+                                   :spread-safe {:caller caller
+                                                 :owned-handler-keys #{}}})
+               nil)
+     :cljs (do (rt/spread-safe->props "div" caller #{} [:site "p"] nil) nil)))
+
+(defn- seam-denied? [f m]
+  (= :rf.error/ui-tree-malformed (:rf.error/id (denied-data #(f m)))))
+
+(deftest the-seam-denies-every-rejected-spelling
+  (testing "ui/spread — the shared runtime converter"
+    (doseq [k rejected-spellings]
+      (is (seam-denied? convert {k hostile-markup})
+          (str "spread seam denies " (pr-str k)))))
+  (testing "ui/spread-safe caller map — same seam"
+    (doseq [k rejected-spellings]
+      (is (seam-denied? convert-safe {k hostile-markup})
+          (str "spread-safe seam denies " (pr-str k))))))
+
+(deftest the-seam-denies-the-dangerous-aliases
+  (doseq [k dangerous-aliases]
+    (is (seam-denied? convert {k hostile-markup})
+        (str "spread seam denies alias " (pr-str k)))))
+
+(deftest the-seam-passes-a-legitimate-map
+  (testing "an ordinary spread map still converts"
+    (is (nil? (convert {:title "t" :class "c" :data-a "b" :tab-index 3})))
+    (is (nil? (convert-safe {:title "t" :class "c" :aria-label "a"})))))
+
+;; ---------------------------------------------------------------------------
+;; 3. End-to-end — through the real emitters
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (defn- props-obj [m]
+     (reduce-kv (fn [o k v] (unchecked-set o (subs (str k) 1) v) o) #js {} m)))
+
+#?(:cljs
+   (defn- render-html [view m]
+     (rds/renderToStaticMarkup (rt/jsx2 view (props-obj m)))))
+
+(defn- render-denied?
+  "Render a compiled view on THIS host with the given props; did the deny fire?"
+  [view m]
+  (= :rf.error/ui-tree-malformed
+     (:rf.error/id (denied-data
+                    #?(:clj  #(tree/render view m)
+                       :cljs #(render-html view m))))))
+
+(deftest a-compiled-spread-cannot-smuggle-raw-markup
+  (testing "via `overrides`"
+    (is (render-denied? spread-only
+                        {:extra {:dangerouslySetInnerHTML
+                                 #?(:clj  {:__html hostile-markup}
+                                    :cljs #js {:__html hostile-markup})}})))
+  (testing "via `base`"
+    (is (render-denied? spread-base-only
+                        {:hostile {:dangerouslySetInnerHTML
+                                   #?(:clj  {:__html hostile-markup}
+                                      :cljs #js {:__html hostile-markup})}})))
+  (testing "via a string-keyed alias"
+    (is (render-denied? spread-only
+                        {:extra {"dangerouslySetInnerHTML"
+                                 #?(:clj  {:__html hostile-markup}
+                                    :cljs #js {:__html hostile-markup})}})))
+  (testing "a smuggled `children` slot cannot displace positional children"
+    (is (render-denied? spread-only {:extra {:children "smuggled"}}))))
+
+#?(:cljs
+   (deftest the-rendered-markup-carries-no-injection
+     ;; The security assertion proper: whatever the emitter does, the hostile
+     ;; markup must never appear in the served HTML.
+     (doseq [k dangerous-aliases]
+       (let [html (try (render-html spread-only
+                                    {:extra {k #js {:__html hostile-markup}}})
+                       (catch :default _ ""))]
+         (is (not (str/includes? html "<img src=x"))
+             (str "no injection through " (pr-str k) " — got: " html))
+         (is (not (str/includes? html "onerror"))
+             (str "no injection through " (pr-str k)))))))
+
+;; ---------------------------------------------------------------------------
+;; 4. Positive controls — the sanctioned path still works
+;; ---------------------------------------------------------------------------
+
+(def trusted-markup "<b>bold &amp; raw</b>")
+
+#?(:cljs
+   (deftest ui-html-still-renders-raw-markup
+     (testing "ui/html alone"
+       (let [html (render-html trusted-control {:markup trusted-markup})]
+         (is (str/includes? html "<b>bold &amp; raw</b>")
+             (str "trust assertion honoured — got: " html))))
+     (testing "ui/html COMPOSED with ui/spread on the same element (rf2-29s75)"
+       (let [html (render-html spread-trusted-control
+                               {:extra {} :markup trusted-markup})]
+         (is (str/includes? html "<b>bold &amp; raw</b>")
+             (str "spread + html compose — got: " html))
+         (is (str/includes? html "data-a=\"b\"")
+             (str "the spread props still land — got: " html))))
+     (testing "a live spread map alongside ui/html is unaffected"
+       (let [html (render-html spread-trusted-control
+                               {:extra {:title "t"} :markup trusted-markup})]
+         (is (str/includes? html "<b>bold &amp; raw</b>"))
+         (is (str/includes? html "title=\"t\""))))))
+
+#?(:clj
+   (defn- rendered-root
+     "`tree/render` returns the view-boundary wrapper; the element is its
+     sole child."
+     [view props]
+     (get-in (tree/render view props) [:children 0])))
+
+#?(:clj
+   (deftest ui-html-still-renders-raw-markup-on-the-jvm
+     (testing "ui/html alone"
+       (is (= [{:html trusted-markup}]
+              (:children (rendered-root trusted-control {:markup trusted-markup})))))
+     (testing "ui/html COMPOSED with ui/spread on the same element"
+       (let [t (rendered-root spread-trusted-control
+                              {:extra {:title "t"} :markup trusted-markup})]
+         (is (= [{:html trusted-markup}] (:children t)))
+         (is (= "t" (get-in t [:attrs :title])))
+         (is (= "b" (get-in t [:attrs :data-a])))))))

--- a/implementation/ui/test/re_frame/ui/spread_rejected_prop_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/spread_rejected_prop_elision_prod_test.cljs
@@ -1,0 +1,63 @@
+(ns re-frame.ui.spread-rejected-prop-elision-prod-test
+  "rf2-5pr75 — the smallest ADVANCED-PRODUCTION proof that the runtime
+  rejected-prop-spelling deny throws in EVERY build, not dev-only.
+
+  Runs ONLY in `:browser-test-prod-elision` (`:advanced`, goog.DEBUG=false).
+  `re-frame.ui.rules/assert-spread-prop-key!` — invoked by BOTH the CLJS
+  converter (`runtime/convert-prop-map!`, shared by `spread->props` and
+  `spread-safe->props`) and the JVM tree fold, before any prop is set — calls
+  `error/throw-error!` unconditionally, with NO `goog.DEBUG` or
+  diagnostic-channel gate.
+
+  This is the security-load-bearing half of the fix. A `goog.DEBUG`-gated guard
+  would leave PRODUCTION — the only build an attacker meets — as the one place
+  `:dangerouslySetInnerHTML` still reaches React through a runtime spread map.
+  Production must not be less safe than dev, so the deny is unconditional, and
+  this test is what keeps it that way.
+
+  The offending map is read from an atom so the optimizer cannot constant-fold
+  the denied shape away — the throw must survive advanced compilation."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.interop :as interop]
+            [re-frame.ui.rules :as rules]
+            [re-frame.ui.runtime :as rt]))
+
+;; RUNTIME-dynamic values the advanced compiler cannot fold to compile-time
+;; known denied literals.
+(defonce ^:private hostile-spread
+  (atom {:dangerouslySetInnerHTML #js {:__html "<img src=x onerror=alert(1)>"}}))
+(defonce ^:private hostile-key (atom :dangerouslySetInnerHTML))
+
+(defn- ex-of [thunk]
+  (try (thunk) nil (catch :default e (ex-data e))))
+
+(deftest advanced-production-rejected-spread-key-still-throws
+  (testing "the build IS the elided/production regime"
+    (is (false? interop/debug-enabled?)
+        "goog.DEBUG=false — the diagnostic channel is elided in this build"))
+  (testing "yet the rejected-spelling deny is production-reachable"
+    (let [data (ex-of #(rules/assert-spread-prop-key! @hostile-key))]
+      (is (= :rf.error/ui-tree-malformed (:rf.error/id data))
+          "the deny throw survives :advanced + goog.DEBUG=false")
+      (is (= 're-frame.ui/spread (:where data))
+          "thrown as the spread rejected-spelling guard")
+      (is (= :dangerouslySetInnerHTML (:key data))
+          "the offending key is carried through in production too")))
+  (testing "the CONVERTER seam denies it in production, not just the predicate"
+    (let [data (ex-of #(rt/spread->props "div" nil @hostile-spread nil
+                                         [:site "p"] nil))]
+      (is (= :rf.error/ui-tree-malformed (:rf.error/id data))
+          "ui/spread cannot smuggle raw markup in an advanced build"))
+    (let [data (ex-of #(rt/spread-safe->props "div" @hostile-spread #{}
+                                              [:site "p"] nil))]
+      (is (= :rf.error/ui-tree-malformed (:rf.error/id data))
+          "the ui/spread-safe caller map shares the deny in an advanced build")))
+  (testing "alternate spellings of React's raw-markup slot are denied here too"
+    (doseq [k [:caller/dangerouslySetInnerHTML "dangerouslySetInnerHTML" :children]]
+      (let [data (ex-of #(rt/spread->props "div" nil {k "x"} nil [:site "p"] nil))]
+        (is (= :rf.error/ui-tree-malformed (:rf.error/id data))
+            (str "alias denied in the elided build: " (pr-str k))))))
+  (testing "a legitimate spread map still converts in production (no false positive)"
+    (let [o (rt/spread->props "div" nil {:title "t" :class "c"} nil [:site "p"] nil)]
+      (is (= "t" (unchecked-get o "title")))
+      (is (= "c" (unchecked-get o "className"))))))


### PR DESCRIPTION
Fixes **rf2-5pr75** (P2, security-shaped). The runtime `ui/spread` path could smuggle `:dangerouslySetInnerHTML` — and every other prop the compiler rejects — past the compile-time deny and into the DOM.

## The hole, reproduced before any change

`rules/rejected-prop-spellings` ("one spelling per name, and it is a node variant") is enforced by the analyzer on **literal** props only (`analyze.cljc` `check-rejected-spelling!`). A `(ui/spread base overrides)` map is assembled at **runtime**, so the compiler cannot see it, and `rules/react-prop-name` passes an unrecognized name **verbatim**. Live capture through real `react-dom/server`, at `origin/main`:

```
no injection through :dangerouslySetInnerHTML — got:
  <div class="card" data-a="b"><img src=x onerror=alert(1)></div>
```

No `(ui/html …)` anywhere in the source. That is an injection path in any consumer app that forwards a user-influenced attr map through `ui/spread`.

### Exactly which props were reachable

Probed per host, per spelling, before the fix:

| author key | CLJS emitted slot | reachable? |
|---|---|---|
| `:dangerouslySetInnerHTML` | `dangerouslySetInnerHTML` | **YES — live XSS.** React's raw-markup slot, verbatim |
| `"dangerouslySetInnerHTML"` / `'dangerouslySetInnerHTML` / `:ns/dangerouslySetInnerHTML` | `dangerouslySetInnerHTML` | **YES — same slot; all four aliases injected** |
| `:children` | `children` | **YES** on a spread element with **no positional children** (`jsx-spread2`'s 0-child arm never overwrites the slot). Not injection — React escapes children — but it displaces the positional-children contract |
| `:dangerously-set-inner-html` | `dangerously-set-inner-html` | reached the element, **inert** — React is case-sensitive, so this is a junk attribute, not the raw-markup slot |
| `:inner-html` | `inner-html` | reached the element, inert |
| `:class-name` | `class-name` | reached the element, inert |
| `:html-for` | `html-for` | reached the element, inert |

**JVM:** all seven landed in the semantic tree's `:attrs` verbatim (a *map*-valued `:dangerouslySetInnerHTML` threw only incidentally, via `attr-val-semantic`'s `coll?` guard — the wrong error for the right key). No React there, so no injection, but the host divergence was real: CLJS rendered raw markup where the JVM emitted an attribute.

### What #6327 already blocked

**Nothing, in general.** rf2-29s75 (#6327) attaches the compiler-owned `dangerouslySetInnerHTML` **after** `spread->props` returns, so an explicit `(ui/html …)` *wins a collision* on that one element. That is a collision-ordering guarantee, not a deny: the smuggle path is `[:div (ui/spread m)]` with **no** `ui/html` at the site, where there is nothing to win against. Every row above was captured on a view with no `ui/html`. #6327's comment stays true and its ordering is untouched by this PR — but it closed none of these cases.

## The fix

The deny lives at the **one runtime seam both hosts fold a spread map through**: `runtime/convert-prop-map!` (shared by `spread->props` **and** `spread-safe->props`) and `tree/fold-dyn-entry`. One call site per host covers `ui/spread` and the `ui/spread-safe` caller map together.

`rules/assert-spread-prop-key!` compares the key's **canonical emitted slot** (`caller-key-slot` — composing with, not fighting, the rf2-xdvob spread-safe canonicalization) rather than the literal keyword. That is what makes the deny *total* for the one spelling that carries a trust boundary:

- every alias of React's raw-markup prop — string, symbol, namespaced keyword — reduces to the **same slot** and is denied;
- a spelling that reduces to any **other** slot (`:dangerouslysetinnerhtml`, `:DangerouslySetInnerHTML`) cannot reach React's slot at all, so denying it would be theatre. Pinned as such;
- **no legitimate prop collides**: `:class` slots to `className` and `:for` to `htmlFor`, distinct from the rejected `:class-name` / `:html-for`. Pinned across 15 ordinary props.

The guard runs **before** the `cond`/branch dispatch on both hosts, so no later branch — including the custom-element property branch — can route around it, and it denies on **key presence, value irrelevant** (the compile-time rule rejects the *name*; a value-dependent trust check is a check with a hole in it).

### Drop vs reject: **reject, loudly, in every build**

Throws `:rf.error/ui-tree-malformed`, **not** `goog.DEBUG`-gated — the same production-reachability the sibling `assert-safe-caller!` owned-key deny has, and the shape the bead itself argued for.

Dropping would be fail-safe against injection but invisible twice over: an author who *meant* raw markup ships a silently empty element, and an author who did *not* never learns their forwarded prop map carries a smuggled key. That is the silent-no-op defect class this codebase has been removing. The message names the escape — `(ui/html …)` — exactly as the compile error does.

**Production vs dev: identical.** No gate, no elision. A `goog.DEBUG`-gated guard would have left production — the only build an attacker meets — as the one place the hole stayed open. `spread_rejected_prop_elision_prod_test.cljs` exists to keep it that way, and asserts through the **converter seam** (not just the predicate) under `:advanced` + `goog.DEBUG=false`, reading the offending map from an atom so Closure cannot fold the denied shape away.

### Error id — no Spec 009 co-edit triggered

**No new id.** `:rf.error/ui-tree-malformed` genuinely fits and is already the id this seam throws for its neighbours (`assert-safe-caller!`, `attr-val-semantic`, `tree/html`, `keyed-run`); its Spec 009 catalogue row already names `re-frame.ui.rules` / `re-frame.ui.runtime` / `re-frame.ui.tree` among its emitters, and `spec/API.md`'s `spread-safe` row already documents a runtime offender throwing it. So the hard gate (new runtime id ⇒ catalogue row + Spec-Schemas row in the same PR) is not tripped, and no hot-zone spec file is touched.

**Normative status:** Spec 004 (~line 704) already states the rule this PR makes the runtime obey — the implementation was non-conformant, the prose was not wrong. `spec/004-Views.md` is hot-zone and fenced for rf2-vxcl7 (#6348), so it is deliberately untouched here; a follow-up bead should add the one sentence pinning that the deny is *runtime-enforced on spread maps in every build*, not compile-time only.

## Scope discipline

No sanitiser. No general prop-policy engine. No props beyond the six the bead names. No change to the spread grammar. Three source files, ~30 lines of logic.

## Quality gates

Run **foreground, to completion**, in this worktree (real `npm install`, **no** junction/symlink into the mayor tree — mayor `node_modules` canaried intact before and after).

| Gate | Result |
|---|---|
| `cd implementation/ui && clojure -M:test` (JVM) | **911 tests / 15884 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` (node) | **10067 tests / 49696 assertions, 0 failures, 0 errors** |
| `npm run test:browser` | **462 tests / 2589 assertions, 0 failures, 0 errors** |
| `npm run test:adapter-smokes` | **3 adapter-smoke specs, 0 failures** (Reagent / UIx / Helix) |
| `npm run test:browser-prod-elision` (`:advanced`, `goog.DEBUG=false`) | **100 tests / 387 assertions, 0 failures, 0 errors** — includes the new elision proof (confirmed present in the advanced bundle by its literals, so the pass is not vacuous) |

### Red-before / green-after, both hosts

Captured by reverting **only the two seam call-sites** (keeping the law and the tests), so the red is the hole itself and not a compile error:

| | red before | green after |
|---|---|---|
| JVM focused (`clojure -M:test -n re-frame.ui.spread-rejected-prop-cljs-test`) | 10 tests / 98 assertions, **21 failures** | 10 / 98, **0 failures** |
| CLJS focused (`npm run test:ui`) | 849 tests / 4568 assertions, **28 failures** | 849 / 4568, **0 failures** |

The red-before CLJS run is the security evidence: `the-rendered-markup-carries-no-injection` failed for **all four** aliases with the served HTML printed in the failure message (quoted at the top of this PR).

Adversarial cases covered: the key arriving via **`base`** and via **`overrides`**; **string**, **symbol**, and **namespaced-keyword** spellings; the `ui/spread-safe` **caller** map on the same seam; case-variant spellings pinned as *not* denied (they cannot reach React's slot); and non-nameable keys left to their existing channel.

### Positive control — `ui/html` still works

Asserted on **both** hosts, and it is green:

- **CLJS**, through `react-dom/server`: `(ui/html markup)` alone renders `<b>bold &amp; raw</b>`; **composed with `ui/spread` on the same element** (the rf2-29s75 shape) the markup renders **and** the spread props (`data-a="b"`, a live `:title`) still land.
- **JVM**, through `tree/render`: the `{:html …}` node is the element's sole child, with the spread attrs on the element.

The sanctioned path never meets this guard by construction — #6327 attaches the compiler-owned prop *outside* the runtime prop map.

Do not merge without CI.
