### PR TITLE
docs(EP): re-source the draft-only citation in EP-0034's gate-roster heading (rf2-p65us)

### DIFF
--- a/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
+++ b/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
@@ -192,7 +192,11 @@ no prop-driven re-render, identical output); value-stabilization invariants (equ
 results ⇒ identical references). Fingerprints pin build identity; the corpus doubles
 as the hydration-parity suite, including multi-root failure isolation.
 
-### 4. The gate roster (07 §5 is the source; one line per gate)
+### 4. The gate roster (one line per gate)
+
+This table is the roster of record — G-1..G-18 as ruled here, including the
+2026-07-16 additions. The synthesis dossier's earlier roster (`07-testing.md` §5)
+is its predecessor, not its source: where the two differ, this table governs.
 
 | Gate | Asserts |
 |---|---|
@@ -288,7 +292,7 @@ governing the compatibility tier until the `ui.test` contract graduates into 008
 
 ## Bead Plan / Reference Implementation
 
-Carried by the program epic's stage children (12 §3): **S1/S2 (done)** — `ui.test`
+Carried by the program epic's stage children ([EP-0030 §Bead Plan](EP-0030-the-compiled-view-substrate-program.md#bead-plan--reference-implementation)): **S1/S2 (done)** — `ui.test`
 Tier-1 core, selector grammar (004D live), tree contract (004B live), G-1/G-14 then
 G-3/4/5/6/13 wired. **S3** — elision gates G-7/G-11; G-8 including the widened arm;
 G-15..G-18 + the proof pack. **S5** — root manifests, multi-root hydration, failure
@@ -303,7 +307,7 @@ API defect.
 ## Resolved Decisions
 
 
