### PR TITLE
fix(ssr): unify ordinary script/style raw-text emission across both emitters, remove refusal (rf2-xbvzh)

### DIFF
--- a/docs/api/re-frame.ssr.md
+++ b/docs/api/re-frame.ssr.md
@@ -26,6 +26,7 @@ The `re-frame.core` facade re-exports a curated set of render and head primitive
   ```
 - **Description**: The canonical server-side render. Walks the hiccup tree once and emits a string. Pure and JVM-runnable.
   - It resolves callable-headed views (Var / `(rf/view :id)`), `:tag#id.cls` shorthand, and HTML5 void elements. It escapes text and attribute values.
+  - Ordinary inline `<script>` / `<style>` string content is HTML **raw text**: emitted verbatim with only React's context-safe closing-sequence rewrite (an embedded `</script>` / `</style>` breakout is respelled so the parser cannot terminate the element early), never entity-escaped and never refused. This is byte-identical across `render-to-string`, the streaming shell walk, and `emit-ui-tree`. Structured data belongs on its own channel: JSON-LD / head content via `reg-head` (which applies the stricter `<`→`<` data escape), the hydration payload via the `__rf_payload` wire.
   - `opts` keys (all optional):
     - `:doctype?` — prefixes `<!DOCTYPE html>`.
     - `:emit-hash?` — injects `data-rf-render-hash` on the tree's first DOM-tag element, for client-side mismatch detection.
@@ -33,7 +34,6 @@ The `re-frame.core` facade re-exports a curated set of render and head primitive
   - Raises:
     - `:rf.error/invalid-tag-name` — malformed tag name.
     - `:rf.error/ssr-invalid-attribute-name` — malformed attribute key.
-    - `:rf.error/ssr-raw-text-in-body` — a raw string child of a body-position `<script>` / `<style>`.
     - `:rf.error/ssr-reagent-native-head` — a `:>` interop head.
     - `:rf.error/ssr-suspense-boundary-outside-stream` — a `:rf/suspense-boundary` marker reached this non-streaming emitter.
 - **Example**:

--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -72,28 +72,28 @@
 ;; ---- raw-text body tags ---------------------------------------------------
 ;;
 ;; `<script>` and `<style>` are HTML "raw text" elements: their content is
-;; NOT parsed as markup, so the body emitter's `escape-html` (which rewrites
-;; `<`→`&lt;`, `>`→`&gt;`, `&`→`&amp;`, `"`/`'` → entities) does the WRONG
-;; thing — it is XSS-safe but silently CORRUPTS legitimate inline content
-;; (`[:style "a > b {…}"]` → `a &gt; b`, `[:script "if (a<b){…}"]` →
-;; `if (a&lt;b)`, an inline JSON-LD blob → broken JSON).
+;; NOT parsed as markup, so routing it through `escape-html` (which rewrites
+;; `<`→`&lt;`, `>`→`&gt;`, `&`→`&amp;`, `"`/`'` → entities) CORRUPTS it — the
+;; HTML parser never decodes character references inside a raw-text element,
+;; so `[:style "a > b {…}"]` would ship the literal DOM text `a &gt; b` and
+;; `[:script "if (a<b){…}"]` would ship `if (a&lt;b)`.
 ;;
-;; There is no single correct escape for raw author content in the body:
-;;   - JSON-LD wants `<` → `<` (round-trips through `JSON.parse`),
-;;   - raw JS/CSS must NOT be `<`-escaped (JS does not decode `<`
-;;     outside string literals — `if (a < b)` is a syntax error).
-;; So body-position `<script>`/`<style>` with raw STRING content is
-;; unsupported by design: it is fail-loud rather than silently corrupting
-;; the author's content (or, worse, guessing an escape that opens an XSS or
-;; breaks the script). The two structured channels are:
-;;   - JSON-LD / structured `<head>` content → `reg-head` (its emitter
-;;     applies the JSON-LD `<` escape — see `re-frame.ssr.head.emit`),
-;;   - trusted inline JS/CSS → the host shell's trusted `:body-end` /
-;;     `:head-extra` opt (caller-trusted, not author-data).
-;; A `<script>`/`<style>` with NO string children (element-only or empty)
-;; is left alone — it is structurally inert and the guard only fires on a
-;; raw string child.
-(def ^:private raw-text-tags #{"script" "style"})
+;; Per rf2-xbvzh (ruling Option (a)): an ordinary inline `<script>`/`<style>`
+;; with STRING content is AUTHOR CONTENT — trust the programmer. It is
+;; emitted VERBATIM with only React's context-safe closing-sequence rewrite
+;; (`html/escape-raw-text`), the ONE shared implementation this emitter, the
+;; streaming walker, and the S5 serialiser (`re-frame.ssr.ui-tree`) all call,
+;; so the same author content is byte-identical on every SSR path. This is
+;; NOT sanitisation — the rewrite is the same breakout guard React applies,
+;; aimed at attacker-supplied `</script>` DATA that must not terminate the
+;; element early; residual JS/CSS-context safety is author-owned, as in
+;; React. The DATA-payload channels are unchanged and keep their stricter
+;; data-aware escapes: JSON-LD / structured `<head>` content via `reg-head`
+;; (`re-frame.ssr.head.emit`, `<`→`<`) and the trusted host-shell
+;; `:head`/`:body-end` opts. A `<script>`/`<style>` with no string children
+;; (element-only or empty) is structurally inert and emits unchanged; the
+;; raw-text set + escape live in `re-frame.ssr.html-helpers`
+;; (`html/raw-text-tags` / `html/escape-raw-text`).
 
 ;; Tag-name injection gate. Gate the tag
 ;; component itself: HTML5 / SVG / MathML element names require an ASCII
@@ -277,40 +277,6 @@
                (if (contains? m k) m (assoc m k v)))
              attrs
              root-attrs))
