### PR TITLE
feat(ui): wire hydrate-root through the ssr/discover-root-manifest late-bind seam (rf2-3omxp)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -722,6 +722,12 @@
     :design-bead "rf2-fcj33"
     :description "Clear the SSR side-channel atoms (pending-error-traces, request-slots, response-slots) for a destroyed frame, per Spec 011 §Per-request frame teardown contract. The response-slots entry joined under rf2-jbcmt when the `:rf/response` accumulator moved off `app-db` to plug a hydration-payload leak + per-fx full-app-db swap. Also invokes `:ssr/head-on-frame-destroyed` (if registered) so the head ns can release per-frame snapshot bookkeeping (rf2-4dra9)."}
 
+   ;; ---- re-frame.ssr.manifest (Root Manifest v1 discovery) -----------------
+   {:key         :ssr/discover-root-manifest
+    :producer-ns 're-frame.ssr.manifest
+    :design-bead "rf2-3omxp"
+    :description "CLJS-only Root Manifest discovery `(fn [container]) -> validated Root Manifest | nil`, published by `re-frame.ssr.manifest` at ns-load and consumed by the compiled `re-frame.ui.client/hydrate-root*`. Discovery is POSITIONAL — the manifest is the container's immediately following element sibling and nothing else is searched (Spec 011 §Discovery); identity is then read from the CONTENT (`:root-id`, `:identifier-prefix`), never from the element. THE HOOK DOES EXACTLY WHAT ITS NAME SAYS: it resolves and validates one manifest. It exposes NO payload install and no other ssr operation — `re-frame.ssr/hydrate!` remains the explicit SSR state-boot call (payload read → `:rf/hydrate` → verify) and `ui/hydrate-root` is the DOM-adoption call, so the two-call boot model stays the public contract. A corrupt wire still throws `:rf.error/root-manifest-invalid` out of `validate!`; `nil` means \"no manifest here\" and the CALLER decides — `hydrate-root` fails loud `{:missing :manifest}`, a client-only mount never asks. Unbound when the ssr artefact is absent: `hydrate-root` resolves through `late-bind/require-fn!` and fails loud with `:rf.error/ssr-artefact-missing` naming `day8/re-frame2-ssr`. This is the third instance of the `ui -> core registry <- optional-artefact` shape ui already exercises against routing (`:routing/link-model` / `:routing/activate-link!`) — a direct `ui -> ssr` require is forbidden by the Independence rule AND would fail to compile every non-SSR ui app."}
+
    ;; ---- re-frame.ssr.head (head/meta contract) -----------------------------
    {:key         :ssr/reg-head
     :producer-ns 're-frame.ssr.head

--- a/implementation/ssr/src/re_frame/ssr/manifest.cljc
+++ b/implementation/ssr/src/re_frame/ssr/manifest.cljc
@@ -74,6 +74,10 @@
             [re-frame.error :as error]
             [re-frame.ssr.constants :as constants]
             [re-frame.ssr.html-helpers :as html]
+            ;; CLJS-only: the `:ssr/discover-root-manifest` publication at the
+            ;; bottom of this namespace is the DOM-side discovery seam, so the
+            ;; registry is only reached on the host that has a DOM.
+            #?(:cljs [re-frame.late-bind :as late-bind])
             #?(:clj  [clojure.edn :as edn]
                :cljs [cljs.reader :as reader])))
 
