### PR TITLE
docs: finish the G-18 proof-boundary wording after graduation (rf2-fyya5)

### DIFF
--- a/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
+++ b/docs/EP/EP-0034-re-frame-ui-production-ssr-testing.md
@@ -203,12 +203,15 @@ table governs.
 
 Methodology, binding on every gate: identical fixtures, distributions not best
 runs, pinned browsers, cold+warm, dev overhead separate, no precomputed-props
-cheating. The component-library **proof pack** (controlled input, selection
-controller, slotted list cell, safe-attrs form control, schema-described
-component, inline popover, single-view import) is rendered and exercised by a
-mounted DOM suite (`re-frame.ui.proof-pack.library-dom-cljs-test`) — its
+cheating. The component-library **proof pack**'s six library views (controlled
+input, selection controller, slotted list cell, safe-attrs form control,
+schema-described component, inline popover) are rendered and exercised by a
+mounted DOM suite (`re-frame.ui.proof-pack.library-dom-cljs-test`) — their
 host-bearing views have no JVM side and cannot be dual-emitter parity-corpus
-rows; the substrate takes no build dependency on re-com.
+rows. The separate single-view import consumer
+(`re-frame.ui.proof-pack.single-view`) roots exactly one of those views for the
+advanced reachability scan that proves G-18 sibling isolation; it is not part of
+the mounted suite. The substrate takes no build dependency on re-com.
 
 ### 5. Gate wiring status
 

--- a/implementation/ui/proof-pack/re_frame/ui/proof_pack/single_view.cljs
+++ b/implementation/ui/proof-pack/re_frame/ui/proof_pack/single_view.cljs
@@ -1,8 +1,10 @@
 (ns re-frame.ui.proof-pack.single-view
   "G-18 subject: a consumer that imports EXACTLY ONE view (`controlled-input`)
   from the multi-view proof-pack library. Under an advanced build the five
-  unimported siblings — and their sentinels, schemas, docs, and dev
-  registration — must be absent (fixture-first)."
+  unimported siblings' render sentinels must be absent (fixture-first) — that
+  sibling render-sentinel isolation is the whole of G-18's claim. The
+  production absence of the library's schemas, docs projections, and dev
+  registration is a separate roster owned by G-11, not this consumer."
   (:require [re-frame.ui.proof-pack.library :as lib]))
 
 (defn -main []

--- a/spec/008-Testing.md
+++ b/spec/008-Testing.md
@@ -669,11 +669,12 @@ portals, presence timing, error recovery) requires a Tier-3 mounted test. This i
 same JVM-structural-subset boundary [004-Views.md §The JVM structural subset](004-Views.md#the-jvm-structural-subset)
 draws — Tier-1 is that subset's test surface.
 
-## Compiled-view gates — G-1, G-14, and the parity corpus
+## Compiled-view gates
 
-The compiled-view substrate ships three CI gates that [004-Views.md](004-Views.md)
-references (portability-law parity, expansion budget); they are catalogued here as the
-owning testing surface.
+The compiled-view substrate ships the CI gates that [004-Views.md](004-Views.md)
+references — portability-law parity and expansion budget among them; they are
+catalogued here as the owning testing surface, every row below owned by this
+document.
 
 | Gate | Asserts | Where |
 |---|---|---|


### PR DESCRIPTION
## What

PR #6471 (rf2-kxork) graduated the narrow G-18 sibling-isolation contract into spec/008 and moved the real six-view behaviour to the mounted DOM suite, honestly declining the schema/docs/dev-registration arms (they belong to G-11). Three live carriers still described the pre-graduation boundary. This finishes the wording so the proof boundary reads accurately and consistently across all three sites — wording only, no normative change.

**What G-18 actually proves now:** an advanced build importing exactly one view from a multi-view library namespace retains no unused sibling views — measured as each sibling `defview`'s render-sentinel literal, over a roster derived from the proof-pack library source. That sibling render-sentinel isolation is the whole of G-18's claim. Production absence of the library's schemas, docs projections, and dev registration is owned by **G-11**; the six library views are separately rendered and exercised for behaviour by the mounted DOM suite (`re-frame.ui.proof-pack.library-dom-cljs-test`).

## Sites reconciled

- **`implementation/ui/proof-pack/.../single_view.cljs`** (docstring) — retired the claim that the siblings' schemas, docs, and dev registration must be absent under G-18; narrowed to sibling render-sentinel isolation and pointed the moved arms at G-11.
- **`docs/EP/EP-0034-...md`** (§4 methodology paragraph) — separated the six mounted library views from the single-view import consumer, which only roots one Var for the advanced reachability scan that proves G-18 isolation.
- **`spec/008-Testing.md`** (§Compiled-view gates heading + intro) — the heading named only G-1/G-14/parity and the intro claimed "three CI gates" though the table now also owns G-17/G-18; made both roster-neutral with no brittle count. The G-18 row itself was already correct and is unchanged.

No EP status flipped. No G-11 rider, §4/§5 stage-honesty text, other EP, or spec/009 touched. No collision with syell (it touches `check-ui-facade-isolation.cjs` + the mounted suite roster, not this docstring).

## Quality gates

All run in the foreground to completion:

- `python -m mkdocs build --strict` — exit 0
- `python scripts/check_doc_slugs.py` — exit 0
- `python scripts/check_ep_status_sync.py` — exit 0
- `npm run test:ui-facade-isolation` (the G-18 gate) — exit 0; advanced-build scan confirms single-view import retains 0/5 siblings, G-18 PASS
- `cd implementation/ui && clojure -M:test` — exit 0; 1001 tests, 19596 assertions, 0 failures, 0 errors (includes `guide_truth_jvm_test.clj`, which pins EP-0034 by exact path — green, no pinned sentence touched)