-
-(defn reject-raw-text-string-children!
-  "Throw `:rf.error/ssr-raw-text-in-body` when a body-position raw-text
-  element (`<script>` / `<style>`, per `raw-text-tags`) carries a raw
-  STRING child. Per rf2-ee38b.10 — the body emitter cannot apply a single
-  correct escape to raw author content (JSON-LD needs `<`→`\\u003c`; raw
-  JS/CSS must not be `<`-escaped at all), so silently `escape-html`-ing it
-  corrupted legit inline content while masking the lack of a real channel.
-  Fail loud and point the author at the structured surfaces. Element-only
-  / empty `<script>`/`<style>` is left alone (no string child → no throw).
-
-  rf2-hzttr finding 3 — the raw-text classification is CASE-INSENSITIVE:
-  `<SCRIPT>` / `<Style>` (admitted by `validate-tag-name!`) must hit the
-  same guard as their lower-case spellings, or an upper-case tag silently
-  bypasses the body-position script/style protection (XSS-adjacent). The
-  membership test lower-cases the tag; the error message keeps the
-  author's original casing."
-  [tag-name children source-head]
-  (when (and (contains? raw-text-tags (clojure.string/lower-case tag-name))
-             (some string? children))
-    (error/throw-error!
-      :rf.error/ssr-raw-text-in-body
-      'rf.ssr/emit
-      (str "Raw string content under a body-position <"
-           tag-name "> (hiccup head " (pr-str source-head)
-           ") is unsupported — the body emitter has no"
-           " single safe escape for raw script/style"
-           " content. Put JSON-LD / structured head"
-           " content through reg-head, and trusted"
-           " inline JS/CSS through the host shell's"
-           " trusted :body-end / :head-extra opt.")
-      {:recovery :move-content-to-reg-head-or-shell-opts
-       :extra    {:tag    tag-name
-                  :source source-head}})))
 
 (defn reserved-rf-head?
   "True when `head` is a keyword in the framework-reserved `:rf/*` scheme
@@ -628,18 +594,31 @@
                ;; upper/mixed-case names (`[:BR]`, `[:SCRIPT …]`), but
                ;; `void-elements` / `raw-text-tags` are keyed lower-case,
                ;; so a `[:BR]` was emitted as a non-void open+close pair
-               ;; and a `[:SCRIPT "if (a<b)"]` bypassed the raw-text body
-               ;; guard (XSS-adjacent). Normalise for classification while
-               ;; preserving the author's emitted case.
+               ;; and a `[:SCRIPT "a<b"]` would classify wrongly. Normalise
+               ;; for classification while preserving the author's emitted
+               ;; case.
                norm-tag     (clojure.string/lower-case tag-name)
-               void?        (contains? void-elements (keyword norm-tag))]
-           (if void?
-             (str "<" tag-name (attr-string attrs) ">")
-             (do
-               (reject-raw-text-string-children! tag-name children head)
-               (str "<" tag-name (attr-string attrs) ">"
-                    (emit-children children)
-                    "</" tag-name ">"))))
+               void?        (contains? void-elements (keyword norm-tag))
+               raw-text?    (contains? html/raw-text-tags norm-tag)]
+           (cond
+             void?     (str "<" tag-name (attr-string attrs) ">")
+             ;; rf2-xbvzh — an ordinary inline <script>/<style> with STRING
+             ;; content is author content: emit it VERBATIM with only the
+             ;; shared closing-sequence rewrite (`html/escape-raw-text`),
+             ;; byte-identical to the S5 serialiser and the streaming walker.
+             ;; The `every? string?` gate mirrors the compiled path — an
+             ;; all-string body is the real inline-script/style shape; any
+             ;; structural child leaves the existing per-child walk untouched
+             ;; (element children pass through inert; the hiccup emitter gains
+             ;; no compiled child-shape grammar).
+             (and raw-text? (seq children) (every? string? children))
+             (str "<" tag-name (attr-string attrs) ">"
+                  (html/escape-raw-text norm-tag (clojure.string/join children))
+                  "</" tag-name ">")
+             :else
+             (str "<" tag-name (attr-string attrs) ">"
+                  (emit-children children)
+                  "</" tag-name ">")))
 
          ;; Callable component head — a plain fn OR a Var reference
          ;; (`[#'component & args]`). On the JVM a Var is `ifn?` but NOT

