### PR TITLE
fix(ui): substrate record — render-key truth + StrictMode replay idempotence (rf2-8ds0v)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -3255,9 +3255,17 @@
 ;; OPTION 1A (honest capture). The record carries exactly what the substrate owns
 ;; at commit, and NOT what it cannot honestly source:
 ;;   - :render-key is a MODULE-GLOBAL monotonic integer minted fresh at EACH
-;;     connected commit (so re-renders increment it) — a total order over
-;;     committed renders the sub→view recompute edge (`:rf.sub/reader-render-key`)
-;;     and a React Performance-Tracks timeline correlate against.
+;;     DISTINCT connected commit (so a genuine re-render increments it; a
+;;     StrictMode re-commit of the SAME capture does NOT — see
+;;     `mint-commit-record!`) — a total order over committed renders for the
+;;     `data-rf-render-key` DOM stamp (rf2-ny34u) and a React Performance-Tracks
+;;     timeline correlate. It is NOT the legacy `:rf.sub/reader-render-key`: that
+;;     is a DIFFERENT identity (the stock-adapter `[view-id instance-token]` wire
+;;     shape), stamped during render-time sub reads from `re-frame.views/
+;;     *render-key*` — a dynamic var implementation/ui never binds, so a compiled
+;;     defview read stamps none. The direct sub→view relation is this record's
+;;     OWN `:observations`/`:query` rows, not a cross-key correlation to a key
+;;     this substrate never mints (rf2-8ds0v truth repair, PR #6562).
 ;;   - frame attribution is PER-OBSERVATION, never a single fabricated fact: a
 ;;     ViewCell observes a SET of frames (an override-only cell observes none),
 ;;     so each observation carries its own target's :frame-id and the record
@@ -3494,43 +3502,68 @@
   longer be LOST: a fold that commits BEFORE the CAS fails it (the loop re-reads,
   fences it by the waterline, and keeps it as residual), and one AFTER enrols a
   fresh next stash. `next-render-key!` is minted ONCE before the loop, so a retry
-  never wastes a key. Single-threaded CLJS runs exactly one iteration."
+  never wastes a key. Single-threaded CLJS runs exactly one iteration.
+
+  STRICTMODE REPLAY IDEMPOTENCE (rf2-8ds0v, PR #6567). React 19 StrictMode
+  intentionally re-invokes the ViewCell's reconcile layout effect
+  (setup→cleanup→setup) with the SAME committed capture (the effect closure of
+  ONE committed render). The reconciler is already OWNERSHIP-idempotent (kept-
+  check retains/reacquires), but a naive re-mint OVERWROTE the genuine first
+  record — its `:mount` cause — with a spurious `:foreign-or-react` replay record,
+  advanced `:render-key` twice for ONE rendered commit, and drained the causes.
+  So a mint is keyed on the ORIGINATING capture's object identity (stamped as
+  `:commit-record-capture`): a re-commit of the EXACT same capture is a no-op —
+  the first record stands, `:render-key` does not advance (the counter is not even
+  touched), and causes are not drained. This is not a StrictMode special case but
+  the honest invariant it exposed: ONE committed-instance record per DISTINCT
+  committed render. A genuine re-render (or a real hide→reveal that re-renders)
+  produces a FRESH capture object, so it is never mistaken for a replay and mints
+  honestly; a pure hide→reveal that does NOT re-render reuses the capture and is
+  correctly not a new committed render."
   [^ViewCell cell cap new-order new-by mounting? to-acquire]
-  (let [st         (state cell)
-        st0        @st
-        waterline  (:cause-waterline cap)
-        ;; ONE ruled record per (re)acquired Story-override target, in render order
-        ;; — `keep` preserves siblings that `some` (first-only) dropped (rf2-sy536).
-        override-details (into []
-                               (keep (fn [sid]
-                                       (let [t (:target (new-by sid))]
-                                         (when (= :story-override (:kind t))
-                                           {:override-id (:override-id t)
-                                            :version     (:version t)}))))
-                               to-acquire)
-        base       {:render-key    (next-render-key!)
-                    :view-id       (:view-id st0)
-                    :generation    (:generation cap)
-                    :root-id       (:root st0)
-                    :connection    :connected
-                    :observations  (project-observations new-order new-by)}]
-    (loop []
-      (let [s        @st
-            pending  (or (:pending-commit-causes s) [])
-            n        (count pending)
-            cut      (if (and waterline (< waterline n)) waterline n)
-            eligible (subvec pending 0 cut)
-            residual (subvec pending cut)
-            causes   (commit-causes eligible mounting? override-details
-                                    (boolean (:local-state-committed? s)))
-            record   (assoc base :rf.view/causes causes)
-            next-s   (-> (assoc s :commit-record record)
-                         (assoc :pending-commit-causes residual)
-                         (dissoc :local-state-committed?))]
-        (when-some [barrier *commit-publish-barrier*] (barrier cell))
-        (if (compare-and-set! st s next-s)
-          record
-          (recur))))))
+  (let [st  (state cell)
+        st0 @st]
+    (if (identical? cap (:commit-record-capture st0))
+      ;; StrictMode replay of the EXACT same committed capture — idempotent: the
+      ;; genuine first record stands, no render-key is minted, no causes drained.
+      (:commit-record st0)
+      (let [waterline  (:cause-waterline cap)
+            ;; ONE ruled record per (re)acquired Story-override target, in render
+            ;; order — `keep` preserves siblings `some` (first-only) dropped
+            ;; (rf2-sy536).
+            override-details (into []
+                                   (keep (fn [sid]
+                                           (let [t (:target (new-by sid))]
+                                             (when (= :story-override (:kind t))
+                                               {:override-id (:override-id t)
+                                                :version     (:version t)}))))
+                                   to-acquire)
+            base       {:render-key    (next-render-key!)
+                        :view-id       (:view-id st0)
+                        :generation    (:generation cap)
+                        :root-id       (:root st0)
+                        :connection    :connected
+                        :observations  (project-observations new-order new-by)}]
+        (loop []
+          (let [s        @st
+                pending  (or (:pending-commit-causes s) [])
+                n        (count pending)
+                cut      (if (and waterline (< waterline n)) waterline n)
+                eligible (subvec pending 0 cut)
+                residual (subvec pending cut)
+                causes   (commit-causes eligible mounting? override-details
+                                        (boolean (:local-state-committed? s)))
+                record   (assoc base :rf.view/causes causes)
+                next-s   (-> (assoc s :commit-record record)
+                             ;; stamp the originating capture so a StrictMode
+                             ;; re-commit of THIS capture is caught as a replay.
+                             (assoc :commit-record-capture cap)
+                             (assoc :pending-commit-causes residual)
+                             (dissoc :local-state-committed?))]
+            (when-some [barrier *commit-publish-barrier*] (barrier cell))
+            (if (compare-and-set! st s next-s)
+              record
+              (recur))))))))
 
 (defn- commit*
   "Run the 8-step layout commit for `cell` against the exact immutable

--- a/implementation/ui/test/re_frame/ui/reactive_commit_record_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_commit_record_cljs_test.cljc
@@ -100,6 +100,59 @@
         (str "render-key increments fresh per connected commit — " (pr-str keys)))))
 
 ;; ===========================================================================
