### PR TITLE
fix(ui): honest custom-element reload results and explicit cycle ownership (rf2-za45g, rf2-84173)

### DIFF
--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -932,6 +932,37 @@
           {}
           (sort-by str (keys sources))))
 
+(defn- report-publication-escape!
+  "Surface the contained observer failure from ONE reload publication (rf2-za45g).
+
+  Bounded to a single diagnostic per publication and itself contained: the
+  machinery that reports a failed observer must never become a second way for a
+  committed reload to fail. Dev-only by construction — the only caller sits
+  inside `reload-ledger?`, so `:advanced` production carries neither.
+
+  CLJS-only, mirroring the analogous descriptor-HMR reporter in
+  `re-frame.ui.reactive` (rf2-vxgfnd.215): shadow's `^:dev/after-load` hook — the
+  thing an escaping observer would falsify — exists only on CLJS. The JVM arm of
+  this ledger drives the protocol headless from compiler / tree-builder fixtures,
+  where there is no reload outcome to misreport and no console to report it to."
+  [build-id tag-count error]
+  #?(:cljs
+     (try
+       (when (exists? js/console)
+         (.warn js/console
+                (str "[re-frame.ui] a custom-element publication observer threw "
+                     "while publishing build " (pr-str build-id)
+                     "'s reload commit (" tag-count
+                     " declared tags live) — the throw was CONTAINED and the "
+                     "reload REMAINS SUCCESSFUL: the ledger was already "
+                     "reconciled and the cycle closed before publication began. "
+                     "Cause: "
+                     (if (nil? error)
+                       "nil"
+                       (error/ex-message-safe error)))))
+       (catch :default _ nil))
+     :clj (do build-id tag-count error nil)))
+
 (defn- publish!
   "Republish the public aggregate as a pure projection of the CURRENT ledger
   `::sources`. Called AFTER an authoritative `ledger-state` transition, never
@@ -943,9 +974,45 @@
   it can never overwrite a concurrent write-through's row with a stale aggregate.
   On CLJS it is a single uncontended recompute.
 
-  Reached only from `commit-reload!`, so it is ledger-only by construction."
-  []
-  (swap! custom-elements (fn [_] (aggregate (::sources @ledger-state))))
+  ## Publication is DELIVERY, not authority (rf2-za45g)
+
+  By the time this runs the reload is already committed: `commit-reload!`
+  reconciled `::sources` and closed the cycle in ONE atomic swap, and only then
+  called here. Publication is the DELIVERY of that outcome, so it needs delivery's
+  failure semantics — the same split rf2-vxgfnd.215 drew for descriptor HMR.
+
+  An observer of `custom-elements` is arbitrary code. `swap!` notifies watches
+  SYNCHRONOUSLY and with no containment, so a throwing observer used to escape
+  here, out of `commit-reload!`, and into shadow's `^:dev/after-load` hook — which
+  reports the whole reload FAILED even though the framework had committed it. That
+  is a lie about authority told by a listener, so the throw is contained and
+  reported instead.
+
+  Containment is safe because BOTH hosts publish the atom's new value BEFORE
+  notifying watches (CLJS `-reset!` sets state then `-notify-watches`; the JVM
+  `Atom.swap` CAS's then `notifyWatches`). A contained observer throw therefore
+  leaves the live aggregate, the projected ledger and the cycle state exactly as a
+  clean publication would — quiescent and coherent — never half-applied.
+
+  What containment does NOT buy: SIBLING delivery. Watch fan-out belongs to the
+  host's `IAtom`, which abandons the remaining watches when one throws, and
+  replacing that would mean shipping a listener framework this ledger has no
+  consumer for — there are no framework-owned observers of `custom-elements` at
+  all (classification reads `custom-element-properties`, never a watch). So
+  arbitrary watches are explicitly UNSUPPORTED observers: they are contained and
+  diagnosed, but their mutual delivery order and completeness are the host's
+  semantics, not a framework guarantee."
+  [build-id]
+  (let [failure (try
+                  (swap! custom-elements (fn [_] (aggregate (::sources @ledger-state))))
+                  {:failed? false :error nil}
+                  ;; The explicit `:failed?` bit — never the truthiness of
+                  ;; `:error` — preserves failure identity when CLJS throws a
+                  ;; falsey value (`(throw nil)`, `(throw false)` are both legal).
+                  (catch #?(:clj Throwable :cljs :default) e
+                    {:failed? true :error e}))]
+    (when (:failed? failure)
+      (report-publication-escape! build-id (count @custom-elements) (:error failure))))
   nil)
 
 (defn- reconcile-sources
@@ -1053,7 +1120,13 @@
 
   shadow-cljs runs after-load only on a SUCCESSFUL reload, so an aborted reload
   never reaches here and the last known-good manifest survives. A no-op when no
-  cycle is open."
+  cycle is open.
+
+  Because this IS the `^:dev/after-load` hook, whatever escapes it is what shadow
+  reports as the reload's outcome. The authority transition above is already
+  complete when `publish!` runs, so a throwing publication observer must not be
+  able to escape and recast a committed reload as a failed one — `publish!`
+  contains it and reports it instead (rf2-za45g)."
   ([] (commit-reload! (current-build-id)))
   ([build-id]
    (when reload-ledger?
@@ -1072,7 +1145,7 @@
        ;; be recaptured or dropped by this commit. `publish!` recomputes from the
        ;; LIVE ledger, so a concurrent write-through's row is never clobbered.
        (when (contains? (::cycles old) build-id)
-         (publish!))))
+         (publish! build-id))))
    nil))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -806,6 +806,49 @@
 ;; namespace (one `$CLJS`, one set of atoms, one `defonce`d producer) cannot be
 ;; told apart by any mechanism shadow exposes, because the hooks themselves are
 ;; then a single shared singleton.
