### PR TITLE
refactor(routing): remove the dormant clear-route and current-url wrappers (rf2-sy7zr)

### DIFF
--- a/implementation/core/src/re_frame/core_routing.cljc
+++ b/implementation/core/src/re_frame/core_routing.cljc
@@ -12,17 +12,23 @@
    :maven         "day8/re-frame2-routing"
    :require-ns    "re-frame.routing"})
 
-;; rf2-bcjpq5 / rf2-wad2fl: `match-url` / `route-url` are NOT facade
-;; exports. Per the czn2m0 D1 ruling the tiering rule is reg-* macros +
-;; primary ergonomic verbs on `rf/`, advanced query/codec functions in
-;; their owning namespace — so these two live only as
-;; `re-frame.routing/match-url` / `re-frame.routing/route-url`
+;; rf2-bcjpq5 / rf2-sy7zr / rf2-wad2fl: `match-url`, `route-url`,
+;; `clear-route` and `current-url` are NOT facade exports. Per the czn2m0
+;; D1 ruling the tiering rule is reg-* macros + primary ergonomic verbs on
+;; `rf/`, advanced query / codec / registry-lifecycle functions in their
+;; owning namespace — so all four live only as `re-frame.routing/<name>`
 ;; (consistent with resources / machines / schemas). The dormant
-;; `defwrapper`s that used to sit here — and their `:routing/match-url`
-;; / `:routing/route-url` late-bind hooks — are GONE; `re-frame.core`
-;; never exported them, so nothing consumed them. A routing app already
-;; requires `re-frame.routing` at boot, so there is no second public
-;; home to justify. Pre-alpha, no back-compat shim.
+;; `defwrapper`s that used to sit here — and their `:routing/match-url`,
+;; `:routing/route-url`, `:routing/clear-route` and `:routing/current-url`
+;; late-bind hooks — are GONE; `re-frame.core` never exported them, so
+;; nothing consumed them. A routing app already requires `re-frame.routing`
+;; at boot, so there is no second public home to justify.
+;;
+;; What remains below is exactly the two surfaces that still NEED a
+;; core-side wrapper: `reg-route` (the façade registration macro's fn-form
+;; delegate — source-coord capture, no owned-ns macro form) and
+;; `route-link` (a view with no owned-namespace peer). Pre-alpha, no
+;; back-compat shim.
 
 (defwrapper reg-route
   "Fn-form delegate that performs the late-bind lookup for `reg-route`.
@@ -35,25 +41,6 @@
   {:hook :routing/reg-route :artefact routing-artefact :on-absent :throw
    :ex-data {:route-id id}}
   ([id metadata path] :delegate))
