### PR TITLE
fix(ssr): partial SSR version-model residue in hydrate + STOP-report on recovery value (rf2-07mhr)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/hydrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hydrate.cljc
@@ -333,8 +333,13 @@
     ;; check fxs as part of `:fx` so a mismatch surfaces a structured
     ;; trace event without crashing the hydration path. Both fxs gate on
     ;; payload-key presence — the scalar form passed here is the
-    ;; server's value (the "expected"); the fx looks up the client-side
-    ;; "actual" via late-bind.
+    ;; server's value (the "expected"). The two fxs resolve the client-
+    ;; side "actual" DIFFERENTLY: `:rf.ssr/check-version` reads the SSR
+    ;; artefact's compiled-in `payload-policy/pattern-protocol-version`
+    ;; constant (always resolves — the version check never skips), while
+    ;; `:rf.ssr/check-schema-digest` resolves through its optional
+    ;; `:schemas/app-schemas-digest` late-bind hook (absent hook → the
+    ;; comparison is skipped).
     ;;
     ;; SSR hydration metadata is durable,
     ;; serializable framework runtime state (it must survive epoch-restore /

--- a/implementation/ssr/test/re_frame/ssr_hydration_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_test.clj
@@ -32,8 +32,10 @@
       → hydration-baseline-post-hydrate-dispatch-mutates-seeded-db
     spec.cjs #8-11 (resp-status/ct/cookies-count/cookie-name)
       → hydration-baseline-rf-response-slice-round-trips-via-payload
-    spec.cjs #12 (:rf.ssr/compatibility-check-skipped trace)
-      → hydration-baseline-emits-compatibility-check-skipped-trace
+    spec.cjs #12 (version check silently matches the SSR pattern-protocol
+                  constant — no :rf.ssr/compatibility-check-skipped, since
+                  the version check reads the constant and never skips)
+      → hydration-baseline-version-matches-ssr-constant-silently
     spec.cjs #13 (no :rf.ssr/hydration-mismatch on baseline)
       → hydration-baseline-no-mismatch-trace-when-server-hash-nil
 


### PR DESCRIPTION
## Summary

`rf2-07mhr` (a #6548 follow-up) enumerates three residues. I fixed the two
that are **in-fence and uncontested** (correct regardless of how the third
resolves), and **STOP-report** the third — the `:recovery` value — because
investigation shows the bead's premise for it appears inverted, and the fix
would require editing a hot-zone spec file the dispatch brief explicitly forbids.

## What shipped in this PR

**1. hydrate.cljc — stale late-bind comment (bead AC#1).** The compatibility-
check dispatch comment claimed *both* fxs resolve the client "actual" via
late-bind. Shipped reality: only `check-schema-digest-fx` late-binds (the
`:schemas/app-schemas-digest` hook, which can be absent → skip); `check-version-fx`
reads `payload-policy/pattern-protocol-version` directly (`runtime-version-lookup`,
never nil, never skips). Comment now states each fx's resolution. The 009 row's
own *description* cell already says this correctly.

**2. ssr_hydration_test.clj — stale migration map (bead AC#2, in-fence part).**
The namespace-docstring migration map pointed assertion #12 at the removed
`hydration-baseline-emits-compatibility-check-skipped-trace`. The shipped
replacement is `hydration-baseline-version-matches-ssr-constant-silently`
(version equals the SSR constant → silent match, no skipped trace). Map updated.

## STOP-report: the `:recovery` value (bead AC#4) — needs Mike's ruling

The bead asks to change **Spec 009** `:rf.ssr/compatibility-check-skipped`'s
recovery cell from `:logged-and-skipped` → `:skipped` (align spec to the shipped
code, "do not change an emitter"). The dispatch brief asks the **opposite**
(align code/test → the 009 value, do NOT edit 009 — it's authoritative + hot-zone).

Investigation shows **the 009 row is defensible / likely correct**, per 009's
own recovery-value glossary:

- **`:skipped`** (009 L2501) = "the runtime **declined to act**
  (`:rf.fx/skipped-on-platform`, `:rf.cofx/skipped-on-platform`)" — scoped to
  platform-gating, where the fx/cofx is **not invoked**.
- **`:logged-and-skipped`** (009 L2503) = "the runtime **emitted the trace** and
  dropped the offending input; sibling inputs still apply" — the established
  value used by ~8 diagnostic rows (`:rf.error/effect-map-shape`,
  `:rf.schema/violation`, `:rf.error/machine-action-wrote-db`, nav-token,
  malformed-url, machines, schemas, xray).

But `check-schema-digest-fx` **is invoked** (client platform), **emits a
`:warning` trace**, then no-ops the comparison because the actual value can't
resolve. That is *not* "declined to act" (`:skipped`); it is "logged + no-opped."
So the code's `:skipped` is the anomaly, and the 009 row's `:logged-and-skipped`
is the glossary-consistent value. **The bead's premise (009 is the residue) is
contradicted.** Neither value is a perfect fit, so this is a spec-vocabulary
decision for the owner, not a mechanical residue fix. I changed neither 009 nor
the emitter/test pending a ruling.

## Out-of-fence residue items (flagged, not touched)

Also independent of the recovery direction, and outside this worker's fence:

- `tools/story/spec/Migration-Audit.md` L208 still names the removed
  `hydration-baseline-emits-compatibility-check-skipped-trace` for assertion #12
  (`tools/**` — brief-forbidden). *(The brief's surface named a nonexistent
  `spec/Migration-Audit.md`.)*
- `testbeds/ssr_basic/core.cljs` L28-31 prose says absent late-bind "hooks"
  (plural) emit `:rf.ssr/compatibility-check-skipped`; only the schema-digest
  hook can (version never skips). (`testbeds/**` — not in the brief's surface.)

Recommend the mayor re-dispatch these two prose fixes (fence expanded to
`tools/story/spec/` + `testbeds/ssr_basic/`) once the recovery-value direction
is ruled, since the assertion-#12 wording there mirrors the recovery decision.

## Quality gates

- `cd implementation/ssr && clojure -M:test` → **523 tests, 2519 assertions,
  0 failures, 0 errors** (exit 0).
- `implementation/core` catalogue-conformance + `mkdocs build --strict` +
  `check_doc_slugs.py`: **not run — unaffected.** This PR touches only two
  code comments/docstrings; no catalogue row, no spec/009, no docs/Migration-Audit
  content changed.

No runtime or API change. Did NOT edit `spec/009-Instrumentation.md`, `tools/**`,
`testbeds/**`, `implementation/ui`, or `ai/**`.
