### PR TITLE
fix(core): canonicalize the cross-host view-annotation value (rf2-5q0jv)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/source_coord_parity_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/source_coord_parity_cljs_test.cljs
@@ -24,6 +24,8 @@
   the SAME literals. If either host's formatter drifts, its test fails.
   The literals ARE the byte-comparison point — both sides pin independently."
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.adapter.context :as adapter-context]
+            [re-frame.source-coords :as source-coords]
             [re-frame.views]
             [re-frame.views.source-coord-annotation :as source-coord]))
 
@@ -100,3 +102,32 @@
           (str "CLJS degraded shape: expected "
                (pr-str expected-attr-no-line-no-col)
                " — got: " (pr-str cljs-output))))))
+
+;; ---- convergence: source-coords is the single cross-host owner (rf2-5q0jv) -
+;;
+;; Before rf2-5q0jv the CLJS formatters (in `re-frame.adapter.context`) and the
+;; JVM formatters (in `re-frame.views.jvm-source-coord-annotation`) were two
+;; hand-kept copies; a canonical-literal test could only catch a drift AFTER it
+;; shipped. They now alias one `.cljc` implementation in `re-frame.source-coords`,
+;; so a CLJS copy can no longer drift from the JVM host. Prove it: the neutral
+;; owner emits the canonical literals directly, and the adapter.context vars ARE
+;; that same fn object (`identical?` on fn references, not a keyword literal).
+
+(deftest neutral-owner-is-the-single-cljs-formatter-implementation
+  (testing "rf2-5q0jv — the CLJS adapter.context vars (and the re-frame.views /
+            spine re-exports built on them) alias the one cross-host
+            implementation in re-frame.source-coords; the neutral owner emits
+            the canonical literals and the adapter.context var is the identical
+            fn object."
+    (is (= expected-attr
+           (source-coords/format-source-coord fixture-id fixture-meta))
+        "neutral owner must emit the canonical data-rf2-source-coord literal")
+    (is (= expected-view-id
+           (source-coords/format-view-id fixture-id))
+        "neutral owner must emit the canonical data-rf-view literal")
+    (is (identical? source-coords/format-source-coord
+                    adapter-context/format-source-coord)
+        "CLJS format-source-coord must be an alias of the neutral owner")
+    (is (identical? source-coords/format-view-id
+                    adapter-context/format-view-id)
+        "CLJS format-view-id must be an alias of the neutral owner")))

