### PR TITLE
fix(ui): suppress the frame-owned route for dead-incarnation capture failures (rf2-qjfrw)

### DIFF
--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -2088,7 +2088,14 @@
   KNOW the realm and pass it: the `capture-frame` stale-op PRE-CHECK seam
   (`emit-captured-frame-superseded!`), AND — rf2-a2x2w — the router's LATE
   captured-op fences (the A→B incarnation mismatch + the post-token-match /
-  pre-enqueue / pre-drain-acquire window in `dispatch!` / `dispatch-sync!`)."
+  pre-enqueue / pre-drain-acquire window in `dispatch!` / `dispatch-sync!`).
+
+  A present `op` ALSO suppresses the EP-0015 frame-owned sink route (rf2-qjfrw,
+  the capture-realm extension of the rf2-bf0io UI seam): every op-bearing caller
+  is a KNOWN-DEAD captured incarnation whose bare `frame-id` may now name a live
+  same-id SUCCESSOR, so routing to it would leak a dead incarnation's failure
+  into the successor's own sink. The corpus fan-out + dev trace still fire; only
+  the frame-owned route is dropped. Nil `op` (address-directed) keeps its route."
   ([event-id event frame-id]
    (emit-frame-destroyed! event-id event frame-id nil))
   ([event-id event frame-id op]
@@ -2100,12 +2107,31 @@
    ;; — the ratified-public `:op` realm attribution, which also steers source-
    ;; coord); nil `op` leaves the record shape exactly as the bare-drain
    ;; callers have always emitted it (no `:op` key).
+   ;;
+   ;; rf2-qjfrw: `route-frame?` false SUPPRESSES ONLY the EP-0015 frame-owned
+   ;; sink route (the rf2-bf0io seam, extended from the UI `(frame)` bundle to
+   ;; the core `capture-frame` primitive) whenever `op` is present. A present
+   ;; `op` marks a CAPTURED-op rejection — the pre-check seam
+   ;; (`emit-captured-frame-superseded!`) and the router's late captured-op
+   ;; fences (the A→B incarnation mismatch + the post-token-match windows in
+   ;; `dispatch!` / `dispatch-sync!`). Every one of those is a KNOWN-DEAD
+   ;; captured incarnation whose bare `frame-id` no longer names the incarnation
+   ;; the failure belongs to: a same-id destroy→reincarnation may have reseated
+   ;; a live SUCCESSOR B under it, and resolving the bare id to B would deliver a
+   ;; dead incarnation's failure into B's OWN `:observability :errors` sink
+   ;; (frame isolation; exact-incarnation attribution). The corpus fan-out
+   ;; (axis 1 listener) and the dev trace (axis 2) still fire exactly once; only
+   ;; the frame-owned route is dropped. A nil `op` (the ordinary
+   ;; address-directed router drain / no-such-frame emit) keeps the default
+   ;; route — an ordinary frame-destroyed's bare id is address-directed, so it
+   ;; stays route-eligible.
    (error-emit/emit-error-both!
      :rf.error/frame-destroyed
      event event-id frame-id nil 0 (interop/now-ms)
      (cond-> {:frame frame-id :event event :reason :frame-destroyed}
        op (assoc :op op))
-     (when op {:op op}))))
+     (when op {:op op})
+     (nil? op))))
 
 (defn- handle-frame-destroyed!
   "Per Spec 002 §Run-to-completion: a frame disposed between enqueue and

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -958,8 +958,19 @@
   under the unresolvable frame (rf2-t55hxg.18's fail-closed guards policy-walked
   VALUE slots, which identity slots never consult). `:op` rides BOTH the
   dev-trace tags (axis 2) and the ratified-public always-on record-attrs
-  (axis 1), exactly like `router/emit-frame-destroyed!`."
-  [frame-id query-v]
+  (axis 1), exactly like `router/emit-frame-destroyed!`.
+
+  `route-frame?` (rf2-qjfrw) gates ONLY the EP-0015 frame-owned sink route (the
+  capture-realm extension of the rf2-bf0io UI seam). A CAPTURED subscribe whose
+  pinned incarnation was SUPERSEDED passes false: its bare `frame-id` may now
+  name a live same-id SUCCESSOR B, and A's dead-incarnation failure must not
+  land in B's OWN `:observability :errors` sink (frame isolation;
+  exact-incarnation attribution). The corpus fan-out (axis 1) and dev trace
+  (axis 2) still fire exactly once. An ORDINARY address-directed subscribe to a
+  missing/destroyed frame passes true — its bare id names no captured
+  incarnation, so it keeps the default route (and, its frame being absent,
+  resolves to no sink anyway)."
+  [frame-id query-v route-frame?]
   (when-let [emit-error-both!
              (late-bind/get-fn-cached :error-emit/emit-error-both)]
     (emit-error-both!
@@ -974,7 +985,8 @@
        :query-v  query-v
        :recovery :replaced-with-default
        :op       :subscribe}        ;; dev-trace tags (axis 2)
-      {:op :subscribe}))            ;; always-on record realm attribution (axis 1)
+      {:op :subscribe}              ;; always-on record realm attribution (axis 1)
+      route-frame?))                ;; suppress the frame-owned route for a dead captured incarnation (rf2-qjfrw)
   ;; RECOVER to nil (the `:replaced-with-default` value the subscribe surfaces),
   ;; independent of the emit hook's own return.
   nil)
