### PR TITLE
fix(ui): server-rendered ViewCell reads frame from useContext (rf2-2rzx0)

### DIFF
--- a/implementation/core/src/re_frame/adapter/context.cljs
+++ b/implementation/core/src/re_frame/adapter/context.cljs
@@ -264,6 +264,43 @@
 ;; silently routing to a default. (This superseded the retired
 ;; `:rf.warning/plain-fn-under-non-default-frame-once` warning.)
 
+(defn context-value->current-frame
+  "Classify a raw frame-context value `v` into the scope frame keyword, or
+  **nil** when `v` names no frame — the shared sentinel / coercion /
+  corruption rules, applied to a value already OBTAINED from the shared
+  frame-context. Two callers source `v` differently but classify it
+  identically:
+
+    - the public `useContext` RETURN — the renderer-agnostic hook path the
+      compiled-view ViewCell takes (`re-frame.ui.viewcell/use-frame-context!`,
+      rf2-2rzx0); and
+    - a direct `_currentValue` slot read — the substrate-portable reader path
+      ([[function-component-current-frame]] below).
+
+  Both must resolve one way, so the rules live here once rather than drifting
+  between the two sites:
+
+    - the no-provider sentinel resolves to nil ('no scope'), NOT a synthesised
+      `:rf/default` (the EP-0002 carried invariant; the common, benign case —
+      NOT corruption);
+    - a frame keyword (or Reagent's prop-stringified-keyword shape, via
+      `coerce-context-value`) names the enclosing Provider's frame;
+    - anything else (false, a number, an empty string, a JS object) means the
+      React-context boundary was disturbed (rf2-8q66) — a portal rendering
+      outside its Provider, a library mutating the slot, or a Provider authored
+      with a non-keyword value. The runtime emits
+      `:rf.error/frame-context-corrupted` and returns nil (recovery
+      `:no-frame-context`).
+
+  Does NOT observe the dynamic tier (`frame/*current-frame*`) — its callers
+  layer that precedence in front of it."
+  [v]
+  (cond
+    (= v no-provider-sentinel) nil
+    (coerce-context-value v)   (coerce-context-value v)
+    :else                      (do (emit-frame-context-corrupted! v)
+                                   nil)))
+
 (defn function-component-current-frame
   "Resolution chain (READER) for function-component substrates (UIx,
   Helix). Returns the scope frame, or **nil** when no scope is
