### PR TITLE
test(ui): advanced custom-element fixture proves raw property passthrough (rf2-tu2cg)

### DIFF
--- a/implementation/ui/test/re_frame/ui/custom_element_property_elision_prod_test.cljs
+++ b/implementation/ui/test/re_frame/ui/custom_element_property_elision_prod_test.cljs
@@ -26,18 +26,24 @@
   `react-dom/client` root, so the compiled `accentPayload` key is finally observed
   in the mode it is written for.
 
-  Mutation teeth (each reddens the fixture — the read is `(unchecked-get el
-  \"accentPayload\")`, the same literal string the emitter emits):
+  Mutation teeth (each reddens the fixture — the reads are `(unchecked-get el
+  \"accentPayload\")` and `(unchecked-get el \"accentKind\")`, the same literal
+  strings the emitter emits):
     - the emitter emitting a NON-string (renameable) property key ⇒ `:advanced`
-      renames it ⇒ React never finds `\"accentPayload\"` `in` the element instance,
+      renames it ⇒ React never finds the string key `in` the element instance,
       falls back to `setAttribute` under the mangled name ⇒ the read is undefined;
-    - routing a declared property through `attr-val` ⇒ the object is stringified
-      onto an attribute ⇒ the property is never set, `identical?` fails;
+    - routing a declared property VALUE through `attr-val` ⇒ `attr-val` stringifies
+      a keyword/symbol via `name`, so the `accentKind` property carries the STRING
+      `\"spilled-ink\"` instead of the keyword `:spilled-ink` ⇒ `keyword?`/`=` RED.
+      (An OBJECT value is a NO-OP under attr-val — the object stays identical and
+      the `accentPayload` identity check STAYS GREEN — which is exactly why the
+      keyword oracle, not the object, supplies these teeth. Reproduced against main:
+      the attr-val mutation was false-green until `accentKind` was added.)
     - dropping `:accent-payload` from the `:properties` declaration ⇒ it lowers
       to the VERBATIM kebab attribute name `accent-payload`, which the element
       does not define ⇒ React `setAttribute`s it (`\"[object Object]\"`) ⇒ RED.
