### PR TITLE
fix(ssr): honor {:html …} children in the raw-text script/style branch (rf2-0spji)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
+++ b/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
@@ -558,25 +558,40 @@
   survives the parse round-trip."
   #{"pre" "listing" "textarea"})
 
+(defn- sole-newline-content
+  "The single content STRING React's leading-LF rule applies to, or nil. React
+  compensates only when a newline-eating element's body is ONE string: a lone
+  text child, OR a lone `{:html s}` trusted-markup child — React's
+  `dangerouslySetInnerHTML.__html`, likewise a `typeof … === 'string'` body it
+  doctors the same way (rf2-0spji). A multi-child, element, or non-string-`:html`
+  body is left untouched. `content` is the element's content as a seq — one entry
+  means a single (already text-coalesced) string child, a textarea's `:value`, or
+  a sole trusted-markup child."
+  [content]
+  (when (= 1 (count content))
+    (let [c (first content)]
+      (cond
+        (string? c)                        c
+        (and (map? c) (string? (:html c))) (:html c)
+        :else                              nil))))
+
 (defn leading-newline-compensation
   "-> the compensating LF (`\"\\n\"`) react-dom/server 19.2 prefixes inside a
   newline-eating element (`newline-eating-tags`), or `\"\"` when none is owed.
 
   HTML parsing eats the FIRST LF immediately after `<pre>`/`<listing>`/
-  `<textarea>` (the newline-eating elements). So a tree whose textarea value or
-  pre text begins with LF would, without compensation, parse to a DOM carrying
-  one FEWER newline than authored — an S5 hydration/correctness gap. React
-  prefixes exactly one LF, but ONLY when the element's content is a SINGLE
-  STRING (its `typeof children === 'string'` guard): multiple or element
-  children are left untouched, because the parser's newline-eating still
-  applies but React does not doctor a multi-child body. `content-strings` is the
-  element's content as a seq — one entry means a single (already text-coalesced)
-  string child, or a textarea's `:value`."
-  [tag-lc content-strings]
+  `<textarea>` (the newline-eating elements). So a tree whose textarea value, pre
+  text, or sole trusted-markup (`:html`) body begins with LF would, without
+  compensation, parse to a DOM carrying one FEWER newline than authored — an S5
+  hydration/correctness gap. React prefixes exactly one LF, but ONLY when the
+  element's content is a SINGLE STRING body (its `typeof … === 'string'` guard,
+  applied to a string child AND to `dangerouslySetInnerHTML.__html`): multiple or
+  element children are left untouched, because the parser's newline-eating still
+  applies but React does not doctor a multi-child body."
+  [tag-lc content]
   (if (and (contains? newline-eating-tags tag-lc)
-           (= 1 (count content-strings))
-           (let [c (first content-strings)]
-             (and (string? c) (str/starts-with? c "\n"))))
+           (let [c (sole-newline-content content)]
+             (and (some? c) (str/starts-with? c "\n"))))
     "\n"
     ""))
 
@@ -729,6 +744,44 @@
       (fn [i c] (emit-node c (conj parent-path :children i)))
       children)))
 