+;;
+;; ## Overlapping cycles are unsupported, and no token can change that (rf2-84173)
+;;
+;; A build's cycle is identified by `build-id` alone. That is not an omission
+;; awaiting a generation token — it is the most any token could achieve, because
+;; of two facts about shadow's loader (read off the pinned shadow-cljs client:
+;; `shadow.cljs.devtools.client.{browser,shared,env}`):
+;;
+;;   1. NO CONVEYANCE. Lifecycle hooks are resolved by name off `$CLJS` and
+;;      invoked with NO arguments. A `^:dev/after-load` invocation is therefore
+;;      ANONYMOUS: it cannot present a claim minted by the `^:dev/before-load`
+;;      that opened its cycle. A token would have to be minted AND checked
+;;      entirely inside this ledger, where `commit-reload!` could only compare it
+;;      against the live slot it already reads — agreeing with itself by
+;;      construction. That is a tautology wearing an identity check's clothes,
+;;      which is precisely why this ledger has none.
+;;
+;;   2. NO PAIRING. `do-js-reload*` walks a task chain and ABANDONS the remainder
+;;      when a task throws, so a failed load never runs `^:dev/after-load` at all.
+;;      before-load and after-load are therefore not a balanced pair, which also
+;;      rules out every depth/refcount scheme: one aborted reload would leave the
+;;      count permanently above zero and hot reload would silently stop
+;;      committing, forever.
+;;
+;; Shadow adds no single-flight guard of its own — no pending flag, no queue, no
+;; dedup — so back-to-back `build-complete` messages each run a full independent
+;; reload chain. What actually serializes them is JavaScript: with only
+;; SYNCHRONOUS lifecycle hooks the whole before -> load -> after chain runs inside
+;; one event-loop turn, so cycle N's after-load always precedes cycle N+1's
+;; before-load and cycles cannot overlap. An `^:dev/before-load-async` /
+;; `^:dev/after-load-async` hook ANYWHERE in the build parks that chain and lets a
+;; second before-load land mid-cycle.
+;;
+;; So the honest boundary is: exactly ONE live cycle per build, overlapping
+;; same-build cycles unsupported, and the supersession made LOUD instead of silent
+;; (`notify-reload!`). The degradation under a genuine overlap is bounded and
+;; self-healing — stale classification rows until the next full page load, the
+;; same bound `note-reloaded-sources!` already documents for a deleted file.
+;;
+;; NOTE the word "generation" elsewhere in this namespace means something
+;; narrower and real: the open-vs-closed cycle state a registration observes
+;; ATOMICALLY (rf2-vxgfnd.144), which decides staging vs write-through. That is a
+;; property of the ledger transition, NOT an identity for a cycle.
 ;; ---------------------------------------------------------------------------
 
 (defonce ^{:doc "tag keyword -> {:properties #{kebab-kw}}. The LIVE aggregate
@@ -1070,17 +1113,87 @@
      (swap! custom-elements assoc tag decl))
    tag))
 
