### PR TITLE
docs(skills): repair reagent-migration operational truth — 4 seams (rf2-sbje4)

### DIFF
--- a/docs/skills/reagent-migration.md
+++ b/docs/skills/reagent-migration.md
@@ -7,7 +7,7 @@
 This skill is not on anyone's critical path:
 
 - **It is the OPTIONAL, SECOND step.** The migration journey is two moves, in order: **(1)** re-frame v1 → re-frame2 (the *required* foundation — [re-frame-migration](re-frame-migration.md); it leaves your views on Reagent), then **(2)** — optionally — Reagent views → re-frame.ui (*this* skill). Do (2) only after (1), and only if you want the compiled-view substrate.
-- **re-frame.ui is EXPERIMENTAL.** Parts are still staged (the outward `ui/->react` bridge, an explicit-frame `sub` pin). The skill names those gaps and holds the affected views on Reagent.
+- **re-frame.ui is EXPERIMENTAL.** Parts are still staged (the outward `ui/->react` bridge, an explicit-frame `sub` pin). The skill names those gaps and holds the affected views on Reagent. It ships in `day8/re-frame2-ui`, which is currently **in-tree / pre-publication** (not yet on Maven) — the target project must be able to consume the in-tree / git-source artifact before there is anything to migrate onto.
 - **Staying on Reagent views is a first-class, fully-supported choice.** A re-frame2 app running Reagent views through the Reagent adapter is a complete, supported configuration — never a half-migrated one.
 
 ## What it does
@@ -38,7 +38,7 @@ Do **not** use it for:
 
 ## How the migration runs (incremental)
 
-The skill migrates a **closed subtree** at a time, leaf → root (a converted `ui/defview` can only be consumed by other converted views until the outward bridge ships). For each candidate view it **gates the whole view first**: if any part trips a judgment call or a capability gap, the *entire* view stays on Reagent — no half-migrated bodies. It applies the M-tier rewrites to the clean views, cleans up the requires last, and hands the author a compile + **render** + test loop before moving to the next subtree. "Compiles" is not the done-bar — a converted view must be rendered.
+The skill migrates a **closed subtree** at a time, leaf → root (a converted `ui/defview` can only be consumed by other converted views until the outward bridge ships). For each candidate view it **gates the whole view first**: a **capability gap** (or a genuine reject) holds the *entire* view on Reagent, and a **judgment call** is decided with the author, then the whole view converts or the whole view stays — never a half-migrated body. It applies the M-tier rewrites to the clean views, cleans up the requires last, then **runs the compile + test gates itself** and hands the programmer the **render** check before moving to the next subtree. "Compiles" is not the done-bar — a converted view must still be rendered and eyeballed.
 
 ## Where the skill lives
 

--- a/skills/reagent-migration/README.md
+++ b/skills/reagent-migration/README.md
@@ -31,7 +31,7 @@ This skill is **not on anyone's critical path**, and the README says so before a
 - Greenfield setup — [`re-frame2-setup`](../re-frame2-setup).
 - Live-runtime inspection — [`re-frame2-pair`](../re-frame2-pair).
 - The **dataflow layer** — the skill rewrites the *view tier* only; where a view forces a `reg-sub`/event change, it *names* it for the author, it does not make it.
-- Running the author's build / render / tests — that is the author's, in their own environment.
+- The interactive visual confirmation — booting the app and eyeballing the render — that is the programmer's, in their own environment. (The skill *does* run the project's own noninteractive compile/test gates as it goes.)
 
 ## How the skill works
 

--- a/skills/reagent-migration/SKILL.md
+++ b/skills/reagent-migration/SKILL.md
@@ -25,6 +25,15 @@ allowed-tools:
   - Bash(rg -l *)
   - Bash(git -C * rev-parse *)
   - Bash(git -C * grep *)
+  # Run the project's OWN noninteractive compile/test gates (verify-as-you-go).
+  # These routine wildcards are blessed by the published-skill allowed-tools
+  # baseline (skills/README.md §Published-skill allowed-tools baseline —
+  # trust the explicit invoker); the skill discovers and runs the nearest safe
+  # gate, it never wildcards an arbitrary shell.
+  - Bash(npm *)
+  - Bash(npx *)
+  - Bash(clojure *)
+  - Bash(shadow-cljs *)
   - Read
   - Edit
   - Write
