### PR TITLE
feat(ui): the effect-dependency rule (rf2-u53yy.6)

### DIFF
--- a/docs/EP/EP-0032-re-frame-ui-reactivity-and-ownership.md
+++ b/docs/EP/EP-0032-re-frame-ui-reactivity-and-ownership.md
@@ -290,6 +290,20 @@ error by the ABI guard.
   The correction is factual — the shipped scheduler batches at the host
   checkpoint, never at drain quiescence — but per the ruling it is recorded, not
   applied by silently rewriting the settled prose.
+- **One effect-dependency equality doctrine: `rf=` across native and interop
+  tiers (2026-07-21, rf2-u53yy.6).** The native `ui/effect` compared deps by
+  `rf=` (value equality) while the `re-frame.ui.react` interop wrappers
+  (`use-effect` / `use-layout-effect`) compared per authored slot by `Object.is`
+  — two equality doctrines one keystroke apart, plus a spec/implementation
+  drift. Ruled (Mike, 2026-07-20): converge on `rf=` **everywhere**, native and
+  interop. The interop tier now derives its effect token from the shared `rf=`
+  comparator (`re-frame.ui.hooks/deps-token`), so a distinct-but-value-equal
+  CLJS deps value no longer re-runs an effect in either tier — value semantics,
+  stated plainly. The superseded per-slot `Object.is` interop behaviour (the
+  ".95.12 correction") is retired; `spec/004-Views.md`'s react-tier deps law is
+  the normative statement. Should a future foreign integration demonstrably
+  require identity semantics, that is a new per-wrapper decision made and
+  documented then — never a silent split.
 
 ## Open Issues
 

--- a/docs/api/re-frame.ui.react.md
+++ b/docs/api/re-frame.ui.react.md
@@ -40,16 +40,18 @@ JVM structural render it is an inert ref (`current` nil, stays nil).
 after paint). `setup` is a zero-arg fn returning a cleanup fn or nil, honoured on dep
 change, disconnect, and unmount; StrictMode dev replay is expected and must be
 idempotent-safe. The one-arg form runs after every commit; a `deps` vector is compared
-per authored slot by **`Object.is`** — React's own effect-dependency rule (a distinct
-value-equal host value *is* a change; `rf=` stays the memo/prop comparator). `[]` deps ⇒
-connect-only. Effects do not run on the JVM (capability metadata only).
+by **`rf=`** (VALUE equality) against the previous render's deps — the one equality
+doctrine shared with the native `effect` and the memo/prop comparator, never a second
+per-tier regime. A distinct-but-value-equal CLJS deps value is **not** a change (it does
+not rerun); a value-different one does; host/foreign values fall through to identity. `[]`
+deps ⇒ connect-only. Effects do not run on the JVM (capability metadata only).
 
 ### `use-layout-effect`
 
 `(react/use-layout-effect setup)` / `(… setup deps)` → nil (`useLayoutEffect`, after DOM
 mutation, **before paint**) for measure-then-mutate work that would flicker under passive
 timing — the native component-library measure-before-paint door
-([recipe](../core/how-to/measure-before-paint.md)). Same setup/cleanup/`Object.is`-deps
+([recipe](../core/how-to/measure-before-paint.md)). Same setup/cleanup/`rf=`-value-deps
 contract as `use-effect`.
 
 ### `use-effect-event`

