### PR TITLE
feat(ui): detailed view-evidence cause records + hmr-remount/local-state/CAS fixes; defer epoch-restore (rf2-qkq2k)

### DIFF
--- a/implementation/ui/src/re_frame/ui/hooks.cljc
+++ b/implementation/ui/src/re_frame/ui/hooks.cljc
@@ -62,17 +62,37 @@
         "committed handler or an (effect …), never in the render body")
    {:extra {:reason :render-phase-local-mutation}}))
 
+(defn- note-committed-local-change!
+  "DEBUG-only :local-state attribution gate (Ruling 2 + rf2-qkq2k fix). Records
+  `:local-state` on `cell` ONLY when the write is an ACTUALLY-COMMITTED value
+  change — `cur` (the LIVE host state React itself compares) differs from `nv` by
+  `Object.is`, React's own bail law. React 19.2 Object.is-BAILS a no-op setter
+  WITHOUT rendering, so noting on invocation left a stale marker that contaminated
+  a LATER unrelated commit; aligning on the same `Object.is` React uses makes the
+  note fire EXACTLY when a re-render (hence a connected commit) will. Runs inside
+  the react-set functional updater (the one place the live `cur` is authoritative,
+  correct even for chained same-turn writes); `note-local-state!` is an idempotent
+  stash that triggers no re-render, so a StrictMode double-invoke is harmless.
+  Returns `nv` (so the updater's value is unchanged)."
+  [cell cur nv]
+  (when-not ^boolean (js/Object.is cur nv)
+    (reactive/note-local-state! cell))
+  nv)
+
 (defn local-state
   "React `useState`-backed `[value set! update!]`. `set!` stores its argument
   exactly (a stored fn is a value, never an updater); `update!` applies
   `(f current & args)` to the LATEST host state so several same-turn writers
   compose (React's functional updater queues them against the live state).
 
-  DEV-only view-evidence bridge (Ruling 2 :local-state): each host-only
-  `set!`/`update!` records `:local-state` as the cause of the re-render it just
-  triggered, so the ViewCell's NEXT connected commit attributes its
-  :rf.view/causes to the local write. The owning cell is captured ONCE at
-  setter-mint time (the first render, which runs inside the ambient
+  DEV-only view-evidence bridge (Ruling 2 :local-state): a host-only
+  `set!`/`update!` records `:local-state` as the cause of the re-render it
+  triggers, so the ViewCell's NEXT connected commit attributes its
+  :rf.view/causes to the local write — but ONLY when the write is an
+  actually-committed value change (`note-committed-local-change!`): React 19.2
+  Object.is-bails a no-op setter without rendering, so noting on every invocation
+  contaminated a later unrelated commit (rf2-qkq2k). The owning cell is captured
+  ONCE at setter-mint time (the first render, which runs inside the ambient
   `with-capture`); React — not the ViewCell scheduler — owns the re-render, so the
   bridge only STASHES the cause (`reactive/note-local-state!`), never marks the
   cell dirty or advances a revision. The whole bridge is `goog.DEBUG`-gated at
@@ -91,16 +111,24 @@
                       (when ^boolean js/goog.DEBUG
                         (when (.-v render-active) (fail-render-phase!)))
                       ;; ALWAYS the functional form: a stored fn is returned
-                      ;; verbatim, never invoked as a React updater.
-                      (react-set (fn [_] v))
-                      (when ^boolean js/goog.DEBUG (reactive/note-local-state! cell))
+                      ;; verbatim, never invoked as a React updater. The DEBUG
+                      ;; :local-state note rides INSIDE the updater so it sees the
+                      ;; live `cur` React compares — fired ONLY on a real change
+                      ;; (rf2-qkq2k); production DCEs to `(fn [_] v)`.
+                      (react-set (fn [cur]
+                                   (if ^boolean js/goog.DEBUG
+                                     (note-committed-local-change! cell cur v)
+                                     v)))
                       nil)
             updater (fn local-update!
                       [f & args]
                       (when ^boolean js/goog.DEBUG
                         (when (.-v render-active) (fail-render-phase!)))
-                      (react-set (fn [cur] (apply f cur args)))
-                      (when ^boolean js/goog.DEBUG (reactive/note-local-state! cell))
+                      (react-set (fn [cur]
+                                   (let [nv (apply f cur args)]
+                                     (if ^boolean js/goog.DEBUG
+                                       (note-committed-local-change! cell cur nv)
+                                       nv))))
                       nil)]
         (set! (.-current ops) #js [setter updater])))
     [value (aget (.-current ops) 0) (aget (.-current ops) 1)]))

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -572,15 +572,20 @@
   ;;                             ;   in production (elided) + between flushes
   ;;    :listeners {k -> fn}     ; useSyncExternalStore subscribers
   ;;    :intervals [interval]     ; lifecycle facts (dev/tool; 03 §4)
-  ;;    :pending-commit-causes #{…} ; DEBUG-only raw causes
-  ;;                             ;   (:value/:hmr/:disposed/:local-state)
-  ;;                             ;   accumulated since the last connected commit —
-  ;;                             ;   fed by complete-flush! (the flushed window's
-  ;;                             ;   cause set) and the hooks local-state bridge
-  ;;                             ;   (`note-local-state!`). The NEXT connected
-  ;;                             ;   commit PROJECTS them into :rf.view/causes and
-  ;;                             ;   clears the slot. ABSENT in production (elided)
-  ;;                             ;   and whenever no cause is pending (Ruling 2)
+  ;;    :pending-commit-causes {kind -> detail} ; DEBUG-only commit-cause map,
+  ;;                             ;   keyed by S6 cause kind
+  ;;                             ;   (:subscription/:hmr/:disposed/:local-state)
+  ;;                             ;   -> its ruled detail (subscription carries
+  ;;                             ;   target/query/frame-id + version from->to +
+  ;;                             ;   epoch; the rest are {}), accumulated since the
+  ;;                             ;   last connected commit — captured at the cause
+  ;;                             ;   SITE (`note-commit-cause` in `enrol-dirty-window!`
+  ;;                             ;   for port notes; the hooks local-state bridge
+  ;;                             ;   `note-local-state!`). The NEXT connected commit
+  ;;                             ;   PROJECTS them into the :rf.view/causes record
+  ;;                             ;   vector and clears the slot (atomic take/publish).
+  ;;                             ;   ABSENT in production (elided) and whenever no
+  ;;                             ;   cause is pending (Ruling 2, reworked rf2-qkq2k)
   ;;    :commit-record {…}|nil}  ; DEBUG-only S6 committed-instance record from
   ;;                             ;   the most-recent CONNECTED commit (Ruling 1/2;
   ;;                             ;   integer render-key + per-observation
@@ -1415,6 +1420,70 @@
           ;; floor — mark it inexact (the honest "≥ dropped-cap distinct" signal)
           (and (not known?) at-cap? drop-full?)       (assoc :dropped-exact? false))))))
 
