### PR TITLE
fix(skills): reagent-migration — document effect signature + correct MIG-17 unmount lifecycle (rf2-14dj2)

### DIFF
--- a/skills/reagent-migration/README.md
+++ b/skills/reagent-migration/README.md
@@ -64,7 +64,7 @@ skills/reagent-migration/
 │   ├── procedure.md           # incremental, closed-subtree passes
 │   └── gotchas.md             # bare-symbol trap, whole-view coherence, keyed-child, staged-gap
 ├── evals/
-│   └── evals.json             # trigger fixtures + one behavioural fixture per M/D/R tier
+│   └── evals.json             # trigger fixtures + behavioural fixtures across the M/D/R tiers
 └── spec/
     ├── design.md              # locked design decisions
     ├── inputs.md              # canonical inputs the skill leans on

--- a/skills/reagent-migration/evals/evals.json
+++ b/skills/reagent-migration/evals/evals.json
@@ -71,6 +71,16 @@
        "Converts item and lst to ui/defview and moves ^{:key t} to a :key prop (MIG-07): [item {:key t :t t}].",
        "Does NOT treat the bare symbol child in [:li t] as a props map — `t` is content, never (ui/spread t) (the bare-symbol trap).",
        "Leaves the plain hiccup structure otherwise unchanged (MIG-14)."
+     ]},
+
+    {"id": 19, "kind": "behavioural", "tier": "D", "name": "d-mig17-lifecycle-rehome-unmount",
+     "prompt": "Migrate this Reagent Form-3 view to re-frame.ui:\n(ns app.editor (:require [reagent.core :as r] [reagent.dom :as rdom]))\n(defn editor []\n  (let [{:keys [dispatch]} (rf/capture-frame)]\n    (r/create-class\n     {:component-did-mount    (fn [this] (.focus (rdom/dom-node this)))\n      :component-will-unmount (fn [_] (dispatch [:resource/release]))\n      :reagent-render         (fn [] [editor-form])})))",
+     "expectations": [
+       "Recognises MIG-17 Form-3 lifecycle and decomposes each body into host/DOM work vs domain work — a judgment call held WHOLE (cardinal rule 2), not an automatic rewrite.",
+       "Routes the host/DOM work (focus the node on mount) to (effect :connect …), with the body's RETURN value as the cleanup — a trailing (fn [] …), NOT the React useEffect shape (a setup fn that returns a cleanup fn), which compiles but silently never runs.",
+       "Recognises there is NO dispatch-at-unmount in native re-frame.ui: (ui/dispatch-fn) fails loud at disconnect with :rf.error/dispatch-disconnected (the leaked-listener law), so an effect cleanup is NOT a place to smuggle the domain release.",
+       "Re-homes the unmount domain work (the [:resource/release] dispatch) OUT of the view — to the causal events that end the resource's life — and names those events / the minting owner for the author (cardinal rule 5); the migrated view becomes a pure defview that owns no lease.",
+       "Mentions the view-declared (ui/lease …) only as the alternative for a genuinely view-scoped, unconditional resource (framework releases at teardown, no dispatch) — not for an app-minted / conditional / dynamically-keyed owner."
      ]}
   ]
 }

--- a/skills/reagent-migration/references/catalog-judgment.md
+++ b/skills/reagent-migration/references/catalog-judgment.md
@@ -33,15 +33,81 @@
 
 ```clojure
 ;; before
-(r/create-class {:component-did-mount #(init! …)
-                 :should-component-update …
-                 :reagent-render (fn [] [:div …])})
+(r/create-class {:component-did-mount     #(focus! …)
+                 :component-will-unmount   #(dispatch [:resource/release])
+                 :should-component-update  …
+                 :reagent-render           (fn [] [:div …])})
 ```
 
-**The decision: decompose each lifecycle body into host work vs domain work.** Mechanical parts first: delete `:should-component-update` (memo-by-default makes it dead), and extract `:reagent-render` as the view body (the other rules apply to it). Then, per lifecycle body:
+**The decision: decompose each lifecycle body into host work vs domain work.** Mechanical parts first: delete `:should-component-update` (memo-by-default makes it dead), and extract `:reagent-render` as the view body (the other rules apply to it). Then, per lifecycle body, split by *what the body does*:
 
