### PR TITLE
fix(ui): carry raw subscribe-realm query identity on the frames.cljc frame-destroyed egress (rf2-wd4ac)

### DIFF
--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -1112,10 +1112,12 @@
 
   The record carries the exact `frame-id`, the failing `op`
   (`:dispatch` / `:dispatch-sync` / `:subscribe`, or `:capture` for a `(frame)`
-  read that resolved a dead incarnation), and the attempted `payload` (the event
-  or query vector, as the record's elided `:event`; its head as `:event-id`) so
-  an off-box shipper attributes the failure. `payload` is nil for the `:capture`
-  arm (the read failed before any op was invoked).
+  read that resolved a dead incarnation), and the attempted `payload` on the
+  record's `:event` slot (its head as `:event-id`) so an off-box shipper
+  attributes the failure. A SUBSCRIBE query vector is public IDENTITY (rf2-zwgqe
+  / rf2-alk8a) and rides `:event` RAW; a DISPATCH / dispatch-sync payload is
+  redacted to `:rf/redacted` (see the fail-closed section). `payload` is nil for
+  the `:capture` arm (the read failed before any op was invoked).
 
   The THROWN exception mirrors the same STRUCTURAL attribution in its `:extra`
   ex-data — `:frame`, `:op`, and the event/query `:event-id` HEAD (rf2-r79gr) —
@@ -1145,34 +1147,61 @@
   the walk would BORROW the successor's (unrelated, possibly permissive) policy
   and project incarnation A's raw payload off-box — under BOTH the corpus-wide
   record AND the frame-owned observability sink route, which `dispatch-on-error!`
