### PR TITLE
test(ui): real Shadow warm-watch fixture proving harvest topology identity (rf2-tm1xi)

### DIFF
--- a/implementation/package.json
+++ b/implementation/package.json
@@ -32,6 +32,7 @@
     "test:ui-isolation": "node scripts/check-ui-adapter-isolation.cjs --self-test && shadow-cljs compile node-test-ui && node scripts/check-ui-adapter-isolation.cjs",
     "test:ui-digest-carrier": "node scripts/check-ui-digest-carrier.cjs",
     "test:ui-final-schedule": "node scripts/check-ui-final-schedule.cjs",
+    "test:ui-warm-watch": "node scripts/check-ui-warm-watch.cjs",
     "test:ui-advanced-elision": "node scripts/check-ui-advanced-elision.cjs",
     "test:ui-g1": "node scripts/run-ui-bench.cjs",
     "test:ui-g13": "node scripts/run-ui-g13.cjs",

--- a/implementation/scripts/check-ui-warm-watch.cjs
+++ b/implementation/scripts/check-ui-warm-watch.cjs
@@ -1,0 +1,463 @@
+#!/usr/bin/env node
+'use strict';
+
+// rf2-tm1xi (Arm 2 of rf2-4vm19) — a real Shadow 3.4.10 warm-watch/file-edit
+// fixture proving the re-frame.ui custom-element HARVEST TOPOLOGY survives real
+// warm edits, and that a removed/renamed saved source's `:build-sources` graph
+// delta evicts (or re-owns) its runtime declarations. It complements the
+// synthetic JVM fixtures (compiler_harvest_hook_jvm_test / custom_element_
+// warm_staleness_jvm_test), which hand-build build state and cannot exercise a
+// real Shadow watch, real inherited-then-build-local hook deep-merge, or real
+// file delete/rename/move.
+//
+// Per the rf2-4vm19 Arm-1 ruling the build-topology obligation is proving ONE
+// real dev build's identity at the runtime seam — a non-::default build id, the
+// inherited hook's discovery/order, and stage-annotation load-bearingness — NOT
+// two-build isolation (a broken realm Shadow does not support). This gate reads
+// only the accepted topology re-frame.ui's inherited hook establishes; a
+// build-local OBSERVE hook (deep-merged AFTER, never mutating build state)
+// records it at :compile-finish.
+//
+// ONE warm daemon is walked, via real file edits, through:
+//   1. COLD ACCEPT — card declares :probe-card #{:model :size}, leaf declares
+//      :probe-leaf #{:flag}, the no-require-edge view consumes :probe-card. The
+//      accepted build id is :ui-warm-watch (never ::default): the inherited hook
+//      ran and its stage annotation is load-bearing.
+//   2. ZERO-DECLARATION warm pass — a viewless/declarationless trigger edit. The
+//      manifest is unchanged, the consumer view is a warm cache hit (coarse
+//      invalidation does NOT over-fire), the digest is stable.
+//   3. DECLARATION-SHRINK warm pass — card drops :size. The harvest re-reads card
+//      (manifest :probe-card -> #{:model}) and the coarse manifest-change
+//      invalidation RECOMPILES the no-require-edge consumer view so it re-bakes;
+//      the digest moves. If the warm rebuild failed to re-harvest, the manifest
+//      would still read #{:model :size} -> RED.
+//   4. SAME-NAMESPACE FILE MOVE — leaf.cljs is relocated to the fixture's second
+//      source-path root, keeping its namespace. Because re-frame.ui's eviction
+//      unit is the declaring NAMESPACE (not the resource/file), :probe-leaf's
+//      ownership survives the file move: it stays in the manifest and `…leaf`
+//      stays in `:build-sources`.
+//   5. RENAME — leaf's namespace becomes `…leaf-renamed` and the client `:require`
+//      is repointed. The old namespace leaves `:build-sources`, the new one
+//      enters, and :probe-leaf is re-owned by the renamed namespace.
+//   6. DELETE — the renamed source and its client `:require` are removed. Its
+//      namespace leaves `:build-sources` with no successor, so :probe-leaf is
+//      EVICTED from the accepted manifest — the removed saved-source graph delta,
+//      applied with no page reload.
+//   7. FAILED COMPILE — card is rewritten to a syntax error. The build fails,
+//      no candidate is finalized (no new :finish record), and the accepted
+//      last-known-good manifest is preserved.
+//   8. SUCCESSFUL RETRY — card is fixed. The build converges clean and the
+//      manifest matches the last good state (:probe-card #{:model}).
+//
+// TEETH (documented mutation/revert; run at development time, NOT committed):
+//   * Drop the `{:shadow.build/stages …}` annotation on
+//     re-frame.ui.compiler.build-hook/hook -> Shadow never runs the inherited
+//     hook -> the accepted build id falls back to ::default and no manifest is
+//     established -> COLD ACCEPT goes RED (annotation load-bearingness).
+//   * Delete the `build/seed-shadow-elements (harvest-seed …)` call (or the whole
+//     harvest) -> :probe-card is never seeded, so COLD ACCEPT's card-props read
+//     `nil`/attributes -> RED (the real source producer is load-bearing).
+//   * Delete the `(reconcile-declaration-edits build-state)` call -> the
+//     DECLARATION-SHRINK pass no longer recompiles the no-require-edge view
+//     (view-output-present stays true) and the stale manifest is not re-baked
+//     -> RED (coarse invalidation).
+//   * Break `keep-members`/membership eviction in shadow-finish-candidate -> the
+//     DELETE pass keeps :probe-leaf's ghost declaration (leaf-tag-present stays
+//     true) -> RED (the `:build-sources` delta).
+// All were exercised red-before-green during development.
+
+const fs = require('fs');
+const path = require('path');
+const {
+  spawnHarnessProcess,
+  terminateProcessTree,
+} = require('./lib/local-browser-harness.cjs');
+
+const IMPL = path.join(__dirname, '..');
+const FIX = path.join(
+  IMPL, 'ui', 'test', 're_frame', 'ui', 'digest_probe', 'warm_watch',
+);
+const CLIENT = path.join(FIX, 'client.cljs');
+const CARD = path.join(FIX, 'card.cljs');
+const VIEW = path.join(FIX, 'view.cljs');
+const TRIGGER = path.join(FIX, 'trigger.cljs');
+const LEAF = path.join(FIX, 'leaf.cljs');
+const ALT_LEAF = path.join(
+  FIX, 'alt_src', 're_frame', 'ui', 'digest_probe', 'warm_watch', 'leaf.cljs',
+);
+const LEAF_RENAMED = path.join(FIX, 'leaf_renamed.cljs');
+const TARGET = path.join(IMPL, 'target', 'ui-warm-watch');
+const OUT = path.join(IMPL, 'out', 'ui-warm-watch');
+const BUILD_ID = 'ui-warm-watch';
+const TIMEOUT = 120000;
+
+function fail(message) {
+  throw new Error(`FAIL: ${message}`);
+}
+
+function observeFile() {
+  return path.join(TARGET, `observe-${BUILD_ID}.jsonl`);
+}
+function readRecords() {
+  const f = observeFile();
+  if (!fs.existsSync(f)) return [];
+  return fs.readFileSync(f, 'utf8').trim().split(/\r?\n/).filter(Boolean);
+}
+function bool(line, key) {
+  const m = line.match(new RegExp(`:${key} (true|false)`));
+  return m ? m[1] === 'true' : null;
+}
+function num(line, key) {
+  const m = line.match(new RegExp(`:${key} (-?\\d+)`));
+  return m ? Number(m[1]) : null;
+}
+function str(line, key) {
+  const m = line.match(new RegExp(`:${key} "([^"]*)"`));
+  return m ? m[1] : null;
+}
+function lastOfStage(stage) {
+  const recs = readRecords().filter((l) => l.includes(`:stage :${stage}`));
+  return recs.length ? recs[recs.length - 1] : null;
+}
+function countStage(stage) {
+  return readRecords().filter((l) => l.includes(`:stage :${stage}`)).length;
+}
+
+// --- real source edits ------------------------------------------------------
+
+function editTrigger(marker) {
+  const src = fs.readFileSync(TRIGGER, 'utf8');
+  const next = src
+    .replace(/warm-watch-trigger-marker:\S+/, `warm-watch-trigger-marker:${marker}`)
+    .replace(/\(def trigger :\S+\)/, `(def trigger :${marker})`);
+  if (next === src) fail(`trigger edit was a no-op for marker ${marker}`);
+  fs.writeFileSync(TRIGGER, next);
+}
+
+// Rewrite the whole card source. A full write (not a regex patch) is used so the
+// same edit can both SHRINK a well-formed declaration and REPAIR the broken card
+// on the successful-retry pass.
+function writeCard(image, marker) {
+  fs.writeFileSync(CARD,
+    '(ns re-frame.ui.digest-probe.warm-watch.card\n'
+    + '  (:require [re-frame.ui :as ui]))\n'
+    + `;; warm-watch-card-properties:${marker}\n`
+    + `(ui/custom-element :probe-card {:properties ${image}})\n`);
+}
+
+function breakCard() {
+  fs.writeFileSync(CARD,
+    '(ns re-frame.ui.digest-probe.warm-watch.card\n'
+    + '  (:require [re-frame.ui :as ui]))\n'
+    + ';; warm-watch-card-properties:broken\n'
+    + '(ui/custom-element :probe-card {:properties #{:model\n'); // unbalanced
+}
+
+// Replace the client's require block between the sentinel comments.
+function setClientLeaf(mode) {
+  const src = fs.readFileSync(CLIENT, 'utf8');
+  const lines = {
+    leaf: '            [re-frame.ui.digest-probe.warm-watch.leaf]',
+    'leaf-renamed': '            [re-frame.ui.digest-probe.warm-watch.leaf-renamed]',
+    none: null,
+  };
+  const body = [
+    '            ;; warm-watch-client-requires:start',
+    '            [re-frame.ui.digest-probe.warm-watch.card]',
+    '            [re-frame.ui.digest-probe.warm-watch.view]',
+    ...(lines[mode] ? [lines[mode]] : []),
+    '            ;; warm-watch-client-requires:end',
+  ].join('\n');
+  const next = src.replace(
+    /\s*;; warm-watch-client-requires:start[\s\S]*?;; warm-watch-client-requires:end/,
+    `\n${body}`,
+  );
+  if (next === src) fail(`client require edit was a no-op for mode ${mode}`);
+  fs.writeFileSync(CLIENT, next);
+}
+
+// --- shadow watch driver (mirrors check-ui-final-schedule.cjs) ---------------
+
+function watch() {
+  const child = spawnHarnessProcess(process.execPath, [
+    require.resolve('shadow-cljs/cli/runner.js', { paths: [IMPL] }),
+    'watch', BUILD_ID,
+  ], { cwd: FIX, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
+
+  let successes = 0;
+  let failures = 0;
+  let transcript = '';
+  let buf = '';
+  const waiters = [];
+  function settle() {
+    for (let i = waiters.length - 1; i >= 0; i -= 1) {
+      const w = waiters[i];
+      const c = w.kind === 'success' ? successes : failures;
+      if (c > w.after) { clearTimeout(w.timer); waiters.splice(i, 1); w.resolve(c); }
+    }
+  }
+  function ingest(chunk) {
+    const t = chunk.toString();
+    transcript += t;
+    process.stdout.write(t);
+    const lines = (buf + t).split(/\r?\n/);
+    buf = lines.pop();
+    for (const l of lines) {
+      if (l.includes(`[:${BUILD_ID}] Build completed.`)) successes += 1;
+      if (l.includes(`[:${BUILD_ID}] Build failure:`)) failures += 1;
+    }
+    settle();
+  }
+  child.stdout.on('data', ingest);
+  child.stderr.on('data', ingest);
+  child.on('exit', (code, signal) => {
+    const err = new Error(
+      `shadow watch exited before proof completed (code=${code}, signal=${signal})`,
+    );
+    while (waiters.length) { const w = waiters.pop(); clearTimeout(w.timer); w.reject(err); }
+  });
+  function wait(kind, after) {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(
+        `timed out waiting for ${kind} after count ${after}\n${transcript.slice(-3000)}`,
+      )), TIMEOUT);
+      waiters.push({ kind, after, resolve, reject, timer });
+      settle();
+    });
+  }
+  return {
+    child,
+    waitSuccess: (after) => wait('success', after),
+    waitFailure: (after) => wait('failure', after),
+    successCount: () => successes,
+    failureCount: () => failures,
+    transcript: () => transcript,
+  };
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function awaitRecord(stage, priorCount) {
+  for (let i = 0; i < 100; i += 1) {
+    if (countStage(stage) > priorCount) return;
+    await sleep(50);
+  }
+  fail(`no new :${stage} observe record appeared`);
+}
+
+// --- the proof --------------------------------------------------------------
+
+let digestPrev;
+
+async function coldAccept(w) {
+  await w.waitSuccess(0);
+  await awaitRecord('finish', 0);
+  const fin = lastOfStage('finish');
+  if (str(fin, 'accepted-build-id') !== ':ui-warm-watch') {
+    fail(`cold accept: accepted build id is not the real dev build id (${str(fin, 'accepted-build-id')})`);
+  }
+  if (str(fin, 'card-props') !== '[:model :size]') {
+    fail(`cold accept: :probe-card did not harvest #{:model :size} (${str(fin, 'card-props')})`);
+  }
+  if (str(fin, 'leaf-props') !== '[:flag]' || bool(fin, 'leaf-tag-present') !== true) {
+    fail(`cold accept: :probe-leaf not declared (${fin})`);
+  }
+  if (!(bool(fin, 'member-card') && bool(fin, 'member-leaf') && bool(fin, 'member-view'))) {
+    fail(`cold accept: a probe namespace is missing from :build-sources (${fin})`);
+  }
+  if (bool(fin, 'view-present') !== true) fail(`cold accept: the consumer view is missing (${fin})`);
+  const digest0 = str(fin, 'digest');
+  if (!/^bd1-[0-9a-f]{16}$/.test(digest0)) fail(`cold accept: digest invalid (${digest0})`);
+  digestPrev = digest0;
+  console.log(`  cold accept: build id ${str(fin, 'accepted-build-id')}, :probe-card #{:model :size}, :probe-leaf #{:flag}, digest ${digest0}`);
+}
+
+async function zeroDeclarationPass(w) {
+  const sc = w.successCount();
+  const fc = countStage('finish');
+  editTrigger('control');
+  await w.waitSuccess(sc);
+  await awaitRecord('finish', fc);
+  const prep = lastOfStage('prepare');
+  const fin = lastOfStage('finish');
+  if (bool(prep, 'view-output-present') !== true) {
+    fail(`zero-declaration: coarse invalidation over-fired on a non-declaration edit (${prep})`);
+  }
+  if (str(fin, 'card-props') !== '[:model :size]' || str(fin, 'leaf-props') !== '[:flag]') {
+    fail(`zero-declaration: a viewless edit perturbed the manifest (${fin})`);
+  }
+  if (str(fin, 'digest') !== digestPrev) {
+    fail(`zero-declaration: a viewless edit moved the digest (${str(fin, 'digest')} != ${digestPrev})`);
+  }
+  console.log('  zero-declaration pass: manifest + digest stable, consumer view a warm cache hit');
+}
+
+async function declarationShrinkPass(w) {
+  const sc = w.successCount();
+  const fc = countStage('finish');
+  writeCard('#{:model}', 'model');
+  await w.waitSuccess(sc);
+  await awaitRecord('finish', fc);
+  const prep = lastOfStage('prepare');
+  const fin = lastOfStage('finish');
+  if (str(fin, 'card-props') !== '[:model]') {
+    fail(`declaration-shrink: the warm rebuild did not re-harvest :probe-card (${str(fin, 'card-props')})`);
+  }
+  if (bool(prep, 'view-output-present') !== false) {
+    fail(`declaration-shrink: coarse invalidation did not recompile the no-require-edge consumer view (${prep})`);
+  }
+  if (str(fin, 'digest') === digestPrev) {
+    fail(`declaration-shrink: shrinking :probe-card did not move the digest (${str(fin, 'digest')})`);
+  }
+  digestPrev = str(fin, 'digest');
+  console.log(`  declaration-shrink pass: :probe-card -> #{:model}, consumer view re-baked (coarse invalidation), digest ${digestPrev}`);
+}
+
+async function sameNamespaceMovePass(w) {
+  const sc = w.successCount();
+  const fc = countStage('finish');
+  fs.mkdirSync(path.dirname(ALT_LEAF), { recursive: true });
+  fs.renameSync(LEAF, ALT_LEAF); // same namespace, new source-path root
+  await w.waitSuccess(sc);
+  await awaitRecord('finish', fc);
+  const fin = lastOfStage('finish');
+  if (bool(fin, 'leaf-tag-present') !== true || str(fin, 'leaf-props') !== '[:flag]') {
+    fail(`same-namespace move: :probe-leaf's ownership did not survive the file move (${fin})`);
+  }
+  if (bool(fin, 'member-leaf') !== true) {
+    fail(`same-namespace move: the moved namespace left :build-sources (${fin})`);
+  }
+  console.log('  same-namespace file move: :probe-leaf ownership preserved (eviction unit is the namespace, not the file)');
+}
+
+async function renamePass(w) {
+  const sc = w.successCount();
+  const fc = countStage('finish');
+  fs.writeFileSync(LEAF_RENAMED,
+    '(ns re-frame.ui.digest-probe.warm-watch.leaf-renamed\n'
+    + '  (:require [re-frame.ui :as ui]))\n'
+    + '(ui/custom-element :probe-leaf {:properties #{:flag}})\n');
+  setClientLeaf('leaf-renamed');
+  fs.rmSync(ALT_LEAF, { force: true });
+  await w.waitSuccess(sc);
+  await awaitRecord('finish', fc);
+  const fin = lastOfStage('finish');
+  if (bool(fin, 'member-leaf') !== false) {
+    fail(`rename: the old namespace was not removed from :build-sources (${fin})`);
+  }
+  if (bool(fin, 'member-leaf-renamed') !== true) {
+    fail(`rename: the renamed namespace did not enter :build-sources (${fin})`);
+  }
+  if (bool(fin, 'leaf-tag-present') !== true) {
+    fail(`rename: :probe-leaf was lost across a namespace rename (${fin})`);
+  }
+  console.log('  rename: `…leaf` -> `…leaf-renamed` in :build-sources, :probe-leaf re-owned by the renamed namespace');
+}
+
+async function deletePass(w) {
+  const sc = w.successCount();
+  const fc = countStage('finish');
+  setClientLeaf('none');
+  fs.rmSync(LEAF_RENAMED, { force: true });
+  await w.waitSuccess(sc);
+  await awaitRecord('finish', fc);
+  const fin = lastOfStage('finish');
+  if (bool(fin, 'member-leaf-renamed') !== false) {
+    fail(`delete: the deleted namespace remained in :build-sources (${fin})`);
+  }
+  if (bool(fin, 'leaf-tag-present') !== false) {
+    fail(`delete: :probe-leaf's ghost declaration survived (the :build-sources delta did not evict it) (${fin})`);
+  }
+  if (str(fin, 'card-props') !== '[:model]') {
+    fail(`delete: an unrelated declaration was disturbed (${fin})`);
+  }
+  console.log('  delete: `…leaf-renamed` left :build-sources, :probe-leaf evicted from the manifest with no page reload');
+}
+
+async function failedCompileThenRetry(w) {
+  // FAILED COMPILE — last-known-good manifest preserved.
+  const failBefore = w.failureCount();
+  const finBefore = countStage('finish');
+  breakCard();
+  await w.waitFailure(failBefore);
+  await sleep(300);
+  if (countStage('finish') !== finBefore) {
+    fail('failed-compile: a candidate was finalized despite a compile failure');
+  }
+  console.log('  failed compile: build failed, no candidate finalized, last-known-good manifest preserved');
+
+  // SUCCESSFUL RETRY — converges clean at the last good manifest.
+  const sc = w.successCount();
+  writeCard('#{:model}', 'model'); // rewrites the broken file to the good #{:model} form
+  await w.waitSuccess(sc);
+  await awaitRecord('finish', finBefore);
+  const fin = lastOfStage('finish');
+  if (str(fin, 'card-props') !== '[:model]') {
+    fail(`retry: the fixed build did not converge to the last good manifest (${str(fin, 'card-props')})`);
+  }
+  if (!/^bd1-[0-9a-f]{16}$/.test(str(fin, 'digest'))) {
+    fail(`retry: converged digest invalid (${str(fin, 'digest')})`);
+  }
+  console.log('  successful retry: build converged clean, :probe-card #{:model}');
+}
+
+async function drive() {
+  console.log(`\n=== ${BUILD_ID} (real warm watch, parallel compile schedule) ===`);
+  const w = watch();
+  try {
+    await coldAccept(w);
+    await zeroDeclarationPass(w);
+    await declarationShrinkPass(w);
+    await sameNamespaceMovePass(w);
+    await renamePass(w);
+    await deletePass(w);
+    await failedCompileThenRetry(w);
+    console.log(`  PASS ${BUILD_ID}`);
+  } finally {
+    await terminateProcessTree(w.child, { timeoutMs: 5000 });
+  }
+}
+
+let originals;
+
+function snapshot() {
+  originals = {
+    [CLIENT]: fs.readFileSync(CLIENT, 'utf8'),
+    [CARD]: fs.readFileSync(CARD, 'utf8'),
+    [VIEW]: fs.readFileSync(VIEW, 'utf8'),
+    [TRIGGER]: fs.readFileSync(TRIGGER, 'utf8'),
+    [LEAF]: fs.readFileSync(LEAF, 'utf8'),
+  };
+}
+
+function restore() {
+  for (const [p, content] of Object.entries(originals)) fs.writeFileSync(p, content);
+  fs.rmSync(ALT_LEAF, { force: true });
+  fs.rmSync(LEAF_RENAMED, { force: true });
+}
+
+async function run() {
+  snapshot();
+  if (!/warm-watch-trigger-marker:v1/.test(originals[TRIGGER])) {
+    fail('trigger fixture is not at its checked-in v1 marker');
+  }
+  // Fresh slate: a prior run's cache/output/markers must not mask a regression.
+  fs.rmSync(TARGET, { recursive: true, force: true });
+  fs.rmSync(OUT, { recursive: true, force: true });
+  fs.mkdirSync(TARGET, { recursive: true });
+  try {
+    await drive();
+    console.log('\nui warm-watch harvest topology: PASS');
+  } finally {
+    restore();
+  }
+}
+
+module.exports = { run };
+
+if (require.main === module) {
+  run().catch((error) => {
+    console.error(error.stack || error.message || String(error));
+    process.exitCode = 1;
+  });
+}

