### PR TITLE
fix(story): fence a11y run-state mutations against supersession (rf2-2amkm)

### DIFF
--- a/tools/story/src/re_frame/story/ui/a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/a11y.cljs
@@ -64,15 +64,33 @@
   (r/atom {}))
 
 (defonce
-  ^{:doc "Per-frame run state.
-         `{frame-id → :idle|:loading|:running|:done|:error|:no-root|:no-consent}`.
-         `:no-consent` means the dev hasn't approved the CDN load yet."}
+  ^{:doc "Per-frame run state. `{frame-id → {:status … :token …}}`.
+
+         `:status` is `:idle|:loading|:running|:done|:error|:no-root|
+         :no-consent`; `:no-consent` means the dev hasn't approved the
+         CDN load yet. Read it through `status-for`, which supplies
+         `:idle` for a frame with no slot.
+
+         `:token` is the identity of the run currently OWNING this
+         frame's scan (see `new-run-token`). Present only while a run is
+         in flight or has finished; the synchronous refusals
+         (`:no-root` / `:no-consent`) claim no run and carry none."}
   run-state
   (r/atom {}))
 
+(defn status-for
+  "The run status the panel renders for `frame-id`. A frame with no slot
+  — never scanned, or torn down — reads `:idle`."
+  [frame-id]
+  (:status (get @run-state frame-id) :idle))
+
 (defn drop-frame-state!
   "Clear all a11y state for `frame-id`. Called from the canvas /
-  shell teardown when a variant frame is destroyed."
+  shell teardown when a variant frame is destroyed.
+
+  Dropping the slot also revokes any in-flight run's claim on it: the
+  run's token no longer matches, so its settlement is refused rather
+  than resurrecting the frame (see `stale-run?`)."
   [frame-id]
   (swap! violations-by-frame dissoc frame-id)
   (swap! run-state           dissoc frame-id)
@@ -112,6 +130,80 @@
   (reset! violations-by-frame {})
   (reset! run-state {})
   nil)
+
+;; ---- the supersession fence ---------------------------------------------
+;;
+;; An axe run is asynchronous twice over: it awaits the CDN load, then
+;; awaits the scan. Across either gap the frame can be torn down
+;; (`drop-frame-state!`, `reset-state!`) or a newer `run-axe!` can claim
+;; the same frame. A settlement that mutates the run-state slot without
+;; re-checking it therefore lands on a surface that is no longer its own.
+;;
+;; WHAT THAT COSTS, and why it is not a crash (rf2-2amkm, the shape
+;; rf2-6pfpt measured on the play-runner's sibling path): under teardown
+;; the mutation does not throw. `(swap! run-state assoc frame-id :done)`
+;; over a map the frame was dissoc'd from RESURRECTS the entry — a
+;; phantom slot reading `:done`, alongside a resurrected
+;; `violations-by-frame` entry that the below-the-UI executor seam
+;; (`browser/register-a11y-reader!`) then serves to `:rf.assert/a11y`.
+;; A scan of a frame that is gone reporting a clean verdict; a fabricated
+;; green, not a hang.
+;;
+;; WHY A TOKEN IN THE SLOT rather than a conveyed binding. The hazard is
+;; a run OUTLIVING its claim, not a claim failing to reach a callback —
+;; the inverse of the conveyance problem. The claim already arrives
+;; everywhere it is needed (the closures capture it); what it must be
+;; checked AGAINST is the LIVE slot, and a `^:dynamic` Var or any other
+;; conveyed mechanism cannot do that — conveyed into the callback, it
+;; would agree with the callback by construction. So: a plain value,
+;; compared to the world as it now is.
+;;
+;; WHY THE TOKEN LIVES IN THE SLOT rather than beside it. Carrying it in
+;; the run-state value makes "does the slot still exist" and "is it still
+;; mine" ONE question with ONE answer, and gives the fence no separate
+;; lifecycle to keep in step: every present and future path that clears a
+;; frame's state invalidates its token by construction, with nothing to
+;; remember to bump. A side atom would have to be cleared at each of
+;; those sites, and a site that forgot would silently ADMIT a stale
+;; settlement.
+
+(defn new-run-token
+  "Mint a fresh identity for ONE axe run. Shared with the chrome panel
+  (`ui/chrome-a11y`), which fences the same way over its own slot.
+
+  A bare JS object: unforgeable, allocation-cheap, and distinguishable
+  by `identical?` alone — no counter to maintain and no equality to
+  collide. Identity is the whole point, and the reason the fences below
+  use `identical?` rather than `=`: two runs of the same frame are
+  legitimately EQUAL in every other respect and must still be told
+  apart."
+  []
+  #js {})
+
+(defn- stale-run?
+  "True when the run carrying `token` no longer owns `frame-id`'s slot,
+  and must therefore mutate nothing.
+
+  The two ways to lose the slot collapse into one comparison:
+
+    - the slot is GONE — the frame was torn down mid-run, so there is no
+      live token to match;
+    - the slot carries a DIFFERENT token — a newer `run-axe!` claimed it,
+      and that run's verdict is the one the panel owes the dev.
+
+  A token-less caller never owns the slot: ownership requires holding a
+  real token AND its being the one in the slot. (This is deliberately
+  stricter than the play-runner's `stale-run?`, which treats a
+  token-LESS slot as still-owned so hand-seeded run states predating the
+  token scheme keep working. There is no such caller here — every a11y
+  run is minted by `run-axe!` — so the stricter rule costs nothing and
+  refuses more.)
+
+  Staleness is one-way: tokens are minted fresh per run and never
+  re-stamped, so a run that has lost the slot can never regain it."
+  [frame-id token]
+  (let [live (:token (get @run-state frame-id))]
+    (not (and (some? token) (identical? token live)))))
 
 ;; ---- axe-core CDN load (opt-in) -----------------------------------------
 ;;
@@ -363,7 +455,7 @@
      ;; degraded state instead of silently scanning the wrong tree.
      (nil? context)
      (do
-       (swap! run-state assoc frame-id :no-root)
+       (swap! run-state assoc frame-id {:status :no-root})
        (js/console.warn
          "[story.a11y] no variant root found for"
          (pr-str frame-id)
@@ -376,32 +468,53 @@
      ;; that explains the egress) before re-invoking `run-axe!`.
      (not (cdn-opt-in?))
      (do
-       (swap! run-state assoc frame-id :no-consent)
+       (swap! run-state assoc frame-id {:status :no-consent})
        (js/Promise.resolve nil))
 
      :else
-     (do
-       (swap! run-state assoc frame-id :loading)
+     ;; SUPERSESSION FENCE (rf2-2amkm). Claiming the slot and every later
+     ;; mutation of it are gated on ONE token — see `stale-run?` for the
+     ;; full rationale. Each check sits in the SAME synchronous turn as
+     ;; the mutation it guards, so nothing can take the slot between
+     ;; them.
+     (let [token (new-run-token)]
+       (swap! run-state assoc frame-id {:status :loading :token token})
        (-> (ensure-axe-loaded!)
            (.then
              (fn [^js axe]
-               (swap! run-state assoc frame-id :running)
-               (.run axe context)))
+               ;; First gap: the CDN load. A run that lost the slot here
+               ;; also declines to SCAN — not merely to record. There is
+               ;; nothing to learn from axe-core about a torn-down tree,
+               ;; and a superseded run's findings belong to nobody.
+               (when-not (stale-run? frame-id token)
+                 (swap! run-state assoc frame-id {:status :running :token token})
+                 (.run axe context))))
            (.then
              (fn [^js results]
-               (let [vs        (.-violations results)
-                     scope-el  (when (and (some? context)
-                                          (some? (.-nodeType context)))
-                                 context)]
-                 (swap! violations-by-frame assoc frame-id (vec (array-seq vs)))
-                 (doseq [v (array-seq vs)]
-                   (record-violation-overlay! scope-el v)
-                   (emit-warning-for-violation frame-id v))
-                 (swap! run-state assoc frame-id :done)
-                 vs)))
+               ;; Second gap: the scan itself. `results` is nil only when
+               ;; the fence above already declined, and staleness is
+               ;; one-way, so this fence has necessarily refused by then
+               ;; too — the nil never reaches `.-violations`.
+               (when-not (stale-run? frame-id token)
+                 (let [vs        (.-violations results)
+                       scope-el  (when (and (some? context)
+                                            (some? (.-nodeType context)))
+                                   context)]
+                   (swap! violations-by-frame assoc frame-id (vec (array-seq vs)))
+                   (doseq [v (array-seq vs)]
+                     (record-violation-overlay! scope-el v)
+                     (emit-warning-for-violation frame-id v))
+                   (swap! run-state assoc frame-id {:status :done :token token})
+                   vs))))
            (.catch
              (fn [e]
-               (swap! run-state assoc frame-id :error)
+               ;; The STATE write is fenced; the console line is not. A
+               ;; failed CDN load (offline, CSP, SRI mismatch) is real
+               ;; diagnostic information about the dev's environment even
+               ;; when the run that hit it has been superseded, and
+               ;; swallowing it would hide a genuine misconfiguration.
+               (when-not (stale-run? frame-id token)
+                 (swap! run-state assoc frame-id {:status :error :token token}))
                (js/console.error "[story.a11y]" e)
                nil)))))))
 
