### PR TITLE
docs(ui): publish the load-bearing Shadow configuration as a shipped contract (rf2-vxgfnd.196)

### DIFF
--- a/docs/core/how-to/index.md
+++ b/docs/core/how-to/index.md
@@ -14,6 +14,7 @@ This is where most of your time goes: turning a feature request into stages of t
 
 | I want to… | Recipe |
 |---|---|
+| set up a re-frame.ui project — the dependency and the two load-bearing Shadow settings | [Install re-frame.ui and configure Shadow](install-re-frame-ui.md) |
 | boot and mount the app, with hot reload | [Boot and mount an app](boot-and-mount-an-app.md) |
 | add login and keep the user logged in | [Add authentication](add-auth.md) |
 | build a form — local edits, validation, clean submit | [Build a form](build-a-form.md) |

--- a/docs/core/how-to/install-re-frame-ui.md
+++ b/docs/core/how-to/install-re-frame-ui.md
@@ -1,0 +1,126 @@
+# Install re-frame.ui and configure Shadow
+
+Two settings in `shadow-cljs.edn` decide whether your development build tells the truth about itself. They are not tuning knobs and they are not optional: `re-frame.ui` builds its registries by macro expansion at compile time, so a build that skips expansion — or that never runs the reconciliation step — ships registries that are quietly incomplete. Configure both, once, and the problem disappears for the life of the project. Configure neither, or only one, and the build fails closed rather than handing you a plausible lie.
+
+This page is the whole setup: the dependency, the two settings, why each one is load-bearing, the Shadow version we support, what the failures look like, and a smoke test that proves it worked.
+
+## Add the dependency
+
+`re-frame.ui` is a separate artefact from the core library. An app that requires namespaces from both declares both — a direct `:require` deserves a direct dependency.
+
+```clojure
+;; deps.edn
+{:paths ["src"]
+ :deps  {org.clojure/clojure       {:mvn/version "1.12.0"}
+         org.clojure/clojurescript {:mvn/version "1.12.145"}
+
+         day8/re-frame2            {:mvn/version "..."}
+         day8/re-frame2-ui         {:mvn/version "..."}}}
+```
+
+React arrives through npm rather than Clojure — `package.json` carries `react` and `react-dom`, and Shadow resolves them from `node_modules` at compile time.
+
+!!! note "Pre-publication coordinates"
+
+    `day8/re-frame2` and `day8/re-frame2-ui` are not on Clojars yet. Until they are, projects inside a monorepo checkout resolve them with `:local/root`, the way [`examples/ui/minimal-counter`](https://github.com/day8/re-frame2/tree/main/examples/ui/minimal-counter) does. The two Shadow settings below are unaffected by which coordinate style you use.
+
+## The two settings
+
+Put both at the **top level** of `shadow-cljs.edn` — not inside a build. `:build-defaults` applies the hook to every configured build, and Shadow unions the top-level `:cache-blockers` into each build's options, so one declaration covers the whole project.
+
+<!-- rf2:shadow-ui-contract -->
+
+```clojure
+{:cache-blockers #{re-frame.ui}
+ :build-defaults {:build-hooks [(re-frame.ui.compiler.build-hook/hook)]}}
+```
+
+That is the complete contract. Dropping it into an otherwise ordinary config looks like this:
+
+```clojure
+{:deps     {:aliases [:shadow]}
+ :dev-http {8280 "resources/public"}
+
+ :cache-blockers #{re-frame.ui}
+ :build-defaults {:build-hooks [(re-frame.ui.compiler.build-hook/hook)]}
+
+ :builds
+ {:app
+  {:target     :browser
+   :output-dir "resources/public/js"
+   :asset-path "/js"
+   :modules    {:main {:init-fn my.app/run}}}}}
+```
+
+### What the cache blocker does
+
+`re-frame.ui`'s registries are populated as a *side effect* of macro expansion. Shadow's disk cache exists precisely to avoid re-expanding sources it believes are unchanged — which is normally a gift and here is a trap. On a warm daemon start, a source restored from cache contributes nothing to the registries, because the macro that would have registered its members never ran. The build then holds a registry that is missing members it has no way to know are missing.
+
+`:cache-blockers #{re-frame.ui}` tells Shadow never to restore `re-frame.ui` or any source that requires it from disk cache. Registry contents become a pure function of the current build inputs instead of an accident of what the daemon happened to have lying around.
+
+### What the build hook does
+
+The hook is the build-lifecycle adapter. It runs at two stages and owns four jobs:
+
+- **the build transaction** — macro expansion writes to scratch, and at compile-finish the hook reconciles scratch against the authoritative whole-build source graph. Shadow keeps the result only if every later stage succeeds; a downstream failure discards the candidate and the next attempt seeds from the last accepted snapshot.
+- **version-zero retained-output invalidation** — the cache blocker stops sources being *loaded* from disk cache, but Shadow can still enter compile-prepare holding output maps retained by its wider build cache. On a daemon's first accepted pass the hook drops those maps for every blocked source, closing the last path by which un-expanded output could survive.
+- **the cache-blocker check** — the hook validates that the blocker is configured before it opens scratch, and refuses the build if it is not.
+- **digest-carrier projection** — the hook computes the whole-build digest once and patches it into exactly one fixed-width slot in the compiled output, giving the running app a cheap, accurate identity for the build it came from.
+
+Both settings are dev-time machinery. The carrier, sentinel, digest literal, view manifests, and descriptor projections are all `goog.DEBUG`-guarded and vanish from advanced production output — no production bytes, no production work.
+
+## Supported Shadow version
+
+The hook is written against Shadow's 3.4.10 build lifecycle: its compile stages, its `:compiled-at` semantics, and its output projection. **3.4.10 is the sole supported version.**
+
+<!-- rf2:shadow-ui-version -->
+
+```clojure
+;; deps.edn — shadow-cljs's JVM half
+{:aliases
+ {:shadow
+  {:extra-deps {thheller/shadow-cljs {:mvn/version "3.4.10"}}}}}
+```
+
+The two halves of shadow-cljs must match, so pin the same version in `package.json`:
+
+```json
+{"devDependencies": {"shadow-cljs": "3.4.10"}}
+```
+
+!!! warning "Pre-alpha posture"
+
+    Other Shadow versions are untested and unsupported. They may fail outright at compile time, or — worse — publish a stale identity on a warm start. This is a deliberate pre-alpha stance rather than a permanent one: widening to a supported range waits on a multi-version test matrix. Until then, a version mismatch is not a bug report, it is an unsupported configuration.
+
+## When it's misconfigured
+
+Every failure mode here is fail-closed by design. A build that cannot prove its own identity refuses to publish one.
+
+| What's missing | Where it fails | What you see |
+|---|---|---|
+| `:cache-blockers` (hook present) | build, at compile-prepare | `:re-frame.ui.compiler.build-hook/cache-blocker-missing` — *"re-frame.ui dev builds require `:cache-blockers #{re-frame.ui}`; refusing a plausible but incomplete warm-cache digest"*. The `ex-data` carries `:configured` (what you actually set) and `:expected`. |
+| the hook (blocker present or not) | runtime, on namespace load | `re-frame.ui build digest was not finalized. Configure (re-frame.ui.compiler.build-hook/hook) in Shadow :build-hooks and keep re-frame.ui in :cache-blockers.` |
+| carrier drift — the hook ran but the output shape isn't what it requires | build, at compile-finish | `:re-frame.ui.compiler.build-hook/carrier-output-invalid`, e.g. *"re-frame.ui expected exactly one compiled digest carrier output"*. Usually an unsupported Shadow version or a build hook ordering problem. |
+
+The middle row is the one worth internalising. **The cache-blocker check lives inside the hook**, so omitting the hook omits the check too — there is no build-time error to read. The failure surfaces instead when the app loads: the carrier still holds its unpatched sentinel, the digest never validates as a finalized `bd1-` value, and the namespace throws on load rather than letting the app limp along with a false identity. Both `ex-data` maps carry `:recovery :configure-ui-build-hook-and-cache-blocker` — one recovery, because there is one correct configuration.
+
+## Prove it works
+
+The smoke test is short, and worth running once when you set the project up:
+
+1. `npx shadow-cljs watch app` — the build compiles with no `build-hook` error.
+2. Open the page. It renders, and the browser console is free of the "build digest was not finalized" throw.
+3. **Stop the watch and start it again without touching a source file.** This is the step that matters: the second start is a warm daemon, exactly the condition a missing cache blocker breaks. The app must render identically.
+4. Edit a view, save, and confirm hot reload replaces it without a full page load.
+
+Step 3 is the one people skip, and it is the only one that exercises the warm-cache path these settings exist to protect.
+
+Working from a checkout of this repository? `npm run test:ui-digest-carrier` is the in-repo proof, and [`examples/ui/minimal-counter`](https://github.com/day8/re-frame2/tree/main/examples/ui/minimal-counter) is a complete runnable project carrying exactly the configuration above.
+
+## The hook is a host seam, not an API
+
+`re-frame.ui.compiler.build-hook/hook` is a **required host-integration seam**: a versioned contract between re-frame.ui and one specific build tool at one specific version. You name it once in `shadow-cljs.edn` and never again — you don't call it, wrap it, compose it, or reach past it.
+
+Everything else in that namespace is internal implementation and carries no stability promise. `promote-served-generation` in particular is an opt-in helper this repository installs on a single internal build; it is not part of the supported consumer configuration and application code should not reach for it. If you ever find yourself calling into the namespace from application code, the answer is somewhere else — the [API reference](../../api/README.md) carries the surfaces meant for you.
+
+For the normative statement of this contract, see `spec/004C-Roots-and-Mount.md` §2.1.1.

--- a/implementation/ui/scaffold-smoke/test/scaffold_smoke_test.clj
+++ b/implementation/ui/scaffold-smoke/test/scaffold_smoke_test.clj
@@ -22,7 +22,8 @@
    The manifest is the single source of truth: it lives in the README (the
    file authors read) and is parsed here (the file CI runs), so the documented
    claim and the tested contract cannot drift."
-  (:require [clojure.java.io :as io]
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]))
 
