### PR TITLE
docs(spec): correct the retired per-drain render law in Conventions and 009 (rf2-gx2n7)

### DIFF
--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -688,7 +688,9 @@ The finer-grained stage sequence, grouped by phase:
 | **render** | **derive** | Recompute the subscriptions whose inputs the commit invalidated. |
 | **render** | **render** | Repaint the views the derivation changed. |
 
-**The update and commit phases run per event; the render phase runs once per drain at settle.** A [**drain**](002-Frames.md#run-to-completion-dispatch-drain-semantics) processes the originating event plus every event its handlers dispatch, each running its own full **assemble → transform → commit → perform** sequence, back-to-back to fixed point. The render phase (**derive → render**) runs **once**, at drain settle, over the final committed state — not once per event. This is why **drain** is kept as a distinct term: it is the scheduling unit that bounds when the render phase runs.
+**The update and commit phases run per event; the render phase runs once per render batch.** A [**drain**](002-Frames.md#run-to-completion-dispatch-drain-semantics) processes the originating event plus every event its handlers dispatch, each running its own full **assemble → transform → commit → perform** sequence, back-to-back to fixed point. The render phase (**derive → render**) then runs over the final committed state — not once per event.
+
+A **render batch** is the pending read/render window that ends at the next CLJS host microtask checkpoint, or at an explicit headless/test flush. It is armed by the **first dirty mark** and closes at the **host's** checkpoint, not at the end of a drain — the scheduler takes no hook from router drain finalization and observes no drain boundary at all. Two consequences are guaranteed: a synchronous drain **cannot** be split across batches (the window cannot close while the stack is still unwinding), and the epochs one drain settles coalesce into **one** batch. The converse does not hold — several drains finishing before the same host checkpoint **may** share a batch, and only a real host yield separates renders. **No render count may be inferred from the number of event/frame epochs, nor from the number of drains:** "one render batch per router drain" is **retired** as normative and survives only as the common case, true exactly when callers yield between drains. **Drain** stays a distinct term because it is the run-to-completion unit whose intermediate states never render, not because it bounds a render batch; the normative render-batch contract lives in [006-ReactiveSubstrate](006-ReactiveSubstrate.md).
 
 ### The triple — pipeline / run / epoch
 
@@ -697,7 +699,7 @@ Three distinct nouns for three distinct things; do not use one for another:
 | Noun | Is |
 |---|---|
 | **pipeline** | The **structure** — the fixed stage sequence itself (assemble → transform → commit → perform → derive → render). It does not "happen"; it is the shape every traversal follows. |
-| **run** (a **pipeline run**) | **One traversal** of the pipeline — one dequeued event going through its update and commit phases (and the drain's shared render phase at settle). This is the unit that replaces the retired "event cascade" for a *single* traversal. |
+| **run** (a **pipeline run**) | **One traversal** of the pipeline — one dequeued event going through its update and commit phases (and the render batch its drain's epochs coalesce into). This is the unit that replaces the retired "event cascade" for a *single* traversal. |
 | **epoch** | The **record a run leaves** — one [`:rf/epoch-record`](Spec-Schemas.md#rfepoch-record) per dequeued event, the durable, snapshottable boundary a run produces (per [002 §Drain versus event — the epoch unit](002-Frames.md#drain-versus-event--the-epoch-unit)). |
 
 ### Deprecations


### PR DESCRIPTION
Closes rf2-gx2n7 (partially — see **Scope** below).

`spec/Conventions.md` is the authoritative home for the event-pipeline vocabulary that `spec/002` defers to, and its §The phases still stated the **retired per-drain render rule in full**. PR #6393 corrects the same law in `spec/006`, so the moment #6393 merges the corrected text contradicts the document the other specs point at. This transcribes #6393's ruled wording into the authoritative home.

## The corrected law (transcribed from #6393, not re-derived)

- A **render batch** is the pending read/render window that ends at the next CLJS host microtask checkpoint, or at an explicit headless/test flush. It is armed by the **first dirty mark** and closes at the **host's** checkpoint, not at the end of a drain — the scheduler takes no hook from router drain finalization and **observes no drain boundary at all**.
- **Guaranteed:** a synchronous drain cannot be split across batches; the epochs one drain settles coalesce into one batch.
- **A permission, not a guarantee:** several drains finishing before the same host checkpoint **may** share a batch. #6393 deliberately did not assert this as a guarantee — it measured a second `dispatch-sync!` advancing the first drain's mark — so it is written here as the permission it is. Only a real host yield separates renders.
- "One render batch per router drain" is **retired** as normative, surviving only as the common case.
- **Drain** keeps its distinct-term status for the correct reason — it is the run-to-completion unit whose intermediate states never render — not because it bounds a render.

## Sentences corrected, not just a lead

Per #6393's lesson that *"a banner alone leaves false sentences greppable"*, this corrects the false **sentences**. A derived sweep of `spec/Conventions.md` found **two**, and both are fixed:

1. §The phases — "the render phase runs once per drain at settle" + "drain … is the scheduling unit that bounds when the render phase runs".
2. §The triple — the `run` row's "(and the drain's shared render phase at settle)", which a single-regex census **missed**; it was caught only by widening the sweep to every `render`/`settle`/`drain` mention in the file.

No banner was added.

## Scope — the `spec/009` half is deliberately NOT here

Two blockers, both verified rather than assumed:

- **`spec/009-Instrumentation.md` is held.** Open PR #6389 changes it (`:rf.error/root-manifest-invalid`, `:rf.error/frame-payload-conflict`) and is currently `CONFLICTING`. Both files are hot-zone — sequential, never parallel — so the `:rf.error/reentrant-graph-op` row (line 1930, residue confirmed present) waits for #6389.
- **The allowlist entry does not exist on main.** The bead asks for the `spec/009` allowlist entry to be removed so it cannot become a permanent exemption. That allowlist — and the repo-wide `git ls-files` census it belongs to — arrives with **unmerged** #6393. On main the drift gate is still the older `observation.cljc`-scoped version with **zero** `allowlist` occurrences, so there is nothing to remove yet. Removing it remains a required follow-up once #6393 lands.

`spec/Conventions.md` was confirmed free of holders at edit time (no open PR touches it).

## Quality gates

All foreground, unpiped, run to completion against the final tree.

| Gate | Result |
|---|---|
| `python -m mkdocs build --strict` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `python scripts/check_keyword_catalogue_drift.py` | exit 0 |
| `python scripts/check_skill_re_frame2_drift.py --verbose` | exit 0 — 50 leaves / 7416 lines scanned |
| render-law drift gate (`observation-render-law-drift-test`) | **2 tests / 4 assertions**, 0 failures |
| `implementation/core` `clojure -M:test` | **2074 tests / 9930 assertions**, 0 failures |
| `implementation/ui` `clojure -M:test` | **935 tests / 16158 assertions**, 0 failures |
| `scripts/check-no-hardcoded-paths.sh` | exit 0 |

### Teeth probe — and a gap it exposes

The bead's teeth proof (remove allowlist → gate still passes; re-seed retired wording → gate reds) is **not applicable**, since the allowlist is not on main. So the probe actually run was the directly relevant one: the retired sentence was **re-seeded into `spec/Conventions.md`** and every gate was re-run.

**Every gate still passed.** Nothing on main catches this defect — which is why the bead correctly called for a manual read. Worth noting for follow-up: #6393's incoming census matches the per-**epoch** shapes (`epoch-close notify`, `render per epoch`), not the per-**drain** shapes corrected here, so `Conventions.md` stays uncovered even after #6393 merges.

Links use anchor-free/stable targets only (`006-ReactiveSubstrate.md` with no anchor; the two existing `002` anchors, which #6393 does not rename), so the page is correct and `mkdocs --strict`-clean both before and after #6393 merges.
