### PR TITLE
docs(spec): certified/specified split for view identity and retire the bare-handlers lint key (rf2-ed1py, rf2-b6pua)

### DIFF
--- a/docs/EP/EP-0030-the-compiled-view-substrate-program.md
+++ b/docs/EP/EP-0030-the-compiled-view-substrate-program.md
@@ -100,7 +100,7 @@ The program was ratified as one decision record (2026-07-11). The rulings:
 | R-1 | Spec 004 | Staged merge: the portability law landed immediately; the full normative rewrite merged atomically with the first conforming Stage-1 slice. |
 | R-2 | Spec 006 | Observation-port semantics frozen up front, exact shapes from the ownership spike; the port lives outside the closed ten-fn adapter map. Normative in Spec 006 since S2. |
 | R-3 | Name | `re-frame.ui`, alias `ui`, artifact `day8/re-frame2-ui`; "facet" never public vocabulary. |
-| R-4 | Bare fns | Legal only in known native event properties (invoker + phase known); day-one strict lint `{:re-frame.ui/bare-handlers :warn\|:error}`. |
+| R-4 | Bare fns | Legal only in known native event properties (invoker + phase known); the proposed day-one strict lint was withdrawn pre-alpha (style, not safety — rf2-b6pua ruling, 2026-07-19). |
 | R-5 | Resumability | Research-tier, decisively; serializability preserves the option and creates no obligation. |
 | R-6 | Packaging | Separate artifact on a lockstep release train; not casually revisited at alpha. |
 

--- a/docs/EP/EP-0031-re-frame-ui-programming-model.md
+++ b/docs/EP/EP-0031-re-frame-ui-programming-model.md
@@ -114,10 +114,10 @@ retained as data in the manifest and JVM tree.
 `ui/event` (committed phase + the live event; `nil` ⇒ no dispatch), `ui/handler`
 (imperative, stable identity), `ui/render-fn` (render phase, pure — and also the
 value an internal `ui/slot` accepts), the **narrow bare-fn law (R-4)** — bare
-`#(…)` legal only in known native event properties, with a day-one strict lint
-(`{:re-frame.ui/bare-handlers :warn|:error}`) instead of a language flip (the
-lint key is reserved in `spec/Conventions.md`; compiler enforcement is a known
-build gap — see Open Issues) — a compile error at foreign-component boundaries,
+`#(…)` legal only in known native event properties (invoker and phase known),
+the language permissive rather than flipped (the proposed day-one strict lint was
+withdrawn pre-alpha — style, not safety; rf2-b6pua ruling, 2026-07-19) — a compile
+error at foreign-component boundaries,
 and `ui/raw-fn` for identity-as-protocol APIs and callback refs. Dynamic handler
 expressions classify at runtime by type; placeholders are recognized in literal
 vectors only (dev warns on a placeholder riding a runtime vector); loop handlers
@@ -249,7 +249,9 @@ Reagent-compat appendix).
   local ephemera); the forbidden tier is defined by what the *value* needs, not
   by whether any handler ever reads it.
 - **R-4 — the narrow bare-fn law (2026-07-12).** Bare fns only in known native
-  event properties; a strict lint over a language flip.
+  event properties; the language permissive, not flipped. (The proposed strict
+  lint was withdrawn pre-alpha — style, not safety; rf2-b6pua ruling,
+  2026-07-19.)
 - **Placeholder vocabulary closed (2026-07-12).** Three scalars;
   `:rf.ui/form-data` and `:rf.ui/event` rejected — both cases belong to
   `ui/event`.
@@ -275,9 +277,7 @@ Reagent-compat appendix).
 
 ## Open Issues
 
-None on the decision surface. One known build gap: the
-`{:re-frame.ui/bare-handlers :warn|:error}` strict lint is reserved in
-`spec/Conventions.md` but not yet implemented in the compiler.
+None on the decision surface.
 
 ## References
 

