### PR TITLE
fix(examples): RealWorld editor releases its app-minted owner via causal events (rf2-y4mgw)

### DIFF
--- a/examples/real-apps/realworld_resources/article_editor.cljs
+++ b/examples/real-apps/realworld_resources/article_editor.cljs
@@ -53,7 +53,6 @@
             ;; `:rf.fx/reg-flow` effect has something to resolve against; without
             ;; it, the effect raises.
             [re-frame.flows]
-            [reagent.core :as r]
             [realworld-resources.http :as rh]
             [realworld-shared.schema :as schema])
   (:require-macros [re-frame.core :refer [reg-view]]))
@@ -229,59 +228,44 @@
 
 (rf/reg-event :editor/initialise
   {:doc "Create-mode entry (`:realworld.editor/new` `:on-match`). Resets the editor
-         slice to a blank draft and clears any leftover save instance. Because
-         edit and create share the one `editor-page` component (core.cljs), an
-         edit -> new navigation never unmounts it, so this also releases the
-         outgoing edit lease (mirroring the slug-change branch of
-         `:editor/load-article`) so its `:realworld/article` cache entry can go
-         inactive and GC. The `:editor/can-submit?` flow is registered ONCE at
-         boot by `:editor/register-flow`, not per entry."}
+         slice to a blank draft and clears any leftover save instance. Reaching
+         `/editor` from an edit route is a real navigation, so the runtime has
+         already released the outgoing edit article owner — the ROUTE owns the
+         edit read (`:realworld.editor/edit` `:resources`, routing.cljs) and drops
+         it on leave — leaving this event only the slice reset. The
+         `:editor/can-submit?` flow is registered ONCE at boot by
+         `:editor/register-flow`, not per entry."}
   (fn [{:keys [db]} _]
-    (let [prev-slug (get-in db [:editor :slug])]
-      {:db (assoc db :editor (editor-slice))
-       :fx (cond-> [[:dispatch [:rf.mutation/clear {:instance save-instance}]]]
-             ;; edit -> new re-uses the same `editor-page` component, so no
-             ;; unmount fires to release the edit lease — and blanking the slice
-             ;; to a nil slug here would strand it. Release the outgoing slug's
-             ;; lease before the slice is cleared, or its `:realworld/article`
-             ;; cache entry stays pinned active for the rest of the session
-             ;; (N edits -> N leaked entries).
-             prev-slug
-             (conj [:dispatch [:editor/release-article prev-slug]]))})))
+    {:db (assoc db :editor (editor-slice))
+     :fx [[:dispatch [:rf.mutation/clear {:instance save-instance}]]]}))
 
 (rf/reg-event :editor/load-article
-  {:doc "Edit-mode entry (`:realworld.editor/edit` `:on-match`). Seeds the draft
-         from the existing article via a one-shot resource ensure under a
-         releaseable lease, and asks to be told when that read settles with the
-         ensure's call-site `:reply-to [:editor/article-loaded]` — no off-render
-         reaction. Clears any leftover save instance, and (on a same-component
-         `/editor/A` -> `/editor/B` re-match) releases the outgoing slug's lease
-         before taking the new one. The `:editor/can-submit?` flow is registered
-         ONCE at boot by `:editor/register-flow`, not per entry. The seeded
-         baseline is what gives the dirty-check something to compare against."}
-  (fn [{:keys [db] rt :rf.db/runtime} _]
-    (let [slug      (get-in rt [:rf.runtime/routing :current :params :slug])
-          prev-slug (get-in db [:editor :slug])]
+  {:doc "Edit-mode entry (`:realworld.editor/edit` `:on-match`). Resets the editor
+         slice to a blank draft under the incoming slug, then asks to be told when
+         the article read the ROUTE owns settles, so it can seed the draft +
+         baseline. The route declares `:realworld/article` as a `:resources` entry
+         (routing.cljs), owning it under `[:route :realworld.editor/edit nav-token]`
+         and releasing it on every leave; this event fires an OWNERLESS
+         `:reply-to [:editor/article-loaded]` ensure that JOINS that same read — a
+         cache-hit fires the continuation immediately, an in-flight fetch fires it
+         on settle — purely to seed. It mints NO lease of its own (nothing here to
+         release), and a `/editor/A` -> `/editor/B` re-match is a fresh navigation,
+         so the runtime releases the A owner and ensures B on its own — this event
+         only re-seeds. The `:editor/can-submit?` flow is registered ONCE at boot
+         by `:editor/register-flow`, not per entry. The seeded baseline is what
+         gives the dirty-check something to compare against."}
+  (fn [{rt :rf.db/runtime :keys [db]} _]
+    (let [slug (get-in rt [:rf.runtime/routing :current :params :slug])]
       {:db (assoc db :editor (editor-slice slug blank-draft))
-       :fx (cond-> [[:dispatch [:rf.mutation/clear {:instance save-instance}]]
-                    ;; Ensure the article read so the editor can seed its
-                    ;; baseline. A fresh entry is a cache-hit (the `:reply-to`
-                    ;; continuation fires immediately); otherwise it fetches and
-                    ;; the continuation fires on settle. The lease is released on
-                    ;; leave by `:editor/release-article`.
-                    [:dispatch [:rf.resource/ensure
-                                {:resource :realworld/article
-                                 :params   {:slug slug}
-                                 :owner    [:lease :editor/article slug]
-                                 :cause    [:route-entry :realworld.editor/edit]
-                                 :reply-to [:editor/article-loaded]}]]]
-             ;; `/editor/A` -> `/editor/B` re-matches the SAME route under a new
-             ;; slug, so this component never unmounts — release the OUTGOING
-             ;; slug's lease here. The event is the natural home for the
-             ;; slug-change release (navigation is causal); the component's
-             ;; unmount handles leaving the editor entirely.
-             (and prev-slug (not= prev-slug slug))
-             (conj [:dispatch [:editor/release-article prev-slug]]))})))
+       :fx [[:dispatch [:rf.mutation/clear {:instance save-instance}]]
+            ;; Join the route-owned read to seed the baseline — no owner, so this
+            ;; ensure adds no lease and there is nothing to release. The route's
+            ;; own `:resources` ownership handles the read's whole lifecycle.
+            [:dispatch [:rf.resource/ensure
+                        {:resource :realworld/article
+                         :params   {:slug slug}
+                         :cause    [:route-entry :realworld.editor/edit]
+                         :reply-to [:editor/article-loaded]}]]]})))
 
 (rf/reg-event :editor/article-loaded
   {:doc "The article-read completion continuation (the ensure's `:reply-to`
@@ -299,18 +283,12 @@
       (when-let [article (:article value)]
         {:db (assoc db :editor (editor-slice (:slug article) (draft-from-article article)))}))))
 
