### PR TITLE
docs(conventions): canonical require-alias for framework subsystems is rf.<leaf> (rf2-lgeron)

### DIFF
--- a/docs/api/re-frame.routing.md
+++ b/docs/api/re-frame.routing.md
@@ -14,7 +14,7 @@ This namespace is the public boot point and façade for the routing artefact. Re
 For motivation and narrative, see the [Routing guide](../routing/index.md).
 
 ```clojure
-(:require [re-frame.routing :as routing])
+(:require [re-frame.routing :as rf.routing])
 ```
 
 Throughout, `rf` is the `re-frame.core` facade alias (`[re-frame.core :as rf]`). The `reg-route` macro and the `route-link` view live on that facade.
@@ -115,12 +115,12 @@ The URL ↔ route mapping is a prism. `match-url` reads a URL into route data. `
 - **Example**:
   ```clojure
   ;; with (rf/reg-route :user/show {} "/users/:id") registered:
-  (routing/match-url "/users/42")
+  (rf.routing/match-url "/users/42")
   ;; => {:route-id :user/show, :params {:id "42"}, :query {},
   ;;     :fragment nil, :validation-failed? false}
 
   ;; nil when no route matches:
-  (routing/match-url "/no/such/path")  ;; => nil
+  (rf.routing/match-url "/no/such/path")  ;; => nil
   ```
 
 ### `route-url`
@@ -146,10 +146,10 @@ The URL ↔ route mapping is a prism. `match-url` reads a URL into route data. `
 - **Example**:
   ```clojure
   ;; with (rf/reg-route :user/show {} "/users/:id") registered:
-  (routing/route-url :user/show {:id 42})            ;; => "/users/42"
+  (rf.routing/route-url :user/show {:id 42})            ;; => "/users/42"
 
   ;; query params are appended and percent-encoded:
-  (routing/route-url :search {} {:q "hello world"})  ;; => "/search?q=hello%20world"
+  (rf.routing/route-url :search {} {:q "hello world"})  ;; => "/search?q=hello%20world"
   ```
 
 ### `malformed-url?`
@@ -186,7 +186,7 @@ This is the read-side surface over the route registry and the live route slice. 
 - **Description**: Return a vector of every registered route id. This is the static-registry "enumerate" half of routing introspection; the live per-frame slice is read through the `:rf.route/*` subs instead. Mirrors the sibling accessors: `resource-ids` for resources, `machines` for machines.
 - **Example**:
   ```clojure
-  (routing/route-ids)  ;; => [:route/cart :user/show]
+  (rf.routing/route-ids)  ;; => [:route/cart :user/show]
   ```
 
 ### `route-meta`
@@ -367,7 +367,7 @@ At most one frame owns the browser URL at a time. A frame claims ownership by re
   ```clojure
   ;; one frame opts into URL ownership at boot:
   (rf/make-frame {:id :app/main :url-bound? true})
-  (routing/url-owner-frame-id)  ;; => :app/main
+  (rf.routing/url-owner-frame-id)  ;; => :app/main
   ```
 
 ### `reset-url-claims!`
@@ -381,7 +381,7 @@ At most one frame owns the browser URL at a time. A frame claims ownership by re
 
 ## URL strategies
 
-A `:url-strategy` is a frame-level config map declared on the URL-owning frame — `(rf/make-frame {:id :app :url-bound? true :url-strategy routing/hash-url-strategy})`. The strategy is consulted at exactly four egress/ingress points: the two history fxs, the `route-link` href render, and the URL-listener install. `route-url`, `match-url`, and the navigation cascade stay pure and path-form. A strategy map carries `{:encode :decode :push! :replace! :install-listener!}`. The side-effecting keys (`:push!` / `:replace!` / `:install-listener!`) are present on CLJS only. SSR ignores strategies: the server emits path-form hrefs and takes the request URL via `:rf.route/handle-url-change`.
+A `:url-strategy` is a frame-level config map declared on the URL-owning frame — `(rf/make-frame {:id :app :url-bound? true :url-strategy rf.routing/hash-url-strategy})`. The strategy is consulted at exactly four egress/ingress points: the two history fxs, the `route-link` href render, and the URL-listener install. `route-url`, `match-url`, and the navigation cascade stay pure and path-form. A strategy map carries `{:encode :decode :push! :replace! :install-listener!}`. The side-effecting keys (`:push!` / `:replace!` / `:install-listener!`) are present on CLJS only. SSR ignores strategies: the server emits path-form hrefs and takes the request URL via `:rf.route/handle-url-change`.
 
 ### `history-url-strategy`
 
