### PR TITLE
feat(ui): view-evidence DOM annotation (compiler emit) (rf2-hac8p)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr/render_static_jvm_test.clj
+++ b/implementation/ssr/test/re_frame/ssr/render_static_jvm_test.clj
@@ -102,9 +102,12 @@
     (let [html (ui/render-static [static-card {:title "x"}])]
       (doseq [marker ["data-rf-root" "data-rf-manifest" "__rf_payload"
                       "data-rf-render-hash" "rf.root/schema-version" "rf.ssr"
-                      ;; compiled views carry no dev source-coord annotation on
-                      ;; the JVM (register-view! does not wrap), so the static
-                      ;; markup is free of every rf annotation too
+                      ;; The compiler emits the DEV host-root view-evidence
+                      ;; annotation into the structural tree (rf2-hac8p, gated on
+                      ;; interop/debug-enabled?), but render-static is the pure,
+                      ;; non-hydrating static path — `emit-static-html` strips it
+                      ;; before serialisation, so the static markup is free of
+                      ;; every rf annotation too
                       "data-rf2-source-coord" "data-rf-view"]]
         (is (not (str/includes? html marker))
             (str "render-static output must not carry the hydration/adoption "
@@ -161,11 +164,15 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest render-static-composes-emit-ui-tree
-  (testing "render-static's HTML equals emit-ui-tree over the same versioned tree
-            (it reuses the ssr static-emit path, builds no new renderer)"
-    (is (= (ssr/emit-ui-tree
-            (ui-tree/render-root-tree
-             (fn [] (static-card {:title "Hello"}))))
+  (testing "render-static's HTML equals emit-ui-tree over the same versioned tree,
+            minus the DEV host-root annotation render-static strips as the pure
+            non-hydrating static path (it reuses the ssr static-emit path via
+            emit-static-html, builds no new renderer — rf2-hac8p)"
+    (is (= (str/replace
+            (ssr/emit-ui-tree
+             (ui-tree/render-root-tree
+              (fn [] (static-card {:title "Hello"}))))
+            #"\s+data-rf(?:2-source-coord|-view)=\"[^\"]*\"" "")
            (ui/render-static [static-card {:title "Hello"}])))))
 
 ;; ===========================================================================

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -426,6 +426,15 @@
                                (cljs.core/js-obj "__html" ~(:form html)))
                               ~props-sym))
                          built)
+            ;; A DEV-gated view-evidence annotation rides the host root's props
+            ;; when this spread element is the view's compiler-owned root (a
+            ;; spread element is a single DOM host node, so the same annotation
+            ;; as the plain-element branch applies — parity with emit-jvm's
+            ;; `static-form` and the adapter source-coord walk). It DCEs in
+            ;; production.
+            props-form (cond-> props-form
+                         (:rf.ui/annotate node)
+                         (annotate-host-root-props (:rf.ui/annotate node)))
             chs        (children-forms st (:children node) inner-inline?)]
         (if (:present? key-info)
           `(re-frame.ui.runtime/jsx-spread3 ~tag-str ~props-form
@@ -468,6 +477,14 @@
             props-form  `(let [~owned-sym ~owned-obj
                                ~caller-sym ~caller-obj]
                            (re-frame.ui.runtime/spread-safe-props ~caller-sym ~owned-sym))
+            ;; Host-root view-evidence annotation (DEV-gated) when this
+            ;; spread-safe element is the view's compiler-owned root — parity
+            ;; with the plain-element / `ui/spread` branches, emit-jvm, and the
+            ;; adapter source-coord walk. Rides ABOVE the owned/caller merge, so
+            ;; it stamps the final props object; it DCEs in production.
+            props-form  (cond-> props-form
+                          (:rf.ui/annotate node)
+                          (annotate-host-root-props (:rf.ui/annotate node)))
             chs         (children-forms st (:children node) inner-inline?)]
         (if (:present? key-info)
           `(re-frame.ui.runtime/jsx-spread3 ~tag-str ~props-form

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -16,6 +16,7 @@
   both hosts' test suites can golden the emission as data."
   (:require [clojure.string :as str]
             [clojure.walk :as walk]
+            [re-frame.source-coords :as source-coord]
             [re-frame.ui.compiler.analyze :as ana]
             [re-frame.ui.rules :as rules]
             ;; JVM-only: a self-recursive view completes the same-named `:refer`
@@ -325,18 +326,55 @@
          props-form
          (when (:present? key-info) [(:expr key-info)])))
 
-(defn- jsx-call [tag-form pairs children-forms key-info]
-  (let [nch           (count children-forms)
-        multi?        (> nch 1)
-        children-form (cond
-                        (zero? nch) nil
-                        (= 1 nch)   (first children-forms)
-                        :else       `(cljs.core/array ~@children-forms))
-        props-form    (ordered-literal-object
-                       (concat (map (fn [{:keys [name form]}] [name form]) pairs)
-                               (when (some? children-form)
-                                 [["children" children-form]])))]
-    (jsx-runtime-call multi? tag-form props-form key-info)))
+(defn- annotate-host-root-props
+  "Stamp the DEV view-evidence DOM annotation onto a compiler-owned host root's
+  props object: `data-rf2-source-coord` (the `<ns>:<sym>:<line>:<col>` source
+  coordinate — click-to-source) and `data-rf-view` (the view id — the record
+  identity Xray matches its hover-highlight against). This is today's attribute
+  vocabulary (Spec 004 §View identity — Source ↔ DOM navigation; Spec 006
+  §Source-coord annotation + §View tagging contract), reusing the ONE cross-host
+  `re-frame.source-coords` value projections so the compiler-owned host root and
+  the Reagent/UIx/Helix adapter walks emit byte-identical attribute values by
+  construction — existing Xray click-to-source works day one.
+
+  The stamp sits behind `^boolean js/goog.DEBUG`, so under :advanced +
+  goog.DEBUG=false Closure constant-folds the gate to false and DCEs the whole
+  branch — the literal `data-rf2-source-coord` / `data-rf-view` strings never
+  reach the production bundle (both are on the standard elision sentinel set).
+  The props object is mutated in place BEFORE it reaches the JSX runtime, exactly
+  as the trusted-markup spread branch sets `dangerouslySetInnerHTML`.
+
+  The per-commit integer `render-key` is deliberately NOT stamped here: it is
+  minted at CONNECTED COMMIT in the ViewCell layout effect (`reactive/commit*`),
+  which runs AFTER this child host element has already committed, so no honest
+  value for THIS commit exists at render time. Stamping render-key onto the DOM
+  is therefore a commit-time concern owned by the substrate, not the compiler."
+  [props-form {:keys [source-coord view-tag]}]
+  (let [p (gensym "rf-ui-host-root")]
+    `(let [~p ~props-form]
+       (when ~(with-meta 'js/goog.DEBUG {:tag 'boolean})
+         (cljs.core/unchecked-set ~p "data-rf2-source-coord" ~source-coord)
+         (cljs.core/unchecked-set ~p "data-rf-view" ~view-tag))
+       ~p)))
+
+(defn- jsx-call
+  ([tag-form pairs children-forms key-info]
+   (jsx-call tag-form pairs children-forms key-info nil))
+  ([tag-form pairs children-forms key-info annotate]
+   (let [nch           (count children-forms)
+         multi?        (> nch 1)
+         children-form (cond
+                         (zero? nch) nil
+                         (= 1 nch)   (first children-forms)
+                         :else       `(cljs.core/array ~@children-forms))
+         props-form    (ordered-literal-object
+                        (concat (map (fn [{:keys [name form]}] [name form]) pairs)
+                                (when (some? children-form)
+                                  [["children" children-form]])))]
+     (jsx-runtime-call multi? tag-form
+                       (cond-> props-form
+                         annotate (annotate-host-root-props annotate))
+                       key-info))))
 
 (defn- emit-element [node st inline?]
   (let [static?       (:static? node)
@@ -441,8 +479,11 @@
       :else
       (let [pairs (element-prop-pairs st node inner-inline?)
             chs   (children-forms st (:children node) inner-inline?)
-            ;; prebuilt static props object under a dynamic key
-            call  (jsx-call tag-str pairs chs key-info)]
+            ;; prebuilt static props object under a dynamic key. A DEV-gated
+            ;; view-evidence annotation rides the host root's props when this
+            ;; element is the view's compiler-owned root (marked by
+            ;; `mark-host-root-annotation`); it DCEs in production.
+            call  (jsx-call tag-str pairs chs key-info (:rf.ui/annotate node))]
         (if (and static? (not inline?))
           (hoist! st :el call)
           call)))))
