### PR TITLE
docs: correct auth return-to route-state + form-action routing guidance (rf2-67go9 rf2-ppi5k)

### DIFF
--- a/docs/core/how-to/add-auth.md
+++ b/docs/core/how-to/add-auth.md
@@ -228,27 +228,58 @@ The fix is to normalise all three to one target, then redirect identically:
 
 ```clojure
 ;; Adapted from examples/real-apps/realworld_http/routing.cljs
+(defn- in-place-query
+  "Fold an in-place request's query edit onto the current query: :query
+   replaces wholesale ({} clears); :query-merge folds, a nil value dropping a
+   key; neither present carries the current query unchanged."
+  [{:keys [query query-merge]} current-query]
+  (cond
+    (some? query) query
+    query-merge   (into {} (remove (comp nil? val)) (merge current-query query-merge))
+    :else         current-query))
+
+(defn- matched-address
+  "match-url → a resolved address, or nil for a non-match OR a schema-invalid
+   match (:validation-failed? true) — which the runtime itself routes to
+   not-found, so the guard must not treat it as a real destination."
+  [url]
+  (when-let [{:keys [route-id params query fragment validation-failed?]} (routing/match-url url)]
+    (when-not validation-failed?
+      {:to route-id :params (or params {}) :query (or query {}) :fragment fragment})))
+
 (defn- nav-target
-  "Normalise a navigation event to {:id <route-id> :params <map>}; nil for
-   non-navigation events (the guard short-circuits). `current` is the current
-   route slice ([:rf.runtime/routing :current]) — an in-place navigate request
-   resolves against it, exactly as the runtime resolves it."
+  "Normalise a navigation event to a resolved ADDRESS map —
+   {:to <route-id> :params <map> :query <map> :fragment <string-or-nil>}, the
+   FULL route state, so a login bounce-back returns to the exact URL (path,
+   params, query, and fragment). nil for a non-navigation event, a non-match,
+   or a malformed request the runtime's own structural gate will reject
+   (:rf.error/navigate-bad-request) — the guard leaves those to the router
+   rather than reclassifying them as a valid destination. Address keys only:
+   policy fields (:replace?, :scroll, :bypass-guards?) are dropped. `current`
+   is the current route slice ([:rf.runtime/routing :current]) — an in-place
+   request resolves against it, exactly as the runtime resolves it."
   [[ev-id a] current]
   (case ev-id
-    :rf.route/navigate          (let [{:keys [to url params]} a]          ;; a is the request map
-                                  (cond
-                                    to  {:id to :params (or params {})}
-                                    url (when-let [{:keys [route-id params]} (routing/match-url url)]
-                                          {:id route-id :params (or params {})})  ;; {:url ...} escape hatch
-                                    :else                                 ;; in-place: stay on the current route
-                                    {:id (:route-id current) :params (or (:params current) {})}))
-    :rf.route/url-requested           (let [{:keys [to params url]} a]     ;; route-link click
-                                  (cond
-                                    to  {:id to :params (or params {})}
-                                    url (when-let [{:keys [route-id params]} (routing/match-url url)]
-                                          {:id route-id :params (or params {})})))
-    :rf.route/handle-url-change (when-let [{:keys [route-id params]} (routing/match-url a)]
-                                  {:id route-id :params (or params {})})  ;; URL bar / reload / back-forward
+    :rf.route/navigate
+    (let [{:keys [to url params]} a]                          ;; a is the request map
+      (cond
+        to  {:to to :params (or params {}) :query (or (:query a) {}) :fragment (:fragment a)}
+        url (matched-address url)                             ;; {:url ...} escape hatch
+        ;; in-place: no :to/:url/:params, at least one query/fragment edit —
+        ;; stay on the current route, resolve the edit against its query.
+        (and (nil? params)
+             (or (contains? a :query) (contains? a :query-merge) (contains? a :fragment)))
+        {:to       (:route-id current)
+         :params   (or (:params current) {})
+         :query    (in-place-query a (:query current))
+         :fragment (if (contains? a :fragment) (:fragment a) (:fragment current))}
+        :else nil))                                           ;; malformed → router rejects
+    :rf.route/url-requested                                   ;; route-link click
+    (let [{:keys [to url]} a]
+      (cond
+        to  {:to to :params (or (:params a) {}) :query (or (:query a) {}) :fragment (:fragment a)}
+        url (matched-address url)))
+    :rf.route/handle-url-change (matched-address a)           ;; URL bar / reload / back-forward
     nil))
 ```
 
@@ -262,28 +293,28 @@ Now the guard itself. An *event* interceptor's `ctx` splits into two halves: `:c
      ;; The current route slice is framework runtime-db state — read it from the
      ;; :rf.db/runtime coeffect so an in-place navigate request resolves to
      ;; the protected route the user is already on.
