### PR TITLE
fix(core): make call-site instrumentation evaluation-order-transparent and restore the synchronous dispatch contract (rf2-i3dvj)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -207,6 +207,30 @@
 (def ^:no-doc dispatch-sync-impl router/dispatch-sync!)
 (def ^:no-doc subscribe-impl     subs/subscribe)
 
+(defn ^:no-doc stamp-opts
+  "Merge macro-stamped `extra` into a call's user-supplied `opts`, TOLERANTLY:
+  a malformed (non-map, non-nil) `opts` passes through UNTOUCHED so the callee's
+  own validation still produces its clean framework error rather than a raw
+  host `ClassCastException` (`subscribe`'s pinned malformed-opts contract —
+  non-map opts fall to the ambient path and fail loud with
+  `:rf.error/no-frame-context`, never a misroute).
+
+  Reached ONLY from the debug-gated stamped branch of the call-site macros, so
+  it DCEs under `:advanced` + `goog.DEBUG=false`. It is deliberately GENERIC —
+  no reserved keyword literal lives in this body, keeping the elision probe's
+  `rf.trace/call-site`-absent-from-prod-bundle assertion intact (the keyword
+  literal stays in the macro expansion, which DCEs).
+
+  Per rf2-i3dvj it is also a plain FN CALL by construction: the call-site
+  macros may splice only yield-free expression forms into the caller's context,
+  and an inline `(if (map? opts) …)` would need a `let` to avoid double
+  evaluation — which the CLJS compiler lowers to an awaited async IIFE inside
+  an async context. A function call cannot lower that way."
+  [opts extra]
+  (if (or (map? opts) (nil? opts))
+    (merge opts extra)
+    opts))
+
 ;; ---- CLJS fn-aliases for registration ------------------------------------
 ;;
 ;; Source-coord capture on CLJS rides the JVM-emitted macros above. The

--- a/implementation/core/src/re_frame/core_call_site_macros.cljc
+++ b/implementation/core/src/re_frame/core_call_site_macros.cljc
@@ -69,18 +69,25 @@
 
 #?(:clj
    (defn- build-stamped-2
-     "Emit the STAMPED dispatch-family call — ALWAYS a 2-arity `disp` call so the
+     "Emit the STAMPED call-site-family call — ALWAYS a 2-arity `disp` call so the
      `:rf.trace/call-site` keyword literal lives ONLY in THIS debug-gated macro
      expansion (DCE'd in production), never in the production-reachable owning-ns
      fn body. `disp-sym` is the fully-qualified `^:no-doc` seam var
-     (`re-frame.core/dispatch-impl` / `re-frame.core/dispatch-sync-impl` —
-     `def`-aliases of `re-frame.router/dispatch!` / `-dispatch-sync!`, NOT the
+     (`re-frame.core/dispatch-impl` / `-dispatch-sync-impl` / `subscribe-impl`
+     — `def`-aliases of `re-frame.router/dispatch!` / `-dispatch-sync!` /
+     `re-frame.subs/subscribe`, NOT the
      owning-ns fns directly: a `defn` there would let the CLJS compiler attach
      inline fixed-arity metadata to a call site referencing it directly, so a
      `with-redefs`'d fn whose arity set differs couldn't satisfy it). When the
-     user wrote two args, `(disp event-vec (assoc opts :rf.trace/call-site
-     cs))`. The 1-arg case is the ambient-frame form, stamped via the 2-arity
-     opts map."
+     user wrote two args, `(disp arg1 (assoc opts :rf.trace/call-site cs))`
+     — `arg1` being the event-vec for the dispatch pair, the query-v for
+     `subscribe`. The 1-arg case is the ambient-frame form, stamped via the
+     2-arity opts map.
+
+     The emitted form is a plain CALL whose only non-literal operand is the
+     user's own expression — no `binding`, no `cond->`, nothing that the CLJS
+     compiler could lower to an awaited async IIFE in the caller's context
+     (rf2-i3dvj)."
      [disp-sym arg1 arg2 cs-form]
      (if arg2
        `(~disp-sym ~arg1 (assoc ~arg2 :rf.trace/call-site ~cs-form))
@@ -110,22 +117,32 @@
    (defn build-subscribe-form
      "Build the expansion for the `subscribe` macro. `arg1` is the user's
      `query-v`; `arg2` is the optional `opts` map (may carry `{:frame
-     target}`), nil for the 1-arity. The call-site coord rides a
-     `trace/with-call-site` wrapper (not an opts assoc). The two forms emit
-     POSITIONALLY (`(subscribe-impl arg1 arg2)`), matching
-     `re-frame.subs/subscribe`'s `[query-v]` / `[query-v opts]` sig exactly.
-     Targets the `^:no-doc` `re-frame.core/subscribe-impl` seam (a `def`-alias
-     of `re-frame.subs/subscribe`) for the same with-redefs-safety reason
+     target}`), nil for the 1-arity. Targets the `^:no-doc`
+     `re-frame.core/subscribe-impl` seam (a `def`-alias of
+     `re-frame.subs/subscribe`) for the same with-redefs-safety reason
      `build-dispatch-form` targets `dispatch-impl`. The OUTERMOST debug-gate
      keeps the whole stamped branch DCE-able under `:advanced` +
-     `goog.DEBUG=false`."
+     `goog.DEBUG=false`.
+
+     The call-site coord rides the SHARED [[build-stamped-2]] opts-map seam —
+     the same `:rf.trace/call-site` key `dispatch` / `dispatch-sync` use — and
+     `re-frame.subs/subscribe` establishes the `trace/with-call-site` scope
+     from it INSIDE ITS OWN BODY (the mirror of `router/dispatch!`'s existing
+     `(with-call-site (:rf.trace/call-site opts) ...)`).
+
+     Per rf2-i3dvj this placement is a CORRECTNESS requirement, not a
+     tidy-up. `with-call-site` expands to a `binding`, and a `binding`
+     spliced into the CALLER's context compiles to `await (async
+     function(){...})()` when the call site sits in a CLJS async context —
+     inserting a real microtask yield immediately before the read. The
+     caller-side wrapper this replaces was an independent yield source of
+     exactly the class the `coords-form` fix removes. See
+     [[re-frame.source-coords/coords-form]] for the standing principle:
+     a call-site expansion splices ONLY yield-free expression forms into
+     the caller; dynamic scope is established in the callee's body."
      [form-meta ns-sym file arg1 arg2]
      (let [cs-form (call-site-form form-meta ns-sym file)
-           stamped (if arg2
-                     `(re-frame.trace/with-call-site ~cs-form
-                        (re-frame.core/subscribe-impl ~arg1 ~arg2))
-                     `(re-frame.trace/with-call-site ~cs-form
-                        (re-frame.core/subscribe-impl ~arg1)))
+           stamped (build-stamped-2 're-frame.core/subscribe-impl arg1 arg2 cs-form)
            plain   (if arg2
                      `(re-frame.core/subscribe-impl ~arg1 ~arg2)
                      `(re-frame.core/subscribe-impl ~arg1))]

--- a/implementation/core/src/re_frame/core_call_site_macros.cljc
+++ b/implementation/core/src/re_frame/core_call_site_macros.cljc
@@ -79,10 +79,11 @@
      owning-ns fns directly: a `defn` there would let the CLJS compiler attach
      inline fixed-arity metadata to a call site referencing it directly, so a
      `with-redefs`'d fn whose arity set differs couldn't satisfy it). When the
-     user wrote two args, `(disp arg1 (assoc opts :rf.trace/call-site cs))`
-     — `arg1` being the event-vec for the dispatch pair, the query-v for
-     `subscribe`. The 1-arg case is the ambient-frame form, stamped via the
-     2-arity opts map.
+     user wrote two args, `(disp arg1 (stamp-opts opts {:rf.trace/call-site
+     cs}))` — `arg1` being the event-vec for the dispatch pair, the query-v for
+     `subscribe`; [[re-frame.core/stamp-opts]] merges tolerantly so a malformed
+     non-map opts still reaches the callee for its own clean error. The 1-arg
+     case is the ambient-frame form, stamped via the 2-arity opts map.
 
      The emitted form is a plain CALL whose only non-literal operand is the
      user's own expression — no `binding`, no `cond->`, nothing that the CLJS
@@ -90,7 +91,8 @@
      (rf2-i3dvj)."
      [disp-sym arg1 arg2 cs-form]
      (if arg2
-       `(~disp-sym ~arg1 (assoc ~arg2 :rf.trace/call-site ~cs-form))
+       `(~disp-sym ~arg1 (re-frame.core/stamp-opts
+                           ~arg2 {:rf.trace/call-site ~cs-form}))
        `(~disp-sym ~arg1 {:rf.trace/call-site ~cs-form}))))
 
 #?(:clj

