### PR TITLE
fix(ui): make S6 commit-record root identity exact (rf2-vxgfnd.98.1.2)

### DIFF
--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -592,10 +592,13 @@
   ;;                             ;   commit-time fact). ABSENT in production + when unset
   ;;    :commit-record {…}|nil}  ; DEBUG-only S6 committed-instance record from
   ;;                             ;   the most-recent CONNECTED commit (Ruling 1/2;
-  ;;                             ;   integer render-key + per-observation
-  ;;                             ;   observations + the per-commit :rf.view/causes
-  ;;                             ;   vector). ABSENT in production (elided) and nil
-  ;;                             ;   before the first connect
+  ;;                             ;   integer render-key + :root-incarnation — the
+  ;;                             ;   PRIVATE opaque incarnation token, nil before
+  ;;                             ;   attach-root!, resolved to the authored root-id
+  ;;                             ;   downstream at the tool boundary — + per-
+  ;;                             ;   observation observations + the per-commit
+  ;;                             ;   :rf.view/causes vector). ABSENT in production
+  ;;                             ;   (elided) and nil before the first connect
   )
 
 (defn cell?
@@ -3479,10 +3482,17 @@
 (defn- mint-commit-record!
   "DEBUG-only: mint a fresh monotonic :render-key and publish the S6
   committed-instance record onto `cell` for THIS connected commit (Ruling 1/2).
-  Reads the cell's just-published state, so :view-id / :generation / :root-id
-  reflect the commit that connected. `:root-id` is the owning root incarnation —
-  the opaque per-mount token the tool projection resolves to the authored root-id
-  name (nil under no root, e.g. Tier-1/JVM). Projects the per-commit
+  Reads the cell's just-published state, so :view-id / :generation /
+  :root-incarnation reflect the commit that connected. `:root-incarnation` is the
+  PRIVATE opaque per-mount root-incarnation token (`make-root-incarnation`) the
+  cell is attached to, compared only by `identical?` — NOT a serializable authored
+  root-id, and NEVER exposed as one under a `:root-id` key. It is nil on the FIRST
+  connected commit (the mount seam's `attach-root!` runs in the LATER lifecycle
+  effect, after this reconcile commit) and the opaque token thereafter; under no
+  root (Tier-1/JVM) it stays nil. The developer-facing authored root-id keyword is
+  resolved DOWNSTREAM at the tool boundary (`re-frame.ui.tool.evidence`'s
+  incarnation->root-id index over the live-root registry), never minted here — the
+  substrate holds only opaque identity. Projects the per-commit
   :rf.view/causes vector of DETAILED cause records (Ruling 2, reworked rf2-qkq2k)
   from the carry-forward cause stash plus the commit-time lifecycle / override
   facts, then CLEARS the stash so a subsequent causeless re-render honestly reports
@@ -3538,12 +3548,12 @@
                                                {:override-id (:override-id t)
                                                 :version     (:version t)}))))
                                    to-acquire)
