### PR TITLE
feat(ui): admit ui/spread at foreign-component call sites (rf2-u53yy.5)

### DIFF
--- a/docs/api/re-frame.ui.md
+++ b/docs/api/re-frame.ui.md
@@ -178,10 +178,26 @@ from ordinary Clojure code fails loud** (they are not runtime helpers).
 ### `spread`
 
 - **Kind**: function (template interop form)
-- **Signature**: `(spread base overrides)`
-- **Description**: Runtime prop-map merge through the **same conversion rule table**
-  as the compiler. Legal in a DOM element's props position only:
-  `[:div (ui/spread base attrs)]`. Direct call → `:rf.error/ui-spread-outside-template`.
+- **Signature**: `(spread base overrides)` (DOM element) · `(spread literal-part
+  runtime-map)` or `(spread runtime-map)` (foreign component)
+- **Description**: The one runtime prop-map form. Its behaviour depends on the head:
+  - **DOM / custom element** — `(ui/spread base overrides)`, e.g.
+    `[:div (ui/spread base attrs)]`: two runtime maps merged through the **same
+    conversion rule table** as the compiler (later-arg-wins).
+  - **Foreign component** — `[DatePicker (ui/spread {…} forwarded)]`: the standard
+    wrapper idiom (accept a map, forward it onto a foreign component). The optional
+    **literal part** is analysed exactly like a literal call-site props map (its
+    `ui/event`/`ui/handler`/`ui/render-fn` compile to committed callbacks, prop
+    checks run, `:key`/`:ref` extract); the **runtime map** is an opaque
+    foreign-boundary map that passes through **unconverted** (verbatim author-key
+    names — a foreign head owns its own prop ABI) and marks the site `:dynamic`.
+    The compiled literal props **win** any collision (the forwarded map is layered
+    under them, mirroring `spread-safe`'s owned-wins, minus the deny law). An
+    **internal view** rejects `ui/spread` — `:rf.ui.compile/spread-internal-view`,
+    it requires a literal props map (its per-slot memo comparator and slot ABI need
+    the literal keys).
+- **Errors**: direct call → `:rf.error/ui-spread-outside-template`; `ui/spread` at
+  an internal-view call site → `:rf.ui.compile/spread-internal-view`.
 
 ### `spread-safe`
 

--- a/docs/core/re-frame.ui/interop-and-limits.md
+++ b/docs/core/re-frame.ui/interop-and-limits.md
@@ -71,12 +71,14 @@ Real apps embed React that someone else wrote. The doors are explicit and narrow
   [handler decision table](events-and-handlers.md#the-decision-table); a bare fn on
   a foreign callback prop is a compile error precisely because the compiler can't
   know the invoker's phase.
-- **`ui/spread`** merges a runtime prop map through the same conversion rule table
-  as the compiler — the one dynamic-map path, its cost visible at the call site.
-  `ui/spread-safe` is its component-library sibling: it forwards a consumer's attr
-  map onto an internal element while barring the structural/controlled keys
-  (`:key` `:ref` `:value` `:checked` and owned handlers) in every build, so a
-  library input keeps its controlled guarantee.
+- **`ui/spread`** is the one runtime prop-map form. On a **DOM/custom element**
+  (`[:div (ui/spread base attrs)]`) it merges two runtime maps through the same
+  conversion rule table as the compiler. On a **foreign component** it is the
+  wrapper idiom — accept a map, forward it — shown below. `ui/spread-safe` is its
+  component-library sibling: it forwards a consumer's attr map onto an internal
+  element while barring the structural/controlled keys (`:key` `:ref` `:value`
+  `:checked` and owned handlers) in every build, so a library input keeps its
+  controlled guarantee.
 - **`ui/html`** is the one escaping bypass — visible at the call site, you vouch
   for the string.
 - **React hooks at a genuine foreign boundary** come from `re-frame.ui.react`
@@ -84,6 +86,34 @@ Real apps embed React that someone else wrote. The doors are explicit and narrow
   tier. Inside ordinary views you never reach for them: `sub`, `local`, and
   `effect` are the component story. See the
   [`re-frame.ui.react` reference](../../api/re-frame.ui.react.md).
+
+### Forwarding props onto a foreign component: `ui/spread`
+
+A component call site normally takes a **literal props map** — an internal view
+needs the literal keys for its per-slot memo comparator, so a wholly-dynamic props
+expression there is a compile error. A **foreign** component has no such
+invariant: its props are open and pass through untouched. So the standard wrapper
+idiom — take a props map, add your own, forward the rest onto the widget — is
+admitted at a foreign head through `ui/spread`:
+
+```clojure
+(defview date-field [{:keys [date on-pick] :as props}]
+  ;; owned :selected/:on-change are compiled here; the rest of `props`
+  ;; is forwarded onto the foreign DatePicker, unconverted
+  [DatePicker (ui/spread {:selected date
+                          :on-change (ui/handler [v] (on-pick v))}
+                         (dissoc props :date :on-pick))])
+```
+
+The **literal part** (`{:selected … :on-change …}`) is analysed exactly like a
+literal call-site map — the `ui/handler` compiles to a committed, per-site-stable
+callback. The **forwarded map** is opaque: it passes through verbatim (a foreign
+head owns its own prop ABI) and marks the site dynamic. The compiled literal props
+**win** any key collision, so the forwarded map can never clobber your committed
+callback. `(ui/spread forwarded)` with no literal part forwards a map alone.
+`ui/spread` at an *internal view* stays a compile error
+(`:rf.ui.compile/spread-internal-view`) — use `ui/spread-safe` when a component
+library needs to forward a consumer's attrs onto an internal element.
 
 ### Exporting a view outward: `ui/->react`
 
@@ -178,7 +208,8 @@ island behind a thin `ui/raw` boundary, not a `defview` full of runtime structur
 | Need | Door | Notes |
 |---|---|---|
 | A React element a foreign lib already built | `ui/raw` | Boundary, not a template feature |
-| Dynamic prop maps | `ui/spread` / `ui/spread-safe` | Runtime conversion on the compiler's own rule table |
+| A runtime prop map on a DOM element | `ui/spread` / `ui/spread-safe` | Runtime conversion on the compiler's own rule table |
+| Forwarding props onto a foreign component | `ui/spread` | Literal part compiled, forwarded map opaque (internal views stay literal) |
 | Unescaped HTML you vouch for | `ui/html` | Explicit at the call site |
 | Host-only leaf under SSR | `ui/client-only` | Fallback is plain markup — [SSR](ssr.md) |
 | Parameterised markup for a library | `ui/render-fn` + `ui/slot` | Pure; compiled; no runtime hiccup |

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/ui_context.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/ui_context.clj
@@ -461,10 +461,15 @@ committed frame.
   `:rf.ui.compile/bare-fn-ref`. An internal **view forwards `:ref` only by
   declaring it** in its header (React 19 ref-as-prop) — passing `:ref` to a view
   carries it on the props object, and the callee reads it via the declared slot.
-- **Spreading props:** `(ui/spread base overrides)` is the one generic runtime
-  prop-map merge, legal only in a **DOM/custom element's** props position (not
-  an internal-view call). `(ui/spread-safe owned caller)` is the literal
-  safe-forward for a component library (structural/controlled keys `:key`
+- **Spreading props:** `(ui/spread base overrides)` in a **DOM/custom element's**
+  props position is the one generic runtime prop-map merge (rule-table
+  conversion, later-arg-wins). At a **foreign component** call site
+  `(ui/spread literal-part runtime-map)` is the wrapper idiom — the literal part
+  is analysed normally (compiled handlers/props), the forwarded runtime map is
+  opaque and passes through unconverted, and the literal props win a collision;
+  an **internal view** still requires a literal props map
+  (`:rf.ui.compile/spread-internal-view`). `(ui/spread-safe owned caller)` is the
+  literal safe-forward for a component library (structural/controlled keys `:key`
   `:ref` `:value` `:checked` and owned `:on-*` are denied in the caller map).
 - **Trusted markup:** `(ui/html s)` as the **sole child** of a DOM element.
 - **Custom elements:** declare with `(ui/custom-element :my-el {:properties #{…}})`

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -2134,23 +2134,93 @@
               :classification kind
               :literal? false}))))
 