--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -607,12 +607,35 @@
            path)))))
 
 (defn coords-form
-  "Construct the compile-time `(cond-> {:ns 'sym} ...)` form that every
-  reg-* macro emits as the value of its `*pending-coords*` binding.
+  "Construct the compile-time coord MAP LITERAL that every reg-* macro
+  emits as the value of its `*pending-coords*` binding.
 
   `form-meta` is `(meta &form)`; `file` is `*file*`; `ns-sym` is the
   consumer's namespace symbol. The returned form is syntax-quote-safe
   data the caller splices into its expansion.
+
+  EVALUATION-ORDER TRANSPARENCY (rf2-i3dvj — standing, binds all future
+  macro emission). The `cond->` runs HERE, in Clojure, at expansion time;
+  absent keys are simply omitted from the emitted literal. It is NOT
+  emitted as a runtime `cond->` form. That distinction is a CORRECTNESS
+  requirement, not a micro-optimisation:
+
+    Framework instrumentation must be EVALUATION-ORDER-TRANSPARENT. A
+    call-site macro expansion may splice ONLY yield-free expression forms
+    (compile-time literals and plain calls) into the CALLER's context; any
+    dynamic-scope establishment happens INSIDE THE CALLEE's own function
+    body, where it can never compile as an awaited async IIFE.
+
+  The reason: the call-site macros (`dispatch`, `dispatch-sync`,
+  `subscribe`) splice this form directly into USER code. When that user
+  code sits in a CLJS async context (`cljs.test/async`, a `go` block, any
+  `^:async` fn), the compiler lowers a spliced multi-step form such as a
+  runtime `cond->` to `await (async function(){...})()` — inserting a real
+  microtask YIELD immediately BEFORE the instrumented call. That silently
+  broke the documented same-stack synchronicity of `dispatch-sync!` and was
+  mis-attributed to the router (PR #6432, since reversed). A map literal
+  cannot lower that way. Harmonises with [[form-coords]]'s existing
+  expansion-time literal emission on the machines path.
 
   :file picks the form-meta value over `*file*` and rejects the
   `\"NO_SOURCE_PATH\"` sentinel via `resolve-file`.
@@ -635,10 +658,13 @@
   (let [chosen-file (resolve-file form-meta file)
         chosen-file #?(:clj  (when chosen-file (absolutise-file chosen-file))
                        :cljs chosen-file)]
-    `(cond-> {:ns '~ns-sym}
-       ~chosen-file         (assoc :file ~chosen-file)
-       ~(:line form-meta)   (assoc :line ~(:line form-meta))
-       ~(:column form-meta) (assoc :column ~(:column form-meta)))))
+    ;; Symbols inside `:ns` need explicit quoting — otherwise the splice
+    ;; would namespace-resolve them at compile time (same rationale as
+    ;; `stamp-machine-spec-expr` / `form-coords`).
+    (cond-> {:ns (list 'quote ns-sym)}
+      chosen-file         (assoc :file chosen-file)
+      (:line form-meta)   (assoc :line (:line form-meta))
+      (:column form-meta) (assoc :column (:column form-meta)))))
 
 #?(:clj
    (defn prod-coords-form
@@ -656,8 +682,11 @@
             ~(coords-form form-meta file ns-sym)
             ~(prod-coords-form form-meta file ns-sym))
 
-     Both branches use `cond->` so absent keys (e.g. nil `:line` on a
-     programmatic synthesis) elide cleanly.
+     Both branches build with `cond->` AT EXPANSION TIME so absent keys
+     (e.g. nil `:line` on a programmatic synthesis) elide cleanly from the
+     emitted LITERAL — see [[coords-form]] for why the `cond->` must not
+     survive into the emitted form (rf2-i3dvj evaluation-order
+     transparency).
 
      Per rf2-wvsxg: the picked `:file` is absolutised via
      [[absolutise-file]] at macro-expansion time so the downstream URI
@@ -666,9 +695,9 @@
      [form-meta file ns-sym]
      (let [chosen-file (resolve-file form-meta file)
            chosen-file (when chosen-file (absolutise-file chosen-file))]
-       `(cond-> {:ns '~ns-sym}
-          ~chosen-file       (assoc :file ~chosen-file)
-          ~(:line form-meta) (assoc :line ~(:line form-meta))))))
+       (cond-> {:ns (list 'quote ns-sym)}
+         chosen-file       (assoc :file chosen-file)
+         (:line form-meta) (assoc :line (:line form-meta))))))
 
 ;; ---- co-located reference-site (states-tree) coord stamping --------------
 ;;

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -1641,6 +1641,20 @@
              ;; Miss: the durable build carries the captured token (rf2-7w1im).
              (compute-and-cache! frame-id query-v expected-incarnation))))))))))) ;; close or + let[frame-record superseded?] + fn + call-with-frame-resolution + normalize-target let + 3-arity + subscribe-in-frame
 
