### PR TITLE
fix(ui): elide presence undefined-key diagnostic traversal from production (rf2-vz6a1)

### DIFF
--- a/implementation/ui/src/re_frame/ui/presence_runtime.cljc
+++ b/implementation/ui/src/re_frame/ui/presence_runtime.cljc
@@ -297,7 +297,14 @@
   [incoming]
   (let [[pairs dups] (claim-identities (collect-elements [] incoming))]
     (warn-duplicate-identities! dups)
-    (warn-keyless-drops! (count-keyless 0 incoming))
+    ;; `count-keyless` is a SECOND full walk of the child tree, run purely to
+    ;; feed the dev advisory. Gate the traversal AND its warning together behind
+    ;; the compile-time `goog.DEBUG` branch so `:advanced` + `goog.DEBUG=false`
+    ;; DCEs the whole walk — an eager argument would otherwise still execute in
+    ;; production and discard its result (rf2-vz6a1). `dups` above needs no such
+    ;; gate: it is already computed by `claim-identities`, so its warning is free.
+    (when ^boolean js/goog.DEBUG
+      (warn-keyless-drops! (count-keyless 0 incoming)))
     pairs))
 
 (defn- render-entries


### PR DESCRIPTION
## What

The presence runtime's undefined-key diagnostic (`count-keyless`) shipped in production. `incoming-identities` evaluated `(count-keyless 0 incoming)` **eagerly as an argument** to `warn-keyless-drops!`, so the recursive second child-tree walk executed on every production presence render even though the warning body itself was `goog.DEBUG`-gated. The eager argument evaluates before the call, so it did not DCE.

## Change

One small gating change in `re-frame.ui.presence-runtime/incoming-identities`: the `count-keyless` traversal and its warning are now gated **together** behind the compile-time `^boolean js/goog.DEBUG` branch, so `:advanced` + `goog.DEBUG=false` constant-folds the whole form away and DCEs both `count-keyless` and `warn-keyless-drops!`.

```
-    (warn-keyless-drops! (count-keyless 0 incoming))
+    (when ^boolean js/goog.DEBUG
+      (warn-keyless-drops! (count-keyless 0 incoming)))
```

No new diagnostic framework, no warning-lifecycle state, no API, no test-matrix change. No behaviour change: the dev warning still fires under `goog.DEBUG=true`; the child drop itself stays unconditional in `collect-elements`.

## Production-elision proof (before/after advanced bundle)

Rebuilt `out/browser-test-prod-elision/js/test.js` on origin/main (baseline) vs this branch (fixed):

- **Baseline**: `count-keyless` compiles to `function M9(a,b){return b==null?a:...b.key==null?a+1:a:a}` and its caller executes the discarded call `M9(0,a);` on every presence render — exactly the audit residue.
- **Fixed**: the count-keyless body signature (`.key==null?X+1`) appears **0 times**; the discarded `M9(0,a);` call is **gone**; bundle is 156 bytes smaller. The traversal is fully DCE'd, name-independently.

## Quality gates

- `implementation/ui && clojure -M:test` — 993 tests, 0 failures, 0 errors
- `npm run test:cljs` — 10364 tests, 0 failures, 0 errors (incl. `presence-dom-cljs-test` `keyless-child-drops-with-dev-warning`, which pins the dev warning still fires under `goog.DEBUG=true`)
- `npm run test:elision` — PASS, production 60/60 absent
- `npm run test:browser-prod-elision` — `ui mounted production elision: PASS`, 116 browser tests / 501 assertions, 0 failures (includes the just-merged `presence-retention-elision-prod-test` fixture, which stays green — the retention machine is untouched)

Closes rf2-vz6a1.