### PR TITLE
feat(ui/compiler): admit the if-let binder family to the closed grammar (rf2-u53yy.4)

### DIFF
--- a/docs/EP/EP-0031-re-frame-ui-programming-model.md
+++ b/docs/EP/EP-0031-re-frame-ui-programming-model.md
@@ -96,6 +96,20 @@ evaluated-only host specials. **Every other macro — core or user — is reject
 reactive call from site indexing, falsify the manifest, and let production elide
 a ViewCell that was not actually sub-free. The set grows only by ruling.
 
+> **Addendum — 2026-07-21 (ratified UIx-review programme, rf2-u53yy.4).** The two
+> clauses above enumerated the grammar as first ratified. Both tiers now admit the
+> conditional-binder family `if-let` / `when-let` / `if-some` / `when-some`: they
+> join the template control forms (after `when-not`) and the binder-aware structural
+> expression tier (after `try`). Each desugars into the analyzer's own `let` +
+> `if`/`when` over a reserved temp — the position-aware binder machinery the analyzer
+> already fully controls — so the init lowers a finite reactive site, the pattern's
+> reactive-escape is rejected, and the closed-grammar / manifest / elision invariants
+> are unchanged. The admission is exactly those four forms; `case` in expression
+> position, `condp`, `doto`, and other conveniences stay **deferred** under the
+> "demonstrated demand at a real call site" trigger. The set still grows only by
+> ruling, each addition carrying its lexical-scope + hidden-reactive-injection
+> counterfixtures. Normative home: [spec/004-Views.md §Template grammar](../../spec/004-Views.md).
+
 DOM prop spelling is pinned (`:on-click`, never `:on-keydown`); prop conversion
 is compile-time, contextual, and total — one rule table (004B) serves static
 props, `ui/spread`, and both emitters; custom elements get the bounded

--- a/docs/core/re-frame.ui/interop-and-limits.md
+++ b/docs/core/re-frame.ui/interop-and-limits.md
@@ -17,10 +17,11 @@ where this substrate is the wrong tool.
 > piece of markup **at compile time**, that spelling is illegal in a `defview` body.
 
 "Prove" means: after normalising the control forms it understands — `let`, `if`,
-`when`, `cond`, `case`, `for`, and friends — every tag head, every `sub`/`lease`
-site, and every list identity is finite and visible. Ordinary branching and binding
-are *free*: both arms of an `if`, every `cond` clause, the body of a `for` all lower
-into the AST, so you are never forced into one linear template.
+`when`, `if-let`, `when-let`, `if-some`, `when-some`, `cond`, `case`, `for`, and
+friends — every tag head, every `sub`/`lease` site, and every list identity is finite
+and visible. Ordinary branching and binding are *free*: both arms of an `if`, every
+`cond` clause, the bound branch of an `if-let`, the body of a `for` all lower into the
+AST, so you are never forced into one linear template.
 
 ## Template structure
 
