### PR TITLE
fix(ui): viewcell reads frame from useContext + correct render-events wrapper selection (rf2-wobnf)

### DIFF
--- a/implementation/ui/src/re_frame/ui/viewcell.cljs
+++ b/implementation/ui/src/re_frame/ui/viewcell.cljs
@@ -262,11 +262,21 @@
 (defn render-events
   "Production wrapper for an event-bearing view with no reactive sites.  It is
   a real frame-context consumer so provider retargets produce a fresh candidate
-  whose locked destination is published at commit."
+  whose locked destination is published at commit.
+
+  The `useContext` frame flows two ways from the single leading hook: it is the
+  committed event destination threaded into `events/with-capture`, AND it is
+  BOUND into `re-frame.frame/*current-frame*` around the synchronous body
+  (`with-current-frame`) so a `(frame)` site the body also carries — the
+  event+`(frame)` view this wrapper is selected for — resolves the provider
+  through the dynamic tier, not the `_currentValue` slot `react-dom/server`
+  leaves empty (rf2-wobnf). The bound thunk is what `with-capture` evaluates, so
+  event capture still sees the same frame it always did."
   [view-id thunk]
   (let [frame-id                (use-frame-context!)
         owner                   (use-event-owner view-id)
-        [element event-capture] (events/with-capture owner frame-id thunk)]
+        [element event-capture] (events/with-capture owner frame-id
+                                                      (with-current-frame frame-id thunk))]
     (use-event-commit-and-lifecycle! owner event-capture)
     element))
 
@@ -288,10 +298,19 @@
   "Production wrapper for a FRAME-ONLY view: a `(frame)` site but no sub sites
   (rf2-vxgfnd.228). It observes no reactive source, so it needs no ViewCell —
   only frame-context CONSUMPTION so a provider retarget re-renders it.
-  Structurally zero `useSyncExternalStore` / passive hooks; one `useContext`."
+  Structurally zero `useSyncExternalStore` / passive hooks; one `useContext`.
+
+  The `useContext` frame is BOUND into `re-frame.frame/*current-frame*` around
+  the synchronous body (`with-current-frame`) — like every sub wrapper — so the
+  body's `(frame)` site resolves the closest live provider through the dynamic
+  tier rather than the private `_currentValue` slot, which `react-dom/server`
+  leaves empty under React 19.2 (it populates `_currentValue2`). Without the
+  binding a server-rendered frame-only view raised `:rf.error/no-frame-context`
+  even under a live `frame-provider` (rf2-wobnf, extending the rf2-2rzx0 hook
+  fix into this wrapper)."
   [_view-id thunk]
-  (use-frame-context!)
-  (thunk))
+  (let [frame-id (use-frame-context!)]
+    ((with-current-frame frame-id thunk))))
 
 (defn render-subs
   "Production wrapper for a view with sub sites.

--- a/implementation/ui/test/re_frame/ui/viewcell_server_frame_context_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/viewcell_server_frame_context_cljs_test.cljs
@@ -36,14 +36,19 @@
   `:node-test` gate, never the browser build."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
+            ["react" :as react]
             ["react-dom/server" :as rds]
+            [re-frame.adapter.context :as adapter-context]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.test-support :as test-support]
             [re-frame.ui :as ui :refer [defview frame-provider sub]]
-            [re-frame.ui.frames]     ;; loads re-frame.ui.substrate — routes the
-                                     ;; :adapter/current-frame React-context reader
-            [re-frame.ui.runtime :as rt]))
+            [re-frame.ui.frames :as frames]  ;; loads re-frame.ui.substrate — routes
+                                             ;; the :adapter/current-frame reader; the
+                                             ;; alias exposes frame-ops for the direct
+                                             ;; production-wrapper regressions below
+            [re-frame.ui.runtime :as rt]
+            [re-frame.ui.viewcell :as viewcell]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter       ui/adapter
@@ -120,3 +125,118 @@
                        (catch :default e (:rf.error/id (ex-data e))))))]
       (is (= :rf.error/no-frame-context err)
           "no scope above the ViewCell → fail loud, never a default frame"))))
