### PR TITLE
fix(ui): include custom-element declarations in the build digest; pin what advances a pending batch (rf2-0wvoj, rf2-kahkr)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -709,13 +709,38 @@
           (fn [committed]
             (select-keys committed (filter keep? (keys committed))))))
 
+(defn- committed-rows
+  "Pure: one finalized slice's COMMITTED rows for `reg-id`, merged across
+  sources (the same fold `committed-aggregate` performs, over an explicit
+  slice)."
+  [slice reg-id]
+  (reduce-kv (fn [m _src regs] (merge m (get regs reg-id)))
+             {} (:committed slice)))
+
 (defn- digest-for-slice
-  "Pure whole-build digest of one finalized slice's committed view rows."
+  "Pure whole-build digest of one finalized slice's committed build-identity
+  rows: the view rows AND the custom-element declarations.
+
+  Element declarations are in the fold because they are build OUTPUT, not
+  bookkeeping. A tag's declared `:properties` decide whether `ui/spread` emits
+  a prop as a DOM property or as an attribute (see `element-properties`), so
+  two builds with IDENTICAL view sources but different element classification
+  emit DIFFERENT DOM. The digest is build identity; folding only the views made
+  those two builds indistinguishable to every digest consumer — caching,
+  staleness detection, served-output freshness (rf2-0wvoj).
+
+  Declaration PROVENANCE is deliberately excluded: `element-declarations`
+  (tag -> owning ns) records WHO declared a fact, not WHAT the build emits, so
+  moving a declaration between namespaces must not change build identity.
+
+  Each row is keyed by `[reg-id k]`, so a view-id and an element tag can never
+  collide in the digest's sorted input."
   [slice]
   (fingerprint/build-digest
-   (mapv (fn [[id [tf hs]]] [id tf hs])
-         (reduce-kv (fn [m _src regs] (merge m (get regs views)))
-                    {} (:committed slice)))))
+   (into (mapv (fn [[id [tf hs]]] [[views id] tf hs])
+               (committed-rows slice views))
+         (map (fn [[tag decl]] [[elements tag] decl]))
+         (committed-rows slice elements))))
 
 (defn finalized-build-digest
   "The accepted whole-build digest in the ambient compiler context, or the

--- a/implementation/ui/src/re_frame/ui/fingerprint.cljc
+++ b/implementation/ui/src/re_frame/ui/fingerprint.cljc
@@ -38,11 +38,17 @@
                             re-serialises every hook signature: a deliberate
                             one-time global remount wave when S3 lands (pre-
                             alpha, no shim).
-      build-digest          \"bd1-\"  input: the SORTED vector of
-                            [view-id template-fingerprint hook-signature]
-                            triples of every view in the build (sorted by
-                            view-id so the digest is compile-order
-                            independent)
+      build-digest          \"bd1-\"  input: the SORTED vector of the build's
+                            identity rows, each `[row-key & values]` (sorted
+                            by row-key so the digest is compile-order
+                            independent). The caller supplies the rows; the
+                            compiler's build slice contributes one per view
+                            ([[::views view-id] template-fingerprint
+                            hook-signature]) and one per custom-element
+                            declaration ([[::elements tag] declaration]) —
+                            element :properties decide attribute-vs-property
+                            emission, so they are build output, not
+                            bookkeeping (rf2-0wvoj)
       config-fingerprint    \"cf1-\"  input: [frame-id config-source-map]
                             — a root form's static frame plan (S1c,
                             root-identity contract §6): the frame-root's
