### PR TITLE
fix(xray): honor the configured :rf.xray/filters seed as the production boot baseline (rf2-fhtes)

### DIFF
--- a/tools/xray/spec/015-Configuration.md
+++ b/tools/xray/spec/015-Configuration.md
@@ -643,8 +643,10 @@ semantics predate the popup; the popup-managed surface is the
 
 ### `:rf.xray/filters`
 
-Host-supplied seed pill set the registry hydrates `:active-filters`
-with on **first install** (when localStorage is empty). Per
+Host-supplied seed pill set applied to `:active-filters` as the explicit
+**boot baseline**. The host opts in; `mount.cljs/::seed-configured-filters`
+(a first-mount hook that runs AFTER the transient-filter reset) lands a
+non-empty seed on **every** load. Per
 [`018-Event-Spine.md`](./018-Event-Spine.md) §7 'Empty defaults',
 Xray ships with no filters by default (first-session honesty beats
 first-session quietness). The seed is the escape hatch for hosts
@@ -653,19 +655,25 @@ testbeds that need a known starting point for reproducibility.
 
 | Value | Meaning |
 |---|---|
-| `{:in [{:pattern <…>} …] :out [{:pattern <…>} …]}` | Seed the slot on first install only. The seed never clobbers a user's hand-tuned set — once localStorage carries any pill, the seed is ignored. |
-| `nil` (default) | No seed; registry defaults to `{:in [] :out []}`. |
+| `{:in [{:pattern <…>} …] :out [{:pattern <…>} …]}` | The host's explicit boot baseline, applied to `:active-filters` on every load after the transient reset. This is NOT durable user-filter persistence — a user's own session pills always reset — and it never depends on localStorage. |
+| `nil` (default) | No seed; the slot stays at its unfiltered registry default `{:in [] :out []}` — a fully-unfiltered first paint. |
 
-> **Transient vs durable (rf2-swclw).** The IN/OUT pills, the
-> muted-event-id set, and the frame view-scope are **transient
-> exploration filters**: they persist via localStorage *within* a session
-> but RESET on every load — `mount.cljs/::reset-transient-filters` does
-> not hydrate them and clears the stored value so a stale filter can never
-> silently hide rows on reload (rf2-jvghz; an inspector must show the
-> truth). Only **durable view prefs** (the persisted Settings shape below
-> — mode, density, panel layout) hydrate on boot. The `:rf.xray/filters`
-> seed therefore lands only on a genuinely-empty first install, before the
-> reset hook has a stored value to clear.
+> **Transient user filters vs the explicit host seed (rf2-swclw,
+> rf2-fhtes).** The IN/OUT pills, the muted-event-id set, and the frame
+> view-scope are **transient exploration filters**: they persist via
+> localStorage *within* a session but RESET on every load —
+> `mount.cljs/::reset-transient-filters` does not hydrate them and clears
+> the stored value so a stale filter can never silently hide rows on
+> reload (rf2-jvghz; an inspector must show the truth). Durable view prefs
+> (the persisted Settings shape below — mode, density, panel layout)
+> hydrate on boot via their own hooks. The `:rf.xray/filters` seed is a
+> THIRD, distinct category: an EXPLICIT host boot baseline the programmer
+> opted into. It is re-applied every load by `::seed-configured-filters`,
+> which runs immediately AFTER the transient reset — so the host's baseline
+> always wins over (and is never clobbered by) a user's stale
+> localStorage/session filters, while a `nil` seed leaves the paint fully
+> unfiltered. It is neither durable user-filter persistence nor an
+> unreachable first-install-only value.
 
 ### `:rf.xray/filters-storage-key`
 

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -1348,7 +1348,7 @@ writes pills through to localStorage *within* a session so a mid-session
 mutation survives a sub-recompute; it is the LOAD that resets, not the
 write that stops.
 
