### PR TITLE
test: scope the two remaining async global diagnostic witnesses (rf2-veyfp)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
@@ -401,10 +401,21 @@
                     "the delta (which arrived FIRST) is quarantined once its boundary resolved FAILED — never merged")
                 (is (zero? (count (array-seq (.querySelectorAll host (str "[" wire/attr-suspense-hydrate "]")))))
                     "the contradictory delta script is consumed")
+                ;; Scope the match to THIS boundary's own id. `captured` is a
+                ;; PROCESS-GLOBAL trace listener — it observes every namespace's
+                ;; events, including any deferred emit a sibling suite leaked into
+                ;; this test's `js/setTimeout` settle window — so an
+                ;; `:operation`+`:recovery`-only match could go green on a foreign
+                ;; `:quarantined-delta` while THIS `:card.flaky` boundary emitted
+                ;; none (the rf2-veyfp false-green). The producer carries the
+                ;; authored boundary under `[:tags :id]` (see string-boundary-id
+                ;; test); scoping by it is a pure narrowing — it can only reject a
+                ;; foreign boundary, never loosen the subject match.
                 (is (some #(and (= :rf.ssr/suspense-boundary-failed (:operation %))
-                                (= :quarantined-delta (:recovery %)))
+                                (= :quarantined-delta (:recovery %))
+                                (= :card.flaky (-> % :tags :id)))
                           @captured)
-                    ":quarantined-delta diagnostic emitted for the failed-boundary delta")
+                    ":quarantined-delta diagnostic emitted for the :card.flaky failed-boundary delta")
                 (stop!)
                 (remove-root! host)
                 (done))

--- a/implementation/ui/test/re_frame/ui/adapter_generation_fence_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/adapter_generation_fence_dom_cljs_test.cljs
@@ -232,7 +232,13 @@
             cap       (rf/capture-frame :qt/frame)        ;; pins incarnation A
             errors    (atom [])
             cleanup   (js/Error. "queue-then-throw host cleanup")]
