### PR TITLE
fix(ssr): restrict manifest numerics to the cross-host round-trip subset (rf2-v4foc)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/manifest.cljc
+++ b/implementation/ssr/src/re_frame/ssr/manifest.cljc
@@ -244,6 +244,68 @@
 ;; Render-time props (004C §5)
 ;; ---------------------------------------------------------------------------
 
+(def ^:const max-safe-integer
+  "`2^53 - 1` — the largest integer a browser number (an IEEE-754 double)
+  holds EXACTLY. Beyond it, consecutive integers share a representation:
+  the CLJS reader turns `9007199254740993` into `9007199254740992` and
+  says nothing (rf2-v4foc)."
+  9007199254740991)
+
+(defn- wire-number?
+  "Can the number `v` cross the wire UNCHANGED? The whole predicate is
+  the round-trip equality itself — `v` is admitted exactly when printing
+  it here and reading it on the OTHER host yields an EQUAL value.
+
+  The two hosts answer differently because they hold different numbers,
+  not because there are two rules:
+
+  **CLJS** — every number IS an IEEE-754 double, and the JVM reader
+  reconstructs a double exactly, so every CLJS number crosses unchanged.
+  The single exception is `##NaN`, which the property excludes on its
+  own terms: NaN is not `=` to itself, so no NaN can satisfy a
+  round-trip-EQUALITY test on any host.
+
+  **JVM** — the server holds numeric types the browser has none of, and
+  integers wider than a double can hold. Both cross badly, and both
+  cross SILENTLY (rf2-v4foc):
+
+  | JVM value | prints | CLJS reads back |
+  |---|---|---|
+  | `9007199254740993N` (BigInt)  | `9007199254740993N` | `9007199254740992` |
+  | `1.5M` (BigDecimal)           | `1.5M`   | `1.5` |
+  | `1/3` (Ratio)                 | `1/3`    | `0.3333333333333333` |
+  | `9007199254740993` (Long)     | same     | `9007199254740992` |
+  | `(float 0.1)` (Float)         | `0.1`    | `0.1` ≠ the Float |
+
+  So: no Ratio, BigDecimal, BigInt or Float; integers only within the
+  safe range; no NaN. `Float` is rejected for failing the property on
+  the JVM ALONE — `(= (float 0.1) (read \"0.1\"))` is already false,
+  because the printed shortest-decimal names the *double* 0.1.
+
+  A large DOUBLE (`1.0E308`) is fine and is not a contradiction: it is
+  already an IEEE-754 double, so the far side reconstructs it bit for
+  bit. The safe-integer bound is about REPRESENTABILITY, not magnitude —
+  a Long past `2^53` carries precision no double can hold, while a
+  double of any size carries only precision a double can hold.
+
+  Rejecting rather than coercing follows the `record?` arm below: a
+  BigInt silently arriving as a plain number, or a Ratio as an
+  approximation, changes the prop's TYPE between server and client,
+  which is the very defect a fail-loud wire exists to prevent. The
+  author narrows the value explicitly, so both hosts agree about what
+  they are holding."
+  [v]
+  #?(:clj
+     (cond
+       (or (ratio? v) (decimal? v))    false
+       (integer? v)                    (and (not (instance? clojure.lang.BigInt v))
+                                            (not (instance? java.math.BigInteger v))
+                                            (<= (- max-safe-integer) v max-safe-integer))
+       (double? v)                     (not (Double/isNaN v))
+       :else                           false)
+     :cljs
+     (not (js/Number.isNaN v))))
+
 (defn edn-carryable?
   "Can `v` ride the manifest's EDN wire? Scalars (nil / boolean / number
   / string / keyword / symbol) and collections of carryable values.
@@ -251,13 +313,17 @@
   silently dropped (see `serialise-props`).
 
   The question this answers is exactly `(= v (read (pr-str v)))` under
