### PR TITLE
fix(ui): elide the descriptor registry traversal from advanced browser releases (rf2-vxgfnd.299)

### DIFF
--- a/implementation/scripts/check-ui-advanced-elision.cjs
+++ b/implementation/scripts/check-ui-advanced-elision.cjs
@@ -83,19 +83,24 @@
 // `assertSentinelSet`, never as a union — a union-only guard stays silent
 // while all but one member regresses.
 //
-// THE RETENTION THIS GATE FOUND (RETAINED_STRINGS, follow-up bead
-// rf2-vxgfnd.299). `re-frame.ui.client/descriptor` and `/descriptor-index`
-// carry NO `goog.DEBUG` gate. Their docstrings say "Empty in production" /
-// "nil in production", which is true BEHAVIOURALLY — `current-build-digest`
-// returns nil and the live-root registry is empty — but the registry-traversal
-// code and the `:build-digest` keyword literal still cost production bytes.
-// That is precisely the browser-specific retention the bead predicted would
-// "remain unobserved", and this gate is what surfaced it. Fixing it means
-// editing implementation/ui/src/re_frame/ui/client.cljs, which is outside this
-// arm's surface, so the residue is PINNED PRESENT rather than left to a
-// comment: when the follow-up gates those two fns, this gate goes RED and the
-// entry must move into ABSENT_STRINGS. A pin that announces itself beats a
-// TODO nobody reads, and it doubles as the production-side non-vacuity floor.
+// THE RETENTION THIS GATE FOUND, AND ITS FIX (rf2-vxgfnd.299 — CLOSED).
+// `re-frame.ui.client/descriptor` and `/descriptor-index` carried NO
+// `goog.DEBUG` gate. Their docstrings said "Empty in production" / "nil in
+// production", which was true BEHAVIOURALLY — `current-build-digest` returns
+// nil and the live-root registry is empty — but the registry-traversal code and
+// the `:build-digest` keyword literal still cost production bytes. That is
+// precisely the browser-specific retention rf2-vxgfnd.195 predicted would
+// "remain unobserved", and this gate is what surfaced it.
+//
+// The arm-4 PR could not fix it (implementation/ui/src/** was outside its
+// surface), so it PINNED the residue PRESENT in RETAINED_STRINGS — a failure
+// that announces itself beats a TODO nobody reads. rf2-vxgfnd.299 then gated
+// both fns on `goog.DEBUG`, the pin went RED exactly as designed, and the
+// `build-digest` entry MOVED into ABSENT_STRINGS below, where it now carries a
+// control assertion like every other absence claim. Measured across the fix:
+// `build-digest` 2 -> 0 occurrences in the production bundle, 2 -> 2 in the
+// control. The production-side non-vacuity floor it had been doubling as was
+// handed to `rf2-advanced-elision-live-probe:` (see RETAINED_STRINGS).
 //
 // TEETH (documented mutation/revert; run at development time, NOT committed).
 // Every ABSENT_STRINGS entry has a demonstrated lever, with measured counts:
@@ -107,11 +112,19 @@
 //     "someone removed a gate" actually looks like.
 //   * L3 — ungate `current` alone (`(when true …)`). RED on `bd1-` (0 -> 1)
 //     via the `finalized-digest?` prefix test that `current` calls.
+//   * L4 — DROP the `goog.DEBUG` gate on `client/descriptor` and
+//     `/descriptor-index` (i.e. revert rf2-vxgfnd.299). RED on `build-digest`
+//     (0 -> 2). This is the lever the whole entry exists for, and it is not
+//     hypothetical: 2 is the count this gate actually measured on main before
+//     the fix landed, which is what filed the bead.
 //   * L-vacuity — rename a sentinel in digest_carrier.cljs with a PREFIX
 //     change and do NOT update this gate: the CONTROL assertion for that entry
 //     goes RED, proving the token is live rather than folklore.
 //   * L-mistarget — point the production scan at the control directory: the
