### PR TITLE
test(ui): render and exercise all six proof-pack views, reconcile the parity stand-ins (rf2-kxork)

### DIFF
--- a/implementation/scripts/check-ui-facade-isolation.cjs
+++ b/implementation/scripts/check-ui-facade-isolation.cjs
@@ -8,8 +8,19 @@
 // must retain NO unused sibling views — measured as the render sentinel literal
 // each sibling `defview` carries.
 //
-// WHAT IT DOES NOT PROVE (rf2-kxork): production absence of schemas, docs
-// projections, and dev registration. Those are owned by G-11, whose companion
+// WHAT IT DOES NOT PROVE (rf2-kxork), FIRST: that the library views RENDER.
+// This gate's two consumers root view VARS (`single_view` roots one into a
+// global, `all_views` roots all six into a JS array) so Closure's reachability
+// can be measured; neither ever mounts a node. Sentinel PRESENCE in a bundle is
+// a reachability fact, not a behavioural one — a view whose render body was
+// broken would still satisfy every assertion here. Behaviour is owned by
+// `re-frame.ui.proof-pack.library-dom-cljs-test`, which mounts all six views on
+// a real React root and exercises each one scoped to its own sentinel. Keep the
+// split: adding render assertions here would need a third advanced build and
+// would duplicate a proof that already has an owner.
+//
+// WHAT IT DOES NOT PROVE (rf2-kxork), SECOND: production absence of schemas,
+// docs projections, and dev registration. Those are owned by G-11, whose companion
 // scanner `check-ui-mounted-prod-elision.cjs` asserts them against the
 // `browser-test-prod-elision` :advanced bundle — the `rf$view_shell`
 // registration literal plus dedicated props-schema and view-docstring

