### PR TITLE
feat(ui): stamp render-key onto committed DOM at commit time (rf2-ny34u)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -3797,7 +3797,12 @@
 
 (defn render-key
   "The integer :render-key of the cell's most-recent connected commit, or nil.
-  Module-global monotonic and fresh per connected commit (tool/test read)."
+  Module-global monotonic and fresh per connected commit (tool/test read).
+
+  The React ViewCell commit site (`re-frame.ui.viewcell`) reads this back right
+  after `commit!` to stamp `data-rf-render-key` onto the committed host-root DOM
+  node (dev only; rf2-ny34u) — the DOM-navigation counterpart to the compiler's
+  static `data-rf-view` / `data-rf2-source-coord` host-root annotation."
   [^ViewCell cell]
   (:render-key (commit-record cell)))
 

--- a/implementation/ui/src/re_frame/ui/viewcell.cljs
+++ b/implementation/ui/src/re_frame/ui/viewcell.cljs
@@ -136,24 +136,88 @@
         (reactive/with-capture cell thunk)))
     (reactive/with-capture cell thunk)))
 
+;; ---------------------------------------------------------------------------
+;; DEV-only render-key DOM stamp (rf2-ny34u; Spec 004 §View identity — Source ↔
+;; DOM navigation).
+;;
+;; The compiler stamps the STATIC host-root annotation (`data-rf2-source-coord` /
+;; `data-rf-view`) at render (rf2-hac8p), but the per-commit render-key does not
+;; exist at render time — it is minted at CONNECTED COMMIT inside
+;; `reactive/commit!` (reactive.cljc), AFTER the child host element has already
+;; committed (reading it at render is stale-by-one / nil-at-mount, an I-1/I-2
+;; violation). So the substrate stamps it HERE, in the ViewCell's reconcile
+;; layout effect, onto the committed host-root DOM node — the same node the
+;; static annotation rides — as `data-rf-render-key`, reading the just-minted key
+;; back through the `reactive/render-key` reader. reactive.cljc's commit path
+;; stays host-agnostic (it also runs headless on the JVM plain-atom host, which
+;; has no DOM node); the DOM-specific stamp lives at this React commit site.
+;;
+;; DEBUG-ONLY, production-erased (I-12, exactly like the static annotation):
+;; every hook and branch below sits behind `^boolean js/goog.DEBUG`, so Closure
+;; constant-folds the gate to false and DCEs the whole thing — the host-node ref,
+;; the `data-rf-render-key` literal, and the `setAttribute` — under :advanced +
+;; goog.DEBUG=false. A production ViewCell keeps exactly its two layout effects
+;; and stamps nothing.
+;; ---------------------------------------------------------------------------
+
+(defn- stampable-host-root?
+  "True when `element` is a compiler-owned host element (a React element whose
+  type is a tag STRING, so React attaches a DOM node to a ref placed on it) that
+  carries no authored `:ref`. This is the same root the static host-root
+  annotation lands on. A view / foreign-component / fragment root has no DOM node
+  to stamp, and a host root the author already `:ref`s is left untouched rather
+  than clobbering the user's ref — such a view forgoes the DOM-attribute
+  convenience (its render-key is still readable via `reactive/render-key`)."
+  [element]
+  (and (react/isValidElement element)
+       (string? (.-type element))
+       (nil? (.. element -props -ref))))
+
 (defn- use-commit-and-lifecycle!
-  "Publish an observation-only capture and own React visibility lifecycle."
-  [cell root-incarnation capture]
-  ;; Reconcile after every committed render. There is deliberately no cleanup:
-  ;; retained observation owners live on the cell, not on a render.
-  (react/useLayoutEffect
-    (fn reconcile []
-      (reactive/commit! cell capture)
-      js/undefined))
-  ;; Connect via commit above; cleanup releases ownership on both unmount and
-  ;; Activity hide. Root enrolment deliberately survives hide so root teardown
-  ;; can reap an entirely-hidden subtree.
-  (react/useLayoutEffect
-    (fn lifecycle []
-      (when (some? root-incarnation)
-        (reactive/attach-root! cell root-incarnation))
-      (fn cleanup [] (reactive/disconnect! cell)))
-    #js [root-incarnation]))
+  "Publish an observation-only capture, own React visibility lifecycle, and — in
+  DEV only — stamp the per-commit render-key onto the committed host-root DOM
+  node. Returns the element to render: in DEV a clone of `element` carrying a
+  stable host-node ref when the root is a stampable host element; unchanged in
+  production (the whole DEV arm DCEs)."
+  [cell root-incarnation capture element]
+  ;; DEV: capture the committed host-root DOM node so the reconcile effect can
+  ;; stamp render-key onto it. Both hooks are goog.DEBUG-gated, so production
+  ;; carries neither — its ViewCell keeps exactly the two layout effects below.
+  (let [host-ref (when ^boolean js/goog.DEBUG (react/useRef nil))
+        host-cb  (when ^boolean js/goog.DEBUG
+                   (react/useCallback
+                     (fn capture-host-node [node] (set! (.-current host-ref) node))
+                     #js []))]
+    ;; Reconcile after every committed render. There is deliberately no cleanup:
+    ;; retained observation owners live on the cell, not on a render.
+    (react/useLayoutEffect
+      (fn reconcile []
+        (reactive/commit! cell capture)
+        ;; render-key is minted inside `commit!` above (reactive.cljc). Stamp it
+        ;; onto the just-committed host node so DOM-oriented tooling can read
+        ;; which render produced the on-screen node. No-op when there is no host
+        ;; node (a non-stampable root) or no render-key (a non-connected commit
+        ;; publishes no record). Production-erased with the whole DEV plane.
+        (when ^boolean js/goog.DEBUG
+          (let [node (some-> host-ref .-current)
+                rk   (reactive/render-key cell)]
+            (when (and node (some? rk))
+              (.setAttribute node "data-rf-render-key" (str rk)))))
+        js/undefined))
+    ;; Connect via commit above; cleanup releases ownership on both unmount and
+    ;; Activity hide. Root enrolment deliberately survives hide so root teardown
+    ;; can reap an entirely-hidden subtree.
+    (react/useLayoutEffect
+      (fn lifecycle []
+        (when (some? root-incarnation)
+          (reactive/attach-root! cell root-incarnation))
+        (fn cleanup [] (reactive/disconnect! cell)))
+      #js [root-incarnation])
+    ;; DEV: return the host-root clone carrying the stable node ref; production
+    ;; returns the element untouched (this whole arm folds away under :advanced).
+    (if (and ^boolean js/goog.DEBUG (stampable-host-root? element))
+      (react/cloneElement element #js {:ref host-cb})
+      element)))
 
 (defn- use-frame-context!
   "Register the calling component as a real React CONSUMER of the shared frame
@@ -289,8 +353,8 @@
         [element capture event-capture]
         (capture-reactive-and-events
          owner frame-id
-         #(capture-with-overrides cell overrides (with-current-frame frame-id thunk)))]
-    (use-commit-and-lifecycle! cell root-incarnation capture)
+         #(capture-with-overrides cell overrides (with-current-frame frame-id thunk)))
+        element (use-commit-and-lifecycle! cell root-incarnation capture element)]
     (use-event-commit-and-lifecycle! owner event-capture)
     element))
 
@@ -328,8 +392,7 @@
         overrides              (use-sub-revision! cell)
         [element capture]      (capture-with-overrides
                                 cell overrides (with-current-frame frame-id thunk))]
-    (use-commit-and-lifecycle! cell root-incarnation capture)
-    element))
+    (use-commit-and-lifecycle! cell root-incarnation capture element)))
 
 (defn render-dev
   "Stable Fast Refresh wrapper: the full hook superset regardless of the
@@ -345,8 +408,8 @@
         [element capture event-capture]
         (capture-reactive-and-events
          owner frame-id
-         #(capture-with-overrides cell overrides (with-current-frame frame-id thunk)))]
-    (use-commit-and-lifecycle! cell root-incarnation capture)
+         #(capture-with-overrides cell overrides (with-current-frame frame-id thunk)))
+        element (use-commit-and-lifecycle! cell root-incarnation capture element)]
     (use-event-commit-and-lifecycle! owner event-capture)
     element))
 