-(defn- analyze-component-props
-  "View/foreign call-site props (Q2/Q3/Q4): literal map required; :key
-  extracted (never a prop); :children as an explicit key rejected
-  (children are positional). Bare fn values: rejected at a FOREIGN boundary
-  (the narrow bare-fn law — invoker/phase unknown), but LEGAL as an opaque
-  identity-compared value at an INTERNAL-view boundary (C-13a) — the framework
-  never invokes it and promises no phase; ui/handler/ui/render-fn opt a phase
-  in. `ui/event`/`ui/handler` are the explicit committed callbacks at either."
+(defn- analyze-foreign-spread
+  "Parse `(ui/spread …)` in a FOREIGN component's props position (rf2-u53yy.5):
+  an OPTIONAL leading LITERAL map — the component's own props, analysed exactly
+  like a literal call-site props map (compiled `ui/handler`/`ui/event`/
+  `ui/render-fn`, prop-key checks, `:key`/`:ref` extraction) — plus an opaque
+  forwarded runtime map. The forwarded map is the visible foreign-boundary
+  opt-in: a foreign head's props are open and pass through UNCONVERTED (there is
+  no per-slot memo comparator or slot ABI to defend, so nothing is converted),
+  and the compiled LITERAL props WIN any key collision — mirroring
+  `ui/spread-safe`'s owned-wins layering, minus the deny law. The forwarded map
+  marks the site `:dynamic` in the manifest exactly as a dynamic handler
+  expression does. -> `[literal-map spread-node|nil]`.
+
+  Shapes: `(ui/spread runtime-map)` — the plain forwarded map, no literal part;
+  `(ui/spread literal-map runtime-map)` — literal part plus the forwarded map. A
+  leading literal map is the literal part; a leading non-map expression is the
+  forwarded map."
   [e head-info props-form]
-  (when (and (some? props-form) (not (map? props-form)))
+  (let [args (rest props-form)
+        n    (count args)]
+    (when-not (<= 1 n 2)
+      (env/fail! e :rf.ui.compile/bad-spread
+                 (str "(ui/spread runtime-map) or (ui/spread literal-part "
+                      "runtime-map) at the foreign component " (:sym head-info))
+                 {:form props-form}))
+    (let [[a b]   args
+          literal (if (map? a)
+                    a
+                    (when (= n 2)
+                      (env/fail! e :rf.ui.compile/bad-spread
+                                 (str "(ui/spread literal-part runtime-map) — the "
+                                      "first argument must be a LITERAL props map "
+                                      "(analysed for the component's compiled "
+                                      "handlers and props); the second is the "
+                                      "opaque forwarded runtime map")
+                                 {:form props-form})))
+          runtime (cond
+                    (= n 2)  b
+                    (map? a) nil
+                    :else    a)]
+      [(or literal {})
+       (when (some? runtime)
+         (let [identity (event-site-identity e :spread props-form)]
+           (add-event-site! e identity
+                            {:prop :spread :handler :opaque
+                             :classification :spread :serializable? false
+                             :sync? false})
+           (merge identity {:base (walk-expr e [:spread :base] runtime)})))])))
+
+(defn- analyze-component-props
+  "View/foreign call-site props (Q2/Q3/Q4): a literal map — or, at a FOREIGN
+  head only, `(ui/spread …)` (rf2-u53yy.5, the foreign wrapper idiom). :key
+  extracted (never a prop); :children as an explicit key rejected (children are
+  positional). Bare fn values: rejected at a FOREIGN boundary (the narrow
+  bare-fn law — invoker/phase unknown), but LEGAL as an opaque identity-compared
+  value at an INTERNAL-view boundary (C-13a) — the framework never invokes it
+  and promises no phase; ui/handler/ui/render-fn opt a phase in. `ui/event`/
+  `ui/handler` are the explicit committed callbacks at either. `ui/spread` at an
+  INTERNAL view is rejected — an internal view requires a literal props map (its
+  generated per-slot memo comparator and slot ABI need the literal keys)."
+  [e head-info props-form]
+  (let [spread? (spread-form? e props-form)
+        view?   (= :view (:kind head-info))]
+   (cond
+    (and spread? view?)
+    (env/fail! e :rf.ui.compile/spread-internal-view
+               (str "(ui/spread …) at the internal view " (:view-id head-info)
+                    " — an internal view requires a LITERAL props map: its "
+                    "generated per-slot memo comparator and slot ABI need the "
+                    "literal keys. ui/spread is admitted at a FOREIGN component "
+                    "call site (its props are open and pass through unconverted) "
+                    "and in a DOM/custom element's props position")
+               {:head (:sym head-info)})
+
+    (and (some? props-form) (not (map? props-form)) (not spread?))
     (env/fail! e :rf.ui.compile/dynamic-props-map
                (str "component call sites take a LITERAL props map — a wholly-"
                     "dynamic props expression is not v1 grammar (conservative "
-                    "S1 pin; ui/spread converts dynamic maps for DOM elements "
-                    "only)")
-               {:head (:sym head-info) :form props-form}))
-  (let [m (or props-form {})]
+                    "S1 pin). At a FOREIGN component forward a runtime map with "
+                    "(ui/spread literal-part runtime-map); a DOM/custom element "
+                    "also takes (ui/spread base overrides)")
+               {:head (:sym head-info) :form props-form})
+
+    :else
+    (let [[m spread-node] (if spread?
+                            (analyze-foreign-spread e head-info props-form)
+                            [(or props-form {}) nil])]
     (doseq [k (keys m)]
       (when-not (keyword? k)
         (env/fail! e :rf.ui.compile/non-keyword-prop
@@ -2235,16 +2305,20 @@
       (let [key-form* (if (and (contains? m :key) (not (literal-scalar? key-form)))
                         (walk-expr e [:component-key] key-form)
                         key-form)]
-      {:key {:present? (contains? m :key) :expr key-form*
-             :literal? (literal-scalar? key-form)}
-       :entries entries
-       :ref ref-a}))))
+      (cond-> {:key {:present? (contains? m :key) :expr key-form*
+                     :literal? (literal-scalar? key-form)}
+               :entries entries
+               :ref ref-a}
+        spread-node (assoc :spread spread-node))))))))
 
 (defn- analyze-component [e form]
   (let [head      (nth form 0)
         info      (env/classify-head e head)
         second*   (nth form 1 nil)
-        has-props (map? second*)
+        ;; a `(ui/spread …)` second form is PROPS at a component head, not a
+        ;; child — admitted at a FOREIGN head (rf2-u53yy.5), rejected at an
+        ;; internal view by analyze-component-props (literal props required).
+        has-props (or (map? second*) (spread-form? e second*))
         props     (analyze-component-props e info (when has-props second*))
         child-fs  (vec (if has-props (drop 2 form) (drop 1 form)))
         ;; a view/foreign boundary ENDS the static top region (S1c):

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -583,9 +583,36 @@
                     `(if ~(with-meta 'js/goog.DEBUG {:tag 'boolean})
                        (re-frame.ui.runtime/warn-bare-view-alias! ~head-sym)
                        ~head-sym)
-                    head-sym)]
+                    head-sym)
+        spread    (get-in node [:props :spread])]
     (when self? (swap! st assoc :self-ref? true))
-    (jsx-runtime-call multi? head-form props-form key-info)))
+    (if spread
+      ;; ui/spread at a FOREIGN component call site (rf2-u53yy.5): the LITERAL
+      ;; part's compiled props are built as a literal object; the forwarded
+      ;; runtime map is layered UNDER them (literal wins) by
+      ;; `foreign-spread-props`, which passes the forwarded keys through
+      ;; UNCONVERTED (a foreign boundary owns its own prop ABI). Children ride
+      ;; the same jsx-spread call.
+      ;;
+      ;; EVALUATION ORDER: the authored order is `(ui/spread literal runtime)`,
+      ;; so the literal object binds BEFORE the forwarded expression — the
+      ;; single-evaluation `let` temporaries mirror the element spread branch
+      ;; and fold away under :advanced.
+      (let [literal-obj (ordered-literal-object
+                         (concat (map #(component-prop-pair % st) entries)
+                                 (when ref-a [["ref" (:form ref-a)]])))
+            lit-sym     (gensym "rf-ui-lit")
+            fwd-sym     (gensym "rf-ui-fwd")
+            props-obj   `(let [~lit-sym ~literal-obj
+                               ~fwd-sym ~(:base spread)]
+                           (re-frame.ui.runtime/foreign-spread-props ~fwd-sym ~lit-sym))]
+        (if (:present? key-info)
+          `(re-frame.ui.runtime/jsx-spread3 ~head-form ~props-obj
+                                            ~(:expr key-info)
+                                            (cljs.core/array ~@chs))
+          `(re-frame.ui.runtime/jsx-spread2 ~head-form ~props-obj
+                                            (cljs.core/array ~@chs))))
+      (jsx-runtime-call multi? head-form props-form key-info))))
 
 (defn- row-key-expr [body]
   (or (get-in body [:props :key :expr]) (get-in body [:key :expr])))

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -535,6 +535,37 @@
         (unchecked-set caller-obj "className" (str owned-class " " caller-class))))
     caller-obj))
 
