### PR TITLE
ci: promote the six-view proof pack and G-18 to required (rf2-kxork)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -572,6 +572,20 @@ else
         cljs_node_test=true
         ui_gates=true
         ;;
+      implementation/scripts/check-ui-facade-isolation.cjs)
+        # rf2-kxork — the checker IS the G-18 library-facade-isolation gate
+        # (cljs-ui-facade-isolation, gated on ui_gates). A checker-only PR must
+        # fire the job it implements, otherwise the gate could silently edit
+        # itself out of CI — the same self-protection the G-1/G-13/G-8
+        # launchers and the two sibling ui checkers above already carry.
+        # cljs_node_test stays armed so the checker keeps the generic
+        # implementation/scripts/* coverage too; this widens, never narrows.
+        # No cljs_browser/bundle_isolation fan-out: G-18 is a shadow-cljs
+        # release plus a bundle string inspection — it drives no browser and
+        # no packaging boundary beyond its own two proof-pack builds.
+        cljs_node_test=true
+        ui_gates=true
+        ;;
       implementation/scripts/check-ui-digest-carrier.cjs)
         # This checker IS the real-browser digest-carrier proof hosted by
         # cljs-browser. A checker-only PR must start that Playwright-owning

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -864,6 +864,65 @@ jobs:
           path: implementation/out/ui-g8.json
           if-no-files-found: error
 
