### PR TITLE
feat(ssr): cross-host suspense component and streaming hydration lifecycle (rf2-ycz3k)

### DIFF
--- a/docs/api/re-frame.ssr.md
+++ b/docs/api/re-frame.ssr.md
@@ -86,7 +86,33 @@ The `re-frame.core` facade re-exports a curated set of render and head primitive
 
 ## Streaming render
 
-Streaming emits the shell HTML first, then continues rendering boundary subtrees as their data settles. The render tree marks boundaries with `:rf/suspense-boundary`. Each boundary becomes a continuation.
+Streaming emits the shell HTML first, then continues rendering boundary subtrees as their data settles. Authors mark a streamed region with the `boundary` component; on the server it expands to the internal `:rf/suspense-boundary` marker, and each marker becomes a continuation.
+
+### `boundary`
+
+- **Kind**: function (component)
+- **Signature**:
+  ```clojure
+  (boundary attrs & body) → hiccup
+  ```
+- **Description**: Declare a streaming suspense boundary around `body`. This is the authoring surface for a streamed region — one form that works on every host. `attrs` requires two keys:
+  - `:id` — the boundary's identity, unique per page. It is how an arriving chunk is paired with its placeholder. A keyword or a string.
+  - `:fallback` — hiccup rendered inline in the shell while the body is still resolving, and re-rendered by this component when the boundary is reported failed.
+
+  Per host:
+  - **Server**: expands to the internal `:rf/suspense-boundary` marker the shell walker consumes. That marker is wire syntax, never authored directly; outside a stream the non-streaming emitter still rejects it with `:rf.error/ssr-suspense-boundary-outside-stream`.
+  - **Client**: renders `body`, or `:fallback` when `:id` is in the page's failed-boundary record written at stream finalization. No recorded outcome — a plain client mount, a non-streamed page — renders `body`, so it fails soft by construction.
+
+  Malformed `attrs` raise `:rf.error/suspense-boundary-invalid-attrs`.
+
+  This is not React Suspense: no promises, no thrown thenables, no selective hydration. The server decides what defers; the client paints the fallback and swaps content as chunks land.
+- **Example**:
+  ```clojure
+  (require '[re-frame.ssr :as ssr])
+
+  [ssr/boundary {:id :card.revenue :fallback [card-skeleton :revenue]}
+   [card-view :revenue]]
+  ```
 
 ### `streaming-render-shell`
 

--- a/docs/ssr/coming-from-nextjs.md
+++ b/docs/ssr/coming-from-nextjs.md
@@ -22,7 +22,7 @@ So read this page as a translation table, not a feature comparison. The capabili
 | `redirect()` / `notFound()` | The data effects `:rf.server/redirect` / a routing miss your [error projector](concepts.md#when-the-server-throws) maps to `404`. |
 | `cookies().set(...)` | The `:rf.server/set-cookie` effect — a structured map; [response control](response.md). |
 | The `Metadata` API / `generateMetadata` | [`reg-head`](head.md) — a head model *derived from app-db*, shaped exactly like a sub. |
-| `<Suspense fallback>` + `loading.js` (streaming) | [`:rf/suspense-boundary`](streaming.md) — one hiccup marker with a `:fallback`, streams its subtree in as a chunk. |
+| `<Suspense fallback>` + `loading.js` (streaming) | [`ssr/boundary`](streaming.md) — one component with a `:fallback`, streams its subtree in as a chunk. |
 | Hydration mismatch (console warning, content flash) | A [hydration mismatch](glossary.md#hydration-mismatch) caught by a structural hash comparison — a structured trace you can alert on, plus a strict mode that fails CI. |
 | `unstable_cache` / `fetch` cache | A [resource](../resources/glossary.md#resource) — preloaded server-side, ridden across in the payload, renders without a duplicate fetch. |
 | `next/server` runtime, route handlers, middleware | The Ring host adapter (`day8/re-frame2-ssr-ring`). One handler constructor; the lifecycle is yours to read, not a framework you configure. |
@@ -67,7 +67,7 @@ re-frame2 folds both into the same data discipline everything else obeys. The [h
 
 React 18 streaming and Next.js's `loading.js` give you `<Suspense>` boundaries — a real component with a `fallback` prop, plus conventions about where `loading.js` lives in the route tree. It's powerful and it's a surface to learn.
 
-re-frame2's [`:rf/suspense-boundary`](streaming.md) is one declarative hiccup marker: an `:id`, a `:fallback`, a subtree. The walker flushes the shell with fallbacks in place (your first byte), then streams each region in as its data resolves. Failure isolation is free; the final chunk is the canonical full payload — if deltas and payload disagree, the payload wins. Details: [Streaming](streaming.md).
+re-frame2's [`ssr/boundary`](streaming.md) is one declarative component: an `:id`, a `:fallback`, a subtree. It is the same form on the server and in the browser. The walker flushes the shell with fallbacks in place (your first byte), then streams each region in as its data resolves. Failure isolation is free; the final chunk is the canonical full payload — if deltas and payload disagree, the payload wins. Details: [Streaming](streaming.md).
 
 ---
 

--- a/docs/ssr/concepts.md
+++ b/docs/ssr/concepts.md
@@ -418,6 +418,7 @@ Same `:frame` on `hydrate!` and `frame-provider`. Full walk-through:
 <a id="controlling-the-response--rfserver"></a>
 <a id="head-metadata----opengraph-json-ld"></a>
 <a id="streaming-rfsuspense-boundary"></a>
+<a id="streaming-ssrboundary"></a>
 
 Same model, more keys — open a page only when a need appears:
 

--- a/docs/ssr/examples.md
+++ b/docs/ssr/examples.md
@@ -7,4 +7,4 @@ Runnable SSR apps in the repo. Build the lifecycle yourself first
 |---|---|---|
 | [ssr](../../examples/capabilities/ssr/ssr) | Hand-rolled per-request frame, payload script, `hydrate!`, `:platforms #{:client}` skip; ships a frozen `index.html` so you can watch hydration without a JVM | [Tutorial](tutorial.md) |
 | [resources_ssr](../../examples/capabilities/ssr/resources_ssr) | Blocking resource wait before render; allowed cache projection in the payload; no double-fetch on hydrate | [The model](concepts.md), [Resources](../resources/concepts.md) |
-| [ssr_streaming](../../examples/capabilities/ssr/ssr_streaming) | `:rf/suspense-boundary` shell + chunks; canonical final payload as correctness lock | [Streaming](streaming.md) |
+| [ssr_streaming](../../examples/capabilities/ssr/ssr_streaming) | `ssr/boundary` shell + chunks; canonical final payload as correctness lock | [Streaming](streaming.md) |

--- a/docs/ssr/glossary.md
+++ b/docs/ssr/glossary.md
@@ -44,4 +44,4 @@ The pure function that maps a rich internal trace to a sanitized, client-safe `:
 
 ### **suspense boundary**
 
-The streaming marker `:rf/suspense-boundary` — an `:id`, a `:fallback`, a subtree. The server flushes the page shell with fallbacks in place (fast first byte), then streams each boundary's subtree in as its data resolves. One boundary failing keeps its fallback and traces; the rest of the page streams on. Recipe: [Streaming](streaming.md).
+The streaming component `ssr/boundary` — an `:id`, a `:fallback`, a subtree. It defers the subtree on the server and renders it in the browser, so one view serves both hosts (`:rf/suspense-boundary` survives only as internal wire syntax). The server flushes the page shell with fallbacks in place (fast first byte), then streams each boundary's subtree in as its data resolves. One boundary failing keeps its fallback and traces; the rest of the page streams on. Recipe: [Streaming](streaming.md).

--- a/docs/ssr/streaming.md
+++ b/docs/ssr/streaming.md
@@ -1,9 +1,9 @@
-# Streaming: `:rf/suspense-boundary`
+# Streaming: `ssr/boundary`
 
 You know [plain SSR](concepts.md) — one drain, one HTML string, one payload. This page
 is one job: **ship a shell on the first byte, then stream slow regions in**.
 
-React 18 / Next.js `loading.js` use `<Suspense>`; re-frame2 uses one hiccup marker.
+React 18 / Next.js `loading.js` use `<Suspense>`; re-frame2 uses one component.
 Runnable tree:
 [`examples/capabilities/ssr/ssr_streaming/`](../../examples/capabilities/ssr/ssr_streaming).
 
@@ -13,29 +13,36 @@ Runnable tree:
 !!! note "Don't reach for streaming by default"
 
     No independently-slow regions → plain `ssr-handler` is enough. A
-    `:rf/suspense-boundary` on the non-streaming emitter fails loud.
+    boundary on the non-streaming emitter fails loud.
 
 ## Mark slow regions
 
 ```clojure
 ;; Adapted from examples/capabilities/ssr/ssr_streaming/core.cljc
+(require '[re-frame.ssr :as ssr])
+
 (rf/reg-view ^{:rf/id :article/page} article-page []
   [:main.article-page
    [:header [:h1 @(rf/subscribe [:article/title])]]
    [:div.article-body @(rf/subscribe [:article/body])]
    [:section.article-extras
-    [:rf/suspense-boundary
+    [ssr/boundary
      {:id :region.comments :fallback [comments-skeleton]}
      [comments]]
-    [:rf/suspense-boundary
+    [ssr/boundary
      {:id :region.author-feed :fallback [author-feed-skeleton]}
      [author-feed]]]])
 ```
 
-Two things about the heads inside a boundary. Reference views by **Var**
-(`comments`, which `rf/reg-view` defs for you) or by `(rf/view :id)` lookup — a
-bare `[:article/comments]` head is an *HTML element*, never a view, so it paints
-`<comments>` on every host, server included.
+**One view, both runtimes.** On the server each boundary defers its body; in the
+browser the same form renders that body. There is no server-flavoured copy of
+the view and no reader conditional — this is an ordinary `reg-view` that happens
+to name two regions as "allowed to arrive late".
+
+Reference views inside a boundary by **Var** (`comments`, which `rf/reg-view`
+defs for you) or by `(rf/view :id)` lookup — a bare `[:article/comments]` head is
+an *HTML element*, never a view, so it paints `<comments>` on every host, server
+included.
 
 That rule used to have an exception, and the exception was the dangerous part:
 the JVM SSR emitters resolved keyword heads through the view registry, so the
@@ -45,14 +52,15 @@ could catch it and only the client went wrong — silently, as wrong pixels rath
 than an error. That exception is gone (rf2-j81hs): both emitters now treat a
 keyword head as an element, matching every client substrate.
 
-And `:rf/suspense-boundary` itself is **server-only** — it means something to the
-streaming shell walker and to nothing else. Your client render tree carries the
-resolved subtree directly (a view that reads its own app-db slice and falls back
-to its skeleton when that slice is absent renders correctly in both runtimes; see
-`card-slot` in
-[the worked example](../../examples/capabilities/ssr/ssr_streaming/core.cljc)).
-Left in a client render tree, the marker's name passes the DOM tag grammar and
-React paints a phantom `<suspense-boundary>` element.
+That same rule is why the boundary is a **component** and not a hiccup keyword.
+`:rf/suspense-boundary` still exists, but it is internal wire syntax between
+`ssr/boundary` and the streaming shell walker — never something you write. Left
+in a client render tree its name passes the DOM tag grammar, so React paints a
+phantom `<suspense-boundary>` element rather than raising anything. And it could
+not simply be taught client semantics either: stock Reagent's element dispatch is
+an external dependency, and UIx / Helix views are `defui` / `$` forms where a
+hiccup keyword head cannot occur at all. A callable component is the one form
+that works everywhere.
 
 The streaming walker emits the shell on the first byte, with each boundary's
 `:fallback` markup carried inside an **inert** `<template data-rf2-suspense-fallback>`
@@ -84,12 +92,55 @@ Use the streaming Ring constructor (re-exported on `re-frame.ssr.ring`):
 ```
 
 On the client, opt in with `ssr/streaming-install!` (same carried `:frame` as
-`hydrate!`). It does two jobs: it materialises the inert fallback `<template>`s into
-visible mounts, then swaps each mount's content for its resolved chunk — merging that
-chunk's delta — as the chunks arrive. A streaming page therefore *requires* the
-client runtime to paint fallbacks at all: a non-JS client sees the shell structure
-but no skeletons until the final payload lands and `hydrate!` renders everything at
-once.
+`hydrate!`), and **hydrate from its `:on-ready` callback**:
+
+```clojure
+(ssr/streaming-install!
+  {:frame    :app/main
+   :on-ready (fn [_outcomes]
+               (let [payload (ssr/hydrate! {:frame :app/main})
+                     el      (js/document.getElementById "app")
+                     tree    [rf/frame-provider {:frame :app/main}
+                              [(rf/view :article/page)]]]
+                 (if payload
+                   (reset! react-root (rdc/hydrate-root el tree))
+                   (do (reset! react-root (rdc/create-root el))
+                       (rdc/render @react-root tree)))))})
+```
+
+The runtime materialises the inert fallback `<template>`s into visible mounts,
+then swaps each mount's content for its resolved chunk — merging that chunk's
+delta — as the chunks arrive. A streaming page therefore *requires* the client
+runtime to paint fallbacks at all: a non-JS client sees the shell structure but
+no skeletons until the final payload lands.
+
+`:on-ready` fires once, when the last chunk has landed, every delta is consumed,
+and every `<rf-suspense>` mount the runtime created has been **unwrapped**. That
+unwrapping is why hydration waits: those mounts are transport, and no render tree
+on any host can express them, so hydrating while they are still in the DOM is a
+structural mismatch at every boundary — React discards the streamed page and
+re-renders it, and you pay for streaming without getting any.
+
+!!! warning "Don't guess at readiness"
+
+    Don't poll for `__rf_payload`, don't hydrate on a timer, and above all don't
+    fall through to `create-root` because the payload "hasn't arrived yet" — on a
+    live stream that is true for most of the page's life, and `create-root`
+    throws away the markup the server streamed. The protocol is: progressive
+    pre-hydration paint, then **one** ordinary whole-root hydration, triggered by
+    readiness.
+
+## Failed boundaries render their declared fallback
+
+A boundary whose server render threw ships its fallback markup and no delta, and
+the final payload names it in a failed set. The client's `ssr/boundary` reads
+that and re-renders the `:fallback` it declared — the exact markup the failed
+chunk left in the DOM.
+
+This is why your views need no defensive nil branch duplicating the skeleton: the
+boundary that declared the fallback is the one that shows it. `comments` renders
+comments; deciding whether to show `comments-skeleton` instead is the boundary's
+job, stated once.
 
 ??? note "Correctness lock"
 

--- a/examples/capabilities/ssr/ssr_streaming/README.md
+++ b/examples/capabilities/ssr/ssr_streaming/README.md
@@ -11,27 +11,31 @@ timings.
 
 That's *streaming SSR*: the page stops waiting on its slowest part. It's
 the React-18 / Next.js `loading.js` move — ship the shell first, fill the
-holes as the data lands. In re-frame2 it's *one marker*, not a component
-API. You wrap every slow region of the
-[view](../../../../docs/core/glossary.md#view) in a
-[`:rf/suspense-boundary`](../../../../docs/ssr/concepts.md#streaming-rfsuspense-boundary)
+holes as the data lands. In re-frame2 you wrap every slow region of the
+[view](../../../../docs/core/glossary.md#view) in an
+[`ssr/boundary`](../../../../docs/ssr/concepts.md#streaming-ssrboundary)
 and name a `:fallback` to show in the meantime:
 
 ```clojure
-[:rf/suspense-boundary
+[ssr/boundary
  {:id :card.revenue :fallback [card-skeleton :revenue]}
  [card-view :revenue]]
 ```
+
+That is one form for both runtimes. On the server it becomes a deferred
+region; in the browser it renders the card. There is no server-flavoured
+copy of the view and no reader conditional.
 
 Note the children are **Var references**, not keywords. A bare
 `[:dashboard/card :revenue]` head is an HTML element, never a view — the
 runtime doesn't intercept the keyword case to dispatch through the view
 registry (see
 [Conventions §Render-tree shape vs runtime lookup](../../../../spec/Conventions.md)),
-so it would paint `<card>revenue</card>` in the browser. The JVM SSR
-emitter *does* resolve keyword heads through the registry, which is what
-makes that mistake so easy to ship: the server renders it correctly and
-only the client goes wrong.
+so it would paint `<card>revenue</card>`. That rule now holds on **every**
+host, server included: the JVM SSR emitter is a pure hiccup → HTML
+function with no registry lookup, so a keyword head paints the same
+element there as it does in the browser. Render trees reference views by
+Var (`card-view`, which `reg-view` defs for you) or by `(rf/view :id)`.
 
 One caveat up front: this demo runs **offline**, with no Clojure server.
 Instead of fetching from three real services, `:rf/server-init` seeds all
@@ -45,13 +49,14 @@ companion to
 
 ## What this demonstrates
 
-- **The whole streaming API is one marker.** Wrap a subtree with
-  `:rf/suspense-boundary`, name a `:fallback`, and give it a stable
-  `:id`. The streaming walker emits the fallback
+- **The whole streaming API is one component.** Wrap a subtree with
+  `ssr/boundary`, name a `:fallback`, and give it a stable `:id`. The
+  streaming walker emits the fallback
   [hiccup](../../../../docs/core/glossary.md#hiccup) into the shell and
   flushes it on the first byte, then renders the real subtree and streams
   it in as its own chunk. There's no streaming-render mode and no
-  per-host API — the marker *is* the contract.
+  per-host API — and because the boundary is a component rather than a
+  keyword, the same form is what the browser renders too.
 
 - **Each chunk carries its own slice of state.** A streamed-in card is no
   use if its [subscriptions](../../../../docs/core/glossary.md#subscription)
@@ -106,27 +111,37 @@ against *each* with a `{:frame …}` override, because that's where the
 its per-request frame-id from the payload, so the client's explicit
 `:frame` stands rather than tripping a frame-id mismatch.
 
-The other subtlety is that `:rf/suspense-boundary` is a **server-only**
-marker. It means something to the streaming shell walker and to nothing
-else — there is no client-side rendering for it. So the browser's render
-tree carries the resolved card directly, and `card-slot` in
-[`core.cljc`](core.cljc) is the single reader-conditional where the two
-runtimes part company. Leaving the marker in a client render tree is a
-quiet failure rather than a loud one: its name passes the DOM tag grammar,
-so React paints a phantom `<suspense-boundary>` element instead of raising
-anything.
+The other subtlety is the boundary itself. `ssr/boundary` is a
+**component**, not a hiccup keyword, and that is load-bearing rather than
+cosmetic. A keyword head is an HTML element on every host, so a marker
+left in a client render tree paints a phantom `<suspense-boundary>`
+element — a quiet failure, not a loud one. And the marker could not be
+given client semantics either: stock Reagent is an external dependency
+whose element dispatch isn't ours to extend, and UIx / Helix views are
+`defui` / `$` forms where a hiccup keyword head cannot occur at all. A
+callable component is the one form expressible everywhere, so that is the
+authoring surface. `:rf/suspense-boundary` still exists, demoted to
+internal wire syntax between the component and the shell walker.
 
-Which cards the client can actually render falls out of app-db, not out of
-the boundary structure. `card-view` renders the skeleton when its card
-isn't in app-db yet — which is the true state for a chunk still in flight,
-and the permanent state for `:card.flaky`, whose boundary failed and
-therefore shipped no delta. That's why the client's render agrees with the
-DOM the stream painted without having to know which boundaries succeeded.
+Which fallback the client shows is the boundary's business, not every
+view's. `:card.flaky`'s boundary failed on the server, so the final
+payload reports it in its failed set, and the boundary that declared
+`[card-skeleton :flaky]` re-renders exactly that. `card-view` needs no
+defensive nil branch duplicating the skeleton to keep the client's render
+agreeing with the DOM the stream painted.
+
+Hydration waits for **readiness**. The streaming runtime signals
+`:on-ready` once the last chunk has landed, every delta is consumed, and
+every `<rf-suspense>` mount it created has been unwrapped; only then does
+`run` hydrate. Those wrappers are transport, and hydrating while they are
+still in the DOM is a structural mismatch on every boundary — the page's
+content can be byte-correct and React will still discard it.
 
 The `.cljc` shape mirrors [`examples/capabilities/ssr/ssr/core.cljc`](../ssr/core.cljc):
-the server branch lives in `:clj`, the browser branch in `:cljs`. The
-`:clj` branch is what a Ring streaming adapter would invoke per request;
-the `:cljs` branch is what the page bootstraps once the chunks land. One
+the server entry point lives in `:clj`, the browser bootstrap in `:cljs`.
+The `:clj` branch is what a Ring streaming adapter would invoke per
+request; the `:cljs` branch is what the page bootstraps once the chunks
+land. The *views* are shared verbatim — only the entry points differ. One
 artefact, two runtimes — the same trick the non-streaming SSR example
 plays, with the streaming counterparts swapped in.
 

--- a/examples/capabilities/ssr/ssr_streaming/core.cljc
+++ b/examples/capabilities/ssr/ssr_streaming/core.cljc
@@ -9,16 +9,17 @@
   shape as collected data; it does not simulate network timings.
 
   Six ideas earn their keep here:
-   - `:rf/suspense-boundary` — one hiccup marker that says \"this region
-     may arrive late.\" That marker IS the whole streaming API.
-   - The marker is **server-only**. It has meaning to the streaming shell
-     walker and to nothing else, so the browser's render tree carries the
-     resolved card instead — see `card-slot`, the one place this example
-     is genuinely two programs.
+   - `ssr/boundary` — one component that says \"this region may arrive
+     late.\" That component IS the whole streaming API.
+   - It is **cross-host**: the same form defers a region on the server and
+     renders it in the browser, so the views are shared verbatim and there
+     is no reader-conditional slot where the two runtimes part company.
    - A `:fallback` to show in the meantime — here a skeleton card.
    - Failure isolation — one card throws on purpose, to prove a blown
      boundary stays on its fallback instead of taking the page down with
-     it.
+     it. The final payload names the failed boundaries, so the client
+     re-renders that boundary's DECLARED fallback rather than every view
+     having to guess from absent state.
    - Per-card state — each chunk's `<script data-rf2-suspense-hydrate>`
      carries that card's app-db delta, so the streamed-in subtree's subs
      have something to read.
@@ -92,16 +93,14 @@
   ;; in the browser against whatever the streamed delta or the final payload
   ;; put there.
   ;;
-  ;; The nil branch isn't defensive padding — it's the client's honest state
-  ;; for a card whose chunk hasn't landed yet, or (see `:card.flaky` below)
-  ;; never will, because a failed boundary ships no delta. Falling back to
-  ;; the skeleton is what keeps the client's render agreeing with the DOM
-  ;; the stream actually painted.
-  (if-let [card @(subscribe [:card/by-id card-id])]
+  ;; No nil branch. This view renders a card; showing a loading state is
+  ;; the BOUNDARY's job, and `card-slot` declares that fallback once. A
+  ;; card whose boundary failed never reaches this view on the client —
+  ;; the boundary short-circuits to the skeleton it declared.
+  (let [card @(subscribe [:card/by-id card-id])]
     [:div.card
      [:h3 (:title card)]
-     [:p.value (str (:value card))]]
-    [card-skeleton card-id]))
+     [:p.value (str (:value card))]]))
 
 (rf/reg-view ^{:rf/id :dashboard/throwing-card} throwing-card []
   ;; The card that fails on purpose, standing in for that one flaky
@@ -116,43 +115,46 @@
   (throw (ex-info "flaky third-party metric service" {})))
 
 (defn- card-slot
-  "One card's slot in the dashboard — and the one place this example is
-  genuinely two programs.
+  "One card's slot in the dashboard — and, since the boundary became a
+  component, ONE program rather than two.
 
-  SERVER — a `:rf/suspense-boundary`, the whole streaming trick in one
-  marker. It wraps a region that's allowed to arrive late: the `:fallback`
-  ships inline in the shell right now, and `body` renders separately and
-  streams in as its own chunk once it resolves. The `:id` is how the client
-  pairs an arriving chunk with its placeholder — you pick it, and it has to
-  be unique.
+  `ssr/boundary` wraps a region that's allowed to arrive late. On the
+  server the `:fallback` ships inline in the shell right now, and `body`
+  renders separately and streams in as its own chunk once it resolves. In
+  the browser the same form renders `body` — or, when this boundary is one
+  the server reported as FAILED, the `:fallback` declared right here. The
+  `:id` is how the client pairs an arriving chunk with its placeholder:
+  you pick it, and it has to be unique on the page.
 
-  CLIENT — just the card. `:rf/suspense-boundary` is a **server-only**
-  marker: per [Spec 011 §Streaming SSR](../../../../spec/011-SSR.md#streaming-ssr)
-  it is recognised only by the streaming shell walker, and a browser render
-  tree is not somewhere it means anything. Leave one in a client render tree
-  and its name sails straight through the DOM tag grammar — React paints a
-  phantom `<suspense-boundary>` element with `:id` and `:fallback` mangled
-  into attributes.
+  This was a reader conditional until recently — `:rf/suspense-boundary`
+  on the server, a bare card on the client — and it was the one place this
+  example was genuinely two programs. It had to be, while the boundary was
+  a hiccup keyword: a keyword head is an HTML element on every client
+  substrate, so leaving the marker in a browser render tree sails straight
+  through the DOM tag grammar and paints a phantom `<suspense-boundary>`
+  with `:id` and `:fallback` mangled into attributes. And the marker could
+  not simply be taught client semantics either — stock Reagent's element
+  dispatch is an external dependency, and UIx / Helix views are `defui` /
+  `$` forms where a hiccup keyword head cannot occur at all.
 
-  The same trap sits one level down, and it's the more tempting one: a bare
+  A callable component has none of those problems, and removing the
+  conditional removed something else with it: `card-view` no longer needs
+  a nil branch duplicating the skeleton to keep the client's render
+  agreeing with the DOM the stream painted. The boundary that declared the
+  fallback is the one that re-renders it.
+
+  The related trap is one level down and more tempting: a bare
   `[:dashboard/card :revenue]` head is an **HTML element**, never a view.
   The runtime does not intercept the keyword case to dispatch through the
   view registry (Conventions §Render-tree shape vs runtime lookup), so that
   head paints `<card>revenue</card>` — tag from the keyword's name, argument
-  as a text node. Render trees reference views by **Var** (`card-view`, which
-  `reg-view` defs for you) or by `(rf/view :id)` lookup. The JVM SSR emitter
-  does resolve a keyword head through the registry, which is exactly why the
-  mistake survives a server-side test and only shows up in the browser.
-
-  By the time the browser renders, every boundary has already resolved — the
-  streaming runtime swapped each chunk into the DOM and merged its delta, and
-  the final payload seeded the rest — so the client renders the resolved card
-  and `hydrate-root` adopts the DOM the stream painted."
+  as a text node. That rule holds on EVERY host, server included: the JVM
+  SSR emitter is a pure hiccup → HTML function that resolves no ids. Render
+  trees reference views by **Var** (`card-view`, which `reg-view` defs for
+  you) or by `(rf/view :id)` lookup."
   [boundary-id card-id body]
-  #?(:clj  [:rf/suspense-boundary
-            {:id boundary-id :fallback [card-skeleton card-id]}
-            body]
-     :cljs [card-view card-id]))
+  [ssr/boundary {:id boundary-id :fallback [card-skeleton card-id]}
+   body])
 
 (rf/reg-view ^{:rf/id :dashboard/root} root-view []
   [:main.dashboard
@@ -224,6 +226,12 @@
                                         id (pr-str delta)))
                       :failed? failed?}))
                  continuations)
+           ;; Which boundaries blew up. The server has always known this
+           ;; per continuation; carrying it into the final payload is what
+           ;; lets the client's boundary re-render its declared fallback
+           ;; instead of every view inferring failure from missing state.
+           failed-boundaries (into #{} (comp (filter :failed?) (map :id))
+                                   resolved-chunks)
            render-hash (rf/with-frame fid (ssr/render-tree-hash hiccup))
            ;; The final payload: the canonical, whole app-db. This is the
            ;; load-bearing idea of the example. Those per-card deltas are a
@@ -242,7 +250,8 @@
                            (ssr/streaming-build-final-payload
                              fid render-hash
                              {:version 1
-                              :payload :rf.ssr.payload/whole-app-db}))
+                              :payload :rf.ssr.payload/whole-app-db
+                              :failed-boundaries failed-boundaries}))
            ;; Strip the payload's `:rf/frame-id` before it goes over the
            ;; wire. The two sides don't share a frame id: the server renders
            ;; under this per-request gensym frame (`fid`), the client hydrates
