### PR TITLE
test(ci): prove G13 interval containment and wire the G-14 watch-loop arm (rf2-a0i2y, rf2-gv8gr)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -640,7 +640,8 @@ jobs:
     # suite: the compiler slice's .cljc arms genuinely run on the JVM
     # (analyzer/emitters/tree/ui.test), the S1f parity corpus's
     # canonical-form + normalization-N invariants, and the G-14
-    # compile-budget gate (defview expansion p95 + the 02 §8 REPL
+    # compile-budget gate (defview expansion p95, the watch-loop rebuild
+    # delta over the dashboard fixture — rf2-gv8gr — and the 02 §8 REPL
     # re-registration story). Job-level gated like jvm-core: the
     # classifier fires implementation_jvm for implementation/ui/**.
     needs: detect_changed_surfaces

--- a/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
+++ b/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
@@ -226,10 +226,19 @@ takes no build dependency on re-com.
 
 Every stage wires its own gates into CI in that stage, never later. As of 2026-07-18:
 **wired and green** — G-1 (S1, complete; `npm run test:ui-g1` under the noise-robust
-estimator, as CI job `cljs-ui-g1`); G-14's `defview` expansion-p95 arm **only** —
+estimator, as CI job `cljs-ui-g1`); **two of G-14's three arms** —
 `g14_compile_budget_jvm_test.clj` expands three fixture sizes against a 50 ms
-pathology bar in CI job `jvm-ui`, alongside the REPL re-registration story (the gate's
-other two arms are named open below, so G-14 is **not** complete at S1); the S2 family
+pathology bar (`defview` expansion p95) **and** measures the watch-loop rebuild delta
+over an 11-view dashboard-shaped roster against a derived absolute bar (K × the
+per-view pathology bar), both in CI job `jvm-ui` alongside the REPL re-registration
+story. The rebuild arm proves the measured pass actually rebuilt the roster — K
+realisations, K **distinct** template fingerprints, all forced inside the timed span —
+before any duration is compared, so a shrunken, collapsed, or lazily-deferred pass
+cannot report "cheap". Its limit is stated rather than implied: at this roster size the
+absolute bar catches a runaway rebuild but does **not** separate a strictly quadratic
+pass, which needs a namespace-scale roster or a scaling ratio across two roster sizes
+(the suite carries the arithmetic). G-14's third arm is named open below, so G-14 is
+**not** complete at S1; the S2 family
 G-3/G-4/G-5/G-6/G-13 (landed with the S2 slice; S2 core verified
 S3-ready under the rf2-vxgfnd.22 boundary review, which absorbed the real-sub-cache
 graft conformance the S-3 spike left open); the G-8 real-browser matrix **including**
@@ -241,10 +250,9 @@ G-15 atomic-local writer matrix (`npm run test:browser`); G-17 (its advanced arm
 prod-elision build, its dev arms in the `:node-test` and JVM suites); and G-12 (`npm run
 test:ui-isolation`, which fails closed unless both arms run). **Named open** — G-7
 beyond its production-absence arm: the dev↔prod equivalence matrix over generated
-shapes has no test yet; G-14's remaining two arms — the watch-loop rebuild delta,
-which needs the S2+ dashboard fixture, and bounded guide-fixtures CI cost, which needs
-the guide-examples corpus (its wall-clock budget is an S3 stage item) — neither of
-which has an assertion anywhere in the repository, as the gate's own suite states;
+shapes has no test yet; G-14's **remaining** arm — bounded guide-fixtures CI cost,
+which needs the guide-examples corpus (its wall-clock budget is an S3 stage item) —
+which has no assertion anywhere in the repository, as the gate's own suite states;
 G-16's "manifest slot sites present" arm (its cross-emitter
 parity and slot-arity arms do run); G-18, whose fixture and
 `test:ui-facade-isolation` script exist but are self-declared RED and deliberately held

--- a/implementation/scripts/_g13-timing-evidence.test.cjs
+++ b/implementation/scripts/_g13-timing-evidence.test.cjs
@@ -21,6 +21,9 @@
 
 const assert = require('assert/strict');
 