--- a/implementation/ui/proof-pack/re_frame/ui/proof_pack/library_dom_cljs_test.cljs
+++ b/implementation/ui/proof-pack/re_frame/ui/proof_pack/library_dom_cljs_test.cljs
@@ -1,0 +1,295 @@
+(ns re-frame.ui.proof-pack.library-dom-cljs-test
+  "rf2-kxork — the proof pack RENDERED. G-18's two consumers
+  (`single_view` / `all_views`) root the library's view VARS into a global JS
+  array so Closure's advanced DCE can be measured; neither one ever renders a
+  node. That proves ISOLATION and nothing about behaviour, so until this file
+  landed `selection-controller` and `inline-popover` were rendered NOWHERE in
+  the corpus and the other four were only approximated by differently-shaped
+  stand-ins in the cross-host parity corpus.
+
+  This namespace mounts EVERY view of `re-frame.ui.proof-pack.library` on a
+  real React root and exercises it — the REAL view, never a re-implementation.
+  Each test drives exactly one view through its own frame, and every assertion
+  is scoped to that view's own render sentinel (`data-pp=...`) or to its own
+  frame's app-db, so a neighbouring view's breakage cannot satisfy or falsify
+  it. That scoping is deliberate: an aggregate or process-global observation
+  can pass on another namespace's leftovers (rf2-veyfp).
+
+  WHY THE PARITY CORPUS IS NOT THE VEHICLE. `parity_fixtures.cljc` is a
+  DUAL-EMITTER `.cljc` corpus: every row must render on the JVM as well as
+  through react-dom/server. The library is `.cljs`, and four of its six views
+  are host-bearing — `ui/sub` (controlled-input, safe-form-control), `ui/local`
+  + `ui/handler` (selection-controller), `ui/effect :connect` (inline-popover)
+  — so they have no JVM side to compare and can never BE a corpus row. The
+  corpus keeps only the two grammar shapes it genuinely owns, under honest
+  names; behaviour lives here.
+
+  The whole file self-skips under :node (no `js/document`), so a green
+  `npm run test:cljs` proves nothing here — `npm run test:browser` is the
+  suite that runs it."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.proof-pack.library :as lib]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.test :as uit]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter ui/adapter
+    :ambient-frame nil
+    :async? true
+    :init-fn reactive/reset-scheduler!}))
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- host-turn! []
+  (js/Promise. (fn [resolve _] (js/setTimeout #(resolve nil) 0))))
+
+(defn- dispatch-native! [el event] (.dispatchEvent el event))
+(defn- click! [el] (dispatch-native! el (js/MouseEvent. "click" #js {:bubbles true})))
+(defn- input! [el value]
+  (set! (.-value el) value)
+  (dispatch-native! el (js/Event. "input" #js {:bubbles true :cancelable true})))
+
+(defn- app-db [frame-id] @(:app-db (frame/frame frame-id)))
+(defn- make-frame [id db] (rf/make-frame {:id id :initial-events [[:rf/set-db db]]}))
+
+;; Registrations are process-global but the per-test runtime reset wipes the
+;; registrar, so each test re-registers before mounting. `register-pp!` is the
+;; library's OWN registration entry point — the one a consumer would call.
+(defn- register! []
+  (lib/register-pp!)
+  (rf/reg-event ::typed (fn [{:keys [db]} [_ value]] {:db (assoc db :text value)})))
+
+;; Sentinel selectors — each view's own render sentinel is the scope of its
+;; assertions. Spelled out (not derived) so a sentinel rename reds this file
+;; loudly rather than silently widening the scope to "any view".
+(def ^:private sel-controlled-input "[data-pp='rf2-pp-controlled-input-sentinel']")
+(def ^:private sel-selection-controller "[data-pp='rf2-pp-selection-controller-sentinel']")
+(def ^:private sel-list-cell "[data-pp='rf2-pp-list-cell-sentinel']")
+(def ^:private sel-safe-form-control "[data-pp='rf2-pp-safe-form-control-sentinel']")
+(def ^:private sel-schema-described "[data-pp='rf2-pp-schema-described-sentinel']")
+(def ^:private sel-inline-popover "[data-pp='rf2-pp-inline-popover-sentinel']")
+
+;; ---------------------------------------------------------------------------
+;; 1 — controlled-input: the reusable event-prefix control (P0-2 door)
+;; ---------------------------------------------------------------------------
+
+(defview ci-host []
+  [lib/controlled-input {:on-change [::typed]}])
+
+(deftest controlled-input-renders-and-round-trips-the-event-prefix
+  (if-not (browser?)
+    (is true ":node — the browser suite renders proof-pack controlled-input")
+    (let [f (make-frame ::ci {:text "seed"})]
+      (register!)
+      (async done
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [ci-host]]]
+              (let [el (uit/query root sel-controlled-input)]
+                (is (some? el)
+                    "controlled-input renders a node carrying its own sentinel")
+                (is (= "INPUT" (.-tagName el)) "and it is the <input> it declares")
+                (is (= "seed" (.-value el))
+                    "ui/sub [:rf.pp/text] drives the controlled value from app-db")
+                (-> (uit/flush! #(do (input! el "typed & <kept>") (host-turn!)))
+                    (.then
+                     (fn []
+                       (is (= "typed & <kept>" (:text (app-db ::ci)))
+                           "the :on-change prefix is conj'd with the live native value and dispatched")
+                       (is (= "typed & <kept>" (.-value el))
+                           "and the committed app-db value flows back through the sub"))))))
+            (.then (fn [] (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f)
+                     (is false (str "controlled-input: " e)) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — selection-controller: multi-writer atomic transitions (update!)
+;; ---------------------------------------------------------------------------
+
+;; Captured OUTSIDE the frame: `on-select` is an opaque fn prop, and this is
+;; the only way to observe the value the view read at click time.
+(defonce ^:private selected (atom ::unset))
+
+(defview sc-host []
+  [lib/selection-controller {:on-select (fn [sel] (reset! selected sel))}])
+
+(deftest selection-controller-renders-and-composes-two-same-turn-writers
+  (if-not (browser?)
+    (is true ":node — the browser suite renders proof-pack selection-controller")
+    (let [f (make-frame ::sc {})]
+      (register!)
+      (reset! selected ::unset)
+      (async done
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [sc-host]]]
+              (let [host  (uit/query root sel-selection-controller)
+                    count-el (uit/query root (str sel-selection-controller " [data-role='count']"))
+                    btn   (uit/query root (str sel-selection-controller " button"))]
+                (is (some? host)
+                    "selection-controller renders a node carrying its own sentinel")
+                (is (= "0" (.-textContent count-el))
+                    "ui/local seeds the selection empty")
+                (-> (uit/flush! #(do (click! btn) (host-turn!)))
+                    (.then
+                     (fn []
+                       (is (= "2" (.-textContent count-el))
+                           "TWO same-turn update! writers compose over the LATEST host state (#{} -> #{:a :b})")
+                       (is (= #{} @selected)
+                           "on-select receives the COMMITTED selection the render read, not the in-flight one"))))))
+            (.then (fn [] (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f)
+                     (is false (str "selection-controller: " e)) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — list-cell: parameterized markup through ui/slot + render-fn
+;; ---------------------------------------------------------------------------
+
+(defview lc-host [{:keys [rows]}]
+  [lib/list-cell {:rows rows
+                  :render (ui/render-fn [idx row]
+                            [:span {:data-role "cell"} (str idx "=" (:name row))])}])
+
+(deftest list-cell-renders-each-row-through-the-callers-slot
+  (if-not (browser?)
+    (is true ":node — the browser suite renders proof-pack list-cell")
+    (let [f    (make-frame ::lc {})
+          rows [{:id 1 :name "a & <b>"} {:id 2 :name "second"}]]
+      (register!)
+      (async done
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [lc-host {:rows rows}]]]
+              (let [ul    (uit/query root sel-list-cell)
+                    items (when ul (.querySelectorAll ul "li"))
+                    cells (when ul (.querySelectorAll ul "[data-role='cell']"))]
+                (is (some? ul) "list-cell renders a node carrying its own sentinel")
+                (is (= "UL" (.-tagName ul)) "and it is the <ul> it declares")
+                (is (= 2 (.-length items)) "one keyed <li> per row, no more")
+                (is (= 2 (.-length cells))
+                    "ui/slot invokes the caller's render-fn exactly once per row")
+                (is (= ["0=a & <b>" "1=second"]
+                       (mapv #(.-textContent %) (array-seq cells)))
+                    "the slot receives (index row) in order and its output is escaped text")))
+            (.then (fn [] (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f)
+                     (is false (str "list-cell: " e)) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — safe-form-control: caller attrs through the spread-safe policy
+;; ---------------------------------------------------------------------------
+
+(defview sfc-host []
+  [lib/safe-form-control
+   {:on-change [::typed]
+    ;; `:data-pp` deliberately COLLIDES with the view's owned sentinel prop:
+    ;; the safe-spread policy says owned props win, so the sentinel must
+    ;; survive. If the caller could clobber it, this view's own scope selector
+    ;; would stop matching and every assertion below would red.
+    :attrs {:aria-label "pp field"
+            :data-testid "pp-sfc"
+            :data-pp "caller-override-attempt"
+            :class "caller-extra"}}])
+
+(deftest safe-form-control-renders-with-owned-props-winning-the-collision
+  (if-not (browser?)
+    (is true ":node — the browser suite renders proof-pack safe-form-control")
+    (let [f (make-frame ::sfc {:text "owned & <kept>"})]
+      (register!)
+      (async done
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [sfc-host]]]
+              (let [el (uit/query root sel-safe-form-control)]
+                (is (some? el)
+                    "safe-form-control renders a node still carrying its OWNED sentinel — the colliding caller :data-pp lost")
+                (is (= "INPUT" (.-tagName el)) "and it is the <input> it declares")
+                (is (= "owned & <kept>" (.-value el))
+                    "the owned controlled :value survives the spread — the sync door is retained")
+                (testing "non-colliding caller attrs pass through"
+                  (is (= "pp field" (.getAttribute el "aria-label")))
+                  (is (= "pp-sfc" (.getAttribute el "data-testid")))
+                  (is (.contains (.-classList el) "caller-extra")))
+                (-> (uit/flush! #(do (input! el "typed via spread") (host-turn!)))
+                    (.then
+                     (fn []
+                       (is (= "typed via spread" (:text (app-db ::sfc)))
+                           "the OWNED :on-input handler survives the spread and dispatches"))))))
+            (.then (fn [] (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f)
+                     (is false (str "safe-form-control: " e)) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — schema-described: a literal props schema over ordinary markup
+;; ---------------------------------------------------------------------------
+
+(defview sd-host []
+  [lib/schema-described {:label "Name & <label>"}])
+
+(deftest schema-described-renders-its-label
+  (if-not (browser?)
+    (is true ":node — the browser suite renders proof-pack schema-described")
+    (let [f (make-frame ::sd {})]
+      (register!)
+      (async done
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [sd-host]]]
+              (let [el (uit/query root sel-schema-described)]
+                (is (some? el)
+                    "schema-described renders a node carrying its own sentinel")
+                (is (= "LABEL" (.-tagName el)) "and it is the <label> it declares")
+                (is (= "Name & <label>" (.-textContent el))
+                    "the declared :label prop reaches the markup as escaped text")))
+            (.then (fn [] (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f)
+                     (is false (str "schema-described: " e)) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; 6 — inline-popover: the measure-before-paint geometry shell (interop tier)
+;; ---------------------------------------------------------------------------
+
+(defview ip-host []
+  [lib/inline-popover {:content "popover body & <content>"}])
+
+(deftest inline-popover-mounts-its-connect-effect-and-renders-its-shell
+  (if-not (browser?)
+    (is true ":node — the browser suite renders proof-pack inline-popover")
+    (let [f (make-frame ::ip {})]
+      (register!)
+      (async done
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [ip-host]]]
+              (let [el (uit/query root sel-inline-popover)]
+                ;; `with-root` awaits the initial COMMIT, so reaching this point
+                ;; means the view's `ui/effect :connect` ran without throwing.
+                ;; The library's connect body is `(fn [] nil)` by design — a
+                ;; pure structural shell (its comment says the C-6
+                ;; measure-before-paint work lives there), so there is no
+                ;; observable side effect to assert and none is claimed.
+                (is (some? el)
+                    "inline-popover renders a node carrying its own sentinel after a committed mount")
+                (is (= "DIV" (.-tagName el)) "and it is the <div> it declares")
+                (is (= "dialog" (.getAttribute el "role"))
+                    "the geometry shell keeps its dialog role")
+                (is (= "popover body & <content>" (.-textContent el))
+                    "the :content child renders inside the shell")))
+            (.then (fn [] (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f)
+                     (is false (str "inline-popover: " e)) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; Roster completeness — the six tests above must cover the whole library
+;; ---------------------------------------------------------------------------
+
+(deftest every-library-view-is-rendered-somewhere-in-this-namespace
+  ;; Runs on BOTH runtimes: it is a static roster claim, not a mounted one.
+  ;; G-18 derives its sentinel roster from library.cljs; this pins the RENDER
+  ;; side to the same six, so adding a seventh view arms this test too instead
+  ;; of quietly escaping render coverage (the rf2-r4q98 drift shape).
+  (is (= 6 (count [lib/controlled-input lib/selection-controller lib/list-cell
+                   lib/safe-form-control lib/schema-described lib/inline-popover]))
+      "the library ships exactly the six views this namespace mounts")
+  (is (= 6 (count (distinct [sel-controlled-input sel-selection-controller
+                             sel-list-cell sel-safe-form-control
+                             sel-schema-described sel-inline-popover])))
+      "each view is scoped by a DISTINCT sentinel selector — no test can be satisfied by a sibling"))

--- a/implementation/ui/test/re_frame/ui/parity_fixtures.cljc
+++ b/implementation/ui/test/re_frame/ui/parity_fixtures.cljc
@@ -398,52 +398,68 @@
                          [:span.cell (:name only-row)])}])
 
 ;; ---------------------------------------------------------------------------
-;; Component-library PROOF PACK (readiness §7; EP-0035) — representative
-;; library-shaped components donated to the parity corpus as a rolling consumer
-;; (the substrate takes no re-com build dependency). These prove CROSS-HOST
-;; STRUCTURAL equivalence of the component-library shapes; the behavioural
-;; guarantees ride the owning gates (controlled-input sync door / IME / caret =
-;; G-8; multi-writer local = G-15; safe-spread deny = G-17; slot purity = G-16;
-;; manifest + production absence = G-7/G-11; single-view import = G-18).
+;; Library-shaped grammar rows (rf2-kxork)
+;;
+;; These three rows USED to be named `pp-*` and documented as the
+;; "component-library PROOF PACK … donated to the parity corpus", which read as
+;; though this corpus covered `re-frame.ui.proof-pack.library`. IT NEVER DID.
+;; They are independent re-implementations with materially different markup and
+;; props, so the framing was an assertions-decoupled-from-reality claim: the
+;; corpus asserted on these while the real library went unrendered. The claim is
+;; retired here; the rows survive on their own grammar merit, under names that
+;; describe what they actually are.
+;;
+;; The real library is now RENDERED AND EXERCISED — all six views, on a real
+;; React root — by `re-frame.ui.proof-pack.library-dom-cljs-test`. It cannot be
+;; a member of THIS corpus: the corpus is dual-emitter `.cljc` (every row must
+;; also render on the JVM), the library is `.cljs`, and four of its six views
+;; are host-bearing (`ui/sub`, `ui/local` + `ui/handler`, `ui/effect :connect`)
+;; and so have no JVM side to compare.
+;;
+;; A fourth row, `pp-controlled-input`, was RETIRED outright rather than
+;; renamed: its shape (a literal `:value` co-present with an `:on-input`
+;; handler, plus `:read-only`) is already covered exactly by `form-controls`
+;; rows 1 and 3, so nothing is left uncovered by its removal.
 ;; ---------------------------------------------------------------------------
 
-(defview pp-controlled-input
-  "Proof pack — reusable controlled text input (the event-prefix control's
-  STRUCTURAL shell; the synchronous door + IME/caret behaviour is G-8). A
-  literal :value co-present with the handler is the controlled site."
-  [{:keys [value]}]
-  [:input.pp-input {:type :text :value value :read-only true
-                    :on-input [:pp/typed :rf.ui/value]}])
-
-(defview pp-list-cell
-  "Proof pack — a reusable list rendering each row through an INLINE compiled
-  render slot (keys/occurrences preserved; JVM structure faithful)."
+(defview inline-slot-render-fn
+  "Grammar row: a list rendering each row through a render-fn constructed
+  INLINE at the `ui/slot` call site — the complement of `slot-consumer`, which
+  carries its render-fn as a PROP. Keys/occurrences preserved; JVM structure
+  faithful. NOT the proof-pack library's `list-cell` (that view takes `render`
+  as a prop; it is exercised in library-dom-cljs-test)."
   [{:keys [rows]}]
-  [:ul.pp-list
+  [:ul.slot-list
    (for [[i r] (map-indexed vector rows)]
-     [:li.pp-cell {:key (:id r)}
-      (ui/slot (ui/render-fn [idx row] [:span.pp-body (str idx ":" (:name row))]) i r)])])
+     [:li.slot-cell {:key (:id r)}
+      (ui/slot (ui/render-fn [idx row] [:span.slot-body (str idx ":" (:name row))]) i r)])])
 
-(defview pp-safe-form-control
-  "Proof pack — a form control forwarding caller attrs through the spread-safe
-  policy onto its owned input: owned props win, aria-*/data-* pass through, the
-  controlled site is retained."
+(defview safe-spread-controlled
+  "Grammar row: `ui/spread-safe` over a CONTROLLED owned map — the clause
+  `safe-spread-trusted` does not reach, since its owned map carries no
+  `:value`. Owned props win, aria-*/data-* pass through, and the literal
+  `:value` co-present with the handler keeps the sync door across the spread.
+  NOT the proof-pack library's `safe-form-control` (that view sources its value
+  from `ui/sub`, not a prop; it is exercised in library-dom-cljs-test)."
   [{:keys [value attrs]}]
-  [:input.pp-form (ui/spread-safe {:type :text :value value :read-only true
-                                   :on-input [:pp/typed :rf.ui/value]}
-                                  attrs)])
+  [:input.safe-form (ui/spread-safe {:type :text :value value :read-only true
+                                     :on-input [:corpus/typed :rf.ui/value]}
+                                    attrs)])
 
-(defview pp-schema-described
-  "Proof pack — a schema-described component: its literal props schema drives the
-  view-manifest projection (Story/docs/Xray) and is proven production-absent
-  under G-7/G-11. Structurally it is ordinary markup."
+(defview schema-described-markup
+  "Grammar row: the corpus's only view carrying a LITERAL props schema, pinning
+  that a schema-described view renders identically on both hosts (the schema is
+  manifest/validation metadata and must not perturb output). NOT the proof-pack
+  library's `schema-described`, whose schema is `{:closed true}` over `:label`
+  ALONE and whose markup is a single `<label>` — this row's `:hint` prop does
+  not exist there and would violate that closed schema."
   {:props [:map
            [:label {:doc "the field label"} :string]
            [:hint {:doc "optional helper text" :optional true} :string]]}
   [{:keys [label hint]}]
-  [:div.pp-described
-   [:span.pp-label label]
-   (when hint [:small.pp-hint hint])])
+  [:div.described
+   [:span.described-label label]
+   (when hint [:small.described-hint hint])])
 
 ;; ---------------------------------------------------------------------------
 ;; S4 corpus additions (W14; rf2-yho9j) — the S4 surfaces that HAVE two
@@ -527,10 +543,10 @@
    :children-flow   children-flow
    :slot-consumer   slot-consumer
    :slot-empty      slot-empty
-   :pp-controlled-input   pp-controlled-input
-   :pp-list-cell          pp-list-cell
-   :pp-safe-form-control  pp-safe-form-control
-   :pp-schema-described   pp-schema-described
+   ;; rf2-kxork — library-shaped grammar rows (formerly the `pp-*` stand-ins)
+   :inline-slot-render-fn    inline-slot-render-fn
+   :safe-spread-controlled   safe-spread-controlled
+   :schema-described-markup  schema-described-markup
    ;; S4 (W14, rf2-yho9j)
    :presence-toasts       presence-toasts
    :presence-inline       presence-inline
@@ -584,14 +600,14 @@
                                                                     {:id 3 :name "third"}]}}
    {:id :slot-empty           :view :slot-empty      :props {:rows [{:id 1 :name "x"}
                                                                     {:id 2 :name "y"}]}}
-   {:id :pp-controlled-input  :view :pp-controlled-input :props {:value "typed & <kept>"}}
-   {:id :pp-list-cell         :view :pp-list-cell       :props {:rows [{:id 1 :name "a & <b>"}
-                                                                       {:id 2 :name "second"}]}}
-   {:id :pp-safe-form-control :view :pp-safe-form-control :props {:value "v & <x>"
-                                                                  :attrs {:aria-label "field"
-                                                                          :data-testid "pp"
-                                                                          :class "extra"}}}
-   {:id :pp-schema-described  :view :pp-schema-described :props {:label "Name" :hint "your full name"}}
+   ;; rf2-kxork — library-shaped grammar rows (formerly the `pp-*` stand-ins)
+   {:id :inline-slot-render-fn :view :inline-slot-render-fn :props {:rows [{:id 1 :name "a & <b>"}
+                                                                          {:id 2 :name "second"}]}}
+   {:id :safe-spread-controlled :view :safe-spread-controlled :props {:value "v & <x>"
+                                                                      :attrs {:aria-label "field"
+                                                                              :data-testid "sc"
+                                                                              :class "extra"}}}
+   {:id :schema-described-markup :view :schema-described-markup :props {:label "Name" :hint "your full name"}}
    ;; --- S4 (W14; rf2-yho9j) — the dual-emitter S4 rows -------------------
    {:id :presence-two         :view :presence-toasts :props {:toasts [{:id 1 :msg "a & <b>"}
                                                                       {:id 2 :msg "second"}]}}


### PR DESCRIPTION
## What this does (rf2-kxork split (a))

Split (b) shipped in #6451 (G-18 narrowed + the mandatory G-11 rider). This PR is split (a) only: make the proof pack actually prove its acceptance criterion #1 — that the six library views are *rendered/exercised*, not merely reachable.

Before this PR, G-18's two consumers (`single_view` / `all_views`) root the library's view **vars** into a global JS array so Closure reachability can be measured; neither ever mounts a node. Render coverage lived only in `parity_fixtures.cljc`, which re-implemented four differently-shaped stand-ins — and `selection-controller` + `inline-popover` were rendered **nowhere**.

### Six views, now rendered for real
New mounted DOM suite `re-frame.ui.proof-pack.library-dom-cljs-test` mounts **all six** real library views (`controlled-input`, `selection-controller`, `list-cell`, `safe-form-control`, `schema-described`, `inline-popover`) on a real React root via `ui.test/with-root`, using the library's own `register-pp!`. Each test:
- drives exactly one view through its own frame;
- scopes every assertion to that view's own `data-pp` render sentinel (or its own frame's app-db) — no aggregate/process-global observation (rf2-veyfp trap avoided);
- exercises behaviour, not just presence: the event-prefix `:on-change` round-trip, two same-turn `update!` writers composing (`#{}` → `#{:a :b}`), one `ui/slot` invocation per row, the spread-safe owned-`:value` winning a deliberate `:data-pp` collision, the declared `:label`, and the committed-mount `:connect` effect + dialog shell.

A roster-completeness test pins the render side to the same six views G-18 derives, so a 7th view arms it too.

### Four stand-ins reconciled/retired (no silent substitution)
- `pp-list-cell` → **renamed** `inline-slot-render-fn` (it is genuinely the inline-render-fn complement of `slot-consumer`).
- `pp-safe-form-control` → **renamed** `safe-spread-controlled` (spread-safe over a controlled owned map — a shape the existing `safe-spread-trusted` row does not reach).
- `pp-schema-described` → **renamed** `schema-described-markup` (the corpus's only literal-props-schema row).
- `pp-controlled-input` → **retired outright**; its shape is already covered by `form-controls` rows 1 and 3, so nothing is left uncovered.

Each renamed row's docstring now says plainly it is **NOT** the like-named library view and points at the mounted suite. The old "component-library proof pack donated to the parity corpus" framing — which read as though this corpus covered the real library, when it never did — is removed.

### Finding: the stand-ins were materially different from the real views (reported, not silently aligned)
The four stand-ins were not faithful proxies:
- `pp-schema-described` carried a `:hint` prop and a `<small>` element that **do not exist** in the real `schema-described`, whose schema is `{:closed true}` over `:label` alone — `:hint` would violate that closed schema.
- `pp-controlled-input` / `pp-safe-form-control` took `:value` as a **prop**; the real views source it from `ui/sub [:rf.pp/text]`.
- Markup differed throughout (`.pp-*` classes vs the real sentinels). These are captured in the new docstrings rather than patched to match.

### Checker header
`check-ui-facade-isolation.cjs` header now states, first, that the gate proves **reachability, not render** — behaviour is owned by the new mounted suite — and keeps the existing G-11 ownership note.

## Quality gates (foreground, unpiped, to completion)

- `npm run test:ui-facade-isolation` — **PASS**, exit 0. Self-test PASS (derived roster + per-entry anti-vacuity + bundle arms); roster derives **6 views**, single-view import retains **0/5** siblings; G-18 PASS.
- `npm run test:browser` — **PASS**, exit 0. 489 tests / 2737 assertions, 0 failures. The 7 new tests run here (proven by the red-before levers below); they self-skip under node.
- `cd implementation/ui && clojure -M:test` — **PASS**, exit 0. 978 tests / 18705 assertions, 0 failures.
- `npm run test:cljs` — **PASS**, exit 0. 10265 tests / 50648 assertions, 0 failures.
- `npm run test:browser-prod-elision` — **PASS**, exit 0. 113 tests / 480 assertions, 0 failures; "ui mounted production elision: PASS". #6451's G-11 arms undisturbed.
- `scripts/check-no-hardcoded-paths.sh` — **PASS**.

### Red-before, one lever per newly-exercised view
Each lever is a single one-line break in `library.cljs`, reverted after; each produced its own scoped failure and no other:
| View | Lever | Sole failure |
|---|---|---|
| controlled-input | `:value (ui/sub …)` → `"WRONG"` | `controlled-input-renders...` value assertion |
| selection-controller | 2nd `(update-sel conj :b)` → `conj :a` | count `"2"` → `"1"` |
| list-cell | drop `(ui/slot render i r)` | cell count 2 → 0 (2 asserts, same test) |
| safe-form-control | owned `:value (ui/sub …)` → `"WRONG"` | owned-value-wins assertion |
| schema-described | `(str label)` → `"static"` | label text |
| inline-popover | `:role "dialog"` → `:role "note"` | dialog-role assertion |

Scope held: no new shadow build, no CI job, no `shadow-cljs.edn` edit; the G-18 subject files (`library.cljs` / `all_views.cljs` / `single_view.cljs`), the G-11 rider, spec/EP, and core are untouched.
