### PR TITLE
fix(ssr): render-static capability elision + root-site registration + ssr-artefact-missing error (rf2-uv7n6)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr/render_static_jvm_test.clj
+++ b/implementation/ssr/test/re_frame/ssr/render_static_jvm_test.clj
@@ -15,6 +15,7 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [re-frame.ui :as ui]
+            [re-frame.ui.compiler :as compiler]
             [re-frame.ui.compiler.root :as root]
             [re-frame.ui.tree :as ui-tree]
             [re-frame.ssr :as ssr]))
@@ -69,6 +70,30 @@
 (ui/defview dup-probe
   [_]
   [:main "probe"])
+
+;; ---------------------------------------------------------------------------
+;; rf2-uv7n6 audit-hole fixtures (the three re-verified conformance holes in the
+;; no-silent-elision proof). All compiled top-to-bottom so their view-static facts
+;; are indexed + registered when render-static below expands against them.
+;; ---------------------------------------------------------------------------
+
+;; HOLE 1 — an INLINE client-only interactive child (the live content authored
+;; directly, NOT behind a separate referenced view). Only the capability-free
+;; fallback is server-reachable, so render-static must render the fallback; the
+;; committed handler lives inside the browser-only child, whose sites must NOT be
+;; counted against the static root (server reachability governs cap collection).
+(ui/defview inline-island-card
+  [_]
+  [:div [:h2 "static"]
+   (ui/client-only {:fallback [:span "loading"]}
+     [:button {:on-click [:go]} "live"])])
+
+;; HOLE 3 — an AUTHORED element :ref (a commit-phase host hook a static render
+;; cannot honour). The JVM emitter drops refs, so an unchecked ref would render as
+;; inert HTML with the ref silently removed; render-static must reject it loud.
+(ui/defview authored-ref-card
+  [{:keys [node-ref]}]
+  [:div {:ref node-ref} "x"])
 
 (defn- caught-id
   "Run `f`; -> the thrown compile-error id (`:rf.ui.compile/error` ex-data),
@@ -333,3 +358,93 @@
             call renders — the late resolution loads and folds through emit-ui-tree"
     (is (= "<div class=\"card\"><h2>x</h2><p>static</p></div>"
            (ui/render-static [static-card {:title "x"}])))))
