### PR TITLE
fix(core): keep deferred trace batches ahead of later listener-authored traces (rf2-t6vs3)

### DIFF
--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -819,9 +819,13 @@
 ;; Emission ORDER is preserved:
 ;; the ring push and epoch capture still run inline, the pending vector
 ;; is FIFO, and the whole batch is flushed under one monitor hold, so a drain's
-;; own traces reach listeners contiguously and in order. Each deferred event is
-;; driven through its OWN `run-outermost-fanout!`, so a listener's reentrant emit
-;; is scheduled against that event exactly as it would have been inline.
+;; own traces reach listeners contiguously and in order. The WHOLE captured batch
+;; is queued onto ONE fan-out schedule before any callback runs (rf2-t6vs3) —
+;; `run-outermost-fanout!` for a top-level flush, `into` the active `*fanout-ctx*`
+;; for an integrated one — so a listener that authors a later trace while an
+;; earlier deferred entry is being fanned out appends BEHIND the still-pending
+;; later entries rather than overtaking them, exactly as an inline delivery of the
+;; same run would have ordered them.
 ;;
 ;; Same-thread reentrancy does NOT re-acquire the monitor: a nested emit sees
 ;; `*fanout-ctx*` already bound and takes the append+drive branch below, so it
@@ -968,27 +972,30 @@
                 (recur))))))))
 
 (defn- run-outermost-fanout!
-  "Seed a fresh fan-out schedule for `event`, bind it as `*fanout-ctx*` so
-  reentrant emits from listener bodies advance the SAME schedule, and drive it to
-  completion. Always runs under `fanout-monitor` on the JVM so concurrent emits
-  serialize (rf2-uw7hg) — either directly (a clean emit) or inside the post-drain
-  flush of a deferred batch (rf2-wxy1c); see the `deliver-to-tooling!` outermost
-  branch. The binding + drive are the whole critical section.
+  "Seed ONE fresh fan-out schedule for a whole `batch` of queue entries, bind it
+  as `*fanout-ctx*` so reentrant emits from listener bodies advance the SAME
+  schedule, and drive it to completion. Always runs under `fanout-monitor` on the
+  JVM so concurrent emits serialize (rf2-uw7hg) — either a single clean emit
+  (`batch` is one entry) or the whole post-drain flush of a deferred batch
+  (rf2-wxy1c); see the `deliver-to-tooling!` outermost branch and
+  `drain-deferred-batch!`. The binding + drive are the whole critical section.
 
-  `entries` pre-seeds the listener snapshot for THIS event instead of letting the
-  driver take one at delivery time. The post-drain flush passes the snapshot
-  captured when the event was APPENDED, so a deferred delivery reaches exactly the
-  listeners an inline delivery would have; nil (the default) keeps the ordinary
-  snapshot-at-delivery behaviour. Reentrant events queued behind this one always
-  re-snapshot — the driver resets `:entries` to nil as it advances."
-  ([event continue?] (run-outermost-fanout! event continue? nil))
-  ([event continue? entries]
-   (let [ctx {:q       (volatile! [[event continue?]])
-              :head    (volatile! 0)
-              :entries (volatile! entries)
-              :lcursor (volatile! 0)}]
-     (binding [*fanout-ctx* ctx]
-       (drive-fanout! ctx)))))
+  Seeding the WHOLE batch before driving is what keeps a deferred batch FIFO
+  (rf2-t6vs3): a listener that authors a later trace while an EARLIER deferred
+  entry is being fanned out appends BEHIND the still-pending later entries rather
+  than overtaking them. `:entries` starts nil and `drive-fanout!` re-reads it per
+  event as it advances `:head`, so a queued triple `[event continue? snapshot]`
+  delivers under the listener snapshot captured when it was APPENDED (exactly the
+  listeners an inline delivery would have reached), while a plain pair
+  `[event continue?]` — a single clean emit, or a reentrant child queued behind
+  the batch — re-snapshots live, as an inline listener-body emit always does."
+  [batch]
+  (let [ctx {:q       (volatile! (vec batch))
+             :head    (volatile! 0)
+             :entries (volatile! nil)
+             :lcursor (volatile! 0)}]
+    (binding [*fanout-ctx* ctx]
+      (drive-fanout! ctx))))
 
 (def ^:private unread
   "Distinct baseline sentinel for `deferred-continue` — a fresh object, held by
@@ -1079,23 +1086,27 @@
           ;; A listener-initiated `dispatch-sync` (rf2-6t6qk): the flush runs
           ;; while an OUTER listener fan-out is still paused inside the very
           ;; listener body that opened this drain. INTEGRATE into that active
-          ;; schedule rather than seeding fresh outermost fan-outs — `drive-
+          ;; schedule rather than seeding fresh outermost fan-outs. Enqueue the
+          ;; WHOLE captured batch FIRST, then drive once (rf2-t6vs3): `drive-
           ;; fanout!` advances the paused outer event to its remaining listeners
           ;; FIRST, so every listener still observes the outer event before these
-          ;; nested drain-owned ones (rf2-1zxlsm), and the whole batch is
-          ;; delivered before the enclosing `dispatch-sync` returns (rf2-s522m).
-          ;; The appended triple carries the append-time listener snapshot, which
-          ;; `drive-fanout!` honours. No monitor re-acquire is needed: the outer
-          ;; drive already holds it (JVM), and CLJS has none.
-          (doseq [[event continue? entries] batch]
-            (vswap! (:q ctx) conj [event continue? entries])
-            (drive-fanout! ctx))
-          ;; Outermost drain (a top-level dispatch-sync / async drain): each
-          ;; event is its own outermost fan-out under its append-time snapshot,
-          ;; so a listener's reentrant emit is scheduled against it exactly as it
-          ;; would have been inline.
-          (doseq [[event continue? entries] batch]
-            (run-outermost-fanout! event continue? entries)))
+          ;; nested drain-owned ones (rf2-1zxlsm); the whole batch is delivered
+          ;; before the enclosing `dispatch-sync` returns (rf2-s522m); and a
+          ;; listener that authors a later trace while an EARLIER batch item is
+          ;; being driven appends BEHIND the still-pending later items instead of
+          ;; overtaking them (rf2-t6vs3 FIFO). Each entry already carries its
+          ;; append-time listener snapshot, which `drive-fanout!` honours. No
+          ;; monitor re-acquire is needed: the outer drive already holds it (JVM),
+          ;; and CLJS has none.
+          (do (vswap! (:q ctx) into batch)
+              (drive-fanout! ctx))
+          ;; Outermost drain (a top-level dispatch-sync / async drain): seed ONE
+          ;; fresh outermost schedule for the WHOLE batch (rf2-t6vs3), so the
+          ;; entire batch is queued before any callback runs and a listener's
+          ;; reentrant emit during an earlier deferred event lands behind the
+          ;; later ones rather than overtaking them. Each event is still delivered
+          ;; under its own append-time snapshot.
+          (run-outermost-fanout! batch))
         (recur)))))
 
 (defn- flush-deferred-fanout!
@@ -1248,8 +1259,8 @@
        ;; held for the whole drive, and nothing can wait on it through a
        ;; drain-lock. CLJS is single-threaded and runs every outermost emit inline
        ;; with no monitor.
-       #?(:clj  (locking fanout-monitor (run-outermost-fanout! event continue?))
-          :cljs (run-outermost-fanout! event continue?))))))
+       #?(:clj  (locking fanout-monitor (run-outermost-fanout! [[event continue?]]))
+          :cljs (run-outermost-fanout! [[event continue?]]))))))
 
 (late-bind/set-fn! :trace.tooling/deliver! deliver-to-tooling!)
 

--- a/implementation/core/test/re_frame/trace_listener_deferred_batch_fifo_cljs_test.cljc
+++ b/implementation/core/test/re_frame/trace_listener_deferred_batch_fifo_cljs_test.cljc
@@ -1,0 +1,175 @@
+(ns re-frame.trace-listener-deferred-batch-fifo-cljs-test
+  "rf2-t6vs3 — a DEFERRED trace batch must stay AHEAD of any later
+  listener-authored trace, on EVERY host.
+
+  ## The defect this pins (rf2-t6vs3)
+
+  PR #6452's post-drain flush (`re-frame.trace.tooling/drain-deferred-batch!`)
+  preserved FIFO only among the deferred items it had ALREADY inserted into a
+  fan-out schedule. It took the captured `pending` batch but appended and drove
+  one item at a time — both when integrating into an active `*fanout-ctx*` and
+  when opening fresh outermost fan-outs. While driving the FIRST deferred event,
+  a listener could synchronously `trace/emit!`; that later trace was appended to
+  the current schedule and delivered BEFORE the flush loop had inserted the older
+  deferred events still sitting in the batch.
+
+  ## The probe (identical on both hosts)
+
+  Dispatch ONE event. The drain emits `:rf.event/run-start` … `:rf.event/run-end`
+  while it owns the frame's lock, so those emits DEFER as one batch. A listener
+  reacts to that event's `run-start` by authoring a new trace
+  (`:audit/listener-nested`). Because that authored trace is emitted at flush
+  time it carries a HIGHER `:id` than the already-captured `run-end`. An observer
+  listener records the `:id` (the authoritative emission order) of every event in
+  DELIVERY order:
+
+    - correct (post-fix): the whole batch is queued before any callback runs, so
+      the authored trace lands behind `run-end`. Delivery IDs stay monotonically
+      increasing and the observer sees run-start, run-end, THEN the nested trace.
+    - overtake (the defect): the flush drives `run-start` before `run-end` is even
+      inserted, so the nested trace (higher id) overtakes the still-pending
+      `run-end`. Delivery IDs REGRESS — the observer sees run-start, the nested
+      trace, then run-end.
+
+  The assertion is an OBSERVABLE OUTCOME — the delivery-ID order — never an
+  exception; this class does not throw, it silently misorders. Ring/ID emission
+  order stays correct throughout, so a stateful tool folding the delivered stream
+  now receives a different order from the authoritative IDs — the exact drift the
+  bead reports.
+
+  Two levers pin the two seams the flush must keep FIFO (bead acceptance):
+
+    - `deferred-batch-outranks-listener-authored-trace-at-top-level` — the
+      OUTERMOST flush (a top-level `dispatch-sync`; `*fanout-ctx*` unbound), which
+      seeds fresh outermost fan-outs.
+    - `deferred-batch-outranks-listener-authored-trace-when-integrated` — the
+      INTEGRATE path (a listener-initiated `dispatch-sync` whose batch folds into
+      an already-active outer fan-out; `*fanout-ctx*` bound).
+
+  Dual-host (`npm run test:cljs` + `clojure -M:test`): intra-drain listener
+  influence is platform-uniform, so the same deftests pin JVM and CLJS. `-cljs-test`
+  matches the shadow `:node-test` ns-regexp and cognitect-test-runner's `*-test`
+  discovery."
+  (:require #?(:clj  [clojure.test :refer [deftest is use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is use-fixtures]])
+            [re-frame.core                 :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.trace                :as trace]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private nested-op :audit/listener-nested)
+
+(defn- monotonic?
+  "True iff `xs` never decreases — the delivered `:id` stream must climb, since
+  each `:id` is stamped in emission order and a later emit must never be
+  delivered before an earlier one."
+  [xs]
+  (or (< (count xs) 2) (apply <= xs)))
+
+(defn- index-of [xs x]
+  (first (keep-indexed (fn [i y] (when (= x y) i)) xs)))
+
+(deftest deferred-batch-outranks-listener-authored-trace-at-top-level
+  ;; OUTERMOST seam: a top-level `dispatch-sync` defers the whole run batch, then
+  ;; flushes it with `*fanout-ctx*` unbound (fresh outermost fan-outs). A
+  ;; run-start listener authors a later trace; it must not overtake the
+  ;; already-captured run-end still sitting in the batch.
+  (let [seen     (atom [])          ;; observer's [operation id] stream, in delivery order
+        emitted? (atom false)]
+    (rf/reg-event :t6vs3/noop (fn [{:keys [db]} _] {:db db}))
+    ;; EMITTER (registered first): on THIS event's run-start, author exactly one
+    ;; nested trace. Emitted at flush time, so its `:id` exceeds run-end's.
+    (trace/register-listener! ::emitter
+      (fn [ev]
+        (when (and (= :rf.event/run-start (:operation ev))
+                   (= :t6vs3/noop (first (-> ev :tags :rf.event/v)))
+                   (compare-and-set! emitted? false true))
+          (trace/emit! :info nested-op {}))))
+    ;; OBSERVER: record every event's operation + id, in the order delivered.
+    (trace/register-listener! ::observer
+      (fn [ev] (swap! seen conj [(:operation ev) (:id ev)])))
+    (try
+      (rf/dispatch-sync [:t6vs3/noop] {:frame :rf/default})
+      (let [stream @seen
+            ids    (mapv second stream)
+            ops    (mapv first stream)]
+        ;; Vacuity guard: the lever actually engaged.
+        (is (true? @emitted?)
+            "the run-start listener never authored its nested trace")
+        (is (some #{nested-op} ops)
+            "the observer never received the listener-authored trace")
+        ;; PRIMARY lever: delivery IDs must not regress. Under the defect the
+        ;; nested trace (higher id) is delivered before run-end (lower id).
+        (is (monotonic? ids)
+            (str "delivery IDs regressed — a listener-authored trace overtook an "
+                 "older still-pending deferred item. Stream: " (pr-str stream)))
+        ;; The bead's exact observation: run-start, run-end, THEN the nested trace
+        ;; — never run-start, nested, run-end.
+        (let [ro (index-of ops :rf.event/run-end)
+              no (index-of ops nested-op)]
+          (is (and ro no (< ro no))
+              (str "the listener-authored trace was delivered before the "
+                   "already-captured run-end. Ops in delivery order: "
+                   (pr-str ops)))))
+      (finally
+        (trace/unregister-listener! ::emitter)
+        (trace/unregister-listener! ::observer)))))
+
+(deftest deferred-batch-outranks-listener-authored-trace-when-integrated
+  ;; INTEGRATE seam: a `::trigger` listener reacts to a clean, frameless emit (so
+  ;; an OUTER fan-out is in flight and `*fanout-ctx*` is bound) by
+  ;; `dispatch-sync`-ing into a frame. That nested drain defers its run batch and,
+  ;; on the way out, the flush INTEGRATES the batch into the still-active outer
+  ;; schedule. A run-start listener authors a later trace; the same FIFO law must
+  ;; hold — it must not overtake the still-pending run-end.
+  (let [seen     (atom [])
+        fired?   (atom false)
+        emitted? (atom false)]
+    (rf/reg-event :t6vs3/inner (fn [{:keys [db]} _] {:db db}))
+    ;; TRIGGER (registered first): reentrant dispatch-sync from inside the outer
+    ;; fan-out — opens the nested drain whose batch integrates on flush.
+    (trace/register-listener! ::trigger
+      (fn [ev]
+        (when (and (= :t6vs3/trigger (:operation ev))
+                   (compare-and-set! fired? false true))
+          (rf/dispatch-sync [:t6vs3/inner] {:frame :rf/default}))))
+    ;; EMITTER: on the INNER event's run-start, author one nested trace.
+    (trace/register-listener! ::emitter
+      (fn [ev]
+        (when (and (= :rf.event/run-start (:operation ev))
+                   (= :t6vs3/inner (first (-> ev :tags :rf.event/v)))
+                   (compare-and-set! emitted? false true))
+          (trace/emit! :info nested-op {}))))
+    ;; OBSERVER: record the delivery order of every event.
+    (trace/register-listener! ::observer
+      (fn [ev] (swap! seen conj [(:operation ev) (:id ev)])))
+    (try
+      (trace/emit! :info :t6vs3/trigger {})
+      (let [stream @seen
+            ids    (mapv second stream)
+            ops    (mapv first stream)]
+        (is (true? @fired?)
+            "the trigger listener never opened the nested dispatch-sync")
+        (is (true? @emitted?)
+            "the inner run-start listener never authored its nested trace")
+        (is (some #{nested-op} ops)
+            "the observer never received the listener-authored trace")
+        ;; PRIMARY lever: delivery IDs must not regress even when the batch is
+        ;; integrated into an active outer schedule.
+        (is (monotonic? ids)
+            (str "delivery IDs regressed on the integrate path — a "
+                 "listener-authored trace overtook an older still-pending "
+                 "deferred item. Stream: " (pr-str stream)))
+        (let [ro (index-of ops :rf.event/run-end)
+              no (index-of ops nested-op)]
+          (is (and ro no (< ro no))
+              (str "the listener-authored trace was delivered before the inner "
+                   "drain's already-captured run-end. Ops in delivery order: "
+                   (pr-str ops)))))
+      (finally
+        (trace/unregister-listener! ::trigger)
+        (trace/unregister-listener! ::emitter)
+        (trace/unregister-listener! ::observer)))))


### PR DESCRIPTION
## Summary

PR #6452's post-drain flush (`re-frame.trace.tooling/drain-deferred-batch!`) preserved FIFO only among the deferred items it had **already** inserted into a fan-out schedule. It took the captured `pending` batch but **appended and drove one item at a time** — both when integrating into an active `*fanout-ctx*` and when opening fresh outermost fan-outs. While driving the **first** deferred event a listener could synchronously `trace/emit!`; that later trace was appended to the current schedule and delivered **before** the flush loop had inserted the older deferred events still sitting in `batch`.

Ring/ID emission order stayed correct throughout, so a stateful tool folding the delivered stream received a **different order from the authoritative IDs** — a violation of the public trace-listener law (every listener sees events in runtime emission order) and Spec 009.

## The fix (one ordering correction inside the existing seam)

Queue the **whole** captured batch onto **one** fan-out schedule before driving any callback:

- **Integrate path** (listener-initiated `dispatch-sync`; `*fanout-ctx*` bound): `into` the batch onto the active queue, then `drive-fanout!` once.
- **Outermost path** (top-level dispatch / async drain; `*fanout-ctx*` unbound): seed **one** fresh schedule for the whole batch, then drive.

Either way a listener-authored later emit appends **behind** every older deferred item, while `drive-fanout!` still advances the paused outer event to its remaining listeners first (rf2-1zxlsm) and completes the batch before the enclosing `dispatch-sync` returns (rf2-s522m). Each queued triple still carries its append-time listener snapshot, which the driver honours per event.

The two now-symmetric outermost helpers collapse into a single `run-outermost-fanout!` taking a batch (a single clean emit is a batch of one), retiring the dead per-event `entries` arity.

**No scheduler, async delivery, public API, event-shape classifier, or platform split** — the rf2-wxy1c charter (one private post-drain ownership seam, serialized process-wide, platform-uniform) is intact. **No new error id and no Spec 009 prose change**: the change makes the implementation conform to the existing FIFO contract.

## Proof

Red-before on the bead's exact public-API repro, on **both hosts**:

- **Outermost seam**: `[[:rf.event/run-start 10] [:audit/listener-nested 14] [:rf.event/db-pending 11] [:rf.event/db-noop 12] [:rf.event/run-end 13]]` — the listener-authored trace (id 14) overtakes the still-pending run-end (13); delivery IDs regress.
- **Integrate seam**: same shape (id 25 overtakes 22/23/24).
- Green after: run-start, run-end, then the nested trace; delivery IDs monotonic.

## Quality gates

| Gate | Result |
|------|--------|
| `implementation/core` `clojure -M:test` | 2095 tests, 10326 assertions, **0 failures** |
| `implementation/machines` `clojure -M:test` | 1195 tests, 4164 assertions, **0 failures** |
| `npm run test:cljs` (dual-host) | 10288 tests, 50738 assertions, **0 failures** |
| `npm run test:bundle-isolation` | **PASS** (trace `:cljs` seam DCEs out of production) |
| `npm run test:elision` | **PASS** (production 60/60 absent) |

New dual-host suite `trace_listener_deferred_batch_fifo_cljs_test.cljc` pins both seams; #6452 regression suites (reentrant dispatch-sync deferral, post-drain settled state, concurrent-drain serialization, nested emission order) stay green.