@@ -107,14 +108,34 @@
                "  unexpected (on disk, not documented): " (sort (remove allowed on-disk)) "\n"
                "  missing   (documented, not on disk):  " (sort (remove on-disk allowed)))))))
 
+(def ^:private contract-keys [:cache-blockers :build-defaults])
+
+(defn- read-config
+  "Read a shadow-cljs.edn as data. `:default` absorbs the build-tool reader tags
+  (`#shadow/env`) that appear in the monorepo's own config."
+  [file]
+  (edn/read-string {:default (fn [_tag v] v)} (slurp file)))
+
 (deftest shadow-config-carries-the-two-load-bearing-settings
   ;; spec/004C-Roots-and-Mount.md §2.1.1: both are load-bearing on Shadow.
-  (let [shadow (slurp (scaffold-file "shadow-cljs.edn"))]
-    (is (str/includes? shadow ":cache-blockers #{re-frame.ui}")
-        "shadow-cljs.edn dropped :cache-blockers #{re-frame.ui} — warm-cache starts get incomplete registries")
-    (is (re-find #":build-defaults\s+\{:build-hooks\s+\[\(re-frame\.ui\.compiler\.build-hook/hook\)\]\}"
-                 shadow)
-        "shadow-cljs.edn dropped the re-frame.ui.compiler.build-hook build hook")))
+  ;;
+  ;; rf2-vxgfnd.196 — DERIVED, not restated. This test used to spell the two
+  ;; settings as string literals, which made it a copy of the rule checking
+  ;; itself: edit the real configuration and this stayed green. The expected
+  ;; value is now the monorepo's own shadow-cljs.edn, read at run time, so the
+  ;; scaffold is pinned to what the framework actually configures.
+  (let [real (select-keys (read-config (io/file @root "implementation/shadow-cljs.edn"))
+                          contract-keys)]
+    ;; Shape guard first: if the framework config lost the settings, both sides
+    ;; would be {} and the comparison would pass vacuously.
+    (is (= (set contract-keys) (set (keys real)))
+        (str "implementation/shadow-cljs.edn no longer carries both top-level "
+             "settings; found " (sort (keys real))))
+    (is (= real (select-keys (read-config (scaffold-file "shadow-cljs.edn"))
+                             contract-keys))
+        (str "the scaffold's shadow-cljs.edn diverged from the framework's own "
+             "re-frame.ui configuration — a consumer copying this scaffold would "
+             "get incomplete registries on a warm-cache start"))))
 
 (deftest host-page-wires-the-mount-target-and-bundle
   (let [html (slurp (scaffold-file "resources/public/index.html"))]

--- a/implementation/ui/test/re_frame/ui/shadow_config_contract_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/shadow_config_contract_jvm_test.clj
@@ -1,0 +1,225 @@
+(ns re-frame.ui.shadow-config-contract-jvm-test
+  "rf2-vxgfnd.196 — pin the PUBLISHED re-frame.ui Shadow configuration against
+  the repository's own real wiring.
+
+  `docs/core/how-to/install-re-frame-ui.md` ships two settings as a consumer
+  contract:
+
+      :cache-blockers #{re-frame.ui}
+      :build-defaults {:build-hooks [(re-frame.ui.compiler.build-hook/hook)]}
+
+  and a supported shadow-cljs version. This suite proves the published text
+  still matches what the repository ACTUALLY configures — never a fourth
+  hand-copy of the rule.
+
+  THE DESIGN CONSTRAINT, and the whole point of the bead: this namespace
+  contains NO literal expected value. It never spells `#{re-frame.ui}`, never
+  spells the hook form, never spells a version number. The expected value IS
+  `implementation/shadow-cljs.edn`, read at run time. The only literals here are
+  the KEY names being compared at (`:cache-blockers`, `:build-defaults`) and the
+  markdown anchors — coordinates, not truth. A gate that restates the rule can
+  only ever confirm its own copy of it (the rf2-5e3ic failure mode: gates that
+  answered `true` for a 404 and for a path outside the repo).
+
+  Three holders, compared as DATA:
+
+    1. the published page       docs/core/how-to/install-re-frame-ui.md
+    2. this repo's own build    implementation/shadow-cljs.edn        (top level)
+    3. the consumer scaffold    examples/ui/minimal-counter/shadow-cljs.edn
+
+  Each is a separate lever: mutate any ONE of the three and this suite reds,
+  naming which holder diverged.
+
+  Shape assertions run BEFORE any comparison (the
+  `frame-destroyed-op-schema-jvm-test` precedent): a moved anchor, a deleted
+  fence, or an emptied setting THROWS with a diagnosis rather than silently
+  comparing two nils and passing."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]))
+
+;; ---------------------------------------------------------------------------
+;; Locating the repo — cwd-independent, no hardcoded depth
+;; ---------------------------------------------------------------------------
+
+(def ^:private page-rel "docs/core/how-to/install-re-frame-ui.md")
+(def ^:private impl-config-rel "implementation/shadow-cljs.edn")
+(def ^:private example-config-rel "examples/ui/minimal-counter/shadow-cljs.edn")
+(def ^:private example-deps-rel "examples/ui/minimal-counter/deps.edn")
+(def ^:private impl-package-rel "implementation/package.json")
+
+(defn- repo-root
+  "Walk up from the working dir until a directory holds BOTH the published page
+  and this repo's own shadow config. `clojure -M:test` runs from
+  implementation/ui; CI and editors may start elsewhere."
+  []
+  (or (some (fn [dir]
+              (let [d (.getCanonicalFile (io/file dir))]
+                (when (and (.isFile (io/file d page-rel))
+                           (.isFile (io/file d impl-config-rel)))
+                  d)))
+            (take 8 (iterate #(io/file % "..") (io/file "."))))
+      (throw (ex-info "rf2-vxgfnd.196: cannot locate the repo root"
+                      {:looking-for [page-rel impl-config-rel]
+                       :cwd (System/getProperty "user.dir")}))))
+
+(def ^:private root (delay (repo-root)))
+
+(defn- slurp-rel [rel]
+  (let [f (io/file @root rel)]
+    (when-not (.isFile f)
+      (throw (ex-info "rf2-vxgfnd.196: a compared holder is missing"
+                      {:missing rel})))
+    (slurp f)))
+
+(defn- read-config
+  "Read a shadow-cljs.edn / deps.edn as data. `:default` absorbs build-tool
+  reader tags (`#shadow/env`) that appear deeper in this repo's config."
+  [rel]
+  (edn/read-string {:default (fn [_tag v] v)} (slurp-rel rel)))
+
+;; ---------------------------------------------------------------------------
+;; The published page — parsed out of the markdown at run time
+;; ---------------------------------------------------------------------------
+
+(defn- anchored-block
+  "The body of the fenced ```<lang> block immediately following the HTML comment
+  anchor `<!-- anchor -->`. Throws when the anchor or its fence is gone, so
+  moving either reds here instead of quietly yielding nil."
+  [markdown anchor lang]
+  (let [pat  (re-pattern (str "(?s)<!--\\s*" (java.util.regex.Pattern/quote anchor)
+                              "\\s*-->\\s*```" lang "\\r?\\n(.*?)```"))
+        body (second (re-find pat markdown))]
+    (when (str/blank? (str body))
+      (throw (ex-info (str "rf2-vxgfnd.196: no ```" lang " block follows the "
+                           anchor " anchor in the published page")
+                      {:page page-rel :anchor anchor})))
+    body))
+
+(defn- published-contract
+  "The two-setting map the page publishes, as data."
+  []
+  (let [form (edn/read-string (anchored-block (slurp-rel page-rel)
+                                              "rf2:shadow-ui-contract"
+                                              "clojure"))]
+    (when-not (map? form)
+      (throw (ex-info "rf2-vxgfnd.196: the published contract block is not a map"
+                      {:read form})))
+    form))
+
+(defn- published-shadow-version
+  "The shadow-cljs version the page publishes, dug out of the `:shadow` alias it
+  shows. Reads the coordinate the page actually prints — no version literal
+  lives in this file."
+  []
+  (let [form (edn/read-string (anchored-block (slurp-rel page-rel)
+                                              "rf2:shadow-ui-version"
+                                              "clojure"))
+        v    (->> (get-in form [:aliases :shadow :extra-deps])
+                  (keep (fn [[sym coord]]
+                          (when (= "shadow-cljs" (name sym)) (:mvn/version coord))))
+                  first)]
+    (when (str/blank? (str v))
+      (throw (ex-info "rf2-vxgfnd.196: the published version block carries no shadow-cljs coordinate"
+                      {:read form})))
+    v))
+
+;; ---------------------------------------------------------------------------
+;; The real holders
+;; ---------------------------------------------------------------------------
+
+(def ^:private contract-keys [:cache-blockers :build-defaults])
+
+(defn- top-level-contract
+  "The contract slice of a real shadow-cljs.edn — the source of truth this gate
+  compares the published page AGAINST."
+  [rel]
+  (select-keys (read-config rel) contract-keys))
+
+(defn- deps-shadow-version [rel]
+  (->> (get-in (read-config rel) [:aliases :shadow :extra-deps])
+       (keep (fn [[sym coord]]
+               (when (= "shadow-cljs" (name sym)) (:mvn/version coord))))
+       first))
+
+(defn- npm-shadow-version
+  "The npm half's pin, read straight out of package.json. Regex rather than a
+  JSON dependency: this artefact's test classpath carries no JSON reader, and
+  the value is still DERIVED from the real file."
+  [rel]
+  (second (re-find #"\"shadow-cljs\"\s*:\s*\"([^\"]+)\"" (slurp-rel rel))))
+
+;; ---------------------------------------------------------------------------
+;; Shape guards — run before any comparison
+;; ---------------------------------------------------------------------------
+
+(deftest source-of-truth-is-non-vacuous
+  (testing "this repo's own build actually carries both settings, non-empty"
+    ;; Without this, deleting the settings from ALL holders would make every
+    ;; comparison below `{} = {}` and the suite would pass on a repo that no
+    ;; longer configures re-frame.ui at all.
+    (let [real (top-level-contract impl-config-rel)]
+      (is (= (set contract-keys) (set (keys real)))
+          (str impl-config-rel " no longer carries both top-level settings; "
+               "found " (sort (keys real))))
+      (is (and (set? (:cache-blockers real)) (seq (:cache-blockers real)))
+          (str impl-config-rel " :cache-blockers is not a non-empty set"))
+      (let [hooks (get-in real [:build-defaults :build-hooks])]
+        (is (and (vector? hooks) (seq hooks))
+            (str impl-config-rel " :build-defaults :build-hooks is not a non-empty vector"))))))
+
+(deftest published-page-is-parseable
+  (testing "both anchors resolve to blocks that read as data"
+    ;; anchored-block / published-* throw on a moved anchor; calling them here
+    ;; converts that into a named failure rather than an error inside a
+    ;; comparison test.
+    (is (map? (published-contract)))
+    (is (string? (published-shadow-version)))))
+
+;; ---------------------------------------------------------------------------
+;; The drift comparisons — three levers, one per holder
+;; ---------------------------------------------------------------------------
+
+(deftest published-contract-matches-this-repos-own-build
+  (testing "the page publishes exactly what implementation/shadow-cljs.edn configures"
+    (is (= (top-level-contract impl-config-rel) (published-contract))
+        (str "the published snippet in " page-rel " has drifted from "
+             impl-config-rel ". Reconcile the page against the real build "
+             "config — the config is the source of truth."))))
+
+(deftest published-contract-matches-the-consumer-scaffold
+  (testing "the runnable example carries exactly what the page tells consumers to write"
+    (is (= (top-level-contract example-config-rel) (published-contract))
+        (str "the published snippet in " page-rel " has drifted from "
+             example-config-rel ". A consumer copying the page would not get "
+             "the scaffold's configuration."))))
+
+(deftest the-two-real-configs-agree
+  (testing "this repo and the scaffold configure re-frame.ui identically"
+    ;; Transitively implied by the two tests above, but asserted directly so a
+    ;; failure names the two configs rather than blaming the page.
+    (is (= (top-level-contract impl-config-rel)
+           (top-level-contract example-config-rel))
+        (str impl-config-rel " and " example-config-rel
+             " no longer configure re-frame.ui the same way."))))
+
+;; ---------------------------------------------------------------------------
+;; Version posture — 3.4.10 sole supported (bead ruling 2026-07-15), lockstep
+;; ---------------------------------------------------------------------------
+
+(deftest published-version-matches-every-pin
+  (testing "the supported version on the page is the version actually pinned"
+    (let [published (published-shadow-version)
+          npm       (npm-shadow-version impl-package-rel)
+          example   (deps-shadow-version example-deps-rel)]
+      (is (not (str/blank? (str npm)))
+          (str "no shadow-cljs pin found in " impl-package-rel))
+      (is (not (str/blank? (str example)))
+          (str "no thheller/shadow-cljs coordinate found in " example-deps-rel))
+      (is (= published npm)
+          (str "the page's supported shadow-cljs version (" published ") has "
+               "drifted from " impl-package-rel " (" npm ")"))
+      (is (= published example)
+          (str "the page's supported shadow-cljs version (" published ") has "
+               "drifted from " example-deps-rel " (" example ")")))))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -182,6 +182,7 @@ nav:
     - "Run to completion (detail)": core/run-to-completion.md
     - "How-to recipes":
       - core/how-to/index.md
+      - "Install re-frame.ui and configure Shadow": core/how-to/install-re-frame-ui.md
       - "Boot and mount an app": core/how-to/boot-and-mount-an-app.md
       - "Add auth": core/how-to/add-auth.md
       - "Build a form": core/how-to/build-a-form.md


### PR DESCRIPTION
Closes rf2-vxgfnd.196.

A consumer of `day8/re-frame2-ui` must configure two top-level Shadow settings. Both were documented only in `spec/004C-Roots-and-Mount.md` §2.1.1, the `build_hook.clj` docstring, and one example — zero hits for `cache-blockers` or `build-hooks` anywhere under `docs/`. A fresh consumer following tracked user-facing documentation could install the artefact but could not obtain a supported watch/HMR build.

## The page

`docs/core/how-to/install-re-frame-ui.md`, nav entry **Core → How-to recipes → "Install re-frame.ui and configure Shadow"** (first row, before "Boot and mount an app"), plus a row in the how-to index's "Build it" table.

It covers the dependency, the two settings, the distinct correctness job each one does, the Shadow **3.4.10 sole-supported** posture with its pre-alpha disclaimer (bead ruling, 2026-07-15), the fail-closed diagnostics, a warm-start smoke checklist, and the hook catalogued as a **required host-integration seam** rather than an application API (`promote-served-generation` explicitly marked internal).

The diagnostics table names all three real failure modes, including the one that is easy to miss: **the cache-blocker check lives inside the hook**, so omitting the hook omits the check — there is no build-time error, and the failure surfaces instead as the runtime "build digest was not finalized" throw when the unpatched sentinel fails `bd1-` validation.

## How the gate derives rather than restates

`implementation/ui/test/re_frame/ui/shadow_config_contract_jvm_test.clj` contains **no literal expected value** — it never spells `#{re-frame.ui}`, never spells the hook form, never spells a version number. The expected value *is* `implementation/shadow-cljs.edn`, read at run time. The only literals are the key names being compared at and the markdown anchors: coordinates, not truth.

Three holders, compared as data — each with its own lever:

1. the published page (parsed from `<!-- rf2:shadow-ui-contract -->` at run time)
2. `implementation/shadow-cljs.edn` (top-level slice)
3. `examples/ui/minimal-counter/shadow-cljs.edn`

Version posture is derived the same way: the page's `:shadow` alias coordinate is compared against `implementation/package.json` and the scaffold's `deps.edn`.

Shape assertions run **before** any comparison (the `frame-destroyed-op-schema-jvm-test` precedent), so a moved anchor errors with a diagnosis instead of silently comparing nils. A non-vacuity guard on the source of truth stops an all-deleted repo passing on `{} = {}`.

## The scaffold-smoke restatement — fixed

`scaffold_smoke_test.clj` lines 110-117 hardcoded both settings as string literals: a copy of the rule checking itself, which stayed green when the real configuration changed underneath it. That is exactly the defect this bead exists to prevent. It now derives its expected value from the monorepo config. Arm B below is the proof — the old version would have stayed green there.

## Quality gates

All foreground, run to completion.

| Gate | Result |
|---|---|
| `python -m mkdocs build --strict` | clean, built in 17.71s |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `cd implementation/ui && clojure -M:test` | **934 tests / 16149 assertions, 0 failures** (baseline ~928 / ~16132; +6 / +12 from the new gate) |
| `cd implementation/ui/scaffold-smoke && clojure -M:test` | **7 tests / 16 assertions, 0 failures** |
| `node implementation/scripts/_changed-surfaces.test.cjs` | **168 passed** |
| `sh scripts/check-no-hardcoded-paths.sh` | portability gate OK |

### Per-arm teeth proof

Each arm got its own lever, and each was reverted before the next. Green arms are noted where staying green is the *correct* answer.

| Arm | Mutation | Result |
|---|---|---|
| **A** | published page snippet only | **2 failures** — both page↔real comparisons. `the-two-real-configs-agree` correctly green (the configs still agree). |
| **B** | `implementation/shadow-cljs.edn` only | **2 gate failures** + **1 scaffold-smoke failure**. `published-contract-matches-the-consumer-scaffold` correctly green. |
| **C** | `examples/ui/minimal-counter/shadow-cljs.edn` only | **2 gate failures** + **1 scaffold-smoke failure**. `published-contract-matches-this-repos-own-build` correctly green. |
| **D** | page's version coordinate → `3.9.99` | **2 failures** — both pins (`package.json`, scaffold `deps.edn`). |
| **E** | anchor renamed | **3 errors**, each naming the page and the missing anchor — a moved anchor reds, never silently passes. |
| **F** | both settings deleted from the source of truth | **5 failures**, including all three non-vacuity guards. |

`implementation/shadow-cljs.edn` is hot-zone: **confirmed free at edit time** (no open PR or live worker touching it), mutated only temporarily for arms B and F, and reverted via `git checkout` — its committed diff is empty.

## Scope

Out of scope and deliberately untouched: `rf2-vxgfnd.195`'s synthetic arms, and `rf2-ftb3s` (the setup skill omitting both settings, sequenced after this). The gate could be extended to cover `docs/skills/re-frame2-setup.md` as a fourth holder once `rf2-ftb3s` adds the settings there — one more anchored block and one more comparison, no structural change.
