### PR TITLE
fix(ci): run the adapter-disposition guard unconditionally in verify-readme-links (rf2-2718r)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -507,6 +507,24 @@ jobs:
       - name: Validate README inventories (layout-map <-> disk + count claims)
         run: python scripts/check_readme_inventories.py --verbose
 
+      # Adapter disposition (Mike, 2026-07-17; source of record EP-0030 §Resolved
+      # Decisions): `re-frame.ui` is a NEW, EXPERIMENTAL substrate offered
+      # alongside the adapters; Reagent, reagent-slim, and UIx live on as
+      # first-class, actively-supported adapters; ONLY Helix is removed. An
+      # earlier "frozen compatibility adapters / reagent-slim removed / only
+      # taught view layer" shape had propagated into planning, implementor,
+      # source-comment, and synthesis authorities — dispatching from any of them
+      # would have removed or downgraded a supported surface. This guard scans a
+      # closed roster of ACTIVE authorities for that superseded shape. Pure
+      # Python stdlib — no extra deps.
+      # The guard scans a fixed cross-repo roster, not the diff, so it runs
+      # unconditionally (rf2-2718r).
+      - name: Self-test the adapter-disposition guard (rf2-vxgfnd.290)
+        run: python scripts/check_adapter_disposition.py --self-test --verbose
+
+      - name: Guard the current adapter disposition
+        run: python scripts/check_adapter_disposition.py --verbose --ci
+
   # rf2-vxgfnd.135 — the pre-publication re-frame.ui synthesis guide is
   # tracked and authoritative, but intentionally does not enter MkDocs until
   # S6. Give exactly guide/** + active drafts/** their own link/anchor pass,
@@ -548,22 +566,6 @@ jobs:
 
       - name: Guard the synthesis plan's S0 coverage-pass authority
         run: python scripts/check_synthesis_plan_authority.py --verbose
-
-      # Adapter disposition (Mike, 2026-07-17; source of record EP-0030 §Resolved
-      # Decisions): `re-frame.ui` is a NEW, EXPERIMENTAL substrate offered
-      # alongside the adapters; Reagent, reagent-slim, and UIx live on as
-      # first-class, actively-supported adapters; ONLY Helix is removed. An
-      # earlier "frozen compatibility adapters / reagent-slim removed / only
-      # taught view layer" shape had propagated into planning, implementor,
-      # source-comment, and synthesis authorities — dispatching from any of them
-      # would have removed or downgraded a supported surface. This guard scans a
-      # closed roster of ACTIVE authorities for that superseded shape. Pure
-      # Python stdlib — no extra deps.
-      - name: Self-test the adapter-disposition guard (rf2-vxgfnd.290)
-        run: python scripts/check_adapter_disposition.py --self-test --verbose
-
-      - name: Guard the current adapter disposition
-        run: python scripts/check_adapter_disposition.py --verbose --ci
 
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -972,6 +972,39 @@ test('synthesis-docs job runs the opt-in link scan and focused guide truth fixtu
   assert.match(aggregator, /- synthesis-docs\r?\n/);
 });
 
