### PR TITLE
docs(ep): retrofit r7ahi errata form onto EP-0032's post-final edits; strike closed ledger rows

### DIFF
--- a/docs/EP/EP-0032-re-frame-ui-reactivity-and-ownership.md
+++ b/docs/EP/EP-0032-re-frame-ui-reactivity-and-ownership.md
@@ -149,7 +149,19 @@ callback) under the split equality law (`:override-id` by `=`, `:version` by
 render resolves and probes without ownership · commit acquires the exact
 captured target · acquire before release · release is synchronous and
 idempotent · moved evidence corrects before paint · one notification per
-dirty cell per render batch (boundary at the host checkpoint, never epoch close).
+dirty cell per drain (boundary at quiescence, never epoch close).
+
+> **Erratum — 2026-07-19 (`rf2-vxgfnd.166`, PR #6393).** The sixth invariant is
+> preserved above as graduated, and its boundary clause was recorded wrongly:
+> the shipped scheduler takes no hook from router drain finalization, so the
+> notification boundary is the **host checkpoint**, not drain quiescence — one
+> notification per dirty cell per **render batch**. The corrected law is
+> normative in `spec/006-ReactiveSubstrate.md` (§The six frozen invariants,
+> invariant 6; §Render-batch finalization — the host-checkpoint boundary); the
+> spec governs. The same PR reworded this EP's Goals bullet, §One ViewCell
+> prose, and §Push economics paragraph in place from the stale drain-quiescence
+> phrasing; those three passages (not verbatim-frozen) now read as corrected.
+> The other five invariants are unchanged.
 
 ### Transactional multi-acquire
 
@@ -283,7 +295,7 @@ Evidence and landing record (epic `rf2-vxgfnd`):
 Guide impact: the new-substrate guide's reactivity chapters teach hot reload as
 the default workflow and the three-state lifecycle as the tool vocabulary; no
 legacy-adapter guide changes (those coexisting adapters are unaffected by this work; they
-live on per EP-0030).
+live on per EP-0030, Resolved Decisions 2026-07-17).
 
 ## Resolved Decisions
 
@@ -317,8 +329,8 @@ the program epic (`rf2-vxgfnd`).
 
 | Bead | Gap |
 |---|---|
-| `rf2-vxgfnd.166` | render batches must be defined by host checkpoint, not router drain (the G-5 boundary prose) |
-| `rf2-vxgfnd.167` | per-epoch render-law sweep incomplete (force-tracked ai) |
+| ~~`rf2-vxgfnd.166`~~ | ~~render batches must be defined by host checkpoint, not router drain (the G-5 boundary prose)~~ — closed (PR #6393; see the erratum beside the six frozen invariants) |
+| ~~`rf2-vxgfnd.167`~~ | ~~per-epoch render-law sweep incomplete (force-tracked ai)~~ — closed (PR #6393) |
 | ~~`rf2-vxgfnd.169`~~ | ~~empty root-incarnation entries not pruned after weak member collection~~ — closed |
 | ~~`rf2-vxgfnd.204`~~ | ~~CLJS SSR emitter not replayed when `re-frame.ui/adapter` is reinstalled~~ — closed |
 | ~~`rf2-vxgfnd.94.15`, `.94.17`–`.94.21`~~ | ~~compatible-HMR migration evidence/drift-guard family~~ — closed (`.94.16` closed earlier) |


### PR DESCRIPTION
## What

A read-only audit of EP-0032 (final, graduated 2026-07-16) verified its frozen content against the shipped system and found the content TRUE but three process/currency gaps against the rf2-r7ahi freeze-meaning ruling. This PR applies the corrections; rf2-r7ahi is the governing ruling.

## The freeze-meaning finding

PR #6393 (commit ef5a1c98c1, merged 2026-07-18T17:24Z — postdating the rf2-r7ahi ruling recorded 2026-07-18 18:07 AUSEST) rewrote settled passages of a `final` EP in place, undated: the Goals bullet, the §One ViewCell prose, the §Push economics paragraph, and — most significantly — the sixth of "the six frozen invariants", which the EP itself labels **graduated verbatim** ("per drain (boundary at quiescence)" became "per render batch (boundary at the host checkpoint)"). Under rf2-r7ahi that is a Tier-2 correction (changes the meaning of a settled passage) executed as a Tier-1 silent edit.

## The retrofit

- **Sixth invariant**: the original graduated wording is restored, with a dated erratum blockquote immediately beside it recording the 2026-07-19 correction — the boundary is the host checkpoint / per render batch, normative in `spec/006-ReactiveSubstrate.md` (§The six frozen invariants inv. 6; §Render-batch finalization — the host-checkpoint boundary), the spec governs. The erratum also records that the same PR reworded the three non-verbatim passages in place (those keep the corrected prose for readability; the erratum makes the history visible).
- **Ledger strikes** (Tier 1 per the ledger's own protocol): rows `rf2-vxgfnd.166` and `rf2-vxgfnd.167` struck — both beads closed 2026-07-18, shipped via PR #6393.
- **One-line dated marker** on the Guide-impact line that the 2026-07-17 rf2-ukq8qt reframe silently synced ("frozen" -> "live on"): now cites EP-0030 Resolved Decisions 2026-07-17.

## Verified

The underlying #6393 correction content is right — the host-checkpoint contract was checked against `implementation/ui/src/re_frame/ui/reactive.cljc` and `spec/006-ReactiveSubstrate.md`; this PR changes form, not substance. Where EP and spec differ, the spec governs (EP-0009).

`docs/EP/README.md` deliberately untouched (owned by another worker this round).

Gates (foreground, from the worktree): `check_doc_slugs.py` PASS, `check_ep_status_sync.py` PASS, `mkdocs build --strict` PASS.