### PR TITLE
docs(re-frame.ui): complete the guide section

### DIFF
--- a/docs/core/re-frame.ui/custom-elements.md
+++ b/docs/core/re-frame.ui/custom-elements.md
@@ -1,0 +1,59 @@
+# Custom elements
+
+Web components work in templates directly. A tag containing a `-` is a **custom
+element** — a keyword head is always a DOM or custom element, on every host, so
+`[:user-picker {…}]` renders the element itself and is never forced through
+`ui/raw` or mistaken for a view lookup.
+
+The one thing the compiler cannot guess is which prop names are JS **properties**
+(set on the element object) versus **attributes** (written into markup). Declare
+the properties once, at the top level:
+
+```clojure
+(ui/custom-element :user-picker {:properties #{:users :selected-id}})
+
+(ui/defview team-picker [{:keys [users current-id]}]
+  [:user-picker {:users           users
+                 :selected-id     current-id
+                 :placeholder     "Choose…"
+                 :on-picker-close [:team/picker-closed]}])
+```
+
+The rules, in full:
+
+- **Declared names become JS properties**, kebab-case mapped to camelCase
+  (`:selected-id` → `selectedId`) — the same spelling philosophy as the rest of the
+  DOM grammar.
+- **Undeclared names are attributes.** Undeclared *elements* need no declaration at
+  all — an element that only takes attributes works with zero ceremony.
+- `:class`, `:style`, and booleans follow the ordinary DOM rules.
+- The `{:properties #{…}}` map is the entire declaration grammar — the options map
+  is closed.
+- **Events ride the normal handler grammar.** A native custom event
+  (`:on-picker-close` above) takes an event vector like any DOM listener; when the
+  payload lives on `event.detail`, reach for `ui/event`:
+
+```clojure
+[:user-picker {:users users
+               :on-picker-change (ui/event [e]
+                                   [:team/picked (.. e -detail -id)])}]
+```
+
+- **On the JVM / SSR the emitter writes attributes only** — property props are
+  applied at hydration, when a live element object exists to set them on.
+
+## When it goes wrong
+
+| If you write | What you see | The fix |
+|---|---|---|
+| A malformed declaration — a non-set `:properties`, an unknown option | Compile error `:rf.ui.compile/bad-custom-element` | The grammar is `(ui/custom-element tag {:properties #{…}})`, nothing more |
+| Two conflicting declarations for one tag | `:rf.ui.compile/custom-element-conflict` (runtime: `:rf.error/custom-element-conflict`) | One declaration per tag — put it beside the element's interop wrapper |
+
+## When not
+
+- If a wrapper library already exposes the component as a **React** component,
+  embed it as a foreign head (`[TheComponent {…}]`) instead — that boundary and its
+  callback rules live on the [interop page](interop-and-limits.md).
+- And the standing note: `re-frame.ui` is experimental — the retained adapters are
+  the default choice; under Reagent/UIx, custom elements follow those libraries'
+  own interop conventions.

