### PR TITLE
fix(testbeds): SSR testbeds read hydration metadata from runtime-db (rf2-kabpj)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/hydrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hydrate.cljc
@@ -544,7 +544,7 @@
 
   opts may carry :first-diff-path, :failing-id, AND :server-hash.
   The :server-hash opt overrides the
-  [:rf.runtime/ssr :hydration :server-hash] slot in app-db — useful
+  [:rf.runtime/ssr :hydration :server-hash] slot in runtime-db — useful
   when the user's :rf/hydrate handler doesn't populate that slot
   (e.g. fixture-overridden handlers).
 

--- a/testbeds/ssr_basic/README.md
+++ b/testbeds/ssr_basic/README.md
@@ -15,7 +15,7 @@ shape the JVM-side `render-to-string` + payload builder would emit per
 | `data-testid` | What it carries / proves |
 |---|---|
 | `ssr-basic` | Root marker — visible from first byte (pre-rendered). |
-| `not-hydrated` / `hydrated` | Discriminator on `:rf/hydration` presence in app-db. The static HTML ships the `not-hydrated` marker; first render after `:rf/hydrate` swaps to `hydrated`. |
+| `not-hydrated` / `hydrated` | Discriminator on the `[:rf.runtime/ssr :hydration]` metadata presence in runtime-db (read via a `reg-runtime-sub`). The static HTML ships the `not-hydrated` marker; first render after `:rf/hydrate` swaps to `hydrated`. |
 | `count` | Seeded via payload's `:rf/app-db {:count 7}`. Click `inc` mutates → re-render → count++. |
 | `title` | Seeded via payload's `:rf/app-db {:title "seeded"}`. Click `set-title` writes `"hydrated"`. |
 | `resp-status` / `resp-ct` / `resp-cookies-count` / `resp-cookie-name` | Materialise the payload's `:rf/response` slice — proves per-request `:rf.server/*` accumulator round-trips through the wire into the view layer. |
@@ -31,7 +31,7 @@ cljs vars.
 |---|---|
 | §Hydration is a defined protocol | Payload arrives, `:rf/hydrate` replaces app-db, client renders. |
 | §Payload scope (canonical boundary) | The four required keys plus optional `:rf/response`; nothing else on the wire. |
-| §The `:rf/hydrate` event | `:replace-app-db` policy carries the server's slice verbatim; `[:rf/hydration]` metadata stashed. |
+| §The `:rf/hydrate` event | `:replace-app-db` policy carries the server's slice verbatim; hydration metadata stashed in runtime-db at `[:rf.runtime/ssr :hydration]`. |
 | §Hydration-mismatch detection | `verify-hydration!` invoked post first-render; no mismatch when server-hash is nil (baseline). |
 | §`:rf.ssr/check-version` (rf2-69ad2) | Fx dispatched as part of `:rf/hydrate`'s `:fx`; trace event surfaces via the listener. |
 | §Response storage substrate | The payload-carried `:rf/response` shape exercises the canonical `{:status :headers :cookies :redirect}` accumulator. |
@@ -49,19 +49,34 @@ cljs vars.
 
 ## Running
 
+This surface is a dev / Xray observation target — it is **not** staged
+by any smoke gate. The adapter-smoke orchestrator
+(`implementation/adapters/scripts/serve-and-run-adapter-smokes.cjs`)
+compiles + serves only the three adapter smokes under
+`implementation/adapters/<name>/testbed/`; top-level `testbeds/**` stay
+in-tree as observation targets. Build and view this one by hand.
+
 From `implementation/`:
 
 ```bash
-shadow-cljs watch testbeds/ssr-basic
-# Or via the orchestrator:
-npm run test:adapter-smokes
+# Watch-compile (the dev launcher seeds the on-disk checkout root so
+# 'open in editor' resolves):
+npm run dev -- :testbeds/ssr-basic
+# …or a one-shot compile:
+npx shadow-cljs compile :testbeds/ssr-basic
 ```
 
