### PR TITLE
docs(EP): restore settled passages with dated errata per the freeze-meaning ruling (rf2-r7ahi)

### DIFF
--- a/docs/EP/EP-0032-re-frame-ui-reactivity-and-ownership.md
+++ b/docs/EP/EP-0032-re-frame-ui-reactivity-and-ownership.md
@@ -262,6 +262,27 @@ error by the ABI guard.
   finalization. The corrected law is normative in
   `spec/006-ReactiveSubstrate.md`; this EP's text above states it as
   corrected. The other five invariants were never in question.
+- **Original drain-quiescence wording preserved (2026-07-19, rf2-r7ahi).** The
+  host-checkpoint correction did not touch invariant 6 alone: PR #6393 reworded
+  three further settled passages in place from the original drain-quiescence
+  phrasing, and the Abstract summary carries the same drain → host-checkpoint
+  change. Those rewrites read as current truth above, but the freeze-meaning
+  ruling (rf2-r7ahi) requires the settled originals to stay visible, so they are
+  preserved here — `spec/006-ReactiveSubstrate.md` (host-checkpoint render
+  batching) remains the current normative truth:
+  - **Goals** originally read "committed push economics with *drain-quiescence
+    batching* and a test flush".
+  - **§One ViewCell per view** originally read "one `useSyncExternalStore` over a
+    scalar revision snapshot, one *notification per drain*".
+  - **§Push economics** originally read "Every queued event commits its own epoch
+    record inside the run-to-completion drain; *at quiescence each dirty cell
+    flushes exactly once and React performs one read/render batch for the whole
+    drain*, on a true microtask (never a macrotask that could let a torn frame
+    paint)".
+
+  The correction is factual — the shipped scheduler batches at the host
+  checkpoint, never at drain quiescence — but per the ruling it is recorded, not
+  applied by silently rewriting the settled prose.
 
 ## Open Issues
 


### PR DESCRIPTION
Implements the ruled **rf2-r7ahi** doctrine — (b) "freeze meaning, not bytes": a settled EP passage whose factual premise/scope/meaning changes must keep its original text with a dated correction recorded beside it, never silently rewritten.

## EP-0008 — already complete, untouched here
`rf2-0b9b0` (PR #6423) already landed the full owed work on `main`: the wholesale revert of the five in-place PR #6304 edits back to the pre-#6304 text, the single dated addendum under `### The ruling`, and follow-through items 4/5 (EP-0009 §Durability rule 3 semantic test + the EP-template sentence). Verified the current file is byte-identical to the pre-#6304 blob except for that addendum. Nothing remained, so EP-0008 is not modified in this PR.

## EP-0032 — the remaining work (this PR)
The #6426 merged-PR audit flagged three settled passages that PR #6393 reworded **in place** from the original drain-quiescence phrasing to host-checkpoint render batching, and #6426 left them on the "not verbatim-frozen" reasoning — which the freeze-meaning ruling does not grant as an exception:

1. the **Goals** bullet
2. **§One ViewCell per view**
3. **§Push economics**

Since the audit, a later `de-historicalise EP-0032 to PEP-standard form` commit reshaped the file again, folding the invariant-6 erratum into clean current-truth prose and consolidating the correction into one Resolved-Decisions entry. Rather than re-inject now-stale wording into that de-historicalised body, this PR takes the ruling's explicitly-sanctioned alternative for a document-wide change: **one honest dated erratum in Resolved Decisions that preserves the original settled clauses** of the three named passages (quoting each), and notes the Abstract summary and invariant 6 carry the same drain → host-checkpoint correction.

`spec/006-ReactiveSubstrate.md` remains the current normative truth. No EP status changed; no checker or policy expansion; no other EP, spec, or implementation file touched.

Found-vs-named: the ruling named 3 passages; the same drain → host-checkpoint change is present at 5 body locations (Abstract summary, Goals/Scope bullet, §One ViewCell, the six-invariants line, §Push economics). The six-invariants line already carries a dated correction (the "Invariant-6 boundary corrected" entry); the Abstract summary is the additional same-class passage, named in the new erratum.

## Quality gates
- `python scripts/check_doc_slugs.py` — exit 0
- `python scripts/check_ep_status_sync.py` — exit 0
- `python -m mkdocs build --strict` — exit 0
- `sh scripts/check-no-hardcoded-paths.sh` — exit 0 (portability gate OK)
- `implementation/ui` CLJS test gate — not applicable: `guide_truth_jvm_test.clj` pins EP-0030/EP-0034 by exact path, not EP-0008 or EP-0032 (verified), so this docs-only change touches no pinned surface.
