### PR TITLE
spec(conformance): declare Stage 4 conforming (rf2-vxgfnd.96.3)

### DIFF
--- a/implementation/ui/test/re_frame/ui/s4_conformance_profile_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/s4_conformance_profile_jvm_test.clj
@@ -435,13 +435,26 @@
     (testing "an UNKEYED child under a presence boundary is a build failure"
       (is (= unkeyed
              (compile-err-id '(presence {:timeout-ms 300} [:li "no key"])))))
-    (testing "the well-formed shape compiles (the checks are not blanket rejections)"
-      ;; The keyed `(for …)` — keyed by construction. NOTE: a keyed LITERAL
-      ;; element is currently still rejected here; that is the open bug
-      ;; rf2-vxgfnd.96.1, deliberately not asserted either way by this profile.
+    (testing "the well-formed shapes compile (the checks are not blanket rejections)"
+      ;; The LANDED grammar §1.1 now states. Both legal child shapes: the keyed
+      ;; `(for …)`, keyed by construction, and the keyed LITERAL element, which
+      ;; rf2-vxgfnd.96.1 (#6331) stopped wrongly rejecting.
       (is (= :presence (:op (ana/analyze (presence-env)
                                          '(presence {:timeout-ms 300}
-                                            (for [t ts] [:li {:key (:id t)} "a"])))))))))
+                                            (for [t ts] [:li {:key (:id t)} "a"]))))))
+      (is (= :presence (:op (ana/analyze (presence-env)
+                                         '(presence {:timeout-ms 300}
+                                            [:li {:key "a"} "a"]))))
+          "a keyed literal child is legal (rf2-vxgfnd.96.1)"))
+    (testing "a props-bearing but UNKEYED fragment does NOT pass as keyed (rf2-xoz1s, #6337)"
+      ;; The permissive half: `[:<> {} …]` used to report its PROPS MAP's
+      ;; presence as a key, so the boundary admitted a child it had no identity
+      ;; to retain. Key presence is now `:key`'s own presence.
+      (is (= unkeyed (compile-err-id '(presence {:timeout-ms 300} [:<> {} [:li "x"]]))))
+      (is (= :presence (:op (ana/analyze (presence-env)
+                                         '(presence {:timeout-ms 300}
+                                            [:<> {:key "k"} [:li "x"]]))))
+          "a genuinely keyed fragment is still legal"))))
 
 ;; --- custom-element pins ----------------------------------------------------
 
@@ -628,30 +641,55 @@
 
 ;; --- the ruled sequencing, non-parity, S5-wall and hand-off obligations ------
 
-(def open-presence-grammar-bugs
-  "The two OPEN S4-epic bugs that change the ACCEPTED presence grammar. The
-  profile's presence rows state the post-fix grammar and must say so, and §8
-  must make closing both part of the S4-conforming declaration."
-  ["rf2-vxgfnd.96.1" "rf2-vxgfnd.96.2"])
+(def landed-presence-grammar-fixes
+  "The presence grammar bugs that GATED the S4-conforming declaration, and the
+  PRs that closed them (rf2-vxgfnd.96.3). §1.1 must record them as LANDED and §8
+  must declare the stage conforming on that basis."
+  ["rf2-vxgfnd.96.1" "rf2-vxgfnd.96.2" "rf2-xoz1s" "#6331" "#6337"])
 