@@ -583,3 +587,34 @@
      (let [el (some-> container .-nextElementSibling)]
        (when (manifest-script? el)
          (read-manifest 'rf.ssr/discover-root-manifest (.-textContent el))))))
+
+;; ---------------------------------------------------------------------------
+;; The `ui -> core late-bind <- ssr` discovery seam (rf2-3omxp)
+;; ---------------------------------------------------------------------------
+;;
+;; `re-frame.ui/hydrate-root` must resolve a container's Root Manifest, but the
+;; discovery code lives HERE, in the optional `day8/re-frame2-ssr` artefact. A
+;; direct `re-frame.ui -> re-frame.ssr.manifest` require is ruled out twice
+;; over: the Independence rule reserves the single sanctioned direct
+;; cross-artefact require for `core -> ui` (Conventions §Internal cross-artefact
+;; seams), and this namespace is absent from a ui-only app's classpath — a
+;; static require would fail to COMPILE every non-SSR ui app and drag ssr into
+;; every ui bundle.
+;;
+;; So the seam is late-bind, the third instance of the shape ui already
+;; exercises against routing (`:routing/link-model` / `:routing/activate-link!`).
+;; The hook does EXACTLY what its name says: hand back the validated adjacent
+;; Root Manifest, or nil when there is none. It exposes no payload install and
+;; no other ssr operation — the two-call boot model (`ssr/hydrate!` for state,
+;; then `ui/hydrate-root` for DOM adoption) is unchanged by it.
+;;
+;; Validation failures still throw `:rf.error/root-manifest-invalid` out of
+;; `validate!` (a corrupt manifest is a wire fault, not an absence); nil means
+;; "no manifest here" and the CALLER decides — `ui/hydrate-root` fails loud with
+;; `{:missing :manifest}`, a client-only mount never asks.
+;;
+;; Per Spec 011 §Discovery and the drift-parity rule (Conventions §Late-bind
+;; hook key grammar rule 3, enforced by `late_bind_drift_test.clj`): this
+;; publication, the `re-frame.late-bind.directory` row, and the
+;; `re-frame.ui.client/hydrate-root*` consumer land as ONE change.
+#?(:cljs (late-bind/set-fn! :ssr/discover-root-manifest discover))

--- a/implementation/ssr/test/re_frame/ssr/hydrate_root_seam_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/hydrate_root_seam_dom_cljs_test.cljs
@@ -1,0 +1,317 @@
+(ns re-frame.ssr.hydrate-root-seam-dom-cljs-test
+  "Real-DOM proof of the `:ssr/discover-root-manifest` late-bind seam that
+  connects `re-frame.ui/hydrate-root` to the optional SSR artefact (rf2-3omxp).
+
+  ## Why this test lives in the ssr tree
+
+  The seam is cross-artefact by necessity. `ui/hydrate-root` must resolve a
+  container's Root Manifest, but the discovery code lives in
+  `re-frame.ssr.manifest` — a different Maven jar. A direct `ui -> ssr` require
+  is forbidden by the Independence rule AND would fail to compile every non-SSR
+  ui app, so the connection is the late-bind hook the manifest namespace
+  publishes at ns-load and `hydrate-root*` resolves through the core registry
+  (`ui -> core late-bind <- ssr`, the shape `ui/route-link` already uses against
+  routing).
+
+  A test proving that seam has to have BOTH artefacts loaded, and the `ssr`
+  test tree is where the repository already puts cross-artefact SSR DOM proofs
+  (`re-frame.ssr.ssr-startup-recipe-dom-cljs-test` requires the Reagent
+  adapter the same way).
+
+  ## What this proves
+
+    1. `hydrate-root-adopts-server-dom-with-server-state-and-prefix` — THE
+       vertical. Plant server markup + an adjacent Root Manifest + an
+       `__rf_payload`, then run the PUBLIC two-call boot in its documented
+       order: `re-frame.ssr/hydrate!` (state) followed by
+       `re-frame.ui/hydrate-root` (DOM adoption). Then assert three observable
+       outcomes:
+
+         (a) the FIRST compiled render saw SERVER STATE — the retained server
+             `<span>` carries the greeting derived from the payload's app-db
+             (`\"seam-server\"`), which exists nowhere in the client's initial
+             db. A boot that mounted before `ssr/hydrate!` installed the
+             payload would render the client default and turn this red;
+         (b) the first compiled render ADOPTED that DOM — the exact `<span>`
+             node object captured before the boot is still `identical?` and
+             still `isConnected` afterwards. A `createRoot` path would mint a
+             new node;
+         (c) the root took the SERVER-AUTHORED identifier prefix — the
+             `(react/use-id)` value the compiled view renders contains the
+             manifest's `:identifier-prefix` (`\"srv7-\"`). The prefix is
+             deliberately a string the client could not have synthesised: the
+             ui default is derived from the root-id, so a `srv7-` substring can
+             only have come from the manifest's content.
+
+    2. `hydrate-root-without-adjacent-manifest-fails-loud` — the artefact IS
+       present, discovery finds nothing adjacent: `:rf.error/root-manifest-invalid`
+       with ex-data `{:missing :manifest}`.
+
+    3. `hydrate-root-without-ssr-artefact-fails-loud` — the hook is UNBOUND
+       (the state a ui-only app is in): `:rf.error/ssr-artefact-missing`,
+       carrying the copy-pasteable `day8/re-frame2-ssr` Maven coordinate and
+       the `re-frame.ssr` require-ns.
+
+  Every assertion reads an OBSERVABLE OUTCOME — a DOM node's identity, its
+  text, the id string actually rendered, the thrown `:rf.error/id` plus its
+  ex-data. None of them merely assert that an exception occurred.
+
+  Browser-only — hydration is a real-DOM operation and the discovery hook
+  reaches `.nextElementSibling`. The `-dom-cljs-test` suffix opts this file
+  into the `:browser-test` build; the `:node-test` build loads it too (it
+  matches `cljs-test$`) and every body gates on `(browser?)`, so a node run is
+  an honest skip rather than a vacuous pass."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.error :as error]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.constants :as constants]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.client :as ui-client]
+            [re-frame.ui.react :as react]))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; ---------------------------------------------------------------------------
+;; The app under the boot — ids unique to this ns so the shared bundle cannot
+;; collide at image assembly.
+;; ---------------------------------------------------------------------------
+
+(def ^:private app-frame ::frame)
+
+(rf/reg-sub ::greeting
+  (fn [db _] (or (:greeting db) "client-default")))
+
+;; The compiled root. `(react/use-id)` is a supported ui hook and its output is
+;; derived from the ROOT's `identifierPrefix` — which, for a hydrating root, is
+;; whatever the manifest said the server used. Rendering it into the DOM is
+;; what makes the server-authored prefix an observable outcome rather than an
+;; invisible React option.
+(defview seam-root []
+  (let [id (react/use-id)]
+    [:div.seam
+     [:span.greeting (ui/sub [::greeting])]
+     [:i.uid id]]))
+
+;; ---------------------------------------------------------------------------
+;; Server-side artefacts, planted by hand (this test proves the CLIENT half of
+;; the seam; the server emitter is item 2's surface and already shipped).
+;; ---------------------------------------------------------------------------
+
+(def ^:private server-root-id ::seam-root)
+
+;; A prefix the client could NEVER synthesise: ui's default prefix is derived
+;; from the root-id, so `srv7-` appearing in the rendered `use-id` output can
+;; only have come from the manifest's content.
+(def ^:private server-prefix "srv7-")
+
+(def ^:private server-manifest
+  {:rf.root/schema-version 1
+   :root-id                server-root-id
+   :identifier-prefix      server-prefix
+   :element-locator        {:id "seam-container"}})
+
+(defn- plant-host!
+  "Append the shape a real server render emits: the root's container, its Root
+  Manifest as the IMMEDIATELY FOLLOWING element sibling (that adjacency is the
+  whole discovery rule), and the page-wide `__rf_payload`. Returns the wrapper
+  host so the test can remove it.
+
+  `:manifest?` false plants the container with NO adjacent manifest — the
+  `{:missing :manifest}` arm."
+  [{:keys [manifest? server-html]}]
+  (let [host (.createElement js/document "div")]
+    (set! (.-innerHTML host)
+          (str "<div id=\"seam-container\">" (or server-html "") "</div>"
+               (when manifest?
+                 (str "<script type=\"application/edn\" "
+                      constants/root-manifest-marker-attribute ">"
+                      (pr-str server-manifest)
+                      "</script>"))
+               "<script id=\"" constants/payload-script-id
+               "\" type=\"application/edn\">"
+               (pr-str {:rf/version 1
+                        :rf/app-db  {:greeting "seam-server"}})
+               "</script>"))
+    (.appendChild (.-body js/document) host)
+    host))
+
+(defn- container [host] (.querySelector host "#seam-container"))
+
+(defn- teardown! [host root-atom]
+  (when-let [root @root-atom]
+    (try (ui/unmount! root) (catch :default _ nil)))
+  (reset! root-atom nil)
+  (when-let [p (.-parentNode host)] (.removeChild p host)))
+
+;; The shared `:browser-test` page leaves `IS_REACT_ACT_ENVIRONMENT` true from
+;; sibling hook suites. Hydration commits on React's own schedule here, so turn
+;; it off for the duration and restore it on teardown (the same treatment
+;; `ssr-startup-recipe-dom-cljs-test` applies).
+(defn- disable-act-env! []
+  (let [prev (.-IS_REACT_ACT_ENVIRONMENT js/globalThis)]
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+    prev))
+
+(defn- restore-act-env! [prev]
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) prev))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter ui/adapter :async? true :ambient-frame nil}))
+
+(defn- thrown-error
+  "Run `f`, returning `{:id :data :msg}` for the ex-info it throws, or nil when
+  it does not throw. Never asserts merely that something was raised — the
+  caller pins the canonical `:rf.error/id` and the ex-data."
+  [f]
+  (try (f) nil
+       (catch :default e
+         {:id   (:rf.error/id (ex-data e))
+          :data (ex-data e)
+          :msg  (ex-message e)})))
+
+;; ---------------------------------------------------------------------------
+;; 1. The vertical
+;; ---------------------------------------------------------------------------
+
+(deftest hydrate-root-adopts-server-dom-with-server-state-and-prefix
+  (when (browser?)
+    (async done
+      (let [act-prev (disable-act-env!)
+            ;; The markup the server render emitted for `seam-root` against the
+            ;; SERVER's app-db. The `use-id` slot is left empty: its value is a
+            ;; React-internal token no hand-authored fixture can predict, and
+            ;; the point under test is which PREFIX the client root was created
+            ;; with, which is read off the rendered output below.
+            host     (plant-host!
+                      {:manifest?   true
+                       :server-html (str "<div class=\"seam\">"
+                                         "<span class=\"greeting\">seam-server</span>"
+                                         "<i class=\"uid\"></i>"
+                                         "</div>")})
+            root-atom (atom nil)]
+        (rf/init! ui/adapter)
+        (rf/make-frame {:id app-frame :platform :client})
+        ;; THE PUBLIC TWO-CALL BOOT, in its documented order.
+        ;; (1) state: read `__rf_payload`, install it, dispatch `:rf/hydrate`.
+        (ssr/hydrate! {:frame app-frame})
+        ;; The captured server node — adoption is proven by OBJECT IDENTITY, so
+        ;; it must be read before any React work touches the container.
+        (let [server-span (.querySelector host "span.greeting")]
+          ;; (2) DOM adoption: identity comes from the manifest, via the hook.
+          (reset! root-atom
+                  (ui/hydrate-root (container host)
+                                   [ui/frame-provider {:frame app-frame}
+                                    [seam-root]]))
+          (js/setTimeout
+           (fn []
+             (try
+               (testing "the first compiled render saw SERVER state"
+                 (is (= "seam-server" (.-textContent (.querySelector host "span.greeting")))
+                     (str "the greeting rendered from the payload's app-db — "
+                          "'client-default' here would mean the compiled render "
+                          "ran before ssr/hydrate! installed the server state"))
+                 (is (not= "client-default"
+                           (.-textContent (.querySelector host "span.greeting")))
+                     "and it is definitively not the client default"))
+
+               (testing "the first compiled render ADOPTED the server DOM"
+                 (is (identical? server-span (.querySelector host "span.greeting"))
+                     (str "the exact server-emitted node object is still the "
+                          "mounted one — a createRoot path would have minted a "
+                          "fresh node"))
+                 (is (true? (.-isConnected server-span))
+                     "and the retained node is still in the document"))
+
+               (testing "the root took the SERVER-AUTHORED identifier prefix"
+                 (let [uid (.-textContent (.querySelector host "i.uid"))]
+                   (is (seq uid)
+                       "the compiled view rendered a use-id value")
+                   (is (str/includes? uid server-prefix)
+                       (str "the rendered use-id " (pr-str uid) " carries the "
+                            "manifest's :identifier-prefix " (pr-str server-prefix)
+                            " — a client-synthesised default is derived from the "
+                            "root-id and could not contain it"))))
+
+               (testing "the root is registered under the MANIFEST's root-id"
+                 (is (= server-root-id (ui-client/root-id-of @root-atom))
+                     "identity came from the manifest content, not from opts"))
+               (finally
+                 (teardown! host root-atom)
+                 (restore-act-env! act-prev)
+                 (done))))
+           0))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. Artefact present, no adjacent manifest
+;; ---------------------------------------------------------------------------
+
+(deftest hydrate-root-without-adjacent-manifest-fails-loud
+  (when (browser?)
+    (let [act-prev (disable-act-env!)
+          host     (plant-host! {:manifest? false})
+          root-atom (atom nil)]
+      (try
+        (rf/init! ui/adapter)
+        (rf/make-frame {:id app-frame :platform :client})
+        (let [{:keys [id data msg]}
+              (thrown-error #(ui/hydrate-root (container host)
+                                              [ui/frame-provider {:frame app-frame}
+                                               [seam-root]]))]
+          (is (= :rf.error/root-manifest-invalid id)
+              "the canonical discriminator — a hydrating root with no manifest")
+          (is (= :manifest (:missing data))
+              "ex-data names WHICH part is missing, per Spec 011 §Discovery")
+          (is (= 're-frame.ui/hydrate-root (:where data))
+              "and the error is stamped at the hydrate site")
+          (is (error/message-has-id-token? msg)
+              "the message carries the greppable [:rf.error/...] token"))
+        (finally
+          (teardown! host root-atom)
+          (restore-act-env! act-prev))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. The SSR artefact is absent entirely
+;; ---------------------------------------------------------------------------
+
+(deftest hydrate-root-without-ssr-artefact-fails-loud
+  (when (browser?)
+    (let [act-prev (disable-act-env!)
+          host     (plant-host! {:manifest? true})
+          root-atom (atom nil)
+          ;; The ssr artefact IS on this page's classpath (this ns requires
+          ;; it), so the absent state is re-established by flipping the hook to
+          ;; nil for the duration — the established mechanism from
+          ;; `re-frame.ssr.late-bind-missing-test`. Restored in `finally`.
+          original (late-bind/get-fn :ssr/discover-root-manifest)]
+      (try
+        (rf/init! ui/adapter)
+        (rf/make-frame {:id app-frame :platform :client})
+        (late-bind/set-fn! :ssr/discover-root-manifest nil)
+        (let [{:keys [id data msg]}
+              (thrown-error #(ui/hydrate-root (container host)
+                                              [ui/frame-provider {:frame app-frame}
+                                               [seam-root]]))]
+          (is (= :rf.error/ssr-artefact-missing id)
+              "a ui-only app calling hydrate-root is told the artefact is absent")
+          (is (= 're-frame.ui/hydrate-root (:where data))
+              "stamped at the hydrate site, not somewhere inside ssr")
+          (is (= :no-recovery (:recovery data))
+              "there is no in-process recovery — the app must add a dependency")
+          (is (str/includes? msg "day8/re-frame2-ssr")
+              (str "the message carries the COPY-PASTEABLE Maven coordinate — "
+                   "saw " (pr-str msg)))
+          (is (str/includes? msg "re-frame.ssr")
+              "and the namespace to require at app boot")
+          (is (error/message-has-id-token? msg)
+              "plus the greppable [:rf.error/ssr-artefact-missing] token"))
+        (finally
+          (late-bind/set-fn! :ssr/discover-root-manifest original)
+          (teardown! host root-atom)
+          (restore-act-env! act-prev))))))

--- a/implementation/ssr/test/re_frame/ssr/hydrate_root_seam_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/hydrate_root_seam_dom_cljs_test.cljs
@@ -87,16 +87,29 @@
 (rf/reg-sub ::greeting
   (fn [db _] (or (:greeting db) "client-default")))
 
-;; The compiled root. `(react/use-id)` is a supported ui hook and its output is
-;; derived from the ROOT's `identifierPrefix` — which, for a hydrating root, is
-;; whatever the manifest said the server used. Rendering it into the DOM is
-;; what makes the server-authored prefix an observable outcome rather than an
-;; invisible React option.
+(rf/reg-sub ::revealed? (fn [db _] (boolean (:revealed? db))))
+
+(rf/reg-event ::reveal-uid (fn [{:keys [db]} _] {:db (assoc db :revealed? true)}))
+
+;; The compiled root. `(react/use-id)` runs at the TOP of the view body, so it
+;; is called on the FIRST render — the hydrating one — and React's `useId` is
+;; stable for a component's position across every later render of the same
+;; fiber. Its value is derived from the ROOT's `identifierPrefix`, which for a
+;; hydrating root is whatever the manifest said the server used.
+;;
+;; The id is rendered into the DOM only once `::revealed?` flips, and that is
+;; deliberate. Its value (`_srv7-R_0_` under React 19) is an INTERNAL React
+;; token no hand-authored server fixture can predict, so emitting it on the
+;; first render would guarantee a text mismatch — React would regenerate the
+;; tree and destroy the very node-identity signal the adoption assertion reads.
+;; Deferring the DISPLAY costs nothing: the string revealed is the one the
+;; first render computed, and the assertion stays format-agnostic (it matches
+;; on the prefix SUBSTRING, not on React's token shape).
 (defview seam-root []
   (let [id (react/use-id)]
     [:div.seam
      [:span.greeting (ui/sub [::greeting])]
-     [:i.uid id]]))
+     [:i.uid (when (ui/sub [::revealed?]) id)]]))
 
 ;; ---------------------------------------------------------------------------
 ;; Server-side artefacts, planted by hand (this test proves the CLIENT half of
@@ -185,10 +198,11 @@
     (async done
       (let [act-prev (disable-act-env!)
             ;; The markup the server render emitted for `seam-root` against the
-            ;; SERVER's app-db. The `use-id` slot is left empty: its value is a
-            ;; React-internal token no hand-authored fixture can predict, and
-            ;; the point under test is which PREFIX the client root was created
-            ;; with, which is read off the rendered output below.
+            ;; SERVER's app-db, byte-matching what the first client render
+            ;; produces for that same state (`::revealed?` false ⇒ an empty
+            ;; `<i class="uid">`). A byte-match is what keeps hydration a clean
+            ;; ADOPTION, so the node-identity assertion below measures the
+            ;; adopt-vs-replace distinction rather than a mismatch recovery.
             host     (plant-host!
                       {:manifest?   true
                        :server-html (str "<div class=\"seam\">"
@@ -229,23 +243,38 @@
                  (is (true? (.-isConnected server-span))
                      "and the retained node is still in the document"))
 
-               (testing "the root took the SERVER-AUTHORED identifier prefix"
-                 (let [uid (.-textContent (.querySelector host "i.uid"))]
-                   (is (seq uid)
-                       "the compiled view rendered a use-id value")
-                   (is (str/includes? uid server-prefix)
-                       (str "the rendered use-id " (pr-str uid) " carries the "
-                            "manifest's :identifier-prefix " (pr-str server-prefix)
-                            " — a client-synthesised default is derived from the "
-                            "root-id and could not contain it"))))
-
                (testing "the root is registered under the MANIFEST's root-id"
                  (is (= server-root-id (ui-client/root-id-of @root-atom))
                      "identity came from the manifest content, not from opts"))
-               (finally
+               (catch :default e
                  (teardown! host root-atom)
                  (restore-act-env! act-prev)
-                 (done))))
+                 (done)
+                 (throw e)))
+
+             ;; Reveal the id the FIRST render computed. `useId` is stable for
+             ;; a fiber's position, so what appears now is the token allocated
+             ;; during the hydrating render — under the prefix `hydrate-root`
+             ;; read out of the manifest.
+             (rf/dispatch-sync [::reveal-uid] {:frame app-frame})
+             (js/setTimeout
+              (fn []
+                (try
+                  (testing "the root took the SERVER-AUTHORED identifier prefix"
+                    (let [uid (.-textContent (.querySelector host "i.uid"))]
+                      (is (seq uid)
+                          "the compiled view rendered the use-id value")
+                      (is (str/includes? uid server-prefix)
+                          (str "the rendered use-id " (pr-str uid) " carries the "
+                               "manifest's :identifier-prefix " (pr-str server-prefix)
+                               " — the ui default prefix is derived from the "
+                               "root-id, so this substring can only have come "
+                               "from the manifest's content"))))
+                  (finally
+                    (teardown! host root-atom)
+                    (restore-act-env! act-prev)
+                    (done))))
+              0))
            0))))))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -45,10 +45,17 @@
   untouched. Pinned by the G-4/G-6 fixtures
   (`re-frame.ui.preflight-frame-wiring-dom-cljs-test`).
 
-  S1 scope notes: hydration manifests land S5, so `hydrate-root*` fails
-  loud (`:rf.error/root-manifest-invalid`) — there is no server to have
-  emitted a manifest yet (hydrate preflight will share the same
-  `execute-frame-plans!` path when it lands). Descriptors + site coords
+  `hydrate-root*` runs that same preflight path and then ADOPTS the
+  server-rendered DOM (rf2-3omxp): it resolves the container's Root
+  Manifest through the `:ssr/discover-root-manifest` late-bind hook the
+  optional SSR artefact publishes, takes `:root-id` and
+  `:identifier-prefix` from the validated manifest's CONTENT, and hands
+  the compiled element to `hydrateRoot`. It does NOT install the
+  hydration payload — `re-frame.ssr/hydrate!` owns that, and the public
+  boot is the two calls in order (`ssr/hydrate!`, then
+  `ui/hydrate-root`). No manifest is a loud
+  `:rf.error/root-manifest-invalid` `{:missing :manifest}`; no SSR
+  artefact is a loud `:rf.error/ssr-artefact-missing`. Descriptors + site coords
   ride the registry in dev only (goog.DEBUG — production carries no
   manifests, I-12); root-id and container ownership are load-bearing
   identity and stay in production."
@@ -56,6 +63,7 @@
             ["react-dom/client" :as rdc]
             [clojure.string :as str]
             [re-frame.error :as error]
+            [re-frame.late-bind :as late-bind]
             [re-frame.ui.digest-carrier :as digest-carrier]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.ui.frames :as frames]