--- a/implementation/ui/test/re_frame/ui/preflight_frame_wiring_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/preflight_frame_wiring_dom_cljs_test.cljs
@@ -32,13 +32,14 @@
 (defn- browser? [] (exists? js/document))
 
 (defn- strip-view-evidence
-  "Drop the DEV host-root view-evidence annotation the compiler stamps on a
-  view's compiler-owned root element in dev builds (rf2-hac8p). These pins assert
-  the frame-provider's transparent scoping / rendered template shape, not the
-  annotation — whose own coverage is the emit-annotation tests, the parity
-  corpus, and test:elision."
+  "Drop the DEV host-root view-evidence annotations from committed markup: the
+  compiler's static `data-rf2-source-coord` / `data-rf-view` (rf2-hac8p) and the
+  substrate's commit-time `data-rf-render-key` (rf2-ny34u). These pins assert the
+  frame-provider's transparent scoping / rendered template shape, not the
+  annotations — whose own coverage is the emit-annotation tests, the parity
+  corpus, the render-key DOM-stamp tests, and test:elision."
   [html]
-  (str/replace html #"\s+data-rf(?:2-source-coord|-view)=\"[^\"]*\"" ""))
+  (str/replace html #"\s+data-rf(?:2-source-coord|-view|-render-key)=\"[^\"]*\"" ""))
 
 ;; ---------------------------------------------------------------------------
 ;; The canonical React act() helper (rf2-vxgfnd.89 template; rf2-powx4d sweep)

--- a/implementation/ui/test/re_frame/ui/render_key_dom_stamp_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/render_key_dom_stamp_dom_cljs_test.cljs
@@ -1,0 +1,95 @@
+(ns re-frame.ui.render-key-dom-stamp-dom-cljs-test
+  "rf2-ny34u (.98.1 slice c follow-up) — the render-key DOM stamp at commit time.
+
+  rf2-hac8p ships the compiler's STATIC host-root annotation (`data-rf-view` /
+  `data-rf2-source-coord`) at render; rf2-rvs56 ships the integer `:render-key`
+  minted at CONNECTED COMMIT. This proves the third leg: the substrate stamps
+  that per-commit render-key onto the committed host-root DOM node as
+  `data-rf-render-key`, in the ViewCell's reconcile layout effect (after
+  `reactive/commit!` mints it). DOM-oriented tooling reads it to learn which
+  render produced the on-screen node.
+
+  Real DOM only: the stamp runs in a React layout effect against a committed
+  host node, so the proof mounts a compiled sub ViewCell through
+  `ui/create-root` and reads the attribute off the committed element. The
+  `browser?` gate makes the node runtime (`npm run test:cljs`) a no-op and the
+  browser runtime (`npm run test:browser`) the real body. Production erasure is
+  the twin `render_key_dom_stamp_elision_prod_test`."
+  (:require [cljs.test :refer [deftest is testing use-fixtures]]
+            ["react-dom" :as ReactDOM]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.reactive :as reactive]))
+
+(def ^:private frame-id :render-key-stamp/frame)
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter ui/adapter :ambient-frame nil :init-fn reactive/reset-scheduler!}))
+
+(defn- browser? [] (exists? js/document))
+
+(defview stamped-view
+  "A sub-bearing view with a compiler-owned host root — the root that carries the
+  static `data-rf-view` annotation and, at commit, the `data-rf-render-key`
+  stamp. `:label` changes force a fresh connected commit (hence a fresh key)
+  independently of the subscription value."
+  [{:keys [label]}]
+  [:div {:data-role "stamped"} (str label ":" (ui/sub [:rk/n]))])
+
+(defn- stamped-node [container]
+  (.querySelector container "[data-role='stamped']"))
+
+(defn- stamp [container]
+  (some-> (stamped-node container) (.getAttribute "data-rf-render-key")))
+
+(defn- owning-cell []
+  ;; The one live cell that committed ownership of [:rk/n] under this frame.
+  (let [want #{[:sub frame-id [:rk/n]]}]
+    (some (fn [cell]
+            (when (= want (reactive/committed-target-keys cell)) cell))
+          (reactive/current-live-cells))))
+
+(deftest render-key-is-stamped-on-the-committed-dom-node-and-updates-per-commit
+  (if-not (browser?)
+    (is true ":node — the browser gate owns the real committed-DOM proof")
+    (do
+      (rf/reg-sub :rk/n (fn [db _] (:n db)))
+      (rf/make-frame {:id frame-id :doc "render-key DOM stamp proof"})
+      (frame/replace-app-db! frame-id {:n 1})
+      (let [container (js/document.createElement "div")
+            root      (ui/create-root container {:root-id :render-key-stamp/root})]
+        (.appendChild js/document.body container)
+        (try
+          ;; --- mount: the committed node carries the render-key ---------------
+          (ReactDOM/flushSync
+           #(ui/render! root [ui/frame-provider {:frame frame-id}
+                              [stamped-view {:label "a"}]]))
+          (let [cell (owning-cell)
+                k1   (some-> (stamp container) js/parseInt)]
+            (is (some? (stamped-node container)) "the host root committed")
+            (is (some? cell) "exactly one cell owns the subscription")
+            (is (some? (stamp container))
+                "GREEN: the committed host node carries data-rf-render-key")
+            (is (and (integer? k1) (pos? k1))
+                "the stamped value is a positive integer render-key")
+            (is (= (reactive/render-key cell) k1)
+                "the DOM stamp equals the substrate's minted render-key")
+
+            ;; --- re-render: a fresh commit re-stamps a greater key ------------
+            (ReactDOM/flushSync
+             #(ui/render! root [ui/frame-provider {:frame frame-id}
+                                [stamped-view {:label "b"}]]))
+            (let [k2 (some-> (stamp container) js/parseInt)]
+              (is (= (reactive/render-key cell) k2)
+                  "the re-render re-stamps the node with the new minted key")
+              (is (> k2 k1)
+                  "render-key is monotonic per connected commit — the on-screen
+                   node reports the render that produced it")
+              (testing "the rendered text still reflects the live subscription"
+                (is (= "b:1" (.-textContent (stamped-node container)))))))
+          (finally
+            (ReactDOM/flushSync #(ui/unmount! root))
+            (.remove container)))))))

