### PR TITLE
refactor(ui): unify disposal-cause :value → :subscription vocabulary (rf2-ao46i)

### DIFF
--- a/docs/EP/EP-0033-re-frame-ui-view-evidence.md
+++ b/docs/EP/EP-0033-re-frame-ui-view-evidence.md
@@ -59,7 +59,7 @@ of the schema this EP specifies.
 **Shipped:** the five `re-frame.ui.tool` projections; occurrence-shaped
 instance records (`:occurrence` ordinal + `:view-id` + `:root-id` +
 `:connection` + `:lifecycle` intervals + bounded render evidence) with explicit
-loss accounting; and a bounded render-cause **set** — `#{:value :hmr
+loss accounting; and a bounded render-cause **set** — `#{:subscription :hmr
 :disposed}`. Host-state writers (`local`) are proven through G-15's writer
 composition and render count, not a `:local-state` cause row — that render
 cause is specified for S6, not shipped at S3.
@@ -163,13 +163,13 @@ exactly as `tools/xray/spec/021` §3.4.1 does; nothing is emitted for these):
   using only the view-global remount counter; honest per-instance attribution needs
   a teardown→remount pairing signal (cross-surface + a fiddly closing rule).
 
-**Schema version + vocabulary residue.** The record + roster ship under
+**Schema version + vocabulary.** The record + roster ship under
 `re-frame.ui.tool/schema-version` **3** (bumped from 2 in this same change; Xray,
 Story, and Pair move in lockstep so none degrades to `[]`). The `:value`→
-`:subscription` rename lands on the per-commit record surface only; the observation
-**port keyword** and Xray's **cumulative** `explain-render` window keep the
-`#{:value :hmr :disposed}` vocabulary — the port-wide vocabulary unification is a
-separate cross-substrate move (a tracked follow-up), not part of this bump.
+`:subscription` rename first landed on the per-commit record surface; the port-wide
+unification (rf2-ao46i, RULING 2) then carried it to the observation **port keyword**
+and Xray's **cumulative** `explain-render` window, so the whole substrate now speaks
+the one `#{:subscription :hmr :disposed}` vocabulary — no two-vocabulary residue.
 
 ### Two evidence layers
 

--- a/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_cljs_test.cljs
@@ -5,7 +5,7 @@
 
   The plain-atom port suites (`re-frame.observation-port-cljs-test`) are
   IDeref-only: their derived sub values are NOT `IWatchable`, so the per-handle
-  `add-watch` the port installs never fires and the entire `{:cause :value}`
+  `add-watch` the port installs never fires and the entire `{:cause :subscription}`
   fan-out — the delivered-value node-record advance, the handle `:last` update,
   and that path's dev reentrancy guard — runs in no test there (the untested
   half of `acquire!`). This file grafts the SAME port onto the stock Reagent
@@ -29,7 +29,7 @@
   The push path: a `dispatch-sync` MOVES the sub's value; `reagent.ratom/flush!`
   re-runs the driver (and through it the node), and — the value changed — the
   node notifies the port watch, which advances the node record with the
-  DELIVERED value (no recompute, I-5) and fans `{:cause :value …}` to the
+  DELIVERED value (no recompute, I-5) and fans `{:cause :subscription …}` to the
   handle's own `on-change`.
 
   CLJS-only (Reagent is CLJS); ns ends in `-cljs-test` so the consolidated
@@ -41,7 +41,7 @@
   clojure/cljs `=` (and Reagent's `=`-gated reaction-notify) treat `NaN ≠ NaN`,
   so a NaN→NaN recompute genuinely FIRES the host watch — yet the movement law
   (`node-value=` / `eq/rf=`, NaN self-equal on both hosts) is NO movement, so
-  the port must fan NO `:cause :value` note, advance NO node version, dirty NO
+  the port must fan NO `:cause :subscription` note, advance NO node version, dirty NO
   ViewCell, and drive NO render. A naive raw `not=` at the make-watch-handler
   seam would spuriously fan a phantom movement against a stable node. These
   proofs (a) stand an INDEPENDENT sentinel watch to show the host callback
@@ -136,12 +136,12 @@
   cell)
 
 ;; ===========================================================================