-//     three ABSENT entries go RED (they are present there by construction).
+//     four ABSENT entries go RED (they are present there by construction).
+//   * L-floor — rename `live-probe`'s literal in consumer.cljs without updating
+//     RETAINED_STRINGS: the production floor goes RED (1 -> 0), proving the
+//     floor is a live observation rather than a token that can never fail.
 //
 // A REJECTED TOOTH, recorded because it is instructive. The obvious first
 // lever — make `compiled-digest` unconditional
@@ -163,16 +176,50 @@ const ABSENT_STRINGS = [
     source: 're-frame.ui.digest-carrier (fail-loud unfinalized-build DEBUG MANIFEST diagnostic)',
     sentinel: 're-frame.ui build digest was not finalized',
   },
+  {
+    source: 're-frame.ui.client/descriptor + /descriptor-index (registry traversal + read-time :build-digest stamp — rf2-vxgfnd.299)',
+    sentinel: 'build-digest',
+  },
 ];
 
-// Asserted PRESENT in the PRODUCTION bundle. Two jobs: it is the production-
-// side non-vacuity floor (proving the descriptor path really is compiled into
-// the artifact being scanned), and it is the self-announcing pin on the one
-// residue class that is genuinely retained today.
+// Asserted PRESENT in the PRODUCTION bundle — the production-side non-vacuity
+// floor. Its job is to prove that the fixture's consumer graph really is
+// compiled into the artifact being scanned, so that a wrong path, a stale
+// directory or a mis-targeted scan fails loudly instead of passing vacuously.
+// The control bundle alone cannot catch a production-side mis-target.
+//
+// WHY THIS SENTINEL. Until rf2-vxgfnd.299 the floor was `build-digest`, the
+// pinned descriptor retention. That entry has now legitimately moved into
+// ABSENT_STRINGS, so the floor had to be re-based onto a token that MUST
+// survive production — otherwise the gate would keep only absence assertions
+// and could pass over an empty bundle.
+//
+// `live-probe` is the honest replacement, and it was authored for exactly this
+// job (see the fixture's docstring: "the KNOWN-PRESENT control ... Without it,
+// 'the carrier function names are absent' could not be distinguished from 'the
+// grep does not work on this artifact'"). It qualifies on every count the
+// oracle requires:
+//   - it is a STRING LITERAL, so Closure never rewrites it and inlining cannot
+//     make it vanish — the failure mode that killed the function-name oracle;
+//   - it carries NO `goog.DEBUG` gate and is rooted from `init`, so production
+//     retaining it is correct behaviour, not a leak this gate should chase;
+//   - it is reached through `client/live-root-ids`, an UNGATED client registry
+//     read, so its presence witnesses that `re-frame.ui.client` itself is
+//     compiled into the scanned artifact — which is what makes the neighbouring
+//     `build-digest` absence attributable to the gate rather than to the whole
+//     namespace having been dropped;
+//   - it is a distinctive full literal, not a tail of any other token (the
+//     SUBSTRING CONTAINMENT rule above).
+//
+// VERIFYING THE VERIFIER, measured in the SAME production bundle: the identical
+// grep finds 'rf2-advanced-elision-live-probe:' at 1 occurrence and
+// '__RF2_UI_DIGEST_XX__' at 0. One blob, one grep, a known-present and a
+// known-absent token discriminated — so a PRESENT result here is a real
+// observation and not an artifact of the check always succeeding.
 const RETAINED_STRINGS = [
   {
-    source: 're-frame.ui.client/descriptor + /descriptor-index (UNGATED registry traversal — rf2-vxgfnd.299)',
-    sentinel: 'build-digest',
+    source: 'advanced-elision fixture live-probe via client/live-root-ids (UNGATED — production non-vacuity floor)',
+    sentinel: 'rf2-advanced-elision-live-probe:',
   },
 ];
 