@@ -1304,22 +1312,143 @@
         (abort-seated-attempt! rid receipt incarnation)
         (throw e)))))
 
+(def ^:private ssr-artefact
+  ;; The optional-artefact identity the fail-loud missing-hook error reports.
+  ;; Mirrors `re-frame.core-ssr/ssr-artefact` (core owns its private copy for
+  ;; the `rf/*` wrappers) exactly as `re-frame.ui.route-link-seam` carries its
+  ;; own routing copy — the ui artefact names the missing ssr artefact at the
+  ;; hydrate site without reaching into core internals.
+  {:error-keyword :rf.error/ssr-artefact-missing
+   :maven         "day8/re-frame2-ssr"
+   :require-ns    "re-frame.ssr"})
+
+(defn- discover-root-manifest!
+  "Resolve the `:ssr/discover-root-manifest` hook and read `container`'s Root
+  Manifest — the validated manifest, or nil when there is none.
+
+  `hydrate-root` is a BOOT-TIME caller, so this is the plain unmemoised
+  resolution (Conventions §Late-bind hook key grammar rule 6): no cached
+  resolution, because this is not a hot path. `require-fn!` supplies the
+  hook-absent throw — `:rf.error/ssr-artefact-missing`, carrying the
+  copy-pasteable `day8/re-frame2-ssr` coordinate and the `re-frame.ssr`
+  require-ns — so an app that compiled `ui/hydrate-root` without the SSR
+  artefact on its classpath is told exactly what to add."
+  [container]
+  ((late-bind/require-fn! :ssr/discover-root-manifest
+                          're-frame.ui/hydrate-root
+                          ssr-artefact)
+   container))
+
+(defn- react-opts-with-identifier-prefix
+  "Return a fresh copy of `react-opts` carrying the SERVER-AUTHORED
+  `identifierPrefix`. Hydration cannot choose its own prefix: React's `useId`
+  output is derived from it, so a client prefix that disagrees with the one the
+  server render used produces different ids and breaks hydration. The compiled
+  `hydrate-root` call site therefore emits `nil` for the prefix (identity opts
+  client-side are a COMPILE error) and the effective value arrives here, from
+  the manifest's content. A manifest that carries no `:identifier-prefix` means
+  the server used none, so none is set — never a synthesised default, which
+  would be exactly the disagreement this guards."
+  [react-opts identifier-prefix]
+  (let [o (if react-opts (js/Object.assign #js {} react-opts) #js {})]
+    (when (some? identifier-prefix)
+      (unchecked-set o "identifierPrefix" identifier-prefix))
+    o))
+
 (defn hydrate-root*
-  "Runtime half of `ui/hydrate-root`. Hydrating mounts read identity FROM
-  the server-emitted manifest adjacent to the container — and server
-  rendering, the manifest script-element convention, and hydrate preflight
-  all land S5. At S1 no manifest can exist, so every hydrate fails loud
-  (`:rf.error/root-manifest-invalid`) rather than guessing identity."
-  [_container _element-thunk _plans-thunk _react-opts]
+  "Runtime half of `ui/hydrate-root` — the compiled-view DOM-ADOPTION call.
+
+  Hydrating mounts read identity FROM the server-emitted Root Manifest adjacent
+  to the container, never from opts (identity opts at a hydrate site are a
+  compile error) and never from the container element itself. Discovery lives in
+  the optional SSR artefact and is reached through the `:ssr/discover-root-
+  manifest` late-bind hook (rf2-3omxp) — `ui -> core registry <- ssr`, the same
+  shape `route-link` uses against routing; a direct require is forbidden by the
+  Independence rule and would fail to compile every non-SSR ui app.
+
+  RESPONSIBILITY BOUNDARY (Spec 011 §Client-side hydration boot helper). This
+  function adopts server-rendered DOM; it does NOT install the hydration
+  payload. `re-frame.ssr/hydrate!` remains the explicit SSR state-boot call —
+  it reads `__rf_payload`, installs it idempotently, dispatches `:rf/hydrate`,
+  and verifies. The public boot is therefore TWO calls, in order: `ssr/hydrate!`
+  then `ui/hydrate-root`, so the first compiled render already sees the server's
+  app-db.
+
+  Two distinct failures, neither of them a new error id:
+
+    - the SSR artefact is ABSENT — `:rf.error/ssr-artefact-missing` from
+      `require-fn!`, naming `day8/re-frame2-ssr`;
+    - the artefact is present but discovery finds NO adjacent manifest —
+      `:rf.error/root-manifest-invalid` `{:missing :manifest}`. There is
+      nothing left to hydrate *as*, so this fails loud rather than guessing
+      identity (Spec 011 §Discovery). A corrupt manifest already threw the same
+      id out of the SSR artefact's own `validate!`.
+
+  ORDER mirrors `mount*`'s fresh path — claim check, preflight, adapter-
+  admission revalidation, claim re-check, then React — with ONE forced
+  difference: React fuses root creation and the initial render for hydration
+  (`hydrateRoot` takes the children as its second argument), so registration and
+  the pending-attempt seat necessarily follow the call rather than precede the
+  render. The incarnation is minted BEFORE `hydrateRoot` and baked into the
+  element, so every ViewCell is scoped to this root regardless of that ordering;
+  registration and seating are plain `swap!`s with no user code between them and
+  the call, so they complete before React can flush the scheduled hydration
+  work. A synchronous throw from the element thunk or `hydrateRoot` settles the
+  preflight receipt and leaves no registry entry (there is nothing to roll back
+  — registration had not happened)."
+  [container element-thunk plans-thunk react-opts]
   (require-root-creation-open! 're-frame.ui/hydrate-root)
-  (error/throw-error!
-   :rf.error/root-manifest-invalid 're-frame.ui/hydrate-root
-   (str "no root manifest is discoverable — hydrating mounts take root-id "
-        "and identifier-prefix from the manifest the server render emits "
-        "adjacent to the container, and server rendering lands with S5. "
-        "Use ui/mount for a client-only root")
-   {:recovery :use-ui-mount
-    :extra {:missing :manifest}}))
+  ;; The root-id is genuinely unknown until the manifest is read, so a nil
+  ;; container is reported before discovery — otherwise `discover` would walk
+  ;; `nil.nextElementSibling`, return nil, and the honest "you handed me no
+  ;; container" fault would masquerade as "no manifest here".
+  (require-container! 're-frame.ui/hydrate-root nil container)
+  (let [manifest (discover-root-manifest! container)]
+    (when (nil? manifest)
+      (error/throw-error!
+       :rf.error/root-manifest-invalid 're-frame.ui/hydrate-root
+       (str "no root manifest is discoverable — hydrating mounts take root-id "
+            "and identifier-prefix from the manifest the server render emits "
+            "as the container's immediately following element sibling, and "
+            "nothing was found there. Use ui/mount for a client-only root")
+       {:recovery :use-ui-mount
+        :extra {:missing :manifest}}))
+    (let [root-id (:root-id manifest)
+          prefix  (:identifier-prefix manifest)
+          info    {:root-id           root-id
+                   :provenance        :manifest
+                   :identifier-prefix prefix}]
+      (check-root-claim! 're-frame.ui/hydrate-root info container)
+      ;; rf2-vxgfnd.199 — capture the EXACT adapter generation admitting this
+      ;; hydrate BEFORE the side-effecting preflight, and revalidate after.
+      (let [adapter-receipt (current-adapter-generation)
+            receipt         (run-preflight! root-id plans-thunk)
+            incarnation     (reactive/make-root-incarnation)]
+        (try
+          (require-adapter-generation-open! 're-frame.ui/hydrate-root
+                                            adapter-receipt)
+          ;; rf2-vxgfnd.52 — preflight drained `:initial-events` synchronously
+          ;; (arbitrary app code) which may have claimed this id / container /
+          ;; prefix. Re-check before any React work.
+          (check-root-claim! 're-frame.ui/hydrate-root info container)
+          (let [react-root (rdc/hydrateRoot
+                            container
+                            (render-attempt-element
+                             receipt root-id incarnation (element-thunk))
+                            (react-opts-with-attempt-abort
+                             (react-opts-with-identifier-prefix react-opts prefix)
+                             root-id incarnation))
+                root       (Root. react-root container root-id)]
+            (register-live-root! info container root incarnation)
+            (seat-pending-attempt! root-id receipt incarnation)
+            root)
+          (catch :default e
+            ;; The element thunk, the claim fence, or the host hydrate threw.
+            ;; No registry entry exists on this path, so `abort-seated-attempt!`
+            ;; does exactly what is owed: settle the receipt terminally (it
+            ;; aborts unconditionally, seated or not) and clear nothing.
+            (abort-seated-attempt! root-id receipt incarnation)
+            (throw e)))))))
 
 (defn unmount!*
   "Runtime half of `ui/unmount!` — TOTAL teardown: unmount the React root

--- a/spec/004C-Roots-and-Mount.md
+++ b/spec/004C-Roots-and-Mount.md
@@ -367,7 +367,12 @@ top-region wrappers, in document order.)
   additive per §2's compatibility rule.
 - Payload install remains **idempotent and order-independent** (ratified): the first
   hydrating root referencing a payload installs it; later roots find it live and do
-  not re-seed. Conflict is the exception, and it is fail-loud (§7).
+  not re-seed. Conflict is the exception, and it is fail-loud (§7). Install is the
+  **state-boot** call's work, not the DOM-adoption call's: it is `re-frame.ssr/hydrate!`
+  that reads the payload and installs it, and `ui/hydrate-root` never does
+  ([011 §Client-side hydration boot helper](011-SSR.md#client-side-hydration-boot-helper)).
+  "The first hydrating root installs it" therefore describes the ORDER the two-call boot
+  runs in across N roots on a page, not a step hidden inside `hydrate-root`.
 
 ## 7. Duplicate and conflict detection — fail-loud, three layers
 
@@ -618,7 +623,7 @@ unregisters (a leaked registration failing a later mount is a test-harness bug, 
 | Surface | Stage |
 |---|---|
 | Root Descriptor v1, mount grammar + identity opts, derivation + slug, Layer-1 + Layer-3 duplicate detection, client mount/`create-root`/`render!`/`unmount!`, `ui.test/render` forms, frame-plan-conflict preflight (the `:config-fingerprint` ENSURE arm — build tier S1c, client-mount/`render!` runtime tier S2c) | **S1** (the S1 "root descriptor" deliverable, defined by §2 above; stage roster per [EP-0030 §Stages S1–S7](../docs/EP/EP-0030-the-compiled-view-substrate-program.md#stages-s1s7)) |
-| Root Manifest v1 extension keys, `hydrate-root` preflight (manifest discovery/validation → payload install → hydrate), locator generation, Layer-2 registry, payload-**content-digest** conflict preflight (the hydrate arm of `:rf.error/frame-payload-conflict` only — the plan-fingerprint arm ships at S1c/S2c, row above), `render-static` identity participation | **S5** (the S5 "root manifests" deliverable — the additive extension of S1; see [011 §Root Manifest v1](011-SSR.md#root-manifest-v1)) |
+| Root Manifest v1 extension keys, the hydrating-root boot sequence (manifest discovery/validation → payload install → hydrate) — `ui/hydrate-root` owns manifest discovery/validation and DOM adoption, while payload install and `:rf/hydrate` belong to `re-frame.ssr/hydrate!`, the state-boot call that runs first — locator generation, Layer-2 registry, payload-**content-digest** conflict preflight (the hydrate arm of `:rf.error/frame-payload-conflict` only — the plan-fingerprint arm ships at S1c/S2c, row above), `render-static` identity participation | **S5** (the S5 "root manifests" deliverable — the additive extension of S1; see [011 §Root Manifest v1](011-SSR.md#root-manifest-v1)) |
 
 ## Q24–Q28 coverage
 

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -586,6 +586,27 @@ total rather than true of `:props` alone.
 The manifest is pure data, so the SSR artefact does not depend on the UI artefact to
 carry it.
 
+**How `hydrate-root` reaches `discover`.** The dependency runs the other way and it,
+too, is not a require: `re-frame.ui` is a *separate optional artefact* and a static
+`ui → ssr` require would fail to compile every non-SSR ui app and pull server code into
+every client bundle. So `discover` is published as the late-bind hook
+**`:ssr/discover-root-manifest`** — `(fn [container])` returning the validated manifest
+or `nil` — registered by `re-frame.ssr.manifest` at namespace load and resolved by
+`ui/hydrate-root` through the core registry. The packaging graph is
+`ui → core late-bind ← ssr`, the same shape `ui/route-link` uses to reach the routing
+artefact, and neither optional artefact requires the other.
+
+The hook does exactly what its name says: it resolves **one** manifest. It carries no
+payload install and no other SSR operation — `re-frame.ssr/hydrate!` remains the
+explicit state-boot call (see [§Client-side hydration boot
+helper](#client-side-hydration-boot-helper)), so the public boot stays two calls in
+order: `ssr/hydrate!`, then `ui/hydrate-root`.
+
+When the SSR artefact is absent the hook is unbound and `ui/hydrate-root` fails loud
+with `:rf.error/ssr-artefact-missing`, naming the `day8/re-frame2-ssr` coordinate and
+the `re-frame.ssr` namespace to require. That is distinct from the artefact being
+present and finding nothing adjacent, which is the `{:missing :manifest}` case above.
+
 ### Hydration preflight and idempotent payload install
 
 A server-rendered page is N roots referencing M frames, and **M is routinely smaller


### PR DESCRIPTION
Implements **item 1** of `rf2-3omxp` (RULED by Fable, 2026-07-19 16:15): wire `re-frame.ui/hydrate-root` to the optional SSR artefact's manifest discovery through a newly-minted late-bind hook. Items 2 (shipped in #6448) and 3 (blocked on `rf2-jygc8`) remain — **the bead stays open.**

## The seam — three pieces, one change (drift-parity rule 3)

Late-bind by necessity: a static `ui → ssr` require is forbidden by the Independence rule and would fail to compile every non-SSR ui app. This is the third instance of the `ui → core registry ← optional-artefact` shape ui already exercises against routing.

1. **PRODUCER** — `re-frame.ssr.manifest` publishes its existing `discover` fn via `#?(:cljs (late-bind/set-fn! :ssr/discover-root-manifest discover))` at ns-load. Contract `(fn [container]) -> validated Root Manifest | nil`; validation failures keep throwing `:rf.error/root-manifest-invalid` from `validate!`.
2. **DIRECTORY** — one row in `implementation/core/src/re_frame/late_bind/directory.cljc`.
3. **CONSUMER** — `re-frame.ui.client/hydrate-root*` resolves via `late-bind/require-fn!` (plain, unmemoised — boot-time caller, grammar rule 6). Takes `:root-id` + `:identifier-prefix` from the validated manifest content → existing claim/preflight machinery → `rdc/hydrateRoot`.

All three land in this one PR, enforced by `late_bind_drift_test.clj`.

## Responsibility division (the Codex correction)

- `re-frame.ssr/hydrate!` remains the explicit **SSR state-boot** call (payload read → `:rf/hydrate` → verify).
- `ui/hydrate-root` becomes the **DOM-adoption** call. It does **not** install the payload.
- The two-call boot model (`ssr/hydrate!` then `ui/hydrate-root`) stays the public contract. 004C wording that read as if payload install happens inside `ui/hydrate-root` is reconciled in the same PR.

## Error semantics — no new error ids

- Hook **absent** (ssr not on classpath): `:rf.error/ssr-artefact-missing` via `require-fn!`, carrying the copy-pasteable `day8/re-frame2-ssr` coordinate + `re-frame.ssr` require-ns.
- Hook present, discover → **nil**: `:rf.error/root-manifest-invalid {:missing :manifest}` (already normative, 011 §Discovery).

## Proof — one public real-DOM vertical

`implementation/ssr/test/re_frame/ssr/hydrate_root_seam_dom_cljs_test.cljs` (mounted, browser). Runs the public two-call boot and asserts **observable outcomes**: the first compiled render sees server state (`seam-server` greeting from the payload), adopts the exact server `<span>` node (`identical?` + `isConnected`), and takes the server-authored identifier prefix (`srv7-` substring in the rendered `use-id`). Both error paths proven by `:rf.error/id` + ex-data. Reuses the established multi-root/adoption coverage shape.

## Spec

- `spec/011 §Discovery Artefact` names the hook (sole-toucher, re-verified no in-flight 011 PR).
- `spec/004C` ownership-wording reconciliation (payload install belongs to the state-boot call).

## Scope

No second discovery mode, no fallback, no version negotiation, no orchestrator, no caching, no new error id. The S4 conformance profile §5 row is **not** graduated.

## Quality gates

All foreground, run to completion, exit codes captured by redirect:

| Gate | Result |
|---|---|
| `core clojure -M:test` | **2088 tests, 0 failures** |
| `ssr clojure -M:test` | **485 tests, 0 failures** |
| `ui clojure -M:test` | **978 tests, 0 failures** |
| `npm run test:cljs` | **10261 tests, 0 failures** |
| `npm run test:browser` | **484 tests, 0 failures** (the real-DOM vertical) |
| `npm run test:elision` | PASS (60/60 absent) |
| `npm run test:bundle-isolation` | PASS (22 artefacts; ssr sentinels absent) |
| advanced ui build (`ui-g13-prod`) grep | **0** `rf.server/` / `rf/hydrate` / `re_frame.ssr` / `day8/re-frame2-ssr` |
| `python -m mkdocs build --strict` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `api-manifest gen --check` + `doc-api-check` | in sync (520 public vars; no new public var) |
| `check-no-hardcoded-paths.sh` | OK |

**Red-before / vacuity probe:** removing the directory row reds `late_bind_drift_test` naming `:ssr/discover-root-manifest`; flipping the state and prefix assertions reds the browser vertical at the exact lines. Both restored byte-identical.
