### PR TITLE
docs(synthesis): reconcile slice-memo authorities to the host-window law (rf2-cpalh)

### DIFF
--- a/ai/findings/new-substrate-synthesis/drafts/spec-006-observation-port-amendment.md
+++ b/ai/findings/new-substrate-synthesis/drafts/spec-006-observation-port-amendment.md
@@ -1,6 +1,44 @@
-# DRAFT — Spec 006 amendment (R-2): the internal observation port
+# Spec 006 amendment (R-2): the internal observation port — SUPERSEDED (merged, then amended)
 
-> **Status: DRAFT — not merged · 2026-07-12.** Target: `spec/006-ReactiveSubstrate.md`.
+> **Status: SUPERSEDED — historical staging material. Do not apply.**
+>
+> **All three edits below have LANDED in `spec/006-ReactiveSubstrate.md`**, which is the
+> current contract: Insertion 1 as §The internal observation port (adapter-internal),
+> sitting exactly where this draft placed it — after `### Per-host implementation notes`,
+> before `## What happens when a sub references an unknown sub`; Insertion 2 as the
+> "**The internal observation port is not part of this contract**" blockquote in
+> §The adapter API contract; the companion edit as the "**Observation-target consultation
+> (observation-port substrate)**" paragraph in §The sub-override subscribe seam. Applying
+> this draft again would duplicate all three.
+>
+> **The merged §The slice-scoped probe memo has since been amended** (⟨rf2-er64a⟩,
+> ⟨rf2-2g7pxq⟩) and no longer reads as it does below. The current law is **per-host**:
+>
+> - **JVM** — a thread-local render scope (`*slice*`, opened by `with-slice-memo`); the
+>   binding discards the table synchronously when the render thunk returns. There is no
+>   microtask on the JVM.
+> - **CLJS** — a module holder **released at the host microtask checkpoint**
+>   (`queueMicrotask`, under a CAS guard). That checkpoint is the holder's **maximum**
+>   lifetime, and what it guarantees is exactly this: no holder or table survives *past* it
+>   into the next window. **The whole host-microtask window is one CLJS slice** — because
+>   `queueMicrotask` is FIFO, a genuinely-later render in a microtask interposed *before*
+>   that checkpoint finds the holder still installed and reuses it. That is a bounded
+>   within-window economy and the intended design, not a shortfall; one holder can serve
+>   several synchronous render passes.
+>
+> **§The slice-scoped probe memo below states the retired universal wording** — the table
+> "scoped to the **current synchronous execution slice**", with no entry surviving into "a
+> later slice" — which read as *sharing ends with the originating synchronous call*.
+> PR #6070's executable inverse-FIFO proof disproved that for CLJS. It is preserved
+> verbatim as design history and is deliberately NOT corrected in place; read it as
+> archaeology, never as direction. Its shape source carries the same disproven inference —
+> see the correction notice on [spikes/s3-ownership-report.md](../spikes/s3-ownership-report.md).
+>
+> Current authorities: `spec/006-ReactiveSubstrate.md` §The slice-scoped probe memo,
+> [03-reactivity-and-ownership §3](../03-reactivity-and-ownership.md), and the
+> `slice-memo*` docstring in `implementation/ui/src/re_frame/ui/reactive.cljc` (⟨rf2-5ea8f⟩).
+
+**Original status:** DRAFT — not merged · 2026-07-12. Target: `spec/006-ReactiveSubstrate.md`.
 > Semantics **and shapes final**: spike S-3 has run, and per the binding codex2
 > disposition ([09 §codex2 disposition, F1](../09-review-disposition.md)) the spike's
 > §5 target/evidence/lease model
@@ -335,6 +373,14 @@ The port and the public read API split deliberately ⟨09 codex2 F1 — binding�
   unknown input mid-graph, sub-body exception, cycle detection]**
 
 ### The slice-scoped probe memo
+
+> **⚠ SUPERSEDED — retired wording, preserved as design history.** The "**current
+> synchronous execution slice**" lifetime stated below was disproven for CLJS by PR #6070's
+> executable inverse-FIFO proof. The current law is per-host and lives in
+> `spec/006-ReactiveSubstrate.md` §The slice-scoped probe memo: on the JVM the thread-local
+> scope discards synchronously when the render thunk returns; on CLJS **the whole
+> host-microtask window is one slice**, so a genuinely-later callback interposed before the
+> microtask checkpoint reuses the still-installed holder. See this document's header.
 
 Probes are ownership-free, so N sibling sites probing the same query during one render
 pass (first-mount fan-out: N rows probing `[:orders/by-id id]`) would recompute shared

