### PR TITLE
spec(ssr): reconcile the 011 residue — defer fingerprint, retire wire-accounting/failed-root, keep duplicate-root-id (rf2-v2gv9)

### DIFF
--- a/spec/004B-UI-Tree-and-Conversion.md
+++ b/spec/004B-UI-Tree-and-Conversion.md
@@ -416,16 +416,25 @@ shapes.
 - **Owner:** the `day8/re-frame2-ssr` artifact, `re-frame.ssr` namespace — the existing
   SSR artefact consumes the JVM emitter; there is no second server product. See
   [011 §Resolved decisions](011-SSR.md#resolved-decisions) and the API artefact table.
-- **Signature (recommended names; final naming rides the diff-time facade rule):**
-  - `(re-frame.ssr/emit-ui-tree tree opts) → HTML string` — consumes a version-1
-    structural tree; applies the serialisation half of the conversion table (final
-    names, boolean emission, property-only omission, escaping, void handling); erases
-    view boundaries (dev coord annotation policy stays 011-owned); writes trusted-HTML
-    nodes verbatim. `opts` carries a single current option, `:doctype?`, which prefixes
-    `<!DOCTYPE html>`; other keys are ignored (the `render-to-string` option set does not
-    transfer to this seam).
-  - `(re-frame.ssr/ui-tree-fingerprint tree) → digest` — hashes the canonical-EDN
-    serialisation of `N(tree)` (§Normalization); algorithm/encoding owned by 011.
+- **Signature — the shipped seam.** `(re-frame.ssr/emit-ui-tree tree opts) → HTML
+  string` — consumes a version-1 structural tree; applies the serialisation half of the
+  conversion table (final names, boolean emission, property-only omission, escaping, void
+  handling); erases view boundaries (dev coord annotation policy stays 011-owned); writes
+  trusted-HTML nodes verbatim. `opts` carries a single current option, `:doctype?`, which
+  prefixes `<!DOCTYPE html>`; other keys are ignored (the `render-to-string` option set
+  does not transfer to this seam). This is the **shipped, final contract** (final naming
+  rides the diff-time facade rule); a reader who greps the name finds the function that
+  meets it.
+- **Deferred candidate — not an owed function.** `(re-frame.ssr/ui-tree-fingerprint tree)
+  → digest` would hash the canonical-EDN serialisation of `N(tree)` (§Normalization),
+  algorithm/encoding owned by 011. It is a **non-binding candidate**, not a second S5
+  obligation: no such function exists and none is owed. It revives only if Spec 011
+  deliberately restores the structural render-hash / manifest `render-fingerprint` channel
+  — which [011 §Hydration-mismatch detection](011-SSR.md#hydration-mismatch-detection)
+  designed the compiled and native tiers *without*, recording its revival as "a
+  deliberately-deferred future leaf, not a defect" — **and** a named concrete consumer
+  needs it. The algorithm prose below (§Markup and fingerprint) is design-of-record for if
+  that happens.
 - **Version incompatibility:** the seam validates `:rf.ui/tree-version` **first,
   before any emission**. A missing field, a non-integer, or an unsupported version
   throws `:rf.error/ssr-ui-tree-version-unsupported` with ex-data
@@ -446,21 +455,28 @@ shapes.
   `emit-ui-tree`; the response accumulator, error projection, and payload machinery are
   unchanged `re-frame2-ssr` surfaces.
 
-### Stage — the emit seam ships; the fingerprint leads code
+### Stage — the emit seam is shipped; the fingerprint is a deferred candidate
 
-This section's two functions land at different points of S5 (`rf2-vxgfnd.97`). The
+This section's two functions sit at very different points of S5 (`rf2-vxgfnd.97`). The
 **emit seam has shipped**: `re-frame.ssr/emit-ui-tree` is the JVM's tree→HTML path
 (rf2-3omxp), and its version gate raises the now-catalogued
 `:rf.error/ssr-ui-tree-version-unsupported`. Where the repo names `emit-ui-tree` —
 `re-frame.ui.compiler.root`'s compile-error message, the guide's pipeline sentence — it
 points at *this contract*, and a reader who greps the name now finds the function that
-meets it.
+meets it. That contract is final.
 
-The **fingerprint half still leads code**: `re-frame.ssr/ui-tree-fingerprint` has no
-function yet, and the hash algorithm and digest encoding it will apply are Spec 011's
-(§Normalization, and [011 §Root Manifest v1](011-SSR.md#root-manifest-v1)). Spec leads
-code here, so a reader who greps *that* name and finds no function has found the design
-working rather than a gap.
+The **fingerprint half is a deferred, non-binding candidate — not an owed function**.
+`re-frame.ssr/ui-tree-fingerprint` has no function, and none is owed at S5. Spec 011 owns
+whether the structural render-hash / manifest `render-fingerprint` channel ever revives,
+and it revives only when 011 deliberately restores that channel **and** a named concrete
+consumer needs it. Today the channel is deliberately absent: [011 §Hydration-mismatch
+detection](011-SSR.md#hydration-mismatch-detection) states the compiled and native tiers
+"deliberately carry no such hash" (a compiled root has no hashable client render-tree),
+and records that reviving it is "a deliberately-deferred future leaf, not a defect." The
+hash algorithm and digest encoding this candidate would apply, if it revives, are Spec
+011's (§Normalization, and [011 §Root Manifest v1](011-SSR.md#root-manifest-v1)) — kept
+below as design-of-record. A reader who greps *that* name and finds no function has found
+a deferred candidate, not a gap or an outstanding obligation.
 
 Before the emit seam shipped the JVM had no tree→HTML path at all. The pre-existing
 [011 §The render-tree → HTML emitter](011-SSR.md#the-render-tree--html-emitter-cljs-reference)
@@ -536,11 +552,14 @@ the code half from re-implementing them:
 
 ### Markup and fingerprint read one tree by two rules
 
-`emit-ui-tree` and `ui-tree-fingerprint` are handed the **same tree value**, and they
-disagree about it on purpose. Markup is the conversion table applied to the tree as
-built; the fingerprint is the canonical-EDN serialisation of `N(tree)` (§Normalization),
-which has already spliced view boundaries and fragments, dropped `:events` and `:key`s,
-and coalesced text.
+This subsection is **design-of-record for the deferred fingerprint candidate** (see the
+Stage note above), not a description of a shipped second function: it records how a
+revived `ui-tree-fingerprint` would read the tree, so the design survives intact if Spec
+011 ever restores the channel. So framed: `emit-ui-tree` and a revived `ui-tree-fingerprint`
+would be handed the **same tree value**, and they disagree about it on purpose. Markup is
+the conversion table applied to the tree as built; the fingerprint is the canonical-EDN
+serialisation of `N(tree)` (§Normalization), which has already spliced view boundaries and
+fragments, dropped `:events` and `:key`s, and coalesced text.
 
 The consequence is worth stating outright: **a difference normalization erases does not
 move the fingerprint, even where it moves the bytes.** Two renders differing only in a


### PR DESCRIPTION
Reconciles the stale S5 stage-prose in the Spec 011 residue leaf (`rf2-v2gv9`) against shipped reality, following the delegated ruling on the bead exactly. The whole thrust is *do NOT build frameworks to satisfy stale prose* — so this is one focused prose reconciliation, plus verified-no-op dispositions with reasons. **No fingerprint/hash machinery, no metrics/ledger, no failed-root continuation, no new error ids, no 009 row minted; spec/009, spec/004-Views, and the S1 compiler files (analyze/emit/env) untouched.**

## Dispositions (per the bead ruling, 1–5)

**1. ui-tree-fingerprint → DEFERRED (the one concrete edit).** Spec 011's `§Hydration-mismatch detection` already states the compiled/native tiers "deliberately carry no such hash" and that reviving the render-fingerprint channel is "a deliberately-deferred future leaf, not a defect." 004B contradicted this by presenting `re-frame.ssr/ui-tree-fingerprint` as the owed second S5 function under a shared "Signature (recommended names…)" heading with the shipped `emit-ui-tree`. Reconciled:
- Split the shared signature block: `emit-ui-tree` now reads as the **shipped, final contract**; `ui-tree-fingerprint` reads as a **non-binding candidate**, gated on 011 reviving the channel **and** a named concrete consumer.
- Softened the Stage section (`the fingerprint leads code` → `the fingerprint is a deferred candidate`), citing 011's authority verbatim.
- Kept the algorithm prose (`§Markup and fingerprint`) as **design-of-record for if the channel revives**, reframed so it no longer implies a shipped second function.

**2. 004C false 009-row claim → LEFT FOR ITS OWNER.** `spec/004C:465` cites `:rf.error/root-hydration-mismatch` as an existing 009 row (verified false — no such row in spec/009). Per the ruling's rider + implementation-guidance (2), this edit is **owned by rf2-vxgfnd.249**, which is still **OPEN** (blocked on .248/.191). Not edited from this bead; no 009 row minted.

**3. Server wire-accounting → RETIRED.** Per-root manifest/payload byte-size ledger + teardown rider: zero presence in spec/ or implementation/, no consumer. Nothing specced or built.

**4. Failed-root wire artifact → RETIRED.** Whole-response fail-closed (011:1398/1405) stays. No per-root server continuation, fallback markup, or comment shape added.

**5. Layer-2 registry / duplicate-root-id → CONCRETE-BUT-GATED (verified no owner).** The ruling scopes this as "the Layer-2 server registry + server-tier duplicate-root-id as one unit, attached to a real multi-root page assembler **when one exists**." Verified no such assembler exists: `install.cljc:77`, `manifest.cljc:69-71` ("a later S5 leaf"), `004C:586` ("Layer 2 does not exist without a server"), and the multi-root tests hand-assemble page HTML. `root.cljc:852` already states Layer-2 detection "is the SSR host's per-response registry, not the macro's", and `:rf.ui.compile/static-root-requires-runtime` (item 4) already ships at `root.cljc:903` (the `:rf.error/ssr-*` spelling appears nowhere in spec/). Spec and code are already honest and consistent — building the registry now would be framework-ahead-of-consumer over-engineering the ruling forbids. Left gated; **no code change**.

## Quality gates
- `python -m mkdocs build --strict` → exit 0
- `python scripts/check_doc_slugs.py` → exit 0
- `implementation/core` `clojure -M:test` → 2104 tests, 10420 assertions, **0 failures, 0 errors** (catalogue-conformance green — no 009 change)
- `implementation/ui` and `implementation/ssr` suites not run: the change is pure spec-markdown prose, touches no code (root.cljc / emit / root contracts unchanged).