--- a/docs/EP/EP-0033-re-frame-ui-view-evidence.md
+++ b/docs/EP/EP-0033-re-frame-ui-view-evidence.md
@@ -63,7 +63,7 @@ loss accounting; and a bounded render-cause **set** — `#{:value :hmr
 :disposed}` — with `:local-state` cause evidence riding G-15.
 
 **Specified below but not yet shipped:** the integer `:render-key` /
-`:parent-render-key` / `:frame-id` / `:generation` record fields; the
+`:parent-render-key` / `:generation` record fields and the keyword `:frame-id`; the
 `:rf.view/causes` **vector** and its full cause-kind roster (`:mount`,
 `:subscription` with version from→to, `:prop`, `:epoch-restore`,
 `:hydration-correction`, `:reconnect-correction`, `:foreign-or-react`, …); the
@@ -72,9 +72,10 @@ roots; and the Spec 009 evidence-schema rows.
 
 Consumers tolerate the absences explicitly rather than fabricating them
 (`tools/xray/spec/021` §3.4.1: the S3 producer emits no epoch-restore evidence
-op, and Xray does not invent one). The unshipped delta carries no stage
-assignment and no owner — the Spec 004 ledger row names only budget/absence
-gates for S6 (see Open Issues). The schema below is the ruled design intent.
+op, and Xray does not invent one). The unshipped delta is staged to **S6** and
+owned by `rf2-vxgfnd.98.1` (rf2-ed1py ruling, 2026-07-19); the Spec 004 ledger
+row names its budget/absence gates for S6. The schema below is the ruled design
+intent.
 
 ### Two evidence layers
 
@@ -251,9 +252,11 @@ its own versioned schema from day one.
 
 ## Open Issues
 
-1. The specified-but-unshipped evidence-schema delta (§Shipped surface and
-   specified extensions) has no stage assignment and no owner — the Spec 004
-   ledger row names only budget/absence gates for S6.
+1. **Resolved by assignment (rf2-ed1py ruling, 2026-07-19).** The
+   specified-but-unshipped evidence-schema delta (§Shipped surface and specified
+   extensions) is staged to **S6** and owned by `rf2-vxgfnd.98.1`, a
+   trigger-gated child of the S6 epic. The Spec 004 ledger row's budget/absence
+   gates for S6 stand.
 2. Deferred with a named trigger: a Static-mode mounted-views/manifest-browse
    surface goes to the post-S3 IA review, triggered only if dogfooding shows
    the Views-tab + `mounted-views` assembly failing.

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -384,10 +384,9 @@ built on it is not v1).
 
 **The narrow bare-fn law (R-4).** As an *invoked callback*, a bare fn is legal **only**
 in known native event properties, where the invoker and phase are known. One callback
-never serves both phases. A day-one **strict lint** — `{:re-frame.ui/bare-handlers :warn}`
-(or `:error`) — lets a team adopt explicit-everywhere as policy without a language change;
-the language itself stays permissive (flipping it later would break source; the lint is
-the honest lever). **An ordinary fn prop between INTERNAL views** (compile-resolved Vars)
+never serves both phases. Event vectors are the canonical handler form; the bare fn is
+intentionally legal only where invoker and phase are known, and the language itself stays
+permissive. **An ordinary fn prop between INTERNAL views** (compile-resolved Vars)
 is **not** a callback position: it is a **legal opaque value** — identity-compared like
 any other prop, never invoked by the framework, promising **no** invocation phase; the
 receiving view's own contract decides its use (C-13a). To opt a fn into a *phase*, use
@@ -1369,7 +1368,7 @@ a conflict is resolved in that order and is a defect in this table.
 | §Template grammar — prop conversion (the rule table; `ui/spread`) | **S1** | conversion-table fixtures consumed by both emitters (owning table: [004B-UI-Tree-and-Conversion.md](004B-UI-Tree-and-Conversion.md)); `spread` dynamic-map cases |
 | §Template grammar — custom elements (`ui/custom-element`, RULED grammar) | **S4** | property-vs-attribute classification; SSR attributes-only; W14 fixtures |
 | §Handlers — event vectors as structural data (manifest flags; JVM-tree `:events`) | **S1** | vectors/options-maps retained as data in tree + manifest; placeholder keywords retained as keywords |
