### PR TITLE
docs(skills): point the setup skill at the published Shadow contract (rf2-ftb3s)

### DIFF
--- a/implementation/ui/test/re_frame/ui/shadow_config_contract_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/shadow_config_contract_jvm_test.clj
@@ -21,11 +21,17 @@
   only ever confirm its own copy of it (the rf2-5e3ic failure mode: gates that
   answered `true` for a 404 and for a path outside the repo).
 
-  Three holders, compared as DATA:
+  Four holders, compared as DATA:
 
     1. the published page       docs/core/how-to/install-re-frame-ui.md
     2. this repo's own build    implementation/shadow-cljs.edn        (top level)
     3. the consumer scaffold    examples/ui/minimal-counter/shadow-cljs.edn
+    4. the setup skill          skills/re-frame2-setup/references/shadow-cljs.md
+
+  Holder 4 arrives with rf2-ftb3s. The setup skill points authors at the
+  published page for the reasoning and carries only the settings themselves,
+  behind the same `rf2:shadow-ui-contract` anchor — so the skill is pinned to
+  the real build config rather than becoming a fourth copy free to drift.
 
   Each is a separate lever: mutate any ONE of the three and this suite reds,
   naming which holder diverged.
@@ -48,6 +54,7 @@
 (def ^:private example-config-rel "examples/ui/minimal-counter/shadow-cljs.edn")
 (def ^:private example-deps-rel "examples/ui/minimal-counter/deps.edn")
 (def ^:private impl-package-rel "implementation/package.json")
+(def ^:private skill-rel "skills/re-frame2-setup/references/shadow-cljs.md")
 
 (defn- repo-root
   "Walk up from the working dir until a directory holds BOTH the published page
@@ -97,16 +104,31 @@
                       {:page page-rel :anchor anchor})))
     body))
 
