### PR TITLE
test(ui): land G-7 Layer 1 — advanced parity-corpus prod-elision proof + reconcile G-7 to the two-layer contract (rf2-ckyfh)

### DIFF
--- a/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
+++ b/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
@@ -79,9 +79,11 @@ source-coord walkers; no manifests, cause vectors, histories, timings, warning
 text, `data-rf2-*` strings, project paths; no schema engines when elided; **no
 JVM renderer in any browser entry**; no proxy/signal/atom/query-cache runtimes.
 Debug erasure is a proof: advanced builds are scanned for exact absence (G-11),
-and dev/prod behavioral equivalence is gated per generated shape + pairwise
-capabilities + high-risk triples (G-7) — full powersets are not a practical
-gate. Ordinary view registration is **already `goog.DEBUG`-gated in the
+and dev/prod behavioral equivalence is gated in two layers (G-7): Layer 1 gates
+the GENERATED STRUCTURAL output per generated shape (dev-CLJS == JVM-truth ==
+advanced-CLJS, the parity corpus rendered in both regimes against one embedded
+JVM truth), and Layer 2 gates per-production-wrapper MOUNTED behaviour through
+causal fixtures — no powersets, no pairwise-capability generator. Ordinary view registration is **already `goog.DEBUG`-gated in the
 emitter** (the registration branch of `compiler/emit_cljs.cljc` — the
 production arm is a direct `React.memo` with no registry); G-18 is
 fixture-first, and a new elision mode or packaging change is justified only if
@@ -186,7 +188,7 @@ table governs.
 | **G-4** equality no-op | `rf=` results ⇒ zero revisions, zero prop/sub-driven renders, stable references |
 | **G-5** drain fan-in | eight queued update+commit epochs all execute in one run-to-completion drain and share exactly **one** read/render batch at the following host checkpoint — a drain is never split across batches; coalescing never drops writes; epoch count is never evidence of render/commit count |
 | **G-6** abandonment/disposal | 10k headless abandoned renders/cold probes and bounded mounted StrictMode/Activity cycles return every ownership surface to exact baseline |
