### PR TITLE
fix(ssr): reject cross-host numeric-key and set collisions before manifest emission (rf2-pdcoh)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/manifest.cljc
+++ b/implementation/ssr/src/re_frame/ssr/manifest.cljc
@@ -443,6 +443,61 @@
           (when-not (and (edn-carryable? k) (edn-carryable? v)) k))
         m))
 
+(defn- browser-number
+  "The one IEEE-754 double a wire-number becomes on the BROWSER, where
+  every number is a double and there is a single zero (`+0.0 === -0.0`).
+  Two SERVER-distinct numbers collide on the client exactly when this
+  projection is `=`: a Long `1` and a double `1.0` both name `1.0`, and
+  `0` and `-0.0` both name `0.0`. `##NaN` never reaches here —
+  `edn-carryable?` excludes it, and it is not `=` to itself anyway."
+  [v]
+  (let [d (double v)]
+    (if (zero? d) 0.0 d)))
+
+(defn- numeric-collision
+  "-> a DATA map naming the FIRST cross-host numeric collision reachable
+  from `v` — a map whose distinct numeric KEYS, or a set whose distinct
+  numeric ELEMENTS, collapse to one `browser-number` — else `nil`.
+
+  `edn-carryable?` asks whether each value ALONE rides the wire; this
+  asks whether a whole map or set survives the crossing. It need not,
+  even when every element passes `edn-carryable?`: the server holds
+  numbers the browser cannot tell apart. `1` and `1.0`, or `0` and
+  `-0.0`, are two distinct keys on the JVM, but the browser reads both as
+  one double, so `pr-str`'ing the collection and reading it back on the
+  client rejects a DUPLICATE key/element (PR #6437 screened each value in
+  isolation and missed this). The check recurs through nested maps, sets,
+  vectors and lists — the same reach `edn-carryable?` walks — and `path`
+  records the route to the offending collection so the author can narrow
+  one key deliberately."
+  ([v] (numeric-collision v []))
+  ([v path]
+   (letfn [(collapse [kind xs]
+             (some (fn [[d members]]
+                     (when (next members)
+                       {:invalid        :cross-host-numeric-collision
+                        :collision       kind
+                        :path            path
+                        :collapses       (vec members)
+                        :browser-number  d}))
+                   (group-by browser-number (filter number? xs))))]
+     (cond
+       (map? v)
+       (or (collapse :map-keys (keys v))
+           (some (fn [[k val]]
+                   (or (numeric-collision k   (conj path {:key k}))
+                       (numeric-collision val (conj path k))))
+                 v))
+
+       (set? v)
+       (or (collapse :set-elements v)
+           (some #(numeric-collision % (conj path {:in-set %})) v))
+
+       (coll? v)
+       (first (keep-indexed (fn [i x] (numeric-collision x (conj path i))) v))
+
+       :else nil))))
+
 (defn script-html
   "-> the manifest's WIRE FORM: one `<script type=\"application/edn\"
   data-rf-root>` element carrying the `pr-str`'d manifest, escaped by
@@ -468,7 +523,19 @@
   (rf2-v4foc).
 
   One predicate, `edn-carryable?`, spelled once and enforced at both
-  points. Not a second rule."
+  points. Not a second rule.
+
+  ## The collision gate
+
+  `edn-carryable?` clears each value ALONE; it cannot see that a whole
+  map or set fails to CROSS. The server holds `1` and `1.0`, or `0` and
+  `-0.0`, as two distinct keys — each rides the wire — yet the browser
+  reads every number as one double and collapses the pair, so the emitted
+  body reads back with a DUPLICATE key and the manifest changes
+  cardinality across the wire (PR #6437 checked each value in isolation
+  and missed this). So the whole manifest is also screened for cross-host
+  numeric collisions here, at the one door onto the wire, and a colliding
+  manifest is refused rather than emitted."
   [m]
   (validate! 'rf.ssr/manifest-script m)
   (when-let [k (unwireable-key m)]
@@ -487,6 +554,24 @@
           "manifest must be plain EDN data both hosts hold identically")
      {:recovery :pass-serialisable-root-props
       :extra    {:unserialisable-manifest-key k}}))
+  (when-let [{:keys [collision path collapses browser-number] :as c}
+             (numeric-collision m)]
+    (error/throw-error!
+     :rf.error/root-manifest-invalid 'rf.ssr/manifest-script
+     (str "root manifest holds a cross-host numeric collision at "
+          (pr-str path) ": the distinct "
+          (if (= :map-keys collision) "map keys " "set elements ")
+          (pr-str collapses) " are separate values on the server, but the "
+          "browser reads every number as one IEEE-754 double, so they "
+          "collapse to " (pr-str browser-number) " on the client — the "
+          "emitted body would not read back, the reader rejecting it as a "
+          "duplicate " (if (= :map-keys collision) "key" "element")
+          " and changing the collection's cardinality between server and "
+          "client. Each value rides the wire alone, so this is not a "
+          "carryability failure: narrow one of the colliding numbers so "
+          "both hosts agree on the collection")
+     {:recovery :re-render-the-root-manifest
+      :extra    c}))
   (str "<script type=\"" manifest-script-type "\" "
        constants/root-manifest-marker-attribute ">"
        (html/escape-edn-script-body (pr-str m))

--- a/implementation/ssr/test/re_frame/ssr/root_manifest_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/root_manifest_cljs_test.cljc
@@ -551,6 +551,7 @@
     (doseq [v [0 -1 1 1.5 -1.5 9.0 0.1
                manifest/max-safe-integer
                (- manifest/max-safe-integer)
+               ##Inf ##-Inf
                #?(:clj 1.0E308 :cljs 1e308)]]
       (is (manifest/edn-carryable? v) (str "must still carry " (pr-str v))))
 
@@ -586,6 +587,171 @@
     (testing "a large DOUBLE is admitted though it dwarfs the integer
               bound — the bound is about representability, not magnitude"
       (is (manifest/edn-carryable? #?(:clj 1.0E308 :cljs 1e308))))))
+
+;; ---------------------------------------------------------------------------
+;; ±INFINITY RIDES; ONLY NaN IS EXCLUDED (rf2-pdcoh — Spec 011 same-contract)
+;; ---------------------------------------------------------------------------
+;;
+;; Spec 011 once read "finite doubles", but `wire-number?` admits ±Infinity and
+;; always has: EDN prints `##Inf` / `##-Inf` and reads them back EXACTLY, so
+;; they satisfy the round-trip property. `##NaN` alone is excluded — it is not
+;; `=` to itself. The predicate, the spec prose, and these pins now agree, on
+;; BOTH hosts.
+
+(deftest infinities-ride-only-nan-is-excluded
+  (testing "±Infinity is admitted on both hosts — EDN round-trips it exactly"
+    (is (manifest/edn-carryable? ##Inf))
+    (is (manifest/edn-carryable? ##-Inf)))
+  (testing "…and NaN alone is refused, by the round-trip property on its own terms"
+    (is (not (manifest/edn-carryable? #?(:clj Double/NaN :cljs js/NaN)))))
+  (testing "±Infinity survives the shipped wire, both hosts — the accepted pin"
+    (doseq [inf [##Inf ##-Inf]]
+      (let [m (manifest/manifest {:rf.root/schema-version 1 :root-id :page/shop}
+                                 {:props {:v inf}})]
+        (is (round-trips? m) (str "±Inf prop " (pr-str inf) " round-trips"))
+        (is (= inf (get-in (manifest/read-manifest
+                            'test (script-body (manifest/script-html m)))
+                           [:props :v]))
+            "the exact infinity the server rendered is what the reader returns")))))
+
+;; ---------------------------------------------------------------------------
+;; CROSS-HOST NUMERIC KEY / SET COLLISIONS (rf2-pdcoh)
+;; ---------------------------------------------------------------------------
+;;
+;; PR #6437 made `wire-number?` decide, PER VALUE, whether a number crosses the
+;; JVM→CLJS wire. Per-value acceptance is not enough for a whole map or set:
+;; the server and the browser do not share numeric key identity. On the JVM `1`
+;; and `1.0` (and `0` and `-0.0`) are two DISTINCT keys that BOTH pass
+;; `edn-carryable?`; the browser reads every number as one double, so the
+;; emitted body reads back with a DUPLICATE key — the accepted manifest does
+;; not round-trip, and its cardinality changes across the wire. As with the
+;; numeric-scalar arm above, no same-host suite can see it: the server reads its
+;; own two-key body back perfectly. So this proof, too, is joined by BYTES.
+
+(def ^:private collision-bodies
+  "Exact `<script>` bodies a PRE-fix server emitted for colliding manifests,
+  pinned as BYTES because bytes are what cross. Map-key, set-element, and
+  signed-zero arms. The JVM half pins the tokens against the live printer so
+  these literals cannot go stale."
+  {:map  "{:rf.root/schema-version 1, :root-id :page/shop, :phase :server, :props {:lookup {1 :integer, 1.0 :double}}}"
+   :set  "{:rf.root/schema-version 1, :root-id :page/shop, :phase :server, :props {:tags #{1.0 1}}}"
+   :zero "{:rf.root/schema-version 1, :root-id :page/shop, :phase :server, :props {:lookup {0 :a, -0.0 :b}}}"})
+
+(deftest colliding-wire-bytes-part-across-hosts
+  (testing "rf2-pdcoh — the SAME wire bytes, read by the shipped `read-manifest`
+            on each host, PART: the server reads its own body back with BOTH
+            keys; the browser rejects it as a duplicate. One wire, two
+            cardinalities — the defect as an executable fact, and WHY emission
+            must now refuse the value."
+    #?(:clj
+       (do
+         (is (= "{1 :integer, 1.0 :double}" (pr-str {1 :integer 1.0 :double}))
+             "the map tokens pinned in `collision-bodies` match the live printer")
+         (is (= "#{1.0 1}" (pr-str #{1 1.0}))
+             "…and the set token — if either reds, the pinned bytes are stale")
+         (is (= 2 (count (get-in (manifest/read-manifest 'test (:map collision-bodies))
+                                 [:props :lookup])))
+             "the server round-trips two distinct keys — same-host is blind")
+         (is (= 2 (count (get-in (manifest/read-manifest 'test (:set collision-bodies))
+                                 [:props :tags])))))
+       :cljs
+       (doseq [[label body] collision-bodies]
+         (let [data (try (manifest/read-manifest 'test body) nil
+                         (catch cljs.core/ExceptionInfo e (ex-data e)))]
+           (is (= :rf.error/root-manifest-invalid (:rf.error/id data))
+               (str label " — the browser rejects the colliding body"))
+           (is (= :unreadable (:invalid data))
+               (str label " — as an unreadable body: the CLJS reader flags the "
+                    "duplicate the two server numbers collapsed into")))))))
+
+#?(:clj
+   (deftest cross-host-numeric-collision-fails-before-emission
+     (testing "rf2-pdcoh — the server holds two distinct keys the browser cannot
+               tell apart; `script-html` refuses the manifest BEFORE emission,
+               naming the offending collection, its colliding keys, and the one
+               browser double they share."
+       ;; map-key collision, nested under :props
+       (let [collide {1 :integer 1.0 :double}
+             m       {:rf.root/schema-version 1 :root-id :page/shop
+                      :props {:lookup collide}}]
+         (is (= 2 (count collide)) "the server really does hold two distinct keys")
+         (is (manifest/edn-carryable? collide)
+             "THE LEVER: each key and value rides the wire ALONE — exactly what
+              PR #6437 checked. Per-value carryability is not the property.")
+         (let [data (try (manifest/script-html m) nil
+                         (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+           (is (= :rf.error/root-manifest-invalid (:rf.error/id data))
+               "the EXISTING error id — a colliding manifest is a malformed
+                manifest, not a new failure kind, so no new catalogue row")
+           (is (= :cross-host-numeric-collision (:invalid data)))
+           (is (= :map-keys (:collision data)))
+           (is (= [:props :lookup] (:path data)) "the offending collection is NAMED")
+           (is (= #{1 1.0} (set (:collapses data))) "and its colliding keys")
+           (is (= 1.0 (:browser-number data)) "and the one browser double they share")))
+
+       ;; set-element collision
+       (let [m    {:rf.root/schema-version 1 :root-id :page/shop
+                   :props {:tags #{1 1.0}}}
+             data (try (manifest/script-html m) nil
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+         (is (= :cross-host-numeric-collision (:invalid data)))
+         (is (= :set-elements (:collision data)))
+         (is (= [:props :tags] (:path data)))
+         (is (= #{1 1.0} (set (:collapses data)))))
+
+       ;; signed zero — the JVM keeps Long 0 and double -0.0 apart; the browser
+       ;; holds ONE zero (verified: `(= 0 -0.0)` is true on CLJS)
+       (let [collide (into {} [[0 :a] [-0.0 :b]])
+             m       {:rf.root/schema-version 1 :root-id :page/shop
+                      :props {:lookup collide}}]
+         (is (= 2 (count collide)) "0 (Long) and -0.0 (double) are two keys on the JVM")
+         (let [data (try (manifest/script-html m) nil
+                         (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+           (is (= :cross-host-numeric-collision (:invalid data)))
+           (is (= 0.0 (:browser-number data)) "0 and -0.0 share the browser's one zero")))
+
+       ;; the gate is TOTAL: a DESCRIPTOR key `serialise-props` never sees is
+       ;; gated too, because `script-html` is the one door onto the wire
+       (let [m    {:rf.root/schema-version 1 :root-id :page/shop
+                   :static-props {:m {1 :a 1.0 :b}}}
+             data (try (manifest/script-html m) nil
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+         (is (= :cross-host-numeric-collision (:invalid data)))
+         (is (= [:static-props :m] (:path data))
+             "a descriptor key collides too — the check is at emission, not props-only"))
+
+       ;; nested through a vector — collisions are found at any depth
+       (let [m    {:rf.root/schema-version 1 :root-id :page/shop
+                   :props {:xs [{:a 1} #{2 2.0}]}}
+             data (try (manifest/script-html m) nil
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+         (is (= :cross-host-numeric-collision (:invalid data)))
+         (is (= :set-elements (:collision data)))
+         (is (= [:props :xs 1] (:path data)) "the path indexes into the vector")))))
+
+(deftest a-mutation-that-resolves-the-collision-emits-fine
+  (testing "rf2-pdcoh — THE RED-BEFORE MUTATION: change one colliding number so
+            the two keys/elements no longer share a browser double, and the very
+            same shape emits and round-trips. This proves each rejection above is
+            the COLLISION, not the shape — and that the gate does not narrow
+            ordinary numeric props."
+    (doseq [[label m]
+            {:map-mutated  {:rf.root/schema-version 1 :root-id :page/shop
+                            :props {:lookup {1 :integer 2.0 :double}}}
+             :set-mutated  {:rf.root/schema-version 1 :root-id :page/shop
+                            :props {:tags #{1.0 2}}}
+             :zero-mutated {:rf.root/schema-version 1 :root-id :page/shop
+                            :props {:lookup {0 :a 1.0 :b}}}
+             :single-key   {:rf.root/schema-version 1 :root-id :page/shop
+                            :props {:lookup {1 :only}}}
+             :distinct-set {:rf.root/schema-version 1 :root-id :page/shop
+                            :props {:tags #{1 2 3}}}
+             :nested-ok    {:rf.root/schema-version 1 :root-id :page/shop
+                            :props {:a [1 {:b #{2 3.5}}]}}}]
+      (is (string? (manifest/script-html m))
+          (str label " — a non-colliding numeric collection still emits"))
+      (is (round-trips? m)
+          (str label " — …and round-trips exactly")))))
 
 #?(:clj
    (deftest non-carryable-number-fails-before-emission

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -511,11 +511,13 @@ than hypotheticals:
   browser's reader reconstructs `9007199254740992`; `1/3` arrives as
   `0.3333333333333333`. This one does not throw at the far end — it *succeeds*, with a
   different value, so the app hydrates against props the server never rendered. The
-  admitted subset is therefore fixed-width integers within ±(2^53−1) and finite doubles;
-  no ratio, bigdec, bigint or float, and no `##NaN` (which the round-trip property
-  excludes on its own terms, not being `=` to itself). A large *double* still rides: the
-  bound is about **representability, not magnitude** — a double of any size carries only
-  precision a double carries.
+  admitted subset is therefore fixed-width integers within ±(2^53−1) and every double
+  except `##NaN` — including `##Inf` and `##-Inf`, which EDN prints and reads back
+  exactly; no ratio, bigdec, bigint or float. `##NaN` alone is excluded, by the
+  round-trip property on its own terms: it is not `=` to itself, so it cannot read back
+  equal on any host. A large *double* still rides: the bound is about
+  **representability, not magnitude** — a double of any size carries only precision a
+  double carries.
 
 The first two defects fail loud at the far end; the third is silent, which is why the
 predicate is stated as the crossing rather than as "is this printable EDN". A same-host
@@ -530,6 +532,17 @@ server and client — the very defect a fail-loud wire exists to prevent.
 The check belongs at **emission**, not only at prop assembly: descriptor keys reach the
 wire too, so gating `:props` alone leaves the property true of one key and false of the
 manifest. One predicate, enforced at the one door onto the wire.
+
+**Per-value carryability is not whole-collection carryability.** The predicate above
+clears each value *alone*; a whole map or set can still fail to cross. The server holds
+`1` and `1.0`, or `0` and `-0.0`, as two *distinct* map keys (or set elements); each
+rides the wire alone, yet the browser reads every number as one double and collapses the
+pair. The emitted body then fails to read back — the reader rejects a duplicate key — so
+the manifest changes *cardinality* across the wire, and no same-host suite can see it (the
+server reads its own two-key body back perfectly, exactly as with a bigint). Emission
+therefore also rejects, at that same one door, any map whose distinct keys or set whose
+distinct elements collapse under the browser's numeric identity — at any nesting depth,
+naming the offending collection so the author narrows one key deliberately.
 
 **Identity is spelled exactly once, in the content.** The root-id lives in the
 manifest's `:root-id` key and nowhere else on the wire. Putting it in the attribute as


### PR DESCRIPTION
## What

PR #6437's `wire-number?` decides **per value** whether a number crosses the JVM→CLJS Root Manifest wire. Per-value acceptance is not enough for a whole **map or set**, because the server and the browser do not share numeric key identity. On the JVM `1` and `1.0` (and Long `0` vs double `-0.0`) are two *distinct* map keys that each pass `edn-carryable?`, so the shipped `manifest` / `script-html` accept and emit e.g.:

```clojure
{:props {:lookup {1 :integer, 1.0 :double}}}
```

The browser reads every number as one IEEE-754 double, so the emitted body reads back with a **duplicate key** — the CLJS reader rejects `{1 :integer, 1.0 :double}` as *"Map literal contains duplicate key: 1"*. An accepted server manifest changes cardinality across the wire and never hydrates. Same class for set elements (`#{1 1.0}`) and signed zero (`0` / `-0.0`).

## Fix

One whole-manifest collision walk at the **emission gate** (`script-html`, the one door onto the wire), added beside the existing per-value `unwireable-key` check. It rejects any map whose distinct keys, or set whose distinct elements, collapse under the browser's numeric projection — **at any nesting depth** — under the **existing** `:rf.error/root-manifest-invalid` id, naming the offending collection (`:path`), the colliding values (`:collapses`), and the browser double they share (`:browser-number`).

No new error id, no codec, no tagged-reader registry, no schema framework, no blanket numeric-key ban. Valid single-numeric-key maps and distinct-number sets still emit unchanged.

Also resolves the **Spec 011 same-contract wording rider**: the prose said only *"finite doubles"* ride, but `wire-number?` admits ±Infinity and always has (EDN round-trips `##Inf` / `##-Inf` exactly); only `##NaN` is excluded. Spec 011 and the predicate now agree, with accepted/rejected pins on both hosts.

## Proof

- **Red-before with its own lever** — `edn-carryable?` accepts the colliding map (exactly what #6437 checked), yet `script-html` now refuses it with full attribution.
- **Dual-host** — the JVM constructs the collision and reads its own two-key body back (same-host is blind); the *exact JVM-emitted bytes*, read by the shipped CLJS `read-manifest`, are rejected as unreadable duplicates. Map, set, and signed-zero arms (`(= 0 -0.0)` verified true on CLJS).
- **Resolving mutation** — changing one colliding number so the pair no longer shares a browser double, each fixture emits and round-trips (the gate rejects collisions, not valid manifests).
- **#6477 / rf2-v4foc regression** stays green; the omitted-prefix/duplicate-prefix behaviour and the numeric-scalar round-trip are unchanged.

## Quality gates

- `implementation/ssr` JVM (`clojure -M:test`): **502 tests / 2393 assertions, 0 failures, 0 errors**.
- CLJS (`npm run test:cljs`): **10314 tests / 50867 assertions, 0 failures, 0 errors** (warm run; a cold-build run showed 5 failures isolated to `test-quiet` subprocess-spawn self-tests — disjoint from this diff, environmental, green on warm re-run).
- `python scripts/check_doc_slugs.py`: 44 self-tests pass, no broken links.
- `mkdocs build --strict`: passes.
- Core / Spec 009 catalogue gate: **not run** — reuses the existing `:rf.error/root-manifest-invalid` id, so the catalogue is untouched.

Surface: `implementation/ssr/src/re_frame/ssr/manifest.cljc`, its `.cljc` test, and `spec/011-SSR.md` only.