--- a/docs/core/re-frame.ui/events-and-handlers.md
+++ b/docs/core/re-frame.ui/events-and-handlers.md
@@ -1,0 +1,213 @@
+# Events and handlers
+
+The idiomatic handler is not a function. It is the **event vector**:
+
+```clojure
+[:button {:on-click [:cart/add product-id]} "Add to cart"]
+```
+
+Clicked → `[:cart/add product-id]` dispatches to the frame this view runs under.
+Your intent was already data everywhere else in re-frame2
+([Events](../events.md)); the view layer stops converting it to a closure for the
+last ten feet.
+
+> **A handler is data until it can't be** — and each non-data form names exactly
+> what it needs.
+
+Why vectors win, in four lines: they're **readable** (what does this button do? it
+says so — in source, in [Xray](../observability.md) before any click); **testable
+without a DOM** (assert the vector on the JVM tree —
+[Testing](testing.md)); **stale-closure-free** (nothing is captured; the handler
+reads committed values and the committed frame); and **fast** (vectors are values,
+so props stay honestly comparable and memoisation keeps working).
+
+## Payloads: three placeholders
+
+```clojure
+[:input {:on-input  [:form/typed :email :rf.ui/value]}]
+[:input {:type :checkbox :on-change [:prefs/set :dark :rf.ui/checked]}]
+[:div   {:on-key-down [:editor/key :rf.ui/key]}]        ; "Enter", "a", …
+```
+
+`:rf.ui/value`, `:rf.ui/checked`, `:rf.ui/key` — a closed set of three scalars,
+spliced into the vector at dispatch time. There is deliberately no `:rf.ui/event`
+and no `:rf.ui/form-data`: raw events are host objects and form payloads aren't
+data — both cases are what `ui/event` (below) exists for.
+
+**Placeholders work in literal vectors only.** They are compiled, not interpreted:
+a vector forwarded through props dispatches its contents as-is, and dev warns
+(`:rf.warning/placeholder-in-dynamic-vector`) if it spots a placeholder riding one.
+
+DOM listener options use the map form, with an explicit closed vocabulary
+(`:prevent-default`, `:stop-propagation`, `:capture`, `:passive`, `:once`):
+
+```clojure
+[:form {:on-submit {:event [:signup/requested] :prevent-default true}}]
+```
+
+## The live event: `ui/event`
+
+For payloads that need the native event — form contents, files, coordinates,
+filtering — `ui/event` runs a body when the callback fires and dispatches whatever
+event vector the body returns (`nil` means dispatch nothing):
+
+```clojure
+[:input {:on-key-down (ui/event [e]
+                        (when (= "Enter" (.-key e))
+                          [:todo/added item-id]))}]
+```
+
+The callback is per-site stable and sees the view's **committed** values plus the
+live event. When the body is *only* a literal vector, prefer the plain vector
+handler — `ui/event` earns its keep when the payload needs the event or a `nil`
+filter.
+
+## Controlled inputs and the sync door
+
+```clojure
+[:input {:value (sub [:form/email]) :on-input [:form/typed :email :rf.ui/value]}]
+```
+
+works without caret jumps or IME breakage. Where the compiler can *prove* an
+element controlled — a literal `:value`/`:checked` co-present with the handler —
+dispatches from that site drain **synchronously within the DOM event**: input event
+→ drain and commit → React's re-render observes the same value, so React performs
+no restorative DOM write. This is the one sanctioned synchronous door; everything
+else batches. You do not configure it; it is the law of those sites.
+
+Two handler shapes ride the door: a **literal event vector**, and a **synchronous
+`ui/event` whose result is an event vector** (`nil` = no dispatch) — the shape a
+reusable input control uses to append its live payload to an event prefix it
+received through props. A dynamic props map, general `ui/spread`, or a bare-fn
+dispatch at such a site falls back to ordinary batching, and dev tells you so
+(`:rf.ui.compile/controlled-input-async-handler`). Keep controlled fields literal.
+
+A whole form is fields over app-db — one event, one sub, every field; the
+[Build a form](../how-to/build-a-form.md) recipe carries the full pattern.
+**Uncommitted drafts stay in `local`**: when only this view cares until submit,
+hold the draft locally and dispatch on submit — the search-box seam in
+[State](state.md#local-ephemera-local).
+
+## Forwarding intent through components
+
+Parents pass data; the child's site dispatches in its committed frame:
+
+```clojure
+(ui/defview icon-button [{:keys [event label icon]}]
+  [:button {:aria-label label :on-click event}
+   [icon-view {:name icon}]])
+
+[icon-button {:event [:item/deleted item-id] :label "Delete" :icon :trash}]
+```
+
+A library control that cannot know your event grammar takes an **event prefix** and
+appends its payload at dispatch time:
+
+```clojure
+[text-input {:value email :on-value [:form/set-email]}]
+;; inside the control:
+;;   [:input {:value value
+;;            :on-input (ui/event [e] (conj on-value (.. e -target -value)))}]
+```
+
+Three rules keep this honest:
+
+1. Placeholders are never expanded in a vector received through props — build
+   literals at your own DOM sites; hand libraries a prefix.
+2. At a compiler-proven controlled site, the control's synchronous `ui/event`
+   vector result rides the same sync door as a literal vector — the caret/IME
+   guarantee reaches library inputs.
+3. An ordinary fn prop between **internal** views is a legal **opaque value** —
+   identity-compared like any other prop, never invoked by the framework, promising
+   no phase. To opt a fn into a phase, use `ui/handler` (committed, per-site
+   stable) or `ui/render-fn` (pure, during render).
+
+## The decision table
+
+| You need | Write | Notes |
+|---|---|---|
+| Dispatch intent (the 90%) | `[:event … :rf.ui/value]` | data; canonical |
+| The live event — forms, files, filtering | `(ui/event [e] … [:vector …])` | committed values + the event; `nil` filters |
+| Imperative work, stable identity | `(ui/handler [x] …)` | return ignored; foreign change-callbacks, internal fn-prop seams |
+| A callback invoked **while rendering** — a row-key, a cell renderer | `(ui/render-fn [x] …)` | pure; current render; no dispatch/state inside |
+| Quick local work in a **native** `:on-*` | bare `#(…)` | legal there only — shorthand for `ui/handler` |
+| Any callback prop on a **foreign component** | one of the forms above, explicitly | a bare fn there is a compile error |
+| Identity-as-protocol foreign APIs, callback refs | `(ui/raw-fn f)` | passes identity through untouched |
+
+**The phase rule** is why the forms are distinct: event handlers see **committed**
+values (a click on old DOM means old values — coherent with what the user saw);
+render callbacks see the **current** render. One function cannot promise both.
+
+```clojure
+;; ui/handler — a foreign change-callback with stable identity
+[VirtualList {:items rows
+              :on-scroll (ui/handler [offset] (save-scroll! offset))}]
+
+;; ui/render-fn — called while rendering, pure
+[DataGrid {:rows rows
+           :row-key (ui/render-fn [row] (:id row))}]
+```
+
+`ui/render-fn` doubles as the value a library's `ui/slot` seam accepts — the
+[interop page](interop-and-limits.md) covers that library-author territory.
+
+## Lists
+
+A handler that ignores the loop variable is fine inline — `{:on-click
+[:list/refresh]}` is one shared callback and every row can carry it. The moment a
+handler needs the row itself, extract a keyed child view so each row owns its own
+site; a vector that captures the loop binding is a compile error with that fix in
+the message.
+
+## Links that navigate
+
+For in-app navigation, `ui/route-link` is a framework-provided compiled view over
+the optional routing artefact: it renders a **real** `<a href=…>` (copy-link,
+open-in-new-tab, and keyboard activation all work) and, on a plain left click,
+dispatches `:rf.route/url-requested` to the committed frame instead of reloading.
+
+```clojure
+[ui/route-link {:to :orders/show :params {:id order-id}} "Open order"]
+```
+
+Rendering it without `day8/re-frame2-routing` on the classpath fails loud with
+`:rf.error/routing-artefact-missing`; a plain `[:a]` stays available for
+intentional browser-native navigation. The click law and route grammar live in the
+[Routing corpus](../../routing/concepts.md).
+
+## Lifecycle is not an event
+
+There is deliberately no `:on-mount`. React mounts, replays, hides, and restores
+components for mechanical reasons (StrictMode, hidden subtrees, hot reload, error
+recovery) — "the user viewed this" cannot be inferred from them. Dispatch domain
+visibility from domain transitions (a route match, a machine state, the event that
+opened the modal); synchronise with the host world in `effect`
+([State](state.md#the-world-outside-effect-and-dispatch-fn)).
+
+## Safety nets
+
+Every rule on this page fails where you can see it — at build time, or at the
+first dev render. None of them becomes a handler that silently does nothing:
+
+| If you write | What you see | The fix |
+|---|---|---|
+| A typo'd event id — `[:cart/ad id]` | Dev warning `:rf.warning/unregistered-event-id` at render, with the element's file:line | Fix the spelling, or register the event |
+| A placeholder inside a vector received through props | Dev warning `:rf.warning/placeholder-in-dynamic-vector`; the vector dispatches as-is | Build literals at your own DOM sites; hand libraries a prefix |
+| A bare `#(…)` on a **foreign** component's callback prop | Compile error `:rf.ui.compile/bare-fn-prop` | Choose a form from the decision table |
+| A bare fn as `:ref` | Compile error `:rf.ui.compile/bare-fn-ref` | `(ui/raw-fn set-node)` or an object ref |
+| A vector handler that captures the loop binding | Compile error `:rf.ui.compile/loop-capturing-handler` | Extract a keyed child view so each row owns its site |
+| A bare fn inside a loop | Dev warning `:rf.ui.compile/bare-fn-in-loop` — works, at per-row closure cost | Prefer a data handler or a keyed child view |
+| A dynamic props map or `ui/spread` at a controlled input | Dev warning `:rf.ui.compile/controlled-input-async-handler`; the site batches | Keep `:value`/`:checked` and the handler literal |
+
+## When not
+
+- Vectors are the default, not a straitjacket: real imperative work (driving a
+  foreign widget, flipping `local` state) belongs in `ui/handler`, and genuinely
+  event-shaped payloads in `ui/event`. Reaching for them *first* — before a data
+  handler — is the smell.
+- The event *vocabulary* itself — naming, granularity, `dispatch` semantics — is
+  core territory ([Events](../events.md)); this page only changes the spelling at
+  the DOM site.
+- And the standing note: `re-frame.ui` is experimental — the retained adapters are
+  the default choice, where handlers are ordinary closures and this page does not
+  apply.

--- a/docs/core/re-frame.ui/index.md
+++ b/docs/core/re-frame.ui/index.md
@@ -66,11 +66,21 @@ supported, first-class choice.
 
 ## This section
 
+Read the first three in order — they teach the model on a growing counter. The rest
+are depth: open each when the need appears.
+
 | Page | What it covers |
 |---|---|
 | [Mental model](mental-model.md) | The three shifts from Reagent: views compile, `defview` is the one form, and `(sub …)` reads as a value. |
 | [Build a view](build-a-view.md) | A worked walkthrough — `defview`, `sub`, an event, local state, and the mount — built up one step at a time. |
 | [Reactivity and ownership](reactivity-and-ownership.md) | How a compiled view stays reactive, what re-computes when, and why subscriptions never leak. |
+| [State: the four inputs](state.md) | `sub`, props, `local`, and `lease` — the whole state surface, and where each value belongs. |
+| [Events and handlers](events-and-handlers.md) | Handlers as data, the placeholder vocabulary, controlled inputs, and when to escape to `ui/event` / `ui/handler`. |
+| [Custom elements](custom-elements.md) | Web components in templates — the property-vs-attribute declaration. |
+| [Presence: exit animations](presence.md) | `ui/presence` — bounded enter/exit retention, DOM-agnostic, your CSS animates. |
+| [Testing with ui.test](testing.md) | Headless-first view tests on the JVM, mounted tests when the DOM is the point. |
+| [SSR and hydration](ssr.md) | The same views on the server: roots, hydration, the phase flip, `render-static`. |
+| [Interop and the closed grammar](interop-and-limits.md) | Foreign React, the compile-time walls and their escapes, and when *not* to use this substrate. |
 
 New to re-frame2 entirely? Read the [introduction](../introduction.md) and the
 concept pages ([events](../events.md) through [views](../views.md)) first — they

--- a/docs/core/re-frame.ui/interop-and-limits.md
+++ b/docs/core/re-frame.ui/interop-and-limits.md
@@ -1,0 +1,195 @@
+# Interop and the closed grammar
+
+`defview` does not *interpret* hiccup at runtime. It **lowers** the template at
+build time — direct React construction in the browser, a versioned structural tree
+on the JVM — which is what makes the memoisation, the elision, and the tooling
+sound. The price is a **closed template grammar**: anything the compiler cannot see
+through is a build failure, with a message that names the fix, rather than a silent
+runtime surprise.
+
+This page is the honest one. It catalogues what the compiler forbids, the explicit
+doors for when you genuinely need runtime structure, how foreign React fits in, and
+where this substrate is the wrong tool.
+
+## The one-sentence rule
+
+> If the compiler cannot prove the structure, the reactive sites, and the keys of a
+> piece of markup **at compile time**, that spelling is illegal in a `defview` body.
+
+"Prove" means: after normalising the control forms it understands — `let`, `if`,
+`when`, `cond`, `case`, `for`, and friends — every tag head, every `sub`/`lease`
+site, and every list identity is finite and visible. Ordinary branching and binding
+are *free*: both arms of an `if`, every `cond` clause, the body of a `for` all lower
+into the AST, so you are never forced into one linear template.
+
+## Template structure
+
+| You cannot | Why | Do this instead |
+|---|---|---|
+| Dynamic tag heads — `[(if big? :h1 :h2) title]` | The emitter must know the element constructor at compile time | Write both branches, or vary attributes on a fixed tag |
+| Markup-returning `map` — `(map row-view rows)` | Lazy seqs hide keys and reactive sites | `(for [r rows] [row-view {:key …}])`, or a child view |
+| Unkeyed list items in a `for` | List identity is a proof obligation, not a warning | `{:key …}` on every list child — missing key is a **build failure** |
+| Keywords in child position — `[:div :oops]` | Silent-text footguns | Strings, numbers, `nil`/`false`, or nested markup |
+| An app prop named `:key` | `:key` is React's list-identity slot | Rename the prop |
+| Children passed to a view that declares no `:children` | Child acceptance is opt-in and compile-checked | Declare the `:children` binding in that view |
+| `#js` / hand-rolled camelCase on compiled DOM paths | One conversion table serves both emitters | Keyword props; let the compiler convert |
+| Runtime-assembled root forms at `mount` / `render!` / `ui.test/render` | Root identity and frame plans are compile-time contracts | Literal root vectors; wrap multi-view compositions in one `defview` |
+
+## Reactive sites must be finite
+
+Every `(sub …)` and `(lease …)` is a compile-indexed site on the view's single
+React bridge. A `sub` may sit in a branch — it is not a hook — but no site may
+appear inside an unbounded loop, and a `lease` is stricter still: it is a *leading
+declaration*, never an expression. Both fixes are the same shape as
+[State](state.md#when-you-get-it-wrong): extract a keyed child view, or move a
+condition into a `lease` descriptor.
+
+Expression positions — prop values, condition tests, `for` collections — hold
+ordinary Clojure *values*, but their lexical *syntax* is audited so every reactive
+call stays visible. That closes the door on arbitrary macros in those positions: an
+unaudited macro could inject a `sub` the manifest never saw. The accepted set is
+the transparent core forms (`or` `and` `when` `when-not` `cond` `->` `->>` `some->`
+`some->>` `cond->` `cond->>`), the binder forms (`let` `fn` `loop` `letfn` `try`),
+and ordinary function calls; everything else is `:rf.ui.compile/unsupported-form`,
+and the fix is always to move the computation into a plain function or another
+`defview`.
+
+## Foreign React
+
+Real apps embed React that someone else wrote. The doors are explicit and narrow:
+
+```clojure
+[:div (ui/raw badge-element)]              ; a React element a foreign lib handed you
+[DatePicker {:selected date                ; a foreign component as a template head
+             :on-change (ui/handler [v] (pick! v))}]
+```
+
+- **`ui/raw`** embeds an existing React element in child position. It is a
+  boundary, not a template feature.
+- **A foreign component** used as a head takes open props — JS values pass through
+  untouched. Its callbacks pick a form from the
+  [handler decision table](events-and-handlers.md#the-decision-table); a bare fn on
+  a foreign callback prop is a compile error precisely because the compiler can't
+  know the invoker's phase.
+- **`ui/spread`** merges a runtime prop map through the same conversion rule table
+  as the compiler — the one dynamic-map path, its cost visible at the call site.
+  `ui/spread-safe` is its component-library sibling: it forwards a consumer's attr
+  map onto an internal element while barring the structural/controlled keys
+  (`:key` `:ref` `:value` `:checked` and owned handlers) in every build, so a
+  library input keeps its controlled guarantee.
+- **`ui/html`** is the one escaping bypass — visible at the call site, you vouch
+  for the string.
+- **React hooks at a genuine foreign boundary** come from `re-frame.ui.react`
+  (`use-ref`, `use-effect`, `use-context`, …) — thin wrappers, an interop/migration
+  tier. Inside ordinary views you never reach for them: `sub`, `local`, and
+  `effect` are the component story. See the
+  [`re-frame.ui.react` reference](../../api/re-frame.ui.react.md).
+
+### Library render slots
+
+When a reusable view accepts *parameterised markup* — a row renderer, a cell
+template — that markup is a `ui/render-fn` (pure, compiled, renders from its
+arguments alone) and the library invokes it through `ui/slot`:
+
+```clojure
+;; consumer hands the library a pure render callback:
+[data-grid {:rows rows :render-row (ui/render-fn [row] [:td (:name row)])}]
+
+;; inside the library, at the seam:
+(ui/slot render-row row)
+```
+
+This is the middle of the customization taxonomy — data props, then pure render
+slots, then registered stateful views (that last tier is not in v1). A `render-fn`
+body is pure render phase: `sub`/`lease`/`frame` are allowed, but dispatch, hooks,
+state, and effects inside are compile errors — a stateful part is a pure slot body
+that mounts a static `defview` owning its own state.
+
+## Containing a crash: `ui/error-boundary`
+
+A third-party widget or a risky subtree can throw during render. `ui/error-boundary`
+catches render/lifecycle throws *below* it — not event-handler or async errors,
+which keep their own typed paths — so one crash doesn't take the whole page:
+
+```clojure
+[ui/error-boundary {:fallback error-panel
+                    :reset-key route-id
+                    :on-error [:ui/render-failed]}
+ [risky-subtree]]
+```
+
+On catch, the `:fallback` **view** renders with `:error` and its props;
+`:on-error` (optional) dispatches *after* the failing commit through a live frame —
+never during render; and changing `:reset-key` (compared `rf=`) clears the caught
+error, so a retry is just a state change that moves the key. On the server there is
+no boundary recovery — a throw follows the server failure policy ([SSR](ssr.md)).
+Bad opts or a non-view fallback fail loud at compile time
+(`:rf.ui.compile/bad-error-boundary`).
+
+## Genuinely data-driven UI
+
+For CMS trees or server-defined form schemas — markup whose *shape* is data, not
+source — the answer is an explicit interpreter, opt-in with a visible cost. That
+interpreter (`re-frame.ui.data`) is a **planned wave-2 artefact and does not ship in
+v1**; until it lands, a runtime-chosen foreign head goes through `ui/raw` of an
+element you construct. If an escape starts to look like the main path through your
+app, the design is probably wrong for this substrate — you want a foreign React
+island behind a thin `ui/raw` boundary, not a `defview` full of runtime structure.
+
+## The doors, at a glance
+
+| Need | Door | Notes |
+|---|---|---|
+| A React element a foreign lib already built | `ui/raw` | Boundary, not a template feature |
+| Dynamic prop maps | `ui/spread` / `ui/spread-safe` | Runtime conversion on the compiler's own rule table |
+| Unescaped HTML you vouch for | `ui/html` | Explicit at the call site |
+| Host-only leaf under SSR | `ui/client-only` | Fallback is plain markup — [SSR](ssr.md) |
+| Parameterised markup for a library | `ui/render-fn` + `ui/slot` | Pure; compiled; no runtime hiccup |
+| A hook at a foreign boundary | `re-frame.ui.react/*` | Interop tier — not for ordinary views |
+| Logic the template must not see | An ordinary function, or another `defview` | The preferred recovery for an unsupported form |
+
+## How errors show up
+
+- **Build time** for structure and site rules — dynamic heads, loops, missing
+  keys, unsupported forms, missing required props on literal call sites. Messages
+  name the fix and usually carry file:line.
+- **First dev render** for what only a live value can prove — a schema failure on
+  dynamic props, an unknown event id, a dynamic child that turns out to be a
+  keyword.
+- **Production** never re-teaches you: the illegal form never compiled. Greppable
+  ids like `:rf.ui.compile/unsupported-form` and `:rf.ui.compile/dynamic-head` are
+  part of the contract.
+
+## Planned and absent surfaces
+
+Honesty about what is *not* here yet, so you don't hunt for it:
+
+- **`ui/->react`** — export a view as a React component for incremental migration
+  into a React codebase. **Planned for a later stage; not shipped.** Don't build
+  against it today.
+- **`ui/element`, `ui/view`, `ui/portal`, `re-frame.ui.data/render`** — a
+  runtime-chosen head, a registry-addressed component, a portal, the data
+  interpreter. **Wave-2: not in v1**, gated behind demand. `ui/raw` covers
+  runtime-chosen heads in the meantime.
+
+The authoritative roster of what exists lives in the
+[`re-frame.ui` API reference](../../api/re-frame.ui.md).
+
+## When not to use this substrate at all
+
+The closed grammar is the bill for the machinery. Weigh it honestly:
+
+- **You need runtime-shaped markup as the norm** — a CMS renderer, a form engine
+  driven by server schemas. The escapes exist, but if they're your main path, an
+  interpreter (or a foreign React island) fits better.
+- **You have a large existing Reagent or re-com application** and no appetite to
+  migrate the view tier now. The dataflow half is already shared; the views can
+  stay.
+- **You want stable ground today.** `re-frame.ui` is pre-alpha, delivered in
+  staged slices, and not on Clojars yet.
+
+In every one of those cases the answer is the same, and it bears repeating as this
+guide's standing note: **the retained adapters — Reagent, reagent-slim, UIx — are
+the default choice.** They are first-class and actively supported, not a fallback.
+Choosing one is a supported decision, and the dataflow you learned in the
+[core guide](../introduction.md) works identically behind all of them.

--- a/docs/core/re-frame.ui/mental-model.md
+++ b/docs/core/re-frame.ui/mental-model.md
@@ -108,7 +108,8 @@ placeholders don't cover, or to decide whether to dispatch at all — reach for
 
 And for imperative work that dispatches nothing — driving a foreign widget,
 flipping local state — there's `ui/handler`. The guiding rule: **a handler is
-data until it can't be**, and each non-data form names exactly what it needs.
+data until it can't be**, and each non-data form names exactly what it needs. The
+[events and handlers page](events-and-handlers.md) walks the full decision table.
 
 ## State and lifecycle are body forms
 
@@ -123,6 +124,7 @@ four explicit body forms rather than a component-shape change:
 | `frame` | The committed-frame ops bundle, for the rare imperative or foreign-callback case. |
 
 The [build-a-view walkthrough](build-a-view.md) uses `local` and an event; the
+[state page](state.md) takes all four inputs in turn, and the
 [reactivity page](reactivity-and-ownership.md) explains why `local` sits outside
 re-frame2's epochs and app-db does not.
 

--- a/docs/core/re-frame.ui/presence.md
+++ b/docs/core/re-frame.ui/presence.md
@@ -1,0 +1,58 @@
+# Presence: exit animations
+
+When state says an element is gone, React removes it instantly. Toasts want to
+slide out; modals want to fade. `ui/presence` owns the gap between *no longer
+true* and *no longer visible* — and nothing more. It is deliberately **not** an
+animation system: it retains exiting children for a bounded time and tells each
+child what phase it is in; the animating is your CSS's job.
+
+```clojure
+(ui/defview toast-card [{:keys [toast]}]
+  (let [phase (ui/presence-phase)]         ; :mounting | :present | :unmounting
+    [:div.toast {:class (name phase)}
+     (:message toast)]))
+
+(ui/defview toast-tray []
+  (ui/presence {:timeout-ms 300}
+    (for [t (sub [:toasts/visible])]
+      [toast-card {:key (:id t) :toast t}])))
+```
+
+How it behaves:
+
+- Keyed children pass through `:mounting` → `:present` → `:unmounting`. A removed
+  child keeps rendering as `:unmounting` for **exactly `:timeout-ms`**, then
+  removal is terminal and exactly-once — subscriptions and leases released. The
+  timeout is the mandatory exit retention duration *and* the terminal bound; the
+  boundary watches no transition events, so make it match (or exceed) your CSS
+  transition time.
+- `(ui/presence-phase)` is the single phase read. Outside any presence boundary it
+  returns `:present`, so presence-aware children stay reusable anywhere.
+- Removing then re-inserting a key interrupts the exit and re-enters
+  deterministically.
+- The boundary is **DOM-agnostic**: it inserts no wrapper node, stamps no
+  attributes, and observes no DOM events. The child owns its own exit styling *and*
+  accessibility — stamp `inert` / `aria-hidden` and the exit class when its phase is
+  `:unmounting`, and let its stylesheet honour `prefers-reduced-motion`.
+- On the JVM / SSR there is no lifecycle to retain: the structural render yields
+  `:present`.
+
+In tests, transitions advance on a fake clock with `ui.test/flush-presence!` —
+never a wall-clock sleep ([Testing](testing.md#tier-3--mounted-tests-when-the-dom-is-the-point)).
+
+## When it goes wrong
+
+| If you write | What you see | The fix |
+|---|---|---|
+| `presence` without `:timeout-ms` (or a non-positive one) | Compile error `:rf.ui.compile/bad-presence` | The timeout is mandatory — it is the terminal bound |
+| An unkeyed child under the boundary | Compile error `:rf.ui.compile/presence-unkeyed-child` | Give each child a stable `{:key …}` |
+
+## When not
+
+- Most removals need no exit animation. Reach for `presence` when a design
+  genuinely calls for one — not as a default wrapper around every list.
+- Anything beyond enter/exit retention — springs, orchestrated sequences, layout
+  animation — is a foreign animation library's job, embedded at an explicit interop
+  boundary ([Interop and the closed grammar](interop-and-limits.md)).
+- And the standing note: `re-frame.ui` is experimental — the retained adapters are
+  the default choice, with the React ecosystem's own transition tooling.

--- a/docs/core/re-frame.ui/ssr.md
+++ b/docs/core/re-frame.ui/ssr.md
@@ -1,0 +1,153 @@
+# SSR and hydration
+
+A compiled `defview` renders on the JVM as readily as in the browser: the same
+template lowers to a versioned structural tree there, and the SSR artefact folds
+that tree to HTML. This page covers what the **view layer** owns — what renders on
+a server, root identity, hydration, and the client-only escape. The server side of
+the story — requests, payloads, responses, streaming — is the
+[SSR corpus](../../ssr/index.md); this page points rather than repeats.
+
+## What renders on the server
+
+The JVM render is the *structural subset* — full semantics where rendering is
+pure, honest fallbacks where only a browser could answer:
+
+| Full semantics | Honest fallbacks |
+|---|---|
+| Structure, props, branches, keyed lists | `local` → its initial value |
+| Subscriptions (pure snapshot reads) | effects do not run; refs are absent |
+| Event intent — vectors ride the tree as data | `client-only` → its declared fallback |
+| `ui/html` | presence → `:present` |
+| | error boundaries render the child — server failure policy applies |
+
+A view that *is* its host behaviour (a canvas chart, a map) wraps the leaf in
+`ui/client-only` and keeps the shared markup outside.
+
+## Roots and frames — two different things
+
+A **root** is one React unit in one DOM container. A **frame** is one re-frame2
+state world ([Frames](../frames.md)). A page can have several of each, and they mix
+freely — two roots can reference one shared frame; one root can scope several.
+
+Every root has a **root-id**. You usually write none: a single-root page derives it
+from the mounted view's registered id — the [Build a view](build-a-view.md) counter
+path, zero ceremony. Author identity the moment a page outgrows that:
+
+```clojure
+(ui/mount [ui/frame-root {:id :shop} [product-panel]] left-el
+          {:root-id :panel/left})
+(ui/mount [ui/frame-root {:id :shop} [product-panel]] right-el
+          {:root-id :panel/right})
+```
+
+- The same view mounted twice with neither site authored fails loud with
+  `:rf.error/duplicate-root-id` — at build time where both sites are visible, and
+  at runtime *before any render*.
+- Identity opts (`:root-id`, `:disambiguator`, `:identifier-prefix`) are
+  compile-time literals; the opts map also carries plain-fn host error callbacks
+  (`:on-uncaught-error`, …).
+- Root forms are **literal** at every entry point — `mount`, `render!`,
+  `hydrate-root`, `render-static`, and `ui.test/render` alike. A runtime-assembled
+  vector is the compile error `:rf.ui.compile/runtime-root-form`.
+
+Hosts needing more control than `mount` use the host tier directly —
+`create-root` (identity without rendering; authored `:root-id` required),
+`render!` (re-render a literal form into a Root), and `unmount!` (total teardown).
+`mount` is exactly `create-root` + frame preflight + `render!`, one-shot and
+idempotent per root — mounting again with the same id and container re-renders in
+place, which is the hot-reload path.
+
+## Hydration
+
+A server-rendered page boots on the client in **two calls**: install the state
+payload, then adopt the DOM.
+
+```clojure
+(ssr/hydrate! {:frame :app :payload payload})   ; state only — no :render-tree-fn
+(ui/hydrate-root (js/document.getElementById "root")
+                 [ui/frame-provider {:frame :app} [app-root]])
+```
+
+Two rules with no exceptions:
+
+- **Identity comes from the server's manifest**, never from client opts — passing
+  `:root-id` or `:identifier-prefix` to `hydrate-root` is an error, and a hydrate
+  with no valid manifest fails loud with `:rf.error/root-manifest-invalid`. The
+  server decided; the client matches or fails loudly.
+- **Roots hydrate independently.** Each root ships its own manifest; frame
+  payloads install idempotently (if two roots reference `:session`, whichever
+  hydrates first installs it, the other finds it live); and a root that fails to
+  boot (`:rf.error/root-boot-failed`) leaves its server markup standing, inert,
+  without touching its neighbours.
+
+**How mismatches surface.** A compiled root verifies by *React-native adoption*:
+React diffs the root's first server-phase render against the server DOM, and the
+recoverable divergences it patches — divergent text, a missing or extra element —
+surface as a dev-only `:rf.ssr/hydration-mismatch` diagnostic (composed over any
+`:on-recoverable-error` you pass, never replacing it). React has already recovered
+by the time the diagnostic fires, so it is a signal to fix the drift, not a crash.
+One honest limit: **attribute-only** mismatches — a stale `class` or ARIA value on
+an element whose tag and text still match — take React's development-only warning
+path and produce **no** trace, by design. The walkthrough, including the hiccup
+substrates' hash-based tier, is the [SSR tutorial](../../ssr/tutorial.md).
+
+## Browser-only subtrees: `client-only` and the phase flip
+
+```clojure
+(ui/client-only {:fallback [:div.map-shell "Map loads in the browser"]}
+  [MapboxView {:center center}])
+```
+
+The fallback is **mandatory and capability-free** — plain markup, compiler-checked
+(`:rf.ui.compile/capability-in-fallback` otherwise) — because it renders three
+times over: on the JVM, and on the client's *first* hydration pass, so React adopts
+markup structurally identical to the server's.
+
+After a hydrating root's first commit, the runtime flips that root from its
+`:server` phase to `:client` — **once per root, as one root-scoped write** — and
+every `client-only` site under it swaps to its client subtree in that single
+update. There is no per-site flip and no page-wide barrier: each root flips when
+its own hydration commits, and a failed root never flips (its fallback markup is
+exactly the part designed to stand without a runtime). Non-hydrating mounts are
+born in `:client` phase and never flip — a `client-only` site under plain
+`ui/mount` just renders its client subtree.
+
+## Static output is a decision, not a guess
+
+A root with no client capabilities can ship as inert HTML — no manifest, no
+payload, no hydration, no phase flip — but only when you say so:
+
+```clojure
+(ui/render-static [site-footer {:year 2026}])   ; ⇒ an HTML string
+```
+
+`ui/render-static` is a **macro, JVM/server only** (a CLJS expansion is a compile
+error). It enforces the same literal root form as the other entry points, and the
+compiler proves the tree needs no client runtime — declaring static something that
+is not fails the build (`:rf.ui.compile/static-root-requires-runtime`). Nothing is
+silently stripped by inference. The HTML folding itself lives in the SSR artefact
+(`re-frame.ssr/emit-ui-tree`), which `render-static` reaches by late resolution —
+calling it without `day8/re-frame2-ssr` on the classpath fails loud with
+`:rf.error/ssr-artefact-missing`.
+
+## When it goes wrong
+
+| Symptom | Named error | Fix |
+|---|---|---|
+| Hydrating with client identity opts, or no valid server manifest | `:rf.error/root-manifest-invalid` | Let the manifest own identity; check the server actually emitted one |
+| Two roots deriving the same id | `:rf.error/duplicate-root-id` | Author `:root-id` (or `:disambiguator`) at each site |
+| A root's boot throws | `:rf.error/root-boot-failed` — that root only; siblings unaffected | Read the dev diagnostic; the server markup stays standing |
+| Text/structural drift between server and client render | Dev diagnostic `:rf.ssr/hydration-mismatch`; React patches the DOM | Make the first client render match the server's — usually a `client-only` fallback that drifted |
+| `render-static` on a tree that needs a client runtime | Compile error `:rf.ui.compile/static-root-requires-runtime` | Hydrate it instead, or push the capability behind `client-only` |
+| `render-static` without the SSR artefact | `:rf.error/ssr-artefact-missing` | Add `day8/re-frame2-ssr` to the server classpath |
+
+## When not
+
+- A page with no server rendering needs nothing on this page — `ui/mount` and the
+  [boot recipe](../how-to/boot-and-mount-an-app.md) are the whole story.
+- Request handling, payload allowlists, response control, streaming, and the head
+  grammar are the [SSR corpus](../../ssr/concepts.md)'s territory — don't rebuild
+  them from view-layer parts.
+- And the standing note: `re-frame.ui` is experimental — the retained adapters are
+  the default choice, and their SSR path (the hash-verified hiccup tier) is covered
+  by the same SSR corpus.

--- a/docs/core/re-frame.ui/state.md
+++ b/docs/core/re-frame.ui/state.md
@@ -1,0 +1,220 @@
+# State: the four inputs
+
+A view has **four inputs**, each with exactly one spelling:
+
+| Question | Answer |
+|---|---|
+| Shared application state? | `(sub [:query …])` |
+| Given by my parent? | props |
+| Ephemeral, mine, gone on unmount? | `(ui/local initial)` |
+| Keep a resource alive while I'm visible? | `(ui/lease descriptor)` |
+
+There is no fifth — and that is the feature. No ratoms, cursors, reactions, or
+external stores. State that matters lives in [app-db](../app-db.md), where events,
+time-travel, and [Xray](../observability.md) can all see it.
+
+Start with `sub` and props: most views want nothing else. The sections below take
+each input in turn, then add `effect` and `dispatch-fn` for the times a view must
+reach the world outside the tree.
+
+## Shared state: `sub`
+
+```clojure
+(ui/defview order-summary [{:keys [order-id]}]
+  (let [order (sub [:orders/by-id order-id])
+        total (sub [:orders/total order-id])]
+    [:div
+     [:h3 (:title order)]
+     [:strong (str "$" total)]]))
+```
+
+- `(sub …)` returns the **current value** and re-renders this view when it changes —
+  the contract the [reactivity page](reactivity-and-ownership.md) unpacks.
+- Parametric queries just work: when `order-id` changes, the old target releases and
+  the new one acquires atomically. You never see order A's data against order B's id,
+  even for one frame.
+- **Conditional reads are legal.** `sub` is not a hook — a collapsed row that reads
+  nothing genuinely subscribes to nothing:
+
+```clojure
+(let [details (when expanded? (sub [:orders/details id]))] …)   ; fine
+```
+
+The *one* restriction is loops: a `(sub …)` inside `(for …)` is a compile error,
+because a view's read sites must be finite. The fix is the natural factoring —
+a keyed child view that subscribes for one row:
+
+```clojure
+(ui/defview order-row [{:keys [id]}]
+  [:li (:title (sub [:orders/by-id id]))])
+
+(ui/defview order-list []
+  [:ul (for [id (sub [:orders/visible-ids])]
+         [order-row {:key id :id id}])])
+```
+
+Keep real computation in `rf/reg-sub` — shared, cached, visible to tools, and
+testable on the JVM ([Subscriptions](../subscriptions.md)). Views do presentation
+math only. Outside a view — in a test or a tool — use core's `rf/subscribe`;
+`(sub …)` is a view form and fails loudly anywhere else.
+
+## Props
+
+Props arrive as one map, destructured in the header, and are compared **by value,
+per slot** to decide re-renders — the memoisation story from the
+[mental model](mental-model.md).
+
+- Prefer named slots (`:keys`) over `:as` — `:as` materialises the whole map and
+  switches the view to generic comparison, a visible dev cost.
+- Children arrive as `:children`; declaring that binding is what opts a view into
+  accepting them. Passing children to a view that never declared them is a compile
+  error.
+- `:key` is reserved for React's list-identity slot — it is never one of your own
+  props.
+
+## Local ephemera: `local`
+
+Some state has no business in app-db: uncommitted field text, an open/closed
+disclosure, a hover flag. That is `local` — host component-local state that lives
+**outside** re-frame2's epochs, is invisible to subs and tools, and re-renders only
+this view.
+
+```clojure
+(ui/defview search-box []
+  (let [[text set-text] (ui/local "")]
+    [:div.search
+     [:input {:value text
+              :on-input (ui/event [e] (set-text (.. e -target -value)) nil)}]
+     [:button {:on-click [:search/run text]} "Search"]]))
+```
+
+`(ui/local initial)` returns a **three-tuple** `[value set! update!]`; two-element
+destructuring, as above, stays valid when you don't need the updater.
+
+- `set!` stores its argument **exactly** — a stored function is a value, never a
+  React-style updater.
+- `update!` applies `(f current & args)` to the **latest** host state, so several
+  same-turn writers (a key handler, a pointer handler, a timer) compose instead of
+  losing writes.
+- Both are **host-only**: call them from a committed handler or an `effect`
+  callback, never during render.
+
+Note the seam in the search box: the *keystroke* stays local; the *intent*
+(`[:search/run text]`) is data — the moment the draft crosses into an event vector
+is exactly the moment it becomes product state. When another view must react to
+every keystroke, the keystroke already *is* product state — skip `local` and
+dispatch placeholders instead:
+
+```clojure
+[:input {:value (sub [:form/email]) :on-input [:form/typed :email :rf.ui/value]}]
+```
+
+`local` is **forbidden** for anything needing cross-view observation, replay,
+persistence, schema or tool inspection, or subscription-derived computation — a
+loading flag is the classic offender. When in doubt, prefer app-db: a value wrongly
+kept local is invisible to tools and unrecoverable on replay; a value in app-db that
+turns out never to be read is merely slightly verbose. The
+[Where should this value live?](../where-state-lives.md) page walks the fuller
+decision.
+
+## The world outside: `effect` and `dispatch-fn`
+
+`effect` synchronises with the host world — DOM measurement, a chart or animation
+library attached through a ref. Never app logic; that is events and
+[effects](../effects.md).
+
+```clojure
+(ui/defview chart [{:keys [series]}]
+  (let [[node set-node] (ui/local nil)]
+    (ui/effect [node series]              ; value deps, compared by rf=
+      (when node
+        (draw! node series)
+        #(destroy! node)))                ; optional cleanup fn
+    [:canvas {:ref (ui/raw-fn set-node)}]))
+```
+
+Deps are **values** — a rebuilt-but-equal vector is the same dep. No identity
+traps, no `useCallback`, no stale closures. The returned cleanup runs on dep
+change, disconnect, and unmount; StrictMode's dev replay is expected, and cleanup
+is what makes it harmless.
+
+- `(ui/effect :connect body)` runs at each connect (mount, or reveal after a hide)
+  with cleanup at each disconnect. There is deliberately no "once" or "mount" name
+  in a lifecycle React can replay.
+- To dispatch from an effect or a foreign callback, capture `(ui/dispatch-fn)` in
+  the view body: one **stable** function per view instance, bound to the committed
+  frame, and loud if called after the view disconnects — a leaked listener becomes
+  an error you see, not a dispatch into the void.
+
+```clojure
+(ui/defview media-bridge [{:keys [stream-id]}]
+  (let [dispatch! (ui/dispatch-fn)]
+    (ui/effect [stream-id]
+      (let [stop (listen! stream-id #(dispatch! [:stream/sample %]))]
+        stop))
+    [:div.bridge]))
+```
+
+For the rare case that needs more than dispatch, `(ui/frame)` returns the
+committed-frame ops bundle (`:frame` / `:dispatch` / `:dispatch-sync` /
+`:subscribe`) — the same shape core's `capture-frame` gives you outside views. Exact
+contract in the [API reference](../../api/re-frame.ui.md).
+
+## Resource liveness: `lease`
+
+```clojure
+(ui/defview latency-tile []
+  (ui/lease {:resource :metrics/latency-feed})
+  (let [{:keys [status data]} (sub [:rf/resource {:resource :metrics/latency-feed}])]
+    (case status
+      (:idle :loading) [:div.tile.skeleton "…"]
+      :error   [:div.tile.error "Feed unavailable"]
+      ;; :loaded — and :fetching, which keeps prior data visible mid-refresh
+      [:div.tile [:h3 "p95 latency"] [:strong (str (:p95 data) "ms")]])))
+```
+
+`lease` declares *interest*: while this view is mounted and visible, keep the
+resource alive. First lease in → the resource is ensured (fetch starts, or joins an
+in-flight one); last lease out → it can wind down. **Lease never returns data and
+never fetches during render** — the load is a consequence of the view's committed,
+visible presence, and reading is always the passive `(sub [:rf/resource …])`.
+
+A `lease` is a *leading declaration*, not an expression — it sits before the
+template, never inside a `when`, a prop, or a loop. Conditional liveness moves into
+the descriptor, which may evaluate to `nil` (lease nothing):
+
+```clojure
+(ui/lease (when live? {:resource :metrics/latency-feed}))
+```
+
+Rule of thumb: loading that belongs to navigation or workflow rides route/event
+resource plans; `lease` is for liveness that genuinely follows visible UI —
+dashboard tiles, hover cards, modals. The resource system itself — registration,
+caching, refetch, the transport — is the [Resources corpus](../../resources/concepts.md);
+nothing on this page fetches.
+
+## When you get it wrong
+
+The four inputs have few rules, and the ones they have fail where you can see them:
+
+| If you write | What you see | The fix |
+|---|---|---|
+| `(sub …)` inside a `for` | Compile error `:rf.ui.compile/sub-in-loop` | Extract a keyed child view that subscribes for one row |
+| `lease` in expression position — inside a `when`, a prop, a template | Compile error `:rf.ui.compile/unsupported-form` | Move the condition into the descriptor: `(ui/lease (when live? descriptor))` |
+| `lease` inside a loop | Compile error `:rf.ui.compile/lease-in-loop` | Extract a keyed child view; each child leases its own resource |
+| `local` / `effect` below a branch or inside a loop | Compile error `:rf.ui.compile/hook-misplaced` | Keep them in the view's unconditional top region |
+| `set!` / `update!` during render | Loud error `:rf.error/ui-tree-malformed` naming the render-phase mutation | Call setters from a committed handler or an `effect` callback |
+| `(ui/dispatch-fn)` called after the view disconnected | Loud error `:rf.error/dispatch-disconnected` | Return a cleanup fn from the `effect` so the listener is removed |
+| A `sub` with no frame above the view | `:rf.error/no-frame-context` | Mount under `frame-root`, or scope with `frame-provider` |
+
+## When not
+
+- State with product meaning goes to **app-db behind events** — the default. Reach
+  for `local` only for keystroke-latency ephemera, and for `lease` only when
+  liveness genuinely follows visible UI.
+- `effect` is for the host world, not app logic — fetching in an `effect` bypasses
+  events, epochs, and every tool that watches them.
+- And the standing note for this whole section: `re-frame.ui` is experimental. The
+  retained adapters (Reagent, reagent-slim, UIx) are the default choice, and this
+  same state discipline — app-db, events, narrow subscriptions — applies there
+  unchanged.

--- a/docs/core/re-frame.ui/testing.md
+++ b/docs/core/re-frame.ui/testing.md
@@ -1,0 +1,180 @@
+# Testing with ui.test
+
+Views here are pure functions whose interaction surface is data — so most UI
+testing needs no DOM, no browser, and no flake. `re-frame.ui.test` has two tiers
+that share nothing; work down the list and stop at the first tier that answers
+your question.
+
+**Tier 1 — headless — is the daily driver.** Tier 2 is unchanged re-frame2
+dataflow testing. Tier 3 is for when the DOM itself is under test. Exact
+signatures for everything below live in the
+[`re-frame.ui.test` API reference](../../api/re-frame.ui.test.md).
+
+## Test namespace setup
+
+`rf/make-frame` needs an installed substrate adapter. Install one once through the
+reset fixture, and keep the ambient frame clear because each test owns its own
+throwaway frame:
+
+```clojure
+(ns shop.ui-test
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui.test :as ui.test]
+            [shop.ui :as app]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :ambient-frame nil}))
+```
+
+`plain-atom` is the headless JVM adapter for these tests, not a second view
+programming model. In a mounted CLJS test namespace, use the same fixture with
+`ui/adapter` and `:async? true`.
+
+## Tier 1 — headless view tests
+
+`ui.test/render` runs the real view against a real frame **on the JVM** — real
+subscriptions, real registrations, no React — and returns the versioned structural
+tree, which is plain data:
+
+```clojure
+(deftest add-button-carries-intent
+  (rf/with-new-frame
+    [frame (rf/make-frame {:initial-events [[:rf/set-db {:cart #{}}]]})]
+    (let [tree (ui.test/render [app/product-card {:product (product 42)}]
+                               {:frame frame})]
+      (is (= [:cart/add 42] (-> tree (ui.test/find :button) ui.test/attrs :on-click)))
+      (is (= "Add to cart"  (-> tree (ui.test/find :button) ui.test/text))))))
+```
+
+Because handlers are event vectors, "what does this button do" is an equality
+check — no click simulation, no event mocking.
+
+**Selectors are a small closed grammar:**
+
+```clojure
+(ui.test/find tree :button)                 ; unqualified keyword — element tag
+(ui.test/find tree :shop/product-card)      ; qualified keyword — a view id (or the Var)
+(ui.test/find tree {:data-testid "save"})   ; attr map — every entry matches, by value
+(ui.test/find-all tree :li)                 ; all matches, in document order
+```
+
+Attr-map values compare by `rf=`, and handler slots hold event vectors as data —
+so `{:on-click [:cart/add 42]}` finds a button by its *intent*. A predicate fn is
+the escape for anything the data forms cannot say. `find` returns the node or
+`nil`, and a found node is itself a valid tree, so finds compose.
+
+**Reads go through projections.** Use `(ui.test/attrs node)` and
+`(ui.test/text node)`. Never keyword-look-up an attribute on a node — `(:on-click
+node)` reads a node *field* that is not there and silently misses.
+
+**Drive state with real events:**
+
+```clojure
+(ui.test/dispatch! frame [:cart/add 42])
+```
+
+`dispatch!` takes the frame (value or id) and the event: a real dispatch plus a
+drain to fixed point — then re-render and assert. Loading and error states are
+app-db values you install or events you dispatch. When you need to pin a
+presentation state directly, stub a sub:
+
+```clojure
+(ui.test/render [app/cart-badge] {:frame frame
+                                  :sub-overrides {[:cart/locked?] true}})
+```
+
+**One constructor, one grammar.** There is no test-only way to make a frame:
+`rf/make-frame` with `:initial-events`, exactly like production. Seed with
+`[:rf/set-db {…}]` — or better, run your app's own init events so fixtures cannot
+drift from a state the real app can reach. `rf/with-new-frame` destroys the
+caller-owned frame after the body returns or throws. `render` also accepts a
+**literal root form** (the same grammar `ui/mount` takes), and a test root mounts
+exactly one view — wrap multi-view compositions in one `defview`.
+
+**Two ground rules:**
+
+1. Events and subs your view touches must be `.cljc` — they run on the JVM here.
+2. Tier 1 renders the *structural subset*: `local` shows its initial value
+   (calling its setter is a typed error pointing at Tier 3), effects do not run,
+   refs are absent. State transitions and host behaviour are Tier-3 subjects by
+   design.
+
+These run in your JVM watch loop in milliseconds and never flake on timing.
+
+## Tier 2 — dataflow tests
+
+Handlers, subs, machines, fx: test them as the pure functions they are. The view
+tier assumes this tier exists — do not test business logic through views. See the
+[core testing guide](../testing/index.md).
+
+## Tier 3 — mounted tests, when the DOM is the point
+
+For focus, IME, foreign widgets — things only a real mount exercises — use
+`with-root`, `query`, and `flush!` in a browser/jsdom test namespace.
+
+```clojure
+(deftest count-updates-in-the-dom
+  (async done
+    (-> (ui.test/with-root [root [ui/frame-root {:id :app
+                                                 :initial-events [[:app/init]]}
+                                  [app/counter]]]
+          (-> (ui.test/flush! #(ui.test/dispatch! :app [:count/inc]))
+              (.then (fn []
+                       (is (= "1" (.-textContent (ui.test/query root ".count"))))))))
+        (.then (fn [_] (done))
+               (fn [e] (is false (str e)) (done))))))
+```
+
+- `with-root` owns one real React mount with total teardown on every exit, and
+  returns a Promise — **await it** before asserting or starting another mounted
+  operation.
+- `query` answers a **native CSS selector** against the mounted DOM — the Tier-3
+  counterpart of `find`, sharing nothing with the Tier-1 grammar.
+- When a test *writes*, put the write inside `flush!`'s thunk: it runs inside
+  React `act`, and the returned Promise settles when framework and React reach a
+  fixed point. There is no second flush idiom, no `setTimeout` settle, and no
+  "wait a tick" folklore.
+- Native DOM mechanics that are already host-owned — focus, selection, a foreign
+  component's raw callback — use ordinary platform APIs. There is no library
+  gesture language.
+
+Presence transitions advance with `ui.test/flush-presence!`, the
+[presence](presence.md) twin of `flush!` — a fake clock, never a wall-clock sleep.
+The zero-arity form advances to quiescence, firing every pending exit;
+`(flush-presence! ms)` advances the logical clock by `ms` and fires only the exits
+that come due. On the JVM both arities are a no-op (the structural render has no
+lifecycle), so a `.cljc` test body calls them on either host.
+
+## What you can trust without testing it yourself
+
+The substrate's own CI pins ownership under concurrent React, browser/JVM tree
+parity, dev/prod behavioural equivalence, bundle absence, and performance budgets.
+Your tests cover *your* app; they get to assume the substrate. (For tooling and
+agents, the dev-only `re-frame.ui.tool` namespace exposes the same evidence Xray
+reads — view manifests, mounted views, render explanations.)
+
+## When it goes wrong
+
+| If you write | What you see | The fix |
+|---|---|---|
+| A CSS string to `find`, or a structural tree to `query` | Typed error `:rf.error/ui-test-tier-mismatch` naming the other tier | Tier 1 speaks data selectors; Tier 3 speaks CSS |
+| A second mounted operation before the first settles | `:rf.error/ui-test-overlapping-act` | Await every `with-root` / `flush!` Promise |
+| `flush!` inside an open event drain | `:rf.error/flush-in-open-epoch` | Flush after the dispatch, not from inside a handler |
+| An unsupported selector value | `:rf.error/ui-test-bad-selector` naming the closed grammar | Keyword, view id/Var, attr map, or predicate fn |
+
+## Rules of thumb
+
+- If you are simulating a click to check a dispatch, assert the vector on the tree
+  instead — Tier 1. Simulate interactions only when the DOM mechanics are under
+  test.
+- If a view is hard to set up, it is reading too much — narrow its subs. That is a
+  design smell surfacing in the test, which is the point of tests.
+- When not: business logic belongs in Tier-2 dataflow tests, and on the retained
+  adapters — the default, non-experimental choice — view testing goes through the
+  hiccup helpers in the [core testing guide](../testing/views.md) instead of
+  `ui.test`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -198,6 +198,13 @@ nav:
       - "Mental model": core/re-frame.ui/mental-model.md
       - "Build a view": core/re-frame.ui/build-a-view.md
       - "Reactivity and ownership": core/re-frame.ui/reactivity-and-ownership.md
+      - "State: the four inputs": core/re-frame.ui/state.md
+      - "Events and handlers": core/re-frame.ui/events-and-handlers.md
+      - "Custom elements": core/re-frame.ui/custom-elements.md
+      - "Presence: exit animations": core/re-frame.ui/presence.md
+      - "Testing with ui.test": core/re-frame.ui/testing.md
+      - "SSR and hydration": core/re-frame.ui/ssr.md
+      - "Interop and the closed grammar": core/re-frame.ui/interop-and-limits.md
     - "Testing":
       - core/testing/index.md
       - "Event handlers": core/testing/event-handlers.md


### PR DESCRIPTION
## What

Completes the official `re-frame.ui` guide section (`docs/core/re-frame.ui/`), growing it from four pages (491 lines) to eleven. Content quarried from the tombstoned draft at `ai/findings/new-substrate-synthesis/guide/` (15 chapters), with **every claim re-verified against current main** (`spec/004-Views.md`, `spec/011-SSR.md`, the `spec/API.md` freeze table, and `implementation/ui/`) before it landed — the draft predates a week of rulings and was treated strictly as quarry.

## Correctness audit of the four existing pages

Audited `index.md`, `mental-model.md`, `build-a-view.md`, and `reactivity-and-ownership.md` (491 lines) against current specs, checking every API symbol, example, error id, and semantic statement.

**Finding: 0 corrections needed.** The four pages are already current. Specifically verified clean against the brief's known-staleness list:
- None mention the rejected presence contract, the phase flip, `render-static`, the retired bare-handlers lint, or `ui/->react` — so no stale prose to correct.
- The `local` three-tuple `[value set! update!]` (P0-1) is used correctly in `build-a-view.md` (`[open? _ update-open!]` + `(update-open! not)` via `ui/handler`).
- Setters described host-only; `frame-root` ensure/preflight timing, the three-state lifecycle (`connected`/`disconnected`/`dead`), the single React bridge, `rf=` stabilisation, and the experimental-alongside framing all match the specs.

The only edits to existing pages are additive: the index "This section" table and two `mental-model.md` cross-links now reach the new pages.

## New page map (draft chapter → official page)

| Draft chapter(s) | Official page | Notes |
|---|---|---|
| 03-state | `state.md` | Four inputs; `local` three-tuple; `effect`/`dispatch-fn`; app-db/local placement rule (narrow law, per spec/004) |
| 04-events | `events-and-handlers.md` | Handlers-as-data, three placeholders, controlled-input sync door, C-13 event-prefix + C-13a opaque fn-props, decision table, `route-link` |
| 02-views §custom elements | `custom-elements.md` | Property-vs-attribute declaration; keyword heads are DOM/custom elements on every host |
| 02-views §presence | `presence.md` | **Ruled** timeout-only / DOM-agnostic contract (spec/004 §Presence) — the draft's rejected pre-ruling prose was NOT propagated |
| 08-testing | `testing.md` | `ui.test` tiers 1 & 3; tier 2 pointed at core testing |
| 11-ssr | `ssr.md` | Roots, hydration, the two-value phase flip (spec/011), React-native-adoption mismatch diagnostic, `render-static` **as a macro**; points at `docs/ssr/` rather than duplicating |
| 02/13/14 | `interop-and-limits.md` | Foreign React, `error-boundary`, `render-fn`/`slot`, closed grammar + escapes, **planned `->react` (not taught as available)**, wave-2 absences, honest "when not to use this substrate" |

Chapters deliberately **not** given their own official page: 01 (getting-started — the existing `build-a-view.md` + the install how-to already own it), 05 (frames — core `frames.md` owns it; the ui-specific `frame`/`dispatch-fn` bits fold into `state.md`), 06/07 (worked-app / servers — resources corpus + core own the dataflow; the ui-side leases live in `state.md`/`ssr.md`), 09/10/12 (debugging / performance / how-it-works — dev-tooling and mechanism explainers, deferred to observability, the reactivity page, and the design suite), 13 (from-other-worlds — the migration skill + core migration own it).

## Completeness table — blessed shipped surface → where taught

From `spec/API.md` §"re-frame.ui — blessed public-surface freeze" (§2) and §Compiled views (S1–S5 rows). Every shipped surface is taught on a page or deliberately deferred to the API reference; none is silently missing.

| Surface | Stage | Taught in |
|---|---|---|
| `defview` | S1 | mental-model, build-a-view (+ all) |
| `sub` | S2 | state, mental-model, build-a-view, reactivity |
| `lease` | S2→S3 | state, reactivity |
| `frame-root` | S1→S2 | build-a-view, mental-model, ssr |
| `frame-provider` | S2 | mental-model, ssr |
| `adapter` | S2 | build-a-view (boot) |
| `frame` | S2 | state (ops bundle), mental-model |
| `local` | S3 | state, build-a-view, mental-model |
| `effect` | S3 | state |
| `dispatch-fn` | S3 | state |
| `event` | S3 | events-and-handlers |
| `handler` | S3 | events-and-handlers, mental-model |
| `render-fn` | S3 | events-and-handlers (table), interop (slots) |
| `slot` | S3→S4 | interop |
| `spread` | S1 | interop |
| `spread-safe` | S3 | interop |
| `raw` | S1→S4 | interop |
| `raw-fn` | S3 | state (ref), events (table), interop |
| `html` | S1 | interop |
| `custom-element` | S4 | custom-elements |
| `error-boundary` | S3 | interop |
| `client-only` | S3→S5 | ssr |
| `route-link` | S3 | events-and-handlers |
| `presence` / `presence-phase` | S4 | presence |
| `mount` / `create-root` / `render!` / `hydrate-root` / `unmount!` | S1→S5 | ssr (+ build-a-view mount) |
| `render-static` | S5 | ssr (taught **as a macro**) |
| `re-frame.ui.test/*` | S1→S4 | testing |
| `re-frame.ui.react/*` | S3 | interop (named; deferred to API reference) |
| `re-frame.ui.tool/*` | S3 | testing (named; deferred to API reference) |
| `->react` | **S6 — planned, not shipped** | interop (mentioned as planned, never taught as available) |
| `element` / `view` / `portal` / `data/render` | **wave-2, not v1** | interop (marked absent) |

## Scope, fixture, and gates

- **Scope fences respected**: only `docs/core/re-frame.ui/**` and the mkdocs nav rows changed. No `spec/**`, `docs/EP/**`, draft tree, other core pages, or hot-zone files touched. `install-re-frame-ui.md` needed no cross-ref change.
- **Guide-truth fixture**: `implementation/ui/test/re_frame/ui/guide_truth_jvm_test.clj` pins the *draft* tree (`ai/findings/.../guide/`) and a few spec/EP/implementation authorities — **not** the official `docs/core/re-frame.ui/` pages. No page I edited is pinned there, so the fixture needs no change and is unaffected by this PR (verified by grep across `implementation/`, `scripts/`, `.github/`).
- **Gates, all green from the worktree**: `python scripts/check_doc_slugs.py` ✓, `python -m mkdocs build --strict` ✓ (no warnings referencing the new pages), `python scripts/check_adapter_disposition.py` ✓ (experimental-alongside framing preserved; retained adapters named as the default choice on every page's "when not").

## Draft status

The draft tree remains **tombstoned quarry** — this PR copied nothing wholesale and its S7 deletion is unaffected.
