### PR TITLE
fix(ui): harvest custom-element declarations before view analysis for order-independent lowering (rf2-vxgfnd.141)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -17,7 +17,8 @@
             [re-frame.ui.compiler.build :as build]
             [re-frame.ui.compiler.env :as env]
             [re-frame.ui.fingerprint :as fingerprint]
-            [re-frame.ui.rules :as rules]))
+            [re-frame.ui.rules :as rules]
+            #?@(:clj [[re-frame.ui.compiler.harvest :as harvest]])))
 
 (def node-ops
   "The CLOSED op set — the AST-shape gate's vocabulary. `:frame-root` (S1c,
@@ -1830,7 +1831,19 @@
         ;; resolves the CURRENT build's declarations — never a process-global
         ;; last-writer-wins mirror that a sibling build could clobber between
         ;; this tag's declaration and this classification read.
-        properties (when custom? (build/element-properties tag))
+        ;;
+        ;; On the plain-JVM / SSR path there is no `:compile-prepare` hook to
+        ;; pre-seed the slice, and macros expand top-to-bottom, so a view
+        ;; expanded before a declaration below it would read an empty slice and
+        ;; lower a declared property to an attribute. Harvest this namespace's
+        ;; OWN literal declarations once, here, before classifying — making the
+        ;; verdict order-independent (rf2-vxgfnd.141, dimension 2). Under a real
+        ;; Shadow compile the build hook already seeded the slice, so this is a
+        ;; no-op there (`shadow-compile?`).
+        properties (when custom?
+                     #?(:clj (when-not (build/shadow-compile?)
+                               (harvest/ensure-namespace-harvested! (:ns e))))
+                     (build/element-properties tag))
         spread?    (spread-form? e props-form)
         spread-safe? (spread-safe-form? e props-form)]
     (when (and (some? props-form) (not (map? props-form))

--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -380,6 +380,16 @@
      (pass-open? (current-build-id))))
   ([build-id] (:pass-open? (get @state build-id empty-slice) false)))
 
+(defn shadow-compile?
+  "Whether an OWNED Shadow compiler-env carrier is bound — a real Shadow
+  build/watch/REPL compile, where the build hook's `:compile-prepare` harvest
+  (or the REPL's own top-to-bottom order) governs custom-element seeding. False
+  on the plain-JVM / SSR path, where no compiler env is bound and the harvest
+  must lazily read the ambient namespace's own source instead (rf2-vxgfnd.141).
+  Always false on CLJS (there is no compile-path host there)."
+  []
+  #?(:clj (boolean (validated-compiler-state)) :cljs false))
+
 ;; ---------------------------------------------------------------------------
 ;; Contribution (pure transitions)
 ;; ---------------------------------------------------------------------------
@@ -595,6 +605,38 @@
                         (sort-by str (keys registries)))]
     (::conflict outcome)))
 
+(defn- stage-element-checked
+  "Pure: admit `source`'s `tag` -> `decl` into `slice` under the ruled
+  cross-source conflict law, returning `[slice' conflict|nil]`. The barrier both
+  the ambient `contribute-element-checked!` and the pre-pass
+  `seed-shadow-elements` share, so no aggregation path can pick a merge-order
+  winner regardless of which route wrote the row. An `rf=`-equal duplicate is
+  idempotent; a contradiction from another live source (or a second
+  contradictory declaration in the same open pass of one ns) is refused without
+  writing, leaving the last-known-good slice untouched."
+  [slice source tag decl]
+  (let [other-decl (get (effective slice elements source) tag)
+        other-owner (get (effective slice element-declarations source) tag)
+        ;; Own STAGED row only: a second, contradictory declaration of the same
+        ;; tag in the same pass of the same ns. Committed/no-pass rows are the
+        ;; source replacing itself and must stay admissible.
+        own-decl (when (:pass-open? slice)
+                   (get-in slice [:staged source elements tag]))
+        conflict (cond
+                   (and (some? other-decl) (not (eq/rf= other-decl decl)))
+                   {:owner other-owner :declaration other-decl}
+
+                   (and (some? own-decl) (not (eq/rf= own-decl decl)))
+                   {:owner source :declaration own-decl}
+
+                   :else nil)]
+    (if conflict
+      [slice conflict]
+      [(-> slice
+           (write-slice element-declarations source tag source)
+           (write-slice elements source tag decl))
+       nil])))
+
 (defn contribute-element-checked!
   "Atomically contribute ONE custom-element declaration under the ruled
   cross-source conflict law (rf2-vxgfnd.143, delegated ruling 2026-07-15
@@ -622,28 +664,30 @@
   (let [outcome (atom nil)]
     (update-current-slice!
      (fn [slice]
-       (let [other-decl (get (effective slice elements source) tag)
-             other-owner (get (effective slice element-declarations source) tag)
-             ;; Own STAGED row only: a second, contradictory declaration of the
-             ;; same tag in the same pass of the same ns. Committed/no-pass rows
-             ;; are the source replacing itself and must stay admissible.
-             own-decl (when (:pass-open? slice)
-                        (get-in slice [:staged source elements tag]))
-             conflict (cond
-                        (and (some? other-decl) (not (eq/rf= other-decl decl)))
-                        {:owner other-owner :declaration other-decl}
-
-                        (and (some? own-decl) (not (eq/rf= own-decl decl)))
-                        {:owner source :declaration own-decl}
-
-                        :else nil)]
-         (if conflict
-           (do (reset! outcome {:conflict conflict}) slice)
-           (do (reset! outcome nil)
-               (-> slice
-                   (write-slice element-declarations source tag source)
-                   (write-slice elements source tag decl)))))))
+       (let [[slice' conflict] (stage-element-checked slice source tag decl)]
+         (reset! outcome (when conflict {:conflict conflict}))
+         slice')))
     @outcome))
+
+(defn seed-shadow-elements
+  "Purely PRE-STAGE harvested custom-element declarations into `build-state`'s
+  open scratch pass, BEFORE any view analyzes — the order-independence seam the
+  build hook uses at `:compile-prepare` (rf2-vxgfnd.141, dimension 2). Each
+  `[source tag decl]` triple is admitted under the SAME cross-source conflict
+  law as `contribute-element-checked!`: an `rf=`-equal duplicate co-exists, a
+  contradictory same-tag declaration is REFUSED here (the `ui/custom-element`
+  macro reports it with source coordinates when it later expands) so the slice
+  never carries a merge-order winner. A pure build-state transform because
+  `cljs.env/*compiler*` is not bound during hook execution; when no scratch pass
+  is open the build-state is returned unchanged."
+  [build-state seeded]
+  (if (get-in build-state [:compiler-env scratch-key])
+    (update-in build-state [:compiler-env scratch-key]
+               (fn [slice]
+                 (reduce (fn [s [source tag decl]]
+                           (first (stage-element-checked s source tag decl)))
+                         slice seeded)))
+    build-state))
 
 ;; ---------------------------------------------------------------------------
 ;; Pass boundaries

--- a/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
@@ -97,7 +97,8 @@
   It is currently wired only by the digest-probe build, not `:build-defaults`."
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
-            [re-frame.ui.compiler.build :as build]))
+            [re-frame.ui.compiler.build :as build]
+            [re-frame.ui.compiler.harvest :as harvest]))
 
 (def digest-sentinel
   "The unique fixed-width literal emitted by re-frame.ui.digest-carrier.
@@ -207,31 +208,41 @@
    #{}
    build-sources))
 
