### PR TITLE
feat(ui): view-evidence substrate record plumbing — render-key + per-commit record (rf2-8ds0v)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -582,7 +582,12 @@
   ;;                             ;   pending window (see `fold-evidence`); nil
   ;;                             ;   in production (elided) + between flushes
   ;;    :listeners {k -> fn}     ; useSyncExternalStore subscribers
-  ;;    :intervals [interval]}   ; lifecycle facts (dev/tool; 03 §4)
+  ;;    :intervals [interval]     ; lifecycle facts (dev/tool; 03 §4)
+  ;;    :commit-record {…}|nil}  ; DEBUG-only S6 committed-instance record from
+  ;;                             ;   the most-recent CONNECTED commit (Ruling 1;
+  ;;                             ;   integer render-key + per-observation
+  ;;                             ;   observations). ABSENT in production (elided)
+  ;;                             ;   and nil before the first connect
   )
 
 (defn cell?
@@ -3784,6 +3789,92 @@
                 :published
                 (recur)))))))))
 
+;; ---------------------------------------------------------------------------
+;; S6 committed-instance record (Ruling 1; EP-0033 §Two evidence layers,
+;; spec/004 §View identity) — the per-commit view-evidence record minted on the
+;; connected-commit path.
+;;
+;; DEBUG-ONLY. The whole view-evidence plane is production-erased (G-7/G-11);
+;; every mint below sits behind `interop/debug-enabled?` at the call site (in
+;; `commit*`), so Closure DCEs it and the render-key source is never allocated
+;; nor advanced in an :advanced production build — the same gate the invalidation
+;; evidence plane and the HMR provisional field already ride.
+;;
+;; OPTION 1A (honest capture). The record carries exactly what the substrate owns
+;; at commit, and NOT what it cannot honestly source:
+;;   - :render-key is a MODULE-GLOBAL monotonic integer minted fresh at EACH
+;;     connected commit (so re-renders increment it) — a total order over
+;;     committed renders the sub→view recompute edge (`:rf.sub/reader-render-key`)
+;;     and a React Performance-Tracks timeline correlate against.
+;;   - frame attribution is PER-OBSERVATION, never a single fabricated fact: a
+;;     ViewCell observes a SET of frames (an override-only cell observes none),
+;;     so each observation carries its own target's :frame-id and the record
+;;     claims NO singular top-level :frame-id.
+;;   - :parent-render-key is DEFERRED — no S6 surface consumes view parentage, so
+;;     NO parent-capture machinery exists here.
+;;   - :rf.view/causes (the per-commit cause vector) rides a LATER slice; this
+;;     record carries no causes slot yet.
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private render-key-counter
+  ;; The module-global monotonic :render-key source (DEBUG-only; nil in
+  ;; production, where no committed-instance record is ever minted). `defonce` is
+  ;; module-lived and deliberately survives `reset-scheduler!` — render-keys are a
+  ;; strictly-increasing total order over EVERY committed render for the module's
+  ;; lifetime, so consumers compare them (a later commit's key is greater), never
+  ;; read absolute values.
+  (when interop/debug-enabled? (atom 0)))
+
+(defn- next-render-key!
+  "Mint the next monotonic render-key. Called ONLY under `interop/debug-enabled?`
+  at the connected-commit site, so production never reaches it and the counter
+  stays nil + unallocated there."
+  []
+  (swap! render-key-counter inc))
+
+(defn- project-observations
+  "Project this render's captured sites into the per-commit :observations vector,
+  in compiler render order. PURE PROJECTION of data the capture already holds —
+  the resolved site target plus its ownership-free probe evidence — so it makes
+  no port call, reads no lease, and performs no NEW capture (Ruling 1: the frame
+  is 'already captured per-site').
+
+  Each observation carries its TARGET'S :frame-id — the amended per-observation
+  frame attribution (nil for a Story override, which resolves against no frame).
+  :target-id / :version are the node identity + version THIS render observed
+  (nil when probed cold, or for a static override); :owned? is true for an owned
+  subscription node lease and false for a static Story-override lease."
+  [new-order new-by]
+  (mapv (fn [sid]
+          (let [{:keys [target evidence query]} (get new-by sid)
+                kind (:kind target)]
+            {:kind      kind
+             :frame-id  (:frame-id target)
+             :query     query
+             :target-id (:node-key evidence)
+             :version   (:node-version evidence)
+             :owned?    (= :subscription kind)}))
+        new-order))
+
+(defn- mint-commit-record!
+  "DEBUG-only: mint a fresh monotonic :render-key and publish the S6
+  committed-instance record onto `cell` for THIS connected commit (Ruling 1).
+  Reads the cell's just-published state, so :view-id / :generation / :root-id
+  reflect the commit that connected. `:root-id` is the owning root incarnation —
+  the opaque per-mount token the tool projection resolves to the authored root-id
+  name (nil under no root, e.g. Tier-1/JVM). Returns the record."
+  [^ViewCell cell cap new-order new-by]
+  (let [st     (state cell)
+        st0    @st
+        record {:render-key   (next-render-key!)
+                :view-id      (:view-id st0)
+                :generation   (:generation cap)
+                :root-id      (:root st0)
+                :connection   :connected
+                :observations (project-observations new-order new-by)}]
+    (swap! st assoc :commit-record record)
+    record))
+
 (defn- commit*
   "Run the 8-step layout commit for `cell` against the exact immutable
   `capture` returned beside the committed host element by `with-capture`.
@@ -4042,14 +4133,24 @@
                               (frame/frame-incarnation-closing? fid token))
                             incarnations))
                 (teardown! cell)
