### PR TITLE
fix(spec): resolve the epoch-record cardinality contradiction and simplify the G-13 proof (rf2-2deuf, rf2-muhsq)

### DIFF
--- a/implementation/scripts/_g13-timing-evidence.test.cjs
+++ b/implementation/scripts/_g13-timing-evidence.test.cjs
@@ -15,14 +15,21 @@
  * rendering are pure and pinned here so a regression can be caught without
  * spawning shadow-cljs or Playwright. Standalone node runner, matching the
  * sibling `_*.test.cjs` convention.
+ *
+ * rf2-muhsq — the source-text half of the containment proof used to live here
+ * too: a Clojure string/comment blanker, private-defn delimiters, and exact
+ * form/multiplicity regexes over `dev.cljs`, duplicated again in
+ * `run-ui-g13.cjs`. Containment is now a property of the measurement seam
+ * (`re-frame.ui.g13.measure/measure-dispatch-to-commit!`), whose call order is
+ * asserted directly in `re-frame.ui.g13.measure-cljs-test`. What remains here
+ * is `assertTimedIntervalDidWork` — the runtime half — which, now that the
+ * seam owns both witness reads, also rejects a dispatch hoisted out of the
+ * flushed thunk.
  */
 
 'use strict';
 
 const assert = require('assert/strict');
-
-const fs = require('fs');
-const path = require('path');
 
 const {
   RECORDED_SAMPLES,
@@ -34,8 +41,6 @@ const {
   assertColdIsFirstDrain,
   assertColdOrderControl,
   assertTimedIntervalDidWork,
-  assertTimedRegionShape,
-  codeOnly,
   buildSummary,
 } = require('./lib/g13-timing-evidence.cjs');
 
@@ -363,148 +368,6 @@ test('assertTimedIntervalDidWork rejects a non-positive queued-writes basis', ()
   assert.throws(
     () => assertTimedIntervalDidWork(0, 0, 0),
     /queued-writes must be a positive finite number/,
-  );
-});
-
-// ----- assertTimedRegionShape: STRUCTURAL containment (rf2-a0i2y) ------------
-//
-// Containment is a property of the measured region's SHAPE, so it is proven by
-// construction against the fixture source rather than inferred from samples that
-// happen to pass. These tests drive the real `dev.cljs`, then mutate it.
-
-const DEV_FIXTURE_SOURCE = path.join(
-  __dirname, '..', 'ui', 'g13', 're_frame', 'ui', 'g13', 'dev.cljs',
-);
-const DEV_SOURCE = fs.readFileSync(DEV_FIXTURE_SOURCE, 'utf8');
-
-const TIMED_DISPATCH_FORM = '(uit/dispatch! frame [::fixture/step fixture/queued-writes])';
-const TIMED_START_FORM = 'started (js/performance.now)]';
-const TIMED_ELAPSED_FORM = '(let [elapsed-ms (- (js/performance.now) started)]';
-const TIMED_POST_WITNESS_FORM = ':post-hot (:hot (rf/app-db-value frame))';
-
-function mutated(edits) {
-  let out = DEV_SOURCE;
-  for (const [find, replaceWith] of edits) {
-    const next = out.replace(find, replaceWith);
-    // A stale anchor would hand the checker an UNCHANGED source, and "unchanged
-    // passes" reads exactly like "the mutation was caught".
-    assert.notEqual(next, out, `stale tooth anchor — dev.cljs no longer contains: ${find}`);
-    out = next;
-  }
-  return out;
-}
-
-test('assertTimedRegionShape accepts the real fixture: dispatch and commit are inside the span', () => {
-  assert.deepEqual(assertTimedRegionShape(DEV_SOURCE), [
-    'the pre-dispatch app-db witness read',
-    'the interval START timestamp',
-    'the flush! that owns the measured interval',
-    'the timed dispatch',
-    'the interval END timestamp',
-    'the post-commit app-db witness read',
-  ]);
-});
-
-test('assertTimedRegionShape REJECTS the dispatch removed from the flushed thunk', () => {
-  assert.throws(
-    () => assertTimedRegionShape(mutated([[TIMED_DISPATCH_FORM, 'nil']])),
-    /expected exactly 1 dispatch! calls in the timed region, found 0/,
-  );
-});
-
-test('assertTimedRegionShape REJECTS the dispatch replaced with a no-op event', () => {
-  assert.throws(
-    () => assertTimedRegionShape(
-      mutated([[TIMED_DISPATCH_FORM, '(uit/dispatch! frame [::fixture/noop])']]),
-    ),
-    /the timed dispatch is absent from the timed region/,
-  );
-});
-
-test('assertTimedRegionShape REJECTS the dispatch hoisted above the start timestamp', () => {
-  // THE MUTANT THE RUNTIME WITNESS CANNOT SEE. The pre-hot read still precedes
-  // the hoisted dispatch, so post-minus-pre is still exactly queued-writes — yet
-  // the measured span no longer covers the eight write epochs. Only the source
-  // order shows it.
-  assert.throws(
-    () => assertTimedRegionShape(mutated([
-      [TIMED_DISPATCH_FORM, 'nil'],
-      [TIMED_START_FORM, `_ ${TIMED_DISPATCH_FORM}\n        ${TIMED_START_FORM}`],
-    ])),
-    /the timed dispatch does not follow the flush! that owns the measured interval/,
-  );
-});
-
-test('assertTimedRegionShape REJECTS the dispatch moved past the end timestamp', () => {
-  assert.throws(
-    () => assertTimedRegionShape(mutated([
-      [TIMED_DISPATCH_FORM, 'nil'],
-      [TIMED_ELAPSED_FORM, `${TIMED_ELAPSED_FORM}\n                   ${TIMED_DISPATCH_FORM}`],
-    ])),
-    /the interval END timestamp does not follow the timed dispatch/,
-  );
-});
-
-test('assertTimedRegionShape REJECTS the closing witness read moved inside the span', () => {
-  // The closing witness must cost the measured interval nothing; reading it
-  // before the end timestamp would put validation work on the clock.
-  assert.throws(
-    () => assertTimedRegionShape(mutated([
-      [TIMED_ELAPSED_FORM,
-        '(let [post-hot (:hot (rf/app-db-value frame))\n'
-        + '                       elapsed-ms (- (js/performance.now) started)]'],
-      [TIMED_POST_WITNESS_FORM, ':post-hot post-hot'],
-    ])),
-    /the post-commit app-db witness read does not follow the interval END timestamp/,
-  );
-});
-
-test('assertTimedRegionShape rejects an extra timestamp reading inside the region', () => {
-  assert.throws(
-    () => assertTimedRegionShape(mutated([
-      [TIMED_START_FORM, `mid (js/performance.now)\n        ${TIMED_START_FORM}`],
-    ])),
-    /expected exactly 2 performance.now readings in the timed region, found 3/,
-  );
-});
-
-test('assertTimedRegionShape fails loudly when the measured region cannot be located', () => {
-  assert.throws(() => assertTimedRegionShape(''), /fixture source was not readable/);
-  assert.throws(
-    () => assertTimedRegionShape(DEV_SOURCE.replace('(defn- timing-cycle!', '(defn- timed-cycle!')),
-    /could not locate `\(defn- timing-cycle!`/,
-  );
-  assert.throws(
-    () => assertTimedRegionShape(DEV_SOURCE.replace('(defn- correctness-cycle!', '(defn- audit-cycle!')),
-    /could not locate `\(defn- correctness-cycle!`/,
-  );
-});
-
-test('codeOnly blanks strings and comments, preserving offsets — prose cannot satisfy the proof', () => {
-  // The region's docstring genuinely says "dispatch" and "performance"; without
-  // this the ordering would be computed over prose, the byte-slice mistake the
-  // deps-boundary arm already refuses to make.
-  const src = '(a "str ; not-a-comment" b) ; (uit/dispatch! x)\n(c)';
-  const out = codeOnly(src);
-  assert.equal(out.length, src.length, 'offsets must be preserved');
-  assert.equal(out.includes('not-a-comment'), false);
-  assert.equal(out.includes('uit/dispatch!'), false);
-  // The code parens survive in place; only the literal's bytes are blanked.
-  assert.equal(out.indexOf('(a '), 0);
-  assert.equal(out.indexOf('b)'), src.indexOf('b)'));
-  assert.equal(out.endsWith('\n(c)'), true, 'newlines must survive');
-});
-
-test('codeOnly does not let a docstring mention forge the region shape', () => {
-  // Deleting the real dispatch while leaving one NAMED in the docstring must
-  // still fail: the mention lives in a string and is blanked before counting.
-  const forged = mutated([
-    [TIMED_DISPATCH_FORM, 'nil'],
-    ['Returns `{:elapsed-ms', `${TIMED_DISPATCH_FORM} Returns \`{:elapsed-ms`],
-  ]);
-  assert.throws(
-    () => assertTimedRegionShape(forged),
-    /expected exactly 1 dispatch! calls in the timed region, found 0/,
   );
 });
 