-     (if-let [{:keys [id params]} (nav-target (get-in ctx [:coeffects :event])
-                                              (get-in ctx [:coeffects :rf.db/runtime
-                                                           :rf.runtime/routing :current]))]
-       (let [needs-auth? (contains? (:tags (rf/handler-meta :route id)) :requires-auth)
+     (if-let [target (nav-target (get-in ctx [:coeffects :event])
+                                 (get-in ctx [:coeffects :rf.db/runtime
+                                              :rf.runtime/routing :current]))]
+       (let [needs-auth? (contains? (:tags (rf/handler-meta :route (:to target))) :requires-auth)
              logged-in?  (some? (get-in ctx [:coeffects :db :auth :user]))]
          (if (and needs-auth? (not logged-in?))
            (-> ctx
                (assoc :rf/skip-handler? true)        ;; the protected route never commits
-               (assoc-in [:effects :db]              ;; stash the target for the bounce-back
+               (assoc-in [:effects :db]              ;; stash the resolved address for the bounce-back
                          (assoc-in (get-in ctx [:coeffects :db])
-                                   [:auth :return-to] {:id id :params params}))
+                                   [:auth :return-to] target))
                (assoc-in [:effects :fx]
                          [[:dispatch [:rf.route/navigate {:to :app/login}]]]))
            ctx))
        ctx))})
 ```
 
-Two helpers do the reading, and both are *pure* — they compute from their arguments without touching app-db, which is exactly why the guard can call them inline:
+The reads are all *pure* — they compute from their arguments without touching app-db, which is exactly why the guard can call them inline:
 
-- **`routing/match-url`** parses a URL string into a map — `{:route-id :params :query :fragment :validation-failed?}` — or `nil` when nothing matches. (Its inverse, `routing/route-url`, builds a URL from an address map.) Note the namespace: it lives in `re-frame.routing`, **not** on the `rf/` facade. `nav-target` reaches for it in **three** places: the link-click and URL-bar events carry a raw URL, and `:rf.route/navigate` accepts a `{:url "/settings"}` **escape-hatch** request (deep links, redirects) that is a URL, not a route id — resolve it the same way the runtime does, or a logged-out `[:rf.route/navigate {:url "/settings"}]` slips past the tag check.
-- **An in-place navigate request** is the *third* shape `:rf.route/navigate` accepts — no `:to` and no `:url`, meaning *stay on the current route, change only the query* (search, pagination, tabs). It names no route id; the runtime resolves the target from the current route slice, so the guard resolves it the same way, off `current`. Miss it and the guard fails **open** exactly where it hurts: a session that expires *while the user sits on a protected route* can navigate in place (`?page=2`, a tab switch) and — because the request carries no route id to tag-check — slip past. That is why the guard reads the current slice from the `:rf.db/runtime` coeffect and threads it into `nav-target`: resolved to `:app/settings`, the in-place nav is gated and the expired session is bounced to login.
-- **`rf/handler-meta`** reads back the metadata you stamped at registration. `(rf/handler-meta :route id)` returns that route's registration map; the guard pulls its `:tags` and checks for `:requires-auth`.
+- **`routing/match-url`** parses a URL string into a map — `{:route-id :params :query :fragment :validation-failed?}` — or `nil` when nothing matches. (Its inverse, `routing/route-url`, builds a URL from an address map.) Note the namespace: it lives in `re-frame.routing`, **not** on the `rf/` facade. `matched-address` wraps it in the two checks the guard needs: a URL that matches nothing (`nil`) **and** a URL that matches but fails the route's `:params`/`:query` schema (`:validation-failed? true`) are *both* non-matches, because the runtime routes a validation-failed URL to not-found — so the guard must not tag-check a route it will never actually land on. `nav-target` reaches for it in **three** places: the link-click and URL-bar events carry a raw URL, and `:rf.route/navigate` accepts a `{:url "/settings"}` **escape-hatch** request (deep links, redirects) that is a URL, not a route id — resolve it the same way the runtime does, or a logged-out `[:rf.route/navigate {:url "/settings"}]` slips past the tag check.
+- **An in-place navigate request** is the *third* shape `:rf.route/navigate` accepts — no `:to` and no `:url`, meaning *stay on the current route, change only the query or fragment* (search, pagination, tabs). It names no route id; the runtime resolves the target — and the resulting query — from the current route slice, so the guard resolves it the same way, off `current`, and `in-place-query` folds a `:query`/`:query-merge` edit onto the current query exactly as the runtime does (`:query` replaces, `:query-merge` folds, a `nil` value drops a key). Miss it and the guard fails **open** exactly where it hurts: a session that expires *while the user sits on a protected route* can navigate in place (`?page=2`, a tab switch) and — because the request carries no route id to tag-check — slip past. That is why the guard reads the current slice from the `:rf.db/runtime` coeffect and threads it into `nav-target`: resolved to `:app/settings`, the in-place nav is gated and the expired session is bounced to login. A request that is *neither* a destination nor a valid in-place edit (a bare `{:params …}`, a stray key) resolves to `nil` — the guard steps aside and lets the runtime's own structural gate reject it with `:rf.error/navigate-bad-request`, rather than reclassifying a malformed request as a valid guarded destination.
+- **`rf/handler-meta`** reads back the metadata you stamped at registration. `(rf/handler-meta :route (:to target))` returns that route's registration map; the guard pulls its `:tags` and checks for `:requires-auth`. `nav-target` resolves every navigation to the same address shape — `{:to :params :query :fragment}` — so the tag check reads `:to` and, when the guard bounces, the *whole* address is stashed for an exact return (below). Policy fields (`:replace?`, `:scroll`, `:bypass-guards?`) are addressless and dropped.
 
 The redirect works by *skip-and-dispatch*. `:rf/skip-handler?` — the public short-circuit primitive an interceptor's `:before` sets on its ctx — stops the original handler, so the protected slice never commits and its `:on-match` loads never fire. The guard then dispatches the login navigation itself.
 
@@ -293,7 +324,7 @@ The redirect works by *skip-and-dispatch*. `:rf/skip-handler?` — the public sh
 
 !!! warning "Gotcha — a bad URL is a non-match, not a crash"
 
-    If `match-url` can't resolve a path — an unknown route, or path params that fail the route's `:params` schema (`:validation-failed? true`) — it returns a non-match (`nil`), and `nav-target` short-circuits the guard for that event. The runtime's own URL-change handler routes the same non-match to [`:rf.route/not-found`](../../routing/glossary.md#not-found). So a logged-out user pasting a garbage protected-looking URL lands on not-found, never inside a guarded slice.
+    A URL can fail to resolve two different ways, and `match-url` reports them differently. An **unknown** route returns `nil`. A route that **matches but fails its `:params`/`:query` schema** returns a *map* carrying `:validation-failed? true` — **not** `nil`. `matched-address` collapses both to a non-match, so `nav-target` short-circuits the guard for either, because the runtime's own URL-change handler routes *both* to [`:rf.route/not-found`](../../routing/glossary.md#not-found). Reading only for `nil` (the easy mistake) would let a schema-invalid protected URL past the tag check onto a route the runtime then sends to not-found anyway. So a logged-out user pasting a garbage protected-looking URL lands on not-found, never inside a guarded slice.
 
 ### Wire the guard frame-wide
 
@@ -336,7 +367,7 @@ The init event from step 1 restores the saved session and classifies the token p
 
 ## 5. Bounce back after login
 
-A guard's headline feature is returning the user to exactly where they were headed. Step 4's guard stashed that target at `[:auth :return-to]`; step 2's success handler already dispatches `:auth/post-login-redirect`. Here's the handler it calls — it reads **and clears** the stash in one step:
+A guard's headline feature is returning the user to *exactly* where they were headed — the same path, params, query, and fragment. Step 4's guard stashed that resolved address at `[:auth :return-to]` as a `{:to :params :query :fragment}` map — a valid navigate request in its own right — so the bounce-back is just that map with an intentional `:replace? true` (the login URL never lands on the back stack). Step 2's success handler already dispatches `:auth/post-login-redirect`; here's the handler it calls — it reads **and clears** the stash in one step:
 
 ```clojure
 ;; Adapted from examples/real-apps/realworld_http/auth.cljs
