### PR TITLE
docs(skills): correct epoch-cardinality per-drain claim to per-event in the pair preload (rf2-yiwag)

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -1183,9 +1183,11 @@
 ;; ---------------------------------------------------------------------------
 ;;
 ;; re-frame2 ships first-class epoch recording. The listener fires once
-;; per drain-settle with the assembled `:rf/epoch-record`. We register
-;; ours under id :re-frame2-pair-epoch — multi-tool coexistence per
-;; Spec 009 §Listener ordering.
+;; per dequeued event (run-to-completion), NOT per drain-settle, with the
+;; assembled `:rf/epoch-record` — a parent and its `:fx`-queued child
+;; commit TWO records, one per event, even though both settle in one drain.
+;; We register ours under id :re-frame2-pair-epoch — multi-tool coexistence
+;; per Spec 009 §Listener ordering.
 ;;
 ;; Runtime-direct reads, no parallel epoch capture buffer.
 ;; The pair session is a THIN, runtime-direct reader: every epoch read


### PR DESCRIPTION
## What

`skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs:1185` (the assembled-stream epoch listener docstring) claimed:

> The listener fires once **per drain-settle** with the assembled `:rf/epoch-record`.

That is stale. The code-grounded cardinality is one `:rf/epoch-record` **per DEQUEUED EVENT (run-to-completion)**, NOT per drain-settle — a parent and its `:fx`-queued child commit TWO records even though both settle in one drain.

Corrected the comment to say per-event and note the parent/`:fx`-child → two-records case.

## Grounding (the emit sites established by #6479 / #6481)

- `implementation/epoch/src/re_frame/epoch.cljc:284` — `settle!`: *"Settle one dequeued event, not an entire drain. Parent and child events in one drain produce separate records."*
- `implementation/core/src/re_frame/router.cljc:3278` — `settle-event-epoch!`: *"commits one `:rf/epoch-record` per event. A drain that processes a parent and an `:fx [[:dispatch …]]` child it queued therefore commits TWO records — one per event — even though both settled in one drain."*

## Scope

- Comment/docstring only — **no runtime logic changed**. This is a `.cljs` file; no keyword-literal `identical?` or anything of the sort was touched.
- Left `runtime.cljs:1503/1556/3892` and the per-cascade refs alone — the #6481 (ydddw) worker verified those are DIFFERENT mechanisms (trace-bundle grouping by dispatch-id; dispatch-sync synchrony; a cascade = one event run-to-completion = per-event, already correct). Only :1185 was the epoch-record cardinality defect.

Out-of-fence sibling of #6479 (rf2-wspya, merged) and #6481 (rf2-ydddw, merged).

## Quality gates

- **Compile**: N/A to run — comment-only edit to a `.cljs` file. The preload lives under the dev-only `:devtools :preloads` source-path (`../skills/re-frame2-pair/preload` in `implementation/shadow-cljs.edn`), "never ships to release bundles" and is attached only via the Tool-Pair transport for live debugging; it is not built by a production CI gate. The ClojureScript reader strips `;;` comments before analysis and only `;;`-prefixed lines changed, so compilation output is provably unchanged.
- **mkdocs `--strict` / `check_doc_slugs.py`**: N/A — the mkdocs nav renders the skill *doc* (`skills/re-frame2-pair.md`), not this preload source file. `runtime.cljs` does not render in the site.
- The comment text itself is ungated (which is why it drifted); the fix is grounded directly in the epoch emit code above.