### PR TITLE
feat(ui): implement the client-only phase flip per the spec/011 contract (rf2-3omxp)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr/phase_flip_hydration_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/phase_flip_hydration_dom_cljs_test.cljs
@@ -1,0 +1,331 @@
+(ns re-frame.ssr.phase-flip-hydration-dom-cljs-test
+  "Real-DOM proof of the `ui/client-only` PHASE FLIP — the S5 half of
+  `ui/client-only` (rf2-3omxp; Spec 011 §Phase flip).
+
+  ## Why this test lives in the ssr tree
+
+  The flip is a property of a HYDRATING root, and only `re-frame.ssr` +
+  `re-frame.ui.client/hydrate-root` together produce one: `ssr/hydrate!` boots
+  the frame state and `ui/hydrate-root` adopts the server DOM (via the
+  `:ssr/discover-root-manifest` seam). A test that drives a real flip therefore
+  needs BOTH artefacts loaded, which is what the `ssr` test tree provides (the
+  same reason `hydrate-root-seam-dom-cljs-test` lives here).
+
+  ## What this proves — the SIX ruled points of Spec 011 §Phase flip
+
+    1. PHASE-CONDITIONAL SITE + SINGLE UPDATE — a `reg-view` `ui/client-only`
+       site renders its FALLBACK in `:server` phase during hydration, then swaps
+       to the CLIENT subtree after the hydration commit. The swap replaces the
+       exact server-emitted fallback node with the client subtree.
+
+    3. TIMING — the flip runs as the root's NEXT ORDINARY UPDATE after the
+       hydration commit, never before. Proven negatively: hydration is CLEAN —
+       no `onRecoverableError` fires — which can only be true if the first
+       (hydration) render produced the FALLBACK (matching the server markup),
+       not the client subtree. A phase that booted `:client` would render the
+       `<button>` against a server `<p>` and fire a recoverable mismatch.
+
+    4. FAILED ROOT — a root that fails to boot never flips: its server fallback
+       markup stays in place, inert (composes with the `rf2-1b0po` missing-
+       manifest failure — no scenario multiplication).
+
+    5. MULTI-ROOT — two roots flip independently; a failed sibling does not
+       delay or block a good root's flip (no page-wide barrier).
+
+  Every assertion reads an OBSERVABLE OUTCOME — a DOM node's presence, its
+  text, its identity, or the absence of a recoverable-error callback. None
+  merely asserts that an exception occurred.
+
+  Browser-only — a flip is a real-DOM operation (a passive effect after a
+  real hydration commit). The `-dom-cljs-test` suffix opts this file into the
+  `:browser-test` build; the `:node-test` build loads it too (it matches
+  `cljs-test$`) and every body gates on `(browser?)`, so a node run is an
+  honest skip rather than a vacuous pass."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.constants :as constants]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.client :as ui-client]))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; ---------------------------------------------------------------------------
+;; The app under the boot — ids unique to this ns so the shared bundle cannot
+;; collide at image assembly.
+;; ---------------------------------------------------------------------------
+
+(def ^:private app-frame ::frame)
+
+(rf/reg-sub ::label (fn [db _] (or (:label db) "client-label")))
+
+;; A compiled root with a `ui/client-only` site. The FALLBACK is capability-
+;; free static markup (`<p class="fb">`), the deterministic JVM/SSR +
+;; first-hydration render. The CLIENT subtree is the live reactive content
+;; (`<button class="live">` reading a sub). `<span class="static">` sits
+;; OUTSIDE the client-only site — it hydrates normally in every phase and
+;; proves the rest of the tree is untouched by the flip.
+(defview phase-root []
+  [:div.phaseapp
+   [:span.static "always"]
+   (ui/client-only {:fallback [:p.fb "loading"]}
+     [:button.live (ui/sub [::label])])])
+
+;; ---------------------------------------------------------------------------
+;; Server-side artefacts, planted by hand. The server render emits the fallback
+;; markup for a client-only site (its client subtree never appears on the
+;; JVM/SSR tree), so the planted body is the fallback.
+;; ---------------------------------------------------------------------------
+
+(def ^:private server-body
+  ;; Exactly what a server render of `phase-root` emits: the static sibling and
+  ;; the client-only FALLBACK, the `:rf.ui/boundary :client-only` fragment being
+  ;; transparent in HTML. A byte-match keeps hydration a clean adoption.
+  (str "<div class=\"phaseapp\">"
+       "<span class=\"static\">always</span>"
+       "<p class=\"fb\">loading</p>"
+       "</div>"))
+
+(defn- manifest-for [root-id container-id]
+  {:rf.root/schema-version 1
+   :root-id                root-id
+   :identifier-prefix      (str (name root-id) "-")
+   :element-locator        {:id container-id}})
+
+(defn- manifest-script [root-id container-id]
+  (str "<script type=\"application/edn\" "
+       constants/root-manifest-marker-attribute ">"
+       (pr-str (manifest-for root-id container-id))
+       "</script>"))
+
+(defn- plant-host!
+  "Append the shape a server render emits for ONE root: a container holding the
+  server body (the fallback markup), followed IMMEDIATELY by its Root Manifest
+  as the next element sibling (that adjacency is the discovery rule). When
+  `:manifest?` is false the manifest is omitted — the broken-markup shape a
+  hydrating root must FAIL on. Returns the wrapper host."
+  [{:keys [manifest? root-id container-id body]
+    :or   {manifest? true root-id ::phase-root container-id "phase-container"
+           body server-body}}]
+  (let [host (.createElement js/document "div")]
+    (set! (.-innerHTML host)
+          (str "<div id=\"" container-id "\">" body "</div>"
+               (when manifest? (manifest-script root-id container-id))))
+    (.appendChild (.-body js/document) host)
+    host))
+
+(defn- container [host container-id]
+  (.querySelector host (str "#" container-id)))
+
+(defn- teardown! [host & roots]
+  (doseq [ra roots]
+    (when-let [root @ra]
+      (try (ui/unmount! root) (catch :default _ nil)))
+    (reset! ra nil))
+  (when-let [p (.-parentNode host)] (.removeChild p host)))
+
+;; Hydration commits on React's own schedule here, so turn the act environment
+;; off for the duration (same treatment `hydrate-root-seam-dom-cljs-test` and
+;; `ssr-startup-recipe-dom-cljs-test` apply). With act off, a genuine hydration
+;; mismatch reaches `:on-recoverable-error`.
+(defn- disable-act-env! []
+  (let [prev (.-IS_REACT_ACT_ENVIRONMENT js/globalThis)]
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+    prev))
+
+(defn- restore-act-env! [prev]
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) prev))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter ui/adapter :async? true :ambient-frame nil}))
+
+(defn- thrown-error [f]
+  (try (f) nil
+       (catch :default e
+         {:id (:rf.error/id (ex-data e)) :data (ex-data e)})))
+
+(defn- wait-for
+  "Poll `pred` every 5ms up to ~1s, then call `k`. Bounded so a flip that never
+  arrives lets the assertions in `k` fail honestly rather than hang."
+  [pred k]
+  (let [tries (atom 0)]
+    (letfn [(step []
+              (if (or (pred) (>= @tries 200))
+                (k)
+                (do (swap! tries inc) (js/setTimeout step 5))))]
+      (step))))
+
+;; ---------------------------------------------------------------------------
+;; 1. The vertical — fallback at hydration, client subtree after ONE update
+;; ---------------------------------------------------------------------------
+
+(deftest phase-flip-swaps-fallback-to-client-in-one-post-commit-update
+  (when (browser?)
+    (async done
+      (let [act-prev    (disable-act-env!)
+            host        (plant-host! {})
+            root-atom   (atom nil)
+            recoverable (atom [])]
+        (rf/init! ui/adapter)
+        (rf/make-frame {:id app-frame :platform :client})
+        ;; The flip is a property of DOM ADOPTION (`ui/hydrate-root`), independent
+        ;; of the `ssr/hydrate!` state boot (item 1, proven by
+        ;; `hydrate-root-seam-dom-cljs-test`): the capability-free fallback carries
+        ;; no state, so the flip is exercised by hydration alone.
+        (let [fb-node (.querySelector host "p.fb")]
+          (reset! root-atom
+                  (ui/hydrate-root (container host "phase-container")
+                                   [ui/frame-provider {:frame app-frame} [phase-root]]
+                                   {:on-recoverable-error
+                                    (fn [e _] (swap! recoverable conj e))}))
+          ;; SYNCHRONOUS — the flip is a passive effect; it has NOT run yet. The
+          ;; hydrating root is in :server phase, so the fallback is the live
+          ;; content and the client subtree is absent.
+          (is (some? (.querySelector host "p.fb"))
+              "fallback present at hydration — the root booted :server phase")
+          (is (nil? (.querySelector host "button.live"))
+              "client subtree absent at hydration — the site is phase-conditional")
+          (is (true? (.-isConnected fb-node))
+              "the server-emitted fallback node is the hydrated content")
+          (wait-for
+           #(some? (.querySelector host "button.live"))
+           (fn []
+             (try
+               (testing "the post-commit flip swapped fallback -> client subtree in ONE update"
+                 (is (some? (.querySelector host "button.live"))
+                     "the client subtree is present after the flip")
+                 (is (nil? (.querySelector host "p.fb"))
+                     "the fallback was swapped away — one root-scoped update, not left tearing")
+                 (is (false? (.-isConnected fb-node))
+                     "the exact server fallback node was removed by the flip"))
+               (testing "the non-client-only part of the tree hydrated normally"
+                 (is (some? (.querySelector host "span.static"))
+                     "the static sibling stayed through both phases"))
+               (testing "the flipped subtree is the LIVE client render over hydrated state"
+                 (is (= "client-label"
+                        (.-textContent (.querySelector host "button.live")))
+                     "the client subtree rendered its reactive sub value"))
+               (testing "TIMING — hydration was clean, so the FIRST render was the fallback"
+                 (is (empty? @recoverable)
+                     (str "no hydration-mismatch recoverable error fired. A flip "
+                          "that beat the hydration commit — or a site born :client "
+                          "— would have rendered the <button> against the server "
+                          "<p> and fired a mismatch. Clean hydration proves the "
+                          "first render was the :server-phase fallback")))
+               (testing "the root is registered under the manifest's root-id"
+                 (is (= ::phase-root (ui-client/root-id-of @root-atom))))
+               (finally
+                 (teardown! host root-atom)
+                 (restore-act-env! act-prev)
+                 (done))))))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. A failed root never flips — its fallback stays inert (Spec 011 point 4)
+;; ---------------------------------------------------------------------------
+
+(deftest failed-root-fallback-stays-inert-never-flips
+  (when (browser?)
+    (async done
+      (let [act-prev  (disable-act-env!)
+            ;; No adjacent manifest — the rf2-1b0po failed-root shape: a
+            ;; hydrating root that cannot discover its identity fails to boot.
+            host      (plant-host! {:manifest? false})
+            root-atom (atom nil)]
+        (rf/init! ui/adapter)
+        (rf/make-frame {:id app-frame :platform :client})
+        (let [{:keys [id data]}
+              (thrown-error
+               #(ui/hydrate-root (container host "phase-container")
+                                 [ui/frame-provider {:frame app-frame} [phase-root]]))]
+          (is (= :rf.error/root-manifest-invalid id)
+              "the root failed to boot — composes with rf2-1b0po (missing manifest)")
+          (is (= :manifest (:missing data))
+              "ex-data names which part is missing"))
+        ;; The root never created a React tree, so nothing can ever flip it.
+        ;; Give the scheduler a turn, then prove the fallback stayed inert.
+        (wait-for
+         (constantly false)  ;; just let a macrotask pass; nothing to await
+         (fn []
+           (try
+             (testing "a failed root's server fallback stays in place, inert"
+               (is (some? (.querySelector host "p.fb"))
+                   "the capability-free fallback still stands — degrades gracefully")
+               (is (nil? (.querySelector host "button.live"))
+                   "and it NEVER flipped to the client subtree"))
+             (finally
+               (teardown! host root-atom)
+               (restore-act-env! act-prev)
+               (done)))))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. Multi-root — siblings flip independently; a failed sibling never blocks
+;;    a good root's flip (Spec 011 point 5 — no page-wide barrier)
+;; ---------------------------------------------------------------------------
+
+(def ^:private frame-a ::frame-a)
+(def ^:private frame-b ::frame-b)
+
+(defn- plant-two-roots!
+  "A real two-root page: root A (good, with manifest) and root B (BROKEN — no
+  adjacent manifest). Each container holds the fallback body."
+  []
+  (let [host (.createElement js/document "div")]
+    (set! (.-innerHTML host)
+          (str "<div id=\"root-a\">" server-body "</div>"
+               (manifest-script ::root-a "root-a")
+               "<div id=\"root-b\">" server-body "</div>"))  ;; B: no manifest
+    (.appendChild (.-body js/document) host)
+    host))
+
+(deftest sibling-roots-flip-independently-failed-sibling-does-not-block
+  (when (browser?)
+    (async done
+      (let [act-prev    (disable-act-env!)
+            host        (plant-two-roots!)
+            root-a      (atom nil)
+            recoverable (atom [])]
+        (rf/init! ui/adapter)
+        (rf/make-frame {:id frame-a :platform :client})
+        (rf/make-frame {:id frame-b :platform :client})
+        ;; Root B fails to boot (no manifest) BEFORE root A is even mounted —
+        ;; the failure is contained (rf2-1b0po) and must not stop A flipping.
+        (let [{:keys [id]}
+              (thrown-error
+               #(ui/hydrate-root (.querySelector host "#root-b")
+                                 [ui/frame-provider {:frame frame-b} [phase-root]]))]
+          (is (= :rf.error/root-manifest-invalid id)
+              "sibling B failed to boot — a contained failure"))
+        ;; Root A boots normally. Its flip must land despite B's failure.
+        (reset! root-a
+                (ui/hydrate-root (.querySelector host "#root-a")
+                                 [ui/frame-provider {:frame frame-a} [phase-root]]
+                                 {:on-recoverable-error
+                                  (fn [e _] (swap! recoverable conj e))}))
+        (wait-for
+         #(some? (.querySelector (.querySelector host "#root-a") "button.live"))
+         (fn []
+           (try
+             (testing "root A flipped independently of its failed sibling"
+               (is (some? (.querySelector (.querySelector host "#root-a") "button.live"))
+                   "good root A swapped to its client subtree — no page-wide barrier")
+               (is (nil? (.querySelector (.querySelector host "#root-a") "p.fb"))
+                   "and its fallback was swapped away"))
+             (testing "the failed sibling B stayed on its inert fallback"
+               (is (some? (.querySelector (.querySelector host "#root-b") "p.fb"))
+                   "broken root B never flipped — its fallback still stands")
+               (is (nil? (.querySelector (.querySelector host "#root-b") "button.live"))
+                   "and B never produced a client subtree"))
+             (testing "root A's flip was a CLEAN post-commit update, not a hydration mismatch"
+               (is (empty? @recoverable)
+                   (str "root A hydrated its fallback cleanly then flipped — no "
+                        "recoverable mismatch. A site born :client would have "
+                        "mismatched the server <p> and fired this")))
+             (finally
+               (teardown! host root-a)
+               (restore-act-env! act-prev)
+               (done)))))))))

--- a/implementation/ui/src/re_frame/ui/client.cljs
+++ b/implementation/ui/src/re_frame/ui/client.cljs
@@ -68,6 +68,7 @@
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.ui.frames :as frames]
             [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.runtime :as runtime]
             [re-frame.ui.viewcell :as viewcell]))
 
 ;; ---------------------------------------------------------------------------
@@ -1433,8 +1434,18 @@
           (check-root-claim! 're-frame.ui/hydrate-root info container)
           (let [react-root (rdc/hydrateRoot
                             container
+                            ;; rf2-3omxp — a HYDRATING root is the one root kind
+                            ;; that flips: wrap the compiled element in the phase
+                            ;; flipper, which boots `:server` (first render =
+                            ;; fallbacks, matching the server markup) and flips to
+                            ;; `:client` as its next ordinary update after the
+                            ;; hydration commit. `(element-thunk)` still evaluates
+                            ;; first, so a synchronous throw from it propagates to
+                            ;; the rollback catch unchanged. Non-hydrating mounts
+                            ;; (mount* / render!*) wrap nothing and never flip.
                             (render-attempt-element
-                             receipt root-id incarnation (element-thunk))
+                             receipt root-id incarnation
+                             (runtime/with-phase-flip root-id (element-thunk)))
                             (react-opts-with-attempt-abort
                              (react-opts-with-identifier-prefix react-opts prefix)
                              root-id incarnation))

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -2425,9 +2425,14 @@
 (defn- analyze-client-only
   "(ui/client-only {:fallback tpl} client-tpl) — a browser-only subtree with a
   mandatory, capability-free fallback (compiler-checked). The JVM/SSR renders
-  the fallback (a deterministic `:rf.ui/boundary :client-only` node); the client
-  renders the client subtree (the S3 activation; the single-update SSR
-  phase-flip completes S5, per [011])."
+  the fallback (a deterministic `:rf.ui/boundary :client-only` node); the CLJS
+  emitter lowers the site to a PHASE-CONDITIONAL runtime boundary
+  (`re-frame.ui.runtime/client-only`) that renders the fallback in `:server`
+  phase and the client subtree in `:client` phase — the S5 phase flip a
+  hydrating root drives `:server` -> `:client` after its hydration commit (Spec
+  011 §Phase flip, rf2-3omxp). A non-hydrating mount reads the `:client` phase
+  default and renders the client subtree on the first render (the S3
+  activation)."
   [e form]
   (let [opts  (nth form 1 nil)
         rest* (drop 2 form)]

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -664,10 +664,20 @@
     :slot     (emit-slot node st)
     :error-boundary (emit-error-boundary node st)
     :presence (emit-presence node st)
-    ;; S3: the browser renders the client subtree directly (activation). The
-    ;; capability-free fallback is the JVM/SSR path only; the single-update SSR
-    ;; phase-flip (fallback→client per root) completes S5.
-    :client-only (emit-node (:child node) st inline?)
+    ;; client-only (S5 phase flip, rf2-3omxp; Spec 011 §Phase flip): the site
+    ;; compiles to a PHASE-CONDITIONAL runtime boundary. It renders the
+    ;; capability-free fallback in `:server` phase (the JVM/SSR + first-hydration
+    ;; render) and the client subtree in `:client` phase, reading a root-scoped
+    ;; phase context a hydrating root flips `:server` -> `:client` in one update
+    ;; after its hydration commit. Both arms therefore ride the client bundle:
+    ;; the fallback template now compiles in (the ruled, perf-budget-covered cost
+    ;; — the browser must materialise the fallback vdom during the hydration
+    ;; render). A non-hydrating mount has no phase Provider, so the boundary reads
+    ;; the `:client` default and renders the client subtree on the first render,
+    ;; byte-identical to S3.
+    :client-only `(re-frame.ui.runtime/client-only
+                   ~(emit-node (:fallback node) st false)
+                   ~(emit-node (:child node) st false))
     ;; Leading (effect …) statements spliced before the template: a `do`
     ;; sequences the lowered effect hook calls, then renders the template.
     :hook-prefix `(do ~@(:statements node) ~(emit-node (:body node) st inline?))

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -14,6 +14,7 @@
             [re-frame.error :as error]
             [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
+            [re-frame.trace :as trace :include-macros true]
             [re-frame.ui.eq :as eq]
             [re-frame.ui.events :as events]
             [re-frame.ui.reactive :as reactive]
@@ -613,3 +614,114 @@
   (jsx2 ErrorBoundary
         #js {:fallback fallback :resetKey reset-key
              :onError on-error :children child}))
+
+;; ---------------------------------------------------------------------------
+;; ui/client-only — the S5 phase flip (rf2-3omxp; Spec 011 §Phase flip)
+;;
+;; S3 shipped the `ui/client-only` macro: a site with a mandatory,
+;; capability-free `:fallback` (the JVM/SSR + first-hydration render) and a
+;; client subtree. What S3 left unbuilt is HOW the fallback becomes the client
+;; subtree after a server-rendered root hydrates. This is that mechanism.
+;;
+;; A root renders in one of two PHASES, `:server` or `:client` (the same
+;; vocabulary as the Root Manifest `:phase` key). The phase is ONE root-scoped
+;; value, carried by `phase-context`. A compiled `ui/client-only` site is
+;; phase-conditional: it reads the phase and renders its fallback in `:server`
+;; phase, its client subtree in `:client` phase.
+;;
+;; The context DEFAULT is `:client`, so every tree with no phase Provider above
+;; it — every non-hydrating mount (`mount` / `render!` / `ui.test/render`) and
+;; `render-static` — reads `:client` and renders the client subtree on the
+;; first and only render, byte-identical to S3 (there is no fallback pass to
+;; flip away from). Only a hydrating root installs a Provider (see
+;; `PhaseFlipper` / `with-phase-flip`), boots `:server`, and flips once.
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private phase-context
+  (react/createContext :client))
+
+(defn ^:private ClientOnly
+  ;; The phase-conditional runtime for one compiled `ui/client-only` site: a
+  ;; React function component that SUBSCRIBES to the root-scoped phase context
+  ;; (`useContext`). Because context propagation ignores `React.memo`
+  ;; boundaries, React re-renders THIS boundary directly when a hydrating root
+  ;; flips `:server` -> `:client` — the enclosing memoised ViewCell needs no
+  ;; involvement. Returns `fallback` in `:server` phase, `children` (the client
+  ;; subtree) in `:client` phase. A function component adds no DOM of its own,
+  ;; so the `:server`-phase render is structurally the fallback — exactly the
+  ;; server-emitted markup, so hydration is a clean adoption.
+  [^js props]
+  (if (= :server (react/useContext phase-context))
+    (.-fallback props)
+    (.-children props)))
+
+(when ^boolean js/goog.DEBUG
+  (set! (.-displayName ClientOnly) "rf.ui/client-only"))
+
+(defn client-only
+  "Build a phase-conditional `(ui/client-only {:fallback fb} child)` element —
+  the CLJS emitter's lowering target (S5 phase flip, rf2-3omxp). `fallback` is
+  the capability-free `:server`/first-hydration subtree; `child` is the client
+  subtree. See `ClientOnly`."
+  [fallback child]
+  (jsx2 ClientOnly #js {:fallback fallback :children child}))
+
+(defn ^:private emit-phase-flip!
+  ;; The ONE `:rf.ssr/phase-flip` diagnostic trace, at the flip commit. Rides
+  ;; the diagnostic channel via `re-frame.trace/emit!`; the `interop/debug-
+  ;; enabled?` gate DCEs the whole call under `:advanced` + `goog.DEBUG=false`
+  ;; (Spec 009 §Production builds). It is NOT an event and mints no epoch —
+  ;; called from a React passive effect, outside any dispatch/handler scope, so
+  ;; it never correlates to an epoch (`emit!` reads a nil `*handler-scope*`).
+  [root-id]
+  (when interop/debug-enabled?
+    (trace/emit! :info :rf.ssr/phase-flip {:root-id root-id})))
+
+(defn ^:private PhaseFlipper
+  ;; Drives the phase flip for ONE hydrating root. It boots `:server` (so the
+  ;; first = hydration render produces fallbacks, matching the server markup and
+  ;; keeping the hydration-mismatch snapshot honest — the snapshot is taken over
+  ;; the `:server`-phase tree by `ssr/hydrate!` BEFORE this even mounts), then
+  ;; flips to `:client` as the root's NEXT ORDINARY UPDATE after the hydration
+  ;; commit. A passive effect (`useEffect`) does the flip: passive effects run
+  ;; after the commit AND after paint, so the flip never beats the snapshot, and
+  ;; a painted fallback frame before the swap is by design (there is no
+  ;; `flushSync` — the capability-free fallback is presentable UI, nothing to
+  ;; race). The single phase-context write swaps EVERY client-only site in the
+  ;; root in the one update it produces. A root that fails to boot never commits
+  ;; this component, so its passive effect never runs and it never flips — its
+  ;; server fallback markup stays inert (`:rf.error/root-boot-failed` already
+  ;; fired; no additional error). Per-root and independent: each flipper is keyed
+  ;; to its own root's commit, so a slow/failed sibling never delays this flip.
+  [^js props]
+  (let [root-id   (.-rfRootId props)
+        pair      (react/useState :server)
+        phase     (aget pair 0)
+        set-phase (aget pair 1)]
+    (react/useEffect
+     (fn phase-flip []
+       ;; The effect fires once per phase value. On the `:server` (mount /
+       ;; hydration) commit it schedules the flip; on the `:client` commit — the
+       ;; flip commit — it emits the trace. `phase` is monotonic (`:server` ->
+       ;; `:client`, once), so the trace fires exactly once per hydrating root.
+       (if (= :server phase)
+         (set-phase :client)
+         (emit-phase-flip! root-id))
+       js/undefined)
+     #js [phase])
+    (react/createElement (.-Provider phase-context)
+                         #js {:value phase}
+                         (.-children props))))
+
+(when ^boolean js/goog.DEBUG
+  (set! (.-displayName PhaseFlipper) "rf.ui/phase-flipper"))
+
+(defn with-phase-flip
+  "Wrap a hydrating root's compiled `element` in the phase flipper (S5 phase
+  flip, rf2-3omxp). ONLY `ui/hydrate-root` calls this. A non-hydrating mount
+  installs no flipper, so its tree has no phase Provider and every
+  `ui/client-only` site reads the `:client` default and renders its client
+  subtree on the first render — byte-identical to S3. `render-static` likewise
+  installs none and stays pure `:server`."
+  [root-id element]
+  (react/createElement PhaseFlipper #js {:rfRootId root-id} element))


### PR DESCRIPTION
Implements **item 3 of `rf2-3omxp`** — the client-only phase flip, the last unbuilt piece of S5 — against the shipped `spec/011 §Phase flip` contract (rf2-jygc8, #6461). Items 1 (hydrate-root seam, #6458) and 2 (emit-ui-tree serialiser, #6448) already shipped.

## The six ruled points (implemented exactly, no invented semantics)

1. **Phase model** — a root-scoped phase context (`re-frame.ui.runtime/phase-context`, default `:client`) makes the compiled `ui/client-only` site phase-conditional: fallback in `:server`, client subtree in `:client`. Non-hydrating mounts (`mount`/`render!`/`ui.test/render`) and `render-static` install no provider, read the `:client` default, and never flip — S3 byte-identical.
2. **Single update** — one root-scoped context write (`set-phase :client`) swaps every client-only site in the root; no per-site flip state.
3. **Timing** — a hydrating root boots `:server` (first render = fallbacks, matching the server markup so the mismatch snapshot `ssr/hydrate!` takes before the mount stays honest), then flips as the next ordinary update via a **passive** `useEffect` — after the commit and after paint, no `flushSync`; a painted fallback frame is by design.
4. **Failed root** — a root that fails to boot never installs the flipper (React tree never commits), so its fallback stays inert; no additional error.
5. **Multi-root** — the flipper is per-root, keyed to its own commit; no page-wide barrier; a failed sibling never blocks a good root's flip.
6. **Observability** — one `:rf.ssr/phase-flip` `:info` diagnostic trace at the flip commit, `{:root-id …}`, on the diagnostic channel via `trace/emit!`; DCE'd under `:advanced` + `goog.DEBUG=false`; **not** an event and mints **no** epoch (emitted from a passive effect, outside any dispatch scope).

## Design

The compiled site lowers to a `ClientOnly` boundary **component** that subscribes to the phase context — mirroring the `ui/error-boundary` / `ui/presence` runtime pattern. Context propagation ignores `React.memo`, so the single flip re-renders every boundary directly, independent of the enclosing memoised ViewCell. `hydrate-root*` wraps the root element in the phase flipper; `mount*`/`render!*` wrap nothing. Per the contract, the **fallback template now rides the client bundle** (the ruled, perf-budget-covered cost) — no new size gate added.

Surface: `emit_cljs.cljc` (phase-conditional site), `runtime.cljs` (phase context + `ClientOnly` boundary + `PhaseFlipper` + trace), `client.cljs` (flipper wrap in `hydrate-root*`), `analyze.cljc` (docstring). No shipped spec edited; no new error id; no new public API var (`api-manifest gen --check`: 520 vars, in sync).

## Proof

`implementation/ssr/test/re_frame/ssr/phase_flip_hydration_dom_cljs_test.cljs` — mounted-browser acceptance:
- **vertical**: fallback present at hydration (`:server` phase, synchronous), client subtree present after one post-commit update; the exact server fallback node is removed by the flip; **clean hydration** (no `:on-recoverable-error`) proves the first render was the fallback, not the client subtree;
- **failed root** stays inert (composes with `rf2-1b0po` missing-manifest failure);
- **multi-root** independence — a good root flips despite a failed sibling; no page-wide barrier.

**Red-before verified**: reverting the flip wrap reds exactly the two flip tests on `(is (empty? @recoverable))` — the site is born `:client`, renders the `<button>` against the server `<p>`, and fires a hydration mismatch. All S3 tests stayed green (only my 2 failed), confirming byte-identical non-hydrating behaviour.

## Quality gates

All green on the rebased base (current `origin/main`):

| Gate | Result |
|---|---|
| `implementation/ui` JVM (`clojure -M:test`) | **997 tests**, 0 failures |
| `npm run test:cljs` (node CLJS) | **10285 tests**, 50731 assertions, 0 failures |
| `npm run test:browser` | **498 tests**, 2785 assertions, 0 failures (flip proof mounted) |
| `npm run test:elision` | PASS — production 60/60 absent, control 60/60 present; `phase-flip` sentinel **absent** from the release bundle (direct grep = 0) |
| `npm run test:browser-prod-elision` | **113 tests**, 0 failures; ui-mounted prod elision PASS |
| `npm run test:perf-bundle` | PASS — off=626020, on=626805 chars, no budget breach (fallback rides the bundle, as ruled — no gate added) |
| `api-manifest gen --check` | in sync, 520 public vars, no new public var |
| `check-no-hardcoded-paths` | OK |