### PR TITLE
fix(story): stop tests shadowing open-in-editor and surface Promise-backed presence failures (rf2-oslyz, rf2-iz0t8)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1130,6 +1130,20 @@ framework's own JVM arm of `flush-presence!` remains a no-op, and correctly
 so: there the structural host provably has no lifecycle to advance. An absent
 hook establishes no such thing.)
 
+**A Promise-backed host is AWAITED before the next step.** On CLJS the
+canonical verb (`re-frame.ui.test/flush-presence!`) returns a Promise, so
+reaching the host is not the same as the flush having succeeded. The runner
+therefore settles the returned thenable before it records the step: a
+fulfilled flush records the ordinary no-assertion step, and a REJECTED one
+(a React `act` failure, `:rf.error/flush-convergence-exceeded`) becomes the
+same step-exception a synchronously throwing host produces, failing the run.
+A rejection is never left unobserved, and can never arrive too late to change
+the verdict — the run cannot report `:pass` over a flush that failed. The
+interactive step-debugger records the settled result too, so it and the
+auto-run loop always agree. Synchronous hosts — the JVM verb, a custom
+synchronous advance — keep their existing behaviour exactly: nothing is
+deferred that was not already asynchronous.
+
 **Source metadata is preserved for narrative projection.** The runner
 keeps the script step on every step-result and trace record, and the
 evidence projection (`re-frame.story.play.evidence/narrative`) attributes
@@ -1869,8 +1883,9 @@ tokens it requires:
 - `[:dispatch …]` / `[:dispatch-sync …]` → `#{:app-db}` (the headless
   floor drains the queue to a fixed point); `[:wait …]` / `[:wait-until
   …]` / `[:flush-presence …]` → `#{}` (the boundary ladder governs flush,
-  not the capability set; the presence clock is a process-global registry
-  and a host without one advances a no-op — §Presence-bearing variants);
+  not the capability set; the presence clock is a process-global registry,
+  and `[:flush-presence]` with no host installed REFUSES `:cannot-run`
+  rather than advancing a no-op — §Presence-bearing variants);
   `[:click …]` / `[:type …]` / `[:focus …]` / `[:assert-dom …]` →
   `#{:dom}`.
 - An in-script `[:assert <atom>]` checkpoint folds the WRAPPED atom's

