### PR TITLE
docs(migration): correct the epoch projection guidance to the shipped per-event model (rf2-yyxtn)

### DIFF
--- a/migration/from-re-frame-v1/observability-logging-sweep.md
+++ b/migration/from-re-frame-v1/observability-logging-sweep.md
@@ -318,7 +318,12 @@ When the v1 observer assembled a per-cascade summary (an audit-log entry per dra
 (rf/register-listener! :epoch :my-app/post-mortem-shipper
   (fn epoch-shipper [epoch-record]
     (when-not (:rf.epoch/sensitive? epoch-record)                  ;; honour epoch-level rollup
-      (let [[bounded dropped] (cap-or-elide epoch-record
+      ;; Project at the egress boundary FIRST — the listener holds the RAW record.
+      ;; projected-record is the single off-box projection (frame/profile redaction,
+      ;; raw :db-before / :db-after stripped, plus any installed :redact-fn); the
+      ;; size-cap below then bounds the already-projected payload.
+      (let [projected         (rf/projected-record epoch-record)
+            [bounded dropped] (cap-or-elide projected
                                             {:threshold-bytes 65536
                                              :frame           (:frame epoch-record)})]
         (when (pos? dropped)
@@ -337,7 +342,8 @@ When the v1 observer assembled a per-cascade summary (an audit-log entry per dra
 Two epoch-specific notes:
 
 - **`(:rf.epoch/sensitive? epoch-record)`** is the framework-computed rollup over the schema-declared sensitive leaves of `:db-before` / `:db-after` / `:trigger-event` / `:trace-events` (per [Security.md §Sensitive rollup at the record level](../../spec/Security.md#epoch-privacy-posture--raw-in-process-records-vs-projected-egress)). The shipper MUST default-drop sensitive epochs; the rollup is exactly the signal to gate on.
-- **The `(rf/configure! {:epoch-history {:redact-fn ...}})` build-time hook** is a stronger alternative — instead of every off-box forwarder applying its own `cap-or-elide`, the operator installs one redact-fn at boot that erases sensitive material from each `:rf/epoch-record` **once, as it is committed** (per record — not once per off-box forwarder); every downstream consumer (ring buffer, listener fan-out, off-box egress) sees the redacted shape. The agent SHOULD recommend the build-time hook when the codebase has multiple forwarders against the same epoch surface; for single-forwarder codebases the per-listener `cap-or-elide` is sufficient.
+- **Every off-box epoch forwarder MUST project at the egress boundary.** The listener receives the **raw** record, so a forwarder that ships `epoch-record` straight off-box leaks whatever the raw record holds. Route it through `(rf/projected-record record)` first (or `(rf/projected-history frame-id)` for the whole ring) — the single off-box egress projection: it applies the frame/profile classification and strips the raw `:db-before` / `:db-after`. Do **not** assume the record was scrubbed at storage; it was not.
+- **The `(rf/configure! {:epoch-history {:redact-fn ...}})` hook is a *projection-side* advanced override, not a storage-time scrub and not a substitute for `projected-record`.** When installed it runs **once per projection call, inside `projected-record`, after** the built-in frame/profile projection — an escape hatch for sensitive slots the frame's classification can't prove. It never mutates stored records: the in-process ring buffer and every `register-epoch-listener!` listener still deliver the **raw** record (epoch records are causal replay material — mutating them at rest would corrupt `restore-epoch!` fidelity), so installing a `:redact-fn` does **not** let a forwarder skip `projected-record`. Reach for it when the payload carries sensitive material the schema-driven projection can't reach — declared once at boot, it composes into every forwarder's `projected-record` rather than being hand-rolled per site; where the schema already classifies those slots, `projected-record` alone suffices.
 
 ### Shape C — per-frame `:interceptors` for behaviour-modifying interceptors
 


### PR DESCRIPTION
Closes rf2-yyxtn. Follow-up to #6481 (rf2-ydddw), which touched this file's
`:redact-fn` bullet while sweeping the epoch-cardinality wording.

## The defect

#6481 left (and reinforced) a stale claim in the Shape B "epoch-specific notes"
of `migration/from-re-frame-v1/observability-logging-sweep.md`. The `:redact-fn`
bullet read that the hook "erases sensitive material from each `:rf/epoch-record`
**once, as it is committed** (per record ...); every downstream consumer (ring
buffer, listener fan-out, off-box egress) sees the redacted shape."

That is the **opposite** of the shipped contract. Per
`spec/Privacy.md`, `spec/Security.md` (§105/§106/§108), `spec/API.md` (:1100),
and `implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj`
(`A-override-runs-after-frame-profile-projection`; *"the RAW ring record is
unredacted (storage-side redaction gone)"*):

- `:redact-fn` is a **projection-side** advanced override — invoked **once per
  record at the off-box egress boundary, inside `projected-record`, after** the
  frame/profile projection. **Never** at commit/storage.
- The in-process **ring buffer and every `register-epoch-listener!` listener
  deliver the RAW record** (causal replay material — mutating it at rest would
  corrupt `restore-epoch!` fidelity).
- Every off-box epoch forwarder **MUST** first pass the raw record through
  `projected-record` / `projected-history`.

A programmer following the old text could forward a raw listener record off-box
believing it was already scrubbed — a sensitive-data leak (label: security).

## The correction (prose + example only)

- Rewrote the `:redact-fn` bullet to the projection-side model: `projected-record`
  is the mandatory off-box egress boundary; the override runs inside it, after
  the built-in projection, once per projection call; the ring + listeners stay raw.
- Added an explicit "**every off-box epoch forwarder MUST project**" note.
- Aligned the sole off-box epoch code example (Shape B `post-mortem-shipper`) to
  call `(rf/projected-record epoch-record)` before the size-cap, so the example
  demonstrates the rule instead of forwarding the raw record.

General-case (any v1 -> re-frame2 migration; `my-app` placeholders only, no
repo-coupled paths/naming). Sole toucher; no `README.md`/hot-zone touched.

Out of fence, filed separately: `spec/009-Instrumentation.md:1297` still says
`:redact-fn` "runs at build-time before ring-append", which contradicts the
correct 009:1349 ("projection-side override ... never at ring-append / listener
fan-out"). Left untouched (spec/** is outside this bead's surface).

## Quality gates

Local, foreground, migration/ renders in the site (mkdocs nav):

- `python -m mkdocs build --strict` -> exit 0 (built in 50.4s; no warnings
  referencing this file).
- `python scripts/check_doc_slugs.py` -> exit 0 (clean).
