### PR TITLE
fix(ui): make data-rf-render-key an owned, truthful DOM stamp (rf2-vxgfnd.98.1.3)

### DIFF
--- a/implementation/ui/src/re_frame/ui/viewcell.cljs
+++ b/implementation/ui/src/re_frame/ui/viewcell.cljs
@@ -152,12 +152,30 @@
 ;; stays host-agnostic (it also runs headless on the JVM plain-atom host, which
 ;; has no DOM node); the DOM-specific stamp lives at this React commit site.
 ;;
+;; OWNED + TRUTHFUL (rf2-vxgfnd.98.1.3, mirroring the compiler's rf2-x1nbv
+;; authored-wins collision law). The imperative stamp has an explicit ownership
+;; boundary so the DOM evidence never lies and dev never overwrites what
+;; production preserves:
+;;   - A programmer-authored `data-rf-render-key` on the host root WINS: the
+;;     framework detects the attribute already present on a node it does not own
+;;     and leaves it untouched (trust the programmer). Only an UNCLAIMED root is
+;;     stamped, and once claimed the framework re-stamps ONLY its own node on each
+;;     connected commit — the truthful per-commit key.
+;;   - The framework tracks the single node it currently owns a stamp on
+;;     (`owned-ref`). When the host callback DETACHES or ownership moves — the
+;;     no-ref → authored-ref transition on a REUSED host node, where the callback
+;;     detaches while React keeps the DOM node — it removes ONLY its own stamp, so
+;;     a now-opted-out node carries no stale render-key. An authored value was
+;;     never owned, so it is never in `owned-ref` and never removed; the authored
+;;     callback / object ref is preserved (we clone in a ref only onto a root the
+;;     author did not `:ref`, and we only ever touch the attribute, never the ref).
+;;
 ;; DEBUG-ONLY, production-erased (I-12, exactly like the static annotation):
 ;; every hook and branch below sits behind `^boolean js/goog.DEBUG`, so Closure
 ;; constant-folds the gate to false and DCEs the whole thing — the host-node ref,
