### PR TITLE
fix(ssr): move dev view annotation into reg-view so SSR hydration adopts server DOM (rf2-8vi4q)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/source_coord_parity_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/source_coord_parity_cljs_test.cljs
@@ -1,35 +1,31 @@
 (ns re-frame.source-coord-parity-cljs-test
-  "Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) and Spec
-  011 §Source-coord annotation under SSR: the CLJS-side Reagent
-  adapter's `format-source-coord` (in `re-frame.views`) and the JVM-
-  side SSR emitter's `format-view-source-coord` (in `re-frame.ssr`)
-  MUST produce byte-identical attribute values for the same input —
-  same id, same captured `:line` / `:column`. Pair tools that consume
-  the `data-rf2-source-coord` attribute parse the same shape regardless
-  of whether the HTML came from server-side rendering or client-side
-  Reagent — divergent formats would silently break the source-mapping
-  contract.
+  "Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) + §View
+  tagging contract (rf2-01il5): the CLJS-side Reagent adapter's
+  `format-source-coord` / `format-view-id` and the JVM-side
+  registration-boundary formatters (in
+  `re-frame.views.jvm-source-coord-annotation`) MUST produce byte-
+  identical attribute VALUES for the same input — same id, same captured
+  `:line` / `:column`. Pair tools that consume `data-rf2-source-coord` /
+  `data-rf-view` parse the same shape whether the HTML came from server-
+  side rendering or client-side Reagent — divergent formats would
+  silently break the source-mapping contract.
 
-  The parser fix in rf2-7g2q's re-frame2-pair work assumed both sides produce
-  the same `<ns>:<sym>:<line>:<col>` string for the same registration.
-  No test exercises both paths against a single fixture to confirm.
-  This file pins parity from the CLJS side (rf2-d4v7 sub-gap 3 /
-  rf2-o423 audit); the JVM-side counterpart lives at
-  `implementation/ssr/test/re_frame/source_coord_parity_test.clj`
-  and pins the same canonical literal against
-  `format-view-source-coord`.
+  rf2-8vi4q moved server-side annotation to the reg-view registration
+  boundary and added `data-rf-view` to the SSR side, so both hosts now
+  emit BOTH attributes. This file pins BOTH formatters from the CLJS side
+  (rf2-d4v7 sub-gap 3 / rf2-o423 audit); the JVM-side counterpart lives at
+  `implementation/ssr/test/re_frame/source_coord_parity_test.clj` and pins
+  the same canonical literals.
 
-  Strategy: each helper is `defn-` (private), but the var is
-  reachable via `#'ns/sym`. This CLJS test exercises
-  `re-frame.views/format-source-coord` against fixture inputs and
-  asserts it produces a single canonical literal. The companion JVM
-  test exercises `re-frame.ssr/format-view-source-coord` against the
-  SAME fixture and asserts the SAME canonical literal. If either
-  helper drifts from the canonical shape, the corresponding host's
-  test fails. The literal IS the byte-comparison point — both sides
-  pin it independently."
+  Strategy: this CLJS test exercises `re-frame.views/format-source-coord`
+  and `re-frame.views.source-coord-annotation/format-view-id` against
+  fixture inputs and asserts single canonical literals. The companion JVM
+  test exercises the JVM formatters against the SAME fixtures and asserts
+  the SAME literals. If either host's formatter drifts, its test fails.
+  The literals ARE the byte-comparison point — both sides pin independently."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.views]))
+            [re-frame.views]
+            [re-frame.views.source-coord-annotation :as source-coord]))
 
 ;; ---- the canonical attribute-value shape (shared spec) -------------------
 ;;
@@ -48,6 +44,9 @@
 
 ;; Canonical: <ns>=rf.parity-test, <sym>=sample-view, <line>=42, <col>=7.
 (def expected-attr "rf.parity-test:sample-view:42:7")
+
+;; `data-rf-view` is `(str id)` — a printed keyword, leading colon included.
+(def expected-view-id ":rf.parity-test/sample-view")
 
 ;; Degraded canonical: programmatic registration with no macro coords.
 (def fixture-meta-no-line-no-col
@@ -72,6 +71,17 @@
           (str "CLJS `format-source-coord` MUST produce the canonical "
                "<ns>:<sym>:<line>:<col> shape. Expected: "
                (pr-str expected-attr) " — got: " (pr-str cljs-output))))))
+
+;; ---- CLJS side: format-view-id pins the canonical data-rf-view value -----
+
+(deftest cljs-format-view-id-byte-identical-to-canonical
+  (testing "rf2-8vi4q — CLJS `format-view-id` produces `(str id)`, the same
+            `data-rf-view` value the JVM host now stamps. Both hosts emit
+            this attribute; before rf2-8vi4q only the client did."
+    (is (= expected-view-id (source-coord/format-view-id fixture-id))
+        (str "CLJS `format-view-id` MUST produce `(str id)`. Expected: "
+             (pr-str expected-view-id) " — got: "
+             (pr-str (source-coord/format-view-id fixture-id))))))
 
 ;; ---- CLJS side: degraded shape (no line / col) pins the canonical -------
 

--- a/implementation/adapters/reagent/test/re_frame/ssr_reg_view_hydration_adoption_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/ssr_reg_view_hydration_adoption_dom_cljs_test.cljs
@@ -96,9 +96,15 @@
 
 (defn- hydrate-over
   "Put `server-html` in a container, hydrate `tree` over it with REAL React,
-  report `{:complaints [str …] :node <root-div> :text \"…\"}`. `node` is the
-  `div.card` element as it stands AFTER hydration commits, read off the
-  container the caller captured its pre-hydration identity from."
+  and report — all captured BEFORE unmount / container teardown, so the
+  teardown-sensitive readings (`:connected?`, the attributes) are honest:
+
+    {:complaints [str …]   ;; hydration-relevant console output
+     :node       <div.card> ;; the root element ref (attributes survive detach)
+     :text       \"…\"       ;; textContent while mounted
+     :view-attr  \"…\"       ;; data-rf-view on the live node
+     :coord-attr \"…\"       ;; data-rf2-source-coord on the live node
+     :connected? bool}      ;; node.isConnected while mounted"
   [server-html tree]
   (let [container  (.createElement js/document "div")
         complaints (atom [])
@@ -123,10 +129,15 @@
                       (r/as-element [rf/frame-provider {:frame test-frame} tree])
                       #js {:onRecoverableError
                            (fn [err _info] (record! "onRecoverableError" err))}))))