--- a/implementation/ui/test/re_frame/ui/render_key_dom_stamp_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/render_key_dom_stamp_elision_prod_test.cljs
@@ -1,0 +1,58 @@
+(ns re-frame.ui.render-key-dom-stamp-elision-prod-test
+  "rf2-ny34u — the PRODUCTION-erasure twin of `render_key_dom_stamp_dom_cljs_test`.
+
+  Runs ONLY in `:browser-test-prod-elision` (`shadow-cljs release` ⇒
+  `:optimizations :advanced`, goog.DEBUG=false), where the ViewCell's DEV-only
+  render-key DOM stamp DCEs. It mounts a compiled sub ViewCell — the same shape
+  the dev twin stamps — and asserts the committed host node carries NO
+  `data-rf-render-key` attribute (the whole `js/goog.DEBUG` arm in
+  `re-frame.ui.viewcell/use-commit-and-lifecycle!` folds away: no host-node ref,
+  no clone, no `setAttribute`). This is the I-12 production-erasure proof for the
+  stamp (the DOM-attribute counterpart of the static-annotation erasure the
+  parity corpus already pins for `data-rf-view` / `data-rf2-source-coord`).
+
+  Two teeth guard against a vacuous pass:
+    (i)  `debug-regime-is-off` — `interop/debug-enabled?` is false in-bundle, so
+         the absence assertion cannot silently run in the dev regime.
+    (ii) the same test asserts the host node DID commit (a real
+         `[data-role='stamped']` element), so the missing attribute is a genuine
+         erasure, not an unmounted view."
+  (:require [cljs.test :refer [deftest is testing]]
+            ["react-dom" :as ReactDOM]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.reactive :as reactive]))
+
+(defview prod-stamped-view
+  [{:keys [label]}]
+  [:div {:data-role "stamped"} (str label ":" (ui/sub [:rk/n]))])
+
+(deftest debug-regime-is-off
+  (testing "goog.DEBUG=false in-bundle — the erasure assertion below is not vacuous"
+    (is (false? interop/debug-enabled?)
+        "interop/debug-enabled? must constant-fold to false in this advanced build")))
+
+(deftest render-key-dom-stamp-is-absent-in-production
+  (reactive/reset-scheduler!)
+  (rf/reg-sub :rk/n (fn [db _] (:n db)))
+  (let [fa        (rf/make-frame {:initial-events [[:rf/set-db {:n 1}]]})
+        fa-id     (frame/frame-target->id fa)
+        container (js/document.createElement "div")
+        root      (ui/create-root container {:root-id :render-key-stamp/prod-root})]
+    (.appendChild js/document.body container)
+    (try
+      (ReactDOM/flushSync
+       #(ui/render! root [ui/frame-provider {:frame fa}
+                          [prod-stamped-view {:label "p"}]]))
+      (let [node (.querySelector container "[data-role='stamped']")]
+        (is (some? node)
+            "positive control: the sub ViewCell committed a real host node")
+        (is (= "p:1" (.-textContent node))
+            "the compiled sub resolved its value (the mount is real)")
+        (is (nil? (.getAttribute node "data-rf-render-key"))
+            "ERASED: production carries no render-key DOM stamp"))
+      (finally
+        (ReactDOM/flushSync #(ui/unmount! root))
+        (.remove container)))))

