### PR TITLE
fix(examples): RealWorld auth return-to preserves query+fragment (rf2-k5zty)

### DIFF
--- a/examples/real-apps/realworld_http/auth.cljs
+++ b/examples/real-apps/realworld_http/auth.cljs
@@ -173,8 +173,13 @@
   (fn [{:keys [db]} _]
     (let [return-to (get-in db [:auth :return-to])]
       {:db (update db :auth dissoc :return-to)
+       ;; The stash IS the resolved address (path + params + query + #fragment)
+       ;; — a valid :rf.route/navigate request in its own right — so return
+       ;; there wholesale. A partial {:to :params} would drop the query string
+       ;; and #fragment and land the user somewhere subtly wrong. :replace? true
+       ;; keeps /login off the back stack.
        :fx [[:dispatch (if return-to
-                         [:rf.route/navigate {:to (:id return-to) :params (:params return-to)}]
+                         [:rf.route/navigate (assoc return-to :replace? true)]
                          [:rf.route/navigate {:to :realworld/home}])]]})))
 
 ;; ============================================================================

--- a/examples/real-apps/realworld_http/routing.cljs
+++ b/examples/real-apps/realworld_http/routing.cljs
@@ -156,20 +156,31 @@
 ;; `:can-enter` rejects, the runtime writes `:rf/pending-navigation` (with the
 ;; target the user aimed at) and dispatches `:rf.route/entry-blocked`. This
 ;; handler turns that into a login redirect and stashes the target for the
-;; post-login bounce-back. The auth machine's `:store-session` action
-;; (auth.cljs) reads `[:auth :return-to]` on a successful login and navigates
+;; post-login bounce-back. `:auth/post-login-redirect` (auth.cljs) reads and
+;; clears `[:auth :return-to]` on a successful interactive login and navigates
 ;; there. Both the rejection and the eventual resume therefore remain ordinary,
 ;; traceable routing events.
 ;;
 ;; The pending-nav slot carries `:rejecting-route` (the target route-id) and
