### PR TITLE
docs(EP): de-historicalise the six re-frame.ui EPs to PEP-standard form

### DIFF
--- a/docs/EP/EP-0030-the-compiled-view-substrate-program.md
+++ b/docs/EP/EP-0030-the-compiled-view-substrate-program.md
@@ -2,374 +2,376 @@
 
 Status: accepted
 Type: standards-track
-
-> **Graduating in stages.** The S1 and S2 slices have already landed in `spec/`:
-> the full Spec 004 rewrite plus [`spec/004B-UI-Tree-and-Conversion.md`](../../spec/004B-UI-Tree-and-Conversion.md),
-> [`spec/004C-Roots-and-Mount.md`](../../spec/004C-Roots-and-Mount.md), and
-> [`spec/004D-UI-Test-Selectors.md`](../../spec/004D-UI-Test-Selectors.md) merged
-> atomically with the Stage-1 conformance slice (ruling R-1), and the observation-port
-> ABI is normative in [`spec/006-ReactiveSubstrate.md`](../../spec/006-ReactiveSubstrate.md)
-> §The internal observation port (ruling R-2). Per EP-0009 the spec governs wherever it
-> and this EP differ; every later stage graduates the same way — spec edits merge
-> atomically with that stage's conformance fixtures, never ahead of them.
-
-> This is the umbrella EP of the compiled-view substrate program. It records **one
-> decision surface**: add a first-party compiled view library, **`re-frame.ui`**, as a
-> **new, experimental view substrate offered alongside the existing adapters**, delivered
-> as staged conformance slices S1–S7 behind a demand-bar-gated public surface.
-> `re-frame.ui` is an additional option, **not** a mandated replacement and **not** the
-> only taught view layer: **Reagent, UIx, and reagent-slim live on as first-class,
-> actively-supported adapters; only Helix is removed** (Resolved Decisions, 2026-07-17).
-> The program-level decision, delivery plan, and operator rulings live here; the
-> per-domain contracts live in the sibling EPs (EP-0031–EP-0035). Normative home: the
-> Spec 004 family, Spec 006, and the Spec 008/009/011 rows each stage amends.
+Created: 2026-07-16
+Resolution: accepted 2026-07-11 (program ratification); adapter disposition reframed 2026-07-17
 
 ## Abstract
 
-re-frame2 gets one first-party view layer. Views are hiccup with event vectors as
-handlers; a shared analyzer lowers them to a normalized AST, and each host build emits
-from its own — direct React code for the browser, a structural render tree for the
-JVM — no interpreter ships. A view's
-reads share one React bridge under a committed push-ownership protocol, frames are
-created at host preflight (never from render), dev builds are a glass cockpit that
-provably vanishes from production. `re-frame.ui` ships as a **new, experimental,
-first-party view substrate** — an additional option, not a mandated replacement; stock
-Reagent, UIx, and reagent-slim live on as first-class, actively-supported adapters; only
-Helix is removed once the S7 soak gates pass.
+This is the umbrella EP of the compiled-view substrate program. It records **one
+decision surface**: add a first-party compiled view library, **`re-frame.ui`**, as
+a **new, experimental view substrate offered alongside the existing adapters**,
+delivered as staged conformance slices S1–S7 behind a demand-bar-gated public
+surface.
+
+Views are hiccup with event vectors as handlers; a shared analyzer lowers them to
+a normalized AST, and each host build emits from its own — direct React code for
+the browser, a structural render tree for the JVM — no interpreter ships. A
+view's reads share one React bridge under a committed push-ownership protocol,
+frames are created at host preflight (never from render), and dev builds are a
+glass cockpit that provably vanishes from production.
+
+`re-frame.ui` is an additional option, **not** a mandated replacement and **not**
+the only taught view layer: stock **Reagent, UIx, and reagent-slim live on as
+first-class, actively-supported adapters; only Helix is removed**, behind the S7
+soak gates. The program-level decision, delivery plan, and operator rulings live
+here; the per-domain contracts live in the sibling EPs (EP-0031–EP-0035). The
+normative homes are the Spec 004 family, Spec 006, and the Spec 008/009/011 rows
+each stage amends; per EP-0009 the spec governs wherever it and this EP differ,
+and every stage graduates the same way — spec edits merge atomically with that
+stage's conformance fixtures, never ahead of them.
 
 ## Motivation
 
-The adapter trio was the exploration phase, and it worked — but it leaves the project
-paying three taxes at once. **A parity tax:** every capability, test matrix, example,
-and teaching page is built three ways or held to the weakest adapter. **An
-interpretation tax:** hiccup walked at runtime, wrapper components, per-render
-allocation — costs a compiler deletes wholesale. **A correctness ceiling:** modern React
-(concurrent rendering, StrictMode, Activity, hydration, HMR) punishes render-time
-ownership and speculative publication, a fight a first-party substrate ends by
-construction. Meanwhile the things re-frame2 is actually about — frames carried
-explicitly, events as the transition boundary, subscriptions as the one reactive
-grammar, causal debuggability — deserve a view layer designed around them.
+The adapter trio was the exploration phase, and it worked — but it leaves the
+project paying three taxes at once. **A parity tax:** every capability, test
+matrix, example, and teaching page is built three ways or held to the weakest
+adapter. **An interpretation tax:** hiccup walked at runtime, wrapper components,
+per-render allocation — costs a compiler deletes wholesale. **A correctness
+ceiling:** modern React (concurrent rendering, StrictMode, Activity, hydration,
+HMR) punishes render-time ownership and speculative publication, a fight a
+first-party substrate ends by construction. Meanwhile the things re-frame2 is
+actually about — frames carried explicitly, events as the transition boundary,
+subscriptions as the one reactive grammar, causal debuggability — deserve a view
+layer designed around them.
 
-The unresolved alternatives (keep the trio; bless one existing adapter; build new) were
-worked through a full synthesis dossier with spikes, adversarial reviews, and a ratified
-decision record — a conversation that does not fit in a bead. This EP is its durable
-record.
-
-## Goals / Non-Goals
-
-**Goals (ranked; the sibling EPs carry the full statements):**
-
-1. Correct under modern React — concurrent rendering, StrictMode, hydration, HMR; no
-   leaked owners, no render-time domain events.
-2. re-frame2-native conceptual integrity — frames carried, events as the boundary,
-   subscriptions as reads; no second state model.
-3. Excellent ergonomics — one obvious spelling per job; no manual memoization, deps
-   arrays, or frame-capture boilerplate.
-4. Exceptional production efficiency — no interpreter, no dev machinery in production;
-   claims are CI gates, not adjectives.
-5. Causal debuggability — a committed repaint joins to its exact causes, emitted at the
-   cause site, via public React behavior only.
-6. Determinism and testability — headless-first; structural parity across CLJS and JVM.
-7. Web-platform correctness as a design input — forms/IME, custom elements, trusted
-   markup, focus are contracts, not polish.
-
-**Non-Goals:** reproducing Reagent/UIx/Helix APIs inside `re-frame.ui`; a second state
-model (signals, ratoms, cursors, form runtimes); Suspense-as-loading-state, RSC,
-`startTransition` over app-db; pre-hydration event replay / resumability (research-tier
-by ruling R-5); non-React emitters in v1 (priced by an AST-shape gate, not a maintained
-implementation). This EP also does not decide the per-domain contracts — those are
-EP-0031–EP-0034 — nor the component-library readiness package (EP-0035).
-
-## Relationships
-
-- **Sibling EPs (authored with this one; each a narrow decision surface):**
-  **EP-0031** (programming model — `defview`, templates, the handler law, presence,
-  interop), **EP-0032** (reactivity & ownership — observation targets, ViewCell,
-  commit protocol, frames/preflight ENSURE, HMR), **EP-0033** (view evidence &
-  debugging), **EP-0034** (production, SSR, and testing posture), **EP-0035**
-  (component-library readiness — the directed S3 amendments and the re-com consumer).
-- **EP-0014** names the derivation/process algebra; the substrate reads through that one
-  reactive grammar and adds no second one.
-- **EP-0029** is the format precedent for this EP family and keeps machines ordinary
-  projections the view layer merely reads.
-- **EP-0002 / EP-0024** own explicit frame resolution and unified frame identity — the
-  substrate's carried-frame law and preflight ENSURE build directly on them.
-- **Specs:** the Spec 004 family (`004-Views.md`, 004B/004C/004D),
-  `spec/006-ReactiveSubstrate.md` (observation port; adapter contract), `spec/008`
-  (the `ui.test` contract home), `spec/009-Instrumentation.md` (evidence and catalogue
-  rows), `spec/011` (SSR roots and hydration).
-- **Source dossier:** `ai/findings/new-substrate-synthesis/README.md` (the tombstone
-  pointer map) — the design record this EP family distills, tombstoned per the Bead Plan
-  (rf2-mgy7pz); the decision surface now lives in this EP family + the `spec/` tree, with
-  `reviews/` and `spikes/` retained as durable evidence.
+The alternatives were genuine: keep the trio, bless one existing adapter, or
+build new. They were worked through a full synthesis dossier with spikes,
+adversarial reviews, and a ratified decision record — a conversation that does
+not fit in a bead. This EP is that record's durable home.
 
 ## Specification
 
+### Goals and non-goals
+
+**Goals (ranked; the sibling EPs carry the full statements):**
+
+1. Correct under modern React — concurrent rendering, StrictMode, hydration, HMR;
+   no leaked owners, no render-time domain events.
+2. re-frame2-native conceptual integrity — frames carried, events as the
+   boundary, subscriptions as reads; no second state model.
+3. Excellent ergonomics — one obvious spelling per job; no manual memoization,
+   deps arrays, or frame-capture boilerplate.
+4. Exceptional production efficiency — no interpreter, no dev machinery in
+   production; claims are CI gates, not adjectives.
+5. Causal debuggability — a committed repaint joins to its exact causes, emitted
+   at the cause site, via public React behavior only.
+6. Determinism and testability — headless-first; structural parity across CLJS
+   and JVM.
+7. Web-platform correctness as a design input — forms/IME, custom elements,
+   trusted markup, focus are contracts, not polish.
+
+**Non-goals:** reproducing Reagent/UIx/Helix APIs inside `re-frame.ui`; a second
+state model (signals, ratoms, cursors, form runtimes);
+Suspense-as-loading-state, RSC, `startTransition` over app-db; pre-hydration
+event replay / resumability (research-tier by ruling R-5); non-React emitters in
+v1 (priced by an AST-shape gate, not a maintained implementation). This EP also
+does not decide the per-domain contracts — those are EP-0031–EP-0034 — nor the
+component-library readiness package (EP-0035).
+
 ### The decision
 
-`re-frame.ui` (artifact `day8/re-frame2-ui`, alias `ui` — ruling R-3) is a **new,
-experimental, first-party view substrate** of re-frame2 — an additional option, **not** a
-mandated replacement and **not** the only taught view layer. It is the focus of the
-program's new compiled-substrate capability, performance, and debugging-integration work.
-**Stock Reagent, UIx, and reagent-slim live on as first-class, actively-supported
-adapters** — they are not frozen and are not scheduled for removal, keeping their
-contract suites plus one browser smoke each. **Only Helix is removed** after the
-proof/soak gates (S7). The v1 runtime law is unchanged: exactly one adapter is installed
-per process, chosen at boot; foreign React interop (`ui/raw`, `ui/->react`) never selects
-a second adapter.
+`re-frame.ui` (artifact `day8/re-frame2-ui`, alias `ui` — ruling R-3) is a
+**new, experimental, first-party view substrate** of re-frame2 — an additional
+option, **not** a mandated replacement and **not** the only taught view layer. It
+is the focus of the program's new compiled-substrate capability, performance, and
+debugging-integration work. **Stock Reagent, UIx, and reagent-slim live on as
+first-class, actively-supported adapters** — they are not frozen and are not
+scheduled for removal, keeping their contract suites plus one browser smoke each.
+**Only Helix is removed**, after the proof/soak gates (S7). The v1 runtime law is
+unchanged: exactly one adapter is installed per process, chosen at boot; foreign
+React interop (`ui/raw`, `ui/->react`) never selects a second adapter.
 
-### The program decision record (ratified 2026-07-11)
+### The program decision record
 
-The full record is reproduced below — graduated into this EP from `08-delivery.md` §5 in
-the tombstoned synthesis tree (rf2-mgy7pz). The rulings:
+The program was ratified as one decision record (2026-07-11). The rulings:
 
 | # | Surface | Ruling |
 |---|---|---|
-| R-1 | Spec 004 | Staged merge: the portability law lands immediately; the full normative rewrite merges atomically with the first conforming Stage-1 slice. *(Fired — landed with S1.)* |
-| R-2 | Spec 006 | Observation-port semantics frozen up front, exact shapes proposed by spike S-3; the port lives outside the closed ten-fn adapter map. *(Normative in Spec 006 since S2.)* |
+| R-1 | Spec 004 | Staged merge: the portability law landed immediately; the full normative rewrite merged atomically with the first conforming Stage-1 slice. |
+| R-2 | Spec 006 | Observation-port semantics frozen up front, exact shapes from the ownership spike; the port lives outside the closed ten-fn adapter map. Normative in Spec 006 since S2. |
 | R-3 | Name | `re-frame.ui`, alias `ui`, artifact `day8/re-frame2-ui`; "facet" never public vocabulary. |
 | R-4 | Bare fns | Legal only in known native event properties (invoker + phase known); day-one strict lint `{:re-frame.ui/bare-handlers :warn\|:error}`. |
 | R-5 | Resumability | Research-tier, decisively; serializability preserves the option and creates no obligation. |
 | R-6 | Packaging | Separate artifact on a lockstep release train; not casually revisited at alpha. |
 
-Named companion rulings from the same record: the **presence** contract (`ui/presence`
-wrapper, no reserved nodes, mandatory timeout safety bound); the **adapters** ruling
-(the coexistence shape above — Reagent + re-com enable the two-step v1 migration; UIx
-apps keep a correct boot choice; **the original "frozen compatibility adapters" /
-"reagent-slim removed" shape is superseded on the adapter-disposition point by the
-2026-07-17 reframing — see Resolved Decisions**); the **proof app** (RealWorld-resources
-— one vertical page at S3, the full app at S6); the **budget** (B-lite: never saturate
-all worker slots on the substrate pre-proof); and the **frame chain** (R-7 — the staged
-frame-root/provider split, since landed).
+Named companion rulings from the same record: the **presence** contract
+(`ui/presence` wrapper, no reserved nodes, mandatory timeout safety bound); the
+**adapters** ruling (the coexistence shape above — Reagent + re-com enable the
+two-step v1 migration; UIx apps keep a correct boot choice — later reframed on
+the adapter-disposition point; see Resolved Decisions); the **proof app**
+(RealWorld-resources — one vertical page at S3, the full app at S6); the
+**budget** (B-lite: never saturate all worker slots on the substrate pre-proof);
+and the **frame chain** (R-7 — the staged frame-root/provider split, since
+landed).
 
 ### Stages S1–S7
 
-Delivery is staged conformance slices; each stage wires its gates into CI in that stage
-and merges its spec edits atomically with its fixtures. Stage 0 (rulings + five spikes:
-codegen, push falsification, concurrency, dual host, input synchrony) completed with all
-spikes feasibility-PASS before any production code.
+Delivery is staged conformance slices; each stage wires its gates into CI in that
+stage and merges its spec edits atomically with its fixtures. Stage 0 (the
+rulings plus five feasibility spikes: codegen, push falsification, concurrency,
+dual host, input synchrony) completed with every spike a feasibility PASS before
+any production code.
 
-1. **S1 — compiler slice:** `defview`, AST, dual emitters (CLJS + JVM), roots/mount,
-   compile-error roster, `ui.test` Tier-1 core, parity corpus, G-1/G-14 gates.
-2. **S2 — ownership + frames + HMR:** observation port, ViewCell + commit algorithm,
-   preflight ENSURE, host-checkpoint render batching, `flush!`, the full HMR matrix.
-3. **S3 — committed host behavior + debugging as first consumer:** event vectors,
-   sync-input door, `local`/`effect`/`dispatch-fn`, foreign boundaries, error boundary,
-   evidence schema consumed by Xray, elision gates, one RealWorld vertical page. Carries
-   the directed component-library readiness amendments (EP-0035).
-4. **S4 — presence + web boundaries:** presence, custom elements, head policy, a11y
-   diagnostics.
-5. **S5 — SSR roots + hydration:** root manifests, idempotent frame payloads, failure
-   isolation, `render-static`.
-6. **S6 — production specialization + repo adoption:** capability-specialized output,
-   absence/equivalence/budget gates, migrator, examples/docs/skills/template/CI
-   rewrite; RealWorld-resources + Story + Xray green is the proof.
-7. **S7 — alpha + Helix-removal wave:** every gate green, demand-bar prune, **only Helix
-   removed** — strictly behind the soak gates (two consecutive green nightlies + one week
-   of repo work with no fallback). Reagent, UIx, and reagent-slim live on as first-class
-   adapters; `re-frame.ui` remains a new experimental substrate, not their replacement.
+1. **S1 — compiler slice:** `defview`, AST, dual emitters (CLJS + JVM),
+   roots/mount, compile-error roster, `ui.test` Tier-1 core, parity corpus,
+   G-1/G-14 gates.
+2. **S2 — ownership + frames + HMR:** observation port, ViewCell + commit
+   algorithm, preflight ENSURE, host-checkpoint render batching, `flush!`, the
+   full HMR matrix.
+3. **S3 — committed host behavior + debugging as first consumer:** event
+   vectors, sync-input door, `local`/`effect`/`dispatch-fn`, foreign boundaries,
+   error boundary, evidence schema consumed by Xray, elision gates, one
+   RealWorld vertical page. Carries the directed component-library readiness
+   amendments (EP-0035).
+4. **S4 — presence + web boundaries:** presence, custom elements, head policy,
+   a11y diagnostics.
+5. **S5 — SSR roots + hydration:** root manifests, idempotent frame payloads,
+   failure isolation, `render-static`.
+6. **S6 — production specialization + repo adoption:** capability-specialized
+   output, absence/equivalence/budget gates, migrator,
+   examples/docs/skills/template/CI rewrite; RealWorld-resources + Story + Xray
+   green is the proof.
+7. **S7 — alpha + Helix-removal wave:** every gate green, demand-bar prune,
+   **only Helix removed** — strictly behind the soak gates (two consecutive
+   green nightlies + one week of repo work with no fallback). Reagent, UIx, and
+   reagent-slim live on as first-class adapters; `re-frame.ui` remains a new
+   experimental substrate, not their replacement.
+
+S1–S4 are complete and declared conforming (the S3 and S4 conformance profiles
+live under `spec/conformance/`); S5 is the live stage. For a stage in flight the
+program's tracker is the state, not this page. Trigger-gated spikes (`ui/tpl`,
+registered `ui/view`, `ui/portal`, `defview-alias`, reset-key `local`) sit
+outside stage scope until their named triggers fire; EP-0035 records the
+rulings. The re-com native port is a separate directed program — deliberately
+not a program stage, so component migration never blocks S3–S7 (and vice
+versa).
 
 ### The demand-bar-gated public surface
 
-Every public name needed a named consumer **before Stage 1**, recorded in the blessed
-API table — `spec/API.md` §"re-frame.ui — blessed public-surface freeze", with the
-§2b authoritative surface matrix (name → stage / owner / proof fixture / spec home).
-This EP references those tables rather than duplicating them; **anything not in the
-table is not part of `re-frame.ui`'s public surface** (the demand bar disciplines the new
-substrate's own API — it says nothing about the retained adapters). The table was
-**blessed as-is by Mike on 2026-07-12 00:39
-AUSEST as the API freeze for v1**, with a delta protocol: findings that touch the table
-return as row-level deltas for re-ruling; the freeze itself is not reopened. Five deltas
-are ruled under it: **#1** `ui/custom-element` to v1 (2026-07-12), **#2** `ui/->react`
-(the outward migration bridge, lands S6), **#3** `ui/spread` (the single dynamic-map
-conversion path), **#4** `ui/slot` + internal `render-fn` widening (directed
-2026-07-16), **#5** `ui/spread-safe`, the literal safe-policy sibling of `ui/spread`
-(2026-07-16). Guide examples
-authored by this project never count as independent demand for platform-scale features
-— the rule that keeps resumability research-tier.
+Every public name needed a named consumer **before Stage 1**, recorded in the
+blessed API table — `spec/API.md` §"re-frame.ui — blessed public-surface
+freeze", with the §2b authoritative surface matrix (name → stage / owner / proof
+fixture / spec home). This EP references those tables rather than duplicating
+them; **anything not in the table is not part of `re-frame.ui`'s public
+surface** (the demand bar disciplines the new substrate's own API — it says
+nothing about the retained adapters). The table is blessed as the v1 API freeze
+(2026-07-12), with a delta protocol: findings that touch the table return as
+row-level deltas for re-ruling; the freeze itself is not reopened. Five deltas
+are ruled under it: **#1** `ui/custom-element`, **#2** `ui/->react` (the outward
+migration bridge; lands S6), **#3** `ui/spread` (the single dynamic-map
+conversion path), **#4** `ui/slot` plus the internal `render-fn` widening, and
+**#5** `ui/spread-safe` (the literal safe-policy sibling of `ui/spread`). Guide
+examples authored by this project never count as independent demand for
+platform-scale features — the rule that keeps resumability research-tier.
 
 ### Adoption workstreams
 
-The library alone is not the program. Fifteen workstreams
-(`11-adoption-workstreams.md`) decompose everything beyond it: the migrator tool (W1),
-migration + authoring skills (W2/W6), the docs/guide rewrite (W3), examples gaining
-`re-frame.ui` variants while `substrates/` is **retained** minus its Helix arm (W4), the
-hot-zone spec-tree waves (W5), tool evidence
-consumption into Xray/Story/Pair (W7a, S3 — debugging is the *first* consumer, not the
-last), the tools' own UIs migrating as the dogfood proof (W7b), the template gaining a
-`re-frame.ui` scaffold and losing its Helix variant (W8), the CI rewrite ending at
-**four** named causal suites (W9), SSR hosts (W10), one-time benchmarks against the
-existing adapters before Helix removal (W11), repo meta-docs (W12),
-the Helix-removal wave (W13), conformance corpus (W14), and program management (W15).
-None are optional; `ui.test`, the migrator, and the skills are critical path.
+The library alone is not the program. Fifteen workstreams decompose everything
+beyond it: the migrator tool (W1), migration + authoring skills (W2/W6), the
+docs/guide rewrite (W3), examples gaining `re-frame.ui` variants while
+`substrates/` is **retained** minus its Helix arm (W4), the hot-zone spec-tree
+waves (W5), tool evidence consumption into Xray/Story/Pair (W7a, S3 — debugging
+is the *first* consumer, not the last), the tools' own UIs migrating as the
+dogfood proof (W7b), the template gaining a `re-frame.ui` scaffold and losing
+its Helix variant (W8), the CI rewrite ending at **four** named causal suites
+(W9), SSR hosts (W10), one-time benchmarks against the existing adapters before
+Helix removal (W11), repo meta-docs (W12), the Helix-removal wave (W13), the
+conformance corpus (W14), and program management (W15). None are optional;
+`ui.test`, the migrator, and the skills are critical path.
 
-Because the retained adapters keep their example coverage, their suites, and their boot
-choices, none of these workstreams deletes a surface that belongs to Reagent, UIx, or
-reagent-slim; each one *adds* the `re-frame.ui` option beside them and subtracts only
-Helix. The template's post-Helix variant menu is now a **ruled supported external-alpha
-surface** (2026-07-19, delegated — see Resolved Decisions): W8 adds the experimental
-`re-frame.ui` scaffold beside the retained `:reagent` (default) and `:uix` variants,
-drops `:helix`, and leaves reagent-slim a reserved future variant on its existing
-trigger. Whether the menu ever narrows *later* remains a product choice reserved to
-Mike, and W8 does not presume one.
+Because the retained adapters keep their example coverage, their suites, and
+their boot choices, none of these workstreams deletes a surface that belongs to
+Reagent, UIx, or reagent-slim; each one *adds* the `re-frame.ui` option beside
+them and subtracts only Helix. The template's post-Helix variant menu is a
+ruled, supported external-alpha surface (see Resolved Decisions): W8 adds the
+experimental `re-frame.ui` scaffold beside the retained `:reagent` (default) and
+`:uix` variants, drops `:helix`, and leaves reagent-slim a reserved future
+variant on its existing trigger. Whether the menu ever narrows later remains a
+product choice reserved to Mike, and W8 does not presume one.
 
 ### Migration posture
 
-The external story is a **two-step migration** (`10-migration-from-reagent.md`): step 1
-moves a v1 Reagent/re-com app's *dataflow* to re-frame2 with views unchanged on the
-coexisting Reagent adapter — gaining Xray, epochs, Story, schemas, machines immediately;
-step 2 optionally migrates views to `ui` per subtree, on the app's schedule, with the
-migrator (~80–90% mechanical). re-com widgets are the last movers; their `ui`-native answer is now a
-**directed program** — epic `rf2-6ajm6z`, with substrate readiness riding S3 per EP-0035.
+The external story is a **two-step migration**. Step 1 moves a v1 Reagent/re-com
+app's *dataflow* to re-frame2 with views unchanged on the coexisting Reagent
+adapter — gaining Xray, epochs, Story, schemas, and machines immediately. Step 2
+optionally migrates views to `ui` per subtree, on the app's schedule, with the
+migrator (~80–90% mechanical). re-com widgets are the last movers; their
+`ui`-native answer is a directed program of its own, with substrate readiness
+delivered at S3 per EP-0035.
+
+### The design-record retirement
+
+The synthesis dossier this EP family distills is retired in two steps, and the
+first is done: its index is a tombstone pointer map, the blessed API tables
+graduated to their durable home (`spec/API.md` §`re-frame.ui`, carrying the
+delta protocol with them), and the binding per-finding review dispositions are
+retained under the tree's `reviews/` directory as durable evidence. The tree
+itself is removed at S7, once every cited contract has its spec home and no live
+brief dangles. Until then: `drafts/*` survive until their owning stage consumes
+them (spec merges under the atomic-landing rule, or the W1/W3/W7a/W9/W11
+workstreams for the tool/docs/CI-facing drafts); `guide/` moves to `docs/guide`
+at S6 (W3); `skill/` moves to `skills/` at S6 (W6); `spikes/` and `reviews/`
+remain historical evidence referenced from this EP family.
 
 ### Risks
 
