### PR TITLE
fix(ui): identity-only reload ownership + enforce one-build-per-root, retire synthetic multi-build tests (rf2-ymfix, rf2-4vm19)

### DIFF
--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -719,12 +719,11 @@
 ;;
 ;; .48 evicted a source's contribution ONLY when it re-registered — i.e. it used
 ;; a SURVIVING declaration as the signal that the source was rebuilt. That left
-;; three holes: a source that deletes its LAST declaration (or whose file is
+;; two holes: a source that deletes its LAST declaration (or whose file is
 ;; deleted) never re-registers, so its stale rows lingered until a full page
-;; reload; a reload that threw mid-way left the live registry half-mutated; and
-;; two builds sharing one runtime atom cross-contaminated. .67 replaces
-;; registration-triggered eviction with an explicit reload-cycle protocol driven
-;; from the reload BOUNDARY, not from re-registration:
+;; reload; and a reload that threw mid-way left the live registry half-mutated.
+;; .67 replaces registration-triggered eviction with an explicit reload-cycle
+;; protocol driven from the reload BOUNDARY, not from re-registration:
 ;;
 ;;   (notify-reload! [build?])    ^:dev/before-load — OPEN a reload cycle. From
 ;;                                here re-registrations STAGE; the live aggregate
@@ -756,20 +755,24 @@
 ;; closed cycle and write-through's into the next generation instead of staging
 ;; into a cycle the commit is about to discard.
 ;;
-;; Ownership is [build-id ns-sym] so two builds sharing one atom (two bundles in
-;; one JS realm, a shared JVM, a test) reconcile independently — evicting one
-;; build's source can never drop another's rows.
+;; A ledger row is keyed [build-id ns-sym]. The `ns-sym` is what partitions a real
+;; host's sources; the `build-id` is the INTERNAL PRODUCER SEAM — the identity the
+;; reset producer stamps and every arity default resolves through — and, in tests,
+;; a STATE-PARTITION TOKEN that lets one process drive several independent ledgers
+;; without them colliding. It is NOT a claim that two dev builds can share one copy
+;; of this namespace and reconcile independently: they cannot, and nothing shadow
+;; exposes could tell them apart. See §THE ISOLATION UNIT below for the contract
+;; that bounds this.
 ;;
-;; That key is only worth its weight if `build-id` is a REAL identity, and every
-;; participant in a cycle agrees on it (rf2-vxgfnd.142). It used to be the
-;; placeholder `::default` on every real path — emitted registrations, both
-;; lifecycle hooks, the reset producer — with a second identity reachable only
-;; from a test-only arity. Two real builds sharing a realm therefore collapsed
-;; into one row at [::default ns], and reloading one could evict or replace the
-;; other's contribution. Now `current-build-id` resolves shadow's own build name
-;; and is the default for EVERY arity in the protocol, so an emitted registration
-;; and the cycle that reconciles it cannot key a row differently. The explicit
-;; build-scoped arities remain the seam for multi-build reconciliation and tests.
+;; The key is only worth its weight if `build-id` is COHERENT — every participant
+;; in a cycle must agree on it (rf2-vxgfnd.142). It used to be the placeholder
+;; `::default` on every real path — emitted registrations, both lifecycle hooks,
+;; the reset producer — with a second identity reachable only from a test-only
+;; arity, so an emitted registration and the cycle meant to reconcile it could key
+;; a row differently and strand it. Now `current-build-id` is the ONE rule every
+;; arity default resolves through, so they cannot disagree. The explicit
+;; build-scoped arities remain the seam the producer routes through and the token
+;; tests partition state with.
 ;;
 ;; ## Production carries none of this (rf2-k9yuy)
 ;;
@@ -794,19 +797,41 @@
 ;; `goog.DEBUG=true`) stages, reconciles and commits real cycles, so removing the
 ;; dev branch reddens there rather than silently satisfying the bundle grep.
 ;;
-;; ## Bounded by shadow's reload surface (the honest edge)
+;; ## THE ISOLATION UNIT — one dev build per CLJS root (rf2-4vm19, NORMATIVE)
 ;;
