### PR TITLE
fix(reagent-slim): make the tag-name cache prototype-free so tag names cannot collide with JS-object keys (rf2-tsuk6)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -243,6 +243,26 @@
 (defn- ^boolean reserved-prop-key? [n]
   (contains? reserved-prop-keys n))
 
+;; Unspoofable own-property test for the shared `#js {}` caches (rf2-tsuk6).
+;;
+;; The caches key entries by user-controlled names: `tag-name-cache` on tag
+;; heads (a string head like "hasOwnProperty" is accepted) and
+;; `prop-name-cache` on prop-key names (`{:hasOwnProperty x}` is accepted).
+;; Testing a hit with `(.hasOwnProperty cache n)` reads the method OFF the
+;; cache object — so caching a tag or prop literally named "hasOwnProperty"
+;; `aset`s a value under that exact own-property name and SHADOWS the method.
+;; The lookup itself was fine (`.hasOwnProperty` checks own props, so
+;; inherited prototype keys never falsely hit), but the very next lookup then
+;; invokes the shadowing value as a function and throws a raw host TypeError,
+;; disabling every later parse until reload. `Object.prototype.hasOwnProperty`
+;; called with an explicit receiver can never be shadowed by cache contents.
+(defn- ^boolean own-key?
+  "True when `obj` carries `k` as an OWN property, tested via
+  `Object.prototype.hasOwnProperty.call(obj, k)` so a cache entry named
+  `hasOwnProperty` cannot shadow the check (rf2-tsuk6)."
+  [obj k]
+  (.call (.. js/Object -prototype -hasOwnProperty) obj k))
+
 (def ^:private tag-name-cache #js {})
 
 ;; The cache key is the head's FULLY-QUALIFIED name, not its bare `name`
@@ -287,7 +307,7 @@
   (reject-reserved-rf-head! k element)
   (let [n (cache-key k)]
     (if (and (not (reserved-prop-key? n))
-             (.hasOwnProperty tag-name-cache n))
+             (own-key? tag-name-cache n))
       (aget tag-name-cache n)
       (let [v (parse-tag k element)]
         (when-not (reserved-prop-key? n)
@@ -363,7 +383,7 @@
         (reserved-prop-key? n) n
 
         :else
-        (if-some [cached (when (.hasOwnProperty prop-name-cache n)
+        (if-some [cached (when (own-key? prop-name-cache n)
                            (aget prop-name-cache n))]
           cached
           (let [v (dash-to-prop-name k)]

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
@@ -899,3 +899,57 @@
       (doseq [k ["__proto__" "constructor" "prototype"]]
         (is (not (.call (.. js/Object -prototype -hasOwnProperty) out k))
             (str "reserved key '" k "' is not an own property"))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-tsuk6: an ACCEPTED tag/prop name must not poison the shared caches
+;;
+;; `tag-name-cache` and `prop-name-cache` are plain `#js {}` objects keyed on
+;; user-controlled names. String Hiccup heads are accepted, so "hasOwnProperty"
+;; is a valid head; prop-key names are accepted, so `{:hasOwnProperty x}` is a
+;; valid prop. Testing a cache hit with `(.hasOwnProperty cache n)` reads the
+;; method OFF the cache object, so caching an entry NAMED "hasOwnProperty"
+;; `aset`s a value under that own-property name and shadows the method — and
+;; the NEXT lookup then invokes that value as a function and throws a raw host
+;; TypeError, taking down every later render until reload. The fix tests
+;; membership with `Object.prototype.hasOwnProperty.call(cache, n)`, which no
+;; cache entry can shadow.
+;;
+;; The lever is ORDER: seed the "hasOwnProperty"-named entry FIRST (that render
+;; succeeds and shadows the method), THEN render an ordinary tag/prop — before
+;; the fix that second render throws; after it, it parses normally. The tests
+;; assert the OBSERVABLE parse result (`.-type` / `props`) of BOTH renders, so
+;; a spurious-crash is distinguished from a correct-parse (not vacuous: a stub
+;; returning nil would fail the type assertions).
+;; ---------------------------------------------------------------------------
+
+(deftest tag-name-cache-accepts-hasownproperty-head-rf2-tsuk6
+  (testing "rf2-tsuk6: caching the accepted string head \"hasOwnProperty\"
+            does not break the NEXT tag lookup"
+    ;; Seed FIRST: this render succeeds and, pre-fix, `aset`s a HiccupTag
+    ;; under the own-property name "hasOwnProperty", shadowing the method.
+    (let [^js seeded (template/as-element ["hasOwnProperty" "first"])]
+      (is (= "hasOwnProperty" (.-type seeded))
+          "the accepted string head renders as its own custom element"))
+    ;; The very next ordinary lookup must parse normally. Pre-fix,
+    ;; `(.hasOwnProperty tag-name-cache \"div\")` invokes the shadowing
+    ;; HiccupTag as a function → raw TypeError; the render never returns.
+    (let [^js el (template/as-element ["div" "second"])]
+      (is (= "div" (.-type el))
+          "the subsequent ordinary tag renders correctly, not a TypeError"))))
+
+(deftest prop-name-cache-accepts-hasownproperty-key-rf2-tsuk6
+  (testing "rf2-tsuk6: caching the accepted prop key :hasOwnProperty does
+            not break the NEXT prop-name lookup"
+    ;; Seed FIRST: `cached-prop-name :hasOwnProperty` `aset`s "hasOwnProperty"
+    ;; under that own-property name in prop-name-cache, shadowing the method.
+    (let [^js seeded (template/as-element [:div {:hasOwnProperty "x"}])]
+      (is (= "div" (.-type seeded))
+          "an element carrying a :hasOwnProperty prop renders"))
+    ;; The next element with ANY prop must convert normally. Pre-fix,
+    ;; `(.hasOwnProperty prop-name-cache \"class\")` invokes the shadowing
+    ;; string as a function → raw TypeError.
+    (let [^js el (template/as-element [:span {:class "c"}])]
+      (is (= "span" (.-type el))
+          "the subsequent element parses, not a TypeError")
+      (is (= "c" (.. el -props -className))
+          "and its prop still camelCases through prop-name-cache"))))


### PR DESCRIPTION
## Problem

`reagent2.impl.template/tag-name-cache` and `prop-name-cache` are plain `#js {}` objects keyed on user-controlled names. String Hiccup heads are accepted, so `"hasOwnProperty"` is a valid tag head; prop-key names are accepted, so `{:hasOwnProperty x}` is a valid prop. Both caches tested a hit with `(.hasOwnProperty cache n)`, which reads the method **off the cache object**. Caching an entry literally named `"hasOwnProperty"` `aset`s a value under that own-property name and **shadows the method** — the very next lookup then invokes that value as a function and throws a raw host `TypeError`, taking down every later render until reload.

(The lookup itself was correct — `.hasOwnProperty` checks own props, so inherited prototype keys such as `constructor`/`toString` never falsely hit. The defect is the shadowing of the method by an accepted own-key name, exactly as `bd show rf2-tsuk6` describes.)

## Fix (minimal)

A single private `own-key?` helper tests membership with `Object.prototype.hasOwnProperty.call(cache, n)` — an unspoofable check no cache entry can shadow — and both lookup sites call it. The sibling `prop-name-cache` carries the *exact same* pattern and is equally reachable (via a `:hasOwnProperty` prop key), so it is widened per the bead's bounded solution.

- **#6478's reserved-`:rf/*` head reject ordering** (run before the lookup in `cached-parse`) is untouched — this change is the cache's KEY SPACE, not the lookup order.
- The **rf2-dwds9 reserved-prop-key guards** are untouched.
- No cache subsystem, map wrapper, or public API introduced. The helper matches the file's existing `(.call (.. js/Object -prototype -hasOwnProperty) …)` idiom (already used in the rf2-dwds9 tests).

## Proof

Two focused regressions in `template_cljs_test.cljs`. Each seeds the accepted `"hasOwnProperty"` tag head / `:hasOwnProperty` prop key FIRST (that render succeeds and shadows the method), then renders an ordinary tag/prop and asserts the **observable** parse result (`.-type` / `props`) of both renders — not vacuous (a stub returning nil fails the type assertions).

- **Red-before** (reverted to `.hasOwnProperty`): `Ran 10318 tests … 0 failures, 8 errors` — both new tests plus 6 cascade errors, all `TypeError: …tag_name_cache.hasOwnProperty is not a function` (the broad SPA impact: one poisoned tag breaks every later render).
- **Green-after**: `Ran 10318 tests containing 50876 assertions. 0 failures, 0 errors.`

## Quality gates

All foreground, run to completion:

| Gate | Result |
| --- | --- |
| `npm run test:cljs` | 10318 tests / 50876 assertions — 0 failures, 0 errors |
| reagent-slim JVM (`clojure -M:test`) | 11 tests — 0 failures, 0 errors |
| `npm run test:reagent-slim:bundle-isolation` | PASS — slim free of stock Reagent/react-dom/server |
| `npm run test:bundle-isolation` | PASS (all sub-checks) |
| `npm run test:browser-prod-elision` | ui mounted prod elision PASS; 113 tests — 0 failures |
| `npm run test:adapter-smokes` | 3 adapter mount+dispatch specs — 0 failures |

Closes rf2-tsuk6.