@@ -64,7 +73,7 @@ re-frame v1/Reagent runs your view **at render time as an ordinary function** th
 3. **Incremental, never big-bang.** Migrate one namespace / one closed subtree at a time; verify it renders and its tests pass; then move on. A bad bulk conversion is worse than none — [`references/procedure.md`](references/procedure.md).
 4. **The [MIG rule catalog](references/catalog-mechanical.md) is the shared vocabulary.** Every rewrite cites a `MIG-NN` id (the same ids the framework's own rule table uses), so the author can trace any change back to a rule. Don't invent transforms; if a construct matches no rule, treat it as a reject-and-hold (rule 2).
 5. **Views only.** This skill rewrites the **view tier** — hiccup, handlers, mounts, view-local state. It never touches events, subs, fx, machines, schemas, or routes (that dataflow is re-frame2 already, from step 1). Where a view forces a dataflow change (a new `reg-sub`, a hoisted event), the skill *names* it for the author to do — it does not reach across into the dataflow layer itself.
-6. **The author runs builds, tests, and the app — not the skill.** The skill prints the compile / test command and the author runs it; a build executes arbitrary project code. "Compiles" is necessary but not sufficient — a converted view must be *rendered* and eyeballed, because a few gaps (a converted subtree referenced from unconverted Reagent) surface only at runtime.
+6. **The skill runs the compile/test gates; the programmer owns the visual confirmation.** Migration is verify-as-you-go, so the skill **discovers and runs the nearest safe noninteractive gate itself** — compile the subtree and run its tests (`npx shadow-cljs compile …`, `npm test`, `clojure -M:test`, whatever the project uses) under the repo's trust-the-explicit-invoker `allowed-tools` baseline. "Compiles" is necessary but not sufficient — a converted view must still be *rendered* and eyeballed, because a few gaps (a converted subtree referenced from unconverted Reagent) surface only at runtime. That interactive render-and-eyeball step is the programmer's when there is no connected browser/runtime to drive (or a `re-frame2-pair` read when there is).
 
 ## The transformation catalog — organised by tier
 
@@ -82,7 +91,7 @@ Full loop in [`references/procedure.md`](references/procedure.md). The shape:
 2. **Assess the view first (rule 2).** Scan each candidate view for D/R hits. An **R** hit (a reject or an unshipped-capability construct) → hold the whole view on Reagent. A **D** hit → *decide it with the author*, then convert the whole view or hold the whole view — don't reflexively leave it behind, and don't half-migrate it (the non-gating D rules, MIG-27/28, convert with their noted check).
 3. **Apply the M-tier rewrites** to the clean views, atomically per view (a header change and all its call sites in one edit).
 4. **Fix the ns requires last** (MIG-24): add `[re-frame.ui :as ui :refer [defview sub]]`; drop `reagent.*` requires only when nothing in the namespace still needs them.
-5. **Author compiles + renders + tests** the subtree. Only then move to the next.
+5. **Compile + test the subtree (the skill runs the gates); the programmer renders + eyeballs it.** Only then move to the next.
 
 ## Gotchas
 
@@ -96,7 +105,7 @@ The traps that mangle a view silently → [`references/gotchas.md`](references/g
 - [ ] The D-tier views were *decided with the author*, not silently rewritten.
 - [ ] The R-tier / capability-gap views were left on Reagent with an honest reason ("re-frame.ui doesn't handle this yet — keep this on Reagent, or wait").
 - [ ] Requires cleaned up last (MIG-24); no orphaned `reagent.*` requires, none dropped that a held view still needs.
-- [ ] The author compiled, **rendered**, and ran the affected views' tests — and they pass.
+- [ ] The subtree compiles and its tests pass (the skill ran the gates), and the programmer has **rendered** and eyeballed the converted views.
 
 Hand off: *"Views migrated to `re-frame.ui` where it made sense; the rest stay on Reagent (a fully-supported configuration). Switch to **`re-frame2`** for new application code, or **`re-frame2-pair`** for live inspection."*
 

--- a/skills/reagent-migration/evals/evals.json
+++ b/skills/reagent-migration/evals/evals.json
@@ -53,7 +53,7 @@
      "expectations": [
        "Declines — Reagent component-introspection / scheduler calls have no compiled equivalent (MIG-35).",
        "Warns that r/current-component still COMPILES after conversion and fails/returns nil at runtime, so the build gate will not catch it.",
-       "Keeps the view on Reagent, or restructures away from the introspection (props/children the view already receives; effect for next-tick/after-render)."
+       "Keeps the view on Reagent, or restructures away from the introspection (props/children the view already receives); does NOT equate the schedulers r/next-tick / r/after-render with ui/effect — those stay on Reagent unless the author redesigns phase/frequency/ownership."
      ]},
 
     {"id": 18, "kind": "behavioural", "tier": "D", "name": "d-mig18-handler-split",
@@ -81,6 +81,24 @@
        "Recognises there is NO dispatch-at-unmount in native re-frame.ui: (ui/dispatch-fn) fails loud at disconnect with :rf.error/dispatch-disconnected (the leaked-listener law), so an effect cleanup is NOT a place to smuggle the domain release.",
        "Re-homes the unmount domain work (the [:resource/release] dispatch) OUT of the view — to the causal events that end the resource's life — and names those events / the minting owner for the author (cardinal rule 5); the migrated view becomes a pure defview that owns no lease.",
        "Mentions the view-declared (ui/lease …) as the alternative only when the resource lifetime genuinely follows the view site (framework releases at teardown, no dispatch — valid even if activation is conditional or params are dynamic); here the owner is app-minted (route-minted, released by the causal events), so it re-homes rather than becoming a view lease."
+     ]},
+
+    {"id": 20, "kind": "behavioural", "tier": "D", "name": "d-mig17-measure-before-paint-layout-effect",
+     "prompt": "Migrate this Reagent Form-3 view to re-frame.ui:\n(ns app.popover (:require [reagent.core :as r] [reagent.dom :as rdom]))\n(defn popover [anchor]\n  (r/create-class\n   {:component-did-mount (fn [this] (place! (rdom/dom-node this) (measure anchor)))\n    :reagent-render      (fn [a] [:div.popover])}))",
+     "expectations": [
+       "Recognises MIG-17 Form-3 and that :component-did-mount here does MEASURE-then-mutate BEFORE paint (reads geometry to place the popover), so a passive effect would measure a frame late and flicker.",
+       "Does NOT route this to (effect :connect …); routes it to re-frame.ui.react/use-ref + use-layout-effect (the measure-before-paint door), preserving the pre-paint semantics component-did-mount gave.",
+       "Uses the React interop shape for the hook — (react/use-layout-effect (fn [] … cleanup-or-nil) deps) with a setup fn returning a cleanup fn or nil — NOT ui/effect's body-return shape, and reads the node via (.-current (react/use-ref)).",
+       "Keeps ordinary listeners / focus / deferrable host work on the passive effect — the split is only for the narrow pre-paint case, not a wholesale hooks migration.",
+       "Holds/decides the WHOLE view (cardinal rule 2) rather than half-migrating it."
+     ]},
+
+    {"id": 21, "kind": "behavioural", "tier": "R", "name": "r-scheduler-not-effect",
+     "prompt": "Migrate this view to re-frame.ui:\n(ns f (:require [reagent.core :as r]))\n(defn flasher [] (r/after-render #(flash!)) [:div \"hi\"])",
+     "expectations": [
+       "Does NOT equate r/after-render (or r/next-tick) with ui/effect — they are Reagent one-shot render-queue schedulers (fire immediately before the next flush / immediately after queued renders, even when nothing renders), not component-owned passive post-commit effect work (MIG-35).",
+       "Keeps the scheduler call R-tier: holds the view on Reagent unless the author EXPLICITLY redesigns the work's phase, frequency, and ownership (a deliberate re-model, not a rename).",
+       "Warns that the call still COMPILES after conversion and misbehaves only at runtime, so the build gate will not catch a silent swap to effect."
      ]}
   ]
 }