--- a/implementation/core/src/re_frame/adapter/context.cljs
+++ b/implementation/core/src/re_frame/adapter/context.cljs
@@ -27,6 +27,7 @@
   (:require ["react" :as React]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
+            [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
 (def no-provider-sentinel
@@ -110,43 +111,35 @@
 ;;
 ;; The `data-rf2-source-coord` / `data-rf-view` DOM attribute VALUES are
 ;; pure string projections of the registry slot's id + captured coords.
-;; The DOM output MUST be byte-identical across substrates (Reagent's
-;; hiccup walk in `re-frame.views.source-coord-annotation` and the
-;; React-element-clone walk in `re-frame.substrate.spine` produce the SAME
-;; attribute string for the same view), so the formatters live here once —
-;; a shared leaf both walks already require — rather than as drifting
-;; per-walk copies. The injection WALKS stay split (hiccup vs React-element
-;; are genuinely different); only these pure formatters are shared.
+;; The DOM output MUST be byte-identical across substrates AND across hosts
+;; (Reagent's hiccup walk in `re-frame.views.source-coord-annotation`, the
+;; React-element-clone walk in `re-frame.substrate.spine`, and the JVM
+;; registration-boundary annotation in
+;; `re-frame.views.jvm-source-coord-annotation` all emit the SAME attribute
+;; string for the same view). rf2-5q0jv moved the single implementation into
+;; the neutral `.cljc` contract owner `re-frame.source-coords`, co-located
+;; with its inverse parsers, so a JVM copy and a CLJS copy can no longer
+;; drift. These two vars are CLJS-side aliases preserving the historical
+;; `re-frame.adapter.context` names the injection walks (and the
+;; `re-frame.views` / `re-frame.substrate.spine` re-exports) already call.
+;; The injection WALKS stay split (hiccup vs React-element are genuinely
+;; different); only these pure formatters are shared.
 
-(defn format-source-coord
-  "Render the registry slot's captured coords as the attribute value shape
-  `<ns>:<sym>:<line>:<col>`. The id keyword's namespace and name give us
-  `<ns>` and `<sym>`; `<line>` / `<col>` come from the captured coords
-  (CLJS reg-view macro at expansion time). `<col>` is `?` when the column
-  was not captured (the column-key is optional per Spec 001). Per Spec 006
-  §Source-coord annotation. Shared by the Reagent hiccup walk
-  (`re-frame.views.source-coord-annotation`) and the React-element-clone
-  walk (`re-frame.substrate.spine`) so the attribute value is identical
-  across substrates."
-  [id coords]
-  (let [ns-part  (or (namespace id) "?")
-        sym-part (name id)
-        line     (:line coords)
-        col      (:column coords)]
-    (str ns-part ":" sym-part ":"
-         (if line (str line) "?")
-         ":"
-         (if col (str col) "?"))))
+(def format-source-coord
+  "Render the registry slot's captured coords as the `data-rf2-source-coord`
+  attribute value `<ns>:<sym>:<line>:<col>` (Spec 006 §Source-coord
+  annotation). CLJS-side alias of the neutral cross-host owner
+  [[re-frame.source-coords/format-source-coord]] (rf2-5q0jv) — kept under this
+  name so the Reagent hiccup walk, the React-element-clone walk, and the
+  `re-frame.views` re-export are unchanged."
+  source-coords/format-source-coord)
 
-(defn format-view-id
-  "Render the registry id keyword as the `:data-rf-view` attribute value.
-  Returns `(str id)` so `:rf.foo/bar` → `\":rf.foo/bar\"`. The walker reads
-  it back via `(keyword (subs s 1))` when the leading `:` is present. Per
-  Spec 006 §View tagging contract (rf2-01il5). Shared by the Reagent and
-  React-element walks so the attribute value is identical across
-  substrates."
-  [id]
-  (str id))
+(def format-view-id
+  "Render the registry id keyword as the `:data-rf-view` attribute value
+  `(str id)`, so `:rf.foo/bar` → `\":rf.foo/bar\"` (Spec 006 §View tagging
+  contract, rf2-01il5). CLJS-side alias of the neutral cross-host owner
+  [[re-frame.source-coords/format-view-id]] (rf2-5q0jv)."
+  source-coords/format-view-id)
 
 (defn non-dom-root-warning
   "Build the one-shot `console.warn` text for a reg-view'd component whose

--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -111,21 +111,83 @@
         (merge coords (or user-meta {}))
         (or user-meta {})))))
 
