### PR TITLE
refactor(ui): unwind the retired candidate/stable generation split per the .271 ruling (rf2-vxgfnd.271)

### DIFF
--- a/docs/core/how-to/install-re-frame-ui.md
+++ b/docs/core/how-to/install-re-frame-ui.md
@@ -121,6 +121,6 @@ Working from a checkout of this repository? `npm run test:ui-digest-carrier` is 
 
 `re-frame.ui.compiler.build-hook/hook` is a **required host-integration seam**: a versioned contract between re-frame.ui and one specific build tool at one specific version. You name it once in `shadow-cljs.edn` and never again — you don't call it, wrap it, compose it, or reach past it.
 
-Everything else in that namespace is internal implementation and carries no stability promise. `promote-served-generation` in particular is an opt-in helper this repository installs on a single internal build; it is not part of the supported consumer configuration and application code should not reach for it. If you ever find yourself calling into the namespace from application code, the answer is somewhere else — the [API reference](../../api/README.md) carries the surfaces meant for you.
+Everything else in that namespace is internal implementation and carries no stability promise; it is not part of the supported consumer configuration and application code should not reach for it. If you ever find yourself calling into the namespace from application code, the answer is somewhere else — the [API reference](../../api/README.md) carries the surfaces meant for you.
 
 For the normative statement of this contract, see `spec/004C-Roots-and-Mount.md` §2.1.1.

--- a/implementation/scripts/check-ui-digest-carrier.cjs
+++ b/implementation/scripts/check-ui-digest-carrier.cjs
@@ -27,27 +27,8 @@ const LOADED_SOURCE = path.join(
   IMPL, 'ui', 'test', 're_frame', 'ui', 'digest_probe', 'loaded.cljs',
 );
 const OUT = path.join(IMPL, 'out', 'ui-digest-probe-lazy');
-// rf2-vxgfnd.237 — artifact generation/activation separation. Shadow flushes
-// the CANDIDATE generation to OUT/candidate (its :output-dir); the browser is
-// served the STABLE generation from OUT/stable (the dev-http :http-root). The
-// re-frame.ui promote hook publishes candidate -> stable only on a fully
-// successful flush, so a downstream failure leaves the served bytes on the
-// prior accepted generation.
-const CANDIDATE = path.join(OUT, 'candidate');
-const STABLE = path.join(OUT, 'stable');
-// The SERVED (stable) module bytes — what a fresh page load / first lazy-module
-// request actually receives.
-const LAZY_JS = path.join(STABLE, 'lazy.js');
-const CARRIER_JS = path.join(
-  STABLE, 'cljs-runtime', 're_frame.ui.digest_carrier.js',
-);
-// The CANDIDATE module bytes Shadow speculatively flushed — after a downstream
-// failure these hold the REJECTED generation, which the separation must keep
-// off the served URLs.
-const CANDIDATE_LAZY_JS = path.join(CANDIDATE, 'lazy.js');
-const CANDIDATE_CARRIER_JS = path.join(
-  CANDIDATE, 'cljs-runtime', 're_frame.ui.digest_carrier.js',
-);
+// Shadow serves the build's single :output-dir directly; the browser shell and
+// the compiled modules both live under OUT.
 const TARGET = path.join(IMPL, 'target', 'ui-digest-probe');
 const FAIL_MARKER = path.join(TARGET, 'fail-after-compile');
 const ACCEPTED_FILE = path.join(TARGET, 'accepted-digest.txt');
