### PR TITLE
fix(ui): linearize custom-element conflict admission and preserve all equal declarers (rf2-u25hr, rf2-7uyl9)

### DIFF
--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -1031,22 +1031,26 @@
 ;; the same pure function.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private owner-key
-  "Owner provenance slot on a live aggregate entry: the `[build-id ns-sym]` of
-  the source whose declaration is live for that tag.
+(def ^:private owners-key
+  "Owner provenance slot on a live aggregate entry: the SET of `[build-id ns-sym]`
+  sources whose `rf=`-equal declarations are live for that tag.
 
-  Written in the SAME swap as the declaration itself, because the law's evidence
-  needs BOTH anchors and production carries no ledger to look an incumbent up in
-  (rf2-k9yuy). Readers are unaffected — `custom-element-properties` reads
-  `:properties` off the entry — and there is deliberately NO second atom and no
-  parallel index that could drift from it."
-  ::owner)
+  A SET, not a single canonical owner (rf2-7uyl9): several sources may
+  legitimately state the same fact, and a later replacement from one of them must
+  be able to name EVERY other source still contributing it — otherwise it could
+  silently overwrite a manifest another source still declares, and the conflict
+  evidence could not name every declarer. Written in the SAME swap as the
+  declaration itself, because the law's evidence needs every anchor and production
+  carries no ledger to look incumbents up in (rf2-k9yuy). Readers are unaffected —
+  `custom-element-properties` reads `:properties` off the entry — and there is
+  deliberately NO second atom and no parallel index that could drift from it."
+  ::owners)
 
 (defn- declaration
   "The DECLARATION half of a live entry — the entry minus its provenance. What
-  two sources must agree on, `rf=`, for their declarations to co-exist."
+  the equal declarers all agree on, `rf=`, for their declarations to co-exist."
   [entry]
-  (dissoc entry owner-key))
+  (dissoc entry owners-key))
 
 (defn- conflict-row
   "One anchor of a contradiction, in the ruled evidence shape (mirrors the
@@ -1055,63 +1059,64 @@
   {:build build-id :ns ns-sym :properties (:properties decl #{})})
 
 (defn- conflict-evidence
-  "Both anchors of a contradiction, SORTED — so the evidence is byte-identical
-  under every permutation of source names, evaluation order and build ids."
-  [tag incumbent-owner incumbent-decl source decl]
+  "Every anchor of a contradiction, SORTED. `incumbent-owners` are all the
+  sources whose `rf=`-equal `incumbent-decl` is live for `tag`; `source`/`decl`
+  is the arriving contradiction. Naming EVERY equal declarer — not one canonical
+  owner (rf2-7uyl9) — is what stops a replacement silently overwriting a manifest
+  another source still declares, and makes the anchors complete. Sorting by
+  `[build ns]` keeps the evidence byte-identical under every permutation of
+  source names, evaluation order and build ids."
+  [tag incumbent-owners incumbent-decl source decl]
   {:tag tag
-   :declarations (vec (sort-by (juxt (comp str :build) (comp str :ns))
-                               [(conflict-row incumbent-owner incumbent-decl)
-                                (conflict-row source decl)]))})
-
-(defn- canonical-owner
-  "Which of two sources declaring the SAME fact is named as the entry's owner:
-  the lexicographically smaller `[build-id ns-sym]`.
-
-  `rf=`-equal duplicates co-exist, so neither is a winner over the other — but
-  one of them has to be the anchor a LATER contradiction is reported against.
-  Taking the smaller makes that anchor a function of the SET of equal declarers
-  rather than of the order they happened to evaluate in, which is what keeps
-  conflict evidence identical under every permutation. It decides nothing
-  observable about the manifest: the two declarations it chooses between are
-  equal, so no property classification depends on the choice."
-  [a b]
-  (if (neg? (compare (mapv str a) (mapv str b))) a b))
+   :declarations (->> (conj (mapv #(conflict-row % incumbent-decl) incumbent-owners)
+                            (conflict-row source decl))
+                      (sort-by (juxt (comp str :build) (comp str :ns)))
+                      vec)})
 
 (defn- admit
   "THE law, as one pure step: fold `source`'s declaration of `tag` into
   aggregate `agg`.
 
   Returns `{:aggregate agg'}` when the declaration is admitted, or
-  `{:conflict evidence}` — carrying BOTH `[build-id ns-sym]` anchors — when it
-  contradicts a live declaration from a DIFFERENT source, in which case NOTHING
-  is written and `agg` remains the last-known-good aggregate.
+  `{:conflict evidence}` — naming EVERY equal live declarer plus `source`
+  (rf2-7uyl9) — when it contradicts a live declaration from a DIFFERENT source,
+  in which case NOTHING is written and `agg` remains the last-known-good
+  aggregate.
 
-  Three admissions and one rejection:
+  Each entry records the SET of sources whose `rf=`-equal declarations are live
+  (`owners-key`). Four cases:
 
-    - no live declaration for `tag`  -> admitted; `source` owns the entry.
-    - the live one is `source`'s OWN -> REPLACED. A source never conflicts with
-                                        itself: re-declaration is what a reload
-                                        or a REPL re-eval legitimately does.
-    - the live one is `rf=`-EQUAL    -> duplicates co-exist (idempotent — two
-                                        namespaces may legitimately state the
-                                        same fact); `canonical-owner` decides
-                                        which is named in future evidence.
-    - anything else                  -> CONFLICT. Never a merge, never a winner
-                                        by evaluation or sort order.
+    - no live declaration for `tag`  -> admitted; `source` is its sole declarer.
+    - the arriving decl is `rf=`-EQUAL to the live one -> `source` JOINS the
+                                        declarer set (idempotent if already in);
+                                        duplicates co-exist, and every one is now
+                                        named in any future contradiction.
+    - not equal, but `source` is the SOLE live declarer -> REPLACED. A source
+                                        never conflicts with itself: re-declaration
+                                        is what a reload or a REPL re-eval does.
+    - not equal, and OTHER sources still declare the live value -> CONFLICT,
+                                        naming every remaining declarer. Never a
+                                        merge, never a winner by evaluation order.
 
   Pure and total, so the production write barrier (`write-element!`) and the
   dev-side ledger projection (`aggregate`) apply literally the same law and
   cannot drift from one another."
   [agg tag decl source]
-  (let [entry    (get agg tag)
-        owner    (get entry owner-key)
-        admit-as (fn [o] {:aggregate (assoc agg tag (assoc decl owner-key o))})]
+  (let [entry  (get agg tag)
+        owners (get entry owners-key)]
     (cond
-      (nil? owner)                      (admit-as source)
-      (= owner source)                  (admit-as source)
-      (eq/rf= (declaration entry) decl) (admit-as (canonical-owner owner source))
-      :else {:conflict (conflict-evidence tag owner (declaration entry)
-                                          source decl)})))
+      (nil? owners)
+      {:aggregate (assoc agg tag (assoc decl owners-key #{source}))}
+
+      (eq/rf= (declaration entry) decl)
+      {:aggregate (assoc agg tag (assoc decl owners-key (conj owners source)))}
+
+      (= owners #{source})
+      {:aggregate (assoc agg tag (assoc decl owners-key #{source}))}
+
+      :else
+      {:conflict (conflict-evidence tag (disj owners source)
+                                    (declaration entry) source decl)})))
 
 (defn- throw-element-conflict!
   "Raise the ruled runtime conflict on the ALWAYS-ON error seam — never a

--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -1305,6 +1305,30 @@
           {:keys [conflict]} (aggregate reconciled)]
       (if conflict {:conflict conflict} {:sources reconciled}))))
 
+(defn- write-through-verdict
+  "Pure: the verdict of admitting `source`'s declaration of `tag` into ledger
+  value `st` on the WRITE-THROUGH path (no cycle open for the build).
+
+  Decided against the ledger's OWN projection (`aggregate` over `::sources`), so
+  the whole admission is ONE decision on the single `ledger-state` atom
+  (rf2-u25hr) — never a check against a snapshot of `@custom-elements`, which a
+  concurrent, differently-timed live write can leave stale. That split is exactly
+  the defect: two write-throughs each prechecked the still-empty live aggregate,
+  both entered `::sources`, and only one live write won — stranding the loser's
+  row in the ledger while the projection went nil. Deciding against `::sources`
+  instead serialises the two on this one atom: the second sees the first's row
+  and is rejected before it can enter.
+
+  Returns `{:sources st'}` with the row recorded in `::sources` when admitted, or
+  `{:conflict evidence}` when it contradicts a live source, leaving `::sources`
+  untouched. `::sources` is conflict-free by invariant (a rejected row never
+  enters it), so its projection is always a clean aggregate."
+  [st source tag decl]
+  (let [live (:aggregate (aggregate (::sources st)))]
+    (if-let [conflict (:conflict (admit live tag decl source))]
+      {:conflict conflict}
+      {:sources (update-in st [::sources source] (fnil assoc {}) tag decl)})))
+
 (defn register-custom-element!
   "Register `tag`'s runtime property classification under its declaring source.
   Emitted top-level by `ui/custom-element`, so it re-runs on every ns hot-reload.
@@ -1344,30 +1368,39 @@
                            (if (contains? (::cycles st) build-id)
                              (update-in st [::cycles build-id :staged source]
                                         (fnil assoc {}) tag decl)
-                             ;; WRITE-THROUGH. Apply the SAME verdict the
-                             ;; aggregate barrier below is about to apply, so a
-                             ;; REJECTED write-through leaves no row behind for a
-                             ;; later `commit-reload!` to publish — which would
-                             ;; let the next reload defeat the barrier, and would
-                             ;; wedge every subsequent commit against a ledger
-                             ;; that can no longer be projected.
+                             ;; WRITE-THROUGH. The admission verdict is decided
+                             ;; INSIDE this one `ledger-state` swap, against the
+                             ;; ledger's OWN projection (`write-through-verdict`),
+                             ;; never against a snapshot of `@custom-elements` a
+                             ;; concurrent live write can leave stale (rf2-u25hr).
+                             ;; Two write-throughs for one tag therefore serialise
+                             ;; on this atom: the second sees the first's row in
+                             ;; `::sources` and is rejected, so a rejected row can
+                             ;; never remain in `::sources` while the live
+                             ;; aggregate holds the winner. A rejected write-through
+                             ;; leaves `::sources` untouched here and (below)
+                             ;; publishes nothing — NEITHER atom moves off
+                             ;; last-known-good.
                              ;;
                              ;; A STAGED row is deliberately NOT checked here: it
                              ;; is not live yet, and the rows it would be checked
                              ;; against are the very ones this cycle is about to
-                             ;; replace, so a stage-time check would reject
-                             ;; legitimate edits. The reconciled fold in
-                             ;; `commit-reload!` is the staged path's check, and
-                             ;; it decides on the POST-reconciliation value.
-                             (if (:conflict (admit @custom-elements tag decl source))
-                               st
-                               (update-in st [::sources source]
-                                          (fnil assoc {}) tag decl)))))]
-         ;; The winning transition saw `old`; if `old` had no open cycle it was a
-         ;; write-through, so publish this row incrementally. (Staged
+                             ;; replace. `commit-reload!` is the staged path's
+                             ;; check, on the POST-reconciliation value.
+                             (:sources (write-through-verdict st source tag decl)
+                                       st))))]
+         ;; The winning transition saw `old`; re-derive its verdict from that same
+         ;; `old` to PUBLISH or to RAISE. `::sources` already carries the admitted
+         ;; row (written in the swap above), so `publish!` — a pure projection of
+         ;; the LIVE ledger — republishes it without a second, differently-timed
+         ;; opinion and cannot lose it to a concurrent commit; a rejected
+         ;; write-through raises without either atom having moved. (Staged
          ;; registrations stay invisible until commit.)
          (when-not (contains? (::cycles old) build-id)
-           (write-element! tag decl source)))
+           (let [{:keys [conflict]} (write-through-verdict old source tag decl)]
+             (if conflict
+               (throw-element-conflict! conflict)
+               (publish! build-id)))))
        (write-element! tag decl source)))
    tag))
 

