### PR TITLE
docs(examples): make the streaming SSR stand-in carry a coherent failed-boundary output (rf2-rcowh)

### DIFF
--- a/examples/capabilities/ssr/ssr_streaming/README.md
+++ b/examples/capabilities/ssr/ssr_streaming/README.md
@@ -40,10 +40,13 @@ Var (`card-view`, which `reg-view` defs for you) or by `(rf/view :id)`.
 One caveat up front: this demo runs **offline**, with no Clojure server.
 Instead of fetching from three real services, `:rf/server-init` seeds all
 three card values synchronously, and the page boots from a hand-written
-`index.html` with the final resolved state and payload pre-baked. The
-`:clj` side still produces the full *wire shape* — shell, per-card
-chunks, final payload — as plain data returned from `handle-request`,
-frozen and replayable, no live streaming host needed. It's the worked
+`index.html` that bakes the whole streamed *wire shape* — the shell with a
+fallback `<template>` per boundary, each card's resolved chunk, the failed
+`:card.flaky` chunk, and the final payload — captured verbatim from the
+streaming emitter (the plain data `handle-request` returns), frozen and
+replayable, no live streaming host needed. The client runtime processes
+those baked bytes exactly as it would a live stream; only the network
+*timing* is missing. It's the worked
 companion to
 [Spec 011 §Streaming SSR](../../../../spec/011-SSR.md#streaming-ssr).
 

--- a/examples/capabilities/ssr/ssr_streaming/core.cljc
+++ b/examples/capabilities/ssr/ssr_streaming/core.cljc
@@ -314,13 +314,21 @@
 ;; and [hydrate, then verify](../../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify).
 ;;
 ;; One honest caveat: this example boots from a hand-written `index.html`
-;; that plays the part of the streaming server, with the resolved chunks and
-;; final payload baked in. No Clojure server runs in the loop. That works
-;; because the streaming runtime is additive — a page whose chunks already
-;; resolved hydrates exactly the same way: the install sweep finds nothing
-;; left to swap, sees `__rf_payload` already there, and goes straight to the
-;; `ssr/hydrate!` reconciliation. The genuinely progressive path (swap on
-;; chunk arrival, merge the delta, then the final payload) is what the
+;; that plays the part of the streaming server. No Clojure server runs in
+;; the loop. It bakes the WHOLE wire byte sequence at once — the shell with
+;; a `<template data-rf2-suspense-fallback>` per boundary, then every
+;; resolved chunk, the `data-rf2-suspense-failed` chunk for `:card.flaky`,
+;; and the final `__rf_payload` — captured verbatim from the streaming
+;; emitter (the same bytes `handle-request` above returns). Those bytes are
+;; the real streamed shape, so `install!` runs the SAME path a live stream
+;; drives: it materialises each fallback into an `<rf-suspense>` mount, swaps
+;; in each resolved chunk, records `:card.flaky` as FAILED from its marker,
+;; then unwraps the mounts on the final payload and hydrates. The failed
+;; boundary keeps its declared skeleton because the client observed the
+;; failed chunk, exactly as it would on the wire. The one thing the offline
+;; stand-in drops is the network TIMING — every chunk is present at once
+;; instead of arriving over the wire. That genuinely time-separated arrival
+;; (swap on each chunk, merge its delta, then the final payload) is what the
 ;; browser acceptance test `re-frame.ssr.streaming-client-dom-cljs-test`
 ;; drives end to end.
 

--- a/examples/capabilities/ssr/ssr_streaming/index.html
+++ b/examples/capabilities/ssr/ssr_streaming/index.html
@@ -16,50 +16,87 @@
 </head>
 <body>
   <!--
-    A real server (re-frame.ssr.ring/stream-handler from
-    day8/re-frame2-ssr-ring) would stream this page chunk by chunk:
+    This static page stands in for a live streaming server. A real host
+    (re-frame.ssr.ring/stream-handler from day8/re-frame2-ssr-ring) would
+    flush these exact bytes chunk by chunk; here they are baked in one file
+    so the browser can boot the example via shadow-cljs with no Clojure
+    server in the loop. The bytes below ARE the wire shape, frozen — the
+    same sequence the streaming emitter produces, captured verbatim from
+    the example's own `handle-request` (ssr-streaming/core.cljc):
 
-      1. Shell prefix + this <body> opening, <div id="app"> with the
-         skeleton fallback cards
+      1. Shell prefix + this <body> opening, then <div id="app"> holding
+         the shell HTML — the <main class="dashboard"> with an inline
+         <template data-rf2-suspense-fallback="1"> placeholder per boundary
+         (each carrying its skeleton fallback). #app CLOSES here; every
+         chunk below streams OUTSIDE the hydrated root.
       2. <template data-rf2-suspense-id=":card.revenue"
-                   data-rf2-suspense-resolved="1">…</template>
-         + <script data-rf2-suspense-hydrate=":card.revenue">delta</script>
+                   data-rf2-suspense-resolved="1">…resolved card…</template>
+         + <script data-rf2-suspense-hydrate=":card.revenue"
+                   type="application/edn">delta</script>
+         The delta is {} here: :rf/server-init seeds all three card values
+         up front (ssr-streaming/core.cljc), so each continuation only READS
+         app-db and mutates nothing. A per-service-fetch app would carry a
+         non-empty delta per card.
       3. (same for :card.signups, :card.latency)
-      4. The "flaky" card chunk carries data-rf2-suspense-failed="1"
-      5. <script id="__rf_payload">canonical-payload</script>
+      4. The "flaky" boundary's chunk carries data-rf2-suspense-failed="1"
+         and NO hydrate delta: its subtree threw on the server, so the
+         chunk ships the DECLARED fallback (the skeleton) rather than the
+         card body.
+      5. <script id="__rf_payload">canonical-payload</script> — the final
+         chunk. Its :rf/runtime-db names the failed boundary set
+         (#{:card.flaky}); the deltas were speculative, this payload wins.
       6. </body></html>
 
-    This static index.html stands in for the streaming output — it
-    ships with the final resolved state pre-baked so the browser can
-    boot the example via shadow-cljs without a Clojure server in the
-    middle. The same code that's wired up to streaming server-side
-    (ssr-streaming/core.cljc) hydrates this static page just fine
-    because the streaming runtime's contract is purely additive — a
-    page with the final payload already inlined skips the per-chunk
-    swap path and goes straight to :rf/hydrate.
+    This resolved-and-failed DOM is produced by the STREAMING emitter, NOT
+    by `rf/render-to-string`. Standard rendering deliberately REJECTS a
+    :rf/suspense-boundary marker (:rf.error/ssr-suspense-boundary-outside-
+    stream) — boundaries only serve through the streaming pipeline:
+    `render-shell` walks the tree into the shell + a continuation per
+    boundary, `render-continuation` drains each subtree (catching a throw
+    into the failed fallback), and `build-final-payload` seals the
+    canonical state. The client streaming runtime (`ssr/streaming-install!`,
+    wired in ssr-streaming/core.cljc's `run`) consumes exactly the bytes
+    below: it materialises each inert fallback <template> into a live
+    <rf-suspense> mount (now the skeletons paint), swaps in each resolved
+    chunk, records :card.flaky as FAILED from its data-rf2-suspense-failed
+    marker, then on the final payload unwraps every mount and signals
+    :on-ready. Hydration adopts the resulting DOM: the boundary that
+    declared [card-skeleton :flaky] re-renders that skeleton (it is in the
+    failed set), so the client render matches the painted markup exactly.
 
-    The #app subtree is the dev-build FINAL resolved DOM — every boundary
-    already swapped to its body, and the flaky boundary to its declared
-    skeleton fallback — as `rf/render-to-string` emits it. In a dev build
-    the reg-view REGISTRATION boundary stamps `data-rf2-source-coord`
-    (`<ns>:<sym>:<line>:<col>`, the reg-view call site) and `data-rf-view`
-    (`(str id)`) on every registered view's root DOM element (Spec 006
-    §Source-coord annotation / §View tagging contract, moved cross-host to
-    the reg-view boundary by rf2-8vi4q). So `:dashboard/root` stamps the
-    `<main class="dashboard">` root, each resolved `:dashboard/card` stamps
-    its `<div class="card">`, and the flaky boundary's declared fallback
-    `:dashboard/card-skeleton` stamps `<div class="card skeleton">`. The
-    client's dev render stamps the same attributes, so the page adopts
-    cleanly and pair-shaped tooling can map each node to its view; a
-    production build elides them on both hosts.
+    In a dev build the reg-view REGISTRATION boundary stamps
+    `data-rf2-source-coord` (`<ns>:<sym>:<line>:<col>`, the reg-view call
+    site) and `data-rf-view` (`(str id)`) on every registered view's root
+    DOM element (Spec 006 §Source-coord annotation / §View tagging contract,
+    moved cross-host to the reg-view boundary by rf2-8vi4q). So
+    `:dashboard/root` stamps the `<main class="dashboard">` root, each
+    resolved `:dashboard/card` stamps its `<div class="card">`, and each
+    `:dashboard/card-skeleton` fallback stamps its `<div class="card
+    skeleton">`. The client's dev render stamps the same attributes, so the
+    page adopts cleanly and pair-shaped tooling can map each node to its
+    view; a production build elides them on both hosts.
+
+    (`:rf/render-hash` in the payload is the placeholder "00000000": this
+    offline stand-in leaves out `:render-tree-fn`, so hydration runs no
+    render-hash mismatch check — see the note in ssr-streaming/core.cljc's
+    `run`. A real streaming server stamps the genuine body hash and passes
+    `:render-tree-fn` to switch verification on.)
   -->
-  <div id="app"><main class="dashboard" data-rf2-source-coord="dashboard:root:159:1" data-rf-view=":dashboard/root"><header><h1>Dashboard</h1><p>Streamed SSR demo — shell renders first, cards stream in.</p></header><section class="cards"><div class="card" data-rf2-source-coord="dashboard:card:89:1" data-rf-view=":dashboard/card"><h3>Revenue (last 7 days)</h3><p class="value">42375</p></div><div class="card" data-rf2-source-coord="dashboard:card:89:1" data-rf-view=":dashboard/card"><h3>New signups (last 7 days)</h3><p class="value">318</p></div><div class="card" data-rf2-source-coord="dashboard:card:89:1" data-rf-view=":dashboard/card"><h3>P50 latency (ms)</h3><p class="value">24</p></div><div class="card skeleton" data-rf2-source-coord="dashboard:card-skeleton:84:1" data-rf-view=":dashboard/card-skeleton"><h3>Loading flaky …</h3><p class="value">—</p></div></section><footer><p>Each card above is a `:rf/suspense-boundary`.</p></footer></main></div>
+  <div id="app"><main class="dashboard" data-rf2-source-coord="dashboard:root:159:1" data-rf-view=":dashboard/root"><header><h1>Dashboard</h1><p>Streamed SSR demo — shell renders first, cards stream in.</p></header><section class="cards"><template data-rf2-suspense-id=":card.revenue" data-rf2-suspense-fallback="1"><div class="card skeleton" data-rf2-source-coord="dashboard:card-skeleton:84:1" data-rf-view=":dashboard/card-skeleton"><h3>Loading revenue …</h3><p class="value">—</p></div></template><template data-rf2-suspense-id=":card.signups" data-rf2-suspense-fallback="1"><div class="card skeleton" data-rf2-source-coord="dashboard:card-skeleton:84:1" data-rf-view=":dashboard/card-skeleton"><h3>Loading signups …</h3><p class="value">—</p></div></template><template data-rf2-suspense-id=":card.latency" data-rf2-suspense-fallback="1"><div class="card skeleton" data-rf2-source-coord="dashboard:card-skeleton:84:1" data-rf-view=":dashboard/card-skeleton"><h3>Loading latency …</h3><p class="value">—</p></div></template><template data-rf2-suspense-id=":card.flaky" data-rf2-suspense-fallback="1"><div class="card skeleton" data-rf2-source-coord="dashboard:card-skeleton:84:1" data-rf-view=":dashboard/card-skeleton"><h3>Loading flaky …</h3><p class="value">—</p></div></template></section><footer><p>Each card above is a `:rf/suspense-boundary`.</p></footer></main></div>
+  <template data-rf2-suspense-id=":card.revenue" data-rf2-suspense-resolved="1"><div class="card" data-rf2-source-coord="dashboard:card:89:1" data-rf-view=":dashboard/card"><h3>Revenue (last 7 days)</h3><p class="value">42375</p></div></template>
+  <script data-rf2-suspense-hydrate=":card.revenue" type="application/edn">{}</script>
+  <template data-rf2-suspense-id=":card.signups" data-rf2-suspense-resolved="1"><div class="card" data-rf2-source-coord="dashboard:card:89:1" data-rf-view=":dashboard/card"><h3>New signups (last 7 days)</h3><p class="value">318</p></div></template>
+  <script data-rf2-suspense-hydrate=":card.signups" type="application/edn">{}</script>
+  <template data-rf2-suspense-id=":card.latency" data-rf2-suspense-resolved="1"><div class="card" data-rf2-source-coord="dashboard:card:89:1" data-rf-view=":dashboard/card"><h3>P50 latency (ms)</h3><p class="value">24</p></div></template>
+  <script data-rf2-suspense-hydrate=":card.latency" type="application/edn">{}</script>
+  <template data-rf2-suspense-id=":card.flaky" data-rf2-suspense-resolved="1" data-rf2-suspense-failed="1"><div class="card skeleton" data-rf2-source-coord="dashboard:card-skeleton:84:1" data-rf-view=":dashboard/card-skeleton"><h3>Loading flaky …</h3><p class="value">—</p></div></template>
   <script id="__rf_payload" type="application/edn">
 {:rf/version 1
  :rf/app-db {:cards {:revenue {:title "Revenue (last 7 days)" :value 42375}
                      :signups {:title "New signups (last 7 days)" :value 318}
                      :latency {:title "P50 latency (ms)" :value 24}}}
- :rf/render-hash "00000000"}
+ :rf/render-hash "00000000"
+ :rf/runtime-db {:rf.runtime/ssr {:streaming {:failed-boundaries #{:card.flaky}}}}}
   </script>
   <script src="main.js"></script>
 </body>


### PR DESCRIPTION
## What

Fixes the checked-in `examples/capabilities/ssr/ssr_streaming/index.html`
stand-in, which carried an incoherent / false failed-boundary output
(rf2-rcowh, reopened by the #6485 chronological audit for the narrower
case the runtime verification didn't cover). Bounded to the example — the
streaming **runtime is untouched and correct**.

### The two defects

1. **Incoherent baked failed-boundary DOM.** The stand-in pre-baked the
   final swapped DOM and stripped every suspense template/chunk marker. With
   no `data-rf2-suspense-failed` chunk on the wire,
   `streaming.client/install!` records an empty `seen` map,
   `finalize!`/`record-failed-boundaries!` publishes the empty failed set,
   and the client `:card.flaky` boundary renders its `throwing-card` body
   instead of the declared skeleton — the hydration render throws on boot.
2. **False `rf/render-to-string` attribution.** The page claimed its final
   boundary-resolved DOM was emitted by `rf/render-to-string`. That is
   false: standard rendering deliberately rejects a `:rf/suspense-boundary`
   marker (`:rf.error/ssr-suspense-boundary-outside-stream`); boundaries
   only serve through the streaming pipeline.

### The fix (example-only, existing protocol reused)

- `index.html` now bakes the **whole streamed wire byte sequence** — the
  shell with a `<template data-rf2-suspense-fallback>` per boundary, each
  card's resolved chunk, the `data-rf2-suspense-failed` chunk for
  `:card.flaky`, the `{}` hydrate-delta scripts (`:rf/server-init` seeds
  synchronously, so continuations only read app-db), and a final
  `__rf_payload` whose `:rf/runtime-db` names `#{:card.flaky}`. **Captured
  verbatim from the example's own `handle-request`** (the streaming
  emitter), not hand-written. `install!` now runs the same
  materialise → swap → record-failed → unwrap → hydrate path a live stream
  drives, so the flaky boundary keeps its skeleton and hydration adopts the
  DOM cleanly.
- Corrected the prose in `index.html`, `core.cljc`, and `README.md` to
  attribute the resolved/failed DOM to the streaming pipeline
  (`render-shell` / `render-continuation` / `build-final-payload`) rather
  than `rf/render-to-string`, and to describe the baked full-wire shape
  instead of a pre-swapped final DOM.

`:rf/render-hash` stays the documented `"00000000"` placeholder (the offline
bootstrap omits `:render-tree-fn`, so no mismatch check runs).

Idiomatic (app-db + events + subs unchanged), test-free (no `*.spec.cjs`
added), no new example, no streaming infra.

## Quality gates

- `npx shadow-cljs compile examples/ssr-streaming` — **Build completed.
  (207 files, 206 compiled, 0 warnings, 30.4s)**, `main.js` emitted.
- Baked `__rf_payload` EDN parses via `clojure.edn`:
  `:rf/version 1`, 3 cards, `:failed-boundaries #{:card.flaky}`, no
  `:rf/frame-id`.
- Wire-marker counts (excluding the explanatory comment) match the
  empirical capture exactly: 4 fallback templates, 3 resolved + 1 failed
  chunk, 3 hydrate-delta scripts.
- Coherence triangulated against the shipped tests that already pin this
  shape: `ssr-streaming-example-runs-end-to-end` (JVM wire shape:
  4 chunks, 1 `data-rf2-suspense-failed`, failed-boundaries `#{:card.flaky}`,
  payload runtime-db slice) and `streaming-client-dom-cljs-test` (the
  progressive client-DOM path the baked bytes are the output of).