-  the BUNDLED safe reader — not \"is `v` map-shaped\". The distinction is
-  what the `record?` arm below exists for."
+  the BUNDLED safe reader ON EITHER HOST — not \"is `v` map-shaped\", and
+  not \"is `v` a number\". Those two distinctions are what the `record?`
+  and `wire-number?` arms below exist for."
   [v]
   (cond
     (nil? v)     true
     (boolean? v) true
-    (number? v)  true
+    ;; Not every number crosses. The JVM has numeric types and integer
+    ;; widths the browser has none of, and each one arrives silently
+    ;; WRONG rather than failing — see `wire-number?` (rf2-v4foc).
+    (number? v)  (wire-number? v)
     (string? v)  true
     (keyword? v) true
     (symbol? v)  true
@@ -309,10 +375,15 @@
                 (if bad-key? "KEY" "value")
                 " the manifest's EDN wire cannot carry — the manifest "
                 "records RENDER-TIME prop values and hydration applies "
-                "them as the server-rendered truth, so dropping one would "
-                "hydrate a different tree. Pass serialisable data (derive "
-                "the opaque value inside the view instead of handing it "
-                "in as a prop)")
+                "them as the server-rendered truth, so carrying one "
+                "INEXACTLY would hydrate a different tree. Either the "
+                "value is opaque (a fn, a host object, a record), or it "
+                "is a JVM-only number the browser's reader cannot "
+                "reproduce (a ratio, a bigdec, a bigint, a float, or an "
+                "integer beyond " max-safe-integer "). Pass data both "
+                "hosts hold identically — derive an opaque value inside "
+                "the view, and narrow a number to a double or an "
+                "in-range integer at the point you know what it means")
            {:recovery :pass-serialisable-root-props
             :extra    {:unserialisable-prop k
                        :unserialisable-half (if bad-key? :key :value)}}))))
@@ -400,11 +471,16 @@
     (error/throw-error!
      :rf.error/root-manifest-invalid 'rf.ssr/manifest-script
      (str "root manifest key " (pr-str k) " holds a value the EDN wire "
-          "cannot carry, so the emitted body would not read back — "
-          "`pr-str` emits a tagged or host-object literal the bundled "
-          "safe reader has no constructor for, which would defer an "
-          "emit-time authoring mistake into a client hydration failure. "
-          "Every value on the manifest must be plain EDN data")
+          "cannot carry, so the emitted body would not read back AS "
+          "WRITTEN — either `pr-str` emits a tagged or host-object "
+          "literal the bundled safe reader has no constructor for, or "
+          "it emits a JVM-only number (a ratio, a bigdec, a bigint, a "
+          "float, or an integer beyond " max-safe-integer ") that the "
+          "browser's reader silently reproduces as a DIFFERENT value. "
+          "Both defer an emit-time authoring mistake into the client: "
+          "the first as a hydration failure, the second as a hydration "
+          "that quietly disagrees with the server. Every value on the "
+          "manifest must be plain EDN data both hosts hold identically")
      {:recovery :pass-serialisable-root-props
       :extra    {:unserialisable-manifest-key k}}))
   (str "<script type=\"" manifest-script-type "\" "

--- a/implementation/ssr/test/re_frame/ssr/root_manifest_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/root_manifest_cljs_test.cljc
@@ -466,6 +466,159 @@
   (testing "a record used as a prop KEY is caught by the same arm"
     (is (not (manifest/edn-carryable? {(->WireProbeRecord 1) :v})))))
 
