### PR TITLE
fix(core): serialize trace listeners across concurrent frame drains (rf2-wxy1c)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1680,40 +1680,18 @@
     (when-let [frame-record (frame frame-id)]
       (current-thread-is-drainer? frame-record))))
 
-(defn thread-owns-drain-serialization?
-  "True when the CALLING thread currently holds `frame-id`'s single-drainer
-  serialization — via EITHER path that takes the frame's `:drain-lock`: it is the
-  frame's active event DRAINER (`:in-drain?`, stamped around `run-one-pass!`), OR
-  the holder of a cold `call-serialized-with-drain!` critical section
-  (`:serialized-holder`). The both-axis sibling of `in-drain?` (which reports the
-  drainer axis alone).
-
-  This is the REAL lock-ownership evidence the trace tooling consults (via the
-  `:frame/thread-owns-drain-serialization?` late-bind hook) to decide whether an
-  outermost trace emit must drive its listener fan-out INLINE — a thread that
-  owns a frame's drain-lock must never block acquiring the trace `fanout-monitor`,
-  or a listener already holding the monitor that `dispatch-sync`es into that frame
-  closes the rf2-jl75r AB-BA cycle — versus serialize on the monitor like every
-  other clean emit (rf2-uw7hg). Unlike a `:frame`-tag / ambient-frame shape guess
-  (rf2-rakqk), this reports what the thread ACTUALLY holds right now, so a
-  frame-shaped emit issued OUTSIDE any held drain-lock (a public / manual / stale
-  `:frame` tag, an ambient-frame tool emit) correctly reports false and stays
-  serialized.
-
-  Returns false for an absent frame (nothing can be draining it, so no drain-lock
-  is held and no cycle can form)."
-  [frame-id]
-  (boolean
-    (when-let [frame-record (frame frame-id)]
-      (current-thread-owns-drain-serialization? frame-record))))
-
-;; Publish the drain-lock ownership probe so `re-frame.trace.tooling` can route
-;; an outermost emit inline-vs-monitor on REAL lock ownership (rf2-rakqk) rather
-;; than event-shape inference. Late-bound (not a static require) so a production
-;; CLJS bundle that never loads the tooling sibling still DCEs this edge, exactly
-;; like the sibling `:frame/current-frame-id` publication above.
-(late-bind/set-fn! :frame/thread-owns-drain-serialization?
-                   thread-owns-drain-serialization?)
+;; rf2-wxy1c retired the by-frame-id `thread-owns-drain-serialization?` probe and
+;; its `:frame/thread-owns-drain-serialization?` late-bind publication. It existed
+;; for exactly one consumer — `re-frame.trace.tooling`, which asked it whether an
+;; outermost trace emit should drive its listener fan-out inline (off
+;; `fanout-monitor`) to avoid the rf2-jl75r AB-BA cycle. That question no longer
+;; arises: the trace tooling now DEFERS a drain-owned fan-out to the post-drain
+;; boundary the three `:drain-lock` regions establish
+;; (`trace/call-with-deferred-listener-delivery` — `re-frame.router/drain-try!` /
+;; `drain-block!` and `call-serialized-with-drain!` below), so the deferral scope
+;; itself is the ownership evidence and no cross-namespace probe is needed. The
+;; private `current-thread-owns-drain-serialization?` above remains, serving the
+;; reentrancy fast-path it was written for.
 
 (defn call-serialized-with-drain!
   "Run thunk `f` serialized against `frame-id`'s event drain, returning its
@@ -1734,56 +1712,66 @@
     `re-frame.router/drain-block!` uses — bounded wait: an active drainer holds
     it for at most `drain-depth` events), stamp this thread as the
     `:serialized-holder`, run `f`, then clear the holder and release the lock
-    in a `finally`."
+    in a `finally`.
+
+  The cold acquire → run → release region is wrapped in
+  `trace/call-with-deferred-listener-delivery` (rf2-wxy1c): trace events emitted
+  inside a held cold section are delivered at that post-drain boundary, once the
+  lock is down, rather than running arbitrary listener code under it. The
+  already-owns branch inherits its owner's scope (the wrapper is nesting-aware),
+  so a nested serialized op appends to the SAME batch and the outermost holder
+  flushes it once."
   [frame-id f]
   (if-let [frame-record (frame frame-id)]
     (if (current-thread-owns-drain-serialization? frame-record)
       (f)
-      (let [drain-lock (:drain-lock frame-record)
-            holder     (:serialized-holder frame-record)]
-        (loop []
-          (when-not (compare-and-set! drain-lock false true)
-            #?(:clj (Thread/yield))
-            (recur)))
-        (reset! holder #?(:clj (Thread/currentThread) :cljs true))
-        (try
-          (f)
-          (finally
-            ;; Clear the holder BEFORE releasing the lock: once the lock is
-            ;; free another thread may acquire it and stamp its own holder, so
-            ;; clearing after the release could clobber that new owner.
-            (reset! holder nil)
-            ;; Per rf2-x76af2.22 (a): the cold release must mirror the
-            ;; drainer's `try-release-on-empty!`. A `dispatch!` that arrived
-            ;; DURING the hold set `:scheduled?` true and scheduled a
-            ;; `drain-try!` that CAS-lost to us and gave up — and, because we
-            ;; are NOT a drainer, nothing is left to re-check the queue. So a
-            ;; plain `(reset! drain-lock false)` PERMANENTLY STRANDS the queue
-            ;; (`:scheduled?` stuck true no-ops every later
-            ;; `ensure-drain-scheduled!`). Under the same lock submitters take
-            ;; in `ensure-drain-scheduled!`, snapshot the queue (stable — we
-            ;; still hold `:drain-lock`, so no drainer is popping) and release;
-            ;; if non-empty, re-kick a fresh async `drain-try!` (via the
-            ;; `:router/reschedule-drain!` late-bind seam — frame cannot
-            ;; `:require` router) so the stranded events drain. The one
-            ;; exception is a thunk that just CLAIMED destruction of this exact
-            ;; incarnation: claim is the queued-work cutoff, so re-kicking here
-            ;; would manufacture work inside the claim -> lifecycle-dead
-            ;; window. An already-submitted drain that has not CAS-lost yet is
-            ;; fenced independently by `frame-disposed-for-drain?`; suppressing
-            ;; this fresh kick handles the already-lost/no-retry case without
-            ;; stranding any LIVE frame. Releasing first lets an allowed
-            ;; re-kicked `drain-try!` CAS-acquire the now-free lock.
-            (let [router  (:router frame-record)
-                  strand? (locking router
-                            (let [pending? (seq (:queue @router))
-                                  closing? (frame-incarnation-closing?
-                                             frame-id drain-lock)]
-                              (reset! drain-lock false)
-                              (boolean (and pending? (not closing?)))))]
-              (when strand?
-                (when-let [reschedule! (late-bind/get-fn :router/reschedule-drain!)]
-                  (reschedule! frame-id frame-record))))))))
+      (trace/call-with-deferred-listener-delivery
+       (fn []
+         (let [drain-lock (:drain-lock frame-record)
+               holder     (:serialized-holder frame-record)]
+           (loop []
+             (when-not (compare-and-set! drain-lock false true)
+               #?(:clj (Thread/yield))
+               (recur)))
+           (reset! holder #?(:clj (Thread/currentThread) :cljs true))
+           (try
+             (f)
+             (finally
+               ;; Clear the holder BEFORE releasing the lock: once the lock is
+               ;; free another thread may acquire it and stamp its own holder, so
+               ;; clearing after the release could clobber that new owner.
+               (reset! holder nil)
+               ;; Per rf2-x76af2.22 (a): the cold release must mirror the
+               ;; drainer's `try-release-on-empty!`. A `dispatch!` that arrived
+               ;; DURING the hold set `:scheduled?` true and scheduled a
+               ;; `drain-try!` that CAS-lost to us and gave up — and, because we
+               ;; are NOT a drainer, nothing is left to re-check the queue. So a
+               ;; plain `(reset! drain-lock false)` PERMANENTLY STRANDS the queue
+               ;; (`:scheduled?` stuck true no-ops every later
+               ;; `ensure-drain-scheduled!`). Under the same lock submitters take
+               ;; in `ensure-drain-scheduled!`, snapshot the queue (stable — we
+               ;; still hold `:drain-lock`, so no drainer is popping) and release;
+               ;; if non-empty, re-kick a fresh async `drain-try!` (via the
+               ;; `:router/reschedule-drain!` late-bind seam — frame cannot
+               ;; `:require` router) so the stranded events drain. The one
+               ;; exception is a thunk that just CLAIMED destruction of this exact
+               ;; incarnation: claim is the queued-work cutoff, so re-kicking here
+               ;; would manufacture work inside the claim -> lifecycle-dead
+               ;; window. An already-submitted drain that has not CAS-lost yet is
+               ;; fenced independently by `frame-disposed-for-drain?`; suppressing
+               ;; this fresh kick handles the already-lost/no-retry case without
+               ;; stranding any LIVE frame. Releasing first lets an allowed
+               ;; re-kicked `drain-try!` CAS-acquire the now-free lock.
+               (let [router  (:router frame-record)
+                     strand? (locking router
+                               (let [pending? (seq (:queue @router))
+                                     closing? (frame-incarnation-closing?
+                                                frame-id drain-lock)]
+                                 (reset! drain-lock false)
+                                 (boolean (and pending? (not closing?)))))]
+                 (when strand?
+                   (when-let [reschedule! (late-bind/get-fn :router/reschedule-drain!)]
+                     (reschedule! frame-id frame-record))))))))))
     (f)))
 
 ;; ---- frame presets (Spec 002 §Frame presets) ------------------------------

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -1104,10 +1104,6 @@
     :producer-ns 're-frame.frame
     :design-bead "rf2-g1b2m"
     :description "Read the currently-bound frame id from `re-frame.frame/*current-frame*`. Consulted by `re-frame.trace.tooling/push-to-ring!` as the routing fallback when the trace event itself does not carry a `:frame` tag (e.g. sub recompute / view render emits inside an in-flight cascade)."}
-   {:key         :frame/thread-owns-drain-serialization?
-    :producer-ns 're-frame.frame
-    :design-bead "rf2-rakqk"
-    :description "Return true when the CALLING thread currently holds `frame-id`'s single-drainer serialization — the frame's active event drainer (`:in-drain?`, stamped around `run-one-pass!`) OR the holder of a cold `call-serialized-with-drain!` critical section (`:serialized-holder`); the both-axis sibling of the drainer-only `in-drain?`. Consulted by `re-frame.trace.tooling/emit-under-owned-drain-lock?` as the REAL lock-ownership discriminator (not event-shape inference) that routes an outermost trace emit inline-vs-monitor: a thread that owns the target frame's `:drain-lock` must drive its listener fan-out INLINE (a listener already holding `fanout-monitor` may `dispatch-sync` into that frame and spin on its `:drain-lock` — the rf2-jl75r AB-BA seam), while a frame-shaped emit issued outside any held drain-lock serializes on the monitor like every clean emit (rf2-uw7hg). Returns false for an absent frame (nothing can be draining it). Dev-only: late-bound so a production CLJS bundle that never loads the tooling sibling DCEs the edge."}
 
    ;; ---- re-frame.trace.cascade (focused-event-only cascade-DAG aggregator) ----
    ;;

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -3502,22 +3502,30 @@
   for the queue (its release block re-checks under lock — see
   drain-loop!). On win, runs the drain body and releases.
 
+  Wrapped in `trace/call-with-deferred-listener-delivery` (rf2-wxy1c): the whole
+  acquire → drain → release region is one post-drain trace-delivery boundary, so
+  this drain's traces reach listeners only once the `:drain-lock` is back down —
+  never concurrently with a sibling frame's drain, and never with arbitrary
+  listener code running under our lock.
+
   Per rf2-ynk7 §single-drainer invariant."
   [frame-id frame-record]
-  (let [drain-lock  (:drain-lock frame-record)
-        router      (:router frame-record)
-        drain-depth (get-in frame-record [:config :drain-depth] drain-depth-default)]
-    (when (compare-and-set! drain-lock false true)
-      ;; Exact-target revalidation belongs INSIDE the acquired serialization
-      ;; boundary.  A scheduled callback for obsolete incarnation A must never
-      ;; re-resolve the bare id and become an eager drain of same-id B.
-      (if (frame/frame-incarnation-live? frame-id drain-lock)
-        (try
-          (drain-loop! frame-id frame-record router drain-lock drain-depth false)
-          (catch #?(:clj Throwable :cljs :default) t
-            (drain-emergency-release! router drain-lock)
-            (throw t)))
-        (reset! drain-lock false)))))
+  (trace/call-with-deferred-listener-delivery
+    (fn []
+      (let [drain-lock  (:drain-lock frame-record)
+            router      (:router frame-record)
+            drain-depth (get-in frame-record [:config :drain-depth] drain-depth-default)]
+        (when (compare-and-set! drain-lock false true)
+          ;; Exact-target revalidation belongs INSIDE the acquired serialization
+          ;; boundary.  A scheduled callback for obsolete incarnation A must never
+          ;; re-resolve the bare id and become an eager drain of same-id B.
+          (if (frame/frame-incarnation-live? frame-id drain-lock)
+            (try
+              (drain-loop! frame-id frame-record router drain-lock drain-depth false)
+              (catch #?(:clj Throwable :cljs :default) t
+                (drain-emergency-release! router drain-lock)
+                (throw t)))
+            (reset! drain-lock false)))))))
 
 (defn- drain-block!
   "Synchronous drain entry point (called from `dispatch-sync!`). Unlike
@@ -3542,11 +3550,19 @@
   post-CAS incarnation revalidation passed. `false` when A was lost during the
   spin-CAS wait, so the seed-push was skipped and the lock reset (rf2-a2x2w:
   `dispatch-sync!` reads that signal to recover-but-emit exactly once for a
-  captured op that lost its pinned incarnation before the drain-lock acquire)."
+  captured op that lost its pinned incarnation before the drain-lock acquire).
+
+  Wrapped in `trace/call-with-deferred-listener-delivery` (rf2-wxy1c) so the whole
+  acquire → seed → drain → release region — `under-lock-fn` included, since it too
+  emits while the lock is held — is one post-drain trace-delivery boundary. The
+  deferred batch is flushed before this returns, so `dispatch-sync`'s
+  settle-before-return contract still covers listener delivery."
   [frame-id frame-record under-lock-fn]
-  (let [drain-lock  (:drain-lock frame-record)
-        router      (:router frame-record)
-        drain-depth (get-in frame-record [:config :drain-depth] drain-depth-default)]
+  (trace/call-with-deferred-listener-delivery
+    (fn []
+      (let [drain-lock  (:drain-lock frame-record)
+            router      (:router frame-record)
+            drain-depth (get-in frame-record [:config :drain-depth] drain-depth-default)]
         ;; Spin-CAS until we acquire. On JVM the active drainer holds
         ;; the lock for the duration of one drain pass — bounded by
         ;; drain-depth events at most — so the wait is bounded. CLJS
@@ -3555,18 +3571,18 @@
           (when-not (compare-and-set! drain-lock false true)
             #?(:clj (Thread/yield))
             (recur)))
-    ;; The caller accepted THIS record.  Revalidate it only after acquiring its
-    ;; lock; never re-resolve by id after a wait in which A may become B.
-    (if (frame/frame-incarnation-live? frame-id drain-lock)
-      (try
-        (under-lock-fn)
-        (drain-loop! frame-id frame-record router drain-lock drain-depth false)
-        true
-        (catch #?(:clj Throwable :cljs :default) t
-          (drain-emergency-release! router drain-lock)
-          (throw t)))
-      (do (reset! drain-lock false)
-          false))))
+        ;; The caller accepted THIS record.  Revalidate it only after acquiring its
+        ;; lock; never re-resolve by id after a wait in which A may become B.
+        (if (frame/frame-incarnation-live? frame-id drain-lock)
+          (try
+            (under-lock-fn)
+            (drain-loop! frame-id frame-record router drain-lock drain-depth false)
+            true
+            (catch #?(:clj Throwable :cljs :default) t
+              (drain-emergency-release! router drain-lock)
+              (throw t)))
+          (do (reset! drain-lock false)
+              false))))))
 
 (defn- drain-reentrant!
   "Reentrant synchronous-drain entry for a thread that ALREADY owns

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -132,6 +132,57 @@
   (let [p *continuation-predicate*]
     (fn [] (or (nil? p) (p)))))
 
+#?(:clj
+   (defn- call-with-ordinary-delivery-scope
+     "Run `f` under the ordinary delivery defaults the public trace-listener
+     fan-out is entitled to — the same four axes `deliver!` restores around an
+     inline fan-out (rf2-vf2qke + rf2-eaxnai): epoch capture, frame-no-emit policy
+     and ring retention back to their defaults, and the exact-owner continuation
+     neutralised.
+
+     `deliver!` gets this for free because an inline fan-out runs inside its
+     `binding`. A DEFERRED fan-out (rf2-wxy1c) runs later, at the post-drain
+     boundary, long after `deliver!` returned — so without re-establishing the
+     scope here a listener body would inherit whatever authority the DRAIN was
+     running under. That is precisely the rf2-eaxnai defect: a listener whose
+     nested authored work (dispatch / destroy / create) consults a fence that
+     belongs to the drain's own event tail gets silently dropped.
+
+     JVM-only, like the deferral seam it serves."
+     [f]
+     (binding [*epoch-capture-enabled?*  true
+               *frame-policy-enabled?*   true
+               *ring-retention-enabled?* true
+               *continuation-predicate*  nil]
+       (f))))
+
+(defn ^:no-doc call-with-deferred-listener-delivery
+  "Run `f` as one post-drain trace-listener delivery region — the rf2-wxy1c seam.
+  Trace events emitted inside it while the framework owns a frame's `:drain-lock`
+  are appended rather than fanned out, and delivered on the way out, serialized
+  process-wide, before the enclosing dispatch / drain call returns.
+
+  The drain engine wraps its `:drain-lock` acquire → run → release regions in this
+  (`re-frame.router/drain-try!` / `drain-block!` and
+  `re-frame.frame/call-serialized-with-drain!`) so that arbitrary listener code is
+  never invoked — nor awaited — while a drain lock is held, and so that two
+  independent frames draining concurrently cannot enter one listener at once. See
+  `re-frame.trace.tooling/call-with-deferred-fanout` for the mechanism and the
+  invariants that placement carries.
+
+  JVM-only by construction, and the reader conditional is load-bearing for
+  BUNDLE ISOLATION, not just for clarity. The drain is production code, so this
+  fn is live in a production CLJS build; routing it through the tooling sibling
+  unconditionally would give that always-reachable call site a static reference
+  into `re-frame.trace.tooling`, pulling the dev-only listener registry + ring
+  machinery (and its `check-bundle-isolation.cjs` sentinel) into the production
+  counter bundle. CLJS is single-threaded — no concurrent drains, no monitor,
+  nothing to defer — so the `:cljs` arm is the identity call and emits no
+  reference at all."
+  [f]
+  #?(:clj  (trace-tooling/call-with-deferred-fanout f call-with-ordinary-delivery-scope)
+     :cljs (f)))
+
 (defn ^:no-doc call-with-structural-delivery
   "Deliver a structural trace without bare-id epoch/policy attribution and
   without any per-frame ring retention.

--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -738,7 +738,7 @@
 ;;
 ;; ---- cross-thread fan-out serialization (rf2-uw7hg) -----------------------
 ;;
-;; `*fanout-ctx*` is thread-local (a dynamic binding), so it only schedules
+;; `*fanout-ctx*` is per-thread (a dynamic binding), so it only schedules
 ;; SAME-thread reentrant emits. It says nothing about two emits racing on two JVM
 ;; threads: each opens its OWN outermost fan-out and each would invoke the SAME
 ;; registered listener callback CONCURRENTLY. That violates the public listener
@@ -758,7 +758,7 @@
 ;; emit still returns only after its record's callback has run (the monitor is
 ;; held for the whole synchronous drive and released before `emit!` returns).
 ;;
