### PR TITLE
fix(ui): render-static conformance repairs — no-silent-elision, root-site registration, typed missing-artefact error (rf2-uv7n6)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr/render_static_jvm_test.clj
+++ b/implementation/ssr/test/re_frame/ssr/render_static_jvm_test.clj
@@ -26,6 +26,43 @@
   [{:keys [title]}]
   [:div.card [:h2 title] [:p "static"]])
 
+;; ---------------------------------------------------------------------------
+;; Fixtures for the no-silent-elision proof (rf2-uv7n6 repair 1). All compiled
+;; top-to-bottom so their view-static facts are indexed when render-static below
+;; expands against them.
+;; ---------------------------------------------------------------------------
+
+;; A DIRECTLY interactive view — a committed event handler in its body is a
+;; live-runtime capability a pure :server static render cannot honour.
+(ui/defview interactive-card
+  [{:keys [label]}]
+  [:button {:on-click [:clicked]} label])
+
+;; A static parent whose ONLY child is the interactive view — the capability is
+;; NESTED, so it is only visible through the transitive closure.
+(ui/defview static-parent
+  [_]
+  [interactive-card {:label "x"}])
+
+;; A live (interactive) leaf used only inside a client-only island below.
+(ui/defview live-widget
+  [_]
+  [:button {:on-click [:go]} "live"])
+
+;; A static view carrying a client-only island: its browser-only subtree is the
+;; interactive `live-widget`, guarded by a capability-free fallback. render-static
+;; renders ONLY the fallback (a static root never flips), so the island is legal.
+(ui/defview island-card
+  [_]
+  [:div [:h2 "static"] (ui/client-only {:fallback [:span "loading"]} [live-widget])])
+
+;; A dedicated static root for the Layer-1 registration proof (repair 2) — kept
+;; distinct from static-card so its derived root-id is exercised by exactly one
+;; test and cannot collide with the sibling render-static suites.
+(ui/defview dup-probe
+  [_]
+  [:main "probe"])
+
 (defn- caught-id
   "Run `f`; -> the thrown compile-error id (`:rf.ui.compile/error` ex-data),
   or ::no-throw. `macroexpand-1` wraps a macro-expansion ExceptionInfo in a
@@ -130,3 +167,138 @@
             (ui-tree/render-root-tree
              (fn [] (static-card {:title "Hello"}))))
            (ui/render-static [static-card {:title "Hello"}])))))