--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -10,6 +10,19 @@
     - `escape-attr`              — attribute-value escaping (we always
                                     emit double-quoted values, so only
                                     `&` and `\"` matter).
+    - `raw-text-tags` /
+      `escape-raw-text`          — the HTML raw-text elements (`<script>`
+                                    / `<style>`) whose body is emitted
+                                    VERBATIM with only React's context-
+                                    safe closing-sequence rewrite — NO
+                                    entity escaping (the HTML parser never
+                                    decodes character references inside a
+                                    raw-text element). ONE shared
+                                    implementation for the S5 serialiser
+                                    (`re-frame.ssr.ui-tree`) and both
+                                    hiccup emitters (`emit` /
+                                    `streaming`), so every SSR path emits
+                                    byte-identical raw-text.
     - `escape-script-body-string`— escape `<` as `\\u003c` for strings
                                     dropped inside `<script>` bodies. JSON bodies
                                     only — every `<` is in a string.
@@ -45,6 +58,67 @@
   (-> (str s)
       (str/replace "&" "&amp;")
       (str/replace "\"" "&quot;")))
+
+;; ---------------------------------------------------------------------------
+;; Raw-text elements — <script>/<style> content is HTML RAW TEXT (rf2-2dh3b)
+;;
+;; The single shared home for the raw-text emission rule (hoisted from
+;; `re-frame.ssr.ui-tree` per rf2-xbvzh, ruling Option (a)). ALL three SSR
+;; paths — the S5 structural serialiser and both hiccup emitters — call
+;; this ONE implementation, so an ordinary inline `<script>`/`<style>`
+;; with the same author content serialises to byte-identical HTML on every
+;; path. This is the AUTHOR-CONTENT channel; the stricter DATA-payload
+;; helpers (`escape-script-body-string` / `escape-edn-script-body`, below)
+;; are a separate concern and unchanged.
+;; ---------------------------------------------------------------------------
+
+(def raw-text-tags
+  "The HTML RAW-TEXT elements whose text children react-dom/server 19.2 emits
+  WITHOUT entity escaping. React special-cases EXACTLY these two: `:title` and
+  `:textarea` are escapable RCDATA (escaped normally, so NOT here)."
+  #{"script" "style"})
+
+(defn escape-raw-text
+  "Serialise the text content of a raw-text element (`<script>` / `<style>`)
+  the way react-dom/server 19.2 does — the raw-text half of the conversion
+  table's escaping row (Spec 004B §Children, text, and escaping; the blanket
+  `escape-html` row does NOT hold inside raw-text elements).
+
+  The HTML parser does not decode character references inside raw-text
+  elements, so routing script/style text through `escape-html` CORRUPTS it: a
+  valid `a & b < c` becomes the literal DOM text `a &amp; b &lt; c`, and CSS/JS
+  containing `<`/`&` stops meaning what it says. React therefore emits the text
+  VERBATIM and only rewrites an embedded closing-tag sequence to a
+  CONTEXT-SAFE spelling so the raw-text parser cannot terminate the element
+  early (byte-parity with React's `scriptRegex`/`styleRegex` + replacers):
+
+    - `<script>`: `(<|</)script` (case-insensitive) -> the `s`/`S` becomes the
+      JavaScript unicode escape `\\u0073` / `\\u0053`. The JS engine reads it
+      back as `s`/`S`; the HTML parser no longer sees `</script`. The same
+      escape is a valid JSON string escape, so a JSON data island written as
+      ordinary `<script>` string content round-trips through `JSON.parse`.
+    - `<style>`:  `(<|</)style`  -> the `s`/`S` becomes the CSS escape
+      `\\73 ` / `\\53 ` (the trailing space terminates the hex escape). CSS
+      reads it back as `s`/`S`.
+
+  NOT a sanitiser, and NO XSS hole beyond React's own. Raw-text emission is
+  the same trusted content react-dom/server itself emits raw; the closing-
+  sequence rewrite is the same breakout guard React applies — aimed at the
+  DATA (an attacker-supplied `</script>` payload can no longer terminate the
+  element and pivot into HTML parsing). Residual JS/CSS-language-context
+  safety of interpolated data is author-owned, exactly as in React. The
+  DATA-payload channels (JSON-LD head, `__rf_payload`/EDN wire) keep their
+  stricter data-aware escapes (`escape-script-body-string` /
+  `escape-edn-script-body`)."
+  [tag-lc s]
+  (case tag-lc
+    "script" (str/replace s #"(</?)([sS])([cC][rR][iI][pP][tT])"
+                          (fn [[_ prefix s-char suffix]]
+                            (str prefix (if (= s-char "s") "\\u0073" "\\u0053") suffix)))
+    "style"  (str/replace s #"(</?)([sS])([tT][yY][lL][eE])"
+                          (fn [[_ prefix s-char suffix]]
+                            (str prefix (if (= s-char "s") "\\73 " "\\53 ") suffix)))
+    s))
 
 (defn escape-script-body-string
   "Escape a string that will be emitted raw inside a `<script>…</script>`

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -370,25 +370,29 @@
                                 [(second el) (drop 2 el)]
                                 [{} (rest el)])
         merged-attrs          (emit/merge-class-attrs tag-attrs user-attrs)
-        ;; Void classification is case-insensitive,
-        ;; mirroring the non-streaming emitter. A `[:BR]` admitted by
+        ;; Void + raw-text classification are case-insensitive, mirroring
+        ;; the non-streaming emitter. A `[:BR]` admitted by
         ;; `validate-tag-name!` must be recognised as void here too, or the
-        ;; shell walker emits a `<BR></BR>` open+close pair. The raw-text
-        ;; body guard below (`reject-raw-text-string-children!`) already
-        ;; lower-cases internally for the same reason.
-        void?                 (contains? emit/void-elements
-                                         (keyword (clojure.string/lower-case tag-name)))]
-    (if void?
-      (str "<" tag-name (emit/attr-string merged-attrs) ">")
-      (do
-        ;; Mirror the non-streaming emitter's raw-text body
-        ;; guard so a body-position `<script>`/`<style>` with raw string
-        ;; content fails loud in the shell walk too (rather than silently
-        ;; `escape-html`-ing it via the standard emitter).
-        (emit/reject-raw-text-string-children! tag-name children head)
-        (str "<" tag-name (emit/attr-string merged-attrs) ">"
-             (walk-children children acc)
-             "</" tag-name ">")))))
+        ;; shell walker emits a `<BR></BR>` open+close pair.
+        norm-tag              (clojure.string/lower-case tag-name)
+        void?                 (contains? emit/void-elements (keyword norm-tag))
+        raw-text?             (contains? html/raw-text-tags norm-tag)]
+    (cond
+      void?     (str "<" tag-name (emit/attr-string merged-attrs) ">")
+      ;; rf2-xbvzh — mirror the non-streaming emitter: an ordinary inline
+      ;; `<script>`/`<style>` with STRING content is author content, emitted
+      ;; VERBATIM with only the shared closing-sequence rewrite
+      ;; (`html/escape-raw-text`), byte-identical to the sync emitter and the
+      ;; S5 serialiser. Any structural child falls through to the standard
+      ;; child walk (element children pass through inert).
+      (and raw-text? (seq children) (every? string? children))
+      (str "<" tag-name (emit/attr-string merged-attrs) ">"
+           (html/escape-raw-text norm-tag (clojure.string/join children))
+           "</" tag-name ">")
+      :else
+      (str "<" tag-name (emit/attr-string merged-attrs) ">"
+           (walk-children children acc)
+           "</" tag-name ">"))))
 
 (defn- suspense-attrs? [m]
   (and (map? m) (contains? m :id) (contains? m :fallback)))