-;; ---- the drain-lock ownership seam (rf2-jl75r + rf2-rakqk) -----------------
+;; ---- the post-drain deferral seam (rf2-jl75r + rf2-rakqk + rf2-wxy1c) -------
 ;;
 ;; Holding `fanout-monitor` across arbitrary listener bodies is NOT safe for an
 ;; emit issued while the emitting thread holds a frame's `:drain-lock`. Public
@@ -772,50 +772,65 @@
 ;; Neither can progress. `drain-block!`'s bounded-wait assumption is false because
 ;; the active drainer (T2) is itself waiting on the caller (T1).
 ;;
-;; The fix keeps the whole synchronous, ordered, serialized fan-out but takes the
-;; monitor OUT of the cycle for exactly the emits that can close it: an emit whose
-;; thread ACTUALLY holds the target frame's `:drain-lock`
-;; (`emit-under-owned-drain-lock?`) NEVER acquires the monitor — it drives its
-;; fan-out inline (exactly as CLJS always does), so the "drain-lock holder waits
-;; on the monitor" edge is removed and no cycle can form.
+;; jl75r broke that cycle by routing a drain-owned emit's fan-out INLINE, off the
+;; monitor; rakqk made the discriminator real drain-lock OWNERSHIP rather than
+;; event-shape inference. Both fixes shared one assumption — that an inline
+;; drain-owned fan-out is already mutually exclusive, because a frame has a single
+;; drainer. It is not. The drain-lock serializes ONE FRAME's drain; the listener
+;; registry is PROCESS-global. Two INDEPENDENT frames draining on two JVM threads
+;; each own their own lock, so both qualified for the inline path and both entered
+;; the same arbitrary listener callback at once (rf2-wxy1c) — the rf2-uw7hg serial
+;; law lost again, this time drain-vs-drain, with arbitrary programmer / tool
+;; listener code additionally running while the framework held a drain lock.
 ;;
-;; The discriminator is REAL LOCK-OWNERSHIP EVIDENCE, not event-shape inference
-;; (rf2-rakqk). jl75r's first cut keyed on frame ROUTABILITY — any `:frame` tag,
-;; caller-supplied dispatch-id, ambient frame, or `retain? false` bypassed the
-;; monitor — but a frame-SHAPED emit is not proof of lock ownership: a public /
-;; manual / stale `:frame` tag, an ambient-frame tool emit, or a retained
-;; frame-shaped `trace/emit!` issued OUTSIDE any drain owns no lock, yet was
-;; routed inline and so LOST the rf2-uw7hg whole-fanout serial law. The fix asks
-;; the frame engine (`:frame/thread-owns-drain-serialization?`) whether THIS
-;; thread holds that frame's single-drainer serialization right now — the active
-;; drainer (`:in-drain?`, stamped around `run-one-pass!`) OR the holder of a cold
-;; `call-serialized-with-drain!` section (`:serialized-holder`). Only then does it
-;; drive inline; otherwise it serializes on the monitor like every other emit.
+;; The repair is to the TIMING, not the classifier. A drain-owned emit no longer
+;; fans out at all while the lock is held: it is APPENDED to a per-thread pending
+;; vector and delivered at ONE explicit post-drain boundary
+;; (`call-with-deferred-fanout`, established by `re-frame.router/drain-try!` /
+;; `drain-block!` and `re-frame.frame/call-serialized-with-drain!` around their
+;; whole acquire → run → release region), where the batch is flushed under
+;; `fanout-monitor` before the enclosing dispatch / drain call returns.
 ;;
-;; This is EXACT for every genuine drain / settle / teardown emit and no longer
-;; over-broad. The epoch cascade trailers (`:rf.epoch/snapshotted` /
-;; `:rf.epoch/outcome`) fire AFTER the buffer is harvested with a nil dispatch-id,
-;; yet carry a top-level `:frame` and run inside `settle-event-epoch!` while
-;; `:in-drain?` is still stamped — so ownership reports true and they stay inline
-;; (a dispatch-id-only test misclassified them). The retentionless structural
-;; terminals (`:rf.frame/destroyed` / `:rf.frame/drain-interrupted`) carry `:frame`
-;; and are emitted while the drain / destroy path owns the serialization — also
-;; inline, without a blanket `retain? false` bypass. Same-thread reentrant
-;; delivery of the drain's own nested emits is unaffected — those take the
-;; `*fanout-ctx*` append+drive branch, never the monitor. Because the evidence is
-;; exact, deadlock-freedom is unconditional: a false result PROVES no drain-lock is
-;; held (no AB-BA edge through the monitor); a true result acquires no monitor. The
-;; residual JVM-only relaxation is now the exact, minimal one — two genuinely
-;; concurrent frame drains of the SAME frame (never a thing on the single-threaded
-;; CLJS target) each own their drain-lock and drive inline.
+;; That single change discharges both laws at once, and the dynamic scope IS the
+;; ownership evidence — no frame resolution, no ownership probe, no shape guess:
+;;
+;;   - SERIAL (rf2-uw7hg / rf2-wxy1c). Every listener fan-out — clean or
+;;     drain-owned — now runs under `fanout-monitor`. No callback overlaps itself
+;;     and records reach each listener in one process-wide order.
+;;   - DEADLOCK-FREE (rf2-jl75r). The monitor is acquired at exactly two places:
+;;     an outermost emit OUTSIDE any deferral scope, and the post-drain flush. The
+;;     scope is bound for the entire dynamic extent in which the thread can hold a
+;;     drain-lock (entered before the acquire, exited after the release), so an
+;;     unscoped emit PROVES its thread holds no drain-lock, and the flush runs
+;;     with the lock already dropped and the scope rebound nil. No thread ever
+;;     waits on the monitor while owning a drain-lock, so the AB-BA edge cannot
+;;     exist — an invariant of the seam's construction, not a property of any
+;;     particular interleaving.
+;;
+;; Delivery CONTENT is unchanged — only its timing. Two things are captured at
+;; append time so a deferred fan-out delivers exactly what an inline one would
+;; have: the listener SNAPSHOT (so a listener registered / unregistered later in
+;; the same drain does not gain or lose an earlier event), and a one-shot latch
+;; over `continue?` (`deferred-continue`) so an incarnation destroyed later in the
+;; drain cannot retroactively suppress an event that was already authorised at
+;; emission, while a listener that destroys it DURING the deferred fan-out still
+;; suppresses the remainder exactly as rf2-eaxnai requires. Emission ORDER is
+;; preserved: the ring push and epoch capture still run inline, the pending vector
+;; is FIFO, and the whole batch is flushed under one monitor hold, so a drain's
+;; own traces reach listeners contiguously and in order. Each deferred event is
+;; driven through its OWN `run-outermost-fanout!`, so a listener's reentrant emit
+;; is scheduled against that event exactly as it would have been inline.
 ;;
 ;; Same-thread reentrancy does NOT re-acquire the monitor: a nested emit sees
 ;; `*fanout-ctx*` already bound and takes the append+drive branch below, so it
 ;; never reaches the lock — no self-deadlock, and the reentrant schedule advances
-;; the SAME critical section. `locking` is a reentrant monitor regardless, so even
-;; a hypothetical re-entry could not deadlock on itself. CLJS is single-threaded
-;; (no concurrent emits): the `:cljs` arm runs the drive inline with no monitor,
-;; preserving production elision.
+;; the SAME critical section. `locking` is a reentrant monitor regardless, so a
+;; listener whose `dispatch-sync` drains a frame and flushes that drain's deferred
+;; batch while its own fan-out still holds the monitor simply re-enters it.
+;;
+;; CLJS is single-threaded: no concurrent emits, no monitor, no deferral (the
+;; scope is never bound and `call-with-deferred-fanout` is the identity call).
+;; Delivery stays inline exactly as before, preserving production elision.
 
 (def ^:private ^:dynamic *fanout-ctx*
   "When bound, the shared fan-out schedule for the outermost listener fan-out in
@@ -829,72 +844,45 @@
 
 #?(:clj
    (def ^:private ^Object fanout-monitor
-     "Process-global JVM monitor serializing every EXTERNAL/clean OUTERMOST
-     trace-listener fan-out across concurrent emits (rf2-uw7hg), so no registered
+     "Process-global JVM monitor serializing EVERY outermost trace-listener
+     fan-out across concurrent emits (rf2-uw7hg / rf2-wxy1c), so no registered
      listener callback is ever invoked on two threads at once and records reach
-     each listener in one defined order. Held for the whole synchronous drive of
-     such an emit. An emit whose thread actually owns the target frame's
-     `:drain-lock` (`emit-under-owned-drain-lock?`) NEVER acquires it — see the
-     deadlock note below — and reentrant same-thread emits never acquire it (they
-     advance the bound `*fanout-ctx*` schedule). CLJS is single-threaded and has no
-     counterpart."
+     each listener in one defined order. Held for the whole synchronous drive of a
+     clean emit, and for the whole post-drain flush of a deferred batch. Reentrant
+     same-thread emits never acquire it (they advance the bound `*fanout-ctx*`
+     schedule), and a thread that owns a frame's `:drain-lock` never acquires it
+     (it appends to `*deferred-drain-fanout*` instead — see the seam note above).
+     CLJS is single-threaded and has no counterpart."
      (Object.)))
 
 #?(:clj
-   (defn- emit-under-owned-drain-lock?
-     "True when this outermost emit is issued by a thread that ACTUALLY holds the
-     target frame's `:drain-lock` right now — the ONLY condition under which
-     acquiring `fanout-monitor` could close the rf2-jl75r AB-BA cycle. Such an emit
-     MUST drive its fan-out INLINE (off the monitor): a listener already holding
-     the monitor is allowed to `dispatch-sync` into that same frame and would spin
-     on its `:drain-lock`, and if the emitting drainer thread then blocked
-     acquiring the monitor neither could progress. Driving inline removes the
-     drain-lock↔monitor edge entirely.
+   (def ^:private ^ThreadLocal deferred-drain-fanout
+     "When set, the post-drain deferral scope for THIS thread: a volatile FIFO
+     vector of `[event continue? entries]` triples awaiting listener delivery.
 
-     The discriminator is REAL LOCK-OWNERSHIP EVIDENCE, not event-shape inference
-     (rf2-rakqk). The emit's target frame is resolved exactly as `push-to-ring!`
-     routes to a per-frame ring — an explicit `[:tags :frame]`, a top-level
-     `:frame`, or the in-flight run's `frame/*current-frame*` (the
-     `:frame/current-frame-id` hook) — and we then ask the frame engine whether
-     THIS thread owns that frame's single-drainer serialization (the
-     `:frame/thread-owns-drain-serialization?` hook: true iff the thread is the
-     frame's active event drainer `:in-drain?`, OR the holder of a cold
-     `call-serialized-with-drain!` critical section `:serialized-holder` — the two
-     paths that take the frame's `:drain-lock`). Every genuine drain / settle /
-     teardown emit — including the epoch cascade trailers (`:rf.epoch/snapshotted`
-     / `:rf.epoch/outcome`, which fire AFTER the buffer is harvested with a nil
-     dispatch-id yet carry a top-level `:frame` and run on the drainer thread while
-     `:in-drain?` is stamped) and the retentionless structural terminals
-     (`:rf.frame/destroyed` / `:rf.frame/drain-interrupted`, carrying `:frame` and
-     emitted while the drain / destroy path owns the serialization) — resolves its
-     frame and reports true, so it stays off the monitor and the deadlock cannot
-     form.
+     `call-with-deferred-fanout` sets it around each region in which the thread
+     can hold a frame's `:drain-lock` — `re-frame.router/drain-try!` /
+     `drain-block!` and `re-frame.frame/call-serialized-with-drain!`, each
+     bracketing its whole acquire → run → release — and flushes the batch under
+     `fanout-monitor` on the way out. So `set` is exactly \"this thread may
+     currently own a drain-lock\", which is why the outermost emit branch below
+     needs no frame resolution and no ownership probe: an emit that finds this nil
+     PROVES its thread holds no drain-lock and may safely block on the monitor.
 
-     A frame-SHAPED emit that is NOT under a held drain-lock — a public / manual /
-     stale / malformed `:frame` tag, an ambient-frame tool emit, a retained-frame
-     `trace/emit!` outside any drain — owns NO lock, so it reports false and
-     serializes on the monitor like every other clean emit. This RESTORES the
-     rf2-uw7hg whole-fanout serial law the prior event-shape heuristic lost for
-     those emits: event payload shape can no longer opt an emit out of
-     serialization. A frameless clean emit resolves no frame and likewise
-     serializes.
-
-     Because the evidence is exact, deadlock-freedom holds unconditionally: a
-     false result PROVES the thread holds no drain-lock (so no AB-BA edge through
-     the monitor), and a true result drives inline (so no monitor is acquired at
-     all).
-
-     JVM-only: the `:cljs` outermost arm has no monitor, so it needs no predicate."
-     [event]
-     (when-let [frame-id (or (get-in event [:tags :frame])
-                             (:frame event)
-                             (when-let [current-frame
-                                        (late-bind/get-fn-cached :frame/current-frame-id)]
-                               (current-frame)))]
-       (boolean
-         (when-let [owns? (late-bind/get-fn-cached
-                            :frame/thread-owns-drain-serialization?)]
-           (owns? frame-id))))))
+     A `ThreadLocal`, deliberately NOT a `^:dynamic` Var. Drain-lock ownership is
+     a property of a THREAD, and a Var binding is a property of a logical call
+     context that Clojure will happily CONVEY to other threads: JVM
+     `re-frame.interop/next-tick` and `set-timeout!` both wrap their callback in
+     `bound-fn`. An `ensure-drain-scheduled!` issued mid-drain would therefore
+     hand the executor thread the draining thread's scope, and an armed
+     `:dispatch-later` would hand it to the timer thread — each then appending its
+     own, entirely unrelated, trace events to a batch whose owner has long since
+     flushed and walked away. Those events would never be delivered to any
+     listener. A `ThreadLocal` is not conveyed, so a scheduled task starts clean
+     and opens its own scope. Cleared with `.remove` on the way out, so the flush
+     — and any drain a listener body starts from it — sees no scope. JVM-only:
+     CLJS has no concurrent drains and keeps the historical inline delivery."
+     (ThreadLocal.)))
 
 (defn- drive-fanout!
   "Drive the shared fan-out schedule `ctx` to completion: deliver every queued
@@ -938,19 +926,127 @@
 (defn- run-outermost-fanout!
   "Seed a fresh fan-out schedule for `event`, bind it as `*fanout-ctx*` so
   reentrant emits from listener bodies advance the SAME schedule, and drive it to
-  completion. On the JVM an emit whose thread does NOT own the target frame's
-  drain-lock runs this under `fanout-monitor` so concurrent emits serialize
-  (rf2-uw7hg); an emit that DOES own it (`emit-under-owned-drain-lock?`) runs it
-  inline, off the monitor, to break the drain-lock↔monitor cycle (rf2-jl75r /
-  rf2-rakqk — see the `deliver-to-tooling!` outermost branch). Either way the
-  binding + drive are the whole critical section."
-  [event continue?]
-  (let [ctx {:q       (volatile! [[event continue?]])
-             :head    (volatile! 0)
-             :entries (volatile! nil)
-             :lcursor (volatile! 0)}]
-    (binding [*fanout-ctx* ctx]
-      (drive-fanout! ctx))))
+  completion. Always runs under `fanout-monitor` on the JVM so concurrent emits
+  serialize (rf2-uw7hg) — either directly (a clean emit) or inside the post-drain
+  flush of a deferred batch (rf2-wxy1c); see the `deliver-to-tooling!` outermost
+  branch. The binding + drive are the whole critical section.
+
+  `entries` pre-seeds the listener snapshot for THIS event instead of letting the
+  driver take one at delivery time. The post-drain flush passes the snapshot
+  captured when the event was APPENDED, so a deferred delivery reaches exactly the
+  listeners an inline delivery would have; nil (the default) keeps the ordinary
+  snapshot-at-delivery behaviour. Reentrant events queued behind this one always
+  re-snapshot — the driver resets `:entries` to nil as it advances."
+  ([event continue?] (run-outermost-fanout! event continue? nil))
+  ([event continue? entries]
+   (let [ctx {:q       (volatile! [[event continue?]])
+              :head    (volatile! 0)
+              :entries (volatile! entries)
+              :lcursor (volatile! 0)}]
+     (binding [*fanout-ctx* ctx]
+       (drive-fanout! ctx)))))
+
+#?(:clj
+   (defn- deferred-continue
+     "Wrap an appended event's `continue?` snapshot so deferral cannot change
+     WHETHER the event is delivered — only when.
+
+     Under inline delivery the driver's first `continue?` check happens in the
+     same breath as `deliver!`'s own `(continuing?)` gate, so it always passes;
+     only a LISTENER acting during the fan-out can flip it and suppress the
+     remaining listeners (rf2-eaxnai). Deferral opens a gap: the rest of the drain
+     runs before the first check, so an incarnation this drain destroys later
+     would retroactively cancel a fan-out that was already authorised at emission
+     — silently dropping the event.
+
+     The latch restores the inline reading exactly: the first check (before the
+     first listener) passes unconditionally, and every check thereafter — i.e.
+     after a listener body has actually run — consults the live predicate. So
+     rf2-eaxnai's mid-fan-out suppression is preserved while the pre-fan-out gap
+     the deferral introduced is closed."
+     [continue?]
+     (let [delivered (volatile! false)]
+       (fn []
+         (if @delivered
+           (continue?)
+           (do (vreset! delivered true) true))))))
+
+#?(:clj
+   (defn- flush-deferred-fanout!
+     "Deliver a drain's appended trace events to their listeners at the post-drain
+     boundary. The caller has already released the frame's `:drain-lock`, so this
+     is the first point at which arbitrary listener code may run and the first at
+     which blocking on `fanout-monitor` is safe.
+
+     The whole batch is flushed under ONE monitor hold, so a drain's traces reach
+     every listener contiguously and in emission order rather than interleaved
+     with a concurrent drain's. Each event is driven through its own outermost
+     schedule under the listener snapshot taken when it was appended, so a
+     listener's reentrant emit is scheduled against that event exactly as it would
+     have been inline. The drain loop re-reads `pending` so an append that somehow
+     raced the flush still settles here — exactly once — rather than being
+     stranded."
+     [pending]
+     (when (seq @pending)
+       (locking fanout-monitor
+         (loop []
+           (let [batch @pending]
+             (when (seq batch)
+               (vreset! pending [])
+               (doseq [[event continue? entries] batch]
+                 (run-outermost-fanout! event continue? entries))
+               (recur))))))))
+
+(defn ^:no-doc call-with-deferred-fanout
+  "Run `f` as one post-drain listener-delivery region: trace events emitted inside
+  it by a thread that owns a frame's `:drain-lock` are appended rather than fanned
+  out, and the batch is delivered here, on the way out, under `fanout-monitor`.
+
+  Wrap the WHOLE acquire → run → release region of every path that takes a
+  `:drain-lock` (`re-frame.router/drain-try!` / `drain-block!` and
+  `re-frame.frame/call-serialized-with-drain!`). Two properties of that placement
+  are load-bearing (see the seam note above): the scope must OPEN before the
+  acquire, so no drain-owned emit can escape deferral and block on the monitor
+  while holding a lock; and it must CLOSE after the release, so the flush — which
+  runs arbitrary listener code and does block on the monitor — owns no lock. The
+  flush runs in a `finally`, so a drain that throws still settles its traces
+  exactly once.
+
+  `flush-scope` receives the flush thunk and must run it under the ORDINARY
+  delivery scope `re-frame.trace/deliver!` establishes around an inline fan-out —
+  epoch capture, frame policy and ring retention restored to their defaults, and
+  the exact-owner continuation neutralised (rf2-vf2qke / rf2-eaxnai), so a
+  listener's nested authored work is not strangled by the scope the DRAIN was
+  running under. Inline delivery gets that binding for free because the fan-out
+  happens inside `deliver!`; a deferred fan-out happens after `deliver!` has
+  returned, so the scope has to be re-established here. It is supplied as an
+  argument because those dynamic vars are private to `re-frame.trace`, which this
+  sibling deliberately cannot see — the same reason `deliver!` passes `retain?`
+  and `continue?` explicitly rather than letting this ns read them.
+
+  Nesting is inherited, not re-established: a reentrant drain (`drain-reentrant!`
+  under a cold serialized section, an `:rf.fx/reg-flow` mid-drain) already runs
+  inside its owner's scope and appends to the same batch, which the OWNER flushes
+  once it has dropped the lock.
+
+  JVM-only behaviour. CLJS has no concurrent drains, no monitor, and keeps its
+  historical inline delivery, so this is the identity call there — and in
+  production, where the trace fan-out is elided entirely."
+  [f flush-scope]
+  #?(:clj  (if (or (not interop/debug-enabled?)
+                   (.get deferred-drain-fanout))
+             (f)
+             (let [pending (volatile! [])]
+               (try
+                 (.set deferred-drain-fanout pending)
+                 (f)
+                 (finally
+                   ;; Clear BEFORE flushing: the flush runs listener bodies, and a
+                   ;; listener that dispatches must open its own scope rather than
+                   ;; append to the batch currently draining.
+                   (.remove deferred-drain-fanout)
+                   (flush-scope #(flush-deferred-fanout! pending))))))
+     :cljs (f)))
 
 (defn- deliver-to-tooling!
   "Push `event` onto its in-flight frame's run-keyed ring (when the run has a
@@ -998,28 +1094,28 @@
          nil)
      ;; Outermost fan-out.
      ;;
-     ;; An emit issued by a thread that ACTUALLY holds the target frame's
-     ;; `:drain-lock` (`emit-under-owned-drain-lock?` — resolved from REAL
-     ;; lock-ownership evidence, not event-shape inference; rf2-rakqk) MUST NOT
-     ;; block acquiring `fanout-monitor`: a listener already holding the monitor is
-     ;; free to `dispatch-sync` into that same frame and spin on its `:drain-lock`,
-     ;; closing a hard AB-BA cycle (rf2-jl75r). Such an emit drives its fan-out
-     ;; inline — exactly as the single-threaded CLJS host always does — so no
-     ;; process-global lock is ever held by, or awaited by, a drain-lock-owning
-     ;; emit. This is the "no fan-out lock across arbitrary listener code that may
-     ;; dispatch-sync into the draining frame" seam.
+     ;; A thread inside a deferral scope may currently own a frame's `:drain-lock`
+     ;; (`call-with-deferred-fanout` brackets every acquire → run → release
+     ;; region), so it MUST NOT block acquiring `fanout-monitor`: a listener
+     ;; already holding the monitor is free to `dispatch-sync` into that frame and
+     ;; spin on its `:drain-lock`, closing a hard AB-BA cycle (rf2-jl75r). Such an
+     ;; emit APPENDS instead — capturing the listener snapshot and latching
+     ;; `continue?` so the deferred delivery reaches exactly what an inline one
+     ;; would have — and the post-drain flush delivers it under the monitor once
+     ;; the lock is released, before the enclosing dispatch / drain returns
+     ;; (rf2-wxy1c). No lock is held by, or awaited by, a drain-owned emit.
      ;;
-     ;; Every OTHER outermost emit — a frameless external/clean emit, AND a
-     ;; frame-shaped emit whose thread does NOT hold that frame's drain-lock (a
-     ;; public/manual/stale `:frame` tag, an ambient-frame tool emit) — serializes
-     ;; on `fanout-monitor` across concurrent emits (rf2-uw7hg) so no listener
-     ;; callback overlaps itself and records reach each listener in
-     ;; monitor-acquisition order; the monitor is held for that whole drive. Such a
-     ;; thread holds no `:drain-lock`, so nothing waits on it through one and the
-     ;; drain-lock↔monitor cycle cannot form. CLJS is single-threaded and runs
-     ;; every outermost emit inline with no monitor.
-     #?(:clj  (if (emit-under-owned-drain-lock? event)
-                (run-outermost-fanout! event continue?)
+     ;; Every OTHER outermost emit is, by that same bracketing, provably issued by
+     ;; a thread holding NO drain-lock — so it serializes on `fanout-monitor`
+     ;; across concurrent emits (rf2-uw7hg) with the monitor held for the whole
+     ;; drive, and nothing can wait on it through a drain-lock. CLJS is
+     ;; single-threaded, never opens a deferral scope, and runs every outermost
+     ;; emit inline with no monitor.
+     #?(:clj  (if-let [pending (.get deferred-drain-fanout)]
+                (do (vswap! ^clojure.lang.Volatile pending conj
+                            [event (deferred-continue continue?)
+                             (vec (seq @listeners))])
+                    nil)
                 (locking fanout-monitor (run-outermost-fanout! event continue?)))
         :cljs (run-outermost-fanout! event continue?)))))
 

