### PR TITLE
fix(story): fence Promise-backed presence settlement with the run token (rf2-6pfpt)

### DIFF
--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -408,13 +408,41 @@
               ;; the executor returns. The executor calls this back with the
               ;; SETTLED result a microtask later, so the stepper records the
               ;; same verdict the auto-run loop would. Every other step calls
-              ;; back synchronously, BEFORE the slot below exists — hence the
-              ;; bounds guard: the synchronous return value already recorded
-              ;; the final result in that case, and there is nothing to amend.
+              ;; back synchronously, BEFORE the slot below exists — which
+              ;; `recorded` (still `::none`) is what declines: the synchronous
+              ;; return value already recorded the final result in that case,
+              ;; and there is nothing to amend.
+              ;;
+              ;; STALE-SETTLEMENT FENCE (rf2-6pfpt). The gap between parking
+              ;; and settling is one a user can reset the session across
+              ;; (`begin-stepper!` / `stepper-rewind!` / `stepper-step-back!` /
+              ;; `end-stepper!` / `clear-all-play-state!`). A BOUNDS guard —
+              ;; all this used to carry — is a size test, not an identity
+              ;; test: it correctly declines while a reset has left `:results`
+              ;; shorter than `idx`, then silently permits the clobber once a
+              ;; new cursor has grown back past `idx`, landing a stale
+              ;; amendment on a different session's step.
+              ;;
+              ;; The claim a settling step actually needs is narrower than a
+              ;; session: amend the record I MYSELF recorded, not whatever now
+              ;; occupies my index. That is the provisional record's own object
+              ;; identity, which is why this is `identical?` and not `=` — two
+              ;; runs of the same step are legitimately EQUAL and must still be
+              ;; told apart. It also needs no session counter and no bump at
+              ;; those five mutation sites: it is automatically correct at
+              ;; every cursor change, including ones not yet written. A
+              ;; generation would additionally be WRONG at
+              ;; `stepper-step-back!`, which pops only the last step — an
+              ;; amendment still owed for an EARLIER index remains valid, and a
+              ;; session-level bump would refuse it, quietly reinstating the
+              ;; rf2-iz0t8 hazard of a clean flush shown over a failed one.
+              recorded (atom ::none)
               settle! (fn [settled]
                         (swap! stepper-state update-in [frame-id :results]
                                (fn [rs]
-                                 (if (and rs (< idx (count rs)))
+                                 (if (and rs
+                                          (< idx (count rs))
+                                          (identical? (nth rs idx) @recorded))
                                    (assoc rs idx settled)
                                    rs))))
               result  (cond
@@ -428,6 +456,12 @@
                             (runner/step-skip idx step))
 
                         :else (runner/step-skip idx step))]
