### PR TITLE
test(spec): pin the S3 dispatch! stage and spread-safe row identities (rf2-kc4kl)

### DIFF
--- a/implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj
@@ -738,6 +738,95 @@
             (is (str/includes? line shipped)
                 (str path " (" label ") must still list " shipped))))))))
 
+;; --- The S3 frozen-surface corrections in spec/API.md (rf2-kc4kl) ------------
+;;
+;; rf2-3iwpr corrected two claims that no gate objected to for as long as they
+;; were false, and recorded that the corrected truth stayed UNGUARDED:
+;;
+;;   (a) frame-targeted `ui.test/dispatch!` was attributed to the §2b row's S2
+;;       clause while it actually landed at S1 — `ffe8824b00`, the ui.test
+;;       Tier-1 core commit, is the sole commit to introduce `defn dispatch!`
+;;       and the S2 slice never touched it;
+;;   (b) the shipped `re-frame.ui/spread-safe` was absent from the blessed §2
+;;       table, whose own closing rule is "anything not in this table does not
+;;       exist" — so a shipped public fn was formally not public. The second-
+;;       arity spelling was considered and NOT taken: it is a sibling name.
+;;
+;; Both rows are bound BY REGION, and (b) by region AND row. That binding is
+;; load-bearing on real history, not a synthetic worry: spec/API.md carries
+;; THREE `spread-safe` table rows — §Compiled views, §2 and §2b — and before
+;; the correction the §Compiled-views one already existed while §2 and §2b both
+;; lacked theirs. A document-wide "a `spread-safe` row exists" census was
+;; therefore GREEN through the entire falsehood, which is exactly the blindness
+;; rf2-vxcl7 named: a census cannot see WHERE a claim sits.
+
+(def ^:private api-blessed-heading
+  "\n### Public surface + demand-bar audit (the blessed §2 table)\n")
+
+(def ^:private api-matrix-heading
+  "\n### Authoritative surface matrix (§2b — name → stage / owner / proof / spec home)\n")
+
+;; The ONE sanctioned mention of `dispatch!` inside the row's S2 clause: it
+;; names the S1 surface being reused, not an S2 landing. Excising it before the
+;; negative assertion is what lets that assertion stay exact — the clause may
+;; explain the reuse, it may not claim the landing.
+(def ^:private s2-dispatch-reuse-note
+  "the S1 `dispatch!` is reused unchanged inside a mounted root, not re-landed here")
+
+(deftest api-s2b-binds-ui-test-dispatch-to-the-s1-clause
+  (let [matrix (subsection-text (slurp (root-file "spec/API.md")) api-matrix-heading)]
+    (when (is (some? matrix) "spec/API.md lost its §2b surface-matrix subsection")
+      (let [row (table-row matrix "`re-frame.ui.test/*`")]
+        (when (is (some? row) "§2b lost its `re-frame.ui.test/*` row")
+          (let [s1-at (str/index-of row "**S1 core**")
+                s2-at (str/index-of row "**S2 mounted semantics**")
+                s3-at (str/index-of row "**S3**")]
+            (when (is (and s1-at s2-at s3-at (< s1-at s2-at s3-at))
+                      "§2b's ui.test row lost its S1 → S2 → S3 stage clauses")
+              (let [s1-clause (subs row s1-at s2-at)
+                    s2-clause (subs row s2-at s3-at)]
+                (testing "the S1 clause is where dispatch! lands"
+                  (is (str/includes? s1-clause "`dispatch!`")
+                      (str "§2b's ui.test row moved `dispatch!` out of its S1 clause; "
+                           "ffe8824b00 landed it in the Tier-1 core slice"))
+                  (is (str/includes? s1-clause "frame-targeted synchronous `dispatch!`")
+                      "the S1 clause lost the frame-targeted synchronous characterisation"))
+                (testing "the S2 clause claims no dispatch! landing of its own"
+                  (is (str/includes? s2-clause s2-dispatch-reuse-note)
+                      "the S2 clause lost its explicit S1-reuse note")
+                  (is (not (str/includes? (str/replace s2-clause s2-dispatch-reuse-note "")
+                                          "dispatch!"))
+                      (str "§2b's ui.test row again attributes `dispatch!` to S2; "
+                           "the S2 slice never touched it")))))))))))
+
+(def ^:private api-spread-regions
+  "Each blessed table that must carry `spread` and `spread-safe` as two rows,
+  with the anti-overload sentence that table states in its own voice."
+  [{:label   "§2 blessed public-surface table"
+    :heading api-blessed-heading
+    :row     "`spread`"
+    :states  "not an overload of this row"}
+   {:label   "§2b authoritative surface matrix"
+    :heading api-matrix-heading
+    :row     "`spread-safe`"
+    :states  "a distinct sibling name, never an arity of `spread`"}])
+
+(deftest api-tables-keep-spread-safe-as-a-distinct-row
+  (let [api (slurp (root-file "spec/API.md"))]
+    (doseq [{:keys [label heading row states]} api-spread-regions]
+      (testing (str "spec/API.md " label)
+        (let [region (subsection-text api heading)]
+          (when (is (some? region) (str "spec/API.md lost its " label " subsection"))
+            (is (some? (table-row region "`spread`"))
+                (str label " lost its `spread` row"))
+            (is (some? (table-row region "`spread-safe`"))
+                (str label " lost its distinct `spread-safe` row — `re-frame.ui/spread-safe`"
+                     " ships, and this table's own rule is that anything not in it"
+                     " does not exist"))
+            (is (str/includes? (or (table-row region row) "") states)
+                (str label " stopped stating that `spread-safe` is a sibling name"
+                     " rather than a second `spread` arity"))))))))
+
 (deftest xray-s3-stays-on-existing-views-surfaces
   (let [views       (slurp-guide "02-views.md")
         debugging   (slurp-guide "09-debugging.md")


### PR DESCRIPTION
Closes rf2-kc4kl.

`rf2-3iwpr` (#6371) made two `spec/API.md` claims true and recorded that the corrected truth was left **unguarded** — nothing failed if `dispatch!` drifted back to S2, or if `spread-safe` re-merged into the `spread` row. `rf2-5jbev` (#6372) declined the pin because it is content validation of a graduated spec file, a different guard from its directory-marker census, and filed this bead so it could be done once, properly.

## What is pinned

Two assertions, added to the **existing** `guide_truth_jvm_test.clj` census (its `subsection-text` + `table-row` helpers already do region- and row-scoped spec reading) rather than a new checker — per the bead's "smallest focused authority guard" criterion. No new file.

**(a) §2b's `re-frame.ui.test/*` row binds `dispatch!` inside its S1 clause.** The row is sliced at its own `**S1 core**` / `**S2 mounted semantics**` / `**S3**` markers. The assertion is positive on the S1 clause *and* negative on the S2 clause; the one sanctioned S1-reuse note is excised before the negative check, so the clause may explain the reuse but may not claim the landing.

**(b) §2 and §2b each carry `spread` and `spread-safe` as two distinct rows**, each stating the sibling-not-an-arity rule in its own voice.

## Both facts verified against source

| Claim | Evidence |
|---|---|
| `dispatch!` is S1, not S2 | `git log -S"defn dispatch!"` on `implementation/ui/src/re_frame/ui/test.cljc` returns exactly one commit: `ffe8824b00` *"feat(ui): ui.test Tier-1 core — render/find/find-all/text/attrs over JVM trees (rf2-vxgfnd.4)"*. The S2 slice never touched it. `spec/008-Testing.md:627` now names it in the S1 list. |
| `spread-safe` is a distinct sibling name | Ships as its own `defn` at `implementation/ui/src/re_frame/ui.cljc:484`, separate from `spread`; §2b row 370 carries **G-17** and the literal compile-error id `:rf.ui.compile/spread-safe-owned-key`. The second-arity option was not taken. |

## Why the binding is region-scoped

Load-bearing on **real history**, not a synthetic worry. `spec/API.md` carries **three** `spread-safe` table rows — §Compiled views (line 248), §2 (308) and §2b (370). Before the correction, the §Compiled-views row **already existed** while §2 and §2b both lacked theirs. A document-wide *"a `spread-safe` row exists"* census was therefore green through the entire falsehood. That is `rf2-vxcl7`'s lesson exactly: a census cannot see **where** a claim sits.

The same applies to (a) — `dispatch!` legitimately appears in §2's roster row, so only clause-level binding within the §2b row can tell S1 from S2.

## Mutation proof — 2 mutations, 8 assertions red

Both mutations are the **actual pre-reconciliation wording** recovered from `bbe02dd454~1`, not invented.

| Mutation | Result | Document-wide census |
|---|---|---|
| `dispatch!` reverted to the S2 clause | **4 red** — S1 clause lost it (×2) *and* S2 clause reclaimed it (×2) | **green**: `dispatch!` still appears 4× in the file, `S1 core` still present |
| `spread-safe` re-merged into the `spread` row, both tables | **4 red** — 2 per region (missing distinct row + lost anti-overload statement) | **green**: a `\| spread-safe \|` row still survives at line 248 |

Each mutation reds only its own deftest, so the two assertions are independent — the load-bearing pair shape `rf2-vxgfnd.96.3` established. `spec/API.md` is byte-identical to `origin/main` in this PR; it was restored and re-verified after each mutation.

## Quality gates

All foreground, run to completion.

| Gate | Result |
|---|---|
| `cd implementation/ui && clojure -M:test` | **928 tests / 16130 assertions, 0 failures, 0 errors** (baseline ~926/~16114; +2 tests / +16 assertions are the two new deftests) |
| `python -m mkdocs build --strict` | pass — built in 30.22s, INFO only |
| `python scripts/check_doc_slugs.py` | pass (silent) |

Mutation runs reported non-zero counts (19 tests / 663 assertions for the single-ns run), so the "Ran 0 tests reads as green" trap was not hit.
