### PR TITLE
fix(core): keep sub-error query vectors raw at production egress, per the #6441 ruling (rf2-px0i9)

### DIFF
--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -136,6 +136,79 @@
     :rf.error/no-such-sub
     :rf.error/observation-on-change-failed})
 
+;; ---- raw query-vector identity on the always-on error :event slot --------
+;;
+;; #6441 / rf2-zwgqe (RULED — option c, accepted fail-open, documented): a
+;; subscription QUERY VECTOR is IDENTITY — the sub-cache key (Spec 006), the
+;; skip-dedup key, the reactive-graph edge endpoint. Identity is structurally
+;; public to every layer that touches the cache, so it is NEVER redacted at the
+;; classification chokepoint; it egresses VERBATIM on EVERY query-vector-bearing
+;; slot, INCLUDING "the always-on error `:query-v` / `:event` slots" (the
+;; ruling's own words). The only retained exception is the SEPARATE Spec 010
+;; schema-axis backstop (a `:sensitive?`-schema'd sub's validation-failure trace
+;; whole-slot scrubs `:rf.sub/query-v` in `re-frame.schemas.validate`), which
+;; this path does not touch.
+;;
+;; `dispatch-on-error!` runs `:event` through `elision/elide-wire-value` (the
+;; frame's durable app-db elision registry). For a DISPATCHED EVENT that is
+;; payload hygiene. For a SUB error `:event` is the query vector, and a concrete
+;; integer app-db path coincidentally matching a query-vector coordinate mutates
+;; identity at egress (`[1]` turns `[:patient/record "SECRET"]` into
+;; `[:patient/record :rf/redacted]`). The closed decision note WRONGLY reasoned
+;; an app-db path could not match a query vector; concrete integer paths prove
+;; otherwise (`elision_test.clj` pins that behaviour — it is correct for
+;; position-precise app-db elision and stays). So the always-on error path must
+;; skip elision for a query-vector `:event`.
+
+(def ^:private query-vector-event-categories
+  "Every production `:rf.error/*` category whose positional `:event` slot
+  carries a subscription QUERY VECTOR (raw IDENTITY per #6441 / rf2-zwgqe), NOT
+  a dispatched event. ENUMERATED STRUCTURALLY by reading each emit site — NOT
+  matched by a category-name prefix: a `sub-*` prefix check catches the
+  reactive/compute + input-fn categories but MISSES the observation-port
+  query-vector categories and the frame-destroyed subscribe realm, re-leaking
+  the exact rf2-s3n6h 'bound that does not bound' class.
+
+  A SUPERSET of [[sub-error-categories]] (whose narrower purpose is `[:sub id]`
+  SOURCE-COORD resolution). It ALSO includes the two observation-port
+  categories whose `:event` is the lease's query vector but whose source-coord
+  is deliberately NOT `[:sub]`-resolved:
+    - `:rf.error/read-after-release`         (`observation/read` on a released lease)
+    - `:rf.error/observation-retry-exhausted`(`observation/acquire!` — fired for a
+                                             frame it KNOWS is LIVE, so the
+                                             coincidental-path match genuinely bites)
+  Both pass the lease's `query-v` through `observation/emit-and-throw!` /
+  `observation/read`. The realm-AMBIGUOUS `:rf.error/frame-destroyed` is handled
+  separately in [[raw-identity-query-vector-event?]] — it carries a query vector
+  only in the `:subscribe` operation realm."
+  #{:rf.error/sub-input-fn-exception
+    :rf.error/sub-input-fn-bad-return
+    :rf.error/sub-exception
+    :rf.error/no-such-sub
+    :rf.error/observation-on-change-failed
+    :rf.error/read-after-release
+    :rf.error/observation-retry-exhausted})
+
+(defn- raw-identity-query-vector-event?
+  "STRUCTURAL discriminator: does the positional `event` slot for an `error-kw`
+  / `op` error record carry a subscription QUERY VECTOR that must egress
+  VERBATIM (raw IDENTITY per #6441 / rf2-zwgqe), rather than a dispatched EVENT
+  whose args keep their existing per-path app-db elision (payload hygiene)?
+
+  True for every category in [[query-vector-event-categories]], and for the
+  realm-ambiguous `:rf.error/frame-destroyed` ONLY in the `:subscribe`
+  operation realm — a captured / superseded subscribe passes the attempted
+  query vector as `:event` (the record carries `:op :subscribe`, stamped by
+  `subs/emit-frame-destroyed-recovery!` and `router/emit-frame-destroyed!`),
+  whereas a `:dispatch` / `:dispatch-sync` passes a dispatched event that keeps
+  its elision. Keyed on `=`, never `identical?`, on the keyword operands (a
+  `.cljc` `identical?` keyword compare is JVM-only sound, CLJS-unreachable —
+  #6365)."
+  [error-kw op]
+  (or (contains? query-vector-event-categories error-kw)
+      (and (= :rf.error/frame-destroyed error-kw)
+           (= :subscribe op))))
+
 (defn- error-source-coord
   "Resolve the `{:ns :file :line}` source-coord for the failing `id` of an
   `error-kw` category, pivoting on the registry kind the `id` was
@@ -272,14 +345,27 @@
                               (throw e))))]
        ;; Generation/source resolution is a callback-bearing stage.
        (when (trace/continuation-live?)
-         (let [;; Per-path wire-walker: paths flagged `:sensitive?` / `:large?`
+         (let [;; #6441 / rf2-zwgqe: a subscription QUERY VECTOR is raw IDENTITY
+               ;; on the always-on error `:event` slot — it egresses VERBATIM,
+               ;; NEVER app-db-elided (a concrete integer path coincidentally
+               ;; matching a query-vector coordinate would otherwise mutate
+               ;; identity). Enumerated STRUCTURALLY (see
+               ;; [[raw-identity-query-vector-event?]] /
+               ;; [[query-vector-event-categories]]), not by a category-name
+               ;; prefix. A dispatched EVENT keeps its per-path elision below.
+               raw-identity-event? (raw-identity-query-vector-event?
+                                     error-kw (:op attrs))
+               ;; Per-path wire-walker: paths flagged `:sensitive?` / `:large?`
                ;; via the per-frame `:rf.runtime/elision` registry get their
-               ;; per-path substitutions.
-               elided-event (try
-                              (elision/elide-wire-value event {:frame frame-id})
-                              (catch #?(:clj Throwable :cljs :default) e
-                                (when (trace/continuation-live?)
-                                  (throw e))))
+               ;; per-path substitutions. Skipped for a raw-identity query
+               ;; vector, which egresses verbatim.
+               elided-event (if raw-identity-event?
+                              event
+                              (try
+                                (elision/elide-wire-value event {:frame frame-id})
+                                (catch #?(:clj Throwable :cljs :default) e
+                                  (when (trace/continuation-live?)
+                                    (throw e)))))
                ;; Lift the component-attributed slots into the always-on
                ;; record so an off-box shipper sees WHICH interceptor / cofx
                ;; failed in production (the `:event-id` slot carries the EVENT
@@ -314,13 +400,17 @@
              ((:fan-out registry) record trace/continuation-live?)
              ;; EP-0015 §9: frame-owned observability sink route. Pass the RAW
              ;; event so the sink projects under its own egress profile rather
-             ;; than double-eliding. Late-bound to avoid a require cycle.
+             ;; than double-eliding. `raw-identity-event?` (#6441 / rf2-zwgqe)
+             ;; rides through so the sink keeps a sub query vector VERBATIM on
+             ;; THIS second egress route too — otherwise `project-error-record`
+             ;; app-db-walks `:event` and the same coincidental integer path
+             ;; redacts identity here. Late-bound to avoid a require cycle.
              (when (trace/continuation-live?)
                (when-let [route-error! (late-bind/get-fn-cached
                                          :observability/route-error)]
                  (try
                    (route-error! error-kw event event-id frame-id exception
-                                 elapsed-ms time nil)
+                                 elapsed-ms time nil raw-identity-event?)
                    (catch #?(:clj Throwable :cljs :default) e
                      (when (trace/continuation-live?)
                        (throw e)))))))))))

--- a/implementation/core/src/re_frame/observability.cljc
+++ b/implementation/core/src/re_frame/observability.cljc
@@ -239,22 +239,35 @@
   Fail-closed: a NO-OP when `frame-id` is unresolved or declares no
   `:errors` policy. Returns nil. Called from `error-emit/dispatch-on-error!`
   via the `:observability/route-error` late-bind hook, ALONGSIDE the
-  always-on corpus-wide error-listener fan-out."
-  [error-kw event event-id frame-id exception elapsed-ms time correlation]
-  (let [observability (frame-observability frame-id)
-        entries       (:errors observability)]
-    (when (seq entries)
-      (let [record (cond-> {:kind       :rf.observe/error
-                            :frame      frame-id
-                            :error      error-kw
-                            :event-id   event-id
-                            :event      event
-                            :exception  exception
-                            :elapsed-ms elapsed-ms
-                            :time       time}
-                     (some? correlation) (assoc :correlation correlation))]
-        (route-stream! frame-id record entries))))
-  nil)
+  always-on corpus-wide error-listener fan-out.
+
+  `raw-event?` (trailing, default false — #6441 / rf2-zwgqe) marks `:event` as
+  a subscription QUERY VECTOR: raw IDENTITY that egresses VERBATIM, never
+  app-db-elided. When set, the record carries `:rf.observe/raw-event?` so
+  `re-frame.projection/project-error-record` keeps `:event` raw on this sink
+  route rather than policy-walking it (a concrete integer app-db path
+  coincidentally matching a query-vector coordinate would otherwise mutate
+  identity here, exactly as it did on the corpus-wide record). The 8-arity
+  keeps every dispatched-event caller unchanged (elided as before)."
+  ([error-kw event event-id frame-id exception elapsed-ms time correlation]
+   (route-error! error-kw event event-id frame-id exception elapsed-ms time
+                 correlation false))
+  ([error-kw event event-id frame-id exception elapsed-ms time correlation raw-event?]
+   (let [observability (frame-observability frame-id)
+         entries       (:errors observability)]
+     (when (seq entries)
+       (let [record (cond-> {:kind       :rf.observe/error
+                             :frame      frame-id
+                             :error      error-kw
+                             :event-id   event-id
+                             :event      event
+                             :exception  exception
+                             :elapsed-ms elapsed-ms
+                             :time       time}
+                      (some? correlation) (assoc :correlation correlation)
+                      raw-event?          (assoc :rf.observe/raw-event? true))]
+         (route-stream! frame-id record entries))))
+   nil))
 
 ;; ---- non-event union record route (EP-0008) -------------------------------
 ;;

--- a/implementation/core/src/re_frame/projection.cljc
+++ b/implementation/core/src/re_frame/projection.cljc
@@ -318,16 +318,30 @@
 
 (defn- project-error-record
   [record opts elision-opts]
-  (let [base (select-keys record error-summary-keys)
+  (let [;; #6441 / rf2-zwgqe: a subscription QUERY VECTOR rides `:event` as raw
+        ;; IDENTITY — it egresses VERBATIM, never app-db-elided (a concrete
+        ;; integer path coincidentally matching a query-vector coordinate would
+        ;; mutate identity). `error-emit/dispatch-on-error!` (the caller) marks
+        ;; the record with `:rf.observe/raw-event?`; keep `:event` raw here on
+        ;; the sink route, exactly as the corpus-wide record does. The marker is
+        ;; neither a summary nor a tree key, so it is dropped from the projected
+        ;; output (never delivered to a sink).
+        raw-event? (:rf.observe/raw-event? record)
+        base (select-keys record error-summary-keys)
         ;; Tree-shaped slots → walker. The `:event` slot is REGISTRATION-owned
         ;; (EP-0015): apply the event handler's marks before the
-        ;; frame-policy walk. `:tags` is frame-policy-only (it is the generic
-        ;; non-event tree-lift from `route-error-record!`).
+        ;; frame-policy walk — UNLESS it is a raw-identity query vector, which
+        ;; passes through verbatim. `:tags` is frame-policy-only (it is the
+        ;; generic non-event tree-lift from `route-error-record!`).
         with-tree (reduce
                     (fn [acc k]
                       (if (contains? record k)
-                        (assoc acc k (if (= k :event)
+                        (assoc acc k (cond
+                                       (and (= k :event) raw-event?)
+                                       (get record k)
+                                       (= k :event)
                                        (project-event-slot (get record k) elision-opts)
+                                       :else
                                        (walk-slot (get record k) elision-opts)))
                         acc))
                     base

--- a/implementation/core/test/re_frame/sub_error_query_vector_identity_cljs_test.cljc
+++ b/implementation/core/test/re_frame/sub_error_query_vector_identity_cljs_test.cljc
@@ -1,0 +1,218 @@
+(ns re-frame.sub-error-query-vector-identity-cljs-test
+  "rf2-px0i9 — honor raw query-vector IDENTITY on the always-on production
+  sub-error egress, per the #6441 / rf2-zwgqe ruling.
+
+  RULED (option c, accepted fail-open, documented): a subscription query
+  vector is IDENTITY — the sub-cache key (Spec 006), the skip-dedup key, the
+  reactive-graph edge endpoint. It is structurally public and NEVER redacted at
+  the classification chokepoint; it egresses VERBATIM on every
+  query-vector-bearing slot, INCLUDING the always-on error `:query-v` / `:event`
+  slots. The only retained exception is the SEPARATE Spec 010 schema-axis
+  backstop (a `:sensitive?`-schema'd sub's validation-failure trace whole-slot
+  scrubs `:rf.sub/query-v` in `re-frame.schemas.validate`) — a different path,
+  untouched here.
+
+  THE DEFECT this file pins closed: `error-emit/dispatch-on-error!` ran every
+  `:event` argument through the frame's durable app-db elision registry. For a
+  dispatched event that is payload hygiene; for a SUB error `:event` is the
+  query vector, so a COINCIDENTAL concrete integer app-db path (`[1]`) redacted
+  a query-vector coordinate — `[:patient/record \"SECRET\"]` became
+  `[:patient/record :rf/redacted]` — mutating identity at egress. The generic
+  walker is CORRECT (integer paths matching vector coordinates is intended,
+  position-precise app-db elision — `elision_test.clj` pins it and it stays);
+  the fix is that the always-on error CALLER must SKIP elision for a
+  query-vector `:event`.
+
+  PROOF DISCIPLINE. Each defect test asserts the OBSERVABLE payload the
+  consumer receives on BOTH production egress routes — the corpus-wide
+  `register-error-listener!` record AND the frame-owned `:observability :errors`
+  sink — and, on the SAME frame + declaration + input, asserts the generic
+  walker STILL redacts (so the redaction machinery is intact and WOULD have
+  bitten — the fix is the caller skipping it, not a broken walker). The
+  regression pins show a genuine DISPATCHED-EVENT error still gets its app-db
+  elision on both routes.
+
+  Dual-runtime `*_cljs_test.cljc`: the shadow-cljs `:node-test`
+  (`npm run test:cljs`) AND the JVM `clojure -M:test` runner both pick it up.
+  Plain CLJC; no DOM dependency, no `identical?` on keyword literals."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.event-emit :as event-emit]
+            [re-frame.frame :as frame]
+            [re-frame.observability :as observability]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as ts]))
+
+(use-fixtures :each
+  (ts/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn []
+                (event-emit/clear-event-listeners!)
+                (error-emit/clear-error-listeners!)
+                (observability/clear-observability-sinks!))}))
+
+;; ---------------------------------------------------------------------------
+;; Shared harness. A LIVE frame `:probe` that (a) classifies the concrete
+;; integer app-db path `[1]` sensitive through the EP-0025 commit-plane effect
+;; path (the durable frame annotation is removed; this is the canonical durable
+;; classification the bead's reproduction names), and (b) declares an `:errors`
+;; observability sink so BOTH production egress routes are live. A corpus-wide
+;; listener and the sink both record every error they see.
+;; ---------------------------------------------------------------------------
+
+(def ^:private secret "SECRET")
+(def ^:private query-v [:patient/record secret])  ;; the sub's query vector — IDENTITY
+
+(defn- install-probe!
+  "Register a corpus-wide error listener under `:px0i9/listener` and an
+  `:errors` sink under `:px0i9/sink`, make the live `:probe` frame declaring
+  that sink, and classify the concrete integer path `[1]` sensitive on it.
+  Returns `[listener-seen sink-seen]` atoms."
+  []
+  (let [listener-seen (atom [])
+        sink-seen     (atom [])]
+    (rf/register-observability-sink! :px0i9/sink
+                                     (fn [record] (swap! sink-seen conj record)))
+    (rf/register-listener! :errors :px0i9/listener
+                           (fn [record] (swap! listener-seen conj record)))
+    (rf/make-frame {:id :probe
+                    :observability
+                    {:errors [{:sink :px0i9/sink
+                               :rf.egress/profile :rf.egress/off-box-observability}]}})
+    ;; Durable app-db classification at the CONCRETE integer path `[1]` — the
+    ;; coordinate that coincidentally matches query-vector position 1.
+    (frame/swap-runtime-db! :probe
+      (fn [rt] (elision/apply-classification-effects rt {:sensitive [[1]]})))
+    [listener-seen sink-seen]))
+
+(defn- emit!
+  "Drive `error-emit/dispatch-on-error!` exactly as a production error site
+  does — positional `[error-kw event event-id frame exception elapsed-ms time
+  attrs]`. `:time` is a fixed literal (never asserted — it is performance.now()
+  on CLJS, variable-length)."
+  ([error-kw event event-id] (emit! error-kw event event-id nil))
+  ([error-kw event event-id attrs]
+   (error-emit/dispatch-on-error!
+     error-kw event event-id :probe nil 0 1000 attrs)))
+
+(defn- only [xs] (is (= 1 (count xs))) (first xs))
+
+;; ---------------------------------------------------------------------------
+;; 1. The headline reproduction — :rf.error/sub-exception, BOTH routes.
+;; ---------------------------------------------------------------------------
+
+(deftest sub-exception-query-vector-egresses-raw-on-both-routes
+  (testing "the bead's exact reproduction: a durable classification at `[1]`,
+            `:rf.error/sub-exception` with `[:patient/record \"SECRET\"]`. The
+            generic walker STILL redacts the coordinate (machinery intact), yet
+            BOTH production egress routes ship the query vector VERBATIM."
+    (let [[listener-seen sink-seen] (install-probe!)]
+      ;; The generic walker redacts the coincidental integer coordinate — this
+      ;; is the value dispatch-on-error! USED to ship (and must no longer).
+      (is (= [:patient/record :rf/redacted]
+             (elision/elide-wire-value query-v {:frame :probe}))
+          "the walker still redacts `[1]` — position-precise app-db elision is
+           intact (elision_test.clj); the fix is the CALLER skipping it")
+      (emit! :rf.error/sub-exception query-v :patient/record)
+      ;; Route 1 — corpus-wide always-on listener record.
+      (let [r (only @listener-seen)]
+        (is (= :rf.error/sub-exception (:error r)))
+        (is (= :patient/record (:event-id r)))
+        (is (= query-v (:event r))
+            "corpus listener :event is the RAW query vector, VERBATIM (#6441)"))
+      ;; Route 2 — frame-owned observability sink (projected, still raw).
+      (let [r (only @sink-seen)]
+        (is (= :rf.observe/error (:kind r)))
+        (is (= :rf.error/sub-exception (:error r)))
+        (is (= query-v (:event r))
+            "observability sink :event is the RAW query vector, VERBATIM (#6441)")
+        (is (not (contains? r :rf.observe/raw-event?))
+            "the internal raw-event? marker is dropped from the projected record")))))
+
+;; ---------------------------------------------------------------------------
+;; 2. Every query-vector-bearing category — enumerated STRUCTURALLY, not by a
+;;    `sub-*` prefix. Includes the two observation-port categories the bead did
+;;    NOT name (`:rf.error/read-after-release`,
+;;    `:rf.error/observation-retry-exhausted`) but which pass the lease's query
+;;    vector on a LIVE frame — found by reading the emit sites.
+;; ---------------------------------------------------------------------------
+
+(deftest every-query-vector-category-egresses-raw
+  (testing "every category whose `:event` is a query vector ships it VERBATIM
+            on both routes — the sub-* categories AND the observation-port
+            categories a prefix check would miss (rf2-s3n6h)."
+    (doseq [cat [:rf.error/sub-input-fn-exception
+                 :rf.error/sub-input-fn-bad-return
+                 :rf.error/sub-exception
+                 :rf.error/no-such-sub
+                 :rf.error/observation-on-change-failed
+                 :rf.error/read-after-release
+                 :rf.error/observation-retry-exhausted]]
+      (let [[listener-seen sink-seen] (install-probe!)]
+        (emit! cat query-v :patient/record)
+        (is (= query-v (:event (only @listener-seen)))
+            (str cat " — corpus listener :event VERBATIM"))
+        (is (= query-v (:event (only @sink-seen)))
+            (str cat " — observability sink :event VERBATIM"))
+        ;; isolate the sinks/listeners between categories
+        (rf/unregister-observability-sink! :px0i9/sink)
+        (error-emit/clear-error-listeners!)
+        (rf/destroy-frame! :probe)))))
+
+;; ---------------------------------------------------------------------------
+;; 3. The realm-attributed :rf.error/frame-destroyed subscription case — a
+;;    prefix check misses it; the fix keys on the `:subscribe` operation realm.
+;; ---------------------------------------------------------------------------
+
+(deftest frame-destroyed-subscribe-realm-egresses-raw-dispatch-still-elides
+  (testing "`:rf.error/frame-destroyed` is realm-ambiguous: the `:subscribe`
+            realm carries a QUERY VECTOR (raw identity) while `:dispatch`
+            carries a dispatched EVENT (keeps elision). Both proven on the
+            corpus route on the SAME classified live frame."
+    (let [[listener-seen _] (install-probe!)]
+      ;; subscribe realm — a captured/superseded subscribe against a live
+      ;; successor: the query vector must ride VERBATIM.
+      (emit! :rf.error/frame-destroyed query-v :patient/record {:op :subscribe})
+      (is (= query-v (:event (only @listener-seen)))
+          "frame-destroyed :subscribe :event is the RAW query vector, VERBATIM"))
+    ;; dispatch realm — a dispatched event into a destroyed frame keeps its
+    ;; per-path app-db elision (payload hygiene).
+    (let [[listener-seen _] (install-probe!)]
+      (emit! :rf.error/frame-destroyed [:some/event secret] :some/event {:op :dispatch})
+      (is (= [:some/event :rf/redacted] (:event (only @listener-seen)))
+          "frame-destroyed :dispatch :event keeps its app-db elision"))))
+
+;; ---------------------------------------------------------------------------
+;; 4. Regression — a genuine DISPATCHED-EVENT error still elides on BOTH routes.
+;;    (You fixed sub-errors without breaking event hygiene.)
+;; ---------------------------------------------------------------------------
+
+(deftest dispatched-event-error-still-elides-on-both-routes
+  (testing "a `:rf.error/handler-exception` (a dispatched-event error) still
+            has its `[1]`-classified event arg elided on both egress routes —
+            the query-vector exception did NOT weaken event payload hygiene."
+    (let [[listener-seen sink-seen] (install-probe!)]
+      (emit! :rf.error/handler-exception [:some/event secret] :some/event)
+      (is (= [:some/event :rf/redacted] (:event (only @listener-seen)))
+          "corpus listener still elides the dispatched event's sensitive arg")
+      (is (= [:some/event :rf/redacted] (:event (only @sink-seen)))
+          "observability sink still elides the dispatched event's sensitive arg"))))
+
+;; ---------------------------------------------------------------------------
+;; 5. The generic walker's integer-path-matches-coordinate behaviour is
+;;    UNTOUCHED (the fix must not weaken position-precise app-db elision —
+;;    elision_test.clj's own pin lives in JVM; this is the CLJC restatement).
+;; ---------------------------------------------------------------------------
+
+(deftest integer-path-still-matches-vector-coordinate-in-generic-walker
+  (testing "`elide-wire-value` still redacts a concrete integer path against a
+            vector coordinate — the position-precise behaviour is correct and
+            preserved; only the always-on error CALLER opts out for a query
+            vector."
+    (let [_ (install-probe!)]
+      (is (= [:some/event :rf/redacted]
+             (elision/elide-wire-value [:some/event secret] {:frame :probe}))
+          "the walker redacts position 1 against decl `[1]` — unchanged"))))


### PR DESCRIPTION
Closes rf2-px0i9.

## The defect

Per the **#6441 / rf2-zwgqe** ruling (option c, accepted fail-open, documented), a subscription **query vector is IDENTITY** — the sub-cache key (Spec 006), the skip-dedup key, the reactive-graph edge endpoint — so it is never redacted at the classification chokepoint and egresses **verbatim on every query-vector-bearing slot, including "the always-on error `:query-v` / `:event` slots."**

`error-emit/dispatch-on-error!` ran **every** `:event` argument through the frame's durable app-db elision registry. For a dispatched event that is payload hygiene. For a **sub** error `:event` is the query vector, so a **coincidental concrete integer app-db path** (`[1]`) redacted a query-vector coordinate — `[:patient/record "SECRET"]` became `[:patient/record :rf/redacted]` — mutating identity at egress. The generic walker is correct (integer paths matching vector coordinates is intended, position-precise app-db elision — `elision_test.clj` pins it and it is untouched); the fix is that the **caller** must skip elision for a query-vector `:event`.

## The fix (one structural distinction, both egress routes)

A structural discriminator `raw-identity-query-vector-event?` (category + `:op` realm, keyed on `=` never `identical?`) decides "is this `:event` a sub query vector?" It skips app-db elision on **both** production egress routes:

- **Corpus-wide listener** record (`error_emit/dispatch-on-error!`) — the `:event` slot is the raw query vector.
- **Frame-owned observability sink** (`route-error!` → `project-error-record`) — a new trailing `raw-event?` marks the `:rf.observe/error` record so the projector keeps `:event` verbatim instead of policy-walking it (the same coincidental integer path would otherwise redact identity on this second route). The marker is dropped from the projected output.

Dispatched-event errors keep their existing app-db elision. The **Spec 010 schema-validation-failure scrub** (`:sensitive?`-schema'd sub's validation trace whole-slot-scrubs `:rf.sub/query-v` in `re-frame.schemas.validate`) is a separate path and is untouched. **No new error id, no spec/009 touch, no classification axis / taint tracking / blanket scrub / new policy.**

## Sub-error callers — found vs named (enumerated structurally, by reading each emit site)

The bead named the "sub" categories + "realm-attributed frame-destroyed subscription cases." Reading every `dispatch-on-error!` / `emit-error-both!` emit site found **more** query-vector-as-`:event` callers than named (the "beads under-count" pattern):

| Category | Emit site | In prior `sub-error-categories`? |
|---|---|---|
| `:rf.error/sub-input-fn-exception` | `subs/emit-input-fn-error!` | yes |
| `:rf.error/sub-input-fn-bad-return` | `subs/emit-input-fn-error!` | yes |
| `:rf.error/sub-exception` | `subs.cljc`, `subs/memo.cljc` | yes |
| `:rf.error/no-such-sub` | `subs.cljc` ×2, `observation/throw-no-such-sub!` | yes |
| `:rf.error/observation-on-change-failed` | `observation/drain-pending-disposals!` | yes |
| **`:rf.error/read-after-release`** | `observation/read` | **NO — found by reading** |
| **`:rf.error/observation-retry-exhausted`** | `observation/acquire!` (frame is `:live`) | **NO — found by reading** |
| `:rf.error/frame-destroyed` **(`:op :subscribe`)** | `subs/emit-frame-destroyed-recovery!` (captured), `router/emit-frame-destroyed!` (captured subscribe) | realm-keyed |

The two observation-port categories carry the lease's query vector but are deliberately **not** in `sub-error-categories` (that set is for `[:sub id]` source-coord resolution). `observation-retry-exhausted` fires for a frame it **knows is live**, so the coincidental-path match genuinely bites — a prefix check on `sub-*` would miss both and re-leak (the rf2-s3n6h "bound that does not bound" class). The fix therefore uses a dedicated `query-vector-event-categories` superset.

The realm-attributed `frame-destroyed :subscribe` case (captured/superseded subscribe against a **live** successor) is caught by the `:op` realm. The UI `emit-and-throw-frame-destroyed!` seam already redacts its captured payload body to `:rf/redacted` at source (rf2-01ihi) and always carries `:op`, so it never ships a raw query vector — unaffected.

## Out of scope — reported, not fixed (per the bead's "STOP and report if more than the narrow contract")

The **op-nil ordinary address-directed** `frame-destroyed` subscribe (`subs/emit-frame-destroyed-recovery!` 2-arity; `observation/throw-frame-destroyed!`) always fires against an **unresolvable** frame, so its `:event` fails closed to `:rf/redacted` via a **different** mechanism (**rf2-t55hxg.18**), not the coincidental-path-match on a live frame that this bead fixes. Making it raw would (a) reverse rf2-a2x2w's deliberate op-omission in `subs.cljc` (outside this error_emit surface) and (b) contradict rf2-t55hxg.18's fail-closed pin. That is a genuine **rf2-t55hxg.18 vs rf2-zwgqe** decision tension that needs a ruling — filed as follow-up, not resolved unilaterally.

## Quality gates

All foreground, run to completion, exit codes captured by redirect (never piped).

- `cd implementation/core && clojure -M:test` — **2093 tests**, 10314 assertions, 0 failures/0 errors. EXIT=0.
- `npm run test:cljs` — **10264 tests**, 50689 assertions, 0 failures/0 errors. EXIT=0.
- `npm run test:elision` — PASS (production 60/60 absent; control 60/60 present). EXIT=0.
- `npm run test:browser-prod-elision` — **113 tests**, 481 assertions, 0 failures/0 errors. EXIT=0.
- `python scripts/check_keyword_catalogue_drift.py` — EXIT=0 (only references existing catalogued `:rf.error/*` ids; no new id).
- **Vacuity probe**: flipped the corpus-listener verbatim assertion → the gate red-lit naming `sub-exception-query-vector-egresses-raw-on-both-routes`; restored byte-identical.
- **Dual-host**: the new `.cljc` proof runs on BOTH the JVM (`clojure -M:test`) and CLJS (`npm run test:cljs`) hosts; no `identical?` on keyword literals (#6365).

### Proof (`sub_error_query_vector_identity_cljs_test.cljc`, dual-host)

- **Red-before / after on both routes**: durable classification at `[1]`, `:rf.error/sub-exception` with `[:patient/record "SECRET"]`. On the same frame + declaration + input, `elision/elide-wire-value` **still** produces `[:patient/record :rf/redacted]` (walker intact — the value the caller used to ship), yet the corpus listener **and** the observability sink both receive `[:patient/record "SECRET"]` **verbatim**.
- **Every query-vector category** (all 7, incl. the two found-not-named observation-port ones) egresses verbatim on both routes.
- **frame-destroyed realm**: `:op :subscribe` verbatim; `:op :dispatch` still elided (`[:some/event :rf/redacted]`).
- **Regression pin**: a genuine `:rf.error/handler-exception` (dispatched-event) still elides its `[1]`-classified arg to `[:some/event :rf/redacted]` on both routes; `elide-wire-value`'s integer-path-matches-coordinate behaviour is unchanged.