-;; Per-build isolation reaches exactly as far as shadow's runtime seam allows.
-;; `before-load-src` calls each SHADOW_NS_RESET callback with the reloaded ns and
-;; NOTHING else, and lifecycle hooks are invoked with no arguments after being
-;; resolved by name off the SHARED `$CLJS` object. So a callback learns which
-;; build is reloading only from the identity BAKED INTO ITS OWN BUNDLE — which is
-;; exactly what `current-build-id` reads. Two bundles, each with their own copy of
-;; this namespace, are therefore isolated: each copy carries its own build's name
-;; and reconciles only its own rows. Two builds that share ONE copy of this
-;; namespace (one `$CLJS`, one set of atoms, one `defonce`d producer) cannot be
-;; told apart by any mechanism shadow exposes, because the hooks themselves are
-;; then a single shared singleton.
+;; THE CONTRACT: ONE Shadow dev build per CLJS global namespace root containing
+;; `re-frame.ui.rules`. That is the unit this ledger isolates. It is a stated
+;; boundary, not an aspiration — everything below follows from what shadow's
+;; runtime seam does and does not convey.
+;;
+;; The unit is the CLJS ROOT — not the page, and not the output file. Separate
+;; output files are not automatically separate runtime copies: standard shadow dev
+;; output shares the global root, and single-module release output is wrapped by
+;; default.
+;;
+;; SUPPORTED, and isolated by construction:
+;;   - one app plus its `:preloads` tools — that is ONE build;
+;;   - iframes and workers — separate JS realms, so separate roots;
+;;   - independently compiled release bundles — output-wrapped, own copy, and no
+;;     ledger at all (see §Production carries none of this);
+;;   - separate pages.
+;;
+;; UNSUPPORTED, and UNOBSERVABLE from inside: two dev builds fused onto ONE shared
+;; root. `before-load-src` calls each SHADOW_NS_RESET callback with the reloaded ns
+;; and NOTHING else, and lifecycle hooks are invoked with no arguments after being
+;; resolved by name off the SHARED `$CLJS` object. So a callback learns which build
+;; is reloading only from the identity BAKED INTO ITS OWN BUNDLE — which is exactly
+;; what `current-build-id` reads. Two bundles that each carry their OWN copy of
+;; this namespace are therefore isolated: each copy resolves its own build's name
+;; and reconciles only its own rows. But two builds sharing ONE copy (one `$CLJS`,
+;; one set of atoms, one `defonce`d producer) share one set of hooks — a single
+;; shared singleton — and cannot be told apart by anything shadow exposes.
+;;
+;; There is deliberately NO runtime detection, warning, or error for the fused
+;; case. From inside the shared copy the condition is unobservable, so any check
+;; would be heuristic or tautological — the same "agreeing with itself by
+;; construction" defect this namespace rejects for cycle tokens below. The
+;; boundary is held by construction and stated here, never policed at runtime.
 ;;
 ;; ## Overlapping cycles are unsupported, and no token can change that (rf2-84173)
 ;;
@@ -1580,12 +1605,15 @@
 ;; `defonce` still guarantees exactly one entry, while the BEHAVIOUR it runs is
 ;; always the freshly loaded code.
 ;;
-;; The trampoline is TAGGED with its owning build identity, so the install can
-;; REPLACE its own previous entry instead of appending, and never touches an
-;; entry owned by shadow or another library. The tag carries the build id
-;; because `SHADOW_NS_RESET` lives on `goog.global` — SHARED across every build
-;; in one realm — so two builds' producers must coexist rather than evict each
-;; other.
+;; The trampoline carries its owning build identity as a TAG, and the install
+;; REPLACES the entry it already owns instead of appending — but what identifies
+;; that entry is OBJECT IDENTITY, never the tag (rf2-ymfix); the tag is provenance
+;; a reader can inspect, not an ownership lever. An entry owned by shadow or
+;; another library is never touched at all. The tag names a build because
+;; `SHADOW_NS_RESET` lives on `goog.global`, which is SHARED across a whole JS
+;; realm: two bundles that each carry their OWN copy of this namespace (the
+;; supported multi-copy topology — see §THE ISOLATION UNIT) put two producers on
+;; that one array, so they must coexist rather than evict each other.
 ;;
 ;; ## And the INSTALL is self-upgrading too (rf2-mp6fz)
 ;;