--- a/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
+++ b/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
@@ -58,7 +58,8 @@
   the conversion-table rows the seam needs ships here."
   (:require [clojure.string :as str]
             [re-frame.error :as error]
-            [re-frame.ssr.hash :as hash]))
+            [re-frame.ssr.hash :as hash]
+            [re-frame.ssr.html-helpers :as html]))
 
 ;; ---------------------------------------------------------------------------
 ;; Version gate — the headline. Validated FIRST, before any emission.
@@ -500,52 +501,11 @@
       (str/replace "\"" "&quot;")
       (str/replace "'" "&#x27;")))
 
-;; ---------------------------------------------------------------------------
-;; Raw-text elements — <script>/<style> content is HTML RAW TEXT (rf2-2dh3b)
-;; ---------------------------------------------------------------------------
-
-(def raw-text-tags
-  "The HTML RAW-TEXT elements whose text children react-dom/server 19.2 emits
-  WITHOUT entity escaping. React special-cases EXACTLY these two: `:title` and
-  `:textarea` are escapable RCDATA (escaped normally, so NOT here)."
-  #{"script" "style"})
-
-(defn escape-raw-text
-  "Serialise the text content of a raw-text element (`<script>` / `<style>`)
-  the way react-dom/server 19.2 does — the raw-text half of the conversion
-  table's escaping row (Spec 004B §Children, text, and escaping; the blanket
-  `escape-html` row does NOT hold inside raw-text elements).
-
-  The HTML parser does not decode character references inside raw-text
-  elements, so routing script/style text through `escape-html` CORRUPTS it: a
-  valid `a & b < c` becomes the literal DOM text `a &amp; b &lt; c`, and CSS/JS
-  containing `<`/`&` stops meaning what it says. React therefore emits the text
-  VERBATIM and only rewrites an embedded closing-tag sequence to a
-  CONTEXT-SAFE spelling so the raw-text parser cannot terminate the element
-  early (byte-parity with React's `scriptRegex`/`styleRegex` + replacers):
-
-    - `<script>`: `(<|</)script` (case-insensitive) -> the `s`/`S` becomes the
-      JavaScript unicode escape `\\u0073` / `\\u0053`. The JS engine reads it
-      back as `s`/`S`; the HTML parser no longer sees `</script`.
-    - `<style>`:  `(<|</)style`  -> the `s`/`S` becomes the CSS escape
-      `\\73 ` / `\\53 ` (the trailing space terminates the hex escape). CSS
-      reads it back as `s`/`S`.
-
-  NOT a sanitiser, and NO XSS hole beyond React's own. `emit-ui-tree`
-  serialises an ALREADY-RENDERED, server-authored structural tree (this ns's
-  trust contract — every value is a literal the server's own views produced,
-  never user input), exactly the trusted content react-dom/server itself emits
-  raw; the closing-sequence escape is the same breakout guard React applies.
-  Untrusted author markup has its own explicit, unrelated bypass (`:html`)."
-  [tag-lc s]
-  (case tag-lc
-    "script" (str/replace s #"(</?)([sS])([cC][rR][iI][pP][tT])"
-                          (fn [[_ prefix s-char suffix]]
-                            (str prefix (if (= s-char "s") "\\u0073" "\\u0053") suffix)))
-    "style"  (str/replace s #"(</?)([sS])([tT][yY][lL][eE])"
-                          (fn [[_ prefix s-char suffix]]
-                            (str prefix (if (= s-char "s") "\\73 " "\\53 ") suffix)))
-    s))
+;; Raw-text elements — <script>/<style> content is HTML RAW TEXT (rf2-2dh3b).
+;; The serialisation rule (`html/raw-text-tags` + `html/escape-raw-text`) is
+;; the ONE shared implementation in `re-frame.ssr.html-helpers`, called
+;; identically by this serialiser and both hiccup emitters so every SSR path
+;; emits byte-identical raw text for the same author content (rf2-xbvzh).
 
 ;; ---------------------------------------------------------------------------
 ;; Newline-eating elements — leading-LF compensation (rf2-z05di)
@@ -784,7 +744,7 @@
   [tag-lc children path]
   (cond
     (every? string? children)
-    (escape-raw-text tag-lc (str/join children))
+    (html/escape-raw-text tag-lc (str/join children))
 
     (and (= 1 (count children))
          (map? (first children))
@@ -895,7 +855,7 @@
         tag-name  (name tag)
         norm-tag  (str/lower-case tag-name)
         void?     (contains? void-tags (keyword norm-tag))
-        raw-text? (contains? raw-text-tags norm-tag)
+        raw-text? (contains? html/raw-text-tags norm-tag)
         pp        (if (custom-element-tag? tag)
                     (set (or (:rf.ui/property-props el) #{}))
                     #{})

--- a/implementation/ssr/test/re_frame/ssr_emit_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_emit_test.clj
@@ -34,9 +34,37 @@
             [re-frame.core :as rf]
             [re-frame.ssr.emit :as emit]
             [re-frame.ssr.streaming :as streaming]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.ssr.ui-tree :as ui-tree]))
 
 (use-fixtures :each tf/reset-runtime)
+
+;; ---------------------------------------------------------------------------
+;; rf2-xbvzh — shared raw-text emission across ALL three SSR paths.
+;; ---------------------------------------------------------------------------
+
+(defn- v1
+  "Wrap a structural node as a version-1 tree for `emit-ui-tree`."
+  [node]
+  (assoc node :rf.ui/tree-version 1))
+
+(defn- assert-emitters-agree
+  "The load-bearing cross-emitter proof (rf2-xbvzh ruling Option (a)): for a
+  raw-text `tag` (`:script`/`:style`) carrying a single string `content`, all
+  three SSR paths — the sync hiccup emitter, the streaming shell walker, and
+  the S5 structural serialiser — emit the SAME `expected-inner` body between
+  the tags. `expected-inner` is the raw-text body AFTER the closing-sequence
+  rewrite (verbatim but for that rewrite; NO entity escaping)."
+  [tag content expected-inner]
+  (let [tag-name (name tag)
+        expected (str "<" tag-name ">" expected-inner "</" tag-name ">")]
+    (is (= expected (emit/render-to-string [tag content] {}))
+        (str "sync render-to-string byte-mismatch for <" tag-name ">"))
+    (is (str/includes? (:shell-html (streaming/render-shell [:div [tag content]]))
+                       expected)
+        (str "streaming render-shell byte-mismatch for <" tag-name ">"))
+    (is (= expected (ui-tree/emit-ui-tree (v1 {:tag tag :children [content]})))
+        (str "emit-ui-tree byte-mismatch for <" tag-name ">"))))
 
 ;; ===========================================================================
 ;; G1 — strip-prop XSS rule through `render-to-string` / `emit-element`
@@ -254,30 +282,98 @@
           "the handler body never reaches the shell"))))
 
 ;; ===========================================================================