@@ -412,7 +412,7 @@ A `:url-strategy` is a frame-level config map declared on the URL-owning frame �
   ```clojure
   (rf/make-frame {:id :app
                   :url-bound?   true
-                  :url-strategy routing/hash-url-strategy})
+                  :url-strategy rf.routing/hash-url-strategy})
   ```
 
 ### `with-base-path`
@@ -427,8 +427,8 @@ A `:url-strategy` is a frame-level config map declared on the URL-owning frame �
   ```clojure
   (rf/make-frame {:id :app
                   :url-bound?   true
-                  :url-strategy (routing/with-base-path
-                                  routing/history-url-strategy
+                  :url-strategy (rf.routing/with-base-path
+                                  rf.routing/history-url-strategy
                                   "/realworld")})
   ```
 

--- a/docs/routing/concepts.md
+++ b/docs/routing/concepts.md
@@ -28,7 +28,7 @@ To *build* a three-page app step by step, use the [tutorial](tutorial.md).
 ;; Adapted from examples/capabilities/routing/routing/core.cljs
 (ns app.core
   (:require [re-frame.core :as rf]
-            [re-frame.routing :as routing]))
+            [re-frame.routing :as rf.routing]))
 
 ;; 1. A route is data in the registry.
 (rf/reg-route :app/home {} "/")
@@ -434,11 +434,11 @@ tests).
 ```clojure
 (rf/make-frame {:id           :app
                 :url-bound?   true
-                :url-strategy routing/hash-url-strategy})  ;; default: history-url-strategy
+                :url-strategy rf.routing/hash-url-strategy})  ;; default: history-url-strategy
 ```
 
 `route-url` / `match-url` stay path-form; strategy encodes `#` at the edges.
-`routing/with-base-path` for deploy under a subpath. SSR ignores strategies (path
+`rf.routing/with-base-path` for deploy under a subpath. SSR ignores strategies (path
 form on the wire; client re-encodes on hydrate).
 
 <a id="converting-routes--urls-by-hand"></a>
@@ -446,9 +446,9 @@ form on the wire; client re-encodes on hydrate).
 ### Codec by hand
 
 ```clojure
-(routing/route-url :app/article {:id "intro"})
+(rf.routing/route-url :app/article {:id "intro"})
 ;; => "/articles/intro"
-(routing/match-url "/articles/intro")
+(rf.routing/match-url "/articles/intro")
 ;; => {:route-id :app/article :params {:id "intro"} …}
 ```
 

--- a/docs/routing/how-to/require-sign-in-on-a-route.md
+++ b/docs/routing/how-to/require-sign-in-on-a-route.md
@@ -45,7 +45,7 @@ A reader reaches a route three different ways, each a different event:
 Guard `:rf.route/navigate` alone and the third row defeats you: a logged-out reader pasting `/settings` into the address bar, or reloading a protected page, never goes through `navigate`. So the guard normalises **all three** to one "where are we headed?" target, then decides once:
 
 ```clojure
-(:require [re-frame.routing :as routing])   ;; match-url lives here, not on rf/
+(:require [re-frame.routing :as rf.routing])   ;; match-url lives here, not on rf/
 
 (defn- nav-target
   "Normalise any navigation event to {:id <route-id> :params <map>}, or nil.
@@ -60,7 +60,7 @@ Guard `:rf.route/navigate` alone and the third row defeats you: a logged-out rea
       {:id (:route-id current) :params (or (:params current) {})}
 
       (map? a)                                           ;; {:url ...} escape-hatch target
-      (when-let [{:keys [route-id params]} (routing/match-url (:url a))]
+      (when-let [{:keys [route-id params]} (rf.routing/match-url (:url a))]
         {:id route-id :params (or params {})})
 
       :else                                              ;; route-id target — unchanged
@@ -70,11 +70,11 @@ Guard `:rf.route/navigate` alone and the third row defeats you: a logged-out rea
     (let [{:keys [to params url]} a]
       (cond
         to  {:id to :params (or params {})}
-        url (when-let [{:keys [route-id params]} (routing/match-url url)]
+        url (when-let [{:keys [route-id params]} (rf.routing/match-url url)]
               {:id route-id :params (or params {})})))
 
     :rf.route/handle-url-change
-    (when-let [{:keys [route-id params]} (routing/match-url a)]
+    (when-let [{:keys [route-id params]} (rf.routing/match-url a)]
       {:id route-id :params (or params {})})
 
     nil))

--- a/docs/routing/testing.md
+++ b/docs/routing/testing.md
@@ -16,7 +16,7 @@ The setup is the same as the [core testing pages](../core/testing/index.md): a J
 (ns my-app.routing-test
   (:require [clojure.test :refer [deftest is use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.routing :as routing]
+            [re-frame.routing :as rf.routing]
             [re-frame.test-support :as ts]
             [my-app.routes]))    ;; loading the ns registers the routes
 
@@ -30,21 +30,21 @@ The setup is the same as the [core testing pages](../core/testing/index.md): a J
 ```clojure
 (deftest article-urls-round-trip
   ;; route → URL
-  (is (= "/articles/intro" (routing/route-url :app/article {:id "intro"})))
+  (is (= "/articles/intro" (rf.routing/route-url :app/article {:id "intro"})))
   (is (= "/search?q=clojure&page=2#results"
-         (routing/route-url :app/search {} {:q "clojure" :page 2} "results")))
+         (rf.routing/route-url :app/search {} {:q "clojure" :page 2} "results")))
   ;; URL → route — schemas validate AND coerce, so :page comes back an int