@@ -49,10 +50,10 @@ ordinary Clojure *values*, but their lexical *syntax* is audited so every reacti
 call stays visible. That closes the door on arbitrary macros in those positions: an
 unaudited macro could inject a `sub` the manifest never saw. The accepted set is
 the transparent core forms (`or` `and` `when` `when-not` `cond` `->` `->>` `some->`
-`some->>` `cond->` `cond->>`), the binder forms (`let` `fn` `loop` `letfn` `try`),
-and ordinary function calls; everything else is `:rf.ui.compile/unsupported-form`,
-and the fix is always to move the computation into a plain function or another
-`defview`.
+`some->>` `cond->` `cond->>`), the binder forms (`let` `fn` `loop` `letfn` `try`, and
+the conditional binders `if-let` `when-let` `if-some` `when-some`), and ordinary
+function calls; everything else is `:rf.ui.compile/unsupported-form`, and the fix is
+always to move the computation into a plain function or another `defview`.
 
 ## Foreign React
 

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -117,7 +117,63 @@
           keys vals seq re-seq]))
 
 (def ^:private control-heads
-  #{'if 'if-not 'when 'when-not 'cond 'case 'let 'letfn 'do 'for})
+  #{'if 'if-not 'when 'when-not 'cond 'case 'let 'letfn 'do 'for
+    'if-let 'when-let 'if-some 'when-some})
+
+(def ^:private if-let-family
+  "The admitted conditional-binder family (rf2-u53yy.4): if-let / when-let /
+  if-some / when-some. `:some?` selects the some?-based test over truthiness;
+  `:else?` selects the two-arm if-let/if-some shape over the single-body
+  when-let/when-some shape. The set is CLOSED — case in expression position,
+  condp, doto and the rest stay outside the grammar (Spec 004 §Expression
+  positions); additions are S1e roster changes."
+  {'if-let    {:some? false :else? true}
+   'if-some   {:some? true  :else? true}
+   'when-let  {:some? false :else? false}
+   'when-some {:some? true  :else? false}})
+
+(defn- binder-temp
+  "A deterministic, reserved temp symbol for the if-let-family desugar. Stable
+  per lexical `anchor` (so template identity is stable across compiles) and
+  never a user local (the reserved `rf-ui-` prefix). The temp holds the raw
+  init value so the truthiness / some? test examines it BEFORE the pattern
+  destructures — the exact hygiene clojure.core's own if-let uses (a
+  destructuring pattern must never be tested for truthiness)."
+  [anchor]
+  (symbol (str "rf-ui-binder-" (fingerprint/digest "bnd1-" anchor))))
+
+(defn- desugar-if-let
+  "Desugar one if-let/when-let/if-some/when-some form into the analyzer's own
+  let + if/when over a reserved temp — mirroring clojure.core's expansions. The
+  init is an ordinary evaluated expression (it may own a finite reactive site);
+  the pattern binds into the then/body branch ONLY; the else branch never sees
+  it. Both grammar tiers then reuse their EXISTING let/if machinery on the
+  result, so the family inherits the SAME scope threading, destructuring, and
+  reactive-escape rejection as a hand-written let + if — no runtime interpreter,
+  no dynamic site, no open macro system. Fails with the shared bad-let/bad-if
+  ids on a malformed binding vector or branch arity."
+  [e head temp form]
+  (let [{:keys [some? else?]} (get if-let-family head)
+        [_ bindings & body] form]
+    (when-not (and (vector? bindings) (= 2 (count bindings)))
+      (env/fail! e :rf.ui.compile/bad-let
+                 (str head " needs a single binding pair: (" head
+                      " [pattern init] " (if else? "then else?" "body …") ")")
+                 {:form form}))
+    (let [[pattern init] bindings
+          test  (if some? (list 'some? temp) temp)
+          inner (fn [& tail] (apply list 'let [pattern temp] tail))]
+      (if else?
+        (do
+          (when-not (<= 1 (count body) 2)
+            (env/fail! e :rf.ui.compile/bad-if
+                       (str head " takes a then and an optional else after the "
+                            "binding: (" head " [pattern init] then else?)")
+                       {:form form}))
+          (list 'let [temp init]
+                (list 'if test (inner (first body)) (second body))))
+        (list 'let [temp init]
+              (list 'when test (apply inner body)))))))
 
 (defn- fn-form? [f]
   (and (seq? f) (contains? #{'fn 'fn* 'clojure.core/fn 'cljs.core/fn} (first f))))
@@ -1017,6 +1073,18 @@
                    (= 'letfn* head) (rw-letfn* f locals p)
                    (= 'try head) (rw-try f locals p)
 
+                   ;; if-let / when-let / if-some / when-some (rf2-u53yy.4):
+                   ;; admitted conditional binders. Desugar into the analyzer's
+                   ;; own let + if/when — the position-aware binder machinery it
+                   ;; already controls — so the init lowers a reactive site, the
+                   ;; pattern's reactive-escape is rejected, and the deferred /
+                   ;; loop position law all fall out of the existing rw-let / if
+                   ;; recursion. A local shadow of the spelling falls through to
+                   ;; an ordinary call (tier 1's control-heads guard, mirrored).
+                   (and (contains? if-let-family head)
+                        (not (contains? locals head)))
+                   (rw (desugar-if-let e head (binder-temp p) f) locals p)
+
                    (and (macro-info e* head locals)
                         (contains? transparent-macro-fqns
                                    (:fqn (macro-info e* head locals))))
@@ -1037,8 +1105,10 @@
                    ;; hosts no render-time reactive site — sub/lease/frame are
                    ;; already illegal here (rejected above) — so there is nothing
                    ;; for lexical site analysis to protect. Opaque host macros
-                   ;; (`..`, `doto`, `case`, `if-let`, …) are ordinary callback
-                   ;; code: pass the form through verbatim. A reactive call
+                   ;; (`..`, `doto`, `case` in expression position, …) are
+                   ;; ordinary callback code: pass the form through verbatim
+                   ;; (the admitted if-let family is handled above, never here).
+                   ;; A reactive call
                    ;; smuggled inside one stays illegal in deferred scope and fails
                    ;; loud at its resolution-only var when the callback runs.
                    (and (macro-info e* head locals)
@@ -3098,7 +3168,15 @@
         do       (if (:hooks-region? e)
                    (analyze-hooks-body e "do" (vec (rest form)) form)
                    (analyze e (single-body! e "do" (vec (rest form)) form)))
-        for      (analyze-for e form))
+        for      (analyze-for e form)
+        ;; if-let / when-let / if-some / when-some (rf2-u53yy.4): admitted
+        ;; conditional binders. Desugar into the analyzer's own let + if/when and
+        ;; re-analyze — the branch is a conditional (its then/else leave the
+        ;; hooks region, exactly like if/when), the init lowers a finite reactive
+        ;; site, and the pattern's reactive-escape is rejected, all through the
+        ;; existing template machinery.
+        (if-let when-let if-some when-some)
+        (analyze e (desugar-if-let e head (binder-temp (:path e)) form)))
       (cond
         (raw-form? e form)
         (let [[_ x & extra] form]

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -378,10 +378,11 @@
 
 (deftest deferred-callback-bodies-accept-opaque-host-macros
   ;; A deferred callback (ui/event / bare fn) is opaque host code: interop and
-  ;; binder macros (.. , if-let, …) that a RENDER body rejects pass through here
-  ;; verbatim, because sub/frame — the only things lexical analysis
+  ;; other non-admitted macros (.. , doto, …) that a RENDER body rejects pass
+  ;; through here verbatim, because sub/frame — the only things lexical analysis
   ;; protects — are already illegal in deferred scope. The canonical ui/event
-  ;; payload `(.. e -target -value)` therefore compiles.
+  ;; payload `(.. e -target -value)` therefore compiles. (The admitted if-let
+  ;; family is analyzed, not passed through — see the admitted-family deftest.)
   (testing "a ui/event body keeps its interop macro verbatim"
     (let [el (ana* '[:input {:on-input
                              (event [e] (conj on-value (.. e -target -value)))}])
@@ -395,6 +396,59 @@
   (testing "a render-body opaque macro is still rejected (the deferred/render split)"
     (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
                  (ana* '[:div {:title (.. x -y -z)}])))))
+
+(deftest if-let-binder-family-is-admitted
+  ;; rf2-u53yy.4 — if-let / when-let / if-some / when-some are admitted
+  ;; conditional binders in BOTH grammar tiers. Each desugars into the
+  ;; analyzer's OWN let + if/when: the binding init owns a finite reactive site,
+  ;; the pattern binds into the then/body branch only, and the some?-variants
+  ;; test the raw init value with some? (never destructure-then-test). The closed
+  ;; grammar is unchanged — out-of-family macros still reject (see the reject
+  ;; table); this admits exactly the four named forms and nothing more.
+  (testing "template position desugars through the analyzer's own let, init is a finite site"
+    (doseq [form '[(if-let    [u (sub [:user])] [:p "hi"] [:p "bye"])
+                   (if-some   [u (sub [:user])] [:p "hi"] [:p "bye"])
+                   (when-let  [u (sub [:user])] [:p "hi"])
+                   (when-some [u (sub [:user])] [:p "hi"])
+                   (if-let    [u (sub [:user])] [:p "hi"])]] ; no else -> nothing
+      (let [{:keys [ast sites]} (ana-full form)]
+        (is (= :let (:op ast)) (str "desugars through the analyzer's let: " form))
+        (is (= :if (get-in ast [:body :op])) (str "the branch is a conditional: " form))
+        (is (= 1 (count (:subs sites)))
+            (str "the binding init is a single finite reactive site: " form)))))
+  (testing "some?-variants test the raw init with some?; truthy-variants test it bare"
+    (is (= 'some? (first (get-in (:ast (ana-full '(if-some [u v] [:p "a"] [:p "b"])))
+                                 [:body :test])))
+        "if-some tests (some? temp)")
+    (is (= 'some? (first (get-in (:ast (ana-full '(when-some [u v] [:p "a"])))
+                                 [:body :test])))
+        "when-some tests (some? temp)")
+    (is (symbol? (get-in (:ast (ana-full '(if-let [u v] [:p "a"] [:p "b"])))
+                         [:body :test]))
+        "if-let tests the bare temp")
+    (is (= :nothing (get-in (:ast (ana-full '(when-let [u v] [:p "a"])))
+                            [:body :else :op]))
+        "a when-* form renders nothing on the falsy branch (no else)"))
+  (testing "expression position (a prop value) lowers the init's reactive site"
+    (doseq [form '[[:div {:title (if-let    [x (sub [:q])] x "none")}]
+                   [:div {:title (if-some   [x (sub [:q])] x "none")}]
+                   [:div {:title (when-let  [x (sub [:q])] x)}]
+                   [:div {:title (when-some [x (sub [:q])] x)}]]]
+      (let [{:keys [ast sites]} (ana-full form)]
+        (is (= 1 (count (:subs sites))) (str "prop-value init lowers one site: " form))
+        (is (re-find #"re-frame.ui.reactive/sub-read" (pr-str ast))
+            (str "the lowered runtime site is present: " form)))))
+  (testing "the binding pattern is still host-consumed — a reactive escape rejects"
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+                 (ana* '(if-let [{:keys [x] :or {x (sub [:q])}} m] [:p x] [:p "no"])))
+        "a (sub …) manufactured in an :or default cannot own a lexical site")
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+                 (ana* '[:div {:title (when-let [{:keys [x] :or {x (sub [:q])}} m] x)}]))
+        "the pattern escape rejects in expression position too"))
+  (testing "a malformed binding vector fails loudly (bad-let)"
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+                 (ana* '(if-let [a b c] [:p "x"] [:p "y"])))
+        "the binding is a single [pattern init] pair")))
 
 (deftest event-sites-index-into-the-manifest
   (let [{:keys [sites]} (ana-full '[:div
@@ -871,6 +925,8 @@
      [:<> [:i "f1"] [:i "f2"]]]
     (let [x 1] (case x 1 [:p "one"] [:p "other"]))
     (letfn [(f [n] n)] [:p (f 1)])
+    (if-let [u (sub [:user])] [:p "hi"] [:p "bye"])
+    [:div {:title (when-some [x (sub [:q])] x)}]
     [:div (spread b o)]
     [:input.form-control (spread-safe {:value v :on-change [:set :rf.ui/value]} attr)]
     (raw el)

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -81,9 +81,13 @@
          (reject-id '[:div {:title (mapv (fn [x] (sub [:q x])) xs)}])))
   (is (= :rf.ui.compile/sub-in-loop
          (reject-id '[:div {:title (loop [x 0] (sub [:q x]))}])))
+  ;; rf2-u53yy.4 admits if-let / when-let / if-some / when-some — the family
+  ;; DESUGARS into the analyzer's own let + if, so a (sub …) in the init lowers
+  ;; (see if-let-binder-family-is-admitted). The admission is BOUNDED: an
+  ;; out-of-family macro still fails loudly — the closed grammar did not open.
   (is (= :rf.ui.compile/unsupported-form
-         (reject-id '[:div {:title (if-let [x maybe] (sub [:q x]) nil)}]))
-      "opaque binder macros fail loudly instead of receiving an unsound rewrite")
+         (reject-id '[:div {:title (.. x -y -z)}]))
+      "an out-of-family macro (.. / doto / case in expression position) still fails loudly — the if-let admission did not relax the closed grammar")
   (is (= :rf.ui.compile/unsupported-form
          (reject-id '[:div {:title (-> [:q] sub)}]))
       "a macro cannot turn a bare resolved sub reference into an unindexed call")

--- a/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
@@ -63,15 +63,26 @@
 (deftest real-cljs-binder-macros-fail-while-transparent-expressions-lower
   (with-real-cljs-env
     (fn [_ e]
+      ;; A USER binder macro that expands to the SAME let + if is still opaque —
+      ;; only the four core forms if-let/when-let/if-some/when-some are admitted
+      ;; (rf2-u53yy.4), by exact name, never by "looks like a binder". A bare
+      ;; threading step below `->` also stays rejected.
       (doseq [form
-              ['[:div {:title (if-let [x maybe] (sub [:q x]) nil)}]
-               '[:div {:title
+              ['[:div {:title
                        (re-frame.ui.compiler-macro-resolution-jvm-test/user-binder
                         [x maybe] (sub [:q x]) nil)}]
                '[:div {:title (-> [:q] sub)}]]]
         (is (= :rf.ui.compile/unsupported-form
                (compile-error-id #(analyze/analyze e form)))
             (pr-str form)))
+      ;; The admitted core if-let desugars into the analyzer's own let + if, so
+      ;; the (sub …) in a branch lowers to its indexed manifest site.
+      (let [e*  (assoc e :sites (atom {:events [] :subs [] :htmls []}))
+            ast (analyze/analyze e* '[:div {:title (if-let [x maybe] (sub [:q x]) nil)}])]
+        (is (= 1 (count (:subs @(:sites e*))))
+            "the admitted if-let lowers the branch (sub …) to one manifest site")
+        (is (re-find #"re-frame.ui.reactive/sub-read" (pr-str ast))
+            "the lowered runtime site is present in the desugared let + if"))
       (is (= :rf.ui.compile/unsupported-form
              (compile-error-id
               #(analyze/analyze

--- a/skills/re-frame2-ui-context/SKILL.md
+++ b/skills/re-frame2-ui-context/SKILL.md
@@ -277,9 +277,11 @@ not edit it by hand.
   - (ui/html string) takes exactly one argument
   - (ui/html x) requires a string
 - **`:rf.ui.compile/bad-if`**
+  - takes a then and an optional else after the binding: ( [pattern init] then else?)
   - if takes test then else?
   - if-not takes test then else?
 - **`:rf.ui.compile/bad-let`**
+  - needs a single binding pair: ( [pattern init] then else? / body …)
   - letfn* needs a vector of an even number of flat name/initializer bindings [name init …]
   - letfn* binding names must be simple (unqualified) symbols
   - each letfn* initializer must be a fn/fn* form with a [argv] body or ([argv] body …) arity lists

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -150,8 +150,12 @@ be host-native and need not themselves be serialisable.**
 ## Template grammar
 
 Reagent-familiar hiccup with the ambiguities removed. Control forms — `let` / `letfn` /
-`if` / `if-not` / `when` / `when-not` / `cond` / `case` / statically-pure `do` / `for` —
-normalize **into the AST**; all analyzers and both emitters see through branches.
+`if` / `if-not` / `when` / `when-not` / `if-let` / `when-let` / `if-some` / `when-some` /
+`cond` / `case` / statically-pure `do` / `for` — normalize **into the AST**; all
+analyzers and both emitters see through branches. The four conditional binders desugar
+into the analyzer's own `let` + `if`/`when` over a reserved temp (mirroring
+`clojure.core`'s expansions), so they inherit the same scope threading, destructuring,
+and reactive-escape rejection as a hand-written `let` + `if`.
 
 | Form | Meaning |
 |---|---|
@@ -186,7 +190,12 @@ expression grammar is therefore **closed**:
 
 - **Binder-aware structural forms**, handled with position-aware traversal:
   `quote` (never traversed — quoted data is not executable), `fn`/`fn*`, `let`/`let*`,
-  `loop`/`loop*`, `letfn`/`letfn*`, `try`. Binding patterns and destructuring `:or`
+  `loop`/`loop*`, `letfn`/`letfn*`, `try`, and the conditional binders `if-let` /
+  `when-let` / `if-some` / `when-some`. The four conditional binders desugar into the
+  analyzer's own `let` + `if`/`when` over a reserved temp: the binding init is an
+  ordinary evaluated expression that may own a finite reactive site, the pattern binds
+  into the then/body branch only, and the `some?`-variants test the raw init value
+  (never destructure-then-test). Binding patterns and destructuring `:or`
   defaults may contain neither reactive calls nor unaudited macros — those positions
   are consumed by the host compiler, not expression rewriting, so they cannot own a
   lexical render site (hoist the read into the view body and bind its value). This is
@@ -215,20 +224,26 @@ expression grammar is therefore **closed**:
   didactically: *macro X is outside the compiler's audited expression set and could
   inject, duplicate, or defer a reactive call after lexical site analysis; rewrite it
   with ordinary functions/control forms, or hoist the computation around the view
-  template.* This covers core macros outside the set (`if-let`, `when-let`, `case`,
-  `doto`, `for` in expression position, …) and every user/library macro — macro
+  template.* This covers core macros outside the set (`case` in expression position,
+  `condp`, `doto`, `for` in expression position, …) and every user/library macro — macro
   authority is the host analyzer's own flag, not a name heuristic. Recovery paths, in
   preference order: use a supported core form; move the pure computation into an
   ordinary function and call it; pass reactive values into the helper (read `sub` in
   the view body, hand the value down); or make the reactive boundary a `defview` of
   its own.
 
+`case` in expression position, `condp`, `doto`, and the other conveniences are
+**deferred**, not refused — the trigger is *demonstrated demand at a real call site*.
+Admitting one is a bounded grammar-set growth by the same rule below; do not implement
+one before its trigger fires.
+
 There is deliberately **no** generic double macroexpansion, no macro interpreter, no
 runtime dynamic reactive site, no ViewCell overhead for sub-free views, and no
-compatibility fallback. The set grows only by ruling, and any future addition requires
+compatibility fallback. The set grows only by ruling, and any addition requires
 lexical-scope plus hidden-reactive-injection counterfixtures (the rf2-vxgfnd.100
 hidden-sub / helper / binder-macro proofs in
-`re-frame.ui.compiler-macro-resolution-jvm-test` are the template).
+`re-frame.ui.compiler-macro-resolution-jvm-test` are the template — the admitted
+`if-let` family adds its own binder-lowering + out-of-family + pattern-escape rows).
 
 **DOM prop spelling is pinned:** hyphenated lowercase words mirroring React's camelCase
 — `:on-click`, `:on-key-down`, `:on-input` (never `:on-keydown`). Handler-map options:


### PR DESCRIPTION
Ratified UIx-review programme child **rf2-u53yy.4** (parent epic rf2-u53yy). Admits the conditional-binder family **`if-let` / `when-let` / `if-some` / `when-some`** to re-frame.ui's closed `defview` grammar — the highest-frequency paper cut (`if-let` was `:rf.ui.compile/unsupported-form`, forcing a manual `let` + `if` rewrite).

## What changed

Both grammar tiers now admit exactly these four forms:
- **Template control-form set** (`analyze-list`) — joins `let`/`if`/`when`/`cond`/`case`/`for`/…
- **Audited expression-macro grammar** (`rewrite-expr`) — joins the binder-aware structural tier alongside `let`/`fn`/`loop`/`letfn`/`try`.

Each form **desugars into the analyzer's own `let` + `if`/`when`** over a deterministic reserved temp (mirroring `clojure.core`'s own expansions) — the position-aware binder machinery the analyzer already fully controls. Consequences, all falling out of the existing `let`/`if` machinery:
- the binding **init** is an ordinary evaluated expression that lowers a **finite reactive site** (`(if-let [u (sub [:user])] …)` reads once);
- the pattern binds into the **then/body branch only** (the else never sees it);
- the `some?`-variants test the **raw init value** with `some?` (never destructure-then-test);
- a reactive **escape in the binding pattern** (`:or` default) is rejected exactly as for `let`.

**Bounded, no grammar relaxation.** Only the four named forms are admitted, by exact name (never "looks like a binder"). `case`-in-expression, `condp`, `doto` and other conveniences stay **demand-gated** ("demonstrated demand at a real call site"). A look-alike *user* macro that expands to the same `let` + `if` stays rejected.

**No new AST node, no emitter change** — the desugar reuses the `:let`/`:if` nodes both emitters already lower (verified: emit tiers untouched, admission is free at the emit layer).

## Red → green

- `if-let` in a prop value that was `:rf.ui.compile/unsupported-form` now compiles and lowers its branch `(sub …)` to one indexed manifest site (`compiler-macro-resolution-jvm-test`, `analyze-accept`).
- An out-of-family macro (`..` / `doto` / `case`-in-expression) **still rejects** — the closed grammar held (`analyze-reject`).

## Spec / docs / EP

- `spec/004-Views.md` — both rosters (template control forms + expression binder-aware tier), the rejected-macro example list, the demand-gated deferral note, and the counterfixture note.
- `docs/core/re-frame.ui/interop-and-limits.md` — both enumerations.
- `docs/EP/EP-0031` — dated addendum (EP-0009 convention; accepted text preserved).
- Examples swept (no `let`+`if` view-body shims present); skills swept grep-driven (no file asserts the old rejection).

## Quality gates

| Gate | Result |
|---|---|
| `implementation/ui` → `clojure -M:test` | 1004 tests, **0 failures, 0 errors** |
| `implementation` → `npm run test:cljs` | 10329 tests, **0 failures, 0 errors** |
| `implementation` → `npm run test:elision` | **PASS** (60/60 absent; control present) |
| `mkdocs build --strict` | exit 0 |
| `scripts/check_doc_slugs.py` | exit 0 |

Disjoint from live workers `5e8zv.2` (reactive.cljc + spec/002/005/006/009) and `9utbt`. Hot-zone `spec/004-Views.md` touched — other 004-children sequence behind this merge.