-(defn- published-contract
-  "The two-setting map the page publishes, as data."
-  []
-  (let [form (edn/read-string (anchored-block (slurp-rel page-rel)
+(defn- anchored-contract
+  "The two-setting map a MARKDOWN holder publishes behind the shared
+  `rf2:shadow-ui-contract` anchor, as data. Every prose holder — the published
+  page, the setup skill — carries the settings under the same anchor, so one
+  reader serves them all."
+  [rel]
+  (let [form (edn/read-string (anchored-block (slurp-rel rel)
                                               "rf2:shadow-ui-contract"
                                               "clojure"))]
     (when-not (map? form)
-      (throw (ex-info "rf2-vxgfnd.196: the published contract block is not a map"
-                      {:read form})))
+      (throw (ex-info "rf2-vxgfnd.196: an anchored contract block is not a map"
+                      {:holder rel :read form})))
     form))
+
+(defn- published-contract
+  "The two-setting map the published how-to page publishes, as data."
+  []
+  (anchored-contract page-rel))
+
+(defn- skill-contract
+  "The two-setting map the re-frame2-setup skill hands authors, as data. The
+  skill points at the published page for the reasoning and carries only the
+  settings — this is what stops that block being a fourth free-drifting copy."
+  []
+  (anchored-contract skill-rel))
 
 (defn- published-shadow-version
   "The shadow-cljs version the page publishes, dug out of the `:shadow` alias it
@@ -175,7 +197,11 @@
     ;; converts that into a named failure rather than an error inside a
     ;; comparison test.
     (is (map? (published-contract)))
-    (is (string? (published-shadow-version)))))
+    (is (string? (published-shadow-version))))
+  (testing "the setup skill's anchored block resolves too"
+    ;; Same conversion for holder 4: delete the skill's anchor or its fence and
+    ;; the failure names the skill, rather than surfacing inside the comparison.
+    (is (map? (skill-contract)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The drift comparisons — three levers, one per holder
@@ -194,6 +220,19 @@
         (str "the published snippet in " page-rel " has drifted from "
              example-config-rel ". A consumer copying the page would not get "
              "the scaffold's configuration."))))
+
+(deftest setup-skill-matches-this-repos-own-build
+  (testing "the setup skill hands authors exactly what a real build configures"
+    ;; Compared against the CONFIG rather than the page, deliberately: the
+    ;; config is the source of truth this suite exists to defend, so mutating
+    ;; either the skill's block or the real build reds here. A skill compared
+    ;; only against the page would agree with a page that had itself drifted.
+    (is (= (top-level-contract impl-config-rel) (skill-contract))
+        (str "the anchored block in " skill-rel " has drifted from "
+             impl-config-rel ". An author following the setup skill would not "
+             "configure re-frame.ui the way this repo actually does — "
+             "reconcile the skill against the real build config, and see "
+             page-rel " for the published reasoning."))))
 
 (deftest the-two-real-configs-agree
   (testing "this repo and the scaffold configure re-frame.ui identically"

--- a/skills/re-frame2-setup/references/shadow-cljs.md
+++ b/skills/re-frame2-setup/references/shadow-cljs.md
@@ -5,6 +5,7 @@ The minimal `shadow-cljs.edn` build for a greenfield re-frame2 Reagent single-pa
 ## Contents
 
 - The day-one `shadow-cljs.edn`
+- If you add `re-frame.ui`: two required top-level settings
 - The `index.html` that loads the bundle
 - `:devtools` block (the Xray preload + hot reload)
 - `.gitignore` — what the build generates
@@ -44,6 +45,28 @@ Five things matter for re-frame2:
 The template also ships a second `:test {:target :node-test ...}` build under `:builds` — out of scope here (this skill stops at "the counter mounts"), but present in the scaffold if you compare.
 
 The build id (`:app` above) is the name for `shadow-cljs watch <build-id>`; `:app` is convention.
+
+## If you add `re-frame.ui`: two required top-level settings
+
+`day8/re-frame2-ui` — the compiled-view substrate — is **not** in the day-one set, and the build above is complete without it. It is, however, the one artefact whose arrival is more than a coordinate: adding it to `deps.edn` obliges you to add two settings to `shadow-cljs.edn` in the same change.
+
+<!-- rf2:shadow-ui-contract -->
+
+```clojure
+{:cache-blockers #{re-frame.ui}
+ :build-defaults {:build-hooks [(re-frame.ui.compiler.build-hook/hook)]}}
+```
+
+Both go at the **top level**, beside `:dev-http` — not inside a build. `:build-defaults` applies the hook to every configured build, and shadow-cljs unions the top-level `:cache-blockers` into each build's options, so one declaration covers the whole project.
+
+Two ways to get this wrong:
+
+- **Only add them once `day8/re-frame2-ui` is actually on the classpath.** The hook form names a namespace that ships inside that artefact, so configuring it without the dependency fails the build on an unresolvable `re-frame.ui.compiler.build-hook`. These are not settings to add speculatively to a project that has no compiled views.
+- **Add both, not one.** They cover different halves of the same problem, and neither substitutes for the other.
+
+Nothing here degrades quietly: with one setting missing the build refuses at compile-prepare, and with the hook missing the app throws on namespace load rather than running on an identity it cannot prove.
+
+**Why each setting is load-bearing, the diagnostics each failure produces, the supported shadow-cljs version, and a warm-start smoke check are published as a shipped contract** in [Install re-frame.ui and configure Shadow](../../../docs/core/how-to/install-re-frame-ui.md). That page is the source of truth. The block above is the same contract, held against it by a drift gate rather than retyped, so read the page for the reasoning instead of expecting it restated here.
 
 ## The `index.html` that loads the bundle
 


### PR DESCRIPTION
Closes rf2-ftb3s.

## What was wrong

`skills/re-frame2-setup/references/shadow-cljs.md` mentioned neither of the two load-bearing `re-frame.ui` settings. An author who added `day8/re-frame2-ui` by following the setup skill got no signal that the artefact needs build configuration at all.

## What it says now

A new section, **"If you add `re-frame.ui`: two required top-level settings"**, carrying the settings behind the same `rf2:shadow-ui-contract` anchor the published contract uses, plus placement, the two ways to get it wrong, and a pointer to [Install re-frame.ui and configure Shadow](docs/core/how-to/install-re-frame-ui.md) for the reasoning.

**Referenced, not hand-copied.** rf2-vxgfnd.196 (#6390) published the settings as a shipped contract with a gate holding three holders in agreement. This PR does not restate that page's rationale, diagnostics, version posture or smoke checklist — it points at them. The settings block itself is gate-pinned, so there is no fourth *drifting* copy: it cannot diverge from `implementation/shadow-cljs.edn` without reddening CI.

## The guidance is conditional, deliberately

`day8/re-frame2-ui` is a separate artefact (`implementation/ui/deps.edn` depends on core; neither core nor the Reagent adapter pulls it) and is **not** in the setup skill's day-one set (core + reagent + schemas + xray). The hook form names `re-frame.ui.compiler.build-hook`, which ships only in `implementation/ui/src/`.

So adding these settings unconditionally to the day-one Reagent config would break the greenfield build on an unresolvable namespace. The section fires when the author adds the artefact, not before — and says so.

## Fourth holder in the existing gate

`implementation/ui/test/re_frame/ui/shadow_config_contract_jvm_test.clj` gains one anchored block and one comparison, no structural change, as `.196` predicted. The skill is compared against `implementation/shadow-cljs.edn` — the real source of truth — rather than against the page, so a page that had itself drifted cannot drag the skill along with it. No literal expected value was added; the reader is the shared `anchored-contract` helper the page holder already used.

`implementation/shadow-cljs.edn` (hot-zone) was read and temporarily mutated for the teeth proof only; it is byte-identical to `origin/main`.

## Quality gates

All foreground, unpiped, run to completion.

| Gate | Result |
|---|---|
| `python scripts/check_skill_re_frame2_drift.py --verbose` | exit 0 — 50 leaves / 7416 lines scanned, no Rule 6b residue |
| `python -m mkdocs build --strict` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `cd implementation/ui && clojure -M:test` | **940 tests / 16187 assertions, 0 failures** |
| `bb skills/re-frame2-setup/tests/setup_drift_test.clj` | 29 tests / 87 assertions, 0 failures |
| `sh scripts/check-no-hardcoded-paths.sh` | exit 0 |

Extended namespace alone: **7 tests / 14 assertions** (was 6 / 12), non-zero and green.

### Teeth — four independent levers

Each mutation applied alone, then reverted:

| Mutated holder | Reds |
|---|---|
| the setup skill's block (new) | `setup-skill-matches-this-repos-own-build` — 1 failure |
| `implementation/shadow-cljs.edn` | `published-contract-matches-this-repos-own-build`, **`setup-skill-matches-this-repos-own-build`**, `the-two-real-configs-agree` — 3 failures |
| `examples/ui/minimal-counter/shadow-cljs.edn` | `published-contract-matches-the-consumer-scaffold`, `the-two-real-configs-agree` — 2 failures |
| `docs/core/how-to/install-re-frame-ui.md` | `published-contract-matches-this-repos-own-build`, `published-contract-matches-the-consumer-scaffold` — 2 failures |
| none | 0 failures |

The three pre-existing holders still fail independently after the `anchored-contract` refactor. The new holder correctly does *not* red on a page-only mutation — it is anchored to the build config, which is the point.

## Genericity

The section teaches the mechanism (two top-level settings, when they apply, why the dependency must come first) and never names this repo's config, testbeds or paths. `implementation/shadow-cljs.edn` appears nowhere in the skill. The one repo-specific link is to the published how-to page, matching the file's existing house style for cross-references.