@@ -281,7 +328,7 @@ function run() {
   report.detail('[advanced-elision] production (goog.DEBUG=false) — residue must be ABSENT:');
   const absent = assertSet(prod, 'production', ABSENT_STRINGS, false);
 
-  report.detail('[advanced-elision] production — pinned retention + non-vacuity floor (must be PRESENT):');
+  report.detail('[advanced-elision] production — non-vacuity floor (must be PRESENT):');
   const retained = assertSet(prod, 'production', RETAINED_STRINGS, true);
 
   report.detail('[advanced-elision] control (goog.DEBUG=true) — the same residue must be PRESENT:');
@@ -290,17 +337,23 @@ function run() {
   if (!(absent.ok && retained.ok && control1.ok)) {
     if (!absent.ok) {
       console.error('Dev-only whole-build digest machinery survived an :advanced');
-      console.error(':browser release. The carrier, its sentinel, the bd1- literal');
-      console.error('and the fail-loud diagnostic must cost production zero bytes');
-      console.error('(Spec 004C §2). Check the goog.DEBUG gates in digest_carrier.cljs.');
+      console.error(':browser release. The carrier, its sentinel, the bd1- literal,');
+      console.error('the fail-loud diagnostic and the client descriptor projection');
+      console.error('must cost production zero bytes (Spec 004C §2). Check the');
+      console.error('goog.DEBUG gates in digest_carrier.cljs, and — for build-digest');
+      console.error('— on client/descriptor + client/descriptor-index in');
+      console.error('implementation/ui/src/re_frame/ui/client.cljs (rf2-vxgfnd.299).');
     }
     if (!retained.ok) {
-      console.error('The pinned retention is ABSENT from the production bundle.');
-      console.error('Either the descriptor path is no longer compiled into this');
-      console.error('artifact — in which case every absence result above is vacuous');
-      console.error('and the fixture must be repaired — or rf2-vxgfnd.299 landed');
-      console.error('and gated the registry traversal, in which case move the entry');
-      console.error('from RETAINED_STRINGS into ABSENT_STRINGS.');
+      console.error('The production non-vacuity FLOOR is absent from the production');
+      console.error('bundle. This does not mean elision improved — it means the');
+      console.error('artifact being scanned may not contain the fixture consumer at');
+      console.error('all, in which case every absence result above is vacuous. Check');
+      console.error('for a wrong/stale output directory, then that consumer.cljs');
+      console.error('still roots live-probe and its literal still matches');
+      console.error('RETAINED_STRINGS. Do not "fix" this by deleting the entry: the');
+      console.error('gate would then hold absence assertions only and could pass on');
+      console.error('an empty bundle.');
     }
     if (!control1.ok) {
       console.error('The goog.DEBUG=true control is MISSING residue tokens, so the');

--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -292,10 +292,18 @@
   descriptor must treat nil as not-yet-known; the static core alone does not
   identify a build mid-fence. nil if `root-id` is not live, its entry carries
   no descriptor yet (a `create-root` before its first `render!`), or in
-  production."
+  production.
+
+  `goog.DEBUG`-gated, so the registry read and the `:build-digest` keyword cost
+  advanced production output zero bytes (Spec 004C §2: the descriptor/digest
+  projections are absent from production, not merely empty there). Before
+  rf2-vxgfnd.299 the nil was purely BEHAVIOURAL — `current-build-digest` folded
+  to nil and the registry was empty — while the lookup and the keyword literal
+  still shipped."
   [root-id]
-  (when-let [d (:descriptor (get @live-roots root-id))]
-    (assoc d :build-digest (current-build-digest))))
+  (when ^boolean js/goog.DEBUG
+    (when-let [d (:descriptor (get @live-roots root-id))]
+      (assoc d :build-digest (current-build-digest)))))
 
 (defn descriptor-index
   "Every live root's COMPLETE Root Descriptor v1 (dev): root-id -> static core
@@ -306,14 +314,21 @@
   remains its static core with `:build-digest` nil. Consumers requiring
   finalized-complete descriptors must treat nil as not-yet-known; the static
   core alone does not identify a build mid-fence. Roots still awaiting their
-  first `render!` (no descriptor yet) are omitted. Empty in production."
+  first `render!` (no descriptor yet) are omitted. Empty in production.
+
+  `goog.DEBUG`-gated, so the registry TRAVERSAL and the `:build-digest` keyword
+  are removed from advanced production output rather than merely running over an
+  empty registry (Spec 004C §2). The empty-map return is kept as the production
+  branch so the documented shape holds on both sides of the gate."
   []
-  (let [bd (current-build-digest)]
-    (into {}
-          (keep (fn [[rid entry]]
-                  (when-let [d (:descriptor entry)]
-                    [rid (assoc d :build-digest bd)])))
-          @live-roots)))
+  (if ^boolean js/goog.DEBUG
+    (let [bd (current-build-digest)]
+      (into {}
+            (keep (fn [[rid entry]]
+                    (when-let [d (:descriptor entry)]
+                      [rid (assoc d :build-digest bd)])))
+            @live-roots))
+    {}))
 
 (defn- container-owner
   "root-id of the live root owning `container` (identical?), nil if

--- a/implementation/ui/test/re_frame/ui/digest_probe/advanced_elision/consumer.cljs
+++ b/implementation/ui/test/re_frame/ui/digest_probe/advanced_elision/consumer.cljs
@@ -30,10 +30,11 @@
   the control build carries the residue. Under `:advanced` + `goog.DEBUG=false`
   each body folds to nil and the entire graph must disappear.
 
-  `live-probe` is the KNOWN-PRESENT control for the function-name oracle: it is
-  rooted and carries no debug gate, so it must survive into the pseudo-named
-  release. Without it, \"the carrier function names are absent\" could not be
-  distinguished from \"the grep does not work on this artifact\"."
+  `live-probe` is the KNOWN-PRESENT control: it is rooted and carries no debug
+  gate, so it must survive into the `:advanced` release. Without it, \"the
+  residue is absent\" could not be distinguished from \"the grep does not work on
+  this artifact\". Its STRING LITERAL is the gate's production non-vacuity floor
+  (rf2-vxgfnd.299) — see `RETAINED_STRINGS` in check-ui-advanced-elision.cjs."
   (:require [re-frame.ui :as ui]
             [re-frame.ui.client :as client]
             [re-frame.ui.digest-carrier :as digest-carrier]))
@@ -42,13 +43,25 @@
   [:main {:data-probe "advanced-elision"} "advanced elision probe"])
 
 (defn live-probe
-  "The function-name oracle's KNOWN-PRESENT control.
+  "The gate's KNOWN-PRESENT control — its production non-vacuity FLOOR.
 
-  Rooted from `init` and NOT `goog.DEBUG`-gated, so its pseudo-name must appear
-  in the `:advanced` release. The gate greps for this name in the very artifact
-  in which it greps for the carrier names' ABSENCE — so a broken grep (wrong
-  artifact, unreadable names, empty blob) fails loudly instead of passing
-  vacuously."
+  Rooted from `init` and NOT `goog.DEBUG`-gated, so its string literal must
+  appear in the `:advanced` production release. The gate greps for that literal
+  in the very artifact in which it greps for the residue's ABSENCE — so a broken
+  scan (wrong artifact, stale directory, empty blob) fails loudly instead of
+  passing vacuously.
+
+  It reads through `client/live-root-ids`, an UNGATED client registry read.
+  That is deliberate: its presence witnesses that `re-frame.ui.client` really is
+  compiled into the scanned bundle, which is what makes the neighbouring
+  `build-digest` ABSENCE attributable to the `goog.DEBUG` gate on
+  `client/descriptor` + `/descriptor-index` (rf2-vxgfnd.299) rather than to the
+  whole namespace having been dropped.
+
+  A literal, not a function name, on purpose: Closure inlines small functions
+  but never rewrites string literals (see the gate's rejected function-name
+  oracle). Renaming this literal without updating the gate's RETAINED_STRINGS
+  turns the floor RED — which is what proves the floor can fail at all."
   []
   (str "rf2-advanced-elision-live-probe:" (count (client/live-root-ids))))
 