-;; rf2-ee38b.10 — body-position raw <script>/<style> string content is
-;; fail-loud, not silently HTML-escaped (which corrupted legit inline JS /
-;; CSS / JSON-LD). Element-only / empty raw-text tags are inert.
+;; rf2-xbvzh (supersedes the rf2-ee38b.10 refusal) — ordinary inline
+;; <script>/<style> STRING content is AUTHOR content: emitted VERBATIM with
+;; only React's context-safe closing-sequence rewrite, NO entity escaping and
+;; NO refusal. The refusal (`:rf.error/ssr-raw-text-in-body`) was pushing real
+;; content into the genuinely-unguarded trusted shell opts, which is strictly
+;; LESS safe than a guarded render-tree element. ONE raw-text semantics now
+;; holds across all three SSR paths (sync hiccup, streaming hiccup, S5
+;; serialiser); the DATA-payload channels keep their stricter escapes.
 ;; ===========================================================================
 
-(deftest render-to-string-rejects-raw-string-under-body-script
-  (testing "rf2-ee38b.10 — a `<script>` in the body render-tree with a raw
-            string child throws :rf.error/ssr-raw-text-in-body rather than
-            corrupting the content via escape-html."
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #":rf.error/ssr-raw-text-in-body"
-                          (emit/render-to-string
-                            [:script {:type "application/ld+json"} "{\"a\":\"<b>\"}"] {})))))
+(deftest raw-text-body-content-is-emitted-verbatim-not-escaped
+  (testing "rf2-xbvzh — literal JS/CSS operators and `&` are NOT entity-escaped
+            (escape-html would corrupt them), and all three SSR paths agree."
+    ;; escape-html would have produced `if (a &lt; b)` / `a &gt; .b` — a
+    ;; corrupted script/style body. Raw text emits them literally.
+    (assert-emitters-agree :script "if (a < b) { x() }" "if (a < b) { x() }")
+    (assert-emitters-agree :script "a & b && c" "a & b && c")
+    (assert-emitters-agree :style "a > .b { color: red }" "a > .b { color: red }")
+    (assert-emitters-agree :style "x & y" "x & y")))
 