@@ -344,8 +375,13 @@ A guard's headline feature is returning the user to exactly where they were head
   (fn [{:keys [db]} _]
     (let [return-to (get-in db [:auth :return-to])]
       {:db (update db :auth dissoc :return-to)
+       ;; The stash IS the resolved address (path + params + query + fragment),
+       ;; and a valid navigate request in its own right — return there wholesale.
+       ;; A partial {:to :params} would drop the query string and #fragment and
+       ;; land the user somewhere subtly wrong. :replace? true keeps /login off
+       ;; the back stack.
        :fx [[:dispatch (if return-to
-                         [:rf.route/navigate {:to (:id return-to) :params (:params return-to)}]
+                         [:rf.route/navigate (assoc return-to :replace? true)]
                          [:rf.route/navigate {:to :app/home}])]]})))
 ```
 

--- a/docs/resources/tutorial/03-auth-and-forms.md
+++ b/docs/resources/tutorial/03-auth-and-forms.md
@@ -244,10 +244,14 @@ On success Conduit replies `{:user {... :token "<jwt>"}}`. The success handler s
                (update-in [:auth :login-form]
                           #(assoc % :status :submitted :submitted (:draft %))))
        :fx [[:auth.session/persist {:token (:token user)}]
-            ;; :replace? true so the login URL never lands on the back stack —
-            ;; pressing Back after signing in shouldn't return you to /login.
+            ;; return-to is the resolved ADDRESS the guard stashed — path,
+            ;; params, query, AND fragment — and a valid navigate request in
+            ;; its own right, so bounce there wholesale (a partial {:to :params}
+            ;; would drop the query string and #fragment). :replace? true so the
+            ;; login URL never lands on the back stack — pressing Back after
+            ;; signing in shouldn't return you to /login.
             [:dispatch (if return-to
-                         [:rf.route/navigate {:to (:id return-to) :params (:params return-to) :replace? true}]
+                         [:rf.route/navigate (assoc return-to :replace? true)]
                          [:rf.route/navigate {:to :conduit/home :replace? true}])]]})))
 ```
 
