### PR TITLE
fix(ssr): reject nested numeric-key and set collisions at any depth before manifest emission (rf2-pdcoh)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/manifest.cljc
+++ b/implementation/ssr/src/re_frame/ssr/manifest.cljc
@@ -454,10 +454,39 @@
   (let [d (double v)]
     (if (zero? d) 0.0 d)))
 
+(defn- browser-project
+  "Project `v` into the browser's numeric world for CROSS-HOST identity:
+  every number becomes its `browser-number`, and every map / set / vector /
+  list keeps its shape with its members projected the same way. Two
+  SERVER-DISTINCT values are `=` after this projection EXACTLY when the
+  browser — which holds one double per number and one zero — reads them as
+  one value.
+
+  `browser-number` alone catches a numeric key beside a numeric key (`1`
+  beside `1.0`), because both are numbers at the SAME level. It cannot see a
+  COMPOSITE key beside a composite key: `[1]` and `[1.0]` are two distinct
+  vectors on the server, and NEITHER is a number, yet the browser reads both
+  as `[1.0]` and rejects the second as a duplicate. Projecting the WHOLE
+  key/element — to any depth — before siblings are compared is what closes
+  that gap (PR #6489 grouped only the directly-numeric siblings and missed
+  it). The projected value is used only to GROUP siblings for `=`; it is
+  never emitted, so a key whose own numbers collapse (a nested collision the
+  recursion reports on its own) is projected to a well-defined value here
+  without hiding that inner failure."
+  [v]
+  (cond
+    (number? v)     (browser-number v)
+    (map? v)        (into {} (map (fn [[k val]]
+                                    [(browser-project k) (browser-project val)]))
+                          v)
+    (set? v)        (into #{} (map browser-project) v)
+    (sequential? v) (mapv browser-project v)
+    :else           v))
+
 (defn- numeric-collision
   "-> a DATA map naming the FIRST cross-host numeric collision reachable
-  from `v` — a map whose distinct numeric KEYS, or a set whose distinct
-  numeric ELEMENTS, collapse to one `browser-number` — else `nil`.
+  from `v` — a map whose distinct KEYS, or a set whose distinct ELEMENTS,
+  collapse to one value under `browser-project` — else `nil`.
 
   `edn-carryable?` asks whether each value ALONE rides the wire; this
   asks whether a whole map or set survives the crossing. It need not,
@@ -466,21 +495,29 @@
   `-0.0`, are two distinct keys on the JVM, but the browser reads both as
   one double, so `pr-str`'ing the collection and reading it back on the
   client rejects a DUPLICATE key/element (PR #6437 screened each value in
-  isolation and missed this). The check recurs through nested maps, sets,
-  vectors and lists — the same reach `edn-carryable?` walks — and `path`
-  records the route to the offending collection so the author can narrow
-  one key deliberately."
+  isolation and missed this).
+
+  The collision need not be a bare number. `[1]` and `[1.0]` are two
+  distinct VECTOR keys on the server, neither a number, yet the browser
+  reads both as `[1.0]` and rejects the duplicate all the same (PR #6489
+  grouped only the directly-numeric siblings and missed this). So siblings
+  are grouped by `browser-project`, which folds a WHOLE key/element to any
+  depth, not by the bare-number projection. The check also recurs through
+  nested maps, sets, vectors and lists — the same reach `edn-carryable?`
+  walks — so a collision buried inside one key or value is found too, and
+  `path` records the route to the offending collection so the author can
+  narrow one key deliberately."
   ([v] (numeric-collision v []))
   ([v path]
    (letfn [(collapse [kind xs]
-             (some (fn [[d members]]
+             (some (fn [[browser-value members]]
                      (when (next members)
                        {:invalid        :cross-host-numeric-collision
                         :collision       kind
                         :path            path
                         :collapses       (vec members)
-                        :browser-number  d}))
-                   (group-by browser-number (filter number? xs))))]
+                        :browser-number  browser-value}))
+                   (group-by browser-project xs)))]
      (cond
        (map? v)
        (or (collapse :map-keys (keys v))

--- a/implementation/ssr/test/re_frame/ssr/root_manifest_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/root_manifest_cljs_test.cljc
@@ -631,11 +631,15 @@
 (def ^:private collision-bodies
   "Exact `<script>` bodies a PRE-fix server emitted for colliding manifests,
   pinned as BYTES because bytes are what cross. Map-key, set-element, and
-  signed-zero arms. The JVM half pins the tokens against the live printer so
-  these literals cannot go stale."
-  {:map  "{:rf.root/schema-version 1, :root-id :page/shop, :phase :server, :props {:lookup {1 :integer, 1.0 :double}}}"
-   :set  "{:rf.root/schema-version 1, :root-id :page/shop, :phase :server, :props {:tags #{1.0 1}}}"
-   :zero "{:rf.root/schema-version 1, :root-id :page/shop, :phase :server, :props {:lookup {0 :a, -0.0 :b}}}"})
+  signed-zero arms, plus the rf2-pdcoh COMPOSITE arms — a VECTOR key and a
+  vector set element, where each key/element is a collection whose numeric
+  leaves (not the key itself) collapse. The JVM half pins the tokens against
+  the live printer so these literals cannot go stale."
+  {:map     "{:rf.root/schema-version 1, :root-id :page/shop, :phase :server, :props {:lookup {1 :integer, 1.0 :double}}}"
+   :set     "{:rf.root/schema-version 1, :root-id :page/shop, :phase :server, :props {:tags #{1.0 1}}}"
+   :zero    "{:rf.root/schema-version 1, :root-id :page/shop, :phase :server, :props {:lookup {0 :a, -0.0 :b}}}"
+   :vec-map "{:rf.root/schema-version 1, :root-id :page/shop, :phase :server, :props {:lookup {[1] :integer-vector, [1.0] :double-vector}}}"
+   :vec-set "{:rf.root/schema-version 1, :root-id :page/shop, :phase :server, :props {:tags #{[1.0] [1]}}}"})
 
 (deftest colliding-wire-bytes-part-across-hosts
   (testing "rf2-pdcoh — the SAME wire bytes, read by the shipped `read-manifest`
@@ -649,10 +653,20 @@
              "the map tokens pinned in `collision-bodies` match the live printer")
          (is (= "#{1.0 1}" (pr-str #{1 1.0}))
              "…and the set token — if either reds, the pinned bytes are stale")
+         (is (= "{[1] :integer-vector, [1.0] :double-vector}"
+                (pr-str {[1] :integer-vector [1.0] :double-vector}))
+             "the COMPOSITE map-key tokens — the residual #6489's direct walk missed")
+         (is (= "#{[1.0] [1]}" (pr-str #{[1] [1.0]}))
+             "…and the composite set-element token")
          (is (= 2 (count (get-in (manifest/read-manifest 'test (:map collision-bodies))
                                  [:props :lookup])))
              "the server round-trips two distinct keys — same-host is blind")
          (is (= 2 (count (get-in (manifest/read-manifest 'test (:set collision-bodies))
+                                 [:props :tags]))))
+         (is (= 2 (count (get-in (manifest/read-manifest 'test (:vec-map collision-bodies))
+                                 [:props :lookup])))
+             "…and two distinct VECTOR keys — same-host is blind to composites too")
+         (is (= 2 (count (get-in (manifest/read-manifest 'test (:vec-set collision-bodies))
                                  [:props :tags])))))
        :cljs
        (doseq [[label body] collision-bodies]
@@ -727,7 +741,52 @@
                        (catch clojure.lang.ExceptionInfo e (ex-data e)))]
          (is (= :cross-host-numeric-collision (:invalid data)))
          (is (= :set-elements (:collision data)))
-         (is (= [:props :xs 1] (:path data)) "the path indexes into the vector")))))
+         (is (= [:props :xs 1] (:path data)) "the path indexes into the vector"))
+
+       ;; rf2-pdcoh RESIDUAL — COMPOSITE sibling KEYS. `[1]` and `[1.0]` are two
+       ;; distinct vectors on the server, and NEITHER is a number, so #6489's
+       ;; directly-numeric grouping accepted them and emitted the body; the
+       ;; browser reads both as `[1.0]` and rejects the duplicate. The walk now
+       ;; projects the WHOLE key before comparing siblings.
+       (let [collide {[1] :integer-vector [1.0] :double-vector}
+             m       {:rf.root/schema-version 1 :root-id :page/shop
+                      :props {:lookup collide}}]
+         (is (= 2 (count collide)) "two distinct VECTOR keys on the server")
+         (is (manifest/edn-carryable? collide)
+             "THE LEVER: each composite key rides the wire ALONE, and each is a
+              vector, not a number — so the directly-numeric group had nothing to
+              grab. Per-key carryability is not the property.")
+         (let [data (try (manifest/script-html m) nil
+                         (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+           (is (= :rf.error/root-manifest-invalid (:rf.error/id data))
+               "the EXISTING id — still a malformed manifest, no new catalogue row")
+           (is (= :cross-host-numeric-collision (:invalid data)))
+           (is (= :map-keys (:collision data)))
+           (is (= [:props :lookup] (:path data)) "the offending collection is NAMED")
+           (is (= #{[1] [1.0]} (set (:collapses data))) "and its colliding vector keys")
+           (is (= [1.0] (:browser-number data))
+               "and the one browser value they collapse to")))
+
+       ;; composite SET elements — same class, one collection out
+       (let [m    {:rf.root/schema-version 1 :root-id :page/shop
+                   :props {:tags #{[1] [1.0]}}}
+             data (try (manifest/script-html m) nil
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+         (is (= :cross-host-numeric-collision (:invalid data)))
+         (is (= :set-elements (:collision data)))
+         (is (= [:props :tags] (:path data)))
+         (is (= #{[1] [1.0]} (set (:collapses data)))))
+
+       ;; DEEP composite collision — a set inside a vector inside a map: the
+       ;; residual is closed at ARBITRARY depth, not just one collection down.
+       (let [m    {:rf.root/schema-version 1 :root-id :page/shop
+                   :props {:xs [{:k #{[1] [1.0]}}]}}
+             data (try (manifest/script-html m) nil
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+         (is (= :cross-host-numeric-collision (:invalid data)))
+         (is (= :set-elements (:collision data)))
+         (is (= [:props :xs 0 :k] (:path data))
+             "the path threads map -> vector -> map -> set to the colliding set")))))
 
 (deftest a-mutation-that-resolves-the-collision-emits-fine
   (testing "rf2-pdcoh — THE RED-BEFORE MUTATION: change one colliding number so
@@ -747,7 +806,20 @@
              :distinct-set {:rf.root/schema-version 1 :root-id :page/shop
                             :props {:tags #{1 2 3}}}
              :nested-ok    {:rf.root/schema-version 1 :root-id :page/shop
-                            :props {:a [1 {:b #{2 3.5}}]}}}]
+                            :props {:a [1 {:b #{2 3.5}}]}}
+             ;; rf2-pdcoh — the COMPOSITE mutations: change one leaf so the two
+             ;; vector keys/elements no longer project to one browser value, and
+             ;; the same composite shape emits and round-trips. Proves the
+             ;; residual rejection is the COLLISION, not the composite shape.
+             :vec-map-ok   {:rf.root/schema-version 1 :root-id :page/shop
+                            :props {:lookup {[1] :integer-vector [2.0] :double-vector}}}
+             :vec-set-ok   {:rf.root/schema-version 1 :root-id :page/shop
+                            :props {:tags #{[1] [2.0]}}}
+             :deep-vec-ok  {:rf.root/schema-version 1 :root-id :page/shop
+                            :props {:xs [{:k #{[1] [2.0]}}]}}
+             ;; distinct composite keys that are NOT a collision must still emit
+             :two-vec-ok   {:rf.root/schema-version 1 :root-id :page/shop
+                            :props {:lookup {[1 2] :a [1 3] :b}}}}]
       (is (string? (manifest/script-html m))
           (str label " — a non-colliding numeric collection still emits"))
       (is (round-trips? m)


### PR DESCRIPTION
Completes the emission-gate collision walk from PR #6489 to arbitrary nesting depth. Reopened by the #6489 audit (rf2-uqd7o).

## The residual

#6489's `numeric-collision`/`collapse` grouped only the DIRECTLY-numeric siblings of each map/set (`(group-by browser-number (filter number? xs))`). A collision carried by a COMPOSITE key or element escaped:

- `{[1] :integer-vector [1.0] :double-vector}` has JVM count 2, is `edn-carryable?`, and `script-html` emitted it — but the browser reads both keys as `[1.0]`, and the shipped CLJS `read-manifest` rejects the body: *Map literal contains duplicate key: [1]*. The JVM-accepted manifest changed cardinality on the wire.

Red-before confirmed executably: the pre-fix direct-numeric grouping returns `nil` (accepts) for `{[1] … [1.0] …}` and `#{[1] [1.0]}`; the new `browser-project` grouping returns the colliding members (rejects).

## The fix

Add `browser-project`, which folds a WHOLE key/element into the browser's numeric-equality world to arbitrary depth (every number → `browser-number`; maps/sets/vectors/lists keep shape with members projected). `collapse` now groups siblings by `browser-project` instead of the bare-number projection. The `numeric-collision` cond (map/set/coll recursion + `path`) is unchanged, so #6489's direct-numeric cases and nested-direct recursion behave exactly as before.

- Reuses the existing `:rf.error/root-manifest-invalid` id and its `:path` / `:collapses` / `:browser-number` evidence shape.
- **No** codec, tagged-reader registry, schema framework, blanket numeric-key ban, or new error id.
- Spec 011 already carries the ±Infinity wording ("every double except `##NaN` — including `##Inf` and `##-Inf`") and the "any nesting depth" collision clause from #6489, so it is untouched (hot-zone).
- No `identical?` on keyword literals (#6365); proven on both hosts.

## Tests (dual-host, byte-level)

- `collision-bodies` gains composite vector-key and vector-set byte fixtures. JVM half pins the tokens against the live printer and reads count-2 (same-host blindness); CLJS half reads the exact bytes and proves the shipped reader rejects them as duplicates — the red-before.
- `cross-host-numeric-collision-fails-before-emission` gains composite map-key, composite set-element, and a DEEP (map→vector→map→set, path `[:props :xs 0 :k]`) arm, each with the `edn-carryable?` lever and full path/collapses/browser-number evidence.
- `a-mutation-that-resolves-the-collision-emits-fine` gains resolving composite mutations (vacuity) plus a distinct-composite-key case that must still emit.

## Quality gates

- `cd implementation/ssr && clojure -M:test` — **506 tests / 2437 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — **10326 tests / 50920 assertions, 0 failures, 0 errors**
- `python -m mkdocs build --strict` — OK (23.7s, no warnings)
- `check_doc_slugs.py` skipped — spec/011 not touched.

Do NOT merge.