-- **Head ownership (06 §5).** re-frame2's existing head model is the one owner of
+- **Head ownership ([004 §The document head is host-owned](../../spec/004-Views.md#the-document-head-is-host-owned)).** re-frame2's existing head model is the one owner of
   document-head output; substrate views never hoist metadata through React's
   head/resource mechanisms, and a foreign head is an explicit interop boundary. S4
   hardens head policy; the ruling itself is settled here.
@@ -312,8 +316,8 @@ API defect.
   (S-1-measured). The S-1 PASS predated the ruling; the rerun under the revised
   estimator was executed and wired at S1f (`rf2-vxgfnd.6`, closed 2026-07-12 —
   `npm run test:ui-g1`, all components within the 1.10 budget, emitted-JS golden
-  84 direct calls / 0 IFn traps). The source dossier's 07 §5 row predates that
-  close and reads stale; this EP records the current state.
+  84 direct calls / 0 IFn traps). The source dossier's G-1 row (`07-testing.md` §5)
+  predates that close and reads stale; this EP records the current state.
   Companion ruling: an **emitted-JS golden test** pins direct `jsx` calls — a
   CLJS-var-bound jsx fn silently reintroduces IFn dispatch under `:advanced` (~5–8%,
   S-1's trap).


### PR DESCRIPTION
Fixes `rf2-p65us`. Found by the `rf2-drwdy` worker (#6398) outside its fence; its own assessment was that this one "matters more than anything I fixed."

## Why this outranks the API.md sweep it came from

#6391 / #6395 / #6398 were urgent because **S7 deletes the synthesis tree**, taking with it the information needed to re-source those citations. EP-0034 is a **tracked** document — it survives S7, so its citations don't have a deadline, they simply stay broken forever.

## The defect is collision, not dangling

A bare `NN §M` **reads as** `spec/0NN` but **resolves into the draft tree**. Every one of the four here collides with a **live, tracked spec document** — a reader lands on a real page about the wrong subject and nothing announces it. (#6398's `03 §N` at least pointed at a `spec/003` that doesn't exist, which fails loudly. These don't.)

| Site | Appeared to reference | Actually resolved to | New target |
|---|---|---|---|
| §4 **heading** `07 §5` | `spec/007-Stories.md` §5 | `07-testing.md` §5 "The gate roster" | provenance claim removed — stated locally |
| Bead Plan `12 §3` | `spec/012-Routing.md` §3 | `12-implementation-plan.md` §3 "Stage → bead plan" | [EP-0030 §Bead Plan](docs/EP/EP-0030-the-compiled-view-substrate-program.md) |
| Resolved Decisions `06 §5` | `spec/006-ReactiveSubstrate.md` §5 | `06-ssr-islands.md` §5 "Head, streaming, RSC" | [004 §The document head is host-owned](spec/004-Views.md) |
| G-1 row `07 §5` | `spec/007-Stories.md` §5 | `07-testing.md` §5 | `` `07-testing.md` §5 `` (filename form) |

## The heading's claim was also false

`### 4. The gate roster (07 §5 is the source; …)` — but this EP's own Resolved Decisions says the dossier row "predates that close and reads stale; this EP records the current state", and §4 carries G-15..G-18 which the dossier roster lacks. So the dossier is the **predecessor**, not the source. The heading now claims no external source, and two sentences beneath record that this table governs.

**Section number `4.` is deliberately preserved** — three sites under `implementation/ui` cite `EP-0034 §4` (`g8/dev.cljs`, `s3_conformance_profile_jvm_test.clj`, `s4_conformance_profile_jvm_test.clj`).

## Re-sourcing notes

- `06 §5` lands on the anchor that **already owns the claim**: `spec/011-SSR.md:838` names `004 §The document head is host-owned` as the normative owner of exactly this structural-absence fact, so this is a fold onto a live authority rather than a new assertion.
- The G-1 row's staleness note is **load-bearing** (it explains why the EP differs from the dossier), so it is preserved verbatim — only the misdirecting coordinate changed, to the filename form already used at `local_effect_dispatch_fn_dom_cljs_test.cljs:344`.

## What anchored to the old heading, and the pin

- **Inbound anchor links to the changed heading: none.** Corpus-wide grep for `EP-0034#…` returns empty.
- **`guide_truth_jvm_test.clj` pin did not need moving.** It pins EP-0034 by exact path in `compiler-model-authorities`, but asserts two whole-document regexes drawn from **§2** (`hands that build's own AST to exactly one emitter`, `hosts never meet as ASTs`) plus the retired-claim census. Nothing slices on the §4 heading. Pin verified still green at its exact expected count.

## Not fixed, deliberately: the `ai/findings/` citation

The bead also named `ai/findings/new-substrate-synthesis/01-goals-and-invariants.md:34` (`08 §3` → `08-delivery.md` §3 "The demand bar"). The file **is** tracked, but I've left it:

1. **It isn't the same defect.** Inside the synthesis tree, `NN §M` is the tree's own native numbering — there are **98** such citations across the tree and **17 in that one file** (5 on lines 31–39 alone). The ambient namespace there is the dossier, not `spec/`, so there is no collision. The defect appears when a citation is *exported* into a tracked doc where the ambient namespace is `spec/`.
2. **Fixing exactly one is worse than fixing none** — it would make a single citation in a self-consistently numbered file use a different convention.
3. **That file does not survive S7**, so the bead's own "it's tracked, therefore permanent" logic inverts here.

## Also spotted (outside this fence, not touched)

Three more bare `07 §5` under `implementation/**`, same collision, each already paired with a live `EP-0034 §4` pointer — so each is a **fold** candidate, not a re-source:

- `implementation/ui/g8/re_frame/ui/g8/dev.cljs:3`
- `implementation/ui/test/re_frame/ui/s3_conformance_profile_jvm_test.clj:165`
- `implementation/ui/test/re_frame/ui/s4_conformance_profile_jvm_test.clj:247`

`local_effect_dispatch_fn_dom_cljs_test.cljs:344` already uses the correct disambiguated form (`07-testing.md §5 :145`) and is the house-style precedent.

## Post-fix census

Zero bare `NN §M` remain in EP-0034. Both surviving `NN §` occurrences sit **inside markdown links** whose targets are slug-validated by the gate.

## Quality gates

No gate covers this defect class — a bare `07 §5` is not a link, so every link checker is blind to it. **The resolved-target table above is the evidence.** The gates below prove the *new* anchors resolve and that nothing regressed.

| Gate | Result |
|---|---|
| `python scripts/check_doc_slugs.py` | **exit 0**, no output |
| `python -m mkdocs build --strict` | **exit 0**, 0 warnings / 0 errors |
| `cd implementation/ui && clojure -M:test` | **exit 0** — **Ran 940 tests / 16184 assertions, 0 failures, 0 errors** |
| pin ns `re-frame.ui.guide-truth-jvm-test` | **exit 0** — **Ran 19 tests / 663 assertions, 0 failures, 0 errors** |
| `scripts/check-no-hardcoded-paths.sh` | **exit 0** |

940 tests sits at the top of the expected 929–940 band; 16184 assertions is inside the observed 16136–16187 generative drift. The pin namespace matched its deterministic 19 / 663 exactly. All counts **non-zero** (run from `implementation/ui`, not `implementation/`, so no silent "Ran 0 tests" false-green).

**Slug gate probe-verified, not blind:** I deliberately broke the new EP-0030 anchor and re-ran — it failed **exit 1** naming `EP-0034…md:295`, confirming the earlier exit 0 is a genuine green rather than an unscanned file. Restored from a backup taken before the probe.

## Surface

`docs/EP/EP-0034-*.md` only — one file, +9/-5. Hot-zone clear: checked **all 13 sibling worktrees** for dirty *and* committed edits against each one's own merge-base (not `gh pr list`, which can't see live workers with no PR yet). No holder touches `docs/EP/**`.