-Shadow-cljs build id is `testbeds/ssr-basic`; output lands in
-`implementation/out/testbeds/ssr-basic/`. The orchestrator
-(`implementation/adapters/scripts/serve-and-run-adapter-smokes.cjs`) stages this
-testbed's `index.html` next to `main.js` and serves the directory
-at `/ssr-basic/`.
+Shadow-cljs build id is `:testbeds/ssr-basic`; `main.js` lands in
+`implementation/out/examples/testbed-ssr-basic/`. To watch the hydration
+round-trip in a browser, stage this testbed's `index.html` next to that
+`main.js` and serve the directory with any static file server:
+
+```bash
+cp testbeds/ssr_basic/index.html out/examples/testbed-ssr-basic/
+npx http-server out/examples/testbed-ssr-basic -p 8080
+# open http://127.0.0.1:8080/ — the data-testid='hydrated' marker
+# flips from 'not-hydrated' once :rf/hydrate lands the runtime-db metadata.
+```
 
 ## Cross-references
 

--- a/testbeds/ssr_basic/core.cljs
+++ b/testbeds/ssr_basic/core.cljs
@@ -22,9 +22,11 @@
     - The pre-rendered counter / title / response panel are visible from
       the first byte (before main.js loads).
     - After main.js boots, `:rf/hydrate` replaces app-db with the
-      payload's `:rf/app-db` slice. The hydrate metadata lands at
-      [:rf/hydration] in app-db and a `data-testid='hydrated'` element
-      switches from `not-hydrated` to `hydrated`.
+      payload's `:rf/app-db` slice. The hydrate metadata lands in
+      runtime-db at [:rf.runtime/ssr :hydration] (durable framework
+      runtime state per Conventions §Reserved runtime-db keys) and a
+      `data-testid='hydrated'` element switches from `not-hydrated` to
+      `hydrated`.
     - `:rf.ssr/check-version` (always) and `:rf.ssr/check-schema-digest`
       (when the payload carries a digest) fxs run. `check-version`
       resolves its client-side actual from the SSR artefact's compiled-in
@@ -46,6 +48,10 @@
   dispatch, and post-render `verify-hydration!`."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
+            ;; SSR hydration metadata is durable runtime-db state, so the
+            ;; :hydrated? discriminator is a runtime-db sub (reg-runtime-sub
+            ;; lives on the re-frame.subs surface).
+            [re-frame.subs :as subs]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.ssr :as ssr]
@@ -110,7 +116,12 @@
 (rf/reg-sub :count       (fn [db _] (or (:count db) 0)))
 (rf/reg-sub :title       (fn [db _] (or (:title db) "untitled")))
 (rf/reg-sub :server-resp (fn [db _] (:server-response db)))
-(rf/reg-sub :hydrated?   (fn [db _] (boolean (:rf/hydration db))))
+;; The SSR hydration metadata is durable runtime-db state — the `:rf/hydrate`
+;; handler stashes it at [:rf.runtime/ssr :hydration] in the runtime-db
+;; partition (NOT app-db). So :hydrated? is a runtime-db sub reading the
+;; canonical source.
+(subs/reg-runtime-sub :hydrated?
+  (fn [rt _] (boolean (get-in rt [:rf.runtime/ssr :hydration]))))
 
 ;; ----------------------------------------------------------------------------
 ;; Views
