### PR TITLE
fix(ui/compiler): complete declared :ref forwarding, delete stale S1 pin (rf2-u53yy.3)

### DIFF
--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/ui_context.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/ui_context.clj
@@ -456,10 +456,11 @@ committed frame.
   literal foreign-component var as the head — its props are passed through; a
   **bare fn** on a foreign prop is `:rf.ui.compile/bare-fn-prop`, so wrap it in
   `(ui/handler …)` or `(ui/raw-fn …)`.
-- **Refs:** `:ref` takes a `(ui/raw-fn f)` callback ref (identity-as-protocol),
-  or the declared-`:ref`-forwarding form. A **bare fn** at `:ref` is
-  `:rf.ui.compile/bare-fn-ref`. `:ref` on a *view* is rejected
-  (`:rf.ui.compile/ref-on-view-s1`) — forward through a declared prop instead.
+- **Refs:** `:ref` takes an object ref (preferred) or a `(ui/raw-fn f)` callback
+  ref (identity-as-protocol); a **bare fn** at `:ref` is
+  `:rf.ui.compile/bare-fn-ref`. An internal **view forwards `:ref` only by
+  declaring it** in its header (React 19 ref-as-prop) — passing `:ref` to a view
+  carries it on the props object, and the callee reads it via the declared slot.
 - **Spreading props:** `(ui/spread base overrides)` is the one generic runtime
   prop-map merge, legal only in a **DOM/custom element's** props position (not
   an internal-view call). `(ui/spread-safe owned caller)` is the literal

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -1594,8 +1594,14 @@
                     "render fragment; a ref is a commit-phase host hook, which a "
                     "slot body may not own. Mount a defview that owns the ref")
                {:form form}))
