### PR TITLE
test(ui): derive the mounted proof-pack roster from the real library source (rf2-syell)

### DIFF
--- a/implementation/scripts/check-ui-facade-isolation.cjs
+++ b/implementation/scripts/check-ui-facade-isolation.cjs
@@ -70,11 +70,28 @@
 // must not be shared between views, and an empty or single-view roster FAILS —
 // a derivation that stops matching must RED, not pass (rf2-5jbev, rf2-vxgfnd.167).
 //
+// ROSTER COMPLETENESS OF THE MOUNTED SUITE (rf2-syell). The same library-source
+// roster this gate already derives also pins the RENDER side. The mounted
+// browser suite `re-frame.ui.proof-pack.library-dom-cljs-test` exercises each
+// view scoped to that view's own `[data-pp=...]` sentinel, but its own
+// roster-completeness claim used to be a hand-maintained `(= 6 (count [lib/... ]))`:
+// a seventh `defview` armed neither side, so a shipped view rendered nowhere
+// stayed green — the exact regression #6459 meant to prevent (rf2-kxork probe:
+// 495 tests / 2765 assertions green with a real seventh view). A `.cljs` test
+// cannot read library.cljs at runtime to self-derive without a macro/generated
+// source, so the completeness claim is owned here, next to the roster it already
+// derives: the derived defview set is compared against the sentinel literals the
+// mounted suite references (its `sel-*` selectors). A view uncovered by the suite
+// FAILS (a shipped view rendered nowhere), and a suite selector no library view
+// owns FAILS (a stale entry a removed/renamed view left behind) — so neither
+// side can drift on a hard-coded count. No new build, CI job, or registry: it is
+// a pure source comparison reusing this file's own defview derivation.
+//
 // `--self-test` drives the derivation over synthetic sources, including the
-// seven-view drift case and every anti-vacuity branch. It needs no build, no
-// JVM and no toolchain, so it is the arm that runs cheaply everywhere; the
-// bundle assertions above are verified by CI. Same shape as
-// check-ui-adapter-isolation.cjs --self-test.
+// seven-view drift case, the roster-completeness red paths, and every
+// anti-vacuity branch. It needs no build, no JVM and no toolchain, so it is the
+// arm that runs cheaply everywhere; the bundle assertions above are verified by
+// CI. Same shape as check-ui-adapter-isolation.cjs --self-test.
 
 const fs = require('fs');
 const path = require('path');
@@ -88,6 +105,7 @@ const ALL = path.join(IMPL, 'out', 'proof-pack-all');
 const PROOF_PACK = path.join(IMPL, 'ui', 'proof-pack', 're_frame', 'ui', 'proof_pack');
 const LIBRARY_SRC = path.join(PROOF_PACK, 'library.cljs');
 const CONSUMER_SRC = path.join(PROOF_PACK, 'single_view.cljs');
+const MOUNTED_SUITE_SRC = path.join(PROOF_PACK, 'library_dom_cljs_test.cljs');
 
 // The namespace the single-view consumer imports from. Naming the derivation's
 // two INPUTS is not a roster — what is derived is which views exist and which
@@ -249,6 +267,55 @@ function deriveRoster(librarySource, consumerSource) {
   };
 }
 