-            base       {:render-key    (next-render-key!)
-                        :view-id       (:view-id st0)
-                        :generation    (:generation cap)
-                        :root-id       (:root st0)
-                        :connection    :connected
-                        :observations  (project-observations new-order new-by)}]
+            base       {:render-key       (next-render-key!)
+                        :view-id          (:view-id st0)
+                        :generation       (:generation cap)
+                        :root-incarnation (:root st0)
+                        :connection       :connected
+                        :observations     (project-observations new-order new-by)}]
         (loop []
           (let [s        @st
                 pending  (or (:pending-commit-causes s) [])
@@ -3902,7 +3912,10 @@
   "The cell's most-recent CONNECTED-commit S6 committed-instance record, or nil
   when the cell has never connected — and always nil in a production build, where
   the view-evidence plane is elided. The per-commit record (Ruling 1/2; EP-0033
-  §Two evidence layers): integer :render-key, :view-id, :generation, :root-id,
+  §Two evidence layers): integer :render-key, :view-id, :generation,
+  :root-incarnation (the PRIVATE opaque per-mount incarnation token — nil before
+  the mount seam's `attach-root!` and under no root, resolved to the authored
+  root-id keyword downstream at the tool boundary, never a serializable id here),
   :connection, a per-observation :observations vector, and the per-commit
   :rf.view/causes vector (Ruling 2 — the SIX shipped kinds `:mount` /
   `:story-override` / `:subscription` / `:local-state` / `:hmr` / `:disposed`

--- a/implementation/ui/test/re_frame/ui/reactive_commit_record_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_commit_record_cljs_test.cljc
@@ -15,7 +15,16 @@
   commit is caused by `:mount`. The record still invents NO :parent-render-key
   (deferred — no capture machinery) and claims NO singular top-level :frame-id
   (frame attribution is PER-OBSERVATION). The full per-cause cause-vector proof
-  lives in `reactive_commit_causes_cljs_test`."
+  lives in `reactive_commit_causes_cljs_test`.
+
+  ROOT IDENTITY (rf2-vxgfnd.98.1.2): the record's owning-root field carries the
+  PRIVATE opaque per-mount incarnation token (`make-root-incarnation`) under
+  `:root-incarnation` — never a serializable authored root-id keyword under a
+  `:root-id` key. The authored root-id is resolved DOWNSTREAM at the tool
+  boundary (`re-frame.ui.tool.evidence`'s incarnation->root-id index over the
+  live-root registry); the substrate holds only opaque identity, and the FIRST
+  connected commit is honestly nil-rooted because the mount seam's `attach-root!`
+  runs in the LATER lifecycle effect, after this reconcile commit."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core                 :as rf]
@@ -151,6 +160,91 @@
       (reactive/commit! cell cap2)
       (is (> (reactive/render-key cell) rk1)
           "a distinct capture is a distinct committed render — render-key advances"))))