+
+;; ===========================================================================
+;; rf2-wobnf — the two PRODUCTION wrappers that carried the SAME frame but did
+;; not BIND it around their body.
+;;
+;; PR #6550 (rf2-2rzx0) corrected the SHARED hook `use-frame-context!` to return
+;; the renderer-agnostic `useContext` value, and every SUB wrapper binds that
+;; value into `frame/*current-frame*` around the body (`with-current-frame`). But
+;; two production wrappers did NOT: `render-frame` invoked its thunk with the
+;; return DISCARDED, and `render-events` retained the frame only as the event
+;; destination and invoked the body thunk unbound. So a `(frame)` site inside
+;; either body re-entered the private-slot reader
+;; (`function-component-current-frame` → `_currentValue`), which React 19.2's
+;; `react-dom/server` leaves empty (it populates `_currentValue2`) — a
+;; provider-scoped frame-only / event+`(frame)` view still raised
+;; `:rf.error/no-frame-context` on the server.
+;;
+;; DEBUG `defview` coverage MASKS this: DEBUG routes every view through
+;; `render-dev`, whose stable superset already binds the frame. So these
+;; regressions call the PRODUCTION wrappers DIRECTLY — a function component whose
+;; render body is the wrapper — under a real `provider-element` and the REAL
+;; `react-dom/server` renderer. RED before rf2-wobnf, GREEN after.
+;; ===========================================================================
+
+;; Frame-only: a `(frame)` read, no sub, no event → the `render-frame` wrapper.
+;; The body renders the resolved frame id so a lost frame is observable as an
+;; absence in the markup (and a raised error on the pre-fix server path).
+(defn- frame-only-wrapper-fc [_props]
+  (viewcell/render-frame
+   :test/frame-only
+   (fn [] (react/createElement "output" #js {:data-role "fo"}
+                               (str (:frame (frames/frame-ops)))))))
+
+;; Event+`(frame)`: the `render-events` wrapper (its selected shape for a view
+;; carrying event sites plus `(frame)`), with a `(frame)` read in the body.
+(defn- event-and-frame-wrapper-fc [_props]
+  (viewcell/render-events
+   :test/event-and-frame
+   (fn [] (react/createElement "output" #js {:data-role "ef"}
+                               (str (:frame (frames/frame-ops)))))))
+
+(defn- render-under-provider
+  "Server-render `element` beneath a live frame-context Provider carrying
+  `frame-kw`, capturing either the html or the raised typed error id."
+  [frame-kw element]
+  (silence-console-error
+   (fn []
+     (try {:html (rds/renderToStaticMarkup
+                  (adapter-context/provider-element frame-kw element))}
+          (catch :default e
+            {:error (or (:rf.error/id (ex-data e)) (ex-message e))})))))
+
+(deftest server-rendered-render-frame-wrapper-binds-provider-frame
+  ;; RED-BEFORE (rf2-wobnf): `render-frame` discarded the `use-frame-context!`
+  ;; return and invoked the thunk unbound, so the body's `(frame)` read hit the
+  ;; server-empty `_currentValue` slot and threw `:rf.error/no-frame-context`.
+  ;; GREEN-AFTER: the wrapper binds the useContext frame around the body via
+  ;; `with-current-frame`, so `(frame)` resolves `:app/a` and the markup shows it.
+  (reg!)
+  (frames/reset-frame-ops-cache!)
+  (rf/make-frame {:id :app/a})
+  (frame/replace-app-db! :app/a {:n 42})
+  (let [result (render-under-provider
+                :app/a (react/createElement frame-only-wrapper-fc (js-obj)))]
+    (is (nil? (:error result))
+        (str "render-frame must bind the useContext frame so its body's (frame) "
+             "resolves under react-dom/server — pre-fix it threw "
+             (pr-str (:error result)) " (rf2-wobnf)"))
+    (is (str/includes? (str (:html result)) ":app/a")
+        "the frame-only production wrapper resolved its provider frame :app/a")))
+
+(deftest server-rendered-render-events-wrapper-binds-provider-frame
+  ;; RED-BEFORE (rf2-wobnf): `render-events` kept the frame only as the event
+  ;; destination and invoked the body thunk unbound, so a combined event+`(frame)`
+  ;; view's `(frame)` read took the same broken server path. GREEN-AFTER: the
+  ;; body thunk is wrapped in `with-current-frame` (still the same frame threaded
+  ;; into event capture), so `(frame)` resolves `:app/a` on the server too.
+  (reg!)
+  (frames/reset-frame-ops-cache!)
+  (rf/make-frame {:id :app/a})
+  (frame/replace-app-db! :app/a {:n 42})
+  (let [result (render-under-provider
+                :app/a (react/createElement event-and-frame-wrapper-fc (js-obj)))]
+    (is (nil? (:error result))
+        (str "render-events must bind the useContext frame around its body so a "
+             "combined event+(frame) view resolves under react-dom/server — "
+             "pre-fix it threw " (pr-str (:error result)) " (rf2-wobnf)"))
+    (is (str/includes? (str (:html result)) ":app/a")
+        "the event+(frame) production wrapper resolved its provider frame :app/a")))
+
+(deftest server-rendered-production-wrappers-without-provider-fail-loud
+  ;; VACUITY GUARD: with NO Provider above them, BOTH production wrappers resolve
+  ;; the no-provider sentinel to nil (EP-0002: no `:rf/default` floor) and their
+  ;; body's `(frame)` read fails loud with `:rf.error/no-frame-context`. Stable
+  ;; before AND after the fix, so the green results above are attributable ONLY
+  ;; to the provider frame flowing through `useContext`, never to a synthesised
+  ;; default the binding might have introduced.
+  (reg!)
+  (frames/reset-frame-ops-cache!)
+  (rf/make-frame {:id :app/a})
+  (frame/replace-app-db! :app/a {:n 42})
+  (letfn [(err [element]
+            (silence-console-error
+             (fn []
+               (try (rds/renderToStaticMarkup element)
+                    nil
+                    (catch :default e (:rf.error/id (ex-data e)))))))]
+    (testing "render-frame with no provider fails loud"
+      (is (= :rf.error/no-frame-context
+             (err (react/createElement frame-only-wrapper-fc (js-obj))))
+          "no scope above render-frame → fail loud, never a default frame"))
+    (testing "render-events with no provider fails loud"
+      (is (= :rf.error/no-frame-context
+             (err (react/createElement event-and-frame-wrapper-fc (js-obj))))
+          "no scope above render-events → fail loud, never a default frame"))))


