### PR TITLE
fix(core): carry raw subscribe-realm identity on the frame-destroyed dev-trace projection (rf2-wd4ac)

### DIFF
--- a/implementation/core/src/re_frame/classification.cljc
+++ b/implementation/core/src/re_frame/classification.cljc
@@ -1078,7 +1078,26 @@
                         (contains? tags :rf.event/v)
                         (project-event-tags :rf.event/v)
 
-                        (contains? tags :event)
+                        ;; The bare `:event` slot on the realm-AMBIGUOUS
+                        ;; `:rf.error/frame-destroyed` trace carries a raw
+                        ;; subscription QUERY VECTOR in the `:subscribe` realm
+                        ;; (public IDENTITY — rf2-zwgqe / rf2-alk8a / Spec 015),
+                        ;; NOT a dispatched event. It egresses VERBATIM here,
+                        ;; mirroring the always-on record's
+                        ;; `error-emit/raw-identity-query-vector-event?` skip
+                        ;; (keyed on the SAME `:op :subscribe` realm the UI /
+                        ;; core emitters stamp). Projecting it would misread the
+                        ;; vector as a dispatched event and borrow a same-id
+                        ;; EVENT registration's `:sensitive` paths to mutate the
+                        ;; identity — a LEGAL event/sub id collision, since the
+                        ;; two live in SEPARATE registries (rf2-wd4ac). Every
+                        ;; OTHER `:event` slot still projects — including the
+                        ;; `:dispatch` / `:dispatch-sync` frame-destroyed realms,
+                        ;; whose `:event` IS a dispatched-event payload. `=` on
+                        ;; keyword operands, never `identical?` (#6365).
+                        (and (contains? tags :event)
+                             (not (and (= :rf.error/frame-destroyed operation)
+                                       (= :subscribe (:op tags)))))
                         (project-event-tags :event)
 
                         ;; `:rf.event/fx` — the WHOLE returned effect vector on

--- a/implementation/core/test/re_frame/frame_destroyed_subscribe_devtrace_identity_cljs_test.cljc
+++ b/implementation/core/test/re_frame/frame_destroyed_subscribe_devtrace_identity_cljs_test.cljc
@@ -1,0 +1,160 @@
+(ns re-frame.frame-destroyed-subscribe-devtrace-identity-cljs-test
+  "rf2-wd4ac (dev-trace arm) — the `:rf.error/frame-destroyed` DEV-TRACE `:event`
+  tag carries a raw subscription QUERY VECTOR in the `:subscribe` realm (public
+  IDENTITY — rf2-zwgqe / rf2-alk8a / Spec 015), and the classification projector
+  must NOT redact it.
+
+  ## The residual this file pins closed
+
+  #6516 (the wd4ac original) fixed the UI PRODUCER: `re-frame.ui.frames`'
+  `emit-and-throw-frame-destroyed!` now passes the raw query vector on BOTH the
+  always-on `:event` slot AND the dev-trace `:event` tag for the `:subscribe`
+  realm. The always-on egress (axis 1) then stays raw because
+  `error-emit/raw-identity-query-vector-event?` skips elision keyed on
+  `(:rf.error/frame-destroyed, :op :subscribe)`.
+
+  But the DEV-TRACE egress (axis 2) flows through
+  `re-frame.classification/project-trace-event`, which had NO realm-awareness:
+  it unconditionally ran the bare `:event` tag through
+  `redact-event-by-registration`, treating EVERY `:event` tag as a dispatched
+  event. Events and subscriptions live in SEPARATE registries, so a sub id may
+  LEGALLY collide with an event id. When it does, the colliding EVENT
+  registration's `:sensitive` paths were applied to the raw subscribe query
+  vector — mutating public identity at dev-trace egress. #6516's own dev-trace
+  assertion was VACUOUS against this: its query head (`:reinc/n`) was registered
+  only as a sub, so `redact-event-by-registration` was a no-op and the raw value
+  survived whether or not the projector was realm-aware.
+
+  ## The fix (rf2-wd4ac)
+
+  `project-trace-event` now SKIPS bare-`:event` registration projection for
+  `:rf.error/frame-destroyed` + `:op :subscribe` ONLY — mirroring the always-on
+  record's `raw-identity-query-vector-event?` skip on the same realm. Every
+  other `:event` tag still projects, INCLUDING the `:dispatch` / `:dispatch-sync`
+  frame-destroyed realms (whose `:event` IS a dispatched-event payload — they
+  KEEP their registration redaction).
+
+  ## Proof discipline (non-vacuity)
+
+  The collision is made REAL: an event registered under the SAME keyword as the
+  subscription declares `:token` sensitive, and the control assertion proves the
+  SAME registration DOES redact that vector through `redact-event-by-registration`
+  (the machinery is live and WOULD have bitten) — so the subscribe realm's raw
+  egress is the GUARD's doing, not an absent registration. The dispatch
+  counterpaths assert the redaction still lands, and capture stays payload-free.
+
+  Dual-runtime `*_cljs_test.cljc`: the shadow-cljs `:node-test`
+  (`npm run test:cljs`) AND the JVM `clojure -M:test` runner both pick it up.
+  Plain CLJC, no DOM dependency; `=` on keyword operands, never `identical?`
+  (#6365)."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.classification :as classification]
+            [re-frame.privacy :as privacy]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as ts]))
+
+(use-fixtures :each
+  (ts/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; A sub id that COLLIDES with an event id (legal — separate registries).
+(def ^:private shared-id :audit6516/same-id)
+;; The sub's parameterized query vector — public IDENTITY. `:token` is the arg
+;; the colliding event registration classifies sensitive.
+(def ^:private secret :RAW-IDENTITY)
+(def ^:private query-v [shared-id {:token secret}])
+;; The value the registration redacts the arg-map's `:token` to — the mutation
+;; the subscribe realm must NOT suffer, and the dispatch realm MUST.
+(def ^:private redacted [shared-id {:token privacy/redacted-sentinel}])
+
+(defn- register-colliding-event! []
+  ;; Register an EVENT under the SAME keyword as the subscription, declaring
+  ;; `:token` sensitive. `registration-classification :event shared-id` now
+  ;; derives `{:sensitive [[:token]]}`, so `redact-event-by-registration`
+  ;; redacts the arg-map's `:token`. Events and subs are separate registries —
+  ;; nothing about this makes the keyword a subscription.
+  (registrar/register! :event shared-id {:sensitive [[:token]]}))
+
+(defn- frame-destroyed-devtrace
+  "The axis-2 dev-trace event `emit-and-throw-frame-destroyed!` fans (frames.cljc):
+  `{:operation :rf.error/frame-destroyed :tags {:frame … :op … :event … …}}`."
+  [op event]
+  {:operation :rf.error/frame-destroyed
+   :tags {:frame :some-frame :op op :event event :reason :frame-destroyed}})
+
+(defn- project-event
+  "Project a frame-destroyed dev-trace through the single dev-trace chokepoint
+  and return its `:event` tag as the consumer would receive it."
+  [op event]
+  (get-in (classification/project-trace-event (frame-destroyed-devtrace op event))
+          [:tags :event]))
+
+;; ---------------------------------------------------------------------------
+;; 1. Headline — the subscribe realm preserves the raw query vector even with a
+;;    colliding, matching event registration (RED before rf2-wd4ac dev arm).
+;; ---------------------------------------------------------------------------
+
+(deftest frame-destroyed-subscribe-devtrace-preserves-raw-query-identity
+  (testing "a `:rf.error/frame-destroyed` + `:op :subscribe` dev trace ships its
+            query vector VERBATIM through project-trace-event even when a
+            same-id EVENT registration declares a matching `:sensitive` path."
+    (register-colliding-event!)
+    ;; Machinery intact: the SAME registration DOES redact this exact vector
+    ;; when routed through the event-vector chokepoint — so a raw subscribe
+    ;; egress below is the realm GUARD's doing, not an absent registration
+    ;; (the non-vacuity the #6516 dev-trace assertion lacked).
+    (is (= redacted (classification/redact-event-by-registration query-v))
+        "the colliding EVENT registration WOULD redact :token — machinery live")
+    ;; THE FIX: the subscribe realm skips bare-event projection.
+    (is (= query-v (project-event :subscribe query-v))
+        "frame-destroyed :subscribe dev-trace :event is the RAW query vector, VERBATIM")
+    (is (not= redacted (project-event :subscribe query-v))
+        "the query vector is NOT mutated to the redaction the registration would apply")
+    ;; Non-destructive: projection is egress-only — the raw vector is untouched.
+    (is (= secret (get-in query-v [1 :token]))
+        "projection did not mutate the raw query vector")))
+
+;; ---------------------------------------------------------------------------
+;; 2. Dispatch counterpath — the dispatch realms STILL project (WHAT-STAYS): a
+;;    dispatched event vector is payload, and keeps its registration redaction.
+;; ---------------------------------------------------------------------------
+
+(deftest frame-destroyed-dispatch-devtrace-still-projects
+  (testing "the `:dispatch` / `:dispatch-sync` frame-destroyed realms carry a
+            dispatched EVENT payload, so their dev-trace :event tag KEEPS the
+            registration redaction — the guard is realm-precise, not a blanket
+            frame-destroyed skip."
+    (register-colliding-event!)
+    (is (= redacted (project-event :dispatch query-v))
+        "frame-destroyed :dispatch dev-trace :event keeps its registration redaction")
+    (is (= redacted (project-event :dispatch-sync query-v))
+        "frame-destroyed :dispatch-sync dev-trace :event keeps its registration redaction")))
+
+;; ---------------------------------------------------------------------------
+;; 3. Capture — payload-free (WHAT-STAYS): the capture arm ran no op, so its
+;;    dev-trace :event is nil; projection leaves it nil.
+;; ---------------------------------------------------------------------------
+
+(deftest frame-destroyed-capture-devtrace-stays-payload-free
+  (testing "the `:capture` realm carries no op payload — its dev-trace :event is
+            nil, and projection is a no-op even with the colliding registration."
+    (register-colliding-event!)
+    (is (nil? (project-event :capture nil))
+        "frame-destroyed :capture dev-trace :event stays payload-free (nil)")))
+
+;; ---------------------------------------------------------------------------
+;; 4. Guard scope — the skip requires BOTH conjuncts. A NON-frame-destroyed
+;;    operation carrying `:event` still projects, so the guard cannot leak the
+;;    raw-identity exemption onto ordinary dispatched-event error traces.
+;; ---------------------------------------------------------------------------
+
+(deftest guard-scoped-to-frame-destroyed-operation
+  (testing "the raw-identity skip is scoped to :rf.error/frame-destroyed — a
+            different error operation carrying the same :event tag still projects
+            through its event registration (the operation conjunct is load-bearing)."
+    (register-colliding-event!)
+    (let [ev {:operation :rf.error/handler-exception
+              :tags {:frame :some-frame :op :subscribe :event query-v}}]
+      (is (= redacted (get-in (classification/project-trace-event ev) [:tags :event]))
+          "a non-frame-destroyed op's :event tag is NOT exempted — still redacted"))))


### PR DESCRIPTION
## Surface divergence from the brief (important)

The dispatch brief named `implementation/ui/src/re_frame/ui/frames.cljc` as the surface, but the **AUTHORITATIVE AUDIT REOPEN note** on rf2-wd4ac located the residual precisely in the core dev-trace **projector**, and the code confirms it:

- **#6516 already made `frames.cljc` correct.** `emit-and-throw-frame-destroyed!` passes the raw `egress-event` on BOTH the always-on `:event` slot *and* the dev-trace `:event` tag for the `:subscribe` realm (commit `5b4104f31d`, `frames.cljc:1220`). There was nothing left to fix there.
- **The always-on egress (axis 1) stays raw** via `error-emit/raw-identity-query-vector-event?`, keyed on `(:rf.error/frame-destroyed, :op :subscribe)`.
- **The dev-trace egress (axis 2)** flows through `classification/project-trace-event`, which had **no realm-awareness**: it ran every bare `:event` tag through `redact-event-by-registration`. Events and subs live in **separate registries**, so a sub id may **legally collide** with an event id. When it does, the colliding event's `:sensitive` paths mutated the raw subscribe query vector at dev-trace egress. This is the exact audit reproduction; #6516's dev-trace assertion was *vacuous* against it (its query head was sub-only, so the projection was a no-op regardless of realm-awareness).

The fix therefore lands in `implementation/core/src/re_frame/classification.cljc`, which is disjoint from the live SSR / ui-compiler workers.

## The fix

`project-trace-event` now skips bare-`:event` registration projection for `:rf.error/frame-destroyed` + `:op :subscribe` **only** — mirroring the always-on record's `raw-identity-query-vector-event?` skip on the same realm. `=` on keyword operands, never `identical?` (#6365).

## WHAT-STAYS (verified)

- **Dispatch / dispatch-sync** dev-trace `:event` still projects (keeps registration redaction) — pinned.
- **Capture** dev-trace `:event` stays payload-free (nil) — pinned.
- **No dispatched vector made raw.**
- **#6516's always-on slot, the `route-frame?` seam, and the corpus record are untouched** (this PR does not touch `frames.cljc` or `error_emit.cljc`).

## Regression (new, dual-host JVM + CLJS)

`implementation/core/test/re_frame/frame_destroyed_subscribe_devtrace_identity_cljs_test.cljc` drives `project-trace-event` with a **legal same-id event/sub collision**:

- **Red-before / green-after:** without the guard the subscribe query vector mutates to `[:audit6516/same-id {:token :rf/redacted}]`; after, it ships **verbatim**. (Confirmed by removing the guard: 2 subscribe assertions fail; restoring: green.)
- **Non-vacuity control:** the same registration DOES redact the vector through `redact-event-by-registration` (machinery live).
- **Dispatch counterpath:** `:dispatch` / `:dispatch-sync` still redact.
- **Capture:** payload-free.
- **Guard scope:** a non-frame-destroyed op carrying the same `:event` tag still projects (both AND conjuncts load-bearing).

Runs on JVM (`clojure -M:test`) and CLJS (`npm run test:cljs`). Production DCE: the projector is `debug-enabled?`-gated upstream, so the change DCEs under `:advanced` with the rest of the dev-trace path (elision gate confirms).

## Quality gates

All green (main's gates green except #6511, red-by-design, unrelated):

| Gate | Result |
| --- | --- |
| `implementation/core` `clojure -M:test` | 2101 tests, 10348 assertions, **0 failures / 0 errors** |
| `implementation/ui` `clojure -M:test` | 1006 tests, 19666 assertions, **0 failures / 0 errors** |
| `npm run test:cljs` | 10338 tests, 51006 assertions, **0 failures / 0 errors** |
| `npm run test:elision` | production 60/60 absent, control 60/60 present — **PASS** |
| `npm run test:browser-prod-elision` | ui mounted production elision PASS; 114 tests, 497 assertions, **0 / 0** |

Closes rf2-wd4ac (dev-trace arm).