--- a/implementation/ui/test/re_frame/ui/root_mount_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/root_mount_dom_cljs_test.cljs
@@ -162,12 +162,14 @@
   (ui/mount [mini-app {:title "hello S1c"}] c {:root-id :dom-smoke/main}))
 
 (defn- strip-view-evidence
-  "Drop the DEV host-root view-evidence annotation the compiler stamps on a
-  view's compiler-owned root element in dev builds (rf2-hac8p). This smoke pins
-  the rendered template shape, not the annotation — whose own coverage is the
-  emit-annotation tests, the parity corpus, and test:elision."
+  "Drop the DEV host-root view-evidence annotations from committed markup: the
+  compiler's static `data-rf2-source-coord` / `data-rf-view` (rf2-hac8p) and the
+  substrate's commit-time `data-rf-render-key` (rf2-ny34u). This smoke pins the
+  rendered template shape, not the annotations — whose own coverage is the
+  emit-annotation tests, the parity corpus, the render-key DOM-stamp tests, and
+  test:elision."
   [html]
-  (str/replace html #"\s+data-rf(?:2-source-coord|-view)=\"[^\"]*\"" ""))
+  (str/replace html #"\s+data-rf(?:2-source-coord|-view|-render-key)=\"[^\"]*\"" ""))
 
 (deftest mount-smoke
   (when (browser?)


### PR DESCRIPTION
## Summary

`.98.1` slice (c) follow-up. rf2-hac8p ships the compiler's **static** host-root annotation (`data-rf2-source-coord` / `data-rf-view`) at render; rf2-rvs56 ships the integer `:render-key` minted at **connected commit**. This adds the third leg: the substrate stamps that per-commit render-key onto the committed host-root DOM node so DOM-oriented tooling (Xray click-to-source / render attribution) can read *which render produced the on-screen node*.

## What changed

- **`ui/viewcell.cljs`** — the ViewCell commit site. The reconcile layout effect reads the just-minted key back via `reactive/render-key` (after `reactive/commit!`) and sets `data-rf-render-key="<int>"` on the committed host-root DOM node, captured through a stable callback ref cloned onto the host root.
- **`ui/reactive.cljc`** — one-line cross-reference on the `render-key` reader docstring (the commit path stays host-agnostic; the DOM stamp lives at the React commit site because the headless JVM plain-atom host has no DOM node).
- Two committed-`innerHTML` DOM tests (`root_mount` / `preflight_frame_wiring`) now strip the new annotation alongside the static ones.

## Design notes

- **DEBUG-only, production-erased (I-12).** The host-node ref, the element clone, and the `setAttribute` all sit behind `^boolean js/goog.DEBUG` and DCE under `:advanced` — a production ViewCell keeps exactly its two layout effects and stamps nothing.
- **Attribute:** `data-rf-render-key`, following the existing `data-rf-view` / `data-rf-render-hash` vocabulary (Spec 004 §View identity — Source ↔ DOM navigation).
- **No render-key semantics changed** (rvs56 shipped the integer key); no compiler emit touched (per the bead, the stamp is a commit-time substrate concern, not compiler emit).
- A host root the author already `:ref`s is left untouched — no clobbering a user ref; that view forgoes the DOM-attribute convenience (its render-key stays readable via `reactive/render-key`).
- **Spec/004 row deferred** to a follow-up sequenced after S4 (5e8zv.6 currently owns `spec/004-Views.md`), per the code-only fence. This PR is code + tests only.

## Proof (red→green)

- `render_key_dom_stamp_dom_cljs_test` (browser): after commit the on-screen node carries `data-rf-render-key` equal to `reactive/render-key`; a re-render re-stamps a strictly-greater key (monotonic).
- `render_key_dom_stamp_elision_prod_test` (`:advanced`, goog.DEBUG=false): the committed node carries **no** `data-rf-render-key` (erased), with `interop/debug-enabled?` = false as the non-vacuity tooth.

## Quality gates

All run foreground to completion:

- `implementation/ui` `clojure -M:test` (JVM ui): **1009 tests, 0 failures**
- `npm run test:cljs` (consolidated node): **10338 tests, 0 failures**
- `npm run test:browser` (real-DOM proof; incl. the new dom test + the 2 strip-helper fixes): **506 tests, 0 failures**
- advanced prod-elision bundle in-browser (`serve-and-run` on `browser-test-prod-elision`; incl. the erasure proof): **116 tests, 0 failures**
- `npm run test:elision` (core no-regression): **PASS 60/60 absent, control 60/60 present**

Note: the string-scan gates (`check-elision.cjs`, `check-ui-mounted-prod-elision.cjs`) are `scripts/` (fenced to S4) and were not modified; erasure of the new `data-rf-render-key` string is proven behaviorally by the elision-prod test above (a raw bundle grep is inconclusive because the test file itself contains the string, as with the existing `data-rf-view` erasure). CI runs the full `test:browser-prod-elision`.
