### PR TITLE
docs(ep): true up retired references in the re-frame.ui EP family + core docs (rf2-3qb5w)

### DIFF
--- a/docs/EP/EP-0030-the-compiled-view-substrate-program.md
+++ b/docs/EP/EP-0030-the-compiled-view-substrate-program.md
@@ -181,9 +181,11 @@ platform-scale features — the rule that keeps resumability research-tier.
 
 The library alone is not the program. Fifteen workstreams decompose everything
 beyond it: the Reagent→`re-frame.ui` migration skill (W1 — an AI skill,
-`skills/reagent-migration`, not a codemod tool), its sibling migration +
-authoring skills (W2/W6), the
-docs/guide rewrite (W3), examples gaining `re-frame.ui` variants while
+`skills/reagent-migration`, not a codemod tool; the former W2 sibling migration
+skill is absorbed into this single skill), the authoring skills (W6), the
+additive `docs/core/re-frame.ui` guide (W3 — its wholesale docs rewrite
+superseded by the shipped additive guide, later growth demand-driven), examples
+gaining `re-frame.ui` variants while
 `substrates/` is **retained** minus its Helix arm (W4), the hot-zone spec-tree
 waves (W5), tool evidence consumption into Xray/Story/Pair (W7a, S3 — debugging
 is the *first* consumer, not the last), the tools' own UIs migrating as the
@@ -210,9 +212,9 @@ The external story is a **two-step migration**. Step 1 moves a v1 Reagent/re-com
 app's *dataflow* to re-frame2 with views unchanged on the coexisting Reagent
 adapter — gaining Xray, epochs, Story, schemas, and machines immediately. Step 2
 optionally migrates views to `ui` per subtree, on the app's schedule, with the
-migration skill — its rule table carries the mechanical rewrites and flags the
-judgment-tier call sites for review rather than guessing. re-com widgets are
-the last movers; their
+migration skill — it applies the M-tier mechanical rewrites and reasons through
+the D-tier judgment cases with the author rather than guessing. re-com widgets
+are the last movers; their
 `ui`-native answer is a directed program of its own, with substrate readiness
 delivered at S3 per EP-0035.
 
@@ -226,8 +228,9 @@ retained under the tree's `reviews/` directory as durable evidence. The tree
 itself is removed at S7, once every cited contract has its spec home and no live
 brief dangles. Until then: `drafts/*` survive until their owning stage consumes
 them (spec merges under the atomic-landing rule, or the W1/W3/W7a/W9/W11
-workstreams for the skill/docs/CI-facing drafts); `guide/` moves to `docs/guide`
-at S6 (W3); `skill/` moves to `skills/` at S6 (W6); `spikes/` and `reviews/`
+workstreams for the skill/docs/CI-facing drafts); `guide/` is overtaken by the
+shipped additive `docs/core/re-frame.ui` guide (W3), not relocated; `skill/`
+moves to `skills/` at S6 (W6); `spikes/` and `reviews/`
 remain historical evidence referenced from this EP family.
 
 ### Risks
@@ -356,8 +359,9 @@ baseline is a recorded comparison, not a standing gate.
 - **Migration ships as an AI skill (2026-07-20).** W1 is the
   Reagent→`re-frame.ui` migration skill (`skills/reagent-migration`), not a
   codemod tool; the skill's rule table and fixture corpus carry the mechanical
-  tier and flag the judgment tiers for review. W2 lands as a sibling skill of
-  the existing v1 migration skill rather than an extension of it.
+  tier and reason through the judgment tiers with the author. W1 absorbed the
+  former W2 into this single sibling skill of the existing v1 migration skill
+  rather than shipping a second one.
 
 ## Open Issues
 

--- a/docs/EP/EP-0035-component-library-readiness.md
+++ b/docs/EP/EP-0035-component-library-readiness.md
@@ -213,8 +213,8 @@ a permissive alternative, and those refusals are half an EP's value.
 ## Backwards Compatibility
 
 Pre-alpha; no shims. `local`'s two-tuple destructuring sites migrate to the
-three-tuple (the migration skill's `swap!` rewrite retargets to `update!`,
-retiring its MANUAL flag on multi-writer idioms). The sync-door widening is
+three-tuple (the migration skill's `swap!` rewrite retargets to `update!` for
+multi-writer idioms). The sync-door widening is
 strictly additive at proven-controlled sites — no narrower door was ever
 shipped law — and the v1 API freeze is not
 reopened: deltas #4/#5 entered under the freeze's own delta protocol.


### PR DESCRIPTION
Follow-up to #6547 (EP-currency sweep): EP-0030/0035 retained the retired codemod-era adoption plan the sweep missed. Small current-truth corrections only — no workstream renumber, bulk doc rewrite, new skill, or machinery.

## What changed

**EP-0030 (`docs/EP/EP-0030-...md`)**
- **Adoption workstreams** — W2 (the former second migration skill) is recorded as *absorbed into W1*'s single sibling AI skill `skills/reagent-migration`; stable W numbers preserved (no renumber). W3 is now the *additive* `docs/core/re-frame.ui` guide (delivered by rf2-b1wv9/#6544), its wholesale docs rewrite + `guide/` -> `docs/guide` move superseded, later growth demand-driven — the nonexistent `docs/guide` destination is gone.
- **Migration posture** + **Resolved Decisions** — the W1 skill *applies M-tier mechanical rewrites and reasons through D-tier judgment cases with the author*, rather than emitting review flags.
- **Design-record retirement** — the synthesis tree's `guide/` draft is *overtaken by* the shipped additive guide, not relocated to `docs/guide`.

**EP-0035 (`docs/EP/EP-0035-...md`)**
- **Backwards Compatibility** — removed the MANUAL-flag language; the `swap!` -> `update!` migration fact is preserved. `Status: final` is untouched (hp9rp intact).

**S6 epic** — `rf2-vxgfnd` received a current-truth override note (via `--append-notes`) so the closed `rf2-nwgzha` (W2) and `rf2-3339ri` (W3) are not redispatched.

`docs/core/re-frame.ui/**` and `docs/guide/**` carried no matching residue on re-verify (`docs/guide` does not exist; the re-frame.ui pages' only "flag" uses are ordinary boolean flags; `docs/core/25-from-re-frame-v1.md` describes the separate `skills/re-frame-migration` v1->v2 skill, whose Type-B flagging is current) — NOTE + skipped per the three-outcome rule.

## Quality gates
- `python -m mkdocs build --strict` — exit 0
- `python scripts/check_doc_slugs.py` — exit 0
- `python scripts/check_ep_status_sync.py` — exit 0 (EP-0035 stays `final`)
- `scripts/check-no-hardcoded-paths.sh` — exit 0

Touched only `docs/EP/EP-0030*.md` + `docs/EP/EP-0035*.md`; no spec/, skills/, ai/, or implementation/ changes.