-  (let [m (routing/match-url "/search?q=clojure&page=2")]
+  (let [m (rf.routing/match-url "/search?q=clojure&page=2")]
     (is (= :app/search (:route-id m)))
     (is (= 2 (get-in m [:query :page]))))
   ;; and the misses are values, not exceptions
-  (is (nil? (routing/match-url "/no/such/page")))
-  (is (:validation-failed? (routing/match-url "/search?q=x&page=abc"))))
+  (is (nil? (rf.routing/match-url "/no/such/page")))
+  (is (:validation-failed? (rf.routing/match-url "/search?q=x&page=abc"))))
 ```
 
 !!! warning "Gotcha — the nil-policy asymmetry is worth a test of its own"
 
-    A `nil` **path** param is a hard error — `route-url` throws `:rf.error/missing-route-param`, because there's no URL to build without the segment; a `nil` **query** param is *silently elided* (`{:page nil}` just omits the key). If your app leans on the elision — "only add `?sort=` when chosen" — pin it: `(is (= "/search?q=x" (routing/route-url :app/search {} {:q "x" :sort nil})))`.
+    A `nil` **path** param is a hard error — `route-url` throws `:rf.error/missing-route-param`, because there's no URL to build without the segment; a `nil` **query** param is *silently elided* (`{:page nil}` just omits the key). If your app leans on the elision — "only add `?sort=` when chosen" — pin it: `(is (= "/search?q=x" (rf.routing/route-url :app/search {} {:q "x" :sort nil})))`.
 
 ## 2. Navigation through a test frame
 

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -70,10 +70,10 @@ Audience column: **user** = an event apps dispatch or handle directly; **runtime
 
 ### Pure helpers
 
-Both live in `re-frame.routing` — they are **not** on the `rf/` (`re-frame.core`) facade; callers require `[re-frame.routing :as routing]`.
+Both live in `re-frame.routing` — they are **not** on the `rf/` (`re-frame.core`) facade; callers require `[re-frame.routing :as rf.routing]`.
 
-- `(routing/match-url url)` → `{:route-id :params :query :fragment :validation-failed?}` or `nil`. Pure; JVM- and CLJS-runnable.
-- `(routing/route-url route-id path-params [query-params [fragment]])` → URL string. Pure; JVM- and CLJS-runnable.
+- `(rf.routing/match-url url)` → `{:route-id :params :query :fragment :validation-failed?}` or `nil`. Pure; JVM- and CLJS-runnable.
+- `(rf.routing/route-url route-id path-params [query-params [fragment]])` → URL string. Pure; JVM- and CLJS-runnable.
 
 ### Frame-level configuration
 
@@ -382,7 +382,7 @@ A **malformed** declaration (a non-vector axis, a non-sequential path entry, a n
     ;; §`resolve-target` below.
     (let [{:keys [route-id path-params query-params fragment]} (resolve-target target params opts rt)
           route-meta (rf/handler-meta :route route-id)
-          url        (routing/route-url route-id path-params query-params fragment)
+          url        (rf.routing/route-url route-id path-params query-params fragment)
           push-fx-id (if (:replace? opts) :rf.nav/replace-url :rf.nav/push-url)
           nav-token  (rf/gen-nav-token)]
       {:rf.db/runtime (-> rt
@@ -516,7 +516,7 @@ Neither delegates to the other — they are sibling handlers over one shared sli
   {:doc       "Triggered by URL change (popstate or initial load). Sets the route slice in runtime-db from the URL."
    :platforms #{:client :server}}                 ;; same handler is used by SSR
   (fn handler-route-handle-url-change [{rt :rf.db/runtime} [_ url]]
-    (let [{:keys [route-id params query fragment validation-failed?]} (routing/match-url url)
+    (let [{:keys [route-id params query fragment validation-failed?]} (rf.routing/match-url url)
           route-meta                                                  (rf/handler-meta :route route-id)
           prev-route                                                  (get-in rt [:rf.runtime/routing :current])
           fragment-only?                                              (and prev-route
@@ -655,14 +655,14 @@ Pattern: a single `case` (or equivalent) over the route id at the top of the tre
 
 ### Bidirectional URL ↔ params
 
-Two pure helpers, both registered, both queryable. Both live in `re-frame.routing` (require `[re-frame.routing :as routing]`) — **not** on the `rf/` (`re-frame.core`) facade:
+Two pure helpers, both registered, both queryable. Both live in `re-frame.routing` (require `[re-frame.routing :as rf.routing]`) — **not** on the `rf/` (`re-frame.core`) facade:
 
-- `(routing/match-url url)` → `{:route-id :keyword :params {...} :query {...} :fragment <string-or-nil> :validation-failed? boolean}` or `nil`.
+- `(rf.routing/match-url url)` → `{:route-id :keyword :params {...} :query {...} :fragment <string-or-nil> :validation-failed? boolean}` or `nil`.
   - Returns `nil` when no path-pattern matches the URL at all.
   - Returns the match map when *some* route's path-pattern matches. The `:params` map carries the captured **path** params (post-coercion against the route's `:params` schema, when one is present). The `:query` map carries the parsed **query-string** params, with `:query-defaults` filled in for absent keys and the route's `:query` schema applied for coercion (e.g. `"2"` → `2` for an `:int` field). The `:fragment` field carries the URL's `#fragment` portion (string or `nil` if absent); see "Fragments" below.
   - If schema validation fails (path params don't conform to `:params`, or query params don't conform to `:query`), the map carries `:validation-failed? true` plus a `:validation-error` field with the schema-explanation (per [Spec 010](010-Schemas.md)). The runtime's `:rf.route/handle-url-change` event treats validation-failure the same as no-match: it routes to `:rf.route/not-found` with the URL in params.
   - Pure; runs on JVM and CLJS.
