### PR TITLE
fix(tools): make re-frame.ui tool schema-version exact + bounded (rf2-vxgfnd.98.1.1)

### DIFF
--- a/implementation/ui/src/re_frame/ui/tool.cljc
+++ b/implementation/ui/src/re_frame/ui/tool.cljc
@@ -50,7 +50,11 @@
   S6 committed-instance evidence schema (rf2-vxgfnd.98.1 / EP-0033 §S6 view-evidence
   delta): the DEBUG-only per-commit committed-instance record the reactive substrate
   now mints and exposes through `re-frame.ui.reactive/commit-record` — integer
-  `:render-key`, per-observation `:observations`, `:root-id`, `:generation`,
+  `:render-key`, per-observation `:observations`, `:root-incarnation` (the opaque
+  per-mount root-incarnation token the raw record carries, nil before
+  `attach-root!` — NOT a serializable authored root-id; the tool projection
+  resolves it to the authored root-id it surfaces downstream via
+  `re-frame.ui.tool.evidence`), `:generation`,
   `:connection`, and the per-commit `:rf.view/causes` vector (the six shipped kinds
   :mount / :subscription / :story-override / :local-state / :hmr / :disposed, plus
   the :foreign-or-react honesty fallback). Consumers that pin this version exactly

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/view_tool.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/view_tool.cljs
@@ -36,15 +36,25 @@
   absence is surfaced HONESTLY as `:reason :view-tier-unavailable` — the S3
   'tolerate absent evidence explicitly' discipline, not a fabricated emptiness.
 
-  ## Absent / older evidence (S3 tolerance)
+  ## Absent / older evidence + version gate (S3 tolerance)
 
-  The eval form resolves to one of:
+  The eval form resolves to a `{:ok? …}` envelope, which the shared
+  `versioned-envelope-result` `on-value` GATES against `consumed-schema-version`
+  — the evidence-schema version THIS Pair build understands — before it reaches
+  the wire:
 
     - `{:ok? true …projection…}`      — the projection, `:rf.ui.tool/version`
-                                        stamped, forwarded verbatim (the agent
-                                        reads the version and reconciles if it
-                                        differs from what it expects — the tier's
-                                        versioned-degrade contract);
+                                        MATCHING `consumed-schema-version`,
+                                        forwarded verbatim;
+    - `{:ok? false :reason :view-tier-version-mismatch :expected N :actual M}` —
+                                        the projection stamped a version this
+                                        build was NOT written against. Pair
+                                        connects to an arbitrary running app, so
+                                        the producer's stamp cannot define
+                                        support: an unrecognized version is a
+                                        typed mismatch, never forwarded as
+                                        success (the version boundary the tier
+                                        promises, made real on the consumer side);
     - `{:ok? false :reason :view-tier-unavailable}`  — `re-frame.ui.tool` is not
                                         loaded (optional substrate absent);
     - `{:ok? false :reason :view-not-available :view-id …}` — no compiled view
@@ -53,9 +63,11 @@
                                         nil-gates the whole tier;
     - `{:ok? false :reason :view-tier-error :message …}` — the projection threw.
 
-  Every `:ok? false` rides `isError:true` via `probe/map-envelope-result`
-  (spec/003 §'Every :ok? false response is isError: true'), so a degraded read is
-  never cached and never masquerades as a successful empty answer.
+  Every `:ok? false` rides `isError:true` via `versioned-envelope-result` (which
+  wraps `probe/map-envelope-result`; spec/003 §'Every :ok? false response is
+  isError: true'), so a degraded read — an unavailable tier, an absent view, OR a
+  version mismatch — is never cached and never masquerades as a successful
+  answer.
 
   ## Hot swap — the existing nREPL HMR path
 
@@ -90,6 +102,45 @@
        "lives in day8/re-frame2-ui (the optional compiled-view substrate). It "
        "is present whenever Xray is active, or when the app itself loads it. "
        "Load re-frame.ui.tool into the running build and retry."))
