### PR TITLE
docs(EP): align the EP process and template with the PEP structure (rf2-iywds)

### DIFF
--- a/docs/EP/EP-0009-the-ep-process.md
+++ b/docs/EP/EP-0009-the-ep-process.md
@@ -136,15 +136,28 @@ The `Status:` line is machine-readable. Its value MUST be one of:
 
 ### Document conventions
 
-- Filename `EP-NNNN-slug.md`; preamble lines `Status:` and `Type:`; standard
-  sections (Abstract, Motivation, Goals/Non-Goals, Relationships,
-  Specification, Rationale, Backwards Compatibility, Bead Plan /
-  Reference Implementation, Open Issues, Recommendation) as applicable.
+- Filename `EP-NNNN-slug.md`; preamble lines `Status:` and `Type:`, plus
+  `Created:` and — from acceptance onward — `Resolution:` for new EPs. New and
+  materially revised EPs follow one forward-looking top-level structure:
+  **Abstract → Motivation → Specification → Rationale → Backwards Compatibility
+  → Resolved Decisions → Open Issues → References**, keeping the sections that
+  apply. This is the compact PEP shape the EP-0030..EP-0035 corpus adopted, and
+  it is the authoring default. Older EPs (this one included) keep their existing
+  sections — their bodies are a historical record, not a migration backlog.
+- Where the older house sections now live: **scope** (goals/non-goals) opens the
+  Specification, and the **ownership** half of the old Relationships section
+  joins it there; **relationships/provenance** — dependencies, cross-references,
+  and supporting spikes/findings — live in **References**; **implementation
+  tracking** lives in the beads issue tracker (referenced from References), and
+  the graduation **guide-impact** assessment closes the Specification (rule 5);
+  **resolved rulings** live in **Resolved Decisions** (rule 2); and the author's
+  **recommendation** is argued in the body and dispositioned under Resolved
+  Decisions once the operator rules.
 - New EPs carry `Type: standards-track` or `Type: process`. EPs predating this
   process may omit `Type:` and are treated as standards-track.
 - State the positive principle first; subtractive framing is migration
   mechanics, not the rule (the EP-0002 lesson).
-- Dependencies live in `Relationships`; the index row in `docs/EP/README.md`
+- Dependencies live in `References`; the index row in `docs/EP/README.md`
   carries status + one-line summary. `check_ep_status_sync.py` enforces README
   status sync, the status grammar, and the `Type:` header rule for post-EP-0005
   EPs.

--- a/docs/EP/EP-template.md
+++ b/docs/EP/EP-template.md
@@ -2,6 +2,7 @@
 
 Status: proposal
 Type: standards-track
+Created: <YYYY-MM-DD>
 
 <!--
 AUTHORING TEMPLATE — copy this file to `EP-NNNN-<slug>.md`, fill it in, and
