### PR TITLE
docs(adapter): correct the Reagent resource-lease frame precedence (rf2-5cmf7)

### DIFF
--- a/docs/api/re-frame.adapter.reagent.md
+++ b/docs/api/re-frame.adapter.reagent.md
@@ -72,7 +72,7 @@ The migration (a four-line swap) is in [Use UIx, Helix, or reagent-slim](../core
 
   Behaviour:
   - On mount, dispatches `:rf.resource/ensure` with a per-instance `[:lease token]` owner; on unmount, dispatches `:rf.resource/release-owner` for that owner into the same frame.
-  - Frame resolution tries, in order: the explicit `:frame` opt, the surrounding React context installed by a `frame-provider` (SCOPE) or a `frame-root` (ENSURE), then the dynamic frame binding. If none is in scope, it raises `:rf.error/no-frame-context`.
+  - Frame resolution happens at render time and tries, in order: the explicit `:frame` opt, the dynamic `with-frame` binding, then the surrounding React context installed by a `frame-provider` (SCOPE) or a `frame-root` (ENSURE). If none is in scope, it raises `:rf.error/no-frame-context`. This matches the UIx / Helix `use-resource-lease` chain — a `with-frame` binding nested inside a provider or root wins over that boundary.
   - The lease token is minted once per mounted instance, so a hot-reload re-mount settles to exactly one held lease.
   - Under `render-to-string` (SSR) lifecycle methods do not run, so the acquire/release is a no-op.
 - **Example**:

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -87,7 +87,10 @@
     :cause  — recorded on the ensure (observability; free-form data value).
               Defaults to `[:lease :mount]`.
     :frame  — pin the lease to an explicit frame id, bypassing ambient
-              frame-provider / dynamic-var resolution.
+              resolution — which, when `:frame` is omitted, reads the
+              dynamic `with-frame` binding FIRST, then the surrounding
+              `frame-provider` (SCOPE) / `frame-root` (ENSURE) React
+              context, else raises `:rf.error/no-frame-context`.
 
   The component is one stable Form-3 class, not a Form-2 that creates a new
   class on every render. It resolves the target frame during render, then uses

--- a/implementation/core/test/re_frame/scope_ensure_authority_test.clj
+++ b/implementation/core/test/re_frame/scope_ensure_authority_test.clj
@@ -138,12 +138,25 @@
     :required  [[#"`frame-provider`\s*\(SCOPE\) / `frame-root`\s*\(ENSURE\)"
                  "the SCOPE/ENSURE boundary pair"]]}
 
+   ;; Two DISTINCT contracts on one line, and #6438 fixed the first while
+   ;; breaking the second (rf2-5cmf7): it correctly renamed the boundary to
+   ;; the SCOPE/ENSURE pair — satisfying the row as it then stood — but
+   ;; REVERSED the two ambient tiers, claiming React context outranks the
+   ;; dynamic binding. The executable resolver
+   ;; (`resource-lease/resolve-lease-frame` -> `frame/require-current-frame!`)
+   ;; reads dynamic-var FIRST, React-context SECOND. So this row pins the
+   ;; ORDER as well as the NAMING; a row that only checked naming went green
+   ;; on a page that had become wrong.
    {:file      "docs/api/re-frame.adapter.reagent.md"
     :why       "with-resource-lease's frame-resolution order"
     :forbidden [[#"the surrounding `frame-provider` context, then the dynamic"
-                 "a provider-only resolution order"]]
+                 "a provider-only resolution order"]
+                [#"\(ENSURE\),? then the dynamic"
+                 "the REVERSED ambient tiers — React context ranked above the dynamic binding"]]
     :required  [[#"`frame-provider`\s*\(SCOPE\) or a `frame-root`\s*\(ENSURE\)"
-                 "the SCOPE/ENSURE boundary pair"]]}
+                 "the SCOPE/ENSURE boundary pair"]
+                [#"the dynamic `with-frame` binding, then the surrounding"
+                 "the executable tier order — dynamic binding BEFORE React context"]]}
 
    {:file      "docs/api/re-frame.adapter.uix.md"
     :why       "use-subscribe's standard chain"


### PR DESCRIPTION
## What

`#6438` edited the public `re-frame.adapter.reagent` `with-resource-lease` API page to state that an omitted `:frame` resolves as **explicit -> surrounding `frame-provider`/`frame-root` React context -> dynamic binding**. That reversed the two ambient tiers.

## Verified against the shipped code

The shared executable resolver (`re-frame.adapter.resource-lease/resolve-lease-frame`) is:

```
(or explicit-frame
    (frame/require-current-frame! reader {:where where}))
```

and `require-current-frame!` delegates to `resolve-current-frame`, whose two scope tiers are, in order:

1. `*current-frame*` — the dynamic `with-frame` binding (**FIRST**)
2. the closest enclosing frame boundary — `frame-provider` (SCOPE) or `frame-root` (ENSURE) — via React context (**SECOND**)

So the actual chain is **explicit `:frame` -> dynamic `with-frame` binding -> `frame-provider`/`frame-root` React context -> `:rf.error/no-frame-context`**. The UIx and Helix API pages already document this order.

**The code is correct; only the docs were wrong** — a narrow public-contract defect, not a resolver-design problem. A programmer following the old Reagent page would have expected the outer React frame when a `with-frame` binding was nested inside a provider/root, while the lease actually targets the dynamically-bound frame.

## Changes (prose + guard only; runtime behaviour unchanged)

- `docs/api/re-frame.adapter.reagent.md` — the `with-resource-lease` frame-resolution bullet now states the executable order and notes it matches the UIx / Helix chain.
- `implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs` — the adapter docstring's `:frame` note now spells the ambient order (dynamic first, then provider/root) instead of leaving it ordering-ambiguous.
- `implementation/core/test/re_frame/scope_ensure_authority_test.clj` — strengthened the existing `rf2-kk2uf` SCOPE/ENSURE authority-guard row for this page: it now pins the tier ORDER as well as the boundary naming. `#6438` satisfied the old naming-only row while breaking the order, so the row is now `:forbidden` the reversed-tier phrasing and `:required` the dynamic-before-context phrasing. Verified non-vacuous: injecting the reversal turns the guard red on both the forbidden pattern and the missing truthful anchor.

Used the current `frame-provider` (SCOPE) / `frame-root` (ENSURE) vocabulary; did not resurrect any retired terminology. No new resolver, doc framework, or terminology sweep.

## Quality gates

All run in the worktree, foreground, exit codes captured by redirect:

- `python -m mkdocs build --strict` -> exit 0
- `python scripts/check_doc_slugs.py` -> exit 0 (run separately — strict alone is not sufficient)
- `clojure -M -m re-frame.api-manifest.gen --check` -> exit 0 (`spec/api-manifest.edn` in sync, 520 public vars)
- `clojure -M -m re-frame.api-manifest.doc-api-check` -> exit 0 (run separately so `gen --check` cannot mask it; page+member coverage in sync)
- `re-frame.scope-ensure-authority-test` (JVM) -> 3 tests, 48 assertions, 0 failures; proven red on an injected reversal, then restored green
- `shadow-cljs compile node-test` -> 0 warnings; `node out/node-test.js` -> 10259 tests, 50642 assertions, 0 failures (contains the reagent adapter suite)
- `npm run test:adapter-smokes` -> 3 adapter-smoke specs, 0 failures

`implementation/ui` suite not run: no guide-truth pin (`guide_truth_jvm_test.clj`) names either file I touched, so it does not cover this change.