### PR TITLE
fix(ui): presence-review cluster — re-verified post-keystone (rf2-xqmt7, rf2-1kb0v, rf2-vz6a1)

### DIFF
--- a/implementation/ui/src/re_frame/ui/presence_runtime.cljc
+++ b/implementation/ui/src/re_frame/ui/presence_runtime.cljc
@@ -235,6 +235,21 @@
     (react-element? x)    (if-some [k (.-key x)] (conj acc [k x]) acc)
     :else                 acc))
 
+(defn- count-keyless
+  "Count the flattened children whose runtime `.-key` is nil — the elements
+  `collect-elements` DROPS (an unkeyed child cannot be retention-tracked, so it
+  never renders). The analyzer guarantees a `:key` FORM on every presence child,
+  but the form's VALUE can be nil at runtime (`{:key (:id x)}` with a missing
+  `:id`), which compile cannot catch. This parallel dev-only walk lets the render
+  path warn about the otherwise-silent drop; the drop itself stays in
+  `collect-elements`, unconditional in production."
+  [n x]
+  (cond
+    (nil? x)              n
+    (js/Array.isArray x)  (reduce count-keyless n x)
+    (react-element? x)    (if (nil? (.-key x)) (inc n) n)
+    :else                 n))
+
 (defn- warn-duplicate-identities!
   "Dev diagnostic for a key claimed twice at ONE presence boundary. Reuses the
   catalogued `:rf.error/ui-duplicate-key` — same failure, same string-coercion
@@ -253,12 +268,32 @@
             "compare after React's string coercion: 1 collides with \"1\")."))))
   nil)
 
+(defn- warn-keyless-drops!
+  "Dev diagnostic for a presence child whose runtime `:key` evaluated to nil.
+  Mirrors `warn-duplicate-identities!`: advisory dev output stripped in
+  production by `goog.DEBUG`, while the drop itself (in `collect-elements`) is
+  unconditional, so a production build never diverges. No catalogued
+  `:rf.error/*` id — a nil runtime key is not a new failure mode (compile still
+  guarantees the `:key` form), and `:rf.error/ui-duplicate-key` does not honestly
+  fit; this is a plain advisory. One warning per dropped element."
+  [n]
+  (when ^boolean js/goog.DEBUG
+    (dotimes [_ n]
+      (js/console.warn
+       (str "presence: a child under a (ui/presence …) boundary has a nil "
+            "runtime key and was DROPPED — it never renders. Presence tracks "
+            "children BY KEY, so ensure every child's :key expression (e.g. "
+            "(:id x)) is non-nil at render time. Outside a boundary React would "
+            "index-key and warn; under one the child silently vanishes."))))
+  nil)
+
 (defn- incoming-identities
   "The flattened children of this boundary as ordered, ownership-unique
   `[key element]` pairs — the only shape the retention machine may see."
   [incoming]
   (let [[pairs dups] (claim-identities (collect-elements [] incoming))]
     (warn-duplicate-identities! dups)
+    (warn-keyless-drops! (count-keyless 0 incoming))
     pairs))
 
 (defn- render-entries

--- a/implementation/ui/src/re_frame/ui/presence_runtime.cljc
+++ b/implementation/ui/src/re_frame/ui/presence_runtime.cljc
@@ -237,11 +237,14 @@
 
 (defn- count-keyless
   "Count the flattened children whose runtime `.-key` is nil — the elements
-  `collect-elements` DROPS (an unkeyed child cannot be retention-tracked, so it
+  `collect-elements` DROPS (a keyless child cannot be retention-tracked, so it
   never renders). The analyzer guarantees a `:key` FORM on every presence child,
-  but the form's VALUE can be nil at runtime (`{:key (:id x)}` with a missing
-  `:id`), which compile cannot catch. This parallel dev-only walk lets the render
-  path warn about the otherwise-silent drop; the drop itself stays in
+  but the form's runtime VALUE can be `undefined` (e.g. a JS-interop read of an
+  absent property), which React's jsx-runtime leaves as a nil `.-key` — compile
+  cannot catch it. NOTE a CLJS-nil key value is a different case: jsx coerces it
+  to the string \"null\" (a valid key), so `{:key (:id x)}` with a missing `:id`
+  RENDERS rather than dropping. This parallel dev-only walk lets the render path
+  warn about the otherwise-silent drop; the drop itself stays in
   `collect-elements`, unconditional in production."
   [n x]
   (cond
@@ -280,11 +283,11 @@
   (when ^boolean js/goog.DEBUG
     (dotimes [_ n]
       (js/console.warn
-       (str "presence: a child under a (ui/presence …) boundary has a nil "
-            "runtime key and was DROPPED — it never renders. Presence tracks "
-            "children BY KEY, so ensure every child's :key expression (e.g. "
-            "(:id x)) is non-nil at render time. Outside a boundary React would "
-            "index-key and warn; under one the child silently vanishes."))))
+       (str "presence: a keyless child under a (ui/presence …) boundary was "
+            "DROPPED — its :key evaluated to `undefined` (a nil React key), so "
+            "it never renders. Presence tracks children BY KEY; give the child a "
+            "defined key. (A CLJS-nil key value becomes the string \"null\" and "
+            "renders — a nil React key comes from an `undefined` value.)"))))
   nil)
 
 (defn- incoming-identities

--- a/implementation/ui/test/re_frame/ui/presence_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/presence_dom_cljs_test.cljs
@@ -256,3 +256,46 @@
             (.then (fn [_] (restore) (rf/destroy-frame! f) (done))
                    (fn [e] (restore) (rf/destroy-frame! f)
                      (reject-unexpectedly! done "duplicate presence identities rejected" e))))))))
