### PR TITLE
fix(ssr): raw-text script/style, leading-newline preservation, and empty hydration prefix in emit-ui-tree (rf2-2dh3b, rf2-z05di, rf2-y3swx)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/manifest.cljc
+++ b/implementation/ssr/src/re_frame/ssr/manifest.cljc
@@ -552,6 +552,28 @@
 ;; Discovery (CLJS — it reaches into the DOM)
 ;; ---------------------------------------------------------------------------
 
+(defn canonicalize-effective-prefix
+  "Resolve a validated manifest's EFFECTIVE React identifier prefix for
+  hydration identity (rf2-y3swx). React 19.2's `hydrateRoot` has no distinct
+  \"no prefix\" state: it canonicalizes an OMITTED `identifierPrefix` option to
+  the empty string `\"\"`, and `useId` derives its ids from that empty prefix
+  (server `renderToString` with no prefix does the same). A Root Manifest that
+  OMITS `:identifier-prefix` therefore records that the server rendered under
+  React's effective EMPTY prefix — NOT \"no effective prefix at all\".
+
+  Discovery IS the client hydration identity boundary, so it stamps that
+  effective value: an absent `:identifier-prefix` becomes `\"\"`. This lets the
+  client-runtime live-root uniqueness fence (Spec 004C Layer 3) see two
+  omitted-prefix roots as BOTH owning `\"\"` and reject the second before any
+  React work, and it feeds React the empty prefix it already uses — never a
+  client-synthesized, root-id-derived prefix, which would disagree with the
+  server and break hydration. An AUTHORED prefix passes through untouched. This
+  resolves the effective IDENTITY only; the wire form and `valid?` keep
+  `:identifier-prefix` an OPTIONAL extension key (this is not a schema change)."
+  [m]
+  (cond-> m
+    (not (contains? m :identifier-prefix)) (assoc :identifier-prefix "")))
+
 #?(:cljs
    (defn manifest-script?
      "Is `el` a root-manifest script element? Both marks must be present:
@@ -586,7 +608,11 @@
      [container]
      (let [el (some-> container .-nextElementSibling)]
        (when (manifest-script? el)
-         (read-manifest 'rf.ssr/discover-root-manifest (.-textContent el))))))
+         ;; rf2-y3swx — stamp React's effective empty prefix onto an
+         ;; omitted `:identifier-prefix`, so the hydration identity the caller
+         ;; reads matches what React actually uses (an omitted prefix is `""`).
+         (canonicalize-effective-prefix
+          (read-manifest 'rf.ssr/discover-root-manifest (.-textContent el)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The `ui -> core late-bind <- ssr` discovery seam (rf2-3omxp)

--- a/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
+++ b/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
@@ -501,6 +501,53 @@
       (str/replace "'" "&#x27;")))
 
 ;; ---------------------------------------------------------------------------
+;; Raw-text elements — <script>/<style> content is HTML RAW TEXT (rf2-2dh3b)
+;; ---------------------------------------------------------------------------
+
+(def raw-text-tags
+  "The HTML RAW-TEXT elements whose text children react-dom/server 19.2 emits
+  WITHOUT entity escaping. React special-cases EXACTLY these two: `:title` and
+  `:textarea` are escapable RCDATA (escaped normally, so NOT here)."
+  #{"script" "style"})
+
+(defn escape-raw-text
+  "Serialise the text content of a raw-text element (`<script>` / `<style>`)
+  the way react-dom/server 19.2 does — the raw-text half of the conversion
+  table's escaping row (Spec 004B §Children, text, and escaping; the blanket
+  `escape-html` row does NOT hold inside raw-text elements).
+
+  The HTML parser does not decode character references inside raw-text
+  elements, so routing script/style text through `escape-html` CORRUPTS it: a
+  valid `a & b < c` becomes the literal DOM text `a &amp; b &lt; c`, and CSS/JS
+  containing `<`/`&` stops meaning what it says. React therefore emits the text
+  VERBATIM and only rewrites an embedded closing-tag sequence to a
+  CONTEXT-SAFE spelling so the raw-text parser cannot terminate the element
+  early (byte-parity with React's `scriptRegex`/`styleRegex` + replacers):
+
+    - `<script>`: `(<|</)script` (case-insensitive) -> the `s`/`S` becomes the
+      JavaScript unicode escape `\\u0073` / `\\u0053`. The JS engine reads it
+      back as `s`/`S`; the HTML parser no longer sees `</script`.
+    - `<style>`:  `(<|</)style`  -> the `s`/`S` becomes the CSS escape
+      `\\73 ` / `\\53 ` (the trailing space terminates the hex escape). CSS
+      reads it back as `s`/`S`.
+
+  NOT a sanitiser, and NO XSS hole beyond React's own. `emit-ui-tree`
+  serialises an ALREADY-RENDERED, server-authored structural tree (this ns's
+  trust contract — every value is a literal the server's own views produced,
+  never user input), exactly the trusted content react-dom/server itself emits
+  raw; the closing-sequence escape is the same breakout guard React applies.
+  Untrusted author markup has its own explicit, unrelated bypass (`:html`)."
+  [tag-lc s]
+  (case tag-lc
+    "script" (str/replace s #"(</?)([sS])([cC][rR][iI][pP][tT])"
+                          (fn [[_ prefix s-char suffix]]
+                            (str prefix (if (= s-char "s") "\\u0073" "\\u0053") suffix)))
+    "style"  (str/replace s #"(</?)([sS])([tT][yY][lL][eE])"
+                          (fn [[_ prefix s-char suffix]]
+                            (str prefix (if (= s-char "s") "\\73 " "\\53 ") suffix)))
+    s))
+
+;; ---------------------------------------------------------------------------
 ;; Attribute value serialisation (the value half of the table).
 ;; ---------------------------------------------------------------------------
 
@@ -660,6 +707,7 @@
         tag-name  (name tag)
         norm-tag  (str/lower-case tag-name)
         void?     (contains? void-tags (keyword norm-tag))
+        raw-text? (contains? raw-text-tags norm-tag)
         pp        (if (custom-element-tag? tag)
                     (set (or (:rf.ui/property-props el) #{}))
                     #{})
@@ -681,6 +729,10 @@
         open      (str "<" tag-name (attrs->string attrs pp))]
     (cond
       void?          (str open ">")
+      ;; rf2-2dh3b — <script>/<style> content is HTML raw text: emit it
+      ;; unescaped (only the closing-sequence escape), matching react-dom/server.
+      raw-text?      (str open ">" (escape-raw-text norm-tag (str/join (:children el)))
+                          "</" tag-name ">")
       (some? ta-val) (str open ">" (escape-html (coerce-val ta-val)) "</" tag-name ">")
       :else
       (let [children (if (some? sel-val)

--- a/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
+++ b/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
@@ -548,6 +548,39 @@
     s))
 
 ;; ---------------------------------------------------------------------------
+;; Newline-eating elements — leading-LF compensation (rf2-z05di)
+;; ---------------------------------------------------------------------------
+
+(def newline-eating-tags
+  "The HTML elements whose parser DROPS one leading LF immediately after the
+  start tag — `<pre>`, `<listing>`, `<textarea>`. react-dom/server 19.2
+  compensates by prefixing one extra LF so content that begins with a newline
+  survives the parse round-trip."
+  #{"pre" "listing" "textarea"})
+
+(defn leading-newline-compensation
+  "-> the compensating LF (`\"\\n\"`) react-dom/server 19.2 prefixes inside a
+  newline-eating element (`newline-eating-tags`), or `\"\"` when none is owed.
+
+  HTML parsing eats the FIRST LF immediately after `<pre>`/`<listing>`/
+  `<textarea>` (the newline-eating elements). So a tree whose textarea value or
+  pre text begins with LF would, without compensation, parse to a DOM carrying
+  one FEWER newline than authored — an S5 hydration/correctness gap. React
+  prefixes exactly one LF, but ONLY when the element's content is a SINGLE
+  STRING (its `typeof children === 'string'` guard): multiple or element
+  children are left untouched, because the parser's newline-eating still
+  applies but React does not doctor a multi-child body. `content-strings` is the
+  element's content as a seq — one entry means a single (already text-coalesced)
+  string child, or a textarea's `:value`."
+  [tag-lc content-strings]
+  (if (and (contains? newline-eating-tags tag-lc)
+           (= 1 (count content-strings))
+           (let [c (first content-strings)]
+             (and (string? c) (str/starts-with? c "\n"))))
+    "\n"
+    ""))
+
+;; ---------------------------------------------------------------------------
 ;; Attribute value serialisation (the value half of the table).
 ;; ---------------------------------------------------------------------------
 
@@ -733,12 +766,21 @@
       ;; unescaped (only the closing-sequence escape), matching react-dom/server.
       raw-text?      (str open ">" (escape-raw-text norm-tag (str/join (:children el)))
                           "</" tag-name ">")
-      (some? ta-val) (str open ">" (escape-html (coerce-val ta-val)) "</" tag-name ">")
+      ;; rf2-z05di — a textarea :value beginning with LF needs the compensating
+      ;; leading LF the parser will eat back off (single-string content).
+      (some? ta-val) (let [cv (coerce-val ta-val)]
+                       (str open ">"
+                            (leading-newline-compensation norm-tag [cv])
+                            (escape-html cv) "</" tag-name ">"))
       :else
       (let [children (if (some? sel-val)
                        (mark-selected (:children el) (coerce-val sel-val))
                        (:children el))]
-        (str open ">" (emit-children children path) "</" tag-name ">")))))
+        ;; rf2-z05di — <pre>/<listing>/<textarea> with a single string child
+        ;; beginning with LF get the one compensating LF react-dom/server emits.
+        (str open ">"
+             (leading-newline-compensation norm-tag children)
+             (emit-children children path) "</" tag-name ">")))))
 
 (defn- node-text
   "Concatenated text content of a RAW element/fragment node — its text

--- a/implementation/ssr/test/re_frame/ssr/emit_ui_tree_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/emit_ui_tree_cljs_test.cljc
@@ -287,6 +287,67 @@
                   :children [{:tag :option :attrs {:value "a"} :children ["A"]}
                              {:tag :option :attrs {:value "b"} :children ["B"]}]}))))))
 
