### PR TITLE
fix(ci): fire the synthesis-docs job for every guarded path; correct the EP-0030 presence owner (rf2-rf7gu, rf2-yyzle)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -174,8 +174,17 @@ else
     # material gets a narrow gate without classifying unrelated ai/ scratch
     # or pulling the guide into MkDocs before S6. The checker and focused JVM
     # fixture arm their own job so a gate edit cannot avoid its proof.
+    #
+    # rf2-rf7gu — these arms MUST mirror check_doc_slugs.py's --synthesis-only
+    # inventory (SYNTHESIS_ROOTS + SYNTHESIS_FILES). rf2-d9v3n (#6127) widened
+    # that guard to prep/** and 11-adoption-workstreams.md without widening the
+    # trigger, so a PR touching only those paths never fired the job that runs
+    # the guard. Keep the two lists in lockstep; _changed-surfaces.test.cjs pins
+    # every guarded path. Note the roots are not a directory sweep — the 01-10
+    # narrative chapters and README sit beside the named files and stay
+    # deliberately unclassified.
     case "$file" in
-      ai/findings/new-substrate-synthesis/guide/*|ai/findings/new-substrate-synthesis/drafts/*|scripts/check_doc_slugs.py|scripts/_test_fixtures/check_doc_slugs/*|implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj)
+      ai/findings/new-substrate-synthesis/guide/*|ai/findings/new-substrate-synthesis/drafts/*|ai/findings/new-substrate-synthesis/prep/*|ai/findings/new-substrate-synthesis/11-adoption-workstreams.md|scripts/check_doc_slugs.py|scripts/_test_fixtures/check_doc_slugs/*|implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj)
         synthesis_docs=true
         ;;
     esac

--- a/docs/EP/EP-0030-the-compiled-view-substrate-program.md
+++ b/docs/EP/EP-0030-the-compiled-view-substrate-program.md
@@ -343,7 +343,11 @@ posture recorded in their spec homes.
 
 - **Sibling EPs (authored with this one; each a narrow decision surface):**
   [EP-0031](EP-0031-re-frame-ui-programming-model.md) — programming model
-  (`defview`, templates, the handler law, presence, interop);
+  (`defview`, templates, the handler law, interop); **presence is not
+  EP-0031's** — its normative contract is
+  [`spec/004-Views.md` §Presence](../../spec/004-Views.md#presence--declarative-enterexit),
+  and the companion ruling (`ui/presence` wrapper, no reserved nodes, mandatory
+  timeout safety bound) is recorded above in this EP;
   [EP-0032](EP-0032-re-frame-ui-reactivity-and-ownership.md) — reactivity and
   ownership (observation targets, ViewCell, commit protocol, frames/preflight
   ENSURE, HMR); [EP-0033](EP-0033-re-frame-ui-view-evidence.md) — view evidence

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -912,6 +912,56 @@ test('tracked synthesis guide and active drafts arm their focused docs gate only
   assert.equal(classify('ai/findings/unrelated-scratch.md').synthesis_docs, 'false');
 });
 
+// rf2-rf7gu — the classifier's synthesis_docs arms MUST cover every path
+// check_doc_slugs.py guards under --synthesis-only (its SYNTHESIS_ROOTS +
+// SYNTHESIS_FILES). rf2-d9v3n (#6127) widened that guard to prep/** and
+// 11-adoption-workstreams.md but left the trigger behind, so a PR touching
+// only those paths never fired the job that runs the guard — the newly-covered
+// inventory went unchecked for exactly the PRs it was expanded to protect.
+// These arms pin the two ends together; a future SYNTHESIS_ROOTS widening that
+// forgets the trigger fails here instead of silently skipping CI.
+test('every check_doc_slugs --synthesis-only guarded path fires the synthesis-docs job (rf2-rf7gu)', () => {
+  // SYNTHESIS_ROOTS — all three directory roots.
+  assert.equal(
+    classify('ai/findings/new-substrate-synthesis/guide/03-state.md').synthesis_docs,
+    'true',
+  );
+  assert.equal(
+    classify('ai/findings/new-substrate-synthesis/drafts/spec-004-rewrite-draft.md').synthesis_docs,
+    'true',
+  );
+  assert.equal(
+    classify('ai/findings/new-substrate-synthesis/prep/w3-docs-disposition.md').synthesis_docs,
+    'true',
+  );
+  assert.equal(
+    classify('ai/findings/new-substrate-synthesis/prep/w9-ci-matrix-disposition.md').synthesis_docs,
+    'true',
+  );
+
+  // SYNTHESIS_FILES — the two named top-level operational authorities.
+  assert.equal(
+    classify('ai/findings/new-substrate-synthesis/11-adoption-workstreams.md').synthesis_docs,
+    'true',
+  );
+  assert.equal(
+    classify('ai/findings/new-substrate-synthesis/12-implementation-plan.md').synthesis_docs,
+    'true',
+  );
+
+  // The roots are NOT a whole-directory sweep: the 01-10 narrative chapters and
+  // README sit beside the named files and stay unguarded, so they must stay
+  // unclassified. This keeps the arms above honest rather than vacuously true.
+  assert.equal(
+    classify('ai/findings/new-substrate-synthesis/08-delivery.md').synthesis_docs,
+    'false',
+  );
+  assert.equal(
+    classify('ai/findings/new-substrate-synthesis/README.md').synthesis_docs,
+    'false',
+  );
+});
+
 test('synthesis-docs job runs the opt-in link scan and focused guide truth fixture (rf2-vxgfnd.135)', () => {
   const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'synthesis-docs');
   assert.match(block, /if: needs\.detect_changed_surfaces\.outputs\.synthesis_docs == 'true'/);


### PR DESCRIPTION
Two independent, small corrections. CI-wiring plus one factual doc pointer.

## 1. `rf2-rf7gu` — the synthesis-docs trigger missed paths its own guard covers

`rf2-d9v3n` (#6127) widened `check_doc_slugs.py`'s `--synthesis-only` inventory (`SYNTHESIS_ROOTS` + `SYNTHESIS_FILES`) to cover `prep/**` and `11-adoption-workstreams.md`, but left `report-changed-surfaces.sh`'s `synthesis_docs` arms behind. A PR touching **only** those paths never fired the job that runs the guard — so the newly-covered inventory went unchecked for exactly the PRs it was expanded to protect.

**Guard inventory vs. classifier coverage (5 entries, verified against the source):**

| Guarded path | Before | After |
|---|---|---|
| `guide/**` | fires | fires |
| `drafts/**` | fires | fires |
| `prep/**` | **never fired** | fires |
| `11-adoption-workstreams.md` | **never fired** | fires |
| `12-implementation-plan.md` | fires (own case, `rf2-vs60jg`) | unchanged |

**Proven red before green.** The new arms were run against the *unfixed* script first and failed as expected (`prep/w3-docs-disposition.md` → `'false' !== 'true'`, exit 1). Only then was the classifier fixed. Harness goes **172 → 173 passed**. The negative arms (`08-delivery.md`, `README.md`) keep the roots honest — this is a named inventory, not a directory sweep.

### ⚠️ Scope note: `.github/workflows/test.yml` is NOT modified

The brief anticipated a hot-zone edit here and the operator cleared one, **but no change turned out to be needed**, so none was made. Reviewers should know the reasoning rather than assume an oversight:

- the `pull_request` trigger is **deliberately unfiltered** (the `rf2-dtvmb` phantom-pending-aggregator trap), so there is no PR-side path filter to align; and
- the only path filter is the **push-to-main** `paths-ignore`, which does not list `ai/**` — the guarded paths already reach the classifier.

The diff touches `.github/scripts/report-changed-surfaces.sh` (not hot-zone) and no workflow file. Verified at edit time that the only open PR (#6454) touches no `.github/**` path.

## 2. `rf2-yyzle` — EP-0030 credited presence to an EP that never covered it

EP-0030's sibling-EP mapping listed presence among EP-0031's surfaces. **Premise verified before editing:** EP-0031 carries no presence content in *any* region — Abstract, Motivation, Scope, §1–§6, Guide impact, Rationale, Backwards Compatibility, Resolved Decisions, Open Issues, References. Its only `presen` matches are the unrelated `:value`/`:checked` **co-presence** predicate, and its Scope paragraph enumerates both what it owns and what it disclaims — presence is in neither list.

The contract actually lives in **`spec/004-Views.md` §Presence**, with the companion ruling (`ui/presence` wrapper, no reserved nodes, mandatory timeout safety bound) recorded in **EP-0030's own** companion-rulings paragraph. The mapping sentence now points there.

Deliberately **no** presence section or dated addendum in EP-0031 — it never covered presence, and manufacturing that ownership would be the wrong repair. **No EP status flipped.** This is a pointer correction, not a change of settled meaning: Tier 1 editorial under `rf2-r7ahi`'s "freeze meaning, not bytes".

> Note: the mapping sentence was at **line 345**, not the ~86 recorded on the bead — the EP has drifted substantially since filing.

## Quality gates

All run in the foreground to completion, unpiped, exit codes captured by redirect.

| Gate | Result |
|---|---|
| `node implementation/scripts/_changed-surfaces.test.cjs` | **173 passed**, exit 0 (was 172; re-run green post-rebase) |
| ↳ same, against the **unfixed** script | **1 failed**, exit 1 — the intended red-before |
| `npm run test:script-policy` | pass, exit 0 |
| `python -m mkdocs build --strict` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `python scripts/check_doc_slugs.py --synthesis-only` | exit 0 — 41 files, no broken links |
| `python scripts/check_ep_status_sync.py` | exit 0 |
| `python scripts/check_adapter_disposition.py` | exit 0 — 10 authorities intact (EP-0030 is rostered) |
| `sh scripts/check-no-hardcoded-paths.sh` | exit 0 |
| `clojure -M:test -n re-frame.ui.guide-truth-jvm-test` | **19 tests / 663 assertions**, 0 failures (pins EP-0030 by exact path) |
| `cd implementation/ui && clojure -M:test` | **978 tests / 18717 assertions**, 0 failures |
| `bash -n` on the edited script | exit 0 |
| `shellcheck` | **not installed on this host** — CI runs it |

Both doc gates are reported separately on purpose: `mkdocs --strict` has been observed exiting 0 while `check_doc_slugs.py` exits 1 on the same tree.

## Follow-up found, deliberately not actioned

`scripts/check_adapter_disposition.py` also runs in the `synthesis-docs` job but has **zero** classifier coverage, and its 10-file `ACTIVE_AUTHORITIES` roster reaches well outside the synthesis tree (`docs/EP/EP-0030…`, `spec/004-Views.md`, `implementation/README.md`, `skills/re-frame2-implementor/…`). Editing any of them — including this PR's own EP-0030 change — does not by itself fire the guard that pins it. That is the same bug class as `rf2-rf7gu` but a **different guard's inventory**, and closing it means classifying `docs/EP/**` and `spec/**` as `synthesis_docs` — a much wider widening than this bead authorises. Worth its own bead and an operator call. (This PR is unaffected: editing `report-changed-surfaces.sh` hits `mark_all`, so every job fires here.)