@@ -494,26 +498,57 @@ That normaliser is `nav-target` below. The link-click and URL-bar cases carry a 
 `:rf.route/navigate` has a **third** shape too: an *in-place* request — no `:to` and no `:url` — meaning *stay on the current route, change only the query* (search, pagination, tabs). It names no route id; the runtime resolves the target from the current route slice, so `nav-target` takes that slice (`current`) and resolves it the same way. This closes the trap's nastiest corner: a session that *expires while the user is already on `/settings`* would otherwise navigate in place (a filter toggle, `?page=2`) straight past a guard that only knows how to read route ids and URLs — the request carries no route id to tag-check. Resolved to `:conduit.user/settings`, the in-place nav is gated and the stale session is bounced to login:
 
 ```clojure
+(defn- in-place-query
+  "Fold an in-place request's query edit onto the current query: :query
+   replaces wholesale ({} clears); :query-merge folds, a nil value dropping a
+   key; neither present carries the current query unchanged."
+  [{:keys [query query-merge]} current-query]
+  (cond
+    (some? query) query
+    query-merge   (into {} (remove (comp nil? val)) (merge current-query query-merge))
+    :else         current-query))
+
+(defn- matched-address
+  "match-url → a resolved address, or nil for a non-match OR a schema-invalid
+   match (:validation-failed? true) — which the runtime routes to not-found,
+   so the guard must not treat it as a real destination."
+  [url]
+  (when-let [{:keys [route-id params query fragment validation-failed?]} (routing/match-url url)]
+    (when-not validation-failed?
+      {:to route-id :params (or params {}) :query (or query {}) :fragment fragment})))
+
 (defn- nav-target
-  "Normalise any navigation event to {:id route-id :params m};
-   nil for non-navigation events (the guard stands aside). `current` is the
-   current route slice ([:rf.runtime/routing :current]) — an in-place navigate
-   request resolves against it, as the runtime resolves it."
+  "Normalise any navigation event to a resolved ADDRESS map —
+   {:to route-id :params m :query m :fragment s-or-nil}, the FULL route state,
+   so a login bounce-back returns to the exact URL (path, params, query, and
+   fragment). nil for a non-navigation event, a non-match, or a malformed
+   request the runtime's structural gate will reject
+   (:rf.error/navigate-bad-request) — the guard leaves those to the router
+   rather than reclassifying them. Address keys only; policy fields (:replace?,
+   :scroll, :bypass-guards?) are dropped. `current` is the current route slice
+   ([:rf.runtime/routing :current]) — an in-place request resolves against it,
+   as the runtime resolves it."
   [[event-id a] current]
   (case event-id
-    :rf.route/navigate          (let [{:keys [to url params]} a]      ;; a is the request map
-                                  (cond
-                                    to  {:id to :params (or params {})}
-                                    url (when-let [m (routing/match-url url)]
-                                          {:id (:route-id m) :params (or (:params m) {})})
-                                    :else                              ;; in-place: stay on the current route
-                                    {:id (:route-id current) :params (or (:params current) {})}))
-    :rf.route/url-requested           (if-let [to (:to a)]
-                                  {:id to :params (or (:params a) {})}
-                                  (when-let [m (routing/match-url (:url a))]
-                                    {:id (:route-id m) :params (or (:params m) {})}))
-    :rf.route/handle-url-change (when-let [m (routing/match-url a)]
-                                  {:id (:route-id m) :params (or (:params m) {})})
+    :rf.route/navigate
+    (let [{:keys [to url params]} a]                          ;; a is the request map
+      (cond
+        to  {:to to :params (or params {}) :query (or (:query a) {}) :fragment (:fragment a)}
+        url (matched-address url)
+        ;; in-place: no :to/:url/:params, at least one query/fragment edit.
+        (and (nil? params)
+             (or (contains? a :query) (contains? a :query-merge) (contains? a :fragment)))
+        {:to       (:route-id current)
+         :params   (or (:params current) {})
+         :query    (in-place-query a (:query current))
+         :fragment (if (contains? a :fragment) (:fragment a) (:fragment current))}
+        :else nil))                                           ;; malformed → router rejects
+    :rf.route/url-requested                                   ;; route-link click
+    (let [{:keys [to url]} a]
+      (cond
+        to  {:to to :params (or (:params a) {}) :query (or (:query a) {}) :fragment (:fragment a)}
+        url (matched-address url)))
+    :rf.route/handle-url-change (matched-address a)
     nil))
 
 (rf/reg-interceptor :conduit/auth-guard
@@ -523,18 +558,18 @@ That normaliser is `nav-target` below. The link-click and URL-bar cases carry a 
      ;; The route slice is framework runtime-db state — read it from the
      ;; :rf.db/runtime coeffect so an in-place navigate request resolves
      ;; to the protected route the user is already on.
-     (let [{:keys [id params]} (nav-target (get-in ctx [:coeffects :event])
-                                           (get-in ctx [:coeffects :rf.db/runtime
-                                                        :rf.runtime/routing :current]))
-           needs-auth? (when id
-                         (contains? (:tags (rf/handler-meta :route id)) :requires-auth))
+     (let [target      (nav-target (get-in ctx [:coeffects :event])
+                                    (get-in ctx [:coeffects :rf.db/runtime
+                                                 :rf.runtime/routing :current]))
+           needs-auth? (when target
+                         (contains? (:tags (rf/handler-meta :route (:to target))) :requires-auth))
            signed-in?  (some? (get-in ctx [:coeffects :db :auth :user]))]
        (if (and needs-auth? (not signed-in?))
          (-> ctx
              (assoc :rf/skip-handler? true)        ;; the protected route never commits
-             (assoc-in [:effects :db]              ;; stash the target for the bounce-back
+             (assoc-in [:effects :db]              ;; stash the resolved address for the bounce-back
                        (assoc-in (get-in ctx [:coeffects :db])
-                                 [:auth :return-to] {:id id :params params}))
+                                 [:auth :return-to] target))
              (assoc-in [:effects :fx]
                        [[:dispatch [:rf.route/navigate {:to :conduit.auth/login}]]]))
          ctx)))})
@@ -542,11 +577,11 @@ That normaliser is `nav-target` below. The link-click and URL-bar cases carry a 
 
 You register the guard once, under the id `:conduit/auth-guard` — exactly like registering an event or a sub — and then the frame's chain *references* that id. A few pieces are doing precise work:
 
-- **`routing/match-url`** is the URL codec from `re-frame.routing` (`(:require [re-frame.routing :as routing])`) — **not** the `rf/` front porch. It's a pure function, `url → {:route-id :params :query :fragment :validation-failed?}` (or `nil` for a URL that matches nothing), and it runs on both hosts. `nav-target` uses it for the two cases that arrive as a raw URL string.
-- **The current route slice** (`current`, read from the `:rf.db/runtime` coeffect at `[:rf.runtime/routing :current]`) is what resolves an *in-place* navigate request — no `:to`/`:url` means "the route I'm already on," so the guard reads that route's id from the slice, exactly as the runtime does, and then checks its `:tags`.
-- **`rf/handler-meta :route id`** reads the route's [registration](../../core/glossary.md#registration) metadata — including its `:tags` — without activating it. It's the introspection seam pair tools use too, so the guard asks the registry the same question Xray would.
+- **`routing/match-url`** is the URL codec from `re-frame.routing` (`(:require [re-frame.routing :as routing])`) — **not** the `rf/` front porch. It's a pure function, `url → {:route-id :params :query :fragment :validation-failed?}` (or `nil` for a URL that matches nothing), and it runs on both hosts. `matched-address` wraps it in the two rejections the guard needs: a `nil` (unknown route) **and** a `:validation-failed? true` map (a match whose path/query params fail the route's schema) are *both* non-matches — the runtime routes a validation-failed URL to not-found, so the guard must not tag-check a route it will never land on. `nav-target` uses it for the two cases that arrive as a raw URL string.
+- **The current route slice** (`current`, read from the `:rf.db/runtime` coeffect at `[:rf.runtime/routing :current]`) is what resolves an *in-place* navigate request — no `:to`/`:url` means "the route I'm already on," so the guard reads that route's id from the slice, exactly as the runtime does, then folds any `:query`/`:query-merge` edit onto the current query (`in-place-query`) before checking `:tags`. A request that is neither a destination nor a valid in-place edit resolves to `nil`, so the guard stands aside and lets the runtime's structural gate reject it with `:rf.error/navigate-bad-request` rather than reclassifying a malformed request as a valid guarded destination.
+- **`rf/handler-meta :route (:to target)`** reads the route's [registration](../../core/glossary.md#registration) metadata — including its `:tags` — without activating it. It's the introspection seam pair tools use too, so the guard asks the registry the same question Xray would.
 - **`:rf/skip-handler? true`** tells the runtime to skip the event's own handler. For a navigation that means the protected route never commits and its `:on-match` loads (`[:settings/load]`) never fire — a signed-out user can't even trigger the route's data fetch.
-- **The stash** lands the destination at `[:auth :return-to]` — the same spot `submit-success` read earlier — and the guard dispatches the login navigation instead.
+- **The stash** lands the *resolved address* — `{:to :params :query :fragment}`, the full route state — at `[:auth :return-to]`, the same spot `submit-success` read earlier, so the bounce-back returns to the exact URL (query string and `#fragment` included). The guard dispatches the login navigation instead.
 
 Attached frame-wide, the guard wraps every event and quietly stands aside (returns `ctx` untouched) for everything `nav-target` returns `nil` for — which is every event that isn't a navigation. [Interceptors](../../core/interceptors.md) is the deeper model.
 

