### PR TITLE
fix(examples): release prior preview owner on replace in Resources example (rf2-5jtsh)

### DIFF
--- a/examples/capabilities/resources/resources/README.md
+++ b/examples/capabilities/resources/resources/README.md
@@ -49,6 +49,10 @@ live. They go from "the framework decides" to "a workflow decides":
   preview** dispatches `:resources.app/preview-closed` to release it. *You* opened
   the owner, so *you* must close it. Forget the release and the entry pins forever
   (Xray lints the orphan). That is the trade for holding the owner yourself.
+  Opening a preview while a *different* one is open **replaces** it, so
+  `:resources.app/preview-opened` releases the prior slug's owner before ensuring
+  the new one — otherwise the replaced owner is stranded, out of reach of the one
+  Close control.
 
 - **Manual refresh — a cause with no owner.** The **Refresh** button dispatches
   `:rf.resource/refetch` with a `:cause` and deliberately **no** `:owner`. A

--- a/examples/capabilities/resources/resources/core.cljs
+++ b/examples/capabilities/resources/resources/core.cljs
@@ -211,14 +211,29 @@
 (rf/reg-event :resources.app/preview-opened
   {:doc "Open a lightweight article preview from the list — ensure the
          detail under a releaseable owner, and record the open slug in
-         app-db so the view can render the preview panel."}
+         app-db so the view can render the preview panel. Opening a
+         preview while a *different* one is already open REPLACES it: the
+         prior slug's owner is released first, so the old entry can GC
+         rather than pin forever. The single Close control only ever
+         reaches the current slug, so a replaced owner would otherwise be
+         unreachable and leak. Reopening the SAME slug re-ensures its owner
+         without churn (a fresh-skip inside the stale window)."}
   (fn [{:keys [db]} [_ slug]]
-    {:db (assoc db :resources.app/preview-slug slug)
-     :fx [[:dispatch [:rf.resource/ensure
-                      {:resource :article/by-slug
-                       :params   {:slug slug}
-                       :owner    [:resources.app/preview-opened slug]
-                       :cause    [:event :resources.app/preview-opened]}]]]}))
+    (let [prev   (:resources.app/preview-slug db)
+          ensure [:dispatch [:rf.resource/ensure
+                             {:resource :article/by-slug
+                              :params   {:slug slug}
+                              :owner    [:resources.app/preview-opened slug]
+                              :cause    [:event :resources.app/preview-opened]}]]]
+      {:db (assoc db :resources.app/preview-slug slug)
+       ;; Replacing a *different* preview: release the prior slug's owner
+       ;; first so its entry can GC. (Reopening the same slug skips the
+       ;; release — re-ensuring the owner it already holds, no churn.)
+       :fx (if (and prev (not= prev slug))
+             [[:dispatch [:rf.resource/release-owner
+                          {:owner [:resources.app/preview-opened prev]}]]
+              ensure]
+             [ensure])})))
 
 (rf/reg-event :resources.app/preview-closed
   {:doc "Close the preview — release the owner so the entry can GC, and

--- a/implementation/adapters/reagent/test/re_frame/resources_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/resources_example_cljs_test.cljs
@@ -181,6 +181,13 @@
 (defn- entry [scoped-key]
   (get-in (runtime-db) (state/entry-path scoped-key)))
 
+(defn- entry-in
+  "Read a resource entry from an EXPLICIT frame's runtime-db. The preview
+   tests drive their own anon frame (via `with-new-frame`), not `:rf/default`,
+   so they resolve entries against that frame rather than the shared helper."
+  [f scoped-key]
+  (get-in (:rf.db/runtime (rf/frame-state-value f)) (state/entry-path scoped-key)))
+
 (defn- list-key []
   (state/scoped-resource-key :rf.scope/global :articles/list {}))
 
@@ -276,6 +283,78 @@
         (let [e (get-in (:rf.db/runtime (rf/frame-state-value f)) (state/entry-path dkey))]
           (is (not (contains? (:active-owners e) preview-owner))
               "the owner was released — no dangling owner pins the entry"))))))