--- a/ai/findings/new-substrate-synthesis/spikes/s3-ownership-report.md
+++ b/ai/findings/new-substrate-synthesis/spikes/s3-ownership-report.md
@@ -1,5 +1,41 @@
 # Spike S-3 report — ViewCell ownership/concurrency (+ S-2 push falsification, S-5 input synchrony riders)
 
+> **⚠ CORRECTION (⟨rf2-cpalh⟩) — one inference in §5 was later disproven. The report is
+> otherwise unamended and still stands.**
+>
+> This is a dated experimental record of a throwaway spike, preserved verbatim: its 55/55
+> fixtures stand, and its §5 target/evidence/lease model remains the binding **sole shape
+> source** for the observation port (⟨09 codex2 F1⟩). One inference in
+> [§5 The pass token](#the-pass-token-memo-table-lifetime--the-mechanism-s-3-was-asked-to-settle)
+> is **wrong** and must not be built on:
+>
+> - **Disproven:** "React's scheduler yields via a macrotask, so the microtask always runs
+>   at slice end", and therefore that a `queueMicrotask` clear ends sharing with the
+>   originating synchronous call.
+> - **Disproven:** "staleness impossible within a slice (single-threaded — no dispatch can
+>   interleave)" — a dispatch **can** interleave within the window.
+> - **The law, as PR #6070's executable inverse-FIFO proof settled it:** `queueMicrotask`
+>   is FIFO, so a callback enqueued *before* the first probe drains *before* the clear. **The
+>   whole bounded host-microtask window is one CLJS slice**, and a genuinely-later render
+>   interposed before the checkpoint finds the holder still installed and reuses it. One
+>   holder can serve several synchronous render passes. That wider lifetime is the
+>   **intended design**, not a shortfall; the checkpoint is the holder's **maximum**
+>   lifetime, guaranteeing only that no holder or table survives *past* it into the next
+>   window.
+>
+> **The spike's conclusion survives; only its reason was wrong.** The memo is still safe —
+> not because nothing can interleave, but because every table hit is re-validated against
+> the handle's own exact `(frame, frame-epoch, registry-epoch)` + incarnation tag, so an
+> interposed later render at a moved epoch fails the tag check and mints a fresh table
+> rather than serving a stale value. The two-guard rule covers the rest. Exact
+> incarnation/epoch tag safety and bounded within-window reuse are distinct properties.
+>
+> Current authorities: `spec/006-ReactiveSubstrate.md` §The slice-scoped probe memo,
+> [03-reactivity-and-ownership §3](../03-reactivity-and-ownership.md), and the `slice-memo*`
+> docstring in `implementation/ui/src/re_frame/ui/reactive.cljc` (⟨rf2-5ea8f⟩). The
+> amendment draft that took this spike as its shape source is superseded for the same reason
+> ([drafts/spec-006-observation-port-amendment.md](../drafts/spec-006-observation-port-amendment.md)).
+
 **2026-07-11 23:23:18 AUSEST** · spike branch: **`spike/ui-s3-ownership`** (worktree
 `re-frame2-worktrees/spike-ui-s3-ownership`, code under `spikes/ui-s3-ownership/`;
 throwaway, no PR to main) · React **19.2.0** (from a pinned fresh install matching
@@ -216,6 +252,13 @@ through the pass memo.
   static-lease concept and needs its Tier-3 fixture in Stage 2.)*
 
 ### The pass token (memo-table lifetime — the mechanism S-3 was asked to settle)
+
+> **⚠ CORRECTION — the paragraph below carries the disproven inference.** See the correction
+> notice at the top of this report. The recommendation ("adopt slice-scoped") was adopted, but *slice* is
+> bounded **per-host**: on CLJS the whole host-microtask window is one slice, so sharing does
+> **not** end with the originating synchronous call and a dispatch **can** interleave before
+> the clear. Preserved verbatim as the spike's record; read it as archaeology, never as
+> direction.
 
 There is no public React render-pass token. The prototype's answer: scope the table
 to the **current synchronous execution slice** — created lazily on first probe,

--- a/implementation/ui/test/re_frame/ui/slice_memo_lifetime_census_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/slice_memo_lifetime_census_jvm_test.clj
@@ -315,3 +315,133 @@ interrupted or abandoned slice's table becomes unreachable garbage.")
       (is (contains? (slice-memo-lifetime-violations (drift section match replace))
                      expect)
           (str "census must reject " label " when " drift-label)))))