+
+;; ===========================================================================
+;; rf2-uv7n6 REPAIR 1 — no-silent-elision proof (Spec 004C §3, EP-0034 §2).
+;;
+;; RED before: `(ui/render-static [interactive-card {:label "x"}])` expanded and
+;; returned "<button>x</button>" — the `:on-click [:clicked]` handler was
+;; SILENTLY elided; `[static-parent]` did the same through a nested view.
+;; GREEN after: any runtime-requiring capability in the static root's
+;; server-reachable view closure is a loud `:rf.ui.compile/static-root-requires-runtime`
+;; BUILD error. `ui/client-only` (capability-free fallback) + static views stay legal.
+;; ===========================================================================
+
+;; A clojure.test RUN binds *ns* to the runner, not the test ns, so a
+;; `macroexpand-1` of a render-static form with an internal-VIEW head cannot
+;; resolve the head. Drive the REAL macro body (root/render-static-form, the
+;; shipped JVM path) with *ns* rebound to THIS namespace so the view heads
+;; resolve — exactly what the compiler does when the file compiles in-ns.
+(defn- expand-render-static
+  "Expand render-static's macro body against THIS namespace; returns the emitted
+  form or throws the compile-error ExceptionInfo (the real JVM render-static path)."
+  [root-form]
+  (binding [*ns* (find-ns 're-frame.ssr.render-static-jvm-test)]
+    (root/render-static-form nil nil root-form)))
+
+(defn- render-static-error-id [root-form]
+  (try (expand-render-static root-form) ::no-throw
+       (catch clojure.lang.ExceptionInfo e (:rf.ui.compile/error (ex-data e)))))
+
+(deftest render-static-rejects-a-directly-interactive-view
+  (testing "a committed event handler in the mounted view's own body is a loud
+            build error, never a silently dropped capability (EP-0034 §2)"
+    (is (= :rf.ui.compile/static-root-requires-runtime
+           (render-static-error-id '[interactive-card {:label "x"}])))))
+
+(deftest render-static-rejects-a-nested-interactive-view
+  (testing "the capability proof is TRANSITIVE — a static parent whose only child
+            is an interactive view fails through the direct-view-dependency closure
+            (checking the root view alone would silently ship inert UI)"
+    (is (= :rf.ui.compile/static-root-requires-runtime
+           (render-static-error-id '[static-parent])))))
+
+(deftest render-static-names-the-offending-capability-and-view
+  (testing "the build error names the runtime capability and the offending view,
+            so the author can find and move the live subtree"
+    (let [ex  (try (expand-render-static '[static-parent])
+                   nil
+                   (catch clojure.lang.ExceptionInfo e e))
+          msg (some-> ex ex-message)]
+      (is (some? msg))
+      (is (str/includes? msg "handler") "names the runtime-requiring capability")
+      (is (str/includes? msg "interactive-card") "names the offending nested view"))))
+
+(deftest render-static-allows-a-static-and-client-only-island
+  (testing "a purely-static root renders (no capability in the closure)"
+    (is (= "<div class=\"card\"><h2>Hi</h2><p>static</p></div>"
+           (ui/render-static [static-card {:title "Hi"}]))))
+  (testing "a ui/client-only island with a capability-free fallback stays legal —
+            render-static renders ONLY the fallback, the browser-only interactive
+            subtree never reaches the JVM tree (a static root never flips)"
+    (let [html (ui/render-static [island-card])]
+      (is (= "<div><h2>static</h2><span>loading</span></div>" html))
+      (is (not (str/includes? html "button"))
+          "the client-only interactive subtree is NOT rendered into the static output"))))
+
+;; ===========================================================================
+;; rf2-uv7n6 REPAIR 2 — Layer-1 identity registration (Spec 004C §7).
+;;
+;; RED before: `resolve-root-identity` ran but its result was discarded;
+;; render-static never called `register-root-site!`, so its root was absent from
+;; the build-tier duplicate-root-id index (unlike mount / render! / hydrate-root).
+;; GREEN after: the derived identity is retained and registered.
+;; ===========================================================================
+
+(deftest render-static-registers-its-root-site
+  (testing "render-static registers its DERIVED root-id into the Layer-1 build
+            index (§7) — the identity resolve-root-identity produced is retained,
+            not discarded"
+    (ui/render-static [dup-probe])
+    (let [rid   :re-frame.ssr.render-static-jvm-test/dup-probe
+          roots (root/build-roots)]
+      (is (contains? roots rid)
+          "the render-static root site lands in the shared build-roots index")
+      (is (= :derived (:provenance (get roots rid)))
+          "the site is recorded with its derived provenance")))
+  (testing "a SECOND site in a DIFFERENT namespace resolving to the same root-id
+            is the build-tier :rf.error/duplicate-root-id — proving render-static
+            participates in the same shared Layer-1 index mount / render! use"
+    (let [ex (try (root/register-root-site!
+                   'ui/render-static
+                   :re-frame.ssr.render-static-jvm-test/dup-probe :derived
+                   'some.other.server.render-ns {:file "other.clj" :line 1})
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (= :rf.error/duplicate-root-id (:rf.error/id (ex-data ex)))))))
+
+;; ===========================================================================
+;; rf2-uv7n6 REPAIR 3 — typed missing-SSR-artefact error (not ClassNotFoundException).
+;;
+;; RED before: the macro emitted a bare `re-frame.ssr/emit-ui-tree` call, so a
+;; documented render-static call in a namespace that required only `re-frame.ui`
+;; failed to COMPILE with a raw `ClassNotFoundException: re-frame.ssr`.
+;; GREEN after: the macro emits a call to the ui-side late-resolution seam
+;; (`re-frame.ui.tree/emit-static-html`) — the caller's namespace carries no
+;; compile-time `re-frame.ssr` reference, and an absent artefact is the ruled,
+;; typed `:rf.error/ssr-artefact-missing`.
+;; ===========================================================================
+
+(deftest render-static-emits-no-compile-time-ssr-reference
+  (testing "the expansion folds the tree through re-frame.ui.tree/emit-static-html
+            (a ui-side seam that late-resolves the emitter), NOT a bare
+            re-frame.ssr/emit-ui-tree reference — so a caller requiring only
+            re-frame.ui compiles rather than raising ClassNotFoundException: re-frame.ssr"
+    (let [expansion (expand-render-static '[static-card {:title "x"}])
+          head      (first expansion)]
+      (is (= 're-frame.ui.tree/emit-static-html head)
+          "render-static emits a call to the ui-side late-resolution seam")
+      (is (not (str/includes? (pr-str expansion) "re-frame.ssr"))
+          "the emitted code names no re-frame.ssr symbol (no compile-time ui->ssr reference)"))))
+
+(deftest render-static-missing-ssr-artefact-is-a-typed-error
+  (testing "when the day8/re-frame2-ssr artefact is absent (the emitter cannot be
+            resolved), render-static raises the ruled typed
+            :rf.error/ssr-artefact-missing naming the artefact — never a raw host
+            exception, never a fallback"
+    (let [ex (try (with-redefs [ui-tree/resolve-ssr-emitter (constantly nil)]
+                    (ui/render-static [static-card {:title "x"}]))
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (= :rf.error/ssr-artefact-missing (:rf.error/id (ex-data ex))))
+      (is (str/includes? (ex-message ex) "day8/re-frame2-ssr")
+          "the typed error names the missing artefact coordinate")))
+  (testing "with the artefact present (the normal ssr test classpath) the same
+            call renders — the late resolution loads and folds through emit-ui-tree"
+    (is (= "<div class=\"card\"><h2>x</h2><p>static</p></div>"
+           (ui/render-static [static-card {:title "x"}])))))

--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -149,6 +149,71 @@
       (scan ast))
     @caps))
 
+;; ---------------------------------------------------------------------------
+;; Per-view static-render facts (Spec 004C §3 / EP-0034 §2 — the render-static
+;; no-silent-elision proof)
+;; ---------------------------------------------------------------------------
+
+(def ^:private runtime-requiring-site-caps
+  "Site-kind -> the runtime-requiring capability token render-static rejects.
+  Every one names a live-runtime need a pure `:server` static render cannot
+  honour (a sub read, a committed handler, a lease/frame read, a host hook)."
+  {:events :handler :subs :sub :leases :lease :frame-ops :frame
+   :locals :local :effects :effect :dispatch-fns :dispatch-fn})
+
+(defn view-static-facts
+  "The SERVER-REACHABLE static-render facts for one analyzed body — the small
+  internal projection the render-static transitive proof closes over (Spec 004C
+  §3, EP-0034 §2 no-silent-elision):
+
+    {:caps <set of runtime-requiring capability tokens in THIS body>
+     :deps <set of directly-referenced view-ids>}
+
+  `:caps` unions the runtime-requiring SITE kinds (subs / committed handlers /
+  leases / frame reads / host locals / effects / dispatch-fns), the
+  re-frame.ui.react host hooks (use-ref -> `:ref`, use-context -> `:context`,
+  use-effect family -> `:effect`; `use-id` is EXEMPT — an inert deterministic id
+  is static-safe), and foreign heads (`:foreign`, which a `react/lazy` head folds
+  into). `:deps` are the view references to close over transitively.
+
+  A `ui/client-only` subtree is skipped: the JVM emitter renders only its
+  capability-free FALLBACK, so the browser-only child is not server-reachable —
+  its views and capabilities never reach the static output and must not be
+  counted (a static root never flips)."
+  [ast sites]
+  (let [deps     (volatile! #{})
+        foreign? (volatile! false)]
+    (letfn [(walk [n]
+              (when (map? n)
+                (if (= :client-only (:op n))
+                  ;; browser-only child never reaches the JVM tree; only the
+                  ;; capability-free fallback does.
+                  (walk (:fallback n))
+                  (do
+                    (when (= :view (:op n))    (vswap! deps conj (:view-id n)))
+                    (when (= :foreign (:op n)) (vreset! foreign? true))
+                    (doseq [[_ v] n]
+                      (cond
+                        (map? v)    (walk v)
+                        (vector? v) (run! walk v)))))))]
+      (walk ast))
+    {:caps (cond-> (into (into #{}
+                               (keep (fn [[kind cap]]
+                                       (when (seq (get sites kind)) cap)))
+                               runtime-requiring-site-caps)
+                         (keep {:ref :ref :context :context :effect :effect
+                                :layout-effect :effect :effect-event :effect})
+                         (map :kind (:react sites)))
+             @foreign? (conj :foreign))
+     :deps @deps}))
+
+(defn build-view-static
+  "The ambient build's per-view static-render facts index (view-id ->
+  `{:caps :deps}`) — the read `re-frame.ui/render-static`'s transitive proof
+  closes over (Spec 004C §3). Per-build like every other registry read."
+  []
+  (build/aggregate build/view-static))
+
 (defn- source-coords [form cljs?]
   (let [m (meta form)]
     (cond-> {:file (if cljs?
@@ -321,6 +386,13 @@
              :namespace ns-sym
              :declaration [ns-sym vname]
              :existing-declaration conflict}))
+    ;; Per-view static-render facts for the render-static transitive proof
+    ;; (Spec 004C §3 / EP-0034 §2). Keyed per declaring ns like every other
+    ;; registry row, so a recompiled / removed source replaces / evicts its
+    ;; contribution; not folded into the build digest (derived from the same
+    ;; source the `views` digest already tracks).
+    (build/contribute! build/view-static ns-sym view-id
+                       (view-static-facts ast sites))
     (if cljs?
       ;; Direct no-pass REPL evaluation may replace the runtime view body, but
       ;; carries no digest assignment. Only a successful configured file/watch

--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -51,6 +51,7 @@
 
 (def views       ::views)        ; view-id -> [template-fp hook-sig] (digest)
 (def ^:private view-declarations ::view-declarations) ; view-id -> [ns var]
+(def view-static ::view-static)  ; view-id -> {:caps #{..} :deps #{..}} (static-root proof, Spec 004C §3)
 (def roots       ::roots)        ; Layer-1 root-site index
 (def plans       ::plans)        ; Layer-1 frame-plan index
 (def descriptors ::descriptors)  ; Root Descriptor index

--- a/implementation/ui/src/re_frame/ui/compiler/root.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/root.cljc
@@ -789,32 +789,77 @@
                 ~(plans-thunk-form plans)
                 ~(react-opts-form nil opts)))))))))
 
+(defn- static-capability-offender
+  "The render-static transitive static-capability proof (Spec 004C §3, EP-0034
+  §2 no-silent-elision): given the ROOT form's own `{:caps :deps}` facts and the
+  ambient build's per-view `view-static` index, return `{:view-id .. :caps ..}`
+  for the FIRST server-reachable view (or the root form itself,
+  `:rf.root/root-form`) that carries a runtime-requiring capability, or nil when
+  the whole server-reachable closure is static-safe.
+
+  Cycle-safe: the closure follows direct compiled-view dependencies breadth-first
+  over a `seen` set, so a self-recursive or mutually-recursive view terminates.
+  A view-id absent from the index (compiled in another build/context) contributes
+  no known capability and is skipped — the proof catches the KNOWN interactive
+  views loaded in this render's build."
+  [own-facts index]
+  (if (seq (:caps own-facts))
+    {:view-id :rf.root/root-form :caps (:caps own-facts)}
+    (loop [queue (vec (:deps own-facts)), seen #{}]
+      (when (seq queue)
+        (let [vid   (peek queue)
+              queue (pop queue)]
+          (if (contains? seen vid)
+            (recur queue seen)
+            (let [{:keys [caps deps]} (get index vid)]
+              (if (seq caps)
+                {:view-id vid :caps caps}
+                (recur (into queue deps) (conj seen vid))))))))))
+
 (defn render-static-form
   "`(ui/render-static root-form)` — the pure `:server`-phase static-HTML render
   (Spec 004C §3; Spec 011 §Phase flip). JVM-ONLY, the counterpart of the client
   mount verbs: it compiles the LITERAL root form to the versioned JVM structural
-  tree and hands it to `re-frame.ssr/emit-ui-tree`, folding it to an INERT HTML
-  string — NO manifest, NO hydration payload, NO phase flip (a `client-only` site
-  renders its capability-free fallback and stops there; there is no fallback pass
-  to flip away from). It is the static-page path, not the SSR-then-hydrate path.
+  tree and folds it to an INERT HTML string through `re-frame.ssr/emit-ui-tree`
+  (late-resolved — see INDEPENDENCE) — NO manifest, NO hydration payload, NO phase
+  flip (a `client-only` site renders its capability-free fallback and stops there;
+  there is no fallback pass to flip away from). It is the static-page path, not the
+  SSR-then-hydrate path.
 
-  Three invariants, all reusing the mount-surface machinery:
+  Four invariants, all reusing the mount-surface machinery:
 
     - LITERAL ROOT FORM — `analyze-root` rejects a runtime-assembled vector with
       the SAME `:rf.ui.compile/runtime-root-form` compile error mount / render! /
       hydrate-root / ui.test-render raise (a macro sees the literal form; a fn
       cannot). This is the kind-label delta a fn could not honour.
+    - NO SILENT ELISION (Spec 004C §3, EP-0034 §2) — a runtime-requiring
+      capability (subs, committed handlers, effects, refs, context, foreign / lazy
+      heads) anywhere in the root's SERVER-REACHABLE view closure is a loud
+      `:rf.ui.compile/static-root-requires-runtime` build error with source
+      coordinates, never a capability dropped from the static output. The proof is
+      transitive: `compiler/view-static-facts` projects each compiled view's own
+      server-reachable capabilities + direct-view dependencies into the
+      `view-static` build index, and `static-capability-offender` closes over it
+      cycle-safe. `use-id` is exempt (an inert deterministic id is static-safe);
+      `ui/client-only` stays legal (only its capability-free fallback is
+      server-reachable — a static root never flips).
     - IDENTITY PARTICIPATION (§7) — with no opts the root-id derives from the
       single mounted view, so `resolve-root-identity` enforces exactly one view
-      (`:rf.ui.compile/no-single-mounted-view` otherwise); the render itself needs
-      no id (no manifest is emitted), but the static root is identity-bearing the
-      way the derivation default is. Layer-2 duplicate detection (server render
-      time, S5) is the SSR host's per-response registry, not the macro's.
-    - INDEPENDENCE — the macro EMITS a `re-frame.ssr/emit-ui-tree` call rather
-      than requiring it, so `re-frame.ui` never statically depends on
-      `re-frame.ssr` (Spec 011 §wall — no `ui → ssr` static require). The emitted
-      code runs where the server render already has `re-frame.ssr` on the
-      classpath.
+      (`:rf.ui.compile/no-single-mounted-view` otherwise). The derived identity is
+      RETAINED and registered into the Layer-1 build-tier duplicate-root-id index
+      via `register-root-site!`, exactly like mount / render! / hydrate-root — a
+      second site resolving to the same root-id is `:rf.error/duplicate-root-id`.
+      Layer-2 duplicate detection (server render time, S5) is the SSR host's
+      per-response registry, not the macro's.
+    - INDEPENDENCE — the macro emits a call to the ui-side late-resolution seam
+      `re-frame.ui.tree/emit-static-html` (NOT a bare `re-frame.ssr/emit-ui-tree`
+      reference), so `re-frame.ui` never statically depends on `re-frame.ssr` (Spec
+      011 §wall — no `ui → ssr` static require) AND the caller's namespace carries
+      no compile-time `re-frame.ssr` reference: a documented render-static call in
+      a namespace that requires only `re-frame.ui` compiles and renders (the seam
+      loads the emitter at render time) instead of failing with a raw
+      `ClassNotFoundException`. A missing `day8/re-frame2-ssr` artefact is the
+      ruled, typed `:rf.error/ssr-artefact-missing`, never a raw host exception.
 
   Expanding in a CLJS build is a compile error (`:rf.ui.compile/ui-render-static-jvm-only`)
   — CLJS has no structural trees (the client emitter targets React directly), and
@@ -831,19 +876,56 @@
                "in a .clj / .cljc-on-JVM server render namespace, and mount in the "
                "browser with ui/mount / ui/hydrate-root")
           nil))
-  (let [coords (source-coords form false)]
+  (let [coords (source-coords form false)
+        ns-sym (ns-name *ns*)]
     (anchored coords
       (fn []
-        (let [e (-> (env/make-env {:host :clj :ns-sym (ns-name *ns*)})
+        (let [e (-> (env/make-env {:host :clj :ns-sym ns-sym})
                     (env/with-locals (keys menv)))
-              {:keys [ast views]} (analyze-root e 'ui/render-static root-form)]
-          ;; Identity participation (§7): no opts ⇒ derive from the single mounted
-          ;; view; reuse the exact one-view invariant + its frozen compile id.
-          (resolve-root-identity 'ui/render-static {} views)
+              {:keys [ast views]} (analyze-root e 'ui/render-static root-form)
+              ;; Identity participation (§7): no opts ⇒ derive from the single
+              ;; mounted view; reuse the exact one-view invariant + its frozen
+              ;; compile id.
+              {:keys [root-id provenance]} (resolve-root-identity
+                                            'ui/render-static {} views)]
           (print-warnings! e 'ui/render-static)
-          ;; Emit (not require) the SSR serialiser over the JVM structural tree —
-          ;; `~'` keeps `re-frame.ui` free of any static `re-frame.ssr` require.
-          `(~'re-frame.ssr/emit-ui-tree
+          ;; No-silent-elision proof (Spec 004C §3, EP-0034 §2): a pure :server
+          ;; static render cannot honour a live-runtime capability, so any
+          ;; runtime-requiring capability in the root's server-reachable view
+          ;; closure (subs, committed handlers, effects, refs, context, foreign /
+          ;; lazy heads) is a loud BUILD error with source coordinates — never a
+          ;; silently dropped capability. `ui/client-only` stays legal (only its
+          ;; capability-free fallback is server-reachable); `use-id` is exempt.
+          (when-let [{:keys [view-id caps]}
+                     (static-capability-offender
+                      (compiler/view-static-facts ast @(:sites e))
+                      (compiler/build-view-static))]
+            (fail :rf.ui.compile/static-root-requires-runtime
+                  (str "ui/render-static: the static root's server-reachable view "
+                       "closure requires runtime capability "
+                       (str/join ", " (map name (sort caps)))
+                       (if (= :rf.root/root-form view-id)
+                         " in the root form itself"
+                         (str " (via view " (pr-str view-id) ")"))
+                       " — render-static is the pure :server static-HTML path (no "
+                       "subs, handlers, effects, refs, context, or foreign/lazy "
+                       "heads; no manifest, no hydration, no phase flip). Mount "
+                       "this tree in the browser with ui/mount / ui/hydrate-root, "
+                       "or move the live subtree behind a ui/client-only with a "
+                       "capability-free fallback")
+                  {:root-id root-id :offending-view view-id
+                   :capabilities (vec (sort caps))}))
+          ;; Layer-1 identity registration (§7): the static root participates in
+          ;; the build-tier duplicate-root-id index exactly like mount / render! /
+          ;; hydrate-root — the derived identity is retained, not discarded.
+          (register-root-site! 'ui/render-static root-id provenance ns-sym coords)
+          ;; Emit a call to the ui-side late-resolution seam (NOT a bare
+          ;; `re-frame.ssr/emit-ui-tree` reference) so the caller's namespace
+          ;; carries no compile-time `re-frame.ssr` reference — a missing SSR
+          ;; artefact is the ruled typed `:rf.error/ssr-artefact-missing`, not a
+          ;; raw ClassNotFoundException. `re-frame.ui` still takes no static
+          ;; require on `re-frame.ssr` (the resolve is late, at render time).
+          `(~'re-frame.ui.tree/emit-static-html
             (~'re-frame.ui.tree/render-root-tree
              (fn [] ~(emit-jvm/emit-node ast)))))))))
 

--- a/implementation/ui/src/re_frame/ui/tree.cljc
+++ b/implementation/ui/src/re_frame/ui/tree.cljc
@@ -525,3 +525,42 @@
   (reactive/with-slice-memo
     (fn []
       (assoc (thunk) :rf.ui/tree-version tree-version))))
+
+#?(:clj
+   (defn resolve-ssr-emitter
+     "Late-resolve `re-frame.ssr/emit-ui-tree` on the JVM — the SSR artefact's
+     pure tree -> HTML serialiser. Returns the resolved var (loading
+     `re-frame.ssr` on demand if it is on the classpath but not yet required),
+     or nil when the artefact is absent. The `hydrate-root` late-require
+     precedent: `re-frame.ui` takes NO static require on `re-frame.ssr`, so a
+     server namespace that requires only `re-frame.ui` still renders (the emitter
+     is loaded here, at render time), and Spec 011's `ui -> ssr` static wall
+     stays intact. Extracted as its own seam so the artefact-absent branch is
+     drivable in a test."
+     []
+     (try
+       (requiring-resolve 're-frame.ssr/emit-ui-tree)
+       (catch java.io.FileNotFoundException _ nil))))
+
+#?(:clj
+   (defn emit-static-html
+     "Fold a JVM structural `tree` to an inert HTML string through the SSR
+     artefact's `re-frame.ssr/emit-ui-tree`, resolved LATE (see
+     `resolve-ssr-emitter`). This is the runtime seam `re-frame.ui/render-static`
+     emits a call to instead of naming `re-frame.ssr/emit-ui-tree` directly — a
+     direct emit compiled a hard `re-frame.ssr` reference into the caller's
+     namespace, so a documented render-static call in a namespace that required
+     only `re-frame.ui` failed to COMPILE with a raw `ClassNotFoundException:
+     re-frame.ssr`. When the `day8/re-frame2-ssr` artefact is absent from the
+     server classpath this raises the ruled, typed
+     `:rf.error/ssr-artefact-missing` naming the artefact — never a raw host
+     exception, never a fallback."
+     [tree]
+     (if-let [emit (resolve-ssr-emitter)]
+       (emit tree)
+       (error/throw-error!
+        :rf.error/ssr-artefact-missing
+        'ui/render-static
+        (str "re-frame.ui/render-static requires day8/re-frame2-ssr on the "
+             "classpath; add it to deps and require re-frame.ssr at app boot.")
+        {:extra {:maven "day8/re-frame2-ssr" :require-ns "re-frame.ssr"}}))))

--- a/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
@@ -146,6 +146,10 @@
     ;; macro rejects a CLJS expansion (no structural trees in the browser; a CLJS
     ;; expansion would emit the JVM tree + SSR serialiser into a browser bundle)
     :rf.ui.compile/ui-render-static-jvm-only
+    ;; render-static no-silent-elision proof (S5, rf2-uv7n6) — a runtime-requiring
+    ;; capability anywhere in the static root's server-reachable view closure is a
+    ;; loud build error, never a silently dropped capability (EP-0034 §2)
+    :rf.ui.compile/static-root-requires-runtime
     ;; a11y-diagnostic suppression grammar (S4-C, rf2-74vlo) — a malformed
     ;; ^{:rf.ui/suppress {<id> "reason"}} is loud, never a silent no-op
     :rf.ui.compile/bad-suppress})
@@ -191,7 +195,10 @@
     test_render_jvm_test     bad-test-render-form / bad-test-root
     render_static_jvm_test   ui-render-static-jvm-only (re-frame.ssr artefact —
                              render-static is a JVM/server surface, so its CLJS-
-                             expansion rejection is exercised where it renders)
+                             expansion rejection is exercised where it renders) +
+                             static-root-requires-runtime (the no-silent-elision
+                             proof needs the build view-static index populated —
+                             not reachable by macroexpanding a single form)
     custom_element_conflict_jvm_test
                              custom-element-conflict (needs TWO declaring
                              sources in one build — not reachable by
@@ -212,7 +219,8 @@
     :rf.ui.compile/client-entry-on-jvm
     :rf.ui.compile/bad-test-render-form
     :rf.ui.compile/bad-test-root
-    :rf.ui.compile/ui-render-static-jvm-only})
+    :rf.ui.compile/ui-render-static-jvm-only
+    :rf.ui.compile/static-root-requires-runtime})
 
 (def ^:private direct-call-ids
   "Ids exercised by a direct analyzer-fn call below (defensive sites the


### PR DESCRIPTION
Fixes three reproduced conformance gaps between the shipped `re-frame.ui/render-static` macro (#6511) and the obligations its own **rf2-oo5lb** ruling states. These are conformance repairs to an EXISTING ruling — not a new decision. Each gap was reproduced RED against current `origin/main` first (rebased onto merged #6511 + #6550/2rzx0), then fixed and pinned green on the real render-static path.

## The three repairs

### 1. Silent capability elision → no-silent-elision proof (Spec 004C §3, EP-0034 §2)
**Current wrong (main):** `render-static-form` analyzed the root, emitted the JVM tree, and serialized it, never checking view capabilities. `(ui/render-static [interactive-card {:label "x"}])` — where `interactive-card` is `[:button {:on-click [:clicked]} label]` — returned `"<button>x</button>"`, silently eliding the handler; `(ui/render-static [static-parent])` (whose only child is that view) did the same through the nested reference.

**Ruled-correct:** any runtime-requiring capability in the root's server-reachable view closure (subs, committed handlers, effects, refs, context, foreign/lazy heads) is a loud BUILD error — no silent elision. `use-id` exempt; capability-free `ui/client-only` fallback legal.

**Fix:** the ruling's small, cycle-safe projection — a per-view `view-static` build index (`view-id -> {:caps :deps}`) of each view's OWN server-reachable runtime capabilities + direct-view dependencies (`compiler/view-static-facts`), closed over transitively at expansion (`static-capability-offender`). Now raises `:rf.ui.compile/static-root-requires-runtime` with source coordinates, naming the capability and the offending view. `client-only` subtrees are skipped (only the fallback is server-reachable — a static root never flips); `use-id` is exempt.

### 2. `register-root-site!` never called → Layer-1 identity registration (Spec 004C §7)
**Current wrong (main):** `resolve-root-identity` ran but its result was discarded; render-static never called `register-root-site!`. After a render-static call, `build-roots` was `{}` — the root was absent from the build-tier duplicate-root-id index that mount/render!/hydrate-root all populate.

**Ruled-correct:** retain the derived `{root-id, provenance}` and register the site.

**Fix:** capture the identity and call the existing `register-root-site!` seam. A second site resolving to the same root-id from another namespace is now `:rf.error/duplicate-root-id`, exactly as for the other root verbs.

### 3. `ClassNotFoundException` → typed missing-SSR-artefact error
**Current wrong (main):** the macro emitted a bare `re-frame.ssr/emit-ui-tree` call, compiling a hard `re-frame.ssr` reference into the caller's namespace. A documented render-static call in a namespace requiring only `[re-frame.ui]` failed to COMPILE with a raw `ClassNotFoundException: re-frame.ssr`.

**Ruled-correct:** late resolution + the typed `:rf.error/ssr-artefact-missing` family (the id already exists) when the SSR artefact is absent.

**Fix:** emit a call to a ui-side late-resolution seam `re-frame.ui.tree/emit-static-html` (JVM), which `requiring-resolve`s `re-frame.ssr/emit-ui-tree` at render time. The caller carries no compile-time `re-frame.ssr` reference (requires-only-ui now compiles and renders), `re-frame.ui` keeps no static ssr dependency, and an absent `day8/re-frame2-ssr` raises the ruled typed `:rf.error/ssr-artefact-missing` naming the artefact — never a raw host exception.

## Bounded
No macro re-litigation, no render-static refactor, no capability beyond the three. One new public id (`:rf.ui.compile/static-root-requires-runtime`, a `:rf.ui.compile/*` compile-family id — no Spec 009 catalogue row) added to the frozen error roster. No `identical?` on keyword literals. Touched no `emit_cljs.cljc` (55zsd), `spec/Spec-Schemas.md` (rl6ue), `skills/` (l8oa9), or `ai/`.

Files: `compiler/root.cljc`, `compiler.cljc`, `compiler/build.cljc`, `tree.cljc` + the render-static / error-roster tests.

## Quality gates
All foreground, run to completion:
- `ui` JVM: **1016 tests / 19786 assertions, 0 failures** (render-static, root, frozen error roster)
- `ssr` JVM: **523 tests / 2519 assertions, 0 failures** (SSR artefact / render-static end-to-end)
- `core` JVM: **2104 tests / 10420 assertions, 0 failures** (catalogue-conformance for `:rf.error/ssr-artefact-missing`)
- `test:cljs`: **10352 tests / 51122 assertions, 0 failures, 0 warnings** (cross-artefact render-static path)
- `test:elision`: **PASS** (production 60/60 absent; render-static is JVM-only, adds no CLJS runtime code)
- `check-no-hardcoded-paths.sh`: OK