+  cljs-ui-facade-isolation:
+    name: CLJS ui G-18 library facade isolation (:advanced single-view DCE)
+    # rf2-kxork — G-18 (07 §5, EP-0035 readiness §4) promoted into the required
+    # matrix. #6182 donated this fixture-first checker RED (unreferenced view
+    # defs bound to React.memo(...) survived :advanced); #6195 repaired the DCE
+    # mechanism and it now passes, so the acceptance test for that repair
+    # becomes a standing regression net rather than a parked fixture.
+    #
+    # The gate builds the two proof-pack :advanced bundles and greps them:
+    #   - positive control (proof-pack-all): all six sentinels PRESENT, so an
+    #     absence in the single-view build is genuine elision, not a renamed
+    #     or missing literal (non-vacuity).
+    #   - isolation (proof-pack-single): the ONE imported view's sentinel
+    #     PRESENT and the five unimported siblings' sentinels ABSENT.
+    #
+    # No browser: it is a shadow-cljs release plus a bundle string inspection,
+    # so it needs the JDK/Node/Maven trio only — no Playwright install.
+    # Fired by the ui_gates surface (implementation/ui/** — which contains the
+    # proof-pack library and the compiler/runtime DCE surface it exercises —
+    # the build-config trio, or the checker script itself).
+    needs: detect_changed_surfaces
+    if: needs.detect_changed_surfaces.outputs.ui_gates == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: implementation
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: implementation/package-lock.json
+
+      - name: Cache Maven / gitlibs (shadow-cljs deps)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ${{ runner.os }}-cljs-${{ hashFiles('implementation/shadow-cljs.edn', 'implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-cljs-
+
+      - name: npm install
+        run: npm ci
+
+      - name: G-18 library facade isolation gate
+        run: npm run test:ui-facade-isolation
+
   jvm-reagent:
     name: Diagnostic skip-ok JVM reagent-adapter classpath probe
     needs: detect_changed_surfaces
@@ -3729,6 +3788,7 @@ jobs:
       - cljs-ui-g1
       - cljs-ui-g13
       - cljs-ui-g8
+      - cljs-ui-facade-isolation
       - jvm-reagent
       - jvm-reagent-slim
       - jvm-uix

--- a/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
+++ b/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
@@ -250,17 +250,18 @@ its widened event-prefix arm — `npm run test:ui-g8` runs as CI job `cljs-ui-g8
 `ui_gates` surface in real Chromium **and** WebKit, superseding S-5's jsdom-only
 evidence; G-11 (`npm run test:browser-prod-elision`, CI job
 `cljs-browser-prod-elision`, plus the absence scan `npm run test:ui-g1` carries); the
-G-15 atomic-local writer matrix (`npm run test:browser`); G-17 (its advanced arm in the
-prod-elision build, its dev arms in the `:node-test` and JVM suites); and G-12 (`npm run
-test:ui-isolation`, which fails closed unless both arms run). **Named open** — G-7
+G-15 atomic-local writer matrix (`npm run test:browser`); G-12 (`npm run
+test:ui-isolation`, which fails closed unless both arms run); and G-18 (`npm run
+test:ui-facade-isolation`, CI job `cljs-ui-facade-isolation`), whose single-view
+isolation assertion went green with the #6195 DCE packaging repair and which
+`rf2-kxork` promoted into the required matrix — its roster of proven views is the six
+named in the checker, not the library as a whole (`rf2-r4q98`). **Named open** — G-7
 beyond its production-absence arm: the dev↔prod equivalence matrix over generated
 shapes has no test yet; G-14's **remaining** arm — bounded guide-fixtures CI cost,
 which needs the guide-examples corpus (its wall-clock budget is an S3 stage item) —
 which has no assertion anywhere in the repository, as the gate's own suite states;
 G-16's "manifest slot sites present" arm (its cross-emitter
-parity and slot-arity arms do run); G-18, whose fixture and
-`test:ui-facade-isolation` script exist but are self-declared RED and deliberately held
-out of the required matrix until they go green; G-2/G-9 (wire with the stages shipping
+parity and slot-arity arms do run); G-2/G-9 (wire with the stages shipping
 their subjects); root-manifest hydration + failed-root isolation (S5 — the S-4 spike
 passed dual-host structural output only); G-10 and the remaining
 absence/equivalence/budget gates plus the one-time W11 trio table (S6). S3 closed

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -1608,6 +1608,62 @@ test('run-ui-g8.cjs launcher change arms ui_gates (rf2-vxgfnd.95.10)', () => {
   assert.equal(classify('implementation/scripts/run-ui-g8.cjs').ui_gates, 'true');
 });
 
+// rf2-kxork — G-18 library facade isolation promoted into the required matrix.
+// The checker was donated RED (#6182) and parked outside CI; #6195 repaired the
+// DCE mechanism and it now passes, so it becomes a standing regression net.
+// These three tests are the wiring's own proof: the classifier must arm the
+// gate, the job must be surface-gated and actually run it, and the required
+// aggregator must depend on it. Remove any one of those and a test reds.
+
+test('the G-18 facade-isolation checker fires the gate it implements (rf2-kxork)', () => {
+  const result = classify('implementation/scripts/check-ui-facade-isolation.cjs');
+  assert.equal(
+    result.ui_gates,
+    'true',
+    'a checker-only PR must satisfy the cljs-ui-facade-isolation job condition',
+  );
+  // widens, never narrows: the generic scripts surface stays armed
+  assert.equal(result.cljs_node_test, 'true');
+});
+
+test('implementation/ui proof-pack + DCE surface arms G-18 (rf2-kxork)', () => {
+  // The library the gate imports from, and the compiler/runtime surface whose
+  // DCE behaviour it measures, both live under implementation/ui/**.
+  assert.equal(
+    classify('implementation/ui/proof-pack/re_frame/ui/proof_pack/library.cljs').ui_gates,
+    'true',
+  );
+  assert.equal(
+    classify('implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc').ui_gates,
+    'true',
+  );
+  assert.equal(
+    classify('implementation/ui/src/re_frame/ui/runtime.cljs').ui_gates,
+    'true',
+  );
+  // the two proof-pack builds are declared in the build-config trio
+  assert.equal(classify('implementation/shadow-cljs.edn').ui_gates, 'true');
+});
+
+test('cljs-ui-facade-isolation is surface-gated and runs the G-18 gate (rf2-kxork)', () => {
+  const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'cljs-ui-facade-isolation');
+  assert.match(block, /needs: detect_changed_surfaces/);
+  assert.match(
+    block,
+    /if: needs\.detect_changed_surfaces\.outputs\.ui_gates == 'true'/,
+  );
+  assert.match(block, /npm run test:ui-facade-isolation/);
+});
+
+test('all-required-passed aggregator needs cljs-ui-facade-isolation (rf2-kxork)', () => {
+  const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'all-required-passed');
+  assert.match(
+    block,
+    /- cljs-ui-facade-isolation\r?\n/,
+    'aggregator must list cljs-ui-facade-isolation in needs:',
+  );
+});
+
 // rf2-vxgfnd.90 — re-frame.ui now ships REAL DOM tests
 // (`*-dom-cljs-test.{cljs,cljc}`) in the `:browser-test` build (the S1c/S2
 // mount + reactivity + frame-scope keystone fixtures — the ONLY place

--- a/implementation/scripts/check-ui-facade-isolation.cjs
+++ b/implementation/scripts/check-ui-facade-isolation.cjs
@@ -14,18 +14,27 @@
 //   isolation (single-view): the imported `controlled-input` sentinel PRESENT,
 //     and the five unimported siblings' sentinels ABSENT.
 //
-// FIXTURE-FIRST STATUS: as of landing this fixture, the isolation assertion is
-// RED — the unimported sibling render functions are retained because the
-// production `defview` arm binds `re-frame.ui.runtime/memo-view`'s
-// `React.memo(renderFn, cmp)` call to a top-level `def`, and Closure does not
-// treat that call as side-effect-free, so the unreferenced def (and its render
-// fn + sentinel strings) survive `:advanced`. Per EP-0035 readiness §4 that is
-// exactly the structural failure that JUSTIFIES a substrate packaging change
-// (pure-annotating the emitted view def / memo-view so an unreferenced view
-// DCEs). That change touches the shipped emitter/runtime and is tracked
-// separately (see bead rf2-edpam); this gate is the
-// acceptance test for it and is intentionally NOT in the required CI matrix
-// until it goes green.
+// STATUS (rf2-kxork): GREEN and REQUIRED. This fixture landed RED in #6182 —
+// unimported sibling render functions were retained because the production
+// `defview` arm bound `re-frame.ui.runtime/memo-view`'s `React.memo(renderFn,
+// cmp)` call to a top-level `def`, which Closure does not treat as
+// side-effect-free, so the unreferenced def (and its render fn + sentinel
+// strings) survived `:advanced`. #6195 repaired that packaging behaviour and
+// the isolation assertion now passes, so the gate has been promoted from
+// parked acceptance test to standing regression net: it runs as the
+// `cljs-ui-facade-isolation` job in .github/workflows/test.yml (fired by the
+// ui_gates surface) and the required `all-required-passed` aggregator
+// `needs:` it.
+//
+// SCOPE BOUND — read before adding a view. IMPORTED/SIBLINGS below is a
+// HARDCODED roster, not one derived from the library source. The gate proves
+// the isolation contract for exactly the six views it names; a SEVENTH view
+// added to library.cljs is invisible to it, and would be retained in the
+// single-view bundle without turning this gate red (verified by probe under
+// rf2-kxork). Adding a view to the proof-pack library therefore REQUIRES
+// adding its sentinel here. Deriving the roster from the library source is
+// tracked separately (rf2-r4q98) — do not read the current PASS as covering
+// views absent from these two lists.
 
 const path = require('path');
 const { spawnSync } = require('child_process');
@@ -96,10 +105,11 @@ function main() {
   if (retained.length) {
     problems.push(
       `isolation: ${retained.length} unimported sibling view(s) retained in the advanced single-view ` +
-      `bundle -> ${retained.join(', ')}. This is the fixture-first STRUCTURAL FAILURE (EP-0035 readiness ` +
-      `§4): unreferenced view defs bound to React.memo(...) are not DCE'd. Remediation is a substrate ` +
-      `packaging change to the emitted view def / memo-view purity — off-limits to the conformance bead; ` +
-      `tracked by rf2-edpam.`);
+      `bundle -> ${retained.join(', ')}. A single-view import must not drag its siblings into the ` +
+      `bundle (EP-0035 readiness §4). This is the REGRESSION #6195 fixed: unreferenced view defs bound ` +
+      `to React.memo(...) stop being DCE'd when the emitted view def / memo-view loses its purity ` +
+      `annotation, so suspect a change to the defview emitter (compiler/emit_cljs.cljc) or to ` +
+      `memo-view (ui/runtime.cljs).`);
   }
 
   if (problems.length) {


### PR DESCRIPTION
Closes rf2-kxork.

G-18 (library facade isolation) landed RED in #6182 as a parked fixture-first acceptance test: a single-view import of a multi-view library retained its unimported siblings, because the production `defview` arm bound `React.memo(renderFn, cmp)` to a top-level `def` that Closure would not drop. #6195 repaired that packaging behaviour and the gate went green — but nothing ran it. No workflow job, no changed-surface arm, and the checker still carried "self-declared RED / intentionally NOT in the required CI matrix" commentary. The proof existed and was doing no work.

## What changed

- **`cljs-ui-facade-isolation`** job in `test.yml`, gated on `ui_gates`. No Playwright — it is a shadow-cljs release plus a bundle string inspection, so it needs the JDK/Node/Maven trio only, mirroring `cljs-ui-g1`.
- **Listed in `all-required-passed`**, the single required context. That is what makes it required.
- **Classifier arm** so a checker-only PR fires the gate it implements, mirroring the `check-ui-adapter-isolation.cjs` precedent — the gate cannot silently edit itself out of CI.
- **Four self-tests** pinning that wiring (168 → 172).
- **Stale commentary replaced** in the checker and in EP-0034, which still listed G-18 under "Named open".

## Teeth — every arm mutated before promotion

Promoting a check to required makes it load-bearing, so each arm was made to fail by mutating the thing it claims to measure. Baseline green: exit 0, `0/5` siblings retained.

| Arm | Mutation | Result |
|---|---|---|
| positive control (all-views) | renamed a sibling sentinel to a non-substring variant | **exit 1**, 1 problem, names the sentinel |
| imported view present | single-view consumer roots nothing | **exit 1**, `present=false` |
| siblings absent (the contract) | single-view consumer also roots `selection-controller` | **exit 1**, `1/5 -> selection-controller`, import arm stays green |

The mutations are independent: T3 reds the isolation arm while the import arm stays green, so the arms are not one assertion wearing three hats. A rename mutation must avoid substring containment — the oracle uses `String.includes`, so appending a suffix would have passed.

**Sequence proof** (the output dir persists across runs and shadow compiles incrementally, so a stale bundle could mask a result): clean **PASS** → violate **FAIL** (`selection-controller`) → recover **PASS** → violate again **FAIL** (`inline-popover`). Different sibling each time; the gate is neither latched nor reusing stale output.

**Wiring teeth**: removing the classifier arm, the job's gate command, or the aggregator entry each reds exactly one self-test with the right message.

## Scope bound found and NOT fixed here

`IMPORTED`/`SIBLINGS` is a hardcoded roster, not derived from the library. **Verified by probe**: a seventh view added to the library and rooted in the single-view consumer is genuinely retained in the advanced bundle — its sentinel greps out of `out/proof-pack-single` — while the gate reports `0/5` and `G-18 PASS`, exit 0.

This is not a false green on today's contract: the library has exactly six views, all six are in the roster, and all three arms have proven teeth. It is drift risk on future additions. Deriving the roster is a change to the oracle rather than a promotion, so it is filed as **rf2-r4q98** and the bound is now stated in the checker docstring instead of left implicit.

## Not promoted

The bead also asks for schema/docs/dev-registration absence arms beyond the six render sentinels. Those oracles do not exist, and building them is extending the gate, not promoting it — left out deliberately, so what is required is exactly what has been shown to measure. Those acceptance criteria stay open on the bead.

## Quality gates

| Gate | Result |
|---|---|
| `npm run test:ui-facade-isolation` (the promoted gate, final HEAD) | **exit 0** — 6/6 positive control, 0/5 retained |
| `node implementation/scripts/_changed-surfaces.test.cjs` | **exit 0** — 172 passed (was 168; +4 deliberate) |
| `npm run test:script-policy` | **exit 0** |
| `shellcheck 0.11.0` on the modified `.sh` | **exit 0**, no findings |
| `scripts/check-no-hardcoded-paths.sh` | **exit 0** |
| `re-frame.ui.guide-truth-jvm-test` (reads EP-0034) | **exit 0** — 19 tests, 663 assertions |
| workflow YAML parse + aggregator reference check | 56 jobs, no `needs:` entry referencing a nonexistent job |

Gates were run in the foreground with exit codes captured by redirect, never piped. shellcheck is not installed locally; 0.11.0 was obtained via `npx` and canary-tested against a deliberately broken script (exit 1, SC2154) to confirm it was not reporting a vacuous clean. The runner's 0.9.0 was not available, and `.github/scripts/report-changed-surfaces.sh` is not shellchecked by CI at all — `portability.yml` covers only the two `scripts/` gate scripts.

**CI is the real verification for workflow changes.** Because `test.yml` is in the classifier's `mark_all` case, this PR fires the full matrix — including the new job — so `cljs-ui-facade-isolation` gets exercised on this very PR.

## Operator action

**None required.** `all-required-passed` is the single required context and the ruleset already points at it, so adding the job to its `needs:` is what makes it required — no branch-protection change. If the ruleset is ever repointed at individual job contexts, `cljs-ui-facade-isolation` would need adding there too.