-The register is `08-delivery.md` §4; the headline stop conditions: push economics
-falsified late (S-2/G-13 run early; failure reopens the ownership design, no silent
-fork), the sync-input door leaking into general dispatch (keyed to controlled-input
-sites; a fixture pins it), the compiler growing a second Clojure (closed control-form
-grammar; explicit escapes), and HMR identity drift (release/remount on ambiguity —
-correctness over preservation).
+The headline stop conditions: push economics falsified late (the falsification
+benchmark runs early; failure reopens the ownership design, no silent fork), the
+sync-input door leaking into general dispatch (keyed to controlled-input sites;
+a fixture pins it), the compiler growing a second Clojure (closed control-form
+grammar; explicit escapes), and HMR identity drift (release/remount on ambiguity
+— correctness over preservation).
+
+### Guide impact
+
+The program adds `re-frame.ui` coverage across the `docs/core` view surface (W3)
+— views, frames, the introduction counter, forms — keeps the substrate-choice
+teaching (presenting `re-frame.ui` as a new experimental option alongside the
+retained Reagent/UIx/reagent-slim boot choices), and rebuilds the playground.
+Sibling EPs name per-domain impacts.
 
 ## Rationale
 
-**One substrate, first-party** beats both alternatives. Keeping the trio preserves the
-three taxes forever and makes every future capability a four-way negotiation. Blessing
-one existing adapter inherits its runtime model — interpretation cost, render-time
-ownership, foreign HMR semantics — and still leaves re-frame2's frame and evidence
-contracts bolted on from outside. A compiler whose target *is* re-frame2 makes the
-invariants (EP-0031/0032) hold by construction and makes production claims provable by
-absence gates rather than discipline.
+**One substrate, first-party** beats both alternatives. Keeping the trio
+preserves the three taxes forever and makes every future capability a four-way
+negotiation. Blessing one existing adapter inherits its runtime model —
+interpretation cost, render-time ownership, foreign HMR semantics — and still
+leaves re-frame2's frame and evidence contracts bolted on from outside. A
+compiler whose target *is* re-frame2 makes the invariants (EP-0031/0032) hold by
+construction and makes production claims provable by absence gates rather than
+discipline.
 
 **Staged conformance slices** rather than a big-bang: each stage lands with its
-fixtures, its gates in CI, and its spec edits atomic — so the repo is never knowingly
-nonconformant and a fresh reviewer can say exactly what "Stage-N-conforming" asserts.
+fixtures, its gates in CI, and its spec edits atomic — so the repo is never
+knowingly nonconformant and a fresh reviewer can say exactly what
+"Stage-N-conforming" asserts.
 
-**The demand bar** exists because the failure mode of a green-field view layer is
-surface sprawl. Freezing the table before Stage 1 — then admitting change only as
-ruled row-level deltas — keeps the surface honest while staying amendable where real
-consumers (re-com being the first) demonstrate need.
+**The demand bar** exists because the failure mode of a green-field view layer
+is surface sprawl. Freezing the table before Stage 1 — then admitting change
+only as ruled row-level deltas — keeps the surface honest while staying
+amendable where real consumers (re-com being the first) demonstrate need.
 
-**Keep Reagent, UIx, and reagent-slim as first-class adapters, and offer `re-frame.ui`
-alongside them** rather than as their replacement. All three have named consumers: the
-two-step migration for existing v1/re-com apps, a correct boot choice for existing UIx
-apps, and the slim-bundle option. They stay actively supported — `re-frame.ui` is the new
-experimental substrate, not a mandate to leave them. **Only Helix is removed** once `ui`
-ships; the others cover its niche.
+**Keep Reagent, UIx, and reagent-slim as first-class adapters, and offer
+`re-frame.ui` alongside them** rather than as their replacement. All three have
+named consumers: the two-step migration for existing v1/re-com apps, a correct
+boot choice for existing UIx apps, and the slim-bundle option. They stay
+actively supported — `re-frame.ui` is the new experimental substrate, not a
+mandate to leave them. **Only Helix is removed** once `ui` ships; the others
+cover its niche.
 
 ## Backwards Compatibility
 
-Pre-alpha: no compatibility shims. Within this repo, view surfaces gain `re-frame.ui` as
-a new option over S6–S7 (examples, testbeds, tools, template, docs) while the retained
-adapters keep working. For external apps the compatibility surface is deliberate: the
-Reagent, UIx, and reagent-slim adapters stay first-class and actively supported, keeping
-their contract suites and smokes in CI (`reg-view` stays with stock Reagent), and the
-removal wave touches **only Helix**, behind the S7 soak gates. Benchmarks against the
-existing adapters run **once**, before Helix removal; the results, fixtures, and a git
-tag of the removed surface survive. They run once because keeping an adapter first-class
-promises continued *support*, not ongoing performance parity — the baseline is a recorded
-comparison, not a standing gate.
-
-## Bead Plan / Reference Implementation
-
-The program epic is **`rf2-vxgfnd`** (`EPIC: re-frame.ui program (S1–S7)`), with
-per-stage child epics filed at the *prior* stage boundary so every brief cites
-then-current contracts. **S1 and S2 merged** (S1's six children landed 2026-07-12;
-S2 core verified S3-ready under the `rf2-vxgfnd.22` adversarial boundary review);
-**S3 closed 2026-07-18** as epic `rf2-vxgfnd.95`, its children `.95.1`–`.95.10` and
-the directed readiness children (`rf2-8k14ia`, `rf2-ri0k6n`, `rf2-isdqjv`) closed
-with it; and **S4** (`rf2-vxgfnd.96`) closed and was declared conforming. The stages
-after S4 ride their own epics — S5 `rf2-vxgfnd.97`, S6 `rf2-vxgfnd.98`, S7
-`rf2-vxgfnd.99`. This paragraph records stages that have closed; for a stage still in
-flight the epic is the state, not this page. Trigger-gated spikes (`ui/tpl`, registered
-`ui/view`, `ui/portal`, `defview-alias`, reset-key `local`) sit on the program epic,
-not in stage scope, until their named triggers fire. The **re-com native port is a
-separate directed epic, `rf2-6ajm6z`** — deliberately not a program stage, so component
-migration never blocks S3–S7 (and vice versa).
-
-**Source-folder retirement (directed by Mike 2026-07-16, in-session — the fold-into-EPs
-direction; two steps, reconciled with the standing S7 cleanup bead
-`rf2-vxgfnd.99.1`).** Step one, at the **S3→S4 boundary**: a tombstone README replaces
-the dossier index, and a citation sweep repoints live references — bead briefs **and
-this EP family's own into-folder citations** — to this EP family and the specs. Two
-relocations gate that tombstone: (i) the **blessed 12 §2/§2b API tables** — a *living*
-freeze authority with an active delta protocol — graduate to their durable home,
-`spec/API.md` §`re-frame.ui` (the W5 manifest), carrying the delta protocol with them;
-(ii) `09-review-disposition.md` — the binding codex2 per-finding rulings — relocates
-under `reviews/` as retained historical evidence. *(Fired — rf2-mgy7pz merged
-2026-07-18; both relocations landed.)* Step two, at **S7 per
-`rf2-vxgfnd.99.1`**: the tree itself is git-rm'd once every cited contract has its
-spec home and no live brief dangles (that bead's own audit). Until step two the tree
-remains force-tracked in place. Survival rules meanwhile: `drafts/*` survive until
-their owning stage **consumes** them — spec merges under the Q61 atomic-landing rule,
-or the W1/W3/W7a/W9/W11 workstreams for the tool/docs/CI-facing drafts; `prep/*`
-survives until its PREP-ANCHORED beads consume it (`rf2-gria2b`, `rf2-nwgzha`,
-`rf2-3339ri`, `rf2-nojiwy`); `guide/` moves to `docs/guide` at S6 (W3); `skill/` moves
-to `skills/` at S6 (W6); `spikes/` and `reviews/` remain as historical evidence
-referenced from this EP.
-
-**Guide-impact assessment (EP-0009 rule 5):** the program adds `re-frame.ui` coverage
-across the `docs/core` view surface (W3) — views, frames, the introduction counter,
-forms — keeps the substrate-choice teaching (now presenting `re-frame.ui` as a new
-experimental option alongside the retained Reagent/UIx/reagent-slim boot choices), and
-rebuilds the playground. Sibling EPs name per-domain impacts.
+Pre-alpha: no compatibility shims. Within this repo, view surfaces gain
+`re-frame.ui` as a new option over S6–S7 (examples, testbeds, tools, template,
+docs) while the retained adapters keep working. For external apps the
+compatibility surface is deliberate: the Reagent, UIx, and reagent-slim adapters
+stay first-class and actively supported, keeping their contract suites and
+smokes in CI (`reg-view` stays with stock Reagent), and the removal wave touches
+**only Helix**, behind the S7 soak gates. Benchmarks against the existing
+adapters run **once**, before Helix removal; the results, fixtures, and a git
+tag of the removed surface survive. They run once because keeping an adapter
+first-class promises continued *support*, not ongoing performance parity — the
+baseline is a recorded comparison, not a standing gate.
 
 ## Resolved Decisions
 
-- **Program ratification (2026-07-11, Mike).** The 08 §5 decision record — R-1…R-6 plus
-  the presence, adapters, proof-app, budget, and frame-chain rulings — is the ruled
-  decision surface this EP records. Its provenance log is
-  `ai/findings/new-substrate-synthesis/reviews/09-review-disposition.md` (relocated per
-  rf2-mgy7pz; a pointer remains at the old `09-review-disposition.md` path). *(The adapters ruling's
-  original "frozen compatibility adapters" / "reagent-slim removed" shape is superseded on
-  the adapter-disposition point by the 2026-07-17 reframing below; all other rulings
-  stand.)*
-- **API freeze (2026-07-12 00:39 AUSEST, Mike).** The `re-frame.ui` public-surface table
-  (graduated to `spec/API.md` §"re-frame.ui — blessed public-surface freeze") is
-  blessed as-is as the v1 API freeze, governed by the row-level delta protocol; deltas
-  #1–#5 (custom-element, `->react`, `spread`, `slot`/internal `render-fn`,
+- **Program ratification (2026-07-11).** The decision record above — R-1…R-6
+  plus the presence, adapters, proof-app, budget, and frame-chain rulings — is
+  the ruled decision surface this EP records; the per-finding provenance log is
+  retained under the synthesis tree's `reviews/` directory. The adapters ruling
+  is superseded on the adapter-disposition point by the 2026-07-17 reframing
+  below; all other rulings stand.
+- **API freeze (2026-07-12).** The `re-frame.ui` public-surface table
+  (`spec/API.md` §"re-frame.ui — blessed public-surface freeze") is blessed
+  as-is as the v1 API freeze, governed by the row-level delta protocol; deltas
+  #1–#5 (`custom-element`, `->react`, `spread`, `slot` + internal `render-fn`,
   `spread-safe`) are ruled and recorded in the table.
-- **Conditional S3 advance (2026-07-15, Mike; recorded in `rf2-vxgfnd.95` NOTES).** S3
-  starts immediately in parallel with the bounded S2 correction tail, overriding the
-  epic's original entry condition; S2's truth conditions stand — it is not declared
-  conforming until its correction beads and adversarial proof are green, and S3 must
-  not weaken or silently absorb those corrections. Hot-zone files stay single-owner
-  behind the S2 owner. A throughput ruling, not a proof waiver.
-- **Component-library readiness (2026-07-16, Mike, directed).** re-com is the first and
-  most important consumer test; the substrate gets ready now. S3 carries the P0 triad
-  (atomic `local` updater, the `ui/event` vector-outcome sync-door arm, internal render
-  slots) plus the safe-spread policy, native-library layout/ref blessing, and the
-  docs/slot manifest projection — full contract in **EP-0035**; the port itself is epic
-  `rf2-6ajm6z`.
-- **Adapter disposition reframed (2026-07-17, Mike).** `re-frame.ui` is a **new,
-  experimental view substrate offered as an additional option** — not a mandated
-  replacement of the adapter trio and not the only taught view layer. Stock **Reagent,
-  UIx, and reagent-slim live on as first-class, actively-supported adapters** (not frozen,
-  not scheduled for removal); **only Helix is removed** at S7, behind the soak gates. This
-  supersedes the adapter-disposition point of the 2026-07-11 ratification (the "frozen
-  compatibility adapters" and "reagent-slim removed" shape). The technical interop-boundary
-  contract for legacy Reagent embedded in a `ui` host is **unchanged** — the coexistence
-  mechanism (shared React context object, `frame-provider`, HMR-inward, sibling/inward/
-  outward granularities) stays valid because Reagent still coexists with `re-frame.ui`;
-  only the "frozen tier" *labeling* is retired in favour of "compatibility/interop tier."
-- **Template variant menu ruled a supported surface (2026-07-19, delegated; recorded in
-  `rf2-deiym` NOTES).** The template's post-Helix variant menu is a **supported
-  external-alpha surface**, not superseded by `re-frame.ui`: `:reagent` (default) and
-  `:uix` stay supported variants, W8 adds the experimental `re-frame.ui` scaffold beside
-  them (labelled experimental), `:helix` is removed behind the S7 soak gates, and
-  reagent-slim remains a reserved future variant on its existing trigger — consistent
-  with the 2026-07-17 adapter disposition above. The parked rf2-deiym G1–G4
-  external-alpha gate ruling is restated on its surviving basis (no emitted
-  `day8/re-frame2*` coordinate resolves remotely yet), retiring its superseded
-  W8-collapse premise; the deferred gate contract itself stands. Whether the menu ever
-  narrows later is expressly reserved as a future product decision on its own evidence.
+- **Conditional S3 advance (2026-07-15).** S3 started in parallel with the
+  bounded S2 correction tail, overriding the program's original entry
+  condition; S2's truth conditions stood unchanged, and S3 was not permitted to
+  weaken or silently absorb the corrections. A throughput ruling, not a proof
+  waiver.
+- **Component-library readiness (2026-07-16, directed).** re-com is the first
+  and most important consumer test; the substrate got ready ahead of the port.
+  S3 carried the P0 triad (atomic `local` updater, the `ui/event`
+  vector-outcome sync-door arm, internal render slots) plus the safe-spread
+  policy, native-library layout/ref blessing, and the docs/slot manifest
+  projection — full contract in **EP-0035**.
+- **Adapter disposition reframed (2026-07-17).** `re-frame.ui` is a **new,
+  experimental view substrate offered as an additional option** — not a
+  mandated replacement of the adapter trio and not the only taught view layer.
+  Stock **Reagent, UIx, and reagent-slim live on as first-class,
+  actively-supported adapters** (not frozen, not scheduled for removal); **only
+  Helix is removed** at S7, behind the soak gates. This supersedes the
+  ratification's original "frozen compatibility adapters" / "reagent-slim
+  removed" shape. The technical interop-boundary contract for legacy Reagent
+  embedded in a `ui` host is unchanged — the coexistence mechanism (shared
+  React context object, `frame-provider`, HMR-inward, sibling/inward/outward
+  granularities) stays valid because Reagent still coexists with `re-frame.ui`;
+  only the "frozen tier" labeling is retired in favour of
+  "compatibility/interop tier".
+- **Template variant menu ruled a supported surface (2026-07-19, delegated).**
+  The template's post-Helix variant menu is a supported external-alpha surface,
+  not superseded by `re-frame.ui`: `:reagent` (default) and `:uix` stay
+  supported variants, W8 adds the experimental `re-frame.ui` scaffold beside
+  them (labelled experimental), `:helix` is removed behind the S7 soak gates,
+  and reagent-slim remains a reserved future variant on its existing trigger —
+  consistent with the 2026-07-17 adapter disposition above. The deferred
+  external-alpha gate contract stands on its surviving basis (no emitted
+  `day8/re-frame2*` coordinate resolves remotely yet). Whether the menu ever
+  narrows later is expressly reserved as a future product decision on its own
+  evidence.
 
-## Recommendation
+## Open Issues
 
-Keep EP-0030 `accepted` while the stages land; it moves to `final` when S7 completes —
-every gate green, the demand-bar prune done, **Helix removed** behind the soak gates, and
-the retained adapters' continued-support posture recorded in their spec homes. The
-program's shape is already proving itself: S1–S3 merged under adversarial boundary
-reviews, S4 closed and declared conforming, and the first external consumer (re-com)
-driving real contract work through the API freeze's own delta protocol rather than
-around it.
+Graduation only: this EP stays `accepted` while the stages land and moves to
+`final` when S7 completes — every gate green, the demand-bar prune done, Helix
+removed behind the soak gates, and the retained adapters' continued-support
+posture recorded in their spec homes.
+
+## References
+
+- **Sibling EPs (authored with this one; each a narrow decision surface):**
+  [EP-0031](EP-0031-re-frame-ui-programming-model.md) — programming model
+  (`defview`, templates, the handler law, presence, interop);
+  [EP-0032](EP-0032-re-frame-ui-reactivity-and-ownership.md) — reactivity and
+  ownership (observation targets, ViewCell, commit protocol, frames/preflight
+  ENSURE, HMR); [EP-0033](EP-0033-re-frame-ui-view-evidence.md) — view evidence
+  and debugging; [EP-0034](EP-0034-re-frame-ui-production-ssr-testing.md) —
+  production, SSR, and testing posture;
+  [EP-0035](EP-0035-component-library-readiness.md) — component-library
+  readiness (the directed S3 amendments and the re-com consumer).
+- **[EP-0014](EP-0014-derivation-and-process-algebra.md)** names the
+  derivation/process algebra; the substrate reads through that one reactive
+  grammar and adds no second one.
+- **[EP-0029](EP-0029-xstate-v6-machine-parity.md)** is the format precedent for
+  this EP family and keeps machines ordinary projections the view layer merely
+  reads.
+- **[EP-0002](EP-0002-frame-target-resolution.md) /
+  [EP-0024](EP-0024-unified-frame-identity-and-lifecycle.md)** own explicit
+  frame resolution and unified frame identity — the substrate's carried-frame
+  law and preflight ENSURE build directly on them.
+- **Specs:** the Spec 004 family ([`spec/004-Views.md`](../../spec/004-Views.md),
+  [`spec/004B-UI-Tree-and-Conversion.md`](../../spec/004B-UI-Tree-and-Conversion.md),
+  [`spec/004C-Roots-and-Mount.md`](../../spec/004C-Roots-and-Mount.md),
+  [`spec/004D-UI-Test-Selectors.md`](../../spec/004D-UI-Test-Selectors.md)),
+  [`spec/006-ReactiveSubstrate.md`](../../spec/006-ReactiveSubstrate.md)
+  (observation port; adapter contract),
+  [`spec/008-Testing.md`](../../spec/008-Testing.md) (the `ui.test` contract
+  home), [`spec/009-Instrumentation.md`](../../spec/009-Instrumentation.md)
+  (evidence and catalogue rows), [`spec/011-SSR.md`](../../spec/011-SSR.md)
+  (SSR roots and hydration), and [`spec/API.md`](../../spec/API.md) (the blessed
+  public-surface freeze); conformance profiles under `spec/conformance/`.
+- **Design provenance:** the synthesis dossier at
+  `ai/findings/new-substrate-synthesis/` (tombstoned; see §The design-record
+  retirement), with `reviews/` and `spikes/` retained as durable evidence.

--- a/docs/EP/EP-0031-re-frame-ui-programming-model.md
+++ b/docs/EP/EP-0031-re-frame-ui-programming-model.md
@@ -2,35 +2,30 @@
 
 Status: final
 Type: standards-track
-
-> **Graduation banner.** Graduated to `final` — recorded 2026-07-19
-> (rf2-hgwpq). [`spec/004-Views.md`](../../spec/004-Views.md) (with companions
-> [004B](../../spec/004B-UI-Tree-and-Conversion.md),
-> [004C](../../spec/004C-Roots-and-Mount.md),
-> [004D](../../spec/004D-UI-Test-Selectors.md)) is the normative home, and per
-> EP-0009 **where this EP and the spec differ, the spec governs**. Stage
-> honesty as of the flip: **S1–S4 are asserted** — S1/S2 by their landed
-> conformance slices, S3 by `spec/conformance/S3-view-conformance-profile.md`
-> (#6182), S4 by `spec/conformance/S4-view-conformance-profile.md` §8. The
-> stages still ahead ride their own epics — the `client-only` phase flip (S5,
-> `rf2-vxgfnd.97`), `->react` (S6, `rf2-vxgfnd.98`), 004A landing + Helix
-> removal (S7, `rf2-vxgfnd.99`). This EP is the durable design record behind
-> that contract: what was decided, why, what was rejected; the per-item stage
-> markers below are the historical staging record (their cited beads have
-> closed).
+Created: 2026-07-16
+Resolution: final 2026-07-19
 
 ## Abstract
 
-`re-frame.ui` introduces, for the new compiled substrate, one authoring contract:
-**`defview` is the one component form** (one props map, memoized by default on a
-generated `rf=` comparator); **templates are hiccup with the ambiguities removed**,
-compiled — never interpreted — under a closed macro grammar in expression positions;
-**event handlers are data** (event vectors with a closed placeholder vocabulary,
-plus a small explicit-form decision table for what genuinely is not data);
-view-side state and lifecycle are exactly four body forms (`local`, `effect`,
-`lease`, `frame`); every escape to the host world is a **named interop boundary**
-with a stated cost. Everything else — Form-1/2/3, `reg-view`, positional args,
-ratoms, `:on-mount` — is a normative absence.
+`re-frame.ui` introduces, for the new compiled substrate, one authoring
+contract: **`defview` is the one component form** (one props map, memoized by
+default on a generated `rf=` comparator); **templates are hiccup with the
+ambiguities removed**, compiled — never interpreted — under a closed macro
+grammar in expression positions; **event handlers are data** (event vectors with
+a closed placeholder vocabulary, plus a small explicit-form decision table for
+what genuinely is not data); view-side state and lifecycle are exactly four body
+forms (`local`, `effect`, `lease`, `frame`); every escape to the host world is a
+**named interop boundary** with a stated cost. Everything else — Form-1/2/3,
+`reg-view`, positional args, ratoms, `:on-mount` — is a normative absence.
+
+The normative home is [`spec/004-Views.md`](../../spec/004-Views.md), with
+companions [004B](../../spec/004B-UI-Tree-and-Conversion.md),
+[004C](../../spec/004C-Roots-and-Mount.md), and
+[004D](../../spec/004D-UI-Test-Selectors.md); per EP-0009, where this EP and the
+spec differ, **the spec governs**. This EP is the durable design record behind
+that contract: what was decided, why, and what was rejected. `final` means what
+EP-0009 says — the decisions are settled and the spec is authoritative; it does
+not assert the build is gap-free.
 
 ## Motivation
 
@@ -39,308 +34,270 @@ honestly: three component forms with different closure semantics; handlers as
 anonymous closures that capture stale renders and defeat memoization; hiccup
 interpreted at runtime by a walker that guesses at tags, components, and seqs;
 ratoms silently creating a second reactivity model. Each is an unresolved
-alternative the synthesis had to close — which components exist, what a handler
+alternative this design had to close — which components exist, what a handler
 *is*, what the compiler may see through, where ephemeral state may live, how the
-foreign-React world is admitted. Those are feature-level public-contract decisions
-with real rejected alternatives: an EP, not a bead. The full design study graduated into
-this EP and the normative `spec/004-Views.md`; the original working study
-(`02-programming-model.md`, final 2026-07-11, codex2 fold-in 2026-07-12, component-library
-amendments 2026-07-16) is tombstoned in the synthesis tree (rf2-mgy7pz). This EP records
-its decision surface durably.
-
-## Goals / Non-Goals
-
-Goals — the **authoring contract** of the compiled substrate:
-
-- the one component form and its props/memo/registration semantics;
-- the template grammar, including the closed macro grammar in expression positions;
-- handlers-as-data: the vector form, placeholders, the decision table, the
-  controlled-input synchrony door and its 2026-07-16 widening;
-- the four body forms (`local` / `effect` / `lease` / `frame`) and the `local`
-  placement law;
-- the interop boundary rows and their staging.
-
-Non-goals (owned elsewhere; one EP, one decision surface): reactivity, ownership,
-and the observation port (**EP-0032**); evidence, manifests, and instrumentation
-(**EP-0033**); the readiness deltas' own design records (**EP-0035** — summarized
-here only where they amend this surface); SSR/roots/hydration mechanics beyond the
-authoring seam (Specs 004C/011); Reagent migration mechanics (the S6/S7 migration wave —
-the W1 migrator + the `spec/004A` Reagent-compat appendix).
-
-## Relationships
-
-- **EP-0030** — the program umbrella for the compiled-substrate rewrite; this EP is
-  its programming-model pillar.
-- **EP-0032 (reactivity)** owns `sub`'s semantics; this EP owns only the call-site
-  grammar (`(sub [:query …])` as a compile-indexed site).
-- **EP-0033 (evidence)** owns the compiler manifest and committed instance records;
-  this EP's grammars are what make those surfaces statically derivable.
-- **EP-0035 (readiness deltas)** owns the component-library readiness package
-  (`drafts/component-library-readiness.md`); its amendments to this surface are
-  folded in below with stage-honesty markers.
-- **EP-0018 (one event registration)** supplies the registered-event world
-  handlers-as-data dispatches into (the dev unregistered-id warning is the seam);
-  **EP-0025 (classification)** governs the posture `:props` schemas and production
-  elision respect.
-- Normative homes: `spec/004-Views.md` + 004B (tree/conversion), 004C (roots/mount),
-  004D (test selectors).
+foreign-React world is admitted. Those are feature-level public-contract
+decisions with real rejected alternatives: an EP, not a bead.
 
 ## Specification
 
-Stage-honesty legend, used per item: **[spec-live]** = asserted by the landed S1/S2
-conformance slices; **[accepted → S3+]** = ruled and in spec text as declared rows,
-enforcement landing with the cited bead.
+**Scope.** This EP owns the authoring contract of the compiled substrate: the
+one component form and its props/memo/registration semantics; the template
+grammar, including the closed macro grammar in expression positions;
+handlers-as-data (the vector form, placeholders, the decision table, and the
+controlled-input synchrony door); the four body forms and the `local` placement
+law; and the interop boundary rows. It does not own reactivity, ownership, or
+the observation port (EP-0032); evidence, manifests, and instrumentation
+(EP-0033); the component-library readiness deltas' own design records (EP-0035 —
+summarized here only where they amend this surface); SSR/roots/hydration
+mechanics beyond the authoring seam (Specs 004C/011); or Reagent migration
+mechanics (the S6/S7 migration wave — the migrator plus the `spec/004A`
+Reagent-compat appendix).
 
-### 1. `defview` — the one component form [spec-live, S1]
+### 1. `defview` — the one component form
 
