### PR TITLE
docs(ssr): keep data-rf-root out of the emit seam root-identity boundary (rf2-kzp2l)

### DIFF
--- a/spec/004B-UI-Tree-and-Conversion.md
+++ b/spec/004B-UI-Tree-and-Conversion.md
@@ -452,11 +452,16 @@ the code half from re-implementing them:
   hydration payload, and the install ledger are
   [011 §Root Manifest v1](011-SSR.md#root-manifest-v1) and the sections following it.
   `emit-ui-tree` neither writes them nor reads them.
-- **No container, no identity.** Root-ids, identifier prefixes, element locators and the
-  root marker attribute are root identity
+- **No container, no identity.** Root-ids, identifier prefixes and element locators are
+  root identity
   ([004C §7](004C-Roots-and-Mount.md#7-duplicate-and-conflict-detection--fail-loud-three-layers)),
   settled before the seam is called and stamped by whatever assembles the page around
-  its output.
+  its output. The `data-rf-root` marker is **not** identity, and it does not belong on
+  the emitted tree either: it is a bare discriminator on the manifest script that the
+  page assembler writes immediately after the container, saying only that a manifest is
+  here and never which root
+  ([011 §The wire form](011-SSR.md#the-wire-form)). *Which* root is the manifest's
+  `:root-id`, spelled once, in the content.
 - **No response.** Status, headers, cookies and redirects live in the per-request
   response accumulator
   ([011 §HTTP response contract](011-SSR.md#http-response-contract)). A string is the


### PR DESCRIPTION
Closes rf2-kzp2l.

## The defect

`spec/004B`'s "No container, no identity" bullet (added by #6436) grouped **the root marker attribute** with root-id, identifier-prefix and element locator as root identity settled before `emit-ui-tree` and "stamped by whatever assembles the page around its output".

That misclassifies the concrete marker. `spec/011` §The wire form pins `data-rf-root` as a **bare discriminator on the immediately-adjacent manifest `<script>`** — "no value, no identity". Root identity lives in the manifest *content* (`:root-id`), read via `manifest/discover`. Calling the marker identity obscures which layer emits it and invites an implementer to stamp it on the root container or the emitted tree.

## Verification of the premise (code vs. prose)

The **code is already correct** — this is a doc-only correction, not a code fix:

- `re-frame.ssr.manifest/script-html` emits the bare marker and its docstring already states the rule: *"The marker attribute is bare: it says 'a root manifest is here', never WHICH root — that is the content's `:root-id`."*
- `#6448`'s new `re-frame.ssr.ui-tree` serialiser is **clean of root identity** — it contains no marker/root-id/identifier-prefix code at all (its `marker*` hits are the SVG `markerEnd`/`markerUnits` attribute alias table, unrelated). So the seam does not stamp the marker today; the prose was the only thing saying it might.
- Two tests already pin the bare shape: `wire-form-round-trips` asserts `(not (re-find #"data-rf-root=" html))`, and `marker-attribute-is-pinned-in-one-place` pins the spelling.

Not a duplicate of #6448 — that PR added the serialiser, it did not touch the 004B classification, which is still wrong on `main`.

## The change

One bullet. Keeps root-id, identifier-prefix and element locator outside the seam as page/root-assembly facts exactly as before, and describes `data-rf-root` separately as the bare manifest-script discriminator the page assembler writes after the container, linking `011 §The wire form` as owner. Marker spelling, the seam signature, and the remaining S5 page-assembly work are untouched.

**Sites: 1 found, 1 named** — the bead's count is accurate. A full sweep of 004B for `rf-root` / "root marker" / "root identity" / "Root-id" and every occurrence of "identity" surfaces only this bullet (the other "identity" hit, line 45, is about text nodes carrying no identity — unrelated).

## Quality gates

Doc-only change; no code, no new public vars, no error ids.

| Gate | Result |
| --- | --- |
| `python scripts/check_doc_slugs.py` | **exit 0** |
| `python -m mkdocs build --strict` | **exit 0** |
| `python scripts/check_keyword_catalogue_drift.py` | **exit 0** |
| `implementation/ssr` `clojure -M:test` | **exit 0** — 485 tests, 2307 assertions, 0 failures/errors |
| `npm run test:cljs` | **exit 0** — 10262 tests, 50657 assertions, 0 failures/errors |

Doc gates re-run after rebasing onto current `origin/main`; both still exit 0.

**No Spec 009 row needed** — no new or changed error id, so the held hot-zone catalogue was not opened. Core suite not required for the same reason (nothing the core catalogue/conformance reads was touched).

### Lever / vacuity probe

Since this is a doc change, the lever is the anchor gate. Flipping the new link to `011-SSR.md#the-wire-form-PROBE`:

```
PROBE check_doc_slugs EXIT=1
  BROKEN ANCHOR: spec\004B-UI-Tree-and-Conversion.md:463 -> 011-SSR.md#the-wire-form-PROBE
PROBE mkdocs EXIT=0
```

The gate reds naming **my exact line and my new anchor** — so the added link is really checked, not vacuously green. Note the second line: `mkdocs --strict` exits **0** on that same broken tree, confirming strict alone would not have caught it. Probe reverted and the file verified byte-identical by sha1 (`0e647d7988…`) before commit.