@@ -558,7 +671,7 @@
   [variant-id]
   (ensure-stylesheet!)
   (let [vs    (get @violations-by-frame variant-id [])
-        state (get @run-state           variant-id :idle)
+        state (status-for variant-id)
         busy? (or (= state :loading) (= state :running))]
     [:div {:style (:wrap styles)}
      [:div {:style (:header styles)}

--- a/tools/story/src/re_frame/story/ui/chrome_a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/chrome_a11y.cljs
@@ -90,19 +90,50 @@
   (r/atom []))
 
 (defonce
-  ^{:doc "Run state: :idle|:loading|:running|:done|:error|:no-root|:no-consent.
-         Mirrors the per-frame run-state slot in `ui/a11y.cljs` for UX
-         parity with the variant panel."}
+  ^{:doc "Run state, `{:status … :token …}`. `:status` is
+         `:idle|:loading|:running|:done|:error|:no-root|:no-consent`;
+         read it through `status`.
+
+         `:token` identifies the run currently OWNING the chrome scan —
+         see `a11y/new-run-token` and `stale-run?` below. Mirrors the
+         per-frame run-state slot in `ui/a11y.cljs` for UX parity with
+         the variant panel, and fences the same way."}
   run-state
-  (r/atom :idle))
+  (r/atom {:status :idle}))
+
+(defn status
+  "The run status the panel renders."
+  []
+  (:status @run-state :idle))
+
+(defn- stale-run?
+  "True when the run carrying `token` no longer owns the chrome scan.
+
+  The singleton counterpart of `a11y/stale-run?`, and narrower for it:
+  the chrome slot is one atom that always exists, so there is no
+  teardown-resurrection to refuse — only supersession. A run loses the
+  slot when a newer `run-axe!` claims it, or when `reset-state!` returns
+  the panel to `:idle`, both of which replace the token.
+
+  Same reasoning as the variant panel: the hazard is a run outliving its
+  claim, so the fence compares a captured value to the LIVE slot rather
+  than conveying a binding that would agree with itself. Carrying the
+  token IN the slot is what makes `reset-state!` revoke it for free."
+  [token]
+  (let [live (:token @run-state)]
+    (not (and (some? token) (identical? token live)))))
 
 (defn reset-state!
   "Test-fixture helper. Clears the violations vector + resets the run-
   state to :idle. The CDN opt-in is NOT cleared (that's the variant
-  panel's concern + a persisted user decision)."
+  panel's concern + a persisted user decision).
+
+  Resetting also revokes any in-flight run's claim, so a scan still
+  pending when the panel is reset settles into nothing rather than
+  reinstating its verdict over the cleared state."
   []
   (reset! violations [])
-  (reset! run-state :idle)
+  (reset! run-state {:status :idle})
   nil)
 
 ;; ---- Use-system-colors? toggle ------------------------------------------
@@ -289,7 +320,7 @@
      ;; flag any pre-shell content the page hosts).
      (nil? context)
      (do
-       (reset! run-state :no-root)
+       (reset! run-state {:status :no-root})
        (js/console.warn
          "[story.chrome-a11y] no chrome root found"
          "— the Story shell does not appear to be mounted.")
@@ -299,32 +330,46 @@
      ;; consent approves both panels.
      (not (a11y/cdn-opt-in?))
      (do
-       (reset! run-state :no-consent)
+       (reset! run-state {:status :no-consent})
        (js/Promise.resolve nil))
 
      :else
-     (do
-       (reset! run-state :loading)
+     ;; SUPERSESSION FENCE (rf2-2amkm) — the variant panel's fence over
+     ;; this panel's singleton slot. Every mutation on the far side of an
+     ;; await is gated on the token claimed here, in the same synchronous
+     ;; turn as the mutation it guards.
+     (let [token (a11y/new-run-token)]
+       (reset! run-state {:status :loading :token token})
        (-> (a11y/ensure-axe-loaded!)
            (.then
              (fn [^js axe]
-               (reset! run-state :running)
-               (.run axe context)))
+               ;; A superseded run declines to SCAN, not merely to
+               ;; record — its findings would belong to nobody.
+               (when-not (stale-run? token)
+                 (reset! run-state {:status :running :token token})
+                 (.run axe context))))
            (.then
              (fn [^js results]
-               (let [vs        (.-violations results)
-                     scope-el  (when (and (some? context)
-                                          (some? (.-nodeType context)))
-                                 context)]
-                 (reset! violations (vec (array-seq vs)))
-                 (doseq [v (array-seq vs)]
-                   (a11y/record-violation-overlay! scope-el v)
-                   (a11y/emit-warning-for-violation chrome-frame-id v))
-                 (reset! run-state :done)
-                 vs)))
+               ;; `results` is nil only when the fence above declined,
+               ;; and staleness is one-way, so this fence has refused by
+               ;; then too — the nil never reaches `.-violations`.
+               (when-not (stale-run? token)
+                 (let [vs        (.-violations results)
+                       scope-el  (when (and (some? context)
+                                            (some? (.-nodeType context)))
+                                   context)]
+                   (reset! violations (vec (array-seq vs)))
+                   (doseq [v (array-seq vs)]
+                     (a11y/record-violation-overlay! scope-el v)
+                     (a11y/emit-warning-for-violation chrome-frame-id v))
+                   (reset! run-state {:status :done :token token})
+                   vs))))
            (.catch
              (fn [e]
-               (reset! run-state :error)
+               ;; State write fenced, console line not — see the variant
+               ;; panel's `.catch` for why the diagnostic survives.
+               (when-not (stale-run? token)
+                 (reset! run-state {:status :error :token token}))
                (js/console.error "[story.chrome-a11y]" e)
                nil)))))))
 