-- **Zero or one argument, semantically a props map.** Header destructuring lowers to
-  direct property reads on the host props object; `:as` opts into materialization at
-  a documented dev cost. **No positional args.**
-- **Props ABI:** deterministic quoted JS property names preserving namespace + name;
-  `:key` is reserved (a literal `:key` prop is a compile error); `:children` compares
-  as one slot; the manifest maps production slot indexes back to keywords.
-- **Closed options map:** `:props` (Malli — compile-time on literal call sites, dev
-  runtime on dynamic values, elided in production), `:id`, `:display-name`. Nothing
-  else — `:memo false`, `:on-mount`/`:on-unmount`, and `:catch`/`:fallback` were
-  considered and rejected (Resolved Decisions).
-- **Registration:** `defview` defs a Var and registers under the registrar's `:view`
-  kind (source metadata, template fingerprint, hook signature, capability bits) —
-  Story mounts by view id, Xray lists by registry query, the Pair hot-swaps a view
-  like an event handler.
-- **Memo-by-default, no opt-out:** every internal view is memoized on a generated
-  straight-line `rf=` comparator over its declared prop slots — per slot,
-  `Object.is` OR CLJS value equality; host/foreign values fall through to identity.
-  Teach as "React.memo, except CLJS data compares by value".
+- **Zero or one argument, semantically a props map.** Header destructuring
+  lowers to direct property reads on the host props object; `:as` opts into
+  materialization at a documented dev cost. **No positional args.**
+- **Props ABI:** deterministic quoted JS property names preserving namespace +
+  name; `:key` is reserved (a literal `:key` prop is a compile error);
+  `:children` compares as one slot; the manifest maps production slot indexes
+  back to keywords.
+- **Closed options map:** `:props` (Malli — compile-time on literal call sites,
+  dev runtime on dynamic values, elided in production), `:id`, `:display-name`.
+  Nothing else — `:memo false`, `:on-mount`/`:on-unmount`, and
+  `:catch`/`:fallback` were considered and rejected (Resolved Decisions).
+- **Registration:** `defview` defs a Var and registers under the registrar's
+  `:view` kind (source metadata, template fingerprint, hook signature,
+  capability bits) — Story mounts by view id, Xray lists by registry query, the
+  Pair hot-swaps a view like an event handler.
+- **Memo-by-default, no opt-out:** every internal view is memoized on a
+  generated straight-line `rf=` comparator over its declared prop slots — per
+  slot, `Object.is` OR CLJS value equality; host/foreign values fall through to
+  identity. Teach as "React.memo, except CLJS data compares by value".
 
-### 2. The template grammar [forms spec-live S1; expression grammar spec-live S2]
+### 2. The template grammar
 
-Reagent-familiar hiccup with the ambiguities removed. Control forms (`let`/`letfn`/
-`if`/`if-not`/`when`/`when-not`/`cond`/`case`/statically-pure `do`/`for`) normalize
-**into the AST**; both emitters (direct React code; the JVM structural tree owned by
-004B) see through branches. Rejected at compile time with didactic messages: dynamic
-tag heads, markup-returning `map`, keywords in child position, raw lazy seqs,
-unkeyed list items, `sub`/`lease` in loops.
+Reagent-familiar hiccup with the ambiguities removed. Control forms (`let`/
+`letfn`/`if`/`if-not`/`when`/`when-not`/`cond`/`case`/statically-pure `do`/
+`for`) normalize **into the AST**; both emitters (direct React code; the JVM
+structural tree owned by 004B) see through branches. Rejected at compile time
+with didactic messages: dynamic tag heads, markup-returning `map`, keywords in
+child position, raw lazy seqs, unkeyed list items, `sub`/`lease` in loops.
 
-**Expression positions carry a closed macro grammar** (rf2-vxgfnd.100 lineage — the site-identity bead the spec cites — with the grammar
-reconciled by rf2-vxgfnd.112/.224; owning text Spec 004 §Template grammar): expressions are value-opaque with respect to markup but
+**Expression positions carry a closed macro grammar** (owning text: Spec 004
+§Template grammar): expressions are value-opaque with respect to markup but
 lexically audited for finite reactive ownership. Accepted: the binder-aware
 structural tier (`quote`, `fn`, `let`, `loop`, `letfn`, `try`), the audited
-transparent core macro set (`or` `and` `when` `when-not` `cond` `->` `->>` `some->`
-`some->>` `cond->` `cond->>`), and ordinary function calls plus evaluated-only host
-specials. **Every other macro — core or user — is rejected**
-(`:rf.ui.compile/unsupported-form`): an unaudited expansion could hide a reactive
-call from site indexing, falsify the manifest, and let production elide a ViewCell
-that was not actually sub-free. The set grows only by ruling.
+transparent core macro set (`or` `and` `when` `when-not` `cond` `->` `->>`
+`some->` `some->>` `cond->` `cond->>`), and ordinary function calls plus
+evaluated-only host specials. **Every other macro — core or user — is rejected**
+(`:rf.ui.compile/unsupported-form`): an unaudited expansion could hide a
+reactive call from site indexing, falsify the manifest, and let production elide
+a ViewCell that was not actually sub-free. The set grows only by ruling.
 
