### PR TITLE
feat(ui): view-evidence cause-vector emission — 8 ruled causes; epoch-restore stop-reported (rf2-qkq2k)

### DIFF
--- a/implementation/ui/src/re_frame/ui/hooks.cljc
+++ b/implementation/ui/src/re_frame/ui/hooks.cljc
@@ -29,7 +29,8 @@
   #?(:cljs (:require ["react" :as react]
                      [re-frame.error :as error]
                      [re-frame.ui.eq :as eq]
-                     [re-frame.ui.events :as events])
+                     [re-frame.ui.events :as events]
+                     [re-frame.ui.reactive :as reactive])
      :clj  (:require [re-frame.ui.tree :as tree])))
 
 #?(:cljs
@@ -65,7 +66,17 @@
   "React `useState`-backed `[value set! update!]`. `set!` stores its argument
   exactly (a stored fn is a value, never an updater); `update!` applies
   `(f current & args)` to the LATEST host state so several same-turn writers
-  compose (React's functional updater queues them against the live state)."
+  compose (React's functional updater queues them against the live state).
+
+  DEV-only view-evidence bridge (Ruling 2 :local-state): each host-only
+  `set!`/`update!` records `:local-state` as the cause of the re-render it just
+  triggered, so the ViewCell's NEXT connected commit attributes its
+  :rf.view/causes to the local write. The owning cell is captured ONCE at
+  setter-mint time (the first render, which runs inside the ambient
+  `with-capture`); React — not the ViewCell scheduler — owns the re-render, so the
+  bridge only STASHES the cause (`reactive/note-local-state!`), never marks the
+  cell dirty or advances a revision. The whole bridge is `goog.DEBUG`-gated at
+  both ends and elides in production."
   [init]
   (let [pair      (react/useState init)
         value     (aget pair 0)
@@ -74,19 +85,22 @@
     ;; The React setter identity is stable across renders, so set!/update! are
     ;; minted once and kept stable (attach them as handlers/listeners freely).
     (when (nil? (.-current ops))
-      (let [setter  (fn local-set!
+      (let [cell    (when ^boolean js/goog.DEBUG (reactive/ambient-cell))
+            setter  (fn local-set!
                       [v]
                       (when ^boolean js/goog.DEBUG
                         (when (.-v render-active) (fail-render-phase!)))
                       ;; ALWAYS the functional form: a stored fn is returned
                       ;; verbatim, never invoked as a React updater.
                       (react-set (fn [_] v))
+                      (when ^boolean js/goog.DEBUG (reactive/note-local-state! cell))
                       nil)
             updater (fn local-update!
                       [f & args]
                       (when ^boolean js/goog.DEBUG
                         (when (.-v render-active) (fail-render-phase!)))
                       (react-set (fn [cur] (apply f cur args)))
+                      (when ^boolean js/goog.DEBUG (reactive/note-local-state! cell))
                       nil)]
         (set! (.-current ops) #js [setter updater])))
     [value (aget (.-current ops) 0) (aget (.-current ops) 1)]))

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -583,11 +583,21 @@
   ;;                             ;   in production (elided) + between flushes
   ;;    :listeners {k -> fn}     ; useSyncExternalStore subscribers
   ;;    :intervals [interval]     ; lifecycle facts (dev/tool; 03 §4)
+  ;;    :pending-commit-causes #{…} ; DEBUG-only raw causes
+  ;;                             ;   (:value/:hmr/:disposed/:local-state)
+  ;;                             ;   accumulated since the last connected commit —
+  ;;                             ;   fed by complete-flush! (the flushed window's
+  ;;                             ;   cause set) and the hooks local-state bridge
+  ;;                             ;   (`note-local-state!`). The NEXT connected
+  ;;                             ;   commit PROJECTS them into :rf.view/causes and
+  ;;                             ;   clears the slot. ABSENT in production (elided)
+  ;;                             ;   and whenever no cause is pending (Ruling 2)
   ;;    :commit-record {…}|nil}  ; DEBUG-only S6 committed-instance record from
-  ;;                             ;   the most-recent CONNECTED commit (Ruling 1;
+  ;;                             ;   the most-recent CONNECTED commit (Ruling 1/2;
   ;;                             ;   integer render-key + per-observation
-  ;;                             ;   observations). ABSENT in production (elided)
-  ;;                             ;   and nil before the first connect
+  ;;                             ;   observations + the per-commit :rf.view/causes
+  ;;                             ;   vector). ABSENT in production (elided) and nil
+  ;;                             ;   before the first connect
   )
 
 (defn cell?
@@ -1134,6 +1144,15 @@
       #?(:clj  (with-slice-memo (fn [] (let [el (thunk)] [el @cap])))
          :cljs (let [el (thunk)] [el @cap])))))
 
+(defn ambient-cell
+  "The ViewCell of the ambient render capture, or nil outside a render. The
+  `re-frame.ui.hooks` local-state bridge reads this at setter-mint time (which
+  runs inside `with-capture`) so a later host-only `set!`/`update!` can attribute
+  its re-render to the owning cell (`note-local-state!`; Ruling 2 :local-state).
+  Internal runtime seam."
+  []
+  (:cell *ambient*))
+
 ;; ---- useSyncExternalStore contract ------------------------------------------
 
 (defn get-snapshot
@@ -1647,9 +1666,20 @@
     (loop []
       (let [s @st]
         (when (:dirty? s)
-          (let [cleared (-> s
-                            (assoc :dirty? false :evidence nil)
-                            (update :revision inc))]
+          ;; DEBUG plane (Ruling 2): carry the flushed window's cause set
+          ;; FORWARD to the next connected commit's :rf.view/causes. The window's
+          ;; evidence is cleared here (scheduler ownership), so the causes cannot
+          ;; be re-read at the later re-render/commit — the flush stashes them.
+          ;; `interop/debug-enabled?` is a STANDALONE gate so Closure DCEs the
+          ;; whole `:pending-commit-causes` arm (and its keyword/`into`) out of the
+          ;; advanced production bundle, exactly as the invalidation-evidence fold
+          ;; already elides.
+          (let [ev-causes (when interop/debug-enabled? (seq (:causes (:evidence s))))
+                cleared   (cond-> (-> s
+                                      (assoc :dirty? false :evidence nil)
+                                      (update :revision inc))
+                            ev-causes (update :pending-commit-causes
+                                              (fnil into #{}) ev-causes))]
             (when-some [barrier *completion-barrier*] (barrier cell))
             (if (compare-and-set! st s cleared)
               [cell (when interop/debug-enabled? (:evidence s))]
@@ -2009,7 +2039,14 @@
   (letfn [(detach-and-clear! []
             (let [[detached _] (swap-vals! dirty-cells (constantly #{}))]
               (doseq [cell detached]
-                (swap! (state cell) assoc :dirty? false :evidence nil))))]
+                (swap! (state cell)
+                       (fn [m]
+                         (-> (assoc m :dirty? false :evidence nil)
+                             ;; DEBUG-only carry-forward slot (Ruling 2): a fixture
+                             ;; clean slate must not leak stashed causes across
+                             ;; tests. Absent in production, so this dissoc is a
+                             ;; no-op there.
+                             (dissoc :pending-commit-causes)))))))]
     #?(:clj  (locking dirty-cells (detach-and-clear!))
        :cljs (detach-and-clear!)))
   (reset! flush-scheduled? false)
@@ -3812,8 +3849,14 @@
 ;;     claims NO singular top-level :frame-id.
 ;;   - :parent-render-key is DEFERRED — no S6 surface consumes view parentage, so
 ;;     NO parent-capture machinery exists here.
-;;   - :rf.view/causes (the per-commit cause vector) rides a LATER slice; this
-;;     record carries no causes slot yet.
+;;   - :rf.view/causes is the per-commit cause VECTOR (Ruling 2, slice b): the
+;;     nine ruled kinds projected from their EXISTING sources, never a new capture
+;;     machine. :mount / :hmr-remount from the connect lifecycle + HMR slot;
+;;     :story-override from a (re)acquired override target; :subscription / :hmr /
+;;     :disposed / :local-state carried forward from the flushed pending-window
+;;     cause set (:value -> :subscription) via `:pending-commit-causes`; and
+;;     :foreign-or-react as the honesty fallback when a commit carries no cause.
+;;     :epoch-restore is NOT emitted here (see `commit-causes`).
 ;; ---------------------------------------------------------------------------
 
 (defonce ^:private render-key-counter
@@ -3856,23 +3899,115 @@
              :owned?    (= :subscription kind)}))
         new-order))
 
+(defn note-local-state!
+  "DEBUG-only bridge (Ruling 2 :local-state): the substrate-owned local writer
+  (`re-frame.ui.hooks` `local-state` `set!`/`update!`) records that a host-only
+  local mutation drove `cell`'s next re-render. React (not the ViewCell
+  scheduler) owns that re-render, so there is no flush to carry the cause through
+  the pending window — the writer stashes `:local-state` DIRECTLY into the
+  carry-forward slot the next connected commit projects into :rf.view/causes.
+  No-op on a nil cell (a `local` used outside a live capture) and elided whole in
+  production. Never marks the cell dirty or advances a revision — React already
+  re-renders, so double-scheduling is deliberately avoided. Returns nil."
+  [^ViewCell cell]
+  (when (and interop/debug-enabled? (some? cell))
+    (swap! (state cell) update :pending-commit-causes (fnil conj #{}) :local-state))
+  nil)
+
+(def ^:private ^:const cause-order
+  "The canonical, deterministic ordering of the S6 :rf.view/causes roster
+  (Ruling 2). A commit's cause SET is projected into a vector in this order so
+  the record is stable across hosts and runs. `:epoch-restore` keeps its ruled
+  slot for a future producer even though slice b emits none (see `commit-causes`);
+  `:foreign-or-react` is the standalone honesty fallback."
+  [:mount :hmr-remount :story-override :subscription
+   :local-state :hmr :disposed :epoch-restore :foreign-or-react])
+
+(defn- s6-cause
+  "Map a RAW pending-window / stash cause to its S6 :rf.view/causes vocabulary.
+  Only `:value` is renamed (to `:subscription`, Ruling 2); every other stashed
+  cause (`:hmr` / `:disposed` / `:local-state`) already carries its S6 spelling.
+  The `:value` -> `:subscription` rename lives HERE (projection-time), never at
+  the port note: the port keyword rename rides slice d's schema-version bump that
+  moves the pinned Xray/Pair consumers in lockstep — projecting the new vector
+  from the still-`:value` port note keeps the two vocabularies from colliding
+  before that coordinated bump."
+  [raw]
+  (case raw
+    :value :subscription
+    raw))
+
+(defn- commit-causes
+  "Project THIS connected commit's :rf.view/causes vector (Ruling 2) from
+  signals that ALREADY exist — no new capture machinery:
+
+    - :mount          `mounting?` — the cell's pre-commit lifecycle was :fresh
+                      (the :fresh->:connected transition).
+    - :hmr-remount    a mount whose view has a non-zero HMR remount generation
+                      (`view-remount-generation`) — the hook-signature-change
+                      remount key already on the HMR slot. (Honest at view
+                      granularity: a fresh instance of a previously-remounted view
+                      also reads > 0; the DEV signal is 'mounted under a remounted
+                      view'.)
+    - :story-override a (re)acquired site this commit whose target is a static
+                      Story override (`:story-override` kind) — classification of
+                      the render capture, not reconstruction.
+    - :subscription / :hmr / :disposed / :local-state
+                      the causes the last flush (or the local-state bridge)
+                      carried forward in `:pending-commit-causes`, mapped through
+                      `s6-cause`.
+    - :foreign-or-react
+                      the honesty fallback (Ruling 2) — a commit that carries no
+                      other cause (a foreign React re-render, or a headless value
+                      move caught at commit step 5 with no evidence window).
+
+  `:epoch-restore` is deliberately absent: its ruled emission — threading the
+  restore-operation token through the port fan-out — is NOT a clean projection of
+  an existing signal, because the value-movement watch fires from the DEFERRED
+  reactive commit loop, outside the restore's dynamic extent (see the worker
+  report / STOP-REPORT). Consumers already tolerate its absence (Xray 021 §3.4.1).
+  Empty by construction is impossible: the fallback always yields at least one."
+  [stash-causes mounting? remount? override?]
+  (let [present (cond-> (into #{} (map s6-cause) stash-causes)
+                  mounting? (conj :mount)
+                  remount?  (conj :hmr-remount)
+                  override? (conj :story-override))]
+    (if (empty? present)
+      [:foreign-or-react]
+      (filterv present cause-order))))
+
 (defn- mint-commit-record!
   "DEBUG-only: mint a fresh monotonic :render-key and publish the S6
-  committed-instance record onto `cell` for THIS connected commit (Ruling 1).
+  committed-instance record onto `cell` for THIS connected commit (Ruling 1/2).
   Reads the cell's just-published state, so :view-id / :generation / :root-id
   reflect the commit that connected. `:root-id` is the owning root incarnation —
   the opaque per-mount token the tool projection resolves to the authored root-id
-  name (nil under no root, e.g. Tier-1/JVM). Returns the record."
-  [^ViewCell cell cap new-order new-by]
-  (let [st     (state cell)
-        st0    @st
-        record {:render-key   (next-render-key!)
-                :view-id      (:view-id st0)
-                :generation   (:generation cap)
-                :root-id      (:root st0)
-                :connection   :connected
-                :observations (project-observations new-order new-by)}]
-    (swap! st assoc :commit-record record)
+  name (nil under no root, e.g. Tier-1/JVM). Projects the per-commit
+  :rf.view/causes vector (Ruling 2) from the carry-forward cause stash plus the
+  commit-time lifecycle / override facts, then CLEARS the stash so a subsequent
+  causeless re-render honestly reports :foreign-or-react. `mounting?` is the cell's
+  PRE-connect lifecycle fact (`:fresh`), read by the caller before `connect!`.
+  Returns the record."
+  [^ViewCell cell cap new-order new-by mounting? to-acquire]
+  (let [st        (state cell)
+        st0       @st
+        view-id   (:view-id st0)
+        override? (boolean (some (fn [sid]
+                                   (= :story-override
+                                      (:kind (:target (new-by sid)))))
+                                 to-acquire))
+        remount?  (and mounting? (pos? (view-remount-generation view-id)))
+        causes    (commit-causes (:pending-commit-causes st0)
+                                 mounting? remount? override?)
+        record    {:render-key    (next-render-key!)
+                   :view-id       view-id
+                   :generation    (:generation cap)
+                   :root-id       (:root st0)
+                   :connection    :connected
+                   :observations  (project-observations new-order new-by)
+                   :rf.view/causes causes}]
+    (swap! st (fn [m] (-> (assoc m :commit-record record)
+                          (dissoc :pending-commit-causes))))
     record))
 
 (defn- commit*
@@ -4134,15 +4269,21 @@
                             incarnations))
                 (teardown! cell)
                 (do
-                  ;; S6 committed-instance record (Ruling 1; EP-0033 §Two evidence
-                  ;; layers). Only a CONNECTED commit reaches here — a stale,
-                  ;; superseded, torn-down or never-committed (speculative) render
-                  ;; publishes nothing, so no instance is fabricated (I-1/I-2). Mint
-                  ;; a fresh monotonic :render-key + the per-commit record.
+                  ;; S6 committed-instance record (Ruling 1/2; EP-0033 §Two
+                  ;; evidence layers). Only a CONNECTED commit reaches here — a
+                  ;; stale, superseded, torn-down or never-committed (speculative)
+                  ;; render publishes nothing, so no instance is fabricated
+                  ;; (I-1/I-2). Mint a fresh monotonic :render-key + the per-commit
+                  ;; record, incl. the Ruling-2 :rf.view/causes vector. `st0` is the
+                  ;; PRE-`connect!` state read at the top of `commit*`, so its
+                  ;; `:fresh` lifecycle is the honest :mount fact (connect! has since
+                  ;; flipped it to :connected); `to-acquire` names the (re)acquired
+                  ;; sites, classifying a moved Story override.
                   ;; DEBUG-ONLY: the whole plane is production-erased (G-7/G-11), so
                   ;; this DCEs under goog.DEBUG=false and no render-key advances.
                   (when interop/debug-enabled?
-                    (mint-commit-record! cell cap new-order new-by))
+                    (mint-commit-record! cell cap new-order new-by
+                                         (= :fresh (:lifecycle st0)) to-acquire))
                   ;; step 8 — moved evidence corrects before paint. The staged catch
                   ;; always advances synchronously; a RETAINED catch advances only when
                   ;; no live watch already caught the move — a pending (`dirty?`) cell is
@@ -4220,12 +4361,13 @@
 (defn commit-record
   "The cell's most-recent CONNECTED-commit S6 committed-instance record, or nil
   when the cell has never connected — and always nil in a production build, where
-  the view-evidence plane is elided. The per-commit record (Ruling 1; EP-0033
+  the view-evidence plane is elided. The per-commit record (Ruling 1/2; EP-0033
   §Two evidence layers): integer :render-key, :view-id, :generation, :root-id,
-  :connection, and a per-observation :observations vector. There is deliberately
-  NO singular :frame-id (frame attribution is per-observation), NO
-  :parent-render-key (deferred), and no causes slot yet (a later slice).
-  Tool/test read."
+  :connection, a per-observation :observations vector, and the per-commit
+  :rf.view/causes vector (Ruling 2 — the nine ruled kinds projected from their
+  existing sources; `:epoch-restore` is not produced by slice b). There is
+  deliberately NO singular :frame-id (frame attribution is per-observation) and NO
+  :parent-render-key (deferred). Tool/test read."
   [^ViewCell cell]
   (:commit-record @(state cell)))
 

--- a/implementation/ui/test/re_frame/ui/reactive_commit_causes_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_commit_causes_cljs_test.cljc
@@ -1,0 +1,221 @@
+(ns re-frame.ui.reactive-commit-causes-cljs-test
+  "rf2-qkq2k (S6 slice b) — the per-commit `:rf.view/causes` vector on the REAL
+  ViewCell commit path (Ruling 2). A connected commit projects the NINE ruled
+  cause kinds from signals that ALREADY exist — never a new capture machine:
+
+    :mount          the :fresh->:connected transition (pre-commit lifecycle).
+    :hmr-remount    a mount whose view has a non-zero HMR remount generation.
+    :story-override a (re)acquired site whose target is a static Story override.
+    :subscription   a `:value` port note carried forward by the flush (renamed).
+    :local-state    the hooks local-state writer bridge (`note-local-state!`).
+    :hmr            a real registrar-replacement `:hmr` fan-out, flushed forward.
+    :disposed       a `:disposed` port note carried forward by the flush.
+    :foreign-or-react the honesty fallback — a commit that carries no other cause.
+
+  `:epoch-restore` is the ninth ruled kind but is NOT produced by slice b: its
+  emission (threading the restore-operation token through the port fan-out) is
+  not a clean projection of an existing signal, because the value-movement watch
+  fires from the DEFERRED reactive commit loop, outside the restore's dynamic
+  extent (worker STOP-REPORT). Consumers already tolerate its absence (Xray 021
+  §3.4.1) — the same way they tolerate the deferred five.
+
+  The DEBUG carry-forward (`:pending-commit-causes`) is the seam the flush and
+  the local-state bridge feed and the next connected commit drains: on the
+  headless plain-atom hosts a value MOVE has no watch (it is caught at commit
+  step 5, never fanned), so the `:value`/`:disposed` port notes are driven
+  through the SAME private `enrol-dirty!` the watchable-host on-change calls —
+  the honest payload, not a simulation. `:hmr` rides the REAL registrar fan-out.
+
+  `.cljc` ending `-cljs-test` rides `npm run test:cljs` (node) AND
+  `clojure -M:test` (JVM), so the cause vector is graft-checked on both hosts
+  over the plain-atom adapter."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core                 :as rf]
+            [re-frame.frame                :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.ui.reactive          :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(def ^:private fid :rf/default)
+
+(defn- seed! [db] (frame/replace-app-db! fid db))
+
+(defn- causes [cell] (:rf.view/causes (reactive/commit-record cell)))
+
+(defn- render+commit!
+  "Render (probe) `sites` (`[[sid query] …]`) under the ambient frame, then commit."
+  [cell sites]
+  (let [[_ cap] (rf/with-frame fid
+                  (reactive/with-capture
+                    cell
+                    (fn [] (mapv (fn [[sid q]] (reactive/sub-read sid q)) sites))))]
+    (reactive/commit! cell cap))
+  cell)
+
+(defn- connect-empty!
+  "Commit one empty render so `cell` connects with no observation owners."
+  [cell]
+  (let [[_ cap] (reactive/with-capture cell (fn [] nil))]
+    (reactive/commit! cell cap))
+  cell)
+
+;; The private on-change enrolment the watchable-host value-move / disposal
+;; fan-out calls — the honest payload driver on a headless host (which has no
+;; value-move watch, per the observation-port host-honesty note).
+(def ^:private enrol-dirty! @#'reactive/enrol-dirty!)
+
+(defn- fan-cause!
+  "Fold ONE `cause`-tagged port note (targeting `query`) into `cell`'s pending
+  window exactly as the watchable-host on-change would, then flush it FORWARD."
+  [cell cause query]
+  (enrol-dirty! cell {:cause       cause
+                      :target      {:kind :subscription :frame-id fid :query query}
+                      :frame-epoch 1})
+  (reactive/flush-pending!))
+
+;; ===========================================================================
+;; :mount — the first connected commit (:fresh -> :connected)
+;; ===========================================================================
+
+(deftest mount-is-the-first-connected-commits-cause
+  (rf/reg-sub :cc/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (reactive/make-cell ::v)]
+    (render+commit! cell [[[:cc/site 0] [:cc/a]]])
+    (is (= [:mount] (causes cell))
+        "a first connected commit is caused by :mount, and nothing else")))
+
+;; ===========================================================================
+;; :foreign-or-react — the honesty fallback (a causeless re-commit)
+;; ===========================================================================
+
+(deftest a-causeless-recommit-is-foreign-or-react
+  (rf/reg-sub :cc/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (reactive/make-cell ::v)]
+    (render+commit! cell [[[:cc/site 0] [:cc/a]]])
+    (is (= [:mount] (causes cell)))
+    (testing "a second commit with no movement, stash, or new acquire is honest"
+      (render+commit! cell [[[:cc/site 0] [:cc/a]]])
+      (is (= [:foreign-or-react] (causes cell))
+          "no cause pending, connected, retained leases -> the honesty fallback"))))
+
+;; ===========================================================================
+;; :subscription — a :value port note, carried forward + renamed
+;; ===========================================================================
+
+(deftest a-value-movement-recommits-as-subscription
+  (rf/reg-sub :cc/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (reactive/make-cell ::v)]
+    (render+commit! cell [[[:cc/site 0] [:cc/a]]])
+    (fan-cause! cell :value [:cc/a])          ;; the flush stashes :value forward
+    (render+commit! cell [[[:cc/site 0] [:cc/a]]])
+    (is (= [:subscription] (causes cell))
+        ":value is renamed to :subscription at projection (Ruling 2)")))
+
+;; ===========================================================================
+;; :disposed — a :disposed port note, carried forward verbatim
+;; ===========================================================================
+
+(deftest a-disposal-recommits-as-disposed
+  (rf/reg-sub :cc/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (reactive/make-cell ::v)]
+    (render+commit! cell [[[:cc/site 0] [:cc/a]]])
+    (fan-cause! cell :disposed [:cc/a])
+    (render+commit! cell [[[:cc/site 0] [:cc/a]]])
+    (is (= [:disposed] (causes cell))
+        ":disposed rides forward unchanged")))
+
+;; ===========================================================================
+;; :hmr — a REAL registrar-replacement fan-out, flushed forward
+;; ===========================================================================
+
+(deftest a-real-hmr-reregistration-recommits-as-hmr
+  (rf/reg-sub :cc/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (render+commit! (reactive/make-cell ::v) [[[:cc/site 0] [:cc/a]]])]
+    (is (= [:mount] (causes cell)))
+    (rf/reg-sub :cc/a (fn [db _] (:a db)))     ;; real :hmr fan-out to the lease
+    (is (reactive/dirty? cell) "the HMR invalidation marked the cell dirty")
+    (is (= #{:hmr} (:causes (reactive/pending-evidence cell)))
+        "the real :hmr cause is in the pending window")
+    (reactive/flush-pending!)                  ;; carries :hmr forward
+    (render+commit! cell [[[:cc/site 0] [:cc/a]]])
+    (is (= [:hmr] (causes cell))
+        "a real registrar-replacement fan-out projects :hmr")))
+
+;; ===========================================================================
+;; :local-state — the hooks local-state writer bridge
+;; ===========================================================================
+
+(deftest a-local-state-write-recommits-as-local-state
+  (rf/reg-sub :cc/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (render+commit! (reactive/make-cell ::v) [[[:cc/site 0] [:cc/a]]])]
+    (reactive/note-local-state! cell)          ;; the substrate-owned local writer
+    (render+commit! cell [[[:cc/site 0] [:cc/a]]])
+    (is (= [:local-state] (causes cell))
+        "a host-only local write is the honest cause of its re-render")))
+
+(deftest note-local-state-is-a-no-op-on-a-nil-cell
+  (is (nil? (reactive/note-local-state! nil))
+      "a (local …) used outside a live capture stashes nothing and never throws"))
+
+;; ===========================================================================
+;; :story-override — a (re)acquired static Story-override target
+;; ===========================================================================
+
+(deftest a-moved-story-override-recommits-as-story-override
+  (rf/reg-sub :cc/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (reactive/make-cell ::v)]
+    (binding [reactive/*sub-overrides* {[:cc/a] 10}]
+      (render+commit! cell [[[:cc/site 0] [:cc/a]]]))
+    (is (= #{[:override [:cc/a]]} (reactive/committed-target-keys cell))
+        "the site resolved to a static override target")
+    (is (contains? (set (causes cell)) :mount)
+        "the first override commit is a mount")
+    (testing "moving the override retargets the site -> :story-override, not mount"
+      (binding [reactive/*sub-overrides* {[:cc/a] 20}]      ;; new value -> retarget
+        (render+commit! cell [[[:cc/site 0] [:cc/a]]]))
+      (is (= [:story-override] (causes cell))
+          "a re-acquired override target classifies the commit as :story-override"))))
+
+;; ===========================================================================
+;; :hmr-remount — a mount whose view has a non-zero HMR remount generation
+;; ===========================================================================
+
+(deftest a-mount-under-a-remounted-view-is-hmr-remount
+  (let [vid ::remount-view]
+    (reactive/register-view-descriptor! vid :sig-a {:impl :a})
+    (reactive/register-view-descriptor! vid :sig-b {:impl :b})   ;; hook shape change
+    (is (= 1 (reactive/view-remount-generation vid))
+        "an incompatible hook edit advanced the remount generation")
+    (let [gen  (reactive/view-generation vid)          ;; the current body revision
+          cell (reactive/make-cell vid gen)]           ;; mint at the live revision
+      (connect-empty! cell)
+      (is (= [:mount :hmr-remount] (causes cell))
+          "a mount under a remounted view carries BOTH :mount and :hmr-remount"))))
+
+;; ===========================================================================
+;; Canonical order — the cause vector is deterministic across hosts/runs
+;; ===========================================================================
+
+(deftest the-cause-vector-is-in-canonical-order
+  (rf/reg-sub :cc/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (reactive/make-cell ::v)]
+    ;; A mount that ALSO carries a movement: mount + a stashed :value.
+    (fan-cause! cell :value [:cc/a])           ;; stash :value onto the fresh cell
+    (render+commit! cell [[[:cc/site 0] [:cc/a]]])
+    (is (= [:mount :subscription] (causes cell))
+        ":mount precedes :subscription in the canonical roster order")))

--- a/implementation/ui/test/re_frame/ui/reactive_commit_record_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_commit_record_cljs_test.cljc
@@ -10,10 +10,12 @@
   over the plain-atom adapter — the same headless discipline the reconcile
   fixtures use.
 
-  Scope fence (slice a): this slice mints the record shape ONLY. It emits NO
-  causes (`:rf.view/causes` is a LATER slice), invents NO :parent-render-key
-  (deferred — no capture machinery), and claims NO singular top-level :frame-id
-  (frame attribution is PER-OBSERVATION)."
+  Scope fence: slice a minted the record shape; slice b (rf2-qkq2k) added the
+  per-commit `:rf.view/causes` vector — this file now asserts a first connected
+  commit is caused by `:mount`. The record still invents NO :parent-render-key
+  (deferred — no capture machinery) and claims NO singular top-level :frame-id
+  (frame attribution is PER-OBSERVATION). The full per-cause cause-vector proof
+  lives in `reactive_commit_causes_cljs_test`."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core                 :as rf]
@@ -67,14 +69,19 @@
       (is (vector? (:observations record)) ":observations is a vector")
       (is (= (reactive/render-key cell) (:render-key record))
           "the render-key reader mirrors the record's :render-key"))
-    (testing "slice-a scope fences — the record ships NONE of the later slices"
+    (testing "slice-a scope fences — the record still invents no deferred fields"
       (let [record (reactive/commit-record cell)]
         (is (not (contains? record :parent-render-key))
             "no :parent-render-key is invented (deferred — no capture machinery)")
         (is (not (contains? record :frame-id))
-            "no singular top-level :frame-id (attribution is per-observation)")
-        (is (not (contains? record :rf.view/causes))
-            "no causes slot yet (that is a later slice)")))))
+            "no singular top-level :frame-id (attribution is per-observation)")))
+    (testing "slice-b adds the per-commit :rf.view/causes vector (Ruling 2)"
+      (let [record (reactive/commit-record cell)]
+        (is (contains? record :rf.view/causes)
+            "the causes vector now ships on the record")
+        (is (vector? (:rf.view/causes record)) ":rf.view/causes is a vector")
+        (is (= [:mount] (:rf.view/causes record))
+            "a first connected commit is caused by :mount")))))
 
 ;; ===========================================================================
 ;; render-key is monotonic, minted fresh PER COMMIT


### PR DESCRIPTION
Slice (b) of rf2-vxgfnd.98.1 (Ruling 2). Adds the per-commit `:rf.view/causes` vector to the S6 committed-instance record shipped by slice (a) (#6562), projected from signals that **already exist** — no new capture machine.

## The 8 causes shipped (Ruling 2 source → emission)

| cause | Ruling 2 source | emission site |
|---|---|---|
| `:mount` | first connected commit (`:fresh`→`:connected`) | `commit*` reads the pre-`connect!` `st0` lifecycle |
| `:subscription` | the port note's `:cause :value` (+ target) | `:value` folded → flush stashes → projection renames `:value`→`:subscription` |
| `:story-override` | the port note whose target IS the override target | a `(re)acquired` `:story-override`-kind site in `to-acquire` |
| `:local-state` | `hooks.cljc` `local-state` `set!`/`update!` bridges to the cell | `reactive/note-local-state!` stashes `:local-state` directly |
| `:hmr` | ships from the port; keep | real registrar-replacement `:hmr` fan-out → evidence → flush stash |
| `:hmr-remount` | `:hmr-remount-generation` on the HMR slot | a mount whose `view-remount-generation` > 0 |
| `:disposed` | roster addition (ships from the port) | `:disposed` port note folded → flush stash |
| `:foreign-or-react` | commit-path tag when the pending window is empty | the fallback when no other cause is present |

**The carry-forward seam.** The pending-window evidence is cleared at `complete-flush!` **before** the deferred re-render/commit, so the causes cannot be re-read at commit. `complete-flush!` (and the local-state bridge) stash the cause set into a DEBUG-only per-cell `:pending-commit-causes` slot; the next connected commit drains it into `:rf.view/causes` and clears it. The `:value`→`:subscription` rename lives at **projection** time, never at the port note — that keyword rename rides slice (d)'s schema-version bump that moves the pinned Xray/Pair consumers in lockstep.

## Deferred / stop-reported

- **DEFER 5** (`:prop`, `:frame`/`:context`, `:resource`, `:hydration-correction`, `:reconnect-correction`) — NOT emitted, as ruled.
- **`:epoch-restore` STOP-REPORTED.** Ruling 2 assumed "thread the restore-operation token through the port fan-out" is a clean projection of an existing signal. It is not: the value-movement watch fires from the **deferred** reactive commit loop (Reagent/React spine), outside `perform-restore!`'s dynamic extent — and the headless plain-atom hosts have **no** value-movement watch at all (movement is caught at commit step 5, never fanned). A `binding` around the restore write is therefore not active when the note fires. Making it work needs new capture infra to carry restore provenance to the deferred movement — beyond the fence. Consumers already tolerate its absence (Xray 021 §3.4.1), exactly as the deferred five.

## Scope

Touches only `reactive.cljc` (causes vector + carry-forward + HMR slot read), `hooks.cljc` (local-state bridge), and tests. **Not touched:** `emit_cljs.cljc` (slice c), `viewcell.cljs` render-frame, `spec/**` (slice d), `ai/**`, the 5 deferred causes.

## Quality gates

- `cd implementation/ui && clojure -M:test` — **1032 tests / 19844 assertions, 0 failures**
- `npm run test:cljs` (cross-artefact) — **10369 tests / 51181 assertions, 0 failures**
- `npm run test:elision` — **PASS** (production 60/60 absent). Direct proof: the causes-only keyword strings (`rf.view/causes`, `foreign-or-react`, `pending-commit-causes`) are absent from the `:advanced` counter bundle while the reactive substrate state keys are retained.
- Red→green per-cause coverage in `reactive_commit_causes_cljs_test.cljc` (10 tests, both hosts).

Do NOT merge — slice (d) `rvs56` blocks on this + slice (c).