### PR TITLE
docs(ai): redact the leaked worktree path unblocking the portability gate

### DIFF
--- a/ai/decisions/rf2-bbdbs2.guide-register-pass-review.md
+++ b/ai/decisions/rf2-bbdbs2.guide-register-pass-review.md
@@ -10,7 +10,8 @@ Fresh evidence gathered 2026-07-18 AUSEST:
 - Current `origin/main` is
   `ba34f87185fa0a59a15254937478d8747f775bf6`.
 - Candidate worktree:
-  `C:\Users\miket\code\re-frame2-worktrees\guide-register-bbdbs2`
+  `<worktree-parent>/guide-register-bbdbs2` (the `re-frame2-worktrees` sibling of
+  the primary checkout — see `scripts/assert-worker-worktree.sh`)
 - Candidate branch: `worker/guide-register-bbdbs2`
 - Candidate commit:
   `f83380421c06fcdf4d2d785675d2ff16d6908eda`


### PR DESCRIPTION
## What

One line, one file. `ai/decisions/rf2-bbdbs2.guide-register-pass-review.md:13` carried an absolute maintainer worktree path. It is replaced with a placeholder plus a pointer to the guard script that derives the real root:

```
  `<worktree-parent>/guide-register-bbdbs2` (the `re-frame2-worktrees` sibling of
  the primary checkout — see `scripts/assert-worker-worktree.sh`)
```

The absolute path was convenience only — line 14 already carries the durable handle, `worker/guide-register-bbdbs2`.

## Why it blocks everything

`scripts/check-no-hardcoded-paths.sh` was failing **on `origin/main`**, tripping both detectors (literal `miket` token, and the personal-named-path root form). Since GitHub tests the PR *merge* commit, every open PR inherited main's violation and showed the "No hardcoded personal/home paths" check red. Three PRs were misdiagnosed as introducing it — they are clean. Merging this turns them all green with no branch changes.

## Quality gates

Run in the foreground, unpiped, from a fresh worktree off `origin/main`.

| Gate | Before | After |
| --- | --- | --- |
| `sh scripts/check-no-hardcoded-paths.sh` | `Portability gate FAILED: 2 hardcoded personal/home path violation(s).` (exit 1) | `Portability gate OK: no hardcoded personal/home paths in tracked files.` (exit 0) |
| `shellcheck scripts/check-no-hardcoded-paths.sh` | not installed locally | not installed locally — script is byte-identical to `main`, so CI's result is unchanged by this PR |

The failure reproduced on a clean checkout of `origin/main` before any edit, confirming main as the source rather than any PR branch.

**Scope of coverage:** nothing else is affected. The file is a local decision dossier outside the mkdocs tree — no build, test, or docs gate reads it. No broader suite was run, and none is implicated.

## What this PR deliberately does NOT do

- **The gate is not weakened.** Not modified, not allow-listed, no `continue-on-error`. It caught a real leak and worked exactly as designed.
- **`.gitignore` is not edited.** `/ai/` excludes the directory, so git will not descend into it even for already-tracked files; `git add -f` was required to stage this tracked file. That inertness is the known defect `rf2-2dupb` and is out of scope here.
- No other dossier touched, no commit reverted, no restructuring of `ai/decisions/`.

**Named, not acted on:** whether these dossiers should be tracked at all is `rf2-2dupb` / `rf2-4lv73`, not this PR.