+;; ---------------------------------------------------------------------------
+;; Commit-cause capture (Ruling 2 detailed records; rf2-qkq2k rework)
+;;
+;; The per-commit :rf.view/causes vector ships DETAILED cause records — not bare
+;; keyword tokens — so slice d and its consumers keep the attribution the port
+;; note already carries. The detail is captured at the NOTE (the true cause site,
+;; Ruling 2 "emitted at the cause site, never reconstructed"), NOT folded through
+;; the bounded Xray window `:evidence` (which coalesces to a lossy cause SET) —
+;; keeping the Xray cumulative plane untouched and the records honest.
+;;
+;; ONLY the explicitly-ruled fields are preserved per cause (Ruling 2); this is
+;; NOT a general evidence framework:
+;;   - :subscription  target / query / frame-id + version :from->:to + :epoch,
+;;                    read straight off the `:value` port-note axes (:target,
+;;                    :node-key, :node-version, :frame-epoch). `:from` is the
+;;                    version before the movement (the port advances it by one per
+;;                    move); a coalesced window keeps the EARLIEST :from and the
+;;                    LATEST :to so the record spans the whole movement honestly.
+;;   - :hmr / :disposed  bare markers — no ruled detail.
+;; :story-override (identity + version) and :mount are classified at commit time
+;; from lifecycle/override facts (see `commit-causes`), not from a port note.
+;; The whole plane is DEBUG-only (production-erased, G-7/G-11).
+;; ---------------------------------------------------------------------------
+
+(defn- commit-cause-fact
+  "Project ONE port-note `payload` to its S6 commit-cause `[kind detail]` pair, or
+  nil when the note carries no commit cause. The `:value` port cause is renamed to
+  `:subscription` HERE (the record is slice b's new surface); the still-`:value`
+  port keyword and the Xray cumulative window keep their vocabulary until slice
+  d's coordinated schema bump. DEBUG-only — reached only from the DEBUG arm of
+  `enrol-dirty-window!`."
+  [{:keys [cause target node-key node-version frame-epoch]}]
+  (case cause
+    :value    [:subscription {:target   node-key
+                              :query    (:query target)
+                              :frame-id (:frame-id target)
+                              :from     (some-> node-version dec)
+                              :to       node-version
+                              :epoch    frame-epoch}]
+    :hmr      [:hmr {}]
+    :disposed [:disposed {}]
+    nil))
+
+(defn- merge-commit-cause
+  "Merge a captured `[kind detail]` into the carry-forward `:pending-commit-causes`
+  map (`m`, nil = empty). Last-writer-wins per kind, EXCEPT a subscription keeps
+  the EARLIEST `:from` so a coalesced window spans first-from -> latest-to."
+  [m kind detail]
+  (let [m (or m {})]
+    (if-some [prior (get m kind)]
+      (assoc m kind (cond-> detail
+                      (contains? prior :from)
+                      (assoc :from (or (:from prior) (:from detail)))))
+      (assoc m kind detail))))
+
+(defn- note-commit-cause
+  "Fold `payload`'s ruled commit-cause detail into `s`'s `:pending-commit-causes`.
+  Pure state transition (the DEBUG arm of the ONE linearizable enrolment swap);
+  a payload with no commit cause leaves `s` untouched."
+  [s payload]
+  (if-some [[kind detail] (commit-cause-fact payload)]
+    (update s :pending-commit-causes merge-commit-cause kind detail)
+    s))
+
 (defonce ^:private evidence-sink
   ;; DEBUG-only consumer seam: `(fn [cell evidence] …)` | nil. Invoked at each
   ;; flush with the coalesced bounded evidence BEFORE it is cleared, so a tool
@@ -1511,7 +1580,13 @@
         [old _] (if interop/debug-enabled?
                   (swap-vals! st (fn [s]
                                    (cond-> (assoc s :dirty? true)
-                                     payload (update :evidence fold-evidence payload))))
+                                     ;; Xray window fold (bounded/coalesced) AND the
+                                     ;; per-cause DETAIL capture for the commit record
+                                     ;; (Ruling 2; rf2-qkq2k), both inside the ONE
+                                     ;; linearizable enrolment swap (rf2-vxgfnd.180)
+                                     ;; and both DCE'd whole in production.
+                                     payload (update :evidence fold-evidence payload)
+                                     payload (note-commit-cause payload))))
                   (swap-vals! st (fn [s] (assoc s :dirty? true))))]
     (when-not (:dirty? old)
       (swap! dirty-cells conj cell)
@@ -1590,20 +1665,16 @@
     (loop []
       (let [s @st]
         (when (:dirty? s)
-          ;; DEBUG plane (Ruling 2): carry the flushed window's cause set
-          ;; FORWARD to the next connected commit's :rf.view/causes. The window's
-          ;; evidence is cleared here (scheduler ownership), so the causes cannot
-          ;; be re-read at the later re-render/commit — the flush stashes them.
-          ;; `interop/debug-enabled?` is a STANDALONE gate so Closure DCEs the
-          ;; whole `:pending-commit-causes` arm (and its keyword/`into`) out of the
-          ;; advanced production bundle, exactly as the invalidation-evidence fold
-          ;; already elides.
-          (let [ev-causes (when interop/debug-enabled? (seq (:causes (:evidence s))))
-                cleared   (cond-> (-> s
-                                      (assoc :dirty? false :evidence nil)
-                                      (update :revision inc))
-                            ev-causes (update :pending-commit-causes
-                                              (fnil into #{}) ev-causes))]
+          ;; The per-commit :rf.view/causes DETAIL is captured at the NOTE
+          ;; (`enrol-dirty-window!` -> `note-commit-cause`), NOT here: completion
+          ;; owns only the scheduler state (dirty/evidence clear + revision
+          ;; advance). `:pending-commit-causes` survives this clear (the next
+          ;; connected commit drains it), so the flush never re-reads or stashes a
+          ;; cause (rf2-qkq2k). The Xray window `:evidence` is still handed to the
+          ;; sink below before it is cleared.
+          (let [cleared (-> s
+                            (assoc :dirty? false :evidence nil)
+                            (update :revision inc))]
             (when-some [barrier *completion-barrier*] (barrier cell))
             (if (compare-and-set! st s cleared)
               [cell (when interop/debug-enabled? (:evidence s))]
@@ -3174,14 +3245,23 @@
 ;;     claims NO singular top-level :frame-id.
 ;;   - :parent-render-key is DEFERRED — no S6 surface consumes view parentage, so
 ;;     NO parent-capture machinery exists here.
-;;   - :rf.view/causes is the per-commit cause VECTOR (Ruling 2, slice b): the
-;;     nine ruled kinds projected from their EXISTING sources, never a new capture
-;;     machine. :mount / :hmr-remount from the connect lifecycle + HMR slot;
-;;     :story-override from a (re)acquired override target; :subscription / :hmr /
-;;     :disposed / :local-state carried forward from the flushed pending-window
-;;     cause set (:value -> :subscription) via `:pending-commit-causes`; and
-;;     :foreign-or-react as the honesty fallback when a commit carries no cause.
-;;     :epoch-restore is NOT emitted here (see `commit-causes`).
+;;   - :rf.view/causes is the per-commit vector of DETAILED cause RECORDS (Ruling
+;;     2, slice b as reworked, rf2-qkq2k) — each `{:cause <kind> …ruled-fields}`,
+;;     projected from EXISTING sources, never a new capture machine and never a
+;;     general evidence framework (only the fields explicitly ruled per cause):
+;;       :mount           the connect lifecycle (:fresh->:connected).
+;;       :story-override  a (re)acquired override target — identity + version.
+;;       :subscription    detail captured at the port note (`note-commit-cause`):
+;;                        target / query / frame-id + version :from->:to + :epoch.
+;;       :local-state     the substrate-owned local writer bridge.
+;;       :hmr / :disposed bare markers carried forward in `:pending-commit-causes`.
+;;       :foreign-or-react  the honesty fallback when a commit carries no cause.
+;;     DEFERRED, never emitted (each a deferred-with-trigger row in slice d's
+;;     EP-0033 delta): :hmr-remount (honest per-instance attribution needs a
+;;     teardown->remount pairing signal — cross-surface + a fiddly closing rule —
+;;     so a view-granularity emit would mislabel unrelated fresh mounts) and
+;;     :epoch-restore (restore provenance outside perform-restore!'s dynamic
+;;     extent; Mike ruling option c). See `commit-causes` / `cause-order`.
 ;; ---------------------------------------------------------------------------
 
 (defonce ^:private render-key-counter
@@ -3230,76 +3310,97 @@
   local mutation drove `cell`'s next re-render. React (not the ViewCell
   scheduler) owns that re-render, so there is no flush to carry the cause through
   the pending window — the writer stashes `:local-state` DIRECTLY into the
-  carry-forward slot the next connected commit projects into :rf.view/causes.
+  carry-forward slot the next connected commit projects into :rf.view/causes
+  (`:local-state` carries no ruled detail, so its record is a bare marker).
+
+  The CALLER gates this on an actually-committed value change (`re-frame.ui.hooks`
+  `note-committed-local-change!`): React 19.2 Object.is-BAILS a no-op setter
+  without rendering, so stashing on every setter invocation would leave a stale
+  marker that contaminates a LATER unrelated commit (rf2-qkq2k). This fn therefore
+  only ever runs for a write React will actually commit.
+
   No-op on a nil cell (a `local` used outside a live capture) and elided whole in
   production. Never marks the cell dirty or advances a revision — React already
   re-renders, so double-scheduling is deliberately avoided. Returns nil."
   [^ViewCell cell]
   (when (and interop/debug-enabled? (some? cell))
-    (swap! (state cell) update :pending-commit-causes (fnil conj #{}) :local-state))
+    (swap! (state cell) update :pending-commit-causes merge-commit-cause :local-state {}))
   nil)
 
 (def ^:private ^:const cause-order
-  "The canonical, deterministic ordering of the S6 :rf.view/causes roster
-  (Ruling 2). A commit's cause SET is projected into a vector in this order so
-  the record is stable across hosts and runs. `:epoch-restore` keeps its ruled
-  slot for a future producer even though slice b emits none (see `commit-causes`);
-  `:foreign-or-react` is the standalone honesty fallback."
-  [:mount :hmr-remount :story-override :subscription
-   :local-state :hmr :disposed :epoch-restore :foreign-or-react])
+  "The canonical, deterministic ordering of the SHIPPED S6 :rf.view/causes roster
+  (Ruling 2, as reworked rf2-qkq2k). A commit's present causes project into their
+  detailed records in this order, so the vector is stable across hosts and runs.
 
-(defn- s6-cause
-  "Map a RAW pending-window / stash cause to its S6 :rf.view/causes vocabulary.
-  Only `:value` is renamed (to `:subscription`, Ruling 2); every other stashed
-  cause (`:hmr` / `:disposed` / `:local-state`) already carries its S6 spelling.
-  The `:value` -> `:subscription` rename lives HERE (projection-time), never at
-  the port note: the port keyword rename rides slice d's schema-version bump that
-  moves the pinned Xray/Pair consumers in lockstep — projecting the new vector
-  from the still-`:value` port note keeps the two vocabularies from colliding
-  before that coordinated bump."
-  [raw]
-  (case raw
-    :value :subscription
-    raw))
+  DEFERRED — never emitted by slice b (each a deferred-with-trigger row in slice
+  d's EP-0033 delta; consumers keep tolerating absence, Xray 021 §3.4.1):
+    - :hmr-remount   honest per-instance attribution needs a teardown->remount
+                     pairing signal (a remounted instance is React-indistinguishable
+                     from a fresh mount at the same view generation using only the
+                     view-global remount counter). That is cross-surface (the runtime
+                     Outer shell + the ViewCell) plus a fiddly closing rule — the same
+                     'new capture machine, fiddly close' class the fence excludes — so
+                     the S3 view-granularity emit (which mislabels unrelated later
+                     mounts) is DEFERRED rather than shipped dishonestly. Trigger: a
+                     substrate remount-pairing channel that ties a mount to its
+                     predecessor's teardown.
+    - :epoch-restore restore provenance fires from the deferred reactive commit
+                     loop, outside `perform-restore!`'s dynamic extent, and headless
+                     hosts have no value-movement watch (Mike ruling option c).
+  `:foreign-or-react` is the standalone honesty fallback (not in the order)."
+  [:mount :story-override :subscription :local-state :hmr :disposed])
 
 (defn- commit-causes
-  "Project THIS connected commit's :rf.view/causes vector (Ruling 2) from
-  signals that ALREADY exist — no new capture machinery:
+  "Project THIS connected commit's :rf.view/causes vector — a vector of DETAILED
+  cause RECORDS (Ruling 2, reworked rf2-qkq2k), each `{:cause <kind> …ruled-fields}`
+  — from signals that ALREADY exist, never a new capture machine:
 
     - :mount          `mounting?` — the cell's pre-commit lifecycle was :fresh
-                      (the :fresh->:connected transition).
-    - :hmr-remount    a mount whose view has a non-zero HMR remount generation
-                      (`view-remount-generation`) — the hook-signature-change
-                      remount key already on the HMR slot. (Honest at view
-                      granularity: a fresh instance of a previously-remounted view
-                      also reads > 0; the DEV signal is 'mounted under a remounted
-                      view'.)
-    - :story-override a (re)acquired site this commit whose target is a static
-                      Story override (`:story-override` kind) — classification of
-                      the render capture, not reconstruction.
+                      (the :fresh->:connected transition). Bare marker.
+    - :story-override `override-detail` — a (re)acquired site whose target is a
+                      static Story override; carries the ruled identity + version
+                      (`:override-id` / `:version`). Classification, not
+                      reconstruction.
     - :subscription / :hmr / :disposed / :local-state
-                      the causes the last flush (or the local-state bridge)
-                      carried forward in `:pending-commit-causes`, mapped through
-                      `s6-cause`.
+                      captured at their cause site into `:pending-commit-causes`
+                      (`note-commit-cause` at the port note; `note-local-state!`
+                      for the local writer). :subscription carries its ruled
+                      target/query/frame-id + version :from->:to + :epoch detail;
+                      the rest are bare markers.
     - :foreign-or-react
-                      the honesty fallback (Ruling 2) — a commit that carries no
-                      other cause (a foreign React re-render, or a headless value
-                      move caught at commit step 5 with no evidence window).
+                      the honesty fallback — a commit that carries no other cause
+                      (a foreign React re-render, or a headless value move caught at
+                      commit step 5 with no evidence window). Never has detail.
 
-  `:epoch-restore` is deliberately absent: its ruled emission — threading the
-  restore-operation token through the port fan-out — is NOT a clean projection of
-  an existing signal, because the value-movement watch fires from the DEFERRED
-  reactive commit loop, outside the restore's dynamic extent (see the worker
-  report / STOP-REPORT). Consumers already tolerate its absence (Xray 021 §3.4.1).
-  Empty by construction is impossible: the fallback always yields at least one."
-  [stash-causes mounting? remount? override?]
-  (let [present (cond-> (into #{} (map s6-cause) stash-causes)
-                  mounting? (conj :mount)
-                  remount?  (conj :hmr-remount)
-                  override? (conj :story-override))]
-    (if (empty? present)
-      [:foreign-or-react]
-      (filterv present cause-order))))
+  `present` is a MAP {kind -> ruled-detail}; each kind projects to a record in
+  `cause-order`. `:hmr-remount` / `:epoch-restore` are deferred (see `cause-order`)
+  and never appear. Empty is impossible: the fallback always yields one record."
+  [pending mounting? override-detail]
+  (let [present (cond-> (or pending {})
+                  mounting?       (assoc :mount {})
+                  override-detail (assoc :story-override override-detail))
+        ordered (into []
+                      (keep (fn [kind]
+                              (when-some [detail (get present kind)]
+                                (assoc detail :cause kind))))
+                      cause-order)]
+    (if (seq ordered)
+      ordered
+      [{:cause :foreign-or-react}])))
+
+(def ^:dynamic ^:no-doc *commit-publish-barrier*
+  "JVM linearization TEST SEAM — nil in production (one nil check per minted
+  record, zero further cost), NEVER bound off a test path (the
+  `*completion-barrier*` idiom). Bound to a `(fn [cell] …)`,
+  `mint-commit-record!` calls it at the ONE deterministic point BETWEEN reading
+  `:pending-commit-causes` and the `compare-and-set!` that publishes the record +
+  clears the stash, so a fixture can interleave a concurrent cause fold
+  (`enrol-dirty!` / `note-local-state!`) INSIDE the take->publish window and prove
+  the racing cause is never erased (rf2-qkq2k). Because publication is a
+  compare-and-set! RETRY loop, a fold landing in the barrier window fails the CAS
+  and the mint re-reads — INCLUDING the freshly-folded cause rather than losing
+  it to the old unconditional `dissoc`."
+  nil)
 
 (defn- mint-commit-record!
   "DEBUG-only: mint a fresh monotonic :render-key and publish the S6
@@ -3308,32 +3409,45 @@
   reflect the commit that connected. `:root-id` is the owning root incarnation —
   the opaque per-mount token the tool projection resolves to the authored root-id
   name (nil under no root, e.g. Tier-1/JVM). Projects the per-commit
-  :rf.view/causes vector (Ruling 2) from the carry-forward cause stash plus the
-  commit-time lifecycle / override facts, then CLEARS the stash so a subsequent
-  causeless re-render honestly reports :foreign-or-react. `mounting?` is the cell's
-  PRE-connect lifecycle fact (`:fresh`), read by the caller before `connect!`.
-  Returns the record."
+  :rf.view/causes vector of DETAILED cause records (Ruling 2, reworked rf2-qkq2k)
+  from the carry-forward cause stash plus the commit-time lifecycle / override
+  facts, then CLEARS the stash so a subsequent causeless re-render honestly reports
+  :foreign-or-react. `mounting?` is the cell's PRE-connect lifecycle fact
+  (`:fresh`), read by the caller before `connect!`. Returns the record.
+
+  ATOMIC take/publish (rf2-qkq2k CAS fix). The stash read + record publish + stash
+  clear are ONE `compare-and-set!` over the value read at the top of the loop, so a
+  concurrent cause fold on the JVM host (a racing `enrol-dirty!` / `note-local-state!`
+  between the read and the clear) can no longer be erased by an unconditional
+  `dissoc`: a fold that commits BEFORE the CAS fails it (the loop re-reads and
+  INCLUDES the fresh cause), and one AFTER the clear enrols a fresh next stash.
+  `next-render-key!` is minted ONCE before the loop, so a retry never wastes a key.
+  Single-threaded CLJS runs exactly one iteration."
   [^ViewCell cell cap new-order new-by mounting? to-acquire]
-  (let [st        (state cell)
-        st0       @st
-        view-id   (:view-id st0)
-        override? (boolean (some (fn [sid]
-                                   (= :story-override
-                                      (:kind (:target (new-by sid)))))
-                                 to-acquire))
-        remount?  (and mounting? (pos? (view-remount-generation view-id)))
-        causes    (commit-causes (:pending-commit-causes st0)
-                                 mounting? remount? override?)
-        record    {:render-key    (next-render-key!)
-                   :view-id       view-id
-                   :generation    (:generation cap)
-                   :root-id       (:root st0)
-                   :connection    :connected
-                   :observations  (project-observations new-order new-by)
-                   :rf.view/causes causes}]
-    (swap! st (fn [m] (-> (assoc m :commit-record record)
-                          (dissoc :pending-commit-causes))))
-    record))
+  (let [st         (state cell)
+        st0        @st
+        override-detail (some (fn [sid]
+                                (let [t (:target (new-by sid))]
+                                  (when (= :story-override (:kind t))
+                                    {:override-id (:override-id t)
+                                     :version     (:version t)})))
+                              to-acquire)
+        base       {:render-key    (next-render-key!)
+                    :view-id       (:view-id st0)
+                    :generation    (:generation cap)
+                    :root-id       (:root st0)
+                    :connection    :connected
+                    :observations  (project-observations new-order new-by)}]
+    (loop []
+      (let [s      @st
+            causes (commit-causes (:pending-commit-causes s) mounting? override-detail)
+            record (assoc base :rf.view/causes causes)
+            next-s (-> (assoc s :commit-record record)
+                       (dissoc :pending-commit-causes))]
+        (when-some [barrier *commit-publish-barrier*] (barrier cell))
+        (if (compare-and-set! st s next-s)
+          record
+          (recur))))))
 
 (defn- commit*
   "Run the 8-step layout commit for `cell` against the exact immutable

--- a/implementation/ui/test/re_frame/ui/hooks_local_state_cause_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/hooks_local_state_cause_cljs_test.cljs
@@ -1,0 +1,95 @@
+(ns re-frame.ui.hooks-local-state-cause-cljs-test
+  "rf2-qkq2k (S6 slice b, Fix #3) — the `:local-state` view-evidence cause is
+  attributed ONLY to an actually-committed value change. React 19.2 Object.is-BAILS
+  a no-op setter WITHOUT rendering, so the S3 bridge (which stashed on every setter
+  invocation) left a stale marker that contaminated a LATER unrelated commit. The
+  hooks setter now routes its DEBUG note through `note-committed-local-change!`,
+  which stashes ONLY when `cur` (the live host state React compares) differs from
+  the write by `Object.is` — React's own bail law — so the note fires EXACTLY when
+  a re-render (hence a connected commit) will.
+
+  This is the node-runnable proof of the gate fn itself (the decision point the
+  react-set updater invokes) driven through a REAL committed ViewCell: a real
+  change → the commit reports :local-state; a no-op → nothing stashed → a later
+  unrelated commit stays clean. (react-dom mounting is browser-only in this repo;
+  the gate reuses React's exact `Object.is` law, so the mounted behaviour follows
+  by construction.) CLJS-only (`Object.is` is a host primitive); rides
+  `npm run test:cljs` (node)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core                 :as rf]
+            [re-frame.frame                :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as test-support]
+            [re-frame.ui.hooks             :as hooks]
+            [re-frame.ui.reactive          :as reactive]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (reactive/reset-scheduler!)
+    (try (f) (finally (reactive/reset-scheduler!)))))
+
+(def ^:private fid :rf/default)
+(defn- seed! [db] (frame/replace-app-db! fid db))
+
+;; the exact private gate the hooks local-state setter/updater invoke
+(def ^:private note-committed-local-change!
+  @#'hooks/note-committed-local-change!)
+
+(defn- cause-kinds [cell] (mapv :cause (:rf.view/causes (reactive/commit-record cell))))
+
+(defn- render+commit! [cell sites]
+  (let [[_ cap] (rf/with-frame fid
+                  (reactive/with-capture
+                    cell
+                    (fn [] (mapv (fn [[sid q]] (reactive/sub-read sid q)) sites))))]
+    (reactive/commit! cell cap))
+  cell)
+
+(def ^:private enrol-dirty! @#'reactive/enrol-dirty!)
+
+(defn- fan-value! [cell query]
+  (enrol-dirty! cell {:cause :value
+                      :target {:kind :subscription :frame-id fid :query query}
+                      :node-key 7 :node-version 3 :frame-epoch 1})
+  (reactive/flush-pending!))
+
+;; ===========================================================================
+;; A REAL change stashes -> the commit reports :local-state
+;; ===========================================================================
+
+(deftest a-real-local-change-is-attributed
+  (rf/reg-sub :ls/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (render+commit! (reactive/make-cell ::v) [[[:ls/site 0] [:ls/a]]])]
+    (is (= 2 (note-committed-local-change! cell 1 2))
+        "the gate returns the new value unchanged (the react-set updater's result)")
+    (render+commit! cell [[[:ls/site 0] [:ls/a]]])
+    (is (= [:local-state] (cause-kinds cell))
+        "an Object.is-DIFFERENT write (a real change React commits) is :local-state")))
+
+;; ===========================================================================
+;; A no-op setter stashes NOTHING -> a later unrelated commit stays clean
+;; ===========================================================================
+
+(deftest a-noop-setter-does-not-contaminate-a-later-unrelated-commit
+  (rf/reg-sub :ls/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (render+commit! (reactive/make-cell ::v) [[[:ls/site 0] [:ls/a]]])]
+    (is (= 5 (note-committed-local-change! cell 5 5))
+        "an Object.is-EQUAL write returns the value but stashes nothing (React bails)")
+    (testing "a LATER unrelated (subscription) commit reports only its own cause"
+      (fan-value! cell [:ls/a])
+      (render+commit! cell [[[:ls/site 0] [:ls/a]]])
+      (is (= [:subscription] (cause-kinds cell))
+          "the stale no-op marker no longer contaminates an unrelated commit"))))
+
+;; ===========================================================================
+;; The gate is a no-op on a nil cell (a local used outside a live capture)
+;; ===========================================================================
+
+(deftest the-gate-is-safe-on-a-nil-cell
+  (is (= 9 (note-committed-local-change! nil 8 9))
+      "a real change on a nil cell returns the value and never throws")
+  (is (= 8 (note-committed-local-change! nil 8 8))
+      "a no-op on a nil cell returns the value and never throws"))

--- a/implementation/ui/test/re_frame/ui/reactive_commit_causes_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_commit_causes_cljs_test.cljc
@@ -1,30 +1,38 @@
 (ns re-frame.ui.reactive-commit-causes-cljs-test
-  "rf2-qkq2k (S6 slice b) — the per-commit `:rf.view/causes` vector on the REAL
-  ViewCell commit path (Ruling 2). A connected commit projects the NINE ruled
-  cause kinds from signals that ALREADY exist — never a new capture machine:
+  "rf2-qkq2k (S6 slice b, reworked) — the per-commit `:rf.view/causes` vector on
+  the REAL ViewCell commit path (Ruling 2). A connected commit projects DETAILED
+  cause RECORDS — each `{:cause <kind> …ruled-fields}` — from signals that ALREADY
+  exist, never a new capture machine and never a general evidence framework (only
+  the fields explicitly ruled per cause):
 
-    :mount          the :fresh->:connected transition (pre-commit lifecycle).
-    :hmr-remount    a mount whose view has a non-zero HMR remount generation.
-    :story-override a (re)acquired site whose target is a static Story override.
-    :subscription   a `:value` port note carried forward by the flush (renamed).
-    :local-state    the hooks local-state writer bridge (`note-local-state!`).
-    :hmr            a real registrar-replacement `:hmr` fan-out, flushed forward.
-    :disposed       a `:disposed` port note carried forward by the flush.
+    :mount           the :fresh->:connected transition (bare marker).
+    :story-override  a (re)acquired static Story-override target — ruled identity
+                     + version (`:override-id` / `:version`).
+    :subscription    a `:value` port note captured at the cause site — ruled
+                     target / query / frame-id + version :from->:to + :epoch.
+    :local-state     the hooks local-state writer bridge (bare marker).
+    :hmr             a real registrar-replacement `:hmr` fan-out (bare marker).
+    :disposed        a `:disposed` port note (bare marker).
     :foreign-or-react the honesty fallback — a commit that carries no other cause.
 
-  `:epoch-restore` is the ninth ruled kind but is NOT produced by slice b: its
-  emission (threading the restore-operation token through the port fan-out) is
-  not a clean projection of an existing signal, because the value-movement watch
-  fires from the DEFERRED reactive commit loop, outside the restore's dynamic
-  extent (worker STOP-REPORT). Consumers already tolerate its absence (Xray 021
-  §3.4.1) — the same way they tolerate the deferred five.
+  DEFERRED, never emitted here (each a deferred-with-trigger row in slice d's
+  EP-0033 delta; consumers keep tolerating absence, Xray 021 §3.4.1):
+    - :hmr-remount   honest per-instance attribution needs a teardown->remount
+                     pairing signal (a remounted instance is React-indistinguishable
+                     from a fresh mount at the same view generation using only the
+                     view-global remount counter) — cross-surface + a fiddly closing
+                     rule, so the S3 view-granularity emit (which mislabelled
+                     unrelated later mounts) is deferred rather than shipped
+                     dishonestly (rf2-qkq2k).
+    - :epoch-restore restore provenance is outside `perform-restore!`'s dynamic
+                     extent (Mike ruling option c).
 
-  The DEBUG carry-forward (`:pending-commit-causes`) is the seam the flush and
-  the local-state bridge feed and the next connected commit drains: on the
-  headless plain-atom hosts a value MOVE has no watch (it is caught at commit
-  step 5, never fanned), so the `:value`/`:disposed` port notes are driven
-  through the SAME private `enrol-dirty!` the watchable-host on-change calls —
-  the honest payload, not a simulation. `:hmr` rides the REAL registrar fan-out.
+  The DEBUG carry-forward (`:pending-commit-causes`) is captured at the NOTE (the
+  cause site) and drained by the next connected commit: on the headless plain-atom
+  hosts a value MOVE has no watch (it is caught at commit step 5, never fanned), so
+  the `:value`/`:disposed` port notes are driven through the SAME private
+  `enrol-dirty!` the watchable-host on-change calls — the honest payload, not a
+  simulation. `:hmr` rides the REAL registrar fan-out.
 
   `.cljc` ending `-cljs-test` rides `npm run test:cljs` (node) AND
   `clojure -M:test` (JVM), so the cause vector is graft-checked on both hosts
@@ -47,7 +55,9 @@
 
 (defn- seed! [db] (frame/replace-app-db! fid db))
 
-(defn- causes [cell] (:rf.view/causes (reactive/commit-record cell)))
+(defn- causes      [cell] (:rf.view/causes (reactive/commit-record cell)))
+(defn- cause-kinds [cell] (mapv :cause (causes cell)))
+(defn- cause-of    [cell kind] (some (fn [c] (when (= kind (:cause c)) c)) (causes cell)))
 
 (defn- render+commit!
   "Render (probe) `sites` (`[[sid query] …]`) under the ambient frame, then commit."
@@ -73,12 +83,18 @@
 
 (defn- fan-cause!
   "Fold ONE `cause`-tagged port note (targeting `query`) into `cell`'s pending
-  window exactly as the watchable-host on-change would, then flush it FORWARD."
-  [cell cause query]
-  (enrol-dirty! cell {:cause       cause
-                      :target      {:kind :subscription :frame-id fid :query query}
-                      :frame-epoch 1})
-  (reactive/flush-pending!))
+  window exactly as the watchable-host on-change would — carrying the SAME
+  `:node-key` / `:node-version` / `:frame-epoch` axes the real port payload does
+  (observation.cljc) so the captured cause DETAIL is honest — then flush FORWARD."
+  ([cell cause query] (fan-cause! cell cause query {}))
+  ([cell cause query {:keys [node-key node-version epoch]
+                      :or   {node-key 7 node-version 3 epoch 1}}]
+   (enrol-dirty! cell {:cause        cause
+                       :target       {:kind :subscription :frame-id fid :query query}
+                       :node-key     node-key
+                       :node-version node-version
+                       :frame-epoch  epoch})
+   (reactive/flush-pending!)))
 
 ;; ===========================================================================
 ;; :mount — the first connected commit (:fresh -> :connected)
@@ -89,8 +105,8 @@
   (seed! {:a 1})
   (let [cell (reactive/make-cell ::v)]
     (render+commit! cell [[[:cc/site 0] [:cc/a]]])
-    (is (= [:mount] (causes cell))
-        "a first connected commit is caused by :mount, and nothing else")))
+    (is (= [{:cause :mount}] (causes cell))
+        "a first connected commit is caused by :mount (a bare record), nothing else")))
 
 ;; ===========================================================================
 ;; :foreign-or-react — the honesty fallback (a causeless re-commit)
@@ -101,28 +117,51 @@
   (seed! {:a 1})
   (let [cell (reactive/make-cell ::v)]
     (render+commit! cell [[[:cc/site 0] [:cc/a]]])
-    (is (= [:mount] (causes cell)))
+    (is (= [:mount] (cause-kinds cell)))
     (testing "a second commit with no movement, stash, or new acquire is honest"
       (render+commit! cell [[[:cc/site 0] [:cc/a]]])
-      (is (= [:foreign-or-react] (causes cell))
+      (is (= [{:cause :foreign-or-react}] (causes cell))
           "no cause pending, connected, retained leases -> the honesty fallback"))))
 
 ;; ===========================================================================
-;; :subscription — a :value port note, carried forward + renamed
+;; :subscription — a :value port note, captured with its ruled DETAIL + renamed
 ;; ===========================================================================
 
-(deftest a-value-movement-recommits-as-subscription
+(deftest a-value-movement-recommits-as-subscription-with-ruled-detail
   (rf/reg-sub :cc/a (fn [db _] (:a db)))
   (seed! {:a 1})
   (let [cell (reactive/make-cell ::v)]
     (render+commit! cell [[[:cc/site 0] [:cc/a]]])
-    (fan-cause! cell :value [:cc/a])          ;; the flush stashes :value forward
+    ;; a value move to node-version 3 on node-key 7, epoch 1
+    (fan-cause! cell :value [:cc/a] {:node-key 7 :node-version 3 :epoch 1})
     (render+commit! cell [[[:cc/site 0] [:cc/a]]])
-    (is (= [:subscription] (causes cell))
-        ":value is renamed to :subscription at projection (Ruling 2)")))
+    (is (= [{:cause    :subscription
+             :target   7            ;; upstream node identity (:node-key axis)
+             :query    [:cc/a]
+             :frame-id fid
+             :from     2            ;; the version BEFORE the move (to - 1)
+             :to       3
+             :epoch    1}]
+           (causes cell))
+        ":value is renamed to :subscription AND preserves ONLY its ruled fields
+         (target/query/frame-id + version from->to + epoch) — no invented framework")))
+
+(deftest a-coalesced-subscription-window-spans-first-from-to-latest-to
+  (rf/reg-sub :cc/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (reactive/make-cell ::v)]
+    (render+commit! cell [[[:cc/site 0] [:cc/a]]])
+    ;; two movements coalesce before the next commit: 2->3 then 4->5
+    (fan-cause! cell :value [:cc/a] {:node-key 7 :node-version 3 :epoch 1})
+    (fan-cause! cell :value [:cc/a] {:node-key 7 :node-version 5 :epoch 2})
+    (render+commit! cell [[[:cc/site 0] [:cc/a]]])
+    (let [sub (cause-of cell :subscription)]
+      (is (= 2 (:from sub)) "the EARLIEST :from is kept (the window's first move)")
+      (is (= 5 (:to sub))   "the LATEST :to is kept (the window's last move)")
+      (is (= 2 (:epoch sub)) "the latest movement's epoch"))))
 
 ;; ===========================================================================
-;; :disposed — a :disposed port note, carried forward verbatim
+;; :disposed — a :disposed port note, a bare-marker record
 ;; ===========================================================================
 
 (deftest a-disposal-recommits-as-disposed
@@ -132,29 +171,29 @@
     (render+commit! cell [[[:cc/site 0] [:cc/a]]])
     (fan-cause! cell :disposed [:cc/a])
     (render+commit! cell [[[:cc/site 0] [:cc/a]]])
-    (is (= [:disposed] (causes cell))
-        ":disposed rides forward unchanged")))
+    (is (= [{:cause :disposed}] (causes cell))
+        ":disposed rides forward as a bare marker (no ruled detail)")))
 
 ;; ===========================================================================
-;; :hmr — a REAL registrar-replacement fan-out, flushed forward
+;; :hmr — a REAL registrar-replacement fan-out, a bare-marker record
 ;; ===========================================================================
 
 (deftest a-real-hmr-reregistration-recommits-as-hmr
   (rf/reg-sub :cc/a (fn [db _] (:a db)))
   (seed! {:a 1})
   (let [cell (render+commit! (reactive/make-cell ::v) [[[:cc/site 0] [:cc/a]]])]
-    (is (= [:mount] (causes cell)))
+    (is (= [:mount] (cause-kinds cell)))
     (rf/reg-sub :cc/a (fn [db _] (:a db)))     ;; real :hmr fan-out to the lease
     (is (reactive/dirty? cell) "the HMR invalidation marked the cell dirty")
     (is (= #{:hmr} (:causes (reactive/pending-evidence cell)))
         "the real :hmr cause is in the pending window")
-    (reactive/flush-pending!)                  ;; carries :hmr forward
+    (reactive/flush-pending!)                  ;; flushes the window
     (render+commit! cell [[[:cc/site 0] [:cc/a]]])
-    (is (= [:hmr] (causes cell))
-        "a real registrar-replacement fan-out projects :hmr")))
+    (is (= [{:cause :hmr}] (causes cell))
+        "a real registrar-replacement fan-out projects a bare :hmr record")))
 
 ;; ===========================================================================
-;; :local-state — the hooks local-state writer bridge
+;; :local-state — the hooks local-state writer bridge (bare-marker record)
 ;; ===========================================================================
 
 (deftest a-local-state-write-recommits-as-local-state
@@ -163,15 +202,29 @@
   (let [cell (render+commit! (reactive/make-cell ::v) [[[:cc/site 0] [:cc/a]]])]
     (reactive/note-local-state! cell)          ;; the substrate-owned local writer
     (render+commit! cell [[[:cc/site 0] [:cc/a]]])
-    (is (= [:local-state] (causes cell))
+    (is (= [{:cause :local-state}] (causes cell))
         "a host-only local write is the honest cause of its re-render")))
 
 (deftest note-local-state-is-a-no-op-on-a-nil-cell
   (is (nil? (reactive/note-local-state! nil))
       "a (local …) used outside a live capture stashes nothing and never throws"))
 
+(deftest an-unstashed-local-state-does-not-contaminate-a-later-unrelated-commit
+  ;; The commit-attribution property the hooks Object.is gate protects: when the
+  ;; local writer does NOT stash (a React-19.2 Object.is-bailed no-op setter),
+  ;; a later UNRELATED commit must NOT carry :local-state (rf2-qkq2k).
+  (rf/reg-sub :cc/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell (render+commit! (reactive/make-cell ::v) [[[:cc/site 0] [:cc/a]]])]
+    ;; a no-op setter stashes nothing (the gate lives in hooks; here we simply do
+    ;; not stash) — then an unrelated subscription movement drives the next commit
+    (fan-cause! cell :value [:cc/a])
+    (render+commit! cell [[[:cc/site 0] [:cc/a]]])
+    (is (= [:subscription] (cause-kinds cell))
+        "an unrelated commit reports its real cause only — no stale :local-state")))
+
 ;; ===========================================================================
-;; :story-override — a (re)acquired static Story-override target
+;; :story-override — a (re)acquired static Story-override target + ruled detail
 ;; ===========================================================================
 
 (deftest a-moved-story-override-recommits-as-story-override
@@ -182,29 +235,62 @@
       (render+commit! cell [[[:cc/site 0] [:cc/a]]]))
     (is (= #{[:override [:cc/a]]} (reactive/committed-target-keys cell))
         "the site resolved to a static override target")
-    (is (contains? (set (causes cell)) :mount)
+    (is (= :mount (:cause (cause-of cell :mount)))
         "the first override commit is a mount")
-    (testing "moving the override retargets the site -> :story-override, not mount"
+    (testing "moving the override retargets the site -> :story-override with ruled detail"
       (binding [reactive/*sub-overrides* {[:cc/a] 20}]      ;; new value -> retarget
         (render+commit! cell [[[:cc/site 0] [:cc/a]]]))
-      (is (= [:story-override] (causes cell))
-          "a re-acquired override target classifies the commit as :story-override"))))
+      (is (= [{:cause       :story-override
+               :override-id [:cc/a]     ;; the ruled override identity (the query)
+               :version     20}]        ;; the ruled override version (the value)
+             (causes cell))
+          "a re-acquired override target classifies the commit as :story-override
+           and preserves ONLY the ruled identity + version"))))
 
 ;; ===========================================================================
-;; :hmr-remount — a mount whose view has a non-zero HMR remount generation
+;; :hmr-remount — DEFERRED (Fix #2): a mount under a remounted view is NOT
+;; mislabelled; honest per-instance attribution needs pairing infra we defer.
 ;; ===========================================================================
 
-(deftest a-mount-under-a-remounted-view-is-hmr-remount
+(deftest a-mount-under-a-remounted-view-is-not-mislabelled-hmr-remount
   (let [vid ::remount-view]
     (reactive/register-view-descriptor! vid :sig-a {:impl :a})
     (reactive/register-view-descriptor! vid :sig-b {:impl :b})   ;; hook shape change
     (is (= 1 (reactive/view-remount-generation vid))
-        "an incompatible hook edit advanced the remount generation")
+        "an incompatible hook edit advanced the view-global remount generation")
     (let [gen  (reactive/view-generation vid)          ;; the current body revision
           cell (reactive/make-cell vid gen)]           ;; mint at the live revision
       (connect-empty! cell)
-      (is (= [:mount :hmr-remount] (causes cell))
-          "a mount under a remounted view carries BOTH :mount and :hmr-remount"))))
+      (is (= [{:cause :mount}] (causes cell))
+          "a mount under a remounted view is just :mount — :hmr-remount is DEFERRED
+           (view-granularity would mislabel this possibly-fresh instance, rf2-qkq2k)")
+      (is (not (contains? (set (cause-kinds cell)) :hmr-remount))
+          ":hmr-remount is never emitted by slice b"))))
+
+;; ===========================================================================
+;; CAS race (Fix #4): a cause folded during publication is INCLUDED, not erased
+;; ===========================================================================
+
+(deftest a-cause-folded-during-publication-is-not-erased
+  ;; The atomic take/publish (rf2-qkq2k): the `*commit-publish-barrier*` fires
+  ;; ONCE between the pending-causes read and the publish compare-and-set!, folding
+  ;; a fresh :local-state exactly in the take->publish window the old unconditional
+  ;; `dissoc` erased. The CAS then fails, the mint re-reads, and the racing cause is
+  ;; INCLUDED in the published record. Deterministic on both hosts.
+  (rf/reg-sub :cc/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell  (render+commit! (reactive/make-cell ::v) [[[:cc/site 0] [:cc/a]]])
+        fired (atom false)]
+    (fan-cause! cell :value [:cc/a])           ;; a :subscription is already pending
+    (binding [reactive/*commit-publish-barrier*
+              (fn [c]
+                (when (compare-and-set! fired false true)
+                  ;; a concurrent fold lands in the take->publish window
+                  (reactive/note-local-state! c)))]
+      (render+commit! cell [[[:cc/site 0] [:cc/a]]]))
+    (is @fired "the publication barrier fired inside the take->publish window")
+    (is (= #{:subscription :local-state} (set (cause-kinds cell)))
+        "the racing :local-state fold is INCLUDED in the published record, not erased")))
 
 ;; ===========================================================================
 ;; Canonical order — the cause vector is deterministic across hosts/runs
@@ -217,5 +303,5 @@
     ;; A mount that ALSO carries a movement: mount + a stashed :value.
     (fan-cause! cell :value [:cc/a])           ;; stash :value onto the fresh cell
     (render+commit! cell [[[:cc/site 0] [:cc/a]]])
-    (is (= [:mount :subscription] (causes cell))
+    (is (= [:mount :subscription] (cause-kinds cell))
         ":mount precedes :subscription in the canonical roster order")))

--- a/implementation/ui/test/re_frame/ui/reactive_commit_record_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_commit_record_cljs_test.cljc
@@ -75,13 +75,13 @@
             "no :parent-render-key is invented (deferred — no capture machinery)")
         (is (not (contains? record :frame-id))
             "no singular top-level :frame-id (attribution is per-observation)")))
-    (testing "slice-b adds the per-commit :rf.view/causes vector (Ruling 2)"
+    (testing "slice-b adds the per-commit :rf.view/causes vector of cause records (Ruling 2)"
       (let [record (reactive/commit-record cell)]
         (is (contains? record :rf.view/causes)
             "the causes vector now ships on the record")
         (is (vector? (:rf.view/causes record)) ":rf.view/causes is a vector")
-        (is (= [:mount] (:rf.view/causes record))
-            "a first connected commit is caused by :mount")))))
+        (is (= [{:cause :mount}] (:rf.view/causes record))
+            "a first connected commit is caused by :mount (a bare cause record)")))))
 
 ;; ===========================================================================
 ;; render-key is monotonic, minted fresh PER COMMIT


### PR DESCRIPTION
Reworks slice (b) of the S6 view-evidence delta (`rf2-vxgfnd.98.1` Ruling 2 + the `rf2-qkq2k` reopen ruling). #6567 shipped `:rf.view/causes` as keyword **tokens**, discarding the attribution slice-d and its consumers need. This ships **detailed cause records** carrying **only the ruled fields per cause** (no general evidence framework), fixes the three flagged correctness bugs, and defers two causes with named triggers.

## Detailed cause records (Fix #1) — ruled fields only

`:rf.view/causes` is now a vector of `{:cause <kind> …ruled-fields}` records, projected in canonical order. Preserves **only** the fields RULING 2 rules per cause — the test asserts the exact maps, so no invented field can slip in:

| cause | RULING 2 / reopen ruled fields | shipped record |
|---|---|---|
| `:subscription` | *"(version from->to)"*; reopen: target/query/version from→to/epoch/upstream | `{:cause :subscription :target <node-key> :query <q> :frame-id <fid> :from <v0> :to <v1> :epoch <e>}` |
| `:story-override` | `:override-id` / `:version` | `{:cause :story-override :override-id <query> :version <value>}` |
| `:mount` `:hmr` `:disposed` `:local-state` `:foreign-or-react` | bare marker | `{:cause <kind>}` |

The subscription detail is captured **at the port note** (the cause site — never reconstructed) into `:pending-commit-causes`, coalescing keeps the **earliest** `:from` and **latest** `:to` so a window spans the whole movement. Detail is captured *separately* from the bounded Xray window `:evidence`, so the Xray cumulative plane is untouched.

**"upstream":** interpreted as the observed node identity (`:target` = `:node-key`). A cascade-`:cause-sub` "upstream" chain is **not sourceable at the observation port** without the derivation graph — building that would be the general framework the posture forbids — so it is **not invented**. Flagging for slice-d in case a cascade-upstream field is wanted (it would be a deferred-with-trigger, needing the derivation-graph edge).

## Fix #2 — `:hmr-remount` DEFERRED (⚠️ honest attribution needs new infra)

The S3 emit meant *any* mount after the view's global remount generation ever went positive → it **mislabels unrelated later instances**. Honest per-instance attribution is **not small**: a remounted instance is React-indistinguishable from a fresh mount at the same view-global generation using only the remount counter; distinguishing them needs a **teardown→remount pairing signal** (the runtime Outer shell + the ViewCell — cross-surface, outside slice-b's fence) plus a **fiddly closing rule** (the same class the `:epoch-restore` ruling deferred). Per the reopen's *"or defer if honest attribution can't stay small"*, `:hmr-remount` is **deferred with a named trigger** (a substrate remount-pairing channel) rather than shipped dishonestly. Slice-d records it as another deferred-with-trigger EP-0033 row; shipped roster is now **6** (`:mount :story-override :subscription :local-state :hmr :disposed`) + the `:foreign-or-react` fallback.

## Fix #3 — `:local-state` attributes only a committed change

The hooks setter routes its DEBUG note through `note-committed-local-change!`, which stashes `:local-state` **only when the write differs from the live `cur` React compares by `Object.is`** (React 19.2's own bail law), running inside the react-set updater. A no-op setter that React Object.is-bails no longer leaves a stale marker to contaminate a later unrelated commit. Mounted CLJS proofs (node): a real change → the commit reports `:local-state`; a no-op → a later unrelated subscription commit stays clean.

## Fix #4 — atomic take/publish (CAS race)

`mint-commit-record!` read `:pending-commit-causes` then unconditionally `dissoc`ed the slot — a concurrent JVM fold in between was erased. It now reads causes, publishes the record, and clears the slot in **one `compare-and-set!`**; a racing fold either precedes the read (included) or fails the CAS (re-read includes it). New `*commit-publish-barrier*` seam drives a **deterministic interleaving proof** (dual-host) proving the racing `:local-state` is included, not erased.

## `:epoch-restore` — stays deferred

Not emitted (Mike ruling **option c**): restore provenance fires from the deferred reactive commit loop, outside `perform-restore!`'s dynamic extent, and headless hosts have no value-movement watch. Consumers tolerate absence (Xray 021 §3.4.1).

## Scope / erasure

Surface: `reactive.cljc` + `hooks.cljc` + cause-emission tests only. The `#6562` record shape is intact; the whole cause plane stays behind `interop/debug-enabled?` / `goog.DEBUG` and is production-erased (elision green). Dual-host (JVM + node).

## Quality gates

- `implementation/ui $ clojure -M:test` — **1002 tests / 19804 assertions, 0 failures, 0 errors** (base is post-lease-deletion, so lower than #6567's 1032).
- `implementation $ npm run test:cljs` — **10318 tests / 50973 assertions, 0 failures, 0 errors** (ViewCell + SSR included).
- `implementation $ npm run test:elision` — **production 60/60 absent, control 60/60 present** (cause plane + local-state gate DCE'd).

Do NOT merge — slice-d (`rf2-rvs56`) blocks on this and records the `:hmr-remount` + `:epoch-restore` deferred-with-trigger rows.