-(deftest profile-sequences-presence-behind-the-open-grammar-bugs
-  (testing "§1.1 states that the presence rows track the POST-FIX grammar, naming both open bugs"
+(def stale-blocker-phrases
+  "The PRE-declaration wording. Each of these asserted an open presence grammar
+  bug or a not-yet-conforming stage; all are now false, so their reappearance
+  ANYWHERE in the profile is drift. Absence is the one claim a document-wide
+  census states correctly — 'nowhere' is stronger than 'not in this section' —
+  whereas the positive claims below are bound to the REGION that must carry
+  them (rf2-vxcl7)."
+  ["S4 is not yet declarable conforming"
+   "not yet declarable"
+   "bugs are **open**"
+   "Closing both is part of the S4-conforming declaration"
+   "track the POST-FIX presence grammar"
+   "will ship once both close"])
+
+(deftest profile-declares-s4-conforming-on-the-landed-grammar
+  ;; REGION-bound, not document-wide: §1.1 and §8 legitimately name the SAME
+  ;; beads and PRs, so a whole-document `includes?` would let either site alone
+  ;; satisfy both checks — the exact false-green class rf2-vxcl7 fixed. Each
+  ;; claim is asserted against the section that must carry it.
+  (testing "§1.1 records the presence grammar as LANDED, naming every closed bug and its PR"
     (let [section (section-between (slurp (profile-doc)) "### 1.1" "### 1.2")]
       (is (some? section) "the profile must have a §1.1 presence section and a §1.2 header")
       (when section
-        (doseq [claim (concat open-presence-grammar-bugs
-                              ["POST-FIX presence grammar"
-                               "part of the S4-conforming"])]
+        (doseq [claim (concat landed-presence-grammar-fixes
+                              ["LANDED presence grammar"
+                               "no presence grammar bug is open"])]
           (is (str/includes? section claim)
               (str "§1.1 must state: " claim))))))
-  (testing "§8 makes closing both bugs part of the S4-conforming declaration"
+  (testing "§8 DECLARES the stage conforming, on the cumulative profile and the green named suites"
     (let [text (slurp (profile-doc))
           tail (subs text (str/index-of text "## 8."))]
-      (doseq [claim (concat open-presence-grammar-bugs
-                            ["S4 is not yet declarable conforming"
-                             "Closing both is part of the S4-conforming declaration"])]
+      (doseq [claim (concat landed-presence-grammar-fixes
+                            ["S4 IS DECLARED CONFORMING"
+                             "rf2-vxgfnd.96.3"
+                             "**cumulative** inheritance of §0"
+                             "**all green**"])]
         (is (str/includes? tail claim)
-            (str "§8 must state: " claim))))))
+            (str "§8 must state: " claim)))))
+  (testing "the pre-declaration blocker wording is gone from the WHOLE document — its return is drift"
+    (let [text (slurp (profile-doc))]
+      (doseq [stale stale-blocker-phrases]
+        (is (not (str/includes? text stale))
+            (str "stale pre-declaration wording returned to the profile: " stale))))))
 
 (deftest profile-rows-the-intentional-non-parity-facts
   (testing "§4.1 rows each non-parity S4 fact against its real proof home — never the structural comparator"

--- a/spec/conformance/S4-view-conformance-profile.md
+++ b/spec/conformance/S4-view-conformance-profile.md
@@ -68,15 +68,20 @@ inserts no wrapper node, stamps no attributes, and observes no DOM events. A
 presence-aware child owns its own exit styling and accessibility by reading
 `(ui/presence-phase)`.
 
-> **Sequencing — these rows track the POST-FIX presence grammar.** Two S4-epic
-> bugs are **open** and both change the *accepted* presence grammar:
-> `rf2-vxgfnd.96.1` (**P1** — keyed literal children are wrongly rejected) and
-> `rf2-vxgfnd.96.2` (**P2** — duplicate ownership identities are wrongly
-> accepted). The rows below state the grammar as ruled, which is the grammar
-> that will ship once both close; today's compiler rejects a keyed *literal*
-> child that these rows admit. **Closing both is part of the S4-conforming
-> declaration** — S4 cannot honestly be declared conforming over a known P1
-> presence grammar bug (see §8).
+> **These rows state the LANDED presence grammar.** The two S4-epic bugs that
+> changed the *accepted* grammar shipped in **#6331**: `rf2-vxgfnd.96.1` (keyed
+> literal children were wrongly **rejected** — the key-presence probe read an
+> `:element`'s key at the node rather than inside its analyzed props) and
+> `rf2-vxgfnd.96.2` (duplicate ownership identities were wrongly **accepted** —
+> two children of one boundary claiming one key now drop the later claimant
+> under the existing `:rf.error/ui-duplicate-key`, rather than aliasing the
+> first's phase and exit timer). The fragment correction `rf2-xoz1s`
+> (**#6337**) closed the last permissive path: `[:<> {} …]` reported its
+> *props map's* presence as a key, so a props-bearing but unkeyed fragment
+> passed the keyed-child requirement while offering the boundary no identity to
+> retain. The rows below are therefore the grammar the shipped compiler
+> enforces, and **no presence grammar bug is open** — which is what makes the
+> §8 declaration honest.
 
 | Form | Kind | Contract | Loud failure | Proven by |
 |---|---|---|---|---|
@@ -336,9 +341,12 @@ rows of §4; and none of the non-surfaces (§5). It must also be **S3-conforming
 this one. The gate arms in §6 and the suites named throughout are the executable
 acceptance; `scripts/test-fast-pr.sh` plus the S4 CI matrix run them.
 
-**S4 is not yet declarable conforming.** Two presence grammar bugs are open —
-`rf2-vxgfnd.96.1` (**P1**, keyed literal children wrongly rejected) and
-`rf2-vxgfnd.96.2` (**P2**, duplicate ownership identities wrongly accepted) —
-and both change the accepted presence grammar this profile's §1.1 rows state.
-**Closing both is part of the S4-conforming declaration**; the stage cannot
-honestly be declared conforming over a known P1 presence grammar bug.
+**S4 IS DECLARED CONFORMING** (`rf2-vxgfnd.96.3`). Every presence grammar bug
+that gated this declaration has shipped: `rf2-vxgfnd.96.1` and
+`rf2-vxgfnd.96.2` in **#6331**, and the `[:<> {} …]` fragment correction
+`rf2-xoz1s` in **#6337**. §1.1's rows therefore state the grammar the shipped
+compiler enforces, not a post-fix target, and the declaration rests on evidence
+this profile already carries — the **cumulative** inheritance of §0, the named
+proof homes of §1, the corpus rows of §4, and the two gate arms of §6, which
+are **all green**. The declaration is bounded by §5: S4 claims conformance for
+**none** of the S5 surfaces deferred there.


### PR DESCRIPTION
Closes `rf2-vxgfnd.96.3`, the last leaf of epic `rf2-vxgfnd.96` — so S5 is no longer blocked by stale bookkeeping.

The S4 profile and its JVM drift guard still preserved the pre-declaration state: §1.1 said its presence rows tracked a *POST-FIX* grammar behind two **open** bugs, and §8 said the stage was "not yet declarable conforming". Both claims became false when the blockers shipped. This reconciles the **stage boundary**, not the Presence design — no new gate, status framework, or profile section.

## What landed, and what §1.1 now records

| Fix | PR | Effect on the accepted presence grammar |
|---|---|---|
| `rf2-vxgfnd.96.1` | #6331 | keyed **literal** children were wrongly **rejected** — the key-presence probe read an `:element`'s key at the node rather than inside its analyzed props |
| `rf2-vxgfnd.96.2` | #6331 | duplicate ownership identities were wrongly **accepted** — two children of one boundary claiming one key now drop the later claimant under the existing `:rf.error/ui-duplicate-key` |
| `rf2-xoz1s` | #6337 | `[:<> {} …]` reported its *props map's* presence as a key, so a props-bearing but unkeyed fragment passed the keyed-child requirement while offering the boundary no identity to retain |

§8 now reads **"S4 IS DECLARED CONFORMING"**, resting on evidence the profile already carries — the cumulative inheritance of §0, the named proof homes of §1, the corpus rows of §4, and the two gate arms of §6 — and explicitly bounded by §5, for which S4 still claims nothing.

## The guard binding (the substance)

A declaration nobody guards is the defect class this repo keeps finding, so the binding is **region-scoped, not document-wide**. §1.1 and §8 legitimately name the same beads and PRs; a whole-document `includes?` would let either site alone satisfy both checks — the exact false-green class `rf2-vxcl7` fixed after two of `rf2-yho9j`'s own rows false-greened on a twice-occurring phrase. So:

- every **positive** claim is asserted against the section that must carry it (`section-between` for §1.1, the §8 tail);
- the **stale blocker phrases** are asserted absent **document-wide** — absence is the one claim a census states correctly, since "nowhere" is strictly stronger than "not in this section".

The guard's executable half is now truthful too: it pinned only the keyed `(for …)` child, with a comment calling the keyed literal an open bug. It now pins both legal child shapes plus the unkeyed-fragment rejection.

### Mutation proof — 4 mutations, 4 red

| # | Mutation | Result |
|---|---|---|
| M1 | restored the original §1.1 open-blocker blockquote | **8 failures** (5 §1.1 landed-claims + 3 stale-phrase reappearances) |
| M2 | restored §8's "S4 is not yet declarable conforming" | **4 failures** (2 §8 claims + 2 stale-phrase reappearances) |
| M3 | deleted `#6337` from **§1.1 only**, leaving it in §8 | **1 failure**, `§1.1 must state: #6337` |
| M4 | deleted `#6337` from **§8 only**, leaving it in §1.1 | **1 failure**, `§8 must state: #6337` |

M3/M4 are the region-binding proof: a document-wide census would have stayed **green** through both.

## Untouched, deliberately

`rf2-yho9j`'s reconciled shape is preserved — §0 still inherits S1–S3 **by exact reference** (nothing restated), the guard still **composes with** the S3 guard rather than duplicating it, the **G-7 growth stays bounded** to the S4-shape dev↔prod arms, and §7 keeps its `rf2-vxgfnd.97` hand-off row. The S3 guard and S3 profile are byte-identical to `main`. No file under `implementation/ui/src/` is touched.

## Quality gates

Run in the worktree, foreground, to completion, rebased onto current `main`.

| Gate | Result |
|---|---|
| `implementation/ui` JVM (`clojure -M:test`) | **913 tests / 15986 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` | **10067 tests / 49700 assertions, 0 failures, 0 errors** |
| `npm run test:browser` | **462 tests / 2589 assertions, 0 failures, 0 errors** (exit 0) |
| `python -m mkdocs build --strict` | clean, exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |
| S4 drift guard alone | 29 tests / 349 assertions, 0 failures |

The JVM figure is the `origin/main` baseline (913 / 15966, measured in a clean probe worktree) plus this PR's **20 added assertions and 0 added tests** — the delta is fully accounted for.

`test:browser` is stated separately and deliberately: the mounted Presence tests **self-skip** under node without `js/document`, so a node-only run would make the §1.1 Presence claim vacuous. Verified non-vacuous — `re_frame.ui.presence_dom_cljs_test` is compiled into the `browser-test` build and referenced by the shadow test runner, and `(exists? js/document)` is true in the Chromium host, so the mounted `:mounting → :present → :unmounting` path really executed.