--- a/docs/routing/how-to/require-sign-in-on-a-route.md
+++ b/docs/routing/how-to/require-sign-in-on-a-route.md
@@ -47,11 +47,22 @@ Guard `:rf.route/navigate` alone and the third row defeats you: a logged-out rea
 ```clojure
 (:require [re-frame.routing :as rf.routing])   ;; match-url lives here, not on rf/
 
+(defn- matched-id
+  "match-url → {:id <route-id> :params <map>}, or nil for a non-match OR a
+   schema-invalid match (:validation-failed? true) — which the runtime routes
+   to not-found, so the guard must not tag-check a route it will never land on."
+  [url]
+  (when-let [{:keys [route-id params validation-failed?]} (rf.routing/match-url url)]
+    (when-not validation-failed?
+      {:id route-id :params (or params {})})))
+
 (defn- nav-target
-  "Normalise any navigation event to {:id <route-id> :params <map>}, or nil.
-  `current` is the current route slice ([:rf.runtime/routing :current]) — an
-  in-place navigate request (no :to / :url) means the route you are already on,
-  so pass it in and the guard resolves it exactly as the runtime does."
+  "Normalise any navigation event to {:id <route-id> :params <map>}, or nil —
+  for a non-navigation event, a non-match, or a malformed request the runtime's
+  own structural gate will reject (:rf.error/navigate-bad-request). `current` is
+  the current route slice ([:rf.runtime/routing :current]) — an in-place
+  navigate request (no :to / :url) means the route you are already on, so pass
+  it in and the guard resolves it exactly as the runtime does."
   [[ev-id a] current]
   (case ev-id
     :rf.route/navigate
@@ -59,28 +70,33 @@ Guard `:rf.route/navigate` alone and the third row defeats you: a logged-out rea
       (cond
         to  {:id to :params (or params {})}              ;; route-id destination
 
-        url (when-let [{:keys [route-id params]} (rf.routing/match-url url)]
-              {:id route-id :params (or params {})})     ;; {:url ...} escape hatch
+        url (matched-id url)                             ;; {:url ...} escape hatch
 
-        :else                                            ;; in-place: stay on the current route
-        {:id (:route-id current) :params (or (:params current) {})}))
+        ;; in-place: no :to/:url/:params, at least one query/fragment edit —
+        ;; stay on the current route (its id is what the tag check needs).
+        (and (nil? params)
+             (or (contains? a :query) (contains? a :query-merge) (contains? a :fragment)))
+        {:id (:route-id current) :params (or (:params current) {})}
+
+        :else nil))                                      ;; malformed → router rejects
 
     :rf.route/url-requested
-    (let [{:keys [to params url]} a]
+    (let [{:keys [to params]} a]
       (cond
         to  {:id to :params (or params {})}
-        url (when-let [{:keys [route-id params]} (rf.routing/match-url url)]
-              {:id route-id :params (or params {})})))
+        (:url a) (matched-id (:url a))))
 
-    :rf.route/handle-url-change
-    (when-let [{:keys [route-id params]} (rf.routing/match-url a)]
-      {:id route-id :params (or params {})})
+    :rf.route/handle-url-change (matched-id a)
 
     nil))
 ```
 
