### PR TITLE
test(ui): remove an order-dependent pass and an unchecked arity shadow (rf2-i36h6, rf2-qw31o)

### DIFF
--- a/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_probe.cljc
+++ b/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_probe.cljc
@@ -149,9 +149,22 @@
        intentionally, never forced equal). A function the analyzer surfaces no
        arity for is itself drift (`:arity-unobserved`).
      - MACROS are host-invariant (one `.cljc` definition expanded on both
-       hosts) — their call grammar is pinned once on the JVM lane and the
-       analyzer does not reliably surface their arglists, so they are not
-       arity-checked here.
+       hosts) — their call grammar is pinned once on the JVM lane, against the
+       live JVM `:arglists`, and the analyzer does not reliably surface macro
+       arglists so it is never treated as authority here. What IS checked is
+       that the sidecar's two halves AGREE: a macro's `:cljs` grammar must
+       EQUAL its `:clj` grammar (`:macro-host-variance`).
+
+   MACRO HOST-INVARIANCE (rf2-qw31o). The `:cljs` half of a macro row used to
+   be read by nothing at all: this lane skipped macros outright and the JVM
+   lane reads only `:clj`, so an arbitrary mutation to `render`'s or
+   `with-root`'s `:cljs` grammar stayed green on BOTH lanes — a duplicated
+   field carrying misleading contract authority. Requiring equality is what
+   gives the stored `:cljs` meaning: `:clj` is pinned to the live JVM macro
+   arglists on the other lane, so equality transitively pins `:cljs` to that
+   same live authority WITHOUT consulting the CLJS analyzer. Functions are
+   untouched — `flush!`'s 0-arity JVM vs 0/1-arity CLJS difference is real and
+   stays independently exact on each lane.
 
    Names are reconciled exactly: a contract var the live surface does not
    expose → `:var-absent`; a live blessed var with no contract entry →
@@ -161,15 +174,18 @@
   (->>
    (concat
     (mapcat
-     (fn [[var {:keys [kind cljs]}]]
+     (fn [[var {:keys [kind clj cljs]}]]
        (if-let [{live-kind :kind live-arities :arities} (get surface var)]
          (concat
           (when (not= kind live-kind)
             [{:kind :kind-mismatch :var var :declared kind :live-kind live-kind}])
+          ;; Both branches are selected by the AUTHORITATIVE live kind.
           (when (= live-kind :fn)
             (cond
               (nil? live-arities)      [{:kind :arity-unobserved :var var :expected cljs}]
-              (not= cljs live-arities) [{:kind :arity-mismatch :var var :expected cljs :got live-arities}])))
+              (not= cljs live-arities) [{:kind :arity-mismatch :var var :expected cljs :got live-arities}]))
+          (when (and (= live-kind :macro) (not= clj cljs))
+            [{:kind :macro-host-variance :var var :expected clj :got cljs}]))
          [{:kind :var-absent :var var :expected cljs}]))
      contract)
     (keep (fn [[var _]]
@@ -200,6 +216,13 @@
              :arity-mismatch
              (str "    " var ": live CLJS " (pr-str got)
                   " ; contract :cljs " (pr-str expected))
+             :macro-host-variance
+             (str "    " var ": MACRO contract :clj " (pr-str expected)
+                  " but :cljs " (pr-str got)
+                  " — a ui.test macro is ONE .cljc defmacro expanded on both"
+                  " hosts, so its call grammar cannot differ by host. Set :cljs"
+                  " equal to :clj (" (pr-str expected) "); if the grammar really"
+                  " changed, change BOTH.")
              :arity-unobserved
              (str "    " var ": the analyzer surfaced NO arity (expected :cljs "
                   (pr-str expected) ") — a function must be observable")

--- a/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
+++ b/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
@@ -67,6 +67,7 @@
                             emit-classification-rows emit-ns-surface
                             emit-ui-test-signature-contract]])
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]
             [re-frame.api-manifest.cljs-probe :as probe]
             ;; The covered CLJS-only namespaces. The `:require` forces the
             ;; analyzer to analyse each before `emit-ns-publics` expands,
@@ -260,11 +261,14 @@
 ;; Synthetic reconciler contracts — the mutation proof, exercised directly on
 ;; the pure `signature-problems` so a reshape / kind flip goes RED and the
 ;; in-sync state stays green regardless of the live analyzer.