-Host-supplied seed via `(xray-config/configure! {:rf.xray/filters {:in […] :out […]}})` lands ONLY on first install when localStorage is empty — the seed never clobbers a user's hand-tuned set. Per the [`Empty defaults`](#empty-defaults--recommended-quick-add) policy above, Xray itself ships with `nil` seed (first-session honesty).
+A host-supplied seed via `(xray-config/configure! {:rf.xray/filters {:in […] :out […]}})` is a distinct category from the transient user filters above: it is the host's EXPLICIT boot baseline. `mount.cljs`'s `::seed-configured-filters` first-mount hook — which runs immediately AFTER `::reset-transient-filters` — re-applies a non-empty seed to `:active-filters` on **every** load, ignoring localStorage entirely (rf2-fhtes). So the host's opted-in posture always wins over a user's stale session filters and never depends on a genuinely-empty first install; it is neither durable user-filter persistence nor an unreachable first-install-only value. Per the [`Empty defaults`](#empty-defaults--recommended-quick-add) policy above, Xray itself ships with `nil` seed (first-session honesty) — a `nil` seed keeps the first paint fully unfiltered.
 
 ### "N events hidden by filters" indicator + Clear Filters (rf2-jvghz)
 

--- a/tools/xray/src/day8/re_frame2_xray/config.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/config.cljc
@@ -1477,10 +1477,13 @@
 ;; via localStorage per host-app under a Xray-namespaced key. Two
 ;; configure! axes:
 ;;
-;;   - `:filters/seed` — initial pill set hosts can ship as a default
-;;     (Story testbeds use this to inject a known starting point for
-;;     reproducibility). Default `nil` — no seed; the user surfaces
-;;     filters themselves per spec/018 §7 'Empty defaults'.
+;;   - `:filters/seed` — an explicit host BOOT BASELINE pill set. When a
+;;     host opts in, `mount.cljs`'s `::seed-configured-filters` first-mount
+;;     hook applies it to `:active-filters` on EVERY load, AFTER the
+;;     transient-user-filter reset (rf2-fhtes) — Story testbeds use this to
+;;     inject a known, reproducible starting posture. Default `nil` — no
+;;     seed; the slot stays fully unfiltered per spec/018 §7 'Empty
+;;     defaults'.
 ;;
 ;;   - `:rf.xray/filters-storage-key` — localStorage key the persistence layer
 ;;     reads / writes. Default `"re-frame2.xray.filters.v1"`. Hosts
@@ -1500,17 +1503,23 @@
   {:in [] :out []})
 
 (defonce
-  ^{:doc "Atom holding the host-supplied seed filter set Xray
-         hydrates the slot with on FIRST install (when localStorage
-         is empty). Default `nil` — no seed; the registry's default
-         empty shape wins."}
+  ^{:doc "Atom holding the host-supplied `:rf.xray/filters` seed — the
+         explicit BOOT BASELINE for `:active-filters`. `mount.cljs`'s
+         `::seed-configured-filters` first-mount hook applies a non-empty
+         seed on EVERY load, AFTER the transient-user-filter reset
+         (rf2-fhtes): this is an opted-in host posture, NOT durable
+         user-filter persistence and NOT a first-install-only value.
+         Default `nil` — no seed; the slot stays at its unfiltered
+         registry default `{:in [] :out []}`."}
   filter-seed
   (atom nil))
 
 (defn set-filter-seed!
-  "Set the seed filter set the registry hydrates `:active-filters`
-  with on first install when localStorage is empty. `nil` clears the
-  seed. Shape: `{:in [{:pattern <kw-or-str>}] :out [{:pattern <…>}]}`."
+  "Set the `:rf.xray/filters` seed — the explicit host boot baseline
+  `mount.cljs`'s `::seed-configured-filters` first-mount hook applies to
+  `:active-filters` on every load, AFTER the transient-filter reset
+  (rf2-fhtes). `nil` clears the seed (fully unfiltered). Shape:
+  `{:in [{:pattern <kw-or-str>}] :out [{:pattern <…>}]}`."
   [seed]
   (reset! filter-seed seed)
   nil)
@@ -1660,11 +1669,15 @@
        normal per-knob write path; this key is the bulk-set escape
        hatch (e.g. host wants to ship its own default theme).
     `{:rf.xray/filters <{:in [...] :out [...]}>}` — host-supplied
-       seed pill set the registry hydrates `:active-filters` with on
-       FIRST install (when localStorage is empty). Default `nil` per
-       spec/018 §7 'Empty defaults' — first-session honesty beats
-       first-session quietness. Story testbeds use this to inject a
-       known starting point for reproducibility.
+       seed pill set applied to `:active-filters` as the explicit boot
+       BASELINE. `mount.cljs`'s `::seed-configured-filters` first-mount
+       hook lands a non-empty seed on EVERY load, AFTER the transient-
+       user-filter reset (rf2-fhtes) — an opted-in host posture, NOT
+       durable user-filter persistence. Default `nil` per spec/018 §7
+       'Empty defaults' — first-session honesty beats first-session
+       quietness; a `nil` seed keeps the first paint fully unfiltered.
+       Story testbeds use this to inject a known, reproducible starting
+       posture.
     `{:rf.xray/filters-storage-key <string>}` — localStorage key
        the filter persistence layer reads / writes. Default
        `\"re-frame2.xray.filters.v1\"`. Hosts that run multiple

--- a/tools/xray/src/day8/re_frame2_xray/filters.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters.cljs
@@ -69,8 +69,8 @@
 ;; ---- hydration ---------------------------------------------------------
 
 (defn hydrate!
-  "Drive the localStorage / seed / empty hydration order per spec/018
-  §7:
+  "The localStorage-preferring DATA LAYER for `:active-filters`. Drives
+  the localStorage / seed / empty resolution order:
 
     1. localStorage value (the user's last-session pill set);
     2. host-supplied seed via `(xray-config/configure! {:rf.xray/filters …})`
@@ -79,17 +79,24 @@
     3. registry default empty shape `{:in [] :out []}` per
        'Empty defaults' (first-session honesty).
 
-  Re-entrant. Safe to call from `install!` (preload-time, before the
-  frame is registered) AND from `mount.cljs/ensure-xray-frame!`
-  (first open, frame registered). Both invocations converge on the
-  same slot because:
+  ## NOT the production init path (rf2-fhtes)
+
+  This fn is DELIBERATELY NOT on the production `ensure-xray-frame!`
+  path: the USER's persisted pills are a transient exploration filter
+  that MUST reset on every load (`mount.cljs`'s `::reset-transient-
+  filters`), so restoring localStorage here on boot would resurrect the
+  stale set the reset exists to kill. The host-configured SEED lands via
+  a distinct seed-only hook (`mount.cljs`'s `::seed-configured-filters`)
+  that ignores localStorage entirely. `hydrate!` is retained for its
+  existing data-layer callers — the persistence round-trip tests, and
+  hosts that deliberately opt back into localStorage-restoring behaviour.
+
+  Re-entrant + idempotent because:
 
   - the load + seed reads are pure;
   - the hydrate dispatch is a wholesale `(assoc db :active-filters …)`
     so re-running with the same source produces the same slot;
-  - the frame guard short-circuits the pre-mount call without losing
-    state — the seed lives in the config atom, the localStorage value
-    lives in localStorage; both are still readable at second call.
+  - the frame guard short-circuits when `:rf/xray` is not yet registered.
 
   Returns nil. No-op when no source has any pills."
   []
@@ -482,13 +489,24 @@
       {:db (assoc db :active-filters
                 (or filters {:in [] :out []}))}))
 
-  ;; NO hydrate on install. The IN/OUT pills are a TRANSIENT
+  ;; NO hydrate on install. The USER's IN/OUT pills are a TRANSIENT
   ;; exploration filter — they reset to unfiltered on every page load so
   ;; a fresh session never silently carries a stale filter. The slot
   ;; starts at its registry default `{:in [] :out []}` and
   ;; `mount.cljs`'s `::reset-transient-filters` first-mount hook clears
-  ;; the stale localStorage slot so storage matches. `hydrate!` / `load`
-  ;; remain as the data layer (exercised by the persistence round-trip
-  ;; tests + reachable by hosts that opt back in), but init does not
-  ;; restore.
+  ;; the stale localStorage slot so storage matches.
+  ;;
+  ;; A host-configured `:rf.xray/filters` seed is the ONE exception, and
+  ;; it is honoured NOT here but on the real production mount path:
+  ;; `mount.cljs`'s `::seed-configured-filters` first-mount hook (which
+  ;; runs AFTER the transient reset) applies an explicitly configured
+  ;; seed as the boot BASELINE (rf2-fhtes). That seed is the host's
+  ;; opt-in — an explicit boot posture re-applied each load — NOT durable
+  ;; user-filter persistence and NOT an unreachable first-install-only
+  ;; promise; `nil` (the default) stays fully unfiltered.
+  ;;
+  ;; `hydrate!` / `load` remain as the localStorage-preferring data layer
+  ;; (exercised by the persistence round-trip tests + reachable by hosts
+  ;; that opt back in), but neither the user's persisted pills nor
+  ;; `hydrate!` itself restore on the production init path.
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -603,10 +603,53 @@
   ;; still hydrate via their own hooks below — only transient filters
   ;; reset. The #1962 'N events hidden by filters' indicator stays as
   ;; the in-session safety net once the user reaches for a filter.
+  ;;
+  ;; An explicitly configured host seed (`:rf.xray/filters`) is NOT a
+  ;; transient user filter — it is the host's opted-in boot posture, so
+  ;; the `::seed-configured-filters` hook immediately below re-applies it
+  ;; ON TOP of this clean slate. Sequencing matters: this hook runs FIRST
+  ;; and clears the stale localStorage slot, then the seed hook lands the
+  ;; host baseline — so a user's stale session filters never survive
+  ;; reload, while the host's explicit seed always does (rf2-fhtes).
   (fn [_frame-id]
     (filters-persistence/clear!)
     (spine-filters/clear-raw!)
     (frame-switcher/clear!)))
+
+(register-first-mount-hook!
+  ::seed-configured-filters
+  ;; Apply the host-configured `:rf.xray/filters` seed as the boot
+  ;; BASELINE for `:active-filters`, AFTER `::reset-transient-filters`
+  ;; above has wiped any stale user/localStorage filter state (rf2-fhtes).
+  ;;
+  ;; This closes a false public contract: `configure!` accepted
+  ;; `:rf.xray/filters` and the config/spec prose promised the seed would
+  ;; hydrate `:active-filters`, but production never called
+  ;; `filters/hydrate!` — `filters/install!` explicitly does NO hydrate and
+  ;; nothing on the real `ensure-xray-frame!` path read the seed. A host
+  ;; using the documented key got no error and an unfiltered first paint.
+  ;;
+  ;; The policy is small and coherent: an EXPLICITLY configured seed is the
+  ;; programmer's opt-in and lands as the boot baseline on EVERY load (a
+  ;; fresh, host-owned posture — not durable user-filter persistence, which
+  ;; the reset hook deliberately kills). A `nil` seed (the default) leaves
+  ;; the slot at its unfiltered registry default `{:in [] :out []}`, so a
+  ;; host that never configured filters keeps a fully-unfiltered first
+  ;; paint. Only a non-empty seed dispatches, so the no-seed case is a
+  ;; genuine no-op.
+  ;;
+  ;; Mirrors the `::hydrate-static-mode` shape (read via a config helper,
+  ;; dispatch the owning event). `filters/hydrate!` stays as-is for its
+  ;; existing data-layer callers — this hook is seed-only and never reads
+  ;; localStorage, so it cannot resurrect a stale user set. The `:rf.xray/
+  ;; hydrate-filters` event (registered by `filters/install!`) is the
+  ;; single `:active-filters` write seam.
+  (fn [frame-id]
+    (let [seed (config/get-filter-seed)]
+      (when (and seed
+                 (or (seq (:in seed)) (seq (:out seed))))
+        (rf/with-frame frame-id
+          (rf/dispatch-sync [:rf.xray/hydrate-filters seed]))))))
 
 (register-first-mount-hook!
   ::hydrate-column-widths

--- a/tools/xray/test/day8/re_frame2_xray/init_filter_reset_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/init_filter_reset_cljs_test.cljs
@@ -30,6 +30,7 @@
   nor linger in storage after the reset hook runs."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.filters.persistence :as filters-persistence]
             [day8.re-frame2-xray.frame-switcher :as frame-switcher]
             [day8.re-frame2-xray.mount :as mount]
@@ -68,7 +69,13 @@
                    (filters-persistence/clear!)
                    (spine-filters/clear-raw!)
                    (frame-switcher/clear!)
-                   (static-persistence/clear!))}))
+                   (static-persistence/clear!)
+                   ;; rf2-fhtes — the host `:rf.xray/filters` seed atom is
+                   ;; process-global and now LOAD-BEARING on the boot path
+                   ;; (`::seed-configured-filters`). Clear it before each
+                   ;; test so a sibling test's `configure!` cannot leak a
+                   ;; seed into the reset-policy scenarios below.
+                   (config/set-filter-seed! nil))}))
 
 (defn- with-local-storage-stub
   "Install an in-memory `js/window.localStorage` for the test's duration,
@@ -228,3 +235,76 @@
         "transient mute slot cleared")
     (is (nil? (frame-switcher/load))
         "transient frame-pin slot cleared")))
+
+;; -------------------------------------------------------------------------
+;; (6) EXPLICIT host filter SEED lands as the boot baseline (rf2-fhtes)
+;; -------------------------------------------------------------------------
+;;
+;; `configure!` accepts `:rf.xray/filters` and the config/spec/API prose
+;; promised the seed would hydrate `:active-filters`, but production never
+;; called `filters/hydrate!` — the real `ensure-xray-frame!` hook table
+;; only RESET transient filters and never READ the seed, so a host using
+;; the documented key got no error and an unfiltered first paint. The
+;; passing persistence tests only proved this by calling `filters/hydrate!`
+;; MANUALLY (routing around the hook table), so the gap stayed green.
+;;
+;; These tests drive the REAL production `ensure-xray-frame!` path (the
+;; same `boot!` the reset-policy tests above use) and NEVER call
+;; `filters/hydrate!` — the lever that was red on main. The policy: an
+;; EXPLICITLY configured seed is the host's opt-in and lands as the boot
+;; baseline AFTER the transient reset; a `nil` seed stays fully unfiltered.
+
+(def ^:private host-seed
+  "An explicit host-configured seed, as a Story testbed (or any host)
+  would ship via `(configure! {:rf.xray/filters …})`."
+  {:in  [{:pattern ":order/*"}]
+   :out [{:pattern ":mouse-move"}]})
+
+(deftest configured-seed-lands-as-boot-baseline
+  (testing "an explicitly configured :rf.xray/filters seed is observed in
+            :active-filters after the REAL ensure-xray-frame! path — WITHOUT
+            calling filters/hydrate! manually (rf2-fhtes criterion 1)"
+    (config/configure! {:rf.xray/filters host-seed})
+    ;; No localStorage pill state — the seed is the only source.
+    (is (= {:in [] :out []} (filters-persistence/load))
+        "precondition: localStorage carries no user pills")
+    (boot!)
+    (is (= host-seed (frame-sub [:rf.xray/active-filters]))
+        "the host seed IS the boot baseline for :active-filters on the real
+         production path — the false-hydrate contract is now honoured")))
+
+(deftest no-seed-first-mount-stays-fully-unfiltered
+  (testing "with NO host seed, production first mount comes up fully
+            unfiltered (rf2-fhtes criterion 2 — nil remains unfiltered)"
+    (is (nil? (config/get-filter-seed))
+        "precondition: the fixture cleared any seed")
+    (boot!)
+    (is (= {:in [] :out []} (frame-sub [:rf.xray/active-filters]))
+        "no seed → registry-default empty pills → unfiltered first paint")))
+
+(deftest configured-seed-wins-over-stale-localstorage
+  (testing "a stale user/localStorage pill set NEITHER survives reload NOR
+            overrides the explicit host boot posture (rf2-fhtes criterion 2)"
+    ;; A past session persisted its own pills AND the host ships a seed.
+    (filters-persistence/save! stale-pills)
+    (config/configure! {:rf.xray/filters host-seed})
+    (is (= stale-pills (filters-persistence/load))
+        "precondition: localStorage holds the stale user pills")
+    (boot!)
+    (is (= host-seed (frame-sub [:rf.xray/active-filters]))
+        "the host seed baseline wins — the stale user pills never override it")
+    (is (not= stale-pills (frame-sub [:rf.xray/active-filters]))
+        "the stale user pills did NOT resurface")))
+
+(deftest configured-seed-is-not-durable-user-persistence
+  (testing "the seed is an explicit boot baseline re-applied each load — it
+            is NOT written to localStorage as durable user pills (rf2-fhtes
+            criterion 3 — not durable user-filter persistence)"
+    (config/configure! {:rf.xray/filters host-seed})
+    (boot!)
+    (is (= host-seed (frame-sub [:rf.xray/active-filters]))
+        "seed is the live baseline in app-db")
+    (is (= {:in [] :out []} (filters-persistence/load))
+        "the seed did NOT persist into the user filter localStorage slot —
+         `::reset-transient-filters` clears it and the seed hook writes only
+         app-db, so the baseline is re-derived from configure! each load")))


### PR DESCRIPTION
## Summary

Closes a **false public Xray contract**. `configure!` accepted `:rf.xray/filters` and the config/spec prose promised the seed would hydrate `:active-filters`, but **production never called `filters/hydrate!`** — `filters/install!` explicitly does NO hydrate, and the real `ensure-xray-frame!` first-mount hook table only *reset* transient filters (`::reset-transient-filters`), never reading the seed. A host using the documented key got **no error and an unfiltered first paint**.

The passing persistence tests hid the gap: their `xray-setup!` called `filters/hydrate!` **manually** (and even claimed production did so), routing around the real hook table — a false-green proxy.

## The fix (small, coherent)

A new `mount.cljs` `::seed-configured-filters` first-mount hook, registered immediately **after** `::reset-transient-filters`, applies a non-empty configured seed to `:active-filters` as the **explicit host boot baseline** on every load. It mirrors the existing `::hydrate-static-mode` shape (read via a config helper, dispatch the owning `:rf.xray/hydrate-filters` event).

- **Opted-in seed = boot baseline** (the programmer chose it) — re-applied each load.
- **`nil` seed = fully unfiltered** first paint (the default; genuine no-op).
- **Seed-only, never reads localStorage** — a user's stale session pills are cleared by `::reset-transient-filters` first, then the host seed lands on top, so stale filters never survive reload *or* override the explicit posture.
- **Not durable user-filter persistence** — the seed writes only app-db, is re-derived from `configure!` each load; the localStorage user slot stays cleared.

`filters/hydrate!` is unchanged and retained for its existing data-layer callers.

## Acceptance criteria (bead rf2-fhtes)

1. ✅ A test drives the **actual production `ensure-xray-frame!` path** after `configure! {:rf.xray/filters seed}` and observes the seed in `:active-filters` — **without calling `filters/hydrate!`**. Red-before proven (see gates).
2. ✅ No seed → first mount fully unfiltered; stale user/localStorage filters neither survive reload nor override the explicit posture.
3. ✅ config / filter / mount / Spec 015 / Spec 018 wording reconciled to "explicit host boot baseline" — not durable user-filter persistence, not an unreachable first-install-only promise.
4. ✅ Story's live/pending preset behaviour stays green (full node suite, incl. all Story CLJS tests).
5. ✅ No install marker, migration, new public API, compatibility shim, or hydration subsystem — the hook is an anonymous fn under a mount-internal id; only docstrings/comments/specs otherwise.

## Scope

`tools/xray/src/{mount,filters,config}` + `tools/xray/spec/{015,018}` + one xray test. No `implementation/**`, no Spec 009 / Tool-Pair surface, no `spec/API.md` (top-level `spec/API.md` carries **no** `:rf.xray/filters` hydrate prose — Xray config keys live in Xray's own spec, so there is no hot-zone contention). Co-edit rule honoured (Spec 015 + 018 updated in this PR; Spec 017 unchanged — it makes no first-install claim).

## Quality gates

- ✅ **tools/xray JVM suite** (`clojure -M:test`): 1270 tests, 5908 assertions, **0 failures, 0 errors**.
- ✅ **Node CLJS suite** (`npm run test:cljs`): 10290 tests, 50738 assertions, **0 failures, 0 errors** (includes the new seed tests driving the real `ensure-xray-frame!` path + all Story preset tests).
- ✅ **Red-before proven**: with the seed hook neutralized (reproducing on-main behaviour), exactly the 3 seed-landing assertions fail while the no-seed control + all 10287 other tests pass; restoring the hook → all green.
- ✅ **Docs**: `python -m mkdocs build --strict` exit 0; `python scripts/check_doc_slugs.py` exit 0.
- ⏳ **Xray feature-matrix gate** (`npm run test:xray-feature-gate`): running (cold Chromium compile under heavy concurrent-worker load); result appended when complete.
- n/a **mcp-conformance**: not run — this change does not touch the Tool-Pair / Spec 009 surface.
