### PR TITLE
test: finish the exact-attempt helper and fixture vocabulary (rf2-wlqfq)

### DIFF
--- a/implementation/machines/src/re_frame/machines/reply.cljc
+++ b/implementation/machines/src/re_frame/machines/reply.cljc
@@ -105,8 +105,9 @@
 ;;                         with no `#n` suffix carries generation 1 for an
 ;;                         ordinary `:spawn`; a `:spawn-all` child reuses this
 ;;                         SAME slot for its runtime-minted join-attempt token,
-;;                         because that exact authority distinguishes reuse of
-;;                         the fixed address without inventing another identity.
+;;                         because that exact-attempt coordinate distinguishes
+;;                         reuse of the fixed address without inventing another
+;;                         identity.
 ;; ---------------------------------------------------------------------------
 
 (defn- generated-actor-generation

--- a/implementation/machines/test/re_frame/join_attempt_effect_path_test.cljc
+++ b/implementation/machines/test/re_frame/join_attempt_effect_path_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.join-authority-effect-path-test
+(ns re-frame.join-attempt-effect-path-test
   "rf2-2lzk8a — keep the `:spawn-all` join-completion transport RESERVED and
   NON-REDIRECTABLE so the framework path can't be captured or suppressed (it is
   a fold-fence protection, not authentication — rf2-cpbjfp).
@@ -323,8 +323,8 @@
     (reg-parent! :jae.ha/rp :jae.ha/ca :jae.ha/cb)
     (rf/dispatch-sync [:jae.ha/rp [:start]])
     (rf/reg-event :jae.ha/forge
-      (fn [_ [_ ev auth]]
-        {:fx [[:rf.machine/join-dispatch {:event ev :rf/join-attempt auth}]]}))
+      (fn [_ [_ ev attempt]]
+        {:fx [[:rf.machine/join-dispatch {:event ev :rf/join-attempt attempt}]]}))
     (let [j          (join-state :jae.ha/rp)
           a          (get-in j [:children :a])
           mismatched {:parent-id :jae.ha/rp :invoke-id [:racing]

--- a/implementation/machines/test/re_frame/join_parallel_attempt_select_test.clj
+++ b/implementation/machines/test/re_frame/join_parallel_attempt_select_test.clj
@@ -1,4 +1,4 @@
-(ns re-frame.join-parallel-authority-select-test
+(ns re-frame.join-parallel-attempt-select-test
   "rf2-wsrtlw — select parallel `:spawn-all` joins by EXACT-ATTEMPT COORDINATE before
   folding.
 
@@ -96,7 +96,7 @@
           (when (= on-complete (get-in js [:spec :on-all-complete])) js))
         (spawned-joins)))
 
-(deftest later-region-folds-only-itself-by-exact-authority
+(deftest later-region-folds-only-itself-by-exact-attempt
   (testing "two active parallel regions reuse child id :worker + event :child/done;
             completing :r2's worker folds ONLY into :r2 — :r1 and its worker are
             untouched, and no attempt-superseded / bad-child evidence fires for
@@ -135,7 +135,7 @@
         (is (empty? (mtest/events-of :rf.error/machine-spawn-all-bad-child-id))
             "no bad-child-id evidence fired for the legitimate carrier")))))
 
-(deftest later-region-failure-folds-only-itself-by-exact-authority
+(deftest later-region-failure-folds-only-itself-by-exact-attempt
   (testing "the failure side: completing :r2's worker via :fail routes the error
             carrier to :r2's join only (:r2 folds :worker into :failed); :r1 is
             untouched and no mis-route evidence fires."

--- a/implementation/machines/test/re_frame/join_parallel_recordable_controls_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_parallel_recordable_controls_cljs_test.cljc
@@ -89,11 +89,11 @@
           (when (= on-complete (get-in js [:spec :on-all-complete])) [invoke js]))
         (spawned-joins)))
 
-(defn- auth-for
+(defn- attempt-for
   "The exact-attempt tuple for `:worker` in the region named by
   `[invoke-id join-state]`, with optional per-key `overrides` (to forge a
   wrong-spawned-id / wrong-invoke carrier)."
-  ([invoke-id js] (auth-for invoke-id js {}))
+  ([invoke-id js] (attempt-for invoke-id js {}))
   ([invoke-id js overrides]
    (merge {:parent-id  parent-kw
            :invoke-id  invoke-id
@@ -103,11 +103,12 @@
           overrides)))
 
 (defn- dispatch-carrier!
-  "Dispatch a completion carrier `[parent [kw child-id]]` carrying `auth` on the
-  recordable `:rf.cofx` fact (nil auth dispatches the bare, unstamped carrier)."
-  [inner auth]
-  (if auth
-    (rf/dispatch-sync [parent-kw inner] {:rf.cofx {:rf.machine/join-attempt auth}})
+  "Dispatch a completion carrier `[parent [kw child-id]]` carrying `attempt` on
+  the recordable `:rf.cofx` fact (nil attempt dispatches the bare, unstamped
+  carrier)."
+  [inner attempt]
+  (if attempt
+    (rf/dispatch-sync [parent-kw inner] {:rf.cofx {:rf.machine/join-attempt attempt}})
     (rf/dispatch-sync [parent-kw inner])))
 
 (defn- stale-reasons []
@@ -175,7 +176,7 @@
     (let [[r2-invoke r2-js] (region-invoke+join [:r2/done])]
       (mtest/reset-captured!)
       (dispatch-carrier! [:child/done :worker]
-                         (auth-for r2-invoke r2-js {:spawned-id :lud4af-par/bogus-instance}))
+                         (attempt-for r2-invoke r2-js {:spawned-id :lud4af-par/bogus-instance}))
       (let [[_ r2'] (region-invoke+join [:r2/done])]
         (is (= #{} (:done r2')) ":r2 folded nothing on the wrong-spawned-id carrier")
         (is (= [:rf.machine.spawn-all/attempt-superseded] (stale-reasons))
@@ -188,7 +189,7 @@
     (let [[r2-invoke r2-js] (region-invoke+join [:r2/done])]
       (mtest/reset-captured!)
       (dispatch-carrier! [:child/done :worker]
-                         (auth-for r2-invoke r2-js {:invoke-id [:r9 :nope]}))
+                         (attempt-for r2-invoke r2-js {:invoke-id [:r9 :nope]}))
       (let [[_ r1'] (region-invoke+join [:r1/done])
             [_ r2'] (region-invoke+join [:r2/done])]
         (is (= #{} (:done r1')) ":r1 folded nothing")
@@ -204,7 +205,7 @@
     (let [[r2-invoke r2-js] (region-invoke+join [:r2/done])]
       (mtest/reset-captured!)
       (dispatch-carrier! [:child/done :ghost]
-                         (auth-for r2-invoke r2-js {:child-id :ghost}))
+                         (attempt-for r2-invoke r2-js {:child-id :ghost}))
       (let [[_ r1'] (region-invoke+join [:r1/done])
             [_ r2'] (region-invoke+join [:r2/done])]
         (is (= #{} (:done r1')) ":r1 folded nothing")

--- a/implementation/machines/test/re_frame/join_reap_auth_test.clj
+++ b/implementation/machines/test/re_frame/join_reap_auth_test.clj
@@ -29,6 +29,16 @@
   pre-fix code: there, the forged shape tears the live actor down with the
   caller-chosen `:rf.machine/join-reaped` reason and no cancellation.
 
+  TERMINOLOGY (rf2-wlqfq census) — the `auth`/AUTHENTICATED vocabulary here is
+  DELIBERATE and stays. This fixture is not about the exact-attempt coordinate:
+  the reap is verified against LIVE join state the caller cannot supply, so
+  membership in `:done ∪ :failed` is genuinely authenticated. Contrast the join
+  coordinate (`join_attempt_effect_path_test`,
+  `join_parallel_attempt_select_test`, the recordable transport/control
+  fixtures), which is caller-suppliable exact-current correlation evidence — a
+  fold FENCE, not authentication — and therefore carries attempt/coordinate
+  names.
+
   JVM-only `.clj`, alongside its sibling reap fixtures in
   `spawn_all_reply_envelope_test`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]

--- a/implementation/machines/test/re_frame/join_recordable_transport_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_recordable_transport_cljs_test.cljc
@@ -2,7 +2,7 @@
   "rf2-t154jx — carry the `:spawn-all` join-attempt coordinate through REPLAY and DELAYED
   dispatch.
 
-  #5839 placed the only exact-attempt credential in METADATA on the inner
+  #5839 placed the only exact-attempt coordinate in METADATA on the inner
   completion event vector. That coordinate did not survive two supported delivery
   paths:
 
@@ -99,7 +99,7 @@
                          :on-all-complete [:all/done]}
                         :on {:abort :idle}}}}))
 
-(defn- auth-for
+(defn- attempt-for
   "Build the exact-attempt tuple a live child :a completion carries, from the
   live join-state."
   [parent-kw]
@@ -135,7 +135,7 @@
 ;; replay-faithful recordable transport
 ;; ---------------------------------------------------------------------------
 
-(deftest recorded-authority-survives-edn-roundtrip-and-folds
+(deftest recorded-attempt-survives-edn-roundtrip-and-folds
   (testing "rf2-t154jx — the exact-attempt coordinate rides the RECORDABLE :rf.cofx fact
             :rf.machine/join-attempt, so an EDN-roundtripped recorded event + causal
             coeffects strict-replays into the SAME fold. Removing the recordable
@@ -145,9 +145,9 @@
     (rf/reg-machine :jt/cb (mk-child :jt/rp))
     (reg-parent! :jt/rp :jt/ca :jt/cb)
     (rf/dispatch-sync [:jt/rp [:start]])
-    (let [auth        (auth-for :jt/rp)
+    (let [attempt     (attempt-for :jt/rp)
           rec-event   (edn-roundtrip [:jt/rp [:child/done :a]])
-          rec-cofx    (edn-roundtrip {:rf.machine/join-attempt auth})]
+          rec-cofx    (edn-roundtrip {:rf.machine/join-attempt attempt})]
       (mtest/reset-captured!)
       ;; Strict replay: redispatch the recorded event PLUS its recorded causal
       ;; coeffects (the `:rf.cofx` map, EDN-roundtripped).
@@ -173,9 +173,9 @@
     (rf/reg-machine :jt/mb (mk-child :jt/mp))
     (reg-parent! :jt/mp :jt/ma :jt/mb)
     (rf/dispatch-sync [:jt/mp [:start]])
-    (let [auth        (auth-for :jt/mp)
+    (let [attempt     (attempt-for :jt/mp)
           ;; The #5839 wire shape: coordinate on inner-event METADATA.
-          meta-event  [:jt/mp (with-meta [:child/done :a] {:rf/join-attempt auth})]
+          meta-event  [:jt/mp (with-meta [:child/done :a] {:rf/join-attempt attempt})]
           replayed    (edn-roundtrip meta-event)]  ;; EDN drops metadata
       (mtest/reset-captured!)
       (rf/dispatch-sync replayed)
@@ -241,16 +241,16 @@
     (rf/reg-machine :jt/ob (mk-child :jt/op))
     (reg-parent! :jt/op :jt/oa :jt/ob)
     (rf/dispatch-sync [:jt/op [:start]])
-    (let [attempt1-auth (auth-for :jt/op)]
+    (let [attempt1-coord (attempt-for :jt/op)]
       ;; Re-enter: attempt 2.
       (rf/dispatch-sync [:jt/op [:abort]])
       (rf/dispatch-sync [:jt/op [:start]])
       (let [j2 (join-state :jt/op)]
-        (is (not= (:attempt attempt1-auth) (:rf/attempt j2)) "attempt 2 minted a new token")
+        (is (not= (:attempt attempt1-coord) (:rf/attempt j2)) "attempt 2 minted a new token")
         (mtest/reset-captured!)
         ;; The stale straggler delivered with attempt-1 coordinate on the cofx.
         (rf/dispatch-sync [:jt/op [:child/done :a]]
-                          {:rf.cofx {:rf.machine/join-attempt attempt1-auth}})
+                          {:rf.cofx {:rf.machine/join-attempt attempt1-coord}})
         (is (= #{} (:done (join-state :jt/op)))
             "the old-attempt delayed completion folded nothing")
         (is (= [:rf.machine.spawn-all/attempt-superseded] (stale-reasons))

--- a/implementation/machines/test/re_frame/spawn_all_authority_catalogue_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_authority_catalogue_test.clj
@@ -2,6 +2,12 @@
   "The AUTHORITATIVE catalogue/schema proof for `:spawn-all` exact-attempt folding
   (rf2-p53o47, completed rf2-2ai15g).
 
+  TERMINOLOGY (rf2-wlqfq census) — `authority` in this namespace name means
+  CANONICAL DOCUMENT authority (`spec/Spec-Schemas.md` + `spec/009-Instrumentation.md`
+  are the authorities these assertions read from), NOT the join coordinate.
+  It therefore keeps the word. Fixtures naming the caller-suppliable join
+  coordinate use attempt/fence language instead.
+
   This pins the normative facts the spec/catalogue reconciliation landed so a
   regression FAILS here rather than drifting the spec silently. Every schema
   assertion validates runtime-produced records against the EXECUTABLE canonical
@@ -290,7 +296,7 @@
           spawned-a (get-in j [:children :a])
           ;; the exact-attempt coordinate a late carrier would present — captured
           ;; from the LIVE attempt so it is genuinely exact-current, not forged.
-          auth      {:parent-id  :sac/tomb
+          attempt   {:parent-id  :sac/tomb
                      :invoke-id  [:racing]
                      :child-id   :a
                      :spawned-id spawned-a
@@ -317,7 +323,7 @@
         ;; (rf2-nsbwft — the metadata slot is not read).
         (mtest/reset-captured!)
         (rf/dispatch-sync [:sac/tomb [:child/done :a]]
-                          {:rf.cofx {:rf.machine/join-attempt auth}})
+                          {:rf.cofx {:rf.machine/join-attempt attempt}})
         (let [after (join-state :sac/tomb [:racing])
               stale (first (mtest/events-of :rf.machine.spawn-all/stale-completion))]
           (is (= #{} (:done after))


### PR DESCRIPTION
Finishes the bounded terminology cleanup that #6222 deliberately left behind, so the caller-suppliable join coordinate stops borrowing authority/credential language it has not earned. Pure vocabulary: no runtime keyword, serialized shape, public API, fold behaviour, accepted source or mismatch-handling change.

## What #6222 left unfinished (confirmed, still present on main)

All four residues named on the bead were verified against `origin/main` before any edit:

- `machines/reply.cljc` still said `because that exact authority distinguishes reuse`.
- `auth-for` / `auth` / `attempt1-auth` coordinate locals survived in the recordable join transport and parallel control fixtures.
- `join_authority_effect_path_test` / `join_parallel_authority_select_test` and the two `*-by-exact-authority` deftests still carried coordinate-facing authority names.
- Per the bead NOTES, `join_recordable_transport_cljs_test` still called the coordinate an "exact-attempt credential".

## Renamed (coordinate-facing)

- `reply.cljc` — the spawn-all work-id slot is an exact-attempt **coordinate**.
- `auth-for` → `attempt-for` plus the `auth` / `attempt1-auth` locals across the transport, parallel-control and catalogue fixtures; "credential" → "coordinate".
- `join_authority_effect_path_test` → `join_attempt_effect_path_test`; `join_parallel_authority_select_test` → `join_parallel_attempt_select_test`; both `*-by-exact-authority` deftests → `*-by-exact-attempt`.

## Preserved, and now classified in-file

The census kept the two fixtures whose authority vocabulary is precise, and wrote the reason into each namespace docstring so the distinction survives the next grep rather than living only in a PR body:

- `join_reap_auth_test` keeps AUTHENTICATED — the reap is verified against **live join state the caller cannot supply**, so membership in `:done ∪ :failed` genuinely is authenticated. The join coordinate, by contrast, is a fold **fence**.
- `spawn_all_authority_catalogue_test` keeps "authority" — it means canonical **document** authority (`Spec-Schemas.md` + `009-Instrumentation.md`), not the coordinate. Its one genuinely coordinate-facing local still moved to `attempt`.

## The discovery trap this bead walks past

A rename bead's real false-green risk is discovery, not assertions: a renamed namespace that a runner stops finding reports as a green run of nothing.

- **JVM** discovers by directory scan (`re-frame.test-quiet.runner`), so renames are picked up automatically.
- **CLJS** discovers by `:ns-regexp "cljs-test$"`. The two `*-cljs-test` namespaces were therefore **deliberately not renamed** — renaming them to `-test` would have silently removed them from `npm run test:cljs`. Only their internal helper/local names changed.

Discovery is positively verified, not assumed: the machines JVM suite reports an **identical 1197 tests / 4172 assertions** before and after, and each renamed namespace runs at exactly the count previously recorded against its old name (9/34 and 2/16). The renamed `attempt_for` helper is confirmed present in the compiled `node-test` bundle for both `-cljs-test` namespaces.

## Proof each changed fixture can still fail

A green run after a rename proves nothing about the rename, so every touched fixture was driven red by breaking the production behaviour it names. Each mutation was reverted; `join.cljc` is byte-for-byte identical to `main`.

| Fixture | Mutation applied to production source | Result |
| --- | --- | --- |
| `join_attempt_effect_path_test` | `join-attempt-current?` accepts any map | **2 failures** |
| `join_recordable_transport_cljs_test` | same | **2 failures** |
| `join_parallel_recordable_controls_cljs_test` | same | **3 failures** |
| `join_parallel_attempt_select_test` | `exact-attempt-match?` dropped from region selection (child-id-only routing — the tooth the fixture's own docstring names) | **4 failures** |
| `spawn_all_authority_catalogue_test` | `:cancelled` tombstone clause removed from the resurrection gate | **3 failures** |

Two findings worth recording: the fence mutation left `join_parallel_attempt_select_test` and the catalogue **green**, because those fixtures name region *selection* and the *tombstone* gate respectively, not the fold fence. Each needed the mutation matching its own claim. `join_reap_auth_test` is a docstring-only change with no assertion touched.

## Quality gates

| Gate | Covers | Result |
| --- | --- | --- |
| `clojure -M:test` from `implementation/machines` | every renamed file, both renamed deftests, the `reply.cljc` comment, and the `.cljc` fixtures on the JVM host | **1197 tests / 4172 assertions, 0 failures** (identical to the pre-change baseline) |
| `npm run test:cljs` from `implementation` | the two `*-cljs-test` namespaces and the renamed `attempt-for` helper on the node host | **10099 tests / 49944 assertions, 0 failures** |
| `clojure -M:test -r re-frame.join-attempt-effect-path-test` | renamed ns is discovered | **9 tests / 34 assertions** |
| `clojure -M:test -r re-frame.join-parallel-attempt-select-test` | renamed ns is discovered | **2 tests / 16 assertions** |

No fixture DSL, matcher library or terminology framework was introduced, and no compatibility alias or provenance check was added — this is a rename plus two classification comments.
