### PR TITLE
docs(EP): reconcile adoption bookkeeping after W1/W2/W3 supersession (rf2-3qb5w)

### DIFF
--- a/docs/EP/EP-0030-the-compiled-view-substrate-program.md
+++ b/docs/EP/EP-0030-the-compiled-view-substrate-program.md
@@ -244,11 +244,15 @@ grammar; explicit escapes), and HMR identity drift (release/remount on ambiguity
 
 ### Guide impact
 
-The program adds `re-frame.ui` coverage across the `docs/core` view surface (W3)
-— views, frames, the introduction counter, forms — keeps the substrate-choice
-teaching (presenting `re-frame.ui` as a new experimental option alongside the
-retained Reagent/UIx/reagent-slim boot choices), and rebuilds the playground.
-Sibling EPs name per-domain impacts.
+The program's `re-frame.ui` teaching shipped as the **additive
+`docs/core/re-frame.ui` guide** (W3; rf2-b1wv9/#6544) — a dedicated subtree
+covering the mental model, building a view, state, events/handlers,
+reactivity/ownership, presence, SSR, testing, and interop — rather than a
+wholesale rewrite of the existing `docs/core` view chapters, which keep working
+and keep the substrate-choice teaching (presenting `re-frame.ui` as a new
+experimental option alongside the retained Reagent/UIx/reagent-slim boot
+choices). Later guide growth — and any playground work — is demand-driven, not a
+program-scale promise. Sibling EPs name per-domain impacts.
 
 ## Rationale
 
@@ -372,6 +376,29 @@ baseline is a recorded comparison, not a standing gate.
   one shallow props-conversion rule (children + ref preserved). W7b's dependency
   on `->react` landing (2026-07-19 above) is now satisfied. The `spec/API.md`
   blessed-freeze row and the api-manifest flip planned→live with this ruling.
+- **ADDENDUM — W1/W2/W3 adoption clauses trued to current truth (2026-07-20,
+  rf2-3qb5w).** The pre-#6560 EP text carried the retired codemod-era adoption
+  plan; #6560 corrected it in place. Per the EP-0009 convention (freeze meaning,
+  not bytes — rf2-r7ahi) the replaced clauses are preserved here beside their
+  current disposition. **Prior text:** §Adoption workstreams named "its sibling
+  migration + authoring skills (W2/W6), the docs/guide rewrite (W3)"; §Migration
+  posture said the migration skill's "rule table carries the mechanical rewrites
+  and flags the judgment-tier call sites for review rather than guessing"; §The
+  design-record retirement said "`guide/` moves to `docs/guide` at S6 (W3)"; and
+  the 2026-07-20 "Migration ships as an AI skill" ruling said "the skill's rule
+  table and fixture corpus carry the mechanical tier and flag the judgment tiers
+  for review. W2 lands as a sibling skill of the existing v1 migration skill
+  rather than an extension of it." **Current disposition (W numbers preserved,
+  no renumber):** W2 is **absorbed into W1** — the Reagent→`re-frame.ui`
+  migration ships as the single sibling AI skill `skills/reagent-migration`
+  (rf2-3bjvs, #6543); the former W2 second skill (closed rf2-nwgzha) is
+  superseded, not redispatched. W3's **wholesale docs rewrite and
+  `guide/`→`docs/guide` move are superseded** by the additive
+  `docs/core/re-frame.ui` guide already shipped (rf2-b1wv9, #6544); there is no
+  `docs/guide` destination and later guide growth is demand-driven (closed
+  rf2-3339ri records the plan as overtaken, not relocated). The W1 skill
+  **applies the M-tier mechanical rewrites and reasons through the D-tier
+  judgment cases with the author — it emits no review flags.**
 
 ## Open Issues
 

--- a/docs/EP/EP-0035-component-library-readiness.md
+++ b/docs/EP/EP-0035-component-library-readiness.md
@@ -219,6 +219,15 @@ strictly additive at proven-controlled sites — no narrower door was ever
 shipped law — and the v1 API freeze is not
 reopened: deltas #4/#5 entered under the freeze's own delta protocol.
 
+> **Erratum (2026-07-20, rf2-3qb5w).** The pre-#6560 text of the clause above
+> read "the migration skill's `swap!` rewrite retargets to `update!`, retiring
+> its MANUAL flag on multi-writer idioms." The MANUAL-flag language described the
+> retired codemod-era plan; the shipped Reagent→`re-frame.ui` migration skill
+> (W1, `skills/reagent-migration` — EP-0030) is an AI skill that reasons through
+> judgment cases with the author and emits no MANUAL flag. The `swap!`→`update!`
+> migration fact is unchanged and preserved above; only the retired flag
+> language is corrected. Meaning frozen, not bytes (EP-0009, rf2-r7ahi).
+
 ## Resolved Decisions
 
 Delegated rulings (2026-07-16):


### PR DESCRIPTION
Reconciles the EP adoption/supersession bookkeeping the #6560 audit (2026-07-20; completeness/correctness) flagged as stale after the W1/W2/W3 supersession. Each stale-record claim was verified against the current EP + the actual W1/W2/W3 outcome before editing.

The core defect: the #6560 currency sweep corrected EP-0030/0035's retired codemod-era adoption clauses **in place**, but EP-0009/rf2-r7ahi requires a settled EP's meaning to be preserved through a dated erratum/addendum (freeze meaning, not bytes). This PR adds those preservation records and fixes the one untouched stale paragraph.

## What changed

**EP-0030 — dated adoption ADDENDUM (Resolved Decisions).** Preserves the exact pre-#6560 clauses verbatim (verified against git blob `837d617542^`) beside their current disposition:
- §Adoption workstreams: `"its sibling migration + authoring skills (W2/W6), the docs/guide rewrite (W3)"`
- §Migration posture: the skill `"rule table carries the mechanical rewrites and flags the judgment-tier call sites for review"`
- §design-record retirement: `` "`guide/` moves to `docs/guide` at S6 (W3)" ``
- 2026-07-20 AI-skill ruling: `"...flag the judgment tiers for review. W2 lands as a sibling skill..."`

Current disposition (W numbers preserved, no renumber): W2 **absorbed into W1** (single sibling AI skill `skills/reagent-migration`, rf2-3bjvs/#6543; former W2 rf2-nwgzha closed/superseded); W3's wholesale rewrite + `guide/`→`docs/guide` move **superseded** by the shipped additive `docs/core/re-frame.ui` guide (rf2-b1wv9/#6544), later growth demand-driven (closed rf2-3339ri = overtaken, not relocated); the W1 skill reasons through D-tier cases with the author and emits **no review flags**.

**EP-0030 — Guide impact paragraph.** Replaced the untouched paragraph promising wholesale `docs/core` view rewrites + a playground rebuild with the delivered additive-guide truth; later guide/playground work is demand-driven.

**EP-0035 — dated erratum (Backwards Compatibility).** Preserves the old MANUAL-flag sentence (`"...retargets to update!, retiring its MANUAL flag on multi-writer idioms"`) beside the corrected behavior; the `swap!`→`update!` migration fact is unchanged.

## Verification (each audit claim confirmed stale before editing)
- W2 absorbed: only `skills/reagent-migration/` exists — no second migration skill. **Confirmed.**
- W1 skill emits no flags: `SKILL.md` reasons through D-tier cases with the author, `grep MANUAL` in the skill returns nothing. **Confirmed.**
- W3 additive guide shipped: `docs/core/re-frame.ui/` exists; `docs/guide` does **not** exist anywhere. **Confirmed.**
- `swap!`→`update!` fact real: present in the skill's catalog-judgment/gotchas/evals. **Confirmed, preserved.**
- docs/core / docs/guide prose: swept — no stale re-frame.ui view-migration bookkeeping and no broken `docs/guide` links (the `25-from-re-frame-v1.md` codemod/flags prose is the separate, real v1-dataflow codemod — correctly untouched).

## Out of scope / remaining
- Bead NOTES item (3) — `ai/findings/new-substrate-synthesis/README.md` pointer-map row (`guide/` → `docs/guide/` should be `docs/core/re-frame.ui`, overtaken-not-relocated) — **left untouched**: the dispatch brief explicitly fenced `ai/**` out of this worker's surface. Flagged on the bead for a separate one-line dispatch (the row is still stale).
- Disjoint from live workers u53yy.5 (analyze + spec/004 + re-frame.ui.md + interop-and-limits.md), flf7f (spec/API + ssr), 6isc2 (spec/012 + conformance) — none of their files touched.

## Quality gates
- `python -m mkdocs build --strict` — **PASS** (exit 0)
- `python scripts/check_doc_slugs.py` — **PASS** (exit 0)
- `python scripts/check_ep_status_sync.py` — **PASS** (exit 0)
- `sh scripts/check-no-hardcoded-paths.sh` — **PASS** (exit 0)