+
+;; ---------------------------------------------------------------------------
+;; The retired-wording sources (rf2-cpalh)
+;; ---------------------------------------------------------------------------
+;;
+;; Two authority-SHAPED documents still state the retired universal wording. They
+;; are deliberately NOT censused by `slice-memo-lifetime-violations` above: they
+;; quote the retired claim verbatim as design history, and correcting it in place
+;; would rewrite archaeology as though it had always said something else.
+;;
+;;   - `drafts/spec-006-observation-port-amendment.md` — all three of its edits
+;;     LANDED in Spec 006 (§The internal observation port et al), and the merged
+;;     section was then amended per-host by rf2-er64a. Its merge condition was
+;;     satisfied and then overtaken, so it is superseded, not pending.
+;;   - `spikes/s3-ownership-report.md` — a dated experimental record whose 55/55
+;;     fixtures stand and whose §5 model remains the port's binding shape source.
+;;     Exactly ONE inference in it was disproven by the inverse-FIFO proof; the
+;;     report is corrected at that claim, not superseded wholesale.
+;;
+;; What they must carry instead is an unmistakable marker that reaches a reader
+;; BEFORE the retired prose does — including one who deep-links straight to the
+;; carrying section. That is what this arm pins.
+
+(def ^:private retired-wording-sources
+  [{:label   "ai/findings/new-substrate-synthesis/drafts/spec-006-observation-port-amendment.md"
+    :path    "ai/findings/new-substrate-synthesis/drafts/spec-006-observation-port-amendment.md"
+    :section "### The slice-scoped probe memo"}
+   {:label   "ai/findings/new-substrate-synthesis/spikes/s3-ownership-report.md"
+    :path    "ai/findings/new-substrate-synthesis/spikes/s3-ownership-report.md"
+    :section "### The pass token"}])
+
+(def ^:private retired-marker-re
+  "The supersession / correction marker. Either spelling is unmistakable at a
+  glance; both must precede the retired prose they guard."
+  #"(?i)\*\*Status:\s*SUPERSEDED|⚠\s*(?:CORRECTION|SUPERSEDED)|—\s*SUPERSEDED")
+
+(defn retired-source-violations
+  "Census ONE retired-wording source; return the SET of violations (empty =
+  conformant). Pure over text, so the negative arm can prove it has teeth."
+  [text section-heading]
+  (let [marker-at   (some-> (re-find retired-marker-re text) (->> (str/index-of text)))
+        claim-at    (some-> (re-find obsolete-synchronous-slice-re text)
+                            (->> (str/index-of text)))
+        section-at  (str/index-of text section-heading)
+        after-head  (when section-at (subs text section-at))
+        sec-marker  (some-> after-head (->> (re-find retired-marker-re))
+                            (->> (str/index-of after-head)))
+        sec-claim   (some-> after-head (->> (re-find obsolete-synchronous-slice-re))
+                            (->> (str/index-of after-head)))]
+    (cond-> #{}
+      ;; It must be marked at all, and prominently — within the opening of the
+      ;; document, not buried where a scanning reader never reaches it.
+      (nil? marker-at)
+      (conj :marker/missing)
+
+      (and marker-at (> marker-at 400))
+      (conj :marker/not-prominent)
+
+      ;; The marker must not be vacuous: it states the law that replaced the
+      ;; retired claim, in the same words the live authorities use.
+      (not (re-find cljs-window-reuse-re text))
+      (conj :marker/host-window-law-missing)
+
+      ;; ... and points at the document that now carries the contract.
+      (not (str/includes? text "spec/006-ReactiveSubstrate.md"))
+      (conj :marker/current-authority-unlinked)
+
+      ;; The retired claim must never lead. A reader meets the marker first.
+      (and claim-at marker-at (< claim-at marker-at))
+      (conj :claim/precedes-marker)
+
+      ;; Deep-link guard: the carrying section must be marked in its own right,
+      ;; before its retired prose — the document header is invisible to a reader
+      ;; who lands on the anchor.
+      (nil? section-at)
+      (conj :section/heading-missing)
+
+      (and section-at (nil? sec-marker))
+      (conj :section/unmarked)
+
+      (and sec-claim sec-marker (< sec-claim sec-marker))
+      (conj :section/claim-precedes-marker))))
+
+(deftest retired-wording-sources-read-as-history-not-direction
+  (doseq [{:keys [label path section]} retired-wording-sources]
+    (testing label
+      (is (= #{} (retired-source-violations (slurp (io/file @root path)) section))
+          (str label " preserves the retired slice-memo wording as design "
+               "history, so it must carry a prominent supersession/correction "
+               "marker — document-level AND on the carrying section — that "
+               "states the host-window law and points at Spec 006")))))
+
+(def ^:private pre-cpalh-amendment-draft
+  "The ACTUAL opening and carrying section of the amendment draft before this
+  bead — the state in which it read as PENDING design direction while stating
+  the retired universal wording. The census must reject it."
+  "# DRAFT — Spec 006 amendment (R-2): the internal observation port
+
+> **Status: DRAFT — not merged · 2026-07-12.** Target: `spec/006-ReactiveSubstrate.md`.
+> Semantics **and shapes final**: spike S-3 has run.
+
+### The slice-scoped probe memo
+
+Probes are ownership-free, so N sibling sites probing the same query during one render
+pass would recompute shared derivation parents N times. The port permits one mitigation:
+a **slice-scoped pure memo table**. Within one slice, probes share computed derivation
+parents; the table dies with the slice. No entry survives into cache state, ownership
+state, or a later slice.
+
+**Lifetime (S-3-settled).** There is no public React render-pass token; the table is
+scoped to the **current synchronous execution slice**: created lazily on first probe,
+cleared by `queueMicrotask`, and belt-and-braces tagged with
+`(frame, frame-epoch, registry-epoch)` — invalidated on any mismatch.")
+
+(deftest retired-source-census-rejects-the-unmarked-pre-cpalh-state
+  (testing "an unmarked draft stating the retired wording as live direction is
+            rejected: no marker at all, no host-window law, and a carrying
+            section a deep-link reader would meet unguarded"
+    (is (= #{:marker/missing
+             :marker/host-window-law-missing
+             :section/unmarked}
+           (retired-source-violations pre-cpalh-amendment-draft
+                                      "### The slice-scoped probe memo"))))
+  (testing "dropping the pointer to the current authority is caught on the live text"
+    (let [{:keys [path section]} (first retired-wording-sources)
+          text (slurp (io/file @root path))]
+      (is (contains? (retired-source-violations
+                      (drift text "spec/006-ReactiveSubstrate.md" "some other document")
+                      section)
+                     :marker/current-authority-unlinked)))))


### PR DESCRIPTION
Closes rf2-cpalh.

PR #6070's executable inverse-FIFO proof settled that **the whole bounded host-microtask window is one slice**, so a genuinely later callback within that window shares the memo table. `rf2-er64a` repaired canonical Spec 006 and synthesis 03; `rf2-5ea8f` (#6354) repaired the `slice-memo*` docstring. Two authority-shaped documents still carried the rejected universal wording, and no live bead owned the residual.

## Both sites confirmed before editing

| Site | Retired wording found |
|---|---|
| `drafts/spec-006-observation-port-amendment.md` §The slice-scoped probe memo | table "scoped to the **current synchronous execution slice**", "cleared by `queueMicrotask`", "No entry survives … into a later slice" — under `Status: DRAFT — not merged` |
| `spikes/s3-ownership-report.md` §5 The pass token | same scope claim, plus "React's scheduler yields via a macrotask, so the microtask **always runs at slice end**" and "staleness impossible within a slice (single-threaded — **no dispatch can interleave**)" |

## Verdict per document, and the anchor test that decided it

**`drafts/spec-006-observation-port-amendment.md` — SUPERSEDED, not reworded.**

The anchor test resolved *more* decisively than in #6353, and in the opposite direction. Every placement anchor is still present in `spec/006-ReactiveSubstrate.md` — but **all three of the draft's edits have already landed**:

| Draft edit | Landed in `spec/006-ReactiveSubstrate.md` |
|---|---|
| Insertion 1 | `## The internal observation port (adapter-internal)` — L1134, sitting *exactly* where the draft placed it: after `### Per-host implementation notes` (L1128), before `## What happens when a sub references an unknown sub` (L1773) |
| Insertion 2 | "The internal observation port is not part of this contract" blockquote — L103 |
| Companion edit | "Observation-target consultation (observation-port substrate)" — L2058 |

So it is unappliable for the mirror-image reason to #6353's: not "the target revision is gone" but "**it has already been applied — applying it again would duplicate all three sections**". Its merge condition was satisfied and then overtaken, and the merged §The slice-scoped probe memo was subsequently amended per-host by `rf2-er64a`. Correcting the draft in place would rewrite archaeology as though it had always said something else. The retired text stays verbatim under a supersession header.

**`spikes/s3-ownership-report.md` — CORRECTED at one claim, deliberately NOT superseded wholesale.**

This one is *not* a merge-condition draft, so the #6353 anchor test does not apply to it. It is a dated experimental record of a throwaway spike: its 55/55 fixtures stand and its §5 target/evidence/lease model **remains the binding sole shape source** for the observation port (⟨09 codex2 F1⟩, still cited by Spec 006). Retiring it wholesale would kill a document the live spec legitimately depends on; rewording its findings would falsify the experimental record. Exactly one inference was disproven, so it gets a targeted correction notice with the original preserved verbatim.

The substantive point the correction makes: **the spike's conclusion survives; only its reason was wrong.** The memo is still safe — not because nothing can interleave (it can), but because every table hit is re-validated against the handle's own exact `(frame, frame-epoch, registry-epoch)` + incarnation tag. That keeps exact tag safety and bounded within-window reuse distinct, per the bead's third acceptance criterion.

## Wording matches #6354, not a third phrasing

Both markers reuse #6354's and the live spec's terms rather than inventing new ones: the microtask checkpoint as the holder's **maximum** lifetime; the guarantee being that no holder or table survives **past** it into the next window; `queueMicrotask` FIFO ordering; "**the whole host-microtask window is one CLJS slice**"; a genuinely-later render "finds the holder still installed and reuses it"; and the wider lifetime stated as the **intended design, not a shortfall**. No runtime behaviour changes; no spec file touched.

## Quality gates

All run in the foreground on this branch, all green:

| Gate | Result |
|---|---|
| `python scripts/check_synthesis_plan_authority.py` | exit 0 |
| `python scripts/check_synthesis_plan_authority.py --self-test` | exit 0 |
| `python scripts/check_doc_slugs.py --synthesis-only` | exit 0 (41 files) |
| `python -m mkdocs build --strict` | exit 0 (54.6s) |
| `clojure -M:test -n re-frame.ui.slice-memo-lifetime-census-jvm-test` | 5 tests / 21 assertions, 0 failures |

**Gate coverage, stated plainly:** the four brief-named gates assert **nothing** about the slice-memo claims in either edited file. `check_doc_slugs.py --synthesis-only` covers the amendment draft for *link validity only* and does **not** cover `spikes/` at all (the spike report is not among its 41 files); `check_synthesis_plan_authority.py` is a stage-token gate; `mkdocs --strict` does not build the `ai/` tree. This matches what #6353 found for the same file class. Without the census arm below, this diff would have **zero** gate coverage.

One gate did do real work: the census initially **red** on `:section/unmarked` because the spike's section marker did not lead with a recognized token. Fixed in the prose (marker reworded to lead `⚠ CORRECTION`), not by loosening the checker.

## Guard (bead acceptance criterion 4)

One `deftest` pair added to the **existing** bounded census `slice_memo_lifetime_census_jvm_test.clj` (rf2-2mop6r) — no new framework, no general prose parser, no cross-document checker.

These two files are deliberately **not** censused for the retired claim: they quote it verbatim as design history by design, exactly as #6353 reasoned about its own draft. What they must carry instead is an unmistakable marker that reaches a reader *before* the retired prose does. The arm pins, per file: a marker present and **prominent** (within the document opening); the marker **non-vacuous** (it states the host-window law in the live authorities' own words) and pointing at `spec/006-ReactiveSubstrate.md`; the retired claim never leading the marker; and a **deep-link guard** — the carrying section must be marked in its own right, because the document header is invisible to a reader who lands straight on the anchor.

**Negative arm proves teeth:** the actual unmarked pre-cpalh state of the draft is rejected with exactly `#{:marker/missing :marker/host-window-law-missing :section/unmarked}`, and dropping the pointer to the current authority is caught on the live text.

## Guard gap worth naming (not built here)

The census now covers four documents (Spec 006, synthesis 03, and these two). The general gap remains: **`ai/findings/new-substrate-synthesis/` drafts and spikes are authority-shaped and git-tracked, but no census enumerates them as a class** — #6353 found the #6310 `compiler-model-authorities` census excludes exactly this file class, and `--synthesis-only` skips `spikes/` entirely. Each retired-claim sweep therefore has to rediscover these files by hand, which is how both of these survived `rf2-er64a`. A bounded directory-level enumeration — every tracked file under `drafts/` and `spikes/` must carry either a current-status marker or a supersession/correction marker — would close it. Naming it per the brief; not building it here.