+(declare subscribe)
+
+(defn- subscribe-with-opts
+  "INTERNAL body of `subscribe`'s 2-arity, factored out so the
+  `trace/with-call-site` scope push can be applied CONDITIONALLY around it
+  (rf2-i3dvj). `with-call-site` sets `:call-site` unconditionally, so
+  pushing it with a nil coord would CLOBBER an inherited one — exactly what
+  `make-capture-frame`'s `:subscribe` op relies on, since it wraps its own
+  view coord around a call that carries no `:rf.trace/call-site` in `opts`."
+  [query-v opts]
+  (if-some [target (:frame opts)]
+    (subscribe-in-frame target query-v (:rf.frame/expected-incarnation opts))
+    (subscribe query-v)))
+
 (defn subscribe
   "Per Spec 006 §Lookup algorithm. Returns the reaction for query-v;
   build-and-cache on miss; reuse on hit. The 1-arity ambient form
@@ -1666,9 +1680,18 @@
   This is the runtime-callable fn form. The macro form
   `re-frame.core/subscribe` captures `(meta &form)` and calls straight
   through to THIS fn (rf2-m90brg — no `re-frame.core/subscribe*` facade
-  indirection), wrapping the call in `trace/with-call-site` so any error
-  emitted inside the synchronous miss path (`:rf.error/no-such-sub`,
-  `:rf.error/frame-destroyed`) carries the invocation coord."
+  indirection), stamping the coord onto `opts` as `:rf.trace/call-site`.
+  THIS BODY then establishes the `trace/with-call-site` scope from it, so
+  any error emitted inside the synchronous miss path
+  (`:rf.error/no-such-sub`, `:rf.error/frame-destroyed`) carries the
+  invocation coord.
+
+  Per rf2-i3dvj the scope push lives HERE, in the callee, and not in the
+  macro expansion: `with-call-site` expands to a `binding`, and a `binding`
+  spliced into the CALLER's context compiles to `await (async
+  function(){...})()` inside a CLJS async context — a hidden microtask yield
+  before a call documented as same-stack synchronous. Mirrors
+  `router/dispatch!`, which reads the identical opts key in its own body."
   ([query-v]
    ;; EP-0002 §Subscriptions And Read Helpers — the carried-invariant
    ;; read. The 1-arity ambient form resolves the frame through the
@@ -1698,9 +1721,15 @@
    ;; `:subscribe` op's pinned token — INTERNAL, reserved `:rf.frame/` ns)
    ;; rides alongside `:frame` so the read is fenced to the exact captured
    ;; incarnation. nil for every ordinary explicit-frame read.
-   (if-some [target (:frame opts)]
-     (subscribe-in-frame target query-v (:rf.frame/expected-incarnation opts))
-     (subscribe query-v))))
+   ;;
+   ;; rf2-i3dvj: `:rf.trace/call-site` is the macro-stamped invocation coord
+   ;; (dev-only — the whole stamped branch DCEs under `:advanced` +
+   ;; `goog.DEBUG=false`, so this reads nil in production). The scope push is
+   ;; INSIDE this body by contract; see the docstring. Conditional, because a
+   ;; nil push would clobber an inherited coord — see `subscribe-with-opts`.
+   (if-some [cs (when interop/debug-enabled? (:rf.trace/call-site opts))]
+     (trace/with-call-site cs (subscribe-with-opts query-v opts))
+     (subscribe-with-opts query-v opts))))
 
 (defn- subscribe-once-in-frame
   "INTERNAL worker for `subscribe-once`. `target` may be a frame-id

--- a/implementation/machines/test/re_frame/machine_view_unmount_teardown_mounted_dom_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machine_view_unmount_teardown_mounted_dom_cljs_test.cljs
@@ -97,6 +97,20 @@
   [traces op]
   (filterv #(= op (:operation %)) traces))
 
+(defn- view-ops-of
+  "`ops-of`, narrowed to the events tagged with `view-id`.
+
+  The trace listener is PROCESS-GLOBAL and the `:browser-test` runner shares
+  one page across every `-dom-cljs-test` namespace, so an unrelated suite's
+  deferred `:rf.view/unmounted` disposal can land inside this fixture's
+  settle window. Counting every view's teardown marker was therefore always
+  an under-specified way to assert THIS view's teardown — it passed on
+  scheduling luck, and rf2-i3dvj (which removed compiler-inserted awaits from
+  call-site expansions in async contexts) shifted that luck. Narrowing to the
+  view under test asserts what the fixture actually means."
+  [traces op view-id]
+  (filterv #(= view-id (-> % :tags :rf.view/id)) (ops-of traces op)))
+
 (defn- settle-macrotasks
   "Resolve after `n` macrotask turns so Reagent's deferred render-reaction
   disposal (which fires the `:rf.view/unmounted` marker on a real unmount)
@@ -161,7 +175,7 @@
                                     [(rf/view :mvut/session-view)]]))
               (is (some? (mtest/snapshot frame-id machine-id))
                   "machine still live while the view is mounted")
-              (is (zero? (count (ops-of @traces view-unmounted)))
+              (is (zero? (count (view-ops-of @traces view-unmounted :mvut/session-view)))
                   "no :rf.view/unmounted before the unmount (nothing torn down yet)")
 
               ;; UNMOUNT via the real host teardown path. The disposal that fires
@@ -171,7 +185,8 @@
                   (.then
                     (fn [_]
                       ;; (1) the REAL host-unmount path fired exactly one marker.
-                      (let [unmounts (ops-of @traces view-unmounted)]
+                      (let [unmounts (view-ops-of @traces view-unmounted
+                                                  :mvut/session-view)]
                         (is (= 1 (count unmounts))
                             "exactly one :rf.view/unmounted fired via the REAL
                              reaction-disposal path — NOT a direct emit")
@@ -285,7 +300,8 @@
             (-> (settle-macrotasks 3)
                 (.then
                   (fn [_]
-                    (is (= 1 (count (ops-of @traces view-unmounted)))
+                    (is (= 1 (count (view-ops-of @traces view-unmounted
+                                                 :mvut/ed-view)))
                         "the mounted view's REAL unmount fired exactly one
                          :rf.view/unmounted teardown marker")
                     (is (= 1 (count (ops-of @traces fx-destroyed)))

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -83,23 +83,24 @@
        back-to-back `dispatch-sync!` calls in one JavaScript stack render
        once, not twice; so do nested cross-frame synchronous drains.
 
-       Read that example precisely. Guarantee 3 is a PERMISSION — "drains
-       that finish before the same checkpoint MAY share a batch" — and it
-       stays a permission. The example is nonetheless UNCONDITIONAL because
-       its own phrase `in one JavaScript stack` supplies the condition: a
-       stack that has not yielded cannot have reached a host checkpoint (the
-       microtask armed by the first mark cannot run until the stack unwinds),
-       so both drains necessarily finish inside one window. The example is
-       therefore a THEOREM of guarantees 1, 3 and 4 together — not a promotion
-       of the permission into a general "separate drains always share" rule.
-       Two drains with a real yield between them still render separately, by
+       Read that example precisely. Guarantee 3 is a PERMISSION — drains that
+       finish before the same checkpoint MAY share a batch — and it stays a
+       permission. The example is nonetheless UNCONDITIONAL because its own
+       phrase `in one JavaScript stack` supplies the condition: a stack that
+       has not yielded cannot have reached a host checkpoint (the microtask
+       armed by the first mark cannot run until the stack unwinds), so both
+       drains necessarily finish inside one window. The example is therefore a
+       THEOREM of guarantees 1, 3 and 4 together — NOT a promotion of the
+       permission into a general `separate drains always share` rule. Two
+       drains with a real yield between them still render separately, by
        guarantee 4.
     4. Drains separated by a real HOST YIELD render separately.
 
   Guarantee 3's example held on the mounted React path all along. It was
   briefly retracted (rf2-kahkr) on a measurement — three back-to-back
   `dispatch-sync!` calls advancing the revision 0 -> 1 -> 2, with a control
-  microtask observed running "mid-call" — that was REAL but MISATTRIBUTED.
+  microtask observed running seemingly MID-CALL — that was REAL but
+  MISATTRIBUTED.
   The yield was INSTRUMENTATION, not the router (rf2-i3dvj): the DEBUG
   call-site stamp emitted a runtime `cond->` into the caller's context, which
   the CLJS compiler lowered to `await (async function(){...})()` because the

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -79,32 +79,38 @@
        the window cannot close while the stack is still unwinding.
     2. N epochs/events settled within ONE drain coalesce into ONE batch.
     3. SEVERAL drains — or listener re-entry after a completed batch — that
-       finish before the SAME host checkpoint MAY SHARE one batch. Nested
-       cross-frame synchronous drains do.
+       finish before the SAME host checkpoint MAY SHARE one batch. Two
+       back-to-back `dispatch-sync!` calls in one JavaScript stack render
+       once, not twice; so do nested cross-frame synchronous drains.
 
-       This is a PERMISSION, not a guarantee, and the difference is load
-       bearing. It used to carry an UNCONDITIONAL example — two back-to-back
-       `dispatch-sync!` calls in one JavaScript stack render once, not twice —
-       which is retracted (rf2-kahkr). It holds HEADLESS, where
-       `render-batch-host-checkpoint-cljs-test` still pins a genuinely shared
-       batch. It is FALSE on the MOUNTED React path, so it could never be
-       stated unconditionally.
-
-       Measured on the mounted path, three back-to-back `dispatch-sync!` calls
-       advance the revision 0 -> 1 -> 2: a host microtask checkpoint runs DURING
-       the second and third calls, so each flushes its predecessor's mark.
-       What advances it is the ordinary armed `schedule-flush!` microtask —
-       every captured `flush-scope!` stack terminated at that closure with no
-       router frame above it, and `commit*`/`advance-revision!` never ran. It is
-       NOT a hidden synchronous flush and NOT a React layout-commit correction.
-       A control `js/queueMicrotask` enqueued by the fixture ran at the same
-       point, so the checkpoint is the host's: `dispatch-sync!` is simply not
-       microtask-atomic on this path — it yields. Whether it SHOULD is a ROUTER
-       question, not a scheduler one, and is deliberately left open.
-
-       So: do not rely on two separate `dispatch-sync!` calls sharing a batch.
-       Guarantees 1 and 2 — one drain, one batch — are what a caller may lean on.
+       Read that example precisely. Guarantee 3 is a PERMISSION — "drains
+       that finish before the same checkpoint MAY share a batch" — and it
+       stays a permission. The example is nonetheless UNCONDITIONAL because
+       its own phrase `in one JavaScript stack` supplies the condition: a
+       stack that has not yielded cannot have reached a host checkpoint (the
+       microtask armed by the first mark cannot run until the stack unwinds),
+       so both drains necessarily finish inside one window. The example is
+       therefore a THEOREM of guarantees 1, 3 and 4 together — not a promotion
+       of the permission into a general "separate drains always share" rule.
+       Two drains with a real yield between them still render separately, by
+       guarantee 4.
     4. Drains separated by a real HOST YIELD render separately.
+
+  Guarantee 3's example held on the mounted React path all along. It was
+  briefly retracted (rf2-kahkr) on a measurement — three back-to-back
+  `dispatch-sync!` calls advancing the revision 0 -> 1 -> 2, with a control
+  microtask observed running "mid-call" — that was REAL but MISATTRIBUTED.
+  The yield was INSTRUMENTATION, not the router (rf2-i3dvj): the DEBUG
+  call-site stamp emitted a runtime `cond->` into the caller's context, which
+  the CLJS compiler lowered to `await (async function(){...})()` because the
+  fixture's calls sat inside a `cljs.test/async` body. The `await` — not
+  `dispatch-sync!` — reached the microtask checkpoint that flushed the
+  previous mark. `dispatch-sync!` and the synchronously-observable call-site
+  family (`dispatch`, `dispatch-sync`, `subscribe`) are SAME-STACK
+  SYNCHRONOUS IN EVERY BUILD, dev included; call-site macros now splice only
+  yield-free literals. Nothing about the scheduler changed, and no router,
+  scheduler or drain-finalization seam was added: there was never a router
+  question here to leave open.
 
   `One render batch per router drain` is RETIRED as normative. It remains
   merely the COMMON CASE — true exactly when callers yield between drains

--- a/implementation/ui/test/re_frame/ui/render_batch_host_checkpoint_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/render_batch_host_checkpoint_dom_cljs_test.cljs
@@ -7,57 +7,44 @@
   the loop on the host that actually owns the checkpoint: a mounted root, a
   React `Profiler` counting genuine commits, and a genuine microtask yield.
 
-  It proves the two halves that only a real host can distinguish:
+  It proves the three halves that only a real host can distinguish:
 
     - A COMPLETED DRAIN CLOSES NOTHING. A full `dispatch-sync!` drain returns
       with the cell still pending, the revision unmoved and React having
       committed nothing. Only the following host checkpoint advances it. This
       is the direct falsification of the retired per-drain rule.
+    - NO YIELD → ONE BATCH. Two back-to-back `dispatch-sync` calls in one
+      JavaScript stack — INSIDE a `cljs.test/async` body, the exact context
+      that produced the rf2-kahkr misreading — share one window: a control
+      microtask queued BEFORE the second call cannot run until both calls have
+      returned, and the pair yields ONE revision advance and ONE root commit.
     - HOST YIELD → TWO BATCHES. Two drains separated by a real microtask yield
       produce two revision advances and two real root commits (guarantee 4).
 
-  On sharing: the ruled contract says drains finishing before one checkpoint
-  MAY share a batch, and the headless sibling pins a real shared batch. This
-  namespace deliberately does NOT assert sharing, because it was measured not
-  to hold universally here — a second `dispatch-sync!` in the same stack
-  advances the first drain's pending mark before making its own. Asserting the
-  permission as though it were the guarantee is exactly the over-claim this
-  bead exists to remove.
+  ## What the earlier measurement actually measured (rf2-kahkr → rf2-i3dvj)
 
-  ## What advances that pending mark (rf2-kahkr — traced, not inferred)
+  This namespace previously recorded that a second `dispatch-sync!` in the
+  same stack advanced the first drain's pending mark before making its own —
+  revision 0 -> 1 -> 2, with a control `js/queueMicrotask` running between a
+  call's begin and end markers — and concluded that `dispatch-sync!` yields.
 
-  The mechanism is now identified, and it is NOT a hidden synchronous flush.
-  Three back-to-back `dispatch-sync!` calls were instrumented on this exact
-  fixture (stack capture on `flush-scope!` and on `advance-revision!`, with
-  console markers bracketing each call). Across 3 browser runs, identically:
+  The measurement was real. The ATTRIBUTION was wrong, and it is now reversed.
+  `dispatch-sync!` never yielded. The yield was INSTRUMENTATION: the DEBUG
+  call-site stamp spliced a runtime `cond->` coord-map construction into the
+  CALLER's context, and the CLJS compiler lowers a spliced multi-step form to
+  `await (async function(){...})()` when the call site sits inside an async
+  context — which every body in this namespace is (`cljs.test/async`). The
+  compiler-inserted `await` immediately BEFORE the second `dispatch_sync_impl`
+  invocation is what reached the microtask checkpoint. The captured
+  `flush-scope!` stacks correctly terminated at the armed `schedule-flush!`
+  microtask closure with no router frame above them precisely BECAUSE the
+  flush ran at that `await`, not inside the router.
 
-    - the revision advanced 0 -> 1 -> 2, one advance per call after the first;
-    - EVERY `flush-scope!` stack was the same three frames —
-      `flush-scope!` <- `flush-pending!` <- the `schedule-flush!` microtask
-      closure — terminating there, with NO router or dispatch frame above it.
-      That is a host job-queue entry point, i.e. the ordinary armed microtask;
-    - `advance-revision!` (the `commit*` / step-8 route) NEVER fired, so the
-      advance is scheduler phase 1, not a React layout-commit correction;
-    - the flush was logged BETWEEN the `begin` and `end` markers of the second
-      and third calls — i.e. a microtask checkpoint ran DURING `dispatch-sync!`.
-
-  The control that settles it: a plain `js/queueMicrotask` enqueued by the
-  fixture itself, immediately before the second call, ALSO ran between that
-  call's begin and end markers. Nothing in re-frame is involved in that
-  callback, so the checkpoint is genuinely the host's.
-
-  Conclusion: `dispatch-sync!` is not microtask-atomic on the mounted path — it
-  yields, and the ordinary checkpoint therefore lands mid-call and flushes the
-  previous drain's mark. So there is nothing here to remove: the scheduler is
-  behaving exactly as specified, and the earlier `flush-render!` /
-  `dispatch-committed!` / late-bound-hook suspects are correctly ruled out.
-
-  Whether `dispatch-sync!` SHOULD yield is a ROUTER question living in
-  `implementation/core`, and it is a ruling, not a measurement. It is left open
-  deliberately. Until it is ruled, no fixture here asserts sharing OR
-  non-sharing across two `dispatch-sync!` calls: the first would assert a
-  permission as a guarantee, the second would freeze possibly-unintended
-  router behaviour into a contract. Both are over-claims.
+  Per rf2-i3dvj the call-site macros now emit compile-time coord LITERALS and
+  push dynamic scope inside the callee's own body, so nothing yield-bearing
+  reaches the caller. `no-yield-in-one-stack-shares-one-batch` below is the
+  standing regression: it asserts the ordering causally, and it FAILS if a
+  pre-call yield is ever reintroduced into the expansion.
 
   ## Why the awaits here are ordering guarantees, not races
 
@@ -180,22 +167,8 @@
   ;; still pending. Nothing about the router closes a render batch — only the
   ;; host checkpoint does.
   ;;
-  ;; MEASURED SCOPE NOTE (rf2-vxgfnd.166; mechanism traced by rf2-kahkr). The
-  ;; ruled contract says drains finishing before one checkpoint MAY share a
-  ;; batch; it does not promise they always will. On this mounted path they do
-  ;; not always: a SECOND `dispatch-sync!` in the same stack was measured to
-  ;; advance the first drain's pending mark before making its own. So this
-  ;; fixture asserts the guarantee (a finished drain leaves the window open)
-  ;; rather than the permission. The headless sibling pins an actual shared
-  ;; batch, where the scheduler is observed without React in the loop.
-  ;;
-  ;; That advance is now traced: it is the ordinary armed `schedule-flush!`
-  ;; microtask, landing mid-call because `dispatch-sync!` yields to the host
-  ;; microtask queue. See the namespace docstring for the instrumentation, the
-  ;; control microtask that identifies it, and why nothing asserts sharing (or
-  ;; non-sharing) across two `dispatch-sync!` calls pending a router ruling.
-  ;;
-  ;; This test itself performs exactly ONE drain, so it is unaffected either way.
+  ;; This test performs exactly ONE drain. Sharing across TWO same-stack drains
+  ;; is pinned separately by `no-yield-in-one-stack-shares-one-batch` below.
   (if-not (browser?)
     (is true ":node — no DOM; the :browser-test runner exercises the DOM body")
     (async
@@ -231,6 +204,79 @@
                             "exactly one REAL React root commit followed it")
                         (is (= "1" (.-textContent (.querySelector c ".leaf")))
                             "…and the DOM shows the write"))
+                      (react-dom/flushSync #(ui/unmount! root))
+                      (done)))))))))
+
+(deftest no-yield-in-one-stack-shares-one-batch
+  ;; rf2-i3dvj — the standing regression against a hidden pre-call yield, and
+  ;; the restoration of guarantee 3's example on the MOUNTED path.
+  ;;
+  ;; The whole point is WHERE this runs: inside a `cljs.test/async` body, which
+  ;; is a CLJS async context. That is the exact setting in which a call-site
+  ;; macro expansion carrying a runtime `cond->` (or a `binding`) gets lowered
+  ;; by the compiler to `await (async function(){...})()` — a real microtask
+  ;; yield spliced in immediately BEFORE the instrumented call. rf2-kahkr
+  ;; measured that yield and mis-attributed it to `dispatch-sync!` itself.
+  ;;
+  ;; The assertion is CAUSAL, not incidental. A control microtask is queued
+  ;; BETWEEN the two `dispatch-sync` calls. A microtask cannot run while a
+  ;; JavaScript stack is live, so:
+  ;;
+  ;;   - expansion is evaluation-order-transparent → the control runs AFTER
+  ;;     both calls have returned; the log reads [1 2 control];
+  ;;   - a pre-call yield is reintroduced → the second call's `await` reaches
+  ;;     the microtask checkpoint, the control runs BETWEEN the calls, the log
+  ;;     reads [1 control 2], and this test REDS.
+  ;;
+  ;; Nothing here asserts that an exception was thrown: a compiler-inserted
+  ;; yield does not throw on CLJS, so only observable ORDERING (plus the
+  ;; revision and real-commit counts) can discriminate it.
+  (if-not (browser?)
+    (is true ":node — no DOM; the :browser-test runner exercises the DOM body")
+    (async
+     done
+     (let [c    (container)
+           root (mount-probe! c)]
+       (let [cell         (leaf-cell)
+             base-rev     (reactive/revision cell)
+             base-commits (:root-commits @evidence)
+             log          (atom [])]
+         ;; DRAIN 1.
+         (rf/dispatch-sync [:rbhcd/inc] {:frame frame-kw})
+         (swap! log conj :returned-from-call-1)
+         ;; THE CONTROL — queued before call 2, on the same live stack.
+         (js/queueMicrotask (fn [] (swap! log conj :control-microtask)))
+         ;; DRAIN 2 — same JavaScript stack, no yield between them.
+         (rf/dispatch-sync [:rbhcd/inc] {:frame frame-kw})
+         (swap! log conj :returned-from-call-2)
+
+         (testing "two back-to-back dispatch-sync calls are ONE stack"
+           (is (= [:returned-from-call-1 :returned-from-call-2] @log)
+               "the control microtask queued BEFORE the second dispatch-sync
+                had NOT run by the time that call returned — neither call
+                yielded to the host (rf2-i3dvj)")
+           (is (= base-rev (reactive/revision cell))
+               "no revision advanced during either drain — the window is still
+                open, so nothing flushed mid-stack")
+           (is (= base-commits (:root-commits @evidence))
+               "and React committed nothing during either drain"))
+
+         (-> (await-microtask)
+             (.then (fn [_]
+                      (settle-react!)
+                      (testing "the two same-stack drains SHARED one batch"
+                        (is (= [:returned-from-call-1 :returned-from-call-2
+                                :control-microtask]
+                               @log)
+                            "the control ran at the checkpoint, strictly after
+                             both calls returned")
+                        (is (= (inc base-rev) (reactive/revision cell))
+                            "ONE revision advance for TWO drains (guarantee 3's
+                             example, on the real mounted host)")
+                        (is (= (inc base-commits) (:root-commits @evidence))
+                            "ONE real React root commit for TWO drains")
+                        (is (= "2" (.-textContent (.querySelector c ".leaf")))
+                            "…and that single render shows BOTH writes"))
                       (react-dom/flushSync #(ui/unmount! root))
                       (done)))))))))
 

--- a/implementation/ui/test/re_frame/ui/render_batch_host_checkpoint_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/render_batch_host_checkpoint_dom_cljs_test.cljs
@@ -26,7 +26,8 @@
   This namespace previously recorded that a second `dispatch-sync!` in the
   same stack advanced the first drain's pending mark before making its own —
   revision 0 -> 1 -> 2, with a control `js/queueMicrotask` running between a
-  call's begin and end markers — and concluded that `dispatch-sync!` yields.
+  call's begin and end markers, i.e. seemingly MID-CALL — and concluded that
+  `dispatch-sync!` yields.
 
   The measurement was real. The ATTRIBUTION was wrong, and it is now reversed.
   `dispatch-sync!` never yielded. The yield was INSTRUMENTATION: the DEBUG


### PR DESCRIPTION
Implements the ruled REVERSAL on **rf2-i3dvj** (Option A, ratified in full).

PR #6432 (rf2-kahkr) retracted a shipped contract guarantee on a measurement that was **real but misattributed**. `dispatch-sync!` never yielded. The measured mid-call flush was the **DEBUG call-site stamp**: `coords-form` emitted a *runtime* `cond->`, which the CLJS compiler lowers to `await (async function(){...})()` when the call site sits inside a CLJS async context. The yield was instrumentation, not the router.

**Restored contract:** `dispatch-sync!` and the synchronously-observable call-site family (`dispatch`, `dispatch-sync`, `subscribe`) are same-stack synchronous in **every** build, dev included.

## Pinned principle (standing — binds all future macro emission)

> Framework instrumentation must be **evaluation-order-transparent**. A call-site macro expansion may splice **only yield-free expression forms** (compile-time literals and plain calls) into the caller's context; any dynamic-scope establishment happens **inside the callee's own function body**, where it can never compile as an awaited async IIFE.

It lives at the macro seam it governs — `source-coords/coords-form`'s docstring, cross-referenced from `build-stamped-2`, `build-subscribe-form`, `core/stamp-opts` and `subs/subscribe`.

## The changes

1. **`source_coords.cljc`** — `coords-form` / `prod-coords-form` emit compile-time **literal** coord maps. The `cond->` now runs in Clojure at expansion time; absent keys are simply omitted from the literal. Harmonises with the machines path's existing `form-coords` literal emission. Dev coordinates, the rf2-wvsxg `:file` absolutisation, and `:advanced` + `goog.DEBUG=false` elision are all preserved; the literal stays inside the outermost debug gate.
2. **`core_call_site_macros.cljc` + `subs.cljc`** — `subscribe`'s `trace/with-call-site` scope push moves out of the caller-side expansion (a `binding` there is an independent awaited-IIFE yield source of the same class) and into the callee body, through the **shared** `build-stamped-2` opts seam the dispatch pair already uses. `subs/subscribe` establishes the scope from `:rf.trace/call-site` in its own body, mirroring `router/dispatch!`.
3. **`core.cljc`** — `stamp-opts`, a yield-free tolerant merge. An inline `(if (map? opts) …)` would need a `let`, which is exactly what lowers to an async IIFE; a function call cannot. Tolerant because `subscribe` has a pinned contract that a malformed non-map opts falls to the ambient path and fails loud with `:rf.error/no-frame-context` — a raw `ClassCastException` would be a regression. Deliberately generic, so no reserved keyword literal enters a production-reachable body.
4. **`ui/reactive.cljc`** — guarantee 3's unconditional back-to-back example restored; the retraction, the false *"dispatch-sync! … yields"* attribution and the *"deliberately left open"* router marker deleted.
5. **DOM fixture** — same false attribution corrected, plus the standing regression `no-yield-in-one-stack-shares-one-batch`.

Guarantee 3 remains a **permission**. The example is unconditional because its own phrase *"in one JavaScript stack"* supplies the condition — a stack that has not yielded cannot have reached a host checkpoint — making it a **theorem** of guarantees 1, 3 and 4, not a promotion of the MAY-share permission into a general rule. The docstring says so explicitly.

**No** router, scheduler, drain-finalization seam or new async abstraction was added. `spec/006-ReactiveSubstrate.md` and `docs/core/glossary.md` were verified as residue-only: both still state the unconditional example, and **neither was edited**.

## Evidence

**Generated dev JS** (`out/browser-test/…/render_batch_host_checkpoint_dom_cljs_test.js`) — the two back-to-back calls compile to straight-line statements with **no `await`** and no async IIFE:

```js
var G__43432_43738 = re_frame.core.stamp_opts(
  {:frame frame_kw},
  {"rf.trace/call-site": {ns: …, file: …, line: 246, column: 10}});   // flat literal