+// --- mounted-suite roster completeness (rf2-syell) --------------------------
+
+// Which library-view render sentinels the mounted browser suite references.
+// Each per-view test scopes its assertions by a `[data-pp='<sentinel>']`
+// selector, so the sentinel literals present in the suite source are exactly the
+// views it exercises — the same "sentinel literal present" coverage signal G-18
+// reads from a bundle, here read from the mounted suite's own source.
+function deriveMountedCoverage(mountedSuiteSource) {
+  return [...new Set(mountedSuiteSource.match(SENTINEL_RE) || [])];
+}
+
+// The completeness contract, pure over the derived views and the suite's covered
+// set so the self-test can drive both red paths without a browser. Every library
+// view must be exercised by the suite, and every sentinel the suite references
+// must be owned by a live view (no stale entry from a removed/renamed view).
+function evaluateMountedCoverage(views, covered) {
+  const problems = [];
+  const coveredSet = new Set(covered);
+
+  // Forward: each library view must have at least one of its sentinels covered.
+  for (const v of views) {
+    if (!v.sentinels.some((s) => coveredSet.has(s))) {
+      problems.push(
+        `roster completeness: library view ${v.name} (sentinel ${v.sentinels.join(', ')}) is NOT ` +
+        'exercised by the mounted suite (library-dom-cljs-test). A shipped proof-pack view rendered ' +
+        'nowhere is the rf2-kxork drift #6459 exists to prevent: mount it on a real root and scope an ' +
+        'assertion to its own [data-pp=...] sentinel.');
+    }
+  }
+
+  // Reverse: every sentinel the suite references must belong to a live view.
+  const owned = new Set(views.flatMap((v) => v.sentinels));
+  for (const s of covered) {
+    if (!owned.has(s)) {
+      problems.push(
+        `roster completeness: the mounted suite references sentinel ${s}, which NO library view owns ` +
+        '— a stale roster entry a removed or renamed view left behind. Drop the dead selector or ' +
+        'restore the view; a renamed view must RED here, not pass on a hard-coded selector.');
+    }
+  }
+
+  return problems;
+}
+
+function checkMountedCoverageFromRepo(views) {
+  const covered = deriveMountedCoverage(readSource(MOUNTED_SUITE_SRC, 'proof-pack mounted suite'));
+  return { covered, problems: evaluateMountedCoverage(views, covered) };
+}
+
 function readSource(abs, label) {
   let src;
   try {
@@ -335,6 +402,20 @@ function main() {
   console.log(`  rooted by the single-view consumer: ${roster.importedView} (alias ${roster.alias}/)`);
   console.log(`  imported sentinel(s): ${roster.imported.join(', ')}`);
   console.log(`  sibling sentinel(s): ${roster.siblings.length}`);
+
+  // Roster completeness (rf2-syell): every derived library view must be
+  // exercised by the mounted browser suite, checked from source rather than from
+  // a hand-maintained count in the suite. Pure source comparison — no build — so
+  // it fails fast before the release below.
+  const { covered, problems: coverageProblems } = checkMountedCoverageFromRepo(roster.views);
+  console.log('=== mounted-suite roster completeness ===');
+  console.log(`  library views: ${roster.views.length}; mounted suite covers ${covered.length} sentinel(s)`);
+  if (coverageProblems.length) {
+    console.error('\n=== proof-pack roster completeness FAIL ===');
+    for (const p of coverageProblems) console.error(`  - ${p}`);
+    process.exit(1);
+  }
+  console.log('  roster complete — every library view is exercised by the mounted suite.');
 
   shadow('release', 'proof-pack-single', 'proof-pack-all');
 
@@ -568,6 +649,78 @@ function selfTest() {
     );
   });
 
+  // --- mounted-suite roster completeness, driven over synthetic sources ------
+  //
+  // rf2-syell. The mounted browser suite named its own roster with a hardcoded
+  // count, so a 7th view could ship rendered nowhere while it stayed green
+  // (the rf2-kxork probe: 495 tests green with a real seventh view). These arms
+  // drive `evaluateMountedCoverage` over the same synthetic library the bundle
+  // arms use, so a 7th view REDs until it is exercised and a stale selector REDs
+  // when a view is removed/renamed — the completeness gap #6459 could not see.
+  //
+  // `mountedSuite` fakes the suite as the sel-* selector constants that carry
+  // the sentinels it exercises — the same shape the real suite has.
+  const mountedSuite = (...sentinels) =>
+    '(ns re-frame.ui.proof-pack.library-dom-cljs-test)\n' +
+    sentinels.map((s, i) => `(def ^:private sel-${i} "[data-pp='${s}']")`).join('\n') + '\n';
+  const SIX_SENTINELS = [
+    'rf2-pp-alpha-sentinel', 'rf2-pp-beta-sentinel', 'rf2-pp-gamma-sentinel',
+    'rf2-pp-delta-sentinel', 'rf2-pp-epsilon-sentinel', 'rf2-pp-zeta-sentinel',
+  ];
+
+  check('COVERAGE: a suite exercising every view passes completeness', () => {
+    const r = deriveRoster(lib(...SIX), consumer('alpha'));
+    const covered = deriveMountedCoverage(mountedSuite(...SIX_SENTINELS));
+    const problems = evaluateMountedCoverage(r.views, covered);
+    assert(problems.length === 0, `expected complete, got: ${problems.join(' | ')}`);
+  });
+
+  // THE rf2-syell DRIFT, now caught. A seventh library view the suite does not
+  // mount stays rendered nowhere. Under the retired hardcoded `(= 6 (count ...))`
+  // roster the suite counted its own six vars and passed; here it REDs.
+  check('COVERAGE: a SEVENTH view unexercised by the suite FAILS (the rf2-syell drift)', () => {
+    const r = deriveRoster(lib(...SEVEN), consumer('alpha'));
+    const covered = deriveMountedCoverage(mountedSuite(...SIX_SENTINELS)); // suite still only the six
+    const problems = evaluateMountedCoverage(r.views, covered);
+    assert(
+      problems.some((p) => p.includes('eta') && p.includes('NOT') && p.includes('exercised')),
+      `the 7th view must be reported unexercised, got: ${problems.join(' | ')}`,
+    );
+
+    // Negative control: a hand-maintained count of the six the suite DID mount
+    // sees nothing wrong — that six-equals-six pass is exactly the drift closed.
+    assert(covered.length === 6, `the suite still covers six, got ${covered.length}`);
+  });
+
+  check('COVERAGE: a stale suite selector (removed/renamed view) FAILS', () => {
+    const r = deriveRoster(lib(...SIX), consumer('alpha'));
+    // The suite still references a sentinel for a view no longer in the library.
+    const covered = deriveMountedCoverage(mountedSuite(...SIX_SENTINELS, 'rf2-pp-ghost-sentinel'));
+    const problems = evaluateMountedCoverage(r.views, covered);
+    assert(
+      problems.some((p) => p.includes('rf2-pp-ghost-sentinel') && p.includes('stale')),
+      `the stale selector must be reported, got: ${problems.join(' | ')}`,
+    );
+  });
+
+  check('COVERAGE: a renamed view REDs on BOTH sides (uncovered new + stale old)', () => {
+    const r = deriveRoster(lib(...SIX), consumer('alpha'));
+    // library renamed zeta's sentinel; the suite still carries the OLD one.
+    const renamed = r.views.map((v) =>
+      v.name === 'zeta' ? { ...v, sentinels: ['rf2-pp-zeta2-sentinel'] } : v);
+    const covered = deriveMountedCoverage(mountedSuite(...SIX_SENTINELS)); // old zeta sentinel
+    const problems = evaluateMountedCoverage(renamed, covered);
+    assert(problems.some((p) => p.includes('zeta') && p.includes('NOT')), 'the renamed view must be uncovered');
+    assert(problems.some((p) => p.includes('rf2-pp-zeta-sentinel') && p.includes('stale')), 'the old selector must be stale');
+  });
+
+  check('COVERAGE: the real mounted suite exercises every real library view', () => {
+    const r = rosterFromRepo();
+    const { covered, problems } = checkMountedCoverageFromRepo(r.views);
+    assert(problems.length === 0, `real roster completeness must hold, got: ${problems.join(' | ')}`);
+    console.log(`       real coverage: ${covered.length} sentinel(s) cover all ${r.views.length} views`);
+  });
+
   if (failed > 0) {
     console.error(`[ui-facade-isolation] self-test FAILED: ${failed}`);
     process.exit(1);
@@ -588,4 +741,7 @@ if (require.main === module) {
   }
 }
 
-module.exports = { deriveRoster, deriveViews, deriveRooted, rosterFromRepo, evaluateBundles };
+module.exports = {
+  deriveRoster, deriveViews, deriveRooted, rosterFromRepo, evaluateBundles,
+  deriveMountedCoverage, evaluateMountedCoverage, checkMountedCoverageFromRepo,
+};

--- a/implementation/ui/proof-pack/re_frame/ui/proof_pack/library_dom_cljs_test.cljs
+++ b/implementation/ui/proof-pack/re_frame/ui/proof_pack/library_dom_cljs_test.cljs
@@ -278,18 +278,21 @@
                      (is false (str "inline-popover: " e)) (done))))))))
 
 ;; ---------------------------------------------------------------------------