+;; ---- source-coord annotation value formatters (rf2-5q0jv) -----------------
+;;
+;; The pure string projections of the two dev-mode DOM-annotation attribute
+;; VALUES: `data-rf2-source-coord` = `<ns>:<sym>:<line>:<col>` (Spec 006
+;; §Source-coord annotation) and `data-rf-view` = `(str id)` (Spec 006 §View
+;; tagging contract). They live HERE, in the neutral `.cljc` source-coord
+;; contract owner, so BOTH hosts compile the SAME source and emit byte-
+;; identical attribute values BY CONSTRUCTION:
+;;
+;;   - JVM registration-boundary annotation
+;;     (`re-frame.views.jvm-source-coord-annotation`) aliases these.
+;;   - CLJS injection walks — the Reagent hiccup walk
+;;     (`re-frame.views.source-coord-annotation`) and the React-element-clone
+;;     walk (`re-frame.substrate.spine`), both routed through
+;;     `re-frame.adapter.context` — alias these.
+;;
+;; Before rf2-5q0jv the JVM copy (`.clj`) and the CLJS copy (`.cljs`,
+;; in `adapter.context`) were two hand-kept duplicates; the canonical-literal
+;; parity tests could only catch a drift AFTER it shipped. Collapsing both
+;; into this single `.cljc` implementation makes cross-host divergence
+;; structurally impossible and honours this namespace's contract that a
+;; format and its inverse parse live together (the parsers below,
+;; [[parse-source-coord]] / [[parse-view-id]], are their inverses). The
+;; host-specific hiccup / React injection WALKS stay split — they are
+;; genuinely different — but the pure value projections are shared.
+
+(defn format-source-coord
+  "Render a registry slot's id + captured coords as the `data-rf2-source-coord`
+  attribute value `<ns>:<sym>:<line>:<col>`. `<ns>` / `<sym>` derive from the
+  id keyword (`(namespace id)` / `(name id)`), degrading `<ns>` to `?` for an
+  unqualified id; `<line>` / `<col>` come from the macro-captured `coords`
+  (`:line` / `:column`) and degrade to `?` when absent (a programmatic
+  `reg-view*` that bypassed the macro path — `:column` is optional per Spec
+  001). Per Spec 006 §Source-coord annotation.
+
+  The single cross-host implementation (rf2-5q0jv): the JVM registration-
+  boundary annotation and the CLJS Reagent / React-element injection walks
+  all alias this one `.cljc` fn, so the value is byte-identical across hosts
+  by construction. Its inverse is [[parse-source-coord]] below."
+  [id coords]
+  (let [ns-part  (or (namespace id) "?")
+        sym-part (name id)
+        line     (:line coords)
+        col      (:column coords)]
+    (str ns-part ":" sym-part ":"
+         (if line (str line) "?")
+         ":"
+         (if col (str col) "?"))))
+
+(defn format-view-id
+  "Render a registry id keyword as the `data-rf-view` attribute value —
+  `(str id)`, so `:rf.foo/bar` → `\":rf.foo/bar\"` (leading colon included).
+  Per Spec 006 §View tagging contract (rf2-01il5).
+
+  The single cross-host implementation (rf2-5q0jv): the JVM registration-
+  boundary annotation and the CLJS injection walks all alias this one `.cljc`
+  fn. Its inverse is [[parse-view-id]] below (which reads the leading `:` back
+  into a keyword)."
+  [id]
+  (str id))
+
 ;; ---- DOM source-coord attribute parser (rf2-nr7vf2) -----------------------
 ;;