+
+;; ---------------------------------------------------------------------------
+;; Nil runtime key at a MOUNTED boundary (rf2-vz6a1)
+;;
+;; The analyzer guarantees a :key FORM on every presence child, but the form's
+;; VALUE can be nil at runtime — `toast-list`'s `{:key (:id t)}` with a toast
+;; missing :id. `collect-elements` drops a nil-keyed element (it cannot be
+;; retention-tracked), so the child hard-vanishes with no phase and no DOM. A
+;; goog.DEBUG-only warning names the silent drop; the drop itself is unchanged.
+;; ---------------------------------------------------------------------------
+
+(deftest keyless-child-drops-with-dev-warning
+  (if-not (browser?)
+    (is true "mounted presence needs a DOM host — covered in the browser job")
+    (async done
+      (let [f       (rf/make-frame {:initial-events
+                                    ;; the second toast has NO :id → :key is nil
+                                    ;; at runtime under `toast-list`.
+                                    [[::set-toasts [{:id 1 :msg "kept"}
+                                                    {:msg "dropped"}]]]})
+            warns   (atom [])
+            restore (capture-console-warn! warns)]
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [toast-list]]]
+              (-> (uit/flush!)
+                  (.then (fn [_]
+                           (restore)
+                           (testing "the nil-keyed child is dropped; the keyed one renders"
+                             (is (= 1 (count (toasts root)))
+                                 "only the keyed child renders")
+                             (is (= "present" (phase-of root "kept")))
+                             (is (nil? (phase-of root "dropped"))
+                                 "the nil-keyed child never rendered — no phase, no DOM"))
+                           (testing "a dev-console warning names the silent drop"
+                             ;; render may run more than once (StrictMode / the
+                             ;; enter flip), so assert the warning FIRED — same
+                             ;; not-exactly-once shape as the duplicate-key test.
+                             (let [drops (filter #(str/includes? % "nil runtime key") @warns)]
+                               (is (seq drops) "the keyless-drop warning fired")
+                               (is (some #(str/includes? % "presence") drops)
+                                   "…naming the presence boundary")))))))
+            (.then (fn [_] (restore) (rf/destroy-frame! f) (done))
+                   (fn [e] (restore) (rf/destroy-frame! f)
+                     (reject-unexpectedly! done "keyless presence child rejected" e))))))))

--- a/implementation/ui/test/re_frame/ui/presence_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/presence_dom_cljs_test.cljs
@@ -258,41 +258,50 @@
                      (reject-unexpectedly! done "duplicate presence identities rejected" e))))))))
 
 ;; ---------------------------------------------------------------------------
-;; Nil runtime key at a MOUNTED boundary (rf2-vz6a1)
+;; Keyless child at a MOUNTED boundary (rf2-vz6a1)
 ;;
-;; The analyzer guarantees a :key FORM on every presence child, but the form's
-;; VALUE can be nil at runtime — `toast-list`'s `{:key (:id t)}` with a toast
-;; missing :id. `collect-elements` drops a nil-keyed element (it cannot be
-;; retention-tracked), so the child hard-vanishes with no phase and no DOM. A
-;; goog.DEBUG-only warning names the silent drop; the drop itself is unchanged.
+;; A presence child whose runtime React `.-key` is nil is dropped by
+;; `collect-elements` — no phase, no DOM. The analyzer guarantees a `:key` FORM,
+;; but a nil `.-key` still arises when the key VALUE is `undefined` (a JS-interop
+;; read of an absent property): React's jsx-runtime leaves `undefined` as a null
+;; key. IMPORTANT (verified React 19): a CLJS-nil key value does NOT drop —
+;; jsx coerces `null` to the string "null" (a valid key), so `{:key (:id t)}`
+;; with a missing :id RENDERS with key "null". The genuine drop needs an
+;; `undefined` key, spelled here as `(.-id #js {})` (reading an absent prop). A
+;; goog.DEBUG-only warning names the otherwise-silent drop; the drop itself is
+;; unchanged.
 ;; ---------------------------------------------------------------------------