+;; ---------------------------------------------------------------------------
+;; Newline-eating elements — leading-LF compensation (rf2-z05di)
+;;
+;; ANCHOR (rf2-z05di): HTML parsing eats the FIRST LF immediately after
+;; <pre>/<listing>/<textarea>, so react-dom/server 19.2 prefixes one
+;; compensating LF when the element's content is a SINGLE STRING beginning with
+;; LF (its `typeof children === 'string'` guard) — making the intended content
+;; survive the parse round-trip. Multiple/element children are left untouched.
+;; The expected strings are byte-pinned against react-dom/server 19.2
+;; (renderToStaticMarkup); "\n\n" below is a real doubled newline.
+;; ---------------------------------------------------------------------------
+
+(deftest leading-newline-compensated-for-pre-and-listing
+  (testing "<pre> single text child beginning with LF gets the doubled LF"
+    ;; RED-BEFORE lever: the shipped serialiser emitted "<pre>\nhello</pre>",
+    ;; which parses to a DOM with one FEWER newline than the tree authored.
+    (is (= "<pre>\n\nhello</pre>"
+           (ui-tree/emit-ui-tree (v1 {:tag :pre :children ["\nhello"]})))))
+  (testing "each extra authored LF survives (one is eaten, the rest remain)"
+    (is (= "<pre>\n\n\nhello</pre>"
+           (ui-tree/emit-ui-tree (v1 {:tag :pre :children ["\n\nhello"]})))))
+  (testing "pre child text is still HTML-escaped alongside the compensation"
+    (is (= "<pre>\n\n&lt;a&gt; &amp; b</pre>"
+           (ui-tree/emit-ui-tree (v1 {:tag :pre :children ["\n<a> & b"]})))))
+  (testing "<listing> is a newline-eating element too"
+    (is (= "<listing>\n\nhello</listing>"
+           (ui-tree/emit-ui-tree (v1 {:tag :listing :children ["\nhello"]}))))))
+
+(deftest leading-newline-compensated-for-textarea-value
+  (testing ":value on <textarea> beginning with LF gets the doubled LF"
+    ;; RED-BEFORE lever: emitted "<textarea>\nhello</textarea>" (one LF).
+    (is (= "<textarea>\n\nhello</textarea>"
+           (ui-tree/emit-ui-tree (v1 {:tag :textarea :attrs {:value "\nhello"}})))))
+  (testing "textarea :value is RCDATA-escaped alongside the compensation"
+    (is (= "<textarea>\n\n&lt;a&gt;&amp;</textarea>"
+           (ui-tree/emit-ui-tree (v1 {:tag :textarea :attrs {:value "\n<a>&"}})))))
+  (testing "a single string child (no :value) is compensated the same way"
+    (is (= "<textarea>\n\nhi</textarea>"
+           (ui-tree/emit-ui-tree (v1 {:tag :textarea :children ["\nhi"]}))))))
+
+(deftest leading-newline-own-lever-only-a-single-lf-string-child
+  (testing "VACUITY: no LF prefix ⇒ no compensation (the fix must not add one)"
+    (is (= "<pre>hello</pre>"
+           (ui-tree/emit-ui-tree (v1 {:tag :pre :children ["hello"]})))
+        "content not beginning with LF is emitted unchanged")
+    (is (= "<textarea>hello</textarea>"
+           (ui-tree/emit-ui-tree (v1 {:tag :textarea :attrs {:value "hello"}})))))
+  (testing "a leading CR (\\r) is NOT a newline-eating trigger — matches React"
+    (is (= "<pre>\r\nhello</pre>"
+           (ui-tree/emit-ui-tree (v1 {:tag :pre :children ["\r\nhello"]})))
+        "only a leading LF is eaten by the parser, so only LF is compensated"))
+  (testing "MULTIPLE children ⇒ no compensation (React's single-string guard)"
+    ;; Two text children are React's `children` array, not a string — no doctoring.
+    (is (= "<pre>\nab</pre>"
+           (ui-tree/emit-ui-tree (v1 {:tag :pre :children ["\na" "b"]})))
+        "a multi-child pre body is left untouched even when the first begins LF"))
+  (testing "a non-newline-eating element is never compensated"
+    (is (= "<div>\nhello</div>"
+           (ui-tree/emit-ui-tree (v1 {:tag :div :children ["\nhello"]})))
+        "the compensation is scoped to pre/listing/textarea only")))
+
 (deftest doctype-opt
   (is (= "<!DOCTYPE html><html></html>"
          (ui-tree/emit-ui-tree (v1 {:tag :html}) {:doctype? true}))))

