### PR TITLE
docs(xray): reconcile the :rf.xray/filters config-key doc with the shipped boot-baseline behaviour (rf2-4jeoc)

### DIFF
--- a/docs/xray/api/config-keys.md
+++ b/docs/xray/api/config-keys.md
@@ -47,7 +47,7 @@ The full v1 key surface, grouped by topical cluster:
    ;; Settings cluster — bulk-replace the Settings popup state
    :rf.xray/settings              {:theme :dark :general {:density :cosy}}
 
-   ;; Filters cluster — host-supplied seed pill set on first install
+   ;; Filters cluster — host-supplied boot-baseline seed (re-applied every load)
    :rf.xray/filters               {:out [{:pattern ":mouse-move"}]}
    :rf.xray/filters-storage-key   "re-frame2.xray.filters.v1"})
 ```
@@ -209,7 +209,7 @@ The settings persist under the localStorage key `day8.re-frame2-xray/settings/v1
 
 ## Filters cluster
 
-The Trace panel ships filter pills (`+ pattern`, `- pattern`, `+ :origin`, `+ frame`) that drive in / out filtering of the displayed events. Filter state persists in localStorage across reloads; hosts that want to seed a starting filter set on first install reach for the filters cluster.
+The Trace panel ships filter pills (`+ pattern`, `- pattern`, `+ :origin`, `+ frame`) that drive in / out filtering of the displayed events. A user's own pills are **transient** — written to localStorage only *within* a session and reset to unfiltered on every load, so a stale filter never silently hides rows after a reload. Hosts that want a known starting set reach for the filters cluster's seed: an explicit **boot baseline**, re-applied on every load, not durable user-filter persistence.
 
 ### `set-filter-seed!`
 