-(deftest render-to-string-rejects-raw-string-under-body-style
-  (testing "rf2-ee38b.10 — a body `<style>` with raw string content throws
-            rather than mangling `a > b {…}` into `a &gt; b`."
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #":rf.error/ssr-raw-text-in-body"
-                          (emit/render-to-string [:style "a > b { color: red }"] {})))))
+(deftest raw-text-body-closing-sequence-is-rewritten-case-insensitively
+  (testing "rf2-xbvzh — an embedded `(<|</)script`/`style` closing sequence is
+            rewritten to a context-safe spelling so the raw-text parser cannot
+            terminate the element early, matching react-dom/server's
+            scriptRegex/styleRegex byte-for-byte (case-insensitive), and all
+            three SSR paths agree."
+    ;; <script>: s/S -> s / S (a valid JS *and* JSON string escape).
+    (assert-emitters-agree :script "var x = '</script>';"
+                           "var x = '</\\u0073cript>';")
+    (assert-emitters-agree :script "a</ScRiPt>b" "a</\\u0053cRiPt>b")
+    (assert-emitters-agree :script "a<script>b" "a<\\u0073cript>b")
+    ;; <style>: s/S -> \73 / \53  (trailing space terminates the CSS hex escape).
+    (assert-emitters-agree :style "@import '</style>';"
+                           "@import '</\\73 tyle>';")
+    (assert-emitters-agree :style "x</StYlE>y" "x</\\53 tYlE>y")))
+
+(deftest raw-text-classification-is-case-insensitive-on-the-tag
+  (testing "rf2-xbvzh + rf2-hzttr finding 3 — an UPPER/MIXED-case <SCRIPT> /
+            <Style> tag is still classified as raw text (author case preserved
+            in the emitted markup), so its literal `<` is NOT entity-escaped."
+    (doseq [tag [:SCRIPT :Script :sCrIpT]]
+      (is (= (str "<" (name tag) ">if (a < b)</" (name tag) ">")
+             (emit/render-to-string [tag "if (a < b)"] {}))
+          (str tag " body emitted as raw text, not escaped")))
+    (doseq [tag [:STYLE :Style]]
+      (is (= (str "<" (name tag) ">a > .b { }</" (name tag) ">")
+             (emit/render-to-string [tag "a > .b { }"] {}))
+          (str tag " body emitted as raw text, not escaped")))))
+
+(deftest raw-text-json-island-round-trips-through-json-parse
+  (testing "rf2-xbvzh — a JSON data island written as ordinary <script> string
+            content is emitted raw with the closing-sequence rewrite; the
+            embedded `</script>` cannot terminate the element, and because
+            `\\u0073` is ALSO a valid JSON string escape the payload round-trips
+            back through JSON.parse."
+    (let [json "{\"@type\":\"WebSite\",\"u\":\"a</script>b\"}"
+          out  (emit/render-to-string
+                 [:script {:type "application/ld+json"} json] {})]
+      (is (= (str "<script type=\"application/ld+json\">"
+                  "{\"@type\":\"WebSite\",\"u\":\"a</\\u0073cript>b\"}"
+                  "</script>")
+             out)
+          "the embedded </script> is rewritten to </\\u0073cript>, element not terminated")
+      ;; Reversing `s` -> `s` (exactly what a JS engine / JSON.parse does
+      ;; when decoding the escape) restores the author's JSON verbatim — the
+      ;; round-trip the ruling requires.
+      (let [body    (-> out
+                        (str/replace-first "<script type=\"application/ld+json\">" "")
+                        (str/replace-first "</script>" ""))
+            decoded (str/replace body "\\u0073" "s")]
+        (is (= json decoded)
+            "decoding \\u0073 -> s restores the original JSON island (JSON.parse round-trip)")))))
+
+(deftest data-payload-json-ld-channel-uses-stricter-escape-unchanged
+  (testing "rf2-xbvzh — the DATA-payload channel (reg-head JSON-LD) is
+            UNCHANGED: the SAME `</script>` payload keeps the stricter
+            data-aware `\\u003c` escape, DISTINCT from the author-content
+            raw-text closing-sequence rewrite. Removing the body refusal did
+            NOT touch the data-payload escape path."
+    (let [html (rf/head-model->html
+                 {:json-ld [{"@type"    "Article"
+                             "headline" "</script><script>alert(1)</script>"}]})]
+      (is (str/includes? html "\\u003c/script>\\u003cscript>")
+          "JSON-LD data payload still escapes every `<` as the JSON `\\u003c` escape")
+      (is (not (str/includes? html "</\\u0073cript>"))
+          "the data channel does NOT use the author-content raw-text rewrite")
+      (is (not (str/includes? html "</script><script>alert"))
+          "the hostile breakout literal does not survive on the data channel"))))
 
 (deftest render-to-string-allows-empty-or-element-only-raw-text-tags
-  (testing "rf2-ee38b.10 — a raw-text tag with NO string child is inert
-            and emits unchanged; only a raw STRING child trips the guard."
+  (testing "rf2-xbvzh — a raw-text tag with NO string child is inert and emits
+            unchanged; the raw-text emission only applies to string content."
     (is (= "<script></script>"
            (emit/render-to-string [:script] {}))
         "empty <script> is fine")
@@ -288,34 +384,15 @@
            (emit/render-to-string [:script {:src "/main.js"}] {}))
         "an attribute-only <script> (the common external-script shape) is fine")))
 
