### PR TITLE
fix: resolve the EP-0034 G-7 contract and correct the ai-ratchet push base (rf2-ckyfh, rf2-7hq4l)

### DIFF
--- a/.github/workflows/portability.yml
+++ b/.github/workflows/portability.yml
@@ -117,28 +117,64 @@ jobs:
     name: No newly tracked files under ai/
     runs-on: ubuntu-latest
     steps:
-      # fetch-depth: 2 is REQUIRED, not incidental (rf2-ow7dz). The gate
-      # compares the tracked ai/ set against the same set at HEAD^ — the
-      # base-branch tip on a pull_request merge commit, the previous main
-      # tip on a push. At the default depth of 1 that parent is absent and
-      # the gate FAILS closed rather than passing vacuously, so this line is
-      # load-bearing.
+      # fetch-depth: 0 is REQUIRED, not incidental (rf2-ow7dz, rf2-7hq4l). The
+      # gate compares the tracked ai/ set against the last ACCEPTED state, and
+      # that base is the event's accepted base — resolved in the step below,
+      # NOT HEAD^:
+      #   * push to main: github.event.before, the tip main pointed at before
+      #     this push. On a MULTI-COMMIT push HEAD^ is only the second-to-last
+      #     commit of this same push, so a path first tracked in an earlier
+      #     commit and retained at the tip is present on both sides and escapes
+      #     (the rf2-7hq4l defect). The accepted base can be arbitrarily deep,
+      #     so a full checkout is the only depth that is guaranteed to hold it.
+      #   * pull_request: github.event.pull_request.base.sha, the base-branch
+      #     tip — which equals the merge commit's first parent, so HEAD^ was
+      #     already sound here; the base sha is passed explicitly so both event
+      #     shapes share one contract instead of relying on HEAD^ by accident.
+      # If the base cannot be resolved the script FAILS closed rather than
+      # passing vacuously (its own guard), so a missing base certifies nothing.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       # Same precedent as the gate above: lint the gate script itself so a
       # future edit cannot introduce a shell bug that silently weakens it.
       - name: Shellcheck the ratchet script
         run: shellcheck scripts/check-ai-tracking-ratchet.sh
 
+      # Select the event's ACCEPTED base (rf2-7hq4l): the previous main tip for
+      # a push, the PR base tip for a pull_request. A null `before` SHA (the
+      # first push to a fresh ref) and every other event shape leave the ref
+      # empty, so the script falls back to its own HEAD^ default. Context
+      # values arrive via `env:` — never interpolated into the script body — so
+      # the step is injection-safe regardless of what the event carries.
+      - name: Resolve the accepted base
+        id: base
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -eu
+          case "$EVENT_NAME" in
+            push)         base="$PUSH_BEFORE" ;;
+            pull_request) base="$PR_BASE_SHA" ;;
+            *)            base='' ;;
+          esac
+          if [ "$base" = '0000000000000000000000000000000000000000' ]; then
+            base=''
+          fi
+          echo "ref=$base" >> "$GITHUB_OUTPUT"
+
       # Fails when any path is tracked under ai/ that was NOT tracked at the
-      # base, naming every such path. Counts are irrelevant to the decision,
-      # which is what makes it a ratchet rather than a ceiling: an addition
-      # fails even after an earlier removal, and even when a swap leaves the
-      # total unchanged. A decrease passes — S7 (rf2-vxgfnd.99.1) removes the
-      # remaining trees and must never be blocked by this gate — and the base
-      # then tightens on its own, because it is read from git. Invoked via
-      # `sh` so the script needs no executable bit on the runner.
+      # accepted base, naming every such path. Counts are irrelevant to the
+      # decision, which is what makes it a ratchet rather than a ceiling: an
+      # addition fails even after an earlier removal, and even when a swap
+      # leaves the total unchanged. A decrease passes — S7 (rf2-vxgfnd.99.1)
+      # removes the remaining trees and must never be blocked by this gate —
+      # and the base tightens on its own, because it is read from the event.
+      # Invoked via `sh` so the script needs no executable bit on the runner.
       - name: Run the tracked-ai/ ratchet
+        env:
+          AI_RATCHET_BASE_REF: ${{ steps.base.outputs.ref }}
         run: sh scripts/check-ai-tracking-ratchet.sh

