### PR TITLE
fix(ci): narrow G-18 to sibling isolation and prove the residual absences in G-11 (rf2-kxork)

### DIFF
--- a/ai/findings/new-substrate-synthesis/07-testing.md
+++ b/ai/findings/new-substrate-synthesis/07-testing.md
@@ -147,7 +147,7 @@ standing every-stage-wires-its-gates rule]:**
 | G-15 atomic-local writer matrix | two (and N) same-turn host writers through `update!` both land — key+pointer, timer+listener, observer+handler arms; fn-value `set!` stores exactly; mixed `update!`+dispatch; StrictMode replay; JVM typed failure; `:local-state` cause-evidence rows emitted; HMR hook-signature ride |
 | G-16 render-slot parity | slotted output (client emitter vs JVM tree) normalized-structurally equivalent; keyed reorder under slots; purity diagnostics fire for `sub`/`lease`/`local`/`effect`/dispatch/hooks inside a slot body; manifest slot sites present |
 | G-17 safe-spread ownership | the policy form rejects owned keys (`:key` `:ref` `:value` `:checked` owned `:on-*`) in dev **and** advanced builds; `aria-*`/`data-*` pass; a controlled site under the policy form **retains** the sync door; general `spread` at the same site still forfeits it |
-| G-18 library façade isolation | advanced build importing **one** view from a multi-view library namespace retains no unused sibling views, schemas, docs projections, or dev registration (fixture-first per the readiness §4 DCE row — a substrate packaging change is justified only if this fails structurally) |
+| G-18 library façade isolation | advanced build importing **one** view from a multi-view library namespace retains no unused sibling views (fixture-first per the readiness §4 DCE row — a substrate packaging change is justified only if this fails structurally) |
 
 The component-library **proof pack** (readiness §7 — controlled input, selection
 controller, slotted list cell, safe-attrs form control, schema-described component,

--- a/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
+++ b/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
@@ -197,7 +197,7 @@ table governs.
 | **G-15** atomic-local writer matrix | N same-turn host writers through `update!` all land (key+pointer, timer+listener, observer+handler arms); fn-value `set!` stores exactly; mixed `update!`+dispatch; StrictMode replay; JVM typed failure; `:local-state` cause evidence; HMR ride |
 | **G-16** render-slot parity | slotted output normalized-structurally equivalent across both emitters; keyed reorder under slots; purity diagnostics fire inside slot bodies; manifest slot sites present |
 | **G-17** safe-spread ownership | the policy form rejects owned keys (`:key` `:ref` `:value` `:checked` owned `:on-*`) in dev **and** advanced builds; `aria-*`/`data-*` pass; the policy form retains the sync door where general `spread` forfeits it |
-| **G-18** library façade isolation | an advanced build importing one view from a multi-view library namespace retains no unused sibling views, schemas, docs projections, or dev registration (fixture-first; see §1) |
+| **G-18** library façade isolation | an advanced build importing one view from a multi-view library namespace retains no unused sibling views (fixture-first; see §1) |
 
 Methodology, binding on every gate: identical fixtures, distributions not best
 runs, pinned browsers, cold+warm, dev overhead separate, no precomputed-props

--- a/docs/EP/EP-0035-component-library-readiness.md
+++ b/docs/EP/EP-0035-component-library-readiness.md
@@ -150,7 +150,7 @@ absence is proven under G-7/G-11.
 | G-15 atomic-local writer matrix | N same-turn host writers through `update!` all land (key+pointer, timer+listener, observer+handler arms); fn-value `set!` stores exactly; mixed `update!`+dispatch; StrictMode replay; JVM typed failure; `:local-state` cause rows; HMR ride |
 | G-16 render-slot parity | client/JVM slotted output normalized-structurally equivalent; keyed reorder under slots; purity diagnostics fire inside slot bodies; manifest slot sites present |
 | G-17 safe-spread ownership | owned-key rejection in dev **and** advanced builds; `aria-*`/`data-*` pass; policy form retains the sync door while general spread forfeits it |
-| G-18 library façade isolation | an advanced build importing **one** view retains no unused sibling views, schemas, docs projections, or dev registration — fixture-first: a packaging change is justified only if this fails structurally |
+| G-18 library façade isolation | an advanced build importing **one** view retains no unused sibling views — fixture-first: a packaging change is justified only if this fails structurally |
 
 The **component-library proof pack** lands in the conformance/parity corpus
 as a rolling consumer (no re-com build dependency): controlled input ·

--- a/implementation/scripts/check-ui-facade-isolation.cjs
+++ b/implementation/scripts/check-ui-facade-isolation.cjs
@@ -3,10 +3,24 @@
 
 // G-18 — library facade isolation (fixture-first; 07 §5, EP-0035, readiness §4).
 //
-// An advanced build importing EXACTLY ONE view from a multi-view library
-// namespace must retain NO unused sibling views, schemas, docs, or dev
-// registration. This runner builds the proof-pack single-view + all-views
-// advanced bundles and asserts:
+// WHAT THIS GATE PROVES, EXACTLY: sibling render-sentinel isolation. An
+// advanced build importing EXACTLY ONE view from a multi-view library namespace
+// must retain NO unused sibling views — measured as the render sentinel literal
+// each sibling `defview` carries.
+//
+// WHAT IT DOES NOT PROVE (rf2-kxork): production absence of schemas, docs
+// projections, and dev registration. Those are owned by G-11, whose companion
+// scanner `check-ui-mounted-prod-elision.cjs` asserts them against the
+// `browser-test-prod-elision` :advanced bundle — the `rf$view_shell`
+// registration literal plus dedicated props-schema and view-docstring
+// sentinels. `spec/conformance/S3-view-conformance-profile.md` assigns the
+// exact production-absence rosters to G-11 (§4/§5) and gives G-18 only the
+// sibling-isolation row; under EP-0034's one-owner-per-claim doctrine G-18
+// must not duplicate that proof. The EP G-18 roster rows were narrowed to
+// match this scope in the same change.
+//
+// This runner builds the proof-pack single-view + all-views advanced bundles
+// and asserts:
 //
 //   positive control (all-views): every sentinel PRESENT — proves the library
 //     views compile and their sentinels are real, DCE-able strings (so a

--- a/implementation/scripts/check-ui-mounted-prod-elision.cjs
+++ b/implementation/scripts/check-ui-mounted-prod-elision.cjs
@@ -234,6 +234,65 @@ if (!bundle.includes(CONFLICT_CONTROL)) {
 }
 
 /*
+ * rf2-kxork — G-11 owns the view-payload absence claims that G-18 used to
+ * over-promise.
+ *
+ * The EP G-18 roster rows asserted that a one-view import retains no unused
+ * sibling views, SCHEMAS, DOCS PROJECTIONS, or DEV REGISTRATION, while the
+ * shipped G-18 gate (`check-ui-facade-isolation.cjs`) only ever measured
+ * sibling render sentinels. `spec/conformance/S3-view-conformance-profile.md`
+ * already assigns the exact production-absence rosters to G-11, so the EP rows
+ * were narrowed to sibling isolation and the residual three arms land HERE —
+ * in the gate that owns them — rather than being silently retired.
+ *
+ * Each arm is a source positive control plus a bundle absence, the pattern used
+ * throughout this file. The absences are NOT vacuous: this bundle roots and
+ * really RENDERS `js-hint-view` (binding_plan_advanced_elision_prod_test calls
+ * `markup` on it and asserts the committed HTML), and it links
+ * `re-frame.ui.runtime`, whose `view-shell-mark` is the registration marker.
+ * So each literal has a live compiled carrier in this exact artifact; if the
+ * dev-only material rode along, it would be here.
+ */
+const RUNTIME_SOURCE = path.join(ROOT, 'ui', 'src', 're_frame', 'ui',
+                                 'runtime.cljs');
+const runtimeSource = fs.readFileSync(RUNTIME_SOURCE, 'utf8');
+const VIEW_SHELL_MARK = 'rf$view_shell';
+if (!runtimeSource.includes(`(def ^:private view-shell-mark "${VIEW_SHELL_MARK}")`)) {
+  fail(`dev-registration source positive control is absent: view-shell-mark "${VIEW_SHELL_MARK}"`);
+}
+
+const BINDING_PLAN_PROD_TEST = path.join(ROOT, 'ui', 'test', 're_frame', 'ui',
+                                         'binding_plan_advanced_elision_prod_test.cljs');
+const bindingPlanProdTest = fs.readFileSync(BINDING_PLAN_PROD_TEST, 'utf8');
+const SCHEMA_DOC_SENTINEL = 'rf2-g11-schema-doc-sentinel-v1';
+const VIEW_DOCSTRING_SENTINEL = 'rf2-g11-view-docstring-sentinel-v1';
+
+// The carrier must be a REALLY RENDERED view, not merely a declared one — an
+// unrendered defview could be DCE'd wholesale, which would make both absences
+// below pass for the wrong reason.
+if (!/\(markup js-hint-view\b/.test(bindingPlanProdTest)) {
+  fail('G-11 payload sentinels lost their rendered carrier: binding_plan_advanced_elision_prod_test no longer renders js-hint-view');
+}
+for (const expected of [
+  `{:props [:map {:doc "${SCHEMA_DOC_SENTINEL}"}]}`,
+  `"${VIEW_DOCSTRING_SENTINEL} `,
+]) {
+  if (!bindingPlanProdTest.includes(expected)) {
+    fail(`G-11 view-payload source positive control is absent: ${expected}`);
+  }
+}
+
+for (const [forbidden, what] of [
+  [VIEW_SHELL_MARK, 'DEV view registration (view-shell-mark)'],
+  [SCHEMA_DOC_SENTINEL, 'view props-schema metadata'],
+  [VIEW_DOCSTRING_SENTINEL, 'view docstring / docs projection'],
+]) {
+  if (bundle.includes(forbidden)) {
+    fail(`${what} survived advanced output: ${forbidden}`);
+  }
+}
+
+/*
  * rf2-vxgfnd.94.8 — REAL compiled mutation control. A second advanced build
  * flips a private goog-define which roots an unrelatedly named atom/reset path
  * inside re-frame.ui.tool.evidence. The same production test must turn red on

--- a/implementation/ui/test/re_frame/ui/binding_plan_advanced_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/binding_plan_advanced_elision_prod_test.cljs
@@ -60,7 +60,16 @@
 ;; The fixture under proof. The group local is QUALIFIED (`probe/node`) as well
 ;; as `^js`-hinted, so it exercises the name-strip and the metadata carriage in
 ;; one shape — the host binds `node`, reading slot "probe/node".
+;; rf2-kxork — G-11 payload sentinels. This view is REALLY RENDERED below in
+;; the `:advanced` bundle, so its docstring and its props-schema `:doc` are
+;; carried by a live, rooted view rather than a dead declaration. The G-11
+;; scanner (`scripts/check-ui-mounted-prod-elision.cjs`) asserts both literals
+;; ABSENT from that bundle: docs projections and schema metadata are dev-only
+;; material and must not reach production. Do not rename or delete them without
+;; updating that scanner — they are its subjects, not decoration.
 (defview js-hint-view
+  "rf2-g11-view-docstring-sentinel-v1 — docs-projection egress probe."
+  {:props [:map {:doc "rf2-g11-schema-doc-sentinel-v1"}]}
   [{:keys [^js probe/node]}]
   [:span {:data-role "bp-hinted"} (str "[" (.-bpAdvancedHinted node) "]")])
 


### PR DESCRIPTION
Implements the ruled split (b) of `rf2-kxork` (Fable, delegated by Mike, 2026-07-19).

## The drift

The EP G-18 roster rows claimed an advanced one-view import retains no unused sibling views, **schemas, docs projections, or dev registration**. The shipped G-18 gate (`check-ui-facade-isolation.cjs`) only ever measured sibling *render sentinels* — the other three arms were honestly declined at promotion (#6408) rather than shipped weak. The four-arm wording was the inconsistent duplicate.

`spec/conformance/S3-view-conformance-profile.md` already assigns the exact production-absence rosters to **G-11** and gives G-18 only the sibling-isolation row. Under EP-0034's one-owner-per-claim doctrine the fix is to align the EP rows to S3 and put the residual proof in the gate that already owns it — not to re-prove the same `goog.DEBUG` fold in G-18 via a new control build and a third advanced compile in required CI.

## Part 1 — wording

Three four-arm rows existed in the tracked corpus; all three are narrowed to sibling views only:

- `docs/EP/EP-0034-…:200` (named)
- `docs/EP/EP-0035-…:153` (named)
- `ai/findings/new-substrate-synthesis/07-testing.md:150` (the tracked origin row; already tracked, no new `ai/` path)

`check-ui-facade-isolation.cjs`'s header now states exactly what the gate proves (sibling render-sentinel isolation) and that schemas/docs/registration production absence is owned by G-11.

`S3-view-conformance-profile.md:195` was already narrow and is untouched, as is EP-0035 P1-5's G-7/G-11 pointer. No EP status flipped; no G-7 row touched.

## Part 2 — the mandatory G-11 rider

Narrowing alone would silently retire a requirement — the exact defect this bead exists to prevent. So `check-ui-mounted-prod-elision.cjs` gains three absence arms over the **existing** `browser-test-prod-elision` advanced bundle, following that file's established source-positive-control + bundle-absence pattern:

| arm | sentinel | source positive control |
|---|---|---|
| dev registration | `rf$view_shell` | `view-shell-mark` at `runtime.cljs:58` (zero fixture edits) |
| schemas | `rf2-g11-schema-doc-sentinel-v1` | `:props [:map {:doc …}]` on `js-hint-view` |
| docs projection | `rf2-g11-view-docstring-sentinel-v1` | docstring on the same view |

The two payload sentinels ride `js-hint-view`, which that bundle **really renders** (`markup js-hint-view`, committed HTML asserted). The scanner also pins that the carrier still renders — a DCE'd declaration would make both absences pass for the wrong reason.

No new shadow build, no new CI job, no bundle analyser, no `shadow-cljs.edn` edit, no per-view matrix in G-18.

## Teeth

A `goog.DEBUG=true` control build of the identical namespace set (run as verification, **not** added to the gate) confirms every arm is a real elision proof rather than absence-by-omission:

| sentinel | `goog.DEBUG=true` control | advanced production |
|---|---|---|
| `rf$view_shell` | **1** | 0 |
| `rf2-g11-schema-doc-sentinel-v1` | **1** | 0 |
| `rf2-g11-view-docstring-sentinel-v1` | **1** | 0 |

**No arm landed red.** The ruling flagged that arm (c) might, given the 225 `goog.DEBUG` occurrences measured inside docstrings by var reification — that retention does not reach this view's docstring. Nothing was softened, gated around, or dropped.

The deliberate load-bearing `:infer-warning` on `js-unhinted-control-view` remains **exactly one** — the added `:props` schema did not introduce a second.

## Quality gates

All run in the foreground to completion, unpiped:

| gate | result |
|---|---|
| `npm run test:browser-prod-elision` | **PASS** — `ui mounted production elision: PASS`; 108 tests / 429 assertions, 0 failures, 0 errors |
| `npm run test:ui-facade-isolation` | **PASS** — self-test 19/19; roster 6 views, imported=controlled-input, siblings 0/5 retained |
| `npm run test:elision` | **PASS** — production 60/60 absent, control 60/60 present |
| `python -m mkdocs build --strict` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `python scripts/check_ep_status_sync.py` | exit 0 |
| `implementation/ui` → `clojure -M:test` | **982 tests / 18742 assertions, 0 failures, 0 errors** (pins EP-0034 by exact path) |
| `scripts/check-no-hardcoded-paths.sh` | exit 0 |

## Fence

Test-merged against the open #6449 (`worker/ep0034-g7-layer1-ckyfh`), which also edits EP-0034: **auto-merges cleanly, no conflict**. Its rows are G-7 (§1 prose, the G-7 roster row, §5 named-open); mine is the G-18 roster row at a disjoint location.