@@ -205,8 +216,9 @@
       (if payload
         ;; HOT PATH — :rf/hydrate is auto-registered by re-frame.ssr;
         ;; replaces app-db with the payload's :rf/app-db, stashes
-        ;; metadata at [:rf/hydration], dispatches the two compatibility-
-        ;; check fxs (which the trace listener mirrors).
+        ;; metadata in runtime-db at [:rf.runtime/ssr :hydration],
+        ;; dispatches the two compatibility-check fxs (which the trace
+        ;; listener mirrors).
         (rf/dispatch-sync [:rf/hydrate payload])
         ;; Degraded path: no payload baked. Don't crash — render against
         ;; the empty app-db. This is the "client-only first load" shape.
@@ -214,8 +226,9 @@
     (rdc/render react-root [rf/frame-provider {:frame :rf/default} [root]])
 
     ;; HOT PATH — verify-hydration! reads the server-hash stashed at
-    ;; [:rf/hydration :server-hash], computes the client-render hash,
-    ;; and emits :rf.ssr/hydration-mismatch on disagreement.
+    ;; [:rf.runtime/ssr :hydration :server-hash] in runtime-db, computes
+    ;; the client-render hash, and emits :rf.ssr/hydration-mismatch on
+    ;; disagreement.
     ;; Resolve the view under the current (default) frame so the
     ;; subs evaluate against the post-hydrate app-db.
     (when payload

--- a/testbeds/ssr_hydration_mismatch/README.md
+++ b/testbeds/ssr_hydration_mismatch/README.md
@@ -3,7 +3,8 @@
 The deliberate-mismatch surface. The payload bakes a known-wrong
 `:rf/render-hash` (`"deadbeef"`) into the static `index.html`. The
 browser-side `run` dispatches `:rf/hydrate` (so the bogus hash lands
-at `[:rf/hydration :server-hash]`), renders the view, and calls
+in runtime-db at `[:rf.runtime/ssr :hydration :server-hash]`), renders
+the view, and calls
 `verify-hydration!` — which computes the client-side hash, compares,
 disagrees, and emits `:rf.ssr/hydration-mismatch` per
 [`spec/011-SSR.md` §Hydration-mismatch detection](../../spec/011-SSR.md).
@@ -15,7 +16,7 @@ structured payload visible inline.
 | `data-testid` | What it carries / proves |
 |---|---|
 | `ssr-hydration-mismatch` | Root marker. |
-| `hydrated` / `not-hydrated` | Discriminator on `:rf/hydration` presence. |
+| `hydrated` / `not-hydrated` | Discriminator on the `[:rf.runtime/ssr :hydration]` metadata presence in runtime-db (read via a `reg-runtime-sub`). |
 | `mismatch-banner` / `mismatch-banner-empty` | Pre-mismatch the `-empty` variant is rendered; post-mismatch the banner with the structured payload replaces it. |
 | `mismatch-server-hash` | The payload's `:rf/render-hash` (`"deadbeef"`). |
 | `mismatch-client-hash` | The runtime's computed hash for the resolved client tree — an 8-char lowercase hex string per Spec 011 §Hydration-mismatch detection. |
@@ -29,7 +30,7 @@ structured payload visible inline.
 |---|---|
 | §Hydration-mismatch detection | `verify-hydration!` reads the server hash, computes the client hash, emits `:rf.ssr/hydration-mismatch` on disagreement with structured tags (`:server-hash`, `:client-hash`, `:failing-id`, `:recovery`). |
 | §Mismatch recovery and configuration | Default posture is `:warned-and-replaced` — the trace fires but the client renders against the seeded state and the page stays interactive. |
-| §The `:rf/hydrate` event | The server-hash is stashed at `[:rf/hydration :server-hash]` automatically by the framework-registered handler — user code didn't have to participate. |
+| §The `:rf/hydrate` event | The server-hash is stashed in runtime-db at `[:rf.runtime/ssr :hydration :server-hash]` automatically by the framework-registered handler — user code didn't have to participate. |
 
 ## Why a known-wrong hex string instead of a "real" mismatch
 
@@ -50,16 +51,30 @@ shape (8 lowercase-hex chars).
 
 ## Running
 
+This surface is a dev / Xray observation target — it is **not** staged
+by any smoke gate (the adapter-smoke orchestrator serves only the three
+adapter smokes under `implementation/adapters/<name>/testbed/`). Build
+and view it by hand.
+
 From `implementation/`:
 
 ```bash
-shadow-cljs watch testbeds/ssr-hydration-mismatch
-# Or via the orchestrator:
-npm run test:adapter-smokes
+npm run dev -- :testbeds/ssr-hydration-mismatch
+# …or a one-shot compile:
+npx shadow-cljs compile :testbeds/ssr-hydration-mismatch
 ```
 
-Build id `testbeds/ssr-hydration-mismatch`; served at
-`/testbed-ssr-hydration-mismatch/`.
+Shadow-cljs build id is `:testbeds/ssr-hydration-mismatch`; `main.js`
+lands in `implementation/out/examples/testbed-ssr-hydration-mismatch/`.
+To view the mismatch banner in a browser, stage this testbed's
+`index.html` next to that `main.js` and serve the directory:
+
+```bash
+cp testbeds/ssr_hydration_mismatch/index.html out/examples/testbed-ssr-hydration-mismatch/
+npx http-server out/examples/testbed-ssr-hydration-mismatch -p 8080
+# open http://127.0.0.1:8080/ — verify-hydration! fires
+# :rf.ssr/hydration-mismatch and the mismatch-banner renders its payload.
+```
 
 ## Cross-references
 

--- a/testbeds/ssr_hydration_mismatch/core.cljs
+++ b/testbeds/ssr_hydration_mismatch/core.cljs
@@ -3,8 +3,8 @@
 
   Per [spec/011-SSR.md §Hydration-mismatch detection]: after the first
   client render, `verify-hydration!` recomputes the structural hash of
-  the resolved render-tree, reads the server hash stashed at
-  `[:rf/hydration :server-hash]`, and emits
+  the resolved render-tree, reads the server hash stashed in runtime-db
+  at `[:rf.runtime/ssr :hydration :server-hash]`, and emits
   `:rf.ssr/hydration-mismatch` (op-type `:error`, recovery
   `:warned-and-replaced`) on disagreement.
 
@@ -33,6 +33,10 @@
       not crash."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
+            ;; SSR hydration metadata is durable runtime-db state, so the
+            ;; :hydrated? discriminator is a runtime-db sub (reg-runtime-sub
+            ;; lives on the re-frame.subs surface).
+            [re-frame.subs :as subs]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.ssr :as ssr]
@@ -101,7 +105,12 @@
 
 (rf/reg-sub :count     (fn [db _] (or (:count db) 0)))
 (rf/reg-sub :mismatch  (fn [db _] (:mismatch db)))