--- a/skills/reagent-migration/references/catalog-judgment.md
+++ b/skills/reagent-migration/references/catalog-judgment.md
@@ -41,9 +41,30 @@
 
 **The decision: decompose each lifecycle body into host work vs domain work.** Mechanical parts first: delete `:should-component-update` (memo-by-default makes it dead), and extract `:reagent-render` as the view body (the other rules apply to it). Then, per lifecycle body, split by *what the body does*:
 
-- **Host / DOM work** (focus a node, wire a listener, measure, attach a chart) → `(effect :connect …)`. Its signature is a trap — read **the `effect` signature** below before you emit one.
+- **Host / DOM work** → split by *timing*, because `component-did-mount` fired **before paint** and the passive `effect` fires **after** it. Ordinary listeners and deferrable host work (wire a listener, focus a node, kick off a fetch, attach a chart that sizes itself) → `(effect :connect …)`; its signature is a trap — read **the `effect` signature** below before you emit one. But work that **measures or mutates the DOM before the browser paints** — reading a node's geometry to place a popover/dropdown, sizing a table viewport — must NOT move to the passive `effect` (it would measure a frame late and flicker). Route that to **`re-frame.ui.react/use-ref` + `use-layout-effect`** — the measure-before-paint door (see **below**).
 - **Domain work on MOUNT** ("mark viewed", "load on mount") → a route/domain **event** through the dataflow (name it for the author). There is deliberately **no** `:on-mount` primitive; domain-on-mount is a dispatch through the dataflow, not a lifecycle hook.
 - **Domain work on UNMOUNT** ("release the lease", "mark the draft abandoned") → **re-home it OUT of the view** — see **Domain work on unmount** below. There is **no dispatch-at-unmount** in native re-frame.ui; you do **not** preserve it as an `effect` cleanup.
+
+### Measure/mutate before paint → `use-ref` + `use-layout-effect`
+
+Only for the narrow pre-paint case (geometry read, DOM mutation the layout depends on), and only when a passive `effect` would visibly flicker. The interop hooks live in `re-frame.ui.react` (`[re-frame.ui.react :as react]`) and take React's own `setup`→cleanup shape (a `setup` fn returning a cleanup fn or `nil`) — *unlike* `ui/effect`'s body-return shape:
+
+```clojure
+;; before — measurement in :component-did-mount (pre-paint), Form-3
+(r/create-class
+ {:component-did-mount (fn [this] (place! (rdom/dom-node this) (measure anchor)))
+  :reagent-render      (fn [] [:div.popover …])})
+
+;; after — pre-paint semantics preserved by the layout effect, node via use-ref
+(ui/defview popover [{:keys [anchor]}]
+  (let [el (react/use-ref)]
+    (react/use-layout-effect
+      (fn [] (place! (.-current el) (measure anchor)) nil)   ; runs BEFORE paint; nil = no cleanup
+      [anchor])
+    [:div.popover {:ref el} …]))
+```
+
+Everything else — listeners, focus, deferrable work — stays on the passive `effect` below. This is a targeted door, not a hooks-migration framework.
 
 ### `effect`'s signature (verify against `ui.cljc` — REQUIRED)
 
@@ -163,15 +184,22 @@ Keep the caveat: views using refs/effects need `ui/client-only` (or restructure)
 
 **The decision: this is a *second state model* — restructure it into app-db.** There is no direct re-frame.ui equivalent, and that is deliberate: a shared top-level ratom (and `add-watch`/`track!`/`run!` reactions driving effects) was a **latent concurrency bug in Reagent too**. The move is a *causal-event* restructure: the reads become subs, the writes become events, and an `add-watch` becomes the event handler that made the change (the handler carries the consequence) — **not** a mechanical rewrite to `effect`. A watcher fires *synchronously mid-`swap!`, before render*; an effect runs *after commit* — swapping one for the other is a behaviour change no diff review catches. **Compat escape:** the views on this store stay on Reagent until the store is restructured. This is a dataflow re-model the skill scopes and names; the author does it.
 
