### PR TITLE
fix(epoch): keep the production HTTP projection rows available to the pure projector regardless of the debug gate (rf2-92uvq)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -1279,30 +1279,39 @@
   whose body can ride in more than one slot (retry-attempt) is covered with
   one general rule rather than a per-slot special case.
 
-  The table is the tool-pair off-box enforcement,
-  not the on-box stamp — it lives behind the same `interop/debug-enabled?`
-  boundary that elides the whole epoch off-box projection surface in
-  production (`epoch/projected-record` — \"Production builds elide the
-  entire epoch surface\"). Gating it matters because `:rf.http/retry-attempt`
-  is a DEV-ONLY trace op (its only emit sites are `(when
-  interop/debug-enabled? (trace/emit! :info :rf.http/retry-attempt …))`);
-  holding it as a literal KEY in a top-level production-loaded `def` is the
-  one route that would float its keyword constant into the production
-  bundle (the Spec 009 elision probe asserts that sentinel ABSENT). Under
-  `:advanced` + `goog.DEBUG=false` the map literal is dead code, so the def
-  folds to `nil`, the dev-only constant DCEs, and `omit-off-box-http-bodies`
-  short-circuits to a pass-through (it is never called on a production egress
-  path — off-box projection is dev/tool-only). The sibling production-real
-  operation keywords (`:rf.http/replied`, `:rf.http/http-4xx`, …) already
-  ride the bundle as `:kind`/`:operation` data values, so the gate is about
-  the dev-only `:rf.http/retry-attempt` constant, not the table per se."
-  (when interop/debug-enabled?
-    {:rf.http/replied        [[:value]]
-     :rf.http/accept-failure [[:decoded]]
-     :rf.http/http-4xx       [[:body]]
-     :rf.http/http-5xx       [[:body]]
-     :rf.http/decode-failure [[:body-text]]
-     :rf.http/retry-attempt  [[:failure :body] [:failure :body-text]]}))
+  The five PRODUCTION-REAL operation rows (`:rf.http/replied`,
+  `:rf.http/accept-failure`, `:rf.http/http-4xx`, `:rf.http/http-5xx`,
+  `:rf.http/decode-failure`) are bound UNCONDITIONALLY — NOT behind
+  `interop/debug-enabled?`. `projected-record` is a PURE off-box projection
+  transform callable even when the debug gate is false (a JVM SSR process
+  started with `RE_FRAME_DEBUG=false`, or an already-held / synthetic record —
+  the gate elides record ASSEMBLY, not record PROJECTION). Its contract is
+  FAIL-CLOSED on a stamped unschematized HTTP body, so the slots it consults
+  must be present whether or not the gate was ever true. Gating the whole
+  table (rf2-92uvq) left it `nil` in a cold gate-false process, so
+  `omit-off-box-http-bodies` found no slot path and passed every stamped body
+  through raw — a mandatory-off-box-safe breach. These five operation keywords
+  already ride the production bundle as `:kind`/`:operation` data values, so
+  binding them here at namespace load leaks nothing new.
+
+  ONLY the DEV-ONLY `:rf.http/retry-attempt` row stays behind the gate. That
+  op is a dev-only trace op (Spec 014 §Retry and backoff — its only emit sites
+  are `(when interop/debug-enabled? (trace/emit! :info :rf.http/retry-attempt …))`),
+  so its keyword literal must NOT float into the `:advanced` production bundle
+  (the Spec 009 elision probe / `scripts/check-elision.cjs` assert the
+  `rf.http/retry-attempt` sentinel ABSENT). Under `:advanced` +
+  `goog.DEBUG=false` the gated `assoc` is dead code, so the keyword constant
+  DCEs and the table folds to the five production rows; on the JVM the gate is
+  read once at load and a prod process simply omits the row. A retry-attempt
+  record only ever exists in a debug build anyway, so omitting its row under
+  prod is unreachable, not a fail-open."
+  (cond-> {:rf.http/replied        [[:value]]
+           :rf.http/accept-failure [[:decoded]]
+           :rf.http/http-4xx       [[:body]]
+           :rf.http/http-5xx       [[:body]]
+           :rf.http/decode-failure [[:body-text]]}
+    interop/debug-enabled?
+    (assoc :rf.http/retry-attempt [[:failure :body] [:failure :body-text]])))
 
 (defn- omit-off-box-http-bodies
   "Enforce the fail-closed rule for off-box HTTP body trace events. For each

--- a/implementation/epoch/test/re_frame/epoch_egress_trace_events_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_trace_events_test.clj
@@ -49,6 +49,7 @@
             [re-frame.elision :as elision]
             [re-frame.epoch :as epoch]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             ;; Side-effect require (mirror epoch_test.clj fixture).
@@ -601,3 +602,58 @@
       (is (= body (get-in ev [:tags :body]))
           "the hand-built ring record carries the raw error body (no projection
            ran) — projected-record is the boundary, the ring stays raw"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-92uvq — COLD gate-false seam. `projected-record` is a PURE off-box
+;; projection transform callable even when `interop/debug-enabled?` is false
+;; (a JVM SSR process booted with RE_FRAME_DEBUG=false, or an already-held /
+;; synthetic record — the gate elides record ASSEMBLY, not PROJECTION). Its
+;; fail-closed HTTP-body contract must therefore hold when the debug gate is
+;; false FROM namespace/process start, so the five production-real HTTP
+;; operation rows of the body-slot table must be bound regardless of the gate.
+;;
+;; The existing disabled-gate tests miss this seam: they load the ns gate-TRUE
+;; (which populates the table) and only then flip the gate, so the table is
+;; already full. This test reproduces a genuine cold process-start by
+;; RE-LOADING tool-pair with the gate redefed false — recomputing the
+;; body-slot table under the false gate exactly as a prod JVM boot would — and
+;; confirms public projected-record still omits every production-real stamped
+;; HTTP body. Red-before: the wholly-gated table folded to nil, so
+;; `omit-off-box-http-bodies` found no slot path and passed the raw body
+;; through. After: the five production rows are unconditional, so it fails
+;; closed. The `finally` restores the normal gate-true table for the rest of
+;; the suite.
+;; ---------------------------------------------------------------------------
+
+(deftest off-box-http-fail-closed-survives-cold-gate-false
+  (testing "rf2-92uvq — with interop/debug-enabled? false FROM namespace load
+            (a production-start JVM), the pure projector still omits each
+            production-real unschematized HTTP body off-box"
+    (rf/make-frame {:id :test/http})
+    (try
+      ;; Recompute the tool-pair defs (incl. the HTTP body-slot table) with
+      ;; the debug gate false — a cold process-start reproduction. Existing
+      ;; tests never reach this: their table loaded gate-true. projected-record
+      ;; is a pure transform (it never consults the gate), so it runs after.
+      (with-redefs [interop/debug-enabled? false]
+        (require 're-frame.epoch.tool-pair :reload))
+      ;; The five PRODUCTION-REAL operations, one per body slot.
+      (doseq [[operation body-slot] [[:rf.http/replied        :value]
+                                     [:rf.http/accept-failure :decoded]
+                                     [:rf.http/http-4xx       :body]
+                                     [:rf.http/http-5xx       :body]
+                                     [:rf.http/decode-failure :body-text]]]
+        (let [record    (http-record :test/http operation body-slot
+                                     {:token http-body-secret :user-id 7} :omit)
+              projected (epoch/projected-record record)
+              ev        (first (:trace-events projected))]
+          (is (= :rf/redacted (get-in ev [:tags body-slot]))
+              (str "cold gate-false: " operation " body slot " body-slot
+                   " is omitted off-box (fail-closed)"))
+          (is (not (contains-http-secret? projected))
+              (str "cold gate-false: the raw token appears nowhere in the "
+                   operation " projected record"))))
+      (finally
+        ;; Restore the full gate-true table (incl. the dev-only
+        ;; :rf.http/retry-attempt row) for the remaining tests.
+        (require 're-frame.epoch.tool-pair :reload)))))


### PR DESCRIPTION
## Problem

`re-frame.epoch/projected-record` is a **pure off-box projection transform callable even when the debug gate is false** (per the lpypq #6529 contract): a JVM SSR process booted with `RE_FRAME_DEBUG=false`, or an already-held / synthetic record. The gate elides record *assembly*, not record *projection*. Its contract is **fail-closed** on a stamped unschematized HTTP response body.

But the HTTP body-slot table in `implementation/epoch/src/re_frame/epoch/tool_pair.cljc` was created **wholly inside** `(when interop/debug-enabled? ...)`. In a cold gate-false process (the gate false from namespace/process start) the table is `nil`, so `omit-off-box-http-bodies` found no slot path and passed **every stamped body through raw** — a mandatory-off-box-safe breach that can expose response data from imported/held records.

The existing disabled-gate tests miss the seam: they load the namespace while the gate is **true** (which populates the table), then flip the gate — so the table is already full and the cold-start path is never exercised.

## Smallest repair

Bind the **five production-real** operation rows (`:rf.http/replied`, `:rf.http/accept-failure`, `:rf.http/http-4xx`, `:rf.http/http-5xx`, `:rf.http/decode-failure`) **unconditionally**. Keep **only** the dev-only `:rf.http/retry-attempt` row behind the gate (via a `cond->` `assoc`), so its keyword literal still DCEs from the `:advanced` production bundle — the Spec 009 elision probe / `scripts/check-elision.cjs` assert the `rf.http/retry-attempt` sentinel absent. The five production keywords already ride the production bundle as `:kind`/`:operation` data values, so binding them at namespace load leaks nothing new.

No new projector, privacy framework, runtime switch, or config knob; the redact-fn egress model (#6514/#6524/#6529) is untouched.

## Proof — cold gate-false seam (red-before / green-after)

New JVM test `off-box-http-fail-closed-survives-cold-gate-false` re-loads `re-frame.epoch.tool-pair` with `interop/debug-enabled?` redefed **false** — recomputing the body-slot table under the false gate exactly as a production process-start would — then asserts public `projected-record` omits each production-real stamped body. Unlike the existing tests, it loads **gate-false from start**.

- **Red-before** (whole table gated): 10 failures — all in the new test (5 operations × 2 assertions); every raw body passed through.
- **After**: 0 failures.

Dual-host: the fix lives in `.cljc` (compiles both hosts). JVM production-start is pinned by the new test; CLJS `:advanced` DCE is pinned by the elision probe.

## Quality gates

| Gate | Result |
| --- | --- |
| `epoch clojure -M:test` | 441 tests, 6291 assertions, 0 failures |
| `core clojure -M:test` | 2101 tests, 10348 assertions, 0 failures |
| `npm run test:cljs` | 10340 tests, 51039 assertions, 0 failures |
| `npm run test:elision` | PASS — production 60/60 sentinels absent (`rf.http/retry-attempt` DCE'd); control 60/60 present |
| `npm run test:bundle-isolation` | PASS — all 22 artefacts; nothing dev leaked into production bundles |

Confirmed: the whole diagnostic surface was **not** un-gated (only the five production rows moved out; the dev-only `:rf.http/retry-attempt` row stays gated), and nothing dev leaked into production (elision + bundle-isolation green).