+;; Carries BOTH halves, exactly like a real sidecar row: `flush!` keeps the
+;; blessed host-specific function difference (0-arity JVM, 0/1-arity CLJS),
+;; and the two macros are host-invariant (`:clj` = `:cljs`).
 (def ^:private synthetic-contract
-  {"attrs"     {:kind :fn    :cljs #{[1]}}
-   "flush!"    {:kind :fn    :cljs #{[0] [1]}}
-   "render"    {:kind :macro :cljs #{[1] [2]}}
-   "with-root" {:kind :macro :cljs #{[1 :&]}}})
+  {"attrs"     {:kind :fn    :clj #{[1]}     :cljs #{[1]}}
+   "flush!"    {:kind :fn    :clj #{[0]}     :cljs #{[0] [1]}}
+   "render"    {:kind :macro :clj #{[1] [2]} :cljs #{[1] [2]}}
+   "with-root" {:kind :macro :clj #{[1 :&]}  :cljs #{[1 :&]}}})
 
 ;; The live SURFACE fixture: {var {:kind :arities}}. A macro's analyzer arities
 ;; may be nil (host-invariant, never arity-checked here).
@@ -340,11 +344,75 @@
 
 (deftest cljs-macros-are-not-arity-checked
   (testing "macros (render / with-root) are host-invariant — the CLJS lane does
-            NOT arity-flag them even when the analyzer surfaces no arity for them
-            (their grammar is pinned on the JVM lane), as long as they are
-            present with the :macro classification"
+            NOT arity-flag them against the ANALYZER even when it surfaces no
+            arity for them (their grammar is pinned on the JVM lane, against
+            the live JVM :arglists), as long as they are present with the
+            :macro classification"
     (is (empty? (probe/signature-problems
                  synthetic-contract
                  (-> synthetic-live-in-sync
                      (assoc-in ["render" :arities] nil)
                      (assoc-in ["with-root" :arities] nil)))))))
+
+;; ---------------------------------------------------------------------------
+;; MACRO HOST-INVARIANCE — the unchecked shadow contract (rf2-qw31o)
+;;
+;; A macro row's `:cljs` half used to be read by NOTHING: this lane skipped
+;; macros outright and the JVM lane reads only `:clj`, so an arbitrary mutation
+;; to `render`'s or `with-root`'s `:cljs` grammar stayed green on BOTH lanes.
+;; Now both reconcilers require a macro's two halves to be equal. Neither
+;; consults the analyzer for a macro arity — the check is sidecar-internal, and
+;; `:clj` is what stays pinned to the live JVM `:arglists`.
+;; ---------------------------------------------------------------------------
+
+(deftest cljs-macro-cljs-only-mutation-goes-red
+  (testing "THE BUG (rf2-qw31o): mutating render's grammar ONLY on the :cljs
+            side is host-variance a single .cljc defmacro cannot have. It used
+            to be invisible to every lane; it is now RED with an actionable
+            diagnostic naming both halves"
+    (let [problems (probe/signature-problems
+                    (assoc-in synthetic-contract ["render" :cljs] #{[7] [9]})
+                    synthetic-live-in-sync)]
+      (is (= [:macro-host-variance] (map :kind problems)))
+      (is (= "render" (:var (first problems))))
+      (is (= #{[1] [2]} (:expected (first problems))) "the :clj half")
+      (is (= #{[7] [9]} (:got (first problems)))      "the mutated :cljs half")
+      (let [report (probe/signature-report problems)]
+        (is (str/includes? report "render") "the report NAMES the offending var")
+        (is (str/includes? report ":cljs equal to :clj")
+            "and names the remedy — an actionable diagnostic, not a bare diff")))))
+
+(deftest cljs-macro-clj-only-mutation-goes-red
+  (testing "the OTHER direction: mutating with-root's :clj half alone is the
+            same host-variance and is equally rejected here (the JVM lane
+            additionally catches it against the live Var :arglists), so neither
+            half can be edited on its own"
+    (let [problems (probe/signature-problems
+                    (assoc-in synthetic-contract ["with-root" :clj] #{[2 :&]})
+                    synthetic-live-in-sync)]
+      (is (= [:macro-host-variance] (map :kind problems)))
+      (is (= "with-root" (:var (first problems)))))))
+
+(deftest cljs-macro-grammar-changed-in-both-halves-stays-green
+  (testing "POSITIVE CONTROL — over-tightening would be worse than the bug. A
+            macro grammar that REALLY changed, changed in BOTH halves together,
+            is in sync and must not be flagged. Without this, 'always flag a
+            macro' would pass the two mutation tests above while making every
+            legitimate grammar change unrepresentable"
+    (is (empty? (probe/signature-problems
+                 (-> synthetic-contract
+                     (assoc-in ["render" :clj]  #{[1] [2] [3]})
+                     (assoc-in ["render" :cljs] #{[1] [2] [3]}))
+                 synthetic-live-in-sync)))))
+
+(deftest cljs-function-host-difference-is-never-forced-equal
+  (testing "POSITIVE CONTROL for the other half of the rule — host-invariance
+            binds MACROS only. flush!'s contract is deliberately :clj #{[0]}
+            and :cljs #{[0] [1]}, a real reader-conditional difference, and
+            reconciles clean. A check that forced :clj = :cljs for every kind
+            would redden this legitimate row"
+    (is (not= (get-in synthetic-contract ["flush!" :clj])
+              (get-in synthetic-contract ["flush!" :cljs]))
+        "the fixture really does carry the host difference")
+    (is (empty? (probe/signature-problems synthetic-contract
+                                          synthetic-live-in-sync)))))

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
@@ -616,24 +616,45 @@
    The sidecar's declared `:kind` is NOT trusted: it is RECONCILED against the
    live kind and a disagreement is REJECTED (`:kind-mismatch`) — so a sidecar
    kind flipped `:fn`→`:macro` reddens THIS lane instead of being silently
-   ignored, closing the JVM half of the rf2-d7sso seam. Three directions:
+   ignored, closing the JVM half of the rf2-d7sso seam. Four directions:
      - every CONTRACT var must resolve live with a matching kind AND matching
        `:clj` arities (`:kind-mismatch` / `:arity-mismatch`; a contract var that
        no longer resolves → `:var-absent`);
+     - a MACRO's `:cljs` grammar must EQUAL its `:clj` grammar
+       (`:macro-host-variance`) — see below;
      - every LIVE blessed var must be in the contract (a fresh export with no
-       signature → `:uncontracted-var`)."
+       signature → `:uncontracted-var`).
+
+   MACRO HOST-INVARIANCE (rf2-qw31o). A ui.test macro is a single `.cljc`
+   `defmacro` expanded on both hosts, so its call grammar CANNOT differ by
+   host — `:clj` and `:cljs` are two spellings of one fact. The sidecar stored
+   both anyway while nothing read the `:cljs` half of a macro row: this lane
+   reads only `:clj`, and the CLJS lane deliberately does not arity-check
+   macros (the analyzer does not reliably surface macro arglists, and treating
+   it as authority is exactly what the design refuses). An arbitrary mutation
+   to `render`'s or `with-root`'s `:cljs` grammar therefore stayed green on
+   BOTH lanes — a duplicated field carrying misleading contract authority.
+   Requiring the two halves to be EQUAL is what makes the stored `:cljs` mean
+   something: `:clj` stays pinned to the live JVM macro arglists above, so
+   equality transitively pins `:cljs` to that same live authority without
+   consulting the CLJS analyzer at all. FUNCTIONS are untouched — their
+   host-specific arities (`flush!`'s 0-arity JVM vs 0/1-arity CLJS) are real
+   and stay independently exact on each lane."
   [signatures surface]
   (sort-by
    :var
    (concat
     (mapcat
-     (fn [[var {:keys [kind clj]}]]
+     (fn [[var {:keys [kind clj cljs]}]]
        (if-let [{live-kind :kind live-arities :arities} (get surface var)]
          (concat
           (when (not= kind live-kind)
             [{:kind :kind-mismatch :var var :declared kind :live-kind live-kind}])
           (when (not= clj live-arities)
-            [{:kind :arity-mismatch :var var :expected clj :got live-arities}]))
+            [{:kind :arity-mismatch :var var :expected clj :got live-arities}])
+          ;; Selected by the AUTHORITATIVE live kind, never the declared one.
+          (when (and (= live-kind :macro) (not= clj cljs))
+            [{:kind :macro-host-variance :var var :expected clj :got cljs}]))
          [{:kind :var-absent :var var :expected clj}]))
      signatures)
     (keep (fn [[var {live-arities :arities}]]
@@ -770,6 +791,16 @@
                 :arity-mismatch
                 (println (format "  %-12s ARITY:  live JVM %s; contract :clj %s"
                                  var (pr-str got) (pr-str expected)))
+                :macro-host-variance
+                (do (println (format "  %-12s HOST-VARIANCE: macro contract :clj %s but :cljs %s"
+                                     var (pr-str expected) (pr-str got)))
+                    (println (format "  %-12s               a ui.test macro is ONE .cljc defmacro expanded on both"
+                                     ""))
+                    (println (format "  %-12s               hosts — its call grammar cannot differ by host. Set :cljs"
+                                     ""))
+                    (println (format "  %-12s               equal to :clj (%s), or, if the grammar really changed,"
+                                     "" (pr-str expected)))
+                    (println (format "  %-12s               change BOTH to the new shape." "")))
                 :var-absent
                 (println (format "  %-12s ABSENT: contract expects :clj %s but the var did not resolve"
                                  var (pr-str expected)))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
@@ -645,18 +645,20 @@
 ;; COUNTS an ordinary function's &form/&env params (bead AC).
 ;; ---------------------------------------------------------------------------
 
-;; The :clj projection of the nine blessed vars' signature contract (mirrors
-;; the committed :ui-test-signatures :vars, :clj half).
+;; The nine blessed vars' signature contract, carrying BOTH halves exactly as
+;; the committed :ui-test-signatures rows do. `flush!` keeps the blessed
+;; reader-conditional FUNCTION difference (0-arity JVM, 0/1-arity CLJS); the
+;; two MACROS are host-invariant, so their halves are equal (rf2-qw31o).
 (def ^:private ui-test-clj-contract
-  {"attrs"     {:kind :fn    :clj #{[1]}}
-   "text"      {:kind :fn    :clj #{[1]}}
-   "find"      {:kind :fn    :clj #{[2]}}
-   "find-all"  {:kind :fn    :clj #{[2]}}
-   "query"     {:kind :fn    :clj #{[2]}}
-   "dispatch!" {:kind :fn    :clj #{[2]}}
-   "flush!"    {:kind :fn    :clj #{[0]}}
-   "render"    {:kind :macro :clj #{[1] [2]}}
-   "with-root" {:kind :macro :clj #{[1 :&]}}})
+  {"attrs"     {:kind :fn    :clj #{[1]}     :cljs #{[1]}}
+   "text"      {:kind :fn    :clj #{[1]}     :cljs #{[1]}}
+   "find"      {:kind :fn    :clj #{[2]}     :cljs #{[2]}}
+   "find-all"  {:kind :fn    :clj #{[2]}     :cljs #{[2]}}
+   "query"     {:kind :fn    :clj #{[2]}     :cljs #{[2]}}
+   "dispatch!" {:kind :fn    :clj #{[2]}     :cljs #{[2]}}
+   "flush!"    {:kind :fn    :clj #{[0]}     :cljs #{[0] [1]}}
+   "render"    {:kind :macro :clj #{[1] [2]} :cljs #{[1] [2]}}
+   "with-root" {:kind :macro :clj #{[1 :&]}  :cljs #{[1 :&]}}})
 
 ;; The matching live-JVM SURFACE for an in-sync tree: {var {:kind :arities}}.
 (def ^:private ui-test-live-in-sync
@@ -758,6 +760,87 @@
       (is (= "flush!" (:var (first problems))))
       (is (= :macro (:declared (first problems))))
       (is (= :fn (:live-kind (first problems)))))))
+
+;; ---------------------------------------------------------------------------
+;; MACRO HOST-INVARIANCE — the unchecked shadow contract (rf2-qw31o)
+;;
+;; A ui.test macro is ONE .cljc `defmacro` expanded on both hosts, so `:clj`
+;; and `:cljs` are two spellings of one fact. This lane reads only `:clj` and
+;; the CLJS lane never arity-checks a macro (analyzer macro arglists are not
+;; reliable authority), so the `:cljs` half of a macro row was read by NOTHING
+;; and an arbitrary mutation to it stayed green on BOTH lanes. Both reconcilers
+;; now require the halves to be equal; `:clj` remains pinned to the live JVM
+;; `:arglists` above, so equality transitively pins `:cljs` to the same live
+;; authority without introducing any new signature parser.
+;; ---------------------------------------------------------------------------
+
+(deftest macro-cljs-only-mutation-goes-red
+  (testing "THE BUG (rf2-qw31o): mutating render's grammar ONLY on the :cljs side
+            is host-variance a single .cljc defmacro cannot have. It was
+            invisible to every lane; it is now RED here, and the live :clj
+            arities still match so ONLY the host-variance fires"
+    (let [problems (c/ui-test-arity-problems
+                    (assoc-in ui-test-clj-contract ["render" :cljs] #{[7] [9]})
+                    ui-test-live-in-sync)]
+      (is (= [:macro-host-variance] (map :kind problems)))
+      (is (= "render" (:var (first problems))))
+      (is (= #{[1] [2]} (:expected (first problems))) "the :clj half")
+      (is (= #{[7] [9]} (:got (first problems)))      "the mutated :cljs half"))))
+
+(deftest with-root-cljs-only-mutation-goes-red
+  (testing "with-root's :cljs half mutated alone is rejected the same way — both
+            macro rows are covered, not just the first"
+    (let [problems (c/ui-test-arity-problems
+                    (assoc-in ui-test-clj-contract ["with-root" :cljs] #{[42]})
+                    ui-test-live-in-sync)]
+      (is (= [:macro-host-variance] (map :kind problems)))
+      (is (= "with-root" (:var (first problems)))))))
+
+(deftest macro-clj-only-mutation-goes-red-on-both-counts
+  (testing "mutating a macro's :clj half alone drifts from BOTH authorities: the
+            live JVM :arglists (:arity-mismatch) and its own :cljs twin
+            (:macro-host-variance). Neither half can be edited on its own"
+    (let [problems (c/ui-test-arity-problems
+                    (assoc-in ui-test-clj-contract ["render" :clj] #{[1]})
+                    ui-test-live-in-sync)]
+      (is (= [:arity-mismatch :macro-host-variance] (sort (map :kind problems))))
+      (is (every? #(= "render" (:var %)) problems)))))
+
+(deftest macro-grammar-changed-in-both-halves-stays-green
+  (testing "POSITIVE CONTROL — over-tightening would be worse than the bug. A
+            macro grammar that REALLY changed, changed in BOTH halves AND in the
+            live source together, is in sync and must not be flagged. Without
+            this, 'always flag a macro' would pass every mutation test above
+            while making a legitimate grammar change unrepresentable"
+    (is (empty? (c/ui-test-arity-problems
+                 (-> ui-test-clj-contract
+                     (assoc-in ["render" :clj]  #{[1] [2] [3]})
+                     (assoc-in ["render" :cljs] #{[1] [2] [3]}))
+                 (assoc-in ui-test-live-in-sync ["render" :arities] #{[1] [2] [3]}))))))
+
+(deftest function-host-difference-is-never-forced-equal
+  (testing "POSITIVE CONTROL for the other half of the rule — host-invariance
+            binds MACROS only. flush! is deliberately :clj #{[0]} / :cljs
+            #{[0] [1]}, a real reader-conditional difference, and reconciles
+            clean. A check that forced :clj = :cljs for every kind would redden
+            this legitimate row"
+    (is (not= (get-in ui-test-clj-contract ["flush!" :clj])
+              (get-in ui-test-clj-contract ["flush!" :cljs]))
+        "the fixture really does carry the host difference")
+    (is (empty? (c/ui-test-arity-problems ui-test-clj-contract ui-test-live-in-sync)))))
+
+(deftest committed-sidecar-macro-rows-are-host-invariant
+  (testing "the COMMITTED sidecar (not a fixture) really does carry equal :clj
+            and :cljs halves for every macro row — the reconcilers above check
+            the rule, this checks the live artefact obeys it, and that macro
+            rows exist at all (a vacuous pass if the enumeration collapsed)"
+    (let [contract (:vars (c/read-ui-test-signatures))
+          macros   (filter (fn [[_ v]] (= :macro (:kind v))) contract)]
+      (is (= #{"render" "with-root"} (set (map key macros)))
+          "the two blessed ui.test macros are rowed")
+      (doseq [[var {:keys [clj cljs]}] macros]
+        (is (= clj cljs)
+            (str var ": macro :clj and :cljs must be equal (one .cljc defmacro)"))))))
 
 (deftest removed-var-flagged-absent
   (testing "a contract var whose live var no longer resolves is :var-absent

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -65,10 +65,22 @@
  ;;     `npm run test:cljs`) reads the live analyzer arities of the
  ;;     reader-conditional CLJS surface and reconciles the FUNCTION arities
  ;;     against :cljs here. A CLJS-only reshape (e.g. dropping `flush!`'s
- ;;     1-arity) turns the probe RED. Macros are host-invariant (one .cljc
- ;;     definition expanded on both hosts), so their grammar is pinned once
- ;;     on the JVM lane; the reader-conditional :clj/:cljs difference for a
- ;;     function is represented intentionally rather than forced equal.
+ ;;     1-arity) turns the probe RED. The reader-conditional :clj/:cljs
+ ;;     difference for a FUNCTION is represented intentionally rather than
+ ;;     forced equal.
+ ;;
+ ;; MACRO ROWS ARE HOST-INVARIANT, AND BOTH LANES ENFORCE IT (rf2-qw31o).
+ ;; A ui.test macro is ONE .cljc `defmacro` expanded on both hosts, so its
+ ;; call grammar cannot differ by host: :clj and :cljs are two spellings of
+ ;; one fact. Neither lane arity-checks a macro against the CLJS analyzer
+ ;; (macro arglists are not reliable authority there), so for a while the
+ ;; :cljs half of a macro row was read by NOTHING — an arbitrary mutation to
+ ;; `render`'s or `with-root`'s :cljs grammar stayed green on both lanes,
+ ;; leaving a duplicated field with misleading contract authority. Both
+ ;; reconcilers now REQUIRE a macro's :cljs to EQUAL its :clj
+ ;; (`:macro-host-variance`). Since :clj stays pinned to the live JVM macro
+ ;; :arglists, equality transitively pins :cljs to that same live authority.
+ ;; Changing a macro's grammar means changing BOTH halves together.
  ;; --------------------------------------------------------------------------
  :ui-test-signatures
  {:namespace "re-frame.ui.test"

--- a/tools/story/test/re_frame/story/play/presence_real_clock_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/play/presence_real_clock_cljs_test.cljs
@@ -29,6 +29,11 @@
   The wall clock is DISABLED throughout, so the logical advance is the sole
   removal driver — the determinism the whole rung exists for.
 
+  This namespace establishes EVERYTHING it consumes and is run standalone as
+  well as in the consolidated bundle (rf2-i36h6). In particular it awaits each
+  Promise-backed advance through the run loop's own settle seam rather than
+  assuming a macrotask yield outran React `act`; see `flush-presence-step!`.
+
   The final block (rf2-iz0t8) covers the PROMISE-BACKED-ness itself rather
   than the clock: resolved and rejected thenable controls driven through the
   real run loop and the real interactive stepper. Those need a host whose
@@ -79,46 +84,91 @@
   (presence-rt/schedule-exit!
     300 #(router/dispatch-sync! [:presence/exited] {:frame shared/presence-frame})))
 
-(defn- after-tick
-  "Yield one macrotask — exactly what the run loop does after an async-yield
-  step (`runner/async-yield-step-types`). The framework verb holds a SINGLE
-  in-flight act token, so calling it again before the previous act settles is
-  the framework's own `:rf.error/ui-test-overlapping-act` misuse error. A
-  `setTimeout` 0 runs only after the microtask queue has drained to empty, so
-  the act has settled. A test driving `exec-step!` DIRECTLY owes the same
-  yield the loop gives — including after the LAST advance, or the still-active
-  act leaks into the next test."
-  [f]
-  (js/setTimeout f 0))
+(def ^:private settle-step-result!
+  "The private SETTLED-result seam, reached via var-quote — the same
+  established Story-test seam `shared/exec-step!` uses, one step further down
+  the run loop. `(settle-step-result! idx step provisional k)` calls `k` with
+  the step's FINAL result: for a Promise-backed `[:flush-presence]` that means
+  once the host's thenable has settled, for every other step immediately."
+  @#'re/settle-step-result!)
+
+(defn- flush-presence-step!
+  "Drive ONE `[:flush-presence …]` step to completion and hand `k` its SETTLED
+  step-result. These are the two moves `runner-events/run-loop!` makes for a
+  Promise-backed presence host, in this order:
+
+    1. AWAIT the advance's thenable (`settle-step-result!`). On CLJS the
+       framework verb runs its advance inside React `act` and its Promise
+       settles on act's OWN task — so 'the advance is over' is a fact ONLY
+       that thenable can report.
+    2. THEN yield one macrotask, so the React commits the advance queued have
+       landed before the next step reads them.
+
+  A test driving `exec-step!` DIRECTLY owes BOTH. This namespace used to owe
+  only the yield, on the premise that a `setTimeout` 0 lands after the act has
+  settled. It does not: a macrotask is not ordered against act's own task, and
+  whenever the yield lost that race the NEXT step threw
+  `:rf.error/ui-test-overlapping-act` and advanced NOTHING.
+
+  That made this namespace's pass ORDER-DEPENDENT (rf2-i36h6): green under
+  `npm run test:cljs`, where a namespace ahead of it had already exercised the
+  act path, and RED for anyone narrowing to it alone — a result carrying no
+  information, and actively misleading to a developer whose own bug it is not.
+  The fix is to establish the settlement HERE, the way the run loop does,
+  rather than to pin a suite order that would only hide the next instance."
+  [idx step k]
+  (settle-step-result!
+    idx step (shared/exec-step! shared/presence-frame idx step)
+    (fn [settled] (js/setTimeout #(k settled) 0))))
+
+(defn- advance-reached-the-verb!
+  "POSITIVE CONTROL for one advance. The retention assertions around it hold
+  in TWO different worlds — the advance ran, or the advance never happened at
+  all (`pending-count` is unchanged either way below `:timeout-ms`, and a
+  never-fired exit leaves `:toast` nil exactly like a not-yet-due one). The
+  STEP-RESULT is what tells those worlds apart, so every advance is checked
+  through it: a reached, settled advance carries no `:exception` and no
+  `:cannot-run?`. Without this the overlapping-act failure above would have
+  surfaced only as a downstream retention assertion two ticks later, which is
+  precisely why it read as somebody else's bug."
+  [result]
+  (is (nil? (:exception result))
+      "the advance REACHED the framework verb and settled cleanly")
+  (is (nil? (:cannot-run? result))
+      "a presence host was installed — this is a real advance, not a refusal"))
 
 (deftest real-flush-presence-advances-the-framework-clock
   (async done
     (install-real-presence-host!)
     (schedule-real-exit!)
     (is (= 1 (presence-rt/pending-count)) "one exit retained")
-    (shared/exec-step! shared/presence-frame 0 [:flush-presence 100])
-    ;; The advance + its removal callbacks run synchronously inside the awaited
-    ;; act; only the React commits settle on the microtask queue.
-    (is (= 1 (presence-rt/pending-count))
-        "below :timeout-ms the exit is STILL retained — the partial-advance
-         arity is what lets a script observe the :unmounting phase")
-    (is (nil? (:toast (shared/db))))
-    (after-tick
-      (fn []
-        (shared/exec-step! shared/presence-frame 1 [:flush-presence])
-        (is (zero? (presence-rt/pending-count))
-            "advancing to quiescence fired the retained exit")
-        (is (= :removed (:toast (shared/db)))
-            "the terminal removal is observable to the next script step")
-        (after-tick
-          (fn []
-            ;; exactly-once: a further advance re-fires nothing.
-            (shared/exec-step! shared/presence-frame 2 [:flush-presence])
-            (is (zero? (presence-rt/pending-count)))
-            (is (= :removed (:toast (shared/db))))
-            ;; Yield once more so THIS act settles before the test ends — an
-            ;; act still in flight would collide with the next test's advance.
-            (after-tick done)))))))
+    (flush-presence-step!
+      0 [:flush-presence 100]
+      (fn [r]
+        (advance-reached-the-verb! r)
+        (is (= 1 (presence-rt/pending-count))
+            "below :timeout-ms the exit is STILL retained — the partial-advance
+             arity is what lets a script observe the :unmounting phase")
+        (is (nil? (:toast (shared/db))))
+        (flush-presence-step!
+          1 [:flush-presence]
+          (fn [r]
+            (advance-reached-the-verb! r)
+            (is (zero? (presence-rt/pending-count))
+                "advancing to quiescence fired the retained exit")
+            (is (= :removed (:toast (shared/db)))
+                "the terminal removal is observable to the next script step")
+            (flush-presence-step!
+              2 [:flush-presence]
+              (fn [r]
+                ;; exactly-once: a further advance re-fires nothing.
+                (advance-reached-the-verb! r)
+                (is (zero? (presence-rt/pending-count)))
+                (is (= :removed (:toast (shared/db))))
+                ;; `flush-presence-step!` already awaited THIS act and yielded
+                ;; past its commits, so no act is in flight as the test ends —
+                ;; one would collide with the next test's advance.
+                (done)))))))))
 
 (deftest real-playback-settles-a-presence-bearing-script
   (async done


### PR DESCRIPTION
Two tests that proved less than they appeared to. Both are "coverage that can
go vacuously green"; each fix adds a positive control so the new coverage
cannot.

## rf2-i36h6 — a pass that only held because another namespace ran first

`re-frame.story.play.presence-real-clock-cljs-test` passed under
`npm run test:cljs` and failed when selected alone.

**The coupling.** The namespace drove `exec-step!` directly and yielded a
single `setTimeout` 0 between advances, on the stated premise that a macrotask
lands after React `act` has settled. It does not: on CLJS `flush-presence!`
runs its advance inside `act`, whose Promise settles on act's own task, which
a macrotask is not ordered against. When the yield lost that race the next
step threw `:rf.error/ui-test-overlapping-act` and advanced **nothing**,
leaving the retention assertions two ticks downstream to fail. In the
consolidated bundle a namespace ahead of it had already exercised the act path
and the race was won every time.

**The fix — establish it here, do not pin an order.** `flush-presence-step!`
makes the two moves `runner-events/run-loop!` itself makes for a
Promise-backed presence host: **await** the advance's thenable through the run
loop's own `settle-step-result!` seam, **then** yield one macrotask for the
React commits it queued. Reached via the established var-quote Story-test
seam, beside the `exec-step!` this namespace already borrowed. No execution
order is pinned anywhere.

**Positive control.** `(= 1 (pending-count))` and a nil `:toast` hold in two
different worlds — the advance ran and stayed under `:timeout-ms`, or the
advance never happened at all — which is exactly why the overlapping-act
refusal read as a downstream retention bug. Every advance is now checked
through its step-result (`advance-reached-the-verb!`): a reached, settled
advance carries no `:exception` and no `:cannot-run?`, so a refused advance
fails at the step that was refused.

## rf2-qw31o — the unchecked CLJS macro-arity shadow contract

**The shadow.** The `:ui-test-signatures` sidecar stores a `:clj` and a
`:cljs` arity set for every blessed `re-frame.ui.test` var, including the two
macros. Nothing read the `:cljs` half of a macro row: the JVM lane reconciles
only `:clj`, and the CLJS lane skips macros by design because analyzer macro
arglists are not reliable authority. `render` and `with-root` each carried a
duplicated field with the look of contract authority and none of the
substance.

Verified, not assumed: with `render :cljs #{[7] [9]}` and
`with-root :cljs #{[42]}`, `api-md-check` exited 0 ("OK ... in sync") and the
CLJS probe ran 13 tests / 51 assertions with 0 failures.

**The fix** (the AC's second disjunct). A ui.test macro is one `.cljc`
defmacro expanded on both hosts, so `:clj` and `:cljs` are two spellings of
one fact. Both reconcilers now require a macro's halves to be equal
(`:macro-host-variance`), selected by the authoritative **live** kind. The
check is sidecar-internal — no analyzer macro arity is consulted, no signature
parser is introduced. Since `:clj` stays pinned to the live JVM `:arglists`,
equality transitively pins `:cljs` to that same live authority. Enforced on
both lanes for the same reason the sidecar `:kind` is (rf2-d7sso): a one-lane
check would re-create the assumption that the other lane had it covered.

Functions are untouched — `flush!`'s deliberate `:clj #{[0]}` /
`:cljs #{[0] [1]}` difference still reconciles clean and stays independently
exact per lane.

**Positive controls** (both lanes), because "always flag a macro" would pass
every mutation test while making a legitimate grammar change unrepresentable:
a macro grammar changed in *both* halves is green, and `flush!`'s real host
difference is green with the fixture asserting it really differs first.
`committed-sidecar-macro-rows-are-host-invariant` checks the committed
artefact obeys the rule and that the macro rows exist at all, so a collapsed
enumeration cannot pass vacuously. The synthetic fixtures now carry both
halves like real sidecar rows — as `:clj`-only maps every macro row would have
looked host-variant.

The sidecar's data is unchanged; its diff is comment-only.

## Quality gates

All foreground, run to completion.

| Gate | Result |
| --- | --- |
| `implementation/ui` → `clojure -M:test` | **926 tests / 16119 assertions, 0 failures** |
| `implementation` → `npm run test:cljs` | **10088 tests / 49791 assertions, 0 failures** |
| `scripts/api-manifest` → `clojure -M:test` | **110 tests / 243 assertions, 0 failures** |
| `clojure -M -m re-frame.api-manifest.api-md-check` | **EXIT 0**, 217 var-rows in sync |
| `scripts/check-no-hardcoded-paths.sh` | **OK** |

### rf2-i36h6 — the namespace alone, both ways

`node out/node-test.js --test=re-frame.story.play.presence-real-clock-cljs-test`

| | tests / assertions | result |
| --- | --- | --- |
| unfixed HEAD, 10 runs | 6 / 25 | **RED on 4 of 10** (2 failures each) |
| fixed, 10 runs | 6 / **31** | **green 10 of 10** |
| fixed, but with the await removed again, 8 runs | 6 / 31 | **RED on 3 of 8** — and the positive control is the *first* assertion to fail, naming the cause |

The defect is a race the consolidated-bundle ordering masked completely; alone
it surfaced roughly 4 runs in 10. Red-before was produced by breaking the
thing under test (removing the await), not by breaking an assertion. **No
execution order is pinned.**

### rf2-qw31o — end-to-end acceptance

Mutating `render`'s `:cljs` half **alone**, in the real sidecar, with the fix
in place:

- `api-md-check` → **EXIT 1**, naming the var, both halves, and the remedy
- CLJS probe → **1 failure**, same diagnostic

Restored → both green.

### Not run, and why

`npm run test:browser` selects on `-dom-cljs-test$`. Neither touched namespace
(`presence-real-clock-cljs-test`, `cljs-manifest-probe-cljs-test`) matches, so
the browser build cannot run either file. No mounted behaviour is touched:
bead 1's namespace is headless by design (it schedules an exit directly on the
presence-clock registry and mounts nothing), and bead 2 is pure data
reconciliation. Nothing here can self-skip under node — the assertions were
observed going red.

## Named, not fixed

- **The per-namespace isolation gate does not cover where this class keeps
  appearing.** `implementation/scripts/check-per-ns-isolation.cjs` exists
  precisely for order-dependent passes, but its curated allowlist is 15
  `re-frame.*` frame/image-construction namespaces. Neither this instance nor
  rf2-oslyz's Story ownership namespace is on it. Widening its charter is a
  deliberate decision, not a worker's call.
- **Sibling scan came back clean.** The `js/setTimeout`-beside-a-`ui.test`-verb
  shape in the `*_dom_cljs_test.cljs` family (`callbacks_boundaries`,
  `passive_events`, `react_interop`, and siblings) is a `host-turn!` helper
  awaited *in addition to* the flush Promise — a yield, not a substitute for
  awaiting. The other direct `exec-step!` drivers (`presence_cljs_test.cljc`,
  `step_runner_test.cljc`) use synchronous stub hosts or never reach the
  Promise-backed verb.
