### PR TITLE
fix(ui): concurrency-safe token for the native ui/effect (rf2-u53yy.6)

### DIFF
--- a/implementation/ui/src/re_frame/ui/hooks.cljc
+++ b/implementation/ui/src/re_frame/ui/hooks.cljc
@@ -140,39 +140,58 @@
   (let [c (body-fn)] (if (fn? c) c js/undefined)))
 
 (defn- deps-token
-  "Render-time pure token for an authored deps vector held in the useRef cell
-  `ref`. Returns one internal token whose identity changes iff the authored deps
-  stop being PER-SLOT `rf=` (`eq/deps-rf=?`) against the previous render's deps —
-  a distinct-but-`rf=`-equal deps value keeps the SAME token, so React's own
-  cleanup→setup does not fire. Deriving the token during render is a pure
-  function of (prev, deps): equal deps yield the same token, so a StrictMode
-  double-render (or any re-render with `rf=`-equal deps) is idempotent. Because
-  the comparison is kernel-internal (a held previous-deps slot, not React's
-  native deps array) the authored deps arity may vary between renders behind a
-  fixed one-element React deps array.
+  "WIP/concurrency-safe identity token for an authored deps vector, held in
+  ordinary React hook STATE (`useState`) — never a mutable `useRef` cell written
+  during render. Returns a token (a monotone counter) whose value changes iff the
+  authored deps stop being PER-SLOT `rf=` (`eq/deps-rf=?`) against the last
+  COMMITTED deps — a distinct-but-`rf=`-equal deps value keeps the SAME token, so
+  React's own cleanup→setup does not fire. Because the comparison is
+  kernel-internal (a held previous-deps slot, not React's native deps array) the
+  authored deps arity may vary between renders behind a fixed one-element React
+  deps array.
+
+  Why hook state, not a render-time ref (rf2-u53yy.6 obl-2): React shares ONE
+  mutable ref object across a fiber's current AND work-in-progress renders, but
+  DOUBLE-BUFFERS hook state per WIP fiber. A ref-held token is poisoned by a
+  concurrent render that is later ABANDONED — committed A holds token 0; a
+  suspended transition render B writes deps-B/token-1 into the shared ref; B is
+  abandoned; then an unchanged A re-renders, reads B's leftover deps, and
+  spuriously mints a new token → React cleanup/setups an effect whose COMMITTED
+  deps never changed. Holding (deps, token) in `useState` isolates B's write to
+  B's WIP fiber, discarded on abandon; the committed fiber keeps its own deps +
+  token, so the unchanged-A re-render skips the effect.
+
+  On an `rf=` dep change the token is advanced via a set-state-DURING-render (the
+  React-supported \"adjust state while rendering\" pattern: React re-renders with
+  the new state before committing, so the effect registers the advanced token).
+  The set NEVER fires on `rf=`-equal deps, so a StrictMode double-render — or any
+  re-render with `rf=`-equal deps — is idempotent; the token is a plain number,
+  Object.is-stable by value, so React's native deps array carries it faithfully.
 
   This is re-frame.ui's ONE effect-dependency equality doctrine — the same `rf=`
   the memo/prop comparator and the native `effect` tier use, walked PER SLOT so a
   stable `##NaN` slot (which whole-vector `rf=` would falsely report changed) or
   a rebuilt-but-equal CLJS collection slot does not re-run the effect. Shared
   verbatim by the react-interop wrappers, never a second per-tier regime."
-  [^js ref deps]
-  (let [prev ^js (.-current ref)]
-    (if (and (some? prev) (eq/deps-rf=? (.-deps prev) deps))
-      (.-token prev)
-      (let [t #js {}]
-        (set! (.-current ref) #js {:deps deps :token t})
+  [deps]
+  (let [pair      (react/useState (fn init-deps-state [] #js {:deps deps :token 0}))
+        state     (aget pair 0)
+        set-state (aget pair 1)]
+    (if ^boolean (eq/deps-rf=? (.-deps ^js state) deps)
+      (.-token ^js state)
+      (let [t (inc (.-token ^js state))]
+        (set-state #js {:deps deps :token t})
         t))))
 
 (defn effect-value
   "Passive host effect with `rf=` VALUE deps. A stable per-effect token changes
   identity only when the deps stop being `rf=`, so React's own `useEffect`
   drives cleanup-then-setup on dep change, on disconnect/unmount, and under
-  StrictMode replay — no hand-rolled scheduling."
+  StrictMode replay — no hand-rolled scheduling. The token is WIP/concurrency-safe
+  (held in React hook state, not a shared render-time ref — see `deps-token`)."
   [body-fn deps]
-  (let [ref (react/useRef nil)]
-    (react/useEffect #(run-effect body-fn) #js [(deps-token ref deps)])
-    js/undefined))
+  (react/useEffect #(run-effect body-fn) #js [(deps-token deps)])
+  js/undefined)
 
 (defn effect-connect
   "Passive host effect that runs at each CONNECT with cleanup at each disconnect
@@ -207,32 +226,31 @@
 
 (defn use-effect
   "react/use-effect lowering target — `useEffect` (passive, after paint). Both
-  arities allocate the same fixed hook shape (a held deps cell + the effect), so
-  editing deps presence is a same-signature edit. No-deps ⇒ a fresh token every
-  render (runs after every commit); deps ⇒ `rf=` VALUE deps via the shared
-  `deps-token` — a distinct-but-`rf=`-equal CLJS deps value does NOT rerun (the
-  one equality doctrine shared with `effect` and memo, never a second per-tier
-  regime)."
+  arities allocate the same fixed hook shape (a held deps-state cell + the
+  effect), so editing deps presence is a same-signature edit. No-deps ⇒ a fresh
+  token every render (runs after every commit); deps ⇒ `rf=` VALUE deps via the
+  shared WIP-safe `deps-token` — a distinct-but-`rf=`-equal CLJS deps value does
+  NOT rerun (the one equality doctrine shared with `effect` and memo, never a
+  second per-tier regime)."
   ([setup]
-   (let [_ref (react/useRef nil)]
-     (react/useEffect #(run-effect setup) #js [#js {}]))
+   (react/useState nil) ;; shape-match the deps arity's `deps-token` hook state
+   (react/useEffect #(run-effect setup) #js [#js {}])
    js/undefined)
   ([setup deps]
-   (let [ref (react/useRef nil)]
-     (react/useEffect #(run-effect setup) #js [(deps-token ref deps)]))
+   (react/useEffect #(run-effect setup) #js [(deps-token deps)])
    js/undefined))
 
 (defn use-layout-effect
   "react/use-layout-effect lowering target — `useLayoutEffect` (after DOM
   mutation, before paint): the measure-before-paint door. Same fixed hook shape
-  and `rf=` value-deps contract as `use-effect`."
+  and `rf=` value-deps contract as `use-effect` (the deps token is WIP-safe —
+  held in React hook state, not a shared render-time ref — see `deps-token`)."
   ([setup]
-   (let [_ref (react/useRef nil)]
-     (react/useLayoutEffect #(run-effect setup) #js [#js {}]))
+   (react/useState nil) ;; shape-match the deps arity's `deps-token` hook state
+   (react/useLayoutEffect #(run-effect setup) #js [#js {}])
    js/undefined)
   ([setup deps]
-   (let [ref (react/useRef nil)]
-     (react/useLayoutEffect #(run-effect setup) #js [(deps-token ref deps)]))
+   (react/useLayoutEffect #(run-effect setup) #js [(deps-token deps)])
    js/undefined))
 
 (defn use-effect-event

--- a/implementation/ui/test/re_frame/ui/react_interop_dom_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_interop_dom_cljs_test.cljs
@@ -7,7 +7,9 @@
     - use-effect: passive, `rf=` VALUE deps (a distinct-but-value-equal CLJS
       deps value is NOT a change — rf2-u53yy.6 converged the interop tier onto
       `rf=`, superseding the .95.12 Object.is split), cleanup on dep change +
-      unmount;
+      unmount; the deps token is WIP/concurrency-safe — an ABANDONED suspended
+      transition render at a new dep does not poison the committed dep's token
+      (rf2-u53yy.6 obl-2);
     - use-layout-effect: the readiness C-6 measure-before-paint NATIVE consumer
       (measure in the layout effect, pure geometry, apply, clean up exactly);
       StrictMode replay is idempotent-safe; unmount (reconnect) runs cleanup;
@@ -176,6 +178,115 @@
             (.then (fn []
                      (rf/destroy-frame! f) (done))
                    (fn [e] (rf/destroy-frame! f) (is false (str e)) (done))))))))
+
+;; The WIP/concurrency-safe deps token (rf2-u53yy.6 obl-2). A ref-held deps token
+;; is SHARED across a fiber's current and work-in-progress renders, so a suspended
+;; transition render (an ABANDONED WIP at a NEW dep) poisons the ref; when the
+;; unchanged COMMITTED fiber later re-renders, it reads the abandoned deps and
+;; spuriously re-runs the effect. Holding the (deps, token) in React hook STATE
+;; (double-buffered per WIP fiber) isolates the abandoned write — the committed
+;; fiber keeps its own token, so an unchanged committed dep does NOT re-run. This
+;; is a REAL concurrent-render case: it needs a startTransition + Suspense on a
+;; real React root, which is why it lives in the browser gate.
+
+;; A foreign child that SUSPENDS while `dep` is the transition target (1) until
+;; the test resolves it — the thrown thenable drives the transition WIP to
+;; abandon while the committed dep-0 tree stays mounted.
+(defonce ^:private txn-suspender (atom nil))
+(defn- arm-suspender! []
+  (let [box (volatile! nil)
+        p   (js/Promise. (fn [res _] (vreset! box res)))]
+    (reset! txn-suspender {:promise p :resolve @box :resolved? false})))
+(defn- resolve-suspender! []
+  (when-let [s @txn-suspender]
+    (swap! txn-suspender assoc :resolved? true)
+    ((:resolve s))))
+
+(defn- txn-suspender-el [^js props]
+  (let [dep (.-dep props)
+        s   @txn-suspender]
+    (if (and (= dep 1) s (not (:resolved? s)))
+      (throw (:promise s))
+      (React/createElement "span" #js {:data-role "sus"} "ready"))))
+
+;; The effect-bearing view — dep is its ONLY effect dependency; `other` is an
+;; unrelated urgent-update prop. Rendered FIRST under the Suspense boundary so its
+;; deps token is derived before the sibling suspender throws.
+(defview txn-effect-view [{:keys [dep other]}]
+  (let [_ (react/use-effect
+           (fn []
+             (swap! log conj [:trun dep])
+             (fn [] (swap! log conj [:tcleanup dep])))
+           [dep])]
+    [:div
+     [:span {:data-role "td"} (str dep)]
+     [:span {:data-role "to"} (str other)]]))
+
+;; Foreign controller: dep + other are REACT state, so the transition priority is
+;; React's own (not the frame notification path). Setters are stashed for the test.
+(defonce ^:private txn-controls (atom nil))
+(defn- txn-controller [^js _props]
+  (let [ds        (React/useState 0)
+        os        (React/useState 0)
+        dep       (aget ds 0)
+        set-dep   (aget ds 1)
+        other     (aget os 0)
+        set-other (aget os 1)]
+    (reset! txn-controls #js [set-dep set-other])
+    (React/createElement
+     (.-Suspense React)
+     #js {:fallback (React/createElement "span" #js {:data-role "fb"} "loading")}
+     (React/createElement txn-effect-view #js {:dep dep :other other})
+     (React/createElement txn-suspender-el #js {:dep dep}))))
+
+(defview txn-abandon-host []
+  (ui/raw (React/createElement txn-controller #js {})))
+
+(defn- only-truns [] (filterv #(= (first %) :trun) @log))
+
+(deftest use-effect-abandoned-transition-does-not-rerun-committed-dep
+  (if-not (browser?)
+    (is true ":node — browser gate runs the abandoned-transition WIP-safe token")
+    (async done
+      (reset-log!)
+      (reset! txn-controls nil)
+      (arm-suspender!)
+      (-> (uit/with-root [root [txn-abandon-host]]
+            (-> (host-turn!)
+                (.then (fn []
+                         ;; committed A: dep=0 ran the effect exactly once.
+                         (is (= [[:trun 0]] (only-truns)) "effect ran once at mount (committed dep 0)")
+                         ;; start a transition to dep=1 whose WIP SUSPENDS (abandoned).
+                         (uit/flush! #(React/startTransition
+                                       (fn [] ((aget @txn-controls 0) 1))))))
+                (.then host-turn!)
+                (.then (fn []
+                         ;; the transition is pending: the committed (dep-0) tree stays
+                         ;; mounted (a transition never shows the fallback).
+                         (is (some? (.querySelector root "[data-role='td']"))
+                             "committed dep-0 tree stays mounted (no fallback) while the transition suspends")
+                         (is (= "0" (.-textContent (.querySelector root "[data-role='td']")))
+                             "committed dep is still 0")
+                         ;; urgent update: re-renders the COMMITTED fiber (dep=0), which
+                         ;; reads the deps-token cell the abandoned WIP touched.
+                         (uit/flush! #((aget @txn-controls 1) 9))))
+                (.then host-turn!)
+                (.then (fn []
+                         (is (= "9" (.-textContent (.querySelector root "[data-role='to']")))
+                             "the urgent (other) update committed")
+                         (is (= "0" (.-textContent (.querySelector root "[data-role='td']")))
+                             "the committed dep is still 0")
+                         ;; THE REGRESSION: the abandoned dep-1 WIP must NOT poison the
+                         ;; committed dep-0 token — no spurious cleanup/re-run.
+                         (is (= [[:trun 0]] (only-truns))
+                             "an unchanged committed dep did NOT re-run the effect (WIP-safe token)")
+                         (is (not-any? #(= % [:tcleanup 0]) @log)
+                             "no spurious cleanup of the still-committed dep-0 effect")
+                         ;; settle the suspended transition so teardown is clean.
+                         (resolve-suspender!)
+                         (uit/flush!)))
+                (.then host-turn!)))
+          (.then (fn [] (done)) (fn [e] (is false (str e)) (done)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; use-layout-effect — the readiness C-6 measure-before-paint NATIVE consumer


### PR DESCRIPTION
Obligation 2 of `rf2-u53yy.6` (the WIP/concurrency-safe effect-deps token). Obligations 1 + 3 (the per-slot `eq/deps-rf=?` doctrine and the `Object.is` wording sweep) shipped via #6622; this PR completes only obl-2.

## The defect

The effect deps token was held in a `useRef` cell mutated **during render**. React shares one ref object across a fiber's *current* and *work-in-progress* renders (refs are not double-buffered). So a suspended transition render at a new dep poisons the shared ref: committed `A/token-0`, a suspended transition render `B` writes `deps-B/token-1` into the ref, `B` is abandoned, then an unchanged `A` re-renders, reads `B`'s leftover deps, and spuriously mints a new token → React `cleanup`/`setup`s an effect whose **committed** deps never changed.

## The fix

Hold the `(deps, token)` in ordinary React hook **state** (`useState`), which *is* double-buffered per WIP fiber, and advance the token via a set-state-during-render (React's supported "adjust state while rendering" pattern) only on an `rf=` dep change. An abandoned WIP render's write is isolated to its own fiber and discarded on abandon; the committed fiber keeps its own deps + token, so an unchanged committed dep skips the effect. The token is a plain number (`Object.is`-stable by value); the set never fires on `rf=`-equal deps, so StrictMode replay stays idempotent and #6622's per-slot `eq/deps-rf=?` doctrine is untouched. Shared verbatim by the react-interop `use-effect` / `use-layout-effect` wrappers (the documented "same fixed hook shape" is preserved).

Bounded: no new API, no scheduler/history machinery — one hook swapped from `useRef` to `useState`.

## Regression (browser-validated — the concurrency case is real-DOM)

`use-effect-abandoned-transition-does-not-rerun-committed-dep` in `react_interop_dom_cljs_test.cljs`: a `startTransition` to a suspending dep abandons the WIP render, then an urgent update re-renders the committed dep-0 fiber and asserts the effect does **not** re-run.

RED → GREEN proof: with the old shared-ref token restored (test kept), the browser suite showed exactly **2 failures** — both this test's regression assertions ("did NOT re-run the effect (WIP-safe token)" + "no spurious cleanup") — and no other test broke. With the `useState` fix the whole suite is green.

## Quality gates

- `implementation/ui` `clojure -M:test` — 953 tests / 19124 assertions, 0 failures, 0 errors
- `npm run test:cljs` — 10361 tests / 51196 assertions, 0 failures, 0 errors
- `npm run test:browser` — **ran to completion**, 512 tests / 2830 assertions, 0 failures, 0 errors (the acceptance gate for this real-DOM concurrency case)
- `npm run test:elision` — PASS (production 60/60 absent, control 60/60 present)

No regression to #6622's per-slot `deps-rf=?` or 8ds0v's StrictMode idempotence. Disjoint from live workers `u53yy.4` (analyze/spec-004) and `fyt5i` (http).