--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -1624,23 +1624,14 @@
 
 #?(:cljs
    (def ^:private producer-tag
-     "The JS property re-frame.ui stamps on its own `SHADOW_NS_RESET` entry. Its
-     value is the owning build id, so a re-install replaces exactly this build's
-     producer and every other owner's callback is left alone."
+     "The JS property re-frame.ui stamps on its own `SHADOW_NS_RESET` entry,
+     carrying the owning build id as PROVENANCE: it marks an entry as re-frame.ui's
+     and names the build that installed it, which diagnostics and tests read to
+     tell this framework's producers from shadow's and other libraries'. It is NOT
+     the ownership lever — a re-install finds its own entry by OBJECT IDENTITY,
+     never by tag, because the same tag can appear on a co-loaded bundle's entry
+     that only identity can distinguish from ours (rf2-ymfix)."
      "reFrameUiReloadSourceReset"))
-
-#?(:cljs
-   (defn- tagged-producer-index
-     "Index of `build-id`'s re-frame.ui producer in `arr`, or -1 when absent.
-     Identifies by TAG, never by position or object identity — other owners'
-     callbacks sit in the same shared array."
-     [arr build-id]
-     (let [want (str build-id)]
-       (loop [i 0]
-         (cond
-           (>= i (alength arr))                             -1
-           (= want (unchecked-get (aget arr i) producer-tag)) i
-           :else                                            (recur (inc i)))))))
 
 #?(:cljs
    (defonce ^{:private true
@@ -1683,28 +1674,35 @@
      neither clobbers nor is clobbered by shadow's own init), so shadow calls it
      with each reloaded source's ns from `before-load-src`.
 
-     IDEMPOTENT, and SELF-UPGRADING across a hot reload (rf2-mp6fz). It reuses
-     the slot this copy already owns — its own previous entry (by identity, so
-     the slot is reused even when the tag it captured has since gone stale),
-     else this build's tagged entry — and REPLACES it in place; only a copy that
-     owns nothing appends. So repeated installs can neither duplicate the
-     producer nor strand a predecessor still routing to an identity this build
-     no longer resolves, and entries owned by shadow or other libraries/builds
-     are never inspected for anything but their tag, never moved, and never
-     retired. Dev-only (gated on `js/goog.DEBUG`, elided from `:advanced`
-     production)."
+     IDEMPOTENT, and SELF-UPGRADING across a hot reload (rf2-mp6fz). Ownership is
+     OBJECT IDENTITY, with NO tag fallback (rf2-ymfix): it reuses the exact entry
+     this copy already installed — found by identity on the shared array, so the
+     slot is reused even when the build tag that entry captured has since gone
+     stale — and REPLACES it in place. A copy that owns nothing there — a first
+     install, or one whose remembered entry has gone — APPENDS its own; it never
+     adopts an entry by tag, because a same-tagged callback may belong to a
+     co-loaded bundle and only identity can tell the two apart. So repeated
+     installs can neither duplicate this copy's producer nor strand a predecessor
+     still routing to an identity this build no longer resolves, and an entry owned
+     by shadow, another library, or another bundle is never replaced, moved,
+     reordered, or invoked. Dev-only (gated on `js/goog.DEBUG`, elided from
+     `:advanced` production)."
      []
      (when ^boolean js/goog.DEBUG
        (let [arr      (or js/goog.global.SHADOW_NS_RESET #js [])
              build-id (current-build-id)]
          (set! (.-SHADOW_NS_RESET js/goog.global) arr)
          (let [prev @owned-producer
-               mine (if prev (.indexOf arr prev) -1)
-               i    (if (neg? mine) (tagged-producer-index arr build-id) mine)
+               ;; OWNERSHIP IS OBJECT IDENTITY, with no tag fallback (rf2-ymfix):
+               ;; locate only the exact entry this copy installed. A same-tagged
+               ;; entry we did not install may belong to a co-loaded bundle, and
+               ;; only identity tells the two apart — so an absent predecessor is
+               ;; NOT authority to replace one.
+               i    (if prev (.indexOf arr prev) -1)
                f    (make-reload-source-producer build-id)]
            (if (neg? i)
-             (.push arr f)
-             (aset arr i f))
+             (.push arr f)    ; own nothing on the array → APPEND; never adopt by tag
+             (aset arr i f))  ; replace exactly this copy's own entry, in place
            (reset! owned-producer f))
          true))))
 

--- a/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
@@ -291,23 +291,6 @@
             :b-el {:properties #{:b-prop}}} (declared))
         "the recovering reload commits the full new manifest, no ghost of the abort")))
 