-(defn- recompiled-member-nss
-  "Declaring namespaces whose CLJS source Shadow 3.4.10 will actually compile.
+(defn- parallel-build?
+  "Whether Shadow schedules this build in parallel — output presence is then the
+  exact cache-hit / recompile signal."
+  [build-state]
+  (and (:executor build-state)
+       (not (false? (get-in build-state
+                            [:compiler-options :parallel-build])))))
 
-  At `:compile-prepare`, watch reset has already removed output for modified
-  and affected sources. Parallel compilation schedules precisely sources with
-  no retained output map; sequential compilation calls
+(defn- pass-recompiles-cljs?
+  "Whether Shadow 3.4.10 will actually (re)compile CLJS resource `resource-id`
+  this pass. At `:compile-prepare`, watch reset has already removed output for
+  modified and affected sources. Parallel compilation schedules precisely
+  sources with no retained output map; sequential compilation calls
   `generate-output-for-source`, which also recompiles retained outputs carrying
   warnings. Mirror those two Shadow branches rather than treating every graph
   member as dirty: warm cache-hit silence must preserve accepted registry rows."
-  [{:keys [build-sources sources output executor] :as build-state}]
-  (let [parallel? (and executor
-                       (not (false? (get-in build-state
-                                           [:compiler-options
-                                            :parallel-build]))))]
+  [{:keys [sources output] :as build-state} parallel? resource-id]
+  (let [{:keys [type]} (get sources resource-id)
+        prior-output (get output resource-id)]
+    (and (= :cljs type)
+         (if parallel?
+           (not (map? prior-output))
+           (or (nil? prior-output)
+               (seq (:warnings prior-output)))))))
+
+(defn- recompiled-member-nss
+  "Declaring namespaces whose CLJS source Shadow 3.4.10 will actually compile."
+  [{:keys [build-sources sources] :as build-state}]
+  (let [parallel? (parallel-build? build-state)]
     (reduce
      (fn [acc resource-id]
-       (let [{:keys [type ns provides]} (get sources resource-id)
-             prior-output (get output resource-id)
-             scheduled? (if parallel?
-                          (not (map? prior-output))
-                          (or (nil? prior-output)
-                              (seq (:warnings prior-output))))]
-         (if (and (= :cljs type) scheduled?)
-           (into acc (or provides (when ns #{ns})))
-           acc)))
+       (if (pass-recompiles-cljs? build-state parallel? resource-id)
+         (let [{:keys [ns provides]} (get sources resource-id)]
+           (into acc (or provides (when ns #{ns}))))
+         acc))
      #{}
      build-sources)))
 
@@ -637,6 +648,51 @@
           (publish-tree! candidate stable)))))
   build-state)
 
+;; ---------------------------------------------------------------------------
+;; Deterministic custom-element pre-seed (rf2-vxgfnd.141, dimension 2)
+;;
+;; Compile-time property lowering reads the `elements` slice at macroexpansion,
+;; and macros expand top-to-bottom, so a view expanded before its tag's
+;; `(ui/custom-element …)` declaration — or in a source that compiled before the
+;; declaring source, with no `:require` edge to order them — saw an empty slice
+;; and lowered a declared property to an HTML attribute. Reading each RECOMPILED
+;; UI source's top-level literal declarations here, at `:compile-prepare`, and
+;; staging them into the open pass BEFORE any view analyzes makes classification
+;; a pure function of the build's declarations rather than evaluation order.
+;; Restricted to recompiled sources: a warm cache-hit keeps its accepted rows
+;; (re-staging elements-only would evict its committed views at commit) and its
+;; declarations stay visible through the committed aggregate anyway.
+;; ---------------------------------------------------------------------------
+
+(defn- resource-source
+  "Source text of a Shadow CLJS resource: its already-loaded `:source` string,
+  else read from `:url` / `:file`. nil (a source we cannot read) makes the
+  harvest a graceful no-op for that member — the `ui/custom-element` macro
+  remains the authority."
+  [{:keys [source url file]}]
+  (cond
+    (string? source) source
+    url  (try (slurp url) (catch Throwable _ nil))
+    file (try (slurp file) (catch Throwable _ nil))
+    :else nil))
+
+(defn- harvest-seed
+  "The `[source tag decl]` triples for every RECOMPILED re-frame.ui-consumer
+  source scheduled this pass — the declarations that must seed the elements
+  slice before any view analyzes."
+  [{:keys [build-sources sources] :as build-state}]
+  (let [parallel? (parallel-build? build-state)]
+    (into []
+          (mapcat
+           (fn [resource-id]
+             (let [{:keys [ns] :as rc} (get sources resource-id)]
+               (when (and ns
+                          (pass-recompiles-cljs? build-state parallel? resource-id)
+                          (ui-cache-blocked-source? rc))
+                 (some->> (resource-source rc)
+                          (harvest/source-seed ns))))))
+          build-sources)))
+
 (defn hook
   "Shadow build hook. Configure once in `:build-defaults` as
   `:build-hooks [(re-frame.ui.compiler.build-hook/hook)]`."
@@ -672,6 +728,11 @@
                                         build-id
                                         (member-nss stamped)
                                         (recompiled-member-nss stamped))
+            ;; Pre-seed this pass's recompiled custom-element declarations into
+            ;; the open scratch BEFORE any view analyzes, so property lowering is
+            ;; order-independent (rf2-vxgfnd.141, dimension 2). Pure build-state
+            ;; transform — `cljs.env/*compiler*` is not bound during the hook.
+            (build/seed-shadow-elements (harvest-seed stamped))
             (assoc-in [:compiler-env build/scratch-key :pass-token]
                       pass-token)
             (assoc-in [:compiler-env build/scratch-key :compile-witness]

--- a/implementation/ui/src/re_frame/ui/compiler/harvest.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/harvest.clj
@@ -1,0 +1,248 @@
+(ns re-frame.ui.compiler.harvest
+  "Deterministic pre-seed of compile-time custom-element declarations.
+
+  A view's custom-element property lowering (property vs attribute) is decided
+  at MACROEXPANSION by reading the ambient build's `elements` slice through
+  `build/element-properties`. Because macros expand top-to-bottom, a view
+  expanded BEFORE its tag's `(ui/custom-element …)` declaration read an EMPTY
+  slice and lowered the prop to an HTML attribute; the same forms in the
+  opposite order lowered it to a JS property. Two source files with no `:require`
+  edge compiled in an arbitrary order and could differ the same way. That
+  violated deterministic compilation (rf2-vxgfnd.141, dimension 2).
+
+  This namespace closes that by reading each build source's TOP-LEVEL LITERAL
+  `(ui/custom-element …)` forms and seeding the `elements` slice BEFORE any view
+  analyzes, so classification is a pure function of the build's declarations and
+  NOT of evaluation order. It is a SYNTACTIC read, never a general interpreter:
+  the ruled grammar is top-level, literal and compile-resolvable (`:properties`
+  MUST be a literal set), so recognizing the exact `(<ui>/custom-element <kw>
+  <map>)` shape — and rejecting anything the macro would reject rather than
+  seeding it — is sound. A non-literal or malformed form is simply not seeded;
+  the `ui/custom-element` macro still expands and reports it with the
+  declaration's own source coordinates.
+
+  Two callers seed through it:
+
+  * the Shadow build hook, at `:compile-prepare`, folds every RECOMPILED UI
+    source's declarations into the open pass's disposable scratch
+    (`build/seed-shadow-elements`) — a pure build-state transform, since
+    `cljs.env/*compiler*` is not bound during hook execution;
+
+  * the plain-JVM / SSR path (which has no `:compile-prepare`) harvests the
+    ambient namespace's own source ONCE, lazily, the first time a view in it
+    classifies a custom element (`ensure-namespace-harvested!`), seeding through
+    the ambient `build/contribute-element-checked!`.
+
+  Both routes admit through the ONE cross-source conflict barrier
+  (`build/contribute-element-checked!` / `build/seed-shadow-elements`): an
+  `rf=`-equal duplicate co-exists; a contradictory same-tag declaration is
+  refused here and reported by the macro with source coordinates. JVM-only: it
+  reads source text at build time and is never emitted into any bundle."
+  (:require [clojure.java.io :as io]
+            [clojure.tools.reader :as rdr]
+            [clojure.tools.reader.reader-types :as rt]
+            [re-frame.ui.compiler.build :as build]))
+
+;; ---------------------------------------------------------------------------
+;; ns-form alias analysis — how THIS source names re-frame.ui/custom-element
+;; ---------------------------------------------------------------------------
+
+(def ^:private custom-element-fqn 're-frame.ui/custom-element)
+(def ^:private ui-lib 're-frame.ui)
+
+(defn- lib-spec-seq
+  "Every `:require` / `:require-macros` library spec in an `(ns …)` form."
+  [ns-form]
+  (mapcat (fn [clause]
+            (when (and (seq? clause)
+                       (contains? #{:require :require-macros} (first clause)))
+              (rest clause)))
+          (rest ns-form)))
+
+(defn- ui-heads
+  "The set of head symbols that, in THIS source, name
+  `re-frame.ui/custom-element`: the fully-qualified symbol always, plus each
+  `:as` alias of `re-frame.ui`, plus a bare `custom-element` when it is
+  `:refer`red from `re-frame.ui`. Reading the source's OWN `(ns …)` aliases is
+  what makes recognition robust across `[re-frame.ui :as ui]`,
+  `re-frame.ui/custom-element`, and `:refer [custom-element]` without resolving
+  vars."
+  [ns-form]
+  (reduce
+   (fn [heads spec]
+     (let [[lib & opts] (if (sequential? spec) spec [spec])
+           opts (apply hash-map opts)]
+       (if (= lib ui-lib)
+         (cond-> heads
+           (symbol? (:as opts))
+           (conj (symbol (name (:as opts)) "custom-element"))
+           (and (sequential? (:refer opts))
+                (some #{'custom-element} (:refer opts)))
+           (conj 'custom-element))
+         heads)))
+   #{custom-element-fqn}
+   (lib-spec-seq ns-form)))
+
+;; ---------------------------------------------------------------------------
+;; Literal-form recognition — mirrors the macro's `:properties` grammar checks
+;; ---------------------------------------------------------------------------
+
+(defn- valid-tag? [tag]
+  (and (keyword? tag) (nil? (namespace tag))
+       (clojure.string/includes? (name tag) "-")))
+
+(defn- valid-properties? [props]
+  (and (set? props)
+       (every? #(and (keyword? %) (nil? (namespace %))) props)))
+
+(defn- declaration
+  "If `form` is a recognized, LITERAL `(<ui>/custom-element <tag> <opts>)` — the
+  exact shape the macro accepts — return `{:tag tag :properties #{…}}`, else
+  nil. Anything the macro would reject (non-literal tag, non-map opts, unknown
+  option, non-literal `:properties`) is NOT recognized here: the macro still
+  expands the form and reports the error with its own coordinates, so the
+  declaration never silently seeds a bad classification (rf2-vxgfnd.141)."
+  [heads form]
+  (when (and (seq? form) (contains? heads (first form)))
+    (let [[_ tag opts] form]
+      (when (and (valid-tag? tag)
+                 (map? opts)
+                 (empty? (remove #{:properties} (keys opts))))
+        (let [props (get opts :properties #{})]
+          (when (valid-properties? props)
+            {:tag tag :properties props}))))))
+
+;; ---------------------------------------------------------------------------
+;; Tolerant source reading — well-formed CLJS/CLJC source, top-level forms only
+;; ---------------------------------------------------------------------------
+
+(defn- alias-map
+  "The `alias -> namespace` map for `::alias/kw` resolution, read from the ns
+  form's `:as` clauses. Populated before reading the body so an auto-resolved
+  keyword in a form preceding a declaration does not abort the read."
+  [ns-form]
+  (reduce (fn [m spec]
+            (let [[lib & opts] (if (sequential? spec) spec [spec])
+                  {:keys [as]} (apply hash-map opts)]
+              (if (and lib (symbol? as)) (assoc m as lib) m)))
+          {}
+          (lib-spec-seq ns-form)))
+
+(defn- read-all-forms
+  "Read every top-level form of `src` (a CLJS/CLJC/CLJ source string) tolerantly:
+  reader conditionals resolve under `:cljs`, every tagged literal (`#js`,
+  `#uuid`, custom) degrades to its value, `#=` eval is disabled, and `::alias/kw`
+  resolves through `aliases`. A read failure ends the scan gracefully — the
+  `ui/custom-element` macro remains the authority, so a source we cannot fully
+  read merely falls back to evaluation-order behaviour rather than breaking the
+  build. Returns the vector of forms read."
+  [^String src aliases]
+  (let [reader (rt/string-push-back-reader src)
+        eof (Object.)
+        opts {:eof eof :read-cond :allow :features #{:cljs}}]
+    (binding [rdr/*default-data-reader-fn* (fn [_tag v] v)
+              rdr/*read-eval* false
+              rdr/*alias-map* aliases]
+      (loop [forms []]
+        (let [form (try (rdr/read opts reader)
+                        (catch Throwable _ eof))]
+          (if (identical? form eof)
+            forms
+            (recur (conj forms form))))))))
+
+(defn- ns-form [forms]
+  (first (filter #(and (seq? %) (= 'ns (first %))) forms)))
+
+(defn declarations-in-source
+  "PURE: every literal custom-element declaration in CLJS/CLJC/CLJ source string
+  `src`, as `[{:tag … :properties #{…}} …]` in source order. Resolves the
+  source's own `(ns …)` aliases so the recognized head is exactly how that
+  source spells `re-frame.ui/custom-element`. Order in the returned vector is
+  irrelevant to classification (the conflict barrier makes duplicates idempotent
+  and contradictions refuse); it is kept only for deterministic seeding."
+  [src]
+  (let [;; A cheap first pass gets the ns form (and thus aliases) so the full
+        ;; read can resolve ::alias/kw; the ns form itself never carries one.
+        head-forms (read-all-forms src {})
+        nsf (ns-form head-forms)
+        forms (if nsf (read-all-forms src (alias-map nsf)) head-forms)
+        heads (if nsf (ui-heads nsf) #{custom-element-fqn})]
+    (into [] (keep #(declaration heads %)) forms)))
+
+;; ---------------------------------------------------------------------------
+;; Seeding — the two callers
+;; ---------------------------------------------------------------------------
+
+(defn source-seed
+  "The `[source tag decl]` triples `build/seed-shadow-elements` folds into an
+  open scratch pass, for one build source declaring namespace `ns-sym` with
+  `src` text. `ns-sym` is the declaring source (the conflict/eviction unit)."
+  [ns-sym src]
+  (mapv (fn [{:keys [tag properties]}]
+          [ns-sym tag {:properties properties}])
+        (declarations-in-source src)))
+
+;; --- plain-JVM / SSR lazy own-source harvest -------------------------------
+
+(defonce ^{:private true
+           :doc "Namespaces already harvested on the plain-JVM/SSR path, keyed
+  [build-id ns-sym]. The declarations are stable per source-load, so a namespace
+  is read at most once per build identity. Cleared by `reset-harvested!` for
+  test isolation; never consulted on the Shadow pass path (that seeds from the
+  build graph at `:compile-prepare`)."}
+  harvested (atom #{}))
+
+(defn reset-harvested! []
+  (reset! harvested #{})
+  nil)
+
+(defn- classpath-source
+  "Source text of namespace `ns-sym` located on the classpath, or nil. Tries the
+  CLJS/CLJC/CLJ extensions in the order the compiler would."
+  [ns-sym]
+  (let [base (-> (str ns-sym)
+                 (clojure.string/replace "-" "_")
+                 (clojure.string/replace "." "/"))]
+    (some (fn [ext]
+            (when-let [url (io/resource (str base ext))]
+              (slurp url)))
+          [".cljc" ".cljs" ".clj"])))
+
+(defn- current-file-source
+  "Source text of the file currently being compiled (`*file*`), or nil. Covers
+  a source loaded off the classpath (e.g. `clojure.main <script>`); nil for the
+  REPL sentinel `NO_SOURCE_PATH`, whose forms are already ordered."
+  []
+  (let [f *file*]
+    (when (and (string? f) (not= f "NO_SOURCE_PATH"))
+      (or (let [file (io/file f)]
+            (when (.isFile file) (slurp file)))
+          (when-let [url (io/resource f)] (slurp url))))))
+
+(defn- ns->source
+  "The source text for namespace `ns-sym`: the classpath resource (the exact
+  file the compiler loaded) with the file currently being compiled as a
+  fallback for off-classpath sources. nil (REPL forms, generated namespaces)
+  makes the harvest a graceful no-op."
+  [ns-sym]
+  (or (classpath-source ns-sym)
+      (current-file-source)))
+
+(defn ensure-namespace-harvested!
+  "Plain-JVM / SSR path: seed namespace `ns-sym`'s OWN literal custom-element
+  declarations into the ambient build ONCE, before its views classify. Reads the
+  namespace's source from the classpath and admits each declaration through the
+  ambient conflict barrier (`build/contribute-element-checked!`), so a view
+  expanded before a declaration textually below it still classifies against the
+  whole source. Idempotent, memoized per [build-id ns-sym]; a no-op when the
+  source cannot be located (a REPL/generated namespace, whose forms are already
+  ordered)."
+  [ns-sym]
+  (when (symbol? ns-sym)                 ; a missing ns must never memoize a
+    (let [key [(build/current-build-id) ns-sym]]  ; nil key that poisons every ns
+      (when-not (contains? @harvested key)
+        (swap! harvested conj key)
+        (when-let [src (ns->source ns-sym)]
+          (doseq [{:keys [tag properties]} (declarations-in-source src)]
+            (build/contribute-element-checked! ns-sym tag {:properties properties}))))))
+  nil)

--- a/implementation/ui/test/re_frame/ui/compiler_harvest_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_harvest_jvm_test.clj
@@ -1,0 +1,88 @@
+(ns re-frame.ui.compiler-harvest-jvm-test
+  "Unit tests for the custom-element source harvest (rf2-vxgfnd.141, dimension 2).
+
+  `declarations-in-source` is a PURE syntactic read: it recognizes the exact
+  literal `(<ui>/custom-element <tag> <opts>)` shape — resolving how the source's
+  own `(ns …)` aliases spell `re-frame.ui/custom-element` — and rejects anything
+  the macro would reject rather than seeding it. These tests pin the recognition
+  and the rejection so the harvest can never seed a classification the macro
+  would not, nor miss one it would."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ui.compiler.harvest :as harvest]))
+
+(defn- decls [src] (harvest/declarations-in-source src))
+
+(deftest recognizes-aliased-head
+  (let [src "(ns app.a (:require [re-frame.ui :as ui]))
+             (ui/custom-element :x-card {:properties #{:model :help-text}})"]
+    (is (= [{:tag :x-card :properties #{:model :help-text}}] (decls src)))))
+
+(deftest recognizes-fully-qualified-head
+  (let [src "(ns app.a (:require [re-frame.ui]))
+             (re-frame.ui/custom-element :x-badge {:properties #{:count}})"]
+    (is (= [{:tag :x-badge :properties #{:count}}] (decls src)))))
+
+(deftest recognizes-referred-head
+  (let [src "(ns app.a (:require [re-frame.ui :refer [custom-element]]))
+             (custom-element :x-tag {:properties #{:value}})"]
+    (is (= [{:tag :x-tag :properties #{:value}}] (decls src)))))
+
+(deftest bare-alias-only-matches-that-spelling
+  ;; With only `:as ui`, a bare `custom-element` (unreferred) is NOT the macro
+  ;; and must not be harvested — nor a foreign `other/custom-element`.
+  (let [src "(ns app.a (:require [re-frame.ui :as ui] [other.lib :as other]))
+             (ui/custom-element :x-real {:properties #{:model}})
+             (custom-element :x-bare {:properties #{:nope}})
+             (other/custom-element :x-foreign {:properties #{:nope}})"]
+    (is (= [{:tag :x-real :properties #{:model}}] (decls src)))))
+
+(deftest empty-properties-declaration-is-recognized
+  (let [src "(ns app.a (:require [re-frame.ui :as ui]))
+             (ui/custom-element :x-plain {:properties #{}})
+             (ui/custom-element :x-empty {})"]
+    (is (= [{:tag :x-plain :properties #{}}
+            {:tag :x-empty :properties #{}}]
+           (decls src)))))
+
+(deftest finds-declarations-regardless-of-position
+  ;; A declaration textually BELOW a view is exactly the dimension-2 defect; the
+  ;; harvest must find it wherever it sits.
+  (let [src "(ns app.a (:require [re-frame.ui :as ui :refer [defview]]))
+             (defview v [] [:x-card {:model \"m\"}])
+             (ui/custom-element :x-card {:properties #{:model}})"]
+    (is (= [{:tag :x-card :properties #{:model}}] (decls src)))))
+
+(deftest rejects-what-the-macro-would-reject
+  (testing "non-literal :properties (a symbol) is not seeded"
+    (let [src "(ns app.a (:require [re-frame.ui :as ui]))
+               (ui/custom-element :x-dyn {:properties some-var})"]
+      (is (= [] (decls src)))))
+  (testing "unknown option is not seeded"
+    (let [src "(ns app.a (:require [re-frame.ui :as ui]))
+               (ui/custom-element :x-opt {:properties #{:m} :events #{:go}})"]
+      (is (= [] (decls src)))))
+  (testing "a tag without '-' is not a custom element and is not seeded"
+    (let [src "(ns app.a (:require [re-frame.ui :as ui]))
+               (ui/custom-element :plain {:properties #{:m}})"]
+      (is (= [] (decls src)))))
+  (testing "qualified property keywords are not seeded"
+    (let [src "(ns app.a (:require [re-frame.ui :as ui]))
+               (ui/custom-element :x-q {:properties #{:ns/q}})"]
+      (is (= [] (decls src))))))
+
+(deftest tolerates-reader-conditionals-tagged-literals-and-alias-keywords
+  ;; A well-formed CLJC source with `#?`, `#js`, and `::alias/kw` in forms
+  ;; surrounding the declaration must still yield the declaration — the harvest
+  ;; reads under `:cljs`, degrades unknown tags to their value, and resolves
+  ;; alias keywords from the ns form.
+  (let [src "(ns app.a (:require [re-frame.ui :as ui] [other.lib :as o]))
+             (def opts #?(:cljs #js {:a 1} :clj {:a 1}))
+             (def k ::o/thing)
+             (ui/custom-element :x-cond {:properties #{:model}})"]
+    (is (= [{:tag :x-cond :properties #{:model}}] (decls src)))))
+
+(deftest source-seed-carries-the-declaring-namespace
+  (let [src "(ns app.a (:require [re-frame.ui :as ui]))
+             (ui/custom-element :x-card {:properties #{:model}})"]
+    (is (= [['app.decl :x-card {:properties #{:model}}]]
+           (harvest/source-seed 'app.decl src)))))

--- a/implementation/ui/test/re_frame/ui/custom_element_harvest_hook_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/custom_element_harvest_hook_jvm_test.clj
@@ -1,0 +1,106 @@
+(ns re-frame.ui.custom-element-harvest-hook-jvm-test
+  "Clean-build ORDER DETERMINISM across TWO SOURCES on the Shadow build path
+  (rf2-vxgfnd.141, dimension 2).
+
+  Two source files with no `:require` edge compile in an arbitrary order, so a
+  consumer view could analyze before the declaring source's macro ran and lower a
+  declared property to an attribute. The build hook closes this at
+  `:compile-prepare` by harvesting every recompiled UI source's top-level literal
+  `(ui/custom-element …)` forms and staging them into the open pass BEFORE any
+  view analyzes. This file drives the REAL hook over a two-source graph in BOTH
+  `:build-sources` orders and asserts the consumer view emits the SAME
+  classification — declaration source first or consumer source first.
+
+  The declaring source's own macro is never run here; the ONLY thing that can
+  declare `:ce-two` is the prepare-time harvest reading its `:source`. So this
+  is a clean red-before lever of its own: revert the `build/seed-shadow-elements`
+  call in `build-hook/hook` and both orders classify `:model` as an attribute
+  (the emitted node carries no `:rf.ui/property-props`), while every other proof
+  stays green. The observable is the emitted node, not merely that nothing threw."
+  (:require [cljs.env :as cljs-env]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.ui.compiler :as compiler]
+            [re-frame.ui.compiler.build :as build]
+            [re-frame.ui.compiler.build-hook :as build-hook]
+            [re-frame.ui.compiler.harvest :as harvest]
+            [re-frame.ui.tree :as tree]))
+
+(use-fixtures :each
+  (fn [f]
+    (build/reset-build!)
+    (harvest/reset-harvested!)
+    (try (f) (finally (build/reset-build!) (harvest/reset-harvested!)))))
+
+(def ^:private decl-source
+  "(ns app.decl (:require [re-frame.ui :as ui]))
+   (ui/custom-element :ce-two {:properties #{:model}})")
+
+(defn- graph
+  "A clean-build (version-0, all-scheduled) two-source graph: `app.decl`
+  declares `:ce-two`, `app.view` consumes it. `order` fixes which resource is
+  first in `:build-sources`."
+  [build-id order]
+  {:shadow.build/build-id build-id
+   :shadow.build/stage :compile-prepare
+   :compiler-env {}
+   :executor (Object.)
+   :analyzer-passes []
+   :build-sources (vec order)
+   :sources {'app.decl {:ns 'app.decl :provides #{'app.decl} :type :cljs
+                        :requires #{'re-frame.ui} :source decl-source}
+             'app.view {:ns 'app.view :provides #{'app.view} :type :cljs
+                        :requires #{'re-frame.ui} :source ""}}
+   :output {}})
+
+(defn- classify-consumer
+  "Under `prepared`'s compiler-env (which the hook seeded at prepare),
+  macroexpand + eval a consumer defview using `:ce-two` and render it; return the
+  emitted element node. `view-ns` is a fresh namespace so repeated runs never
+  collide."
+  [prepared view-ns]
+  (let [compiler (atom (assoc (:compiler-env prepared)
+                              :shadow.build.cljs-bridge/state prepared))
+        template [:ce-two {:model "m" :data-x "d"}]]
+    (binding [cljs-env/*compiler* compiler
+              *ns* (create-ns view-ns)]
+      (eval (compiler/defview*
+             (with-meta (list 'defview 'probe [] template) {:line 1})
+             {} 'probe (list [] template)))
+      (first (:children (tree/render @(resolve (symbol (str view-ns) "probe")) {}))))))
+
+(deftest two-source-order-permutations-classify-identically
+  (let [decl-first (do (build/reset-build!) (harvest/reset-harvested!)
+                       (classify-consumer
+                        (build-hook/hook (graph :order-a ['app.decl 'app.view]))
+                        'probe.decl-first))
+        view-first (do (build/reset-build!) (harvest/reset-harvested!)
+                       (classify-consumer
+                        (build-hook/hook (graph :order-b ['app.view 'app.decl]))
+                        'probe.view-first))]
+    (testing "declaration source compiled first: :model is a property"
+      (is (= #{:model} (:rf.ui/property-props decl-first)))
+      (is (= {:model "m" :data-x "d"} (:attrs decl-first))))
+    (testing "consumer source compiled first: :model is STILL a property (harvest)"
+      (is (= #{:model} (:rf.ui/property-props view-first))))
+    (testing "the two orders emit an identical property classification — the AC"
+      (is (= (:rf.ui/property-props decl-first)
+             (:rf.ui/property-props view-first))))))
+
+(deftest an-undeclared-tag-in-neither-source-stays-an-attribute
+  ;; The harvest seeds declared tags only; a tag no source declares must remain
+  ;; all-attributes (this is what makes "consulted-and-missing = undeclared"
+  ;; sound — after harvest, the absent classification is genuine, not a race).
+  (let [prepared (build-hook/hook (graph :order-c ['app.decl 'app.view]))
+        compiler (atom (assoc (:compiler-env prepared)
+                              :shadow.build.cljs-bridge/state prepared))
+        template [:ce-missing {:model "m"}]]
+    (binding [cljs-env/*compiler* compiler
+              *ns* (create-ns 'probe.undeclared)]
+      (eval (compiler/defview*
+             (with-meta (list 'defview 'probe [] template) {:line 1})
+             {} 'probe (list [] template)))
+      (let [node (first (:children (tree/render
+                                    @(resolve 'probe.undeclared/probe) {})))]
+        (is (nil? (:rf.ui/property-props node))
+            "an undeclared tag is not seeded -> attribute")
+        (is (= {:model "m"} (:attrs node)))))))

--- a/implementation/ui/test/re_frame/ui/custom_element_order_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/custom_element_order_jvm_test.clj
@@ -1,0 +1,71 @@
+(ns re-frame.ui.custom-element-order-jvm-test
+  "Clean-build ORDER DETERMINISM for custom-element property lowering on the
+  plain-JVM / SSR path (rf2-vxgfnd.141, dimension 2).
+
+  Property-vs-attribute classification is baked at MACROEXPANSION by reading the
+  ambient build's `elements` slice, and macros expand top-to-bottom. Before the
+  source harvest, a view expanded BEFORE its tag's `(ui/custom-element …)`
+  declaration read an EMPTY slice and lowered a declared property to an HTML
+  ATTRIBUTE; the same forms reversed lowered it to a JS PROPERTY. That is the
+  order dependence this file pins away: on the plain-JVM path there is no
+  `:compile-prepare` hook, so `analyze` harvests this namespace's own literal
+  declarations before classifying.
+
+  RED-BEFORE LEVER (this file's own): revert the `harvest/ensure-namespace-
+  harvested!` call in `analyze/analyze-element-props` and `below-view` /
+  `spread-below-view` classify `:model` as an attribute — `declaration-above-and-
+  below-classify-identically` and the markup assertions go red, and NO other
+  proof does. The observable asserted is the emitted classification itself
+  (`:rf.ui/property-props`, and property omission from SSR markup), never that
+  something merely threw."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.semantic :as semantic]
+            [re-frame.ui.tree :as tree]))
+
+;; --- declaration ABOVE its view -------------------------------------------
+(ui/custom-element :ce-order-above {:properties #{:model}})
+(defview above-view [] [:ce-order-above {:model "m" :data-x "d"}])
+
+;; --- declaration BELOW its view (the defect case) -------------------------
+(defview below-view [] [:ce-order-below {:model "m" :data-x "d"}])
+(ui/custom-element :ce-order-below {:properties #{:model}})
+
+;; --- a fully-qualified declaration BELOW its view -------------------------
+(defview below-fqn-view [] [:ce-order-fqn {:model "m"}])
+(re-frame.ui/custom-element :ce-order-fqn {:properties #{:model}})
+
+;; --- an UNDECLARED element stays all-attributes ---------------------------
+(defview undeclared-view [] [:ce-order-undeclared {:model "m" :data-x "d"}])
+
+(defn- element [view] (first (:children (tree/render view {}))))
+(defn- markup-attrs [view] (:attrs (first (semantic/normalize (tree/render view {})))))
+
+(deftest declaration-above-and-below-classify-identically
+  (testing "declaration ABOVE the view classifies :model as a property"
+    (is (= #{:model} (:rf.ui/property-props (element above-view)))))
+  (testing "declaration BELOW the view classifies :model IDENTICALLY (harvest)"
+    (is (= #{:model} (:rf.ui/property-props (element below-view)))))
+  (testing "a fully-qualified declaration below the view is found too"
+    (is (= #{:model} (:rf.ui/property-props (element below-fqn-view)))))
+  (testing "the two orders produce the same classification — the AC"
+    (is (= (:rf.ui/property-props (element above-view))
+           (:rf.ui/property-props (element below-view)))))
+  (testing "the undeclared name is an attribute regardless of harvest"
+    (is (nil? (:rf.ui/property-props (element undeclared-view))))))
+
+(deftest declared-property-is-omitted-from-ssr-markup-in-either-order
+  ;; The server cannot set a property, so a property-classified name is OMITTED
+  ;; from markup (applied at hydration). Whether the declaration sits above or
+  ;; below the view, the observable markup must be identical.
+  (doseq [[label view] [["above" above-view] ["below" below-view]]]
+    (let [attrs (markup-attrs view)]
+      (testing (str "declaration " label ": :model omitted, :data-x kept")
+        (is (not (contains? attrs "model")) "kebab property name absent from markup")
+        (is (not (contains? attrs "modelValue")))
+        (is (= "d" (get attrs "data-x")) "the plain attribute survives")))))
+
+(deftest undeclared-element-keeps-every-name-as-markup
+  (let [attrs (markup-attrs undeclared-view)]
+    (is (= "m" (get attrs "model")) "undeclared -> :model is a plain attribute")
+    (is (= "d" (get attrs "data-x")))))

--- a/implementation/ui/test/re_frame/ui/custom_element_spread_parity_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/custom_element_spread_parity_jvm_test.clj
@@ -1,0 +1,58 @@
+(ns re-frame.ui.custom-element-spread-parity-jvm-test
+  "LITERAL-vs-SPREAD property-manifest parity, order-independent (rf2-vxgfnd.141,
+  dimension 2 AC: 'Literal props and dynamic `ui/spread` use the same
+  authoritative property manifest').
+
+  A literal prop is classified at COMPILE time (the harvested/analyzed `elements`
+  slice); a `ui/spread` prop is classified at RENDER time (the runtime ledger the
+  emitted `register-custom-element!` populates). Two manifests, one truth: for a
+  declared tag both must classify a name identically — property here, property
+  there — so the SSR markup a literal view and a spread view emit for the same
+  declared tag agree. The declaration sits BELOW both views, so the literal path
+  depends on the source harvest; the parity therefore also witnesses order
+  determinism.
+
+  RED-BEFORE LEVER: revert the plain-JVM harvest seam in `analyze` and the
+  LITERAL view classifies `:model` as an attribute while the SPREAD view still
+  reads the runtime ledger as a property — the two manifests DISAGREE and
+  `literal-and-spread-agree-on-the-declared-property` goes red. The observable is
+  the emitted `:rf.ui/property-props` and the normalized markup, not a throw."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.rules :as rules]
+            [re-frame.ui.semantic :as semantic]
+            [re-frame.ui.tree :as tree]))
+
+;; Views ABOVE their declaration — the literal path relies on the harvest.
+(defview literal-view [] [:ce-parity {:model "m" :data-x "d"}])
+(defview spread-view  [] [:ce-parity (ui/spread {:model "m" :data-x "d"})])
+(ui/custom-element :ce-parity {:properties #{:model}})
+
+(defn- element [view] (first (:children (tree/render view {}))))
+(defn- markup [view] (:attrs (first (semantic/normalize (tree/render view {})))))
+
+(deftest literal-and-spread-agree-on-the-declared-property
+  (let [literal (:rf.ui/property-props (element literal-view))
+        spread  (:rf.ui/property-props (element spread-view))]
+    (testing "the literal (compile-time) manifest classifies :model a property"
+      (is (= #{:model} literal)))
+    (testing "the spread (runtime-ledger) manifest classifies :model a property"
+      (is (= #{:model} spread)))
+    (testing "the two manifests agree — the parity AC"
+      (is (= literal spread)))
+    (testing "and both agree with the runtime ledger the register call populated"
+      (is (= #{:model} (rules/custom-element-properties :ce-parity))))))
+
+(deftest literal-and-spread-emit-identical-ssr-markup
+  ;; The property is omitted from server markup (applied at hydration); the plain
+  ;; attribute survives. Literal and spread must produce the SAME markup for the
+  ;; same declared tag.
+  (let [lit (markup literal-view)
+        spr (markup spread-view)]
+    (is (not (contains? lit "model")) "literal: :model omitted (property)")
+    (is (not (contains? spr "model")) "spread: :model omitted (property)")
+    (is (= "d" (get lit "data-x")) "literal: :data-x kept (attribute)")
+    (is (= "d" (get spr "data-x")) "spread: :data-x kept (attribute)")
+    (is (= (select-keys lit ["data-x" "model"])
+           (select-keys spr ["data-x" "model"]))
+        "literal and spread emit the same property/attribute split")))


### PR DESCRIPTION
## Dimension 2 — clean-build order determinism (rf2-vxgfnd.141)

Compile-time custom-element property lowering depended on declaration **evaluation order**. A view expanded **before** `(ui/custom-element :x-card {:properties #{:model}})` lowered `:model` to an HTML **attribute**; the same forms reversed lowered it to a JS **property**. Two sources with no `:require` edge compiled in an arbitrary order and could differ the same way.

### Fix
New `re-frame.ui.compiler.harvest` reads each build source's **top-level literal** `(ui/custom-element …)` forms and seeds the `elements` slice **before any view analyzes**, so classification is a pure function of the build's declarations, not evaluation order. It is a **syntactic** read of the ruled literal grammar (resolving the source's own `(ns …)` aliases) — not a general interpreter: anything the macro would reject is not seeded, so *consulted-and-missing = genuinely undeclared*.

Two callers seed through it, both admitting through the one cross-source conflict barrier (`stage-element-checked`, extracted from `contribute-element-checked!`):

- **Shadow build hook** — at `:compile-prepare`, `harvest-seed` folds every **recompiled** UI source's declarations into the open pass via the pure `build/seed-shadow-elements`. Restricted to recompiled sources: a warm cache-hit keeps its accepted rows (re-staging elements-only would evict its committed views at commit), and its declarations remain visible through the committed aggregate anyway.
- **plain-JVM / SSR path** (no `:compile-prepare`) — `analyze` harvests the ambient namespace's own source **once**, lazily, before its views classify (`ensure-namespace-harvested!`), gated by `build/shadow-compile?` so it is a no-op under a real Shadow compile.

The digest dimension (dimension 1) already shipped in #6432 and is untouched. This PR delivers dimension 2 only; dimension 3 (declaration-edit warm staleness) follows in a stacked PR.

### Bans honoured
No declaration-before-use ceremony, no per-write runtime fallback classification, no public API change, no per-render registry lookup.

### Proof (causal cases, each with its own lever)
- `custom-element-order-jvm-test` — declaration **above vs below** the view classifies identically (plain-JVM). Lever: the `analyze` seam.
- `custom-element-harvest-hook-jvm-test` — two-source **order permutations** (`:build-sources` [decl view] vs [view decl]) classify identically (Shadow hook). Lever: `build/seed-shadow-elements`.
- `custom-element-spread-parity-jvm-test` — literal-prop and `ui/spread` agree on the same property manifest, declaration below the views.
- `compiler-harvest-jvm-test` — pure recognition + rejection unit tests.

Each proof asserts the **observable** classification (`:rf.ui/property-props`, property omission from SSR markup), never merely that something threw. Red-before verified per dimension with an isolated lever: disabling the `analyze` seam reds only the plain-JVM proofs; disabling the hook seam reds only the two-source proof.

### Gates (green)
- `implementation/ui` JVM: **994 tests**, 0 failures
- `npm run test:cljs`: **10259 tests**, 0 failures
- `npm run test:browser`: **482 tests**, 0 failures
- `npm run test:elision`: PASS
- `npm run test:perf-bundle`: PASS (off 625078 / on 625863 chars — no regression)