+;; ---------------------------------------------------------------------------
+;; ui/spread at a FOREIGN component call site (rf2-u53yy.5)
+;; ---------------------------------------------------------------------------
+
+(defn foreign-spread-props
+  "Merge a FOREIGN component spread's forwarded runtime map (`fwd`) UNDER its
+  LITERAL compiled props object (`literal-obj`). The literal props — the
+  component's own compiled handlers and props — WIN every key collision; the
+  forwarded map fills in the rest. A foreign boundary is OPEN: its props pass
+  through UNCONVERTED (no DOM rule table, no kebab→camel, no handler
+  classification — the foreign head owns its own prop ABI), so each forwarded
+  key is the author keyword's verbatim name (`namespace/name`, matching the
+  compiler's `prop-slot-name`) and its value is set as-is.
+
+  Mirrors `spread-safe-props`' owned-wins layering, minus the deny law — a
+  foreign boundary defends no owned/structural key (there is no per-slot memo
+  comparator or slot ABI to protect). NIL-MEANS-ABSENT: a compiled literal prop
+  whose dynamic value normalizes to nil sits in `literal-obj` as an explicit
+  null; layer key-by-key skipping nil so a nil literal stays ABSENT and the
+  forwarded value survives. Returns the merged JS object."
+  [fwd literal-obj]
+  (let [o (js-obj)]
+    (when (some? fwd)
+      (doseq [[k v] fwd]
+        (unchecked-set o (if-some [ns* (namespace k)] (str ns* "/" (name k)) (name k)) v)))
+    (doseq [k (js/Object.keys literal-obj)]
+      (let [v (unchecked-get literal-obj k)]
+        (when (some? v)
+          (unchecked-set o k v))))
+    o))
+
 (defn jsx-spread2
   "jsx over a runtime-built (spread) props object, children attached."
   [t props-obj children-arr]

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -337,6 +337,55 @@
                                         :on-select (event [e] [:pick (:id row)])}]))))))
 
 ;; ---------------------------------------------------------------------------