re_frame.core.dispatch_sync_impl.cljs$core$IFn$_invoke$arity$2(G__43431_43737, G__43432_43738);
cljs.core.swap_BANG_(log, conj, :returned-from-call-1);
queueMicrotask(function(){ return swap_BANG_(log, conj, :control-microtask); });
// …second call, identical shape — no await between them
```

The only `(async function (){` occurrences are the three `cljs.test/async` test bodies themselves; every `await` match is the identifier `await_microtask`. Call-site coordinates are still captured and usable.

**Causal red-before** — reverting only `coords-form` to the runtime `cond->` reds the new fixture at four assertions, reproducing #6432's exact symptom:

```
actual: (not (= [:returned-from-call-1 :returned-from-call-2 :control-microtask]
                [:returned-from-call-1 :control-microtask :returned-from-call-2]))
actual: (not (= 1 2))   ;; ONE revision advance for TWO drains → became two (the 0 -> 1 -> 2 sequence)
actual: (not (= 2 3))   ;; ONE real React root commit for TWO drains → became two
```

The probe was then reverted; the tree is byte-identical to the green run.

## Note on the machine-view teardown fixture

Removing the compiler-inserted awaits shifted microtask scheduling across the shared `:browser-test` page and exposed a latent under-specification: `machine_view_unmount_teardown_mounted_dom_cljs_test` counted `:rf.view/unmounted` markers from a **process-global** trace listener, so it was catching an unrelated suite's deferred disposals (`:rf.22ds-7/probe`) that a non-async sibling test never awaits. It passed on scheduling luck. The count is now scoped to the view under test — which is what the very next assertion in that fixture already checked.

## Quality gates

All foreground, unpiped, run to completion.

| Gate | Result |
| --- | --- |
| `implementation/core` `clojure -M:test` | **PASS** — 2086 tests / 10184 assertions, 0 failures, 0 errors |
| `npm run test:cljs` | **PASS** — 10245 tests / 50593 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **PASS** — 482 tests / 2707 assertions, 0 failures, 0 errors |
| `npm run test:elision` | **PASS** — production 60/60 sentinels absent; control 60/60 present |
| `npm run test:browser-prod-elision` | **PASS** — 108 tests / 429 assertions; ui mounted production elision PASS |
| `implementation/ui` `clojure -M:test` | **PASS** — 982 tests / 18738 assertions, 0 failures, 0 errors |

## Out of scope (per the ruling)

Registration-macro emission in async contexts. `with-coords-form` still splices a `binding` for `*pending-coords*` into the caller's context, so a `reg-*` call inside an async body carries the same lowering — but registration macros have no synchronicity contract, and the ruling parks this. Not observed to bite; file separately if it does.