--- a/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/alt_src/re_frame/ui/digest_probe/warm_watch/.gitkeep
+++ b/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/alt_src/re_frame/ui/digest_probe/warm_watch/.gitkeep
@@ -1,0 +1,4 @@
+Second source-path root for the same-namespace file-move pass of
+check-ui-warm-watch.cjs. The runner relocates leaf.cljs here (keeping its
+namespace) to prove ownership survives a file move; the tree is kept so Shadow
+watches it from daemon start. No committed source lives here.

--- a/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/card.cljs
+++ b/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/card.cljs
@@ -1,0 +1,13 @@
+(ns re-frame.ui.digest-probe.warm-watch.card
+  "The declaring source under test. The runner rewrites the single properties
+  marker below on a warm pass to SHRINK :probe-card's property set, so the harvest
+  must re-read this source and the coarse manifest-change invalidation must
+  re-bake the (no-`:require`-edge) consumer view against the new manifest.
+
+  A syntax-broken variant of this file drives the failed-compile / successful-
+  retry pass: while it does not compile, no candidate is finalized and the
+  accepted last-known-good manifest is preserved."
+  (:require [re-frame.ui :as ui]))
+
+;; warm-watch-card-properties:model+size
+(ui/custom-element :probe-card {:properties #{:model :size}})

--- a/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/client.cljs
+++ b/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/client.cljs
@@ -1,0 +1,17 @@
+(ns re-frame.ui.digest-probe.warm-watch.client
+  "The UI-client entry that pulls the compiler-owned digest carrier and every
+  fixture source into ONE real Shadow dev build graph, so `ui-client-build?`
+  holds and re-frame.ui projects a whole-build digest over the accepted
+  custom-element manifest and view aggregate.
+
+  The runner rewrites the `:require` list below to drop `leaf` (on the RENAME and
+  DELETE passes) so the removed/renamed saved source really leaves Shadow's
+  authoritative `:build-sources`; every other pass leaves this file untouched."
+  (:require [re-frame.ui.client]
+            [re-frame.ui.digest-carrier]
+            ;; warm-watch-client-requires:start
+            [re-frame.ui.digest-probe.warm-watch.card]
+            [re-frame.ui.digest-probe.warm-watch.view]
+            [re-frame.ui.digest-probe.warm-watch.leaf]
+            ;; warm-watch-client-requires:end
+            [re-frame.ui.digest-probe.warm-watch.trigger]))

--- a/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/hook.clj
+++ b/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/hook.clj
@@ -1,0 +1,119 @@
+(ns re-frame.ui.digest-probe.warm-watch.hook
+  "Test-only OBSERVE hook for the real Shadow warm-watch/file-edit fixture
+  (rf2-tm1xi, Arm 2 of rf2-4vm19).
+
+  Deep-merged AFTER the inherited re-frame.ui compile hook (configured in
+  :build-defaults), so at every stage Shadow runs re-frame.ui's hook FIRST and
+  this one SECOND — the real inherited-then-build-local deep-merge/order a real
+  consumer build produces, proved by config rather than by a hand-built
+  build-state. It NEVER mutates build state: it only reads re-frame.ui's accepted
+  compiler topology and appends it to a JSONL the runner parses.
+
+  What it records is the observable build-topology the runner asserts survives
+  each real warm edit, per the rf2-4vm19 Arm-1 ruling — proving ONE real dev
+  build's identity at the runtime seam, NOT two-build isolation:
+
+  * :accepted-build-id — the build id re-frame.ui stamped onto the accepted
+    snapshot. For this real dev build it is `:ui-warm-watch`, never `::default`;
+    a fallback to `::default` (or a bare name mismatch) means the inherited hook
+    never ran or its stage annotation was dropped — the annotation load-bearing
+    proof.
+  * the accepted custom-element manifest (:probe-card / :probe-leaf properties)
+    — a pure function of the build's declarations after the harvest, so a shrink
+    that the warm rebuild failed to re-harvest, or an eviction that a
+    `:build-sources` delta failed to apply, is directly visible.
+  * `:build-sources` membership for each probe namespace — the compile-side
+    Shadow authority whose delta must evict a removed/renamed owner.
+  * whether the no-`:require`-edge consumer view is recompiling THIS pass — the
+    coarse manifest-change invalidation witness.
+
+  Pure JVM dev-build tooling; never part of any CLJS bundle."
+  (:require [clojure.java.io :as io]
+            [re-frame.ui.compiler.build :as build]))
+
+;; Shadow runs with CWD = this fixture directory (the runner spawns it there),
+;; so climb back to implementation/target — the same gitignored tree the
+;; :cache-root uses — rather than littering target under the test source tree.
+(def ^:private out-dir
+  (io/file "../../../../../../target" "ui-warm-watch"))
+
+(def ^:private card-ns 're-frame.ui.digest-probe.warm-watch.card)
+(def ^:private view-ns 're-frame.ui.digest-probe.warm-watch.view)
+(def ^:private leaf-ns 're-frame.ui.digest-probe.warm-watch.leaf)
+(def ^:private leaf-renamed-ns 're-frame.ui.digest-probe.warm-watch.leaf-renamed)
+(def ^:private card-tag :probe-card)
+(def ^:private leaf-tag :probe-leaf)
+(def ^:private view-id :re-frame.ui.digest-probe.warm-watch.view/probe-view)
+
+(defn- observe-file [build-id]
+  (io/file out-dir (str "observe-" (name build-id) ".jsonl")))
+
+(defn- record! [build-id m]
+  (let [f (observe-file build-id)]
+    (io/make-parents f)
+    (spit f (str (pr-str (assoc m :build-id (name build-id))) "\n") :append true)))
+
+(defn- source-rid
+  "The build resource-id whose declaring namespace is `ns-sym`, or nil."
+  [{:keys [build-sources sources]} ns-sym]
+  (some (fn [rid] (when (= ns-sym (get-in sources [rid :ns])) rid))
+        build-sources))
+
+(defn- member-nss
+  "The declaring namespaces of Shadow's authoritative `:build-sources` — the
+  compile-side membership whose delta re-frame.ui's eviction is keyed on."
+  [{:keys [build-sources sources]}]
+  (reduce (fn [acc rid]
+            (let [rc (get sources rid)]
+              (into acc (or (:provides rc)
+                            (when-let [n (:ns rc)] #{n})))))
+          #{}
+          build-sources))
+
+(defn- props-image
+  "A stable, runner-parseable image of `tag`'s accepted :properties (a sorted
+  vector), or \"nil\" when the tag has no accepted declaration."
+  [manifest tag]
+  (if-let [decl (get manifest tag)]
+    (pr-str (vec (sort (:properties decl))))
+    "nil"))
+
+(defn hook
+  {:shadow.build/stages #{:compile-prepare :compile-finish}}
+  [{build-id :shadow.build/build-id
+    stage    :shadow.build/stage
+    :as      build-state}]
+  (case stage
+    :compile-prepare
+    ;; re-frame.ui's inherited hook has already run its coarse manifest-change
+    ;; invalidation, so a view scheduled to recompile has had its retained output
+    ;; removed. Record whether the no-require-edge consumer view is recompiling
+    ;; this pass: present output = warm cache hit; absent = coarse invalidation
+    ;; forced a re-bake.
+    (let [view-rid (source-rid build-state view-ns)]
+      (record! build-id
+               {:stage :prepare
+                :view-output-present (some? (get-in build-state [:output view-rid]))})
+      build-state)
+
+    :compile-finish
+    (let [snap     (build/accepted-snapshot build-state)
+          manifest (build/accepted-aggregate build/elements build-state)
+          views    (build/accepted-aggregate build/views build-state)
+          members  (member-nss build-state)]
+      (record! build-id
+               {:stage :finish
+                :accepted-build-id (pr-str (:build-id snap))
+                :version (:version snap)
+                :digest (:digest snap)
+                :card-props (props-image manifest card-tag)
+                :leaf-props (props-image manifest leaf-tag)
+                :leaf-tag-present (contains? manifest leaf-tag)
+                :member-card (contains? members card-ns)
+                :member-leaf (contains? members leaf-ns)
+                :member-leaf-renamed (contains? members leaf-renamed-ns)
+                :member-view (contains? members view-ns)
+                :view-present (contains? views view-id)})
+      build-state)
+
+    build-state))

--- a/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/leaf.cljs
+++ b/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/leaf.cljs
@@ -1,0 +1,21 @@
+(ns re-frame.ui.digest-probe.warm-watch.leaf
+  "A leaf declaring source that no view consumes, so the runner can MOVE, RENAME,
+  and DELETE it through real file edits without breaking any consumer's compile.
+
+  * MOVE (same namespace, new file): the runner relocates this file to the
+    fixture's second source-path root, keeping the namespace `…warm-watch.leaf`.
+    Because Shadow's `:build-sources` membership — and hence re-frame.ui's
+    eviction unit — is keyed by the declaring NAMESPACE, not the resource/file,
+    :probe-leaf's ownership survives the file move unchanged.
+
+  * RENAME (namespace changes): the runner renames this source to
+    `…warm-watch.leaf-renamed` and updates the client's `:require`. The old
+    namespace leaves `:build-sources`, the new one enters, and :probe-leaf is
+    re-owned by the renamed namespace — the saved-source graph delta.
+
+  * DELETE: the runner removes the (renamed) file and its client `:require`. The
+    namespace leaves `:build-sources` with no successor, so :probe-leaf is evicted
+    from the accepted manifest with no page reload."
+  (:require [re-frame.ui :as ui]))
+
+(ui/custom-element :probe-leaf {:properties #{:flag}})

--- a/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/shadow-cljs.edn
+++ b/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/shadow-cljs.edn
@@ -1,0 +1,42 @@
+;; Real Shadow 3.4.10 fixture for the warm-watch/file-edit harvest-topology proof
+;; (rf2-tm1xi, Arm 2 of rf2-4vm19).
+;;
+;; A genuine UI client dev build whose INHERITED re-frame.ui compile hook
+;; (configured in :build-defaults, so Shadow deep-merges it FIRST) establishes the
+;; custom-element harvest topology, coarse manifest-change invalidation, and
+;; `:build-sources`-keyed eviction; a build-local OBSERVE hook (deep-merged AFTER)
+;; records the accepted topology at :compile-finish so the runner can assert it
+;; survives each real warm edit. Per the rf2-4vm19 Arm-1 ruling this proves ONE
+;; real dev build's identity at the runtime seam (a non-::default build id, the
+;; inherited-hook discovery/order, annotation load-bearingness) — NOT two-build
+;; isolation.
+;;
+;; Kept independent of implementation/shadow-cljs.edn on purpose (the same choice
+;; the sibling final-schedule fixture makes): its defining property is a REAL,
+;; inherited build-default hook running before a real build-local hook, proved by
+;; config rather than by a hand-built build-state. `alt_src` is a SECOND source-
+;; path root the runner relocates leaf.cljs into (keeping its namespace) to prove
+;; a same-namespace file move preserves ownership.
+{:source-paths ["../../../../../../core/src"
+                "../../../../../src"
+                "../../../.."
+                "alt_src"]
+ :cache-root "../../../../../../target/ui-warm-watch/shadow-cache"
+ :cache-blockers #{re-frame.ui}
+ :js-options {:js-package-dirs ["../../../../../../node_modules"]}
+ ;; The production compile hook is inherited here EXACTLY as real consumer builds
+ ;; inherit it — from :build-defaults — so Shadow deep-merges it ahead of this
+ ;; build's own :build-hooks.
+ :build-defaults {:build-hooks [(re-frame.ui.compiler.build-hook/hook)]}
+ :builds
+ {:ui-warm-watch
+  {:target :browser
+   :output-dir "../../../../../../out/ui-warm-watch"
+   :asset-path "."
+   :modules
+   {:main {:entries [re-frame.ui.digest-probe.warm-watch.client]}}
+   ;; Deep-merged AFTER the inherited re-frame.ui compile hook: this build-local
+   ;; OBSERVE hook records the accepted topology at :compile-finish (and the
+   ;; consumer-recompile witness at :compile-prepare) without mutating build
+   ;; state.
+   :build-hooks [(re-frame.ui.digest-probe.warm-watch.hook/hook)]}}}

--- a/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/trigger.cljs
+++ b/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/trigger.cljs
@@ -1,0 +1,9 @@
+(ns re-frame.ui.digest-probe.warm-watch.trigger
+  "A VIEWLESS, declarationless source the runner rewrites to drive a warm watch
+  pass WITHOUT any custom-element manifest delta. Editing it must move nothing in
+  the manifest and must NOT trigger the coarse consumer invalidation, so it is the
+  zero-declaration warm-edit proof and the control against which a real
+  declaration edit is measured.")
+
+;; warm-watch-trigger-marker:v1
+(def trigger :v1)

--- a/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/view.cljs
+++ b/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/view.cljs
@@ -1,0 +1,15 @@
+(ns re-frame.ui.digest-probe.warm-watch.view
+  "A consumer view that references :probe-card WITHOUT a `:require` edge to the
+  declaring `card` source. Shadow's dependency tracking therefore never schedules
+  this source when `card`'s declaration changes; only the coarse manifest-change
+  invalidation (rf2-vxgfnd.141, dimension 3) forces it to recompile so it re-bakes
+  its property/attribute lowering against the changed manifest. Whether this
+  source is recompiled on a warm pass is exactly the coarse-invalidation witness
+  the runner asserts.
+
+  It references :model AND :size so a manifest shrink of EITHER is observable in
+  the baked classification, and :data-x is always a plain attribute."
+  (:require [re-frame.ui :refer [defview]]))
+
+(defview probe-view []
+  [:probe-card {:model "m" :size "s" :data-x "d"}])


### PR DESCRIPTION
Arm 2 of **rf2-4vm19**, split out as **rf2-tm1xi**. A real Shadow 3.4.10 warm-watch/file-edit fixture that drives ONE warm dev daemon through real file edits and asserts the accepted custom-element **harvest topology** survives each warm rebuild, plus the removed/renamed saved-source **`:build-sources` graph delta**. Complements the synthetic JVM fixtures (`compiler_harvest_hook_jvm_test`, `custom_element_warm_staleness_jvm_test`), which hand-build build state and cannot exercise a real Shadow watch, real inherited-then-build-local hook deep-merge, or real file delete/rename/move.

## What it drives (one real warm daemon, real file edits)

A build-local OBSERVE hook — deep-merged AFTER the inherited `re-frame.ui` compile hook (the real inherited-then-build-local order) — records the accepted topology at `:compile-finish` **without mutating build state**. The runner (`check-ui-warm-watch.cjs`, modelled on the sibling `check-ui-final-schedule.cjs`) walks the daemon through:

1. **cold accept** — build id `:ui-warm-watch` (never `::default`), `:probe-card #{:model :size}`, `:probe-leaf #{:flag}`, the no-`:require`-edge consumer view present;
2. **zero-declaration** trigger edit — manifest + digest stable, consumer view a warm cache hit (coarse invalidation does not over-fire);
3. **declaration shrink** — harvest re-reads `card` (`:probe-card -> #{:model}`), the coarse manifest-change invalidation recompiles the no-`:require`-edge consumer view so it re-bakes, digest moves;
4. **same-namespace file move** — `leaf.cljs` relocates to a second source-path root, keeping its namespace; ownership survives because the eviction unit is the namespace, not the file;
5. **rename** — `…leaf -> …leaf-renamed`; the `:build-sources` delta re-owns `:probe-leaf`;
6. **delete** — the renamed source and its client `:require` are removed; `:probe-leaf` is evicted from the accepted manifest with no page reload (the removed saved-source graph delta);
7. **failed compile then successful retry** — last-known-good manifest preserved across the failure, retry converges clean.

Per the **rf2-4vm19 Arm-1 ruling** this proves ONE real dev build's identity at the runtime seam (non-`::default` build id, inherited-hook discovery/order, annotation load-bearingness) — **not** two-build isolation.

## Scope / fence

- **JVM harvest fixture, not mounted** — the runner reads the JVM observe JSONL; no browser is launched, so `test:browser` does not apply.
- **No runtime change.** The harvest/build-hook runtime and every conflict classification are untouched (k1ouh untouched).
- **No hot-zone change.** Self-contained fixture with its own `shadow-cljs.edn` and second source-path root; the top-level `implementation/shadow-cljs.edn` is not touched. `package.json` gains one script (`test:ui-warm-watch`).
- **Red-before, executed:** with `reconcile-declaration-edits` neutralised the fixture REDs at the declaration-shrink pass (`coarse invalidation did not recompile the no-require-edge consumer view`), then reverted. Three further teeth (drop the stage annotation, drop the harvest seed, break `keep-members` eviction) are documented in the runner header.

## Quality gates

- `check-ui-warm-watch.cjs` (the real warm cycle, 8 passes): **PASS**
- `cd implementation/ui && clojure -M:test`: **1001 tests, 19596 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **10316 tests, 50871 assertions, 0 failures, 0 errors**
- `npm run test:perf-bundle`: **PASS**