-;; The inverse of `re-frame.adapter.context/format-source-coord` (re-exported
-;; as `re-frame.views/format-source-coord` / `re-frame.substrate.spine/
+;; The inverse of [[format-source-coord]] above (aliased on the CLJS side as
+;; `re-frame.adapter.context/format-source-coord`, re-exported as
+;; `re-frame.views/format-source-coord` / `re-frame.substrate.spine/
 ;; format-source-coord`). The formatter renders a registry slot's id + coords
 ;; into the `data-rf2-source-coord` DOM-attribute value `<ns>:<sym>:<line>:
 ;; <col>`; this parser recovers `{:ns :handler-id :line :col}` from that
-;; string. It lives HERE — in the source-coord contract owner (Spec 006
-;; §Source-coord annotation / Tool-Pair §Source-mapping), not in the
-;; CLJS-only `adapter.context` ns — because consumers reading the attribute
-;; include JVM-side `.cljc` surfaces (Story's element-inspector pure helpers,
-;; the SSR round-trip parity test). Co-locating format + parse here keeps the
-;; round-trip a single source of truth (rf2-nr7vf2 collapses the parser that
-;; was reimplemented near-byte-for-byte in Story's element_inspector.cljc and
-;; the re-frame2-pair preload runtime).
+;; string. Both live HERE — in the source-coord contract owner (Spec 006
+;; §Source-coord annotation / Tool-Pair §Source-mapping) — because consumers
+;; reading the attribute include JVM-side `.cljc` surfaces (Story's
+;; element-inspector pure helpers, the SSR round-trip parity test).
+;; Co-locating format + parse here keeps the round-trip a single source of
+;; truth (rf2-nr7vf2 collapses the parser that was reimplemented near-byte-
+;; for-byte in Story's element_inspector.cljc and the re-frame2-pair preload
+;; runtime; rf2-5q0jv brought the formatters home beside them).
 ;;
 ;; Tool-Pair.md declares the attribute value opaque to consumers and warns
 ;; downstream callers MUST NOT depend on the parsed shape's stability across
@@ -146,7 +208,8 @@
 (defn parse-source-coord
   "Parse a `data-rf2-source-coord` attribute value into
   `{:ns :handler-id :line :col}`, or nil. The inverse of
-  `re-frame.adapter.context/format-source-coord` (re-exported as
+  [[format-source-coord]] above (aliased on the CLJS side as
+  `re-frame.adapter.context/format-source-coord`, re-exported as
   `re-frame.views/format-source-coord`).
 
   Per Spec 006 §Attribute value format the value is a four-segment colon-
@@ -178,18 +241,20 @@
 
 ;; ---- data-rf-view attribute parser (rf2-ztxnm8 / rf2-16znzb) ---------------
 ;;
-;; The inverse of `re-frame.adapter.context/format-view-id` (re-exported as
+;; The inverse of [[format-view-id]] above (aliased on the CLJS side as
+;; `re-frame.adapter.context/format-view-id`, re-exported as
 ;; `re-frame.views/format-view-id` / `re-frame.substrate.spine/format-view-id`).
 ;; The formatter renders a registry id keyword into the `data-rf-view` DOM-
 ;; attribute value via `(str id)` — `:rf.foo/bar` → `":rf.foo/bar"`; this parser
-;; recovers the id from that string. It lives HERE — beside `parse-source-coord`,
-;; in the source-coord contract owner (Spec 006 §View tagging contract /
-;; §Source-coord annotation) — because the read rule used to live ONLY in
-;; `format-view-id`'s docstring + Spec 006 prose and was re-implemented inline by
-;; every consumer (the Xray fallback view-walker and the re-frame2-pair preload
-;; runtime's `view-entity`). Co-locating format + parse keeps the round-trip a
-;; single source of truth (rf2-ztxnm8 collapses those re-derivations — the
-;; data-rf-view analogue of the `parse-source-coord` work in rf2-nr7vf2).
+;; recovers the id from that string. Both live HERE — in the source-coord
+;; contract owner (Spec 006 §View tagging contract / §Source-coord annotation) —
+;; because the read rule used to live ONLY in `format-view-id`'s docstring +
+;; Spec 006 prose and was re-implemented inline by every consumer (the Xray
+;; fallback view-walker and the re-frame2-pair preload runtime's `view-entity`).
+;; Co-locating format + parse keeps the round-trip a single source of truth
+;; (rf2-ztxnm8 collapses those re-derivations — the data-rf-view analogue of the
+;; `parse-source-coord` work in rf2-nr7vf2; rf2-5q0jv brought the formatters
+;; home beside them).
 ;;
 ;; Tool-Pair.md declares the attribute value opaque to consumers and warns
 ;; downstream callers MUST NOT depend on the parsed shape's stability across
@@ -198,7 +263,8 @@
 
 (defn parse-view-id
   "Parse a `data-rf-view` attribute value back into the registry id. The
-  inverse of `re-frame.adapter.context/format-view-id` (re-exported as
+  inverse of [[format-view-id]] above (aliased on the CLJS side as
+  `re-frame.adapter.context/format-view-id`, re-exported as
   `re-frame.views/format-view-id` / `re-frame.substrate.spine/format-view-id`),
   which renders the id via `(str id)`.
 

--- a/implementation/core/src/re_frame/views/jvm_source_coord_annotation.clj
+++ b/implementation/core/src/re_frame/views/jvm_source_coord_annotation.clj
@@ -35,43 +35,40 @@
 
   ## The dialect is shared, not reinvented
 
-  `format-source-coord` / `format-view-id` produce byte-identical VALUES
-  to their CLJS counterparts in `re-frame.adapter.context` (there is no
-  shared `.cljc` home for them — the CLJS copy is `.cljs`-only), and the
-  hiccup walk mirrors `re-frame.views.source-coord-annotation`'s DOM-root
-  branch exactly: merge both attributes onto a DOM-tag root, preserve any
-  author-supplied value, recurse through Form-2 fns, skip fragment /
-  callable-head roots. The `source-coord-parity` tests (JVM + CLJS) pin
-  the two formatters to one canonical literal so they cannot drift."
-  (:require [re-frame.interop :as interop]))
+  `format-source-coord` / `format-view-id` are the SAME implementation on
+  every host: rf2-5q0jv moved them into the neutral `.cljc` contract owner
+  `re-frame.source-coords` (co-located with their inverse parsers), and both
+  the vars below and the CLJS `re-frame.adapter.context` counterparts are
+  thin aliases of it — so a JVM copy and a CLJS copy can no longer drift.
+  The hiccup walk here still mirrors
+  `re-frame.views.source-coord-annotation`'s DOM-root branch exactly: merge
+  both attributes onto a DOM-tag root, preserve any author-supplied value,
+  recurse through Form-2 fns, skip fragment / callable-head roots. The
+  `source-coord-parity` tests (JVM + CLJS) pin the shared formatters to one
+  canonical literal and assert both hosts resolve to the neutral owner."
+  (:require [re-frame.interop :as interop]
+            [re-frame.source-coords :as source-coords]))
 
 (set! *warn-on-reflection* true)
 
-(defn format-source-coord
+(def format-source-coord
   "Render a registry slot's id + captured coords as the
   `data-rf2-source-coord` attribute value `<ns>:<sym>:<line>:<col>`.
   `<line>` / `<col>` degrade to `?` when the coords were not captured
   (a programmatic `reg-view*` that bypassed the macro path). Per Spec 006
-  §Source-coord annotation. Byte-identical to the CLJS
-  `re-frame.adapter.context/format-source-coord` — the two are pinned to
-  one canonical literal by the `source-coord-parity` tests."
-  [id coords]
-  (let [ns-part  (or (namespace id) "?")
-        sym-part (name id)
-        line     (:line coords)
-        col      (:column coords)]
-    (str ns-part ":" sym-part ":"
-         (if line (str line) "?")
-         ":"
-         (if col (str col) "?"))))
+  §Source-coord annotation. JVM-side alias of the neutral cross-host owner
+  `re-frame.source-coords/format-source-coord` (rf2-5q0jv) — the single
+  implementation both hosts share, pinned to one canonical literal by the
+  `source-coord-parity` tests so it cannot drift."
+  source-coords/format-source-coord)
 
-(defn format-view-id
+(def format-view-id
   "Render a registry id keyword as the `data-rf-view` attribute value —
   `(str id)`, so `:rf.foo/bar` → `\":rf.foo/bar\"` (leading colon
-  included). Per Spec 006 §View tagging contract. Byte-identical to the
-  CLJS `re-frame.adapter.context/format-view-id`."
-  [id]
-  (str id))
+  included). Per Spec 006 §View tagging contract. JVM-side alias of the
+  neutral cross-host owner `re-frame.source-coords/format-view-id`
+  (rf2-5q0jv)."
+  source-coords/format-view-id)
 
 (defn- dom-tag-head?
   "True when `head` is a Hiccup DOM-tag keyword. The React-fragment marker

--- a/implementation/ssr/test/re_frame/source_coord_parity_test.clj
+++ b/implementation/ssr/test/re_frame/source_coord_parity_test.clj
@@ -27,6 +27,7 @@
   if either host's formatter drifts, its test fails."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.source-coords :as source-coords]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.test-fixture :as tf]
             [re-frame.views.jvm-source-coord-annotation :as jvm-annot]))