@@ -54,6 +55,12 @@ require the header; the gate enforces it).
     (e.g. EP-0007 names `Conventions.md` §Namespacing) or the active EP
     itself (the PEP-8 precedent — EP-0009's home is EP-0009). Name exactly one.
 
+==== Created / Resolution ====
+
+`Created:` is the date this EP file was first added (ISO `YYYY-MM-DD`). Add a
+`Resolution:` line when the operator rules — the acceptance or finalisation date
+(the six re-frame.ui EPs carry both). A `proposal` has no `Resolution:` yet.
+
 ==== Not every EP graduates into spec/ ====
 
 Graduation is per-type, and graduation is not the only outcome. A process EP
@@ -94,49 +101,50 @@ subtractive framing is migration mechanics, not the rule.
 <!-- The problem. Why a bead is not enough — the unresolved alternatives or the
 durable rationale that warrants an EP. -->
 
-## Goals / Non-Goals
-
-<!-- What is in scope for this decision surface, and what is explicitly out.
-One EP, one decision surface — bundling independent decisions invites
-all-or-nothing rulings. -->
-
-## Relationships
-
-<!-- Dependencies and cross-references live HERE (not scattered in prose):
-the EPs and specs this builds on, supersedes, or is constrained by. The
-README index row carries only status + a one-line summary. -->
-
 ## Specification
 
-<!-- The normative content. For a standards-track EP this is the design that
-will graduate into `spec/`; for a process EP it is the rule (and, if the home
-is this EP, this section IS the rule and the rest of the document is
-rationale). Normative-voiced text is permitted at `proposal` — it makes
-graduation a move, not a rewrite — but it binds nothing until accepted. -->
+<!-- The normative content. OPEN with a **Scope** paragraph: what this decision
+surface owns and what is explicitly out — this absorbs the older Goals/Non-Goals
+section and the ownership half of the older Relationships section. One EP, one
+decision surface — bundling independent decisions invites all-or-nothing
+rulings. For a standards-track EP the body is the design that will graduate into
+`spec/`; for a process EP it is the rule (and, if the home is this EP, this
+section IS the rule and the rest of the document is rationale). Normative-voiced
+text is permitted at `proposal` — it makes graduation a move, not a rewrite —
+but it binds nothing until accepted. CLOSE with a **Guide impact** paragraph
+naming which `docs/core` chapters change and which payoffs become newly
+teachable, or recording "no human-facing guide change yet" and why (EP-0009
+§Durability rules 5). Implementation tracking lives in the beads issue tracker,
+not a section here — reference the tracker or program record from References. -->
 
 ## Rationale
 
-<!-- Why this shape over the alternatives considered. -->
+<!-- Why this shape over the alternatives considered. This is where the proposal
+argues its recommended disposition; the operator's ruling on it is recorded
+under Resolved Decisions. -->
 
 ## Backwards Compatibility
 
 <!-- Pre-alpha: there is usually no compatibility surface to preserve. State
 the migration mechanics, if any, here — not as the headline rule. -->
 
-## Bead Plan / Reference Implementation
+## Resolved Decisions
 
-<!-- The waves that carry this EP into its normative home + implementation.
-Each graduation wave includes a guide-impact assessment: name which
-`docs/core` chapters change and which payoffs become newly teachable, or
-record "no human-facing guide change yet" and why. Ledger rows cite live
-bead ids and are struck as they close. -->
+<!-- Operator rulings on this EP's open issues, as they land: decision +
+rationale, dated. An EP MUST NOT go `final`/`active` with open issues silently
+unresolved (EP-0009 §Durability rules 2 — the EP-0001/0002 pattern); a fresh
+proposal may have none yet. After resolution the body is a historical record —
+later factual drift is corrected with dated errata/addenda beside the affected
+passage, never by rewriting settled prose (EP-0009 §Durability rules 3). -->
 
 ## Open Issues
 
-<!-- Questions awaiting an operator ruling. An EP MUST NOT go `final`/`active`
-with open issues silently unresolved — record the disposition of each in a
-`Resolved Decisions` section as rulings land (the EP-0001/0002 pattern). -->
+<!-- Questions awaiting an operator ruling. Each is dispositioned under
+Resolved Decisions as its ruling lands. -->
 
-## Recommendation
+## References
 
-<!-- The author's recommended disposition for the operator to rule on. -->
+<!-- Dependencies, cross-references, and provenance live HERE (not scattered in
+prose): the EPs and specs this builds on, supersedes, or is constrained by, plus
+supporting spikes/findings and the beads/program record that tracks
+implementation. The README index row carries only status + a one-line summary. -->


### PR DESCRIPTION
## What

Aligns the two EP authoring authorities — `docs/EP/EP-0009-the-ep-process.md`
§Document conventions and `docs/EP/EP-template.md` — to the compact PEP shape
that PR #6433 established for the EP-0030..EP-0035 corpus. A programmer or agent
following the template now produces the corpus shape #6433 presents as the
improved standard. Closes the contradiction filed in **rf2-iywds**.

The forward-looking structure both authorities now prescribe:

- Preamble `Status:` / `Type:` / `Created:` / `Resolution:`
- Sections **Abstract → Motivation → Specification (Scope open, Guide impact
  close) → Rationale → Backwards Compatibility → Resolved Decisions → Open
  Issues → References**

Where the older house sections went, stated explicitly in both files:

- **scope** (goals/non-goals) opens the Specification; the **ownership** half of
  the old Relationships section joins it there
- **relationships/provenance** (dependencies, cross-references, spikes) → References
- **implementation tracking** → the beads tracker, referenced from References
- **guide-impact** assessment closes the Specification (EP-0009 rule 5)
- **resolved rulings** → Resolved Decisions (rule 2)
- the author's **recommendation** is argued in the body and dispositioned under
  Resolved Decisions once the operator rules

The PEP shape is the authoring default; older EPs (including EP-0009 itself) keep
their existing sections as historical record — no migration sweep, no checker,
no new framework.

## Scope guarded

- EP lifecycle, status/type grammar, guide-impact rule, and the **rf2-r7ahi**
  freeze-meaning-not-bytes durability rules are unchanged.
- **Tier 1** edit: a forward-looking convention update, operator-directed via
  the bead; no settled decision's meaning changed. EP-0009's own body sections
  and its Bead Plan ledger (including the item-3 defect tracked on rf2-hgwpq) are
  left exactly as-is. No EP status flipped.
- Two files touched, 55 insertions / 34 deletions.

## Quality gates

Run in the worktree, foreground, to completion:

- `python scripts/check_ep_status_sync.py --verbose` — **exit 0**; 35 EP files in sync.
- `python scripts/check_doc_slugs.py --verbose` — **exit 0**; 531 markdown files scanned, no broken links.
- `python -m mkdocs build --strict` — **exit 0**; built in 38.83s, no WARNING/ERROR (only pre-existing INFO relative-link notes on `spec/README.md` / `spec/SPEC-AUTHORING.md`, unrelated to this change).
- Guide-truth JVM test (`implementation/ui/.../guide_truth_jvm_test.clj`) — **not run**: it pins EP paths by exact path and pins only EP-0034 and EP-0030, neither of which this PR touches.