--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -403,8 +403,22 @@
       (when step
         (let [idx     (count (:ran (get @stepper-state frame-id)))
               run-fn  (late-bind/get-fn :run-play-step)
+              ;; rf2-iz0t8 — a `[:flush-presence]` against a Promise-backed
+              ;; host is the ONE step whose outcome is not known by the time
+              ;; the executor returns. The executor calls this back with the
+              ;; SETTLED result a microtask later, so the stepper records the
+              ;; same verdict the auto-run loop would. Every other step calls
+              ;; back synchronously, BEFORE the slot below exists — hence the
+              ;; bounds guard: the synchronous return value already recorded
+              ;; the final result in that case, and there is nothing to amend.
+              settle! (fn [settled]
+                        (swap! stepper-state update-in [frame-id :results]
+                               (fn [rs]
+                                 (if (and rs (< idx (count rs)))
+                                   (assoc rs idx settled)
+                                   rs))))
               result  (cond
-                        run-fn (run-fn frame-id idx step)
+                        run-fn (run-fn frame-id idx step settle!)
 
                         ;; Fallback: executor unavailable. Drive dispatch
                         ;; steps directly via `dispatch-one!`; record nothing

--- a/tools/story/src/re_frame/story/play/presence.cljc
+++ b/tools/story/src/re_frame/story/play/presence.cljc
@@ -81,6 +81,16 @@
   []
   (late-bind/get-fn presence-flush-hook-key))
 
+(defn- thenable
+  "`x` as a thenable, or nil. CLJS-only: the canonical host verb
+  (`re-frame.ui.test/flush-presence!`) is Promise-backed there, while the JVM
+  arm is a synchronous no-op and a custom host may be synchronous on either.
+  Duck-typed on `.then` rather than `instance? js/Promise` so any thenable a
+  host hands back is observed."
+  [x]
+  #?(:clj  (do x nil)
+     :cljs (when (and (some? x) (fn? (unchecked-get x "then"))) x)))
+
 (defn advance!
   "Advance the presence clock by `ms` (nil → to quiescence) through the
   installed host verb. Returns a small result map:
@@ -92,16 +102,61 @@
                                          docstring)
     {:status :error    :ms … :error s} — the host verb threw
 
+  An `:advanced` result additionally carries `:pending <thenable>` when the
+  host verb returned one and has therefore NOT finished (rf2-iz0t8). The
+  canonical CLJS host does exactly that — `flush-presence!` is Promise-backed
+  — so returning `:advanced` bare would report that the advance succeeded
+  while its outcome was still unknown. `settle!` is how a caller waits for the
+  answer; `:advanced` on its own means only 'the verb was reached'.
+
   Never throws, and never judges: this is pure data → data reporting of what
   happened. The executor (`runner-events/exec-flush-presence!`) projects the
   map into a step-result."
   [ms]
   (if-let [f (presence-flush-fn)]
     (try
-      (f ms)
-      {:status :advanced :ms ms}
+      (let [ret (f ms)]
+        (if-let [p (thenable ret)]
+          {:status :advanced :ms ms :pending p}
+          {:status :advanced :ms ms}))
       (catch #?(:clj Throwable :cljs :default) e
         {:status :error
          :ms     ms
          :error  #?(:clj (.getMessage ^Throwable e) :cljs (str e))}))
     {:status :no-host :ms ms}))
+
+(defn settle!
+  "Call `k` with the FINAL `advance!` result for `res`. Returns nil.
+
+  SYNCHRONOUS — `k` runs before `settle!` returns — for every advance that is
+  already over: the JVM verb, a synchronous custom host, `:no-host`, and a
+  host that threw. Those paths keep their existing behaviour exactly.
+
+  When `res` carries a `:pending` thenable (the Promise-backed CLJS host),
+  `k` runs once it settles:
+
+    fulfilled → the same `:advanced` result with `:pending` dropped
+    rejected  → `{:status :error :ms … :error s}` — the SAME shape a
+                synchronously throwing host produces, so a rejection needs no
+                new vocabulary downstream
+
+  This is the whole of rf2-iz0t8: before it, `advance!` returned `:advanced`
+  the instant the verb was CALLED, the executor recorded a clean step, and a
+  later rejection (a React `act` failure, `:rf.error/flush-convergence-
+  exceeded`) became an unhandled rejection that could no longer change the
+  recorded result — a presence-bearing play reported `:pass` over a flush that
+  had actually failed.
+
+  Rejection is observed via the two-argument `.then`, not a chained `.catch`:
+  a `.catch` would also swallow — and re-enter `k` for — a throw from `k`
+  itself on the fulfilled path."
+  [res k]
+  #?(:clj  (do (k res) nil)
+     :cljs (if-let [p (:pending res)]
+             (do (.then p
+                        (fn [_] (k (dissoc res :pending)))
+                        (fn [e] (k {:status :error
+                                    :ms     (:ms res)
+                                    :error  (str e)})))
+                 nil)
+             (do (k res) nil))))

--- a/tools/story/src/re_frame/story/play/runner.cljc
+++ b/tools/story/src/re_frame/story/play/runner.cljc
@@ -62,8 +62,13 @@
   `[:wait ms]`, and the reason a presence-bearing variant does not need the
   determinism opt-out. It routes through
   `re-frame.story.play.presence` to the framework's own
-  `re-frame.ui.test/flush-presence!`; with no presence host installed it is
-  a no-op (host parity, exactly as the framework's JVM arm is).
+  `re-frame.ui.test/flush-presence!`; with no presence host installed the
+  step REFUSES (`:cannot-run`) rather than skipping — an absent hook does not
+  prove an absent presence runtime, so a silent no-op there would let a
+  presence-bearing play report a clean verdict over a clock that never moved
+  (rf2-36biz). On CLJS the verb is Promise-backed, and the run loop awaits it
+  before the next step, so a rejected flush fails the step instead of being
+  lost (rf2-iz0t8).
 
   | Step                               | Semantics                                                     |
   |------------------------------------|---------------------------------------------------------------|

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -1061,6 +1061,29 @@
                                         "queue/state predicate did not hold "
                                         "after the preceding dispatch settled)")}))))
 