-(rf/reg-sub :hydrated? (fn [db _] (boolean (:rf/hydration db))))
+;; The SSR hydration metadata is durable runtime-db state — the `:rf/hydrate`
+;; handler stashes it at [:rf.runtime/ssr :hydration] in the runtime-db
+;; partition (NOT app-db). So :hydrated? is a runtime-db sub reading the
+;; canonical source.
+(subs/reg-runtime-sub :hydrated?
+  (fn [rt _] (boolean (get-in rt [:rf.runtime/ssr :hydration]))))
 
 ;; ----------------------------------------------------------------------------
 ;; Views
@@ -180,9 +189,9 @@
     (rf/with-frame :rf/default
       (when payload
         ;; HOT PATH — :rf/hydrate replaces app-db; the payload's
-        ;; :rf/render-hash 'deadbeef' is stashed at
-        ;; [:rf/hydration :server-hash] so verify-hydration! can compare
-        ;; against the client's computed hash.
+        ;; :rf/render-hash 'deadbeef' is stashed in runtime-db at
+        ;; [:rf.runtime/ssr :hydration :server-hash] so verify-hydration!
+        ;; can compare against the client's computed hash.
         (rf/dispatch-sync [:rf/hydrate payload])))
     (rdc/render react-root [rf/frame-provider {:frame :rf/default} [root]])
 