@@ -1039,7 +1051,12 @@
      ;; rf2-alk8a: `emit-frame-destroyed-recovery!` is subscribe-realm by
      ;; construction and stamps `:op :subscribe`, so the resolved `:source-coord`
      ;; names the EXACT `[:sub id]` realm, never the realm-ambiguous fallback.
-     (do (emit-frame-destroyed-recovery! frame-id query-v) nil)
+     ;; rf2-qjfrw: this branch is reached ONLY for a CAPTURED subscribe (guarded
+     ;; by `some? expected-incarnation`) whose pinned incarnation is dead, so the
+     ;; bare `frame-id` may name a live same-id successor B — pass `route-frame?`
+     ;; false to keep A's failure out of B's frame-owned `:observability :errors`
+     ;; sink (corpus record + dev trace still fire).
+     (do (emit-frame-destroyed-recovery! frame-id query-v false) nil)
      ;; else — the existing build, against the validated `frame-record` for a
      ;; captured read (never a bare-id re-resolve), or re-resolved by id for the
      ;; unchanged ambient/address-directed path.
@@ -1607,7 +1624,13 @@
          ;; the EXACT `[:sub id]` realm (omitting when the sub-id is genuinely
          ;; unregistered), and the attempted query vector egresses on the `:event`
          ;; slot as raw IDENTITY (rf2-zwgqe) rather than fail-closed to redacted.