-      (Verified by mutation: flipping `:properties #{:accent-payload}` to `#{}`,
-      rebuilding this advanced bundle, reddens the identity + non-reflection
+      (Verified by mutation: flipping `:properties #{:accent-payload :accent-kind}`
+      to drop a name, rebuilding this advanced bundle, reddens that property's
       assertions.)
 
   Its DEV positive control is `custom_element_classification_dom_cljs_test`; its
@@ -52,52 +58,78 @@
 (defn- browser? []
   (and (exists? js/document) (some? (.-createElement js/document))))
 
-;; A real custom element whose `accentPayload` PROPERTY is a plain accessor with
-;; NO attribute reflection: the getter returns exactly what the setter stored.
+;; A real custom element whose declared PROPERTIES are plain accessors with NO
+;; attribute reflection: each getter returns exactly what the setter stored.
 ;; React 19 assigns a prop as a JS property when a matching property EXISTS on the
 ;; instance — `key in domElement ? (domElement[key] = value) : setAttribute(...)`
 ;; (react-dom 19.2.0) — so a DECLARED property lands HERE while an undeclared name
 ;; (no matching property) falls to an attribute.
 ;;
-;; `accentPayload` is HYPHENATED at the author boundary (`:accent-payload`)
-;; precisely so the classification is OBSERVABLE — the camelCase property spelling
-;; differs from the verbatim kebab attribute spelling; a single-word name would be
-;; indistinguishable.
+;; Two accessors, each proving a distinct half of "properties pass through RAW":
+;;   accentPayload — carries an OBJECT; identity pins the property KEY (`:advanced`
+;;                   rename teeth) and non-reflection, but is a NO-OP under an
+;;                   `attr-val` mutation (attr-val leaves objects unchanged), so it
+;;                   cannot by itself detect value-coercion;
+;;   accentKind    — carries a KEYWORD; `attr-val` DOES stringify keywords (via
+;;                   `name`), so this accessor is the oracle that reddens when the
+;;                   declared-property VALUE is routed through attr-val.
 ;;
-;; The property name is declared through `Object.defineProperty` with a STRING key,
-;; NOT an unquoted class accessor: under `:advanced` Closure would rename an
-;; unquoted `accentPayload` accessor, so `"accentPayload" in el` (the exact string
-;; the emitter puts in the props object) would then MISS and React would fall to
-;; the attribute. A real web component's property name is a stable string; this
-;; models that faithfully, so the fixture proves the emitter's key matches a
-;; genuinely-named DOM property rather than an artefact of the same build's
-;; renaming. Defined once at ns-load and guarded off the non-DOM host.
+;; Both names are HYPHENATED at the author boundary (`:accent-payload`,
+;; `:accent-kind`) precisely so the classification is OBSERVABLE — the camelCase
+;; property spelling differs from the verbatim kebab attribute spelling; a
+;; single-word name would be indistinguishable.
+;;
+;; The property names are declared through `Object.defineProperty` with STRING
+;; keys, NOT unquoted class accessors: under `:advanced` Closure would rename an
+;; unquoted accessor, so `"accentPayload" in el` (the exact string the emitter puts
+;; in the props object) would then MISS and React would fall to the attribute. A
+;; real web component's property name is a stable string; this models that
+;; faithfully, so the fixture proves the emitter's key matches a genuinely-named
+;; DOM property rather than an artefact of the same build's renaming. Defined once
+;; at ns-load and guarded off the non-DOM host.
 (when (and (exists? js/customElements)
            (not (js/customElements.get "ce-prop-probe")))
-  (let [ctor (js* "(class extends HTMLElement {})")]
-    ;; STRING-keyed descriptor (js-obj) so `:advanced` cannot rename the accessor
-    ;; name or the descriptor keys — the property is genuinely "accentPayload".
+  (let [ctor  (js* "(class extends HTMLElement {})")
+        proto (unchecked-get ctor "prototype")]
+    ;; STRING-keyed descriptors (js-obj) so `:advanced` cannot rename the accessor
+    ;; names or the descriptor keys — the properties are genuinely "accentPayload"
+    ;; and "accentKind".
     (js/Object.defineProperty
-     (unchecked-get ctor "prototype") "accentPayload"
+     proto "accentPayload"
      (js-obj "configurable" true
              "get" (fn [] (this-as this (unchecked-get this "__ap")))
              "set" (fn [v] (this-as this (unchecked-set this "__ap" v)))))
+    (js/Object.defineProperty
+     proto "accentKind"
+     (js-obj "configurable" true
+             "get" (fn [] (this-as this (unchecked-get this "__ak")))
+             "set" (fn [v] (this-as this (unchecked-set this "__ak" v)))))
     (js/customElements.define "ce-prop-probe" ctor)))
 
-(ui/custom-element :ce-prop-probe {:properties #{:accent-payload}})
+(ui/custom-element :ce-prop-probe {:properties #{:accent-payload :accent-kind}})
 
-;; A non-string, non-scalar value referenced as a VAR (so the emit exercises the
-;; DYNAMIC `:property` branch — `(= kind :property) value`, the "properties pass
-;; through" line — not the literal branch). An object also cannot survive an
-;; attribute round-trip intact, so identity-equality is a crisp raw-passthrough
-;; proof: neither renamed by `:advanced` nor stringified through `attr-val`.
-(def ^:private probe-payload #js {:probe "custom-element-property-passthrough"})
+;; Both values are referenced as VARS (so the emit exercises the DYNAMIC
+;; `:property` branch — `(= kind :property) value`, the "properties pass through"
+;; line — not the compile-time literal branch, which would fold a literal keyword
+;; to a string before it ever reaches the property).
+;;
+;; probe-payload is a non-string, non-scalar OBJECT: identity pins the property KEY
+;;   and non-reflection, but an object is UNCHANGED by attr-val, so it cannot see a
+;;   value-coercion mutation.
+;; probe-accent-kind is a KEYWORD — the value class attr-val actually rewrites
+;;   (`(name :spilled-ink)` -> "spilled-ink"). Routing the declared property through
+;;   attr-val would deliver that STRING; raw passthrough delivers the exact keyword.
+;;   This is the oracle for acceptance-criterion 1.
+(def ^:private probe-payload    #js {:probe "custom-element-property-passthrough"})
+(def ^:private probe-accent-kind :spilled-ink)
 
 (defview prop-probe-host []
-  ;; :accent-payload is DECLARED -> camelCase JS PROPERTY (accentPayload),
-  ;;   value passes through RAW;
-  ;; :label is NOT declared        -> attribute (the all-attributes default).
-  [:ce-prop-probe {:accent-payload probe-payload :label "ride-as-attr"}])
+  ;; :accent-payload / :accent-kind are DECLARED -> camelCase JS PROPERTIES
+  ;;   (accentPayload / accentKind), values pass through RAW;
+  ;; :label is NOT declared                       -> attribute (the all-attributes default).
+  [:ce-prop-probe {:accent-payload probe-payload
+                   :accent-kind    probe-accent-kind
+                   :label          "ride-as-attr"}])
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -124,12 +156,24 @@
                    ;; string the emitter also emitted — the exact interop contract.
                    (is (identical? probe-payload (unchecked-get el "accentPayload"))
                        (str "the declared property landed as the camelCase JS property carrying the "
-                            "EXACT object reference — the emitted string key matched `in el`, the "
-                            "value was NOT coerced through attr-val"))
+                            "EXACT object reference — the emitted string key matched `in el`"))
                    (is (nil? (.getAttribute el "accent-payload"))
                        "a declared property is NOT reflected as the kebab attribute")
                    (is (nil? (.getAttribute el "accentpayload"))
                        "nor as any attribute spelling — it is a PROPERTY, not markup"))
+                 (testing "declared :accent-kind carries a KEYWORD RAW — attr-val coercion is not applied"
+                   ;; The RAW-passthrough oracle: attr-val stringifies keywords, so
+                   ;; if the declared-property branch routed the value through
+                   ;; attr-val the property would hold the STRING "spilled-ink".
+                   ;; Raw passthrough delivers the exact keyword object.
+                   (let [got (unchecked-get el "accentKind")]
+                     (is (keyword? got)
+                         (str "the keyword-valued property is a RAW keyword, NOT the string "
+                              "attr-val would produce via `name`"))
+                     (is (= probe-accent-kind got)
+                         "the EXACT keyword reached the property — no attr-val name-coercion"))
+                   (is (nil? (.getAttribute el "accent-kind"))
+                       "the keyword property is NOT reflected as the kebab attribute"))
                  (testing "undeclared names ride as ATTRIBUTES (the all-attributes default)"
                    (is (= "ride-as-attr" (.getAttribute el "label")))
                    (is (nil? (unchecked-get el "label"))


### PR DESCRIPTION
Strengthens the advanced custom-element property fixture (`custom_element_property_elision_prod_test.cljs`) so it actually proves RAW property passthrough under `:advanced`. Follows gvcnu (#6578).

## Why

#6578's fixture advertised a raw-value oracle that was false-green. It passed a JS object and asserted identity, but `re-frame.ui.runtime/attr-val` leaves every non-keyword/non-symbol value unchanged. Mutating `emit_cljs`'s declared-property branch from raw `value` to `(attr-val value)` therefore left the object identical and all assertions green — the fixture could not detect value-coercion (per bead rf2-tu2cg, discovered by the #6578 audit rf2-vpecw).

## What

- Adds a second declared property `:accent-kind` carrying a **keyword** via a var (so it exercises the dynamic `:property` branch, `(= kind :property) value`, not the compile-time literal-keyword fold).
- Backs it with a string-keyed `accentKind` accessor on the `ce-prop-probe` element (pure store/return, no attribute reflection), the same `:advanced`-safe modelling as `accentPayload`.
- Asserts the exact keyword reaches the property (`keyword?` + `=`) — the value class `attr-val` actually rewrites (`name` → `"spilled-ink"`), so routing through `attr-val` reddens.
- Keeps the existing camelCase-key, object-identity, non-reflection, and undeclared-attribute controls untouched.
- Corrects the docstring's misleading claim that `attr-val` would stringify the object onto an attribute (React still chooses the property because the accessor exists; the object is simply a no-op under `attr-val`).

Fixture-only — no product-code branch, harness, or matrix added.

## Quality gates

Run to completion, foreground, unpiped (exit codes captured by redirect):

- `cd implementation/ui && clojure -M:test` → **PASS** (1009 tests / 19901 assertions, 0 failures)
- `npm run test:cljs` → **PASS** (10337 tests / 51082 assertions, 0 failures)
- `npm run test:browser-prod-elision` → **PASS** (114 tests / 495 assertions, 0 failures)

Red-meaningful proof (advanced Chromium bundle):
- raw passthrough (main) → **GREEN** (495 assertions)
- mutate declared-property branch to `(attr-val value)`, rebuild → **RED**: exactly the two new `accentKind` assertions fail (`(not (keyword? "spilled-ink"))`), while the `accentPayload` object-identity check stays green — reproducing the documented false-green
- revert → **GREEN** again

`test:elision` not run: the emitter was not changed (mutation reverted; product code clean). gvcnu / 55zsd fixtures ran green inside the same 114-test browser suite (no regression).