### PR TITLE
spec(views): pin the runtime-enforced rejected-prop deny on spreads (rf2-0znjl)

### DIFF
--- a/implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj
@@ -550,6 +550,80 @@
       (let [to (str/index-of text "\n## " (+ from (count heading)))]
         (subs text from (or to (count text)))))))
 
+(defn- subsection-text
+  "The text of `### ` subsection `heading` up to the next heading at the same or
+  a higher level, or nil if absent.
+
+  `section-text` slices to the next `## `, which swallows every sibling `### `
+  after the one asked for — too coarse to say WHERE a claim sits inside a long
+  chapter. That is rf2-vxcl7's lesson taken one level down: a census blind to
+  position lets a correct sentence in a neighbouring subsection keep a false one
+  green."
+  [text heading]
+  (let [text (str/replace text "\r\n" "\n")]
+    (when-let [from (str/index-of text heading)]
+      (let [after (+ from (count heading))
+            ends  (keep #(str/index-of text % after) ["\n### " "\n## "])]
+        (subs text from (if (seq ends) (apply min ends) (count text)))))))
+
+;; --- The RUNTIME half of the rejected-prop-spelling deny (rf2-0znjl) ---------
+;;
+;; rf2-5pr75 closed a live injection path: `rejected-prop-spellings` ("one
+;; spelling per name, and it is a node variant") was enforced only on LITERAL
+;; props by the analyzer, so `:dangerouslySetInnerHTML` inside a RUNTIME
+;; `ui/spread` map reached React's raw-markup slot with no `(ui/html ...)` trust
+;; assertion anywhere in the source. Spec 004's trusted-markup subsection said
+;; outright that "the browser has no equivalent runtime guard", which the fix
+;; falsified.
+;;
+;; The census is bound to that ONE subsection deliberately. Both the false
+;; sentence and its replacement are about `ui/html`, and the safe-spread policy
+;; chapter carries its own "every build" deny prose — so a document-wide row
+;; would be answerable by the wrong section in either direction, exactly the
+;; false-green shape rf2-vxcl7 named.
+(deftest spec-004-teaches-the-runtime-rejected-spelling-deny
+  (let [trusted (subsection-text
+                 (slurp (root-file "spec/004-Views.md"))
+                 "\n### Trusted markup — what `ui/html` does not do\n")]
+    (when (is (some? trusted)
+              "spec/004-Views.md lost its trusted-markup subsection")
+      (testing "the spelling deny is stated as runtime-enforced, both hosts, every build"
+        (doseq [[fact pattern]
+                [["the rule is not compile-time only"
+                  #"(?is)rule\s+is\s+not\s+compile-time\s+only"]
+                 ["ui/spread carries the runtime deny"
+                  #"(?is)\(ui/spread\s+base\s+overrides\)"]
+                 ["the spread-safe caller map shares it"
+                  #"(?is)`caller`\s+map\s+of\s+`\(ui/spread-safe\s+owned\s+caller\)`"]
+                 ["both hosts, throwing the existing malformed id"
+                  #"(?is)on\s+\*\*both\s+hosts\*\*,\s+throwing\s+`:rf\.error/ui-tree-malformed`"]
+                 ;; The mechanism is TOTALITY by canonicalization, not a
+                 ;; blocklist of spellings — a spec that taught the latter would
+                 ;; invite readers to hunt for an unlisted alias.
+                 ["canonical emitted slot, not a list of spellings"
+                  #"(?is)compares\s+each\s+key's\s+\*\*canonical\s+emitted\s+slot\*\*\s+rather\s+than\s+matching\s+a\s+list\s+of\s+spellings"]
+                 ["every alias of the raw-markup slot"
+                  #"(?is)every\s+alias\s+reducing\s+to\s+React's\s+raw-markup\s+slot"]
+                 ["not dev-only"
+                  #"(?is)runs\s+in\s+\*\*every\s+build\*\*"]
+                 ["production is the build that matters"
+                  #"(?is)production\s+being\s+the\s+only\s+build\s+an\s+attacker\s+meets"]
+                 ["the sanctioned escape sits outside the runtime map"
+                  #"(?is)outside\s+the\s+runtime\s+prop\s+map"]]]
+          (is (re-find pattern trusted)
+              (str "spec/004-Views.md trusted-markup subsection lost: " fact))))
+      (testing "the value-validation gap it really has is still stated"
+        ;; The JVM node builder checks the `ui/html` VALUE and the browser does
+        ;; not. That asymmetry is real and must survive the correction — the
+        ;; retired sentence was wrong about the browser being unguarded at
+        ;; runtime, not about the value going unchecked.
+        (is (re-find #"(?is)no\s+equivalent\s+check\s+to\s+the\s+\*\*value\*\*" trusted)
+            "spec/004-Views.md stopped stating the browser's unchecked ui/html value"))
+      (testing "the falsified sentence stays retired"
+        (is (not (re-find #"(?is)browser\s+has\s+no\s+equivalent\s+runtime\s+guard" trusted))
+            (str "spec/004-Views.md again claims the browser has no runtime guard; "
+                 "rf2-5pr75 shipped one at the shared spread seam on both hosts"))))))
+
 (deftest spec-004-abstract-teaches-per-host-analysis
   (let [abstract (section-text (slurp (root-file "spec/004-Views.md"))
                                "\n## Abstract\n")]

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -701,11 +701,25 @@ The checks that *do* exist are **shape** checks, and they are deliberately parti
   **runtime** expression is accepted unvalidated — the compiler cannot know the
   value, and the site is recorded as non-serialisable.
 - A non-string value reaching the JVM node builder raises
-  `:rf.error/ui-tree-malformed`. The browser has no equivalent runtime guard: the
-  value is handed to React unchecked.
+  `:rf.error/ui-tree-malformed`. The browser applies no equivalent check to the
+  **value**: it is handed to React as written. The gap is in value validation
+  alone — the browser is not unguarded at runtime, as the spelling rule below
+  makes plain.
 - The prop spellings (`:dangerouslySetInnerHTML`, `:dangerously-set-inner-html`,
   `:inner-html`) are compile errors naming `(ui/html …)` as the replacement — there
-  is exactly one spelling, and it is a node variant, not a prop.
+  is exactly one spelling, and it is a node variant, not a prop. **The rule is not
+  compile-time only.** A prop map assembled at runtime — `(ui/spread base
+  overrides)`, or the `caller` map of `(ui/spread-safe owned caller)` — is denied
+  the same spellings on **both hosts**, throwing `:rf.error/ui-tree-malformed`.
+  The deny compares each key's **canonical emitted slot** rather than matching a
+  list of spellings, so every alias reducing to React's raw-markup slot — keyword,
+  string, symbol, or namespace-qualified — is denied, while a spelling reducing to
+  a different slot is left alone precisely because it cannot reach that slot. It
+  runs in **every build**: an advanced production build denies exactly what dev
+  denies, production being the only build an attacker meets. A runtime map is
+  otherwise the one place raw markup can reach React with no `(ui/html …)` trust
+  assertion visible anywhere in the source. The sanctioned escape is unchanged —
+  `(ui/html …)`, attached at its own visible site, outside the runtime prop map.
 
 **The caller's guarantee.** Every `(ui/html s)` site asserts that `s` is trusted
 markup: an author-controlled literal, or a value that passed a real sanitiser at the


### PR DESCRIPTION
Closes rf2-0znjl. Follow-up to rf2-5pr75 (#6352), which shipped the runtime deny; Spec 004 was hot-zone-fenced at the time and could not be corrected in that PR.

## The falsified sentence

`spec/004-Views.md` §Trusted markup carried:

> A non-string value reaching the JVM node builder raises `:rf.error/ui-tree-malformed`. **The browser has no equivalent runtime guard: the value is handed to React unchecked.**

#6352 falsified the bolded half. The browser now raises `:rf.error/ui-tree-malformed` at runtime, from `rules/assert-spread-prop-key!` at the shared spread seam.

## The correction

The sentence was false by **over-reach**, not wholly false, so it is split rather than deleted. The browser genuinely does not check the `ui/html` **value** — that asymmetry with the JVM node builder is real, survives the fix, and is kept. What it no longer supports is the general claim that the browser is unguarded at runtime, so the bullet now scopes itself to value validation and points at the spelling rule.

The spelling bullet then gains the runtime half of the contract:

- **Both spread forms, both hosts.** A prop map assembled at runtime — `(ui/spread base overrides)`, or the `caller` map of `(ui/spread-safe owned caller)` — is denied the same spellings on both hosts, throwing the existing `:rf.error/ui-tree-malformed` (no new error id).
- **Canonical emitted slot, not a blocklist.** Stated as a comparison of each key's canonical emitted slot, so every alias reducing to React's raw-markup slot (keyword, string, symbol, namespace-qualified) is denied, and a spelling reducing elsewhere is left alone precisely because it cannot reach that slot. Totality is the mechanism — a spec teaching a list of spellings would invite readers to hunt for an unlisted alias.
- **Every build.** An advanced production build denies exactly what dev denies, production being the only build an attacker meets.
- **The sanctioned escape is unchanged** — `(ui/html …)`, at its own visible site, outside the runtime prop map.

Spec prose only. No code change; the guard is already merged and is not re-touched.

## The pin, and its blind spot

`guide_truth_jvm_test` gains a **region-bound** row over the trusted-markup subsection, carrying the positive facts, the surviving value-gap statement, and a negative on the retired sentence.

rf2-vxcl7 established that a document-wide census cannot see *where* a claim sits. That applies here with force: both the false sentence and its replacement are about `ui/html`, and the safe-spread policy chapter carries its own "every build" deny prose — so a document-wide row would be answerable by the wrong section in either direction. The existing `section-text` slices to the next `## `, which would swallow every sibling `### `; a new `subsection-text` slices to the next same-or-higher heading, taking rf2-vxcl7's lesson one level down.

**Mutation proof.** Restoring the false sentence verbatim reds two assertions in the new row — the retired-claim negative, and the positive value-gap row (whose wording the restoration removes):

```
FAIL in (spec-004-teaches-the-runtime-rejected-spelling-deny)
the falsified sentence stays retired
  spec/004-Views.md again claims the browser has no runtime guard;
  rf2-5pr75 shipped one at the shared spread seam on both hosts
FAIL in (spec-004-teaches-the-runtime-rejected-spelling-deny)
the value-validation gap it really has is still stated
Ran 17 tests containing 642 assertions.
2 failures, 0 errors.
```

The failure dump also confirms the slice is bound to the trusted-markup subsection alone — it ends before §The document head is host-owned.

## Scope held

The bead offered an optional matching clause on `spec/API.md`'s `spread` row. Not taken: `API.md` is hot-zone and was not fenced to this round, and its `spread-safe` row already documents the every-build runtime deny. Worth a follow-up if the mayor wants the `spread` row to match.

Nothing else in 004 was restructured, no guard machinery was added beyond the one row, and no other prop-policy prose was touched.

One accuracy note carried from #6352: only two of the six rejected spellings were genuinely reachable pre-fix — React is case-sensitive, so the kebab-case variants landed as inert junk attributes. The prose does not overstate the pre-fix hole.

## Quality gates

All foreground, run to completion, non-zero counts confirmed.

| Gate | Result |
|---|---|
| `cd implementation/ui && clojure -M:test` | **914 tests / 15975 assertions — 0 failures, 0 errors** |
| `npm run test:cljs` | **10067 tests / 49696 assertions — 0 failures, 0 errors** |
| `python -m mkdocs build --strict` | **pass** (INFO only) |
| `python scripts/check_doc_slugs.py` | **pass** (exit 0) |
| Mutation proof (false sentence restored) | **2 failures** as designed, then restored to green |

Baselines were ~911/~15884 and ~10056; the JVM delta is the new row plus the suite's noted mild non-determinism. The CLJS gate cannot be affected by this diff (Markdown plus a JVM-only `.clj`) and was run to confirm rather than to detect.

No `node_modules` junction into the mayor checkout — a real `npm install` ran inside the worktree, and the mayor tree's `node_modules` was verified intact afterwards.