-         (emit-frame-destroyed-recovery! frame-id query-v)   ;; emits, returns nil
+         ;; rf2-qjfrw: suppress the EP-0015 frame-owned sink route ONLY for a dead
+         ;; CAPTURED incarnation (`superseded?` — a captured pin whose frame was
+         ;; destroyed/reseated, so the bare `frame-id` may name a live same-id
+         ;; successor B). An ORDINARY address-directed subscribe (`superseded?`
+         ;; false, `expected-incarnation` nil, frame simply missing) keeps its
+         ;; default route — its bare id names no captured incarnation.
+         (emit-frame-destroyed-recovery! frame-id query-v (not superseded?)) ;; emits, returns nil
 
          :else
          (let [cache (:sub-cache frame-record)

--- a/implementation/core/test/re_frame/capture_frame_reincarnation_sink_route_cljs_test.cljc
+++ b/implementation/core/test/re_frame/capture_frame_reincarnation_sink_route_cljs_test.cljc
@@ -1,0 +1,289 @@
+(ns re-frame.capture-frame-reincarnation-sink-route-cljs-test
+  "rf2-qjfrw — keep a stale `rf/capture-frame` op's dead-incarnation failure OUT of
+  the same-id SUCCESSOR frame's own `:observability :errors` sink. The capture-realm
+  residual of rf2-bf0io (which fixed the compiled `re-frame.ui` `(frame)` bundle).
+
+  `rf/capture-frame` is EXACT-INCARNATION authority: an op invoked on a bundle
+  captured for incarnation A, after A is destroyed, RECOVER-but-EMITs
+  `:rf.error/frame-destroyed` (never leaks into a same-id successor). The emit
+  fans out on TWO channels — the corpus-wide always-on record (axis 1) and the
+  dev trace (axis 2). But the corpus emit ALSO drove the EP-0015 §9 frame-OWNED
+  `:observability :errors` sink route, which resolves the record's bare frame id
+  to the CURRENT frame. When a same-id SUCCESSOR B has replaced the destroyed A,
+  that bare id resolves to B — so A's stale-op failure was delivered into B's OWN
+  error sink (the bead's repro: B's sink receives A's `:rf.error/frame-destroyed`).
+  A dead incarnation must NOT reach a live frame's sink (frame isolation;
+  exact-incarnation attribution).
+
+  The fix reuses rf2-bf0io's internal `route-frame?` seam at BOTH capture rejection
+  sites:
+    - the SYNCHRONOUS supersession PRE-CHECK (`capture-target-superseded?` →
+      `router/emit-captured-frame-superseded!` → `router/emit-frame-destroyed!`,
+      which now passes `route-frame?` false whenever a captured-op `:op` is
+      present), and
+    - the durable LATE expected-incarnation-mismatch fences in `dispatch!` /
+      `dispatch-sync!` (router) and `subscribe-in-frame` (subs — via
+      `emit-frame-destroyed-recovery!`, which now takes an explicit
+      `route-frame?`).
+  The corpus-wide record and the dev trace still fire EXACTLY ONCE; only the
+  frame-owned sink route is suppressed. Ordinary address-directed errors keep the
+  default route.
+
+  These tests pin, for `:dispatch` / `:dispatch-sync` / `:subscribe`:
+    - the REINCARNATION regression through the PRE-CHECK seam: A's stale captured
+      op never increments same-id B's `:errors` sink (red-before: it does;
+      after: 0), with a vacuity probe proving B's sink is genuinely armed;
+    - the same regression through the LATE expected-incarnation-mismatch seam
+      (the op passes the pre-check, then A is superseded by B before the bare-id
+      resolve — reproduced by a one-shot interposition on the pre-check's own
+      liveness read);
+    - PRESERVED: exactly one corpus-wide `:rf.error/frame-destroyed` record +
+      one dev trace still fire; the surviving record keeps A's bare frame id,
+      `:op` realm, and structural head; a subscribe keeps RAW query identity;
+    - LIVE routing intact: an ordinary handler-exception on a LIVE frame still
+      reaches its frame-owned sink (the default `route-frame?` path is untouched).
+
+  Dual-runtime `*_cljs_test.cljc`: the shadow `:node-test` build
+  (`npm run test:cljs`) AND the JVM `clojure -M:test` runner both run it. Plain
+  CLJC; no DOM dependency. The interposition redefines the PUBLIC
+  `frame/frame-incarnation-live?` (a plain `defn`), so `with-redefs` intercepts
+  the cross-namespace pre-check call on both hosts."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core          :as rf]
+            [re-frame.error-emit    :as error-emit]
+            [re-frame.frame         :as frame]
+            [re-frame.observability :as observability]
+            [re-frame.privacy       :as privacy]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support  :as test-support]
+            [re-frame.trace         :as trace]))
+
+;; Rebuild registrar / frames / runtime per test; additionally clear the corpus
+;; error-listener registry AND the observability sink registry so a listener /
+;; sink from one test cannot leak into the next.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       plain-atom/adapter
+     :ambient-frame nil
+     :init-fn       (fn []
+                      (error-emit/clear-error-listeners!)
+                      (observability/clear-observability-sinks!))}))
+
+;; The attempted event / query the stale captured op carries: a keyword head plus
+;; a distinctive body leaf, so a leak into a sink would be unmistakable.
+(def ^:private secret-event    [:audit/secret {:password :TOP-SECRET}])
+(def ^:private subscribe-query [:reinc/n {:token :SUBSCRIBE-IDENTITY}])
+
+;; The three captured ops under test, each invoking its arm of a captured bundle.
+;; `head` is the structural event/query head that must ride the surviving record;
+;; `raw-event` is the corpus `:event` we can pin (subscribe keeps RAW identity per
+;; #6497/#6516; dispatch/dispatch-sync `:event` is elision-dependent and NOT
+;; asserted here — the route suppression this bead adds does not touch it).
+(def ^:private op-cases
+  [{:op :subscribe     :invoke (fn [h] ((:subscribe h)     subscribe-query))
+    :head :reinc/n      :raw-event subscribe-query}
+   {:op :dispatch      :invoke (fn [h] ((:dispatch h)      secret-event))
+    :head :audit/secret :raw-event ::unchecked}
+   {:op :dispatch-sync :invoke (fn [h] ((:dispatch-sync h) secret-event))
+    :head :audit/secret :raw-event ::unchecked}])
+
+(defn- register-event+sub!
+  "Register the trivial event / sub the captured ops target, so a LEAK into
+  successor B would actually resolve a handler / reaction (making the zero a real
+  suppression, not an unresolved miss)."
+  []
+  (rf/reg-event :audit/secret (fn [{:keys [db]} _] {:db (assoc db :marked-by :stale-capture)}))
+  (rf/reg-sub   :reinc/n      (fn [db _] (:n db))))
+
+(defn- make-frame-with-error-sink!
+  "Create frame `id` declaring an `:observability :errors` sink named `sink-id`,
+  and register the concrete sink fn (conj'ing every record it receives into
+  `seen`). Returns `id`."
+  [id sink-id seen]
+  (observability/register-observability-sink! sink-id (fn [r] (swap! seen conj r)))
+  (rf/make-frame {:id id
+                  :observability {:errors [{:sink sink-id
+                                            :rf.egress/profile :rf.egress/off-box-observability}]}})
+  id)
+
+(defn- capture-emits
+  "Run `thunk` (a stale captured op — RECOVERS, never throws), capturing the
+  corpus-wide always-on `:rf.error/frame-destroyed` records (axis 1) AND the
+  dev-trace frame-destroyed events (axis 2) it fans. Returns `{:records [...]
+  :traces [...] :result <thunk-return>}`. Freshly-gensym'd listener keys,
+  unregistered on the way out."
+  [thunk]
+  (let [recs   (atom [])
+        traces (atom [])
+        ekey   (keyword "test" (name (gensym "qjfrw-rec")))
+        tkey   (keyword "test" (name (gensym "qjfrw-trace")))]
+    (error-emit/register-error-listener!
+      ekey (fn [r] (when (= :rf.error/frame-destroyed (:error r)) (swap! recs conj r))))
+    (trace/register-listener!
+      tkey (fn [ev] (when (= :rf.error/frame-destroyed (:operation ev)) (swap! traces conj ev))))
+    (try
+      (let [result (thunk)]
+        {:records @recs :traces @traces :result result})
+      (finally
+        (error-emit/unregister-error-listener! ekey)
+        (trace/unregister-listener! tkey)))))
+
+(defn- assert-preserved-record!
+  "The route suppression must NOT drop the corpus record or the dev trace, nor
+  mutate the surviving record's attribution. Exactly one of each still fires,
+  carrying A's bare captured frame id, the `:op` realm, and the structural head."
+  [{:keys [records traces]} op fid head raw-event]
+  (is (= 1 (count records)) "EXACTLY ONE corpus-wide :rf.error/frame-destroyed record still fans")
+  (is (= 1 (count traces))  "EXACTLY ONE dev trace on axis 2 still fires")
+  (let [r (first records)]
+    (is (= :rf.error/frame-destroyed (:error r))    "corpus category retained")
+    (is (= fid (:frame r))                          "corpus record carries A's captured bare frame id")
+    (is (= op  (:op r))                             "operation realm retained")
+    (is (= head (:event-id r))                      "structural event/query head retained")
+    (when (not= ::unchecked raw-event)
+      (is (= raw-event (:event r))
+          "subscribe keeps RAW query identity on the surviving corpus record (#6497/#6516)"))))
+
+(defn- probe-vacuity!
+  "B's sink IS armed and capable of receiving: an ordinary error routed DIRECTLY
+  to B lands in it — so the zero above is REAL suppression, not an unwired /
+  mis-declared sink. Mirrors the rf2-bf0io vacuity probe."
+  [fid b-sink]
+  (let [before (count @b-sink)]
+    (observability/route-error!
+      :rf.error/handler-exception [:qjfrw/probe] :qjfrw/probe fid nil 0 0 nil)
+    (is (= (inc before) (count @b-sink))
+        "B's sink IS live — a directly-routed ordinary error reaches it")))
+
+;; ---------------------------------------------------------------------------
+;; Seam 1 — the SYNCHRONOUS supersession PRE-CHECK.
+;;
+;; Destroy A, reseat same-id B (with an armed sink), THEN invoke A's stale
+;; captured op: `capture-target-superseded?` sees A's pin gone and recover-but-
+;; emits via `router/emit-captured-frame-superseded!`.
+;; ---------------------------------------------------------------------------
+
+(deftest stale-capture-precheck-never-reaches-successor-error-sink
+  (testing "Per rf2-qjfrw (pre-check seam): a captured op whose pinned incarnation
+            A was destroyed and reseated as same-id B fails the synchronous
+            pre-check and recover-but-emits — but B's OWN :errors sink stays CLEAN
+            (red before: B's sink count is 1 with A's stale op). The dead
+            incarnation's bare frame id must never resolve to the live successor's
+            sink."
+    (doseq [{:keys [op invoke head raw-event]} op-cases]
+      (testing (str "stale " (name op) " across a same-id reincarnation (pre-check)")
+        (register-event+sub!)
+        (let [fid     (keyword "qjfrw.pre" (str "id-" (name op)))
+              sink-id (keyword "qjfrw.pre.sinks" (str "sentry-" (name op)))
+              b-sink  (atom [])]
+          ;; A: create + capture its incarnation-fenced bundle, then destroy.
+          (rf/make-frame {:id fid})
+          (let [stale (rf/capture-frame fid)]              ; pins incarnation A
+            (rf/destroy-frame! fid)
+            ;; B: same id, declaring its OWN :errors sink (armed BEFORE the op).
+            (make-frame-with-error-sink! fid sink-id b-sink)
+            (is (some? (frame/frame fid)) "successor B is live under the reused id")
+            ;; Fire A's stale captured op into the same-id successor world.
+            (let [emits (capture-emits #(invoke stale))]
+              ;; THE REGRESSION: B's OWN sink must stay clean.
+              (is (zero? (count @b-sink))
+                  "A's dead-incarnation failure NEVER reaches successor B's :errors sink")
+              ;; PRESERVED: one corpus record + one dev trace, unchanged attribution.
+              (assert-preserved-record! emits op fid head raw-event)
+              ;; RECOVERY: the op returns nil and never mutates B.
+              (is (nil? (:result emits)) "the stale captured op recovers to nil")
+              (is (nil? (:marked-by (rf/app-db-value fid)))
+                  "the stale captured op mutated nothing in successor B"))
+            ;; VACUITY: B's sink is genuinely armed.
+            (probe-vacuity! fid b-sink)))))))
+
+;; ---------------------------------------------------------------------------
+;; Seam 2 — the durable LATE expected-incarnation MISMATCH fence.
+;;
+;; A one-shot interposition on the pre-check's own liveness read destroys A and
+;; reseats same-id B (with an armed sink) at the moment the pre-check validates A
+;; as live — so the op PASSES the pre-check, then resolves the bare id to B and
+;; hits the late fence (`dispatch!` / `dispatch-sync!` A→B mismatch;
+;; `subscribe-in-frame` `superseded?`). This is the exact JVM interleaving the
+;; pre-check seam cannot reach; single-threaded + deterministic (the swap runs
+;; inside the interposed call), so no latch.
+;; ---------------------------------------------------------------------------
+
+(defn- run-superseded-after-precheck
+  "Interpose ONE-SHOT on `frame/frame-incarnation-live?` (the predicate the
+  capture pre-check consults): when the pre-check validates incarnation `a-token`
+  of `frame-id` as live, run `(make-b!)` (destroy A + reseat same-id B with an
+  armed sink) BEFORE handing back A's (true) liveness, then run `op`. The
+  interposition fires exactly once (the pre-check); every later call — including
+  the destroy/create machinery's own — delegates to the real fn."
+  [frame-id a-token make-b! op]
+  (let [real  frame/frame-incarnation-live?
+        fired (atom false)]
+    (with-redefs [frame/frame-incarnation-live?
+                  (fn [id token]
+                    (let [live? (real id token)]
+                      (when (and (not @fired)
+                                 (= id frame-id)
+                                 (identical? token a-token)
+                                 live?)
+                        (reset! fired true)   ;; set BEFORE make-b! so the
+                        ;; destroy/create's own liveness reads take the real path
+                        (make-b!))
+                      live?))]
+      (op))))
+
+(deftest stale-capture-late-mismatch-never-reaches-successor-error-sink
+  (testing "Per rf2-qjfrw (late expected-incarnation-mismatch seam): a captured op
+            that PASSES the pre-check, then loses A to a same-id successor B before
+            the bare-id resolve, recover-but-emits at the late fence — but B's OWN
+            :errors sink stays CLEAN (red before: B's sink receives A's failure).
+            Reproduces the concurrent-JVM destroy-A/create-B window deterministically."
+    (doseq [{:keys [op invoke head raw-event]} op-cases]
+      (testing (str "stale " (name op) " across a same-id reincarnation (late mismatch)")
+        (register-event+sub!)
+        (let [fid     (keyword "qjfrw.late" (str "id-" (name op)))
+              sink-id (keyword "qjfrw.late.sinks" (str "sentry-" (name op)))
+              b-sink  (atom [])]
+          (rf/make-frame {:id fid})
+          (let [a-token (frame/frame-incarnation-token fid)
+                stale   (rf/capture-frame fid)             ; pins incarnation A
+                make-b! (fn []
+                          (rf/destroy-frame! fid)
+                          (make-frame-with-error-sink! fid sink-id b-sink))
+                emits   (capture-emits
+                          #(run-superseded-after-precheck fid a-token make-b! (fn [] (invoke stale))))]
+            (is (some? (frame/frame fid)) "successor B is live under the reused id")
+            ;; THE REGRESSION: the LATE fence routed nothing to B's own sink.
+            (is (zero? (count @b-sink))
+                "A's dead-incarnation failure NEVER reaches successor B's :errors sink (late fence)")
+            ;; PRESERVED: one corpus record + one dev trace, unchanged attribution.
+            (assert-preserved-record! emits op fid head raw-event)
+            (is (nil? (:result emits)) "the stale captured op recovers to nil")
+            (is (nil? (:marked-by (rf/app-db-value fid)))
+                "the late-superseded captured op mutated nothing in successor B")
+            ;; VACUITY: B's sink is genuinely armed.
+            (probe-vacuity! fid b-sink)))))))
+
+;; ---------------------------------------------------------------------------
+;; PRESERVED — live routing is untouched: the default route-frame? path still
+;; delivers an ordinary handler-exception to a LIVE frame's own sink.
+;; ---------------------------------------------------------------------------
+
+(deftest ordinary-live-error-still-reaches-frame-owned-sink
+  (testing "the default route-frame? path is untouched (rf2-qjfrw suppresses ONLY
+            the dead-incarnation capture seams): a handler-exception on a LIVE
+            frame still routes ONE :rf.observe/error record to that frame's
+            declared :observability :errors sink."
+    (let [seen    (atom [])
+          fid     :qjfrw/live
+          sink-id :qjfrw.sinks/live-sentry]
+      (make-frame-with-error-sink! fid sink-id seen)
+      (rf/reg-event :qjfrw/boom {:frame fid}
+        (fn [_ _] (throw (ex-info "kaboom" {:cause :test}))))
+      (rf/dispatch-sync [:qjfrw/boom] {:frame fid})
+      (is (= 1 (count @seen)) "the live frame's error sink still receives exactly one record")
+      (let [r (first @seen)]
+        (is (= :rf.observe/error (:kind r)))
+        (is (= fid (:frame r)))
+        (is (= :rf.error/handler-exception (:error r)))))))


### PR DESCRIPTION
## What

Extends #6528's dead-incarnation route suppression to the CAPTURE realm.

#6528 kept a stale compiled `re-frame.ui` `(frame)` bundle's dead-incarnation failure out of a same-id successor's frame-owned `:observability :errors` sink (for subscribe/dispatch/dispatch-sync). But the **public `rf/capture-frame` primitive** still had the same composition bug: its **synchronous supersession pre-check** reaches `router/emit-frame-destroyed!`, and its **durable late expected-incarnation fences** in router/subs reach `emit-error-both!`, all with the default frame route enabled. So after A is destroyed and same-id B reseats with an armed error sink, a stale captured `:dispatch` / `:dispatch-sync` / `:subscribe` delivered A's `:rf.error/frame-destroyed` into B's OWN sink.

**Found-vs-named:** the brief anticipated `frames.cljc` as the emit site, but that UI `(frame)`-bundle path (incl. its `:capture` arm) was already suppressed by #6528. The actual capture-realm residual lives where the bead DESCRIPTION points — `router.cljc` + `subs.cljc` (the `rf/capture-frame` core path). Three-outcome verdict: **(a) fix** — the capture route was live (red-before: B's sink count is 1).

## The fix

Reuse #6528's internal `route-frame?` seam (no new API, no abstraction) at the two capture rejection sites:

- **`router/emit-frame-destroyed!`** now passes `route-frame?` = `(nil? op)`. A present `op` marks a captured-op rejection — the pre-check seam (`emit-captured-frame-superseded!`, covering all three ops) and the router's late captured-op fences (`dispatch!` / `dispatch-sync!` A→B mismatch + post-token-match windows). Every one is a known-dead captured incarnation whose bare frame id may name a live successor. A nil `op` (ordinary address-directed drain / no-such-frame) keeps the default route.
- **`subs/emit-frame-destroyed-recovery!`** now takes an explicit `route-frame?`: the `subscribe-in-frame` fence passes `(not superseded?)`, the durable `build-and-cache!*` captured fence passes `false`. An ordinary address-directed subscribe to a missing frame keeps its route.

The corpus-wide record (axis 1) + dev trace (axis 2) still fire **exactly once**; only the EP-0015 frame-owned sink route is suppressed. Corpus/observation channel untouched; #6528's frames.cljc sites untouched.

## Proof

New dual-host `.cljc` reincarnation regression (`capture_frame_reincarnation_sink_route_cljs_test.cljc`):
- B's sink stays **0** across BOTH the pre-check seam and the late expected-incarnation-mismatch seam, for `:dispatch` / `:dispatch-sync` / `:subscribe`.
- **Red-before verified:** neutralizing the fix (force `route-frame?` true) → 6 failures (B's sink count 1); restored → green.
- **Non-vacuity:** a directly-routed ordinary error still lands in B's armed sink.
- **Preserved:** exactly one corpus `:rf.error/frame-destroyed` record + one dev trace, unchanged attribution (bare frame id, `:op` realm, structural head; subscribe keeps RAW query identity); ordinary live handler-exception still routes to a live frame's sink; existing capture-race tests green.

## Quality gates

All green (main's gates green except #6511, red-by-design/unrelated):

- `cd implementation/ui && clojure -M:test` — **1006 tests, 0 failures** (#6528 subscribe/dispatch suppression stays green)
- `cd implementation/core && clojure -M:test` — **2104 tests, 0 failures** (frame-destroyed record routing green)
- `npm run test:cljs` — **10343 tests, 0 failures** (dual-host: new test runs on Node CLJS too)
- `npm run test:elision` — PASS (production 60/60 absent; control 60/60 present; raw identity survives `:advanced`)
- `npm run test:browser-prod-elision` — **114 tests, 0 failures** (frame-destroyed prod pin)