--- a/implementation/ssr/test/re_frame/ssr/emit_ui_tree_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/emit_ui_tree_cljs_test.cljc
@@ -199,6 +199,69 @@
     (is (= "<div><b>raw</b></div>"
            (ui-tree/emit-ui-tree (v1 {:tag :div :children [{:html "<b>raw</b>"}]}))))))
 
+;; ---------------------------------------------------------------------------
+;; Raw-text elements — <script>/<style> content (rf2-2dh3b)
+;;
+;; ANCHOR (rf2-2dh3b): react-dom/server 19.2 emits <script>/<style> text as HTML
+;; RAW TEXT — the parser decodes no entities inside them, so the content is NOT
+;; sent through `escape-html`; only an embedded closing-tag sequence is rewritten
+;; to a context-safe spelling (a JS `s` unicode escape for </script, a CSS
+;; `\73 ` escape for </style) so the raw-text parser cannot terminate early. This
+;; is the raw-text EXCEPTION to Spec 004B §Children, text, and escaping's blanket
+;; 5-char escaping row; the expected strings below are byte-pinned against
+;; react-dom/server 19.2 (renderToStaticMarkup). It is NOT a sanitiser: the tree
+;; is already-rendered, server-authored content (the ns trust contract), exactly
+;; what react-dom/server itself emits raw.
+;; ---------------------------------------------------------------------------
+
+(deftest raw-text-script-style-is-not-html-escaped
+  (testing "ordinary ampersand / less-than / greater-than in <script> stays LITERAL"
+    ;; RED-BEFORE lever: the shipped `escape-html` path emitted
+    ;; "<script>a &amp; b &lt; c &gt; d</script>" — a corrupted script body.
+    (is (= "<script>a & b < c > d</script>"
+           (ui-tree/emit-ui-tree (v1 {:tag :script :children ["a & b < c > d"]}))))
+    (is (= "<script>if (a && b) {}</script>"
+           (ui-tree/emit-ui-tree (v1 {:tag :script :children ["if (a && b) {}"]})))))
+  (testing "ordinary ampersand / less-than in <style> stays LITERAL"
+    (is (= "<style>a & b < c > d</style>"
+           (ui-tree/emit-ui-tree (v1 {:tag :style :children ["a & b < c > d"]})))))
+  (testing "a childless raw-text element still emits an explicit close tag"
+    (is (= "<script></script>" (ui-tree/emit-ui-tree (v1 {:tag :script}))))
+    (is (= "<style></style>" (ui-tree/emit-ui-tree (v1 {:tag :style}))))))
+
+(deftest raw-text-closing-sequences-get-context-safe-spellings
+  (testing "<script> content: (<|</)script -> the s/S becomes \\u0073 / \\u0053"
+    ;; RED-BEFORE lever: the escape path emitted the entity spellings
+    ;; "&lt;/script&gt;" whose entities stay LITERAL inside raw text — the DOM
+    ;; would carry the text </script> and terminate the element early.
+    (is (= "<script>var x = '</\\u0073cript>';</script>"
+           (ui-tree/emit-ui-tree (v1 {:tag :script :children ["var x = '</script>';"]}))))
+    (is (= "<script>a<\\u0073cript>b</script>"
+           (ui-tree/emit-ui-tree (v1 {:tag :script :children ["a<script>b"]})))
+        "an OPENING <script in content is escaped too, matching React")
+    (is (= "<script>a</\\u0053CRIPT>b</script>"
+           (ui-tree/emit-ui-tree (v1 {:tag :script :children ["a</SCRIPT>b"]})))
+        "case is preserved except the escaped s/S; uppercase S -> \\u0053")
+    (is (= "<script>a</\\u0053cRiPt>b</script>"
+           (ui-tree/emit-ui-tree (v1 {:tag :script :children ["a</ScRiPt>b"]})))
+        "mixed-case suffix preserved verbatim"))
+  (testing "<style> content: (<|</)style -> the s/S becomes \\73 / \\53 (CSS escape)"
+    (is (= "<style>.x{content:'</\\73 tyle>'}</style>"
+           (ui-tree/emit-ui-tree (v1 {:tag :style :children [".x{content:'</style>'}"]}))))
+    (is (= "<style>a</\\53 TYLE>b</style>"
+           (ui-tree/emit-ui-tree (v1 {:tag :style :children ["a</STYLE>b"]}))))))
+
+(deftest raw-text-own-lever-p-still-escapes
+  (testing "VACUITY probe: the SAME text in a NON-raw-text element IS escaped"
+    ;; The fix is narrow: only <script>/<style> bypass entity escaping. If the
+    ;; branch mis-fired for ordinary elements this would drop the entities.
+    (is (= "<p>a &amp; b &lt; c &gt; d</p>"
+           (ui-tree/emit-ui-tree (v1 {:tag :p :children ["a & b < c > d"]})))
+        "an ordinary <p> keeps full 5-char escaping")
+    (is (= "<div>&lt;/script&gt;</div>"
+           (ui-tree/emit-ui-tree (v1 {:tag :div :children ["</script>"]})))
+        "and </script> in a <div> is inert escaped text, not a raw-text escape")))
+
 (deftest custom-element-property-props-omitted
   (testing "property-classified props never reach markup; attributes do"
     (is (= "<my-widget id=\"w\"></my-widget>"

--- a/implementation/ssr/test/re_frame/ssr/hydrate_root_seam_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/hydrate_root_seam_dom_cljs_test.cljs
@@ -129,6 +129,13 @@
    :identifier-prefix      server-prefix
    :element-locator        {:id "seam-container"}})
 
+;; rf2-y3swx — a BARE manifest OMITS :identifier-prefix: the server rendered
+;; under React's effective EMPTY prefix. Valid per the subset property.
+(def ^:private bare-manifest
+  {:rf.root/schema-version 1
+   :root-id                server-root-id
+   :element-locator        {:id "seam-container"}})
+
 (defn- plant-host!
   "Append the shape a real server render emits: the root's container, its Root
   Manifest as the IMMEDIATELY FOLLOWING element sibling (that adjacency is the
@@ -136,15 +143,16 @@
   host so the test can remove it.
 
   `:manifest?` false plants the container with NO adjacent manifest — the
-  `{:missing :manifest}` arm."
-  [{:keys [manifest? server-html]}]
+  `{:missing :manifest}` arm. `:manifest` overrides the planted manifest
+  (defaults to `server-manifest`)."
+  [{:keys [manifest? server-html manifest]}]
   (let [host (.createElement js/document "div")]
     (set! (.-innerHTML host)
           (str "<div id=\"seam-container\">" (or server-html "") "</div>"
                (when manifest?
                  (str "<script type=\"application/edn\" "
                       constants/root-manifest-marker-attribute ">"
-                      (pr-str server-manifest)
+                      (pr-str (or manifest server-manifest))
                       "</script>"))
                "<script id=\"" constants/payload-script-id
                "\" type=\"application/edn\">"
@@ -344,3 +352,117 @@
           (late-bind/set-fn! :ssr/discover-root-manifest original)
           (teardown! host root-atom)
           (restore-act-env! act-prev))))))
+
+;; ---------------------------------------------------------------------------
+;; 4. Omitted manifest prefix -> React's effective empty prefix (rf2-y3swx)
+;;
+;; A Root Manifest that OMITS :identifier-prefix means the server rendered under
+;; React's effective EMPTY prefix "" (hydrateRoot canonicalizes an omitted
+;; identifierPrefix to ""; useId derives from it). The client must treat it the
+;; same, so (a) the client's useId is React's empty-prefix token — identical to
+;; what the server's omitted-prefix render uses, i.e. server and client useId
+;; AGREE — and never a client-synthesized root-id-derived prefix; and (b) two
+;; live omitted-prefix roots both own "" and the second is rejected.
+;; ---------------------------------------------------------------------------
+
+(defn- plant-two-bare-roots!
+  "Two adjacent [container + BARE manifest] pairs (distinct root-ids) in one
+  host — the shape two independently-rendered omitted-prefix roots produce on
+  one page. Server HTML byte-matches the client's first render (`::revealed?`
+  false ⇒ an empty `<i class=\"uid\">`) so hydration is a clean adoption."
+  []
+  (let [host (.createElement js/document "div")
+        pair (fn [id root-id]
+               (str "<div id=\"" id "\"><div class=\"seam\">"
+                    "<span class=\"greeting\">client-default</span>"
+                    "<i class=\"uid\"></i></div></div>"
+                    "<script type=\"application/edn\" "
+                    constants/root-manifest-marker-attribute ">"
+                    (pr-str {:rf.root/schema-version 1
+                             :root-id                root-id
+                             :element-locator        {:id id}})
+                    "</script>"))]
+    (set! (.-innerHTML host) (str (pair "bare-a" ::bare-a) (pair "bare-b" ::bare-b)))
+    (.appendChild (.-body js/document) host)
+    host))
+
+(deftest two-omitted-prefix-hydrations-collide-on-empty-effective-prefix
+  (when (browser?)
+    (async done
+      (let [act-prev  (disable-act-env!)
+            host      (plant-two-bare-roots!)
+            root-atom (atom nil)]
+        (rf/init! ui/adapter)
+        (rf/make-frame {:id app-frame :platform :client})
+        (try
+          ;; the FIRST omitted-prefix root hydrates and registers
+          (reset! root-atom
+                  (ui/hydrate-root (.querySelector host "#bare-a")
+                                   [ui/frame-provider {:frame app-frame} [seam-root]]))
+          (testing "the live-root registry records the actual effective prefix \"\""
+            (is (= "" (:identifier-prefix (ui-client/live-root-entry ::bare-a)))
+                "an omitted manifest prefix is stored as React's effective empty prefix"))
+          ;; the SECOND — distinct root-id, distinct container — is rejected
+          ;; BEFORE any React work, because both own the effective "" prefix
+          (let [{:keys [id data]}
+                (thrown-error #(ui/hydrate-root (.querySelector host "#bare-b")
+                                                [ui/frame-provider {:frame app-frame}
+                                                 [seam-root]]))]
+            (testing "the second omitted-prefix root is rejected loud"
+              (is (= :rf.error/duplicate-identifier-prefix id)
+                  "two live roots cannot share React's effective \"\" prefix")
+              (is (= "" (:identifier-prefix data))
+                  "the collision reports the effective empty prefix")
+              (is (= ::bare-a (:owner-root-id data))
+                  "and names the owning root")))
+          (finally
+            (js/setTimeout
+             (fn [] (teardown! host root-atom) (restore-act-env! act-prev) (done))
+             0)))))))
+
+(deftest hydrate-root-omitted-prefix-uses-react-effective-empty-prefix
+  (when (browser?)
+    (async done
+      (let [act-prev (disable-act-env!)
+            host     (plant-host!
+                      {:manifest?   true
+                       :manifest    bare-manifest
+                       :server-html (str "<div class=\"seam\">"
+                                         "<span class=\"greeting\">seam-server</span>"
+                                         "<i class=\"uid\"></i>"
+                                         "</div>")})
+            root-atom (atom nil)]
+        (rf/init! ui/adapter)
+        (rf/make-frame {:id app-frame :platform :client})
+        (ssr/hydrate! {:frame app-frame})
+        (reset! root-atom
+                (ui/hydrate-root (container host)
+                                 [ui/frame-provider {:frame app-frame} [seam-root]]))
+        (js/setTimeout
+         (fn []
+           (rf/dispatch-sync [::reveal-uid] {:frame app-frame})
+           (js/setTimeout
+            (fn []
+              (try
+                (testing "the omitted-prefix root took React's effective EMPTY prefix"
+                  (let [uid (.-textContent (.querySelector host "i.uid"))]
+                    (is (seq uid)
+                        "the compiled view rendered the use-id value")
+                    ;; React 19.2's empty-prefix useId is `_R_<n>_` — the prefix
+                    ;; segment between the leading `_` and `R` is EMPTY. A
+                    ;; non-empty prefix would appear there (e.g. `_srv7-R_0_`),
+                    ;; and the ui-derived default would inject the root-id slug.
+                    ;; The empty prefix is EXACTLY what the server uses when it
+                    ;; omits identifierPrefix, so server and client useId AGREE.
+                    (is (str/starts-with? uid "_R")
+                        (str "the rendered use-id " (pr-str uid) " carries React's "
+                             "empty-prefix marker — the same effective prefix the "
+                             "server used, so server and client use-id agree"))
+                    (is (not (str/includes? uid "rf2-"))
+                        "no root-id-derived prefix was synthesized on the client")))
+                (finally
+                  (teardown! host root-atom)
+                  (restore-act-env! act-prev)
+                  (done))))
+            0))
+         0)))))