-| §Handlers — committed behaviour (decision table, bare-fn law + lint, dynamic classification, loops, refs, the synchrony door) | **S3** | decision-table fixtures; sync-door fixture (input-door predicate; G-8 real-browser matrix is the residual named gate); loop/ref diagnostics |
+| §Handlers — committed behaviour (decision table, bare-fn law, dynamic classification, loops, refs, the synchrony door) | **S3** | decision-table fixtures; sync-door fixture (input-door predicate; G-8 real-browser matrix is the residual named gate); loop/ref diagnostics |
 | §Reactive reads — `sub` | **S2** | one-ViewCell binding; stabilization; conditional reads (the loop *rejection* is a compile error from S1) |
 | §The committed-frame ops bundle — `frame` | **S2** | the mounted committed-frame bind (dispatch-through-the-bundle repaints the mounted `sub`; cross-render bundle-identity stability); ambient `frame-provider` retarget; the same-id reincarnation race (the stale bundle fails loud, the replacement frame is untouched, a fresh read re-mints a new identity); stale-op `:rf.error/frame-destroyed` fencing; JVM live-ops (a real bundle during Tier-1 render, not a `jvm-host-op` stub); the always-on observability fan-out on every bundle failure (one record + one dev trace before the throw). The zero-arity, loop, deferred-callback, and root-expression *rejections* are compile-time — asserted with the form at S2 through the accept/reject analyzer fixtures (the form rides the S2 closed-macro expression grammar) |
 | §Process substrate — `ui/adapter` | **S2** | exact closed adapter map; canonical `:rf.adapter/ui` discriminator; copied-kind routing; dispose/re-init; watch re-arm; real provider/render/flush/dispose browser proof |
@@ -1411,7 +1410,7 @@ non-reactive rows · the removed-forms absences. That set passing its named asse
 [TRANSITION] land at **S7** with the Helix-removal wave — no row moves to a 004A
 appendix, because none lands;
 identity/naming/reservation rows (Conventions reserved `:rf.ui/*` namespace + artifact
-registration + lint key, Ownership's new-surface rows, `spec/API.md`'s `re-frame.ui`
+registration, Ownership's new-surface rows, `spec/API.md`'s `re-frame.ui`
 additions, the 008 `ui.test`/selector rows) land at **S1** with this rewrite;
 behaviour rows land with the stage that asserts their subject (002 frame chain → S2,
 006 observation port → S2, 009 evidence schema + catalogue rows → their features'
@@ -1429,7 +1428,8 @@ stages in small batches, 011 → S5).
 - **R-3 — naming.** `re-frame.ui`, alias `ui`, artifact `day8/re-frame2-ui`; supporting
   `re-frame.ui.test` / `.react` / (if earned) `.data`. Separate artifact on a lockstep
   release train initially (R-6).
