### PR TITLE
docs(re-com): repoint readiness authorities to the resolved ten-ruling register (rf2-6ajm6z.1)

### DIFF
--- a/ai/findings/new-substrate-synthesis/08-delivery.md
+++ b/ai/findings/new-substrate-synthesis/08-delivery.md
@@ -149,9 +149,12 @@ gaining Xray/epochs/Story/schemas/
 machines immediately; (2) views migrate to `ui` per subtree, later, with the migrator
 ([10-migration-from-reagent.md](10-migration-from-reagent.md)); re-com widgets are the
 last movers (Reagent islands / foreign heads until the `ui`-native answer lands — that
-answer is now a **directed program**: the re-com native-port epic `rf2-6ajm6z`, Wave 0
-gated on the `ai/decisions/re-com-readiness.product-rulings.md` register; substrate
-readiness rides S3 per `drafts/component-library-readiness.md`, 2026-07-16). **The repo's own adoption** (examples, testbeds, Story/Xray
+answer is now a **directed program**: the re-com native-port epic `rf2-6ajm6z`, whose
+Wave-0 product register is **resolved** — the ten rulings R‑1…R‑10 in
+[EP-0035](../../../docs/EP/EP-0035-component-library-readiness.md) §Resolved Decisions,
+the durable source of record, restated in that epic's NOTES; substrate
+readiness rides S3 per `drafts/component-library-readiness.md`, 2026-07-16; register
+resolved 2026-07-16, R‑1's coordinate confirmed 2026-07-17). **The repo's own adoption** (examples, testbeds, Story/Xray
 scenes, guides exercising `ui` where it earns its place) remains the budgeted Stage-6
 workstream — adoption of an experimental option, not a forced migration off the
 retained adapters.

--- a/ai/findings/new-substrate-synthesis/11-adoption-workstreams.md
+++ b/ai/findings/new-substrate-synthesis/11-adoption-workstreams.md
@@ -2,11 +2,16 @@
 
 **Status:** final · 2026-07-11. 08 §2 budgets "migrate the repo" as a Stage-6
 workstream; this doc decomposes the full adoption surface so it can become stage epics.
-*[2026-07-16: the **re-com native port** is deliberately NOT a W-row here — it is a
-separate directed epic (`rf2-6ajm6z`, Wave 0 gated on
-`ai/decisions/re-com-readiness.product-rulings.md`) so component migration never
+*[2026-07-16, updated 2026-07-17: the **re-com native port** is deliberately NOT a W-row
+here — it is a separate directed epic (`rf2-6ajm6z`) so component migration never
 blocks a substrate stage; its substrate prerequisites ride S3 per
-`drafts/component-library-readiness.md`.]*
+`drafts/component-library-readiness.md`. Its Wave-0 product register is **resolved**:
+the ten rulings R‑1…R‑10 in
+[EP-0035](../../../docs/EP/EP-0035-component-library-readiness.md) §Resolved Decisions
+(durable source of record), restated in the epic's NOTES. What remains scheduled are
+per-wave **entry** decisions, not a Wave-0 gate: the Wave-2 input roster (R‑7), the
+Wave-4 foreign-engine selection (R‑5), the adoption-wave compat-tier policy, and the
+post-parity Bootstrap-layer removal (R‑10).]*
 Each row: what, when it starts, what gates it. Rule of thumb throughout: nothing here
 starts before the thing it documents/teaches/tests exists — but *none of it is optional*,
 and several items (ui.test, the migrator, skills) are on the critical path, not trailing

--- a/ai/findings/new-substrate-synthesis/drafts/component-library-readiness.md
+++ b/ai/findings/new-substrate-synthesis/drafts/component-library-readiness.md
@@ -175,8 +175,8 @@ API redesign or a named interop boundary, not a substrate exception.
 
 Spike/checkpoint beads (§4) are filed against the **program epic** (`rf2-vxgfnd`) with
 their triggers in the description; the re-com **port** itself is a separate epic stub
-(Wave 0 gated on the §8 rulings) so the substrate stage epic never blocks on component
-migration.
+(whose Wave-0 product register is resolved — §8, R‑1…R‑10) so the substrate stage epic
+never blocks on component migration.
 
 ## 7. The conformance proof pack (rolling consumer)
 