-;; Roster completeness — the six tests above must cover the whole library
+;; Roster completeness is owned by the G-18 checker (rf2-syell)
 ;; ---------------------------------------------------------------------------
-
-(deftest every-library-view-is-rendered-somewhere-in-this-namespace
-  ;; Runs on BOTH runtimes: it is a static roster claim, not a mounted one.
-  ;; G-18 derives its sentinel roster from library.cljs; this pins the RENDER
-  ;; side to the same six, so adding a seventh view arms this test too instead
-  ;; of quietly escaping render coverage (the rf2-r4q98 drift shape).
-  (is (= 6 (count [lib/controlled-input lib/selection-controller lib/list-cell
-                   lib/safe-form-control lib/schema-described lib/inline-popover]))
-      "the library ships exactly the six views this namespace mounts")
-  (is (= 6 (count (distinct [sel-controlled-input sel-selection-controller
-                             sel-list-cell sel-safe-form-control
-                             sel-schema-described sel-inline-popover])))
-      "each view is scoped by a DISTINCT sentinel selector — no test can be satisfied by a sibling"))
+;;
+;; "Every library view is exercised here" used to be a deftest in this file, but
+;; its only roster assertion was a hand-maintained `(= 6 (count [lib/... ]))`
+;; over a spelled-out var list: a seventh `defview` in library.cljs armed
+;; NEITHER side, so a shipped view rendered nowhere stayed green — the exact
+;; regression #6459 exists to prevent (rf2-kxork probe: a real seventh view left
+;; 495 tests / 2765 assertions green). A .cljs test cannot read library.cljs at
+;; runtime to derive that roster without a macro or generated source, so the
+;; completeness claim lives in the one seam that already derives the library
+;; roster from source: scripts/check-ui-facade-isolation.cjs (the required
+;; cljs-ui-facade-isolation gate). It compares the derived `defview` set against
+;; the sentinel selectors THIS suite references — the sel-* constants above are
+;; that suite's half of the comparison. So a seventh view REDs the gate until it
+;; is mounted and scoped here, and a removed/renamed view REDs on its stale
+;; selector, neither able to drift on a hard-coded count. Sentinel distinctness
+;; (no test satisfied by a sibling) is likewise enforced there, per view.