+;; ---------------------------------------------------------------------------
+;; THE NUMERIC HALF OF THE ROUND TRIP (rf2-v4foc, Codex audit of #6407)
+;; ---------------------------------------------------------------------------
+;;
+;; The round-trip property above is driven by ONE host at a time: the JVM
+;; suite emits and reads with `clojure.edn`, the CLJS suite with
+;; `cljs.reader`. Every JVM-only numeric form passes THAT test — it is
+;; the CROSSING that loses, and no same-host suite can see it. This is
+;; why SSR 419/1911, UI 928/16132 and CLJS 10099/49944 were all green
+;; while the wire silently changed application-visible hydration props.
+;;
+;; So the proof below is joined by BYTES rather than by a shared host.
+;; `jvm-emitted-body` is the exact script body the shipped emitter
+;; produced for `{:props {:x 9007199254740993N}}`. Each host then asserts
+;; its OWN half against those same bytes, with the shipped reader:
+;;
+;;   JVM  reads them back as 9007199254740993N  — the value rendered
+;;   CLJS reads them back as 9007199254740992   — a DIFFERENT number
+;;
+;; One wire, two hosts, two values, no error on either side. That is the
+;; defect stated as an executable fact, and it stays executable after the
+;; fix: it is *why* the emitter must now refuse the value.
+
+(def ^:private jvm-emitted-body
+  "The exact `<script>` body the JVM emitter produced for a bigint prop
+  before this fix. Pinned as BYTES because bytes are what actually cross
+  — reconstructing it per-host would beg the question the test asks.
+
+  The JVM half below pins the one token that matters
+  (`9007199254740993N`) against the live printer, so this literal cannot
+  quietly go stale."
+  "{:rf.root/schema-version 1, :root-id :page/shop, :phase :server, :props {:x 9007199254740993N}}")
+
+(deftest jvm-emitted-number-reads-back-differently-on-cljs
+  (testing "rf2-v4foc — the SAME wire bytes, read by the SHIPPED
+            `read-manifest` on each host, yield DIFFERENT hydration props.
+            Asserted as an observable VALUE: nothing throws, which is the
+            entire danger."
+    (let [x (get-in (manifest/read-manifest 'test jvm-emitted-body) [:props :x])]
+      #?(:clj
+         (do
+           (is (= (pr-str 9007199254740993N) "9007199254740993N")
+               "the JVM printer really does emit the bigint token pinned in
+                `jvm-emitted-body` — if this reds, that literal is stale")
+           (is (= 9007199254740993N x)
+               "the SERVER reads its own wire back exactly")
+           (is (= "9007199254740993N" (pr-str x))))
+
+         :cljs
+         (do
+           (is (= "9007199254740992" (pr-str x))
+               "THE DEFECT: the browser's reader silently rounds the
+                server's 9007199254740993 down to 9007199254740992. The app
+                hydrates with a number the server never rendered.")
+           (is (not= "9007199254740993" (pr-str x))
+               "stated the other way round, so the assertion cannot pass by
+                naming the value it is supposed to reject"))))))
+
+(deftest numeric-wire-guard-is-load-bearing
+  (testing "THE RED-BEFORE for the numeric arm, kept executable in the same
+            shape as the `record?` lever above: re-create the predicate
+            that said `(number? v) true` and prove it ACCEPTS the very
+            value the test above shows the far host mangles."
+    (let [lenient-number? (fn [v] (number? v))]
+      #?(:clj
+         (doseq [v [9007199254740993N 1.5M 1/3 9007199254740993 (float 0.1)]]
+           (is (true? (lenient-number? v))
+               (str "the defective predicate waves " (pr-str v) " through — if
+                     this ever goes false the lever is gone"))
+           (is (not (manifest/edn-carryable? v))
+               (str "…and the SHIPPED predicate refuses it: " (pr-str v))))
+         :cljs
+         (let [nan js/NaN]
+           (is (true? (lenient-number? nan)))
+           (is (not (manifest/edn-carryable? nan))))))))
+
+(deftest only-cross-host-numbers-ride-the-wire
+  (testing "rf2-v4foc — what the numeric subset ADMITS. These must keep
+            working: narrowing the wire must not narrow ordinary props."
+    (doseq [v [0 -1 1 1.5 -1.5 9.0 0.1
+               manifest/max-safe-integer
+               (- manifest/max-safe-integer)
+               #?(:clj 1.0E308 :cljs 1e308)]]
+      (is (manifest/edn-carryable? v) (str "must still carry " (pr-str v))))
+
+    (testing "…including through nesting and as a prop KEY"
+      (is (manifest/edn-carryable? {:a [1 {:b #{2 3.5}}]}))
+      (is (manifest/edn-carryable? {1 :v}))))
+
+  (testing "what it REFUSES, and why each one is not merely pedantic"
+    (is (not (manifest/edn-carryable? #?(:clj Double/NaN :cljs js/NaN)))
+        "NaN is excluded by the round-trip property itself — it is not `=`
+         to itself, so it cannot read back EQUAL on any host")
+
+    #?(:clj
+       (do
+         (is (not (manifest/edn-carryable? 9007199254740993N))
+             "bigint: prints an `N` token the browser reproduces as a
+              different number")
+         (is (not (manifest/edn-carryable? 1.5M))
+             "bigdec: prints an `M` token the browser reads as a plain
+              number, changing the prop's TYPE")
+         (is (not (manifest/edn-carryable? 1/3))
+             "ratio: the browser reads `1/3` as 0.3333333333333333 — an
+              APPROXIMATION, silently")
+         (is (not (manifest/edn-carryable? (inc manifest/max-safe-integer)))
+             "a Long one past 2^53-1 carries precision no double holds")
+         (is (not (manifest/edn-carryable? (- (inc manifest/max-safe-integer))))
+             "…and the bound is symmetric about zero")
+         (is (not (manifest/edn-carryable? (float 0.1)))
+             "float: fails the property on the JVM ALONE — the printed
+              shortest-decimal names the DOUBLE 0.1, so it does not read
+              back equal even here")))
+
+    (testing "a large DOUBLE is admitted though it dwarfs the integer
+              bound — the bound is about representability, not magnitude"
+      (is (manifest/edn-carryable? #?(:clj 1.0E308 :cljs 1e308))))))
+
+#?(:clj
+   (deftest non-carryable-number-fails-before-emission
+     (testing "rf2-v4foc — a JVM-only number is refused at ASSEMBLY naming
+               the prop, and at the EMISSION gate naming the manifest key,
+               exactly as an opaque value is. Not a second mechanism —
+               the same `edn-carryable?`, told the truth about numbers."
+       (let [data (try (manifest/manifest
+                        'test {:rf.root/schema-version 1 :root-id :page/shop}
+                        {:props {:promo :spring :ratio 1/3}})
+                       nil
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+         (is (= :rf.error/root-manifest-invalid (:rf.error/id data))
+             "the EXISTING error id — a non-carryable number is not a new
+              failure kind, so it needs no new catalogue row")
+         (is (= :ratio (:unserialisable-prop data)) "the offending prop is NAMED")
+         (is (= :value (:unserialisable-half data))))
+
+       (testing "and the emission gate covers a DESCRIPTOR key too, which
+                 `serialise-props` never sees"
+         (let [data (try (manifest/script-html
+                          {:rf.root/schema-version 1
+                           :root-id                :page/shop
+                           :static-props           {:limit 9007199254740993N}})
+                         nil
+                         (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+           (is (= :rf.error/root-manifest-invalid (:rf.error/id data)))
+           (is (= :static-props (:unserialisable-manifest-key data)))))
+
+       (testing "the bigint that started this: `script-html` no longer
+                 emits the body the CLJS reader mangles"
+         (is (thrown? clojure.lang.ExceptionInfo
+                      (manifest/script-html
+                       (assoc {:rf.root/schema-version 1 :root-id :page/shop}
+                              :props {:x 9007199254740993N}))))))))
+
 (deftest script-emission-gates-the-whole-manifest
   (testing "rf2-v4foc — `serialise-props` screens `:props` at assembly, but
             `script-html` is the only door onto the wire and DESCRIPTOR

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -496,8 +496,9 @@ The manifest rides **one script element per root**:
 **The round trip is exact, and emission is where that is enforced.** For every manifest
 that reaches the wire, reading the body back yields *the same manifest* — not merely a
 readable one. The acceptance predicate is therefore the round trip itself: a value rides
-only if `pr-str` prints it in a form the bundled safe reader reconstructs. Two
-consequences are easy to get wrong, and both are real defects rather than hypotheticals:
+only if `pr-str` prints it in a form **the reader on the OTHER host** reconstructs
+*equal*. Three consequences are easy to get wrong, and all three are real defects rather
+than hypotheticals:
 
 - **Map-shaped is not map-printing.** A record satisfies `map?` yet prints as the tagged
   literal `#my.ns.R{…}`, which the safe reader has no constructor for. Testing shape
@@ -505,6 +506,26 @@ consequences are easy to get wrong, and both are real defects rather than hypoth
 - **Both halves of a prop entry ride the wire**, so both are validated. Screening only
   values admits an opaque *key*, which prints as a host-object literal and fails the same
   way.
+- **Not every number crosses.** The server holds numeric types the browser has none of,
+  and integers wider than a double can hold. `9007199254740993N` prints, and the
+  browser's reader reconstructs `9007199254740992`; `1/3` arrives as
+  `0.3333333333333333`. This one does not throw at the far end — it *succeeds*, with a
+  different value, so the app hydrates against props the server never rendered. The
+  admitted subset is therefore fixed-width integers within ±(2^53−1) and finite doubles;
+  no ratio, bigdec, bigint or float, and no `##NaN` (which the round-trip property
+  excludes on its own terms, not being `=` to itself). A large *double* still rides: the
+  bound is about **representability, not magnitude** — a double of any size carries only
+  precision a double carries.
+
+The first two defects fail loud at the far end; the third is silent, which is why the
+predicate is stated as the crossing rather than as "is this printable EDN". A same-host
+suite cannot see it — the server reads its own bigint back perfectly — so the conformance
+proof is joined by the wire **bytes**, each host reading one pinned body with the shipped
+reader and reporting what it got.
+
+Rejecting rather than coercing is the rule in all three cases. A record silently read
+back as a plain map, or a bigint as a plain number, changes the value's **type** between
+server and client — the very defect a fail-loud wire exists to prevent.
 
 The check belongs at **emission**, not only at prop assembly: descriptor keys reach the
 wire too, so gating `:props` alone leaves the property true of one key and false of the


### PR DESCRIPTION
Closes the last open path in `rf2-v4foc`. Commit `8fa9ac4c3d` already shipped the record-valued props, opaque prop-map keys, and trailing-garbage/second-form arms; this is the numeric one the Codex audit of #6407 found still open.

## The defect

`edn-carryable?` asked *"is this a number?"* where the property it claims is *"does this read back **equal** on the other host?"*. For every numeric form the JVM has and the browser does not, those are different questions — and the gap was silent at both ends:

| JVM emits | browser reads back |
|---|---|
| `9007199254740993N` (bigint) | `9007199254740992` |
| `1.5M` (bigdec) | `1.5` |
| `1/3` (ratio) | `0.3333333333333333` |
| `9007199254740993` (Long) | `9007199254740992` |
| `(float 0.1)` | `0.1` ≠ the Float — fails on the **JVM alone** |

Nothing throws. The app hydrates with application-visible props the server never rendered.

Every same-host suite passed while this was live (SSR 419/1911, UI 928/16132, CLJS 10099/49944) — which is the point. `clojure.edn` reads a bigint back perfectly; only the **crossing** loses.

## The fix

`wire-number?` states the crossing directly. The hosts answer differently because they hold different numbers, not because there are two rules:

- **CLJS** — every number is an IEEE-754 double and the JVM reader reconstructs one exactly, so all of them cross. `##NaN` alone is excluded, and the round-trip property excludes it *on its own terms*: NaN is not `=` to itself, so it cannot read back equal anywhere.
- **JVM** — no ratio, bigdec, bigint or float; integers only within ±(2^53−1).

A large **double** (`1.0E308`) still rides, and is not a contradiction: the safe-integer bound is about **representability, not magnitude**. A Long past 2^53 carries precision no double holds; a double of any size carries only precision a double holds.

Rejecting rather than coercing follows the `record?` arm already in this file — a bigint arriving as a plain number changes the prop's **type** between server and client, the very defect a fail-loud wire exists to prevent.

**No new error id.** A non-carryable number is not a new failure kind, so it rides the existing `:rf.error/root-manifest-invalid` through the existing assembly and emission gates. **No Spec 009 co-edit owed** — `spec/009-Instrumentation.md` is untouched (it is hot-zone on #6365). Both diagnostics now name the numeric cause instead of describing every rejection as an opaque value.

**No codec, no tagged-reader registry, no schema framework** — the bead excludes all three, and none was needed.

## The proof is a genuine cross-host round trip

Joined by **bytes**, not by a shared host. One pinned body — the exact bytes the JVM emitter produced for `{:props {:x 9007199254740993N}}` — read by each host with the **shipped** `read-manifest`:

- JVM reads `9007199254740993N` — the value rendered
- CLJS reads `9007199254740992` — a different number

Same wire, two hosts, two values, nothing thrown. Asserted as an **observable value**, never as a thrown exception, because this class never raises. The JVM half also pins the `9007199254740993N` token against the live printer, so the literal cannot go stale.

## Quality gates

Both foreground, run to completion, unpiped, exit codes captured by redirect.

| Gate | Result |
|---|---|
| `implementation/ssr` → `clojure -M:test` | **467 tests / 2242 assertions, 0 failures** (baseline 463/2203 → +4 tests / +39 assertions) |
| `implementation` → `npm run test:cljs` | **10226 tests / 50533 assertions, 0 failures** |
| `scripts/check-no-hardcoded-paths.sh` | clean |

`npm run test:browser` **not run, and not coupled**: the diff is a pure predicate plus reader logic in `manifest.cljc`, with no mounted hydration and no DOM path touched (`discover` is unchanged). Nothing outside `implementation/ssr` requires `re-frame.ssr.manifest`, and no consumer of `edn-carryable?` exists outside the artefact — verified, not assumed.

### Vacuity probes

Two, each isolating its own lever rather than mutating broadly:

1. **JVM** — reverted `wire-number?` to accept everything. Gate went red with **18 failures across exactly the three fix-asserting tests, by name** (`numeric-wire-guard-is-load-bearing`, `only-cross-host-numbers-ride-the-wire`, `non-carryable-number-fails-before-emission`), and **no neighbouring fixture reddened**. Restored byte-identical.
2. **CLJS** — flipped the cross-host assertion's expected value. Gate went red with **exactly 1 failure naming `jvm-emitted-number-reads-back-differently-on-cljs`**, reporting `actual: (not (= "PROBE-EXPECT-RED" "9007199254740992"))` — the browser reader's real output on the JVM's bytes, observed in the gate rather than assumed. Restored byte-identical.

The red-before is also kept **executable** in the shipped suite, in the same shape as the existing `record?` lever: the defective `(number? v)` predicate is re-created inline and shown to accept the very values the far host mangles.