--- a/implementation/scripts/lib/g13-timing-evidence.cjs
+++ b/implementation/scripts/lib/g13-timing-evidence.cjs
@@ -93,27 +93,33 @@ const COLD_FIRST_DRAIN_PRE_HOT = 0;
 
 // rf2-a0i2y — DID THE MEASURED INTERVAL CONTAIN ITS OWN DISPATCH AND COMMIT?
 //
-// Every witness above describes state BEFORE the timed dispatch, so none of them
+// Every OTHER witness describes state BEFORE the timed dispatch, so none of them
 // can separate a real measured drain from an EMPTY one. Delete the dispatch from
-// `timing-cycle!` and the whole gate stays green: `timing-first` pre-hot is still
-// the mount seed 0, `correctness-first` pre-hot still advances to queued-writes
-// (the SEPARATE untimed correctness cycle advanced it), and that same correctness
-// cycle still supplies every projection — so the runner labels a flush interval
-// that did nothing "dispatch-to-commit" and reports it as evidence.
+// `timing-cycle!` and the rest of the gate stays green: `timing-first` pre-hot is
+// still the mount seed 0, `correctness-first` pre-hot still advances to
+// queued-writes (the SEPARATE untimed correctness cycle advanced it), and that
+// same correctness cycle still supplies every projection — so the runner would
+// label a flush interval that did nothing "dispatch-to-commit".
 //
-// The closing witness is the timed cycle's own POST-commit app-db `:hot`, read
-// AFTER its end timestamp (no validation work enters the measured span) and
-// returned with that same cycle. `post - pre` is exactly the number of writes
-// that committed between the two reads. The reads bracket the two timestamps by
-// construction — nothing but the `performance.now` call itself sits between the
-// pre read and `started`, and nothing but the elapsed subtraction sits between
-// the end timestamp and the post read — so a delta of `queuedWrites` is proof
-// that this interval carried the drain it is named for. A removed, no-op, or
-// hoisted-out dispatch yields 0 (or the wrong delta) and is rejected here.
+// Both witnesses are read by the measurement seam itself
+// (`re-frame.ui.g13.measure/measure-dispatch-to-commit!`): `pre-hot` before its
+// start timestamp, `post-hot` after its end timestamp. `post - pre` is therefore
+// exactly the number of writes that committed inside the measured interval, and
+// a delta of `queuedWrites` is proof that this interval carried the drain it is
+// named for.
 //