-## MIG-28 — computed / dynamic DOM props → `ui/spread`
+## MIG-28 — computed / dynamic DOM props → `ui/spread-safe` or `ui/spread`
+
+**The decision: which spread?** re-frame.ui ships an *ergonomic fork* (both DOM elements only) — reach for the safe form first, and drop to the generic one only when the props are genuinely opaque.
+
+- **Literal owned props + a caller-forwarded attr map → `ui/spread-safe`** (the component-library shape, and the ergonomic default). `(ui/spread-safe owned caller)` takes a **literal** `owned` map — the compiler analyses it exactly like an element's props map, so a literal `:value`/`:checked` co-present with its handler **retains the controlled-input synchrony door** — and merges the runtime `caller` attrs over it. A compiler-visible **deny law** (enforced in *every* build) keeps `caller` from clobbering the structural/controlled/owned keys `:key` `:ref` `:value` `:checked` and the component's own `:on-*` handlers; owned props win a collision and `:class` composes. This is the shape a reusable input/control uses to forward a consumer's `data-*`/`aria-*`/`:class` without losing its own guarantees:
 
 ```clojure
-;; before → after
-[:input (merge props {:type "text" :value (or draft "")})]
-=> [:input (ui/spread (merge props {:type "text" :value (or draft "")}))]
+;; before — a control forwards the caller's attrs onto its <input>, holding its own value + handler
+[:input (merge attrs {:type "text" :value (:title draft) :on-input on-input})]
+;; after — owned props literal (sync door KEPT); caller attrs spread safely (deny law applies)
+[:input (ui/spread-safe {:type "text" :value (:title draft) :on-input on-input} attrs)]
 ```
 
-The rewrite is emitted (`ui/spread` is the one generic runtime prop-map conversion, DOM elements only) — but it carries a **named check the human weighs**: a spread site forfeits the static manifest row *and* the controlled-input synchrony door (which needs a provably-literal `:value`/`:checked` co-present on the element). Decision: shrink the spread to genuinely pass-through props and lift `:value`/handlers back to literals, or accept the dynamic site knowingly. **Component call sites stay literal-map (MIG-01), never `ui/spread`.** See the **bare-symbol trap** ([`gotchas.md`](gotchas.md)) — a bare symbol *child* is content, never a spread.
+- **A genuinely opaque runtime props map → `ui/spread`** (the visible-cost escape). `(ui/spread base overrides)` is the one *generic* runtime conversion for a map the compiler cannot see into. It **forfeits the static manifest row *and* the controlled-input synchrony door** (which needs a provably-literal `:value`/`:checked` on the element). Weigh it knowingly: shrink the spread to genuinely pass-through props and lift `:value`/handlers back to literals where you can — or, if the owned/forwarded split is clean, prefer `ui/spread-safe`.
+
+**Component call sites stay literal-map (MIG-01), never a spread.** See the **bare-symbol trap** ([`gotchas.md`](gotchas.md)) — a bare symbol *child* is content, never a spread.
 
 ## MIG-22 — third-party Reagent wrapper components (re-com et al.)
 
@@ -197,6 +225,6 @@ The outward direction (a compiled view *inside* a Reagent tree) needs the `ui/->
 | **MIG-13** | markup-returning `(map (fn …) xs)` in child position | Rewrite to a keyed `for` (`(for [t ts] [item {:key (:id t) :t t}])`) — mechanical only when the fn is a literal with a keyed hiccup body; confirm the candidate. |
 | **MIG-26** | ambient `subscribe`/`dispatch` in a plain unregistered `defn` | Grep for these — they throw `:rf.error/no-frame-context`. Preference order: (1) register as a view; (2) hoist the op to the nearest registered ancestor and pass values down; (3) explicit `{:frame f}`. |
 | **MIG-27** | fn-valued prop on an **internal-view** call site | **Legal and opaque** (a plain fn prop is an identity-compared value — *not* a compile error; non-gating). *Recommend*, don't force: forward a data vector where you want tool-visibility (`:on-commit [:commit]`, child places it at its DOM `:on-*` site), or `ui/handler`/`ui/render-fn` where a phase/stable-identity is genuinely needed. |
-| **MIG-30** | runtime-built markup helper (`(md/render …)` walking an AST) | No compiled spelling for runtime hiccup *data*. Template-ise the callee into `defview` branches (then MIG-01 applies), or route genuinely data-driven markup to `re-frame.ui.data` (a separate artifact), or hold the view. |
+| **MIG-30** | runtime-built markup helper (`(md/render …)` walking an AST) | No compiled spelling for runtime hiccup *data*. Template-ise the callee into `defview` branches (then MIG-01 applies), or hold the view on Reagent. There is **no `re-frame.ui.data` today** — the runtime UI interpreter is a reserved future wave-2 artifact (a *possible future home*, not a namespace you can require now). |
 
 Every row above is a view the skill leaves whole until the decision is made. Decide it, then convert the whole view or hold the whole view — never a partial body.

--- a/skills/reagent-migration/references/catalog-reject.md
+++ b/skills/reagent-migration/references/catalog-reject.md
@@ -17,7 +17,9 @@
 (r/force-update c) · (r/next-tick f) · (r/after-render f)
 ```
 