+const fs = require('fs');
+const path = require('path');
+
 const {
   RECORDED_SAMPLES,
   PERCENTILE_CONVENTION,
@@ -30,6 +33,9 @@ const {
   summarizeWarm,
   assertColdIsFirstDrain,
   assertColdOrderControl,
+  assertTimedIntervalDidWork,
+  assertTimedRegionShape,
+  codeOnly,
   buildSummary,
 } = require('./lib/g13-timing-evidence.cjs');
 
@@ -225,10 +231,17 @@ test('assertColdIsFirstDrain rejects a missing pre-hot witness', () => {
 
 const QUEUED_WRITES = 8;
 
+// rf2-a0i2y — each order path now reports its timed cycle's witness PAIR, so the
+// path proves both which state preceded its dispatch AND that its own measured
+// interval contained that dispatch and its commit.
+function pair(preHot) {
+  return { 'pre-hot': preHot, 'post-hot': preHot + QUEUED_WRITES };
+}
+
 test('assertColdOrderControl accepts the causal 0 / queued-writes divergence', () => {
   // Real inverted execution advances :hot by queued-writes before the timer, so a
   // causal witness reports 0 (timing-first) vs 8 (correctness-first).
-  const order = { 'timing-first': 0, 'correctness-first': QUEUED_WRITES };
+  const order = { 'timing-first': pair(0), 'correctness-first': pair(QUEUED_WRITES) };
   assert.equal(assertColdOrderControl(order, QUEUED_WRITES), order);
 });
 
@@ -236,7 +249,7 @@ test('assertColdOrderControl REJECTS a correctness-first witness that stayed 0 (
   // THE TEETH. A witness captured before the timed dispatch stays 0 in BOTH
   // orders — the exact false-green this bead repairs. It must be rejected even
   // though the per-sample cold-first assertion (0 === 0) would still pass.
-  const collapsed = { 'timing-first': 0, 'correctness-first': 0 };
+  const collapsed = { 'timing-first': pair(0), 'correctness-first': pair(0) };
   assert.throws(
     () => assertColdOrderControl(collapsed, QUEUED_WRITES, 'V=100 cold-first order control'),
     /non-causal, vacuous cold-first control/,
@@ -249,7 +262,7 @@ test('assertColdOrderControl REJECTS a correctness-first witness that stayed 0 (
 
 test('assertColdOrderControl rejects a correctness-first witness that advanced by the wrong amount', () => {
   assert.throws(
-    () => assertColdOrderControl({ 'timing-first': 0, 'correctness-first': 16 }, QUEUED_WRITES),
+    () => assertColdOrderControl({ 'timing-first': pair(0), 'correctness-first': pair(16) }, QUEUED_WRITES),
     /did not advance to queued-writes/,
   );
 });
@@ -258,7 +271,7 @@ test('assertColdOrderControl rejects a timing-first witness that left the mount 
   // If the timed cycle did NOT run first, its witness is nonzero and the reported
   // "cold" span is a warmed drain — the control must reject it.
   assert.throws(
-    () => assertColdOrderControl({ 'timing-first': 8, 'correctness-first': QUEUED_WRITES }, QUEUED_WRITES),
+    () => assertColdOrderControl({ 'timing-first': pair(8), 'correctness-first': pair(QUEUED_WRITES) }, QUEUED_WRITES),
     /timing-first witness is not the mount seed/,
   );
 });
@@ -270,8 +283,228 @@ test('assertColdOrderControl rejects a missing order control', () => {
 
 test('assertColdOrderControl rejects a non-positive queued-writes basis', () => {
   assert.throws(
-    () => assertColdOrderControl({ 'timing-first': 0, 'correctness-first': 8 }, 0),
+    () => assertColdOrderControl({ 'timing-first': pair(0), 'correctness-first': pair(8) }, 0),
     /queued-writes must be a positive finite number/,
+  );
+});
+
+test('assertColdOrderControl rejects an order path whose timed interval did no work', () => {
+  // rf2-a0i2y — the divergence can be perfectly causal on a path that measured an
+  // EMPTY interval; each path must carry its own containment proof.
+  assert.throws(
+    () => assertColdOrderControl(
+      { 'timing-first': { 'pre-hot': 0, 'post-hot': 0 }, 'correctness-first': pair(QUEUED_WRITES) },
+      QUEUED_WRITES,
+    ),
+    /\(timing-first\): the measured interval did not contain its own dispatch and commit/,
+  );
+  assert.throws(
+    () => assertColdOrderControl(
+      { 'timing-first': pair(0), 'correctness-first': { 'pre-hot': 8, 'post-hot': 8 } },
+      QUEUED_WRITES,
+    ),
+    /\(correctness-first\): the measured interval did not contain/,
+  );
+});
+
+test('assertColdOrderControl rejects a path degraded back to a witness-free scalar', () => {
+  // The pre-rf2-a0i2y shape reported one number per path. A result still carrying
+  // it has no closing witness at all and must not be accepted.
+  assert.throws(
+    () => assertColdOrderControl({ 'timing-first': 0, 'correctness-first': 8 }, QUEUED_WRITES),
+    /did not report a timed-cycle witness pair/,
+  );
+});
+
+// ----- assertTimedIntervalDidWork: the containment witness (rf2-a0i2y) -------
+//
+// The gap this closes: every other check reads state from BEFORE the timed
+// dispatch, so removing that dispatch entirely leaves them all green — the
+// separate untimed correctness cycle advances app-db and supplies every
+// projection either way, and the runner labels an empty flush interval
+// "dispatch-to-commit".
+
+test('assertTimedIntervalDidWork accepts an interval that advanced :hot by queued-writes', () => {
+  assert.equal(assertTimedIntervalDidWork(0, 8, QUEUED_WRITES), 8);
+  assert.equal(assertTimedIntervalDidWork(24, 32, QUEUED_WRITES), 8);
+});
+
+test('assertTimedIntervalDidWork REJECTS an empty measured interval (the bead\'s false-green)', () => {
+  // The exact defect: `timing-cycle!` dispatches nothing, so its own post-commit
+  // witness never advances, while pre-hot still reports the mount seed.
+  assert.throws(
+    () => assertTimedIntervalDidWork(0, 0, QUEUED_WRITES, 'V=100 cold timing evidence'),
+    /the measured interval did not contain its own dispatch and commit/,
+  );
+  assert.throws(
+    () => assertTimedIntervalDidWork(0, 0, QUEUED_WRITES, 'V=100 cold timing evidence'),
+    /V=100 cold timing evidence/,
+  );
+});
+
+test('assertTimedIntervalDidWork rejects a partial drain and an over-long interval', () => {
+  assert.throws(() => assertTimedIntervalDidWork(0, 7, QUEUED_WRITES), /delta=7, expected 8/);
+  assert.throws(() => assertTimedIntervalDidWork(0, 16, QUEUED_WRITES), /delta=16, expected 8/);
+});
+
+test('assertTimedIntervalDidWork rejects a missing or non-finite witness', () => {
+  assert.throws(
+    () => assertTimedIntervalDidWork(0, undefined, QUEUED_WRITES),
+    /post-hot witness is missing or not a finite number/,
+  );
+  assert.throws(
+    () => assertTimedIntervalDidWork(undefined, 8, QUEUED_WRITES),
+    /pre-hot witness is missing or not a finite number/,
+  );
+  assert.throws(() => assertTimedIntervalDidWork(0, NaN, QUEUED_WRITES), /not a finite number/);
+});
+
+test('assertTimedIntervalDidWork rejects a non-positive queued-writes basis', () => {
+  assert.throws(
+    () => assertTimedIntervalDidWork(0, 0, 0),
+    /queued-writes must be a positive finite number/,
+  );
+});
+
+// ----- assertTimedRegionShape: STRUCTURAL containment (rf2-a0i2y) ------------
+//
+// Containment is a property of the measured region's SHAPE, so it is proven by
+// construction against the fixture source rather than inferred from samples that
+// happen to pass. These tests drive the real `dev.cljs`, then mutate it.
+
+const DEV_FIXTURE_SOURCE = path.join(
+  __dirname, '..', 'ui', 'g13', 're_frame', 'ui', 'g13', 'dev.cljs',
+);
+const DEV_SOURCE = fs.readFileSync(DEV_FIXTURE_SOURCE, 'utf8');
+
+const TIMED_DISPATCH_FORM = '(uit/dispatch! frame [::fixture/step fixture/queued-writes])';
+const TIMED_START_FORM = 'started (js/performance.now)]';
+const TIMED_ELAPSED_FORM = '(let [elapsed-ms (- (js/performance.now) started)]';
+const TIMED_POST_WITNESS_FORM = ':post-hot (:hot (rf/app-db-value frame))';
+
+function mutated(edits) {
+  let out = DEV_SOURCE;
+  for (const [find, replaceWith] of edits) {
+    const next = out.replace(find, replaceWith);
+    // A stale anchor would hand the checker an UNCHANGED source, and "unchanged
+    // passes" reads exactly like "the mutation was caught".
+    assert.notEqual(next, out, `stale tooth anchor — dev.cljs no longer contains: ${find}`);
+    out = next;
+  }
+  return out;
+}
+
+test('assertTimedRegionShape accepts the real fixture: dispatch and commit are inside the span', () => {
+  assert.deepEqual(assertTimedRegionShape(DEV_SOURCE), [
+    'the pre-dispatch app-db witness read',
+    'the interval START timestamp',
+    'the flush! that owns the measured interval',
+    'the timed dispatch',
+    'the interval END timestamp',
+    'the post-commit app-db witness read',
+  ]);
+});
+
+test('assertTimedRegionShape REJECTS the dispatch removed from the flushed thunk', () => {
+  assert.throws(
+    () => assertTimedRegionShape(mutated([[TIMED_DISPATCH_FORM, 'nil']])),
+    /expected exactly 1 dispatch! calls in the timed region, found 0/,
+  );
+});
+
+test('assertTimedRegionShape REJECTS the dispatch replaced with a no-op event', () => {
+  assert.throws(
+    () => assertTimedRegionShape(
+      mutated([[TIMED_DISPATCH_FORM, '(uit/dispatch! frame [::fixture/noop])']]),
+    ),
+    /the timed dispatch is absent from the timed region/,
+  );
+});
+
+test('assertTimedRegionShape REJECTS the dispatch hoisted above the start timestamp', () => {
+  // THE MUTANT THE RUNTIME WITNESS CANNOT SEE. The pre-hot read still precedes
+  // the hoisted dispatch, so post-minus-pre is still exactly queued-writes — yet
+  // the measured span no longer covers the eight write epochs. Only the source
+  // order shows it.
+  assert.throws(
+    () => assertTimedRegionShape(mutated([
+      [TIMED_DISPATCH_FORM, 'nil'],
+      [TIMED_START_FORM, `_ ${TIMED_DISPATCH_FORM}\n        ${TIMED_START_FORM}`],
+    ])),
+    /the timed dispatch does not follow the flush! that owns the measured interval/,
+  );
+});
+
+test('assertTimedRegionShape REJECTS the dispatch moved past the end timestamp', () => {
+  assert.throws(
+    () => assertTimedRegionShape(mutated([
+      [TIMED_DISPATCH_FORM, 'nil'],
+      [TIMED_ELAPSED_FORM, `${TIMED_ELAPSED_FORM}\n                   ${TIMED_DISPATCH_FORM}`],
+    ])),
+    /the interval END timestamp does not follow the timed dispatch/,
+  );
+});
+
+test('assertTimedRegionShape REJECTS the closing witness read moved inside the span', () => {
+  // The closing witness must cost the measured interval nothing; reading it
+  // before the end timestamp would put validation work on the clock.
+  assert.throws(
+    () => assertTimedRegionShape(mutated([
+      [TIMED_ELAPSED_FORM,
+        '(let [post-hot (:hot (rf/app-db-value frame))\n'
+        + '                       elapsed-ms (- (js/performance.now) started)]'],
+      [TIMED_POST_WITNESS_FORM, ':post-hot post-hot'],
+    ])),
+    /the post-commit app-db witness read does not follow the interval END timestamp/,
+  );
+});
+
+test('assertTimedRegionShape rejects an extra timestamp reading inside the region', () => {
+  assert.throws(
+    () => assertTimedRegionShape(mutated([
+      [TIMED_START_FORM, `mid (js/performance.now)\n        ${TIMED_START_FORM}`],
+    ])),
+    /expected exactly 2 performance.now readings in the timed region, found 3/,
+  );
+});
+
+test('assertTimedRegionShape fails loudly when the measured region cannot be located', () => {
+  assert.throws(() => assertTimedRegionShape(''), /fixture source was not readable/);
+  assert.throws(
+    () => assertTimedRegionShape(DEV_SOURCE.replace('(defn- timing-cycle!', '(defn- timed-cycle!')),
+    /could not locate `\(defn- timing-cycle!`/,
+  );
+  assert.throws(
+    () => assertTimedRegionShape(DEV_SOURCE.replace('(defn- correctness-cycle!', '(defn- audit-cycle!')),
+    /could not locate `\(defn- correctness-cycle!`/,
+  );
+});
+
+test('codeOnly blanks strings and comments, preserving offsets — prose cannot satisfy the proof', () => {
+  // The region's docstring genuinely says "dispatch" and "performance"; without
+  // this the ordering would be computed over prose, the byte-slice mistake the
+  // deps-boundary arm already refuses to make.
+  const src = '(a "str ; not-a-comment" b) ; (uit/dispatch! x)\n(c)';
+  const out = codeOnly(src);
+  assert.equal(out.length, src.length, 'offsets must be preserved');
+  assert.equal(out.includes('not-a-comment'), false);
+  assert.equal(out.includes('uit/dispatch!'), false);
+  // The code parens survive in place; only the literal's bytes are blanked.
+  assert.equal(out.indexOf('(a '), 0);
+  assert.equal(out.indexOf('b)'), src.indexOf('b)'));
+  assert.equal(out.endsWith('\n(c)'), true, 'newlines must survive');
+});
+
+test('codeOnly does not let a docstring mention forge the region shape', () => {
+  // Deleting the real dispatch while leaving one NAMED in the docstring must
+  // still fail: the mention lives in a string and is blanked before counting.
+  const forged = mutated([
+    [TIMED_DISPATCH_FORM, 'nil'],
+    ['Returns `{:elapsed-ms', `${TIMED_DISPATCH_FORM} Returns \`{:elapsed-ms`],
+  ]);
+  assert.throws(
+    () => assertTimedRegionShape(forged),
+    /expected exactly 1 dispatch! calls in the timed region, found 0/,
   );
 });
 

--- a/implementation/scripts/lib/g13-timing-evidence.cjs
+++ b/implementation/scripts/lib/g13-timing-evidence.cjs
@@ -91,6 +91,72 @@ function summarizeWarm(raw, where = 'warm timing evidence') {
 // wall-clock threshold; this pins the cold IDENTITY, not its duration.
 const COLD_FIRST_DRAIN_PRE_HOT = 0;
 
+// rf2-a0i2y — DID THE MEASURED INTERVAL CONTAIN ITS OWN DISPATCH AND COMMIT?
+//
+// Every witness above describes state BEFORE the timed dispatch, so none of them
+// can separate a real measured drain from an EMPTY one. Delete the dispatch from
+// `timing-cycle!` and the whole gate stays green: `timing-first` pre-hot is still
+// the mount seed 0, `correctness-first` pre-hot still advances to queued-writes
+// (the SEPARATE untimed correctness cycle advanced it), and that same correctness
+// cycle still supplies every projection — so the runner labels a flush interval
+// that did nothing "dispatch-to-commit" and reports it as evidence.
+//
+// The closing witness is the timed cycle's own POST-commit app-db `:hot`, read
+// AFTER its end timestamp (no validation work enters the measured span) and
+// returned with that same cycle. `post - pre` is exactly the number of writes
+// that committed between the two reads. The reads bracket the two timestamps by
+// construction — nothing but the `performance.now` call itself sits between the
+// pre read and `started`, and nothing but the elapsed subtraction sits between
+// the end timestamp and the post read — so a delta of `queuedWrites` is proof
+// that this interval carried the drain it is named for. A removed, no-op, or
+// hoisted-out dispatch yields 0 (or the wrong delta) and is rejected here.
+//
+// This is the RUNTIME half of the containment proof. The LEXICAL half — dispatch
+// inside the flushed thunk, thunk between the two timestamps — is pinned by
+// `assertTimedRegionShape` below, which reads the fixture source itself.
+function assertTimedIntervalDidWork(pre, post, queuedWrites, where = 'timed interval work witness') {
+  if (typeof queuedWrites !== 'number' || !Number.isFinite(queuedWrites) || queuedWrites <= 0) {
+    throw evidenceFail(
+      `${where}: queued-writes must be a positive finite number; got ${JSON.stringify(queuedWrites)}`,
+    );
+  }
+  for (const [label, value] of [['pre-hot', pre], ['post-hot', post]]) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      throw evidenceFail(
+        `${where}: the timed cycle's ${label} witness is missing or not a finite number ` +
+          `(got ${JSON.stringify(value)}); without both witnesses the measured interval ` +
+          'cannot be shown to contain its own dispatch and commit',
+      );
+    }
+  }
+  const delta = post - pre;
+  if (delta !== queuedWrites) {
+    throw evidenceFail(
+      `${where}: the measured interval did not contain its own dispatch and commit ` +
+        `(pre-hot=${pre}, post-hot=${post}, delta=${delta}, expected ${queuedWrites}); ` +
+        'the timed dispatch-to-commit span was empty, partial, or ran outside the timestamps ' +
+        '— the untimed correctness cycle cannot supply this witness',
+    );
+  }
+  return delta;
+}
+
+// Read one order-control path's witness pair and prove that path's own timed
+// interval did the work. Returns the path's `pre-hot` for the divergence checks.
+function orderWitness(order, path, queuedWrites, where) {
+  const witness = order[path];
+  if (!witness || typeof witness !== 'object') {
+    throw evidenceFail(
+      `${where}: the ${path} order path did not report a timed-cycle witness pair ` +
+        `(got ${JSON.stringify(witness)})`,
+    );
+  }
+  assertTimedIntervalDidWork(
+    witness['pre-hot'], witness['post-hot'], queuedWrites, `${where} (${path})`,
+  );
+  return witness['pre-hot'];
+}
+
 // Assert the cold sample is the first post-mount drain. `where` labels the call
 // site (e.g. "V=100 cold timing evidence"). Returns the sample on success.
 function assertColdIsFirstDrain(cold, where = 'cold timing evidence') {
@@ -130,8 +196,10 @@ function assertColdOrderControl(order, queuedWrites, where = 'cold-first order c
       `${where}: queued-writes must be a positive finite number; got ${JSON.stringify(queuedWrites)}`,
     );
   }
-  const timingFirst = order['timing-first'];
-  const correctnessFirst = order['correctness-first'];
+  // rf2-a0i2y — each order path reports its timed cycle's witness PAIR, and each
+  // path must independently prove its own measured interval did the work.
+  const timingFirst = orderWitness(order, 'timing-first', queuedWrites, where);
+  const correctnessFirst = orderWitness(order, 'correctness-first', queuedWrites, where);
   // The real cold order: the timed cycle ran before any drain, so its witness is
   // the mount seed and the cold-first assertion must ACCEPT it.
   if (timingFirst !== COLD_FIRST_DRAIN_PRE_HOT) {
@@ -166,6 +234,191 @@ function assertColdOrderControl(order, queuedWrites, where = 'cold-first order c
     );
   }
   return order;
+}
+
+// ---------------------------------------------------------------------------
+// rf2-a0i2y — the STRUCTURAL half of the containment proof.
+//
+// The runtime witness above proves the interval did `queuedWrites` of work
+// between the two app-db reads. Those reads sit immediately outside the two
+// timestamps, so the remaining question is purely lexical: is the dispatch
+// actually inside the flushed thunk, and is that thunk actually between the
+// start and end timestamps? That is a property of the fixture's SOURCE, and it
+// is better proven by construction than by any number of green samples — so it
+// is asserted here over `dev.cljs` itself, the same way the lease-free arm
+// asserts its positive controls against `reactive.cljc`.
+//
+// It also closes the one mutant the runtime witness cannot see. Hoisting the
+// dispatch above `started` leaves the post-pre delta at exactly `queuedWrites`
+// (the pre read still precedes the hoisted dispatch), yet the measured span no
+// longer contains the eight write epochs. Only the source order shows that, and
+// the ordering assertion below rejects it.
+// ---------------------------------------------------------------------------
+
+const TIMED_REGION_OPEN = '(defn- timing-cycle!';
+const TIMED_REGION_CLOSE = '(defn- correctness-cycle!';
+
+// Blank out Clojure string literals, `;` comments and `\x` character literals,
+// PRESERVING byte offsets and newlines, so the ordering below is computed over
+// CODE only. This region's docstring legitimately says "dispatch", "pre-hot" and
+// "performance"; a raw indexOf over the text would count prose as structure —
+// precisely the byte-slice mistake the deps-boundary arm already refuses to make
+// (rf2-5e3ic/rf2-han0r). Prose can no longer satisfy — or break — this proof.
+function codeOnly(source) {
+  let out = '';
+  let i = 0;
+  const n = source.length;
+  while (i < n) {
+    const ch = source[i];
+    if (ch === '\\') { // character literal: \( \; \" ...
+      out += ' ';
+      i += 1;
+      if (i < n) { out += source[i] === '\n' ? '\n' : ' '; i += 1; }
+      continue;
+    }
+    if (ch === '"') {
+      out += ' ';
+      i += 1;
+      while (i < n && source[i] !== '"') {
+        if (source[i] === '\\') {
+          out += ' ';
+          i += 1;
+          if (i < n) { out += source[i] === '\n' ? '\n' : ' '; i += 1; }
+          continue;
+        }
+        out += source[i] === '\n' ? '\n' : ' ';
+        i += 1;
+      }
+      if (i < n) { out += ' '; i += 1; }
+      continue;
+    }
+    if (ch === ';') {
+      while (i < n && source[i] !== '\n') { out += ' '; i += 1; }
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+}
+
+function occurrences(haystack, re) {
+  const global = new RegExp(re.source, `${re.flags.replace('g', '')}g`);
+  const found = [];
+  let m = global.exec(haystack);
+  while (m !== null) {
+    found.push(m.index);
+    if (m.index === global.lastIndex) global.lastIndex += 1;
+    m = global.exec(haystack);
+  }
+  return found;
+}
+
+// The measured region's required lexical shape, in required source order. Each
+// row names WHY it is where it is, because the failure message is the only thing
+// a future editor will read.
+const TIMED_REGION_ANCHORS = [
+  {
+    name: 'the pre-dispatch app-db witness read',
+    re: /rf\/app-db-value/,
+    nth: 1,
+    why: 'the opening witness must be read BEFORE the interval starts',
+  },
+  {
+    name: 'the interval START timestamp',
+    re: /js\/performance\.now/,
+    nth: 1,
+    why: 'the measured span opens here',
+  },
+  {
+    name: 'the flush! that owns the measured interval',
+    re: /\(uit\/flush!/,
+    nth: 1,
+    why: 'the flush whose Promise resolution IS the commit must open inside the span',
+  },
+  {
+    name: 'the timed dispatch',
+    re: /\(uit\/dispatch!\s+frame\s+\[::fixture\/step\s+fixture\/queued-writes\]\)/,
+    nth: 1,
+    why: 'the dispatch under measurement must sit INSIDE the flushed thunk, after the start timestamp',
+  },
+  {
+    name: 'the interval END timestamp',
+    re: /js\/performance\.now/,
+    nth: 2,
+    why: 'the measured span closes here, once the commit has resolved',
+  },
+  {
+    name: 'the post-commit app-db witness read',
+    re: /rf\/app-db-value/,
+    nth: 2,
+    why: 'the closing witness must be read AFTER the end timestamp, so it adds no work to the span',
+  },
+];
+
+// Exact multiplicities. Without these an extra `performance.now` or a second
+// dispatch could satisfy the ordering while changing what is measured.
+const TIMED_REGION_COUNTS = [
+  { name: 'performance.now readings', re: /js\/performance\.now/, exactly: 2 },
+  { name: 'app-db witness reads', re: /rf\/app-db-value/, exactly: 2 },
+  { name: 'flush! calls', re: /\(uit\/flush!/, exactly: 1 },
+  { name: 'dispatch! calls', re: /\(uit\/dispatch!/, exactly: 1 },
+];
+
+// Prove, from `devSource`, that the timed region contains its dispatch and its
+// commit BY CONSTRUCTION. Returns the pinned order on success.
+function assertTimedRegionShape(devSource, where = 'G-13 timed region containment') {
+  if (typeof devSource !== 'string' || devSource.length === 0) {
+    throw evidenceFail(`${where}: the fixture source was not readable`);
+  }
+  const open = devSource.indexOf(TIMED_REGION_OPEN);
+  if (open < 0) {
+    throw evidenceFail(
+      `${where}: could not locate \`${TIMED_REGION_OPEN}\` — the measured region this proof ` +
+        'is about no longer exists under that name; re-establish containment before renaming it',
+    );
+  }
+  const close = devSource.indexOf(TIMED_REGION_CLOSE, open);
+  if (close < 0) {
+    throw evidenceFail(
+      `${where}: could not locate \`${TIMED_REGION_CLOSE}\` after the timed region — the proof ` +
+        'delimits the timed cycle by the untimed cycle that must follow it',
+    );
+  }
+  const region = codeOnly(devSource.slice(open, close));
+  for (const { name, re, exactly } of TIMED_REGION_COUNTS) {
+    const n = occurrences(region, re).length;
+    if (n !== exactly) {
+      throw evidenceFail(
+        `${where}: expected exactly ${exactly} ${name} in the timed region, found ${n}. ` +
+          'The measured dispatch-to-commit span is defined by exactly these forms; ' +
+          'adding or removing one changes what the reported number means.',
+      );
+    }
+  }
+  const positions = TIMED_REGION_ANCHORS.map((anchor) => {
+    const at = occurrences(region, anchor.re)[anchor.nth - 1];
+    if (at === undefined) {
+      throw evidenceFail(
+        `${where}: ${anchor.name} is absent from the timed region (${anchor.why}). ` +
+          'A measured interval missing this form does not contain the dispatch and commit it is named for.',
+      );
+    }
+    return { ...anchor, at };
+  });
+  for (let i = 1; i < positions.length; i += 1) {
+    const previous = positions[i - 1];
+    const current = positions[i];
+    if (!(previous.at < current.at)) {
+      throw evidenceFail(
+        `${where}: ${current.name} does not follow ${previous.name} in the timed region ` +
+          `(offsets ${previous.at} then ${current.at}). ${current.why}. The dispatch and commit ` +
+          'are no longer inside the measured span by construction — the reported ' +
+          'dispatch-to-commit number would describe a different region than its label claims.',
+      );
+    }
+  }
+  return positions.map((p) => p.name);
 }
 
 function fmt(x) {
@@ -214,10 +467,15 @@ module.exports = {
   RECORDED_SAMPLES,
   PERCENTILE_CONVENTION,
   COLD_FIRST_DRAIN_PRE_HOT,
+  TIMED_REGION_OPEN,
+  TIMED_REGION_CLOSE,
   warmPercentile,
   validateWarmSamples,
   summarizeWarm,
   assertColdIsFirstDrain,
   assertColdOrderControl,
+  assertTimedIntervalDidWork,
+  assertTimedRegionShape,
+  codeOnly,
   buildSummary,
 };

--- a/implementation/scripts/run-ui-g13.cjs
+++ b/implementation/scripts/run-ui-g13.cjs
@@ -39,6 +39,8 @@ const {
   summarizeWarm,
   assertColdIsFirstDrain,
   assertColdOrderControl,
+  assertTimedIntervalDidWork,
+  assertTimedRegionShape,
   buildSummary,
 } = require('./lib/g13-timing-evidence.cjs');
 
@@ -49,6 +51,12 @@ const DEV = path.join(OUT, 'ui-g13');
 const PROD = path.join(OUT, 'ui-g13-prod');
 const MINT_CONTROL = path.join(OUT, 'ui-g13-mint-control');
 const PROD_MANIFEST = path.join(PROD, 'manifest.edn');
+// rf2-a0i2y — the measured region's own source. The structural containment proof
+// reads it directly, so the claim "the dispatch and commit are inside the timed
+// span" rests on the fixture's shape rather than on samples that happen to pass.
+const DEV_FIXTURE_SOURCE = path.join(
+  IMPL, 'ui', 'g13', 're_frame', 'ui', 'g13', 'dev.cljs',
+);
 const REPORT = path.join(OUT, 'ui-g13.json');
 const TIMEOUT = 90000;
 const SENTINELS = [
@@ -406,6 +414,18 @@ function assertDevResult(result) {
     // proves the timer ran before any correctness dispatch or O(V) audit; a
     // nonzero value means the reported "cold" span is a warmed second dispatch.
     assertColdIsFirstDrain(size.cold, `V=${size.v} cold timing evidence`);
+    // rf2-a0i2y — and the cold interval must have CONTAINED that dispatch. The
+    // check above proves only which state PRECEDED the timed dispatch; it stays
+    // green for an interval that dispatched nothing, because the separate untimed
+    // correctness cycle supplies every projection either way. The timed cycle's
+    // own post-commit witness, read after its end timestamp, closes that: app-db
+    // :hot must have advanced by exactly queued-writes across the measured span.
+    assertTimedIntervalDidWork(
+      size.cold['timing-pre-hot'],
+      size.cold['timing-post-hot'],
+      result['queued-writes'],
+      `V=${size.v} cold timing evidence`,
+    );
     if (!Array.isArray(size.samples) || size.samples.length !== 9) {
       fail(`V=${size.v} did not retain exactly nine warm samples`);
     }
@@ -424,12 +444,78 @@ function assertDevResult(result) {
       if (sample['fixed-shell-idle-cells'] !== 2) {
         fail(`warm sample at V=${size.v}/${sample.label} lost the empty HMR shells`);
       }
+      // rf2-a0i2y — EVERY recorded sample's timed interval, not just the cold
+      // one, must prove it contained its own dispatch and commit.
+      assertTimedIntervalDidWork(
+        sample['timing-pre-hot'],
+        sample['timing-post-hot'],
+        result['queued-writes'],
+        `V=${size.v}/${sample.label} warm timing evidence`,
+      );
     }
     projections.push(size.cold.projection);
   }
   if (projections.length !== 2 || !sameJson(projections[0], projections[1])) {
     fail('count projection is not V-independent');
   }
+}
+
+// rf2-a0i2y — the source anchors the containment teeth rewrite. Held as named
+// constants so a tooth and the fixture cannot drift apart silently.
+const TIMED_DISPATCH_FORM = '(uit/dispatch! frame [::fixture/step fixture/queued-writes])';
+const TIMED_START_FORM = 'started (js/performance.now)]';
+const TIMED_ELAPSED_FORM = '(let [elapsed-ms (- (js/performance.now) started)]';
+const TIMED_POST_WITNESS_FORM = ':post-hot (:hot (rf/app-db-value frame))';
+
+// Apply an ordered list of literal source edits, FAILING LOUDLY if any of them
+// matches nothing. A tooth whose anchor drifted would otherwise hand the checker
+// an unchanged source, and "unchanged source passes" is indistinguishable from
+// "the mutation was caught" — the shape of false-green this whole arm exists to
+// refuse (rf2-jxpf3).
+function mutateSource(source, edits) {
+  let out = source;
+  for (const [find, replaceWith] of edits) {
+    const next = out.replace(find, replaceWith);
+    if (next === out) {
+      fail(
+        `timed-region containment tooth is stale: dev.cljs no longer contains \`${find}\`. ` +
+          'Re-establish the containment proof against the current source rather than deleting the tooth.',
+      );
+    }
+    out = next;
+  }
+  return out;
+}
+
+// The four ways the dispatch can stop being inside the measured span, plus the
+// one way the closing witness can leak INTO it. Each is a real source shape a
+// reviewer could plausibly write, not a JSON edit — the runtime witness alone
+// cannot see the third of these, because hoisting the dispatch above the start
+// timestamp leaves the post-minus-pre delta at exactly queued-writes while the
+// measured span no longer covers the eight write epochs.
+function timedRegionMutations(devSource) {
+  return [
+    ['timed dispatch removed from the flushed thunk', mutateSource(devSource, [
+      [TIMED_DISPATCH_FORM, 'nil'],
+    ])],
+    ['timed dispatch replaced with a no-op event', mutateSource(devSource, [
+      [TIMED_DISPATCH_FORM, '(uit/dispatch! frame [::fixture/noop])'],
+    ])],
+    ['timed dispatch hoisted above the start timestamp', mutateSource(devSource, [
+      [TIMED_DISPATCH_FORM, 'nil'],
+      [TIMED_START_FORM, `_ ${TIMED_DISPATCH_FORM}\n        ${TIMED_START_FORM}`],
+    ])],
+    ['timed dispatch moved past the end timestamp', mutateSource(devSource, [
+      [TIMED_DISPATCH_FORM, 'nil'],
+      [TIMED_ELAPSED_FORM, `${TIMED_ELAPSED_FORM}\n                   ${TIMED_DISPATCH_FORM}`],
+    ])],
+    ['closing witness read moved inside the measured span', mutateSource(devSource, [
+      [TIMED_ELAPSED_FORM,
+        '(let [post-hot (:hot (rf/app-db-value frame))\n'
+        + '                       elapsed-ms (- (js/performance.now) started)]'],
+      [TIMED_POST_WITNESS_FORM, ':post-hot post-hot'],
+    ])],
+  ];
 }
 
 function expectMutationFailure(label, thunk) {
@@ -487,12 +573,45 @@ function assertMutationTeeth(result) {
     // the correctness-first witness would collapse to the mount seed and the gate
     // must go red; timing-first must stay the mount seed; the control cannot vanish.
     ['order control correctness-first collapsed to the mount seed (non-causal witness)', (r) => {
-      r['cold-first-order-control']['correctness-first'] = 0;
+      r['cold-first-order-control']['correctness-first'] = { 'pre-hot': 0, 'post-hot': 8 };
     }],
     ['order control timing-first advanced off the mount seed', (r) => {
-      r['cold-first-order-control']['timing-first'] = 8;
+      r['cold-first-order-control']['timing-first'] = { 'pre-hot': 8, 'post-hot': 16 };
     }],
     ['order control absent', (r) => { delete r['cold-first-order-control']; }],
+    // rf2-a0i2y — the CONTAINMENT teeth. Every check above reads state from
+    // BEFORE the timed dispatch, so all of them stay green when `timing-cycle!`
+    // dispatches nothing: the untimed correctness cycle advances app-db and
+    // supplies every projection regardless, and the runner would go on labelling
+    // an empty flush interval "dispatch-to-commit". The timed cycle's own
+    // post-commit witness must therefore show its span advanced app-db by exactly
+    // queued-writes — on the cold sample, on every warm sample, and on BOTH
+    // fresh-frame order-control paths.
+    ['cold timed interval was empty (post-hot never advanced)', (r) => {
+      r.results[0].cold['timing-post-hot'] = r.results[0].cold['timing-pre-hot'];
+    }],
+    ['cold timed interval committed a partial drain', (r) => {
+      r.results[0].cold['timing-post-hot'] = r.results[0].cold['timing-pre-hot'] + 1;
+    }],
+    ['cold closing witness absent', (r) => { delete r.results[0].cold['timing-post-hot']; }],
+    ['warm timed interval was empty (post-hot never advanced)', (r) => {
+      const sample = r.results[1].samples[4];
+      sample['timing-post-hot'] = sample['timing-pre-hot'];
+    }],
+    ['warm closing witness absent', (r) => {
+      delete r.results[1].samples[0]['timing-post-hot'];
+    }],
+    ['order control timing-first interval was empty', (r) => {
+      const w = r['cold-first-order-control']['timing-first'];
+      w['post-hot'] = w['pre-hot'];
+    }],
+    ['order control correctness-first interval was empty', (r) => {
+      const w = r['cold-first-order-control']['correctness-first'];
+      w['post-hot'] = w['pre-hot'];
+    }],
+    ['order control path degraded to a witness-free scalar', (r) => {
+      r['cold-first-order-control']['timing-first'] = 0;
+    }],
     // rf2-vxgfnd.212 — workload-roster teeth. Each must fail validation, proving
     // the exact one-to-one V=100/V=500 roster before projections are compared.
     // 'duplicate V=100' is the bead's exact false-green: the V=500 row silently
@@ -584,6 +703,14 @@ function assertMutationTeeth(result) {
       `${prodManifest}\n"re_frame/resources/internal/runtime.cljs"`,
     );
   }));
+  // rf2-a0i2y — the STRUCTURAL containment teeth, driven against the real
+  // fixture source rather than a JSON result. Containment is a property of the
+  // measured region's shape, so it is proven by construction here and only
+  // corroborated by the runtime witness above.
+  const devSource = fs.readFileSync(DEV_FIXTURE_SOURCE, 'utf8');
+  for (const [label, mutated] of timedRegionMutations(devSource)) {
+    red.push(expectMutationFailure(label, () => assertTimedRegionShape(mutated)));
+  }
   return red;
 }
 
@@ -619,6 +746,14 @@ async function main() {
   let browser;
   let tearingDown = false;
   try {
+    // rf2-a0i2y — prove containment BY CONSTRUCTION before spending a compile on
+    // measuring anything: the dispatch must be lexically inside the flushed thunk
+    // and that thunk lexically between the two timestamps, with the closing
+    // witness read strictly after the end timestamp. No sample can establish
+    // this, and a green sample set does not need to.
+    const timedRegionOrder = assertTimedRegionShape(
+      fs.readFileSync(DEV_FIXTURE_SOURCE, 'utf8'),
+    );
     shadow('compile', 'ui-g13');
     shadow('release', 'ui-g13-prod', 'ui-g13-mint-control');
     writePage(DEV);
@@ -687,6 +822,14 @@ async function main() {
       status: 'pass',
       correctness: 'exact counts; one post-drain root commit',
       timing: 'evidence-only; no threshold',
+      // rf2-a0i2y — how the measured interval is known to contain the work it is
+      // named for: lexically by construction (this ordered region shape) and, on
+      // every sample and both order-control paths, by the timed cycle's own
+      // post-commit witness. Still no wall-clock threshold.
+      timedIntervalContainment: {
+        structural: timedRegionOrder,
+        runtime: 'timed-cycle post-hot minus pre-hot equals queued-writes',
+      },
       mutationTeeth,
       development: devState.result,
       advanced: { bundles, dom: prodState },

--- a/implementation/ui/g13/re_frame/ui/g13/dev.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/dev.cljs
@@ -85,7 +85,24 @@
   sourced from the timed cycle's own dispatch — not from `sample!` entry — makes
   it causal to the measurement: any drain that preceded this cycle shows up as a
   nonzero witness, so a warmed cycle can never masquerade as the cold first
-  drain. Returns `{:elapsed-ms <ms> :pre-hot <app-db :hot at dispatch>}`."
+  drain.
+
+  rf2-a0i2y — the `:post-hot` CLOSING witness. Every witness above describes
+  state BEFORE the timed dispatch, so none of them can tell a real measured
+  drain from an EMPTY one: delete the dispatch from this function and `:pre-hot`
+  still reports the mount seed, the separate untimed correctness cycle still
+  advances app-db and still supplies every projection, and the runner would go
+  on labelling a flush interval that did nothing `dispatch-to-commit`.
+  `:post-hot` is app-db `:hot` read AFTER the end timestamp — so no validation
+  work enters the measured span — and returned with this same cycle. The gate
+  asserts `post-hot - pre-hot = queued-writes`: the two reads bracket the two
+  timestamps by construction, so that delta is the work this interval actually
+  contained. A removed, no-op, or empty dispatch yields 0 and turns the gate red.
+  The lexical containment itself (dispatch inside the flushed thunk, thunk
+  between the two `performance.now` reads) is pinned structurally by
+  `assertTimedRegionShape` over THIS source region.
+
+  Returns `{:elapsed-ms <ms> :pre-hot <:hot at dispatch> :post-hot <:hot at commit>}`."
   [frame]
   (let [pre-hot (:hot (rf/app-db-value frame))
         started (js/performance.now)]
@@ -94,8 +111,13 @@
            ;; dispatch! completes all eight write epochs synchronously; the
            ;; render phase runs when flush!'s Promise advances to the commit.
            (uit/dispatch! frame [::fixture/step fixture/queued-writes])))
-        (.then (fn [_] {:elapsed-ms (- (js/performance.now) started)
-                        :pre-hot pre-hot})))))
+        (.then (fn [_]
+                 ;; The end timestamp is taken FIRST and bound, so the closing
+                 ;; witness read below cannot land inside the measured span.
+                 (let [elapsed-ms (- (js/performance.now) started)]
+                   {:elapsed-ms elapsed-ms
+                    :pre-hot pre-hot
+                    :post-hot (:hot (rf/app-db-value frame))}))))))
 
 (defn- correctness-cycle!
   "Exact push-work accounting for ONE drain — UNTIMED. Owns the O(V) live-cell
@@ -225,7 +247,12 @@
   FIRST post-mount dispatch. Because it rides the timed cycle rather than being
   read at `sample!` entry, running correctness before timing advances it to
   `queued-writes` and the cold-first control fails; it cannot pass vacuously.
-  The exact counts still come from a cycle never on the clock."
+  The exact counts still come from a cycle never on the clock.
+
+  rf2-a0i2y — `:timing-post-hot` is that same timed cycle's CLOSING witness, read
+  after its end timestamp. Every sample therefore carries the pair the runner
+  needs to prove the measured interval contained its own dispatch and commit:
+  `timing-post-hot` minus `timing-pre-hot` must be `queued-writes` for THIS cycle."
   [root frame v label]
   ;; rf2-6k4cm — the timed cycle runs FIRST and reports its OWN pre-hot witness;
   ;; `:timing-pre-hot` is that witness, so it is causal to the measured dispatch.
@@ -233,11 +260,12 @@
   ;; witness off the mount seed and redden the cold-first control — it can no
   ;; longer stay 0 while the timer measures a warmed second drain.
   (-> (timing-cycle! frame)
-      (.then (fn [{:keys [elapsed-ms pre-hot]}]
+      (.then (fn [{:keys [elapsed-ms pre-hot post-hot]}]
                (-> (correctness-cycle! root frame v label)
                    (.then (fn [c]
                             (assoc c :elapsed-ms elapsed-ms
-                                   :timing-pre-hot pre-hot))))))))
+                                   :timing-pre-hot pre-hot
+                                   :timing-post-hot post-hot))))))))
 
 ;; rf2-6k4cm — the CAUSAL cold-first order control. The gate's `assertColdIsFirstDrain`
 ;; rests on `:timing-pre-hot` being 0 for the cold sample. Forging that field, or
