### PR TITLE
docs(spec): reconcile the 004 transition annex and ui synthesis to the current rulings (rf2-y27a7, rf2-yhlfe)

### DIFF
--- a/implementation/ui/test/re_frame/ui/test_guide02_fixture_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/test_guide02_fixture_jvm_test.clj
@@ -14,8 +14,10 @@
 
   HOST BOUNDARY, stated rather than papered over: the JVM structural
   render has no lifecycle, so the three-phase enter/exit machine (a
-  removed child retained as `:unmounting` until its transition ends or
-  `:timeout-ms` fires, then terminal exactly-once removal) is NOT
+  removed child retained as `:unmounting` for exactly the mandatory
+  `:timeout-ms` retention duration — the boundary is DOM-agnostic and
+  observes no transition or animation completion — then terminal
+  exactly-once removal) is NOT
   provable here — it rides `presence_dom_cljs_test` on the client, and
   `flush-presence!` advances it there (guide 08's fixture binds that
   contract). What this file binds on the JVM is what the JVM genuinely

--- a/scripts/check_adapter_disposition.py
+++ b/scripts/check_adapter_disposition.py
@@ -58,11 +58,6 @@ current ruling. Deleting the ruling from EP-0030 while leaving every other file
 merely silent would otherwise pass; `EP0030_REQUIRED` prevents that.
 
 NOT YET IN THE ROSTER (pending, deliberate):