+(defn- emit-raw-text-children
+  "Emit the children of a raw-text element (`<script>`/`<style>`) — the raw-text
+  half of the child grammar (rf2-0spji). React's model: a raw-text element's body
+  is EITHER HTML raw text (string children) OR a single trusted-markup bypass
+  (`ui/html` → `dangerouslySetInnerHTML`), never both.
+
+    - all-string content → HTML raw text: emitted verbatim but for the
+      context-safe closing-sequence rewrite (`escape-raw-text`), matching
+      react-dom/server's string-`children` path (rf2-2dh3b).
+    - a sole `{:html s}` child → the trusted-markup bypass: `s` VERBATIM, no
+      rewrite — react-dom/server pushes `dangerouslySetInnerHTML.__html` raw. This
+      REUSES `emit-node`'s general `:html` row, so the body is byte-identical to a
+      `:html` node anywhere else and a non-string `:html` is the SAME shared
+      malformed-tree error.
+
+  Any other shape — an element/view-boundary/fragment child, string content mixed
+  with a structural child, or several structural children — is NOT raw text and
+  must not be stringified (the pre-fix fast path `(str/join (:children el))`
+  printed such a child's EDN literally into the script/style body). It fails loud
+  through the shared `:rf.error/ui-tree-malformed` path, locating the element."
+  [tag-lc children path]
+  (cond
+    (every? string? children)
+    (escape-raw-text tag-lc (str/join children))
+
+    (and (= 1 (count children))
+         (map? (first children))
+         (contains? (first children) :html))
+    (emit-node (first children) (conj path :children 0))
+
+    :else
+    (malformed-node!
+      (str "a <" tag-lc "> raw-text element takes EITHER string content OR a "
+           "single trusted-markup (:html) child — never a structural, mixed, or "
+           "multi-child body (which the raw-text fast path would otherwise "
+           "stringify into the element): " (pr-str children))
+      path {:value children})))
+
 (defn- emit-element
   "Emit an element node. Applies the form-control special forms
   (`:default-value`/`:default-checked` -> `value`/`checked`; `:value` on
@@ -764,7 +817,10 @@
       void?          (str open ">")
       ;; rf2-2dh3b — <script>/<style> content is HTML raw text: emit it
       ;; unescaped (only the closing-sequence escape), matching react-dom/server.
-      raw-text?      (str open ">" (escape-raw-text norm-tag (str/join (:children el)))
+      ;; rf2-0spji — but honor a sole `{:html s}` child (the ui/html trusted
+      ;; bypass) verbatim, and fail loud on any other structural child instead of
+      ;; stringifying it.
+      raw-text?      (str open ">" (emit-raw-text-children norm-tag (:children el) path)
                           "</" tag-name ">")
       ;; rf2-z05di — a textarea :value beginning with LF needs the compensating
       ;; leading LF the parser will eat back off (single-string content).

--- a/implementation/ssr/test/re_frame/ssr/emit_ui_tree_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/emit_ui_tree_cljs_test.cljc
@@ -262,6 +262,63 @@
            (ui-tree/emit-ui-tree (v1 {:tag :div :children ["</script>"]})))
         "and </script> in a <div> is inert escaped text, not a raw-text escape")))
 