### PR DESCRIPTION
## What

The mounted proof-pack browser suite's roster-completeness claim
(`every-library-view-is-rendered-somewhere-in-this-namespace`) was a
**hand-maintained** `(= 6 (count [lib/controlled-input ... lib/inline-popover]))`
over a spelled-out var list. A seventh `defview` in `library.cljs` armed
**neither** side, so a shipped proof-pack view rendered nowhere would stay green —
the exact regression #6459 exists to prevent (the rf2-kxork probe added a real
seventh view and the suite stayed green at 495 tests / 2765 assertions).

A `.cljs` test cannot read `library.cljs` at runtime to self-derive that roster
without a macro or generated source (both forbidden by the bead), so the
completeness claim now lives in the one seam that **already** derives the library
roster from source: `scripts/check-ui-facade-isolation.cjs` (the required
`cljs-ui-facade-isolation` gate, G-18). It reuses that file's own `defview`
derivation and compares the derived view set against the sentinel selectors the
mounted suite references (its `sel-*` constants):

- a library view **uncovered** by the mounted suite FAILS (a view rendered nowhere);
- a suite selector **no live view owns** FAILS (a stale entry a removed/renamed view left behind).

Neither side can drift on a hard-coded count. The check is a pure source
comparison that runs **before** the release build (fast fail).

No new build, CI job, registry, generated source, or parser framework. The G-18
isolation contract and its bundle logic are unchanged; the retired deftest is
replaced by a comment pointing at the checker. The six `sel-*` constants and the
six per-view mounted tests are untouched.

## Drift proof (real sources)

Adding a seventh unmounted `defview` to `library.cljs` REDs the gate before the
build, naming the view:

```
=== mounted-suite roster completeness ===
  library views: 7; mounted suite covers 6 sentinel(s)
=== proof-pack roster completeness FAIL ===
  - roster completeness: library view drift-probe (sentinel rf2-pp-drift-probe-sentinel) is NOT exercised by the mounted suite ...
```

Reverted byte-identical (sha unchanged). The derived roster equals the shipped
six: `library views: 6; mounted suite covers 6 sentinel(s); roster complete`.

## Quality gates

All foreground, run to completion in the worktree:

- `npm run test:ui-facade-isolation` (G-18, self-test + advanced build) — **PASS**; new self-test arms `COVERAGE: *` all green; `roster complete — every library view is exercised by the mounted suite`; isolation `0/5` siblings retained, `G-18 PASS`.
- `cd implementation/ui && clojure -M:test` — **1001 tests / 19583 assertions, 0 failures, 0 errors**.
- `npm run test:cljs` — **10312 tests / 50840 assertions, 0 failures, 0 errors**.
- `npm run test:browser` (mounted proof-pack suite) — **501 tests / 2809 assertions, 0 failures, 0 errors**.

`test:xray-feature-gate` not applicable — the roster feeds the G-18 facade gate, not any xray gate.

Closes rf2-syell.