-`match-url` is pure: URL string → match map, or `nil` when nothing resolves (garbage
-URLs short-circuit the guard rather than crash it). Note the `:rf.route/navigate` branch
+`match-url` is pure: URL string → match map, or `nil` when nothing resolves. `matched-id`
+wraps it in the two rejections a guard needs: a URL that matches nothing (`nil`) **and** a
+URL that matches but fails the route's `:params`/`:query` schema (`:validation-failed? true`)
+are *both* non-matches — the runtime routes a validation-failed URL to not-found, so the guard
+must not tag-check a route it will never land on. Either way the guard short-circuits rather
+than crash. Note the `:rf.route/navigate` branch
 also leans on it: navigate accepts a `{:url "/settings"}` **escape-hatch target** (deep
 links, server-side redirects, any URL the app didn't build itself), and a raw URL is not a
 route id — so the guard resolves it through `match-url` exactly as the runtime does before
@@ -97,6 +113,14 @@ id to check, waves it through. Resolving the in-place request against the curren
 `(:route-id current)` — makes the guard see `:app/settings`'s `:requires-auth` tag and fail
 **closed**, bouncing the expired session to login. That's why the interceptor reads the
 current slice out of the `:rf.db/runtime` coeffect and threads it into `nav-target`.
+
+One more distinction the normaliser must draw: a request that is *neither* a destination
+(`:to` / `:url`) *nor* a valid in-place edit (a `:query` / `:query-merge` / `:fragment`
+change) — say a bare `{:params …}` or a stray key — resolves to `nil`, not to the current
+route. Such a request is malformed, and the runtime's own always-on structural gate rejects it
+with `:rf.error/navigate-bad-request` before any navigation happens; the guard stands aside and
+lets it, rather than reclassifying a request that will never navigate as a valid guarded
+destination.
 
 ## 3. Redirect with skip-and-dispatch
 

--- a/skills/re-frame2/patterns/form-action.md
+++ b/skills/re-frame2/patterns/form-action.md
@@ -61,18 +61,26 @@ The view runs on both platforms; the `action` attribute is what makes it work JS
    :schema [:cat [:= :cart/add-item] AddToCartForm]      ;; server-side schema check, never skipped
    :rf.cofx/requires [:rf.server/request
                       :app.csrf/active-token]}            ;; app-owned cofx — see §CSRF