+// rf2-2718r — the adapter-disposition guard scans a FIXED cross-repo roster
+// (ACTIVE_AUTHORITIES: EP-0030, spec/004-Views.md, implementation/README.md,
+// skills/…), not the diff. Conditional execution keyed to a diff classifier is
+// a category mismatch for a guard that scans a fixed inventory — a PR editing a
+// roster file may not fire the guard that pins it (the same inventory<->trigger
+// bug class as rf2-d9v3n / rf2-rf7gu). The ruled fix (option (e)) moves the
+// guard out of the surface-gated synthesis-docs job into the UNCONDITIONAL
+// verify-readme-links job so it runs on every PR, dissolving the roster<->
+// classifier sync problem with zero machinery. These arms pin the wiring:
+// verify-readme-links must carry BOTH guard invocations and synthesis-docs must
+// carry NONE. A future PR un-moving or gutting the wiring fails here (this file
+// runs under the unconditional js-harness-self-tests job's test:script-policy).
+test('adapter-disposition guard runs UNCONDITIONALLY in verify-readme-links, not synthesis-docs (rf2-2718r)', () => {
+  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+  const readmeLinks = jobBlock(workflow, 'verify-readme-links');
+  assert.match(
+    readmeLinks,
+    /python scripts\/check_adapter_disposition\.py --self-test --verbose/,
+    'verify-readme-links must self-test the adapter-disposition guard (unconditional job)',
+  );
+  assert.match(
+    readmeLinks,
+    /python scripts\/check_adapter_disposition\.py --verbose --ci/,
+    'verify-readme-links must run the adapter-disposition guard (unconditional job)',
+  );
+  const synthesis = jobBlock(workflow, 'synthesis-docs');
+  assert.doesNotMatch(
+    synthesis,
+    /check_adapter_disposition/,
+    'the surface-gated synthesis-docs job must no longer carry the fixed-roster guard (rf2-2718r moved it)',
+  );
+});
+
 // rf2-f79t8 (a) — workflow-level shape: jvm-core + cljs must be
 // job-level gated (needs + if), NOT trigger-filtered, and the
 // pull_request trigger must stay unfiltered so the aggregator is always


### PR DESCRIPTION
## What

`scripts/check_adapter_disposition.py` scans a **fixed cross-repo roster** (`ACTIVE_AUTHORITIES`: EP-0030, `spec/004-Views.md`, `implementation/README.md`, `skills/…`), not the diff — yet it ran only inside the **surface-gated synthesis-docs** job. A PR editing one of those roster files could therefore skip the very guard that pins it. Conditional execution keyed to a diff classifier is a category mismatch for a guard that scans a fixed inventory — the same inventory↔trigger bug class as rf2-d9v3n / rf2-rf7gu.

**Ruled fix (option (e), Fable/Mike 2026-07-19):** move the two guard steps **verbatim** out of `synthesis-docs` into the always-on **`verify-readme-links`** job (unconditional — no `needs`/`if:`, already provisions Python 3.12 + `pip install -r requirements.txt`, already in the required-checks aggregator). The classifier in `report-changed-surfaces.sh` is **untouched**; no roster-keyed trigger, no cross-language sync ratchet, no new job — with the guard unconditional there is no second list to keep in sync. Coverage becomes total and permanent (every roster file + every future roster addition + edits to the guard itself), at ~1s per PR.

## Changes

- `.github/workflows/test.yml` — moved the "Self-test the adapter-disposition guard (rf2-vxgfnd.290)" and "Guard the current adapter disposition" steps verbatim from `synthesis-docs` to `verify-readme-links` (appended after the README-inventory steps), carrying the existing rationale comment block plus one line noting the move.
- `implementation/scripts/_changed-surfaces.test.cjs` — added one workflow-shape arm (via the existing `jobBlock` helper) asserting `verify-readme-links` contains both guard command lines and `synthesis-docs` contains none. Runs under `test:script-policy`, so a future PR un-moving the wiring fails its own CI.

**Red-before (mandated):** the arm was written first and run against the unmoved workflow — it failed (`verify-readme-links must self-test the adapter-disposition guard`), then passed after the move.

## Quality gates

All run locally in the worktree, foreground, to completion:

- `npm run test:script-policy` → exit 0 (27 sub-gates green; `changed-surfaces tests: 174 passed` incl. the new arm; `lint-workflow-policy: 4 passed`; `docs-workflow-policy: 5 passed`; `ai/-tracking-ratchet teeth: 8 passed`)
- `npm run test:script-helpers` → exit 0 (10 sub-gates green)
- `python scripts/check_adapter_disposition.py --self-test --verbose` → exit 0 (all cases passed)
- `python scripts/check_adapter_disposition.py --verbose --ci` → exit 0 (adapter disposition intact across 10 authorities — no drift)
- `.github/workflows/test.yml` parses as valid YAML (56 jobs); `scripts/check-no-hardcoded-paths.sh` → exit 0

`shellcheck` is not installed locally (CI runs it); no `.sh` files were touched, so no exec-bit concern.