+
+;; The test above pins the SIMPLE case (open X → close X). The two below pin the
+;; REPLACE case — the leak rf2-5jtsh named. The list leaves every Preview button
+;; live, so opening B while A is open REPLACES A, but there is only ONE Close
+;; control and it reaches only the current slug. If :resources.app/preview-opened
+;; did not release the prior slug's owner on replace, [:resources.app/preview-
+;; opened A] would stay pinned and unreachable after A→B→close — an app-event
+;; owner LEAK against the very release teaching this example exists to make.
+
+(deftest replacing-a-preview-releases-the-prior-slug-owner-so-neither-leaks
+  (testing "examples/capabilities/resources/resources — opening preview B while
+            preview A is open REPLACES A: :resources.app/preview-opened releases
+            the prior slug's app-event owner [:resources.app/preview-opened A]
+            before ensuring B, so A's entry is no longer pinned. A→B→close then
+            proves NEITHER owner remains (the single Close control only ever
+            reaches the current slug, so a replaced owner left attached would
+            leak forever — rf2-5jtsh)."
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+                                       :fx-overrides {:rf.nav/push-url :rf/no-op}})]
+      (let [owner-a [:resources.app/preview-opened "resources-101"]
+            owner-b [:resources.app/preview-opened "owners-vs-causes"]
+            dkey-a  (detail-key "resources-101")
+            dkey-b  (detail-key "owners-vs-causes")]
+        ;; OPEN A — ensures A under owner-a; settle it :loaded so this mirrors the
+        ;; real flow (user previews A, it loads, then previews B).
+        (rf/dispatch-sync [:resources.app/preview-opened "resources-101"] {:frame f})
+        (reply-success! @last-managed-args {:slug "resources-101" :title "R101" :body "..."})
+        (is (contains? (:active-owners (entry-in f dkey-a)) owner-a)
+            "A is ensured under its app-event owner")
+        ;; OPEN B — replaces A. The prior slug's owner MUST be released here.
+        (rf/dispatch-sync [:resources.app/preview-opened "owners-vs-causes"] {:frame f})
+        (is (= "owners-vs-causes"
+               (rf/compute-sub [:resources.app/preview-slug] (rf/frame-state-value f)))
+            "the open slug is now B")
+        (is (not (contains? (:active-owners (entry-in f dkey-a)) owner-a))
+            "REPLACE released A's owner — the prior preview is no longer pinned (the fix)")
+        (is (contains? (:active-owners (entry-in f dkey-b)) owner-b)
+            "B is now ensured under its own app-event owner")
+        ;; CLOSE B — the only close control releases the CURRENT slug (B).
+        (rf/dispatch-sync [:resources.app/preview-closed "owners-vs-causes"] {:frame f})
+        (is (nil? (rf/compute-sub [:resources.app/preview-slug] (rf/frame-state-value f)))
+            "closing clears the open slug")
+        (is (not (contains? (:active-owners (entry-in f dkey-b)) owner-b))
+            "close released B's owner")
+        (is (not (contains? (:active-owners (entry-in f dkey-a)) owner-a))
+            "and A's owner is STILL released — neither preview leaks (A→B→close)")))))
+
+(deftest reopening-the-same-preview-slug-does-not-churn-its-owner
+  (testing "examples/capabilities/resources/resources — clicking Preview on the
+            ALREADY-open slug must not release-then-reacquire its owner. The
+            replace path is guarded on (not= prev slug), so reopening the same
+            slug re-ensures the owner it already holds (a fresh-skip cache hit —
+            attach-owner is a no-op for an owner already present) rather than
+            churning it. A release+reacquire would bump the entry's :revision
+            (detach of a present owner bumps it, Spec 016 rf2-cxwuhl); a clean
+            re-ensure leaves it untouched."
+    (with-new-frame [f (frame/make-anon-frame-record! {:url-bound? true
+                                       :fx-overrides {:rf.nav/push-url :rf/no-op}})]
+      (let [owner-a [:resources.app/preview-opened "fresh-skip"]
+            dkey-a  (detail-key "fresh-skip")]
+        (rf/dispatch-sync [:resources.app/preview-opened "fresh-skip"] {:frame f})
+        (reply-success! @last-managed-args {:slug "fresh-skip" :title "Fresh" :body "..."})
+        (let [rev-before (:revision (entry-in f dkey-a))]
+          (reset! last-managed-args nil)
+          ;; Reopen the SAME slug.
+          (rf/dispatch-sync [:resources.app/preview-opened "fresh-skip"] {:frame f})
+          (is (contains? (:active-owners (entry-in f dkey-a)) owner-a)
+              "the owner is still held after reopening the same slug")
+          (is (= rev-before (:revision (entry-in f dkey-a)))
+              "no churn — the owner was not released+reacquired (:revision unchanged)")
+          (is (nil? @last-managed-args)
+              "reopening the fresh slug fresh-skips — no refetch either"))))))
 
 ;; ============================================================================
 ;; 3. MANUAL REFRESH — a `:cause`, never an owner


### PR DESCRIPTION
## What

The canonical Resources example (`examples/capabilities/resources/resources/`) teaches app-event owners with an explicit release path, but `:resources.app/preview-opened` overwrote `:resources.app/preview-slug` and ensured a new slug-specific owner **without releasing the prior slug's owner**. Every Preview button stays live, so:

> Preview **A** → Preview **B** → Close **B**

left `[:resources.app/preview-opened A]` permanently pinned and unreachable from the single Close control — an app-event owner **leak**, against the very owner/release teaching the example exists to make (rf2-5jtsh).

## Fix

When a *different* preview replaces the current one, release the prior slug's owner **before** ensuring the new slug. Guarded on `(not= prev slug)`, so reopening the **same** slug re-ensures the owner it already holds (a fresh-skip cache hit) with **no release/reacquire churn**.

Purely a local example/event repair — no new ownership abstraction, route hook, or lifecycle framework (per the bead's fence). The example stays clean idiomatic re-frame2 (app-db + events + subs; no raw atoms).

## Tests

The example source stays **test-free** per the locked policy (rf2-8cevm) — no `spec.cjs` added. The regression lives in the adapter integration test tree (`implementation/adapters/reagent/test/re_frame/resources_example_cljs_test.cljs`):

- **`replacing-a-preview-releases-the-prior-slug-owner-so-neither-leaks`** — A → B → close proves **neither** owner remains (the leak).
- **`reopening-the-same-preview-slug-does-not-churn-its-owner`** — reopening the same slug leaves the entry's `:revision` untouched and issues no refetch (no churn).

Verified the replace test actually catches the leak: temporarily reverting the fix fails exactly those 2 assertions; restoring greens them.

## Quality gates

Run from `implementation/` (foreground, to completion):

- `npx shadow-cljs compile examples/resources` → **Build completed. (211 files, 210 compiled, 0 warnings)**, exit 0
- `npm run test:cljs` → **Ran 10363 tests containing 51165 assertions. 0 failures, 0 errors.**, exit 0
- Revert-verification: reverted fix → `2 failures, 0 errors` (exactly the two new replace assertions) → restored → `0 failures, 0 errors`