-Each of these encodes a Reagent-specific assumption about *this renderer's* component object and render scheduling, and has no compiled equivalent. **The dangerous part:** these are ordinary calls, so a converted view **still compiles** with them in it — and then fails or returns `nil` at runtime, *outside a Reagent render*. The build gate does **not** catch this; you must. Restructure instead: `props`/`children` are the props map and positional children the view already receives; `force-update` dissolves under memo-by-default + committed slots; `next-tick`/`after-render` are `effect` (post-commit, with cleanup). A view that genuinely needs the introspection stays on Reagent.
+Each of these encodes a Reagent-specific assumption about *this renderer's* component object and render scheduling, and has no compiled equivalent. **The dangerous part:** these are ordinary calls, so a converted view **still compiles** with them in it — and then fails or returns `nil` at runtime, *outside a Reagent render*. The build gate does **not** catch this; you must. Restructure the introspection: `props`/`children` are the props map and positional children the view already receives; `force-update` dissolves under memo-by-default + committed slots.
+
+**The schedulers `next-tick`/`after-render` are NOT `ui/effect`** — do not equate them. Reagent's one-shot render-queue callbacks fire immediately *before the next flush* and immediately *after its queued renders* (even when nothing renders); `ui/effect` is **component-owned passive post-commit work keyed to connect / dependency changes**. Those are different phases, frequencies, and owners — a silent swap changes behaviour no diff review catches, and it **compiles**. So they stay **R-tier**: keep them on Reagent unless the author *explicitly* redesigns the work's phase, frequency, and ownership (a deliberate re-model, not a rename). A view that genuinely needs the introspection or a scheduler call stays on Reagent.
 
 ### MIG-21 — dynamic tag heads
 
@@ -25,7 +27,7 @@ Each of these encodes a Reagent-specific assumption about *this renderer's* comp
 [(if big? :h1 :h2) props …]     ; head is a runtime expression
 ```
 
-Rejected at compile time — the compiler resolves heads statically. Bind the attrs and split the branches (`(if big? [:h1 …] [:h2 …])`), or, for genuinely data-driven UI, use `re-frame.ui.data` (a separate artifact). If neither fits, the view stays on Reagent.
+Rejected at compile time — the compiler resolves heads statically. Bind the attrs and split the branches (`(if big? [:h1 …] [:h2 …])`) — that fits most cases, a *finite* set of heads. For genuinely data-driven heads there is **no available escape today**: `re-frame.ui.data` (the runtime UI interpreter) is a **reserved future wave-2 artifact — not a namespace you can require now**. So template-ise the head into `defview` branches, or the view stays on Reagent. (`re-frame.ui.data` is named here only as a *possible future home*, for direction — do not emit a require for it.)
 
 ### MIG-25 — effectful subscription bodies
 

--- a/skills/reagent-migration/references/gotchas.md
+++ b/skills/reagent-migration/references/gotchas.md
@@ -37,7 +37,7 @@ The fix for all three is the same structural move: **extract a keyed child view*
 [(if big? :h1 :h2) props …]      ; no compiled form
 ```
 
-The head must resolve statically. This has no mechanical rewrite — bind the attrs and split the branches, or route to `re-frame.ui.data`, or hold the view (MIG-21, [`catalog-reject.md`](catalog-reject.md)). Don't try to be clever with a computed head; the compiler will reject it.
+The head must resolve statically. This has no mechanical rewrite — bind the attrs and split the branches (finite heads), or template-ise into `defview` branches, or hold the view (MIG-21, [`catalog-reject.md`](catalog-reject.md)). There is no `re-frame.ui.data` to route to today — it is a reserved future wave-2 artifact, not a namespace you can require now. Don't try to be clever with a computed head; the compiler will reject it.
 
 ## StrictMode replays effects — `:connect` cleanup runs per-disconnect, not once
 
@@ -45,7 +45,7 @@ React 18 dev **StrictMode deliberately replays** the mount cycle — connect→d
 
 ## Computed props vs the controlled-input door
 
