### PR TITLE
fix(reagent-slim): reject reserved heads before the type-aliased cache lookup (rf2-sgbna)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -95,10 +95,17 @@
 ;; recognised interop heads (`:<>`, `:>`, `:r>`, `:f>`) are unnamespaced
 ;; and are consumed by `vec-to-elem` before the tag grammar is reached.
 ;;
-;; COST: this sits in `parse-tag`, which `cached-parse` reaches only on a
-;; cache MISS — once per distinct head — so steady-state rendering pays
-;; nothing (the ruling's requirement). `reagent2.dom.server` calls
-;; `parse-tag` directly, so the one guard covers both surfaces.
+;; COST: the guard runs in `parse-tag` (the cache-MISS path, and the
+;; `reagent2.dom.server` direct-call path) AND once more at the top of
+;; `cached-parse`, BEFORE the cache lookup (rf2-sgbna). A `parse-tag`-only
+;; guard was reached only on a cache MISS, but the reserved keyword `:rf/x`
+;; and a valid STRING head "rf/x" share the same cache key "rf/x", so an
+;; app that first rendered the string form let the later reserved keyword
+;; ride the cache-HIT path and skip the reject entirely — see the note on
+;; `cached-parse`. The pre-lookup guard is a single cheap `reserved-rf-head?`
+;; predicate (keyword? + namespace, false-fast for the common unnamespaced
+;; head), so a legitimate head still resolves through the cache at
+;; essentially the same cost.
 ;;
 ;; ALWAYS-ON: no `goog.DEBUG` gate. This is a correctness reject on a
 ;; runtime DATA branch, so it survives `:advanced` + `goog.DEBUG=false`
@@ -249,6 +256,14 @@
 ;; reads `(name …)`, so the two spellings always produced the same
 ;; `HiccupTag` — the collision was harmless until this guard made the head's
 ;; namespace load-bearing.)