+  ;; :element and :view share the ref contract: object refs preferred, a
+  ;; callback ref MUST be explicit `(ui/raw-fn f)` (React invokes it during
+  ;; commit before the owning view's layout publication, so no committed-slot
+  ;; promise), a bare fn is rejected. An internal view accepts a forwarded ref
+  ;; only by declaring `:ref` in its header; React 19 passes `:ref` as an
+  ;; ordinary prop, so the call site just carries it into the props object.
   (case context
-    :element
+    (:element :view)
     (cond
       (fn-form? form)
       (env/fail! e :rf.ui.compile/bare-fn-ref
@@ -1606,13 +1612,7 @@
       (raw-fn-form? e form)
       {:form (walk-expr e [:ref :raw-fn] (second form)) :raw-fn? true}
       :else
-      {:form (walk-expr e [:ref :element] form) :raw-fn? false})
-    :view
-    (env/fail! e :rf.ui.compile/ref-on-view-s1
-               (str ":ref at an internal-view call site — internal views "
-                    "forward :ref only by declaring it, and declared ref "
-                    "forwarding lands S3. (Conservative S1 pin.)")
-               {:form form})
+      {:form (walk-expr e [:ref context] form) :raw-fn? false})
     :foreign
     {:form (walk-expr e [:ref :foreign] form) :raw-fn? false}))
 

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -549,9 +549,13 @@
                         :else       `(cljs.core/array ~@chs))
         entries  (get-in node [:props :entries])
         ref-a    (get-in node [:props :ref])
+        ;; A forwarded ref rides the props object as `ref` (React 19
+        ;; ref-as-prop): a foreign component receives it, and an internal view
+        ;; receives it iff it declares `:ref` in its header. Object refs pass
+        ;; through verbatim; a `(ui/raw-fn f)` callback ref carries its fn.
         props-form (ordered-literal-object
                     (concat (map #(component-prop-pair % st) entries)
-                            (when (and ref-a (= :foreign (:op node)))
+                            (when ref-a
                               [["ref" (:form ref-a)]])
                             (when (some? children-form)
                               [["children" children-form]])))

--- a/implementation/ui/src/re_frame/ui/compiler/header.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/header.cljc
@@ -22,7 +22,8 @@
     call sites are compile errors).
   - `:key` cannot be a declared prop (it feeds React's key slot);
     `:children` in the header declares child acceptance (Q4); `:ref`
-    declaration is the S3 forwarding spelling and is rejected at S1.
+    is an ordinary declarable slot — a view forwards a ref only by
+    declaring it (React 19 ref-as-prop).
   - `:strs`/`:syms` are outside the props ABI (slots are keywords)."
   (:require [re-frame.ui.compiler.binding-plan :as bp]
             [re-frame.ui.compiler.env :as env]))
@@ -38,21 +39,19 @@
   (if-let [ns* (namespace k)] (str ns* "/" (name k)) (name k)))
 
 (defn- reserved-slot-check!
-  "A view prop keyword may not be a reserved React slot. `:key` feeds React's
-  key slot; `:ref` forwarding is the S3 spelling. Both are rejected wherever the
-  author names them — a `:keys [key]` group symbol or an explicit `{p :key}`
-  value alike — judged on what was WRITTEN, so the canonical collapse can never
-  hide a reserved declaration."
+  "A view prop keyword may not be the reserved React `:key` slot (it feeds
+  React's key slot). It is rejected wherever the author names it — a
+  `:keys [key]` group symbol or an explicit `{p :key}` value alike — judged on
+  what was WRITTEN, so the canonical collapse can never hide a reserved
+  declaration. `:ref` is NOT rejected here: React 19 passes it as an ordinary
+  prop, so a view forwards a ref by declaring `:ref` like any other slot (a
+  ref's commit-phase contract lives at the `:ref` call site, not the header)."
   [k]
   (when (= k :key)
     (fail :rf.ui.compile/key-prop-declared
           (str ":key cannot be a view prop — it is reserved (it feeds React's "
                "key slot). Callers pass :key at the call site; it never "
                "arrives in props — remove the :key binding")
-          {:key k}))
-  (when (= k :ref)
-    (fail :rf.ui.compile/ref-prop-declared-s1
-          ":ref forwarding is declared per view and lands S3 — remove the :ref binding (conservative S1 pin)"
           {:key k}))
   k)
 
@@ -61,7 +60,7 @@
   plan collapses it: `:or` must be a map; `:strs`/`:syms` are outside the props
   ABI; a group needs a vector of symbols; a non-group keyword key is
   unsupported; an explicit entry's lookup value must be a prop keyword; and no
-  produced slot may be a reserved `:key`/`:ref`. Collapse must never SUPPRESS a
+  produced slot may be the reserved `:key`. Collapse must never SUPPRESS a
   diagnostic, so these run on the raw entries, not the de-collided units."
   [b or-map]
   (when-not (map? or-map)
@@ -87,9 +86,9 @@
            ;; Derive each group key with the CANONICAL transform the binding plan
            ;; uses (`bp/key-group-directive-fn`), so `{:keys [acct/key]}` derives
            ;; the qualified `:acct/key` — NOT a bare `:key` from `(keyword (name
-           ;; s))` — while a genuinely bare `:keys [key]`/`:keys [ref]` still
-           ;; derives the reserved `:key`/`:ref` and fails. One namespace rule for
-           ;; the diagnostic and the plan, so equivalent host spellings agree.
+           ;; s))` — while a genuinely bare `:keys [key]` still derives the
+           ;; reserved `:key` and fails. One namespace rule for the diagnostic
+           ;; and the plan, so equivalent host spellings agree.
            (let [group-key (bp/key-group-directive-fn k)]
              (doseq [s v]
                (reserved-slot-check! (group-key s)))))

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -605,9 +605,16 @@
       "callback refs must be explicit (ui/raw-fn f)")
   (is (nil? (reject-id '[:div {:ref (raw-fn (fn [el] el))} "x"]))
       "(ui/raw-fn f) is the callback-ref spelling")
-  (is (= :rf.ui.compile/ref-on-view-s1
-         (reject-id '[child-view {:ref r}]))
-      ":ref forwarding on internal views lands S3 (conservative pin)"))
+  ;; rf2-u53yy.3: an internal view forwards :ref (React 19 ref-as-prop) — an
+  ;; object ref carries through the props object; the ref contract is the
+  ;; element's, so a bare fn still needs the explicit (ui/raw-fn f).
+  (is (nil? (reject-id '[child-view {:ref object-ref}]))
+      "an object :ref forwards to an internal view (declared-ref forwarding)")
+  (is (nil? (reject-id '[child-view {:ref (raw-fn (fn [el] el))}]))
+      "(ui/raw-fn f) is the callback-ref forwarding spelling on a view")
+  (is (= :rf.ui.compile/bare-fn-ref
+         (reject-id '[child-view {:ref (fn [el] el)}]))
+      "a bare-fn :ref on an internal view still needs (ui/raw-fn f)"))
 
 (deftest ui-handler-grammar
   (is (= :rf.ui.compile/bad-ui-handler

--- a/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/defview_grammar_jvm_test.clj
@@ -216,9 +216,8 @@
          (expand-error '(re-frame.ui/defview v {:props [:map [:key :string]]}
                           [] [:div])))
       "…including via the :props schema")
-  (is (= :rf.ui.compile/ref-prop-declared-s1
-         (expand-error '(re-frame.ui/defview v [{r :ref}] [:div])))
-      ":ref forwarding declaration lands S3")
+  (is (nil? (expand-error '(re-frame.ui/defview v [{r :ref}] [:div {:ref r}])))
+      "a declared :ref is an ordinary forwardable slot (React 19 ref-as-prop)")
   (is (= :rf.ui.compile/bad-defview-args
          (expand-error '(re-frame.ui/defview v [{:strs [a]}] [:div a])))
       ":strs/:syms are outside the props ABI — slots are keywords")
@@ -256,13 +255,14 @@
         "the :acct/keys spelling compiles")
     (is (nil? (expand-error '(re-frame.ui/defview v [{k :acct/key r :acct/ref}] [:div "x"])))
         "the explicit qualified-lookup spelling compiles"))
-  (testing "genuinely BARE :key / :ref group symbols stay rejected before collapse"
+  (testing "a genuinely BARE :key group symbol stays rejected; :ref is forwardable"
     (is (= :rf.ui.compile/key-prop-declared
            (expand-error '(re-frame.ui/defview v [{:keys [key]}] [:div "x"])))
         "a bare `:keys [key]` still feeds the reserved React key slot")
-    (is (= :rf.ui.compile/ref-prop-declared-s1
-           (expand-error '(re-frame.ui/defview v [{:keys [ref]}] [:div "x"])))
-        "a bare `:keys [ref]` is still the S3 forwarding spelling — rejected at S1")))
+    (is (nil? (expand-error '(re-frame.ui/defview v [{:keys [ref]}] [:div {:ref ref}])))
+        "a bare `:keys [ref]` declares the forwardable ref slot (React 19 ref-as-prop)")
+    (is (= [:ref] (:slots (header/parse-header '[{:keys [ref]}])))
+        "the declared :ref is a real comparator/manifest slot read from props.ref")))
 
 (deftest q3-slot-encoding-table
   ;; the encode function E — the props-ABI freeze's normative core

--- a/implementation/ui/test/re_frame/ui/emit_cljs_lowering_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/emit_cljs_lowering_cljs_test.cljc
@@ -198,6 +198,29 @@
         "custom-element event tails are verbatim")
     (is (not (str/includes? (pr-str custom-event) "\"myevent\"")))))
 
+(deftest declared-ref-forwards-onto-the-internal-view-props-object
+  ;; rf2-u53yy.3: React 19 ref-as-prop — passing :ref to an internal-view call
+  ;; carries it on the props object under the `ref` key; the callee accepts it by
+  ;; declaring :ref in its header. Object refs pass through verbatim (no
+  ;; element-only object-ref guard at the seam — the view forwards like a foreign
+  ;; component); a (ui/raw-fn f) callback ref forwards its fn.
+  (let [form       (emitted '[child-view {:label label :ref my-ref}])
+        call       (first (jsx-calls form))
+        props-form (nth call 4)]
+    (is (some #{"ref"} (forms-of props-form))
+        "the forwarded ref rides the props object under the `ref` key")
+    (is (some #{'my-ref} (forms-of props-form))
+        "the authored object ref is carried into the view's props")
+    (is (= 're-frame.ui.runtime/jsx-runtime (nth call 2))
+        "the forwarded-ref view still lowers through the ordinary jsx runtime")
+    (is (not-any? #{'re-frame.ui.runtime/assert-object-ref!} (forms-of props-form))
+        "the object ref forwards verbatim at the view seam, as at a foreign one"))
+  (testing "a (ui/raw-fn f) callback ref forwards its fn to the internal view"
+    (let [props-form (nth (first (jsx-calls (emitted '[child-view {:ref (raw-fn cb)}]))) 4)]
+      (is (some #{"ref"} (forms-of props-form)))
+      (is (some #{'cb} (forms-of props-form))
+          "the explicit callback-ref fn is forwarded verbatim"))))
+
 (deftest keyed-passive-ownership-carries-the-once-bound-row-key
   (let [key-expr '(:id row)
         form (emitted

--- a/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
@@ -83,7 +83,6 @@
     :rf.ui.compile/rejected-prop-spelling
     :rf.ui.compile/bare-fn-prop
     :rf.ui.compile/bare-fn-ref
-    :rf.ui.compile/ref-on-view-s1
     :rf.ui.compile/dynamic-props-map
     :rf.ui.compile/bad-spread
     ;; literal safe-spread policy (S3, rf2-isdqjv)
@@ -118,7 +117,6 @@
     :rf.ui.compile/bad-defview-args
     :rf.ui.compile/positional-args
     :rf.ui.compile/key-prop-declared
-    :rf.ui.compile/ref-prop-declared-s1
     :rf.ui.compile/unknown-option
     :rf.ui.compile/bad-view-id
     :rf.ui.compile/bad-custom-element
@@ -460,7 +458,6 @@
    [:rf.ui.compile/bare-fn-prop '[:div {:data-cb (fn [x] x)} "x"] ["ui/raw-fn"]]
    [:rf.ui.compile/bare-fn-prop '[ForeignComp {:on-select (fn [x] x)}] ["ui/raw-fn"]]
    [:rf.ui.compile/bare-fn-ref '[:div {:ref (fn [el] el)} "x"] ["(ui/raw-fn f)"]]
-   [:rf.ui.compile/ref-on-view-s1 '[child-view {:ref r}] ["S3"]]
    [:rf.ui.compile/bad-spread '[:div (spread)] ["(ui/spread base"]]
    [:rf.ui.compile/bad-spread '(spread base) ["props position"]]
    ;; literal safe-spread policy (S3, rf2-isdqjv): malformed form + owned-key deny
@@ -644,7 +641,6 @@
   "[id argv [escape-naming fragments]] — defview header rejections."
   [[:rf.ui.compile/positional-args '[a b] ["one props map"]]
    [:rf.ui.compile/key-prop-declared '[{k :key}] ["call site"]]
-   [:rf.ui.compile/ref-prop-declared-s1 '[{r :ref}] ["S3"]]
    [:rf.ui.compile/bad-defview-args '[{:strs [a]}] [":keys"]]
    [:rf.ui.compile/bad-defview-args '["nope"] ["map-destructuring"]]
    [:rf.ui.compile/bad-defview-args '[{:keys [a] :or [a 1]}] [":or needs a map"]]

--- a/skills/re-frame2-ui-context/SKILL.md
+++ b/skills/re-frame2-ui-context/SKILL.md
@@ -157,10 +157,11 @@ committed frame.
   literal foreign-component var as the head — its props are passed through; a
   **bare fn** on a foreign prop is `:rf.ui.compile/bare-fn-prop`, so wrap it in
   `(ui/handler …)` or `(ui/raw-fn …)`.
-- **Refs:** `:ref` takes a `(ui/raw-fn f)` callback ref (identity-as-protocol),
-  or the declared-`:ref`-forwarding form. A **bare fn** at `:ref` is
-  `:rf.ui.compile/bare-fn-ref`. `:ref` on a *view* is rejected
-  (`:rf.ui.compile/ref-on-view-s1`) — forward through a declared prop instead.
+- **Refs:** `:ref` takes an object ref (preferred) or a `(ui/raw-fn f)` callback
+  ref (identity-as-protocol); a **bare fn** at `:ref` is
+  `:rf.ui.compile/bare-fn-ref`. An internal **view forwards `:ref` only by
+  declaring it** in its header (React 19 ref-as-prop) — passing `:ref` to a view
+  carries it on the props object, and the callee reads it via the declared slot.
 - **Spreading props:** `(ui/spread base overrides)` is the one generic runtime
   prop-map merge, legal only in a **DOM/custom element's** props position (not
   an internal-view call). `(ui/spread-safe owned caller)` is the literal
@@ -368,7 +369,6 @@ not edit it by hand.
 - **`:rf.ui.compile/react-hook-bad-deps`** — (react/ setup deps): deps must be a literal vector (compared per slot by Object.is)
 - **`:rf.ui.compile/react-hook-misplaced`** — (react/ …) is a host hook — legal ONLY where it evaluates unconditionally, once per render: the straight-line top region of a defview body (an outer let binding). It cannot run in a loop, branch, deferred callback, render-fn slot, or root expression — React's hook order must be static. Hoist it to the top of the view body, or extract a keyed child view
 - **`:rf.ui.compile/react-lazy-misplaced`** — (react/lazy …) is DEF-LEVEL only — bind it at the top level: (def HeavyChart (react/lazy load-thunk {:fallback tpl})), then use the component as a foreign head [HeavyChart {…}]. Calling it inside a view body mints a new component type per render and remount-loops
-- **`:rf.ui.compile/ref-on-view-s1`** — :ref at an internal-view call site — internal views forward :ref only by declaring it, and declared ref forwarding lands S3. (Conservative S1 pin.)
 - **`:rf.ui.compile/rejected-prop-spelling`** — is not a prop — one spelling per name, ambiguities removed. Use
 - **`:rf.ui.compile/render-fn-misplaced`**
   - (ui/render-fn …) is a render-slot callback value — legal ONLY as a component call-site prop value or a ui/slot argument, never as a plain expression. The library invokes it through ui/slot


### PR DESCRIPTION
## Summary

Completes declared `:ref` forwarding and deletes the stale S1-era pin (rf2-u53yy.3, ratified 2026-07-20 from the UIx-review programme). `spec/004-Views.md:416` already promised "Internal views forward `:ref` only by declaring it", but the compiler still rejected both a declared `:ref` and a `:ref` passed to an internal-view call. The whole mechanism is React 19 ref-as-prop plus per-view declaration — no separate forward-ref abstraction.

### Before → after

- **Declaration (`header.cljc`)** — declaring `:ref` in a header (`[{:keys [ref]}]` / `[{r :ref}]`) hit `:rf.ui.compile/ref-prop-declared-s1`. Now `:ref` is an ordinary declarable slot (only `:key` stays reserved), so a view accepts a forwarded ref by declaring it and reads `props.ref`.
- **Call site (`analyze.cljc`)** — `[child-view {:ref r}]` hit `:rf.ui.compile/ref-on-view-s1`. Now `:element` and `:view` share one ref contract: object refs preferred, a callback ref requires the explicit `(ui/raw-fn f)`, a bare fn still rejects with `:rf.ui.compile/bare-fn-ref`.
- **Emit (`emit_cljs.cljc`)** — the forwarded ref now rides the props object under `ref` for internal views too (previously `:foreign`-only), so React 19 hands it to the callee.

### Stale pins deleted (grep-verified)

- `:rf.ui.compile/ref-prop-declared-s1` (header declaration) and `:rf.ui.compile/ref-on-view-s1` (internal-call) removed from source, the frozen roster set, and both roster tables. `git grep` across all tracked source/test/spec/docs/skills/generator files finds **no** remaining reference to either id. (One stale mention survives in `ai/findings/**` — the local-only AI working tree, explicitly off-limits per the worker fence and non-load-bearing.)

### JVM tree / SSR

`emit_jvm.cljc`'s `emit-view` reads only `[:props :entries]` and `[:props :key]` — refs are naturally dropped from the structural tree, so they never appear in event vectors or SSR output (per spec/004). No emit_jvm change needed.

### Spec

`spec/004-Views.md` already states the completed contract (lines 412-417, 1011, 1066, 1486) with no residual S1-pin caveat — the spec led, the code lagged. Left as-is per the bead ("stays as-is where it already states the declared contract").

### Generated AI context sheet

Regenerated `skills/re-frame2-ui-context/SKILL.md` (`clojure -M -m re-frame.api-manifest.ui-context`): the auto-scanned catalogue drops the removed `ref-on-view-s1` entry, and the hand-authored "Foreign boundary & refs" prose in `ui_context.clj` now states the completed forwarding. `ui-context --check` is green (69 ids in sync).

### Docs / examples / EPs

Grep-verified none state the old pin: doc `:ref` mentions are `ui/spread-safe` deny-keys and `->react` passthrough; EP `:ref` mentions are the same; the todomvc focus `:ref` is a legitimate *local* callback ref (a plain Reagent-style `defn`, not closed-compiler code), not a parent→child forwarding workaround. No example could forward a ref parent→child before this fix, so the sweep yields no rewrite candidates.

### Tests (red→green)

- `defview_grammar_jvm_test.clj` — a declared `:ref` header now compiles and yields `[:ref]` in `:slots`; `:key` still rejects.
- `analyze_reject_cljs_test.cljc` — an object `:ref` and a `(ui/raw-fn f)` callback ref forward to an internal view; a bare-fn `:ref` still rejects.
- `emit_cljs_lowering_cljs_test.cljc` — new test: the forwarded ref lowers onto the internal-view props object under `ref` (object ref verbatim, no element-only guard; `ui/raw-fn` carries its fn).
- `error_roster_cljs_test.cljc` — both ids removed from the frozen set and their roster rows.

Disjoint from live workers z0lnf (error_emit + spec/009) and ao46i (observation + reactive + Xray).

## Quality gates

- `clojure -M:test` (implementation/ui, JVM) — **1006 tests, 19860 assertions, 0 failures/0 errors**
- `npm run test:cljs` (node) — **10331 tests, 51039 assertions, 0 failures/0 errors**
- `npm run test:elision` — **PASS** (production 60/60 absent; control 60/60 present)
- `python -m mkdocs build --strict` — **exit 0**
- `python scripts/check_doc_slugs.py` — **exit 0**
- `clojure -M -m re-frame.api-manifest.ui-context --check` — **OK, 69 ids in sync**