+
+;; ===========================================================================
+;; rf2-uv7n6 AUDIT HOLES — the three re-verified conformance gaps in the
+;; no-silent-elision proof (each reproduced RED on the real render-static path
+;; before the fix; the three focused falsifiers the audit prescribed).
+;; ===========================================================================
+
+;; HOLE 1 — server reachability must govern CAPABILITY collection, not only the
+;; dependency walk. RED before: view-static-facts read caps from the whole-view
+;; sites atom, so a committed handler AUTHORED inside a ui/client-only child
+;; (whose sites the shared atom still carries) marked the view runtime-requiring,
+;; falsely rejecting a legal static-plus-island root. GREEN after: only the
+;; server-reachable sites count, so render-static renders the fallback.
+(deftest render-static-allows-inline-client-only-live-content
+  (testing "an INLINE client-only interactive child (committed handler authored
+            directly in the fallback-guarded island, not behind a referenced
+            view) is legal — render-static renders ONLY the capability-free
+            fallback, never falsely rejecting the static root"
+    (let [html (ui/render-static [inline-island-card])]
+      (is (= "<div><h2>static</h2><span>loading</span></div>" html))
+      (is (not (str/includes? html "button"))
+          "the inline client-only interactive child is not in the static output"))))
+
+;; HOLE 2 — an unobtainable dependency's facts must not silently pass. RED before:
+;; static-capability-offender treated a view-id absent from the ambient index as
+;; empty caps/deps and continued, so an AOT/other-build interactive dependency
+;; rendered as inert HTML with its handler dropped. GREEN after: facts resolve
+;; from the registered manifest too, and a dependency resolvable from NEITHER
+;; source is the loud :rf.ui.compile/static-root-unproven-dependency.
+(deftest render-static-missing-dependency-facts-cannot-silently-pass
+  (testing "a nested interactive dependency whose facts are UNOBTAINABLE from
+            both the ambient index and the registered manifest is UNPROVEN — a
+            loud build error, never a silent static pass (unknown facts are not
+            proof of static safety)"
+    (is (= :rf.ui.compile/static-root-unproven-dependency
+           (with-redefs [compiler/build-view-static      (constantly {})
+                         root/registered-view-static-facts (constantly nil)]
+             (render-static-error-id '[static-parent])))))
+  (testing "the SAME dependency, absent from the ambient index but resolvable
+            from its REGISTERED manifest (the cross-build/AOT seam), is still
+            caught — the manifest's facts drive the proof, never a silent pass"
+    (is (= :rf.ui.compile/static-root-requires-runtime
+           (with-redefs [compiler/build-view-static (constantly {})
+                         root/registered-view-static-facts
+                         (constantly {:caps #{:handler} :deps #{}})]
+             (render-static-error-id '[static-parent]))))))
+
+;; HOLE 2 (companion) — the manifest actually CARRIES the facts the cross-build
+;; seam resolves. Proven by pure macroexpansion (immune to sibling clear-all!
+;; fixtures): the emitted register-view! call embeds :static-facts on the
+;; manifest, so a view compiled in another build stays fact-bearing here.
+(deftest defview-manifest-embeds-static-facts
+  (testing "a compiled view's emitted register-view! carries its render-static
+            {:caps :deps} facts on the manifest (:static-facts)"
+    (let [expansion (binding [*ns* (find-ns 're-frame.ssr.render-static-jvm-test)]
+                      (macroexpand
+                       '(re-frame.ui/defview uv7n6-facts-probe [_]
+                          [:button {:on-click [:x]} "x"])))
+          text      (pr-str expansion)]
+      (is (str/includes? text ":static-facts")
+          "the emitted manifest embeds :static-facts")
+      (is (str/includes? text ":handler")
+          "the embedded facts name the committed-handler capability")))
+  (testing "registered-view-static-facts reads those facts back off the manifest"
+    (ui-tree/register-view! :uv7n6/seam-probe
+                            (fn [_] nil)
+                            {:view-id :uv7n6/seam-probe
+                             :static-facts {:caps #{:handler} :deps #{}}})
+    (is (= {:caps #{:handler} :deps #{}}
+           (root/registered-view-static-facts :uv7n6/seam-probe)))))
+
+;; HOLE 3 — an authored element :ref is a runtime-requiring capability. RED
+;; before: view-static-facts folded :ref only from re-frame.ui.react use-ref
+;; hooks, never from an authored element/component :ref slot, and the JVM emitter
+;; omits refs — so `[:div {:ref r} "x"]` rendered `<div>x</div>` with the ref
+;; silently removed. GREEN after: a server-reachable authored ref is the loud
+;; :rf.ui.compile/static-root-requires-runtime.
+(deftest render-static-rejects-an-authored-ref
+  (testing "an authored element :ref (a commit-phase host hook a static render
+            cannot honour) is a loud build error, never a ref silently dropped
+            from inert HTML"
+    (is (= :rf.ui.compile/static-root-requires-runtime
+           (render-static-error-id '[authored-ref-card {:node-ref nil}]))))
+  (testing "the build error names the :ref capability"
+    (let [ex  (try (expand-render-static '[authored-ref-card {:node-ref nil}])
+                   nil
+                   (catch clojure.lang.ExceptionInfo e e))
+          msg (some-> ex ex-message)]
+      (is (some? msg))
+      (is (str/includes? msg "ref") "names the runtime-requiring ref capability"))))

--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -149,39 +149,66 @@
   frame reads / host locals / effects / dispatch-fns), the
   re-frame.ui.react host hooks (use-ref -> `:ref`, use-context -> `:context`,
   use-effect family -> `:effect`; `use-id` is EXEMPT — an inert deterministic id
-  is static-safe), and foreign heads (`:foreign`, which a `react/lazy` head folds
-  into). `:deps` are the view references to close over transitively.
+  is static-safe), authored element/component `:ref` slots (a commit-phase host
+  hook a static render cannot honour -> `:ref`), and foreign heads (`:foreign`,
+  which a `react/lazy` head folds into). `:deps` are the view references to close
+  over transitively.
 
-  A `ui/client-only` subtree is skipped: the JVM emitter renders only its
-  capability-free FALLBACK, so the browser-only child is not server-reachable —
-  its views and capabilities never reach the static output and must not be
-  counted (a static root never flips)."
+  SERVER REACHABILITY governs BOTH the dependency walk AND the capability
+  collection: a `ui/client-only` subtree is browser-only — the JVM emitter
+  renders only its capability-free FALLBACK — so its views, its authored refs,
+  and its authored SITES (an inline `:on-click`, `sub`, effect …) never reach the
+  static output and must not be counted (a static root never flips). Since the
+  view-wide `sites` atom also carries the browser-only child's sites (the child
+  is analyzed against the shared atom), each client-only node's `:path` is
+  recorded and a site whose `:path` descends from one is excluded — the capability
+  proof only counts the SERVER-REACHABLE sites, mirroring the dependency walk."
   [ast sites]
   (let [deps     (volatile! #{})
-        foreign? (volatile! false)]
+        foreign? (volatile! false)
+        ref?     (volatile! false)
+        co-paths (volatile! [])]
     (letfn [(walk [n]
               (when (map? n)
                 (if (= :client-only (:op n))
-                  ;; browser-only child never reaches the JVM tree; only the
-                  ;; capability-free fallback does.
-                  (walk (:fallback n))
+                  ;; browser-only child never reaches the JVM tree; record its
+                  ;; path (so its sites drop out of the capability proof) and
+                  ;; walk ONLY the capability-free fallback.
+                  (do (vswap! co-paths conj (:path n))
+                      (walk (:fallback n)))
                   (do
                     (when (= :view (:op n))    (vswap! deps conj (:view-id n)))
                     (when (= :foreign (:op n)) (vreset! foreign? true))
+                    ;; an authored `:ref` (element OR component props) is a
+                    ;; commit-phase host hook — a static render cannot honour it,
+                    ;; so a server-reachable ref is a runtime-requiring capability
+                    ;; (the JVM emitter would otherwise drop it silently).
+                    (when (some? (get-in n [:props :ref])) (vreset! ref? true))
                     (doseq [[_ v] n]
                       (cond
                         (map? v)    (walk v)
                         (vector? v) (run! walk v)))))))]
       (walk ast))
-    {:caps (cond-> (into (into #{}
-                               (keep (fn [[kind cap]]
-                                       (when (seq (get sites kind)) cap)))
-                               runtime-requiring-site-caps)
-                         (keep {:ref :ref :context :context :effect :effect
-                                :layout-effect :effect :effect-event :effect})
-                         (map :kind (:react sites)))
-             @foreign? (conj :foreign))
-     :deps @deps}))
+    (let [cos       @co-paths
+          reachable (if (empty? cos)
+                      (fn [kind] (get sites kind))
+                      (let [under-co? (fn [p]
+                                        (boolean
+                                         (some (fn [co]
+                                                 (and (<= (count co) (count p))
+                                                      (= co (subvec p 0 (count co)))))
+                                               cos)))]
+                        (fn [kind] (remove #(under-co? (:path %)) (get sites kind)))))]
+      {:caps (cond-> (into (into #{}
+                                 (keep (fn [[kind cap]]
+                                         (when (seq (reachable kind)) cap)))
+                                 runtime-requiring-site-caps)
+                           (keep {:ref :ref :context :context :effect :effect
+                                  :layout-effect :effect :effect-event :effect})
+                           (map :kind (reachable :react)))
+               @foreign? (conj :foreign)
+               @ref?     (conj :ref))
+       :deps @deps})))
 
 (defn build-view-static
   "The ambient build's per-view static-render facts index (view-id ->
@@ -273,6 +300,12 @@
                     (println (str "WARNING re-frame.ui [" view-id "] "
                                   (:id w) ": " (:msg w)))))
         sites   @(:sites e)
+        ;; The render-static no-silent-elision facts (Spec 004C §3, EP-0034 §2),
+        ;; computed once: contributed to the ambient `view-static` build index
+        ;; AND carried on the registered manifest so a view compiled in ANOTHER
+        ;; build/context (AOT / precompiled JAR) stays fact-bearing — the
+        ;; render-static proof never treats an unknown dependency as static-safe.
+        static-facts (view-static-facts ast sites)
         ast-projection (ana/template-fingerprint-projection ast)
         tf      (fingerprint/template-fingerprint ast-projection)
         ;; The HMR hook signature: `local` sites (all `:local`) and `effect`
@@ -319,6 +352,10 @@
                                         :layout-effect :effect :effect-event :effect
                                         :context :context})
                                  (map :kind (:react sites)))
+                  ;; The render-static server-reachable {:caps :deps} proof
+                  ;; facts, carried so a cross-build/AOT dependency stays
+                  ;; fact-bearing (rf2-uv7n6 hole 2).
+                  :static-facts static-facts
                   :sites sites}
         args    {:vname vname
                  ;; The canonical current-namespace Var a self-recursive head
@@ -356,8 +393,7 @@
     ;; registry row, so a recompiled / removed source replaces / evicts its
     ;; contribution; not folded into the build digest (derived from the same
     ;; source the `views` digest already tracks).
-    (build/contribute! build/view-static ns-sym view-id
-                       (view-static-facts ast sites))
+    (build/contribute! build/view-static ns-sym view-id static-facts)
     (if cljs?
       ;; Direct no-pass REPL evaluation may replace the runtime view body, but
       ;; carries no digest assignment. Only a successful configured file/watch

--- a/implementation/ui/src/re_frame/ui/compiler/root.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/root.cljc
@@ -48,7 +48,8 @@
             [re-frame.ui.compiler.build :as build]
             [re-frame.ui.compiler.env :as env]
             [re-frame.ui.fingerprint :as fingerprint]
-            #?@(:clj [[re-frame.ui.compiler :as compiler]
+            #?@(:clj [[re-frame.registrar :as registrar]
+                      [re-frame.ui.compiler :as compiler]
                       [re-frame.ui.compiler.emit-cljs :as emit-cljs]
                       [re-frame.ui.compiler.emit-jvm :as emit-jvm]])))
 
@@ -789,19 +790,38 @@
                 ~(plans-thunk-form plans)
                 ~(react-opts-form nil opts)))))))))
 
+(defn registered-view-static-facts
+  "The render-static `{:caps :deps}` facts a compiled view carries on its
+  REGISTERED manifest (`re-frame.ui.tree/register-view!` → the `:view` registrar
+  entry) — the cross-build-context resolution seam (rf2-uv7n6 hole 2). A view
+  compiled in ANOTHER build (AOT / precompiled JAR) is absent from THIS build's
+  `view-static` index, but its registration runs when its namespace loads, so its
+  manifest (carrying `:static-facts`) is resolvable here. nil when the view is
+  unregistered or its manifest predates static-facts — a genuinely UNPROVEN
+  dependency the caller must fail loud on rather than treat as static-safe."
+  [view-id]
+  (get-in (registrar/lookup :view view-id) [:rf.ui/manifest :static-facts]))
+
 (defn- static-capability-offender
   "The render-static transitive static-capability proof (Spec 004C §3, EP-0034
   §2 no-silent-elision): given the ROOT form's own `{:caps :deps}` facts and the
-  ambient build's per-view `view-static` index, return `{:view-id .. :caps ..}`
-  for the FIRST server-reachable view (or the root form itself,
-  `:rf.root/root-form`) that carries a runtime-requiring capability, or nil when
-  the whole server-reachable closure is static-safe.
+  ambient build's per-view `view-static` index, return
+
+    - `{:view-id .. :caps ..}`     the FIRST server-reachable view (or the root
+                                   form itself, `:rf.root/root-form`) carrying a
+                                   runtime-requiring capability;
+    - `{:view-id .. :unproven? true}`  the first referenced view whose facts are
+                                   genuinely UNOBTAINABLE (absent from BOTH the
+                                   ambient index and the registered manifest);
+    - nil                          the whole server-reachable closure is proven
+                                   static-safe.
 
   Cycle-safe: the closure follows direct compiled-view dependencies breadth-first
   over a `seen` set, so a self-recursive or mutually-recursive view terminates.
-  A view-id absent from the index (compiled in another build/context) contributes
-  no known capability and is skipped — the proof catches the KNOWN interactive
-  views loaded in this render's build."
+  Each dependency's facts resolve from the ambient index first, then from its
+  registered manifest (a cross-build/AOT view). Unknown facts are NOT proof of
+  static safety (rf2-uv7n6 hole 2): a dependency resolvable from NEITHER source is
+  reported UNPROVEN, never silently skipped."
   [own-facts index]
   (if (seq (:caps own-facts))
     {:view-id :rf.root/root-form :caps (:caps own-facts)}
@@ -811,10 +831,12 @@
               queue (pop queue)]
           (if (contains? seen vid)
             (recur queue seen)
-            (let [{:keys [caps deps]} (get index vid)]
+            (if-let [{:keys [caps deps]} (or (get index vid)
+                                             (registered-view-static-facts vid))]
               (if (seq caps)
                 {:view-id vid :caps caps}
-                (recur (into queue deps) (conj seen vid))))))))))
+                (recur (into queue deps) (conj seen vid)))
+              {:view-id vid :unproven? true})))))))
 
 (defn render-static-form
   "`(ui/render-static root-form)` — the pure `:server`-phase static-HTML render
@@ -896,25 +918,43 @@
           ;; lazy heads) is a loud BUILD error with source coordinates — never a
           ;; silently dropped capability. `ui/client-only` stays legal (only its
           ;; capability-free fallback is server-reachable); `use-id` is exempt.