+;; ui/spread at a FOREIGN component call site (rf2-u53yy.5)
+;; ---------------------------------------------------------------------------
+
+(deftest foreign-spread-admits-literal-part-plus-opaque-forwarded-map
+  (testing "the literal part is analysed normally (compiled handler + props); "
+           "the forwarded runtime map is opaque and marks the site dynamic"
+    (let [{:keys [ast sites]}
+          (ana-full '[ForeignComp
+                      (spread {:selected date
+                               :on-change (handler [v] (pick! v))}
+                              forwarded-props)])
+          en (first (get-in ast [:props :entries]))]
+      (is (= :foreign (:op ast)) "a foreign head with spread is a foreign component")
+      (is (= 'forwarded-props (get-in ast [:props :spread :base]))
+          "the forwarded runtime map is carried opaque as the spread base")
+      (is (some #(= :on-change (:k %)) (get-in ast [:props :entries]))
+          "the literal part's keys are analysed as ordinary call-site props")
+      (is (= :handler (:marker (some #(when (= :on-change (:k %)) %)
+                                     (get-in ast [:props :entries]))))
+          "a ui/handler in the literal part compiles to a committed callback")
+      (is (some #(= :spread (:classification %)) (:events sites))
+          (str "the forwarded map records ONE opaque :spread event site — "
+               "the manifest marks the call site :dynamic"))))
+  (testing "the plain forwarded-map form has no literal part"
+    (let [ast (ana* '[ForeignComp (spread forwarded-props)])]
+      (is (= :foreign (:op ast)))
+      (is (= 'forwarded-props (get-in ast [:props :spread :base])))
+      (is (empty? (get-in ast [:props :entries])) "no literal part → no entries")))
+  (testing "a lone literal map spelled through spread has NO forwarded part"
+    (let [ast (ana* '[ForeignComp (spread {:a 1})])]
+      (is (= :foreign (:op ast)))
+      (is (nil? (get-in ast [:props :spread]))
+          "a literal-only spread carries no opaque forwarded map")
+      (is (= [:a] (mapv :k (get-in ast [:props :entries])))
+          "its keys are ordinary literal call-site props")))
+  (testing "children ride the same foreign spread call site"
+    (let [ast (ana* '[ForeignComp (spread {:a 1} m) [:p "kid"]])]
+      (is (= :foreign (:op ast)))
+      (is (= 1 (count (:children ast))) "positional children still analyse")))
+  (testing "an internal view rejects spread (literal props required)"
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+                 (ana* '[child-view (spread {:a 1} m)])))
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+                 (ana* '[leaf-view (spread m)]))))
+  (testing "a bare fn in a foreign spread's literal part is still rejected"
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+                 (ana* '[ForeignComp (spread {:on-select (fn [x] x)} m)])))))
+
+;; ---------------------------------------------------------------------------
 ;; ui/error-boundary + ui/client-only (rf2-vxgfnd.95.3)
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -714,7 +714,21 @@
   ;; literal-props pin): a childless view therefore rejects it outright
   (is (= :rf.ui.compile/children-not-accepted
          (reject-id '[leaf-view props-expr]))
-      "no dynamic-props back door — a non-map is a child, and leaf views take none"))
+      "no dynamic-props back door — a non-map is a child, and leaf views take none")
+  ;; rf2-u53yy.5 — ui/spread IS admitted at a FOREIGN component call site, but an
+  ;; internal view keeps the literal-props requirement (its per-slot memo
+  ;; comparator and slot ABI need the literal keys).
+  (is (nil? (reject-id '[ForeignComp (spread {:selected d :on-change (handler [v] (pick v))}
+                                             forwarded)]))
+      "a foreign head accepts (ui/spread literal-part runtime-map)")
+  (is (nil? (reject-id '[ForeignComp (spread forwarded)]))
+      "a foreign head accepts a plain forwarded map spelled through spread")
+  (is (= :rf.ui.compile/spread-internal-view
+         (reject-id '[child-view (spread {:a 1} forwarded)]))
+      "an internal view rejects ui/spread — literal props required")
+  (is (= :rf.ui.compile/spread-internal-view
+         (reject-id '[leaf-view (spread forwarded)]))
+      "the internal-view spread rejection covers the plain forwarded form too"))
 
 (deftest interop-positions
   (is (= :rf.ui.compile/html-not-sole-child

--- a/implementation/ui/test/re_frame/ui/emit_cljs_lowering_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/emit_cljs_lowering_cljs_test.cljc
@@ -299,6 +299,37 @@
                                        [v/card {:x 1}]]))))))
 
 ;; ---------------------------------------------------------------------------
+;; ui/spread at a FOREIGN component call site (rf2-u53yy.5)
+;; ---------------------------------------------------------------------------
+
+(deftest foreign-spread-merges-the-forwarded-map-under-the-literal-props
+  (let [form  (emitted '[ForeignComp
+                         (ui/spread {:selected d :on-change (event [v] [:pick v])}
+                                    forwarded)])
+        props (nth form 2)]
+    (is (= 're-frame.ui.runtime/jsx-spread2 (first form))
+        "a foreign spread routes through the runtime-built-props jsx helper")
+    (is (= '(re-frame.ui.runtime/warn-bare-view-alias! ForeignComp)
+           (nth (nth form 1) 2))
+        "the foreign head keeps its dev-gated bare-view-alias guard")
+    (is (= "let" (name (first props)))
+        "the merged props object binds single-evaluation temporaries")
+    (is (some #{'re-frame.ui.runtime/foreign-spread-props} (forms-of props))
+        "the literal props are layered over the forwarded map by foreign-spread-props")
+    (is (some #{'re-frame.ui.events/event-handler} (forms-of props))
+        "the literal part's ui/event compiles to a committed callback")
+    (is (= 1 (count (filter #{'forwarded} (forms-of form))))
+        "the forwarded runtime map evaluates exactly once")
+    (is (= '(cljs.core/array) (last form))
+        "no positional children on this call site")))
+
+(deftest foreign-spread-with-a-key-selects-the-three-arg-jsx-helper
+  (let [form (emitted '[ForeignComp (ui/spread {:key k :a 1} m)])]
+    (is (= 're-frame.ui.runtime/jsx-spread3 (first form))
+        "a literal :key in the spread's literal part selects the 3-arg spread jsx")
+    (is (= 'k (nth form 3)) "the key expression rides the jsx key argument")))
+
+;; ---------------------------------------------------------------------------
 ;; ui/spread + ui/html compose (rf2-29s75)
 ;;
 ;; The general-spread branch builds its props object at RUNTIME and never goes

--- a/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
@@ -85,6 +85,9 @@
     :rf.ui.compile/bare-fn-ref
     :rf.ui.compile/dynamic-props-map
     :rf.ui.compile/bad-spread
+    ;; ui/spread admitted at a FOREIGN component call site; rejected at an
+    ;; internal view (literal props required) (rf2-u53yy.5)
+    :rf.ui.compile/spread-internal-view
     ;; literal safe-spread policy (S3, rf2-isdqjv)
     :rf.ui.compile/bad-spread-safe
     :rf.ui.compile/spread-safe-owned-key
@@ -460,6 +463,12 @@
    [:rf.ui.compile/bare-fn-ref '[:div {:ref (fn [el] el)} "x"] ["(ui/raw-fn f)"]]
    [:rf.ui.compile/bad-spread '[:div (spread)] ["(ui/spread base"]]
    [:rf.ui.compile/bad-spread '(spread base) ["props position"]]
+   ;; ui/spread at an INTERNAL view call site — rejected (literal props
+   ;; required); admitted only at a FOREIGN head (rf2-u53yy.5)
+   [:rf.ui.compile/spread-internal-view
+    '[child-view (spread {:a 1} m)] ["LITERAL props map" "FOREIGN"]]
+   [:rf.ui.compile/spread-internal-view
+    '[child-view (spread m)] ["LITERAL props map" "FOREIGN"]]
    ;; literal safe-spread policy (S3, rf2-isdqjv): malformed form + owned-key deny
    [:rf.ui.compile/bad-spread-safe '[:div (spread-safe dynmap caller)] ["LITERAL"]]
    [:rf.ui.compile/bad-spread-safe '[:div (spread-safe {})] ["owned caller"]]

--- a/skills/re-frame2-ui-context/SKILL.md
+++ b/skills/re-frame2-ui-context/SKILL.md
@@ -162,10 +162,15 @@ committed frame.
   `:rf.ui.compile/bare-fn-ref`. An internal **view forwards `:ref` only by
   declaring it** in its header (React 19 ref-as-prop) — passing `:ref` to a view
   carries it on the props object, and the callee reads it via the declared slot.
-- **Spreading props:** `(ui/spread base overrides)` is the one generic runtime
-  prop-map merge, legal only in a **DOM/custom element's** props position (not
-  an internal-view call). `(ui/spread-safe owned caller)` is the literal
-  safe-forward for a component library (structural/controlled keys `:key`
+- **Spreading props:** `(ui/spread base overrides)` in a **DOM/custom element's**
+  props position is the one generic runtime prop-map merge (rule-table
+  conversion, later-arg-wins). At a **foreign component** call site
+  `(ui/spread literal-part runtime-map)` is the wrapper idiom — the literal part
+  is analysed normally (compiled handlers/props), the forwarded runtime map is
+  opaque and passes through unconverted, and the literal props win a collision;
+  an **internal view** still requires a literal props map
+  (`:rf.ui.compile/spread-internal-view`). `(ui/spread-safe owned caller)` is the
+  literal safe-forward for a component library (structural/controlled keys `:key`
   `:ref` `:value` `:checked` and owned `:on-*` are denied in the caller map).
 - **Trusted markup:** `(ui/html s)` as the **sole child** of a DOM element.
 - **Custom elements:** declare with `(ui/custom-element :my-el {:properties #{…}})`
@@ -304,6 +309,8 @@ not edit it by hand.
   - (ui/slot render-fn-value arg…) needs a render-fn value (or nil) as its first argument
 - **`:rf.ui.compile/bad-spread`**
   - (ui/spread base) or (ui/spread base overrides)
+  - (ui/spread runtime-map) or (ui/spread literal-part runtime-map) at the foreign component
+  - (ui/spread literal-part runtime-map) — the first argument must be a LITERAL props map (analysed for the component's compiled handlers and props); the second is the opaque forwarded runtime map
   - (ui/spread...) belongs in a DOM element's props position: [:div (ui/spread base overrides)]
 - **`:rf.ui.compile/bad-spread-safe`**
   - (ui/spread-safe owned caller) — `owned` must be a LITERAL props map (the component's own props; the compiler proves the controlled site and keeps the sync door) and `caller` the forwarded runtime attr map
@@ -330,7 +337,7 @@ not edit it by hand.
 - **`:rf.ui.compile/dynamic-head`** — dynamic element head — heads must be literal (a keyword or a component var). Runtime-chosen components are ui/view / ui/element [WAVE-2]; ui/raw covers a runtime React element meanwhile
 - **`:rf.ui.compile/dynamic-props-map`**
   - props of must be a literal map, (ui/spread base overrides), or (ui/spread-safe owned caller)
-  - component call sites take a LITERAL props map — a wholly-dynamic props expression is not v1 grammar (conservative S1 pin; ui/spread converts dynamic maps for DOM elements only)
+  - component call sites take a LITERAL props map — a wholly-dynamic props expression is not v1 grammar (conservative S1 pin). At a FOREIGN component forward a runtime map with (ui/spread literal-part runtime-map); a DOM/custom element also takes (ui/spread base overrides)
 - **`:rf.ui.compile/frame-in-loop`**
   - (frame) must be a finite render-time site in a defview — it cannot run in a loop, deferred callback, raw-fn/ref body, or root expression. Hoist the read into the view body and let the callback capture its committed ops bundle
   - (ui/dispatch-fn) must be a finite render-time site in a defview — it cannot run in a loop, deferred callback, raw-fn/ref body, or root expression. Capture it in the view body and use it from an (effect …) or foreign callback
@@ -374,6 +381,7 @@ not edit it by hand.
   - (ui/render-fn …) is a render-slot callback value — legal ONLY as a component call-site prop value or a ui/slot argument, never as a plain expression. The library invokes it through ui/slot
   - (ui/render-fn …) is a render-slot callback value, not renderable content — invoke it with (ui/slot render-fn arg…), or pass it as a component prop value
 - **`:rf.ui.compile/slot-arity`** — (ui/slot render-fn arg…) passes arguments to an inline (ui/render-fn …) that declares parameters — a render-fn is a FIXED-arity callback, so the slot must pass exactly its declared parameters (host-identically, before invocation). Pass the missing argument(s), or drop the unused parameter(s) / Drop the surplus argument(s), or declare the extra parameter(s)
+- **`:rf.ui.compile/spread-internal-view`** — (ui/spread …) at the internal view — an internal view requires a LITERAL props map: its generated per-slot memo comparator and slot ABI need the literal keys. ui/spread is admitted at a FOREIGN component call site (its props are open and pass through unconverted) and in a DOM/custom element's props position
 - **`:rf.ui.compile/spread-safe-owned-key`** — (ui/spread-safe owned caller) — the caller map may not carry the owned/structural key; it is denied in every build so it can never clobber an owned prop. Forward it through the visible-cost (ui/spread base overrides) instead, or drop it
 - **`:rf.ui.compile/sub-in-loop`** — (sub...) must be a finite render-time site in a defview — it cannot run in a loop, deferred callback, raw-fn/ref body, or root expression. Hoist the read into the view body and let the callback capture its committed value; for rows, extract a keyed child view
 - **`:rf.ui.compile/textarea-children`**

--- a/skills/reagent-migration/references/catalog-judgment.md
+++ b/skills/reagent-migration/references/catalog-judgment.md
@@ -213,7 +213,7 @@ Keep the caveat: views using refs/effects need `ui/client-only` (or restructure)
 
 - **A genuinely opaque runtime props map → `ui/spread`** (the visible-cost escape). `(ui/spread base overrides)` is the one *generic* runtime conversion for a map the compiler cannot see into. It **forfeits the static manifest row *and* the controlled-input synchrony door** (which needs a provably-literal `:value`/`:checked` on the element). Weigh it knowingly: shrink the spread to genuinely pass-through props and lift `:value`/handlers back to literals where you can — or, if the owned/forwarded split is clean, prefer `ui/spread-safe`.
 
-**Component call sites stay literal-map (MIG-01), never a spread.** See the **bare-symbol trap** ([`gotchas.md`](gotchas.md)) — a bare symbol *child* is content, never a spread.
+**Internal-view call sites stay literal-map (MIG-01), never a spread** — an internal view needs the literal keys for its per-slot memo comparator. A **foreign** component call site is the exception: it accepts `(ui/spread literal-part runtime-map)` (the wrapper idiom — the literal part compiles normally, the forwarded map passes through opaque, an internal view still rejects it with `:rf.ui.compile/spread-internal-view`). See the **bare-symbol trap** ([`gotchas.md`](gotchas.md)) — a bare symbol *child* is content, never a spread.
 
 ## MIG-22 — third-party Reagent wrapper components (re-com et al.)
 

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -161,7 +161,7 @@ and reactive-escape rejection as a hand-written `let` + `if`.
 |---|---|
 | `[:div.cls#id {…} …]` | DOM element; **literal head required** |
 | `[view-sym {…} & children]` | internal view (compile-resolved Var) |
-| `[ForeignComponent {…} …]` | foreign React component (open props; JS values pass through) |
+| `[ForeignComponent {…} …]` | foreign React component (open props; JS values pass through; also accepts `(ui/spread …)` — §Interop) |
 | `[:<> …]` | fragment |
 | `(for [x xs] [item {:key …}])` | keyed list → direct JS array; missing key = build failure |
 | `(ui/presence …)` | declarative enter/exit retention (§Presence) |
@@ -666,11 +666,11 @@ enter/exit retention is out of scope):
 | Surface | Contract |
 |---|---|
 | `(ui/raw react-element)` | embed an existing React element (child position; SSR paths need a `client-only` sibling fallback) |
-| `[ForeignComponent {…}]` | foreign React head; open props, JS values pass through; callbacks per §The decision table |
+| `[ForeignComponent {…}]` | foreign React head; open props, JS values pass through; callbacks per §The decision table. Also takes `(ui/spread literal-part runtime-map)` — the foreign-props position rule below |
 | `(ui/->react view)` | export a view as a React component — the outward migration bridge. **v1, lands S6** with the migration wave. Contract: the compat-boundary contract §3, whose rules stay in their committed homes (no `spec/004A` appendix lands) — memoised per view id (returns the stable shell), no new React root/manifest/preflight; the exported view scopes frames, never creates them |
 | `(ui/element type props & children)` | runtime-chosen element/component **[WAVE-2]** |
 | `(ui/view id)` | registry-addressed component; production use requires production registry entries (dev-only string ids cannot serve prod lookup) **[WAVE-2]** |
-| `(ui/spread base overrides)` | the one generic runtime prop-map conversion — **v1**; the conversion architecture's single dynamic-map path, driven by the owning rule table |
+| `(ui/spread base overrides)` | the one generic runtime prop-map conversion — **v1**; the conversion architecture's single dynamic-map path, driven by the owning rule table. In a **DOM/custom element**'s props position both maps are runtime, converted through the rule table, later-arg-wins. At a **FOREIGN component** call site it takes `(ui/spread literal-part runtime-map)` (the foreign-props position rule below) |
 | `(ui/spread-safe owned caller)` | the **literal safe-spread policy** (S3) — a component library forwards a consumer's runtime attr map onto an internal element without clobbering owned props or forfeiting the sync door. `owned` is a LITERAL props map (analysed as element props, so a controlled owned site keeps the door); the structural/controlled/identity keys `:key`/`:ref`/`:value`/`:checked` and the owned `:on-*` handlers are denied to `caller` in **every build** (§The safe-spread policy) |
 | `(ui/portal node child)` | React portal; frame context passes through **[WAVE-2]** |
 | `(ui/client-only {:fallback tpl} client-tpl)` | browser-only subtree; the fallback is mandatory and MUST be capability-free (compiler-checked); the JVM and first hydration render the fallback, then one root phase-flip swaps all sites in a single update (per [011 §Phase flip](011-SSR.md#phase-flip)) |
@@ -683,6 +683,49 @@ tools, or guide fixtures — guide examples authored by this project do not coun
 independent demand for platform-scale features). The seven wrappers of the foreign
 React-interop tier — `re-frame.ui.react` — carry their own call-shape contract in
 §The React interop tier below.
+
+### `ui/spread` at a foreign component call site
+
+A component call site takes a **literal props map** — the internal-view seam needs
+those literal keys for its generated per-slot memo comparator and slot ABI, so a
+wholly-dynamic props expression there is a compile error
+(`:rf.ui.compile/dynamic-props-map`). A **foreign** head has neither invariant:
+its props are *open* and pass through **unconverted** (the foreign component owns
+its own prop ABI), and there is no comparator or slot ABI to defend. The standard
+wrapper idiom — accept a map, forward it onto a foreign component — is therefore
+admitted there through the visible `ui/spread` opt-in:
+
+```clojure
+[DatePicker (ui/spread {:selected date :on-change (ui/handler [v] (pick! v))}
+                       forwarded-props)]
+```
+
+- **Two shapes.** `(ui/spread literal-part runtime-map)` is a **literal** props map
+  plus an opaque forwarded map; `(ui/spread runtime-map)` is the plain forwarded
+  map alone (no literal part). A leading literal map is the literal part; a leading
+  non-map expression is the forwarded map.
+- **The literal part is analysed normally** — handler classification
+  (`ui/event`/`ui/handler`/`ui/render-fn`), prop-key checks, the bare-fn law,
+  `:key`/`:ref` extraction, `:children`-as-a-prop rejection — exactly as a literal
+  call-site props map. So a committed callback still compiles to a per-site-stable
+  identity.
+- **The runtime part is an intentionally opaque foreign-boundary map.** It passes
+  through unconverted (keys are the author keyword's verbatim name; no rule table,
+  no kebab→camel, no handler classification) and marks the call site `:dynamic` in
+  the manifest, exactly as a dynamic handler expression does. Choosing `ui/spread`
+  is the visible cost.
+- **The literal props win any key collision.** The forwarded map is layered
+  *under* the compiled literal props — mirroring `ui/spread-safe`'s owned-wins
+  layering, minus the deny law (a foreign boundary defends no owned/structural
+  key). A compiled committed callback can never be silently clobbered by the
+  opaque forwarded map. (This differs from a DOM element's
+  `(ui/spread base overrides)`, whose two runtime maps merge later-arg-wins.)
+- **INTERNAL views keep the literal-props requirement.** `(ui/spread …)` at an
+  internal-view call site is `:rf.ui.compile/spread-internal-view` — no generic
+  internal-view prop spreading, and `ui/spread-safe` remains the DOM/component-
+  library forwarding policy. On the JVM a foreign component is a host-op boundary
+  (its props never enter the structural tree), so a foreign spread renders under
+  the same `ui/client-only` rule as any foreign head.
 
 ### Trusted markup — what `ui/html` does not do
 
@@ -1431,7 +1474,7 @@ a conflict is resolved in that order and is a defect in this table.
 | §Interop — `ui/error-boundary` | **S3** | phase semantics; `:reset-key`; server-policy contrast |
 | §Interop — `ui/client-only` | **S3** → completes **S5** | capability-free fallback check (S3); SSR phase flip (S5) |
 | §`ui/route-link` — framework-provided compiled view | **S3** | ordinary-defview compilation (no intrinsic branch); strategy-encoded href truth; handler-free path-form SSR shell; the routing-owned late-bound seam (`:routing/link-model` / `:routing/activate-link!`) + `:rf.error/routing-artefact-missing` when routing is absent; the click law (plain-left intercept + `:source :router` committed-frame dispatch; modifier / middle / native deferral; caller `:on-click`-first veto) is [012](012-Routing.md)'s |
-| §Interop — `ui/spread` | **S1** | with the conversion-table row above |
+| §Interop — `ui/spread` | **S1** | with the conversion-table row above; plus the foreign-props position rule (§`ui/spread` at a foreign component call site) — literal part analysed normally, opaque forwarded map layered under it, `:rf.ui.compile/spread-internal-view` at an internal view |
 | §The safe-spread policy — `ui/spread-safe` | **S3** | owned-key deny in dev AND advanced builds (G-17); `aria-*`/`data-*`/`title`/`:class`/`:style` passthrough per the 004B table; allowed `:on-*` classify through the handler table; the controlled split — policy retains the sync door, general spread forfeits it (both asserted) |
 | §Interop — `ui/->react` | **S6** | compat-boundary fixtures, both nesting directions (the compat-boundary contract) |
 | §The React interop tier — `re-frame.ui.react` | **S3** | the seven wrappers' call shapes; the position law (finite-site analyzer extension — conditional/inside-fn rejection); the hook-signature-hash `:react` extension + the one-time remount wave; JVM host-render rows; HMR remount/preservation. Declared until then |


### PR DESCRIPTION
Ratified UIx-review child **rf2-u53yy.5**. A **foreign** React head now accepts `(ui/spread literal-part runtime-map)` — and a plain forwarded map `(ui/spread runtime-map)` — in props position. Internal views keep the literal-props requirement.

## The rule (exactly per the bead)

- **Two shapes.** `(ui/spread literal-part runtime-map)` — a literal props map plus an opaque forwarded map; `(ui/spread runtime-map)` — the plain forwarded map alone. A leading literal map is the literal part; a leading non-map expression is the forwarded map.
- **Literal part analysed normally** — handler classification (`ui/event`/`ui/handler`/`ui/render-fn`), prop-key checks, the bare-fn law, `:key`/`:ref` extraction, `:children`-as-a-prop rejection. A committed callback still compiles to a per-site-stable identity.
- **Runtime part is an intentionally opaque foreign-boundary map** — passes through **unconverted** (verbatim author-key names; no rule table, no kebab→camel, no handler classification) and marks the site `:dynamic` in the manifest exactly as a dynamic handler expression does.
- **Literal props win any key collision** — the forwarded map is layered *under* the compiled literal props (mirroring `ui/spread-safe`'s owned-wins, minus the deny law — a foreign boundary defends no owned/structural key). A committed callback can never be silently clobbered. (This differs from a DOM element's `(ui/spread base overrides)`, whose two runtime maps merge later-arg-wins.)
- **Internal views stay literal** — `(ui/spread …)` at an internal-view call site is the new `:rf.ui.compile/spread-internal-view` (`:rf.ui.compile/*` is Spec-009 catalogue-exempt). No generic internal-view prop spreading; `ui/spread-safe` remains the DOM/component-library forwarding policy.
- **JVM parity** — a foreign component stays a host-op boundary (its props never enter the structural tree), so a foreign spread renders under the same `ui/client-only` rule as any foreign head. **No `emit_jvm.cljc` change needed** (verified: `emit-foreign` ignores props).

## Surface

- `analyze.cljc` — `analyze-foreign-spread` parser + `analyze-component-props` routing; `analyze-component` treats a `(ui/spread …)` second form as props at a component head.
- `emit_cljs.cljc` — `emit-component` spread branch → `foreign-spread-props` + `jsx-spread2`/`3` (literal binds before forwarded; source order preserved).
- `runtime.cljs` — `foreign-spread-props` (literal-wins layering, nil-skip, verbatim forwarded keys).
- `spec/004-Views.md` — the foreign-props position rule + grammar/interop/conformance rows. Sole spec/004 toucher this wave; analyzer ↔ spec consistent.
- `docs/api/re-frame.ui.md` + `docs/core/re-frame.ui/interop-and-limits.md` — rule + worked `date-field` wrapper example; reconciled the "dynamic prop maps" row that overstated what component call sites accept.
- Regenerated `skills/re-frame2-ui-context/SKILL.md` (didactic messages changed); reconciled the `reagent-migration` catalog "never a spread" line (SKILLS CLAUSE).
- Tests: accept / reject / frozen-roster (`spread-internal-view`) / emit-lowering — red→green; existing spread + 55zsd spread-safe fixtures unchanged.

## Quality gates

- `implementation/ui $ clojure -M:test` — **1009 tests, 0 failures**
- `implementation $ npm run test:cljs` — **10337 tests, 0 failures**
- `implementation $ npm run test:elision` — **PASS** (prod 60/60 absent; control 60/60 present)
- `python -m mkdocs build --strict` — **PASS**
- `python scripts/check_doc_slugs.py` — **PASS**
- `ui-context --check` — **OK: in sync (70 ids)** after regeneration

NOTE: ratified u53yy child; rf2-u53yy.7 / ny34u / 0sray queue behind this on spec/004.