### PR TITLE
docs(EP): make re-frame.ui operational state durable rather than pseudo-live (rf2-vxgfnd.296)

### DIFF
--- a/docs/EP/EP-0030-the-compiled-view-substrate-program.md
+++ b/docs/EP/EP-0030-the-compiled-view-substrate-program.md
@@ -260,11 +260,14 @@ the removed surface survive.
 
 The program epic is **`rf2-vxgfnd`** (`EPIC: re-frame.ui program (S1–S7)`), with
 per-stage child epics filed at the *prior* stage boundary so every brief cites
-then-current contracts. Status at this EP's acceptance: **S1 and S2 are merged**
-(S1's six children landed 2026-07-12; S2 core verified S3-ready under the
-`rf2-vxgfnd.22` adversarial boundary review), and **S3 is in flight** as epic
-`rf2-vxgfnd.95` with children `.95.1`–`.95.10` plus the directed readiness children
-(`rf2-8k14ia`, `rf2-ri0k6n`, `rf2-isdqjv`). Trigger-gated spikes (`ui/tpl`, registered
+then-current contracts. **S1 and S2 merged** (S1's six children landed 2026-07-12;
+S2 core verified S3-ready under the `rf2-vxgfnd.22` adversarial boundary review);
+**S3 closed 2026-07-18** as epic `rf2-vxgfnd.95`, its children `.95.1`–`.95.10` and
+the directed readiness children (`rf2-8k14ia`, `rf2-ri0k6n`, `rf2-isdqjv`) closed
+with it; and **S4** (`rf2-vxgfnd.96`) closed and was declared conforming. The stages
+after S4 ride their own epics — S5 `rf2-vxgfnd.97`, S6 `rf2-vxgfnd.98`, S7
+`rf2-vxgfnd.99`. This paragraph records stages that have closed; for a stage still in
+flight the epic is the state, not this page. Trigger-gated spikes (`ui/tpl`, registered
 `ui/view`, `ui/portal`, `defview-alias`, reset-key `local`) sit on the program epic,
 not in stage scope, until their named triggers fire. The **re-com native port is a
 separate directed epic, `rf2-6ajm6z`** — deliberately not a program stage, so component
@@ -340,6 +343,7 @@ rebuilds the playground. Sibling EPs name per-domain impacts.
 Keep EP-0030 `accepted` while the stages land; it moves to `final` when S7 completes —
 every gate green, the demand-bar prune done, **Helix removed** behind the soak gates, and
 the retained adapters' continued-support posture recorded in their spec homes. The
-program's shape is already proving itself: two stages merged under adversarial boundary
-reviews, the third in flight, and the first external consumer (re-com) driving real
-contract work through the API freeze's own delta protocol rather than around it.
+program's shape is already proving itself: S1–S3 merged under adversarial boundary
+reviews, S4 closed and declared conforming, and the first external consumer (re-com)
+driving real contract work through the API freeze's own delta protocol rather than
+around it.

--- a/docs/EP/EP-0032-re-frame-ui-reactivity-and-ownership.md
+++ b/docs/EP/EP-0032-re-frame-ui-reactivity-and-ownership.md
@@ -302,17 +302,19 @@ live on per EP-0030).
 ## Implementation-Errata Ledger
 
 Per EP-0009, `final` asserts the decisions are settled — this ledger tracks the
-known build gaps on this EP's surface. Rows cite live beads and are struck as
-they close; the full S2 correction tail lives on the program epic
-(`rf2-vxgfnd`).
+known build gaps on this EP's surface, and per EP-0009 its rows cite live bead ids
+and are struck as they close. A struck row is closed, and closed is terminal, so it
+cannot go stale; an unstruck row names the bead that owns the gap, and that bead —
+not this table — is the gap's current state. The full S2 correction tail lives on
+the program epic (`rf2-vxgfnd`).
 
-| Live bead | Gap |
+| Bead | Gap |
 |---|---|
 | `rf2-vxgfnd.166` | render batches must be defined by host checkpoint, not router drain (the G-5 boundary prose) |
 | `rf2-vxgfnd.167` | per-epoch render-law sweep incomplete (force-tracked ai) |
-| `rf2-vxgfnd.169` | empty root-incarnation entries not pruned after weak member collection |
-| `rf2-vxgfnd.204` | CLJS SSR emitter not replayed when `re-frame.ui/adapter` is reinstalled |
-| `rf2-vxgfnd.94.15`, `.94.17`–`.94.21` | compatible-HMR migration evidence/drift-guard family (`.94.16` already closed) |
+| ~~`rf2-vxgfnd.169`~~ | ~~empty root-incarnation entries not pruned after weak member collection~~ — closed |
+| ~~`rf2-vxgfnd.204`~~ | ~~CLJS SSR emitter not replayed when `re-frame.ui/adapter` is reinstalled~~ — closed |
+| ~~`rf2-vxgfnd.94.15`, `.94.17`–`.94.21`~~ | ~~compatible-HMR migration evidence/drift-guard family~~ — closed (`.94.16` closed earlier) |
 
 ## Recommendation
 