+(defn- presence-step-result
+  "Project a `presence/advance!` result into a step-result. Pure data → data,
+  and the ONE place the projection lives — the executor projects the
+  provisional result here, and `settle-step-result!` re-projects the settled
+  one through the very same fn, so a Promise-backed host cannot acquire a
+  different vocabulary just by being asynchronous."
+  [idx step res]
+  (case (:status res)
+    :error   (runner/step-exception idx step (:error res))
+    :no-host (runner/step-fail
+               idx step
+               {:cannot-run? true
+                :reason      :no-presence-host
+                :message     (str "cannot run " (pr-str step)
+                                  " — no presence host is installed, so the "
+                                  "presence clock did not advance. An app "
+                                  "that renders re-frame.ui compiled views "
+                                  "installs the verb by requiring "
+                                  "re-frame.story.play.presence-host (or by "
+                                  "calling re-frame.story.play.presence/"
+                                  "install-presence-flush! directly)")})
+    (runner/step-skip idx step)))
+
 (defn- exec-flush-presence!
   "Execute a `[:flush-presence]` / `[:flush-presence ms]` step — advance the
   compiled-view PRESENCE clock through the installed host verb
@@ -1083,25 +1106,34 @@
   grammar requires no following assertion, and an `:assert-db` one needs only
   the headless floor. The refusal NAMES its install path so it is actionable.
 
-  A host verb that THROWS is a step-exception — never swallowed."
+  A host verb that THROWS is a step-exception — never swallowed. So is one
+  whose Promise REJECTS (rf2-iz0t8): the canonical CLJS host is Promise-backed,
+  so `advance!` hands back a `:pending` thenable that has not settled yet. The
+  step-result returned here is provisional in that case and rides
+  `::pending-advance`; `settle-step-result!` replaces it with the real one
+  before the run records anything."
   [_frame-id idx step]
   (let [ms  (runner/step-presence-ms step)
         res (presence/advance! ms)]
-    (case (:status res)
-      :error   (runner/step-exception idx step (:error res))
-      :no-host (runner/step-fail
-                 idx step
-                 {:cannot-run? true
-                  :reason      :no-presence-host
-                  :message     (str "cannot run " (pr-str step)
-                                    " — no presence host is installed, so the "
-                                    "presence clock did not advance. An app "
-                                    "that renders re-frame.ui compiled views "
-                                    "installs the verb by requiring "
-                                    "re-frame.story.play.presence-host (or by "
-                                    "calling re-frame.story.play.presence/"
-                                    "install-presence-flush! directly)")})
-      (runner/step-skip idx step))))
+    (cond-> (presence-step-result idx step res)
+      (:pending res) (assoc ::pending-advance res))))
+
+(defn- settle-step-result!
+  "Call `k` with the FINAL step-result for `result`. Returns nil.
+
+  Synchronous for every step but an unsettled Promise-backed
+  `[:flush-presence]` — the ONE step whose executor can return before its work
+  is over. For that one, `k` runs when the host's thenable settles, over the
+  result the settled advance projects to (a rejection becomes the ordinary
+  step-exception `:error` branch above).
+
+  Both drivers go through this: the auto-run loop and the interactive stepper
+  must not disagree about whether a presence flush failed."
+  [idx step result k]
+  (if-let [res (::pending-advance result)]
+    (presence/settle! res #(k (presence-step-result idx step %)))
+    (k result))
+  nil)
 
 (defn exec-step!
   "Execute ONE step against `frame-id`. Returns a step-result record
@@ -1219,20 +1251,34 @@
 
   Always records its settle boundary under play-key nil — the stepper
   (`play/variant-play-steps`) only ever walks the DEFAULT play, never a
-  named `:plays` entry."
-  [frame-id idx step]
-  (record-settle-boundary! frame-id nil step)
-  (let [result (try
-                 (exec-step! frame-id idx step)
-                 (catch #?(:clj Throwable :cljs :default) e
-                   (runner/step-exception idx step
-                                          #?(:clj  (.getMessage ^Throwable e)
-                                             :cljs (str e)))))]
-    ;; `exec-step!` (via `exec-assert!`) already wrote the canonical
-    ;; assertion record onto `:rf.story/assertions`; no synthetic slot
-    ;; mirror here.
-    (emit-trace! frame-id nil idx step result)
-    result))
+  named `:plays` entry.
+
+  `settled-cb` (optional) receives the FINAL step-result. It is invoked
+  exactly once, and SYNCHRONOUSLY for every step but one: a
+  `[:flush-presence]` against a Promise-backed host settles a microtask later
+  (rf2-iz0t8), and only then is it known whether the flush actually
+  succeeded. The RETURN value is the synchronously-known result, which for
+  that one case is provisional — a caller that records step outcomes must
+  take them from `settled-cb`, or the stepper would show a clean flush the
+  auto-run loop calls a failure."
+  ([frame-id idx step]
+   (run-step! frame-id idx step nil))
+  ([frame-id idx step settled-cb]
+   (record-settle-boundary! frame-id nil step)
+   (let [result (try
+                  (exec-step! frame-id idx step)
+                  (catch #?(:clj Throwable :cljs :default) e
+                    (runner/step-exception idx step
+                                           #?(:clj  (.getMessage ^Throwable e)
+                                              :cljs (str e)))))]
+     ;; `exec-step!` (via `exec-assert!`) already wrote the canonical
+     ;; assertion record onto `:rf.story/assertions`; no synthetic slot
+     ;; mirror here.
+     (settle-step-result! idx step result
+                          (fn [settled]
+                            (emit-trace! frame-id nil idx step settled)
+                            (when settled-cb (settled-cb settled))))
+     result)))
 
 ;; ---- async scheduler -----------------------------------------------------
 
@@ -1385,18 +1431,33 @@
                                                   #?(:clj  (.getMessage ^Throwable e)
                                                      :cljs (str e)))))
                 yield? (runner/async-yield? step)]
-            (record-result! frame-id play-key nm idx step result)
-            ;; Sync-class step → recur synchronously so the next step
-            ;; observes the just-committed effects atomically (the
-            ;; `doseq`-style sequential semantics).
-            ;;
-            ;; Async-class step → yield one tick on CLJS so the
-            ;; queued router work / synthetic DOM event handlers drain
-            ;; before the next step runs.
-            #?(:cljs (if yield?
-                       (js/setTimeout #(run-loop! frame-id play-key token done-cb) 0)
-                       (recur frame-id play-key token done-cb))
-               :clj  (recur frame-id play-key token done-cb))))))))
+            (if (::pending-advance result)
+              ;; A Promise-backed presence host has NOT settled (rf2-iz0t8).
+              ;; AWAIT it before recording anything: a rejection is the step's
+              ;; own exception, and recording the provisional pass first would
+              ;; leave the run reporting `:pass` over a flush that failed.
+              ;; CLJS-only — `advance!` never produces a `:pending` on the JVM,
+              ;; where the verb is a synchronous no-op.
+              #?(:cljs (settle-step-result!
+                         idx step result
+                         (fn [settled]
+                           (record-result! frame-id play-key nm idx step settled)
+                           (js/setTimeout
+                             #(run-loop! frame-id play-key token done-cb) 0)))
+                 :clj  nil)
+              (do
+                (record-result! frame-id play-key nm idx step result)
+                ;; Sync-class step → recur synchronously so the next step
+                ;; observes the just-committed effects atomically (the
+                ;; `doseq`-style sequential semantics).
+                ;;
+                ;; Async-class step → yield one tick on CLJS so the
+                ;; queued router work / synthetic DOM event handlers drain
+                ;; before the next step runs.
+                #?(:cljs (if yield?
+                           (js/setTimeout #(run-loop! frame-id play-key token done-cb) 0)
+                           (recur frame-id play-key token done-cb))
+                   :clj  (recur frame-id play-key token done-cb))))))))))
 
 ;; ---- public driver -------------------------------------------------------
 

