### PR TITLE
docs(spec): fix the 3 epoch publication-model residuals #6524 left (rf2-hbq7c)

### DIFF
--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -672,7 +672,7 @@ The other three streams take the same verb. `:events` and `:errors` are the **al
 ```clojure
 (rf/register-listener! :events id listener-fn)  ;; always-on event-emit record
 (rf/register-listener! :errors id listener-fn)  ;; always-on error-emit record
-(rf/register-listener! :epoch  key callback-fn) ;; one :rf/epoch-record per dequeued event
+(rf/register-listener! :epoch  key callback-fn) ;; assembled :rf/epoch-record — a publication, not a per-event count
 ```
 
 Conventional keys: `:my-app/recorder`, `:my-app/timing-monitor`, etc.
@@ -714,8 +714,10 @@ Alongside the raw `:trace` stream, the `:epoch` stream delivers a parallel **ass
 ;;   stream      — :epoch
 ;;   key         — any comparable value identifying the listener
 ;;                 (replaces same-key registration)
-;;   callback-fn — invoked with one :rf/epoch-record per dequeued event
-;;                 (one per epoch). Signature: (fn [epoch-record] ...)
+;;   callback-fn — invoked with one :rf/epoch-record per publication: one per
+;;                 dequeued event, and again when a post-settle back-fill
+;;                 re-publishes the same epoch (reconcile on [frame epoch-id];
+;;                 see the invocation rules below). Signature: (fn [epoch-record] ...)
 ;;
 ;; The record is the same shape the runtime appends to (rf/epoch-history frame-id):
 ;; assembled :event-id / :trigger-event / :db-before / :db-after, plus the structured
@@ -727,8 +729,8 @@ Alongside the raw `:trace` stream, the `:epoch` stream delivers a parallel **ass
 
 **Invocation rules** (mirrors `register-listener!`):
 
