### PR TITLE
docs(examples): refresh the SSR example stand-ins to the shipped reg-view + S5 path (rf2-hjtf2)

### DIFF
--- a/examples/capabilities/ssr/ssr/index.html
+++ b/examples/capabilities/ssr/ssr/index.html
@@ -25,6 +25,23 @@
     `:rf/hydrate` (replace-frame-state semantics, Spec 011), and renders
     against the now-seeded state.
 
+    The #app subtree is the dev-build output of `rf/render-to-string` — the
+    same string `handle-request` inlines (minus the render-hash attribute
+    noted below). In a dev build the reg-view REGISTRATION boundary stamps two
+    annotations on every registered view's root DOM element (Spec 006
+    §Source-coord annotation / §View tagging contract, moved cross-host to the
+    reg-view boundary by rf2-8vi4q): the `:pages/articles` view's
+    `<div class="page">` root carries
+    `data-rf2-source-coord="pages:articles:228:1"` (its `<ns>:<sym>:<line>:<col>`
+    reg-view call site) and `data-rf-view=":pages/articles"`, so pair-shaped
+    tooling can map the node back to its view. The client's dev render stamps
+    the SAME two attributes, so this page hydrates as a clean ADOPTION rather
+    than an attribute mismatch. `:app/root` renders `[(rf/view :pages/articles)]`
+    — a callable head, not a DOM element — so it contributes no wrapper node and
+    no annotation of its own. A production build (`goog.DEBUG=false` /
+    `re-frame.debug=false`) elides the annotations on both hosts, so prod markup
+    is attribute-free.
+
     The data-rf-render-hash attribute would normally be emitted by
     render-to-string with :emit-hash? true, and the matching :rf/render-hash
     would ride the payload below; we omit BOTH from this static page because
@@ -40,16 +57,7 @@
     implementation/core/test/re_frame/examples_test.clj (and by the
     re-frame.ssr conformance suite).
   -->