+
+(defview keyless-toasts []
+  (ui/presence {:timeout-ms 300}
+    [toast-card {:key "keep" :msg "kept"}]
+    ;; `(.-id #js {})` is `undefined` at runtime → jsx leaves a null `.-key` →
+    ;; `collect-elements` drops it. (A CLJS-nil key would render as "null".)
+    [toast-card {:key (.-id #js {}) :msg "dropped"}]))
 
 (deftest keyless-child-drops-with-dev-warning
   (if-not (browser?)
     (is true "mounted presence needs a DOM host — covered in the browser job")
     (async done
-      (let [f       (rf/make-frame {:initial-events
-                                    ;; the second toast has NO :id → :key is nil
-                                    ;; at runtime under `toast-list`.
-                                    [[::set-toasts [{:id 1 :msg "kept"}
-                                                    {:msg "dropped"}]]]})
+      (let [f       (rf/make-frame {})
             warns   (atom [])
             restore (capture-console-warn! warns)]
-        (-> (uit/with-root [root [ui/frame-provider {:frame f} [toast-list]]]
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [keyless-toasts]]]
               (-> (uit/flush!)
                   (.then (fn [_]
                            (restore)
-                           (testing "the nil-keyed child is dropped; the keyed one renders"
+                           (testing "the keyless (undefined-key) child is dropped; the keyed one renders"
                              (is (= 1 (count (toasts root)))
                                  "only the keyed child renders")
                              (is (= "present" (phase-of root "kept")))
                              (is (nil? (phase-of root "dropped"))
-                                 "the nil-keyed child never rendered — no phase, no DOM"))
+                                 "the keyless child never rendered — no phase, no DOM"))
                            (testing "a dev-console warning names the silent drop"
                              ;; render may run more than once (StrictMode / the
                              ;; enter flip), so assert the warning FIRED — same
                              ;; not-exactly-once shape as the duplicate-key test.
-                             (let [drops (filter #(str/includes? % "nil runtime key") @warns)]
+                             ;; "keyless child" is distinct from the dup-key warn.
+                             (let [drops (filter #(str/includes? % "keyless child") @warns)]
                                (is (seq drops) "the keyless-drop warning fired")
                                (is (some #(str/includes? % "presence") drops)
                                    "…naming the presence boundary")))))))


### PR DESCRIPTION
Re-verifies the three presence-review findings against the post-lease-deletion (rf2-5e8zv.1, keystone) code and actions the in-fence code work. The keystone's lease deletion touched `presence_runtime.cljc` (docstring only: lease→subscription phrasing) and `analyze.cljc` (deleted lease machinery); it did **not** obviate any of the three findings — `reconcile` / `collect-elements` / `analyze-presence` are unchanged.

## Verdicts (three-outcome, re-verified against current code)

**rf2-vz6a1 — warn shipped, with a browser-verified premise correction.** The bead's stated trigger is false: a CLJS-nil key value (`{:key (:id t)}` with a missing `:id`) is coerced by React 19.2's jsx-runtime to the **string "null"** (a valid, non-nil `.-key`), so the child **renders** — it does not silently vanish. (Direct probe: `jsx(t,p,null).key === "null"`; `jsx(t,p,undefined).key === null`. Confirmed by headless-Chromium reproduction: the nil-`:id` child rendered as phase "present".) `collect-elements` drops a child only when its `.-key` is genuinely nil, which requires an **undefined** key value — a JS-interop read of an absent property, not a CLJS nil. The warn itself is correct defensive behaviour (goog.DEBUG-only, mirrors `warn-duplicate-identities!`); it now guards the genuine undefined-key case, and the browser test triggers it honestly via `(.-id #js {})`. Docstring + warn message corrected to describe the real case. **A note on the bead flags this for the mayor** (keep the narrow-but-correct warn, or drop it as gold-plating; worker recommends keep + retitle to "undefined key").

**rf2-xqmt7 — REAL, not actioned here (docs lane).** All cited code premises confirmed current post-keystone (literal `:timeout-ms` check `analyze.cljc` L2522-2527; inline-markup fence L2536-2544 + `a11y-presence-exit-interactive`; re-entry-at-`:present` `reconcile` L61-62; passive-effect enter flip `PresenceComponent` L336). Surface is `docs/core/re-frame.ui/presence.md` ONLY — outside this cluster's code fence; mkdocs unavailable here so its strict docs gate cannot run; coordinates cross-bead doc ownership. Routed to a docs-lane dispatch (note appended to bead).

**rf2-1kb0v — REAL, not actioned here (needs ruling + hot-zone spec).** `reconcile` still freezes order (kept keys render in committed order; incoming reorder affects only the appended tail). Resolution requires Mike's A/B ruling (bless-the-freeze vs respect-incoming-order) — unruled, so not pre-empted — and its acceptance core is a `spec/004-Views.md` normative paragraph (hot-zone, outside this code fence). Routed to a ruled dispatch (note appended to bead).

## Quality gates (all foreground, to completion)
- `npm run test:browser` (headless Chromium) — **496 tests / 2759 assertions, 0 failures, 0 errors** (the keyless test now exercises + passes)
- `cd implementation/ui && clojure -M:test` — **999 tests / 19804 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — **10316 tests / 50967 assertions, 0 failures, 0 errors**
- `npm run test:elision` — **PASS**, 0 warnings (production 60/60 absent, control 60/60 present; the `goog.DEBUG`-gated warn strips)

Disjoint surface held: only `presence_runtime.cljc` + `presence_dom_cljs_test.cljs` changed; no overlap with reactive.cljc / emit_cljs.cljc / viewcell.cljs / spec 009.
