### PR TITLE
docs(spec): correct the auto-elide misconception in the remaining spec/EP surfaces (rf2-3r8ap)

### DIFF
--- a/docs/EP/EP-0025-data-classification.md
+++ b/docs/EP/EP-0025-data-classification.md
@@ -216,8 +216,10 @@ is already a no-op, so when data disappears the redaction effectively disappears
 it. `:clear-sensitive` / `:clear-large` mainly matter when a path is *reused*
 for non-secret data, or when a subsystem tidies its registry on teardown.
 
-**Egress rules.** Sensitive wins over large at the same path. Large auto-elides an
-oversized value even at an undeclared path (the size backstop). A `:large`-marked
+**Egress rules.** Sensitive wins over large at the same path. An oversized value at an
+undeclared path is **not** auto-elided — the size threshold is advisory, firing
+`:rf.warning/large-value-unschema'd` while the value ships unchanged; declaring the
+path `:large` is what elides it. A `:large`-marked
 subtree containing a `:sensitive` descendant redacts rather than showing a size
 preview. **Classification does not propagate** — you redact exactly the paths you
 classify, and nothing is inherited (no "derived output takes its input's sensitivity,"

--- a/spec/015-Data-Classification.md
+++ b/spec/015-Data-Classification.md
@@ -381,7 +381,7 @@ Three rules keep the helper humble without weakening egress correctness:
 - **no** `:rf.egress/output-sensitivity` declassification claim (and no `:rf.egress/inherit` / `:rf.egress/sensitive` / `:rf.egress/public` value set) — there is nothing to declassify because nothing propagates; the key is gone and silently ignored if present;
 - **no** universal "same value redacted everywhere" value-match / taint engine (see the derived-tree note in [§project-egress](#project-egress--the-record-level-boundary-primitive)).
 
-This is a deliberate scope decision: propagation is machinery for an unusual case already covered by classifying the output path, and dropping it keeps the helper lightweight. The egress rules over the paths you *do* classify are unchanged: **sensitive wins over large** at the same path; a `:large`-marked subtree containing a `:sensitive` descendant redacts rather than showing a size preview; large auto-elides an oversized value even at an undeclared path (the size backstop).
+This is a deliberate scope decision: propagation is machinery for an unusual case already covered by classifying the output path, and dropping it keeps the helper lightweight. The egress rules over the paths you *do* classify are unchanged: **sensitive wins over large** at the same path; a `:large`-marked subtree containing a `:sensitive` descendant redacts rather than showing a size preview. An oversized value at an **undeclared** path is **not** auto-elided — the size threshold is advisory, firing `:rf.warning/large-value-unschema'd` once while the value ships unchanged; declaring the path `:large` is what elides it.
 
 ## Author guidance for the exception-path residual
 

--- a/spec/Privacy.md
+++ b/spec/Privacy.md
@@ -353,7 +353,7 @@ Per [API.md §Configure keys](API.md) and [015](015-Data-Classification.md):
 
 | `(rf/configure! {<key> {...}})` | Privacy-relevant opt | Default | Purpose |
 |---|---|---|---|
-| `:elision` | `:rf.size/threshold-bytes N` | `16384` | Wire-elision size cap. Non-negative integer; 0 disables runtime auto-detect (only declared / schema-marked entries elide). |
+| `:elision` | `:rf.size/threshold-bytes N` | `16384` | Wire-elision size threshold — advisory, **not** a cap. An over-threshold value at an undeclared path fires `:rf.warning/large-value-unschema'd` but ships unchanged; only declared / schema-marked entries elide. Non-negative integer; 0 disables the auto-detect warning. |
 | `:epoch-history` | `:redact-fn fn` | `nil` | **Projection-side** advanced override — runs at off-box egress (inside `projected-record`, after the frame/profile projection), never at storage (EP-0015 issue 6). See [Tool-Pair §Redaction hook](Tool-Pair.md). |
 | `:epoch-history` | `:depth N` / `:trace-events-keep N` | depth `50`, trace-events-keep `nil` | Bounds the ring (doesn't redact; bounds the surface). |
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -2826,7 +2826,8 @@ A frame owns two durable partitions held as one physical frame-state container (
   ;; (durable app-db, `:source :effect`), subsystem projection-relative
   ;; declarations (lowered per instance), and flow outputs — the sources UNION
   ;; at egress lookup. Un-declared over-threshold slots fire
-  ;; :rf.warning/large-value-unschema'd; the size backstop auto-elides them.
+  ;; :rf.warning/large-value-unschema'd (advisory only — the value ships
+  ;; unchanged); declaring the path `:large` is what elides it.
   ;; Schema-attached `:sensitive?` / `:large?` slot props do NOT feed this
   ;; registry (schemas describe shape, not durable app-db egress policy).
   [:map


### PR DESCRIPTION
## Summary

FINAL sweep of the advisory-vs-cap misconception, closing the family (nb51q #6522 did the 4 consumer docs incl. the security-critical keep-secrets; 1e984 #6520 did the migration example; this is the last spec/normative sites).

**Code-grounded truth (verified in `implementation/core/src/re_frame/elision.cljc`):** the wire-elision size threshold is an ADVISORY warning, **not** a cap. The `:leaf` handler (~975-989) emits `:rf.warning/large-value-unschema'd` for an undeclared large string and then returns the value **unchanged** (line 989 `v`); only a path declared `:large` elides, via the `:decide` arm's `->marker` (~949-962). This matches `spec/009` (~2787): "The walker does not auto-elide unschema'd values."

## Sites corrected (prose-only)

| Site | Was | Now |
|---|---|---|
| `spec/015-Data-Classification.md` (~384) | "large auto-elides an oversized value even at an undeclared path (the size backstop)" | advisory warning; declaring `:large` is what elides |
| `docs/EP/EP-0025-data-classification.md` (~219) | "Large auto-elides ... (the size backstop)" | advisory warning; declaring `:large` is what elides (**body only; EP status/metadata unchanged**) |
| `spec/Spec-Schemas.md` (~2829, HOT-ZONE) | "the size backstop auto-elides them" | advisory only, value ships unchanged; declaring `:large` elides |
| `spec/Privacy.md` (~356, HOT-ZONE) | "Wire-elision size **cap**" | advisory threshold, **not** a cap |

No code touched (`elision.cljc` is correct — this documents it). No EP status flip. Sole toucher of the two hot-zone files (Spec-Schemas, Privacy) in one sequential PR.

## Additional instances found (reported, NOT expanded per anti-sprawl guard)

The grep surfaced two further terse "size cap" glosses of the same misconception beyond the 4 assigned sites — `spec/Privacy.md:66` and `spec/Security.md:224` (both one-line summary-table labels). Per the bead's "if grep finds MORE, STOP + reassess" guard, these are left untouched for Mike to rule on. Other "size cap" matches are genuinely different mechanisms (author-side listener caps in the migration guide, declared-`:large` egress-profile handling, MCP/cursor caps) and correctly stay.

## Quality gates

- `python -m mkdocs build --strict` — exit 0
- `python scripts/check_doc_slugs.py` — exit 0
- `cd implementation/core && clojure -M:test` — 2097 tests, 10340 assertions, 0 failures, 0 errors

Closes rf2-3r8ap.
