### PR TITLE
docs(core): make the introduction frame-root snippet runnable (rf2-r94by)

### DIFF
--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -16,7 +16,7 @@ To assist explanations, here's a tiny "counter" application. It has:
 (require '[re-frame.core :as rf])
 
 ;; calls to four registration functions
-(rf/reg-event :initialise (fn [_ _] {:db 3}))
+(rf/reg-event :initialise (fn [_ [_ v]] {:db {:value v}}))
 (rf/reg-event :inc        (fn [{:keys [db]} _] {:db (update db :value inc)}))
 (rf/reg-sub   :value      (fn [db _] (:value db 0)))
 
@@ -49,7 +49,7 @@ To do that, we need to create a `frame`, which provides an isolated execution co
 
 ```cljs-rf2
 [:div {:style {:background "LavenderBlush"}}
-   [rf/frame-root {:id :app1}
+   [rf/frame-root {:id :app1 :initial-events [[:initialise 3]]}
      [counter]]]
 ```
 
@@ -139,8 +139,8 @@ speak them: timers, HTTP replies, route loaders. The next page,
 ## One map of state: app-db
 
 Each running instance holds application state as one immutable Clojure map —
-**app-db**. In the counter it starts `{}`, then becomes `{:value 0}` after
-`:initialise`, then `{:value 1}` after the first `:inc`.
+**app-db**. In the counter it starts `{}`, then becomes `{:value 3}` after
+`:initialise`, then `{:value 4}` after the first `:inc`.
 
 Handlers never "set state" as a side effect. They return the next map inside an
 effect description. [app-db](app-db.md) is the dedicated page for that doctrine.
@@ -150,7 +150,7 @@ effect description. [app-db](app-db.md) is the dedicated page for that doctrine.
 The counter mounts under:
 
 ```clojure
-[rf/frame-root {:id :app :initial-events [[:initialise]]}
+[rf/frame-root {:id :app :initial-events [[:initialise 3]]}
  [counter]]
 ```
 


### PR DESCRIPTION
Closes rf2-r94by.

## Premise check against #6377

The bead predates #6377 ("docs(guide): add interactive Hiccup page, flatten Core nav, revise introduction"), which revised this page. Both defects it names by name are gone: `counter` no longer declares a `background` argument, so `[counter]` is correct; and the `:initialise` handler no longer destructures a payload, so `[[:initialise]]` is arity-clean.

The bead is **not** a duplicate, though. Its acceptance criterion — that the snippet be "runnable against the page's own definitions", with "the handler, both mount examples, state transition prose, and first increment agree" — is violated more severely after #6377 than before it. The operator pass collapsed `(fn [_ [_ v]] {:db {:value v}})` to `(fn [_ _] {:db 3})`, dropped `:initial-events` from the live mount cell, and reverted the app-db prose from 3/4 back to 0/1.

Evaluating the page's own definitions:

```
--- BEFORE: (fn [_ _] {:db 3}) seeded by [[:initialise]] ---
app-db after :initialise = 3
displayed value = 0  (page claims 3)
first :inc => THROWS NullPointerException

--- AFTER: (fn [_ [_ v]] {:db {:value v}}) seeded by [[:initialise 3]] ---
app-db after :initialise = {:value 3}
displayed value = 3
first :inc => {:value 4}
```

app-db becomes a bare integer, so the counter displays 0 while the page claims 3, and the first click throws. These are live `cljs-rf2` cells, so this executes on the docs site.

## Changes

Four one-line corrections, no restructuring:

- `:initialise` takes its payload again and seeds a map.
- the live mount cell passes `:initial-events [[:initialise 3]]`, so the seed runs — and the page's own "Change `[:initialise 3]` to `[:initialise 4]`" experiment gets a referent, which it had lost.
- the later `frame-root` snippet seeds `[[:initialise 3]]`.
- the app-db prose reads `{:value 3}` then `{:value 4}`.

app-db.md's deliberately number-independent "same initialization pattern" wording is untouched. No cross-page numeric coupling, compatibility fallback, or documentation checker added.

## Verified against shipped code, not neighbouring prose

`re-frame.views.provider/frame-root` is `[props & children]`, taking the `make-frame` opts (`:id` / `:images` / `:initial-events` / `:url-bound?`) with `:id` a required keyword. Both mount forms match that contract, and `:initial-events` is documented to fire once on first creation — which is what the seed relies on.

Unqualified `subscribe` / `dispatch` inside the view body are correct as written and needed no change: the `reg-view` macro injects them as bindings (`core_reg_view_macro.cljc:190-191`), and the playground's SCI shim mirrors that.

Corroboration: app-db.md already states the intro counter "seeded `:value` explicitly through its `:initialise` event" — true again only after this change.

## Quality gates

| Gate | Result |
|---|---|
| `python -m mkdocs build --strict` | pass (exit 0, built in 29.83s) |
| `python scripts/check_doc_slugs.py` | pass (exit 0) |
| `clojure -M:test -n re-frame.ui.guide-truth-jvm-test` | pass — Ran 17 tests, 648 assertions, 0 failures, 0 errors |

**No gate pins this snippet's content.** `guide_truth_jvm_test` is the only test referencing `docs/core/introduction.md`, and it only counts inbound links for the S6 relocation census — it passed before and after, and would not have caught the broken seed. This fix therefore rests on the reading shown above, which is why the shipped `frame-root` signature and the before/after evaluation are quoted in full rather than asserted.