--- a/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
+++ b/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
@@ -259,8 +259,10 @@ parity and slot-arity arms do run); G-18, whose fixture and
 out of the required matrix until they go green; G-2/G-9 (wire with the stages shipping
 their subjects); root-manifest hydration + failed-root isolation (S5 — the S-4 spike
 passed dual-host structural output only); G-10 and the remaining
-absence/equivalence/budget gates plus the one-time W11 trio table (S6). S3 has landed
-and S4 is in flight; S5–S7 have not started.
+absence/equivalence/budget gates plus the one-time W11 trio table (S6). S3 closed
+2026-07-18, and S4 (`rf2-vxgfnd.96`) closed and was declared conforming. The stages
+after S4 ride their own epics — S5 `rf2-vxgfnd.97`, S6 `rf2-vxgfnd.98`, S7
+`rf2-vxgfnd.99`; for a stage still in flight the epic is the state, not this page.
 
 ## Rationale
 

--- a/docs/EP/EP-0035-component-library-readiness.md
+++ b/docs/EP/EP-0035-component-library-readiness.md
@@ -78,8 +78,9 @@ Non-goals:
   (R-8 below) deliberately matches the XState-v6 duration ruling.
 - **Specs:** `spec/004-Views.md`, `spec/004B-UI-Tree-and-Conversion.md`,
   `spec/006-ReactiveSubstrate.md`, `008-Testing`, `009-Instrumentation`.
-- **Provenance (local working analyses; `ai/` is local-only, content restated
-  in beads):** the owning delta doc — graduated into this EP + the P0/P1 spec homes
+- **Provenance (working analyses; `ai/` is local-only by default, with a few trees
+  force-tracked as a temporary exception — `git ls-files ai/` is the roster — and
+  content restated in beads):** the owning delta doc — graduated into this EP + the P0/P1 spec homes
   (`spec/004-Views.md`, `spec/004B-UI-Tree-and-Conversion.md`,
   `spec/006-ReactiveSubstrate.md`, `spec/008-Testing.md`, `spec/009-Instrumentation.md`),
   from the tombstoned `drafts/component-library-readiness.md` (rf2-mgy7pz);
