### PR TITLE
docs: correct EP-0035's filed-items claim, the xray-embed rationale, and swapped bead metadata (rf2-xd29k, rf2-vpiz0, rf2-zgle3)

### DIFF
--- a/docs/EP/EP-0035-component-library-readiness.md
+++ b/docs/EP/EP-0035-component-library-readiness.md
@@ -8,8 +8,10 @@ Type: standards-track
 > graduation: the Spec 004 rewrite (handler synchrony law, local placement
 > law, render slots, spread), `spec/004B` (conversion table), `spec/008`
 > (gate roster), `spec/009` (diagnostic rows). Directed by Mike 2026-07-16
-> (in-session); accepted on direction — the implementation beads it filed have
-> all since closed (see §Bead Plan).
+> (in-session); accepted on direction — the immediate S3 implementation beads it
+> filed have all since closed; the trigger-gated candidates it also filed are
+> carried on the program epic `rf2-vxgfnd` against the triggers recorded in
+> §Resolved Decisions (see §Bead Plan).
 
 ## Abstract
 

--- a/tools/story/spec/DESIGN-RATIONALE.md
+++ b/tools/story/spec/DESIGN-RATIONALE.md
@@ -2,9 +2,10 @@
 
 > WHY each major design call was made. The capability docs say *what*
 > the surface is; this document says *why* it's that shape and not
-> some other plausible shape. The seven rf2-m6tu §6 decisions, the
-> Phase-2 SOTA additions, plus the calls that emerged during the
-> IMPL-SPEC drafting itself.
+> some other plausible shape. The seven rf2-m6tu §6 decisions and the
+> five ownership boundaries that accompany them, the Phase-2 SOTA
+> additions, plus the calls that emerged during the IMPL-SPEC drafting
+> itself.
 
 ## The seven architectural decisions (rf2-m6tu §6, resolved 2026-05-11)
 
@@ -157,41 +158,98 @@ registration call) and to `nil` in production. Compile-time flag is
 override to `false` for prod builds). See
 [`005-SOTA-Features.md`](005-SOTA-Features.md) §Production elision.
 
-### §xray-embed — embed via `reg-story-panel`
+### §xray-embed — embed via Xray's per-panel mount API
 
-**Decision.** Story does **not** reimplement an epoch UI. Story
-registers Xray's existing epoch / time-travel panel as a story panel
-via (Xray is the structural successor to re-frame-10x, per
+**Decision.** Story does **not** reimplement a diagnostics UI. Story
+mounts Xray's own panels into its right-hand inspector through
+Xray's explicit per-panel mount API (Xray is the structural
+successor to re-frame-10x, per
 [`tools/xray/spec/DESIGN-RATIONALE.md`](../../xray/spec/DESIGN-RATIONALE.md)
-Lock #1):
+Lock #1). The RHS hosts **one** panel at a time; a chip-row picker
+swaps the lens at runtime, and a story may preselect one through the
+`:xray-panel` slot.
+
+The integration point is a single embed descriptor — the sole
+mount-routing owner — pairing each panel id with the
+`day8.re-frame2-xray.panels/mount-<panel>!` fn that renders it:
 
 ```clojure
-(story/reg-story-panel :rf.story/xray-epoch
-  {:doc       "Xray's epoch buffer for the active variant."
-   :title     "Epochs (Xray)"
-   :placement :bottom
-   :render    :day8.re-frame2-xray.panels.time-travel/Panel})
+;; tools/story/src/re_frame/story/ui/xray_embed.cljs
+[{:panel :epoch    :chip? true :mount xray-panels/mount-epoch-panel!}
+ {:panel :app-db   :chip? true :mount xray-panels/mount-app-db-diff!}
+ {:panel :views    :chip? true :mount xray-panels/mount-reactive-panel!}
+ {:panel :trace    :chip? true :mount xray-panels/mount-trace!}
+ {:panel :machines :chip? true :mount xray-panels/mount-machine-inspector!}
+ {:panel :routing  :chip? true :mount xray-panels/mount-routing!}
+ ;; non-chip: routable, but never offered in the picker
+ {:panel :event-spine :chip? false :mount xray-panels/mount-event-spine!}]
 ```
 
-The view is consumed from `day8/re-frame2-xray` (per the
-`tools/xray/` line in [`tools/README.md`](../../README.md)).
-Story's panel is the **adapter**; Xray stays its own artefact, on
-its own release cadence.
+Six chip panels plus the non-chip `:event-spine` band. The chip-row
+catalog, the valid-slot set, and the mount dispatch are all *derived*
+from this one descriptor, so a panel cannot be half-wired; `:chip?`
+is what keeps the exposed set a deliberate curated subset. `:epoch`
+is the default lens.
 
-**Rationale.** The epoch panel's UX (time-travel scrubber, app-db
-follower, event replay) is already best-in-class inside Xray
-(carrying forward the design re-frame-10x established). Reimplementing
-it inside Story would (a) double the implementation surface, (b) split
-the maintenance work, (c) drift over time. Embedding keeps one source
-of truth.
+**Rationale.** Unchanged from the original call — which is why the
+mechanism could be replaced without reopening the decision. Each
+panel's UX is already best-in-class inside Xray (carrying forward the
+design re-frame-10x established). Reimplementing any of it inside
+Story would (a) double the implementation surface, (b) split the
+maintenance work, (c) drift over time. Embedding keeps one source of
+truth.
 