@@ -251,8 +279,10 @@
 ;; runs correctness before timing for real, not a JSON mutation.
 (defn- timed-witness!
   "Mount a FRESH v-sized fixture, run the two cycles in `order` (`:timing-first`
-  or `:correctness-first`), and return the TIMED cycle's own `:pre-hot` witness.
-  Tears the frame down on every exit."
+  or `:correctness-first`), and return the TIMED cycle's own witness PAIR
+  `{:pre-hot _ :post-hot _}` (rf2-a0i2y — the closing witness rides both order
+  paths too, so each fresh-frame path proves its own timed interval did the work,
+  not merely which state preceded it). Tears the frame down on every exit."
   [v order]
   (let [frame (rf/make-frame {:initial-events [[:rf/set-db (fixture/seed v)]]})]
     (-> (uit/with-root [root [ui/frame-provider {:frame frame}
@@ -262,21 +292,23 @@
             ;; the timed cycle runs; the timed cycle must then witness that advance.
             (-> (correctness-cycle! root frame v "order-control")
                 (.then (fn [_] (timing-cycle! frame)))
-                (.then (fn [timed] (:pre-hot timed))))
+                (.then (fn [timed] (select-keys timed [:pre-hot :post-hot]))))
             ;; The true cold order: the timed cycle runs first, so it witnesses 0.
             (-> (timing-cycle! frame)
-                (.then (fn [timed] (:pre-hot timed))))))
-        (.then (fn [pre-hot]
+                (.then (fn [timed] (select-keys timed [:pre-hot :post-hot]))))))
+        (.then (fn [witness]
                  (rf/destroy-frame! frame)
-                 pre-hot)
+                 witness)
                (fn [e]
                  (rf/destroy-frame! frame)
                  (throw e))))))
 
 (defn- order-control!
-  "Report each order's timed-cycle witness for the runner's causal cold-first
-  control: `:timing-first` (expected 0, passes) and `:correctness-first`
-  (expected `queued-writes`, fails)."
+  "Report each order's timed-cycle witness pair for the runner's causal
+  cold-first control: `:timing-first` (`:pre-hot` 0, passes the cold-first
+  assertion) and `:correctness-first` (`:pre-hot` `queued-writes`, fails it).
+  Both pairs also carry the rf2-a0i2y closing witness, so each path proves its
+  own timed interval advanced app-db by exactly `queued-writes`."
   [v]
   (-> (timed-witness! v :timing-first)
       (.then (fn [timing-first]
@@ -363,9 +395,12 @@
                    :affected-viewcells fixture/hot-count
                    :fixed-shell-idle-cells fixture/idle-shell-count
                    ;; rf2-6k4cm — the timed-cycle witness under both cycle orders.
-                   ;; `:timing-first` is the real cold order (0); `:correctness-first`
-                   ;; is a drain before the timer (queued-writes). The runner proves
-                   ;; the cold-first control accepts the former and rejects the latter.
+                   ;; `:timing-first` is the real cold order (:pre-hot 0);
+                   ;; `:correctness-first` is a drain before the timer (:pre-hot
+                   ;; queued-writes). The runner proves the cold-first control accepts
+                   ;; the former and rejects the latter. rf2-a0i2y — each pair also
+                   ;; carries `:post-hot`, so both fresh-frame paths prove their own
+                   ;; timed interval advanced app-db by exactly queued-writes.
                    :cold-first-order-control order
                    :timing-posture "evidence-only; no threshold"
                    ;; rf2-vxgfnd.210 — the explicit candidate-work axis plus the HONEST

--- a/implementation/ui/test/re_frame/ui/g14_compile_budget_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/g14_compile_budget_jvm_test.clj
@@ -13,12 +13,39 @@
   regressions — an accidentally quadratic analyzer pass — not to
   chase microseconds): p95 <= 50ms per expansion.
 
+  WATCH-LOOP REBUILD DELTA over the dashboard fixture (rf2-gv8gr) — what
+  ONE file save costs. A watch-loop rebuild recompiles a whole
+  namespace, so the delta a developer waits for is the expansion of its
+  ENTIRE view roster in one pass, not one view in isolation. That is a
+  different measurement from the p95 arm above, and it is the one the
+  charter names. The budget is derived, not tuned: a rebuild of K views
+  may cost no more than K times the per-view pathology bar already
+  ratified above — what a namespace of pathologically-slow-but-LINEAR
+  views would cost.
+
+  WHAT THIS BAR DOES AND DOES NOT CATCH — stated because an unstated
+  limit is how a gate comes to certify more than it checked. It catches
+  a RUNAWAY rebuild: any regression that pushes one save past K x the
+  per-view pathology bar. It does NOT, at this roster size, separate a
+  strictly quadratic pass. The arithmetic, from this suite's own printed
+  numbers: with K=11 and a measured per-view unit of ~1.6 ms, a linear
+  rebuild costs ~17 ms and a pass where each expansion re-walks its
+  predecessors costs ~K/2 = 5.5x that, ~95 ms — still inside the 550 ms
+  bar. A K x 50 ms bar only separates quadratic from linear once
+  K > ~64. So the quadratic tripwire the G-14 charter asks for needs
+  either a namespace-scale roster or a scaling invariant (a ratio across
+  two roster sizes) rather than an absolute bar; neither is in this
+  bead's scope. The arm below is honest about measuring the rebuild
+  delta and refusing a vacuous measurement; it does not claim the
+  quadratic separation.
+
   ## What is NOT measurable yet (the 07 §5 G-14 remainder)
 
   - the CLJS-emitter half of expansion cost rides shadow-cljs compiles
     (measured implicitly by every CI cljs job's wall clock);
-  - the watch-loop rebuild delta needs the S2+ dashboard fixture;
-  - guide-fixtures CI cost needs the guide-examples corpus (08 §3).
+  - guide-fixtures CI cost needs the guide-examples corpus (08 §3) —
+    still named open, owned by the drafts/guide-fixture-pipeline.md
+    [S3-CONFIRM] item, not by this suite.
 
   ## The REPL story (02 §8, S1 scope)
 
@@ -92,6 +119,139 @@
         "refresh"]]]))
 
 ;; ---------------------------------------------------------------------------
