### PR TITLE
spec(schemas): declare the public frame-destroyed :op tag (rf2-vub3y)

### DIFF
--- a/implementation/ui/test/re_frame/ui/frame_destroyed_op_schema_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/frame_destroyed_op_schema_jvm_test.clj
@@ -1,0 +1,186 @@
+(ns re-frame.ui.frame-destroyed-op-schema-jvm-test
+  "rf2-vub3y — pin the canonical `FrameDestroyedTags` `:op` declaration in
+  `spec/Spec-Schemas.md` against what the runtime ACTUALLY emits on the
+  dev-trace `:tags` channel.
+
+  `:op` is a ratified-PUBLIC, small closed-enum realm attribution on
+  `:rf.error/frame-destroyed` (PR #6254 / rf2-a2x2w; see the Spec 009 error
+  catalogue row). It rides BOTH the always-on record attrs (axis 1) and the
+  dev-trace `:tags` (axis 2) — but only the record side was ever asserted
+  (`frame-ops-cljs-test` checks `(:op r)` and merely COUNTS traces). The
+  per-category `:tags` schema is the canonical CLJS-reference shape that ports
+  translate mechanically, so an undeclared-but-emitted key is a real contract
+  hole. This suite closes it from BOTH ends:
+
+    - the schema is read from the MARKDOWN at run time (never hand-copied
+      here), so deleting or narrowing the `:op` slot goes red;
+    - every value in the declared enum is DRIVEN through a real emit and
+      observed on `[:tags :op]`, so a declared-but-never-emitted value goes
+      red too (the rf2-jxpf3 failure mode — 19 catalogue rows claimed tags
+      that were never emitted);
+    - the ordinary address-directed path is driven and asserted to OMIT
+      `:op`, so promoting the slot to required goes red.
+
+  JVM-only by construction: it slurps the spec markdown directly, so it needs
+  no compile-time extraction macro. The `(frame)` bundle fences it drives are
+  the ONLY surface that reaches all four enum values (`:capture` is ui-only)."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core                 :as rf]
+            [re-frame.error-emit           :as error-emit]
+            [re-frame.frame                :as frame]
+            [re-frame.live-frame           :as live-frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.trace                :as trace]
+            [re-frame.ui.frames            :as frames]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter       plain-atom/adapter
+    :ambient-frame nil
+    :init-fn       (fn [] (error-emit/clear-error-listeners!))})
+  (fn [f]
+    (frames/reset-frame-ops-cache!)
+    (try (f) (finally (frames/reset-frame-ops-cache!)))))
+
+;; ---------------------------------------------------------------------------
+;; The canonical schema, read from spec/Spec-Schemas.md
+;; ---------------------------------------------------------------------------
+
+(def ^:private spec-schemas-candidates
+  ;; Resolve relative to whichever directory the runner starts in
+  ;; (`clojure -M:test` runs from implementation/ui).
+  ["../../spec/Spec-Schemas.md" "../spec/Spec-Schemas.md" "spec/Spec-Schemas.md"])
+
+(defn- frame-destroyed-tags-form
+  "Return the `[:map …]` form of `(def FrameDestroyedTags …)` as data. The `;;`
+  comments in the def are dropped by the EDN reader, so this is the pure
+  canonical shape. Throws if the def is absent or is not a `[:map …]`."
+  []
+  (let [file (or (some (fn [p] (let [f (io/file p)] (when (.exists f) f)))
+                       spec-schemas-candidates)
+                 (throw (ex-info "rf2-vub3y: cannot locate spec/Spec-Schemas.md"
+                                 {:candidates spec-schemas-candidates})))
+        text  (slurp file)
+        start (str/index-of text "(def FrameDestroyedTags")]
+    (when (nil? start)
+      (throw (ex-info "rf2-vub3y: (def FrameDestroyedTags …) not found in Spec-Schemas.md" {})))
+    (let [schema (nth (edn/read-string (subs text start)) 2 nil)]
+      (when-not (and (vector? schema) (= :map (first schema)))
+        (throw (ex-info "rf2-vub3y: FrameDestroyedTags is not a [:map …] form" {:read schema})))
+      schema)))
+
+(defn- op-entry
+  "The canonical FrameDestroyedTags `:op` slot as `{:props … :schema …}`, or nil
+  when the slot is absent. Malli map entries are `[k schema]` OR `[k props
+  schema]`; normalising both here means a slot that DROPS its props map (i.e. is
+  promoted to required) fails the props assertion cleanly instead of throwing."
+  []
+  (when-let [entry (first (filter #(and (vector? %) (= :op (first %)))
+                                  (rest (frame-destroyed-tags-form))))]
+    (if (= 3 (count entry))
+      {:props (nth entry 1) :schema (nth entry 2)}
+      {:props nil :schema (nth entry 1)})))
+
+;; ---------------------------------------------------------------------------
+;; Driving the real emits
+;; ---------------------------------------------------------------------------
+
+(defn- make-frame! [id db]
+  (live-frame/make-frame {:id id})
+  (frame/replace-app-db! id db)
+  id)
+
+(defn- reg! []
+  (rf/reg-event :ops/set-n (fn [_ [_ n]] {:db {:n n}}))
+  (rf/reg-sub :ops/n (fn [db _] (:n db))))
+
+(defn- frame-destroyed-trace-tags
+  "Run `thunk` and return the `:tags` maps of every `:rf.error/frame-destroyed`
+  dev-trace event it emitted. Swallows the typed throw the fail-loud `(frame)`
+  surfaces raise — this suite is about the emitted envelope, not the throw."
+  [thunk]
+  (let [traces (atom [])
+        tkey   (keyword "test" (name (gensym "fd-op-trace")))]
+    (trace/register-listener! tkey
+                              (fn [ev] (when (= :rf.error/frame-destroyed (:operation ev))
+                                         (swap! traces conj (:tags ev)))))
+    (try
+      (try (thunk) (catch clojure.lang.ExceptionInfo _ nil))
+      @traces
+      (finally (trace/unregister-listener! tkey)))))
+
+(defn- emitted-op-for
+  "Drive one `(frame)`-bundle arm and return the single emitted `:tags` map."
+  [thunk]
+  (let [tags (frame-destroyed-trace-tags thunk)]
+    (is (= 1 (count tags)) "exactly one :rf.error/frame-destroyed dev trace")
+    (first tags)))
+
+;; ---------------------------------------------------------------------------
+;; Legs
+;; ---------------------------------------------------------------------------
+
+(deftest canonical-schema-declares-the-public-op-slot
+  (testing "spec/Spec-Schemas.md FrameDestroyedTags declares `:op` as an
+            OPTIONAL closed enum — the ratified-public realm attribution"
+    (let [{:keys [props schema]} (op-entry)]
+      (is (some? (op-entry)) "FrameDestroyedTags declares an :op slot")
+      (is (= {:optional true} props)
+          ":op is OPTIONAL — presence tracks the emit site's knowledge of the realm")
+      (is (= [:enum :dispatch :dispatch-sync :subscribe :capture] schema)
+          ":op is the exact four-value closed enum ratified by Spec 009"))))
+
+(deftest every-declared-op-value-is-actually-emitted-on-the-tags-channel
+  (testing "each value in the canonical enum is reachable through a REAL emit
+            and lands on [:tags :op] — no declared-but-phantom value (rf2-jxpf3)"
+    (reg!)
+    (let [declared (set (rest (:schema (op-entry))))
+          observed (atom #{})]
+      ;; The three stale-bundle-op arms.
+      (make-frame! :ops/doomed {:n 1})
+      (let [b (rf/with-frame :ops/doomed (frames/frame-ops))]
+        (frame/destroy-frame! :ops/doomed)
+        (doseq [[op thunk] [[:dispatch      #((:dispatch b) [:ops/set-n 2])]
+                            [:dispatch-sync #((:dispatch-sync b) [:ops/set-n 2])]
+                            [:subscribe     #((:subscribe b) [:ops/n])]]]
+          (testing (str "stale bundle " op)
+            (let [tags (emitted-op-for thunk)]
+              (is (contains? tags :op) ":op is PRESENT on the dev-trace tags")
+              (is (= op (:op tags)) ":op names the failing operation realm")
+              (is (contains? declared (:op tags))
+                  ":op is a member of the canonical closed enum")
+              (swap! observed conj (:op tags))))))
+      ;; The ui-only `:capture` arm — a `(frame)` read resolving a dead
+      ;; incarnation before any op ran.
+      (testing "capture-time read of a dead incarnation"
+        (let [tags (emitted-op-for
+                    #(binding [frame/*current-frame* :ops/ghost] (frames/frame-ops)))]
+          (is (contains? tags :op) ":op is PRESENT on the dev-trace tags")
+          (is (= :capture (:op tags)) ":op marks the capture-time failure")
+          (is (contains? declared (:op tags))
+              ":op is a member of the canonical closed enum")
+          (swap! observed conj (:op tags))))
+      (is (= declared @observed)
+          "the declared enum is exactly the set of values the runtime emits —
+           neither a phantom declared value nor an undeclared emitted one"))))
+
+(deftest ordinary-address-directed-emit-omits-op
+  (testing "an ordinary address-directed dispatch into a destroyed frame carries
+            NO captured incarnation, so it omits `:op` entirely — which is why
+            the slot is `{:optional true}` and not required"
+    (reg!)
+    (make-frame! :ops/plain {:n 1})
+    (frame/destroy-frame! :ops/plain)
+    (let [tags (frame-destroyed-trace-tags
+                #(rf/dispatch-sync [:ops/set-n 5] {:frame :ops/plain}))]
+      (is (seq tags) "the ordinary path still emits :rf.error/frame-destroyed")
+      (doseq [t tags]
+        (is (not (contains? t :op))
+            "no :op key at all — the tight legacy record shape is unchanged")
+        (is (= :rf.error/frame-destroyed (:category t))
+            ":category IS present — frame-destroyed is an :error envelope
+             (build-event merges {:category operation} on the error branch only)")))))

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -1211,9 +1211,24 @@ Common keys (`:category`, `:failing-id`, `:reason`, `:frame`) are inherited from
    [:reason     :string]])
 
 (def FrameDestroyedTags
+  ;; `:op` (rf2-a2x2w / rf2-vub3y) — the failing operation's REALM, a small closed
+  ;; enum ratified PUBLIC on this category (per the 009 catalogue row). It is
+  ;; OPTIONAL because presence tracks the EMIT SITE'S KNOWLEDGE, not the envelope
+  ;; branch: only a site that already knows the realm stamps it — the compiled-view
+  ;; `(frame)` bundle fences (all four values; `:capture` is ui-only, a `(frame)`
+  ;; read that resolved a dead incarnation before any op ran), the `capture-frame`
+  ;; stale-op pre-check seam, and the router / subs LATE captured-op fences
+  ;; (`:dispatch` / `:dispatch-sync` / `:subscribe`). An ORDINARY address-directed
+  ;; dispatch / subscribe into a destroyed frame carries NO captured incarnation,
+  ;; so it omits `:op` and remains valid without it — that emit keeps its tight
+  ;; keyset and the realm-ambiguous `[:sub]`-then-`[:event]` source-coord fallback.
+  ;; Orthogonal to the envelope's `:category` rule above (`:category` is required
+  ;; here because `:rf.error/frame-destroyed` is an `:error` envelope; `:op`'s
+  ;; optionality is a per-emit-site axis, not a per-branch one).
   [:map
    [:category       :keyword]
    [:frame          :keyword]
+   [:op             {:optional true} [:enum :dispatch :dispatch-sync :subscribe :capture]]
    [:rf.event/v     {:optional true} [:vector :any]]
    [:rf.sub/query-v {:optional true} [:vector :any]]])
 


### PR DESCRIPTION
Closes rf2-vub3y.

PR #6254 ratified `:op` as a **public**, small closed-enum realm attribution on `:rf.error/frame-destroyed`, and the runtime emits it on BOTH the always-on record attrs (axis 1) and the dev-trace `:tags` (axis 2). The canonical per-category schema never moved with that decision — `FrameDestroyedTags` declared only `:category`, `:frame`, `:rf.event/v`, `:rf.sub/query-v`.

The open-map convention means nothing is rejected at runtime, but these per-category schemas are the canonical CLJS-reference shapes that **ports translate mechanically**. Omitting a deliberately public discriminator leaves a port or a generated tool unable to discover or constrain `:op`.

## The declaration

```clojure
[:op {:optional true} [:enum :dispatch :dispatch-sync :subscribe :capture]]
```

Enum verified **at the emit sites**, not from the catalogue:

| Value | Emitted from |
|---|---|
| `:dispatch` | `router.cljc:3912` (late captured-op fence) · `core.cljc:1336/1338` (`capture-frame` pre-check) · `ui/frames.cljc:1302` |
| `:dispatch-sync` | `router.cljc:4067` · `core.cljc:1342/1344` · `ui/frames.cljc:1303` |
| `:subscribe` | `subs.cljc:1040/1607` · `core.cljc:1282` · `ui/frames.cljc:1278` |
| `:capture` | `ui/frames.cljc:1191` — **ui-only**, a `(frame)` read that resolved a dead incarnation before any op ran |

All three emit helpers pass `:op` in the `trace-tags` argument, which `error-emit/emit-error-both!` forwards **unchanged** to `trace/emit-error!`; `build-event` dissocs only `:recovery` / `:sensitive?` (and `:source` off the error branch), so `:op` genuinely lands on `[:tags :op]`.

## How it composes with rf2-jxpf3's envelope rule

`:op`'s optionality is a **per-emit-site** axis, orthogonal to jxpf3's per-branch `:category` rule. `:category` stays **required** here because `:rf.error/frame-destroyed` is an `:error` envelope, so `build-event`'s `(merge {:category operation})` always fires for it. `:op` is optional for a different reason: only a site that already **knows** the realm stamps it. An ordinary address-directed dispatch/subscribe into a destroyed frame carries no captured incarnation, omits `:op`, and remains valid — keeping its tight keyset and the realm-ambiguous `[:sub]`-then-`[:event]` source-coord fallback. Both facts are asserted by the new suite.

## Spec 009 lockstep

**No 009 edit needed.** The `:rf.error/frame-destroyed` catalogue row already names `:op`, all four values, `:capture` as ui-only, the presence-iff-realm-known rule, its absence on the ordinary path, and its trace-tag role. Verified against the emitters — the row is accurate. The two documents now agree on field name, enum, optionality and role.

## Quality gates

Run in the worktree, foreground, to completion.

| Gate | Result |
|---|---|
| **New evidence suite** (`re-frame.ui.frame-destroyed-op-schema-jvm-test`) | **3 tests / 23 assertions**, 0 failures |
| error-catalogue channel conformance (`implementation/core`) | **9 tests / 21 assertions**, 0 failures — matches baseline exactly |
| `implementation/core` → `clojure -M:test` | **2073 tests / 9911 assertions**, 0 failures |
| `implementation/ui` → `clojure -M:test` | **916 tests / 15996 assertions**, 0 failures |
| `npm run test:cljs` | **10067 tests / 49700 assertions**, 0 failures |
| `python -m mkdocs build --strict` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |

### Evidence, and why not the conformance test

The error-catalogue channel-conformance test is **not** offered as evidence: rf2-jxpf3 proved its parser reads only columns 1–3 (`:operation`, `:op-type`, `Channel`), so it does not validate the `:tags` column at all. It is reported above only as a no-regression check.

The real evidence is a new JVM suite that reads `FrameDestroyedTags` **from the markdown at run time** (never hand-copied into the test), drives all four enum values through real emits, and asserts `[:tags :op]` presence and enum membership. This closes a genuine gap: the existing `frame-ops-cljs-test` legs assert `(:op r)` on the always-on **record** but merely **count** traces — the tags channel, which is exactly what `FrameDestroyedTags` schemas, was unasserted.

**Red when inverted** — both directions proven:

- Narrow the enum to three values and drop `{:optional true}` → **4 failures**, including `(not (contains? #{:dispatch-sync :dispatch :subscribe} :capture))` and `(not (= #{...3 values} #{...4 values}))`.
- Remove the `:op` slot entirely (the exact pre-change bug state) → **8 failures**. The suite would have caught the original drift.

The suite also asserts the declared enum **equals** the emitted set, so a declared-but-never-emitted value goes red too — the rf2-jxpf3 failure mode (19 catalogue rows claiming tags that were never emitted), inverted into a gate.

## Sibling omissions noticed — named, not filed

Per the anti-over-engineering fence these are reported only:

1. **`FrameDestroyedTags` declares `:rf.event/v` and `:rf.sub/query-v`, but no frame-destroyed emitter stamps either.** The three emitters actually stamp `:event` (router, ui) and `:query-v` (subs). These look like two phantom slots of exactly the kind jxpf3 removed elsewhere, plus two genuinely-emitted-but-undeclared keys. The 009 catalogue row carries the same claim (`:rf.event/v` "dev-trace tag when called from dispatch", `:rf.sub/query-v` "when called from subscribe"), so the drift is consistent across both documents — which is why it needs a deliberate ruling on which name is canonical rather than a drive-by rename here.
2. `subs.cljc`'s emitter stamps `:recovery :replaced-with-default` into its trace-tags map. Harmless — `build-event` strips it per jxpf3 — but it is dead payload at the call site.