-  (fn [{:keys [db app.csrf/active-token]} [_ form-params]]
+  (fn [{:keys [db rf.server/request app.csrf/active-token]} [_ form-params]]
     (if (not= (:csrf-token form-params) active-token)    ;; CSRF first — fail loud
       {:db (assoc-in db [:cart :add-form :errors :_form] ["Session expired. Refresh and retry."])
        :fx [[:rf.server/set-status 403]]}
       {:db (-> db
                (update-in [:cart :items] (fnil conj []) (select-keys form-params [:item-id :quantity]))
                (assoc-in  [:cart :add-form :status] :submitted))
-       :fx [[:rf.server/redirect {:status 303 :location "/cart"}]   ;; server only
-             [:dispatch [:rf.route/navigate {:to :route/cart}]]]})))  ;; client only — shipped routing event
+       ;; ONE destination, CHOSEN by a platform boundary the handler already
+       ;; reads: the :rf.server/request cofx is present on the server and, being
+       ;; :platforms #{:server}, skipped (absent) on the client. Server → the
+       ;; POST-redirect-GET 303; client → in-app navigation. We do NOT emit both:
+       ;; :rf.route/navigate is not a server no-op — dispatched server-side it
+       ;; writes the route slice and can fire the target route's :on-match work,
+       ;; with no browser history to anchor it.
+       :fx (if request
+             [[:rf.server/redirect {:status 303 :location "/cart"}]]      ;; server: POST-redirect-GET
+             [[:dispatch [:rf.route/navigate {:to :route/cart}]]])})))    ;; client: shipped routing event
 ```
 
-The success/failure effects are the only platform-divergent slot. `:rf.server/redirect` is the server-only POST-redirect-GET fx; on the client, navigate via the shipped routing event `[:rf.route/navigate {:to :route/cart}]` (dispatched through `:fx`) — `:platforms` gating no-ops the server redirect on the client. (`:rf.route/navigate` is the framework's programmatic-navigation event, registered by `day8/re-frame2-routing`; there is **no** `:rf.nav/navigate` fx. If you need a bare URL push rather than a route id, register an **app-owned** fx such as `:cart.nav/navigate` — the framework does not expose `:rf.nav/push-url` as a route-aware navigation surface.)
+The success path is the only platform-divergent slot, and the handler **chooses** the destination — it does not emit both. The boundary is one the handler already reads: the `:rf.server/request` cofx is present on the server and, being `:platforms #{:server}`, is skipped (absent) on the client, so `(if request …)` is a clean platform switch. On the server, emit the server-only POST-redirect-GET fx `:rf.server/redirect`; on the client, navigate in-app via the shipped routing event `[:rf.route/navigate {:to :route/cart}]`. Do **not** emit both and label the navigate "client-only": `:rf.route/navigate` is **not** a server no-op — dispatched server-side it writes the route slice and can run the target's `:on-match` loaders even though there is no browser history. (`:rf.route/navigate` is the framework's programmatic-navigation event, registered by `day8/re-frame2-routing`; there is **no** `:rf.nav/navigate` fx.) For a **raw URL** rather than a route id, the shipped request grammar takes one directly — `[:rf.route/navigate {:url "/cart"}]` (the `:url` escape hatch) — so **no app-owned navigation fx is needed**. Reserve an app-owned fx only for a deliberate routing *bypass* that skips the router entirely (a hard `window.location` assignment, an external redirect), on the rare occasion you actually want that.
 
 ## CSRF
 
@@ -98,7 +106,7 @@ The scrub is per-named-path, owned by the registration, not a whole-action toggl
 
 - **Skipping the `action` attribute.** A JS-only form breaks progressive enhancement. Always emit `method` + `action`; `:on-submit` is additive.
 - **Validating only on the client.** Client validation is UX; the server is the authority. Re-run the schema check via `:schema` on every POST — never trust the body.