@@ -289,10 +295,12 @@
                      :react   (vec react)}]))
 
 (defn build-digest
-  "\"bd1-\" digest over `[[view-id template-fingerprint hook-signature] ...]`
-  triples, sorted by view-id (compile-order independent)."
-  [triples]
-  (digest "bd1-" (vec (sort-by (comp pr-str first) triples))))
+  "\"bd1-\" digest over the build's identity `rows` — each `[row-key & values]`
+  — sorted by row-key (compile-order independent). The compiler's build slice
+  supplies a row per view and a row per custom-element declaration; see the
+  namespace docstring for the row shapes."
+  [rows]
+  (digest "bd1-" (vec (sort-by (comp pr-str first) rows))))
 
 (defn config-fingerprint
   "\"cf1-\" digest of a static frame plan (S1c root-identity contract §6):

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -79,9 +79,31 @@
        the window cannot close while the stack is still unwinding.
     2. N epochs/events settled within ONE drain coalesce into ONE batch.
     3. SEVERAL drains — or listener re-entry after a completed batch — that
-       finish before the SAME host checkpoint MAY SHARE one batch. Two
-       back-to-back `dispatch-sync!` calls in one JavaScript stack render
-       once, not twice; so do nested cross-frame synchronous drains.
+       finish before the SAME host checkpoint MAY SHARE one batch. Nested
+       cross-frame synchronous drains do.
+
+       This is a PERMISSION, not a guarantee, and the difference is load
+       bearing. It used to carry an UNCONDITIONAL example — two back-to-back
+       `dispatch-sync!` calls in one JavaScript stack render once, not twice —
+       which is retracted (rf2-kahkr). It holds HEADLESS, where
+       `render-batch-host-checkpoint-cljs-test` still pins a genuinely shared
+       batch. It is FALSE on the MOUNTED React path, so it could never be
+       stated unconditionally.
+
+       Measured on the mounted path, three back-to-back `dispatch-sync!` calls
+       advance the revision 0 -> 1 -> 2: a host microtask checkpoint runs DURING
+       the second and third calls, so each flushes its predecessor's mark.
+       What advances it is the ordinary armed `schedule-flush!` microtask —
+       every captured `flush-scope!` stack terminated at that closure with no
+       router frame above it, and `commit*`/`advance-revision!` never ran. It is
+       NOT a hidden synchronous flush and NOT a React layout-commit correction.
+       A control `js/queueMicrotask` enqueued by the fixture ran at the same
+       point, so the checkpoint is the host's: `dispatch-sync!` is simply not
+       microtask-atomic on this path — it yields. Whether it SHOULD is a ROUTER
+       question, not a scheduler one, and is deliberately left open.
+
+       So: do not rely on two separate `dispatch-sync!` calls sharing a batch.
+       Guarantees 1 and 2 — one drain, one batch — are what a caller may lean on.
     4. Drains separated by a real HOST YIELD render separately.
 
   `One render batch per router drain` is RETIRED as normative. It remains

--- a/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
@@ -736,7 +736,7 @@
         (is (contains? (:elements incremental) :y-el))
         (is (not (contains? (:elements incremental) :x-el))          "custom-element :x-el gone")
         (is (= 1 (count (:views incremental)))                        "view foo gone, only bar"))
-      (testing "the digest is a function of current views only"
+      (testing "the digest is a function of the CURRENT declared facts — no ghost of the pre-edit source"
         (is (= (:digest clean) (:digest incremental)))))))
 
 ;; ---------------------------------------------------------------------------
@@ -803,6 +803,91 @@
     (build/commit-build! :app)
     (is (not= committed-1 (get-in (root/descriptor-index) [:page/m :build-digest]))
         "the digest advances only at the successful commit boundary")))