--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -810,12 +810,14 @@
 ;; Delivery CONTENT is unchanged — only its timing. Two things are captured at
 ;; append time so a deferred fan-out delivers exactly what an inline one would
 ;; have: the listener SNAPSHOT (so a listener registered / unregistered later in
-;; the same drain does not gain or lose an earlier event), and a one-shot latch
-;; over `continue?` (`deferred-continue`) so an incarnation destroyed later in the
-;; drain cannot retroactively suppress an event that was already authorised at
-;; emission, while a listener that destroys it DURING the deferred fan-out still
-;; suppresses the remainder exactly as rf2-eaxnai requires. Emission ORDER is
-;; preserved: the ring push and epoch capture still run inline, the pending vector
+;; the same drain does not gain or lose an earlier event), and a baseline-relative
+;; reading of `continue?` (`deferred-continue`) so that only a suppression a
+;; listener causes DURING the fan-out stops it — the ordinary post-drain falsity of
+;; a context-dependent fence never does. See `deferred-continue` for why a bare
+;; live re-read of that fence is unsound once the drain has unwound.
+;;
+;; Emission ORDER is preserved:
+;; the ring push and epoch capture still run inline, the pending vector
 ;; is FIFO, and the whole batch is flushed under one monitor hold, so a drain's
 ;; own traces reach listeners contiguously and in order. Each deferred event is
 ;; driven through its OWN `run-outermost-fanout!`, so a listener's reentrant emit
@@ -951,25 +953,59 @@
      "Wrap an appended event's `continue?` snapshot so deferral cannot change
      WHETHER the event is delivered — only when.
 
-     Under inline delivery the driver's first `continue?` check happens in the
-     same breath as `deliver!`'s own `(continuing?)` gate, so it always passes;
-     only a LISTENER acting during the fan-out can flip it and suppress the
-     remaining listeners (rf2-eaxnai). Deferral opens a gap: the rest of the drain
-     runs before the first check, so an incarnation this drain destroys later
-     would retroactively cancel a fan-out that was already authorised at emission
-     — silently dropping the event.
+     THE PROBLEM DEFERRAL CREATES. `drive-fanout!` consults `continue?` before
+     every listener, and rf2-eaxnai gives a false reading ONE meaning: a listener
+     body just suppressed this event, so stop fanning it out. That reading is only
+     sound while every check is taken in the SAME dynamic context, which is what
+     inline delivery guaranteed — the whole fan-out ran inside `deliver!`, inside
+     the drain.
 
-     The latch restores the inline reading exactly: the first check (before the
-     first listener) passes unconditionally, and every check thereafter — i.e.
-     after a listener body has actually run — consults the live predicate. So
-     rf2-eaxnai's mid-fan-out suppression is preserved while the pre-fan-out gap
-     the deferral introduced is closed."
+     A deferred fan-out runs after the drain has unwound, and these predicates are
+     not pure functions of registry state: the dispatch-path fence
+     (`re-frame.router/dispatch!`'s `target-live?`) reaches
+     `frame/event-owner-live?`, which reads the DYNAMIC `frame/*event-owner*`. Once
+     the drain returns that var is unbound, so the fence reads false for every
+     cascaded dispatch — no destroy, no suppression, just an unwound stack. Under a
+     bare live re-read the driver would take that as suppression and abandon
+     listeners 2..N, silently dropping the `:rf.event/dispatched` envelope of every
+     cascaded event for every app with more than one listener. Level-testing a
+     context-dependent predicate outside its context is the defect; the reading has
+     to be made relative to the context the fan-out actually runs in.
+
+     THE DISTINCTION. Detect a TRANSITION, not a level. The first call — taken in
+     the flush, immediately before listener 1 — records the BASELINE and always
+     returns true (mirroring inline, whose first check passed in the same breath as
+     `deliver!`'s own `(continuing?)` gate). Every check thereafter runs in that
+     same flush context, so the only thing that can have changed the reading
+     between two consecutive checks is the listener body that ran between them:
+
+       - baseline TRUE  -> consult the live predicate. A later false is a genuine
+         mid-fan-out suppression and stops the remainder, exactly as rf2-eaxnai
+         requires. This is the case for every context-free fence — notably
+         `process-event!`'s `#(frame/event-continuation-live? frame-id owner-token)`,
+         which reads only the frame registry — so a listener that destroys the
+         outer incarnation still fences that incarnation's remaining fan-out.
+       - baseline FALSE -> the predicate was ALREADY false when the fan-out began,
+         before any listener could act. That is ordinary post-drain state (the
+         unwound owner binding above), never evidence of suppression, so it cannot
+         abandon the remaining listeners. The event was authorised at emission and
+         is delivered in full — just later.
+
+     Deferral therefore changes delivery TIMING only, never the recipient set."
      [continue?]
-     (let [delivered (volatile! false)]
+     (let [baseline (volatile! ::unread)]
        (fn []
-         (if @delivered
-           (continue?)
-           (do (vreset! delivered true) true))))))
+         (let [b @baseline]
+           (cond
+             ;; First check, taken in the flush: record the baseline, always pass.
+             (identical? b ::unread) (do (vreset! baseline (boolean (continue?)))
+                                         true)
+             ;; Already false before any listener ran — ordinary post-drain
+             ;; falsity, not suppression. Never abandon the remaining listeners.
+             (false? b)              true
+             ;; Was live when the fan-out began: a false reading now is a
+             ;; listener-caused suppression (rf2-eaxnai). Honour it.
+             :else                   (boolean (continue?))))))))
 
 #?(:clj
    (defn- flush-deferred-fanout!

--- a/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
@@ -1639,7 +1639,25 @@
     (rf/dispatch-sync [:destroy/trace-fanout-event] {:frame trace-id})
     (is (zero? @trace-sibling)
         "later snapshotted trace listeners stop after listener #1 loses A")
-    (is (zero? @handler-runs) "no handler starts after run-start delivery lost A")
+    ;; rf2-wxy1c: the trace fan-out for a drain-owned emit no longer runs INSIDE
+    ;; the drain — it is deferred to the post-drain boundary, because the
+    ;; framework must never invoke (nor await) arbitrary listener code while it
+    ;; owns a frame's `:drain-lock`. A trace listener therefore observes
+    ;; `:rf.event/run-start` AFTER the cascade has settled and can no longer veto
+    ;; the handler it names. That back-pressure was never a contract — Spec 009
+    ;; listeners are observers of the stream, not participants in the cascade —
+    ;; and removing it is precisely what closes the drain-vs-drain overlap
+    ;; (`re-frame.trace-listener-concurrent-drain-serialization-test`).
+    ;;
+    ;; The suppression that IS contract still holds, and is asserted above and
+    ;; below: within a single fan-out, listener #1 losing A stops the REMAINING
+    ;; listeners (`@trace-sibling`), and the always-on `:events` / `:errors`
+    ;; families — which are not deferred — keep their full synchronous
+    ;; suppression semantics.
+    (is (= 1 @handler-runs)
+        (str "the handler runs: a deferred trace listener destroying the frame "
+             "at the post-drain boundary cannot retract a cascade that has "
+             "already settled (rf2-wxy1c)"))
 
     (rf/make-frame {:id event-id})
     (rf/reg-event :destroy/event-fanout-event (fn [_ _] {}))

--- a/implementation/core/test/re_frame/trace_listener_concurrent_drain_serialization_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_concurrent_drain_serialization_test.clj
@@ -1,0 +1,188 @@
+(ns re-frame.trace-listener-concurrent-drain-serialization-test
+  "rf2-wxy1c — two DIFFERENT frames draining CONCURRENTLY must never enter the
+  same registered trace listener at the same time, and no listener callback may
+  run while the framework owns a frame's `:drain-lock`.
+
+  ## The defect this pins (rf2-wxy1c)
+
+  rf2-rakqk (PR #6248) fixed the shape-based bypass by keying the
+  `fanout-monitor` opt-out on REAL drain-lock ownership: an outermost emit whose
+  thread actually holds the target frame's `:drain-lock` drove its listener
+  fan-out INLINE, off the monitor, so the rf2-jl75r AB-BA cycle
+  (monitor -> listener -> `dispatch-sync` -> drain-lock -> monitor) could not
+  close. That is deadlock-correct but NOT serial: a single frame cannot have two
+  simultaneous drain-lock owners, yet two INDEPENDENT frames can drain at the
+  same time on two JVM threads, each owning its OWN frame's lock. Both then
+  qualified for the inline path and both entered the same arbitrary listener
+  callback concurrently — the public serial-listener contract (Spec 009 §The
+  listener contract: synchronous, event-at-a-time, per-listener ordered
+  delivery) broken exactly where rf2-rakqk left the relaxation, and arbitrary
+  programmer/tool listener code running while the framework held a drain lock,
+  contrary to rf2-rakqk's own acceptance criterion.
+
+  The three merged suites stayed green because they cover clean-vs-clean
+  (`trace-listener-concurrent-serialization-test`), a frame-SHAPED public emit
+  outside any drain (`trace-listener-frame-tagged-serialization-test`), and the
+  one-frame AB-BA cycle (`trace-listener-drain-deadlock-test`) — none of them
+  drain-vs-drain.
+
+  ## The probe
+
+  One listener. Thread A `dispatch-sync`es into frame ALPHA and the listener
+  LATCHES inside its `:rf.event/run-start` callback. While A is latched, thread
+  B `dispatch-sync`es into frame BETA — a different frame, so a different
+  `:drain-lock`, so no mutual exclusion between the two drains.
+
+  Pre-fix, B entered the same callback while A was still in flight (max
+  concurrent invocations 2, `[[:enter ALPHA] [:enter BETA] [:exit BETA]]`
+  observed before A was released) and BOTH callbacks ran with their frame's
+  `:drain-lock` held.
+
+  Post-fix, a drain's listener fan-out is DEFERRED to the post-drain boundary
+  (`re-frame.trace/call-with-deferred-listener-delivery`, established around
+  every `:drain-lock` acquire/release region) and flushed there under
+  `fanout-monitor`. A's callback therefore runs with A's lock already released
+  and the monitor held; B's flush BLOCKS contending for that monitor until A's
+  callback returns. Max concurrent invocations 1, strict A-before-B, and every
+  callback observes its frame's `:drain-lock` free.
+
+  JVM-only (`.clj`): CLJS is single-threaded, has no monitor, cannot run two
+  drains at once, and deliberately keeps the historical inline delivery — the
+  overlap cannot manifest there."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            ;; Load-bearing require (mirrors the rf2-jl75r suite): with the epoch
+            ;; artefact on the classpath the per-event settle also emits the
+            ;; cascade trailers on the drainer thread while the drain-lock is
+            ;; held, so the deferral seam is exercised for the trailer emits too
+            ;; and not only for the dispatch-id-carrying in-run emits.
+            [re-frame.epoch]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace :as trace])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private frame-alpha :wxy1c/alpha)
+(def ^:private frame-beta  :wxy1c/beta)
+
+;; Loop the deterministic latch proof so a green run is determinism, not a lucky
+;; interleaving. Env-overridable for a heavier local soak.
+(def ^:private iters
+  (or (some-> (System/getenv "RF2_WXY1C_ITERS") Long/parseLong)
+      25))
+
+(def ^:private latch-timeout-s 10)
+(def ^:private join-timeout-ms 10000)
+
+(defn- drain-lock-held?
+  "True iff `frame-id`'s `:drain-lock` is currently taken — the direct read of
+  the single-drainer cell the router CAS-acquires for a drain pass and
+  `frame/call-serialized-with-drain!` CAS-acquires for a cold section. Read from
+  inside a listener callback this answers the rf2-wxy1c acceptance question
+  literally: is arbitrary listener code running while the framework owns this
+  frame's drain lock?"
+  [frame-id]
+  (boolean (some-> (frame/frame frame-id) :drain-lock deref)))
+
+(deftest concurrent-drains-of-different-frames-never-overlap-one-listener
+  (testing (str "two simultaneous drains of DIFFERENT frames neither enter one "
+                "listener concurrently nor invoke it under a held drain-lock ("
+                iters " iterations)")
+    (dotimes [iter iters]
+      (rf/make-frame {:id frame-alpha :doc "rf2-wxy1c drain A"})
+      (rf/make-frame {:id frame-beta  :doc "rf2-wxy1c drain B"})
+      (rf/reg-event :wxy1c/alpha-work {:frame frame-alpha}
+        (fn [{:keys [db]} _] {:db (assoc db :ran? true)}))
+      (rf/reg-event :wxy1c/beta-work {:frame frame-beta}
+        (fn [{:keys [db]} _] {:db (assoc db :ran? true)}))
+
+      (let [log        (atom [])
+            in-flight  (atom 0)
+            max-conc   (atom 0)
+            under-lock (atom [])
+            a-entered  (CountDownLatch. 1)
+            b-entered  (CountDownLatch. 1)
+            release-a  (CountDownLatch. 1)]
+        (trace/register-listener! ::probe
+          (fn [ev]
+            (when (= :rf.event/run-start (:operation ev))
+              (when-let [f (#{frame-alpha frame-beta} (trace/frame-of ev))]
+                ;; Overlap detector: record the max simultaneous invocations.
+                (let [n (swap! in-flight inc)]
+                  (swap! max-conc max n))
+                (swap! log conj [:enter f])
+                ;; Ownership detector: is the framework holding this frame's
+                ;; drain-lock while our arbitrary callback runs?
+                (swap! under-lock conj [f (drain-lock-held? f)])
+                (if (= f frame-alpha)
+                  (do (.countDown a-entered)
+                      ;; Latch A mid-callback. Never released by B's delivery, so
+                      ;; a serialized B cannot deadlock A.
+                      (.await release-a latch-timeout-s TimeUnit/SECONDS))
+                  (.countDown b-entered))
+                (swap! log conj [:exit f])
+                (swap! in-flight dec)))))
+
+        (let [t1 (Thread. ^Runnable
+                          (fn [] (rf/dispatch-sync [:wxy1c/alpha-work]
+                                                   {:frame frame-alpha}))
+                          "wxy1c-drain-alpha")
+              t2 (Thread. ^Runnable
+                          (fn [] (rf/dispatch-sync [:wxy1c/beta-work]
+                                                   {:frame frame-beta}))
+                          "wxy1c-drain-beta")]
+          (.start t1)
+          ;; A is now inside the listener, latched on release-a.
+          (.await a-entered latch-timeout-s TimeUnit/SECONDS)
+          (.start t2)
+          ;; Wait until t2 has reached the fan-out seam: pre-fix it drives its
+          ;; own drain's fan-out INLINE and enters the listener (b-entered fires,
+          ;; the overlap is already recorded); fixed, it is BLOCKED contending
+          ;; for fanout-monitor at its post-drain flush. Nothing else on t2's
+          ;; path contends for a JVM monitor with t1 (the two frames own
+          ;; independent routers and drain-locks), so a BLOCKED state here means
+          ;; fanout-monitor contention. Deadline-bounded so a mis-started thread
+          ;; cannot hang the suite.
+          (let [deadline (+ (System/currentTimeMillis) 5000)]
+            (loop []
+              (when (and (< (System/currentTimeMillis) deadline)
+                         (pos? (.getCount b-entered))
+                         (not= java.lang.Thread$State/BLOCKED (.getState t2)))
+                (Thread/yield)
+                (recur))))
+          (let [observed-before-release @log]
+            (.countDown release-a)
+            (.join t1 join-timeout-ms)
+            (.join t2 join-timeout-ms)
+            (trace/unregister-listener! ::probe)
+
+            (is (not (.isAlive t1))
+                (str "iter " iter ": frame ALPHA's dispatch-sync never completed"))
+            (is (not (.isAlive t2))
+                (str "iter " iter ": frame BETA's dispatch-sync never completed"))
+            (is (= 1 @max-conc)
+                (str "iter " iter ": two concurrent frame drains overlapped the "
+                     "SAME listener callback (max concurrent invocations "
+                     @max-conc "); each drain owns only its OWN frame's "
+                     ":drain-lock, so drain-lock ownership alone cannot "
+                     "serialize the fan-out. Observed before release: "
+                     (pr-str observed-before-release)))
+            (is (= [[:enter frame-alpha]] observed-before-release)
+                (str "iter " iter ": frame BETA's drain reached the listener "
+                     "while frame ALPHA's callback was still in flight; expected "
+                     "only ALPHA's :enter before the release, got "
+                     (pr-str observed-before-release)))
+            (is (= [[:enter frame-alpha] [:exit frame-alpha]
+                    [:enter frame-beta] [:exit frame-beta]]
+                   @log)
+                (str "iter " iter ": expected strict ALPHA-before-BETA delivery, "
+                     "got " (pr-str @log)))
+            (is (= [[frame-alpha false] [frame-beta false]] @under-lock)
+                (str "iter " iter ": a listener callback ran while the framework "
+                     "owned the frame's :drain-lock; arbitrary listener code "
+                     "must be invoked at the post-drain boundary, got "
+                     (pr-str @under-lock)))))))))

--- a/implementation/core/test/re_frame/trace_listener_drain_deadlock_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_drain_deadlock_test.clj
@@ -23,12 +23,16 @@
   `re-frame.interop/next-tick`'s single-thread executor), where `:in-sync-drain?`
   is false and T1's listener `dispatch-sync` really does spin on the lock.
 
-  The fix keeps the whole synchronous, ordered, serialized clean-emit fan-out
-  (rf2-uw7hg) but takes the monitor OUT of the cycle: an emit whose thread
-  ACTUALLY holds the target frame's `:drain-lock` (`emit-under-owned-drain-lock?`,
-  keyed on real lock ownership per rf2-rakqk, not event-shape inference) never
-  acquires the monitor — it drives its fan-out inline, exactly as the
-  single-threaded CLJS host always does. This suite is the deterministic
+  The fix keeps the whole synchronous, ordered, serialized fan-out (rf2-uw7hg)
+  but takes the monitor OUT of the cycle: an emit issued while the framework owns
+  a frame's `:drain-lock` never acquires the monitor at all. Per rf2-wxy1c it is
+  APPENDED and delivered at the post-drain boundary
+  (`re-frame.trace/call-with-deferred-listener-delivery`, which brackets every
+  `:drain-lock` acquire → run → release region), where the lock is already down —
+  so the drainer's side of the cycle blocks on nothing while holding the lock.
+  (rf2-jl75r's original cut drove such an emit INLINE instead; that broke the
+  deadlock but let two independent frames' drains enter one listener at once,
+  which is what the deferral replaced.) This suite is the deterministic
   barrier/latch proof that the exact AB-BA interleaving now completes within a
   bounded timeout and the listener-dispatched event settles EXACTLY once.
 