--- a/tools/story/test/re_frame/story/open_in_editor_ownership_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/open_in_editor_ownership_cljs_test.cljs
@@ -39,6 +39,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.source-coords.open-endpoint :as open-endpoint]
+            [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story.canonical :as canonical]
             [re-frame.story.config :as story-config]
             [re-frame.story.ui.open-in-editor :as story-open]
@@ -93,9 +94,24 @@
 (defn- install-story! [] (story-open/install!))
 (defn- install-xray!  [] (xray-open/install!))
 
+(defn- ensure-adapter!
+  "Install the plain-atom test adapter unless one is already installed.
+
+  Per rf2-oslyz: `rf/make-frame` needs a state-container factory, and this
+  namespace supplied none — every test here failed with
+  `:rf.error/no-adapter-installed` when the selector ran it ALONE, and only
+  passed in the consolidated run because some earlier namespace happened to
+  have called `init!` first. A suite whose green depends on a neighbour is
+  not a suite. `init!` throws when an adapter is already installed, which is
+  the idempotent case, so the throw is the no-op branch."
+  []
+  (try (rf/init! plain-atom/adapter)
+       (catch :default _ nil)))
+
 (defn- fresh-frames!
   "Story's public event lands on `:rf/default`; Xray's on `:rf/xray`."
   []
+  (ensure-adapter!)
   (frame/ensure-default-frame!)
   (rf/make-frame {:id :rf/xray}))
 

--- a/tools/story/test/re_frame/story/play/presence_real_clock_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/play/presence_real_clock_cljs_test.cljs
@@ -27,10 +27,19 @@
   `presence-cljs-test`, whose harness this ns reuses.
 
   The wall clock is DISABLED throughout, so the logical advance is the sole
-  removal driver — the determinism the whole rung exists for."
+  removal driver — the determinism the whole rung exists for.
+
+  The final block (rf2-iz0t8) covers the PROMISE-BACKED-ness itself rather
+  than the clock: resolved and rejected thenable controls driven through the
+  real run loop and the real interactive stepper. Those need a host whose
+  Promise the test can settle on demand, which the real clock cannot give —
+  so they use two-line stub hosts, and the real-clock tests above are what
+  keep the stubs honest about the shape they stand in for."
   (:require [cljs.test :refer [async deftest is testing use-fixtures]]
             [re-frame.core                     :as rf]
             [re-frame.router                   :as router]
+            [re-frame.story.play               :as play]
+            [re-frame.story.play.presence      :as story-presence]
             ;; The shipped optional bridge — the one canonical installation
             ;; path (rf2-36biz). Requiring it is exactly what a consuming app
             ;; does; `install!` re-arms it after the shared fixture's teardown.
@@ -152,3 +161,115 @@
                (is (= 1 (presence-rt/pending-count))
                    "the real exit is still pending — nothing advanced the clock")
                (done)))))