-        (let [node (.querySelector container "div.card")
-              text (.-textContent container)]
+        ;; Read every teardown-sensitive value while the tree is still mounted.
+        (let [node       (.querySelector container "div.card")
+              text       (.-textContent container)
+              view-attr  (some-> node (.getAttribute "data-rf-view"))
+              coord-attr (some-> node (.getAttribute "data-rf2-source-coord"))
+              connected? (boolean (some-> node .-isConnected))]
           (act-fn (fn [] (some-> @root .unmount)))
-          {:complaints @complaints :node node :text text})
+          {:complaints @complaints :node node :text text
+           :view-attr view-attr :coord-attr coord-attr :connected? connected?})
         (finally
           (set! (.-error js/console) orig-error)
           (set! (.-warn js/console) orig-warn)
@@ -169,18 +180,18 @@
     (testing "rf2-8vi4q — the server markup a registered view now emits
               (root carries both annotations) hydrates SILENTLY, and both
               attributes are present on the live node after hydration."
-      (let [{:keys [complaints node text]}
+      (let [{:keys [complaints node text view-attr coord-attr connected?]}
             (hydrate-over (annotated-server-html)
                           [(rf/view test-view-id) "revenue"])]
         (is (empty? (hydration-complaints complaints))
             (str "React complained about hydrating the reg-view's own "
                  "server markup: " (pr-str (hydration-complaints complaints))))
         (is (some? node) "the root div.card exists after hydration")
-        (is (.-isConnected node) "the adopted node is still in the document")
-        (is (= expected-view (.getAttribute node "data-rf-view"))
+        (is (true? connected?) "the adopted node was in the document while mounted")
+        (is (= expected-view view-attr)
             "the live node carries the view-id annotation (client stamped it,
              and it matched the server ⇒ clean adoption)")
-        (is (= expected-coord (.getAttribute node "data-rf2-source-coord"))
+        (is (= expected-coord coord-attr)
             "the live node carries the source-coord annotation")
         (is (= "revenue" text)
             "the intended text survives hydration — not blanked / rewritten")))))

--- a/implementation/adapters/reagent/test/re_frame/ssr_reg_view_hydration_adoption_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/ssr_reg_view_hydration_adoption_dom_cljs_test.cljs
@@ -1,0 +1,260 @@
+(ns re-frame.ssr-reg-view-hydration-adoption-dom-cljs-test
+  "rf2-8vi4q — does a REGISTERED view's server markup hydrate as a clean
+  ADOPTION in a dev build?
+
+  ## The defect this closes
+
+  In a DEV build the Reagent CLIENT render of a registered view stamps
+  BOTH `data-rf2-source-coord` and `data-rf-view` on the view's root DOM
+  element. Before this bead the JVM SSR emitter stamped NEITHER on a
+  callable-head view (the shape isomorphic pages use), so the server
+  markup could not byte-match the dev client render: React reported a
+  hydration mismatch, leaving the adopted node's attributes unpatched and
+  the page's `no-flash / adopt existing DOM` property degraded in dev.
+  (Production elides the annotations on both hosts, so prod was clean —
+  the divergence was dev-only.)
+
+  rf2-8vi4q moved annotation to the reg-view REGISTRATION boundary on both
+  hosts, so a server render of a registered view now emits the SAME two
+  attributes the client stamps. This file makes React the judge of whether
+  that byte-match actually produces a clean adoption.
+
+  ## The vacuity lever (twin run)
+
+  The same harness runs TWICE, mirroring the sibling
+  `re-frame.ssr-keyword-child-hydration-dom-cljs-test`:
+
+    - GREEN — over the bytes the JVM emitter produces NOW (root carries
+      BOTH annotations, values computed via the SHARED formatters so the
+      fixture is the real dialect): React hydrates SILENTLY, the exact
+      server node is adopted (`identical?` + `isConnected`), and both
+      attributes are present on the live node.
+    - RED-BEFORE — over the bytes the JVM emitter produced BEFORE the fix
+      (root carries NEITHER annotation): React must COMPLAIN. This is the
+      permanently-executable red that licenses the green: without it, an
+      empty-complaints result could mean `adopts cleanly` OR `the capture
+      is broken`, and those are indistinguishable.
+
+  Per the rf2-8vi4q ruling §5 and the #6378 browser probe: on React
+  18.3 / 19.2 an attribute-only mismatch WARNS and is left unpatched but
+  does NOT replace the node — so node identity survives in BOTH arms, and
+  the differentiator is the presence of a hydration complaint plus whether
+  the live node ended up carrying the annotations.
+
+  The `-dom-cljs-test` suffix opts this file into the `:browser-test`
+  build; `:node-test` loads it too (matches `cljs-test$`) where
+  `js/document` is absent and every test gates on `(browser?)` and exits
+  early. A node-only run is VACUOUS by construction — `npm run
+  test:browser` is where it asserts."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            ["react" :as React]
+            ["react-dom/client" :as react-dom-client]
+            [reagent.core :as r]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.views :as views]
+            [re-frame.views.source-coord-annotation :as source-coord]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private test-frame :ssr-reg-view-hydration-adoption/frame)
+(def ^:private test-view-id :adoption-demo/card)
+
+(defn- init! []
+  (rf/make-frame {:id       test-frame
+                  :doc      "reg-view hydration adoption probe frame"
+                  :platform :client})
+  ;; Programmatic registration ⇒ no macro-captured coords ⇒ the source-coord
+  ;; degrades to `<ns>:<sym>:?:?` on BOTH hosts. The render output is a plain
+  ;; DOM-tag root so the annotation lands on it.
+  (rf/reg-view* test-view-id {}
+                (fn [label] [:div.card [:h3 label]])))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter
+     :init-fn init!}))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- get-act []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try (.-act (js/require "react-dom/test-utils"))
+           (catch :default _ nil))))
+
+;; The values the CLIENT reg-view render stamps for `test-view-id` — read
+;; off the SAME shared formatters the JVM emitter uses, so the GREEN server
+;; fixture below is the real cross-host dialect, not a hand-typed guess.
+(def ^:private expected-coord (views/format-source-coord test-view-id {}))
+(def ^:private expected-view  (source-coord/format-view-id test-view-id))
+
+;; ---------------------------------------------------------------------------
+;; The harness
+;; ---------------------------------------------------------------------------
+
+(defn- hydrate-over
+  "Put `server-html` in a container, hydrate `tree` over it with REAL React,
+  report `{:complaints [str …] :node <root-div> :text \"…\"}`. `node` is the
+  `div.card` element as it stands AFTER hydration commits, read off the
+  container the caller captured its pre-hydration identity from."
+  [server-html tree]
+  (let [container  (.createElement js/document "div")
+        complaints (atom [])
+        orig-error (.-error js/console)
+        orig-warn  (.-warn js/console)
+        record!    (fn [& args]
+                     (swap! complaints conj
+                            (str/join " " (map #(str %) args))))]
+    (set! (.-innerHTML container) server-html)
+    (.appendChild (.-body js/document) container)
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (set! (.-error js/console) record!)
+    (set! (.-warn js/console) record!)
+    (let [act-fn (get-act)
+          root   (atom nil)]
+      (try
+        (act-fn
+          (fn []
+            (reset! root
+                    (react-dom-client/hydrateRoot
+                      container
+                      (r/as-element [rf/frame-provider {:frame test-frame} tree])
+                      #js {:onRecoverableError
+                           (fn [err _info] (record! "onRecoverableError" err))}))))
+        (let [node (.querySelector container "div.card")
+              text (.-textContent container)]
+          (act-fn (fn [] (some-> @root .unmount)))
+          {:complaints @complaints :node node :text text})
+        (finally
+          (set! (.-error js/console) orig-error)
+          (set! (.-warn js/console) orig-warn)
+          (.remove container))))))
+
+(defn- hydration-complaints
+  "Only the HYDRATION complaints — React emits unrelated dev warnings, and
+  counting those would make the green case flaky and the red case dishonest."
+  [complaints]
+  (filter #(let [s (str/lower-case %)]
+             (or (str/includes? s "hydrat")
+                 (str/includes? s "did not match")
+                 (str/includes? s "didn't match")
+                 (str/includes? s "server rendered")))
+          complaints))
+
+;; The bytes the JVM emitter produces NOW for `[(rf/view test-view-id) "revenue"]`
+;; — the root DOM element carries BOTH annotations, at the shared-dialect
+;; values. Built from the formatters so a dialect drift on either host fails
+;; the `source-coord-parity` tests, and this fixture stays truthful.
+(defn- annotated-server-html []
+  (str "<div class=\"card\""
+       " data-rf2-source-coord=\"" expected-coord "\""
+       " data-rf-view=\"" expected-view "\">"
+       "<h3>revenue</h3>"
+       "</div>"))
+
+;; The pre-fix bytes: the same element with NEITHER annotation — what the JVM
+;; emitter emitted for a callable-head view before rf2-8vi4q.
+(def ^:private pre-fix-server-html
+  "<div class=\"card\"><h3>revenue</h3></div>")
+
+;; ---------------------------------------------------------------------------
+;; GREEN — a registered view adopts its own server markup, silently
+;; ---------------------------------------------------------------------------
+
+(deftest reg-view-server-markup-hydrates-as-clean-adoption
+  (if-not (browser?)
+    (is true "skipped under node — no js/document; npm run test:browser asserts")
+    (testing "rf2-8vi4q — the server markup a registered view now emits
+              (root carries both annotations) hydrates SILENTLY, and both
+              attributes are present on the live node after hydration."
+      (let [{:keys [complaints node text]}
+            (hydrate-over (annotated-server-html)
+                          [(rf/view test-view-id) "revenue"])]
+        (is (empty? (hydration-complaints complaints))
+            (str "React complained about hydrating the reg-view's own "
+                 "server markup: " (pr-str (hydration-complaints complaints))))
+        (is (some? node) "the root div.card exists after hydration")
+        (is (.-isConnected node) "the adopted node is still in the document")
+        (is (= expected-view (.getAttribute node "data-rf-view"))
+            "the live node carries the view-id annotation (client stamped it,
+             and it matched the server ⇒ clean adoption)")
+        (is (= expected-coord (.getAttribute node "data-rf2-source-coord"))
+            "the live node carries the source-coord annotation")
+        (is (= "revenue" text)
+            "the intended text survives hydration — not blanked / rewritten")))))
+
+;; A second GREEN run that proves NODE IDENTITY survives (adoption, not
+;; replacement) by keeping the SAME container across the capture and the
+;; hydrate — the sibling seam test's `identical?` + `isConnected` pattern.
+(deftest reg-view-adoption-preserves-server-node-identity
+  (if-not (browser?)
+    (is true "skipped under node — no js/document; npm run test:browser asserts")
+    (testing "rf2-8vi4q — the exact server node object is still the mounted
+              one after hydration (adoption); it is not minted afresh."
+      (let [container  (.createElement js/document "div")
+            complaints (atom [])
+            orig-error (.-error js/console)
+            orig-warn  (.-warn js/console)
+            record!    (fn [& a] (swap! complaints conj
+                                        (str/join " " (map #(str %) a))))]
+        (set! (.-innerHTML container) (annotated-server-html))
+        (.appendChild (.-body js/document) container)
+        (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+        (set! (.-error js/console) record!)
+        (set! (.-warn js/console) record!)
+        (let [server-node (.querySelector container "div.card")
+              act-fn      (get-act)
+              root        (atom nil)]
+          (try
+            (act-fn
+              (fn []
+                (reset! root
+                        (react-dom-client/hydrateRoot
+                          container
+                          (r/as-element
+                            [rf/frame-provider {:frame test-frame}
+                             [(rf/view test-view-id) "revenue"]])
+                          #js {:onRecoverableError
+                               (fn [err _i] (record! "onRecoverableError" err))}))))
+            (let [after-node (.querySelector container "div.card")]
+              (is (identical? server-node after-node)
+                  "hydrate-root ADOPTED the server node — the SAME object is
+                   mounted (a replacement would mint a fresh node)")
+              (is (.-isConnected server-node)
+                  "the retained server node is still connected")
+              (is (empty? (hydration-complaints @complaints))
+                  (str "adoption was clean — no hydration complaint: "
+                       (pr-str (hydration-complaints @complaints)))))
+            (act-fn (fn [] (some-> @root .unmount)))
+            (finally
+              (set! (.-error js/console) orig-error)
+              (set! (.-warn js/console) orig-warn)
+              (.remove container))))))))
+
+;; ---------------------------------------------------------------------------
+;; RED-BEFORE — the pre-fix bytes make React complain (kept executable)
+;; ---------------------------------------------------------------------------
+
+(deftest pre-fix-server-markup-makes-react-complain
+  (if-not (browser?)
+    (is true "skipped under node — no js/document; npm run test:browser asserts")
+    (testing "THE RED-BEFORE for rf2-8vi4q, kept executable: the SAME harness
+              over the bytes the JVM emitter produced BEFORE the fix (root
+              carries NEITHER annotation) must make React complain, because
+              the dev client render stamps both attributes and the server has
+              them on neither. This is what licenses the green assertions
+              above — without it an empty-complaints result could mean either
+              `adopts cleanly` or `the capture is broken`."
+      (let [{:keys [complaints node]}
+            (hydrate-over pre-fix-server-html
+                          [(rf/view test-view-id) "revenue"])]
+        (is (seq (hydration-complaints complaints))
+            (str "React must report the pre-fix (unannotated) server markup "
+                 "as a hydration mismatch — if this is silent, the green "
+                 "adoption proof above proves nothing. Complaints seen: "
+                 (pr-str complaints)))
+        (is (some? node)
+            "the node is still present (an attribute mismatch warns but does
+             not replace the node, per the ruling's browser probe)")))))

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -54,6 +54,12 @@
             ;; bundle-isolation gate verifies. Xray's Reactive panel
             ;; loads the ns explicitly from its tools-side build.
             #?@(:clj [[re-frame.trace.cascade]])
+            ;; JVM-only: the server-side reg-view registration-boundary
+            ;; annotation (rf2-8vi4q). The `:clj` branch of `reg-view*`
+            ;; wraps the stored `:handler-fn` with it; the CLJS view path
+            ;; annotates through the substrate wrappers (spine / views),
+            ;; so this ns is deliberately absent from CLJS bundles.
+            #?@(:clj [[re-frame.views.jvm-source-coord-annotation :as jvm-view-annot]])
             [re-frame.event-emit :as event-emit]
             [re-frame.error :as error]
             [re-frame.error-emit :as error-emit]
@@ -704,8 +710,23 @@
    #?(:cljs
       (views/reg-view* id (source-coords/merge-coords metadata) render-fn)
       :clj
-      (registrar/register! :view id (assoc (source-coords/merge-coords metadata)
-                                           :handler-fn render-fn)))
+      ;; rf2-8vi4q — the JVM registration boundary is the single home of
+      ;; the two dev-mode view annotations (`data-rf2-source-coord` /
+      ;; `data-rf-view`), mirroring the CLJS `views/reg-view*` path above
+      ;; which annotates through the substrate wrappers. The stored
+      ;; `:handler-fn` is wrapped with a debug-gated hiccup walk so a
+      ;; server render emits the same evidence the dev client render
+      ;; stamps, and a dev SSR page hydrates as a clean ADOPTION. In a
+      ;; production SSR build (`interop/debug-enabled?` false) the wrap is
+      ;; a no-op — the raw handler-fn is stored and markup stays
+      ;; annotation-free. The coords the walk stamps are the SAME merged
+      ;; coords stored in the slot, so the attribute value matches
+      ;; whatever pair tools read back off the registry.
+      (let [coords (source-coords/merge-coords metadata)]
+        (registrar/register!
+          :view id
+          (assoc coords
+                 :handler-fn (jvm-view-annot/wrap-handler-fn id coords render-fn)))))
    id))
 
 (defn view

--- a/implementation/core/src/re_frame/views/jvm_source_coord_annotation.clj
+++ b/implementation/core/src/re_frame/views/jvm_source_coord_annotation.clj
@@ -1,0 +1,156 @@
+(ns re-frame.views.jvm-source-coord-annotation
+  "Server-side (JVM) dev-mode view annotation, applied at the `reg-view`
+  REGISTRATION boundary. The JVM twin of the client hiccup walk in
+  `re-frame.views.source-coord-annotation` (`.cljs`).
+
+  Per Spec 006 §Source-coord annotation and §View tagging contract the
+  view-registration boundary is the single architectural home for the two
+  dev-mode DOM annotations on EVERY host: `data-rf2-source-coord=\"<ns>:
+  <sym>:<line>:<col>\"` (rf2-z7f7 — maps a rendered node back to its
+  reg-view call site) and `data-rf-view=\"<str id>\"` (rf2-01il5 — the
+  view-hierarchy fallback). The client stamps both at React render time;
+  this namespace stamps both on the server render's hiccup so the two
+  hosts emit the same evidence and a dev SSR page hydrates as a clean
+  ADOPTION rather than an attribute-mismatch (rf2-8vi4q).
+
+  ## Why here, and not in the SSR emitter
+
+  The rejected alternative (rf2-8vi4q Option A) stamped the annotation
+  inside the JVM SSR emitter's keyword-view branch. That branch is gone
+  (rf2-j81hs — a keyword head is a DOM element on every host), and it
+  never fired on the callable-head shape isomorphic pages actually use.
+  Annotation is a property of the REGISTERED VIEW, not of the emitter, so
+  it lives at the registration boundary: `re-frame.core/reg-view*`'s `:clj`
+  branch wraps the stored `:handler-fn` with `wrap-handler-fn` below, and
+  the pure hiccup→HTML emitter carries no annotation logic at all.
+
+  ## Production gate
+
+  The whole wrapper sits behind `interop/debug-enabled?` (the JVM
+  dev/prod gate — true by default, disabled by `-Dre-frame.debug=false`
+  / `RE_FRAME_DEBUG=false`, the counterpart to CLJS `goog.DEBUG`). In a
+  production SSR build the handler-fn is stored UNWRAPPED, so server
+  markup is annotation-free — symmetric with the CLJS `:advanced` +
+  `goog.DEBUG=false` build where Closure DCE folds the client walk away.
+
+  ## The dialect is shared, not reinvented
+
+  `format-source-coord` / `format-view-id` produce byte-identical VALUES
+  to their CLJS counterparts in `re-frame.adapter.context` (there is no
+  shared `.cljc` home for them — the CLJS copy is `.cljs`-only), and the
+  hiccup walk mirrors `re-frame.views.source-coord-annotation`'s DOM-root
+  branch exactly: merge both attributes onto a DOM-tag root, preserve any
+  author-supplied value, recurse through Form-2 fns, skip fragment /
+  callable-head roots. The `source-coord-parity` tests (JVM + CLJS) pin
+  the two formatters to one canonical literal so they cannot drift."
+  (:require [re-frame.interop :as interop]))
+
+(set! *warn-on-reflection* true)
+
+(defn format-source-coord
+  "Render a registry slot's id + captured coords as the
+  `data-rf2-source-coord` attribute value `<ns>:<sym>:<line>:<col>`.
+  `<line>` / `<col>` degrade to `?` when the coords were not captured
+  (a programmatic `reg-view*` that bypassed the macro path). Per Spec 006
+  §Source-coord annotation. Byte-identical to the CLJS
+  `re-frame.adapter.context/format-source-coord` — the two are pinned to
+  one canonical literal by the `source-coord-parity` tests."
+  [id coords]
+  (let [ns-part  (or (namespace id) "?")
+        sym-part (name id)
+        line     (:line coords)
+        col      (:column coords)]
+    (str ns-part ":" sym-part ":"
+         (if line (str line) "?")
+         ":"
+         (if col (str col) "?"))))
+
+(defn format-view-id
+  "Render a registry id keyword as the `data-rf-view` attribute value —
+  `(str id)`, so `:rf.foo/bar` → `\":rf.foo/bar\"` (leading colon
+  included). Per Spec 006 §View tagging contract. Byte-identical to the
+  CLJS `re-frame.adapter.context/format-view-id`."
+  [id]
+  (str id))
+
+(defn- dom-tag-head?
+  "True when `head` is a Hiccup DOM-tag keyword. The React-fragment marker
+  `:<>` and the Reagent interop marker `:>` are NOT DOM tags and are
+  exempt from annotation, mirroring the client `dom-tag?` predicate per
+  Spec 006."
+  [head]
+  (and (keyword? head)
+       (not= :<> head)
+       (not= :> head)))
+
+(defn annotate-root
+  "Merge `:data-rf2-source-coord` (= `coord-attr`) and `:data-rf-view`
+  (= `view-attr`) onto the root DOM element of a view's render output
+  `out`, mirroring `re-frame.views.source-coord-annotation/
+  inject-source-coord-attr`'s hiccup-walk contract:
+
+    - Form-2 (`out` is a fn): return a fn that annotates the inner
+      output when the emitter invokes it (Reagent/UIx/Helix Form-2
+      semantics; the JVM SSR emitter's `resolve-component-head` unwraps
+      the inner fn with the same args).
+    - DOM-tag-rooted hiccup: annotate the existing root element,
+      PRESERVING any author-supplied `:data-rf2-source-coord` /
+      `:data-rf-view` value.
+    - Anything else (fragment `:<>`, a callable/view-ref head, a
+      lazy-seq, a scalar, nil): pass through unannotated — the documented
+      non-DOM-root exemption. Pair tools fall back to the registry
+      `:rf/id` for those.
+
+  It annotates the EXISTING root; it never introduces a synthetic
+  wrapper element (which would change layout / selector semantics), just
+  like the client walk."
+  [id coord-attr view-attr out]
+  (cond
+    ;; Form-2: the render-fn returned an inner render fn. Wrap so the
+    ;; inner fn's output is annotated when the emitter calls through.
+    (fn? out)
+    (fn form-2-wrapper [& args]
+      (annotate-root id coord-attr view-attr (apply out args)))
+
+    ;; Hiccup vector with a DOM-tag keyword head — annotate the root.
+    (and (vector? out) (dom-tag-head? (first out)))
+    (let [head        (first out)
+          maybe-attrs (second out)]
+      (if (map? maybe-attrs)
+        ;; Existing attrs map — merge in, never overwriting an author-set
+        ;; value for either framework key.
+        (let [merged (cond-> maybe-attrs
+                       (not (contains? maybe-attrs :data-rf2-source-coord))
+                       (assoc :data-rf2-source-coord coord-attr)
+                       (not (contains? maybe-attrs :data-rf-view))
+                       (assoc :data-rf-view view-attr))]
+          (into [head merged] (drop 2 out)))
+        ;; No attrs map — splice one in between head and children.
+        (into [head {:data-rf2-source-coord coord-attr
+                     :data-rf-view          view-attr}]
+              (rest out))))
+
+    ;; Non-DOM root — fragment, callable/view-ref head, lazy-seq, scalar,
+    ;; nil. Skip. (The client emits a one-shot dev console.warn here for
+    ;; the pair-tool fallback; the JVM has no equivalent surface and the
+    ;; net DOM effect — no annotation — is identical, so it degrades
+    ;; silently.)
+    :else out))
+
+(defn wrap-handler-fn
+  "Return `render-fn` wrapped so its render output is annotated at the
+  root per `annotate-root`, when `interop/debug-enabled?` is true.
+
+  The gate is read ONCE, at registration time — mirroring the client
+  `re-frame.substrate.spine/make-wrap-view`, which decides whether to
+  wrap when the view is registered rather than per render. In a
+  production SSR build (`interop/debug-enabled?` false) the ORIGINAL
+  `render-fn` is returned unwrapped, so server markup carries no
+  annotation."
+  [id coords render-fn]
+  (if interop/debug-enabled?
+    (let [coord-attr (format-source-coord id coords)
+          view-attr  (format-view-id id)]
+      (fn annotated-view [& args]
+        (annotate-root id coord-attr view-attr (apply render-fn args))))
+    render-fn))

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -878,9 +878,18 @@
     ;; rf2-j81hs — `[(rf/view :greet) "world"]`, not `[:greet "world"]`.
     ;; A keyword head is a DOM / custom element on every host; the emitter
     ;; no longer probes the registry for it.
-    (is (= "<p>hello <strong>world</strong></p>"
-           (rf/render-to-string [(rf/view :greet) "world"]))
-        "render-to-string resolves a callable head")
+    ;;
+    ;; rf2-8vi4q — in a DEV build the registered handle's root also carries
+    ;; the two debug-gated view annotations (data-rf2-source-coord /
+    ;; data-rf-view — their exact bytes are pinned in
+    ;; `re-frame.ssr-source-coord-test`), so assert the RESOLUTION
+    ;; structurally here rather than couple the smoke test to the
+    ;; annotation format.
+    (let [html (rf/render-to-string [(rf/view :greet) "world"])]
+      (is (clojure.string/includes? html "hello <strong>world</strong>")
+          "render-to-string resolves a callable head")
+      (is (clojure.string/starts-with? html "<p ")
+          "the resolved view's <p> root is present (now carrying dev annotations)"))
     (is (fn? (rf/view :greet))
         "view returns the registered render fn")
     (is (nil? (rf/view :no-such-view))))

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -52,7 +52,10 @@
 ;; Per Spec 004B §The SSR consumption boundary (rf2-3omxp).
 (def emit-ui-tree                    ui-tree/emit-ui-tree)
 (def install-render-to-string!       emit/install-render-to-string!)
-(def ^:private format-view-source-coord emit/format-view-source-coord)
+;; rf2-8vi4q — `format-view-source-coord` (and its emitter-side companion
+;; `inject-coord-on-root-hiccup`) are deleted: dev-mode view annotation
+;; now lives at the reg-view registration boundary
+;; (`re-frame.views.jvm-source-coord-annotation`), not in the emitter.
 (def render-tree-hash                hash/render-tree-hash)
 ;; framework-private: tests reach into `#'ssr/canonical-edn` for the
 ;; JVM↔CLJS canonical-EDN parity check (hash_check_cljs_test).

--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -233,90 +233,39 @@
                        (emit-element child (when (zero? i) root-attrs)))
                      v)))))
 
-;; ---- source-coord annotation on registered-view roots --------------------
+;; ---- source-coord annotation: NOT the emitter's job ----------------------
 ;;
-;; ⚠ ORPHANED BY rf2-j81hs — HANDED TO rf2-8vi4q. Read before reusing.
+;; The two dev-mode view annotations — `data-rf2-source-coord` and
+;; `data-rf-view` — are stamped at the reg-view REGISTRATION boundary on
+;; every host, NOT by this emitter (rf2-8vi4q). The JVM half is a
+;; debug-gated hiccup walk wrapping the stored `:handler-fn` in
+;; `re-frame.core/reg-view*`'s `:clj` branch (see
+;; `re-frame.views.jvm-source-coord-annotation`); the CLJS half rides the
+;; substrate wrappers. So a registered view reached through its callable
+;; head (`[(rf/view :id) …]` / a Var — the shape isomorphic pages use)
+;; arrives here ALREADY annotated, and this emitter just stringifies it.
 ;;
-;; Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) and
-;; Spec 011 §Source-coord annotation under SSR, the SSR emitter injected
-;; `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` on a registered
-;; view's root DOM element so pair-tool consumers could map server-
-;; rendered HTML back to the reg-view call site.
-;;
-;; The ONLY call site was the keyword-view branch of `emit-element` (and
-;; its mirror in the streaming walker). rf2-j81hs deleted that branch, so
-;; BOTH fns below are now unreachable from this namespace: no server
-;; render annotates anything. That is the ruled outcome, not an oversight
-;; — per the rf2-j81hs ruling §5 the keyword-branch coord injection "dies
-;; WITH the branch", and per rf2-8vi4q's own evidence it never fired on
-;; any boundary a hydratable page can contain (isomorphic pages compose
-;; via `(rf/view :id)` fn-refs, where the JVM stores the raw unwrapped
-;; handler-fn, so emitter-side annotation never ran there anyway).
-;;
-;; The fns are LEFT IN PLACE deliberately. rf2-8vi4q is the bead that
-;; owns this surface: its ruling moves annotation to the reg-view
-;; REGISTRATION boundary (a debug-gated wrapper on the registered
-;; `:handler-fn`, mirroring Spec 006's client injection) and deletes
-;; `inject-coord-on-root-hiccup` plus its call sites as step 2. Deleting
-;; them here would pre-empt that design and strand its tests; the call
-;; sites are already gone, which is this bead's half of the work.
-;;
-;; Until rf2-8vi4q lands there is NO server-side source-coord annotation.
-;; `re-frame.ssr-source-coord-test` pins exactly that interim contract.
-
-(defn format-view-source-coord
-  "Render the registered view's metadata as the attribute value
-  `<ns>:<sym>:<line>:<col>` per Spec 006 §Source-coord annotation. Returns
-  nil when the slot has no captured coords (programmatic registration that
-  bypassed the macro path) — the emitter then skips the annotation."
-  [id slot]
-  (when (or (:ns slot) (:line slot) (:file slot) (:column slot))
-    (let [ns-part  (or (namespace id) "?")
-          sym-part (name id)
-          line     (:line slot)
-          col      (:column slot)]
-      (str ns-part ":" sym-part ":"
-           (if line (str line) "?")
-           ":"
-           (if col (str col) "?")))))
-
-(defn inject-coord-on-root-hiccup
-  "Inject :data-rf2-source-coord into the root element of a hiccup form,
-  if the root is a DOM-tag keyword. Mirrors the CLJS-side wrapper in
-  re-frame.views per Spec 006 §Source-coord annotation. Non-DOM roots
-  (fragment :<>, fn-or-component head, lazy-seq) are returned unchanged
-  — pair tools fall back to :rf/id for those (documented exemption)."
-  [coord out]
-  (cond
-    (and (vector? out)
-         (keyword? (first out))
-         (not= :<> (first out))
-         (not= :> (first out)))
-    (let [head        (first out)
-          maybe-attrs (second out)]
-      (if (map? maybe-attrs)
-        (if (contains? maybe-attrs :data-rf2-source-coord)
-          out
-          (into [head (assoc maybe-attrs :data-rf2-source-coord coord)]
-                (drop 2 out)))
-        (into [head {:data-rf2-source-coord coord}] (rest out))))
-
-    :else out))
+;; This is the ruled outcome of rf2-8vi4q. The rejected alternative
+;; (Option A) stamped the annotation inside the emitter's keyword-view
+;; branch — a branch rf2-j81hs deleted (a keyword head is a DOM element on
+;; every host) and that never fired on the callable-head shape hydratable
+;; pages actually contain. rf2-j81hs left the orphaned emitter-side
+;; `format-view-source-coord` / `inject-coord-on-root-hiccup` fns for this
+;; bead to delete; they are gone. The emitter is a pure hiccup → HTML
+;; function with no annotation logic.
 
 ;; ---- root-attrs injection (per rf2-lxwse) --------------------------------
 ;;
 ;; The render-hash (data-rf-render-hash) is stamped on the first DOM-tag
 ;; element of the rendered tree. Historically this used a post-emit regex
 ;; replace on the output string; rf2-lxwse refactored that into a
-;; structural injection on the hiccup root before stringification — the
-;; same pattern as `inject-coord-on-root-hiccup` above. To compose with
-;; that source-coord injection (which only runs inside the view-ref
-;; resolution branch of `emit-element`), the injection threads an optional
-;; `root-attrs` map down through `emit-element` and consumes it on the
-;; first DOM-tag emission — past any view-refs, fragments (`:<>`),
-;; Reagent-native heads (`:>`), or fn-headed components on the root path.
-;; Non-DOM-rooted trees silently no-op on the injection (matches the
-;; source-coord exemption).
+;; structural injection on the hiccup root before stringification. The
+;; injection threads an optional `root-attrs` map down through
+;; `emit-element` and consumes it on the first DOM-tag emission — past any
+;; fragments (`:<>`), Reagent-native heads (`:>`), or fn-headed /
+;; view-ref components on the root path. Non-DOM-rooted trees silently
+;; no-op on the injection (the same exemption the registration-boundary
+;; source-coord annotation takes for a non-DOM root).
 
 (defn merge-root-attrs
   "Merge root-level injected attrs (per rf2-lxwse) into the attrs map of

--- a/implementation/ssr/test/re_frame/source_coord_parity_test.clj
+++ b/implementation/ssr/test/re_frame/source_coord_parity_test.clj
@@ -1,146 +1,128 @@
 (ns re-frame.source-coord-parity-test
-  "Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) and Spec
-  011 §Source-coord annotation under SSR: the JVM-side SSR emitter's
-  `format-view-source-coord` (in `re-frame.ssr`) and the CLJS-side
-  Reagent adapter's `format-source-coord` (in `re-frame.views`) MUST
-  produce byte-identical attribute values for the same input — same
-  id, same captured `:line` / `:column`. Pair tools that consume the
-  `data-rf2-source-coord` attribute parse the same shape regardless
-  of whether the HTML came from server-side rendering or client-side
-  Reagent — divergent formats would silently break the source-mapping
-  contract.
+  "Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) + §View
+  tagging contract (rf2-01il5): the JVM-side registration-boundary
+  annotation (`re-frame.views.jvm-source-coord-annotation`) and the
+  CLJS-side Reagent adapter's `format-source-coord` / `format-view-id`
+  (in `re-frame.adapter.context`, re-exported via `re-frame.views`) MUST
+  produce byte-identical attribute VALUES for the same input — same id,
+  same captured `:line` / `:column`. Pair tools that consume
+  `data-rf2-source-coord` / `data-rf-view` parse the same shape whether
+  the HTML came from server-side rendering or client-side Reagent;
+  divergent formats would silently break the source-mapping contract.
 
-  The parser fix in rf2-7g2q's re-frame2-pair work assumed both sides produce
-  the same `<ns>:<sym>:<line>:<col>` string for the same registration.
-  No test exercises both paths against a single fixture to confirm.
-  This file pins parity from the JVM side (rf2-d4v7 sub-gap 3 /
-  rf2-o423 audit); the CLJS-side counterpart lives at
-  `implementation/adapters/reagent/test/re_frame/source_coord_parity_cljs_test.cljs`
-  and pins the same canonical literal against `format-source-coord`.
+  rf2-8vi4q moved server-side annotation from the (now-deleted) emitter
+  fn `re-frame.ssr/format-view-source-coord` to the reg-view registration
+  boundary, and added `data-rf-view` to the SSR side so BOTH attributes
+  are emitted on both hosts (previously the emitter stamped only
+  `data-rf2-source-coord`). This test therefore pins BOTH formatters and,
+  at the end, drives the FULL render path through a callable head — the
+  shape hydratable pages actually use — to prove both attributes reach the
+  server markup.
 
-  Strategy: each helper is `defn-` (private), but Clojure exposes
-  private vars via `#'ns/sym`. This JVM test exercises
-  `re-frame.ssr/format-view-source-coord` against fixture inputs and
-  asserts it produces a single canonical literal. The companion CLJS
-  test exercises `re-frame.views/format-source-coord` against the
-  SAME fixture and asserts the SAME canonical literal. If either
-  helper drifts from the canonical shape, the corresponding host's
-  test fails. The literal IS the byte-comparison point — both sides
-  pin it independently."
-  (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.ssr]))
+  Strategy: exercise the JVM formatters against fixed fixtures and assert
+  the canonical literals. The companion CLJS test
+  (`implementation/adapters/reagent/test/re_frame/source_coord_parity_cljs_test.cljs`)
+  exercises the CLJS formatters against the SAME fixtures and asserts the
+  SAME literals. The literals ARE the cross-host byte-comparison point —
+  if either host's formatter drifts, its test fails."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.views.jvm-source-coord-annotation :as jvm-annot]))
 
-;; ---- the canonical attribute-value shape (shared spec) -------------------
+(use-fixtures :each tf/reset-runtime)
+
+;; ---- the canonical attribute-value shapes (shared spec) ------------------
 ;;
-;; Per Spec 006 §Source-coord annotation: `<ns>:<sym>:<line>:<col>`.
-;; <ns> is the registry id keyword's namespace; <sym> is its name;
-;; <line> / <col> come from `(meta &form)` at reg-view macro-expansion
-;; time. The fixture below is the same "stamped meta" shape both
-;; helpers consume; the expected string is the canonical literal.
+;; `data-rf2-source-coord` = `<ns>:<sym>:<line>:<col>` (Spec 006
+;; §Source-coord annotation). `data-rf-view` = `(str id)` (Spec 006 §View
+;; tagging contract). The fixtures below are the same stamped-meta shape
+;; both hosts' formatters consume; the expected strings are the canonical
+;; literals the CLJS companion pins independently.
 
 (def fixture-id :rf.parity-test/sample-view)
 
-(def fixture-meta {:ns         'rf.parity-test
-                   :line       42
-                   :column     7
-                   :file       "rf/parity_test.cljs"
-                   ;; :handler-id is the slot's id key in the registrar
-                   ;; — neither helper consumes it, but the audit's
-                   ;; bead lists it among the stamped-meta keys so we
-                   ;; carry it for shape-fidelity.
-                   :handler-id fixture-id})
+(def fixture-coords {:ns         'rf.parity-test
+                     :line       42
+                     :column     7
+                     :file       "rf/parity_test.cljs"
+                     :handler-id fixture-id})
 
-;; The byte-string both helpers MUST produce for the fixture above.
 ;; <ns>=rf.parity-test, <sym>=sample-view, <line>=42, <col>=7.
-(def expected-attr "rf.parity-test:sample-view:42:7")
+(def expected-source-coord "rf.parity-test:sample-view:42:7")
 
-;; The degraded-shape canonical literal — a programmatic registration
-;; that bypassed the macro path (no :line / :column captured) but
-;; still carried :ns. Per Spec 006 §Source-coord annotation: 'A
-;; registration that bypassed the macro path … still annotates with
-;; <ns>:<sym>:?:? — degrading gracefully so pair tools can still
-;; resolve <ns>/<sym> via the registrar's :rf/id lookup.'
-(def fixture-meta-no-line-no-col
+;; `data-rf-view` is `(str id)` — a printed keyword, leading colon included.
+(def expected-view-id ":rf.parity-test/sample-view")
+
+;; Degraded canonical: a programmatic registration that bypassed the macro
+;; path (no :line / :column) but still carried :ns. Per Spec 006
+;; §Source-coord annotation the source-coord degrades to <ns>:<sym>:?:?.
+(def fixture-coords-no-line-no-col
   {:ns         'rf.parity-test
    :file       "rf/parity_test.cljs"
-   ;; :line and :column intentionally absent.
    :handler-id fixture-id})
 
-(def expected-attr-no-line-no-col
-  "rf.parity-test:sample-view:?:?")
+(def expected-source-coord-no-line-no-col "rf.parity-test:sample-view:?:?")
 
-;; ---- JVM SSR side: format-view-source-coord pins the canonical literal ---
+;; ---- JVM side: the formatters pin the canonical literals -----------------
 
-(deftest ssr-format-view-source-coord-byte-identical-to-canonical
-  (testing "JVM SSR `format-view-source-coord` consumes the fixture
-            (id + line + column + file) and produces the canonical
-            <ns>:<sym>:<line>:<col> string — bytes match the literal
-            the CLJS-side companion test pins. The literal IS the
-            cross-host byte-comparison point."
-    (let [ssr-format #'re-frame.ssr/format-view-source-coord
-          ssr-output (ssr-format fixture-id fixture-meta)]
-      (is (= expected-attr ssr-output)
-          (str "JVM SSR `format-view-source-coord` MUST produce the "
-               "canonical <ns>:<sym>:<line>:<col> shape. Expected: "
-               (pr-str expected-attr) " — got: " (pr-str ssr-output))))))
+(deftest jvm-format-source-coord-byte-identical-to-canonical
+  (testing "the JVM `format-source-coord` consumes the fixture and produces
+            the canonical <ns>:<sym>:<line>:<col> string — bytes match the
+            literal the CLJS companion pins."
+    (is (= expected-source-coord
+           (jvm-annot/format-source-coord fixture-id fixture-coords))
+        "JVM data-rf2-source-coord value must match the canonical literal")))
 
-;; ---- JVM SSR side: degraded shape (no line / col) pins the canonical -----
+(deftest jvm-format-view-id-byte-identical-to-canonical
+  (testing "rf2-8vi4q — the JVM `format-view-id` produces `(str id)`, the
+            same `data-rf-view` value the CLJS host stamps. This is the
+            attribute the SSR side previously never emitted."
+    (is (= expected-view-id (jvm-annot/format-view-id fixture-id))
+        "JVM data-rf-view value must match the canonical literal")))
 
-(deftest ssr-format-view-source-coord-degraded-shape-byte-identical
-  (testing "When :line / :column are absent (programmatic reg-view*
-            with :ns stamped from a sibling macro registration in the
-            same compilation unit), the SSR helper degrades to
-            <ns>:<sym>:?:? — byte-identical to the CLJS-side helper's
-            degraded shape. Per Spec 006 §Source-coord annotation."
-    (let [ssr-format #'re-frame.ssr/format-view-source-coord
-          ssr-output (ssr-format fixture-id fixture-meta-no-line-no-col)]
-      (is (= expected-attr-no-line-no-col ssr-output)
-          (str "SSR degraded shape: expected "
-               (pr-str expected-attr-no-line-no-col)
-               " — got: " (pr-str ssr-output))))))
+(deftest jvm-format-source-coord-degraded-shape-byte-identical
+  (testing "When :line / :column are absent (programmatic reg-view*), the
+            JVM helper degrades to <ns>:<sym>:?:? — byte-identical to the
+            CLJS helper's degraded shape. Per Spec 006 §Source-coord
+            annotation."
+    (is (= expected-source-coord-no-line-no-col
+           (jvm-annot/format-source-coord fixture-id fixture-coords-no-line-no-col))
+        "JVM degraded source-coord must match the canonical degraded literal")))
 
-;; ---- end-to-end byte parity: SSR-rendered HTML carries the canonical ----
+;; ---- end-to-end byte parity: SSR-rendered HTML carries BOTH attributes ---
+;;
+;; This closes the placeholder rf2-j81hs left (the interim
+;; "carries-no-attribute-pending-rf2-8vi4q" assertion): a registered view
+;; reached through its CALLABLE head — `[(rf/view id) …]` or a Var, the
+;; shape isomorphic pages actually compose with — now renders WITH both
+;; annotations, so the server markup byte-matches the dev client render and
+;; hydration adopts. This is the assertion the old emitter-only test never
+;; covered.
 
-(deftest ssr-rendered-html-carries-no-attribute-pending-rf2-8vi4q
-  (testing "rf2-j81hs — this deftest used to drive the canonical
-            attribute through the FULL render path, not just the helper.
-            It no longer can, and the reason is worth stating precisely
-            because the helper tests above still pass.
-
-            `format-view-source-coord` is intact and still produces the
-            canonical literal — the parity contract those tests pin is
-            untouched. What is gone is its only CALL SITE: the emitter's
-            keyword-view branch. rf2-j81hs made every keyword head a DOM
-            element, so no server render annotates anything, and the
-            callable-head branch never annotated to begin with.
-
-            So parity now holds between a live CLJS formatter and a JVM
-            formatter that nothing calls. That is a real gap, and it is
-            rf2-8vi4q's to close: its ruling moves annotation to the
-            reg-view REGISTRATION boundary on both hosts, at which point
-            this test should be restored driving `[(rf/view id)]` /
-            Var heads — the shape hydratable pages actually use, and the
-            shape this end-to-end assertion never covered.
-
-            Pinned as an explicit absence rather than deleted, so the gap
-            is greppable and so a reintroduced emitter-side injection
-            (rf2-8vi4q's REJECTED Option A) fails loudly here."
-    (require '[re-frame.registrar :as registrar]
-             '[re-frame.ssr      :as ssr])
-    (let [registrar  (resolve 're-frame.registrar/register!)
-          ssr-render (resolve 're-frame.ssr/render-to-string)
-          view-fn    (fn [] [:p "body"])
-          _ (registrar :view fixture-id
-                       (assoc fixture-meta :handler-fn view-fn))
-          ;; A CALLABLE head. `fixture-id` is `:rf.parity-test/sample-view`,
-          ;; which sits in the framework-reserved `:rf.<area>/*` scheme, so
-          ;; as a HEAD it would now (correctly) trip the reserved-head guard
-          ;; and throw rather than render — testing the guard, not this.
-          html (ssr-render [view-fn] {})]
-      (is (= "<p>body</p>" html)
-          (str "the view still renders through its callable head; got: "
+(deftest ssr-rendered-html-carries-both-annotations-through-callable-head
+  (testing "rf2-8vi4q — a registered view reached through `(rf/view id)`
+            renders with BOTH data-rf2-source-coord AND data-rf-view on its
+            root DOM element, and their values are exactly the shared
+            formatters' output for the slot's stored coords."
+    (rf/reg-view* fixture-id fixture-coords (fn [] [:p "body"]))
+    (let [html    (ssr/render-to-string [(rf/view fixture-id)] {})
+          ;; The values the formatters produce for the coords actually
+          ;; stored in the slot (the merge-coords result). Reading them off
+          ;; the shared formatters keeps this test honest even if the fixture
+          ;; coords are altered — it asserts the render used THE dialect, not
+          ;; a hardcoded copy of it.
+          coord   (jvm-annot/format-source-coord fixture-id fixture-coords)
+          view-id (jvm-annot/format-view-id fixture-id)]
+      (is (.contains html (str "data-rf2-source-coord=\"" coord "\""))
+          (str "server markup must carry the source-coord attribute; got: "
                (pr-str html)))
-      (is (not (.contains html "data-rf2-source-coord"))
-          (str "no server-side source-coord annotation until rf2-8vi4q "
-               "relocates it to the registration boundary; got: "
+      (is (.contains html (str "data-rf-view=\"" view-id "\""))
+          (str "server markup must carry the view-id attribute (rf2-8vi4q); "
+               "got: " (pr-str html)))
+      (is (= (str "<p data-rf2-source-coord=\"" coord "\""
+                  " data-rf-view=\"" view-id "\">body</p>")
+             html)
+          (str "the full annotated root, both attributes present; got: "
                (pr-str html))))))

--- a/implementation/ssr/test/re_frame/ssr/ssr_startup_recipe_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/ssr_startup_recipe_dom_cljs_test.cljs
@@ -55,19 +55,25 @@
   adapter — against real planted server DOM.
 
   The view here is a PLAIN component (not `reg-view`) on the `:rf/default`
-  frame — deliberately. In a DEV build a registered-view root carries the
-  `data-rf-view` / `data-rf2-source-coord` annotations the reagent CLIENT
-  render stamps but no server renderer reproduces (`rf/render-to-string`
-  emits only `data-rf2-source-coord`; reagent's SSR renderer emits
-  neither), so a registered view's server markup can never byte-match its
-  own dev client render — React then treats hydration as a mismatch and
-  REGENERATES the tree, masking the adopt-vs-replace distinction under
-  test. A plain component carries no such annotations on either side, so
-  the markup matches and the adoption signal is clean. (Production elides
-  the annotations on both sides; the dev-only asymmetry is a separate
-  finding — filed as an rf2 follow-up.) The app is still idiomatic
-  re-frame2: app-db + a `::toggle` event + a `::show?` sub, dispatched /
-  subscribed on `:rf/default`.
+  frame — for ISOLATION, so this proof reads the adopt-vs-replace signal
+  through the mount branch alone with no annotation reconciliation in the
+  mix. (Historically the plain component was also NECESSARY: in a dev
+  build the reagent CLIENT render of a registered view stamps
+  `data-rf-view` / `data-rf2-source-coord` on the root, and the JVM
+  emitter reproduced NEITHER on a callable-head view — so a registered
+  view's server markup could not byte-match its dev client render. That
+  asymmetry is FIXED (rf2-8vi4q moved annotation to the reg-view
+  registration boundary on both hosts; a registered view now adopts
+  cleanly, proven in
+  `re-frame.ssr-reg-view-hydration-adoption-dom-cljs-test`). Note the
+  causal correction the rf2-8vi4q browser probe established: on React
+  18.3 / 19.2 an attribute-only mismatch WARNS and is left unpatched but
+  does NOT replace the node — the earlier claim that React `regenerates
+  the tree` on that mismatch was wrong. The node survives either way;
+  what the pre-fix asymmetry cost was the clean, warning-free adoption,
+  not the node.) Production elides the annotations on both hosts. The app
+  is still idiomatic re-frame2: app-db + a `::toggle` event + a `::show?`
+  sub, dispatched / subscribed on `:rf/default`.
 
   ## What this proves
 
@@ -162,11 +168,12 @@
   a client-only load).
 
   The tree is a PLAIN component (see the ns docstring), not the recipe's own
-  registered `:app/root` view: a registered view's dev-only `data-rf-*`
-  annotations — which no server renderer reproduces — would make React treat
-  hydration as a mismatch and regenerate the tree, masking the adopt-vs-replace
-  signal. Driving `mount!` with a plain, annotation-free tree keeps that signal
-  clean while still executing the canonical mount branch."
+  registered `:app/root` view: a plain, annotation-free tree keeps the
+  adopt-vs-replace signal isolated from annotation reconciliation while still
+  executing the canonical mount branch. (A registered view now also adopts
+  cleanly — rf2-8vi4q fixed the dev-mode annotation asymmetry — but that is
+  proven separately; here the point is the mount branch, not annotation
+  parity.)"
   [root-atom]
   (rf/init! reagent-adapter/adapter)
   (rf/make-frame {:id app-frame :platform :client})

--- a/implementation/ssr/test/re_frame/ssr_keyword_head_contract_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_keyword_head_contract_test.clj
@@ -160,19 +160,38 @@
            (emit/render-to-string [:dashboard/card.revenue {:data-x "1"} [:b "hi"]] nil)))))
 
 (deftest views-are-referenced-by-callable-head
-  (testing "rf2-j81hs — the two supported spellings both resolve, so the
-            migration away from keyword refs has somewhere to land"
-    (testing "Var reference (the symbol `reg-view` defs)"
+  (testing "rf2-j81hs — the two supported spellings both RESOLVE the view
+            (the head-grammar point: a callable head is a view, a keyword
+            head is an element), so the migration away from keyword refs
+            has somewhere to land. rf2-8vi4q layers on top: the REGISTERED
+            handle `(rf/view :id)` carries the dev-mode registration-
+            boundary annotations, while a bare fn Var that never went
+            through registration does not — a distinction the raw
+            `card-view` fn (a test-only stand-in) now makes visible."
+    (testing "a bare fn Var resolves the view — UNANNOTATED (it is the raw
+              render fn, not the registered handle)"
       (is (= "<div class=\"card\"><h3>:revenue</h3></div>"
              (emit/render-to-string [card-view :revenue] nil))))
 
-    (testing "`(rf/view :id)` runtime handle"
-      (is (= "<div class=\"card\"><h3>:revenue</h3></div>"
+    (testing "`(rf/view :id)` — the REGISTERED handle — resolves the view AND
+              carries both dev annotations (rf2-8vi4q). In idiomatic usage
+              the symbol `reg-view` defs IS `(rf/view id)`, so THIS is what a
+              real Var reference emits."
+      (is (= (str "<div class=\"card\""
+                  " data-rf2-source-coord=\"dashboard:card:?:?\""
+                  " data-rf-view=\":dashboard/card\">"
+                  "<h3>:revenue</h3></div>")
              (emit/render-to-string [(rf/view :dashboard/card) :revenue] nil))))
 
-    (testing "both spellings agree byte-for-byte"
-      (is (= (emit/render-to-string [card-view :revenue] nil)
-             (emit/render-to-string [(rf/view :dashboard/card) :revenue] nil))))))
+    (testing "both spellings resolve to the SAME view subtree — the class and
+              child agree; the registered handle merely adds the debug-gated
+              annotation attributes on the root"
+      (is (str/includes? (emit/render-to-string [card-view :revenue] nil)
+                         "class=\"card\""))
+      (is (str/includes? (emit/render-to-string [(rf/view :dashboard/card) :revenue] nil)
+                         "class=\"card\""))
+      (is (str/includes? (emit/render-to-string [(rf/view :dashboard/card) :revenue] nil)
+                         "<h3>:revenue</h3>")))))
 
 ;; ===========================================================================
 ;; The streaming shell walker — `render-shell`

--- a/implementation/ssr/test/re_frame/ssr_source_coord_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_source_coord_test.clj
@@ -1,183 +1,230 @@
 (ns re-frame.ssr-source-coord-test
-  "INTERIM CONTRACT — no server-side source-coord annotation (rf2-j81hs).
+  "Server-side (JVM) dev-mode view annotation, at the reg-view REGISTRATION
+  boundary (rf2-8vi4q).
 
-  ## What this namespace used to pin, and why it no longer can
+  ## What this pins
 
-  Per Spec 011 §Source-coord annotation under SSR (rf2-z7f7 / rf2-z9n1)
-  the JVM emitter injected `data-rf2-source-coord=\"<ns>:<sym>:<line>:<col>\"`
-  on a registered view's root DOM element, mirroring Spec 006's client
-  contract. Every assertion here drove that through a KEYWORD head —
-  `(ssr/render-to-string [:rf.ssr-coord-test/banner] {})` — because the
-  emitter's keyword branch was the only place the injection ever ran.
+  A registered view reached through its CALLABLE head — `[(rf/view :id) …]`
+  or a Var, the shape isomorphic pages actually compose with — renders on
+  the server WITH both dev-mode annotations: `data-rf2-source-coord`
+  (Spec 006 §Source-coord annotation) and `data-rf-view` (Spec 006 §View
+  tagging contract). The client stamps the same two at React render time,
+  so the server markup byte-matches the dev client render and a dev SSR
+  page hydrates as a clean ADOPTION rather than an attribute mismatch.
 
-  rf2-j81hs deleted that branch: a keyword head is a DOM / custom element
-  on every host, and views are referenced by callable head (the Var
-  `reg-view` defs, or `(rf/view :id)`). The callable branch NEVER
-  annotated. So server-side source-coord annotation is now unreachable —
-  not disabled, not gated, structurally unreachable.
+  ## History
 
-  That is the ruled outcome rather than a regression, on two grounds the
-  rf2-j81hs ruling §5 states directly: the keyword-branch coord injection
-  \"dies WITH the branch\", and per rf2-8vi4q's own evidence it never
-  fired on any boundary a hydratable page can contain — an isomorphic
-  page composes via `(rf/view :id)` fn-refs, where the JVM stores the raw
-  unwrapped handler-fn, so the injection was already dead on every shape
-  that matters. The shipped non-streaming example reaches its DOM root
-  with no attribute server-side while the client stamps two.
+  This namespace used to pin the INTERIM absence rf2-j81hs created: it had
+  deleted the emitter's keyword-view branch (a keyword head is a DOM
+  element on every host) — the branch that carried the old emitter-side
+  injection — leaving no server render annotated. rf2-8vi4q closes that
+  gap by moving annotation to the registration boundary on BOTH hosts (a
+  debug-gated wrapper on the registered `:handler-fn`,
+  `re-frame.views.jvm-source-coord-annotation`), and deletes the orphaned
+  emitter fns. So the assertions here flipped from `not annotated` to
+  `annotated`, and the production-gate arm is reinstated at the new site.
 
-  ## Why pin the absence at all
-
-  Because \"the attribute stopped appearing\" must be a DELIBERATE,
-  greppable fact rather than something a future reader discovers by
-  finding no test. These assertions fail the moment anyone reintroduces
-  emitter-side annotation — which is exactly the design rf2-8vi4q
-  REJECTED (its Option A: emitter-side injection, rejected because it
-  only ever reaches keyword-ref boundaries that hydratable pages cannot
-  use).
-
-  The production-elision property the old `debug-enabled?` tests guarded
-  (rf2-wtd8z finding 3 — a production render must not leak internal
-  source coordinates into public HTML) now holds VACUOUSLY and
-  unconditionally: there is no annotation site left to gate. It is
-  re-pinned below as an absolute rather than as a gate, so the guarantee
-  survives the transition instead of quietly lapsing.
-
-  ## Who takes it from here
-
-  rf2-8vi4q owns the replacement: annotation moves to the reg-view
-  REGISTRATION boundary as a debug-gated wrapper on the registered
-  `:handler-fn`, so BOTH hosts annotate at the same architectural seam
-  and the callable-head shape real pages use is covered for the first
-  time. When that lands, this namespace should be REPLACED by tests that
-  drive annotation through `[(rf/view :id) …]` / Var heads — not restored
-  to its keyword-head form, and its production-gate arm reinstated at the
-  new site.
-
-  The orphaned `format-view-source-coord` / `inject-coord-on-root-hiccup`
-  fns are left in `re-frame.ssr.emit` for rf2-8vi4q to delete; only their
-  call sites are gone."
+  A keyword head is still NOT a view and still NOT annotated — it is a DOM
+  element, unchanged by this bead (`keyword-head-*` below)."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.streaming :as streaming]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.views.jvm-source-coord-annotation :as jvm-annot]))
 
-;; Shared reset fixture lives in `re-frame.ssr.test-fixture` (rf2-i3qc0).
 (use-fixtures :each tf/reset-runtime)
 
-(defn- annotated?
-  "True when `html` carries a source-coord annotation attribute."
-  [html]
-  (str/includes? html "data-rf2-source-coord="))
+(defn- source-coord? [html] (str/includes? html "data-rf2-source-coord="))
+(defn- view-id?      [html] (str/includes? html "data-rf-view="))
+(defn- both-annotations? [html] (and (source-coord? html) (view-id? html)))
 
 ;; ---------------------------------------------------------------------------
-;; The interim contract: nothing the JVM emitters produce is annotated
+;; A registered view reached through a callable head IS annotated
 ;; ---------------------------------------------------------------------------
 
-(deftest callable-head-view-is-not-annotated-server-side
-  (testing "rf2-j81hs — a registered view reached through a CALLABLE head
-            (the shape every isomorphic page actually uses) renders with
-            no source-coord attribute. This was ALREADY true before the
-            keyword branch was deleted; the branch simply hid it, because
-            nothing here exercised the callable shape."
-    (rf/reg-view ^{:rf/id :rf.ssr-coord-test/banner} banner-view []
+(deftest callable-head-view-is-annotated-server-side
+  (testing "rf2-8vi4q — a view reached through its callable head (the shape
+            every isomorphic page uses) renders with BOTH annotations on
+            its root DOM element."
+    (rf/reg-view ^{:rf/id :ssr-coord-test/banner} banner-view []
       [:h1 "hi"])
 
     (testing "Var head"
-      (is (not (annotated? (ssr/render-to-string [banner-view] {})))))
+      (is (both-annotations? (ssr/render-to-string [banner-view] {}))))
 
     (testing "`(rf/view :id)` head"
-      (is (not (annotated? (ssr/render-to-string
-                             [(rf/view :rf.ssr-coord-test/banner)] {})))))
+      (is (both-annotations?
+            (ssr/render-to-string [(rf/view :ssr-coord-test/banner)] {}))))
 
-    (testing "the view genuinely rendered — otherwise this asserts nothing"
-      (is (= "<h1>hi</h1>" (ssr/render-to-string [banner-view] {}))))))
+    (testing "the data-rf-view value is `(str id)`"
+      (is (str/includes? (ssr/render-to-string [banner-view] {})
+                         "data-rf-view=\":ssr-coord-test/banner\"")))
 
-(deftest keyword-head-is-an-element-and-is-not-annotated
-  (testing "rf2-j81hs — the head that USED to be annotated is now an
-            element. It carries no source-coord attribute because it
-            resolves to no view at all: `:coord-demo/banner` renders
-            `<banner>`, taking the keyword's name as the tag.
+    (testing "the view genuinely rendered its own root — not swallowed"
+      (is (str/starts-with? (ssr/render-to-string [banner-view] {}) "<h1 ")))))
 
-            Registered under an UNRESERVED namespace deliberately. The
-            rest of this file registers under `:rf.ssr-coord-test/*`,
-            which sits inside the framework-reserved `:rf.<area>/*` scheme
-            — harmless as a registry id, but as a HEAD it now trips the
-            reserved-head guard and throws instead of rendering an
-            element. Using a reserved id here would test the guard, not
-            the element branch."
-    (rf/reg-view ^{:rf/id :coord-demo/banner} banner-view []
-      [:h1 "hi"])
-    (let [html (ssr/render-to-string [:coord-demo/banner] {})]
-      (is (= "<banner></banner>" html))
-      (is (not (annotated? html))))))
+;; ---------------------------------------------------------------------------
+;; Exact byte shape for a programmatic (coordless) registration — degrade
+;; ---------------------------------------------------------------------------
 
-(deftest plain-hiccup-not-annotated
-  (testing "unchanged by rf2-j81hs — ordinary tags were never annotated"
-    (is (not (annotated? (ssr/render-to-string [:div [:span "x"]] {}))))))
+(deftest coordless-programmatic-registration-degrades-to-question-marks
+  (testing "rf2-8vi4q — a `reg-view*` with no macro-captured coords still
+            annotates, degrading the source-coord to <ns>:<sym>:?:? so both
+            hosts match on the programmatic path too."
+    (rf/reg-view* :ssr-coord-test/prog {} (fn [] [:div "prog"]))
+    (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/prog)] {})]
+      (is (= (str "<div data-rf2-source-coord=\"ssr-coord-test:prog:?:?\""
+                  " data-rf-view=\":ssr-coord-test/prog\">prog</div>")
+             html)
+          (str "coordless degrade must produce exactly the client shape; got: "
+               (pr-str html))))))
 
-(deftest streaming-walker-emits-no-source-coord
-  (testing "rf2-j81hs — the streaming shell walker mirrored the sync
-            emitter's injection on its OWN keyword branch. Both are gone,
-            so a streamed shell is unannotated too. Pinned separately
-            because the walker carried its own copy: a partial restore
-            touching only one emitter would leave the two diverging again,
-            which is the whole failure class this bead closes."
-    (rf/reg-view ^{:rf/id :rf.ssr-coord-test/shell} shell-view []
+;; ---------------------------------------------------------------------------
+;; Author-supplied attribute values are PRESERVED
+;; ---------------------------------------------------------------------------
+
+(deftest author-supplied-annotation-values-are-preserved
+  (testing "rf2-8vi4q — an author who set data-rf2-source-coord / data-rf-view
+            on the root keeps THEIR value; the wrapper only fills a missing
+            key. Mirrors the client `inject-source-coord-attr` preservation."
+    (rf/reg-view* :ssr-coord-test/authored {}
+                  (fn [] [:div {:data-rf-view "author-owned"
+                                :id           "x"} "a"]))
+    (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/authored)] {})]
+      (is (str/includes? html "data-rf-view=\"author-owned\"")
+          "the author's data-rf-view value survives")
+      (is (not (str/includes? html "data-rf-view=\":ssr-coord-test/authored\""))
+          "the wrapper did not overwrite it")
+      (is (source-coord? html)
+          "the missing key IS still filled by the wrapper"))))
+
+;; ---------------------------------------------------------------------------
+;; Form-2 views: the inner render fn's output is annotated
+;; ---------------------------------------------------------------------------
+
+(deftest form-2-view-inner-output-is-annotated
+  (testing "rf2-8vi4q — a Form-2 view (outer fn returns an inner render fn)
+            has the INNER output annotated, mirroring the client Form-2
+            wrapper. The emitter unwraps the inner fn; the wrapper's Form-2
+            branch re-wraps so the inner hiccup gets the attributes."
+    (rf/reg-view* :ssr-coord-test/form2 {}
+                  (fn [] (fn [] [:section "inner"])))
+    (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/form2)] {})]
+      (is (both-annotations? html)
+          (str "Form-2 inner output must be annotated; got: " (pr-str html)))
+      (is (str/starts-with? html "<section ")))))
+
+;; ---------------------------------------------------------------------------
+;; Non-DOM roots (fragment, nested view-ref head) skip — documented exemption
+;; ---------------------------------------------------------------------------
+
+(deftest fragment-root-is-not-annotated
+  (testing "rf2-8vi4q — a fragment `:<>` root is a non-DOM root: the wrapper
+            skips it (the exact exemption the client walk takes), so the
+            fragment's children emit unwrapped."
+    (rf/reg-view* :ssr-coord-test/frag {}
+                  (fn [] [:<> [:p "a"] [:p "b"]]))
+    (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/frag)] {})]
+      (is (= "<p>a</p><p>b</p>" html))
+      (is (not (both-annotations? html))))))
+
+(deftest nested-view-ref-root-is-not-doubly-annotated
+  (testing "rf2-8vi4q — a view whose root is ANOTHER view-ref (a callable
+            head) skips at the outer wrapper: the head is a fn, not a
+            DOM-tag keyword. The inner view annotates its own root, so the
+            single annotated element is the inner one — no double-stamp."
+    (rf/reg-view* :ssr-coord-test/inner {} (fn [] [:span "in"]))
+    (rf/reg-view* :ssr-coord-test/outer {}
+                  (fn [] [(rf/view :ssr-coord-test/inner)]))
+    (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/outer)] {})]
+      (is (str/includes? html "data-rf-view=\":ssr-coord-test/inner\"")
+          "the inner view annotated its own root")
+      (is (not (str/includes? html "data-rf-view=\":ssr-coord-test/outer\""))
+          "the outer view (callable-head root) did not stamp itself")
+      (is (= 1 (count (re-seq #"data-rf-view=" html)))
+          (str "exactly one annotated element; got: " (pr-str html))))))
+
+;; ---------------------------------------------------------------------------
+;; The streaming shell walker inherits annotation through the handler-fn
+;; ---------------------------------------------------------------------------
+
+(deftest streaming-shell-annotates-through-the-wrapped-handler
+  (testing "rf2-8vi4q — the streaming walker carries NO annotation logic; it
+            resolves callable heads through the SAME wrapped handler-fn, so a
+            streamed shell is annotated identically to the sync render. The
+            emitter-side asymmetry (two walkers, two copies) that rf2-j81hs
+            worried about is gone: one wrapper, both paths."
+    (rf/reg-view ^{:rf/id :ssr-coord-test/shell} shell-view []
       [:main "shell"])
     (let [{:keys [shell-html]} (streaming/render-shell [shell-view])]
-      (is (= "<main>shell</main>" shell-html))
-      (is (not (annotated? shell-html))))))
-
-(deftest no-emitter-path-annotates
-  (testing "rf2-j81hs — a sweep across the shapes the old tests covered
-            (nested views, fragment roots, programmatic registration).
-            None annotates. Stated as one sweep rather than five near-
-            identical deftests: the contract is now uniform, and its
-            uniformity is the point."
-    (rf/reg-view ^{:rf/id :rf.ssr-coord-test/inner} inner-view []
-      [:span "in"])
-    (rf/reg-view ^{:rf/id :rf.ssr-coord-test/outer} outer-view []
-      [:section [inner-view]])
-    (rf/reg-view ^{:rf/id :rf.ssr-coord-test/frag} frag-view []
-      [:<> [:p "a"] [:p "b"]])
-    ;; Programmatic registration — no macro-captured coords at all.
-    (rf/reg-view* :rf.ssr-coord-test/programmatic {} (fn [] [:div "prog"]))
-
-    (doseq [[label tree]
-            [["nested views"  [outer-view]]
-             ["fragment root" [frag-view]]
-             ["programmatic"  [(rf/view :rf.ssr-coord-test/programmatic)]]]]
-      (is (not (annotated? (ssr/render-to-string tree {})))
-          (str label " must not carry a source-coord annotation")))))
+      (is (both-annotations? shell-html)
+          (str "streamed shell must be annotated; got: " (pr-str shell-html)))
+      (is (str/includes? shell-html "data-rf-view=\":ssr-coord-test/shell\"")))))
 
 ;; ---------------------------------------------------------------------------