-          (when-let [{:keys [view-id caps]}
+          (when-let [{:keys [view-id caps unproven?]}
                      (static-capability-offender
                       (compiler/view-static-facts ast @(:sites e))
                       (compiler/build-view-static))]
-            (fail :rf.ui.compile/static-root-requires-runtime
-                  (str "ui/render-static: the static root's server-reachable view "
-                       "closure requires runtime capability "
-                       (str/join ", " (map name (sort caps)))
-                       (if (= :rf.root/root-form view-id)
-                         " in the root form itself"
-                         (str " (via view " (pr-str view-id) ")"))
-                       " — render-static is the pure :server static-HTML path (no "
-                       "subs, handlers, effects, refs, context, or foreign/lazy "
-                       "heads; no manifest, no hydration, no phase flip). Mount "
-                       "this tree in the browser with ui/mount / ui/hydrate-root, "
-                       "or move the live subtree behind a ui/client-only with a "
-                       "capability-free fallback")
-                  {:root-id root-id :offending-view view-id
-                   :capabilities (vec (sort caps))}))
+            (if unproven?
+              ;; A referenced view whose render-static facts are UNOBTAINABLE
+              ;; (absent from both the ambient index and the registered manifest)
+              ;; is UNPROVEN — a loud build error, never a silently-inert render
+              ;; that could drop an interactive dependency's handler (hole 2).
+              (fail :rf.ui.compile/static-root-unproven-dependency
+                    (str "ui/render-static: the static root depends on view "
+                         (pr-str view-id) " whose render-static facts are "
+                         "UNPROVEN — they are absent from this build's view-static "
+                         "index AND from the view's registered manifest (an "
+                         "AOT/precompiled view compiled before static-facts, or a "
+                         "stale registration). Unknown facts are not proof of "
+                         "static safety, so render-static fails loud rather than "
+                         "shipping a possibly-inert render. Recompile "
+                         (pr-str view-id) " against a current re-frame.ui, or "
+                         "mount this tree in the browser with ui/mount / "
+                         "ui/hydrate-root")
+                    {:root-id root-id :unproven-view view-id})
+              (fail :rf.ui.compile/static-root-requires-runtime
+                    (str "ui/render-static: the static root's server-reachable view "
+                         "closure requires runtime capability "
+                         (str/join ", " (map name (sort caps)))
+                         (if (= :rf.root/root-form view-id)
+                           " in the root form itself"
+                           (str " (via view " (pr-str view-id) ")"))
+                         " — render-static is the pure :server static-HTML path (no "
+                         "subs, handlers, effects, refs, context, or foreign/lazy "
+                         "heads; no manifest, no hydration, no phase flip). Mount "
+                         "this tree in the browser with ui/mount / ui/hydrate-root, "
+                         "or move the live subtree behind a ui/client-only with a "
+                         "capability-free fallback")
+                    {:root-id root-id :offending-view view-id
+                     :capabilities (vec (sort caps))})))
           ;; Layer-1 identity registration (§7): the static root participates in
           ;; the build-tier duplicate-root-id index exactly like mount / render! /
           ;; hydrate-root — the derived identity is retained, not discarded.

--- a/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
@@ -150,6 +150,10 @@
     ;; capability anywhere in the static root's server-reachable view closure is a
     ;; loud build error, never a silently dropped capability (EP-0034 §2)
     :rf.ui.compile/static-root-requires-runtime
+    ;; render-static UNPROVEN dependency (S5, rf2-uv7n6 hole 2) — a referenced view
+    ;; whose static facts are absent from BOTH the ambient index and its registered
+    ;; manifest is a loud build error; unknown facts are not proof of static safety
+    :rf.ui.compile/static-root-unproven-dependency
     ;; a11y-diagnostic suppression grammar (S4-C, rf2-74vlo) — a malformed
     ;; ^{:rf.ui/suppress {<id> "reason"}} is loud, never a silent no-op
     :rf.ui.compile/bad-suppress})