-        (rf/register-listener! :errors ::qt-leak (fn [r] (swap! errors conj (:error r))))
+        ;; Retain the FULL error record (not just `(:error r)`): `:errors` is a
+        ;; PROCESS-GLOBAL always-on listener, so a bare `:error`-kw match could go
+        ;; green on a foreign `:rf.error/frame-destroyed` a sibling suite leaked
+        ;; into one of the act / queued-microtask / mount / macrotask settle
+        ;; windows this test crosses (the rf2-veyfp false-green). Keeping the
+        ;; record lets the assertion scope to THIS frame's own attribution.
+        (rf/register-listener! :errors ::qt-leak (fn [r] (swap! errors conj r)))
         (-> (act-promise
              #(vreset! root* (ui/mount [cell-less-root] container {:root-id :qt/root})))
             (.then
@@ -271,9 +277,25 @@
                (is (nil? (:leaked? (rf/app-db-value :qt/frame)))
                    "the queued predecessor captured dispatch did not enter same-id
                     frame B — clearing DOM/markers was not treated as settlement")
-               (is (some #{:rf.error/frame-destroyed} @errors)
+               ;; Scope to THIS frame's own stale op. Matching only the
+               ;; `:rf.error/frame-destroyed` category would accept a foreign
+               ;; same-category record a sibling suite leaked into a settle
+               ;; window. The subject record carries its own attribution — the
+               ;; core `capture-frame` stale-dispatch path stamps `:frame
+               ;; :qt/frame`, `:event-id :qt/mutate`, `:event [:qt/mutate]`, and
+               ;; `:op :dispatch-sync` — so require all of them. A pure
+               ;; narrowing: it still matches the subject's own emit, but a
+               ;; foreign same-category record cannot substitute.
+               (is (some #(and (= :rf.error/frame-destroyed (:error %))
+                               (= :qt/frame (:frame %))
+                               (= :qt/mutate (:event-id %))
+                               (= [:qt/mutate] (:event %))
+                               (= :dispatch-sync (:op %)))
+                         @errors)
                    "the superseded queued dispatch recovered-but-emitted
-                    :rf.error/frame-destroyed")
+                    :rf.error/frame-destroyed for THIS frame's own stale
+                    :dispatch-sync op (a foreign same-category record cannot
+                    satisfy it)")
                (rf/unregister-listener! :errors ::qt-leak)
                (act-promise rf/destroy-adapter!)))
             (.then (fn [] (done))


### PR DESCRIPTION
Completes PR #6488. Its mounted-DOM census scoped two process-global *listener* assertions but missed two async *positive* witnesses in the same false-green class — each accepted ANY matching-category async event, so a foreign event leaked into a `js/setTimeout` settle window could substitute for the subject event.

Reopened by the chronological three-lens audit of #6488 (rf2-veyfp). This applies the SAME one-conjunct narrowing #6488 used (scope each witness to its own test's identity).

## The two witnesses (fix scope: these two predicates only)

**1. `implementation/ssr/.../streaming_client_dom_cljs_test.cljs` — `failed-boundary-suppresses-delta-arriving-first`**
The `:quarantined-delta` assertion matched only `:operation` + `:recovery`. Now it also requires the authored boundary under `[:tags :id]` = `:card.flaky` (the producer already carries it — same slot the `string-boundary-id` and #6488 `exactly-once` tests read). A foreign boundary's `:quarantined-delta` can no longer satisfy it.

**2. `implementation/ui/.../adapter_generation_fence_dom_cljs_test.cljs` — `queue-then-throw-cleanup-cannot-enter-a-same-id-successor`**
The `:errors` listener discarded attribution (`(swap! errors conj (:error r))`) and the assertion accepted any `:rf.error/frame-destroyed`. It now retains the FULL record and matches the subject's own attribution: `:frame :qt/frame`, `:event-id :qt/mutate`, `:event [:qt/mutate]`, `:op :dispatch-sync` (empirically confirmed on the record — the stale dispatch flows through core's `capture-frame` path, which carries the un-redacted `:event`). A foreign same-category record cannot substitute.

Both are pure narrowings (added conjuncts / retained record): strictly stronger, still matched by each subject's own emit. **No runtime change, no listener registry, no shared framework, no general checker** — the deferred `frame_provider_context` source leak was separately fixed by rf2-vp3m9/#6502 and is untouched here.

## Quality gates
Run in the worktree off current `origin/main`:

- `implementation/ssr` JVM `clojure -M:test` — **506 tests, 2410 assertions, 0 failures, 0 errors**
- `implementation/ui` JVM `clojure -M:test` — **1001 tests, 19593 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node) — **10326 tests, 50908 assertions, 0 failures, 0 errors**
- `npm run test:browser` (Chromium, in-suite) — **504 tests, 2834 assertions, 0 failures, 0 errors**
- **Run-alone** (single-namespace Chromium, each corrected ns in isolation): `streaming-client-dom-cljs-test` **16 tests / 107 assertions, 0 failures**; `adapter-generation-fence-dom-cljs-test` **3 tests / 21 assertions, 0 failures** — each witness matches its own subject event with no siblings present (self-contained).
- **Substitute probe** (temporary, reverted): flipping each scoped identity to a non-emitted value (`:card.flaky-PROBE-FOREIGN` / `:qt/frame-PROBE-FOREIGN`) reds **exactly these two tests and nothing else** — proving each scoped predicate is load-bearing and non-vacuous. The probe's `actual` dumps showed each witness buffer held ONLY its subject's own events (streaming: two `:card.flaky` events; ui: one `:qt/frame` record) — no foreign pollution present even in the full suite.

One unrelated flaky red (`identical-compiled-root-adopts-cleanly-then-flips-in-one-update`, `actual (not (= 1 0))`) appeared once under 112-process resource contention and cleared on re-run — not in the touched surface.