+          ;; Publish the claim BEFORE the record is visible in `:results`, so
+          ;; there is no window in which a settlement could see its own record
+          ;; at `idx` without recognising it. Both are synchronous and
+          ;; adjacent; a settlement that already fired (every step but a
+          ;; pending presence flush) saw `::none` and correctly declined.
+          (reset! recorded result)
           (swap! stepper-state update frame-id
                  (fn [s] (-> s
                              (update :remaining subvec 1)

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -1359,6 +1359,35 @@
          (catch #?(:clj Throwable :cljs :default) _ nil)))
   nil)
 
+(defn- stale-run?
+  "True when the `[frame-id play-key]` run-state `state` no longer belongs to
+  the run carrying `token`. The ONE definition of \"this run has lost its
+  slot\", consulted at EVERY point a run is about to mutate shared state.
+
+  Two ways to lose it, and they are answered identically (`settle-abort!` —
+  settle this run's own continuation, mutate nothing):
+
+    - the slot is GONE (nil `state`) — the frame was torn down mid-run;
+    - the slot carries a DIFFERENT `:run-token` — a newer `run!` took it over
+      (rf2-ftow6), and the newer loop owns the continuation now.
+
+  A slot carrying NO token is deliberately NOT stale: a hand-seeded state
+  (tests, a caller driving `run-loop!` directly) predates the token scheme and
+  is left alone.
+
+  Why a plain value rather than a `^:dynamic` Var or a ThreadLocal (rf2-6pfpt):
+  the hazard here is a run OUTLIVING its claim on shared state, not a claim
+  failing to reach a child. `token` is already conveyed correctly — it rides as
+  an argument through `run-loop!` and is captured by the settlement closure, so
+  it arrives everywhere it is needed. What it must be checked AGAINST is the
+  live slot, and a conveyed mechanism cannot do that: a binding conveyed into
+  the callback would agree with the callback by construction. The fence has to
+  compare the captured claim to the current world, which is exactly this."
+  [token state]
+  (boolean
+    (or (nil? state)
+        (and token (some? (:run-token state)) (not= token (:run-token state))))))
+
 (defn- run-loop!
   "Iterate over the script, running each step. `:wait` steps yield
   to the scheduler and resume from the wait time onwards.
@@ -1382,22 +1411,15 @@
   [frame-id play-key token done-cb]
   (let [state (current-state-for-play frame-id play-key)]
     (cond
-      ;; abort if state has gone missing (frame torn down mid-run).
-      ;; Still settle `done-cb` so the awaiting continuation advances and
-      ;; the play-promise (and the outer `run-variant` promise) resolves
-      ;; rather than hanging forever. We do NOT `finish!` here — the
-      ;; run-state slot is gone, so there is nothing to transition; we only
-      ;; release the continuation.
-      (nil? state)
-      (settle-abort! frame-id play-key done-cb)
-
-      ;; abort if a newer run! has taken over the state slot — the
-      ;; newer loop owns continuation now, so the stale loop bails
-      ;; rather than racing it. The stale loop must STILL settle ITS OWN
-      ;; `done-cb` (the continuation/promise for THIS run) so it does not
-      ;; strand the chain — but via `settle-abort!` (no `update-state!`),
-      ;; so it never clobbers the newer run's run-state slot.
-      (and token (some? (:run-token state)) (not= token (:run-token state)))
+      ;; The slot is no longer ours — the frame was torn down mid-run, or a
+      ;; newer `run!` took the slot over (`stale-run?` carries the full
+      ;; rationale). Either way this loop bails rather than racing the owner.
+      ;;
+      ;; It must STILL settle ITS OWN `done-cb` (the continuation/promise for
+      ;; THIS run) so it does not strand the chain — but via `settle-abort!`,
+      ;; which does no `update-state!`: an aborted loop must neither clobber
+      ;; the newer run's run-state slot nor resurrect a torn-down one.
+      (stale-run? token state)
       (settle-abort! frame-id play-key done-cb)
 
       (runner/done? state)
@@ -1441,7 +1463,43 @@
               #?(:cljs (settle-step-result!
                          idx step result
                          (fn [settled]
-                           (record-result! frame-id play-key nm idx step settled)
+                           ;; RUN-TOKEN FENCE (rf2-6pfpt). Awaiting the
+                           ;; thenable opens a window the synchronous path
+                           ;; never had: between parking here and settling,
+                           ;; a newer `run!` can take the slot or the frame
+                           ;; can be torn down. EVERY ordinary step is
+                           ;; already fenced — `run-loop!` re-checks the slot
+                           ;; before the next one mutates it — but this
+                           ;; callback used to `record-result!` FIRST and
+                           ;; re-enter the loop (where the check lives)
+                           ;; afterwards, putting the mutation on the far
+                           ;; side of the fence. A stale settlement then
+                           ;; appended ITS result to the REPLACEMENT run,
+                           ;; advancing a cursor past a step that run never
+                           ;; took; under teardown it fabricated a run-state
+                           ;; entry out of nil (`(inc nil)` is 1 on CLJS, so
+                           ;; nothing even threw) which, carrying no
+                           ;; `:run-token`, the guard below then declined to
+                           ;; abort on — a resurrected run reaching a
+                           ;; `finish!` verdict for a frame that was gone.
+                           ;;
+                           ;; Checking the live slot HERE closes it. The
+                           ;; check and the mutation are one synchronous
+                           ;; turn, so nothing can take the slot between
+                           ;; them.
+                           (when-not (stale-run?
+                                       token
+                                       (current-state-for-play frame-id play-key))
+                             (record-result! frame-id play-key nm idx step settled))
+                           ;; Re-enter unconditionally either way. When the
+                           ;; slot IS still ours the loop advances as before;
+                           ;; when it is not, the loop's own stale branch
+                           ;; settles this run's `done-cb` through
+                           ;; `settle-abort!`. That keeps ONE abort decision
+                           ;; in the codebase rather than a second copy of it
+                           ;; here — and a stale run still owes its
+                           ;; continuation, which the play-promise and the
+                           ;; outer `run-variant` promise resolve through.
                            (js/setTimeout
                              #(run-loop! frame-id play-key token done-cb) 0)))
                  :clj  nil)

--- a/tools/story/test/re_frame/story/play/presence_stale_settlement_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/play/presence_stale_settlement_cljs_test.cljs
@@ -1,0 +1,468 @@
+(ns re-frame.story.play.presence-stale-settlement-cljs-test
+  "rf2-6pfpt — STALE SETTLEMENT of a Promise-backed `[:flush-presence]`.
+
+  rf2-iz0t8 (#6367) made the presence step AWAIT its host's thenable before
+  recording, closing the 'reported `:pass` over a flush that failed' hazard.
+  Awaiting introduces a gap the synchronous path never had: between the
+  executor parking on the Promise and the Promise settling, ANOTHER agent can
+  take over the run — a concurrent `run!` stamping a fresher `:run-token` on
+  the `[frame-id play-key]` slot, or frame teardown removing the slot outright.
+  Story already fences that gap for every ordinary step: `run-loop!` re-checks
+  the slot's existence AND its token before the next step mutates anything.
+  The settled-Promise callback did NOT — it called `record-result!` first and
+  re-entered the loop (where the token check lives) afterwards, so the
+  mutation happened on the far side of the fence.
+
+  What that costs, concretely: run A parks on a presence Promise; run B takes
+  the slot; A settles and appends ITS step-result into B's run-state, bumping
+  B's cursor past a step B never ran and contaminating B's verdict. Under
+  teardown, `record-step-result` applied to a nil state does not even throw on
+  CLJS — `(inc nil)` is 1 — so it RESURRECTS a phantom run-state entry carrying
+  no `:run-token`, which the loop's token guard (`(some? (:run-token state))`)
+  then declines to abort on.
+
+  THE SAME SHAPE IN THE INTERACTIVE STEPPER. `play/step-once!` amends its
+  recorded result when the presence Promise settles, guarded only by a BOUNDS
+  check (`idx < (count results)`). A bounds check is a size test, not an
+  identity test: it correctly declines when a reset has SHRUNK `:results` below
+  `idx`, and then silently permits the clobber once a new cursor has grown back
+  past `idx` — a stale amendment landing on a different session's step.
+
+  Every test here is DETERMINISTIC. The host returns a hand-rolled thenable
+  whose settlement this namespace triggers explicitly (`resolve!` / `reject!`
+  run the stored callbacks synchronously), so 'A settles AFTER B took the slot'
+  is placed exactly, not raced. A real `js/Promise` would settle on a microtask
+  the test cannot interleave against — which is what made this defect class
+  intermittent in the wild, and is precisely what a regression test must not
+  reproduce.
+
+  Pure `.cljs`: the `::pending-advance` branch is reader-gated to CLJS (the JVM
+  presence verb is a synchronous no-op, so `advance!` never yields a
+  `:pending`), and the `async` tests below require cljs.test MAP fixtures,
+  which a `.cljc` may not use (`re-frame.story.meta-fixtures-test`)."
+  (:require [cljs.test :refer [async deftest is testing use-fixtures]]
+            [re-frame.story.play                    :as play]
+            [re-frame.story.play.presence           :as story-presence]
+            [re-frame.story.play.runner             :as runner]
+            [re-frame.story.play.runner-events      :as re]
+            ;; The shared harness (fresh registrar + runtime + variant frame),
+            ;; reused rather than re-built — one harness across the presence
+            ;; rung's coverage.
+            [re-frame.story.play.presence-cljs-test :as shared]))
+
+;; `clear-all-runs!` on top of the shared setup: `shared/setup!` resets
+;; `re/run-state` but not `runs-by-play`, and every assertion here reads the
+;; slot through `current-state-for-play` (which derefs `runs-by-play`). A slot
+;; surviving from a previous test would make a stale-settlement assertion read
+;; a state this test never seeded.
+(use-fixtures :each
+  {:before (fn [] (shared/setup!) (re/clear-all-runs!))
+   :after  (fn [] (shared/teardown!) (re/clear-all-runs!))})
+
+;; The private run-loop seam, reached via var-quote — the established
+;; Story-test seam (`runner-events-cljs-test` drives the abort branches the
+;; same way).
+(def ^:private run-loop!  @#'re/run-loop!)
+(def ^:private set-state! @#'re/set-state!)
+
+;; ---------------------------------------------------------------------------
+;; A deferred whose settlement the TEST places
+;; ---------------------------------------------------------------------------
+
+(defn- deferred
+  "A thenable that records its callbacks and settles only when this test says
+  so. `presence/thenable` duck-types on `.then` being a fn, so a hand-rolled
+  object is observed exactly as a `js/Promise` is — without a microtask the
+  test cannot schedule against."
+  []
+  (let [cbs (atom [])]
+    {:thenable (js-obj "then" (fn [on-ok on-err]
+                                (swap! cbs conj [on-ok on-err])
+                                nil))
+     :armed?   (fn [] (boolean (seq @cbs)))
+     :resolve! (fn [v] (doseq [[ok _] @cbs] (ok v)) nil)
+     :reject!  (fn [e] (doseq [[_ err] @cbs] (err e)) nil)}))
+
+(defn- install-deferred-host!
+  "Install a presence host whose advance parks on `d`. `calls` records each
+  advance's ms so a test can prove the verb was REACHED — a fence that worked
+  by never running the host would pass every staleness assertion here."
+  [d calls]
+  (story-presence/install-presence-flush!
+    (fn [ms] (swap! calls conj ms) (:thenable d))))
+
+(defn- seed-run!
+  "Stamp a fresh run carrying `token` onto the `[presence-frame nil]` slot.
+  Returns the seeded state."
+  [token script]
+  (let [started (-> (runner/start
+                      (runner/initial-state {:name nil :script script}) 0)
+                    (assoc :run-token token))]
+    (set-state! shared/presence-frame nil started)
+    started))
+
+(defn- start-run!
+  "Seed a run carrying `token` and drive `run-loop!` for it. With a
+  `[:flush-presence]` leading step against a deferred host the loop PARKS: it
+  returns having recorded nothing, its continuation held by the thenable."
+  ([token script] (start-run! token script nil))
+  ([token script done-cb]
+   (seed-run! token script)
+   (run-loop! shared/presence-frame nil token done-cb)))
+
+(defn- slot []
+  (re/current-state-for-play shared/presence-frame nil))
+
+(def ^:private presence-script
+  [[:flush-presence] [:dispatch [:presence/tick]]])
+
+;; ===========================================================================
+;; The auto-run loop: the run-token fence
+;; ===========================================================================
+
+(deftest a-parked-presence-run-has-recorded-nothing-yet
+  (testing "the premise every test below rests on — with the host's thenable
+            unsettled the loop has PARKED: the verb was reached, and the run
+            state carries no result for the step whose outcome is still unknown"
+    (let [d     (deferred)
+          calls (atom [])]
+      (install-deferred-host! d calls)
+      (start-run! "tok-A" presence-script)
+      (is (= [nil] @calls) "the presence verb was REACHED (bare arity → nil ms)")
+      (is (true? ((:armed? d))) "and the run parked on its thenable")
+      (is (= 0 (:step-idx (slot))) "no cursor movement while pending")
+      (is (= 0 (count (:results (slot)))) "and nothing recorded"))))
+
+(deftest stale-settlement-does-not-mutate-the-replacement-run
+  (testing "THE BUG (rf2-6pfpt): run A parks on a presence Promise, a
+            concurrent run B takes over the `[frame play-key]` slot, and A
+            THEN settles. A's result must not land in B's run-state — it would
+            advance B's cursor past a step B never ran and contaminate B's
+            verdict. `record-result!` used to run BEFORE the token check the
+            loop performs on re-entry"
+    (let [d     (deferred)
+          calls (atom [])]
+      (install-deferred-host! d calls)
+      (start-run! "tok-A" presence-script)
+      ;; A newer `run!` replaces the slot — exactly what `run!` does when the
+      ;; selection-watcher fires while an orchestrated run is mid-script.
+      (seed-run! "tok-B" [[:dispatch [:presence/tick]]])
+      (is (= 0 (:step-idx (slot))) "precondition: B is at its first step")
+      ;; A settles LATE, on the far side of the takeover.
+      ((:resolve! d) :ok)
+      (let [s (slot)]
+        (is (= "tok-B" (:run-token s))
+            "B still OWNS the slot — the stale settlement did not re-stamp it")
+        (is (= 0 (:step-idx s))
+            "rf2-6pfpt — A's settled result did NOT advance B's cursor")
+        (is (= 0 (count (:results s)))
+            "and was NOT appended to B's results")
+        (is (= :running (:status s))
+            "B is still running — no terminal transition leaked in")))))
+
+(deftest teardown-while-pending-neither-throws-nor-resurrects-state
+  (testing "rf2-6pfpt — the frame is torn down (`clear-state!`, the
+            `:drop-run-state` teardown hook) while the presence Promise is in
+            flight. Settling must not throw, and must not RESURRECT the slot:
+            `record-step-result` over a nil state does not throw on CLJS
+            (`(inc nil)` is 1), it fabricates a state map carrying no
+            `:run-token` — which the loop's token guard then declines to abort
+            on, because it only fires when a token is PRESENT"
+    (let [d     (deferred)
+          calls (atom [])]
+      (install-deferred-host! d calls)
+      (start-run! "tok-A" presence-script)
+      (re/clear-state! shared/presence-frame)
+      (is (nil? (slot)) "precondition: teardown removed the slot")
+      (is (nil? ((:resolve! d) :ok))
+          "settling after teardown completes without throwing")
+      (is (nil? (slot))
+          "and left NO phantom entry in runs-by-play")
+      (is (nil? (get @re/run-state shared/presence-frame))
+          "nor in run-state — update-state! writes BOTH atoms, so both are
+           checked"))))
+
+(deftest an-owning-run-still-records-its-resolved-result
+  (testing "POSITIVE CONTROL. A fence that simply stopped recording settled
+            presence results would pass every staleness test above while
+            breaking every real presence run — and would silently reinstate the
+            rf2-iz0t8 hazard it was built on top of. The run that still OWNS
+            the slot records exactly as before"
+    (let [d     (deferred)
+          calls (atom [])]
+      (install-deferred-host! d calls)
+      (start-run! "tok-A" presence-script)
+      ((:resolve! d) :ok)
+      (let [s (slot)]
+        (is (= 1 (:step-idx s)) "the owning run's cursor advanced")
+        (is (= 1 (count (:results s))) "and its settled result was recorded")
+        (is (nil? (:exception (first (:results s))))
+            "a resolved advance is a clean step")))))
+
+(deftest an-owning-run-still-records-its-rejected-result
+  (testing "POSITIVE CONTROL, the other outcome. A rejection is the whole
+            reason the await exists (rf2-iz0t8) — it must still reach the run
+            state as the ordinary step-exception, unchanged by the fence"
+    (let [d     (deferred)
+          calls (atom [])]
+      (install-deferred-host! d calls)
+      (start-run! "tok-A" presence-script)
+      ((:reject! d) (ex-info "presence flush failed" {}))
+      (let [s (slot)
+            r (first (:results s))]
+        (is (= 1 (:step-idx s)))
+        (is (true? (:exception r))
+            "the rejection lands in the EXISTING step-exception vocabulary")
+        (is (false? (:passed? r)))
+        (is (nil? (:cannot-run? r))
+            "a rejected flush is a failure, not a refusal — the host WAS
+             reached")))))
+
+(deftest the-run-token-fence-does-not-latch
+  (testing "THE SEQUENCE, not just the cases. A state-carrying fence can be
+            correct on every single transition and still be broken as a
+            machine: it may latch shut after its first refusal, or latch open
+            after its first admission. Four transitions in one process, each
+            asserted: ADMIT a settlement, REFUSE a stale one, ADMIT again
+            (proving the refusal did not latch shut), REFUSE again (proving
+            the admission did not latch open)"
+    (let [calls (atom [])]
+      ;; 1 — CLEAN: the owning run settles and is admitted.
+      (let [d1 (deferred)]
+        (install-deferred-host! d1 calls)
+        (start-run! "tok-1" presence-script)
+        ((:resolve! d1) :ok)
+        (is (= 1 (:step-idx (slot))) "1/4 ADMITTED — the owner recorded"))
+      ;; 2 — VIOLATE: a stale run settles after a takeover; refused.
+      (let [d2 (deferred)]
+        (install-deferred-host! d2 calls)
+        (start-run! "tok-2" presence-script)
+        (seed-run! "tok-2-usurper" presence-script)
+        ((:resolve! d2) :ok)
+        (is (= 0 (:step-idx (slot))) "2/4 REFUSED — the usurper is untouched"))
+      ;; 3 — RECOVER: a fresh owning run settles; admitted again. If the fence
+      ;; latched shut on the refusal above, this is where it shows.
+      (let [d3 (deferred)]
+        (install-deferred-host! d3 calls)
+        (start-run! "tok-3" presence-script)
+        ((:resolve! d3) :ok)
+        (is (= 1 (:step-idx (slot)))
+            "3/4 ADMITTED AGAIN — the refusal did not latch the fence shut"))
+      ;; 4 — VIOLATE AGAIN: the tooth that the `ai/` ratchet was missing. A
+      ;; fence that accepted a second violation after a recovery would have
+      ;; passed all three transitions above.
+      (let [d4 (deferred)]
+        (install-deferred-host! d4 calls)
+        (start-run! "tok-4" presence-script)
+        (seed-run! "tok-4-usurper" presence-script)
+        ((:resolve! d4) :ok)
+        (is (= 0 (:step-idx (slot)))
+            "4/4 REFUSED AGAIN — the admission did not latch the fence open"))
+      (is (= 4 (count @calls))
+          "all four runs really reached the presence verb"))))
+
+(deftest a-stale-run-settles-its-own-continuation
+  (testing "rf2-6pfpt — refusing the MUTATION must not strand the CONTINUATION.
+            The stale run still owes its own `done-cb` (the play-promise, and
+            the outer `run-variant` promise chained off it, resolve through it
+            and carry no timeout). The fence declines to record and re-enters
+            the loop, which reaches the SAME `settle-abort!` every other stale
+            exit path uses — one abort decision, not a second copy"
+    (async done
+      (let [d     (deferred)
+            calls (atom [])]
+        (install-deferred-host! d calls)
+        (start-run! "tok-A" presence-script
+                    (fn [final]
+                      (is (= "tok-B" (:run-token final))
+                          "the stale run settled with the LAST-KNOWN slot state,
+                           without mutating it")
+                      (is (= 0 (:step-idx (slot)))
+                          "and B's cursor is still untouched at settle time")
+                      (done)))
+        (seed-run! "tok-B" presence-script)
+        ((:resolve! d) :ok)))))
+
+(deftest a-torn-down-run-settles-its-own-continuation
+  (testing "rf2-6pfpt — the same obligation under TEARDOWN. The slot is gone,
+            so there is nothing to record and nothing to transition; the
+            continuation is still owed and settles with the last-known (nil)
+            state rather than hanging forever"
+    (async done
+      (let [d     (deferred)
+            calls (atom [])]
+        (install-deferred-host! d calls)
+        (start-run! "tok-A" presence-script
+                    (fn [final]
+                      (is (nil? final)
+                          "settled with nil — the slot was torn down, and the
+                           continuation only chains the next play")
+                      (done)))
+        (re/clear-state! shared/presence-frame)
+        ((:resolve! d) :ok)))))
+
+;; ===========================================================================
+;; The interactive stepper: the same shape, fenced by RECORD IDENTITY
+;; ===========================================================================
+;;
+;; The stepper has no run token to carry — its session identity is not minted
+;; at one entry point but mutated at five (`begin-stepper!`,
+;; `stepper-step-back!`, `stepper-rewind!`, `end-stepper!`,
+;; `clear-all-play-state!`). A generation counter would have to be bumped at
+;; each, and a bump at `stepper-step-back!` would ALSO invalidate a still-valid
+;; amendment for an EARLIER index that step-back never touched.
+;;
+;; The claim a settling step actually needs is narrower than a session: 'amend
+;; the record I MYSELF recorded, not whatever now occupies my index'. That is
+;; the provisional record's own object identity — captured with no extra state,
+;; and automatically correct at every cursor mutation, including ones not yet
+;; written.
+
+(defn- seed-stepper!
+  "Seed the stepper cursor directly, as `presence-real-clock-cljs-test` does:
+  `begin-stepper!` resolves its script off a REGISTERED variant, and
+  registering one would add a fixture without adding coverage. `stepper-state`
+  is the documented substrate surface and `step-once!` is driven exactly as the
+  UI widget drives it."
+  [steps]
+  (swap! play/stepper-state assoc shared/presence-frame
+         {:remaining steps :ran [] :results []})
+  nil)
+
+(defn- stepper-results []
+  (:results (get @play/stepper-state shared/presence-frame)))
+
+(deftest stale-stepper-settlement-does-not-clobber-a-new-session
+  (testing "THE BUG in the stepper (rf2-6pfpt): a presence step parks, the
+            session is REWOUND, and the new cursor runs a different step into
+            the same index. The bounds guard (`idx < (count results)`) is a
+            SIZE test — it declines while the rewound `:results` is short, then
+            permits the clobber the moment the new cursor has grown back past
+            `idx`, overwriting a step the stale settlement never ran"
+    (let [stale (deferred)
+          live  (deferred)
+          calls (atom [])]
+      (install-deferred-host! stale calls)
+      (seed-stepper! [[:flush-presence 100] [:dispatch [:presence/tick]]])
+      (play/step-once! shared/presence-frame)
+      (is (true? ((:armed? stale))) "the stepper parked on the thenable")
+      ;; A real reset/new-cursor path — the UI's rewind button.
+      (play/stepper-rewind! shared/presence-frame)
+      (is (= 0 (count (stepper-results))) "the rewind emptied :results")
+      ;; The new session parks on a DIFFERENT deferred, so settling the stale
+      ;; one settles ONLY the abandoned session — otherwise one `resolve!`
+      ;; would fire both callbacks and the assertion could not tell a refused
+      ;; stale amendment from an admitted live one.
+      (install-deferred-host! live calls)
+      (play/step-once! shared/presence-frame)
+      (let [fresh (first (stepper-results))]
+        (is (= 1 (count (stepper-results))) "index 0 belongs to the new session")
+        (is (= :flush-presence (:type fresh))
+            "precondition: the rewound session re-runs the same first step,
+             so the stale amendment's index is occupied again")
+        ;; The ABANDONED session's Promise settles.
+        ((:resolve! stale) :ok)
+        (is (identical? fresh (first (stepper-results)))
+            "rf2-6pfpt — the stale settlement did NOT overwrite the new
+             session's record at that index")
+        ;; ... and the LIVE session's own settlement is still admitted, so the
+        ;; refusal above is a fence, not a blanket refusal to amend.
+        ((:reject! live) (ex-info "presence flush failed" {}))
+        (is (true? (:exception (first (stepper-results))))
+            "the OWNING session's amendment landed")))))
+
+(deftest an-owning-stepper-step-still-receives-its-settled-result
+  (testing "POSITIVE CONTROL. The whole point of the stepper's settle callback
+            (rf2-iz0t8) is that the debugger shows the SAME verdict the auto-run
+            loop records. The fence must not cost that: an untouched session's
+            record is still amended in place when its Promise rejects"
+    (let [d     (deferred)
+          calls (atom [])]
+      (install-deferred-host! d calls)
+      (seed-stepper! [[:flush-presence 100]])
+      (play/step-once! shared/presence-frame)
+      (is (nil? (:exception (first (stepper-results))))
+          "provisional: the parked step reads clean before settlement")
+      ((:reject! d) (ex-info "presence flush failed" {}))
+      (let [r (first (stepper-results))]
+        (is (true? (:exception r))
+            "the settled failure replaced the provisional record — the stepper
+             agrees with the auto-run path")
+        (is (false? (:passed? r)))))))
+
+(deftest a-step-back-does-not-invalidate-an-earlier-pending-amendment
+  (testing "WHY IDENTITY, NOT A GENERATION. `stepper-step-back!` pops only the
+            LAST step; a pending amendment for an EARLIER index is still owed
+            and still correct. A session-level generation bumped on step-back
+            would refuse it — silently reinstating the rf2-iz0t8 'clean flush
+            over a failed one' hazard. The record-identity fence admits it,
+            because the object at that index is still the one it recorded"
+    (let [d     (deferred)
+          calls (atom [])]
+      (install-deferred-host! d calls)
+      (seed-stepper! [[:flush-presence 100] [:dispatch [:presence/tick]]])
+      (play/step-once! shared/presence-frame)          ; idx 0 — parks
+      (play/step-once! shared/presence-frame)          ; idx 1 — synchronous
+      (is (= 2 (count (stepper-results))))
+      (play/stepper-step-back! shared/presence-frame)  ; pops idx 1 only
+      (is (= 1 (count (stepper-results))) "idx 1 was dropped; idx 0 survives")
+      (play/step-once! shared/presence-frame)          ; re-runs into idx 1
+      (is (= 2 (count (stepper-results))))
+      ((:reject! d) (ex-info "presence flush failed" {}))
+      (is (true? (:exception (first (stepper-results))))
+          "idx 0's amendment was ADMITTED — step-back never touched it"))))
+
+(deftest the-stepper-fence-does-not-latch
+  (testing "THE SEQUENCE for the stepper fence: ADMIT, REFUSE, ADMIT again,
+            REFUSE again — the same four transitions the run-token fence is
+            held to above, for the same reason"
+    (let [calls (atom [])]
+      ;; 1 — ADMIT.
+      (let [d1 (deferred)]
+        (install-deferred-host! d1 calls)
+        (seed-stepper! [[:flush-presence 100]])
+        (play/step-once! shared/presence-frame)
+        ((:reject! d1) (ex-info "boom" {}))
+        (is (true? (:exception (first (stepper-results))))
+            "1/4 ADMITTED — the owning step was amended"))
+      ;; 2 — REFUSE across a rewind. The post-rewind step parks on its OWN
+      ;; deferred (see `stale-stepper-settlement-does-not-clobber-a-new-session`
+      ;; for why the two sessions must not share one).
+      (let [d2 (deferred)
+            l2 (deferred)]
+        (install-deferred-host! d2 calls)
+        (seed-stepper! [[:flush-presence 100]])
+        (play/step-once! shared/presence-frame)
+        (play/stepper-rewind! shared/presence-frame)
+        (install-deferred-host! l2 calls)
+        (play/step-once! shared/presence-frame)
+        (let [fresh (first (stepper-results))]
+          ((:reject! d2) (ex-info "boom" {}))
+          (is (identical? fresh (first (stepper-results)))
+              "2/4 REFUSED — the new session's record stands")))
+      ;; 3 — ADMIT again: the refusal must not have latched the fence shut.
+      (let [d3 (deferred)]
+        (install-deferred-host! d3 calls)
+        (seed-stepper! [[:flush-presence 100]])
+        (play/step-once! shared/presence-frame)
+        ((:reject! d3) (ex-info "boom" {}))
+        (is (true? (:exception (first (stepper-results))))
+            "3/4 ADMITTED AGAIN — the fence did not latch shut"))
+      ;; 4 — REFUSE again: the admission must not have latched it open.
+      (let [d4 (deferred)
+            l4 (deferred)]
+        (install-deferred-host! d4 calls)
+        (seed-stepper! [[:flush-presence 100]])
+        (play/step-once! shared/presence-frame)
+        (play/stepper-rewind! shared/presence-frame)
+        (install-deferred-host! l4 calls)
+        (play/step-once! shared/presence-frame)
+        (let [fresh (first (stepper-results))]
+          ((:reject! d4) (ex-info "boom" {}))
+          (is (identical? fresh (first (stepper-results)))
+              "4/4 REFUSED AGAIN — the fence did not latch open")))
+      (is (= 6 (count @calls))
+          "every stepped presence step really reached the verb (four sessions,
+           two of them stepped twice across a rewind)")
+      ;; `stepper-state` is process-global — leave no cursor behind.
+      (swap! play/stepper-state dissoc shared/presence-frame))))


### PR DESCRIPTION
Closes rf2-6pfpt.

## The defect

rf2-iz0t8 (#6367) made `[:flush-presence]` AWAIT its host's thenable before recording, closing the "reported `:pass` over a flush that failed" hazard. Awaiting opens a window the synchronous path never had: between the executor parking on the Promise and the Promise settling, a newer `run!` can take the `[frame-id play-key]` slot, or the frame can be torn down.

Story already fences that window for every ordinary step — `run-loop!` re-checks the slot's existence and its `:run-token` before the next step mutates anything. The settled-Promise callback did not. It called `record-result!` **first** and re-entered the loop (where the check lives) **afterwards**, so the mutation happened on the far side of the fence.

Two consequences, both reproduced:

- **Contamination.** Run A parks on a presence Promise; run B takes the slot; A settles and appends its step-result into B's run-state, advancing B's cursor past a step B never took.
- **Resurrection.** Under teardown, `record-step-result` over a nil state does not even throw on CLJS (`(inc nil)` is `1`), so it fabricates a run-state entry. That entry carries no `:run-token`, and the loop's token guard only fires when a token is *present* — so the resurrected run was not aborted and ran on to a `finish!` verdict of **`:status :pass` for a frame that was gone**.

## The fix

The slot-ownership test is extracted to `stale-run?` — one definition, consulted by both the loop and the settlement callback, so the two cannot drift. The callback checks it before recording, then re-enters the loop **unconditionally**: when the slot is still ours the loop advances as before; when it is not, the loop's own stale branch settles this run's `done-cb` through the same `settle-abort!` every other stale exit uses. One abort decision in the codebase, not a second copy — and a stale run still owes its continuation, which the play-promise and the outer `run-variant` promise resolve through.

Execution order is **not** pinned anywhere; the fence is a check against the live slot, which is what makes it robust to any interleaving rather than to one.

### Mechanism: value, not conveyance

Deliberately *not* a `^:dynamic` Var or ThreadLocal. The hazard is a run **outliving its claim** on shared state, not a claim failing to reach a child. `token` is already conveyed correctly — it rides as an argument through `run-loop!` and is captured by the settlement closure. What it must be checked *against* is the live slot, and a conveyed mechanism cannot do that: a binding conveyed into the callback would agree with the callback by construction. The check and the mutation are one synchronous turn, so nothing can take the slot between them.

### The interactive stepper

`play/step-once!` shares the shape. Its amendment was guarded by a **bounds** check (`idx < (count results)`) — a size test, not an identity test. It correctly declines while a reset has left `:results` shorter than `idx`, then silently permits the clobber once a new cursor has grown back past `idx`, landing a stale amendment on a different session's step.

It is now fenced on the provisional record's own **object identity** (hence `identical?`, not `=`: two runs of the same step are legitimately equal and must still be told apart). Identity was chosen over a generation counter because the stepper's session identity is not minted at one entry point but mutated at five (`begin-stepper!`, `stepper-step-back!`, `stepper-rewind!`, `end-stepper!`, `clear-all-play-state!`) — and because a session-level generation would be actively *wrong* at `stepper-step-back!`, which pops only the last step: an amendment still owed for an earlier index remains valid, and a generation bump would refuse it, quietly reinstating the rf2-iz0t8 hazard. A dedicated test pins that.

## Measurement

The defect class is intermittent in the wild, so the regression test is built to be the opposite. The host returns a hand-rolled thenable whose settlement the test triggers explicitly, placing "A settles after B took the slot" exactly rather than racing it.

| | trials | result |
|---|---|---|
| new namespace, fix **reverted** | 10 | **10/10 RED** — 11 failures every run, identical failure set |
| new namespace, fix applied | 10 | **10/10 GREEN** — 0 failures |

The fence carries state, so it is proved as a **sequence**, not just as cases: ADMIT → REFUSE → ADMIT again → REFUSE again, in one process, for both the run-token fence and the stepper fence. A fence that latched shut after its first refusal, or open after its first admission, passes the single transitions and fails these.

Positive controls throughout: an owning run still records its resolved result *and* its rejected result; an owning stepper step still receives its settled amendment. A fence that simply stopped recording settled presence results would pass every staleness assertion and silently undo rf2-iz0t8.

## Quality gates

All foreground, run to completion, exit codes captured by redirect (never piped).

| gate | result |
|---|---|
| `cd tools/story && clojure -M:test` | **Ran 1836 tests, 6792 assertions — 0 failures, 0 errors** (exit 0) |
| `npm run test:cljs` | **Ran 10140 tests, 50071 assertions — 0 failures, 0 errors** (exit 0) |
| new namespace alone × 10 | 26 tests, 97 assertions — 0 failures (exit 0), 10/10 |
| new namespace alone × 10, fix reverted | 11 failures (exit 1), 10/10 |
| `scripts/check-no-hardcoded-paths.sh` | OK (exit 0) |

**Vacuity probe.** The full CLJS runner prints no per-namespace headers, so a green total does not by itself prove the new namespace executed inside it. An assertion was deliberately flipped and `npm run test:cljs` re-run: it went **red with exactly 1 failure, naming the probe**, then was restored. The coverage is real, not vacuous.

`npm run test:browser` was not run: this change involves no mounted behaviour. The presence host is a stub thenable, no DOM is touched, and a node-only mounted claim would be vacuous anyway.

## Scope

Three files, all under `tools/story/**`: `runner_events.cljc`, `play.cljc`, and the new test namespace. No `spec/009` row is needed — no new error id is introduced (the existing vocabulary is reused throughout). Nothing under `tools/xray/` or `tools/machines-viz/` is touched, so the `rf2-xray-specs` rule does not apply.

## Same shape elsewhere — named, not fixed

- `tools/story/src/re_frame/story/ui/a11y.cljs` (`run-axe!`) and its sibling `chrome_a11y.cljs` mutate `run-state` and `violations-by-frame`, both keyed by frame-id, inside `.then` callbacks with no check that the frame still exists or that a newer scan superseded this one. Same ownership-boundary shape; out of scope here.
- `runner-events/run-step!`'s settle callback still calls `emit-trace!` unfenced, so an abandoned stepper session's presence settlement emits a trace event. Left deliberately: `run-step!` is a public, late-bound one-shot executor with no session identity of its own — giving it one would change the `:run-play-step` hook signature — and the event is a factual record of a flush that really did settle, carrying its own idx/step. The *recorded verdict*, which is what a consumer reads, is fenced on the caller's side.