@@ -198,7 +202,10 @@
                              expansion rejection is exercised where it renders) +
                              static-root-requires-runtime (the no-silent-elision
                              proof needs the build view-static index populated —
-                             not reachable by macroexpanding a single form)
+                             not reachable by macroexpanding a single form) +
+                             static-root-unproven-dependency (an unobtainable-facts
+                             dependency, exercised there via a controlled index +
+                             registry gap)
     custom_element_conflict_jvm_test
                              custom-element-conflict (needs TWO declaring
                              sources in one build — not reachable by
@@ -220,7 +227,8 @@
     :rf.ui.compile/bad-test-render-form
     :rf.ui.compile/bad-test-root
     :rf.ui.compile/ui-render-static-jvm-only
-    :rf.ui.compile/static-root-requires-runtime})
+    :rf.ui.compile/static-root-requires-runtime
+    :rf.ui.compile/static-root-unproven-dependency})
 
 (def ^:private direct-call-ids
   "Ids exercised by a direct analyzer-fn call below (defensive sites the


### PR DESCRIPTION
Closes the three re-verified conformance holes in the render-static
no-silent-elision proof (rf2-uv7n6 — the audit-reopened obligations of
rf2-oo5lb). The original three ruled repairs shipped in #6557; a follow-up
audit found the static-capability proof (repair 1) still had three causal
holes. Each is reproduced RED on the real render-static path and fixed GREEN.

## The three holes

**Hole 1 — inline client-only content falsely rejected.** `view-static-facts`
read `:caps` from the whole-view `sites` atom, but the `ui/client-only` child
is analyzed against that shared atom, so a committed handler / sub / effect
authored *inline* inside a fallback-guarded island falsely marked the whole
view runtime-requiring. Server reachability now governs capability collection
as well as the dependency walk: each client-only node's `:path` is recorded and
a site whose path descends from one is excluded — only server-reachable sites
count. (The shipped legal-island test hid this by putting the live content in a
separate referenced view, whose dependency the walk already skipped.)

**Hole 2 — an unobtainable dependency's facts silently passed.**
`static-capability-offender` destructured a nil index row as empty caps/deps and
continued, so an AOT / precompiled / other-build interactive dependency could
render as inert HTML with its handler dropped. The `{:caps :deps}` facts are now
carried on the registered manifest (`:static-facts`) and resolved cross-build via
`registered-view-static-facts`; a dependency resolvable from **neither** the
ambient index nor the manifest is the loud
`:rf.ui.compile/static-root-unproven-dependency`. Unknown facts are not proof of
static safety.

**Hole 3 — authored `:ref` omitted.** An authored element/component `:ref` (a
commit-phase host hook the JVM emitter drops) was folded into the capability
proof only from `re-frame.ui.react` use-ref hooks, never from an authored `:ref`
slot — so `[:div {:ref r} "x"]` rendered `<div>x</div>` with the ref silently
removed. A server-reachable authored ref is now the loud
`:rf.ui.compile/static-root-requires-runtime`.

## Error id

One new compile-tier id, `:rf.ui.compile/static-root-unproven-dependency`, frozen
in the error roster. No Spec 009 catalogue row — `:rf.ui.compile/*` ids are
macroexpansion diagnostics, never runtime traces (per the roster's own
classification note and the core catalogue-conformance gate, which stays green).

## Reproduction (the actual failing path)

Each hole was reproduced RED against current main on a real render-static SSR
render (driving the shipped `root/render-static-form` with `*ns*` rebound, not a
synthetic proxy), then fixed GREEN. Three focused falsifiers added:
`render-static-allows-inline-client-only-live-content`,
`render-static-missing-dependency-facts-cannot-silently-pass` (+ the
manifest-embedding companion), and `render-static-rejects-an-authored-ref`.

## Quality gates

All foreground, run to completion:

- ssr JVM `clojure -M:test` — 528 tests / 2537 assertions / 0 fail
- ui JVM `clojure -M:test` — 993 tests / 19223 assertions / 0 fail (incl. the frozen error-roster completeness assertion for the new id)
- core JVM `clojure -M:test` — 2104 tests / 10413 assertions / 0 fail (catalogue-conformance — no Spec 009 row needed)
- `npm run test:cljs` — 10368 tests / 51191 assertions / 0 fail
- `npm run test:elision` — PASS (production 60/60 absent)
- portability path-guard — OK

Surface: the render-static path (`compiler.cljc` `view-static-facts` + manifest,
`compiler/root.cljc` render-static) + the frozen error-roster test + the ssr
render-static tests. Disjoint from the live workers (viewcell .98.1.3, presence
vz6a1, u53yy hooks/react, realworld example); rebased clean onto current main.