-**Implication.** Story's `:rf.story/xray-epoch` registration ships
-with v1 but the panel only activates if `day8/re-frame2-xray` is on
-the classpath (per the late-bind hook in spec/002). If Xray is
-absent, the sidebar entry hides. The Xray artefact owns the actual
-view; Story owns the *integration*. See
+Per-panel mounting beats the whole-shell embed it replaced on two
+further counts. **Width:** Xray's four-layer chrome needs roughly
+720px to render usefully and Story's RHS is 320px, so the whole shell
+clipped horizontally on every render. **Focus:** Story is a workshop
+— the user hovers over one component asking one diagnostic question,
+and one panel is one diagnostic lens.
+
+**Implication.** Story owns the *integration* — the descriptor, the
+chip row, the context bridge, and lifecycle cleanup. Xray owns the
+panel internals and stays its own artefact, on its own release
+cadence. Every mount path wraps the panel in
+`[rf/frame-provider {:frame :rf/xray} …]`, so a panel's own state
+resolves on `:rf/xray` regardless of the host's React context.
+
+`reg-story-panel` is **not** this mechanism. It remains Story's own
+chrome extension point (a11y, schema validation, layout debug) plus a
+user-facing authoring hook for third-party panels; the machines-viz
+panel-adapter promise was dropped on exactly that reading
+(`rf2-w9rohp`, closed), with the Machines chip above standing as
+Story's machine-chart surface. The provenance for the per-panel
+change lives in the `re-frame.story.ui.xray-embed` namespace
+docstring. See
 [`005-SOTA-Features.md`](005-SOTA-Features.md) §Xray epoch panel
 embed.
+
+## The five ownership boundaries (rf2-m6tu)
+
+The same decision packet closed with a refinement the seven calls
+depend on: state the ownership boundaries precisely, so that a later
+feature cannot quietly annex a neighbour's job. They are recorded
+here because they are the test a Story change has to pass, not
+commentary on it.
+
+1. **Story-MCP owns protocol transport; Story owns artefacts and
+   execution.** The split is the one §separate-mcp-jar makes
+   physical — transport lives behind a jar boundary precisely so it
+   cannot leak into the core.
+2. **The Tool Pair is the only live-browser agent door**
+   (`rf2-3fc89f.22`, closed). Story does not grow a second, parallel
+   channel for agents to reach a running browser.
+3. **Story owns scenario context; Xray owns diagnostic computation
+   and panels.** This is §xray-embed stated as a rule rather than a
+   mechanism, and it is what makes "just one small duplicate
+   inspector" the way the boundary erodes.
+4. **Local storage owns ephemeral layout preference; exported
+   registered EDN/transit owns durable team intent.** A pane the user
+   dragged is not a decision the team made; only the exported form
+   travels.
+5. **The unified run result owns truth; UI, tests, and agents only
+   project it.** Three consumers, one record — none of them may
+   compute a fourth answer of its own.
 
 ## Decisions surfaced during IMPL-SPEC drafting
 
