### PR TITLE
docs(EP): land the ruled EP-0009 semantic test and stop the census flagging local drafts (rf2-0b9b0, rf2-kqv44)

### DIFF
--- a/docs/EP/EP-0008-production-observability-channels.md
+++ b/docs/EP/EP-0008-production-observability-channels.md
@@ -34,15 +34,9 @@ are kept here as a closed record and no longer reopen any ruling:
 - **Fixed (PR #3860, impl)** — the frame-teardown report: a single
   always-on `:rf.error/frame-teardown-failed` record carrying a `:hook-failures`
   vector, emitted from `destroy-frame!` through a **finally-shaped** boundary so a
-  partial teardown (abort after step 3 of 7) still flushes the collected entries.
-  Each entry names a failed teardown **step** — a late-bound cleanup hook, or a
-  guarded direct step such as the `:frame/notify-machine-destruction!` machine
-  cascade. The dev-only per-step diagnostic
-  (`:rf.warning/teardown-hook-exception`) stays at its causal positions, funneled
-  through the shared `record-teardown-failure!` boundary every teardown catch
-  site routes through (`safe-call-hook!` for the late-bound hooks,
-  `safe-teardown-step!` for the guarded direct steps), and DCE-elides in
-  production.
+  partial teardown (abort after hook 3 of 7) still flushes the collected entries.
+  The dev-only per-hook diagnostic (`:rf.warning/teardown-hook-exception`) stays
+  at its causal positions inside `safe-call-hook!` and DCE-elides in production.
 - **Fixed (audit)** — graded the full `:rf.error/*` /
   `:rf.warning/*` catalogue against the promotion criterion and filed promotion-fix
   beads for the gaps the sweep found. Teardown was the known first row (resolved by
@@ -241,7 +235,7 @@ the *always-on* emission is a single report.
 
 | Category | Today | Under the criterion |
 |---|---|---|
-| frame-teardown hook failures | per-hook `:rf.warning/teardown-hook-exception`, diagnostic (DCE'd) | **Promote to a single always-on report** → `:rf.error/frame-teardown-failed`, default `:recovery :ignored` (teardown continues best-effort; the one bounded record ships through the always-on axis carrying `:hook-failures`), finally-shaped so a partial teardown still flushes. The per-step `:rf.warning/teardown-hook-exception` **stays diagnostic** (dev, at causal positions inside `safe-call-hook!` for the late-bound hooks and `safe-teardown-step!` for the guarded direct steps). The known C4 fix |
+| frame-teardown hook failures | per-hook `:rf.warning/teardown-hook-exception`, diagnostic (DCE'd) | **Promote to a single always-on report** → `:rf.error/frame-teardown-failed`, default `:recovery :ignored` (teardown continues best-effort; the one bounded record ships through the always-on axis carrying `:hook-failures`), finally-shaped so a partial teardown still flushes. The per-hook `:rf.warning/teardown-hook-exception` **stays diagnostic** (dev, at causal positions inside `safe-call-hook!`). The known C4 fix |
 | `:rf.error/sub-input-fn-exception` / `-bad-return` | always-on | Correct as-is (the precedent rows) |
 | `:rf.error/no-frame-context` | always-on | Correct (frameless errors need the frameless axis — EP-0002 R6) |
 | `:rf.warning/app-handler-runtime-effect` | diagnostic | Correct — dev-time teaching diagnostic; leg 2 fails (the write applies; nothing leaks) |
@@ -274,10 +268,9 @@ release-notes material.
 2. Teardown bead: emit a **single** always-on
    `:rf.error/frame-teardown-failed` record carrying a `:hook-failures` vector
    from `destroy-frame!`, through a **finally-shaped** boundary so a partial
-   teardown still flushes the collected entries (R1). Keep the per-step
+   teardown still flushes the collected entries (R1). Keep the per-hook
    `:rf.warning/teardown-hook-exception` dev diagnostic at its causal positions
-   inside `safe-call-hook!` — and, for the guarded direct steps, inside
-   `safe-teardown-step!` (R2 — diagnostic channel, DCE'd in production). Plus a
+   inside `safe-call-hook!` (R2 — diagnostic channel, DCE'd in production). Plus a
    teardown-report test.
 3. Audit bead: grade the full catalogue; file promotion fixes found.
 4. Conformance bead: the catalogue/channel pin test.
@@ -320,14 +313,13 @@ refinements are recorded here verbatim; the normative shape lives in
 
 ### The ruling
 
+> **Addendum — 2026-07-18 (delegated ruling, rf2-r7ahi).** The 2026-06-11 ruling below speaks of cleanup hooks because those were the only teardown-failure sites then in scope. The runtime later added guarded direct teardown steps (`safe-teardown-step!` — e.g. the `:frame/notify-machine-destruction!` machine cascade); they join the late-bound hooks at the same shared `record-teardown-failure!` boundary and the same single bounded `:rf.error/frame-teardown-failed` report. Report shape, `:hook-failures`/`:hook` wire names, channels, and recovery semantics are unchanged. `spec/009-Instrumentation.md` is the current normative contract; the ruling below is retained as made.
+
 Frame-destroy emits a **single always-on teardown report** — one bounded event
-summarizing all teardown-step failures — NOT per-step always-on emissions. The
-always-on category is named for the report-fact: `:rf.error/frame-teardown-failed`,
+summarizing all hook failures — NOT per-hook always-on emissions. The always-on
+category is named for the report-fact: `:rf.error/frame-teardown-failed`,
 `:recovery :ignored` (teardown stays best-effort), carrying a `:hook-failures`
-vector (one entry per failed teardown step — a late-bound cleanup hook, or a
-guarded direct step such as the `:frame/notify-machine-destruction!` machine
-cascade; the `:hook-failures` / `:hook` wire names are deliberately stable).
-It is **not** the per-step-shaped
+vector (one entry per failed hook). It is **not** the per-hook-shaped
 `:rf.error/teardown-hook-exception` reused for a multi-hook record —
 one-name-per-fact applies to the fact actually emitted (EP-0007).
 
@@ -353,13 +345,11 @@ one-name-per-fact applies to the fact actually emitted (EP-0007).
   aborts after hook 3 of 7 the collected entries still flush. This neutralizes
   the one genuine advantage per-hook emission had (incremental delivery surviving
   a mid-teardown collapse). The contract is stated in Spec 009.
-- **R2 — axis scope.** "Instead of per-step emissions" is scoped to the
-  **always-on axis only**. In dev, the per-step diagnostic trace rows
+- **R2 — axis scope.** "Instead of per-hook emissions" is scoped to the
+  **always-on axis only**. In dev, the per-hook diagnostic trace rows
   (`:rf.warning/teardown-hook-exception`) at their causal positions inside
-  `safe-call-hook!` — and, for the guarded direct steps, inside
-  `safe-teardown-step!` — STAY (more useful there; DCE'd in production).
-  Per-step visibility does not disappear — only the always-on emission is a
-  single report.
+  `safe-call-hook!` STAY (more useful there; DCE'd in production). Per-hook
+  visibility does not disappear — only the always-on emission is a single report.
 
 ## Recommendation
 

--- a/docs/EP/EP-0009-the-ep-process.md
+++ b/docs/EP/EP-0009-the-ep-process.md
@@ -118,7 +118,11 @@ The `Status:` line is machine-readable. Its value MUST be one of:
 3. **Amendment is allowed only before implementation.** Once an EP is accepted
    and beads are in flight, substantive changes go through a new EP or a
    recorded ruling — not silent edits. (Mechanical corrections and errata-ledger
-   updates are always fine.)
+   updates are always fine.) Mechanical means the edit cannot change a
+   reasonable reader's understanding of the proposal, alternatives, rationale,
+   ruling, or scope; anything past that line is recorded as a dated
+   erratum/addendum beside the affected passage, preserving the original text —
+   freeze meaning, not bytes (rf2-r7ahi).
 4. **One EP, one decision surface.** Bundling independent decisions invites
    all-or-nothing rulings; prefer narrow EPs and cross-references.
 5. **Graduation includes a guide-impact assessment:** the graduating EP names

--- a/docs/EP/EP-template.md
+++ b/docs/EP/EP-template.md
@@ -61,7 +61,10 @@ may graduate into the active EP itself rather than `spec/`; any EP may end at
 `rejected` / `withdrawn` / `deferred` / `superseded` and is kept as the record.
 `final`/`active` asserts the DECISIONS are settled — it does not, on its own,
 assert the implementation is build-complete (a `final` EP may carry an
-implementation-errata ledger; the EP-0005 pattern).
+implementation-errata ledger; the EP-0005 pattern). After resolution the body is
+a historical record: later factual drift is corrected with dated errata/addenda
+beside the affected passage, never by rewriting settled prose (EP-0009
+§Durability rules 3).
 
 ==== Is an EP even warranted? ====
 

--- a/implementation/ui/test/re_frame/ui/slice_memo_lifetime_census_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/slice_memo_lifetime_census_jvm_test.clj
@@ -51,6 +51,7 @@
   the marker-PRESENCE half of that arm generalises to the directory. See
   §The synthesis standing-marker census below."
   (:require [clojure.java.io :as io]
+            [clojure.java.shell :as shell]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]))
 
@@ -583,14 +584,57 @@ cleared by `queueMicrotask`, and belt-and-braces tagged with
 ;; Positive arm — every tracked document in the censused directories
 ;; ---------------------------------------------------------------------------
 
-(defn- directory-roster
-  "The roster: the DIRECTORY LISTING of `dir`'s markdown files, sorted for a
-  stable failure order. Never a maintained list of names."
+(defn- tracked-markdown-names
+  "The names of the markdown files Git TRACKS directly under `dir`.
+
+  Admission is the TRACKED set, not the raw directory listing. `/ai` is
+  gitignored — the tree is local-by-default and this censused subtree is a
+  deliberate tracked exception — so a programmer's or agent's local scratch
+  draft, spike, or review sits in these very directories untracked. Such a file
+  ships nothing, cannot reach CI, and changes no authority; censusing it would
+  red the whole `implementation/ui` suite over a private note, which is how a
+  gate trains its readers to ignore it.
+
+  Asking Git keeps the roster exact in BOTH directions, with nothing maintained
+  by hand: `ls-files` reads the INDEX, so a document is admitted by the very
+  commit that tracks it — force-add a new review and it is censused, and must
+  carry a marker, in that same change.
+
+  `-z` so a path is never returned in Git's quoted form. Non-recursive, matching
+  the directory listing this filters. A failed `git` call throws rather than
+  yielding an empty set: an unreadable tracked set must not read as a clean
+  census."
   [dir]
-  (let [d (io/file @root synthesis-root dir)]
-    (->> (.listFiles d)
+  (let [rel    (str synthesis-root "/" dir)
+        prefix (str rel "/")
+        {:keys [exit out err]} (shell/sh "git" "ls-files" "-z" "--" rel
+                                         :dir @root)]
+    (when-not (zero? exit)
+      (throw (ex-info (str "`git ls-files` failed for " rel " — the census cannot "
+                           "derive its tracked roster and must not pass vacuously")
+                      {:dir rel :exit exit :err err})))
+    (into #{}
+          (comp (remove str/blank?)
+                (filter #(str/starts-with? % prefix))
+                (map #(subs % (count prefix)))
+                (remove #(str/includes? % "/"))
+                (filter #(str/ends-with? % ".md")))
+          (str/split out #"\x00"))))
+
+(defn- directory-roster
+  "The roster: `dir`'s markdown files as Git tracks them, sorted for a stable
+  failure order. Discovery is still the DIRECTORY LISTING; admission is the
+  tracked set (`tracked-markdown-names`). Both halves are derived — never a
+  maintained list of names.
+
+  Intersecting the two, rather than trusting `ls-files` alone, keeps a tracked
+  file that is absent from the worktree out of the roster instead of failing on
+  the `slurp`; the coverage assertion in the roster test is what reds on that."
+  [dir]
+  (let [tracked (tracked-markdown-names dir)]
+    (->> (.listFiles (io/file @root synthesis-root dir))
          (filter #(.isFile ^java.io.File %))
-         (filter #(str/ends-with? (.getName ^java.io.File %) ".md"))
+         (filter #(contains? tracked (.getName ^java.io.File %)))
          (sort-by #(.getName ^java.io.File %)))))
 
 (deftest every-authority-shaped-synthesis-document-declares-its-standing
@@ -599,9 +643,11 @@ cleared by `queueMicrotask`, and belt-and-braces tagged with
       (let [roster (directory-roster dir)]
         (is (seq roster)
             (str synthesis-root "/" dir "/ censuses no documents — the directory "
-                 "is missing or empty. If the S7 removal wave (rf2-vxgfnd.99.1) "
-                 "deleted it, drop its row from `censused-directories` in the "
-                 "same change; do not let the census pass vacuously"))
+                 "is missing, or holds no TRACKED markdown (untracked local "
+                 "drafts are deliberately not censused). If the S7 removal wave "
+                 "(rf2-vxgfnd.99.1) deleted it, drop its row from "
+                 "`censused-directories` in the same change; do not let the "
+                 "census pass vacuously"))
         (doseq [^java.io.File f roster]
           (testing (.getName f)
             (is (= #{} (standing-marker-violations (slurp f) accepts))
@@ -610,6 +656,36 @@ cleared by `queueMicrotask`, and belt-and-braces tagged with
                      "supersession/correction banner, or (in spikes/ and reviews/) "
                      "a dated-record header — in its opening, before the first "
                      "`##` heading. What the marker SAYS is not censused"))))))))
+
+(defn- roster-names
+  [dir]
+  (into #{} (map #(.getName ^java.io.File %)) (directory-roster dir)))
+
+(deftest the-standing-census-roster-is-gits-tracked-set
+  (testing "admission is Git's tracked set, so an ignored local draft is not
+            censused while every tracked document stays covered. Asserted PER
+            DIRECTORY, never over the union: a roster that dropped one
+            directory's documents entirely would still look populated in
+            aggregate, and the census would go quietly blind exactly there"
+    (doseq [{:keys [dir]} censused-directories]
+      (testing (str synthesis-root "/" dir "/")
+        (let [tracked (tracked-markdown-names dir)
+              probe   (io/file @root synthesis-root dir
+                               "zz-untracked-local-draft-probe.md")]
+          (is (seq tracked)
+              (str dir " tracks no markdown — the arm below would prove nothing"))
+          (is (= tracked (roster-names dir))
+              (str "every tracked document in " dir " must stay censused; a "
+                   "tracked file missing from the worktree reds here rather "
+                   "than silently shrinking the roster"))
+          (try
+            ;; `/ai` is gitignored, so this lands untracked exactly as a real
+            ;; local scratch note does — the case that was reddening the suite.
+            (spit probe "# Local scratch note\n\nNo standing marker.\n\n## Body\n\nx\n")
+            (is (= tracked (roster-names dir))
+                (str "an untracked local draft entered " dir "'s roster — the "
+                     "census is reading the directory listing, not Git"))
+            (finally (.delete probe))))))))
 
 (deftest the-three-real-dispositions-pass-the-standing-census
   (testing "the census admits every disposition actually found, so no document is


### PR DESCRIPTION
Two beads, two commits.

## rf2-0b9b0 — land rf2-r7ahi's ruled EP-0008 revert + addendum

`rf2-r7ahi` is RULED: **(b), precised as "freeze meaning, not bytes"**, applying to the whole EP corpus, with a Tier 1 / Tier 2 split. Tier 1 (edit in place, undated) is editorial maintenance that "cannot change a reasonable reader's understanding of the proposal, alternatives, rationale, ruling, or scope". Tier 2 — "any edit that changes the apparent meaning, scope, factual premise, ruled name/shape, or implementation context of a settled passage" — preserves the original text and adds a dated erratum beside the affected passage.

PR #6304 merged without that reshaping, so its on-branch disposition ("revert on `worker/docs-truth-cluster` before merge") could no longer be executed. This lands the ruled content as a mainline docs change; the ruling's edit content is unchanged.

1. **EP-0008 restored to its pre-#6304 text.** The edit commit rebased to `ae94e1b4ff`; nothing has touched the file since, so the restore is wholesale from `ae94e1b4ff~1` and is byte-identical to it. That undoes all five Tier-2 locations: the closed "Fixed (PR #3860, impl)" errata row, the audit-table teardown row, plan item 2, "### The ruling", and R2. #3860 predates `safe-teardown-step!`, so rewriting the closed rows misattributed just as the ruling edit did.
2. **One dated addendum**, verbatim from the ruling, as a blockquote directly under "### The ruling". Not repeated at the other four locations.
3. **EP-0009 §Durability rules rule 3** — the semantic test for what "mechanical" means (ruling item 4).
4. **EP-template.md** — the matching author-facing sentence (ruling item 5).

Items 4 and 5 were confirmed genuinely unlanded: no "freeze meaning" anywhere under `docs/`, and rule 3 ended at "(Mechanical corrections and errata-ledger updates are always fine.)". Everything else #6304 shipped (spec/009, the how-to, skills references, source comments, the pinned test, the playground bundle) stands as current truth and is untouched. **No EP status flipped.**

## rf2-kqv44 — the census must ignore local untracked drafts

`directory-roster` discovered documents with `.listFiles`, so admission was the raw directory listing. `/ai` is gitignored, so every local scratch draft, spike, or review under `drafts/`, `spikes/`, or `reviews/` was censused: one private note with no standing banner reddened the whole `implementation/ui` suite over a file that ships nothing and cannot reach CI.

Admission is now `git ls-files`. Because it reads the **index** rather than HEAD, a force-added document is admitted by the very commit that tracks it. Discovery is still the directory listing; the tracked set filters it, so a tracked file absent from the worktree stays out of the roster instead of throwing in `slurp`.

Pinned by `the-standing-census-roster-is-gits-tracked-set`, asserted **per directory, never over the union** — a roster that dropped one directory's documents entirely would still look populated in aggregate. The marker vocabularies, preamble/deep-link rule, real-disposition controls, and the negative arm's mutation teeth are untouched. No filename roster, no Markdown parser, no content validation.

## Quality gates

All foreground, unpiped, run to completion.

| Gate | Result |
|---|---|
| `python -m mkdocs build --strict` | exit 0, 0 warnings/errors |
| `python scripts/check_doc_slugs.py` | exit 0 — **531 markdown files scanned** |
| `python scripts/check_ep_status_sync.py` | exit 0 |
| `implementation/ui` → `clojure -M:test` | exit 0 — **956 tests, 18656 assertions**, 0 failures |
| census namespace focused | exit 0 — **13 tests, 120 assertions** |

**Both doc gates cover the diff — proven, not assumed.** A deliberate broken anchor added to EP-0009 and EP-template made `check_doc_slugs.py` exit 1 naming both files; the same tree made `mkdocs build --strict` exit **0**, logging both as INFO. `check_doc_slugs.py` is the real link gate here. Probe reverted; the committed edits were verified intact after.

**The census bug was reproduced and the fix proven both directions:**

- *Before* — three ignored untracked `.md` files (one per censused directory) → **3 failures**, the message claiming each was "authority-shaped and tracked".
- *After* — same three files present → **green, 0 mentions** of them.
- *Still has teeth* — a genuine **tracked** document (`reviews/09-review-disposition.md`) mutated to strip its `**Status:**` marker → **census reds**, naming that file, while the untracked probes stayed silent. Mutation reverted and the marker verified restored.
- *Index semantics* — verified in a throwaway repo that `git ls-files -z` returns a merely-staged, never-committed file and not its untracked sibling. Done outside this repo deliberately: nothing was `git add -f`ed under `ai/`, and `git diff --diff-filter=A origin/main...HEAD -- ai/` is empty, so the AI-tracking ratchet is safe.

`test:script-policy` not run — no file under `scripts/` or `implementation/scripts/` is touched. `guide_truth_jvm_test.clj` pins EP paths by exact path but pins only EP-0034 and EP-0030, neither touched; the full `ui` suite was run regardless.

**Fence:** all eight sibling worktrees checked for dirty *and* committed edits against their own merge-base. No overlap on any of the four files. `spec009-cardinality` and `opt-6001` both touch `implementation/ui/test/` but neither touches `slice_memo_lifetime_census_jvm_test.clj`; `ruled-trio-b72to` touches `implementation/scripts/check-per-ns-isolation.cjs` and `.gitignore`, where this census does not live.