@@ -278,7 +315,8 @@
        the same shared context, so a read resolves identically beneath
        either. Reads `_currentValue` off the shared context object
        directly (the substrate-portable path; UIx's `use-context` and
-       Helix's `use-context` are both sugar over this read).
+       Helix's `use-context` are both sugar over this read) and classifies
+       it through the shared [[context-value->current-frame]] rules.
 
   Returns nil when neither tier names a frame — a component rendered
   beneath neither frame boundary observes the no-provider sentinel, which
@@ -287,33 +325,13 @@
   `frame/require-current-frame!`; low-level readers / tooling model 'no
   context' with the nil directly.
 
-  Tolerates Reagent's prop-stringified-keyword shape via
-  `coerce-context-value` — relevant when a UIx / Helix subtree is
-  embedded in a tree whose `frame-provider` was authored as a Reagent
-  `[:> ...]` interop call.
-
-  Corrupted-`_currentValue` detection (rf2-8q66): the `createContext`
-  default is now the no-provider sentinel (a keyword), so a function-
-  component read should always observe either a frame keyword, the prop-
-  stringified-keyword shape, or the sentinel. Anything else (false, a
-  number, an empty string, a JS object) means the React-context boundary
-  was disturbed — a portal rendering outside its Provider, a library
-  mutating `_currentValue`, or a Provider authored with a non-keyword
-  value. The runtime emits `:rf.error/frame-context-corrupted` and returns
-  nil (recovery `:no-frame-context`)."
+  NOTE (rf2-2rzx0): the direct `_currentValue` slot read is CLIENT-renderer
+  only — React 19.2's `react-dom/server` populates the secondary slot
+  `_currentValue2`, not `_currentValue`. Callers that CAN observe the
+  renderer-agnostic value (a component reading `useContext` inside render,
+  e.g. the compiled ViewCell) pass that value to
+  [[context-value->current-frame]] directly rather than routing through this
+  slot-reading reader."
   []
   (or frame/*current-frame*
-      (let [v (.-_currentValue ^js frame-context)]
-        (cond
-          ;; No enclosing Provider — the sentinel resolves to nil ('no
-          ;; scope'), NOT a synthesised default. This is the common,
-          ;; benign case; it is NOT corruption.
-          (= v no-provider-sentinel) nil
-          ;; A real frame keyword (or prop-stringified keyword) names the
-          ;; enclosing Provider's frame.
-          (coerce-context-value v)   (coerce-context-value v)
-          ;; Corrupted branch: not a frame keyword, not the sentinel —
-          ;; covers false, numbers, empty strings, and JS objects. Emit
-          ;; the structured error and return nil (no synthesis).
-          :else                      (do (emit-frame-context-corrupted! v)
-                                         nil)))))
+      (context-value->current-frame (.-_currentValue ^js frame-context))))

--- a/implementation/ui/src/re_frame/ui/viewcell.cljs
+++ b/implementation/ui/src/re_frame/ui/viewcell.cljs
@@ -210,15 +210,30 @@
   `events/with-capture` as the committed destination, and every sub/lease wrapper
   binds it into `re-frame.frame/*current-frame*` around the compiled body
   (`with-current-frame`) so ambient `(sub …)` / `(lease …)` resolution hits the
-  precedence-first dynamic tier. The `useContext` call above owns the repaint
-  SUBSCRIPTION either way. Called as a compile-time-selected LEADING hook, so it
-  is stable in hook order for every render of a given compiled view's component
-  (never conditional at runtime)."
+  precedence-first dynamic tier. Called as a compile-time-selected LEADING hook,
+  so it is stable in hook order for every render of a given compiled view's
+  component (never conditional at runtime).
+
+  The frame VALUE is the PUBLIC `useContext` RETURN (rf2-2rzx0), not a re-read
+  of the private `_currentValue` slot. `useContext` is renderer-agnostic — it
+  resolves the closest Provider under BOTH the client renderer and
+  `react-dom/server`. `function-component-current-frame` reads `_currentValue`
+  directly, which React 19.2's SERVER renderer does NOT populate (it uses
+  `_currentValue2`), so sourcing the frame there lost the Provider under
+  `react-dom/server` and a server-rendered compiled sub/lease ViewCell could
+  still raise `:rf.error/no-frame-context`. Resolution keeps the same explicit
+  precedence and the same validation: an ambient `frame/*current-frame*` still
+  wins, otherwise the hook value flows through the SHARED sentinel / coercion /
+  corruption rules (`adapter-context/context-value->current-frame`) — identical
+  to the reader's classification, since on the client `useContext` observes the
+  same value `_currentValue` holds."
   []
-  (react/useContext adapter-context/frame-context)
-  ;; Preserve the full carried-invariant precedence (dynamic binding before
-  ;; React context) while the useContext call above owns repaint subscription.
-  (adapter-context/function-component-current-frame))
+  (let [ctx-frame (react/useContext adapter-context/frame-context)]
+    ;; Dynamic binding before React context (the carried-invariant precedence);
+    ;; the single `useContext` call above owns the repaint SUBSCRIPTION and now
+    ;; also supplies the renderer-agnostic frame value.
+    (or frame/*current-frame*
+        (adapter-context/context-value->current-frame ctx-frame))))
 
 (defn- with-current-frame
   "Wrap compiled body `thunk` so `re-frame.frame/*current-frame*` is bound to

--- a/implementation/ui/test/re_frame/ui/viewcell_server_frame_context_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/viewcell_server_frame_context_cljs_test.cljs
@@ -1,0 +1,122 @@
+(ns re-frame.ui.viewcell-server-frame-context-cljs-test
+  "rf2-2rzx0 — the SERVER-render sibling of the rf2-4rwtd client fix: a compiled
+  sub/lease ViewCell must resolve its `frame-provider` frame under
+  `react-dom/server`, not only under the client renderer.
+
+  ## The defect this hardens
+
+  `re-frame.ui.viewcell/use-frame-context!` calls `React.useContext` to subscribe
+  the component to context changes, but — before this fix — DISCARDED the return
+  and re-derived the frame through
+  `re-frame.adapter.context/function-component-current-frame`, which reads the
+  PRIVATE `_currentValue` slot off the shared context object. React 19.2's SERVER
+  renderer (`react-dom/server`) populates the SECONDARY slot `_currentValue2`, not
+  `_currentValue`; a repository-local probe confirmed that under a Provider both
+  `renderToStaticMarkup` and `renderToString` see `useContext = provider` while
+  `_currentValue = default`. So a server-rendered compiled sub/lease ViewCell with
+  no outer dynamic binding sourced nil, `with-current-frame` bound nil, and the
+  body's ambient `(sub …)` resolved no frame — raising
+  `:rf.error/no-frame-context`. The client repair (rf2-4rwtd) was correct but
+  covered only the client renderer, whose `_currentValue` read succeeds.
+
+  The fix retains the PUBLIC `useContext` return (renderer-agnostic) as the frame
+  source, keeping the same precedence (an ambient `frame/*current-frame*` still
+  wins) and the same shared sentinel / coercion / corruption validation
+  (`adapter-context/context-value->current-frame`).
+
+  ## The REAL server path, not a client proxy
+
+  Every body renders through `react-dom/server`'s `renderToStaticMarkup` — the
+  actual server renderer, whose context slot behaviour is the defect. The pure-ui
+  runtime routes `:adapter/current-frame` to `function-component-current-frame`
+  (plain-atom reader, `re-frame.ui.substrate`), which ALSO reads `_currentValue`,
+  so before the fix BOTH the hook and the reader lost the frame on the server —
+  no stand-in reader is needed to reproduce it. Node-only (`react-dom/server` is a
+  JS library): the ns ends `-cljs-test` (not `-dom-`), so it runs under the
+  `:node-test` gate, never the browser build."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            ["react-dom/server" :as rds]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview frame-provider sub]]
+            [re-frame.ui.frames]     ;; loads re-frame.ui.substrate — routes the
+                                     ;; :adapter/current-frame React-context reader
+            [re-frame.ui.runtime :as rt]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter       ui/adapter
+                                            :ambient-frame nil}))
+
+(defn- reg! []
+  (rf/reg-sub :scope/n (fn [db _] (:n db))))
+
+;; A compiled SUB view — its body ambiently subscribes `[:scope/n]`, so it owns
+;; the `render-subs` wrapper: the exact path `use-frame-context!` feeds through
+;; `with-current-frame`.
+(defview n-view [] [:div.n (str "n=" (sub [:scope/n]))])
+
+;; Scope `n-view` to the already-live `:app/a` via `frame-provider` (the SCOPE
+;; form). Server-rendered, the compiled provider emits the shared React-context
+;; Provider; the inner ViewCell must read `:app/a` back through `useContext`.
+(defview provider-wrap [] [:div.wrap [frame-provider {:frame :app/a} [n-view]]])
+
+(defn- silence-console-error [thunk]
+  ;; React logs a render error to console.error before rethrowing; silence it so
+  ;; the throw under test is the only signal on a green run.
+  (let [orig js/console.error]
+    (set! js/console.error (fn [& _] nil))
+    (try (thunk) (finally (set! js/console.error orig)))))
+
+;; ---------------------------------------------------------------------------
+;; The red→green server-render proof
+;; ---------------------------------------------------------------------------
+
+(deftest server-rendered-compiled-sub-viewcell-resolves-provider-frame
+  ;; RED-BEFORE (rf2-2rzx0): under `react-dom/server`, `use-frame-context!`
+  ;; sourced the frame from the client-only `_currentValue` slot (unpopulated by
+  ;; the server renderer), so the ambient `(sub …)` resolved nil and the render
+  ;; threw `:rf.error/no-frame-context`. GREEN-AFTER: the hook reads the frame
+  ;; from the public `useContext` return, binds `:app/a`, and the sub resolves —
+  ;; the server markup shows `n=42`.
+  (reg!)
+  (rf/make-frame {:id :app/a})
+  (frame/replace-app-db! :app/a {:n 42})
+  (let [result (silence-console-error
+                 (fn []
+                   (try {:html (rds/renderToStaticMarkup
+                                 (rt/jsx2 provider-wrap (js-obj)))}
+                        (catch :default e
+                          {:error (or (:rf.error/id (ex-data e))
+                                      (ex-message e))}))))]
+    (is (nil? (:error result))
+        (str "server render must not raise — pre-fix it threw "
+             (pr-str (:error result)) " because use-frame-context! read the "
+             "client-only _currentValue slot under react-dom/server (rf2-2rzx0)"))
+    (is (str/includes? (str (:html result)) "n=42")
+        (str "the server-rendered compiled sub ViewCell resolved its "
+             "frame-provider frame :app/a from the useContext return"))))
+
+;; ---------------------------------------------------------------------------
+;; Vacuity — the green result is the PROVIDER frame, not a synthesised default
+;; ---------------------------------------------------------------------------
+
+(deftest server-rendered-sub-without-a-provider-fails-loud
+  ;; VACUITY GUARD: with NO `frame-provider` above it, the SAME compiled sub
+  ;; ViewCell has no scope — under `react-dom/server` the no-provider sentinel
+  ;; resolves to nil ('no scope', EP-0002: no `:rf/default` floor) and the render
+  ;; fails loud with `:rf.error/no-frame-context`. Stable before AND after the
+  ;; fix, so the green result above is attributable ONLY to the provider frame
+  ;; flowing through `useContext`, never to a synthesised default.
+  (reg!)
+  (rf/make-frame {:id :app/a})
+  (frame/replace-app-db! :app/a {:n 42})
+  (testing "a provider-less server-rendered sub ViewCell resolves no frame"
+    (let [err (silence-console-error
+                (fn []
+                  (try (rds/renderToStaticMarkup (rt/jsx2 n-view (js-obj)))
+                       nil
+                       (catch :default e (:rf.error/id (ex-data e))))))]
+      (is (= :rf.error/no-frame-context err)
+          "no scope above the ViewCell → fail loud, never a default frame"))))


### PR DESCRIPTION
Closes rf2-2rzx0. The SERVER-render sibling of the merged rf2-4rwtd client fix (PR #6540), re-filed from the rf2-mx60r audit.

## The gap

`re-frame.ui.viewcell/use-frame-context!` calls `React.useContext` to subscribe the compiled ViewCell to context changes, but **discarded its return** and re-derived the frame through `adapter-context/function-component-current-frame`, which reads the **private `_currentValue` slot**:

```clojure
;; before
(react/useContext adapter-context/frame-context)          ; discarded
(adapter-context/function-component-current-frame)         ; reads _currentValue
```

React 19.2's `react-dom/server` populates the **secondary** slot `_currentValue2`, not `_currentValue` (a repository-local probe confirmed: under a Provider, both `renderToStaticMarkup` and `renderToString` see `useContext = provider` while `_currentValue = default`). So a server-rendered compiled sub/lease ViewCell with no outer dynamic binding sourced nil, bound nil into `*current-frame*`, and its ambient `(sub …)` raised `:rf.error/no-frame-context`. The pure-ui runtime routes `:adapter/current-frame` to that same `_currentValue` reader, so on the server BOTH the hook and the reader lost the frame. The client path was correct — this is the server leg only.

## The fix (bounded)

Retain the **public `useContext` return** (renderer-agnostic) as the frame source, keeping the same precedence and the same validation the audit specified:

```clojure
;; after
(let [ctx-frame (react/useContext adapter-context/frame-context)]
  (or frame/*current-frame*
      (adapter-context/context-value->current-frame ctx-frame)))
```

The sentinel / coercion / corruption-validation rules are **extracted** from `function-component-current-frame` into the shared, behavior-preserving `adapter-context/context-value->current-frame`, so the hook value and the reader's `_currentValue` read classify one way and cannot drift. The reader delegates to it unchanged. No `_currentValue2` probe, no renderer detection, no new API.

The client path is provably identical: on the client `useContext` observes the same value `_currentValue` holds, so `context-value->current-frame` yields the same result — including corrupted-emit and the `frame/*current-frame*`-wins precedence. rf2-4rwtd's `with-current-frame` binding is untouched.

## Quality gates

- `implementation/ui` `clojure -M:test` (JVM) — **1016 tests, 19795 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node, cross-artefact) — **10352 tests, 51118 assertions, 0 failures, 0 errors**
- Red→green proof (focused `node-test-ui`): the new `react-dom/server` regression `server-rendered-compiled-sub-viewcell-resolves-provider-frame` is **RED before** (threw `:rf.error/no-frame-context`) and **GREEN after** (renders `n=42`); a vacuity pin asserts a provider-less server render still fails loud. The rf2-4rwtd client test stays green.
- Docs untouched — no mkdocs/slug check needed.

Surface: `implementation/ui/src/re_frame/ui/viewcell.cljs` + its new test, plus the behavior-preserving classifier extraction in `implementation/core/src/re_frame/adapter/context.cljs` (the home of the existing validation rules the audit directed the hook value through). No changes to `ssr/`, `docs/`, or `examples/`.