### PR TITLE
docs(guide): add interactive Hiccup page, flatten Core nav, revise introduction

### DIFF
--- a/docs/core/AUTHORING.md
+++ b/docs/core/AUTHORING.md
@@ -116,7 +116,8 @@ each add one capability; operate pages own production failure modes.
 
 Diátaxis with reference first-class.
 
-**Core track** (nav nested by arc): introduction (the **event pipeline**) →
+**Core track** (flat nav, learning order; the arc below is conceptual):
+introduction (the **event pipeline**) → hiccup (the notation) →
 **pure pipeline** (events → app-db → subscriptions → views) → **impurity**
 (effects, including run-to-completion teaching; coeffects) → **structure**
 (frames → flows → interceptors) → **operations** (errors → observability) →
@@ -139,7 +140,8 @@ not re-teach it.
 | Event vocabulary, `dispatch` | [Events](events.md) |
 | `{:db}`, facts vs conclusions, seed-as-event | [app-db](app-db.md) |
 | Named derivation, layers, `=` gate | [Subscriptions](subscriptions.md) |
-| Hiccup, `reg-view`, thin views | [Views](views.md) |
+| Hiccup notation, view-in-view composition | [Hiccup](hiccup.md) |
+| `reg-view` semantics, thin views | [Views](views.md) |
 | `:fx` grammar, RTC *idea*, `reg-fx` | [Effects](effects.md) |
 | Managed HTTP depth / retry / abort | [async](../async/http.md) (not Core) |
 | `:rf.cofx/requires`, grades, `reg-cofx` | [Coeffects](coeffects.md) |