-(deftest render-shell-rejects-raw-string-under-body-script
-  (testing "rf2-ee38b.10 — the streaming walk's DOM-tag branch mirrors the
-            non-streaming guard."
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #":rf.error/ssr-raw-text-in-body"
-                          (streaming/render-shell
-                            [:div [:style "p { margin: 0 }"]])))))
-
 ;; ===========================================================================
-;; rf2-hzttr finding 3 — raw-text + void classification is CASE-INSENSITIVE.
-;; `validate-tag-name!` admits upper/mixed-case names, but the raw-text +
-;; void element SETS are keyed lower-case. Without normalisation, `[:SCRIPT
-;; "if (a<b)"]` bypassed the body-position raw-text guard (XSS-adjacent) and
-;; `[:BR]` was emitted as a non-void <BR></BR> pair. Same void issue in the
-;; streaming walker.
+;; rf2-hzttr finding 3 — void classification is CASE-INSENSITIVE.
+;; `validate-tag-name!` admits upper/mixed-case names, but the void element
+;; SET is keyed lower-case. Without normalisation, `[:BR]` was emitted as a
+;; non-void <BR></BR> pair. Same void issue in the streaming walker. (The
+;; case-insensitive RAW-TEXT classification is exercised by the rf2-xbvzh
+;; emission tests above — `raw-text-classification-is-case-insensitive-on-the-tag`
+;; and `render-shell-raw-text-is-case-insensitive`.)
 ;; ===========================================================================
-
-(deftest render-to-string-raw-text-guard-is-case-insensitive
-  (testing "rf2-hzttr finding 3 — an UPPER/MIXED-case <SCRIPT>/<Style> body
-            element with a raw string child trips the SAME raw-text guard as
-            its lower-case spelling. The case-sensitive check let `[:SCRIPT
-            \"if (a<b)\"]` slip past the body-position script protection."
-    (doseq [tag [:SCRIPT :Script :sCrIpT :STYLE :Style]]
-      (testing (str tag " body string fails loud")
-        (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #":rf.error/ssr-raw-text-in-body"
-                              (emit/render-to-string [tag "if (a < b) { x() }"] {}))
-            (str tag " with a raw string child must throw, not emit"))))))
 
 (deftest render-to-string-void-classification-is-case-insensitive
   (testing "rf2-hzttr finding 3 — an UPPER/MIXED-case void tag is recognised
@@ -352,14 +429,21 @@
       (is (str/includes? shell-html "<Img src=\"/a.png\">"))
       (is (not (str/includes? shell-html "</Img>"))))))
 
-(deftest render-shell-raw-text-guard-is-case-insensitive
-  (testing "rf2-hzttr finding 3 — the streaming walk's raw-text guard is also
-            case-insensitive (it delegates to the shared
-            `reject-raw-text-string-children!`)."
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #":rf.error/ssr-raw-text-in-body"
-                          (streaming/render-shell
-                            [:div [:STYLE "p { margin: 0 }"]])))))
+(deftest render-shell-raw-text-is-case-insensitive
+  (testing "rf2-xbvzh — the streaming walk classifies raw-text tags
+            case-insensitively too: an UPPER/MIXED-case <STYLE>/<SCRIPT> body
+            is emitted as raw text (author case preserved), NOT entity-escaped
+            and NOT refused."
+    (let [{:keys [shell-html]} (streaming/render-shell
+                                 [:div
+                                  [:STYLE "p > a { margin: 0 }"]
+                                  [:Script "if (a < b) { x() }"]])]
+      (is (str/includes? shell-html "<STYLE>p > a { margin: 0 }</STYLE>")
+          "upper-case <STYLE> body emitted raw in the streaming shell")
+      (is (str/includes? shell-html "<Script>if (a < b) { x() }</Script>")
+          "mixed-case <Script> body emitted raw in the streaming shell")
+      (is (not (str/includes? shell-html "&lt;"))
+          "no entity escaping leaked into a raw-text body"))))
 
 ;; ===========================================================================
 ;; rf2-ee38b.10 — Reagent-native interop head `:>` cannot be statically