--- a/testbeds/ssr_multi_frame/README.md
+++ b/testbeds/ssr_multi_frame/README.md
@@ -16,7 +16,7 @@ and dispatches `[:rf/hydrate slice]` against each frame.
 | `panel-A`, `panel-B`, `panel-log` | Per-frame panel containers. |
 | `n-A`, `n-B` | The seeded `:n` from each counter frame's payload slice (`10`, `99`). |
 | `entries-count` | The `:log` frame's payload-seeded entry count (`2`). |
-| `hyd-A`, `hyd-B`, `hyd-log` | `true` once each frame's `:rf/hydration` metadata lands. |
+| `hyd-A`, `hyd-B`, `hyd-log` | `true` once each frame's `[:rf.runtime/ssr :hydration]` metadata lands in its runtime-db (read via a `reg-runtime-sub`). |
 | `hash-A`, `hash-B`, `hash-log` | The payload-supplied `:rf/render-hash` per frame (`aaaa1111`, `bbbb2222`, `cccc3333`). |
 | `summary-{a,b,log}-hash` | Cross-frame readout via `rf/subscribe-once frame-id`. |
 | `summary-all-distinct` | `true` iff the three per-frame `:server-hash` values are pairwise distinct — proves no cross-frame bleed. |
@@ -43,16 +43,31 @@ and dispatches `[:rf/hydrate slice]` against each frame.
 
 ## Running
 
+This surface is a dev / Xray observation target — it is **not** staged
+by any smoke gate (the adapter-smoke orchestrator serves only the three
+adapter smokes under `implementation/adapters/<name>/testbed/`). Build
+and view it by hand.
+
 From `implementation/`:
 
 ```bash
-shadow-cljs watch testbeds/ssr-multi-frame
-# Or via the orchestrator:
-npm run test:adapter-smokes
+npm run dev -- :testbeds/ssr-multi-frame
+# …or a one-shot compile:
+npx shadow-cljs compile :testbeds/ssr-multi-frame
 ```
 
-Build id `testbeds/ssr-multi-frame`; served at
-`/testbed-ssr-multi-frame/`.
+Shadow-cljs build id is `:testbeds/ssr-multi-frame`; `main.js` lands in
+`implementation/out/examples/testbed-ssr-multi-frame/`. To view the
+three per-frame panels in a browser, stage this testbed's `index.html`
+next to that `main.js` and serve the directory:
+
+```bash
+cp testbeds/ssr_multi_frame/index.html out/examples/testbed-ssr-multi-frame/
+npx http-server out/examples/testbed-ssr-multi-frame -p 8080
+# open http://127.0.0.1:8080/ — the summary block shows three distinct
+# per-frame server-hashes (all-distinct=true), each read from its own
+# frame's runtime-db.
+```
 
 ## Cross-references
 

--- a/testbeds/ssr_multi_frame/core.cljs
+++ b/testbeds/ssr_multi_frame/core.cljs
@@ -23,9 +23,10 @@
   subtrees render the three panels. Each subtree reads ONLY its own
   frame's app-db — `:counter/a`'s `:n` sub fires against `:counter/a`'s
   app-db, never `:counter/b`'s. A `data-testid='hydration-summary'`
-  element renders the three frames' post-hydrate `:rf/hydration`
-  metadata to prove each frame's hydrate-event fired against its own
-  app-db (no cross-frame bleed).
+  element renders the three frames' post-hydrate hydration metadata —
+  read from each frame's runtime-db at `[:rf.runtime/ssr :hydration]` —
+  to prove each frame's hydrate-event fired against its own frame-state
+  (no cross-frame bleed).
 
   What a Playwright consumer observes:
 
@@ -33,12 +34,16 @@
       frame id. Cross-frame state is independent (Inc-A only bumps
       `:counter/a`; A's panel reads 11, B's panel still reads 99).
     - The hydration-summary block confirms three independent
-      `:rf/hydration {:server-hash ...}` records — one per frame —
-      proving the round-trip is per-frame.
+      runtime-db `[:rf.runtime/ssr :hydration] {:server-hash ...}`
+      records — one per frame — proving the round-trip is per-frame.
 
   This is NOT a tutorial — bodies are stark."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