-| **G-7** dev/prod equivalence | per generated shape + pairwise capabilities + high-risk triples: committed DOM/events/owners/cleanup/hydration agree, debug off |
+| **G-7** dev/prod equivalence | two layers: **(1)** generated structural output equivalent per generated shape — dev-CLJS / JVM-truth / advanced-CLJS agree, debug off; **(2)** per-production-wrapper mounted behaviour — committed DOM/events/owners/cleanup/hydration agree, debug off |
 | **G-8** input correctness (hard) and latency evidence | **Hard gate:** in real Chromium **and** WebKit — pre-paint synchronous commit under the sync door, ordering, caret restoration, IME composition, exactly one attributable React commit per ordinary input and exactly one at the committed IME boundary, with the deliberate async-door regression as the tooth; the matrix runs through a **reusable event-prefix component** (`ui/event` vector-outcome door) — toy literal fixtures alone do not close it. **Evidence only:** event→commit p95 against an equivalent hand-written React control in the same warmed run — the ratio, the 10% reference-budget observation, the sample count and the noise policy are recorded and reported; no wall-clock number gates (G-13's posture), and an over-budget observation feeds performance follow-up, never a G-8 failure |
 | **G-9** list updates | keyed 1k rows: one entity change renders its row + true dependents; stable handler identity; no retained lazy seqs |
 | **G-10** bundle | kernel ≤ 4 KB gz; counter ≤ React + 6 KB gz; relative targets vs UIx-adapter/slim with symbol-reachability escalation (methodology: pinned three-module splits, per-module measurement, N=3 determinism, checked-in EDN baseline, ratio + floor + slope guard) |
@@ -247,19 +249,25 @@ the stages ahead follow
   slot bodies all run, and the **manifest slot-site arm now ships** — the
   analyzer indexes each slot site into the compiler manifest and the public
   `:render-slots` projection reports it, both pinned by focused acceptance.
+- **G-7 Layer 1**, the generated-structural-output equivalence arm
+  (`npm run test:browser-prod-elision`, the advanced parity-corpus prod-elision
+  proof). The production-absence arm is green, and the corpus now renders
+  through the **advanced** CLJS emitter and compares — in the same
+  normalized-semantic space the dev-lane parity corpus uses — against the JVM
+  emitter's compile-time truth. Paired with the dev-lane corpus
+  (`parity_corpus_cljs_test`) this closes the triangle: dev-CLJS == JVM-truth
+  **and** advanced-CLJS == JVM-truth, so dev == prod per generated shape across
+  all 43 corpus cases, with no golden files.
 
 **Named open:**
 
-- **G-7's broad equivalence matrix.** The production-absence arm is wired and
-  green, and the per-stage equivalence arms landed with their conformance
-  profiles — the S3-shape arm (S3 profile) and the S4-shapes-only arm (S4
-  profile, which deliberately bounded itself to S4 shapes and left the broader
-  debt to its owner). What has no test yet is the *broad, retroactive* S1–S3
-  dev↔prod equivalence matrix over generated shapes — per generated shape,
-  pairwise capabilities, high-risk triples. The requirement stands in full and
-  is owned by **S6** (`rf2-vxgfnd.98`), the stage carrying the remaining
-  absence/equivalence/budget gates (below); it is deferred to that owner, not
-  narrowed.
+- **G-7 Layer 2**, the shape-specialization arm: per-production-wrapper mounted
+  causal fixtures (gaps: presence retention/removal, custom-element property
+  application, the missing event/combination wrapper shapes) — owner
+  **`rf2-55zsd`** (the S6 leaf under `rf2-vxgfnd.98`). Layer 1 above proves the
+  generated structure equivalent per shape; Layer 2 proves the mounted
+  behaviour each distinct production wrapper adds. Not a powerset, not a
+  pairwise generator — one causal fixture per distinct wrapper shape.
 - **G-14's remaining arm** — bounded guide-fixtures CI cost, which needs the
   guide-examples corpus and has no assertion anywhere in the repository, as the
   gate's own suite states.

--- a/implementation/ui/test/re_frame/ui/parity_corpus_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/parity_corpus_elision_prod_test.cljs
@@ -1,0 +1,185 @@
+(ns re-frame.ui.parity-corpus-elision-prod-test
+  "rf2-ckyfh, G-7 Layer 1 — the ADVANCED-CLJS half of the dev<->prod
+  structural-equivalence triangle.
+
+  `parity_corpus_cljs_test` already closes ONE leg: for every corpus case
+  the DEV CLJS emitter's output (`:node-test`, `:none`, goog.DEBUG=true),
+  rendered against real React via react-dom/server, is NORMALIZED-
+  STRUCTURALLY-EQUIVALENT under normalization N to the JVM emitter's
+  truth. That proves dev-CLJS == JVM-truth.
+
+  This namespace closes the OTHER leg in the mode it is written for. It
+  runs ONLY in `:browser-test-prod-elision` (`shadow-cljs release` =>
+  `:optimizations :advanced`, goog.DEBUG=false), renders the SAME corpus
+  through the ADVANCED CLJS emitter via react-dom/server, and compares in
+  the SAME normalized-semantic space against the SAME JVM truth. That
+  proves advanced-CLJS == JVM-truth.
+
+  The two legs share one vertex — the JVM truth, embedded at CLJS COMPILE
+  time by `re-frame.ui.parity-embed/embedded-jvm-semantics` (a Clojure
+  macro whose expansion is identical at every optimization level, so the
+  advanced build receives byte-for-byte the same truth the dev build
+  does). dev-CLJS == JVM and advanced-CLJS == JVM therefore compose to
+  dev-CLJS == advanced-CLJS per generated shape — with NO golden files
+  and NO cross-build artifact protocol. A production-only structural
+  divergence (the class rf2-vxgfnd.253 recorded a real wrapper-selection
+  bug in) fails HERE while the dev leg stays green.
+
+  What this DOES cover: the generated STRUCTURAL output of all 43 corpus
+  cases (28 views, incl. the S4 presence / custom-element rows — for custom
+  elements, the tag / children / non-property attrs; see the property-prop
+  note by `render-case`). What it does NOT cover: mounted production-wrapper
+  BEHAVIOUR (retention timers, event targets, sub/lease ownership, cleanup)
+  and custom-element DOM property APPLICATION — Layer 2, owned by the S6 leaf
+  rf2-55zsd (per-wrapper mounted causal fixtures).
+
+  Three teeth guard against a silent pass:
+    (i)   `debug-regime-is-off` asserts `interop/debug-enabled?` is false
+          in-bundle, so the corpus comparison cannot silently run in the
+          dev regime and pass vacuously.
+    (ii)  `advanced-build-really-renames-unexterned-property-reads` is the
+          non-vacuity control (the binding_plan pattern): it proves this
+          exact bundle is genuinely `:advanced` with property renaming
+          LIVE, so the corpus comparison is a real proof rather than a
+          build that quietly stopped optimizing.
+    (iii) a deliberate production-arm mutation (breaking the direct-memo /
+          `memo-view` arm) was demonstrated during development to turn
+          `every-case-normalized-structural-equivalence` RED here while
+          the dev corpus stayed green — then restored (rf2-ckyfh)."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            ["react-dom/server" :as rds]
+            [re-frame.interop :as interop]
+            [re-frame.ui :refer [defview]]
+            [re-frame.ui.parity-fixtures :as fx]
+            [re-frame.ui.parity-html :as ph]
+            [re-frame.ui.rules :as rules]
+            [re-frame.ui.runtime :as rt])
+  (:require-macros [re-frame.ui.parity-embed :refer [embedded-jvm-semantics]]))
+
+;; The JVM emitter's normalized truth, computed in the compiler's OWN JVM at
+;; CLJS compile time and embedded as literals — the SAME vertex the dev-lane
+;; `parity_corpus_cljs_test` compares against. Its value does not depend on the
+;; optimization level: the macro renders `.cljc` fixtures through the JVM emitter
+;; regardless of whether the CLJS side is later compiled `:none` or `:advanced`.
+(def jvm-semantics (embedded-jvm-semantics))
+
+(defn- ->props
+  "Corpus EDN props -> JS props object per the frozen props ABI
+  (deterministic quoted slot names preserving namespace+name)."
+  [m]
+  (reduce-kv (fn [o k v]
+               (unchecked-set o (subs (str k) 1) v)
+               o)
+             #js {} m))
+
+(defn- render-case [{:keys [view props]}]
+  (rds/renderToStaticMarkup (rt/jsx2 (get fx/views view) (->props props))))
+
+;; --- Layer 1 / Layer 2 boundary for the custom-element rows -----------------
+;; `parity_html/html->semantic` strips DECLARED custom-element property-props
+;; from the React side via the RUNTIME registry (`rules/custom-element-properties`)
+;; — React SSR serialises a custom-element property as a camelCase attribute
+;; (`accentColor="…"`, `tabIndex="…"`), and the contract's semantic space omits
+;; it because it is applied as a DOM property, not authored structure. In THIS
+;; advanced bundle that runtime registry is EMPTY — the corpus's top-level
+;; `ui/custom-element` registrations do not repopulate `custom-element-properties`
+;; here (FINDING, rf2-ckyfh: worth a root-cause follow-up — the same registry
+;; feeds production dynamic `ui/spread` custom-element classification). The
+;; emitter OUTPUT is identical dev<->prod (React serialises the property-prop the
+;; same way regardless of goog.DEBUG); only the harness's registry-driven strip
+;; is unavailable. So Layer 1 strips those property-props here directly, from the
+;; SAME compile-time classification the emitter and the JVM truth use, keeping the
+;; comparison in one semantic space. Custom-element property APPLICATION is Layer
+;; 2 (rf2-55zsd); Layer 1 proves the generated STRUCTURE (tag, children,
+;; non-property attrs). Keep in sync with parity-fixtures' `ui/custom-element`
+;; declarations (`:parity-widget` / `:parity-attrish`).
+(def ^:private corpus-ce-property-attr-names
+  {"parity-widget"  #{(rules/custom-element-property-name (name :accent-color))}  ;; "accentColor"
+   "parity-attrish" #{(rules/custom-element-property-name (name :tab-index))}})   ;; "tabIndex"
+
+(defn- strip-ce-property-props
+  "Drop the corpus's declared custom-element property-prop attrs from a semantic
+  vector/node — the Layer 1/Layer 2 boundary `parity_html` draws in dev via the
+  runtime registry. A pure walk: no global state, no test-order coupling."
+  [x]
+  (cond
+    (vector? x) (mapv strip-ce-property-props x)
+    (map? x)
+    (let [drop-set (get corpus-ce-property-attr-names (name (:tag x)))
+          x        (if (and drop-set (:attrs x))
+                     (let [attrs' (apply dissoc (:attrs x) drop-set)]
+                       (if (seq attrs') (assoc x :attrs attrs') (dissoc x :attrs)))
+                     x)]
+      (if (:children x)
+        (assoc x :children (mapv strip-ce-property-props (:children x)))
+        x))
+    :else x))
+
+;; ---------------------------------------------------------------------------
+;; Tooth (i) — the build IS the elided / production regime
+;; ---------------------------------------------------------------------------
+
+(deftest debug-regime-is-off
+  (testing "goog.DEBUG=false in-bundle — the corpus comparison below cannot
+            silently run in the dev regime and pass vacuously"
+    (is (false? interop/debug-enabled?)
+        "interop/debug-enabled? must constant-fold to false in this advanced build")))
+
+;; ---------------------------------------------------------------------------
+;; Tooth (ii) — non-vacuity control: this bundle really is `:advanced` and
+;; renaming unexterned reads (the binding_plan "advanced-build-really-renames"
+;; pattern). Without it, a build that had stopped optimizing would let the
+;; corpus comparison pass while proving nothing about the production emitter.
+;; ---------------------------------------------------------------------------
+
+;; `js-obj` sets properties by STRING (`goog.object.create`), so these keys are
+;; dynamic — Closure can neither rename them nor read them as an object literal.
+;; Whether the dotted read below finds its value therefore depends on ONE thing:
+;; whether the READ was renamed.
+(def ^:private probe (js-obj "corpusRenameProbe" "kept"))
+
+;; The group local `node` is UNHINTED, so nothing externs `.corpusRenameProbe`
+;; and `:advanced` renames the read away from the object's live string key.
+(defview corpus-renaming-control-view
+  [{:keys [probe/node]}]
+  [:span {:data-role "corpus-renaming-control"} (str "[" (.-corpusRenameProbe node) "]")])
+
+(deftest advanced-build-really-renames-unexterned-property-reads
+  (testing "the probe's string key is intact (js-obj keys are unrenamable)"
+    (is (= "kept" (unchecked-get probe "corpusRenameProbe"))))
+  (testing "yet an UNHINTED dotted read of it renders empty — the read was renamed,
+            so this bundle really is :advanced and the corpus proof below is real"
+    (is (= "<span data-role=\"corpus-renaming-control\">[]</span>"
+           (rds/renderToStaticMarkup
+            (rt/jsx2 corpus-renaming-control-view (js-obj "probe/node" probe))))
+        (str "rf-parity-corpus-advanced-renaming-live-v1: :advanced renamed the "
+             "unexterned read, so advanced-CLJS == JVM-truth below is a genuine "
+             "production proof, not a build that stopped optimizing"))))
+
+;; ---------------------------------------------------------------------------
+;; The proof — advanced-CLJS == JVM-truth per generated shape
+;; ---------------------------------------------------------------------------
+
+(deftest corpus-covers-every-case
+  (is (= (count fx/cases) (count jvm-semantics)))
+  (is (= (set (map :id fx/cases)) (set (keys jvm-semantics)))))
+
+(deftest every-case-normalized-structural-equivalence
+  (doseq [{:keys [id] :as c} fx/cases]
+    (let [html   (render-case c)
+          react  (strip-ce-property-props (ph/html->semantic html))
+          jvm    (ph/expand-trusted (get jvm-semantics id))
+          diff   (when (not= jvm react) (ph/first-divergence jvm react))]
+      (is (= jvm react)
+          (str "advanced-CLJS/JVM parity divergence in case " id
+               "\n  first divergence: " (pr-str diff)
+               "\n  react html: " html)))))
+
+(deftest no-handler-attributes-ever
+  ;; belt-and-braces over the parser's hard failure: the serialised markup of
+  ;; handler-bearing cases carries no on* attribute names in production either
+  (doseq [id [:handlers-on :handlers-off :spread-override :page]]
+    (let [c    (some #(when (= id (:id %)) %) fx/cases)
+          html (render-case c)]
+      (is (nil? (re-find #"\son[A-Za-z-]+=" html))
+          (str "handler attribute leaked into HTML for " id ": " html)))))

--- a/implementation/ui/test/re_frame/ui/s4_conformance_profile_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/s4_conformance_profile_jvm_test.clj
@@ -734,10 +734,10 @@
     (let [section (section-between (slurp (profile-doc)) "## 6." "## 7.")]
       (when section
         (doseq [claim ["**S4 shapes only**"
-                       "first"
-                       "in scope here"
-                       "named-open owner"
-                       "existing"]]
+                       "Layer 1"
+                       "mounted"
+                       "rf2-55zsd"
+                       "in scope here"]]
           (is (str/includes? section claim)
               (str "§6 must bound the G-7 growth: " claim)))))))
 

--- a/spec/conformance/S3-view-conformance-profile.md
+++ b/spec/conformance/S3-view-conformance-profile.md
@@ -186,7 +186,7 @@ roster. The S3-specific arms this profile certifies:
 | Gate | S3 arm |
 |---|---|
 | **G-6** | `effect`/`error-boundary` lifecycle + StrictMode/Activity ownership baselines |
-| **G-7** | dev/prod equivalence; `client-only` fallback; committed DOM/events/owners agree with debug off |
+| **G-7** | dev↔prod **structural** equivalence over the generated corpus (Layer 1 — wired by the advanced parity-corpus prod-elision proof, debug off); `client-only` fallback; committed-DOM/events/owner **mounted** behaviour named-open under the S6 leaf (`rf2-55zsd`) |
 | **G-8** | real Chromium **and** WebKit controlled-input matrix — IME composition, caret restoration, event ordering, pre-paint — through the reusable event-prefix component, with the deliberate async-door regression as the tooth |
 | **G-11** | exact production absence of the debug + absence rosters (view evidence, manifest, HMR shell, source-coord, `re-frame.ui.test`) from advanced bundles |
 | **G-15** | atomic-local writer matrix — N same-turn `update!` writers land; fn-value `set!` stores exactly; **mixed `update!`+dispatch**; StrictMode replay; JVM typed failure; writer composition + render count (not a `:local-state` cause row — that cause is specified for S6); HMR ride |

--- a/spec/conformance/S4-view-conformance-profile.md
+++ b/spec/conformance/S4-view-conformance-profile.md
@@ -296,17 +296,21 @@ ones:
 
 | Gate | S4 arm |
 |---|---|
-| **G-7** | dev↔prod equivalence for **S4 shapes only** — committed DOM, presence retention/removal, and custom-element property application agree with debug off; the a11y roster is compile-tier and emits nothing at runtime in either build |
+| **G-7** | dev↔prod equivalence for **S4 shapes only** — the S4 presence / custom-element corpus rows' generated **structure** agrees with debug off (Layer 1, via the advanced parity corpus); presence retention/removal and custom-element property **application** are **mounted** arms, named-open under the S6 leaf (`rf2-55zsd`); the a11y roster is compile-tier and emits nothing at runtime in either build |
 | **G-11** | S4 diagnostic / site / reload / test machinery absent from advanced production output — `re-frame.ui.test` (now including `flush-presence!`) and every compile-tier diagnostic string stay out of advanced production bundles |
 
-**The G-7 growth is bounded, deliberately.** G-7 today has no equivalence test
-beyond its production-absence arm, so S4 writes G-7's **first** equivalence arms
-— and writes them for **S4 shapes only**. The broader retroactive S1–S3
-equivalence-matrix debt is **not** in scope here and keeps its existing
-named-open owner; S4 does not discharge it, and no row in this profile should be
-read as claiming it. Both arms wire into the **existing** required
-JVM / CLJS / DOM / parity / production-elision jobs — no new job, no new named
-gate, and no S5 SSR build in the S4 matrix.
+**The G-7 growth is bounded, deliberately.** S4's presence and custom-element
+corpus rows ride **Layer 1** — the advanced parity-corpus prod-elision proof —
+so their generated **structure** is proven dev↔prod-equivalent with debug off,
+for **S4 shapes only** and no wider. What is **not** yet executable is the
+**mounted** behaviour these shapes add: presence retention/removal over time and
+custom-element DOM property application. Those arms are named-open under the S6
+leaf **`rf2-55zsd`** (per-production-wrapper mounted causal fixtures); S4 does
+not discharge them, and no row in this profile should be read as claiming the
+mounted behaviour is proven. The broader retroactive S1–S3 equivalence-matrix
+debt is likewise **not** in scope here. Layer 1 wires into the **existing**
+required JVM / CLJS / DOM / parity / production-elision jobs — no new job, no new
+named gate, and no S5 SSR build in the S4 matrix.
 
 Everything else S4 froze is proven by the named suites in §1 and the parity
 corpus in §4, not by a gate arm.


### PR DESCRIPTION
Implements the `rf2-ckyfh` operator ruling (Fable, delegated by Mike, 2026-07-19 14:58). PR #6442 merged ~7 minutes before this work began and carried only the *pre-ruling* reconciliation, so it retained the wording the ruling rejects and shipped no Layer 1 proof. This PR lands both.

The ruling **retains** G-7 (arm (a)) in a **two-layer** form and **rejects** the original row's *"per generated shape + pairwise capabilities + high-risk triples"* wording as unowned combinatorics.

## Layer 1 — generated structural output (lands here)

New `implementation/ui/test/re_frame/ui/parity_corpus_elision_prod_test.cljs`. The ns matches the existing `-elision-prod-test$` regexp, so the **existing** `:browser-test-prod-elision` build (`:advanced`, `goog.DEBUG false`, runner `re-frame.prod-elision-runner`) picks it up — **no new CI job, no `shadow-cljs.edn` edit, no golden files**.

The `parity-embed` macro expands in the compiler's own JVM at every optimization level, so the advanced build receives byte-for-byte the same embedded JVM truth the dev lane uses. Rendering all **43 corpus cases** (28 views, incl. the S4 presence / custom-element rows) through the **advanced** CLJS emitter via `react-dom/server` and comparing in the same normalized-semantic space closes the triangle:

> dev-CLJS == JVM-truth (existing node test) **+** advanced-CLJS == JVM-truth (this test) => **dev == prod per generated shape**

**Layer 2** — per-production-wrapper mounted causal fixtures — is owner **`rf2-55zsd`** (the S6 leaf under `rf2-vxgfnd.98`). Not started here (S6-gated).

### Three teeth

1. **`debug-regime-is-off`** asserts `interop/debug-enabled?` is **false** in-bundle, so the corpus comparison cannot silently run in the dev regime and pass vacuously.
2. **`advanced-build-really-renames-unexterned-property-reads`** — the non-vacuity control in the `binding_plan` pattern: an unexterned dotted read really *is* renamed in this exact bundle, so the comparison is a real proof rather than a build that stopped optimizing. Its deliberate `:infer-warning` is load-bearing evidence, exactly as in `binding_plan_advanced_elision_prod_test`.
3. **Demonstrated then restored.** A deliberate production-arm mutation of the direct-memo arm (`runtime/memo-view`, the emitter's direct-`React.memo` production path) turned this test **RED** on the specific divergence `{:path [0 :attrs "data-prodmut"], :jvm nil, :react "x"}` for `:static-kitchen` / `:class-static` / ... (47 failures), **while the dev corpus stayed fully green** in the same mutated state (node lane: 10228 tests / 50530 assertions / 0 failures) — because the node lane emits `register-view!` and never reaches `memo-view`. `runtime.cljs` was restored and is **not** part of this commit; `memo-view` is byte-identical to main.

**Runner actually executed it** (not a namespace that runs on no host): an intermediate run attributed real failures to `Testing re-frame.ui.parity-corpus-elision-prod-test` at `parity_corpus_elision_prod_test.cljs:173`, and the ns's symbols appear in the shipped advanced bundle (`out/browser-test-prod-elision/js/test.js`).

## Doc reconciliation (the ruling's CONTRADICTION REPAIRS)

- **EP-0034 section 1 + section 4 G-7 rows** — dropped "pairwise capabilities + high-risk triples"; both now state the two-layer contract.
- **EP-0034 section 5** — the structural-corpus arm **moves to "Wired and green"** (Layer 1 lands here); the remaining named-open row is now *"G-7 Layer 2, the shape-specialization arm: per-production-wrapper mounted causal fixtures (gaps: presence retention/removal, custom-element property application, the missing event/combination wrapper shapes) — owner `rf2-55zsd`"*.
- **S3 profile** G-7 row — claims only the proven extent: structural corpus equivalence (wired here) + mounted behaviour named-open under `rf2-55zsd`.
- **S4 profile** section 6 row + prose — the fictitious *"existing named-open owner"* is replaced by the real leaf `rf2-55zsd`; the S4 corpus rows' generated **structure** rides Layer 1, while presence removal and custom-element property **application** are named **mounted** arms, named-open. `s4_conformance_profile_jvm_test.clj`'s `profile-bounds-the-g7-growth` pins were updated in lockstep (`first` / `named-open owner` / `existing` -> `Layer 1` / `mounted` / `rf2-55zsd`).

**Guardrails honoured:** the EP-0034 section 4 **G-18** over-claim row (`rf2-kxork`'s pending ruling) is left byte-identical; no EP status flipped; no new CI job, no `shadow-cljs.edn` edit, no golden files, no mutation framework, no Layer 2 work.

## Finding surfaced by Layer 1 (worth a root-cause follow-up bead)

In the `:advanced` bundle the **runtime custom-element registry is empty** — the corpus's top-level `ui/custom-element` registrations do not repopulate `rules/custom-element-properties` there, so `parity_html` could not strip the declared property-props (`accentColor` / `tabIndex`) it strips in dev. The **emitter output is identical dev/prod** (React SSR serialises the property-prop the same way regardless of `goog.DEBUG`); only the harness's registry-driven strip is unavailable, so this is a harness normalisation gap, not an emitter divergence.

Layer 1 therefore strips those property-props from the **same compile-time classification** the emitter and JVM truth use (a pure walk — no global state, no test-order coupling), keeping all 43 cases in one semantic space. Custom-element property **application** is explicitly Layer 2.

**The registry observation is separate and may matter in production**: the same registry feeds dynamic `ui/spread` custom-element classification. Flagged here rather than papered over — recommend a follow-up bead to root-cause whether the top-level registration survives `:advanced`.

## Quality gates

All foreground, run to completion, on this branch rebased onto current `main`:

- `npm run test:browser-prod-elision` -> **exit 0**, **113 tests / 481 assertions / 0 failures, 0 errors** (`ui mounted production elision: PASS`). This is the `:advanced` bundle where the new test runs.
- **Mutation tooth:** same gate with the `memo-view` production arm mutated -> **exit 1, 47 failures**, the new test red on the specific `data-prodmut` divergence; dev lane green in the same state.
- `cd implementation/ui && clojure -M:test` -> **982 tests / 18744 assertions / 0 failures, 0 errors** (covers the EP-0034-pinning `guide-truth-jvm-test` and the updated `s4-conformance-profile-jvm-test`).
- `npm run test:cljs` (dev/node lane) -> **10228 tests / 50530 assertions / 0 failures, 0 errors**.
- `python -m mkdocs build --strict` -> exit 0 **and** `python scripts/check_doc_slugs.py` -> exit 0 **and** `python scripts/check_ep_status_sync.py` -> exit 0.
- `sh scripts/check-no-hardcoded-paths.sh` -> exit 0.
