### PR TITLE
docs: state the ai/ tracking policy and its end state (rf2-4lv73)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,9 +43,10 @@ Thumbs.db
 # docs, contract drafts — is durable + worker-visible and another AI can pick up
 # the process from a clean clone. The S3–S7 stage epics cite it as the
 # authoritative plan. Content promotes into spec/ across the stages (R-1/R-2);
-# when every cited contract has its spec/ home the tree is git-rm'd. Only this
-# subtree is tracked; all other ai/findings/* stay local. Edits to tracked files
-# commit normally; a NEW synthesis file needs `git add -f`.
+# when every cited contract has its spec/ home the tree is git-rm'd. Other paths
+# under ai/ stay local unless force-added the same way; the end state is that
+# nothing under /ai/ is tracked. Edits to tracked files commit normally; a NEW
+# synthesis file needs `git add -f`.
 
 # Beads / Dolt files (added by bd init)
 .dolt/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ bd close <id>         # Complete work
 
 ## Local working files (the `ai/` tree)
 
-Per `docs/the-mayor-method/`, the `ai/` directory at repo root holds all AI working artefacts. **The whole tree is local-only** (`/ai/` is in `.gitignore`); never `git add` anything under it.
+Per `docs/the-mayor-method/`, the `ai/` directory at repo root holds all AI working artefacts. **The tree is local-only by default** (`/ai/` is in `.gitignore`) — don't `git add` under it unless the file is already tracked. A few trees are deliberately tracked right now as a temporary exception; `git ls-files ai/` is the roster, never a list in this file. **The end state is that nothing under `/ai/` is tracked.** Treat today's exceptions as transitional — never as licence to force-add more.
 
 - **Do not maintain `ai/decisions.md`.** The decisions index file is retired (Mike, 2026-07-17): don't create or refresh it. Surface holds awaiting Mike (review gates, operator-run actions, held beads) in chat and on the beads themselves. Per-decision dossiers, when Mike asks for them, go in `ai/decisions/` as one file per decision.
 - **`ai/findings/`** — exploratory work, audits, design drafts, research notes. Agents writing findings docs put them here.


### PR DESCRIPTION
Closes rf2-4lv73.

`CLAUDE.md:59` said **"The whole tree is local-only (`/ai/` is in `.gitignore`); never `git add` anything under it."** That is false — `origin/main` tracks 89 files under `ai/` — and workers had to violate the instruction to do ordinary work, which erodes trust in the rest of the file.

Per Mike's ruling on the bead, this states the **policy only** and deliberately **does not enumerate** the tracked trees. Git state is the roster, so the file cannot drift out of date the way the old sentence did. The bead's own earlier proposed wording (".gitignore comment block is the authoritative statement") was superseded and is not used.

The new clause carries three things:

1. `ai/` is local **by default**;
2. some trees are deliberately tracked **right now**, as a temporary exception (unenumerated);
3. the **end state is that nothing under `/ai/` is tracked** — today's exceptions are transitional.

Point 3 is the operative addition (Mike, in-session 2026-07-18: *"Nothing under `/ai` should be tracked" — that is the end state*). Without it a reader treats the exceptions as permanent, which is exactly how `ai/decisions/` came to be force-added and leaked a personal worktree path into CI, failing the portability gate on `main` and reddening every open PR for about an hour.

`.gitignore` carried the same class of error two lines from the one being fixed — *"Only this subtree is tracked; all other `ai/findings/*` stay local"* is inaccurate, since `new-substrate-codex/` and `ai/decisions/` are also tracked. Corrected, and anchored to the same end state, since that comment block is what a worker reads when deciding whether to force-add.

**Untracks nothing.** Tracked file count under `ai/` is 89 before and after. The untracking vehicle is `rf2-vxgfnd.99.1` (S7 cleanup).

## Quality gates

| Gate | Result | Covers this diff? |
| --- | --- | --- |
| `sh scripts/check-no-hardcoded-paths.sh` | `Portability gate OK: no hardcoded personal/home paths in tracked files.` | **Yes** — scans tracked files, so both changed files are in scope. This is the only real coverage, and the relevant one given the incident. |
| `python -m mkdocs build --strict` | Built clean in 26.7s (INFO only, no warnings) | **No** — `docs_dir: docs`; `CLAUDE.md` and `.gitignore` are at repo root, outside the built corpus. |
| `python scripts/check_doc_slugs.py` | exit 0 | **No** — `DEFAULT_ROOTS = (docs, spec, skills, migration)`; repo-root files are not scanned. |

Stated plainly: the two docs gates were run and pass, but neither one actually exercises this diff. Only the portability gate does. No test gates apply to an agent-instruction file.

`git ls-files ai/` verified at 89 both before and after the change: `findings/new-substrate-synthesis` 61, `findings/new-substrate-codex` 24, `decisions` 4.