@@ -258,6 +267,7 @@
        {:shell shell-html
         :resolved-chunks resolved-chunks
         :final-payload final-payload
+        :failed-boundaries failed-boundaries
         :render-hash render-hash})))
 
 ;; ============================================================================
@@ -283,15 +293,24 @@
 ;;     subtree in place and merges that subtree's delta into app-db. `run`
 ;;     installs it before the first render, so it catches chunks that already
 ;;     streamed in and any still on the way.
-;;  3. The final `<script id="__rf_payload">` is the canonical full state.
-;;     `run` hands it to `ssr/hydrate!`, which dispatches `:rf/hydrate` and
-;;     replaces the whole client frame-state in one step — app-db plus its
-;;     serialisable runtime-db slice. The runtime auto-disconnects the moment
-;;     it sees `__rf_payload`, so no late delta can race that replace. The
-;;     deltas got each card on screen early; this last step makes the whole
-;;     thing correct.
+;;  3. The final `<script id="__rf_payload">` is the canonical full state, and
+;;     its arrival means the stream is done. The runtime FINALISES: it
+;;     processes any chunk still pending, consumes or quarantines the last
+;;     deltas, unwraps every `<rf-suspense>` mount it created — leaving the
+;;     DOM as the plain markup the author's tree describes — disconnects, and
+;;     calls `:on-ready`. Only then does `run` hydrate: `ssr/hydrate!`
+;;     dispatches `:rf/hydrate`, replacing the whole client frame-state in one
+;;     step (app-db plus its serialisable runtime-db slice, which carries
+;;     which boundaries failed), and `hydrate-root` adopts the painted DOM.
+;;     The deltas got each card on screen early; this last step makes the
+;;     whole thing correct.
 ;;
-;; See the [SSR guide — Streaming](../../../../docs/ssr/concepts.md#streaming-rfsuspense-boundary)
+;;     The protocol is therefore: progressive PRE-HYDRATION PAINT, then ONE
+;;     ordinary whole-root hydration. Templates, `<rf-suspense>` mounts and
+;;     delta scripts are transport — never part of the application tree — and
+;;     none of them is in the DOM by the time React looks at it.
+;;
+;; See the [SSR guide — Streaming](../../../../docs/ssr/concepts.md#streaming-ssrboundary)
 ;; and [hydrate, then verify](../../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify).
 ;;
 ;; One honest caveat: this example boots from a hand-written `index.html`
@@ -356,41 +375,61 @@
      ;; client — both the streamed deltas and the final hydrate — validate
      ;; against the same contract the server used.
      (rf/reg-app-schema [:cards] {:frame app-frame} CardsSchema)
-     ;; Turn on the streaming runtime BEFORE the first render, so it catches
+     ;; Turn on the streaming runtime BEFORE anything renders, so it catches
      ;; resolved-subtree chunks as they arrive (and sweeps up any that already
      ;; landed). For each one it swaps the fallback for the real subtree and
-     ;; merges that subtree's delta into the frame — then disconnects itself
-     ;; the moment `__rf_payload` shows up.
-     (ssr/streaming-install! {:frame app-frame})
-     ;; Now reconcile against the canonical payload: read `__rf_payload` and
-     ;; dispatch `:rf/hydrate` into the explicit `:frame`. This is the truth
-     ;; the streamed deltas defer to. Hydrate BEFORE the first render so that
-     ;; render runs against fully seeded app-db, not a half-filled one.
-     ;; `hydrate!` seeds STATE only — it never touches the DOM — and hands back
-     ;; the payload it applied, or nil on a plain client load with no server
-     ;; render to adopt.
-     ;; (We leave out `:render-tree-fn` because this static demo's shell
-     ;; carries a placeholder render-hash, so mismatch verification would warn
-     ;; every time. A real streaming server stamps the genuine hash and passes
-     ;; `:render-tree-fn` to switch mismatch detection on.)
-     (let [el      (and (exists? js/document) (js/document.getElementById "app"))
-           payload (ssr/hydrate! {:frame app-frame})
-           tree    [rf/frame-provider {:frame app-frame} [(rf/view :dashboard/root)]]]
-       (when el
-         (if payload
-           ;; Server-streamed: ADOPT the painted DOM. Once the shell and every
-           ;; resolved chunk have landed, `hydrate-root` reconciles React
-           ;; against that server markup — same nodes, listeners attached, no
-           ;; re-paint — and returns the retained root. `create-root` + `render`
-           ;; would discard the server DOM and mount fresh, the bug this branch
-           ;; avoids.
-           (reset! react-root (rdc/hydrate-root el tree))
-           ;; No payload means the server never rendered this page — a plain
-           ;; first load. Mount a fresh root; the shell comes up from the
-           ;; client-side render alone.
-           (do
-             (reset! react-root (rdc/create-root el))
-             (rdc/render @react-root tree)))))))
+     ;; merges that subtree's delta into the frame.
+     ;;
+     ;; `:on-ready` is the hydration trigger, and this is the whole shape of a
+     ;; streaming bootstrap. It fires ONCE, when the final payload has landed,
+     ;; every delta is consumed, and every `<rf-suspense>` mount the runtime
+     ;; created has been unwrapped. Those mounts are transport — the live swap
+     ;; targets the runtime materialises from the shell's inert `<template>`
+     ;; fallbacks — and no render tree on any host can express them. Hydrating
+     ;; while they are still in the DOM is a structural mismatch at every
+     ;; boundary, so React discards the streamed page and re-renders it: you
+     ;; pay for streaming and get none of it.
+     ;;
+     ;; Note what is NOT here: no polling for `__rf_payload`, no timer, and no
+     ;; `create-root` fallback taken merely because the payload hasn't arrived
+     ;; yet. On a live stream it hasn't arrived yet for most of the page's
+     ;; life, and mounting a fresh root in the meantime throws away the very
+     ;; markup the server streamed. The readiness callback removes the race by
+     ;; removing the guess.
+     (ssr/streaming-install!
+       {:frame    app-frame
+        :on-ready (fn [_outcomes]
+                    ;; Reconcile against the canonical payload first: read
+                    ;; `__rf_payload` and dispatch `:rf/hydrate` into the
+                    ;; explicit `:frame`. This is the truth the streamed
+                    ;; deltas defer to. `hydrate!` seeds STATE only — it never
+                    ;; touches the DOM — and hands back the payload it applied.
+                    ;; Hydrate BEFORE the render so that render runs against
+                    ;; fully seeded app-db, not a half-filled one.
+                    ;;
+                    ;; (We leave out `:render-tree-fn` because this static demo's
+                    ;; shell carries a placeholder render-hash, so mismatch
+                    ;; verification would warn every time. A real streaming
+                    ;; server stamps the genuine hash and passes
+                    ;; `:render-tree-fn` to switch mismatch detection on.)
+                    (let [payload (ssr/hydrate! {:frame app-frame})
+                          el      (and (exists? js/document)
+                                       (js/document.getElementById "app"))
+                          tree    [rf/frame-provider {:frame app-frame}
+                                   [(rf/view :dashboard/root)]]]
+                      (when el
+                        (if payload
+                          ;; Server-rendered: ADOPT the painted DOM.
+                          ;; `hydrate-root` reconciles React against that
+                          ;; markup — same nodes, listeners attached, no
+                          ;; re-paint — and returns the retained root.
+                          (reset! react-root (rdc/hydrate-root el tree))
+                          ;; No payload means the server never rendered this
+                          ;; page — a plain first load with nothing to adopt.
+                          ;; Mount a fresh root.
+                          (do
+                            (reset! react-root (rdc/create-root el))
+                            (rdc/render @react-root tree))))))})))
 
 ;; The JVM headless test that walks the server stream end to end (shell →
 ;; per-card resolved chunks → final payload) lives over in

--- a/implementation/adapters/reagent/test/re_frame/ssr_streaming_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/ssr_streaming_example_cljs_test.cljs
@@ -40,6 +40,8 @@
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
+            ;; The failed-boundary record the example's boundaries consult.
+            [re-frame.ssr.suspense :as suspense]
             ;; the example's production source — registers :dashboard/root,
             ;; :dashboard/card, :dashboard/card-skeleton and the two subs at
             ;; ns-load.
@@ -88,7 +90,12 @@
 (defn- seed-cards!
   "Stand in for the streamed deltas + the final `__rf_payload` hydrate: the
   three cards whose boundaries RESOLVED land in app-db; `:flaky` (whose
-  continuation threw server-side, shipping no delta) stays absent."
+  continuation threw server-side, shipping no delta) stays absent.
+
+  Also stands in for the streaming client's finalization step, which
+  records the failed boundary ids from the wire. That record is what lets
+  `:card.flaky`'s boundary re-render its DECLARED fallback — the example's
+  `card-view` no longer carries a nil branch duplicating the skeleton."
   []
   (rf/reg-event ::seed
     (fn [{:keys [db]} _]
@@ -96,7 +103,9 @@
                   {:revenue {:title "Revenue (last 7 days)"     :value 42375}
                    :signups {:title "New signups (last 7 days)" :value 318}
                    :latency {:title "P50 latency (ms)"          :value 24}})}))
-  (rf/dispatch-sync [::seed] {:frame test-frame}))
+  (rf/dispatch-sync [::seed] {:frame test-frame})
+  (suspense/reset-failed-boundaries!)
+  (suspense/record-failed-boundaries! #{:card.flaky}))
 
 ;; ---- (1) no server-only marker leaks into the client DOM -------------------
 
@@ -138,12 +147,25 @@
 
 ;; ---- (3) a boundary that never resolved stays on its skeleton --------------
 
-(deftest unresolved-card-renders-its-skeleton
-  (testing "rf2-o4rbh: the `:flaky` card's continuation threw server-side, so
-            no delta ever seeded it. Its client render must degrade to the
-            skeleton rather than paint an empty card — that is the DOM the
-            failed chunk's fallback left in place"
+(deftest failed-boundary-renders-its-declared-fallback
+  (testing "rf2-ycz3k: the `:flaky` card's continuation threw server-side, so
+            the final payload named it in the failed set. Its BOUNDARY
+            re-renders the `:fallback` it declared — the same skeleton the
+            failed chunk's fallback left in the DOM — without `card-view`
+            carrying a nil branch that duplicates it"
     (seed-cards!)
     (let [html (render-client-tree)]
       (is (str/includes? html "class=\"card skeleton\"") html)
-      (is (str/includes? html "Loading flaky") html))))
+      (is (str/includes? html "Loading flaky") html)))
+
+  (testing "the fallback is a consequence of the RECORDED OUTCOME, not of
+            the card's data being absent. Clear the record and the same
+            boundary renders its body — which, for this example's flaky
+            card, is the view that throws on purpose. That throw is the
+            proof: nothing about app-db decides this, the recorded failure
+            does"
+    (seed-cards!)
+    (suspense/reset-failed-boundaries!)
+    (is (thrown? :default (render-client-tree))
+        (str "with no recorded failure the boundary must render its body "
+             "(`throwing-card`), not silently keep showing the fallback"))))

--- a/implementation/core/test/re_frame/examples_test.clj
+++ b/implementation/core/test/re_frame/examples_test.clj
@@ -532,6 +532,17 @@
           (is (clojure.string/includes? (:template c) "class=\"card\"")
               (str "resolved chunk must carry the rendered card body; got "
                    (:template c)))))