-- **Per dequeued event, not per drain — and a publication, not a counter.** An ordinary event's full pipeline run (and, for a machine event, its entire macrostep) is one epoch (per [002 §Drain versus event](002-Frames.md#drain-versus-event--the-epoch-unit)). A drain that settles a parent event and the child it `:fx`-dispatched publishes **two** records — one per event — not one for the drain. A machine's `:raise` sub-events and `:always` microsteps do not publish: they ride inside the triggering event's epoch (per [005 §Drain semantics](005-StateMachines.md#drain-semantics)). But the callback is a record-**publication** notification, not a once-per-event clock: the SAME epoch re-publishes — carrying the same `:epoch-id` — when a post-settle render / sub-run / unmount back-fills into that already-settled epoch (a corrected record), and synthetic records publish with no dequeued event at all (`:rf.epoch/db-replaced`, `:halted-depth`, `:halted-destroy`; see [Spec-Schemas §`:rf/epoch-record` §Outcomes](Spec-Schemas.md#outcomes)). Because the listener is process-global while `:epoch-id` is unique only within one frame, **reconcile on the pair `[(:frame record) (:epoch-id record)]`** — cache under that key and REPLACE on re-publication rather than counting callbacks as events; `:outcome` is record STATE (`:ok` / `:halted-depth` / `:halted-destroy`), not identity. A dequeued event rejected before it runs (no handler) publishes nothing.
-- **After commit.** The callback receives a fully-formed record with `:db-after`, `:sub-runs`, `:renders`, `:effects`, and any optional `:trace-events` populated. An ordinary, `:halted-depth`, or `:rf.epoch/db-replaced` record has already been appended to the frame's `epoch-history` ring buffer when the callback runs; the terminal `:halted-destroy` record is the exception — it is delivered to listeners **only** and never appended (see Halted runs below).
+- **Per dequeued event, not per drain — and a publication, not a counter.** An ordinary event's full pipeline run (and, for a machine event, its entire macrostep) is one epoch (per [002 §Drain versus event](002-Frames.md#drain-versus-event--the-epoch-unit)). A drain that settles a parent event and the child it `:fx`-dispatched publishes **two** records — one per event — not one for the drain. A machine's `:raise` sub-events and `:always` microsteps do not publish: they ride inside the triggering event's epoch (per [005 §Drain semantics](005-StateMachines.md#drain-semantics)). But the callback is a record-**publication** notification, not a once-per-event clock: the SAME epoch re-publishes — carrying the same `:epoch-id` — when a post-settle render / sub-run / unmount back-fills into that already-settled epoch (a corrected record); the synthetic `:rf.epoch/db-replaced` and `:halted-depth` records publish with no dequeued event at all, while the terminal `:halted-destroy` closes an already-started event interrupted mid-drain by frame destruction (see [Spec-Schemas §`:rf/epoch-record` §Outcomes](Spec-Schemas.md#outcomes)). Because the listener is process-global while `:epoch-id` is unique only within one frame, **reconcile on the pair `[(:frame record) (:epoch-id record)]`** — cache under that key and REPLACE on re-publication rather than counting callbacks as events; `:outcome` is record STATE (`:ok` / `:halted-depth` / `:halted-destroy`), not identity. A dequeued event rejected before it runs (no handler) publishes nothing.
+- **After commit.** The callback receives a fully-formed record with `:db-after`, `:sub-runs`, `:renders`, `:effects`, and any optional `:trace-events` populated. An ordinary, `:halted-depth`, or `:rf.epoch/db-replaced` record has been appended to the frame's `epoch-history` ring buffer **when depth permits** — the runtime attempts the append before it publishes, but a depth-0 ring retains nothing while the record still publishes; the terminal `:halted-destroy` record is delivered to listeners **only** and is never appended (see Halted runs below).
 - **Exception isolation.** An exception thrown by an epoch callback is caught and does not propagate. One broken epoch listener cannot break the app or block other listeners (raw-trace or epoch).
 - **Listener ordering** is not contract.
 - **Production elision.** The epoch listener machinery is gated on the same `re-frame.interop/debug-enabled?` flag (alias of `goog.DEBUG`) as the raw-trace surface — see [§Production builds](#production-builds-zero-overhead-zero-code). Production builds elide registration, dispatch, and the epoch ring-buffer all together.

--- a/spec/Tool-Pair.md
+++ b/spec/Tool-Pair.md
@@ -657,35 +657,44 @@ For per-run structured projections (sub-cache hit/miss, render attribution, effe
 
 ### Subscribing to assembled epoch records
 
-`register-epoch-listener!` callbacks publish one record per **dequeued event** (one per epoch, per [002 §Drain versus event](002-Frames.md#drain-versus-event--the-epoch-unit)), with the run's `:sub-runs` / `:renders` / `:effects` projections already computed. A drain that settles several events back-to-back therefore publishes one record per settled event, in dequeue order. The callback is a **publication**, not a counter: the same epoch re-publishes — carrying the same `:epoch-id` — when a post-settle render / sub-run / unmount back-fills into it, and synthetic records (`:rf.epoch/db-replaced`, `:halted-depth`, and the terminal `:halted-destroy`) publish with no dequeued event. Since the listener is process-global while `:epoch-id` is unique only within one frame, reconcile on the pair `[(:frame record) (:epoch-id record)]` and REPLACE on re-publication rather than counting callbacks. Pair-shaped tools, post-mortem dashboards, and "what just happened?" probes typically consume this shape rather than re-folding the raw trace stream:
+`register-epoch-listener!` callbacks publish one record per **dequeued event** (one per epoch, per [002 §Drain versus event](002-Frames.md#drain-versus-event--the-epoch-unit)), with the run's `:sub-runs` / `:renders` / `:effects` projections already computed. A drain that settles several events back-to-back therefore publishes one record per settled event, in dequeue order. The callback is a **publication**, not a counter: the same epoch re-publishes — carrying the same `:epoch-id` — when a post-settle render / sub-run / unmount back-fills into it; the synthetic `:rf.epoch/db-replaced` and `:halted-depth` records publish with no dequeued event, while the terminal `:halted-destroy` closes an already-started event interrupted mid-drain by frame destruction (delivered to listeners only). Since the listener is process-global while `:epoch-id` is unique only within one frame, reconcile on the pair `[(:frame record) (:epoch-id record)]` and REPLACE on re-publication rather than counting callbacks. Pair-shaped tools, post-mortem dashboards, and "what just happened?" probes typically consume this shape rather than re-folding the raw trace stream:
 
 ```clojure
 ;; A pair-tool dashboard routing diagnostics off the assembled per-run record.
-;; - One callback per dequeued event / epoch (NOT per drain, NOT per emitted trace event).
+;; - One callback per PUBLICATION, not per event: the same [frame epoch-id]
+;;   re-publishes when a post-settle render / sub-run / unmount back-fills into
+;;   it, so the callback REPLACES that key's cached summary rather than
+;;   accumulating — cumulative side effects would double-count (and re-fire an
+;;   fx-error alert) on re-publication.
 ;; - The record is fully shaped: :db-before, :db-after, :sub-runs, :renders, :effects.
-;; - The record has already been appended to (rf/epoch-history (:frame ev)).
+;; - The record is in (rf/epoch-history (:frame ev)) only WHEN DEPTH PERMITS — a
+;;   depth-0 ring retains nothing and the terminal :halted-destroy record is
+;;   listener-only — so the dashboard reads its OWN cache, not the ring.
+
+(defonce dashboard-cache (atom {}))   ;; {[frame epoch-id] -> per-run summary}
 
 (rf/register-listener! :epoch
   :my-tool/dashboard
-  (fn [{:keys [frame event-id epoch-id sub-runs renders effects] :as record}]
-    ;; Cache-hit-vs-rerun: every entry in :sub-runs is a recompute;
-    ;; cache-hit subs are absent. Counting :sub-runs answers
-    ;; "how many subs moved this run?"
-    (record-recomputes! frame event-id (count sub-runs))
-
-    ;; Render attribution: :renders[*].:render-key is [<view-id> <instance-token>].
-    ;; Aggregate by first slot to count "view X re-rendered N times this run."
-    (doseq [{:keys [render-key elapsed-ms]} renders]
-      (record-render! frame (first render-key) elapsed-ms))
-
-    ;; Fx outcome: every dispatched fx surfaces exactly one :effects entry.
-    ;; :outcome ∈ {:ok :error :skipped-on-platform}; route :error entries to UI.
-    (doseq [{:keys [fx-id outcome error-trace]} effects]
-      (when (= :error outcome)
-        (surface-fx-error! frame epoch-id fx-id error-trace)))
-
-    ;; The epoch is already in (rf/epoch-history frame); no need to re-query
-    ;; unless the dashboard wants the full vector for context.
+  (fn [{:keys [frame epoch-id sub-runs renders effects]}]
+    ;; Reconcile on [frame epoch-id] and REPLACE that entry: a re-published
+    ;; epoch overwrites its prior summary instead of counting a second time.
+    ;; (:epoch-id is unique only within one frame; the listener is process-global.)
+    (swap! dashboard-cache assoc [frame epoch-id]
+           {;; Cache-hit-vs-rerun: every entry in :sub-runs is a recompute;
+            ;; cache-hit subs are absent. (count sub-runs) answers
+            ;; "how many subs moved this run?"
+            :recomputes      (count sub-runs)
+            ;; Render attribution: :renders[*].:render-key is
+            ;; [<view-id> <instance-token>]. Group by first slot to count
+            ;; "view X re-rendered N times this run."
+            :renders-by-view (frequencies (map (comp first :render-key) renders))
+            ;; Fx outcome: every dispatched fx surfaces exactly one :effects
+            ;; entry. :outcome ∈ {:ok :error :skipped-on-platform}.
+            :fx-errors       (filterv #(= :error (:outcome %)) effects)})
+    ;; Derive / render the dashboard from the cache — idempotent under
+    ;; re-publication because the key's entry was replaced, so an fx-error
+    ;; alert fires once, not again each time the epoch re-publishes.
+    (render-dashboard! @dashboard-cache)
     nil))
 ```
 


### PR DESCRIPTION
Reopened residual sweep of PR #6524. #6524 shipped the epoch publication /
frame-qualified / termination model but left three adjacent inconsistencies
where copyable/normative guidance still taught the retired callback-count
model. Prose-only; no runtime, API, or code change. Surgical edits to the
synthetic-parenthetical clauses inside #6524's corrected rows; the rest of the
corrected publication/reconcile model is untouched.

## What changed

1. **Tool-Pair dashboard example** (`spec/Tool-Pair.md` §Subscribing to
   assembled epoch records) — the example now caches a tool-owned summary under
   `[frame epoch-id]` and **replaces** that entry on re-publication, then
   derives/renders the dashboard from the cache. The prior example did
   cumulative `record-recomputes!` / `record-render!` / `surface-fx-error!`
   side effects, which double-count (and re-fire an fx-error alert) when a
   same-`[frame epoch-id]` back-fill re-publishes the epoch. Retention comments
   qualified as "when depth permits" (a depth-0 ring retains nothing; the
   terminal `:halted-destroy` is listener-only).

2. **Spec 009 one-callback-per-event wording** (`spec/009-Instrumentation.md`)
   — the two direct code-comment copy sites (the `register-listener! :epoch`
   registration form and the `register-epoch-listener!` signature doc-comment)
   aligned to publication-shaped: a same-identity record may re-publish; not
   once-per-event. The "After commit" retention line qualified — the runtime
   *attempts* the append before it publishes, but a depth-0 ring retains
   nothing while the record still publishes. (Corpus mentions of the assembly
   unit are deliberately left per the audit's "correct the direct copy sites,
   not the corpus" scope.)

3. **Synthetic / no-dequeued-event parentheticals** (`spec/009` + `spec/Tool-Pair.md`)
   — the terminal `:halted-destroy` is removed from the no-dequeue synthetic
   list in both parentheticals. It closes an already-started event interrupted
   mid-drain by frame destruction, a distinct class from the
   `:rf.epoch/db-replaced` / `:halted-depth` synthetic markers.

Grounded against the merged epoch code: `epoch/listeners.cljc`
(`notify-listeners!` re-fans the same `[frame epoch-id]` record on back-fill;
the `:halted-destroy` record "is not stored... listener delivery is the only
channel") and `epoch/assembly.cljc` (`:outcome` ∈
`{:ok :halted-depth :halted-destroy :halted-handler-exception}` is record
state, not identity; only the destroy path reaches assembly with a trigger-less
buffer).

Scope note: the bead (rf2-hbq7c) NOTES enumerate a 4th residual — a stale
"interchangeable aliases" aside in `docs/core/observability.md` about the
retired `rf/register-epoch-listener!` facade pair. That is a facade-naming
concern (not publication-model) in `docs/` (not `spec/`), outside this PR's
titled scope; left for a follow-up so this PR stays the 3 spec publication-model
residuals.

## Quality gates
- `implementation/core` `clojure -M:test` — **2097 tests, 10340 assertions, 0 failures, 0 errors** (parses the Spec 009 catalogue; catalogue-conformance green).
- `python -m mkdocs build --strict` — exit 0.
- `python scripts/check_doc_slugs.py` — exit 0 (no broken anchors).