-;; Production elision (rf2-wtd8z finding 3) — now unconditional
+;; A keyword head is an element, still NOT a view, still NOT annotated
 ;; ---------------------------------------------------------------------------
 
-(deftest no-source-coord-leak-in-either-debug-mode
-  (testing "rf2-wtd8z finding 3, restated for the post-rf2-j81hs world:
-            a production render must never leak internal source
-            coordinates into public HTML. The old tests proved this by
-            flipping `interop/debug-enabled?` and checking the OFF arm
-            elided. With no annotation site left, the guarantee is
-            unconditional — so pin it against BOTH settings of the gate.
+(deftest keyword-head-is-an-element-and-is-not-annotated
+  (testing "unchanged by rf2-8vi4q — a keyword head is a DOM / custom element
+            on every host (rf2-j81hs), never a view, so it carries no
+            annotation even when a view of the same id is registered."
+    (rf/reg-view* :coord-demo/card {} (fn [_] [:div.card "x"]))
+    (let [html (ssr/render-to-string [:coord-demo/card :revenue] {})]
+      (is (= "<card>revenue</card>" html))
+      (is (not (both-annotations? html))))))
 
-            Driving debug ON is the load-bearing half: it is the arm that
-            used to annotate, so it is the arm that would catch an
-            accidental reintroduction."
-    (rf/reg-view ^{:rf/id :rf.ssr-coord-test/gated} gated-view []
-      [:h2 "g"])
-    (doseq [debug? [true false]]
-      (with-redefs [interop/debug-enabled? debug?]
-        (testing (str "sync emitter, debug-enabled? = " debug?)
-          (let [html (ssr/render-to-string [gated-view] {})]
-            (is (= "<h2>g</h2>" html))
-            (is (not (annotated? html)))))
+(deftest plain-hiccup-not-annotated
+  (testing "unchanged — ordinary tags were never annotated"
+    (is (not (both-annotations? (ssr/render-to-string [:div [:span "x"]] {}))))))
 
-        (testing (str "streaming walker, debug-enabled? = " debug?)
-          (let [{:keys [shell-html]} (streaming/render-shell [gated-view])]
-            (is (= "<h2>g</h2>" shell-html))
-            (is (not (annotated? shell-html)))))))))
+;; ---------------------------------------------------------------------------
+;; Production gate (rf2-wtd8z finding 3) — reinstated at the new site
+;; ---------------------------------------------------------------------------
+;;
+;; The gate is read at REGISTRATION time (mirroring the client
+;; `make-wrap-view`, which decides whether to wrap when the view is
+;; registered). So the production arm must REGISTER the view under a false
+;; `interop/debug-enabled?`; flipping it only around the render would not
+;; un-wrap an already-wrapped handler-fn. That registration-time semantics
+;; is itself the thing under test — a production SSR build reads the flag
+;; false at boot, before any view registers.
+
+(deftest production-build-emits-no-annotation
+  (testing "rf2-8vi4q — a view REGISTERED under `interop/debug-enabled?`
+            false (the production SSR posture) stores an unwrapped
+            handler-fn, so its server markup carries neither annotation —
+            symmetric with the CLJS :advanced + goog.DEBUG=false build that
+            Closure DCEs the client walk. The dev arm annotates; the prod
+            arm does not."
+    (testing "debug ON at registration — annotated (the load-bearing arm)"
+      (rf/reg-view* :ssr-coord-test/gated-dev {} (fn [] [:h2 "g"]))
+      (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/gated-dev)] {})]
+        (is (str/starts-with? html "<h2 "))
+        (is (both-annotations? html))))
+
+    (testing "debug OFF at registration — NOT annotated"
+      (with-redefs [interop/debug-enabled? false]
+        (rf/reg-view* :ssr-coord-test/gated-prod {} (fn [] [:h2 "g"])))
+      ;; render with debug back at its default — the wrap decision was made
+      ;; at registration, so the markup is unannotated regardless.
+      (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/gated-prod)] {})]
+        (is (= "<h2>g</h2>" html))
+        (is (not (both-annotations? html)))))))
+
+;; ---------------------------------------------------------------------------
+;; The formatter unit itself degrades — belt-and-braces on the shared dialect
+;; ---------------------------------------------------------------------------
+
+(deftest jvm-formatter-produces-the-shared-dialect
+  (testing "rf2-8vi4q — the JVM formatter is byte-identical in shape to the
+            CLJS one (pinned cross-host in `source-coord-parity-test`). Here
+            just confirm the two value shapes directly."
+    (is (= "a.b:c:1:2"
+           (jvm-annot/format-source-coord :a.b/c {:line 1 :column 2})))
+    (is (= "a.b:c:?:?"
+           (jvm-annot/format-source-coord :a.b/c {})))
+    (is (= ":a.b/c" (jvm-annot/format-view-id :a.b/c)))))


