### PR TITLE
docs(guide): tutorial-quality register pass on the synthesis guide (rf2-bbdbs2)

### DIFF
--- a/ai/findings/new-substrate-synthesis/guide/01-getting-started.md
+++ b/ai/findings/new-substrate-synthesis/guide/01-getting-started.md
@@ -1,8 +1,9 @@
 # 01 — Getting started
 
-In this chapter you install re-frame2 UI, write a complete counter, and drive the
-reactive loop — from a button, a REPL, or a test. Later chapters unpack each face:
-views, state, events, frames, then a real dashboard.
+By the end of this page you have a counter on screen and three ways to drive it: click
+the button, dispatch from a REPL, or assert it in a test that never opens a browser.
+Later chapters unpack each face — views, state, events, frames — and then grow the
+counter into a real dashboard.
 
 ## Install
 
@@ -17,17 +18,15 @@ views, state, events, frames, then a real dashboard.
 experimental additional substrate, the view surface this guide teaches. Stock Reagent,
 UIx, and reagent-slim remain first-class, actively-supported adapters; only Helix is deleted.
 
-The browser/runtime must provide the standard JavaScript `WeakRef` constructor (all
-current evergreen browsers and supported modern Node runtimes do). re-frame.ui probes
-it once, before admitting the first Root or attaching ViewCell ownership. An older host
-fails loud with `:rf.error/ui-platform-incompatible`, data
-`{:platform :javascript :capability :js/WeakRef}`, and recovery
-`:use-a-weakref-capable-javascript-runtime`; it never falls back to a leaking strong
-registry. `FinalizationRegistry` is useful but optional — synchronous weak-registry
-compaction covers its absence.
+Any current browser, and any supported modern Node runtime, works out of the box: the
+one platform requirement is the standard JavaScript `WeakRef` constructor. An older host
+is rejected at your first mount — before React allocates anything or any ownership is
+recorded — with a loud `:rf.error/ui-platform-incompatible` rather than degrading
+silently. The probe's timing, its ex-data, and its recovery key are in
+[12 — How it works](12-how-it-works.md#what-a-mount-claims).
 
-The compiler needs one whole-build view of your app. For Shadow CLJS, set these once
-(not once per build):
+The compiler needs one whole-build view of your app, so Shadow CLJS takes two settings.
+Set them once for the project, not once per build:
 
 ```clojure
 ;; shadow-cljs.edn
@@ -38,21 +37,19 @@ The compiler needs one whole-build view of your app. For Shadow CLJS, set these 
  }
 ```
 
-Forget either and the failure is loud: a misconfigured dev bundle refuses to hydrate or
-debug against a false identity. Evaluating a view in the REPL repaints it immediately;
-the *build digest* advances when you save and the next watch pass completes. Why that
-matters is [12 — How it works](12-how-it-works.md). None of this machinery reaches
-advanced production output.
+Miss either one and the failure is loud rather than mysterious: a misconfigured dev
+bundle refuses to hydrate, or to debug against a false identity.
+[12 — How it works](12-how-it-works.md) explains why. None of this machinery reaches
+your production output.
 
-A minimal project is **five** load-bearing files: `deps.edn`, `package.json`, and
-`shadow-cljs.edn` at the root, your app namespace under `src/`, and an `index.html` with
-a `<div id="root">`. The complete, checked, runnable tree — full dependency
-coordinates, the two Shadow settings above, and the exact non-interactive install and
-compile commands — is
-[`examples/ui/minimal-counter`](../../../../examples/ui/minimal-counter/README.md). A CI
-smoke materializes exactly those files, runs `npm install` + `shadow-cljs compile app`,
-and drops any one of them to prove it is genuinely required — so this count cannot quietly
-drift.
+That is the whole setup. A minimal project is **five** load-bearing files: `deps.edn`,
+`package.json`, and `shadow-cljs.edn` at the root, your app namespace under `src/`, and
+an `index.html` with a `<div id="root">`.
+[`examples/ui/minimal-counter`](../../../../examples/ui/minimal-counter/README.md) is
+exactly that tree, complete and checked — full dependency coordinates, the two Shadow
+settings above, and the non-interactive install and compile commands. A CI smoke builds
+it, then drops each file in turn to prove all five are genuinely load-bearing, so the
+count cannot quietly drift.
 
 ## The whole app
 
@@ -149,14 +146,13 @@ test wants one. Full testing story: [08](08-testing.md).
 ```
 
 `mount` is idempotent per root; views re-register by name; the frame is reused; edited
-views repaint against live state. This is the default development loop.
+views repaint against live state. This is the default development loop. Evaluating a
+view in the REPL repaints it immediately; the *build digest* advances when you save and
+the next watch pass completes.
 
-For deliberate shutdown, retain the Root returned by `mount` and call
-`(ui/unmount! root)`. The Root's id, container, and identifier prefix stay claimed
-until React teardown actually settles. That is normally synchronous; a deferred
-teardown releases at its settlement microtask. If host cleanup throws, re-frame.ui
-force-releases that exact incarnation's subscriptions but quarantines the unproven
-container claim, so mount into a fresh container rather than racing React's aborted
-cleanup. A first mount whose render throws follows the same transaction: its claim is
-fenced through cleanup and, on a normal cleanup return, frees on the next FIFO
-microtask before a retry is admitted.
+For deliberate shutdown — a test harness, an embedded widget — keep the Root that
+`mount` returned and call `(ui/unmount! root)`. Its id, container, and identifier prefix
+stay claimed until React's teardown actually settles, so nothing else can claim that id
+or that container while the old root is still winding down. The settlement rules,
+including what happens when host cleanup throws, are in
+[12 — How it works](12-how-it-works.md#what-a-mount-claims).

--- a/ai/findings/new-substrate-synthesis/guide/02-views.md
+++ b/ai/findings/new-substrate-synthesis/guide/02-views.md
@@ -7,6 +7,19 @@ JSX", what ViewCell is), see [12 — How it works](12-how-it-works.md).
 
 ## Defining a view
 
+The minimal `defview` is a name, a props binding, and the hiccup it returns:
+
+```clojure
+(ui/defview greeting [{:keys [name]}]
+  [:p "Hello, " name])
+```
+
+Other views call it by symbol — `[greeting {:name "Ada"}]` — exactly like any other
+element. On day one there is nothing else to learn about defining views.
+
+When a view earns documentation and a checked prop shape, the same form takes a
+docstring and an options map ahead of the argument vector:
+
 ```clojure
 (ui/defview product-card
   "One product tile."
@@ -30,11 +43,10 @@ JSX", what ViewCell is), see [12 — How it works](12-how-it-works.md).
 
 **Calling**
 
-- Views call views by symbol: `[product-card {:product p}]`.
 - Children arrive as `:children` — declaring that binding is what opts a view into
-  accepting them. Passing children to a view that declares none is a compile error.
-- **`:key` is reserved** (React's list-identity slot). An app prop named `:key` is a
-  compile error.
+  accepting them.
+- **`:key` is reserved** for React's list-identity slot, so it is never one of your
+  own props.
 
 **Memoisation**
 
@@ -56,20 +68,26 @@ If you know Reagent hiccup, you are home — minus the traps.
 - `:div.cls#id` sugar; `:style` maps; `:class` as string, vector, or map-of-flags.
 - `[:<> …]` is a fragment. Branch freely with `if` / `when` / `cond` / `case` /
   `let` — the compiler understands them.
-- **Keys on list items are required.** A missing key is a *build failure* with the
-  element's file:line, not a console warning.
-- **Tag heads must be literal.** `[(if big? :h1 :h2) title]` is a compile error —
-  bind attributes dynamically or write two branches.
 - **No `#js`, no camelCase on compiled paths.** Conversion is the compiler's job.
   The browser lowers to direct React construction; the JVM lowers to versioned
   `re-frame.ui.tree` structural data under the same specified conversion contract.
   At S5, `re-frame.ssr/emit-ui-tree` separately serializes that tree to HTML;
   browser/JVM and serializer parity gates detect drift.
-- A `map` that returns markup is rejected (extract a child view, use `for`). Keywords
-  in child position are rejected (silent-text mistakes).
 
-These are not taste rules — they are what compile-time lowering requires. The full
-catalogue of walls, fixes, and escapes is
+About everything else the compiler is strict, and strict at build time. These are not
+taste rules — they are what compile-time lowering requires — and none of them reaches you
+as a console warning you can scroll past:
+
+| If you write | What you see | The fix |
+|---|---|---|
+| A list item without `:key` | Build failure naming the element's file:line | Give each item a stable `{:key …}`, usually its id |
+| A computed tag head — `[(if big? :h1 :h2) title]` | Compile error at that element | Write the two branches out, or vary attributes rather than the tag |
+| A `map` that returns markup | Compile error | Use `for`, or extract a child view |
+| A bare keyword in child position | Compile error | Say what you meant — `(name kw)` or `(str kw)` |
+| An app prop named `:key` | Compile error | Rename it; `:key` belongs to React |
+| Children passed to a view that declares no `:children` | Compile error | Declare the `:children` binding in that view |
+
+The full catalogue of walls, fixes, and escapes is
 [14 — What the compiler forbids](14-compile-time-limits.md).
 
 Genuinely data-driven UI (CMS trees, form definitions) uses an explicit interpreter

--- a/ai/findings/new-substrate-synthesis/guide/03-state.md
+++ b/ai/findings/new-substrate-synthesis/guide/03-state.md
@@ -13,6 +13,11 @@ There is no fifth — and that is the feature. No ratoms, cursors, reactions, or
 external stores. State that matters lives in app-db, where events, time-travel,
 Story, and Xray can all see it.
 
+Start with `sub` and props: most views want nothing else. The sections below take each
+in turn, and add `effect` for the times a view must reach the world outside the tree.
+`sub` and `lease` are shipped today; `local` and `effect` carry a *(lands S3)* marker on
+their headings.
+
 ## Subscriptions: `sub`
 
 ```clojure
@@ -137,6 +142,18 @@ loop is too (extract a keyed child view).
 Rule of thumb: loading that belongs to navigation or workflow rides route/event
 resource plans; `lease` is for liveness that genuinely follows visible UI — dashboard
 tiles, hover cards, modals.
+
+## When you get it wrong
+
+The four inputs have few rules, and the ones they have fail where you can see them:
+
+| If you write | What you see | The fix |
+|---|---|---|
+| `(sub …)` inside a `for` | Compile error — a view's read sites must be finite | Extract a keyed child view that subscribes for one row |
+| `lease` in expression position — inside a `when`, a prop, a template | Compile error | Move the condition into the descriptor: `(lease (when live? descriptor))` |
+| `lease` inside a loop | Compile error | Extract a keyed child view; each child leases its own resource |
+| A dispatch during render | A dev warning pointing back at this page | Dispatch from `(effect …)`, or from a handler ([04](04-events.md)) |
+| `(ui/dispatch-fn)` called after the view disconnected | A loud error rather than a dispatch into the void | Return the cleanup fn from your `effect` so the listener is removed |
 
 !!! note
     Nothing on this page *fetches*. The resource system does. How data actually

--- a/ai/findings/new-substrate-synthesis/guide/04-events.md
+++ b/ai/findings/new-substrate-synthesis/guide/04-events.md
@@ -211,10 +211,9 @@ render. One function cannot do both, so the forms are distinct.
 
 ## Lists
 
-A handler that does not touch the loop variable is fine inline
-(`{:on-click [:list/refresh]}` — one shared callback). One that captures the row
-(`[::open (:id t)]`) is a compile error with the fix: extract a keyed child view —
-each row then owns its site.
+A handler that ignores the loop variable is fine inline — `{:on-click [:list/refresh]}`
+is one shared callback and every row can carry it. The moment a handler needs the row
+itself (`[::open (:id t)]`), extract a keyed child view, so each row owns its own site.
 
 ## Lifecycle is not an event
 
@@ -226,5 +225,13 @@ modal); synchronise with the host world in `(effect …)` ([03](03-state.md)).
 
 ## Safety nets
 
-Dev checks every data handler's event id against the registrar at render — a typo'd
-`[:cart/ad id]` warns immediately with the element's file:line.
+Every rule on this page fails where you can see it — at build time, or at the first
+render. None of them becomes a handler that silently does nothing:
+
+| If you write | What you see | The fix |
+|---|---|---|
+| A typo'd event id — `[:cart/ad id]` | Dev warning at render with the element's file:line; dev checks every data handler's id against the registrar | Fix the spelling, or register the event |
+| A placeholder inside a vector you received through props | Dev warning; the vector dispatches its contents as-is | Build literals at your own DOM sites and hand libraries a prefix |
+| A bare `#(…)` on a **foreign** component's callback prop | Compile error | Choose a form from the decision table above |
+| A row handler inside a `for` that captures the loop variable | Compile error | Extract a keyed child view so each row owns its site |
+| A dynamic props map or `ui/spread` at a controlled input | No error — the site falls back to ordinary batching, and dev tells you so | Keep `:value`/`:checked` and the handler literal at controlled sites |

--- a/ai/findings/new-substrate-synthesis/guide/05-frames.md
+++ b/ai/findings/new-substrate-synthesis/guide/05-frames.md
@@ -1,8 +1,14 @@
 # 05 — Frames
 
 A frame is a running re-frame2 universe: app-db, subscriptions, event queue, epoch
-history. Views live *inside* one. Two components manage that relationship — their
-names say which verb they perform.
+history. Views live *inside* one.
+
+On day one you need one frame and one component to stand it up: `frame-root`, which you
+already wrote in [01](01-getting-started.md). Read the next section, then come back to
+the rest of this page when a page needs more than one world on it.
+
+Two components manage the view-to-frame relationship, and their names say which verb
+each performs.
 
 ## `frame-root` — ensure
 

--- a/ai/findings/new-substrate-synthesis/guide/06-worked-app.md
+++ b/ai/findings/new-substrate-synthesis/guide/06-worked-app.md
@@ -197,7 +197,7 @@ No `useCallback` on the checkbox, no `React.memo` on the tile, no store wiring f
 the feed, no loading-state component library, no test IDs threaded through the DOM
 for a click simulator. The dashboard is the counter, more times.
 
-## Codas
+## Two things to try next
 
 **Serve it.** The dashboard is one mount away from [11](11-ssr.md): the same root form
 renders on the JVM; the same event vectors sit in the server tree.

--- a/ai/findings/new-substrate-synthesis/guide/12-how-it-works.md
+++ b/ai/findings/new-substrate-synthesis/guide/12-how-it-works.md
@@ -332,6 +332,28 @@ preflight, finds the frame live on reload, and does not re-seed — which is exa
 the "your state survives edits" behaviour [01](01-getting-started.md) promises. The
 Pair's hot-swap is this same mechanism, invoked over nREPL.
 
+## What a mount claims
+
+[01](01-getting-started.md) states the platform requirement and the shutdown call in one
+line each. The mechanism behind both is a single admission transaction.
+
+**The platform probe.** re-frame.ui probes for `WeakRef` once, before admitting the
+first Root or attaching ViewCell ownership. A host without it fails loud with
+`:rf.error/ui-platform-incompatible`, data
+`{:platform :javascript :capability :js/WeakRef}`, and recovery
+`:use-a-weakref-capable-javascript-runtime`; it never falls back to a leaking strong
+registry. `FinalizationRegistry` is useful but optional — synchronous weak-registry
+compaction covers its absence.
+
+**The root claim.** A Root's id, container, and identifier prefix stay claimed until
+React teardown actually settles. That is normally synchronous; a deferred teardown
+releases at its settlement microtask. If host cleanup throws, re-frame.ui force-releases
+that exact incarnation's subscriptions but quarantines the unproven container claim, so
+mount into a fresh container rather than racing React's aborted cleanup. A first mount
+whose render throws follows the same transaction: its claim is fenced through cleanup
+and, on a normal cleanup return, frees on the next FIFO microtask before a retry is
+admitted.
+
 ## The dev/prod split *(S3 adds causes/manifests and their elision gates)*
 
 Dev and prod run the same semantics with different amounts of evidence. In dev, every

--- a/ai/findings/new-substrate-synthesis/guide/README.md
+++ b/ai/findings/new-substrate-synthesis/guide/README.md
@@ -4,9 +4,9 @@ re-frame2 UI is an experimental, additional view layer for re-frame2. You write 
 vectors**. The compiler turns them into efficient React at build time — no hiccup
 interpreter in the bundle, no hooks ceremony, no manual memoisation.
 
-This guide teaches the library as a **user**. The dataflow half (events, effects,
-app-db) lives in the [core guide](../../../../docs/core/introduction.md). Design
-rationale for the substrate lives one directory up in the synthesis suite.
+This guide teaches the library as you will use it. The dataflow half — events, effects,
+app-db — lives in the [core guide](../../../../docs/core/introduction.md), and the
+design rationale for the substrate lives one directory up in the synthesis suite.
 
 ---
 
@@ -30,9 +30,13 @@ maps, and the closed grammar's hard limits.
 
 ## How to read this guide
 
-**Read in order through chapter 07.** Each chapter assumes the ones before it.
-Chapters 08–14 are depth: open them when you need them. Chapter 14 is the
-"compile error dictionary" — reach for it when a build failure surprises you.
+**Read in order through chapter 07.** Each chapter assumes the ones before it, and each
+one opens with the least you need to get moving before it goes deeper. If you have ten
+minutes rather than an afternoon, [01](01-getting-started.md) on its own gets a counter
+running.
+
+Chapters 08–14 are depth: open them when you need them. Chapter 14 is the "compile error
+dictionary" — reach for it when a build failure surprises you.
 
 | # | Chapter | Job |
 |---|---------|-----|


### PR DESCRIPTION
Register and voice pass on the synthesis guide (`ai/findings/new-substrate-synthesis/guide/`). The macro-structural rewrite already landed in `72e83868a6`; this pass changes how the material teaches, never what it claims. Operator-reviewed and approved; landing per the go recorded on rf2-bbdbs2.

Eight files, +136/−66, all inside the guide tree. Chapters 07, 08–11, 13, 14 are untouched; 12 is a pure addition.

## What changed

- **01** opens on what the reader gets rather than the install stub. The WeakRef probe detail (timing, ex-data, recovery key) and the failed-mount settlement paragraph (quarantine, FIFO microtask) are relocated **verbatim** into a new guide 12 section, "What a mount claims", linked from both original sites in 01.
- **02** splits two speeds: a minimal `defview` first, the docstring/`:props` form second.
- **03** gains one orientation paragraph (start with `sub` and props) pointing at the existing per-section stage markers.
- **04** gains a "Safety nets" failure table.
- **05** names the day-one path explicitly: one frame, `frame-root`, come back later.
- **06/07** stay worked tutorials; 06 gets one heading rename ("Codas" → "Two things to try next"), 07 is unchanged.
- **README** carries the confident positioning sentence.

Loud-failure tables replace bare prohibitions in 02, 03, and 04 — each row a concrete failure, what the reader sees, and the fix. Every new row traces to an existing baseline rule; no new promises.

## Truth correction

Guide 01 previously said an incompatible host "stops at startup". That was imprecise and contradicted the guide 12 section this pass adds. It now reads:

> An older host is rejected at your first mount — before React allocates anything or any ownership is recorded — with a loud `:rf.error/ui-platform-incompatible` rather than degrading silently.

This matches the shipped contract, verified against this base: `implementation/ui/src/re_frame/ui.cljc:97` (usable `WeakRef` probed once **before admission**), `ui.cljc:185` (gate runs **before React allocation or live-root registration**), and `implementation/ui/src/re_frame/ui/reactive.cljc:2587` (internal **root-admission gate**, throwing "before root/ViewCell ownership mutation").

The literal phrase `` standard JavaScript `WeakRef` constructor `` pinned by `check_ui_root_lifecycle_drift.py` is preserved verbatim — the correction was written around it rather than loosening the checker.

## Preservation

- The four **2026-07-16 readiness amendments** survive with their annotation markers intact and sit outside every changed hunk: 03 P0-1 `(local initial)` three-tuple, 04 P0-2 widened sync door, 04 C-13 event-prefix convention, 04 render-fn / `ui/slot` decision-table row.
- **#6253** adapter disposition intact — zero occurrences of "frozen" tree-wide.
- **#6116** legal conditional-lease form intact; **#6039 + #6141** guide 07 untouched.
- Fence annotations unchanged: `guide:no-fixture` = **8**, `guide:target` = **9**; guide 08's enrolled-fixture inventory untouched.
- Zero `lands S4` future markers (shipped S4 material stays unmarked).
- Chapters **12/13/14** keep their explanation/reference genre.
- No semantic, API, fixture-enrolment, stage-ownership, W3/S6, or `docs/core` changes.

## Quality gates

All run in the foreground on the rebased tree (rebase across 77 commits was clean — zero conflicts, no guide-tree commits on main since the merge base).

| Gate | Result |
| --- | --- |
| `python scripts/check_synthesis_plan_authority.py` | exit 0 |
| `python scripts/check_synthesis_plan_authority.py --self-test` | exit 0 |
| `python scripts/check_doc_slugs.py --synthesis-only --verbose` | 41 files scanned, no broken links |
| `python scripts/check_ui_root_lifecycle_drift.py` | clean, 22 anchors |
| `python scripts/check_ui_root_lifecycle_drift.py --self-test` | PASS, 22 mutation teeth |
| `python -m mkdocs build --strict` | built in 61s, exit 0 |
| `clojure -M:test -n re-frame.ui.guide-truth-jvm-test` (from `implementation/ui`) | **17 tests, 648 assertions, 0 failures, 0 errors** |

The guide-truth count rose from 14 tests / 552 assertions to 17 / 648 because rf2-vxcl7 (#6348) and rf2-0znjl (#6358) added region-bound guard rows after this branch was cut. Those guards pass against this prose as written — none was loosened.

Closes rf2-bbdbs2.