+
+;; ---------------------------------------------------------------------------
+;; The digest covers custom-element declarations too (rf2-0wvoj)
+;;
+;; The digest IS build identity. Custom-element `:properties` decide whether a
+;; prop is emitted as a DOM property or an attribute, so two builds whose
+;; element classification differs EMIT DIFFERENT DOM. A digest that folded only
+;; the view rows called those two builds identical, and everything keyed on the
+;; digest — caching, staleness, served-output freshness — inherited that lie.
+;;
+;; Each assertion below is driven by its OWN two-build fixture (rf2-wlqfq): the
+;; views are held byte-identical and ONLY the element declarations move, so the
+;; sole thing that can make the digests differ is the element fold. Dropping
+;; `elements` from `digest-for-slice` reds these and nothing else has to.
+;; ---------------------------------------------------------------------------
+
+(defn- digest-of
+  "Finalized whole-build digest of a fresh build authority containing exactly
+  what `declare!` contributes. Reset before AND after, so the value depends on
+  nothing a neighbouring test left behind."
+  [declare!]
+  (build/reset-build!)
+  (build/begin-build! :app)
+  (declare!)
+  (build/commit-build! :app)
+  (let [d (compiler/current-build-digest)]
+    (build/reset-build!)
+    d))
+
+(deftest digest-distinguishes-differing-custom-element-properties
+  ;; SAME view source, SAME tag, DIFFERENT :properties — different DOM, so the
+  ;; build identity must differ.
+  (let [with-help (digest-of (fn []
+                               (declare-view!    'app.a 'foo [:div "foo"])
+                               (declare-element! 'app.a :x-el #{:help-text})))
+        with-label (digest-of (fn []
+                                (declare-view!    'app.a 'foo [:div "foo"])
+                                (declare-element! 'app.a :x-el #{:label})))]
+    (is (not= with-help with-label)
+        "#{:help-text} vs #{:label} on the same tag classifies props differently (property vs attribute) — the digest must not call these one build")))
+
+(deftest digest-distinguishes-a-declared-element-from-no-declaration
+  ;; SAME view source; one build declares a custom element, the other declares
+  ;; none. An undeclared tag classifies every prop as an attribute.
+  (let [declared (digest-of (fn []
+                              (declare-view!    'app.a 'foo [:div "foo"])
+                              (declare-element! 'app.a :x-el #{:help-text})))
+        undeclared (digest-of (fn []
+                                (declare-view! 'app.a 'foo [:div "foo"])))]
+    (is (not= declared undeclared)
+        "adding a custom-element declaration changes what the build emits — the digest must advance")))
+
+(deftest digest-distinguishes-a-renamed-custom-element-tag
+  ;; SAME view source, SAME :properties, DIFFERENT tag.
+  (let [x-el (digest-of (fn []
+                          (declare-view!    'app.a 'foo [:div "foo"])
+                          (declare-element! 'app.a :x-el #{:help-text})))
+        y-el (digest-of (fn []
+                          (declare-view!    'app.a 'foo [:div "foo"])
+                          (declare-element! 'app.a :y-el #{:help-text})))]
+    (is (not= x-el y-el)
+        "renaming the declared tag re-points the classification — the digest must advance")))
+
+(deftest digest-is-stable-across-declaring-namespace-and-compile-order
+  ;; The complement, and the guard against "fix" by folding raw slice structure:
+  ;; the digest is a function of the DECLARED FACTS, not of which namespace
+  ;; declared them or in what order the macros expanded.
+  (let [a-first (digest-of (fn []
+                             (declare-view!    'app.a 'foo [:div "foo"])
+                             (declare-element! 'app.a :x-el #{:help-text})
+                             (declare-element! 'app.a :y-el #{:label})))
+        reordered (digest-of (fn []
+                               (declare-element! 'app.a :y-el #{:label})
+                               (declare-element! 'app.a :x-el #{:help-text})
+                               (declare-view!    'app.a 'foo [:div "foo"])))]
+    (is (= a-first reordered)
+        "compile order does not change build identity"))
+  (let [one-ns (digest-of (fn []
+                            (declare-view!    'app.a 'foo [:div "foo"])
+                            (declare-element! 'app.a :x-el #{:help-text})))
+        split-ns (digest-of (fn []
+                              (declare-view!    'app.a 'foo [:div "foo"])
+                              (declare-element! 'app.b :x-el #{:help-text})))]
+    (is (= one-ns split-ns)
+        "moving a declaration to another namespace declares the same fact — same identity")))
 
 (deftest repeated-rebuilds-stay-bounded
   ;; correctness across a watch session — re-declaring the same namespace N

--- a/implementation/ui/test/re_frame/ui/render_batch_host_checkpoint_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/render_batch_host_checkpoint_dom_cljs_test.cljs
@@ -24,6 +24,41 @@
   permission as though it were the guarantee is exactly the over-claim this
   bead exists to remove.
 
+  ## What advances that pending mark (rf2-kahkr — traced, not inferred)
+
+  The mechanism is now identified, and it is NOT a hidden synchronous flush.
+  Three back-to-back `dispatch-sync!` calls were instrumented on this exact
+  fixture (stack capture on `flush-scope!` and on `advance-revision!`, with
+  console markers bracketing each call). Across 3 browser runs, identically:
+
+    - the revision advanced 0 -> 1 -> 2, one advance per call after the first;
+    - EVERY `flush-scope!` stack was the same three frames —
+      `flush-scope!` <- `flush-pending!` <- the `schedule-flush!` microtask
+      closure — terminating there, with NO router or dispatch frame above it.
+      That is a host job-queue entry point, i.e. the ordinary armed microtask;
+    - `advance-revision!` (the `commit*` / step-8 route) NEVER fired, so the
+      advance is scheduler phase 1, not a React layout-commit correction;
+    - the flush was logged BETWEEN the `begin` and `end` markers of the second
+      and third calls — i.e. a microtask checkpoint ran DURING `dispatch-sync!`.
+
+  The control that settles it: a plain `js/queueMicrotask` enqueued by the
+  fixture itself, immediately before the second call, ALSO ran between that
+  call's begin and end markers. Nothing in re-frame is involved in that
+  callback, so the checkpoint is genuinely the host's.
+
+  Conclusion: `dispatch-sync!` is not microtask-atomic on the mounted path — it
+  yields, and the ordinary checkpoint therefore lands mid-call and flushes the
+  previous drain's mark. So there is nothing here to remove: the scheduler is
+  behaving exactly as specified, and the earlier `flush-render!` /
+  `dispatch-committed!` / late-bound-hook suspects are correctly ruled out.
+
+  Whether `dispatch-sync!` SHOULD yield is a ROUTER question living in
+  `implementation/core`, and it is a ruling, not a measurement. It is left open
+  deliberately. Until it is ruled, no fixture here asserts sharing OR
+  non-sharing across two `dispatch-sync!` calls: the first would assert a
+  permission as a guarantee, the second would freeze possibly-unintended
+  router behaviour into a contract. Both are over-claims.
+
   ## Why the awaits here are ordering guarantees, not races
 
   The scheduler arms its flush with `queue-microtask!` during the drain. The
@@ -145,14 +180,22 @@
   ;; still pending. Nothing about the router closes a render batch — only the
   ;; host checkpoint does.
   ;;
-  ;; MEASURED SCOPE NOTE (rf2-vxgfnd.166). The ruled contract says drains
-  ;; finishing before one checkpoint MAY share a batch; it does not promise they
-  ;; always will. On this mounted path they do not always: a SECOND
-  ;; `dispatch-sync!` in the same stack was measured to advance the first
-  ;; drain's pending mark before making its own. So this fixture asserts the
-  ;; guarantee (a finished drain leaves the window open) rather than the
-  ;; permission. The headless sibling pins an actual shared batch, where the
-  ;; scheduler is observed without React in the loop.
+  ;; MEASURED SCOPE NOTE (rf2-vxgfnd.166; mechanism traced by rf2-kahkr). The
+  ;; ruled contract says drains finishing before one checkpoint MAY share a
+  ;; batch; it does not promise they always will. On this mounted path they do
+  ;; not always: a SECOND `dispatch-sync!` in the same stack was measured to
+  ;; advance the first drain's pending mark before making its own. So this
+  ;; fixture asserts the guarantee (a finished drain leaves the window open)
+  ;; rather than the permission. The headless sibling pins an actual shared
+  ;; batch, where the scheduler is observed without React in the loop.
+  ;;
+  ;; That advance is now traced: it is the ordinary armed `schedule-flush!`
+  ;; microtask, landing mid-call because `dispatch-sync!` yields to the host
+  ;; microtask queue. See the namespace docstring for the instrumentation, the
+  ;; control microtask that identifies it, and why nothing asserts sharing (or
+  ;; non-sharing) across two `dispatch-sync!` calls pending a router ruling.
+  ;;
+  ;; This test itself performs exactly ONE drain, so it is unaffected either way.
   (if-not (browser?)
     (is true ":node — no DOM; the :browser-test runner exercises the DOM body")
     (async


### PR DESCRIPTION
## rf2-0wvoj — build digest ignored custom-element declarations

`build/digest-for-slice` folded only the `views` rows, so two builds with identical view sources but different custom-element declarations produced the **same** build digest.

That matters because the digest *is* build identity, and element `:properties` decide whether `ui/spread` emits a prop as a DOM property or an attribute. The digest was calling two builds identical when they emit different DOM, and everything keyed on it — caching, staleness detection, served-output freshness — inherited that.

The fold now covers the committed `elements` rows alongside the views. Each row is keyed `[reg-id k]` so a view-id and an element tag cannot collide in the sorted input. Declaration **provenance** (`element-declarations`, tag → owning ns) stays out: it records *who* declared a fact, not *what* the build emits, so moving a declaration between namespaces must not change build identity.

### Causal acceptance, with its own lever

Four fixtures, each driven by its own two-build helper with the views held identical and only the element declarations moving:

- differing `:properties` on the same tag digest differently
- a declared element differs from no declaration
- a renamed tag digests differently
- the complement: compile order and declaring namespace do **not** change identity

**Red-before:** with elements absent from the fold, all four builds digested to one value (`bd1-5e365af9fe5f6619`). Exactly the 3 discriminating tests failed and **all 43 neighbours in the namespace stayed green** — so the lever is the element fold and nothing else, not a blanket mutation reddening bystanders.

**Vacuity probe:** flipped `not=` → `=` in `digest-distinguishes-differing-custom-element-properties`; the gate red-lit naming that test, then restored byte-identical.

Digest values change build-wide. Nothing asserts a literal digest — only `bd1-` prefix checks — and the stale views-only prose in `fingerprint.cljc` is corrected.

`.141`'s source-harvest was **not** needed; the fix is the one fold, as the bead scoped it.

## rf2-kahkr — what advances a pending batch on a second `dispatch-sync!`

Measured, not reasoned. The bead's observation **reproduces**: three back-to-back `dispatch-sync!` calls advance the revision `0 → 1 → 2`.

Instrumented on the real React 19 + DOM fixture with stack capture on `flush-scope!` and `advance-revision!`, plus console markers bracketing each call. **3 browser runs, identical every time:**

- every `flush-scope!` stack was the same three frames — `flush-scope!` ← `flush-pending!` ← the `schedule-flush!` microtask closure — **terminating there, with no router or dispatch frame above it**. That is a host job-queue entry point, i.e. the ordinary armed microtask.
- `advance-revision!` (the `commit*` / step-8 route) **never fired** — so the advance is scheduler phase 1, confirming the filer's own attribution.
- the flush was logged **between** the begin/end markers of the 2nd and 3rd calls.

**The control that identifies it:** a plain `js/queueMicrotask` enqueued by the fixture immediately before the second call **also** ran between that call's begin and end markers. No re-frame code participates in that callback, so the checkpoint is genuinely the host's.

**Answer:** there is no hidden synchronous flush and no incidental scheduler coupling to remove. The scheduler is correct as specified. `dispatch-sync!` is simply **not microtask-atomic** on the mounted path — it yields, so the ordinary checkpoint lands mid-call and flushes the previous drain's mark. The filer's four ruled-out suspects were all correctly ruled out; the closest (drain 1's microtask firing early) was right about the microtask and wrong only in assuming a mid-stack fire was impossible.

### What is and isn't asserted

Retracts the one false authority statement on this surface: guarantee 3 in `reactive.cljc` carried the **unconditional** example *"two back-to-back `dispatch-sync!` calls in one JavaScript stack render once, not twice."* It holds **headless** (the headless sibling still pins a genuinely shared batch) and is **false mounted**, so it could never be stated unconditionally. The MAY-share permission itself is unchanged and correct.

This PR **deliberately asserts neither sharing nor non-sharing** across two `dispatch-sync!` calls. The first would assert a permission as a guarantee — the exact over-claim the bead exists to remove. The second would freeze possibly-unintended router behaviour into a contract.

### Stopped and reported

Whether `dispatch-sync!` *should* yield is a **router ruling** living in `implementation/core` — off this bead's surface and held by #6365. Filed as **rf2-i3dvj** rather than actioned.

`spec/006-ReactiveSubstrate.md` (~1773-1776) and `docs/core/glossary` (~205) still repeat the retracted claim. Left deliberately: spec/006 is hot-zone, and if the ruling goes "the router should be atomic" the prose becomes correct again and must not be rewritten twice. Sequence after rf2-i3dvj.

## Quality gates

All foreground, unpiped, run to completion on the final tree; exit codes captured by redirect.

| Gate | Result | Exit |
|---|---|---|
| `implementation/ui` → `clojure -M:test` | **959 tests / 18641 assertions**, 0 failures, 0 errors | 0 |
| `implementation` → `npm run test:cljs` | **10217 tests / 50489 assertions**, 0 failures, 0 errors | 0 |
| `implementation` → `npm run test:browser` | **481 tests / 2700 assertions**, 0 failures, 0 errors | 0 |
| `implementation/core` → `clojure -M:test` | **2078 tests / 9960 assertions**, 0 failures, 0 errors | 0 |
| `scripts/check-no-hardcoded-paths.sh` | Portability gate OK | 0 |

The browser gate is load-bearing here, not decorative: the mounted bodies self-skip under node, so the `kahkr` measurement would have been vacuous without it.

No new error ids, so no Spec 009 / Spec-Schemas co-edit is due. `node_modules` is a real `npm install` in this worktree (101 entries) — no junction into the mayor tree.
