### PR TITLE
docs(core): add the re-frame.ui user guide section (rf2-b1wv9)

### DIFF
--- a/docs/core/re-frame.ui/build-a-view.md
+++ b/docs/core/re-frame.ui/build-a-view.md
@@ -1,0 +1,160 @@
+# Build a view
+
+This is the walkthrough the [API reference](../../api/re-frame.ui.md) can't be:
+one small view built up a step at a time, so each new form lands on its own. We'll
+build a counter that increments through an event and reveals a help line through
+local state — enough to touch `defview`, `sub`, an event handler, `local`, and
+the mount, which together are most of what day-to-day view work needs.
+
+The setup this assumes — the dependency and the two Shadow settings — is the
+[Install re-frame.ui and configure Shadow](../how-to/install-re-frame-ui.md)
+recipe. Everything below lives in one namespace.
+
+```clojure
+(ns my.app
+  (:require [re-frame.core :as rf]
+            [re-frame.ui :as ui :refer [defview sub]]))
+```
+
+## Step 1 — the dataflow
+
+None of this is new. The counter's state, the event that changes it, and the
+subscription that reads it are plain re-frame2 — the same code you'd write behind
+any adapter.
+
+```clojure
+(rf/reg-event :app/init  (fn [_ _] {:db {:count 0}}))
+(rf/reg-event :count/inc (fn [{:keys [db]} _] {:db (update db :count inc)}))
+(rf/reg-sub   :count     (fn [db _] (:count db)))
+```
+
+`:app/init` seeds app-db, `:count/inc` bumps the count, and `[:count]` reads it.
+The view is going to *consume* these, not reinvent them.
+
+## Step 2 — the view
+
+Here is the whole component, in its first form:
+
+```clojure
+(defview counter []
+  [:div.counter
+   [:p "Count: " (sub [:count])]])
+```
+
+`defview` takes a props map — here there are no props, so the argument vector is
+empty — and returns a template. `(sub [:count])` is the current value of the
+subscription, dropped straight into the paragraph; when `[:count]` changes, this
+view re-renders and the number updates. No `@`, no deref, no ratom. That's the
+reactive spine of the whole thing, in one line.
+
+## Step 3 — an event
+
+To change the count, dispatch the event. In `re-frame.ui` a handler is an event
+vector — data, not a closure:
+
+```clojure hl_lines="4"
+(defview counter []
+  [:div.counter
+   [:p "Count: " (sub [:count])]
+   [:button {:on-click [:count/inc]} "Increment"]])
+```
+
+`{:on-click [:count/inc]}` says: when this button is clicked, dispatch
+`[:count/inc]` to the frame this view runs under. The handler is visible in
+source and in [Xray](../observability.md) before it ever fires. Click the button,
+`:count/inc` runs, app-db updates, `[:count]` changes, and Step 2's paragraph
+re-renders with the new value — the full pipeline, driven by one vector.
+
+## Step 4 — local state
+
+Some state has no business in app-db. Whether a help line is *showing* is a
+detail of this one view: no other view reads it, you don't want it in the trace,
+and time-travel shouldn't rewind it. That's what `local` is for — component-local
+ephemera that lives outside re-frame2's epochs and re-renders only this view.
+
+```clojure hl_lines="2 6 7 8 9"
+(defview counter []
+  (let [[open? _ update-open!] (ui/local false)]
+    [:div.counter
+     [:p "Count: " (sub [:count])]
+     [:button {:on-click [:count/inc]} "Increment"]
+     [:button {:on-click (ui/handler [_] (update-open! not))}
+      (if open? "Hide help" "Show help")]
+     (when open?
+       [:p.help "The Increment button dispatches the event vector [:count/inc]."])]))
+```
+
+`(ui/local false)` returns a **three-tuple** `[value set! update!]`, bound in the
+view's top-region `let`. Here we read `open?` and keep `update!`; `update-open!`
+applies a function to the latest value, so `(update-open! not)` flips the flag.
+
+The toggle button uses `ui/handler` rather than an event vector, because flipping
+local state is imperative work, not a dispatch — its body runs and its return is
+ignored. (Setters are host-only: you call them from a committed handler like this
+one, never during render.) Then a plain `when` shows or hides the help line based
+on `open?`. Note how the count still flows through app-db and events, while the
+help toggle stays local — the same view, two kinds of state, each in its right
+home.
+
+## Step 5 — mount it
+
+A view becomes a running app when you install the adapter and mount a root:
+
+```clojure
+(defn ^:export run []
+  (rf/init! ui/adapter)
+  (ui/mount [ui/frame-root {:id :app :initial-events [[:app/init]]}
+             [counter]]
+            (js/document.getElementById "root")))
+```
+
+`(rf/init! ui/adapter)` selects the `re-frame.ui` substrate once, at boot.
+`ui/mount` creates the React root and renders the form into `#root`.
+`frame-root` ensures the `:app` frame exists and drains `:initial-events`
+(`[:app/init]`) exactly once, *before* React renders — so the count is `0` on the
+first paint, not `nil`. A hot reload finds the frame already live and reuses it,
+so your state survives edits.
+
+## The complete view
+
+```clojure
+(ns my.app
+  (:require [re-frame.core :as rf]
+            [re-frame.ui :as ui :refer [defview sub]]))
+
+;; ---- dataflow: plain re-frame2 --------------------------------------------
+
+(rf/reg-event :app/init  (fn [_ _] {:db {:count 0}}))
+(rf/reg-event :count/inc (fn [{:keys [db]} _] {:db (update db :count inc)}))
+(rf/reg-sub   :count     (fn [db _] (:count db)))
+
+;; ---- view -----------------------------------------------------------------
+
+(defview counter []
+  (let [[open? _ update-open!] (ui/local false)]
+    [:div.counter
+     [:p "Count: " (sub [:count])]
+     [:button {:on-click [:count/inc]} "Increment"]
+     [:button {:on-click (ui/handler [_] (update-open! not))}
+      (if open? "Hide help" "Show help")]
+     (when open?
+       [:p.help "The Increment button dispatches the event vector [:count/inc]."])]))
+
+;; ---- mount ----------------------------------------------------------------
+
+(defn ^:export run []
+  (rf/init! ui/adapter)
+  (ui/mount [ui/frame-root {:id :app :initial-events [[:app/init]]}
+             [counter]]
+            (js/document.getElementById "root")))
+```
+
+That's a complete, runnable re-frame.ui view: a subscription read as a value, an
+event dispatched as data, and ephemeral state kept local — mounted under an
+explicit frame. For a standalone project carrying exactly this shape plus the
+five load-bearing setup files, the
+[`examples/ui/minimal-counter`](https://github.com/day8/re-frame2/tree/main/examples/ui/minimal-counter)
+scaffold is the thing to copy.
+
+Next: [why this stays reactive](reactivity-and-ownership.md) — what re-computes
+when `[:count]` changes, and why the subscription never leaks.

--- a/docs/core/re-frame.ui/index.md
+++ b/docs/core/re-frame.ui/index.md
@@ -1,0 +1,78 @@
+# re-frame.ui
+
+`re-frame.ui` is the first-party **compiled-view substrate**. Where the
+[Reagent, reagent-slim, and UIx adapters](../how-to/use-uix-helix-or-slim.md)
+interpret your hiccup at runtime, `re-frame.ui` reads your templates at *compile*
+time and lowers them to direct React construction in the browser and a versioned
+structural tree on the JVM — there is no hiccup interpreter in the production
+bundle. Views are written with one macro, `defview`; subscriptions read as plain
+values; and the frame a view runs under is explicit rather than ambient magic.
+
+> **Same pipeline, a compiled view layer.**
+
+This section teaches you how to *build views* with it. It is a guide, not a
+catalogue — for the exact shape of every function the
+[`re-frame.ui` API reference](../../api/re-frame.ui.md) is the complete surface,
+and the [Install re-frame.ui and configure Shadow](../how-to/install-re-frame-ui.md)
+recipe is the one-time setup.
+
+!!! warning "re-frame.ui is experimental"
+
+    It is pre-alpha, delivered in staged slices, and some surfaces are still
+    landing. The Maven coordinates aren't on Clojars yet. Treat it as a track you
+    can *trial* today, not one to bet a shipping product on. The
+    [adapters](../how-to/use-uix-helix-or-slim.md) are where the stable ground is.
+
+## What stays the same
+
+The important thing first: `re-frame.ui` changes only the **view layer**.
+Everything upstream of the view — [events](../events.md), [app-db](../app-db.md),
+[subscriptions](../subscriptions.md), [effects](../effects.md),
+[frames](../frames.md) — is the *same* re-frame2 you already know. You register
+events with `rf/reg-event`, derive values with `rf/reg-sub`, and reason about the
+[event pipeline](../introduction.md) exactly as before. A `defview` reads those
+subscriptions and dispatches those events; it just does so as compiled code
+rather than an interpreted tree.
+
+So this is not a new framework. It is a different way to spell the last stage of
+the one you're already using.
+
+## When to use it
+
+`re-frame.ui` is an **opt-in, additional** view substrate — offered *alongside*
+the adapters, never as a mandated replacement. **Reagent, reagent-slim, and UIx
+remain first-class and actively supported.** You require `re-frame.ui`
+explicitly and install its adapter at boot; nothing pulls it in for you.
+
+Reach for it when you specifically want:
+
+- **Compiled views** — no runtime hiccup walker, no wrapper components, no
+  per-render interpretation. What ships is React construction the compiler wrote.
+- **Value-comparing memo by default** — every view is memoized on its props, and
+  ClojureScript data compares by value, so a parent re-render doesn't re-run a
+  child whose inputs didn't actually change. No manual `React.memo`, no deps
+  arrays.
+- **A view layer designed around the re-frame2 model** — frames carried
+  explicitly, [events as data](mental-model.md#handlers-are-data), subscriptions
+  as the one reactive grammar, no second state model (no ratoms, cursors, or
+  reactions).
+- **Headless-testable views** — a compiled view renders to a structural tree on
+  the JVM, so you can assert on it without a browser.
+
+Stay on the adapters when you need stability now, when you have an existing
+Reagent or re-com application (a migration wave lands later), or when you'd
+rather not ride pre-alpha churn. Choosing an adapter is not a fallback — it is a
+supported, first-class choice.
+
+## This section
+
+| Page | What it covers |
+|---|---|
+| [Mental model](mental-model.md) | The three shifts from Reagent: views compile, `defview` is the one form, and `(sub …)` reads as a value. |
+| [Build a view](build-a-view.md) | A worked walkthrough — `defview`, `sub`, an event, local state, and the mount — built up one step at a time. |
+| [Reactivity and ownership](reactivity-and-ownership.md) | How a compiled view stays reactive, what re-computes when, and why subscriptions never leak. |
+
+New to re-frame2 entirely? Read the [introduction](../introduction.md) and the
+concept pages ([events](../events.md) through [views](../views.md)) first — they
+teach the pipeline this substrate plugs into, using the default adapter. Then
+come back here for the compiled-view spelling.

--- a/docs/core/re-frame.ui/mental-model.md
+++ b/docs/core/re-frame.ui/mental-model.md
@@ -1,0 +1,137 @@
+# Mental model
+
+If you've written Reagent, most of what you know carries over — hiccup is still
+hiccup, a view is still a pure function of data. What changes is *when* and *how*
+the view runs. Three shifts cover almost all of it.
+
+## 1. Views compile
+
+A Reagent view is a function the runtime *interprets*: at render time a walker
+reads your hiccup, guesses at tags and components and sequences, and builds React
+elements on the fly. `re-frame.ui` moves that work to compile time. The compiler
+reads your template once, when you build the project, and lowers it to direct
+React construction — the browser bundle contains the calls, not a tree to walk.
+
+That has three consequences worth internalising:
+
+- **The template grammar is closed.** Because the compiler has to *understand*
+  your template — not just execute it — a few dynamic tricks that a runtime
+  walker tolerates are rejected at compile time, each with a didactic message: a
+  computed tag head (`[(if x :div :span) …]`), a `map` that returns markup,
+  keywords in child position, a `sub` inside a `for`. The fixes are always
+  small, and the payoff is that tools and the JVM emitter can rely on the shape.
+- **Memoization is automatic.** Every view is memoized on its props, compared by
+  value. Think "`React.memo`, except ClojureScript data compares by value" — a
+  parent re-render doesn't re-run a child whose props are equal.
+- **Dev machinery vanishes from production.** The compiled path guards its
+  development affordances behind `goog.DEBUG`, so an advanced build carries no
+  interpreter, no descriptors, no dev-only checks.
+
+## 2. `defview` is the one component form
+
+There is exactly one way to write a component:
+
+```clojure
+(ui/defview greeting [{:keys [name]}]
+  [:p "Hello, " name])
+```
+
+A `defview` takes **zero or one argument** — a props map — and returns a
+template. Header destructuring lowers to direct reads on the props object.
+
+There is no Form-1 / Form-2 / Form-3 distinction, no `reg-view`, no positional
+arguments, and no place to stash a ratom in a closure. The taxonomy Reagent users
+routinely misuse simply isn't here: one form, memoized by default, with no
+opt-out. View-local state and lifecycle, when you need them, are explicit body
+forms (see [below](#state-and-lifecycle-are-body-forms)), not a component shape
+you switch to.
+
+## 3. Subscriptions read as values
+
+In Reagent you deref a subscription: `@(rf/subscribe [:count])`. In a compiled
+view you write:
+
+```clojure
+[:span "Count: " (sub [:count])]
+```
+
+`(sub [:count])` **is the value** — there is nothing to deref, no `@`, no ratom
+behind it. The compiler indexes every `sub` site in the view; when a subscribed
+value changes, the view re-renders. Conditional reads are fine; a `sub` inside a
+`for` is a compile error (extract a keyed child view instead). Outside a view —
+in an event handler, a tool, a test — you still use core's `rf/subscribe`;
+`(sub …)` is a *view* form and fails loudly if called anywhere else.
+
+## Frames are explicit, but usually invisible
+
+Every view runs under a [frame](../frames.md) — the isolated world its
+subscriptions read from and its events dispatch to. In `re-frame.ui` that frame
+is explicit at the two edges and ambient in between:
+
+- At the **root**, `frame-root` ensures the frame exists and seeds its
+  initial events, once, before React renders:
+  `[ui/frame-root {:id :app :initial-events [[:app/init]]} [app]]`.
+- Inside the tree, a view's `sub`, dispatch, and handlers all bind to the
+  **committed** frame automatically — you don't thread it through props. To scope
+  a subtree to a *different* live frame, wrap it in `frame-provider`.
+
+So frames are a first-class part of the model, but day to day you name one at the
+root and forget about it.
+
+## Handlers are data
+
+An event handler is, by default, just an event vector:
+
+```clojure
+[:button {:on-click [:count/inc]} "+"]
+```
+
+The vector is the *intent* — it's dispatched to the committed frame when the
+button is clicked. Being data, it's readable in source, visible in
+[Xray](../observability.md) before anything fires, and assertable on the JVM
+without a DOM. For the small dynamic cases there's a closed set of placeholders —
+`:rf.ui/value`, `:rf.ui/checked`, `:rf.ui/key` — that the runtime fills from the
+event:
+
+```clojure
+[:input {:on-input [:draft/set :rf.ui/value]}]
+```
+
+When you genuinely need the live native event — to read something the
+placeholders don't cover, or to decide whether to dispatch at all — reach for
+`ui/event`, whose body returns the event vector to dispatch (or `nil` for
+"dispatch nothing"):
+
+```clojure
+[:input {:on-input (ui/event [e] [:draft/set (.. e -target -value)])}]
+```
+
+And for imperative work that dispatches nothing — driving a foreign widget,
+flipping local state — there's `ui/handler`. The guiding rule: **a handler is
+data until it can't be**, and each non-data form names exactly what it needs.
+
+## State and lifecycle are body forms
+
+When a view needs its own ephemeral state or a hook into the host world, that's
+four explicit body forms rather than a component-shape change:
+
+| Form | For |
+|---|---|
+| `local` | Component-local ephemera — a toggle, a hover flag — that lives *outside* app-db and re-renders only this view. |
+| `effect` | Synchronising with the world outside the tree: measurement, a chart or animation library attached through a ref. |
+| `lease` | Declaring that a mounted, visible view is interested in a [resource](../../resources/concepts.md), loaded and released around its lifetime. |
+| `frame` | The committed-frame ops bundle, for the rare imperative or foreign-callback case. |
+
+The [build-a-view walkthrough](build-a-view.md) uses `local` and an event; the
+[reactivity page](reactivity-and-ownership.md) explains why `local` sits outside
+re-frame2's epochs and app-db does not.
+
+## What you give up
+
+The absences are deliberate, and they're the same list every time: no ratoms,
+cursors, or reactions (that's a second state model); no Form-2 / Form-3; no
+positional view args; no dynamic tag heads or runtime-interpreted hiccup. Closed
+grammars are precisely what let the compiler be honest about what a view reads
+and does — which is what makes the memoization, the elision, and the tooling
+sound. You trade a little runtime flexibility for a view layer that can be
+compiled, analysed, and taught without hedging.

--- a/docs/core/re-frame.ui/reactivity-and-ownership.md
+++ b/docs/core/re-frame.ui/reactivity-and-ownership.md
@@ -1,0 +1,116 @@
+# Reactivity and ownership
+
+The [build-a-view walkthrough](build-a-view.md) leaned on one sentence — "when
+`[:count]` changes, the view re-renders" — without saying how. This page opens
+that up to the level a view author needs: what re-computes when, and why a
+compiled view's subscriptions never leak. You don't have to manage any of it, but
+knowing the shape makes the framework's behaviour predictable rather than
+magical.
+
+## What re-computes when
+
+Start with the question every view author eventually asks: I changed one value in
+app-db — what runs again?
+
+**One reactive bridge per view.** However many `(sub …)` sites a view has, they
+share a *single* subscription to the store. The compiler indexes every site at
+compile time and wires them to one bridge, so a view with five subscriptions
+still holds one connection, not five. When any of its subscribed values moves,
+the view is marked dirty.
+
+**Only what actually changed.** A dirty view doesn't necessarily re-render.
+Subscriptions are stabilised by value: if a sub's new value is equal (`rf=`) to
+its last, the view sees the *same* value and nothing downstream churns. So
+changing `[:count]` from `1` to `2` re-renders the views that read `[:count]`;
+changing some *other* key, or writing `2` where the value was already `2`, does
+not.
+
+**Children skip on equal props.** Because every view is memoized on its props by
+value, a parent re-render doesn't cascade into a child whose props are `rf=`. The
+re-render stops where the data stops changing.
+
+**Once per batch.** When an event settles, each dirty view flushes at most once —
+several subscription changes from one event coalesce into a single re-render, not
+one per sub. You never see a view render three times because three of its inputs
+moved together.
+
+Put together: *changing a value re-runs exactly the views that read it, once,
+and only if the value really changed.* That's the whole performance story, and
+it's automatic — there is no manual memo, no deps array, no subscription
+bookkeeping.
+
+## Why subscriptions never leak
+
+This is the part that earns the "compiled substrate designed for modern React"
+description, and it's worth understanding even though you never touch it.
+
+Under concurrent React a *render* is speculative: React may run it, restart it,
+or throw it away without ever showing it. Any design that grabs a resource —
+opens a subscription, takes a lock — *during* render is therefore wrong by
+construction, because the render that grabbed it might be abandoned, and the grab
+would leak.
+
+`re-frame.ui` sidesteps this with a strict rule: **render only reads; commit
+owns.** When a view renders, it *resolves and reads* its subscriptions but takes
+no ownership. Only when React *commits* that render — actually puts it on screen —
+does the view acquire its subscriptions, and it releases them when the view
+unmounts or is hidden. Because ownership is keyed to the commit, an abandoned
+render owns nothing to leak, and a StrictMode double-invoke balances out. This is
+why you can lean on subscriptions freely in a compiled view without ever thinking
+about cleanup — the leak classes that plague render-time ownership are closed off
+below the surface.
+
+## Frames survive hot reload
+
+Frames are created at **host preflight** — the moment `frame-root` runs, before
+React renders — never from inside a render. That timing is deliberate: it's what
+makes hot reload a designed workflow rather than a hope. When you save a file and
+Shadow reloads it, preflight runs again, finds the frame already live, and
+reuses it without re-seeding. Your app-db, your count, your form drafts — all
+survive the edit. The view code swaps; the state stays.
+
+## Where state lives: the `local` boundary
+
+The [walkthrough](build-a-view.md#step-4--local-state) put the count in app-db and
+the help toggle in `local`, and the reason is exactly the ownership model above.
+State in app-db is *observed*: subscriptions derive from it, the trace records
+every change, tools inspect it, and [time-travel](../observability.md) can rewind
+it. `local` deliberately sits **outside** all of that — it isn't seen by subs,
+isn't in the epoch history, and re-renders only its own view.
+
+That gives a clean rule for where a value belongs:
+
+- **app-db, behind events** — anything with product meaning: something another
+  view reads, that should replay or persist, that a schema or a tool should see,
+  or that a subscription computes from.
+- **`local`** — keystroke-latency ephemera with no product meaning: a disclosure
+  toggle, a hover flag, a transient bit that only this view cares about.
+
+When in doubt, prefer app-db: it's the observable, replayable home, and the
+[Where should this value live?](../where-state-lives.md) page walks the fuller
+decision.
+
+## The vocabulary tools use
+
+Because public React gives no signal that distinguishes "this view was hidden"
+from "this view was unmounted", `re-frame.ui` models a view as being in one of
+three observable states, and its tools speak in these terms:
+
+- **connected** — mounted and visible; owns its subscriptions.
+- **disconnected** — ownership released (hidden or unmounted); the runtime
+  doesn't yet claim which.
+- **dead** — its frame, adapter, or root was destroyed; reconnection fails
+  loudly rather than silently.
+
+You won't write against these directly, but they're the words [Xray](../observability.md)
+and the reactivity tooling use, so it helps to recognise them.
+
+## Resources: `lease`
+
+The same "commit owns, release on teardown" discipline extends to server data. A
+view declares interest in a [resource](../../resources/concepts.md) with `lease`,
+and the runtime loads it after the view's visible commit and releases it when the
+view goes away — you read its status and data passively with an ordinary
+`(sub [:rf/resource …])`. It's the resource-shaped version of the ownership model:
+liveness declared in the view, acquisition and cleanup handled at the lifecycle
+edges, never during render.

--- a/docs/core/views.md
+++ b/docs/core/views.md
@@ -426,4 +426,7 @@ that survives any async hop. [Frames](frames.md) is that pattern's home.
     Handlers, subs, and app-db never name a rendering library. The adapter
     (`(rf/init! reagent-adapter/adapter)`) is the seam where hiccup becomes pixels.
     Port substrates and only `init!` plus view notation change —
-    [Use UIx, Helix, or reagent-slim](how-to/use-uix-helix-or-slim.md).
+    [Use UIx, Helix, or reagent-slim](how-to/use-uix-helix-or-slim.md). A more
+    radical, still-experimental option is [re-frame.ui](re-frame.ui/index.md), a
+    first-party *compiled* view substrate where views are macro-compiled rather
+    than interpreted at runtime.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -193,6 +193,11 @@ nav:
       - "Report errors in production": core/how-to/report-errors-in-production.md
       - "Configure dev and prod": core/how-to/configure-dev-and-prod.md
       - "Use UIx, Helix, or slim": core/how-to/use-uix-helix-or-slim.md
+    - "re-frame.ui (experimental)":
+      - core/re-frame.ui/index.md
+      - "Mental model": core/re-frame.ui/mental-model.md
+      - "Build a view": core/re-frame.ui/build-a-view.md
+      - "Reactivity and ownership": core/re-frame.ui/reactivity-and-ownership.md
     - "Testing":
       - core/testing/index.md
       - "Event handlers": core/testing/event-handlers.md


### PR DESCRIPTION
## What

Adds `docs/core/re-frame.ui/` — a new, self-contained user guide section teaching how to **build views** with `re-frame.ui`, filling the gap between the API references (`docs/api/re-frame.ui*.md`) and the deep design EPs (EP-0030–0034): there was no user-facing guide for actually authoring views on the compiled substrate.

Built as a **sibling to `docs/core/how-to/`**, mirroring its shape (an `index.md` landing page + topic pages, registered as a grouped nav shelf in `mkdocs.yml`).

### Pages
- **`index.md`** — overview + an honest **"When to use it"**: re-frame.ui is experimental and opt-in; Reagent, reagent-slim, and UIx stay first-class and actively supported; this is a track *alongside* them, not a replacement. Maturity caveats up front.
- **`mental-model.md`** — the three shifts from Reagent: views compile (closed template grammar, memo by default), `defview` is the one component form, and `(sub …)` reads as a value (no `@`/deref). Frames explicit; handlers-as-data.
- **`build-a-view.md`** — a step-by-step walkthrough building a counter: `defview` + `sub`, an event vector, `local` state via a committed `ui/handler`, and the `mount`. Ends with the complete view.
- **`reactivity-and-ownership.md`** — distilled from EP-0031/0032 to user level: one reactive bridge per view, what re-computes when (`rf=` stabilisation, memo, once-per-batch), render-reads/commit-owns (why subs never leak), frames-survive-hot-reload, and the `local` vs app-db boundary.

### Additive only
The Reagent-default concept pages stay authoritative and untouched, apart from a single minimal see-also link added to `views.md`'s substrate-seam note.

## Quality gates
- `python -m mkdocs build --strict` → exit 0 (new section renders; nav valid)
- `python scripts/check_doc_slugs.py` → exit 0 (all anchors/links resolve)
- `cd implementation/ui && clojure -M:test` → 1016 tests, 19801 assertions, 0 failures, 0 errors (guide-truth pins stay green)
- `sh scripts/check-no-hardcoded-paths.sh` → OK
