### PR TITLE
fix(story): reclaim a11y state on frame teardown (rf2-cpbut)

### DIFF
--- a/tools/story/src/re_frame/story/canonical.cljc
+++ b/tools/story/src/re_frame/story/canonical.cljc
@@ -32,6 +32,7 @@
             [re-frame.story.runtime      :as runtime]
             [re-frame.story.save-variant :as save-variant]
             [re-frame.story.ui.cofx      :as ui-cofx]
+            #?(:cljs [re-frame.story.ui.a11y            :as ui-a11y])
             #?(:cljs [re-frame.story.ui.panels          :as ui-panels])
             #?(:cljs [re-frame.story.ui.open-in-editor  :as ui-open-in-editor])
             #?(:cljs [re-frame.story.ui.multi-substrate :as ui-multi-substrate])
@@ -76,7 +77,26 @@
   ;; pending-exceptions eviction does.
   (late-bind/set-fn! :drop-run-state
     (fn [frame-id]
-      (runner-events/clear-state! frame-id))))
+      (runner-events/clear-state! frame-id)))
+  ;; The a11y panel's per-frame axe state (`violations-by-frame` /
+  ;; `run-state`) is evicted on frame teardown via `drop-frame-state!`
+  ;; (rf2-cpbut). This is a MEMORY eviction before it is a correctness one:
+  ;; the violations bag holds raw axe-core violation objects, and each one
+  ;; references the offending elements through `:nodes` / `:target`, so an
+  ;; un-evicted entry pins the destroyed variant's detached DOM subtree for
+  ;; the life of the page.
+  ;;
+  ;; CLJS-only, and registered here rather than at `ui/a11y` load time so the
+  ;; hook is re-armed by every `install!` — a fixture that wiped the registry
+  ;; (`late-bind/clear!`) gets it back, which a load-time `defonce` could not
+  ;; give. `frames` cannot `:require` a `.cljs` ns from a `.cljc` one, so the
+  ;; teardown call routes through the hook exactly as the two evictions above
+  ;; do. The chrome panel (`ui/chrome-a11y`) needs no counterpart: its state
+  ;; is a singleton, with no per-frame accumulation to evict.
+  #?(:cljs
+     (late-bind/set-fn! :drop-a11y-state
+       (fn [frame-id]
+         (ui-a11y/drop-frame-state! frame-id)))))
 
 #?(:cljs
    (defn- render-host-scope

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -962,6 +962,11 @@
     ;; leaves no stale run-state behind once it is torn down.
     (when-let [drop (late-bind/get-fn :drop-run-state)]
       (try (drop frame-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
+    ;; Evict the a11y panel's per-frame axe state (rf2-cpbut), symmetric with
+    ;; `run-teardown-walks!`. An inline frame the dev scanned leaves no
+    ;; retained detached DOM behind once it is torn down.
+    (when-let [drop (late-bind/get-fn :drop-a11y-state)]
+      (try (drop frame-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
     (when (seq loaders-teardown)
       (try (apply-loaders-teardown! frame-id loaders-teardown)
         (catch #?(:clj Throwable :cljs :default) _ nil)))
@@ -1003,6 +1008,16 @@
   ;; through the `:drop-run-state` late-bind hook (frames cannot :require
   ;; runner-events — cycle).
   (when-let [drop (late-bind/get-fn :drop-run-state)]
+    (try (drop variant-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
+  ;; Evict the a11y panel's per-frame axe state (rf2-cpbut). Unlike the two
+  ;; evictions above, the cost here is not a stale verdict but RETAINED DOM:
+  ;; the violations bag holds raw axe-core violation objects, each of which
+  ;; references the offending elements through `:nodes` / `:target`. Left in
+  ;; place, every scanned-then-destroyed variant pins its detached subtree
+  ;; for the life of the page. `ui/a11y` is CLJS-only, so — like the reader
+  ;; seam in `play/browser` — the call routes through a late-bind hook
+  ;; rather than a require this `.cljc` cannot make.
+  (when-let [drop (late-bind/get-fn :drop-a11y-state)]
     (try (drop variant-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
   ;; Step 3 — variant body :loaders-teardown. Runs BEFORE
   ;; decorator teardown so loader-installed narrower state is cleaned

--- a/tools/story/src/re_frame/story/late_bind.cljc
+++ b/tools/story/src/re_frame/story/late_bind.cljc
@@ -52,6 +52,31 @@
                                      teardown call routes through this hook.
                                      Signature: `(f frame-id) → nil`.
 
+  - `:drop-a11y-state`            — ui/a11y → frames. Called on frame
+                                     teardown so the axe-core panel's
+                                     per-frame slots (`violations-by-frame` /
+                                     `run-state`) evict their entries.
+                                     Primarily a MEMORY eviction: a
+                                     violation is a raw axe-core object that
+                                     references the offending elements via
+                                     `:nodes` / `:target`, so an un-evicted
+                                     entry pins the destroyed variant's
+                                     DETACHED DOM subtree for the life of the
+                                     page — one leaked subtree per
+                                     scanned-then-destroyed variant. Dropping
+                                     the slot also revokes any in-flight
+                                     run's claim on it, because the run's
+                                     token lives IN the slot (rf2-2amkm), so
+                                     a scan settling after teardown is
+                                     refused rather than resurrecting the
+                                     frame. `frames` (`.cljc`) cannot
+                                     `:require` the CLJS-only `ui/a11y`, so
+                                     the call routes through this hook.
+                                     Absent on the bare JVM / any build
+                                     without the UI shell, where there is no
+                                     panel state to evict.
+                                     Signature: `(f frame-id) → nil`.
+
   - `:recorder/reset-dom-buffer`   — dom-capture → recorder. Called by
                                      `recorder/start-recording!` and
                                      `recorder/clear!` to cancel every

--- a/tools/story/src/re_frame/story/ui/a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/a11y.cljs
@@ -85,12 +85,30 @@
   (:status (get @run-state frame-id) :idle))
 
 (defn drop-frame-state!
-  "Clear all a11y state for `frame-id`. Called from the canvas /
-  shell teardown when a variant frame is destroyed.
+  "Clear all a11y state for `frame-id`. Called on variant-frame teardown
+  through the `:drop-a11y-state` late-bind hook, which
+  `re-frame.story.frames` invokes from `run-teardown-walks!` (shared by
+  `destroy!` and the in-place `reset-state!`) and from
+  `destroy-inline!` — the same three seams that evict the play-runner's
+  per-frame run-state and the assertion accumulators.
+
+  NOT called from the canvas or the shell, despite what this docstring
+  claimed until rf2-cpbut: `ui/canvas`'s `component-will-unmount` clears
+  its own render sentinels but never destroys a variant frame, and no
+  `ui/` namespace calls `destroy!` at all. The UI reaches teardown only
+  indirectly, via `runtime/reset-variant` (test-mode re-run, stepper) and
+  via `run-variant`'s fresh-run boundary. Naming a caller that did not
+  exist is what let this go unwired.
+
+  Why it matters that this runs at all. The violations bag holds raw
+  axe-core violation objects, each referencing the offending elements
+  through `:nodes` / `:target`; an entry that outlives its frame pins
+  that variant's DETACHED DOM subtree for the life of the page.
 
   Dropping the slot also revokes any in-flight run's claim on it: the
-  run's token no longer matches, so its settlement is refused rather
-  than resurrecting the frame (see `stale-run?`)."
+  run's token lives IN the slot, so it no longer matches and the
+  settlement is refused rather than resurrecting the frame (see
+  `stale-run?`)."
   [frame-id]
   (swap! violations-by-frame dissoc frame-id)
   (swap! run-state           dissoc frame-id)

--- a/tools/story/test/re_frame/story/ui/a11y_teardown_eviction_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/a11y_teardown_eviction_cljs_test.cljs
@@ -1,0 +1,374 @@
+(ns re-frame.story.ui.a11y-teardown-eviction-cljs-test
+  "rf2-cpbut — the a11y panel's per-frame state is RECLAIMED when the
+  variant frame is torn down.
+
+  `drop-frame-state!` existed, was correct, and had no production caller:
+  its docstring named 'the canvas / shell teardown', which does not
+  destroy variant frames (`ui/canvas`'s `component-will-unmount` clears
+  its own render sentinels and nothing else, and no `ui/` namespace calls
+  `frames/destroy!` at all). So every frame ever scanned kept its slot for
+  the life of the page.
+
+  WHAT THAT COSTS. Not a stale verdict — RETAINED DOM. A stored violation
+  is a raw axe-core object that references the offending elements through
+  `:nodes` / `:target`. An entry that outlives its frame therefore pins
+  that variant's DETACHED subtree, one leaked subtree per
+  scanned-then-destroyed variant. `the-leak` below measures exactly that:
+  it asserts the SCANNED NODE OBJECT ITSELF is still reachable from the
+  panel's state after teardown when the eviction is absent, and
+  unreachable when it is present. Reachability by object identity, not a
+  GC probe — deterministic, and it is the retention relation that matters
+  rather than whether a particular collector has run.
+
+  THE LEVER. Every reclamation test here runs twice against the SAME
+  teardown call: once with the `:drop-a11y-state` late-bind hook
+  unregistered (reproducing pre-fix behaviour exactly — before rf2-cpbut
+  no producer ever registered it) and once with it registered. The
+  un-registered arm is the red-before, executed permanently in the suite
+  rather than trusted to a one-off revert.
+
+  Pure `.cljs`: the panel is CLJS-only, and the `async` tests need
+  cljs.test MAP fixtures, which a `.cljc` may not use
+  (`re-frame.story.meta-fixtures-test`)."
+  (:require [cljs.test :refer [async deftest is testing use-fixtures]]
+            [goog.object :as gobj]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story :as story]
+            [re-frame.story.frames :as frames]
+            [re-frame.story.late-bind :as late-bind]
+            [re-frame.story.ui.a11y :as a11y]))
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+;;
+;; Same shape as `a11y-stale-settlement-cljs-test`: installing a fake axe
+;; on `js/window` makes `ensure-axe-loaded!` resolve immediately, so the
+;; REAL `run-axe!` runs end to end with no `with-redefs` routing around
+;; the code under test. The node runtime has no `window`; the fixture
+;; installs one and restores whatever was there, because this process runs
+;; every other CLJS namespace too and a leaked `window` would flip
+;; browser-detection branches elsewhere.
+
+(def ^:private saved-window (atom nil))
+
+(defn- install-axe!
+  "Point the fake axe-core's `run` at `run-fn`, which receives the scan
+  context and returns the results promise."
+  [run-fn]
+  (gobj/set (gobj/get js/globalThis "window") "axe"
+            #js {"run" (fn [ctx] (run-fn ctx))})
+  nil)
+
+(def ^:private variant-id :story.a11y-teardown/probe)
+
+(defn- register-probe-variant!
+  "A minimal events-only variant so `frames/allocate!` takes the
+  fast-path and `frames/destroy!` has a real registered frame to tear
+  down. The teardown seam under test is frame-level, not lifecycle-level,
+  so the variant deliberately carries nothing else."
+  []
+  (story/reg-story :story.a11y-teardown {:doc "teardown probe story"})
+  (story/reg-variant variant-id {:doc "teardown probe variant"}))
+
+(defn- setup! []
+  (reset! saved-window (gobj/get js/globalThis "window"))
+  (gobj/set js/globalThis "window" #js {})
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (register-probe-variant!)
+  (a11y/reset-state!)
+  ;; `ensure-axe-loaded!` latches this once it has seen a global axe;
+  ;; clear it so each test re-reads the fake installed for it.
+  (reset! a11y/axe-loaded? false)
+  (a11y/set-cdn-opt-in! true))
+
+(defn- teardown! []
+  (a11y/set-cdn-opt-in! false)
+  (reset! a11y/axe-loaded? false)
+  (a11y/reset-state!)
+  (gobj/set js/globalThis "window" @saved-window))
+
+(use-fixtures :each {:before setup! :after teardown!})
+
+;; A context object that is `nodeType`-bearing (so `run-axe!` treats it as
+;; the overlay scope) and selector-inert (its `querySelector` finds
+;; nothing, so the overlay decorator is a no-op).
+(defn- ctx [] #js {:nodeType 1 "querySelector" (fn [_] nil)})
+
+(defn- violation-holding
+  "An axe-core-shaped violation whose `nodes` reference `node-obj` — the
+  shape that makes an un-evicted entry retain detached DOM."
+  [id node-obj]
+  #js {:id     id
+       :impact "serious"
+       :help   (str "help for " id)
+       :nodes  #js [#js {"element" node-obj "target" #js ["#probe"]}]})
+
+(defn- results-holding
+  [id node-obj]
+  #js {:violations #js [(violation-holding id node-obj)]})
+
+(defn- never-settles
+  "A promise that never resolves — a scan still in flight when the test
+  makes its assertions, so the run holding the slot demonstrably still
+  holds it."
+  []
+  (js/Promise. (fn [_ _] nil)))
+
+(defn- signal
+  "A promise plus the fn that resolves it. Lets a test wait for a specific
+  point in a run to be reached instead of counting microtask turns."
+  []
+  (let [resolve-fn (atom nil)
+        p          (js/Promise. (fn [res _] (reset! resolve-fn res)))]
+    {:promise p :fire! (fn [] (@resolve-fn true))}))
+
+;; ---------------------------------------------------------------------------
+;; The lever
+;; ---------------------------------------------------------------------------
+;;
+;; Before rf2-cpbut NO producer registered `:drop-a11y-state`, so the
+;; consumer's `when-let` in `frames/run-teardown-walks!` simply skipped.
+;; Unregistering the hook reproduces that state exactly — this is the
+;; red-before lever, and it isolates precisely the wiring this bead added
+;; without touching the teardown call itself.
+
+(defn- with-eviction-hook-removed
+  "Run `f` with the `:drop-a11y-state` hook unregistered, then restore it.
+  Restoration re-reads the live registry rather than assuming, so a
+  failure inside `f` cannot leave the hook off for sibling namespaces in
+  this shared process."
+  [f]
+  (let [saved (late-bind/get-fn :drop-a11y-state)]
+    (try
+      (late-bind/set-fn! :drop-a11y-state nil)
+      (f)
+      (finally
+        (late-bind/set-fn! :drop-a11y-state saved)))))
+
+(defn- allocate-probe-frame! []
+  (frames/allocate! variant-id nil))
+
+(defn- node-reachable-from-panel?
+  "True when `node-obj` is still reachable from the a11y panel's per-frame
+  violations bag — the retention relation the leak is made of. Walks the
+  stored axe violation the same way a real one references its elements
+  (`:nodes` → `element`)."
+  [frame-id node-obj]
+  (boolean
+    (some (fn [v]
+            (some (fn [n] (identical? node-obj (gobj/get n "element")))
+                  (array-seq (gobj/get v "nodes"))))
+          (get @a11y/violations-by-frame frame-id []))))
+
+;; ---------------------------------------------------------------------------
+;; The leak, measured
+;; ---------------------------------------------------------------------------
+
+(deftest the-leak
+  (testing "a scanned-then-destroyed variant retains its detached DOM
+            through the violations bag WITHOUT the teardown eviction, and
+            reclaims it WITH the eviction — same scan, same teardown call,
+            the hook the only difference"
+    (async done
+      (let [detached-node #js {"tagName" "BUTTON" "id" "probe"}]
+        (allocate-probe-frame!)
+        (install-axe! (fn [_] (js/Promise.resolve
+                                (results-holding "color-contrast" detached-node))))
+        (-> (a11y/run-axe! variant-id (ctx))
+            (.then
+              (fn [_]
+                ;; The scan landed: the panel holds the frame's slot AND
+                ;; the node the violation points at.
+                (is (contains? @a11y/violations-by-frame variant-id)
+                    "precondition: the scan stored a per-frame entry")
+                (is (node-reachable-from-panel? variant-id detached-node)
+                    "precondition: the stored violation references the node")
+
+                ;; --- RED-BEFORE arm: no eviction hook ---
+                (with-eviction-hook-removed
+                  (fn []
+                    (frames/destroy! variant-id)
+                    (is (contains? @a11y/violations-by-frame variant-id)
+                        "WITHOUT the eviction the slot survives frame destruction")
+                    (is (node-reachable-from-panel? variant-id detached-node)
+                        "WITHOUT the eviction the DESTROYED variant's detached
+                         node is still reachable from the panel — the leak")))
+
+                ;; --- GREEN arm: hook registered, same teardown call ---
+                ;; Re-allocate + re-scan so the second teardown has real
+                ;; state to reclaim rather than the residue of the first.
+                (allocate-probe-frame!)
+                (-> (a11y/run-axe! variant-id (ctx))
+                    (.then
+                      (fn [_]
+                        (is (node-reachable-from-panel? variant-id detached-node)
+                            "precondition: the re-scan re-stored the node")
+                        (frames/destroy! variant-id)
+                        (is (not (contains? @a11y/violations-by-frame variant-id))
+                            "WITH the eviction the violations slot is ABSENT")
+                        (is (not (contains? @a11y/run-state variant-id))
+                            "WITH the eviction the run-state slot is ABSENT")
+                        (is (not (node-reachable-from-panel? variant-id detached-node))
+                            "WITH the eviction the detached node is no longer
+                             reachable from the panel — reclaimed")
+                        (is (= :idle (a11y/status-for variant-id))
+                            "a reclaimed frame reads :idle, the never-scanned status")
+                        (done)))))))))))
+
+;; ---------------------------------------------------------------------------
+;; Sequence — a guard carrying state can pass every single transition
+;; ---------------------------------------------------------------------------
+
+(deftest the-eviction-does-not-latch
+  (testing "SCAN -> DESTROY -> reclaimed -> SCAN again -> DESTROY again ->
+            reclaimed again, four transitions on one frame id in ONE
+            process. A teardown that reclaimed only once (or only after
+            the first allocation) would pass every single-transition test
+            and still be broken."
+    (async done
+      (let [node-1 #js {"tagName" "A" "id" "first"}
+            node-2 #js {"tagName" "IMG" "id" "second"}]
+        ;; --- round 1 ---
+        (allocate-probe-frame!)
+        (install-axe! (fn [_] (js/Promise.resolve (results-holding "round-1" node-1))))
+        (-> (a11y/run-axe! variant-id (ctx))
+            (.then
+              (fn [_]
+                (is (node-reachable-from-panel? variant-id node-1)
+                    "round 1 ADMIT: the scan stored its violation")
+                (is (= :done (a11y/status-for variant-id))
+                    "round 1 ADMIT: the run reached :done")
+                (frames/destroy! variant-id)
+                (is (not (contains? @a11y/violations-by-frame variant-id))
+                    "round 1 RECLAIM: violations slot absent")
+                (is (not (contains? @a11y/run-state variant-id))
+                    "round 1 RECLAIM: run-state slot absent")
+                (is (not (node-reachable-from-panel? variant-id node-1))
+                    "round 1 RECLAIM: node-1 unreachable")
+
+                ;; --- round 2, SAME frame id, fresh incarnation ---
+                (allocate-probe-frame!)
+                (install-axe! (fn [_] (js/Promise.resolve
+                                        (results-holding "round-2" node-2))))
+                (-> (a11y/run-axe! variant-id (ctx))
+                    (.then
+                      (fn [_]
+                        (is (node-reachable-from-panel? variant-id node-2)
+                            "round 2 ADMIT: a re-allocated frame can scan again —
+                             the first teardown did not poison the slot")
+                        (is (not (node-reachable-from-panel? variant-id node-1))
+                            "round 2 ADMIT: round 1's node did NOT come back")
+                        (is (= :done (a11y/status-for variant-id))
+                            "round 2 ADMIT: the second run reached :done")
+                        (frames/destroy! variant-id)
+                        (is (not (contains? @a11y/violations-by-frame variant-id))
+                            "round 2 RECLAIM: violations slot absent again")
+                        (is (not (contains? @a11y/run-state variant-id))
+                            "round 2 RECLAIM: run-state slot absent again")
+                        (is (not (node-reachable-from-panel? variant-id node-2))
+                            "round 2 RECLAIM: node-2 unreachable")
+                        (done)))))))))))
+
+;; ---------------------------------------------------------------------------
+;; Interaction with the rf2-2amkm supersession fence (#6410)
+;; ---------------------------------------------------------------------------
+;;
+;; #6410 stamped the run token INTO the slot so that "does the slot still
+;; exist" and "is it still mine" are ONE question. This teardown is a NEW
+;; clearing path, so the claim it revokes must be revoked for free. Verify
+;; that rather than assume it.
+;;
+;; NOTE the failure shape being excluded: on CLJS this class does NOT
+;; throw. `(swap! run-state assoc frame-id …)` over a map the frame was
+;; dissoc'd from RESURRECTS the entry. So these assert the slot is ABSENT
+;; and the status terminal — never that an exception was raised.
+
+(deftest teardown-revokes-an-in-flight-runs-claim
+  (testing "a scan still in flight when the frame is torn down settles into
+            NOTHING: it must not resurrect the slot it no longer owns"
+    (async done
+      (let [scan-started (signal)
+            detached     #js {"tagName" "DIV" "id" "in-flight"}
+            release      (atom nil)]
+        (allocate-probe-frame!)
+        ;; The scan parks until the test releases it, so teardown is
+        ;; positioned exactly INSIDE the in-flight window — never raced.
+        (install-axe!
+          (fn [_]
+            ((:fire! scan-started))
+            (js/Promise. (fn [res _] (reset! release #(res (results-holding
+                                                             "late" detached)))))))
+        (a11y/run-axe! variant-id (ctx))
+        (-> (:promise scan-started)
+            (.then
+              (fn [_]
+                (is (contains? @a11y/run-state variant-id)
+                    "precondition: the in-flight run holds the slot")
+                ;; Tear the frame down mid-scan through the PRODUCTION path.
+                (frames/destroy! variant-id)
+                (is (not (contains? @a11y/run-state variant-id))
+                    "teardown cleared the slot the in-flight run held")
+                ;; Now let the scan settle over the cleared state.
+                (@release)
+                ;; Yield past the settlement's own callback chain before
+                ;; reading, so the assertion sees the post-settlement world.
+                (-> (js/Promise.resolve)
+                    (.then (fn [_] nil))
+                    (.then (fn [_] nil))
+                    (.then
+                      (fn [_]
+                        (is (not (contains? @a11y/run-state variant-id))
+                            "the superseded settlement did NOT resurrect the
+                             run-state slot — the fence still declines after a
+                             teardown-driven revocation")
+                        (is (not (contains? @a11y/violations-by-frame variant-id))
+                            "the superseded settlement did NOT resurrect the
+                             violations slot")
+                        (is (not (node-reachable-from-panel? variant-id detached))
+                            "the late scan's node never entered the panel")
+                        (is (= :idle (a11y/status-for variant-id))
+                            "status reads :idle (terminal, never-scanned) rather
+                             than a fabricated :done for a frame that is gone")
+                        (done)))))))))))
+
+(deftest teardown-leaves-an-unrelated-frames-state-alone
+  (testing "the eviction is frame-scoped: destroying one variant frame must
+            not reclaim a SIBLING frame's a11y state"
+    (async done
+      (let [other-id :story.a11y-teardown/sibling
+            node-a   #js {"tagName" "P" "id" "a"}
+            node-b   #js {"tagName" "P" "id" "b"}]
+        (story/reg-variant other-id {:doc "sibling probe variant"})
+        (allocate-probe-frame!)
+        (frames/allocate! other-id nil)
+        (install-axe! (fn [_] (js/Promise.resolve (results-holding "a" node-a))))
+        (-> (a11y/run-axe! variant-id (ctx))
+            (.then
+              (fn [_]
+                (install-axe! (fn [_] (js/Promise.resolve
+                                        (results-holding "b" node-b))))
+                (a11y/run-axe! other-id (ctx))))
+            (.then
+              (fn [_]
+                (is (node-reachable-from-panel? variant-id node-a)
+                    "precondition: probe frame holds its own scan")
+                (is (node-reachable-from-panel? other-id node-b)
+                    "precondition: sibling frame holds its own scan")
+                (frames/destroy! variant-id)
+                (is (not (contains? @a11y/violations-by-frame variant-id))
+                    "the destroyed frame's slot is reclaimed")
+                (is (node-reachable-from-panel? other-id node-b)
+                    "the SIBLING frame's state survives — the eviction is
+                     scoped to the frame being torn down")
+                (is (= :done (a11y/status-for other-id))
+                    "the sibling's run status is untouched")
+                (done))))))))


### PR DESCRIPTION
Closes rf2-cpbut. Follow-up to #6410 (rf2-2amkm), which fenced these sites and filed this.

## The premise, verified

`re-frame.story.ui.a11y/drop-frame-state!` had **no production caller** — `git grep drop-frame-state` returned the definition plus test callers only. Confirmed.

Its docstring was also **wrong about who was supposed to call it**, which is the defect family this bead sits in. It named "the canvas / shell teardown":

- `ui/canvas`'s `:component-will-unmount` exists, but only clears `canvas-last-run-key` and the first-rendered sentinel. It never destroys a variant frame.
- **No `ui/` namespace calls `frames/destroy!` at all.** The UI reaches teardown only indirectly, through `runtime/reset-variant` (test-mode re-run, stepper) and `run-variant`'s fresh-run boundary.

So the named caller did not exist, and the seam that *does* destroy variant frames was somewhere else entirely. The docstring is corrected to name the real path.

## The leak, measured

A stored violation is a raw axe-core object referencing the offending elements via `:nodes` / `:target`. An entry outliving its frame pins that variant's **detached DOM subtree** for the life of the page — one per scanned-then-destroyed variant.

`the-leak` measures this by object-identity reachability (deterministic; not a GC probe), asserting the retention relation directly:

- **without** the eviction: after `frames/destroy!`, the slot survives *and* the scanned node object is still reachable from the panel — and `status-for` reads `:done` for a frame that is gone.
- **with** it: both slots absent, node unreachable, status back to `:idle`.

## Where it is wired, and why that is the natural site

Not an invented seam — the **third instance of an established pattern**. `:drop-assertion-accumulators` and `:drop-run-state` already evict per-frame state at exactly these points; `:drop-a11y-state` joins them at the same three call sites: `frames/run-teardown-walks!` (shared by `destroy!` and the in-place `reset-state!`) and `frames/destroy-inline!`.

It must be a late-bind hook rather than a require: `frames` is `.cljc` and `ui/a11y` is `.cljs`, the same inversion `play/browser`'s existing a11y-reader seam already solves. Registered from `canonical/install-late-bind-shims!` — the file's designated place — so every `install!` re-arms it, which a load-time `defonce` could not.

`ui/chrome-a11y` needs no counterpart: singleton state, no per-frame accumulation (verified, as the bead predicted).

## The #6410 fence still declines

Verified, not assumed. `teardown-revokes-an-in-flight-runs-claim` parks a scan mid-flight, tears the frame down through the production path, then releases the scan. The settlement does not resurrect either slot. The token living *in* the slot means this new clearing path revokes the claim for free — as #6410's rationale predicted, with no side atom to keep in step.

Asserted as **slot ABSENT + status terminal**, never as a thrown exception: this class does not throw on CLJS.

## Sequence, not just cases

`the-eviction-does-not-latch` runs SCAN → DESTROY → reclaimed → SCAN again → DESTROY again → reclaimed again on one frame id in one process, and additionally pins that round 1's node does not come back in round 2. A teardown that reclaimed only once would pass every single-transition test.

`teardown-leaves-an-unrelated-frames-state-alone` pins the eviction as frame-scoped.

## Red-before, with its own lever

Two independent levers:

1. **In-suite, permanent.** Every reclamation test runs the same teardown call twice — once with `:drop-a11y-state` unregistered (reproducing pre-fix behaviour exactly; before this PR no producer ever registered it) and once with it registered. The red-before is executed on every run, not trusted to a one-off revert.
2. **Real revert.** Reverting the two wiring files to `origin/main` and re-running the full gate: **exit 1, 16 failures, all in this namespace, the sole failing namespace.** Every *reclaim* assertion failed; every "WITHOUT the eviction … the leak" assertion **passed**, which is the leak itself measured on unmodified teardown. Restored and re-verified byte-identical to the commit.

## Vacuity probe

The CLJS runner prints no per-namespace headers on success — this namespace's name appears **0 times** in the green log, so a green total proves nothing by itself. Flipped one assertion: full gate went **exit 1 with `VACUITY-PROBE-rf2-cpbut` as the sole failure**, confirming the namespace is live in the gate. Restored; tree verified clean against the commit.

## Quality gates

Both run in the foreground to completion, unpiped, exit codes captured by redirect, and **re-run after the final commit** on a tree verified byte-identical to what is pushed.

| Gate | Result |
| --- | --- |
| `npm run test:cljs` (compile + `node out/node-test.js`) | **10200 tests**, 50459 assertions, 0 failures, **exit 0** |
| `tools/story` `clojure -M:test` | **1836 tests**, 6792 assertions, 0 failures, 0 errors, **exit 0** |
| Red-before (wiring reverted) | exit 1, 16 failures, all in this namespace |
| Vacuity probe | exit 1, sole failure `VACUITY-PROBE-rf2-cpbut` |
| `scripts/check-no-hardcoded-paths.sh` | exit 0 |

Test counts are non-zero and match the expected baselines (~10180 / ~1836).

## Scope

Five files, all under `tools/story/**`. No `tools/xray/` or `tools/machines-viz/` files are touched, so `tools/xray/spec/*` is unchanged — the standing spec rule does not apply here.