-`ui/spread` (MIG-28) is legal, but a spread on an `:input`/`:select` **forfeits the controlled-input synchrony door**. The door needs the `:value`/`:checked` **entry to appear literally on the element's props map** — the *key* present as a literal map entry, so the compiler can see it. This is **not** a requirement that the *value* be a constant: a controlled `:value (:title draft)` is a perfectly good dynamic expression — what must be literal is the **`:value` key's presence on the element**, not the value routed in through a `(ui/spread (merge … {:value …}))`. Fold `:value` into a spread map and the compiler can no longer prove the entry is there, so you silently lose the synchrony guarantee. Lift `:value`/`:checked` (and the input's handlers) back to literal entries on the element; spread only the genuinely pass-through remainder.
+`ui/spread` (MIG-28) is legal, but a spread on an `:input`/`:select` **forfeits the controlled-input synchrony door**. The door needs the `:value`/`:checked` **entry to appear literally on the element's props map** — the *key* present as a literal map entry, so the compiler can see it. This is **not** a requirement that the *value* be a constant: a controlled `:value (:title draft)` is a perfectly good dynamic expression — what must be literal is the **`:value` key's presence on the element**, not the value routed in through a `(ui/spread (merge … {:value …}))`. Fold `:value` into a spread map and the compiler can no longer prove the entry is there, so you silently lose the synchrony guarantee. Lift `:value`/`:checked` (and the input's handlers) back to literal entries on the element; spread only the genuinely pass-through remainder. When you are forwarding a caller's attrs, `ui/spread-safe` **keeps the door**: its `owned` argument is a *literal* map, so a controlled `:value`/`:checked` living there stays compiler-provable (and its deny law bars the caller from overriding them) — that is the fork MIG-28 teaches.
 
 ## The staged-gap trap — never emit an unshipped form
 

--- a/skills/reagent-migration/references/procedure.md
+++ b/skills/reagent-migration/references/procedure.md
@@ -7,10 +7,11 @@
 
 ## Pre-flight — is this migration even in scope?
 
-Confirm both, or stop:
+Confirm all three, or stop:
 
 1. **The app is already on re-frame2.** re-frame.ui is a re-frame2 substrate. If the app is still on re-frame v1, the events/subs/db migration comes first — route to [`re-frame-migration`](../re-frame-migration) and come back only when that is done.
 2. **The author specifically wants the experimental substrate.** If they are content on Reagent views (the supported default), there is nothing to do — say so. Don't migrate views because you can.
+3. **The `re-frame.ui` artifact is actually available to the target project.** `re-frame.ui` ships in `day8/re-frame2-ui`, which is **in-tree / pre-publication** — the Maven coordinate is **not yet published** (publication is separately owned and must not be accelerated). So a project can only adopt it by consuming the **in-tree / git-source** artifact today, not as a released dependency. If the project has no path to that source, there is nothing to migrate *onto* yet — wait for publication. (This is migration honesty, not a reason to publish early.)
 
 ## Step 1 — Scope a closed subtree
 
@@ -20,13 +21,14 @@ Flag any *inbound* Reagent call site you can't include in the subtree — that v
 
 ## Step 2 — Gate every candidate view (whole-view law)
 
-For each view in the subtree, scan for **any** D/R hit before touching it:
+Before touching a view, scan its whole body for **D/R hits** — then route by tier, not by a blanket hold:
 
-- a state/lifecycle decision (MIG-16/17), a derived-state or ratom-store restructure (MIG-19/20);
-- a reject or capability gap (MIG-21/23/25/30/32/35, the `sub` pin, the outward bridge);
-- a loop-legality issue (MIG-08), a foreign-boundary fn prop (MIG-10), an explicit-frame op (MIG-03), ambient ops in a plain fn (MIG-26).
+- **An R hit → hold the WHOLE view on Reagent**, honestly, and record why. That is a genuine reject with no compiled equivalent (Reagent introspection/scheduler MIG-35, dynamic tag heads MIG-21) or an unshipped capability gap (the outward `ui/->react` bridge, the explicit-frame `sub` pin MIG-03). → [`catalog-reject.md`](catalog-reject.md).
+- **A D hit → decide it with the author, then convert the WHOLE view or hold the WHOLE view** — never a partial body. The judgment calls are catalogued in [`catalog-judgment.md`](catalog-judgment.md): state/lifecycle (MIG-16/17), derived state or the ratom-store restructure (MIG-19/20), the `:on-*` handler split (MIG-18), SSR path routing (MIG-23 — *shipped*, route between the static-page and hydrate paths, not a hold), computed DOM props (MIG-28), third-party wrappers (MIG-22), and the loop-key / foreign-boundary / plain-fn-ambient calls (MIG-08/10/13/26/27/30). A couple are non-gating (MIG-27/28 convert with a named check) — read the row.
 
-**If a view has any of these, leave the WHOLE view on Reagent** and record why. Do not rewrite the clean parts — a half-migrated body neither compiles nor runs. Decide the held views with the author separately (D-tier) or hold them honestly (R-tier).
+Do not rewrite the clean parts of a held view — a half-migrated body neither compiles nor runs (whole-view coherence, [`gotchas.md`](gotchas.md)).
+
+Two things are **not** view gates here. The **mechanical** rules — including the `route-link` head-rename (MIG-32) — are applied directly in Step 3, never held. And an **effectful sub body (MIG-25)** is a *dataflow-side* finding you surface for the author (the view's own deref converts fine, MIG-02, once the sub is made pure) — it is **not** a reason to hold the view.
 
 ## Step 3 — Apply the M-tier rewrites to the clean views
 
@@ -37,13 +39,13 @@ For each fully-clean view, apply [`catalog-mechanical.md`](catalog-mechanical.md
 - **Requires (MIG-24):** add `[re-frame.ui :as ui :refer [defview sub]]`; drop `reagent.*` requires **only** when the namespace has zero remaining uses (a held view keeps them).
 - **Mount (MIG-15) / adapter (MIG-33):** once per root / once per app. On a mixed page (some roots still Reagent), keep the Reagent adapter installed and swap only when every root on the page is converted — confirm the root inventory with the author.
 
-## Step 5 — The author compiles, renders, and tests
+## Step 5 — Compile and test (the skill runs the gates); the programmer renders
 
-Print the commands; the author runs them (cardinal rule 6). **"Compiles" is necessary, not sufficient** — a converted subtree referenced from unconverted Reagent, or a `MIG-35` introspection call, can compile clean and fail only at render. So the done-bar for a subtree is:
+Run the nearest safe noninteractive gate **yourself** — discover the project's compile/test command (`npx shadow-cljs compile …`, `npm test`, `clojure -M:test`) and run it (cardinal rule 6, under the trust-the-explicit-invoker `allowed-tools` baseline). The genuinely-interactive step — booting a dev build and eyeballing the render — stays with the programmer when there is no connected browser/runtime to drive. **"Compiles" is necessary, not sufficient** — a converted subtree referenced from unconverted Reagent, or a `MIG-35` introspection call, can compile clean and fail only at render. So the done-bar for a subtree is:
 
-1. it **compiles** (the compiler catches most re-frame.ui grammar errors here — that is the point of a build-time substrate);
-2. it **renders** — the author boots a dev build and eyeballs the converted views (and, cheaply, reads the live frame with `re-frame2-pair` if a subtle behaviour changed);
-3. its **tests pass** (re-baseline render counts if the substrate changed them).
+1. it **compiles** (the skill runs this — the compiler catches most re-frame.ui grammar errors here, the point of a build-time substrate);
+2. it **renders** — the programmer boots a dev build and eyeballs the converted views (and, cheaply, reads the live frame with `re-frame2-pair` if a subtle behaviour changed); the skill runs this itself only where a connected browser/runtime is available;
+3. its **tests pass** (the skill runs these — re-baseline render counts if the substrate changed them).
 
 Only when a subtree is green do you scope the next one. If a view surfaces a new gap mid-pass, hold it (rule 2) and keep going.
 

--- a/skills/reagent-migration/spec/authoring-prompt.md
+++ b/skills/reagent-migration/spec/authoring-prompt.md
@@ -16,7 +16,7 @@
 >
 > *Then write the skill with the file structure locked in `design.md` §4: `SKILL.md` (router) + six reference leaves (`mental-model`, `catalog-mechanical` (M-tier, before→after), `catalog-judgment` (D-tier, "how to DECIDE"), `catalog-reject` (R-tier, the experimental-honesty backbone), `procedure` (incremental closed-subtree), `gotchas`) + three `spec/` meta-docs + `evals/evals.json`. Every leaf one level deep from `SKILL.md`; each leaf ≤250 lines / ≤16 KB.*
 >
-> *Cardinal rules to bake into `SKILL.md`: (1) AI judgment, not a codemod; (2) the whole view is the unit — never half-migrate; (3) incremental, never big-bang; (4) cite `MIG-NN` ids; (5) views only — name dataflow changes; (6) the author runs build/render/tests, not the skill.*
+> *Cardinal rules to bake into `SKILL.md`: (1) AI judgment, not a codemod; (2) the whole view is the unit — never half-migrate; (3) incremental, never big-bang; (4) cite `MIG-NN` ids; (5) views only — name dataflow changes; (6) the skill runs the noninteractive compile/test gates itself (verify-as-you-go, under the trust-the-explicit-invoker baseline); the programmer owns the interactive visual confirmation.*
 >
 > *Front-matter `description` is "pushy" and self-limiting: trigger on Reagent-view→re-frame.ui phrasing (compiled views, reg-view→defview, deref-drop, adopt the experimental substrate, the Reagent view surfaces `r/atom`/`r/with-let`/`r/create-class`/`adapt-react-class`/`:dangerouslySetInnerHTML`), AND state the negatives: the v1→v2 migration is `re-frame-migration`, authoring is `re-frame2`, and staying on Reagent is fine.*
 >

--- a/skills/reagent-migration/spec/design.md
+++ b/skills/reagent-migration/spec/design.md
@@ -16,7 +16,7 @@ Help a programmer migrate **Reagent view code to re-frame2's `re-frame.ui`** com
 
 The same four pillars as the skill family, adapted to this domain.
 
-1. **Correctness** — the mechanical rewrites are recipe-shaped and cite a `MIG-NN` id; the judgment cases are reasoned, not guessed. The skill never *executes* the author's build/render/tests (arbitrary-code-execution trust boundary) — it prints the command and the author runs it.
+1. **Correctness** — the mechanical rewrites are recipe-shaped and cite a `MIG-NN` id; the judgment cases are reasoned, not guessed. The skill **runs the project's own noninteractive compile/test gates** (verify-as-you-go, under the repo's trust-the-explicit-invoker `allowed-tools` baseline) but leaves the interactive visual confirmation — booting and eyeballing the render — to the programmer when no connected runtime exists.
 2. **Idiomaticness** — the rewrite targets are verified against the shipped `re-frame.ui` surface (Spec 004; `implementation/ui/src/re_frame/ui.cljc`). The skill emits no staged form for a capability that hasn't landed.
 3. **Context economy** — `SKILL.md` is a router; the three tier catalogues + mental-model + procedure + gotchas leaves load on demand.
 4. **Assume training knowledge** — the agent knows Reagent, hiccup, React, re-frame2 events/subs. The skill teaches the **Reagent-view → re-frame.ui binding**: which construct is a mechanical rewrite, which is a judgment call, which is a hold.
@@ -39,7 +39,7 @@ The `MIG-01…35` ids are the framework's own Reagent→re-frame.ui rule numberi
 
 ### L4 — The whole view is the unit of migration
 
-Never half-migrate a view. Any gating hit (a judgment call, a reject, an unshipped capability) → the **entire** view stays on Reagent. A partial body neither compiles nor runs. Coherence over coverage. This is cardinal rule 2 in `SKILL.md`.
+Never half-migrate a view. A **reject or unshipped capability** holds the **entire** view on Reagent; a **judgment call** is decided with the author, then the **whole** view converts or the **whole** view holds — never a partial body (which neither compiles nor runs). Coherence over coverage. This is cardinal rule 2 in `SKILL.md`.
 
 ### L5 — Views only; name dataflow changes, never make them
 
@@ -49,9 +49,9 @@ The skill rewrites the view tier — hiccup, handlers, mounts, view-local state.
 
 Migrate leaf → root, closing a subtree from the bottom up, because the outward `ui/->react` bridge is unshipped (a converted `defview` can only be consumed by converted views). Each pass ends compiling, rendering, and tested, so an interrupted migration resumes cleanly.
 
-### L7 — The author runs build/render/tests
+### L7 — The skill runs the compile/test gates; the programmer owns visual confirmation
 
-The skill prints commands; the author executes. "Compiles" is necessary but not the done-bar — a converted subtree can compile and fail only at render (a `MIG-35` introspection call, a converted view called from unconverted Reagent). The done-bar for a subtree is compiles + renders + tests pass.
+The skill **discovers and runs the nearest safe noninteractive gate itself** (compile the subtree, run its tests) under the repo's trust-the-explicit-invoker `allowed-tools` baseline ([`skills/README.md` §Published-skill `allowed-tools` baseline](../../README.md#published-skill-allowed-tools-baseline-security-policy)) — verify-as-you-go, not an arbitrary executor (no `Bash(*)`, no migration machinery). "Compiles" is necessary but not the done-bar — a converted subtree can compile and fail only at render (a `MIG-35` introspection call, a converted view called from unconverted Reagent). The genuinely-interactive step — booting a dev build and eyeballing the render — stays with the programmer when no connected browser/runtime exists. The done-bar for a subtree is compiles + tests pass + rendered.
 
 ### L8 — Generic to ANY Reagent consumer app
 


### PR DESCRIPTION
Corrects operational-truth seams in the `reagent-migration` skill so its rules/examples/claims match how re-frame.ui actually operates. No redesign, no restructure — precise fixes to a shipped skill; OQ1/OQ2 (MIG-13 D-tier, no runnable tool) intact.

The bead (`rf2-sbje4`) enumerates four DESCRIPTION seams plus three NOTES additions; the ACCEPTANCE CRITERIA covers all of them, so all are addressed.

## Seams (reality ↔ correction)

1. **D-vs-R alignment (procedure.md Step 2 + docs mirror + design L4).** Was: "if a view has any D/R hit, leave the WHOLE view on Reagent", with `MIG-21/23/25/30/32/35` listed as one reject/gap roster. Reality: R holds; **D is decided with the author then the whole view converts or holds**; `MIG-23` (SSR) is D (shipped), `MIG-32` (route-link) is mechanical, `MIG-25` (effectful sub) is a dataflow-side finding — not a view hold. Now routes by tier and links the catalogues instead of duplicating a brittle roster.
2. **MIG-28 spread-safe vs spread.** Was: only generic `ui/spread`. Reality: `re-frame.ui/spread-safe` shipped (S3). Now teaches the fork — literal owned props + caller-forwarded attrs → `ui/spread-safe` (keeps the controlled-sync door + deny law); opaque runtime maps → `ui/spread` — with a concrete example.
3. **MIG-17 pre-paint semantics.** Was: focus/listeners/measure/charts all → passive `effect :connect`. Reality: `component-did-mount` runs before paint; passive `effect` runs after. Now splits: listeners/deferrable → `effect`; measure/mutate-before-paint → `re-frame.ui.react/use-ref` + `use-layout-effect`. One focused example + eval; no hooks-migration framework.
4. **Skill may run gates.** Was: "the author runs builds/tests, not the skill" + a round trip after every subtree. Reality: the repo's published-skill `allowed-tools` baseline blesses `npm/npx/clojure/shadow-cljs`. Now the skill discovers and runs the nearest safe noninteractive gate; interactive visual confirmation stays with the programmer when no runtime is connected. (allowed-tools, cardinal rule 6, Step 5, checklist, design L7/Pillar 1, authoring-prompt, README.)
5. **MIG-35 schedulers ≠ effect.** Was: "`next-tick`/`after-render` are `effect`". Reality: Reagent one-shot render-queue callbacks fire before the next flush / after queued renders; `ui/effect` is component-owned passive post-commit work — different phase/frequency/owner. Now kept R-tier, equivalence removed; fixed eval 16, added pinning eval 21.
6. **Preflight honesty.** Was: generic ANY consumer app. Reality: `day8/re-frame2-ui` is in-tree/pre-publication (Maven coordinate not consumable; publication separately owned). Now preflight requires the git-source artifact be available, else wait.
7. **No `re-frame.ui.data` today.** Was: presented as an available escape (MIG-21/30, gotchas). Reality: reserved future wave-2 separate artefact, no namespace exists. Now: split finite heads / template-ise / hold; ui.data named only as a possible future home.

## Quality gates

All foreground, run to completion:

- `clojure -M -m re-frame.api-manifest.skills-check` → **0** (555 public-var refs in sync)
- `python scripts/check_skill_eval_docs.py` → **0**
- `python scripts/check_skill_eval_packaging.py` → **0**
- `python -m mkdocs build --strict` → **0**
- `python scripts/check_doc_slugs.py` → **0**
- sibling skill gates (migration-cites, migration-contract-drift, package-refs, redirect-anchors, mcp-drift) → **0**

Touched only `skills/reagent-migration/**` + `docs/skills/reagent-migration.md`; no flf7f surface (spec/API.md, Ownership.md, ssr.cljc), no repo-level spec/design.md, no `ai/`.