+;; The dashboard fixture (rf2-gv8gr) — the F-dashboard shape, one namespace
+;; ---------------------------------------------------------------------------
+;;
+;; The roster a single watch-loop rebuild re-expands: the F-dashboard shape
+;; shared with G-10 ⟨drafts/g10-bundle-baseline-methodology.md §3⟩ — many views,
+;; mixed capabilities (subs, locals, effects, keyed lists, an error boundary,
+;; presence on one panel), plus the three sizes above so the roster spans the
+;; real range a dashboard namespace holds.
+;;
+;; The bodies are STRUCTURALLY DISTINCT, and that is load-bearing rather than
+;; stylistic: K copies of one body would let the compiler's own caches answer
+;; most of the roster and the arm would measure almost nothing while staying
+;; green. `rebuild-did-work` below enforces distinctness from the expansions
+;; themselves (K distinct template fingerprints), so the roster cannot quietly
+;; collapse into repetition.
+;;
+;; Every interactive affordance is a real control — an `:on-click` on a bare
+;; `:div`/`:li` would (correctly) trip the S4-C a11y roster on every rebuild.
+
+;; The roster is EXPANDED, never evaluated, so the keyed child view below has no
+;; var to resolve against. This is the compiler's own forward/mutual-reference
+;; path, and it keeps the fixture idiomatic: the settings drawer calls a real
+;; keyed child view rather than capturing a `for` binding in a handler.
+(declare ^:rf.ui/view g14-dash-tab)
+
+(def ^:private dashboard-roster
+  [small-form
+   medium-form
+   large-form
+
+   ;; subs + branches: the read-heavy summary strip
+   '(re-frame.ui/defview g14-dash-summary
+      [{:keys [range]}]
+      [:section.summary
+       [:h2 "Summary"]
+       (let [totals (re-frame.ui/sub [:g14/totals range])]
+         [:dl
+          [:dt "open"] [:dd (:open totals)]
+          [:dt "closed"] [:dd (:closed totals)]
+          (when (pos? (:overdue totals)) [:dd.warn (:overdue totals)])])
+       (if (= range :today) [:p.hint "today"] [:p.hint "range"])])
+
+   ;; local + effect: the filter panel's keystroke-latency ephemera
+   '(re-frame.ui/defview g14-dash-filter
+      [{:keys [placeholder]}]
+      (let [[draft set-draft] (re-frame.ui/local "")]
+        (re-frame.ui/effect [draft] (fn [] nil))
+        [:form.filter
+         [:label {:for "g14-q"} "Filter"]
+         [:input#g14-q {:value draft
+                        :placeholder placeholder
+                        :on-change (re-frame.ui/event [e] [:g14/filter e])}]
+         [:button {:on-click [:g14/clear]} "Clear"]]))
+
+   ;; keyed list over an internal view call: the row table
+   '(re-frame.ui/defview g14-dash-rows
+      [{:keys [rows empty-label]}]
+      (if (seq rows)
+        [:table.rows
+         [:tbody
+          (for [r rows]
+            [re-frame.ui.parity-fixtures/list-row {:key (:id r) :item r}])]]
+        [:p.empty empty-label]))
+
+   ;; error boundary: the one panel allowed to fail on its own
+   '(re-frame.ui/defview g14-dash-chart
+      [{:keys [series reset-key]}]
+      [:section.chart
+       (re-frame.ui/error-boundary
+        {:fallback re-frame.ui.parity-fixtures/list-row
+         :reset-key reset-key
+         :on-error [:g14/chart-failed]}
+        [:svg {:viewBox "0 0 100 40" :role "img" :aria-label "trend"}
+         (for [p series]
+           [:circle {:key (:id p) :cx (:x p) :cy (:y p) :r 2}])])])
+
+   ;; presence: declarative enter/exit on the toast rail. Non-focusable
+   ;; children, so the S4-C presence-exit check stays silent.
+   '(re-frame.ui/defview g14-dash-toasts
+      [{:keys [toasts]}]
+      [:aside.toasts
+       (re-frame.ui/presence {:timeout-ms 240}
+                             (for [t toasts]
+                               [:p.toast {:key (:id t) :data-kind (:kind t)}
+                                (:message t)]))])
+
+   ;; the per-row committed slot the grammar requires: a keyed child view owning
+   ;; its own handler, rather than an event vector capturing the `for` binding
+   '(re-frame.ui/defview g14-dash-tab
+      [{:keys [tab current]}]
+      [:button {:class {:active (= tab current)}
+                :aria-current (= tab current)
+                :on-click [:g14/tab tab]}
+       (name tab)])
+
+   ;; nested branching + attribute breadth: the settings drawer
+   '(re-frame.ui/defview g14-dash-settings
+      [{:keys [tab dirty? density]}]
+      [:section.settings {:data-tab (name tab) :aria-busy dirty?}
+       [:nav.tabs
+        (for [t [:general :alerts :access]]
+          [g14-dash-tab {:key t :tab t :current tab}])]
+       (case tab
+         :general [:fieldset [:legend "General"]
+                   [:label {:for "g14-d"} "Density"]
+                   [:select#g14-d {:value density
+                                   :on-change [:g14/density]}
+                    (for [d ["compact" "cosy"]]
+                      [:option {:key d :value d} d])]]
+         :alerts  [:fieldset [:legend "Alerts"]
+                   [:label [:input {:type "checkbox" :checked dirty?
+                                    :on-change [:g14/toggle]}] "email"]]
+         [:p.none "no tab"])])
+
+   ;; the fixed shell: header + footer, sub-free, many literal elements
+   '(re-frame.ui/defview g14-dash-shell
+      [{:keys [title user]}]
+      [:div.shell
+       [:header.bar
+        [:h1 title]
+        [:nav (for [l ["overview" "reports" "audit"]]
+                [:a {:key l :href (str "/" l)} l])]
+        [:span.user {:title user} user]]
+       [:footer.bar
+        [:small "g14 dashboard"]
+        [:button {:on-click {:event [:g14/sign-out] :prevent-default true}}
+         "Sign out"]]])])
+
+;; K — pinned so a roster that silently shrinks cannot measure less work and
+;; stay green. The bar below is derived from it.
+(def ^:private dashboard-view-count 11)
+
+;; ---------------------------------------------------------------------------
 ;; Measurement — expansion runs in THIS ns (internal-view refs resolve)
 ;; ---------------------------------------------------------------------------
 