@@ -367,8 +348,8 @@ async function main() {
   fs.rmSync(FAIL_MARKER, { force: true });
   fs.rmSync(ACCEPTED_FILE, { force: true });
   fs.rmSync(PREPARE_FILE, { force: true });
-  // Fresh candidate/stable slate so a prior run's promoted bytes or served
-  // shell cannot mask a regression in the generation/activation separation.
+  // Fresh output slate so a prior run's served shell or compiled bytes cannot
+  // mask a regression.
   fs.rmSync(OUT, { recursive: true, force: true });
 
   let shadow;
@@ -380,12 +361,12 @@ async function main() {
     shadow = watchShadow(shadowRunner);
     await shadow.waitSuccess(0);
 
-    // The served shell lives in the STABLE directory (the dev-http :http-root),
-    // which the first successful build's promote hook has just created. It is
-    // not a build artifact, so the promote hook never overwrites or deletes it.
-    fs.mkdirSync(STABLE, { recursive: true });
+    // The served shell lives in the build's :output-dir (the dev-http
+    // :http-root), created after the first successful build. It is not a build
+    // artifact, so Shadow's incremental rebuilds leave it in place.
+    fs.mkdirSync(OUT, { recursive: true });
     fs.writeFileSync(
-      path.join(STABLE, 'index.html'),
+      path.join(OUT, 'index.html'),
       '<!doctype html><meta charset="utf-8">' +
       // rf2-vxgfnd.242 — a mount container so base.cljs mounts a REAL root whose
       // rendered program (loaded-view text) and complete Root Descriptor are
@@ -478,93 +459,6 @@ async function main() {
     const afterFailure = await page.evaluate(() => globalThis.__rf2ReadDigest());
     if (afterFailure !== digest2 || acceptedSnapshot().digest !== digest2) {
       fail('late failed pass changed active runtime or accepted JVM witness');
-    }
-
-    // Counterexample 1 — the downstream-OUTPUT invariant, CLOSED by the
-    // generation/activation separation (rf2-vxgfnd.237). Shadow's browser
-    // target flushed candidate d3 to its :output-dir (CANDIDATE) before the
-    // intentional :flush failure, then rolled its functional build-state back
-    // to accepted d2. The re-frame.ui promote hook — the LAST :flush hook —
-    // never ran (the earlier failure aborted the build), so the SERVED stable
-    // directory still holds accepted d2. First prove Shadow really did flush the
-    // rejected candidate (else the invariant would be vacuous), then assert the
-    // served generation stayed accepted. Asserted BY DEFAULT now the fix landed.
-    const candidateLazy = fs.existsSync(CANDIDATE_LAZY_JS)
-      ? fs.readFileSync(CANDIDATE_LAZY_JS, 'utf8') : '';
-    if (!candidateLazy.includes('digest-probe-v3')) {
-      fail('candidate output did not receive the rejected d3 generation; the ' +
-           'downstream-output separation would be vacuously satisfied');
-    }
-    const servedLazy = fs.existsSync(LAZY_JS)
-      ? fs.readFileSync(LAZY_JS, 'utf8') : '';
-    const servedCarrier = fs.existsSync(CARRIER_JS)
-      ? fs.readFileSync(CARRIER_JS, 'utf8') : '';
-    const lazyServesRejected = servedLazy.includes('digest-probe-v3');
-    // The accepted digest is d2; a served carrier that no longer contains d2
-    // (its bytes moved to the rejected candidate d3) is servable-rejected.
-    const carrierServesRejected =
-      servedCarrier.length === 0 || !servedCarrier.includes(digest2);
-    if (lazyServesRejected || carrierServesRejected) {
-      fail(
-        `downstream-output gap: served stable URLs no longer resolve to the ` +
-        `accepted generation after the failed :flush (lazy-serves-v3=` +
-        `${lazyServesRejected}, carrier-not-d2=${carrierServesRejected}); ` +
-        `accepted authority is d2 (${digest2}). A hard reload / first lazy ` +
-        `import would activate the rejected candidate d3.`);
-    }
-    console.log(
-      'ui digest carrier: served (stable) generation stayed on accepted d2 ' +
-      'while the candidate output-dir held the rejected d3',
-    );
-
-    // rf2-vxgfnd.237 — the post-:flush-failure LAZY-MODULE-REQUEST fixture the
-    // existing fixtures deliberately do NOT exercise (they assert the ACTIVE
-    // runtime never lazy-loads). A brand-new page (a hard reload) and a genuine
-    // first `/lazy.js` request, both against the served origin while the failed
-    // d3 candidate is the latest build, must receive the prior accepted d2 — or
-    // a fail-closed response — never the rejected candidate.
-    const freshPage = await browser.newPage();
-    try {
-      await freshPage.goto(URL, { waitUntil: 'load', timeout: TIMEOUT });
-      // Hard reload: the served base carrier must read the accepted d2 (or, if
-      // ever fail-closed, null) — never the rejected candidate d3.
-      const freshDigest = await freshPage.evaluate(async () => {
-        for (let i = 0; i < 200; i += 1) {
-          if (typeof globalThis.__rf2ReadDigest === 'function') {
-            const d = globalThis.__rf2ReadDigest();
-            if (d === null || (typeof d === 'string' && d.startsWith('bd1-'))) return d;
-          }
-          await new Promise((r) => setTimeout(r, 50));
-        }
-        return typeof globalThis.__rf2ReadDigest === 'function'
-          ? globalThis.__rf2ReadDigest() : 'accessor-absent';
-      });
-      if (freshDigest !== digest2 && freshDigest !== null) {
-        fail(`hard reload after the failed :flush advertised ${JSON.stringify(freshDigest)}; ` +
-             `expected the accepted d2 (${digest2}) or a fail-closed null`);
-      }
-      // First lazy import: a genuine request for the served /lazy.js from the
-      // fresh origin must return the accepted d2 generation, never rejected d3.
-      const lazyBody = await freshPage.evaluate(async () => {
-        const res = await fetch('/lazy.js', { cache: 'no-store' });
-        return { ok: res.ok, status: res.status, text: await res.text() };
-      });
-      if (!lazyBody.ok) {
-        fail(`served first /lazy.js request failed (status ${lazyBody.status})`);
-      }
-      if (lazyBody.text.includes('digest-probe-v3')) {
-        fail('first lazy-module request served the rejected candidate d3 (digest-probe-v3)');
-      }
-      if (!lazyBody.text.includes('digest-probe-v2')) {
-        fail('first lazy-module request did not serve the accepted d2 generation (digest-probe-v2)');
-      }
-      console.log(
-        `ui digest carrier: post-failure hard reload + first lazy import both ` +
-        `resolved to the accepted generation ` +
-        `(reload=${freshDigest === null ? 'fail-closed' : freshDigest}, lazy=d2)`,
-      );
-    } finally {
-      await freshPage.close();
     }
 
     // Recovery success starts from Shadow's retained d2 state, not the failed

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -757,32 +757,27 @@
   ;; runner keeps one watch daemon and browser alive across good / downstream-
   ;; failed / good passes, proving warm recompilation and active-runtime LKG.
   ;;
-  ;; rf2-vxgfnd.237 — artifact generation/activation separation. Shadow writes
-  ;; the CANDIDATE module bytes to :output-dir (out/.../candidate); the browser
-  ;; is served the STABLE generation from the dev-http :http-root
-  ;; (out/.../stable). The re-frame.ui promote hook, ordered LAST in
-  ;; :build-hooks, publishes candidate -> stable only when the whole flush
-  ;; pipeline succeeds. The digest-probe test hook (deep-merged FIRST, after the
-  ;; build-default compile hook) injects a downstream :flush failure; being
-  ;; earlier than the promote hook, its throw aborts the build before the
-  ;; publish, so the served stable generation stays on the accepted bytes and a
-  ;; fresh page load / first lazy import never activates the rejected candidate.
+  ;; Shadow serves the build's single :output-dir directly (dev-http :http-root
+  ;; points at it). A downstream :flush failure reverts the accepted compiler
+  ;; snapshot and the active runtime to last-known-good; it does NOT roll back
+  ;; the raw output directory — Shadow's output dir is Shadow's. The digest-probe
+  ;; test hook (deep-merged FIRST, after the build-default compile hook) injects
+  ;; the downstream :flush failure the runner drives.
   :ui-digest-probe-lazy
   {:target :browser
-   :output-dir "out/ui-digest-probe-lazy/candidate"
+   :output-dir "out/ui-digest-probe-lazy"
    :asset-path "."
    :modules
    {:base {:entries [re-frame.ui.digest-probe.base]
            :init-fn re-frame.ui.digest-probe.base/init}
     :lazy {:entries [re-frame.ui.digest-probe.lazy]
            :depends-on #{:base}}}
-   :devtools {:http-root "out/ui-digest-probe-lazy/stable"
+   :devtools {:http-root "out/ui-digest-probe-lazy"
               :http-port 8059}
-   ;; Deep-merged after the load-bearing build-default compile hook: the
-   ;; test hook runs at :flush after target output and injects a true downstream
-   ;; failure; the promote hook runs LAST so that failure aborts before it.
-   :build-hooks [(re-frame.ui.digest-probe.build-hook/hook)
-                 (re-frame.ui.compiler.build-hook/promote-served-generation)]}
+   ;; Deep-merged after the load-bearing build-default compile hook: the test
+   ;; hook runs at :flush after target output and injects a true downstream
+   ;; failure, proving the accepted compiler/runtime authority reverts.
+   :build-hooks [(re-frame.ui.digest-probe.build-hook/hook)]}
 
   ;; rf2-vxgfnd.6 — the G-1 direct-render parity gate (07 §5) for the
   ;; re-frame.ui compiled-view substrate. A :node-script RELEASE build

--- a/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
@@ -90,13 +90,11 @@
   Transaction boundary: the accepted build-state and active HMR runtime are
   last-known-good. Shadow may have partially rewritten its raw output directory
   before a late failure; re-frame.ui does not claim filesystem rollback for that
-  raw directory. The opt-in `promote-served-generation` helper below can copy
-  that output onto a separate served directory after earlier pipeline steps, but
-  it is a best-effort incremental copy, not content-atomic activation: partial
-  failure can expose mixed bytes and candidate-absent destinations are retained.
-  It is currently wired only by the digest-probe build, not `:build-defaults`."
-  (:require [clojure.java.io :as io]
-            [clojure.string :as str]
+  raw directory — Shadow's output directory is Shadow's to publish. A fresh page
+  load served straight from it can therefore briefly execute rejected candidate
+  bytes until the next accepted build overwrites them; the accepted compiler
+  snapshot and runtime digest, which re-frame.ui does own, revert."
+  (:require [clojure.string :as str]
             [re-frame.ui.compiler.build :as build]
             [re-frame.ui.compiler.harvest :as harvest]))
 
@@ -568,85 +566,6 @@
            {:carrier-resource-id rid :sentinel-count n :js-string? (string? js)}))
         (assoc-in build-state [:output rid :js]
                   (str/replace js digest-sentinel digest))))))