-(rf/reg-event :editor/release-article
-  {:doc "Release an edit-mode article lease. Called with an explicit slug (the
-         slug-change release from `:editor/load-article`) or with none (the
-         component's unmount release), in which case it releases the lease for the
-         editor slice's current slug. Dropping the editor's owner lets the article
-         read go inactive and eventually GC — an app-minted lease, like any
-         event-created owner, MUST have a matching release."}
-  (fn [{:keys [db]} [_ slug]]
-    (when-let [slug (or slug (get-in db [:editor :slug]))]
-      {:fx [[:dispatch [:rf.resource/release-owner
-                        {:owner [:lease :editor/article slug]
-                         :cause [:route-leave :realworld.editor/edit]}]]]})))
+;; There is deliberately NO `:editor/release-article` event. The article read is
+;; owned by the ROUTE (`:realworld.editor/edit` `:resources`, routing.cljs), so
+;; the runtime releases `[:route :realworld.editor/edit nav-token]` on every route
+;; leave — there is no app-minted lease for an event to release. This is MIG-17's
+;; re-homing doctrine at its cleanest: the causal owner is the route, and route
+;; leave is the causal end event.
 
 (rf/reg-event :editor/edit-field
   {:schema [:cat [:= :editor/edit-field] :keyword :string]}
@@ -371,9 +349,12 @@
          re-seed the editor from the saved article so the draft reads as clean —
          that way the `:can-leave` guard won't block — clear the instance, and
          navigate to the article detail. On a successful DELETE (no `:article` in
-         the reply value), clear the slice and instance and head home. On `:error`
-         there's nothing to do here; the form already shows it off the instance
-         state."}
+         the reply value), clear the slice and instance and head home. Both
+         continuations NAVIGATE away from the edit route, so the runtime releases
+         the route-owned article read on the way out — neither branch releases a
+         lease by hand (there is none; the route owns the read, routing.cljs). On
+         `:error` there's nothing to do here; the form already shows it off the
+         instance state."}
   (fn [{:keys [db]} [_ {:keys [status value]}]]
     (cond
       (not= :ok status) {}
@@ -385,19 +366,13 @@
               [:dispatch [:rf.route/navigate :realworld.article/show {:slug (:slug article)}]]]})
 
       :else