-DOM prop spelling is pinned (`:on-click`, never `:on-keydown`); prop conversion is
-compile-time, contextual, and total — one rule table (004B) serves static props,
-`ui/spread`, and both emitters; custom elements get the bounded `ui/custom-element`
-classification rule (name exported S1, behaviour asserts S4 — delta #1, 2026-07-12).
+DOM prop spelling is pinned (`:on-click`, never `:on-keydown`); prop conversion
+is compile-time, contextual, and total — one rule table (004B) serves static
+props, `ui/spread`, and both emitters; custom elements get the bounded
+`ui/custom-element` classification rule (API-freeze delta #1).
 
-### 3. Handlers are data [vectors-as-data spec-live S1; committed behaviour → S3]
+### 3. Handlers are data
 
 **Canonical: the event vector.** A vector in an `:on-*` position is the intent,
 dispatched to the committed frame. The **placeholder vocabulary is closed (v1,
-scalars only): `:rf.ui/value`, `:rf.ui/checked`, `:rf.ui/key`** — `:rf.ui/form-data`
-and `:rf.ui/event` deliberately do not exist (both cases belong to `ui/event`).
-Literal vectors are data: value-comparable, JVM-testable, retained as data in the
-manifest and JVM tree.
+scalars only): `:rf.ui/value`, `:rf.ui/checked`, `:rf.ui/key`** —
+`:rf.ui/form-data` and `:rf.ui/event` deliberately do not exist (both cases
+belong to `ui/event`). Literal vectors are data: value-comparable, JVM-testable,
+retained as data in the manifest and JVM tree.
 
-**The decision table** (full table: Spec 004 §Handlers) covers the rest: `ui/event`
-(committed phase + the live event; `nil` ⇒ no dispatch), `ui/handler` (imperative,
-stable identity), `ui/render-fn` (render phase, pure — and, per the 2026-07-16
-amendment, also the value an internal `ui/slot` accepts), the **narrow bare-fn law
-(R-4)** — bare `#(…)` legal only in known native event properties, with a day-one
-strict lint (`{:re-frame.ui/bare-handlers :warn|:error}`) instead of a language
-flip (as of 2026-07-19 the lint key is reserved in `spec/Conventions.md` but not
-yet implemented in the compiler) — a compile error at foreign-component
-boundaries, and `ui/raw-fn` for
-identity-as-protocol APIs and callback refs. Dynamic handler expressions classify at
-runtime by type; placeholders are recognized in literal vectors only (dev warns on a
-placeholder riding a runtime vector); loop handlers that capture the binding are
-compile errors with the extract-a-keyed-child-view fix.
+**The decision table** (full table: Spec 004 §Handlers) covers the rest:
+`ui/event` (committed phase + the live event; `nil` ⇒ no dispatch), `ui/handler`
+(imperative, stable identity), `ui/render-fn` (render phase, pure — and also the
+value an internal `ui/slot` accepts), the **narrow bare-fn law (R-4)** — bare
+`#(…)` legal only in known native event properties, with a day-one strict lint
+(`{:re-frame.ui/bare-handlers :warn|:error}`) instead of a language flip (the
+lint key is reserved in `spec/Conventions.md`; compiler enforcement is a known
+build gap — see Open Issues) — a compile error at foreign-component boundaries,
+and `ui/raw-fn` for identity-as-protocol APIs and callback refs. Dynamic handler
+expressions classify at runtime by type; placeholders are recognized in literal
+vectors only (dev warns on a placeholder riding a runtime vector); loop handlers
+that capture the binding are compile errors with the extract-a-keyed-child-view
+fix.
 
 **The controlled-input synchrony door.** Dispatches from
 `:on-input`/`:on-change`/`:on-before-input` on **compiler-proven controlled**
-elements (the S-5 predicate: literal `:value`/`:checked` co-present with the handler
-site) drain synchronously within the DOM event — the one sanctioned synchronous
-door, protecting caret and IME. **[Amended 2026-07-16, accepted → S3, bead
-rf2-8k14ia]:** the door widens by one arm — at a proven-controlled site, a
-synchronous `ui/event` body whose result is an event vector rides the same drain
-(`nil` = no dispatch; any other synchronous result is a diagnostic). This is the
-reusable-input arm: a library control appends its payload to an event prefix
-received through props. Everything else at such sites still batches with a
-diagnostic; a compiled event-template projection form stays rejected (a second
-handler language). The G-8 real-browser matrix (now including a reusable
-event-prefix component arm) is the residual named gate.
+elements (the S-5 predicate: literal `:value`/`:checked` co-present with the
+handler site) drain synchronously within the DOM event — the one sanctioned
+synchronous door, protecting caret and IME. Two handler forms ride it at a
+proven-controlled site: a literal event vector, and a synchronous `ui/event`
+body whose result is an event vector (`nil` means no dispatch; any other
+synchronous result is a diagnostic). The second is the reusable-input arm: a
+library control appends its payload to an event prefix received through props
+and keeps the IME/caret guarantee. Everything else at such sites batches with a
+diagnostic, and a compiled event-template projection form stays rejected (a
+second handler language). The real-browser matrix that certifies the door —
+including a reusable event-prefix component arm — is gate G-8 (EP-0034).
 
-**Internal fn props + the library event convention [ruled 2026-07-16]:** ordinary
-function props between internal views are legal opaque values, identity-compared,
-with no implicit invocation phase; component libraries accept event
-vectors/prefixes and dispatch `(conj prefix payload…)`.
+**Internal fn props + the library event convention:** ordinary function props
+between internal views are legal opaque values, identity-compared, with no
+implicit invocation phase; component libraries accept event vectors/prefixes and
+dispatch `(conj prefix payload…)`.
 
 ### 4. Body forms — `local`, `effect`, `lease`, `frame`
 
-- **`local` [accepted → S3, bead rf2-vxgfnd.95.2]:** host component-local state,
-  deliberately outside re-frame2 epochs — no frame-resident variant exists or is
-  reserved. **[Amended 2026-07-16]** `(local init)` returns a **three-tuple
-  `[value set! update!]`**: `set!` stores its argument exactly (a stored fn is a
-  value, never an updater); `update!` applies `(f current & args)` to the **latest
-  host state**, so several same-turn host writers compose instead of losing updates.
-  Render-phase use stays a dev error; JVM raises the typed host-op error.
-  Reset-key/derived local stays out (trigger-gated spike, EP-0035).
-  **The placement law (F8, ruled 2026-07-12) is spec-live in 004:** a `local` value
-  MAY be read by same-view committed handlers — committed slots include local
-  ephemera (the guide's search-box seam is canonical); `local` is FORBIDDEN when the
-  value needs cross-view observation, replay/persistence, schema/tool inspection,
-  durable navigation semantics, or subscription-derived computation.
-- **`effect` [accepted → S3, same bead]:** `rf=` value deps, cleanup on dep
-  change/disconnect/unmount, StrictMode-replay-safe; `(effect :connect …)` is named
-  for what it does — **there is no "once"** in a lifecycle React can replay.
-- **`lease` [spec-live S2; view-level confirmation → S3]:** declares resource
-  liveness, reconciled by one aggregated passive effect after commit; reads stay
-  `(sub [:rf/resource …])`; never fetches during render.
-- **`frame` [spec-live S2]:** the committed-frame ops bundle
+- **`local`:** host component-local state, deliberately outside re-frame2
+  epochs — no frame-resident variant exists or is reserved. `(local init)`
+  returns a **three-tuple `[value set! update!]`**: `set!` stores its argument
+  exactly (a stored fn is a value, never an updater); `update!` applies
+  `(f current & args)` to the **latest host state**, so several same-turn host
+  writers compose instead of losing updates. Render-phase use is a dev error;
+  the JVM raises the typed host-op error. Reset-key/derived local stays out
+  (a trigger-gated spike, EP-0035). **The placement law (F8) is spec-live in
+  004:** a `local` value MAY be read by same-view committed handlers —
+  committed slots include local ephemera (the guide's search-box seam is
+  canonical); `local` is FORBIDDEN when the value needs cross-view observation,
+  replay/persistence, schema/tool inspection, durable navigation semantics, or
+  subscription-derived computation.
+- **`effect`:** `rf=` value deps, cleanup on dep change/disconnect/unmount,
+  StrictMode-replay-safe; `(effect :connect …)` is named for what it does —
+  **there is no "once"** in a lifecycle React can replay.
+- **`lease`:** declares resource liveness, reconciled by one aggregated passive
+  effect after commit; reads stay `(sub [:rf/resource …])`; never fetches
+  during render.
+- **`frame`:** the committed-frame ops bundle
   (`{:frame :dispatch :dispatch-sync :subscribe}`), incarnation-fenced, tiered
   advanced alongside `dispatch-fn`.
 
 ### 5. Interop boundary rows
 
-| Row | Ruling | Stage honesty |
+| Row | Ruling | Stage |
 |---|---|---|
-| `ui/raw` | embed a React element; SSR needs a `client-only` sibling | spec-live S1 (boundary corpus completes S4) |
-| `ui/html` | trusted markup, low-friction — the visible call *is* the contract; manifests record the site | spec-live S1 |
-| `ui/spread` | the one generic runtime prop-map conversion, driven by the 004B rule table | spec-live S1 |
-| `ui/spread-safe` | the literal safe-policy **sibling** of `ui/spread` (a distinct name, not a second `spread` arity) — compiler-visible allow/deny: denied structural/controlled/identity keys (`:key` `:ref` `:value` `:checked` owned `:on-*`) fail in **every build**; allowed `:on-*` classify through the decision table; `aria-*`/`data-*` pass; preserves the controlled proof under passthrough | **accepted → S3, bead rf2-isdqjv** (delta #5, 2026-07-16; spelling resolved at spec landing to `ui/spread-safe`) |
-| `ui/slot` | compiler-owned invocation of `ui/render-fn` values at **internal** render seams (row/cell/part renderers): only `render-fn` or `nil`; body compiled under the closed grammar, pure render phase; keys/fingerprints/`ui.test` structure preserved | **accepted → S3→S4, bead rf2-ri0k6n** (delta #4, 2026-07-16) |
-| `ui/client-only` | mandatory capability-free fallback; one root phase-flip | accepted → S3 (flip completes S5) |
-| `ui/error-boundary` | the explicit error component — catches render/lifecycle throws; `:on-error` dispatches after the failing commit; `:reset-key` clears | accepted → S3 |
-| `ui/->react` | the outward migration bridge (export a view as a React component) | v1, **lands S6** (delta #2, ruled 2026-07-12) |
-| `ui/element` / `ui/view` / `ui/portal` / `re-frame.ui.data` | wave-2, demand-gated — no v1 existence. Subsequent rulings (2026-07-16, EP-0035): general `ui/element` **rejected outright** (`rf2-a62fje`); `ui/view` stays gated on an open-set-identity trigger; `ui/portal` superseded-in-part by the inline+top-layer plan (`rf2-efxb1h`) | — |
+| `ui/raw` | embed a React element; SSR needs a `client-only` sibling | shipped (S1) |
+| `ui/html` | trusted markup, low-friction — the visible call *is* the contract; manifests record the site | shipped (S1) |
+| `ui/spread` | the one generic runtime prop-map conversion, driven by the 004B rule table | shipped (S1) |
+| `ui/spread-safe` | the literal safe-policy **sibling** of `ui/spread` (a distinct name, not a second `spread` arity) — compiler-visible allow/deny: denied structural/controlled/identity keys (`:key` `:ref` `:value` `:checked` owned `:on-*`) fail in **every build**; allowed `:on-*` classify through the decision table; `aria-*`/`data-*` pass; preserves the controlled proof under passthrough | shipped (S3; API-freeze delta #5) |
+| `ui/slot` | compiler-owned invocation of `ui/render-fn` values at **internal** render seams (row/cell/part renderers): only `render-fn` or `nil`; body compiled under the closed grammar, pure render phase; keys/fingerprints/`ui.test` structure preserved | shipped (S3–S4; delta #4) |
+| `ui/client-only` | mandatory capability-free fallback; one root phase-flip | shipped (S3); the phase flip completes S5 |
+| `ui/error-boundary` | the explicit error component — catches render/lifecycle throws; `:on-error` dispatches after the failing commit; `:reset-key` clears | shipped (S3) |
+| `ui/->react` | the outward migration bridge (export a view as a React component) | v1; lands S6 (delta #2) |
+| `ui/element` / `ui/view` / `ui/portal` / `re-frame.ui.data` | wave-2, demand-gated — no v1 existence. General `ui/element` is rejected outright; `ui/view` stays gated on an open-set-identity trigger; `ui/portal` is superseded-in-part by the inline + top-layer overlay plan (EP-0035 records the rulings) | — |
 
-The foreign-React hook tier (`re-frame.ui.react`, seven wrappers) belongs to this
-surface; its contract detail is Spec 004 §The React interop tier (declared, asserts
-S3).
+The foreign-React hook tier (`re-frame.ui.react`, seven wrappers) belongs to
+this surface; its contract detail is Spec 004 §The React interop tier.
 
-### 6. Removed forms — normative absences [spec-live S1]
+### 6. Removed forms — normative absences
 
-Form-1/2/3 and the `reg-view` family (not `re-frame.ui` forms — they belong to the
-coexisting Reagent compatibility tier, live home `spec/004A-Reagent-Compat.md` at S7);
-positional view args; plain render fns as
+Form-1/2/3 and the `reg-view` family (not `re-frame.ui` forms — they belong to
+the coexisting Reagent compatibility tier, live home
+`spec/004A-Reagent-Compat.md` at S7); positional view args; plain render fns as
 frame-aware views; ratoms/cursors/reactions (a second state model);
 `:on-mount`/`:on-unmount`; Suspense-as-loading; the `h` macro and bare-keyword
 view heads. Absences are compile errors + export checks from the first slice.
 
+### Guide impact
+
+The teaching seams are guide 03 (state) and guide 04 (events), and both are
+written to this contract: 03 teaches the four-inputs table, the `local`
+three-tuple, and the search-box seam; 04 teaches vectors-first, the three
+placeholders, the decision table, the synchrony door ("keep controlled fields
+literal"), the component-library event-prefix convention (EP-0035, C-13b), and
+"lifecycle is not an event". Newly teachable payoffs: headless handler
+assertions, Xray-before-any-click, and library controls that keep the IME/caret
+guarantee.
+
 ## Rationale
 
-**Data over closures.** An event vector is readable in source, inspectable in Xray
-before any click, assertable on the JVM without a DOM, and comparable — so memo
-keeps working. Closures are none of these; they are admitted only where the thing
-expressed genuinely is not data, and each admission names its invoker, phase,
-identity, and cost (the decision table).
+**Data over closures.** An event vector is readable in source, inspectable in
+Xray before any click, assertable on the JVM without a DOM, and comparable — so
+memo keeps working. Closures are none of these; they are admitted only where the
+thing expressed genuinely is not data, and each admission names its invoker,
+phase, identity, and cost (the decision table).
 
 **Closed grammars are what make the compiler honest.** Site indexing (every
-`sub`/`lease` a compile-indexed site; sub-free views eliding their ViewCell) is only
-sound if the compiler can see every reactive call; one unaudited macro breaks it.
-The same logic closes the options map, the placeholder vocabulary, and the AST node
-set: each closure converts "anything might happen" into a surface tools and the JVM
-emitter can rely on, and each grows only by ruling.
+`sub`/`lease` a compile-indexed site; sub-free views eliding their ViewCell) is
+only sound if the compiler can see every reactive call; one unaudited macro
+breaks it. The same logic closes the options map, the placeholder vocabulary,
+and the AST node set: each closure converts "anything might happen" into a
+surface tools and the JVM emitter can rely on, and each grows only by ruling.
 
 **One component form, memo with no opt-out.** A `:memo false` valve or a
 "simple vs stateful" form split reintroduces exactly the taxonomy Reagent users
-misuse; mutable foreign values belong at an explicit boundary, not a memo exemption.
+misuse; mutable foreign values belong at an explicit boundary, not a memo
+exemption.
 
-**The door is narrow on purpose.** The substrate sanctions exactly one synchronous
-drain, where a proof exists (the S-5 predicate) and correctness (caret/IME) demands
-it. The 2026-07-16 widening extends the *handler form*, never the proof — the site
-stays statically proven controlled — because otherwise precisely the reusable
-inputs the guarantee exists for would forfeit it.
+**The door is narrow on purpose.** The substrate sanctions exactly one
+synchronous drain, where a proof exists (the S-5 predicate) and correctness
+(caret/IME) demands it. The vector-outcome widening extends the *handler form*,
+never the proof — the site stays statically proven controlled — because
+otherwise precisely the reusable inputs the guarantee exists for would forfeit
+it.
 
 ## Backwards Compatibility
 
-Pre-alpha: clean breaks, no shims. The Reagent, UIx, and reagent-slim adapters live on
-as first-class shipping surfaces under Spec 004's [TRANSITION] markers; the Reagent-tier
-forms are retained (not deleted), with their live home `spec/004A-Reagent-Compat.md`
-landing at S7. Only Helix is removed, at the S7 removal wave. Migration rides
-`ui/->react` per-subtree co-mounting (S6; mechanics land with the S6 migration wave —
-the W1 migrator + the `spec/004A` Reagent-compat appendix).
-
-## Bead Plan / Reference Implementation
-
-**Graduated.** S1 and S2 landed complete (the Spec 004 rewrite merged atomically
-with the first conforming Stage-1 slice per its R-1; S2 core verified S3-ready under
-the rf2-vxgfnd.22 boundary review).
-
-**Landed (the S3 epic, `rf2-vxgfnd.95`) — stage closed 2026-07-18.** Every bead
-this EP cited closed: `.95.1` committed event spine; `.95.2` local three-tuple /
-effect / `dispatch-fn` / lease confirmation; `rf2-8k14ia` sync-door widening, which
-landed before `.95.1`'s literal-only door was declared conforming; `rf2-ri0k6n`
-`ui/slot`, the S3→S4 compiler surface; `rf2-isdqjv` safe-spread policy, the last
-blocker on S3 conformance; and `.95.10`, which closed the stage. S4
-(`rf2-vxgfnd.96`, custom-element assertion) followed and was declared conforming.
-The stages still ahead ride their own epics — `client-only` phase flip (S5,
-`rf2-vxgfnd.97`), `->react` (S6, `rf2-vxgfnd.98`), 004A landing + Helix removal
-(S7, `rf2-vxgfnd.99`). This paragraph records stages that have closed; for a stage
-still in flight the epic is the state, not this page.
-
-**Guide-impact assessment (EP-0009 rule 5).** The teaching seams are guide 03
-(state) and guide 04 (events), and both are already written to this contract:
-03 teaches the four-inputs table, the `local` three-tuple (P0-1 text landed
-2026-07-16) and the search-box seam; 04 teaches vectors-first, the three
-placeholders, the decision table, the widened door ("keep controlled fields
-literal"), the component-library event-prefix convention (C-13), and
-"lifecycle is not an event". Newly teachable payoffs: headless handler assertions,
-Xray-before-any-click, and library controls that keep the IME/caret guarantee.
-
-## Open Issues
-
-None open on the decision surface. Named residuals — gates or bounded spec-landing
-choices, not design questions: the G-8 real-browser matrix (including the reusable
-event-prefix arm) — **met 2026-07-17**: certified in real Chromium + WebKit via
-#6182 (`rf2-vxgfnd.95.10`). The two spellings delegated to spec landing by the 2026-07-16
-direction are **now settled**: the render-slot invocation landed as `ui/slot`, and
-the safe-spread form landed as the sibling name `ui/spread-safe` (the second-arity
-option was not taken).
+Pre-alpha: clean breaks, no shims. The Reagent, UIx, and reagent-slim adapters
+live on as first-class shipping surfaces under Spec 004's [TRANSITION] markers;
+the Reagent-tier forms are retained (not deleted), with their live home
+`spec/004A-Reagent-Compat.md` landing at S7. Only Helix is removed, at the S7
+removal wave. Migration rides `ui/->react` per-subtree co-mounting (S6;
+mechanics land with the S6 migration wave — the migrator plus the `spec/004A`
+Reagent-compat appendix).
 
 ## Resolved Decisions
 
-- **F8 — the narrow `local` law + committed-slots ruling (2026-07-12).** Same-view
-  committed handlers MAY read `local` values (committed slots include local
-  ephemera); the earlier "forbidden if any handler ever reads it" strictness is
-  superseded; the forbidden tier is defined by what the *value* needs.
-- **R-4 — the narrow bare-fn law (2026-07-12, with the rewrite ruling set).** Bare
-  fns only in known native event properties; strict lint over language flip.
+- **F8 — the narrow `local` law and committed-slots ruling (2026-07-12).**
+  Same-view committed handlers MAY read `local` values (committed slots include
+  local ephemera); the forbidden tier is defined by what the *value* needs, not
+  by whether any handler ever reads it.
+- **R-4 — the narrow bare-fn law (2026-07-12).** Bare fns only in known native
+  event properties; a strict lint over a language flip.
 - **Placeholder vocabulary closed (2026-07-12).** Three scalars;
-  `:rf.ui/form-data` / `:rf.ui/event` rejected — those cases are `ui/event`'s.
-- **`:on-mount`/`:on-unmount` rejected (2026-07-12).** Mechanical React lifecycle
-  cannot carry domain "once" semantics; `effect :connect` is named for what it does.
-- **S-5 door predicate confirmed (2026-07-12) + vector-outcome widening
-  (2026-07-16).** The controlled proof (literal `:value`/`:checked` co-presence)
-  stands; the handler-form clause widens by the synchronous-`ui/event`-vector arm;
-  the event-template projection form stays rejected.
-- **Blessed API-table deltas (12 §2 delta protocol):** #2 `->react` v1-lands-S6
-  (2026-07-12, delegated authority); #3 `spread` v1 at S1 (2026-07-12); #4 `ui/slot`
-  + internal `render-fn` widening (directed 2026-07-16); #5 `spread-safe`, the
-  literal safe-policy sibling of `spread` (directed 2026-07-16). (#1, `custom-element`, ruled 2026-07-12, is recorded
-  in §2 above.)
-- **Internal fn-props + library event-prefix convention (2026-07-16, C-13a/C-13b).**
-  Fn props between internal views are opaque identity-compared values with no
-  implicit phase; libraries take event prefixes and `conj` payloads; no
-  `dispatch-conj` helper enters core.
+  `:rf.ui/form-data` and `:rf.ui/event` rejected — both cases belong to
+  `ui/event`.
+- **`:on-mount`/`:on-unmount` rejected (2026-07-12).** Mechanical React
+  lifecycle cannot carry domain "once" semantics; `effect :connect` is named
+  for what it does.
+- **The S-5 door predicate confirmed (2026-07-12); the vector-outcome widening
+  (2026-07-16).** The controlled proof (literal `:value`/`:checked`
+  co-presence) stands; the handler-form clause admits the
+  synchronous-`ui/event`-vector arm; the event-template projection form stays
+  rejected.
+- **Blessed API-table deltas (ruled under the freeze's delta protocol).**
+  #1 `ui/custom-element` (2026-07-12); #2 `ui/->react`, lands S6 (2026-07-12);
+  #3 `ui/spread` (2026-07-12); #4 `ui/slot` plus the internal `render-fn`
+  widening (2026-07-16); #5 `ui/spread-safe` (2026-07-16).
+- **Internal fn-props and the library event-prefix convention — C-13a/C-13b
+  (2026-07-16).** Fn props between internal views are opaque identity-compared
+  values with no implicit phase; libraries take event prefixes and `conj`
+  payloads; no `dispatch-conj` helper enters core.
+- **Spellings settled at spec landing.** The render-slot invocation is
+  `ui/slot`; the safe-spread form is the sibling name `ui/spread-safe` (the
+  second-arity option was not taken).
 
-## Recommendation
+## Open Issues
 
-`Status: final` — recorded 2026-07-19 (rf2-hgwpq delegated ruling). The
-graduation trigger this section set — graduate to `final` when the S3
-conformance slice (`rf2-vxgfnd.95.10`, including the widened G-8 and the four
-cited landing beads) closes — is **met**: `.95.10` closed via #6182 (G-8
-certified in real Chromium + WebKit, including the reusable event-prefix arm;
-S3 conformance profile + proof pack landed; G-7/11/15/16/17 certified); the
-four landing beads `rf2-vxgfnd.95.2` / `rf2-8k14ia` / `rf2-ri0k6n` /
-`rf2-isdqjv` all closed; the G-18 carve-out closed via `rf2-edpam` (#6195,
-`test:ui-facade-isolation` now a standing required CI job); the S3 epic
-(`rf2-vxgfnd.95`) closed 2026-07-18; S4 has since been declared conforming
-(`spec/conformance/S4-view-conformance-profile.md` §8). `final` means what
-EP-0009 says: the decisions are settled and the spec is authoritative — it
-does not assert the build is gap-free. Where any wording here drifts from
-Spec 004 and its companions, the spec governs.
+None on the decision surface. One known build gap: the
+`{:re-frame.ui/bare-handlers :warn|:error}` strict lint is reserved in
+`spec/Conventions.md` but not yet implemented in the compiler.
+
+## References
+
+- Normative homes: [`spec/004-Views.md`](../../spec/004-Views.md) with
+  [004B](../../spec/004B-UI-Tree-and-Conversion.md) (tree/conversion),
+  [004C](../../spec/004C-Roots-and-Mount.md) (roots/mount), and
+  [004D](../../spec/004D-UI-Test-Selectors.md) (test selectors).
+- [EP-0030](EP-0030-the-compiled-view-substrate-program.md) — the program
+  umbrella; this EP is its programming-model pillar.
+- [EP-0032](EP-0032-re-frame-ui-reactivity-and-ownership.md) owns `sub`'s
+  semantics; this EP owns only the call-site grammar (`(sub [:query …])` as a
+  compile-indexed site).
+- [EP-0033](EP-0033-re-frame-ui-view-evidence.md) owns the compiler manifest and
+  committed instance records; this EP's grammars are what make those surfaces
+  statically derivable.
+- [EP-0035](EP-0035-component-library-readiness.md) owns the component-library
+  readiness package; its amendments to this surface are folded in above.
+- [EP-0018](EP-0018-one-event-registration.md) supplies the registered-event
+  world handlers-as-data dispatches into (the dev unregistered-id warning is
+  the seam); [EP-0025](EP-0025-data-classification.md) governs the posture —
+  `:props` schemas and production elision respect.
+- Design provenance: the programming-model study in the tombstoned synthesis
+  tree (`ai/findings/new-substrate-synthesis/`).

--- a/docs/EP/EP-0032-re-frame-ui-reactivity-and-ownership.md
+++ b/docs/EP/EP-0032-re-frame-ui-reactivity-and-ownership.md
@@ -2,43 +2,32 @@
 
 Status: final
 Type: standards-track
-
-> This EP records the reactive substrate under compiled views: how a
-> `re-frame.ui` view's subscription reads become React updates without leaks,
-> tears, or over-rendering. Normative home: `spec/006-ReactiveSubstrate.md`,
-> with the ViewCell consumer contract owned by the Spec 004 rewrite.
->
-> **Graduated with the S2 slice** (flip to `final` recorded 2026-07-16; the two
-> normative homes govern — `spec/006` since S2a, and the ViewCell consumer
-> contract since the Spec 004 rewrite merge, R-1 fired via `rf2-vxgfnd.13`).
-> Residual build gaps are tracked in the §Implementation-Errata Ledger below
-> (the EP-0005 pattern): *final means the decisions are settled, not that the
-> build is gap-free.*
->
-> **Graduation banner.** The core of this EP has already landed:
-> [`spec/006-ReactiveSubstrate.md` §The internal observation port](../../spec/006-ReactiveSubstrate.md)
-> is **normative since the S2 slice** (amendment merged with S2a, PR #5706,
-> 2026-07-12) — per EP-0009, where this EP and the spec differ, **the spec
-> governs**. Design provenance: the `03-reactivity-and-ownership.md` study and the
-> `drafts/spec-006-observation-port-amendment.md` amendment graduated into that normative
-> `spec/006-ReactiveSubstrate.md` section (both tombstoned in the synthesis tree per
-> rf2-mgy7pz); the S-3 feasibility evidence lives on at
-> `ai/findings/new-substrate-synthesis/spikes/s3-ownership-report.md` (a durable
-> synthesis-tree survivor).
+Created: 2026-07-16
+Resolution: final 2026-07-16
 
 ## Abstract
 
-Every compiled view reads app state through compile-indexed `(sub …)` sites
-sharing **one** ViewCell — one `useSyncExternalStore` bridge, one scalar
-revision — per view. Under concurrent React, *render* may run, restart, or be
-abandoned, so rendering only **resolves and probes** (ownership-free); *commit*
-alone **owns**, through a six-operation observation port over a strict
-target/evidence/lease split. Notification is **push**: one constant-work mark
-per dirty cell per run-to-completion drain, committed after the pull
-alternative was falsified by benchmark (4.0×–6.5× worse, gap growing with
-scale). Frames are created at **host preflight**, never from render; hot reload
-is a designed contract (stable shells, hook-signature hash, a two-point commit
-fence) rather than a hope.
+This EP records the reactive substrate under compiled views: how a
+`re-frame.ui` view's subscription reads become React updates without leaks,
+tears, or over-rendering. Every compiled view reads app state through
+compile-indexed `(sub …)` sites sharing **one** ViewCell — one
+`useSyncExternalStore` bridge, one scalar revision — per view. Under concurrent
+React, *render* may run, restart, or be abandoned, so rendering only **resolves
+and probes** (ownership-free); *commit* alone **owns**, through a six-operation
+observation port over a strict target/evidence/lease split. Notification is
+**push** — constant-work source-side marking, with each dirty cell flushed once
+per render batch at the host checkpoint — committed after the pull alternative
+was falsified by benchmark (4.0×–6.5× worse, the gap growing with scale). Frames
+are created at **host preflight**, never from render; hot reload is a designed
+contract (stable shells, hook-signature hash, a two-point commit fence) rather
+than a hope.
+
+The normative home is
+[`spec/006-ReactiveSubstrate.md`](../../spec/006-ReactiveSubstrate.md) — §The
+internal observation port is normative there — with the ViewCell consumer
+contract owned by [`spec/004-Views.md`](../../spec/004-Views.md); per EP-0009,
+where this EP and the spec differ, **the spec governs**. `final` means the
+decisions are settled, not that the build is gap-free.
 
 ## Motivation
 
@@ -54,61 +43,31 @@ handles versus re-resolved identities; eager versus transactional
 multi-acquire; whether hide/unmount is distinguishable at cleanup. Each was
 settled by ruling or spike evidence; the record belongs in one durable place.
 
-## Goals / Non-Goals
-
-Goals:
-
-- one reactive bridge per view: compile-indexed sub sites sharing one ViewCell;
-- render/commit ownership split as frozen invariants, with typed failure;
-- the six-operation observation port as an adapter-internal seam;
-- transactional dependency reconciliation (stage-acquire, rollback, publish);
-- an honest observed lifecycle for cells (three states, retroactive labels);
-- committed push economics with host-checkpoint render batching and a test flush;
-- frames at host preflight; an excellent HMR contract, fixture-pinned.
-
-Non-goals:
-
-- the view programming model itself — `defview`, templates, handlers, `local`,
-  effects, presence — is EP-0031's surface; this EP takes it as given;
-- the adapter decision (which view layers exist, are retained, or retire) is EP-0030's;
-- no change to the closed public adapter API contract (the 11-key spec map) or
-  to public `subscribe`/`subscribe-once` semantics;
-- resource freshness under Activity reveal belongs to Spec 016, not the lease.
-
-## Relationships
-
-- **EP-0030** — the `re-frame.ui` substrate adoption decision this EP serves:
-  the compiled-view runtime whose reads this EP makes safe.
-- **EP-0031** — the compiled-view programming model. The one-reactive-grammar
-  table (sub / props / `local` / `lease` / frame) is shared vocabulary, but
-  `local`'s contract — including the `[value set! update!]` three-tuple as
-  amended 2026-07-16 — is **owned by EP-0031 and EP-0035**, not here; this EP
-  fixes only that `local` sits outside epochs and re-renders its own view.
-- **EP-0035** — component-library readiness (the P0 amendments; delta doc
-  `drafts/component-library-readiness.md`).
-- **EP-0014** (derivation and process algebra) — this EP is its view-tier
-  realization: sub sites are declared inputs, the ViewCell is the
-  evaluation/lifecycle boundary, leases are the ownership leg.
-- **EP-0002 / EP-0024** (frame target resolution; unified frame identity) —
-  `resolve-target` is the view tier's single resolution point for the explicit
-  frame-context rule; preflight ENSURE rides the EP-0024 lifecycle.
-- **Specs:** `spec/006-ReactiveSubstrate.md` (normative home — port, cache
-  contract, memo, epoch finalization); the Spec 004 rewrite (ViewCell/commit
-  reconciler, view error boundary); `spec/009` (catalogue rows for every typed
-  error named below).
-
 ## Specification
 
-The decision surface, as ruled; where graduated, the spec is the authority.
+**Scope.** This EP fixes: one reactive bridge per view (compile-indexed sub
+sites sharing one ViewCell); the render/commit ownership split as frozen
+invariants with typed failure; the six-operation observation port as an
+adapter-internal seam; transactional dependency reconciliation (stage-acquire,
+rollback, publish); an honest observed lifecycle for cells (three states,
+retroactive labels); committed push economics with host-checkpoint render
+batching and a test flush; frames at host preflight; and a fixture-pinned HMR
+contract. It does not own the view programming model — `defview`, templates,
+handlers, `local`, effects, presence are EP-0031's surface; the adapter
+decision (which view layers exist and are retained) is EP-0030's; the closed
+public adapter API contract (the 11-key spec map) and public
+`subscribe`/`subscribe-once` semantics are unchanged; resource freshness under
+Activity reveal belongs to Spec 016, not the lease. Where graduated, the spec
+is the authority.
 
 ### One ViewCell per view; rf= stabilization
 
 Every lexical `(sub …)` is a compile-indexed site; all of a view's sites share
 one ViewCell: one `useSyncExternalStore` over a scalar revision snapshot, one
-notification per render batch. Conditional reads are legal; loops are rejected (finite
-sites). Stabilization is by the frozen `rf=` law: literal queries are module
-constants, parametric sites reuse the prior query object while args are `rf=`,
-and a site returns the prior exact value when the new read is `rf=`. One
+notification per render batch. Conditional reads are legal; loops are rejected
+(finite sites). Stabilization is by the frozen `rf=` law: literal queries are
+module constants, parametric sites reuse the prior query object while args are
+`rf=`, and a site returns the prior exact value when the new read is `rf=`. One
 revision integer suffices under the two-guard rule — React's own snapshot
 re-check catches mid-pass movement of watched sites; the commit reconciler's
 evidence comparison catches the rest — no third mechanism.
@@ -145,23 +104,14 @@ acquires a **static lease** (`:owned? false` honestly, pinned value, no
 callback) under the split equality law (`:override-id` by `=`, `:version` by
 `rf=`; NaN-to-NaN retains) — one uniform commit path.
 
-**The six frozen invariants** (graduated verbatim; each deletes a bug class):
-render resolves and probes without ownership · commit acquires the exact
-captured target · acquire before release · release is synchronous and
-idempotent · moved evidence corrects before paint · one notification per
-dirty cell per drain (boundary at quiescence, never epoch close).
-
-> **Erratum — 2026-07-19 (`rf2-vxgfnd.166`, PR #6393).** The sixth invariant is
-> preserved above as graduated, and its boundary clause was recorded wrongly:
-> the shipped scheduler takes no hook from router drain finalization, so the
-> notification boundary is the **host checkpoint**, not drain quiescence — one
-> notification per dirty cell per **render batch**. The corrected law is
-> normative in `spec/006-ReactiveSubstrate.md` (§The six frozen invariants,
-> invariant 6; §Render-batch finalization — the host-checkpoint boundary); the
-> spec governs. The same PR reworded this EP's Goals bullet, §One ViewCell
-> prose, and §Push economics paragraph in place from the stale drain-quiescence
-> phrasing; those three passages (not verbatim-frozen) now read as corrected.
-> The other five invariants are unchanged.
+**The six frozen invariants** (each deletes a bug class): render resolves and
+probes without ownership · commit acquires the exact captured target · acquire
+before release · release is synchronous and idempotent · moved evidence
+corrects before paint · one notification per dirty cell per **render batch**
+(the boundary is the host checkpoint — never epoch close, never drain
+quiescence). The invariants are normative in `spec/006-ReactiveSubstrate.md`
+(§The six frozen invariants; §Render-batch finalization — the host-checkpoint
+boundary).
 
 ### Transactional multi-acquire
 
@@ -200,7 +150,7 @@ epochs settled in one drain coalesce into one), while several drains — or
 listener re-entry after a completed batch — reaching the same checkpoint may
 share one; only a real host yield separates renders. "One batch per drain" is
 the common case, exact whenever callers yield between drains, and is not
-normative. `flush!` is **per-root** (Q51, pinned); `ui.test/flush!` is the sole
+normative. `flush!` is **per-root** (ruled); `ui.test/flush!` is the sole
 public test flush — a Promise on CLJS whose thunk arity runs inside React 19
 `act`, alternating drains and commits to joint quiescence; synchronous on the
 JVM; called inside an open drain it throws `:rf.error/flush-in-open-epoch`
@@ -219,8 +169,8 @@ renders, StrictMode replay, HMR, or error recovery. The emitted `frame-root`
 only scopes the already-live frame; conditional, reactive, or list-generated
 `frame-root` sites are compile errors. `frame-provider` is pure SCOPE.
 Preflight failure fails the mount loudly with the container untouched — no
-auto-retry (Q49, ruled). Landed in `re-frame.ui` (#5711); R-7 carries the spec
-promotion.
+auto-retry (ruled). The staged frame-root/provider split is companion ruling
+R-7 of the program record (EP-0030).
 
 ### The HMR matrix
 
@@ -237,8 +187,8 @@ promotion.
 - **Frames untouched:** preflight re-runs, finds frames live, never re-seeds.
 - **`reg-sub` replacement:** dispose-then-notify-once, cause `:hmr`; no cell
   can pin a disposed node.
-- **The two-point commit fence** (graduated, spec/006 §Body authority): commit
-  verifies dual body authority — cell-local generation plus the registered view
+- **The two-point commit fence** (spec/006 §Body authority): commit verifies
+  dual body authority — cell-local generation plus the registered view
   revision — at commit entry and again at the final publication boundary, so a
   re-registration landing anywhere in the render→commit→publish window can
   never publish a stale body; dev/HMR-only, constant-folds in production.
@@ -249,26 +199,33 @@ Internally fail-loud, publicly recover-to-nil: the port throws typed
 (`:rf.error/no-such-sub`, `:rf.error/frame-destroyed`,
 `:rf.error/read-after-release`, `:rf.error/reentrant-graph-op`, the ABI guard)
 while public `subscribe`/`subscribe-once` keep `:replaced-with-default`
-recovery — one condition, one catalogue id, two emit surfaces; the ViewCell maps
-port throws to the view error boundary. The graduated spec has since extended
-the roster (malformed target/lease diagnostics, displacement retry and
+recovery — one condition, one catalogue id, two emit surfaces; the ViewCell
+maps port throws to the view error boundary. The spec extends the roster
+(malformed target/lease diagnostics, displacement retry and
 `:rf.error/observation-retry-exhausted`, the entry-node fail-loud line) — the
 spec governs; every id carries a Spec 009 catalogue row.
+
+### Guide impact
+
+The substrate guide's reactivity chapters teach hot reload as the default
+workflow and the three-state lifecycle as the tool vocabulary. The retained
+adapters' guides are unaffected — those adapters live on per EP-0030 and are
+untouched by this work.
 
 ## Rationale
 
 Push over pull is the load-bearing bet, so it was made falsifiable rather than
-argued: G-13 frames pull as a standing falsification benchmark, and the S-2 run
-answered decisively — 4.0× at 100 views, 6.5× at 500, pull O(N views) per epoch
-by construction with ~60× the GC pressure. Target-not-handle and
-lease-as-owner-token both came out of the spike the same way: the captured node
-handle failed under HMR (fixture 8), and keying owners by lease identity made
-the worst spine bug structurally impossible instead of merely tested-against.
-Three lifecycle states with retroactive annotation is honesty over
-convenience — the platform does not say hide-or-unmount at cleanup, so the
-runtime never claims it. Transactional staging exists because acquire can fail
-and commit must not corrupt: release-first demonstrably churns shared nodes
-through their zero-owner edge.
+argued: G-13 frames pull as a standing falsification benchmark, and the
+falsification run answered decisively — 4.0× at 100 views, 6.5× at 500, pull
+O(N views) per epoch by construction with ~60× the GC pressure.
+Target-not-handle and lease-as-owner-token both came out of the ownership spike
+the same way: the captured node handle failed under HMR, and keying owners by
+lease identity made the worst spine bug structurally impossible instead of
+merely tested-against. Three lifecycle states with retroactive annotation is
+honesty over convenience — the platform does not say hide-or-unmount at
+cleanup, so the runtime never claims it. Transactional staging exists because
+acquire can fail and commit must not corrupt: release-first demonstrably churns
+shared nodes through their zero-owner edge.
 
 ## Backwards Compatibility
 
@@ -278,68 +235,68 @@ feature predicate is added. Public `subscribe`/`subscribe-once` semantics are
 unchanged. The seam may change shape between lockstep releases; skew is a boot
 error by the ABI guard.
 
-## Bead Plan / Reference Implementation
-
-Evidence and landing record (epic `rf2-vxgfnd`):
-
-- **Spike S-3** (`spikes/s3-ownership-report.md`, 2026-07-11): 55/55
-  ownership/concurrency fixtures on React 19.2 — 10k abandoned renders retain
-  zero; S-2 push falsification PASS; S-5 sync door 24/24 in jsdom.
-- **S2a** (`rf2-vxgfnd.7`, PR #5706): the port over the real sub-cache; Spec 006
-  amendment merged; four `[S2-CONFIRM]` items resolved.
-- **S2b** (`rf2-vxgfnd.8`, PR #5708): ViewCell + commit algorithm + stabilization.
-- **S2c** (`rf2-vxgfnd.9`, PR #5711): preflight ENSURE + frame wiring (Q49 ruled).
-- **S2d** (`rf2-vxgfnd.10`, PR #5713): epoch coalescing + `flush!` (Q51 pinned).
-- **S2e** (`rf2-vxgfnd.11`): the full HMR matrix, fixture-pinned.
-
-Guide impact: the new-substrate guide's reactivity chapters teach hot reload as
-the default workflow and the three-state lifecycle as the tool vocabulary; no
-legacy-adapter guide changes (those coexisting adapters are unaffected by this work; they
-live on per EP-0030, Resolved Decisions 2026-07-17).
-
 ## Resolved Decisions
 
-- **R-2, shapes final (2026-07-11 → 2026-07-12).** Semantics frozen 2026-07-11;
-  spike S-3's §5 target/evidence/lease model ruled the sole ABI source
-  2026-07-12; the amendment merged with S2a the same day. The port is outside
-  the closed public adapter map.
+- **R-2 — port shapes final (2026-07-11/12).** Observation-port semantics
+  frozen ahead of implementation; the ownership spike's target/evidence/lease
+  model is the sole ABI source; the port lives outside the closed public
+  adapter map.
 - **Push ownership committed (2026-07-11).** The pull alternative survives only
-  as the G-13 falsification benchmark; S-2 ran it and push held decisively. If
-  a future run ever inverts, the design is rewritten, not toggled.
-- **Target = evidence-not-handle; lease = owner token (2026-07-11, spike).**
-  No node handle rides a target; owners keyed by lease identity.
-- **Q49 (2026-07-12, `rf2-vxgfnd.9`).** Preflight ENSURE failure fails the
-  mount loudly, container untouched, no auto-retry.
-- **Q51 (2026-07-12, `rf2-vxgfnd.10`).** `flush!` is per-root; the global
-  all-roots flush is the test-only `ui.test/flush!` spelling.
-- **`[S2-CONFIRM]` items (2026-07-12, `rf2-vxgfnd.7`).** Three confirmed (no
+  as the G-13 falsification benchmark, which ran and confirmed push
+  decisively. If a future run ever inverts, the design is rewritten, not
+  toggled.
+- **Target = evidence-not-handle; lease = owner token (2026-07-11).** No node
+  handle rides a target; owners are keyed by lease identity.
+- **Preflight ENSURE failure (2026-07-12).** A failed preflight fails the mount
+  loudly, container untouched, no auto-retry.
+- **`flush!` is per-root (2026-07-12).** The global all-roots flush is the
+  test-only `ui.test/flush!` spelling.
+- **Cold-probe recovery (2026-07-12).** A sub-body throw during a cold probe
+  recovers to nil exactly like a live probe — probe temperature must not be
+  observable; port-entry conditions stay fail-loud. Confirmed alongside: no
   synchronous fan-out from acquire/release; HMR-disposal queue alignment;
-  reverse-order rollback release); one **corrected** — a sub-body throw during
-  a cold probe recovers to nil exactly like a live probe (probe temperature
-  must not be observable); port-entry conditions stay fail-loud.
+  reverse-order rollback release.
+- **Invariant-6 boundary corrected (2026-07-19).** The notification boundary is
+  the **host checkpoint** — one notification per dirty cell per render batch —
+  not drain quiescence: the shipped scheduler takes no hook from router drain
+  finalization. The corrected law is normative in
+  `spec/006-ReactiveSubstrate.md`; this EP's text above states it as
+  corrected. The other five invariants were never in question.
 
-## Implementation-Errata Ledger
+## Open Issues
 
-Per EP-0009, `final` asserts the decisions are settled — this ledger tracks the
-known build gaps on this EP's surface, and per EP-0009 its rows cite live bead ids
-and are struck as they close. A struck row is closed, and closed is terminal, so it
-cannot go stale; an unstruck row names the bead that owns the gap, and that bead —
-not this table — is the gap's current state. The full S2 correction tail lives on
-the program epic (`rf2-vxgfnd`).
+None. No open implementation gaps are tracked on this EP's surface; the
+implementation-errata ledger it carried while the correction tail closed is
+fully struck.
 
-| Bead | Gap |
-|---|---|
-| ~~`rf2-vxgfnd.166`~~ | ~~render batches must be defined by host checkpoint, not router drain (the G-5 boundary prose)~~ — closed (PR #6393; see the erratum beside the six frozen invariants) |
-| ~~`rf2-vxgfnd.167`~~ | ~~per-epoch render-law sweep incomplete (force-tracked ai)~~ — closed (PR #6393) |
-| ~~`rf2-vxgfnd.169`~~ | ~~empty root-incarnation entries not pruned after weak member collection~~ — closed |
-| ~~`rf2-vxgfnd.204`~~ | ~~CLJS SSR emitter not replayed when `re-frame.ui/adapter` is reinstalled~~ — closed |
-| ~~`rf2-vxgfnd.94.15`, `.94.17`–`.94.21`~~ | ~~compatible-HMR migration evidence/drift-guard family~~ — closed (`.94.16` closed earlier) |
+## References
 
-## Recommendation
-
-`Status: final` — recorded 2026-07-16. Both graduation conditions the draft
-review named are met: `spec/006-ReactiveSubstrate.md` has been normative since
-the S2 slice, and the Spec 004 rewrite (the ViewCell consumer contract's home)
-merged when R-1 fired (`rf2-vxgfnd.13`, closed). Every open issue carries a
-ruling (§Resolved Decisions); the residual correction tail is the errata
-ledger's job, not a reason to hold the status.
+- Normative homes:
+  [`spec/006-ReactiveSubstrate.md`](../../spec/006-ReactiveSubstrate.md) (the
+  observation port, cache contract, memo, epoch finalization, the six frozen
+  invariants) and [`spec/004-Views.md`](../../spec/004-Views.md) (the
+  ViewCell/commit reconciler and the view error boundary);
+  [`spec/009-Instrumentation.md`](../../spec/009-Instrumentation.md) carries a
+  catalogue row for every typed error named above.
+- [EP-0030](EP-0030-the-compiled-view-substrate-program.md) — the substrate
+  adoption decision this EP serves.
+- [EP-0031](EP-0031-re-frame-ui-programming-model.md) — the compiled-view
+  programming model. The one-reactive-grammar table (sub / props / `local` /
+  `lease` / frame) is shared vocabulary, but `local`'s contract — including the
+  `[value set! update!]` three-tuple — is owned by EP-0031 and EP-0035, not
+  here; this EP fixes only that `local` sits outside epochs and re-renders its
+  own view.
+- [EP-0035](EP-0035-component-library-readiness.md) — the component-library
+  readiness amendments.
+- [EP-0014](EP-0014-derivation-and-process-algebra.md) — this EP is its
+  view-tier realization: sub sites are declared inputs, the ViewCell is the
+  evaluation/lifecycle boundary, leases are the ownership leg.
+- [EP-0002](EP-0002-frame-target-resolution.md) /
+  [EP-0024](EP-0024-unified-frame-identity-and-lifecycle.md) —
+  `resolve-target` is the view tier's single resolution point for the explicit
+  frame-context rule; preflight ENSURE rides the EP-0024 lifecycle.
+- Evidence: the ownership-spike report at
+  `ai/findings/new-substrate-synthesis/spikes/s3-ownership-report.md` (a
+  durable synthesis-tree survivor) — 55/55 ownership/concurrency fixtures on
+  React 19.2, 10k abandoned renders retaining zero, the push-falsification
+  PASS, and the sync-door jsdom matrix.

--- a/docs/EP/EP-0033-re-frame-ui-view-evidence.md
+++ b/docs/EP/EP-0033-re-frame-ui-view-evidence.md
@@ -2,139 +2,92 @@
 
 Status: accepted
 Type: standards-track
-
-> The ruled design for `re-frame.ui`'s debugging evidence: two evidence layers
-> (a compiler **manifest** for what *can* happen, a **committed instance record**
-> for what *did* happen), attribution emitted at the cause site, five
-> never-conflated identities, source ↔ DOM ↔ cause navigation, the enrich-first
-> tool posture, and production erasure proven by bundle-scan gates. Normative
-> home: `spec/004-Views.md` §View identity and the instrumentation surface;
-> every evidence schema, trace op, and error/warning id lands as a
-> `spec/009-Instrumentation.md` catalogue row (the one-catalogue rule, rf2-cs0kd1).
->
-> **Partially graduated.** That Spec 004 section already carries the interim
-> normative text (the R-1 rewrite); per EP-0009, where it and this EP differ,
-> **the spec governs**. Implementation lands in the S3 wave (asserts **S3**,
-> budget/absence gates complete **S6**) via beads rf2-vxgfnd.95.6/.95.7/.95.8.
-> **[UPDATED 2026-07-19]** The S3 wave has landed: .95.6/.95.7/.95.8 closed
-> 2026-07-17, the S3 epic closed 2026-07-18, and S3/S4 are declared conforming
-> (S5 is the live stage). What S3 **certified** is a bounded subset of the
-> schema this EP specifies — see the dated status note at the top of
-> §Specification.
+Created: 2026-07-16
+Resolution: accepted 2026-07-11
 
 ## Abstract
 
 Dev builds of the compiled view substrate are a glass cockpit: per-view compiler
 manifests describe every slot, site, and capability before mount; per-commit
-instance records carry a `:rf.view/causes` vector, occurrence-level identity, and
-loss-accounted histories. Attribution is **emitted at the cause site, never
-reconstructed** — no Fiber walking, no DOM scraping, no cloneElement tagging. One
-versioned evidence schema is shared by Xray, Story, Pair, compiler diagnostics,
-and tests; production builds contain none of it, provably.
+instance records carry a `:rf.view/causes` vector, occurrence-level identity,
+and loss-accounted histories. Attribution is **emitted at the cause site, never
+reconstructed** — no Fiber walking, no DOM scraping, no cloneElement tagging.
+One versioned evidence schema is shared by Xray, Story, Pair, compiler
+diagnostics, and tests; production builds contain none of it, provably.
+
+The primary normative home is [`spec/004-Views.md`](../../spec/004-Views.md)
+§View identity and the instrumentation surface; per EP-0009, where this EP and
+the spec differ, **the spec governs**. Every runtime-tier evidence schema, trace
+op, and error/warning id this design names gets a catalogue row in
+[`spec/009-Instrumentation.md`](../../spec/009-Instrumentation.md) — the
+one-catalogue rule, scoped to the runtime tier: compile-tier `:rf.ui.compile/*`
+ids live in the maintained compiler roster and deliberately get no Spec 009
+rows.
 
 ## Motivation
 
-Legacy adapters reconstruct render attribution after the fact (post-render walks,
-cloneElement tagging) — imprecise under concurrent rendering, identity-conflating,
-and handing each tool a subtly different truth. The compiler already knows every
-slot, site, and interop boundary; the runtime knows which committed commit each
-observation belongs to. The unresolved alternatives — where evidence is emitted,
-which identities exist, how tools consume them, what production keeps — are
-contract decisions warranting a durable record, not a bead.
-
-## Goals / Non-Goals
-
-Goals: one versioned evidence schema consumed by Xray, Story, Pair, diagnostics,
-and tests; evidence usable *before mount* (the manifest) and truthful *after
-commit* (the instance record — speculative renders publish nothing); honest
-bounds everywhere (loss accounting, `:owned? false` overrides, qualified
-retroactive lifecycle annotations); production erasure as a proof (G-7/G-11).
-
-Non-goals: no new Xray panels at S3 (mounted-views, SSR/roots, heatmap panels
-come only after an information-architecture review — the v1 emit obligation is
-the schema, not panels); no render flamegraphs or per-view timeline scrubbers
-(React Performance Tracks correlate via render-key/epoch ids); no second runtime
-model for Story/Pair, no remote mutation API, no general query engine over
-evidence; no production telemetry — the always-on error channel is EP-0008's.
-
-## Relationships
-
-- **EP-0030** (the compiled-view substrate program) — the umbrella: stages,
-  demand bar, and the blessed API surface this evidence tier instruments.
-- **EP-0031** (the `re-frame.ui` programming model) — the compiler, `defview`,
-  templates, and handler law whose sites the manifest indexes.
-- **EP-0032** (reactivity and ownership) — observation targets and the committed
-  push-ownership protocol; connected commit is the publication boundary for
-  instance records, and the three-state connection lifecycle recorded here is
-  that EP's observed-lifecycle contract.
-- **EP-0034** (production, SSR, and testing posture) — owns the SSR/roots story
-  (**root-id** lives with `spec/011`'s root manifests); the
-  `:hydration-correction` cause names its server/client/probe disagreements;
-  its G-7/G-11 gates prove this tier's production erasure.
-- **EP-0035** (component-library readiness) — the 2026-07-16 amendment package:
-  render-slot sites join the manifest roster (P0-3); the dev/test manifest
-  projection becomes the versioned public docs/slot shape (P1-5).
-- **EP-0008** (production observability channels) — after erasure, production
-  keeps exactly the always-on error channel; this evidence is the dev-only tier.
-- **EP-0025** (data classification) — occurrence keys, override values, query
-  args, and event payloads route through the one egress-projection policy.
-  **[CORRECTED 2026-07-19 — rf2-zwgqe ruling (2026-07-19, delegated):]** sub
-  query vectors do **not** route through the classification egress chokepoint.
-  They are identity — the sub-cache key, the skip-dedup key, reactive-graph
-  edge endpoints — and egress raw on every query-vector-bearing slot as an
-  accepted, documented fail-open (the positional-event-args precedent). Only
-  the Spec 010 schema-axis backstop whole-slot scrubs them, for
-  `:sensitive?`-schema'd subs. The other slots named above route as written.
-- **`spec/009-Instrumentation.md`** — the one-catalogue rule (rf2-cs0kd1): every
-  evidence schema, trace op, and error/warning id this design names gets a
-  catalogue row there. **[QUALIFIED 2026-07-19 — rf2-vxgfnd.95.13 / PR #6153:]**
-  runtime-tier ids only, matching Spec 004 §One catalogue (runtime tier);
-  compile-tier `:rf.ui.compile/*` ids live in the maintained compiler roster
-  and deliberately get no Spec 009 rows. The banner's one-catalogue phrasing
-  reads with this qualifier.
-- **`spec/004-Views.md`** §View identity and the instrumentation surface — the
-  primary normative home (see banner).
-- Design record: graduated into this EP + the normative `spec/009-Instrumentation.md`
-  and `spec/004-Views.md` §View identity (from `04-debugging.md`, amended 2026-07-16);
-  the S3 Xray consumption IA (`drafts/xray-ui-consumption-ia.md`) lands with W7a under
-  `tools/xray/spec/`. Both synthesis-tree sources are tombstoned per rf2-mgy7pz.
+Legacy adapters reconstruct render attribution after the fact (post-render
+walks, cloneElement tagging) — imprecise under concurrent rendering,
+identity-conflating, and handing each tool a subtly different truth. The
+compiler already knows every slot, site, and interop boundary; the runtime knows
+which committed commit each observation belongs to. The unresolved alternatives
+— where evidence is emitted, which identities exist, how tools consume them,
+what production keeps — are contract decisions warranting a durable record, not
+a bead.
 
 ## Specification
 
-> **Status note — 2026-07-19 (specified vs certified).** The S3 wave landed and
-> was certified (`spec/conformance/S3-view-conformance-profile.md`), but the
-> certified surface is a bounded subset of the schema specified below. **Shipped
-> at S3:** the five `re-frame.ui.tool` projections; occurrence-shaped instance
-> records (`:occurrence` ordinal + `:view-id` + `:root-id` + `:connection` +
-> `:lifecycle` intervals + bounded render evidence) with explicit loss
-> accounting; and a bounded render-cause **set** — `#{:value :hmr :disposed}`
-> (≤3 tags), with `:local-state` cause evidence riding G-15. **Specified below
-> but not yet shipped:** the integer `:render-key` / `:parent-render-key` /
-> `:frame-id` / `:generation` record fields; the `:rf.view/causes` **vector**
-> and its full cause-kind roster (`:mount`, `:subscription` with version
-> from→to, `:prop`, `:epoch-restore`, `:hydration-correction`,
-> `:reconnect-correction`, `:foreign-or-react`, …); the
-> `data-rf2-source-coord` + render-key DOM annotation on compiler-owned host
-> roots; and the Spec 009 evidence-schema rows. Consumers tolerate the absences
-> explicitly rather than fabricating them (`tools/xray/spec/021` §3.4.1: the S3
-> producer emits no epoch-restore evidence op, and Xray does not invent one).
-> The delta currently has **no stage assignment and no owning bead** — the Spec
-> 004 ledger row names only budget/absence gates for S6. The schema below
-> remains the ruled design intent, unchanged; this note records
-> landed-vs-not-landed honesty only and assigns nothing.
+**Scope.** This EP fixes one versioned evidence schema consumed by Xray, Story,
+Pair, diagnostics, and tests; evidence usable *before mount* (the manifest) and
+truthful *after commit* (the instance record — speculative renders publish
+nothing); honest bounds everywhere (loss accounting, `:owned? false` overrides,
+qualified retroactive lifecycle annotations); and production erasure as a proof
+(G-7/G-11). It does not add new Xray panels (mounted-views, SSR/roots, and
+heatmap panels come only after an information-architecture review — the v1 emit
+obligation is the schema, not panels); no render flamegraphs or per-view
+timeline scrubbers (React Performance Tracks correlate via render-key/epoch
+ids); no second runtime model for Story/Pair, no remote mutation API, no
+general query engine over evidence; and no production telemetry — the always-on
+error channel is EP-0008's.
+
+### Shipped surface and specified extensions
+
+The evidence tier shipped with the S3 conformance slice, and the certified
+surface (`spec/conformance/S3-view-conformance-profile.md`) is a bounded subset
+of the schema this EP specifies.
+
+**Shipped:** the five `re-frame.ui.tool` projections; occurrence-shaped
+instance records (`:occurrence` ordinal + `:view-id` + `:root-id` +
+`:connection` + `:lifecycle` intervals + bounded render evidence) with explicit
+loss accounting; and a bounded render-cause **set** — `#{:value :hmr
+:disposed}` — with `:local-state` cause evidence riding G-15.
+
+**Specified below but not yet shipped:** the integer `:render-key` /
+`:parent-render-key` / `:frame-id` / `:generation` record fields; the
+`:rf.view/causes` **vector** and its full cause-kind roster (`:mount`,
+`:subscription` with version from→to, `:prop`, `:epoch-restore`,
+`:hydration-correction`, `:reconnect-correction`, `:foreign-or-react`, …); the
+`data-rf2-source-coord` + render-key DOM annotation on compiler-owned host
+roots; and the Spec 009 evidence-schema rows.
+
+Consumers tolerate the absences explicitly rather than fabricating them
+(`tools/xray/spec/021` §3.4.1: the S3 producer emits no epoch-restore evidence
+op, and Xray does not invent one). The unshipped delta carries no stage
+assignment and no owner — the Spec 004 ledger row names only budget/absence
+gates for S6 (see Open Issues). The schema below is the ruled design intent.
 
 ### Two evidence layers
 
 **Compiler manifest — what *can* happen.** Per view, dev-only: source coords,
 prop slots + schema, template fingerprint, hook signature, capability bits, and
 every site — subs with query shapes; events with event shapes and a
-`:serializable?`/`:dynamic` flag; leases; effects; presence sites; trusted-markup
-`ui/html` sites; **render-slot sites [2026-07-16]** — each with source + template
-path. No runtime values; useful before mount, to Xray, Story, editors, and
-agents. **[AMENDED 2026-07-16 — readiness P1-5, cross-ref EP-0035]:** the
-dev/test projection of this manifest is a **versioned public shape** additionally
-carrying per-prop docs/defaults and declared slot metadata — one source of truth
-replacing parallel args-description systems (re-com maintains ~57 such Vars).
+`:serializable?`/`:dynamic` flag; leases; effects; presence sites;
+trusted-markup `ui/html` sites; render-slot sites (P0-3) — each with source +
+template path. No runtime values; useful before mount, to Xray, Story, editors,
+and agents. Per the readiness package (EP-0035, P1-5), the dev/test projection
+of this manifest is a **versioned public shape** additionally carrying per-prop
+docs/defaults and declared slot metadata — one source of truth replacing
+parallel args-description systems (re-com maintains ~57 such Vars).
 
 **Committed instance record — what *did* happen.** Published only at connected
 commit; speculative renders publish nothing. Shape (versioned):
@@ -150,20 +103,21 @@ commit; speculative renders publish nothing. Shape (versioned):
 
 `parent-render-key` gives direct hierarchy — no Fiber or DOM walking (legacy
 adapters keep their fallback; this substrate never needs it). Keyed repetitions
-inside one instance carry **occurrence-path** (e.g. `[{:site 17 :key order-id}]`)
-on DOM annotations, event provenance, and presence records — render-key alone is
-insufficient. Story overrides display honestly: `{:kind :story-override …
-:owned? false}` — a visual override, never evidence a subscription computed it.
+inside one instance carry **occurrence-path** (e.g. `[{:site 17 :key
+order-id}]`) on DOM annotations, event provenance, and presence records —
+render-key alone is insufficient. Story overrides display honestly: `{:kind
+:story-override … :owned? false}` — a visual override, never evidence a
+subscription computed it.
 
-**Connection is recorded as observed** (name unified 2026-07-12): the runtime
-emits exactly three states — `:connected` / `:disconnected` / `:dead` — and the
-immediate cleanup fact is `:disconnected {:reason :unknown}` (public React cannot
-distinguish an Activity hide from an unmount at cleanup). `:activity-hidden` and
-`:unmounted` are qualified **retroactive annotations** of the *prior interval*,
-never runtime states: a reconnect proves a hide; host/root teardown proves
-unmount; GC-based inference (if enabled) is best-effort/eventual — no timestamp,
-a bounded tombstone that never retains the cell. Records distinguish runtime
-state vs tool label vs inference; transitions never fabricate renders.
+**Connection is recorded as observed:** the runtime emits exactly three states
+— `:connected` / `:disconnected` / `:dead` — and the immediate cleanup fact is
+`:disconnected {:reason :unknown}` (public React cannot distinguish an Activity
+hide from an unmount at cleanup). `:activity-hidden` and `:unmounted` are
+qualified **retroactive annotations** of the *prior interval*, never runtime
+states: a reconnect proves a hide; host/root teardown proves unmount; GC-based
+inference (if enabled) is best-effort/eventual — no timestamp, a bounded
+tombstone that never retains the cell. Records distinguish runtime state vs
+tool label vs inference; transitions never fabricate renders.
 
 ### Five identities, never conflated
 
@@ -178,13 +132,14 @@ indexes + source anchors; identity under HMR is source anchor + structural path
 **`:rf.view/causes` is a vector** — a commit can have several causes; headers
 summarize ("3 dependencies changed in `::refresh-complete`"). The roster:
 `:mount` · `:subscription` (target, query, version from→to, epoch, upstream
-event/sub) · `:story-override` · `:prop` (**changed top-level slots** — the sound
-cheap promise; nested paths are a dev diff view on demand, never a default emit)
-· `:local-state` · `:frame` / `:context` · `:resource` · `:hmr` / `:hmr-remount`
-· `:hydration-correction` · `:reconnect-correction` · `:epoch-restore` (**the
-restore operation token + target epoch** — the repaint is caused by the restore
-*operation*; old epoch records are never rewritten or back-filled) ·
-`:foreign-or-react` (the honest fallback — never fabricate precision).
+event/sub) · `:story-override` · `:prop` (**changed top-level slots** — the
+sound cheap promise; nested paths are a dev diff view on demand, never a
+default emit) · `:local-state` · `:frame` / `:context` · `:resource` · `:hmr` /
+`:hmr-remount` · `:hydration-correction` · `:reconnect-correction` ·
+`:epoch-restore` (**the restore operation token + target epoch** — the repaint
+is caused by the restore *operation*; old epoch records are never rewritten or
+back-filled) · `:foreign-or-react` (the honest fallback — never fabricate
+precision).
 
 **Loss accounting:** every bounded buffer reports `total` / `retained` /
 `dropped`; counts are labeled exact only when `dropped` = 0 — no silent
@@ -201,107 +156,138 @@ accessibility checks) land as catalogue rows on the issue surfaces.
 
 ### Source ↔ DOM ↔ cause navigation
 
-Compile-time `data-rf2-source-coord` + render-key (+ occurrence-path) annotation
-on compiler-owned host roots — today's attribute vocabulary, so existing Xray
-click-to-source works day one. Chains both directions: app-db path → subs →
-views → elements, and element → event → handler → effects → state diff → sub
-cascade → commits. React DevTools stays independent; Performance Tracks correlate
-via render-key/epoch ids. Xray answers "why does this view carry a client
-runtime?" from capability bits + sites — the absence story made inspectable.
+Compile-time `data-rf2-source-coord` + render-key (+ occurrence-path)
+annotation on compiler-owned host roots — today's attribute vocabulary, so
+existing Xray click-to-source works day one. Chains both directions: app-db
+path → subs → views → elements, and element → event → handler → effects → state
+diff → sub cascade → commits. React DevTools stays independent; Performance
+Tracks correlate via render-key/epoch ids. Xray answers "why does this view
+carry a client runtime?" from capability bits + sites — the absence story made
+inspectable.
 
 ### Tool integration posture
 
 - **Xray — enrich existing surfaces first.** The Views tab gains the causes
   vector, occurrence identity, and the three-layer lifecycle grammar; dispatch
   surfaces gain event-site provenance; `:epoch-restore` renders where causes
-  render; warning families ride the issue surfaces. New panels come only after an
-  IA review shows an existing surface can't answer the question. Every trace
-  shape is a Spec 009 catalogue row first; every Xray PR updates `tools/xray/spec/*`.
+  render; warning families ride the issue surfaces. New panels come only after
+  an IA review shows an existing surface can't answer the question. Every trace
+  shape is a Spec 009 catalogue row first; every Xray change updates
+  `tools/xray/spec/*` in the same change.
 - **Story:** mounts scenes by **view id**; asserts on JVM structural trees +
-  app-db; sub-overrides via the observation-target protocol with `:owned? false`
-  honesty; JVM override injection is the explicit `ui.test/render` option — one
-  mechanism per host, both named.
-- **Pair:** hot-swap rides the existing nREPL HMR path; the five frozen read-only
-  projections (`view-manifest`, `mounted-views`, `explain-render`,
-  `view-dependencies`, `view-event-sites`) live in `re-frame.ui.tool` — the tool
-  tier, never the authoring namespace.
+  app-db; sub-overrides via the observation-target protocol with `:owned?
+  false` honesty; JVM override injection is the explicit `ui.test/render`
+  option — one mechanism per host, both named.
+- **Pair:** hot-swap rides the existing nREPL HMR path; the five frozen
+  read-only projections (`view-manifest`, `mounted-views`, `explain-render`,
+  `view-dependencies`, `view-event-sites`) live in `re-frame.ui.tool` — the
+  tool tier, never the authoring namespace.
 - **Epochs:** restore causes carry the operation token — the timeline stays
   truthful through time travel; history is never rewritten.
 
 ### Privacy and production erasure
 
 Manifests carry shapes and source, never live values; render values classify
-through their owning sub/schema; sensitive/large values redact per EP-0025 before
-off-box egress; histories are bounded with loss accounting; paths are
-project-relative. **Erasure is a proof:** compile-time defines + the G-7/G-11
-bundle-scan gates put manifests, cause vectors, histories, warning text, and
-`data-rf2-*` strings on the scanned absence roster; the always-on Spec 009
-error contracts (EP-0008) remain.
+through their owning sub/schema; sensitive/large values redact per EP-0025
+before off-box egress; histories are bounded with loss accounting; paths are
+project-relative. Occurrence keys, override values, and event payloads route
+through the one egress-projection policy (EP-0025). Sub query vectors
+deliberately do **not** route through the classification egress chokepoint:
+they are identity — the sub-cache key, the skip-dedup key, reactive-graph edge
+endpoints — and egress raw on every query-vector-bearing slot as an accepted,
+documented fail-open (the positional-event-args precedent); only the Spec 010
+schema-axis backstop whole-slot scrubs them, for `:sensitive?`-schema'd subs.
+**Erasure is a proof:** compile-time defines + the G-7/G-11 bundle-scan gates
+put manifests, cause vectors, histories, warning text, and `data-rf2-*` strings
+on the scanned absence roster; the always-on Spec 009 error contracts (EP-0008)
+remain.
+
+### Guide impact
+
+The substrate guide's debugging chapter teaches the glass cockpit; `docs/core`
+inherits it at promotion. No other human-facing guide change yet.
 
 ## Rationale
 
-Emit-at-cause-site over reconstruction is the load-bearing choice: reconstruction
-made legacy attribution fragile and silently degrades under concurrent rendering.
-Two layers keep the manifest useful before mount and the record truthful after
-it; the five-identity split prevents the conflations that made "which one
-re-rendered?" unanswerable. The honesty rules (`:owned? false`, bounded `:prop`
-precision, `:disconnected {:reason :unknown}`, loss accounting) trade apparent
-precision for provable truth — a tool that fabricates certainty is worse than one
-that says "unknown". Enrich-first keeps Xray's hardest-won asset — its
-information architecture — from dilution by panels bought before demand.
+Emit-at-cause-site over reconstruction is the load-bearing choice:
+reconstruction made legacy attribution fragile and silently degrades under
+concurrent rendering. Two layers keep the manifest useful before mount and the
+record truthful after it; the five-identity split prevents the conflations that
+made "which one re-rendered?" unanswerable. The honesty rules (`:owned?
+false`, bounded `:prop` precision, `:disconnected {:reason :unknown}`, loss
+accounting) trade apparent precision for provable truth — a tool that
+fabricates certainty is worse than one that says "unknown". Enrich-first keeps
+Xray's hardest-won asset — its information architecture — from dilution by
+panels bought before demand.
 
 ## Backwards Compatibility
 
 Pre-alpha; no shims. The legacy `[view-id instance-token]` `:render-key` wire
 shape and the cloneElement/post-render attribution path remain emitted by the
-coexisting adapters (`[TRANSITION]` in Spec 004); the compiled
-substrate emits its own versioned schema from day one, and its interim legacy attribution
-machinery is deleted once equivalent evidence is live (.95.7).
-
-## Bead Plan / Reference Implementation
-
-**[STATUS 2026-07-19]** All four items below are landed and closed
-(.95.6/.95.7/.95.8 on 2026-07-17; .95.10 via #6182; the S3 epic closed
-2026-07-18; S3 and S4 declared conforming). What the certification covered is
-recorded in the §Specification status note.
-
-S3 of the `re-frame.ui` plan (epic rf2-vxgfnd.95):
-
-1. **rf2-vxgfnd.95.6 — versioned view evidence + public `re-frame.ui.tool`
-   projections**: evidence schemas, occurrence/cause/lifecycle fields, loss
-   accounting, the five projections; carries the 2026-07-16 P1-5 amendment. Spec
-   009 catalogue rows precede all consumption (hot-zone — sequenced).
-2. **rf2-vxgfnd.95.7 — Xray consumption** (gated on .95.6): enrich existing
-   surfaces per the S3 IA; delete the legacy attribution path; update
-   `tools/xray/spec/*` atomically.
-3. **rf2-vxgfnd.95.8 — Story and Pair consumers** (gated on .95.6): view-id
-   mounting, honest overrides, the five projections over MCP, HMR-path hot swap.
-4. Conformance, cross-browser, and production-absence gates ride rf2-vxgfnd.95.10;
-   budget/absence completion asserts S6 per the Spec 004 ledger.
-
-Guide impact: the substrate guide's debugging chapter teaches the glass cockpit;
-`docs/core` inherits it at promotion. No other human-facing guide change yet.
+retained adapters (`[TRANSITION]` in Spec 004); the compiled substrate emits
+its own versioned schema from day one.
 
 ## Resolved Decisions
 
-- **Attribution at the cause site (rf2-6j0knp lineage) — ruled.** Evidence is
-  emitted where the cause happens, never reconstructed from React internals.
-- **`:prop` cause precision — ruled.** Changed top-level slots only; nested-path
-  deep diff is an on-demand dev view, never a default emit.
-- **Connection recorded as observed — ruled (name unified 2026-07-12).** Three
-  runtime states; hide/unmount are qualified retroactive annotations with named
+- **Attribution at the cause site — ruled.** Evidence is emitted where the
+  cause happens, never reconstructed from React internals.
+- **`:prop` cause precision — ruled.** Changed top-level slots only;
+  nested-path deep diff is an on-demand dev view, never a default emit.
+- **Connection recorded as observed (name unified 2026-07-12).** Three runtime
+  states; hide/unmount are qualified retroactive annotations with named
   proofs; GC inference explicitly approximate.
-- **P1-5 docs/slot projection — directed 2026-07-16 (EP-0035).** The dev/test
-  projection is a versioned public shape with per-prop docs/defaults and slot
-  metadata; render-slot sites join the site roster.
+- **P1-5 docs/slot projection (2026-07-16, EP-0035).** The dev/test projection
+  is a versioned public shape with per-prop docs/defaults and slot metadata;
+  render-slot sites join the site roster.
+- **One-catalogue scope qualified (2026-07-19).** The one-catalogue rule
+  covers runtime-tier ids only, matching Spec 004 §One catalogue (runtime
+  tier); compile-tier `:rf.ui.compile/*` ids live in the maintained compiler
+  roster and deliberately get no Spec 009 rows.
+- **Sub query vectors egress raw (2026-07-19, delegated).** Query vectors are
+  identity, not payload, and do not route through the EP-0025 egress
+  chokepoint; the raw egress on query-vector-bearing slots is an accepted,
+  documented fail-open, backstopped only by the Spec 010 schema axis for
+  `:sensitive?`-schema'd subs.
 
 ## Open Issues
 
-None open. One question is deferred with a named trigger: a Static-mode
-mounted-views/manifest-browse surface goes to the post-S3 IA review, triggered
-only if dogfooding shows the Views-tab + `mounted-views` assembly failing.
+1. The specified-but-unshipped evidence-schema delta (§Shipped surface and
+   specified extensions) has no stage assignment and no owner — the Spec 004
+   ledger row names only budget/absence gates for S6.
+2. Deferred with a named trigger: a Static-mode mounted-views/manifest-browse
+   surface goes to the post-S3 IA review, triggered only if dogfooding shows
+   the Views-tab + `mounted-views` assembly failing.
 
-## Recommendation
+Graduation: this EP moves to `final` when the full evidence schema asserts and
+the G-7/G-11 erasure gates complete (S6), residue as errata.
 
-Keep EP-0033 `accepted` while the S3 beads land; move to `final` when the Spec 004
-ledger rows assert (S3) and the G-7/G-11 gates complete (S6), residue as errata.
+## References
+
+- Primary normative home: [`spec/004-Views.md`](../../spec/004-Views.md) §View
+  identity and the instrumentation surface;
+  [`spec/009-Instrumentation.md`](../../spec/009-Instrumentation.md) (the
+  runtime-tier catalogue); [`spec/011-SSR.md`](../../spec/011-SSR.md) (root-id
+  lives with its root manifests); `spec/conformance/S3-view-conformance-profile.md`
+  (the certified S3 surface); `tools/xray/spec/021` (consumer tolerance of the
+  unshipped delta).
+- [EP-0030](EP-0030-the-compiled-view-substrate-program.md) — the umbrella:
+  stages, demand bar, and the blessed API surface this evidence tier
+  instruments.
+- [EP-0031](EP-0031-re-frame-ui-programming-model.md) — the compiler,
+  `defview`, templates, and handler law whose sites the manifest indexes.
+- [EP-0032](EP-0032-re-frame-ui-reactivity-and-ownership.md) — observation
+  targets and the committed push-ownership protocol; connected commit is the
+  publication boundary for instance records, and the three-state connection
+  lifecycle recorded here is that EP's observed-lifecycle contract.
+- [EP-0034](EP-0034-re-frame-ui-production-ssr-testing.md) — owns the SSR/roots
+  story; the `:hydration-correction` cause names its server/client/probe
+  disagreements; its G-7/G-11 gates prove this tier's production erasure.
+- [EP-0035](EP-0035-component-library-readiness.md) — the readiness amendment
+  package (render-slot manifest sites, the public docs/slot projection).
+- [EP-0008](EP-0008-production-observability-channels.md) — after erasure,
+  production keeps exactly the always-on error channel; this evidence is the
+  dev-only tier. [EP-0025](EP-0025-data-classification.md) — the
+  egress-projection policy the record slots route through.
+- Design provenance: the debugging study in the tombstoned synthesis tree
+  (`ai/findings/new-substrate-synthesis/`); the S3 Xray consumption IA lands
+  with W7a under `tools/xray/spec/`.

--- a/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
+++ b/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
@@ -2,212 +2,192 @@
 
 Status: accepted
 Type: standards-track
-
-> This EP decides **how the `re-frame.ui` substrate proves itself**: the production
-> posture (capability specialization + a bundle-scan-verified absence roster), the SSR
-> posture (one JVM structural tree consumed by the existing `re-frame2-ssr` artifact;
-> roots/manifests/hydration at S5), the testing posture (the `ui.test` pyramid,
-> `flush!` semantics, the 004D selector grammar, generative parity), and the gate
-> roster **G-1..G-18** that makes every claim falsifiable. Normative homes on
-> graduation: the Spec 004 rewrite's production/capability sections,
-> [`spec/004B-UI-Tree-and-Conversion.md`](../../spec/004B-UI-Tree-and-Conversion.md)
-> and [`spec/004D-UI-Test-Selectors.md`](../../spec/004D-UI-Test-Selectors.md) (both
-> already live — promoted with Stage 1), [`spec/008-Testing.md`](../../spec/008-Testing.md)
-> (the `ui.test` contract's eventual home), and [`spec/011-SSR.md`](../../spec/011-SSR.md)
-> (root manifests + hydration, S5). Each stage's spec edits merge **atomically with
-> that stage's conformance slice**. Ruled 2026-07-11; amended 2026-07-16 by the
-> directed component-library gates addition (see Resolved Decisions and EP-0035).
+Created: 2026-07-16
+Resolution: accepted 2026-07-11; component-library gates added 2026-07-16
 
 ## Abstract
 
-The substrate's product claims are not "faster React" — they are **absence, capability
-specialization, proven debug erasure, one honest server tree, and a testing surface
-that runs on the JVM in milliseconds**. This EP fixes the proof discipline: budgets
-are hypotheses with kill-gates (a missed budget means optimize or prune the feature —
-never weaken ownership or hydration semantics to make a number); absence is verified
-by bundle scan, never assumed from tree-shaking; SSR parity is normalized structural
-equivalence, never byte-identical HTML; every claim is owned by exactly one named gate
-in the G-1..G-18 roster.
+This EP decides **how the `re-frame.ui` substrate proves itself**. The
+substrate's product claims are not "faster React" — they are **absence,
+capability specialization, proven debug erasure, one honest server tree, and a
+testing surface that runs on the JVM in milliseconds**. The EP fixes the proof
+discipline: budgets are hypotheses with kill-gates (a missed budget means
+optimize or prune the feature — never weaken ownership or hydration semantics
+to make a number); absence is verified by bundle scan, never assumed from
+tree-shaking; SSR parity is normalized structural equivalence, never
+byte-identical HTML; every claim is owned by exactly one named gate in the
+G-1..G-18 roster.
+
+The normative homes are the Spec 004 rewrite's production/capability sections,
+[`spec/004B-UI-Tree-and-Conversion.md`](../../spec/004B-UI-Tree-and-Conversion.md)
+and [`spec/004D-UI-Test-Selectors.md`](../../spec/004D-UI-Test-Selectors.md)
+(both live), [`spec/008-Testing.md`](../../spec/008-Testing.md) (the `ui.test`
+contract's eventual home), and [`spec/011-SSR.md`](../../spec/011-SSR.md) (root
+manifests + hydration, S5). Each stage's spec edits merge **atomically with
+that stage's conformance slice**; per EP-0009, where this EP and the spec
+differ, the spec governs.
 
 ## Motivation
 
-A compiled view substrate makes strong claims that are cheap to state and easy to rot:
-"no hiccup interpreter ships", "the server renders what the browser renders", "debug
-machinery is erased from production". Without a decision record each degrades into
-faith — tree-shaking faith, jsdom faith, best-run-benchmark faith. The unresolved
-alternatives were real: byte-identical HTML vs structural equivalence; trusting
-`:advanced` elision vs scanning for exact absence; a second server product vs one JVM
-tree feeding the existing SSR artifact; a gesture-DSL browser story vs a headless-first
-pyramid; best-run estimators vs noise-robust ones (S-1 hit that trap concretely). One
-EP fixes these postures together because they share one enforcement mechanism — the
-gate roster and its stage-wiring rule.
-
-## Goals / Non-Goals
-
-**Goals:**
-
-- fix the production posture: capability specialization, the absence roster, packaging,
-  budgets-as-kill-gates, the scheduling stance;
-- fix the SSR posture: one analyzer, one emitter per build; the honest JVM subset;
-  roots vs frames;
-  root manifests, per-root hydration and failure isolation; explicit static-root
-  policy; the `client-only` phase flip;
-- fix the testing posture: the five-tier pyramid, the `ui.test` contract (`flush!`
-  semantics, the 004D selector grammar), Tier-3 fixtures, scoped generative parity;
-- fix the gate roster G-1..G-14 plus the 2026-07-16 gates G-15..G-18 and the widened
-  G-8, each with one owner and a wiring stage; record which gates are wired/green
-  today and which are named-open (stage honesty).
-
-**Non-Goals:**
-
-- the programming model, reactivity/ownership protocol, and debugging evidence layers
-  (sibling EPs — see Relationships);
-- pre-hydration event replay/resumability (research-tier post-alpha, hard graduation
-  criteria), RSC (the JVM SSR path is the canonical server story), and streaming sugar
-  (the tree emitter is chunkable; policy stays host-side per Spec 011);
-- a dev-bundle size budget (the production claim about debug machinery is *absence*);
-- any ongoing performance-parity promise for the coexisting Reagent/UIx compatibility
-  adapters (the comparison is a one-time S6 table, then an archive).
-
-## Relationships
-
-- **EP-0030** — the program umbrella (stages, demand bar, adapter disposition);
-  stage wiring and the one-time S6 adapter comparison follow its schedule.
-- **EP-0031** — the programming model (compiled `defview`, event-vector handlers,
-  capability grammar): 0031 promises, 0034 verifies.
-- **EP-0032** — reactivity and ownership (observation port, ViewCell, commit
-  algorithm); G-3/4/5/6/13 gate its economics here.
-- **EP-0033** — view evidence and debugging; its erasure obligation is enforced
-  here (G-7/G-11 and the debug roster).
-- **EP-0035** — component-library (re-com) readiness, the directed 2026-07-16 package;
-  G-15..G-18, the widened G-8, and the proof pack originate there.
-- **Specs 008, 011, 004B, 004D** — the graduated homes named in the preamble; 004B/004D
-  are live now, 008 and 011 receive their sections with their stages.
-- **Methodology provenance** — the synthesis drafts `g10-bundle-baseline-methodology.md`
-  and `w11-runtime-benchmark-methodology.md` write down the G-10/W11 methodologies and
-  bind their gates at S6.
+A compiled view substrate makes strong claims that are cheap to state and easy
+to rot: "no hiccup interpreter ships", "the server renders what the browser
+renders", "debug machinery is erased from production". Without a decision
+record each degrades into faith — tree-shaking faith, jsdom faith,
+best-run-benchmark faith. The unresolved alternatives were real: byte-identical
+HTML vs structural equivalence; trusting `:advanced` elision vs scanning for
+exact absence; a second server product vs one JVM tree feeding the existing SSR
+artifact; a gesture-DSL browser story vs a headless-first pyramid; best-run
+estimators vs noise-robust ones (the codegen spike hit that trap concretely).
+One EP fixes these postures together because they share one enforcement
+mechanism — the gate roster and its stage-wiring rule.
 
 ## Specification
 
+**Scope.** This EP fixes the production posture (capability specialization, the
+absence roster, packaging, budgets-as-kill-gates, the scheduling stance); the
+SSR posture (one analyzer, one emitter per build; the honest JVM subset; roots
+vs frames; root manifests, per-root hydration and failure isolation; explicit
+static-root policy; the `client-only` phase flip); the testing posture (the
+five-tier pyramid, the `ui.test` contract, Tier-3 fixtures, scoped generative
+parity); and the gate roster G-1..G-18, each gate with one owner and a wiring
+stage. It does not own the programming model, the reactivity/ownership
+protocol, or the debugging evidence layers (sibling EPs — see References);
+pre-hydration event replay/resumability stays research-tier post-alpha with
+hard graduation criteria; RSC is out (the JVM SSR path is the canonical server
+story); streaming sugar is out (the tree emitter is chunkable; policy stays
+host-side per Spec 011); there is no dev-bundle size budget (the production
+claim about debug machinery is *absence*); and there is no ongoing
+performance-parity promise for the retained Reagent/UIx/reagent-slim adapters
+(the comparison is a one-time S6 table, then an archive).
+
 ### 1. Production: specialization and the absence roster
 
-Production components carry exactly the machinery their capability bits imply — the
-closed vocabulary (`sub · local · effect · event-sites · lease · frame-scope · presence
-· error-boundary · portal · client-only · trusted-html · custom-element · foreign-react
-· dynamic-view · ui-event/handler · debug-site`) covers every feature that changes
-generated code, hydration, ownership, or server behavior. The honest costs are stated:
-an event-only view still pays a small commit step; "no handler allocation" is scoped to
-the compiled vector path; "no wrapper components" is scoped to incidental wrappers;
-memo suppresses *prop-driven* repaints only.
+Production components carry exactly the machinery their capability bits imply —
+the closed vocabulary (`sub · local · effect · event-sites · lease ·
+frame-scope · presence · error-boundary · portal · client-only · trusted-html ·
+custom-element · foreign-react · dynamic-view · ui-event/handler · debug-site`)
+covers every feature that changes generated code, hydration, ownership, or
+server behavior. The honest costs are stated: an event-only view still pays a
+small commit step; "no handler allocation" is scoped to the compiled vector
+path; "no wrapper components" is scoped to incidental wrappers; memo suppresses
+*prop-driven* repaints only.
 
-**The absence roster is bundle-scan-verified, never tree-shaking faith:** no hiccup
-walker, tag parser, generic camelizer, sequence flattener, form detection, second
-scheduler, per-sub hook scaffolding, compatibility stubs, source-coord walkers; no
-manifests, cause vectors, histories, timings, warning text, `data-rf2-*` strings,
-project paths; no schema engines when elided; **no JVM renderer in any browser entry**;
-no proxy/signal/atom/query-cache runtimes. Debug erasure is a proof: advanced builds
-are scanned for exact absence (G-11), and dev/prod behavioral equivalence is gated per
-generated shape + pairwise capabilities + high-risk triples (G-7) — full powersets are
-not a practical gate. Ordinary view registration is **already `goog.DEBUG`-gated in the
-emitter** (the registration branch of `compiler/emit_cljs.cljc` — the production arm
-is a direct `React.memo` with no registry); G-18 is fixture-first, and a new elision
-mode or packaging change is justified only if that fixture fails structurally.
+**The absence roster is bundle-scan-verified, never tree-shaking faith:** no
+hiccup walker, tag parser, generic camelizer, sequence flattener, form
+detection, second scheduler, per-sub hook scaffolding, compatibility stubs,
+source-coord walkers; no manifests, cause vectors, histories, timings, warning
+text, `data-rf2-*` strings, project paths; no schema engines when elided; **no
+JVM renderer in any browser entry**; no proxy/signal/atom/query-cache runtimes.
+Debug erasure is a proof: advanced builds are scanned for exact absence (G-11),
+and dev/prod behavioral equivalence is gated per generated shape + pairwise
+capabilities + high-risk triples (G-7) — full powersets are not a practical
+gate. Ordinary view registration is **already `goog.DEBUG`-gated in the
+emitter** (the registration branch of `compiler/emit_cljs.cljc` — the
+production arm is a direct `React.memo` with no registry); G-18 is
+fixture-first, and a new elision mode or packaging change is justified only if
+that fixture fails structurally.
 
-Packaging: the UI source artifact is `.cljc` (compiler + both emitters as source); the
-browser build never reaches JVM-renderer namespaces (scan-gated); `re-frame2-ssr`
-consumes the JVM emitter — no second server product. Dependencies: re-frame2 core +
-patched React/React DOM 19.2.4+ peers; no Reagent/UIx/Helix/slim anywhere in the graph
-(G-12, Maven/npm level). Budgets are kill-gate hypotheses: kernel ≤ 4 KB gz over React;
-counter ≤ React + 6 KB gz; relative targets vs UIx-adapter and reagent-slim baselines
-with symbol-reachability evidence when chunk subtraction is noisy. Scheduling: no
-`startTransition`, no per-sub priorities, no second render queue — exact work reduction
-plus the one sanctioned synchronous door for controlled inputs; `flush-render!` is for
-deterministic tooling, not applications.
+Packaging: the UI source artifact is `.cljc` (compiler + both emitters as
+source); the browser build never reaches JVM-renderer namespaces (scan-gated);
+`re-frame2-ssr` consumes the JVM emitter — no second server product.
+Dependencies: re-frame2 core + patched React/React DOM 19.2.4+ peers; no
+Reagent/UIx/Helix/slim anywhere in the graph (G-12, Maven/npm level). Budgets
+are kill-gate hypotheses: kernel ≤ 4 KB gz over React; counter ≤ React + 6 KB
+gz; relative targets vs UIx-adapter and reagent-slim baselines with
+symbol-reachability evidence when chunk subtraction is noisy. Scheduling: no
+`startTransition`, no per-sub priorities, no second render queue — exact work
+reduction plus the one sanctioned synchronous door for controlled inputs;
+`flush-render!` is for deterministic tooling, not applications.
 
 ### 2. SSR: one JVM structural tree
 
-`defview` is `.cljc`: each host build runs the shared analyzer and hands that build's own
-AST to exactly one emitter — CLJS → direct JSX; JVM → the canonical serializable render
-tree consumed by `re-frame2-ssr`. The hosts never meet as ASTs. One contextual
-conversion/escaping rule table serves both emitters, and parity **detects** divergence
-between them rather than preventing it. **Parity is normalized structural
-equivalence over semantic nodes** (tag/ns, attr names+values, child order, escaping,
-keyed order, void/boolean, fragments, fallbacks), fingerprinted and generatively tested
-— **byte-identical HTML is not the contract**, consistent with Spec 011's canonical
-hydration-equivalence rule. The JVM subset is honest and closed: structure, props,
-subs, branches, lists, event intent, and `ui/html` carry full semantics; `local`
-contributes its initial value (invoking the setter is a typed error); `effect` is
-recorded, not run; refs are absent; `portal`/`client-only` render explicit
-deterministic fallbacks; `error-boundary` is server failure policy per Spec 011;
-`presence` renders `:present`.
+`defview` is `.cljc`: each host build runs the shared analyzer and hands that
+build's own AST to exactly one emitter — CLJS → direct JSX; JVM → the canonical
+serializable render tree consumed by `re-frame2-ssr`. The hosts never meet as
+ASTs. One contextual conversion/escaping rule table serves both emitters, and
+parity **detects** divergence between them rather than preventing it. **Parity
+is normalized structural equivalence over semantic nodes** (tag/ns, attr
+names+values, child order, escaping, keyed order, void/boolean, fragments,
+fallbacks), fingerprinted and generatively tested — **byte-identical HTML is
+not the contract**, consistent with Spec 011's canonical hydration-equivalence
+rule. The JVM subset is honest and closed: structure, props, subs, branches,
+lists, event intent, and `ui/html` carry full semantics; `local` contributes
+its initial value (invoking the setter is a typed error); `effect` is recorded,
+not run; refs are absent; `portal`/`client-only` render explicit deterministic
+fallbacks; `error-boundary` is server failure policy per Spec 011; `presence`
+renders `:present`.
 
-**A React hydration root is not a re-frame2 frame** — roots (DOM/render units) and
-frames (state worlds) are distinct, many-to-many identities; "island" is not
-vocabulary. Each independently hydratable unit ships a root manifest (root id, element
-locator, view id, props, frame-payload ids, render fingerprint, build digest,
-identifier prefix, phase); mount position is never identity; duplicate root ids are a
-build error; frame payloads install idempotently and order-independently. Hydration
-per root: validate digest + fingerprint → install payloads → `hydrate-root` → one root
-**phase flip** swaps `client-only` fallbacks in a single update → first connected
-commits acquire ownership. Failure scopes are precise (a mismatch fails that root; a
-bad payload affects exactly its referencing roots); no `suppressHydrationWarning`-style
-escape exists. Static roots are explicit policy — compiler proof of no client
-capability **and** a host declaration; "no subs, no handlers" never silently strips a
-runtime. Event vectors are retained as data in the manifest and the JVM tree;
-pre-hydration replay stays research-tier (Non-Goals).
+**A React hydration root is not a re-frame2 frame** — roots (DOM/render units)
+and frames (state worlds) are distinct, many-to-many identities; "island" is
+not vocabulary. Each independently hydratable unit ships a root manifest (root
+id, element locator, view id, props, frame-payload ids, render fingerprint,
+build digest, identifier prefix, phase); mount position is never identity;
+duplicate root ids are a build error; frame payloads install idempotently and
+order-independently. Hydration per root: validate digest + fingerprint →
+install payloads → `hydrate-root` → one root **phase flip** swaps `client-only`
+fallbacks in a single update → first connected commits acquire ownership.
+Failure scopes are precise (a mismatch fails that root; a bad payload affects
+exactly its referencing roots); no `suppressHydrationWarning`-style escape
+exists. Static roots are explicit policy — compiler proof of no client
+capability **and** a host declaration; "no subs, no handlers" never silently
+strips a runtime. Event vectors are retained as data in the manifest and the
+JVM tree; pre-hydration replay stays research-tier (see Scope).
 
 ### 3. Testing: the pyramid and `ui.test`
 
-Five tiers: **1** headless view tests (structural tree + event-vector intent; JVM and
-node; milliseconds, no DOM) · **2** pure dataflow (unchanged re-frame2) · **3** mounted
-contract fixtures against real React · **4** Story variants (CLJS-unit-test shape per
-repo ruling) · **5** the gates. One namespace, `re-frame.ui.test`: `render` (real view
-against a real frame on the JVM → structural tree; `{:sub-overrides …}` is the explicit
-JVM override door, not pretended to be the CLJS context mechanism), `find`/`find-all`
-(Tier-1 structural queries under the **closed 004D grammar** — tag keyword, view-id/Var,
-attr-map matched by `rf=`, predicate escape; no positional combinators; a vector
-selector raises `:rf.error/ui-test-bad-selector` naming the composed-`find` idiom),
-`query` (the Tier-3 live-DOM counterpart), `text`/`attrs`, `dispatch!` (real dispatch +
-drain), `with-root` (CLJS Promise; awaited mount, body, and total teardown), and
-`flush!` — the sole public test flush: on CLJS a Promise running the optional thunk
-inside React 19 `act`, letting the update and commit phases reach **drain quiescence**, then
+Five tiers: **1** headless view tests (structural tree + event-vector intent;
+JVM and node; milliseconds, no DOM) · **2** pure dataflow (unchanged re-frame2)
+· **3** mounted contract fixtures against real React · **4** Story variants
+(CLJS-unit-test shape per repo ruling) · **5** the gates. One namespace,
+`re-frame.ui.test`: `render` (real view against a real frame on the JVM →
+structural tree; `{:sub-overrides …}` is the explicit JVM override door, not
+pretended to be the CLJS context mechanism), `find`/`find-all` (Tier-1
+structural queries under the **closed 004D grammar** — tag keyword, view-id/Var,
+attr-map matched by `rf=`, predicate escape; no positional combinators; a
+vector selector raises `:rf.error/ui-test-bad-selector` naming the
+composed-`find` idiom), `query` (the Tier-3 live-DOM counterpart),
+`text`/`attrs`, `dispatch!` (real dispatch + drain), `with-root` (CLJS Promise;
+awaited mount, body, and total teardown), and `flush!` — the sole public test
+flush: on CLJS a Promise running the optional thunk inside React 19 `act`,
+letting the update and commit phases reach **drain quiescence**, then
 alternating framework drains and React commits to a fixed point; on the JVM a
-synchronous drain of the headless ViewCell registry. The open-drain guard throws
-`:rf.error/flush-in-open-epoch`; a forgotten await fails loudly with
-`:rf.error/ui-test-overlapping-act`; there is no production `ui/flush!`. There is
-deliberately **no frame constructor in `ui.test`** (ruled 2026-07-14): one
-initialization grammar — `rf/make-frame` + `:initial-events` with `[:rf/set-db …]`.
-Tier 1 requires the events/subs a view touches to be `.cljc` — a taught authoring
-constraint. JVM semantics under test follow the SSR subset; setter or effect use in
-Tier 1 is a typed error pointing at Tier 3. The Tier-3 fixture matrix turns the
-ownership walkthrough into tests (abandoned mounts, commit-gap correction,
-StrictMode/Activity, frame swap, hydration races, HMR, presence, the sync door, the
-interop set, Promise-boundary semantics).
+synchronous drain of the headless ViewCell registry. The open-drain guard
+throws `:rf.error/flush-in-open-epoch`; a forgotten await fails loudly with
+`:rf.error/ui-test-overlapping-act`; there is no production `ui/flush!`. There
+is deliberately **no frame constructor in `ui.test`** (ruled): one
+initialization grammar — `rf/make-frame` + `:initial-events` with `[:rf/set-db
+…]`. Tier 1 requires the events/subs a view touches to be `.cljc` — a taught
+authoring constraint. JVM semantics under test follow the SSR subset; setter or
+effect use in Tier 1 is a typed error pointing at Tier 3. The Tier-3 fixture
+matrix turns the ownership walkthrough into tests (abandoned mounts, commit-gap
+correction, StrictMode/Activity, frame swap, hydration races, HMR, presence,
+the sync door, the interop set, Promise-boundary semantics).
 
-**Generative parity is scoped:** props schemas generate props — they cannot generate
-an app-db satisfying arbitrary subs, so apps supply state generators/fixtures (a
-one-liner around `rf/make-frame`). With inputs supplied: JVM tree vs CLJS
-server-equivalent compare as normalized semantic nodes; memo invariants (`rf=` props ⇒
-no prop-driven re-render, identical output); value-stabilization invariants (equal
-results ⇒ identical references). Fingerprints pin build identity; the corpus doubles
-as the hydration-parity suite, including multi-root failure isolation.
+**Generative parity is scoped:** props schemas generate props — they cannot
+generate an app-db satisfying arbitrary subs, so apps supply state
+generators/fixtures (a one-liner around `rf/make-frame`). With inputs supplied:
+JVM tree vs CLJS server-equivalent compare as normalized semantic nodes; memo
+invariants (`rf=` props ⇒ no prop-driven re-render, identical output);
+value-stabilization invariants (equal results ⇒ identical references).
+Fingerprints pin build identity; the corpus doubles as the hydration-parity
+suite, including multi-root failure isolation.
 
 ### 4. The gate roster (one line per gate)
 
-This table is the roster of record — G-1..G-18 as ruled here, including the
-2026-07-16 additions. The synthesis dossier's earlier roster (`07-testing.md` §5)
-is its predecessor, not its source: where the two differ, this table governs.
+This table is the roster of record — G-1..G-18 as ruled, including the
+component-library additions (EP-0035). Where any earlier roster differs, this
+table governs.
 
 | Gate | Asserts |
 |---|---|
-| **G-1** direct-render parity | pure view within 10% of hand-written JSX CLJS (p50/p95) under the noise-robust estimator, plus an emitted-JS golden test pinning direct `jsx` calls (S-1's IFn-dispatch trap) |
+| **G-1** direct-render parity | pure view within 10% of hand-written JSX CLJS (p50/p95) under the noise-robust estimator, plus an emitted-JS golden test pinning direct `jsx` calls (the IFn-dispatch trap) |
 | **G-2** AOT peer | ≥ UIx-AOT parity on pure views; reactive one-read ≤ 15% update-p95 over raw correct `useSyncExternalStore` |
 | **G-3** multi-read scaling | one store listener and one body invocation per ViewCell; independent lexical-site leases; at most one notification per dirty cell; queued writes settle before one read/render batch at the following host checkpoint |
 | **G-4** equality no-op | `rf=` results ⇒ zero revisions, zero prop/sub-driven renders, stable references |
 | **G-5** drain fan-in | eight queued update+commit epochs all execute in one run-to-completion drain and share exactly **one** read/render batch at the following host checkpoint — a drain is never split across batches; coalescing never drops writes; epoch count is never evidence of render/commit count |
 | **G-6** abandonment/disposal | 10k headless abandoned renders/cold probes and bounded mounted StrictMode/Activity cycles return every ownership surface to exact baseline |
 | **G-7** dev/prod equivalence | per generated shape + pairwise capabilities + high-risk triples: committed DOM/events/owners/cleanup/hydration agree, debug off |
-| **G-8** input correctness (hard) & latency evidence (widened 2026-07-16) | **Hard gate:** in real Chromium **and** WebKit — pre-paint synchronous commit under the sync door, ordering, caret restoration, IME composition, exactly one attributable React commit per ordinary input and exactly one at the committed IME boundary, with the deliberate async-door regression as the tooth; the matrix runs through a **reusable event-prefix component** (`ui/event` vector-outcome door) — toy literal fixtures alone do not close it. **Evidence only:** event→commit p95 against an equivalent hand-written React control in the same warmed run — the ratio, the 10% reference-budget observation, the sample count and the noise policy are recorded and reported; no wall-clock number gates (G-13's posture). An over-budget observation informs `rf2-dpwel`, it never fails G-8 |
+| **G-8** input correctness (hard) and latency evidence | **Hard gate:** in real Chromium **and** WebKit — pre-paint synchronous commit under the sync door, ordering, caret restoration, IME composition, exactly one attributable React commit per ordinary input and exactly one at the committed IME boundary, with the deliberate async-door regression as the tooth; the matrix runs through a **reusable event-prefix component** (`ui/event` vector-outcome door) — toy literal fixtures alone do not close it. **Evidence only:** event→commit p95 against an equivalent hand-written React control in the same warmed run — the ratio, the 10% reference-budget observation, the sample count and the noise policy are recorded and reported; no wall-clock number gates (G-13's posture), and an over-budget observation feeds performance follow-up, never a G-8 failure |
 | **G-9** list updates | keyed 1k rows: one entity change renders its row + true dependents; stable handler identity; no retained lazy seqs |
 | **G-10** bundle | kernel ≤ 4 KB gz; counter ≤ React + 6 KB gz; relative targets vs UIx-adapter/slim with symbol-reachability escalation (methodology: pinned three-module splits, per-module measurement, N=3 determinism, checked-in EDN baseline, ratio + floor + slope guard) |
 | **G-11** elision | exact absence of the debug + absence rosters, including `re-frame.ui.test` and its React-`act` boundary, from advanced production bundles |
@@ -219,133 +199,162 @@ is its predecessor, not its source: where the two differ, this table governs.
 | **G-17** safe-spread ownership | the policy form rejects owned keys (`:key` `:ref` `:value` `:checked` owned `:on-*`) in dev **and** advanced builds; `aria-*`/`data-*` pass; the policy form retains the sync door where general `spread` forfeits it |
 | **G-18** library façade isolation | an advanced build importing one view from a multi-view library namespace retains no unused sibling views, schemas, docs projections, or dev registration (fixture-first; see §1) |
 
-Methodology, binding on every gate: identical fixtures, distributions not best runs,
-pinned browsers, cold+warm, dev overhead separate, no precomputed-props cheating. The
-component-library **proof pack** (controlled input, selection controller, slotted list
-cell, safe-attrs form control, schema-described component, inline popover, single-view
-import) lands in the conformance/parity corpus as the rolling consumer; the substrate
-takes no build dependency on re-com.
+Methodology, binding on every gate: identical fixtures, distributions not best
+runs, pinned browsers, cold+warm, dev overhead separate, no precomputed-props
+cheating. The component-library **proof pack** (controlled input, selection
+controller, slotted list cell, safe-attrs form control, schema-described
+component, inline popover, single-view import) lands in the conformance/parity
+corpus as the rolling consumer; the substrate takes no build dependency on
+re-com.
 
-### 5. Stage honesty — wired/green vs named-open
+### 5. Gate wiring status
 
-Every stage wires its own gates into CI in that stage, never later. As of 2026-07-19:
-**wired and green** — G-1 (S1, complete; `npm run test:ui-g1` under the noise-robust
-estimator, as CI job `cljs-ui-g1`); **two of G-14's three arms** —
-`g14_compile_budget_jvm_test.clj` expands three fixture sizes against a 50 ms
-pathology bar (`defview` expansion p95) **and** measures the watch-loop rebuild delta
-over an 11-view dashboard-shaped roster against a derived absolute bar (K × the
-per-view pathology bar), both in CI job `jvm-ui` alongside the REPL re-registration
-story. The rebuild arm proves the measured pass actually rebuilt the roster — K
-realisations, K **distinct** template fingerprints, all forced inside the timed span —
-before any duration is compared, so a shrunken, collapsed, or lazily-deferred pass
-cannot report "cheap". Its limit is stated rather than implied: at this roster size the
-absolute bar catches a runaway rebuild but does **not** separate a strictly quadratic
-pass, which needs a namespace-scale roster or a scaling ratio across two roster sizes
-(the suite carries the arithmetic). G-14's third arm is named open below, so G-14 is
-**not** complete at S1; the S2 family
-G-3/G-4/G-5/G-6/G-13 (landed with the S2 slice; S2 core verified
-S3-ready under the rf2-vxgfnd.22 boundary review — the real-sub-cache graft
-conformance the S-3 spike left open was implemented and proved by S2a
-(`rf2-vxgfnd.7`, PR #5706), and the .22 review subsequently reviewed and
-accepted it); the G-8 real-browser matrix **including**
-its widened event-prefix arm — `npm run test:ui-g8` runs as CI job `cljs-ui-g8` on the
-`ui_gates` surface in real Chromium **and** WebKit, superseding S-5's jsdom-only
-evidence; G-11 (`npm run test:browser-prod-elision`, CI job
-`cljs-browser-prod-elision`, plus the absence scan `npm run test:ui-g1` carries); the
-G-15 atomic-local writer matrix (`npm run test:browser`); G-12 (`npm run
-test:ui-isolation`, which fails closed unless both arms run); and G-18 (`npm run
-test:ui-facade-isolation`, CI job `cljs-ui-facade-isolation`), whose single-view
-isolation assertion went green with the #6195 DCE packaging repair and which
-`rf2-kxork` promoted into the required matrix — its roster of proven views is
-derived from the proof-pack library source (`rf2-r4q98`, closed by #6414), so a
-new library view either arms the gate or fails it. **Named open** — G-7
-beyond its production-absence arm: the dev↔prod equivalence matrix over generated
-shapes has no test yet; G-14's **remaining** arm — bounded guide-fixtures CI cost,
-which needs the guide-examples corpus (its wall-clock budget is an S3 stage item) —
-which has no assertion anywhere in the repository, as the gate's own suite states;
-G-16's "manifest slot sites present" arm (its cross-emitter
-parity and slot-arity arms do run); G-2/G-9 (wire with the stages shipping
-their subjects); root-manifest hydration + failed-root isolation (S5 — the S-4 spike
-passed dual-host structural output only); G-10 and the remaining
-absence/equivalence/budget gates plus the one-time W11 trio table (S6). S3 closed
-2026-07-18, and S4 (`rf2-vxgfnd.96`) closed and was declared conforming. The stages
-after S4 ride their own epics — S5 `rf2-vxgfnd.97`, S6 `rf2-vxgfnd.98`, S7
-`rf2-vxgfnd.99`; for a stage still in flight the epic is the state, not this page.
+Every stage wires its own gates into CI in that stage, never later; a
+feasibility PASS never silently closes a named-open gate. S1–S4 are complete;
+the stages ahead follow
+[EP-0030 §Stages S1–S7](EP-0030-the-compiled-view-substrate-program.md#stages-s1s7).
+
+**Wired and green:**
+
+- **G-1** (`npm run test:ui-g1`, under the noise-robust estimator, with the
+  emitted-JS golden and the absence scan it carries).
+- **Two of G-14's three arms**, in the JVM suite: `defview` expansion p95
+  against a 50 ms pathology bar over three fixture sizes, and the watch-loop
+  rebuild delta over an 11-view dashboard-shaped roster against a derived
+  absolute bar (K × the per-view pathology bar). The rebuild arm proves the
+  measured pass actually rebuilt the roster — K realisations, K **distinct**
+  template fingerprints, all forced inside the timed span — before any duration
+  is compared, so a shrunken, collapsed, or lazily-deferred pass cannot report
+  "cheap". Its limit is stated rather than implied: at this roster size the
+  absolute bar catches a runaway rebuild but does **not** separate a strictly
+  quadratic pass, which needs a namespace-scale roster or a scaling ratio
+  across two roster sizes (the suite carries the arithmetic).
+- **The S2 family G-3/G-4/G-5/G-6/G-13**, landed with the S2 slice over the
+  real sub-cache.
+- **G-8**, including its widened event-prefix arm (`npm run test:ui-g8`, in
+  real Chromium **and** WebKit — superseding the input-synchrony spike's
+  jsdom-only evidence).
+- **G-11** (`npm run test:browser-prod-elision`, plus the absence scan G-1
+  carries).
+- **G-15**, the atomic-local writer matrix (`npm run test:browser`).
+- **G-12** (`npm run test:ui-isolation`, which fails closed unless both arms
+  run).
+- **G-18** (`npm run test:ui-facade-isolation`, a standing required CI job);
+  its roster of proven views is derived from the proof-pack library source, so
+  a new library view either arms the gate or fails it.
+
+**Named open:**
+
+- **G-7** beyond its production-absence arm: the dev↔prod equivalence matrix
+  over generated shapes has no test yet.
+- **G-14's remaining arm** — bounded guide-fixtures CI cost, which needs the
+  guide-examples corpus and has no assertion anywhere in the repository, as the
+  gate's own suite states.
+- **G-16's** "manifest slot sites present" arm (its cross-emitter parity and
+  slot-arity arms do run).
+- **G-2/G-9** — wire with the stages shipping their subjects.
+- Root-manifest hydration + failed-root isolation (S5 — the dual-host spike
+  passed structural output only).
+- **G-10** and the remaining absence/equivalence/budget gates, plus the
+  one-time W11 trio table (S6).
+
+### Guide impact
+
+Guide 08 (SSR/hydration), 09 (testing/debugging), and 10 (performance) teach
+these postures. The guide-fixtures corpus is itself a test surface — every
+example compiles and runs as a fixture; one needing internals explained is an
+API defect.
 
 ## Rationale
 
-One roster, one owner per claim: conflating axes lets one excuse the other (bundle
-bytes vs runtime speed; correctness vs latency), so G-10 refuses runtime questions and
-W11 refuses correctness ones. Structural equivalence over byte-identical HTML follows
-Spec 011's existing lock — serializers legitimately differ; the contract is the
-computed view. Headless-first testing follows from the design's three structural facts
-(views are pure AST→output functions; handlers are data; ownership begins only at
-commit) — the browser is reserved for what only the browser can prove. G-13's framing
-matters most: it exists to *falsify* the committed push economics, and failure reopens
-the design rather than toggling a fork — the roster is honesty, not marketing.
+One roster, one owner per claim: conflating axes lets one excuse the other
+(bundle bytes vs runtime speed; correctness vs latency), so G-10 refuses
+runtime questions and W11 refuses correctness ones. Structural equivalence over
+byte-identical HTML follows Spec 011's existing lock — serializers legitimately
+differ; the contract is the computed view. Headless-first testing follows from
+the design's three structural facts (views are pure AST→output functions;
+handlers are data; ownership begins only at commit) — the browser is reserved
+for what only the browser can prove. G-13's framing matters most: it exists to
+*falsify* the committed push economics, and failure reopens the design rather
+than toggling a fork — the roster is honesty, not marketing. Two disciplines
+give the roster its value: budgets stay kill-gates (miss ⇒ optimize or prune,
+never weaken semantics), and gate status stays explicit (a feasibility PASS
+never silently closes a named-open gate).
 
 ## Backwards Compatibility
 
-Pre-alpha; no back-compat shims. The legacy shared-adapter parity
-matrix collapses into **four** named causal suites (W9): new-UI conformance +
-smoke, and Reagent, UIx, and reagent-slim compatibility suites + one smoke
-each; only the Helix arm retires, at S7. *(Corrected 2026-07-19: an earlier
-revision counted three owners with reagent-slim merely "kept" — EP-0030's ruled
-W9 end state is four suites, reagent-slim first-class.)* The coexisting
-adapters keep a pinned correctness contract —
-a distinct compiled substrate makes no automatic parity promise.
-Spec 008's adapter-era testing surface (`flush-views!`, `re-frame.test-helpers`) keeps
-governing the compatibility tier until the `ui.test` contract graduates into 008.
-
-## Bead Plan / Reference Implementation
-
-Carried by the program epic's stage children ([EP-0030 §Bead Plan](EP-0030-the-compiled-view-substrate-program.md#bead-plan--reference-implementation)): **S1/S2 (done)** — `ui.test`
-Tier-1 core, selector grammar (004D live), tree contract (004B live), G-1/G-14 then
-G-3/4/5/6/13 wired. **S3** — elision gates G-7/G-11; G-8 including the widened arm;
-G-15..G-18 + the proof pack. **S5** — root manifests, multi-root hydration, failure
-isolation, `render-static`, the `client-only` phase flip; Spec 011 edits sequenced
-behind any in-flight Spec-011 PR (hot zone). **S6** — G-10/G-12 and residual budget
-gates; the one-time G-10/W11 comparison tables + archive tag before the S7 Helix-removal
-wave. Guide-impact assessment: guide 08 (SSR/hydration), 09 (testing/debugging), and 10
-(performance) teach these postures; the guide-fixtures corpus is itself a test surface
-— every example compiles and runs as a fixture; one needing internals explained is an
-API defect.
+Pre-alpha; no back-compat shims. The legacy shared-adapter parity matrix
+collapses into **four** named causal suites (W9): new-UI conformance + smoke,
+and Reagent, UIx, and reagent-slim compatibility suites plus one smoke each;
+only the Helix arm retires, at S7. The retained adapters keep a pinned
+correctness contract — a distinct compiled substrate makes no automatic parity
+promise. Spec 008's adapter-era testing surface (`flush-views!`,
+`re-frame.test-helpers`) keeps governing the compatibility tier until the
+`ui.test` contract graduates into 008.
 
 ## Resolved Decisions
 
-
-- **Head ownership ([004 §The document head is host-owned](../../spec/004-Views.md#the-document-head-is-host-owned)).** re-frame2's existing head model is the one owner of
-  document-head output; substrate views never hoist metadata through React's
-  head/resource mechanisms, and a foreign head is an explicit interop boundary. S4
-  hardens head policy; the ruling itself is settled here.
-- **G-1 estimator (ruled).** The gate uses a noise-robust estimator — alternating
-  interleaved rounds, median-of-rounds — because µs-scale p95 is environment-dominated
-  (S-1-measured). The S-1 PASS predated the ruling; the rerun under the revised
-  estimator was executed and wired at S1f (`rf2-vxgfnd.6`, closed 2026-07-12 —
-  `npm run test:ui-g1`, all components within the 1.10 budget, emitted-JS golden
-  84 direct calls / 0 IFn traps). The source dossier's G-1 row (`07-testing.md` §5)
-  predates that close and reads stale; this EP records the current state.
-  Companion ruling: an **emitted-JS golden test** pins direct `jsx` calls — a
-  CLJS-var-bound jsx fn silently reintroduces IFn dispatch under `:advanced` (~5–8%,
-  S-1's trap).
+- **Head ownership
+  ([004 §The document head is host-owned](../../spec/004-Views.md#the-document-head-is-host-owned)).**
+  re-frame2's existing head model is the one owner of document-head output;
+  substrate views never hoist metadata through React's head/resource
+  mechanisms, and a foreign head is an explicit interop boundary. S4 hardened
+  head policy; the ruling itself is settled here.
+- **G-1 estimator (ruled).** The gate uses a noise-robust estimator —
+  alternating interleaved rounds, median-of-rounds — because µs-scale p95 is
+  environment-dominated (spike-measured). Companion ruling: an **emitted-JS
+  golden test** pins direct `jsx` calls — a CLJS-var-bound jsx fn silently
+  reintroduces IFn dispatch under `:advanced` (~5–8%, the spike's trap).
 - **Byte-identical HTML is NOT the contract (ruled).** Dual-emitter parity is
-  normalized structural equivalence over semantic nodes, fingerprinted and generatively
-  tested — consistent with Spec 011's canonical hydration-equivalence rule.
-- **Host-checkpoint render batching is the G-5/G-13 subject (ruled).** Every queued epoch
-  executes; the batch closes at the host's next microtask checkpoint (or an explicit
-  test flush), never at drain finalization — so a drain's epochs always share one
-  read/render batch, and drains reaching the same checkpoint may share one. Epoch count
-  alone is never evidence for render or commit count. G-13 falsifies the committed
-  economics; failure reopens the design.
-- **Component-library gates addition (directed, 2026-07-16).** G-15..G-18, the widened
-  G-8 arm, and the proof pack join the roster per the re-com readiness package
-  (EP-0035); they wire with their S3 features under the every-stage-wires-its-gates
-  rule. G-18 is fixture-first — the registration branch is already `goog.DEBUG`-gated.
+  normalized structural equivalence over semantic nodes, fingerprinted and
+  generatively tested — consistent with Spec 011's canonical
+  hydration-equivalence rule.
+- **Host-checkpoint render batching is the G-5/G-13 subject (ruled).** Every
+  queued epoch executes; the batch closes at the host's next microtask
+  checkpoint (or an explicit test flush), never at drain finalization — so a
+  drain's epochs always share one read/render batch, and drains reaching the
+  same checkpoint may share one. Epoch count alone is never evidence for
+  render or commit count. G-13 falsifies the committed economics; failure
+  reopens the design.
+- **Component-library gates addition (2026-07-16, directed).** G-15..G-18, the
+  widened G-8 arm, and the proof pack join the roster per the re-com readiness
+  package (EP-0035); each wired with its S3 feature under the
+  every-stage-wires-its-gates rule. G-18 is fixture-first — the registration
+  branch is already `goog.DEBUG`-gated.
 
-## Recommendation
+## Open Issues
 
-Accept (ruled 2026-07-11; gates addition directed 2026-07-16) and graduate stage by
-stage under the atomic spec-landing rule. Hold the two disciplines that give the
-roster its value: budgets stay kill-gates (miss ⇒ optimize or prune, never weaken
-semantics), and stage honesty stays explicit (a feasibility PASS never silently closes
-a named-open gate).
+The named-open gates in §5 are the open surface; each has one owner and a
+wiring stage. Graduation: this EP stays `accepted` and graduates stage by stage
+under the atomic spec-landing rule — `spec/011` receives its root-manifest and
+hydration sections at S5, `spec/008` receives the `ui.test` contract with its
+stage, and the remaining budget/absence gates complete at S6.
+
+## References
+
+- [EP-0030](EP-0030-the-compiled-view-substrate-program.md) — the program
+  umbrella (stages, demand bar, adapter disposition); stage wiring and the
+  one-time S6 adapter comparison follow its schedule.
+- [EP-0031](EP-0031-re-frame-ui-programming-model.md) — the programming model
+  (compiled `defview`, event-vector handlers, capability grammar): 0031
+  promises, 0034 verifies.
+- [EP-0032](EP-0032-re-frame-ui-reactivity-and-ownership.md) — reactivity and
+  ownership (observation port, ViewCell, commit algorithm); G-3/4/5/6/13 gate
+  its economics here.
+- [EP-0033](EP-0033-re-frame-ui-view-evidence.md) — view evidence and
+  debugging; its erasure obligation is enforced here (G-7/G-11 and the debug
+  roster).
+- [EP-0035](EP-0035-component-library-readiness.md) — component-library
+  (re-com) readiness; G-15..G-18, the widened G-8 arm, and the proof pack
+  originate there.
+- Specs [`008-Testing.md`](../../spec/008-Testing.md),
+  [`011-SSR.md`](../../spec/011-SSR.md),
+  [`004B-UI-Tree-and-Conversion.md`](../../spec/004B-UI-Tree-and-Conversion.md),
+  [`004D-UI-Test-Selectors.md`](../../spec/004D-UI-Test-Selectors.md) — the
+  graduated homes named in the Abstract; 004B/004D are live now, 008 and 011
+  receive their sections with their stages.
+- Methodology provenance: the synthesis drafts
+  `g10-bundle-baseline-methodology.md` and
+  `w11-runtime-benchmark-methodology.md` (under the tombstoned synthesis
+  tree's `drafts/`) write down the G-10/W11 methodologies; their gates bind at
+  S6.

--- a/docs/EP/EP-0035-component-library-readiness.md
+++ b/docs/EP/EP-0035-component-library-readiness.md
@@ -2,31 +2,33 @@
 
 Status: accepted
 Type: standards-track
-
-> The directed amendment package that makes `re-frame.ui`
-> component-library-ready ahead of the re-com native port. Normative homes on
-> graduation: the Spec 004 rewrite (handler synchrony law, local placement
-> law, render slots, spread), `spec/004B` (conversion table), `spec/008`
-> (gate roster), `spec/009` (diagnostic rows). Directed by Mike 2026-07-16
-> (in-session); accepted on direction — the immediate S3 implementation beads it
-> filed have all since closed; the trigger-gated candidates it also filed are
-> carried on the program epic `rf2-vxgfnd` against the triggers recorded in
-> §Resolved Decisions (see §Bead Plan).
+Created: 2026-07-16
+Resolution: accepted 2026-07-16 (directed)
 
 ## Abstract
 
 re-com is the first and most important consumer test for `re-frame.ui`; the
-substrate gets ready for it now, without waiting for the port. The package
-is deliberately small — *correct three semantics, add two library contracts,
-clarify two rules, gate the rest, never cross the wall* — putting into the
-substrate only what a library cannot build soundly itself; everything else
-is a guide convention or a trigger-gated candidate with a recorded ruling.
+substrate gets ready for it ahead of the port. The package is deliberately
+small — *correct three semantics, add two library contracts, clarify two rules,
+gate the rest, never cross the wall* — putting into the substrate only what a
+library cannot build soundly itself; everything else is a guide convention or a
+trigger-gated candidate with a recorded ruling.
+
+The normative homes are the Spec 004 rewrite (handler synchrony law, local
+placement law, render slots, spread),
+[`spec/004B-UI-Tree-and-Conversion.md`](../../spec/004B-UI-Tree-and-Conversion.md)
+(conversion table), [`spec/008-Testing.md`](../../spec/008-Testing.md) (gate
+roster), and [`spec/009-Instrumentation.md`](../../spec/009-Instrumentation.md)
+(diagnostic rows); per EP-0009, where this EP and the spec differ, the spec
+governs. The package shipped with the S3 conformance slice; the trigger-gated
+candidates remain gated on the triggers recorded in Resolved Decisions.
 
 ## Motivation
 
-The tri-analysis of re-com (three analyses + three cross-reviewed syntheses
-against `0e2675a`, no material divergence) found exactly three places where
-the in-flight S3 contracts force a library into unsound workarounds:
+The tri-analysis of re-com (three analyses plus three cross-reviewed syntheses
+of re-com at `0e2675a`, no material divergence) found exactly three places
+where the S3 contracts as first drafted would force a library into unsound
+workarounds:
 
 1. **Last-write-wins local state.** re-com has 348 `reset!`/`swap!` lines in
    27 files, with multi-writer idioms throughout. A setter computed from the
@@ -43,54 +45,23 @@ props (36 re-com `:attr` files) and one manifest projection replacing ~57
 parallel args-desc Vars — public-contract decisions with rejected
 alternatives; an EP, not a bead.
 
-## Goals / Non-Goals
-
-Goals:
-
-- amend the S3 contracts so a native component library builds on
-  `re-frame.ui` without unsound workarounds — before the port begins;
-- keep the amendment minimal: substrate changes only where a library
-  provably cannot supply the semantics itself;
-- gate every speculative candidate behind a named, measurable trigger with a
-  recorded ruling; record the doctrine and the wall as durable rationale.
-
-Non-goals:
-
-- the re-com port itself (separate epic, `rf2-6ajm6z`; its ruled product
-  register is recorded here because it anchors the triggers);
-- any wall crossing: no ratoms/cursors/reactions or generic `IDeref`, runtime
-  hiccup interpreter in core, parts interpreter, dynamic heads or blanket
-  `ui/element`, Form-2/3 / `component-did-*`, render-phase mutation, memo
-  opt-out, theme registry / widget controllers / async loaders / focus
-  policy, dual kwargs/map parser, or CSS/Bootstrap ownership;
-- reopening the blessed v1 API freeze — the row-level changes here entered
-  under the freeze's own delta protocol (deltas #4 and #5).
-
-## Relationships
-
-- **EP-0030** (the `re-frame.ui` program) owns the staged program this
-  package amends; stage epic `rf2-vxgfnd.95` carries the fold-in.
-- **EP-0031** (the compiled-view contracts) defines the amended surfaces:
-  handler decision table + synchrony law, `local`/`effect` placement law,
-  template grammar, `ui/spread`.
-- **EP-0032 / EP-0033 / EP-0034** (siblings of this wave) own the adjacent
-  touched surfaces — interop tier, tool/evidence projections,
-  conformance/production gates; amendments land in their normative homes.
-- **EP-0029** is the ISO-8601 precedent: the port register's date/time ruling
-  (R-8 below) deliberately matches the XState-v6 duration ruling.
-- **Specs:** `spec/004-Views.md`, `spec/004B-UI-Tree-and-Conversion.md`,
-  `spec/006-ReactiveSubstrate.md`, `008-Testing`, `009-Instrumentation`.
-- **Provenance (working analyses; `ai/` is local-only by default, with a few trees
-  force-tracked as a temporary exception — `git ls-files ai/` is the roster — and
-  content restated in beads):** the owning delta doc — graduated into this EP + the P0/P1 spec homes
-  (`spec/004-Views.md`, `spec/004B-UI-Tree-and-Conversion.md`,
-  `spec/006-ReactiveSubstrate.md`, `spec/008-Testing.md`, `spec/009-Instrumentation.md`),
-  from the tombstoned `drafts/component-library-readiness.md` (rf2-mgy7pz);
-  the tri-synthesis consensus `synthesis.{fable,codex,grok}.md` under
-  `ai/findings/re-com-port/`; the blessed table's delta record (`spec/API.md`
-  §"re-frame.ui — blessed public-surface freeze"); the 07 gate roster.
-
 ## Specification
+
+**Scope.** This EP amends the S3 contracts so a native component library builds
+on `re-frame.ui` without unsound workarounds — before the port begins; keeps
+the amendment minimal (substrate changes only where a library provably cannot
+supply the semantics itself); and gates every speculative candidate behind a
+named, measurable trigger with a recorded ruling, recording the doctrine and
+the wall as durable rationale. It does not own the re-com port itself (a
+separate directed program; its ruled product register is recorded here because
+it anchors the triggers); it does not cross the wall — no
+ratoms/cursors/reactions or generic `IDeref`, no runtime hiccup interpreter in
+core, no parts interpreter, no dynamic heads or blanket `ui/element`, no
+Form-2/3 / `component-did-*`, no render-phase mutation, no memo opt-out, no
+theme registry / widget controllers / async loaders / focus policy, no dual
+kwargs/map parser, no CSS/Bootstrap ownership; and it does not reopen the
+blessed v1 API freeze — the row-level changes here entered under the freeze's
+own delta protocol (deltas #4 and #5).
 
 ### P0 — three semantic corrections
 
@@ -103,7 +74,8 @@ handler) compose instead of last-write-wins. Both are legal in committed
 handlers and effect callbacks; render-phase use remains the existing dev
 error; `update!` joins `:local-state` cause evidence, rides the HMR hook
 signature, and raises the same typed `:rf.error/jvm-host-op` on the JVM.
-Out: reset-key / derived local (a scheduled spike) and fn-overloaded setters.
+Out: reset-key / derived local (a trigger-gated spike) and fn-overloaded
+setters.
 
 **P0-2 · Sync-door widening: compiler-known `ui/event` vector outcomes.** At
 a compiler-proven controlled DOM site (the unchanged S-5 predicate: literal
@@ -118,12 +90,12 @@ existing diagnostic. The competing compiled event-template projection is
 **demoted** — a second handler language — revisited only on proven JVM/Xray
 inadequacy evidence.
 
-**P0-3 · Internal compiled render slots.** `ui/render-fn` becomes valid for
+**P0-3 · Internal compiled render slots.** `ui/render-fn` is valid for
 **internal** library seams (previously foreign-boundary only), invoked
-exclusively through the compiler-owned form **`ui/slot`** (name final at spec
-landing). `ui/slot` accepts only `ui/render-fn` values or `nil`; the callback
-body is lexically visible at the consumer call site and therefore **compiled**
-(both emitters, closed grammar inside); the body is pure render phase —
+exclusively through the compiler-owned form **`ui/slot`**. `ui/slot` accepts
+only `ui/render-fn` values or `nil`; the callback body is lexically visible at
+the consumer call site and therefore **compiled** (both emitters, closed
+grammar inside); the body is pure render phase —
 `sub`/`lease`/`local`/`effect`/dispatch/hooks inside are didactic errors;
 result normalization/error behaviour, keys/occurrence identity,
 capability/fingerprint propagation, `ui.test` structural representation,
@@ -136,9 +108,9 @@ props · pure render slots · registered stateful views (gated).
 
 ### P1 — two library-facing contracts
 
-**P1-4 · Literal safe-spread policy.** A policy form joins `ui/spread` as a
-**distinct sibling name** — landed at spec landing as `ui/spread-safe`, not as a
-second `spread` arity — with compiler-visible allow/deny: denied structural/controlled/identity keys
+**P1-4 · Literal safe-spread policy.** A policy form joins `ui/spread` as the
+**distinct sibling name `ui/spread-safe`** — not a second `spread` arity —
+with compiler-visible allow/deny: denied structural/controlled/identity keys
 (`:key` `:ref` `:value` `:checked` owned `:on-*`) are rejected in **every
 build**, never dev-only; allowed `:on-*` values classify through the handler
 decision table; `aria-*`/`data-*`/`title`/class/style pass through per the
@@ -184,6 +156,7 @@ The **component-library proof pack** lands in the conformance/parity corpus
 as a rolling consumer (no re-com build dependency): controlled input ·
 selection controller · slotted list cell · safe-attrs form control ·
 schema-described component · inline popover · single-view advanced import.
+EP-0034 owns the roster of record and the wiring status.
 
 ### The trigger-gated candidate register
 
@@ -195,7 +168,7 @@ Nothing below is pre-approved; each row's full ruling is in Resolved Decisions:
 | lexical `ui/tpl` | Wave-3 checkpoint; if fired, pre-committed as literal-only **sugar over zero-arg `ui/render-fn` + `ui/slot`**, never a parallel primitive |
 | registered `ui/view` | gate **closed** for re-com v1; trigger refined to runtime-**open** identity (never mere statefulness) |
 | `ui/portal` | superseded-in-part: overlay plan of record is **inline + native top-layer** (`dialog.showModal()`, the `popover` attribute); graduation bar raised |
-| `defview-alias` | fallback-first (canonical defviews in the public ns); if fired, a meta-copying macro; bare-alias **dev warning ruled in now** |
+| `defview-alias` | fallback-first (canonical defviews in the public ns); if fired, a meta-copying macro; the bare-alias **dev warning is ruled in and shipped** |
 | event-template projection | demoted (second handler language); revisit only on JVM/Xray inadequacy evidence from P0-2 |
 | library DCE/packaging | fixture-first: only a structural G-18 failure justifies packaging work; the emitter already `goog.DEBUG`-gates registration (production arm is a direct `React.memo`) |
 
@@ -207,6 +180,14 @@ executable value crossing a library boundary has an explicit phase, identity,
 ownership, host meaning, evidence shape, and production cost. A consumer
 that appears to need the wall crossed gets an API redesign or a named
 interop boundary, never a substrate exception.
+
+### Guide impact
+
+The events guide gains the C-13b event-prefix convention; the interop guide
+gains the C-6 measure-before-paint recipe and the safe-spread passthrough
+pattern; the component-library authoring guide lands from port Wave 0 (R-6);
+the four-lane content convention (see the `ui/tpl` ruling) is publishable
+ahead of Wave 3.
 
 ## Rationale
 
@@ -226,130 +207,113 @@ a permissive alternative, and those refusals are half an EP's value.
 Pre-alpha; no shims. `local`'s two-tuple destructuring sites migrate to the
 three-tuple (the migrator's `swap!` rewrite retargets to `update!`, retiring
 its MANUAL flag on multi-writer idioms). The sync-door widening is strictly
-additive at proven-controlled sites — `.95.1`'s literal-only door was an
+additive at proven-controlled sites — the earlier literal-only door was an
 implementation waypoint, never shipped law — and the v1 API freeze is not
 reopened: deltas #4/#5 entered under the freeze's own delta protocol.
 
-## Bead Plan / Reference Implementation
-
-The per-bead fold-in against S3 stage epic `rf2-vxgfnd.95`, which closed
-2026-07-18. Per EP-0009 a ledger's rows cite live bead ids and are struck as they
-close; every row below is now closed, so this table records finished work rather
-than tracking it.
-
-| Delta | Owning bead | State |
-|---|---|---|
-| P0-1 three-tuple `local` + G-15 | `rf2-vxgfnd.95.2` (amended notes authoritative over its original scope) | closed |
-| P0-2 sync-door widening + widened G-8 | `rf2-8k14ia` — the pre-conformance **correction** filed after `.95.1` merged (the completeness audit fixed the epic's truncated reference to it); blocked `.95.10` | closed |
-| P0-3 `ui/slot` + G-16 (the delta as filed also folded in the bare-alias dev warning) | `rf2-ri0k6n` — `ui/slot` + G-16; blocked `.95.10`; S3→S4 compiler surface. The bare-alias dev warning was **not** delivered under `rf2-ri0k6n`: it shipped separately as `rf2-vxgfnd.95.15`, also closed. | closed |
-| P1-4 safe-spread policy + G-17 | `rf2-isdqjv`; blocked `.95.10` | closed |
-| C-6 interop blessing + fixtures | `rf2-vxgfnd.95.4` | closed |
-| C-13a fn-prop fixtures | `rf2-vxgfnd.95.3` (kept distinct from `rf2-ri0k6n`'s internal-slot fixtures) | closed |
-| P1-5 manifest projection | `rf2-vxgfnd.95.6` | closed |
-| Gates wiring + proof pack + G-18 fixture | `rf2-vxgfnd.95.10` (deps added on the three new children) | closed |
-| RealWorld vertical rider | `rf2-vxgfnd.95.9` — unchanged; the proof pack complements it | closed |
-
-Spike/checkpoint beads live on the **program epic** (`rf2-vxgfnd`):
-`rf2-nzst23`, `rf2-1hm7a3`, `rf2-a62fje`, `rf2-efxb1h`, `rf2-ho1iba`. The
-re-com **port** is the separate epic `rf2-6ajm6z`, whose Wave-0 product
-register is resolved — the ten rulings R-1..R-10 below; the substrate stage
-epic never blocks on component migration.
-
-Guide-impact assessment (EP-0009 rule 5): the events guide gains the C-13b
-event-prefix convention; the interop guide gains the C-6 measure-before-paint
-recipe and the safe-spread passthrough pattern; the component-library
-authoring guide lands from port Wave 0 (R-6); the four-lane content
-convention (below) is publishable ahead of Wave 3.
-
-## Open Issues
-
-None open at acceptance. The two spellings that deferred to spec landing as
-mechanical choices are **now settled**: the render-slot invocation landed as
-`ui/slot`, and the safe-spread form landed as the sibling name `ui/spread-safe`
-(the second-arity option was not taken). The gated candidates each carry a
-recorded ruling and trigger.
-
 ## Resolved Decisions
 
-Rulings of 2026-07-16, delegated per Mike's in-session direction; each bead's
-NOTES block is authoritative over any summary here.
+Delegated rulings (2026-07-16):
 
-- **Reset-key `local` (`rf2-nzst23`) — SCHEDULED, with the init ruling.**
-  The bounded `(local initial reset-key)` spike runs at port Wave-2 entry
-  with the controlled-vs-commit/draft input classification (aborting if
-  every internal-model case dissolves into redesign). **Non-negotiable:** the
-  key is an explicit caller revision, never the model value — value-equality
-  is provably blind to same-value rejection. **Init ruling:** `initial` **is
+- **Reset-key `local` — SCHEDULED, with the init ruling.** The bounded
+  `(local initial reset-key)` spike runs at port Wave-2 entry with the
+  controlled-vs-commit/draft input classification (aborting if every
+  internal-model case dissolves into redesign). **Non-negotiable:** the key
+  is an explicit caller revision, never the model value — value-equality is
+  provably blind to same-value rejection. **Init ruling:** `initial` **is
   re-evaluated at reset**, render-pure and retry-correct. Mechanism: the
   bounded compiler-emitted adjust-during-render idiom (effect-based reset,
   key-remount, and general render-time state setting all rejected). Public
   promotion needs a second distinct buffered consumer + all ten pins green.
-- **`ui/tpl` (`rf2-1hm7a3`) — demand-gated; pre-committed as slot sugar.**
-  Disposition A: not in v1; runtime hiccup values / a general template
-  function rejected permanently. If the measurable trigger fires (≥3
-  unrelated components + ≥20 materially-improved call sites + ≥1 defect
-  beyond verbosity), the authorized spike is literal-only call-site sugar
-  lowering onto zero-arg `ui/render-fn` + `ui/slot`. Primary checkpoint is
-  Wave 3 (popovers); Wave 1 is early-warning only. The library-wide content
-  convention is decided now, tpl-independently: rich content → child
-  position/compound children; parameterized fragments → `ui/render-fn` via
-  `ui/slot`; unparameterized named fragments → zero-arg `ui/render-fn`;
-  strings stay data props.
-- **Registered `ui/view` (`rf2-a62fje`) — gate closed; trigger refined.**
-  Statefulness and runtime-chosen identity are orthogonal; only the latter
-  needs a registry. A stateful replacement is already expressible as a pure
-  slot body mounting a static stateful defview; runtime choice among a known
-  finite set compiles as a `case` over view heads (re-com has zero
-  open-set-id part sites, and firing would create the substrate's first-ever
-  production registry). The trigger now fires only on irreducibly
-  runtime-**open** identity (open-set ids from config/app-db/CMS) with
-  finite `case` and `re-frame.ui.data` both proven inadequate, or a
-  parts-ceiling escalation; general `ui/element` is rejected outright,
-  forever.
-- **`ui/portal` (`rf2-efxb1h`) — superseded-in-part by inline + top-layer.**
-  Overlay plan of record: `<dialog>` + `showModal()` for modals (native
-  backdrop, inert background, Esc, focus return); the `popover` attribute +
-  measured geometry for anchored overlays; `position:fixed` + pure geometry
-  elsewhere. re-com uses zero portals (parity needs none); the top layer is
-  immune to its fixed-position emulation's failure modes. Graduation now
-  requires evidence the **top layer** cannot solve it (foreign-DOM-node
-  rendering is the one portal-only capability); a thin `createPortal`
-  wrapper is rejected permanently.
-- **`defview-alias` (`rf2-ho1iba`) — fallback-first; dev warning now.** The
-  facade strategy is canonical `defview`s in the public namespace, impl
-  namespaces demoted to helpers; try that first. A bare
-  `(def alias impl/view)` renders correctly but silently loses compile-time
-  props/children checks and view identity — so a **dev-only warning** when a
-  foreign-classified head's runtime value is a registered view shell is
-  ruled in and lands now (absorbed into `rf2-ri0k6n`). If the trigger fires
-  (material facade-prototype harm, or a consumer incident from silent
-  check-loss), the authorized shape is a meta-copying macro — no compiler
-  naming graph; wrapper views / dynamic forwarding rejected permanently.
+- **`ui/tpl` — demand-gated; pre-committed as slot sugar.** Not in v1;
+  runtime hiccup values / a general template function rejected permanently.
+  If the measurable trigger fires (≥3 unrelated components + ≥20
+  materially-improved call sites + ≥1 defect beyond verbosity), the
+  authorized spike is literal-only call-site sugar lowering onto zero-arg
+  `ui/render-fn` + `ui/slot`. Primary checkpoint is Wave 3 (popovers); Wave 1
+  is early-warning only. The library-wide content convention is decided now,
+  tpl-independently: rich content → child position/compound children;
+  parameterized fragments → `ui/render-fn` via `ui/slot`; unparameterized
+  named fragments → zero-arg `ui/render-fn`; strings stay data props.
+- **Registered `ui/view` — gate closed; trigger refined.** Statefulness and
+  runtime-chosen identity are orthogonal; only the latter needs a registry. A
+  stateful replacement is already expressible as a pure slot body mounting a
+  static stateful defview; runtime choice among a known finite set compiles
+  as a `case` over view heads (re-com has zero open-set-id part sites, and
+  firing would create the substrate's first-ever production registry). The
+  trigger fires only on irreducibly runtime-**open** identity (open-set ids
+  from config/app-db/CMS) with finite `case` and `re-frame.ui.data` both
+  proven inadequate, or a parts-ceiling escalation; general `ui/element` is
+  rejected outright, forever.
+- **`ui/portal` — superseded-in-part by inline + top-layer.** Overlay plan of
+  record: `<dialog>` + `showModal()` for modals (native backdrop, inert
+  background, Esc, focus return); the `popover` attribute + measured geometry
+  for anchored overlays; `position:fixed` + pure geometry elsewhere. re-com
+  uses zero portals (parity needs none); the top layer is immune to its
+  fixed-position emulation's failure modes. Graduation requires evidence the
+  **top layer** cannot solve it (foreign-DOM-node rendering is the one
+  portal-only capability); a thin `createPortal` wrapper is rejected
+  permanently.
+- **`defview-alias` — fallback-first; dev warning ruled in.** The facade
+  strategy is canonical `defview`s in the public namespace, impl namespaces
+  demoted to helpers; try that first. A bare `(def alias impl/view)` renders
+  correctly but silently loses compile-time props/children checks and view
+  identity — so a **dev-only warning** when a foreign-classified head's
+  runtime value is a registered view shell is ruled in, and has shipped. If
+  the trigger fires (material facade-prototype harm, or a consumer incident
+  from silent check-loss), the authorized shape is a meta-copying macro — no
+  compiler naming graph; wrapper views / dynamic forwarding rejected
+  permanently.
 
-**The port product register (`rf2-6ajm6z`) — R-1..R-10, all ruled:**
+**The port product register — R-1..R-10, all ruled:**
 
 | # | Ruling |
 |---|---|
-| R-1 packaging | same repo; native `re-com/re-com-ui` with `re-com.ui.*`; the coexisting Reagent legacy keeps `re-com.*` |
+| R-1 packaging | same repo; native `re-com/re-com-ui` with `re-com.ui.*` (coordinate confirmed final 2026-07-17); the coexisting Reagent legacy keeps `re-com.*` |
 | R-2 parts ceiling | data/style values + pure compiled slots only; slots receive the component's declared state; no registered stateful replacements in v1 |
 | R-3 uncontrolled tier | narrow, per-component `:default-value`; `:value` XOR `:default-value` validated; type-based ownership inference rejected permanently |
 | R-4 theme transport | explicit props + frame subscriptions; theme values plain data only (context graduation stays non-breaking) |
-| R-5 tables/grids | foreign-virtualization-first behind a re-com-owned data/event/slot boundary; four named criteria to ever go native; engine selection is a Wave-4-entry decision bead |
+| R-5 tables/grids | foreign-virtualization-first behind a re-com-owned data/event/slot boundary; four named criteria to ever go native; engine selection is a Wave-4-entry decision |
 | R-6 helper artifact | generic internals + the authoring guide from Wave 0; a public middle artifact only on a second consuming library |
 | R-7 input ownership | ownership law approved now (controlled roster vs commit/draft vs local interaction state; rejected drafts identified only by explicit `:reset-key`); per-component roster frozen at Wave-2 entry |
 | R-8 dates/times | host-neutral ISO-8601 strings as the canonical ABI (EP-0029 consistency); no `goog.date`/`js/Date`/`java.time` across the public ABI |
 | R-9 accessibility | WAI-ARIA APG semantics per component class, shipped with each component's wave — legacy parity (one `aria-` attribute total) is not the bar |
-| R-10 CSS/Bootstrap | retained through the parity waves as an isolated, removable theme-data layer; removal is a named post-parity decision bead |
+| R-10 CSS/Bootstrap | retained through the parity waves as an isolated, removable theme-data layer; removal is a named post-parity decision |
 
-> **Errata — 2026-07-17 (delegated, recorded on `rf2-6ajm6z`).** R-1's native
-> coordinate — `re-com/re-com-ui` with the `re-com.ui.*` namespace family — was
-> confirmed final; the original ruling's "may be adjusted before first
-> publication" window is now closed.
+## Open Issues
 
-## Recommendation
+None. Every gated candidate carries a recorded ruling and a measurable
+trigger (Resolved Decisions); firing one later is execution, not design
+reopening. The package's contract text lives in its normative homes with
+`spec/008`/`spec/009` carrying gates and catalogue rows; the port proceeds on
+its ruled register — the substrate never waits on it, and the wall never
+moves.
 
-Accepted as directed. Land the package through the mapped S3 beads with
-gates wired in-stage; hold every candidate to its recorded trigger; graduate
-the contract text into the Spec 004/004B rewrite with `spec/008`/`spec/009`
-carrying gates and catalogue rows. The port proceeds on its ruled register —
-the substrate never waits on it, and the wall never moves.
+## References
+
+- [EP-0030](EP-0030-the-compiled-view-substrate-program.md) — the
+  `re-frame.ui` program this package amends; the S3 stage carried the
+  fold-in.
+- [EP-0031](EP-0031-re-frame-ui-programming-model.md) — the compiled-view
+  contracts this package amends: handler decision table + synchrony law,
+  `local`/`effect` placement law, template grammar, `ui/spread`.
+- [EP-0032](EP-0032-re-frame-ui-reactivity-and-ownership.md) /
+  [EP-0033](EP-0033-re-frame-ui-view-evidence.md) /
+  [EP-0034](EP-0034-re-frame-ui-production-ssr-testing.md) — siblings of this
+  wave owning the adjacent touched surfaces — interop tier, tool/evidence
+  projections, conformance/production gates; amendments land in their
+  normative homes.
+- [EP-0029](EP-0029-xstate-v6-machine-parity.md) — the ISO-8601 precedent: the
+  port register's date/time ruling (R-8) deliberately matches the XState-v6
+  duration ruling.
+- Specs: [`spec/004-Views.md`](../../spec/004-Views.md),
+  [`spec/004B-UI-Tree-and-Conversion.md`](../../spec/004B-UI-Tree-and-Conversion.md),
+  [`spec/006-ReactiveSubstrate.md`](../../spec/006-ReactiveSubstrate.md),
+  [`spec/008-Testing.md`](../../spec/008-Testing.md),
+  [`spec/009-Instrumentation.md`](../../spec/009-Instrumentation.md); the
+  blessed table's delta record in [`spec/API.md`](../../spec/API.md)
+  §"re-frame.ui — blessed public-surface freeze".
+- Design provenance: the readiness delta document graduated into this EP and
+  the P0/P1 spec homes from the tombstoned synthesis tree
+  (`ai/findings/new-substrate-synthesis/`); the tri-synthesis consensus
+  analyses under `ai/findings/re-com-port/`.


### PR DESCRIPTION
## Direction

Per Mike's direction: de-historicalise the six re-frame.ui EPs (EP-0030..EP-0035) and bring them to good Python Enhancement Proposal standards, improving them in passing and making them consistent as a corpus. **For these six, this direction supersedes the dated-errata presentation** — the erratum blockquotes, [UPDATED]/[CORRECTED]/[QUALIFIED] markers, "as of" datelines, strike-through ledger rows, stage play-by-play, and bead/PR narration are folded into clean current-truth prose. Git history remains the historical record; each EP now states the design as it stands.

## Corpus-wide changes

- Uniform PEP preamble on all six: `Status:` / `Type:` / `Created: 2026-07-16` (first commit of the family) / `Resolution:` (acceptance or finalisation date).
- Uniform section order: Abstract → Motivation → Specification (opening with a Scope paragraph that absorbs Goals/Non-Goals + the ownership half of Relationships, closing with Guide impact per EP-0009 rule 5) → Rationale → Backwards Compatibility → Resolved Decisions → Open Issues → References (absorbing Relationships + provenance).
- Resolved-decision registers tightened to decision + rationale, dates as single trailing parentheses; ruling-ceremony language and bead/PR ids removed.
- Cross-EP terminology aligned ("retained adapters", the S-5 predicate, the API-freeze delta protocol, spec-governs language); duplicated facts pruned toward one home (gate roster and wiring live in EP-0034; candidate rulings in EP-0035; program record in EP-0030).
- All externally-linked anchors preserved: `#resolved-decisions`, `#stages-s1s7`, `#the-demand-bar-gated-public-surface` (0030), `#preflight-ensure-for-frames` (0032), `#two-evidence-layers`, `#tool-integration-posture` (0033), `#2-ssr-one-jvm-structural-tree` (0034). The one link to EP-0030's removed Bead Plan heading (from EP-0034) now points at `#stages-s1s7`.
- Statuses unchanged (0030/0033/0034/0035 accepted; 0031/0032 final). `docs/EP/README.md` untouched (no title/status changes).

## Per-EP

- **EP-0030**: graduation banners, fired-ruling asides, and the S1-S4 close narration folded into current truth; ratified R-1..R-6 register kept as the decision record; source-folder retirement narrative condensed to the standing survival rules ("The design-record retirement"); adapter-disposition reframing kept as the one supersession record in Resolved Decisions (guard-compliant).
- **EP-0031**: stage-honesty legend and per-item stage/bead markers removed; the widened synchrony door and `local` three-tuple stated as the contract; interop table gains a clean Stage column; settled `ui/slot` / `ui/spread-safe` spellings recorded in Resolved Decisions; the unimplemented `bare-handlers` lint carried as a named build gap in Open Issues.
- **EP-0032**: the three banners and the invariant-6 erratum folded — the six frozen invariants now state the corrected host-checkpoint render-batch boundary directly, with the correction recorded once in Resolved Decisions (2026-07-19); the fully-struck errata ledger and per-slice PR listing dissolved; spike evidence moved to References.
- **EP-0033**: the specified-vs-certified split is now a clean "Shipped surface and specified extensions" section; the sub-query-vector egress ruling and the runtime-tier one-catalogue qualifier integrated where they apply and registered in Resolved Decisions; the unshipped evidence-schema delta (no stage, no owner) carried as a real Open Issue.
- **EP-0034**: the dated stage-honesty section became a clean "Gate wiring status" (wired-green vs named-open, keyed to npm entry points; CI-job and PR narration removed); G-8 row cleaned of the dated widening marker and bead reference; the backwards-compatibility correction note collapsed into the plain four-suite statement.
- **EP-0035**: direction banner, the all-closed bead fold-in table, and the R-1 coordinate erratum folded; package stated as shipped with S3; candidate register rulings kept in full, without bead ids; R-1 row absorbs the coordinate-final note.

## Conservatively kept

- EP-0033's "Shipped surface and specified extensions" keeps the exact shipped/unshipped inventory (including the bounded cause set and consumer-tolerance rule) rather than restating the full schema as live — the delta genuinely has no stage assignment, so this is current truth, not history.
- EP-0034 keeps the honest G-14 rebuild-arm limit statement (absolute bar vs quadratic separation) and the named-open list verbatim in substance — that is standing gate-status truth, now undated.
- EP-0031 keeps "the S-5 predicate" as the stable name for the controlled-site proof (cross-referenced from EP-0035 and the spec).
- Program-position statements ("S1-S4 complete and declared conforming; S5 is the live stage") are retained once in EP-0030 with the tracker named as the authority for in-flight stages.

## Out of scope (follow-up)

- EP-0009 / EP-template process-doc alignment: EP-0009's document-conventions section still lists the older house section names (Goals/Non-Goals, Relationships, Bead Plan, Recommendation). Aligning the process doc and template to the PEP-standard shape these six now use is a follow-up.
- spec/**, all other EPs, and beads untouched.

## Gates (run locally from the worktree, all green)

- `python scripts/check_ep_status_sync.py` — in sync (35 EPs).
- `python scripts/check_adapter_disposition.py` — intact across 10 authorities (EP-0030 positive assertions kept; supersession markers preserved).
- `python scripts/check_doc_slugs.py` — 531 files, no broken links.
- `python -m mkdocs build --strict` — exit 0.