### PR TITLE
docs(machines): align the guard illustration with the 3-attempt tutorial (rf2-vkowt)

### DIFF
--- a/docs/machines/concepts.md
+++ b/docs/machines/concepts.md
@@ -158,10 +158,16 @@ Return truthy/falsey. No combinator DSL — compound logic is ordinary Clojure:
 
 ```clojure
 :guards
-{:under-retry-limit (fn [{data :data}] (< (:attempts data) 3))
+{:under-retry-limit (fn [{data :data}] (< (:attempts data) 2))   ;; three attempts total
  :form-valid?       (fn [{[_ creds] :event}]
                       (and (seq (:email creds)) (seq (:password creds))))}
 ```
+
+A guard sees the snapshot as it stands *before* the transition's action runs, so
+`:under-retry-limit` reads the count from the two failures already recorded and
+the boundary sits one below the total you want — `2` for the
+[tutorial](tutorial.md)'s three-attempt lockout. XState guards evaluate in the
+same place, ahead of the `assign`, so the off-by-one reads the same there.
 
 <a id="name-them-or-inline-them"></a>
 


### PR DESCRIPTION
Closes rf2-vkowt.

## The mismatch

`docs/machines/concepts.md` illustrated `:under-retry-limit` as
`(< (:attempts data) 3)`. The tutorial that same page accompanies teaches a
three-attempt lockout and writes the guard as `(< (:attempts data) 2)`, with the
prose "the guard reads the *pre-action* `:attempts`, so it passes for the first
two failures". The illustration uses the tutorial's own vocabulary
(`:auth.login/failure`, `:submitting`, `:form-valid?`), so a reader lands on it
expecting the machine they just built and copies a boundary that yields four
attempts.

## Verdict: the illustration was wrong

Checked against the runtime rather than the prose. `transition/callback-ctx`
builds a guard's context from `(:data snapshot)` — the snapshot as it stands
when the transition is *selected* — and `pick-transition` resolves the candidate
before any action runs, so a guard never sees its own transition's write. The
shipped JVM smoke coverage pins exactly this on the same machine shape: with a
`(< (:attempts data) 3)` guard, "3 failures land in `:error-shown`, 4th in
`:locked-out`".

So the tutorial's prose is correct, the code matches it, and only the
illustration was out of step. `2` for three attempts, `3` for four.

The fix aligns the boundary and names the off-by-one, since a bare `2` for
"three attempts" otherwise begs the question. XState evaluates guards in the
same place, ahead of the `assign`, so that anchor carries over unchanged — no
divergence to flag.

Docs-only; no file under `implementation/` is touched.

## Noted, not actioned

Two sibling pages carry the same `(< (:attempts data) 3)` boundary in
illustrations of the tutorial's machine — `docs/machines/glossary.md` and
`docs/machines/coming-from-xstate.md`. Both are outside this bead's fence and
worth a follow-up. `examples/core/login/` also uses `3`, but that example is
self-consistent: its stories state the fourth failure locks out, so it is a
deliberate four-attempt policy rather than drift.

## Quality gates

All foreground, unpiped, from the branch worktree:

- `python -m mkdocs build --strict` — pass (built in 40.64s, no warnings; only
  the pre-existing INFO lines main already carries).
- `python scripts/check_doc_slugs.py` — pass (silent). No headings or anchors
  were added or moved.
- `python scripts/check_skill_re_frame2_drift.py --verbose` — pass: "scanned 50
  user-facing leaves (7416 lines) … no bead-id leaks, no agent-run
  verification-posture drift, no bare reg-event + make-machine-handler recipe
  …". Rule 6b(i) not tripped; no rule was loosened.

No mutation proof included: the illustration is not pinned by a doc-truth test.
A sweep for references to `docs/machines/` across `.clj/.cljc/.cljs/.edn/.py/.sh`
returns only example sources and `check_doc_slugs.py`, none of which assert on
the guard body.
