### PR TITLE
fix(conformance): Resources fixtures use causal app-event owners (rf2-jouzd)

### DIFF
--- a/spec/conformance/fixtures/resources-dedupe-join.edn
+++ b/spec/conformance/fixtures/resources-dedupe-join.edn
@@ -14,7 +14,7 @@
 {:fixture/id           :resources/dedupe-join
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:resources/dedupe}
- :fixture/doc          "ensure :res/article (slug=w) with owner [:route :r 1] → :loading gen 1; a second ensure with owner [:app :x 2] while in flight JOINS — no new generation, both owners attached, :rf.resource/deduped emitted. The entry stays :loading on generation 1."
+ :fixture/doc          "ensure :res/article (slug=w) with owner [:route :r 1] → :loading gen 1; a second ensure with owner [:article/opened \"w\"] while in flight JOINS — no new generation, both owners attached, :rf.resource/deduped emitted. The entry stays :loading on generation 1."
 
  :fixture/registry
  {:resource
@@ -35,10 +35,10 @@
                         :params {:slug "w"} :owner [:route :r 1] :cause :route-enter}]
 
   ;; Step 2: a SECOND ensure while the first is in flight. JOINS the live work
-  ;; record — no new generation, attaches owner [:app :x 2] to the same entry.
+  ;; record — no new generation, attaches owner [:article/opened "w"] to the same entry.
   ;; No second fetch fires. :rf.resource/deduped emits.
   [:rf.resource/ensure {:resource :res/article :scope :rf.scope/global
-                        :params {:slug "w"} :owner [:app :x 2] :cause :view-mount}]]
+                        :params {:slug "w"} :owner [:article/opened "w"] :cause :view-mount}]]
 
  :fixture/expect
  {;; The entry is still in flight on its single generation — the join added a
@@ -51,4 +51,4 @@
   :trace-emissions
   [;; The second ensure joined the in-flight work (no new generation minted).
    {:operation :rf.resource/deduped
-    :tags      {:generation 1 :cause :view-mount :owner [:app :x 2]}}]}}
+    :tags      {:generation 1 :cause :view-mount :owner [:article/opened "w"]}}]}}

--- a/spec/conformance/fixtures/resources-ensure-fresh-skip.edn
+++ b/spec/conformance/fixtures/resources-ensure-fresh-skip.edn
@@ -51,7 +51,7 @@
  [;; Step 1: first ensure. No-data entry → :loading, mints generation 1,
   ;; attaches the owner, lowers the managed-HTTP fetch.
   [:rf.resource/ensure {:resource :res/article :scope :rf.scope/global
-                        :params {:slug "w"} :owner [:app :t 1] :cause :first-load}]
+                        :params {:slug "w"} :owner [:article/opened "w"] :cause :first-load}]
 
   ;; Step 2: the transport reply arrives (fed directly). Verified against the
   ;; live entry by work-id + generation, it settles :loaded with the data.
@@ -64,7 +64,7 @@
   ;; Step 3: a SECOND ensure of the fresh :loaded entry. FRESH-SKIP: serve
   ;; cache, no new generation, no new load; emit :rf.resource/cache-hit.
   [:rf.resource/ensure {:resource :res/article :scope :rf.scope/global
-                        :params {:slug "w"} :owner [:app :t 1] :cause :revisit}]]
+                        :params {:slug "w"} :owner [:article/opened "w"] :cause :revisit}]]
 
  :fixture/expect
  {;; The public state view-model after the fresh-skip: :loaded with the

--- a/spec/conformance/fixtures/resources-owner-release-gc.edn
+++ b/spec/conformance/fixtures/resources-owner-release-gc.edn
@@ -7,7 +7,7 @@
 ;; :active-owners + nil :current-work) — there is no stored "gc-eligible"
 ;; boolean. Release alone does not remove; the fired GC re-check does.
 ;;
