### PR TITLE
fix(ui): self-upgrading reload-source producer; own reload evidence by the addressed cycle (rf2-mp6fz, rf2-4vm19)

### DIFF
--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -1330,6 +1330,26 @@
 ;; because `SHADOW_NS_RESET` lives on `goog.global` — SHARED across every build
 ;; in one realm — so two builds' producers must coexist rather than evict each
 ;; other.
+;;
+;; ## And the INSTALL is self-upgrading too (rf2-mp6fz)
+;;
+;; A trampoline keeps the entry's BEHAVIOUR current. It cannot keep the ENTRY
+;; current — the object's own construction, its captured owner, and the installer
+;; that placed it are all fixed at the moment of installation. While the install
+;; was `defonce`d that moment was the page's first load, forever: a live page
+;; kept whatever entry it had, and the only way to adopt a change to this
+;; machinery was a full reload. The concrete failure that names: an entry
+;; installed before shadow's build-id carrier was consulted captured `::default`,
+;; and the page went on routing every reset to the placeholder owner even once
+;; the real build identity became resolvable.
+;;
+;; So the install runs on EVERY load and retires what this copy already owns
+;; (`owned-producer`). Ownership is OBJECT IDENTITY, never the tag: the tag says
+;; which build an entry claims, identity says this copy put it there, and the two
+;; diverge in exactly the cases that matter — our own entry whose captured tag
+;; has gone stale, and a co-loaded bundle's entry carrying the tag we are leaving
+;; behind. `defonce` moved from the install (where it froze the machinery) to the
+;; ownership record (where surviving the reload is the whole point).
 ;; ---------------------------------------------------------------------------
 
 #?(:cljs
@@ -1367,6 +1387,27 @@
            :else                                            (recur (inc i)))))))
 
 #?(:cljs
+   (defonce ^{:private true
+              :doc "The array entry THIS copy of the namespace currently owns, or
+  nil before its first install (and always in `:advanced` production, which
+  installs no producer at all — the atom is gated exactly like `ledger-state`, so
+  no cell is allocated there either).
+
+  `defonce` because it is the one thing that must SURVIVE a hot-reload of this
+  namespace while the install itself deliberately does not (rf2-mp6fz): it is how
+  the freshly loaded installer learns which entry the PREVIOUS generation of this
+  code put on the shared array, so it can retire it instead of appending beside
+  it.
+
+  Identity, not tag, is the ownership proof. A tag says which BUILD an entry
+  claims; only object identity says that THIS copy installed it. The two diverge
+  exactly when migration matters — an entry whose captured tag is now stale is
+  still ours, and a co-loaded bundle's entry carrying the very same tag is not.
+  Retiring by tag would get both of those backwards."}
+     owned-producer
+     (when ^boolean js/goog.DEBUG (atom nil))))
+
+#?(:cljs
    (defn- make-reload-source-producer
      "One stable callback object owned by `build-id` that resolves the CURRENT
      `reload-source-reset!` on every call. `reload-source-reset!` compiles to a
@@ -1386,30 +1427,45 @@
      neither clobbers nor is clobbered by shadow's own init), so shadow calls it
      with each reloaded source's ns from `before-load-src`.
 
-     IDEMPOTENT per build identity: an existing entry tagged with this build is
-     REPLACED in place, never appended to, and entries owned by shadow or other
-     libraries/builds are never inspected for anything but their tag. Dev-only
-     (gated on `js/goog.DEBUG`, elided from `:advanced` production)."
+     IDEMPOTENT, and SELF-UPGRADING across a hot reload (rf2-mp6fz). It reuses
+     the slot this copy already owns — its own previous entry (by identity, so
+     the slot is reused even when the tag it captured has since gone stale),
+     else this build's tagged entry — and REPLACES it in place; only a copy that
+     owns nothing appends. So repeated installs can neither duplicate the
+     producer nor strand a predecessor still routing to an identity this build
+     no longer resolves, and entries owned by shadow or other libraries/builds
+     are never inspected for anything but their tag, never moved, and never
+     retired. Dev-only (gated on `js/goog.DEBUG`, elided from `:advanced`
+     production)."
      []
      (when ^boolean js/goog.DEBUG
        (let [arr      (or js/goog.global.SHADOW_NS_RESET #js [])
              build-id (current-build-id)]
          (set! (.-SHADOW_NS_RESET js/goog.global) arr)
-         (let [i (tagged-producer-index arr build-id)
-               f (make-reload-source-producer build-id)]
+         (let [prev @owned-producer
+               mine (if prev (.indexOf arr prev) -1)
+               i    (if (neg? mine) (tagged-producer-index arr build-id) mine)
+               f    (make-reload-source-producer build-id)]
            (if (neg? i)
              (.push arr f)
-             (aset arr i f)))
+             (aset arr i f))
+           (reset! owned-producer f))
          true))))
 