@@ -270,12 +328,18 @@ RENDERS a host app's design tokens for the developer to inspect;
 the chrome's own tokens are the substrate that affordance would
 render against.)
 
-### §xray-embed-inert-without-xray — Xray embed registration ships in v1 but stays inert if Xray absent
+### §xray-embed-inert-without-xray — the Xray embed ships in v1 but degrades gracefully if Xray is absent
 
-Per §xray-embed above. The `reg-story-panel` call is unconditional;
-the panel's `:render` resolves via late-bind to a hidden no-op if
-Xray isn't present. This keeps the user experience graceful when
-Xray isn't on the classpath.
+Per §xray-embed above, and still the call: Story never takes a hard
+dependency on Xray merely to avoid an empty inspector. What ships is
+an explicit unavailable state rather than a silently hidden one — the
+embed surface checks whether Xray is on the classpath and, when it
+isn't, renders a short "Xray is not loaded in this build" placeholder
+in the RHS. Variants keep running; only the diagnostic lens is
+missing, and the reason is on screen instead of inferred from a gap.
+
+The popout-to-full-Xray chip is gated on the same check, so it cannot
+offer a door that doesn't open.
 
 ## Phase-2 SOTA additions — tier choices
 
@@ -520,8 +584,8 @@ pixel-space tests. This is the
 
 ### Rejected: Full Xray reimplementation
 
-**Rejected (delegated).** Story embeds Xray's epoch panel (the
-structural successor to re-frame-10x); does not own a parallel
+**Rejected (delegated).** Story embeds Xray's panels (Xray being the
+structural successor to re-frame-10x); it does not own a parallel
 implementation. See §xray-embed above.
 
 **Why.** Xray's UX is mature; replicating it would split maintenance


### PR DESCRIPTION
Three independent documentation corrections, one commit each. Every factual
claim below was verified against the tracker or the source, not taken from
the beads.

## rf2-xd29k — EP-0035's filed-items claim

PR #6381 (commit `14e19f61ca`) replaced the header's live claim
"implementation beads are live" with "the implementation beads it filed have
all since closed". Converting a live claim to a terminal one was right, but it
generalised from the nine-row Bead Plan table to *every* bead the EP filed —
and the EP also filed five trigger-gated spike/checkpoint beads that are not
in that table, two sections further down.

Verified: all nine table rows are closed (`rf2-vxgfnd.95.2`, `rf2-8k14ia`,
`rf2-ri0k6n`, `rf2-isdqjv`, `.95.4`, `.95.3`, `.95.6`, `.95.10`, `.95.9`), as
are `rf2-vxgfnd.95`, `.96` and `.95.15`. The five trigger-gated beads
(`rf2-nzst23`, `rf2-1hm7a3`, `rf2-a62fje`, `rf2-efxb1h`, `rf2-ho1iba`) are all
open. **False conclusion** — the universal "all" was false, and the document
contradicted itself. Replaced with the narrower truth.

The new sentence is terminal in its first half (names closed work) and
stateless in its second (names the owning program epic `rf2-vxgfnd` and the
recorded triggers, asserting no state). No EP status was flipped; EP-0035
still reads `accepted`.

## rf2-vpiz0 — Story §xray-embed

`§xray-embed` and `§xray-embed-inert-without-xray` still described the retired
whole-shell embed that registered
`:day8.re-frame2-xray.panels.time-travel/Panel` through `reg-story-panel`.

Verified against source: the shipped mechanism is Xray's per-panel mount API,
driven by the embed descriptor in `re-frame.story.ui.xray-embed` — six chip
panels (`:epoch` `:app-db` `:views` `:trace` `:machines` `:routing`) plus the
non-chip `:event-spine` band, each naming a `panels/mount-<panel>!` fn, with
the chip catalog, valid-slot set and mount dispatch all derived from that one
descriptor. `default-panel` is `:epoch`. Xray-absence renders an explicit
"Xray is not loaded in this build" placeholder gated on `xray-available?`, not
the late-bind hidden no-op the doc claimed.

Both sections were **dead basis under a surviving conclusion**: "don't
reimplement Xray, embed it" and "degrade gracefully when Xray is absent" both
still hold, so the conclusions are kept and only the bases rewritten. Neither
was a false conclusion.

