### PR TITLE
docs(api): make epoch-listener guidance frame-qualified, publication-shaped, and termination-aware (rf2-lwqmu)

### DIFF
--- a/docs/api/re-frame.core.md
+++ b/docs/api/re-frame.core.md
@@ -1181,7 +1181,7 @@ There is deliberately **no** facade `clear-listeners!` verb. Dropping every list
   ```clojure
   (epoch-history frame-id) → vector of epoch records
   ```
-- **Description**: Per-frame epoch snapshots in dev builds. Ordinary event processing commits one record per dequeued event, not one per drain: a parent and the `:fx [[:dispatch …]]` child it queues are separate records, while a machine macrostep stays a single epoch. `replace-frame-state!` writes and depth/destroy halts also land synthetic records (see [Epoch-settled listeners](#epoch-settled-listeners)). Returns `[]` for an unknown / destroyed frame. Used by pair-shaped tools for time-travel and post-mortem analysis. Production builds elide entirely. See [re-frame.epoch.md](re-frame.epoch.md).
+- **Description**: Per-frame epoch snapshots in dev builds. Ordinary event processing commits one record per dequeued handled event, not one per drain: a parent and the `:fx [[:dispatch …]]` child it queues are separate records, while a machine macrostep stays a single epoch. `replace-frame-state!` writes and `:halted-depth` halts also land synthetic records; a `:halted-destroy` halt is published to listeners only, never retained here (see [Epoch-settled listeners](#epoch-settled-listeners)). Returns `[]` for an unknown / destroyed frame. Used by pair-shaped tools for time-travel and post-mortem analysis. Production builds elide entirely. See [re-frame.epoch.md](re-frame.epoch.md).
 - **Example**:
   ```clojure
   (rf/epoch-history :app/main)
@@ -1231,12 +1231,14 @@ There is deliberately **no** facade `clear-listeners!` verb. Dropping every list
 Epoch-settled listeners are the `:epoch` stream of the stream-parameterized listener verb. There is no separate facade `register-epoch-listener!` fn — the per-channel pair was retired in API-shrink #4. The epoch stream registers through the one verb exactly like `:trace` / `:events` / `:errors`.
 
 - **Signature**: `(rf/register-listener! :epoch key callback-fn)` / `(rf/unregister-listener! :epoch key)`
-- **Description**: Process-global assembled-epoch listener, dev-only. The callback is a record-**publication** notification, not a once-per-event clock. It receives the assembled `:rf/epoch-record` when an epoch first commits, and again — carrying the same `:epoch-id` — when a post-settle backfill (a late render, sub-run, or unmount attributed to that epoch) corrects the record, so a consumer caching `epoch-history` re-syncs to the fixed snapshot. It also receives synthetic records that no dequeued event produced: a `:rf.epoch/db-replaced` record for each `replace-frame-state!` write, and a `:halted-depth` / `:halted-destroy` record when a drain halts. Reconcile on `:epoch-id` and `:outcome` rather than counting callbacks as events. Re-registering the same `key` replaces. A callback whose previously-observed frame is destroyed receives a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace. Returns `key`, or `nil` when the `day8/re-frame2-epoch` artefact is absent.
+- **Description**: Process-global assembled-epoch listener, dev-only. The callback is a record-**publication** notification, not a once-per-event clock. It receives the assembled `:rf/epoch-record` when an epoch first commits, and again — carrying the same `:epoch-id` — when a post-settle backfill (a late render, sub-run, or unmount attributed to that epoch) corrects the record, so a consumer caching `epoch-history` re-syncs to the fixed snapshot. It also publishes non-ordinary records: a `:rf.epoch/db-replaced` record for each `replace-frame-state!` write and a `:halted-depth` record when a drain hits the depth ceiling (both ring-retained when depth permits), plus the terminal `:halted-destroy` — an already-started event interrupted by frame destruction, delivered to listeners only and never retained. Because the listener is process-global while `:epoch-id` is unique only within one frame, reconcile on the pair `[(:frame record) (:epoch-id record)]` — cache under that key and replace on re-publication rather than counting callbacks; `:outcome` is record state, not identity. Re-registering the same `key` replaces. A callback whose previously-observed frame is destroyed receives a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace. Returns `key`, or `nil` when the `day8/re-frame2-epoch` artefact is absent.
 - **Example**:
   ```clojure
+  ;; Key by [frame epoch-id]; a re-published record replaces its entry.
+  (def epochs (atom {}))
   (rf/register-listener! :epoch :my-app/epoch-watch
     (fn [record]
-      (js/console.log (:frame record) (:epoch-id record))))
+      (swap! epochs assoc [(:frame record) (:epoch-id record)] record)))
 
   (rf/unregister-listener! :epoch :my-app/epoch-watch)
   ```

--- a/docs/api/re-frame.epoch.md
+++ b/docs/api/re-frame.epoch.md
@@ -1,6 +1,6 @@
 # re-frame.epoch
 
-`re-frame.epoch` is the per-frame epoch-history surface: dev-only time-travel and post-mortem. On each dequeued event, the runtime records one `:rf/epoch-record` into a per-frame ring buffer. Recording happens at the event's run-to-completion boundary, not once per drain. Each record captures before/after frame-state, the triggering event, and the harvested trace stream. Pair-shaped tools (Xray, re-frame2-pair, Story) read this history. Production builds (`:advanced` + `goog.DEBUG=false`) elide the whole surface: no allocation, no storage, no overhead.
+`re-frame.epoch` is the per-frame epoch-history surface: dev-only time-travel and post-mortem. On each handled event, the runtime records one `:rf/epoch-record` into a per-frame ring buffer. Recording happens at the event's run-to-completion boundary, not once per drain. Each record captures before/after frame-state, the triggering event, and the harvested trace stream. Pair-shaped tools (Xray, re-frame2-pair, Story) read this history. Production builds (`:advanced` + `goog.DEBUG=false`) elide the whole surface: no allocation, no storage, no overhead.
 
 ```clojure
 (:require [re-frame.epoch :as epoch])
@@ -10,7 +10,7 @@ Most of this surface is re-exported on the `re-frame.core` facade, so `rf/restor
 
 ## Epoch history
 
-Per-frame epoch snapshots, recorded on each dequeued event's run-to-completion in dev builds. Read by pair-shaped tools for time-travel and post-mortem. Production builds elide entirely.
+Per-frame epoch snapshots, recorded on each handled event's run-to-completion in dev builds. Read by pair-shaped tools for time-travel and post-mortem. Production builds elide entirely.
 
 ### `epoch-history`
 
@@ -111,16 +111,20 @@ Per-frame epoch snapshots, recorded on each dequeued event's run-to-completion i
   (register-epoch-listener! id callback-fn) → id
   ```
 - **Description**: Registers a process-global assembled-epoch listener. Returns the `id`. The app-facing route is `(rf/register-listener! :epoch id callback-fn)`, the `:epoch` stream of the one stream-parameterized listener verb. `epoch/register-epoch-listener!` is the direct epoch-namespace form of the same registry. There is no `rf/register-epoch-listener!` facade re-export; it was retired in API-shrink #4.
-  - `callback-fn` is invoked with the fully-assembled raw `:rf/epoch-record`, after it lands in the frame's ring buffer. Records commit once per dequeued event, but the callback is **not** one-invocation-per-event: the same `:epoch-id` re-publishes when a post-settle render / sub-run / unmount back-fills into an already-settled epoch (a corrected same-`:epoch-id` record), and synthetic records fire with no dequeued event at all (`:rf.epoch/db-replaced` from `replace-frame-state!`, and the terminal `:halted-destroy`). Reconcile on `:epoch-id` + `:outcome`; do not count callbacks as events. Listeners receive every record regardless of `:outcome`.
+  - `callback-fn` is invoked with the fully-assembled raw `:rf/epoch-record`. The callback is a record **publication** notification, not a once-per-event clock. An ordinary handled event publishes one initial record when it settles; the SAME record re-publishes — carrying the same `:epoch-id` — when a post-settle render / sub-run / unmount back-fills into that already-settled epoch (a corrected record). Non-ordinary records publish too: `:rf.epoch/db-replaced` for each `replace-frame-state!` write and a `:halted-depth` record when a drain hits the depth ceiling (both ring-retained when depth permits), plus the terminal `:halted-destroy` — an already-started event interrupted by frame destruction, delivered to listeners only and never retained (the destroyed frame's history is already gone). A dequeued event rejected before it runs (no handler) publishes nothing.
+  - The listener is **process-global**, but `:epoch-id` is unique only within one frame's history. Reconcile on the pair `[(:frame record) (:epoch-id record)]`: cache each record under that key and REPLACE it on re-publication, so a same-identity backfill corrects the snapshot rather than double-counting. `:outcome` is record STATE (`:ok` / `:halted-depth` / `:halted-destroy`) read off the record — not part of its identity and not an event counter. Listeners receive every record regardless of `:outcome`.
   - `id` may be any comparable value; registering the same `id` twice replaces.
   - Listener exceptions are caught and isolated, emitting `:rf.epoch.cb/listener-exception`. One broken listener cannot block others.
   - When a frame that a callback has observed is destroyed, the framework emits a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace for that callback.
 
 ```clojure
-;; Observe each assembled epoch as frames settle (app-facing route).
+;; Reconcile a per-[frame epoch-id] cache as records publish. Re-publication
+;; (a backfilled same-identity record) REPLACES its entry, so it corrects the
+;; snapshot rather than double-counting (app-facing route).
+(def epochs (atom {}))
 (rf/register-listener! :epoch :my-app/epoch-watch
   (fn [record]
-    (js/console.log (:frame record) (:epoch-id record))))
+    (swap! epochs assoc [(:frame record) (:epoch-id record)] record)))
 
 ;; Equivalent direct epoch-namespace form.
 (epoch/register-epoch-listener! :my-app/epoch-watch


### PR DESCRIPTION
## Summary

The shipped epoch listener is a **publication stream**, but the two api docs still described it in ways that were not frame-qualified, publication-shaped, or termination-aware. This adds those three angles to `docs/api/re-frame.core.md` and `docs/api/re-frame.epoch.md`, building on #6498's (ablz8) per-event + re-publication model and #6499's (69fyr) sweep — not re-doing or contradicting them.

### The missing angles

- **frame-qualified** — the listener is process-global while `:epoch-id` is unique only within one frame's history. Guidance now reconciles on the pair `[(:frame record) (:epoch-id record)]`, and `:outcome` is described as record state (`:ok` / `:halted-depth` / `:halted-destroy`), not identity. Previously both docs said "reconcile on `:epoch-id` + `:outcome`" (bare-ID, outcome-as-identity).
- **publication-shaped** — a same-identity backfill (late render / sub-run / unmount) re-publishes the record. The worked example now caches by `[frame epoch-id]` and **replaces** on re-publication, so a backfill corrects the snapshot rather than double-counting.
- **termination-aware** — `:rf.epoch/db-replaced` and `:halted-depth` are ring-retained when depth permits; `:halted-destroy` is an **already-started** event interrupted by frame destruction, delivered to listeners only and **never retained** (the destroyed frame's history is gone). A no-handler dequeue publishes nothing. Previously the docs grouped depth/destroy halts together and the `epoch-history` description wrongly claimed destroy halts land in history.

### Consistency with #6498 / #6499

ablz8's publication / not-once-per-event / same-`:epoch-id` re-publication prose is preserved verbatim; the additions layer on top. Corrected only the factual misclassifications the bead flags (destroy-halt-in-history, bare-ID reconciliation). No code, spec, or checker changes — docs/api only.

## Quality gates

- `python -m mkdocs build --strict` → exit 0
- `python scripts/check_doc_slugs.py` → exit 0
- `implementation/ui` guide-truth JVM test — **not applicable**: `guide_truth_jvm_test.clj` pins `docs/core/*`, `spec/Ownership.md`, `spec/004-Views.md`, `spec/API.md`, and the EP docs, not `docs/api/re-frame.core.md` or `docs/api/re-frame.epoch.md` (verified by grep). Skipped per brief.

Closes rf2-lwqmu.
