### PR TITLE
fix(ui): coarse-invalidate literal consumers on a declaration edit (rf2-vxgfnd.141)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
@@ -693,6 +693,79 @@
                           (harvest/source-seed ns))))))
           build-sources)))
 
+;; ---------------------------------------------------------------------------
+;; Declaration-edit warm staleness — COARSE invalidation (rf2-vxgfnd.141, dim 3)
+;;
+;; A literal view bakes its property/attribute classification at compile from the
+;; effective manifest. So a WARM edit that changes only a declaration — a source
+;; whose `(ui/custom-element …)` grew, shrank, or vanished — leaves every
+;; consumer view that Shadow does NOT recompile (no `:require` edge to that
+;; declaring source) with a STALE baked lowering: the warm build no longer equals
+;; a clean build. The digest dimension (#6432) DETECTS this; it does not re-bake.
+;;
+;; The ruled fix (rf2-vxgfnd.141 DECISION, coarse per the Codex opinion) is
+;; deliberately NOT a per-tag declaration->consumer dependency graph: declarations
+;; are few and change rarely, so when the harvested manifest changes THIS pass we
+;; recompile the whole re-frame.ui literal-consumer set (the cache-blocked set the
+;; hook already identifies). Every consumer then re-bakes against the new manifest
+;; = a clean build. A change is detected against the ACCEPTED manifest, so an
+;; ordinary view-only edit (no declaration delta) invalidates nothing, and a pure
+;; cross-namespace move that leaves the tag->properties manifest identical (the
+;; provenance-only case the digest also ignores) does not either.
+;; ---------------------------------------------------------------------------
+
+(defn- effective-manifest
+  "The `tag -> decl` manifest this pass WILL commit: the accepted rows of the
+  sources NOT recompiled this pass, overlaid with the harvested declarations of
+  the recompiled sources (whose accepted rows are being replaced). A pure
+  function of the accepted snapshot plus this pass's harvest."
+  [build-state recompiled-nss seed]
+  (let [warm (reduce-kv
+              (fn [m src regs]
+                (if (contains? recompiled-nss src)
+                  m
+                  (merge m (get regs build/elements))))
+              {}
+              (:registries (build/accepted-snapshot build-state)))]
+    (reduce (fn [m [_src tag decl]] (assoc m tag decl)) warm seed)))
+
+(defn- manifest-changed?
+  "Whether this pass's effective `tag -> decl` manifest differs from the accepted
+  one — the coarse invalidation trigger. Compares only the property manifest, so
+  a declaration's provenance (owning namespace) moving does not count as a change
+  unless the declared properties actually differ."
+  [build-state recompiled-nss seed]
+  (not= (build/accepted-aggregate build/elements build-state)
+        (effective-manifest build-state recompiled-nss seed)))
+
+(defn- invalidate-ui-consumers
+  "Reset retained output for every re-frame.ui literal-consumer source, so the
+  next schedule recompiles and re-bakes them against the changed manifest. Coarse
+  by design (the ruled dimension-3 mechanism): a declaration change is rare, and
+  a full UI-consumer recompile trivially restores warm=clean without a per-tag
+  dependency graph."
+  [build-state]
+  (reduce (fn [bs resource-id]
+            (if (ui-cache-blocked-source? (get-in bs [:sources resource-id]))
+              (update bs :output dissoc resource-id)
+              bs))
+          build-state
+          (:build-sources build-state)))
+
+(defn- reconcile-declaration-edits
+  "If this pass changes the custom-element manifest on a WARM build (accepted
+  version > 0), coarse-invalidate the UI literal-consumer set so no view keeps a
+  stale baked lowering (rf2-vxgfnd.141, dimension 3). On the version-0 pass
+  `reset-cold-ui-consumer-output` already covers it, so this only acts warm."
+  [build-state]
+  (let [version (long (or (:version (build/accepted-snapshot build-state)) 0))]
+    (if (and (pos? version)
+             (manifest-changed? build-state
+                                (recompiled-member-nss build-state)
+                                (harvest-seed build-state)))
+      (invalidate-ui-consumers build-state)
+      build-state)))
+
 (defn hook
   "Shadow build hook. Configure once in `:build-defaults` as
   `:build-hooks [(re-frame.ui.compiler.build-hook/hook)]`."
@@ -705,6 +778,12 @@
     (do
       (validate-ui-cache-blocker! build-state)
       (let [build-state (reset-cold-ui-consumer-output build-state)
+            ;; Coarse dimension-3 invalidation: a WARM edit that changed the
+            ;; custom-element manifest recompiles every UI literal consumer so
+            ;; none keeps a stale baked lowering (rf2-vxgfnd.141). Must precede
+            ;; the schedule/stamp so the widened consumer set is scheduled and
+            ;; re-seeded this same pass.
+            build-state (reconcile-declaration-edits build-state)
             pass-token  (str (java.util.UUID/randomUUID))
             witnessed   (atom #{})
             stamped     (-> build-state

--- a/implementation/ui/test/re_frame/ui/custom_element_warm_staleness_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/custom_element_warm_staleness_jvm_test.clj
@@ -1,0 +1,156 @@
+(ns re-frame.ui.custom-element-warm-staleness-jvm-test
+  "Declaration-edit WARM STALENESS — warm build equals clean build
+  (rf2-vxgfnd.141, dimension 3).
+
+  A literal view bakes its property/attribute classification at COMPILE from the
+  effective manifest. A warm edit that changes ONLY a declaration recompiles the
+  declaring source but NOT a consumer view Shadow does not see as affected (no
+  `:require` edge), so the consumer keeps a STALE baked lowering: the warm build
+  no longer equals a clean build. The ruled fix (DECISION, coarse per Codex) is
+  NOT a per-tag dependency graph — when the harvested manifest changes this pass,
+  `build-hook` recompiles the whole re-frame.ui literal-consumer set, so every
+  consumer re-bakes against the new manifest = a clean build.
+
+  This file drives the REAL hook across two passes: a clean pass, then a warm
+  pass that edits the declaration while the consumer is a cache hit, and asserts
+  the consumer's re-baked classification EQUALS a clean build of the edited
+  source — the warm=clean law. It also pins that an edit with NO manifest delta
+  invalidates nothing (the coarse trigger is a manifest CHANGE, not any UI edit).
+
+  RED-BEFORE LEVER (this file's own): revert `reconcile-declaration-edits` in
+  `build-hook/hook` and the consumer is not rescheduled on a warm declaration
+  edit — `consumer-is-rescheduled...` and the warm=clean shrink/grow assertions
+  go red (the consumer keeps its stale baked lowering), while every other proof
+  stays green. The observable is the emitted `:rf.ui/property-props`, not a throw."
+  (:require [cljs.env :as cljs-env]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.ui.compiler.build :as build]
+            [re-frame.ui.compiler.build-hook :as build-hook]
+            [re-frame.ui.compiler.harvest :as harvest]
+            [re-frame.ui.shadow-compile-model :as shadow]
+            [re-frame.ui.tree :as tree]))
+
+(use-fixtures :each
+  (fn [f]
+    (build/reset-build!) (harvest/reset-harvested!)
+    (try (f) (finally (build/reset-build!) (harvest/reset-harvested!)))))
+
+(defn- decl-src [props]
+  (str "(ns app.decl (:require [re-frame.ui :as ui]))\n"
+       "(ui/custom-element :x-card {:properties " (pr-str props) "})"))
+
+(def ^:private view-src
+  ;; The view references :model AND :size so a manifest grow/shrink of EITHER is
+  ;; observable in its baked classification; :data-x is always a plain attribute.
+  (str "(ns app.view (:require [re-frame.ui :refer [defview]]))\n"
+       "(defview card [] [:x-card {:model \"m\" :size \"s\" :data-x \"d\"}])"))
+
+(defn- sources [props]
+  {'app.decl {:ns 'app.decl :provides #{'app.decl} :type :cljs
+              :requires #{'re-frame.ui} :source (decl-src props)}
+   'app.view {:ns 'app.view :provides #{'app.view} :type :cljs
+              :requires #{'re-frame.ui} :source view-src}})
+
+(defn- prepare-state [build-id props accepted output]
+  (cond-> {:shadow.build/build-id build-id
+           :shadow.build/stage :compile-prepare
+           :compiler-env {}
+           :executor (Object.)
+           :analyzer-passes []
+           :build-sources ['app.decl 'app.view]
+           :sources (sources props)
+           :output output}
+    accepted (assoc-in [:compiler-env build/accepted-snapshot-key] accepted)))
+
+(defn- scheduled [state] (#'build-hook/recompiled-member-nss state))
+
+(defn- eval-source!
+  "Macroexpand + eval a source's forms under `prepared`'s compiler-env — the real
+  compile that bakes the view fn — returning the mutated compiler-env carried
+  back into the build-state (as Shadow retains it)."
+  [prepared ns-sym src]
+  (let [compiler (atom (assoc (:compiler-env prepared)
+                              :shadow.build.cljs-bridge/state prepared))]
+    (binding [cljs-env/*compiler* compiler
+              *ns* (create-ns ns-sym)]
+      (doseq [form (read-string (str "[" src "]"))]
+        (eval form)))
+    (assoc prepared :compiler-env (dissoc @compiler :shadow.build.cljs-bridge/state))))
+
+(defn- run-pass
+  "One faithful build pass: prepare (hook), compile every SCHEDULED source (fresh
+  output + compile witness + real macroexpansion), finish (hook). Returns the
+  accepted snapshot, the scheduled set, and the consumer view's freshly baked
+  `:rf.ui/property-props`."
+  [{:keys [build-id props accepted output]}]
+  (let [prepared (build-hook/hook (prepare-state build-id props accepted output))
+        sched    (scheduled prepared)
+        srcs     (sources props)
+        with-out (reduce (fn [s n]
+                           (assoc-in s [:output n]
+                                     {:resource-id n :js "compiled" :cached false}))
+                         prepared sched)
+        _        (doseq [n sched]
+                   (shadow/compile-ns! (assoc with-out :shadow.build/stage :compile-finish) n))
+        compiled (reduce (fn [s n] (eval-source! s n (get-in srcs [n :source])))
+                         with-out sched)
+        finished (build-hook/hook (assoc compiled :shadow.build/stage :compile-finish))]
+    {:accepted  (build/accepted-snapshot finished)
+     :scheduled sched
+     :bpp       (:rf.ui/property-props
+                 (first (:children (tree/render @(resolve 'app.view/card) {}))))}))
+
+(defn- clean-bpp
+  "The consumer's baked classification in a fresh clean build with declared
+  `props` — the warm-build target."
+  [props]
+  (build/reset-build!) (harvest/reset-harvested!)
+  (:bpp (run-pass {:build-id :clean :props props :accepted nil :output {}})))
+
+(defn- warm-bpp
+  "Edit the declaration from `p1-props` to `p2-props` on a WARM build where the
+  consumer `app.view` is a cache hit (retained output). Returns the pass-2
+  scheduled set and the consumer's re-baked classification."
+  [p1-props p2-props]
+  (build/reset-build!) (harvest/reset-harvested!)
+  (let [p1 (run-pass {:build-id :warm :props p1-props :accepted nil :output {}})
+        p2 (run-pass {:build-id :warm :props p2-props
+                      :accepted (:accepted p1)
+                      ;; consumer retained (warm cache hit); declaring source
+                      ;; reset (Shadow schedules the edited file).
+                      :output {'app.view {:resource-id 'app.view :js "cached"}}})]
+    {:p1-bpp (:bpp p1) :p2-scheduled (:scheduled p2) :p2-bpp (:bpp p2)}))
+
+(deftest warm-declaration-shrink-equals-clean
+  ;; Remove :model from the manifest on a warm build; the consumer must re-bake
+  ;; :model as an ATTRIBUTE, exactly as a clean build of the edited source does.
+  (let [{:keys [p1-bpp p2-scheduled p2-bpp]} (warm-bpp #{:model} #{})]
+    (is (= #{:model} p1-bpp) "pass 1 baked :model a property")
+    (is (contains? p2-scheduled 'app.view)
+        "the warm declaration edit rescheduled the consumer (coarse invalidation)")
+    (is (= (clean-bpp #{}) p2-bpp)
+        "warm re-bake equals a clean build — :model is now an attribute")
+    (is (nil? p2-bpp) "concretely: no property classification survives")))
+
+(deftest warm-declaration-grow-equals-clean
+  ;; Add :size to the manifest on a warm build; the consumer must re-bake both
+  ;; :model and :size as properties.
+  (let [{:keys [p1-bpp p2-scheduled p2-bpp]} (warm-bpp #{:model} #{:model :size})]
+    (is (= #{:model} p1-bpp))
+    (is (contains? p2-scheduled 'app.view) "the consumer was rescheduled")
+    (is (= (clean-bpp #{:model :size}) p2-bpp)
+        "warm re-bake equals a clean build")
+    (is (= #{:model :size} p2-bpp) "concretely: both are properties now")))
+
+(deftest a-warm-edit-with-no-manifest-delta-invalidates-nothing
+  ;; Re-saving the declaration UNCHANGED must NOT reschedule the consumer — the
+  ;; coarse trigger is a manifest CHANGE, not any UI edit (so an ordinary edit
+  ;; does not needlessly recompile every consumer).
+  (build/reset-build!) (harvest/reset-harvested!)
+  (let [p1 (run-pass {:build-id :nodelta :props #{:model} :accepted nil :output {}})
+        p2 (run-pass {:build-id :nodelta :props #{:model}
+                      :accepted (:accepted p1)
+                      :output {'app.view {:resource-id 'app.view :js "cached"}}})]
+    (is (not (contains? (:scheduled p2) 'app.view))
+        "an unchanged declaration leaves the warm consumer a cache hit")
+    (is (= #{:model} (:bpp p1)) "still a property throughout")))


### PR DESCRIPTION
## Dimension 3 — declaration-edit warm staleness (rf2-vxgfnd.141)

Dimension 2 landed on `main` as `48eddb5281` (formerly PR #6464). This is dimension 3, rebased cleanly onto current `main`.

> Note: an earlier stacked PR (#6468) for this same commit was merged by the automation into its stale base branch `worker/ce-harvest-141` rather than `main`, so dimension 3 is **not** on `main`. This fresh PR retargets the same work at `main`.

A literal view bakes its property/attribute classification at **compile** from the effective manifest. A **warm** edit that changes only a declaration recompiles the declaring source but **not** a consumer view Shadow does not see as affected (no `:require` edge) — the consumer keeps a **stale** baked lowering, so the warm build no longer equals a clean build. The digest dimension (#6432) *detects* this; it does not *re-bake*.

### Fix (coarse, per the ruling)
Deliberately **not** a per-tag `declaration -> consumer` dependency graph. At `:compile-prepare`, `reconcile-declaration-edits` compares this pass's effective `tag -> decl` manifest against the **accepted** one, and when it changed on a **warm** build recompiles the whole re-frame.ui literal-consumer set (the cache-blocked set the hook already identifies) so every consumer re-bakes against the new manifest = a clean build. The trigger is a manifest **change**, so an ordinary view-only edit invalidates nothing, and a pure cross-namespace move that leaves the `tag -> properties` manifest identical (the provenance-only case the digest also ignores) does not either.

### Bans honoured
No declaration->consumer dependency graph, no public API change, no per-render registry lookup, no declaration-before-use ceremony, no per-write runtime fallback.

### Proof
`custom-element-warm-staleness-jvm-test` drives the real hook across two passes: **warm shrink** (`#{:model}` → `#{}`) and **warm grow** (`#{:model}` → `#{:model :size}`), each asserting the consumer is **rescheduled** and its re-baked `:rf.ui/property-props` equals a clean build of the edited source, plus a **no-delta** case that invalidates nothing. Red-before verified with an isolated lever (disabling `reconcile-declaration-edits` reds only these proofs).

### Gates (green)
- `implementation/ui` JVM: **997 tests**, 0 failures
- `npm run test:cljs`: **10259 tests**, 0 failures
- `npm run test:browser`: **482 tests**, 0 failures
- `npm run test:elision`: PASS
- `npm run test:perf-bundle`: PASS (no regression)