@@ -90,6 +91,36 @@
     (is (= expected-source-coord-no-line-no-col
            (jvm-annot/format-source-coord fixture-id fixture-coords-no-line-no-col))
         "JVM degraded source-coord must match the canonical degraded literal")))
+
+;; ---- convergence: source-coords is the single cross-host owner (rf2-5q0jv) -
+;;
+;; Before rf2-5q0jv the JVM formatters (this ns) and the CLJS formatters (in
+;; `re-frame.adapter.context`) were two hand-kept copies; a canonical-literal
+;; test could only catch a drift AFTER it shipped. They now alias one `.cljc`
+;; implementation in `re-frame.source-coords`, co-located with their inverse
+;; parsers, so cross-host divergence is structurally impossible. Prove it: the
+;; neutral owner emits the canonical literals directly, and the JVM annotation
+;; vars ARE that same fn (an alias, not a re-derivable copy). `identical?` here
+;; compares fn-object identity — NOT a keyword literal, so it is not the
+;; rf2-6365 `.cljc` interning trap (and these are `.clj` / `.cljs` test files).
+
+(deftest neutral-owner-is-the-single-jvm-formatter-implementation
+  (testing "rf2-5q0jv — `re-frame.source-coords` owns the one cross-host
+            implementation; the JVM annotation vars alias it, so the neutral
+            owner emits the canonical literals and the JVM vars are the
+            identical fn (not a re-derived copy that could drift)."
+    (is (= expected-source-coord
+           (source-coords/format-source-coord fixture-id fixture-coords))
+        "neutral owner must emit the canonical data-rf2-source-coord literal")
+    (is (= expected-view-id
+           (source-coords/format-view-id fixture-id))
+        "neutral owner must emit the canonical data-rf-view literal")
+    (is (identical? source-coords/format-source-coord
+                    jvm-annot/format-source-coord)
+        "JVM format-source-coord must be an alias of the neutral owner")
+    (is (identical? source-coords/format-view-id
+                    jvm-annot/format-view-id)
+        "JVM format-view-id must be an alias of the neutral owner")))
 
 ;; ---- end-to-end byte parity: SSR-rendered HTML carries BOTH attributes ---
 ;;