### PR DESCRIPTION
## What

Dev-mode view annotation (`data-rf2-source-coord` + `data-rf-view`) now lives at the **reg-view registration boundary on every host** — SSR emitters carry no annotation logic (Option A-prime; the rejected emitter-side Option A only reached keyword-ref boundaries hydratable pages cannot use).

- **Core `reg-view*` `:clj` branch** wraps the stored `:handler-fn` in a debug-gated hiccup walk (new `re-frame.views.jvm-source-coord-annotation`) that mirrors the client injection rules exactly: merges BOTH attributes onto a DOM-tag root, preserves author-supplied values, recurses through Form-2 fns, skips fragment / callable-head roots, and degrades a coordless (programmatic) registration to `<ns>:<sym>:?:?`. Values are byte-identical to the CLJS `format-source-coord` / `format-view-id`.
- **Emitter-side deletion**: `format-view-source-coord` and `inject-coord-on-root-hiccup` removed from `re-frame.ssr.emit`, plus the private `re-frame.ssr` re-export. Both call sites were already gone (#6378, rf2-j81hs); this closes the residual — including the latent dev-mode arity leak, which died with the keyword-view branch. `re-frame.ssr.streaming` inherits annotation through the wrapped handler-fn, so shell/fallbacks/continuations are annotated with no walker-local logic.

So a registered view reached through its callable head (`[(rf/view :id) …]` / a Var — the shape isomorphic pages compose with) now emits the same two annotations the dev client render stamps: server markup byte-matches, and a dev SSR page hydrates as a **clean adoption** instead of an attribute mismatch. Production stays annotation-free on both hosts (JVM `interop/debug-enabled?` gate at registration; CLJS Closure DCE — unchanged).

## Proofs

- **Dev-hydration ADOPTION** (browser, mounted — `re-frame.ssr-reg-view-hydration-adoption-dom-cljs-test`): a reg-view hydrated over its now-annotated server markup adopts the exact server node (`identical?` + `isConnected`, captured while mounted) with **no** hydration complaint and both attributes present. Twin-run RED-before: the pre-fix (unannotated) server markup makes React complain — the vacuity lever that licenses the green.
- **Byte-match parity** (`source_coord_parity_test` + CLJS companion, extended): both hosts' formatters pinned to one canonical literal for BOTH attributes (previously only `data-rf2-source-coord`), plus an end-to-end JVM render asserting a callable-head view carries both.
- **Production annotation-free**: `test:elision` control-build oracle (prod 60/60 absent, control 60/60 present); JVM `production-build-emits-no-annotation` (register under `debug-enabled? false` ⇒ unannotated; dev arm annotates — load-bearing).
- **Causal correction** (ruling §5): the byio7 plain-component adoption test's "React regenerates the subtree" claim is corrected — an attribute-only mismatch warns and is left unpatched but does NOT replace the node.

## Specs / error ids

No new error id, no spec/009 row. **Spec 006/011 prose edits STOPPED**: both are hot-zone and spec/011 has the live `phaseflip-spec-jygc8` worker — filed **rf2-0qpqu** to land them (spec/006 line ~672 "the JVM SSR emitter injects…" is now stale; spec/011 §Source-coord annotation under SSR is written pending-rf2-8vi4q) sequenced after phaseflip merges.

## Quality gates

All foreground, run to completion (main's gates are green):

| Gate | Result |
| --- | --- |
| `implementation/core` `clojure -M:test` | **2088 tests, 0 failures** |
| `implementation/ssr` `clojure -M:test` | **491 tests, 0 failures** |
| `npm run test:cljs` | **10273 tests, 0 failures** |
| `npm run test:browser` | **495 tests, 0 failures** (adoption + RED-before + parity mounted) |
| `npm run test:elision` | **PASS** (prod 60/60 absent, control 60/60 present) |
| `npm run test:browser-prod-elision` | **113 tests, 0 failures** |