--- a/implementation/core/test/re_frame/trace_listener_frame_tagged_serialization_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_frame_tagged_serialization_test.clj
@@ -21,17 +21,19 @@
   A deterministic latch probe below starts two `{:frame :rf/default}`-tagged
   emits on two threads while the first listener callback is latched. Pre-fix the
   second entered the callback while the first was still in flight (max concurrent
-  invocations 2). With the drain-lock OWNERSHIP discriminator
-  (`re-frame.trace.tooling/emit-under-owned-drain-lock?`), neither emitting thread
-  owns `:rf/default`'s drain-lock (no drain is in flight), so both serialize on
-  the monitor: the second is BLOCKED contending for it until the first callback
-  returns. max concurrent invocations 1, strict A-before-B.
+  invocations 2). Post-fix neither emitting thread is inside a drain — no
+  `:drain-lock` region, so no post-drain deferral scope
+  (`re-frame.trace/call-with-deferred-listener-delivery`, rf2-wxy1c) — so both
+  emits take the ordinary clean-emit path and serialize on the monitor: the second
+  is BLOCKED contending for it until the first callback returns. Max concurrent
+  invocations 1, strict A-before-B. Event payload SHAPE never enters the routing
+  decision, which is the law this suite pins.
 
-  The complementary law — an emit that GENUINELY owns the target drain-lock (an
-  in-run / settle / teardown emit on the drainer thread) still drives inline and
-  never deadlocks against a listener's `dispatch-sync` — is pinned by
-  `re-frame.trace-listener-drain-deadlock-test` (rf2-jl75r) and is deliberately
-  not duplicated here.
+  The complementary laws — a drain-owned emit never deadlocks against a
+  listener's `dispatch-sync` (`re-frame.trace-listener-drain-deadlock-test`,
+  rf2-jl75r), and two concurrent drains of DIFFERENT frames never overlap one
+  listener (`re-frame.trace-listener-concurrent-drain-serialization-test`,
+  rf2-wxy1c) — are pinned by those suites and deliberately not duplicated here.
 
   JVM-only (`.clj`): CLJS is single-threaded, has no monitor, and cannot race two
   emits — the overlap cannot manifest there."

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -458,11 +458,21 @@
   registrar currently holds — so the moment it is chosen is a correctness
   property, not a scheduling detail. Forcing it here, inside the `(continue?)`
   fence and immediately before the physical write, is the LAST point ahead of
-  the swap; every callback-bearing pre-install emission (the caller's
-  `:rf.machine.spawn/spawned` trace and this fn's own
-  `:rf.error/system-id-collision` trace, both of which fan synchronously to
-  application listeners that can unregister or replace the child's TYPE) has
-  already run and is therefore already reflected in the reference this stamps."
+  the swap, so every pre-install emission and every in-drain mutation it may
+  have provoked is already reflected in the reference this stamps.
+
+  Note the premise has NARROWED (rf2-wxy1c). The pre-install emissions named
+  above — the caller's `:rf.machine.spawn/spawned` trace and this fn's own
+  `:rf.error/system-id-collision` trace — no longer fan synchronously to
+  application listeners: trace listeners are OBSERVERS, and internal
+  drain-owned emits deliver at the POST-DRAIN boundary, so no listener body
+  can unregister or replace the child's TYPE between the caller's bindings and
+  this write. That window is now closed BY CONSTRUCTION. This placement is kept
+  regardless: it costs nothing, it is the honest place to read a registrar-derived
+  value, and it remains load-bearing for in-drain application code that CAN run
+  ahead of the write — a prepared child's own `[:schemas :data]` validator runs
+  after its `:type-spec` was retained, so the definition-lifetime rule must still
+  decide against the registrar as it stands at COMMIT."
   [frame-id rt-after-alloc spec spawned-id initial-snap
    {:keys [system-id parent-id invoke-id track? type-ref-fn continue? owner-token]}]
   (let [existing (when system-id (get-in rt-after-alloc (paths/system-id-path system-id)))]
@@ -509,17 +519,28 @@
             ;; `:machine-id` keyword while the registrar still holds the prepared
             ;; definition, pin that definition once the registrar has diverged —
             ;; but the CHOICE was taken in `spawn-fx*`'s `let` bindings, ahead of
-            ;; two callback-bearing emissions that still run before this write:
-            ;; the caller's `:rf.machine.spawn/spawned` trace and the
-            ;; `:rf.error/system-id-collision` trace above. Both fan synchronously
-            ;; to application listeners. A listener that UNREGISTERED or REPLACED
-            ;; the admitted child's TYPE therefore diverged the registrar AFTER
-            ;; `prepared-type-ref` had observed it intact and returned the
-            ;; keyword — so the install stamped a now-STALE keyword and the child
-            ;; came up INERT (nothing resolves; it never leaves `:initial`, and
-            ;; every event raises `:rf.error/no-such-handler`) or SPLIT (a
-            ;; prepared-v1 snapshot driven by an unrelated current-v2 handler).
-            ;; The very failure modes rxjy3 removed, reached through a later door.
+            ;; the two emissions that still run before this write: the caller's
+            ;; `:rf.machine.spawn/spawned` trace and the
+            ;; `:rf.error/system-id-collision` trace above. Those then fanned
+            ;; synchronously to application listeners, so a listener that
+            ;; UNREGISTERED or REPLACED the admitted child's TYPE diverged the
+            ;; registrar AFTER `prepared-type-ref` had observed it intact and
+            ;; returned the keyword — the install stamped a now-STALE keyword and
+            ;; the child came up INERT (nothing resolves; it never leaves
+            ;; `:initial`, and every event raises `:rf.error/no-such-handler`) or
+            ;; SPLIT (a prepared-v1 snapshot driven by an unrelated current-v2
+            ;; handler). The very failure modes rxjy3 removed, reached through a
+            ;; later door.
+            ;;
+            ;; rf2-wxy1c CLOSED that door from the other side: those two emits are
+            ;; internal and drain-owned, so their listeners now run at the
+            ;; post-drain boundary and no listener body can act here at all. The
+            ;; late force is retained because it is still the correct reading
+            ;; point for a registrar-derived value, and because in-drain
+            ;; application code — notably a prepared child's own
+            ;; `[:schemas :data]` validator, which `prepare-spawn-all-child` runs
+            ;; AFTER retaining `:type-spec` — can still diverge the registrar
+            ;; ahead of this write.
             ;;
             ;; Deferring the CHOICE — rather than re-checking anything — is the
             ;; whole fix: `type-ref-fn` reads the registrar as it stands at
@@ -929,16 +950,25 @@
         ;; keyword, so hot-reload semantics are unchanged).
         ;;
         ;; rf2-zo5n9 — a THUNK, deliberately unforced here. `prepared-type-ref`
-        ;; is the one registrar-DERIVED input the install still needs, and
-        ;; everything between this binding and the write is callback-bearing:
-        ;; the `:rf.machine.spawn/spawned` trace below and `install-spawn!`'s
-        ;; `:rf.error/system-id-collision` trace both fan synchronously to
-        ;; application listeners that can unregister or replace the child's TYPE.
-        ;; Choosing here would read a registrar those callbacks then invalidate,
-        ;; stamping a stale keyword onto the snapshot (inert child / split
-        ;; authority). `install-spawn!` forces it at the last point before the
-        ;; swap instead. `machine-type-ref` is pure over `args` and reads no
-        ;; registrar, so the non-prepared path is timing-independent either way.
+        ;; is the one registrar-DERIVED input the install still needs, so it is
+        ;; read as late as possible: `install-spawn!` forces it at the last point
+        ;; before the swap, and the definition-lifetime rule therefore decides
+        ;; against the registrar as it stands at COMMIT rather than at this
+        ;; binding.
+        ;;
+        ;; This originally guarded against TRACE LISTENERS — the
+        ;; `:rf.machine.spawn/spawned` trace below and `install-spawn!`'s
+        ;; `:rf.error/system-id-collision` trace fanned synchronously to
+        ;; application listeners that could unregister or replace the child's
+        ;; TYPE mid-drain. rf2-wxy1c retired that premise: both are internal
+        ;; drain-owned emits, delivered at the post-drain boundary, so no
+        ;; listener body runs between here and the write. The thunk stays because
+        ;; the late read is still correct and still load-bearing for ordinary
+        ;; in-drain application code — a prepared child's `[:schemas :data]`
+        ;; validator runs after `prepare-spawn-all-child` retained `:type-spec`,
+        ;; so a registrar it mutates must be the one the rule sees.
+        ;; `machine-type-ref` is pure over `args` and reads no registrar, so the
+        ;; non-prepared path is timing-independent either way.
         type-ref-fn (if prepared
                       #(prepared-type-ref args prepared)
                       (constantly (machine-type-ref args)))

--- a/implementation/machines/test/re_frame/destroyed_exit_order_test.clj
+++ b/implementation/machines/test/re_frame/destroyed_exit_order_test.clj
@@ -12,11 +12,24 @@
   for tools (Xray, re-frame-10x, story-mcp) that key on the trace.
 
   Spec 005 §Declarative `:spawn` §Composition with explicit `:entry` /
-  `:exit` (005:2138) pins the order: the `:exit` action reads the
-  actor's final snapshot *before* the auto-destroy clears it, so a
-  consumer observing the db between `:exit` and `:rf.machine/destroyed`
-  sees the live snapshot. That makes exit-then-destroyed the
-  spec-correct convention; this file pins it on all three paths.
+  `:exit` (005:3026) pins what is guaranteed: the user's `:exit` ACTION
+  reads the actor's final snapshot *before* the auto-destroy clears it.
+  That is an ACTION-ordering guarantee, and both sides of it run in-drain,
+  so it is what makes exit-then-destroyed the spec-correct convention.
+  This file pins that convention on all three paths.
+
+  SCOPE CORRECTION (rf2-wxy1c). This docstring used to cite 005:2138 —
+  which is the state-tags worked example, not a destroy-ordering rule —
+  and to extend the guarantee into a claim that \"a consumer observing the
+  db between `:exit` and `:rf.machine/destroyed` sees the live snapshot\".
+  That sentence existed only here; the spec never wrote it. It read an
+  action-vs-fx ordering guarantee as a TRACE-INTERLEAVING one, which the
+  governing section does not give. Under rf2-wxy1c internal drain-owned
+  traces deliver at the post-drain boundary, so a multi-child teardown
+  batches its `:destroyed` traces after the whole `:exit` cascade — and
+  that is the order rf2-wxy1c's own \"no partially settled state\"
+  criterion prefers, since the old interleaving let a consumer keyed on
+  child A's `:destroyed` read a db with child B still half-alive.
 
   Mechanism: a shared ordered log captures both the `:exit` action's
   fire (the action conjes a marker) and the `:rf.machine/destroyed`
@@ -103,7 +116,7 @@
 ;; ---- Path 2: :spawn-all per-child teardown (destroy-spawn-all-children!) --
 
 (deftest destroyed-after-exit-on-invoke-all-teardown
-  (testing ":spawn-all per-child teardown fires each :exit BEFORE its :destroyed"
+  (testing ":spawn-all per-child teardown fires every :exit BEFORE any :destroyed"
     (let [log   (atom [])
           unreg (record-order! log)]
       (try
@@ -128,11 +141,20 @@
                      :idle {}}})
         (rf/dispatch-sync [:eo/ia-parent [:rf.machine.spawn/spawned]])
         (rf/dispatch-sync [:eo/ia-parent [:ia/cancel]])     ;; tear children down
-        ;; Two children: each fires :exit then :destroyed. The
-        ;; per-child loop runs them sequentially, so the log is a
-        ;; strict [:exit :destroyed :exit :destroyed].
-        (is (= [:exit :destroyed :exit :destroyed] @log)
-            "each child emits :exit then :destroyed, in per-child order")
+        ;; Two children torn down inside ONE events-fx walk. The `:exit`
+        ;; actions are in-drain and run per-child, sequentially; the
+        ;; `:rf.machine/destroyed` traces are internal drain-owned emits,
+        ;; so under rf2-wxy1c they deliver together at the post-drain
+        ;; boundary — in EMISSION ORDER, after the whole cascade. Hence
+        ;; the BATCHED [:exit :exit :destroyed :destroyed], not the old
+        ;; interleaved [:exit :destroyed :exit :destroyed].
+        ;;
+        ;; The convention this file exists to pin is intact: every
+        ;; `:exit` still precedes every `:destroyed`. What changed is the
+        ;; INTERLEAVING between two children, which the spec never
+        ;; guaranteed (see the ns docstring's scope correction).
+        (is (= [:exit :exit :destroyed :destroyed] @log)
+            "every :exit precedes every :destroyed — the destroyed traces batch at the post-drain boundary")
         (finally (unreg))))))
 
 ;; ---- Path 3: final-state auto-destroy (finalize-machine) ------------------

--- a/implementation/machines/test/re_frame/spawn_all_authoritative_preflight_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/spawn_all_authoritative_preflight_cljs_test.cljc
@@ -14,11 +14,21 @@
   accepted per-child spawn re-resolved / rebuilt / re-validated the same child:
 
    - a direct all-valid invoke observed TWO validator calls per child, and
-   - a `:rf.machine.spawn-all/started` listener could re-register the child TYPE
-     between the two passes, so the preflight accepted v1 and published a live
-     child-bearing join while the per-child install resolved a now-rejecting v2
-     and installed NO snapshot — leaving an impossible half-live join naming a
-     child whose snapshot a SECOND verdict omitted.
+   - a mid-drain re-registration of the child TYPE between the two passes meant
+     the preflight accepted v1 and published a live child-bearing join while the
+     per-child install resolved a now-rejecting v2 and installed NO snapshot —
+     leaving an impossible half-live join naming a child whose snapshot a SECOND
+     verdict omitted.
+
+  MID-DRAIN INSTRUMENTS (rf2-wxy1c). Both the validator-cardinality sample and
+  the mid-drain re-registration used to run in a TRACE LISTENER. Under the
+  rf2-wxy1c ruling trace listeners are OBSERVERS: internal drain-owned emits
+  deliver at the post-drain boundary on every platform, so a listener body can
+  neither sample nor mutate inside a drain. Both instruments now ride the child's
+  own `[:schemas :data]` validator — ordinary in-drain application code the
+  framework calls synchronously, positioned by `prepare-spawn-all-child` strictly
+  after the child's TYPE was resolved + retained and strictly before its install.
+  Platform-uniform: schema validation is not reader-conditional.
 
   Pinned here (JVM + CLJS):
 