-// This is the RUNTIME half of the containment proof. The LEXICAL half — dispatch
-// inside the flushed thunk, thunk between the two timestamps — is pinned by
-// `assertTimedRegionShape` below, which reads the fixture source itself.
+// rf2-muhsq — because the seam owns BOTH reads rather than taking them from its
+// caller, this check now also rejects the mutant that used to need a source-text
+// proof: work HOISTED out of the flushed thunk. A caller that dispatches before
+// calling the seam has advanced app-db by the time `pre-hot` is read, so pre and
+// post agree and the delta is 0. Removed, no-op, hoisted-above, and deferred-past
+// dispatches all collapse the delta and are rejected here.
+//
+// What this does NOT establish is the seam's own internal order — that the work
+// runs inside the flush and the two witness reads sit outside the two
+// timestamps. That is a call-order property of one small function and is
+// asserted directly, with a fake clock and a fake flush, by
+// `re-frame.ui.g13.measure-cljs-test`. No source text is read by either half.
 function assertTimedIntervalDidWork(pre, post, queuedWrites, where = 'timed interval work witness') {
   if (typeof queuedWrites !== 'number' || !Number.isFinite(queuedWrites) || queuedWrites <= 0) {
     throw evidenceFail(
@@ -236,191 +242,6 @@ function assertColdOrderControl(order, queuedWrites, where = 'cold-first order c
   return order;
 }
 
-// ---------------------------------------------------------------------------
-// rf2-a0i2y — the STRUCTURAL half of the containment proof.
-//
-// The runtime witness above proves the interval did `queuedWrites` of work
-// between the two app-db reads. Those reads sit immediately outside the two
-// timestamps, so the remaining question is purely lexical: is the dispatch
-// actually inside the flushed thunk, and is that thunk actually between the
-// start and end timestamps? That is a property of the fixture's SOURCE, and it
-// is better proven by construction than by any number of green samples — so it
-// is asserted here over `dev.cljs` itself, the same way the lease-free arm
-// asserts its positive controls against `reactive.cljc`.
-//
-// It also closes the one mutant the runtime witness cannot see. Hoisting the
-// dispatch above `started` leaves the post-pre delta at exactly `queuedWrites`
-// (the pre read still precedes the hoisted dispatch), yet the measured span no
-// longer contains the eight write epochs. Only the source order shows that, and
-// the ordering assertion below rejects it.
-// ---------------------------------------------------------------------------
-
-const TIMED_REGION_OPEN = '(defn- timing-cycle!';
-const TIMED_REGION_CLOSE = '(defn- correctness-cycle!';
-
-// Blank out Clojure string literals, `;` comments and `\x` character literals,
-// PRESERVING byte offsets and newlines, so the ordering below is computed over
-// CODE only. This region's docstring legitimately says "dispatch", "pre-hot" and
-// "performance"; a raw indexOf over the text would count prose as structure —
-// precisely the byte-slice mistake the deps-boundary arm already refuses to make
-// (rf2-5e3ic/rf2-han0r). Prose can no longer satisfy — or break — this proof.
-function codeOnly(source) {
-  let out = '';
-  let i = 0;
-  const n = source.length;
-  while (i < n) {
-    const ch = source[i];
-    if (ch === '\\') { // character literal: \( \; \" ...
-      out += ' ';
-      i += 1;
-      if (i < n) { out += source[i] === '\n' ? '\n' : ' '; i += 1; }
-      continue;
-    }
-    if (ch === '"') {
-      out += ' ';
-      i += 1;
-      while (i < n && source[i] !== '"') {
-        if (source[i] === '\\') {
-          out += ' ';
-          i += 1;
-          if (i < n) { out += source[i] === '\n' ? '\n' : ' '; i += 1; }
-          continue;
-        }
-        out += source[i] === '\n' ? '\n' : ' ';
-        i += 1;
-      }
-      if (i < n) { out += ' '; i += 1; }
-      continue;
-    }
-    if (ch === ';') {
-      while (i < n && source[i] !== '\n') { out += ' '; i += 1; }
-      continue;
-    }
-    out += ch;
-    i += 1;
-  }
-  return out;
-}
-
-function occurrences(haystack, re) {
-  const global = new RegExp(re.source, `${re.flags.replace('g', '')}g`);
-  const found = [];
-  let m = global.exec(haystack);
-  while (m !== null) {
-    found.push(m.index);
-    if (m.index === global.lastIndex) global.lastIndex += 1;
-    m = global.exec(haystack);
-  }
-  return found;
-}
-
-// The measured region's required lexical shape, in required source order. Each
-// row names WHY it is where it is, because the failure message is the only thing
-// a future editor will read.
-const TIMED_REGION_ANCHORS = [
-  {
-    name: 'the pre-dispatch app-db witness read',
-    re: /rf\/app-db-value/,
-    nth: 1,
-    why: 'the opening witness must be read BEFORE the interval starts',
-  },
-  {
-    name: 'the interval START timestamp',
-    re: /js\/performance\.now/,
-    nth: 1,
-    why: 'the measured span opens here',
-  },
-  {
-    name: 'the flush! that owns the measured interval',
-    re: /\(uit\/flush!/,
-    nth: 1,
-    why: 'the flush whose Promise resolution IS the commit must open inside the span',
-  },
-  {
-    name: 'the timed dispatch',
-    re: /\(uit\/dispatch!\s+frame\s+\[::fixture\/step\s+fixture\/queued-writes\]\)/,
-    nth: 1,
-    why: 'the dispatch under measurement must sit INSIDE the flushed thunk, after the start timestamp',
-  },
-  {
-    name: 'the interval END timestamp',
-    re: /js\/performance\.now/,
-    nth: 2,
-    why: 'the measured span closes here, once the commit has resolved',
-  },
-  {
-    name: 'the post-commit app-db witness read',
-    re: /rf\/app-db-value/,
-    nth: 2,
-    why: 'the closing witness must be read AFTER the end timestamp, so it adds no work to the span',
-  },
-];
-
-// Exact multiplicities. Without these an extra `performance.now` or a second
-// dispatch could satisfy the ordering while changing what is measured.
-const TIMED_REGION_COUNTS = [
-  { name: 'performance.now readings', re: /js\/performance\.now/, exactly: 2 },
-  { name: 'app-db witness reads', re: /rf\/app-db-value/, exactly: 2 },
-  { name: 'flush! calls', re: /\(uit\/flush!/, exactly: 1 },
-  { name: 'dispatch! calls', re: /\(uit\/dispatch!/, exactly: 1 },
-];
-
-// Prove, from `devSource`, that the timed region contains its dispatch and its
-// commit BY CONSTRUCTION. Returns the pinned order on success.
-function assertTimedRegionShape(devSource, where = 'G-13 timed region containment') {
-  if (typeof devSource !== 'string' || devSource.length === 0) {
-    throw evidenceFail(`${where}: the fixture source was not readable`);
-  }
-  const open = devSource.indexOf(TIMED_REGION_OPEN);
-  if (open < 0) {
-    throw evidenceFail(
-      `${where}: could not locate \`${TIMED_REGION_OPEN}\` — the measured region this proof ` +
-        'is about no longer exists under that name; re-establish containment before renaming it',
-    );
-  }
-  const close = devSource.indexOf(TIMED_REGION_CLOSE, open);
-  if (close < 0) {
-    throw evidenceFail(
-      `${where}: could not locate \`${TIMED_REGION_CLOSE}\` after the timed region — the proof ` +
-        'delimits the timed cycle by the untimed cycle that must follow it',
-    );
-  }
-  const region = codeOnly(devSource.slice(open, close));
-  for (const { name, re, exactly } of TIMED_REGION_COUNTS) {
-    const n = occurrences(region, re).length;
-    if (n !== exactly) {
-      throw evidenceFail(
-        `${where}: expected exactly ${exactly} ${name} in the timed region, found ${n}. ` +
-          'The measured dispatch-to-commit span is defined by exactly these forms; ' +
-          'adding or removing one changes what the reported number means.',
-      );
-    }
-  }
-  const positions = TIMED_REGION_ANCHORS.map((anchor) => {
-    const at = occurrences(region, anchor.re)[anchor.nth - 1];
-    if (at === undefined) {
-      throw evidenceFail(
-        `${where}: ${anchor.name} is absent from the timed region (${anchor.why}). ` +
-          'A measured interval missing this form does not contain the dispatch and commit it is named for.',
-      );
-    }
-    return { ...anchor, at };
-  });
-  for (let i = 1; i < positions.length; i += 1) {
-    const previous = positions[i - 1];
-    const current = positions[i];
-    if (!(previous.at < current.at)) {
-      throw evidenceFail(
-        `${where}: ${current.name} does not follow ${previous.name} in the timed region ` +
-          `(offsets ${previous.at} then ${current.at}). ${current.why}. The dispatch and commit ` +
-          'are no longer inside the measured span by construction — the reported ' +
-          'dispatch-to-commit number would describe a different region than its label claims.',
-      );
-    }
-  }
-  return positions.map((p) => p.name);
-}
-
 function fmt(x) {
   return Number(x).toFixed(3);
 }
@@ -467,15 +288,11 @@ module.exports = {
   RECORDED_SAMPLES,
   PERCENTILE_CONVENTION,
   COLD_FIRST_DRAIN_PRE_HOT,
-  TIMED_REGION_OPEN,
-  TIMED_REGION_CLOSE,
   warmPercentile,
   validateWarmSamples,
   summarizeWarm,
   assertColdIsFirstDrain,
   assertColdOrderControl,
   assertTimedIntervalDidWork,
-  assertTimedRegionShape,
-  codeOnly,
   buildSummary,
 };

--- a/implementation/scripts/run-ui-g13.cjs
+++ b/implementation/scripts/run-ui-g13.cjs
@@ -40,7 +40,6 @@ const {
   assertColdIsFirstDrain,
   assertColdOrderControl,
   assertTimedIntervalDidWork,
-  assertTimedRegionShape,
   buildSummary,
 } = require('./lib/g13-timing-evidence.cjs');
 
@@ -51,12 +50,6 @@ const DEV = path.join(OUT, 'ui-g13');
 const PROD = path.join(OUT, 'ui-g13-prod');
 const MINT_CONTROL = path.join(OUT, 'ui-g13-mint-control');
 const PROD_MANIFEST = path.join(PROD, 'manifest.edn');
-// rf2-a0i2y — the measured region's own source. The structural containment proof
-// reads it directly, so the claim "the dispatch and commit are inside the timed
-// span" rests on the fixture's shape rather than on samples that happen to pass.
-const DEV_FIXTURE_SOURCE = path.join(
-  IMPL, 'ui', 'g13', 're_frame', 'ui', 'g13', 'dev.cljs',
-);
 const REPORT = path.join(OUT, 'ui-g13.json');
 const TIMEOUT = 90000;
 const SENTINELS = [
@@ -460,64 +453,6 @@ function assertDevResult(result) {
   }
 }
 
-// rf2-a0i2y — the source anchors the containment teeth rewrite. Held as named
-// constants so a tooth and the fixture cannot drift apart silently.
-const TIMED_DISPATCH_FORM = '(uit/dispatch! frame [::fixture/step fixture/queued-writes])';
-const TIMED_START_FORM = 'started (js/performance.now)]';
-const TIMED_ELAPSED_FORM = '(let [elapsed-ms (- (js/performance.now) started)]';
-const TIMED_POST_WITNESS_FORM = ':post-hot (:hot (rf/app-db-value frame))';
-
-// Apply an ordered list of literal source edits, FAILING LOUDLY if any of them
-// matches nothing. A tooth whose anchor drifted would otherwise hand the checker
-// an unchanged source, and "unchanged source passes" is indistinguishable from
-// "the mutation was caught" — the shape of false-green this whole arm exists to
-// refuse (rf2-jxpf3).
-function mutateSource(source, edits) {
-  let out = source;
-  for (const [find, replaceWith] of edits) {
-    const next = out.replace(find, replaceWith);
-    if (next === out) {
-      fail(
-        `timed-region containment tooth is stale: dev.cljs no longer contains \`${find}\`. ` +
-          'Re-establish the containment proof against the current source rather than deleting the tooth.',
-      );
-    }
-    out = next;
-  }
-  return out;
-}
-
-// The four ways the dispatch can stop being inside the measured span, plus the
-// one way the closing witness can leak INTO it. Each is a real source shape a
-// reviewer could plausibly write, not a JSON edit — the runtime witness alone
-// cannot see the third of these, because hoisting the dispatch above the start
-// timestamp leaves the post-minus-pre delta at exactly queued-writes while the
-// measured span no longer covers the eight write epochs.
-function timedRegionMutations(devSource) {
-  return [
-    ['timed dispatch removed from the flushed thunk', mutateSource(devSource, [
-      [TIMED_DISPATCH_FORM, 'nil'],
-    ])],
-    ['timed dispatch replaced with a no-op event', mutateSource(devSource, [
-      [TIMED_DISPATCH_FORM, '(uit/dispatch! frame [::fixture/noop])'],
-    ])],
-    ['timed dispatch hoisted above the start timestamp', mutateSource(devSource, [
-      [TIMED_DISPATCH_FORM, 'nil'],
-      [TIMED_START_FORM, `_ ${TIMED_DISPATCH_FORM}\n        ${TIMED_START_FORM}`],
-    ])],
-    ['timed dispatch moved past the end timestamp', mutateSource(devSource, [
-      [TIMED_DISPATCH_FORM, 'nil'],
-      [TIMED_ELAPSED_FORM, `${TIMED_ELAPSED_FORM}\n                   ${TIMED_DISPATCH_FORM}`],
-    ])],
-    ['closing witness read moved inside the measured span', mutateSource(devSource, [
-      [TIMED_ELAPSED_FORM,
-        '(let [post-hot (:hot (rf/app-db-value frame))\n'
-        + '                       elapsed-ms (- (js/performance.now) started)]'],
-      [TIMED_POST_WITNESS_FORM, ':post-hot post-hot'],
-    ])],
-  ];
-}
-
 function expectMutationFailure(label, thunk) {
   try {
     thunk();
@@ -703,14 +638,26 @@ function assertMutationTeeth(result) {
       `${prodManifest}\n"re_frame/resources/internal/runtime.cljs"`,
     );
   }));
-  // rf2-a0i2y — the STRUCTURAL containment teeth, driven against the real
-  // fixture source rather than a JSON result. Containment is a property of the
-  // measured region's shape, so it is proven by construction here and only
-  // corroborated by the runtime witness above.
-  const devSource = fs.readFileSync(DEV_FIXTURE_SOURCE, 'utf8');
-  for (const [label, mutated] of timedRegionMutations(devSource)) {
-    red.push(expectMutationFailure(label, () => assertTimedRegionShape(mutated)));
-  }
+  // rf2-muhsq — the five source-text containment teeth that used to run here
+  // (dispatch removed from the flushed thunk / replaced with a no-op / hoisted
+  // above the start timestamp / moved past the end timestamp, and the closing
+  // witness read moved inside the span) are gone, along with the Clojure
+  // blanker and private-defn anchors they needed. They are not un-tested:
+  //
+  //   - The first four all collapse `post-hot - pre-hot` to 0 now that the
+  //     measurement seam owns BOTH witness reads, so they land on the
+  //     `timed interval was empty` teeth above — the cold, warm, and both
+  //     order-control paths each assert the delta on real browser samples.
+  //     The hoist is the one that previously escaped a runtime witness; that
+  //     it no longer does is exercised directly by
+  //     `work-hoisted-out-of-the-thunk-collapses-the-delta`.
+  //   - The fifth is a call-order property of the seam and is asserted by
+  //     `seam-brackets-the-flushed-work-with-clock-then-witness`, which
+  //     compares the whole call log and so also rejects an extra timestamp.
+  //
+  // Both live in `re-frame.ui.g13.measure-cljs-test` and ride `npm run
+  // test:cljs`. Nothing reads fixture source text any more, so renaming a
+  // private fn or extracting a helper no longer fails CI.
   return red;
 }
 
@@ -746,14 +693,6 @@ async function main() {
   let browser;
   let tearingDown = false;
   try {
-    // rf2-a0i2y — prove containment BY CONSTRUCTION before spending a compile on
-    // measuring anything: the dispatch must be lexically inside the flushed thunk
-    // and that thunk lexically between the two timestamps, with the closing
-    // witness read strictly after the end timestamp. No sample can establish
-    // this, and a green sample set does not need to.
-    const timedRegionOrder = assertTimedRegionShape(
-      fs.readFileSync(DEV_FIXTURE_SOURCE, 'utf8'),
-    );
     shadow('compile', 'ui-g13');
     shadow('release', 'ui-g13-prod', 'ui-g13-mint-control');
     writePage(DEV);
@@ -822,12 +761,16 @@ async function main() {
       status: 'pass',
       correctness: 'exact counts; one post-drain root commit',
       timing: 'evidence-only; no threshold',
-      // rf2-a0i2y — how the measured interval is known to contain the work it is
-      // named for: lexically by construction (this ordered region shape) and, on
-      // every sample and both order-control paths, by the timed cycle's own
-      // post-commit witness. Still no wall-clock threshold.
+      // rf2-a0i2y / rf2-muhsq — how the measured interval is known to contain the
+      // work it is named for. Structurally: one seam owns witness, start, flush
+      // of the supplied work thunk, end, witness, so the caller never sees the
+      // clock (call order asserted in re-frame.ui.g13.measure-cljs-test, which
+      // rides npm run test:cljs). At runtime: on every sample and both
+      // order-control paths, the timed cycle's own post-commit witness. Because
+      // the seam owns both witness reads, work hoisted out of the thunk collapses
+      // the delta too. Still no wall-clock threshold.
       timedIntervalContainment: {
-        structural: timedRegionOrder,
+        structural: 'measure-dispatch-to-commit! seam; order asserted in re-frame.ui.g13.measure-cljs-test',
         runtime: 'timed-cycle post-hot minus pre-hot equals queued-writes',
       },
       mutationTeeth,

--- a/implementation/ui/g13/re_frame/ui/g13/dev.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/dev.cljs
@@ -6,6 +6,7 @@
             [re-frame.substrate.observation :as obs]
             [re-frame.ui :as ui]
             [re-frame.ui.g13.fixture :as fixture]
+            [re-frame.ui.g13.measure :as measure]
             [re-frame.ui.reactive :as reactive]
             [re-frame.ui.test :as uit]))
 
@@ -72,52 +73,35 @@
 (defn- timing-cycle!
   "CLEAN dispatch-to-commit measurement. The measured interval spans exactly
   the eight write epochs plus the single read/render commit: no pre-commit
-  evidence scan and no post-commit validation runs inside it. The end
-  timestamp is taken the instant the post-commit Promise resolves — before any
-  delta scan, counter comparison, or DOM query — so the sample is the true
-  dispatch-to-commit span and is independent of the V-scaled audit work done by
-  the correctness cycle.
+  evidence scan and no post-commit validation runs inside it, so the sample is
+  independent of the V-scaled audit work done by the correctness cycle.
 
-  rf2-6k4cm — the `:pre-hot` witness (app-db `:hot` immediately before THIS
-  timed dispatch) is read here, adjacent to the dispatch it guards, and returned
-  WITH this exact timed cycle. It is read before `started`, so it sits OUTSIDE
-  the measured interval and leaves the dispatch-to-commit span unchanged. Being
-  sourced from the timed cycle's own dispatch — not from `sample!` entry — makes
-  it causal to the measurement: any drain that preceded this cycle shows up as a
-  nonzero witness, so a warmed cycle can never masquerade as the cold first
-  drain.
+  This function supplies the collaborators and the WORK; it does not own the
+  clock. `measure/measure-dispatch-to-commit!` owns the interval — witness,
+  start, flush of the supplied thunk, end, witness — and its docstring carries
+  the containment argument in full. The two properties that matter here:
 
-  rf2-a0i2y — the `:post-hot` CLOSING witness. Every witness above describes
-  state BEFORE the timed dispatch, so none of them can tell a real measured
-  drain from an EMPTY one: delete the dispatch from this function and `:pre-hot`
-  still reports the mount seed, the separate untimed correctness cycle still
-  advances app-db and still supplies every projection, and the runner would go
-  on labelling a flush interval that did nothing `dispatch-to-commit`.
-  `:post-hot` is app-db `:hot` read AFTER the end timestamp — so no validation
-  work enters the measured span — and returned with this same cycle. The gate
-  asserts `post-hot - pre-hot = queued-writes`: the two reads bracket the two
-  timestamps by construction, so that delta is the work this interval actually
-  contained. A removed, no-op, or empty dispatch yields 0 and turns the gate red.
-  The lexical containment itself (dispatch inside the flushed thunk, thunk
-  between the two `performance.now` reads) is pinned structurally by
-  `assertTimedRegionShape` over THIS source region.
+  rf2-6k4cm — `:pre-hot` is causal to the measurement. It is read inside the
+  seam, so any drain that preceded this cycle shows up as a nonzero witness and
+  a warmed cycle can never masquerade as the cold first drain.
 
-  Returns `{:elapsed-ms <ms> :pre-hot <:hot at dispatch> :post-hot <:hot at commit>}`."
+  rf2-a0i2y / rf2-muhsq — `:post-hot` is the closing witness, read after the
+  end timestamp. The gate asserts `post-hot - pre-hot = queued-writes`. Because
+  the seam reads BOTH witnesses, a dispatch removed from `:work!`, replaced
+  with a no-op, hoisted above this call, or deferred past the resolved Promise
+  all collapse the delta and turn the gate red. That is why the work is passed
+  as a thunk rather than written inline around a timestamp.
+
+  Returns a Promise of
+  `{:elapsed-ms <ms> :pre-hot <:hot at dispatch> :post-hot <:hot at commit>}`."
   [frame]
-  (let [pre-hot (:hot (rf/app-db-value frame))
-        started (js/performance.now)]
-    (-> (uit/flush!
-         (fn []
-           ;; dispatch! completes all eight write epochs synchronously; the
-           ;; render phase runs when flush!'s Promise advances to the commit.
-           (uit/dispatch! frame [::fixture/step fixture/queued-writes])))
-        (.then (fn [_]
-                 ;; The end timestamp is taken FIRST and bound, so the closing
-                 ;; witness read below cannot land inside the measured span.
-                 (let [elapsed-ms (- (js/performance.now) started)]
-                   {:elapsed-ms elapsed-ms
-                    :pre-hot pre-hot
-                    :post-hot (:hot (rf/app-db-value frame))}))))))
+  (measure/measure-dispatch-to-commit!
+   {:read-hot (fn [] (:hot (rf/app-db-value frame)))
+    :now      (fn [] (js/performance.now))
+    :flush!   uit/flush!
+    ;; dispatch! completes all eight write epochs synchronously; the render
+    ;; phase runs when flush!'s Promise advances to the commit.
+    :work!    (fn [] (uit/dispatch! frame [::fixture/step fixture/queued-writes]))}))
 
 (defn- correctness-cycle!
   "Exact push-work accounting for ONE drain — UNTIMED. Owns the O(V) live-cell

--- a/implementation/ui/g13/re_frame/ui/g13/measure.cljs
+++ b/implementation/ui/g13/re_frame/ui/g13/measure.cljs
@@ -1,0 +1,81 @@
+(ns re-frame.ui.g13.measure
+  "The G-13 dispatch-to-commit MEASUREMENT SEAM.
+
+  One helper owns the measured interval — opening witness, start timestamp,
+  flush of the supplied work thunk, end timestamp, closing witness — so
+  containment is a property of THIS function rather than of the caller's
+  layout. `timing-cycle!` supplies the collaborators and the work; it does not
+  get to decide where the clock starts.
+
+  The collaborators are passed in rather than closed over so the call ORDER
+  can be asserted directly, with a fake clock and a fake flush, by
+  `re-frame.ui.g13.measure-cljs-test`. That test is the whole of the lexical
+  half of the proof; nothing reads source text.
+
+  This namespace deliberately has NO requires. It is pure plumbing over four
+  supplied functions, which is what makes it testable on the node runner
+  without React, a frame, or a browser.")
+
+(defn measure-dispatch-to-commit!
+  "Measure one dispatch-to-commit interval. Returns a Promise of
+  `{:elapsed-ms _ :pre-hot _ :post-hot _}`.
+
+  Takes `{:keys [read-hot now flush! work!]}`:
+
+    :read-hot  0-arity — the app-db `:hot` witness read
+    :now       0-arity — the clock
+    :flush!    1-arity — runs the supplied thunk and resolves on commit
+    :work!     0-arity — the work under measurement (the timed dispatch)
+
+  WHAT THIS PROVES, and how:
+
+  1. The work runs INSIDE the flush, and the flush sits between the two clock
+     reads. True by construction: `work!` is used in exactly one place — as
+     the argument to `flush!` — and that call is the only thing between
+     `started` and the end reading. A caller cannot place the work anywhere
+     else and still have it measured, because the caller never sees the clock.
+
+  2. Neither witness read is on the clock. `pre-hot` is read before `started`;
+     `post-hot` is read after `elapsed-ms` is bound. So the reported span is
+     the drain, not the drain plus two map lookups.
+
+     Properties 1 and 2 are ORDER properties of this function's body. They are
+     asserted directly in `measure-cljs-test` by passing a recording clock and
+     a recording flush and comparing the resulting call log against the exact
+     expected sequence — which also rejects an extra clock reading, since the
+     log is compared whole.
+
+  3. The measured interval actually CONTAINED its own dispatch and commit.
+     This is the runtime half, checked by the gate as
+     `post-hot - pre-hot = queued-writes` (`assertTimedIntervalDidWork` in
+     `lib/g13-timing-evidence.cjs`), and it is why `read-hot` lives HERE
+     rather than in the caller.
+
+     Because the opening witness is read inside the seam — after anything the
+     caller did before calling it — work hoisted OUT of `work!` is visible in
+     the delta. A caller that dispatches before calling this function has
+     already advanced app-db by the time `pre-hot` is read (`uit/dispatch!` is
+     `dispatch-sync!`: the write epochs land synchronously), so `pre-hot`
+     and `post-hot` agree and the delta collapses to 0. Same for work deferred
+     until after the returned Promise resolves: `post-hot` was read first.
+
+     That is the one containment mutant a witness read in the CALLER cannot
+     see — with the read outside the seam, hoisting the dispatch above the
+     start timestamp leaves the delta at exactly `queued-writes` while the
+     measured span no longer covers the write epochs. Owning the read closes
+     it, which is what let the previous source-text proof retire (rf2-muhsq).
+     Both directions are exercised in `measure-cljs-test`.
+
+  What this does NOT prove: that the elapsed number is any particular size.
+  G-13 has no wall-clock threshold; timing is evidence only."
+  [{:keys [read-hot now flush! work!]}]
+  (let [pre-hot (read-hot)
+        started (now)]
+    (-> (flush! work!)
+        (.then (fn [_]
+                 ;; End timestamp FIRST, so the closing witness read below
+                 ;; cannot land inside the measured span.
+                 (let [elapsed-ms (- (now) started)]
+                   {:elapsed-ms elapsed-ms
+                    :pre-hot    pre-hot
+                    :post-hot   (read-hot)}))))))

--- a/implementation/ui/test/re_frame/ui/g13/measure_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/g13/measure_cljs_test.cljs
@@ -1,0 +1,112 @@
+(ns re-frame.ui.g13.measure-cljs-test
+  "Focused proof of the G-13 measurement seam (rf2-muhsq).
+
+  This is the LEXICAL half of G-13's dispatch-to-commit containment proof. It
+  replaces a source-text checker that read `dev.cljs`, blanked its strings and
+  comments at preserved offsets, delimited the private `timing-cycle!` by the
+  private `correctness-cycle!` that had to follow it, and pinned exact forms,
+  multiplicities and offsets (rf2-a0i2y). That checker proved the right thing
+  and cost the wrong price: renaming a private fn, extracting a helper, or
+  writing an equivalent form failed CI.
+
+  The seam owns the interval instead, so the property is now a plain call-order
+  property of one small function and is asserted here with a recording clock
+  and a recording flush. No source text is read.
+
+  Deliberately requires ONLY `re-frame.ui.g13.measure` — not the G-13 fixture,
+  which pulls in React. The seam takes its collaborators as arguments, so there
+  is nothing to stand up."
+  (:require [cljs.test :refer-macros [deftest is testing async]]
+            [re-frame.ui.g13.measure :as measure]))
+
+;; The fixture's per-drain :hot advance. Inlined rather than required from
+;; `re-frame.ui.g13.fixture` so this suite stays React-free on the node runner;
+;; its only role here is to be a recognisable nonzero delta.
+(def queued-writes 8)
+
+(defn- recorder
+  "A seam collaborator set that appends a label per call. `hot` is the app-db
+  `:hot` stand-in; `work!` advances it, exactly as the real timed dispatch
+  does synchronously via `dispatch-sync!`."
+  [log hot ticks]
+  {:read-hot (fn [] (swap! log conj :read-hot) @hot)
+   :now      (fn [] (swap! log conj :clock) (swap! ticks + 10))
+   :flush!   (fn [work!]
+               (swap! log conj :flush)
+               (js/Promise.resolve (work!)))
+   :work!    (fn [] (swap! log conj :work) (swap! hot + queued-writes) nil)})
+
+(deftest seam-brackets-the-flushed-work-with-clock-then-witness
+  (testing "witness, start, flush(work), end, witness — in exactly that order"
+    (async done
+      (let [log   (atom [])
+            hot   (atom 0)
+            ticks (atom 0)]
+        (-> (measure/measure-dispatch-to-commit! (recorder log hot ticks))
+            (.then
+             (fn [{:keys [elapsed-ms pre-hot post-hot]}]
+               ;; The WHOLE log is compared, not a subsequence — so this also
+               ;; rejects an extra clock reading or a second flush inside the
+               ;; seam, the multiplicity the retired regex counts pinned.
+               (is (= [:read-hot :clock :flush :work :clock :read-hot] @log)
+                   "the work must run inside the flush, the flush between the two
+                    clock reads, and both witness reads outside them")
+               ;; The opening witness precedes the start timestamp and the
+               ;; closing witness follows the end timestamp, so neither read is
+               ;; on the clock: elapsed is exactly the two ticks apart.
+               (is (= 10 elapsed-ms)
+                   "elapsed is end minus start, with no witness read between them")
+               (is (= 0 pre-hot) "the opening witness is read before the work")
+               (is (= queued-writes (- post-hot pre-hot))
+                   "and the closing witness after it, so the delta is the work
+                    the measured interval contained")
+               (done)))
+            (.catch (fn [e] (is false (str "seam rejected: " e)) (done))))))))
+
+(deftest work-hoisted-out-of-the-thunk-collapses-the-delta
+  (testing "a caller that does the work BEFORE calling the seam reds the gate"
+    ;; THE MUTANT NO CALLER-SIDE WITNESS CAN SEE. While the opening witness was
+    ;; read in `timing-cycle!` — above the dispatch it guarded — hoisting the
+    ;; dispatch above the start timestamp left post-minus-pre at exactly
+    ;; queued-writes while the measured span no longer covered the write epochs.
+    ;; Only source order showed it, which is why the source-text checker existed.
+    ;;
+    ;; The seam owns the read, so the hoisted work now lands BEFORE the opening
+    ;; witness and the delta collapses to 0 — which `assertTimedIntervalDidWork`
+    ;; rejects. This is the substitution that let the source lexer retire.
+    (async done
+      (let [hot (atom 0)]
+        (swap! hot + queued-writes)                    ;; the hoisted dispatch
+        (-> (measure/measure-dispatch-to-commit!
+             {:read-hot (fn [] @hot)
+              :now      (fn [] 0)
+              :flush!   (fn [work!] (js/Promise.resolve (work!)))
+              :work!    (fn [] nil)})                  ;; ...leaving an empty thunk
+            (.then
+             (fn [{:keys [pre-hot post-hot]}]
+               (is (= queued-writes pre-hot)
+                   "the hoisted work advanced app-db before the seam's own
+                    opening witness read")
+               (is (= 0 (- post-hot pre-hot))
+                   "so the delta is 0 and the runtime containment witness reds")
+               (done)))
+            (.catch (fn [e] (is false (str "seam rejected: " e)) (done))))))))
+
+(deftest work-deferred-past-the-commit-collapses-the-delta
+  (testing "a caller that does the work AFTER the resolved Promise reds the gate"
+    (async done
+      (let [hot (atom 0)]
+        (-> (measure/measure-dispatch-to-commit!
+             {:read-hot (fn [] @hot)
+              :now      (fn [] 0)
+              :flush!   (fn [work!] (js/Promise.resolve (work!)))
+              :work!    (fn [] nil)})
+            ;; The closing witness was already read inside the seam, so work
+            ;; chained on afterwards cannot be credited to the interval.
+            (.then (fn [result] (swap! hot + queued-writes) result))
+            (.then
+             (fn [{:keys [pre-hot post-hot]}]
+               (is (= 0 (- post-hot pre-hot))
+                   "work deferred past the end timestamp is not in the delta")
+               (done)))
+            (.catch (fn [e] (is false (str "seam rejected: " e)) (done))))))))

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -661,7 +661,7 @@ The other three streams take the same verb. `:events` and `:errors` are the **al
 ```clojure
 (rf/register-listener! :events id listener-fn)  ;; always-on event-emit record
 (rf/register-listener! :errors id listener-fn)  ;; always-on error-emit record
-(rf/register-listener! :epoch  key callback-fn) ;; one :rf/epoch-record per drain-settle
+(rf/register-listener! :epoch  key callback-fn) ;; one :rf/epoch-record per dequeued event
 ```
 
 Conventional keys: `:my-app/recorder`, `:my-app/timing-monitor`, etc.


### PR DESCRIPTION
Two beads, one PR, one commit each.

## `rf2-2deuf` — the epoch-record cardinality contradiction

`spec/009-Instrumentation.md` contradicted itself. The inline comment on the
`register-listener!` example said **"one `:rf/epoch-record` per drain-settle"**,
while the contract prose below it — and the *identical* inline comment on the
very next code block — say **"per dequeued event"**, and spell out that a drain
settling a parent plus its `:fx`-dispatched child fires the callback **twice**.

**Verified against the runtime, not against either sentence.** The document was
wrong; the code was right.

- `router/run-one-pass!` calls `settle-event-epoch!` inside the per-event loop
  body, once per dequeued envelope, with that event's own pre-/post-cascade
  frame-state pair. Its docstring: *"the epoch boundary is the dequeued EVENT,
  not the drain-settle."*
- `epoch/settle!` opens *"Settle one dequeued event, not an entire drain.
  Parent and child events in one drain produce separate records."*
- Already test-pinned: `epoch-test` drives one drain of `:outer` plus two
  `:fx`-dispatched children and asserts **three** epochs (*"one epoch per
  dequeued event — the `:fx`-dispatched children are NOT folded into `:outer`'s
  epoch"*); `listener-fires-per-event-settle` asserts the callback fires once
  per event.

The comment's *conclusion* ("one `:rf/epoch-record` per X") was already correct
— only its basis, the unit X, had drifted. Basis rewritten, conclusion kept.

**No Spec 009 co-edit was owed:** no error id added, removed or renamed.

### Sibling contradictions spotted, deliberately NOT swept

The same "per drain-settle" wording survives outside this bead's scope. Naming,
not touching — two of these are hot-zone files this PR has no mandate for:

- `spec/API.md` **self-contradicts exactly as 009 did**: `:793` and `:842` say
  "per drain-settle" while `:829` correctly says "once per dequeued event …
  **not** once per drain: a drain that processes a parent event and the
  `:fx [[:dispatch …]]` child it queued commits two records". (hot-zone)
- `spec/Conventions.md:1296`, `:1796` — "the epoch drain-settle listener". (hot-zone)
- `spec/Security.md:100` — "records, per drain-settle, an `:rf/epoch-record`".
- `docs/api/re-frame.core.md:1234` — "fires once per drain-settle".
- `docs/api/re-frame.epoch.md:9`, `tools/xray/spec/011-Launch-Modes.md:645`.

## `rf2-muhsq` — simplify the G-13 containment proof

The proof was half runtime witness, half source-text checker. The textual half
read `dev.cljs`, blanked strings/comments/character literals at preserved
offsets, delimited the private `timing-cycle!` by the private
`correctness-cycle!` that had to follow it, and pinned exact forms,
multiplicities and lexical offsets — duplicated again as a mutation matrix in
`run-ui-g13.cjs`. Renaming a private fn or extracting a helper failed CI.

It existed for exactly one mutant: **hoisting the dispatch above the start
timestamp** left `post-hot − pre-hot` at exactly `queued-writes` while the
measured span no longer covered the write epochs.

**That premise held only because the opening witness was read in the CALLER.**
Move the read into the seam that owns the interval and the mutant becomes
runtime-visible: a caller that dispatches before calling the seam has already
advanced app-db by the time `pre-hot` is read (`uit/dispatch!` is
`dispatch-sync!`), so pre and post agree and the delta collapses to 0.

So `re-frame.ui.g13.measure/measure-dispatch-to-commit!` now owns witness →
start → flush(work thunk) → end → witness. `timing-cycle!` supplies
collaborators and work; it never sees the clock. The seam has **no requires**,
so its call order is asserted directly with a fake clock and a fake flush in
`re-frame.ui.g13.measure-cljs-test`. No source text is read by either half.

Removed: `codeOnly`, `assertTimedRegionShape`, `TIMED_REGION_OPEN/CLOSE`, the
anchor and multiplicity tables, `mutateSource`, `timedRegionMutations`, and the
duplicated source-mutation cases in both the runner and the unit suite.
**Net −200 lines.**

### Mutation set re-run — 13/13 still red

The 8 runtime containment teeth are untouched and ran red inside the browser
gate (**42 teeth, all rejected**). The 5 retired source mutants were
re-applied to the real sources and driven through the real gates:

| # | Mutant | Verdict | Caught by |
|---|---|---|---|
| 09 | dispatch removed from the flushed thunk | **RED** | runtime witness, `delta=0` |
| 10 | dispatch replaced with a no-op event | **RED** | runtime witness, `delta=0` |
| 11 | dispatch hoisted above the start timestamp | **RED** | runtime witness, `pre-hot=8, post-hot=8, delta=0` |
| 12 | dispatch moved past the end timestamp | **RED** | post-drain work projection drift |
| 13 | closing witness read moved inside the span | **RED** | `seam-brackets-the-flushed-work-with-clock-then-witness` |

Mutant 11 reds with exactly the predicted signature — that is the empirical
confirmation that the seam substitutes for the lexer rather than leaving a hole.

### Docstrings claim only what is proven

Per `rf2-gv8gr`'s lesson. The seam's docstring separates the by-construction
order properties from the runtime delta property and states plainly what it
does **not** prove (that the elapsed number is any particular size — G-13 still
has no wall-clock threshold). `assertTimedIntervalDidWork`'s comment previously
claimed it rejected a "hoisted-out" dispatch, which was **not true** under the
old witness placement; it is true now, and the comment says why.

## Quality gates

All foreground, unpiped, run to completion.

| Gate | Result |
|---|---|
| `implementation/core` → `clojure -M:test` | **2078 tests, 9960 assertions, 0 failures** |
| error-catalogue conformance (`error-catalogue-channel-conformance-test`) | **9 tests, 21 assertions, 0 failures** |
| render-law drift gate (`observation-render-law-drift-test`) | **5 tests, 23 assertions, 0 failures** |
| `npm run test:cljs` | **10217 tests, 50489 assertions, 0 failures** |
| `npm run test:ui-g13` (G-13 runner) | **PASS — 42 mutation teeth, all red** |
| G-13 retired-mutant re-run | **5/5 RED** |
| `node scripts/_g13-timing-evidence.test.cjs` | **38 passed** |
| `npm run test:script-helpers` | **PASS** |
| `npm run test:cljs-isolation` | **15/15 namespaces pass standalone** |
| `python -m mkdocs build --strict` | **exit 0** |
| `python scripts/check_doc_slugs.py` | **exit 0** |
| `scripts/check-no-hardcoded-paths.sh` | **PASS** |

**Vacuity probe.** Flipped the expected call log in
`seam-brackets-the-flushed-work-with-clock-then-witness` to mutant 13's
signature. The full `npm run test:cljs` gate went red (exit 1) naming the test:
`FAIL in (seam-brackets-the-flushed-work-with-clock-then-witness)`, with
`actual: [:read-hot :clock :flush :work :clock :read-hot]` — proving the seam
really does read the closing witness after the end timestamp. Test count held
at 10217 across both runs, so the namespace was genuinely discovered. Restored
and verified byte-identical.

**Hot-zone.** `spec/009-Instrumentation.md` — sole toucher, verified by sweeping
every sibling worktree for dirty *and* committed edits against its own
merge-base, before the work and again before push. Only stale `opt-6001`
carries a `spec/009` edit (~940 commits behind, no PR, distant catalogue row,
will rebase). **#6365 does not overlap:** its files are `frame.cljc`,
`late_bind/directory.cljc`, `router.cljc`, `trace.cljc`, `trace/tooling.cljc`
and four trace/frame tests — the render-law drift test is not among them, and
this PR does not edit it. No `shadow-cljs.edn` edit was needed: `ui/g13` and
`ui/test` are already on `:source-paths`, and the new test namespace matches
the existing `:node-test` `cljs-test$` regex.