+
+;; ===========================================================================
+;; Root identity (rf2-vxgfnd.98.1.2) — the record carries the PRIVATE opaque
+;; per-mount incarnation under :root-incarnation, never an opaque token
+;; masquerading as a serializable authored root-id under :root-id.
+;; ===========================================================================
+
+(deftest rooted-commit-records-the-opaque-incarnation-never-a-root-id-keyword
+  (rf/reg-sub :cr/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell        (reactive/make-cell ::v)
+        incarnation (reactive/make-root-incarnation)]
+    ;; The FIRST connected commit runs BEFORE the mount seam's `attach-root!`
+    ;; (which fires in the LATER lifecycle effect, not this reconcile commit),
+    ;; so the record is honestly nil-rooted — never a fabricated keyword.
+    (render+commit! cell [[[:cr/site 0] [:cr/a]]])
+    (let [rec0 (reactive/commit-record cell)]
+      (is (not (contains? rec0 :root-id))
+          "the record NEVER exposes a :root-id key — no opaque root-incarnation
+           token is allowed to masquerade as a serializable authored root-id")
+      (is (contains? rec0 :root-incarnation)
+          "the owning-root field is the honestly-named :root-incarnation")
+      (is (nil? (:root-incarnation rec0))
+          "the FIRST connected commit is nil-rooted — attach-root! has not run yet
+           (the record captures the state at reconcile-commit time)"))
+    ;; The mount seam attaches the cell to its per-mount root incarnation; a
+    ;; subsequent commit records THAT exact opaque token.
+    (reactive/attach-root! cell incarnation)
+    (render+commit! cell [[[:cr/site 0] [:cr/a]]])
+    (let [rec1 (reactive/commit-record cell)]
+      (is (not (contains? rec1 :root-id))
+          "still no :root-id — the opaque token is never exposed under that key")
+      (is (identical? incarnation (:root-incarnation rec1))
+          "a rooted commit records the EXACT opaque per-mount incarnation token
+           under :root-incarnation — private identity, compared by identical?")
+      (is (not (keyword? (:root-incarnation rec1)))
+          "the substrate holds only opaque identity, never the authored keyword —
+           that resolution happens downstream at the tool boundary")
+      (is (identical? (reactive/cell-root cell) (:root-incarnation rec1))
+          "the record's :root-incarnation is exactly the cell's attached root
+           incarnation (`cell-root`) — the record ties to its owning root"))))
+
+(deftest distinct-roots-record-distinct-incarnations-no-collision
+  ;; Two views mounted under two DISTINCT root incarnations (e.g. two frames /
+  ;; two app instances) must key two DISTINCT commit-records — the root identity
+  ;; uniquely ties each record to its owning root and never collides with a
+  ;; sibling root.
+  (rf/reg-sub :cr/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell-a (reactive/make-cell ::a)
+        cell-b (reactive/make-cell ::b)
+        inc-a  (reactive/make-root-incarnation)
+        inc-b  (reactive/make-root-incarnation)]
+    (reactive/attach-root! cell-a inc-a)
+    (reactive/attach-root! cell-b inc-b)
+    (render+commit! cell-a [[[:cr/site 0] [:cr/a]]])
+    (render+commit! cell-b [[[:cr/site 0] [:cr/a]]])
+    (let [ra (:root-incarnation (reactive/commit-record cell-a))
+          rb (:root-incarnation (reactive/commit-record cell-b))]
+      (is (identical? inc-a ra) "cell-a's record carries root A's incarnation")
+      (is (identical? inc-b rb) "cell-b's record carries root B's incarnation")
+      (is (not (identical? ra rb))
+          "distinct roots produce distinct :root-incarnation identities — no
+           collision between sibling roots"))))
+
+(deftest a-remount-under-a-fresh-incarnation-records-the-new-root
+  ;; A root that re-mounts under the same reusable authored root-id gets a
+  ;; DISTINCT incarnation (rf2-vxgfnd.85); a commit after re-attach records the
+  ;; NEW incarnation, so a record is never keyed to a stale root.
+  (rf/reg-sub :cr/a (fn [db _] (:a db)))
+  (seed! {:a 1})
+  (let [cell  (reactive/make-cell ::v)
+        inc-1 (reactive/make-root-incarnation)
+        inc-2 (reactive/make-root-incarnation)]
+    (reactive/attach-root! cell inc-1)
+    (render+commit! cell [[[:cr/site 0] [:cr/a]]])
+    (is (identical? inc-1 (:root-incarnation (reactive/commit-record cell)))
+        "the first rooted commit records the first incarnation")
+    ;; Re-mount: attaching a DIFFERENT incarnation first drops the old
+    ;; membership, so the cell never straddles two roots.
+    (reactive/attach-root! cell inc-2)
+    (render+commit! cell [[[:cr/site 0] [:cr/a]]])
+    (is (identical? inc-2 (:root-incarnation (reactive/commit-record cell)))
+        "a commit after re-attach records the FRESH incarnation, never the stale
+         one — the record's root identity tracks the live root")))
 
 ;; ===========================================================================
 ;; Observations carry PER-OBSERVATION frame attribution (Ruling-1 amendment)


### PR DESCRIPTION
## What & why

`bd show rf2-vxgfnd.98.1.2`. The S6 per-commit committed-instance record (shipped by 8ds0v) stamped `(:root st0)` — the **opaque per-mount root-incarnation object** — under a `:root-id` key. But the version-3 claim + the record docstrings promise a *serializable authored root-id keyword*. Worse, the **first** connected commit was nil-rooted, because the mount seam's `attach-root!` runs in the later lifecycle effect, after the reconcile commit — so `:root-id` was either an opaque `Object`/`js-obj` or `nil`, never the promised authored id. No tool projection reads the raw record; the S3 tier already resolves the authored root-id independently via `re-frame.ui.tool.evidence`'s incarnation→root-id index over the live-root registry.

## The fix (minimal, substrate-scoped)

Path B from the bead ("do not expose an opaque token under `:root-id`; treat the raw record as an internal debug seam"), applied entirely within the reactive substrate fence:

- **`reactive.cljc` `mint-commit-record!`**: rename the raw record field `:root-id` → `:root-incarnation` — the honest name the tool evidence layer already uses for exactly this token. Same field, same value `(:root st0)`; no record-shape rework, no new vocab, no fabricated field.
- Corrected the `mint-commit-record!` / `commit-record` docstrings + the ViewCell state comment to describe it as the **PRIVATE opaque per-mount incarnation** (nil before `attach-root!` and under no root, compared only by `identical?`), whose authored root-id keyword is resolved **downstream at the tool boundary**, never minted at the substrate.

DEBUG-gated and production-erased exactly as before (see elision gate). viewcell.cljs and the compiler are untouched — no DOM/StrictMode surface changed; 8ds0v's StrictMode replay idempotence, render-key truth, the cause-attribution fixes (bvqu0/sy536/eww3k), and ny34u's render-key DOM stamp all stand.

### before → after (rooted commit record)
```
before: {... :root-id #object[java.lang.Object 0x..]  ...}   ; opaque token under a serializable-id key
        {... :root-id nil ...}                                ; first connected commit — nil-rooted
after:  {... :root-incarnation #object[..] ...}              ; honestly-named private token
        {... :root-incarnation nil ...}                       ; first commit still honestly nil-rooted
```

## Red → green proof

Added headless rooted proofs (run on **both** JVM and node CLJS via `-cljs-test.cljc`) to the .98.1 record test:
- a rooted commit records the exact opaque incarnation under `:root-incarnation` and never a `:root-id` key;
- the first connected commit is honestly nil-rooted (attach-root! runs later);
- distinct roots key distinct incarnations (no sibling-root collision);
- a re-mount records the fresh incarnation, never the stale one.

Against the unfixed source these fail 10/10 on the two new-shape assertions (the dumped record showed `:root-id` holding the opaque object / nil); green after the rename.

## Scope / disjointness

- Surface: `implementation/ui/src/re_frame/ui/reactive.cljc` + the `.98.1` record test only. **No file overlap** with sibling `rf2-vxgfnd.98.1.1` (the tool schema-version consumer boundary — tools/xray, tools/story, tools/re-frame2-pair-mcp).
- **Deliberately not touched (belongs to the tool-exposure / atomic-schema slice, not this substrate slice):** `tool.cljc`'s `schema-version` docstring still lists `:root-id` as a record field — now stale after the rename. It should be reconciled to `:root-incarnation` (and clarify the authored root-id resolves at the tool boundary) in the atomic spec+version-bump slice (rf2-rvs56) / alongside 98.1.1, per the umbrella's SAME-PR rule. The stale "five further cause kinds" count (bead criterion 6) lives in hot-zone `spec/004-Views.md` and likewise rides that prose slice.

## Quality gates

Run to completion, foreground, unpiped (exit codes captured by redirect):

| Gate | Result |
| --- | --- |
| `clojure -M:test` (ui JVM) | **PASS** — 1023 tests, 20005 assertions, 0 failures, 0 errors |
| `npm run test:cljs` (node CLJS) | **PASS** — 10364 tests, 51167 assertions, 0 failures, 0 errors |
| `npm run test:elision` | **PASS** — production 60/60 absent (record plane erased); control 60/60 present |

`npm run test:browser` not run: this change touches no DOM/StrictMode surface (pure substrate field rename + docstrings + headless tests); the root-identity proof needs no real DOM. StrictMode replay idempotence is covered headlessly and unchanged.

Builds on 8ds0v's merged .98.1 record. Do not merge.