### PR DESCRIPTION
## What & why

Implements the RULED Option (a) from `rf2-xbvzh`: **ONE raw-text semantics** for ordinary inline `<script>`/`<style>` STRING content across all three SSR paths — the sync hiccup emitter (`render-to-string`), the streaming hiccup walker (`render-shell`), and the S5 structural serialiser (`emit-ui-tree`).

- **Author content** (an ordinary inline `<script>`/`<style>` string in a view): trust the programmer — emitted **verbatim** with only react-dom/server's context-safe closing-sequence rewrite (`escape-raw-text`), never entity-escaped, never refused. The rewrite is byte-parity with React's `scriptRegex`/`styleRegex`.
- **Refusal removed** (not weakened): the old `:rf.error/ssr-raw-text-in-body` throw was pushing real content into the genuinely-unguarded trusted shell opts — strictly *less* safe than a guarded render-tree element.
- **Data payloads UNCHANGED**: the JSON-LD head channel (`escape-script-body-string`, `<`→`<`) and the `__rf_payload`/EDN wire (`escape-edn-script-body`) keep their stricter data-aware escapes. The data-payload escape path was not touched.

## Both emitters' prior behaviour → ruled target

- **Before**: compiled `emit-ui-tree` already emitted raw text (React-aligned); the legacy sync emitter and the streaming walker both **refused** a raw string child of a body `<script>`/`<style>` (`:rf.error/ssr-raw-text-in-body`). The two SSR families disagreed.
- **After**: all three emit the **same raw-text bytes** for the same author content.

## Implementation

- Hoisted `raw-text-tags` + `escape-raw-text` from `ui_tree.cljc` into the shared `html_helpers.cljc` — the ONE shared implementation, now called by the serialiser and both hiccup emitters.
- `emit.cljc`: deleted `reject-raw-text-string-children!`; a body-position raw-text tag with all-string children routes through the shared `escape-raw-text`; non-string children keep their existing inert pass-through (no new compiled child-shape grammar in the hiccup path).
- `streaming.cljc`: `walk-dom-tag` mirrors the same raw-text emission.
- Tests: the sync + streaming **throw-tests converted to emission tests**; a shared `assert-emitters-agree` proves all three paths **byte-match** on a focused corpus (literal `<`/`>` operators, `&` unmolested, case-insensitive `</ScRiPt>`/`</StYlE>` rewrite). A JSON data island written as ordinary `<script>` string content **round-trips through `JSON.parse`** (the `s` rewrite is also a valid JSON string escape). A JSON-LD data-payload fixture asserts the stricter `<` escape is **untouched** and distinct from the author-content rewrite.
- `docs/api/re-frame.ssr.md`: error bullet rewritten to state the raw-text rule.

Refusal is not re-introduced in any new form; no config knob / escaping framework added; render-static's static-emit code was not touched.

## Deferred (hot-zone, for the mayor to sequence after merge)

Per the dispatch fence, the **hot-zone spec-doc half** of `rf2-xbvzh` is intentionally NOT in this PR (a `boundary-schema` worker is live on spec/009; spec/011 + spec/Security are hot-zone). Outstanding, to be sequenced solo after this merges:
- `spec/009-Instrumentation.md:2322` — retire the `:rf.error/ssr-raw-text-in-body` catalogue row. (Verified gate-safe to leave now: the error-catalogue conformance test is emitted→catalogued only; the orphan row passes.)
- `spec/011-SSR.md:303-304` — rewrite the fail-loud bullet to the raw-text rule + fix the `&lt;`→`<` JSON-LD spelling.
- `spec/Security.md:60-64` + matrix row `:308` — restate the split + same spelling fix.

## Quality gates

All run foreground to completion (exit codes captured by redirect, not piped):

| Gate | Result |
| --- | --- |
| `implementation/ssr` `clojure -M:test` | **516 tests, 2506 assertions, 0 failures, 0 errors** |
| `implementation/ui` `clojure -M:test` (render-static consumers) | **1016 tests, 19796 assertions, 0 failures, 0 errors** |
| `implementation` `npm run test:cljs` | **10345 tests, 51113 assertions, 0 failures, 0 errors** |
| `mkdocs build --strict` | exit 0 |
| `scripts/check_doc_slugs.py` | exit 0 |
| core `error-catalogue-channel-conformance-test` (drift gate) | 9 tests, 21 assertions, 0/0 |