--- a/docs/core/hiccup.md
+++ b/docs/core/hiccup.md
@@ -1,0 +1,183 @@
+# Hiccup: HTML as data
+
+Before we discuss more about re-frame2, we need to understand **hiccup** — the
+notation we'll be using to create DOM. You've already seen it: the
+[Introduction](introduction.md)'s counter view returned nested vectors shaped
+like the screen. That's hiccup, and every view you write will return it.
+
+There's no state and no clicks on this page — that machinery starts with
+[Events](events.md). Just the notation, live: every cell below renders its last
+form, and you can edit any of them. Press **Ctrl-Enter** (**Cmd-Enter** on
+macOS) after an edit to re-evaluate.
+
+> **Hiccup is HTML as data: a vector per element, a map for attributes, strings
+> for text.**
+
+## An element is a vector
+
+```cljs-rf2
+[:p "Hello from a vector"]
+```
+
+The keyword at the head names the tag. Everything after it is content. Change
+`:p` to `:h1` and re-evaluate.
+
+## Children follow, and they nest
+
+```cljs-rf2
+[:div
+ [:h2 "Shopping list"]
+ [:p "Three things, " [:em "maybe"] " four:"]
+ [:ul
+  [:li "Bread"]
+  [:li "Milk"]
+  [:li "Cheese"]]]
+```
+
+Strings become text nodes; vectors become child elements; order is document
+order. The indentation is just formatting — the structure lives entirely in the
+nesting.
+
+## Attributes are a map in second position
+
+```cljs-rf2
+[:div {:style {:background "LavenderBlush"
+               :padding "1em"
+               :border-radius "8px"
+               :font-family "sans-serif"}}
+ "A " [:a {:href "https://clojurescript.org"} "link"]
+ " in a styled box"]
+```
+
+If an element's second slot is a map, those are its attributes — `:href`,
+`:title`, `:disabled`, anything the element takes. `:style` is itself a map:
+CSS properties as keywords, values as strings.
+
+!!! tip "Try it"
+
+    `"LavenderBlush"` is a real CSS colour name, and so is `"PapayaWhip"`.
+    Swap one in, add `:border "2px solid Tomato"`, re-evaluate.
+
+Two shorthands, borrowed from CSS selectors, fold classes and ids into the tag
+keyword:
+
+```clojure
+[:div.card ...]          ; <div class="card">
+[:input#email.wide ...]  ; <input id="email" class="wide">
+```
+
+## It's data, so code writes it
+
+There is no template language to learn — the screen is a data structure, and
+all of ClojureScript already works on data:
+
+```cljs-rf2
+(def fruits ["Apples" "Pears" "Plums" "Cherries"])
+
+(into [:ul]
+  (for [f fruits]
+    [:li f]))
+```
+
+`for` produces a `[:li ...]` per fruit; `into` pours them into the `[:ul]`.
+Add a fruit. Then make it `(for [f (sort fruits)] ...)`.
+
+Conditional markup is plain `when`, because a `nil` child renders as nothing:
+
+```cljs-rf2
+(def sale? true)
+
+[:h3 "Ferocious slippers "
+ (when sale?
+   [:em {:style {:color "Tomato"}} "— on sale!"])]
+```
+
+Change `true` to `false` and the emphasis vanishes — no special syntax for
+"render this conditionally", just an expression that is sometimes `nil`.
+
+??? info "For JavaScript developers"
+
+    Hiccup is JSX with the compiler deleted. Both describe a tree of elements,
+    but hiccup is literal data — vectors and maps you can `map`, `filter`,
+    `sort`, and pass to functions — with no build-time transform and no
+    `{}`-escape hatch, because you never left the language.
+
+## Naming a piece of screen: `reg-view`
+
+So far our hiccup has been anonymous. Real apps are built from *named* pieces,
+and you met the registration for that in the Introduction:
+
+```cljs-rf2
+(require '[re-frame.core :as rf])
+
+(rf/reg-view greeting [who]
+  [:p "Hello, " [:strong who] "!"])
+
+[greeting "world"]
+```
+
+`reg-view` reads like `defn` — arguments in, hiccup out — and it also
+*registers* the view under an id derived from its name, so the framework and
+its tooling can find it. Notice how the view gets used: not called like a
+function, but placed at the **head of a vector**, where a tag keyword would
+go, with its arguments as the tail. `[greeting "world"]` is still just data.
+
+## Views use views
+
+That head-of-vector rule is the composition rule. A view's hiccup can contain
+other views, exactly the way a `:div` contains a `:span`:
+
+```cljs-rf2
+(require '[re-frame.core :as rf])
+
+(rf/reg-view price-tag [amount]
+  [:span {:style {:color "MediumSeaGreen" :font-weight "bold"}}
+   "$" amount])
+
+(rf/reg-view product-card [{:keys [title price]}]
+  [:div {:style {:border "1px solid #ccc" :border-radius "8px"
+                 :padding "0.5em 1em" :margin "0.5em 0"}}
+   [:h3 title]
+   [:p "Yours for " [price-tag price]]])
+
+[:div
+ [product-card {:title "Aeron chair" :price 1200}]
+ [product-card {:title "Standing desk" :price 800}]]
+```
+
+The same shape repeats at every level: `product-card` uses `price-tag` the way
+`:div` uses `:span`. A screen is a tree of views, and views bottom out in
+element keywords.
+
+!!! tip "Try it"
+
+    View usage is data too, so the `for`/`into` trick from earlier composes
+    views as easily as `:li`s:
+
+    ```clojure
+    (def products [{:title "Aeron chair" :price 1200}
+                   {:title "Standing desk" :price 800}])
+
+    (into [:div]
+      (for [p products]
+        [product-card p]))
+    ```
+
+## When it doesn't render
+
+| What you wrote | The rule it tripped | Fix |
+|---|---|---|
+| `["div" "hi"]` | The head must be a tag keyword or a view — a string head is neither | `[:div "hi"]` |
+| `[:p "hi" {:style ...}]` | The attribute map must be **second**; anywhere later it's just another child | `[:p {:style ...} "hi"]` |
+| The cell reports a reader error | A bracket is unbalanced — hiccup is data before it is anything else | Balance the brackets |
+
+## Day-one checklist
+
+You can read the hiccup any view returns; write nested elements with
+attributes and inline styles; generate markup with `for`, `when`, and plain
+data; name a piece of screen with `reg-view`; and compose views inside views.
+That's all the notation the rest of this guide leans on.
+
+What hiccup can't do alone is *change*. Reacting to clicks and showing live
+application state is the [event pipeline](glossary.md#event-pipeline)'s job —
+and teaching it starts with [Events](events.md).

--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -2,76 +2,66 @@
 
 To understand re-frame2, you need to understand how it does computation.
 
-Which is an odd opening for a Single Page Application (SPA) library, I know. But bear with me.
+Which is an odd opening for a Single Page Application (SPA) library, I know, but bear with me.
 
 ## A working app
 
-To assist explanations, here's a tiny application — a counter app:
+To assist explanations, here's a tiny "counter" application. It has:
 
 - an increment button
-- a displayed value that gets incremented on each button click
+- a displayed value (initially 3), incremented by each button click
 
 ```cljs-rf2
+;; The re-frame2 core API namespace
 (require '[re-frame.core :as rf])
 
 ;; calls to four registration functions
-(rf/reg-event :initialise (fn [_ [_ v]] {:db {:value v}}))
+(rf/reg-event :initialise (fn [_ _] {:db 3}))
 (rf/reg-event :inc        (fn [{:keys [db]} _] {:db (update db :value inc)}))
 (rf/reg-sub   :value      (fn [db _] (:value db 0)))
 
-(rf/reg-view counter [background]
-  [:div {:style {:background background}}
+(rf/reg-view counter []
+  [:div 
    [:span "Count: " @(subscribe [:value]) " "]
    [:button {:on-click #(dispatch [:inc])} "+"]])
 ```
 
-None of this code has been explained yet, but all you need
-to grasp at the moment is that this entire application is simply a series of function calls,
-starting with `reg-`. Four function calls:
+The entire application is 4 calls to functions starting with `reg-xxx` and all four of them have the form:
+```clojure
+(reg-xxx id function)
+```
 
-- To start with, `reg-event` is called twice (to register two event handlers)
+- `reg-event` is called twice (to register two event handlers, and, yes, more on this soon)
 - then, `reg-sub` is called once (to register a subscription handler)
 - and finally, `reg-view` is called once (to register a view)
 
-**A re-frame2 app is a set of registrations**. Each registration associates:
+**A re-frame2 app is a set of registrations**.
 
-- an `id` (like `:inc` or `:initialise` above)
-- with a function like `(fn [_ _] {:db {:value 3}})`.
+Later, when your re-frame2 application is running, and the user is clicking buttons and seeing new DOM, etc., the re-frame2 runtime will look up these functions by their `id` and call them, and **THAT** is why you need to understand how re-frame2 does computation (the claim at the top of the page).  
 
-We don't **yet** need to understand what these functions are doing, but we do need to latch on to the idea that programming re-frame2 involves:
+You need to understand how to write functions that slot into the re-frame2 runtime.
 
-- writing functions
-- and registering them with an `id`
+## Running Counter
 
-Later, when the application is running, and the user is clicking buttons etc., these functions will be called by the re-frame2 computational engine to perform certain calculations.
+We might have created the Counter app (via those 4 registrations), but we haven't run it yet.
 
-## Running our app
-
-We might have created the Counter app (via those 4 registrations), but we haven't run it yet. To do that, we need to create a `frame`, which provides an isolated execution context.
-
-In fact, to double the excitement, let's create two `frames` and have two instances of our Counter app on the page at the same time: one with a blue background and one with a lavender background:
+To do that, we need to create a `frame`, which provides an isolated execution context. And, here's how:
 
 ```cljs-rf2
-[:div
-   [rf/frame-root
-     {:id :app1
-      :initial-events [[:initialise 3]]}
-     [counter "LightBlue"]]
-   [rf/frame-root
-     {:id :app2
-      :initial-events [[:initialise 10]]}
-     [counter "LavenderBlush"]]]
+[:div {:style {:background "LavenderBlush"}}
+   [rf/frame-root {:id :app1}
+     [counter]]]
 ```
 
-This code is `hiccup` (a data structure representing DOM). And in this in-browser dev environment, hiccup at the end of an interactive block is rendered, which is why we see the application running.
+This code is `hiccup` — a data structure representing DOM. And in this in-browser dev environment, hiccup at the end of an interactive block is rendered, which is why we see the DOM for the app above.
 
 That hiccup is:
 
-- a `[:div ...]`
-- containing two child `frame-root` nodes
-- each `frame-root` wraps the previously registered `counter` view, like this: `[counter "a colour"]`
+- a `<div>` which has a background style and which wraps ...
+- a `frame-root` node which injects an **ambient frame** into the DOM tree (think Provider)
+- a child `counter` view, previously registered above 
 
-When you see `frame-root` think of **Provider** in the **React Context** sense. A `frame-root` is like a wrapping view node which provides context to its child views — in this case a `frame` (an isolated execution context) is ambiently available to each of the two `counter` views, which are in different branches of the DOM.
+When you see `frame-root` think of **Provider** in the **React Context** sense. A `frame-root` is like a wrapping DOM node which provides context to its child views — in this case a `frame` (an isolated execution context) is ambiently available to the `counter` view beneath it.
 
 Experiment/edit this code:
 
@@ -149,8 +139,8 @@ speak them: timers, HTTP replies, route loaders. The next page,
 ## One map of state: app-db
 
 Each running instance holds application state as one immutable Clojure map —
-**app-db**. In the counter it starts `{}`, then becomes `{:value 3}` after
-`:initialise`, then `{:value 4}` after the first `:inc`.
+**app-db**. In the counter it starts `{}`, then becomes `{:value 0}` after
+`:initialise`, then `{:value 1}` after the first `:inc`.
 
 Handlers never "set state" as a side effect. They return the next map inside an
 effect description. [app-db](app-db.md) is the dedicated page for that doctrine.

--- a/docs/core/views.md
+++ b/docs/core/views.md
@@ -71,7 +71,7 @@ Notes:
 
 ## Hiccup: the screen is data
 
-A view returns [hiccup](glossary.md#hiccup) — nested Clojure vectors shaped like the DOM they describe:
+A view returns [hiccup](hiccup.md) — the notation from early in the track: nested Clojure vectors shaped like the DOM they describe:
 
 ```clojure
 [:div.cart

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,28 +160,26 @@ nav:
   - Core:
     # Introduction is an explicit titled row (not navigation.indexes): the
     # LHS should read "Introduction", not repeat the section label "Core".
-    # Nested groups mark the learning arc: pure pipeline → impurity → structure
-    # → operations → advanced. Run-to-completion is taught on Effects; its
-    # page remains for operational deep links (not a main-track stop).
+    # The main concept track is a flat list in learning order — each page
+    # leans only on what came before. Grouped sections remain for the how-to,
+    # testing, explanation, and migration shelves. Run-to-completion is taught
+    # on Effects; its page remains for operational deep links (not a
+    # main-track stop).
     - Introduction: core/introduction.md
-    - "The pure pipeline":
-      - "Events: the vocabulary": core/events.md
-      - "app-db: one map": core/app-db.md
-      - "Subscriptions: derived data": core/subscriptions.md
-      - "Views: pure screens": core/views.md
-    - "Impurity":
-      - "Effects: the way out": core/effects.md
-      - "Coeffects: the way in": core/coeffects.md
-    - "Structure":
-      - "Frames: isolated worlds": core/frames.md
-      - "Flows: derived values your handlers can read": core/flows.md
-      - "Interceptors: cross-cutting (rare)": core/interceptors.md
-    - "Operations":
-      - "Errors: dossiers": core/errors.md
-      - "Observability: one wire": core/observability.md
-    - "Advanced":
-      - "Images: registration sets": core/images.md
-      - "Run to completion (detail)": core/run-to-completion.md
+    - "Hiccup: HTML as data": core/hiccup.md
+    - "Events: the vocabulary": core/events.md
+    - "app-db: one map": core/app-db.md
+    - "Subscriptions: derived data": core/subscriptions.md
+    - "Views: pure screens": core/views.md
+    - "Effects: the way out": core/effects.md
+    - "Coeffects: the way in": core/coeffects.md
+    - "Frames: isolated worlds": core/frames.md
+    - "Flows: derived values your handlers can read": core/flows.md
+    - "Interceptors: cross-cutting (rare)": core/interceptors.md
+    - "Errors: dossiers": core/errors.md
+    - "Observability: one wire": core/observability.md
+    - "Images: registration sets": core/images.md
+    - "Run to completion (detail)": core/run-to-completion.md
     - "How-to recipes":
       - core/how-to/index.md
       - "Boot and mount an app": core/how-to/boot-and-mount-an-app.md


### PR DESCRIPTION
Adds a new interactive **Hiccup** page to the Core guide, presenting directly after the Introduction.

## Changes

- **New `docs/core/hiccup.md`** — brief interactive primer on hiccup: element-as-vector, nesting, attributes + styling, generating hiccup with code (`for`/`into`/`when`), naming a piece with `reg-view`, and view-in-view composition. Six live cells, no subscribe/dispatch.
- **`mkdocs.yml`** — Hiccup row slots after Introduction; the Core arc group headings (Pure pipeline / Impurity / Structure / Operations / Advanced) are flattened into a flat learning-order list. How-to, Testing, explanation, and migration groups kept.
- **`AUTHORING.md`** — core-track line reflects the flat nav and the hiccup stop; technique-owner table splits hiccup notation (Hiccup page) from `reg-view` semantics / thin views (Views page).
- **`views.md`** — hiccup section links back to the new notation owner.
- **`introduction.md`** — operator editing pass on the opening/counter narrative, plus typo fixes.

## Known follow-ups (next editing pass)

- [ ] Counter seeding: `:initialise` returns `{:db 3}` but the sub reads `(:value db 0)` and `:inc` updates `:value` — needs `{:db {:value 3}}` (or equivalent) and `:initial-events [[:initialise]]` on the `frame-root` cell
- [ ] Experiment 2 references `[:initialise 3]`, which no longer appears in the cell
- [ ] app-db section's `{:value 0}`/`{:value 1}` narrative vs the "initially 3" bullet
- [ ] "The next page, Events" wording now that Hiccup sits between
- [ ] Click the new live cells in a browser

## Gates

- `python scripts/check_doc_slugs.py` — exit 0
- `mkdocs build --strict` — exit 0