-  feeds the RAW event. We therefore redact the payload BODY to the reserved
-  `:rf/redacted` sentinel HERE, at the only site that knows the incarnation is
-  dead: the structural event/query HEAD still rides `:event-id`, no successor
-  policy can be borrowed, and no policy-snapshot machinery is introduced. The
-  absent-frame and destroyed-without-successor arms fail closed identically."
+  feeds the RAW event. We therefore redact a DISPATCH / dispatch-sync payload
+  BODY to the reserved `:rf/redacted` sentinel HERE, at the only site that knows
+  the incarnation is dead: the structural event/query HEAD still rides
+  `:event-id`, no successor policy can be borrowed, and no policy-snapshot
+  machinery is introduced. The absent-frame and destroyed-without-successor arms
+  fail closed identically.
+
+  The SUBSCRIBE realm is EXEMPT from this source-redaction (rf2-alk8a). A
+  subscription query vector is public IDENTITY, not payload (rf2-zwgqe / Spec
+  015 — \"a subscription's query vector is identity, and it egresses raw\"), so
+  it rides `:event` VERBATIM. rf2-t55hxg.18's unresolvable-frame fail-closed
+  guards policy-walked VALUE slots — an identity slot never consults frame
+  policy, so there is no successor policy to borrow: downstream
+  `error-emit/raw-identity-query-vector-event?` (keyed on the ratified-public
+  `:op :subscribe` this seam stamps) SKIPS elision on the query vector across
+  BOTH egress routes, exactly as the core subscribe emitters do after #6497.
+  This mirrors `subs/emit-frame-destroyed-recovery!` and
+  `observation/throw-frame-destroyed!`; only the DISPATCH realm stays redacted."
   [frame-id op payload reason]
-  (let [;; Body redacted at source (rf2-01ihi) — a dead incarnation has no
-        ;; trustworthy policy for its captured payload on EITHER channel. nil
-        ;; for the `:capture` arm (no op was invoked, so no payload to redact).
-        redacted-event (when (some? payload) privacy/redacted-sentinel)
+  (let [;; A SUBSCRIBE query vector is public IDENTITY (rf2-zwgqe / rf2-alk8a),
+        ;; NOT payload, so it egresses RAW (see the fail-closed section above).
+        ;; Keyed on `=`, NEVER `identical?`, on the keyword operand — a `.cljc`
+        ;; `identical?` keyword compare is JVM-only sound and CLJS-unreachable
+        ;; (#6365).
+        subscribe?     (= :subscribe op)
+        ;; The event/query BODY that egresses on the always-on `:event` slot AND
+        ;; the dev-trace `:event` tag. For the SUBSCRIBE realm it is the RAW
+        ;; query vector (identity — downstream `raw-identity-query-vector-event?`
+        ;; skips elision on it, so no dead/successor frame policy is ever
+        ;; consulted). For a DISPATCH / dispatch-sync it is a dispatched event
+        ;; vector — payload, not identity — redacted at source to the reserved
+        ;; `:rf/redacted` sentinel (rf2-01ihi): a dead incarnation has no
+        ;; trustworthy policy, and a same-id successor's policy must never be
+        ;; borrowed to un-redact it. nil for the `:capture` arm (no op ran).
+        egress-event   (cond
+                         (nil? payload) nil
+                         subscribe?     payload
+                         :else          privacy/redacted-sentinel)
         ;; The STRUCTURAL event/query HEAD — the attempted vector's first
-        ;; element (the event-id / sub-id keyword), NEVER the raw payload body
-        ;; (rf2-01ihi redacts the body; only the head survives). nil for the
-        ;; `:capture` arm. Rides BOTH the always-on record's `:event-id` slot
-        ;; AND the thrown exception's `:extra :event-id` (rf2-r79gr), so a
-        ;; synchronous catcher attributes the stale op from the exception alone,
-        ;; without correlating the async record stream — head only, so no
-        ;; successor elision policy can be borrowed to egress the body.
+        ;; element (the event-id / sub-id keyword). Rides BOTH the always-on
+        ;; record's `:event-id` slot AND the thrown exception's `:extra
+        ;; :event-id` (rf2-r79gr), so a synchronous catcher attributes the stale
+        ;; op from the exception alone. The raw payload BODY never rides the
+        ;; thrown exception on ANY realm — the subscribe query vector egresses
+        ;; raw only on the always-on record's `:event` slot, not the exception.
         event-id       (when payload (first payload))]
     (error-emit/emit-error-both!
      :rf.error/frame-destroyed
-     redacted-event                  ;; attempted event/query body, redacted at source (elided as :event); nil for :capture
+     egress-event                    ;; :event — RAW query vector for :subscribe (identity); :rf/redacted for dispatch; nil for :capture
      event-id                        ;; :event-id / sub-id — the structural vector head (survives)
      frame-id
      nil                             ;; no exception — a dead-incarnation op, not a caught throw
      0                               ;; elapsed-ms — not a timed path
      (interop/now-ms)                ;; time
-     {:frame frame-id :op op :event redacted-event :reason :frame-destroyed} ;; dev-trace tags (axis 2)
+     {:frame frame-id :op op :event egress-event :reason :frame-destroyed} ;; dev-trace tags (axis 2)
      {:op op})                       ;; category-specific attribution for the always-on record (axis 1)
     (error/throw-error!
      :rf.error/frame-destroyed 're-frame.ui/frame

--- a/implementation/ui/test/re_frame/ui/frame_ops_always_on_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/frame_ops_always_on_elision_prod_test.cljs
@@ -118,6 +118,48 @@
           (is (not (deep-contains? r :TOP-SECRET))
               "the raw secret reaches the production record NOWHERE"))))))
 
+(deftest stale-subscribe-across-reincarnation-egresses-raw-under-prod
+  (testing "Per rf2-wd4ac / rf2-alk8a: under `:advanced` + goog.DEBUG=false —
+            where the dev trace (axis 2) is DCE'd and the always-on record is the
+            SOLE surviving channel — a stale SUBSCRIBE bundle op fired after a
+            same-id reincarnation egresses its query vector RAW (identity, not
+            payload) on the `:event` slot with `:op :subscribe`. Incarnation A
+            owns a sensitive elision policy; successor B is unclassified. A query
+            vector is identity, so the raw-identity path SKIPS elision and no A/B
+            frame policy is walked — the raw vector survives the prod build. This
+            is the production pin that #6497's core subscribe raw egress and the
+            UI seam agree under `:advanced`. Contrast the dispatch-sync leg above,
+            whose payload fails closed to `:rf/redacted`."
+    (rf/reg-event :prod.reinc/classify
+      (fn [{:keys [db]} _]
+        {:db        (assoc-in db [:secret] "A-owned")
+         :sensitive [[:secret]]}))
+    (rf/reg-sub :prod.reinc/n (fn [db _] (:n db)))
+    (make-frame! :prod.reinc.sub/id {:n 1})
+    (let [stale (rf/with-frame :prod.reinc.sub/id (frames/frame-ops))
+          seen  (atom [])
+          query [:prod.reinc/n {:token :SUBSCRIBE-IDENTITY}]]
+      ((:dispatch-sync stale) [:prod.reinc/classify])
+      (is (contains? (elision/sensitive-declarations :prod.reinc.sub/id) [:secret])
+          "incarnation A owns a sensitive elision policy")
+      (frame/destroy-frame! :prod.reinc.sub/id)
+      (make-frame! :prod.reinc.sub/id {:n 41})    ;; unclassified successor B
+      (is (empty? (elision/sensitive-declarations :prod.reinc.sub/id))
+          "successor B is permissive — its policy must NOT be walked over identity")
+      (rf/register-listener! :errors :prod/recorder (fn [r] (swap! seen conj r)))
+      (is (thrown? js/Error ((:subscribe stale) query))
+          "the stale subscribe still fails loud with the typed error under prod")
+      (let [reports (filter #(= :rf.error/frame-destroyed (:error %)) @seen)]
+        (is (= 1 (count reports)) "EXACTLY ONE always-on record survives prod")
+        (let [r (first reports)]
+          (is (= :prod.reinc.sub/id (:frame r)) ":frame names the captured incarnation")
+          (is (= :subscribe (:op r)) ":op :subscribe stamps the raw-identity realm")
+          (is (= :prod.reinc/n (:event-id r)) ":event-id is the structural query head")
+          (is (= query (:event r))
+              ":event carries the RAW query vector VERBATIM under prod — identity, not elided")
+          (is (deep-contains? r :SUBSCRIBE-IDENTITY)
+              "the raw query-vector identity survives the prod build in the record"))))))
+
 (deftest absent-capture-fans-one-always-on-record-under-prod
   (testing "Per rf2-vxgfnd.230: the absent/closing `(frame)` CAPTURE arm follows
             the same prod-survival contract — a `(frame)` read resolving a stamp

--- a/implementation/ui/test/re_frame/ui/frame_ops_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/frame_ops_cljs_test.cljc
@@ -221,8 +221,12 @@
               (is (= :rf.error/frame-destroyed (:error r)))
               (is (= :ops/doomed (:frame r)) ":frame names the destroyed frame")
               (is (= op (:op r)) ":op names the failing bundle operation")
-              ;; :event fails closed to :rf/redacted under the unresolvable
-              ;; (destroyed) frame; the structural :event-id head survives.
+              ;; This leg pins the realm-AGNOSTIC structural attribution (one
+              ;; record + one trace, frame / op / head). The `:event` BODY policy
+              ;; is realm-specific and pinned elsewhere: a dispatched payload
+              ;; fails closed to `:rf/redacted`
+              ;; (`frame-ops-reincarnation-elision-cljs-test`), while a subscribe
+              ;; query vector egresses RAW as identity (rf2-wd4ac, same file).
               (is (= head (:event-id r)) ":event-id is the attempted vector head"))
             (is (= 1 (count traces))
                 "exactly ONE dev trace on the axis-2 surface")))))))