+            ;; SSR hydration metadata is durable runtime-db state, so the
+            ;; per-frame :hydration readout is a runtime-db sub
+            ;; (reg-runtime-sub lives on the re-frame.subs surface).
+            [re-frame.subs :as subs]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.ssr :as ssr]
@@ -75,7 +80,13 @@
 
 (rf/reg-sub :n          (fn [db _] (:n db)))
 (rf/reg-sub :entries    (fn [db _] (:entries db)))
-(rf/reg-sub :hydration  (fn [db _] (:rf/hydration db)))
+;; The SSR hydration metadata is durable runtime-db state — the `:rf/hydrate`
+;; handler stashes it at [:rf.runtime/ssr :hydration] in each frame's
+;; runtime-db partition (NOT app-db). So :hydration is a runtime-db sub; the
+;; frame-explicit `{:frame f}` reads in `hydration-summary` resolve it against
+;; each named frame's runtime-db.
+(subs/reg-runtime-sub :hydration
+  (fn [rt _] (get-in rt [:rf.runtime/ssr :hydration])))
 
 ;; ----------------------------------------------------------------------------
 ;; Views
@@ -124,8 +135,9 @@
         [:li (pr-str e)])]]))
 
 (reg-view hydration-summary []
-  ;; Cross-frame readout — proves each frame's :rf/hydration metadata
-  ;; was written independently. Reactive `subscribe` with the frame-explicit
+  ;; Cross-frame readout — proves each frame's runtime-db hydration
+  ;; metadata ([:rf.runtime/ssr :hydration]) was written independently.
+  ;; Reactive `subscribe` with the frame-explicit
   ;; opts form (`[query-v {:frame f}]`) so each reaction resolves against the
   ;; named frame's app-db (this view renders OUTSIDE any `frame-provider`),
   ;; and the summary re-renders when a frame's hydration metadata changes.
@@ -184,6 +196,14 @@
   (rf/make-frame {:id frame-a :initial-events [[::counter-init]]})
   (rf/make-frame {:id frame-b :initial-events [[::counter-init]]})
   (rf/make-frame {:id frame-log :initial-events [[::log-init]]})
+  ;; EP-0002 (rf2-9o48ih): `root` is a `reg-view`, so its wrapper resolves
+  ;; a frame at render time for its injected bindings — it must render under
+  ;; a provider. Use a neutral SHELL frame (`:rf/default`) as the page-root
+  ;; scope; the three per-frame providers nested inside `root` override it
+  ;; for their subtrees, and `hydration-summary`'s frame-explicit
+  ;; `{:frame f}` reads target the three app frames directly, so the shell
+  ;; carries no app state of its own.
+  (rf/make-frame {:id :rf/default})
 
   (let [payload (read-server-payload)
         ;; payload shape:
@@ -198,4 +218,4 @@
       ;; spec/002 §Routing the dispatch envelope).
       (doseq [[fid slice] per-frame]
         (rf/dispatch-sync [:rf/hydrate slice] {:frame fid})))
-    (rdc/render react-root [root])))
+    (rdc/render react-root [rf/frame-provider {:frame :rf/default} [root]])))

--- a/testbeds/ssr_multi_frame/index.html
+++ b/testbeds/ssr_multi_frame/index.html
@@ -16,8 +16,9 @@
   <div class="rf2-testbed-shell">
   <!--
     The pre-rendered HTML is a placeholder (`not-hydrated`); the
-    interesting assertion is the per-frame `:rf/hydration` metadata
-    after hydrate completes. Each frame receives its own
+    interesting assertion is the per-frame runtime-db hydration
+    metadata (`[:rf.runtime/ssr :hydration]`) after hydrate completes.
+    Each frame receives its own
     `:rf/hydrate` dispatch with a distinct payload slice; the post-
     hydrate summary block proves the three frames hold independent
     metadata (distinct `:server-hash` values) and the three counter


