### PR TITLE
fix(http): honest managed-HTTP retry timeline (rf2-fyt5i)

### DIFF
--- a/implementation/http/src/re_frame/http/transport.cljc
+++ b/implementation/http/src/re_frame/http/transport.cljc
@@ -1189,7 +1189,15 @@
                                   :attempt         attempt
                                   :max-attempts    max-attempts
                                   :failure         failure
-                                  :next-backoff-ms delay-ms}
+                                  :next-backoff-ms delay-ms
+                                  ;; rf2-fyt5i — this arm SCHEDULES another
+                                  ;; attempt (`:next-backoff-ms` non-nil), so its
+                                  ;; honest disposition is `:retried`. Spec 009's
+                                  ;; `:rf.http/retry-attempt` row promises this;
+                                  ;; `trace/build-event` hoists `:recovery` on an
+                                  ;; `:info` event ONLY when the producer supplies
+                                  ;; it, so an absent tag left consumers reading nil.
+                                  :recovery        :retried}
                                  (true? (:sensitive? ctx))
                                  {:frame (:frame ctx)})
                          (or (contains? failure :body)
@@ -1247,7 +1255,13 @@
                                   :attempt         attempt
                                   :max-attempts    max-attempts
                                   :failure         failure
-                                  :next-backoff-ms nil}
+                                  :next-backoff-ms nil
+                                  ;; rf2-fyt5i — the retained terminal-exhaustion
+                                  ;; marker schedules NOTHING (discriminated by
+                                  ;; `:next-backoff-ms nil`); stamping `:retried`
+                                  ;; here would be a lie, so its honest disposition
+                                  ;; is `:no-recovery` — no further attempt occurs.
+                                  :recovery        :no-recovery}
                                  (true? (:sensitive? ctx))
                                  {:frame (:frame ctx)})
                          (or (contains? failure :body)

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -608,7 +608,17 @@
             `:retry {:on #{:rf.http/http-5xx} :max-attempts 3}` retries
             twice and exhausts on attempt 3; the trace stream must carry the
             per-attempt retry-attempt events (the final one with
-            :next-backoff-ms nil)."
+            :next-backoff-ms nil).
+
+            rf2-fyt5i — the same exhaustion sequence proves the retry
+            timeline reports its `:recovery` disposition HONESTLY: an
+            intermediate attempt that SCHEDULES another (`:next-backoff-ms`
+            non-nil) carries `:recovery :retried`; the retained terminal
+            exhaustion marker (`:next-backoff-ms nil`) schedules nothing and
+            carries `:recovery :no-recovery`, never a phantom `:retried`.
+            `:recovery` is hoisted top-level on the `:info` event by
+            `trace/build-event`; before the fix neither producer arm supplied
+            it, so consumers read nil."
     (let [traces      (atom [])
           listener-id ::upexd3-eligible
           {:keys [port] :as srv}
@@ -632,12 +642,33 @@
           (is (= :error (get-in db [:reply :status])))
           (is (= :rf.http/http-5xx (get-in db [:reply :error :kind])))
           (let [retry-traces (filter #(= :rf.http/retry-attempt (:operation %))
-                                     @traces)]
+                                     @traces)
+                ;; rf2-fyt5i — the `:next-backoff-ms nil` discriminator splits
+                ;; the timeline into the intermediate SCHEDULING arm and the
+                ;; retained terminal-exhaustion marker.
+                {intermediate false terminal true}
+                (group-by #(nil? (get-in % [:tags :next-backoff-ms])) retry-traces)]
             (is (seq retry-traces)
                 "a retry-eligible exhaustion MUST still emit retry-attempt traces")
             ;; The terminal exhaustion trace carries :next-backoff-ms nil.
             (is (some #(nil? (get-in % [:tags :next-backoff-ms])) retry-traces)
-                "the final exhaustion retry-attempt carries :next-backoff-ms nil")))
+                "the final exhaustion retry-attempt carries :next-backoff-ms nil")
+            ;; rf2-fyt5i — honest recovery dispositions. `:recovery` is hoisted
+            ;; top-level on the `:info` event; both arms must now supply it.
+            (is (seq intermediate)
+                "the 5xx exhaustion retries twice, so intermediate scheduling
+                 retry-attempt traces (`:next-backoff-ms` non-nil) must exist")
+            (is (every? #(= :retried (:recovery %)) intermediate)
+                (str "each intermediate attempt SCHEDULES another, so it must "
+                     "carry `:recovery :retried`; saw "
+                     (pr-str (mapv :recovery intermediate))))
+            (is (= 1 (count terminal))
+                "exactly one terminal-exhaustion marker (`:next-backoff-ms nil`)")
+            (is (every? #(= :no-recovery (:recovery %)) terminal)
+                (str "the terminal-exhaustion marker schedules nothing, so it "
+                     "must carry the honest `:recovery :no-recovery`, never a "
+                     "phantom `:retried`; saw "
+                     (pr-str (mapv :recovery terminal))))))
         (finally
           (trace/unregister-listener! listener-id)
           (stop-server! srv))))))


### PR DESCRIPTION
Closes rf2-fyt5i.

## Problem

Both `:rf.http/retry-attempt` emit arms in `implementation/http/src/re_frame/http/transport.cljc` omitted `:recovery`. `trace/build-event` hoists `:recovery` on an `:info` event **only** when the producer supplies it, so Xray and other consumers received `nil` instead of the disposition Spec 009's `:rf.http/retry-attempt` catalogue row documents.

The two arms are **not** semantically identical, so blindly stamping `:retried` on both would make the metadata look complete while remaining false.

## Current-wrong ↔ honest-correct

| Arm | Discriminator | Before | After (honest) |
|-----|---------------|--------|----------------|
| Intermediate — schedules another attempt | `:next-backoff-ms` non-nil | `:recovery` absent → hoists `nil` | `:recovery :retried` |
| Retained terminal-exhaustion marker — schedules nothing | `:next-backoff-ms nil` | `:recovery` absent → hoists `nil` | `:recovery :no-recovery` |

## Proof (red → green)

Extended the existing exhaustion test `jvm-retry-eligible-exhaustion-still-emits-retry-attempts` to split the timeline on the `:next-backoff-ms nil` discriminator and assert both recovery values.

- **Red before** (transport reverted to HEAD): intermediate `saw [nil nil]`, terminal `saw [nil]` — 2 failures.
- **Green after**: intermediate carry `:retried`, terminal carries `:no-recovery`.

## Scope

Minimal / proportional: two `:recovery` keys added to shared `.cljc` producer code plus a test extension. No registry, runtime validator, new category/API/policy, or tooling-specific handling — the open keyword Recovery schema is correct; this is one producer's missing metadata.

**Not in this PR (fenced out of `spec/**`):** the bead also asks to update Spec 009's catalogue row and Spec 014's retry-timeline wording to document both arms. `spec/**` is a hot-zone the dispatch fence excluded from this worker; that doc update should land as a sequential follow-up.

## Quality gates

- `cd implementation/http && clojure -M:test` → **492 tests, 3776 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (cross-artefact node suite) → **10359 tests, 51162 assertions, 0 failures, 0 errors**