@@ -190,12 +190,33 @@ door preserved) · schema-described component (one manifest projection → Story
 production elision) · inline popover (ref/layout-effect/passive split + pure geometry;
 informs the portal decision) · single-view advanced import (unused siblings absent).
 
-## 8. Residual product rulings (Mike; tracked in `ai/decisions/re-com-readiness.product-rulings.md`)
+## 8. Product rulings — RESOLVED as R‑1…R‑10 (was: six residual rulings)
 
-1. native/compat package + namespace names · 2. v1 parts power ceiling (data+slots
-only vs stateful registered) · 3. uncontrolled convenience tier (`:default-value`
-wrappers) · 4. theme transport (prop/frame-sub baseline; context only if proven) ·
-5. tables foreign-first confirmation · 6. middle-artifact timing (recommended: generic
-internals + guide now; public artifact on second consumer).
+**Status 2026-07-17: ruled and durable.** The six entries this section once listed as
+awaiting Mike were ruled on 2026-07-16 (R‑1's native coordinate confirmed 2026-07-17)
+and now live as the **ten-entry register R‑1…R‑10** in
+[EP-0035](../../../../docs/EP/EP-0035-component-library-readiness.md) §Resolved
+Decisions — the durable source of record — restated in the `rf2-6ajm6z` epic NOTES,
+which are authoritative over any summary. **Cite EP-0035, never this section.**
 
-None of these gate the P0/P1 package above; the spikes' triggers absorb them.
+The former six map onto the first six rulings, and the ruling **added four more** —
+read all ten, not the six:
+
+| Former residual entry | Ruling |
+|---|---|
+| 1. native/compat package + namespace names | **R‑1** packaging |
+| 2. v1 parts power ceiling (data+slots vs stateful registered) | **R‑2** parts ceiling |
+| 3. uncontrolled convenience tier (`:default-value`) | **R‑3** uncontrolled tier |
+| 4. theme transport (prop/frame-sub baseline; context only if proven) | **R‑4** theme transport |
+| 5. tables foreign-first confirmation | **R‑5** tables/grids |
+| 6. middle-artifact timing | **R‑6** helper artifact |
+| *(not previously listed)* | **R‑7** input ownership · **R‑8** cross-host date/time · **R‑9** accessibility target · **R‑10** CSS/Bootstrap posture |
+
+None of the ten gate the P0/P1 package above — that conclusion is unchanged, and now
+rests on the rulings being settled rather than on the spikes' triggers absorbing open
+questions. The spike triggers in §4 stand on their own terms.
+
+**Still scheduled** (per-wave *entry* decisions, not a Wave-0 gate, and not complete):
+the Wave-2 input roster freeze feeding `rf2-nzst23` (R‑7), the Wave-4 foreign-engine
+selection (R‑5), the adoption-wave compat-tier fix-acceptance/deletion policy, and the
+post-parity Bootstrap-layer removal decision (R‑10).

--- a/docs/EP/EP-0035-component-library-readiness.md
+++ b/docs/EP/EP-0035-component-library-readiness.md
@@ -248,9 +248,9 @@ than tracking it.
 
 Spike/checkpoint beads live on the **program epic** (`rf2-vxgfnd`):
 `rf2-nzst23`, `rf2-1hm7a3`, `rf2-a62fje`, `rf2-efxb1h`, `rf2-ho1iba`. The
-re-com **port** is the separate epic `rf2-6ajm6z` (Wave 0 gated on the
-product register, now ruled — R-1..R-10 below); the substrate stage epic
-never blocks on component migration.
+re-com **port** is the separate epic `rf2-6ajm6z`, whose Wave-0 product
+register is resolved — the ten rulings R-1..R-10 below; the substrate stage
+epic never blocks on component migration.
 
 Guide-impact assessment (EP-0009 rule 5): the events guide gains the C-13b
 event-prefix convention; the interop guide gains the C-6 measure-before-paint


### PR DESCRIPTION
Closes `rf2-6ajm6z.1`.

## The defect

Three synthesis authorities pointed workers at `ai/decisions/re-com-readiness.product-rulings.md` for the re-com port's Wave-0 product register. **That file has never existed** — not tracked, and not present untracked in a local checkout either (`ai/decisions/` holds exactly four unrelated dossiers). The pointer resolved to nothing while reading as a live, unresolved gate, so a worker following the owning synthesis would wait on an already-settled decision.

The rulings are resolved and durable as the ten-entry **R-1..R-10** register in `docs/EP/EP-0035-component-library-readiness.md` §Resolved Decisions, restated in the `rf2-6ajm6z` epic NOTES (authoritative over any summary).

## Each authority — what it pointed at vs. what it now points at

| Authority | Pointed at | Now points at |
|---|---|---|
| `ai/findings/new-substrate-synthesis/08-delivery.md` §6 | "Wave 0 gated on the `ai/decisions/re-com-readiness.product-rulings.md` register" | EP-0035 §Resolved Decisions, R-1..R-10, stated **resolved** (2026-07-16; R-1 coordinate confirmed 2026-07-17) |
| `ai/findings/new-substrate-synthesis/11-adoption-workstreams.md` header note | same dangling path | EP-0035 R-1..R-10, plus the four genuinely scheduled per-wave **entry** decisions |
| `ai/findings/new-substrate-synthesis/drafts/component-library-readiness.md` §8 | "Residual product rulings (Mike; tracked in `…product-rulings.md`)" + a six-entry list | the resolved register, with a mapping table: the six were R-1..R-6, and the ruling **added R-7..R-10** |
| same file, §6 | "(Wave 0 gated on the §8 rulings)" | "(whose Wave-0 product register is resolved — §8, R-1..R-10)" |
| `docs/EP/EP-0035…` Bead Plan | "Wave 0 gated on the product register, now ruled — R-1..R-10 below" | leads with the resolved state rather than a present-tense gate |

The six-entry list was the sharpest instance: a reader who stopped there would have missed **four whole rulings** — input ownership (R-7), cross-host date/time (R-8), the accessibility target (R-9), and the CSS/Bootstrap posture (R-10) — each added by the ruling, not present in the residual list.

## True-conclusion / dead-basis

§8 closed with *"None of these gate the P0/P1 package above; the spikes' triggers absorb them."* The conclusion is **true and kept**; only its stated basis collapsed — the rulings no longer need absorbing because they are settled. The basis is rewritten and the conclusion preserved rather than deleted.

## Not done, deliberately

No ruling re-litigated, no Wave-0 child filed, no link-checking gate added, no restructuring of the planning docs, and the port itself untouched. The four still-scheduled wave-entry decisions (Wave-2 input roster, Wave-4 engine selection, adoption-wave compat policy, post-parity Bootstrap removal) are preserved as scheduled work, not marked complete.

## Quality gates

| Gate | Result |
|---|---|
| `python -m mkdocs build --strict` | pass (18.8s, no warnings) |
| `python scripts/check_doc_slugs.py` | pass |
| `python scripts/check_ep_status_sync.py` | pass (EP body edit; front matter untouched) |
| `python scripts/check_skill_re_frame2_drift.py --verbose` | pass — 50 leaves / 7416 lines scanned |
| `sh scripts/check-no-hardcoded-paths.sh` | pass |
| `cd implementation/ui && clojure -M:test` | **929 tests / 16146 assertions, 0 failures, 0 errors** |

The JVM suite was run because `guide_truth_jvm_test.clj:508` pins `ai/findings/new-substrate-synthesis/08-delivery.md` by exact path. Its assertion scopes to the markdown row whose leading cell is `R-1` (`| R-1 |`, line 122 — that file's own Spec-004 decision row, unrelated to re-com's R-1); this diff edits prose only and adds no table row to that file.

**Does any gate cover the repointing? No.** mkdocs would catch a broken anchor inside `docs/`, but three of the five sites are under `ai/`, which mkdocs does not build, and no gate anywhere verifies that a citation resolves to the *right* target rather than a plausible wrong one — which is this defect exactly. The per-reference resolved-target evidence above is the proof.

## Bead

`rf2-6ajm6z` (parent epic) title and description updated in the same pass, per the acceptance criteria: the title no longer advertises a resolved blocker, and the description's `WAVE 0 (file children when Mike rules the product register — …product-rulings.md)` clause now records the condition as MET and names EP-0035. Its NOTES — including the ten rulings and every MAYOR TODO — were preserved verbatim (`--body-file`, never `--notes`).