--- a/implementation/ssr/test/re_frame/ssr/hydrate_root_seam_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/hydrate_root_seam_dom_cljs_test.cljs
@@ -423,46 +423,65 @@
 (deftest hydrate-root-omitted-prefix-uses-react-effective-empty-prefix
   (when (browser?)
     (async done
+      ;; No `ssr/hydrate!` here — the `::greeting` sub returns "client-default"
+      ;; with no payload installed, so a `client-default` server span BYTE-MATCHES
+      ;; the client's first render and hydration is a clean ADOPTION (the
+      ;; server-state boot is proven by the vertical test above). This isolates
+      ;; the omitted-prefix question: does the bare manifest hydrate under React's
+      ;; effective empty prefix?
       (let [act-prev (disable-act-env!)
             host     (plant-host!
                       {:manifest?   true
                        :manifest    bare-manifest
                        :server-html (str "<div class=\"seam\">"
-                                         "<span class=\"greeting\">seam-server</span>"
+                                         "<span class=\"greeting\">client-default</span>"
                                          "<i class=\"uid\"></i>"
                                          "</div>")})
             root-atom (atom nil)]
         (rf/init! ui/adapter)
         (rf/make-frame {:id app-frame :platform :client})
-        (ssr/hydrate! {:frame app-frame})
-        (reset! root-atom
-                (ui/hydrate-root (container host)
-                                 [ui/frame-provider {:frame app-frame} [seam-root]]))
-        (js/setTimeout
-         (fn []
-           (rf/dispatch-sync [::reveal-uid] {:frame app-frame})
-           (js/setTimeout
-            (fn []
-              (try
-                (testing "the omitted-prefix root took React's effective EMPTY prefix"
-                  (let [uid (.-textContent (.querySelector host "i.uid"))]
-                    (is (seq uid)
-                        "the compiled view rendered the use-id value")
-                    ;; React 19.2's empty-prefix useId is `_R_<n>_` — the prefix
-                    ;; segment between the leading `_` and `R` is EMPTY. A
-                    ;; non-empty prefix would appear there (e.g. `_srv7-R_0_`),
-                    ;; and the ui-derived default would inject the root-id slug.
-                    ;; The empty prefix is EXACTLY what the server uses when it
-                    ;; omits identifierPrefix, so server and client useId AGREE.
-                    (is (str/starts-with? uid "_R")
-                        (str "the rendered use-id " (pr-str uid) " carries React's "
-                             "empty-prefix marker — the same effective prefix the "
-                             "server used, so server and client use-id agree"))
-                    (is (not (str/includes? uid "rf2-"))
-                        "no root-id-derived prefix was synthesized on the client")))
-                (finally
-                  (teardown! host root-atom)
-                  (restore-act-env! act-prev)
-                  (done))))
-            0))
-         0)))))
+        ;; captured before any React work — clean ADOPTION under the omitted
+        ;; prefix is proven by object identity (a mismatch would mint a fresh node).
+        (let [server-span (.querySelector host "span.greeting")]
+          (reset! root-atom
+                  (ui/hydrate-root (container host)
+                                   [ui/frame-provider {:frame app-frame} [seam-root]]))
+          (js/setTimeout
+           (fn []
+             (try
+               (testing "the bare-manifest root hydrated CLEANLY (server/client agree)"
+                 (is (identical? server-span (.querySelector host "span.greeting"))
+                     "the exact server-emitted node is still mounted — adopted, not regenerated")
+                 (is (true? (.-isConnected server-span))
+                     "and the retained node is still in the document"))
+               (catch :default e
+                 (teardown! host root-atom) (restore-act-env! act-prev) (done) (throw e)))
+             (rf/dispatch-sync [::reveal-uid] {:frame app-frame})
+             (js/setTimeout
+              (fn []
+                (try
+                  (testing "the omitted-prefix root took React's effective EMPTY prefix"
+                    (let [uid (.-textContent (.querySelector host "i.uid"))]
+                      (is (seq uid)
+                          "the compiled view rendered the use-id value")
+                      ;; React 19.2's useId is `_<prefix>r_<n>_` (client format uses
+                      ;; lowercase `r`, the server renderer uppercase `R` — hence the
+                      ;; case-insensitive check). For the EMPTY prefix the segment
+                      ;; between the leading `_` and the `r_` marker is empty, so the
+                      ;; value is `_r_<n>_`. A non-empty prefix appears there instead
+                      ;; — `_srv7-r_0_`, or the ui-derived default `_rf2-…r_0_`. The
+                      ;; empty prefix is EXACTLY what the server uses when it omits
+                      ;; identifierPrefix, so server and client use-id agree.
+                      (is (str/starts-with? (str/lower-case uid) "_r_")
+                          (str "the rendered use-id " (pr-str uid) " carries React's "
+                               "EMPTY-prefix marker (no prefix segment) — the same "
+                               "effective prefix the server used, so server and "
+                               "client use-id agree"))
+                      (is (not (str/includes? uid "rf2-"))
+                          "no root-id-derived prefix was synthesized on the client")))
+                  (finally
+                    (teardown! host root-atom)
+                    (restore-act-env! act-prev)
+                    (done))))
+              0))
+           0))))))

