### PR TITLE
spec(ui): draft the surviving emit-seam + page-assembly residue of the retired Spec-011 amendment (rf2-vxgfnd.97.2)

### DIFF
--- a/spec/004B-UI-Tree-and-Conversion.md
+++ b/spec/004B-UI-Tree-and-Conversion.md
@@ -434,26 +434,36 @@ shapes.
   rows-land-with-stages rule): `:rf.error/ui-tree-malformed` **already has its catalogue
   row** (landed with S1 — the shared tree-consumer id, which also carries the
   semantic-`N` root-version-gate arm); `:rf.error/ssr-ui-tree-version-unsupported` is the
-  SSR-seam sibling whose row **lands with the S5 serialiser** that raises it — not yet
-  catalogued, by design.
+  SSR-seam sibling, and its dedicated
+  [Spec 009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue) row
+  **landed with the S5 serialiser** that raises it (rf2-3omxp). The two ids partition one
+  seam's failures by class — version-skew vs. structure — and it is the machine
+  discriminator `:rf.error/id`, not ex-data sniffing, that separates them (both carry the
+  same `{:got … :supported #{1}}` shape at the version gate).
 - The compiled root render pipeline (011's per-root flow) is: JVM emitter → tree →
   `emit-ui-tree`; the response accumulator, error projection, and payload machinery are
   unchanged `re-frame2-ssr` surfaces.
 
-### Stage — spec ahead of code
+### Stage — the emit seam ships; the fingerprint leads code
 
-Both halves belong to S5 (`rf2-vxgfnd.97`): the spelling in this section, and the
-serialiser in the SSR artefact that must meet it. Where the repo already names
-`emit-ui-tree` — `re-frame.ui.compiler.root`'s compile-error message, the guide's
-pipeline sentence — it is pointing at *this contract*, under the same
-rows-land-with-stages rule that leaves the version gate's catalogue row uncatalogued
-above. Spec leads code here, so a reader who greps the name and finds no function has
-found the design working rather than a gap.
+This section's two functions land at different points of S5 (`rf2-vxgfnd.97`). The
+**emit seam has shipped**: `re-frame.ssr/emit-ui-tree` is the JVM's tree→HTML path
+(rf2-3omxp), and its version gate raises the now-catalogued
+`:rf.error/ssr-ui-tree-version-unsupported`. Where the repo names `emit-ui-tree` —
+`re-frame.ui.compiler.root`'s compile-error message, the guide's pipeline sentence — it
+points at *this contract*, and a reader who greps the name now finds the function that
+meets it.
 
-Until that stage the JVM has no tree→HTML path at all.
+The **fingerprint half still leads code**: `re-frame.ssr/ui-tree-fingerprint` has no
+function yet, and the hash algorithm and digest encoding it will apply are Spec 011's
+(§Normalization, and [011 §Root Manifest v1](011-SSR.md#root-manifest-v1)). Spec leads
+code here, so a reader who greps *that* name and finds no function has found the design
+working rather than a gap.
+
+Before the emit seam shipped the JVM had no tree→HTML path at all. The pre-existing
 [011 §The render-tree → HTML emitter](011-SSR.md#the-render-tree--html-emitter-cljs-reference)
 serves the Reagent/hiccup tier and does not transfer — for the reason below, which is
-also why there was never a shim between them available to write.
+also why there was never a shim between the two tree shapes available to write.
 
 ### What the seam consumes
 


### PR DESCRIPTION
## What

The residue leaf `rf2-vxgfnd.97.2` was filed 2026-07-18 against a baseline that has since largely shipped. Reconciled against current `origin/main`, the **emit-seam residue is already merged** (code + spec + catalogue), so the one genuine, code-backed, in-surface deliverable is a reconciliation: the `spec/004B` "§The SSR consumption boundary" section still framed the emit seam as *spec-ahead-of-code*, which is now false.

`rf2-3omxp` shipped `re-frame.ssr/emit-ui-tree` (the JVM tree→HTML path, `implementation/ssr/src/re_frame/ssr/ui_tree.cljc`) and catalogued its version-gate id `:rf.error/ssr-ui-tree-version-unsupported` (`spec/009` row, landed by `docs(009): catalogue …` in `rf2-3omxp`). The 004B section still said "not yet catalogued, by design", "a reader who greps the name and finds no function has found the design working", and "the JVM has no tree→HTML path at all" — all three now false for the emit half.

This PR reconciles those to reality while **preserving** the still-accurate spec-ahead framing for the fingerprint half (`re-frame.ssr/ui-tree-fingerprint` + the FNV-1a/hex algorithm, which `re-frame.ui.fingerprint` and 004B both defer to Spec 011).

- Version-incompatibility bullet: `:rf.error/ssr-ui-tree-version-unsupported`'s row **landed with the S5 serialiser** (`rf2-3omxp`), with a link to Spec 009 §Error event catalogue; the machine-discriminator note (id, not ex-data sniffing) matches the shipped 009 row.
- "### Stage — spec ahead of code" → "### Stage — the emit seam ships; the fingerprint leads code": emit seam shipped (function exists, id catalogued); fingerprint half still leads code.

No error-id is introduced, moved, or re-spelled. The `## The SSR consumption boundary` H2 anchor (referenced by `004-Views`, `009:2356`, `api-manifest-metadata.edn`, and the code) is unchanged.

## Scope reconciliation (what shipped vs. what remains)

The bead's residue inventory is exhaustive; verified against `origin/main`, item-by-item:

| Residue item | State on main | Action |
|---|---|---|
| 1. `emit-ui-tree` seam + version gate | **Shipped**: 004B prose (#6436) + code (`rf2-3omxp`) + 009 row (2356) | 004B stage-marking reconciled (this PR) |
| 2. `ui-tree-fingerprint` hash algorithm/encoding | Spec-011-owned, not shipped (`re-frame.ui.fingerprint` defers `render-fingerprint` to 011) | Out of surface — 004B already defers to 011; framing preserved |
| 3. `render-static` + `:rf.error/ssr-static-root-requires-runtime` | `render-static` shipped (`rf2-oo5lb`); the error id is **not emitted anywhere** and absent from all spec | Spec-ahead, home 011/004C — NOTED, not drafted |
| 4. Layer-2 server page registry (`:rf.error/duplicate-root-id` server tier) | **Spec done**: `004C §7` fully documents Layer 2 (lines 395–406, roster table); code absent (per #6511 audit) | Already in 004C — no action |
| 5. Server wire-accounting ledger (renamed) | Spec-011-owned | Out of surface — NOTED |
| 6. Server per-root render-throw containment + failed-root artefact | **Shipped** as `:rf.error/root-boot-failed` (009 row 2382 + `ssr/boot.cljc`) | Already done — no action |
| Four Spec 009 rows | Row 1 exists+correct (2356); `ui-tree-malformed` (2355) already reconciled ("has its own row"); `duplicate-root-id` (2375) notes server tier "lands S5" (code pending); `ssr-static-root-requires-runtime`/fingerprint-verification id are spec-ahead, no code | Row 1 verified; others correctly spec-ahead — not invented (per anti-over-engineering fence + #6511 audit "do not invent a registry framework") |
| Ownership.md:42 venue change | **Done** — already assigns the `emit-ui-tree` SSR consumption boundary (version-gated) to 004B | No action |
| Spec-Schemas.md rows | No seam schema (node ABI is 004B-owned per Ownership:42); the bead's own 6-item inventory does not list Spec-Schemas | No action |

Stayed strictly within the residue inventory; touched no code; sole editor of the hot-zone spec surface (only edited 004B). Noted below, not actioned: `004C:465` references `:rf.error/root-hydration-mismatch` as "an existing Spec 009 catalogue row" but that id is not in 009 — pre-existing drift, outside this bead's inventory (worth a follow-up bead).

## Quality gates

Foreground, unpiped, exit captured by redirect:

- `python -m mkdocs build --strict` — exit 0 (validates the new 009 / 011 links)
- `python scripts/check_doc_slugs.py` — exit 0 (531 files, no broken anchors)
- `implementation/core` `clojure -M:test` — exit 0, **2104 tests / 10420 assertions / 0 failures 0 errors** (catalogue-conformance parses spec/009 + Spec-Schemas — stays green)
- `implementation/ssr` `clojure -M:test` — exit 0, **516 tests / 2499 assertions / 0 failures 0 errors** (the emit-seam the spec describes)
- `scripts/check-no-hardcoded-paths.sh` — exit 0

No merge.