@@ -45,7 +55,6 @@
    ;; publishes Malli's validate/explain into the late-bind table.
    [re-frame.schemas]
    [re-frame.schemas.malli]
-   [re-frame.trace :as trace]
    #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
        :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
 
@@ -105,37 +114,38 @@
 
 (deftest each-spawn-all-child-is-validated-exactly-once-per-attempt
   (testing "an all-valid :spawn-all child's [:schemas :data] validator runs
-            EXACTLY once for the attempt — the preflight prepares + validates it
-            and the per-child install CONSUMES that prepared snapshot rather than
-            re-validating (the pre-fix all-valid path observed TWO calls). The
-            count is sampled at the child's :rf.machine.lifecycle/spawned trace —
-            after the install, before any later macrostep re-validation."
-    (let [calls       (atom 0)
-          at-install  (atom nil)
-          listener-id ::count-at-install]
-      ;; A conforming schema that COUNTS every validate call. It passes
-      ;; ({:n 1} is a pos-int?), so the child installs on both the fixed and the
-      ;; pre-fix path — the DISCRIMINATOR is how many times it was validated by
-      ;; install time, not whether it installed.
+            EXACTLY once BY INSTALL TIME for the attempt — the preflight prepares
+            + validates it and the per-child install CONSUMES that prepared
+            snapshot rather than re-validating (the pre-fix all-valid path
+            observed TWO calls, the second at the install)."
+    (let [pre-install (atom 0)]
+      ;; A conforming schema that counts every validate call taken BEFORE the
+      ;; child's snapshot exists. It passes ({:n 1} is a pos-int?), so the child
+      ;; installs on both the fixed and the pre-fix path — the DISCRIMINATOR is
+      ;; how many times it was validated by install time, not whether it
+      ;; installed.
+      ;;
+      ;; THE SAMPLING INSTRUMENT (rf2-wxy1c). This count used to be sampled in a
+      ;; trace listener on `:rf.machine.lifecycle/spawned`. Internal drain-owned
+      ;; traces now deliver at the POST-DRAIN boundary, so that sample is taken
+      ;; after the actor's later macrosteps have re-validated a LIVE child's
+      ;; `:data` — it measures liveness, not install-time cardinality. The
+      ;; validator's own view of the runtime-db has no such assumption: a call
+      ;; taken while the snapshot is absent is BY DEFINITION pre-install. No
+      ;; listener, no timing assumption, no platform split.
       (rf/reg-machine :sa/counted
                       {:initial :running
                        :data    {:n 1}
-                       :schemas {:data [:fn (fn [v] (swap! calls inc) (pos-int? (:n v)))]}
+                       :schemas {:data [:fn (fn [v]
+                                              (when (nil? (snap-of :sa/counted#1))
+                                                (swap! pre-install inc))
+                                              (pos-int? (:n v)))]}
                        :states  {:running {}}})
       (rf/reg-machine :sup/count (parent-over [{:id :c :machine-id :sa/counted}]))
-      (trace/register-listener!
-        listener-id
-        (fn [ev]
-          (when (and (= :rf.machine.lifecycle/spawned (:operation ev))
-                     (= :sa/counted#1 (get-in ev [:tags :spawned-id]))
-                     (nil? @at-install))
-            (reset! at-install @calls))))
-      (try
-        (rf/dispatch-sync [:sup/count [:start]])
-        (finally (trace/unregister-listener! listener-id)))
+      (rf/dispatch-sync [:sup/count [:start]])
       (is (some? (snap-of :sa/counted#1))
           "(precondition) the conforming child installed a live snapshot")
-      (is (= 1 @at-install)
+      (is (= 1 @pre-install)
           "validated EXACTLY once by install time — the preflight prepared it and
            the install consumed that result (the pre-fix path re-validated → 2)"))))
 
@@ -145,32 +155,41 @@
 ;; ===========================================================================
 
 (deftest type-reregistration-between-preflight-and-install-cannot-omit-a-snapshot
-  (testing "a :rf.machine.spawn-all/started listener that RE-REGISTERS a child
-            TYPE to a now-rejecting spec cannot flip the admitted child into a
-            rejected one: the per-child install consumes the preflight's prepared
-            v1 snapshot rather than re-resolving + re-validating the v2 the
-            listener installed, so the child installs and the join is FULLY live
-            — never a child-bearing join whose snapshot a SECOND verdict omitted."
-    (rf/reg-machine :sa/strict strict-child)         ; v1 — pos-int?, data {:n 1}, conforms
-    (rf/reg-machine :sup/rereg (parent-over [{:id :c :machine-id :sa/strict}]))
-    (let [listener-id ::rereg
-          fired       (atom false)]
-      (trace/register-listener!
-        listener-id
-        (fn [ev]
-          (when (and (= :rf.machine.spawn-all/started (:operation ev))
-                     (not @fired))
-            (reset! fired true)
-            ;; v2 — the SAME states but a schema that REJECTS the very {:n 1}
-            ;; data the preflight already admitted. A pre-fix install re-resolves
-            ;; this and rejects the child, installing no snapshot.
-            (rf/reg-machine :sa/strict
-                            (assoc strict-child :schemas {:data [:map [:n neg-int?]]})))))
-      (try
-        (rf/dispatch-sync [:sup/rereg [:start]])
-        (finally (trace/unregister-listener! listener-id)))
+  (testing "a mid-drain mutator that RE-REGISTERS a child TYPE to a now-rejecting
+            spec cannot flip the admitted child into a rejected one: the
+            per-child install consumes the preflight's prepared v1 snapshot
+            rather than re-resolving + re-validating the v2 that landed, so the
+            child installs and the join is FULLY live — never a child-bearing
+            join whose snapshot a SECOND verdict omitted."
+    ;; THE MID-DRAIN MUTATOR (rf2-wxy1c). This used to re-register from a
+    ;; `:rf.machine.spawn-all/started` trace listener. Internal drain-owned emits
+    ;; now deliver POST-DRAIN on every platform, so a listener body can no longer
+    ;; run in the preflight→install window. The child's own `[:schemas :data]`
+    ;; validator still can, and is ordinary in-drain application code:
+    ;; `prepare-spawn-all-child` resolves + retains the TYPE, builds the
+    ;; snapshot, THEN runs the validator — so a registrar mutation from inside it
+    ;; lands strictly after the child was prepared and strictly before its
+    ;; install.
+    (let [fired (atom false)]
+      ;; v1 — pos-int?, data {:n 1}, conforms. Its validator swaps the registrar
+      ;; to a v2 whose schema REJECTS the very {:n 1} data the preflight is
+      ;; admitting in this very call. A pre-fix install re-resolves that v2 and
+      ;; rejects the child, installing no snapshot.
+      (rf/reg-machine :sa/strict
+                      (assoc strict-child
+                             :schemas
+                             {:data [:fn (fn [v]
+                                           (when-not @fired
+                                             (reset! fired true)
+                                             (rf/reg-machine
+                                               :sa/strict
+                                               (assoc strict-child
+                                                      :schemas {:data [:map [:n neg-int?]]})))
+                                           (pos-int? (:n v)))]}))
+      (rf/reg-machine :sup/rereg (parent-over [{:id :c :machine-id :sa/strict}]))
+      (rf/dispatch-sync [:sup/rereg [:start]])
       (is (true? @fired)
-          "(precondition) the started listener fired and re-registered the type"))
+          "(precondition) the mid-drain mutator ran and re-registered the type"))
     (let [slot (join-slot :sup/rereg)]
       (is (contains? slot :children)
           "a LIVE child-bearing join was seeded")

--- a/implementation/machines/test/re_frame/spawn_all_prepared_unregister_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/spawn_all_prepared_unregister_cljs_test.cljc
@@ -2,28 +2,50 @@
   "An ADMITTED+prepared `:spawn-all` child CONSUMES its invoke's authoritative
   preflight verdict — `spawn-fx` must NOT re-run its child-local
   `unregistered-spawn-type?` registry recheck against an already-prepared child
-  (rf2-v4oqd).
+  (rf2-v4oqd) — and stays HANDLER-RESOLVABLE when the registrar DIVERGES from
+  the definition its invoke prepared (rf2-rxjy3).
 
   `spawn-all-init-fx` (the FIRST fx in the entry vector) resolves, stamps,
   builds, and validates every declarative `:spawn-all` child EXACTLY ONCE and
   RETAINS the prepared result under the join slot's `:rf/prepared` scratch
   (rf2-ek435). But the per-child `:rf.machine/spawn` fx STILL consulted the
   CURRENT registry via `unregistered-spawn-type?` BEFORE reading its keyed
-  prepared entry. A `:rf.machine.spawn-all/started` listener that UNREGISTERED
-  the admitted child TYPE between the preflight and the install then flipped the
-  already-admitted child to rejected: the per-child spawn emitted a SECOND
+  prepared entry, so a mid-drain UNREGISTER of an admitted child TYPE flipped
+  the already-admitted child to rejected: the per-child spawn emitted a SECOND
   `:rf.error/machine-spawn-unregistered-type` reject and installed NO snapshot —
   after the live child-bearing join had already been published. The result was
   the exact impossible half-live join (a join naming a child whose snapshot a
   second verdict omitted) the authoritative handoff exists to make impossible.
 
+  THE MID-DRAIN MUTATOR THIS SUITE USES (rf2-wxy1c). These tests originally
+  diverged the registrar from a TRACE LISTENER on
+  `:rf.machine.spawn-all/started` / `:rf.machine.spawn/spawned` /
+  `:rf.error/system-id-collision`. That instrument is gone: under the rf2-wxy1c
+  ruling trace listeners are OBSERVERS, not participants — internal drain-owned
+  emits deliver at the POST-DRAIN boundary, so a listener body can no longer run
+  between an admitted child's preparation and its install ON ANY PLATFORM. The
+  window those listeners reached is now closed BY CONSTRUCTION.
+
+  The mechanism under test is NOT, though — the definition-lifetime rule still
+  has to hold for any mid-drain divergence, and one in-drain, non-listener
+  mutator still lands in exactly that window: the child's own `[:schemas :data]`
+  VALIDATOR. `prepare-spawn-all-child` resolves the TYPE and retains
+  `:type-spec` FIRST, then builds the snapshot, then runs the application
+  validator LAST — so a validator that mutates the registrar diverges it strictly
+  AFTER the prepared definition was captured and strictly BEFORE
+  `install-spawn!` forces `prepared-type-ref`. That is the same window, reached
+  by ordinary in-drain application code rather than by an observer, and it is
+  platform-uniform: schema validation is not reader-conditional.
+
+  So these tests assert the SAME pinning outcomes as before — an admitted child
+  always installs, and its `:rf/machine-type` is the revertible KEYWORD while the
+  registrar still holds the prepared definition, the PINNED definition once the
+  registrar has diverged from it.
+
   The sibling `spawn_all_authoritative_preflight` suite (rf2-ek435) pins the
-  RE-REGISTER seam (the type stays present, so the recheck passed through) and
-  the all-valid validator cardinality. This suite pins the UNREGISTER seam that
-  note called out as NOT covered — the recheck's fail-closed branch — on JVM +
-  CLJS."
+  RE-REGISTER seam and the all-valid validator cardinality. This suite pins the
+  UNREGISTER seam — the recheck's fail-closed branch — on JVM + CLJS."
   (:require
-   [clojure.string :as str]
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
@@ -31,15 +53,15 @@
    ;; machine fxs when this ns runs alone.
    [re-frame.machines]
    [re-frame.machines.test-support :as mtest]
-   ;; Unregister a machine TYPE mid-drain (from the started-listener) by
-   ;; dropping its `:event` registrar entry — the seam the recheck tripped on.
+   ;; Unregister a machine TYPE mid-drain (from the child's own `[:schemas :data]`
+   ;; validator) by dropping its `:event` registrar entry — the seam the recheck
+   ;; tripped on.
    [re-frame.registrar :as registrar]
    ;; The schemas artefact ships the registered-validator hot path the
    ;; `:where :machine-data` boundary routes through; the `.malli` adapter
    ;; publishes Malli's validate/explain into the late-bind table.
    [re-frame.schemas]
    [re-frame.schemas.malli]
-   [re-frame.trace :as trace]
    #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
        :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
 
@@ -100,6 +122,28 @@
    :states  {:v2-initial {:on {:rf.machine.spawn/spawned :v2-boot}}
              :v2-boot    {}}})
 
+(defn- mutating-child
+  "`child` augmented with a `[:schemas :data]` validator that runs `f` exactly
+  once and always PASSES — the suite's NON-LISTENER mid-drain mutator.
+
+  `prepare-spawn-all-child` retains the child's `:type-spec` (its resolved
+  definition) BEFORE it runs this validator, and `install-spawn!` forces
+  `prepared-type-ref` AFTER it — so whatever `f` does to the registrar lands in
+  the preflight→install window, from ordinary in-drain application code the
+  framework calls synchronously on every platform.
+
+  It always returns `true`: the child is ADMITTED (the divergence must never be
+  read as a re-verdict — rf2-v4oqd), and the FORM of its installed
+  `:rf/machine-type` reference is the only thing under test."
+  [child f]
+  (let [fired (atom false)]
+    (assoc child :schemas
+           {:data [:fn (fn [_]
+                         (when-not @fired
+                           (reset! fired true)
+                           (f))
+                         true)]})))
+
 (defn- parent-over
   "A `:spawn-all` parent over `children` with join mode `:all`."
   [children]
@@ -133,88 +177,49 @@
   [actor-id]
   (:rf/machine-type (snap-of actor-id)))
 
-(defn- on-started-once
-  "Register a synchronous trace listener that runs `f` exactly once, on the
-  first `:rf.machine.spawn-all/started` emit (fired by `spawn-all-init-fx`
-  AFTER it publishes the live join, BEFORE the per-child spawn fxs run). Returns
-  an unregister thunk."
-  [listener-id f]
-  (let [fired (atom false)]
-    (trace/register-listener!
-      listener-id
-      (fn [ev]
-        (when (and (= :rf.machine.spawn-all/started (:operation ev))
-                   (not @fired))
-          (reset! fired true)
-          (f))))
-    #(trace/unregister-listener! listener-id)))
-
-(defn- on-operation-once
-  "Register a synchronous trace listener that runs `f` exactly once, on the first
-  `operation` emit. Returns an unregister thunk.
-
-  The generalisation of `on-started-once` to the LATER callback-bearing seams
-  rf2-zo5n9 covers — the per-child `:rf.machine.spawn/spawned` trace and
-  `install-spawn!`'s `:rf.error/system-id-collision` trace — both of which run
-  AFTER the prepared entry has been selected and BEFORE the snapshot's
-  `:rf/machine-type` is written."
-  [listener-id operation f]
-  (let [fired (atom false)]
-    (trace/register-listener!
-      listener-id
-      (fn [ev]
-        (when (and (= operation (:operation ev)) (not @fired))
-          (reset! fired true)
-          (f))))
-    #(trace/unregister-listener! listener-id)))
-
-(defn- on-every-spawned
-  "Register a synchronous listener that runs `(f <spawned-id>)` on EVERY per-child
-  `:rf.machine.spawn/spawned` emit. Returns an unregister thunk."
-  [listener-id f]
-  (trace/register-listener!
-    listener-id
-    (fn [ev]
-      (when (= :rf.machine.spawn/spawned (:operation ev))
-        (f (get-in ev [:tags :spawned-id])))))
-  #(trace/unregister-listener! listener-id))
-
 ;; ===========================================================================
-;; (1) THE BUG — a started-listener UNREGISTERS an admitted child TYPE between
+;; (1) THE BUG — a mid-drain mutator UNREGISTERS an admitted child TYPE between
 ;;     the preflight and the install. The child must STILL install from its
 ;;     prepared entry, with no duplicate reject and a fully-live join.
+;;
+;;     Both legs of the definition-lifetime rule ride one invoke here: child :a
+;;     diverges its own TYPE and must PIN, sibling :b leaves the registrar
+;;     intact and must keep the revertible KEYWORD.
 ;; ===========================================================================
 
 (deftest unregister-between-preflight-and-install-still-installs-the-admitted-child
-  (testing "a :rf.machine.spawn-all/started listener that UNREGISTERS an admitted
-            child TYPE cannot flip the already-prepared child into a rejected one:
-            the per-child install consumes the prepared entry rather than
-            re-consulting the (now-empty) registry, so the child installs its
-            prepared snapshot, the join stays fully live, and NO duplicate
+  (testing "a mid-drain mutator that UNREGISTERS an admitted child TYPE cannot
+            flip the already-prepared child into a rejected one: the per-child
+            install consumes the prepared entry rather than re-consulting the
+            (now-empty) registry, so the child installs its prepared snapshot,
+            the join stays fully live, and NO duplicate
             :rf.error/machine-spawn-unregistered-type reject fires (the pre-fix
             recheck rejected the child + stranded a snapshotless half-live join)."
-    (rf/reg-machine :sa/plain plain-child)
-    (rf/reg-machine :sup/unreg (parent-over [{:id :a :machine-id :sa/plain}
-                                             {:id :b :machine-id :sa/plain}]))
-    (let [off (on-started-once ::unreg
-                #(registrar/unregister! :event :sa/plain))]
-      (try
-        (rf/dispatch-sync [:sup/unreg [:start]])
-        (finally (off))))
-    (let [slot (join-slot :sup/unreg)]
-      (is (contains? slot :children)
-          "a LIVE child-bearing join was seeded (not the reject sentinel)")
-      (is (= 2 (count (:children slot)))
-          "the join names both admitted children")
-      (is (not (contains? slot :rf/prepared))
-          "every admitted child consumed + dropped its prepared scratch — the durable join retains none")
-      (doseq [id (vals (:children slot))]
-        (is (some? (snap-of id))
-            (str "child " id " INSTALLED its prepared snapshot even though its TYPE was unregistered mid-drain"))
-        (is (= :running (mtest/machine-state id))
-            (str "child " id " installed the PREPARED spec verbatim (state :running), not a re-derivation"))))
-    (is (empty? (unregistered-rejects))
-        "NO :rf.error/machine-spawn-unregistered-type reject fired — the recheck was skipped for the prepared child")))
+    (let [child-a (mutating-child plain-child
+                                  #(registrar/unregister! :event :sa/plain-a))]
+      (rf/reg-machine :sa/plain-a child-a)
+      (rf/reg-machine :sa/plain-b plain-child)
+      (rf/reg-machine :sup/unreg (parent-over [{:id :a :machine-id :sa/plain-a}
+                                               {:id :b :machine-id :sa/plain-b}]))
+      (rf/dispatch-sync [:sup/unreg [:start]])
+      (let [slot (join-slot :sup/unreg)]
+        (is (contains? slot :children)
+            "a LIVE child-bearing join was seeded (not the reject sentinel)")
+        (is (= 2 (count (:children slot)))
+            "the join names both admitted children")
+        (is (not (contains? slot :rf/prepared))
+            "every admitted child consumed + dropped its prepared scratch — the durable join retains none")
+        (doseq [id (vals (:children slot))]
+          (is (some? (snap-of id))
+              (str "child " id " INSTALLED its prepared snapshot even though its TYPE was unregistered mid-drain"))
+          (is (= :running (mtest/machine-state id))
+              (str "child " id " installed the PREPARED spec verbatim (state :running), not a re-derivation")))
+        (is (= child-a (type-ref-of (get (:children slot) :a)))
+            "the DIVERGED child pinned its prepared definition — the registrar no longer speaks for it")
+        (is (= :sa/plain-b (type-ref-of (get (:children slot) :b)))
+            "the UNDISTURBED sibling kept the revertible TYPE keyword — divergence is per-child, not batch-wide"))
+      (is (empty? (unregistered-rejects))
+          "NO :rf.error/machine-spawn-unregistered-type reject fired — the recheck was skipped for the prepared child"))))
 
 ;; ===========================================================================
 ;; (2) Adversarial: unregister BOTH admitted children between preflight and
@@ -222,26 +227,26 @@
 ;; ===========================================================================
 
 (deftest unregister-all-children-between-preflight-and-install-installs-all
-  (testing "when the started listener unregisters EVERY child TYPE, EVERY
-            admitted child still installs from its prepared entry — the whole
-            batch consumes its authoritative verdict; no reject, no partial install."
-    (rf/reg-machine :sa/one plain-child)
-    (rf/reg-machine :sa/two plain-child)
+  (testing "when EVERY child TYPE is unregistered mid-drain — each from that
+            child's OWN validator, so each divergence lands in that child's own
+            preflight→install window — EVERY admitted child still installs from
+            its prepared entry: the whole batch consumes its authoritative
+            verdict; no reject, no partial install."
+    (rf/reg-machine :sa/one (mutating-child plain-child
+                                            #(registrar/unregister! :event :sa/one)))
+    (rf/reg-machine :sa/two (mutating-child plain-child
+                                            #(registrar/unregister! :event :sa/two)))
     (rf/reg-machine :sup/allunreg (parent-over [{:id :a :machine-id :sa/one}
                                                 {:id :b :machine-id :sa/two}]))
-    (let [off (on-started-once ::allunreg
-                (fn []
-                  (registrar/unregister! :event :sa/one)
-                  (registrar/unregister! :event :sa/two)))]
-      (try
-        (rf/dispatch-sync [:sup/allunreg [:start]])
-        (finally (off))))
+    (rf/dispatch-sync [:sup/allunreg [:start]])
     (let [slot (join-slot :sup/allunreg)]
       (is (contains? slot :children) "a live child-bearing join was seeded")
       (is (not (contains? slot :rf/prepared)) "all prepared scratch consumed")
       (doseq [id (vals (:children slot))]
         (is (some? (snap-of id))
-            (str "child " id " installed despite both TYPEs being unregistered mid-drain"))))
+            (str "child " id " installed despite both TYPEs being unregistered mid-drain"))
+        (is (map? (type-ref-of id))
+            (str "child " id " pinned its prepared definition"))))
     (is (empty? (unregistered-rejects))
         "no duplicate unregistered-type reject fired for either child")))
 
@@ -251,14 +256,20 @@
 ;;     between the preflight and the install (the recheck, and any second
 ;;     spawn-time validation, is skipped for the prepared child).
 ;;
-;;     The count is sampled at the child's `:rf.machine.lifecycle/spawned`
-;;     trace, exactly as ek435's sibling `each-spawn-all-child-is-validated-
-;;     exactly-once-per-attempt` does — NOT at the end of the drain. A LIVE
-;;     actor re-validates its `:data` at every later macrostep (its synthetic
-;;     bootstrap included), so an end-of-drain total measures liveness, not
-;;     install-time cardinality. This assertion previously read `(= 1 @calls)`
-;;     at the end of the drain and passed only because the unregistered child
-;;     was INERT and never bootstrapped — the false-green rf2-rxjy3 names.
+;;     THE SAMPLING INSTRUMENT (rf2-wxy1c). The count used to be sampled in a
+;;     trace listener on the child's `:rf.machine.lifecycle/spawned` emit. That
+;;     instrument no longer measures what it names: internal drain-owned traces
+;;     now deliver at the POST-DRAIN boundary, so the sample is taken after the
+;;     actor's later macrosteps have already re-validated a LIVE child's `:data`
+;;     — an end-of-drain total, which measures liveness rather than install-time
+;;     cardinality (the very confound the old comment warned about, now reached
+;;     through the sampling point itself).
+;;
+;;     The instrument is now the validator's OWN view of the runtime-db: a call
+;;     taken while the child's snapshot is absent is BY DEFINITION a pre-install
+;;     validation. No listener, no timing assumption, no platform split — and it
+;;     still discriminates exactly what the test is about, because the pre-fix
+;;     path's second validation ran at the install, ahead of the write.
 ;; ===========================================================================
 
 (deftest schema-validator-runs-once-by-install-even-when-type-unregistered-mid-drain
@@ -268,55 +279,65 @@
             child still installs even though its TYPE was unregistered between
             the preflight and the install (the recheck's fail-closed branch is
             skipped for the prepared child)."
-    (let [calls       (atom 0)
-          at-install  (atom nil)
-          listener-id ::count-at-install]
+    (let [pre-install (atom 0)
+          fired       (atom false)]
       (rf/reg-machine :sa/counted
                       {:initial :running
                        :data    {:n 1}
-                       :schemas {:data [:fn (fn [v] (swap! calls inc) (pos-int? (:n v)))]}
+                       :schemas {:data [:fn (fn [v]
+                                              ;; A call taken while the child's
+                                              ;; snapshot is still absent is a
+                                              ;; PRE-INSTALL validation.
+                                              (when (nil? (snap-of :sa/counted#1))
+                                                (swap! pre-install inc))
+                                              ;; Diverge the registrar ONCE, in
+                                              ;; the preflight→install window.
+                                              (when-not @fired
+                                                (reset! fired true)
+                                                (registrar/unregister! :event :sa/counted))
+                                              (pos-int? (:n v)))]}
                        :states  {:running {}}})
       (rf/reg-machine :sup/count1 (parent-over [{:id :c :machine-id :sa/counted}]))
-      (trace/register-listener!
-        listener-id
-        (fn [ev]
-          (when (and (= :rf.machine.lifecycle/spawned (:operation ev))
-                     (= :sa/counted#1 (get-in ev [:tags :spawned-id]))
-                     (nil? @at-install))
-            (reset! at-install @calls))))
-      (let [off (on-started-once ::count1
-                  #(registrar/unregister! :event :sa/counted))]
-        (try
-          (rf/dispatch-sync [:sup/count1 [:start]])
-          (finally
-            (off)
-            (trace/unregister-listener! listener-id))))
+      (rf/dispatch-sync [:sup/count1 [:start]])
       (is (some? (snap-of :sa/counted#1))
           "the child installed its prepared snapshot despite the mid-drain unregister")
-      (is (= 1 @at-install)
+      (is (= 1 @pre-install)
           "the [:schemas :data] validator ran EXACTLY once by install time — the install consumed the prepared result, it did not re-validate")
+      (is (map? (type-ref-of :sa/counted#1))
+          "the diverged child pinned its prepared definition")
       (is (empty? (unregistered-rejects))
           "no unregistered-type reject fired for the prepared child"))))
 
 ;; ===========================================================================
 ;; rf2-rxjy3 — a prepared child must stay HANDLER-RESOLVABLE, not merely
 ;; snapshot-present. Consuming the prepared verdict (above) installs the child,
-;; but the snapshot's `:rf/machine-type` still named the (now-unregistered) TYPE
-;; keyword, so the lazy resolver resolved NOTHING: the actor was inert — it
-;; never bootstrapped and every later event fell through to
+;; but if the snapshot's `:rf/machine-type` still named the (now-unregistered)
+;; TYPE keyword, the lazy resolver would resolve NOTHING: the actor would be
+;; inert — never bootstrapped, and every later event falling through to
 ;; `:rf.error/no-such-handler`.
 ;;
 ;; DEFINITION-LIFETIME RULE (rf2-rxjy3). A prepared `:spawn-all` child's
 ;; definition authority is the definition its invoke PREPARED. The install
 ;; keeps the revertible `:machine-id` KEYWORD reference while the registrar
 ;; still holds exactly that definition — so ordinary hot-reload semantics are
-;; unchanged and live children continue to track a re-registered TYPE (test 7).
+;; unchanged and live children continue to track a re-registered TYPE (test 6).
 ;; The moment the registrar has DIVERGED from the prepared definition —
-;; unregistered (test 4) or replaced (test 6) — the prepared definition is
+;; unregistered (test 4) or replaced (test 5) — the prepared definition is
 ;; pinned onto the snapshot verbatim, exactly as an inline `:definition` spawn
 ;; carries its own spec. So a prepared child is never installed against a
 ;; MISSING definition, and never mixes a prepared-v1 snapshot with an unrelated
 ;; current-v2 handler.
+;;
+;; rf2-zo5n9 refined WHEN that comparison is taken: `spawn-fx*` passes
+;; `prepared-type-ref` as a THUNK and `install-spawn!` forces it at the LAST
+;; point before the runtime-db swap, so the rule decides against the registrar
+;; as it stands at COMMIT. That placement stands unchanged. What no longer
+;; exists is a way for APPLICATION code to act between `spawn-fx*`'s bindings
+;; and the write: the only callbacks there were the `:rf.machine.spawn/spawned`
+;; and `:rf.error/system-id-collision` traces, and under rf2-wxy1c those deliver
+;; post-drain. zo5n9's window is closed BY CONSTRUCTION rather than by late
+;; selection, so it carries no separate red/green lever and the suites that used
+;; to reach it through a listener are folded into the tests below.
 ;; ===========================================================================
 
 ;; ===========================================================================
@@ -325,105 +346,71 @@
 ;; ===========================================================================
 
 (deftest unregistered-prepared-child-is-a-live-resolvable-actor
-  (testing "an admitted child whose TYPE a started-listener UNREGISTERED between
-            the preflight and the install is a LIVE actor, not an inert
-            snapshot: its synthetic [:rf.machine.spawn/spawned] bootstrap
-            RESOLVES a handler and transitions it :idle → :ready, its
-            :rf/bootstrap-pending? marker clears, no :rf.error/no-such-handler
-            fires, and a LATER ordinary event still runs (:ready → :working)."
-    (rf/reg-machine :sa/boot booting-child)
-    (rf/reg-machine :sup/bootunreg (parent-over [{:id :c :machine-id :sa/boot}]))
-    (let [off (on-started-once ::bootunreg
-                #(registrar/unregister! :event :sa/boot))]
-      (try
-        (rf/dispatch-sync [:sup/bootunreg [:start]])
-        (finally (off))))
-    (let [child (get (:children (join-slot :sup/bootunreg)) :c)]
-      (is (some? (snap-of child))
-          "the admitted child installed its prepared snapshot (rf2-v4oqd)")
-      (is (= :ready (mtest/machine-state child))
-          "the child COMPLETED its synthetic bootstrap — it resolved a handler despite the mid-drain unregister")
-      (is (not (:rf/bootstrap-pending? (snap-of child)))
-          "the :rf/bootstrap-pending? marker cleared — the initial-entry cascade actually ran")
-      (is (empty? (no-such-handler-errors))
-          "NO :rf.error/no-such-handler fired — the prepared child's definition rides its snapshot")
-      ;; A LATER ordinary event executes against the same coherent definition.
-      (rf/dispatch-sync [child [:go]])
-      (is (= :working (mtest/machine-state child))
-          "a later ordinary event ran against the prepared definition too")
-      (is (empty? (no-such-handler-errors))
-          "still no :rf.error/no-such-handler after the ordinary event"))
-    (is (empty? (unregistered-rejects))
-        "rf2-v4oqd preserved — the prepared verdict was consumed, the registry recheck never re-ran")))
-
-;; ===========================================================================
-;; (5) Adversarial: EVERY child's TYPE unregistered mid-drain — every child is
-;;     a live, bootstrapped actor, not just snapshot-present.
-;; ===========================================================================
-
-(deftest all-children-stay-live-when-every-type-unregistered-mid-drain
-  (testing "when the started listener unregisters EVERY admitted child TYPE, every
-            child still bootstraps to :ready and no :rf.error/no-such-handler
-            fires for any of them — the whole batch stays handler-resolvable."
-    (rf/reg-machine :sa/boot-a booting-child)
-    (rf/reg-machine :sa/boot-b booting-child)
-    (rf/reg-machine :sup/bootall (parent-over [{:id :a :machine-id :sa/boot-a}
-                                               {:id :b :machine-id :sa/boot-b}]))
-    (let [off (on-started-once ::bootall
-                (fn []
-                  (registrar/unregister! :event :sa/boot-a)
-                  (registrar/unregister! :event :sa/boot-b)))]
-      (try
-        (rf/dispatch-sync [:sup/bootall [:start]])
-        (finally (off))))
-    (let [slot (join-slot :sup/bootall)]
-      (is (= 2 (count (:children slot))) "the join names both admitted children")
-      (doseq [id (vals (:children slot))]
+  (testing "an admitted child whose TYPE was UNREGISTERED between the preflight
+            and the install is a LIVE actor, not an inert snapshot: its
+            synthetic [:rf.machine.spawn/spawned] bootstrap RESOLVES a handler
+            and transitions it :idle → :ready, its :rf/bootstrap-pending? marker
+            clears, no :rf.error/no-such-handler fires, and a LATER ordinary
+            event still runs (:ready → :working)."
+    (let [child (mutating-child booting-child
+                                #(registrar/unregister! :event :sa/boot))]
+      (rf/reg-machine :sa/boot child)
+      (rf/reg-machine :sup/bootunreg (parent-over [{:id :c :machine-id :sa/boot}]))
+      (rf/dispatch-sync [:sup/bootunreg [:start]])
+      (let [id (get (:children (join-slot :sup/bootunreg)) :c)]
+        (is (some? (snap-of id))
+            "the admitted child installed its prepared snapshot (rf2-v4oqd)")
+        (is (= child (type-ref-of id))
+            "the prepared definition is PINNED verbatim — the diverged registrar keyword is not the authority")
         (is (= :ready (mtest/machine-state id))
-            (str "child " id " bootstrapped — its prepared definition rides its snapshot"))
-        (is (map? (type-ref-of id))
-            (str "child " id " pinned its prepared definition (the registrar no longer holds it)"))))
-    (is (empty? (no-such-handler-errors))
-        "no :rf.error/no-such-handler fired for either child")
-    (is (empty? (unregistered-rejects))
-        "no duplicate unregistered-type reject fired for either child")))
+            "the child COMPLETED its synthetic bootstrap — it resolved a handler despite the mid-drain unregister")
+        (is (not (:rf/bootstrap-pending? (snap-of id)))
+            "the :rf/bootstrap-pending? marker cleared — the initial-entry cascade actually ran")
+        (is (empty? (no-such-handler-errors))
+            "NO :rf.error/no-such-handler fired — the prepared child's definition rides its snapshot")
+        ;; A LATER ordinary event executes against the same coherent definition.
+        (rf/dispatch-sync [id [:go]])
+        (is (= :working (mtest/machine-state id))
+            "a later ordinary event ran against the prepared definition too")
+        (is (empty? (no-such-handler-errors))
+            "still no :rf.error/no-such-handler after the ordinary event"))
+      (is (empty? (unregistered-rejects))
+          "rf2-v4oqd preserved — the prepared verdict was consumed, the registry recheck never re-ran"))))
 
 ;; ===========================================================================
-;; (6) Adversarial: RE-REGISTER an admitted child TYPE to an UNRELATED v2
+;; (5) Adversarial: RE-REGISTER an admitted child TYPE to an UNRELATED v2
 ;;     between the preflight and the install. The child must run the definition
 ;;     it was PREPARED from — never a prepared-v1 snapshot driven by a
 ;;     current-v2 handler (the split-authority failure).
 ;; ===========================================================================
 
 (deftest reregister-to-unrelated-v2-mid-drain-keeps-one-coherent-authority
-  (testing "a started listener that RE-REGISTERS an admitted child TYPE to an
+  (testing "a mid-drain mutator that RE-REGISTERS an admitted child TYPE to an
             UNRELATED definition cannot split the child's authority: the
             snapshot AND the handler both come from the definition the preflight
             prepared (v1), so the child bootstraps into v1's :ready — never into
             v2's :v2-boot, and never against a v2 definition that does not even
             name v1's states."
-    (rf/reg-machine :sa/swap booting-child)
-    (rf/reg-machine :sup/swap (parent-over [{:id :c :machine-id :sa/swap}]))
-    (let [off (on-started-once ::swap
-                #(rf/reg-machine :sa/swap unrelated-v2))]
-      (try
-        (rf/dispatch-sync [:sup/swap [:start]])
-        (finally (off))))
-    (let [child (get (:children (join-slot :sup/swap)) :c)]
-      (is (= :ready (mtest/machine-state child))
-          "the child bootstrapped through the PREPARED v1 definition (:idle → :ready)")
-      (is (not= :v2-boot (mtest/machine-state child))
-          "the child did NOT resolve its handler from the unrelated current v2")
-      (is (= booting-child (type-ref-of child))
-          "the prepared v1 definition is pinned on the snapshot — the diverged registrar keyword is not the authority")
-      (rf/dispatch-sync [child [:go]])
-      (is (= :working (mtest/machine-state child))
-          "a later ordinary event ran against v1 too — one coherent authority, not a v1 snapshot on a v2 handler"))
-    (is (empty? (no-such-handler-errors))
-        "no :rf.error/no-such-handler fired")))
+    (let [child (mutating-child booting-child
+                                #(rf/reg-machine :sa/swap unrelated-v2))]
+      (rf/reg-machine :sa/swap child)
+      (rf/reg-machine :sup/swap (parent-over [{:id :c :machine-id :sa/swap}]))
+      (rf/dispatch-sync [:sup/swap [:start]])
+      (let [id (get (:children (join-slot :sup/swap)) :c)]
+        (is (= child (type-ref-of id))
+            "the prepared v1 definition is pinned on the snapshot — the diverged registrar keyword is not the authority")
+        (is (= :ready (mtest/machine-state id))
+            "the child bootstrapped through the PREPARED v1 definition (:idle → :ready)")
+        (is (not= :v2-boot (mtest/machine-state id))
+            "the child did NOT resolve its handler from the unrelated current v2")
+        (rf/dispatch-sync [id [:go]])
+        (is (= :working (mtest/machine-state id))
+            "a later ordinary event ran against v1 too — one coherent authority, not a v1 snapshot on a v2 handler"))
+      (is (empty? (no-such-handler-errors))
+          "no :rf.error/no-such-handler fired"))))
 
 ;; ===========================================================================
-;; (7) The other leg of the definition-lifetime rule: with NO mid-drain registry
+;; (6) The other leg of the definition-lifetime rule: with NO mid-drain registry
 ;;     mutation, the install keeps the REVERTIBLE keyword reference, so ordinary
 ;;     hot-reload of a TYPE still reaches its live spawned children.
 ;; ===========================================================================
@@ -450,167 +437,35 @@
         "no :rf.error/no-such-handler fired")))
 
 ;; ===========================================================================
-;; rf2-zo5n9 — the POST-SELECTION seam. rf2-rxjy3 (tests 4-7 above) made the
-;; prepared child's definition-lifetime choice correct, but `spawn-fx*` took
-;; that choice in its `let` bindings — BEFORE the two callback-bearing
-;; emissions that still run ahead of the install:
-;;
-;;   (a) the per-child `:rf.machine.spawn/spawned` trace, and
-;;   (b) `install-spawn!`'s `:rf.error/system-id-collision` trace.
-;;
-;; Both fan synchronously to application listeners, and both complete BEFORE
-;; the runtime-db swap that writes `:rf/machine-type`. A listener on either
-;; that unregistered or replaced the admitted child's TYPE therefore diverged
-;; the registrar AFTER `prepared-type-ref` had already observed it intact and
-;; returned the revertible `:machine-id` KEYWORD. The install then stamped that
-;; now-stale keyword, and the lazy resolver re-materialised NOTHING (inert
-;; actor) or an unrelated successor definition (split authority) — exactly the
-;; two failure modes rxjy3 eliminated, reached through a later door.
-;;
-;; The suites above mutate the registrar from `:rf.machine.spawn-all/started`,
-;; which fires BEFORE the per-child spawn fx runs at all, so they cannot see
-;; either seam. These tests pin the later ones: the reference is now selected
-;; at the LAST safe point, after every callback-bearing pre-install emission
-;; and immediately before the physical write.
+;; (7) The `install-spawn!` interior — two admitted children sharing a
+;;     `:system-id` make the second child's install fan the
+;;     `:rf.error/system-id-collision` trace and REBIND the name. That install
+;;     path is the tightest one the definition-lifetime rule has to hold on, so
+;;     it is pinned here with the same non-listener mid-drain mutator: the
+;;     rebound child's own validator diverges its TYPE, and its install must
+;;     still land a pinned, resolvable definition.
 ;; ===========================================================================
 
-;; ===========================================================================
-;; (8) THE BUG — a per-child `:rf.machine.spawn/spawned` listener UNREGISTERS
-;;     the admitted child TYPE. The child must still be a LIVE actor.
-;; ===========================================================================
-
-(deftest unregister-from-the-spawned-trace-listener-keeps-the-child-live
-  (testing "a :rf.machine.spawn/spawned listener that UNREGISTERS the admitted
-            child TYPE — after the prepared entry was selected, before the
-            snapshot's :rf/machine-type is written — cannot leave the child
-            inert: the reference is chosen at the last safe point, so the
-            diverged registrar is seen and the prepared definition is pinned.
-            The child bootstraps :idle → :ready and a later ordinary event runs."
-    (rf/reg-machine :sa/late-unreg booting-child)
-    (rf/reg-machine :sup/late-unreg (parent-over [{:id :c :machine-id :sa/late-unreg}]))
-    (let [off (on-operation-once ::late-unreg :rf.machine.spawn/spawned
-                #(registrar/unregister! :event :sa/late-unreg))]
-      (try
-        (rf/dispatch-sync [:sup/late-unreg [:start]])
-        (finally (off))))
-    (let [child (get (:children (join-slot :sup/late-unreg)) :c)]
-      (is (some? (snap-of child))
-          "the admitted child installed its prepared snapshot")
-      (is (map? (type-ref-of child))
-          "the prepared definition is PINNED — the registrar diverged on the spawned-trace callback, after the keyword would have been chosen")
-      (is (= :ready (mtest/machine-state child))
-          "the child COMPLETED its synthetic bootstrap — a stale keyword would have resolved nothing and left it at :idle")
-      (is (not (:rf/bootstrap-pending? (snap-of child)))
-          "the :rf/bootstrap-pending? marker cleared — the initial-entry cascade actually ran")
-      (rf/dispatch-sync [child [:go]])
-      (is (= :working (mtest/machine-state child))
-          "a later ordinary event ran against the prepared definition too")
-      (is (empty? (no-such-handler-errors))
-          "NO :rf.error/no-such-handler fired"))
-    (is (empty? (unregistered-rejects))
-        "rf2-v4oqd preserved — no registry recheck re-ran for the prepared child")))
-
-;; ===========================================================================
-;; (9) THE BUG, other leg — a per-child `:rf.machine.spawn/spawned` listener
-;;     RE-REGISTERS the admitted child TYPE to an UNRELATED v2.
-;; ===========================================================================
-
-(deftest reregister-from-the-spawned-trace-listener-keeps-one-coherent-authority
-  (testing "a :rf.machine.spawn/spawned listener that RE-REGISTERS the admitted
-            child TYPE to an UNRELATED definition cannot split the child's
-            authority: the snapshot AND the handler both come from the prepared
-            v1, so the child bootstraps into v1's :ready — never v2's :v2-boot."
-    (rf/reg-machine :sa/late-swap booting-child)
-    (rf/reg-machine :sup/late-swap (parent-over [{:id :c :machine-id :sa/late-swap}]))
-    (let [off (on-operation-once ::late-swap :rf.machine.spawn/spawned
-                #(rf/reg-machine :sa/late-swap unrelated-v2))]
-      (try
-        (rf/dispatch-sync [:sup/late-swap [:start]])
-        (finally (off))))
-    (let [child (get (:children (join-slot :sup/late-swap)) :c)]
-      (is (= booting-child (type-ref-of child))
-          "the prepared v1 definition is pinned — the registrar diverged after the keyword would have been chosen")
-      (is (= :ready (mtest/machine-state child))
-          "the child bootstrapped through the PREPARED v1 definition (:idle → :ready)")
-      (is (not= :v2-boot (mtest/machine-state child))
-          "the child did NOT resolve its handler from the unrelated current v2")
-      (rf/dispatch-sync [child [:go]])
-      (is (= :working (mtest/machine-state child))
-          "a later ordinary event ran against v1 too — one coherent authority"))
-    (is (empty? (no-such-handler-errors))
-        "no :rf.error/no-such-handler fired")))
-
-;; ===========================================================================
-;; (10) Adversarial — EVERY child's TYPE unregistered from its OWN
-;;      `:rf.machine.spawn/spawned` emit. Each child's reference must be chosen
-;;      against the registrar as it stands at ITS OWN install, so every child
-;;      stays live and the join still folds to completion.
-;; ===========================================================================
-
-(deftest every-child-unregistered-from-its-own-spawned-trace-stays-live
-  (testing "when each admitted child's TYPE is unregistered from that child's OWN
-            :rf.machine.spawn/spawned emit, every child pins its prepared
-            definition, bootstraps to :ready, and the :all join still folds —
-            no inert child, no :rf.error/no-such-handler, no reject."
-    (rf/reg-machine :sa/late-a booting-child)
-    (rf/reg-machine :sa/late-b booting-child)
-    (rf/reg-machine :sup/late-all (parent-over [{:id :a :machine-id :sa/late-a}
-                                                {:id :b :machine-id :sa/late-b}]))
-    (let [off (on-every-spawned ::late-all
-                (fn [spawned-id]
-                  ;; `<type>#n` — unregister the TYPE this very child was
-                  ;; prepared from, on its own pre-install callback.
-                  (when-let [t (some #(when (= (name %)
-                                               (first (str/split (name spawned-id) #"#")))
-                                        %)
-                                     [:sa/late-a :sa/late-b])]
-                    (registrar/unregister! :event t))))]
-      (try
-        (rf/dispatch-sync [:sup/late-all [:start]])
-        (finally (off))))
-    (let [slot (join-slot :sup/late-all)]
-      (is (= 2 (count (:children slot))) "the join names both admitted children")
-      (doseq [id (vals (:children slot))]
-        (is (map? (type-ref-of id))
-            (str "child " id " pinned its prepared definition"))
-        (is (= :ready (mtest/machine-state id))
-            (str "child " id " bootstrapped — it is a live actor, not an inert snapshot"))))
-    (is (empty? (no-such-handler-errors))
-        "no :rf.error/no-such-handler fired for either child")
-    (is (empty? (unregistered-rejects))
-        "no unregistered-type reject fired for either child")))
-
-;; ===========================================================================
-;; (11) Adversarial — the OTHER pre-install callback: `install-spawn!`'s
-;;      `:rf.error/system-id-collision` trace. Two admitted children sharing a
-;;      `:system-id` make the second child's install fan that trace; a listener
-;;      on it unregisters that child's TYPE. This seam is INSIDE
-;;      `install-spawn!`, later even than the spawned trace, so it is the
-;;      tightest window the fix must still cover.
-;; ===========================================================================
-
-(deftest unregister-from-the-system-id-collision-listener-keeps-the-child-live
-  (testing "a :rf.error/system-id-collision listener that UNREGISTERS the
-            colliding child's TYPE — the LAST callback before the runtime-db
-            swap — still cannot install a stale keyword: the rebound child pins
-            its prepared definition and bootstraps to :ready."
-    (rf/reg-machine :sa/sys-a booting-child)
-    (rf/reg-machine :sa/sys-b booting-child)
-    (rf/reg-machine :sup/sys (parent-over
-                               [{:id :a :machine-id :sa/sys-a :system-id :sys/shared}
-                                {:id :b :machine-id :sa/sys-b :system-id :sys/shared}]))
-    (let [off (on-operation-once ::sys :rf.error/system-id-collision
-                #(registrar/unregister! :event :sa/sys-b))]
-      (try
-        (rf/dispatch-sync [:sup/sys [:start]])
-        (finally (off))))
-    (let [slot  (join-slot :sup/sys)
-          child (get (:children slot) :b)]
-      (is (= 1 (count (mtest/events-of :rf.error/system-id-collision)))
-          "the shared :system-id fanned exactly one collision trace (the second child's install)")
-      (is (map? (type-ref-of child))
-          "the rebound child pinned its prepared definition — the registrar diverged on the collision callback, INSIDE install-spawn!")
-      (is (= :ready (mtest/machine-state child))
-          "the rebound child bootstrapped — it is live, not inert")
-      (is (empty? (no-such-handler-errors))
-          "no :rf.error/no-such-handler fired"))))
+(deftest system-id-rebound-child-still-pins-its-prepared-definition
+  (testing "the colliding child's install — the one that rebinds a shared
+            :system-id — still cannot install a stale keyword: the rebound child
+            pins its prepared definition and bootstraps to :ready, and exactly
+            one collision trace fans for the invoke."
+    (let [child-b (mutating-child booting-child
+                                  #(registrar/unregister! :event :sa/sys-b))]
+      (rf/reg-machine :sa/sys-a booting-child)
+      (rf/reg-machine :sa/sys-b child-b)
+      (rf/reg-machine :sup/sys (parent-over
+                                 [{:id :a :machine-id :sa/sys-a :system-id :sys/shared}
+                                  {:id :b :machine-id :sa/sys-b :system-id :sys/shared}]))
+      (rf/dispatch-sync [:sup/sys [:start]])
+      (let [slot  (join-slot :sup/sys)
+            child (get (:children slot) :b)]
+        (is (= 1 (count (mtest/events-of :rf.error/system-id-collision)))
+            "the shared :system-id fanned exactly one collision trace (the second child's install)")
+        (is (= child-b (type-ref-of child))
+            "the rebound child pinned its prepared definition")
+        (is (= :ready (mtest/machine-state child))
+            "the rebound child bootstrapped — it is live, not inert")
+        (is (empty? (no-such-handler-errors))
+            "no :rf.error/no-such-handler fired")))))

--- a/implementation/machines/test/re_frame/trace_listener_post_drain_mutation_test.clj
+++ b/implementation/machines/test/re_frame/trace_listener_post_drain_mutation_test.clj
@@ -1,0 +1,193 @@
+(ns re-frame.trace-listener-post-drain-mutation-test
+  "Trace listeners are OBSERVERS, not participants (rf2-wxy1c).
+
+  THE CONTRACT THIS PINS. A trace listener's body never runs while the framework
+  owns a frame's drain lock. Internal drain-owned emits are delivered at the
+  POST-DRAIN boundary — serialized process-wide, in emission order, completing
+  before the enclosing dispatch / drain call returns. The consequence for
+  application code is the thing worth pinning directly, because it is the part a
+  programmer can observe:
+
+    A registrar mutation performed from inside a trace listener takes effect
+    when the listener's callback RUNS — post-drain. It is therefore exactly
+    equivalent to performing the same mutation on the line AFTER `dispatch-sync`
+    returns. Intra-drain influence by listener side effects is OUT OF CONTRACT.
+
+  ARM 1 ≡ ARM 2 is the whole test. Arm 1 mutates the registrar from a listener
+  on an emit the drain owns; arm 2 performs the identical mutation immediately
+  after the same `dispatch-sync` returns. Every observable — the installed
+  `:rf/machine-type` reference FORM, the actor's reachable state, and the
+  `:rf.error/no-such-handler` count — must agree. Arm 3 is the undisturbed
+  control, so a bug that flattened all three arms into one value could not pass
+  silently.
+
+  `:spawn-all` child installation is the probe because it is the most
+  timing-sensitive consumer of the registrar in the codebase: `install-spawn!`
+  forces `prepared-type-ref` at the last point before the runtime-db write, and
+  the definition-lifetime rule (rf2-rxjy3 / rf2-zo5n9) makes the FORM of the
+  stamped reference a pure function of whether the registrar had diverged BY
+  THAT INSTANT. If a listener could still act inside the drain, arm 1 would pin
+  a definition map and arm 2 would keep a keyword — which is precisely what this
+  test would catch.
+
+  WHY THIS IS NOT A PLATFORM-SPLIT TEST. The assertion is on OBSERVABLE OUTCOMES
+  (reference form, reachable state, error counts), never on exceptions and never
+  on delivery mechanics. CLJS delivers inline — that is an implementation detail
+  of the `trace.cljc` seam (load-bearing for bundle isolation), not a promise —
+  and the outcome contract is identical on both platforms. This suite is JVM
+  because the deferral seam it characterises is JVM-only by construction; what
+  it asserts is the cross-platform contract.
+
+  RED-BEFORE LEVER. Make `re-frame.trace/call-with-deferred-listener-delivery`
+  the identity on JVM (`#?(:clj (f) :cljs (f))`), restoring the pre-rf2-wxy1c
+  inline fan-out: arm 1 then pins a definition map and reaches `:working` while
+  arm 2 keeps a keyword and strands the child, and the arm-1 ≡ arm-2 assertions
+  fail."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  mtest/trace-capture-fixture)
+
+(def ^:private booting-child
+  "A child whose synthetic `[:rf.machine.spawn/spawned]` bootstrap causes an
+  OBSERVABLE `:idle` → `:ready` transition, and which then accepts an ordinary
+  `:go` event. An installed-but-unresolvable child stays at `:idle` instead —
+  so the reachable state distinguishes a LIVE actor from an inert snapshot."
+  {:initial :idle
+   :data    {}
+   :states  {:idle    {:on {:rf.machine.spawn/spawned :ready}}
+             :ready   {:on {:go :working}}
+             :working {}}})
+
+(defn- parent-over [children]
+  {:initial :idle
+   :states
+   {:idle    {:on {:start :forking}}
+    :forking {:spawn-all {:children         children
+                          :join             :all
+                          :on-child-done    :sa/done
+                          :on-child-error   :sa/failed
+                          :on-all-complete  [:all/done]}
+              :on {:all/done :ready}}
+    :ready   {}}})
+
+(defn- snap-of [actor-id]
+  (get-in (mtest/runtime-db) [:rf.runtime/machines :snapshots actor-id]))
+
+(defn- observe
+  "The arm's observable end state — deliberately NOT a delivery-mechanics
+  reading. `:pinned?` is the FORM of the installed reference (a pinned
+  definition map vs the revertible TYPE keyword), `:state` is the state the
+  actor actually reaches after an ordinary later event, and
+  `:no-such-handler` counts the resolver failures an inert actor would raise.
+
+  Note the CLJS-safety of this shape (rf2-wxy1c): a stale reference does not
+  THROW on either platform — it strands the actor — so every reading here is an
+  outcome, never an exception.
+
+  The resolver-failure count is filtered to THIS child: the trace capture is
+  cumulative across the arms in one deftest, and an unfiltered count would make
+  arm 2 differ from arm 1 for a reason that has nothing to do with the contract."
+  [child-id]
+  (rf/dispatch-sync [child-id [:go]])
+  {:pinned?         (map? (:rf/machine-type (snap-of child-id)))
+   :installed?      (some? (snap-of child-id))
+   :state           (mtest/machine-state child-id)
+   :no-such-handler (count (filterv #(= child-id (get-in % [:tags :rf.trace/event-id]))
+                                    (mtest/events-of :rf.error/no-such-handler)))})
+
+(defn- run-arm
+  "Register `type-kw` + a `:spawn-all` parent over it, dispatch the fork, and
+  return `(observe child)`. `during` runs from a trace listener on the
+  drain-owned `:rf.machine.spawn-all/started` emit; `after` runs on the line
+  following `dispatch-sync`. Exactly one of them is supplied per arm."
+  [type-kw parent-kw {:keys [during after]}]
+  (rf/reg-machine type-kw booting-child)
+  (rf/reg-machine parent-kw (parent-over [{:id :c :machine-id type-kw}]))
+  (let [listener-id ::arm
+        fired       (atom false)]
+    (when during
+      (trace/register-listener!
+        listener-id
+        (fn [ev]
+          (when (and (= :rf.machine.spawn-all/started (:operation ev))
+                     (not @fired))
+            (reset! fired true)
+            (during)))))
+    (try
+      (rf/dispatch-sync [parent-kw [:start]])
+      (when after (after))
+      (finally
+        (when during (trace/unregister-listener! listener-id))))
+    (when during
+      (is (true? @fired)
+          "(precondition) the listener ran — deferred delivery still DELIVERS"))
+    (observe (get-in (mtest/runtime-db)
+                     [:rf.runtime/machines :spawned parent-kw [:forking] :children :c]))))
+
+;; ===========================================================================
+;; UNREGISTER — a listener that unregisters the child TYPE mid-drain lands
+;; post-drain, so it is indistinguishable from unregistering after the call.
+;; ===========================================================================
+
+(deftest mid-drain-listener-unregister-is-equivalent-to-unregistering-after-the-drain
+  (testing "a :rf.machine.spawn-all/started listener that UNREGISTERS the child
+            TYPE produces EXACTLY the observable end state that the same
+            unregister performed one line after dispatch-sync produces — the
+            listener body runs at the post-drain boundary, so it cannot
+            influence the install it appears to precede (rf2-wxy1c)."
+    (let [arm-1 (run-arm :pd/a1 :pd/sup-a1
+                         {:during #(registrar/unregister! :event :pd/a1)})
+          arm-2 (run-arm :pd/a2 :pd/sup-a2
+                         {:after  #(registrar/unregister! :event :pd/a2)})
+          arm-3 (run-arm :pd/a3 :pd/sup-a3 {})]
+      (is (= arm-1 arm-2)
+          (str "ARM 1 ≡ ARM 2 — mid-drain listener mutation lands post-drain. "
+               "arm-1=" arm-1 " arm-2=" arm-2))
+      ;; The controls below keep the equality honest: they pin what the shared
+      ;; value actually IS, so a regression that made every arm agree on some
+      ;; degenerate reading could not pass.
+      (is (false? (:pinned? arm-1))
+          "the install saw an INTACT registrar and kept the revertible keyword — the unregister had not happened yet")
+      (is (true? (:installed? arm-1))
+          "the admitted child installed regardless (rf2-v4oqd)")
+      (is (= :ready (:state arm-1))
+          "the child bootstrapped, then the post-drain unregister stranded its later :go — the accepted cost of the revertible keyword")
+      (is (pos? (:no-such-handler arm-1))
+          "the stranded later event raised :rf.error/no-such-handler — an OUTCOME, not an exception")
+      (is (= {:pinned? false :installed? true :state :working :no-such-handler 0}
+             arm-3)
+          "the undisturbed control is unaffected: keyword reference, live actor, no resolver failure"))))
+
+;; ===========================================================================
+;; RE-REGISTER — the other leg. A listener that swaps the TYPE to a successor
+;; definition is likewise a post-drain mutation.
+;; ===========================================================================
+
+(deftest mid-drain-listener-reregister-is-equivalent-to-reregistering-after-the-drain
+  (testing "a listener that RE-REGISTERS the child TYPE to a successor definition
+            is equally post-drain: the live child tracks the successor exactly as
+            it would had the re-registration been written after dispatch-sync —
+            ordinary hot-reload semantics, reached at the ordinary time."
+    (let [v2    (assoc-in booting-child [:states :ready :on :go] :hot-reloaded)
+          v2'   (assoc-in v2 [:states :hot-reloaded] {})
+          arm-1 (run-arm :pd/b1 :pd/sup-b1
+                         {:during #(rf/reg-machine :pd/b1 v2')})
+          arm-2 (run-arm :pd/b2 :pd/sup-b2
+                         {:after  #(rf/reg-machine :pd/b2 v2')})]
+      (is (= arm-1 arm-2)
+          (str "ARM 1 ≡ ARM 2 — the re-registration lands post-drain either way. "
+               "arm-1=" arm-1 " arm-2=" arm-2))
+      (is (false? (:pinned? arm-1))
+          "the install kept the revertible keyword — the registrar was intact at commit")
+      (is (= :hot-reloaded (:state arm-1))
+          "the live child followed the re-registered definition — hot-reload semantics preserved")
+      (is (zero? (:no-such-handler arm-1))
+          "no resolver failure — the successor definition resolves"))))

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -14,7 +14,7 @@ The tracing surface is designed to be **stable** (required fields don't change),
 
 ## The trace event model
 
-A trace event is an immutable map describing one moment of work in the runtime — an event dispatch, a sub recomputation, a render, an fx invocation, a machine transition. Events flow into a single per-application trace stream; listeners receive each event synchronously, one at a time.
+A trace event is an immutable map describing one moment of work in the runtime — an event dispatch, a sub recomputation, a render, an fx invocation, a machine transition. Events flow into a single per-application trace stream, and listeners receive them one at a time, never concurrently. Delivery is **two-tier**: a **public** emit fans out synchronously, while an **internal, drain-owned** emit is delivered at the post-drain boundary of the operation that produced it, before that operation returns (see [§Subscription / consumption](#subscription--consumption)).
 
 The shape is documented below.
 
@@ -621,7 +621,18 @@ Pair-shaped tools and Xray's flow panel filter `op-type :flow` (per [Tool-Pair �
 
 ## Subscription / consumption
 
-re-frame2's trace API uses **synchronous, event-at-a-time delivery** — every registered listener is invoked once per emitted trace event while the runtime is still on the emit call stack. Listener-invocation order is **not contract**; tools must not depend on the order in which sibling listeners receive a given event. There is no batching, debounce window, or background delivery loop. Listeners SHOULD do minimal work in the callback (queue, append to a buffer, mark a flag) and defer expensive work to a separate timer or animation frame they own.
+re-frame2's trace API uses **event-at-a-time delivery**: every registered listener is invoked once per emitted trace event, one event at a time, never concurrently with itself. There is no batching, debounce window, or background delivery loop — every event a public operation produces is delivered before that operation returns. Listener-invocation order is **not contract**; tools must not depend on the order in which sibling listeners receive a given event. Listeners SHOULD do minimal work in the callback (queue, append to a buffer, mark a flag) and defer expensive work to a separate timer or animation frame they own.
+
+**Trace listeners are observers, not participants.** *When* a listener is invoked depends on who emitted the event, and the runtime distinguishes two tiers:
+
+- **Public emits** — an emit raised outside a frame drain, including one an application or tool raises itself — fan out **synchronously**, on the emitting call stack, through callback completion.
+- **Internal, drain-owned emits** — those the runtime raises while it owns a frame's drain lock — are delivered at the **post-drain boundary**. They are queued during the drain and fanned out on the way out: **serialized process-wide**, in **emission order**, and **completing before the enclosing dispatch / drain call returns**. A listener therefore never observes a partially settled state, and two frames draining concurrently can never enter the same listener at once.
+
+The reason is a hard invariant: **arbitrary listener code is never invoked, nor awaited, while the framework owns any frame drain lock.** A listener that dispatched, destroyed a frame, or blocked would otherwise be running inside the runtime's own critical section — which on a multi-threaded host admits overlapping delivery across independent frames, and lock cycles through listener-authored work.
+
+The corollary is a contract boundary tools must respect: **a listener's side effects cannot influence the drain that produced the event.** A mutation performed in a callback takes effect when that callback runs, which for a drain-owned emit is after the drain has finished — exactly as if it had been written on the line following `dispatch-sync`. Code that depends on a listener body altering the outcome of the in-flight operation is **out of contract on every platform**. Single-threaded hosts may deliver inline, but that is an implementation detail of the host, not a promise; portable tools must not read intra-drain influence into it.
+
+Observation itself is unaffected: every event is still delivered, exactly once, in emission order, before the operation that produced it returns.
 
 ### The listener API
 


### PR DESCRIPTION
Closes rf2-wxy1c (P1).

## The interleaving (demonstrated red first)

`rf2-rakqk` (#6248) keyed the `fanout-monitor` opt-out on REAL drain-lock ownership: an outermost emit whose thread held the target frame's `:drain-lock` drove its listener fan-out INLINE, off the monitor, so the `rf2-jl75r` AB-BA cycle could not close. Deadlock-correct, but not serial — the drain-lock serializes **one frame's** drain while the listener registry is **process-global**. Two independent frames draining on two JVM threads each own their own lock, so both qualified for the inline path and both entered the same arbitrary listener callback at once.

New suite `trace_listener_concurrent_drain_serialization_test.clj` drives exactly that: one listener; thread A `dispatch-sync`es into frame ALPHA and latches inside its `:rf.event/run-start` callback; while A is latched, thread B `dispatch-sync`es into frame BETA. **Red on the pre-fix tree, deterministically, on every iteration** — reproducing the bead's recorded evidence:

```
max concurrent invocations 2
observed before release: [[:enter :wxy1c/alpha] [:enter :wxy1c/beta] [:exit :wxy1c/beta]]
under-lock:              [[:wxy1c/alpha true] [:wxy1c/beta true]]
```

That last line is the second half of the defect: both callbacks ran while the framework still held their frame's `:drain-lock`. 12 failures across 3 iterations pre-fix; 150/150 assertions green post-fix (25 iterations, `RF2_WXY1C_ITERS`-tunable).

## The post-drain point, and why that one

`re-frame.trace/call-with-deferred-listener-delivery` brackets the **whole acquire -> run -> release region** of each of the three — and, by grep, only three — `:drain-lock` CAS sites: `router/drain-try!`, `router/drain-block!`, `frame/call-serialized-with-drain!`. A drain-owned emit appends to a per-thread pending vector; the batch is flushed there, under `fanout-monitor`, before the enclosing dispatch/drain returns.

This composes with what exists rather than adding machinery: each of those three sites already had the acquire/release structure, and the classifier work drops out entirely. **The dynamic scope IS the ownership evidence** — no frame resolution, no ownership probe — so `frame/thread-owns-drain-serialization?` and its `:frame/thread-owns-drain-serialization?` late-bind hook are retired (the classifier was their only consumer), with the directory row removed alongside them.

The scope is a **`ThreadLocal`, deliberately not a `^:dynamic` Var**. JVM `next-tick` and `set-timeout!` wrap their callbacks in `bound-fn`, so a Var binding is *conveyed to other threads*: an `ensure-drain-scheduled!` issued mid-drain would hand the executor thread the draining thread's scope, and an armed `:dispatch-later` would hand it to the timer thread — each then appending its own unrelated traces to a batch whose owner had long since flushed, stranding them undelivered forever. This was caught as a real red (`substrate_source_test`'s dispatch-later child timing out), not reasoned about in the abstract.

## Content unchanged — ordering only

Delivered envelopes are identical: build, classification projection, ring push and epoch capture all still run inline, in emission order, untouched. Two things are captured at **append** time so a deferred fan-out delivers exactly what an inline one would have:

- the **listener snapshot** — a listener registered or unregistered later in the same drain neither gains nor loses an earlier event;
- a one-shot latch over **`continue?`** — an incarnation destroyed later in the drain cannot retroactively suppress an event that was already authorised at emission, while a listener that destroys it *during* the deferred fan-out still suppresses the remainder (rf2-eaxnai preserved).

The flush also re-establishes the ordinary delivery scope `deliver!` gives an inline fan-out (epoch capture / frame policy / ring retention restored to defaults, exact-owner continuation neutralised). Without that, a listener body would inherit whatever authority the *drain* was running under — which is precisely the rf2-eaxnai defect.

**One behavioural consequence, called out for review.** It is inherent to the bead's own criterion that listener code is "neither invoked nor awaited while the framework owns any target frame drain lock": a trace listener now observes `:rf.event/run-start` *after* the cascade settles, so it can no longer veto the handler it names by destroying the frame mid-fan-out. Spec 009 listeners are observers of the stream, not participants in the cascade — and letting arbitrary tool code halt a cascade mid-flight is exactly the hazard the bead set out to remove. One assertion in `frame_destroy_incarnation_jvm_test` was inverted to pin the new contract explicitly, with the reasoning inline. The suppression that *is* contract still holds: within a single fan-out, listener #1 losing A still stops the remaining listeners, and the always-on `:events` / `:errors` families are not deferred and keep their full synchronous suppression semantics.

## Why the race is unreachable, not merely unobserved

The argument is structural, not statistical:

1. `fanout-monitor` is acquired at exactly **two** sites — the outermost emit branch (reached only when the ThreadLocal is unset) and the post-drain flush.
2. `:drain-lock` is CAS-acquired at exactly **three** sites, each now *fully* enclosed by a scope set before the acquire and `.remove`d after the release. Every instant at which a thread holds a drain-lock therefore lies inside a set scope, so **site 1 is unreachable while holding a drain-lock**.
3. The flush runs after `.remove` and after the enclosed region returned, and every exit path of all three regions releases the lock (`try-release-on-empty!` / `force-release-on-halt!` / `drain-emergency-release!` / the not-live `reset!` / the cold `finally`). The one path that deliberately keeps the lock held — `drain-loop!` with `hold-lock? true` — is reached only from `drain-reentrant!`, which runs *inside* an outer cold scope and so establishes no scope and performs no flush. So **site 2 is unreachable while holding a drain-lock**.

No thread can ever wait on the monitor while owning a drain-lock: the AB-BA edge cannot exist, for any interleaving, rather than merely failing to appear in N runs. Progress follows from the same invariant — a thread blocked on the monitor holds no drain-lock, so a drain-lock holder always makes progress — and `locking` is reentrant, so a listener whose `dispatch-sync` drains a frame and flushes that batch while its own fan-out still holds the monitor simply re-enters it.

## Spec 009

**Amended** (~lines 17 and 624) to state the two-tier delivery contract per rf2-rakqk's accepted criteria and the rf2-wxy1c ruling: public emits fan out synchronously; internal drain-owned emits deliver at the post-drain boundary — serialized process-wide, in emission order, exposing no partially settled state, and completing before the enclosing dispatch/drain returns. Intra-drain influence by listener side effects is stated **out of contract on every platform**; a single-threaded host's inline delivery is an implementation detail, not a promise.

Spec 009 is hot-zone: verified unheld at edit time — no open PR touched the file, and the only unmerged sibling-worktree edit was a catalogue row at line 2299 (1600+ lines from these edits). `spec009-cardinality`'s line-664 edit had already merged. No Spec-Schemas row; still no new runtime error/trace id.

## Quality gates

### Ruled test-rework pass — fence lifted (Fable ruling, 2026-07-19)

The 17 JVM machines failures were **expected**: they are exactly what the ruling re-bases. All 17 are now green, re-based rather than weakened.

| Gate | Result |
|---|---|
| `implementation/core` full JVM suite | 2079 tests / **10107 assertions**, **0 failures** |
| `implementation/machines` full JVM suite | 1195 tests / **4164 assertions**, **0 failures** (was **17 failures**) |
| `implementation` CLJS node gate (`npm run test:cljs`) | 10213 tests / **50469 assertions**, **0 failures** |
| `npm run test:elision` | **PASS** — production 60/60 absent, control 60/60 present |
| `tools/mcp-conformance/wire-vocab` (trace-catalogue lint) | 100 tests / **1069 assertions**, 0 failures |
| `python -m mkdocs build --strict` | exit **0** |
| `python scripts/check_doc_slugs.py` | exit **0** |
| `python scripts/check_keyword_catalogue_drift.py` | exit **0** |

**The non-listener mid-drain mutator.** The ruling named "an fx interleaved in the entry vector between preflight and install". No such slot exists: `apply-transition-once` composes `all-fx` as `cascade-fx ++ after-cancel ++ destroy ++ spawn-fx ++ after ++ done`, and `handle-spawn-all-decl` contributes `[init-fx, spawn-a, spawn-b]` as one contiguous framework-owned block — application fx land strictly *before* the preflight. Rather than add an fx-ordering hook to serve a test, the suites use the mutator that already sits in exactly that window: **the child's own `[:schemas :data]` validator**. `prepare-spawn-all-child` resolves and retains `:type-spec` **first**, builds the snapshot, then runs the application validator **last** — so a registrar mutation from inside it lands strictly after the child was prepared and strictly before `install-spawn!` forces `prepared-type-ref`. Same window, ordinary in-drain application code, and **platform-uniform** (schema validation is not reader-conditional — these `.cljc` suites pass identically under CLJS's inline delivery).

**New contract test** — `re-frame.trace-listener-post-drain-mutation-test` (JVM, 2 tests / 12 assertions). Pins the ruling directly: a mid-drain listener mutation lands post-drain, so **arm 1 ≡ arm 2** (mutate from a listener on a drain-owned emit ≡ mutate on the line after `dispatch-sync`), with arm 3 as the undisturbed control so a degenerate flattening cannot pass.

*Red-before, with its own lever:* making `re-frame.trace/call-with-deferred-listener-delivery` the identity on JVM (restoring pre-rf2-wxy1c inline fan-out) turns it **RED — 7 of 12 assertions**, with `arm-1 = {:pinned? true, :state :working}` vs `arm-2 = {:pinned? false, :state :hot-reloaded}`. That is precisely the ruling's 3-arm probe reproduced as a standing test. Lever reverted; `git diff` empty.

**Assertions are observable outcomes, never exceptions** — reference *form* (pinned map vs revertible keyword), reachable state, and per-child `:rf.error/no-such-handler` counts. As the ruling notes, this class does not throw on CLJS (`(inc nil)` is `1`), so a stale callback resurrects state rather than erroring; nothing here asserts a throw.

**No new mechanism.** No scheduler, no event-shape classifier, no public synchronization surface, no listener prohibition. `install-spawn!` needed **no code change**: the `spawn.cljc` diff is comment/docstring-only at 3 sites, retiring the now-false "fan synchronously to application listeners" premise.

**Test-count delta.** Machines 1197 → 1195: the three `rf2-zo5n9` later-seam suites folded (their window — the `:rf.machine.spawn/spawned` and `:rf.error/system-id-collision` callbacks — is now closed *by construction*, so they were verbatim duplicates of the rxjy3 tests modulo the mutator); the `:system-id` collision path is kept and re-based. CLJS 10217 → 10213 is the same four `.cljc` deftests, confirming the re-base is platform-uniform.

**Family 3 record correction.** `destroyed_exit_order_test` moves to the batched `[:exit :exit :destroyed :destroyed]`. Its stale **005:2138** citation (the state-tags worked example) is corrected to **005:3026** §"Composition with explicit `:entry`/`:exit`", and the docstring's claim narrowed: that section guarantees only that the user's `:exit` **action** reads the actor's final snapshot before auto-destroy. The "consumer observing the db between `:exit` and `:rf.machine/destroyed`" sentence existed only in that docstring and extended an action-ordering guarantee into a trace-interleaving one the spec never wrote.

### Rework pass — regression fix for the deferred-fanout fence (`44386ba13b`)

Completed, foreground, non-zero counts:

| Gate | Result |
|---|---|
| `implementation/core` full JVM suite | 2074 tests / **10058 assertions**, **0 failures** |
| `implementation/routing` full JVM suite | 443 tests / **2288 assertions**, **0 failures** (was 2) |
| `implementation` CLJS node gate (`npm run test:cljs`) | 10056 tests / **49589 assertions**, **0 failures** |
| `implementation/machines` full JVM suite | 1197 tests / **4172 assertions**, **17 failures** — unchanged by this pass; see the ruling request below |

**Multi-listener acceptance proof.** Three trace listeners, one `dispatch-sync`
cascading through four events, 800 ms settle before sampling (so a missing
envelope is proven dropped, not merely late):

| Build | L1 | L2 | L3 |
|---|---|---|---|
| `origin/main` | 35 traces / 4 dispatch envelopes | 35 / 4 | 35 / 4 |
| branch **pre-fix** (`ec5f5cb`) | 35 / 4 | **32 / 1** | **32 / 1** |
| branch **post-fix** (`44386ba`) | 35 / 4 | 35 / 4 | 35 / 4 |

The post-fix branch is identical to `main` on every axis. **Regression 1 is closed**, and the two `implementation/routing` failures went with it — they were the same defect.

`test:elision`, `test:bundle-isolation` and `test:perf-bundle` are left to CI; the rework touches only a `#?(:clj)` form, so the CLJS surface is unchanged.

No `node_modules` junction or symlink into the mayor tree; the mayor tree's `node_modules` was canaried before and after.

### Original pass

| Gate | Result |
|---|---|
| New suite, **pre-fix** | **RED** — 12 failures / 18 assertions (3 iters) |
| New suite, **post-fix** | **150 assertions**, 0 failures (25 iters) |
| Adjacent trace/drain suites (`trace-listener-drain-deadlock`, `trace-listener-frame-tagged-serialization`, `trace-listener-concurrent-serialization`, `trace-listener`, `trace`, `trace-buffer`, `drain`, `cold-serialized-drain`, `router-drain-race`, `late-bind-drift`) | 92 tests / **1284 assertions**, 0 failures |
| `implementation/epoch` drain-serialization + silencing suites | 6 tests / **44 assertions**, 0 failures |
| `implementation/flows` drain-race + destroy-linearization | 14 tests / **1075 assertions**, 0 failures |

The CLJS-side change is a reader conditional whose `:cljs` arm is the identity call and emits no reference into `re-frame.trace.tooling` — deliberately so, because the drain is production code and an unconditional route through the tooling sibling would drag the dev-only listener registry (and its bundle-isolation sentinel) into the production counter bundle.