### PR DESCRIPTION
## Summary

The three SSR browser testbeds subscribed to the retired app-db `:rf/hydration` slot, so their hydration evidence was **false** even though hydration itself succeeds. The runtime stashes hydration metadata in each frame's **runtime-db** at `[:rf.runtime/ssr :hydration]` (the canonical source, per the JVM `ssr_hydration_test.clj` shape). The testbeds now read it via `re-frame.subs/reg-runtime-sub`.

Fixes `rf2-kabpj`. This is a testbed/tooling integrity repair — no SSR runtime, storage, or public-API change.

## Changes (before → after)

| Testbed | Before | After |
|---|---|---|
| `ssr_basic` | `(rf/reg-sub :hydrated? (fn [db _] (boolean (:rf/hydration db))))` | `(subs/reg-runtime-sub :hydrated? (fn [rt _] (boolean (get-in rt [:rf.runtime/ssr :hydration]))))` |
| `ssr_hydration_mismatch` | same app-db `:hydrated?` sub | runtime-db `:hydrated?` sub |
| `ssr_multi_frame` | `(rf/reg-sub :hydration (fn [db _] (:rf/hydration db)))` | `(subs/reg-runtime-sub :hydration (fn [rt _] (get-in rt [:rf.runtime/ssr :hydration])))` — frame-explicit `{:frame f}` summary reads preserved |

Also:
- **ssr_multi_frame render fix**: `root` is a `reg-view`, so it must render under a frame scope; it was rendered `[root]` bare and threw a pre-existing `:rf.error/no-frame-context` at render time (blocking any browser render). Now scoped under a neutral `:rf/default` shell frame-provider, matching the sibling `testbeds/multi_frame`. The three nested per-frame providers still override for their subtrees.
- Corrected the nearby source comments + all three READMEs to name the runtime-db path, and corrected the **build/output/serve instructions**: the adapter-smoke orchestrator does **not** stage these builds (they are dev/Xray observation targets), and the output dir is `out/examples/testbed-ssr-*` (ssr-basic previously named the wrong dir).
- Corrected `re-frame.ssr/verify-hydration!`'s one stale "slot in app-db" docstring phrase → runtime-db.

Idiomatic re-frame2 throughout (app-db + events + subs; runtime-db read via the framework `reg-runtime-sub`). No raw atoms, no teaching layers, no new machinery.

## Quality gates

All foreground, run to completion:

- **Real-browser verification (Chromium/Playwright)** of all three served builds:
  - `ssr-basic`: `data-testid=hydrated` flips from `not-hydrated`; count=7, title=seeded.
  - `ssr-hydration-mismatch`: hydrated present; mismatch-banner shows `server-hash=deadbeef`, `client-hash=9681480b`, `recovery=:warned-and-replaced`.
  - `ssr-multi-frame`: three distinct hashes `aaaa1111/bbbb2222/cccc3333`, `all-distinct=true`, all three `hydrated=true`. No page/web errors.
- **All three shadow builds compile**: `testbeds/ssr-basic`, `testbeds/ssr-hydration-mismatch`, `testbeds/ssr-multi-frame` — 0 warnings each.
- **JVM SSR suite** (`implementation/ssr` `clojure -M:test`): 523 tests, 2524 assertions, 0 failures, 0 errors.
- **`npm run test:cljs`**: 10337 tests, 51082 assertions, 0 failures, 0 errors.
- **`npm run test:browser`**: 505 tests, 2786 assertions, 0 failures, 0 errors.

## Notes

- SSR-testbed bug only; `uqe1b`'s root-scoped `phase-context` hydration fact is the merged reference for runtime-db hydration state.
- Disjoint from live workers `5e8zv.6` (S4 analyze/ai/scripts/spec-004) and `ny34u` (reactive/substrate) — touches only the three SSR testbeds + the one `verify-hydration!` docstring phrase.