-- **R-4 — the narrow bare-fn law + strict lint** (§Handlers).
+- **R-4 — the narrow bare-fn law** (§Handlers). *(strict lint withdrawn pre-alpha —
+  style, not safety; rf2-b6pua ruling, 2026-07-19)*
 - **Presence ruling** — wrapper form, no reserved nodes; `:timeout-ms` mandatory (it *is*
   the exit retention duration, and the boundary stays DOM-agnostic — rf2-0ufty);
   `presence-phase` returns `:present` outside a boundary (§Presence).

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -1139,6 +1139,21 @@ here), **occurrence-path** (a keyed repetition inside one instance — owned her
 compile-time indexes + source anchors; identity under HMR is source anchor + structural
 path + generation, released/remounted on ambiguity.
 
+**Specified vs certified.** The surface below is the ruled design intent; the S3
+conformance slice certifies a bounded **subset** of it
+([`spec/conformance/S3-view-conformance-profile.md`](conformance/S3-view-conformance-profile.md)),
+mirroring [EP-0033 §Shipped surface](../docs/EP/EP-0033-re-frame-ui-view-evidence.md#shipped-surface-and-specified-extensions).
+**Certified today:** occurrence-shaped instance records — an `:occurrence` ordinal +
+`:view-id` + `:root-id` + `:connection` + `:lifecycle` intervals + bounded render evidence
+with explicit loss accounting — and a bounded render-cause **set**, `#{:value :hmr
+:disposed}`. **Specified for S6:** the rich per-commit committed-instance record (integer
+`render-key` / `parent-render-key` / `generation`; **keyword** `frame-id`; `root-id`,
+`view-id`, connection state, observations); the full `:rf.view/causes` **vector** and its
+cause-kind roster; the `data-rf2-source-coord` + render-key DOM annotation on
+compiler-owned host roots; and the Spec 009 evidence-schema rows. That unshipped delta is
+staged to **S6** and owned by `rf2-vxgfnd.98.1`; consumers tolerate the absences
+explicitly rather than fabricating them (`tools/xray/spec/021` §3.4.1).
+
 - **Compiler manifest — what *can* happen.** Per view, dev: source coords, prop slots +
   schema, template fingerprint, hook signature, capability bits, and every site (subs
   with query shapes; events with event shapes + `:serializable?`/`:dynamic` flags;
@@ -1377,7 +1392,7 @@ a conflict is resolved in that order and is a defect in this table.
 | §Roots and mounting — frame preflight ENSURE (runtime) + `frame-root`/`frame-provider` scoping | **S2** | preflight-exactly-once, non-reseed, StrictMode/HMR-immune fixtures |
 | §Roots and mounting — hydration + Root Manifest v1 | **S5** | manifest extension keys; multi-root hydration + failed-root isolation |
 | `ui.test` surfaces this Spec references | **S1** core (render/find/find-all/text/attrs over Tier-1 trees; the frame-targeted synchronous `dispatch!` dispatch-and-drain, no mounted variant; `query` enforces the tier split) → **S2** mounted semantics (Promise-backed `with-root`; native-CSS `query`; Promise-backed zero/thunk `flush!` on CLJS, synchronous nil on JVM; platform APIs for already-host-owned DOM mechanics, no gesture DSL) → **S4** `flush-presence!` | selector-grammar fixtures; JVM-subset enforcement; real React mount/query/total-teardown/open-drain/forgotten-await/fixed-point fixtures. Compiled event-vector delivery through native events rides the S3 handler row, not the S2 mount surface |
-| §View identity and the instrumentation surface | **S3** → budget/absence gates complete **S6** | manifests, instance records, cause vectors, Xray consumption (compile-time site anchors exist from S1; the evidence schema asserts S3); production erasure G-7/G-11 |
+| §View identity and the instrumentation surface | **S3** → budget/absence gates complete **S6** | manifests, instance records, cause vectors, Xray consumption (compile-time site anchors exist from S1; the **bounded evidence subset** asserts S3 — the full evidence schema plus the budget/absence gates complete S6, owned by `rf2-vxgfnd.98.1`); production erasure G-7/G-11 |
 | §The JVM structural subset — structure/props/branches/lists/event intent/`ui/html` + `:rf.error/jvm-host-op` | **S1** | Tier-1 rendering against the tree contract |
 | §The JVM structural subset — subs via the pure snapshot path | **S2** | the Q32/Q22 answer: `sub` *grammar* compiles at S1, but no Stage-1 Tier-1 fixture exercises a sub read — a Tier-1 render through a sub site (frame or `:sub-overrides`) is an S2 assertion |
 | §Hot reload — the view-side contract | **S2** | the full HMR matrix ([EP-0030 §Stages S1–S7](../docs/EP/EP-0030-the-compiled-view-substrate-program.md#stages-s1s7) places it with reactivity, deliberately early) |

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -149,7 +149,6 @@ The v1 `re-frame.alpha` namespace is **not part of v2**. The generalised `reg`/`
 
 - **Per-kind registration macros**: `reg-event`, `reg-sub`, `reg-fx`, `reg-cofx`, `reg-flow`, `reg-route`, `reg-machine`, `reg-app-schema`, `reg-view`, `ui/defview`. (`ui/defview` — the compiled-view substrate's registration macro (`re-frame.ui`, artifact `day8/re-frame2-ui`) — registers under the same registrar `:view` kind as `reg-view`; `reg-view` lives on as part of the stock-Reagent compatibility/interop adapter, per [Spec 004 §Removed forms](004-Views.md#removed-forms--normative-absences).)
 - **Vector-form subscribe**: `(rf/subscribe [::id arg])`.
-- **Compiled-view lint config**: `{:re-frame.ui/bare-handlers :warn|:error}` is the reserved build-config lint key that opts a team into explicit-everywhere handler policy (rejecting the permissive bare-fn shorthand at native event properties). The `re-frame.ui` namespace is reserved for such compiled-view build/lint config keys, per [Spec 004 §Handlers](004-Views.md#handlers-are-data--the-callback-law).
 
 The per-frame sub-cache uses a single disposal algorithm — synchronous ref-counting (dispose on derefer-count → 0) — per [Spec 006 §Reference counting and disposal](006-ReactiveSubstrate.md#reference-counting-and-disposal). For one-shot or persistent-value edge cases that would have leaned on a specific lifecycle policy, file a bead naming the actual need rather than reaching for a removed API.
 

--- a/spec/conformance/S3-view-conformance-profile.md
+++ b/spec/conformance/S3-view-conformance-profile.md
@@ -151,8 +151,11 @@ S3 view evidence is a dev/test-only projection with **no production egress**
 props schema, per-prop docs/defaults, declared render-slot sites, interop sites,
 capability cost, and site counts — the one projection Story, docs, Xray, and
 agents consume. Sibling projections: `mounted-views`, `explain-render` (the
-`:value`/`:hmr`/`:disposed` render-cause set), `view-dependencies`. Host-state
-writers (`local`) participate in `:local-state` cause evidence. All of it is
+`:value`/`:hmr`/`:disposed` render-cause set), `view-dependencies`. The shipped
+cause union is exactly `#{:value :hmr :disposed}`; host-state writers (`local`)
+are proven through G-15's writer-composition and render-count evidence, **not** a
+`:local-state` cause row — a `:local-state` render cause is specified for S6
+(`rf2-vxgfnd.98.1`), not shipped at S3. All of it is
 absent from advanced production bundles (`tool_evidence_elision_prod_test`,
 `tool_view_elision_prod_test`, `sub_overrides_elision_prod_test`).
 
@@ -186,7 +189,7 @@ roster. The S3-specific arms this profile certifies:
 | **G-7** | dev/prod equivalence; `client-only` fallback; committed DOM/events/owners agree with debug off |
 | **G-8** | real Chromium **and** WebKit controlled-input matrix — IME composition, caret restoration, event ordering, pre-paint — through the reusable event-prefix component, with the deliberate async-door regression as the tooth |
 | **G-11** | exact production absence of the debug + absence rosters (view evidence, manifest, HMR shell, source-coord, `re-frame.ui.test`) from advanced bundles |
-| **G-15** | atomic-local writer matrix — N same-turn `update!` writers land; fn-value `set!` stores exactly; **mixed `update!`+dispatch**; StrictMode replay; JVM typed failure; `:local-state` cause rows; HMR ride |
+| **G-15** | atomic-local writer matrix — N same-turn `update!` writers land; fn-value `set!` stores exactly; **mixed `update!`+dispatch**; StrictMode replay; JVM typed failure; writer composition + render count (not a `:local-state` cause row — that cause is specified for S6); HMR ride |
 | **G-16** | render-slot parity across both emitters; keyed reorder under slots; purity diagnostics inside slot bodies; manifest slot sites |
 | **G-17** | safe-spread owned-key rejection in dev **and** advanced builds; `aria-*`/`data-*` pass; the policy form retains the sync door where general `spread` forfeits it |
 | **G-18** | library façade isolation — an advanced build importing one view retains no unused siblings (fixture-first; a substrate packaging change is justified only if it fails structurally) |


### PR DESCRIPTION
Two operator rulings (Fable, delegated by Mike, 2026-07-19), both editing `spec/004-Views.md` (hot-zone) — sequenced as two commits, one file shared.

## rf2-ed1py — certified/specified split for view identity (Option A)

The rich view-evidence schema stays as **design intent**; the unshipped delta is staged to **S6**, owned by existing bead `rf2-vxgfnd.98.1` (referenced, not duplicated).

- **`spec/004-Views.md` §View identity** — added a specified-vs-certified split mirroring EP-0033 §Shipped surface (certified = the S3 bounded model: occurrence-shaped instance records + `#{:value :hmr :disposed}`; specified-for-S6 = rich per-commit fields, full `:rf.view/causes` vector, DOM annotation, Spec 009 evidence rows).
- **`spec/004-Views.md` conformance-ledger row** — corrected the false "the evidence schema asserts S3" claim: the bounded evidence **subset** asserts S3; the full schema plus budget/absence gates complete S6.
- **Type fix** — `frame-id` is a **keyword**, not integer (Spec 002 / Spec-Schemas; EP-0033's own example uses `:frame-id :shop`). Fixed the "integer" grouping in EP-0033 §Shipped surface; the new spec/004 prose types it correctly. No second schema.
- **S3-profile correction** — `spec/conformance/S3-view-conformance-profile.md` (§4 prose + G-15 roster row) claimed a `:local-state` cause the implementation never emits. The shipped union is exactly `:value`/`:hmr`/`:disposed` (verified in `implementation/ui/src/re_frame/ui/tool/evidence.cljc`; `:local-state` appears nowhere in `implementation/ui/src` as a cause). The `:local-state` cause moved to the S6 delta.
- **EP-0033** — Open Issue 1 resolved-by-assignment; §Shipped surface stale "no owner/stage" sentence updated. Graduation clause and EP status unchanged.

## rf2-b6pua — retire the bare-handlers lint key

Retired the `{:re-frame.ui/bare-handlers :warn|:error}` lint key and its day-one promise entirely; kept the narrow bare-fn law (**R-4**) exactly as shipped. The reserved key's `:warn|:error` shape contradicted Spec 004's own compile-warning contract (a warning never fails a build — no severity configuration).

- **`spec/004-Views.md`** — dropped the strict-lint sentence from the R-4 law (replaced with a plain permissive statement); "bare-fn law + lint" → "bare-fn law"; dropped "+ lint key" from the ripple row; R-4 resolved decision + dated withdrawal note.
- **`spec/Conventions.md`** — deleted the reserved Compiled-view lint config bullet.
- **`docs/EP/EP-0030` + `docs/EP/EP-0031`** — recorded the pre-alpha withdrawal (dated notes); EP-0031 Open Issues returns to "None on the decision surface." EP statuses unchanged.

R-4's structural law (bare fns legal only at known native event properties; compile error at foreign/ref/non-event sites) is untouched.

## Quality gates

All run in the foreground to completion:

- `python -m mkdocs build --strict` — exit 0 (built in 39.25s; no WARNING/ERROR; the only INFO lines are pre-existing and unrelated to edited files).
- `python scripts/check_doc_slugs.py` — exit 0.
- `python scripts/check_ep_status_sync.py` — exit 0.
- `cd implementation/ui && clojure -M:test` — **965 tests, 18664 assertions, 0 failures, 0 errors** (exit 0). Includes `guide_truth_jvm_test` (pins `spec/004-Views.md` by exact path) and the `s3_conformance_profile_jvm_test` drift-guard — both green.