-;; the value-movement watch channel — {:cause :value} end-to-end
+;; the value-movement watch channel — {:cause :subscription} end-to-end
 ;; ===========================================================================
 
 (deftest watchable-host-value-movement-fires-cause-value-end-to-end
   (testing "on a WATCHABLE (Reagent) host, a sub value MOVEMENT fires the
-            port's per-handle watch → {:cause :value} with an ADVANCED
+            port's per-handle watch → {:cause :subscription} with an ADVANCED
             node-version and the handle :last updated to the DELIVERED value —
             the make-watch-handler channel the plain-atom suites cannot reach"
     (register!)
@@ -169,11 +169,11 @@
             ;; --- MOVE the value; flush the reaction queue (the push) ---
             (rf/dispatch-sync [:obs/set-n 2])
             (ratom/flush!)
-            (testing "the value-movement watch fired the {:cause :value} channel"
+            (testing "the value-movement watch fired the {:cause :subscription} channel"
               (is (pos? (count @notes))
                   "the port's per-handle watch fired on the value movement")
-              (is (every? #(= :value (:cause %)) @notes)
-                  "every fan-out on this path carries {:cause :value}")
+              (is (every? #(= :subscription (:cause %)) @notes)
+                  "every fan-out on this path carries {:cause :subscription}")
               (let [ev (peek @notes)]
                 (is (= target (:target ev)) "the payload carries the handle target")
                 (is (= node0 (:node-key ev)) "same node — a MOVEMENT, not a rebuild")
@@ -191,7 +191,7 @@
 
 (deftest watchable-host-idempotent-move-does-not-fan-cause-value
   (testing "a commit that leaves the sub value UNMOVED does not fire the
-            {:cause :value} channel — the reaction's `=` notify gate (and the
+            {:cause :subscription} channel — the reaction's `=` notify gate (and the
             node-record's rf= version hold) mean an equal re-commit is silent"
     (register!)
     (rf/dispatch-sync [:obs/set-n 7])
@@ -208,7 +208,7 @@
             (rf/dispatch-sync [:obs/set-n 7])
             (ratom/flush!)
             (is (empty? @notes)
-                "an unmoved value fans nothing on the :value channel")
+                "an unmoved value fans nothing on the :subscription channel")
             (is (= v0 (:version (handle-last handle)))
                 "the node-version did not advance for an equal re-commit"))
           (finally
@@ -221,7 +221,7 @@
 
 (deftest watchable-host-value-fan-out-holds-the-reentrancy-guard
   (testing "an on-change that mutates graph ownership (release!) from INSIDE
-            the {:cause :value} fan-out trips the dev reentrancy guard —
+            the {:cause :subscription} fan-out trips the dev reentrancy guard —
             :rf.error/reentrant-graph-op — the make-watch-handler-path leg of
             the guard the plain-atom suites cannot reach"
     (register!)
@@ -260,7 +260,7 @@
 (deftest watchable-host-nan-to-nan-fires-watch-but-fans-no-value-movement
   (testing "on a WATCHABLE (Reagent) host, a NaN→NaN recompute FIRES the
             underlying host watch (an independent sentinel proves the callback
-            ran) yet the port's node-value= gate emits NO {:cause :value} note
+            ran) yet the port's node-value= gate emits NO {:cause :subscription} note
             and advances NO node version — the make-watch-handler NaN-suppression
             proven through PUBLIC acquire!. A raw not= at the seam (NaN≠NaN
             natively) would spuriously fan a phantom value movement."
@@ -291,15 +291,15 @@
                   "the underlying Reagent host watch FIRED for NaN→NaN — the
                    port's make-watch-handler callback genuinely ran (non-vacuous)")
               (is (empty? @notes)
-                  "NaN→NaN emitted NO {:cause :value} note — node-value= suppressed
+                  "NaN→NaN emitted NO {:cause :subscription} note — node-value= suppressed
                    the fan-out (raw not= would fan a phantom movement)")
               (is (= v0 (:version (handle-last handle)))
                   "the node version did NOT advance — NaN=NaN under the movement law"))
             (testing "positive control — a REAL move fans exactly once + advances"
               (rf/dispatch-sync [:obs/set-n 5])
               (ratom/flush!)
-              (is (= 1 (count @notes)) "exactly one {:cause :value} for a real move")
-              (is (= :value (:cause (first @notes))))
+              (is (= 1 (count @notes)) "exactly one {:cause :subscription} for a real move")
+              (is (= :subscription (:cause (first @notes))))
               ;; EXACT `inc`, not merely `> v0`: `advance-node-record!` advances
               ;; the node version by exactly `(inc (:version rec))` per real
               ;; movement (observation.cljc), and between `v0` and this single

--- a/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_mounted_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_mounted_dom_cljs_test.cljs
@@ -197,7 +197,7 @@
                      reaction          (node-reaction)
                      [nan-hits nan-rm] (install-nan-sentinel! reaction)
                      ;; An INDEPENDENT probe handle on the SAME node: its
-                     ;; `on-change` is the `{:cause :value}` note channel that
+                     ;; `on-change` is the `{:cause :subscription}` note channel that
                      ;; the mounted cell's own (cell-dirtying) `on-change`
                      ;; cannot surface. Same port, same node, same notify sweep
                      ;; — the standard public `acquire!`, not a test bridge.
@@ -235,7 +235,7 @@
                            "the Reagent host watch FIRED for NaN→NaN — make-watch-handler
                             genuinely ran, so the green assertions below are non-vacuous")
                        (is (empty? @notes)
-                           "ZERO {:cause :value} notes — node-value= suppressed the fan-out
+                           "ZERO {:cause :subscription} notes — node-value= suppressed the fan-out
                             (a raw not= at the seam would fan a phantom movement)")
                        (is (= ver0 (:version (obs/read probe)))
                            "node version UNMOVED — NaN=NaN under the movement law")
@@ -253,8 +253,8 @@
                    (fn []
                      (testing "positive control — a REAL move moves all four EXACTLY once"
                        (is (= 1 (count @notes))
-                           "exactly one {:cause :value} note for the real movement")
-                       (is (= :value (:cause (first @notes))))
+                           "exactly one {:cause :subscription} note for the real movement")
+                       (is (= :subscription (:cause (first @notes))))
                        (is (= (inc ver0) (:version (obs/read probe)))
                            "the real move advanced the node version EXACTLY once")
                        (is (= (inc rev0) (reactive/revision cell))

--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -1875,7 +1875,7 @@
   advancement — the core-local `node-value=` `rf=` spelling, NOT raw `not=`
   (rf2-vxgfnd.185). A watchable host notifies its watches on EVERY write,
   value-blind, so a NaN→NaN recompute fires this callback with `prev`/`nu`
-  both NaN; raw `not=` treats NaN≠NaN and would fan a `:cause :value`
+  both NaN; raw `not=` treats NaN≠NaN and would fan a `:cause :subscription`
   notification for NO value movement, while `advance-node-record!` (also
   `node-value=`) leaves the version unchanged — a value-movement notification
   without value movement that dirties a downstream ViewCell against a stable
@@ -1892,7 +1892,7 @@
                 last' {:value nu :version (:version rec) :node-key (:node-key rec)}]
             (swap! state assoc :last last')
             (fan-out! (:on-change st)
-                      {:cause          :value
+                      {:cause          :subscription
                        :target         (:target st)
                        :node-key       (:node-key rec)
                        :node-version   (:version rec)
@@ -2063,7 +2063,7 @@
   evidence comparison's job, invariant 5).
 
   `on-change` MUST be constant-work (mark-dirty with the payload
-  `{:cause :value|:hmr|:disposed :target … :node-key … :node-version …
+  `{:cause :subscription|:hmr|:disposed :target … :node-key … :node-version …
   :frame-epoch … :registry-epoch …}`; it never computes — I-5).
 
   For a `:story-override` target returns the STATIC handle: `:owned? false`

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -497,7 +497,7 @@
 ;; the two cannot drift. A watchable host whose derived value recomputes NaN→NaN
 ;; fires its `add-watch` UNCONDITIONALLY (clojure/cljs atoms notify on every
 ;; reset!, value-blind), but NaN=NaN under the movement law: there is no value
-;; movement, so the port must emit NO `:cause :value` notification. Raw `not=`
+;; movement, so the port must emit NO `:cause :subscription` notification. Raw `not=`
 ;; treated NaN≠NaN and spuriously fanned out — a value-movement notification
 ;; without value movement, dirtying a downstream ViewCell while the node version
 ;; (governed by the same `node-value=`) stayed put.
@@ -567,7 +567,7 @@
                 "value delivery performed ZERO additional observable reads")
             (is (= 1 (count @notes))
                 "the public handle callback received exactly one movement")
-            (is (= :value (:cause (first @notes))))
+            (is (= :subscription (:cause (first @notes))))
             (is (= target (:target (first @notes)))))
           (finally
             (obs/release! handle)))))))
@@ -585,7 +585,7 @@
       ;; watch DOES fire with prev=NaN, nu=NaN, exercising the fan-out gate.
       (reset! host ##NaN)
       (is (empty? @notes)
-          "no :cause :value notification for a NaN→NaN no-movement recompute
+          "no :cause :subscription notification for a NaN→NaN no-movement recompute
            (raw not= would spuriously fan out — NaN≠NaN natively)")
       (is (= base-v (:version (:last @state)))
           "the node version did not advance — NaN=NaN under the movement law"))
@@ -593,9 +593,9 @@
       (let [n-before (count @notes)]
         (reset! host 5)
         (is (= 1 (- (count @notes) n-before))
-            "exactly one :cause :value notification for real movement")
+            "exactly one :cause :subscription notification for real movement")
         (let [note (last @notes)]
-          (is (= :value (:cause note)))
+          (is (= :subscription (:cause note)))
           (is (= target (:target note)))
           (is (= (inc base-v) (:node-version note))
               "the notification carries the once-advanced node version")

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -1370,7 +1370,7 @@
     {:first-epoch    e0    ; the FIRST movement's frame-epoch (the anchor)
      :latest-epoch   eN    ; the most-recent movement's frame-epoch
      :count          n     ; total invalidation OCCURRENCES folded this window
-     :causes         #{…}  ; the SET of causes seen (:value/:hmr/:disposed — ≤3)
+     :causes         #{…}  ; the SET of causes seen (:subscription/:hmr/:disposed — ≤3)
      :targets        [tk…] ; distinct moving targets SHOWN, capped at `target-cap`
      :dropped        #{tk} ; distinct moving targets OMITTED past the shown cap —
                            ;   a BOUNDED SET; its COUNT is the honest fan-out loss
@@ -1433,7 +1433,7 @@
 ;; ONLY the explicitly-ruled fields are preserved per cause (Ruling 2); this is
 ;; NOT a general evidence framework:
 ;;   - :subscription  target / query / frame-id + version :from->:to + :epoch,
-;;                    read straight off the `:value` port-note axes (:target,
+;;                    read straight off the `:subscription` port-note axes (:target,
 ;;                    :node-key, :node-version, :frame-epoch). `:from` is the
 ;;                    version before the movement (the port advances it by one per
 ;;                    move); a coalesced window keeps the EARLIEST :from and the
@@ -1446,21 +1446,21 @@
 
 (defn- commit-cause-fact
   "Project ONE port-note `payload` to its S6 commit-cause `[kind detail]` pair, or
-  nil when the note carries no commit cause. The `:value` port cause is renamed to
-  `:subscription` HERE (the record is slice b's new surface); the still-`:value`
-  port keyword and the Xray cumulative window keep their vocabulary until slice
-  d's coordinated schema bump. DEBUG-only — reached only from the DEBUG arm of
-  `enrol-dirty-window!`."
+  nil when the note carries no commit cause. The port cause keyword is
+  `:subscription` — unified port-wide (rf2-ao46i, RULING 2): the observation port,
+  this per-commit record surface, and the Xray cumulative window all speak the one
+  `:subscription` vocabulary, so no rename happens at this boundary. DEBUG-only —
+  reached only from the DEBUG arm of `enrol-dirty-window!`."
   [{:keys [cause target node-key node-version frame-epoch]}]
   (case cause
-    :value    [:subscription {:target   node-key
-                              :query    (:query target)
-                              :frame-id (:frame-id target)
-                              :from     (some-> node-version dec)
-                              :to       node-version
-                              :epoch    frame-epoch}]
-    :hmr      [:hmr {}]
-    :disposed [:disposed {}]
+    :subscription [:subscription {:target   node-key
+                                  :query    (:query target)
+                                  :frame-id (:frame-id target)
+                                  :from     (some-> node-version dec)
+                                  :to       node-version
+                                  :epoch    frame-epoch}]
+    :hmr          [:hmr {}]
+    :disposed     [:disposed {}]
     nil))
 
 (defn- merge-commit-cause

--- a/implementation/ui/src/re_frame/ui/tool.cljc
+++ b/implementation/ui/src/re_frame/ui/tool.cljc
@@ -213,7 +213,7 @@
 
 (defn explain-render
   "Why did view `view-id`'s live incarnations render? Each occurrence projects the
-  bounded render CAUSES (the `:value`/`:hmr`/`:disposed` cause set), the occurrence
+  bounded render CAUSES (the `:subscription`/`:hmr`/`:disposed` cause set), the occurrence
   and batch counters, the first/latest movement epochs, the moving observation
   targets, and EXPLICIT loss accounting (`:dropped` with an `:exact?` flag — a
   count is a completeness claim only when exact). With no arg, every retained

--- a/implementation/ui/src/re_frame/ui/tool/evidence.cljc
+++ b/implementation/ui/src/re_frame/ui/tool/evidence.cljc
@@ -299,7 +299,7 @@
     :latest-epoch   — the most recent window's latest movement
     :count          — total invalidation OCCURRENCES across every batch
     :batches        — how many flushed batches delivered evidence
-    :causes         — the union cause set (:value/:hmr/:disposed — ≤3)
+    :causes         — the union cause set (:subscription/:hmr/:disposed — ≤3)
     :targets        — bounded non-owning EDN sample of moving targets
     :targets-exact? — false when a target needed an opaque/bounded marker
     :dropped        — bounded loss SET of distinct omitted targets; its

--- a/implementation/ui/test/re_frame/ui/hooks_local_state_cause_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/hooks_local_state_cause_cljs_test.cljs
@@ -49,7 +49,7 @@
 (def ^:private enrol-dirty! @#'reactive/enrol-dirty!)
 
 (defn- fan-value! [cell query]
-  (enrol-dirty! cell {:cause :value
+  (enrol-dirty! cell {:cause :subscription
                       :target {:kind :subscription :frame-id fid :query query}
                       :node-key 7 :node-version 3 :frame-epoch 1})
   (reactive/flush-pending!))

--- a/implementation/ui/test/re_frame/ui/reactive_commit_causes_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_commit_causes_cljs_test.cljc
@@ -8,7 +8,7 @@
     :mount           the :fresh->:connected transition (bare marker).
     :story-override  a (re)acquired static Story-override target — ruled identity
                      + version (`:override-id` / `:version`).
-    :subscription    a `:value` port note captured at the cause site — ruled
+    :subscription    a `:subscription` port note captured at the cause site — ruled
                      target / query / frame-id + version :from->:to + :epoch.
     :local-state     the hooks local-state writer bridge (bare marker).
     :hmr             a real registrar-replacement `:hmr` fan-out (bare marker).
@@ -30,7 +30,7 @@
   The DEBUG carry-forward (`:pending-commit-causes`) is captured at the NOTE (the
   cause site) and drained by the next connected commit: on the headless plain-atom
   hosts a value MOVE has no watch (it is caught at commit step 5, never fanned), so
-  the `:value`/`:disposed` port notes are driven through the SAME private
+  the `:subscription`/`:disposed` port notes are driven through the SAME private
   `enrol-dirty!` the watchable-host on-change calls — the honest payload, not a
   simulation. `:hmr` rides the REAL registrar fan-out.
 
@@ -124,7 +124,7 @@
           "no cause pending, connected, retained handles -> the honesty fallback"))))
 
 ;; ===========================================================================
-;; :subscription — a :value port note, captured with its ruled DETAIL + renamed
+;; :subscription — a :subscription port note, captured with its ruled DETAIL
 ;; ===========================================================================
 
 (deftest a-value-movement-recommits-as-subscription-with-ruled-detail
@@ -133,7 +133,7 @@
   (let [cell (reactive/make-cell ::v)]
     (render+commit! cell [[[:cc/site 0] [:cc/a]]])
     ;; a value move to node-version 3 on node-key 7, epoch 1
-    (fan-cause! cell :value [:cc/a] {:node-key 7 :node-version 3 :epoch 1})
+    (fan-cause! cell :subscription [:cc/a] {:node-key 7 :node-version 3 :epoch 1})
     (render+commit! cell [[[:cc/site 0] [:cc/a]]])
     (is (= [{:cause    :subscription
              :target   7            ;; upstream node identity (:node-key axis)
@@ -143,7 +143,7 @@
              :to       3
              :epoch    1}]
            (causes cell))
-        ":value is renamed to :subscription AND preserves ONLY its ruled fields
+        ":subscription preserves ONLY its ruled fields
          (target/query/frame-id + version from->to + epoch) — no invented framework")))
 
 (deftest a-coalesced-subscription-window-spans-first-from-to-latest-to
@@ -152,8 +152,8 @@
   (let [cell (reactive/make-cell ::v)]
     (render+commit! cell [[[:cc/site 0] [:cc/a]]])
     ;; two movements coalesce before the next commit: 2->3 then 4->5
-    (fan-cause! cell :value [:cc/a] {:node-key 7 :node-version 3 :epoch 1})
-    (fan-cause! cell :value [:cc/a] {:node-key 7 :node-version 5 :epoch 2})
+    (fan-cause! cell :subscription [:cc/a] {:node-key 7 :node-version 3 :epoch 1})
+    (fan-cause! cell :subscription [:cc/a] {:node-key 7 :node-version 5 :epoch 2})
     (render+commit! cell [[[:cc/site 0] [:cc/a]]])
     (let [sub (cause-of cell :subscription)]
       (is (= 2 (:from sub)) "the EARLIEST :from is kept (the window's first move)")
@@ -218,7 +218,7 @@
   (let [cell (render+commit! (reactive/make-cell ::v) [[[:cc/site 0] [:cc/a]]])]
     ;; a no-op setter stashes nothing (the gate lives in hooks; here we simply do
     ;; not stash) — then an unrelated subscription movement drives the next commit
-    (fan-cause! cell :value [:cc/a])
+    (fan-cause! cell :subscription [:cc/a])
     (render+commit! cell [[[:cc/site 0] [:cc/a]]])
     (is (= [:subscription] (cause-kinds cell))
         "an unrelated commit reports its real cause only — no stale :local-state")))
@@ -281,7 +281,7 @@
   (seed! {:a 1})
   (let [cell  (render+commit! (reactive/make-cell ::v) [[[:cc/site 0] [:cc/a]]])
         fired (atom false)]
-    (fan-cause! cell :value [:cc/a])           ;; a :subscription is already pending
+    (fan-cause! cell :subscription [:cc/a])           ;; a :subscription is already pending
     (binding [reactive/*commit-publish-barrier*
               (fn [c]
                 (when (compare-and-set! fired false true)
@@ -300,8 +300,8 @@
   (rf/reg-sub :cc/a (fn [db _] (:a db)))
   (seed! {:a 1})
   (let [cell (reactive/make-cell ::v)]
-    ;; A mount that ALSO carries a movement: mount + a stashed :value.
-    (fan-cause! cell :value [:cc/a])           ;; stash :value onto the fresh cell
+    ;; A mount that ALSO carries a movement: mount + a stashed :subscription.
+    (fan-cause! cell :subscription [:cc/a])           ;; stash :subscription onto the fresh cell
     (render+commit! cell [[[:cc/site 0] [:cc/a]]])
     (is (= [:mount :subscription] (cause-kinds cell))
         ":mount precedes :subscription in the canonical roster order")))

--- a/implementation/ui/test/re_frame/ui/tool_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/tool_cljs_test.cljc
@@ -326,7 +326,7 @@
         sink (evidence/installed-sink)]
     ;; drive real evidence: 8 shown + 2 dropped distinct targets in one window
     (doseq [i (range 10)]
-      (sink cell {:first-epoch 1 :latest-epoch 1 :count 1 :causes #{:value}
+      (sink cell {:first-epoch 1 :latest-epoch 1 :count 1 :causes #{:subscription}
                   :targets [[:sub :rf/default [:demo/q i]]]
                   :dropped #{} :dropped-exact? true}))
     (let [res (tool/explain-render :demo/why)
@@ -334,7 +334,7 @@
       (is (= tool/schema-version (:rf.ui.tool/version res)))
       (is (= :demo/why (:view-id res)))
       (is (= 1 (count (:occurrences res))))
-      (is (= #{:value} (:causes occ)) "the projected render cause")
+      (is (= #{:subscription} (:causes occ)) "the projected render cause")
       (is (= 10 (:render-count occ)) "every occurrence counted")
       (is (= 8 (count (:targets (:observations occ)))) "shown sample capped at 8")
       (is (true? (:identity-exact? (:observations occ)))

--- a/implementation/ui/test/re_frame/ui/tool_evidence_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/tool_evidence_cljs_test.cljc
@@ -77,7 +77,7 @@
   {:first-epoch 1
    :latest-epoch 1
    :count 1
-   :causes #{:value}
+   :causes #{:subscription}
    :targets []
    :dropped #{}
    :dropped-exact? true})
@@ -562,7 +562,7 @@
    :latest-epoch   2
    :count          3
    :batches        1
-   :causes         #{:value}
+   :causes         #{:subscription}
    :targets        (vec targets)
    :targets-exact? true
    :dropped        (set dropped)
@@ -623,7 +623,7 @@
         (is (= 1 (:batches ev)))
         (is (= 1 (:first-epoch ev)))
         (is (= 2 (:latest-epoch ev)))
-        (is (= #{:value} (:causes ev))))
+        (is (= #{:subscription} (:causes ev))))
       (is (= bounded-evidence-keys
              (set (keys (:evidence (entry-for ::legacy-direct)))))
           "migration adds no keys"))

--- a/implementation/ui/test/re_frame/ui/tool_evidence_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/tool_evidence_dom_cljs_test.cljs
@@ -136,7 +136,7 @@
 
 (def ^:private cycle-evidence
   {:first-epoch 1 :latest-epoch 1 :count 1
-   :causes #{:value} :targets [] :dropped #{} :dropped-exact? true})
+   :causes #{:subscription} :targets [] :dropped #{} :dropped-exact? true})
 
 (defn- publish-cycle-refs!
   "Publish direct + nested query→ViewCell cycles, assert the public projection
@@ -221,8 +221,8 @@
                              "…the with-root-minted client root")
                          (is (pos? (:count evidence)))
                          (is (= 1 (:batches evidence)) "one coalesced flush")
-                         (is (contains? (:causes evidence) :value)
-                             "the port's real :value cause")
+                         (is (contains? (:causes evidence) :subscription)
+                             "the port's real :subscription cause")
                          (is (some #(= [::value] (nth % 2)) (:targets evidence))
                              "the moving sub is a shown target")
                          (is (some? (:latest-epoch evidence))

--- a/spec/conformance/S3-view-conformance-profile.md
+++ b/spec/conformance/S3-view-conformance-profile.md
@@ -154,8 +154,8 @@ S3 view evidence is a dev/test-only projection with **no production egress**
 props schema, per-prop docs/defaults, declared render-slot sites, interop sites,
 capability cost, and site counts — the one projection Story, docs, Xray, and
 agents consume. Sibling projections: `mounted-views`, `explain-render` (the
-`:value`/`:hmr`/`:disposed` render-cause set), `view-dependencies`. The certified S3
-cumulative cause union is exactly `#{:value :hmr :disposed}`; host-state writers
+`:subscription`/`:hmr`/`:disposed` render-cause set), `view-dependencies`. The certified S3
+cumulative cause union is exactly `#{:subscription :hmr :disposed}`; host-state writers
 (`local`) are proven through G-15's writer-composition and render-count evidence,
 **not** a cumulative-set `:local-state` cause row. A `:local-state` render cause DID
 ship at S6 (`rf2-vxgfnd.98.1`) — as one kind in the per-commit `:rf.view/causes`

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -775,9 +775,10 @@ six shipped causes — `:mount` / `:subscription` / `:story-override` / `:local-
 producer emits neither, so Xray does NOT fabricate one — absent evidence is tolerated
 explicitly (each renders only when its named trigger lands a framework emit). The
 MOUNTED VIEW EVIDENCE section above reads the CUMULATIVE `explain-render` window,
-whose cause union stays `#{:value :hmr :disposed}` (the per-commit vector is a
-separate raw reader Xray does not yet consume; the `:value`→`:subscription` port
-rename is a tracked follow-up). Likewise a legacy `reg-view` adapter host (no compiled
+whose cause union is `#{:subscription :hmr :disposed}` — unified port-wide with the
+observation port and the per-commit record vocabulary (rf2-ao46i, RULING 2). The
+per-commit `:rf.view/causes` vector is a separate raw reader Xray does not yet
+consume. Likewise a legacy `reg-view` adapter host (no compiled
 manifests / no ViewCell substrate) renders exactly today's zero-row state.
 
 **Ownership + span receipt (rf2-vxgfnd.286).** The stable id
@@ -837,7 +838,7 @@ order, projected from `re-frame.ui.tool/explain-render` (rf2-vxgfnd.95.7) —
      :connection :connected|:disconnected
      :lifecycle {:intervals [{:state _ :reason _ :proof _} …] :dropped n :exact? b}
      :first-epoch e0 :latest-epoch eN :count n :batches b
-     :causes #{:value :hmr :disposed}
+     :causes #{:subscription :hmr :disposed}
      :targets [tk …] :targets-exact? bool
      :dropped-count d :dropped-exact? bool}
 

--- a/tools/xray/src/day8/re_frame2_xray/viewcell_evidence.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/viewcell_evidence.cljs
@@ -353,7 +353,7 @@
      :latest-epoch   eN       ; most recent movement
      :count          n        ; total invalidation/render occurrences
      :batches        b        ; flushed batches that delivered evidence
-     :causes         #{…}     ; union cause set (:value/:hmr/:disposed)
+     :causes         #{…}     ; union cause set (:subscription/:hmr/:disposed)
      :targets        [tk …]   ; bounded shown sample of moving targets
      :targets-exact? bool     ; observation-identity fidelity (false ⇒ opaque)
      :dropped-count  d        ; distinct omitted targets (honest loss)

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_view_cljs_test.cljs
@@ -372,7 +372,7 @@
                :lifecycle {:intervals [{:state :disconnected
                                         :reason :activity-hidden :proof :reconnect}]
                            :dropped 0 :exact? true}
-               :causes #{:value} :count 4 :batches 2
+               :causes #{:subscription} :count 4 :batches 2
                :first-epoch 10 :latest-epoch 14
                :targets [[:sub :rf/app [:a]]] :targets-exact? false
                :dropped-count 70 :dropped-exact? false}]})

--- a/tools/xray/test/day8/re_frame2_xray/viewcell_evidence_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/viewcell_evidence_cljs_test.cljs
@@ -228,7 +228,7 @@
                                                :reason :activity-hidden
                                                :proof :reconnect}]
                                   :dropped 0 :exact? true}
-                      :causes #{:value} :render-count 4 :batches 2
+                      :causes #{:subscription} :render-count 4 :batches 2
                       :first-epoch 10 :latest-epoch 14
                       :observations {:targets [[:sub :rf/app [:a]]]
                                      :identity-exact? false}


### PR DESCRIPTION
Completes RULING 2 (rf2-vxgfnd.98.1)'s no-residue residual (rf2-ao46i). Slice d
(rf2-rvs56) renamed `:value`→`:subscription` on the per-commit `:rf.view/causes`
record surface (schema-version 3), but the observation **port keyword** and Xray's
**cumulative** `explain-render`/`fold-evidence` window still spoke the old
`#{:value :hmr :disposed}` vocabulary — a genuine two-vocabulary residual. This PR
unifies the framework: the port cause keyword and the cumulative window now speak
the one `:subscription` vocabulary, so `commit-cause-fact` no longer renames at the
boundary (it is an identity there now).

## Disposal-CAUSE vs pinned-VALUE
The rename touches ONLY the disposal-**cause** keyword (why a view re-commits: a
subscription's value moved). The pinned-**value** node-record field `:value`
(`{:node-key … :version n :value v}`) and the story-override `:value` field are
**left untouched** — distinguished by structural position (`{:cause :value …}` /
`#{:value …}` / `:causes` set members are the cause; `:value v` map entries are the
pinned value). Behaviour-preserving: record shape + schema-version 3 unchanged; no
`:value`→`:subscription` compat alias (pre-alpha); disposal semantics unchanged.

## Sites
- **Producer** — `core/…/substrate/observation.cljc`: the watch fan-out emission
  `{:cause :subscription …}` + docstrings.
- **Translation/window** — `ui/…/reactive.cljc`: `fold-evidence` cause-set +
  `commit-cause-fact` `case` key + docstrings.
- **UI tool** — `ui/…/tool.cljc` + `tool/evidence.cljc` `explain-render` cause-set docstrings.
- **Xray window** — `tools/xray`: `viewcell_evidence.cljs` docstring, `spec/021`
  prose + example → `#{:subscription :hmr :disposed}`, panel + viewcell-evidence test fixtures.
- **Tests** — observation-port (core + reagent watchable/mounted-DOM), commit-causes +
  hooks-local-state-cause port inputs, tool-evidence (incl. the live-producer DOM assertion).
- **Prose** — `docs/EP/EP-0033` + `spec/conformance/S3-view-conformance-profile.md`.

## Scope boundary
Grep-clean of the disposal-cause `:value` across these surfaces. Deferred to a
coordinated consumer sweep (**rf2-0sray**): the pair-mcp descriptor (generated
`tool-descriptors.edn` + `descriptors_data.cljs` + `spec/003` + conformance fixture),
`story` `view_tool` test, and `skills/re-frame2-pair` `ops.md` — drift/conformance-gated
surfaces outside this bead's gate list, flagged by FINDING 4 as a pair-mcp
lockstep-with-mcp-conformance move. `spec/004-Views.md:1163` left for u53yy.4's fence.
Disjoint from live `z0lnf` (error_emit + spec/009) and `u53yy.4` (analyze + spec/004);
builds on S2A's merged observation-handle rename (orthogonal to this cause rename).

## Quality gates
- `implementation/core` `clojure -M:test` — **2104 tests, 0 failures**
- `implementation/ui` `clojure -M:test` — **1004 tests, 0 failures**
- `implementation` `npm run test:cljs` — **10329 tests, 0 failures**
- `implementation` `npm run test:xray-feature-gate` — **16 scenarios, 0 failures (13 matrix rows)**
- `tools/xray` `clojure -M:test` — **1270 tests, 0 failures**
