### PR TITLE
fix(ui): honest view-cause attribution — fence/local-state/preserve (rf2-bvqu0 rf2-sy536 rf2-eww3k)

### DIFF
--- a/implementation/ui/src/re_frame/ui/hooks.cljc
+++ b/implementation/ui/src/re_frame/ui/hooks.cljc
@@ -62,73 +62,67 @@
         "committed handler or an (effect …), never in the render body")
    {:extra {:reason :render-phase-local-mutation}}))
 
-(defn- note-committed-local-change!
-  "DEBUG-only :local-state attribution gate (Ruling 2 + rf2-qkq2k fix). Records
-  `:local-state` on `cell` ONLY when the write is an ACTUALLY-COMMITTED value
-  change — `cur` (the LIVE host state React itself compares) differs from `nv` by
-  `Object.is`, React's own bail law. React 19.2 Object.is-BAILS a no-op setter
-  WITHOUT rendering, so noting on invocation left a stale marker that contaminated
-  a LATER unrelated commit; aligning on the same `Object.is` React uses makes the
-  note fire EXACTLY when a re-render (hence a connected commit) will. Runs inside
-  the react-set functional updater (the one place the live `cur` is authoritative,
-  correct even for chained same-turn writes); `note-local-state!` is an idempotent
-  stash that triggers no re-render, so a StrictMode double-invoke is harmless.
-  Returns `nv` (so the updater's value is unchanged)."
-  [cell cur nv]
-  (when-not ^boolean (js/Object.is cur nv)
-    (reactive/note-local-state! cell))
-  nv)
-
 (defn local-state
   "React `useState`-backed `[value set! update!]`. `set!` stores its argument
   exactly (a stored fn is a value, never an updater); `update!` applies
   `(f current & args)` to the LATEST host state so several same-turn writers
   compose (React's functional updater queues them against the live state).
 
-  DEV-only view-evidence bridge (Ruling 2 :local-state): a host-only
-  `set!`/`update!` records `:local-state` as the cause of the re-render it
-  triggers, so the ViewCell's NEXT connected commit attributes its
-  :rf.view/causes to the local write — but ONLY when the write is an
-  actually-committed value change (`note-committed-local-change!`): React 19.2
-  Object.is-bails a no-op setter without rendering, so noting on every invocation
-  contaminated a later unrelated commit (rf2-qkq2k). The owning cell is captured
-  ONCE at setter-mint time (the first render, which runs inside the ambient
-  `with-capture`); React — not the ViewCell scheduler — owns the re-render, so the
-  bridge only STASHES the cause (`reactive/note-local-state!`), never marks the
-  cell dirty or advances a revision. The whole bridge is `goog.DEBUG`-gated at
-  both ends and elides in production."
+  DEV-only view-evidence bridge (Ruling 2 :local-state): a host-only write is the
+  cause of the re-render it triggers, so the ViewCell's connected commit attributes
+  its :rf.view/causes to the local write — but ONLY when React ACTUALLY commits the
+  change (rf2-bvqu0). The state updater is PURE (it never touches the evidence
+  stash); the attribution instead rides a DEBUG `useLayoutEffect` keyed on the
+  COMMITTED value. Because a layout effect runs ONLY in the commit phase, a no-op
+  setter and a same-batch net-zero `0->1->0` — which React bails WITHOUT committing
+  — never reach it and never stash a marker (the stale-marker contamination the old
+  per-updater Object.is note left behind, rf2-qkq2k/rf2-bvqu0). A committed-value
+  ref skips the mount run (that commit is :mount, not :local-state) and makes a
+  StrictMode effect replay idempotent. The effect runs BEFORE the ViewCell's own
+  commit effect (same fiber, earlier hook slot), so `note-local-state!`'s flag is
+  set in time for that commit's record. React — not the ViewCell scheduler — owns
+  the re-render, so the bridge only sets the flag, never marks the cell dirty. The
+  whole bridge is `goog.DEBUG`-gated at both ends (and `goog.DEBUG` is
+  build-constant, so the hook order is stable within a build) and elides in
+  production."
   [init]
   (let [pair      (react/useState init)
         value     (aget pair 0)
         react-set (aget pair 1)
         ops       (react/useRef nil)]
+    ;; DEBUG-only committed-change attribution (rf2-bvqu0). The whole block — its
+    ;; useRef + useLayoutEffect included — DCEs in production; goog.DEBUG is
+    ;; build-constant, so the hook order is stable for every render of a build.
+    (when ^boolean js/goog.DEBUG
+      (let [cell      (reactive/ambient-cell)   ;; the owning cell (read during render)
+            committed (react/useRef init)]      ;; the last COMMITTED value observed
+        (react/useLayoutEffect
+         (fn note-committed-local-change []
+           ;; Runs only in a real commit phase. `#js [value]` limits it to a
+           ;; committed value CHANGE (+ the mount run, which the ref then skips).
+           (when-not ^boolean (js/Object.is (.-current committed) value)
+             (set! (.-current committed) value)
+             (reactive/note-local-state! cell))
+           js/undefined)
+         #js [value])))
     ;; The React setter identity is stable across renders, so set!/update! are
     ;; minted once and kept stable (attach them as handlers/listeners freely).
     (when (nil? (.-current ops))
-      (let [cell    (when ^boolean js/goog.DEBUG (reactive/ambient-cell))
-            setter  (fn local-set!
+      (let [setter  (fn local-set!
                       [v]
                       (when ^boolean js/goog.DEBUG
                         (when (.-v render-active) (fail-render-phase!)))
                       ;; ALWAYS the functional form: a stored fn is returned
-                      ;; verbatim, never invoked as a React updater. The DEBUG
-                      ;; :local-state note rides INSIDE the updater so it sees the
-                      ;; live `cur` React compares — fired ONLY on a real change
-                      ;; (rf2-qkq2k); production DCEs to `(fn [_] v)`.
-                      (react-set (fn [cur]
-                                   (if ^boolean js/goog.DEBUG
-                                     (note-committed-local-change! cell cur v)
-                                     v)))
+                      ;; verbatim, never invoked as a React updater. The updater is
+                      ;; PURE — :local-state attribution rides the committed-value
+                      ;; layout effect above, not this updater (rf2-bvqu0).
+                      (react-set (fn [_] v))
                       nil)
             updater (fn local-update!
                       [f & args]
                       (when ^boolean js/goog.DEBUG
                         (when (.-v render-active) (fail-render-phase!)))
-                      (react-set (fn [cur]
-                                   (let [nv (apply f cur args)]
-                                     (if ^boolean js/goog.DEBUG
-                                       (note-committed-local-change! cell cur nv)
-                                       nv))))
+                      (react-set (fn [cur] (apply f cur args)))
                       nil)]
         (set! (.-current ops) #js [setter updater])))
     [value (aget (.-current ops) 0) (aget (.-current ops) 1)]))

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -572,20 +572,24 @@
   ;;                             ;   in production (elided) + between flushes
   ;;    :listeners {k -> fn}     ; useSyncExternalStore subscribers
   ;;    :intervals [interval]     ; lifecycle facts (dev/tool; 03 §4)
-  ;;    :pending-commit-causes {kind -> detail} ; DEBUG-only commit-cause map,
-  ;;                             ;   keyed by S6 cause kind
-  ;;                             ;   (:subscription/:hmr/:disposed/:local-state)
-  ;;                             ;   -> its ruled detail (subscription carries
-  ;;                             ;   target/query/frame-id + version from->to +
-  ;;                             ;   epoch; the rest are {}), accumulated since the
-  ;;                             ;   last connected commit — captured at the cause
-  ;;                             ;   SITE (`note-commit-cause` in `enrol-dirty-window!`
-  ;;                             ;   for port notes; the hooks local-state bridge
-  ;;                             ;   `note-local-state!`). The NEXT connected commit
-  ;;                             ;   PROJECTS them into the :rf.view/causes record
-  ;;                             ;   vector and clears the slot (atomic take/publish).
-  ;;                             ;   ABSENT in production (elided) and whenever no
-  ;;                             ;   cause is pending (Ruling 2, reworked rf2-qkq2k)
+  ;;    :pending-commit-causes [{:cause kind …detail} …] ; DEBUG-only APPEND-ONLY
+  ;;                             ;   vector of PORT folds (:subscription/:hmr/
+  ;;                             ;   :disposed), one distinct entry per move, captured
+  ;;                             ;   at the cause SITE (`note-commit-cause` in
+  ;;                             ;   `enrol-dirty-window!`). A subscription entry
+  ;;                             ;   carries target/query/frame-id + version from->to
+  ;;                             ;   + epoch; the rest are bare. A connected commit
+  ;;                             ;   drains only entries AT/BEFORE the render's
+  ;;                             ;   captured :cause-waterline into :rf.view/causes
+  ;;                             ;   (coalesced per identity) and keeps the residual
+  ;;                             ;   (later folds) for the next commit (rf2-eww3k /
+  ;;                             ;   rf2-sy536, atomic take/publish). ABSENT in
+  ;;                             ;   production (elided) and when no fold is pending
+  ;;    :local-state-committed? bool ; DEBUG-only COMMIT-TIME flag: a substrate local
+  ;;                             ;   write React actually committed (`note-local-state!`).
+  ;;                             ;   Read + cleared by the next connected commit as the
+  ;;                             ;   :local-state cause (NOT waterline-fenced — it is a
+  ;;                             ;   commit-time fact). ABSENT in production + when unset
   ;;    :commit-record {…}|nil}  ; DEBUG-only S6 committed-instance record from
   ;;                             ;   the most-recent CONNECTED commit (Ruling 1/2;
   ;;                             ;   integer render-key + per-observation
@@ -1072,7 +1076,15 @@
   (rf2-vxgfnd.174); on CLJS this is a passthrough (the module holder owns the
   synchronous pass), so the hot path allocates nothing extra."
   [^ViewCell cell thunk]
-  (let [cap (volatile! (fresh-capture (:generation @(state cell))))]
+  (let [s0  @(state cell)
+        ;; DEBUG-only cause WATERLINE (rf2-eww3k): the count of pending port folds
+        ;; at the instant this render begins. The commit drains only folds at/before
+        ;; it, so a fold arriving after this render (a movement that drove no
+        ;; already-rendered commit) is fenced to the render it actually drove. DCE'd
+        ;; whole in production (`interop/debug-enabled?` is build-constant).
+        cap (volatile! (cond-> (fresh-capture (:generation s0))
+                         interop/debug-enabled?
+                         (assoc :cause-waterline (count (:pending-commit-causes s0)))))]
     (binding [*ambient* {:cell cell :capture cap :owner (capture-owner)}]
       #?(:clj  (with-slice-memo (fn [] (let [el (thunk)] [el @cap])))
          :cljs (let [el (thunk)] [el @cap])))))
@@ -1436,11 +1448,18 @@
 ;;                    read straight off the `:subscription` port-note axes (:target,
 ;;                    :node-key, :node-version, :frame-epoch). `:from` is the
 ;;                    version before the movement (the port advances it by one per
-;;                    move); a coalesced window keeps the EARLIEST :from and the
-;;                    LATEST :to so the record spans the whole movement honestly.
+;;                    move); repeated moves of the SAME target coalesce at DRAIN to
+;;                    one record keeping the EARLIEST :from and the LATEST :to/:epoch
+;;                    so it spans the whole movement honestly, while two DISTINCT
+;;                    targets stay two records (rf2-sy536).
 ;;   - :hmr / :disposed  bare markers — no ruled detail.
-;; :story-override (identity + version) and :mount are classified at commit time
-;; from lifecycle/override facts (see `commit-causes`), not from a port note.
+;; Folds are held as an APPEND-ONLY vector (each move a distinct entry); the drain
+;; is FENCED by a render waterline captured with the immutable render capture, so a
+;; fold arriving after that render (including one racing the publish barrier) is
+;; kept for the next render rather than back-attributed here (rf2-eww3k).
+;; :story-override (identity + version) and :mount and :local-state are classified
+;; at commit time from lifecycle/override/host-write facts (see `commit-causes`),
+;; not from the pending port-fold vector.
 ;; The whole plane is DEBUG-only (production-erased, G-7/G-11).
 ;; ---------------------------------------------------------------------------
 
@@ -1463,25 +1482,25 @@
     :disposed     [:disposed {}]
     nil))
 
-(defn- merge-commit-cause
-  "Merge a captured `[kind detail]` into the carry-forward `:pending-commit-causes`
-  map (`m`, nil = empty). Last-writer-wins per kind, EXCEPT a subscription keeps
-  the EARLIEST `:from` so a coalesced window spans first-from -> latest-to."
-  [m kind detail]
-  (let [m (or m {})]
-    (if-some [prior (get m kind)]
-      (assoc m kind (cond-> detail
-                      (contains? prior :from)
-                      (assoc :from (or (:from prior) (:from detail)))))
-      (assoc m kind detail))))
+(defn- fold-commit-cause
+  "Append a captured `[kind detail]` port fold to the append-only
+  `:pending-commit-causes` vector (`v`, nil = empty) as a DISTINCT entry
+  `{:cause kind …ruled-detail}`. Coalescing per causal identity and the
+  render-waterline FENCE both happen at DRAIN time (`mint-commit-record!`), never
+  here — so a fold is never retroactively merged into a cause an earlier render
+  already captured (rf2-eww3k), and two distinct targets never collapse into one
+  fabricated cross-target span (rf2-sy536)."
+  [v kind detail]
+  (conj (or v []) (assoc detail :cause kind)))
 
 (defn- note-commit-cause
-  "Fold `payload`'s ruled commit-cause detail into `s`'s `:pending-commit-causes`.
-  Pure state transition (the DEBUG arm of the ONE linearizable enrolment swap);
-  a payload with no commit cause leaves `s` untouched."
+  "Fold `payload`'s ruled commit-cause detail onto `s`'s append-only
+  `:pending-commit-causes` vector. Pure state transition (the DEBUG arm of the ONE
+  linearizable enrolment swap); a payload with no commit cause leaves `s`
+  untouched."
   [s payload]
   (if-some [[kind detail] (commit-cause-fact payload)]
-    (update s :pending-commit-causes merge-commit-cause kind detail)
+    (update s :pending-commit-causes fold-commit-cause kind detail)
     s))
 
 (defonce ^:private evidence-sink
@@ -3306,25 +3325,29 @@
 
 (defn note-local-state!
   "DEBUG-only bridge (Ruling 2 :local-state): the substrate-owned local writer
-  (`re-frame.ui.hooks` `local-state` `set!`/`update!`) records that a host-only
-  local mutation drove `cell`'s next re-render. React (not the ViewCell
-  scheduler) owns that re-render, so there is no flush to carry the cause through
-  the pending window — the writer stashes `:local-state` DIRECTLY into the
-  carry-forward slot the next connected commit projects into :rf.view/causes
-  (`:local-state` carries no ruled detail, so its record is a bare marker).
+  (`re-frame.ui.hooks` `local-state`) records that a host-only local mutation drove
+  `cell`'s re-render. React (not the ViewCell scheduler) owns that re-render, so
+  there is no pending-window flush to carry the cause — and, unlike a port fold,
+  the write is confirmed only at COMMIT time (post-render), so it is NOT a
+  render-fenced pending fold. The writer instead sets the commit-time
+  `:local-state-committed?` FLAG, which `mint-commit-record!` reads (like
+  `mounting?`) and clears for THIS commit's :rf.view/causes (`:local-state` carries
+  no ruled detail, so its record is a bare marker). Being a commit-time flag rather
+  than a pre-render fold is what keeps it eligible for the very commit whose layout
+  phase confirms it, immune to the eww3k render-waterline fence (rf2-eww3k).
 
-  The CALLER gates this on an actually-committed value change (`re-frame.ui.hooks`
-  `note-committed-local-change!`): React 19.2 Object.is-BAILS a no-op setter
-  without rendering, so stashing on every setter invocation would leave a stale
-  marker that contaminates a LATER unrelated commit (rf2-qkq2k). This fn therefore
-  only ever runs for a write React will actually commit.
+  The CALLER (`re-frame.ui.hooks`) fires this only for an ACTUALLY-COMMITTED value
+  change: React 19.2 bails a no-op setter (and a same-batch net-zero `0->1->0`)
+  WITHOUT committing, so noting on every setter invocation left a stale marker that
+  contaminated a LATER unrelated commit (rf2-qkq2k / rf2-bvqu0). Setting the same
+  boolean flag twice is idempotent, so a StrictMode replay is harmless.
 
   No-op on a nil cell (a `local` used outside a live capture) and elided whole in
   production. Never marks the cell dirty or advances a revision — React already
   re-renders, so double-scheduling is deliberately avoided. Returns nil."
   [^ViewCell cell]
   (when (and interop/debug-enabled? (some? cell))
-    (swap! (state cell) update :pending-commit-causes merge-commit-cause :local-state {}))
+    (swap! (state cell) assoc :local-state-committed? true))
   nil)
 
 (def ^:private ^:const cause-order
@@ -3350,6 +3373,23 @@
   `:foreign-or-react` is the standalone honesty fallback (not in the order)."
   [:mount :story-override :subscription :local-state :hmr :disposed])
 
+(defn- coalesce-kinds
+  "Coalesce the drained fold vector `eligible` into ONE record per cause kind
+  (`{kind -> record}`): last-writer-wins per kind, EXCEPT a `:subscription` keeps
+  the EARLIEST `:from` so a same-target window spans first-from -> latest-to. Each
+  fold already carries its `:cause`. (rf2-sy536 makes this identity-aware so two
+  DISTINCT targets stay two records rather than collapsing.)"
+  [eligible]
+  (reduce (fn [m entry]
+            (let [kind (:cause entry)]
+              (if-some [prior (get m kind)]
+                (assoc m kind (cond-> entry
+                                (contains? prior :from)
+                                (assoc :from (or (:from prior) (:from entry)))))
+                (assoc m kind entry))))
+          {}
+          eligible))
+
 (defn- commit-causes
   "Project THIS connected commit's :rf.view/causes vector — a vector of DETAILED
   cause RECORDS (Ruling 2, reworked rf2-qkq2k), each `{:cause <kind> …ruled-fields}`
@@ -3361,10 +3401,14 @@
                       static Story override; carries the ruled identity + version
                       (`:override-id` / `:version`). Classification, not
                       reconstruction.
-    - :subscription / :hmr / :disposed / :local-state
-                      captured at their cause site into `:pending-commit-causes`
-                      (`note-commit-cause` at the port note; `note-local-state!`
-                      for the local writer). :subscription carries its ruled
+    - :local-state    `local-state?` — the commit-time host-write flag set by the
+                      substrate local writer (`note-local-state!`), confirmed only
+                      at commit (post-render), so it is a COMMIT-TIME fact, not a
+                      render-fenced pending fold. Bare marker.
+    - :subscription / :hmr / :disposed
+                      captured at their cause site into the render-fenced
+                      `:pending-commit-causes` vector (`note-commit-cause` at the
+                      port note). :subscription carries its ruled
                       target/query/frame-id + version :from->:to + :epoch detail;
                       the rest are bare markers.
     - :foreign-or-react
@@ -3372,18 +3416,17 @@
                       (a foreign React re-render, or a headless value move caught at
                       commit step 5 with no evidence window). Never has detail.
 
-  `present` is a MAP {kind -> ruled-detail}; each kind projects to a record in
-  `cause-order`. `:hmr-remount` / `:epoch-restore` are deferred (see `cause-order`)
-  and never appear. Empty is impossible: the fallback always yields one record."
-  [pending mounting? override-detail]
-  (let [present (cond-> (or pending {})
-                  mounting?       (assoc :mount {})
-                  override-detail (assoc :story-override override-detail))
-        ordered (into []
-                      (keep (fn [kind]
-                              (when-some [detail (get present kind)]
-                                (assoc detail :cause kind))))
-                      cause-order)]
+  `eligible` is the render-fenced fold vector (rf2-eww3k); each kind projects to a
+  record in `cause-order`. `:hmr-remount` / `:epoch-restore` are deferred (see
+  `cause-order`) and never appear. Empty is impossible: the fallback always yields
+  one record."
+  [eligible mounting? override-detail local-state?]
+  (let [present (cond-> (coalesce-kinds eligible)
+                  mounting?       (assoc :mount {:cause :mount})
+                  override-detail (assoc :story-override
+                                         (assoc override-detail :cause :story-override))
+                  local-state?    (assoc :local-state {:cause :local-state}))
+        ordered (into [] (keep present) cause-order)]
     (if (seq ordered)
       ordered
       [{:cause :foreign-or-react}])))
@@ -3394,12 +3437,15 @@
   `*completion-barrier*` idiom). Bound to a `(fn [cell] …)`,
   `mint-commit-record!` calls it at the ONE deterministic point BETWEEN reading
   `:pending-commit-causes` and the `compare-and-set!` that publishes the record +
-  clears the stash, so a fixture can interleave a concurrent cause fold
+  advances the stash, so a fixture can interleave a concurrent cause fold
   (`enrol-dirty!` / `note-local-state!`) INSIDE the take->publish window and prove
-  the racing cause is never erased (rf2-qkq2k). Because publication is a
+  the racing cause is never LOST (rf2-qkq2k). Because publication is a
   compare-and-set! RETRY loop, a fold landing in the barrier window fails the CAS
-  and the mint re-reads — INCLUDING the freshly-folded cause rather than losing
-  it to the old unconditional `dissoc`."
+  and the mint re-reads over the fresh state. What that fold then does is decided
+  by the eww3k WATERLINE, not erased: a PORT fold (subscription/hmr/disposed) lands
+  ABOVE the render waterline, so it is FENCED into the residual stash and drives
+  the next commit (rf2-eww3k); the commit-time `:local-state` FLAG is read fresh
+  and belongs to THIS commit. Neither is dropped by an unconditional clear."
   nil)
 
 (defn- mint-commit-record!
@@ -3415,17 +3461,24 @@
   :foreign-or-react. `mounting?` is the cell's PRE-connect lifecycle fact
   (`:fresh`), read by the caller before `connect!`. Returns the record.
 
+  RENDER-WATERLINE FENCE (rf2-eww3k). The pending-cause vector is drained only up
+  to the render's captured `:cause-waterline` (the fold count when THIS render
+  began); folds ABOVE it — a movement that drove no already-rendered commit,
+  including one racing in the publish barrier — stay in the residual stash and
+  drive the next commit rather than being back-attributed here.
+
   ATOMIC take/publish (rf2-qkq2k CAS fix). The stash read + record publish + stash
-  clear are ONE `compare-and-set!` over the value read at the top of the loop, so a
-  concurrent cause fold on the JVM host (a racing `enrol-dirty!` / `note-local-state!`
-  between the read and the clear) can no longer be erased by an unconditional
-  `dissoc`: a fold that commits BEFORE the CAS fails it (the loop re-reads and
-  INCLUDES the fresh cause), and one AFTER the clear enrols a fresh next stash.
-  `next-render-key!` is minted ONCE before the loop, so a retry never wastes a key.
-  Single-threaded CLJS runs exactly one iteration."
+  advance + `:local-state` flag clear are ONE `compare-and-set!` over the value read
+  at the top of the loop, so a concurrent cause fold on the JVM host (a racing
+  `enrol-dirty!` / `note-local-state!` between the read and the advance) can no
+  longer be LOST: a fold that commits BEFORE the CAS fails it (the loop re-reads,
+  fences it by the waterline, and keeps it as residual), and one AFTER enrols a
+  fresh next stash. `next-render-key!` is minted ONCE before the loop, so a retry
+  never wastes a key. Single-threaded CLJS runs exactly one iteration."
   [^ViewCell cell cap new-order new-by mounting? to-acquire]
   (let [st         (state cell)
         st0        @st
+        waterline  (:cause-waterline cap)
         override-detail (some (fn [sid]
                                 (let [t (:target (new-by sid))]
                                   (when (= :story-override (:kind t))
@@ -3439,11 +3492,18 @@
                     :connection    :connected
                     :observations  (project-observations new-order new-by)}]
     (loop []
-      (let [s      @st
-            causes (commit-causes (:pending-commit-causes s) mounting? override-detail)
-            record (assoc base :rf.view/causes causes)
-            next-s (-> (assoc s :commit-record record)
-                       (dissoc :pending-commit-causes))]
+      (let [s        @st
+            pending  (or (:pending-commit-causes s) [])
+            n        (count pending)
+            cut      (if (and waterline (< waterline n)) waterline n)
+            eligible (subvec pending 0 cut)
+            residual (subvec pending cut)
+            causes   (commit-causes eligible mounting? override-detail
+                                    (boolean (:local-state-committed? s)))
+            record   (assoc base :rf.view/causes causes)
+            next-s   (-> (assoc s :commit-record record)
+                         (assoc :pending-commit-causes residual)
+                         (dissoc :local-state-committed?))]
         (when-some [barrier *commit-publish-barrier*] (barrier cell))
         (if (compare-and-set! st s next-s)
           record

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -3373,34 +3373,52 @@
   `:foreign-or-react` is the standalone honesty fallback (not in the order)."
   [:mount :story-override :subscription :local-state :hmr :disposed])
 
-(defn- coalesce-kinds
-  "Coalesce the drained fold vector `eligible` into ONE record per cause kind
-  (`{kind -> record}`): last-writer-wins per kind, EXCEPT a `:subscription` keeps
-  the EARLIEST `:from` so a same-target window spans first-from -> latest-to. Each
-  fold already carries its `:cause`. (rf2-sy536 makes this identity-aware so two
-  DISTINCT targets stay two records rather than collapsing.)"
+(defn- cause-identity
+  "The coalescing identity of a pending port fold: a `:subscription` coalesces by
+  its observed TARGET (the upstream node identity, the `:target` axis); every other
+  kind collapses to one record per kind (rf2-sy536). Two subscriptions to DIFFERENT
+  targets have DIFFERENT identities, so they never merge into one fabricated span."
+  [entry]
+  (if (= :subscription (:cause entry))
+    [:subscription (:target entry)]
+    (:cause entry)))
+
+(defn- coalesce-pending
+  "Coalesce the drained fold vector `eligible` into one record per DISTINCT causal
+  identity, in first-appearance order (rf2-sy536). Repeated same-target
+  `:subscription` folds merge to one record spanning that target's EARLIEST `:from`
+  to its LATEST `:to`/`:epoch`; two DISTINCT targets stay two records and neither
+  disappears; bare markers collapse. It never fabricates a cross-target transition
+  by mixing one target's `:from` with another's `:to`."
   [eligible]
-  (reduce (fn [m entry]
-            (let [kind (:cause entry)]
-              (if-some [prior (get m kind)]
-                (assoc m kind (cond-> entry
-                                (contains? prior :from)
-                                (assoc :from (or (:from prior) (:from entry)))))
-                (assoc m kind entry))))
-          {}
-          eligible))
+  (let [{:keys [order by-id]}
+        (reduce (fn [acc entry]
+                  (let [id (cause-identity entry)]
+                    (if-some [prior (get (:by-id acc) id)]
+                      (assoc-in acc [:by-id id]
+                                (if (= :subscription (:cause entry))
+                                  (assoc entry :from (or (:from prior) (:from entry)))
+                                  entry))
+                      (-> acc
+                          (update :order conj id)
+                          (assoc-in [:by-id id] entry)))))
+                {:order [] :by-id {}}
+                eligible)]
+    (mapv by-id order)))
 
 (defn- commit-causes
   "Project THIS connected commit's :rf.view/causes vector — a vector of DETAILED
   cause RECORDS (Ruling 2, reworked rf2-qkq2k), each `{:cause <kind> …ruled-fields}`
-  — from signals that ALREADY exist, never a new capture machine:
+  — from signals that ALREADY exist, never a new capture machine. EP-0033 makes
+  causes a VECTOR because one commit can have several: two moved dependencies yield
+  two records, not one collapsed span (rf2-sy536).
 
     - :mount          `mounting?` — the cell's pre-commit lifecycle was :fresh
                       (the :fresh->:connected transition). Bare marker.
-    - :story-override `override-detail` — a (re)acquired site whose target is a
-                      static Story override; carries the ruled identity + version
-                      (`:override-id` / `:version`). Classification, not
-                      reconstruction.
+    - :story-override `override-details` — ONE ruled `{:override-id :version}` per
+                      (re)acquired site whose target is a static Story override;
+                      sibling overrides are each preserved (never `some`-dropped).
+                      Classification, not reconstruction.
     - :local-state    `local-state?` — the commit-time host-write flag set by the
                       substrate local writer (`note-local-state!`), confirmed only
                       at commit (post-render), so it is a COMMIT-TIME fact, not a
@@ -3408,25 +3426,27 @@
     - :subscription / :hmr / :disposed
                       captured at their cause site into the render-fenced
                       `:pending-commit-causes` vector (`note-commit-cause` at the
-                      port note). :subscription carries its ruled
-                      target/query/frame-id + version :from->:to + :epoch detail;
-                      the rest are bare markers.
+                      port note) and coalesced per identity. :subscription carries
+                      its ruled target/query/frame-id + version :from->:to + :epoch
+                      detail; the rest are bare markers.
     - :foreign-or-react
                       the honesty fallback — a commit that carries no other cause
                       (a foreign React re-render, or a headless value move caught at
                       commit step 5 with no evidence window). Never has detail.
 
-  `eligible` is the render-fenced fold vector (rf2-eww3k); each kind projects to a
-  record in `cause-order`. `:hmr-remount` / `:epoch-restore` are deferred (see
-  `cause-order`) and never appear. Empty is impossible: the fallback always yields
-  one record."
-  [eligible mounting? override-detail local-state?]
-  (let [present (cond-> (coalesce-kinds eligible)
-                  mounting?       (assoc :mount {:cause :mount})
-                  override-detail (assoc :story-override
-                                         (assoc override-detail :cause :story-override))
-                  local-state?    (assoc :local-state {:cause :local-state}))
-        ordered (into [] (keep present) cause-order)]
+  `eligible` is the render-fenced fold vector (rf2-eww3k). Records project in the
+  canonical `cause-order`; same-kind ordering is stable by first-appearance.
+  `:hmr-remount` / `:epoch-restore` are deferred (see `cause-order`) and never
+  appear. Empty is impossible: the fallback always yields one record."
+  [eligible mounting? override-details local-state?]
+  (let [folded  (coalesce-pending eligible)
+        by-kind (cond-> (group-by :cause folded)
+                  mounting?              (assoc :mount [{:cause :mount}])
+                  (seq override-details) (assoc :story-override
+                                                (mapv #(assoc % :cause :story-override)
+                                                      override-details))
+                  local-state?           (assoc :local-state [{:cause :local-state}]))
+        ordered (into [] (mapcat by-kind) cause-order)]
     (if (seq ordered)
       ordered
       [{:cause :foreign-or-react}])))
@@ -3479,12 +3499,15 @@
   (let [st         (state cell)
         st0        @st
         waterline  (:cause-waterline cap)
-        override-detail (some (fn [sid]
-                                (let [t (:target (new-by sid))]
-                                  (when (= :story-override (:kind t))
-                                    {:override-id (:override-id t)
-                                     :version     (:version t)})))
-                              to-acquire)
+        ;; ONE ruled record per (re)acquired Story-override target, in render order
+        ;; — `keep` preserves siblings that `some` (first-only) dropped (rf2-sy536).
+        override-details (into []
+                               (keep (fn [sid]
+                                       (let [t (:target (new-by sid))]
+                                         (when (= :story-override (:kind t))
+                                           {:override-id (:override-id t)
+                                            :version     (:version t)}))))
+                               to-acquire)
         base       {:render-key    (next-render-key!)
                     :view-id       (:view-id st0)
                     :generation    (:generation cap)
@@ -3498,7 +3521,7 @@
             cut      (if (and waterline (< waterline n)) waterline n)
             eligible (subvec pending 0 cut)
             residual (subvec pending cut)
-            causes   (commit-causes eligible mounting? override-detail
+            causes   (commit-causes eligible mounting? override-details
                                     (boolean (:local-state-committed? s)))
             record   (assoc base :rf.view/causes causes)
             next-s   (-> (assoc s :commit-record record)
@@ -3848,9 +3871,12 @@
   the view-evidence plane is elided. The per-commit record (Ruling 1/2; EP-0033
   §Two evidence layers): integer :render-key, :view-id, :generation, :root-id,
   :connection, a per-observation :observations vector, and the per-commit
-  :rf.view/causes vector (Ruling 2 — the nine ruled kinds projected from their
-  existing sources; `:epoch-restore` is not produced by slice b). There is
-  deliberately NO singular :frame-id (frame attribution is per-observation) and NO
+  :rf.view/causes vector (Ruling 2 — the SIX shipped kinds `:mount` /
+  `:story-override` / `:subscription` / `:local-state` / `:hmr` / `:disposed`
+  projected from their existing sources, plus the `:foreign-or-react` fallback; one
+  record per distinct causal identity, rf2-sy536). Both `:hmr-remount` and
+  `:epoch-restore` are DEFERRED and never produced by slice b. There is deliberately
+  NO singular :frame-id (frame attribution is per-observation) and NO
   :parent-render-key (deferred). Tool/test read."
   [^ViewCell cell]
   (:commit-record @(state cell)))

--- a/implementation/ui/test/re_frame/ui/hooks_local_state_cause_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/hooks_local_state_cause_cljs_test.cljs
@@ -1,26 +1,24 @@
 (ns re-frame.ui.hooks-local-state-cause-cljs-test
-  "rf2-qkq2k (S6 slice b, Fix #3) — the `:local-state` view-evidence cause is
-  attributed ONLY to an actually-committed value change. React 19.2 Object.is-BAILS
-  a no-op setter WITHOUT rendering, so the S3 bridge (which stashed on every setter
-  invocation) left a stale marker that contaminated a LATER unrelated commit. The
-  hooks setter now routes its DEBUG note through `note-committed-local-change!`,
-  which stashes ONLY when `cur` (the live host state React compares) differs from
-  the write by `Object.is` — React's own bail law — so the note fires EXACTLY when
-  a re-render (hence a connected commit) will.
+  "rf2-bvqu0 (S6 slice b) — node companion to the browser mount proof
+  (`hooks_local_state_commit_dom_cljs_test`). The `:local-state` view-evidence cause
+  is attributed ONLY after a REAL React commit. The hooks `local-state` updater is
+  now PURE; attribution rides a DEBUG committed-value `useLayoutEffect` that calls
+  `reactive/note-local-state!` exactly once per committed value change (a no-op
+  setter and a same-batch net-zero `0->1->0` are bailed by React WITHOUT committing,
+  so the layout effect never runs and nothing is stashed).
 
-  This is the node-runnable proof of the gate fn itself (the decision point the
-  react-set updater invokes) driven through a REAL committed ViewCell: a real
-  change → the commit reports :local-state; a no-op → nothing stashed → a later
-  unrelated commit stays clean. (react-dom mounting is browser-only in this repo;
-  the gate reuses React's exact `Object.is` law, so the mounted behaviour follows
-  by construction.) CLJS-only (`Object.is` is a host primitive); rides
-  `npm run test:cljs` (node)."
+  react-dom mounting is browser-only in this repo, so THIS file pins the
+  reactive-side flag contract the hook drives: a set flag contributes exactly one
+  :local-state cause to the next connected commit, and an UNSET flag (a bailed
+  write that never ran the layout effect) leaves a later unrelated commit clean.
+  The end-to-end MOUNTED behaviour — the actual `local` setter driving a real React
+  root — rides the sibling `-dom-cljs-test`. CLJS-only; rides `npm run test:cljs`
+  (node)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core                 :as rf]
             [re-frame.frame                :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support         :as test-support]
-            [re-frame.ui.hooks             :as hooks]
             [re-frame.ui.reactive          :as reactive]))
 
 (use-fixtures :each
@@ -31,11 +29,6 @@
 
 (def ^:private fid :rf/default)
 (defn- seed! [db] (frame/replace-app-db! fid db))
-
-;; the exact private gate the hooks local-state setter/updater invoke
-(def ^:private note-committed-local-change!
-  @#'hooks/note-committed-local-change!)
-
 (defn- cause-kinds [cell] (mapv :cause (:rf.view/causes (reactive/commit-record cell))))
 
 (defn- render+commit! [cell sites]
@@ -55,41 +48,40 @@
   (reactive/flush-pending!))
 
 ;; ===========================================================================
-;; A REAL change stashes -> the commit reports :local-state
+;; A committed local change (the layout effect fired) -> the commit is :local-state
 ;; ===========================================================================
 
-(deftest a-real-local-change-is-attributed
+(deftest a-committed-local-change-is-attributed
   (rf/reg-sub :ls/a (fn [db _] (:a db)))
   (seed! {:a 1})
   (let [cell (render+commit! (reactive/make-cell ::v) [[[:ls/site 0] [:ls/a]]])]
-    (is (= 2 (note-committed-local-change! cell 1 2))
-        "the gate returns the new value unchanged (the react-set updater's result)")
+    ;; the committed-value layout effect (fired for a real change) sets the flag
+    (reactive/note-local-state! cell)
     (render+commit! cell [[[:ls/site 0] [:ls/a]]])
     (is (= [:local-state] (cause-kinds cell))
-        "an Object.is-DIFFERENT write (a real change React commits) is :local-state")))
+        "a committed host-only write contributes exactly one :local-state cause")))
 
 ;; ===========================================================================
-;; A no-op setter stashes NOTHING -> a later unrelated commit stays clean
+;; No committed change (a bailed no-op / net-zero batch) -> a later commit is clean
 ;; ===========================================================================
 
-(deftest a-noop-setter-does-not-contaminate-a-later-unrelated-commit
+(deftest an-uncommitted-write-does-not-contaminate-a-later-unrelated-commit
   (rf/reg-sub :ls/a (fn [db _] (:a db)))
   (seed! {:a 1})
   (let [cell (render+commit! (reactive/make-cell ::v) [[[:ls/site 0] [:ls/a]]])]
-    (is (= 5 (note-committed-local-change! cell 5 5))
-        "an Object.is-EQUAL write returns the value but stashes nothing (React bails)")
-    (testing "a LATER unrelated (subscription) commit reports only its own cause"
+    ;; a no-op setter / net-zero batch never runs the committed-value layout effect,
+    ;; so NOTHING is stashed (the flag stays unset) — then an unrelated subscription
+    ;; movement drives the next commit
+    (testing "the unset flag leaves no marker for a later unrelated commit"
       (fan-value! cell [:ls/a])
       (render+commit! cell [[[:ls/site 0] [:ls/a]]])
       (is (= [:subscription] (cause-kinds cell))
-          "the stale no-op marker no longer contaminates an unrelated commit"))))
+          "no committed local change -> no stale :local-state on an unrelated commit"))))
 
 ;; ===========================================================================
-;; The gate is a no-op on a nil cell (a local used outside a live capture)
+;; note-local-state! is a no-op on a nil cell (a local used outside a live capture)
 ;; ===========================================================================
 
-(deftest the-gate-is-safe-on-a-nil-cell
-  (is (= 9 (note-committed-local-change! nil 8 9))
-      "a real change on a nil cell returns the value and never throws")
-  (is (= 8 (note-committed-local-change! nil 8 8))
-      "a no-op on a nil cell returns the value and never throws"))
+(deftest note-local-state-is-safe-on-a-nil-cell
+  (is (nil? (reactive/note-local-state! nil))
+      "a (local …) used outside a live capture stashes nothing and never throws"))

--- a/implementation/ui/test/re_frame/ui/hooks_local_state_commit_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/hooks_local_state_commit_dom_cljs_test.cljs
@@ -1,0 +1,133 @@
+(ns re-frame.ui.hooks-local-state-commit-dom-cljs-test
+  "rf2-bvqu0 — the MOUNTED proof that `:local-state` is attributed ONLY after a
+  REAL React commit, driven through the ACTUAL `re-frame.ui/local` setter on a real
+  React root (jsdom/browser), not a private comparison helper.
+
+  The hooks `local-state` updater is PURE; attribution rides a DEBUG committed-value
+  `useLayoutEffect`. Because a layout effect runs ONLY in the commit phase (and only
+  when the committed value changed), a REAL change contributes exactly one
+  :local-state cause to that connected commit, while a same-batch net-zero
+  `0->1->0` — which React bails WITHOUT committing — never runs the effect and so
+  leaves NO stale marker to contaminate a later unrelated (subscription) commit. A
+  StrictMode replay is idempotent by construction: the updater is pure and the
+  attribution is a boolean commit-time flag, so a doubled effect run cannot
+  duplicate or fabricate a cause.
+
+  The node companion (`hooks_local_state_cause_cljs_test`) pins the reactive-side
+  flag contract. `(browser?)`-gated so the node build runs it trivially; the real
+  assertions run under `npm run test:browser`."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview local]]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.test :as uit]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter ui/adapter
+    :ambient-frame nil
+    :async? true
+    :init-fn reactive/reset-scheduler!}))
+
+;; ---------------------------------------------------------------------------
+;; Harness helpers (mirroring local_effect_dispatch_fn_dom_cljs_test)
+;; ---------------------------------------------------------------------------
+
+(defn- host-turn! []
+  (js/Promise. (fn [resolve _] (js/setTimeout #(resolve nil) 0))))
+
+(defn- click! [el] (.dispatchEvent el (js/MouseEvent. "click" #js {:bubbles true})))
+
+(defn- make-frame [id db]
+  (rf/make-frame {:id id :initial-events [[:rf/set-db db]]}))
+
+;; The mounted view records its owning ViewCell so the test can read that cell's
+;; per-commit :rf.view/causes after each host turn.
+(defonce ^:private probe-cell (atom nil))
+
+(defview cause-probe []
+  (let [[n set-n] (local 0)
+        a         (ui/sub [::a])
+        _         (reset! probe-cell (reactive/ambient-cell))]
+    [:div
+     [:span {:data-role "n"} (str n)]
+     [:span {:data-role "a"} (str a)]
+     ;; a REAL committed change: 0 -> 1
+     [:button {:data-role "real"
+               :on-click (ui/event [_] (set-n (inc n)) nil)} "r"]
+     ;; a NET-ZERO batch in one turn: 0 -> 1 -> 0 (React bails, commits nothing)
+     [:button {:data-role "netzero"
+               :on-click (ui/event [_] (set-n 1) (set-n 0) nil)} "z"]]))
+
+(defn- causes-of []
+  (mapv :cause (:rf.view/causes (reactive/commit-record @probe-cell))))
+
+;; ===========================================================================
+;; A REAL committed local write -> the connected commit is exactly :local-state
+;; ===========================================================================
+
+(deftest a-real-committed-local-write-is-attributed-local-state
+  (if-not (browser?)
+    (is true ":node — browser gate runs the committed-local-write attribution")
+    (do
+      (rf/reg-sub ::a (fn [db _] (:a db)))
+      (reset! probe-cell nil)
+      (let [f (make-frame ::real {:a 1})]
+        (async done
+          (-> (uit/with-root [root [ui/frame-provider {:frame f} [cause-probe]]]
+                (-> (host-turn!)
+                    (.then
+                     (fn []
+                       (is (= [:mount] (causes-of)) "the first connected commit is :mount")
+                       (uit/flush! #(do (click! (uit/query root "[data-role='real']"))
+                                        (host-turn!)))))
+                    (.then
+                     (fn []
+                       (is (= "1" (.-textContent (uit/query root "[data-role='n']")))
+                           "the real local change committed to the DOM")
+                       (is (= [:local-state] (causes-of))
+                           "a committed host-only write is attributed exactly :local-state")))))
+              (.then (fn [] (rf/destroy-frame! f) (done))
+                     (fn [e] (rf/destroy-frame! f)
+                       (is false (str "real committed local write: " e)) (done)))))))))
+
+;; ===========================================================================
+;; A net-zero batch commits nothing -> no stale :local-state on a later commit
+;; ===========================================================================
+
+(deftest a-net-zero-local-batch-leaves-no-local-state-on-a-later-commit
+  (if-not (browser?)
+    (is true ":node — browser gate runs the net-zero contamination proof")
+    (do
+      (rf/reg-sub ::a (fn [db _] (:a db)))
+      (rf/reg-event ::set-a (fn [{:keys [db]} [_ v]] {:db (assoc db :a v)}))
+      (reset! probe-cell nil)
+      (let [f (make-frame ::nz {:a 1})]
+        (async done
+          (-> (uit/with-root [root [ui/frame-provider {:frame f} [cause-probe]]]
+                (-> (host-turn!)
+                    (.then
+                     (fn []
+                       ;; 0 -> 1 -> 0 in ONE turn: React bails, commits nothing.
+                       (uit/flush! #(do (click! (uit/query root "[data-role='netzero']"))
+                                        (host-turn!)))))
+                    (.then
+                     (fn []
+                       (is (= "0" (.-textContent (uit/query root "[data-role='n']")))
+                           "the net-zero batch committed nothing (DOM value unchanged)")
+                       ;; drive an UNRELATED subscription movement -> the next commit
+                       (uit/flush! #(uit/dispatch! f [::set-a 2]))))
+                    (.then (fn [] (host-turn!)))
+                    (.then
+                     (fn []
+                       (is (= "2" (.-textContent (uit/query root "[data-role='a']")))
+                           "the subscription actually moved (an unrelated commit ran)")
+                       (is (= [:subscription] (causes-of))
+                           "the bailed net-zero batch left NO stale :local-state marker")))))
+              (.then (fn [] (rf/destroy-frame! f) (done))
+                     (fn [e] (rf/destroy-frame! f)
+                       (is false (str "net-zero contamination: " e)) (done)))))))))

--- a/implementation/ui/test/re_frame/ui/reactive_commit_causes_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_commit_causes_cljs_test.cljc
@@ -293,6 +293,49 @@
         "the racing :local-state fold is INCLUDED in the published record, not erased")))
 
 ;; ===========================================================================
+;; eww3k (Fence): a SUBSCRIPTION folded during publication is FENCED to the
+;; correction commit it actually drove — NOT back-attributed to this record
+;; ===========================================================================
+
+(deftest a-subscription-folded-during-publication-is-fenced-to-its-own-commit
+  ;; rf2-eww3k: the render waterline fences a movement that drove NO already-rendered
+  ;; commit. A subscription 2->3 drives render N; a fresh 3->4 movement lands in the
+  ;; publish barrier (ABOVE the render's waterline). The current record must describe
+  ;; ONLY 2->3 (not a back-attributed 2->4), the cell must stay dirty, and the racing
+  ;; 3->4 must own the NEXT commit rather than falling back to :foreign-or-react.
+  ;; Deterministic on both hosts (single-threaded CLJS runs one CAS iteration).
+  (rf/reg-sub :cc/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell  (render+commit! (reactive/make-cell ::v) [[[:cc/site 0] [:cc/a]]])
+        fired (atom false)]
+    ;; 2->3 is pending and drives render N (fan-cause! flushes it forward)
+    (fan-cause! cell :subscription [:cc/a] {:node-key 7 :node-version 3 :epoch 1})
+    (binding [reactive/*commit-publish-barrier*
+              (fn [c]
+                (when (compare-and-set! fired false true)
+                  ;; a NEW movement 3->4 lands in the take->publish window — it drove
+                  ;; no already-rendered commit; it marks the cell dirty for a correction
+                  (enrol-dirty! c {:cause        :subscription
+                                   :target       {:kind :subscription :frame-id fid :query [:cc/a]}
+                                   :node-key     7
+                                   :node-version 4
+                                   :frame-epoch  2})))]
+      (render+commit! cell [[[:cc/site 0] [:cc/a]]]))
+    (is @fired "the publication barrier fired inside the take->publish window")
+    (testing "the record describes ONLY the movement its render saw (2->3), not 2->4"
+      (let [sub (cause-of cell :subscription)]
+        (is (= 2 (:from sub)) "the earliest :from of the render's own window")
+        (is (= 3 (:to sub))   "the barrier-time 3->4 is NOT back-attributed to this record")))
+    (testing "the racing 3->4 stayed pending and drives the correction commit"
+      (is (reactive/dirty? cell) "the barrier-time movement marked the cell dirty")
+      (reactive/flush-pending!)
+      (render+commit! cell [[[:cc/site 0] [:cc/a]]])
+      (let [sub (cause-of cell :subscription)]
+        (is (= 3 (:from sub)) "the correction commit owns the racing move")
+        (is (= 4 (:to sub))
+            "the fenced cause drives its own commit — never left as :foreign-or-react")))))
+
+;; ===========================================================================
 ;; Canonical order — the cause vector is deterministic across hosts/runs
 ;; ===========================================================================
 

--- a/implementation/ui/test/re_frame/ui/reactive_commit_causes_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_commit_causes_cljs_test.cljc
@@ -336,6 +336,48 @@
             "the fenced cause drives its own commit — never left as :foreign-or-react")))))
 
 ;; ===========================================================================
+;; sy536 (Preserve each cause) — distinct causal identities stay distinct
+;; ===========================================================================
+
+(deftest two-subscription-targets-yield-two-truthful-records
+  ;; rf2-sy536: two DIFFERENT targets moving before one commit must yield TWO
+  ;; :subscription records — neither disappears and NO record fabricates a
+  ;; cross-target span (one target's :from with another's :to).
+  (rf/reg-sub :cc/a (fn [db _] (:a db)))
+  (rf/reg-sub :cc/b (fn [db _] (:b db)))
+  (seed! {:a 1 :b 1})
+  (let [cell (reactive/make-cell ::v)]
+    (render+commit! cell [[[:cc/site 0] [:cc/a]] [[:cc/site 1] [:cc/b]]])
+    ;; node A (:node-key 7) moves 2->3; node B (:node-key 8) moves 20->21
+    (fan-cause! cell :subscription [:cc/a] {:node-key 7 :node-version 3  :epoch 1})
+    (fan-cause! cell :subscription [:cc/b] {:node-key 8 :node-version 21 :epoch 1})
+    (render+commit! cell [[[:cc/site 0] [:cc/a]] [[:cc/site 1] [:cc/b]]])
+    (let [subs (filterv #(= :subscription (:cause %)) (causes cell))]
+      (is (= 2 (count subs)) "two distinct targets -> two records; neither disappears")
+      (is (= {7 {:query [:cc/a] :from 2  :to 3}
+              8 {:query [:cc/b] :from 20 :to 21}}
+             (into {} (map (fn [s] [(:target s) (select-keys s [:query :from :to])])) subs))
+          "each record keeps ONLY its own target's identity + version span —
+           no cross-target :from/:to fabrication"))))
+
+(deftest sibling-story-overrides-each-retain-a-record
+  ;; rf2-sy536: two moved Story overrides in one commit retain one detailed record
+  ;; EACH — the old `some` over `to-acquire` dropped the sibling.
+  (rf/reg-sub :cc/a (fn [db _] (:a db)))
+  (rf/reg-sub :cc/b (fn [db _] (:b db)))
+  (seed! {:a 1 :b 1})
+  (let [cell (reactive/make-cell ::v)]
+    (binding [reactive/*sub-overrides* {[:cc/a] 10 [:cc/b] 30}]      ;; mount both overrides
+      (render+commit! cell [[[:cc/site 0] [:cc/a]] [[:cc/site 1] [:cc/b]]]))
+    (binding [reactive/*sub-overrides* {[:cc/a] 20 [:cc/b] 40}]      ;; move BOTH
+      (render+commit! cell [[[:cc/site 0] [:cc/a]] [[:cc/site 1] [:cc/b]]]))
+    (let [ovs (filterv #(= :story-override (:cause %)) (causes cell))]
+      (is (= 2 (count ovs)) "each moved override retains its own record (no sibling drop)")
+      (is (= {[:cc/a] 20 [:cc/b] 40}
+             (into {} (map (fn [o] [(:override-id o) (:version o)])) ovs))
+          "each record carries ONLY its own override's ruled identity + version"))))
+
+;; ===========================================================================
 ;; Canonical order — the cause vector is deterministic across hosts/runs
 ;; ===========================================================================
 


### PR DESCRIPTION
A same-surface cluster refining qkq2k's (#6577) per-commit `:rf.view/causes`
records — three honesty fixes to the detailed cause attribution in
`reactive.cljc` (+ `hooks.cljc` for local-state). Ruled fields only, no
fabricated attribution; the whole plane stays DEBUG-gated and production-erased.

## rf2-eww3k — Fence causes to the render they drove (P3)
`:pending-commit-causes` was a `{kind -> detail}` map that mint drained
wholesale, so a cause folded *after* a render's capture — including one racing
the publish barrier — was back-attributed to the already-rendered commit while
the correction commit it actually drove fell back to `:foreign-or-react`.
It is now an append-only vector; `with-capture` snapshots a DEBUG `:cause-waterline`
onto the immutable capture, and mint drains only folds at/before it, keeping later
folds as residual for the next commit. `:local-state` becomes a commit-time flag
(confirmed post-render), so it is not render-fenced.

## rf2-bvqu0 — Attribute :local-state only after a real React commit (P2)
The local-state note fired inside the react-set functional updater, gated on
`Object.is(cur,nv)` — which proves one queued step changes its input, not that the
batch commits. A same-batch net-zero `0->1->0` ran both updaters, committed
nothing, and left a stale marker that contaminated the next unrelated commit. The
updater is now PURE; attribution rides a DEBUG `useLayoutEffect` keyed on the
committed value (runs only in the commit phase, skips the mount run, idempotent
under StrictMode). `note-local-state!` sets the commit-time flag.

## rf2-sy536 — Preserve each detailed cause, no cross-target span (P2)
Pending detail coalesced every subscription movement under one `:subscription`
key, so two dependencies moving before one commit fabricated a record mixing one
target's `:from` with another's `:to` and dropped the first target; the same
one-per-kind assumption `some`-dropped sibling Story overrides. Coalescing is now
per distinct causal identity (`:subscription` keyed on `:target`), so distinct
targets stay distinct records; mint collects all override siblings with `keep`.
The `commit-record` docstring is truthed to the six shipped kinds + fallback,
both `:hmr-remount`/`:epoch-restore` deferred.

## Quality gates
All run to completion in the foreground on the final rebased tree:
- `clojure -M:test` (UI JVM): 1012 tests / 19913 assertions — 0 failures
- `npm run test:cljs` (node): 10342 tests / 51091 assertions — 0 failures
- `npm run test:browser` (Playwright): 508 tests / 2800 assertions — 0 failures
  (includes the new mounted bvqu0 proof driving the real `local` setter)
- `npm run test:elision`: production 60/60 absent, control 60/60 present — the
  cause plane is production-erased

Each bead is proven red->green: a subscription folded during publication is fenced
to its own commit (eww3k); a mounted net-zero batch leaves no `:local-state` on a
later commit while a real change is exactly `:local-state` (bvqu0); two distinct
subscription targets yield two truthful records and sibling overrides each retain a
record (sy536). Disjoint from the held work (5e8zv.6/j97yg analyze/spec-004,
tu2cg custom-element fixture — already merged); rebased onto current `origin/main`
(incl. ny34u's render-key stamp).