--- a/implementation/ui/test/re_frame/ui/frame_ops_reincarnation_elision_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/frame_ops_reincarnation_elision_cljs_test.cljc
@@ -15,14 +15,23 @@
   (A's payload under unrelated successor B's authority), on BOTH the corpus-wide
   record and the frame-owned observability sink route.
 
-  These legs pin the fix: the dead-incarnation emit seam
-  (`emit-and-throw-frame-destroyed!`) redacts the payload BODY to `:rf/redacted`
-  AT SOURCE, so no successor policy can be borrowed. The record still retains the
-  category, the captured frame id, the operation, and the structural event/query
-  HEAD (`:event-id`). Dispatch, dispatch-sync, and subscribe stay
-  exact-incarnation fenced and still throw after EXACTLY ONE observability
-  fan-out. The absent-frame and destroyed-without-successor paths fail closed
-  identically.
+  These legs pin the fix: for a DISPATCH / dispatch-sync the dead-incarnation
+  emit seam (`emit-and-throw-frame-destroyed!`) redacts the payload BODY to
+  `:rf/redacted` AT SOURCE, so no successor policy can be borrowed. The record
+  still retains the category, the captured frame id, the operation, and the
+  structural event/query HEAD (`:event-id`). Dispatch, dispatch-sync, and
+  subscribe all stay exact-incarnation fenced and still throw after EXACTLY ONE
+  observability fan-out. The absent-frame and destroyed-without-successor paths
+  fail closed identically.
+
+  The SUBSCRIBE realm is the deliberate EXCEPTION (rf2-alk8a): a subscription
+  query vector is public IDENTITY, not payload (rf2-zwgqe / Spec 015), so it
+  egresses RAW on the always-on `:event` slot with `:op :subscribe` — downstream
+  `raw-identity-query-vector-event?` skips elision on it, so no dead / successor
+  frame policy is ever consulted. `stale-subscribe-across-reincarnation-egresses-raw-identity`
+  pins that raw egress; the dispatch legs above pin the WHAT-STAYS (dispatched
+  vectors remain source-redacted). This mirrors #6497's core-path fix in
+  `subs/emit-frame-destroyed-recovery!` / `observation/throw-frame-destroyed!`.
 
   Dual-runtime `*_cljs_test.cljc`: the shadow `:node-test` build
   (`npm run test:cljs`) AND the JVM `clojure -M:test` runner both run it. Plain