--- a/implementation/ssr/test/re_frame/ssr/root_manifest_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/root_manifest_cljs_test.cljc
@@ -26,6 +26,9 @@
             [re-frame.ssr.manifest :as manifest]
             [re-frame.ui.compiler.env :as env]
             [re-frame.ui.compiler.root :as root]
+            ;; CLJS-only: the rf2-y3swx registry-collision proof drives the
+            ;; client Layer-3 root-claim registry (headless — no DOM needed).
+            #?(:cljs [re-frame.ui.client :as ui-client])
             #?(:clj  [clojure.edn]
                :cljs [cljs.reader])))
 
@@ -718,9 +721,13 @@
 
 #?(:cljs
    (deftest discovery-is-adjacency-and-content
+     ;; `m` carries an AUTHORED `:identifier-prefix`, so `discover` passes it
+     ;; through verbatim and this test stays about ADJACENCY (the omitted-prefix
+     ;; canonicalization has its own test below, rf2-y3swx).
      (let [m    (manifest/manifest {:rf.root/schema-version 1
                                     :root-id :page/shop}
-                                   {:element-locator {:id "shop-root"}})
+                                   {:element-locator   {:id "shop-root"}
+                                    :identifier-prefix "shop-"})
            body (pr-str m)
            script (stub-el {:attrs {"type" "application/edn"
                                     constants/root-manifest-marker-attribute ""}
@@ -748,3 +755,101 @@
                     (stub-el {:tag "DIV"
                               :next (stub-el {:tag "DIV" :next script})})))
              "discovery does not walk — adjacency is the whole rule")))))