-  * `spec/004-Views.md` — its transition annex (the `[SUPERSEDED]`-marked block
-    and the reg-view "freezes"/"v1 (frozen — compat tier)" text ABOVE that
-    marker) still carries the superseded shape. It is HOT-ZONE and was held by
-    another worker when rf2-vxgfnd.290 ran, so its repair is sequenced
-    separately. ADD IT TO `ACTIVE_AUTHORITIES` in the same PR that repairs it.
   * `.github/workflows/release.yml` — one stale comment phrase ("the compiled-
     view substrate that will replace the adapter trio"). CI surfaces are owned by
     rf2-nojiwy; add the file here when that owner corrects the phrase.
@@ -85,6 +80,7 @@ from pathlib import Path
 # --- The closed roster of ACTIVE dispatchable authorities ---------------------
 ACTIVE_AUTHORITIES = (
     "docs/EP/EP-0030-the-compiled-view-substrate-program.md",
+    "spec/004-Views.md",
     "skills/re-frame2-implementor/references/phase-2-impl-order.md",
     "implementation/README.md",
     "implementation/adapters/reagent/README.md",

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -657,7 +657,7 @@ enter/exit retention is out of scope):
 |---|---|
 | `(ui/raw react-element)` | embed an existing React element (child position; SSR paths need a `client-only` sibling fallback) |
 | `[ForeignComponent {…}]` | foreign React head; open props, JS values pass through; callbacks per §The decision table |
-| `(ui/->react view)` | export a view as a React component — the outward migration bridge. **v1, lands S6** with the migration wave. Contract: the compat-boundary contract §3 (promotes as `spec/004A-Reagent-Compat.md` at the S7 wave) — memoised per view id (returns the stable shell), no new React root/manifest/preflight; the exported view scopes frames, never creates them |
+| `(ui/->react view)` | export a view as a React component — the outward migration bridge. **v1, lands S6** with the migration wave. Contract: the compat-boundary contract §3, whose rules stay in their committed homes (no `spec/004A` appendix lands) — memoised per view id (returns the stable shell), no new React root/manifest/preflight; the exported view scopes frames, never creates them |
 | `(ui/element type props & children)` | runtime-chosen element/component **[WAVE-2]** |
 | `(ui/view id)` | registry-addressed component; production use requires production registry entries (dev-only string ids cannot serve prod lookup) **[WAVE-2]** |
 | `(ui/spread base overrides)` | the one generic runtime prop-map conversion — **v1**; the conversion architecture's single dynamic-map path, driven by the owning rule table |
@@ -1177,7 +1177,7 @@ path + generation, released/remounted on ambiguity.
   scanned absence roster. The always-on Spec 009 error contracts remain.
 - **[TRANSITION]** The `[view-id instance-token]` `:render-key` wire shape and the
   `[:rf.view/anonymous nil]` fallback for unregistered render fns are emitted by the
-  Reagent, UIx, and reagent-slim adapters — the compatibility/interop tier that lives on —
+  Reagent, UIx, and reagent-slim adapters — first-class, actively-supported adapters —
   and by the Helix adapter until it is removed at S7; the compiled substrate emits its own
   versioned evidence schema (integer render-key + separate `:view-id` + `occurrence-path`)
   in the 009 catalogue.
@@ -1252,21 +1252,22 @@ Compile budgets (expansion p95, watch-loop rebuild) are gated per
 There is exactly **one** component form. The following do not exist in this contract:
 
 - **Form-1 / Form-2 / Form-3.** No closure-form components, no class components, no
-  outer/inner render split; the Forms live on only in the stock-Reagent
-  compatibility/interop tier (live normative home: the compatibility appendix
-  `spec/004A-Reagent-Compat.md`, per §8 of the compat-boundary contract), taught on one
-  migration page only. Form-2 local state is `local`;
+  outer/inner render split; the Forms live on in the stock-Reagent adapter, which
+  remains first-class and actively supported. Their contract stays in the committed
+  homes named in the annex below (per §8 of the compat-boundary contract) — no
+  `spec/004A` appendix lands. Form-2 local state is `local`;
   Form-3 lifecycle work is
   `effect` (+ refs) or a foreign-boundary component; setup-on-mount work is a frame's
   `:initial-events` or a route/domain transition — never a render-phase or
   mount-lifecycle dispatch.
 - **The `reg-view` family.** `reg-view`, `reg-view*`, the two registration lanes, and
-  the `(rf/view id)` runtime lookup are absent from this contract — the family freezes
-  with the stock-Reagent compatibility tier, and its **live contract moves to the
-  compatibility appendix `spec/004A-Reagent-Compat.md`** (lands with the S7 deletion
-  wave; the appendix retains the family's API/facade/Conventions rows under a
-  `v1 (frozen — compat tier)` status — **the exports relocate, they are not removed**;
-  §8 of the compat-boundary contract). `defview` is the one
+  the `(rf/view id)` runtime lookup are absent from this contract — the family ships
+  with the **stock-Reagent adapter, which lives on as first-class and actively
+  supported**. Its live contract stays in the committed homes named in the annex below,
+  and its API/facade/Conventions rows keep their existing status: nothing freezes,
+  nothing relocates, and no `spec/004A` appendix lands (§8 of the compat-boundary
+  contract). Absent *from this contract* is a scoping statement about
+  `re-frame.ui`, not a judgement on the adapter. `defview` is the one
   registration surface;
   the registrar `:view` kind persists as the tooling read surface (Story mounts by view
   id; Xray lists by registry query). Runtime-chosen components are `ui/view` /
@@ -1290,57 +1291,39 @@ There is exactly **one** component form. The following do not exist in this cont
   frameworks, resumability machinery** — non-goals (resumability is research-tier per
   R-5).
 
-> **[SUPERSEDED — adapter disposition reframed 2026-07-17, Mike; EP-0030 Resolved
-> Decisions.]** The freeze/deletion framing in the [TRANSITION] block below is superseded
-> on the adapter-disposition point. **Reagent, UIx, and reagent-slim live on as
-> first-class, actively-supported adapters** (not frozen, not removed), and **only Helix
-> is removed** at S7. `re-frame.ui` is a *new experimental* substrate offered alongside
-> them, so `ui/defview` is **not** the only taught component form. The technical mechanics
-> below — the [TRANSITION] carriers, the `spec/004A-Reagent-Compat.md` appendix as the
-> Reagent tier's live home, the two-direction boundary contract, and old/new co-mounting —
-> remain valid; only the "frozen / adapters removed" labeling is retired. Read "deletion
-> wave" as "Helix-removal wave." A follow-up bead will fold this reframing into the annex
-> prose.
+**[TRANSITION] The adapter tier and this contract coexist.** `re-frame.ui` is a **new,
+experimental** substrate offered **alongside** the existing adapters — not a mandated
+replacement for them. **Stock Reagent (with the `reg-view` family), reagent-slim, and
+UIx all live on as first-class, actively-supported adapters**: not frozen, not scheduled
+for removal, each keeping its artifact, its public exports, its contract suite and one
+smoke, and its documented boot choice. **Only Helix is removed**, at S7 and strictly
+behind the soak gates recorded in
+[EP-0030 §Resolved Decisions](../docs/EP/EP-0030-the-compiled-view-substrate-program.md#resolved-decisions),
+which is the source of record for this disposition. Nothing in this contract retires an
+adapter or relocates its exports, and **no `spec/004A` compatibility appendix lands** —
+there is no compatibility tier to relocate exports into. `ui/defview` is *this*
+contract's one component form; the adapter tier's Forms remain taught alongside it. Old
+and new trees co-mount at explicit boundaries (per the migration guide), and the dataflow
+layer is untouched throughout. The process still installs exactly one adapter at boot —
+never per frame, never within one frame. After the Helix-removal wave, Spec 006's
+host-neutral contracts, the plain-atom substrate, and the benchmark results + fixtures
+are kept, along with a git tag over the removed Helix surfaces **as provenance, not
+contract**.
 
-**[TRANSITION] Until the adapter deletion wave** (proof/default/soak gates per the
-Adapters decision recorded in
-[EP-0030 §Resolved Decisions](../docs/EP/EP-0030-the-compiled-view-substrate-program.md#resolved-decisions):
-RealWorld-resources green · Story + Xray green ·
-SSR/hydration + HMR matrices green · production-specialization + bundle-absence gates
-green · templates/docs/examples defaulted · zero repo-owned non-historical
-UIx/Helix/slim imports · two consecutive green nightlies + one week with no fallback),
-the UIx and Helix adapters (and reagent-slim) remain shipping surfaces governed by the
-carried pre-rewrite contract text under these [TRANSITION] markers — **the markers, not
-git history, are the live contract during the transition** (the git tag is provenance
-only, never a normative home). **The Reagent-tier forms — Form-1/2/3 and the `reg-view`
-family — are not deleted at the wave: they freeze into the stock-Reagent compatibility
-tier**, whose **live normative home is the compatibility appendix
-`spec/004A-Reagent-Compat.md`** (lands with the wave; carries the freeze rules, the
-preserved Form/`reg-view`/Reagent-adapter/frame-context sections as live text, the
-two-direction boundary contract, the retained API/facade rows, and the two-suite CI
-surface — §8 of the compat-boundary contract). Correct but
-frozen: contract suite + one smoke in CI; no new capabilities; taught on exactly one
-migration page; `ui/defview` is the only *taught* component form. Old and new trees
-co-mount at explicit boundaries during migration (per the migration guide); the
-dataflow layer is untouched throughout. After the wave: Spec 006's host-neutral
-contracts, the plain-atom substrate, and benchmark results + fixtures are kept, and a
-git tag of UIx/Helix/slim is kept **as provenance, not contract**; those adapters are
-not.
-
-**Transition annex — where the frozen family's live contract text is carried until S7.**
-The compatibility appendix `spec/004A-Reagent-Compat.md` lands with the deletion wave;
-until then the carried pre-rewrite contract text for the frozen Form/`reg-view` family
-lives in the committed homes that already hold it, and **these markers name those homes
-as the live carriers**: [002](002-Frames.md) (`reg-view` injection + view ergonomics +
-Form pointers), [Conventions](Conventions.md) (the auto-id derivation rule + the
-`*`-suffix pair), [API.md](API.md) (the `reg-view` / `reg-view*` / `view` rows with
-shape + semantics notes), [009](009-Instrumentation.md)
+**Transition annex — where the adapter tier's view contract lives.** The `reg-view`
+family and Form-1/2/3 are absent from *this* contract because this contract specifies
+`re-frame.ui`; they remain live in the adapter tier, and **these markers name the
+committed homes that hold their contract text**: [002](002-Frames.md) (`reg-view`
+injection + view ergonomics + Form pointers), [Conventions](Conventions.md) (the auto-id
+derivation rule + the `*`-suffix pair), [API.md](API.md) (the `reg-view` / `reg-view*` /
+`view` rows with shape + semantics notes), [009](009-Instrumentation.md)
 (`:rf.registry/handler-replaced`), and [Spec-Schemas](Spec-Schemas.md) (the view
-registry-slot shape). Two governing sentences are carried here verbatim so the markers
-are the live contract: **the authoring-lane rule** — a state-touching view MUST be a
-registered view (`reg-view`), never a plain fn — governs the shipping adapters until the
-wave; and **`(rf/view id)` re-resolves the current registered implementation per call**,
-so a hot-reloaded view is picked up on the next render through the id handle.
+registry-slot shape). **Those homes are the live contract; git history never is.** Two
+governing sentences are carried here verbatim so the markers stand on their own: **the
+authoring-lane rule** — a state-touching view MUST be a registered view (`reg-view`),
+never a plain fn — governs the adapter tier; and **`(rf/view id)` re-resolves the current
+registered implementation per call**, so a hot-reloaded view is picked up on the next
+render through the id handle.
 
 ## Stage conformance profiles
 
@@ -1399,7 +1382,7 @@ a conflict is resolved in that order and is a defect in this table.
 | §The JVM structural subset — subs via the pure snapshot path | **S2** | the Q32/Q22 answer: `sub` *grammar* compiles at S1, but no Stage-1 Tier-1 fixture exercises a sub read — a Tier-1 render through a sub site (frame or `:sub-overrides`) is an S2 assertion |
 | §Hot reload — the view-side contract | **S2** | the full HMR matrix ([EP-0030 §Stages S1–S7](../docs/EP/EP-0030-the-compiled-view-substrate-program.md#stages-s1s7) places it with reactivity, deliberately early) |
 | §Removed forms — the absences | **S1** | absences are compile errors + export-surface checks from the first slice |
-| §Removed forms — [TRANSITION] freeze + the 004A appendix | **S7** | deletion-wave soak gates; `spec/004A-Reagent-Compat.md` lands |
+| §Removed forms — the [TRANSITION] coexistence statement | **S7** | Helix-removal soak gates; the retained adapters keep their suites and their contract homes — no appendix lands, no adapter is retired |
 
 **The S1 profile — what the R-1 atomic merge requires:** the rows tagged S1 above —
 portability law + parity corpus v0 · `defview` grammar/props-ABI/registration/
@@ -1410,7 +1393,8 @@ non-reactive rows · the removed-forms absences. That set passing its named asse
 **is** "the first conforming Stage-1 slice".
 
 **Ripple-row timing** (the atomic-merge sets for the inventory below): rows marked
-[TRANSITION] and every "moves to 004A" row land at **S7** with the appendix;
+[TRANSITION] land at **S7** with the Helix-removal wave — no row moves to a 004A
+appendix, because none lands;
 identity/naming/reservation rows (Conventions reserved `:rf.ui/*` namespace + artifact
 registration + lint key, Ownership's new-surface rows, `spec/API.md`'s `re-frame.ui`
 additions, the 008 `ui.test`/selector rows) land at **S1** with this rewrite;


### PR DESCRIPTION
Two bounded truth passes reconciling Spec 004 and the Guide 02 presence fixture to rulings already recorded elsewhere. No restructuring, no re-litigation, no new gate.

## rf2-y27a7 — Spec 004 adapter disposition

Ruling reconciled to: EP-0030 §Resolved Decisions (2026-07-17). `re-frame.ui` is a **new, experimental** substrate offered **alongside** the adapters. **Stock Reagent, reagent-slim and UIx all remain first-class and actively supported. Only Helix is removed** at S7. `spec/004A-Reagent-Compat.md` is not created — verified absent from the tree, and `rf2-vxgfnd.99` states it is not created by the wave.

**The bead named three sites. Nine carried the stale disposition.**

Six were **false conclusions**, replaced outright:

| Site | What it said | What is true |
|---|---|---|
| §Removed forms, `reg-view` bullet *(bead site 1)* | the family "freezes" with a compatibility tier; live contract "moves" to a `v1 (frozen — compat tier)` appendix | ships with stock Reagent, which lives on first-class; nothing freezes or relocates |
| §Removed forms, Form-1/2/3 bullet | Forms live on "only" in a compatibility/interop tier, taught on one migration page | live on in the stock-Reagent adapter; contract stays in its committed homes |
| The `[TRANSITION]` block *(bead site 2)* | UIx/Helix/slim temporary until an adapter deletion wave; Reagent freezes into the appendix; `ui/defview` the only taught form | the tier and this contract coexist; only Helix is removed |
| Stage row *(bead site 3)* | `[TRANSITION] freeze + the 004A appendix \| S7 \| 004A lands` | Helix-removal soak gates; no appendix, no adapter retired |
| Ripple-row timing | every "moves to 004A" row lands at S7 with the appendix | no row moves; none lands |
| The `[SUPERSEDED]` banner | asserted the 004A appendix "remains valid" as the Reagent tier's live home — refuted by the ruling it cites; also carried a live status claim ("a follow-up bead will fold this in") | removed as redundant per the bead, since the block below now states the ruling directly. **No second banner added.** |

Three were **dead bases** — conclusion survived, basis rewritten and kept:

- **§Interop `ui/->react` row** — the contract is still the compat-boundary contract §3; only "promotes as 004A at the S7 wave" dies.
- **§View identity `[TRANSITION]` render-key bullet** — the trio really does emit that wire shape and Helix really is removed at S7, but they are first-class adapters, not "the compatibility/interop tier".
- **The transition annex** — the five named carrier homes (002, Conventions, API.md, 009, Spec-Schemas) and the two verbatim governing sentences are live contract and are **kept intact**; only the "carried until S7, then 004A lands" basis is rewritten.

The `[TRANSITION]` marker token is retained: it is referenced cross-spec (`spec/Ownership.md`) and renaming it is outside this repair.

`spec/004-Views.md` added to `ACTIVE_AUTHORITIES` in `check_adapter_disposition.py`, with its pending-roster note dropped, per the bead and the script's own docstring.

## rf2-yhlfe — timeout-only presence

Verified **against the runtime**, not against prose: `analyze.cljc` makes `:timeout-ms` mandatory and removes the child when it fires; `a11y.cljc` states the boundary is DOM-agnostic, stamps no `inert`/`aria-hidden`, and that the child owns its exit; `presence_runtime.cljc` retains until the bound fires.

The Guide 02 JVM fixture docstring said a removed child is retained "until its transition ends or `:timeout-ms` fires" — a **false conclusion**, asserting the boundary observes transition completion. Corrected to the ruled wording.

Already correct, checked and left alone: `docs/api/re-frame.ui.md` and the `presence_runtime.cljc` docstring both carry #6294's timeout-only, DOM-agnostic, child-owned wording.

## Quality gates

All run in the foreground, unpiped, exit codes captured by redirect.

| Gate | Exit | Result |
|---|---|---|
| `python -m mkdocs build --strict` | **0** | built in 18.44s |
| `python scripts/check_doc_slugs.py` | **0** | clean |
| `python scripts/check_keyword_catalogue_drift.py` | **0** | clean |
| `python scripts/check_skill_re_frame2_drift.py --verbose` | **0** | 50 leaves / 7416 lines scanned |
| `check_adapter_disposition.py --self-test --verbose` | **0** | 37 cases passed |
| `check_adapter_disposition.py --verbose` | **0** | intact across **10** authorities (was 9) |
| `cd implementation/ui && clojure -M:test` | **0** | **955 tests, 18642 assertions, 0 failures** |
| `check-no-hardcoded-paths.sh` / `check-ai-tracking-ratchet.sh` / `check_synthesis_plan_authority.py` | **0** | clean; nothing newly tracked under `ai/` |

### Gate coverage of the corrected prose — honest reading

**No gate covered the nine defects.** Verified by running the scanner over the pre-edit file: `scan_text` reports **0 defects on `origin/main`'s `spec/004-Views.md`**. Rostering the file is still correct (it blocks future reintroduction of the matched status shapes, and both the bead and the script's docstring require it) but it did not, and would not have, caught this class — the stale text was `004A`-appendix and "the family freezes" phrasing that no pattern matches, some of it split across a line wrap that the per-line scan cannot see.

`guide_truth_jvm_test.clj` pins `spec/004-Views.md` by exact path but binds the portability-law, trusted-markup and abstract regions — **not** the annex. The doc gates cover links and slugs, not disposition claims.

Adding a `004A` pattern was considered and **not** done: it is scope growth the brief excludes, and it would immediately red-light four sibling documents this PR is fenced out of (below). That is a ruling, not a determinable fact.

## Named, not swept

Sibling documents still carrying the `004A`/compat-tier framing, outside this PR's fence:

- `spec/Ownership.md:40` — "The Reagent tier's live contract relocates to `spec/004A-Reagent-Compat.md`" (disposition line itself already correct)
- `spec/AI-Audit.md:388` — 004 "[TRANSITION]-tags for relocation to the compatibility appendix at S7"
- `spec/Pattern-StatefulComponents.md:10` — "joins the compatibility family's contract in the compatibility appendix"
- `docs/EP/EP-0031-...md:222,257` — "live home `spec/004A-Reagent-Compat.md` at S7"

## Stopped on

**`rf2-yhlfe`'s synthesis scope.** Seven of the eight files it names sit under `ai/findings/new-substrate-synthesis/`, which was **tombstoned on 2026-07-18** (`rf2-mgy7pz`, PR #6231) — after the bead was filed. Its README now directs readers to "read the graduated home, not the tombstoned source", so the bead's premise that these are *active* authorities has been overtaken, and the tree is outside this worker's fence besides. Whether the tombstone discharges that scope or the files still warrant a truth pass before their S7 deletion is a lifecycle call for the operator. Files: `01-goals-and-invariants.md`, `02-programming-model.md`, `07-testing.md`, `08-delivery.md`, `guide/02-views.md`, `skill/SKILL.md`, `drafts/spec-004-rewrite-draft.md`.

No adapter was described as retiring; no new live status claim was asserted; no EP status was flipped.
