### PR TITLE
docs(EP): make the EP-0031/EP-0035 bead snapshots honest (rf2-rkivs)

### DIFF
--- a/docs/EP/EP-0031-re-frame-ui-programming-model.md
+++ b/docs/EP/EP-0031-re-frame-ui-programming-model.md
@@ -265,13 +265,17 @@ the W1 migrator + the `spec/004A` Reagent-compat appendix).
 with the first conforming Stage-1 slice per its R-1; S2 core verified S3-ready under
 the rf2-vxgfnd.22 boundary review).
 
-**Landing (the S3 epic, `rf2-vxgfnd.95`):** `.95.1` committed event spine —
-**merged**; `.95.2` local three-tuple / effect / `dispatch-fn` / lease confirmation
-— open; `rf2-8k14ia` sync-door widening — in progress (must land before `.95.1`'s
-literal-only door is declared conforming); `rf2-ri0k6n` `ui/slot` — open (S3→S4
-compiler surface); `rf2-isdqjv` safe-spread policy — open (blocks final S3
-conformance); `.95.10` closes the stage. Later: custom-element assertion (S4),
-`client-only` phase flip (S5), `->react` (S6), 004A landing + Helix removal (S7).
+**Landed (the S3 epic, `rf2-vxgfnd.95`) — stage closed 2026-07-18.** Every bead
+this EP cited closed: `.95.1` committed event spine; `.95.2` local three-tuple /
+effect / `dispatch-fn` / lease confirmation; `rf2-8k14ia` sync-door widening, which
+landed before `.95.1`'s literal-only door was declared conforming; `rf2-ri0k6n`
+`ui/slot`, the S3→S4 compiler surface; `rf2-isdqjv` safe-spread policy, the last
+blocker on S3 conformance; and `.95.10`, which closed the stage. S4
+(`rf2-vxgfnd.96`, custom-element assertion) followed and was declared conforming.
+The stages still ahead ride their own epics — `client-only` phase flip (S5,
+`rf2-vxgfnd.97`), `->react` (S6, `rf2-vxgfnd.98`), 004A landing + Helix removal
+(S7, `rf2-vxgfnd.99`). This paragraph records stages that have closed; for a stage
+still in flight the epic is the state, not this page.
 
 **Guide-impact assessment (EP-0009 rule 5).** The teaching seams are guide 03
 (state) and guide 04 (events), and both are already written to this contract:

--- a/docs/EP/EP-0035-component-library-readiness.md
+++ b/docs/EP/EP-0035-component-library-readiness.md
@@ -8,7 +8,8 @@ Type: standards-track
 > graduation: the Spec 004 rewrite (handler synchrony law, local placement
 > law, render slots, spread), `spec/004B` (conversion table), `spec/008`
 > (gate roster), `spec/009` (diagnostic rows). Directed by Mike 2026-07-16
-> (in-session); accepted on direction — implementation beads are live.
+> (in-session); accepted on direction — the implementation beads it filed have
+> all since closed (see §Bead Plan).
 
 ## Abstract
 
@@ -228,19 +229,22 @@ reopened: deltas #4/#5 entered under the freeze's own delta protocol.
 
 ## Bead Plan / Reference Implementation
 
-The per-bead fold-in against live S3 stage epic `rf2-vxgfnd.95` (all filed):
+The per-bead fold-in against S3 stage epic `rf2-vxgfnd.95`, which closed
+2026-07-18. Per EP-0009 a ledger's rows cite live bead ids and are struck as they
+close; every row below is now closed, so this table records finished work rather
+than tracking it.
 
 | Delta | Owning bead | State |
 |---|---|---|