### PR DESCRIPTION
## Summary

Two production ViewCell wrappers (`render-frame`, `render-events`) carried the renderer-agnostic `useContext` frame — via the #6550 `use-frame-context!` fix — but did **not** BIND it into `frame/*current-frame*` around their body. So an ambient `(frame)` site inside re-entered the private-slot reader (`function-component-current-frame` → `_currentValue`), which React 19.2's `react-dom/server` leaves empty (it populates `_currentValue2`). A provider-scoped **frame-only** or **event+`(frame)`** compiled view therefore still raised `:rf.error/no-frame-context` on the server, under a live `frame-provider`.

Fixes `rf2-wobnf` (both enumerated items), re-verified against current `origin/main` after the lease keystone (#6572) rewrote viewcell.

### The two seams

1. **`render-frame`** — was `(use-frame-context!)` then `(thunk)` with the return discarded. Now retains the value and evaluates the thunk under the existing `with-current-frame` binding.
2. **`render-events`** — kept the frame only as the committed event destination and invoked the body thunk unbound. Now wraps the body thunk in `with-current-frame` before `events/with-capture`, still threading the **same** frame into event capture.

### On the "compiler selection" framing

The emitter's `host-render` selection `cond` in `emit_cljs.cljc` is **unchanged**. `render-events` IS the correct wrapper for an event+`(frame)` view (no ViewCell needed) — the bead's acceptance criterion 2 places the item-2 fix in the wrapper, and routing such a view to a combined wrapper would install a needless ViewCell and violate "no new wrapper taxonomy". So the fix is entirely in `viewcell.cljs`.

### Behaviour-preserving on the client

On the client renderer `_currentValue` IS populated, so the pre-fix wrappers already resolved correctly there; the binding resolves to the same provider frame. Existing client provider-retarget / event-ownership / wrapper-shape (55zsd) fixtures stay green.

## Red→green tests

New direct-wrapper Node `react-dom/server` regressions in `viewcell_server_frame_context_cljs_test.cljs` call the **production** wrappers directly under a live `provider-element` (a normal DEBUG `defview` masks the defect because DEBUG routes through `render-dev`, which already binds the frame):

- `server-rendered-render-frame-wrapper-binds-provider-frame` — pre-fix threw `:rf.error/no-frame-context`; post-fix resolves `:app/a`.
- `server-rendered-render-events-wrapper-binds-provider-frame` — same.
- `server-rendered-production-wrappers-without-provider-fail-loud` — vacuity guard; fails loud both before and after, so the green result is attributable only to the provider frame, never a synthesised default.

Confirmed RED before the fix (both positive tests fail with `:rf.error/no-frame-context`), GREEN after.

## Quality gates

Run in the worktree, foreground to completion:

- `cd implementation/ui && clojure -M:test` — **999 tests / 19794 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — **10315 tests / 50966 assertions, 0 failures, 0 errors**
- `npm run test:elision` — **PASS** (production 60/60 absent, EP-0023 provenance + assembly-DCE, control 60/60 present)
- `npm run test:browser-prod-elision` — **112 tests / 483 assertions, 0 failures, 0 errors** + "ui mounted production elision: PASS" (55zsd wrapper-shape fixtures + wrapper selection)

No 55zsd regression; surface disjoint from live workers (only `viewcell.cljs` + its test touched).