### PR TITLE
fix(ssr): exact manifest EDN round trip and byte-identical JVM keyword children (rf2-v4foc, rf2-53lsj)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/ssr_keyword_child_hydration_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/ssr_keyword_child_hydration_dom_cljs_test.cljs
@@ -1,0 +1,213 @@
+(ns re-frame.ssr-keyword-child-hydration-dom-cljs-test
+  "rf2-53lsj — does the JVM emitter's markup actually HYDRATE?
+
+  The two keyword-head contract suites
+  (`re-frame.ssr-keyword-head-contract-test` and its CLJS twin) pin the
+  bytes each host produces. Matching bytes is necessary but it is not the
+  claim that matters: the claim is that server markup and client render
+  reconcile without React complaining and without the text changing under
+  the user. This file makes React itself the judge.
+
+  ## Why this file exists at all
+
+  #6378 asserted the element structure agreed and reasoned that the
+  differing TEXT was harmless because \"element structure is what
+  hydration reconciles\". React reconciles text nodes too. Rather than
+  argue the point again in a comment, the test below hands React the
+  server bytes and the client tree and asks it.
+
+  ## The vacuity lever
+
+  A hydration probe that never fails proves nothing, and a silent
+  `console.error` capture is exactly the shape that rots. So the same
+  harness is run TWICE:
+
+    - over the bytes the emitter produces NOW (`<card>revenue</card>`)
+      — React must be silent;
+    - over the bytes it produced BEFORE the fix (`<card>:revenue</card>`)
+      — React must COMPLAIN.
+
+  The second case is the red-before, kept permanently executable. If
+  React ever stops reporting text mismatches, or the capture stops
+  working, that test goes red and this file stops making a claim it can
+  no longer support — rather than going quietly green.
+
+  The `-dom-cljs-test$` suffix opts this file into the `:browser-test`
+  build. `:node-test` loads it too (it matches `cljs-test$`), where
+  `js/document` is absent and every test here gates on `(browser?)` and
+  exits early. **A node-only run of this namespace is VACUOUS by
+  construction** — `npm run test:browser` is where it asserts."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            ["react" :as React]
+            ["react-dom/client" :as react-dom-client]
+            [reagent.core :as r]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.ssr.install :as install]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private test-frame :ssr-keyword-child-hydration/frame)
+
+(defn- init! []
+  (rf/make-frame {:id       test-frame
+                  :doc      "keyword-child hydration probe frame"
+                  :platform :client})
+  (rf/reg-view* :dashboard/card {}
+                (fn [card-id] [:div.card [:h3 (str card-id)]])))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter
+     :init-fn init!})
+  ;; No test here INSTALLS a hydration payload, but the ledger is a
+  ;; process-global `defonce` that neither `clear-all!` nor a frames
+  ;; reset touches (rf2-aorfy), so a future edit that adds an install
+  ;; would leak into sibling namespaces rather than fail here. Resetting
+  ;; unconditionally keeps that trap shut.
+  (fn [f] (install/reset-installed-payloads!) (f)))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- get-act []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try (.-act (js/require "react-dom/test-utils"))
+           (catch :default _ nil))))
+
+;; ---------------------------------------------------------------------------
+;; The harness
+;; ---------------------------------------------------------------------------
+
+(defn- hydrate-over
+  "Put `server-html` into a detached-then-attached container, hydrate
+  `tree` over it with REAL React, and report what React said.
+
+  -> `{:complaints [str …] :text \"…\"}`.
+
+  React reports hydration mismatches through `console.error`, so both
+  `error` and `warn` are captured for the duration and restored after —
+  the runner installs its own `console.warn` buffer, and this save/
+  restore pairs with it rather than fighting it."
+  [server-html tree]
+  (let [container  (.createElement js/document "div")
+        complaints (atom [])
+        orig-error (.-error js/console)
+        orig-warn  (.-warn js/console)
+        record!    (fn [& args]
+                     (swap! complaints conj
+                            (str/join " " (map #(str %) args))))]
+    (set! (.-innerHTML container) server-html)
+    (.appendChild (.-body js/document) container)
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (set! (.-error js/console) record!)
+    (set! (.-warn js/console) record!)
+    (let [act-fn (get-act)
+          root   (atom nil)]
+      (try
+        ;; React is driven DIRECTLY here rather than through
+        ;; `reagent.dom.client/hydrate-root`. Reagent 2.0.1 destructures
+        ;; `:on-recoverable-error` from its options map and then never
+        ;; passes it to `hydrateRoot`, so the callback React uses to
+        ;; report a recovered hydration mismatch is unreachable through
+        ;; that wrapper. `as-element` still builds the tree the Reagent
+        ;; way, so what is under test is unchanged — only the root
+        ;; handle is ours, so the probe can hear React.
+        (act-fn
+          (fn []
+            (reset! root
+                    (react-dom-client/hydrateRoot
+                      container
+                      (r/as-element [rf/frame-provider {:frame test-frame} tree])
+                      #js {:onRecoverableError
+                           (fn [err _info] (record! "onRecoverableError" err))}))))
+        (let [text (.-textContent container)]
+          (act-fn (fn [] (some-> @root .unmount)))
+          {:complaints @complaints :text text})
+        (finally
+          (set! (.-error js/console) orig-error)
+          (set! (.-warn js/console) orig-warn)
+          (.remove container))))))
+
+(defn- hydration-complaints
+  "Only the complaints that are about HYDRATION — React emits unrelated
+  development warnings, and counting those would make the green case
+  flaky and the red case dishonest."
+  [complaints]
+  (filter #(let [s (str/lower-case %)]
+             (or (str/includes? s "hydrat")
+                 (str/includes? s "did not match")
+                 (str/includes? s "didn't match")
+                 (str/includes? s "server rendered")))
+          complaints))
+
+;; ---------------------------------------------------------------------------
+;; The claim
+;; ---------------------------------------------------------------------------
+
+(deftest jvm-markup-hydrates-without-a-text-mismatch
+  (if-not (browser?)
+    (is true "skipped under node — no js/document; npm run test:browser asserts")
+    (testing "rf2-53lsj — the bytes the JVM emitter produces for
+              `[:dashboard/card :revenue]` hydrate silently, and the text
+              the user sees is the text the server sent"
+      (let [{:keys [complaints text]}
+            (hydrate-over "<card>revenue</card>" [:dashboard/card :revenue])]
+        (is (empty? (hydration-complaints complaints))
+            (str "React complained about hydrating the emitter's own "
+                 "markup: " (pr-str (hydration-complaints complaints))))
+        (is (= "revenue" text)
+            "the intended text survives hydration — not blanked, not
+             rewritten")))))
+
+(deftest hydration-probe-detects-a-real-mismatch
+  (if-not (browser?)
+    (is true "skipped under node — no js/document; npm run test:browser asserts")
+    (testing "THE RED-BEFORE for rf2-53lsj, kept executable: the SAME
+              harness over the bytes the emitter produced BEFORE the fix
+              (`<card>:revenue</card>`) must make React complain.
+
+              This is what licenses the green assertion above. Without it
+              an empty-complaints result could mean `the markup hydrates`
+              or `the capture is broken`, and those are indistinguishable
+              from a passing test. That is not hypothetical: the first
+              version of this harness went through
+              `reagent.dom.client/hydrate-root` and captured NOTHING on
+              either input, because the wrapper drops the
+              `onRecoverableError` it accepts.
+
+              React 19's verdict on the pre-fix bytes, verbatim:
+
+                Hydration failed because the server rendered text didn't
+                match the client. …
+                  <card>
+                +       revenue
+                -       :revenue"
+      (let [{:keys [complaints]}
+            (hydrate-over "<card>:revenue</card>" [:dashboard/card :revenue])]
+        (is (seq (hydration-complaints complaints))
+            "React must report the pre-fix server text as a hydration
+             mismatch — if this is silent, the probe above proves nothing
+             and the `hydration only reconciles element structure` claim
+             would have been right after all")))))
+
+(deftest namespaced-keyword-child-hydrates
+  (if-not (browser?)
+    (is true "skipped under node — no js/document; npm run test:browser asserts")
+    (do
+      (testing "rf2-53lsj — the namespace-dropping case, which a
+                colon-stripping fix would have got wrong: the emitter sends
+                `b` for `:a/b`, and that is what hydrates clean"
+        (let [{:keys [complaints text]}
+              (hydrate-over "<div>b</div>" [:div :a/b])]
+          (is (empty? (hydration-complaints complaints))
+              (str "got: " (pr-str (hydration-complaints complaints))))
+          (is (= "b" text))))
+
+      (testing "…and the spelling a colon-strip would have produced does NOT
+                hydrate, which is why the `name` spelling is the fix"
+        (let [{:keys [complaints]} (hydrate-over "<div>a/b</div>" [:div :a/b])]
+          (is (seq (hydration-complaints complaints))
+              "`a/b` must be a mismatch — pinning this stops a future
+               `simplification` to colon-stripping from landing green"))))))

--- a/implementation/adapters/reagent/test/re_frame/ssr_keyword_head_contract_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/ssr_keyword_head_contract_cljs_test.cljs
@@ -31,13 +31,30 @@
   ## What these tests therefore assert
 
   That the client behaviour is UNCHANGED and is now the single grammar.
-  There is deliberately no client-side production change in this bead —
+  There is deliberately no client-side production change in either bead —
   nothing was added to this adapter. These assertions are the fixed point
   the server was moved onto, so a future edit that \"helpfully\" teaches
   a substrate to resolve keyword heads fails here.
 
+  ## The child spelling (rf2-53lsj)
+
+  rf2-j81hs moved the server onto this substrate's HEAD meaning and left
+  the CHILD spelling diverging: the JVM emitted `<card>:revenue</card>`
+  where this substrate paints `<card>revenue</card>`. The cross-host test
+  below named itself `client-markup-matches-the-jvm-emitter` while
+  checking only the opening and closing tags, and its comment argued the
+  text difference away on the grounds that hydration reconciles element
+  structure. It reconciles text nodes too — so the mismatch was real and
+  the test was the thing hiding it.
+
+  The rule is now the same on both hosts: a keyword or symbol child is
+  spelled by its `name`. Note WHICH spelling — Reagent runs `(name x)`,
+  so `:a/b` paints `b` and the namespace is gone. Stripping the colon
+  would have produced `a/b` and left the hosts apart; that case is pinned
+  explicitly below.
+
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
-  (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
+  (:require [cljs.test :refer-macros [are deftest testing use-fixtures is]]
             [clojure.string :as str]
             [reagent.dom.server :as rds]
             [re-frame.core :as rf]
@@ -72,10 +89,11 @@
 (deftest keyword-head-paints-an-element-not-a-view
   (testing "rf2-j81hs — `:dashboard/card` IS registered here, and the head
             still paints `<card>`: the tag is the keyword's `name`, the
-            namespace is dropped, and the argument lands as a text node.
-            This is the exact markup the JVM emitter now produces for the
-            same head."
+            namespace is dropped, and the argument lands as a text node
+            spelled by ITS `name` too (rf2-53lsj). This is the exact
+            markup the JVM emitter now produces for the same head."
     (let [html (render [:dashboard/card :revenue])]
+      (is (= "<card>revenue</card>" html))
       (is (str/includes? html "<card>") (str "got: " html))
       (is (not (str/includes? html "class=\"card\""))
           (str "the registered view must NOT have been resolved — that is "
@@ -100,21 +118,40 @@
 ;; ===========================================================================
 
 (deftest client-markup-matches-the-jvm-emitter
-  (testing "rf2-j81hs — the bytes this substrate paints for a keyword head
-            are the bytes the JVM emitter now emits for the same head.
+  (testing "rf2-j81hs + rf2-53lsj — the bytes this substrate paints for a
+            keyword head are the bytes the JVM emitter emits for the same
+            head. WHOLE STRING, not a prefix and a suffix.
 
-            The JVM side asserts `\"<card>:revenue</card>\"` exactly (see
-            `re-frame.ssr-keyword-head-contract-test`). React serialises
-            the text child without the keyword's leading colon, so the two
-            are not byte-identical at the TEXT node — but the ELEMENT
-            structure, which is what hydration reconciles and what the bug
-            was about, now agrees. Pinning the element and asserting the
-            absence of the resolved view is the honest form of that claim;
-            asserting byte equality would be a claim this test cannot
-            support."
-    (let [html (render [:dashboard/card :revenue])]
-      (is (str/starts-with? html "<card>") (str "got: " html))
-      (is (str/ends-with? html "</card>") (str "got: " html))))
+            #6378's version of this test asserted only `starts-with?
+            \"<card>\"` / `ends-with? \"</card>\"` and explained in prose
+            that the TEXT nodes differed but that this was fine because
+            \"element structure is what hydration reconciles\". React
+            hydration reconciles text nodes as well, so the server's
+            \":revenue\" could never have hydrated cleanly against this
+            substrate's \"revenue\" — the test's own name promised a byte
+            match it deliberately did not check.
+
+            Every string below is duplicated verbatim in the JVM twin
+            (`re-frame.ssr-keyword-head-contract-test`). A pair of
+            literals is the mechanism: neither host can call the other's
+            emitter, so the equality is proven by both sides pinning the
+            same bytes and both suites having to stay green."
+    (are [expected tree] (= expected (render tree))
+      "<card>revenue</card>"      [:dashboard/card :revenue]
+      "<div>revenue</div>"        [:div :revenue]
+      "<div>b</div>"              [:div :a/b]
+      "<div>leaf</div>"           [:div :ns.deep/leaf]
+      "<div>sym</div>"            [:div 'sym]
+      "<div>b</div>"              [:div 'a/b]
+      "<div>revenue growth</div>" [:div :revenue " " :growth]
+      "<div>1a</div>"             [:div 1 :a]))
+
+  (testing "the namespace is DROPPED — Reagent routes a named child
+            through `(name x)`, so `:a/b` paints `b`. A server-side fix
+            that merely stripped the leading colon would emit `a/b` and
+            still not match."
+    (is (= "<div>b</div>" (render [:div :a/b])))
+    (is (not= "<div>a/b</div>" (render [:div :a/b]))))
 
   (testing "an UNREGISTERED keyword head paints the identical element —
             registration state does not change a head's meaning on either

--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -523,6 +523,28 @@
      ;; unchanged.
      (number? el)      (hash/canonical-number el)
      (boolean? el)     ""
+     ;; A keyword or symbol CHILD is spelled by its `name` — no leading
+     ;; colon, namespace dropped (rf2-53lsj).
+     ;;
+     ;; These used to fall through to `escape-html`, whose `(str s)`
+     ;; keeps a keyword's colon and a symbol's namespace, so the JVM
+     ;; emitted `<card>:revenue</card>` and `<div>a/b</div>` where every
+     ;; client substrate paints `<card>revenue</card>` and `<div>b</div>`.
+     ;; Measured on both hosts: Reagent routes a `named?` child through
+     ;; `(name x)` before handing it to React, which is why the namespace
+     ;; disappears — `:a/b` and `'a/b` both paint `b`.
+     ;;
+     ;; rf2-j81hs aligned the HEAD meaning of a keyword and left the
+     ;; CHILD spelling diverging; a text-node mismatch is not cosmetic,
+     ;; because React hydration reconciles text nodes as well as element
+     ;; structure, so the server's ":revenue" could not hydrate cleanly
+     ;; against the client's "revenue". Same rule, same reason: one
+     ;; render tree means one thing on every host.
+     ;;
+     ;; `(or (keyword? el) (symbol? el))` rather than `named?` — the
+     ;; latter is CLJS-only, and this is a `.cljc` emitter.
+     (or (keyword? el) (symbol? el))
+     (html/escape-html (name el))
      (vector? el)
      (let [head (first el)]
        (cond

--- a/implementation/ssr/src/re_frame/ssr/manifest.cljc
+++ b/implementation/ssr/src/re_frame/ssr/manifest.cljc
@@ -248,7 +248,11 @@
   "Can `v` ride the manifest's EDN wire? Scalars (nil / boolean / number
   / string / keyword / symbol) and collections of carryable values.
   A fn, a host object, or any other opaque value cannot — and is never
-  silently dropped (see `serialise-props`)."
+  silently dropped (see `serialise-props`).
+
+  The question this answers is exactly `(= v (read (pr-str v)))` under
+  the BUNDLED safe reader — not \"is `v` map-shaped\". The distinction is
+  what the `record?` arm below exists for."
   [v]
   (cond
     (nil? v)     true
@@ -257,6 +261,21 @@
     (string? v)  true
     (keyword? v) true
     (symbol? v)  true
+    ;; A record satisfies `map?`, so without this arm it took the map
+    ;; branch, every entry tested carryable, and the record was declared
+    ;; wire-safe (rf2-v4foc). But `pr-str` does not emit a record as a
+    ;; map — it emits the TAGGED literal `#my.ns.R{:x 1}`, and the safe
+    ;; reader has no constructor for that tag, so the body threw
+    ;; `:invalid :unreadable` at the far end of the wire. The check must
+    ;; precede `map?`: a record is map-LIKE but not map-PRINTING, and
+    ;; this predicate is about the printed form.
+    ;;
+    ;; Rejecting rather than converting is deliberate. Reading the record
+    ;; back as a plain map would silently change the prop's TYPE between
+    ;; server and client, which is the same class of defect one layer
+    ;; down; the author converts explicitly (`(into {} r)`) so both hosts
+    ;; agree about what they are holding.
+    (record? v)  false
     (map? v)     (every? (fn [[k v']] (and (edn-carryable? k) (edn-carryable? v'))) v)
     (coll? v)    (every? edn-carryable? v)
     :else        false))
@@ -276,18 +295,27 @@
             (pr-str props))
        {:recovery :re-render-the-root-manifest
         :extra    {:invalid :props :got props}}))
+    ;; Both HALVES of every entry are checked. Testing only the value
+    ;; (rf2-v4foc) let an opaque KEY — a fn, a host object — through: the
+    ;; entry looked fine, `pr-str` emitted `#object[…]` for the key, and
+    ;; the reader rejected the whole body on the client. A prop map is
+    ;; carried key-and-value, so it is validated key-and-value.
     (doseq [[k v] props]
-      (when-not (edn-carryable? v)
-        (error/throw-error!
-         :rf.error/root-manifest-invalid where
-         (str "root prop " (pr-str k) " holds a value the manifest's EDN "
-              "wire cannot carry — the manifest records RENDER-TIME prop "
-              "values and hydration applies them as the server-rendered "
-              "truth, so dropping one would hydrate a different tree. "
-              "Pass serialisable data (derive the opaque value inside the "
-              "view instead of handing it in as a prop)")
-         {:recovery :pass-serialisable-root-props
-          :extra    {:unserialisable-prop k}})))
+      (let [bad-key? (not (edn-carryable? k))]
+        (when (or bad-key? (not (edn-carryable? v)))
+          (error/throw-error!
+           :rf.error/root-manifest-invalid where
+           (str "root prop " (pr-str k) " has a "
+                (if bad-key? "KEY" "value")
+                " the manifest's EDN wire cannot carry — the manifest "
+                "records RENDER-TIME prop values and hydration applies "
+                "them as the server-rendered truth, so dropping one would "
+                "hydrate a different tree. Pass serialisable data (derive "
+                "the opaque value inside the view instead of handing it "
+                "in as a prop)")
+           {:recovery :pass-serialisable-root-props
+            :extra    {:unserialisable-prop k
+                       :unserialisable-half (if bad-key? :key :value)}}))))
     props))
 
 ;; ---------------------------------------------------------------------------
@@ -330,6 +358,16 @@
 ;; The wire form
 ;; ---------------------------------------------------------------------------
 
+(defn- unwireable-key
+  "-> the first manifest KEY whose entry cannot ride the EDN wire, else
+  `nil`. Names the top-level key rather than a deep path: the key is
+  what the author wrote and can change, and `pr-str` of the offending
+  value is already in the message."
+  [m]
+  (some (fn [[k v]]
+          (when-not (and (edn-carryable? k) (edn-carryable? v)) k))
+        m))
+
 (defn script-html
   "-> the manifest's WIRE FORM: one `<script type=\"application/edn\"
   data-rf-root>` element carrying the `pr-str`'d manifest, escaped by
@@ -340,36 +378,95 @@
   Emit this element IMMEDIATELY AFTER the root's container — adjacency
   is the discovery rule (`discover`). The marker attribute is bare: it
   says \"a root manifest is here\", never WHICH root — that is the
-  content's `:root-id`."
+  content's `:root-id`.
+
+  ## The wire gate
+
+  Emission is where \"this value can ride EDN\" stops being advice and
+  becomes a guarantee, so the WHOLE manifest is checked here — not just
+  the `:props` `serialise-props` screened at assembly. The two are not
+  redundant: `serialise-props` fails EARLY, naming the offending prop;
+  this gate makes the property TOTAL. `script-html` is the only door
+  onto the wire, and every descriptor key rides through it too, so
+  without it a non-carryable `:static-props` still produced a body the
+  reader rejects — the same defect as the props one, one layer out
+  (rf2-v4foc).
+
+  One predicate, `edn-carryable?`, spelled once and enforced at both
+  points. Not a second rule."
   [m]
   (validate! 'rf.ssr/manifest-script m)
+  (when-let [k (unwireable-key m)]
+    (error/throw-error!
+     :rf.error/root-manifest-invalid 'rf.ssr/manifest-script
+     (str "root manifest key " (pr-str k) " holds a value the EDN wire "
+          "cannot carry, so the emitted body would not read back — "
+          "`pr-str` emits a tagged or host-object literal the bundled "
+          "safe reader has no constructor for, which would defer an "
+          "emit-time authoring mistake into a client hydration failure. "
+          "Every value on the manifest must be plain EDN data")
+     {:recovery :pass-serialisable-root-props
+      :extra    {:unserialisable-manifest-key k}}))
   (str "<script type=\"" manifest-script-type "\" "
        constants/root-manifest-marker-attribute ">"
        (html/escape-edn-script-body (pr-str m))
        "</script>"))
 
-(defn- read-edn [s]
-  #?(:clj  (edn/read-string s)
-     ;; `cljs.reader/read-string` is the SAFE EDN reader (no `#=` / eval),
-     ;; the same one `read-server-payload` uses for the hydration payload.
-     :cljs (reader/read-string s)))
+(defn- read-edn-forms
+  "-> a vector of EVERY top-level EDN form in `s`.
+
+  Reading `\"[\" s \"\\n]\"` is what makes \"exactly one form\" checkable
+  with the bundled safe readers on BOTH hosts. Neither
+  `clojure.edn/read-string` nor `cljs.reader/read-string` reports what it
+  left unconsumed — each returns the first form and discards the rest —
+  and their stream APIs differ enough that a per-host `read`-loop would
+  be two implementations of one rule. EDN has no context-sensitive
+  syntax, so bracket-wrapping yields exactly the top-level forms.
+
+  The `\\n` before `]` matters: a trailing `;` line comment would
+  otherwise swallow the closing bracket and turn a well-formed body into
+  a spurious read error.
+
+  Both readers are the SAFE EDN readers (no `#=` / eval) — the same ones
+  `read-server-payload` uses for the hydration payload."
+  [s]
+  (let [wrapped (str "[" s "\n]")]
+    #?(:clj  (edn/read-string wrapped)
+       :cljs (reader/read-string wrapped))))
 
 (defn read-manifest
-  "Parse a manifest script BODY -> the validated manifest. Unreadable EDN
-  and a value outside the schema family both fail loud with
-  `:rf.error/root-manifest-invalid` — a hydrating root never guesses
-  identity (004C §3)."
+  "Parse a manifest script BODY -> the validated manifest. Unreadable EDN,
+  a body that is not EXACTLY ONE form, and a value outside the schema
+  family all fail loud with `:rf.error/root-manifest-invalid` — a
+  hydrating root never guesses identity (004C §3).
+
+  The one-form rule is not pedantry. `read-string` returns the FIRST form
+  and silently drops whatever follows, so a body carrying trailing text
+  or a second map — a truncated render, two manifests concatenated by a
+  faulty page assembly, an injected suffix — hydrated happily against the
+  first map and ignored the evidence that the wire was wrong (rf2-v4foc).
+  A manifest is one value; anything else is a corrupt body, not a body
+  with extras."
   [where s]
-  (let [v (try
-            (read-edn (str s))
-            (catch #?(:clj Exception :cljs :default) e
-              (error/throw-error!
-               :rf.error/root-manifest-invalid where
-               (str "root manifest script body is not readable EDN: "
-                    #?(:clj (.getMessage ^Exception e) :cljs (.-message e)))
-               {:recovery :re-render-the-root-manifest
-                :extra    {:invalid :unreadable}})))]
-    (validate! where v)))
+  (let [forms (try
+                (read-edn-forms (str s))
+                (catch #?(:clj Exception :cljs :default) e
+                  (error/throw-error!
+                   :rf.error/root-manifest-invalid where
+                   (str "root manifest script body is not readable EDN: "
+                        #?(:clj (.getMessage ^Exception e) :cljs (.-message e)))
+                   {:recovery :re-render-the-root-manifest
+                    :extra    {:invalid :unreadable}})))]
+    (when-not (= 1 (count forms))
+      (error/throw-error!
+       :rf.error/root-manifest-invalid where
+       (str "root manifest script body must hold EXACTLY ONE EDN form; "
+            "found " (count forms) ". A body with trailing content or a "
+            "second form is a corrupt wire, and adopting its first form "
+            "would hydrate against evidence the render went wrong")
+       {:recovery :re-render-the-root-manifest
+        :extra    {:invalid :form-count :got (count forms)}}))
+    (validate! where (first forms))))
 
 ;; ---------------------------------------------------------------------------
 ;; Discovery (CLJS — it reaches into the DOM)

--- a/implementation/ssr/test/re_frame/ssr/root_manifest_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/root_manifest_cljs_test.cljc
@@ -25,7 +25,15 @@
             [re-frame.ssr.constants :as constants]
             [re-frame.ssr.manifest :as manifest]
             [re-frame.ui.compiler.env :as env]
-            [re-frame.ui.compiler.root :as root]))
+            [re-frame.ui.compiler.root :as root]
+            #?(:clj  [clojure.edn]
+               :cljs [cljs.reader])))
+
+;; A record defined HERE rather than reached for in some production ns:
+;; the rf2-v4foc defect is about any value whose `pr-str` carries a tag
+;; the safe reader cannot construct, and a locally-defined record is the
+;; smallest honest instance of that class on both hosts.
+(defrecord WireProbeRecord [x])
 
 ;; ---------------------------------------------------------------------------
 ;; Driving the REAL S1 descriptor emitter
@@ -278,6 +286,262 @@
                       (ex-data e)))]
       (is (= :rf.error/root-manifest-invalid (:rf.error/id data))
           (str "body " (pr-str body) " — a hydrating root never guesses")))))
+
+;; ---------------------------------------------------------------------------
+;; THE EXACT ROUND TRIP (rf2-v4foc)
+;; ---------------------------------------------------------------------------
+;;
+;; #6383 shipped a wire whose ACCEPTANCE predicate was not equivalent to
+;; its READ. Three ways apart, each measured on both hosts before the fix:
+;;
+;;   1. a record-valued prop satisfied `map?`, so `edn-carryable?` walked
+;;      its entries and said yes — but `pr-str` emits `#my.ns.R{…}` and
+;;      the safe reader has no constructor for that tag;
+;;   2. `serialise-props` tested only the VALUE half of each entry, so an
+;;      opaque KEY (a fn, a host object) emitted `#object[…]`;
+;;   3. `read-manifest` took the first form and silently discarded any
+;;      trailing text or second form.
+;;
+;; All three turn an EMIT-time authoring mistake into a CLIENT hydration
+;; failure, which is the one thing a fail-loud wire exists to prevent.
+;;
+;; The property below is `read(write(m)) = m` driven through the SHIPPED
+;; `script-html` / `read-manifest` — not a hand-transcribed sample, and
+;; not `pr-str` alone: it goes through the real script-body escape, so
+;; the escape is part of what is proven.
+
+(def ^:private script-prefix
+  "<script type=\"application/edn\" data-rf-root>")
+
+(defn- script-body
+  "-> the exact bytes a browser hands back as the script's `.textContent`."
+  [html]
+  (-> html
+      (subs (count script-prefix))
+      (as-> s (subs s 0 (- (count s) (count "</script>"))))))
+
+(defn- round-trips?
+  "The property, through the shipped emitter and the shipped reader."
+  [m]
+  (= m (manifest/read-manifest 'test (script-body (manifest/script-html m)))))
+
+(def ^:private wire-values
+  "Every value class the manifest wire PROMISES to carry, spelled with
+  literals that mean the same thing on both hosts. `nil` appears as a
+  VALUE (distinct from an absent key, which the shapes below cover) and
+  the string/keyword cases carry the `<` and `</script` sequences the
+  body escape has to survive."
+  {:nil            nil
+   :true           true
+   :false          false
+   :string         "plain"
+   :empty-string   ""
+   :unicode        "héllo — ☃"
+   :breakout       "</script><img onerror=x>"
+   :lt-in-string   "a < b"
+   :keyword        :k
+   :ns-keyword     :a/b
+   :lt-in-keyword  :x<y
+   :symbol         'sym
+   :ns-symbol      'a/b
+   :zero           0
+   :negative       -1
+   :decimal        1.5
+   :whole-double   9.0
+   :vector         [1 2 3]
+   :list           '(1 2 3)
+   :set            #{1 2 3}
+   :empty-map      {}
+   :empty-vector   []
+   :string-keys    {"a" 1 "b" 2}
+   :mixed-keys     {:a 1 "b" 2 'c 3}
+   :nil-value      {:a nil}
+   :nested         {:a {:b [1 #{:c} {"d" :e}]}}})
+
+(deftest every-emitted-manifest-round-trips-exactly
+  (testing "rf2-v4foc — the SHIPPED emitter over the SHIPPED S1 descriptor
+            shapes: every manifest that reaches the wire reads back EQUAL,
+            not merely readable"
+    (doseq [[shape d] @real-descriptors]
+      (let [m (manifest/manifest d {:element-locator    {:id "shop-root"}
+                                    :props              {:promo :spring}
+                                    :frame-payload-ids  [:shop :frame/session]
+                                    :render-fingerprint "rf1-abc"
+                                    :identifier-prefix  "rf2-page_Sshop-"})]
+        (is (round-trips? m)
+            (str "descriptor shape " shape " must survive the wire exactly")))))
+
+  (testing "…and with NO extension facts at all, so `nil` vs ABSENT is
+            covered in both directions"
+    (doseq [[shape d] @real-descriptors]
+      (is (round-trips? (manifest/manifest d))
+          (str "bare manifest for shape " shape))))
+
+  (testing "every value class the wire promises to carry, as a prop value
+            and again as a prop KEY where the class can be a key"
+    (doseq [[label v] wire-values]
+      (let [m (manifest/manifest {:rf.root/schema-version 1 :root-id :page/shop}
+                                 {:props {:v v}})]
+        (is (round-trips? m) (str "prop value " label " => " (pr-str v))))))
+
+  (testing "a manifest whose props map is keyed by each carryable scalar —
+            the KEY half of the entry rides the same wire as the value"
+    (doseq [k [:k :a/b 'sym "str" 1 true nil]]
+      (let [m (manifest/manifest {:rf.root/schema-version 1 :root-id :page/shop}
+                                 {:props {k :v}})]
+        (is (round-trips? m) (str "prop key " (pr-str k)))))))
+
+(deftest round-trip-guard-is-load-bearing
+  (testing "THE RED-BEFORE for rf2-v4foc, kept executable: re-create the
+            defective predicate (the one that tested `map?` before
+            `record?`) and prove it ACCEPTS a value whose printed form the
+            reader then REJECTS. That gap is the whole bug; the shipped
+            predicate must never reproduce it, and this test fails if the
+            `record?` arm is ever removed."
+    (let [r (->WireProbeRecord 1)
+          ;; The PRE-FIX predicate, verbatim in the one respect that
+          ;; mattered: `map?` reached before any record test.
+          lenient-carryable?
+          (fn lenient? [v]
+            (cond
+              (nil? v) true (boolean? v) true (number? v) true
+              (string? v) true (keyword? v) true (symbol? v) true
+              (map? v) (every? (fn [[k v']] (and (lenient? k) (lenient? v'))) v)
+              (coll? v) (every? lenient? v)
+              :else false))]
+
+      (testing "the defective predicate waves the record through"
+        (is (true? (lenient-carryable? {:x r}))
+            "if this ever goes false the lever is gone and the guard below
+             proves nothing"))
+
+      (testing "…yet its printed form does NOT read back — the exact
+                asymmetry #6383 shipped"
+        (is (not= (pr-str {:x r}) (pr-str (into {} r)))
+            "a record does not PRINT as a map, which is why map?-shape was
+             the wrong question")
+        (is (thrown? #?(:clj clojure.lang.ExceptionInfo
+                        :cljs cljs.core/ExceptionInfo)
+                     (manifest/read-manifest
+                      'test (pr-str {:rf.root/schema-version 1 :props {:x r}})))
+            "the safe reader has no constructor for the record's tag"))
+
+      (testing "and the SHIPPED predicate closes it"
+        (is (not (manifest/edn-carryable? r)))
+        (is (not (manifest/edn-carryable? {:x r})))
+        (is (not (manifest/edn-carryable? {:x [1 {:y r}]}))
+            "detected through nesting, like every other opaque value")))))
+
+(deftest record-valued-prop-fails-before-emission
+  (testing "rf2-v4foc — a record prop is rejected at ASSEMBLY, naming the
+            prop, rather than emitting a body the client cannot read"
+    (let [data (try (manifest/manifest
+                     'test {:rf.root/schema-version 1 :root-id :page/shop}
+                     {:props {:promo :spring :row (->WireProbeRecord 1)}})
+                    nil
+                    (catch #?(:clj clojure.lang.ExceptionInfo
+                              :cljs cljs.core/ExceptionInfo) e
+                      (ex-data e)))]
+      (is (= :rf.error/root-manifest-invalid (:rf.error/id data)))
+      (is (= :row (:unserialisable-prop data)) "the offending prop is NAMED")
+      (is (= :value (:unserialisable-half data))))))
+
+(deftest opaque-prop-KEY-fails-before-emission
+  (testing "rf2-v4foc — `serialise-props` checked only the value half, so
+            an opaque KEY reached `pr-str` and emitted `#object[…]`. Both
+            halves are carried, so both halves are validated."
+    (let [k    (fn [] 1)
+          data (try (manifest/manifest
+                     'test {:rf.root/schema-version 1 :root-id :page/shop}
+                     {:props {k 1}})
+                    nil
+                    (catch #?(:clj clojure.lang.ExceptionInfo
+                              :cljs cljs.core/ExceptionInfo) e
+                      (ex-data e)))]
+      (is (= :rf.error/root-manifest-invalid (:rf.error/id data)))
+      (is (= :key (:unserialisable-half data))
+          "the diagnostic says WHICH half — a fn key and a fn value are
+           different authoring mistakes")))
+
+  (testing "a record used as a prop KEY is caught by the same arm"
+    (is (not (manifest/edn-carryable? {(->WireProbeRecord 1) :v})))))
+
+(deftest script-emission-gates-the-whole-manifest
+  (testing "rf2-v4foc — `serialise-props` screens `:props` at assembly, but
+            `script-html` is the only door onto the wire and DESCRIPTOR
+            keys ride through it too. A non-carryable `:static-props` was
+            emitted happily before this gate; the property `every manifest
+            accepted for script emission round-trips` is only true if the
+            gate is at emission."
+    (doseq [k [:static-props :props-shape :frame-plans :root-id]]
+      (let [m    (assoc {:rf.root/schema-version 1 :root-id :page/shop}
+                        k {:x (->WireProbeRecord 1)})
+            data (try (manifest/script-html m) nil
+                      (catch #?(:clj clojure.lang.ExceptionInfo
+                                :cljs cljs.core/ExceptionInfo) e
+                        (ex-data e)))]
+        (is (= :rf.error/root-manifest-invalid (:rf.error/id data))
+            (str "descriptor key " k " must be gated too"))
+        (is (= k (:unserialisable-manifest-key data))))))
+
+  (testing "the gate does NOT narrow what a valid manifest may hold — every
+            real descriptor shape still emits"
+    (doseq [[shape d] @real-descriptors]
+      (is (string? (manifest/script-html (manifest/manifest d)))
+          (str shape " still emits — the gate rejects unwireable values, "
+               "not ordinary data")))))
+
+(deftest body-must-hold-exactly-one-edn-form
+  (testing "rf2-v4foc — `read-string` returns the FIRST form and discards
+            the rest, so a truncated render, two concatenated manifests, or
+            an injected suffix all hydrated silently against the first map.
+            A manifest is ONE value."
+    (doseq [[label body] {:trailing-text  "{:rf.root/schema-version 1} trailing"
+                          :second-form    "{:rf.root/schema-version 1} {:second true}"
+                          :second-scalar  "{:rf.root/schema-version 1} 42"
+                          :duplicate      (str "{:rf.root/schema-version 1} "
+                                               "{:rf.root/schema-version 1}")
+                          :empty          ""}]
+      (let [data (try (manifest/read-manifest 'test body) nil
+                      (catch #?(:clj clojure.lang.ExceptionInfo
+                                :cljs cljs.core/ExceptionInfo) e
+                        (ex-data e)))]
+        (is (= :rf.error/root-manifest-invalid (:rf.error/id data))
+            (str label " must be rejected, not silently truncated to its "
+                 "first form"))
+        (is (= :form-count (:invalid data)) (str label)))))
+
+  (testing "…while whitespace around the one form is FINE — the rule is one
+            FORM, not one line"
+    (doseq [body ["  {:rf.root/schema-version 1}  "
+                  "\n\t{:rf.root/schema-version 1}\n"
+                  "{:rf.root/schema-version 1}\n"]]
+      (is (= {:rf.root/schema-version 1} (manifest/read-manifest 'test body))
+          (str "whitespace-padded body " (pr-str body)))))
+
+  (testing "a trailing `;` comment does not swallow the wrapper's closing
+            bracket — the reader wraps in `[ … \\n]` precisely so it cannot"
+    (is (= {:rf.root/schema-version 1}
+           (manifest/read-manifest 'test "{:rf.root/schema-version 1} ; note"))))
+
+  (testing "an EDN discard is not a second form"
+    (is (= {:rf.root/schema-version 1}
+           (manifest/read-manifest 'test "{:rf.root/schema-version 1} #_{:x 1}")))))
+
+(deftest one-form-guard-is-load-bearing
+  (testing "THE RED-BEFORE for the one-form rule, kept executable: the
+            bundled reader really does discard the suffix, so without the
+            count check the bodies above are accepted. If a future reader
+            starts throwing on trailing content this test goes red and the
+            explicit check can be reconsidered — it never rots into a
+            tautology."
+    (doseq [body ["{:rf.root/schema-version 1} trailing"
+                  "{:rf.root/schema-version 1} {:second true}"]]
+      (is (= {:rf.root/schema-version 1}
+             #?(:clj  (clojure.edn/read-string body)
+                :cljs (cljs.reader/read-string body)))
+          (str "the raw reader silently accepts " (pr-str body)
+               " — that is the hole `read-manifest` now closes")))))
 
 (deftest marker-attribute-is-pinned-in-one-place
   (is (= "data-rf-root" constants/root-manifest-marker-attribute))

--- a/implementation/ssr/test/re_frame/ssr_keyword_head_contract_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_keyword_head_contract_test.clj
@@ -23,12 +23,33 @@
   only two emitters that ever diverged from it — the standard emitter and
   the streaming shell walker.
 
+  ## The child spelling (rf2-53lsj)
+
+  rf2-j81hs aligned the HEAD and stopped there, leaving the two hosts
+  emitting different TEXT for the identical tree:
+
+      [:dashboard/card :revenue]  JVM -> <card>:revenue</card>
+                              Reagent -> <card>revenue</card>
+
+  Its cross-host test acknowledged the difference and argued past it —
+  \"element structure is what hydration reconciles\". React hydration
+  reconciles TEXT nodes too, so that was the same bug one layer down,
+  institutionalised under a name (`client-markup-matches-the-jvm-emitter`)
+  that claimed more than it asserted.
+
+  A keyword or symbol child is now spelled by its `name` on every host:
+  no leading colon, and the NAMESPACE IS DROPPED (`:a/b` paints `b`).
+  That second half is the part a colon-stripping fix gets wrong; Reagent
+  routes a named child through `(name x)`, it does not trim the printed
+  form. Namespaced symbols were measured to diverge the same way and are
+  fixed by the same arm.
+
   The client half of the same contract is pinned substrate-side in
   `implementation/adapters/reagent/test/re_frame/ssr_keyword_head_contract_cljs_test.cljs`,
-  which asserts the SAME head paints the SAME element there. Together the
-  two files are the cross-host proof."
+  which asserts the SAME head paints the SAME element AND the same bytes.
+  Together the two files are the cross-host proof."
   (:require [clojure.string :as str]
-            [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.test :refer [are deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.ssr.emit :as emit]
             [re-frame.ssr.streaming :as streaming]
@@ -61,8 +82,14 @@
             view still emits a custom element. The keyword's `name` is the
             tag (matching `parse-tag`'s `(name tag)` on every client
             substrate); its namespace is dropped; the trailing argument is
-            a text child."
-    (is (= "<card>:revenue</card>"
+            a text child.
+
+            rf2-53lsj — the text child is spelled by the keyword's `name`
+            too: no leading colon, namespace dropped. These are the exact
+            bytes Reagent + react-dom/server paints for the same tree
+            (measured, and pinned as a cross-host equality in the CLJS
+            twin)."
+    (is (= "<card>revenue</card>"
            (emit/render-to-string [:dashboard/card :revenue] nil))))
 
   (testing "the registration is genuinely present — this test would be
@@ -76,8 +103,53 @@
   (testing "an unregistered keyword head emits the identical element —
             registration state does not change the head's meaning, which
             is the whole content of the one-grammar rule"
-    (is (= "<card>:revenue</card>"
+    (is (= "<card>revenue</card>"
            (emit/render-to-string [:never-registered/card :revenue] nil)))))
+
+(deftest scalar-children-are-spelled-by-name
+  (testing "rf2-53lsj — a keyword or symbol CHILD is spelled by its `name`:
+            no leading colon, namespace dropped. #6378 aligned the head
+            meaning and left the child spelling diverging, so the same raw
+            tree still produced different TEXT on the two hosts — and
+            React hydration reconciles text nodes, not just elements.
+
+            Every expectation here was measured against Reagent +
+            react-dom/server before it was written; the CLJS twin asserts
+            the same strings from the other side."
+    (are [expected tree] (= expected (emit/render-to-string tree nil))
+      "<div>revenue</div>" [:div :revenue]
+      "<div>b</div>"       [:div :a/b]
+      "<div>leaf</div>"    [:div :ns.deep/leaf]
+      "<div>sym</div>"     [:div 'sym]
+      "<div>b</div>"       [:div 'a/b]
+      "<div>revenue growth</div>" [:div :revenue " " :growth]
+      "<div>1a</div>"      [:div 1 :a]))
+
+  (testing "the namespace is DROPPED, not rendered — the case a
+            colon-stripping fix would have got wrong. `:a/b` paints `b`,
+            never `a/b`, because Reagent routes a named child through
+            `(name x)` rather than trimming the printed form."
+    (is (= "<div>b</div>" (emit/render-to-string [:div :a/b] nil)))
+    (is (not= "<div>a/b</div>" (emit/render-to-string [:div :a/b] nil))))
+
+  (testing "escaping still applies to the NAME — spelling a child by
+            `name` must not become an escape bypass"
+    (is (= "<div>x&lt;y</div>" (emit/render-to-string [:div :x<y] nil))))
+
+  (testing "the classes that already agreed are unchanged"
+    (are [expected tree] (= expected (emit/render-to-string tree nil))
+      "<div>plain</div>" [:div "plain"]
+      "<div>9</div>"     [:div 9]
+      "<div></div>"      [:div nil]
+      "<div></div>"      [:div true]))
+
+  (testing "the streaming walker agrees — its scalar arm delegates to the
+            standard emitter, so this is a delegation pin, not a second
+            implementation"
+    (doseq [tree [[:div :revenue] [:div :a/b] [:div 'a/b] [:dashboard/card :revenue]]]
+      (is (= (emit/render-to-string tree nil)
+             (:shell-html (streaming/render-shell tree)))
+          (str "emitter/walker divergence on " (pr-str tree))))))
 
 (deftest keyword-head-carries-ordinary-element-syntax
   (testing "rf2-j81hs — the element branch is the ORDINARY element branch:
@@ -112,7 +184,7 @@
             only the standard emitter would have left the streaming path
             diverging from every client substrate."
     (let [{:keys [shell-html]} (streaming/render-shell [:dashboard/card :revenue])]
-      (is (= "<card>:revenue</card>" shell-html))))
+      (is (= "<card>revenue</card>" shell-html))))
 
   (testing "and still recurses through the element into nested children,
             so a suspense boundary underneath a keyword head is reachable"
@@ -194,7 +266,7 @@
   (testing "an ORDINARY namespaced keyword is NOT reserved — the guard is
             scoped to `:rf/*` and must not capture app namespaces, which
             are exactly the heads that now render as custom elements"
-    (is (= "<card>:revenue</card>"
+    (is (= "<card>revenue</card>"
            (emit/render-to-string [:dashboard/card :revenue] nil)))
     (is (= "<widget></widget>"
            (emit/render-to-string [:rfid/widget] nil))

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -452,6 +452,30 @@ The manifest rides **one script element per root**:
   the hydration payload uses (see [§HTTP response contract](#http-response-contract)),
   so data cannot break out of the element and the body still round-trips through the EDN
   reader. It is read with the safe EDN reader — never `eval`.
+- **The body holds exactly one EDN form**, plus whitespace. A body carrying trailing
+  content or a second form is a corrupt wire and is rejected, never truncated to its
+  first form. This has to be stated because the obvious implementation does the wrong
+  thing silently: a `read-string` returns the first form and discards the rest, so a
+  truncated render, two manifests concatenated by a faulty page assembly, or an injected
+  suffix would all hydrate happily against the leading map while the evidence that the
+  render went wrong was thrown away. A manifest is one value.
+
+**The round trip is exact, and emission is where that is enforced.** For every manifest
+that reaches the wire, reading the body back yields *the same manifest* — not merely a
+readable one. The acceptance predicate is therefore the round trip itself: a value rides
+only if `pr-str` prints it in a form the bundled safe reader reconstructs. Two
+consequences are easy to get wrong, and both are real defects rather than hypotheticals:
+
+- **Map-shaped is not map-printing.** A record satisfies `map?` yet prints as the tagged
+  literal `#my.ns.R{…}`, which the safe reader has no constructor for. Testing shape
+  rather than printed form admits it and defers the failure to client hydration.
+- **Both halves of a prop entry ride the wire**, so both are validated. Screening only
+  values admits an opaque *key*, which prints as a host-object literal and fails the same
+  way.
+
+The check belongs at **emission**, not only at prop assembly: descriptor keys reach the
+wire too, so gating `:props` alone leaves the property true of one key and false of the
+manifest. One predicate, enforced at the one door onto the wire.
 
 **Identity is spelled exactly once, in the content.** The root-id lives in the
 manifest's `:root-id` key and nowhere else on the wire. Putting it in the attribute as
@@ -491,7 +515,15 @@ smaller one:
   the manifest would disagree. A container the emitter itself produces is synthesised
   deterministically as `"rf2-root-" + root-id-slug`, collision-free because the slug is
   injective ([004C §1](004C-Roots-and-Mount.md#1-root-identity--required-host-authored-derivable)).
-- an **unserialisable prop** — `{:unserialisable-prop :chart-fn}`, naming the offender.
+- an **unserialisable prop** — `{:unserialisable-prop :chart-fn}`, naming the offender,
+  and `{:unserialisable-half :key}` or `:value` saying which half of the entry is at
+  fault (a fn used as a prop key and a fn used as a prop value are different authoring
+  mistakes).
+
+A third arm fails at the wire rather than at assembly: a manifest carrying a value the
+EDN wire cannot carry under **any** key — `{:unserialisable-manifest-key :static-props}`.
+This is the emission gate above; it is what makes "every emitted manifest round-trips"
+total rather than true of `:props` alone.
 
 **Artefact (CLJS reference).** `re-frame.ssr.manifest` — `problems` / `valid?` /
 `validate!` (the schema verdict), `manifest` (assembly), `script-html` / `read-manifest`

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -260,6 +260,37 @@ The failure mode is what made it expensive: **the server fails loud and the clie
 
 **No compatibility shim** (pre-alpha). No hydratable page can depend on the removed behaviour: a keyword ref cannot render client-side at all, so the feature only ever served server-only trees, where `[(rf/view :id) …]` is a drop-in replacement.
 
+#### Scalar children are spelled by `name`
+
+Aligning the head left the *child* diverging, which is the same bug one layer down
+(rf2-53lsj). **A keyword or symbol child is spelled by its `name` on every host**: no
+leading colon, and **the namespace is dropped**. `[:div :a/b]` paints `b`.
+
+The correction is the same shape as the head one — the JVM emitter moved onto the client
+behaviour, not the reverse. It had been sending a keyword child through a generic
+stringify, which preserves the colon (`:revenue`) and the namespace (`a/b`); every client
+substrate routes a named child through `(name x)` before React sees it. Namespaced
+symbols were measured to diverge identically and are covered by the same rule.
+
+Note *which* client spelling this is. Stripping the leading colon looks like the fix and
+is not: it yields `a/b` where the client paints `b`, so the hosts stay apart on exactly
+the trees where a namespace was used to disambiguate.
+
+**A text-node mismatch is a real hydration failure, not a cosmetic one.** React
+reconciles text nodes as well as element structure, so server `:revenue` against client
+`revenue` does not hydrate — React discards the server tree for that root and re-renders
+it on the client, which is the cost SSR exists to avoid. The reference implementation
+pins this with React itself as the judge: it hydrates the emitter's real bytes and
+asserts React reports nothing, and — as a permanently executable red-before — hydrates
+the *pre-fix* bytes and asserts React reports the mismatch. Its verdict on those:
+
+```
+Hydration failed because the server rendered text didn't match the client.
+  <card>
++       revenue
+-       :revenue
+```
+
 **Unrecognised reserved heads fail loud.** With keyword heads uniformly elements, a head in the framework-reserved `:rf/*` scheme that is not one this emitter implements — a misspelt `:rf/suspense-boundry`, say — would otherwise sail through the element branch and paint a phantom `<suspense-boundry>`, reintroducing the same silent-mis-render one keystroke away. The recognised reserved heads are `:<>`, `:>` and `:rf/suspense-boundary`; anything else under `:rf/*` raises `:rf.error/invalid-hiccup-head`. The `:rf/*` root is framework-owned per [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned), so there is no legitimate author element being rejected.
 
 Streaming/chunked emission ships as the `:rf/suspense-boundary` primitive — see [§Streaming SSR](#streaming-ssr) under Detailed design.


### PR DESCRIPTION
Two SSR fidelity defects, both the same shape: a value that should survive a transform unchanged, didn't. Each defect was reproduced **on both hosts, measured** before any code changed.

## `rf2-v4foc` — the manifest wire was not an exact round trip

#6383's acceptance predicate was not equivalent to its read. Measured on JVM against the shipped emitter:

| input | before |
|---|---|
| `{:props {:x (->R 1)}}` | `valid? true`, emits `#user.R{:x 1}`, `read-manifest` throws `:unreadable` |
| `{:props {(fn [] 1) 1}}` | accepted, emits `#object[…]` |
| `"{…1} trailing"` | accepted, returns the first map |
| `"{…1} {:second true}"` | accepted, returns the first map |

Three causes, three fixes:

- **A record satisfies `map?`** but prints as a tagged literal the safe reader cannot construct. Shape was the wrong question — the predicate is about the *printed* form, so `record?` now precedes `map?`. Rejecting rather than silently converting to a plain map keeps server and client agreeing about the prop's type.
- **`serialise-props` tested only the value half** of each entry. A prop map is carried key-and-value, so it is validated key-and-value; the diagnostic now says which half.
- **`read-manifest` took the first form and discarded the rest.** Reading `"[" body "\n]"` makes "exactly one form" checkable with the bundled safe reader on *both* hosts without a per-host `read`-loop; the newline stops a trailing `;` comment swallowing the wrapper's bracket.

`script-html` now gates the **whole** manifest, not just `:props` — it is the only door onto the wire and descriptor keys ride through it too, so gating props alone left the property true of one key and false of the manifest. One predicate, `edn-carryable?`, spelled once, enforced at both points.

**Exact, not representative.** The proof is `read(script_html(m)) = m` driven through the *shipped* emitter and reader over all seven real S1 descriptor shapes (with and without extension facts), plus every value class the wire promises — as prop values and again as prop keys. It runs through the real script-body escape, so the escape is part of what is proven. A per-type sweep confirmed which types actually fail rather than assuming: only records and opaque values do; keyword/string/symbol keys, namespaced keywords, `nil`-as-value, ordering and nesting all round-trip.

## `rf2-53lsj` — keyword children were not byte-identical

Keyword and symbol children fell through to `escape-html`, whose `(str s)` keeps the colon and the namespace. Byte diff, measured:

| tree | JVM before | JVM after | Reagent + react-dom/server |
|---|---|---|---|
| `[:dashboard/card :revenue]` | `<card>:revenue</card>` | `<card>revenue</card>` | `<card>revenue</card>` |
| `[:div :revenue]` | `<div>:revenue</div>` | `<div>revenue</div>` | `<div>revenue</div>` |
| `[:div :a/b]` | `<div>:a/b</div>` | `<div>b</div>` | `<div>b</div>` |
| `[:div 'a/b]` | `<div>a/b</div>` | `<div>b</div>` | `<div>b</div>` |

**The measurement found a case the bead did not name: the namespace is dropped.** Reagent routes a named child through `(name x)`, so a colon-stripping fix would have emitted `a/b` and left the hosts apart on exactly the trees where a namespace disambiguates. Namespaced symbols diverged identically and are covered by the same arm.

The streaming walker needed no change — its scalar arm already delegates to `emit/emit-element`, and that delegation is now pinned. No registry lookup returns.

**A text mismatch is a real hydration failure.** #6378's cross-host test asserted only `starts-with?`/`ends-with?` while its name promised a byte match, and argued the text difference away. Both twins now assert whole strings, and a new browser probe makes React the judge — it hydrates the emitter's real bytes and asserts React reports nothing. Its permanent red-before runs the same harness over the pre-fix bytes, where React 19 says:

```
Hydration failed because the server rendered text didn't match the client.
  <card>
+       revenue
-       :revenue
```

That lever earned its keep: the first harness went through `reagent.dom.client/hydrate-root` and saw **nothing** on either input — Reagent 2.0.1 destructures `:on-recoverable-error` and never passes it to `hydrateRoot` — so it drives `hydrateRoot` directly and would otherwise have shipped as a vacuous green.

## Red-before, per bead, each with its own lever

Every lever verified to red **independently**:

| bead | lever | red |
|---|---|---|
| v4foc | drop the `record?` arm | 15 assertions |
| v4foc | relax the one-form count | 8 |
| v4foc | drop the prop-key half | 2 |
| v4foc | disable the emission gate | 8 |
| 53lsj | disable the `name` arm | 12 |
| 53lsj | flip a DOM assertion (browser-branch execution) | red as required |

## Constraints honoured

- `data-rf-root` is **still a bare marker** — no value added.
- **No extension key was made required**; the subset-property suite still passes against the real compiler's descriptor output.
- **No registry dependency reintroduced** — the JVM emitter stays a pure hiccup→HTML function.
- **No new error id**, so no Spec 009 row was needed and the held file was not touched. Both fixes reuse `:rf.error/root-manifest-invalid` / `:rf.error/invalid-hiccup-head`.
- The new browser test **resets the payload install ledger** in its fixture, even though it installs no payload, so a future edit that adds one cannot leak into siblings.
- Untouched: `ai/**`, `spec/009`, `implementation/ui/src/**`, `implementation/core/**`.

## Quality gates

All foreground, run to completion, exit codes captured by redirect (never piped).

| gate | result |
|---|---|
| `implementation/ssr` `clojure -M:test` | **456 tests**, 2180 assertions, 0F 0E (448 baseline + 8 new) |
| `implementation/ssr-ring` `clojure -M:test` (own dir) | **199 tests**, 978 assertions, 0F 0E |
| `implementation/core` `clojure -M:test` | **2078 tests**, 9960 assertions, 0F 0E |
| `npm run test:cljs` | **10161 tests**, 50281 assertions, 0F 0E |
| `npm run test:browser` | **475 tests**, 2671 assertions, 0F 0E |
| `mkdocs build --strict` | exit 0 |
| `scripts/check-no-hardcoded-paths.sh` | OK |

`npm run test:browser` is stated separately above because the new hydration tests **self-skip under node** — the browser run is the only one where they assert, and that was confirmed by the flipped-assertion probe rather than assumed.