+
+;; ===========================================================================
+;; Promise-backed host settlement (rf2-iz0t8)
+;; ===========================================================================
+;;
+;; The canonical CLJS host returns `re-frame.ui.test/flush-presence!`'s
+;; Promise. `presence/advance!` used to call it inside a synchronous `try` and
+;; immediately return `{:status :advanced}` — so the executor recorded a clean
+;; step, the run loop merely yielded a `setTimeout` 0, and a LATER rejection
+;; (a React `act` failure, `:rf.error/flush-convergence-exceeded`) landed
+;; outside the `try`, became an unhandled rejection, and could no longer
+;; change the already-recorded result. A presence-bearing play reported
+;; `:pass` over a flush that had actually failed.
+;;
+;; The two hosts below differ in exactly ONE thing — whether their Promise
+;; resolves or rejects — so neither verdict can be an artefact of anything
+;; else. The resolving host is the POSITIVE CONTROL: without it, "always
+;; fail the step" would pass the rejection test while breaking every real
+;; presence run.
+
+(defn- install-thenable-host!
+  "Install a host whose advance returns a Promise settling on the next
+  microtask. `outcome` is `:resolve` or `:reject`. Records each advance's ms
+  into `calls` so the tests can prove the verb was actually reached."
+  [outcome calls]
+  (story-presence/install-presence-flush!
+    (fn [ms]
+      (swap! calls conj ms)
+      (if (= :reject outcome)
+        (js/Promise.reject (ex-info "presence flush failed" {:ms ms}))
+        (js/Promise.resolve :ok)))))
+
+(deftest resolving-thenable-host-passes-the-run
+  (async done
+    (let [calls (atom [])]
+      (install-thenable-host! :resolve calls)
+      (re/run! shared/presence-frame "resolving"
+               {:name   "resolving"
+                :script [[:dispatch [:presence/tick]]
+                         [:flush-presence 100]
+                         [:assert-db [:toast] :retained]]}
+               (fn [state]
+                 (is (= :pass (:status state))
+                     "a host whose Promise RESOLVES still passes — the await
+                      must not turn every Promise-backed flush into a failure")
+                 (is (= [100] @calls) "the verb was reached, ms threaded")
+                 (done))))))
+
+(deftest rejecting-thenable-host-fails-the-run
+  (async done
+    (let [calls (atom [])]
+      (install-thenable-host! :reject calls)
+      (re/run! shared/presence-frame "rejecting"
+               {:name   "rejecting"
+                :script [[:dispatch [:presence/tick]]
+                         [:flush-presence 100]
+                         [:assert-db [:toast] :retained]]}
+               (fn [state]
+                 (is (not= :pass (:status state))
+                     "rf2-iz0t8 — the flush FAILED, so the run must not
+                      report a pass. The following :assert-db holds either
+                      way (the toast is retained because nothing advanced,
+                      not because the advance stayed below :timeout-ms), so
+                      only the STEP can carry the failure")
+                 (is (= :fail (:status state)))
+                 (is (= [100] @calls)
+                     "the host really ran — this is a rejection, not a
+                      never-installed host")
+                 (let [flush-result (->> (:results state)
+                                         (filter #(= :flush-presence (:type %)))
+                                         first)]
+                   (is (true? (:exception flush-result))
+                       "the rejection lands in the EXISTING step-exception
+                        vocabulary — the same one a synchronously throwing
+                        host produces, not a new async status")
+                   (is (false? (:passed? flush-result)))
+                   (is (nil? (:cannot-run? flush-result))
+                       "a rejected flush is a failure, not a refusal — the
+                        host WAS installed and WAS reached"))
+                 (done))))))
+
+(deftest stepper-and-auto-run-agree-on-a-rejecting-host
+  (async done
+    (let [calls (atom [])]
+      (install-thenable-host! :reject calls)
+      ;; Seed the stepper cursor directly rather than through
+      ;; `begin-stepper!`, which resolves the script off a REGISTERED
+      ;; variant — registering one would add a story fixture without adding
+      ;; any coverage. `stepper-state` is the documented substrate surface,
+      ;; and `step-once!` (the fn under test) is driven exactly as the UI
+      ;; widget drives it.
+      (swap! play/stepper-state assoc shared/presence-frame
+             {:remaining [[:flush-presence 100]] :ran [] :results []})
+      (play/step-once! shared/presence-frame)
+      ;; The stepper is synchronous, so at THIS point the host's Promise has
+      ;; not settled. One macrotask later it has, and the recorded result must
+      ;; have become the same failure the auto-run loop records — otherwise
+      ;; the debugger would show a clean flush for a run that fails.
+      (js/setTimeout
+        (fn []
+          (let [result (first (:results (get @play/stepper-state
+                                             shared/presence-frame)))]
+            (is (some? result) "the stepper recorded a result for the step")
+            (is (true? (:exception result))
+                "rf2-iz0t8 — the interactive stepper records the SETTLED
+                 result, agreeing with the auto-run path")
+            (is (false? (:passed? result)))
+            (is (= [100] @calls)))
+          ;; `stepper-state` is process-global — leave no cursor behind.
+          (swap! play/stepper-state dissoc shared/presence-frame)
+          (done))
+        0))))

--- a/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
@@ -17,10 +17,11 @@
     `javascript:` / `data:` / `vbscript:` denylist gates the chip now."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
             [re-frame.source-coords.open-endpoint :as open-endpoint]
+            [re-frame.source-store :as source-store]
             [re-frame.story.config :as config]
-            [re-frame.story.ui.open-in-editor :as open-in-editor])
+            [re-frame.story.ui.open-in-editor :as open-in-editor]
+            [re-frame.substrate.plain-atom :as plain-atom])
   (:require-macros [re-frame.core :refer [with-frame]]))
 
 ;; ---- Option B endpoint seam (rf2-wn3bh) ---------------------------------
@@ -546,44 +547,103 @@
 ;; custom panels) can dispatch `[:rf.story/open-in-editor coord]` and
 ;; let the registered fx fire the URI through the same denylist gate.
 ;; Mirrors Xray's `:rf.xray/open-in-editor` + `:rf.story.fx/open-in-editor`
-;; pairing (port per rf2-r2un8). Tests stub the `:rf.story.fx/open-in-editor` reg-fx
-;; with a capture, mirroring the Xray test pattern — no `window.location`
-;; mutation under the test runner.
+;; pairing (port per rf2-r2un8).
+;;
+;; ## The capture seam is PER-FRAME, never a registry write (rf2-oslyz)
+;;
+;; These tests need the fx ARGS, not the navigation, so the effect is
+;; captured. The capture must NOT be a second `rf/reg-fx` of
+;; `:rf.story.fx/open-in-editor` from this namespace: `registrar/register!`
+;; keeps a provenance-stamped source slot per registering namespace, so a
+;; test-namespace registration leaves `[:fx :rf.story.fx/open-in-editor]`
+;; claimed by BOTH `re-frame.story.ui.open-in-editor` and this ns. The next
+;; `rf/make-frame` anywhere in the process then fails default-image assembly
+;; with `:rf.error/image-duplicate-id` — which is exactly how this file used
+;; to break `re-frame.story.open-in-editor-ownership-cljs-test` whenever the
+;; selector ran the two namespaces in that order.
+;;
+;; The capture is therefore the per-frame `:fx-overrides` FUNCTION-VALUE seam
+;; (Spec 002 §Per-frame and per-call overrides): scoped to the one frame these
+;; dispatches land on, invisible to the source store, and gone the moment the
+;; frame is. `capture-frame` is private to this ns so the override can never
+;; leak onto `:rf/default` (which other suites dispatch through).
+;;
+;; A fn-value override runs WITHOUT a registry lookup of the id it shadows, so
+;; on its own it would happily capture an effect production never registered —
+;; the vacuous green this bead is about. `assert-production-registration!`
+;; below is the positive control that forbids that, and
+;; `production-fx-navigates-without-any-override` drives the REAL registered
+;; effect end-to-end with no override at all.
 
 (defonce ^:private captured-editor-fx (atom []))
 
-(defn- install-with-capture!
-  "Install Story's open-in-editor handlers then replace the
-  `:rf.story.fx/open-in-editor` reg-fx with a capture stub so the test can inspect
-  the fx args without touching `window.location`. Same pattern Xray's
-  test suite uses.
+(def ^:private capture-frame
+  "Frame the dispatch-path tests land on. Private to this ns: it carries the
+  `:fx-overrides` capture, and `:rf/default` must stay override-free for the
+  suites that dispatch through it."
+  :story.open-in-editor/capture)
 
-  Per rf2-wn3bh the event now emits the structured `:source-coord`
-  (so the fx can prefer the dev-server endpoint). The capture stub
-  resolves the coord through the SAME `resolve-uri` helper the chip uses
-  and records the resolved URI under `:uri` so the existing
-  URI-equivalence assertions keep their meaning."
+(def ^:private production-fx-ns
+  "The ONE namespace allowed to own `[:fx :rf.story.fx/open-in-editor]`."
+  "re-frame.story.ui.open-in-editor")
+
+(defn- ensure-adapter!
+  "Install the plain-atom test adapter unless one is already installed —
+  `rf/make-frame` needs a state-container factory, and the consolidated run
+  may or may not have had `init!` called by an earlier namespace."
+  []
+  (try (rf/init! plain-atom/adapter)
+       (catch :default _ nil)))
+
+(defn- assert-production-registration!
+  "POSITIVE CONTROL. `:rf.story.fx/open-in-editor` must be registered, and
+  registered from PRODUCTION only. Fails if `install!` stopped registering the
+  effect (which would make every capture below a fn-value override standing in
+  for nothing), and fails if any test namespace re-registers the id (the
+  provenance collision that used to break image assembly)."
+  []
+  (is (= #{production-fx-ns}
+         (set (keys (source-store/descriptors-for
+                      :fx :rf.story.fx/open-in-editor))))
+      "`:rf.story.fx/open-in-editor` is registered, and ONLY by
+       re-frame.story.ui.open-in-editor — no test-namespace shadow"))
+
+(defn- install-with-capture!
+  "Install Story's open-in-editor handlers, verify the production effect
+  registration, then build `capture-frame` carrying an `:fx-overrides`
+  function-value that records the fx args instead of touching
+  `window.location`.
+
+  Per rf2-wn3bh the event emits the structured `:source-coord` (so the fx can
+  prefer the dev-server endpoint). The capture resolves the coord through the
+  SAME `resolve-uri` helper the chip uses and records the resolved URI under
+  `:uri`, so the URI-equivalence assertions keep their meaning."
   []
   (reset! captured-editor-fx [])
-  ;; EP-0002 (rf2-bd4div): `:rf.story/open-in-editor` dispatches under a
-  ;; carried frame stamp. Register the ordinary `:rf/default` frame so the
-  ;; `with-frame :rf/default`-scoped dispatches below have a frame to land
-  ;; on (these tests exercise the dispatch→fx glue, not a variant frame).
-  (frame/ensure-default-frame!)
+  (ensure-adapter!)
   (open-in-editor/install!)
-  (rf/reg-fx :rf.story.fx/open-in-editor
-    (fn [_ctx args]
-      (swap! captured-editor-fx conj
-             (assoc args
-                    :uri (when-let [coord (:source-coord args)]
-                           (open-in-editor/resolve-uri coord)))))))
+  (assert-production-registration!)
+  ;; EP-0002 (rf2-bd4div): `:rf.story/open-in-editor` dispatches under a
+  ;; carried frame stamp, so the `with-frame`-scoped dispatches below need a
+  ;; live frame to land on. Re-`make-frame`-ing the same id is idempotent
+  ;; replacement, so this is safe once per test.
+  (rf/make-frame
+    {:id capture-frame
+     :doc "open-in-editor dispatch-path test frame (carries the fx capture)"
+     :fx-overrides
+     {:rf.story.fx/open-in-editor
+      (fn [_ctx args]
+        (swap! captured-editor-fx conj
+               (assoc args
+                      :uri (when-let [coord (:source-coord args)]
+                             (open-in-editor/resolve-uri coord)))))}}))
 
 (deftest open-in-editor-event-emits-fx-with-resolved-uri
   (testing "rf2-r2un8 — dispatching `:rf.story/open-in-editor` with a
             bare coord produces a `:rf.story.fx/open-in-editor` fx whose :uri is the
             resolved URI"
     (install-with-capture!)
-    (with-frame :rf/default
+    (with-frame capture-frame
       (rf/dispatch-sync [:rf.story/open-in-editor
                          {:file "src/app/events.cljs" :line 17 :column 3}]))
     (is (= 1 (count @captured-editor-fx))
@@ -597,7 +657,7 @@
             wrapper shape some panels use) produces the same fx as the
             bare-coord form"
     (install-with-capture!)
-    (with-frame :rf/default
+    (with-frame capture-frame
       (rf/dispatch-sync [:rf.story/open-in-editor
                          {:source-coord {:file "src/x.cljs" :line 5 :column 1}}]))
     (is (= "vscode://file/src/x.cljs:5:1"
@@ -609,7 +669,7 @@
             flatten coords at projection time can dispatch them as
             strings without losing line info"
     (install-with-capture!)
-    (with-frame :rf/default
+    (with-frame capture-frame
       (rf/dispatch-sync [:rf.story/open-in-editor
                          {:source-coord "src/app/events.cljs:42"}]))
     (is (= "vscode://file/src/app/events.cljs:42:1"
@@ -619,7 +679,7 @@
   (testing "rf2-r2un8 — bare display string (no wrapper) defensively
             handled by the parser"
     (install-with-capture!)
-    (with-frame :rf/default
+    (with-frame capture-frame
       (rf/dispatch-sync [:rf.story/open-in-editor "src/x.cljs:7"]))
     (is (= "vscode://file/src/x.cljs:7:1"
            (:uri (first @captured-editor-fx))))))
@@ -629,7 +689,7 @@
             (the same source of truth the chip render uses)"
     (install-with-capture!)
     (config/set-editor! :cursor)
-    (with-frame :rf/default
+    (with-frame capture-frame
       (rf/dispatch-sync [:rf.story/open-in-editor
                          {:file "src/x.cljs" :line 10}]))
     (is (= "cursor://file/src/x.cljs:10:1"
@@ -641,7 +701,7 @@
             `open!` is a no-op for); the handler doesn't short-circuit"
     (install-with-capture!)
     (config/set-editor! {:custom "javascript:alert(1)"})
-    (with-frame :rf/default
+    (with-frame capture-frame
       (rf/dispatch-sync [:rf.story/open-in-editor
                          {:file "src/x.cljs" :line 1}]))
     (is (= 1 (count @captured-editor-fx))
@@ -655,13 +715,39 @@
             `:rf.story.fx/open-in-editor` can prefer the dev-server endpoint and fall
             back to the `editor://` URI"
     (install-with-capture!)
-    (with-frame :rf/default
+    (with-frame capture-frame
       (rf/dispatch-sync [:rf.story/open-in-editor
                          {:file "src/x.cljs" :line 1}]))
     (is (= {:file "src/x.cljs" :line 1}
            (:source-coord (first @captured-editor-fx)))
         "the structured coord rides the fx verbatim — the endpoint
          resolves the relative :file at runtime on the server")))
+
+(deftest production-fx-navigates-without-any-override
+  (testing "rf2-oslyz — the tests above capture through a per-frame
+            `:fx-overrides` fn-value, and a fn-value override runs without
+            any registry lookup of the id it shadows. So this one drives the
+            REAL registered `:rf.story.fx/open-in-editor` on a frame carrying
+            NO overrides at all, observing Story's own navigator seam. If
+            `install!` stopped registering the effect, the capture tests
+            would still pass and only this one would red — which is the
+            whole point of it being here."
+    (ensure-adapter!)
+    (open-in-editor/install!)
+    (assert-production-registration!)
+    (config/set-editor! :vscode)
+    (rf/make-frame {:id  :story.open-in-editor/production
+                    :doc "no-override frame — drives the REAL effect"})
+    (let [[nav calls] (capturing-navigator)]
+      (with-stub-navigator nav
+        (fn []
+          (with-frame :story.open-in-editor/production
+            (rf/dispatch-sync [:rf.story/open-in-editor
+                               {:file "src/app.cljs" :line 17 :column 3}]))))
+      (is (= ["vscode://file/src/app.cljs:17:3"] @calls)
+          "the production event → production fx → production navigator
+           chain is live end-to-end, with nothing stubbed but the OS
+           handoff itself"))))
 
 ;; ---- rf2-wn3bh — Option B: dev-server endpoint preferred over URI -------
 ;;


### PR DESCRIPTION
Two Story defects where a test proved nothing. Both were reproduced before any code changed, and both fixes were red-before-verified by breaking **production** rather than an assertion.

## rf2-oslyz — open-in-editor tests shadowed the production effect

`story_open_in_editor_cljs_test`'s `install-with-capture!` called `rf/reg-fx` for `:rf.story.fx/open-in-editor` **from the test namespace** after installing the production handler. `registrar/register!` keeps a provenance-stamped source slot per registering namespace, so the id ended up claimed by both `re-frame.story.ui.open-in-editor` and the test ns, and the next `rf/make-frame` anywhere in the process failed default-image assembly.

Reproduced on `origin/main`:

- ownership ns alone → **5 tests / 5 errors**, `:rf.error/no-adapter-installed` (it installed no adapter and only passed because an earlier ns in the consolidated run had called `init!`)
- Story ns selected **before** the ownership ns → **89 tests / 166 assertions / 5 errors**, `:rf.error/image-duplicate-id` naming both colliding namespaces

The capture is now the per-frame `:fx-overrides` function-value seam on a private `:story.open-in-editor/capture` frame — invisible to the source store, and `:rf/default` stays override-free for the suites that dispatch through it. The ownership ns installs the plain-atom test adapter itself.

A fn-value override runs *without* a registry lookup of the id it shadows, so on its own it would capture an effect production never registered — the same vacuous green this bead is about. Two positive controls forbid that: `assert-production-registration!` pins `[:fx :rf.story.fx/open-in-editor]` to exactly one provenance ns, and `production-fx-navigates-without-any-override` drives the real registered effect on an override-free frame down to Story's navigator seam.

Production handlers, public events, effect ids and editor behaviour are unchanged. Story's spec is unchanged — a test-seam repair with no behavioural surface.

## rf2-iz0t8 — Promise-backed presence-host failures were lost

`presence/advance!` called the host inside a synchronous `try` and returned `{:status :advanced}` immediately, discarding the Promise the canonical CLJS host returns. A later rejection landed outside the `try`, became unhandled, and could no longer change the recorded result — so a presence-bearing play reported `:pass` over a flush that had failed.

`advance!` now reports `:pending <thenable>`, and `presence/settle!` observes it: fulfilment yields the `:advanced` result, rejection yields the **same** `{:status :error}` shape a synchronously throwing host already produces. Rejection is observed via two-argument `.then`, not a chained `.catch` — a `.catch` would also swallow, and re-enter the continuation for, a throw from the continuation itself.

The advance-result → step-result projection is extracted as `presence-step-result` and both the provisional and settled results go through it, so an asynchronous host cannot acquire different semantics by being asynchronous. `settle-step-result!` is the one seam both drivers use: the run loop awaits before recording, and `run-step!` gained an optional continuation the interactive stepper uses to record the settled result (without it the debugger would show a clean flush for a run the auto-run path fails).

Synchronous hosts are untouched — `:pending` is never produced on the JVM or by a synchronous custom host, `settle!` calls back inline, and the JVM run loop keeps its `recur` in tail position (rf2-epqsvh). This composes with rf2-36biz rather than reopening it: an absent host still refuses `:cannot-run`, and the bridge seam is unchanged.

Spec 017 §Presence-bearing variants gains the Promise-await contract, and the two retired no-host-no-op claims the bead names (`runner.cljc` docstring, Spec 017 capability-token bullet) are gone.

## Red-before, produced by breaking production

**oslyz** — deleting the `rf/reg-fx` from `install!`: **15 failures** across both namespaces, including both positive controls and every ownership test. Under the old capture those seven dispatch tests stayed green with production deleted, because they registered the effect themselves.

**iz0t8** — restoring the pre-fix `advance!` (thenable dropped): the node process dies on the unhandled rejection (exit 1, no test summary). With node kept alive so the verdict is observable, `expected: (not= :pass (:status state))` / `actual: (not (not= :pass :pass))` — the run reporting `:pass` over a rejected flush — plus the stepper recording a clean flush.

Neither suite can go vacuously green: `resolving-thenable-host-passes-the-run` is the positive control and passes in **both** builds, so "always fail the step" cannot satisfy the suite.

## Quality gates

| Gate | Result |
|---|---|
| `tools/story` → `clojure -M:test` | 1836 tests / 6792 assertions, 0 failures, 0 errors |
| `implementation` → `npm run test:cljs` | 10071 tests / 49717 assertions, 0 failures, 0 errors (10056 baseline; +15 new) |
| `implementation` → `npm run story:build` | green |
| ownership ns **alone** | 5 tests / 13 assertions green (was 5 errors) |
| ownership + Story + Xray, **both** selector orders | 90 tests / 183 assertions green, no `:rf.error/image-duplicate-id` |

## Pre-existing issue spotted, not fixed here

`re-frame.story.play.presence-real-clock-cljs-test/real-flush-presence-advances-the-framework-clock` fails (2 assertions) when that namespace is selected **alone** — verified against unmodified `HEAD`, so it predates this branch and is untouched by it. It passes under `npm run test:cljs`, where `presence-cljs-test` runs first. Same order-dependence family as rf2-oslyz, different namespace and outside both beads' scope; worth its own bead.