@@ -217,7 +217,7 @@ The Trace panel ships filter pills (`+ pattern`, `- pattern`, `+ :origin`, `+ fr
   ```clojure
   (set-filter-seed! seed-map) → nil
   ```
-- **Description**: Host-supplied seed pill set the registry hydrates `:active-filters` with on FIRST install (when localStorage is empty). Shape: `{:in [{...}] :out [{...}]}`. Default `nil` — first session boots with no filters (first-session honesty beats first-session quietness). Story testbeds use this to inject a known starting point for reproducibility.
+- **Description**: Host-supplied seed pill set applied to `:active-filters` as the explicit **boot baseline**. A non-empty seed lands on **every** load via the first-mount `::seed-configured-filters` hook, which runs *after* the transient-filter reset — so the host's baseline always wins over a user's stale session pills. The seed is seed-only: it never reads localStorage and is never persisted. Shape: `{:in [{...}] :out [{...}]}`. Default `nil` — a fully-unfiltered first paint (first-session honesty beats first-session quietness). Story testbeds use this to inject a known, reproducible starting posture. To change filters *live* (mid-session), use the filter pill events / Story path — not a post-mount `configure!`, since the seed is read once per frame at first mount, not on every use.
 
 ### `set-filters-storage-key!`
 

--- a/tools/xray/spec/015-Configuration.md
+++ b/tools/xray/spec/015-Configuration.md
@@ -175,7 +175,12 @@ preload mounts. Calling it after mount is legal — every key is read at
 its consumer's hot path on each use, so changes take effect on the
 next read — but defeats the "boot-time configuration" mental model and
 is reserved for hot-reload / live-rebind scenarios (Settings panel,
-dev REPL).
+dev REPL). The one exception is `:rf.xray/filters`: that seed is a
+**pre-mount boot baseline** consumed once per frame by
+`mount.cljs`'s `::seed-configured-filters` first-mount hook, not
+re-read per use — so a post-mount `configure!` does not take effect
+until the next load. Change filters live via the filter pill events /
+Story path instead.
 
 ## Configuration keys
 
@@ -687,10 +692,13 @@ The localStorage key the filter persistence layer reads / writes.
 Default: `"re-frame2.xray.filters.v1"` (versioned so future schema
 changes can ignore stale payloads).
 
-When both `:rf.xray/filters` and `:rf.xray/filters-storage-key`
-are passed in one call, the storage key is set BEFORE the seed so a
-host that overrides both gets the seed persisted under the right
-key.
+The storage key and the `:rf.xray/filters` seed are independent axes.
+This key governs the **transient user-pill** localStorage round-trip
+(within-session writes + the load-time reset cleanup); the seed is a
+separate in-memory boot baseline that is never persisted (rf2-fhtes).
+When both are passed in one call the storage key is set first, but the
+ordering does not affect the seed — it lands via `mount.cljs`'s
+`::seed-configured-filters` hook, not through this key.
 
 ### Static mode availability
 

--- a/tools/xray/src/day8/re_frame2_xray/config.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/config.cljc
@@ -1780,9 +1780,11 @@
       #?(:cljs
          (when-not (storage-get settings-storage-key)
            (write-storage!)))))
-  ;; Filter seed + storage key. Storage key sets BEFORE seed so a host
-  ;; that overrides both in one call gets the seed persisted under the
-  ;; right key.
+  ;; Filter seed + storage key — two independent axes. The storage key
+  ;; governs the transient user-pill localStorage round-trip (within-
+  ;; session writes + the load-time reset cleanup); the filter seed is
+  ;; an in-memory boot baseline that is never persisted (rf2-fhtes).
+  ;; Storage key is set first, but the ordering does not affect the seed.
   (when (contains? opts :rf.xray/filters-storage-key)
     (set-filters-storage-key! filters-key-opt))
   (when (contains? opts :rf.xray/filters)

--- a/tools/xray/src/day8/re_frame2_xray/filters.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters.cljs
@@ -161,8 +161,11 @@
 
     - Effects: `:rf.xray.filters/persist` — localStorage write fx.
 
-    - Side-effect: hydrate `:active-filters` from localStorage at
-      first install via a no-history dispatch.
+    - Side-effect: NONE — install does NOT hydrate `:active-filters`
+      from localStorage (rf2-fhtes). The slot starts at its registry
+      default; the transient reset and the configured boot-baseline
+      seed land later on the mount path (`mount.cljs`'s `::reset-
+      transient-filters` then `::seed-configured-filters`).
 
   Called from `registry/register-xray-handlers!` after the
   `:rf.xray/active-filters` slot is registered (so the sub-graph


### PR DESCRIPTION
Closes rf2-4jeoc (a #6480 / rf2-fhtes follow-up surfaced by the rf2-h2y8d audit).

## What #6480 shipped
`:rf.xray/filters` is a **non-persistent host boot baseline**. `mount.cljs`'s `::seed-configured-filters` first-mount hook applies a non-empty configured seed to `:active-filters` on **every** load, immediately **after** `::reset-transient-filters`. `nil` stays fully unfiltered. The seed is seed-only — it never reads localStorage and is never persisted, so a user's stale session filters never survive reload or override the host's baseline.

#6480 reconciled the `:rf.xray/filters` entry in Spec 015, Spec 018, the `config.cljc` filter-seed docstrings, and the `filters.cljs` `install!`/`hydrate!` body comments. It left **residual** stale claims of the retired hydrate-on-first-install model in four nearby spots — reconciled here (prose-only).

## Stale claim → shipped truth (found by content; line drift accounted for)
- **`docs/xray/api/config-keys.md`** (untouched by #6480 — the primary). Filters-cluster intro said *"Filter state persists in localStorage across reloads; hosts that want to seed a starting filter set on first install…"*; `set-filter-seed!` said the registry *"hydrates `:active-filters` with on FIRST install (when localStorage is empty)"*. Now: transient user pills reset on every load; the seed is an explicit boot baseline re-applied every load after the reset, never persisted; live changes go via the filter events / Story path.
- **`tools/xray/spec/015-Configuration.md`** — the `:rf.xray/filters-storage-key` section still said a host *"gets the seed persisted under the right key"* (false — the seed is never persisted); the generic configure-timing prose (*"changes take effect on the next read"*) carried no boot-seed exception. Both fixed.
- **`tools/xray/src/.../config.cljc`** — the `configure!` filter-seed comment repeated *"gets the seed persisted under the right key"*. Corrected to two independent axes (storage key = transient user-pill round-trip; seed = in-memory boot baseline, never persisted).
- **`tools/xray/src/.../filters.cljs`** — `install!`'s docstring listed a *"Side-effect: hydrate `:active-filters` from localStorage at first install"* bullet that directly contradicts the fn body's own "NO hydrate on install". Corrected.

## Scope notes
- **Three-outcome:** outcome (a) — docs stale, fixed. #6480 shipped exactly as documented above.
- **Bead vs brief scope:** the brief's surface fence named `config-keys.md` + `tools/xray/spec/*`, but the bead's acceptance criterion #1 (authoritative) also names `config.cljc` and `filters.cljs/install!`, where #6480 left residual comment/docstring falsehoods. Those two edits are **prose-only (no runtime behaviour change)** per criterion #4, so the "don't touch the runtime" intent (no behaviour change) is preserved.
- No runtime change, no schema/validation/migration, no new test harness.

## Quality gates
- `python -m mkdocs build --strict` → **exit 0** (48s; INFO lines are pre-existing, about other files).
- `python scripts/check_doc_slugs.py` → **exit 0**.
- `npm run test:xray-feature-gate` → **skipped, justified.** The gate (`serve-and-run-xray-feature-gate.cjs`) pins `tools/xray/spec/017-Test-Coverage-Matrix.md` and validates the runtime feature matrix. This PR edits `015-Configuration.md` prose only (not 017) and makes no runtime change, so the gate cannot be affected. CI owns the heavy browser/serve gates.