-
-(defwrapper clear-route
-  "Per Spec 012 §Trace events and rf2-dn26r. Remove a registered
-  route; emits `:rf.route/cleared` so tools subscribing to route
-  lifecycle observe the removal. Symmetric with `:rf.flow/cleared`
-  (per [013-Flows.md §Flow tracing](../../../../../spec/013-Flows.md#flow-tracing)).
-  No-op when the route id is not registered. Late-bound via
-  `:routing/clear-route`."
-  {:hook :routing/clear-route :artefact routing-artefact :on-absent :throw
-   :ex-data {:route-id id}}
-  ([id] :delegate))
-
-(defwrapper current-url
-  "Per Spec 012 §URL changes are events. Read the current browser URL as
-  an app-relative string `pathname + search + hash` (CLJS), or `\"/\"`
-  when no `window.location` is available (SSR / node). Late-bound via
-  `:routing/current-url`."
-  {:hook :routing/current-url :artefact routing-artefact :on-absent :throw}
-  ([] :delegate))
 
 ;; rf2-g8pbwg: `install-url-listener!` / `remove-url-listener!` (and their
 ;; retired `install-history-listener!` / `remove-history-listener!` aliases)

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -479,9 +479,6 @@
    {:key         :routing/reg-route
     :producer-ns 're-frame.routing
     :description "Register a route pattern and handler."}
-   {:key         :routing/clear-route
-    :producer-ns 're-frame.routing
-    :description "Remove a registered route; emits :rf.route/cleared."}
    {:key         :routing/reset-counters!
     :producer-ns 're-frame.routing
     :description "Reset the route-registration counter (test isolation)."}
@@ -515,9 +512,6 @@
     :producer-ns 're-frame.routing
     :design-bead "rf2-vxgfnd.95.5"
     :description "CLJS-only route-link activation op `(fn [event on-click render-frame payload native?])` consumed by the compiled `re-frame.ui/route-link` defview: THE router-attributed click decision — run the caller `:on-click` first, defer to the browser on `defaultPrevented` / native? / a non-plain-left (modifier or auxiliary-button) click, else `.preventDefault` + `router/dispatch!` the payload to the captured render frame with `:source :router`. Keeps the modifier/native/veto click law inside routing so the ui artefact reimplements NONE of it (footgun-ownership). Unbound on the JVM (SSR emits a handler-free anchor) and when routing is absent."}
-   {:key         :routing/current-url
-    :producer-ns 're-frame.routing
-    :description "Read the current browser URL as pathname+search+hash (CLJS) / \"/\" (JVM)."}
    {:key         :routing/preflight-frame-config!
     :producer-ns 're-frame.routing
     :design-bead "rf2-ktmto9"

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -24,7 +24,7 @@
   - `re-frame.routing.match`          — pattern parsing + match-against
   - `re-frame.routing.registry`       — reg-route + match-url + route-url + route-table cache
   - `re-frame.routing.classification` — projection-relative route data classification
-  - `re-frame.routing.scroll`         — scroll-restoration helpers + :rf.nav/scroll fxs
+  - `re-frame.routing.scroll`         — scroll-restoration helpers + :rf.nav/scroll + :rf.nav/capture-scroll fxs
   - `re-frame.routing.events`         — shared nav-event helpers + :rf.route.internal/settle-transition
   - `re-frame.routing.plan`           — pure pre-commit navigation-planning seam (fragment/not-found/classification/telemetry/scroll) shared by both nav entry points
   - `re-frame.routing.on-match-error` — :on-match error trap + listener
@@ -370,18 +370,18 @@
 ;; integration points without reversing that dependency.
 
 (late-bind/set-fn! :routing/reg-route          reg-route)
-(late-bind/set-fn! :routing/clear-route        clear-route)
-;; rf2-bcjpq5: no :routing/match-url / :routing/route-url hooks — those two
-;; are not facade exports (czn2m0 D1), so core has nothing to late-bind to.
-;; Callers use `re-frame.routing/match-url` / `re-frame.routing/route-url`
-;; directly; a routing app requires this namespace at boot regardless.
+;; rf2-bcjpq5 / rf2-sy7zr: no :routing/match-url, :routing/route-url,
+;; :routing/clear-route or :routing/current-url hooks — none of those four is
+;; a facade export (czn2m0 D1), so core has nothing to late-bind to. Callers
+;; use `re-frame.routing/match-url` / `route-url` / `clear-route` /
+;; `current-url` directly; a routing app requires this namespace at boot
+;; regardless.
 (late-bind/set-fn! :routing/reset-counters!    reset-counters!)
 ;; Reset hooks clear host-side routing state that a raw frame-container reset
 ;; cannot reach.
 (late-bind/set-fn! :routing/reset-nav-counters! reset-nav-counters!)
 (late-bind/set-fn! :routing/reset-url-claims!  reset-url-claims!)
 (late-bind/set-fn! :routing/route-sub-fn       route-sub-fn)
-(late-bind/set-fn! :routing/current-url        current-url)
 
 ;; Registration-time frame-config preflight (rf2-ktmto9): routing owns the
 ;; MEANING of `:url-strategy` (presence semantics + host-required legs), core

--- a/implementation/routing/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/routing/test/re_frame/late_bind_missing_test.clj
@@ -23,11 +23,18 @@
   `route-url` (and `current-url` / `clear-route`) were demoted off the
   `re-frame.core` façade — they are reached through `re-frame.routing`
   now, so the façade artefact-missing contract no longer applies to them.
-  The façade surfaces that remain are the `reg-route` registration MACRO
+  rf2-bcjpq5 then deleted the dormant `re-frame.core-routing` wrappers for
+  `match-url` / `route-url`, and rf2-sy7zr the `clear-route` / `current-url`
+  pair, along with all four late-bind hooks — nothing consumed them. The
+  façade surfaces that remain are the `reg-route` registration MACRO
   (source-coord capture) and `route-link` (no owned-ns peer); their
   missing-artefact contracts are tested below."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.core :as rf]
+            ;; Required explicitly (rather than relying on the transitive load
+            ;; through `re-frame.core`) so the wrapper-deletion assertions read
+            ;; a genuinely loaded namespace.
+            [re-frame.core-routing]
             [re-frame.late-bind :as late-bind]
             ;; Loading routing registers its late-bind hooks. The
             ;; `with-hook-as-nil` helper below re-establishes the absent
@@ -130,3 +137,67 @@
           "re-frame.routing/match-url is the canonical home")
       (is (some? (get owning 'route-url))
           "re-frame.routing/route-url is the canonical home"))))