+
+;; ---------------------------------------------------------------------------
+;; Omitted identifier-prefix -> React's effective empty prefix (rf2-y3swx)
+;;
+;; React 19.2's hydrateRoot has no distinct "no prefix" state: it canonicalizes
+;; an omitted `identifierPrefix` option to the empty string "", and useId
+;; derives its ids from that empty prefix (server renderToString with no prefix
+;; does the same). So a bare Root Manifest that OMITS :identifier-prefix means
+;; the server rendered under React's effective EMPTY prefix — not "no effective
+;; prefix". Discovery, the hydration identity boundary, resolves that to "".
+;; ---------------------------------------------------------------------------
+
+(deftest canonicalize-effective-prefix-resolves-omitted-to-react-empty
+  (testing "an OMITTED :identifier-prefix resolves to React's effective \"\""
+    (is (= {:rf.root/schema-version 1 :root-id :page/shop :identifier-prefix ""}
+           (manifest/canonicalize-effective-prefix
+            {:rf.root/schema-version 1 :root-id :page/shop})))
+    (is (= "" (:identifier-prefix
+               (manifest/canonicalize-effective-prefix
+                {:rf.root/schema-version 1 :root-id :page/shop})))
+        "the resolved effective prefix is the empty string, not nil"))
+  (testing "an AUTHORED :identifier-prefix is passed through UNTOUCHED"
+    (is (= {:rf.root/schema-version 1 :root-id :page/shop :identifier-prefix "shop-"}
+           (manifest/canonicalize-effective-prefix
+            {:rf.root/schema-version 1 :root-id :page/shop :identifier-prefix "shop-"})))
+    (is (= {:rf.root/schema-version 1 :root-id :page/shop :identifier-prefix ""}
+           (manifest/canonicalize-effective-prefix
+            {:rf.root/schema-version 1 :root-id :page/shop :identifier-prefix ""}))
+        "an explicitly-empty authored prefix is left as-is (already \"\")")))
+
+#?(:cljs
+   (deftest discover-stamps-react-empty-prefix-on-a-bare-manifest
+     ;; RED-BEFORE: the shipped `discover` returned the bare manifest verbatim,
+     ;; so `hydrate-root*` read a NIL prefix and the Layer-3 prefix-uniqueness
+     ;; arm (a no-op on nil) admitted every omitted-prefix root.
+     (let [bare   (manifest/manifest {:rf.root/schema-version 1 :root-id :page/a})
+           script (stub-el {:attrs {"type" "application/edn"
+                                    constants/root-manifest-marker-attribute ""}
+                            :text  (pr-str bare)})
+           found  (manifest/discover (stub-el {:tag "DIV" :next script}))]
+       (testing "the bare manifest omits :identifier-prefix on the wire"
+         (is (not (contains? bare :identifier-prefix))
+             "manifest optionality is preserved — the extension key is absent"))
+       (testing "discovery resolves it to React's effective empty prefix"
+         (is (= "" (:identifier-prefix found)))
+         (is (= (assoc bare :identifier-prefix "") found)
+             "identity is the manifest plus the resolved effective prefix")))))
+
+#?(:cljs
+   (deftest omitted-prefix-roots-collide-on-react-empty-effective-prefix
+     ;; The end-to-end property, driven headlessly through the client Layer-3
+     ;; registry (`re-frame.ui.client`) with infos derived exactly as
+     ;; `hydrate-root*` derives them from a discovered manifest.
+     (try
+       (ui-client/reset-live-roots!)
+       (let [pfx-a (:identifier-prefix (manifest/canonicalize-effective-prefix
+                                        {:rf.root/schema-version 1 :root-id :y3swx/a}))
+             pfx-b (:identifier-prefix (manifest/canonicalize-effective-prefix
+                                        {:rf.root/schema-version 1 :root-id :y3swx/b}))
+             info-a {:root-id :y3swx/a :provenance :manifest :identifier-prefix pfx-a}
+             info-b {:root-id :y3swx/b :provenance :manifest :identifier-prefix pfx-b}
+             c-a    #js {} c-b #js {}]
+         (testing "both omitted-prefix manifests resolve to React's empty prefix"
+           (is (= "" pfx-a))
+           (is (= "" pfx-b)))
+         ;; first bare-manifest root claims + registers
+         (ui-client/check-root-claim! 're-frame.ssr.test info-a c-a)
+         (ui-client/register-live-root! info-a c-a (ui-client/->Root nil c-a :y3swx/a))
+         (testing "the live-root registry records the actual effective prefix \"\""
+           (is (= "" (:identifier-prefix (ui-client/live-root-entry :y3swx/a)))))
+         (testing "a SECOND omitted-prefix root is rejected before any React work"
+           (let [{:keys [id data]}
+                 (try (ui-client/check-root-claim! 're-frame.ssr.test info-b c-b) nil
+                      (catch :default e {:id (:rf.error/id (ex-data e)) :data (ex-data e)}))]
+             (is (= :rf.error/duplicate-identifier-prefix id)
+                 "two omitted-prefix roots share React's effective \"\" prefix")
+             (is (= "" (:identifier-prefix data))
+                 "the collision reports the effective empty prefix")
+             (is (= :y3swx/a (:owner-root-id data))
+                 "and names the owning root"))))
+       (finally (ui-client/reset-live-roots!)))))
+
+#?(:cljs
+   (deftest red-before-nil-prefix-roots-do-not-collide
+     ;; The exact pre-fix gap: a NIL prefix (what un-canonicalized discovery
+     ;; yielded) is a no-op in the prefix-uniqueness arm, so two bare roots were
+     ;; both admitted. This is the failure the canonicalization closes.
+     (try
+       (ui-client/reset-live-roots!)
+       (let [info-a {:root-id :y3swx/c :provenance :manifest :identifier-prefix nil}
+             info-b {:root-id :y3swx/d :provenance :manifest :identifier-prefix nil}
+             c-a    #js {} c-b #js {}]
+         (ui-client/check-root-claim! 're-frame.ssr.test info-a c-a)
+         (ui-client/register-live-root! info-a c-a (ui-client/->Root nil c-a :y3swx/c))
+         (is (nil? (try (ui-client/check-root-claim! 're-frame.ssr.test info-b c-b) nil
+                        (catch :default e (:rf.error/id (ex-data e)))))
+             "with a nil effective prefix the second root is (wrongly) admitted — the gap"))
+       (finally (ui-client/reset-live-roots!)))))

--- a/spec/004C-Roots-and-Mount.md
+++ b/spec/004C-Roots-and-Mount.md
@@ -422,10 +422,19 @@ Registering an id already live in the document throws
 is untouched (failure isolation). This is the last line, catching fragments composed
 client-side by independently shipped bundles. It also asserts **identifier-prefix
 uniqueness** across the document's live roots — the client-tier mirror of the Layer-2
-server check — so two live roots that share an effective `identifierPrefix` (only
-possible via an **authored** `:identifier-prefix`; the derived default is injective
-over root-id, §1) fail loud on the second claim rather than colliding `use-id` output;
-release frees the prefix.
+server check — so two live roots that share an effective `identifierPrefix` fail loud
+on the second claim rather than colliding `use-id` output; release frees the prefix. A
+shared effective prefix arises **two** ways: an **authored** `:identifier-prefix` that
+aliases (the derived mount-path default `"rf2-" + root-id-slug + "-"` is injective over
+root-id, §1, so it never collides on its own); **or** a **hydrating** root whose Root
+Manifest OMITS `:identifier-prefix` — the server rendered under React's effective
+**empty** prefix `""` (React's `hydrateRoot` has no distinct "no prefix" state: it
+canonicalizes an omitted `identifierPrefix` to `""`, and `useId` derives from it), which
+discovery canonicalizes so two such omitted-prefix roots are seen to share `""` and the
+second is rejected. Discovery canonicalizes only the resolved **identity**; the manifest
+wire form keeps `:identifier-prefix` an optional extension key (§2), and no root-id-
+derived prefix is ever synthesized client-side (that would disagree with the server the
+manifest speaks for and break hydration).
 
 A failed first mount that already allocated/registered its React Root is an exact-incarnation
 teardown transaction, not an inline registry delete: mark the whole claim `:tearing-down` before
@@ -449,7 +458,7 @@ prefix-uniqueness backstop share the roster:
 | `:rf.error/duplicate-root-id` | equal root-id at any layer above; client `:existing` includes `:tearing-down? true` while settlement is fenced |
 | `:rf.error/root-container-missing` | hydration locator resolves to no element (§4) |
 | `:rf.error/root-container-in-use` | `create-root`/`mount` on a node already owned by a different live or tearing-down root |
-| `:rf.error/duplicate-identifier-prefix` | `create-root`/`mount` whose effective `identifierPrefix` is already claimed by a different live root — backstops authored `:identifier-prefix` aliasing (the derived default is injective over root-id, §1) |
+| `:rf.error/duplicate-identifier-prefix` | `create-root`/`mount`/`hydrate-root` whose effective `identifierPrefix` is already claimed by a different live root — backstops authored `:identifier-prefix` aliasing, and hydrating roots that share React's effective empty prefix `""` when the manifest omits `:identifier-prefix` (the derived mount default is injective over root-id, §1) |
 | `:rf.error/root-not-live` | `render!` on a `Root` whose id is no longer live — `unmount!`ed, tearing-down, or superseded by a newer root claiming the same id (guarded like `unmount!`, but fails loud rather than no-op, before any side effect) |
 | `:rf.error/root-manifest-invalid` | manifest missing/unreadable at hydrate, schema-version incompatible, identity opts passed client-side, unserialisable props at emit, prefix conflict |
 | `:rf.error/frame-payload-conflict` | below |


### PR DESCRIPTION
Three targeted SSR serialization/manifest corrections in the `emit-ui-tree` +
manifest surface, each aligning re-frame2 to a documented React 19.2 server
semantic. One PR, three fixes (plus a follow-up commit greening the browser gate).

## rf2-2dh3b — `<script>`/`<style>` text is HTML raw text
`emit-ui-tree` sent script/style text through 5-char entity escaping, but the
HTML parser decodes no entities inside raw-text elements: a valid `a & b < c`
became the literal DOM text `a &amp; b &lt; c`, and JS/CSS with `<`/`&` stopped
meaning what it said. Match react-dom/server 19.2: emit the text VERBATIM and
rewrite only an embedded closing-tag sequence to a context-safe spelling —
`(<|</)script` → the s/S becomes `s`/`S`; `(<|</)style` → `\73 `/`\53 `.
Not a sanitiser and no XSS hole beyond React's own (the tree is already-rendered,
server-authored content; untrusted markup keeps its explicit `:html` bypass).

## rf2-z05di — leading newlines in `pre`/`textarea`
HTML parsing eats the first LF immediately after `<pre>`/`<listing>`/`<textarea>`,
so content beginning with LF parsed to a DOM with one fewer newline than
authored. Match react-dom/server 19.2: emit one compensating LF, but ONLY when
the content is a single string beginning with LF (React's `typeof children ===
'string'` guard). The repo parity parser normalizes this newline away, so it is
covered by exact-markup tests instead.

## rf2-y3swx — omitted hydration prefix = React's effective empty prefix
A bare Root Manifest omits `:identifier-prefix`; hydration read a nil prefix and
the Layer-3 uniqueness fence (a no-op on nil) admitted every omitted-prefix root,
so two bare manifests on one document both hydrated while owning the SAME
effective prefix and could alias `useId`. React 19.2 canonicalizes an omitted
`identifierPrefix` to `""`; `re-frame.ssr.manifest/discover` now resolves an
omitted prefix to `""` at the hydration identity boundary. The client claim
registry was already correct for a `some?` prefix, so this is the narrowest fix
and leaves the `ui` artefact untouched. Spec 004C Layer 3 reconciled to name the
omitted-prefix route.

## Quality gates
- `cd implementation/ssr && clojure -M:test` → **498 tests, 2348 assertions, 0 failures, 0 errors** (JVM)
- `npm run test:cljs` → **10298 tests, 50768 assertions, 0 failures, 0 errors** (node)
- `npm run test:browser` (shadow-cljs `:browser-test`, headless Chromium) → **497 tests, 2774 assertions, 0 failures, 0 errors**
- `python -m mkdocs build --strict` → exit 0
- `python scripts/check_doc_slugs.py` → exit 0
- Core conformance suite not run: no `spec/009` catalogue / error-id surface touched.

The `.cljc` `emit-ui-tree` tests run on BOTH hosts (JVM + node). Byte-level
red-before levers per bead; vacuity probes per bead. The y3swx two-root
collision + effective-empty-prefix `useId` proofs run in real headless Chromium
(`:browser-test`), which is now green.

## Notes / flags for the mayor
- **`spec/004B` (HOT-ZONE) not edited.** The 2dh3b bead asked to update 004B's
  blanket escaping row (§Children, text, and escaping) to name the raw-text
  exception. That is a normative change to a hot-zone/do-not-touch file, so per
  the dispatch fence I STOPPED — the raw-text semantics are anchored in the
  `emit-ui-tree` test instead. A cross-ref clause on 004B line ~337 may be
  warranted; flagging for a ruling.