-- `(routing/route-url route-id path-params)` / `(routing/route-url route-id path-params query-params)` / `(routing/route-url route-id path-params query-params fragment)` → URL string. **Pure**; runs on JVM and CLJS.
+- `(rf.routing/route-url route-id path-params)` / `(rf.routing/route-url route-id path-params query-params)` / `(rf.routing/route-url route-id path-params query-params fragment)` → URL string. **Pure**; runs on JVM and CLJS.
   - Builds the URL from the `:path` template, substituting path params, then appends `?key=value&...` for any `query-params`, then appends `#fragment` if the 4-arity `fragment` arg is supplied (and non-nil/non-empty). Ordinary path params, query keys/values, **and the fragment** are percent-encoded **per component** on emission (encodeURIComponent semantics) — symmetric with `match-url`, which decodes each portion the same way. A fragment carrying a literal `%` (`"50% done"`) emits as `#50%25%20done` and `match-url` reads it back as `"50% done"`; emitting the raw value would produce a `#fragment` that `match-url` rejects as malformed (the bare `%` fails to decode) → a route-miss, breaking the bidirectional contract. **Splat values are the one exception: they are encoded PER CHUNK.** A splat capture is a multi-segment string whose embedded `/` are structural separators, not data — so `route-url` splits the value on `/`, `encodeURIComponent`-encodes each chunk, and rejoins with raw `/` (a whole-value `encodeURIComponent` would emit `%2F` for every separator and break the round-trip). `route-url(:route/files, {:rest "a/b/c.txt"})` therefore emits `/files/a/b/c.txt`, and `route-url(:route/files, {:rest "my file/50%.txt"})` emits `/files/my%20file/50%25.txt` — each chunk encoded, the separators preserved. `match-url` is the exact inverse: it segments the raw URL first, then decodes each chunk, so an encoded slash inside a chunk can never change the route's structure.
   - **Keyword-enum values emit their declared token name** (path or query). A slot declared `[:enum :asc :desc]` carrying the keyword `:asc` emits the token `asc` — the exact inverse of `match-url`'s enum decode (which interns the declared name back to `:asc`), so `match-url(route-url(...))` recovers the canonical enum keyword. (Host `(str :asc)` would emit `%3Aasc`, which `match-url`'s enum decoder — keyed on the declared names `asc` / `desc` — reads as the string `":asc"`, not `:asc`, breaking the prism.) This also covers a `:query-retain` value carried as a keyword from a prior match into an outgoing `route-url`. An out-of-enum keyword fails `:rf.error/route-url-validation` rather than being stringified into a URL.
   - **Does not navigate.** It is a string-builder; there is no side-effect on `app-db`, no `pushState`, no dispatch. To navigate, dispatch `:rf.route/navigate` (which uses `route-url` internally).