+
+;; ===========================================================================
+;; rf2-sy7zr — the same sweep, finished: `clear-route` / `current-url` carried
+;; the identical dormancy. They were demoted off the façade by rf2-wad2fl but
+;; kept `re-frame.core-routing` wrappers and `:routing/clear-route` /
+;; `:routing/current-url` late-bind hooks that NOTHING consumed — dead
+;; indirection every reader had to trace before concluding it does nothing.
+;;
+;; Deleted, no shim. `re-frame.core-routing` now holds exactly the two
+;; surfaces that need a core-side wrapper: `reg-route` (the façade macro's
+;; fn-form delegate) and `route-link` (no owned-ns peer).
+;;
+;; Every assertion below is paired with a POSITIVE CONTROL so a typo, an
+;; unloaded namespace, or a renamed hook registry cannot make the negative
+;; legs vacuously green.
+;; ===========================================================================
+
+(deftest clear-route-and-current-url-are-not-facade-exports-rf2-sy7zr
+  (testing "neither clear-route nor current-url is public in re-frame.core"
+    (let [facade (ns-publics 're-frame.core)]
+      (is (nil? (get facade 'clear-route))
+          "clear-route is NOT a re-frame.core export — call rf.routing/clear-route")
+      (is (nil? (get facade 'current-url))
+          "current-url is NOT a re-frame.core export — call rf.routing/current-url")
+      ;; Positive control: the façade IS loaded and DOES export the routing
+      ;; surfaces that legitimately live there.
+      (is (some? (get facade 'reg-route))
+          "control — reg-route IS a re-frame.core export (the registration macro stays)")
+      (is (some? (get facade 'route-link))
+          "control — route-link IS a re-frame.core export (no owned-ns peer)")))
+  (testing "both remain public on their owning namespace, re-frame.routing"
+    (let [owning (ns-publics 're-frame.routing)]
+      (is (some? (get owning 'clear-route))
+          "re-frame.routing/clear-route is the canonical home")
+      (is (some? (get owning 'current-url))
+          "re-frame.routing/current-url is the canonical home"))))
+
+(deftest dormant-core-routing-wrappers-are-gone-rf2-sy7zr
+  (testing "the re-frame.core-routing wrapper vars are deleted, not shimmed"
+    (let [wrappers (ns-publics 're-frame.core-routing)]
+      (doseq [gone '[clear-route current-url match-url route-url]]
+        (is (nil? (get wrappers gone))
+            (str "re-frame.core-routing/" gone " is GONE — no wrapper, no alias, "
+                 "no forwarding shim")))
+      ;; Positive control: the namespace IS loaded and the two live wrappers
+      ;; still resolve, so the nil assertions above mean "deleted", not
+      ;; "namespace never loaded".
+      (is (some? (get wrappers 'reg-route))
+          "control — re-frame.core-routing/reg-route survives (façade macro delegate)")
+      (is (some? (get wrappers 'route-link))
+          "control — re-frame.core-routing/route-link survives (no owned-ns peer)"))))
+
+(deftest dormant-routing-late-bind-hooks-are-unpublished-rf2-sy7zr
+  (testing "routing publishes no hook for the four demoted surfaces"
+    (doseq [hook [:routing/clear-route :routing/current-url
+                  :routing/match-url :routing/route-url]]
+      (is (nil? (late-bind/get-fn hook))
+          (str hook " is unpublished — core has no wrapper to late-bind to")))
+    ;; Positive control: routing IS loaded and DOES publish its live hooks, so
+    ;; the nils above are real deletions rather than an unloaded artefact.
+    (is (some? (late-bind/get-fn :routing/reg-route))
+        "control — :routing/reg-route IS published (the routing artefact is loaded)")
+    (is (some? (late-bind/get-fn :routing/route-link))
+        "control — :routing/route-link IS published")))

--- a/implementation/routing/test/re_frame/routing_jvm_facade_noop_test.clj
+++ b/implementation/routing/test/re_frame/routing_jvm_facade_noop_test.clj
@@ -12,25 +12,25 @@
   BROWSER-LISTENER leg inside its body is CLJS-only, so on the JVM the hook
   runs the claim maintenance and skips the listener work (a graceful no-op —
   never `:rf.error/routing-artefact-missing`). `:routing/reset-url-listener!`
-  stays CLJS-only. The one remaining query-shaped export,
-  `current-url`, is published on BOTH hosts and returns `\"/\"` server-side.
+  stays CLJS-only.
+
+  The query-shaped `current-url` is a `re-frame.routing` export, NOT a
+  `re-frame.core` façade one (rf2-wad2fl demoted it; rf2-sy7zr deleted the
+  dormant `re-frame.core-routing` wrapper and its `:routing/current-url`
+  late-bind hook, which nothing consumed). The SSR contract it carries is
+  unchanged and still pinned below: `re-frame.routing/current-url` must be
+  callable on the JVM and read the SSR root — a CLJS-only definition would
+  break `.cljc` server-side rendering.
 
   These tests pin, with routing PRESENT (required + reloaded by the suite
   fixture, so the late-bind hooks are live on the JVM):
 
     1. `re-frame.routing/current-url` returns `\"/\"` on the JVM (no throw).
-    2. the `re-frame.core-routing/current-url` FACADE wrapper (`:on-absent
-       :throw`) returns `\"/\"` — it does NOT raise
-       `:rf.error/routing-artefact-missing`, because routing publishes the
-       `:routing/current-url` hook on the JVM too (a CLJS-only publication would
-       make this facade throw server-side even with routing loaded — the
-       regression this test guards).
-    3. registering AND destroying a `:url-bound? true` frame on the JVM does
+    2. registering AND destroying a `:url-bound? true` frame on the JVM does
        not throw — the browser listener install/teardown is CLJS-only, so the
        frame-lifecycle hooks are a graceful no-op server-side."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.core-routing :as core-routing]
             [re-frame.frame :as frame]
             [re-frame.routing :as routing]
             [re-frame.routing-test-support :as rts]))
@@ -46,20 +46,14 @@
 
 (deftest current-url-returns-ssr-root-on-jvm-rf2-j1p1fv
   (testing "re-frame.routing/current-url returns the SSR root \"/\" on the JVM
-            (no window.location) without throwing — with routing present"
+            (no window.location) without throwing — with routing present. The
+            no-throw leg is asserted STRUCTURALLY (rf2-sy7zr): a CLJS-only
+            definition of current-url would make every .cljc caller blow up
+            server-side, which is the regression this guards"
+    (is (= :ok (outcome #(routing/current-url)))
+        "current-url must not throw on the JVM")
     (is (= "/" (routing/current-url))
         "current-url reads the SSR root on the JVM")))
-
-(deftest core-routing-facade-current-url-does-not-throw-on-jvm-rf2-j1p1fv
-  (testing "the re-frame.core-routing/current-url FACADE wrapper (:on-absent
-            :throw) delegates to the JVM-published :routing/current-url hook and
-            returns \"/\" — it must NOT raise :rf.error/routing-artefact-missing
-            when routing IS present, so the .cljc/SSR no-op contract holds
-            (a CLJS-only hook publication would make this throw server-side)"
-    (is (= :ok (outcome #(core-routing/current-url)))
-        "the facade current-url must not throw on the JVM with routing present")
-    (is (= "/" (core-routing/current-url))
-        "the facade delegates to the JVM-published hook and returns the SSR root")))
 
 (deftest url-bound-frame-lifecycle-is-a-noop-on-jvm-rf2-j1p1fv
   (testing "registering AND destroying a :url-bound? true frame on the JVM does

--- a/implementation/routing/test/re_frame/routing_registry_test.clj
+++ b/implementation/routing/test/re_frame/routing_registry_test.clj
@@ -2051,8 +2051,10 @@
 ;; rf2-aleg9 — match-against direct function-boundary tests
 ;; (follow-on from rf2-q1z1u F8)
 ;;
-;; `match-against` is the pattern-matcher fn consumed by the routing
-;; facade's match-url. The facade-level tests above exercise it
+;; `match-against` is the pattern-matcher fn consumed by
+;; `re-frame.routing/match-url` (the owning-namespace export — never a
+;; `re-frame.core` façade one; rf2-bcjpq5 deleted the dormant core-side
+;; wrapper). The match-url-level tests above exercise it
 ;; transitively via `:rf.route/navigate`, but a `match-against`-only
 ;; regression that happens to be neutralised by the facade's URL
 ;; normalisation (canonical-route-pattern, query-string parse,


### PR DESCRIPTION
Finishes the `core_routing` dormancy sweep that rf2-bcjpq5 (#6351) started. `clear-route` and `current-url` carried the identical dormancy `match-url` / `route-url` did: `re-frame.core-routing` `defwrapper`s that `re-frame.core` does **not** re-export, reachable only through late-bind hooks that nothing consumed. Dead indirection every reader and AI agent had to trace before concluding it does nothing.

Pre-alpha, no back-compat: **deleted, with no shim, no alias, and no forwarding wrapper.**

## What was deleted

| Surface | File |
| --- | --- |
| `clear-route` / `current-url` `defwrapper`s | `implementation/core/src/re_frame/core_routing.cljc` |
| `:routing/clear-route` / `:routing/current-url` directory entries | `implementation/core/src/re_frame/late_bind/directory.cljc` |
| their two `late-bind/set-fn!` publications | `implementation/routing/src/re_frame/routing.cljc` |

Both symbols remain public on their owning namespace — `re-frame.routing/clear-route` and `re-frame.routing/current-url` — the canonical home under the czn2m0 D1 tiering rule (`reg-*` macros + primary ergonomic verbs on `rf/`; advanced query / codec / registry-lifecycle functions in their owning namespace).

`re-frame.core-routing` now holds exactly the two surfaces that still *need* a core-side wrapper: `reg-route` (the façade registration macro's fn-form delegate — source-coord capture, no owned-ns macro form) and `route-link` (a view with no owned-namespace peer).

Deleting each directory entry together with its publication keeps `late-bind-drift-test` balanced in both directions.

## Same-spelling check (the trap #6351 flagged)

#6351 found `:routing/match-url` also lives as a conformance **capability tag** with an unrelated meaning. Both symbols were checked before a line was removed.

**`current-url` has FOUR distinct same-spelling definitions in tree.** All unrelated, all untouched:

- `re-frame.routing-browser-test-support/current-url` — a **1-arity** test helper, `(current-url *history-state*)`, reassembling a stubbed URL from a history-state atom. ~40 call sites across the CLJS routing suites.
- `re-frame.story.ui.share/current-url` — a private fn in Story's share panel.
- `re-frame.story.ui.url-state` — `embed-flag-from-current-url`, `parse-current-url`, `parse-current-url-or-empty`, `current-url-search+hash`: Story's chrome-internal URL engine.
- `tools/xray/testbeds/routes_epochs/core.cljs` — a testbed-local helper.

A blind grep-and-delete would have been destructive here.

**`clear-route`** has no conformance capability tag (`git grep` over `spec/conformance/` and `tools/mcp-conformance/` returns nothing for it) and no second meaning anywhere in tree.

## Facade-export delta — classified

**Net zero.** `re-frame.core` publics are identical before and after: neither symbol was ever a façade export, so **no consumer-visible export disappears**. The reduction is two internal wrapper vars plus two late-bind hook keys.

`spec/api-manifest.edn` already records both under `re-frame.routing` with `:facade? false` (`clear-route` `:tier :tooling`, `current-url` `:tier :advanced`), so the code now matches the manifest with **zero manifest churn**. `re-frame.core-routing` has no manifest presence at all — it is an internal wrapper namespace — so removing vars from it cannot move a manifest row. This matches #6351's shape exactly.

## Spec 009 — checked in both directions

**No row goes stale; 009 is untouched** (rf2-jxpf3 is live on that file).

- *Retirement direction*: no error id is retired — neither wrapper raised an id of its own.
- *Stale-listing direction* (the one #6351 caught): the `:rf.error/routing-artefact-missing` row names only `reg-route` and `route-link` among its raising surfaces, and **both survive**. Unlike the `match-url` / `route-url` case, neither `clear-route` nor `current-url` is named in any 009 row. The §Trace events mention of `clear-route` still resolves correctly to `re-frame.routing/clear-route`.

## Stale references swept

Both extras named by #6351's worker:

- `routing.cljc` described the scroll module as `:rf.nav/scroll` fxs though it also registers `:rf.nav/capture-scroll`.
- `routing_registry_test.clj` said "the routing facade's match-url" — stale since the demotion.

`registry.cljc` needed no `:where`-stamp sweep this time: #6351 already fixed all nine `route-url` stamps, and neither `clear-route` nor `current-url` throws, so neither ever carried one.

## Grep proof

`git grep` on **tracked** files only (generated `docs/` / `site/` copies are stale and produce false positives). Every remaining hit for `:routing/clear-route` / `:routing/current-url` is an explanatory comment or one of the new assertions — no live publication or consumer is left. Every surviving `clear-route` / `current-url` hit resolves to `re-frame.routing/*` (which stays), to the demotion history, or to one of the four unrelated same-spelling definitions above.

## Tests

New regression tests, **each paired with a positive control** so they cannot go vacuously green:

- `clear-route-and-current-url-are-not-facade-exports-rf2-sy7zr` — negative on `re-frame.core`; controls assert `reg-route` / `route-link` **are** façade exports.
- `dormant-core-routing-wrappers-are-gone-rf2-sy7zr` — all four wrapper vars nil; controls assert `reg-route` / `route-link` still resolve, proving "deleted" rather than "namespace never loaded".
- `dormant-routing-late-bind-hooks-are-unpublished-rf2-sy7zr` — all four hooks unpublished; controls assert `:routing/reg-route` / `:routing/route-link` **are** published, proving the routing artefact is loaded.

The deleted JVM facade-wrapper test's real subject — that `current-url` is callable server-side — is **preserved**, promoted onto `re-frame.routing/current-url` as a structural no-throw assertion. A CLJS-only definition would still fail the suite.

## Quality gates

Run in the worktree, foreground, to completion, unpiped, with non-zero counts confirmed (a bare `-n <ns>` run from `implementation/` reports "Ran 0 tests" and reads as green — avoided).

| Gate | Result |
| --- | --- |
| `implementation/routing` → `clojure -M:test` | **445 tests / 2305 assertions, 0 failures, 0 errors** |
| `implementation/core` → `clojure -M:test` | **2073 tests / 9905 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` | **10056 tests / 49589 assertions, 0 failures, 0 errors** |
| `python -m mkdocs build --strict` | built in 82s, clean |

The routing delta is exactly accountable: baseline 443/2288 → 445/2305 is +3 new deftests, −1 deleted, and +17 assertions (+18 new, −2 deleted, +1 structural no-throw). Core is unchanged from `main` (no `implementation/core/test/` file was touched); it was run anyway because deleting from the core/routing seam puts the late-bind drift pins at risk — `late-bind-drift-test` passes in both directions.

Closes rf2-sy7zr.