-;; the `data-rf-render-key` literal, and the `setAttribute` — under :advanced +
-;; goog.DEBUG=false. A production ViewCell keeps exactly its two layout effects
-;; and stamps nothing.
+;; the owned-node ref, the `data-rf-render-key` literal, the `setAttribute`, and
+;; the ownership `removeAttribute` — under :advanced + goog.DEBUG=false. A
+;; production ViewCell keeps exactly its two layout effects and stamps nothing.
 ;; ---------------------------------------------------------------------------
 
 (defn- stampable-host-root?
@@ -167,7 +185,15 @@
   annotation lands on. A view / foreign-component / fragment root has no DOM node
   to stamp, and a host root the author already `:ref`s is left untouched rather
   than clobbering the user's ref — such a view forgoes the DOM-attribute
-  convenience (its render-key is still readable via `reactive/render-key`)."
+  convenience (its render-key is still readable via `reactive/render-key`).
+
+  This gates only whether the framework attaches its host-node callback (does a
+  stampable node exist, and would a ref collide?). The SECOND collision — an
+  author who wrote their own `data-rf-render-key` — is enforced at stamp time
+  against the committed node's actual attribute (`use-commit-and-lifecycle!`),
+  because an authored value can arrive via a spread and is only truthful on the
+  final committed node, exactly as the compiler's rf2-x1nbv law reads the FINAL
+  props object."
   [element]
   (and (react/isValidElement element)
        (string? (.-type element))
@@ -176,18 +202,35 @@
 (defn- use-commit-and-lifecycle!
   "Publish an observation-only capture, own React visibility lifecycle, and — in
   DEV only — stamp the per-commit render-key onto the committed host-root DOM
-  node. Returns the element to render: in DEV a clone of `element` carrying a
-  stable host-node ref when the root is a stampable host element; unchanged in
-  production (the whole DEV arm DCEs)."
+  node as an OWNED, TRUTHFUL attribute (rf2-vxgfnd.98.1.3). Returns the element to
+  render: in DEV a clone of `element` carrying a stable host-node ref when the
+  root is a stampable host element; unchanged in production (the whole DEV arm
+  DCEs)."
   [cell root-incarnation capture element]
   ;; DEV: capture the committed host-root DOM node so the reconcile effect can
-  ;; stamp render-key onto it. Both hooks are goog.DEBUG-gated, so production
-  ;; carries neither — its ViewCell keeps exactly the two layout effects below.
-  (let [host-ref (when ^boolean js/goog.DEBUG (react/useRef nil))
-        host-cb  (when ^boolean js/goog.DEBUG
-                   (react/useCallback
-                     (fn capture-host-node [node] (set! (.-current host-ref) node))
-                     #js []))]
+  ;; stamp render-key onto it (`host-ref`), and track the ONE node the framework
+  ;; currently OWNS a stamp on (`owned-ref`) so it can (a) distinguish its own
+  ;; stamp from a programmer-authored `data-rf-render-key` — authored wins — and
+  ;; (b) remove ONLY its own stamp when the callback detaches or ownership moves.
+  ;; All three hooks are goog.DEBUG-gated, so production carries none of them —
+  ;; its ViewCell keeps exactly the two layout effects below.
+  (let [host-ref  (when ^boolean js/goog.DEBUG (react/useRef nil))
+        owned-ref (when ^boolean js/goog.DEBUG (react/useRef nil))
+        host-cb   (when ^boolean js/goog.DEBUG
+                    (react/useCallback
+                      (fn capture-host-node [node]
+                        ;; Detach (node=nil) or move to a different node: if the
+                        ;; framework owns a stamp on the node it is LEAVING, erase
+                        ;; ONLY that owned stamp so a now-opted-out node (e.g. a
+                        ;; reused host root that just gained an authored :ref)
+                        ;; carries no stale render-key. An authored value was never
+                        ;; owned, so it is never in `owned-ref` and never removed.
+                        (let [owned (.-current owned-ref)]
+                          (when (and (some? owned) (not (identical? owned node)))
+                            (.removeAttribute owned "data-rf-render-key")
+                            (set! (.-current owned-ref) nil)))
+                        (set! (.-current host-ref) node))
+                      #js []))]
     ;; Reconcile after every committed render. There is deliberately no cleanup:
     ;; retained observation owners live on the cell, not on a render.
     (react/useLayoutEffect
@@ -202,7 +245,20 @@
           (let [node (some-> host-ref .-current)
                 rk   (reactive/render-key cell)]
             (when (and node (some? rk))
-              (.setAttribute node "data-rf-render-key" (str rk)))))
+              (cond
+                ;; The framework already OWNS this node's stamp → update it to the
+                ;; render that just committed (truthful per connected commit).
+                (identical? node (.-current owned-ref))
+                (.setAttribute node "data-rf-render-key" (str rk))
+                ;; A `data-rf-render-key` the framework does NOT own is
+                ;; programmer-authored — trust the programmer, opt out untouched
+                ;; (the rf2-x1nbv authored-wins law, read on the final node).
+                (.hasAttribute node "data-rf-render-key")
+                nil
+                ;; An unclaimed host root → the framework CLAIMS + owns the stamp.
+                :else
+                (do (.setAttribute node "data-rf-render-key" (str rk))
+                    (set! (.-current owned-ref) node))))))
         js/undefined))
     ;; Connect via commit above; cleanup releases ownership on both unmount and
     ;; Activity hide. Root enrolment deliberately survives hide so root teardown

--- a/implementation/ui/test/re_frame/ui/render_key_dom_stamp_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/render_key_dom_stamp_dom_cljs_test.cljs
@@ -39,6 +39,24 @@
   [{:keys [label]}]
   [:div {:data-role "stamped"} (str label ":" (ui/sub [:rk/n]))])
 
+(defview authored-render-key-view
+  "A sub-bearing view whose compiler-owned host root carries a PROGRAMMER-AUTHORED
+  `data-rf-render-key`. Trust the programmer (rf2-vxgfnd.98.1.3 / the rf2-x1nbv
+  authored-wins law): the framework's owned stamp must never clobber it, and must
+  never re-stamp it on later commits."
+  [{:keys [label]}]
+  [:div {:data-role "authored" :data-rf-render-key "author-owned"}
+   (str label ":" (ui/sub [:rk/n]))])
+
+(defview transitioning-root-view
+  "A sub-bearing view whose compiler-owned host root gains an authored `:ref`
+  across a re-render (nil ref → object ref, the preferred authored form). React
+  reuses the same DOM node; the framework, on losing host ownership to the
+  authored ref, must remove ITS OWN stale stamp and leave the ref intact
+  (rf2-vxgfnd.98.1.3)."
+  [{:keys [node-ref]}]
+  [:div {:data-role "transition" :ref node-ref} (str (ui/sub [:rk/n]))])
+
 (defn- stamped-node [container]
   (.querySelector container "[data-role='stamped']"))
 
@@ -90,6 +108,82 @@
                    node reports the render that produced it")
               (testing "the rendered text still reflects the live subscription"
                 (is (= "b:1" (.-textContent (stamped-node container)))))))
+          (finally
+            (ReactDOM/flushSync #(ui/unmount! root))
+            (.remove container)))))))
+
+(deftest programmer-authored-data-rf-render-key-survives-development-commits
+  ;; OWNED + TRUTHFUL (rf2-vxgfnd.98.1.3). Before the ownership fix the reconcile
+  ;; effect unconditionally `setAttribute`d the render-key, clobbering an authored
+  ;; value; now an authored `data-rf-render-key` the framework does not own wins.
+  (if-not (browser?)
+    (is true ":node — the browser gate owns the real committed-DOM proof")
+    (do
+      (rf/reg-sub :rk/n (fn [db _] (:n db)))
+      (rf/make-frame {:id frame-id :doc "authored render-key survives"})
+      (frame/replace-app-db! frame-id {:n 1})
+      (let [container (js/document.createElement "div")
+            root      (ui/create-root container {:root-id :render-key-stamp/authored-root})]
+        (.appendChild js/document.body container)
+        (try
+          (ReactDOM/flushSync
+           #(ui/render! root [ui/frame-provider {:frame frame-id}
+                              [authored-render-key-view {:label "a"}]]))
+          (let [node (.querySelector container "[data-role='authored']")]
+            (is (some? node) "the authored host root committed")
+            (is (= "author-owned" (.getAttribute node "data-rf-render-key"))
+                "RED→GREEN: the authored value survives the first connected commit
+                 (the framework opts out rather than clobbering it)")
+            ;; A fresh connected commit must STILL leave the authored value alone —
+            ;; the framework never claimed it, so it never re-stamps it.
+            (ReactDOM/flushSync
+             #(ui/render! root [ui/frame-provider {:frame frame-id}
+                                [authored-render-key-view {:label "b"}]]))
+            (is (= "author-owned" (.getAttribute node "data-rf-render-key"))
+                "the authored value survives subsequent commits — never re-stamped")
+            (is (= "b:1" (.-textContent node))
+                "the view still rendered its live subscription value"))
+          (finally
+            (ReactDOM/flushSync #(ui/unmount! root))
+            (.remove container)))))))
+
+(deftest no-ref-to-authored-ref-transition-removes-the-framework-stamp
+  ;; The truthfulness half (rf2-vxgfnd.98.1.3): when a stamped host root gains an
+  ;; authored :ref while React REUSES the DOM node, the framework's host callback
+  ;; detaches. Before the fix it detached without removing its stamp, leaving a
+  ;; stale render-key on a now-opted-out node; now it removes ONLY its own stamp.
+  (if-not (browser?)
+    (is true ":node — the browser gate owns the real committed-DOM proof")
+    (do
+      (rf/reg-sub :rk/n (fn [db _] (:n db)))
+      (rf/make-frame {:id frame-id :doc "render-key ownership cleanup"})
+      (frame/replace-app-db! frame-id {:n 1})
+      (let [container (js/document.createElement "div")
+            root      (ui/create-root container {:root-id :render-key-stamp/transition-root})
+            obj-ref   #js {:current nil}]
+        (.appendChild js/document.body container)
+        (try
+          ;; --- render 1: un-reffed root → the framework claims + stamps -------
+          (ReactDOM/flushSync
+           #(ui/render! root [ui/frame-provider {:frame frame-id}
+                              [transitioning-root-view {:node-ref nil}]]))
+          (let [node (.querySelector container "[data-role='transition']")]
+            (is (some? node) "the un-reffed host root committed")
+            (is (some? (.getAttribute node "data-rf-render-key"))
+                "the framework stamped its owned key on the un-reffed root")
+            ;; --- render 2: gain an authored object :ref → node reused, stamp
+            ;; removed (React swaps host-cb → obj-ref on the same DOM node) -------
+            (ReactDOM/flushSync
+             #(ui/render! root [ui/frame-provider {:frame frame-id}
+                                [transitioning-root-view {:node-ref obj-ref}]]))
+            (is (identical? node (.querySelector container "[data-role='transition']"))
+                "React reused the same DOM node across the ref transition")
+            (is (nil? (.getAttribute node "data-rf-render-key"))
+                "RED→GREEN: the framework removed its OWN stale stamp when
+                 ownership moved to the authored ref")
+            (is (identical? node (.-current obj-ref))
+                "the authored object ref received the reused node — ref
+                 semantics preserved, only the framework attribute was touched"))
           (finally
             (ReactDOM/flushSync #(ui/unmount! root))
             (.remove container)))))))

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -1275,10 +1275,25 @@ rather than fabricating them (`tools/xray/spec/021` §3.4.1).
   **no Spec 009 rows** — only runtime-tier ids are catalogued (per the position law
   above). Spec 009 catalogues the runtime diagnostic surface; the compiler owns its
   own compile-error roster.
-- **Source ↔ DOM navigation.** Compile-time `data-rf2-source-coord` + render-key
-  (+ occurrence-path) annotation on compiler-owned host roots — today's attribute
-  vocabulary, so existing Xray click-to-source works day one. Dev-gated; production
-  builds carry none of it.
+- **Source ↔ DOM navigation.** Compile-time `data-rf2-source-coord` (+
+  occurrence-path) annotation and the per-commit `data-rf-render-key` stamp on
+  compiler-owned host roots — today's attribute vocabulary, so existing Xray
+  click-to-source works day one. Dev-gated; production builds carry none of it.
+  The static annotation is stamped at render on the props object; `render-key`
+  does not exist at render time (it is minted at connected commit), so
+  `data-rf-render-key` is stamped **at commit time** onto the committed host-root
+  DOM node, and re-stamped on each connected commit (a truthful per-commit key).
+  **Owned, not clobbered (the authored-wins collision law):** the stamp is an
+  owned attribute with an explicit boundary — a programmer-authored
+  `data-rf-render-key` wins and is left untouched (trust the programmer; only an
+  unclaimed root is stamped), the same law the compiler applies to
+  `data-rf2-source-coord` / `data-rf-view`. **Cleanup:** the framework removes
+  only its **own** stamp when its host callback detaches or ownership moves — a
+  no-ref → authored-ref transition on a reused host node erases the prior
+  framework stamp without disturbing the authored ref, so a now-opted-out node
+  never keeps a stale key. Development-only erasure holds for all three: none of
+  the attributes, the ownership tracking, or the stamp/cleanup reaches a
+  production build.
 - **Production erasure is a proof (I-12).** Compile-time defines + bundle-scan gates;
   manifests, cause vectors, histories, warning text, and `data-rf2-*` strings are on the
   scanned absence roster. The always-on Spec 009 error contracts remain.


### PR DESCRIPTION
## What

PR #6601 stamps `data-rf-render-key` imperatively after a connected commit, but the stamp had **no explicit ownership boundary**:

- In dev it **clobbered** a programmer-authored `data-rf-render-key` (production preserved it → dev/prod drift).
- When a host root gained an authored `:ref` on a **reused** DOM node, the framework host callback detached **without removing its stamp**, leaving a stale render-key on a now-opted-out node — the DOM evidence lied.

This makes the stamp **owned + truthful**, mirroring the compiler's authored-wins collision law (rf2-x1nbv):

- **Trust the programmer.** An authored `data-rf-render-key` the framework does not own **wins** and is left untouched. Only an *unclaimed* host root is stamped; once claimed the framework re-stamps ONLY its own node on each connected commit (the truthful per-commit key).
- **Owned cleanup.** The framework tracks the single node it owns a stamp on (`owned-ref`). When its host callback detaches or ownership moves to an authored ref on a reused node, it removes **only its own** stamp. The authored callback/object ref is never disturbed.
- **DEBUG-only, production-erased (I-12).** `host-ref`, `owned-ref`, the `data-rf-render-key` literal, `setAttribute`, and the ownership `removeAttribute` all sit behind `goog.DEBUG` and DCE under `:advanced`.

Spec 004 now names `data-rf-render-key`, its commit-time ownership, development-only erasure, and the collision/cleanup rule.

Surface: `implementation/ui/src/re_frame/ui/viewcell.cljs` (the imperative stamp) + the stamp DOM tests + `spec/004-Views.md`. No change to `reactive.cljc`'s render-key source. Disjoint from the live `vz6a1` (presence_runtime) worker. No regression to ny34u's stamp, 8ds0v's render-key truth / StrictMode, or 98.1.2's `:root-incarnation`.

Closes the S6 view-evidence epic's last sub-child (.98.1 → vxgfnd.98/S6).

## Red → green (browser, real-DOM)

Two new browser tests pin both transitions. Against the pre-fix `viewcell.cljs` they fail exactly as the defect predicts:

- `programmer-authored-data-rf-render-key-survives-development-commits` — expected `"author-owned"`, actual `"339"` then `"340"` (the framework clobbered + re-stamped the authored value).
- `no-ref-to-authored-ref-transition-removes-the-framework-stamp` — expected `nil`, actual `"341"` (stale framework stamp left on the opted-out reused node).

With the fix both are green and the authored object ref still receives the reused node.

## Quality gates

All run in the worktree, foreground, to completion:

- `cd implementation/ui && clojure -M:test` — **993 tests, 19216 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — **10366 tests, 51169 assertions, 0 failures, 0 errors**
- `npm run test:browser` (the real-DOM teeth, RAN TO COMPLETION) — **512 tests, 2825 assertions, 0 failures, 0 errors**
- `npm run test:elision` — **PASS, production 60/60 absent** (the stamp + ownership plane erased)
- `npm run test:browser-prod-elision` — **118 tests, 526 assertions, 0 failures, 0 errors** (stamp absent in production real-DOM)