--- a/docs/core/how-to/measure-before-paint.md
+++ b/docs/core/how-to/measure-before-paint.md
@@ -59,7 +59,7 @@ This is the one job [`app-db`](../glossary.md#app-db), [subscriptions](../glossa
      "…panel content…"]))
 ```
 
-The deps vector `[anchor-bottom viewport]` is compared per slot by `Object.is` — React's own effect-dependency rule — so the panel re-measures whenever the anchor moves or the viewport resizes, and not otherwise.
+The deps vector `[anchor-bottom viewport]` is compared by `rf=` (value equality) against the previous render's deps — re-frame.ui's one effect-dependency doctrine, shared with `effect` and memo — so the panel re-measures whenever the anchor moves or the viewport resizes, and not otherwise. A rebuilt-but-value-equal deps vector is the same dep (no re-measure); host/foreign values fall through to identity.
 
 ---
 

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -989,7 +989,7 @@
                                  (not (vector? (nth call-args deps-arg))))
                         (env/fail! e :rf.ui.compile/react-hook-bad-deps
                                    (str "(react/" name " setup deps): deps must be a "
-                                        "literal vector (compared per slot by Object.is); "
+                                        "literal vector (compared by rf= value equality); "
                                         "got " (pr-str (nth call-args deps-arg)))
                                    {:form f}))
                       (let [sid   (lexical-site-id e kind f p)

--- a/implementation/ui/src/re_frame/ui/hooks.cljc
+++ b/implementation/ui/src/re_frame/ui/hooks.cljc
@@ -145,23 +145,37 @@
   [body-fn]
   (let [c (body-fn)] (if (fn? c) c js/undefined)))
 
+(defn- deps-token
+  "Render-time pure token for an authored deps vector held in the useRef cell
+  `ref`. Returns one internal token whose identity changes iff the authored deps
+  stop being `rf=` (VALUE equality) against the previous render's deps — a
+  distinct-but-`rf=`-equal deps value keeps the SAME token, so React's own
+  cleanup→setup does not fire. Deriving the token during render is a pure
+  function of (prev, deps): equal deps yield the same token, so a StrictMode
+  double-render (or any re-render with `rf=`-equal deps) is idempotent. Because
+  the comparison is kernel-internal (a held previous-deps slot, not React's
+  native deps array) the authored deps arity may vary between renders behind a
+  fixed one-element React deps array.
+
+  This is re-frame.ui's ONE effect-dependency equality doctrine — the same `rf=`
+  the memo/prop comparator and the native `effect` tier use, shared verbatim by
+  the react-interop wrappers, never a second per-tier regime."
+  [^js ref deps]
+  (let [prev ^js (.-current ref)]
+    (if (and (some? prev) (eq/rf= (.-deps prev) deps))
+      (.-token prev)
+      (let [t #js {}]
+        (set! (.-current ref) #js {:deps deps :token t})
+        t))))
+
 (defn effect-value
   "Passive host effect with `rf=` VALUE deps. A stable per-effect token changes
   identity only when the deps stop being `rf=`, so React's own `useEffect`
   drives cleanup-then-setup on dep change, on disconnect/unmount, and under
   StrictMode replay — no hand-rolled scheduling."
   [body-fn deps]
-  (let [ref   (react/useRef nil)
-        prev  (.-current ref)
-        ;; Deriving the token during render is a pure function of (prev, deps):
-        ;; equal deps yield the same token, so a StrictMode double-render (or any
-        ;; re-render with rf=-equal deps) is idempotent.
-        token (if (and (some? prev) (eq/rf= (.-deps prev) deps))
-                (.-token prev)
-                (let [t #js {}]
-                  (set! (.-current ref) #js {:deps deps :token t})
-                  t))]
-    (react/useEffect #(run-effect body-fn) #js [token])
+  (let [ref (react/useRef nil)]
+    (react/useEffect #(run-effect body-fn) #js [(deps-token ref deps)])
     js/undefined))
 
 (defn effect-connect
@@ -195,57 +209,34 @@
   ([] (react/useRef nil))
   ([initial] (react/useRef initial)))
 
-(defn- deps-object-is-equal?
-  "Per-slot `Object.is` comparison of two authored deps vectors — React's
-  effect-dependency equality (a synchronisation input, NOT a repaint value: a
-  distinct value-equal host object IS a change here). An arity change is never
-  equal. `rf=` stays the memo/prop comparator; effects use this."
-  [prev nxt]
-  (let [n (count prev)]
-    (and (== n (count nxt))
-         (loop [i 0]
-           (or (== i n)
-               (and ^boolean (js/Object.is (nth prev i) (nth nxt i))
-                    (recur (inc i))))))))
-
-(defn- effect-deps-token
-  "Render-time pure token for a react effect's authored deps held in the useRef
-  cell `ref`: one internal token whose identity changes iff any slot changed by
-  `Object.is` or the arity changed — so React owns cleanup→setup and the authored
-  deps arity stays compiler-managed behind a fixed one-element React deps array."
-  [^js ref deps]
-  (let [prev ^js (.-current ref)]
-    (if (and (some? prev) (deps-object-is-equal? (.-deps prev) deps))
-      (.-token prev)
-      (let [t #js {}]
-        (set! (.-current ref) #js {:deps deps :token t})
-        t))))
-
 (defn use-effect
   "react/use-effect lowering target — `useEffect` (passive, after paint). Both
   arities allocate the same fixed hook shape (a held deps cell + the effect), so
   editing deps presence is a same-signature edit. No-deps ⇒ a fresh token every
-  render (runs after every commit); deps ⇒ per-slot `Object.is`."
+  render (runs after every commit); deps ⇒ `rf=` VALUE deps via the shared
+  `deps-token` — a distinct-but-`rf=`-equal CLJS deps value does NOT rerun (the
+  one equality doctrine shared with `effect` and memo, never a second per-tier
+  regime)."
   ([setup]
    (let [_ref (react/useRef nil)]
      (react/useEffect #(run-effect setup) #js [#js {}]))
    js/undefined)
   ([setup deps]
    (let [ref (react/useRef nil)]
-     (react/useEffect #(run-effect setup) #js [(effect-deps-token ref deps)]))
+     (react/useEffect #(run-effect setup) #js [(deps-token ref deps)]))
    js/undefined))
 
 (defn use-layout-effect
   "react/use-layout-effect lowering target — `useLayoutEffect` (after DOM
   mutation, before paint): the measure-before-paint door. Same fixed hook shape
-  and `Object.is` deps contract as `use-effect`."
+  and `rf=` value-deps contract as `use-effect`."
   ([setup]
    (let [_ref (react/useRef nil)]
      (react/useLayoutEffect #(run-effect setup) #js [#js {}]))
    js/undefined)
   ([setup deps]
    (let [ref (react/useRef nil)]
-     (react/useLayoutEffect #(run-effect setup) #js [(effect-deps-token ref deps)]))
+     (react/useLayoutEffect #(run-effect setup) #js [(deps-token ref deps)]))
    js/undefined))
 
 (defn use-effect-event

--- a/implementation/ui/test/re_frame/ui/react_interop_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_interop_dom_cljs_test.cljs
@@ -4,8 +4,10 @@
 
     - use-ref: `.current` survives re-renders; a write never re-renders; the
       ref attaches to a `:ref` position;
-    - use-effect: passive, Object.is deps (a distinct value-equal host value IS
-      a change — the .95.12 correction), cleanup on dep change + unmount;
+    - use-effect: passive, `rf=` VALUE deps (a distinct-but-value-equal CLJS
+      deps value is NOT a change — rf2-u53yy.6 converged the interop tier onto
+      `rf=`, superseding the .95.12 Object.is split), cleanup on dep change +
+      unmount;
     - use-layout-effect: the readiness C-6 measure-before-paint NATIVE consumer
       (measure in the layout effect, pure geometry, apply, clean up exactly);
       StrictMode replay is idempotent-safe; unmount (reconnect) runs cleanup;
@@ -85,7 +87,7 @@
                    (fn [e] (rf/destroy-frame! f) (is false (str e)) (done))))))))
 
 ;; ---------------------------------------------------------------------------
-;; use-effect — Object.is deps, cleanup, and the rf=/Object.is distinction
+;; use-effect — rf= VALUE deps, cleanup (rf2-u53yy.6: one equality doctrine)
 ;; ---------------------------------------------------------------------------
 
 (defview effect-view []
@@ -98,7 +100,7 @@
                [dep])]
     [:span {:data-role "e"} (str dep "/" other)]))
 
-(deftest use-effect-object-is-deps-cleanup
+(deftest use-effect-value-deps-cleanup
   (if-not (browser?)
     (is true ":node — browser gate runs use-effect deps/cleanup")
     (async done
@@ -115,7 +117,7 @@
                   (.then host-turn!)
                   (.then (fn []
                            (is (= 1 (count (filter #(= (first %) :run) @log)))
-                               "an unchanged (Object.is) dep does NOT re-run")
+                               "an unchanged (rf=) dep does NOT re-run")
                            (uit/flush! #(uit/dispatch! f [::set-dep 1]))))
                   (.then host-turn!)
                   (.then (fn []
@@ -123,6 +125,55 @@
                            (is (some #(= % [:run 1]) @log) "then re-runs with the new dep")))))
             (.then (fn []
                      (is (some #(= % [:cleanup 1]) @log) "unmount runs cleanup")
+                     (rf/destroy-frame! f) (done))
+                   (fn [e] (rf/destroy-frame! f) (is false (str e)) (done))))))))
+
+;; The rf= convergence (rf2-u53yy.6): a deps SLOT holding a fresh-but-value-equal
+;; CLJS collection — rebuilt every render — keeps the SAME token, so an unrelated
+;; re-render does NOT rerun the effect. Under the superseded Object.is doctrine
+;; the distinct collection object WOULD have counted as a change and reran; under
+;; `rf=` (value equality) it is the same dep. A value-different collection reruns.
+(defview value-collection-effect-view []
+  (let [n     (ui/sub [::vn])
+        other (ui/sub [::vother])
+        ;; the dep slot is a FRESH map literal every render — object-distinct,
+        ;; but `rf=`-equal whenever n is unchanged.
+        _     (react/use-effect
+               (fn []
+                 (swap! log conj [:vrun n])
+                 (fn [] (swap! log conj [:vcleanup n])))
+               [{:k n}])]
+    [:span {:data-role "v"} (str n "/" other)]))
+
+(deftest use-effect-rf=-equal-collection-dep-skips-rerun
+  (if-not (browser?)
+    (is true ":node — browser gate runs the rf= value-deps convergence")
+    (async done
+      (rf/reg-sub ::vn (fn [db _] (:vn db)))
+      (rf/reg-sub ::vother (fn [db _] (:vother db)))
+      (rf/reg-event ::set-vn (fn [{:keys [db]} [_ v]] {:db (assoc db :vn v)}))
+      (rf/reg-event ::set-vother (fn [{:keys [db]} [_ v]] {:db (assoc db :vother v)}))
+      (reset-log!)
+      (let [f (make-frame ::veff {:vn 0 :vother 0})]
+        (-> (uit/with-root [root [ui/frame-provider {:frame f} [value-collection-effect-view]]]
+              (-> (host-turn!)
+                  (.then (fn [] (is (some #(= % [:vrun 0]) @log) "runs after mount")
+                           ;; unrelated re-render: rebuilds the {:k 0} dep slot to a
+                           ;; DISTINCT-but-rf=-equal object.
+                           (uit/flush! #(uit/dispatch! f [::set-vother 9]))))
+                  (.then host-turn!)
+                  (.then (fn []
+                           (is (= 1 (count (filter #(= (first %) :vrun) @log)))
+                               "a fresh-but-rf=-equal collection dep does NOT rerun (rf=, not Object.is)")
+                           ;; a value-different collection dep DOES rerun.
+                           (uit/flush! #(uit/dispatch! f [::set-vn 1]))))
+                  (.then host-turn!)
+                  (.then (fn []
+                           (is (some #(= % [:vcleanup 0]) @log)
+                               "a value-changed collection dep cleans up the prior run")
+                           (is (some #(= % [:vrun 1]) @log)
+                               "then reruns with the new value")))))
+            (.then (fn []
                      (rf/destroy-frame! f) (done))
                    (fn [e] (rf/destroy-frame! f) (is false (str e)) (done))))))))
 

--- a/skills/re-frame2-ui-context/SKILL.md
+++ b/skills/re-frame2-ui-context/SKILL.md
@@ -366,7 +366,7 @@ not edit it by hand.
 - **`:rf.ui.compile/raw-text-children`**
   - <> is an HTML raw-text element and takes a SINGLE text child, but children were given — React joins them into an array that warns and loses the body. Construct ONE string, e.g. (str a b …), or use (ui/html s) for trusted markup.
   - <> is an HTML raw-text element and takes a SINGLE text child, not structural markup — React drops or stringifies an element child here. Construct ONE string, e.g. (str …), or use (ui/html s) for trusted markup.
-- **`:rf.ui.compile/react-hook-bad-deps`** — (react/ setup deps): deps must be a literal vector (compared per slot by Object.is)
+- **`:rf.ui.compile/react-hook-bad-deps`** — (react/ setup deps): deps must be a literal vector (compared by rf= value equality)
 - **`:rf.ui.compile/react-hook-misplaced`** — (react/ …) is a host hook — legal ONLY where it evaluates unconditionally, once per render: the straight-line top region of a defview body (an outer let binding). It cannot run in a loop, branch, deferred callback, render-fn slot, or root expression — React's hook order must be static. Hoist it to the top of the view body, or extract a keyed child view
 - **`:rf.ui.compile/react-lazy-misplaced`** — (react/lazy …) is DEF-LEVEL only — bind it at the top level: (def HeavyChart (react/lazy load-thunk {:fallback tpl})), then use the component as a foreign head [HeavyChart {…}]. Calling it inside a view body mints a new component type per render and remount-loops
 - **`:rf.ui.compile/rejected-prop-spelling`** — is not a prop — one spelling per name, ambiguities removed. Use

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -997,11 +997,15 @@ below; `lazy` is a def-level constructor, exempt from the position law but subje
 own.
 
 **The deps law.** Everywhere this tier takes a deps vector, deps are a CLJS vector
-compared `rf=` per slot against the previous render's vector (arity change ⇒ re-run) —
-the one equality doctrine already shared by `effect` and memo, never a second per-tier
-regime. `rf=` is a strict refinement of React's `Object.is`-only deps comparison: every
-pair `Object.is` calls equal, `rf=` calls equal, so a wrapper never re-runs *more* often
-than React would, and the extra equalities are value-equal immutable CLJS data where a
+compared by `rf=` (VALUE equality) against the previous render's vector (arity change ⇒
+re-run) — the one equality doctrine already shared by `effect` and memo, never a second
+per-tier regime. The semantics are **value semantics, stated plainly**: a
+distinct-but-`rf=`-equal deps value no longer re-runs the effect — a rebuilt-but-equal
+CLJS collection is the same dep — while a value-different one re-runs; host/foreign values
+(plain JS objects, functions, React elements) fall through to identity. This is a strict
+refinement of React's native identity-based deps rule: every dep pair React would call
+equal, `rf=` also calls equal, so a wrapper never re-runs *more* often than a native
+`useEffect` would, and the extra equalities are value-equal immutable CLJS data where a
 skipped re-run is unobservable. Because the comparison is kernel-internal (a held
 previous-deps slot, not React's native deps array), deps arity may vary between renders
 without touching React's hook order — the property the position law relies on.


### PR DESCRIPTION
## Summary

Ratified UIx-review child **rf2-u53yy.6** — *one effect-dependency equality doctrine*. Converges re-frame.ui's effect-dependency equality onto **one doctrine: `rf=` (value equality) everywhere**, native and interop.

The native `ui/effect` already compared deps by `rf=`; the `re-frame.ui.react` interop wrappers (`use-effect` / `use-layout-effect`) compared per authored slot by `Object.is` — two equality doctrines one keystroke apart, plus a spec/implementation drift. Ruled (Mike, 2026-07-20): converge on `rf=` everywhere; distinct-but-equal values no longer rerun effects — value semantics, stated plainly.

## The change

- **`implementation/ui/src/re_frame/ui/hooks.cljc`** — delete the `Object.is` path (`deps-object-is-equal?`, `effect-deps-token`) and route `effect-value` (native) + `use-effect` + `use-layout-effect` (interop) through **one shared `rf=`-gated `deps-token` helper**. A distinct-but-`rf=`-equal CLJS deps value keeps the same token (no rerun) in either tier; a value-different one reruns; host/foreign values fall through to identity. `effect-value`'s behaviour is byte-identical (it already used `eq/rf=`).
- **`react_interop_dom_cljs_test.cljs`** — red→green: a deps slot holding a fresh-but-value-equal CLJS collection (`[{:k n}]`, rebuilt each render) now skips the rerun on an unrelated re-render (RED under `Object.is` — distinct object → rerun; GREEN under `rf=` — value-equal → same dep), and a value-different collection reruns. Existing suite's doctrine labels updated.
- **`spec/004-Views.md`** — the react-tier deps law states `rf=` value semantics plainly, no `Object.is` residue.
- **`docs/api/re-frame.ui.react.md`**, **`docs/core/how-to/measure-before-paint.md`** — the wrapper deps contract is `rf=`, not per-slot `Object.is`.
- **`docs/EP/EP-0032`** — dated Resolved-Decisions entry recording the superseded `.95.12` `Object.is` interop behaviour and the `rf=` convergence (EP-0009 dated-addendum convention).
- **`analyze.cljc`** + regenerated **`skills/re-frame2-ui-context/SKILL.md`** — the `react-hook-bad-deps` didactic message ("compared per slot by Object.is" → "compared by rf= value equality"), so the compiler, spec, docs, and runtime all state one doctrine. Folded in only after confirming u53yy.3 (which held `analyze.cljc`) merged to main and no open PR touches the file; the JVM reject test asserts the diagnostic ID (unchanged), not the message text.

## Quality gates

- `implementation/ui $ clojure -M:test` — **1006 tests, 19869 assertions, 0 failures, 0 errors**
- `implementation $ npm run test:cljs` — **10332 tests, 51040 assertions, 0 failures, 0 errors**
- `mkdocs build --strict` — clean (exit 0)
- `python scripts/check_doc_slugs.py` — clean (exit 0)
- `ui-context --check` — in sync (69 ids) after regenerating the sheet
- `test:elision` — not run: the change touches no `goog.DEBUG`-gated hook path (those are `local-state`'s render guard / cause bridge, untouched)

Sole `spec/004-Views.md` toucher this wave (u53yy.5/.7 queue behind); disjoint from live workers s5wby (http/spec-009), ao46i (observation/reactive/Xray). Does not merge.