-;; `:requested-url`; we resolve the params off the URL so a deep-link like
-;; `/editor/my-slug` bounces back to the right article after login.
+;; `:requested-url` — the FULL URL the user aimed at, which the runtime built
+;; through `route-url` (path + query + #fragment). We resolve the whole address
+;; off it, not just the params, so the stash is the EXACT place they were
+;; headed: a deep-link like `/editor/my-slug?draft=1#preview` bounces back with
+;; its query and fragment intact, not stranded on a bare `/editor/my-slug`. The
+;; stash is itself a valid `:rf.route/navigate` request; the bounce-back
+;; (auth.cljs) returns there with `:replace? true` so `/login` never lands on
+;; the back stack.
 (rf/reg-event :rf.route/entry-blocked
   {:doc "Steer a logged-out visitor who tried to enter a :requires-auth route to
-         login, remembering where they were headed for the bounce-back."}
+         login, remembering the FULL address they were headed for (path,
+         params, query, and #fragment) so the post-login bounce-back returns to
+         the exact URL."}
   (fn [{:keys [db]} [_ {:keys [rejecting-route requested-url]}]]
-    (let [params (:params (routing/match-url requested-url))]
-      {:db (assoc-in db [:auth :return-to] {:id rejecting-route :params (or params {})})
+    (let [{:keys [params query fragment]} (routing/match-url requested-url)]
+      {:db (assoc-in db [:auth :return-to] {:to       rejecting-route
+                                            :params   (or params {})
+                                            :query    (or query {})
+                                            :fragment fragment})
        :fx [[:dispatch [:rf.route/navigate {:to :realworld.auth/login}]]]})))
 
 ;; ============================================================================

--- a/examples/real-apps/realworld_http/schema.cljs
+++ b/examples/real-apps/realworld_http/schema.cljs
@@ -59,16 +59,21 @@
    :return-to is the breadcrumb: the post-login bounce-back target the routing
    `:rf.route/entry-blocked` handler drops here (routing.cljs) when the
    `:can-enter` auth gate turns a logged-out user away from a `:requires-auth`
-   route. `:auth/post-login-redirect` reads and clears it (auth.cljs). It only
-   exists for the brief window between that redirect and the next successful
-   login."
+   route. It's the FULL resolved address — `{:to :params :query :fragment}`, a
+   valid `:rf.route/navigate` request in its own right — so the bounce-back
+   returns to the exact URL (path, params, query, and #fragment), not just the
+   bare route. `:auth/post-login-redirect` reads and clears it (auth.cljs). It
+   only exists for the brief window between that redirect and the next
+   successful login."
   [:map
    [:user      [:maybe ws/SessionUser]]
    [:token     [:maybe :string]]
    [:return-to {:optional true}
     [:map
-     [:id     :keyword]
-     [:params [:maybe :map]]]]])
+     [:to       :keyword]
+     [:params   :map]
+     [:query    :map]
+     [:fragment [:maybe :string]]]]])
 
 ;; Machine snapshots aren't app-db — they live in the runtime-db partition at
 ;; [:rf.runtime/machines :snapshots <id>]. And `reg-app-schema` only polices

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -889,9 +889,9 @@
     ;; Bounce-back stash: the entry-blocked redirect records the original target
     ;; at [:auth :return-to].
     (rf/dispatch-sync [:rf.route/navigate {:to :realworld.user/settings}] {:frame f})
-    (is (= {:id :realworld.user/settings :params {}}
+    (is (= {:to :realworld.user/settings :params {} :query {} :fragment nil}
            (get-in (rf/frame-state-value f) [:rf.db/app :auth :return-to]))
-        "the redirect stashes the original target for post-login bounce-back")
+        "the redirect stashes the FULL address (path + params + query + fragment) for post-login bounce-back")
 
     ;; Authenticated: the same guarded nav now proceeds (:can-enter passes).
     (rf/dispatch-sync [:auth/store-session {:username "eve" :token "t"}] {:frame f})
@@ -921,18 +921,18 @@
     (rf/dispatch-sync [:rf.route/handle-url-change "/settings"] {:frame f})
     (is (= :realworld.auth/login (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
         "logged-out direct-URL/reload to a :requires-auth route redirects to login")
-    (is (= {:id :realworld.user/settings :params {}}
+    (is (= {:to :realworld.user/settings :params {} :query {} :fragment nil}
            (get-in (rf/frame-state-value f) [:rf.db/app :auth :return-to]))
-        "the direct-URL redirect stashes the original target for bounce-back")
+        "the direct-URL redirect stashes the full address for bounce-back")
 
     ;; Editor route via direct URL with path params is also gated, and
-    ;; the stash carries the params (resolved off the requested URL).
+    ;; the stash carries the full address (resolved off the requested URL).
     (rf/dispatch-sync [:rf.route/handle-url-change "/editor/my-slug"] {:frame f})
     (is (= :realworld.auth/login (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
         "logged-out direct-URL to a :requires-auth editor route redirects to login")
-    (is (= {:id :realworld.editor/edit :params {:slug "my-slug"}}
+    (is (= {:to :realworld.editor/edit :params {:slug "my-slug"} :query {} :fragment nil}
            (get-in (rf/frame-state-value f) [:rf.db/app :auth :return-to]))
-        "the editor direct-URL redirect stashes id + params for bounce-back")
+        "the editor direct-URL redirect stashes the full address (params included) for bounce-back")
 
     ;; A non-auth route via direct URL is unaffected.
     (rf/dispatch-sync [:rf.route/handle-url-change "/profile/eve"] {:frame f})
@@ -950,9 +950,9 @@
                       {:frame f})
     (is (= :realworld.auth/login (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
         "logged-out anchor click to a :requires-auth route redirects to login")
-    (is (= {:id :realworld.user/settings :params {}}
+    (is (= {:to :realworld.user/settings :params {} :query {} :fragment nil}
            (get-in (rf/frame-state-value f) [:rf.db/app :auth :return-to]))
-        "the anchor redirect stashes the original target for bounce-back")
+        "the anchor redirect stashes the full address for bounce-back")
 
     ;; A url-only request still gates via the URL-resolved target.
     (rf/dispatch-sync [:rf.route/url-requested {:url "/editor"}] {:frame f})
@@ -981,6 +981,81 @@
                       {:frame f})
     (is (= :realworld.user/settings (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
         "authenticated anchor click to a :requires-auth route proceeds")))
+
+(defn- auth-guard-return-to-full-address-test []
+  ;; rf2-k5zty — the return-to stash is the FULL resolved address
+  ;; ({:to :params :query :fragment}), so a login bounce-back lands on the EXACT
+  ;; URL the visitor was headed for, not a bare route. Before the fix the stash
+  ;; was {:id :params}, stranding the query string and #fragment. Drives the
+  ;; real example handlers (routing.cljs `:rf.route/entry-blocked` +
+  ;; auth.cljs `:auth/post-login-redirect`).
+
+  ;; --- 1. destination deep-link carrying BOTH query and fragment ---
+  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+                                 :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
+    ;; Logged-out deep-link to the guarded editor with a query AND a fragment.
+    ;; (`:tab` is an undeclared query key — the guarded routes declare none — so
+    ;; it rides as a string key; the point is it SURVIVES rather than being
+    ;; stranded, exactly as the #fragment does.)
+    (rf/dispatch-sync [:rf.route/handle-url-change "/editor/my-slug?tab=preview#comments"] {:frame f})
+    (is (= :realworld.auth/login (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+        "deep-link to a guarded route with ?query#fragment is refused → login")
+    (is (= {:to       :realworld.editor/edit
+            :params   {:slug "my-slug"}
+            :query    {"tab" "preview"}
+            :fragment "comments"}
+           (get-in (rf/frame-state-value f) [:rf.db/app :auth :return-to]))
+        "the stash carries the FULL address — query and #fragment included, not stranded")
+
+    ;; Sign in and bounce back — the return lands on the EXACT address.
+    (rf/dispatch-sync [:auth/store-session {:username "eve" :token "t"}] {:frame f})
+    (rf/dispatch-sync [:auth/post-login-redirect] {:frame f})
+    (is (= :realworld.editor/edit (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+        "bounce-back landed on the editor route")
+    (is (= {:slug "my-slug"} (rf/compute-sub [:rf.route/params] (rf/frame-state-value f)))
+        "bounce-back restored the path params")
+    (is (= {"tab" "preview"} (rf/compute-sub [:rf.route/query] (rf/frame-state-value f)))
+        "bounce-back restored the query — NOT stranded")
+    (is (= "comments" (rf/compute-sub [:rf.route/fragment] (rf/frame-state-value f)))
+        "bounce-back restored the #fragment — NOT stranded")
+    (is (nil? (get-in (rf/frame-state-value f) [:rf.db/app :auth :return-to]))
+        "the crumb was read AND cleared in one step"))
+
+  ;; --- 2. in-place edit under an expired session ---
+  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+                                 :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
+    ;; Enter the editor legitimately, then let the session expire.
+    (rf/dispatch-sync [:auth/store-session {:username "eve" :token "t"}] {:frame f})
+    (rf/dispatch-sync [:rf.route/handle-url-change "/editor/my-slug"] {:frame f})
+    (is (= :realworld.editor/edit (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+        "entered the editor while signed in")
+    (rf/dispatch-sync [:auth/clear-session] {:frame f})
+    ;; An in-place navigation (change only the #fragment) is re-gated by
+    ;; :can-enter — the classic in-place fail-open door, closed — and the stash
+    ;; carries the resolved in-place address.
+    (rf/dispatch-sync [:rf.route/navigate {:fragment "comments"}] {:frame f})
+    (is (= :realworld.auth/login (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+        "the in-place edit under an expired session is refused → login")
+    (is (= {:to       :realworld.editor/edit
+            :params   {:slug "my-slug"}
+            :query    {}
+            :fragment "comments"}
+           (get-in (rf/frame-state-value f) [:rf.db/app :auth :return-to]))
+        "the in-place edit's resolved address (current route + new #fragment) is stashed whole"))
+
+  ;; --- 3. unresolvable requested-url degrades gracefully ---
+  (with-new-frame [f (frame/make-anon-frame-record! {:initial-events [[:app/initialise]]
+                                 :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
+    ;; If match-url can't resolve the requested-url (a malformed URL the runtime
+    ;; should never actually hand this handler), the stash degrades to the
+    ;; rejecting-route with empty query and nil fragment — no crash from the nil
+    ;; match (the handler's `(or params {})` / `(or query {})` guards).
+    (rf/dispatch-sync [:rf.route/entry-blocked {:rejecting-route :realworld.editor/edit
+                                          :requested-url   "/editor/%zz?bad=%"}]
+                      {:frame f})
+    (is (= {:to :realworld.editor/edit :params {} :query {} :fragment nil}
+           (get-in (rf/frame-state-value f) [:rf.db/app :auth :return-to]))
+        "graceful fallback: :to from rejecting-route, :params/:query empty, :fragment nil")))
 
 ;; ============================================================================
 ;; ssr — `hydration-payload` selects the SSR-safe slice keys
@@ -1253,7 +1328,9 @@
   (testing "auth-guard redirects unauthenticated nav to :requires-auth routes (Spec 012)"
     (auth-guard-test))
   (testing "auth-guard fails CLOSED on direct-URL / anchor / reload entry points (rf2-mzqd4.3)"
-    (auth-guard-all-access-paths-test)))
+    (auth-guard-all-access-paths-test))
+  (testing "auth-guard return-to preserves the FULL address — query + #fragment (rf2-k5zty)"
+    (auth-guard-return-to-full-address-test)))
 
 (deftest realworld-ssr
   (testing "hydration-payload selects the SSR-safe slice keys"


### PR DESCRIPTION
The RealWorld (Conduit) example's auth guard normalised the login return-to to `{:id :params}`, so a logged-out visitor deep-linking (or navigating in place) to a protected URL carrying `?query#fragment` lost the query string and `#fragment` — after login they landed on the bare route, not where they were actually headed. This is the example-side twin of the docs fix **rf2-67go9** (#6614), which corrected the same bug in the copyable auth-guard flows; this change brings the example into line with that shipped model and the runtime's own `resolve-target`.

## What changed

- **`routing.cljs`** — `:rf.route/entry-blocked` now resolves the FULL address off the `requested-url` (which the runtime built through `route-url`, carrying path + query + `#fragment`) and stashes all four: `{:to :params :query :fragment}`.
- **`auth.cljs`** — `:auth/post-login-redirect` returns there wholesale: `[:rf.route/navigate (assoc return-to :replace? true)]`. Exact-URL return; `:replace?` keeps `/login` off the back stack. (Before: `{:to (:id return-to) :params (:params return-to)}` dropped query + fragment.)
- **`schema.cljs`** — `:return-to` is now typed as the full address shape (`:to` / `:params` / `:query` / `:fragment`).
- Corrected a stale `routing.cljs` comment: `:auth/post-login-redirect` (not any machine `:store-session` action) reads and clears the return-to.

The example stays clean, idiomatic re-frame2 — it leans on the framework's own `:can-enter` gate + `:rf.route/entry-blocked`, not a hand-rolled interceptor. The fix is proportional: resolve the whole address instead of only the params.

## Regression (the example's own contract test, not an example spec.cjs)

The regression lives in `implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs`, which requires the real `realworld-http.routing` / `realworld-http.auth` and drives the actual handlers (examples are test-free — no spec.cjs added). The existing auth-guard assertions move to the new shape, plus a focused `auth-guard-return-to-full-address-test`:

- a destination deep-link carrying both query and `#fragment` survives the round-trip (red→green — before, both were stranded), and the bounce-back lands on the exact address;
- an in-place edit under an expired session is re-gated by `:can-enter` and stashed whole;
- an unresolvable `requested-url` degrades gracefully (rejecting-route, empty query, nil fragment — no crash from the nil match).

## Quality gates

All run in the foreground to completion:

- `npx shadow-cljs compile :examples/realworld` — **Build completed. (325 files, 0 warnings)**
- `npm run test:cljs` (full node suite) — **10368 tests, 51202 assertions, 0 failures, 0 errors**
- `implementation/routing` `clojure -M:test` — **458 tests, 2382 assertions, 0 failures, 0 errors**
