### PR TITLE
docs(core): reconcile the flow registrar and destroy-hook comments (rf2-qowmk)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -3754,9 +3754,12 @@
                                               `:after` timer table.
          :schemas/on-frame-destroyed!       — drop schemas registered
                                               against this frame.
-         :flows/teardown-on-frame-destroy!  — drop flows + last-inputs
-                                              rows + dead `:flow`
-                                              registrar slots.
+         :flows/teardown-on-frame-destroy!  — release the destroyed
+                                              frame's per-frame flow-store
+                                              slot, its `last-inputs`
+                                              rows, and its pending
+                                              abandoned-output-path
+                                              (vacation) state.
          :routing/on-frame-destroyed!       — release the frame's
                                               host-side transient routing
                                               caches — scroll positions +
@@ -4013,9 +4016,15 @@
         ;; re-frame.schemas is absent (the artefact is optional).
         (safe-call-hook! :schemas/on-frame-destroyed! id)
         ;; Drop every flow registered against the destroyed
-        ;; frame plus its cached `last-inputs` rows, and prune the
-        ;; `:flow` registrar slot when the destroyed frame was the last
-        ;; owner. Symmetric with the machines teardown hook above.
+        ;; frame plus its cached `last-inputs` rows and its pending
+        ;; abandoned-output-path (vacation) state. There is NO `:flow`
+        ;; registrar slot to prune: per rf2-en00bk the `:flow` registrar
+        ;; kind is RESERVED with an intentionally empty slot, and
+        ;; `reg-flow` writes only to the flows artefact's own per-frame
+        ;; `{frame-id {flow-id flow-map}}` store — the single source of
+        ;; truth. Releasing this frame's key from that store (plus the two
+        ;; sibling frame-keyed caches) IS the whole teardown.
+        ;; Symmetric with the machines teardown hook above.
         ;; Without this hook a long-running SSR JVM with
         ;; per-request frame churn grows the flow registry unboundedly.
         ;; This hook does NOT scrub the frame's flow-output elision marks:

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -287,7 +287,7 @@
    {:key         :flows/teardown-on-frame-destroy!
     :producer-ns 're-frame.flows
     :design-bead "rf2-wbtjn"
-    :description "Drop the destroyed frame's per-frame flow registry slot, its `last-inputs` rows, and any `:flow` registrar entries whose last owning frame was destroyed. Invoked by `frame/destroy-frame!` symmetric with the machines teardown hook (rf2-vsigt) — without this hook a long-running SSR JVM with per-request frame churn grows the flow registry unboundedly."}
+    :description "Drop the destroyed frame's per-frame flow registry slot, its `last-inputs` rows, and its pending abandoned-output-path (vacation) state. No `:flow` registrar entry is pruned — per rf2-en00bk that registrar kind is RESERVED-but-empty and `reg-flow` writes only to the flows artefact's per-frame store. Invoked by `frame/destroy-frame!` symmetric with the machines teardown hook (rf2-vsigt) — without this hook a long-running SSR JVM with per-request frame churn grows the flow registry unboundedly."}
 
    ;; ---- re-frame.schemas -----------------------------------------------------
    {:key         :schemas/validate-event!

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -1301,8 +1301,9 @@
 ;; a dev `:reload` of THIS ns does not push a duplicate hook into the registrar's
 ;; `registration-hooks` vector (it dedupes none, and `clear-all!` does not clear
 ;; it) — the same "install a registrar hook once, survive hot-reload" pattern
-;; `re-frame.flows.registry`'s `_hot-reload-hook` and `re-frame.routing`'s
-;; `_url-bound-exclusivity-hook` use. Gated on `interop/debug-enabled?` so the
+;; `re-frame.substrate.observation`'s `_registrar-hooks` and
+;; `re-frame.subs.cache`'s `_hot-reload-hook` use.
+;; Gated on `interop/debug-enabled?` so the
 ;; whole install (and thus any reprojection cost on the registration path) is
 ;; constant-folded away under `:advanced` + `goog.DEBUG=false`: production stops
 ;; `reg-*`-ing after boot, so there is nothing to reproject (EP-0023:530).


### PR DESCRIPTION
Closes rf2-qowmk.

Four core-src comments still described the retired frame-blind `:flow` registrar model. **Verified against the code before editing: the runtime is correct at every site — only the prose was wrong.** No behavioural bug found.

## What the code actually does

`re-frame.flows.registry/teardown-on-frame-destroy!` dissocs the frame key from exactly three per-frame atoms:

```clojure
(swap! flows dissoc frame-id)
(swap! frame-last-inputs dissoc frame-id)
(swap! frame-abandoned-output-paths dissoc frame-id)
```

It never touches the registrar, and structurally cannot: per rf2-en00bk the `:flow` registrar kind is RESERVED with an intentionally empty slot (documented in `registrar.cljc`), `reg-flow` writes only to the per-frame `{frame-id {flow-id flow-map}}` store, and `implementation/flows/src` contains no `register!` call at all. `flow-reload-shape` explicitly bypasses the generic `[:flow flow-id]` dedup table as frame-blind.

## Sites corrected

| Site | Claimed | Truth | Verdict |
|---|---|---|---|
| `frame.cljc` destroy-hook enumeration | hook drops "dead `:flow` registrar slots" | no such slots exist | comment wrong |
| `frame.cljc` destroy-hook call site | "prune the `:flow` registrar slot when the destroyed frame was the last owner" | nothing to prune | comment wrong |
| `late_bind/directory.cljc` `:flows/teardown-on-frame-destroy!` `:description` | "any `:flow` registrar entries whose last owning frame was destroyed" | no such entries | comment wrong |
| `live_frame.cljc` `_auto-reprojection-hook` | cites `flows.registry/_hot-reload-hook` + `routing`'s `_url-bound-exclusivity-hook` as precedents | **both vars are gone** | comment wrong |

The first three now describe only what is released: the destroyed frame's per-frame flow-store slot, its `last-inputs` rows, and its pending abandoned-output-path (vacation) state.

### Retired-var references found and fixed

The fourth site cited **two** dead precedents, not just the flows one the bead named:

- `re-frame.flows.registry/_hot-reload-hook` — removed; single-store `reg-flow` invalidates directly (the flows test suite records the removal).
- `re-frame.routing`'s `_url-bound-exclusivity-hook` — never existed as a defonce hook; `check-url-bound-exclusivity!` is a plain fn called directly from `routing.cljc`.

Repointed at the two genuinely-live precedents: `substrate.observation/_registrar-hooks` (`add-registration-hook!`, the exact analogue) and `subs.cache/_hot-reload-hook` (`add-replacement-hook!`).

## Obsolete acceptance criterion

The bead's final criterion asks for a `docs/cljs/playground-rf2.js` rebuild plus `scripts/check-playground-sci-freshness.sh`. **Both are gone** — rf2-tzy13 removed the baked artefact and CI generates it. Nothing to rebuild; no SCI-digest step applies.

## Quality gates

Comment-only diff, so these confirm **no regression**; they do not validate the wording (nothing gates it — see below).

| Gate | Result |
|---|---|
| `implementation/core` → `clojure -M:test` | **2073 tests / 9908 assertions**, 0 failures, 0 errors |
| `implementation/flows` → `clojure -M:test` (own dir) | **240 tests / 6037 assertions**, 0 failures, 0 errors |
| `implementation/` → `npm run test:cljs` | **10084 tests / 49774 assertions**, 0 failures, 0 errors |

Nothing pins this prose: `late_bind_drift_test.clj` asserts only `(string? (:description entry))` for the directory rows; its one wording assertion targets a different key (`:epoch/snapshot-frame-destroyed`). The single runtime-visible change is that `:description` string, which remains a string — a comment-only diff cannot move test counts.
