### PR TITLE
fix(ui/compiler): annotation collision law + render-static provenance, cross-emitter (rf2-x1nbv rf2-zgezz)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr/render_static_jvm_test.clj
+++ b/implementation/ssr/test/re_frame/ssr/render_static_jvm_test.clj
@@ -26,6 +26,13 @@
   [{:keys [title]}]
   [:div.card [:h2 title] [:p "static"]])
 
+;; rf2-zgezz #3 — a view with a PROGRAMMER-AUTHORED nested attribute spelled like
+;; the host-root annotation. render-static must strip only the compiler-generated
+;; host-root markers, preserving this authored nested value.
+(ui/defview nested-authored-card
+  [_]
+  [:div.card [:span {:data-rf-view "authored-nested"} "x"]])
+
 ;; ---------------------------------------------------------------------------
 ;; Fixtures for the no-silent-elision proof (rf2-uv7n6 repair 1). All compiled
 ;; top-to-bottom so their view-static facts are indexed when render-static below
@@ -112,6 +119,23 @@
         (is (not (str/includes? html marker))
             (str "render-static output must not carry the hydration/adoption "
                  "marker " (pr-str marker) " — it is the non-hydrating static path"))))))
+
+;; ---------------------------------------------------------------------------
+;; Provenance — the strip removes ONLY the compiler-generated host-root markers,
+;; preserving programmer-authored attributes of the same spelling (rf2-zgezz #3).
+;; ---------------------------------------------------------------------------
+
+(deftest render-static-preserves-authored-nested-attrs
+  (testing "an authored nested data-rf-view survives the strip; the host-root
+            compiler annotation is still removed"
+    (let [html (ui/render-static [nested-authored-card])]
+      (is (str/includes? html "data-rf-view=\"authored-nested\"")
+          "RED before provenance — the recursive strip deleted this authored attr")
+      (is (not (str/includes?
+                html "data-rf-view=\":re-frame.ssr.render-static-jvm-test/nested-authored-card\""))
+          "the compiler's host-root view id is still stripped (pure static path)")
+      (is (not (str/includes? html "data-rf2-source-coord=\""))
+          "no compiler source-coord leaks — only the authored nested marker remains"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Literal-root enforcement — a macro sees the literal form; a fn cannot. The

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -344,6 +344,15 @@
   The props object is mutated in place BEFORE it reaches the JSX runtime, exactly
   as the trusted-markup spread branch sets `dangerouslySetInnerHTML`.
 
+  AUTHORED OWN VALUE WINS (rf2-x1nbv): each attribute is stamped ONLY when the
+  props object does not already carry it — an author-supplied own value (a literal
+  pair, a dynamic attr, a `ui/spread` merge, or a `ui/spread-safe` result) is never
+  overwritten. This is the adapter / trust-programmer law: because this runs over
+  the FINAL props object (after every spread/spread-safe merge), the surviving
+  authored value wins uniformly, and the JVM `static-form` twin matches it. The
+  `unchecked-get` presence reads sit INSIDE the `goog.DEBUG` gate, so they DCE with
+  the stamp under :advanced + goog.DEBUG=false.
+
   The per-commit integer `render-key` is deliberately NOT stamped here: it is
   minted at CONNECTED COMMIT in the ViewCell layout effect (`reactive/commit*`),
   which runs AFTER this child host element has already committed, so no honest
@@ -353,8 +362,10 @@
   (let [p (gensym "rf-ui-host-root")]
     `(let [~p ~props-form]
        (when ~(with-meta 'js/goog.DEBUG {:tag 'boolean})
-         (cljs.core/unchecked-set ~p "data-rf2-source-coord" ~source-coord)
-         (cljs.core/unchecked-set ~p "data-rf-view" ~view-tag))
+         (when (cljs.core/undefined? (cljs.core/unchecked-get ~p "data-rf2-source-coord"))
+           (cljs.core/unchecked-set ~p "data-rf2-source-coord" ~source-coord))
+         (when (cljs.core/undefined? (cljs.core/unchecked-get ~p "data-rf-view"))
+           (cljs.core/unchecked-set ~p "data-rf-view" ~view-tag)))
        ~p)))
 
 (defn- jsx-call

--- a/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
@@ -146,6 +146,30 @@
         (when (seq base) base)))
     (when (seq static) static)))
 
+(defn- with-host-root-provenance
+  "Attach DEV, debug-gated PROVENANCE metadata to a host-root element node,
+  recording the compiler's canonical view-evidence values
+  (`:data-rf2-source-coord` / `:data-rf-view`) so `render-static`'s strip
+  (`strip-host-root-annotation`) removes ONLY the generated markers — a key
+  whose runtime value still equals the canonical value — and PRESERVES an
+  authored own value of the same spelling under the rf2-x1nbv collision law
+  (rf2-zgezz #3: the recursive strip otherwise deleted programmer-authored
+  nested attributes too).
+
+  Metadata is out-of-band: it is invisible to structural `=` (goldens),
+  normalization N (parity/fingerprint), and every HTML serialiser — only the
+  JVM render-static strip reads it. Gated on `interop/debug-enabled?`, matching
+  the `static-form` stamp, so a production JVM/SSR build attaches nothing."
+  [element-form annotate]
+  (if annotate
+    (let [{:keys [source-coord view-tag]} annotate]
+      `(cond-> ~element-form
+         re-frame.interop/debug-enabled?
+         (vary-meta assoc :rf.ui/host-root-annotation
+                    {:data-rf2-source-coord ~source-coord
+                     :data-rf-view ~view-tag})))
+    element-form))
+
 (defn- emit-element [node]
   (let [{:keys [props]} node
         annotate  (:rf.ui/annotate node)
@@ -156,7 +180,8 @@
                       (into [] (keep emit-node) (:children node)))
         child-thunk (when (seq child-forms)
                       `(fn [] (re-frame.ui.tree/children ~@child-forms)))]
-    (cond
+    (with-host-root-provenance
+     (cond
       (:spread props)
       (let [spread (:spread props)
             sugar (get-in props [:class :base-str])]
@@ -233,7 +258,7 @@
            :key?   ~(:present? key-info)
            :key-val ~(:expr key-info)
            :props  ~(when (seq pp) pp)
-           :children ~child-thunk})))))
+           :children ~child-thunk}))) annotate)))
 
 ;; ---------------------------------------------------------------------------
 ;; Components

--- a/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
@@ -122,14 +122,28 @@
   `-Dre-frame.debug=false`). So a dev JVM/SSR render carries the SAME host-root
   evidence the CLJS emit stamps (byte-identical values via the one cross-host
   `re-frame.source-coords` projection), and a production SSR build drops it —
-  symmetric with the CLJS `:advanced` + goog.DEBUG=false DCE."
+  symmetric with the CLJS `:advanced` + goog.DEBUG=false DCE.
+
+  AUTHORED OWN VALUE WINS (rf2-x1nbv): the annotation only fills an attribute the
+  view author did NOT already supply as a LITERAL host-root attr — an authored
+  own value in `:static` is preserved, never overwritten. A DYNAMIC / `ui/spread`
+  / `ui/spread-safe`-caller authored value is layered OVER `:static` at runtime by
+  `tree/element` (dyn over static; caller under owned), so it already wins there;
+  this compile-time guard closes the remaining static path so the JVM law matches
+  the CLJS `annotate-host-root-props` set-if-absent law across the whole collision
+  matrix (static / dynamic / ui.spread / spread-safe)."
   [static annotate]
   (if annotate
-    (let [{:keys [source-coord view-tag]} annotate]
-      `(cond-> ~(or static {})
-         re-frame.interop/debug-enabled?
-         (assoc :data-rf2-source-coord ~source-coord
-                :data-rf-view ~view-tag)))
+    (let [{:keys [source-coord view-tag]} annotate
+          base (or static {})
+          ann  (cond-> {}
+                 (not (contains? base :data-rf2-source-coord))
+                 (assoc :data-rf2-source-coord source-coord)
+                 (not (contains? base :data-rf-view))
+                 (assoc :data-rf-view view-tag))]
+      (if (seq ann)
+        `(cond-> ~base re-frame.interop/debug-enabled? (merge ~ann))
+        (when (seq base) base)))
     (when (seq static) static)))
 
 (defn- emit-element [node]

--- a/implementation/ui/src/re_frame/ui/tree.cljc
+++ b/implementation/ui/src/re_frame/ui/tree.cljc
@@ -25,6 +25,7 @@
   these nodes."
   (:require [clojure.string :as str]
             [re-frame.error :as error]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.ui.reactive :as reactive]
             [re-frame.ui.rules :as rules]))
@@ -555,11 +556,24 @@
      static serialisation, exactly as `goog.DEBUG=false` / `-Dre-frame.debug=false`
      erases it in a production build. Only this render-static seam strips it; the
      hydrating `render-to-string` path (a separate `re-frame.ssr.emit` hiccup
-     serialiser) is untouched."
+     serialiser) is untouched.
+
+     PROVENANCE (rf2-zgezz #3): removal is scoped by the out-of-band provenance
+     metadata `:rf.ui/host-root-annotation` the compiler attaches to a host-root
+     element node (`emit-jvm/with-host-root-provenance`) — a `{key -> canonical
+     value}` map. A marker key is dropped ONLY where the node's current attr value
+     still equals the compiler's canonical value; a PROGRAMMER-AUTHORED own value
+     of the same spelling (rf2-x1nbv collision law) differs and is PRESERVED, and a
+     node with no provenance metadata (any nested authored element) is left
+     untouched. The blunt recursive `dissoc` this replaced deleted authored nested
+     attributes of the same spelling."
      [node]
      (if (map? node)
-       (let [node (if-let [a (:attrs node)]
-                    (let [a (dissoc a :data-rf2-source-coord :data-rf-view)]
+       (let [prov (:rf.ui/host-root-annotation (meta node))
+             node (if (and prov (:attrs node))
+                    (let [a (reduce-kv (fn [a k canon]
+                                         (if (= (get a k ::absent) canon) (dissoc a k) a))
+                                       (:attrs node) prov)]
                       (if (seq a) (assoc node :attrs a) (dissoc node :attrs)))
                     node)]
          (cond-> node
@@ -582,10 +596,16 @@
 
      The DEV host-root view-evidence annotation (rf2-hac8p) is stripped from the
      tree first (see `strip-host-root-annotation`): render-static is the pure,
-     non-hydrating static-HTML path and carries no dev / adoption markers."
+     non-hydrating static-HTML path and carries no dev / adoption markers.
+
+     The strip is BYPASSED ENTIRELY when `interop/debug-enabled?` is false
+     (rf2-zgezz #4): the compiler emits no annotation and no provenance metadata in
+     that build, so there is nothing to remove — the whole recursive clone/walk is
+     skipped and the tree reaches the serialiser untouched (identical root/children
+     identities)."
      [tree]
      (if-let [emit (resolve-ssr-emitter)]
-       (emit (strip-host-root-annotation tree))
+       (emit (cond-> tree interop/debug-enabled? strip-host-root-annotation))
        (error/throw-error!
         :rf.error/ssr-artefact-missing
         'ui/render-static

--- a/implementation/ui/test/re_frame/ui/authored_collision_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/authored_collision_cljs_test.cljs
@@ -11,8 +11,15 @@
   `annotate-host-root-props` stamped both keys unconditionally (`unchecked-set`
   after final props construction), so the framework value OVERWROTE the author's —
   the exact CLJS<->JVM divergence the PR #6566 audit reproduced (JVM already let an
-  authored `ui/spread` value win). The cross-host agreement is pinned additionally
-  by the parity corpus `collision-root` fixture."
+  authored `ui/spread` value win).
+
+  CROSS-HOST MATRIX: this file and its JVM twin `authored_collision_jvm_test`
+  assert the SAME authored values for the SAME four prop-construction paths, so
+  together they pin the collision law cross-host BY CONSTRUCTION. The shared parity
+  corpus carries NO collision fixture on purpose — the annotation spelling is an
+  elision sentinel that legitimately survives (as an authored attr) in the
+  advanced/prod bundle, which the prod-elision corpus's blunt annotation strip
+  would misread as a divergence."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             ["react-dom/server" :as rds]
@@ -40,6 +47,12 @@
   "A `ui/spread` runtime prop map carrying the annotation spelling."
   []
   [:div (ui/spread {:data-rf-view "spread-view" :id "sc"})])
+
+(defview safe-owned-collision
+  "A `ui/spread-safe` OWNED map authors the annotation spelling — the owned own
+  value wins over the compiler evidence (and over the caller)."
+  [{:keys [caller]}]
+  [:div (ui/spread-safe {:data-rf-view "owned-view"} caller)])
 
 (defview no-collision
   "No authored collision — the canonical compiler evidence is present (the
@@ -76,6 +89,15 @@
         "a ui/spread-merged value survives — matching the JVM ui/spread path")
     (is (not (str/includes? html "/spread-collision\""))
         "the canonical view id did not overwrite the spread value")))
+
+(deftest a-spread-safe-owned-authored-value-wins
+  ;; the props ABI carries CLJS-map values inside the JS props object (as the
+  ;; parity corpus does), so `caller` reaches the view as a CLJS map.
+  (let [html (render safe-owned-collision #js {:caller {:data-c "c"}})]
+    (is (str/includes? html "data-rf-view=\"owned-view\"")
+        "the spread-safe OWNED value survives — owned wins over the evidence")
+    (is (not (str/includes? html "/safe-owned-collision\""))
+        "the canonical view id did not overwrite the owned value")))
 
 (deftest no-collision-still-carries-the-canonical-evidence
   (let [html (render no-collision #js {})]

--- a/implementation/ui/test/re_frame/ui/authored_collision_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/authored_collision_cljs_test.cljs
@@ -1,0 +1,85 @@
+(ns re-frame.ui.authored-collision-cljs-test
+  "rf2-x1nbv (98.1 slice c — audit obligation #2): the host-root view-evidence
+  annotation obeys the AUTHORED-OWN-VALUE-WINS collision law. When the view author
+  supplies `data-rf-view` / `data-rf2-source-coord` on the compiler-owned host
+  root — as a literal attr, a dynamic attr, a `ui/spread` merge, or a
+  `ui/spread-safe` owned map — the authored value is PRESERVED; the compiler
+  evidence only fills a key the author did not supply (the adapter /
+  trust-programmer law).
+
+  Proven by a REAL react-dom/server render in the NODE CLJS suite. BEFORE the fix,
+  `annotate-host-root-props` stamped both keys unconditionally (`unchecked-set`
+  after final props construction), so the framework value OVERWROTE the author's —
+  the exact CLJS<->JVM divergence the PR #6566 audit reproduced (JVM already let an
+  authored `ui/spread` value win). The cross-host agreement is pinned additionally
+  by the parity corpus `collision-root` fixture."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            ["react-dom/server" :as rds]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.runtime :as rt]))
+
+;; ---------------------------------------------------------------------------
+;; Collision views — the host root authors an annotation-spelled attribute
+;; through each of the four prop-construction paths.
+;; ---------------------------------------------------------------------------
+
+(defview static-collision
+  "Literal host-root attrs of the same spelling as the annotation."
+  []
+  [:div.host {:data-rf-view "authored-view"
+              :data-rf2-source-coord "authored-coord"}
+   "body"])
+
+(defview dynamic-collision
+  "A DYNAMIC (prop-valued) host-root attr — resolved at render, still authored."
+  [{:keys [v]}]
+  [:div {:data-rf-view v}])
+
+(defview spread-collision
+  "A `ui/spread` runtime prop map carrying the annotation spelling."
+  []
+  [:div (ui/spread {:data-rf-view "spread-view" :id "sc"})])
+
+(defview no-collision
+  "No authored collision — the canonical compiler evidence is present (the
+  hac8p regression guard: authored-wins must not suppress the honest stamp)."
+  []
+  [:div.plain "x"])
+
+;; ---------------------------------------------------------------------------
+
+(defn- render [view props] (rds/renderToStaticMarkup (rt/jsx2 view props)))
+
+(deftest a-literal-authored-value-wins
+  (let [html (render static-collision #js {})]
+    (testing "the author's literal own values are preserved on the host root"
+      (is (str/includes? html "data-rf-view=\"authored-view\"")
+          "RED before the set-if-absent law — the framework value overwrote it")
+      (is (str/includes? html "data-rf2-source-coord=\"authored-coord\"")))
+    (testing "the compiler evidence did NOT overwrite either authored value"
+      (is (not (str/includes? html "/static-collision\""))
+          "the canonical view id must not appear — the authored value won")
+      (is (not (re-find #"data-rf2-source-coord=\"[^\"]*:static-collision:" html))
+          "the canonical source coord must not appear either"))))
+
+(deftest a-dynamic-authored-value-wins
+  (let [html (render dynamic-collision #js {:v "dynamic-view"})]
+    (is (str/includes? html "data-rf-view=\"dynamic-view\"")
+        "a prop-valued host-root attr survives — authored-own-value-wins")
+    (is (not (str/includes? html "/dynamic-collision\""))
+        "the canonical view id did not overwrite the authored dynamic value")))
+
+(deftest a-ui-spread-authored-value-wins
+  (let [html (render spread-collision #js {})]
+    (is (str/includes? html "data-rf-view=\"spread-view\"")
+        "a ui/spread-merged value survives — matching the JVM ui/spread path")
+    (is (not (str/includes? html "/spread-collision\""))
+        "the canonical view id did not overwrite the spread value")))
+
+(deftest no-collision-still-carries-the-canonical-evidence
+  (let [html (render no-collision #js {})]
+    (is (str/includes? html "data-rf-view=\"")
+        "an uncollided host root still gains the honest annotation")
+    (is (boolean (re-find #"data-rf-view=\"[^\"]*/no-collision\"" html))
+        "the canonical view id is stamped when the author supplies none")))

--- a/implementation/ui/test/re_frame/ui/authored_collision_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/authored_collision_jvm_test.clj
@@ -8,7 +8,12 @@
   unconditionally, so an authored LITERAL host-root value was overwritten by the
   framework value. A DYNAMIC / `ui/spread` authored value already won on the JVM
   (it layers over `:static` at runtime), so this pins the remaining static path
-  and the cross-host agreement with the CLJS set-if-absent law."
+  and the cross-host agreement with the CLJS set-if-absent law.
+
+  CROSS-HOST MATRIX: this file and its CLJS twin `authored_collision_cljs_test`
+  assert the SAME authored values for the SAME prop-construction paths, pinning
+  the collision law cross-host by construction (the shared parity corpus carries
+  no collision fixture — the annotation spelling is an elision sentinel)."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.ui :as ui :refer [defview]]
             [re-frame.ui.tree :as tree]))
@@ -18,6 +23,10 @@
   [:div.host {:data-rf-view "authored-view"
               :data-rf2-source-coord "authored-coord"}
    "body"])
+
+(defview safe-owned-collision
+  [{:keys [caller]}]
+  [:div (ui/spread-safe {:data-rf-view "owned-view"} caller)])
 
 (defview no-collision
   []
@@ -41,6 +50,12 @@
     (testing "the canonical evidence did not leak in"
       (is (not= "re-frame.ui.authored-collision-jvm-test/static-collision"
                 (:data-rf-view attrs))))))
+
+(deftest a-spread-safe-owned-authored-value-wins-on-the-jvm-tree
+  (let [attrs (host-root-attrs (tree/render safe-owned-collision {:caller {:data-c "c"}}))]
+    (is (= "owned-view" (:data-rf-view attrs))
+        "the spread-safe OWNED value survives — owned wins over the evidence")
+    (is (= "c" (:data-c attrs)) "the caller attr also rides through")))
 
 (deftest no-collision-still-carries-the-canonical-evidence
   (let [attrs (host-root-attrs (tree/render no-collision {}))]

--- a/implementation/ui/test/re_frame/ui/authored_collision_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/authored_collision_jvm_test.clj
@@ -1,0 +1,51 @@
+(ns re-frame.ui.authored-collision-jvm-test
+  "rf2-x1nbv (98.1 slice c — audit obligation #2), JVM side: `static-form` obeys
+  the AUTHORED-OWN-VALUE-WINS collision law. When a view author supplies a
+  host-root attr spelled like the annotation, the JVM structural tree preserves
+  the authored value — the compiler evidence only FILLS a key the author omitted.
+
+  BEFORE the fix, `static-form` `assoc`'d the annotation onto `:static`
+  unconditionally, so an authored LITERAL host-root value was overwritten by the
+  framework value. A DYNAMIC / `ui/spread` authored value already won on the JVM
+  (it layers over `:static` at runtime), so this pins the remaining static path
+  and the cross-host agreement with the CLJS set-if-absent law."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ui :as ui :refer [defview]]
+            [re-frame.ui.tree :as tree]))
+
+(defview static-collision
+  []
+  [:div.host {:data-rf-view "authored-view"
+              :data-rf2-source-coord "authored-coord"}
+   "body"])
+
+(defview no-collision
+  []
+  [:div.plain "x"])
+
+(defn- host-root-attrs
+  "The `:attrs` of the outermost element node in the rendered structural tree —
+  the view's compiler-owned host root."
+  [tree]
+  (->> (tree-seq map? #(filter map? (:children %)) tree)
+       (filter :tag)
+       first
+       :attrs))
+
+(deftest a-literal-authored-value-wins-on-the-jvm-tree
+  (let [attrs (host-root-attrs (tree/render static-collision {}))]
+    (testing "the author's literal own values survive on the host root"
+      (is (= "authored-view" (:data-rf-view attrs))
+          "RED before the static-form guard — the annotation overwrote it")
+      (is (= "authored-coord" (:data-rf2-source-coord attrs))))
+    (testing "the canonical evidence did not leak in"
+      (is (not= "re-frame.ui.authored-collision-jvm-test/static-collision"
+                (:data-rf-view attrs))))))
+
+(deftest no-collision-still-carries-the-canonical-evidence
+  (let [attrs (host-root-attrs (tree/render no-collision {}))]
+    (is (= ":re-frame.ui.authored-collision-jvm-test/no-collision"
+           (:data-rf-view attrs))
+        "an uncollided host root still gains the honest view id")
+    (is (string? (:data-rf2-source-coord attrs))
+        "and the source coordinate")))

--- a/implementation/ui/test/re_frame/ui/parity_fixtures.cljc
+++ b/implementation/ui/test/re_frame/ui/parity_fixtures.cljc
@@ -522,25 +522,15 @@
   [:div.attrish
    [:parity-attrish {:tab-index idx :role "note" :data-k "keep"}]])
 
-;; rf2-x1nbv — the host-root view-evidence AUTHORED-OWN-VALUE-WINS collision law.
-;; A view whose compiler-owned root authors `data-rf-view` /
-;; `data-rf2-source-coord` (the annotation spelling) keeps the AUTHORED value on
-;; BOTH emitters — the compiler evidence never overwrites it. The two hosts agree
-;; by construction (CLJS set-if-absent over the final props object; JVM
-;; static-form fills only absent keys / dyn layered over static), so a divergence
-;; in either annotation path fails the corpus.
-(defview collision-root
-  "Literal host-root attrs spelled like the annotation — authored values win."
-  [{:keys [tag]}]
-  [:div.collide {:data-rf-view "authored-view"
-                 :data-rf2-source-coord "authored-coord"
-                 :data-x tag}])
-
-(defview collision-safe-owned
-  "A `ui/spread-safe` OWNED map authors the annotation spelling — the owned own
-  value wins over the compiler evidence AND the caller (owned-wins)."
-  [{:keys [caller]}]
-  [:div.safe-collide (ui/spread-safe {:data-rf-view "owned-view"} caller)])
+;; NOTE (rf2-x1nbv): the host-root AUTHORED-OWN-VALUE-WINS collision law is pinned
+;; cross-host by the dedicated per-host tests (authored_collision_cljs_test +
+;; authored_collision_jvm_test) asserting IDENTICAL authored values, NOT by a
+;; corpus fixture. A collision fixture authors `data-rf-view` /
+;; `data-rf2-source-coord` — the annotation spelling — which is an elision
+;; sentinel: in the advanced/prod build the compiler annotation is DCE'd but the
+;; AUTHORED attr legitimately survives, so the prod-elision corpus's blunt
+;; `strip-view-evidence` (which removes those names from the JVM truth) would
+;; report a false divergence. Keeping the law out of the shared corpus avoids that.
 
 ;; ---------------------------------------------------------------------------
 ;; Cases — pure data; the SINGLE corpus both hosts consume
@@ -583,9 +573,6 @@
    :presence-toasts       presence-toasts
    :presence-inline       presence-inline
    :ce-attrish            custom-element-attrish
-   ;; rf2-x1nbv — host-root authored-collision law
-   :collision-root        collision-root
-   :collision-safe-owned  collision-safe-owned
    :page            page})
 
 (def cases
@@ -653,8 +640,4 @@
                                                                      {:id "n2" :label "two & <three>"}]}}
    {:id :ce-declared-attr-name :view :ce-attrish     :props {:idx "3"}}
    {:id :trusted-hostile      :view :trusted         :props {:markup "<a href=\"javascript:alert(1)\" target=\"_blank\">click</a><b>bold & raw</b>"}}
-   ;; rf2-x1nbv — the cross-host authored-collision matrix (static literal + a
-   ;; spread-safe owned map); both emitters preserve the authored value.
-   {:id :collision-root       :view :collision-root  :props {:tag "t"}}
-   {:id :collision-safe-owned :view :collision-safe-owned :props {:caller {:data-c "c"}}}
    {:id :page                 :view :page            :props {:items items-3 :on? true}}])

--- a/implementation/ui/test/re_frame/ui/parity_fixtures.cljc
+++ b/implementation/ui/test/re_frame/ui/parity_fixtures.cljc
@@ -522,6 +522,26 @@
   [:div.attrish
    [:parity-attrish {:tab-index idx :role "note" :data-k "keep"}]])
 
+;; rf2-x1nbv — the host-root view-evidence AUTHORED-OWN-VALUE-WINS collision law.
+;; A view whose compiler-owned root authors `data-rf-view` /
+;; `data-rf2-source-coord` (the annotation spelling) keeps the AUTHORED value on
+;; BOTH emitters — the compiler evidence never overwrites it. The two hosts agree
+;; by construction (CLJS set-if-absent over the final props object; JVM
+;; static-form fills only absent keys / dyn layered over static), so a divergence
+;; in either annotation path fails the corpus.
+(defview collision-root
+  "Literal host-root attrs spelled like the annotation — authored values win."
+  [{:keys [tag]}]
+  [:div.collide {:data-rf-view "authored-view"
+                 :data-rf2-source-coord "authored-coord"
+                 :data-x tag}])
+
+(defview collision-safe-owned
+  "A `ui/spread-safe` OWNED map authors the annotation spelling — the owned own
+  value wins over the compiler evidence AND the caller (owned-wins)."
+  [{:keys [caller]}]
+  [:div.safe-collide (ui/spread-safe {:data-rf-view "owned-view"} caller)])
+
 ;; ---------------------------------------------------------------------------
 ;; Cases — pure data; the SINGLE corpus both hosts consume
 ;; ---------------------------------------------------------------------------
@@ -563,6 +583,9 @@
    :presence-toasts       presence-toasts
    :presence-inline       presence-inline
    :ce-attrish            custom-element-attrish
+   ;; rf2-x1nbv — host-root authored-collision law
+   :collision-root        collision-root
+   :collision-safe-owned  collision-safe-owned
    :page            page})
 
 (def cases
@@ -630,4 +653,8 @@
                                                                      {:id "n2" :label "two & <three>"}]}}
    {:id :ce-declared-attr-name :view :ce-attrish     :props {:idx "3"}}
    {:id :trusted-hostile      :view :trusted         :props {:markup "<a href=\"javascript:alert(1)\" target=\"_blank\">click</a><b>bold & raw</b>"}}
+   ;; rf2-x1nbv — the cross-host authored-collision matrix (static literal + a
+   ;; spread-safe owned map); both emitters preserve the authored value.
+   {:id :collision-root       :view :collision-root  :props {:tag "t"}}
+   {:id :collision-safe-owned :view :collision-safe-owned :props {:caller {:data-c "c"}}}
    {:id :page                 :view :page            :props {:items items-3 :on? true}}])

--- a/implementation/ui/test/re_frame/ui/render_static_strip_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/render_static_strip_jvm_test.clj
@@ -1,0 +1,89 @@
+(ns re-frame.ui.render-static-strip-jvm-test
+  "rf2-zgezz (98.1 slice c — audit obligations #3 + #4): `render-static`'s
+  host-root view-evidence strip. Two focused JVM proofs on the seam itself
+  (`re-frame.ui.tree/strip-host-root-annotation` + `emit-static-html`), with the
+  SSR emitter stubbed so no artefact is needed.
+
+  #3 PROVENANCE — the strip removes ONLY the compiler-generated markers, scoped by
+  the out-of-band `:rf.ui/host-root-annotation` provenance metadata, and PRESERVES
+  programmer-authored attributes of the same spelling (nested OR an authored own
+  value on the host root, under the rf2-x1nbv collision law). The pre-fix blunt
+  recursive `dissoc` deleted authored nested attrs.
+
+  #4 DEBUG-DISABLED BYPASS — when `interop/debug-enabled?` is false the compiler
+  emitted no annotation and no provenance, so `emit-static-html` skips the strip
+  ENTIRELY: the serialiser receives the SAME tree object (identical root/children
+  identities), not a clone."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.interop :as interop]
+            [re-frame.ui.tree :as tree]))
+
+(def ^:private strip #'re-frame.ui.tree/strip-host-root-annotation)
+
+(def ^:private canon
+  {:data-rf2-source-coord "app.probe:widget:1:2"
+   :data-rf-view ":app.probe/widget"})
+
+;; ---------------------------------------------------------------------------
+;; #3 PROVENANCE
+;; ---------------------------------------------------------------------------
+
+(deftest strip-removes-only-the-generated-markers
+  (testing "a host root whose values equal the canonical annotation is stripped"
+    (let [node (with-meta {:tag :div
+                           :attrs {:data-rf2-source-coord "app.probe:widget:1:2"
+                                   :data-rf-view ":app.probe/widget"
+                                   :class "card"}}
+                          {:rf.ui/host-root-annotation canon})
+          out  (strip node)]
+      (is (= {:class "card"} (:attrs out))
+          "the two compiler markers are removed; the authored :class survives")))
+
+  (testing "an AUTHORED own value on the host root (differs from canonical) survives"
+    (let [node (with-meta {:tag :div
+                           :attrs {:data-rf-view "authored-view" :class "card"}}
+                          {:rf.ui/host-root-annotation canon})
+          out  (strip node)]
+      (is (= {:data-rf-view "authored-view" :class "card"} (:attrs out))
+          "the rf2-x1nbv collision law is honoured — authored value preserved")))
+
+  (testing "a NESTED authored attribute (no provenance metadata) is untouched"
+    (let [tree (with-meta
+                 {:tag :section
+                  :attrs {:data-rf2-source-coord "app.probe:widget:1:2"
+                          :data-rf-view ":app.probe/widget"}
+                  :children [{:tag :span
+                              :attrs {:data-rf-view "nested-authored"}}]}
+                 {:rf.ui/host-root-annotation canon})
+          out  (strip tree)]
+      (is (nil? (:attrs out))
+          "the host root's markers are gone (both matched canonical)")
+      (is (= {:data-rf-view "nested-authored"}
+             (:attrs (first (:children out))))
+          "RED before provenance — the recursive dissoc deleted this authored attr"))))
+
+;; ---------------------------------------------------------------------------
+;; #4 DEBUG-DISABLED BYPASS
+;; ---------------------------------------------------------------------------
+
+(deftest debug-disabled-bypasses-the-strip-walk-entirely
+  (let [tree     (with-meta {:rf.ui/tree-version 1
+                             :tag :div
+                             :attrs {:data-rf-view ":app.probe/widget"
+                                     :data-rf2-source-coord "app.probe:widget:1:2"}
+                             :children [{:tag :p :attrs {:data-rf-view "nested"}}]}
+                            {:rf.ui/host-root-annotation canon})
+        captured (atom ::unset)]
+    (with-redefs [tree/resolve-ssr-emitter (fn [] (fn [t] (reset! captured t) "<div></div>"))]
+      (testing "debug OFF — the emitter receives the very same tree object"
+        (with-redefs [interop/debug-enabled? false]
+          (tree/emit-static-html tree)
+          (is (identical? tree @captured)
+              "no clone/walk — the strip is bypassed when debug is disabled")))
+      (testing "debug ON — the emitter receives a stripped (walked) tree"
+        (with-redefs [interop/debug-enabled? true]
+          (tree/emit-static-html tree)
+          (is (not (identical? tree @captured))
+              "the strip ran, producing a new tree")
+          (is (nil? (:attrs @captured))
+              "the host root's canonical markers were removed"))))))


### PR DESCRIPTION
Completes the two out-of-fence audit obligations rf2-hac8p (#6605) filed from the PR #6566 chronological audit — obligation #2 (rf2-x1nbv) and obligations #3+#4 (rf2-zgezz). Cross-emitter per hac8p's ruling A: a prop/attribute annotation is inherently cross-emitter, so both emitters move in lockstep.

## rf2-x1nbv — authored-value collision law (cross-emitter)

The DEV host-root view-evidence annotation (`data-rf-view` / `data-rf2-source-coord`) OVERWROTE an author-supplied own value: CLJS `annotate-host-root-props` `unchecked-set` both keys after final props construction; JVM `static-form` `assoc`'d them onto `:static` unconditionally. A live `ui/spread` probe spoofed the pair on JVM (authored already won there via the runtime dyn-over-static merge) while CLJS final-wrote the canonical values — a cross-host divergence and dishonest tool identity.

Implements the adapter / trust-programmer law — **authored own value wins** — identically on both emitters:
- **emit_cljs `annotate-host-root-props`**: stamp each key only when the FINAL props object does not already carry it (set-if-absent, after every spread/spread-safe merge). The `undefined?` reads sit inside the `goog.DEBUG` gate and DCE with the stamp.
- **emit_jvm `static-form`**: fill only the annotation keys the author did not supply as a literal `:static` attr; a dynamic / `ui/spread` / spread-safe authored value already wins at runtime, so this closes the remaining static path.

## rf2-zgezz — render-static provenance (#3) + debug-disabled bypass (#4)

- **#3**: `strip-host-root-annotation` recursively `dissoc`'d the two names from EVERY node's attrs, deleting programmer-authored nested attributes of the same spelling. Now scoped by out-of-band, debug-gated provenance metadata (`:rf.ui/host-root-annotation {key -> canonical value}`) attached by `emit_jvm/with-host-root-provenance`; the strip removes a key ONLY where its runtime value still equals the canonical value, preserving authored own values (nested or host-root, under the x1nbv law). Metadata is invisible to structural `=` (goldens), normalization N (parity), and every HTML serialiser — zero blast radius.
- **#4**: `emit-static-html` bypasses the strip entirely when `interop/debug-enabled?` is false (`cond-> tree interop/debug-enabled? strip`) — no clone/walk in a production build.

## Quality gates

All foreground, run to completion:
- JVM ui suite (`clojure -M:test`): 1017 tests, 0 failures — includes `authored_collision_jvm_test`, `render_static_strip_jvm_test`, and `parity_corpus_jvm` with the new `collision-root` / `collision-safe-owned` fixtures.
- ssr JVM suite (`clojure -M:test`): 524 tests, 0 failures — includes `render-static-preserves-authored-nested-attrs`.
- **Full CLJS suite (`npm run test:cljs`) TO COMPLETION**: 10352 tests / 51125 assertions, 0 failures — the cross-emitter parity teeth (hac8p's reopening reason). Includes `authored_collision_cljs_test` (real react-dom/server: static / dynamic / ui.spread authored-wins + no-collision canonical regression guard) and the parity corpus collision fixtures.
- `npm run test:elision`: production 60/60 absent, control 60/60 present — annotations still DCE at runtime.

No regression to hac8p's conditional-root annotation or ny34u's render-key DOM stamp. CODE-ONLY — the Spec 004 §View-identity annotation-vocab note stays deferred to the S4 (spec/004) fence.