-| P0-1 three-tuple `local` + G-15 | `rf2-vxgfnd.95.2` (amended notes authoritative over its original scope) | open |
-| P0-2 sync-door widening + widened G-8 | `rf2-8k14ia` — the pre-conformance **correction** filed after `.95.1` merged (the completeness audit fixed the epic's truncated reference to it); blocks `.95.10` | in progress |
-| P0-3 `ui/slot` + G-16 (+ absorbed bare-alias dev warning) | `rf2-ri0k6n`; blocks `.95.10`; S3→S4 compiler surface | open |
-| P1-4 safe-spread policy + G-17 | `rf2-isdqjv`; blocks `.95.10` | open |
-| C-6 interop blessing + fixtures | `rf2-vxgfnd.95.4` | open |
-| C-13a fn-prop fixtures | `rf2-vxgfnd.95.3` (kept distinct from `rf2-ri0k6n`'s internal-slot fixtures) | open |
-| P1-5 manifest projection | `rf2-vxgfnd.95.6` | open |
-| Gates wiring + proof pack + G-18 fixture | `rf2-vxgfnd.95.10` (deps added on the three new children) | open |
-| RealWorld vertical rider | `rf2-vxgfnd.95.9` — unchanged; the proof pack complements it | open |
+| P0-1 three-tuple `local` + G-15 | `rf2-vxgfnd.95.2` (amended notes authoritative over its original scope) | closed |
+| P0-2 sync-door widening + widened G-8 | `rf2-8k14ia` — the pre-conformance **correction** filed after `.95.1` merged (the completeness audit fixed the epic's truncated reference to it); blocked `.95.10` | closed |
+| P0-3 `ui/slot` + G-16 (+ absorbed bare-alias dev warning) | `rf2-ri0k6n`; blocked `.95.10`; S3→S4 compiler surface | closed |
+| P1-4 safe-spread policy + G-17 | `rf2-isdqjv`; blocked `.95.10` | closed |
+| C-6 interop blessing + fixtures | `rf2-vxgfnd.95.4` | closed |
+| C-13a fn-prop fixtures | `rf2-vxgfnd.95.3` (kept distinct from `rf2-ri0k6n`'s internal-slot fixtures) | closed |
+| P1-5 manifest projection | `rf2-vxgfnd.95.6` | closed |
+| Gates wiring + proof pack + G-18 fixture | `rf2-vxgfnd.95.10` (deps added on the three new children) | closed |
+| RealWorld vertical rider | `rf2-vxgfnd.95.9` — unchanged; the proof pack complements it | closed |
 
 Spike/checkpoint beads live on the **program epic** (`rf2-vxgfnd`):
 `rf2-nzst23`, `rf2-1hm7a3`, `rf2-a62fje`, `rf2-efxb1h`, `rf2-ho1iba`. The


### PR DESCRIPTION
Closes rf2-rkivs.

EP-0031's S3-landing paragraph and EP-0035's P0/P1 status table carried bead
snapshots that had gone uniformly stale: nine named beads read `open` /
`in progress` while every one of them had closed. EP-0031 still described
`rf2-isdqjv` as the thing that "blocks final S3 conformance" — doubly wrong,
since the S3 epic (`rf2-vxgfnd.95`) closed 2026-07-18 and S4 has since been
declared conforming.

Found by rf2-3iwpr (#6371), which deliberately left it: refreshing one row of a
uniformly-stale column makes the tables *more* inconsistent, and it read the
honest fix as an EP-0009 process question.

## The process question, answered

It is **(b) live status, refreshed** — and the process already said so.

- **EP-0009 §Statuses** defines the errata-ledger pattern in exactly these
  terms: "Ledger rows cite live bead ids and **are struck as they close**."
  These tables *are* that ledger. Striking them is the designed behaviour.
- **EP-0009 §Durability rule 3** restricts post-acceptance amendment but
  explicitly exempts "errata-ledger updates", which "are always fine".
- **`rf2-r7ahi` is ruled**, not open — its NOTES carry a delegated DECISION
  (2026-07-18, "freeze meaning, not bytes"), whose **Tier 1** (edit in place,
  undated) names "mechanical errata-ledger updates (row strikes/closures)".
  So this fix does not depend on an unruled policy, and it does not pre-empt
  one. The settled decisions and rationale in both EPs are untouched — only
  the state column moves.
- **EP-0002** is the corpus precedent for the terminal shape: an implementation
  ledger with "Open errata: None known." above its resolved rows.

Option (a) — re-date as frozen snapshots — would have been the wrong reading:
it treats a ledger as prose, when EP-0009 defines a ledger as the one part of a
final EP that is *meant* to move.

## Applied uniformly, no mixture

Every row in EP-0035's table now reads `closed` (all nine verified via
`bd show`). Every bead in EP-0031's S3 paragraph is recorded as landed, with
the `isdqjv` sentence corrected from "blocks final S3 conformance" to naming it
as the last blocker that *was* cleared. Two adjacent status claims went with
them: EP-0035's banner ("implementation beads are live") and its ledger intro
("against **live** S3 stage epic"). No row is left asserting a state it does
not have.

## What stops the next drift

Both ledgers now cite only **closed** beads, and closed is terminal — there is
no live claim left to falsify. Drift was only ever possible while a row
asserted a non-terminal state. The stages still in flight (S5 `rf2-vxgfnd.97`,
S6 `.98`, S7 `.99`) are named by epic id with **no state asserted**, and each
page states the rule: for a stage in flight the epic is the state, not the EP.
That convention is self-limiting and needs no machinery.

No generator, no bead-sync checker, no restructuring.

## Quality gates

Run in the foreground, unpiped, from this branch:

| Gate | Result |
|---|---|
| `python -m mkdocs build --strict` | pass (exit 0) |
| `python scripts/check_doc_slugs.py` | pass (exit 0) |
| `python scripts/check_ep_status_sync.py` | pass (exit 0) |
| `python scripts/check_skill_re_frame2_drift.py --verbose` | pass (exit 0) |

**No gate covers the rows changed here.** `skills/` does not reference EP-0031
or EP-0035 at all, so the drift checker is vacuous for this diff.
`guide_truth_jvm_test.clj` pins EP-0034 and EP-0030 by explicit path with no
globbing, so `implementation/ui` was not run — nothing in it reads these two
files. The gates above confirm the docs still build and the EP headers stay in
sync; the truth of a `closed` cell rests on the `bd show` verification, not on
CI.