@@ -446,7 +491,7 @@
   [_variant-id]
   (a11y/ensure-stylesheet!)
   (let [vs    @violations
-        state @run-state
+        state (status)
         busy? (or (= state :loading) (= state :running))]
     [:div {:style (:wrap styles) :data-test "story-chrome-a11y-panel"}
      [:div {:style (:header styles)}

--- a/tools/story/test/re_frame/story/ui/a11y_stale_settlement_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/a11y_stale_settlement_cljs_test.cljs
@@ -1,0 +1,412 @@
+(ns re-frame.story.ui.a11y-stale-settlement-cljs-test
+  "rf2-2amkm — STALE SETTLEMENT of an a11y scan, in both axe-core panels.
+
+  `run-axe!` is asynchronous twice over: it awaits the CDN load, then
+  awaits the scan. Across either gap the surface it is scanning can stop
+  being its own — the variant frame torn down (`drop-frame-state!`), the
+  panel reset (`reset-state!`), or a newer `run-axe!` claiming the same
+  slot. Every mutation in the `.then` / `.catch` callbacks used to run
+  unconditionally, so a settlement landed on whatever occupied the slot
+  by then.
+
+  WHAT THAT COSTS, and why it is not a crash. The mutation does not
+  throw under teardown: `(swap! run-state assoc frame-id :done)` over a
+  map the frame was dissoc'd from RESURRECTS the entry rather than
+  failing — the a11y analogue of the `(inc nil)` resurrection rf2-6pfpt
+  measured on the play-runner's `record-result!` path (#6405). The
+  phantom slot reads `:done`, and the resurrected `violations-by-frame`
+  entry beside it is what the below-the-UI executor seam
+  (`browser/register-a11y-reader!`) serves to `:rf.assert/a11y`. A scan
+  of a frame that is GONE reporting a clean verdict: a fabricated green,
+  not a hang and not an exception. `no-throw-and-no-resurrection` below
+  asserts BOTH halves — that it does not throw is exactly why the defect
+  was invisible.
+
+  DETERMINISM. Every test here places its own interleaving. The fake
+  axe-core's `run` is called synchronously by the code under test, so a
+  test can perform the takeover INSIDE the scan — 'the frame was torn
+  down while the scan was in flight' is positioned exactly, never raced.
+  Assertions are chained off the promise `run-axe!` returns (the tail of
+  the whole callback chain) and, where a second run is involved, off a
+  signal the second run's scan fires — so nothing depends on counting
+  microtask turns.
+
+  Pure `.cljs`: the panels are CLJS-only, and the `async` tests below
+  need cljs.test MAP fixtures, which a `.cljc` may not use
+  (`re-frame.story.meta-fixtures-test`)."
+  (:require [cljs.test :refer [async deftest is testing use-fixtures]]
+            [goog.object :as gobj]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story :as story]
+            [re-frame.story.ui.a11y :as a11y]
+            [re-frame.story.ui.chrome-a11y :as chrome-a11y]))
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+;;
+;; `ensure-axe-loaded!` resolves immediately when `js/window.axe` is
+;; already present, so installing a fake axe there drives the REAL
+;; `run-axe!` end to end — the CDN branch is never reached and no
+;; `with-redefs` routes around the code under test. The node test runtime
+;; has no `window`; the fixture installs one and restores whatever was
+;; there, because this process runs every other CLJS namespace too and a
+;; leaked `window` would flip browser-detection branches elsewhere.
+
+(def ^:private saved-window (atom nil))
+
+(defn- install-axe!
+  "Point the fake axe-core's `run` at `run-fn`, which receives the scan
+  context and returns the results promise. Re-installable mid-flight so
+  a test can give a second run different scan behaviour."
+  [run-fn]
+  (gobj/set (gobj/get js/globalThis "window") "axe"
+            #js {"run" (fn [ctx] (run-fn ctx))})
+  nil)
+
+(defn- setup! []
+  (reset! saved-window (gobj/get js/globalThis "window"))
+  (gobj/set js/globalThis "window" #js {})
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (a11y/reset-state!)
+  (chrome-a11y/reset-state!)
+  ;; `ensure-axe-loaded!` latches this once it has seen a global axe;
+  ;; clear it so each test re-reads the fake installed for it.
+  (reset! a11y/axe-loaded? false)
+  (a11y/set-cdn-opt-in! true))
+
+(defn- teardown! []
+  (a11y/set-cdn-opt-in! false)
+  (reset! a11y/axe-loaded? false)
+  (a11y/reset-state!)
+  (chrome-a11y/reset-state!)
+  (gobj/set js/globalThis "window" @saved-window))
+
+(use-fixtures :each {:before setup! :after teardown!})
+
+;; A context object that is `nodeType`-bearing (so `run-axe!` treats it
+;; as the overlay scope) and selector-inert (its `querySelector` finds
+;; nothing, so the overlay decorator is a no-op).
+(defn- ctx [] #js {:nodeType 1 "querySelector" (fn [_] nil)})
+
+(defn- violation
+  "An axe-core-shaped violation carrying `id`, with no nodes — enough for
+  the panel to store and for `emit-warning-for-violation` to read."
+  [id]
+  #js {:id id :impact "serious" :help (str "help for " id) :nodes #js []})
+
+(defn- results
+  "An axe-core results object listing violations with the given ids."
+  [& ids]
+  #js {:violations (apply array (map violation ids))})
+
+(defn- never-settles
+  "A promise that never resolves — a scan still in flight when the test
+  makes its assertions, so the run holding the slot demonstrably still
+  holds it."
+  []
+  (js/Promise. (fn [_ _] nil)))
+
+(defn- signal
+  "A promise plus the fn that resolves it. Lets a test wait for a
+  specific point in a SECOND run to be reached, instead of counting
+  microtask turns to guess when it happened."
+  []
+  (let [resolve-fn (atom nil)
+        p          (js/Promise. (fn [res _] (reset! resolve-fn res)))]
+    {:promise p :fire! (fn [] (@resolve-fn true))}))
+
+(defn- violation-ids
+  "The violation ids the variant panel currently holds for `frame-id`."
+  [frame-id]
+  (mapv #(gobj/get % "id") (get @a11y/violations-by-frame frame-id [])))
+
+(defn- chrome-violation-ids []
+  (mapv #(gobj/get % "id") @chrome-a11y/violations))
+
+(def ^:private frame-id :story.a11y-fence/variant)
+
+;; ===========================================================================
+;; The variant panel (ui/a11y) — a per-frame slot
+;; ===========================================================================
+
+(deftest an-owning-run-records-its-scan
+  (testing "POSITIVE CONTROL, and the premise the refusals rest on. A
+            fence that simply stopped recording settled scans would pass
+            every staleness test below while breaking every real scan.
+            The run that still owns the slot records exactly as before"
+    (async done
+      (let [scans (atom 0)]
+        (install-axe! (fn [_] (swap! scans inc)
+                        (js/Promise.resolve (results "color-contrast"))))
+        (-> (a11y/run-axe! frame-id (ctx))
+            (.then (fn [_]
+                     (is (= 1 @scans) "the scan really ran")
+                     (is (= :done (a11y/status-for frame-id))
+                         "the owning run reached its terminal status")
+                     (is (= ["color-contrast"] (violation-ids frame-id))
+                         "and its violations were recorded")
+                     (done))))))))
+
+(deftest no-throw-and-no-resurrection
+  (testing "THE BUG (rf2-2amkm): the frame is torn down while the scan is
+            in flight. Settling must not throw — and the reason this
+            defect was invisible is that it never did: `assoc` over a map
+            the frame was dissoc'd from RESURRECTS the entry, fabricating
+            a `:done` slot and a violations bag for a frame that is gone,
+            which the executor seam then serves to `:rf.assert/a11y` as a
+            clean verdict"
+    (async done
+      (install-axe!
+        (fn [_]
+          ;; The takeover, placed exactly: the run has claimed the slot
+          ;; and reached `:running`, and the scan is now in flight.
+          (a11y/drop-frame-state! frame-id)
+          (js/Promise.resolve (results "color-contrast"))))
+      (-> (a11y/run-axe! frame-id (ctx))
+          (.then (fn [_]
+                   (is (not (contains? @a11y/run-state frame-id))
+                       "no phantom run-state entry — the slot stayed torn down")
+                   (is (not (contains? @a11y/violations-by-frame frame-id))
+                       "and no phantom violations bag beside it: this is the
+                        entry `browser/register-a11y-reader!` would have
+                        served to :rf.assert/a11y as a verdict")
+                   (is (= :idle (a11y/status-for frame-id))
+                       "a frame with no slot reads :idle, NOT :done")
+                   (done)))
+          (.catch (fn [e]
+                    (is false (str "settling after teardown threw: " e))
+                    (done)))))))
+
+(deftest stale-settlement-does-not-clobber-the-replacement-run
+  (testing "THE OTHER WAY TO LOSE THE SLOT: run A parks on its scan, a
+            newer run B claims the same frame, and A THEN settles. A's
+            findings must not land in B's slot — the panel would show A's
+            verdict over a scan B is still performing"
+    (async done
+      (let [b-scanning (signal)]
+        (install-axe!
+          (fn [_]
+            ;; B claims the slot mid-A-scan and parks in its own scan, so
+            ;; B demonstrably still holds the slot at assertion time.
+            (install-axe! (fn [_] ((:fire! b-scanning)) (never-settles)))
+            (a11y/run-axe! frame-id (ctx))
+            (js/Promise.resolve (results "from-run-a"))))
+        (-> (js/Promise.all #js [(a11y/run-axe! frame-id (ctx))
+                                 (:promise b-scanning)])
+            (.then (fn [_]
+                     (is (= :running (a11y/status-for frame-id))
+                         "B still owns the slot and is still scanning — A's
+                          settlement did not write its terminal :done over it")
+                     (is (= [] (violation-ids frame-id))
+                         "and A's findings were not attributed to B's scan")
+                     (done))))))))
+
+(deftest the-fence-does-not-latch
+  (testing "THE SEQUENCE, not just the cases. A fence can be correct on
+            every single transition and still be broken as a machine: it
+            may latch shut after its first refusal, or latch open after
+            its first admission. Four transitions on ONE frame through
+            ONE fence, each asserted: ADMIT, REFUSE, ADMIT again (the
+            refusal did not latch it shut), REFUSE again (the admission
+            did not latch it open)"
+    (async done
+      (letfn [(admit! [id k]
+                (install-axe! (fn [_] (js/Promise.resolve (results id))))
+                (.then (a11y/run-axe! frame-id (ctx)) k))
+              (refuse! [id k]
+                (let [b (signal)]
+                  (install-axe!
+                    (fn [_]
+                      (install-axe! (fn [_] ((:fire! b)) (never-settles)))
+                      (a11y/run-axe! frame-id (ctx))
+                      (js/Promise.resolve (results id))))
+                  (.then (js/Promise.all #js [(a11y/run-axe! frame-id (ctx))
+                                              (:promise b)])
+                         k)))]
+        (admit!
+          "v1"
+          (fn [_]
+            (is (= ["v1"] (violation-ids frame-id)) "1/4 ADMITTED")
+            (is (= :done (a11y/status-for frame-id)))
+            (refuse!
+              "v2"
+              (fn [_]
+                (is (= ["v1"] (violation-ids frame-id))
+                    "2/4 REFUSED — the superseded run left v1 standing")
+                (is (= :running (a11y/status-for frame-id)))
+                (admit!
+                  "v3"
+                  (fn [_]
+                    (is (= ["v3"] (violation-ids frame-id))
+                        "3/4 ADMITTED AGAIN — the refusal did not latch the
+                         fence shut")
+                    (is (= :done (a11y/status-for frame-id)))
+                    (refuse!
+                      "v4"
+                      (fn [_]
+                        (is (= ["v3"] (violation-ids frame-id))
+                            "4/4 REFUSED AGAIN — the admission did not latch
+                             the fence open")
+                        (is (= :running (a11y/status-for frame-id)))
+                        (done)))))))))))))
+
+(deftest a-superseded-run-declines-to-scan
+  (testing "A run that lost the slot across the CDN-load gap does not
+            scan at all. There is nothing to learn from axe-core about a
+            torn-down tree, and a superseded run's findings belong to
+            nobody — so the fence is consulted before the scan, not only
+            before the record"
+    (async done
+      (let [scans (atom 0)]
+        (install-axe! (fn [_] (swap! scans inc) (js/Promise.resolve (results))))
+        ;; Claim the slot and tear it down before the load settles — the
+        ;; whole of `run-axe!`'s first `.then` is still ahead of us.
+        (let [p (a11y/run-axe! frame-id (ctx))]
+          (a11y/drop-frame-state! frame-id)
+          (-> p
+              (.then (fn [_]
+                       (is (= 0 @scans)
+                           "axe-core was never invoked for the abandoned run")
+                       (is (not (contains? @a11y/run-state frame-id))
+                           "and nothing was resurrected")
+                       (done)))))))))
+
+(deftest a-superseded-run-does-not-report-its-error
+  (testing "The `.catch` mutates run-state too, and sits on the same far
+            side of the await. A superseded run whose scan REJECTS must
+            not stamp `:error` over the run that now owns the slot —
+            otherwise a failed abandoned scan discredits a healthy one"
+    (async done
+      (let [b-scanning (signal)]
+        (install-axe!
+          (fn [_]
+            (install-axe! (fn [_] ((:fire! b-scanning)) (never-settles)))
+            (a11y/run-axe! frame-id (ctx))
+            (js/Promise.reject (js/Error. "axe blew up"))))
+        (-> (js/Promise.all #js [(a11y/run-axe! frame-id (ctx))
+                                 (:promise b-scanning)])
+            (.then (fn [_]
+                     (is (= :running (a11y/status-for frame-id))
+                         "B's in-flight scan was not overwritten with A's :error")
+                     (done))))))))
+
+(deftest a-torn-down-frame-does-not-resurrect-on-error
+  (testing "The same obligation under teardown: a rejected scan for a
+            frame that is gone must leave the slot gone, not resurrect it
+            carrying `:error`"
+    (async done
+      (install-axe!
+        (fn [_]
+          (a11y/drop-frame-state! frame-id)
+          (js/Promise.reject (js/Error. "axe blew up"))))
+      (-> (a11y/run-axe! frame-id (ctx))
+          (.then (fn [_]
+                   (is (not (contains? @a11y/run-state frame-id))
+                       "no phantom :error slot for a torn-down frame")
+                   (done)))))))
+
+;; ===========================================================================
+;; The chrome panel (ui/chrome-a11y) — the same fence over a singleton slot
+;; ===========================================================================
+;;
+;; The chrome slot is one atom that always exists, so there is no
+;; teardown-resurrection to refuse here — only supersession, and
+;; `reset-state!`, which is this panel's analogue of teardown: it returns
+;; the panel to `:idle` and must not be undone by a scan still in flight.
+
+(deftest chrome-owning-run-records-its-scan
+  (testing "POSITIVE CONTROL for the chrome panel"
+    (async done
+      (install-axe! (fn [_] (js/Promise.resolve (results "region"))))
+      (-> (chrome-a11y/run-axe! (ctx))
+          (.then (fn [_]
+                   (is (= :done (chrome-a11y/status)))
+                   (is (= ["region"] (chrome-violation-ids)))
+                   (done)))))))
+
+(deftest chrome-reset-is-not-undone-by-a-pending-scan
+  (testing "rf2-2amkm — the panel is reset while a scan is in flight.
+            The settlement must not reinstate its verdict over the
+            cleared panel: the operator would be shown violations for a
+            scan they had already dismissed, and a `:done` status for a
+            run that no longer exists"
+    (async done
+      (install-axe!
+        (fn [_]
+          (chrome-a11y/reset-state!)
+          (js/Promise.resolve (results "region"))))
+      (-> (chrome-a11y/run-axe! (ctx))
+          (.then (fn [_]
+                   (is (= :idle (chrome-a11y/status))
+                       "the reset stands — the stale settlement did not
+                        restore :done over it")
+                   (is (= [] (chrome-violation-ids))
+                       "and no violations were reinstated")
+                   (done)))))))
+
+(deftest chrome-stale-settlement-does-not-clobber-the-replacement-run
+  (testing "rf2-2amkm — run A parks, run B claims the chrome scan, A
+            settles late. A's findings must not land in B's slot"
+    (async done
+      (let [b-scanning (signal)]
+        (install-axe!
+          (fn [_]
+            (install-axe! (fn [_] ((:fire! b-scanning)) (never-settles)))
+            (chrome-a11y/run-axe! (ctx))
+            (js/Promise.resolve (results "from-run-a"))))
+        (-> (js/Promise.all #js [(chrome-a11y/run-axe! (ctx))
+                                 (:promise b-scanning)])
+            (.then (fn [_]
+                     (is (= :running (chrome-a11y/status))
+                         "B still owns the scan")
+                     (is (= [] (chrome-violation-ids))
+                         "and A's findings were not attributed to it")
+                     (done))))))))
+
+(deftest the-chrome-fence-does-not-latch
+  (testing "THE SEQUENCE for the chrome fence: ADMIT, REFUSE, ADMIT
+            again, REFUSE again — the same four transitions the variant
+            fence is held to above, for the same reason"
+    (async done
+      (letfn [(admit! [id k]
+                (install-axe! (fn [_] (js/Promise.resolve (results id))))
+                (.then (chrome-a11y/run-axe! (ctx)) k))
+              (refuse! [id k]
+                (let [b (signal)]
+                  (install-axe!
+                    (fn [_]
+                      (install-axe! (fn [_] ((:fire! b)) (never-settles)))
+                      (chrome-a11y/run-axe! (ctx))
+                      (js/Promise.resolve (results id))))
+                  (.then (js/Promise.all #js [(chrome-a11y/run-axe! (ctx))
+                                              (:promise b)])
+                         k)))]
+        (admit!
+          "c1"
+          (fn [_]
+            (is (= ["c1"] (chrome-violation-ids)) "1/4 ADMITTED")
+            (refuse!
+              "c2"
+              (fn [_]
+                (is (= ["c1"] (chrome-violation-ids))
+                    "2/4 REFUSED — the superseded run left c1 standing")
+                (admit!
+                  "c3"
+                  (fn [_]
+                    (is (= ["c3"] (chrome-violation-ids))
+                        "3/4 ADMITTED AGAIN — the fence did not latch shut")
+                    (refuse!
+                      "c4"
+                      (fn [_]
+                        (is (= ["c3"] (chrome-violation-ids))
+                            "4/4 REFUSED AGAIN — the fence did not latch open")
+                        (done)))))))))))))

--- a/tools/story/test/re_frame/story_a11y_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_a11y_cljs_test.cljs
@@ -69,7 +69,7 @@
 (deftest drop-frame-state-clears
   (testing "drop-frame-state! removes per-frame state"
     (swap! a11y/violations-by-frame assoc :story.x/y [{:dummy true}])
-    (swap! a11y/run-state           assoc :story.x/y :done)
+    (swap! a11y/run-state           assoc :story.x/y {:status :done})
     (a11y/drop-frame-state! :story.x/y)
     (is (not (contains? @a11y/violations-by-frame :story.x/y)))
     (is (not (contains? @a11y/run-state           :story.x/y)))))
@@ -111,7 +111,7 @@
       (try
         (let [p (a11y/run-axe! frame-id)]
           (is (some? p) "run-axe! returns a Promise even on the no-root path")
-          (is (= :no-root (get @a11y/run-state frame-id))
+          (is (= :no-root (a11y/status-for frame-id))
               "run-state for an unmounted variant must be :no-root, NOT :running or :done — surfacing that the scan was not run against the wrong tree"))
         (finally
           (set! js/console.warn orig-warn)
@@ -158,7 +158,7 @@
       (try
         (let [p (a11y/run-axe! frame-id fake-ctx)]
           (is (some? p) "run-axe! returns a Promise even on :no-consent")
-          (is (= :no-consent (get @a11y/run-state frame-id))
+          (is (= :no-consent (a11y/status-for frame-id))
               "without consent the panel must surface :no-consent —
                NOT :running or :loading — so the consent prompt has
                time to render"))

--- a/tools/story/test/re_frame/story_chrome_a11y_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_chrome_a11y_cljs_test.cljs
@@ -93,15 +93,15 @@
 
 (deftest run-state-starts-idle
   (testing "run-state starts at :idle"
-    (is (= :idle @chrome-a11y/run-state))))
+    (is (= :idle (chrome-a11y/status)))))
 
 (deftest reset-state-clears-everything
   (testing "reset-state! clears violations + resets run-state"
     (reset! chrome-a11y/violations [{:dummy true}])
-    (reset! chrome-a11y/run-state :done)
+    (reset! chrome-a11y/run-state {:status :done})
     (chrome-a11y/reset-state!)
     (is (empty? @chrome-a11y/violations))
-    (is (= :idle @chrome-a11y/run-state))))
+    (is (= :idle (chrome-a11y/status)))))
 
 ;; ---- find-chrome-root degraded-environment safety -----------------------
 


### PR DESCRIPTION
Closes rf2-2amkm. Follows #6405 (rf2-6pfpt), which fixed the same shape on the play-runner path and NAMED these two sites without fixing them.

## The defect

Both axe-core panels mutate their run-state and violations slots inside `.then` / `.catch` callbacks. `run-axe!` awaits twice — the CDN load, then the scan — and across either gap the surface being scanned can stop being its own: the variant frame torn down (`drop-frame-state!`), the panel reset (`reset-state!`), or a newer `run-axe!` claiming the same slot. Every mutation ran unconditionally, so a settlement landed on whatever occupied the slot by then.

**It is not a crash, and that is why it was invisible.** Measured, not reasoned: with the fence removed, 10/10 trials fail with **0 errors** — nothing throws. `(swap! run-state assoc frame-id :done)` over a map the frame was dissoc'd from RESURRECTS the entry:

```
FAIL in (no-throw-and-no-resurrection)
  no phantom run-state entry — the slot stayed torn down
  expected: (not (contains? @a11y/run-state frame-id))
    actual: (not (not true))

FAIL in (no-throw-and-no-resurrection)
  a frame with no slot reads :idle, NOT :done
  expected: (= :idle (a11y/status-for frame-id))
    actual: (not (= :idle :done))
```

The phantom slot reads `:done`, and the resurrected `violations-by-frame` entry beside it is exactly what `browser/register-a11y-reader!` serves to `:rf.assert/a11y`. A scan of a frame that is **gone** reporting a **clean verdict** — a fabricated green, the same class #6405 measured on the sibling path.

## The fence

Each run mints a token and stamps it into the slot it claims; every mutation on the far side of an await is gated on that token still being the live one, with check and mutation in the **same synchronous turn** so nothing can take the slot between them.

**Why a value fence, not a conveyed mechanism.** The hazard is a run *outliving its claim*, not a claim failing to reach a callback — the inverse of the conveyance situation (contrast rf2-vxgfnd.171, where the owner had to ride *in* the conveyed map). The claim already arrives everywhere it is needed; what it must be checked *against* is the live slot, and a `^:dynamic` Var conveyed into the callback would agree with the callback by construction.

**Why the token lives IN the slot, not beside it.** Carrying it in the run-state value makes "does the slot still exist" and "is it still mine" one question with one answer. Every present and future path that clears a frame's state revokes the claim by construction — no side atom to keep in step, and no clearing site that could silently ADMIT a stale settlement by forgetting to bump it. This is the same reasoning that chose identity over a generation counter in #6405.

`identical?`, not `=`: two runs of the same frame are legitimately equal in every other respect and must still be told apart.

**No existing guard was a bounds check in disguise** — there was no guard at all at either site. Every post-await mutation was unconditional, including the `.catch`'s `:error` write, which is fenced here too.

**Execution order is not pinned.** A superseded run declines to *scan* as well as to record (there is nothing to learn from axe-core about a torn-down tree), but the promise chain is otherwise untouched and every run still settles its own tail promise. One predicate consulted at each mutation point — no second copy of the abort decision.

The `.catch`'s console diagnostic is deliberately left **unfenced**: a failed CDN load (offline, CSP, SRI mismatch) is real information about the dev's environment even when the run that hit it has been superseded.

## Verdict on the site #6405 left

`runner-events/run-step!`'s settle callback emits an unfenced `emit-trace!` for an abandoned stepper session. **Re-verified independently, and upheld — left unfenced.** Grounds checked here rather than inherited:

- It mutates no verdict slot. `emit-trace!` appends to the trace bus / ring buffer and is wrapped in its own try/catch.
- No consumer derives a verdict from it. Every trace listener under `tools/story/src/` was checked; the only verdict-bearing one (`play/listener-for-frame`) captures `:rf.error/handler-exception` into `:rf.story/assertions` and does not consume `:rf.story.play/step`.
- **The content is not a fabrication.** The step genuinely ran and genuinely produced that result — a truthful-but-late observation, categorically different from the a11y sites, which fabricate a verdict about a surface that no longer exists.
- Fencing it would mean inventing a session identity for a public, late-bound, one-shot executor that has none; the caller that *does* have session identity already fences its recorded verdict via the `recorded` identity check from #6405.

This would change if a future consumer ever folds `:rf.story.play/step` results into a pass/fail. None does today.

## Quality gates

Measurement isolates the **fence** as the sole variable: the reverted runs keep the slot shape and readers and remove only the `when-not (stale-run? …)` guards.

| | trials | result |
|---|---|---|
| Fence **removed** | 10 | **10/10 RED** — 19 failures, **0 errors**, byte-identical failure set across all 10 (single md5 over the sorted FAIL lines) |
| Fence **applied** | 10 | **10/10 GREEN** — 11 tests, 30 assertions, exit 0 |

Both are deterministic, not flaky-passing: the new tests place their own interleaving. The fake axe-core's `run` is invoked synchronously by the code under test, so the takeover happens *inside* the scan; assertions chain off the promise `run-axe!` returns (the tail of the whole chain) and, where a second run is involved, off a signal that run's scan fires — nothing counts microtask turns.

**Sequence proof, per fence** (`the-fence-does-not-latch`, `the-chrome-fence-does-not-latch`): ADMIT → REFUSE → ADMIT again → REFUSE again, four transitions on one slot through one fence in a single process. Transitions 3 and 4 are the teeth — 3 proves the refusal did not latch the fence shut, 4 proves the admission did not latch it open. Both fail with the fence removed.

**Vacuity probe:** the CLJS runner prints no per-namespace headers, so a green total proves nothing. Flipped one assertion to `VACUITY-PROBE-rf2-2amkm`; the **full** `npm run test:cljs` gate went to exit 1 with that string as the **sole** failure (`1 failures, 0 errors`), confirming the namespace really runs in the gate. Restored.

Full gates, foreground, unpiped, exit codes captured by redirect:

- `npm run test:cljs` — **10180 tests**, 50299 assertions, 0 failures, 0 errors, **exit 0**
- `tools/story && clojure -M:test` — **1836 tests**, 6792 assertions, 0 failures, 0 errors, **exit 0**

Both re-run after the final commit; working tree clean, `scripts/check-no-hardcoded-paths.sh` green.

## Scope

Entirely within `tools/story/` (2 sources, 1 new test ns, 2 existing test nss updated to the new slot shape). No `tools/xray/` or `tools/machines-viz/` files touched, so no `tools/xray/spec/*` update is owed. No new error ids, so no Spec 009 / Spec-Schemas co-edit.