--- a/implementation/ui/test/re_frame/ui/custom_element_reload_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/custom_element_reload_elision_prod_test.cljs
@@ -148,4 +148,34 @@
     (is (= #{:after} (rules/custom-element-properties :own-el))
         (str marker " — a source replaces its own declaration in production"))
 
+    ;; COMPOSITION (rf2-7uyl9) — equal-duplicate admission THEN a replacement from
+    ;; one equal declarer, under :advanced + goog.DEBUG=false. Two sources declare
+    ;; the SAME fact, so BOTH are live declarers; when one then re-declares a
+    ;; different manifest it is NOT a lone self-replacement — the other still
+    ;; contributes #{:p} — so it must be REJECTED with BOTH declarers named, and
+    ;; the shared manifest must survive. This is exactly the provenance the entry
+    ;; must carry through DCE: one canonical owner would have admitted the
+    ;; overwrite here too.
+    (rules/reset-custom-elements!)
+    (rules/register-custom-element! :both-el {:properties #{:p}} 'app.one)
+    (rules/register-custom-element! :both-el {:properties #{:p}} 'app.two)
+    (is (= #{:p} (rules/custom-element-properties :both-el))
+        (str marker " — equal duplicates from two sources co-exist in production"))
+    (let [outcome (try
+                    (rules/register-custom-element! :both-el
+                                                    {:properties #{:changed}}
+                                                    'app.one)
+                    :admitted
+                    (catch :default e (ex-data e)))]
+      (is (= :rf.error/custom-element-conflict (:rf.error/id outcome))
+          (str marker " — a re-declaration over a live equal duplicate is REJECTED "
+               "under DCE, not silently admitted by dropping the other declarer"))
+      (is (= [{:build build :ns 'app.one :properties #{:changed}}
+              {:build build :ns 'app.two :properties #{:p}}]
+             (:declarations outcome))
+          (str marker " — the evidence names EVERY equal declarer, not one "
+               "canonical owner")))
+    (is (= #{:p} (rules/custom-element-properties :both-el))
+        (str marker " — the shared last-known-good manifest survives the rejection"))
+
     (rules/reset-custom-elements!)))

--- a/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
@@ -8,15 +8,16 @@
 
 (defn- declared
   "`agg` (default: the live aggregate) with each entry's owner provenance
-  stripped. rf2-vxgfnd.143 stamps `[build-id ns-sym]` onto every entry in the
-  same swap as the declaration, so the conflict law can anchor BOTH sides of a
-  contradiction without a second atom. The reload-protocol assertions below are
-  about WHICH declarations are live, not who owns them; provenance and the law
-  it serves are pinned by `re-frame.ui.rules-custom-element-conflict-cljs-test`."
+  stripped. rf2-vxgfnd.143 stamps the declarer `[build-id ns-sym]` set onto every
+  entry in the same swap as the declaration (rf2-7uyl9), so the conflict law can
+  anchor every side of a contradiction without a second atom. The reload-protocol
+  assertions below are about WHICH declarations are live, not who owns them;
+  provenance and the law it serves are pinned by
+  `re-frame.ui.rules-custom-element-conflict-cljs-test`."
   ([] (declared @rules/custom-elements))
   ([agg]
    (into {}
-         (map (fn [[tag entry]] [tag (dissoc entry :re-frame.ui.rules/owner)]))
+         (map (fn [[tag entry]] [tag (dissoc entry :re-frame.ui.rules/owners)]))
          agg)))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/ui/test/re_frame/ui/rules_custom_element_conflict_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_custom_element_conflict_cljs_test.cljc
@@ -354,3 +354,100 @@
   (is (= #{:l} (rules/custom-element-properties :lib-el))
       "the other build's row is untouched by the reconcile")
   (is (= (rules/projected-aggregate) @rules/custom-elements)))
+
+;; ---------------------------------------------------------------------------
+;; Every equal declarer is preserved before a replacement (rf2-7uyl9)
+;;
+;; When several sources contribute `rf=`-equal declarations for one tag, the
+;; aggregate must record EVERY one of them — not a single canonical owner. Losing
+;; the others let a source's later self-replacement silently overwrite a manifest
+;; another source still declared, and left conflict evidence unable to name every
+;; declarer. These folds compose the two situations the prior tests covered only
+;; in isolation: equal duplicates, and a source replacing itself.
+;; ---------------------------------------------------------------------------
+
+(deftest an-equal-duplicate-blocks-a-conflicting-self-replacement
+  ;; The bead's canonical repro. Two sources declare the SAME fact, so BOTH are
+  ;; live declarers of :x-el #{:p}. When either of them then re-declares a
+  ;; DIFFERENT manifest it is NOT a lone self-replacement: the OTHER source still
+  ;; contributes #{:p}, so the arriving #{:q} contradicts a live declaration and
+  ;; must be rejected, naming the remaining declarer AND the arrival. Recording
+  ;; one canonical owner lost the other declarer and admitted the overwrite —
+  ;; whether the re-declaration came from the canonical owner or the other one.
+  (doseq [replacer '[a.ns z.ns]]
+    (rules/reset-custom-elements!)
+    (rules/register-custom-element! :x-el {:properties #{:p}} 'a.ns)
+    (rules/register-custom-element! :x-el {:properties #{:p}} 'z.ns)
+    (let [known-good @rules/custom-elements
+          outcome    (register! [:x-el {:properties #{:q}} replacer])
+          arrival    (first (filter #(= replacer (:ns %)) (:declarations outcome)))]
+      (is (= conflict-id (:rf.error/id outcome))
+          (str replacer " re-declaring over a live equal duplicate is rejected"))
+      (is (= 2 (count (:declarations outcome)))
+          "the evidence names the remaining declarer AND the arrival")
+      (is (= #{:q} (:properties arrival))
+          "the arriving source carries its own new declaration")
+      (is (= #{:p} (rules/custom-element-properties :x-el))
+          "the last-known-good manifest is untouched — no silent overwrite")
+      (is (= known-good @rules/custom-elements)
+          "neither the aggregate nor its provenance changed")
+      (is (= (rules/projected-aggregate) @rules/custom-elements)
+          "ledger and aggregate stay coherent — the row never entered ::sources"))))
+
+(deftest a-replacement-conflict-names-every-equal-declarer
+  ;; N sources state the same fact; a contradictory replacement must name EVERY
+  ;; one of them, not a single canonical owner — the anchors are supposed to be
+  ;; complete. And because the evidence is sorted, it is byte-identical under
+  ;; every order the N equal declarers were registered in.
+  (let [declarers '[a.ns m.ns z.ns]
+        run (fn [order]
+              (rules/reset-custom-elements!)
+              (doseq [ns-sym order]
+                (is (= :admitted (register! [:x-el {:properties #{:p}} ns-sym]))
+                    (str ns-sym " states the shared fact and co-exists")))
+              ;; a NEW source contradicts all N equal declarers
+              (register! [:x-el {:properties #{:q}} 'new.ns]))
+        outcomes (map run (permutations declarers))]
+    (is (= 6 (count outcomes)) "all 3! declarer orders ran")
+    (is (every? #(= conflict-id (:rf.error/id %)) outcomes)
+        "the contradiction is rejected in every declarer order")
+    (is (= 1 (count (set outcomes)))
+        "and the evidence is BYTE-IDENTICAL under declarer order")
+    (let [ev (first outcomes)]
+      (is (= 4 (count (:declarations ev)))
+          "all three equal declarers are named, plus the arrival — not one canonical")
+      (is (= '[a.ns m.ns new.ns z.ns] (mapv :ns (:declarations ev)))
+          "every declarer named, sorted by [build ns]")
+      (is (= [#{:p} #{:p} #{:q} #{:p}] (mapv :properties (:declarations ev)))
+          "each equal declarer keeps #{:p}; the arrival carries #{:q}"))
+    (is (= #{:p} (rules/custom-element-properties :x-el))
+        "the last-known-good manifest survives — the replacement never wrote")))
+
+(deftest a-sole-remaining-declarer-can-replace-itself-after-eviction
+  ;; A source replacing its OWN sole declaration is never a conflict. And once a
+  ;; co-declarer is GENUINELY removed — a reload in which it re-runs contributing
+  ;; nothing evicts it — the remaining source becomes sole and may replace itself:
+  ;; provenance shrinks to exactly the live declarers, never a frozen owner.
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :x-el {:properties #{:p}} 'a.ns)
+  (is (= :admitted (register! [:x-el {:properties #{:q}} 'a.ns]))
+      "a sole declarer replaces its own declaration freely")
+  (is (= #{:q} (rules/custom-element-properties :x-el)))
+  ;; Reintroduce a co-declarer: now a.ns can no longer change the manifest.
+  (rules/reset-custom-elements!)
+  (rules/register-custom-element! :x-el {:properties #{:p}} 'a.ns)
+  (rules/register-custom-element! :x-el {:properties #{:p}} 'z.ns)
+  (is (= conflict-id (:rf.error/id (register! [:x-el {:properties #{:q}} 'a.ns])))
+      "while z.ns still co-declares, a.ns cannot replace the shared manifest")
+  ;; z.ns's file drops the declaration: it re-runs this cycle contributing
+  ;; nothing, so the reload evicts its row.
+  (rules/notify-reload!)
+  (rules/note-reloaded-sources! ['z.ns])
+  (rules/register-custom-element! :x-el {:properties #{:p}} 'a.ns) ; a.ns re-runs unchanged
+  (rules/commit-reload!)
+  (is (= #{:p} (rules/custom-element-properties :x-el))
+      "z.ns is evicted; a.ns is the sole declarer")
+  (is (= :admitted (register! [:x-el {:properties #{:q}} 'a.ns]))
+      "now the sole remaining declarer may replace itself")
+  (is (= #{:q} (rules/custom-element-properties :x-el)))
+  (is (= (rules/projected-aggregate) @rules/custom-elements)))

--- a/implementation/ui/test/re_frame/ui/rules_reload_linearizability_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/rules_reload_linearizability_jvm_test.clj
@@ -170,6 +170,61 @@
       (is (= (rules/projected-aggregate) @rules/custom-elements)
           (str "round " round ": settled aggregate equals the ledger projection")))))
 
+(deftest conflicting-write-throughs-linearize-across-ledger-and-live-registry
+  ;; rf2-u25hr. Two DIFFERENT sources write-through a CONTRADICTORY declaration of
+  ;; ONE tag with no cycle open. The admission must be ONE decision across the
+  ;; ledger `::sources` and the live `custom-elements` aggregate: exactly one is
+  ;; admitted, the rejected row is ABSENT from `::sources`, and the ledger
+  ;; projection equals the live registry.
+  ;;
+  ;; THE LEVER is a `CyclicBarrier` redef'd into the live-registry write
+  ;; `write-element!`, forcing BOTH registrations past their ledger step before
+  ;; EITHER live write — the exact interleaving the pre-fix code mis-serialised:
+  ;; both prechecked the still-EMPTY live aggregate `@custom-elements` in their
+  ;; ledger swap, so both entered `::sources`; then one live write won and the
+  ;; other threw, stranding the loser's row in `::sources`. The projection then
+  ;; went nil (a ledger holding a contradiction) while the live aggregate held the
+  ;; winner — the two atoms torn apart. Post-fix the verdict is decided INSIDE the
+  ;; single `ledger-state` swap against the ledger's own projection, so the second
+  ;; write-through sees the first's `::sources` row and is rejected there, never
+  ;; reaching a live write — and the lever, which only trips inside `write-element!`
+  ;; (unused by the dev write-through path), is simply inert.
+  (dotimes [round 200]
+    (rules/reset-custom-elements!)
+    (let [gate  (CyclicBarrier. 2)
+          start (CyclicBarrier. 2)
+          orig  @#'rules/write-element!
+          [ra rb]
+          (with-redefs-fn
+            {#'rules/write-element!
+             (fn [& args] (.await gate) (apply orig args))}
+            (fn []
+              (let [a (future (await-barrier start)
+                              (try (rules/register-custom-element!
+                                    :x-el {:properties #{:a}} 'a.ns :b1)
+                                   :admitted
+                                   (catch Exception e (:rf.error/id (ex-data e)))))
+                    b (future (await-barrier start)
+                              (try (rules/register-custom-element!
+                                    :x-el {:properties #{:z}} 'z.ns :b2)
+                                   :admitted
+                                   (catch Exception e (:rf.error/id (ex-data e)))))]
+                [@a @b])))]
+      (is (= #{:admitted :rf.error/custom-element-conflict} (set [ra rb]))
+          (str "round " round ": exactly one admitted, one conflict-rejected"))
+      (is (= 1 (count @rules/custom-elements))
+          (str "round " round ": the live aggregate holds exactly one winner"))
+      (is (contains? #{#{:a} #{:z}} (rules/custom-element-properties :x-el))
+          (str "round " round ": the winner is one of the two declarations"))
+      ;; THE cross-atom consistency proof: the ledger projects to EXACTLY the live
+      ;; aggregate. A rejected row left in `::sources` would make the projection a
+      ;; contradiction (nil) that diverges from the non-nil live winner — the
+      ;; pre-fix failure this asserts against.
+      (is (= (rules/projected-aggregate) @rules/custom-elements)
+          (str "round " round
+               ": the ledger projection EQUALS the live aggregate — the rejected "
+               "write-through left no row in ::sources")))))
+
 (deftest concurrent-write-throughs-on-distinct-builds-compose
   ;; Two DISJOINT ledger partitions, no cycles: concurrent initial-load
   ;; registrations must both land in the aggregate — the publication path never

--- a/implementation/ui/test/re_frame/ui/rules_reload_linearizability_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/rules_reload_linearizability_jvm_test.clj
@@ -32,13 +32,14 @@
 
 (defn- declared
   "The live aggregate with each entry's owner provenance stripped
-  (rf2-vxgfnd.143 stamps `[build-id ns-sym]` onto every entry in the same swap
-  as the declaration). These rounds assert WHICH declarations are live under a
-  race, which is orthogonal to who owns them; provenance and the conflict law it
-  anchors are pinned by `re-frame.ui.rules-custom-element-conflict-cljs-test`."
+  (rf2-vxgfnd.143 stamps the declarer `[build-id ns-sym]` set onto every entry in
+  the same swap as the declaration — rf2-7uyl9). These rounds assert WHICH
+  declarations are live under a race, which is orthogonal to who owns them;
+  provenance and the conflict law it anchors are pinned by
+  `re-frame.ui.rules-custom-element-conflict-cljs-test`."
   []
   (into {}
-        (map (fn [[tag entry]] [tag (dissoc entry :re-frame.ui.rules/owner)]))
+        (map (fn [[tag entry]] [tag (dissoc entry :re-frame.ui.rules/owners)]))
         @rules/custom-elements))
 
 (deftest register-races-commit-equals-a-legal-serial-execution


### PR DESCRIPTION
Two atomicity/provenance gap-fixes for the custom-element conflict law shipped by #6440 (rf2-vxgfnd.143). Corrections WITHIN the ruled law (Option A, fail-atomically) — no policy change: `rf=`-equal duplicates coexist, same-source re-declaration replaces, any other cross-source declaration fails atomically with both anchors and last-known-good intact. The production check stays on the advanced-surviving `write-element!` write path (not behind `reload-ledger?`); the classification/catalogue and Spec 009 are untouched (reuses `:rf.error/custom-element-conflict`). No mutex, no new atom, no config knob, no evidence framework.

## rf2-u25hr — linearize write-through admission across the two atoms

The dev/JVM write-through decided admission from a snapshot of `@custom-elements` taken inside the `ledger-state` swap, then wrote the live aggregate afterward through a separate barrier. Two conflicting registrations could both precheck the still-empty live aggregate, both enter `::sources`, and then one live write wins while the other throws — stranding the loser's row in `::sources`, so `projected-aggregate` went nil (a ledger holding a contradiction) while the live aggregate held the winner.

Fix: decide the write-through verdict INSIDE the single `ledger-state` swap, against the ledger's own `::sources` projection (`write-through-verdict`), and publish the live aggregate as a pure projection of the committed ledger. Two write-throughs for one tag now serialise on that one atom — the second sees the first's row and is rejected before it can enter. Production keeps its single atomic `write-element!` barrier with the ledger DCE'd (the `else` arm is unchanged).

## rf2-7uyl9 — preserve every equal declarer before a replacement

An entry recorded ONE canonical `::owner` even when several sources contributed `rf=`-equal declarations. A later same-source re-declaration was then admitted by `(= owner source)` though other sources still declared the old manifest — the overwrite went live and the ledger projection turned to a contradiction, and evidence could name only the one canonical declarer.

Fix: record the SET of declarer `[build-id ns-sym]` sources on the entry (`::owner` → `::owners`). `admit` now joins a source on an `rf=`-equal duplicate, replaces only when the source is the SOLE declarer, and otherwise conflicts naming EVERY remaining equal declarer plus the arrival. `canonical-owner` is retired. Readers (`custom-element-properties` → `:properties`) are unchanged; no second atom.

## Quality gates

All run to completion in the worktree (foreground, unpiped):

- `cd implementation/ui && clojure -M:test` — Ran 1001 tests, 19587 assertions, 0 failures, 0 errors
- `npm run test:cljs` — Ran 10289 tests, 50773 assertions, 0 failures, 0 errors
- `npm run test:browser-prod-elision` — `ui mounted production elision: PASS`; browser: Ran 113 tests, 484 assertions, 0 failures, 0 errors (the composition case admits an equal duplicate then rejects a canonical-owner replacement under `:advanced` + `goog.DEBUG=false`)
- `npm run test:elision` — PASS (production 60/60 absent, control 60/60 present)
- `cd implementation/core && clojure -M:test` — Ran 2093 tests, 10317 assertions, 0 failures, 0 errors (catalogue parse: no new/perturbed error id)

Vacuity probes (red-before, own lever, observable state):

- **u25hr**: a JVM `CyclicBarrier` redef'd into `write-element!` forces both conflicting write-throughs past their ledger step before either live write. Red on pre-fix code every one of 200 rounds (`projected-aggregate` nil ≠ live winner); green after.
- **7uyl9**: N `rf=`-equal declarers then a contradictory replacement — 8 assertions red on single-owner code (only 2 declarers named instead of all N; self-replacement silently admitted; ledger poisoned), green after. Evidence names all N and is byte-identical under declarer order.

#6440's 16 permutation deftests and the elision pin remain green; dual-host (JVM + node) throughout.