@@ -238,7 +239,7 @@ than tracking it.
 |---|---|---|
 | P0-1 three-tuple `local` + G-15 | `rf2-vxgfnd.95.2` (amended notes authoritative over its original scope) | closed |
 | P0-2 sync-door widening + widened G-8 | `rf2-8k14ia` — the pre-conformance **correction** filed after `.95.1` merged (the completeness audit fixed the epic's truncated reference to it); blocked `.95.10` | closed |
-| P0-3 `ui/slot` + G-16 (+ absorbed bare-alias dev warning) | `rf2-ri0k6n`; blocked `.95.10`; S3→S4 compiler surface | closed |
+| P0-3 `ui/slot` + G-16 (the delta as filed also folded in the bare-alias dev warning) | `rf2-ri0k6n` — `ui/slot` + G-16; blocked `.95.10`; S3→S4 compiler surface. The bare-alias dev warning was **not** delivered under `rf2-ri0k6n`: it shipped separately as `rf2-vxgfnd.95.15`, also closed. | closed |
 | P1-4 safe-spread policy + G-17 | `rf2-isdqjv`; blocked `.95.10` | closed |
 | C-6 interop blessing + fixtures | `rf2-vxgfnd.95.4` | closed |
 | C-13a fn-prop fixtures | `rf2-vxgfnd.95.3` (kept distinct from `rf2-ri0k6n`'s internal-slot fixtures) | closed |


### PR DESCRIPTION
Closes rf2-vxgfnd.296.

EP-0030/0032/0034/0035 asserted a *current* operational state that nothing updates, so the claims were stale by default. This applies the `rf2-rkivs` pattern (PR #6381) uniformly across the remaining sites.

## The one treatment, applied uniformly

Every operational-state claim in these documents is now either:

- **terminal** — it names work that has **closed**, and closed is terminal, so no live claim survives to be falsified; or
- **stateless** — it names the owning epic/bead id and asserts **no state**, deferring to the tracker.

No passage asserts an in-flight state any more. There is **no mixture** of refreshed and stale rows: every bead id cited at each site was checked against the tracker at edit time.

## Authority

- **EP-0009 §Statuses** — *"Ledger rows cite live bead ids and are struck as they close."* Striking is the designed behaviour, not a rewrite.
- **EP-0009 §Durability rule 3** — *"(Mechanical corrections and errata-ledger updates are always fine.)"*
- **`rf2-r7ahi`** is **RULED** (b) *"freeze meaning, not bytes"*, corpus-wide. Its **Tier 1** (edit in place, undated) explicitly names *"index/status sync, mechanical errata-ledger updates (row strikes/closures)"*. No settled decision, ruling, rationale or scope is touched anywhere in this diff.

## Sites

| Site | Was | Now |
|---|---|---|
| EP-0030 Bead Plan | "**S3 is in flight**" | S1–S3 closed (`.95` closed 2026-07-18), S4 (`.96`) closed + declared conforming; S5–S7 named by epic (`.97`/`.98`/`.99`) with no state asserted |
| EP-0030 Recommendation | "two stages merged … the third in flight" | S1–S3 merged, S4 closed and declared conforming |
| EP-0032 errata ledger | `.169`, `.204`, `.94.15`/`.17`–`.21` listed as live gaps — all closed | those rows **struck**; `.166` (in progress) and `.167` (open) stay unstruck |
| EP-0034 stage honesty | "S3 has landed and S4 is in flight; S5–S7 have not started" | false on both halves; now terminal + epic-only for S5–S7 |
| EP-0035 provenance | "`ai/` is local-only" | false for the cited force-tracked drafts doc; defers to `git ls-files ai/` as the roster |
| EP-0035 P0-3 row | credits `rf2-ri0k6n` with "absorbed bare-alias dev warning" | the warning shipped as `rf2-vxgfnd.95.15` (PR #6157), not `rf2-ri0k6n` (PR #6032); the delta's original scope is preserved, only the delivery owner corrected |

**On the EP-0032 ledger.** `.166` and `.167` are genuinely open gaps, so they cannot be struck without destroying real information. Leaving them unstruck is not a stale claim: the errata ledger is the one surface EP-0009 *designs* to carry live bead ids, with a defined update rule and Tier-1-blessed maintenance. The header now makes both readings explicit — a struck row is closed and therefore terminal; an unstruck row's **bead**, not the table, is the gap's state.

## No sync mechanism built

No generator, bead-status checker, CI/network integration, or prose parser was added. `rf2-rkivs` explicitly considered and rejected a generator, and the terminal/stateless treatment is what makes one unnecessary.

## No status flip

`rf2-hgwpq` (EP-0031's graduation trigger has fired but its status still reads `accepted`) is untouched — that is a lifecycle ruling awaiting Mike, and no site in this diff required it.

## Same defect shape elsewhere — named, not fixed

- **`docs/EP/EP-0009-the-ep-process.md:155-160`** — the implementation checklist reads "1. **Done.** … 2. **Done.** … 3. **Open.**" with **no bead ids at all**, so it cannot even be reconciled against the tracker. This is the same defect in the document that defines the rule; `rf2-rkivs` named it too and it remains unfixed.
- **`docs/EP/EP-0031-re-frame-ui-programming-model.md:209-212`** — §5's "Stage honesty" column carries `accepted → S3` rows whose beads (`rf2-isdqjv`, `rf2-ri0k6n`) have since closed and shipped. Left alone deliberately: each row is dated (`delta #4/#5, 2026-07-16`) and states a *decision* status, not a liveness claim, so it is already terminal — but the `accepted →` reading could drift once readers forget S3 closed.

## Collision check

None. `w1-authorities-188` (`rf2-vxgfnd.176`/`.188`) touches `ai/findings/**` and `spec/004*`/`006`/`009` — **zero `docs/EP/**` files**, verified against its branch. This diff is confined to `docs/EP/**`, and touches none of `ai/`, `spec/`, or `implementation/`.

## Quality gates

Run in the foreground, unpiped, to completion.

| Gate | Result |
|---|---|
| `python -m mkdocs build --strict` | **exit 0** — built in 19.06s |
| `python scripts/check_doc_slugs.py` | **exit 0** |
| `python scripts/check_ep_status_sync.py` | **exit 0** |
| `python scripts/check_skill_re_frame2_drift.py --verbose` | **exit 0** — 50 leaves / 7416 lines scanned |
| `sh scripts/check-no-hardcoded-paths.sh` | **exit 0** — no personal/home paths |
| `cd implementation/ui && clojure -M:test` | **exit 0** — **Ran 929 tests containing 16140 assertions. 0 failures, 0 errors.** |

**Does a gate cover this diff?** Partly, and the shown reasoning is the rest of the evidence.

`guide_truth_jvm_test.clj` **does** pin two of the four edited files by exact path — `docs/EP/EP-0034-…` and `docs/EP/EP-0030-…` — so the JVM suite was run rather than skipped (counts non-zero and consistent with the ~934/~16149 baseline; the false-green `-n <ns>` shape was avoided). But it guards *per-host-AST* phrases and a retired-claim census, not bead state, so it constrains this diff without validating it. `check_ep_status_sync.py` governs front matter and index metadata, not mutable body prose — by design, which is why this class of defect survives CI.

**No gate verifies the truth of an operational-state claim.** The evidence that these edits are correct is the per-bead tracker verification recorded above.
