### PR TITLE
docs(ui): state slice-memo*'s actual synchronization guarantee (rf2-5ea8f)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -402,9 +402,18 @@
   nil)
 
 (def ^:private slice-memo*
-  "CLJS module holder for the current synchronous render pass's probe-memo
-  handle (the JVM per-render scope is the thread-local `*slice*` above).
-  Released at the microtask checkpoint by `current-slice-memo`."
+  "CLJS module holder for the current SLICE's probe-memo handle (the JVM
+  per-render scope is the thread-local `*slice*` above). `current-slice-memo`
+  installs the handle lazily and arms a CAS clear at the host MICROTASK
+  checkpoint. That checkpoint is the holder's MAXIMUM lifetime, and what it
+  guarantees is exactly this: NO holder or table survives PAST it into the next
+  window (rf2-2g7pxq).
+
+  What is NOT guaranteed — do not build on it: that the holder spans exactly one
+  synchronous render pass. Its scope is the host-microtask WINDOW, so a later
+  synchronous render (or a caught-render retry) interposing BEFORE the clear
+  drains reuses the still-installed handle — a bounded economy, re-validated on
+  every table hit by the handle's own exact tag. See `current-slice-memo`."
   (atom nil))
 
 (defn ^:no-doc with-slice-memo


### PR DESCRIPTION
Closes rf2-5ea8f.

## What the docstring claimed vs what the code does

`slice-memo*` (implementation/ui/src/re_frame/ui/reactive.cljc) described itself as:

> CLJS module holder for **the current synchronous render pass's** probe-memo handle … Released at the microtask checkpoint by `current-slice-memo`.

The implementation scopes the holder to the host-microtask **window**, not to one synchronous pass. `current-slice-memo` installs the handle and arms its clear with `queue-microtask!`:

```clojure
(queue-microtask! (fn [] (compare-and-set! slice-memo* h nil)))
```

`queueMicrotask` is FIFO, so a callback enqueued *before* the first probe drains *before* that clear. If it performs a genuinely-later synchronous render, that render's probes find the holder still installed and reuse it. One holder can therefore serve several synchronous render passes.

## Verdict: (a) the docstring overstates — not a bug

The wider lifetime is the deliberate, tag-guarded design, not a shortfall:

- rf2-er64a reconciled the CLJS lifetime to the bounded host-microtask window; rf2-2g7pxq stated the law.
- The ns docstring, the section block comment above `*slice*`, and `current-slice-memo`'s own docstring all already describe the microtask-window lifetime correctly.
- Within-window reuse is re-validated on every table hit by the exact `(frame, frame-epoch, registry-epoch)` + incarnation tag, so an interposed render at a moved epoch mints a fresh table rather than serving a stale value.

Only this one-line holder docstring lagged the reconciliation. No behavioural defect is being papered over.

## The wording

Follows the rf2-iweic pattern: state what actually holds, then put the host-/timing-dependent part under an explicit *"What is NOT guaranteed"* heading. The true half of the original — release at the microtask checkpoint — is kept and sharpened (it names the CAS clear and the checkpoint as the *maximum* lifetime) rather than weakened.

Docstring-only; no logic change.

## Tests

No new test. The corrected guarantee is already pinned in both directions by `reactive-slice-memo-inverse-fifo-cljs-test`: within-window reuse (the interposed render does not recompute the cold parent) and the lifetime law (a render after the checkpoint mints a fresh handle and does recompute). Adding a second fixture for the same contract would be duplication.

## Quality gates

Both run in the foreground to completion on this branch. The change is docstring-only, so these confirm **no regression**; they do not cover the wording itself.

| Gate | Result |
| --- | --- |
| `cd implementation/ui && clojure -M:test` | **Ran 902 tests / 15849 assertions — 0 failures, 0 errors** |
| `cd implementation && npm run test:cljs` | **Ran 10056 tests / 49589 assertions — 0 failures, 0 errors** |

Counts sit just under the quoted ~911 / ~10067 baselines; the branch points at `origin/main` `cdafd7c3ad` and the totals are mildly non-deterministic (`doseq`/race/perf tests). Zero failures in both, and a docstring cannot move a test count.