-
-;; ---------------------------------------------------------------------------
-;; Opt-in served-output copy helper (rf2-vxgfnd.237)
-;;
-;; Shadow's browser target flushes the candidate module bytes to its raw
-;; `:output-dir` at `:flush`, BEFORE any later `:flush` step can fail; on a
-;; downstream failure Shadow discards the returned build-state (reverting the
-;; accepted compiler snapshot) but does NOT roll back that raw directory. So a
-;; fresh page load or a first lazy-module request served straight from
-;; `:output-dir` would execute/advertise the rejected candidate generation.
-;;
-;; With a separate dev-http `:http-root`, configuring this hook last means an
-;; earlier flush failure aborts before copying starts. The copy itself is NOT
-;; atomic generation activation: `publish-tree!` overwrites files one by one,
-;; uses only existence/length/mtime as its freshness check, has no rollback, and
-;; retains destination files absent from the candidate. A copy failure can
-;; therefore leave mixed served bytes. Only the digest-probe build currently
-;; installs this helper; the standard `:build-defaults` do not.
-;; ---------------------------------------------------------------------------
-
-(defn- stale-copy?
-  "Cheap freshness check: copy `src` onto `dest` only when the destination is
-  missing or differs in length / is older. Keeps warm publishes O(changed)."
-  [^java.io.File src ^java.io.File dest]
-  (or (not (.exists dest))
-      (not= (.length src) (.length dest))
-      (> (.lastModified src) (.lastModified dest))))
-
-(defn- publish-tree!
-  "Recursively copy every regular file under `from` onto `to`, creating parent
-  directories and overwriting stale destinations. Deliberately does NOT delete
-  destination files absent from `from`: the served shell (a hand-written
-  index.html) lives in the stable directory and is not a build artifact."
-  [^java.io.File from ^java.io.File to]
-  (when (.isDirectory from)
-    (let [from-path (.toPath from)]
-      (doseq [^java.io.File src (file-seq from)
-              :when (.isFile src)]
-        (let [dest (io/file to (.toString (.relativize from-path (.toPath src))))]
-          (when (stale-copy? src dest)
-            (io/make-parents dest)
-            (io/copy src dest)))))))
-
-(defn promote-served-generation
-  "A `:flush`-stage build hook that makes an opt-in, best-effort incremental
-  copy of just-flushed candidate output onto a separate served directory.
-
-  Configure it as the LAST entry in a dev `:browser` build's `:build-hooks`,
-  with the build's `:output-dir` pointing at a CANDIDATE directory and the
-  dev-http `:http-root` pointing at a separate STABLE served directory:
-
-    :output-dir \"out/<build>/candidate\"
-    :devtools   {:http-root \"out/<build>/stable\" ...}
-    :build-hooks [... (re-frame.ui.compiler.build-hook/promote-served-generation)]
-
-  When configured as the terminal `:flush` hook, ordering ensures earlier
-  pipeline failures abort before copying starts. The hook does not enforce that
-  placement. Once started, it overwrites files one by one using
-  existence/length/mtime freshness, without rollback or removal of destinations
-  absent from the candidate. It is therefore not content-atomic: copy failure
-  can leave mixed served bytes, and a later hook can still reject the build.
-
-  The repository currently installs this helper only in
-  `:ui-digest-probe-lazy`; standard `:build-defaults` do not install it.
-
-  When no separation is configured (`:http-root` absent, or the same path as
-  `:output-dir`) it is a no-op — the served directory IS the output directory,
-  the un-separated legacy behaviour. Dev-only JVM build tooling; never part of
-  any CLJS bundle."
-  {:shadow.build/stages #{:flush}}
-  [build-state]
-  (let [candidate (get-in build-state [:build-options :output-dir])
-        stable    (get-in build-state [:shadow.build/config :devtools :http-root])]
-    (when (and candidate (seq (str stable)))
-      (let [candidate (io/file candidate)
-            stable    (io/file stable)]
-        (when-not (= (.getCanonicalPath candidate) (.getCanonicalPath stable))
-          (publish-tree! candidate stable)))))
-  build-state)
 
 ;; ---------------------------------------------------------------------------
 ;; Deterministic custom-element pre-seed (rf2-vxgfnd.141, dimension 2)


### PR DESCRIPTION
## What

Executes the Fable/Mike ruling on **rf2-vxgfnd.271** (2026-07-19 22:22): the S5 atomic-generation-swap architecture is ruled **do-not-build**, so this removes the speculative candidate/stable served-generation split that was building toward it. That path is now dead — `hydrate-root` is the live SSR path (#6476/#6458) and reads root identity from the DOM-adjacent Root Manifest, never from a served-generation directory. This is a **removal**, not a replacement: no migration shim, no new abstraction.

## The three ruled steps

1. **`build_hook.clj`** — deleted `promote-served-generation`, `publish-tree!`, and `stale-copy?` (a knowingly-partial multi-file in-place copy that cannot be made atomic and suggested more safety than it supplied). Removed the now-orphaned `clojure.java.io` require, and reconciled the namespace-comment transaction-boundary prose to state plainly that Shadow's raw output directory is Shadow's — the accepted compiler snapshot and runtime digest, which re-frame.ui *does* own, still revert on a late failure.
2. **`shadow-cljs.edn`** (`:ui-digest-probe-lazy`) — collapsed the candidate/stable pair to a single `:output-dir "out/ui-digest-probe-lazy"` (dev-http `:http-root` points at it) and dropped the `promote-served-generation` hook entry. The digest-probe test hook stays; its compiler/runtime last-known-good assertions are untouched.
3. **Reference sweep** — trimmed `check-ui-digest-carrier.cjs`: removed the served-generation *file-tree* assertions (candidate output held the rejected d3 while served stable held accepted d2; the post-failure hard-reload + first-lazy-import over the served origin). **Kept** every load-bearing compiler/runtime LKG assertion: active runtime + JVM witness retain d2 after the failed `:flush`, recovery seeds from retained d2, the runtime-activation fence (counterexample 2), and the overlapping-activation generation fence (counterexample 3). Dropped the `promote-served-generation` example from the install how-to. `spec/004C-Roots-and-Mount.md` §2.1 already states the honest position with no served-generation-promotion prose, so it is unchanged.

Net **−192 lines** (27 insertions, 219 deletions). Advanced production stays free of any generation-swap residue.

## Quality gates

All run foreground to completion in the worktree (warm cache):

| Gate | Result |
|------|--------|
| `implementation/ui` `clojure -M:test` | **PASS** — 1001 tests / 19590 assertions, 0 failures / 0 errors |
| `npm run test:cljs` | **PASS** — 10313 tests / 50842 assertions, 0 failures / 0 errors |
| `npm run test:ui-digest-carrier` (digest-carrier fail-closed proof, rf2-vxgfnd.108) | **PASS** — hookless fail-closed + LKG + activation fence + overlap fence + final-schedule |
| `npm run test:elision` | **PASS** — production 60/60 absent, control 60/60 present |
| `npm run test:perf-bundle` | **PASS** — off-count=0, on-count=8 |

The digest/elision probe still functions with the single `:output-dir`: the fail-closed digest-carrier proof and the elision probe stay green; only the unused generation-swap scaffolding is gone.

Sole toucher of `shadow-cljs.edn` (all sibling worktrees swept clean). No hydrate-root or other-worker code touched. Bead stays OPEN — the mayor closes it on merge.