@@ -109,20 +118,20 @@
 (deftest stale-bundle-op-across-reincarnation-fails-closed
   (testing "Per rf2-01ihi: with DIVERGENT A/B policies — incarnation A OWNS a
             sensitive elision policy, successor B is unclassified/permissive — a
-            stale bundle op fired after the same-id reincarnation redacts the
-            attempted payload in the always-on record (never borrows B's policy),
-            while retaining the category, captured frame id, operation, and the
-            structural event/query head. Dispatch, dispatch-sync, and subscribe
-            all fail closed, each throwing after EXACTLY ONE fan-out."
+            stale DISPATCH / dispatch-sync bundle op fired after the same-id
+            reincarnation redacts the attempted payload in the always-on record
+            (never borrows B's policy), while retaining the category, captured
+            frame id, operation, and the structural event/query head. Both
+            dispatch realms fail closed, each throwing after EXACTLY ONE fan-out.
+            (The SUBSCRIBE realm is the deliberate raw-IDENTITY exception —
+            `stale-subscribe-across-reincarnation-egresses-raw-identity`.)"
     (rf/reg-event :reinc/classify
       (fn [{:keys [db]} _]
         {:db        (assoc-in db [:secret] "A-owned")
          :sensitive [[:secret]]}))
-    (rf/reg-sub :reinc/n (fn [db _] (:n db)))
     (doseq [[op invoke head]
             [[:dispatch      (fn [b] ((:dispatch b) secret-event))      :audit/secret]
-             [:dispatch-sync (fn [b] ((:dispatch-sync b) secret-event)) :audit/secret]
-             [:subscribe     (fn [b] ((:subscribe b) secret-event))     :audit/secret]]]
+             [:dispatch-sync (fn [b] ((:dispatch-sync b) secret-event)) :audit/secret]]]
       (testing (str "stale " op " across reincarnation")
         (make-frame! fid {:n 1})
         (let [stale (rf/with-frame fid (frames/frame-ops))]
@@ -146,8 +155,9 @@
               (is (= fid (:frame r))                       "captured frame id retained")
               (is (= op (:op r))                           "operation retained")
               (is (= head (:event-id r))                   "structural event/query head retained")
-              ;; THE FIX: the body is redacted at source — B's permissive policy
-              ;; can never be borrowed to ship A's raw payload.
+              ;; THE WHAT-STAYS: a dispatched event vector is payload, redacted
+              ;; at source — B's permissive policy can never be borrowed to ship
+              ;; A's raw payload (rf2-t55hxg.18 fail-closed stays for dispatch).
               (is (= privacy/redacted-sentinel (:event r))
                   ":event fails closed to the reserved sentinel, NOT B's identity walk")
               (is (not (deep-contains? r secret-value))
@@ -155,6 +165,74 @@
             ;; The dev trace (axis 2) is fenced at the same source.
             (is (not (some #(deep-contains? % secret-value) traces))
                 "the raw secret reaches the dev trace NOWHERE either")))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-wd4ac — the SUBSCRIBE realm is the deliberate raw-IDENTITY exception.
+;; A subscription query vector is public identity (rf2-zwgqe / rf2-alk8a / Spec
+;; 015), NOT payload. Even across a same-id reincarnation with a divergent A/B
+;; policy, the query vector egresses VERBATIM on the always-on `:event` slot
+;; with `:op :subscribe` — downstream `raw-identity-query-vector-event?` skips
+;; elision on it, so no dead-A / successor-B frame policy is EVER consulted. The
+;; UI frames.cljc seam now carries this raw identity, mirroring #6497's core-
+;; path fix (`subs/emit-frame-destroyed-recovery!`), rather than pre-redacting.
+;; ---------------------------------------------------------------------------
+
+;; A subscribe query vector whose body would be visibly mutated if any frame
+;; elision policy were (wrongly) walked over it — a distinctive identity leaf.
+(def ^:private subscribe-query [:reinc/n {:token :SUBSCRIBE-IDENTITY}])
+(def ^:private subscribe-identity-leaf :SUBSCRIBE-IDENTITY)
+
+(deftest stale-subscribe-across-reincarnation-egresses-raw-identity
+  (testing "Per rf2-alk8a: a stale SUBSCRIBE bundle op fired after a same-id
+            reincarnation — incarnation A OWNS a sensitive elision policy,
+            successor B is unclassified — egresses its query vector RAW on the
+            always-on `:event` slot with `:op :subscribe`. The query vector is
+            identity, so it is NOT elided and no A/B frame policy is consulted;
+            the structural head + captured frame id + operation ride alongside.
+            Still exactly ONE always-on record + ONE dev trace, then the typed
+            throw. Contrast the dispatch legs above, whose payload stays redacted."
+    (rf/reg-event :reinc/classify
+      (fn [{:keys [db]} _]
+        {:db        (assoc-in db [:secret] "A-owned")
+         :sensitive [[:secret]]}))
+    (rf/reg-sub :reinc/n (fn [db _] (:n db)))
+    (make-frame! fid {:n 1})
+    (let [stale (rf/with-frame fid (frames/frame-ops))]
+      ;; A owns a sensitive elision policy.
+      ((:dispatch-sync stale) [:reinc/classify])
+      (is (contains? (elision/sensitive-declarations fid) [:secret])
+          "incarnation A owns a non-empty sensitive elision policy")
+      ;; Destroy A; reincarnate an UNCLASSIFIED successor B under the same id.
+      (frame/destroy-frame! fid)
+      (make-frame! fid {:n 41})
+      (is (empty? (elision/sensitive-declarations fid))
+          "successor B is unclassified — a policy that must NOT be walked over identity")
+      ;; Fire A's stale subscribe into the same-id successor world.
+      (let [{:keys [records traces err-id]}
+            (capture-emissions #((:subscribe stale) subscribe-query))]
+        (is (= :rf.error/frame-destroyed err-id)
+            "the stale subscribe still fails loud with the canonical typed error")
+        (is (= 1 (count records)) "EXACTLY ONE always-on record")
+        (is (= 1 (count traces))  "EXACTLY ONE dev trace on axis 2")
+        (let [r (first records)]
+          (is (= :rf.error/frame-destroyed (:error r)) "category retained")
+          (is (= fid (:frame r))                       "captured frame id retained")
+          (is (= :subscribe (:op r))
+              ":op :subscribe stamps the realm (the raw-identity discriminator)")
+          (is (= :reinc/n (:event-id r))               "structural query head retained")
+          ;; THE FIX (red before rf2-wd4ac — the UI seam pre-redacted this to
+          ;; :rf/redacted): the query vector egresses RAW as identity.
+          (is (= subscribe-query (:event r))
+              ":event carries the RAW query vector VERBATIM — identity, not redacted")
+          (is (not= privacy/redacted-sentinel (:event r))
+              ":event is NOT the fail-closed sentinel for the subscribe realm")
+          ;; Non-vacuity: the identity leaf DOES reach the record (contrast the
+          ;; dispatch legs, which assert the payload reaches it NOWHERE).
+          (is (deep-contains? r subscribe-identity-leaf)
+              "the raw query-vector identity reaches the always-on record"))
+        ;; Axis 2 carries the same raw identity (the sibling raw dev-trace path).
+        (is (some #(deep-contains? % subscribe-identity-leaf) traces)
+            "the raw query vector rides the dev trace too")))))
 
 ;; ---------------------------------------------------------------------------
 ;; The sibling dead-incarnation paths fail closed identically.


### PR DESCRIPTION
Finishes the raw-query-identity work on the ui frames path, completing what #6497 (rf2-alk8a) established on the core path. Closes rf2-wd4ac.

## The gap

#6497 made the ordinary core subscribe + internal observation-port `:rf.error/frame-destroyed` records egress their query vector RAW (Option A, `:op :subscribe` stamped, per Spec 015 identity). The core emitters stamp `:op :subscribe` unconditionally so downstream `error-emit/raw-identity-query-vector-event?` (keyed on `:op :subscribe`) skips elision and egresses `:event` verbatim on both egress routes:

```clojure
;; subs/emit-frame-destroyed-recovery! (as merged in #6497)
(emit-error-both!
  :rf.error/frame-destroyed
  query-v                       ;; attempted query-vector (as :event) — RAW
  (first query-v)               ;; sub-id (as :event-id)
  ...
  {... :op :subscribe}          ;; dev-trace tags (axis 2)
  {:op :subscribe})             ;; always-on record realm attribution (axis 1)
```

But `implementation/ui/src/re_frame/ui/frames.cljc` funnels dispatch, dispatch-sync, subscribe, and capture through its own `emit-and-throw-frame-destroyed!` seam, which **unconditionally** redacted every non-nil payload to `:rf/redacted` *before* `emit-error-both!` ever saw it — so the subscribe realm never got the chance to route raw. That contradicted Spec 015 (query vectors ship verbatim) even though the axis-1 record already carried `:op :subscribe`.

## The extension

`emit-and-throw-frame-destroyed!` now computes the egress event realm-aware:

- `:subscribe` → the RAW query vector (public identity; downstream skips elision, so no dead-incarnation / successor-frame policy is ever consulted — rf2-t55hxg.18's fail-closed guards policy-walked VALUE slots, which an identity slot is not).
- `:dispatch` / `:dispatch-sync` → stays `:rf/redacted` at source (**WHAT-STAYS**, rf2-01ihi / rf2-t55hxg.18 — a dispatched event vector is payload, not identity).
- `:capture` → payload-free (no op ran).

The raw query vector rides both the always-on `:event` slot and the dev-trace `:event` tag, exactly like the core emitters. `:op :subscribe` compared with `=` (never `identical?` on a keyword literal — #6365, `.cljc` dual-host).

## What stays fixed / untouched

- The thrown exception is unchanged — head-only `:event-id` on **every** realm (the raw query vector egresses only on the always-on record, never the exception).
- Core path (`subs.cljc` / `observation.cljc` / `error_emit.cljc`) untouched — this extends #6497's mechanism, does not re-edit it.
- No new error id, no new axis, no realm-inference, no policy snapshot — the ratified `:op :subscribe` stamp and existing `:rf.error/frame-destroyed` id are reused.

## Tests (dual-host JVM + CLJS)

- `frame_ops_reincarnation_elision_cljs_test.cljc`: split the reincarnation deftest so the dispatch/dispatch-sync loop pins the WHAT-STAYS (dispatched vectors stay `:rf/redacted`), and added `stale-subscribe-across-reincarnation-egresses-raw-identity` pinning the raw query vector + `:op :subscribe` even across a divergent-policy same-id reincarnation.
- `frame_ops_always_on_elision_prod_test.cljs`: added a subscribe-raw prod leg pinning the raw egress survives `:advanced` + `goog.DEBUG=false`.
- `frame_ops_cljs_test.cljc`: corrected one misleading comment (the structural-attribution leg asserts only frame/op/head, so no assertion change).

## Quality gates

All foreground, run to completion:

- `cd implementation/ui && clojure -M:test` — **1002 tests, 0 failures**
- `cd implementation/core && clojure -M:test` — **2097 tests, 0 failures** (parses the Spec 009 catalogue; #6497's subscribe-raw conformance green)
- `npm run test:cljs` — **10327 tests, 0 failures**
- `npm run test:elision` — PASS (prod 60/60 absent, control 60/60 present)
- `npm run test:browser-prod-elision` — **114 tests, 0 failures** (ui mounted prod elision PASS)

## Out of scope (fenced off this worker; flagging for a follow-up)

The rf2-wd4ac bead description also mentions two completeness pins outside this UI surface: strengthening an existing observation-port destroyed-frame test, and reconciling `error_emit.cljc` architecture comments + a Spec 009 / Spec-Schemas doc pass. Those touch `observation.cljc` tests and hot-zone spec files, which this worker's brief explicitly fenced off — leaving them for a separate dispatch.