--- a/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
+++ b/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
@@ -242,16 +242,27 @@ the stages ahead follow
 - **G-18** (`npm run test:ui-facade-isolation`, a standing required CI job);
   its roster of proven views is derived from the proof-pack library source, so
   a new library view either arms the gate or fails it.
+- **G-16**, render-slot parity, certified with the S3 slice: cross-emitter
+  structural parity, keyed reorder under slots, and purity diagnostics inside
+  slot bodies all run, and the **manifest slot-site arm now ships** — the
+  analyzer indexes each slot site into the compiler manifest and the public
+  `:render-slots` projection reports it, both pinned by focused acceptance.
 
 **Named open:**
 
-- **G-7** beyond its production-absence arm: the dev↔prod equivalence matrix
-  over generated shapes has no test yet.
+- **G-7's broad equivalence matrix.** The production-absence arm is wired and
+  green, and the per-stage equivalence arms landed with their conformance
+  profiles — the S3-shape arm (S3 profile) and the S4-shapes-only arm (S4
+  profile, which deliberately bounded itself to S4 shapes and left the broader
+  debt to its owner). What has no test yet is the *broad, retroactive* S1–S3
+  dev↔prod equivalence matrix over generated shapes — per generated shape,
+  pairwise capabilities, high-risk triples. The requirement stands in full and
+  is owned by **S6** (`rf2-vxgfnd.98`), the stage carrying the remaining
+  absence/equivalence/budget gates (below); it is deferred to that owner, not
+  narrowed.
 - **G-14's remaining arm** — bounded guide-fixtures CI cost, which needs the
   guide-examples corpus and has no assertion anywhere in the repository, as the
   gate's own suite states.
-- **G-16's** "manifest slot sites present" arm (its cross-emitter parity and
-  slot-arity arms do run).
 - **G-2/G-9** — wire with the stages shipping their subjects.
 - Root-manifest hydration + failed-root isolation (S5 — the dual-host spike
   passed structural output only).

--- a/implementation/scripts/_ai-tracking-ratchet.test.cjs
+++ b/implementation/scripts/_ai-tracking-ratchet.test.cjs
@@ -373,6 +373,69 @@ test('ARM 7: an unresolvable base ref fails closed rather than passing vacuously
 });
 
 // ---------------------------------------------------------------------------