+;; ---------------------------------------------------------------------------
+;; Raw-text elements honor the ui/html trusted-markup child (rf2-0spji)
+;;
+;; ANCHOR (rf2-0spji): the raw-text fast path (rf2-2dh3b) ran
+;; `(str/join (:children el))` over ALL children, so a `{:html s}` child — the
+;; `ui/html` trusted-markup bypass, which the CLJS emitter lowers to React
+;; `dangerouslySetInnerHTML` and the JVM tree records as `{:html s}` — was
+;; STRINGIFIED to its printed EDN map instead of emitting its trusted body. The
+;; sole `{:html s}` child must emit `s` VERBATIM (react-dom/server pushes
+;; `dangerouslySetInnerHTML.__html` raw — no entity escape, no closing-sequence
+;; rewrite), byte-identical to the general `:html` node path; any other
+;; structural child fails loud rather than leaking as EDN text.
+;; ---------------------------------------------------------------------------
+
+(deftest raw-text-honors-ui-html-trusted-child
+  (testing "a sole {:html s} child under <script> emits the trusted body, NOT the printed map"
+    ;; RED-BEFORE lever (rf2-0spji): the shipped fast path emitted the literal
+    ;; EDN "<script>{:html \"const x=1;\"}</script>".
+    (is (= "<script>const x=1;</script>"
+           (ui-tree/emit-ui-tree (v1 {:tag :script :children [{:html "const x=1;"}]})))))
+  (testing "a sole {:html s} child under <style> likewise emits its trusted body"
+    (is (= "<style>.x{color:red}</style>"
+           (ui-tree/emit-ui-tree (v1 {:tag :style :children [{:html ".x{color:red}"}]})))))
+  (testing "the :html body is VERBATIM — the trusted bypass, NEITHER escaped NOR closing-sequence-rewritten"
+    ;; Contrast the STRING path: "</script>" as a string CHILD is rewritten to
+    ;; "</\\u0073cript>" (raw-text-closing-sequences-*). The :html trusted bypass
+    ;; writes it verbatim — exactly as react-dom pushes dangerouslySetInnerHTML
+    ;; and as the general :html node path (writes-trusted-html-verbatim) does.
+    (is (= "<script>var s = '</script>';</script>"
+           (ui-tree/emit-ui-tree (v1 {:tag :script :children [{:html "var s = '</script>';"}]}))))
+    (is (= "<script>if (1 < 2 && 3) {}</script>"
+           (ui-tree/emit-ui-tree (v1 {:tag :script :children [{:html "if (1 < 2 && 3) {}"}]})))
+        "< and & stay literal — the :html body is never 5-char escaped")))
+
+(deftest raw-text-structural-child-fails-loud-not-stringified
+  (testing "an element child under <script> is the SHARED malformed id, not stringified EDN"
+    ;; RED-BEFORE lever: the fast path stringified it to
+    ;; "<script>{:tag :b, :children [\"x\"]}</script>".
+    (let [d (caught-ex-data
+              #(ui-tree/emit-ui-tree
+                 (v1 {:tag :script :children [{:tag :b :children ["x"]}]})))]
+      (is (= :rf.error/ui-tree-malformed (:rf.error/id d))
+          "a structural child in a raw-text element is the SHARED malformed id")
+      (is (= [] (:path d)) "locates the offending raw-text element (the root here)")))
+  (testing "a non-string :html under <style> is the SAME shared malformed id, located at the child"
+    (let [d (caught-ex-data
+              #(ui-tree/emit-ui-tree (v1 {:tag :style :children [{:html 42}]})))]
+      (is (= :rf.error/ui-tree-malformed (:rf.error/id d)))
+      (is (= [:children 0] (:path d)) "the reused :html row locates the non-string body")))
+  (testing "a body mixing string content with a structural child is malformed"
+    ;; React forbids both `children` and `dangerouslySetInnerHTML`; a mixed body
+    ;; likewise fails loud rather than half-stringifying.
+    (let [d (caught-ex-data
+              #(ui-tree/emit-ui-tree
+                 (v1 {:tag :script :children ["const x=1;" {:html "y"}]})))]
+      (is (= :rf.error/ui-tree-malformed (:rf.error/id d))))))
+
 (deftest custom-element-property-props-omitted
   (testing "property-classified props never reach markup; attributes do"
     (is (= "<my-widget id=\"w\"></my-widget>"
@@ -347,6 +404,32 @@
     (is (= "<div>\nhello</div>"
            (ui-tree/emit-ui-tree (v1 {:tag :div :children ["\nhello"]})))
         "the compensation is scoped to pre/listing/textarea only")))
+
+;; ---------------------------------------------------------------------------
+;; Leading-LF compensation for a sole trusted-HTML child (rf2-0spji)
+;;
+;; ANCHOR (rf2-0spji): React compensates the eaten leading LF for a single
+;; STRING body applied to a string child AND to `dangerouslySetInnerHTML.__html`.
+;; The shipped `leading-newline-compensation` only recognised a direct string
+;; child, so a valid sole `{:html "\n…"}` child under <pre>/<listing> emitted a
+;; single LF the parser then eats — one FEWER newline than authored.
+;; ---------------------------------------------------------------------------
+
+(deftest leading-newline-compensated-for-sole-trusted-html-child
+  (testing "<pre> sole {:html s} child beginning with LF gets React's compensating LF"
+    ;; RED-BEFORE lever (rf2-0spji): emitted "<pre>\n<b>x</b></pre>" (one LF).
+    (is (= "<pre>\n\n<b>x</b></pre>"
+           (ui-tree/emit-ui-tree (v1 {:tag :pre :children [{:html "\n<b>x</b>"}]})))))
+  (testing "<listing> compensates a sole trusted-HTML LF body the same way"
+    (is (= "<listing>\n\n<i>y</i></listing>"
+           (ui-tree/emit-ui-tree (v1 {:tag :listing :children [{:html "\n<i>y</i>"}]})))))
+  (testing "VACUITY: a :html body NOT beginning with LF gets no compensation"
+    (is (= "<pre><b>x</b></pre>"
+           (ui-tree/emit-ui-tree (v1 {:tag :pre :children [{:html "<b>x</b>"}]})))
+        "the fix must not add an LF when none is owed")
+    (is (= "<div>\n<b>x</b></div>"
+           (ui-tree/emit-ui-tree (v1 {:tag :div :children [{:html "\n<b>x</b>"}]})))
+        "a non-newline-eating element is never compensated, even for a :html body")))
 
 (deftest doctype-opt
   (is (= "<!DOCTYPE html><html></html>"


### PR DESCRIPTION
## What

P1 regression from #6477 (rf2-2dh3b). The `<script>`/`<style>` raw-text fast path in `re-frame.ssr.ui-tree/emit-element` ran `(str/join (:children el))` over ALL children, so a `{:html s}` trusted-markup child (`ui/html` — the CLJS emitter lowers it to React `dangerouslySetInnerHTML`, the JVM tree records `{:html s}`) was stringified to its printed EDN map:

```
{:tag :script :children [{:html "const x=1;"}]}
  ->  <script>{:html "const x=1;"}</script>     ← WRONG (map leaked)
  ->  <script>const x=1;</script>               ← FIXED
```

## Fix (minimal — no redesign)

- New `emit-raw-text-children`: **all-string content** keeps #6477's raw-text emit + closing-sequence rewrite (`escape-raw-text`); a **sole `{:html s}` child** REUSES `emit-node`'s general `:html` row — verbatim body, byte-identical to a `:html` node anywhere else, and the same shared malformed error for a non-string `:html`; **any other structural / mixed / multi-child body** fails loud through `:rf.error/ui-tree-malformed` with location, instead of being stringified.
- `leading-newline-compensation` now recognises a sole `{:html "\n…"}` child (via `sole-newline-content`), so `<pre>`/`<listing>` get React's compensating LF for the trusted-markup body too (react-dom applies the leading-LF rule to `dangerouslySetInnerHTML.__html`, not only string children).

No new escaping layer, no sanitiser, no public options, no serializer framework; `escape-element`/emit-node otherwise untouched. `#6489`'s manifest path untouched.

## XSS posture

`:html` is the explicit trusted-raw bypass (the programmer opted in) — emitted VERBATIM in script/style, consistent with #6477's raw-text-for-trusted-content model and with react-dom's `dangerouslySetInnerHTML`. No new escaping added; non-`:html` string content keeps #6477's closing-sequence breakout guard.

## Quality gates

- `cd implementation/ssr && clojure -M:test` — **506 tests, 2410 assertions, 0 failures** (dual-host JVM)
- `npm run test:cljs` — **10319 tests, 50884 assertions, 0 failures** (node)
- `python -m mkdocs build --strict` — clean (no docs touched)

Red-before (confirmed by evaluating the pre-fix expression): `<script>{:html "const x=1;"}</script>` for the `:html` child, `<script>{:tag :b, :children ["x"]}</script>` for a structural child. Green-after byte-pinned in the new dual-host tests.

## Deferred (bead criteria 4 & 5 — HOT-ZONE / decision, out of this fence)

The bead also asks to (4) state the leading-LF rule + trusted-HTML case in Spec 004B, and (5) reconcile ordinary script/style string semantics across Spec 004B, Spec 011/Security, and the legacy hiccup `render-to-string` emitter. Spec 004B currently has **no leading-LF rule at all** (a pre-existing doc gap from rf2-z05di, widened here). These are HOT-ZONE (spec/004B) and a broader design recommendation needing acceptance — STOP-reported to the mayor for follow-up beads rather than edited in this focused P1 fix.

rf2-0spji