-  <div id="app">
-    <div class="page">
-      <h1>Recent articles</h1>
-      <button class="toggle-bodies" data-testid="toggle-bodies">Hide bodies</button>
-      <ul data-testid="articles-list">
-        <li><h3>Article A</h3><p class="body" data-testid="article-body">Body A</p></li>
-        <li><h3>Article B</h3><p class="body" data-testid="article-body">Body B</p></li>
-      </ul>
-    </div>
-  </div>
+  <div id="app"><div class="page" data-rf2-source-coord="pages:articles:228:1" data-rf-view=":pages/articles"><h1>Recent articles</h1><button class="toggle-bodies" data-testid="toggle-bodies">Hide bodies</button><ul data-testid="articles-list"><li><h3>Article A</h3><p class="body" data-testid="article-body">Body A</p></li><li><h3>Article B</h3><p class="body" data-testid="article-body">Body B</p></li></ul></div></div>
   <script id="__rf_payload" type="application/edn">
 {:rf/version 1
  :rf/app-db {:articles [{:id "a" :title "Article A" :body "Body A"}

--- a/examples/capabilities/ssr/ssr_streaming/index.html
+++ b/examples/capabilities/ssr/ssr_streaming/index.html
@@ -37,36 +37,23 @@
     because the streaming runtime's contract is purely additive — a
     page with the final payload already inlined skips the per-chunk
     swap path and goes straight to :rf/hydrate.
+
+    The #app subtree is the dev-build FINAL resolved DOM — every boundary
+    already swapped to its body, and the flaky boundary to its declared
+    skeleton fallback — as `rf/render-to-string` emits it. In a dev build
+    the reg-view REGISTRATION boundary stamps `data-rf2-source-coord`
+    (`<ns>:<sym>:<line>:<col>`, the reg-view call site) and `data-rf-view`
+    (`(str id)`) on every registered view's root DOM element (Spec 006
+    §Source-coord annotation / §View tagging contract, moved cross-host to
+    the reg-view boundary by rf2-8vi4q). So `:dashboard/root` stamps the
+    `<main class="dashboard">` root, each resolved `:dashboard/card` stamps
+    its `<div class="card">`, and the flaky boundary's declared fallback
+    `:dashboard/card-skeleton` stamps `<div class="card skeleton">`. The
+    client's dev render stamps the same attributes, so the page adopts
+    cleanly and pair-shaped tooling can map each node to its view; a
+    production build elides them on both hosts.
   -->
-  <div id="app">
-    <main class="dashboard">
-      <header>
-        <h1>Dashboard</h1>
-        <p>Streamed SSR demo — shell renders first, cards stream in.</p>
-      </header>
-      <section class="cards">
-        <div class="card">
-          <h3>Revenue (last 7 days)</h3>
-          <p class="value">42375</p>
-        </div>
-        <div class="card">
-          <h3>New signups (last 7 days)</h3>
-          <p class="value">318</p>
-        </div>
-        <div class="card">
-          <h3>P50 latency (ms)</h3>
-          <p class="value">24</p>
-        </div>
-        <div class="card skeleton">
-          <h3>Loading flaky …</h3>
-          <p class="value">—</p>
-        </div>
-      </section>
-      <footer>
-        <p>Each card above is a <code>:rf/suspense-boundary</code>.</p>
-      </footer>
-    </main>
-  </div>
+  <div id="app"><main class="dashboard" data-rf2-source-coord="dashboard:root:159:1" data-rf-view=":dashboard/root"><header><h1>Dashboard</h1><p>Streamed SSR demo — shell renders first, cards stream in.</p></header><section class="cards"><div class="card" data-rf2-source-coord="dashboard:card:89:1" data-rf-view=":dashboard/card"><h3>Revenue (last 7 days)</h3><p class="value">42375</p></div><div class="card" data-rf2-source-coord="dashboard:card:89:1" data-rf-view=":dashboard/card"><h3>New signups (last 7 days)</h3><p class="value">318</p></div><div class="card" data-rf2-source-coord="dashboard:card:89:1" data-rf-view=":dashboard/card"><h3>P50 latency (ms)</h3><p class="value">24</p></div><div class="card skeleton" data-rf2-source-coord="dashboard:card-skeleton:84:1" data-rf-view=":dashboard/card-skeleton"><h3>Loading flaky …</h3><p class="value">—</p></div></section><footer><p>Each card above is a `:rf/suspense-boundary`.</p></footer></main></div>
   <script id="__rf_payload" type="application/edn">
 {:rf/version 1
  :rf/app-db {:cards {:revenue {:title "Revenue (last 7 days)" :value 42375}


### PR DESCRIPTION
## What

`#6469` (rf2-8vi4q) moved the dev-mode `data-rf2-source-coord` + `data-rf-view` annotations from the SSR emitter to the cross-host **reg-view registration boundary**. The two runnable static SSR example stand-ins still shipped **pre-fix** server markup — no annotation on any registered-view DOM root — so a dev build hit an attribute-only React hydration mismatch (left unpatched), and the adopted DOM stayed invisible to view / source-coordinate tooling.

This refreshes both checked-in `#app` stand-ins to the **byte-exact dev-build `rf/render-to-string` output**, captured by rendering the example views on the JVM in a dev build (`interop/debug-enabled? = true`).

### `examples/capabilities/ssr/ssr/index.html`
- `:pages/articles` `<div class="page">` root now carries `data-rf2-source-coord="pages:articles:228:1"` + `data-rf-view=":pages/articles"`.
- `:app/root` renders `[(rf/view :pages/articles)]` — a **callable head, not a DOM element** — so it contributes no wrapper node and carries no annotation of its own (confirmed against the dev-mode render).

### `examples/capabilities/ssr/ssr_streaming/index.html`
- `:dashboard/root` (`<main class="dashboard">`), each of the three resolved `:dashboard/card` roots, and the flaky boundary's declared `:dashboard/card-skeleton` fallback each carry their exact annotations.
- Corrected a stale `<code>:rf/suspense-boundary</code>` footer to the literal backticks the view actually renders (a second, latent divergence from the view output).

Both `#app` subtrees are now the compact byte-exact server output (no whitespace text nodes), so the page hydrates as a clean ADOPTION. The surrounding comments were updated to explain the reg-view annotation contract and its production elision.

## Scope notes
- **No example test added** (examples are test-free, rf2-8cevm), **no new example**, **no `implementation/` change**, **no hot-zone shadow config** touched. Examples consume the shipped SSR API only.
- The two examples remain idiomatic re-frame2 (app-db + events + subs; no raw atoms through views, no frame-ids as view args) — the change is limited to the static stand-in DOM + comments.
- A **third** SSR example, `resources_ssr/index.html`, carries the identical annotation-free defect on its `<div class="page">` root but was **not named** by the bead (which scopes to "both" of the two above). Left untouched; recommend a follow-up bead.

## Quality gates
- Rendered the example views on the JVM in a dev build and diffed the `#app` subtree byte-for-byte against each file — **IDENTICAL** for both.
- `shadow-cljs compile examples/ssr examples/ssr-streaming` → **Build completed, 0 warnings** for both.
- No README touched → no `mkdocs build` / `check_doc_slugs` needed.