-#?(:cljs
-   (defonce ^:private _reload-source-producer
-     ;; Install at client load so the shipped reload path has a producer the
-     ;; moment this ns is present; `defonce` survives a hot-reload of rules.cljc
-     ;; itself, so exactly one entry is registered — and because that entry is a
-     ;; trampoline, it runs the RELOADED implementation rather than the object
-     ;; realized here (rf2-vxgfnd.145).
-     (install-reload-source-producer!)))
+;; Install at client load so the shipped reload path has a producer the moment
+;; this ns is present — and re-install on EVERY load, which is what makes the
+;; producer self-upgrading (rf2-mp6fz).
+;;
+;; This deliberately is NOT `defonce`d. The `defonce` existed to stop the
+;; original `.push` from appending a duplicate on each reload; once .145 gave the
+;; entry an owner tag and a replace-in-place install, that job belonged to the
+;; install itself — and the `defonce` had become the thing PINNING the installer,
+;; so no change to it, to the trampoline's construction, or to the owner tag
+;; could reach a page without a full reload. That is the same staleness .145 fixed
+;; one level down, at the level above it: .145 made the entry run current code,
+;; this makes the ENTRY ITSELF current. `owned-producer` carries the ownership
+;; record across the reload boundary that this form no longer needs to.
+#?(:cljs (install-reload-source-producer!))
 
 (defn reset-custom-elements!
   "Test support: clear the runtime custom-element registry, the per-source

--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -1200,17 +1200,29 @@
   "Record the sources that re-ran (or were removed) in the open reload cycle —
   the signal a zero-declaration source cannot emit for itself, fed in the shipped
   browser reload path by `reload-source-reset!` (the SHADOW_NS_RESET producer;
-  rf2-vxgfnd.77). `sources` is a coll of ns-syms (paired with `build-id`) or
-  ready-made [build ns] pairs. A no-op when no cycle is open (and, in `:advanced`
-  production, when there is no ledger at all — rf2-k9yuy); unions into the cycle
-  so it can be called repeatedly."
+  rf2-vxgfnd.77). `sources` is a coll of ns-syms, or of [build ns] pairs whose
+  ns is taken and whose build is IGNORED. A no-op when no cycle is open (and, in
+  `:advanced` production, when there is no ledger at all — rf2-k9yuy); unions
+  into the cycle so it can be called repeatedly.
+
+  OWNERSHIP TRAVELS WITH THE ADDRESSED CYCLE, NEVER WITH THE PAYLOAD
+  (rf2-4vm19). Every source is normalized to `[build-id ns]` for the build this
+  call addresses, so the reconciliation a cycle performs is total over its OWN
+  rows and can never reach another build's. A ready-made pair used to be taken
+  verbatim, which let evidence handed to build A's open cycle nominate build B
+  as owner — `commit-reload!` then evicted B's row under a cycle B never took
+  part in. Normalizing rather than rejecting keeps the ergonomic ns-only form
+  the only shape anyone needs while making the pair form merely a more verbose
+  spelling of it: one ownership rule, no second path to reason about, and no
+  caller-facing failure mode for a datum whose ns is perfectly usable."
   ([sources] (note-reloaded-sources! sources (current-build-id)))
   ([sources build-id]
    (when reload-ledger?
      (swap! ledger-state
             (fn [st]
               (if (contains? (::cycles st) build-id)
-                (let [pairs (map (fn [s] (if (vector? s) s [build-id s])) sources)]
+                (let [pairs (map (fn [s] [build-id (if (vector? s) (second s) s)])
+                                 sources)]
                   (update-in st [::cycles build-id :touched] (fnil into #{}) pairs))
                 st))))
    nil))

--- a/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
@@ -833,6 +833,42 @@
   (is (= #{:from-app} (rules/custom-element-properties :a-el))
       "nor can it leak into the OTHER build's open cycle"))
 
+(deftest ready-made-pair-cannot-inject-a-foreign-owner-into-an-open-cycle
+  ;; rf2-4vm19. The seam took a ready-made [build ns] pair VERBATIM, so the
+  ;; owner travelled with the datum rather than with the addressed cycle: a
+  ;; source handed to build :a's cycle could name build :b as its owner and
+  ;; `reconcile-sources` would then evict :b's row. Ownership is a property of
+  ;; the CYCLE BEING ADDRESSED, never of the payload — a caller cannot nominate
+  ;; whose rows a cycle reconciles.
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :a-el {:properties #{:a}} 'shared.ns :a)
+  (rules/register-custom-element! :b-el {:properties #{:b}} 'shared.ns :b)
+  (rules/notify-reload! :a)
+  (rules/note-reloaded-sources! [[:b 'shared.ns]] :a)   ; :a's cycle, :b's owner
+  (rules/commit-reload! :a)
+  (is (= #{:b} (rules/custom-element-properties :b-el))
+      "build :b's row survives a cycle it never took part in — the foreign owner
+       in the payload was normalized to the addressed build, not honoured")
+  (is (= #{} (rules/custom-element-properties :a-el))
+      "and the source WAS reconciled, against the build whose cycle is open —
+       normalization re-owns the datum rather than discarding it"))
+
+(deftest ns-only-and-ready-made-pair-are-the-same-evidence
+  ;; The ergonomic ns-only form is preserved, and the pair form is now merely a
+  ;; more verbose spelling of it: for one addressed build both must reconcile
+  ;; the identical row, so there is no second ownership rule to reason about.
+  (doseq [sources [['shared.ns] [[:a 'shared.ns]]]]
+    (rules/reset-custom-elements!)
+    (rules/register-custom-element! :a-el {:properties #{:a}} 'shared.ns :a)
+    (rules/register-custom-element! :b-el {:properties #{:b}} 'shared.ns :b)
+    (rules/notify-reload! :a)
+    (rules/note-reloaded-sources! sources :a)
+    (rules/commit-reload! :a)
+    (is (= #{} (rules/custom-element-properties :a-el))
+        (str "the addressed build's row is reconciled, given " (pr-str sources)))
+    (is (= #{:b} (rules/custom-element-properties :b-el))
+        (str "and no other build's row is touched, given " (pr-str sources)))))
+
 #?(:cljs
    (deftest installed-producer-notes-into-its-own-build-only
      ;; The producer is the one real caller of the ledger seam, so its build

--- a/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
@@ -645,6 +645,26 @@
            (array-seq js/goog.global.SHADOW_NS_RESET))))
 
 #?(:cljs
+   (defn- shadow-build-id-carrier
+     "shadow's OWN build-identity carrier — the object graph `current-build-id`
+     reads through `shadow-build-id`, not a test seam standing in for it. Reading
+     and writing the real carrier is what makes the migration fixture below drive
+     an actual change of resolved build identity."
+     []
+     (let [root (or (unchecked-get js/goog.global "$CLJS") js/goog.global)
+           env  (reduce (fn [o k]
+                          (let [child (or (unchecked-get o k) #js {})]
+                            (unchecked-set o k child)
+                            child))
+                        root
+                        ["shadow" "cljs" "devtools" "client" "env"])]
+       env)))
+
+#?(:cljs
+   (defn- set-shadow-build-id! [v]
+     (unchecked-set (shadow-build-id-carrier) "build_id" v)))
+
+#?(:cljs
    (deftest reload-producer-is-wired-to-shadow-reset-array
      ;; The wire itself: install-reload-source-producer! (run at ns load) must
      ;; have registered a re-frame.ui producer on shadow's per-reload callback
@@ -652,7 +672,14 @@
      (is (exists? js/goog.global.SHADOW_NS_RESET)
          "install-reload-source-producer! ensured the SHADOW_NS_RESET array")
      (is (= 1 (count (rf2-producers)))
-         "exactly one re-frame.ui producer is registered on shadow's array")))
+         "exactly one re-frame.ui producer is registered on shadow's array")
+     ;; rf2-mp6fz — the wire runs on EVERY load of this namespace, so the entry
+     ;; standing on the array is always owned by the identity the CURRENT code
+     ;; resolves. A producer whose tag has drifted from `current-build-id` is a
+     ;; producer installed by a code generation that no longer exists.
+     (is (= (str (rules/current-build-id))
+            (unchecked-get (first (rf2-producers)) "reFrameUiReloadSourceReset"))
+         "the standing producer is tagged with the identity the current code resolves")))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-vxgfnd.145 — the installed producer must run the CURRENT implementation.
@@ -735,6 +762,89 @@
            (let [arr js/goog.global.SHADOW_NS_RESET
                  i   (.indexOf arr foreign)]
              (when-not (neg? i) (.splice arr i 1))))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-mp6fz — the install must be SELF-UPGRADING across the trampoline
+;; boundary.
+;;
+;; .145 made the installed entry a trampoline so the BEHAVIOUR it runs is always
+;; freshly loaded code. But the install itself sat behind a `defonce`, so the
+;; INSTALLER never re-ran: a page loaded before a given generation of this
+;; namespace kept whatever entry it already had, and no change to the installer,
+;; the trampoline's construction, or the owner tag could ever reach it without a
+;; full page reload. The `defonce` was there to stop the pre-.145 `.push` from
+;; appending duplicates — a job the owner tag took over, which is precisely what
+;; made the `defonce` redundant AND the thing blocking self-upgrade.
+;;
+;; Running the install on every load is only safe if it retires what this copy
+;; already owns. Ownership is proven by OBJECT IDENTITY — the exact entry this
+;; copy installed — never by tag, because a co-loaded bundle may legitimately own
+;; a producer under any tag, including the placeholder.
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (deftest producer-install-migrates-the-entry-this-copy-already-owns
+     ;; The bead's concrete live-upgrade failure: an entry created while no real
+     ;; build identity was resolvable captured the ::default placeholder. When
+     ;; the reloaded code resolves the build's real name, re-installing must
+     ;; MIGRATE that entry — one producer, real identity — rather than push a
+     ;; second one and leave the placeholder-routed predecessor executing.
+     (let [arr      js/goog.global.SHADOW_NS_RESET
+           original (unchecked-get (shadow-build-id-carrier) "build_id")
+           foreign  (fn [_ns] nil)
+           before   (count (array-seq arr))]
+       (.push arr foreign)
+       (try
+         (is (= 1 (count (rf2-producers)))
+             "precondition: the ns-load install left exactly one producer")
+         (set-shadow-build-id! "app-migrated")
+         (is (= :app-migrated (rules/current-build-id))
+             "precondition: the code now resolves a REAL build identity, as it
+              does the moment shadow's build-id carrier is present")
+         (rules/install-reload-source-producer!)      ; what every load re-runs
+         (is (= 1 (count (rf2-producers)))
+             "exactly one re-frame.ui producer — the entry this copy already
+              owned was retired, not left standing beside the new one")
+         (is (= ":app-migrated"
+                (unchecked-get (first (rf2-producers)) "reFrameUiReloadSourceReset"))
+             "and the surviving producer carries the build's real identity, so
+              reset evidence stops routing to the placeholder owner")
+         (is (= (inc before) (count (array-seq arr)))
+             "the array grew by exactly the foreign probe — no accumulation")
+         (is (some #(identical? % foreign) (array-seq arr))
+             "a callback owned by shadow or another library is untouched")
+         (finally
+           (set-shadow-build-id! original)
+           (rules/install-reload-source-producer!)
+           (let [i (.indexOf arr foreign)]
+             (when-not (neg? i) (.splice arr i 1))))))))
+
+#?(:cljs
+   (deftest producer-migration-leaves-another-owners-producer-alone
+     ;; Why identity and not tag: a co-loaded bundle's producer may carry ANY
+     ;; tag, including the very placeholder this copy is migrating away from.
+     ;; Retiring by tag would evict it; retiring by identity cannot.
+     (let [arr      js/goog.global.SHADOW_NS_RESET
+           original (unchecked-get (shadow-build-id-carrier) "build_id")
+           ;; another bundle's producer, tagged exactly like the entry this copy
+           ;; is about to migrate away from
+           other    (let [f (fn [_ns] nil)]
+                      (unchecked-set f "reFrameUiReloadSourceReset"
+                                     (str (rules/current-build-id)))
+                      f)]
+       (.push arr other)
+       (try
+         (set-shadow-build-id! "app-migrated")
+         (rules/install-reload-source-producer!)
+         (is (some #(identical? % other) (array-seq arr))
+             "the other owner's identically-tagged producer survives the
+              migration — ownership is the object this copy installed, not a tag
+              any bundle could be carrying")
+         (finally
+           (set-shadow-build-id! original)
+           (let [i (.indexOf arr other)]
+             (when-not (neg? i) (.splice arr i 1)))
+           (rules/install-reload-source-producer!))))))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-vxgfnd.142 — ONE real build identity through the whole reload cycle.


### PR DESCRIPTION
Two bounded correctness fixes on the custom-element reload seam
(`implementation/ui/src/re_frame/ui/rules.cljc`). Both beads' stated surfaces
(`implementation/coercion/routing`, `tools/builds`) turned out to be misreadings
— the first is a namespace named in an acceptance criterion, the second a bead
label — so no coercion/routing or build-tooling file is touched.

## rf2-mp6fz — the producer install is now self-upgrading

.145 made the installed `SHADOW_NS_RESET` entry a trampoline, so the *behaviour*
it runs is always freshly loaded code. The install itself sat behind a
`defonce`, so the *installer* never re-ran: a live page kept whatever entry it
had, and no change to the installer, the trampoline's construction, or the owner
tag could reach it without a full page reload — the same staleness .145 fixed,
one level up. The concrete failure it strands is the one the bead names: an
entry installed before shadow's build-id carrier was consulted captured
`::default`, and the page kept routing every reset to the placeholder owner.

The install now runs on every load and retires what this copy already owns. The
`defonce` moved from the install (where it froze the machinery) to the ownership
record (where surviving the reload is the point). It only ever existed to stop
the original `.push` appending duplicates — a job the owner tag took over in
.145, which is what made it both redundant and the thing blocking self-upgrade.

Ownership is **object identity, never the tag**. A tag says which build an entry
claims; only identity says *this copy* installed it. The two diverge in exactly
the cases that matter: our own entry whose captured tag has gone stale, and a
co-loaded bundle's entry carrying the tag we are leaving behind — retiring by
tag gets both backwards. Foreign entries are still never inspected for anything
but their tag, never moved, never retired.

**Deliberate deviation from AC1**, flagged for review: migrating a *pre-.145*
untagged raw entry is not implemented. It is untagged, so it is
indistinguishable from a foreign callback by any sound test; the only handle is
sniffing the munged CLJS function name, which is compiler-internal and would be
permanent dead weight. It would matter only to a browser tab loaded from a
one-commit-wide historical window that then hot-reloads instead of refreshing —
squarely the in-memory back-compat this project's pre-alpha stance declines. The
general defect (the `defonce` freeze) and every *future* upgrade across that
boundary are fixed.

## rf2-4vm19 (PARTIAL) — reload evidence is owned by the addressed cycle

`note-reloaded-sources!` took a ready-made `[build ns]` pair verbatim, so the
owner travelled with the datum rather than with the cycle being addressed.
Evidence handed to build A's open cycle could nominate build B as owner, and
`commit-reload!` would then evict B's row under a cycle B never took part in.
Sources are now normalized to `[addressed-build ns]`, making a cycle's
reconciliation total over its own rows and unable to reach another build's.

Normalizing rather than rejecting is the bead's own first option: it keeps the
ergonomic ns-only form the only shape anyone needs, makes the pair form a more
verbose spelling of it, and adds no caller-facing failure mode — and therefore
no new error id and no Spec 009 co-edit. No caller in the corpus passed a pair,
so the verbatim branch was unexercised ergonomics that was also the hole.

**This is partial.** The bead's remaining arms are untouched and it stays open:
a real Shadow warm-watch/file-edit fixture, the removed/renamed-source graph
delta, and the co-loaded-build topology question. That last one asks for a
ruling (prove real isolation *or* enforce one-build-per-shared-runtime and
delete the synthetic multi-build tests), not a determinable fix.

## Quality gates

All foreground, unpiped, exit codes captured by redirect.

| Gate | Result |
| --- | --- |
| `implementation/ui` JVM (`clojure -M:test`) | **PASS** — 958 tests / 18660 assertions, 0 failures |
| `npm run test:cljs` | **PASS** — 10221 tests / 50503 assertions, 0 failures |
| `npm run test:elision` | **PASS** — production 60/60 absent, control 60/60 present |
| `npm run test:ui-advanced-elision` | **PASS** — 4/4 residue absent, 1/1 pinned retention present |
| `npm run test:browser-prod-elision` | **PASS** — mounted prod elision PASS; 105 tests / 414 assertions in the `:advanced` bundle |
| `scripts/check-no-hardcoded-paths.sh` | **PASS** |

### Red-before, per bead, each with its own lever

- **rf2-4vm19** (JVM): `ready-made-pair-cannot-inject-a-foreign-owner-into-an-open-cycle`
  failed on the unfixed source with the exact bead symptom — `:b-el` → `#{}`
  (build `:b`'s row evicted by build `:a`'s cycle) and `:a-el` → `#{:a}` (`:a`'s
  own row never reconciled). 2 failures, both naming the test.
- **rf2-mp6fz** (CLJS): `producer-install-migrates-the-entry-this-copy-already-owns`
  failed on the unfixed source with 2 producers instead of 1, the survivor still
  tagged `":re-frame.ui.rules/default"`, and the array grown by 2 not 1. It
  drives shadow's real build-id carrier — the object graph `current-build-id`
  actually reads — rather than a stand-in seam.

### Vacuity probes

Both guard tests (the ones that also pass on unfixed source, so whose
falsifiability the red-before does not establish) were probed by flipping an
assertion and confirming the full gate reds naming them; both restored
byte-identical.

- `ns-only-and-ready-made-pair-are-the-same-evidence` red **twice** — once per
  `doseq` iteration, so both loop bodies demonstrably execute.
- `producer-migration-leaves-another-owners-producer-alone` red once.

### Production-elision placement

Neither fix places a should-be-production law on `reload-ledger?`-gated code, so
neither is the `rf2-2hkfy` / `rf2-5pr75` trap. The `4vm19` fix sits inside
`reload-ledger?`, but the bug is *unreachable* in production rather than merely
unguarded there: `notify-reload!` is a `^:dev/before-load` hook shadow never
installs in a release build, so no production reload cycle exists to inject
into. The `mp6fz` fix is `goog.DEBUG`-gated because HMR has no production
meaning at all, and the bead explicitly requires advanced-production elision to
stay unchanged — verified by the in-bundle browser prod-elision gate above.