+// ARM 8 — THE MULTI-COMMIT PUSH. The base must be the ACCEPTED base of the
+// push, not HEAD^. This is the rf2-7hq4l defect: on a push of more than one
+// commit, HEAD^ is the push's own second-to-last commit, so a path first
+// tracked in an EARLIER commit and retained at the tip is present on both
+// sides of a HEAD^ diff and escapes. The workflow resolves the base to
+// github.event.before (the previously accepted main tip); this arm proves that
+// choice is load-bearing by running the real gate against BOTH bases on one
+// fixture and showing they disagree.
+//
+// Negative control, in the spirit of the count-ceiling controls above but
+// aimed at the BASE-SELECTION defect rather than the counting one: HEAD^ (the
+// pre-fix base) PASSES this fixture — the exact false green — while the
+// accepted push base FAILS and names the path.
+
+test('ARM 8: a multi-commit push — an ai/ path added before the tip escapes HEAD^ but is caught by the accepted push base', () => {
+  withFixtureRepo((h) => {
+    // The previously accepted main tip: one pre-existing tracked ai/ file, no
+    // probe. This SHA is what github.event.before carries for the push below.
+    h.write('README.md', '# fixture\n');
+    h.write('ai/findings/kept.md', '# already accepted\n');
+    h.commit('B: the previously accepted main tip');
+    const acceptedBase = h.git('rev-parse', 'HEAD').trim();
+
+    // c1 — the FIRST commit of a two-commit push ADDS the probe under ai/.
+    h.write('ai/_audit-multicommit-probe.md', '# added in an earlier commit of the push\n');
+    h.commit('c1: track a new ai/ path');
+
+    // c2 — the tip. It touches something unrelated and RETAINS the probe, so
+    // HEAD^ (= c1) already has it.
+    h.write('README.md', '# fixture, edited at the tip\n');
+    h.commit('c2: the pushed tip, probe retained');
+
+    // BUG SHAPE — HEAD^ is c1, which already tracks the probe, so the diff is
+    // empty and the gate PASSES. This is what the unfixed push path did.
+    const viaHeadParent = h.run('HEAD^');
+    assert.equal(
+      viaHeadParent.status,
+      0,
+      'HEAD^ points inside the push and misses a path added before the tip — the rf2-7hq4l blind spot',
+    );
+    assert.equal(viaHeadParent.currentCount, 2);
+    assert.match(viaHeadParent.stdout, /unchanged from base HEAD\^/);
+
+    // FIX SHAPE — comparing the pushed tip against the ACCEPTED base (B) makes
+    // the probe an addition, so the gate FAILS and names it.
+    const viaAcceptedBase = h.run(acceptedBase);
+    assert.equal(
+      viaAcceptedBase.currentCount,
+      2,
+      'the same index is compared — only the base differs',
+    );
+    assert.equal(
+      viaAcceptedBase.status,
+      1,
+      'against the accepted push base a path first tracked in an earlier commit must fail',
+    );
+    assert.match(viaAcceptedBase.stderr, /ADDED: ai\/_audit-multicommit-probe\.md/);
+    assert.match(viaAcceptedBase.stderr, /1 path\(s\) newly tracked under ai\//);
+    assert.match(viaAcceptedBase.stderr, /tracked 1 file\(s\) under ai\/; this change tracks 2/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Non-vacuity of the SUITE itself: the arms above are not all failures. If a
 // future edit made the gate fail unconditionally, arms 1, 3, 6a and the drain
 // would catch it — this asserts that mix is actually present, so the suite
@@ -383,6 +446,7 @@ test('SUITE: the arms include genuine passes, so a fail-everything gate is caugh
   assert.ok(names.some((n) => n.startsWith('ARM 1')), 'a passing arm must be present');
   assert.ok(names.some((n) => n.startsWith('ARMS 3+4')), 'the decrease-then-increase sequence must be present');
   assert.ok(names.some((n) => n.startsWith('ARMS 6a+6b')), 'the end-state sequence must be present');
+  assert.ok(names.some((n) => n.startsWith('ARM 8')), 'the multi-commit push tooth must be present');
 });
 
 let failed = 0;

--- a/scripts/check-ai-tracking-ratchet.sh
+++ b/scripts/check-ai-tracking-ratchet.sh
@@ -59,17 +59,23 @@
 # real cost, and it is the intended one — the alternative is a lever that a
 # force-add can pull on its own.
 #
-# BASE resolution — `HEAD^`, the first parent, which is the last accepted
-# state in both CI shapes:
-#   * pull_request: CI checks out the MERGE commit, whose first parent is
-#     the base-branch tip. Difference = exactly what this PR adds.
-#   * push to main: the first parent is the previously accepted main tip.
-#     Difference = exactly what this push adds.
-# Override with AI_RATCHET_BASE_REF for other shapes and for this gate's own
-# teeth tests. If the base cannot be resolved (root commit, or a depth-1
-# shallow clone) the gate FAILS rather than passing: a guard that cannot see
-# its base must not certify anything. The workflow therefore checks out with
-# fetch-depth: 2.
+# BASE resolution. The base is read from AI_RATCHET_BASE_REF, defaulting to
+# `HEAD^` only when it is unset or empty. CI sets it to the EVENT's accepted
+# base (rf2-7hq4l) and never lets the default stand in for a push:
+#   * pull_request: github.event.pull_request.base.sha, the base-branch tip.
+#     This equals the merge commit's first parent, so HEAD^ was already sound
+#     here; the workflow passes it explicitly so both shapes share one rule.
+#   * push to main: github.event.before, the tip main pointed at before the
+#     push. HEAD^ is NOT that tip on a MULTI-COMMIT push — it is the push's own
+#     second-to-last commit — so a path first tracked in an earlier commit of
+#     the push and retained at the tip would sit on both sides of a HEAD^ diff
+#     and escape. Comparing against the accepted base names it instead.
+# `HEAD^` stays the default for LOCAL and manual runs, where the parent is a
+# sensible base and there is no event to consult. If the base cannot be
+# resolved (root commit, or an over-shallow clone) the gate FAILS rather than
+# passing: a guard that cannot see its base must not certify anything. The
+# workflow therefore checks out with fetch-depth: 0, because the accepted push
+# base can be arbitrarily deep.
 #
 # Cross-platform: POSIX sh. No bashisms (`[[`, arrays, `<<<`, process
 # substitution). Runs identically on the ubuntu-latest CI runner, on macOS,


### PR DESCRIPTION
> **Follow-up:** this PR merged the *pre-ruling* G-7 reconciliation. The `rf2-ckyfh` operator ruling (2026-07-19 14:58) mandates a **two-layer** G-7 contract and rejects the "pairwise capabilities + high-risk triples" wording retained below. **Layer 1 (the advanced parity-corpus prod-elision proof) and the full two-layer reconciliation land in #6449.**

Two independent fixes, one commit each.

## rf2-ckyfh — resolve the ownerless G-7 equivalence contract, retire the stale G-16-open row

EP-0034 §5 left G-7's broad S1–S3 dev↔prod equivalence matrix ownerless while the S4 conformance profile pointed at an *"existing named-open owner"* that no bead named, and it still listed G-16's manifest-slot-sites arm as open after that arm shipped. A reader could not tell whether the broad matrix was required, deferred, or dropped.

**Option chosen: (a) retain, do not narrow.** Building the broad proof was out of scope for this PR (it lives in `implementation/ui/**`) and narrowing G-7 needed an operator ruling not yet available at the time — so the requirement is kept and given a concrete live owner.

- **G-7 — TRUE conclusion, dead basis rewritten.** The conclusion (the broad matrix over generated shapes has no test yet) is kept; the row now names the concrete live owner **S6 (`rf2-vxgfnd.98`)**. *(Superseded by the ruling — see #6449, which replaces this with the two-layer contract and names the S6 leaf `rf2-55zsd`.)*
- **G-16 — FALSE conclusion, replaced.** The manifest-slot-sites arm ships and is pinned (`analyze_accept_cljs_test.cljc` slot-site indexing; the public `:render-slots` projection in `tool_cljs_test.cljc`; `rf2-ri0k6n` closed; G-16 certified at `rf2-vxgfnd.95.10`). The stale open row is removed and G-16 graduates into "Wired and green".

**Guardrails honoured:** the EP-0034 §4 G-18 over-claim row (`rf2-kxork`'s pending ruling) left untouched; no EP status flipped.

## rf2-7hq4l — compare the ai/ ratchet against the actual push base, not HEAD^

The tracked-ai/ ratchet compared the tip index against `HEAD^`. On a push of more than one commit, `HEAD^` is the push's own second-to-last commit, not the previously accepted main tip — so a path first tracked in an **earlier** commit of the push and retained at the tip sits on both sides of the diff and escapes.

**Fix (workflow-level; the set-difference script is preserved).** `portability.yml` resolves the event's accepted base and passes it as `AI_RATCHET_BASE_REF`: `github.event.before` for a push, `github.event.pull_request.base.sha` for a pull_request, empty (script default `HEAD^`) for a null before-SHA or any other event. Context values arrive via `env:`, never interpolated into the script body, so the step is injection-safe. Checkout deepens to `fetch-depth: 0`. The script's fail-closed resolution and its `HEAD^` local/manual default are untouched.

**Tooth — arm 8.** A two-commit push fixture whose ai/ probe is added in the first commit and retained at the tip runs the real gate against both bases: `HEAD^` passes (the blind spot), the accepted base fails and names `ai/_audit-multicommit-probe.md`. Proven red against a mutant that hardcodes `HEAD^`. Suite 7 arms -> 8. The tracked ai/ set is unchanged (**85**).

## Quality gates

- `sh scripts/check-ai-tracking-ratchet.sh` -> PASS, **85** tracked (unchanged from base)
- `node implementation/scripts/_ai-tracking-ratchet.test.cjs` -> **8 arms passed** (7 -> 8)
- `npm run test:script-policy` -> exit 0 (full 25-test chain)
- `python -m mkdocs build --strict` -> exit 0 **and** `python scripts/check_doc_slugs.py` -> exit 0
- `python scripts/check_ep_status_sync.py` -> exit 0
- `cd implementation/ui && clojure -M:test` -> **965 tests / 18672 assertions / 0 failures**
- `sh scripts/check-no-hardcoded-paths.sh` -> exit 0