+      ;; rf2-ycz3k — the drain's `:failed?` reaches the wire. The server has
+      ;; always known which boundaries blew up and used to DROP it, leaving
+      ;; the client to infer failure from absent state. The final payload now
+      ;; names them in its serialisable runtime slice, so the client's
+      ;; boundary re-renders the fallback it declared.
+      (is (= #{:card.flaky} (:failed-boundaries result))
+          "the failed boundary is reported by the drain")
+      (is (= #{:card.flaky}
+             (get-in (:rf/runtime-db (:final-payload result))
+                     [:rf.runtime/ssr :streaming :failed-boundaries]))
+          "and rides the final payload's runtime-db slice")
       ;; Final payload carries the canonical :rf/* keys.
       (is (= 1 (:rf/version (:final-payload result))))
       (is (some? (:rf/render-hash (:final-payload result))))

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -17,6 +17,9 @@
             ;; Loaded eagerly so both hydration boot re-exports resolve.
             [re-frame.ssr.boot :as boot]
             [re-frame.ssr.emit :as emit]
+            ;; The cross-host suspense COMPONENT — the streaming authoring
+            ;; surface on every substrate.
+            [re-frame.ssr.boundary :as boundary]
             [re-frame.ssr.error-listener :as error-listener]
             [re-frame.ssr.error-projector :as error-projector]
             ;; Publishes the head hooks at namespace load.
@@ -102,9 +105,24 @@
 
 ;; ---- streaming SSR public surface -----------------------------------------
 ;;
-;; Per Spec 011 §Streaming SSR — the `:rf/suspense-boundary` hiccup marker
-;; ships through these three façade fns. Host adapters (ssr-ring/streaming)
-;; consume them via the late-bind hooks the streaming ns also publishes.
+;; Per Spec 011 §Streaming SSR. The AUTHORING surface is the `boundary`
+;; component — one `.cljc` form that works on every host. The `:rf/suspense-
+;; boundary` keyword it expands to on the server is internal wire syntax
+;; between the component and the shell walker, not something an author
+;; writes (a keyword head is an HTML element on every client substrate).
+;; The server-side machinery below ships through these façade fns; host
+;; adapters (ssr-ring/streaming) consume them via the late-bind hooks the
+;; streaming ns publishes.
+
+;; The cross-host suspense boundary component:
+;;
+;;     [ssr/boundary {:id :card.revenue :fallback [card-skeleton :revenue]}
+;;      [card-view :revenue]]
+;;
+;; Server: expands to the `:rf/suspense-boundary` marker the shell walker
+;; defers on. Client: renders the body, or the declared `:fallback` when
+;; the boundary is in the failed set the final payload carried.
+(def boundary                       boundary/boundary)
 (def streaming-render-shell         re-frame.ssr.streaming/render-shell)
 (def streaming-render-continuation  re-frame.ssr.streaming/render-continuation)
 (def streaming-build-final-payload  re-frame.ssr.streaming/build-final-payload)

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -19,7 +19,7 @@
             [re-frame.ssr.emit :as emit]
             ;; The cross-host suspense COMPONENT — the streaming authoring
             ;; surface on every substrate.
-            [re-frame.ssr.boundary :as boundary]
+            [re-frame.ssr.suspense :as suspense]
             [re-frame.ssr.error-listener :as error-listener]
             [re-frame.ssr.error-projector :as error-projector]
             ;; Publishes the head hooks at namespace load.
@@ -122,7 +122,7 @@
 ;; Server: expands to the `:rf/suspense-boundary` marker the shell walker
 ;; defers on. Client: renders the body, or the declared `:fallback` when
 ;; the boundary is in the failed set the final payload carried.
-(def boundary                       boundary/boundary)
+(def boundary                       suspense/boundary)
 (def streaming-render-shell         re-frame.ssr.streaming/render-shell)
 (def streaming-render-continuation  re-frame.ssr.streaming/render-continuation)
 (def streaming-build-final-payload  re-frame.ssr.streaming/build-final-payload)

--- a/implementation/ssr/src/re_frame/ssr/boundary.cljc
+++ b/implementation/ssr/src/re_frame/ssr/boundary.cljc
@@ -1,0 +1,166 @@
+(ns re-frame.ssr.boundary
+  "The cross-host suspense boundary — a `.cljc` COMPONENT, not a hiccup
+  keyword head.
+
+  A streaming region is one authoring form that works on every host:
+
+      (require '[re-frame.ssr.boundary :refer [boundary]])
+
+      [boundary {:id :card.revenue :fallback [card-skeleton :revenue]}
+       [card-view :revenue]]
+
+  On the **server** the component expands to the internal
+  `:rf/suspense-boundary` wire marker, which the streaming shell walker
+  (`re-frame.ssr.streaming`) recognises: it materialises the `:fallback`
+  inline as a `<template>` placeholder and registers a continuation for
+  the body. On the **client** the component renders the body directly —
+  or the declared `:fallback` when this boundary is one the server
+  reported as FAILED.
+
+  ## Why a component and not a keyword head
+
+  `:rf/suspense-boundary` cannot be an authoring surface on the client.
+  A keyword head is an HTML element on every host (Spec 004 + Conventions
+  §Render-tree shape vs runtime lookup; rf2-j81hs made that one rule
+  corpus-wide), so a marker left in a client render tree paints a phantom
+  `<suspense-boundary>` element. And the marker could not be *given*
+  client semantics either: stock Reagent is an external dependency whose
+  element dispatch is not ours to extend, and UIx / Helix views are
+  `defui` / `$` forms where a hiccup keyword head cannot occur at all.
+
+  A callable component head is the ONE form expressible on every
+  substrate, so that is the authoring surface. The keyword marker stays,
+  demoted to internal wire syntax between this component and the walker —
+  the walker protocol is unchanged, and the non-streaming emitter's
+  `:rf.error/ssr-suspense-boundary-outside-stream` throw still guards a
+  marker that escapes a stream.
+
+  This also removes the reader-conditional `card-slot` pattern that the
+  streaming example was forced into (a `#?(:clj … :cljs …)` slot, plus
+  hand-maintained fallback duplication in every view's nil branch). One
+  form, two hosts — and because both hosts now hash the SAME raw tree,
+  the render-tree hash agrees by construction. A reader conditional made
+  the two hosts hash structurally different trees; a component head
+  canonicalises to the existing `#fn[]` token on both (Spec 011
+  §Render-tree hash, rf2-jsa2ml), so no hash change is needed.
+
+  ## Not React Suspense
+
+  No promises, no thrown thenables, no selective hydration. This is a
+  server-driven streaming protocol: the server decides what defers, the
+  client paints the fallback and swaps content as chunks land. It shares
+  the *shape* of React 18 / Solid suspense (a visible fallback plus a
+  stable mount) and nothing of the mechanism.
+
+  ## Failed boundaries
+
+  A boundary whose server-side render threw ships its FALLBACK html in
+  the chunk (Spec 011 §Failure semantics — inline fallback) and no
+  hydration delta. The final payload carries that boundary's id in the
+  failed set, which rides the serialisable runtime-db slice to
+  `[:rf.runtime/ssr :streaming :failed-boundaries]`. This component reads
+  that set, so a failed boundary renders its DECLARED `:fallback` — the
+  exact markup the failed chunk left in the DOM. Views no longer need a
+  defensive nil branch to keep the client render agreeing with the
+  painted DOM; the boundary that declared the fallback is the one that
+  re-renders it.
+
+  Absence of a recorded outcome — a plain client mount, a non-streamed
+  page, no frame scope at all — means the body renders. That is the
+  ordinary case and it fails soft by construction."
+  (:require [re-frame.error :as error]
+            [re-frame.frame :as frame]))
+
+;; ---- reserved runtime-db slot ---------------------------------------------
+
+(def failed-boundaries-path
+  "Runtime-db path holding the set of boundary ids whose server-side
+  render FAILED, as reported by the final payload's serialisable
+  runtime-db slice (`re-frame.ssr.streaming/build-final-payload`).
+
+  Under the already-reserved `:rf.runtime/ssr` key (Conventions §Reserved
+  runtime-db keys), a sibling of the `:hydration` metadata the
+  `:rf/hydrate` handler writes. Runtime-managed: user code MUST NOT
+  write it."
+  [:rf.runtime/ssr :streaming :failed-boundaries])
+
+(defn failed-boundaries
+  "The set of failed boundary ids recorded for `frame-id`, or `#{}` when
+  none are recorded (the ordinary case — nothing failed, or this page was
+  never streamed). Never throws for an unknown / destroyed frame."
+  [frame-id]
+  (or (get-in (frame/frame-runtime-db-value frame-id) failed-boundaries-path)
+      #{}))
+
+;; ---- attrs validation ------------------------------------------------------
+
+(defn- valid-attrs? [m]
+  (and (map? m) (contains? m :id) (contains? m :fallback)))
+
+(defn- reject-attrs! [attrs]
+  ;; Same error id the shell walker raises for a malformed marker
+  ;; (`re-frame.ssr.streaming/walk-suspense-boundary`), so the authoring
+  ;; mistake reads identically whichever host catches it first. A
+  ;; client-only app would otherwise discover a missing `:fallback` only
+  ;; when its server build ran.
+  (error/throw-error!
+    :rf.error/suspense-boundary-invalid-attrs
+    'rf.ssr/boundary
+    (str "boundary requires an attrs map with both :id and :fallback; "
+         "give it {:id … :fallback …} as its first argument.")
+    {:recovery :supply-id-and-fallback-attrs
+     :extra    {:got attrs}}))
+
+;; ---- the component ---------------------------------------------------------
+
+(defn- subtree
+  "The body as ONE hiccup form. Mirrors the walker's continuation-subtree
+  construction (`re-frame.ssr.streaming/walk-suspense-boundary`): a lone
+  child renders as itself, several are wrapped in a `:<>` fragment. The
+  fragment emits no DOM, so the client's rendered structure matches the
+  server's resolved-subtree html exactly."
+  [body]
+  (case (count body)
+    0 nil
+    1 (first body)
+    (into [:<>] body)))
+
+(defn boundary
+  "Declare a streaming suspense boundary around `body`.
+
+  `attrs` is a map with two REQUIRED keys:
+
+    :id       — the boundary's identity. Unique per page; it is how an
+                arriving chunk is paired with its placeholder. A keyword
+                or a string.
+    :fallback — hiccup rendered inline in the shell while the body is
+                still resolving, and re-rendered by this component when
+                the boundary is reported failed.
+
+  Server (`:clj`): expands to the internal `:rf/suspense-boundary` marker
+  the streaming shell walker consumes. Outside a stream the standard
+  emitter rejects that marker with
+  `:rf.error/ssr-suspense-boundary-outside-stream` — unchanged.
+
+  Client (`:cljs`): renders `body`, or `:fallback` when `:id` is in the
+  frame's failed-boundary set. The frame is the ambient one (a
+  `frame-provider` / `frame-root` scope, or a `with-frame` binding); no
+  scope at all reads as no recorded outcome and renders `body`."
+  [attrs & body]
+  (when-not (valid-attrs? attrs)
+    (reject-attrs! attrs))
+  (let [{:keys [id fallback]} attrs]
+    #?(:clj
+       ;; Internal wire syntax. Rebuilt (rather than passed through) so
+       ;; only the two contract keys reach the walker.
+       (into [:rf/suspense-boundary {:id id :fallback fallback}] body)
+
+       :cljs
+       ;; `resolve-current-frame` is a READER — nil when no scope is
+       ;; established, never a synthesised `:rf/default` and never a
+       ;; throw. Absence is the plain-client-mount case: render the body.
+       (if-let [f (frame/resolve-current-frame)]
+         (if (contains? (failed-boundaries (frame/frame-value->id f)) id)
+           fallback
+           (subtree body))
+         (subtree body)))))

--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -572,8 +572,14 @@
          ;; splice `(rest el)` through `emit-children`, which would stringify
          ;; the component ref and dump the props map as raw EDN into the
          ;; markup (garbage output, not a rendered component). The author
-         ;; must wrap the React component in a `reg-view` (which the SSR
-         ;; emitter resolves) or render it client-only.
+         ;; wraps the React component in a `reg-view` and references THAT
+         ;; by its callable head — the Var `reg-view` defs, or
+         ;; `(rf/view :id)`. rf2-ycz3k: this used to say the wrapping
+         ;; reg-view was something "the SSR emitter resolves", which has
+         ;; been false since rf2-j81hs made the emitter a pure
+         ;; hiccup → HTML function with no registry lookup. Nothing
+         ;; resolves an id here; the CALLABLE head is what the emitter
+         ;; invokes, which is why the spelling has to be in the message.
          (= :> head)
          (error/throw-error!
            :rf.error/ssr-reagent-native-head
@@ -583,8 +589,12 @@
                 "rendered server-side — it targets a "
                 "React component and there is no React "
                 "on the JVM. Wrap the component in a "
-                "reg-view for SSR, or render it "
-                "client-only.")
+                "reg-view and reference that view by its "
+                "CALLABLE head — the Var reg-view defs "
+                "(`[my-view …]`) or `[(rf/view :my/id) …]` "
+                "— or render it client-only. A bare "
+                "keyword head is an HTML element, not a "
+                "view reference.")
            {:recovery :wrap-in-reg-view-or-render-client-only
             :extra    {:element el}})
 

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -15,7 +15,7 @@
   in document order'`) + `ssr_streaming_conformance_test` (fixture-
   pinned FIFO).
 
-  Authors mark deferred subtrees with the `re-frame.ssr.boundary/boundary`
+  Authors mark deferred subtrees with the `re-frame.ssr.suspense/boundary`
   COMPONENT — the one form expressible on every host:
 
     [boundary
@@ -80,7 +80,7 @@
             ;; require is acyclic: the component expands TO the marker this
             ;; walker consumes, and both sides read the slot path from one
             ;; source rather than repeating the literal.
-            [re-frame.ssr.boundary :as boundary]
+            [re-frame.ssr.suspense :as suspense]
             [re-frame.ssr.emit :as emit]
             [re-frame.ssr.html-helpers :as html]
             [re-frame.ssr.payload-policy :as payload-policy]
@@ -641,7 +641,7 @@
 
 (defn- with-failed-boundaries
   "Record the failed-boundary id set in the projected runtime-db slice, at
-  `re-frame.ssr.boundary/failed-boundaries-path`.
+  `re-frame.ssr.suspense/failed-boundaries-path`.
 
   The server has known `:failed?` per continuation since streaming
   shipped and DROPPED it: the client could see a
@@ -658,7 +658,7 @@
   [projected policy-opts]
   (let [failed (:failed-boundaries policy-opts)]
     (if (seq failed)
-      (assoc-in (or projected {}) boundary/failed-boundaries-path (set failed))
+      (assoc-in (or projected {}) suspense/failed-boundaries-path (set failed))
       projected)))
 
 (defn build-final-payload
@@ -710,7 +710,7 @@
   whose continuation render THREW (each `render-continuation` call
   reports `:failed? true`). The host adapter accumulates them as it
   drains and hands the set here; it rides the serialisable runtime-db
-  slice at `re-frame.ssr.boundary/failed-boundaries-path`, so the
+  slice at `re-frame.ssr.suspense/failed-boundaries-path`, so the
   `:rf/hydrate` `:replace-frame-state` install puts it in the client
   frame's runtime-db with no new payload key and no hydrate-handler
   change. The client `boundary` component reads it to render a failed

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -15,13 +15,27 @@
   in document order'`) + `ssr_streaming_conformance_test` (fixture-
   pinned FIFO).
 
-  The hiccup author marks deferred subtrees with the
-  `:rf/suspense-boundary` reserved hiccup head:
+  Authors mark deferred subtrees with the `re-frame.ssr.boundary/boundary`
+  COMPONENT — the one form expressible on every host:
+
+    [boundary
+     {:id      :news/comments
+      :fallback [:p \"Loading comments…\"]}
+     [comments-section]]
+
+  which expands, on the server, to the internal `:rf/suspense-boundary`
+  wire marker this walker consumes:
 
     [:rf/suspense-boundary
      {:id      :news/comments
       :fallback [:p \"Loading comments…\"]}
-     [:comments/section]]
+     [comments-section]]
+
+  The marker is INTERNAL syntax between the component and this walker,
+  not an authoring surface — a keyword head is an HTML element on every
+  client substrate (rf2-j81hs), so a marker written by hand into a shared
+  render tree paints a phantom `<suspense-boundary>`. The walker protocol
+  below is unchanged by the component's introduction.
 
   Three load-bearing operations:
 
@@ -61,6 +75,12 @@
             ;; debug-gated source-coord injection). The shell walk no longer
             ;; consults the registry to decide what a head means.
             [re-frame.late-bind :as late-bind]
+            ;; The suspense COMPONENT's reserved runtime-db slot. `boundary`
+            ;; depends on core only (frame + error), never on this ns, so the
+            ;; require is acyclic: the component expands TO the marker this
+            ;; walker consumes, and both sides read the slot path from one
+            ;; source rather than repeating the literal.
+            [re-frame.ssr.boundary :as boundary]
             [re-frame.ssr.emit :as emit]
             [re-frame.ssr.html-helpers :as html]
             [re-frame.ssr.payload-policy :as payload-policy]
@@ -619,6 +639,28 @@
            :failed?       true
            :continuations []})))))
 
+(defn- with-failed-boundaries
+  "Record the failed-boundary id set in the projected runtime-db slice, at
+  `re-frame.ssr.boundary/failed-boundaries-path`.
+
+  The server has known `:failed?` per continuation since streaming
+  shipped and DROPPED it: the client could see a
+  `data-rf2-suspense-failed` chunk in the DOM, but nothing survived into
+  the hydrated frame-state, so a client render tree had no way to know
+  which boundaries should re-render their fallback. Carrying the set on
+  the serialisable runtime slice closes that — it rides the existing
+  `:rf/runtime-db` key and the existing `:replace-frame-state` install.
+
+  Empty / absent set contributes NO key: `project-runtime-db` returns nil
+  when no durable subsystem fact is present, and a page where nothing
+  failed must keep that nil so `build-payload` omits `:rf/runtime-db`
+  entirely. Only a genuine failure materialises the slice."
+  [projected policy-opts]
+  (let [failed (:failed-boundaries policy-opts)]
+    (if (seq failed)
+      (assoc-in (or projected {}) boundary/failed-boundaries-path (set failed))
+      projected)))
+
 (defn build-final-payload
   "After every continuation has drained, construct the canonical
   `:rf/hydration-payload` for the `__rf_payload` final chunk. The
@@ -662,7 +704,19 @@
   the whole `app-db`). Absence throws
   `:rf.error/ssr-missing-payload-policy`. The Ring host adapter
   validates at handler-construction time so misconfigured deployments
-  fail at boot rather than at first request."
+  fail at boot rather than at first request.
+
+  `policy-opts` may carry `:failed-boundaries` — the set of boundary ids
+  whose continuation render THREW (each `render-continuation` call
+  reports `:failed? true`). The host adapter accumulates them as it
+  drains and hands the set here; it rides the serialisable runtime-db
+  slice at `re-frame.ssr.boundary/failed-boundaries-path`, so the
+  `:rf/hydrate` `:replace-frame-state` install puts it in the client
+  frame's runtime-db with no new payload key and no hydrate-handler
+  change. The client `boundary` component reads it to render a failed
+  boundary's DECLARED fallback — the markup the failed chunk actually
+  left in the DOM. Empty / absent contributes NO key (the ordinary
+  nothing-failed page carries nothing extra on the wire)."
   [frame-id render-hash {:as policy-opts}]
   (let [;; rf2-j538f7.15 — pin the frame's per-incarnation identity BEFORE
         ;; reading its state. The app-db / runtime-db below are captured off the
@@ -706,7 +760,8 @@
        ;; ambient one. A streaming build called outside `with-frame`, or under a
        ;; different ambient frame, otherwise serialized classified route / machine
        ;; / resource runtime state under nil / the wrong frame's policy.
-       (assoc policy-opts :runtime-db (payload-policy/project-runtime-db runtime-db frame-id)))
+       (assoc policy-opts :runtime-db (-> (payload-policy/project-runtime-db runtime-db frame-id)
+                                          (with-failed-boundaries policy-opts))))
       ;; rf2-j538f7.15 — the request frame was destroyed / re-registered between
       ;; state capture and projection: its classification authority is gone, so
       ;; the captured app-db / runtime-db must NOT ship under absent / substituted

--- a/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
+++ b/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
@@ -259,6 +259,45 @@
       true)
     false))
 
+(defn- unwrap-mount!
+  "Remove one `<rf-suspense>` mount wrapper, splicing its children into
+  the parent at the wrapper's position.
+
+  This is the step that makes a streamed page HYDRATABLE. The mount is
+  PROTOCOL DOM — the client-owned swap target, invented by `install!`,
+  named by no render tree on any host. Left in place it sits between the
+  author's `<section>` and the resolved `<div class=\"card\">`, so React's
+  `hydrateRoot` walks the client tree and finds an element the tree never
+  described: a structural mismatch on every boundary, on a page whose
+  content is otherwise byte-correct (rf2-o4rbh measured exactly this).
+
+  Unwrapping restores the DOM the author's tree DOES describe — the same
+  shape `render-to-string` produces for the equivalent non-streamed
+  tree — so one ordinary whole-root hydration reconciles it.
+
+  Children are moved (not cloned): `insertBefore` relocates a node that
+  already has a parent, so the loop drains the mount in document order
+  without copying, and node identity is preserved for anything already
+  holding a reference."
+  [mount]
+  (when-let [parent (.-parentNode mount)]
+    (loop []
+      (when-let [child (.-firstChild mount)]
+        (.insertBefore parent child mount)
+        (recur)))
+    (.removeChild parent mount)))
+
+(defn- unwrap-mounts!
+  "Unwrap EVERY live mount under `root`. Runs once, at finalization,
+  after the last sweep — so no resolved chunk can arrive to find its swap
+  target gone. A boundary still showing its fallback (the server never
+  resolved it, or it failed) unwraps too: the fallback markup is what the
+  page is left painting, and the client `boundary` component renders that
+  same declared fallback for a failed id, so the two agree."
+  [root]
+  (doseq [m (query-by-attr root attr-suspense-mount)]
+    (unwrap-mount! m)))
+
 ;; ---- delta merge -----------------------------------------------------------
 
 (defn- merge-delta!
@@ -596,6 +635,55 @@
   [root payload-id]
   (some? (element-by-id root payload-id)))
 
+(defn- readiness-report
+  "The outcome summary handed to `:on-ready` — `{:resolved #{ids} :failed
+  #{ids}}` over the boundary ids this runtime actually processed, with
+  ids parsed back to the values the author wrote. Empty sets on a page
+  that carried no boundaries."
+  [seen]
+  (reduce-kv (fn [acc id-str outcome]
+               (update acc (case outcome :failed :failed :resolved)
+                       conj (read-boundary-id id-str)))
+             {:resolved #{} :failed #{}}
+             @seen))
+
+(defn- finalize!
+  "The one-time FINALIZATION step, run when the final `__rf_payload`
+  lands (or when it had already landed at install time).
+
+  Spec 011 pins the streaming protocol as progressive PRE-HYDRATION PAINT
+  followed by ONE ordinary whole-root hydration. Finalization is the
+  boundary between those two phases, and it must leave the DOM carrying
+  nothing but the application tree:
+
+    1. `sweep!` — process any chunk still pending (a resolved
+       `<template>` that landed in the same observer batch as the
+       payload), which also records its outcome and consumes or
+       quarantines its delta.
+    2. `unwrap-mounts!` — remove every `<rf-suspense>` wrapper. This is
+       the structural fix: protocol DOM is transport, never part of the
+       application tree.
+    3. `stop!` — disconnect, so no late mutation can race the canonical
+       `:rf/hydrate` replace.
+    4. `on-ready` — hand the caller its readiness signal, ONCE.
+
+  Ordering is load-bearing. Sweeping after unwrapping would leave a
+  resolved chunk with no mount to swap into; unwrapping after
+  disconnecting would be fine but pointlessly late; and firing
+  `on-ready` before the unwrap would hand the bootstrap a DOM that still
+  carries wrappers — the exact tree `hydrateRoot` cannot match.
+
+  `ready?` is the once-only latch: a `compare-and-set!` on it, not a
+  boolean read, so an observer batch that races the initial sweep cannot
+  fire `on-ready` twice."
+  [root frame seen ready? stop! on-ready]
+  (sweep! root frame seen)
+  (unwrap-mounts! root)
+  (stop!)
+  (when (compare-and-set! ready? false true)
+    (when on-ready
+      (on-ready (readiness-report seen)))))
+
 ;; ---- public surface --------------------------------------------------------
 
 (defn install!
@@ -626,11 +714,32 @@
                   on the final-payload id by construction. Accepted as an
                   opt so a host that overrode the shell's payload id can
                   match it.
+    :on-ready   — 1-arity fn called EXACTLY ONCE when the stream has
+                  FINALISED: every chunk processed, every delta consumed
+                  or quarantined, every `<rf-suspense>` mount unwrapped,
+                  the observer disconnected. Receives a readiness report
+                  `{:resolved #{ids} :failed #{ids}}`.
+
+                  This is the hydration trigger. A streaming bootstrap
+                  calls `ssr/hydrate!` and the adapter's `hydrate-root`
+                  from HERE — not on a timer, not by polling the DOM for
+                  `__rf_payload`, and above all not by falling through to
+                  `create-root` because the payload has not landed yet.
+                  Before readiness the streamed root is server-painted
+                  markup carrying protocol DOM and no framework handlers;
+                  taking React ownership of it early is the
+                  create-root/hydrate-root race a live stream exposes.
+                  Fires SYNCHRONOUSLY during `install!` when the whole
+                  response had already buffered before the bundle booted
+                  (the common fast-page case), so the callback must not
+                  assume a later tick.
 
   Returns a 0-arity `stop!` fn that disconnects the observer early (so a
   host can tear the runtime down on its own schedule — e.g. an SPA
   navigation that abandons the stream). The runtime also auto-disconnects
   when it observes the final-payload node, so most hosts never call it.
+  Calling `stop!` early ABANDONS the stream: finalization does not run
+  and `:on-ready` never fires.
 
   Idempotent per chunk: the same resolved node is applied at most once
   even if the observer batches or the initial sweep races a mutation.
@@ -652,7 +761,7 @@
            ;; the streaming bootstrap calls `ssr/hydrate!` on completion.)
            ))"
   ([] (install! {}))
-  ([{:keys [frame root payload-id]
+  ([{:keys [frame root payload-id on-ready]
      ;; No implicit default: a nil frame is an absent target that
      ;; `require-frame-stamp!` fails
      ;; closed on, never a synthesised `:rf/default`. `payload-id` defaults
@@ -672,10 +781,13 @@
        (fn no-op-stop! [])
        (let [seen      (atom {})   ;; id-str → :resolved | :failed (swap outcome)
              observer  (atom nil)
+             ready?    (atom false) ;; once-only finalization latch
              stop!     (fn stop! []
                          (when-let [o @observer]
                            (.disconnect o)
                            (reset! observer nil)))
+             finish!   (fn finish! []
+                         (finalize! root frame seen ready? stop! on-ready))
              on-mutations
              (fn [_mutations _obs]
                ;; A cheap full re-sweep on any mutation is correct + simple:
@@ -686,17 +798,27 @@
                ;; tree-walking complexity for no measurable win at these
                ;; cardinalities.
                (sweep! root frame seen)
+               ;; The payload is the LAST chunk: its arrival means the
+               ;; stream is done, so run finalization (which re-sweeps for
+               ;; anything in this same batch, unwraps the protocol DOM,
+               ;; disconnects, and signals readiness).
                (when (final-payload-present? root payload-id)
-                 (stop!)))]
+                 (finish!)))]
          ;; Initial sweep — chunks that streamed in before this bundle
          ;; executed (the common case: the shell + several cards land while
          ;; main.js downloads + boots). Materialises fallbacks into visible
          ;; mounts + applies any resolved chunks already present.
          (sweep! root frame seen)
          (if (final-payload-present? root payload-id)
-           ;; Stream already complete by the time we installed — nothing to
-           ;; observe; the bootstrap's `:rf/hydrate` is the reconciliation.
-           (fn already-complete-stop! [])
+           ;; Stream already complete by the time we installed — the whole
+           ;; response buffered before the bundle booted. There is nothing
+           ;; to observe, but finalization still MUST run: the initial
+           ;; sweep materialised fallbacks into `<rf-suspense>` mounts, and
+           ;; leaving them would hand the bootstrap an unhydratable DOM.
+           ;; `:on-ready` fires synchronously here — the fast-page path a
+           ;; readiness-driven bootstrap must not hang on.
+           (do (finish!)
+               (fn already-complete-stop! []))
            (let [obs (js/MutationObserver. on-mutations)]
              (reset! observer obs)
              ;; Observe the whole subtree: resolved `<template>`s + the

--- a/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
+++ b/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
@@ -95,6 +95,9 @@
   (:require [cljs.reader :as reader]
             [re-frame.frame :as frame]
             [re-frame.ssr.constants :as constants]
+            ;; The suspense component's render-time failed-boundary record.
+            ;; `suspense` depends on core only, never on this ns.
+            [re-frame.ssr.suspense :as suspense]
             [re-frame.ssr.streaming.constants :as wire]
             [re-frame.trace :as trace]))
 
@@ -678,11 +681,16 @@
   fire `on-ready` twice."
   [root frame seen ready? stop! on-ready]
   (sweep! root frame seen)
-  (unwrap-mounts! root)
-  (stop!)
-  (when (compare-and-set! ready? false true)
-    (when on-ready
-      (on-ready (readiness-report seen)))))
+  (let [report (readiness-report seen)]
+    ;; Publish the failed set BEFORE unwrapping / readiness: the
+    ;; `boundary` component reads it during the hydration render that
+    ;; `on-ready` triggers, so it has to be in place by then.
+    (suspense/record-failed-boundaries! (:failed report))
+    (unwrap-mounts! root)
+    (stop!)
+    (when (compare-and-set! ready? false true)
+      (when on-ready
+        (on-ready report)))))
 
 ;; ---- public surface --------------------------------------------------------
 

--- a/implementation/ssr/src/re_frame/ssr/suspense.cljc
+++ b/implementation/ssr/src/re_frame/ssr/suspense.cljc
@@ -1,12 +1,29 @@
-(ns re-frame.ssr.boundary
+(ns re-frame.ssr.suspense
   "The cross-host suspense boundary — a `.cljc` COMPONENT, not a hiccup
   keyword head.
 
+  ## Why this namespace is not called `re-frame.ssr.boundary`
+
+  Because the façade exports the component as `re-frame.ssr/boundary`,
+  and in ClojureScript a var and a namespace share ONE JavaScript object
+  graph. A `boundary` var in `re-frame.ssr` compiles to
+  `re_frame.ssr.boundary = …`, which is byte-for-byte the object
+  `goog.provide` created for a namespace named `re-frame.ssr.boundary` —
+  so the def SILENTLY OVERWRITES the namespace, and every other var in it
+  (`failed-boundaries`, `failed-boundaries-path`) becomes `undefined` for
+  anyone who required both. That is not a hypothetical: this namespace
+  WAS called `…ssr.boundary` and the compiled output read
+
+      re_frame.ssr.boundary = re_frame.ssr.boundary.boundary;
+
+  Renaming the namespace keeps the good authoring name (`ssr/boundary`)
+  and removes the collision structurally. Do not rename it back.
+
   A streaming region is one authoring form that works on every host:
 
-      (require '[re-frame.ssr.boundary :refer [boundary]])
+      (require '[re-frame.ssr :as ssr])
 
-      [boundary {:id :card.revenue :fallback [card-skeleton :revenue]}
+      [ssr/boundary {:id :card.revenue :fallback [card-skeleton :revenue]}
        [card-view :revenue]]
 
   On the **server** the component expands to the internal
@@ -81,16 +98,75 @@
   Under the already-reserved `:rf.runtime/ssr` key (Conventions §Reserved
   runtime-db keys), a sibling of the `:hydration` metadata the
   `:rf/hydrate` handler writes. Runtime-managed: user code MUST NOT
-  write it."
+  write it.
+
+  This is the DURABLE record — serialisable, inspectable through ordinary
+  frame state, and the server's own answer. It is not what the component
+  reads at render time; see `failed-boundaries` below for why."
   [:rf.runtime/ssr :streaming :failed-boundaries])
 
-(defn failed-boundaries
-  "The set of failed boundary ids recorded for `frame-id`, or `#{}` when
-  none are recorded (the ordinary case — nothing failed, or this page was
-  never streamed). Never throws for an unknown / destroyed frame."
+(defn frame-failed-boundaries
+  "The durable failed-boundary set recorded in `frame-id`'s runtime-db by
+  hydration, or `#{}`. Never throws for an unknown / destroyed frame.
+
+  For consumers that HAVE a frame — host code, tools, tests, server-side
+  assertions. The component cannot use this; see below."
   [frame-id]
   (or (get-in (frame/frame-runtime-db-value frame-id) failed-boundaries-path)
       #{}))
+
+;; ---- the render-time record ------------------------------------------------
+;;
+;; Why the component does NOT read the frame's runtime-db:
+;;
+;; `boundary` is a plain function component, and on Reagent a plain fn
+;; lacking `:contextType` CANNOT read the enclosing `frame-provider`'s
+;; frame from React context (Spec 006 §Frame-provider via React context —
+;; only `reg-view`-wrapped components carry the stamp; a plain fn's
+;; ambient `subscribe` raises `:rf.error/no-frame-context` for exactly
+;; this reason). So there is no ambient frame to resolve from inside the
+;; component on the dominant substrate, and a frame-scoped read is
+;; structurally unavailable to it.
+;;
+;; Making `boundary` a `reg-view` would buy the frame back, but it would
+;; make the framework's streaming primitive a registrar citizen — with a
+;; registrar-cleared failure mode, and with `reg-view`'s dev-time
+;; `data-rf-view` / `data-rf2-source-coord` root-element stamping landing
+;; on the author's body markup. That is a large amount of machinery to
+;; buy one boolean.
+;;
+;; So the render-time record is a process-level set, written once at
+;; stream finalization by `re-frame.ssr.streaming.client/install!` from
+;; the outcomes it observed on the wire. A page's boundary ids are unique
+;; by contract (duplicates are already `:rf.error/suspense-boundary-
+;; duplicate-id`), so an id identifies a boundary without a frame.
+
+(defonce ^:private failed-registry
+  ;; Process-global. Neither `clear-all!` nor a frames reset touches it —
+  ;; a test that records a failure MUST call `reset-failed-boundaries!`
+  ;; or it leaks into siblings.
+  (atom #{}))
+
+(defn failed-boundaries
+  "The set of boundary ids recorded as FAILED for this page. `#{}` when
+  nothing failed, or when the page was never streamed — the ordinary
+  case, and what makes a plain client mount render bodies."
+  []
+  @failed-registry)
+
+(defn record-failed-boundaries!
+  "Record `ids` as failed. Called once per page by the streaming client's
+  finalization step; additive, so a second streamed root on the same page
+  contributes its own outcomes rather than replacing them."
+  [ids]
+  (swap! failed-registry into ids)
+  nil)
+
+(defn reset-failed-boundaries!
+  "Clear the record. Test surface — see the `defonce` note above."
+  []
+  (reset! failed-registry #{})
+  nil)
 
 ;; ---- attrs validation ------------------------------------------------------
 
@@ -143,9 +219,9 @@
   `:rf.error/ssr-suspense-boundary-outside-stream` — unchanged.
 
   Client (`:cljs`): renders `body`, or `:fallback` when `:id` is in the
-  frame's failed-boundary set. The frame is the ambient one (a
-  `frame-provider` / `frame-root` scope, or a `with-frame` binding); no
-  scope at all reads as no recorded outcome and renders `body`."
+  page's failed-boundary record (`failed-boundaries`, written at stream
+  finalization). No recorded outcome — a plain client mount, a
+  non-streamed page — renders `body`."
   [attrs & body]
   (when-not (valid-attrs? attrs)
     (reject-attrs! attrs))
@@ -156,11 +232,8 @@
        (into [:rf/suspense-boundary {:id id :fallback fallback}] body)
 
        :cljs
-       ;; `resolve-current-frame` is a READER — nil when no scope is
-       ;; established, never a synthesised `:rf/default` and never a
-       ;; throw. Absence is the plain-client-mount case: render the body.
-       (if-let [f (frame/resolve-current-frame)]
-         (if (contains? (failed-boundaries (frame/frame-value->id f)) id)
-           fallback
-           (subtree body))
+       ;; Frame-free by necessity (see the render-time record above). An
+       ;; unrecorded id is the ordinary case and renders the body.
+       (if (contains? (failed-boundaries) id)
+         fallback
          (subtree body)))))

--- a/implementation/ssr/test/re_frame/ssr/streaming_component_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/streaming_component_cljs_test.cljc
@@ -1,0 +1,231 @@
+(ns re-frame.ssr.streaming-component-cljs-test
+  "Cross-host contract for the suspense COMPONENT
+  (`re-frame.ssr.boundary/boundary`) and the failed-boundary set it reads
+  (rf2-ycz3k; rf2-j81hs ruling SS2 + SS3). Per Spec 011 §Streaming SSR.
+
+  Runs on BOTH hosts, which is the point: the component's whole reason to
+  exist is that ONE authoring form has to work on the JVM streaming
+  emitter and on every client substrate. The `:clj` half proves the
+  expansion-to-marker and the walker's deferral; the `:cljs` half proves
+  the body/fallback render and the failed-set read; the host-neutral half
+  proves the attrs contract and — load-bearing — that both hosts hash the
+  SAME tree.
+
+  The DOM lifecycle (finalization, mount unwrapping, readiness, and the
+  real `hydrateRoot` reconciliation) is covered by
+  `re-frame.ssr.streaming-hydration-lifecycle-dom-cljs-test`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.boundary :as boundary :refer [boundary]]
+            [re-frame.ssr.install :as install]
+            [re-frame.test-support :as test-support]
+            #?(:cljs [re-frame.adapter.reagent-slim :as reagent-slim-adapter])))
+
+;; `installed-payloads` is a process-global `defonce` ledger that neither
+;; `clear-all!` nor a frames reset touches — reset it so nothing this
+;; suite does can leak into a sibling.
+;;
+;; A plain FN fixture, deliberately: `clojure.test` has no map-fixture
+;; support, and a map is `IFn` (key lookup), so a `{:before …}` fixture
+;; on the JVM composes to a fn that returns nil WITHOUT calling the test
+;; — the whole namespace then reports "Ran 0 tests" and reads as GREEN.
+;; This suite hit exactly that while being written. `:async?` is left
+;; unset so `make-reset-runtime-fixture` also returns its fn form.
+(use-fixtures :each
+  (fn [f] (install/reset-installed-payloads!) (f))
+  (test-support/make-reset-runtime-fixture
+    {:adapter #?(:clj ssr/adapter :cljs reagent-slim-adapter/adapter)
+     :ambient-frame nil}))
+
+(defn- card-skeleton [id]
+  [:div.card.skeleton [:h3 (str "Loading " (name id))]])
+
+(defn- card-view [id]
+  (let [c @(rf/subscribe [:card/by-id id])]
+    [:div.card [:h3 (:title c)] [:p.value (str (:value c))]]))
+
+(defn- throwing-card []
+  (throw (ex-info "flaky third-party metric service" {})))
+
+;; ---- host-neutral contract -------------------------------------------------
+
+(deftest attrs-are-required-on-every-host
+  (testing "a missing :id or :fallback raises the SAME error id the shell
+            walker raises, so the mistake reads identically whichever
+            host catches it first"
+    (doseq [bad [{} {:id :a} {:fallback [:p]} nil "nope"]]
+      (is (thrown? #?(:clj Exception :cljs :default)
+                   (apply boundary [bad [:p "body"]]))
+          (str "expected a throw for attrs " (pr-str bad))))))
+
+(deftest the-failed-set-path-is-under-the-reserved-ssr-key
+  (testing "the slot lives under the already-reserved :rf.runtime/ssr
+            runtime-db key, a sibling of the :hydration metadata"
+    (is (= :rf.runtime/ssr (first boundary/failed-boundaries-path)))
+    (is (= [:rf.runtime/ssr :streaming :failed-boundaries]
+           boundary/failed-boundaries-path))))
+
+(deftest failed-boundaries-reads-empty-for-an-unknown-frame
+  (testing "never throws for an absent / destroyed frame — absence is the
+            ordinary no-recorded-outcome case, not an error"
+    (is (= #{} (boundary/failed-boundaries :no/such-frame)))))
+
+;; ---- server host -----------------------------------------------------------
+
+#?(:clj
+   (deftest component-expands-to-the-internal-wire-marker
+     (testing "on the JVM the component IS the marker — the keyword head
+               stays internal syntax between component and walker"
+       (is (= [:rf/suspense-boundary
+               {:id :card.revenue :fallback [:p "loading"]}
+               [:div "body"]]
+              (boundary {:id :card.revenue :fallback [:p "loading"]}
+                        [:div "body"])))
+       (testing "only the two contract keys reach the walker"
+         (is (= {:id :a :fallback [:p]}
+                (second (boundary {:id :a :fallback [:p] :stray "dropped"}
+                                  [:div]))))))))
+
+#?(:clj
+   (deftest shell-walk-defers-a-component-boundary
+     (testing "the shell walker resolves the callable head, sees the
+               marker it expands to, and registers a continuation —
+               the walker protocol is unchanged"
+       (let [fid :test/shell-walk]
+         (rf/reg-sub :card/by-id (fn [db [_ id]] (get-in db [:cards id])))
+         (rf/reg-event :server-init {:platforms #{:server}}
+           (fn [_ _] {:db {:cards {:revenue {:title "Revenue" :value 42375}}}}))
+         (rf/make-frame {:id fid :platform :server :initial-events [[:server-init]]})
+         (let [tree  [:section.cards
+                      [boundary {:id :card.revenue :fallback [card-skeleton :revenue]}
+                       [card-view :revenue]]]
+               {:keys [shell-html continuations]}
+               (rf/with-frame fid (ssr/streaming-render-shell tree))]
+           (is (= 1 (count continuations)))
+           (is (= :card.revenue (:id (first continuations))))
+           (is (clojure.string/includes? shell-html "data-rf2-suspense-fallback=\"1\"")
+               "the fallback ships inline as a <template> placeholder")
+           (is (clojure.string/includes? shell-html "Loading revenue")
+               "the DECLARED fallback is what the shell paints")
+           (is (not (clojure.string/includes? shell-html "suspense-boundary"))
+               "no phantom element — the marker never reaches the tag grammar")
+           (testing "draining the continuation renders the deferred body"
+             (let [{:keys [html failed?]}
+                   (rf/with-frame fid
+                     (ssr/streaming-render-continuation fid (first continuations)))]
+               (is (false? failed?))
+               (is (clojure.string/includes? html "42375")))))))))
+
+#?(:clj
+   (deftest failed-continuations-ride-the-final-payloads-runtime-slice
+     (testing "SS3: the server has always known :failed? per continuation
+               and DROPPED it; it now rides the serialisable runtime slice
+               so the client can render the declared fallback"
+       (let [fid :test/failed-payload]
+         (rf/reg-sub :card/by-id (fn [db [_ id]] (get-in db [:cards id])))
+         (rf/make-frame {:id fid :platform :server})
+         (let [tree      [:section.cards
+                          [boundary {:id :card.flaky :fallback [card-skeleton :flaky]}
+                           [throwing-card]]]
+               {:keys [continuations]} (rf/with-frame fid (ssr/streaming-render-shell tree))
+               outcomes  (mapv #(rf/with-frame fid (ssr/streaming-render-continuation fid %))
+                               continuations)
+               failed    (into #{} (comp (filter :failed?) (map :id)) outcomes)]
+           (is (= #{:card.flaky} failed) "the drain reports the failure")
+           (testing "the set lands in the payload's runtime-db slice"
+             (let [payload (rf/with-frame fid
+                             (ssr/streaming-build-final-payload
+                               fid "deadbeef"
+                               {:version 1
+                                :payload :rf.ssr.payload/whole-app-db
+                                :failed-boundaries failed}))]
+               (is (= #{:card.flaky}
+                      (get-in (:rf/runtime-db payload) boundary/failed-boundaries-path)))))
+           (testing "nothing failed contributes NO key — an ordinary page
+                     carries nothing extra on the wire"
+             (let [payload (rf/with-frame fid
+                             (ssr/streaming-build-final-payload
+                               fid "deadbeef"
+                               {:version 1
+                                :payload :rf.ssr.payload/whole-app-db
+                                :failed-boundaries #{}}))]
+               (is (nil? (get-in (:rf/runtime-db payload) boundary/failed-boundaries-path))))))))))
+
+#?(:clj
+   (deftest one-tree-hashes-identically-for-both-hosts
+     (testing "the component canonicalises to the existing #fn[] token, so
+               the render-tree hash of the SHARED tree is stable — the
+               property a reader-conditional card-slot could never have
+               (it made the two hosts hash structurally different trees)"
+       (let [fid :test/hash]
+         (rf/make-frame {:id fid :platform :server})
+         (let [tree [:section.cards
+                     [boundary {:id :card.revenue :fallback [card-skeleton :revenue]}
+                      [card-view :revenue]]]
+               h1   (rf/with-frame fid (ssr/render-tree-hash tree))
+               h2   (rf/with-frame fid (ssr/render-tree-hash tree))]
+           (is (string? h1))
+           (is (= h1 h2) "hashing is deterministic over the component head")
+           (testing "a DIFFERENT boundary id changes the hash (the hash is
+                     not blind to the component's attrs)"
+             (let [other [:section.cards
+                          [boundary {:id :card.other :fallback [card-skeleton :revenue]}
+                           [card-view :revenue]]]]
+               (is (not= h1 (rf/with-frame fid (ssr/render-tree-hash other)))))))))))
+
+;; ---- client host -----------------------------------------------------------
+
+#?(:cljs
+   (deftest client-renders-the-body-when-nothing-failed
+     (testing "the ordinary case: no recorded outcome, render the body"
+       (let [fid :test/client-body]
+         (rf/make-frame {:id fid :platform :client})
+         (is (= [:div "body"]
+                (rf/with-frame fid
+                  (boundary {:id :card.revenue :fallback [:p "loading"]}
+                            [:div "body"]))))))))
+
+#?(:cljs
+   (deftest client-renders-the-declared-fallback-for-a-failed-boundary
+     (testing "SS2: a boundary in the failed set renders its DECLARED
+               fallback — the markup the failed chunk left in the DOM"
+       (let [fid :test/client-failed]
+         (rf/make-frame {:id fid :platform :client})
+         (rf/dispatch-sync
+           [:rf/hydrate {:rf/version 1
+                         :rf/app-db  {}
+                         :rf/runtime-db (assoc-in {} boundary/failed-boundaries-path
+                                                  #{:card.flaky})}]
+           {:frame fid})
+         (is (= #{:card.flaky} (boundary/failed-boundaries fid)))
+         (rf/with-frame fid
+           (is (= [:p "loading"]
+                  (boundary {:id :card.flaky :fallback [:p "loading"]} [:div "body"]))
+               "the failed boundary renders its fallback")
+           (is (= [:div "body"]
+                  (boundary {:id :card.revenue :fallback [:p "loading"]} [:div "body"]))
+               "a sibling that resolved still renders its body"))))))
+
+#?(:cljs
+   (deftest client-renders-the-body-with-no-frame-scope
+     (testing "no ambient frame at all reads as no recorded outcome — a
+               plain client mount renders the body rather than throwing"
+       (is (= [:div "body"]
+              (boundary {:id :card.revenue :fallback [:p "loading"]}
+                        [:div "body"]))))))
+
+#?(:cljs
+   (deftest client-wraps-multiple-children-in-a-fragment
+     (testing "mirrors the walker's continuation-subtree construction, so
+               the client's rendered structure matches the server's
+               resolved-subtree html exactly (a fragment emits no DOM)"
+       (let [fid :test/client-multi]
+         (rf/make-frame {:id fid :platform :client})
+         (rf/with-frame fid
+           (is (= [:div "one"]
+                  (boundary {:id :b :fallback [:p]} [:div "one"]))
+               "a lone child renders as itself — no wrapper")
+           (is (= [:<> [:div "one"] [:div "two"]]
+                  (boundary {:id :b :fallback [:p]} [:div "one"] [:div "two"]))
+               "several children are spliced into a fragment"))))))

--- a/implementation/ssr/test/re_frame/ssr/streaming_component_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/streaming_component_cljs_test.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.ssr.streaming-component-cljs-test
   "Cross-host contract for the suspense COMPONENT
-  (`re-frame.ssr.boundary/boundary`) and the failed-boundary set it reads
+  (`re-frame.ssr.suspense/boundary`) and the failed-boundary set it reads
   (rf2-ycz3k; rf2-j81hs ruling SS2 + SS3). Per Spec 011 §Streaming SSR.
 
   Runs on BOTH hosts, which is the point: the component's whole reason to
@@ -17,7 +17,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.ssr :as ssr]
-            [re-frame.ssr.boundary :as boundary :refer [boundary]]
+            [re-frame.ssr.suspense :as suspense :refer [boundary]]
             [re-frame.ssr.install :as install]
             [re-frame.test-support :as test-support]
             #?(:cljs [re-frame.adapter.reagent-slim :as reagent-slim-adapter])))
@@ -33,7 +33,10 @@
 ;; This suite hit exactly that while being written. `:async?` is left
 ;; unset so `make-reset-runtime-fixture` also returns its fn form.
 (use-fixtures :each
-  (fn [f] (install/reset-installed-payloads!) (f))
+  (fn [f]
+    (install/reset-installed-payloads!)
+    (suspense/reset-failed-boundaries!)
+    (f))
   (test-support/make-reset-runtime-fixture
     {:adapter #?(:clj ssr/adapter :cljs reagent-slim-adapter/adapter)
      :ambient-frame nil}))
@@ -62,14 +65,14 @@
 (deftest the-failed-set-path-is-under-the-reserved-ssr-key
   (testing "the slot lives under the already-reserved :rf.runtime/ssr
             runtime-db key, a sibling of the :hydration metadata"
-    (is (= :rf.runtime/ssr (first boundary/failed-boundaries-path)))
+    (is (= :rf.runtime/ssr (first suspense/failed-boundaries-path)))
     (is (= [:rf.runtime/ssr :streaming :failed-boundaries]
-           boundary/failed-boundaries-path))))
+           suspense/failed-boundaries-path))))
 
-(deftest failed-boundaries-reads-empty-for-an-unknown-frame
+(deftest frame-failed-boundaries-reads-empty-for-an-unknown-frame
   (testing "never throws for an absent / destroyed frame — absence is the
             ordinary no-recorded-outcome case, not an error"
-    (is (= #{} (boundary/failed-boundaries :no/such-frame)))))
+    (is (= #{} (suspense/frame-failed-boundaries :no/such-frame)))))
 
 ;; ---- server host -----------------------------------------------------------
 
@@ -141,7 +144,7 @@
                                 :payload :rf.ssr.payload/whole-app-db
                                 :failed-boundaries failed}))]
                (is (= #{:card.flaky}
-                      (get-in (:rf/runtime-db payload) boundary/failed-boundaries-path)))))
+                      (get-in (:rf/runtime-db payload) suspense/failed-boundaries-path)))))
            (testing "nothing failed contributes NO key — an ordinary page
                      carries nothing extra on the wire"
              (let [payload (rf/with-frame fid
@@ -150,7 +153,7 @@
                                {:version 1
                                 :payload :rf.ssr.payload/whole-app-db
                                 :failed-boundaries #{}}))]
-               (is (nil? (get-in (:rf/runtime-db payload) boundary/failed-boundaries-path))))))))))
+               (is (nil? (get-in (:rf/runtime-db payload) suspense/failed-boundaries-path))))))))))
 
 #?(:clj
    (deftest one-tree-hashes-identically-for-both-hosts
@@ -190,30 +193,40 @@
    (deftest client-renders-the-declared-fallback-for-a-failed-boundary
      (testing "SS2: a boundary in the failed set renders its DECLARED
                fallback — the markup the failed chunk left in the DOM"
-       (let [fid :test/client-failed]
+       (suspense/record-failed-boundaries! #{:card.flaky})
+       (is (= [:p "loading"]
+              (boundary {:id :card.flaky :fallback [:p "loading"]} [:div "body"]))
+           "the failed boundary renders its fallback")
+       (is (= [:div "body"]
+              (boundary {:id :card.revenue :fallback [:p "loading"]} [:div "body"]))
+           "a sibling that resolved still renders its body"))))
+
+#?(:cljs
+   (deftest the-render-time-record-needs-no-frame
+     (testing "`boundary` is a plain fn component, and on Reagent a plain
+               fn cannot read the enclosing provider's frame from React
+               context — so the render-time record is deliberately
+               frame-free and works with no scope established at all"
+       (suspense/record-failed-boundaries! #{:card.flaky})
+       (is (= [:p "loading"]
+              (boundary {:id :card.flaky :fallback [:p "loading"]} [:div "body"])))
+       (is (= [:div "body"]
+              (boundary {:id :card.revenue :fallback [:p "loading"]} [:div "body"]))))))
+
+#?(:cljs
+   (deftest the-durable-set-round-trips-through-hydration
+     (testing "SS3: the payload's runtime slice installs into the frame's
+               runtime-db — the durable, inspectable record (distinct from
+               the render-time one above)"
+       (let [fid :test/client-durable]
          (rf/make-frame {:id fid :platform :client})
          (rf/dispatch-sync
            [:rf/hydrate {:rf/version 1
                          :rf/app-db  {}
-                         :rf/runtime-db (assoc-in {} boundary/failed-boundaries-path
+                         :rf/runtime-db (assoc-in {} suspense/failed-boundaries-path
                                                   #{:card.flaky})}]
            {:frame fid})
-         (is (= #{:card.flaky} (boundary/failed-boundaries fid)))
-         (rf/with-frame fid
-           (is (= [:p "loading"]
-                  (boundary {:id :card.flaky :fallback [:p "loading"]} [:div "body"]))
-               "the failed boundary renders its fallback")
-           (is (= [:div "body"]
-                  (boundary {:id :card.revenue :fallback [:p "loading"]} [:div "body"]))
-               "a sibling that resolved still renders its body"))))))
-
-#?(:cljs
-   (deftest client-renders-the-body-with-no-frame-scope
-     (testing "no ambient frame at all reads as no recorded outcome — a
-               plain client mount renders the body rather than throwing"
-       (is (= [:div "body"]
-              (boundary {:id :card.revenue :fallback [:p "loading"]}
-                        [:div "body"]))))))
+         (is (= #{:card.flaky} (suspense/frame-failed-boundaries fid)))))))
 
 #?(:cljs
    (deftest client-wraps-multiple-children-in-a-fragment

--- a/implementation/ssr/test/re_frame/ssr/streaming_hydration_lifecycle_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/streaming_hydration_lifecycle_dom_cljs_test.cljs
@@ -50,18 +50,23 @@
   early under Node where `js/document` is absent."
   (:require [clojure.string :as str]
             [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            ["react" :as React]
             ["react-dom/client" :as react-dom-client]
             [reagent2.core :as r2]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
             [re-frame.ssr :as ssr]
-            [re-frame.ssr.boundary :as boundary :refer [boundary]]
+            [re-frame.ssr.suspense :as suspense :refer [boundary]]
             [re-frame.ssr.constants :as constants]
             [re-frame.ssr.install :as install]
             [re-frame.ssr.streaming.constants :as wire]
             [re-frame.ssr.streaming.client :as streaming-client]
-            [re-frame.test-support :as test-support]))
+            [re-frame.test-support :as test-support]
+            ;; Publishes the React-context tier `frame-provider` resolves
+            ;; through. Without it the provider renders nothing and every
+            ;; assertion below would read an empty container.
+            [re-frame.views]))
 
 ;; `installed-payloads` is a process-global `defonce` ledger keyed by
 ;; payload id — a table `clear-all!` and a `frame/frames` reset do NOT
@@ -69,8 +74,13 @@
 ;; into siblings. These tests hydrate through `ssr/hydrate!` rather than
 ;; the root-manifest install path, but the reset is cheap and keeps the
 ;; suite honest if that ever changes.
+;; `re-frame.ssr.suspense`'s failed-boundary record is a second such
+;; table — process-global, additive, and read by every `boundary` render
+;; on the page. A test that streams a failure MUST clear it.
 (use-fixtures :each
-  {:before (fn [] (install/reset-installed-payloads!))}
+  {:before (fn []
+             (install/reset-installed-payloads!)
+             (suspense/reset-failed-boundaries!))}
   (test-support/make-reset-runtime-fixture
     {:adapter reagent-slim-adapter/adapter :async? true :ambient-frame nil}))
 
@@ -86,57 +96,123 @@
 
 (defn- register-app! [_frame-id]
   (rf/reg-sub :card/by-id (fn [db [_ id]] (get-in db [:cards id])))
+  (rf/reg-event :test/seed (fn [_ _] {:db {:cards {:revenue {:title "Revenue" :value 42375}}}}))
   nil)
 
-(defn- card-skeleton [card-id]
+;; `reg-view`, not plain fns: a registered view is what carries the frame
+;; stamp down from the enclosing `frame-provider` (Spec 006 §Lookup
+;; algorithm — the React-context tier resolves through the reg-view
+;; wrapper). A plain fn that subscribes raises `:rf.error/no-frame-context`
+;; under a provider, which is exactly what the first draft of this suite
+;; did. The `boundary` component itself stays a plain fn and needs no
+;; wrapper: it runs inside the enclosing registered view's scope.
+(rf/reg-view ^{:rf/id :test.dash/card-skeleton} card-skeleton [card-id]
   [:div.card.skeleton [:h3 (str "Loading " (name card-id))]])
 
-(defn- card-view [card-id]
+(rf/reg-view ^{:rf/id :test.dash/card} card-view [card-id]
   (let [c @(rf/subscribe [:card/by-id card-id])]
     [:div.card
      [:h3 (:title c)]
      [:p.value (str (:value c))]]))
 
+;; The card that fails on purpose. It is only ever INVOKED on the server,
+;; inside its continuation drain — the client's boundary short-circuits to
+;; the declared fallback for a failed id and never calls it. That is the
+;; whole point: one tree, and the failure is a server-side fact the client
+;; is told about rather than something it has to re-discover.
+(rf/reg-view ^{:rf/id :test.dash/throwing-card} throwing-card []
+  (throw (ex-info "flaky third-party metric service" {})))
+
+;; The CLIENT tree — what the browser renders. A plain fn, deliberately:
+;; `reg-view` stamps dev-time `data-rf-view` / `data-rf2-source-coord`
+;; attributes on its root element, and the two trees below must agree on
+;; `<main>` exactly. The leaves ARE reg-views (they subscribe, and they
+;; carry the frame), and the emitter stamps them identically on both
+;; hosts — that parity is what `source_coord_parity_test` pins.
 (defn- dashboard []
   [:main.dashboard
    [:section.cards
     [boundary {:id :card.revenue :fallback [card-skeleton :revenue]}
      [card-view :revenue]]
     [boundary {:id :card.flaky :fallback [card-skeleton :flaky]}
-     [card-view :flaky]]]])
+     [throwing-card]]]])
 
-;; ---- the wire (authored through the SHIPPED server façade fns) -------------
+;; The SERVER tree — the same page, spelled with the internal
+;; `:rf/suspense-boundary` wire marker that `boundary`'s `:clj` branch
+;; expands to. It has to be written out here because this test runs on
+;; CLJS, where the component takes its CLIENT branch and so can never
+;; produce the marker: the shell walker would walk straight into the
+;; throwing body. That the two spellings correspond is not assumed —
+;; `streaming_component_cljs_test/component-expands-to-the-internal-wire-marker`
+;; pins the expansion on the JVM, where it actually happens.
+(defn- server-dashboard []
+  [:main.dashboard
+   [:section.cards
+    [:rf/suspense-boundary {:id :card.revenue :fallback [card-skeleton :revenue]}
+     [card-view :revenue]]
+    [:rf/suspense-boundary {:id :card.flaky :fallback [card-skeleton :flaky]}
+     [throwing-card]]]])
+
+;; ---- the wire (EMITTED, not transcribed) ----------------------------------
 ;;
-;; The JVM shell walker is `.cljc` but registry-and-frame bound, so the
-;; chunk bytes here are assembled from the same façade fns the Ring writer
-;; thread flushes — `ssr/streaming-{fallback,resolved,failed}-template` and
-;; `ssr/streaming-hydrate-delta-script`. The HTML they produce is pinned
-;; against the real JVM emitter by the cross-host suite
-;; (`streaming_component_cljs_test`) and the JVM streaming tests.
+;; The server HTML below is produced by the SHIPPED emitter
+;; (`ssr/render-to-string`, which is `.cljc` and runs here) over the SAME
+;; hiccup the client tree renders, then wrapped in the chunk shapes the
+;; Ring writer thread flushes (`ssr/streaming-{fallback,resolved,failed}-
+;; template`, `ssr/streaming-hydrate-delta-script`).
+;;
+;; Hand-transcribing this markup was a mistake worth recording: a
+;; `reg-view` root carries dev-time `data-rf-view` / `data-rf2-source-coord`
+;; attributes that the emitter writes and a hand-written fixture cannot
+;; know (the coord embeds a LINE NUMBER). Hydration then failed on
+;; attributes rather than on anything the feature does. Emitting the
+;; fixture makes the test a genuine cross-host parity check: same hiccup,
+;; server render vs client render, reconciled by React.
 
-(def ^:private revenue-resolved-html
-  "<div class=\"card\"><h3>Revenue</h3><p class=\"value\">42375</p></div>")
+(def ^:private app-db-seed
+  {:cards {:revenue {:title "Revenue" :value 42375}}})
 
-(def ^:private flaky-fallback-html
-  "<div class=\"card skeleton\"><h3>Loading flaky</h3></div>")
+(defn- server-render!
+  "Run the REAL server pipeline over `[dashboard]` under a server frame:
+  the shell walker registers a continuation per boundary, then each is
+  drained. Returns the chunk bytes plus the failed set the drain
+  reported — everything a streaming host would flush, produced by the
+  shipped code rather than transcribed.
 
-(def ^:private revenue-fallback-html
-  "<div class=\"card skeleton\"><h3>Loading revenue</h3></div>")
+  Both halves are `.cljc`, so this runs here exactly as it does on the
+  JVM. The server frame is destroyed before returning; only bytes escape."
+  []
+  (let [fid :test/server-render]
+    (rf/make-frame {:id fid :platform :server})
+    (rf/dispatch-sync [:test/seed] {:frame fid})
+    (let [{:keys [shell-html continuations]}
+          (rf/with-frame fid (ssr/streaming-render-shell [server-dashboard]))
+          outcomes (mapv #(rf/with-frame fid (ssr/streaming-render-continuation fid %))
+                         continuations)
+          chunks   (mapv (fn [{:keys [id html delta failed?]}]
+                           (str (if failed?
+                                  (ssr/streaming-failed-template id html)
+                                  (ssr/streaming-resolved-template id html))
+                                (when (and (not failed?) (some? delta))
+                                  (ssr/streaming-hydrate-delta-script id (pr-str delta)))))
+                         outcomes)
+          failed   (into #{} (comp (filter :failed?) (map :id)) outcomes)]
+      (rf/destroy-frame! fid)
+      {:shell shell-html :chunks chunks :failed failed
+       :ids (mapv :id outcomes)})))
 
-(defn- shell-html []
-  (str "<main class=\"dashboard\"><section class=\"cards\">"
-       (ssr/streaming-fallback-template :card.revenue revenue-fallback-html)
-       (ssr/streaming-fallback-template :card.flaky flaky-fallback-html)
-       "</section></main>"))
-
-(defn- revenue-chunk []
-  (str (ssr/streaming-resolved-template :card.revenue revenue-resolved-html)
-       (ssr/streaming-hydrate-delta-script
-         :card.revenue (pr-str {:cards {:revenue {:title "Revenue" :value 42375}}}))))
-
-(defn- flaky-chunk []
-  ;; A FAILED continuation: fallback html, `data-rf2-suspense-failed`, no delta.
-  (ssr/streaming-failed-template :card.flaky flaky-fallback-html))
+(defn- finalised-html
+  "What the equivalent NON-streamed render produces for the same page:
+  the resolved card, and the failed boundary's declared fallback. This is
+  the shape the finalised streamed DOM must equal."
+  []
+  (let [fid :test/expected]
+    (rf/make-frame {:id fid :platform :server})
+    (rf/dispatch-sync [:test/seed] {:frame fid})
+    (suspense/record-failed-boundaries! #{:card.flaky})
+    (let [html (rf/with-frame fid (ssr/render-to-string [dashboard] nil))]
+      (rf/destroy-frame! fid)
+      html)))
 
 (defn- payload-chunk
   "The final `__rf_payload`. Its runtime-db slice carries the
@@ -150,14 +226,17 @@
                         :rf/render-hash "00000000"}
                  (seq failed)
                  (assoc :rf/runtime-db
-                        (assoc-in {} boundary/failed-boundaries-path (set failed)))))
+                        (assoc-in {} suspense/failed-boundaries-path (set failed)))))
        "</script>"))
 
 ;; ---- DOM scaffolding -------------------------------------------------------
 
-(defn- make-host! []
+(defn- make-host!
+  "A `#app` host seeded with the server's SHELL — the first bytes a
+  streamed page delivers."
+  [shell]
   (let [host (.createElement js/document "div")]
-    (set! (.-innerHTML host) (str "<div id=\"app\">" (shell-html) "</div>"))
+    (set! (.-innerHTML host) (str "<div id=\"app\">" shell "</div>"))
     (.appendChild (.-body js/document) host)
     host))
 
@@ -183,37 +262,72 @@
 
 ;; ---- the hydration harness -------------------------------------------------
 
+(defn- get-act
+  "React's `act` — the only way to make a concurrent root commit
+  SYNCHRONOUSLY. Without it `hydrateRoot` returns before React has
+  touched the DOM and every assertion races the scheduler."
+  []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try (.-act (js/require "react-dom/test-utils"))
+           (catch :default _ nil))))
+
 (defn- hydrate-capturing!
-  "Hydrate `container` against `tree` by calling React's `hydrateRoot`
-  DIRECTLY, with our own options object carrying `onRecoverableError`.
+  "Hydrate `container` against `tree` with REAL React and report
+  everything React said about it.
 
-  Returns `{:root <React root> :errors (atom [...])}`. Every recoverable
-  error React reports — hydration mismatches among them — lands in
-  `:errors`. Nothing between us and React can drop the option, because
-  we build the options object here.
+  Returns `{:complaints [str …] :html \"…\"}`.
 
-  `r2/as-element` is used only to turn hiccup into a React element; it
-  is not a hydration wrapper and never sees the options object."
+  Two deliberate choices:
+
+    - React's `hydrateRoot` is called DIRECTLY, with an options object we
+      construct here, so nothing between us and React can drop
+      `onRecoverableError`. (`r2/as-element` only builds the element
+      tree; it never sees the options.)
+    - React ALSO reports mismatches through `console.error`, so both
+      `error` and `warn` are captured for the duration and restored
+      after — a mismatch that arrives on the console rather than the
+      callback is still heard.
+
+  The hydrate runs inside `act` so the commit completes before we read
+  the DOM."
   [container tree]
-  (let [errors (atom [])
-        root   (react-dom-client/hydrateRoot
-                 container
-                 (r2/as-element tree)
-                 #js {:onRecoverableError (fn [err _info]
-                                            (swap! errors conj (str (.-message err) "")))})]
-    {:root root :errors errors}))
+  (let [complaints (atom [])
+        orig-error (.-error js/console)
+        orig-warn  (.-warn js/console)
+        record!    (fn [& args]
+                     (swap! complaints conj (str/join " " (map #(str %) args))))
+        act-fn     (get-act)
+        root       (atom nil)]
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (set! (.-error js/console) record!)
+    (set! (.-warn js/console) record!)
+    (try
+      (act-fn
+        (fn []
+          (reset! root
+                  (react-dom-client/hydrateRoot
+                    container
+                    (r2/as-element tree)
+                    #js {:onRecoverableError
+                         (fn [err _info] (record! "onRecoverableError" err))}))))
+      (let [html (.-innerHTML container)]
+        (act-fn (fn [] (some-> @root .unmount)))
+        {:complaints @complaints :html html})
+      (finally
+        (set! (.-error js/console) orig-error)
+        (set! (.-warn js/console) orig-warn)))))
 
-(defn- mismatch-errors
-  "Only the hydration-mismatch reports. React phrases them variously
-  across builds ('Hydration failed', 'did not match', 'server rendered
-  HTML didn't match'), so match on the stable substrings rather than one
-  exact sentence."
-  [errors]
-  (filterv #(or (str/includes? % "Hydration")
-                (str/includes? % "hydration")
-                (str/includes? % "did not match")
-                (str/includes? % "didn't match"))
-           @errors))
+(defn- hydration-complaints
+  "Only the complaints that are about HYDRATION. React emits unrelated
+  development warnings, and counting those would make the green case
+  flaky and the red case dishonest."
+  [complaints]
+  (filterv #(let [s (str/lower-case %)]
+              (or (str/includes? s "hydrat")
+                  (str/includes? s "did not match")
+                  (str/includes? s "didn't match")
+                  (str/includes? s "server rendered")))
+           complaints))
 
 ;; ---- tests -----------------------------------------------------------------
 
@@ -222,23 +336,17 @@
             this, every no-mismatch assertion below would be vacuous"
     (if-not (browser?)
       (is true "skipped under node — no js/document")
-      (let [host      (.createElement js/document "div")
-            _         (.appendChild (.-body js/document) host)
-            ;; Server painted a <span>; the client tree says <div>. React
-            ;; must report a recoverable hydration error.
-            _         (set! (.-innerHTML host) "<span>server</span>")
-            {:keys [errors root]} (hydrate-capturing! host [:div "client"])]
-        (async done
-          (js/setTimeout
-            (fn []
-              (is (seq (mismatch-errors errors))
-                  (str "EXPECTED the harness to capture a hydration mismatch on "
-                       "known-bad HTML; captured: " (pr-str @errors) ". "
-                       "A harness that captures nothing here proves nothing anywhere."))
-              (.unmount root)
-              (remove-host! host)
-              (done))
-            60))))))
+      (let [host (.createElement js/document "div")]
+        (.appendChild (.-body js/document) host)
+        ;; Server painted a <span>; the client tree says <div>. React must
+        ;; report a recoverable hydration error.
+        (set! (.-innerHTML host) "<span>server</span>")
+        (let [{:keys [complaints]} (hydrate-capturing! host [:div "client"])]
+          (is (seq (hydration-complaints complaints))
+              (str "EXPECTED the harness to capture a hydration mismatch on "
+                   "known-bad HTML; captured: " (pr-str complaints) ". "
+                   "A harness that captures nothing here proves nothing anywhere."))
+          (remove-host! host))))))
 
 (deftest streamed-page-hydrates-without-structural-mismatch
   (testing "rf2-o4rbh: a genuinely staggered stream, finalised, hydrates
@@ -246,28 +354,39 @@
     (if-not (browser?)
       (is true "skipped under node — no js/document")
       (let [frame-id :test/streamed
-            host     (make-host!)
+            _        (do (rf/make-frame {:id frame-id :platform :client})
+                         (register-app! frame-id))
+            ;; The REAL server pipeline: shell walk + continuation drain.
+            {:keys [shell chunks failed ids]} (server-render!)
+            host     (make-host! shell)
             ready    (atom nil)]
-        (rf/make-frame {:id frame-id :platform :client})
-        (register-app! frame-id)
+        (is (= [:card.revenue :card.flaky] ids)
+            "the shell walk registered both boundaries in document order")
+        (is (= #{:card.flaky} failed)
+            "the drain reported the throwing boundary as failed")
         (streaming-client/install!
           {:frame frame-id :root host :on-ready #(reset! ready %)})
         ;; Fallbacks are now LIVE mounts — the page paints its skeletons.
         (is (= 2 (count (mounts host)))
             "install materialises each inert fallback template into a visible mount")
         (is (nil? @ready) "not ready until the final payload lands")
-        ;; Stagger the stream: one resolved chunk, one failed chunk, then
-        ;; the payload — each in its own observer batch.
-        (append-chunk! host (revenue-chunk))
+        ;; Stagger the stream: the resolved chunk, then the failed chunk,
+        ;; then the payload — each in its own observer batch.
+        (append-chunk! host (first chunks))
         (async done
           (js/setTimeout
             (fn []
-              (append-chunk! host (flaky-chunk))
+              (append-chunk! host (second chunks))
               (js/setTimeout
                 (fn []
-                  (append-chunk! host (payload-chunk #{:card.flaky}))
+                  (append-chunk! host (payload-chunk failed))
                   (js/setTimeout
+                    ;; Guarded: a throw inside a `setTimeout` callback is an
+                    ;; UNCAUGHT page error that aborts the whole browser
+                    ;; suite rather than failing this test. Surface it as a
+                    ;; normal failure and let the run continue.
                     (fn []
+                     (try
                       ;; --- FINALIZATION ---
                       (is (some? @ready) ":on-ready fired when the payload landed")
                       (is (= #{:card.revenue} (:resolved @ready)))
@@ -281,18 +400,34 @@
                       (is (some? (.querySelector host "section.cards > div.card"))
                           "resolved content sits where the client tree puts it")
                       ;; --- HYDRATION ---
-                      (rf/dispatch-sync [:rf/hydrate (ssr/read-server-payload)] {:frame frame-id})
+                      ;; The public boot path: read `__rf_payload`, validate
+                      ;; it, dispatch `:rf/hydrate` into the explicit frame.
+                      ;; State only — it never touches the DOM.
+                      (is (some? (ssr/hydrate! {:frame frame-id}))
+                          "the final payload is readable and hydrates the frame")
                       (let [tree [rf/frame-provider {:frame frame-id} [dashboard]]
-                            {:keys [errors root]} (hydrate-capturing! (app-el host) tree)]
-                        (js/setTimeout
-                          (fn []
-                            (is (empty? (mismatch-errors errors))
-                                (str "hydrateRoot must reconcile the finalised streamed DOM "
-                                     "with no structural mismatch; got: " (pr-str @errors)))
-                            (.unmount root)
-                            (remove-host! host)
-                            (done))
-                          80)))
+                            {:keys [complaints html]} (hydrate-capturing! (app-el host) tree)]
+                        (is (empty? (hydration-complaints complaints))
+                            (str "hydrateRoot must reconcile the finalised streamed DOM "
+                                 "with no structural mismatch; got: " (pr-str complaints)))
+                        ;; NON-VACUITY: a client tree that rendered NOTHING
+                        ;; would ALSO report no mismatch — React would simply
+                        ;; drop the server DOM and be done. Assert the content
+                        ;; SURVIVED hydration; that is what proves the two
+                        ;; trees actually agreed. (This assertion caught the
+                        ;; first version of this suite rendering an empty
+                        ;; tree and passing.)
+                        (is (str/includes? html "42375")
+                            "the resolved card survives hydration — React adopted the server DOM rather than discarding it")
+                        (is (str/includes? html "Loading flaky")
+                            "the failed boundary's declared fallback survives hydration")
+                        (is (not (str/includes? html "rf-suspense"))
+                            "no protocol DOM in the hydrated tree"))
+                      (catch :default t
+                        (is false (str "threw during finalization/hydration: " t)))
+                      (finally
+                        (remove-host! host)
+                        (done))))
                     40))
                 40))
             40))))))
@@ -306,36 +441,38 @@
       (let [frame-id :test/failed-fallback]
         (rf/make-frame {:id frame-id :platform :client})
         (register-app! frame-id)
-        ;; Seed the frame's runtime-db the way :rf/hydrate would.
         (rf/dispatch-sync
           [:rf/hydrate {:rf/version 1
                         :rf/app-db  {:cards {:revenue {:title "Revenue" :value 42375}}}
-                        :rf/runtime-db (assoc-in {} boundary/failed-boundaries-path
+                        :rf/runtime-db (assoc-in {} suspense/failed-boundaries-path
                                                  #{:card.flaky})}]
           {:frame frame-id})
-        (is (= #{:card.flaky} (boundary/failed-boundaries frame-id))
-            "the failed set survives the hydration round-trip into runtime-db")
+        (is (= #{:card.flaky} (suspense/frame-failed-boundaries frame-id))
+            "the DURABLE set survives the hydration round-trip into runtime-db")
+        ;; The RENDER-TIME record — what the component consults. On a real
+        ;; page the streaming client writes this at finalization; here we
+        ;; stand in for it directly.
+        (suspense/record-failed-boundaries! #{:card.flaky})
+        ;; Hydrate the SAME tree against the markup the finalised stream
+        ;; leaves behind — which is, by construction, what the equivalent
+        ;; non-streamed render of the same tree produces.
         (let [host (.createElement js/document "div")]
           (.appendChild (.-body js/document) host)
-          (let [root (react-dom-client/createRoot host)]
-            (.render root (r2/as-element
-                            [rf/frame-provider {:frame frame-id} [dashboard]]))
-            (async done
-              (js/setTimeout
-                (fn []
-                  (let [html (.-innerHTML host)]
-                    (is (str/includes? html "Loading flaky")
-                        "the FAILED boundary renders its declared fallback")
-                    (is (str/includes? html "42375")
-                        "the resolved boundary renders its body")
-                    (is (not (str/includes? html "suspense-boundary"))
-                        "no phantom <suspense-boundary> element — the component is not a keyword head")
-                    (is (not (str/includes? html "rf-suspense"))
-                        "the component renders no protocol DOM of its own"))
-                  (.unmount root)
-                  (remove-host! host)
-                  (done))
-                60))))))))
+          (set! (.-innerHTML host) (finalised-html))
+          (let [tree [rf/frame-provider {:frame frame-id} [dashboard]]
+                {:keys [complaints html]} (hydrate-capturing! host tree)]
+            (is (str/includes? html "Loading flaky")
+                "the FAILED boundary renders its declared fallback")
+            (is (str/includes? html "42375")
+                "the resolved boundary renders its body")
+            (is (not (str/includes? html "suspense-boundary"))
+                "no phantom <suspense-boundary> element — the component is not a keyword head")
+            (is (not (str/includes? html "rf-suspense"))
+                "the component renders no protocol DOM of its own")
+            (is (empty? (hydration-complaints complaints))
+                (str "the component's client render matches the markup the "
+                     "server painted for a failed boundary; got: " (pr-str complaints)))
+            (remove-host! host)))))))
 
 (deftest finalization-unwraps-mounts-preserving-children
   (testing "unwrapping splices the mount's children into its position,
@@ -343,23 +480,23 @@
     (if-not (browser?)
       (is true "skipped under node — no js/document")
       (let [frame-id :test/unwrap
-            host     (make-host!)]
-        (rf/make-frame {:id frame-id :platform :client})
-        (register-app! frame-id)
+            _        (do (rf/make-frame {:id frame-id :platform :client})
+                         (register-app! frame-id))
+            {:keys [shell chunks failed]} (server-render!)
+            host     (make-host! shell)]
         (streaming-client/install! {:frame frame-id :root host})
-        (append-chunk! host (revenue-chunk))
-        (append-chunk! host (flaky-chunk))
+        (doseq [c chunks] (append-chunk! host c))
         (async done
           (js/setTimeout
             (fn []
-              (append-chunk! host (payload-chunk #{:card.flaky}))
+              (append-chunk! host (payload-chunk failed))
               (js/setTimeout
                 (fn []
-                  (is (= (normalise-html
-                           (str "<main class=\"dashboard\"><section class=\"cards\">"
-                                revenue-resolved-html
-                                flaky-fallback-html
-                                "</section></main>"))
+                  ;; The whole claim of the lifecycle, as one equality: a
+                  ;; streamed page, finalised, is byte-identical to the
+                  ;; equivalent non-streamed render of the same tree. That
+                  ;; is what makes ONE ordinary hydration correct.
+                  (is (= (normalise-html (finalised-html))
                          (normalise-html (.-innerHTML (app-el host))))
                       "the finalised DOM is exactly the non-streamed render of the same tree")
                   (remove-host! host)
@@ -374,14 +511,14 @@
     (if-not (browser?)
       (is true "skipped under node — no js/document")
       (let [frame-id :test/already-complete
-            host     (make-host!)
+            _        (do (rf/make-frame {:id frame-id :platform :client})
+                         (register-app! frame-id))
+            {:keys [shell chunks failed]} (server-render!)
+            host     (make-host! shell)
             calls    (atom 0)]
-        (rf/make-frame {:id frame-id :platform :client})
-        (register-app! frame-id)
         ;; Everything arrived before the bundle booted.
-        (append-chunk! host (revenue-chunk))
-        (append-chunk! host (flaky-chunk))
-        (append-chunk! host (payload-chunk #{:card.flaky}))
+        (doseq [c chunks] (append-chunk! host c))
+        (append-chunk! host (payload-chunk failed))
         (streaming-client/install!
           {:frame frame-id :root host :on-ready (fn [_] (swap! calls inc))})
         (is (= 1 @calls) ":on-ready fires synchronously during install!")
@@ -402,13 +539,14 @@
     (if-not (browser?)
       (is true "skipped under node — no js/document")
       (let [frame-id :test/pre-readiness
-            host     (make-host!)
+            _        (do (rf/make-frame {:id frame-id :platform :client})
+                         (register-app! frame-id))
+            {:keys [shell chunks]} (server-render!)
+            host     (make-host! shell)
             ready    (atom false)]
-        (rf/make-frame {:id frame-id :platform :client})
-        (register-app! frame-id)
         (streaming-client/install!
           {:frame frame-id :root host :on-ready (fn [_] (reset! ready true))})
-        (append-chunk! host (revenue-chunk))
+        (append-chunk! host (first chunks))
         (async done
           (js/setTimeout
             (fn []

--- a/implementation/ssr/test/re_frame/ssr/streaming_hydration_lifecycle_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/streaming_hydration_lifecycle_dom_cljs_test.cljs
@@ -1,0 +1,422 @@
+(ns re-frame.ssr.streaming-hydration-lifecycle-dom-cljs-test
+  "Acceptance coverage for the streaming READINESS + HYDRATION lifecycle
+  and the cross-host suspense COMPONENT (rf2-ycz3k, closing rf2-j81hs
+  SS2 + SS3). Per Spec 011 §Streaming SSR — client-side hydration
+  semantics.
+
+  ## The gap these tests close
+
+  rf2-o4rbh measured it by running it. On a genuinely streamed page
+  `install!` materialises each boundary's inert fallback `<template>`
+  into a LIVE `<rf-suspense data-rf2-suspense-mount>` wrapper — the
+  visible skeleton and the stable swap target. That wrapper is
+  client-invented protocol DOM: no render tree on any host can express
+  it. So the DOM at hydration time was
+
+      <section class=\"cards\"><rf-suspense …><div class=\"card\">…
+
+  while the client tree the author wrote describes
+
+      <section class=\"cards\"><div class=\"card\">…
+
+  and `hydrateRoot` saw a structural mismatch at every boundary, on a
+  page whose content was otherwise byte-correct. Spec 011 never said
+  what a client tree should contain at a boundary, which is why the
+  shipped example had nothing correct to copy.
+
+  The fix is two halves, and both are exercised here:
+
+    - FINALIZATION unwraps every mount before hydration, so the DOM is
+      exactly the tree the author's hiccup describes.
+    - The `boundary` COMPONENT is that hiccup — one `.cljc` form that
+      expands to the wire marker on the server and renders its body (or
+      its declared fallback, for a failed boundary) on the client.
+
+  ## Harness honesty — we drive React's `hydrateRoot` DIRECTLY
+
+  Hydration mismatches surface through React's `onRecoverableError`
+  callback, which must be passed to `hydrateRoot` in its options object.
+  A harness built on an adapter wrapper can silently drop that option
+  and then capture NOTHING — passing identically on broken and fixed
+  HTML, certifying a fix it never observed. So these tests call
+  `react-dom-client/hydrateRoot` themselves with their own options
+  object, and `harness-captures-a-known-bad-hydration` feeds the harness
+  deliberately-wrong HTML FIRST and asserts it reds. Every
+  no-mismatch assertion below is only worth what that probe proves.
+
+  Browser-only: `-dom-cljs-test$` opts this file into `:browser-test`;
+  `:node-test` loads it too (its `cljs-test$` regexp matches both
+  suffixes) and every DOM-dependent body gates on `(browser?)`, exiting
+  early under Node where `js/document` is absent."
+  (:require [clojure.string :as str]
+            [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            ["react-dom/client" :as react-dom-client]
+            [reagent2.core :as r2]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.boundary :as boundary :refer [boundary]]
+            [re-frame.ssr.constants :as constants]
+            [re-frame.ssr.install :as install]
+            [re-frame.ssr.streaming.constants :as wire]
+            [re-frame.ssr.streaming.client :as streaming-client]
+            [re-frame.test-support :as test-support]))
+
+;; `installed-payloads` is a process-global `defonce` ledger keyed by
+;; payload id — a table `clear-all!` and a `frame/frames` reset do NOT
+;; touch. Any suite that installs a payload must reset it or it leaks
+;; into siblings. These tests hydrate through `ssr/hydrate!` rather than
+;; the root-manifest install path, but the reset is cheap and keeps the
+;; suite honest if that ever changes.
+(use-fixtures :each
+  {:before (fn [] (install/reset-installed-payloads!))}
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-slim-adapter/adapter :async? true :ambient-frame nil}))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; ---- the application under test --------------------------------------------
+;;
+;; ONE tree, both hosts. No reader conditional, no `card-slot` two-programs
+;; split, and no defensive nil branch in the card view: the boundary that
+;; declared the fallback is the one that re-renders it.
+
+(defn- register-app! [_frame-id]
+  (rf/reg-sub :card/by-id (fn [db [_ id]] (get-in db [:cards id])))
+  nil)
+
+(defn- card-skeleton [card-id]
+  [:div.card.skeleton [:h3 (str "Loading " (name card-id))]])
+
+(defn- card-view [card-id]
+  (let [c @(rf/subscribe [:card/by-id card-id])]
+    [:div.card
+     [:h3 (:title c)]
+     [:p.value (str (:value c))]]))
+
+(defn- dashboard []
+  [:main.dashboard
+   [:section.cards
+    [boundary {:id :card.revenue :fallback [card-skeleton :revenue]}
+     [card-view :revenue]]
+    [boundary {:id :card.flaky :fallback [card-skeleton :flaky]}
+     [card-view :flaky]]]])
+
+;; ---- the wire (authored through the SHIPPED server façade fns) -------------
+;;
+;; The JVM shell walker is `.cljc` but registry-and-frame bound, so the
+;; chunk bytes here are assembled from the same façade fns the Ring writer
+;; thread flushes — `ssr/streaming-{fallback,resolved,failed}-template` and
+;; `ssr/streaming-hydrate-delta-script`. The HTML they produce is pinned
+;; against the real JVM emitter by the cross-host suite
+;; (`streaming_component_cljs_test`) and the JVM streaming tests.
+
+(def ^:private revenue-resolved-html
+  "<div class=\"card\"><h3>Revenue</h3><p class=\"value\">42375</p></div>")
+
+(def ^:private flaky-fallback-html
+  "<div class=\"card skeleton\"><h3>Loading flaky</h3></div>")
+
+(def ^:private revenue-fallback-html
+  "<div class=\"card skeleton\"><h3>Loading revenue</h3></div>")
+
+(defn- shell-html []
+  (str "<main class=\"dashboard\"><section class=\"cards\">"
+       (ssr/streaming-fallback-template :card.revenue revenue-fallback-html)
+       (ssr/streaming-fallback-template :card.flaky flaky-fallback-html)
+       "</section></main>"))
+
+(defn- revenue-chunk []
+  (str (ssr/streaming-resolved-template :card.revenue revenue-resolved-html)
+       (ssr/streaming-hydrate-delta-script
+         :card.revenue (pr-str {:cards {:revenue {:title "Revenue" :value 42375}}}))))
+
+(defn- flaky-chunk []
+  ;; A FAILED continuation: fallback html, `data-rf2-suspense-failed`, no delta.
+  (ssr/streaming-failed-template :card.flaky flaky-fallback-html))
+
+(defn- payload-chunk
+  "The final `__rf_payload`. Its runtime-db slice carries the
+  failed-boundary set exactly as `build-final-payload` assembles it —
+  the JVM half of that assembly is pinned in
+  `streaming_component_cljs_test`."
+  [failed]
+  (str "<script id=\"" constants/payload-script-id "\" type=\"application/edn\">"
+       (pr-str (cond-> {:rf/version   1
+                        :rf/app-db    {:cards {:revenue {:title "Revenue" :value 42375}}}
+                        :rf/render-hash "00000000"}
+                 (seq failed)
+                 (assoc :rf/runtime-db
+                        (assoc-in {} boundary/failed-boundaries-path (set failed)))))
+       "</script>"))
+
+;; ---- DOM scaffolding -------------------------------------------------------
+
+(defn- make-host! []
+  (let [host (.createElement js/document "div")]
+    (set! (.-innerHTML host) (str "<div id=\"app\">" (shell-html) "</div>"))
+    (.appendChild (.-body js/document) host)
+    host))
+
+(defn- app-el [host] (.querySelector host "#app"))
+
+(defn- append-chunk! [host chunk-html]
+  (let [parser (.createElement js/document "template")]
+    (set! (.-innerHTML parser) chunk-html)
+    (.appendChild host (.-content parser))))
+
+(defn- remove-host! [host]
+  (when-let [p (.-parentNode host)]
+    (.removeChild p host)))
+
+(defn- mounts [host]
+  (array-seq (.querySelectorAll host (str "[" wire/attr-suspense-mount "]"))))
+
+(defn- normalise-html
+  "Collapse insignificant whitespace so a structural comparison is not
+  defeated by formatting."
+  [s]
+  (-> s (str/replace #">\s+<" "><") str/trim))
+
+;; ---- the hydration harness -------------------------------------------------
+
+(defn- hydrate-capturing!
+  "Hydrate `container` against `tree` by calling React's `hydrateRoot`
+  DIRECTLY, with our own options object carrying `onRecoverableError`.
+
+  Returns `{:root <React root> :errors (atom [...])}`. Every recoverable
+  error React reports — hydration mismatches among them — lands in
+  `:errors`. Nothing between us and React can drop the option, because
+  we build the options object here.
+
+  `r2/as-element` is used only to turn hiccup into a React element; it
+  is not a hydration wrapper and never sees the options object."
+  [container tree]
+  (let [errors (atom [])
+        root   (react-dom-client/hydrateRoot
+                 container
+                 (r2/as-element tree)
+                 #js {:onRecoverableError (fn [err _info]
+                                            (swap! errors conj (str (.-message err) "")))})]
+    {:root root :errors errors}))
+
+(defn- mismatch-errors
+  "Only the hydration-mismatch reports. React phrases them variously
+  across builds ('Hydration failed', 'did not match', 'server rendered
+  HTML didn't match'), so match on the stable substrings rather than one
+  exact sentence."
+  [errors]
+  (filterv #(or (str/includes? % "Hydration")
+                (str/includes? % "hydration")
+                (str/includes? % "did not match")
+                (str/includes? % "didn't match"))
+           @errors))
+
+;; ---- tests -----------------------------------------------------------------
+
+(deftest harness-captures-a-known-bad-hydration
+  (testing "the harness reds on deliberately-wrong server HTML — without
+            this, every no-mismatch assertion below would be vacuous"
+    (if-not (browser?)
+      (is true "skipped under node — no js/document")
+      (let [host      (.createElement js/document "div")
+            _         (.appendChild (.-body js/document) host)
+            ;; Server painted a <span>; the client tree says <div>. React
+            ;; must report a recoverable hydration error.
+            _         (set! (.-innerHTML host) "<span>server</span>")
+            {:keys [errors root]} (hydrate-capturing! host [:div "client"])]
+        (async done
+          (js/setTimeout
+            (fn []
+              (is (seq (mismatch-errors errors))
+                  (str "EXPECTED the harness to capture a hydration mismatch on "
+                       "known-bad HTML; captured: " (pr-str @errors) ". "
+                       "A harness that captures nothing here proves nothing anywhere."))
+              (.unmount root)
+              (remove-host! host)
+              (done))
+            60))))))
+
+(deftest streamed-page-hydrates-without-structural-mismatch
+  (testing "rf2-o4rbh: a genuinely staggered stream, finalised, hydrates
+            with ONE ordinary whole-root hydration and no mismatch"
+    (if-not (browser?)
+      (is true "skipped under node — no js/document")
+      (let [frame-id :test/streamed
+            host     (make-host!)
+            ready    (atom nil)]
+        (rf/make-frame {:id frame-id :platform :client})
+        (register-app! frame-id)
+        (streaming-client/install!
+          {:frame frame-id :root host :on-ready #(reset! ready %)})
+        ;; Fallbacks are now LIVE mounts — the page paints its skeletons.
+        (is (= 2 (count (mounts host)))
+            "install materialises each inert fallback template into a visible mount")
+        (is (nil? @ready) "not ready until the final payload lands")
+        ;; Stagger the stream: one resolved chunk, one failed chunk, then
+        ;; the payload — each in its own observer batch.
+        (append-chunk! host (revenue-chunk))
+        (async done
+          (js/setTimeout
+            (fn []
+              (append-chunk! host (flaky-chunk))
+              (js/setTimeout
+                (fn []
+                  (append-chunk! host (payload-chunk #{:card.flaky}))
+                  (js/setTimeout
+                    (fn []
+                      ;; --- FINALIZATION ---
+                      (is (some? @ready) ":on-ready fired when the payload landed")
+                      (is (= #{:card.revenue} (:resolved @ready)))
+                      (is (= #{:card.flaky} (:failed @ready)))
+                      (is (zero? (count (mounts host)))
+                          "every <rf-suspense> mount is unwrapped at readiness — protocol DOM is transport, never part of the application tree")
+                      (is (zero? (count (array-seq (.querySelectorAll host "template[data-rf2-suspense-id]"))))
+                          "no suspense <template> survives finalization")
+                      ;; The resolved card is now a DIRECT child of <section>,
+                      ;; exactly as the author's tree describes it.
+                      (is (some? (.querySelector host "section.cards > div.card"))
+                          "resolved content sits where the client tree puts it")
+                      ;; --- HYDRATION ---
+                      (rf/dispatch-sync [:rf/hydrate (ssr/read-server-payload)] {:frame frame-id})
+                      (let [tree [rf/frame-provider {:frame frame-id} [dashboard]]
+                            {:keys [errors root]} (hydrate-capturing! (app-el host) tree)]
+                        (js/setTimeout
+                          (fn []
+                            (is (empty? (mismatch-errors errors))
+                                (str "hydrateRoot must reconcile the finalised streamed DOM "
+                                     "with no structural mismatch; got: " (pr-str @errors)))
+                            (.unmount root)
+                            (remove-host! host)
+                            (done))
+                          80)))
+                    40))
+                40))
+            40))))))
+
+(deftest failed-boundary-renders-its-declared-fallback
+  (testing "the failed set rides the payload's runtime slice, so the
+            client boundary re-renders the DECLARED fallback — the exact
+            markup the failed chunk left in the DOM"
+    (if-not (browser?)
+      (is true "skipped under node — no js/document")
+      (let [frame-id :test/failed-fallback]
+        (rf/make-frame {:id frame-id :platform :client})
+        (register-app! frame-id)
+        ;; Seed the frame's runtime-db the way :rf/hydrate would.
+        (rf/dispatch-sync
+          [:rf/hydrate {:rf/version 1
+                        :rf/app-db  {:cards {:revenue {:title "Revenue" :value 42375}}}
+                        :rf/runtime-db (assoc-in {} boundary/failed-boundaries-path
+                                                 #{:card.flaky})}]
+          {:frame frame-id})
+        (is (= #{:card.flaky} (boundary/failed-boundaries frame-id))
+            "the failed set survives the hydration round-trip into runtime-db")
+        (let [host (.createElement js/document "div")]
+          (.appendChild (.-body js/document) host)
+          (let [root (react-dom-client/createRoot host)]
+            (.render root (r2/as-element
+                            [rf/frame-provider {:frame frame-id} [dashboard]]))
+            (async done
+              (js/setTimeout
+                (fn []
+                  (let [html (.-innerHTML host)]
+                    (is (str/includes? html "Loading flaky")
+                        "the FAILED boundary renders its declared fallback")
+                    (is (str/includes? html "42375")
+                        "the resolved boundary renders its body")
+                    (is (not (str/includes? html "suspense-boundary"))
+                        "no phantom <suspense-boundary> element — the component is not a keyword head")
+                    (is (not (str/includes? html "rf-suspense"))
+                        "the component renders no protocol DOM of its own"))
+                  (.unmount root)
+                  (remove-host! host)
+                  (done))
+                60))))))))
+
+(deftest finalization-unwraps-mounts-preserving-children
+  (testing "unwrapping splices the mount's children into its position,
+            leaving the DOM the equivalent non-streamed render produces"
+    (if-not (browser?)
+      (is true "skipped under node — no js/document")
+      (let [frame-id :test/unwrap
+            host     (make-host!)]
+        (rf/make-frame {:id frame-id :platform :client})
+        (register-app! frame-id)
+        (streaming-client/install! {:frame frame-id :root host})
+        (append-chunk! host (revenue-chunk))
+        (append-chunk! host (flaky-chunk))
+        (async done
+          (js/setTimeout
+            (fn []
+              (append-chunk! host (payload-chunk #{:card.flaky}))
+              (js/setTimeout
+                (fn []
+                  (is (= (normalise-html
+                           (str "<main class=\"dashboard\"><section class=\"cards\">"
+                                revenue-resolved-html
+                                flaky-fallback-html
+                                "</section></main>"))
+                         (normalise-html (.-innerHTML (app-el host))))
+                      "the finalised DOM is exactly the non-streamed render of the same tree")
+                  (remove-host! host)
+                  (done))
+                60))
+            60))))))
+
+(deftest readiness-fires-once-on-an-already-complete-page
+  (testing "a fully-buffered response (payload already present at install)
+            still finalises and signals readiness — synchronously — so a
+            readiness-driven bootstrap cannot hang"
+    (if-not (browser?)
+      (is true "skipped under node — no js/document")
+      (let [frame-id :test/already-complete
+            host     (make-host!)
+            calls    (atom 0)]
+        (rf/make-frame {:id frame-id :platform :client})
+        (register-app! frame-id)
+        ;; Everything arrived before the bundle booted.
+        (append-chunk! host (revenue-chunk))
+        (append-chunk! host (flaky-chunk))
+        (append-chunk! host (payload-chunk #{:card.flaky}))
+        (streaming-client/install!
+          {:frame frame-id :root host :on-ready (fn [_] (swap! calls inc))})
+        (is (= 1 @calls) ":on-ready fires synchronously during install!")
+        (is (zero? (count (mounts host)))
+            "mounts are unwrapped even on the already-complete path — otherwise the fast page is the unhydratable one")
+        (async done
+          (js/setTimeout
+            (fn []
+              (is (= 1 @calls) ":on-ready is once-only — a later mutation cannot re-fire it")
+              (remove-host! host)
+              (done))
+            60))))))
+
+(deftest no-mounts-and-no-readiness-before-the-payload
+  (testing "readiness is the hydration trigger: before the payload lands
+            the DOM still carries protocol wrappers, so a bootstrap that
+            hydrated early would be hydrating the mismatched tree"
+    (if-not (browser?)
+      (is true "skipped under node — no js/document")
+      (let [frame-id :test/pre-readiness
+            host     (make-host!)
+            ready    (atom false)]
+        (rf/make-frame {:id frame-id :platform :client})
+        (register-app! frame-id)
+        (streaming-client/install!
+          {:frame frame-id :root host :on-ready (fn [_] (reset! ready true))})
+        (append-chunk! host (revenue-chunk))
+        (async done
+          (js/setTimeout
+            (fn []
+              (is (false? @ready) "no readiness before the final payload")
+              (is (pos? (count (mounts host)))
+                  "mounts are still present pre-readiness — this is precisely why hydration must wait")
+              (is (some? (.querySelector host (str "[" wire/attr-suspense-mount "] > div.card")))
+                  "the resolved card is nested inside its mount pre-readiness — the o4rbh mismatch shape")
+              (remove-host! host)
+              (done))
+            60))))))

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -1366,16 +1366,33 @@ On hydration:
 
 > **Status: shipped.** The `:rf/suspense-boundary` hiccup marker described below ships in the `day8/re-frame2-ssr` artefact (`re-frame.ssr.streaming` ns); the chunked-response wiring ships in `day8/re-frame2-ssr-ring` (`re-frame.ssr.ring.streaming` ns + `stream-handler`).
 
-Streaming SSR lets the server flush a usable shell on first byte, then stream subtrees as their data resolves. Crawlers, low-latency rendering, and SOTA parity with Next/Remix `defer` and Solid `Suspense` all benefit. The primitive is one hiccup marker — declarative, walker-driven, no per-host streaming-render-mode API.
+Streaming SSR lets the server flush a usable shell on first byte, then stream subtrees as their data resolves. Crawlers, low-latency rendering, and SOTA parity with Next/Remix `defer` and Solid `Suspense` all benefit. The primitive is one component — declarative, walker-driven, no per-host streaming-render-mode API.
 
-#### The `:rf/suspense-boundary` hiccup marker
+#### The `boundary` component — the authoring surface
 
 ```clojure
-[:rf/suspense-boundary
+(require '[re-frame.ssr :as ssr])
+
+[ssr/boundary
  {:id      :news/comments              ;; required, namespaced keyword or string
   :fallback [:p "Loading comments…"]}  ;; required, hiccup
- [:comments/section]]                  ;; subtree — the deferred body
+ [comments-section]]                   ;; subtree — the deferred body
 ```
+
+**The boundary is a component, not a hiccup keyword, and that is normative.** A keyword head is an HTML element on every host ([§The head grammar is not Spec 011's to extend](#the-head-grammar-is-not-spec-011s-to-extend); Conventions §Render-tree shape vs runtime lookup), so a `:rf/suspense-boundary` left in a client render tree paints a phantom `<suspense-boundary>` element — silently, because the name passes the DOM tag grammar. Nor can the marker be *given* client semantics: stock Reagent is an external dependency whose element dispatch is not the framework's to extend, and UIx / Helix views are `defui` / `$` forms where a hiccup keyword head cannot occur at all. A callable component head is the **only** form expressible on every substrate, so it is the authoring surface.
+
+`:rf/suspense-boundary` remains, demoted to **internal wire syntax** between the component and the shell walker. Implementations MUST NOT present it as an authoring surface, and a render tree an application author writes MUST NOT contain it.
+
+Host semantics:
+
+| Host | `boundary` evaluates to |
+|---|---|
+| Server (`:clj`) | `[:rf/suspense-boundary {:id … :fallback …} & body]` — the marker the shell walker below consumes. The non-streaming emitter's `:rf.error/ssr-suspense-boundary-outside-stream` reject is unchanged, so a marker escaping a stream still fails loud. |
+| Client (`:cljs`) | `body` — or `:fallback`, when this boundary's `:id` is in the page's **failed-boundary record** ([§Failed boundaries on the client](#failed-boundaries-on-the-client)). A lone child renders as itself; several are spliced into a `:<>` fragment, matching the walker's continuation-subtree construction so the two hosts' structures agree. |
+
+Both hosts hash the **same raw tree** ([§Hydration-mismatch detection](#hydration-mismatch-detection)): a component head canonicalises to the existing `#fn[]` token, so no hash change is required. This is a property the alternative could not have — a reader-conditional boundary slot made the two hosts hash structurally different trees.
+
+Missing `:id` or `:fallback` raises `:rf.error/suspense-boundary-invalid-attrs` on **either** host, so the authoring mistake reads identically whichever one catches it first.
 
 Operational semantics (the emitter contract):
 
@@ -1397,7 +1414,30 @@ Client-side hydration semantics (the **shipped** `re-frame.ssr.streaming.client/
 
 1. On install: the client materialises each inert `<template data-rf2-suspense-fallback="1">` into a **live, visible mount** — an `<rf-suspense data-rf2-suspense-mount="<id>">…fallback…</rf-suspense>` wrapper holding the fallback markup. This is load-bearing: a `<template>`'s content is inert by the HTML spec (`.content` is a detached `DocumentFragment`, never painted), so the user would see nothing until swap if the fallback stayed wrapped. The visible mount is also the stable swap target the resolved chunk replaces. (Same model React 18 / Solid use — a visible fallback plus a stable mount — expressed over the server's `<template>`-marker protocol.) The shell otherwise hydrates against whatever payload is already inlined (none, in the streaming case) — the streaming bootstrap waits for the `__rf_payload` script, which arrives last.
 2. As resolved-subtree chunks stream in (driven by a `MutationObserver`, plus an initial synchronous sweep for chunks that landed before the bundle booted): the runtime, per matched boundary `id`, **replaces the live mount's content** with the resolved `<template>`'s parsed content in-place, and merges the per-subtree hydration delta into the target frame's `app-db` via a top-level `(into existing delta)` merge (so a subscription reading the now-resolved region sees the speculative state). This happens **progressively, before the final payload** — the speed prop of suspense boundaries. A `data-rf2-suspense-failed="1"` chunk swaps the fallback HTML and applies **no** delta, surfacing a client-side `:rf.ssr/suspense-boundary-failed` trace (Spec §Failure semantics — inline fallback) without a 500.
-3. After the final chunk: the bootstrap (`ssr/hydrate!`) dispatches `:rf/hydrate` with the full payload — this is the consistency moment; the deltas were speculative, the final payload is canonical (`:replace-frame-state`). The runtime **auto-disconnects its observer** the moment it sees the `__rf_payload` node, so no late delta can race the canonical replace.
+3. **Finalization.** The `__rf_payload` node's arrival means the stream is complete, and triggers a once-only finalization step: process any chunk still pending, consume or quarantine the last deltas and record each boundary's outcome, **unwrap every `<rf-suspense>` mount** (preserving children), disconnect the observer, then signal readiness via the `:on-ready` callback with `{:resolved #{ids} :failed #{ids}}`. Ordering is normative — sweeping after unwrapping would leave a resolved chunk with no mount to swap into, and signalling readiness before unwrapping would hand the bootstrap a DOM that still carries protocol wrappers. Finalization also runs — synchronously, during `install!` — when the whole response had already buffered before the bundle booted, so a readiness-driven bootstrap cannot hang on a fast page.
+4. **Hydration, from readiness.** The bootstrap (`ssr/hydrate!`) dispatches `:rf/hydrate` with the full payload — the consistency moment; the deltas were speculative, the final payload is canonical (`:replace-frame-state`) — and the adapter's `hydrate-root` adopts the DOM. Both run **from `:on-ready`**, never on a timer and never on a DOM poll.
+
+##### The protocol: progressive pre-hydration paint, then one ordinary hydration
+
+This is the contract Spec 011 previously left unstated, and its absence is why the shipped example had nothing correct to copy.
+
+**Protocol DOM is transport, never part of the application tree.** The fallback / resolved `<template>` chunks, the `<rf-suspense>` mounts, and the `data-rf2-suspense-hydrate` delta `<script>`s exist to carry a streamed page across the wire and to paint it before the bundle boots. **None of them is expressible in a render tree on any host**, none participates in the render-tree hash, and none may be present when hydration runs. A streamed page's lifecycle therefore has exactly two phases:
+
+1. **Progressive pre-hydration paint** — the shell paints, fallbacks become visible mounts, resolved chunks swap in, deltas merge. No framework handlers exist inside the streamed root; nothing is React-owned; no root has been created.
+2. **One ordinary whole-root hydration** — after finalization, against a DOM that is byte-identical to what the equivalent **non-streamed** render of the same tree produces.
+
+**A host MUST NOT take React ownership of the streamed root before readiness** — neither `hydrate-root` (the DOM still carries mounts, so every boundary is a structural mismatch) nor `create-root` (which discards the streamed markup entirely, paying streaming's cost for none of its benefit). In particular, a bootstrap MUST NOT fall through to `create-root` merely because the payload has not landed yet: on a live stream that is true for most of the page's life.
+
+##### Failed boundaries on the client
+
+A boundary whose continuation threw ships its **fallback** HTML in the chunk ([§Failure semantics — inline fallback](#failure-semantics--inline-fallback)) and no delta, so after finalization the DOM at that boundary holds the declared fallback markup. The client render tree must agree.
+
+The server has always known `:failed?` per continuation. It is now carried:
+
+- The host adapter accumulates the failed ids as it drains and passes them to `build-final-payload`, which records them in the **serialisable runtime-db slice** at `[:rf.runtime/ssr :streaming :failed-boundaries]` — under the already-reserved `:rf.runtime/ssr` key, a sibling of the `:hydration` metadata. It rides the existing `:rf/runtime-db` payload key and installs through the existing `:replace-frame-state` hydrate; no new payload key, no hydrate-handler change. An empty set contributes **no key** — an ordinary page carries nothing extra on the wire.
+- The streaming client records the same outcomes at finalization, in a **frame-free page-level record** the `boundary` component consults at render time. Frame-free is required, not incidental: `boundary` is a plain function component, and a plain fn cannot read an enclosing `frame-provider`'s frame from React context on Reagent ([§Frame-provider via React context](006-ReactiveSubstrate.md#frame-provider-via-react-context)), so a frame-scoped read is structurally unavailable to it. Boundary ids are unique per page by contract, so an id identifies a boundary without a frame.
+
+The consequence is the ergonomic win: **the boundary that declared the fallback is the one that re-renders it.** Views need no defensive nil branch duplicating the fallback to keep the client's render agreeing with the DOM the stream painted.
 
 The streaming runtime (`re-frame.ssr.streaming.client/install!`, re-exported as `ssr/streaming-install!`) ships in `day8/re-frame2-ssr` and is **host opt-in** — a streaming-aware bootstrap calls it; non-streaming pages skip it entirely. It is CLJS-only (it installs a `MutationObserver` + swaps DOM). `install!` takes `{:frame :payload-id :root}` where **`:frame` is required** (the delta-merge target is *carried*, the same frame the bootstrap `hydrate!`s into; an absent `:frame` raises `:rf.error/no-frame-context`, never `:rf/default`) and `:payload-id` / `:root` default to `"__rf_payload"` / `js/document`. It returns a 0-arity `stop!` fn (auto-disconnect on final payload means most hosts never call it). It is idempotent per chunk (a `seen`-set guards against observer batching + the initial sweep racing the same node).
 

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -1509,6 +1509,12 @@
   ["re-frame.ssr" "render-to-string"]              {:tier :advanced :owner "011" :status "v1"}
   ["re-frame.ssr" "render-tree-hash"]              {:tier :advanced :owner "011" :status "v1"}
   ["re-frame.ssr" "project-error"]                 {:tier :advanced :owner "011" :status "v1"}
+  ;; The cross-host suspense boundary COMPONENT — the streaming AUTHORING
+  ;; surface (rf2-ycz3k). Advanced rather than front-porch: streaming SSR is
+  ;; an opt-in capability in a separate artefact, not day-one app building.
+  ;; It is nonetheless the one form an author writes for a streamed region —
+  ;; `:rf/suspense-boundary` is internal wire syntax, never authored.
+  ["re-frame.ssr" "boundary"]                      {:tier :advanced :owner "011" :status "v1"}
   ["re-frame.ssr" "streaming-render-shell"]        {:tier :advanced :owner "011" :status "v1"}
   ["re-frame.ssr" "streaming-render-continuation"] {:tier :advanced :owner "011" :status "v1"}
   ["re-frame.ssr" "streaming-build-final-payload"] {:tier :advanced :owner "011" :status "v1"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 518,
+ :var-count 519,
  :tier-vocab
  [:front-porch
   :advanced
@@ -308,6 +308,7 @@
   {:namespace "re-frame.schemas", :var "validate-with-registered-fn", :tier :implementation, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr", :var "adapter", :tier :implementation, :kind :var, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr", :var "apply-error-projection!", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ssr", :var "boundary", :tier :advanced, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr", :var "clear-pending-error-traces!", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr", :var "clear-request!", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr", :var "default-error-projector-fn", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
Closes the structural gap `rf2-o4rbh` measured: on a genuinely streamed page, `streaming-install!` materialises each boundary into an `<rf-suspense>` mount that no client render tree on any host can express, so `hydrate-root` sees a structural mismatch at every boundary. Spec 011 never said what a client tree should contain at a boundary — which is why the shipped example had nothing correct to copy.

Implements `rf2-j81hs` ruling SS2 (component) + SS3 (lifecycle).

## The component (SS2)

`ssr/boundary` — one `.cljc` form for every host.

```clojure
[ssr/boundary {:id :card.revenue :fallback [card-skeleton :revenue]}
 [card-view :revenue]]
```

- `:clj` → expands to the internal `:rf/suspense-boundary` marker. **Walker protocol unchanged**; the non-streaming emitter's `:rf.error/ssr-suspense-boundary-outside-stream` reject is untouched; **no registry dependency reintroduced** to either emitter.
- `:cljs` → renders the body, or the declared `:fallback` when this boundary is in the page's failed record.

The marker survives as internal wire syntax only. This kills the example's reader-conditional `card-slot` *and* the hand-maintained fallback duplication in view nil-branches: the boundary that declared the fallback is the one that re-renders it.

## The lifecycle (SS3)

- `build-final-payload` accepts `:failed-boundaries` and records it in the serialisable runtime slice at `[:rf.runtime/ssr :streaming :failed-boundaries]` — under the already-reserved `:rf.runtime/ssr` key, riding the existing `:rf/runtime-db` key and the existing `:replace-frame-state` hydrate. No new payload key, no hydrate-handler change. An empty set contributes **no key**.
- `install!` gains a once-only **finalization** on final-payload arrival: sweep pending chunks → record outcomes → **unwrap every `<rf-suspense>` mount** (preserving children) → disconnect → `:on-ready`. Ordering is load-bearing and spelled out in Spec 011.
- `:on-ready` is the hydration trigger. It also fires **synchronously during `install!`** when the whole response had already buffered, so a readiness-driven bootstrap cannot hang on a fast page. No DOM polling; no `create-root` fallback taken merely because the payload hasn't landed.

**How a client tree now expresses a boundary:** it doesn't have to. Protocol DOM is transport — finalization removes it, leaving a DOM byte-identical to the equivalent *non-streamed* render of the same tree, which the author's ordinary hiccup already describes. Spec 011 now pins that as the contract: progressive pre-hydration paint, then ONE ordinary whole-root hydration.

## Two defects found while building this

1. **Namespace/var collision (shipping bug).** With the ns named `re-frame.ssr.boundary`, the façade's `(def boundary …)` compiled to `re_frame.ssr.boundary = re_frame.ssr.boundary.boundary;` — silently clobbering the namespace object, so every other var in it read `undefined` for anyone requiring both. Fixed structurally by naming the ns `re-frame.ssr.suspense` while keeping the authoring name `ssr/boundary`; the reason is recorded in the ns docstring.
2. **`clojure.test` has no map fixtures.** A map is `IFn`, so a `{:before …}` fixture composes to a fn that returns nil without running the test — the namespace reports "Ran 0 tests" and reads GREEN. Caught because the new suite's count didn't move off the 456 baseline.

## Frame-free failed record — a design constraint, documented

`boundary` is a plain fn component, and on Reagent a plain fn cannot read the enclosing `frame-provider`'s frame from React context (Spec 006 — only `reg-view`-wrapped components carry the stamp). A frame-scoped read is therefore structurally unavailable to it. The render-time record is a process-level set written by finalization; the payload's runtime-db slice remains the durable, serialisable record (`frame-failed-boundaries`). Making `boundary` a `reg-view` would buy the frame back at the cost of a registrar-cleared failure mode and `reg-view`'s dev-time root-element attribute stamping landing on author markup — rejected as machinery for one boolean.

## Corpus completion (bead NOTES)

- `examples/.../ssr_streaming/core.cljc` + `README.md`: the "the JVM SSR emitter *does* resolve keyword heads through the registry" claim was **false since #6378** — corrected. `card-slot` is now the component; `run` hydrates from `:on-ready`.
- `emit.cljc` `:>` guidance no longer claims a reg-view is "resolved by the SSR emitter", and the error now spells the required callable head.
- Spec 011's canonical example body is callable.
- `docs/ssr/streaming.md` carried the same broken snippet — fixed, plus the readiness/hydration recipe.

No new error id — reuses `:rf.error/suspense-boundary-invalid-attrs` on both hosts.

## Quality gates

Run in foreground to completion, unpiped, exit codes captured by redirect. Counts are TEST counts.

| Gate | Result |
|---|---|
| `implementation/ssr` `clojure -M:test` | **463** tests, 0 failures (baseline 456, +7) |
| `implementation/ssr-ring` `clojure -M:test` | **199** tests, 0 failures |
| `implementation/ui` `clojure -M:test` | **955** tests, 0 failures |
| `implementation/core` `clojure -M:test` | **2078** tests, 0 failures |
| `npm run test:cljs` | **10214** tests, 0 failures (baseline ~10180) |
| `npm run test:browser` | **481** tests, 0 failures (baseline ~472, +9) |
| `mkdocs build --strict` | exit 0, no 011 anchor warnings |
| `scripts/check-no-hardcoded-paths.sh` | OK |

### Manifest drift fix (follow-up commit)

The first push landed the sidecar classification for the new `re-frame.ssr/boundary` export but **not** the regenerated manifest, so `Public-API manifest drift-check` went red. Actual generator stderr:

```
DRIFT: generated manifest differs from spec/api-manifest.edn.
  Rows the generator produced that the committed file lacks:
    + re-frame.ssr / boundary -> :advanced :fn v1
```

Regenerating adds exactly that one row (`:var-count` 518 → 519). Behind that first failing step two further gates were also red — an `:advanced`-tier var needs a member heading on its `docs/api` page — so `docs/api/re-frame.ssr.md` gains a `boundary` entry at the head of the Streaming render section, where it is the authoring verb the rest of the section serves.

The gate was **not** weakened: no skip, no `|| true`, no `continue-on-error`, no exclusion, no deleted row.

| Gate | Before | After |
|---|---|---|
| `gen --check` | **exit 1** (drift) | **exit 0**, 519 vars in sync |
| `api-md-check` | not reached | exit 0, 217 var-rows |
| `story-spec-check` | not reached | exit 0, 68 refs |
| `xray-spec-check` | not reached | exit 0, 26 refs |
| `skills-check` | not reached | exit 0, 550 refs |
| `doc-guide-check` | not reached | exit 0, 661 refs |
| `doc-api-check` | **exit 1** (no member heading) | exit 0, 318 refs + 201 vars covered |
| api-manifest `clojure -M:test` | **exit 1**, 2 failures | exit 0, **110** tests, 0 failures |

Full re-run after the fix: ssr **463**, ssr-ring **199**, core **2078**, `test:cljs` **10214**, `test:browser` **481**, `mkdocs build --strict` exit 0 — all matching the baselines above.

**Per-arm red-before, each with its own lever:**

- **ssr JVM** — lever: `with-failed-boundaries` → no-op. Reds `failed-continuations-ride-the-final-payloads-runtime-slice` (1 failure).
- **core JVM** — same lever. Reds `ssr-streaming-example-runs-end-to-end` (1 failure).
- **cljs node** — lever: `boundary`'s `:cljs` branch ignores the record. Reds 2 failures + 3 errors across the component suite and the example client-render suite.
- **browser** — lever: `unwrap-mounts!` removed from finalization. Reds 5 assertions across 3 tests, **including `hydrateRoot` reporting "server rendered HTML didn't match the client"** — the `rf2-o4rbh` mismatch reproduced and measured.
- `ssr-ring` and `ui` are regression-only for this change; no lever claimed.

**`test:browser` non-vacuity** is stated separately: the unwrap lever above reds 5 *mounted DOM* assertions in that run, so the browser arm demonstrably executes them rather than self-skipping.

**Harness honesty:** React's `hydrateRoot` is driven **directly** with an options object constructed in the test (plus `console.error`/`warn` capture and `act`), never through an adapter wrapper. `harness-captures-a-known-bad-hydration` feeds it deliberately-wrong HTML first and asserts it reds. A separate non-vacuity assertion — that the streamed content *survives* hydration — caught the first version of the suite rendering an empty client tree and passing.

**Ledger hygiene:** both new suites reset `install/reset-installed-payloads!` **and** the new `suspense/reset-failed-boundaries!` (a fifth process-global table of that class) in their fixtures.

`data-rf-root` remains a bare marker; the Root Manifest is untouched.