@@ -111,6 +271,114 @@
       {:p50 (percentile xs 0.5) :p95 (percentile xs 0.95)})))
 
 (def ^:private budget-p95-us 50000.0) ; 50ms — pathology bar, not a race
+
+;; ---------------------------------------------------------------------------
+;; Watch-loop rebuild delta (rf2-gv8gr)
+;; ---------------------------------------------------------------------------
+
+(defn- rebuild-once-us
+  "ONE watch-loop rebuild: expand every view of the dashboard namespace, in
+  source order, in a single pass — what one file save costs in the shared
+  compile pipeline. Returns the elapsed microseconds AND the realisations, so
+  the caller can prove the pass did the work rather than trusting a small number.
+
+  `realised` is bound INSIDE the span deliberately. `mapv` is already eager, but
+  a later edit to a lazy `map` would move every expansion OUT of the measured
+  region — the span would then time nothing, report a tiny number, and the arm
+  would certify that rebuilds are cheap because it never rebuilt anything. That
+  is the exact false-green this arm exists to refuse, so realisation is forced
+  where it is measured rather than left to a property of `mapv` that a one-word
+  change can revoke. `count` is O(1) on a vector and fully walks a lazy seq, so
+  it costs the honest case nothing and denies the lazy case its free pass."
+  []
+  (let [t0 (System/nanoTime)
+        realisations (mapv macroexpand-1 dashboard-roster)
+        realised (count realisations)
+        us (/ (- (System/nanoTime) t0) 1000.0)]
+    {:us us :realised realised :realisations realisations}))
+
+(defn- template-fingerprint
+  "The template fingerprint the compile pipeline stamped into this expansion."
+  [expansion]
+  (->> (tree-seq coll? seq expansion)
+       (keep #(when (map? %) (:template-fingerprint %)))
+       first))
+
+(defn- rebuild-did-work
+  "The anti-vacuity witness. A budget assertion over a pass that expanded
+  nothing is the failure mode this arm exists to refuse: a fast number and a
+  green tick certify that a rebuild is cheap when in fact it never happened.
+  So the pass must be shown to have produced K real `defview` realisations with
+  K DISTINCT template fingerprints — an empty, short, or repetition-collapsed
+  roster fails here before any duration is compared. Returns a description."
+  [realisations]
+  (let [heads (mapv #(when (seq? %) (first %)) realisations)
+        registrations (count (filter #(clojure.string/includes?
+                                       (pr-str %) "register-view!")
+                                     realisations))
+        fingerprints (mapv template-fingerprint realisations)]
+    {:views (count realisations)
+     :all-do-forms? (every? #(= 'do %) heads)
+     :registrations registrations
+     :distinct-fingerprints (count (distinct (remove nil? fingerprints)))}))
+
+;; The bar is DERIVED, not tuned to the measurement. The per-view pathology bar
+;; above (50 ms) is already ratified; a namespace of K such views, expanded
+;; linearly, costs K x that, so a rebuild of this roster may cost no more. It is
+;; a pathology bar in the same spirit as its sibling: generous absolute headroom,
+;; never a microsecond race and never a flaky wall-clock target. Measured
+;; headroom is printed on every run so the margin is visible rather than assumed.
+;;
+;; It catches a RUNAWAY rebuild, not a strictly quadratic one — see the "what
+;; this bar does and does not catch" paragraph in the ns docstring for the
+;; arithmetic. Do not tighten it to chase that separation: a tuned wall-clock
+;; number is the flaky target the G-14 posture forbids, and the quadratic
+;; question wants a different instrument (roster scale, or a ratio across two
+;; roster sizes) rather than a smaller bar.
+(def ^:private rebuild-budget-p95-us (* dashboard-view-count budget-p95-us))
+
+(deftest watch-loop-rebuild-delta-within-budget
+  (let [runs (binding [*ns* (the-ns 're-frame.ui.g14-compile-budget-jvm-test)]
+               ;; warm the pipeline exactly as the p95 arm does, inside the same
+               ;; ns binding the internal-view reference resolves against
+               (dotimes [_ 3] (rebuild-once-us))
+               (vec (repeatedly 20 rebuild-once-us)))
+        witness (rebuild-did-work (:realisations (first runs)))
+        ;; realised INSIDE the measured span, on every run — not once
+        realised (mapv :realised runs)
+        p50 (percentile (map :us runs) 0.5)
+        p95 (percentile (map :us runs) 0.95)]
+    (testing "the measured pass actually rebuilt the whole dashboard roster"
+      ;; Checked BEFORE the budget: a pass that expanded nothing is fast, and
+      ;; "fast" must never be reported as evidence that a rebuild is cheap.
+      (is (= dashboard-view-count (count dashboard-roster))
+          (str "the dashboard roster is not " dashboard-view-count " views: " witness))
+      (is (= dashboard-view-count (:views witness)))
+      (is (every? #(= dashboard-view-count %) realised)
+          (str "every timed pass must have realised all " dashboard-view-count
+               " expansions INSIDE its own measured span: " realised))
+      (is (:all-do-forms? witness)
+          "every roster entry must macroexpand to a real defview realisation")
+      (is (= dashboard-view-count (:registrations witness))
+          (str "every expansion must carry its register-view! call: " witness))
+      (is (= dashboard-view-count (:distinct-fingerprints witness))
+          (str "the roster collapsed into repeated bodies — a rebuild over K "
+               "copies of one view measures almost nothing: " witness)))
+    (testing "one rebuild stays under the derived absolute pathology bar"
+      ;; The per-view unit is printed too: it is the number the ns docstring's
+      ;; "does not catch a quadratic pass at this roster size" arithmetic runs
+      ;; on, so a reader can re-derive that limit from the run itself.
+      (println (format (str "G-14 watch-loop rebuild %d views p50=%8.1fus "
+                            "p95=%8.1fus per-view=%6.1fus budget=%.0fus "
+                            "headroom=%.1fx")
+                       dashboard-view-count (double p50) (double p95)
+                       (/ (double p50) dashboard-view-count)
+                       rebuild-budget-p95-us (/ rebuild-budget-p95-us p95)))
+      (is (< p95 rebuild-budget-p95-us)
+          (str "one watch-loop rebuild of the " dashboard-view-count
+               "-view dashboard namespace exceeded the derived pathology "
+               "budget (" dashboard-view-count " x the 50ms per-view bar = "
+               rebuild-budget-p95-us "us): " p95 "us")))))
 
 (deftest defview-expansion-p95-within-budget
   (let [opts {:warmup 30 :samples 200}


### PR DESCRIPTION
Two CI gate arms that proved less than they claimed.

## 1. `rf2-a0i2y` — the G-13 timed interval now contains its own dispatch and commit

Every G-13 timing control read state from **before** the timed dispatch, so none could tell a measured drain from an empty one. Delete the dispatch from `timing-cycle!` and the gate stayed green: `timing-first` pre-hot was still the mount seed, `correctness-first` pre-hot still advanced (the *separate* untimed correctness cycle advanced it), and that cycle still supplied every projection — so the runner labelled an empty flush interval "dispatch-to-commit" and reported it as evidence.

Containment is now proven twice, **structurally first**.

**Structural (by construction — the primary proof).** `assertTimedRegionShape` reads `dev.cljs` and pins the measured region's lexical shape: pre-dispatch witness read → start timestamp → the `flush!` that owns the interval → the dispatch **inside** that flushed thunk → end timestamp → post-commit witness read, in that order, with exact multiplicities. Strings and comments are blanked (offsets preserved) before any token is located, so prose in the region's own docstring can neither satisfy nor break the proof. This also closes the one mutant no runtime witness can see: hoisting the dispatch above `started` leaves `post − pre` at exactly `queued-writes` while the span no longer covers the eight write epochs.

**Runtime (corroboration).** `timing-cycle!` returns `:post-hot`, read *after* its end timestamp (the elapsed subtraction is bound first, so no validation work enters the span). The gate asserts `post-hot − pre-hot = queued-writes` on the cold sample, all nine warm samples per size, and **both** fresh-frame order-control paths, which now report witness pairs rather than a bare scalar.

## 2. `rf2-gv8gr` — the G-14 watch-loop rebuild delta arm

The arm had no assertion anywhere in the repository. A rebuild recompiles a whole namespace, so the delta is the expansion of its **entire** view roster in one pass. The fixture is the F-dashboard shape shared with G-10 — 11 structurally distinct views (subs, locals, effects, keyed lists, an error boundary, presence, branching, fixed shell). It runs in the existing `jvm-ui` job via `clojure -M:test`: no new workflow, no benchmark framework, no new script.

**The measurement cannot be vacuous.** A budget over a pass that expanded nothing is fast and green — the exact failure this arm refuses. The witness is checked *before* any duration: K realisations, all `do` forms, all carrying `register-view!`, with K **distinct** template fingerprints. Realisation is forced *inside* the timed span rather than left to a property of `mapv` a one-word edit can revoke.

**The bar is derived, not tuned:** K × the already-ratified 50 ms per-view pathology bar — what a namespace of pathologically-slow-but-*linear* views would cost.

**Its limit is stated, not implied.** At this roster size the bar catches a runaway rebuild but does **not** separate a strictly quadratic pass: with K=11 and a measured per-view unit ~1.6 ms, a pass re-walking predecessors costs ~K/2 = 5.5× linear (~95 ms), inside the 550 ms bar; separation appears only once K > ~64. The suite carries that arithmetic and says the quadratic tripwire wants a namespace-scale roster or a scaling ratio, not a tighter number. **No bound was widened, none tuned downward to manufacture teeth, and no retry was added.**

The **guide-fixtures CI cost** arm is untouched and stays named open, owned by the `drafts/guide-fixture-pipeline.md` `[S3-CONFIRM]` item.

## Mutation proof — 17 mutations, 17 red

G-13 (13): 5 real source-shape mutants of `dev.cljs` (dispatch removed / no-op event / hoisted above the start timestamp / moved past the end timestamp; closing witness read moved inside the span), each rejected naming its own fault — the teeth fail loudly if an anchor drifts, so a stale tooth cannot masquerade as a caught mutation. Plus 8 result mutants (cold interval empty / partial / witness absent; warm empty / absent; each order path empty; a path degraded to the witness-free scalar).

End-to-end in the real browser: wrapping the dispatch in `(when false …)` **passes the structural arm** and is caught by the runtime witness (`pre-hot=0, post-hot=0, delta=0`); deleting it outright exits 1.

G-14 (4 + 1 defence): roster shrinks 11→9 → RED; roster collapses to repeated bodies with count intact → RED (9 distinct fingerprints); runaway rebuild → RED (1163805µs > 550000µs); lazy span with forged realised count → RED. Lazy span with the honest in-span count is *neutralised* — the pass still costs ~12.8 ms rather than collapsing to ~0.

## Quality gates

All foreground, run to completion.

| Gate | Result |
|---|---|
| `npm run test:ui-g13` (the G-13 runner, real Chromium) | **PASS**, exit 0 — 47 mutation teeth |
| `implementation/ui` full JVM suite (`clojure -M:test`) | **927 tests / 16127 assertions, 0 failures** (was 926/16121) |
| G-14 namespace alone | 3 tests / 17 assertions, 0 failures |
| `node scripts/_g13-timing-evidence.test.cjs` | **48 passed** (was 31) |
| `node scripts/_changed-surfaces.test.cjs` | **168 passed** — pin unchanged |
| `npm run test:script-policy` | exit 0 |
| `npm run test:script-helpers` | exit 0 |
| `python -m mkdocs build --strict` | built, INFO only |
| `check_ep_status_sync.py` / `check_doc_slugs.py` / `check_synthesis_plan_authority.py` | clean |
| `check-no-hardcoded-paths.sh` / `check-ai-tracking-ratchet.sh` | clean (89 tracked under `ai/`, baseline) |

Measured G-14 numbers on this hardware: 11 views, p50 ~10.7 ms, p95 ~11.7 ms, ~47× headroom.

**The `.github/workflows/test.yml` change is a comment only** — the `jvm-ui` job comment now names the rebuild arm. No job, step, `needs:`, `if:` or `working-directory:` changed, and the 168-assertion workflow-shape pin is unmoved. **CI is the real verification for anything workflow-shaped.**
