### PR TITLE
fix(reagent-slim): stamp :element on the invalid-hiccup-head reject to match Spec 009 (rf2-vzno0); rf2-pqbka already resolved by g8ict

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
@@ -745,7 +745,7 @@
   "Emit a hiccup vector whose head is a DOM-tag keyword/symbol/string."
   [^StringBuffer sb argv]
   (let [head      (nth argv 0 nil)
-        parsed    (template/parse-tag head)
+        parsed    (template/parse-tag head argv)
         tag-str   (.-tag parsed)
         [first-arg has-props children-pos] (template/hiccup-shape argv 1)
         user-attrs (when (and has-props (some? first-arg)) first-arg)

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -132,8 +132,19 @@
   not reachable from this bundle-isolated adapter (see the sibling
   `:rf.error/template-empty-vector` throw in `vec-to-elem`). The id and the
   `:recovery` token are the ones the JVM emitters' reserved-head arm already
-  carries, so server and client teach one grammar."
-  [head]
+  carries, so server and client teach one grammar.
+
+  `element` is the WHOLE offending hiccup vector and is REQUIRED (rf2-vzno0).
+  Spec 009's `:rf.error/invalid-hiccup-head` row promises the payload pair
+  `:head`, `:element` on BOTH arms, and the JVM arm
+  (`re-frame.ssr.emit/reject-reserved-rf-hiccup-head!`) supplies both. This
+  arm stamped `:head` alone, so a diagnostic consumer reading the documented
+  payload got the head server-side and nil client-side for the same
+  category — exactly the cross-host friction the shared id exists to avoid.
+  Required rather than optional because every live caller has the vector in
+  hand: an optional arity would only re-open a path that stamps `:element
+  nil`, which is a claim the catalogue does not permit."
+  [head element]
   (when (reserved-rf-head? head)
     (let [reason (str "hiccup vector head " head " is in the framework-reserved "
                       ":rf/* namespace but is not a head this renderer "
@@ -149,7 +160,8 @@
                        :where       'reagent2.template/parse-tag
                        :reason      reason
                        :recovery    :use-a-recognised-reserved-head-or-an-unreserved-keyword
-                       :head        head})))))
+                       :head        head
+                       :element     element})))))
 
 (defn parse-tag
   "Parse a hiccup tag keyword into its `:tag` / `:id` / `:class` parts.
@@ -166,16 +178,19 @@
 
   Examples:
 
-    (parse-tag :div)         → HiccupTag{tag \"div\" id nil  class nil}
-    (parse-tag :div.cls)     → HiccupTag{tag \"div\" id nil  class \"cls\"}
-    (parse-tag :div#id)      → HiccupTag{tag \"div\" id \"id\" class nil}
-    (parse-tag :div#id.a.b)  → HiccupTag{tag \"div\" id \"id\" class \"a b\"}
-    (parse-tag :div.a.b#id)  → HiccupTag{tag nil   id nil  class nil}  ; NOT supported
+    (parse-tag :div        [:div])         → HiccupTag{tag \"div\" id nil  class nil}
+    (parse-tag :div.cls    [:div.cls])     → HiccupTag{tag \"div\" id nil  class \"cls\"}
+    (parse-tag :div#id     [:div#id])      → HiccupTag{tag \"div\" id \"id\" class nil}
+    (parse-tag :div#id.a.b [:div#id.a.b])  → HiccupTag{tag \"div\" id \"id\" class \"a b\"}
+    (parse-tag :div.a.b#id [:div.a.b#id])  → HiccupTag{tag nil   id nil  class nil}  ; NOT supported
 
   Rejects an UNRECOGNISED head in the framework-reserved `:rf/*` scheme —
-  see `reject-reserved-rf-head!` (rf2-01zvu)."
-  [hiccup-tag]
-  (reject-reserved-rf-head! hiccup-tag)
+  see `reject-reserved-rf-head!` (rf2-01zvu). `element` is the whole hiccup
+  vector `hiccup-tag` heads; it is carried ONLY so the reject can stamp the
+  `:element` payload slot Spec 009 promises (rf2-vzno0) and takes no part in
+  parsing. Every call site has it in hand, so it is required, not optional."
+  [hiccup-tag element]
+  (reject-reserved-rf-head! hiccup-tag element)
   (let [[_ tag id class-shorthand]
         (re-matches re-tag (name hiccup-tag))
         class (when class-shorthand
@@ -240,12 +255,12 @@
       (str ns* "/" n)
       n)))
 
-(defn- cached-parse [k]
+(defn- cached-parse [k element]
   (let [n (cache-key k)]
     (if (and (not (reserved-prop-key? n))
              (.hasOwnProperty tag-name-cache n))
       (aget tag-name-cache n)
-      (let [v (parse-tag k)]
+      (let [v (parse-tag k element)]
         (when-not (reserved-prop-key? n)
           (aset tag-name-cache n v))
         v))))
@@ -1028,7 +1043,7 @@
 
       ;; DOM-tag head — keyword, symbol, or string.
       (hiccup-tag? tag)
-      (native-element (cached-parse tag) argv 1)
+      (native-element (cached-parse tag argv) argv 1)
 
       ;; Reagent / React class head — instantiate directly.
       (component/reagent-class? tag)

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
@@ -33,35 +33,35 @@
 
 (deftest parse-tag-bare
   (testing "bare tag: :div"
-    (let [parsed (template/parse-tag :div)]
+    (let [parsed (template/parse-tag :div [:div])]
       (is (= "div" (.-tag parsed)))
       (is (nil? (.-id parsed)))
       (is (nil? (.-className parsed))))))
 
 (deftest parse-tag-with-class
   (testing ":div.foo"
-    (let [parsed (template/parse-tag :div.foo)]
+    (let [parsed (template/parse-tag :div.foo [:div.foo])]
       (is (= "div" (.-tag parsed)))
       (is (nil? (.-id parsed)))
       (is (= "foo" (.-className parsed))))))
 
 (deftest parse-tag-with-id
   (testing ":div#bar"
-    (let [parsed (template/parse-tag :div#bar)]
+    (let [parsed (template/parse-tag :div#bar [:div#bar])]
       (is (= "div" (.-tag parsed)))
       (is (= "bar" (.-id parsed)))
       (is (nil? (.-className parsed))))))
 
 (deftest parse-tag-with-id-and-class
   (testing ":div#bar.foo"
-    (let [parsed (template/parse-tag :div#bar.foo)]
+    (let [parsed (template/parse-tag :div#bar.foo [:div#bar.foo])]
       (is (= "div" (.-tag parsed)))
       (is (= "bar" (.-id parsed)))
       (is (= "foo" (.-className parsed))))))
 
 (deftest parse-tag-with-multiple-classes
   (testing ":div.a.b.c"
-    (let [parsed (template/parse-tag :div.a.b.c)]
+    (let [parsed (template/parse-tag :div.a.b.c [:div.a.b.c])]
       (is (= "div" (.-tag parsed)))
       (is (nil? (.-id parsed)))
       (is (= "a b c" (.-className parsed))
@@ -69,12 +69,12 @@
 
 (deftest parse-tag-input
   (testing ":input — void element parses normally"
-    (let [parsed (template/parse-tag :input)]
+    (let [parsed (template/parse-tag :input [:input])]
       (is (= "input" (.-tag parsed))))))
 
 (deftest parse-tag-id-before-class-supported
   (testing ":div#id.a.b — id MUST precede classes (the supported form)"
-    (let [parsed (template/parse-tag :div#id.a.b)]
+    (let [parsed (template/parse-tag :div#id.a.b [:div#id.a.b])]
       (is (= "div" (.-tag parsed)))
       (is (= "id" (.-id parsed)))
       (is (= "a b" (.-className parsed))))))
@@ -85,7 +85,7 @@
   ;; `re-matches` returns nil and the result carries a nil tag. Pin the
   ;; constraint so the docstring and the code can never silently disagree.
   (testing ":div.a#id — class-before-id is NOT supported (nil tag)"
-    (let [parsed (template/parse-tag :div.a#id)]
+    (let [parsed (template/parse-tag :div.a#id [:div.a#id])]
       (is (nil? (.-tag parsed))
           "class-before-id yields a nil tag, not a parsed element"))))
 

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_reserved_head_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_reserved_head_cljs_test.cljs
@@ -43,7 +43,16 @@
              (:recovery data))
           "same recovery token as the server arm — one target grammar")
       (is (= :rf/suspense-boundry (:head data))
-          "the offending head rides the payload")))
+          "the offending head rides the payload")
+      ;; rf2-vzno0 — Spec 009's `:rf.error/invalid-hiccup-head` row promises
+      ;; `:head`, `:element` on BOTH arms, and the JVM arm
+      ;; (`re-frame.ssr.emit/reject-reserved-rf-hiccup-head!`) supplies both.
+      ;; The client arm stamped `:head` alone, so a diagnostic consumer
+      ;; reading the documented payload got the head but nil for the
+      ;; offending vector — cross-host friction in a structured error API.
+      (is (= [:rf/suspense-boundry {:id 1}] (:element data))
+          "the COMPLETE offending hiccup vector rides the payload, as the
+           catalogue row promises for both arms")))
 
   (testing ":rf/suspense-boundary is server-streaming-only on the client"
     (let [data (head-error [:rf/suspense-boundary {:id 1}])]


### PR DESCRIPTION
## Summary

Two catalogue/schema truth defects were assigned. One was a real code bug and is fixed here; the other was **already resolved on `main`** by a sibling bead, so this PR makes no edit for it.

### rf2-vzno0 — reagent-slim `invalid-hiccup-head` payload (FIXED, code was the wrong side)

Spec 009's `:rf.error/invalid-hiccup-head` catalogue row promises the payload pair **`:head`, `:element` (both arms)**, and the JVM arm (`re-frame.ssr.emit/reject-reserved-rf-hiccup-head!`) supplies both. The reagent-slim client arm (`reagent2.impl.template/reject-reserved-rf-head!`) stamped `:head` **alone** — so a Spec-009-following diagnostic consumer got the complete offending hiccup vector for a server failure but `nil` for the same category client-side.

**Which side was wrong: the CODE.** The catalogue row already promised `:element`; #6431 kept that promise; only the reagent-slim client arm dropped it. This is a behavioural cross-host-friction bug, fixed by threading the whole hiccup vector to the reject so it can stamp `:element`. No `spec/009` edit was needed (the row was already correct) — so this PR does not touch the hot-zone.

- `reject-reserved-rf-head!` now takes `element` (required, not optional) and stamps it into ex-data.
- `parse-tag` / `cached-parse` / both call sites (`as-element` cached path, `reagent2.dom.server/emit-dom-vector`) thread the hiccup vector through. The value is used *only* to populate the payload — it takes no part in parsing and never affects the tag cache (the reject either throws or no-ops).
- **No `:require` on `re-frame.*` was added** — bundle isolation intact (gate below).

### rf2-pqbka — FrameDestroyedTags (NO CHANGE — already fixed on `main` by rf2-g8ict)

`rf2-pqbka` describes phantom `:rf.event/v` / `:rf.sub/query-v` slots in `FrameDestroyedTags`. Walking to the emit sites (not the catalogue), this is **already resolved on `origin/main`** by sibling bead **`rf2-g8ict`** (commit `4a800a6254`, merged after pqbka was filed):

- Phantom `:rf.event/v` **removed** from `FrameDestroyedTags`.
- `:rf.sub/query-v` is **not** phantom — `substrate/observation/throw-frame-destroyed!` stamps it (both the always-on `emit-error-both!` tags and the throw ex-data), matching its `:rf.error/observation-retry-exhausted` sibling.
- `spec/009` row reconciled **in lockstep** (the row cites g8ict).
- g8ict added the exact run-time conformance test pqbka demands: `implementation/ui/test/re_frame/ui/frame_destroyed_op_schema_jvm_test.clj` **slurps** `FrameDestroyedTags` from the markdown, drives all four real emits, asserts **declared-set == emitted-set both directions**, and pins `(not (contains? tags :rf.event/v))`.

The ruling pqbka deferred (bare vs qualified names) was **made by g8ict**: resolution (b) — the schema follows the bare-name emitters, no runtime change. The trivial `:recovery` dead-payload tail was handled by g8ict via documentation + a pinning assertion; the only residual micro-change would touch `subs.cljc`, which is **fenced** (held by PR #6454), so it is correctly left alone. Bead noted; recommend closing pqbka as resolved-by-g8ict.

## Quality gates

All foreground, run to completion, exit codes captured by redirect (never piped through tail/head).

| Gate | Result |
| --- | --- |
| `npm run test:cljs` — **red-before** (added the `:element` assertion, code unfixed) | **EXIT 1**, exactly one FAIL naming `unrecognised-reserved-head-fails-loud` at `template_reserved_head_cljs_test.cljs:53` (10258 tests). This is the per-bead red-before **and** the vacuity proof on the real lever. |
| `npm run test:cljs` — **green-after** (fix applied) | EXIT 0 — 10258 tests, 50642 assertions, 0 failures |
| `cd implementation/core && clojure -M:test` (parses the catalogue) | EXIT 0 — **2088 tests**, 10264 assertions, 0 failures |
| `cd implementation/ui && clojure -M:test` (pins pqbka's g8ict resolution) | EXIT 0 — 978 tests, 0 failures |
| `npm run test:reagent-slim:bundle-isolation` | EXIT 0 — PASS, 6 contracts / 25 sentinel checks, 0 warnings (no require leak) |
| `python scripts/check_keyword_catalogue_drift.py` | EXIT 0 |
| `python -m mkdocs build --strict` | EXIT 0 (INFO-only, pre-existing) |
| `python scripts/check_doc_slugs.py` | EXIT 0 (run separately — strict alone is not sufficient) |
| `scripts/check-no-hardcoded-paths.sh` | EXIT 0 — no personal/worktree paths in tracked files |

No new error id was minted (`:element` is an existing catalogue payload field already emitted by the JVM arm), so no Spec 009 / Spec-Schemas / always-on-axis co-edit is owed. Both hosts covered (`.cljs` client + JVM core/ui suites green).