Also records that `reg-story-panel` itself is *not* retired — it remains
Story's own chrome extension point plus the third-party authoring hook, the
reading the machines-viz panel-adapter ruling rested on (`rf2-w9rohp`,
closed). And folds in the five `rf2-m6tu` ownership boundaries as a sibling
section to the seven decisions, from the same packet.

## rf2-zgle3 — swapped completion metadata

The two beads' completion metadata had genuinely crossed, not merely gone
stale. Established before mutating anything:

| PR | Title | Merge commit | Real owner |
|---|---|---|---|
| #6358 | spec(views): pin the runtime-enforced rejected-prop deny on spreads | `e5721fdbd0` | `rf2-0znjl` |
| #6359 | docs(synthesis): reconcile slice-memo authorities to the host-window law | `80691502b6` | `rf2-cpalh` |

Each PR's file set is its bead's declared surface verbatim, and both merge
commits are on `origin/main`. Authorship of the #6358 prose is confirmed sole
via `git log -S 'The rule is not' -- spec/004-Views.md`, which returns
`e5721fdbd0` and nothing else.

`rf2-0znjl` was left `in_progress` after merge; `rf2-cpalh` was closed with
reason "shipped #6358" — the other bead's PR. Repaired: `rf2-0znjl` closed
against #6358, `rf2-cpalh` stays closed with its reason corrected to #6359.
Both got an `--append-notes` evidence trail first (never `--notes`). No
engineering content altered, neither reopened.

`rf2-0znjl` was `in_progress`, so its holder was checked first: PR merged,
branch deleted locally and remotely, no worktree — stale bookkeeping, not an
active claim. Closing it unblocks `rf2-y27a7`, which is correct. The repair is
bead-record-only, so its commit is deliberately empty;
`.beads/issues.jsonl` is never committed from a worker branch.

## Quality gates

| Gate | Result |
|---|---|
| `python -m mkdocs build --strict` | **exit 0** — built in 27.78s, 0 WARNING lines |
| `python scripts/check_doc_slugs.py` | **exit 0** — 531 markdown files scanned, no broken links |
| `python scripts/check_ep_status_sync.py` | **exit 0** — 35 EP files vs 35 index rows, in sync |
| `python scripts/check_skill_re_frame2_drift.py` | **exit 0** — 50 leaves / 7416 lines |
| `sh scripts/check-no-hardcoded-paths.sh` | **exit 0** — no personal/home paths |

All run in the foreground, unpiped, with exit codes captured by redirect.

`mkdocs build --strict` alone is not sufficient — it logs broken anchors as
INFO and still exits 0 — so `check_doc_slugs.py` was run as the real link
gate; both are reported above.

`implementation/ui`'s `guide_truth_jvm_test.clj` was **not** run, because it
pins EP paths by exact path without globbing and pins only
`docs/EP/EP-0030-*` and `docs/EP/EP-0034-*` — neither EP-0035 nor any
`tools/story/spec/` path appears in its pinned-path list.

**No gate covers the corrected claims.** These are prose truth-claims about
bead state and a shipped API shape; no gate asserts them. The verification
shown above is the evidence.

## Notes

- **Xray boundary:** this is the Story side. Only `tools/story/spec/` is
  touched; nothing under `tools/xray/` or `tools/machines-viz/`, so the
  `tools/xray/spec/*` companion-update rule does not apply.
- **Sibling documents not swept** (named, not fixed):
  - `tools/story/spec/005-SOTA-Features.md` lines 263 / 889 still frame the
    embed as "Xray epoch panel embedded as `reg-story-panel`".
  - `tools/story/src/re_frame/story/ui/xray_embed.cljs` line 11 still lists
    `Issues` among the chip-row panels in its ns docstring, though that panel
    was removed.
  - `docs/EP/EP-0031-re-frame-ui-programming-model.md` was the other half of
    PR #6381 and was not re-audited here.
- **Unresolvable ids:** `rf2-v1ach`, `rf2-gbz39` and `rf2-5gl5r` are cited by
  `rf2-vpiz0` and by the shipped source comments, but none resolves in the
  tracker — they appear only as prose mentions inside other beads. They were
  therefore not minted as citations in the spec doc; the shipped facts were
  verified from source directly and the namespace docstring is named as the
  provenance home instead.