-      (let [prev-slug (get-in db [:editor :slug])]
-        {:db (assoc db :editor (editor-slice))
-         :fx (cond-> [[:dispatch [:rf.mutation/clear {:instance save-instance}]]]
-               ;; Release the deleted article's lease BEFORE the slice is cleared
-               ;; out from under it. The navigate-home below unmounts the editor,
-               ;; whose `:editor/release-article` (no slug) reads the editor
-               ;; slice's slug — but that's now nil, so it would release nothing
-               ;; and leak the lease (and the delete's `[:article slug]`
-               ;; invalidation could even refetch the just-deleted slug while the
-               ;; orphaned lease keeps it active). Releasing the captured
-               ;; outgoing slug here closes that gap.
-               prev-slug (conj [:dispatch [:editor/release-article prev-slug]])
-               true      (conj [:dispatch [:rf.route/navigate :realworld/home]]))}))))
+      {:db (assoc db :editor (editor-slice))
+       :fx [[:dispatch [:rf.mutation/clear {:instance save-instance}]]
+            ;; Navigating home leaves the edit route, so the runtime releases the
+            ;; route-owned `:realworld/article` read; the delete's `[:article slug]`
+            ;; invalidation then reaches an unowned entry that GC reclaims — no
+            ;; orphaned owner, no refetch of the just-deleted slug.
+            [:dispatch [:rf.route/navigate :realworld/home]]]})))
 
 (rf/reg-event :editor/delete
   {:doc "Delete the article (edit mode only). Fires the delete mutation under the
@@ -449,19 +424,26 @@
   (fn [dirty? _] (not dirty?)))
 
 ;; ============================================================================
-;; VIEW  (pure Form-1 render + a Form-3 wrapper holding the editor reactions)
+;; VIEW  (a pure Form-1 render — no lifecycle, because the view owns no lease)
 ;; ============================================================================
 ;;
 ;; Same shape as settings.cljs. The render is a pure registered `reg-view` that
-;; never dispatches; the one off-render reaction it needs (seed-on-load in edit
-;; mode) lives in a Form-3 wrapper's lifecycle hooks. The frame is captured at
-;; render via `rf/capture-frame`, so the reaction's out-of-render dispatch still
-;; carries the right frame.
+;; never dispatches out of band. It needs NO Form-3 lifecycle wrapper: the two
+;; off-render concerns a lifecycle hook would have carried are both re-homed to
+;; the dataflow — the seed-on-load is the route's `:on-match` `:reply-to`
+;; continuation (`:editor/article-loaded`), and the article read's teardown is the
+;; ROUTE's (`:realworld.editor/edit` `:resources`, routing.cljs), released by the
+;; runtime on every route leave. So the view holds no lease and no reaction; it is
+;; a pure function of subs. This is exactly what the native `ui_editor.cljc`
+;; rendition compiles to, and the shape MIG-17 re-homes a Form-3 editor into.
 
-(reg-view ^{:doc "The pure article-editor form — a function of subs, and it never
-                   dispatches. The save/delete continuations live elsewhere, in
-                   the `editor-page` Form-3 wrapper."}
-          editor-form-view []
+(reg-view ^{:doc "The article-editor page — a pure function of subs that never
+                   dispatches out of band. It owns no article lease: the read is a
+                   route `:resource` (routing.cljs), released on every route leave,
+                   and the seed-on-load is the route's `:on-match` `:reply-to`
+                   [:editor/article-loaded] continuation. The save/delete
+                   continuations live in the `:editor/*` events."}
+          editor-page []
   (let [draft       @(subscribe [:editor/draft])
         slug        @(subscribe [:editor/slug])
         can-submit? @(subscribe [:editor/can-submit?])
@@ -519,29 +501,3 @@
              {:type "button" :data-testid "editor-delete" :disabled busy?
               :on-click #(dispatch [:editor/delete])}
              "Delete Article"])]]]]]]))
