### PR TITLE
docs(api): document epoch creation and lifecycle to the shipped per-event model (rf2-ablz8)

### DIFF
--- a/docs/api/re-frame.core.md
+++ b/docs/api/re-frame.core.md
@@ -1181,7 +1181,7 @@ There is deliberately **no** facade `clear-listeners!` verb. Dropping every list
   ```clojure
   (epoch-history frame-id) → vector of epoch records
   ```
-- **Description**: Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Returns `[]` for an unknown / destroyed frame. Used by pair-shaped tools for time-travel and post-mortem analysis. Production builds elide entirely. See [re-frame.epoch.md](re-frame.epoch.md).
+- **Description**: Per-frame epoch snapshots in dev builds. Ordinary event processing commits one record per dequeued event, not one per drain: a parent and the `:fx [[:dispatch …]]` child it queues are separate records, while a machine macrostep stays a single epoch. `replace-frame-state!` writes and depth/destroy halts also land synthetic records (see [Epoch-settled listeners](#epoch-settled-listeners)). Returns `[]` for an unknown / destroyed frame. Used by pair-shaped tools for time-travel and post-mortem analysis. Production builds elide entirely. See [re-frame.epoch.md](re-frame.epoch.md).
 - **Example**:
   ```clojure
   (rf/epoch-history :app/main)
@@ -1231,7 +1231,7 @@ There is deliberately **no** facade `clear-listeners!` verb. Dropping every list
 Epoch-settled listeners are the `:epoch` stream of the stream-parameterized listener verb. There is no separate facade `register-epoch-listener!` fn — the per-channel pair was retired in API-shrink #4. The epoch stream registers through the one verb exactly like `:trace` / `:events` / `:errors`.
 
 - **Signature**: `(rf/register-listener! :epoch key callback-fn)` / `(rf/unregister-listener! :epoch key)`
-- **Description**: Process-global assembled-epoch listener, dev-only. The callback fires once per dequeued event with the assembled `:rf/epoch-record`; re-registering the same `key` replaces. A callback whose previously-observed frame is destroyed receives a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace. Returns `key`, or `nil` when the `day8/re-frame2-epoch` artefact is absent.
+- **Description**: Process-global assembled-epoch listener, dev-only. The callback is a record-**publication** notification, not a once-per-event clock. It receives the assembled `:rf/epoch-record` when an epoch first commits, and again — carrying the same `:epoch-id` — when a post-settle backfill (a late render, sub-run, or unmount attributed to that epoch) corrects the record, so a consumer caching `epoch-history` re-syncs to the fixed snapshot. It also receives synthetic records that no dequeued event produced: a `:rf.epoch/db-replaced` record for each `replace-frame-state!` write, and a `:halted-depth` / `:halted-destroy` record when a drain halts. Reconcile on `:epoch-id` and `:outcome` rather than counting callbacks as events. Re-registering the same `key` replaces. A callback whose previously-observed frame is destroyed receives a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace. Returns `key`, or `nil` when the `day8/re-frame2-epoch` artefact is absent.
 - **Example**:
   ```clojure
   (rf/register-listener! :epoch :my-app/epoch-watch


### PR DESCRIPTION
## What

`docs/api/re-frame.core.md` epoch prose retained the retired **once-per-drain** model. PR #6479 (rf2-wspya, merged) corrected epoch record CREATION to one record per dequeued event but left this public doc stale, and the `:epoch` listener line then over-narrowed the fix into a callback-cardinality claim. This documents epoch creation/lifecycle to the shipped per-event model and separates the two cadences the runtime actually has.

Two description edits, scoped to the epoch section only:

- **`epoch-history`** — was "recorded on each drain-completion". Now: ordinary event processing commits one record **per dequeued event, not per drain** (a parent and the `:fx [[:dispatch …]]` child it queues are separate records; a machine macrostep stays a single epoch), plus synthetic records for `replace-frame-state!` writes and depth/destroy halts.
- **Epoch-settled listeners** — was "fires once per dequeued event". Now: the callback is a record-**publication** notification, not a once-per-event clock. It re-publishes the same epoch (same `:epoch-id`) after a post-settle render/sub-run/unmount **backfill** corrects the snapshot, and delivers the synthetic `:rf.epoch/db-replaced` and `:halted-depth` / `:halted-destroy` records that no dequeued event produced. Guidance: reconcile on `:epoch-id` + `:outcome` rather than counting callbacks as events.

Grounded in the actual epoch code: `re-frame.epoch/settle!` ("Settle one dequeued event, not an entire drain"), `router.cljc` `settle-event-epoch!` (one record per event), `listeners.cljc` `record-render!` / `record-sub-run!` / `record-unmount!` (re-fan corrected record), the `:rf.epoch/db-replaced` synthetic commit, and the depth-halt / `:halted-destroy` publication paths.

## Scope

Surface is `docs/api/re-frame.core.md` only. No runtime/API-shape change, no new checker, no compatibility layer. Out-of-surface occurrences of the same stale model are **named** for follow-up (not edited here) — see the bead. rf2-yiwag's preload line is untouched.

## Quality gates

- `python -m mkdocs build --strict` → exit 0
- `python scripts/check_doc_slugs.py` → exit 0 (validates the new in-doc `#epoch-settled-listeners` anchor)
- Guide-truth JVM test (`~1001`) checked — pins `docs/core/guide/*` + `spec/Ownership.md` + EP-0030/0034, **not** `docs/api/re-frame.core.md`, so not applicable to this change.

Closes rf2-ablz8.