+;;
+;; NOTE (rf2-sgbna): the reserved-head phantom is now prevented at its
+;; source — `cached-parse` rejects a reserved keyword head BEFORE this key
+;; is even computed — so no cache key can serve a reserved head. The
+;; fully-qualified key remains to keep distinct keyword spellings distinct;
+;; it is no longer the reserved-head guard. (This very qualification is also
+;; what made `:rf/x` alias the string head "rf/x", the collision rf2-sgbna
+;; closes.)
 (defn- cache-key [k]
   (let [n (name k)]
     (if-let [ns* (and (keyword? k) (namespace k))]
@@ -256,6 +271,20 @@
       n)))
 
 (defn- cached-parse [k element]
+  ;; Reject a reserved `:rf/*` keyword head BEFORE consulting the cache
+  ;; (rf2-sgbna). `reject-reserved-rf-head!` also runs inside `parse-tag`,
+  ;; but `parse-tag` is reached only on a cache MISS. The fully-qualified
+  ;; `cache-key` for the reserved keyword `:rf/x` is the string "rf/x" —
+  ;; IDENTICAL to the key a valid STRING head "rf/x" seeds (a string's
+  ;; `cache-key` is its own name). So an app that first renders the string
+  ;; form seeds "rf/x", and the later reserved keyword `:rf/x` takes the
+  ;; cache-HIT path, never reaches `parse-tag`, and paints a phantom
+  ;; <rf/x> — the type-aliased cache silently disarming the fail-loud
+  ;; guard. Rejecting here, before the lookup, closes that path. The reject
+  ;; is keyword-only (`reserved-rf-head?` is false-fast for the common
+  ;; unnamespaced head and for any string head), so a legitimate head pays
+  ;; a single cheap predicate and still resolves through the cache.
+  (reject-reserved-rf-head! k element)
   (let [n (cache-key k)]
     (if (and (not (reserved-prop-key? n))
              (.hasOwnProperty tag-name-cache n))

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_reserved_head_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_reserved_head_cljs_test.cljs
@@ -14,9 +14,13 @@
   boundary` is a streaming-SSR-only marker — so the guard is TOTAL: every
   `:rf/*` / `:rf.<area>/*` head is rejected, with no allow-list carve-out.
 
-  The check lives in `parse-tag`, which `cached-parse` reaches ONLY on a
-  cache MISS (zero steady-state cost, per the ruling) and which
-  `reagent2.dom.server` calls directly — one guard, both surfaces.
+  The check lives in `parse-tag` (the cache-MISS path, and the path
+  `reagent2.dom.server` calls directly) AND at the top of `cached-parse`,
+  ahead of the cache lookup (rf2-sgbna) — because the reserved keyword
+  `:rf/x` and a valid string head of the same qualified name share the
+  cache key `rf/x`, so a `parse-tag`-only guard let the string-seeded
+  keyword ride a cache HIT and skip the reject. Two guard points, all
+  three surfaces.
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
@@ -96,3 +100,30 @@
     (is (= :rf.error/invalid-hiccup-head
            (:rf.error/id (head-error [:rf/button {}])))
         "the reserved twin must still fail loud")))
+
+(deftest reserved-head-survives-a-string-aliased-cache-entry
+  ;; rf2-sgbna — the STRING-vs-keyword twin, distinct from the
+  ;; keyword-vs-keyword case above. The rf2-01zvu fix keyed the cache on the
+  ;; head's FULLY-QUALIFIED name, so the reserved keyword `:rf/x` keys to the
+  ;; string "rf/x". A valid STRING head "rf/x" keys to the SAME "rf/x" (a
+  ;; string's `cache-key` is its own `name`). Rendering the string form first
+  ;; therefore SEEDS that entry, and the later reserved keyword took the
+  ;; cache-HIT path — bypassing `parse-tag`'s `reject-reserved-rf-head!` and
+  ;; painting a phantom <rf/x>, its React type the aliased string. The guard
+  ;; must run BEFORE the cache lookup so a type-aliased hit cannot disarm it.
+  ;; The lever: seed the STRING, then probe the reserved KEYWORD twin — with
+  ;; the guard only in `parse-tag` (cache-miss-only) the probe returns nil
+  ;; (rendered, no throw); with the guard hoisted ahead of the lookup it
+  ;; throws the catalogued reject carrying the exact `:element` (#6460).
+  (testing "a string-form twin seeded first does not disarm the guard"
+    (is (some? (template/as-element ["rf/cache-string-twin" "ordinary"]))
+        "seed the cache under the aliased string key \"rf/cache-string-twin\"")
+    (let [data (head-error [:rf/cache-string-twin {:id 1}])]
+      (is (= :rf.error/invalid-hiccup-head (:rf.error/id data))
+          "the reserved keyword twin must still fail loud after the string seed")
+      (is (= :rf/cache-string-twin (:head data))
+          "the offending reserved head rides the payload")
+      ;; #6460 (rf2-vzno0): the reject carries the COMPLETE offending vector,
+      ;; and it must do so on the cache-hit path too — not just from parse-tag.
+      (is (= [:rf/cache-string-twin {:id 1}] (:element data))
+          "the COMPLETE offending vector rides :element, per #6460 / rf2-vzno0"))))

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_reserved_head_elision_prod_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_reserved_head_elision_prod_test.cljs
@@ -73,4 +73,16 @@
   (testing "the cache-collision guard holds in production too"
     (is (some? (:painted (render-outcome [:button "ordinary"]))))
     (is (nil? (:painted (render-outcome [:rf/button {}])))
-        "an unreserved twin must not disarm the guard in the shipped build")))
+        "an unreserved twin must not disarm the guard in the shipped build"))
+
+  (testing "the string-aliased cache-hit guard holds in production too (rf2-sgbna)"
+    ;; A STRING head "rf/x" and the reserved keyword `:rf/x` share the cache
+    ;; key "rf/x"; seeding the string form must not let the keyword ride the
+    ;; cache-HIT path and paint a phantom in the shipped :advanced build.
+    (is (some? (:painted (render-outcome ["rf/prod-string-twin" "ordinary"])))
+        "seed the cache under the aliased string key")
+    (is (nil? (:painted (render-outcome [:rf/prod-string-twin {:id 1}])))
+        "the string-seeded reserved twin must paint NOTHING in production")
+    (is (= :rf.error/invalid-hiccup-head
+           (:rf.error/id (:data (render-outcome [:rf/prod-string-twin {:id 1}]))))
+        "and carry its catalogued identity from the cache-hit path")))


### PR DESCRIPTION
## What

`rf2-sgbna` — a reserved `:rf/*` reagent-slim hiccup head could slip through a **type-aliased cache hit** before the reserved-head rejection fired.

The rf2-01zvu fix keyed `tag-name-cache` on the head's **fully-qualified** name so `:button`/`:rf/button` stop colliding. But that made the reserved keyword `:rf/x` key to the string `"rf/x"` — **identical** to the key a valid string head `"rf/x"` seeds (a string's `cache-key` is its own `name`). So:

1. App renders the string form `["rf/x" ...]` first → seeds `tag-name-cache["rf/x"]`.
2. App later renders the reserved keyword `[:rf/x ...]` → `cache-key` is `"rf/x"` → **cache HIT** → returns the seeded `HiccupTag`, never reaching `parse-tag` → `reject-reserved-rf-head!` is skipped → a phantom `<rf/x>` element is painted.

This violated Spec 009 Layer 1 fail-loud behaviour and bypassed #6460's new exact `:element` payload. A direct probe against the compiled runtime observed `{"seeded":true,"outcome":{"threw":false,"reactType":"rf/audit-cache-twin"}}`.

## The fix (one ordering change)

Hoist `reject-reserved-rf-head!` to the **top of `cached-parse`, before the cache lookup**, so a reserved keyword head is rejected before any type-aliased hit can serve it. The guard also stays in `parse-tag` (the cache-miss path and the `reagent2.dom.server` direct-call path). The pre-lookup check is a single cheap `reserved-rf-head?` predicate (false-fast for the common unnamespaced head and for any string head), so legitimate heads still resolve through the cache. No new public API, error id, registry, or cache subsystem; the cache is reordered, not disabled or redesigned.

## Proof

- **Red-before with its own lever:** new `reserved-head-survives-a-string-aliased-cache-entry` — seed the string `"rf/cache-string-twin"`, then probe the reserved keyword `:rf/cache-string-twin`. With the reject disabled the probe returns `nil` (rendered, no throw); with the fix it throws `:rf.error/invalid-hiccup-head` carrying `:head :rf/cache-string-twin` and `:element [:rf/cache-string-twin {:id 1}]` (the complete offending vector, per #6460). Verified red → green by toggling the one guard line.
- **Regression:** the existing keyword-vs-keyword collision test and #6460's `:element` payload stay green; a legitimate type-aliased head still resolves through the cache.
- **Production:** the string-aliased cache-hit reject is pinned under `:advanced` + `goog.DEBUG=false` (added to `template_reserved_head_elision_prod_test`).

## Quality gates

All run in this worktree (real `npm install`), foreground to completion:

| Gate | Result |
|------|--------|
| `npm run test:cljs` | **Ran 10287 tests, 50733 assertions. 0 failures, 0 errors.** |
| `npm run test:adapter-smokes` | Ran 3 adapter-smoke specs. **0 failures.** |
| `npm run test:reagent-slim:bundle-isolation` | **PASS** — 6 contracts, 25 sentinel checks (slim pulls no stock Reagent/react-dom/server) |
| `npm run test:bundle-isolation` | **PASS** — all 4 checks (self-test, bundle-isolation, uix-helix-reagent-free, login) |
| `npm run test:browser-prod-elision` | **Ran 113 tests, 483 assertions. 0 failures, 0 errors.** |
| reagent-slim JVM suite (`clojure -M:test`) | Ran 11 tests, 12 assertions. **0 failures, 0 errors.** |

Fix is slim-local (`reagent2/impl/template.cljs` + its tests only); no shared `core/**` or `reagent/**` code touched.