-(deftest build-ids-are-isolated
-  ;; AC5: two builds sharing one runtime atom own their rows independently.
-  ;; Reloading (and evicting a source in) build :app cannot touch build :lib.
-  (rules/reset-custom-elements!)
-  (rules/register-custom-element! :app-el {:properties #{:a-prop}} 'app.core :app)
-  (rules/register-custom-element! :lib-el {:properties #{:l-prop}} 'lib.core :lib)
-  (is (= #{:a-prop} (rules/custom-element-properties :app-el)))
-  (is (= #{:l-prop} (rules/custom-element-properties :lib-el)))
-  ;; build :app reloads app.core with its declaration deleted
-  (rules/notify-reload! :app)
-  (rules/note-reloaded-sources! ['app.core] :app)
-  (rules/commit-reload! :app)
-  (is (= #{} (rules/custom-element-properties :app-el))
-      "reconciling build :app evicts its own source")
-  (is (= #{:l-prop} (rules/custom-element-properties :lib-el))
-      "build :lib's row is untouched — reconciling one build cannot delete another's"))
-
 (deftest repl-reeval-converges-to-the-same-manifest-as-file-save-hmr
   ;; AC6: REPL re-evaluation of a source (including a zero-declaration one) goes
   ;; through the SAME begin/stage/commit protocol as a file-save reload, so it
@@ -417,29 +400,6 @@
          (declared))
       "the published aggregate equals the legal serial execution exactly — the
        reentrant row appears once, the committing source's reload applied"))
-
-(deftest reentrant-registration-into-an-open-foreign-cycle-still-stages
-  ;; Generation rule: a reentrant registration whose OWN build still has an open
-  ;; cycle must stage into it (it belongs to that live generation), not leak live.
-  ;; Here build :a commits (firing the watch) while build :b's cycle is open, and
-  ;; the reentrant registration targets build :b.
-  (rules/reset-custom-elements!)
-  (rules/register-custom-element! :a-el {:properties #{:a}} 'app.a :a)
-  (rules/register-custom-element! :b-el {:properties #{:b}} 'app.b :b)
-  (rules/notify-reload! :a)
-  (rules/notify-reload! :b)                                   ; build :b cycle stays open
-  (rules/register-custom-element! :a-el {:properties #{:a2}} 'app.a :a)
-  (with-publication-reentry
-    #(rules/register-custom-element! :b-el {:properties #{:b2}} 'app.b :b) ; :b cycle open -> stages
-    (fn [] (rules/commit-reload! :a)))                        ; commit :a -> publish -> reentry
-  (is (= #{:a2} (rules/custom-element-properties :a-el))
-      "build :a committed")
-  (is (= #{:b} (rules/custom-element-properties :b-el))
-      "the reentrant :b registration STAGED into build :b's still-open cycle —
-       last-known-good until :b commits, not leaked live by :a's commit")
-  (rules/commit-reload! :b)
-  (is (= #{:b2} (rules/custom-element-properties :b-el))
-      "and it commits with build :b's own cycle"))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-84173 — exactly ONE live cycle per build, and the supersession is LOUD.
@@ -899,11 +859,14 @@
 ;; rf2-vxgfnd.142 — ONE real build identity through the whole reload cycle.
 ;;
 ;; Before this, every real path (emitted registrations, both lifecycle hooks, the
-;; reset producer) hard-coded the ::default placeholder; a second identity was
-;; reachable only from a test-only arity. Two real builds sharing a JS realm
-;; collapsed onto one [::default ns] row. `current-build-id` is now the single
-;; rule every arity default resolves through, so the participants in a cycle can
-;; never disagree about who owns a row.
+;; reset producer) hard-coded the ::default placeholder while a second identity was
+;; reachable only from a test-only arity — so an emitted registration and the cycle
+;; meant to reconcile it could key a row differently and strand it.
+;; `current-build-id` is now the single rule every arity default resolves through,
+;; so the participants in ONE build's cycle can never disagree about who owns a
+;; row. These fixtures pin that single-build identity COHERENCE; they are not a
+;; co-loaded-build isolation claim (rf2-4vm19 — see §THE ISOLATION UNIT in
+;; rules.cljc: one Shadow dev build per CLJS root).
 ;; ---------------------------------------------------------------------------
 
 (deftest build-identity-is-one-rule-shared-by-every-arity
@@ -950,48 +913,6 @@
     (is (= #{:p2} (rules/custom-element-properties :stable-el))
         "so the reload reconciled the row the initial load wrote")))
 
-(deftest co-loaded-builds-retain-independent-declarations
-  ;; AC2: two co-loaded builds with EQUAL namespace symbols. Reloading (or
-  ;; zero-declaring) either one may not disturb the other's contribution — the
-  ;; collapse that a shared ::default owner token caused.
-  (rules/reset-custom-elements!)
-  (rules/register-custom-element! :a-el {:properties #{:from-app}} 'shared.ns :app)
-  (rules/register-custom-element! :l-el {:properties #{:from-lib}} 'shared.ns :lib)
-  (is (= #{:from-app} (rules/custom-element-properties :a-el)))
-  (is (= #{:from-lib} (rules/custom-element-properties :l-el)))
-  ;; build :app reloads `shared.ns` declaring NOTHING
-  (rules/notify-reload! :app)
-  (rules/note-reloaded-sources! ['shared.ns] :app)
-  (rules/commit-reload! :app)
-  (is (= #{} (rules/custom-element-properties :a-el))
-      "build :app's own zero-declaration source is evicted")
-  (is (= #{:from-lib} (rules/custom-element-properties :l-el))
-      "build :lib's row under the SAME ns symbol is untouched — equal ns symbols
-       in two builds are two rows, not one")
-  ;; and the reverse direction: :lib zero-declares, :app is re-populated
-  (rules/register-custom-element! :a-el {:properties #{:from-app}} 'shared.ns :app)
-  (rules/notify-reload! :lib)
-  (rules/note-reloaded-sources! ['shared.ns] :lib)
-  (rules/commit-reload! :lib)
-  (is (= #{} (rules/custom-element-properties :l-el))
-      "build :lib's source is evicted by its own cycle")
-  (is (= #{:from-app} (rules/custom-element-properties :a-el))
-      "build :app's row survives build :lib's reconciliation"))
-
-(deftest one-builds-cycle-never-consumes-another-builds-reload-evidence
-  ;; A cycle open for build :app must not be reconciled by evidence belonging to
-  ;; build :lib — the two builds' reload cycles are independent transactions.
-  (rules/reset-custom-elements!)
-  (rules/register-custom-element! :a-el {:properties #{:from-app}} 'shared.ns :app)
-  (rules/register-custom-element! :l-el {:properties #{:from-lib}} 'shared.ns :lib)
-  (rules/notify-reload! :app)
-  (rules/note-reloaded-sources! ['shared.ns] :lib)   ; :lib has NO open cycle → no-op
-  (rules/commit-reload! :app)
-  (is (= #{:from-lib} (rules/custom-element-properties :l-el))
-      "reload evidence addressed to a build with no open cycle cannot evict rows")
-  (is (= #{:from-app} (rules/custom-element-properties :a-el))
-      "nor can it leak into the OTHER build's open cycle"))
-
 (deftest ready-made-pair-cannot-inject-a-foreign-owner-into-an-open-cycle
   ;; rf2-4vm19. The seam took a ready-made [build ns] pair VERBATIM, so the
   ;; owner travelled with the datum rather than with the addressed cycle: a
@@ -1027,25 +948,6 @@
         (str "the addressed build's row is reconciled, given " (pr-str sources)))
     (is (= #{:b} (rules/custom-element-properties :b-el))
         (str "and no other build's row is touched, given " (pr-str sources)))))
-
-#?(:cljs
-   (deftest installed-producer-notes-into-its-own-build-only
-     ;; The producer is the one real caller of the ledger seam, so its build
-     ;; routing is what decides which build a reloaded source is attributed to.
-     ;; A row owned by a DIFFERENT build must be untouched when the installed
-     ;; producer fires — SHADOW_NS_RESET lives on the shared `goog.global`, so
-     ;; every build's producer sees every build's reload.
-     (rules/reset-custom-elements!)
-     (rules/register-custom-element! :own-el {:properties #{:p}} 'shared.ns)      ; this build
-     (rules/register-custom-element! :other-el {:properties #{:q}} 'shared.ns
-                                     :some-other-build)
-     (rules/notify-reload!)
-     (fire-shadow-ns-reset! 'shared.ns)      ; what before-load-src does
-     (rules/commit-reload!)
-     (is (= #{} (rules/custom-element-properties :own-el))
-         "the producer noted the reloaded source into ITS OWN build's cycle")
-     (is (= #{:q} (rules/custom-element-properties :other-el))
-         "another build's row under the same ns symbol is untouched")))
 
 #?(:cljs
    (deftest reinstalled-producer-still-runs-the-current-implementation
@@ -1118,19 +1020,3 @@
          "the dropped :x-el is evicted through the real producer")
      (is (= #{:label} (rules/custom-element-properties :y-el))
          "the surviving :y-el is retained")))
-
-#?(:cljs
-   (deftest reload-producer-is-build-isolated
-     ;; The producer notes into the ::default build (one compiled bundle = one
-     ;; build). Explicit-build rows are untouched by a ::default-build reload —
-     ;; the [build-id ns] ownership holds through the real path too.
-     (rules/reset-custom-elements!)
-     (rules/register-custom-element! :app-el {:properties #{:a-prop}} 'app.core)       ; ::default
-     (rules/register-custom-element! :lib-el {:properties #{:l-prop}} 'lib.core :lib)  ; build :lib
-     (rules/notify-reload!)                       ; opens the ::default cycle
-     (fire-shadow-ns-reset! 'app.core)            ; app.core re-runs, declares nothing
-     (rules/commit-reload!)
-     (is (= #{} (rules/custom-element-properties :app-el))
-         "the ::default reload evicts its own zero-declaration source")
-     (is (= #{:l-prop} (rules/custom-element-properties :lib-el))
-         "build :lib's row is untouched — the producer cannot cross builds")))

--- a/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
@@ -859,6 +859,42 @@
              (when-not (neg? i) (.splice arr i 1)))
            (rules/install-reload-source-producer!))))))
 
+#?(:cljs
+   (deftest producer-install-appends-rather-than-adopting-a-same-tagged-foreign
+     ;; rf2-ymfix. Ownership is OBJECT IDENTITY, with NO tag fallback. When this
+     ;; copy's remembered entry is ABSENT from the shared array, re-installing must
+     ;; APPEND its own producer and leave every entry it did not itself install
+     ;; untouched — INCLUDING one carrying THIS build's tag, which a co-loaded
+     ;; bundle may legitimately hold and which only identity can distinguish from
+     ;; ours. The retired tag fallback treated the first same-tagged entry as ours
+     ;; and REPLACED it, silently evicting a foreign owner.
+     (let [arr      js/goog.global.SHADOW_NS_RESET
+           standing (first (rf2-producers))              ; the entry THIS copy owns
+           std-i    (.indexOf arr standing)
+           ;; a co-loaded bundle's producer, tagged EXACTLY like this copy's — the
+           ;; precise case only object identity can tell apart from our own.
+           foreign  (let [f (fn [_ns] nil)]
+                      (unchecked-set f "reFrameUiReloadSourceReset"
+                                     (str (rules/current-build-id)))
+                      f)]
+       (try
+         ;; The exact fallback trigger: this copy's remembered entry goes ABSENT
+         ;; from the array while `owned-producer` still points at it, so the
+         ;; identity scan misses and the old code fell back to the tag.
+         (.splice arr std-i 1)
+         (.push arr foreign)
+         (rules/install-reload-source-producer!)
+         (is (some #(identical? % foreign) (array-seq arr))
+             "a same-tagged entry this copy did NOT install is preserved — the
+              install APPENDED its own producer instead of adopting the foreign one
+              by tag (rf2-ymfix; the retired fallback replaced it in place)")
+         (finally
+           ;; leave the array with exactly one re-frame.ui producer owned by this
+           ;; copy, as every other producer test expects to find it.
+           (let [fi (.indexOf arr foreign)]
+             (when-not (neg? fi) (.splice arr fi 1)))
+           (rules/install-reload-source-producer!))))))
+
 ;; ---------------------------------------------------------------------------
 ;; rf2-vxgfnd.142 — ONE real build identity through the whole reload cycle.
 ;;

--- a/implementation/ui/test/re_frame/ui/rules_reload_linearizability_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/rules_reload_linearizability_jvm_test.clj
@@ -15,7 +15,14 @@
   still open) reintroduces the loss, so a green run here is load-bearing.
 
   JVM-only: `future`/`CyclicBarrier` real threads. CLJS is single-threaded; its
-  reentrancy proof lives in `re-frame.ui.rules-cljs-test`."
+  reentrancy proof lives in `re-frame.ui.rules-cljs-test`.
+
+  The explicit `build-id` arguments throughout this suite are TEST-STATE PARTITION
+  TOKENS, not a topology claim (rf2-4vm19). They keep a round's rows and cycles
+  from colliding in the one shared ledger, so each race has an unambiguous legal
+  serial outcome. They do NOT assert that two dev builds can share one copy of
+  `re-frame.ui.rules`: the shipped boundary is ONE Shadow dev build per CLJS global
+  namespace root (see §THE ISOLATION UNIT in `rules.cljc`)."
   (:require [clojure.test :refer [deftest is]]
             [re-frame.ui.rules :as rules])
   (:import [java.util.concurrent CyclicBarrier]))
@@ -164,8 +171,11 @@
           (str "round " round ": settled aggregate equals the ledger projection")))))
 
 (deftest concurrent-write-throughs-on-distinct-builds-compose
-  ;; Two builds, no cycles: concurrent initial-load registrations must both land
-  ;; in the aggregate — the publication path never drops one under contention.
+  ;; Two DISJOINT ledger partitions, no cycles: concurrent initial-load
+  ;; registrations must both land in the aggregate — the publication path never
+  ;; drops one under contention. The distinct build-ids are partition tokens that
+  ;; keep the two rows independent (see the ns docstring), never a claim that two
+  ;; co-loaded dev builds share this namespace.
   (dotimes [round 400]
     (rules/reset-custom-elements!)
     (let [barrier (CyclicBarrier. 2)


### PR DESCRIPTION
Two ruled defects, both in `implementation/ui/src/re_frame/ui/rules.cljc`. One commit each, sequenced (they touch the same file and interact).

## rf2-ymfix — the tag fallback could replace a foreign owner

#6434 promised reload-source producer ownership was "object identity, never the tag", but `install-reload-source-producer!` still fell back to `tagged-producer-index` when its remembered object was absent from the shared `SHADOW_NS_RESET` array. In that fallback the FIRST callback carrying the same build tag was treated as ours and replaced in place — and it may belong to a co-loaded bundle, the precise case #6434's own comments say only identity can distinguish. A newly loaded ns copy with a fresh ownership cell had the same ambiguity during tag adoption.

The install now locates only the exact entry this copy installed, by object identity. A copy that owns nothing there — a first install, or one whose remembered entry has gone — **appends** rather than adopting a same-tagged entry it cannot prove it installed. An absent predecessor is no longer authority to replace anything.

`tagged-producer-index` had no other caller and is removed. The producer tag stays, re-documented as **provenance** (which build claims an entry; read by diagnostics and tests) rather than the ownership lever.

The #6434 stale-placeholder-to-current-build migration is unaffected — it proceeds by identity (the predecessor IS on the array), the path `producer-install-migrates-the-entry-this-copy-already-owns` pins.

**Red-before (own lever, observable outcome):** the new fixture removes this copy's standing producer from the array, inserts a foreign callback tagged with `(current-build-id)`, and re-installs. Against the unfixed code the foreign object was GONE from the array — asserted on the array's contents, never on an exception (this class does not throw on CLJS):

```
FAIL in (producer-install-appends-rather-than-adopting-a-same-tagged-foreign)
expected: (some (fn* [p1__54278#] (identical? p1__54278# foreign)) (array-seq arr))
  actual: (not (some #object[Function] (#object[f])))
Ran 888 tests containing 4719 assertions. 1 failures, 0 errors.
```

With the fix: 888 tests, **0 failures**. The red run is itself the mutation tooth, so the assertion is not vacuous.

**Production reachability:** dev-only and *unreachable* in production, not merely unguarded — the whole install already sits inside `(when ^boolean js/goog.DEBUG ...)` and `owned-producer` is gated identically, so `:advanced` carries no producer at all. This is a code *removal* inside that existing gate; no new gate and no always-on behaviour introduced. Verified causally by `test:browser-prod-elision`, which runs `custom_element_reload_elision_prod_test.cljs` *inside* the `:advanced` bundle and asserts this exact function is inert.

## rf2-4vm19 Arm 1 — option (b) scalpel (RULED)

Per the delegated ruling (2026-07-19): enforce the boundary and retire the synthetic multi-build coverage, rather than attempt to prove real isolation.

**The boundary, now stated normatively** in `rules.cljc` (§THE ISOLATION UNIT): **one Shadow dev build per CLJS global namespace root containing `re-frame.ui.rules`.** The isolation unit is the CLJS *root*, not the page and not the output file — separate output files are not automatically separate runtime copies. Supported and isolated by construction: one app plus `:preloads` tools, iframes/workers, independently compiled release bundles, separate pages. Unsupported and unobservable: two dev builds fused onto one shared root.

Commentary rewritten (found by content — #6440 moved every line the ruling cited):

- "Bounded by shadow's reload surface" promoted to the normative contract statement;
- the ownership rationale that presented multi-build reconciliation as shipped behaviour rewritten — the `[build-id ns-sym]` key re-documented as the internal producer seam plus a test-state partition token;
- the `.48` "three holes" list drops the multi-build cross-contamination hole;
- the `.142` test-section header reframed as single-build identity coherence.

**No runtime detection, warning, or error** — from inside the shared copy the fused condition is unobservable, so any check would be heuristic or tautological. Hence **no new error-id, no Spec 009 row, and no `spec/` or `docs/` edits**.

**Six synthetic tests deleted** (sole subject: cross-build independence inside ONE shared namespace copy, a state no real call path can produce):

1. `build-ids-are-isolated`
2. `reentrant-registration-into-an-open-foreign-cycle-still-stages`
3. `co-loaded-builds-retain-independent-declarations`
4. `one-builds-cycle-never-consumes-another-builds-reload-evidence`
5. `installed-producer-notes-into-its-own-build-only`
6. `reload-producer-is-build-isolated`

**Kept and confirmed still executing:** `ready-made-pair-cannot-inject-a-foreign-owner-into-an-open-cycle`, `ns-only-and-ready-made-pair-are-the-same-evidence`, `build-identity-is-one-rule-shared-by-every-arity`, `build-identity-is-stable-across-calls`, the producer-install trio, and the full JVM linearizability suite (its explicit build-ids re-documented as test-state partition tokens).

**Mechanism unchanged:** the `[build-id ns]` ledger key, `current-build-id`, the producer tag and the explicit build-scoped arities all stay. **Not** collapsed to ns-only; no two-build fixture, per-build registry, owner-token protocol, config switch, or wrapper manager added.

## How the two were reconciled

They meet on the shared array and on the normalization invariant:

- **No deleted test covered ymfix's path.** The two producer-level deletions (`installed-producer-notes-into-its-own-build-only`, `reload-producer-is-build-isolated`) exercise the *ledger* seam through `note-reloaded-sources!`, not the *install* path ymfix changes.
- **The kept normalization tests are untouched by ymfix.** `note-reloaded-sources!` normalization ("ownership travels with the addressed cycle, never with the payload") is orthogonal to array ownership; ymfix does not go near it, and both kept tests pass unchanged.
- **The kept producer trio still passes** because it never triggers the old fallback: in all three the predecessor IS on the array, so they take the identity path before and after. That is exactly why they did not catch this bug and a new fixture was required.
- `producer-migration-leaves-another-owners-producer-alone` (kept) and the new ymfix fixture are now complementary: the former proves a same-tagged foreign entry survives when our predecessor is **present**, the latter when it is **absent** — together closing the ownership matrix.
- ymfix's identity-only change made the "co-loaded bundle's entry carrying our tag" case *real behaviour* rather than an aspirational comment; 4vm19's boundary explains which co-loaded topologies are supported (separate copies sharing `goog.global`) versus unobservable (two builds fused on one root). The producer commentary was updated once, coherently, to say both.

## Quality gates

All foreground, unpiped, run to completion; exit codes captured by redirect.

| Gate | Result |
| --- | --- |
| `implementation/ui` → `clojure -M:test` (JVM) | **977 tests**, 0 failures, 0 errors (exit 0) |
| `npm run test:cljs` | **10239 tests / 50574 assertions**, 0 failures, 0 errors (exit 0) |
| `npm run test:elision` | **PASS** — production 60/60 absent, control 60/60 present (exit 0) |
| `npm run test:browser-prod-elision` | **PASS** — ui mounted production elision; 108 browser tests, 0 failures (exit 0) |
| focused `:node-test-ui` (red/green lever) | 888 → **882**, 0 failures (exit 0) |

**Test-count deltas are exactly the six deletions, no more:**

- `test:cljs`: 10244 baseline **+1** (new ymfix fixture) **−6** (deletions) = **10239**
- focused `:node-test-ui`: 888 (with ymfix fixture) **−6** = **882**
- ui JVM: 981 baseline **−4** = **977** — four, not six, because `installed-producer-notes-into-its-own-build-only` and `reload-producer-is-build-isolated` are `#?(:cljs ...)`-only and never ran on the JVM

The ui JVM *assertion* count varies run-to-run (18723 vs 18718 on two runs of identical code) — race-dependent assertions in the concurrency suites. The *test* count is deterministic, so the −4 is exact.