@@ -67,10 +80,22 @@
   (set! (.-__rf2AdvElisionClientDigest js/globalThis)
         (fn [] (client/current-build-digest)))
 
-  ;; The COMPLETE Root Descriptor read — the static core stamped with
-  ;; `:build-digest` at read time.
+  ;; The COMPLETE Root Descriptor read — the static core stamped with the
+  ;; read-time whole-build digest.
+  ;;
+  ;; The WHOLE map is exported rather than the digest plucked out of it, and
+  ;; that is load-bearing for the gate rather than a matter of taste. The
+  ;; `build-digest` sentinel is supposed to witness the keyword that
+  ;; `client/descriptor` + `/descriptor-index` stamp on. If THIS namespace also
+  ;; spells that keyword, the fixture becomes a second source of the very token
+  ;; under test: measured on the rf2-vxgfnd.299 fix, `(:build-digest (client/…))`
+  ;; kept the keyword alive at 2 occurrences as `Wk.g(null)` — the gated call
+  ;; had correctly folded to nil, yet the keyword lookup around it survived and
+  ;; the absence assertion could never reach 0 no matter what client.cljs did.
+  ;; A sentinel the fixture itself emits measures the fixture, not the library.
+  ;; `clj->js` converts at runtime and needs no keyword literal here.
   (set! (.-__rf2AdvElisionDescriptor js/globalThis)
-        (fn [] (:build-digest (client/descriptor ::probe))))
+        (fn [] (clj->js (client/descriptor ::probe))))
 
   ;; REGISTRY TRAVERSAL: the whole live-root fold, the Xray/tool read surface.
   (set! (.-__rf2AdvElisionDescriptorIndex js/globalThis)


### PR DESCRIPTION
Closes rf2-vxgfnd.299.

## The leak

`re-frame.ui.client/descriptor` and `/descriptor-index` carried **no `goog.DEBUG` gate**. Their docstrings' "nil in production" / "Empty in production" was true *behaviourally* — `current-build-digest` folds to nil and the live-root registry is empty — but not *structurally*: the registry traversal and the `:build-digest` keyword literal survived an `:advanced` `:browser` release.

Spec 004C §2 already requires the opposite:

> Dev-only: the carrier, sentinel, digest literal, view manifests and descriptor/digest projections are `goog.DEBUG`-guarded and absent from advanced production output, so the mechanism adds no production bytes or runtime work.

So this is spec conformance, not a contract change.

## No production consumer

Established before gating anything:

| consumer | reads | production? |
|---|---|---|
| `ui/test/.../digest_probe/base.cljs`, `.../advanced_elision/consumer.cljs` | `client/descriptor` | no — test fixtures |
| `ui/test/.../root_registry_cljs_test.cljs` | both | no — CLJS unit tests |
| `ui/src/re_frame/ui/tool/evidence.cljc` (the tool seam) | `live-root-ids` / `live-root-entry` — **not** these fns | n/a |
| `ui/src/re_frame/ui.cljc` (the facade) | `unmount!*`, `drain-live-roots!` — does **not** re-export descriptor | n/a |

Neither fn appears in `spec/api-manifest*.edn`, and no `tools/**` code reaches them by CLJS name or munged JS name. The compiler-side `re-frame.ui.compiler.root/descriptor-index` is a different namespace and is untouched.

**Nothing users need moved behind `goog.DEBUG`.** These were already documented dev-only reads; the gate makes the structure match the documented behaviour rather than withdrawing a guarantee.

## The fix

`(when ^boolean js/goog.DEBUG …)` on `descriptor`; `(if ^boolean js/goog.DEBUG … {})` on `descriptor-index`, matching the `digest_carrier.cljs` idiom. `descriptor-index` keeps returning `{}` on the production branch so the documented empty-map shape holds on both sides of the gate. `current-build-digest` is left alone — its whole body is `(digest-carrier/current)`, already gated, so a second gate would be redundant.

## Red-before / green-after, via the control-build oracle

The `#6413` oracle, extended rather than reinvented: same entry, same `:advanced` level, `goog.DEBUG` the only variable; string literals only, so Closure inlining cannot make a token vanish.

| sentinel | prod BEFORE | prod AFTER | control BEFORE | control AFTER |
|---|---|---|---|---|
| `build-digest` | **2** | **0** | 2 | 2 |
| `rf2-advanced-elision-live-probe:` (floor) | 1 | 1 | 1 | 1 |
| `__RF2_UI_DIGEST_XX__` (known-absent) | 0 | 0 | 2 | 2 |

In the production bundle the projections now fold away entirely — `__rf2AdvElisionDescriptor` compiles to `pj(null)` and `__rf2AdvElisionDescriptorIndex` to `pj(fh(Q))` (`clj->js(keys(EMPTY))`). No traversal, no keyword.

## The pin, and its replacement floor

`#6413` could not fix this (`implementation/ui/src/**` was fenced from it), so it **pinned the residue PRESENT** in `RETAINED_STRINGS`, doubling as the gate's production non-vacuity floor. Gating the fns turned that pin red exactly as designed.

- `build-digest` **moves into `ABSENT_STRINGS`**, where it now carries a per-entry control assertion like every other absence claim, plus an **L4 tooth** recording the revert lever (0 → 2 — not hypothetical; it is the count this gate measured on main, which is what filed the bead).
- The floor is **re-based, not deleted**, onto `rf2-advanced-elision-live-probe:`. It qualifies on every count the oracle requires: a **string literal** (Closure never rewrites them — the failure that killed the function-name oracle); **ungated and rooted from `init`**, so production retaining it is correct behaviour; reached through **`client/live-root-ids`, an ungated client registry read**, so its presence witnesses that `re-frame.ui.client` really is compiled into the scanned artifact — which is what makes the neighbouring `build-digest` absence attributable to the gate rather than to the whole namespace having been dropped; and a distinctive full literal, not a tail of another token. A new **L-floor tooth** documents how to turn it red.

**Verifying the verifier:** in the *same* production bundle, the identical grep finds the floor at 1 occurrence and `__RF2_UI_DIGEST_XX__` at 0 — one blob, one grep, a known-present and a known-absent token discriminated.

## The fixture was emitting the sentinel it was meant to observe

Worth flagging for review. With the gate in place the `build-digest` count stayed **pinned at 2**. Measuring rather than guessing showed the gated call *had* correctly folded to nil, but the fixture's own `(:build-digest (client/descriptor ::probe))` kept the keyword alive as `Wk.g(null)` — the keyword lookup wrapped around a now-nil call. The absence assertion was therefore **unsatisfiable**: it measured the fixture, not the library, and could never reach 0 no matter what `client.cljs` did.

The fixture now exports the whole descriptor via `clj->js`. It still genuinely consumes `client/descriptor` (the gate's `CONSUMED` check passes, 8 entry points rooted), and it no longer spells the token under test.

## Quality gates

All run in the foreground to completion, unpiped, exit codes captured by redirect.

| gate | result |
|---|---|
| `npm run test:ui-advanced-elision` | **PASS** — production 4/4 residue absent + 1/1 floor present; control 4/4 present |
| `npm run test:ui-digest-carrier` | **PASS** (dev-side descriptor reads still work — bead acceptance) |
| `npm run test:elision` | **PASS** — production 60/60 absent; control 60/60 present |
| `implementation/ui` → `clojure -M:test` | **955 tests**, 18637 assertions, 0 failures, 0 errors |
| `npm run test:browser-prod-elision` | **105 tests**, 414 assertions, 0 failures, 0 errors |
| `npm run test:cljs` | **10214 tests**, 50482 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **481 tests**, 2700 assertions, 0 failures, 0 errors |
| `scripts/check-no-hardcoded-paths.sh` | **PASS** |

No public export added, so no API-manifest row is required. Touched files: `implementation/ui/src/re_frame/ui/client.cljs`, `implementation/scripts/check-ui-advanced-elision.cjs`, and the arm-4 fixture. `implementation/core/**`, `spec/009` and `implementation/ssr/**` untouched.
