### PR TITLE
fix: fence stale quiesce-hook warnings and align the Machines retry illustrations (rf2-vy2hj, rf2-z53ph)

### DIFF
--- a/docs/machines/coming-from-xstate.md
+++ b/docs/machines/coming-from-xstate.md
@@ -69,7 +69,7 @@ In XState you build a machine with `createMachine` — and in v6 a `setup()` reg
 import { setup, assign } from 'xstate';
 
 const loginMachine = setup({
-  guards:  { underRetryLimit: ({ context }) => context.attempts < 3 },
+  guards:  { underRetryLimit: ({ context }) => context.attempts < 2 },
   actions: { /* … */ },
 }).createMachine({
   initial: 'idle',
@@ -86,7 +86,7 @@ In re-frame2 the definition is *just data* — one map, with its `:guards` and `
    :data    {:attempts 0 :error nil}
 
    :guards
-   {:under-retry-limit (fn [{:keys [data]}] (< (:attempts data) 3))}
+   {:under-retry-limit (fn [{:keys [data]}] (< (:attempts data) 2))}
 
    :actions
    {:clear-error  (fn [_] {:data {:error nil}})
@@ -163,13 +163,13 @@ on: { FAILURE: [{ guard: 'underRetryLimit', target: 'errorShown' }, { target: 'l
 ```
 
 ```clojure
-:guards {:under-retry-limit (fn [{:keys [data]}] (< (:attempts data) 3))}
+:guards {:under-retry-limit (fn [{:keys [data]}] (< (:attempts data) 2))}
 ;; …on the :submitting node:
 :on {:auth.login/failure [{:guard :under-retry-limit :target :error-shown :action :record-error}
                           {:target :locked-out}]}
 ```
 
-Same guarded candidate vector, first-pass-wins — identical to XState's transition array. A guard (like an action) receives **one context map** and destructures what it needs: `(fn [{:keys [data event state meta]}] …)`. **Divergence:** there is no `{and: [...]}` / `stateIn` data combinator (XState v6 dropped the v5 `and`/`or`/`not`/`stateIn` creators, which re-frame2 never had) — a compound condition goes in one *named* function, so the *name* is what a diagram arrow and an AI read; cross-region coordination uses [tags](#tags). A guard or action that needs a host fact (the clock, a random draw) [declares it as a coeffect](concepts.md#guards-and-actions) rather than calling `(js/Date.now)`, so the decision replays identically under time-travel.
+Same guarded candidate vector, first-pass-wins — identical to XState's transition array. Both sides read `2` for this three-attempt login because a guard is evaluated *before* the transition's action — ahead of the `assign` in XState, ahead of `:record-error` here — so each sees the not-yet-bumped counter and the boundary sits one below the total ([Guards](concepts.md#guards)). A guard (like an action) receives **one context map** and destructures what it needs: `(fn [{:keys [data event state meta]}] …)`. **Divergence:** there is no `{and: [...]}` / `stateIn` data combinator (XState v6 dropped the v5 `and`/`or`/`not`/`stateIn` creators, which re-frame2 never had) — a compound condition goes in one *named* function, so the *name* is what a diagram arrow and an AI read; cross-region coordination uses [tags](#tags). A guard or action that needs a host fact (the clock, a random draw) [declares it as a coeffect](concepts.md#guards-and-actions) rather than calling `(js/Date.now)`, so the decision replays identically under time-travel.
 
 ### Reading the snapshot
 

--- a/docs/machines/glossary.md
+++ b/docs/machines/glossary.md
@@ -25,7 +25,7 @@ The data a machine *is*: a map with `:initial`, the starting [`:data`](#data), t
 ```clojure
 {:initial :idle
  :data    {:attempts 0 :error nil}
- :guards  {:under-retry-limit (fn [{d :data}] (< (:attempts d) 3))}
+ :guards  {:under-retry-limit (fn [{d :data}] (< (:attempts d) 2))}
  :actions {:clear-error (fn [_] {:data {:error nil}})}
  :states  {:idle       {:on {:submit {:target :submitting :action :clear-error}}}
            :submitting {...}}}
@@ -62,6 +62,8 @@ The move from one [state](#state) to another in response to a dispatched [event]
 ### **guard**
 
 A pure yes/no predicate that decides whether a [transition](#transition) fires. Referenced by name from the table and defined once in the machine's `:guards`, so a visualiser can read the condition right off the arrow. It receives the context map `{:data :event :state :meta}` (note: **no** app-db) and returns a boolean. There's no `{:and …}` combinator DSL — compound logic goes in one named function, so the *name* is what tools and AI read off the arrow.
+
+A guard runs *before* the transition's [action](#action), so it sees the pre-action snapshot: a counter the action is about to bump still holds its old value, and the boundary sits one below the total you want — `(< (:attempts d) 2)` for a three-attempt policy. See [Guards](concepts.md#guards).
 
 ### **action**
 

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -729,8 +729,11 @@
   The 2-arity therefore carries the restore's EXACT `incarnation-token` INTO the
   loop and revalidates ownership at every hook boundary, STOPPING the chain the
   moment the incarnation is lost rather than retargeting the remaining A-only
-  cleanup onto B. nil token (the 1-arity) has no incarnation to fence and fires
-  the whole chain, as before."
+  cleanup onto B. That revalidation covers the THROWING path too (rf2-vy2hj):
+  the swallow-and-warn catch is itself a post-callback tail, so it announces
+  only while the captured incarnation is still owned. nil token (the 1-arity)
+  has no incarnation to fence and fires the whole chain — and every warning —
+  as before."
   ([frame-id] (quiesce-orphaned-async-host-work! frame-id nil))
   ([frame-id incarnation-token]
    (let [still-owned? (fn []
@@ -741,12 +744,28 @@
        (when-let [f (late-bind/get-fn hook-key)]
          (try (f frame-id)
               (catch #?(:clj Throwable :cljs :default) ex
-                (trace/emit-error! :rf.warning/restore-quiesce-hook-exception
-                                   {:category  :rf.warning/restore-quiesce-hook-exception
-                                    :hook      hook-key
-                                    :frame     frame-id
-                                    :exception ex
-                                    :recovery  :ignored}))))))
+                ;; rf2-vy2hj: the SETTLED path needs the same fence as the
+                ;; loop's `:while`. A hook is the very callback boundary this
+                ;; chain polices, so hook 1 may destroy A, seat a same-id
+                ;; successor B, and only THEN throw — unwinding into a catch
+                ;; that addresses the frame by BARE id, which B now owns. The
+                ;; unfenced emit does NOT error; it silently RESURRECTS A's
+                ;; cleanup diagnostic as B's, fanning synchronously through B's
+                ;; public trace listeners (and retainable under B's id) BEFORE
+                ;; the loop's next `:while` gets to stop hook 2. The hazard is
+                ;; a run OUTLIVING its claim, not a token failing to arrive —
+                ;; the token is already conveyed correctly — so the repair is
+                ;; the same live-slot comparison, taken once more at the moment
+                ;; of announcement. A hook that throws under a STILL-LIVE
+                ;; incarnation is unaffected: it emits its one warning and the
+                ;; best-effort chain continues.
+                (when (still-owned?)
+                  (trace/emit-error! :rf.warning/restore-quiesce-hook-exception
+                                     {:category  :rf.warning/restore-quiesce-hook-exception
+                                      :hook      hook-key
+                                      :frame     frame-id
+                                      :exception ex
+                                      :recovery  :ignored})))))))
    nil))
 
 (defn commit-resources-restore-traces!

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -5496,6 +5496,139 @@
           (is (= [:machines :http] @fired)
               "every quiesce hook fired, in chain order"))))))
 
+(defn- with-quiesce-warning-capture
+  "Register a global `:trace` listener collecting every
+  `:rf.warning/restore-quiesce-hook-exception` row, run `(f warnings-atom)`,
+  unregister. The warning fans through the PUBLIC trace listener stream, which
+  is precisely the surface a stale A-tail must not reach once B owns the id."
+  [f]
+  (let [k        ::vy2hj-quiesce-warnings
+        warnings (atom [])]
+    (rf/register-listener! :trace k
+      (fn [ev]
+        (when (= :rf.warning/restore-quiesce-hook-exception (:operation ev))
+          (swap! warnings conj ev))))
+    (try (f warnings)
+         (finally (rf/unregister-listener! :trace k)))))
+
+(deftest restore-quiesce-hook-exception-fenced-after-ownership-lost
+  (testing "rf2-vy2hj — a quiesce hook is itself the callback boundary the
+            per-hook token fence exists to police, so the THROWING path needs
+            the same fence as the loop's `:while`. Hook 1 destroys incarnation
+            A, seats a same-id successor B, and only THEN throws. The catch runs
+            with ownership already lost and emits by BARE frame id, so an
+            unfenced emit delivers A's cleanup warning into B's trace stream —
+            the loop's next `:while` stops hook 2 only AFTER that emission. The
+            settled (catch) path must revalidate the SAME `still-owned?`
+            boundary before announcing anything."
+    (rf/make-frame {:id :test/vy2hj-quiesce})
+    (rf/reg-event :set-vq (fn [_ [_ o n]] {:db {:owner o :n n}}))
+    (rf/dispatch-sync [:set-vq :A 1] {:frame :test/vy2hj-quiesce})
+    (rf/dispatch-sync [:set-vq :A 2] {:frame :test/vy2hj-quiesce})
+    (let [target-id (some (fn [r] (when (= {:owner :A :n 1} (:db-after r)) (:epoch-id r)))
+                          (rf/epoch-history :test/vy2hj-quiesce))
+          {:keys [outcome epoch incarnation-token]}
+          (tool-pair/check-restore-preconditions! :test/vy2hj-quiesce target-id)
+          machines-saw (atom [])
+          http-saw     (atom [])]
+      (is (= :ok outcome) "preconditions passed against live incarnation A")
+      (with-quiesce-warning-capture
+        (fn [warnings]
+          (with-quiesce-hook-stubs
+            (fn [fid]
+              (swap! machines-saw conj fid)
+              ;; the cancellation churns A to a same-id successor B ...
+              (rf/destroy-frame! fid)
+              (rf/make-frame {:id fid})
+              (rf/dispatch-sync [:set-vq :B 99] {:frame fid})
+              ;; ... and only THEN fails. The catch is now a stale A tail.
+              (throw (ex-info "quiesce hook failed after seating B" {})))
+            (fn [fid] (swap! http-saw conj fid))
+            (fn []
+              (let [result (tool-pair/perform-restore! :test/vy2hj-quiesce incarnation-token epoch)]
+                (is (true? result)
+                    "the already-committed exact-incarnation install keeps its
+                     documented TRUE return — the throwing tail is best-effort")
+                (is (= [:test/vy2hj-quiesce] @machines-saw)
+                    "the FIRST quiesce hook ran under the live incarnation A")
+                ;; NOTE: the unfenced defect does NOT throw — it silently
+                ;; RESURRECTS A's diagnostic as B's, so absence of the row is
+                ;; the only sound assertion. Never assert an exception here.
+                (is (empty? @warnings)
+                    "ACCEPTANCE — A's quiesce-hook-exception warning is NOT
+                     delivered once the incarnation it describes is lost")
+                (is (empty? @http-saw)
+                    "no later quiesce hook runs after ownership is lost")
+                (is (= {:owner :B :n 99} (rf/app-db-value :test/vy2hj-quiesce))
+                    "successor B's state is untouched by A's throwing tail")))))))))
+
+(deftest restore-quiesce-hook-exception-still-emits-while-incarnation-live
+  (testing "rf2-vy2hj control — the fence rejects only a LOST incarnation. A
+            hook that throws while the captured incarnation is STILL LIVE emits
+            exactly one existing warning under the existing category, and the
+            best-effort chain continues to the next hook."
+    (rf/make-frame {:id :test/vy2hj-quiesce-live})
+    (rf/reg-event :set-vq2 (fn [_ [_ n]] {:db {:n n}}))
+    (rf/dispatch-sync [:set-vq2 1] {:frame :test/vy2hj-quiesce-live})
+    (rf/dispatch-sync [:set-vq2 2] {:frame :test/vy2hj-quiesce-live})
+    (let [target-id (some (fn [r] (when (= {:n 1} (:db-after r)) (:epoch-id r)))
+                          (rf/epoch-history :test/vy2hj-quiesce-live))
+          fired     (atom [])]
+      (with-quiesce-warning-capture
+        (fn [warnings]
+          (with-quiesce-hook-stubs
+            (fn [_fid]
+              (swap! fired conj :machines)
+              (throw (ex-info "machines quiesce failed, incarnation still live" {})))
+            (fn [_fid] (swap! fired conj :http))
+            (fn []
+              (is (true? (rf/restore-epoch! :test/vy2hj-quiesce-live target-id))
+                  "an ordinary within-incarnation restore still succeeds")
+              (is (= [:machines :http] @fired)
+                  "the best-effort chain continued past the throwing hook")
+              (is (= 1 (count @warnings))
+                  "exactly one warning for the one live-incarnation failure")
+              (is (= :rf.warning/restore-quiesce-hook-exception
+                     (:operation (first @warnings)))
+                  "the EXISTING category is reused — no new diagnostic id")
+              (is (= :machines/on-frame-restored!
+                     (:hook (:tags (first @warnings))))
+                  "the warning names the hook that actually threw"))))))))
+
+(deftest quiesce-warning-fence-admits-and-refuses-repeatedly
+  (testing "rf2-vy2hj sequence — the settled-path fence LATCHES NOTHING. Driving
+            ADMIT (throw while live) -> REFUSE (throw after churn) -> ADMIT ->
+            REFUSE inside ONE process proves the guard re-reads the live slot on
+            every announcement rather than tripping once and staying tripped (or
+            arming once and staying open). A single-transition test would pass
+            against a one-shot flag."
+    (let [fid :test/vy2hj-seq
+          ;; One round: seat a fresh incarnation, capture ITS exact token, fire
+          ;; the chain with a hook that throws — optionally churning the
+          ;; incarnation first. Returns the warnings emitted by this round.
+          round (fn [warnings churn?]
+                  (let [before (count @warnings)]
+                    (rf/make-frame {:id fid})
+                    (let [token (frame/frame-incarnation-token fid)]
+                      (with-quiesce-hook-stubs
+                        (fn [f]
+                          (when churn?
+                            (rf/destroy-frame! f)
+                            (rf/make-frame {:id f}))
+                          (throw (ex-info "hook failed" {})))
+                        (fn [_f] nil)
+                        (fn []
+                          (tool-pair/quiesce-orphaned-async-host-work! fid token))))
+                    (- (count @warnings) before)))]
+      (with-quiesce-warning-capture
+        (fn [warnings]
+          (is (= 1 (round warnings false)) "1st ADMIT — incarnation live, warning emitted")
+          (is (= 0 (round warnings true))  "1st REFUSE — ownership lost, warning withheld")
+          (is (= 1 (round warnings false)) "2nd ADMIT — the fence re-opened, not latched shut")
+          (is (= 0 (round warnings true))  "2nd REFUSE — the fence re-closed, not latched open")
+          (is (= 2 (count @warnings))
+              "exactly the two live-incarnation failures announced, in one process"))))))
+
 (deftest restore-trace-commit-carries-owner-token
   (testing "rf2-sdeae — the deferred resource-trace commit is a per-intent
             callback fan-out, so perform-restore! carries the captured exact


### PR DESCRIPTION
Two bounded defects, one commit each.

## rf2-vy2hj — stale quiesce-hook warnings after restore ownership is lost

`quiesce-orphaned-async-host-work!` revalidates the restore's incarnation token at every hook boundary, but only on the loop's `:while`. The swallow-and-warn `catch` emitted unconditionally.

A quiesce hook **is** the callback boundary the chain exists to police, so hook 1 can destroy incarnation A, seat a same-id successor B, and only *then* throw. The catch unwinds as a stale A tail and emits `:rf.warning/restore-quiesce-hook-exception` addressed by **bare frame id** — which B now owns.

**It does not throw.** Measured: the unfenced path silently *resurrects* A's cleanup diagnostic as B's, fanning synchronously through B's public trace listeners, all before the loop's next `:while` gets to stop hook 2. The test therefore asserts the row is **absent**, never that an exception is raised.

**Mechanism.** The token was already conveyed correctly into the 2-arity, so conveyance was never the hazard — the hazard is a run *outliving its claim*. The repair is the same live-slot comparison taken once more at the moment of announcement: gate the emit on the existing `still-owned?` predicate. A conveyed-value mechanism would not help here, because the emission target is resolved from a global slot by bare id at emit time; only a live-slot read at that instant can fence it.

No public token, no new diagnostic id, no lock, retry, or async abstraction; the existing category is reused. **No `spec/009` row needed.**

A hook that throws while its incarnation is still live is unaffected: one warning, chain continues.

## rf2-z53ph — Machines retry illustrations

The **illustrations** were wrong, not the runtime — verified against executable tests rather than prose:

- `examples_test.clj` drives the walkthrough machine and asserts `attempts=2` is the first value at which the guard rejects (three attempts total); its source is `(< … 2)` and cross-references `glossary.md#guard` — the very entry carrying the wrong boundary.
- `smoke_test.clj` drives a `< 3` machine and asserts "3 failures land in `:error-shown`, 4th in `:locked-out`", confirming `< 3` really is a **four**-attempt policy.

Fixed `glossary.md` (snippet `3` → `2`, plus the one-sentence pre-action note its `guard` entry lacked) and both `coming-from-xstate.md` snippets. The XState side of that side-by-side machine moves too: the page states it is built from concepts.md's one running example and that every snippet is real API, and XState evaluates guards ahead of `assign`, so the boundary is genuinely the same on both sides.

`examples/core/login` is deliberately four-attempt and is **untouched** at `< 3`. `inspecting-machines.md` was already consistent.

## Quality gates

All foreground, unpiped, re-run after rebasing onto current `main`.

| Gate | Result |
|---|---|
| `implementation/epoch` `clojure -M:test` | **440 tests**, 6281 assertions, 0 failures |
| `implementation/core` `clojure -M:test` | **2078 tests**, 9960 assertions, 0 failures |
| `implementation/machines` `clojure -M:test` | **1197 tests**, 4172 assertions, 0 failures |
| `npm run test:cljs` | **10214 tests**, 50482 assertions, 0 failures (exit 0) |
| `python -m mkdocs build --strict` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `scripts/check-no-hardcoded-paths.sh` | exit 0 |

`npm run test:browser` not run: no mounted behaviour is involved (quiesce hooks and doc prose), so a browser claim would add nothing.

### Falsifiability

Per-bead red-before with its own lever:

- **vy2hj** — `restore-quiesce-hook-exception-fenced-after-ownership-lost`: **10/10 RED** before, **10/10 GREEN** after, identical failure each trial (deterministic, not intermittent).
- **vy2hj sequence** — `quiesce-warning-fence-admits-and-refuses-repeatedly` drives ADMIT → REFUSE → ADMIT → REFUSE in **one process**. Both REFUSE teeth red pre-fix (4 warnings instead of 2) while both ADMIT teeth pass, so a one-shot flag cannot satisfy it.
- **vy2hj control** — `restore-quiesce-hook-exception-still-emits-while-incarnation-live`: green before *and* after; proves the fence rejects only a lost incarnation.
- **z53ph** — `check_doc_slugs.py` was probed with a deliberately broken anchor in the edited file and reported it by file, line, and target (exit 1); restored.

### Vacuity probes

- Flipping an assertion in the new epoch test redded the **full** epoch gate naming `quiesce-warning-fence-admits-and-refuses-repeatedly`, proving the namespace genuinely runs rather than being silently skipped. Restored; working tree verified byte-identical afterwards.
- Noted: `clojure -M:test -v ns/a ns/b ns/c` silently runs only **one** var. Each test was therefore verified individually.

### Notes

- No existing guard in this path was a bounds check in disguise. `still-owned?` delegates to `event-continuation-live?` → `frame-incarnation-live?`, which is an `identical?` comparison against the live slot. The `(nil? incarnation-token)` disjunct is the documented 1-arity contract, not a bounds test.
- No sibling illustrations left unswept.