-- **Host / DOM work** (focus a node, wire a listener, measure) → `(effect :connect …)`. Note: `:connect` cleanup runs at each *disconnect*, not once at unmount — dev StrictMode replays connect/disconnect, so the cleanup must be disconnect-idempotent.
-- **Domain work** ("mark viewed", "load on mount") → a route/domain **event** through the dataflow (name it for the author). There is deliberately **no** `:on-mount` primitive; domain-on-mount is a dispatch, not a lifecycle hook.
+- **Host / DOM work** (focus a node, wire a listener, measure, attach a chart) → `(effect :connect …)`. Its signature is a trap — read **the `effect` signature** below before you emit one.
+- **Domain work on MOUNT** ("mark viewed", "load on mount") → a route/domain **event** through the dataflow (name it for the author). There is deliberately **no** `:on-mount` primitive; domain-on-mount is a dispatch through the dataflow, not a lifecycle hook.
+- **Domain work on UNMOUNT** ("release the lease", "mark the draft abandoned") → **re-home it OUT of the view** — see **Domain work on unmount** below. There is **no dispatch-at-unmount** in native re-frame.ui; you do **not** preserve it as an `effect` cleanup.
+
+### `effect`'s signature (verify against `ui.cljc` — REQUIRED)
+
+`effect` is a compiler-owned form whose contract is *unlike* React's `useEffect`, and it is documented only in `re-frame.ui`'s source. **Read the `effect` docstring in `implementation/ui/src/re_frame/ui.cljc` before you emit one** (the framework's `effect` var carries the authoritative arglist + cleanup semantics). The shape is easy to get subtly wrong in a way that *compiles but silently never runs the cleanup* — a leak with no error.
+
+Two forms, both a **leading statement** in a `defview`'s top region (before the final template):
+
+```clojure
+(effect [dep …] body…)     ; runs body after commit whenever a dep changes (compared by rf=)
+(effect :connect body…)    ; runs body at each connect (mount / reveal); cleanup at each disconnect
+```
+
+**The body forms run directly** — you do *not* pass a setup function. **The body's RETURN value, when it is a function, is the cleanup.** So the cleanup is a *trailing* `(fn [] …)`, not an inner lambda:
+
+```clojure
+;; RIGHT — the setup forms run at connect; the trailing fn is the cleanup
+(effect :connect
+  (let [node @ref
+        on-key (fn [e] …)]
+    (.addEventListener node "keydown" on-key)
+    (fn [] (.removeEventListener node "keydown" on-key))))   ; ← body's return = cleanup
+
+;; WRONG — the React useEffect shape (a setup fn that RETURNS a cleanup fn).
+;; The body evaluates to a single function, so the framework registers THAT
+;; function as the cleanup and NEVER runs your setup at connect. Compiles,
+;; leaks silently — no error.
+(effect :connect
+  (fn [] (.addEventListener node "keydown" on-key)
+         (fn [] (.removeEventListener node "keydown" on-key))))
+```
+
+`:connect` cleanup runs at each *disconnect*, not once at unmount, and dev StrictMode replays connect/disconnect — so the cleanup must be idempotent (the **StrictMode idempotency** gotcha, [`gotchas.md`](gotchas.md)). `sub`/`lease`/`frame` inside an effect body are compile errors. To dispatch from an effect, capture `(ui/dispatch-fn)` in the view body and call it — **but that dispatcher fails loud at disconnect**, which is exactly why unmount domain-work re-homes (next).
+
+### Domain work on unmount re-homes OUT of the view (no dispatch-at-unmount)
+
+The deepest correction, and the one a skill-only migration gets wrong: a Reagent view that dispatched a domain event from `:component-will-unmount` (release a lease, mark a draft abandoned) has **no compiled equivalent, by design**. Native re-frame.ui has **no dispatch-at-unmount**. The framework's own words on the committed dispatcher (`ui.cljc`, `dispatch-fn`):
+
+> *… it FAILS LOUD in every non-connected state (`:rf.error/dispatch-disconnected`) — the leaked-listener detector for an external callback that outlived its view.*
+
+An unmount cleanup fires while the view is disconnecting, so a `(ui/dispatch-fn)` call there is rejected — the **leaked-listener law**. You cannot dispatch domain work at unmount, and an `effect` cleanup is **not** a place to smuggle it in.
+
+**So re-home the resource lifecycle out of the view.** The hand-migrated reference states it directly (its docstring):
+
+> *"The Reagent page released on `:component-will-unmount`; native re-frame.ui has no dispatch-at-unmount (a committed dispatcher rejects firing from a disconnected view — the leaked-listener law) … So the native view owns no lease — there is nothing at the view tier to leak — and the resource lifecycle stays where the … suite already proves it."*
+
+The pattern, abstractly: the resource was minted by a *causal event* (a route match, a "start editing" event), and it is released by the *causal events that end its life* (navigating away, deleting, finishing) — **not** by the view's teardown. The migrated view becomes a **pure render** of subs; it owns no lease, so there is nothing at the view tier to leak.
+
+```clojure
+;; before — a Form-3 view owns the lease and releases it at unmount
+(defn editor []
+  (let [{:keys [dispatch]} (rf/capture-frame)]
+    (r/create-class
+     {:component-will-unmount (fn [_] (dispatch [:resource/release]))
+      :reagent-render         (fn [] [editor-form])})))
+
+;; after — the view owns no lease; it is a pure defview.
+;; The lease RE-HOMES to the dataflow: the route / "start" event MINTS it
+;;   (e.g. [:lease :resource id]); the causal events that end the resource's
+;;   life RELEASE it. Name those events for the author (cardinal rule 5) — the
+;;   skill does not write them, it scopes them.
+(ui/defview editor [] [editor-form])
+```
+
+**When the resource genuinely IS view-scoped and unconditional**, the compiled owner is a *view-declared* lease — a leading `(ui/lease {:resource :ns/thing …})` declaration the framework acquires on connect and **releases at teardown for you (no dispatch)**. But that is an *unconditional, view-lifetime* model: it does not fit an app-minted, conditionally-held, or dynamically-keyed owner (an edit-mode-only, per-key lease). For those, re-home to the events — as the reference did. Decide which with the author; either way, **the view never dispatches at unmount.**
 
 ## MIG-18 — non-conforming `:on-*` handlers
 

--- a/skills/reagent-migration/references/catalog-mechanical.md
+++ b/skills/reagent-migration/references/catalog-mechanical.md
@@ -51,6 +51,11 @@ Dynamic query args pass through (`(sub [:item id])`). A `subscribe` that is *sto
 ;; before → after
 {:on-input #(dispatch [:typed (-> % .-target .-value)])}
 => {:on-input [:typed :rf.ui/value]}
+
+;; leading LITERAL args sit ahead of the placeholder — the placeholder is
+;; positional, projected into its own slot at dispatch time:
+{:on-input #(dispatch [:edit-field :title (-> % .-target .-value)])}
+=> {:on-input [:edit-field :title :rf.ui/value]}
 ```
 
 **MIG-06 — `preventDefault`/`stopPropagation` become an options map:**

--- a/skills/reagent-migration/references/gotchas.md
+++ b/skills/reagent-migration/references/gotchas.md
@@ -39,9 +39,13 @@ The fix for all three is the same structural move: **extract a keyed child view*
 
 The head must resolve statically. This has no mechanical rewrite — bind the attrs and split the branches, or route to `re-frame.ui.data`, or hold the view (MIG-21, [`catalog-reject.md`](catalog-reject.md)). Don't try to be clever with a computed head; the compiler will reject it.
 
+## StrictMode replays effects — `:connect` cleanup runs per-disconnect, not once
+
+Reagent's `:component-will-unmount` runs **once**, at the real unmount. An `effect`'s cleanup is different: `(effect :connect …)` cleanup runs at **each disconnect**, and React dev **StrictMode deliberately replays** connect→disconnect→connect on the first mount to smoke out effects that aren't idempotent. So an `effect` cleanup must be **idempotent** — safe to run more than once, and safe when its setup half ran more than once (`ui.cljc`: *"StrictMode dev replay is expected and MUST be idempotent-safe — that is what cleanup is for"*). A cleanup that assumes exactly-once (decrement a shared counter, pop a stack, release a token a single time) double-fires in dev and corrupts that state. Write host teardown that tolerates replay: remove the exact listener you added, dispose the chart instance you created, guard a token release. This is a per-disconnect **host** concern only — it is never a place for domain dispatch (MIG-17: no dispatch-at-unmount).
+
 ## Computed props vs the controlled-input door
 
-`ui/spread` (MIG-28) is legal, but a spread on an `:input`/`:select` **forfeits the controlled-input synchrony door** — the compiler needs a *provably-literal* `:value`/`:checked` co-present on the element to guarantee controlled-input behaviour. If you spread a map that carries `:value`, you can silently lose that guarantee. Lift `:value`/`:checked` and the handlers back to literal props on the element; spread only the genuinely pass-through remainder.
+`ui/spread` (MIG-28) is legal, but a spread on an `:input`/`:select` **forfeits the controlled-input synchrony door**. The door needs the `:value`/`:checked` **entry to appear literally on the element's props map** — the *key* present as a literal map entry, so the compiler can see it. This is **not** a requirement that the *value* be a constant: a controlled `:value (:title draft)` is a perfectly good dynamic expression — what must be literal is the **`:value` key's presence on the element**, not the value routed in through a `(ui/spread (merge … {:value …}))`. Fold `:value` into a spread map and the compiler can no longer prove the entry is there, so you silently lose the synchrony guarantee. Lift `:value`/`:checked` (and the input's handlers) back to literal entries on the element; spread only the genuinely pass-through remainder.
 
 ## The staged-gap trap — never emit an unshipped form
 

--- a/skills/reagent-migration/references/procedure.md
+++ b/skills/reagent-migration/references/procedure.md
@@ -47,6 +47,8 @@ Print the commands; the author runs them (cardinal rule 6). **"Compiles" is nece
 
 Only when a subtree is green do you scope the next one. If a view surfaces a new gap mid-pass, hold it (rule 2) and keep going.
 
+**A single file converted in isolation is PROVISIONAL.** If a view's callers live in *other* files that are still Reagent, converting just its file leaves it un-rendered — a compiled `defview` cannot be consumed by an unconverted Reagent parent (the outward bridge is unshipped, [`catalog-reject.md`](catalog-reject.md)). It is not *proven* until a **compiled** caller — a converted route component or parent view — mounts it through the compiled path and you render it. Treat such a file as provisional (it compiles, but "compiles ≠ renders") until its mounting caller is also compiled. That is exactly why the unit of a pass is a *closed subtree*, not a lone file.
+
 ## Resuming an interrupted migration
 
 Because each pass is a closed subtree left in a compiling, rendering, tested state, an interrupted migration resumes cleanly: the converted subtrees are done, the held views are recorded with their reasons, and the next closed subtree is the next unit. There is no global half-state to reconcile — that is the payoff of never big-banging.


### PR DESCRIPTION
Applies the `reagent-migration` skill improvements the dogfood roadtest retrospective surfaced (`rf2-14dj2`, blocking `rf2-8er3t`). A skill-only worker migrated `article_editor.cljs`; the mayor reference-diffed the output against the hand-migrated `ui_editor.cljc`. The skill carried the 80% cleanly — the gaps were all at the one non-hiccup construct (lifecycle / `effect`). Surgical fixes only; the working M-tier content is untouched.

## What changed

**P1 architectural — MIG-17 no longer steers toward a forbidden dispatch-at-unmount.** Native re-frame.ui has **no dispatch-at-unmount**: the committed dispatcher fails loud in every non-connected state, so an unmount cleanup that dispatches is rejected by the leaked-listener law. MIG-17 now teaches that unmount domain-work **re-homes OUT of the view** (to the causal events that mint/release the resource), and is **not** preserved as an `effect` cleanup. Grounded in two verified quotes:

- Framework law (`implementation/ui/src/re_frame/ui.cljc`, `dispatch-fn`): *"it FAILS LOUD in every non-connected state (`:rf.error/dispatch-disconnected`) — the leaked-listener detector for an external callback that outlived its view."*
- Reference pattern (`ui_editor.cljc` docstring): *"native re-frame.ui has no dispatch-at-unmount (a committed dispatcher rejects firing from a disconnected view — the leaked-listener law) … So the native view owns no lease — there is nothing at the view tier to leak."*

**P1 signature — `effect`'s real contract is now documented.** Two forms (`(effect [deps…] body…)` / `(effect :connect body…)`); the body forms run directly (you do not pass a setup fn); the **body's RETURN value, when a fn, is the cleanup**. A RIGHT/WRONG worked example shows the React-`useEffect` shape (a setup fn returning a cleanup fn) that **compiles but silently never runs the cleanup** — the exact leak the roadtest worker shipped. "Read `ui.cljc` to verify" is surfaced as a required step, not a footnote.

**P2/P3 polish:**
- StrictMode idempotency (`:component-will-unmount` once vs `effect` cleanup per-disconnect) promoted from footnote to a named gotcha.
- MIG-05 gains a leading-literal example: `[:edit-field :title :rf.ui/value]`.
- The "provably-literal `:value`" wording reworded — it means the `:value` *key* appears literally on the element (not via a spread), not that the value must be a constant (a dynamic `:value (:title draft)` is fine).
- A single-file migration with out-of-file callers noted as **provisional** until a compiled caller mounts it through the compiled path.
- A corrected-lifecycle eval (id 19) exercises the re-homed unmount + correct `effect` body-return cleanup.

OQ1/OQ2 rulings intact (MIG-13 stays D-tier; no runnable tool). Examples are generic; no framework code, `examples/`, or `ai/` touched. Docs mirror left as-is (its high-level summary remains accurate).

## Quality gates

All run in the foreground to completion:

- `clojure -M -m re-frame.api-manifest.skills-check` (from `implementation/scripts/api-manifest`) — **PASS** (555 public-var references in sync)
- `python scripts/check_skill_eval_docs.py` — **PASS** (exit 0)
- `python scripts/check_skill_eval_packaging.py` — **PASS** (exit 0)
- `python scripts/check_doc_slugs.py` — **PASS** (exit 0)
- `python -m mkdocs build --strict` — **PASS** (exit 0)

Do NOT merge — held for Mike's review (flagship skill).