-;; ensure (owner [:app :gc 1]) → succeed → :loaded; release-owner drops the
+;; ensure (owner [:article/opened "w"]) → succeed → :loaded; release-owner drops the
 ;; owner (:rf.resource/owner-released) leaving the entry owner-free + idle; the
 ;; fired GC (:rf.resource.internal/gc-fired) re-checks and removes it
 ;; (:rf.resource/gc-fired). After removal the public state sub projects the
@@ -24,7 +24,7 @@
 {:fixture/id           :resources/owner-release-gc
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:resources/owner-gc}
- :fixture/doc          "ensure :res/article (owner [:app :gc 1], gc-after 60s) → :loaded; release-owner drops the owner (owner-free + idle → GC-eligible); the fired GC re-check removes the entry. Traces: :rf.resource/owner-released then :rf.resource/gc-fired. The state sub then projects the :idle empty-state. A second resource (:res/no-gc-policy, no :gc-after-ms declared) proves the rf2-bbpu11 default-arming rule: its settle routes schedule-timers with the framework's default GC delay via :timers {:gc 300000}."
+ :fixture/doc          "ensure :res/article (owner [:article/opened \"w\"], gc-after 60s) → :loaded; release-owner drops the owner (owner-free + idle → GC-eligible); the fired GC re-check removes the entry. Traces: :rf.resource/owner-released then :rf.resource/gc-fired. The state sub then projects the :idle empty-state. A second resource (:res/no-gc-policy, no :gc-after-ms declared) proves the rf2-bbpu11 default-arming rule: its settle routes schedule-timers with the framework's default GC delay via :timers {:gc 300000}."
 
  :fixture/registry
  {:resource
@@ -48,7 +48,7 @@
  :fixture/dispatches
  [;; Step 1: ensure with an owner → :loading, generation 1.
   [:rf.resource/ensure {:resource :res/article :scope :rf.scope/global
-                        :params {:slug "w"} :owner [:app :gc 1] :cause :view-mount}]
+                        :params {:slug "w"} :owner [:article/opened "w"] :cause :view-mount}]
 
   ;; Step 2: the reply settles :loaded (entry now idle: :current-work nil).
   [:rf.resource.internal/succeeded
@@ -59,7 +59,7 @@
 
   ;; Step 3: release the owner → entry becomes owner-free (still :loaded, idle).
   ;; Release alone does NOT remove — the entry is GC-eligible, not gone.
-  [:rf.resource/release-owner {:owner [:app :gc 1]}]
+  [:rf.resource/release-owner {:owner [:article/opened "w"]}]
 
   ;; Step 4: the GC timer fires → re-checks (owner-free + idle) → reaps the
   ;; entry. (The internal gc-fired event is what the armed timer dispatches.)
@@ -70,7 +70,7 @@
   ;; across every resource in the frame, not per resource-id), so this
   ;; frame's SECOND ensure mints generation 2.
   [:rf.resource/ensure {:resource :res/no-gc-policy :scope :rf.scope/global
-                        :params {:slug "d"} :owner [:app :gc 2] :cause :view-mount}]
+                        :params {:slug "d"} :owner [:dashboard/opened "d"] :cause :view-mount}]
 
   ;; Step 6: the reply settles :loaded — the :effects-routed expectation below
   ;; is the proof: schedule-timers carries the DEFAULT GC delay (:timers {:gc
@@ -97,7 +97,7 @@
   :trace-emissions
   [;; The owner was released (owner-free liveness change).
    {:operation :rf.resource/owner-released
-    :tags      {:owner [:app :gc 1]}}
+    :tags      {:owner [:article/opened "w"]}}
    ;; The fired GC re-check reaped the owner-free + idle entry.
    {:operation :rf.resource/gc-fired}]
 

--- a/spec/conformance/fixtures/resources-refresh-error-keeps-data.edn
+++ b/spec/conformance/fixtures/resources-refresh-error-keeps-data.edn
@@ -32,7 +32,7 @@
  :fixture/dispatches
  [;; Step 1: ensure → :loading, generation 1.
   [:rf.resource/ensure {:resource :res/article :scope :rf.scope/global
-                        :params {:slug "w"} :owner [:app :rf 1] :cause :first-load}]
+                        :params {:slug "w"} :owner [:article/opened "w"] :cause :first-load}]
 
   ;; Step 2: the reply settles :loaded with the data (generation 1).
   [:rf.resource.internal/succeeded

--- a/spec/conformance/fixtures/resources-stale-reply-suppression.edn
+++ b/spec/conformance/fixtures/resources-stale-reply-suppression.edn
@@ -35,7 +35,7 @@
  :fixture/dispatches
  [;; Step 1: ensure → :loading, generation 1.
   [:rf.resource/ensure {:resource :res/article :scope :rf.scope/global
-                        :params {:slug "w"} :owner [:app :s 1] :cause :first-load}]
+                        :params {:slug "w"} :owner [:article/opened "w"] :cause :first-load}]
 
   ;; Step 2: refetch → forces a new generation (2), supersedes the gen-1 work.
   [:rf.resource/refetch {:resource :res/article :scope :rf.scope/global


### PR DESCRIPTION
Closes rf2-jouzd.

## What

PR #6579 correctly removed the deleted generic `[:lease ...]` owner kind (S2B), but mechanically replaced it with generic-looking `[:app ...]` tokens (e.g. `[:app :gc 1]`) in the five portable Resources conformance fixtures. Spec 016's causal-owner model deliberately has **no** reserved generic `:app` kind — app-owned lifetimes use a keyword naming the real releaseable event/lifetime (e.g. `[:dashboard/opened user-id]`), with an explicit matching release path. Because these fixtures are normative, portable, and highly copyable, `[:app ...]` teaches a renamed generic token that conflicts with the shipped model.

This migrates the five fixtures to semantic event-shaped app owners (before -> after):

| Fixture | Before | After |
|---|---|---|
| `resources-dedupe-join` | `[:app :x 2]` | `[:article/opened "w"]` |
| `resources-ensure-fresh-skip` | `[:app :t 1]` | `[:article/opened "w"]` |
| `resources-owner-release-gc` | `[:app :gc 1]` (released) | `[:article/opened "w"]` (released) |
| `resources-owner-release-gc` | `[:app :gc 2]` | `[:dashboard/opened "d"]` |
| `resources-refresh-error-keeps-data` | `[:app :rf 1]` | `[:article/opened "w"]` |
| `resources-stale-reply-suppression` | `[:app :s 1]` | `[:article/opened "w"]` |

The route owner `[:route :r 1]` in `dedupe-join` was already causal and is left unchanged (it now pairs with `[:article/opened "w"]` on the same entry, illustrating two distinct causal lifetimes pinning one entry).

## Scope / non-goals

Behaviour-preserving. Fixture ids, capabilities, dispatches, and result expectations (`:sub-values`, `:trace-emissions`, `:effects-routed`) are unchanged apart from the owner values and their coupled prose (doc strings + comments; the `owner-release-gc` release-on-owner GC proof is intact — the release still matches `[:article/opened "w"]`). No owner-kind validation, registry, or migration shim was introduced, and the opaque `[:app ...]` unit-test sentinels in the resources artefact tests were left untouched (out of scope per the bead). The pair-mcp **generated** tool-descriptors are not touched (0sray's lockstep surface).

## Quality gates

Run in the worktree, foreground, to completion:

- `implementation/core` `clojure -M:test` (JVM conformance corpus — exercises the 5 resources fixtures via the JVM leaf; all 5 resources capabilities are claimed, so RUNNABLE not skipped): **Ran 2104 tests / 10415 assertions, 0 failures, 0 errors.**
- `implementation/resources` `clojure -M:test`: **Ran 678 tests / 6429 assertions, 0 failures, 0 errors.**
- `implementation/` `npm run test:cljs` (CLJS conformance corpus leaf inlines the fixtures at compile time): **Ran 10348 tests / 51113 assertions, 0 failures, 0 errors.**

`npm run test:mcp-conformance` not applicable — no mcp-conformance fixtures touched.
