### PR TITLE
docs(spec): name resource-only ViewCells and the root-owned arm in the frame-destroy victim contract (rf2-vxgfnd.300)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -3240,9 +3240,11 @@
     cell))
 
 (defn teardown-frame!
-  "Frame-destroy sweep: transition every currently-connected ViewCell observing
-  frame `frame-id`, plus every still-disconnected root-owned ViewCell whose last
-  published site values name it, to `:dead` (03 §4 dead-cell lifecycle). Each
+  "Frame-destroy sweep: transition every currently-connected ViewCell whose
+  retained subscription targets OR resource-incarnation records name frame
+  `frame-id` (resource ownership is not read observation), plus every still-
+  disconnected root-owned ViewCell whose last published site values name it, to
+  `:dead` (03 §4 dead-cell lifecycle). Each
   matched cell's leases are detached, its pending notification dropped, and
   its retained interval proven an unmount (`:unmounted {:proof
   :host-teardown}`) — so a subsequent read/probe on such a cell follows the

--- a/implementation/ui/test/re_frame/ui/reactive_frame_teardown_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_frame_teardown_cljs_test.cljc
@@ -3,9 +3,11 @@
 
   core's `frame/destroy-frame!` fires the named cleanup hook
   `:ui/on-frame-destroyed!` (registered in `re-frame.ui.frames`), which sweeps
-  every currently-connected ViewCell observing the destroyed frame to `:dead`
-  (03 §4 dead-cell lifecycle): leases detached, pending notification dropped,
-  the retained interval proven an unmount (`:unmounted {:proof :host-teardown}`).
+  every currently-connected ViewCell whose retained subscription targets OR
+  resource-incarnation records name the destroyed frame (resource ownership is
+  not read observation) to `:dead` (03 §4 dead-cell lifecycle): leases detached,
+  pending notification dropped, the retained interval proven an unmount
+  (`:unmounted {:proof :host-teardown}`).
 
   Before this wiring `teardown!` had ZERO callers: a destroyed frame left its
   mounted cells LIVE, so the sub-cache teardown's disposal notification marked

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -658,8 +658,12 @@ exact-token teardown cascade described below is the sole executable exception.
    the unified teardown projection, unregister per-actor handlers, and emit
    `:rf.machine.lifecycle/destroyed` with `:reason :parent-frame-destroyed`.
 4. **Compiled-view observer teardown** via `:ui/on-frame-destroyed!` — when
-   `day8/re-frame2-ui` is present, transition connected ViewCells observing this exact
-   frame to dead and release their leases while the sub-cache is still live.
+   `day8/re-frame2-ui` is present, transition the bounded victim set to dead and release
+   their leases while the sub-cache is still live: every currently-connected ViewCell whose
+   retained subscription targets OR resource-incarnation records name this frame (resource
+   ownership is not read observation), PLUS every still-disconnected but React-retained
+   root-owned ViewCell whose last published site values (retained subscription targets /
+   resource reservations) name it.
 5. **Publish lifecycle-dead.** CAS-flip `:destroyed?` only while the claimed incarnation
    token still matches. From this point public dispatch recovers as a no-op, public
    subscribe recovers to `nil`, and both emit the production-survivable


### PR DESCRIPTION
## What

Fixes `rf2-vxgfnd.300` — the frame-destroy victim-set understatement in the source-of-truth spec plus two docstring carriers. Sibling to `rf2-vxgfnd.295` (#6462), which fixed the four code-comment carriers of the same defect; this closes the three higher-value carriers outside that surface.

The connected victim arm is built from `cell-retained-frame?`, whose union is **(committed subscription targets = observation) OR (`:extra-frame-incarnations` resource tokens)** — so a **connected resource-only cell IS a victim**. Three carriers still said only *"observing"* the destroyed frame, which reads to omit the resource-only case (resource ownership is explicitly not observation).

## Sites (3 — matches the bead; tree sweep confirmed no fourth carrier)

1. **`spec/002-Frames.md` step 4 (NORMATIVE, highest value)** — carried the connected-arm understatement AND additionally **omitted the disconnected React-retained root-owned arm entirely**. Both fixed: the connected arm now names the full union, and the disconnected root-owned arm is restored.
2. **`reactive.cljc` `teardown-frame!` docstring opener** — aligned with its own body, which already explains `cell-retained-frame?`'s union.
3. **`reactive_frame_teardown_cljs_test.cljc` test-ns docstring** — same phrasing aligned.

Wording matched verbatim-in-spirit to #6462's four sites so the corpus stays consistent. **Prose/docstring only — no runtime change** to `teardown-frame!` / `cell-retained-frame?`.

## Code evidence

`cell-retained-frame?` returns `(boolean (or observation? extra?))` where `observation?` scans committed subscription targets naming the frame and `extra?` derives from `(:extra-frame-incarnations st)`. `teardown-frame!` builds `victims (into hidden connected)` — the two-arm structure the corrected prose describes. Pinned by existing fixtures `resource-only-cells-are-discoverable-while-connected-and-hidden` (connected resource-only) and `frame-destroy-reaps-an-activity-hidden-cell` (disconnected).

## Quality gates

- `cd implementation/ui && clojure -M:test` — **978 tests, 18701 assertions, 0 failures, 0 errors** (includes both cited fixtures).
- `python -m mkdocs build --strict` — exit 0.
- `python scripts/check_doc_slugs.py` — exit 0 (run separately: strict alone is not sufficient).
- `scripts/check-no-hardcoded-paths.sh` — OK.

Closes rf2-vxgfnd.300.