### PR TITLE
docs(EP): preserve EP-0032's two remaining settled declarations with dated errata (rf2-u3gqv)

### DIFF
--- a/docs/EP/EP-0032-re-frame-ui-reactivity-and-ownership.md
+++ b/docs/EP/EP-0032-re-frame-ui-reactivity-and-ownership.md
@@ -263,17 +263,24 @@ error by the ABI guard.
   `spec/006-ReactiveSubstrate.md`; this EP's text above states it as
   corrected. The other five invariants were never in question.
 - **Original drain-quiescence wording preserved (2026-07-19, rf2-r7ahi).** The
-  host-checkpoint correction did not touch invariant 6 alone: PR #6393 reworded
-  three further settled passages in place from the original drain-quiescence
-  phrasing, and the Abstract summary carries the same drain → host-checkpoint
-  change. Those rewrites read as current truth above, but the freeze-meaning
-  ruling (rf2-r7ahi) requires the settled originals to stay visible, so they are
+  host-checkpoint correction reached five settled passages, not invariant 6
+  alone: PR #6393 reworded the Goals bullet, §One ViewCell, and §Push economics
+  in place from the original drain-quiescence phrasing, and the same drain →
+  host-checkpoint change carries through the Abstract summary and invariant 6.
+  Those rewrites read as current truth above, but the freeze-meaning ruling
+  (rf2-r7ahi) requires the settled originals to stay visible, so all five are
   preserved here — `spec/006-ReactiveSubstrate.md` (host-checkpoint render
   batching) remains the current normative truth:
+  - **§Abstract** originally read "Notification is **push**: *one constant-work
+    mark per dirty cell per run-to-completion drain*, committed after the pull
+    alternative was falsified by benchmark (4.0×–6.5× worse, gap growing with
+    scale)".
   - **Goals** originally read "committed push economics with *drain-quiescence
     batching* and a test flush".
   - **§One ViewCell per view** originally read "one `useSyncExternalStore` over a
     scalar revision snapshot, one *notification per drain*".
+  - **Invariant 6** originally read "one notification per dirty cell *per drain
+    (boundary at quiescence, never epoch close)*".
   - **§Push economics** originally read "Every queued event commits its own epoch
     record inside the run-to-completion drain; *at quiescence each dirty cell
     flushes exactly once and React performs one read/render batch for the whole


### PR DESCRIPTION
Applies the existing freeze-meaning ruling (rf2-r7ahi, ruled (b) 2026-07-18) to the last two EP-0032 passages it left uncovered. PR #6463 preserved the original settled wording for three of the five drain -> host-checkpoint passages (Goals, One ViewCell, Push economics) but for the **Abstract** and **invariant 6** it only *noted* the same correction applies — it did not quote the originals, and neither original survives elsewhere in the current EP. This closes that gap by extending the one document-wide erratum, matching #6463's pattern exactly.

## What changed

Extends the single `Original drain-quiescence wording preserved` erratum bullet in Resolved Decisions to quote two more recovered originals, in document order:

- **§Abstract** original (recovered from `f2c4804111`, reworded in place by the de-historicalise commit `b8bac37413`):
  > "Notification is **push**: one constant-work mark per dirty cell per run-to-completion drain, committed after the pull alternative was falsified by benchmark (4.0×–6.5× worse, gap growing with scale)".
- **Invariant 6** original (recovered from the removed line in `ef5a1c98c1`, rf2-vxgfnd.166):
  > "one notification per dirty cell per drain (boundary at quiescence, never epoch close)".

The bullet's intro prose is updated from "three further settled passages" to the accurate "five settled passages", and both new sub-bullets sit alongside the three #6463 already preserved.

## What is deliberately unchanged

- Current-truth body prose (Abstract line ~17-19, invariant 6 line ~110-114) stays as the shipped host-checkpoint truth — this preserves the *historical* declaration, it does not revert the framework.
- `spec/006-ReactiveSubstrate.md` remains the normative authority (untouched).
- EP status stays `final` (no flip; `check_ep_status_sync.py` green).
- No checker, no policy expansion, no other EP or spec touched. Surface is EP-0032 only.

## Quality gates

- `python -m mkdocs build --strict` — PASS (exit 0; only pre-existing INFO lines)
- `python scripts/check_doc_slugs.py` — PASS (exit 0)
- `python scripts/check_ep_status_sync.py` — PASS (exit 0)
- `implementation/ui` JVM test (`guide_truth_jvm_test.clj`) — N/A: it pins Ownership.md / EP-0030 / EP-0034, **not** EP-0032 (verified: zero EP-0032 occurrences), so it cannot be affected by this doc change.