-                ;; step 8 — moved evidence corrects before paint. The staged catch
-                ;; always advances synchronously; a RETAINED catch advances only when
-                ;; no live watch already caught the move — a pending (`dirty?`) cell is
-                ;; a watchable host whose scheduled flush already corrects before paint,
-                ;; so advancing here too would add a redundant render (rf2-vxgfnd.39).
-                (when (or staged-moved?
-                          (and retained-moved? (not (dirty? cell))))
-                  (advance-revision! cell)))
+                (do
+                  ;; S6 committed-instance record (Ruling 1; EP-0033 §Two evidence
+                  ;; layers). Only a CONNECTED commit reaches here — a stale,
+                  ;; superseded, torn-down or never-committed (speculative) render
+                  ;; publishes nothing, so no instance is fabricated (I-1/I-2). Mint
+                  ;; a fresh monotonic :render-key + the per-commit record.
+                  ;; DEBUG-ONLY: the whole plane is production-erased (G-7/G-11), so
+                  ;; this DCEs under goog.DEBUG=false and no render-key advances.
+                  (when interop/debug-enabled?
+                    (mint-commit-record! cell cap new-order new-by))
+                  ;; step 8 — moved evidence corrects before paint. The staged catch
+                  ;; always advances synchronously; a RETAINED catch advances only when
+                  ;; no live watch already caught the move — a pending (`dirty?`) cell is
+                  ;; a watchable host whose scheduled flush already corrects before paint,
+                  ;; so advancing here too would add a redundant render (rf2-vxgfnd.39).
+                  (when (or staged-moved?
+                            (and retained-moved? (not (dirty? cell))))
+                    (advance-revision! cell))))
               cell)))))))))
 
 (defn commit!
@@ -4115,6 +4216,24 @@
   "The cell's current revision integer (tool/test read)."
   [^ViewCell cell]
   (:revision @(state cell)))
