### PR TITLE
docs(ep): record the 2026-07-17 R-1 coordinate confirmation on EP-0035

### DIFF
--- a/docs/EP/EP-0035-component-library-readiness.md
+++ b/docs/EP/EP-0035-component-library-readiness.md
@@ -341,6 +341,11 @@ NOTES block is authoritative over any summary here.
 | R-9 accessibility | WAI-ARIA APG semantics per component class, shipped with each component's wave — legacy parity (one `aria-` attribute total) is not the bar |
 | R-10 CSS/Bootstrap | retained through the parity waves as an isolated, removable theme-data layer; removal is a named post-parity decision bead |
 
+> **Errata — 2026-07-17 (delegated, recorded on `rf2-6ajm6z`).** R-1's native
+> coordinate — `re-com/re-com-ui` with the `re-com.ui.*` namespace family — was
+> confirmed final; the original ruling's "may be adjusted before first
+> publication" window is now closed.
+
 ## Recommendation
 
 Accepted as directed. Land the package through the mapped S3 beads with


### PR DESCRIPTION
## Gap

EP-0035's R-1 packaging row states the confirmed native coordinate (`re-com/re-com-ui` + `re-com.ui.*`) but carries no record of the 2026-07-17 confirmation; the Resolved Decisions preamble dates everything 2026-07-16 only.

## Evidence

The rf2-6ajm6z epic NOTES carry the 2026-07-17 delegated ruling confirming the coordinate FINAL (closing the R-1 "may be adjusted before first publication" window), plus an explicit MAYOR TODO to add a one-line errata note to EP-0035's Resolved Decisions at the R-1 row recording exactly that.

## Change

Additive only: one dated errata blockquote immediately after the R-1..R-10 register table, in the corpus errata idiom (EP-0001/EP-0013 pattern — a table row cannot host a blockquote). No existing text altered. This closes that rf2-6ajm6z MAYOR TODO.

## Gates

- `python scripts/check_doc_slugs.py` — pass
- `python scripts/check_ep_status_sync.py` — pass
- `python -m mkdocs build --strict` — pass