+
+(def consumed-schema-version
+  "The `re-frame.ui.tool` evidence-schema version THIS Pair build was written to
+  forward — a CONSUMER-OWNED literal. Pair connects to an ARBITRARY running app
+  that may ship an older or newer tier, so it CANNOT trust the producer's own
+  `:rf.ui.tool/version` stamp to define support: a projection stamped a version
+  this build does not understand is reported as a typed `:ok? false` mismatch,
+  never forwarded as a successful read of a shape it cannot parse. Currently 3,
+  matching `re-frame.ui.tool/schema-version` 3; bump ONLY when Pair is taught the
+  new shape."
+  3)
+
+(defn versioned-envelope-result
+  "The `on-value` projection for the five view-tool reads: `probe/map-envelope-
+  result` PLUS a consumer-owned version GATE. A `:ok? true` projection stamped a
+  `:rf.ui.tool/version` this build was not written against is converted to a
+  typed `{:ok? false :reason :view-tier-version-mismatch}` (isError) rather than
+  forwarded as success — Pair may reach an arbitrarily old/new app, so the
+  producer's stamp does not define support. Every other value (a `:ok? false`
+  absence/error envelope, a genuinely-empty `:ok? true` version-matched read, or
+  a blank/non-map result) defers UNCHANGED to `map-envelope-result`, so the
+  isError contract and honest-emptiness handling are unchanged."
+  [v]
+  (if (and (map? v)
+           (true? (:ok? v))
+           (not= consumed-schema-version (:rf.ui.tool/version v)))
+    (wire/err-text {:ok?      false
+                    :reason   :view-tier-version-mismatch
+                    :expected consumed-schema-version
+                    :actual   (:rf.ui.tool/version v)
+                    :hint     (str "the running app's re-frame.ui.tool tier stamped "
+                                   "evidence-schema version "
+                                   (pr-str (:rf.ui.tool/version v))
+                                   " but this pair build understands version "
+                                   consumed-schema-version
+                                   " — the projection shape may have evolved "
+                                   "incompatibly. Align the app's day8/re-frame2-ui "
+                                   "with this tool build (or update the tool).")})
+    (probe/map-envelope-result v)))
 
 (defn projection-form
   "Build the `cljs.core/exists?`-guarded, self-describing eval form for a
@@ -153,7 +204,7 @@
       (let [build-id (wire/arg-build conn raw-args)
             form     (projection-form proj-fn [(pr-str v)] :view-not-available v)]
         (probe/eval-after-runtime!
-          conn build-id form fail-reason probe/map-envelope-result)))))
+          conn build-id form fail-reason versioned-envelope-result)))))
 
 (defn read-view-manifest-tool
   "MCP `read-view-manifest` — the versioned public projection of a compiled
@@ -192,7 +243,7 @@
   (let [build-id (wire/arg-build conn raw-args)
         form     (projection-form "mounted-views" [] :view-tier-inactive nil)]
     (probe/eval-after-runtime!
-      conn build-id form :read-mounted-views-failed probe/map-envelope-result)))
+      conn build-id form :read-mounted-views-failed versioned-envelope-result)))
 
 (defn explain-render-tool
   "MCP `explain-render` — why did a compiled view's live incarnations render? The
@@ -208,4 +259,4 @@
                                   (when (some? view-id) [(pr-str view-id)])
                                   :view-tier-inactive nil)]
     (probe/eval-after-runtime!
-      conn build-id form :explain-render-failed probe/map-envelope-result)))
+      conn build-id form :explain-render-failed versioned-envelope-result)))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -1905,6 +1905,18 @@
     {:isError? false
      :edn-submap {:ok? true :views []}}}
 
+   {:fixture/id    :read-mounted-views/version-mismatch-iserror
+    :fixture/doc   "a projection stamped a schema version this pair build was NOT written against is converted to a typed {:ok? false :reason :view-tier-version-mismatch} (isError) by the consumer-owned version gate — Pair reaches an arbitrarily old/new app, so the producer's stamp does not define support (rf2-vxgfnd.98.1.1). The version boundary is real: an incompatible producer shape is never forwarded as a successful read."
+    :fixture/tool  "read-mounted-views"
+    :fixture/args  {}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"        true]
+     ["re-frame.ui.tool/mounted-views"  {:ok? true :rf.ui.tool/version 9999 :views []}]
+     [:default                          nil]]
+    :fixture/expect
+    {:isError? true
+     :edn-submap {:ok? false :reason :view-tier-version-mismatch :expected 3 :actual 9999}}}
+
    {:fixture/id    :explain-render/happy
     :fixture/doc   "explain-render forwards the render-cause projection with the version + loss/observation fields per occurrence."
     :fixture/tool  "explain-render"

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/view_tool_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/view_tool_test.cljs
@@ -117,6 +117,54 @@
                    (done)))))))
 
 ;; ---------------------------------------------------------------------------
+;; Version gate — the boundary is REAL, not nominal (rf2-vxgfnd.98.1.1)
+;; ---------------------------------------------------------------------------
+
+(deftest a-version-matching-projection-is-forwarded-as-success
+  ;; The ordinary version-`consumed-schema-version` read is unchanged: the
+  ;; envelope passes the gate and rides through as a successful (non-error) read.
+  (async done
+    (let [seen (atom nil)]
+      (-> (with-captured-form! seen {:ok? true
+                                     :rf.ui.tool/version view-tool/consumed-schema-version
+                                     :views []}
+            (fn []
+              (view-tool/read-mounted-views-tool (fresh-conn) #js {})))
+          (.then (fn [result]
+                   (is (false? (tu/error? result))
+                       "a version-matched projection is a successful read")
+                   (let [edn (tu/extract-edn result)]
+                     (is (true? (:ok? edn)))
+                     (is (= [] (:views edn))
+                         "a genuinely-empty version-matched read is NOT mislabelled as an error"))
+                   (done)))))))
+
+(deftest a-producer-version-this-build-does-not-understand-is-a-typed-mismatch
+  ;; rf2-vxgfnd.98.1.1 — Pair connects to an ARBITRARY running app, so it cannot
+  ;; trust the producer's own stamp to define support. A `:ok? true` projection
+  ;; stamped a `:rf.ui.tool/version` this build was NOT written against is a typed
+  ;; `:ok? false :view-tier-version-mismatch` (isError), never forwarded as
+  ;; success. RED before the fix, where every stamped envelope rode through
+  ;; `map-envelope-result` as `:ok? true` with no supported-version check.
+  (async done
+    (let [seen           (atom nil)
+          producer-ahead (+ 100 view-tool/consumed-schema-version)] ; unmistakably foreign
+      (-> (with-captured-form! seen {:ok? true :rf.ui.tool/version producer-ahead :views []}
+            (fn []
+              (view-tool/read-mounted-views-tool (fresh-conn) #js {})))
+          (.then (fn [result]
+                   (is (true? (tu/error? result))
+                       "a producer version this build does not understand is an isError")
+                   (let [edn (tu/extract-edn result)]
+                     (is (= false (:ok? edn)))
+                     (is (= :view-tier-version-mismatch (:reason edn)))
+                     (is (= producer-ahead (:actual edn)) "the producer's stamp is reported")
+                     (is (= view-tool/consumed-schema-version (:expected edn))
+                         "…against the consumer-owned expected version")
+                     (is (string? (:hint edn)) "carries an alignment hint"))
+                   (done)))))))
+
+;; ---------------------------------------------------------------------------
 ;; Tool wiring — the missing-view-id short-circuit
 ;; ---------------------------------------------------------------------------
 

--- a/tools/story/test/re_frame/story/view_tool.cljc
+++ b/tools/story/test/re_frame/story/view_tool.cljc
@@ -50,10 +50,16 @@
   (:require [re-frame.ui.tool :as tool]))
 
 (def consumed-schema-version
-  "The `re-frame.ui.tool/schema-version` this consumer was written against. A
-  projection stamped a DIFFERENT `:rf.ui.tool/version` is surfaced as
-  `:version-mismatch?` (degrade), never mis-parsed as the shape we know."
-  tool/schema-version)
+  "The `re-frame.ui.tool` evidence-schema version THIS consumer was written to
+  parse — a CONSUMER-OWNED literal, deliberately NOT `tool/schema-version`.
+  Binding it to the producer's own var makes ANY producer bump silently
+  'understood', so an evolved shape would be mis-parsed as the shape we know —
+  the version boundary would be nominal. A projection stamped a DIFFERENT
+  `:rf.ui.tool/version` is surfaced as `:version-mismatch?` and DEGRADES (every
+  shape-dependent field suppressed), never mis-parsed. Currently 3, matching
+  `re-frame.ui.tool/schema-version` 3; bump in lockstep only when Story is taught
+  the new shape."
+  3)
 
 (defn- version-of [projection]
   (:rf.ui.tool/version projection))
@@ -119,28 +125,49 @@
   record); a production build → `:tier-available? false` throughout."
   ([view-id] (view-evidence view-id nil))
   ([view-id sub-overrides]
-   (let [manifest (tool/view-manifest view-id)
-         deps     (tool/view-dependencies view-id)
-         events   (tool/view-event-sites view-id)
+   (let [manifest    (tool/view-manifest view-id)
+         deps        (tool/view-dependencies view-id)
+         events      (tool/view-event-sites view-id)
          ;; `mounted-views` / `explain-render` are non-nil in ANY dev build
          ;; (empty-but-versioned envelopes) and nil ONLY in production, so they
          ;; are the tier-liveness discriminator manifest-absence cannot give.
-         mounted  (tool/mounted-views)
-         render   (tool/explain-render view-id)
-         version  (some version-of [manifest deps events mounted render])
-         rows     (filterv #(= view-id (:view-id %)) (:views mounted))]
-     {:view-id            view-id
-      :rf.ui.tool/version version
-      :tier-available?    (some? mounted)
-      :version-mismatch?  (boolean (and version (not= consumed-schema-version version)))
-      :compiled-view?     (some? manifest)
-      :manifest           manifest
-      :dependencies       deps
-      :event-sites        events
-      :mounted            rows
-      :render             (vec (:occurrences render))
-      :observation        {:owned?    false
-                           :overrides (observation-overrides sub-overrides)}})))
+         mounted     (tool/mounted-views)
+         render      (tool/explain-render view-id)
+         version     (some version-of [manifest deps events mounted render])
+         mismatch?   (boolean (and version (not= consumed-schema-version version)))
+         observation {:owned?    false
+                      :overrides (observation-overrides sub-overrides)}]
+     (if mismatch?
+       ;; A producer stamped a version this consumer was not written against.
+       ;; DEGRADE honestly: surface the mismatch + tier liveness, but SUPPRESS
+       ;; every shape-dependent parse (manifest / sites / mounted / render). An
+       ;; evolved shape may mean something different, so returning it as
+       ;; understood would be a mis-parse — the exact hole the version boundary
+       ;; exists to close. This is the explicit empty/status form the absence
+       ;; path already returns, flagged `:version-mismatch? true`.
+       {:view-id            view-id
+        :rf.ui.tool/version version
+        :tier-available?    (some? mounted)
+        :version-mismatch?  true
+        :compiled-view?     false
+        :manifest           nil
+        :dependencies       nil
+        :event-sites        nil
+        :mounted            []
+        :render             []
+        :observation        observation}
+       (let [rows (filterv #(= view-id (:view-id %)) (:views mounted))]
+         {:view-id            view-id
+          :rf.ui.tool/version version
+          :tier-available?    (some? mounted)
+          :version-mismatch?  false
+          :compiled-view?     (some? manifest)
+          :manifest           manifest
+          :dependencies       deps
+          :event-sites        events
+          :mounted            rows
+          :render             (vec (:occurrences render))
+          :observation        observation})))))
 
 ;; ---------------------------------------------------------------------------
 ;; JVM structural-tree vocabulary (Tier-1)

--- a/tools/story/test/re_frame/story/view_tool_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/view_tool_cljs_test.cljc
@@ -114,6 +114,42 @@
     (is (= [] (:render ev)))))
 
 ;; ===========================================================================
+;; view-evidence — the version boundary is REAL (rf2-vxgfnd.98.1.1)
+;; ===========================================================================
+
+(deftest view-evidence-degrades-on-a-producer-version-it-was-not-taught
+  ;; The version boundary must be REAL, not nominal. `consumed-schema-version` is
+  ;; a consumer-owned LITERAL, so a producer that bumps its OWN schema-version
+  ;; (its projections then stamp the new version) is a DETECTABLE mismatch — and
+  ;; on mismatch Story SUPPRESSES every shape-dependent parse rather than shaping
+  ;; the evolved manifest/sites/mounted/render as if understood. RED before the
+  ;; fix, which set `:version-mismatch? true` yet STILL returned the parsed
+  ;; manifest / :compiled-view? / mounted / render — a mis-parse presented as
+  ;; exact.
+  (register-view! :story.demo/widget demo-manifest)
+  (let [producer-ahead (inc view-tool/consumed-schema-version)]
+    ;; Bumping the producer var alone makes the REAL projections stamp the new
+    ;; version — the running app's tier is simply ahead of this consumer.
+    (with-redefs [tool/schema-version producer-ahead]
+      (let [ev (view-tool/view-evidence :story.demo/widget {[:demo/total] 99})]
+        (is (true? (:version-mismatch? ev))
+            "a producer version the consumer was not taught is a detected mismatch")
+        (is (= producer-ahead (:rf.ui.tool/version ev))
+            "the producer's version is reported honestly")
+        (is (true? (:tier-available? ev))
+            "the tier is LIVE — the mismatch is the degrade, not absence")
+        (testing "every shape-dependent parse is suppressed — never mis-parsed as understood"
+          (is (false? (:compiled-view? ev)))
+          (is (nil? (:manifest ev)))
+          (is (nil? (:dependencies ev)))
+          (is (nil? (:event-sites ev)))
+          (is (= [] (:mounted ev)))
+          (is (= [] (:render ev))))
+        (testing "the non-shape-dependent observation frame (Story author data) still rides"
+          (is (false? (:owned? (:observation ev))))
+          (is (= 99 (:value (first (:overrides (:observation ev)))))))))))
+
+;; ===========================================================================
 ;; view-evidence — connected-instance records + render causes
 ;; ===========================================================================
 

--- a/tools/xray/src/day8/re_frame2_xray/viewcell_evidence.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/viewcell_evidence.cljs
@@ -293,13 +293,23 @@
   (sync-sentinel! false)
   nil)
 
+(def ^:private expected-schema-version
+  "The `re-frame.ui.tool` evidence-schema version THIS Xray build was written to
+  parse — a CONSUMER-OWNED literal, deliberately NOT `tool/schema-version`.
+  Deriving support from the producer's own var makes ANY producer bump silently
+  'supported', so an evolved shape would be mis-parsed as exact — the version
+  boundary would be nominal. Pinning a literal makes a producer that bumps its
+  schema a DETECTABLE mismatch until Xray is taught the new shape and this pin is
+  bumped in lockstep. Currently 3, matching `re-frame.ui.tool/schema-version` 3."
+  3)
+
 (defn- supported-version?
-  "True when the projection envelope carries EXACTLY the `re-frame.ui.tool`
-  schema version this Xray build understands. A different (older or newer)
-  producer version is degraded honestly rather than mis-parsed — the shape
-  may have evolved incompatibly."
+  "True when the projection envelope carries EXACTLY the evidence-schema version
+  THIS Xray build understands (`expected-schema-version`, a consumer-owned
+  literal). A different (older or newer) producer version is degraded honestly
+  rather than mis-parsed — the shape may have evolved incompatibly."
   [version]
-  (= version tool/schema-version))
+  (= version expected-schema-version))
 
 (defn- project-occurrence
   "Shape ONE `re-frame.ui.tool/explain-render` occurrence into the

--- a/tools/xray/test/day8/re_frame2_xray/viewcell_evidence_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/viewcell_evidence_cljs_test.cljs
@@ -211,6 +211,31 @@
     (is (= {:version 9999 :supported? false} (viewcell-evidence/version-status))
         "…and the version-status read reports the mismatch honestly")))
 
+(deftest a-producer-bump-alone-does-not-widen-consumer-support
+  ;; rf2-vxgfnd.98.1.1 — the version boundary must be REAL, not nominal. Xray
+  ;; pins the evidence-schema version IT understands to a consumer-owned literal,
+  ;; so a producer that bumps its OWN `re-frame.ui.tool/schema-version` (and thus
+  ;; stamps envelopes with the new version) does NOT become auto-'supported': the
+  ;; bump is a DETECTABLE mismatch until Xray is taught the shape. RED before the
+  ;; fix, where `supported-version?` compared the envelope to the producer's own
+  ;; `tool/schema-version` — moving BOTH here in lockstep, so the incompatible
+  ;; shape was accepted as exact and `rows` mis-parsed it.
+  (is (some? (viewcell-evidence/acquire!)) "Xray owns the span")
+  (let [producer-ahead (inc tool/schema-version)] ; a version the consumer pin is not
+    (with-redefs [tool/schema-version producer-ahead
+                  tool/explain-render
+                  (fn ([] (tool/explain-render nil))
+                    ([_view-id]
+                     {:rf.ui.tool/version producer-ahead
+                      :view-id nil
+                      :occurrences [{:occurrence 1 :view-id ::v :connection :connected
+                                     :render-count 3 :batches 1}]}))]
+      (is (= [] (viewcell-evidence/rows))
+          "a producer-ahead version the consumer was not taught degrades to empty")
+      (is (= {:version producer-ahead :supported? false}
+             (viewcell-evidence/version-status))
+          "…and version-status reports the mismatch against the CONSUMER pin, not the producer var"))))
+
 (deftest disconnected-truncated-and-inexact-project-without-fabrication
   ;; Occurrence identity, the LIVE connection state, the honest hide-vs-unmount
   ;; lifecycle log, the two DISTINCT loss axes (observation-identity fidelity


### PR DESCRIPTION
## What

PR #6582 advertised `re-frame.ui.tool/schema-version` 3 as a lockstep producer/consumer compatibility boundary, but the three consumers did not independently own the version they understand, making the contract **nominal** — an incompatible producer shape could be accepted as if understood:

- **Xray** compared an envelope to the producer's own `tool/schema-version`.
- **Story** defined `consumed-schema-version` as that same producer var and kept shaping manifest/mounted/render data after setting `:version-mismatch?`.
- **Pair** forwarded every stamped envelope as `:ok? true` with no supported-version check.

This makes the boundary **real**. Each consumer now owns a **literal** expected version, so a producer that bumps its own schema is a *detectable* mismatch:

| Consumer | Change | Degrade on mismatch |
|---|---|---|
| Xray | `supported-version?` pins a consumer-owned literal (`expected-schema-version`) | `rows` → `[]`, mismatch surfaced via `version-status` |
| Story | `consumed-schema-version` is a literal; `view-evidence` branches on mismatch | every shape-dependent parse (manifest/sites/mounted/render) **suppressed**; explicit empty/status form, `:version-mismatch? true` |
| Pair | consumer-owned `versioned-envelope-result` gates the `on-value` | `:ok? true` at an unknown version → typed `{:ok? false :reason :view-tier-version-mismatch}` (isError), never forwarded as success |

Ordinary version-3 reads are unchanged. No negotiation, migrations, or compatibility framework (pre-alpha, no back-compat).

## Proof (red → green)

One focused mismatch test per consumer, each injecting a producer stamp **different from the consumer pin** — RED before the fix, GREEN after:

- Xray `a-producer-bump-alone-does-not-widen-consumer-support` — redefines the producer var + envelope; the consumer pin stays decoupled, so it degrades. (Pre-fix, `supported-version?` moved both together and accepted the evolved shape as exact.)
- Story `view-evidence-degrades-on-a-producer-version-it-was-not-taught` — asserts manifest/sites/mounted/render/`:compiled-view?` are all suppressed on mismatch. (Pre-fix, they were returned parsed alongside `:version-mismatch? true`.)
- Pair `a-producer-version-this-build-does-not-understand-is-a-typed-mismatch` + a new `:read-mounted-views/version-mismatch-iserror` **conformance corpus fixture** pinning the typed mismatch end-to-end. (Pre-fix, an unknown version rode through as `:ok? true`.)

## Docstring truth-fix (sibling coordination — merge-order note)

Per coordination with sibling **rf2-vxgfnd.98.1.2 (#6615)**, this PR also corrects the `schema-version` docstring in `implementation/ui/src/re_frame/ui/tool.cljc`: #6615 renames the raw `commit-record` field `:root-id` → `:root-incarnation` (the opaque per-mount incarnation token, not a serializable authored root-id; the tool projection resolves it downstream). The projection's output key `:root-id` is unchanged. Docstring-only, no shape change.

**MERGE ORDER:** the docstring documents #6615's rename — sequence this PR to merge **at or after #6615** so the docstring and `reactive.cljc`'s emitted field name agree.

## Quality gates

All run in foreground to completion:

- Story JVM (`tools/story` `clojure -M:test`): **1846 tests, 0 failures** (also re-run after the tool.cljc docstring edit — loads `re-frame.ui.tool`)
- node-test CLJS (`implementation` `npm run test:cljs`, covers Xray + Story node tests): **10363 tests, 0 failures**
- Pair suite (`tools/re-frame2-pair-mcp` `npm test`, view-tool unit + conformance corpus): **1214 tests, 0 failures**
- `npm run test:mcp-conformance`: **ALL MCP-CONFORMANCE GATES GREEN**
- `npm run test:bundle-isolation`: **all PASS** (tools stay isolated from production bundles)