@@ -945,7 +945,7 @@ An external classification emits `:rf.route/external-url-requested` (carrying `:
 ```clojure
 (rf/reg-view ^{:rf/id :route/link} route-link
   [{:keys [to params query fragment on-click] :as props} & children]
-  (let [base-url (routing/route-url to (or params {}) (or query {}))
+  (let [base-url (rf.routing/route-url to (or params {}) (or query {}))
         url      (if (and fragment (not= "" fragment))
                    (str base-url "#" fragment)
                    base-url)
@@ -1413,7 +1413,7 @@ Fixture `route-entry-blocked.edn` exercises the enter mirror, through EACH of th
 A cross-cutting guard interceptor **must cover all three entry doors**, or it fails *open*: a policy that inspects only `:rf.route/navigate` lets a logged-out user in through a link click (`:rf.route/url-requested`) or a deep-link / Back-Forward (`:rf.route/handle-url-change`), neither of which dispatches `:rf.route/navigate`. So the interceptor resolves the target from *whichever* nav event drove it, then decides:
 
 ```clojure
-;; Requires: [re-frame.core :as rf] [re-frame.routing :as routing]
+;; Requires: [re-frame.core :as rf] [re-frame.routing :as rf.routing]
 ;; `match-url` lives in re-frame.routing — NOT on the rf/ facade.
 
 ;; Resolve the target route + params from ANY of the three navigation
@@ -1428,16 +1428,16 @@ A cross-cutting guard interceptor **must cover all three entry doors**, or it fa
                                     (= :rf.route/self a)          ;; reserved "stay here" target
                                     {:id (:route-id current) :params (or (:params current) {})}
                                     (map? a)                      ;; {:url ...} escape-hatch target
-                                    (when-let [{:keys [route-id params]} (routing/match-url (:url a))]
+                                    (when-let [{:keys [route-id params]} (rf.routing/match-url (:url a))]
                                       {:id route-id :params (or params {})})
                                     :else                         ;; a = route-id
                                     {:id a :params (or b {})})
       :rf.route/url-requested           (let [{:keys [to params url]} a]
                                     (cond
                                       to  {:id to :params (or params {})}
-                                      url (when-let [{:keys [route-id params]} (routing/match-url url)]
+                                      url (when-let [{:keys [route-id params]} (rf.routing/match-url url)]
                                             {:id route-id :params (or params {})})))
-      :rf.route/handle-url-change (when-let [{:keys [route-id params]} (routing/match-url a)]
+      :rf.route/handle-url-change (when-let [{:keys [route-id params]} (rf.routing/match-url a)]
                                     {:id route-id :params (or params {})})
       nil)))
 
@@ -1612,8 +1612,8 @@ A third orthogonal concern — a deployment **sub-path** (a host mounting severa
 ```clojure
 (rf/make-frame {:id :app
                 :url-bound?   true
-                :url-strategy (routing/with-base-path
-                                routing/history-url-strategy
+                :url-strategy (rf.routing/with-base-path
+                                rf.routing/history-url-strategy
                                 "/realworld")})
 ```
 

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -180,6 +180,27 @@ Library-owned prefixes live **outside** `:rf.*` (e.g., Story's `:story.*`, Works
 
 The reserved set is **fixed-and-additive**: names already in the table cannot be repurposed; new sub-namespaces are added by extending the table in a Spec change. New Spec areas ship under `:rf.<spec-area>/*` rather than inventing a top-level prefix.
 
+### Require-alias dialect — a framework subsystem namespace is aliased `rf.<leaf>`
+
+The reserved set above fixes the framework's naming identity: an **`rf` root with a dotted subsystem segment** — `:rf/dispatch-later`, `:rf.route/params`, `:rf.machine/has-tag?`, `:rf.runtime/routing`. **The require-alias surface takes the same dialect.** The canonical alias for a framework subsystem namespace `re-frame.<leaf>` is the dotted **`rf.<leaf>`**:
+
+```clojure
+(:require [re-frame.core     :as rf]            ;; the root itself keeps the bare root alias
+          [re-frame.routing  :as rf.routing]
+          [re-frame.machines :as rf.machines]
+          [re-frame.schemas  :as rf.schemas]
+          [re-frame.ssr      :as rf.ssr]
+          [re-frame.flows    :as rf.flows]
+          [re-frame.epoch    :as rf.epoch]
+          [re-frame.http     :as rf.http])
+```
+
+The point is that a call site reads as **one language** beside the keywords it manipulates: `(rf.routing/match-url url)` sits next to `:rf.route/params` and `rf/dispatch` without changing dialect mid-line. An author who has learned the keyword scheme already knows the alias, and the alias already tells a reader "this symbol came from the framework, not from the app".
+
+`re-frame.core` is the one namespace exempt by construction — it **is** the root, so it takes the bare root alias `rf`, matching the bare `:rf/*` keyword root.
+
+A **bare** leaf alias (`:as routing`, `:as machines`, `:as schemas`) is **reserved for application namespaces**. An app's own `myapp.routing` takes `routing` and never has to be disambiguated against the framework's — which is the second thing the rule buys, and the reason the framework yields the bare form rather than claiming it.
+
 ### The public `rf/image` source keys
 
 `rf/image` is a plain function ([API.md](API.md)) that accepts a **source map** and returns an inert image **value**. The public source map accepts **exactly three** top-level keys ([EP-0026](../docs/EP/EP-0026-image-api-simplification.md) §Image Keys); the normalized value carries the owner-qualified `:rf.image/*` slots above. The source keys are the authoring surface; the `:rf.image/*` namespace names the normalized internal form.


### PR DESCRIPTION
Delivers **rf2-lgeron SCOPE 1** (the normative rule) and **SCOPE 3** (the rf2-bcjpq5 routing-prose coordination).

**Does NOT close the bead.** SCOPE 2 — the repo-wide alias sweep, and the bead's third acceptance criterion ("grep-proven zero bare `[re-frame.<sub> :as <bare-leaf>]`") — is **censused and reported below, deliberately not swept**. rf2-lgeron should stay open for it, or be split so the sweep gets its own coordinated bead once the live holds clear.

## The convention, as stated

`spec/Conventions.md` gains one normative subsection, sited in **Reserved namespaces (framework-owned)** immediately after the fixed-and-additive close — so the keyword-scheme parallel it rests on sits directly above it:

> ### Require-alias dialect — a framework subsystem namespace is aliased `rf.<leaf>`
>
> The reserved set above fixes the framework's naming identity: an **`rf` root with a dotted subsystem segment** — `:rf/dispatch-later`, `:rf.route/params`, `:rf.machine/has-tag?`, `:rf.runtime/routing`. **The require-alias surface takes the same dialect.** The canonical alias for a framework subsystem namespace `re-frame.<leaf>` is the dotted **`rf.<leaf>`** […]
>
> The point is that a call site reads as **one language** beside the keywords it manipulates: `(rf.routing/match-url url)` sits next to `:rf.route/params` and `rf/dispatch` without changing dialect mid-line. […]
>
> `re-frame.core` is the one namespace exempt by construction — it **is** the root, so it takes the bare root alias `rf`, matching the bare `:rf/*` keyword root.
>
> A **bare** leaf alias (`:as routing`, `:as machines`, `:as schemas`) is **reserved for application namespaces**. An app's own `myapp.routing` takes `routing` and never has to be disambiguated against the framework's […]

The keyword-scheme rationale is stated **in the spec text itself**, not only in this PR — a future reader hits the "why" at the rule.

## Sites aligned (SCOPE 3 — the rf2-bcjpq5 coordination surface)

`rf2-bcjpq5` merged as `c9d1220b24`, leaving the routing prose spelling the alias the bare way. Aligning it here means the spec does not contradict its own new rule in the same tree, and `rf.routing` — the exact spelling the ruling settled — is what a reader of the routing surface actually sees.

| File | Alias sites |
|---|---|
| `spec/012-Routing.md` | 14 |
| `docs/api/re-frame.routing.md` | 11 |
| `docs/routing/testing.md` | 7 |
| `docs/routing/concepts.md` | 5 |
| `docs/routing/how-to/require-sign-in-on-a-route.md` | 4 |

The sanctioned `:routing/*` **late-bind hook keys** are deliberately untouched (10 in `012`, 3 in `docs/api`) — they are wiring addresses under their own grammar, not alias-qualified symbols. Grep-verified: hook-key counts unchanged, zero residual bare alias, zero `:rf.routing/` hook-key damage.

`rf.http` already conformed (15 sites) and is cited in the rule as the exemplar.

## SCOPE 2 — the repo-wide sweep is NOT in this PR (reported, not swept)

Census on `origin/main`, excluding `.beads/` and generated `site/`:

| Subsystem | Bare sites | Files |
|---|---|---|
| `re-frame.story` | 141 | 135 |
| `re-frame.machines` | 114 | 112 |
| `re-frame.schemas` | 110 | 107 |
| `re-frame.flows` | 78 | 78 |
| `re-frame.ssr` | 58 | 56 |
| `re-frame.routing` | 58 | 54 |
| `re-frame.epoch` | 34 | 34 |
| **total (7 named)** | **593** | **559** |

The bead's `etc.` reaches further still — `frame` (566), `registrar` (326), `trace` (208), `interop` (179), `error` (134), `fx` (91), `elision` (83), `subs` (74), `privacy` (53) and more put the full-dialect figure in the low thousands.

Three reasons it is deferred rather than partially started:

1. **It cannot be complete-in-one right now**, which is the bead's own requirement ("uniform in a single pass rather than re-litigated per file"). `implementation/routing/**` (27 files) is held by rf2-sy7zr, `spec/conformance/**` by rf2-vxgfnd.96.3, `implementation/ui/**` is arming, and `spec/API.md` / `006` / `011` are hot-zone.
2. **It is not safely mechanical.** The token `routing/` is textually indistinguishable from the sanctioned `:routing/*` late-bind hook keys (`:routing/extra-route-keys`, `:routing/on-frame-destroyed!`, `:routing/link-model`) without per-token care — a naive `routing/` → `rf.routing/` sweep corrupts the DI seam grammar. The same applies to `:epoch/*` and `:schemas/*`, which `Conventions.md §Late-bind hook key grammar` explicitly sanctions.
3. **One gate needs updating in the same PR as the `story` rename.** `implementation/scripts/api-manifest/.../doc_api_check.clj` extracts call-position references for the alias list `["rf" "story"]` (`references-in-files`, line ~136). Renaming `story` → `rf.story` in `docs/story/api/**` makes those ~15 references stop matching. The aggregate `min-references` floor is 20 against a live count of ~50, so the loss would **not** trip the gate — the Story API page would silently lose its reference checking. The sweep must move that alias list to `["rf" "rf.story"]` in lockstep.

## Quality gates

All foreground, run to completion in the worker worktree, all exit 0:

| Gate | Result |
|---|---|
| `python scripts/check_keyword_catalogue_drift.py` | exit 0 — the structural `Conventions.md` table parse is unaffected (the change is prose + a new `###`, no table row) |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `python scripts/check_skill_re_frame2_drift.py --verbose` | exit 0 — 50 user-facing leaves / 7416 lines / 4 bounded hooks-recipe blocks scanned, no drift |
| `python -m mkdocs build --strict` | exit 0 — built in 50.16s |

No artefact suite run: this PR changes spec and docs prose only, no source. Verified no functional change — `git diff --numstat` is 63 insertions / 42 deletions across 6 markdown files.

