### PR TITLE
test: scope process-global trace listeners to their own mounted-DOM tests (rf2-veyfp)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
@@ -934,9 +934,20 @@
               host         (.createElement js/document "div")
               captured     (atom [])
               k            (str (gensym "stream-exactly-once-cb"))
+              ;; Scope the count to THIS boundary's own id. `captured` is a
+              ;; PROCESS-GLOBAL trace listener — it observes every namespace's
+              ;; events, including any deferred emit a sibling suite leaked into
+              ;; this test's `js/setTimeout` settle windows — so an
+              ;; `:operation`-only count measures the SUITE, not this boundary.
+              ;; The `(= 1 (failed-count))` below is the SOLE detector that the
+              ;; trace fired on the successful swap, so an unscoped count could
+              ;; go green on a foreign padding while THIS boundary emitted none
+              ;; (the rf2-veyfp false-green). The failed trace carries the
+              ;; authored id under `[:tags :id]` (see string-boundary-id test).
               failed-count #(count (filter (fn [ev]
-                                             (= :rf.ssr/suspense-boundary-failed
-                                                (:operation ev)))
+                                             (and (= :rf.ssr/suspense-boundary-failed
+                                                     (:operation ev))
+                                                  (= id (-> ev :tags :id))))
                                            @captured))]
           ;; NO fallback <template> for `id` yet — the failed chunk arrives
           ;; before any live mount exists.

--- a/implementation/ui/test/re_frame/ui/mounted_story_override_image_schema_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/mounted_story_override_image_schema_dom_cljs_test.cljs
@@ -362,9 +362,18 @@
                  (let [{:keys [cell sid lease remount]} @seen
                        site      (reactive/committed-site cell sid)
                        nil-lease (:lease site)
+                       ;; Scope to THIS frame's own failures. `errors` is a
+                       ;; PROCESS-GLOBAL trace listener (every `:op-type :error`
+                       ;; across every namespace), so an `:operation`-only count
+                       ;; can be padded by a sibling suite's schema-validation
+                       ;; failure that lands in this fixture's async settle
+                       ;; window — measuring the suite, not this frame
+                       ;; (rf2-veyfp). The failure carries `:tags :frame`
+                       ;; (asserted below), so scope the count to it.
                        failures (filter
-                                 #(= :rf.error/schema-validation-failure
-                                     (:operation %))
+                                 #(and (= :rf.error/schema-validation-failure
+                                          (:operation %))
+                                       (= frame-id (-> % :tags :frame)))
                                  @errors)
                        failure  (first failures)]
                    (testing "HMR revalidates against the new image and installs a nil HIT"


### PR DESCRIPTION
## Summary

Closes the false-green class filed as **rf2-veyfp** — a follow-on to #6454 (rf2-i3dvj), which fixed ONE instance in place. A process-global trace listener in a mounted-DOM test observes events from *every* namespace that ran before it in the shared runner process (including any whose async teardown is never awaited). A test that counts such events by `:operation` alone is measuring the whole suite, not itself — so its count can come out right on scheduling luck (green-in-company).

I swept every mounted-DOM test that installs a process-global listener and scoped the two genuinely-vulnerable count assertions to their own subject. Both fixes are **pure narrowings** (an added conjunct on an existing filter): they can only stop foreign events being counted, never loosen an assertion.

## The two fixes

- **`ssr/…/streaming_client_dom_cljs_test.cljs`** — `emits-exactly-one-…`: `failed-count` now also requires `(= id (-> ev :tags :id))`. This count (asserted across two `js/setTimeout` windows) is the **sole** detector that the `:rf.ssr/suspense-boundary-failed` trace fired on the successful swap, while the DOM check stays green regardless — so an unscoped count was a genuine false-green vector. The failed trace carries the authored id under `[:tags :id]` (`:card.racey` round-trips through `read-boundary-id`), so the scoped count stays exactly 1.

- **`ui/…/mounted_story_override_image_schema_dom_cljs_test.cljs`** — `failures` now also requires `(= frame-id (-> % :tags :frame))`. The schema-validation failure carries `:tags :frame` (already asserted downstream), so the scoped count stays 1 for this frame's own failure.

## Census (every mounted-DOM test that installs a process-global listener)

| test | listener | verdict |
|---|---|---|
| `machine_view_unmount_teardown` | `register-listener!` | **#6454's fixed instance — untouched** (reference) |
| `streaming_client` `emits-exactly-one` | `register-listener!` | **VULNERABLE → scoped to `id`** |
| `mounted_story_override_image_schema` | `register-listener!` | **VULNERABLE → scoped to `frame-id`** |
| `frame_provider_context` scenario-3 | `with-trace-recorder!` | already-isolated (synchronous reset-then-assert; also the leak *source*, see below) |
| `cross_spec` (all `with-trace-recorder!` blocks) | `with-trace-recorder!` | already-isolated (fully synchronous; counts also guarded by `:frame` tag checks) |
| `adapter_generation_fence` | `register-error-listener!` (`:errors`) | already-isolated (membership `some #{…}`, not a count; synchronous window / backed by direct state assertions) |
| `preflight_supersession` | `register-error-listener!` (`:errors`) | already-isolated (asserts *absence* `(= [] @mismatches)`, synchronous) |

Not-a-listener (scoped capture, verified): `observation_port_watchable_host` (scoped `obs/acquire!` lease callback), `committed_events` (scoped fx-handler / dispatch stubs), `pair_dispatch_and_settle` (reads a per-epoch settled record). The remaining `(count …)` hits across the tree are DOM `querySelectorAll` / render-count atoms — inherently scoped to the test's own container.

Found vs the bead's named set: the bead named the pattern (not a specific list) and implied "more than one." Found **2** beyond #6454's fixed instance.

## Non-vacuity

Each corrected assertion still counts exactly the subject's own event (verified: `:card.racey` → `[:tags :id]`, `::story-frame` → `[:tags :frame]`), so it stays green **for the right reason**; if the subject emitted zero of its own the scoped count would be 0 and red. The change adds a conjunct, so it cannot make a previously-failing assertion pass. The mandatory browser run is the *in-suite* (polluting) condition and is green.

## Scope discipline

- No trace-runtime (`src/`) change — the tests misused a process-global listener; the runtime is fine.
- No shared framework, no listener-registry — just two one-predicate scopings.
- #6454's instance left as-is (reference, not a re-fix).

## Related gap (not fixed here — recommend a follow-up)

`frame_provider_context_dom_cljs_test` unmounts its probe views with `(rdc/unmount root)` in `finally` and never awaits React's deferred disposal — that is the **source** of the leaked `:rf.view/unmounted` markers #6454's instance was catching. After this PR no victim counts those markers, so the class is closed from the victim side; awaiting those teardowns at the source is a separate deterministic-teardown fix (the bead notes #6454 left it out of scope).

## Quality gates

- `npm run test:cljs` — **Ran 10313 tests, 50842 assertions, 0 failures, 0 errors**
- `npm run test:browser` (mandatory; mounted DOM) — **Ran 502 tests, 2811 assertions, 0 failures, 0 errors**
- `implementation/ui` JVM `clojure -M:test` — **Ran 1001 tests, 19597 assertions, 0 failures, 0 errors**

All run in the foreground to completion on this branch, rebased onto current `origin/main`.