### PR DESCRIPTION
## Summary

The dev-mode DOM view-annotation value formatters — `format-source-coord` (`data-rf2-source-coord` = `<ns>:<sym>:<line>:<col>`) and `format-view-id` (`data-rf-view` = `(str id)`) — existed as **two hand-kept copies**: a JVM `.clj` copy in `re-frame.views.jvm-source-coord-annotation` (added by #6469) and a CLJS `.cljs` copy in `re-frame.adapter.context`. A canonical-literal parity test could only catch a cross-host drift *after* it shipped, breaking the hydration-adoption invariant (server annotation must byte-match client annotation or a dev SSR page hydrates as a mismatch instead of an adoption).

This collapses both into a **single `.cljc` implementation** in the neutral `re-frame.source-coords` contract owner, co-located with its inverse parsers (`parse-source-coord` / `parse-view-id`) exactly as that namespace's contract commentary already promised. The JVM annotation ns and the CLJS `adapter.context` now **alias** the neutral owner, so the value is byte-identical across hosts **by construction** — cross-host divergence is structurally impossible, not merely tested-after-the-fact.

No behavioral/API drift: the `re-frame.views` / `re-frame.substrate.spine` re-exports and the host-specific hiccup / React-element injection walks are unchanged; only the pure value projections moved. No spec change; no reg-view wiring touched (#6469 owns that, on main).

## What diverged, and the canonical value

Nothing diverged *behaviorally* — the two copies were textually identical, so both hosts already emitted the same bytes. The defect was the **duplication itself** (two implementations to discover and keep in lockstep). The canonical value is the shared one both copies produced; the fix makes it a single source rather than a coincidence:
- `format-source-coord` → `"<ns>:<sym>:<line>:<col>"`, e.g. `rf.parity-test:sample-view:42:7`; degrades to `rf.parity-test:sample-view:?:?` when `:line`/`:column` are absent.
- `format-view-id` → `(str id)`, e.g. `:rf.parity-test/sample-view`.

## Changes

- `re-frame.source-coords` (`.cljc`): add `format-source-coord` + `format-view-id`, co-located with their inverse parsers.
- `re-frame.adapter.context` (CLJS): the two vars become aliases of the neutral owner (preserving the names the walks + re-exports call).
- `re-frame.views.jvm-source-coord-annotation` (JVM): the two vars become aliases of the neutral owner; the now-false "no shared `.cljc` home" docstring is corrected.
- Both parity tests (JVM + CLJS): extended with a convergence assertion — the neutral owner emits the canonical literals and each host var is the identical fn object (an alias, not a re-derivable copy). `identical?` here compares fn references, not a keyword literal, so it is not the `.cljc` interning trap.

## Quality gates

All green on the rebased tree.

- **Core JVM** (`clojure -M:test`): `Ran 2095 tests containing 10326 assertions. 0 failures, 0 errors.`
- **CLJS full** (`npm run test:cljs`): compile `0 warnings`; `Ran 10314 tests containing 50846 assertions. 0 failures, 0 errors.` (A prior run showed 5 non-reproducible flaky failures in async a11y/React tests — `axe blew up`, `data-fooBar` — surfaces this pure-formatter relocation cannot touch; a clean re-run was green.)
- **CLJS elision** (`npm run test:elision`): `PASS elision: production 60/60 absent; control 60/60 present` — the annotation sentinels stay in the dev-gated walkers; the relocated pure formatters DCE cleanly, no prod leak.
- **Targeted parity/convergence:** JVM `re-frame.source-coord-parity-test` → 5 tests / 10 assertions, 0 failures (incl. new JVM convergence test); CLJS `re-frame.source-coord-parity-cljs-test` → 4 tests / 7 assertions, 0 failures (incl. new CLJS convergence test).