+;; StrictMode replay idempotence (rf2-8ds0v, PR #6567) — re-committing the EXACT
+;; SAME capture mints NO second record, does not advance render-key, and does not
+;; overwrite the genuine :mount record with a spurious :foreign-or-react one.
+;; ===========================================================================
+
+(deftest re-committing-the-same-capture-is-idempotent-under-strictmode-replay
+  (rf/reg-sub :cr/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell    (reactive/make-cell ::v)
+        ;; ONE render → ONE immutable capture. React 19 StrictMode re-invokes the
+        ;; reconcile layout effect (setup→cleanup→setup) with THIS exact capture
+        ;; object; the substrate must treat the re-commit as idempotent.
+        [_ cap] (render! cell [[[:cr/site 0] [:cr/a]]])]
+    ;; First commit of the fresh capture mints the genuine committed instance.
+    (reactive/commit! cell cap)
+    (let [rec1 (reactive/commit-record cell)
+          rk1  (reactive/render-key cell)]
+      (is (= [{:cause :mount}] (:rf.view/causes rec1))
+          "the first connected commit of this capture is caused by :mount")
+      (is (integer? rk1) "it minted an integer render-key")
+      ;; Drive the StrictMode effect double-invoke at the substrate seam: the
+      ;; layout-effect CLEANUP disconnects the cell, then the effect re-runs with
+      ;; the IDENTICAL capture (React did not re-render between cleanup and setup).
+      (reactive/disconnect! cell)
+      (reactive/commit! cell cap)
+      (let [rec2 (reactive/commit-record cell)
+            rk2  (reactive/render-key cell)]
+        (is (identical? rec1 rec2)
+            "the replayed re-commit published NO new record — the genuine first
+             record stands (not overwritten)")
+        (is (= [{:cause :mount}] (:rf.view/causes rec2))
+            "the :mount cause is NOT overwritten by a spurious :foreign-or-react
+             replay record")
+        (is (= rk1 rk2)
+            "render-key does NOT advance twice for ONE rendered commit")))))
+
+(deftest a-fresh-render-after-a-commit-still-mints-a-new-record
+  ;; The idempotence guard keys on capture OBJECT identity, so a genuine
+  ;; re-render (a DISTINCT capture) is never mistaken for a replay — it mints a
+  ;; new record with a strictly greater render-key.
+  (rf/reg-sub :cr/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell    (reactive/make-cell ::v)
+        [_ cap1] (render! cell [[[:cr/site 0] [:cr/a]]])]
+    (reactive/commit! cell cap1)
+    (let [rk1 (reactive/render-key cell)
+          [_ cap2] (render! cell [[[:cr/site 0] [:cr/a]]])]
+      (is (not (identical? cap1 cap2)) "each render produces a distinct capture")
+      (reactive/commit! cell cap2)
+      (is (> (reactive/render-key cell) rk1)
+          "a distinct capture is a distinct committed render — render-key advances"))))
+
+;; ===========================================================================
 ;; Observations carry PER-OBSERVATION frame attribution (Ruling-1 amendment)
 ;; ===========================================================================
 

--- a/implementation/ui/test/re_frame/ui/reactive_strictmode_replay_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/reactive_strictmode_replay_dom_cljs_test.cljs
@@ -1,0 +1,167 @@
+(ns re-frame.ui.reactive-strictmode-replay-dom-cljs-test
+  "rf2-8ds0v (PR #6567 audit reopen) — the React 19 StrictMode committed-instance
+  RECORD replay, on the REAL React 19 + real DOM path (the browser reproduction
+  that reopened the obligation).
+
+  React 19 StrictMode intentionally re-invokes a mounting component's layout
+  effects (setup→cleanup→setup). For the ViewCell that means its reconcile layout
+  effect runs `reactive/commit!` with the EXACT SAME committed capture twice, with
+  a `disconnect!` (the effect cleanup) in between. The reconciler was already
+  OWNERSHIP-idempotent, but the per-commit view-evidence record was NOT: the
+  replayed re-commit OVERWROTE the genuine first `:mount` record with a spurious
+  `:foreign-or-react` one and advanced `:render-key` twice for a single rendered
+  commit (the exact browser symptom the audit recorded). The fix keys the mint on
+  the originating capture's identity so a re-commit of the same capture is a no-op
+  (`reactive/mint-commit-record!`).
+
+  This proves the fix on the real path: after a genuine StrictMode dev
+  double-invoke (positively controlled by the doubled body count), the owning
+  cell's committed-instance record is STILL the genuine `:mount` record — not
+  overwritten by a replay. Removing the guard turns the `:mount` assertions red
+  (the record reads `:foreign-or-react`), so this cannot pass vacuously.
+
+  Browser-only body — `-dom-cljs-test$` opts into `:browser-test`; `:node-test`
+  loads it too, where the body gates on `(browser?)` and no-ops. The production
+  elision of the whole record plane is covered by `tool_evidence_elision_prod_test`
+  / `render_key_dom_stamp_elision_prod_test`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            ["react" :as react]
+            ["react-dom" :as react-dom]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]
+            [re-frame.ui :as ui :refer [defview frame-provider sub]]
+            [re-frame.ui.client :as client]
+            [re-frame.ui.reactive :as reactive]
+            [re-frame.ui.viewcell]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+;; StrictMode's full mount→cleanup→mount effect replay is driven synchronously by
+;; React 19's `act` (unlike `flushSync`, which does not complete the layout-effect
+;; replay). Enable the act environment for this suite and restore the prior value
+;; in :after so sibling suites on the shared browser page are unaffected.
+(defonce ^:private prior-act-env (atom nil))
+
+(defn- enable-act-env! []
+  (when (exists? js/globalThis)
+    (reset! prior-act-env (.-IS_REACT_ACT_ENVIRONMENT js/globalThis))
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)))
+
+(defn- restore-act-env! []
+  (when (exists? js/globalThis)
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) @prior-act-env)))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+   {:adapter ui/adapter :ambient-frame nil :async? true})
+  {:before #(do (enable-act-env!) (reactive/reset-scheduler!) (client/reset-live-roots!))
+   :after  #(do (reactive/reset-scheduler!) (client/reset-live-roots!) (restore-act-env!))})
+
+(def ^:private frame-kw :sm-replay/frame)
+(def ^:private StrictMode react/StrictMode)
+
+(defn- container [] (js/document.createElement "div"))
+
+;; Counts leaf render-body invocations — the POSITIVE CONTROL that StrictMode's
+;; dev double-invoke actually happened (it renders the body twice per commit).
+(defonce ^:private body-runs (atom 0))
+
+(defview replay-view
+  "A sub-bearing view (so it owns a ViewCell) with a compiler-owned host root."
+  [_]
+  (let [_ (swap! body-runs inc)]
+    [:div.sm-replay (str (sub [:smr/n]))]))
+
+;; The child mounts into an ALREADY-COMMITTED StrictMode subtree (toggled in by a
+;; sub), so React runs the newly-mounted ViewCell's layout effects
+;; setup→cleanup→setup on the SAME preserved fiber — the exact same-capture
+;; re-commit the audit reproduced. (A StrictMode root's initial mount instead
+;; rebuilds a fresh fiber, so its survivor never sees the replay — rf2-vxgfnd.164.)
+(defview shell-view
+  [_]
+  [:div.sm-shell
+   (when (sub [:smr/show?])
+     [replay-view {}])])
+
+(defn- register-app! []
+  (rf/make-frame {:id frame-kw :doc "StrictMode record-replay probe frame"})
+  (rf/reg-sub :smr/n (fn [db _] (:n db)))
+  (rf/reg-sub :smr/show? (fn [db _] (:show? db)))
+  (rf/reg-event :smr/seed (fn [_ _] {:db {:n 7 :show? false}}))
+  (rf/reg-event :smr/show (fn [{:keys [db]} _] {:db (assoc db :show? true)})))
+
+(defn- owning-cell
+  "The live ViewCell that committed ownership of [:smr/n] under this frame."
+  []
+  (some (fn [cell]
+          (when (contains? (reactive/committed-target-keys cell)
+                           [:sub frame-kw [:smr/n]])
+            cell))
+        (reactive/current-live-cells)))
+
+;; ===========================================================================
+;; A real StrictMode dev double-invoke of the ViewCell's reconcile layout effect
+;; must NOT replay the committed-instance record.
+;; ===========================================================================
+
+(deftest strictmode-replay-does-not-duplicate-the-committed-instance-record
+  (if-not (browser?)
+    (is true ":node — no DOM; the :browser-test runner exercises the DOM body")
+    (async done
+      (let [act-fn (.-act react)]
+        (if-not (fn? act-fn)
+          (do (is true "React.act unavailable in this runner") (done))
+          (do
+            (register-app!)
+            (rf/dispatch-sync [:smr/seed] {:frame frame-kw})
+            (reset! body-runs 0)
+            (let [c    (container)
+                  root (atom nil)
+                  finish!
+                  (fn []
+                    (.then (js/Promise.resolve (act-fn #(some-> @root ui/unmount!)))
+                           (fn [_] (.remove c) (done))))
+                  assert-record!
+                  (fn [_]
+                    (let [cell (owning-cell)]
+                      (testing "the StrictMode dev double-invoke really replayed (positive control)"
+                        (is (> @body-runs 1)
+                            "StrictMode rendered the replay-view body more than once — a
+                             replay genuinely occurred, so this proof cannot pass vacuously"))
+                      (is (= "7" (.-textContent (.querySelector c ".sm-replay")))
+                          "the toggled-in view mounted and rendered under StrictMode")
+                      (is (some? cell) "exactly one live cell owns the subscription")
+                      (when (some? cell)
+                        (let [record (reactive/commit-record cell)]
+                          (is (map? record)
+                              "the connected commit published a committed-instance record")
+                          (is (= :connected (:connection record))
+                              "the cell is connected after the replay")
+                          (is (= [{:cause :mount}] (:rf.view/causes record))
+                              "GREEN: the genuine :mount record STANDS — the StrictMode
+                               re-commit of the SAME capture did NOT overwrite it with a
+                               spurious :foreign-or-react replay record")
+                          (is (integer? (:render-key record))
+                              "render-key is a single integer for the one rendered commit"))))
+                    (finish!))
+                  ;; Step 2: toggle the child IN under the already-committed
+                  ;; StrictMode subtree; its ViewCell's layout effects replay on the
+                  ;; preserved fiber (setup→cleanup→setup), re-committing the SAME
+                  ;; capture. THEN assert the record was not replayed.
+                  show-child!
+                  (fn [_]
+                    (reset! body-runs 0)
+                    (.then (js/Promise.resolve
+                             (act-fn #(rf/dispatch-sync [:smr/show] {:frame frame-kw})))
+                           assert-record!))]
+              (.appendChild js/document.body c)
+              ;; Step 1: mount the shell (child absent) under a PERSISTENT StrictMode.
+              (.then (js/Promise.resolve
+                       (act-fn
+                         #(reset! root
+                                  (ui/mount [StrictMode {}
+                                             [frame-provider {:frame frame-kw}
+                                              [shell-view {}]]]
+                                            c {:root-id :sm-replay/root}))))
+                     show-child!))))))))


### PR DESCRIPTION
Two audit-reopened obligations on the `.98.1` S6 committed-instance record (`implementation/ui/src/re_frame/ui/reactive.cljc`), both DEBUG-gated / production-erased. Fence: reactive.cljc + its tests only (no spec — the normative spec rides slice d; disjoint from hac8p / S4).

## Obligation 1 — PR #6562 truth repair (bounded)

The delivered `OPTION 1A` comment claimed the new integer `:render-key` correlates the sub→view reader edge (`:rf.sub/reader-render-key`). That is false: the legacy reader key is a **different identity** (the stock-adapter `[view-id instance-token]` wire shape, stamped from `re-frame.views/*render-key*` during render-time sub reads) that `implementation/ui` never binds — a compiled defview read stamps none. Repair removes the false cross-key correlation from the source comment; the honest, direct sub→view relation is each record's own `:observations`/`:query` rows. Keep the integer key (it honestly totally-orders committed instances for the DOM stamp + Performance timeline). No bridge plumbing added.

**before → after:** false "correlates `:rf.sub/reader-render-key`" claim → honest "NOT the legacy reader key; the sub→view relation is `:observations`/`:query`". The code was always honest — only the comment lied — so the positive contract is locked by the existing observations tests (a fresh contract-lock test would have no natural red).

## Obligation 2 — PR #6567 React 19 StrictMode record replay (browser-reproduced)

React 19 StrictMode re-invokes the ViewCell's reconcile layout effect (`setup→cleanup→setup`) with the **same committed capture**. The reconciler was ownership-idempotent, but the record mint was not: the replayed re-commit **overwrote the genuine `:mount` record with a spurious `:foreign-or-react` one and advanced `:render-key` twice for one rendered commit**. `mint-commit-record!` now keys the mint on the originating capture's object identity (`:commit-record-capture`) — a re-commit of the exact same capture is a no-op (record stands, `next-render-key!` not even touched, causes not drained). Not a StrictMode special case but the honest invariant it exposed: **one committed-instance record per distinct committed render**. A genuine re-render produces a fresh capture and mints honestly.

**before → after:** replay mints `{:render-key N+1, :rf.view/causes [{:cause :foreign-or-react}]}` overwriting `{:render-key N, :rf.view/causes [{:cause :mount}]}` → replay is a no-op, `[{:cause :mount}]` / render-key `N` stands.

## Proof (red → green)

- **Headless (JVM+CLJS)** — `reactive_commit_record_cljs_test`: re-committing the same capture is idempotent (record identical, `:mount` not overwritten, render-key not advanced); a distinct capture still mints a greater key. Guard bypassed reproduced exactly `render-key 8→9` and `:mount`→`:foreign-or-react`.
- **Browser (react-dom StrictMode double-invoke)** — new `reactive_strictmode_replay_dom_cljs_test`: a view toggled **into an already-committed StrictMode subtree** (preserved fiber → same-cell `setup→cleanup→setup`, driven by `React.act`) re-commits its capture. Guard bypassed → RED (`actual: [{:cause :foreign-or-react}]`); guard restored → GREEN (`[{:cause :mount}]`), with a `body-runs > 1` positive control proving the replay really occurred. (A root-level StrictMode mount rebuilds a fresh fiber and never lands the same-capture replay on the survivor — rf2-vxgfnd.164 — so the reproduction toggles the child in.)

No regression to cause-attribution (`sy536` / `bvqu0` / `eww3k`) or the `ny34u` render-key DOM stamp (untouched, in `viewcell.cljs`).

## Quality gates

| gate | result |
| --- | --- |
| `cd implementation/ui && clojure -M:test` (full ui JVM) | **1014 tests / 19911 assertions, 0 failures** |
| `npm run test:cljs` (node) | **10346 tests / 51100 assertions, 0 failures** |
| `npm run test:browser` (real DOM, to completion) | **509 tests / 2807 assertions, 0 failures** |
| `npm run test:elision` (production erasure) | **PASS — production 60/60 absent, control 60/60 present** |
