### PR TITLE
docs(examples): refresh resources_ssr stand-in to the shipped reg-view path (rf2-ehu32)

### DIFF
--- a/examples/capabilities/ssr/resources_ssr/index.html
+++ b/examples/capabilities/ssr/resources_ssr/index.html
@@ -47,16 +47,26 @@
     deterministically fresh indefinitely — no rebased clock, no rotting
     absolute deadline — with explicit invalidation as the real freshness
     authority. So the hydrated entry is fresh, and the client does NOT refetch.
+
+    The `#app` subtree is the dev-build output of `rf/render-to-string` — the
+    same string `handle-request` inlines, minus the `data-rf-render-hash`
+    attribute (this offline stand-in bakes `:rf/render-hash nil` below, so
+    neither the wire hash nor its DOM twin appears). In a dev build the reg-view
+    REGISTRATION boundary stamps two annotations on every registered view's root
+    DOM element (Spec 006 §Source-coord annotation / §View tagging contract,
+    moved cross-host to the reg-view boundary by rf2-8vi4q): the
+    `:pages/articles` view's `<div class="page">` root carries
+    `data-rf2-source-coord="pages:articles:165:1"` (its `<ns>:<sym>:<line>:<col>`
+    reg-view call site) and `data-rf-view=":pages/articles"`, so pair-shaped
+    tooling can map the node back to its view. The client's dev render stamps
+    the SAME two attributes, so this page hydrates as a clean ADOPTION rather
+    than an attribute mismatch. `:app/root` renders `[(rf/view :pages/articles)]`
+    — a callable head, not a DOM element — so it contributes no wrapper node and
+    no annotation of its own. A production build (`goog.DEBUG=false` /
+    `re-frame.debug=false`) elides the annotations on both hosts, so prod markup
+    is attribute-free.
   -->
-  <div id="app">
-    <div class="page">
-      <h1>Recent articles</h1>
-      <ul data-testid="articles-list">
-        <li data-testid="article-welcome">Welcome to re-frame2</li>
-        <li data-testid="article-resources">Server-state as resources</li>
-      </ul>
-    </div>
-  </div>
+  <div id="app"><div class="page" data-rf2-source-coord="pages:articles:165:1" data-rf-view=":pages/articles"><h1>Recent articles</h1><ul data-testid="articles-list"><li data-testid="article-welcome">Welcome to re-frame2</li><li data-testid="article-resources">Server-state as resources</li></ul></div></div>
   <script id="__rf_payload" type="application/edn">
 {:rf/version 1
  :rf/frame-id :rf/default


### PR DESCRIPTION
## What

`examples/capabilities/ssr/resources_ssr/index.html` carried the same annotation-free stand-in defect that #6485 (rf2-hjtf2) fixed in the two sibling SSR stand-ins (`ssr/`, `ssr_streaming/`). It was FOUND by rf2-hjtf2 but out of that bead's scope — the one file it didn't name.

The `:pages/articles` `<div class="page">` root was missing the dev-build reg-view annotations (`data-rf2-source-coord` + `data-rf-view`, moved to the reg-view registration boundary by #6469 / rf2-8vi4q), so the static `#app` markup diverged from shipped `rf/render-to-string` output and would hydrate as an attribute mismatch instead of a clean adoption. It also carried pretty-print whitespace text nodes.

## Fix (mirrors #6485 exactly)

Refreshed the `#app` stand-in to the **byte-exact dev-build `rf/render-to-string` output**, captured by hydrating the checked-in static payload and rendering `((rf/view :app/root))` on the JVM in a dev build (`interop/debug-enabled? = true`) — the same method #6485 used one file over.

- `:pages/articles` root now carries `data-rf2-source-coord="pages:articles:165:1"` and `data-rf-view=":pages/articles"`.
- `:app/root` renders `[(rf/view :pages/articles)]` — a callable head, no wrapper node — so it contributes no annotation of its own.
- The subtree is now the compact byte-exact server output (no whitespace text nodes).
- Comment updated to explain the reg-view annotation contract + production elision, mirroring #6485.

No example test added (examples are test-free, rf2-8cevm); no new example; no `implementation/` or hot-zone shadow config touched.

## Quality gates

- **Byte-exact verification**: hydrated the checked-in static `__rf_payload` and rendered `((rf/view :app/root))` on the JVM (dev build) via the core `:test` classpath — diffed the resulting `#app` subtree against the new stand-in line: **byte-exact match, zero diff**. Confirms the file was stale before and correct after.
- **Example build**: `npx shadow-cljs compile examples/resources-ssr` → **Build completed. (225 files, 224 compiled, 0 warnings)**, exit 0.
- Not run (not applicable): mkdocs (README unchanged, and it does not embed the stand-in DOM); no example test by convention.