-- **A client-navigation fx for the server redirect.** The client routing event `[:rf.route/navigate …]` is a no-op on the server; use `:rf.server/redirect` for POST-redirect-GET. (And do not invent `:rf.nav/navigate` — it does not exist; `:rf.route/navigate` is the shipped programmatic-navigation event.)
+- **Emitting both the redirect and the navigate unconditionally.** `:rf.route/navigate` is **not** a server no-op — dispatched on the server it writes the route slice and can run the target's `:on-match` work, with no browser history to back it. Choose per platform (the `:rf.server/request` cofx, present only on the server, is the boundary): `:rf.server/redirect` for the server's POST-redirect-GET, `[:rf.route/navigate …]` for the client. (And do not invent `:rf.nav/navigate` — it does not exist; `:rf.route/navigate` is the shipped programmatic-navigation event.)
 - **`302 Found` for POST success.** Some clients re-POST on 302; the canonical status is **303 See Other**. Set `:status 303` explicitly.
 - **CSRF token from a hardcoded value or query string.** Sessions rotate tokens; your app-owned `:app.csrf/active-token` cofx is the single source of truth. URL-borne tokens leak to referrer logs.
 - **Writing `app-db` from a multipart handler.** The drain runs to fixed point — a long upload inside the handler blocks the request thread. Hand the opaque `:tempfile` to a storage fx.


### PR DESCRIPTION
Corrects two documentation-guidance bugs on one surface — the routing/auth how-to + tutorial guides — against the shipped flat request-map routing grammar (vwwvp) and the SSR platform model. Guidance only; no code changes. One commit per bead.

## rf2-67go9 — Auth return-to preserved; invalid navigation rejected

The copyable auth-guard flows normalised a navigation to `{:id :params}`, so the login bounce-back dropped the query string and `#fragment` and ignored in-place `:query`/`:query-merge`/`:fragment` edits despite promising an exact return. They also accepted `match-url` results carrying `:validation-failed? true` and reclassified malformed request maps as valid in-place navigation, pre-empting the runtime's own `:rf.error/navigate-bad-request`.

- `nav-target` now resolves a full **address** map `{:to :params :query :fragment}` against the shipped grammar; the guard stashes it whole and the bounce-back returns there with an intentional `:replace? true` (keeps `/login` off the back stack). Policy fields (`:replace?`, `:scroll`, `:bypass-guards?`) are dropped.
- In-place requests resolve against the current route slice: `:query` replaces wholesale, `:query-merge` folds (a `nil` value drops a key), `:fragment` carries — exactly as the runtime's `resolve-target` does.
- `matched-address` / `matched-id` reject **both** a non-match (`nil`) and a schema-invalid match (`:validation-failed? true`); the runtime routes the latter to not-found, so the guard must not tag-check it.
- A request that is neither a destination nor a valid in-place edit resolves to `nil`; the guard steps aside and lets the runtime's structural gate reject it.
- Corrected the "bad URL returns nil" prose: `match-url` returns a *map* with `:validation-failed? true` for a schema-invalid path, **not** `nil`.

Files: `docs/core/how-to/add-auth.md`, `docs/resources/tutorial/03-auth-and-forms.md`, `docs/routing/how-to/require-sign-in-on-a-route.md` (the last only tag-checks — no return-to — so it keeps the lean `{:id …}` shape with just the two misclassification fixes).

## rf2-ppi5k — Form-action routing chooses per-platform; teaches `{:url ...}`

`skills/re-frame2/patterns/form-action.md` emitted **both** a server redirect and an unconditional `:dispatch` of `:rf.route/navigate`, labelling the latter client-only — but a `:dispatch` is not platform-gated, so on the server that event still writes the route slice and can run the target's `:on-match` work. The same paragraph told authors to register an app-owned fx for a bare URL, though the shipped grammar supports `[:rf.route/navigate {:url ...}]` directly.

- The success path now **chooses** one destination via an existing platform boundary the handler already reads — the `:rf.server/request` cofx, present on the server and skipped (absent) on the client: `(if request <303-redirect> <navigate>)`.
- Removed the false "the navigation event is a server no-op" claim from both the prose and the anti-pattern bullet.
- Teach the built-in `{:url ...}` request for raw URLs; reserve an app-owned fx only for a deliberate router bypass (hard `window.location` / external redirect).

File: `skills/re-frame2/patterns/form-action.md`

## Follow-up (out of scope — fenced `examples/`)

The RealWorld example carries the same route-state-loss bug and needs the same repair plus the bead's focused tests (destination with query+fragment, an in-place edit, invalid input): `examples/real-apps/realworld_http/routing.cljs` stashes `{:id rejecting-route :params …}` and `schema.cljs` types `:return-to` as `:id`/`:params`. Left untouched per the worktree fence; needs a follow-up bead for the example owner.

## Quality gates

Run in the worktree, foreground, to completion:

- `python -m mkdocs build --strict` → exit 0
- `python scripts/check_doc_slugs.py` → exit 0
- `python scripts/check_skill_re_frame2_drift.py` → exit 0
- `python scripts/check_skill_eval_docs.py` → exit 0
- `python scripts/check_skill_redirect_anchors.py` → exit 0
- `python scripts/check_skill_eval_packaging.py` → exit 0

No mkdocs snippet-compile plugin exists; every corrected snippet was verified by hand against the shipped grammar in `spec/012-Routing.md` (request grammar, `resolve-target`, `match-url` shape) and `spec/011-SSR.md` (`:platforms` fx-gating, the `:rf.server/request` cofx boundary).
