### PR TITLE
fix(ui/compiler): annotate host roots under common conditionals (rf2-hac8p)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -870,18 +870,45 @@
 
 (defn- mark-host-root-annotation
   "Stamp the view-evidence DOM-annotation marker onto the view's effective host
-  root — the DOM `:element` the compiler owns at the top of the render. The
+  root(s) — the DOM `:element`(s) the compiler owns at the top of the render. The
   UNCONDITIONAL wrappers (`:hook-prefix` effect prefix, an authored `:let` /
   `:letfn`) are transparent — the marker rides through to the element they wrap.
-  A non-element effective root (a fragment, another view/foreign component, or a
-  conditional / loop) is NOT a single compiler-owned host node, so it carries no
-  annotation — the same host-root exemption the adapter source-coord walk applies
-  to a non-DOM root. `emit-element` reads the marker off the plain element and
-  stamps the props behind the goog.DEBUG gate (see `annotate-host-root-props`)."
+
+  A COMMON CONDITIONAL root is narrowly DESCENDED so its concrete DOM arms are
+  tagged: `if` / `if-not` / `when` / `when-not` / `cond` (each an `:if`), `case`
+  (its clauses + default), and the if-let family (`if-let` / `when-let` /
+  `if-some` / `when-some`, which desugar to `:let` over `:if`). So a view rooted
+  at `(if loading? [:spinner] [:page])` tags whichever arm renders. Spec 006
+  exempts only the render that yields nil; a later concrete DOM output must be
+  tagged. The recursion RETAINS the per-branch host-root exemptions: a branch
+  that is nil (`:nothing`, e.g. a one-arm `when`'s absent else), a fragment,
+  another view/foreign component, or a loop (`:for`) is NOT a single
+  compiler-owned host node and carries no annotation — the same exemption the
+  adapter source-coord walk applies to a non-DOM root.
+
+  `emit-element` reads the marker off the plain element and stamps the props
+  behind the goog.DEBUG gate (see `annotate-host-root-props`). This walk is kept
+  byte-identical to `re-frame.ui.compiler.emit-jvm/mark-host-root-annotation`: a
+  prop/attribute annotation is inherently cross-emitter, so the two walks MUST
+  descend the same forms or a conditional-rooted view diverges under the
+  JVM<->CLJS parity gate and SSR/client hydration."
   [ast annotate]
   (case (:op ast)
     :element (assoc ast :rf.ui/annotate annotate)
     (:hook-prefix :let :letfn) (update ast :body mark-host-root-annotation annotate)
+    :if   (-> ast
+              (update :then mark-host-root-annotation annotate)
+              (update :else mark-host-root-annotation annotate))
+    :case (-> ast
+              (update :clauses
+                      (fn [clauses]
+                        (mapv (fn [[test branch]]
+                                [test (mark-host-root-annotation branch annotate)])
+                              clauses)))
+              (update :default
+                      (fn [d]
+                        (if (= ::ana/none d) d
+                            (mark-host-root-annotation d annotate)))))
     ast))
 
 (defn emit-defview

--- a/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
@@ -371,20 +371,46 @@
 
 (defn- mark-host-root-annotation
   "Stamp the view-evidence DOM-annotation marker onto the view's effective host
-  root — the DOM `:element` the compiler owns at the top of the render. The
+  root(s) — the DOM `:element`(s) the compiler owns at the top of the render. The
   UNCONDITIONAL wrappers (`:hook-prefix` effect prefix, an authored `:let` /
   `:letfn`) are transparent — the marker rides through to the element they wrap.
-  A non-element effective root (a fragment, another view/foreign component, or a
-  conditional / loop) is NOT a single compiler-owned host node, so it carries no
-  annotation — the same host-root exemption the CLJS emit and the adapter
-  source-coord walk apply to a non-DOM root. `emit-element` reads the marker off
-  the plain element and merges the annotation into its `:static` attrs behind the
-  `interop/debug-enabled?` gate (see `static-form`). The JVM twin of
-  `re-frame.ui.compiler.emit-cljs/mark-host-root-annotation`."
+
+  A COMMON CONDITIONAL root is narrowly DESCENDED so its concrete DOM arms are
+  tagged: `if` / `if-not` / `when` / `when-not` / `cond` (each an `:if`), `case`
+  (its clauses + default), and the if-let family (`if-let` / `when-let` /
+  `if-some` / `when-some`, which desugar to `:let` over `:if`). So a view rooted
+  at `(if loading? [:spinner] [:page])` tags whichever arm renders. Spec 006
+  exempts only the render that yields nil; a later concrete DOM output must be
+  tagged. The recursion RETAINS the per-branch host-root exemptions: a branch
+  that is nil (`:nothing`, e.g. a one-arm `when`'s absent else), a fragment,
+  another view/foreign component, or a loop (`:for`) is NOT a single
+  compiler-owned host node and carries no annotation — the same exemption the
+  CLJS emit and the adapter source-coord walk apply to a non-DOM root.
+
+  `emit-element` reads the marker off the plain element and merges the annotation
+  into its `:static` attrs behind the `interop/debug-enabled?` gate (see
+  `static-form`). The JVM twin of
+  `re-frame.ui.compiler.emit-cljs/mark-host-root-annotation`, kept BYTE-IDENTICAL:
+  a prop/attribute annotation is inherently cross-emitter, so the two walks MUST
+  descend the same forms or a conditional-rooted view diverges under the
+  JVM<->CLJS parity gate and SSR/client hydration."
   [ast annotate]
   (case (:op ast)
     :element (assoc ast :rf.ui/annotate annotate)
     (:hook-prefix :let :letfn) (update ast :body mark-host-root-annotation annotate)
+    :if   (-> ast
+              (update :then mark-host-root-annotation annotate)
+              (update :else mark-host-root-annotation annotate))
+    :case (-> ast
+              (update :clauses
+                      (fn [clauses]
+                        (mapv (fn [[test branch]]
+                                [test (mark-host-root-annotation branch annotate)])
+                              clauses)))
+              (update :default
+                      (fn [d]
+                        (if (= ::ana/none d) d
+                            (mark-host-root-annotation d annotate)))))
     ast))
 
 (defn emit-defview

--- a/implementation/ui/test/re_frame/ui/conditional_root_annotation_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/conditional_root_annotation_cljs_test.cljs
@@ -1,0 +1,109 @@
+(ns re-frame.ui.conditional-root-annotation-cljs-test
+  "rf2-hac8p (98.1 slice c — audit obligation #1): the compiler's host-root
+  view-evidence annotation reaches COMMON CONDITIONAL roots. A view whose host
+  root is an `if` / `if-not` / `when` / `when-not` / `cond` / `case` / if-let
+  family gains `data-rf2-source-coord` / `data-rf-view` on whichever concrete DOM
+  arm renders — the same view identity on every arm. Proven here by a REAL
+  react-dom/server render in the NODE CLJS suite (`npm run test:cljs`): the dev
+  build (goog.DEBUG true) carries the annotation in the serialised markup; the
+  `:advanced` + goog.DEBUG=false elision is covered by the shared elision probe.
+
+  This is the acceptance teeth the audit reopening demanded: the defect surfaces
+  on a real CLJS render, not only in the JVM structural emit (which the sibling
+  `emit_cljs_view_evidence_annotation_jvm_test` pins on the emit-data side)."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            ["react-dom/server" :as rds]
+            [re-frame.ui :refer [defview]]
+            [re-frame.ui.runtime :as rt]))
+
+;; ---------------------------------------------------------------------------
+;; Conditional-root views (capability-free — render standalone through jsx2)
+;; ---------------------------------------------------------------------------
+
+(defview if-root
+  "Host root is an (if …): each arm is a single compiler-owned element, so BOTH
+  arms are tagged — whichever renders reports the view."
+  [{:keys [big?]}]
+  (if big? [:div.big "big"] [:section.small "small"]))
+
+(defview when-root
+  "One-arm (when …): the element arm is tagged; the implicit nil else renders
+  nothing and stays exempt."
+  [{:keys [show?]}]
+  (when show? [:p.shown "shown"]))
+
+(defview if-let-root
+  "The if-let family desugars to let-over-if — the descent reaches both arms."
+  [{:keys [v]}]
+  (if-let [x v] [:span.has (str x)] [:span.none "none"]))
+
+(defview case-root
+  "A (case …) host root: each clause branch and the default is a concrete
+  element and is tagged."
+  [{:keys [k]}]
+  (case k
+    :a [:a.arm-a "a"]
+    :b [:b.arm-b "b"]
+    [:i.arm-d "d"]))
+
+(defview fragment-root
+  "Retained exemption: a fragment root has no single positional host node, so it
+  carries no annotation (the same host-root exemption a non-DOM root gets)."
+  [{:keys [a b]}]
+  [:<> [:dt a] [:dd b]])
+
+;; ---------------------------------------------------------------------------
+
+(defn- render [view props] (rds/renderToStaticMarkup (rt/jsx2 view props)))
+
+(defn- tagged-as?
+  "The rendered markup carries the view-evidence pair AND the view tag ends in
+  `/<vname>` (so the annotation is THIS view's, not some inner element's)."
+  [html vname]
+  (and (str/includes? html "data-rf2-source-coord=\"")
+       (boolean (re-find (re-pattern (str "data-rf-view=\"[^\"]*/" vname "\"")) html))))
+
+(deftest an-if-root-tags-whichever-arm-renders
+  (testing "the true arm (a <div>) carries the view-evidence annotation"
+    (let [html (render if-root #js {:big? true})]
+      (is (str/includes? html "<div ") "the div arm rendered")
+      (is (tagged-as? html "if-root")
+          "RED before the walk descends :if — the div host root was untagged")))
+  (testing "the false arm (a <section>) ALSO carries it"
+    (let [html (render if-root #js {:big? false})]
+      (is (str/includes? html "<section ") "the section arm rendered")
+      (is (tagged-as? html "if-root")))))
+
+(deftest a-when-root-tags-the-concrete-arm-and-exempts-the-nil-arm
+  (testing "the present arm (a <p>) is tagged"
+    (let [html (render when-root #js {:show? true})]
+      (is (str/includes? html "<p ") "the p arm rendered")
+      (is (tagged-as? html "when-root"))))
+  (testing "the absent arm renders nothing — no host node, no annotation"
+    (let [html (render when-root #js {:show? false})]
+      (is (not (str/includes? html "data-rf-view=\""))
+          "an empty render carries no host-root annotation"))))
+
+(deftest an-if-let-root-tags-both-arms
+  (testing "the truthy-binding arm is tagged"
+    (let [html (render if-let-root #js {:v 5})]
+      (is (str/includes? html "<span class=\"has\"") "the has arm rendered")
+      (is (tagged-as? html "if-let-root"))))
+  (testing "the else arm is tagged too"
+    (let [html (render if-let-root #js {:v nil})]
+      (is (str/includes? html "<span class=\"none\"") "the none arm rendered")
+      (is (tagged-as? html "if-let-root")))))
+
+(deftest a-case-root-tags-every-clause-and-the-default
+  (doseq [[k tag] [[:a "<a "] [:b "<b "] [:z "<i "]]]
+    (let [html (render case-root #js {:k k})]
+      (is (str/includes? html tag) (str "the " k " arm rendered"))
+      (is (tagged-as? html "case-root")
+          (str "the " k " arm (clause or default) carries the annotation")))))
+
+(deftest a-fragment-root-carries-no-annotation
+  (let [html (render fragment-root #js {:a "x" :b "y"})]
+    (is (str/includes? html "<dt>x</dt>") "the fragment spliced its children")
+    (is (not (str/includes? html "data-rf-view=\""))
+        "a fragment root has no single host node — retained exemption")))

--- a/implementation/ui/test/re_frame/ui/emit_cljs_view_evidence_annotation_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/emit_cljs_view_evidence_annotation_jvm_test.clj
@@ -36,6 +36,17 @@
             (nth x 3 nil)))
         (forms-of form)))
 
+(defn- stamp-count
+  "How many `(cljs.core/unchecked-set _ attr _)` stamps `form` carries for `attr`
+  — one per annotated host element (a conditional root stamps one per concrete
+  DOM arm)."
+  [form attr]
+  (count (filter (fn [x]
+                   (and (seq? x)
+                        (= 'cljs.core/unchecked-set (first x))
+                        (= attr (nth x 2 nil))))
+                 (forms-of form))))
+
 (defn- annotation-gate
   "The `(when <gate> …)` form wrapping the source-coord stamp, or nil. Matches the
   `when` by NAME — the emitter's syntax-quote resolves it against the host core
@@ -84,17 +95,45 @@
       (is (= "app.wrap:boxed:9:2" (data-attr-set form "data-rf2-source-coord")))
       (is (= ":app.wrap/boxed" (data-attr-set form "data-rf-view"))))))
 
-(deftest non-element-roots-carry-no-annotation
-  (testing "a conditional root is not a single compiler-owned host node"
+(deftest common-conditional-roots-annotate-each-concrete-dom-arm
+  ;; rf2-hac8p audit obligation #1: the walk descends common conditional roots so
+  ;; whichever arm renders is tagged (Spec 006 exempts only the render that yields
+  ;; nil). Every branch carries the SAME view identity — the annotation is the
+  ;; view's, not the branch's.
+  (testing "an (if …) root stamps BOTH element arms"
     (let [form (cljs-emit 'app.cond 'branchy '(if x [:a] [:b]) 3 4)]
-      (is (nil? (annotation-gate form)))
-      (is (not (str/includes? (pr-str form) "data-rf2-source-coord"))
-          "no host-root annotation on a non-element effective root")
-      (is (not (str/includes? (pr-str form) "data-rf-view")))))
+      (is (some? (annotation-gate form)))
+      (is (= 2 (stamp-count form "data-rf2-source-coord"))
+          "both arms of the conditional host root carry the source coord")
+      (is (= 2 (stamp-count form "data-rf-view")))
+      (is (= "app.cond:branchy:3:4" (data-attr-set form "data-rf2-source-coord")))
+      (is (= ":app.cond/branchy" (data-attr-set form "data-rf-view")))))
+  (testing "a one-arm (when …) tags the concrete arm; the absent nil arm is exempt"
+    (let [form (cljs-emit 'app.cond 'maybe '(when x [:p "y"]) 5 1)]
+      (is (= 1 (stamp-count form "data-rf-view"))
+          "the element arm is tagged; the implicit nil else carries none")))
+  (testing "a (cond …) — nested (if …) — tags every reachable element arm"
+    (let [form (cljs-emit 'app.cond 'picker
+                          '(cond (= k :a) [:a "A"] (= k :b) [:b "B"] :else [:c "C"]) 2 2)]
+      (is (= 3 (stamp-count form "data-rf-view")))))
+  (testing "a (case …) tags every clause branch AND the default"
+    (let [form (cljs-emit 'app.cond 'chooser '(case k :a [:a] :b [:b] [:c]) 6 3)]
+      (is (= 3 (stamp-count form "data-rf-view"))
+          "two clause branches + the default, each a concrete host element")))
+  (testing "the if-let family (let over if) descends to both arms"
+    (let [form (cljs-emit 'app.cond 'bound '(if-let [v x] [:a v] [:b]) 7 3)]
+      (is (= 2 (stamp-count form "data-rf-view"))))))
+
+(deftest non-host-roots-carry-no-annotation
   (testing "a fragment root is exempt (no positional host node)"
     (let [form (cljs-emit 'app.frag 'grouped '[:<> [:p] [:p]] 1 1)]
       (is (nil? (annotation-gate form)))
-      (is (not (str/includes? (pr-str form) "data-rf2-source-coord"))))))
+      (is (zero? (stamp-count form "data-rf2-source-coord")))))
+  (testing "per-branch exemption survives the conditional descent: an element arm
+            is tagged, a fragment arm is not"
+    (let [form (cljs-emit 'app.mix 'mixed '(if x [:<> [:p] [:p]] [:div "d"]) 4 4)]
+      (is (= 1 (stamp-count form "data-rf-view"))
+          "only the [:div] element arm is tagged; the fragment arm carries none"))))
 
 (deftest render-key-is-not-stamped-on-the-dom-at-render-time
   ;; render-key is minted at connected commit (reactive/commit*), AFTER this

--- a/implementation/ui/test/re_frame/ui/parity_fixtures.cljc
+++ b/implementation/ui/test/re_frame/ui/parity_fixtures.cljc
@@ -125,6 +125,17 @@
      (letfn [(lbl [x] (str "#" x))]
        [:span.lf (lbl n)])]))
 
+(defview conditional-root
+  "rf2-hac8p (98.1 slice c): the view's HOST ROOT is a conditional. Each concrete
+  DOM arm is a single compiler-owned element, so BOTH emitters must annotate
+  whichever arm renders IDENTICALLY — the host-root view-evidence annotation
+  (`data-rf2-source-coord` + `data-rf-view`) is inherently cross-emitter, so a
+  one-sided conditional-root descent diverges here (the exact class that reopened
+  the bead). The `branches` view exercises conditionals MID-TREE; this exercises
+  them at the ROOT."
+  [{:keys [big?]}]
+  (if big? [:div.cr-big "big"] [:section.cr-small "small"]))
+
 (defview list-row
   "Row view for keyed list-over-view fixtures."
   [{:keys [item]}]
@@ -526,6 +537,7 @@
    :class-forms     class-forms
    :text-forms      text-forms
    :branches        branches
+   :conditional-root conditional-root
    :lists           lists
    :fragments       fragments
    :booleans        bool-attrs
@@ -565,6 +577,8 @@
    {:id :branches-a-big       :view :branches        :props {:kind :a :n 42}}
    {:id :branches-b-small     :view :branches        :props {:kind :b :n 1}}
    {:id :branches-default     :view :branches        :props {:kind :z :n 11}}
+   {:id :conditional-root-true  :view :conditional-root :props {:big? true}}
+   {:id :conditional-root-false :view :conditional-root :props {:big? false}}
    {:id :lists-full           :view :lists           :props {:items [{:id 1 :label "a" :hot? true :priority :high}
                                                                      {:id 2 :label "b" :hot? false :priority :low}]
                                                              :groups [{:id "g1" :xs [1 2]} {:id "g2" :xs [3]}]


### PR DESCRIPTION
Audit obligation #1 of the PR #6566 chronological audit (rf2-hac8p reopening). `mark-host-root-annotation` descended only `:hook-prefix` / `:let` / `:letfn` wrappers and stopped at conditionals, so a view whose host root sits under a common conditional — `(if loading? [:spinner] [:page])`, a `when`, a `case`, the if-let family — never carried `data-rf2-source-coord` / `data-rf-view` on the concrete DOM arm it renders. Spec 006 §View tagging (line 727) requires the opposite: only the render that yields nil is exempt; a render that produces a DOM element must be tagged.

## What changed

- **Both emitters, kept byte-identical.** `mark-host-root-annotation` now descends `:if` (then + else) and `:case` (clauses + default) in `emit_cljs.cljc` **and** `emit_jvm.cljc`. A prop/attribute annotation is inherently cross-emitter (Mayor ruling A on this bead): a one-sided descent diverges under the JVM↔CLJS parity gate and SSR/client hydration — the exact failure class that reopened this bead. The extension covers `if` / `if-not` / `when` / `when-not` / `cond` (each an `:if`), `case`, and the if-let family (`if-let` / `when-let` / `if-some` / `when-some`, which desugar to let-over-if).
- **Per-branch exemptions retained.** A branch that is nil (`:nothing`, e.g. a one-arm `when`'s absent else), a fragment, another view/foreign component, or a `:for` loop is not a single compiler-owned host node and carries no annotation.
- **No new vocabulary, still DEBUG-gated / production-erased.** Reuses the existing `data-rf2-source-coord` / `data-rf-view` strings behind the same `goog.DEBUG` / `interop/debug-enabled?` gate.

## Proof (red→green, in the CLJS suite — the reopening reason)

- `conditional_root_annotation_cljs_test.cljs` (new) — a real `react-dom/server` render in the **node CLJS suite** asserts the annotation reaches the `if` / `when` / `if-let` / `case` arms and stays off a fragment root.
- `emit_cljs_view_evidence_annotation_jvm_test.clj` — the old `non-element-roots-carry-no-annotation` (which asserted the buggy behavior) is replaced by `common-conditional-roots-annotate-each-concrete-dom-arm` + a retained `non-host-roots-carry-no-annotation`.
- `parity_fixtures.cljc` — a `conditional-root` corpus view + true/false cases guard the cross-emitter divergence class.

Reverting only the `emit_cljs` walk drives the focused `node-test-ui` build to **11 failures** (node proof + `parity_corpus` divergence `{:jvm annotated, :react nil}`, including the pre-existing `nil-rooted` `when`-root inside `:fragments-on`); restoring it returns to 0.

## Quality gates

- `npm run test:cljs` — **ran to completion**: 10343 tests / 51104 assertions / 0 failures, 0 errors.
- `cd implementation/ui && clojure -M:test` — 1010 tests / 19962 assertions / 0 failures.
- `npm run test:elision` — production 60/60 absent (annotations DCE'd).
- Red→green demonstrated via the focused `node-test-ui` build (11 → 0).

`ny34u`'s render-key DOM stamp (element-root `stamped-view`) is untouched — no regression. Audit obligations **#2** (authored-value collision law — `annotate-host-root-props` + `static-form`) and **#3/#4** (`render-static` provenance + debug-disabled walk bypass) are separate surfaces outside the walk fence, filed as **rf2-x1nbv** and **rf2-zgezz**. Spec 004 annotation-vocab note deferred to S4 (spec/004 fence). CODE-ONLY.