+
+(defn commit-record
+  "The cell's most-recent CONNECTED-commit S6 committed-instance record, or nil
+  when the cell has never connected — and always nil in a production build, where
+  the view-evidence plane is elided. The per-commit record (Ruling 1; EP-0033
+  §Two evidence layers): integer :render-key, :view-id, :generation, :root-id,
+  :connection, and a per-observation :observations vector. There is deliberately
+  NO singular :frame-id (frame attribution is per-observation), NO
+  :parent-render-key (deferred), and no causes slot yet (a later slice).
+  Tool/test read."
+  [^ViewCell cell]
+  (:commit-record @(state cell)))
+
+(defn render-key
+  "The integer :render-key of the cell's most-recent connected commit, or nil.
+  Module-global monotonic and fresh per connected commit (tool/test read)."
+  [^ViewCell cell]
+  (:render-key (commit-record cell)))
 
 (defn cell-view-id
   "The view id `cell` was minted for (tool/test read) — the stable authoring

--- a/implementation/ui/test/re_frame/ui/reactive_commit_record_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_commit_record_cljs_test.cljc
@@ -1,0 +1,152 @@
+(ns re-frame.ui.reactive-commit-record-cljs-test
+  "rf2-8ds0v (S6 slice a) — the S6 committed-instance record plumbing on the
+  REAL ViewCell commit path (Ruling 1 / Option 1A, honest capture; EP-0033 §Two
+  evidence layers). A CONNECTED commit mints a fresh MODULE-GLOBAL monotonic
+  integer :render-key and publishes the per-commit record onto the cell; a
+  never-committed (speculative) render publishes nothing.
+
+  `.cljc` ending `-cljs-test` rides `npm run test:cljs` (node) AND
+  `clojure -M:test` (JVM), so the record plumbing is graft-checked on both hosts
+  over the plain-atom adapter — the same headless discipline the reconcile
+  fixtures use.
+
+  Scope fence (slice a): this slice mints the record shape ONLY. It emits NO
+  causes (`:rf.view/causes` is a LATER slice), invents NO :parent-render-key
+  (deferred — no capture machinery), and claims NO singular top-level :frame-id
+  (frame attribution is PER-OBSERVATION)."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core                 :as rf]
+            [re-frame.frame                :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.ui.reactive          :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private fid :rf/default)
+
+(defn- seed! [db] (frame/replace-app-db! fid db))
+
+(defn- render!
+  "Simulate one render pass over `sites` (`[[sid query] …]`) under the ambient
+  frame, returning the immutable capture — ownership-free, never committed."
+  [cell sites]
+  (rf/with-frame fid
+    (reactive/with-capture
+      cell
+      (fn [] (mapv (fn [[sid q]] (reactive/sub-read sid q)) sites)))))
+
+(defn- render+commit! [cell sites]
+  (let [[_ cap] (rf/with-frame fid
+                  (reactive/with-capture
+                    cell
+                    (fn [] (mapv (fn [[sid q]] (reactive/sub-read sid q)) sites))))]
+    (reactive/commit! cell cap))
+  cell)
+
+;; ===========================================================================
+;; A connected commit mints the committed-instance record (Ruling 1 shape)
+;; ===========================================================================
+
+(deftest connected-commit-mints-the-committed-instance-record
+  (rf/reg-sub :cr/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (reactive/make-cell ::v)]
+    (is (nil? (reactive/commit-record cell))
+        "a fresh, never-committed cell has no committed-instance record")
+    (render+commit! cell [[[:cr/site 0] [:cr/a]]])
+    (let [record (reactive/commit-record cell)]
+      (is (map? record) "a connected commit publishes a per-commit record")
+      (is (integer? (:render-key record)) ":render-key is an integer")
+      (is (= ::v (:view-id record)) ":view-id is the cell's authoring identity")
+      (is (= 0 (:generation record)) ":generation is the committed body generation")
+      (is (= :connected (:connection record))
+          ":connection is the certified :connected state at a connected commit")
+      (is (vector? (:observations record)) ":observations is a vector")
+      (is (= (reactive/render-key cell) (:render-key record))
+          "the render-key reader mirrors the record's :render-key"))
+    (testing "slice-a scope fences — the record ships NONE of the later slices"
+      (let [record (reactive/commit-record cell)]
+        (is (not (contains? record :parent-render-key))
+            "no :parent-render-key is invented (deferred — no capture machinery)")
+        (is (not (contains? record :frame-id))
+            "no singular top-level :frame-id (attribution is per-observation)")
+        (is (not (contains? record :rf.view/causes))
+            "no causes slot yet (that is a later slice)")))))
+
+;; ===========================================================================
+;; render-key is monotonic, minted fresh PER COMMIT
+;; ===========================================================================
+
+(deftest render-key-increments-monotonically-per-commit
+  (rf/reg-sub :cr/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (reactive/make-cell ::v)
+        keys (mapv (fn [_]
+                     (render+commit! cell [[[:cr/site 0] [:cr/a]]])
+                     (reactive/render-key cell))
+                   (range 3))]
+    (is (every? integer? keys) "every connected commit mints an integer render-key")
+    (is (apply < keys)
+        (str "render-key increments fresh per connected commit — " (pr-str keys)))))
+
+;; ===========================================================================
+;; Observations carry PER-OBSERVATION frame attribution (Ruling-1 amendment)
+;; ===========================================================================
+
+(deftest observations-carry-per-observation-frame-id
+  (rf/reg-sub :cr/a (fn [db _] (:a db)))
+  (rf/reg-sub :cr/b (fn [db _] (:b db)))
+  (seed! {:a 1 :b 2})
+  (let [cell (reactive/make-cell ::v)]
+    ;; First commit builds the nodes; the SECOND render probes them live, so the
+    ;; second record's observations carry the observed node identity + version.
+    (render+commit! cell [[[:cr/site 0] [:cr/a]] [[:cr/site 1] [:cr/b]]])
+    (render+commit! cell [[[:cr/site 0] [:cr/a]] [[:cr/site 1] [:cr/b]]])
+    (let [obs (:observations (reactive/commit-record cell))]
+      (is (= 2 (count obs)) "one observation per rendered site, in render order")
+      (is (= [[:cr/a] [:cr/b]] (mapv :query obs))
+          "observations preserve compiler render order + carry each site's query")
+      (is (every? (fn [o] (= :subscription (:kind o))) obs)
+          "each subscription read is a :subscription observation")
+      (is (every? (fn [o] (= fid (:frame-id o))) obs)
+          "each observation carries its OWN target's frame-id — per-observation
+           attribution, not a single fabricated frame fact")
+      (is (every? :owned? obs)
+          "an owned subscription node lease reports :owned? true")
+      (is (every? (fn [o] (integer? (:target-id o))) obs)
+          "the observed live node identity is captured (:target-id)")
+      (is (every? (fn [o] (integer? (:version o))) obs)
+          "the observed live node version is captured (:version)")
+      (is (= #{fid} (into #{} (map :frame-id) obs))
+          "the frames a cell observes are a SET derived from observations —
+           there is no singular :frame-id on the record"))))
+
+;; ===========================================================================
+;; Speculative renders fabricate no instance (I-1/I-2)
+;; ===========================================================================
+
+(deftest speculative-renders-publish-no-record
+  (rf/reg-sub :cr/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (reactive/make-cell ::v)]
+    (dotimes [_ 100]
+      (render! cell [[[:cr/site 0] [:cr/a]]]))
+    (is (nil? (reactive/commit-record cell))
+        "100 renders that never commit fabricate NO committed-instance record")))
+
+;; ===========================================================================
+;; The render-key source is MODULE-GLOBAL — shared across cells
+;; ===========================================================================
+
+(deftest render-key-is-a-module-global-source-across-cells
+  (rf/reg-sub :cr/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell-a (reactive/make-cell ::a)
+        cell-b (reactive/make-cell ::b)]
+    (render+commit! cell-a [[[:cr/site 0] [:cr/a]]])
+    (render+commit! cell-b [[[:cr/site 0] [:cr/a]]])
+    (is (< (reactive/render-key cell-a) (reactive/render-key cell-b))
+        "two cells draw increasing render-keys from ONE module-global source")))


### PR DESCRIPTION
98.1 slice (a) of the ruled S6 view-evidence schema delta (rf2-vxgfnd.98.1, RULING 1 / Option 1A, honest capture). IMPLEMENTATION-ONLY; ships FIRST (unblocks slices b/c/d). No spec changes here (the normative spec + schema-version bump ride slice d).

## What ships (RULING 1 — Option-1A record shape)

A CONNECTED ViewCell commit now mints an integer `:render-key` and publishes a per-commit **S6 committed-instance record** onto the cell (`:commit-record`):

```clojure
{:render-key  <int>            ; module-global monotonic, fresh per connected commit
 :view-id     <keyword>
 :generation  <int>
 :root-id     <incarnation|nil> ; owning root (tool projection resolves the authored name)
 :connection  :connected        ; the certified three-state model
 :observations [{:kind :subscription|:story-override
                 :frame-id <kw|nil>  ; PER-OBSERVATION frame attribution
                 :query <query-vector>
                 :target-id <int|nil> :version <int|nil> :owned? <bool>} ...]}
```

Ruling-1 ↔ impl:
- **`:render-key`** — minted at connected commit from a module-global monotonic source (`render-key-counter` → `next-render-key!`), fresh each connected commit (re-renders increment it). A total order the `:rf.sub/reader-render-key` sub→view edge and React Performance-Tracks correlate against.
- **per-observation `:frame-id`** — the amended frame attribution; each observation carries its own target's frame-id (pure projection of the already-captured site target + probe evidence). No singular top-level `:frame-id`; a cell observes a set of frames.
- **`:parent-render-key` DEFERRED** — no capture machinery built (no S6 consumer of view parentage).
- **`:observations`** — projected from the committed sites in render order; `:owned?` true for a subscription node lease, false for a static Story override.

## Minting site + erasure

Minted in `commit*` on the connected branch only (after `connect!`, in the non-teardown path) — a stale / superseded / torn-down / never-committed (speculative) render publishes nothing (I-1/I-2). The whole thing is behind `interop/debug-enabled?` at the call site, so it DCEs under `:advanced` + `goog.DEBUG=false` (production erasure, G-7/G-11) and the render-key source never advances — the same gate the invalidation-evidence plane already rides.

New readers: `reactive/commit-record`, `reactive/render-key`.

## Scope fences (slice a only)

- NO causes emitted (`:rf.view/causes` is slice b — the record carries no causes slot).
- NO DOM annotation (slice c).
- NO spec touched (slice d — spec/004, spec/009, EP-0033, S3-profile, schema-version bump).
- NO `:parent-render-key` capture mechanism invented.
- Only `reactive.cljc` + a new dual-host test changed; `viewcell.cljs`/`hooks.cljc` needed no change (the commit happens in `commit*`).

## Quality gates

- `cd implementation/ui && clojure -M:test` — **1022 tests, 19825 assertions, 0 failures, 0 errors** (JVM; +5 new tests).
- `npm run test:cljs` — **10359 tests, 51162 assertions, 0 failures, 0 errors** (cross-artefact).
- New `.cljc` test runs on BOTH hosts over the real observation port + plain-atom adapter: record shape, monotonic render-key increment per commit, per-observation frame-id, speculative-render-publishes-nothing, module-global source across cells, and the slice-a scope-fence negatives (no `:parent-render-key` / no singular `:frame-id` / no `:rf.view/causes`).
- Portability gate (`check-no-hardcoded-paths.sh`) OK.