+(defn- report-unpaired-cycle!
+  "Surface an UNPAIRED `^:dev/before-load` — one that found a cycle still open,
+  carrying evidence, and superseded it (rf2-84173).
+
+  Bounded to one diagnostic per supersession and itself contained: a diagnostic
+  must never become a way for opening a cycle to fail. Dev-only by construction
+  (the only caller sits inside `reload-ledger?`).
+
+  Reports the DISCARD because the discard is real and lossy — it is simply the
+  lesser loss (see `notify-reload!`). Silence was the actual defect: the same
+  blind clobber served the routine aborted-reload recovery and the pathological
+  overlapping-cycle case, and nothing told them apart or told anyone."
+  [build-id staged touched]
+  #?(:cljs
+     (try
+       (when (exists? js/console)
+         (.warn js/console
+                (str "[re-frame.ui] build " (pr-str build-id)
+                     " opened a custom-element reload cycle while one was STILL "
+                     "OPEN; the previous cycle's evidence was discarded ("
+                     (reduce + 0 (map count (vals staged))) " staged declaration(s) across "
+                     (count staged) " source(s), " (count touched)
+                     " touched source(s)). EXPECTED after a reload that threw — "
+                     "shadow-cljs skips ^:dev/after-load entirely when a load "
+                     "task fails, so before/after are not a balanced pair, and "
+                     "discarding is how last-known-good is recovered. UNEXPECTED "
+                     "otherwise: overlapping same-build reload cycles are NOT "
+                     "supported, because shadow passes no cycle identity to "
+                     "^:dev/after-load. If you use ^:dev/before-load-async or "
+                     "^:dev/after-load-async, expect custom-element "
+                     "classification to need a full page reload to converge.")))
+       (catch :default _ nil))
+     :clj (do build-id staged touched nil)))
+
 (defn ^:dev/before-load notify-reload!
   "shadow-cljs hot-reload hook (dev only): OPEN a reload cycle for `build-id`
   (the runtime analogue of the compile-side `begin-build!`). Re-registrations
-  from here stage instead of mutating the live aggregate; opening a fresh cycle
-  discards any staging left by a previously ABORTED reload. Production never hot-
+  from here stage instead of mutating the live aggregate. Production never hot-
   reloads (shadow installs no `^:dev/before-load` hook in a release build), so
-  this never fires there and its body folds away with the ledger (rf2-k9yuy)."
+  this never fires there and its body folds away with the ledger (rf2-k9yuy).
+
+  ## Exactly ONE live cycle per build, and why the supersession is loud
+
+  Opening a fresh cycle REPLACES whatever cycle was open for the build, so a
+  build has exactly one live cycle — the generation every registration and every
+  `:touched` note of that reload belongs to. Replacing is deliberate and is the
+  ABORTED-RELOAD RECOVERY: shadow's `do-js-reload*` abandons the remaining task
+  chain when a task throws, so a failed load never reaches `^:dev/after-load` and
+  leaves its cycle open forever. The next before-load must clear it, or the first
+  successful commit would apply a failed reload's partial staging.
+
+  Replacing is also LOSSY, and until rf2-84173 it was silent. The `:touched`
+  evidence in particular cannot be recovered: it is reported once, during the
+  load phase, and `note-reloaded-sources!` no-ops once no cycle is open. So the
+  supersession now reports what it discarded.
+
+  Discarding is the RULED reading of the ambiguity, not an oversight. A second
+  before-load has two possible causes and the ledger cannot tell them apart:
+  the common one is an aborted predecessor (discarding is correct); the rare one
+  is a genuinely overlapping activation (discarding loses a live cycle). Keeping
+  the evidence instead would trade the rare loss for a common one — a source that
+  re-ran in the aborted cycle sits in `:touched` with its staging thrown away, so
+  the next commit would EVICT declarations that still exist in the new code and
+  will not re-register. Losing live rows on every failed reload is strictly worse
+  than degrading an overlap that requires an async lifecycle hook to occur at all.
+
+  See `## Overlapping cycles are unsupported` above for why no token can do
+  better here."
   ([] (notify-reload! (current-build-id)))
   ([build-id]
    (when reload-ledger?
-     (swap! ledger-state assoc-in [::cycles build-id] {:staged {} :touched #{}}))
+     (let [[old _new] (swap-vals! ledger-state
+                                  assoc-in [::cycles build-id]
+                                  {:staged {} :touched #{}})]
+       ;; Only the transition that actually superseded an EVIDENCE-BEARING cycle
+       ;; reports. A cycle opened twice with nothing staged and nothing touched
+       ;; discarded nothing, so there is nothing to warn about — this tests what
+       ;; was LOST, not merely whether a key was present.
+       (when-let [{:keys [staged touched]} (get (::cycles old) build-id)]
+         (when (or (seq staged) (seq touched))
+           (report-unpaired-cycle! build-id staged touched)))))
    nil))
 
 (defn note-reloaded-sources!

--- a/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
@@ -429,6 +429,101 @@
       "and it commits with build :b's own cycle"))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-za45g — publication is DELIVERY, and delivery cannot falsify AUTHORITY.
+;;
+;; `commit-reload!` reconciles `::sources` and closes the cycle in ONE atomic
+;; swap, and only THEN publishes. Publishing `swap!`s the public aggregate, which
+;; notifies watches synchronously and without containment — so a throwing
+;; observer used to escape `publish!`, escape `commit-reload!`, and land in
+;; shadow's `^:dev/after-load` hook, which reports the ENTIRE reload as failed.
+;; The framework had already committed it. That is a listener telling a lie about
+;; authority, the same split rf2-vxgfnd.215 drew for descriptor HMR.
+;;
+;; These fixtures are the FAIL-BEFORE lever: on bare uncontained publication the
+;; throw propagates out of `commit-reload!` and every one of them errors.
+;;
+;; What is deliberately NOT asserted: that sibling observers still run. Watch
+;; fan-out belongs to the host's `IAtom`, which abandons the remaining watches
+;; when one throws. There are no framework-owned observers of `custom-elements`
+;; (classification reads `custom-element-properties`), so arbitrary watches are
+;; explicitly unsupported observers — contained and diagnosed, but their delivery
+;; completeness is the host's semantics, not a framework guarantee.
+;; ---------------------------------------------------------------------------
+
+(defn- with-observers
+  "Run `body` with each `[k f]` of `watches` installed on `custom-elements`, in
+  order, removing every one afterwards even when `body` throws."
+  [watches body]
+  (doseq [[k f] watches] (add-watch rules/custom-elements k f))
+  (try (body)
+       (finally (doseq [[k _] watches] (remove-watch rules/custom-elements k)))))
+
+(deftest throwing-publication-observer-cannot-fail-a-committed-reload
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :seed-el {:properties #{:s}} 'app.seed)
+  (let [ran (atom [])]
+    (with-observers
+      [[::boom (fn [_ _ _ _]
+                 (swap! ran conj :boom)
+                 (throw (ex-info "publication observer exploded" {})))]
+       [::good (fn [_ _ _ _] (swap! ran conj :good))]]
+      (fn []
+        (rules/notify-reload!)
+        (rules/register-custom-element! :seed-el {:properties #{:s2}} 'app.seed)
+        (is (nil? (rules/commit-reload!))
+            "the throwing observer does not escape the commit — shadow's
+             ^:dev/after-load hook sees the reload SUCCEED, because it did")))
+    (is (some #{:boom} @ran)
+        "the throwing observer really ran — the fixture has teeth")
+    (is (= #{:s2} (rules/custom-element-properties :seed-el))
+        "the committed reload is live despite the observer failure")
+    (is (empty? (rules/in-flight-cycles))
+        "the cycle is closed — no orphan cycle survives the contained failure")
+    (is (= (rules/projected-aggregate) @rules/custom-elements)
+        "the published aggregate is exactly the ledger projection — never torn")))
+
+(deftest contained-observer-failure-leaves-the-ledger-reloadable
+  ;; Quiescence: a contained failure must not poison the NEXT cycle. The ledger
+  ;; is a real row store afterwards, not a wedged one.
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :a-el {:properties #{:a}} 'app.a)
+  (with-observers
+    [[::boom (fn [_ _ _ _] (throw (ex-info "boom" {})))]]
+    (fn []
+      (rules/notify-reload!)
+      (rules/register-custom-element! :a-el {:properties #{:a2}} 'app.a)
+      (rules/commit-reload!)))
+  ;; observer gone; a clean subsequent reload still reconciles normally
+  (rules/notify-reload!)
+  (rules/note-reloaded-sources! ['app.a])
+  (rules/commit-reload!)
+  (is (= #{} (rules/custom-element-properties :a-el))
+      "a later zero-declaration reload still evicts — the ledger is not wedged")
+  (is (empty? (rules/in-flight-cycles))
+      "and it closes its cycle cleanly"))
+
+#?(:cljs
+   (deftest falsey-observer-throws-are-contained-without-truthiness-bugs
+     ;; AC: `(throw nil)` / `(throw false)` are legal on CLJS. A containment that
+     ;; branched on the truthiness of the CAUGHT value would treat both as "no
+     ;; failure" — silently dropping the diagnostic for exactly the values whose
+     ;; failure is hardest to spot. The `:failed?` bit is what carries identity.
+     (doseq [thrown [nil false]]
+       (rules/reset-custom-elements!)
+       (rules/register-custom-element! :f-el {:properties #{:f}} 'app.f)
+       (with-observers
+         [[::falsey (fn [_ _ _ _] (throw thrown))]]
+         (fn []
+           (rules/notify-reload!)
+           (rules/register-custom-element! :f-el {:properties #{:f2}} 'app.f)
+           (is (nil? (rules/commit-reload!))
+               (str "a thrown " (pr-str thrown) " is contained like any other"))))
+       (is (= #{:f2} (rules/custom-element-properties :f-el))
+           (str "the reload committed despite the thrown " (pr-str thrown)))
+       (is (empty? (rules/in-flight-cycles))
+           (str "no orphan cycle after a thrown " (pr-str thrown))))))
+
+;; ---------------------------------------------------------------------------
 ;; The production producer (rf2-vxgfnd.77) — the reload ledger's zero-declaration
 ;; eviction fired THROUGH the shipped browser reload path, not a direct
 ;; `note-reloaded-sources!` call. `reload-source-reset!` is what shadow-cljs's

--- a/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
@@ -429,6 +429,99 @@
       "and it commits with build :b's own cycle"))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-84173 — exactly ONE live cycle per build, and the supersession is LOUD.
+;;
+;; `notify-reload!` replaces whatever cycle was open. That is deliberate: shadow
+;; abandons the remaining task chain when a load task throws, so an aborted
+;; reload never runs `^:dev/after-load` and leaves its cycle open forever — the
+;; next before-load must clear it. It is also LOSSY, and it used to be silent:
+;; the same blind clobber served the routine abort-recovery and the pathological
+;; overlapping-cycle case, and nothing distinguished or reported them.
+;;
+;; These fixtures pin the SUPPORTED model honestly, including its documented
+;; loss. They do not pretend overlapping same-build cycles work — shadow conveys
+;; no cycle identity to `^:dev/after-load` and does not pair it with before-load,
+;; so no token in this ledger could make them work (see rules.cljc §Overlapping
+;; cycles are unsupported).
+;; ---------------------------------------------------------------------------
+
+(deftest overlapping-same-build-cycles-settle-without-orphan-or-duplicate
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :base-el {:properties #{:b}} 'app.base :ov)
+  (rules/notify-reload! :ov)                                          ; cycle N
+  (rules/register-custom-element! :n-el {:properties #{:n}} 'app.n :ov) ; N stages
+  (is (= #{:ov} (rules/in-flight-cycles))
+      "one live cycle for the build")
+  (rules/notify-reload! :ov)                                          ; cycle N+1
+  (is (= #{:ov} (rules/in-flight-cycles))
+      "still exactly ONE live cycle — a build never accumulates cycles")
+  (rules/register-custom-element! :m-el {:properties #{:m}} 'app.m :ov) ; N+1 stages
+  (rules/commit-reload! :ov)                                          ; N's after-load
+  (is (empty? (rules/in-flight-cycles))
+      "the single live cycle is closed — no orphan")
+  (is (= #{:m} (rules/custom-element-properties :m-el))
+      "the live cycle's staging committed")
+  (is (= #{} (rules/custom-element-properties :n-el))
+      "the SUPERSEDED cycle's staging was discarded — the documented, diagnosed
+       loss, not a silent one; overlapping same-build cycles are unsupported")
+  (is (= #{:b} (rules/custom-element-properties :base-el))
+      "an untouched source is unaffected by the supersession")
+  ;; the superseded cycle's own after-load arrives later: a harmless no-op that
+  ;; must not close, reopen, or re-apply anything.
+  (rules/commit-reload! :ov)
+  (is (empty? (rules/in-flight-cycles))
+      "the stale completion closes nothing and creates nothing")
+  (is (= {:base-el {:properties #{:b}} :m-el {:properties #{:m}}}
+         @rules/custom-elements)
+      "the settled manifest is exactly the supported model's legal outcome")
+  (is (= (rules/projected-aggregate) @rules/custom-elements)
+      "settled aggregate equals the ledger projection — nothing doubled"))
+
+#?(:cljs
+   (defn- capturing-console-warn
+     "Run `body` with `js/console.warn` captured; returns the captured messages."
+     [body]
+     (let [warnings (atom [])
+           original (.-warn js/console)]
+       (set! (.-warn js/console) (fn [msg] (swap! warnings conj (str msg))))
+       (try (body)
+            (finally (set! (.-warn js/console) original)))
+       @warnings)))
+
+#?(:cljs
+   (deftest superseding-a-live-cycle-is-diagnosed-never-silent
+     ;; FAIL-BEFORE lever: restore the bare `(swap! ledger-state assoc-in ...)`
+     ;; clobber and no diagnostic is emitted, so this reddens.
+     (rules/reset-custom-elements!)
+     (rules/register-custom-element! :s-el {:properties #{:s}} 'app.s :diag)
+     (let [warnings (capturing-console-warn
+                     (fn []
+                       (rules/notify-reload! :diag)
+                       (rules/register-custom-element! :s-el {:properties #{:s2}} 'app.s :diag)
+                       (rules/note-reloaded-sources! ['app.s] :diag)
+                       (rules/notify-reload! :diag)))]   ; UNPAIRED before-load
+       (is (= 1 (count warnings))
+           "the supersession is reported exactly once — bounded, not per-source")
+       (is (re-find #"STILL\s+OPEN" (first warnings))
+           "and names the anomaly it discarded evidence for"))))
+
+#?(:cljs
+   (deftest an-empty-cycle-reopened-discards-nothing-and-is-silent
+     ;; The guard must test what was LOST, not merely whether the cycle key was
+     ;; present — a presence test would warn on every ordinary consecutive
+     ;; reload that happened to stage nothing, training the reader to ignore it.
+     (rules/reset-custom-elements!)
+     (let [warnings (capturing-console-warn
+                     (fn []
+                       (rules/notify-reload! :quiet)
+                       (rules/notify-reload! :quiet)))]
+       (is (empty? warnings)
+           "re-opening a cycle that staged and touched NOTHING discarded nothing"))
+     (rules/commit-reload! :quiet)
+     (is (empty? (rules/in-flight-cycles))
+         "and the ledger still settles cleanly")))
+
+;; ---------------------------------------------------------------------------
 ;; rf2-za45g — publication is DELIVERY, and delivery cannot falsify AUTHORITY.
 ;;
 ;; `commit-reload!` reconciles `::sources` and closes the cycle in ONE atomic

--- a/implementation/ui/test/re_frame/ui/rules_reload_linearizability_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/rules_reload_linearizability_jvm_test.clj
@@ -96,7 +96,61 @@
       (is (= (rules/projected-aggregate) @rules/custom-elements)
           (str "round " round ": aggregate equals the ledger projection when settled"))
       (is (empty? (rules/in-flight-cycles))
-          (str "round " round ": no orphan cycle survives")))))
+          (str "round " round ": no orphan cycle survives"))
+      ;; rf2-84173: the raced registration's MID-race visibility is genuinely
+      ;; order-dependent, but its SETTLED visibility is not — both legal
+      ;; serializations retain it. Write-through-then-notify puts :race-el in
+      ;; ::sources under an untouched source, which the commit keeps;
+      ;; notify-then-write stages it into the cycle, which the commit applies.
+      ;; So asserting the settled manifest costs nothing and closes a real gap:
+      ;; without it this test tolerated losing :race-el entirely.
+      (is (= {:base-el {:properties #{:b}}
+              :race-el {:properties #{:r}}}
+             @rules/custom-elements)
+          (str "round " round
+               ": the raced registration is present EXACTLY once when settled — "
+               "never lost by either serialization, never doubled")))))
+
+(deftest notify-races-commit-closes-only-the-live-cycle
+  ;; rf2-84173 AC: notify-vs-commit, the interleaving the original suite never
+  ;; raced. Build :z has a cycle open with :seed-el staged at :s2. Concurrently
+  ;; the cycle's own after-load commits while the NEXT reload's before-load
+  ;; opens. Both operations transition the SAME atom, so they linearize into
+  ;; exactly two legal serial executions:
+  ;;   (a) commit-then-notify — the commit applies :s2 and closes; notify then
+  ;;       opens a fresh EMPTY cycle. One live cycle; :seed-el at :s2.
+  ;;   (b) notify-then-commit — notify supersedes the cycle (discarding its
+  ;;       staging, the documented and diagnosed loss); the commit then closes
+  ;;       that fresh empty cycle. No live cycle; :seed-el back at :s.
+  ;; Neither may orphan a cycle, tear the projection, or leave a half-applied
+  ;; row — and in NEITHER may a commit close a cycle it did not find live.
+  (dotimes [round 400]
+    (rules/reset-custom-elements!)
+    (rules/register-custom-element! :seed-el {:properties #{:s}} 'app.seed :z)
+    (rules/notify-reload! :z)
+    (rules/register-custom-element! :seed-el {:properties #{:s2}} 'app.seed :z)
+    (let [barrier   (CyclicBarrier. 2)
+          committer (future (await-barrier barrier) (rules/commit-reload! :z))
+          notifier  (future (await-barrier barrier) (rules/notify-reload! :z))]
+      @committer
+      @notifier
+      (is (contains? #{#{} #{:z}} (rules/in-flight-cycles))
+          (str "round " round ": at most ONE live cycle for the build — a race "
+               "never accumulates cycles"))
+      (is (contains? #{#{:s} #{:s2}} (rules/custom-element-properties :seed-el))
+          (str "round " round
+               ": :seed-el is at one of the two legal serial values, never a "
+               "half-applied third"))
+      (is (= (rules/projected-aggregate) @rules/custom-elements)
+          (str "round " round ": the aggregate is exactly the ledger projection "
+               "mid-race — never torn"))
+      ;; settle: close whatever cycle the race left live, then assert quiescence
+      (when (seq (rules/in-flight-cycles))
+        (rules/commit-reload! :z))
+      (is (empty? (rules/in-flight-cycles))
+          (str "round " round ": settles with no orphan cycle"))
+      (is (= (rules/projected-aggregate) @rules/custom-elements)
+          (str "round " round ": settled aggregate equals the ledger projection")))))
 
 (deftest concurrent-write-throughs-on-distinct-builds-compose
   ;; Two builds, no cycles: concurrent initial-load registrations must both land


### PR DESCRIPTION
Two bounded fixes to the custom-element hot-reload ledger in `implementation/ui/src/re_frame/ui/rules.cljc`.

## Scope, stated up front: this is DEV-TOOLING correctness, not a production guarantee

Both beads name machinery inside `reload-ledger?` (`js/goog.DEBUG` on CLJS), which Closure folds to `false` under `:advanced`. **Grep-verified, not argued** — a pseudo-named `:advanced` release (`browser-test-prod-elision` with `:pseudo-names true`, `goog.DEBUG false`) contains this complete `re_frame$ui$rules$*` surface:

```
assert_safe_caller_BANG_   assert_spread_prop_key_BANG_   caller_key_name
caller_key_slot            camelize                       class_part__GT_str
class_val                  classes_str                    custom_element_properties
custom_elements            flag_map_classes               handler_option_keys
owned_handler_slots        react_event_name               react_prop_name
react_style_name           register_custom_element_BANG_  rejected_prop_slots
rejected_prop_spellings    reset_custom_elements_BANG_    spread_safe_denied_structural_slots
standard_names             upper_first
```

No `publish_BANG_`, no `commit_reload_BANG_`, no `notify_reload_BANG_`, no `ledger_state`, no `reconcile_sources`, and neither new diagnostic (`report_publication_escape` / `report_unpaired_cycle` = 0 occurrences). The diagnostic string literals — which Closure never rewrites — are likewise absent from the real release bundle. Classification (`register_custom_element_BANG_`, `custom_elements`, `custom_element_properties`) survives, exactly as designed.

Note for anyone repeating this: `goog.DEBUG` appears **225 times** in that bundle, but every occurrence is inside a **docstring** carried in by the elision companion's var reification — not live code. A bare `goog.DEBUG` count is the wrong oracle for this bundle; the function-name and string-literal greps are the real ones.

So: neither fix is a production guarantee, and neither commit claims to be.

---

## 1. rf2-za45g — a throwing observer could report a committed reload as failed

`commit-reload!` reconciles `::sources` and closes the cycle in ONE atomic swap, then publishes. Publishing `swap!`s the public `custom-elements` aggregate, which notifies watches **synchronously and with no containment** — so a throwing observer escaped `publish!`, escaped `commit-reload!`, and landed in shadow's `^:dev/after-load` hook, which reports the whole reload as failed. The framework had already committed it.

**Observers throw; they do not fail silently.** (The analogous `rf2-1b0po` case turned out to be a no-op rather than a throw — this one is a real throw, and it really propagates.)

Publication is **delivery**, not authority, and gets delivery's failure semantics — the same split `rf2-vxgfnd.215` drew for descriptor HMR, whose `report-hmr-listener-escape!` this mirrors. Containment is sound because both hosts publish the atom's new value **before** notifying watches (CLJS `-reset!` sets state then `-notify-watches`; JVM `Atom.swap` CAS's then `notifyWatches`), so the aggregate, the projected ledger and the cycle state are left exactly as a clean publication leaves them.

Failure identity rides an explicit `:failed?` bit, never the truthiness of the caught value — `(throw nil)` and `(throw false)` are both legal on CLJS, and a truthiness test would silently drop precisely those diagnostics. There is a fixture for each.

**Not delivered, deliberately:** isolated *sibling* delivery. Watch fan-out belongs to the host's `IAtom`, which abandons remaining watches when one throws; replacing it means shipping a listener framework this ledger has no consumer for. There are **zero** framework-owned observers of `custom-elements` — classification reads `custom-element-properties`, never a watch, and the only `add-watch` on it in the corpus is a test fixture. Arbitrary watches are therefore documented as explicitly unsupported observers: contained and diagnosed, delivery completeness left to the host.

## 2. rf2-84173 — cycle ownership, and why a token would have been a tautology

The bead asked for explicit cycle ownership threaded through begin/stage/commit. Pinning shadow's actual loader contract first — as the bead directs — shows that cannot be built here, and that building it would ship a fake guard. From the pinned shadow-cljs client (`shadow.cljs.devtools.client.{browser,shared,env}`):

1. **No conveyance.** Lifecycle hooks are resolved by name off `$CLJS` and invoked with **no arguments**. A `^:dev/after-load` invocation is *anonymous*; it cannot present a claim minted by the before-load that opened its cycle. Any token would be minted **and** checked entirely inside this ledger, where `commit-reload!` could only compare it against the live slot it already reads — agreeing with itself by construction. That is exactly the shape of guard this repo has been burned by: an identity check in name, a re-read of the live slot in fact.
2. **No pairing.** `do-js-reload*` abandons the remaining task chain when a task throws, so a failed load never runs `^:dev/after-load`. before/after are not a balanced pair — which also kills every depth/refcount scheme: one aborted reload would pin the count above zero and hot reload would silently stop committing, forever.

Shadow has no single-flight guard of its own (no pending flag, queue, or dedup). What serializes cycles is JavaScript: with only **synchronous** lifecycle hooks the whole before/load/after chain runs inside one event-loop turn, so cycles cannot overlap. An `^:dev/*-async` hook anywhere in the build parks that chain and lets a second before-load land mid-cycle.

So this takes the bead's **second arm** — enforce the boundary and retire the overlap claim rather than add unused machinery:

- `notify-reload!` no longer clobbers a live cycle **silently**. It detects the unpaired before-load and reports what it discarded, once, bounded.
- The discard is **retained deliberately**: it is the aborted-reload recovery. Keeping the evidence instead trades a rare loss for a common one — a source that re-ran in the aborted cycle sits in `:touched` with its staging gone, so the next commit would evict declarations that still exist and will not re-register. That reasoning is in the docstring.
- **The guard tests what was LOST**, `(or (seq staged) (seq touched))`, not merely whether the cycle key was present. A presence test would fire on every ordinary consecutive reload and train the reader to ignore it — a bounds check wearing an identity check's clothes, which is the failure mode `rf2-6pfpt` just found elsewhere. There is a negative fixture asserting silence when nothing was discarded.
- Prose now documents the real boundary and narrows "generation", which elsewhere in this namespace means the open-vs-closed cycle state a registration observes atomically (`rf2-vxgfnd.144`) — a property of the transition, never an identity for a cycle.

**Not delivered, and reported rather than faked:** AC1's *"a delayed completion from cycle N cannot consume or close cycle N+1"* and the arm-1 reading of AC3. Both require conveyance shadow does not provide. This is the same class of finding that escalated sibling `rf2-vxgfnd.143`, and it wants the same operator decision.

### Existing-guard audit

The pre-existing reentrancy guard (`(contains? (::cycles old) build-id)` in `register-custom-element!` / `commit-reload!`) **is** a genuine state test on the atomically-observed transition, not a size or bounds check in disguise. It is correct as written and untouched.

## Quality gates

All run in the foreground to completion, unpiped, exit codes captured by redirect. Baselines are **test counts**; assertion totals drift run-to-run from the generative suites (observed: JVM 18628 then 18620 on an identical tree).

| Gate | Result |
|---|---|
| `implementation/ui` + `clojure -M:test` | **952 tests**, 0 failures, 0 errors (baseline 948; +2 JVM-visible deftests) |
| `npm run test:cljs` | **10157 tests**, 0 failures, 0 errors |
| `npm run test:browser` | **472 tests**, 2665 assertions, 0 failures, 0 errors |
| `npm run test:elision` | **PASS** — production 60/60 absent, control 60/60 present, EP-0023 provenance + assembly-DCE |
| `npm run test:browser-prod-elision` | **105 tests**, 412 assertions, 0 failures, 0 errors (incl. the renamed-state mutant control) |
| `scripts/check-no-hardcoded-paths.sh` | Portability gate OK |

JVM and CLJS were re-run **after the second commit**; counts stable.

### Red-before, per bead, each with its OWN lever

**rf2-za45g** — lever: restore the bare uncontained `publish!`.

- JVM: **2 errors**, both new fixtures. Green after: 950.
- CLJS: **4 errors** across all 3 new fixtures (the falsey one twice — once for `nil`, once for `false`). Green after: 10154.

**rf2-84173** — lever: restore the blind silent clobber in `notify-reload!`.

- CLJS: **1 failure + 1 error** in `superseding-a-live-cycle-is-diagnosed-never-silent`. Green after: 10157.
- The overlap and race fixtures stay green under this lever **by design** — they are contract *pins* closing the bead's stated proof gap, not falsifiability proofs of the diagnostic. Called out rather than counted as red-before evidence.

## Error ids

**None added.** Both diagnostics are plain bounded DEV `console.warn`s on the established `re-frame.ui` pattern, so no Spec 009 catalogue row and no Spec-Schemas row is due — and no row was added that would have no emit site.

## Surface

`implementation/ui/src/re_frame/ui/rules.cljc` plus its two test files, nothing else. Verified against every sibling worktree (dirty **and** committed-vs-own-merge-base, not just `gh pr list`): only `opt-6001` carries `implementation/ui/src` commits and it does not touch `rules.cljc`. No contract moved, so no Spec 004-family row. Did not touch `spec/009`, `spec/011`, `implementation/ssr/**`, `implementation/routing/**`, `implementation/core/**` (#6365), or `ai/**`.

Siblings `rf2-mp6fz` and `rf2-4vm19` were not in scope and were not touched.