@@ -779,11 +820,36 @@
 ;; defview
 ;; ---------------------------------------------------------------------------
 
+(defn- mark-host-root-annotation
+  "Stamp the view-evidence DOM-annotation marker onto the view's effective host
+  root — the DOM `:element` the compiler owns at the top of the render. The
+  UNCONDITIONAL wrappers (`:hook-prefix` effect prefix, an authored `:let` /
+  `:letfn`) are transparent — the marker rides through to the element they wrap.
+  A non-element effective root (a fragment, another view/foreign component, or a
+  conditional / loop) is NOT a single compiler-owned host node, so it carries no
+  annotation — the same host-root exemption the adapter source-coord walk applies
+  to a non-DOM root. `emit-element` reads the marker off the plain element and
+  stamps the props behind the goog.DEBUG gate (see `annotate-host-root-props`)."
+  [ast annotate]
+  (case (:op ast)
+    :element (assoc ast :rf.ui/annotate annotate)
+    (:hook-prefix :let :letfn) (update ast :body mark-host-root-annotation annotate)
+    ast))
+
 (defn emit-defview
   [{:keys [vname view-id display-name docstring header slots ast manifest
            closed-keys children? lease-declarations self-fqn]}]
   (let [st         (doto (new-state vname) (swap! assoc :self-fqn self-fqn))
-        body       (->> (emit-node ast st false)
+        ;; The DEV view-evidence DOM annotation for this view's compiler-owned
+        ;; host root — the source coordinate + view id, in today's attribute
+        ;; vocabulary (Spec 004 §View identity). Marked onto the effective root
+        ;; element and stamped behind the goog.DEBUG gate; a non-element root
+        ;; carries none. Compile-time literals via the cross-host
+        ;; `re-frame.source-coords` projections (parity with the adapter walks).
+        annotate   {:source-coord (source-coord/format-source-coord
+                                   view-id (:source manifest))
+                    :view-tag     (source-coord/format-view-id view-id)}
+        body       (->> (emit-node (mark-host-root-annotation ast annotate) st false)
                         (hoist-literal-sub-queries st))
         leases     (mapv #(update % :descriptor
                                   (partial hoist-literal-sub-queries st))

--- a/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
@@ -9,7 +9,8 @@
   children raise :rf.error/jvm-host-op lazily (only when their branch
   renders); `ui/raw`/`ui/raw-fn` PROP values become opaque markers
   WITHOUT evaluating their expressions (they may be host-only)."
-  (:require [re-frame.ui.compiler.analyze :as ana]
+  (:require [re-frame.source-coords :as source-coord]
+            [re-frame.ui.compiler.analyze :as ana]
             [re-frame.ui.rules :as rules]))
 
 (def ^:private props-sym 'rf-ui-props)
@@ -109,8 +110,31 @@
           [{} {}]
           events))
 
+(defn- static-form
+  "The `:static` slot value form for a `tree/element` call. `static` is the
+  compile-time-normalized literal attr map (or nil). When `annotate` is present
+  — this element is the view's compiler-owned host root, marked by
+  `mark-host-root-annotation` — the DEV view-evidence annotation
+  (`data-rf2-source-coord` + `data-rf-view`, today's attribute vocabulary per
+  Spec 004 §View identity / Spec 006 §Source-coord annotation + §View tagging
+  contract) merges onto the static attrs behind `re-frame.interop/debug-enabled?`
+  (the JVM counterpart to the CLJS `goog.DEBUG` stamp — true by default, off under
+  `-Dre-frame.debug=false`). So a dev JVM/SSR render carries the SAME host-root
+  evidence the CLJS emit stamps (byte-identical values via the one cross-host
+  `re-frame.source-coords` projection), and a production SSR build drops it —
+  symmetric with the CLJS `:advanced` + goog.DEBUG=false DCE."
+  [static annotate]
+  (if annotate
+    (let [{:keys [source-coord view-tag]} annotate]
+      `(cond-> ~(or static {})
+         re-frame.interop/debug-enabled?
+         (assoc :data-rf2-source-coord ~source-coord
+                :data-rf-view ~view-tag)))
+    (when (seq static) static)))
+
 (defn- emit-element [node]
   (let [{:keys [props]} node
+        annotate  (:rf.ui/annotate node)
         tag       (:tag node)
         key-info  (:key props)
         child-forms (if (:html node)
@@ -124,7 +148,7 @@
             sugar (get-in props [:class :base-str])]
         `(re-frame.ui.tree/element
           ~tag
-          {:static ~(when (seq sugar) {:class sugar})
+          {:static ~(static-form (when (seq sugar) {:class sugar}) annotate)
            :dyn    (merge ~(:base spread) ~(:overrides spread))
            :key?   ~(:present? key-info)
            :key-val ~(:expr key-info)
@@ -159,7 +183,7 @@
                           (:attrs props))]
         `(re-frame.ui.tree/element
           ~tag
-          {:static ~(when (seq static) static)
+          {:static ~(static-form static annotate)
            :norm   ~(when (seq norm) norm)
            :dyn    ~(when (seq dyn) dyn)
            :events ~(when (seq stat-ev) stat-ev)
@@ -187,7 +211,7 @@
                           (:attrs props))]
         `(re-frame.ui.tree/element
           ~tag
-          {:static ~(when (seq static) static)
+          {:static ~(static-form static annotate)
            :norm   ~(when (seq norm) norm)
            :dyn    ~(when (seq dyn) dyn)
            :events ~(when (seq stat-ev) stat-ev)
@@ -345,10 +369,39 @@
 ;; defview
 ;; ---------------------------------------------------------------------------
 
+(defn- mark-host-root-annotation
+  "Stamp the view-evidence DOM-annotation marker onto the view's effective host
+  root — the DOM `:element` the compiler owns at the top of the render. The
+  UNCONDITIONAL wrappers (`:hook-prefix` effect prefix, an authored `:let` /
+  `:letfn`) are transparent — the marker rides through to the element they wrap.
+  A non-element effective root (a fragment, another view/foreign component, or a
+  conditional / loop) is NOT a single compiler-owned host node, so it carries no
+  annotation — the same host-root exemption the CLJS emit and the adapter
+  source-coord walk apply to a non-DOM root. `emit-element` reads the marker off
+  the plain element and merges the annotation into its `:static` attrs behind the
+  `interop/debug-enabled?` gate (see `static-form`). The JVM twin of
+  `re-frame.ui.compiler.emit-cljs/mark-host-root-annotation`."
+  [ast annotate]
+  (case (:op ast)
+    :element (assoc ast :rf.ui/annotate annotate)
+    (:hook-prefix :let :letfn) (update ast :body mark-host-root-annotation annotate)
+    ast))
+
 (defn emit-defview
   [{:keys [vname view-id docstring header ast manifest closed-keys children?
            lease-declarations self-fqn]}]
-  (let [body     (binding [*self-fqn* self-fqn] (emit-node ast))
+  (let [;; The DEV view-evidence DOM annotation for this view's compiler-owned
+        ;; host root — the source coordinate + view id, in today's attribute
+        ;; vocabulary (Spec 004 §View identity), via the cross-host
+        ;; `re-frame.source-coords` projections (byte-identical to the CLJS emit
+        ;; and the adapter walks by construction). Marked onto the effective root
+        ;; element and merged behind the `interop/debug-enabled?` gate; a
+        ;; non-element root carries none.
+        annotate {:source-coord (source-coord/format-source-coord
+                                 view-id (:source manifest))
+                  :view-tag     (source-coord/format-view-id view-id)}
+        body     (binding [*self-fqn* self-fqn]
+                   (emit-node (mark-host-root-annotation ast annotate)))
         bind     (:binding-form header)
         lease-binds
         (vec

--- a/implementation/ui/src/re_frame/ui/tree.cljc
+++ b/implementation/ui/src/re_frame/ui/tree.cljc
@@ -543,6 +543,30 @@
        (catch java.io.FileNotFoundException _ nil))))
 
 #?(:clj
+   (defn- strip-host-root-annotation
+     "Recursively drop the DEV host-root view-evidence annotation
+     (`:data-rf2-source-coord` / `:data-rf-view` — the compiler-emit stamp,
+     rf2-hac8p) from a JVM structural `tree`. `render-static` is the pure
+     `:server`, NON-hydrating static-HTML path (Spec 011 §Phase flip): it carries
+     NO manifest, NO hydration payload, and NO dev / adoption markers, so the
+     compiler's DEBUG-gated host-root annotation — present in the tree the
+     compiled views build (matching the client render, which the SSR-then-hydrate
+     `render-to-string` hiccup path relies on) — is stripped HERE before the pure
+     static serialisation, exactly as `goog.DEBUG=false` / `-Dre-frame.debug=false`
+     erases it in a production build. Only this render-static seam strips it; the
+     hydrating `render-to-string` path (a separate `re-frame.ssr.emit` hiccup
+     serialiser) is untouched."
+     [node]
+     (if (map? node)
+       (let [node (if-let [a (:attrs node)]
+                    (let [a (dissoc a :data-rf2-source-coord :data-rf-view)]
+                      (if (seq a) (assoc node :attrs a) (dissoc node :attrs)))
+                    node)]
+         (cond-> node
+           (:children node) (update :children #(mapv strip-host-root-annotation %))))
+       node)))
+
+#?(:clj
    (defn emit-static-html
      "Fold a JVM structural `tree` to an inert HTML string through the SSR
      artefact's `re-frame.ssr/emit-ui-tree`, resolved LATE (see
@@ -554,10 +578,14 @@
      re-frame.ssr`. When the `day8/re-frame2-ssr` artefact is absent from the
      server classpath this raises the ruled, typed
      `:rf.error/ssr-artefact-missing` naming the artefact — never a raw host
-     exception, never a fallback."
+     exception, never a fallback.
+
+     The DEV host-root view-evidence annotation (rf2-hac8p) is stripped from the
+     tree first (see `strip-host-root-annotation`): render-static is the pure,
+     non-hydrating static-HTML path and carries no dev / adoption markers."
      [tree]
      (if-let [emit (resolve-ssr-emitter)]
-       (emit tree)
+       (emit (strip-host-root-annotation tree))
        (error/throw-error!
         :rf.error/ssr-artefact-missing
         'ui/render-static

--- a/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/binding_plan_host_faithful_cljs_test.cljs
@@ -39,7 +39,17 @@
             [re-frame.ui.reactive :as reactive]
             [re-frame.ui.runtime :as rt]))
 
-(defn- render [el] (rds/renderToStaticMarkup el))
+(defn- strip-view-evidence
+  "Drop the DEV host-root view-evidence annotation (`data-rf2-source-coord` /
+  `data-rf-view`) the compiler stamps on a view's compiler-owned root element
+  (rf2-hac8p). This suite's subject is the header binding plan — the bound value,
+  comparator slot set, `:or` default side effects — not the host-root annotation;
+  its own coverage is the dedicated emit-annotation tests, the parity corpus, and
+  `test:elision`."
+  [html]
+  (str/replace html #"\s+data-rf(?:2-source-coord|-view)=\"[^\"]*\"" ""))
+
+(defn- render [el] (strip-view-evidence (rds/renderToStaticMarkup el)))
 (defn- descriptor [id] (reactive/view-descriptor id))
 (defn- compare-fn [id] (:compare-fn (descriptor id)))
 (defn- prop-slot-keys [id]

--- a/implementation/ui/test/re_frame/ui/custom_element_classification_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/custom_element_classification_jvm_test.clj
@@ -42,7 +42,23 @@
 (defview undeclared-element-view []
   [:ce-plain {:accent-color "x" :data-y "y"}])
 
-(defn- element [view] (first (:children (tree/render view {}))))
+(defn- strip-view-evidence
+  "Recursively drop the DEV host-root view-evidence annotation
+  (:data-rf2-source-coord / :data-rf-view) the compiler stamps on each view's
+  compiler-owned root element (rf2-hac8p). This suite asserts the RULED
+  property-vs-attribute classification, not the host-root annotation (own
+  coverage: the emit-annotation tests, the parity corpus, test:elision)."
+  [node]
+  (if (map? node)
+    (let [node (if-let [a (:attrs node)]
+                 (let [a (dissoc a :data-rf2-source-coord :data-rf-view)]
+                   (if (seq a) (assoc node :attrs a) (dissoc node :attrs)))
+                 node)]
+      (cond-> node
+        (:children node) (update :children #(mapv strip-view-evidence %))))
+    node))
+
+(defn- element [view] (strip-view-evidence (first (:children (tree/render view {})))))
 
 (deftest declared-name-is-a-property-undeclared-is-an-attribute
   (let [el (element declared-props-view)]

--- a/implementation/ui/test/re_frame/ui/custom_element_harvest_hook_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/custom_element_harvest_hook_jvm_test.clj
@@ -52,6 +52,18 @@
                         :requires #{'re-frame.ui} :source ""}}
    :output {}})
 
+(defn- strip-view-evidence
+  "Drop the DEV host-root view-evidence annotation (:data-rf2-source-coord /
+  :data-rf-view) the compiler stamps on a view's compiler-owned root element
+  (rf2-hac8p). This suite asserts custom-element property classification, not the
+  host-root annotation (own coverage: the emit-annotation tests, the parity
+  corpus, test:elision)."
+  [node]
+  (if-let [a (:attrs node)]
+    (let [a (dissoc a :data-rf2-source-coord :data-rf-view)]
+      (if (seq a) (assoc node :attrs a) (dissoc node :attrs)))
+    node))
+
 (defn- classify-consumer
   "Under `prepared`'s compiler-env (which the hook seeded at prepare),
   macroexpand + eval a consumer defview using `:ce-two` and render it; return the
@@ -66,7 +78,8 @@
       (eval (compiler/defview*
              (with-meta (list 'defview 'probe [] template) {:line 1})
              {} 'probe (list [] template)))
-      (first (:children (tree/render @(resolve (symbol (str view-ns) "probe")) {}))))))
+      (strip-view-evidence
+       (first (:children (tree/render @(resolve (symbol (str view-ns) "probe")) {})))))))
 
 (deftest two-source-order-permutations-classify-identically
   (let [decl-first (do (build/reset-build!) (harvest/reset-harvested!)
@@ -99,8 +112,9 @@
       (eval (compiler/defview*
              (with-meta (list 'defview 'probe [] template) {:line 1})
              {} 'probe (list [] template)))
-      (let [node (first (:children (tree/render
-                                    @(resolve 'probe.undeclared/probe) {})))]
+      (let [node (strip-view-evidence
+                  (first (:children (tree/render
+                                     @(resolve 'probe.undeclared/probe) {}))))]
         (is (nil? (:rf.ui/property-props node))
             "an undeclared tag is not seeded -> attribute")
         (is (= {:model "m"} (:attrs node)))))))

--- a/implementation/ui/test/re_frame/ui/emit_cljs_view_evidence_annotation_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/emit_cljs_view_evidence_annotation_cljs_test.cljc
@@ -1,0 +1,89 @@
+(ns re-frame.ui.emit-cljs-view-evidence-annotation-cljs-test
+  "98.1 slice (c) — cross-host golden for the host-root view-evidence annotation
+  wiring (rf2-hac8p). The emitter is `.cljc`, so the exact CLJS expansion is data
+  on BOTH hosts: a host-root-marked element lowers to the DEV-gated
+  `data-rf2-source-coord` / `data-rf-view` stamp on its props object, and an
+  unmarked element lowers unchanged."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ui.compiler.analyze :as ana]
+            [re-frame.ui.compiler.emit-cljs :as emit]
+            [re-frame.ui.compiler.env :as env]))
+
+(defn- forms-of [form] (tree-seq coll? seq form))
+
+(defn- emitted
+  "Analyze `form`, optionally stamp the host-root annotation marker, and lower it
+  to a single inline CLJS form (data on this host)."
+  ([form] (emitted form nil))
+  ([form annotate]
+   (let [e   (env/make-env {:host :clj :ns-sym 'app.test})
+         ast (ana/analyze e form)]
+     (emit/emit-inline (cond-> ast annotate (assoc :rf.ui/annotate annotate))
+                       'annotation-golden))))
+
+(defn- data-attr-set [form attr]
+  (some (fn [x]
+          (when (and (seq? x)
+                     (= 'cljs.core/unchecked-set (first x))
+                     (= attr (nth x 2 nil)))
+            (nth x 3 nil)))
+        (forms-of form)))
+
+(defn- annotation-gate
+  "The `(when <gate> …)` form wrapping the source-coord stamp, or nil. Matches the
+  `when` by NAME — the emitter's syntax-quote resolves it against the host core
+  (`clojure.core/when` on the JVM runner, `cljs.core/when` on the node runner)."
+  [form]
+  (first (filter #(and (seq? %)
+                       (symbol? (first %))
+                       (= "when" (name (first %)))
+                       (some (fn [x]
+                               (and (seq? x)
+                                    (= 'cljs.core/unchecked-set (first x))
+                                    (= "data-rf2-source-coord" (nth x 2 nil))))
+                             (forms-of %)))
+                 (forms-of form))))
+
+(deftest marked-host-root-lowers-to-a-dev-gated-props-stamp
+  (let [form (emitted '[:div {:title t} "x"]
+                      {:source-coord "app.test:widget:12:3"
+                       :view-tag ":app.test/widget"})
+        gate (annotation-gate form)]
+    (is (some? gate) "the marked host root gains the annotation stamp")
+    (is (= 'js/goog.DEBUG (second gate))
+        "goog.DEBUG-gated so :advanced folds the stamp — and its literal
+         attribute strings — out of the production bundle")
+    (is (= "app.test:widget:12:3" (data-attr-set form "data-rf2-source-coord")))
+    (is (= ":app.test/widget" (data-attr-set form "data-rf-view")))
+    (is (= 2 (count (filter #(and (seq? %)
+                                  (= 'cljs.core/unchecked-set (first %))
+                                  (#{"data-rf2-source-coord" "data-rf-view"}
+                                   (nth % 2 nil)))
+                            (forms-of form))))
+        "exactly the two annotation attributes, nothing more")))
+
+(deftest an-unmarked-element-is-not-annotated
+  (let [form (emitted '[:div {:title t} "x"])]
+    (is (nil? (annotation-gate form))
+        "no host-root marker → the emitter stamps nothing")
+    (is (nil? (data-attr-set form "data-rf2-source-coord")))
+    (is (nil? (data-attr-set form "data-rf-view")))))
+
+(deftest the-stamp-mutates-the-props-object-before-the-jsx-runtime
+  ;; the annotated props are a single-evaluation `let` whose body returns the
+  ;; SAME object it mutated — mirroring the trusted-markup spread branch — so the
+  ;; JSX runtime receives the already-stamped object.
+  (let [form (emitted '[:div "x"]
+                      {:source-coord "app.test:c:1:1" :view-tag ":app.test/c"})
+        the-let (first (filter #(and (seq? %)
+                                     (= "let" (name (first %)))
+                                     (some (fn [x]
+                                             (and (seq? x)
+                                                  (= 'cljs.core/unchecked-set (first x))))
+                                           (forms-of %)))
+                               (forms-of form)))]
+    (is (some? the-let))
+    (let [[_ bindings & body] the-let
+          bound-sym (first bindings)]
+      (is (= bound-sym (last body))
+          "the let returns the same props temporary it mutated"))))

--- a/implementation/ui/test/re_frame/ui/emit_cljs_view_evidence_annotation_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/emit_cljs_view_evidence_annotation_jvm_test.clj
@@ -1,0 +1,106 @@
+(ns re-frame.ui.emit-cljs-view-evidence-annotation-jvm-test
+  "98.1 slice (c) — the compiler emits the view-evidence DOM annotation onto its
+  compiler-owned host root (rf2-hac8p).
+
+  Per Spec 004 §View identity (Source ↔ DOM navigation) the compiled substrate
+  stamps `data-rf2-source-coord` + `data-rf-view` (today's attribute vocabulary)
+  on the view's root DOM element, DEV-gated so `:advanced` + goog.DEBUG=false
+  carries none of it. These are end-to-end pins on the REAL cljs `defview*` emit
+  path (menv carries `:ns`, so `emit-cljs/emit-defview` runs and returns the
+  expansion as data on this JVM host)."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.source-coords :as source-coord]
+            [re-frame.ui.compiler :as compiler]))
+
+(defn- cljs-emit
+  "Run the REAL cljs `defview*` emit path for `template` under `ns-sym`/`vname`
+  with source-coord reader meta `{:line :column}`; returns the emitted form as
+  data (the cljs env marker `{:ns …}` selects `emit-cljs/emit-defview`)."
+  [ns-sym vname template line col]
+  (compiler/defview*
+   (with-meta (list 'defview vname [] template) {:line line :column col})
+   {:ns {:name ns-sym}}
+   vname
+   (list [] template)))
+
+(defn- forms-of [form] (tree-seq coll? seq form))
+
+(defn- data-attr-set
+  "The `(cljs.core/unchecked-set _ attr value)` value stamped for `attr`, or nil."
+  [form attr]
+  (some (fn [x]
+          (when (and (seq? x)
+                     (= 'cljs.core/unchecked-set (first x))
+                     (= attr (nth x 2 nil)))
+            (nth x 3 nil)))
+        (forms-of form)))
+
+(defn- annotation-gate
+  "The `(when <gate> …)` form wrapping the source-coord stamp, or nil. Matches the
+  `when` by NAME — the emitter's syntax-quote resolves it against the host core
+  (`clojure.core/when` on this JVM host)."
+  [form]
+  (first (filter #(and (seq? %)
+                       (symbol? (first %))
+                       (= "when" (name (first %)))
+                       (some (fn [x]
+                               (and (seq? x)
+                                    (= 'cljs.core/unchecked-set (first x))
+                                    (= "data-rf2-source-coord" (nth x 2 nil))))
+                             (forms-of %)))
+                 (forms-of form))))
+
+(deftest element-root-carries-the-dev-gated-source-coord-and-view-id
+  (let [form (cljs-emit 'app.probe 'widget '[:div "x"] 12 3)
+        gate (annotation-gate form)]
+    (is (some? gate)
+        "the compiler-owned host root gains the view-evidence annotation")
+    (is (= 'js/goog.DEBUG (second gate))
+        "the annotation is goog.DEBUG-gated so :advanced elides it (I-12)")
+    (is (= "app.probe:widget:12:3" (data-attr-set form "data-rf2-source-coord"))
+        "data-rf2-source-coord is the canonical <ns>:<sym>:<line>:<col> coord")
+    (is (= ":app.probe/widget" (data-attr-set form "data-rf-view"))
+        "data-rf-view is the view id — the record identity Xray matches on")))
+
+(deftest annotation-values-come-from-the-cross-host-source-coords-projection
+  ;; byte-identical to the adapter walks by construction (single .cljc owner)
+  (let [form (cljs-emit 'my.app 'panel '[:section "body"] 5 1)]
+    (is (= (source-coord/format-source-coord :my.app/panel {:line 5 :column 1})
+           (data-attr-set form "data-rf2-source-coord")))
+    (is (= (source-coord/format-view-id :my.app/panel)
+           (data-attr-set form "data-rf-view")))))
+
+(deftest missing-source-column-degrades-not-crashes
+  ;; a macro-generated template with no :column still annotates (coord "?")
+  (let [form (cljs-emit 'app.gen 'made '[:span] 7 nil)]
+    (is (= "app.gen:made:7:?" (data-attr-set form "data-rf2-source-coord")))))
+
+(deftest unconditional-wrappers-are-transparent-to-the-host-root-mark
+  (testing "an authored root let unwraps to the element it wraps"
+    (let [form (cljs-emit 'app.wrap 'boxed '(let [y "z"] [:div y]) 9 2)]
+      (is (some? (annotation-gate form))
+          "the annotation rides through the let to the inner host element")
+      (is (= "app.wrap:boxed:9:2" (data-attr-set form "data-rf2-source-coord")))
+      (is (= ":app.wrap/boxed" (data-attr-set form "data-rf-view"))))))
+
+(deftest non-element-roots-carry-no-annotation
+  (testing "a conditional root is not a single compiler-owned host node"
+    (let [form (cljs-emit 'app.cond 'branchy '(if x [:a] [:b]) 3 4)]
+      (is (nil? (annotation-gate form)))
+      (is (not (str/includes? (pr-str form) "data-rf2-source-coord"))
+          "no host-root annotation on a non-element effective root")
+      (is (not (str/includes? (pr-str form) "data-rf-view")))))
+  (testing "a fragment root is exempt (no positional host node)"
+    (let [form (cljs-emit 'app.frag 'grouped '[:<> [:p] [:p]] 1 1)]
+      (is (nil? (annotation-gate form)))
+      (is (not (str/includes? (pr-str form) "data-rf2-source-coord"))))))
+
+(deftest render-key-is-not-stamped-on-the-dom-at-render-time
+  ;; render-key is minted at connected commit (reactive/commit*), AFTER this
+  ;; child host element commits — no honest value exists at render time, so the
+  ;; compiler emit annotates identity only (source-coord + view id), never a
+  ;; stale render-key. A commit-time DOM stamp is a separate substrate concern.
+  (let [form (cljs-emit 'app.rk 'no-rk '[:div "x"] 2 2)]
+    (is (not (str/includes? (pr-str form) "data-rf-render-key"))
+        "no render-key attribute is stamped by the compiler emit")))

--- a/implementation/ui/test/re_frame/ui/parity_corpus_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/parity_corpus_elision_prod_test.cljs
@@ -115,6 +115,33 @@
         x))
     :else x))
 
+;; --- DEV-only host-root view-evidence annotation (rf2-hac8p) ----------------
+;; The compiler stamps `data-rf2-source-coord` / `data-rf-view` on each view's
+;; compiler-owned host root behind the DEBUG gate — goog.DEBUG on CLJS,
+;; interop/debug-enabled? on the JVM. In THIS advanced bundle (goog.DEBUG=false)
+;; the CLJS emitter DCEs the whole stamp, so the react side carries none. The
+;; shared JVM truth, however, is computed in the compiler's OWN JVM where
+;; interop/debug-enabled? is true (a compile-time regime, not a production SSR
+;; build), so it carries the annotation. A real production SSR JVM
+;; (`-Dre-frame.debug=false`) gates the SAME stamp OFF — so stripping the
+;; DEV-only annotation from the JVM truth here recovers the true-production shape
+;; and meets the advanced-CLJS side in one semantic space. This mirrors the CLJS
+;; DCE exactly as `strip-ce-property-props` above mirrors the empty runtime
+;; property registry. A pure walk: no global state, no test-order coupling.
+(defn- strip-view-evidence
+  [x]
+  (cond
+    (vector? x) (mapv strip-view-evidence x)
+    (map? x)
+    (let [x (if-let [a (:attrs x)]
+              (let [a (dissoc a "data-rf2-source-coord" "data-rf-view")]
+                (if (seq a) (assoc x :attrs a) (dissoc x :attrs)))
+              x)]
+      (if (:children x)
+        (assoc x :children (mapv strip-view-evidence (:children x)))
+        x))
+    :else x))
+
 ;; ---------------------------------------------------------------------------
 ;; Tooth (i) — the build IS the elided / production regime
 ;; ---------------------------------------------------------------------------
@@ -168,7 +195,7 @@
   (doseq [{:keys [id] :as c} fx/cases]
     (let [html   (render-case c)
           react  (strip-ce-property-props (ph/html->semantic html))
-          jvm    (ph/expand-trusted (get jvm-semantics id))
+          jvm    (strip-view-evidence (ph/expand-trusted (get jvm-semantics id)))
           diff   (when (not= jvm react) (ph/first-divergence jvm react))]
       (is (= jvm react)
           (str "advanced-CLJS/JVM parity divergence in case " id

--- a/implementation/ui/test/re_frame/ui/preflight_frame_wiring_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/preflight_frame_wiring_dom_cljs_test.cljs
@@ -18,6 +18,7 @@
   the `:browser-test` build; under `:node-test` every DOM body gates on
   `(browser?)` and exits early."
   (:require [cljs.test :refer [deftest is use-fixtures async]]
+            [clojure.string :as str]
             ["react" :as React]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
@@ -29,6 +30,15 @@
             [re-frame.ui.frames :as frames]))
 
 (defn- browser? [] (exists? js/document))
+
+(defn- strip-view-evidence
+  "Drop the DEV host-root view-evidence annotation the compiler stamps on a
+  view's compiler-owned root element in dev builds (rf2-hac8p). These pins assert
+  the frame-provider's transparent scoping / rendered template shape, not the
+  annotation — whose own coverage is the emit-annotation tests, the parity
+  corpus, and test:elision."
+  [html]
+  (str/replace html #"\s+data-rf(?:2-source-coord|-view)=\"[^\"]*\"" ""))
 
 ;; ---------------------------------------------------------------------------
 ;; The canonical React act() helper (rf2-vxgfnd.89 template; rf2-powx4d sweep)
@@ -441,7 +451,7 @@
        #(ui/mount [scoping-view {:frame-id :app/live}] c
                   {:root-id :dom-pf/scoped}))
       (is (re-find #"<div class=\"wrap\"><div class=\"mini\">inside</div></div>"
-                   (.-innerHTML c))
+                   (strip-view-evidence (.-innerHTML c)))
           "the frame-provider scopes transparently — children render through it"))))
 
 ;; NOTE: the absent-frame fail-loud (`require-scope-frame!` throwing
@@ -499,7 +509,8 @@
                (is (some? root))
                (is (contains? (client/live-root-ids) :dom-absent/root)
                    "the settled root-id + container accept a clean retry")
-               (is (re-find #"<div class=\"mini\">scoped</div>" (.-innerHTML c))
+               (is (re-find #"<div class=\"mini\">scoped</div>"
+                            (strip-view-evidence (.-innerHTML c)))
                    "the provider scopes the now-live frame transparently")
                (act! #(ui/unmount! root)))
              (catch :default e

--- a/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
@@ -18,7 +18,17 @@
             [re-frame.ui.reactive :as reactive]
             [re-frame.ui.runtime :as rt]))
 
-(defn- render [el] (rds/renderToStaticMarkup el))
+(defn- strip-view-evidence
+  "Drop the DEV host-root view-evidence annotation (`data-rf2-source-coord` /
+  `data-rf-view`) the compiler stamps on a view's compiler-owned root element
+  (rf2-hac8p). These goldens assert prop-name conversion, class/style rules,
+  hoisting, slots and handler lowering — the host-root annotation is noise here;
+  its own coverage is the dedicated emit-annotation tests, the parity corpus,
+  and `test:elision`."
+  [html]
+  (str/replace html #"\s+data-rf(?:2-source-coord|-view)=\"[^\"]*\"" ""))
+
+(defn- render [el] (strip-view-evidence (rds/renderToStaticMarkup el)))
 (defn- current-render [id] (:render-fn (reactive/view-descriptor id)))
 (defn- current-compare [id] (:compare-fn (reactive/view-descriptor id)))
 

--- a/implementation/ui/test/re_frame/ui/root_mount_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_mount_dom_cljs_test.cljs
@@ -161,6 +161,14 @@
 (defn- mount-main! [c]
   (ui/mount [mini-app {:title "hello S1c"}] c {:root-id :dom-smoke/main}))
 
+(defn- strip-view-evidence
+  "Drop the DEV host-root view-evidence annotation the compiler stamps on a
+  view's compiler-owned root element in dev builds (rf2-hac8p). This smoke pins
+  the rendered template shape, not the annotation — whose own coverage is the
+  emit-annotation tests, the parity corpus, and test:elision."
+  [html]
+  (str/replace html #"\s+data-rf(?:2-source-coord|-view)=\"[^\"]*\"" ""))
+
 (deftest mount-smoke
   (when (browser?)
     (let [c (container)
@@ -168,7 +176,7 @@
       (is (some? root))
       (is (= :dom-smoke/main (client/root-id-of root)))
       (is (re-find #"<div class=\"mini-app\"><h1>hello S1c</h1></div>"
-                   (.-innerHTML c))
+                   (strip-view-evidence (.-innerHTML c)))
           "the compiled root template renders through the React root")
       (is (contains? (client/live-root-ids) :dom-smoke/main))
       (let [entry (client/live-root-entry :dom-smoke/main)]

--- a/implementation/ui/test/re_frame/ui/test_render_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/test_render_jvm_test.clj
@@ -95,8 +95,24 @@
 ;; Form 1 — a view reference (compile-resolved defview var/symbol)
 ;; ---------------------------------------------------------------------------
 
+(defn- strip-view-evidence
+  "Recursively drop the DEV host-root view-evidence annotation
+  (:data-rf2-source-coord / :data-rf-view) the compiler stamps on each view's
+  compiler-owned root element (rf2-hac8p). This golden asserts the boundary-node
+  tree shape, not the host-root annotation (own coverage: the emit-annotation
+  tests, the parity corpus, test:elision)."
+  [node]
+  (if (map? node)
+    (let [node (if-let [a (:attrs node)]
+                 (let [a (dissoc a :data-rf2-source-coord :data-rf-view)]
+                   (if (seq a) (assoc node :attrs a) (dissoc node :attrs)))
+                 node)]
+      (cond-> node
+        (:children node) (update :children #(mapv strip-view-evidence %))))
+    node))
+
 (deftest view-reference-renders
-  (let [tree (uit/render badge {:props {:label "hi"}})]
+  (let [tree (strip-view-evidence (uit/render badge {:props {:label "hi"}}))]
     (is (= {:view-id ::badge
             :props {:label "hi"}
             :children [{:tag :span :attrs {:class "badge"} :children ["hi"]}]

--- a/implementation/ui/test/re_frame/ui/tree_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/tree_jvm_test.clj
@@ -14,6 +14,23 @@
 
 (defn- boom! [] (throw (ex-info "must never evaluate" {})))
 
+(defn- strip-view-evidence
+  "Recursively drop the DEV host-root view-evidence annotation
+  (:data-rf2-source-coord / :data-rf-view) the compiler stamps on each view's
+  compiler-owned root element (rf2-hac8p — the JVM `static-form` gate). These
+  structural goldens assert the canonical tree SHAPE, not the host-root
+  annotation, whose own coverage is the emit-annotation tests, the parity
+  corpus, and test:elision."
+  [node]
+  (if (map? node)
+    (let [node (if-let [a (:attrs node)]
+                 (let [a (dissoc a :data-rf2-source-coord :data-rf-view)]
+                   (if (seq a) (assoc node :attrs a) (dissoc node :attrs)))
+                 node)]
+      (cond-> node
+        (:children node) (update :children #(mapv strip-view-evidence %))))
+    node))
+
 (def ForeignThing ::not-a-view) ; resolvable var without view meta -> foreign
 
 (ui/custom-element :tree-fancy-el {:properties #{:help-text}})
@@ -118,7 +135,7 @@
                          :on-hover {:event [:row/hover 1] :prevent-default true}}
                 :children ["a"]}]}]}]
           :rf.ui/tree-version 1}
-         (tree/render rows {:ts [{:id 1 :label "a" :p :hi}]}))
+         (strip-view-evidence (tree/render rows {:ts [{:id 1 :label "a" :p :hi}]})))
       "event vectors + options maps retained verbatim as data; placeholder
        keywords stay keywords; boundaries nest; keys ride the boundary"))
 
@@ -207,7 +224,7 @@
 (deftest sub-grammar-compiles-untaken-branch-renders
   (is (= {:view-id ::subby :props {:read? false} :rf.ui/tree-version 1
           :children [{:tag :div}]}
-         (tree/render subby {:read? false}))
+         (strip-view-evidence (tree/render subby {:read? false})))
       "sub GRAMMAR compiles at S1; an untaken branch renders with no read")
   ;; S2b: reads LANDED — the staging :rf.error/ui-sub-unavailable is retired.
   ;; tree/render is frameless, so a taken read resolves the ambient frame
@@ -227,7 +244,7 @@
       "(declare ^:rf.ui/view pong) makes mutual view recursion expressible"))
 
 (deftest custom-element-and-spread-on-jvm
-  (let [el (first (:children (tree/render custom-el-user {})))]
+  (let [el (strip-view-evidence (first (:children (tree/render custom-el-user {}))))]
     (is (= {:tag :tree-fancy-el
             :attrs {:help-text "h" :data-x "d"}
             :rf.ui/property-props #{:help-text}}
@@ -241,7 +258,7 @@
 (deftest trusted-html-node
   (is (= {:tag :div :attrs {:class "content"}
           :children [{:html "<b>raw & bold</b>"}]}
-         (first (:children (tree/render trusted {}))))
+         (strip-view-evidence (first (:children (tree/render trusted {})))))
       "the trusted-HTML node variant — the single escaping bypass"))
 
 (deftest namespace-context-rows-on-jvm


### PR DESCRIPTION
98.1 slice **(c)** of the ruled S6 view-evidence schema delta (rf2-vxgfnd.98.1, RULING 1). IMPLEMENTATION-ONLY; the compiler DOM-emit path (`emit_cljs.cljc`) only. Disjoint from slice-b (`qkq2k`, reactive.cljc cause emission) and slice-d (`rvs56`, spec + version bump).

## What ships (.98.1 annotation shape ↔ emit)

Spec 004 §View identity (Source ↔ DOM navigation): *"Compile-time `data-rf2-source-coord` + render-key annotation on compiler-owned host roots — today's attribute vocabulary, so existing Xray click-to-source works day one. Dev-gated; production builds carry none of it."*

The compiler now stamps the view's **compiler-owned host root** DOM element with:

- **`data-rf2-source-coord`** = the canonical `<ns>:<sym>:<line>:<col>` source coordinate (click-to-source).
- **`data-rf-view`** = the view id — the record identity Xray matches its hover-highlight against (Xray 021 §View-hierarchy matches via `data-rf-view`).

Both values reuse the ONE cross-host `re-frame.source-coords` projections (`format-source-coord` / `format-view-id`), so the compiler-owned host root and the Reagent/UIx/Helix adapter walks emit **byte-identical** attribute values by construction.

`mark-host-root-annotation` stamps the marker on the view's **effective** root element — `:hook-prefix` / `:let` / `:letfn` wrappers are transparent; a non-element effective root (fragment / view / conditional / loop) carries none (the same host-root exemption the adapter source-coord walk applies).

## DEBUG-gated (dev-present / prod-absent)

The stamp mutates the host-root props object in place behind `^boolean js/goog.DEBUG` (mirroring the trusted-markup spread branch's `dangerouslySetInnerHTML` set), so Closure constant-folds the gate to false under `:advanced` + `goog.DEBUG=false` and DCEs the whole branch — the literal `data-rf2-source-coord` / `data-rf-view` strings never reach the production bundle (both are on the standard elision sentinel set; the elision-probe compiles real `re-frame.ui` defviews with DOM roots).

## Scope fences

- **render-key is NOT stamped on the DOM.** It is minted at *connected commit* in the ViewCell layout effect (`reactive/commit*`), which runs AFTER this child host element has already committed — no honest value for THIS commit exists at render time (reading it at render would be stale-by-one / nil-at-mount, an I-1/I-2 honesty violation). Stamping render-key onto the DOM is a **commit-time substrate concern**, out of the compiler slice. Filed as follow-up (see report).
- NO causes emitted (slice b). NO spec / version bump (slice d). `reactive.cljc` / `viewcell.cljs` / `spec/**` untouched; 55zsd's wrapper-shape `cond` logic not restructured (annotated within).

## Cross-emitter follow-up (mayor RULING — option A: PROP, cross-emitter, spec-faithful)

The DOM annotation is inherently cross-emitter: a compiler-owned host root exists on BOTH emitters, so the JVM emitter must annotate identically or the JVM↔CLJS parity gate diverges (the node-suite `parity_corpus_cljs_test` caught this). Per the ruling, `emit_jvm.cljc` now stamps the **identical** annotation — same `data-rf2-source-coord` / `data-rf-view`, same cross-host `re-frame.source-coords` projection (byte-identical values by construction), behind the JVM DEBUG gate `interop/debug-enabled?` (the counterpart to CLJS `goog.DEBUG`; off under `-Dre-frame.debug=false`). So the two emitters produce byte-identical DOM roots, SSR-rendered HTML carries the annotation (hydration-safe: SSR HTML and client render match), and production erases it on both hosts.

`emit_cljs.cljc` also gained the annotation on its `ui/spread` / `ui/spread-safe` host-root branches (hac8p had wired it only into the plain-element branch) — a spread element is a single compiler-owned DOM host node, so it earns the same annotation as any other root (parity with `emit_jvm` and the adapter source-coord walk, which annotate every DOM-tag root regardless of prop shape).

Goldens that assert the exact host-root output were updated for the annotated shape: the two `react-dom/server` HTML goldens (`react_render` / `binding_plan_host_faithful`) strip the DEV annotation in their shared `render` helper (their subject is prop conversion / binding plans, not the host-root annotation, which has its own dedicated coverage); the JVM raw-tree structural goldens (`tree_jvm_test`, `custom_element_classification_jvm_test`, `custom_element_harvest_hook_jvm_test`, `test_render_jvm_test`) strip the two annotation attrs before their canonical-shape assertions; the prod-parity gate `parity_corpus_elision_prod_test` strips the DEV-only annotation from the shared JVM truth (computed in the compiler JVM where `debug-enabled?` is true) so it meets the advanced-CLJS side — which DCEs it — in one semantic space, mirroring the existing `strip-ce-property-props` precedent.

## Second layer — SSR static path + browser client mounts

The cross-emitter annotation rides the JVM structural tree (correct — it matches the client render for the SSR-then-hydrate path), but that surfaced two more touched-surface gates:

- **`ui/render-static`** is the pure `:server`, NON-hydrating static path (Spec 011 §Phase flip): its inert HTML carries no manifest / hydration payload / dev / adoption markers, and its contract test explicitly pins `data-rf2-source-coord` / `data-rf-view` absent. `re-frame.ui.tree/emit-static-html` — the render-static-EXCLUSIVE late-resolve serialisation seam — now strips the DEV host-root annotation from the tree before the pure static serialisation, exactly as `goog.DEBUG=false` / `-Dre-frame.debug=false` erases it in production. The hydrating `render-to-string` (a separate `re-frame.ssr.emit` hiccup serialiser + the reg-view boundary walk) is untouched, so SSR-then-hydrate HTML still carries the annotation and matches the client DOM.
- **Browser `:browser-test`** (real Chromium client mounts): `root_mount_dom` / `preflight_frame_wiring_dom` pin bare host-root `innerHTML`; the dev annotation legitimately appears on the mounted DOM, so those pins strip it before matching (subject is the rendered template / transparent frame scoping, not the annotation).

## Quality gates

All run **foreground to completion, unpiped** (the earlier "deferred to CI" note is what let CI go red — now fixed and every gate verified locally, including the two the CI run flagged):

- `cd implementation/ssr && clojure -M:test` — **523 tests, 2519 assertions, 0 failures, 0 errors** (the previously-RED `JVM ssr` gate). `render-static` output is annotation-free again.
- `npm run test:browser` — **514 tests, 2879 assertions, 0 failures, 0 errors** (the previously-RED `CLJS :browser-test, headless Chromium` gate). Client-mount DOM pins updated.
- `npm run test:cljs` — **10373 tests, 51196 assertions, 0 failures, 0 errors** (node `:node-test`, cold compile). This is the gate CI first failed on; the cross-emitter `emit_jvm` annotation closes the JVM↔CLJS parity divergence.
- `cd implementation/ui && clojure -M:test` — **1041 tests, 20072 assertions, 0 failures, 0 errors** (JVM). The JVM raw-tree structural goldens strip the two annotation attrs before their canonical-shape assertions.
- `npm run test:elision` — **PASS** (production 60/60 sentinels absent). The annotation reuses the already-elided `data-rf2-source-coord` / `data-rf-view` sentinels behind the `goog.DEBUG` gate.
- `npm run test:browser-prod-elision` — **118 tests, 0 failures, 0 errors**; `ui mounted production elision: PASS`. 55zsd's wrapper fixtures intact; the prod-parity gate strips the DEV-only annotation from the JVM truth to meet the DCE'd advanced-CLJS side.
- New dual-host `.cljc` golden (`emit_cljs_view_evidence_annotation_cljs_test.cljc`) + JVM end-to-end (`..._jvm_test.clj`): marked host root → DEV-gated `data-rf2-source-coord` + `data-rf-view` stamp with canonical values; unmarked element unchanged; wrapper-transparency; non-element / fragment / conditional roots exempt; `js/goog.DEBUG` gate.