-
-(defn editor-page
-  "The article-editor page. The render is the pure `editor-form-view`, and the
-   ONE lifecycle concern left is releasing the article read's lease when the
-   editor leaves the screen. There is no off-render reaction: the seed-on-load is
-   the `:realworld/article` ensure's `:reply-to [:editor/article-loaded]`
-   continuation (a declarative causal event, and the read-side counterpart of a
-   mutation's reply continuation), and the same-component
-   `/editor/A` -> `/editor/B` slug-change lease release rides
-   `:editor/load-article` (navigation is causal). So the only thing that
-   genuinely needs a component hook is leaving the editor entirely — the unmount.
-
-   `rf/capture-frame` is captured here during render, under the frame-provider,
-   so the unmount dispatch carries the right frame; `:editor/release-article`
-   with no slug releases whatever lease the editor slice still names."
-  []
-  (let [{:keys [dispatch]} (rf/capture-frame)]
-    (r/create-class
-     {:display-name "realworld-resources.article-editor/editor-page"
-      :component-will-unmount
-      (fn [_this]
-        ;; Release whatever article lease this editor still holds on the way out
-        ;; (the slug is read from the editor slice by the release event).
-        (dispatch [:editor/release-article]))
-      :reagent-render
-      (fn [] [editor-form-view])})))

--- a/examples/real-apps/realworld_resources/routing.cljs
+++ b/examples/real-apps/realworld_resources/routing.cljs
@@ -135,13 +135,25 @@
    :can-leave [:editor/can-leave?]} "/editor")
 
 (rf/reg-route :realworld.editor/edit
-  {:doc       "Edit an existing article (requires auth). `:on-match` seeds the
-               editor from the article read under a releaseable lease — the editor
-               page's load reaction copies the settled data into the draft and
-               baseline. `:can-leave` blocks a dirty navigate-away."
+  {:doc       "Edit an existing article (requires auth). The article read is a
+               declarative route `:resource`, exactly like every other page here:
+               the runtime owns it under `[:route :realworld.editor/edit nav-token]`
+               on entry and RELEASES that owner on every route leave — so leaving
+               the editor for ANY route (home, a profile, settings, the saved
+               article, or a new draft) drops the read with no view teardown and no
+               hand-rolled lease. `:on-match [[:editor/load-article]]` resets the
+               editor slice and asks to be told when that same read settles (an
+               OWNERLESS `:reply-to [:editor/article-loaded]` ensure that joins the
+               route's load) so it can seed the draft + baseline; it mints no owner
+               of its own. It is NON-blocking: the form renders immediately and
+               fills in when the read lands. `:can-leave` blocks a dirty
+               navigate-away."
    :params    [:map [:slug :string]]
    :tags      #{:requires-auth}
    :on-match  [[:editor/load-article]]
+   :resources [{:resource  :realworld/article
+                :params    (fn [route] {:slug (get-in route [:params :slug])})
+                :blocking? false}]
    :can-leave [:editor/can-leave?]} "/editor/:slug")
 
 (rf/reg-route :realworld.article/show

--- a/examples/real-apps/realworld_resources/ui_editor.cljc
+++ b/examples/real-apps/realworld_resources/ui_editor.cljc
@@ -33,17 +33,25 @@
      sub. The render is a pure function of subscriptions — it never dispatches
      out of band, and it is not a Form-3 class component.
 
-   The article read's lease stays a DATAFLOW concern, exactly as in
-   `article_editor.cljs`: the route's `:editor/load-article` mints
-   `[:lease :editor/article slug]` and the `:editor/*` events release it. The
-   Reagent page released on `:component-will-unmount`; native re-frame.ui has no
-   dispatch-at-unmount (a committed dispatcher rejects firing from a disconnected
-   view — the leaked-listener law), and a view-declared `(ui/lease {:resource …})`
-   is a different ownership model — the framework would own the whole lease
-   lifecycle — but this owner is app-minted (route-minted, released by the
-   `:editor/*` events), not view-scoped. So the native view owns no lease — there is
-   nothing at the view tier to leak — and the resource lifecycle stays where the
-   `realworld_resources` suite already proves it."
+   The article read is a DATAFLOW concern that the ROUTE owns, exactly as every
+   other page here does. `:realworld.editor/edit` declares `:realworld/article`
+   as a `:resources` entry (routing.cljs), so the runtime marks it active under
+   the route owner `[:route :realworld.editor/edit nav-token]` on entry and
+   RELEASES that owner on every route leave — edit→home, edit→profile→settings,
+   save→the saved article, edit→new, and edit A→B all release through the one
+   framework lifecycle, with no view teardown involved. Seeding the edit draft's
+   baseline stays a causal event: `:editor/load-article` (the route's `:on-match`)
+   fires an OWNERLESS `:reply-to [:editor/article-loaded]` ensure that JOINS the
+   route's own load purely to be told when it settles — it mints no lease of its
+   own. The Reagent page released on `:component-will-unmount`; native re-frame.ui
+   has no dispatch-at-unmount (a committed dispatcher rejects firing from a
+   disconnected view — the leaked-listener law), so this owner CANNOT ride the
+   view. It doesn't need to: the read is app-minted by a ROUTE, and a route is a
+   causal owner whose end event is route leave (MIG-17 — routes/events/machines
+   are the preferred causal owners; a view lease fits only an owner whose lifetime
+   truly follows the view site, which this route-minted one does not). So the
+   native view owns no lease — there is nothing at the view tier to leak — and the
+   resource lifecycle lives in the route's `:resources`, released on every exit."
   (:require [re-frame.ui :as ui :refer [defview sub]]))
 
 ;; The one stable instance id the editor form watches for the save write — the

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -278,25 +278,24 @@
 (defn- route-params [frame] (rf/compute-sub [:rf.route/params] (state-value frame)))
 (defn- route-query [frame] (rf/compute-sub [:rf.route/query] (state-value frame)))
 
-(defn- owner-index-for
-  "Map the entry-liveness owner-index (keyed on opaque byte key-ids) back to
-   scoped-key vectors, so lease-teardown assertions can read owners in the same
-   `[:lease …]` shape the app mints them. Mirrors the resources-machine-owner-
-   release suite's owner-index helper."
-  [frame]
-  (let [rdb    (runtime-db frame)
-        es     (get-in rdb (state/entries-path))
-        id->sk (into {} (map (fn [[k-id e]] [k-id (:resource/key e)])) es)]
-    (into {} (map (fn [[owner members]]
-                    [owner (into #{} (map #(get id->sk % %)) members)]))
-          (get-in rdb (state/owner-index-path)))))
-
 (defn- gc-recheck!
   "Fire the GC re-check for a scoped key on `frame` (the timer-fired event).
    An owner-free, work-free entry is collected; a still-pinned one survives."
   [frame scoped-key]
   (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource/key scoped-key}]
                     {:frame frame}))
+
+(defn- editor-route-owner?
+  "True iff `entry` carries an active `[:route :realworld.editor/edit _]` owner —
+   the route-owned lease the editor's article read holds while the edit route is
+   live (rf2-y4mgw: the read is a route `:resource`, owned under
+   `[:route route-id nav-token]` and released by the runtime on route leave). The
+   nav-token is opaque, so match on the route id, not the token."
+  [entry]
+  (boolean (some (fn [o] (and (vector? o)
+                              (= :route (first o))
+                              (= :realworld.editor/edit (second o))))
+                 (:active-owners entry))))
 
 ;; ============================================================================
 ;; 1. SESSION-SCOPE RESOLVER — :realworld/session (EP-0016 D3)
@@ -697,80 +696,117 @@
       (is (nil? (:page (route-query f))) "profile page 1 drops ?page="))))
 
 ;; ============================================================================
-;; 9. THE EDITOR EDIT-MODE LOAD + LEASE TEARDOWN + DELETE (rf2-hv7eid)
+;; 9. THE EDITOR EDIT-MODE LOAD + ROUTE-OWNED TEARDOWN + DELETE (rf2-y4mgw)
 ;; ============================================================================
 ;;
 ;; The editor's CREATE path is covered above (editor-flow-gates-…). This pins the
-;; recently-changed EDIT path: the read-side `:reply-to` seed-on-load, and the
-;; lease-teardown NO-LEAK property (rf2-kkqy6q). The footgun: `:editor/load-article`
-;; mints an app-owned `[:lease :editor/article slug]` on the article read; every
-;; exit path MUST have a matching release or `N edits → N leaked entries`. edit→save
-;; and edit→leave release via the component unmount (slug still set); the two
-;; slice-blanking paths — edit→NEW (`:editor/initialise`) and edit→DELETE
-;; (`:editor/replied` delete branch) — must release the OUTGOING slug BEFORE they
-;; blank the slice to a nil slug, else the lease orphans and the entry stays pinned
-;; active forever. Asserted in the shape of the machine-owner-release suite
-;; (active-owners empty + owner-index cleared + GC reclaims).
+;; EDIT path: the read-side `:reply-to` seed-on-load, and the ROUTE-OWNED teardown
+;; NO-LEAK property. rf2-y4mgw re-homed the article read's lifecycle onto the ROUTE:
+;; `:realworld.editor/edit` declares `:realworld/article` as a `:resources` entry,
+;; so the runtime owns it under `[:route :realworld.editor/edit nav-token]` and
+;; RELEASES that owner on every route leave. That closes the leak the app-minted
+;; `[:lease :editor/article slug]` had — the old owner was released only on
+;; edit→new / edit A→B / delete and (in the Reagent tier) the component unmount, so
+;; ordinary route leave in the native (unmount-free) rendition stranded it. Now
+;; EVERY exit (edit→new, edit A→B, save, delete, and edit→any-other-route) releases
+;; through the one framework lifecycle. The seed-on-load is the route's `:on-match`
+;; OWNERLESS `:reply-to [:editor/article-loaded]` ensure — it mints no owner, it
+;; joins the route's own read purely to seed. These tests drive REAL navigations
+;; (so the route plan runs) and assert active-owners + GC reclaim.
 
-(deftest editor-edit-load-seeds-baseline-then-edit-to-new-releases-lease-and-reclaims
+(deftest editor-edit-load-seeds-baseline-then-edit-to-new-releases-owner-and-reclaims
   (testing "examples/real-apps/realworld_resources — edit-mode entry seeds the draft
-            + baseline from the article read via the ensure's :reply-to
-            [:editor/article-loaded] continuation (rf2-p1yri7), pinning the
-            [:lease :editor/article slug] owner; edit→New Article
-            (:editor/initialise, same re-used component, no unmount) releases that
-            outgoing lease so the article entry is reclaimed (edit→new leaks
-            nothing — rf2-kkqy6q FAIL 1)"
+            + baseline from the article read via the route's `:on-match` ownerless
+            :reply-to [:editor/article-loaded] continuation, while the ROUTE owns
+            the read under [:route :realworld.editor/edit nav-token]; navigating
+            edit→New Article releases that owner (the route leave) so the article
+            entry is reclaimed (rf2-y4mgw)"
     (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
-      ;; EDIT-MODE ENTRY: navigating to /editor/:slug fires the route's :on-match
-      ;; [[:editor/load-article]], which ensures :realworld/article under the
-      ;; releaseable lease with :reply-to [:editor/article-loaded].
+      ;; EDIT-MODE ENTRY: navigating to /editor/:slug runs the route plan (owns
+      ;; :realworld/article under the route owner) AND fires :on-match
+      ;; [[:editor/load-article]] (the ownerless :reply-to [:editor/article-loaded]
+      ;; seed ensure, which dedupes onto the route's own read).
       (rf/dispatch-sync [:rf.route/navigate :realworld.editor/edit {:slug "hello-conduit"}] {:frame f})
       (is (some? @last-managed-args) "edit entry lowered the article read")
-      (let [lease [:lease :editor/article "hello-conduit"]]
-        (is (contains? (:active-owners (entry f (article-key "hello-conduit"))) lease)
-            "the article read is pinned by the editor's releaseable lease")
-        ;; the read settles → the :reply-to continuation seeds the baseline
-        (reply-success! @last-managed-args
-                        {:article {:slug "hello-conduit" :title "Hello, Conduit"
-                                   :description "A desc" :body "Some body" :tagList ["clojure"]}}
-                        f)
-        (testing "the :reply-to [:editor/article-loaded] continuation seeded draft + baseline"
-          (is (= "Hello, Conduit" (:title (rf/compute-sub [:editor/draft] (state-value f))))
-              "the draft is seeded from the loaded article")
-          (is (= "clojure" (:tagList (rf/compute-sub [:editor/draft] (state-value f))))
-              "the tag list is joined into the draft's comma-separated string")
-          (is (= "hello-conduit" (rf/compute-sub [:editor/slug] (state-value f))))
-          (is (false? (rf/compute-sub [:editor/dirty?] (state-value f)))
-              "a freshly-seeded edit draft equals its baseline → not dirty")
-          (is (true? (rf/compute-sub [:editor/can-leave?] (state-value f)))
-              "a clean edit draft may leave freely (the :can-leave guard passes)"))
+      (is (editor-route-owner? (entry f (article-key "hello-conduit")))
+          "the article read is pinned by the ROUTE owner, not an app-minted lease")
+      (is (not (contains? (:active-owners (entry f (article-key "hello-conduit")))
+                          [:lease :editor/article "hello-conduit"]))
+          "no app-minted [:lease :editor/article slug] owner is created any more")
+      ;; the read settles → the ownerless :reply-to continuation seeds the baseline
+      (reply-success! @last-managed-args
+                      {:article {:slug "hello-conduit" :title "Hello, Conduit"
+                                 :description "A desc" :body "Some body" :tagList ["clojure"]}}
+                      f)
+      (testing "the :reply-to [:editor/article-loaded] continuation seeded draft + baseline"
+        (is (= "Hello, Conduit" (:title (rf/compute-sub [:editor/draft] (state-value f))))
+            "the draft is seeded from the loaded article")
+        (is (= "clojure" (:tagList (rf/compute-sub [:editor/draft] (state-value f))))
+            "the tag list is joined into the draft's comma-separated string")
+        (is (= "hello-conduit" (rf/compute-sub [:editor/slug] (state-value f))))
+        (is (false? (rf/compute-sub [:editor/dirty?] (state-value f)))
+            "a freshly-seeded edit draft equals its baseline → not dirty")
+        (is (true? (rf/compute-sub [:editor/can-leave?] (state-value f)))
+            "a clean edit draft may leave freely (the :can-leave guard passes)"))
 
-        ;; EDIT → NEW ARTICLE: the same editor-page component is re-used, so no
-        ;; unmount fires; :editor/initialise (the /editor on-match) must release
-        ;; the OUTGOING slug's lease before it blanks the slice.
-        (rf/dispatch-sync [:editor/initialise] {:frame f})
-        (testing "edit→new released the outgoing lease (no orphaned owner)"
-          (is (not (contains? (:active-owners (entry f (article-key "hello-conduit"))) lease))
-              "the outgoing edit lease is released on edit→new")
-          (is (nil? (get (owner-index-for f) lease))
-              "the lease is gone from the owner-index (no dangling pin)")
-          (is (nil? (rf/compute-sub [:editor/slug] (state-value f)))
-              "the slice is blanked to a fresh create draft (nil slug)"))
-        (testing "the released, settled article entry is GC-reclaimed (leak closed)"
-          (is (nil? (:current-work (entry f (article-key "hello-conduit"))))
-              "the settled read pins no in-flight work")
-          (gc-recheck! f (article-key "hello-conduit"))
-          (is (nil? (entry f (article-key "hello-conduit")))
-              "an owner-free, work-free entry is reclaimed — edit→new leaks nothing"))))))
+      ;; EDIT → NEW ARTICLE: a REAL navigation to :realworld.editor/new. The route
+      ;; plan releases the outgoing edit owner (route leave); :editor/initialise
+      ;; (the /editor on-match) resets the slice.
+      (rf/dispatch-sync [:rf.route/navigate :realworld.editor/new] {:frame f})
+      (testing "edit→new released the route-owned read (no orphaned owner)"
+        (is (not (editor-route-owner? (entry f (article-key "hello-conduit"))))
+            "the outgoing edit route owner is released on edit→new")
+        (is (nil? (rf/compute-sub [:editor/slug] (state-value f)))
+            "the slice is blanked to a fresh create draft (nil slug)"))
+      (testing "the released, settled article entry is GC-reclaimed (leak closed)"
+        (is (nil? (:current-work (entry f (article-key "hello-conduit"))))
+            "the settled read pins no in-flight work")
+        (gc-recheck! f (article-key "hello-conduit"))
+        (is (nil? (entry f (article-key "hello-conduit")))
+            "an owner-free, work-free entry is reclaimed — edit→new leaks nothing")))))
 
-(deftest editor-delete-clears-slice-releases-lease-and-navigates-home
+(deftest editor-edit-then-navigate-to-unrelated-route-releases-the-route-owned-read
+  (testing "examples/real-apps/realworld_resources — THE rf2-y4mgw FIX: leaving the
+            edit route for an UNRELATED route (home) releases the editor's article
+            owner. This is the exact path the native (unmount-free) rendition
+            leaked: no :editor/* event fires on an ordinary route leave, and the
+            old app-minted [:lease :editor/article slug] was released only on
+            new/A→B/delete/unmount — so a plain edit→home stranded it. With the
+            read re-homed onto the route `:resources`, route leave IS the release"
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+                                       :fx-overrides {:rf.nav/push-url :rf/no-op}})]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      (rf/dispatch-sync [:rf.route/navigate :realworld.editor/edit {:slug "hello-conduit"}] {:frame f})
+      (reply-success! @last-managed-args
+                      {:article {:slug "hello-conduit" :title "Hello, Conduit"
+                                 :description "A desc" :body "Some body" :tagList []}}
+                      f)
+      (is (editor-route-owner? (entry f (article-key "hello-conduit")))
+          "the article read is owned while the edit route is live")
+      (is (false? (rf/compute-sub [:editor/dirty?] (state-value f)))
+          "the seeded draft is clean, so the :can-leave guard won't block")
+      ;; ORDINARY ROUTE LEAVE — navigate to home, a route that does NOT read this
+      ;; article. RED on the pre-fix code: nothing releases the editor's article
+      ;; owner on this path, so the entry stays pinned active forever.
+      (rf/dispatch-sync [:rf.route/navigate :realworld/home] {:frame f})
+      (is (= :realworld/home (route-id f)) "left the editor for home")
+      (is (not (editor-route-owner? (entry f (article-key "hello-conduit"))))
+          "leaving the editor for an unrelated route releases the article owner")
+      (testing "the now-unowned, settled article entry is GC-reclaimed"
+        (is (nil? (:current-work (entry f (article-key "hello-conduit"))))
+            "the settled read pins no in-flight work")
+        (gc-recheck! f (article-key "hello-conduit"))
+        (is (nil? (entry f (article-key "hello-conduit")))
+            "an owner-free, work-free entry is reclaimed — edit→leave leaks nothing")))))
+
+(deftest editor-delete-clears-slice-releases-route-owner-and-navigates-home
   (testing "examples/real-apps/realworld_resources — :editor/delete fires the delete
             mutation under the shared save instance with :reply-to [:editor/replied];
-            the delete branch clears the slice, releases the OUTGOING slug's lease
-            BEFORE the navigate-home unmount would read a now-nil slug, and heads
-            home (rf2-kkqy6q FAIL 2 — the matching-release invariant)"
+            the delete branch clears the slice and navigates home, and that
+            navigate-home leaves the edit route, so the runtime releases the
+            route-owned article read on the way out (rf2-y4mgw)"
     (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
                                        :fx-overrides {:rf.nav/push-url :rf/no-op}})]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
@@ -779,21 +815,19 @@
                       {:article {:slug "doomed" :title "Doomed" :description "d"
                                  :body "b" :tagList []}}
                       f)
-      (let [lease [:lease :editor/article "doomed"]]
-        (is (contains? (:active-owners (entry f (article-key "doomed"))) lease)
-            "the edit lease is held before delete")
-        ;; DELETE → the delete mutation lowers; reply with no :article (the delete
-        ;; endpoint returns no body) → the :editor/replied DELETE branch runs.
-        (rf/dispatch-sync [:editor/delete] {:frame f})
-        (reply-success! @last-managed-args {} f)
-        (is (not (contains? (:active-owners (entry f (article-key "doomed"))) lease))
-            "the delete flow releases the edit lease before clearing the slice (rf2-kkqy6q)")
-        (is (nil? (get (owner-index-for f) lease))
-            "the lease is gone from the owner-index after delete (no dangling owner)")
-        (is (nil? (rf/compute-sub [:editor/slug] (state-value f)))
-            "the editor slice is cleared to a blank create draft on delete")
-        (is (= :realworld/home (route-id f))
-            "a successful delete navigates home")))))
+      (is (editor-route-owner? (entry f (article-key "doomed")))
+          "the edit route owns the article read before delete")
+      ;; DELETE → the delete mutation lowers; reply with no :article (the delete
+      ;; endpoint returns no body) → the :editor/replied DELETE branch clears the
+      ;; slice and navigates home, which leaves the edit route.
+      (rf/dispatch-sync [:editor/delete] {:frame f})
+      (reply-success! @last-managed-args {} f)
+      (is (not (editor-route-owner? (entry f (article-key "doomed"))))
+          "navigating home on delete leaves the edit route → the route owner is released")
+      (is (nil? (rf/compute-sub [:editor/slug] (state-value f)))
+          "the editor slice is cleared to a blank create draft on delete")
+      (is (= :realworld/home (route-id f))
+          "a successful delete navigates home"))))
 
 ;; ============================================================================
 ;; 10. SESSION-RESTORE-WITH-TOKEN — the documented "restore stays put" invariant,


### PR DESCRIPTION
## What & why

The native re-frame.ui editor rendition (`ui_editor.cljc`) dropped the Reagent Form-3 unmount dispatch, but the article read's app-minted owner (`[:lease :editor/article slug]`) was never re-homed for **ordinary route leave**. The `:editor/*` events released it only on edit→new, edit A→B, and delete, so a plain edit→home / profile / settings (or edit→saved-article) **stranded the owner**, pinning the read until frame teardown. This contradicted `ui_editor.cljc`'s own docstring claim that the `:editor/*` events release the owner, and left MIG-17's reference example wrong. (`rf2-y4mgw`; discovered from the PR #6549 audit `rf2-awinc`.)

## The fix — re-home onto the ROUTE (the bead's preferred option)

Route-owned `:resources` is the same framework lifecycle every other page here uses, and MIG-17's stated preference (routes/events/machines are the preferred causal owners). It covers **every** exit path with one mechanism — the runtime releases `[:route :realworld.editor/edit nav-token]` on every route leave.

- **`routing.cljs`** — `:realworld.editor/edit` declares `:realworld/article` as a `:resources` entry (non-blocking). The route owns the read and releases it on leave.
- **`article_editor.cljs`** — `:editor/load-article` now fires an **ownerless** `:reply-to [:editor/article-loaded]` ensure that *joins* the route's own read purely to seed the draft baseline (no lease of its own). Removed the now-redundant `:editor/release-article` event, the slug-change release, the edit→new release, and the delete-branch release. The Reagent `editor-page` drops its Form-3 unmount wrapper and becomes a pure `reg-view` — matching what the native rendition compiles to, and dropping the now-unused `reagent.core` require.
- **`ui_editor.cljc`** — docstring rewritten to state the route-owned model that actually runs; **the docstring claim is now true**.

An ownerless `:rf.resource/ensure` with `:reply-to` is fully supported (`ensure-load` in `re-frame.resources.events`): it dedupes onto the route's owned load and fans the reply to the seed target on settle (or fires immediately on a cache hit). Seed-on-load is preserved cleanly with no double fetch.

### Current-wrong ↔ fixed
- **Before:** `:editor/load-article` minted `[:lease :editor/article slug]`; ordinary route leave fired no `:editor/*` event → owner stranded.
- **After:** the route owns the read; `edit→new`, `edit A→B`, `save`, `delete`, and `edit→any-other-route` all release through the framework on leave.

## Proof (release across roles)

The reagent-adapter domain suite (`realworld_resources_cljs_test.cljs` section 9) is rewritten to the route-owned model and drives **real navigations** so the route plan runs. A **new non-vacuous test**, `editor-edit-then-navigate-to-unrelated-route-releases-the-route-owned-read`, observes the article owner active on entry and released + GC-reclaimed after an ordinary `edit→home` leave — the exact path that leaked (RED on pre-fix code). Companion tests cover edit→new and delete→home.

## Scope / proportionality

Proportional re-homing of one resource's ownership onto the existing route `:resources` mechanism — no new routing/lifecycle abstraction, no `:on-leave` framework feature. Touched only `examples/real-apps/realworld_resources/{routing,article_editor,ui_editor}.cljc` + the (non-fenced) reagent-adapter domain test. Did **not** touch `implementation/ui`, `implementation/http`, `reagent-slim`, `skills/`, or `spec/`.

Two acceptance-criteria items live behind the fence and are filed as follow-ups:
- **`rf2-7a3uc`** — tighten MIG-17 (skills/) + refresh its now-stale `ui_editor.cljc` docstring quote.
- **`rf2-8yedm`** — de-vacuum the S3 editor ergonomic-proof teardown fixture (`implementation/ui/test/…`, currently `(is true)`) + fix its stale docstring. Verified runtime-safe after this change (create-mode only; docstring-only reference to the removed event).

## Quality gates

- `npm run test:examples-compile` — **PASS**: all 44 example builds compiled with **0 warnings** (`realworld-resources`: 319 files, 318 compiled, 0 warnings).
- `npm run test:cljs` (node-test bundle, runs the example domain suite) — **PASS**: 10360 tests, 51167 assertions, **0 failures, 0 errors**.
- `test:browser` (S3 DOM proof, `implementation/ui`) — not run locally (fenced Chromium sink; CI owns it). Verified runtime-safe: the fenced S3 fixtures reference the removed `:editor/release-article` only in docstrings and use the native `editor-page` (docstring-only change).
- mkdocs — not implicated: the editor is doc-referenced only for its `:editor/can-submit?` flow (unchanged); no docs page references the ownership model.