### PR TITLE
test(ui): correct RealWorld route-owned resource contract assertion (rf2-2c1v3)

### DIFF
--- a/implementation/ui/test/re_frame/realworld_resources_s3_ergonomic_proof_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/realworld_resources_s3_ergonomic_proof_dom_cljs_test.cljs
@@ -23,18 +23,27 @@
     - the `ui/event` form submit — `preventDefault` then dispatch the submit
       vector, running client-side validation;
     - the `:editor/can-submit?` FLOW gating the submit button through a live sub;
-    - the view's ONE lifecycle contract — unmount releases the article owner
-      exactly once (its `effect` cleanup dispatches `[:editor/release-article]`),
-      and a re-render (the hot-reload path) never leaks a spurious release;
+    - the view's re-render / unmount invariant — the native view attaches no
+      owner and holds no local ephemera, so a re-render (the hot-reload path)
+      neither loses the edited draft nor leaks, and a clean unmount emits no
+      domain cleanup dispatch (the ROUTE owns the article read and releases it
+      on route leave — nothing rides the view);
     - the counter and dashboard interactions (event vectors, `local`, a keyed
       list, a controlled filter).
 
   The editor's dataflow is the REAL `article_editor.cljs` registration (required
   below), unchanged by this stage — only its VIEW is native re-frame.ui here.
-  The owner-release DOMAIN logic is pinned in the reagent-adapter suite
-  `realworld_resources_cljs_test`; this suite pins the native VIEW's contribution
-  (the unmount dispatch), so it spies `:editor/release-article` rather than
-  standing up the whole resource runtime."
+  Resource ownership and release are a ROUTING concern, not a view one: the
+  `:realworld.editor/edit` route declares `:realworld/article` as a `:resources`
+  entry (routing.cljs), so the runtime owns the read under
+  `[:route :realworld.editor/edit nav-token]` and RELEASES that owner on every
+  route leave. `article_editor.cljs` deliberately registers no
+  `:editor/release-article` event, and that route-owned release is proved by the
+  route-owner tests in the reagent-adapter suite `realworld_resources_cljs_test`.
+  This native suite adds nothing to the resource lifecycle — it proves the
+  narrower, view-local fact that the native view mounts, drives its interactions,
+  and re-renders / unmounts without emitting any domain cleanup dispatch, because
+  the view owns no owner and there is nothing at the view tier to leak."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]


### PR DESCRIPTION
## What

`implementation/ui/test/re_frame/realworld_resources_s3_ergonomic_proof_dom_cljs_test.cljs`'s namespace docstring preserved a **deleted** programming model (introduced/left stale by PR #6579). It claimed:

- the native editor view runs a `ui/effect` cleanup that dispatches `[:editor/release-article]` on unmount ("the view's ONE lifecycle contract"), and
- this suite *spies* `:editor/release-article`.

Both are false in the shipped tree:

- the native `ui_editor.cljc` view is a pure `defview` — it attaches **no owner and no effect**;
- `article_editor.cljs:286` **deliberately registers no** `:editor/release-article` event;
- the **route** owns the article read — `:realworld.editor/edit` declares `:realworld/article` as a `:resources` entry (`routing.cljs:154`), owned under `[:route :realworld.editor/edit nav-token]` and **released on every route leave**;
- the unmount test (`editor-survives-a-re-render-with-no-leaked-state`) performs **no such spy** — it already asserts a clean unmount with no disconnected dispatch and no leaked listener.

## Change

Docstring-only correction (16 insertions, 7 deletions). Rewrote the two stale passages to:

- attribute resource ownership/release to **routing** (the shipped S2B route-owned model), and
- accurately describe what this native UI suite proves — the native view re-renders / unmounts **without emitting any domain cleanup dispatch**, because it owns no owner.

No component-lifetime owner, runtime machinery, or redundant test added. The test **body** already asserted the correct route-owned behaviour; only the contract prose was stale. Source is correct — this is a test-contract (docstring) correction, not a source change.

## Quality gates

Run to completion, foreground, from the worktree:

- `cd implementation/ui && clojure -M:test` (JVM Tier-1) — **1009 tests, 19901 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node CLJS) — **10338 tests, 51083 assertions, 0 failures, 0 errors**
- `npm run test:browser` (browser DOM gate; compiled `browser-test`, 940 files) — **506 tests, 2794 assertions, 0 failures, 0 errors**

Disjoint from the live `view-cause-cluster` (reactive.cljc), `hac8p` (emit_cljs), and S4/`j97yg` (spec/004/analyze/scripts) work — single-file docstring edit.

Closes rf2-2c1v3.