### PR TITLE
feat(ui): admit the if-let binder family to the view grammar (rf2-u53yy.4)

### DIFF
--- a/docs/EP/EP-0031-re-frame-ui-programming-model.md
+++ b/docs/EP/EP-0031-re-frame-ui-programming-model.md
@@ -108,6 +108,18 @@ a ViewCell that was not actually sub-free. The set grows only by ruling.
 > "demonstrated demand at a real call site" trigger. The set still grows only by
 > ruling, each addition carrying its lexical-scope + hidden-reactive-injection
 > counterfixtures. Normative home: [spec/004-Views.md §Template grammar](../../spec/004-Views.md).
+>
+> **Erratum — 2026-07-21 (rf2-u53yy.4 chronological audit repair).** Two internal
+> corrections to the addendum above; the admitted set and every invariant are
+> unchanged. (1) The desugar target is the analyzer's own `let` + **`if`** — never a
+> generated `when`: the single-body when-* shape lowers to `(if test body nil)` (the
+> special form `if` cannot be captured by a user local named `when`), and the
+> `some?`-variants' nil test is a **host-qualified core nil check written with a plain
+> core function** (un-shadowable, and — unlike the `cljs.core` `some?`/`nil?` macros —
+> accepted by the expression grammar on re-analysis). (2) Admission is
+> **resolver-confirmed**, not raw-spelling: a `:refer`d look-alike user macro named
+> `if-let` resolves to its own var and is rejected as an unaudited macro, and a
+> qualified `clojure.core/if-let` is admitted.
 
 DOM prop spelling is pinned (`:on-click`, never `:on-keydown`); prop conversion
 is compile-time, contextual, and total — one rule table (004B) serves static

--- a/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/analyze.cljc
@@ -117,20 +117,70 @@
           keys vals seq re-seq]))
 
 (def ^:private control-heads
-  #{'if 'if-not 'when 'when-not 'cond 'case 'let 'letfn 'do 'for
-    'if-let 'when-let 'if-some 'when-some})
+  #{'if 'if-not 'when 'when-not 'cond 'case 'let 'letfn 'do 'for})
 
 (def ^:private if-let-family
   "The admitted conditional-binder family (rf2-u53yy.4): if-let / when-let /
-  if-some / when-some. `:some?` selects the some?-based test over truthiness;
-  `:else?` selects the two-arm if-let/if-some shape over the single-body
-  when-let/when-some shape. The set is CLOSED — case in expression position,
-  condp, doto and the rest stay outside the grammar (Spec 004 §Expression
-  positions); additions are S1e roster changes."
+  if-some / when-some, keyed by the UNQUALIFIED core name. `:some?` selects the
+  `some?`-based nil test over truthiness; `:else?` selects the two-arm
+  if-let/if-some shape over the single-body when-let/when-some shape. This map is
+  the source of truth for `if-let-family-fqns`; admission is RESOLVER-confirmed
+  (see `if-let-family-config`), never keyed on the raw spelling. The set is
+  CLOSED — case in expression position, condp, doto and the rest stay outside the
+  grammar (Spec 004 §Expression positions); additions are S1e roster changes."
   {'if-let    {:some? false :else? true}
    'if-some   {:some? true  :else? true}
    'when-let  {:some? false :else? false}
    'when-some {:some? true  :else? false}})
+
+(def ^:private if-let-family-fqns
+  "The four admitted binders' fully-qualified `clojure.core` / `cljs.core` names
+  mapped to their desugar config. Admission is RESOLVER-confirmed against this
+  set (rf2-u53yy.4 audit repair): a same-spelled user macro/var resolves to a
+  different fqn and is NOT admitted (it fails loudly as an unaudited macro), a
+  qualified core binder (`clojure.core/if-let`) IS admitted, and a local shadow
+  yields no resolution at all — the spelling alone never decides admission."
+  (into {}
+        (mapcat (fn [[s cfg]]
+                  [[(symbol "clojure.core" (name s)) cfg]
+                   [(symbol "cljs.core" (name s)) cfg]]))
+        if-let-family))
+
+(defn- if-let-family-config
+  "The desugar config {:some? :else?} for `head` when it is the core
+  if-let-family binder, else nil (rf2-u53yy.4 audit repair). Admission is
+  RESOLVER-confirmed, never keyed on the raw spelling alone:
+
+    - a LOCAL shadow (`head` in `(:locals e)`) is never admitted — it falls
+      through to an ordinary call;
+    - a spelling whose unqualified name is in the family and that resolves to a
+      NON-core var (a `:refer`d look-alike user macro, `my.ns/if-let`) is NOT
+      admitted — it fails loudly as an unaudited macro;
+    - a spelling that resolves to a core binder var (bare `if-let` or qualified
+      `clojure.core/if-let`) IS admitted;
+    - a BARE core name whose host offers no resolution (a data-only emit env)
+      falls back to the name — the plain core spelling with no resolver is
+      overwhelmingly the core macro, matching how the other control heads are
+      admitted in that path.
+
+  The caller passes an env whose `:locals` already carry the lexical scope."
+  [e head]
+  (when (and (symbol? head) (not (contains? (:locals e) head)))
+    (when-let [cfg (get if-let-family (symbol (name head)))]
+      (let [r (env/resolve-sym e head)]
+        (cond
+          (contains? if-let-family-fqns (:fqn r))        cfg
+          (and (nil? r) (nil? (namespace head)))         cfg)))))
+
+(defn- core-sym
+  "A host-qualified `clojure.core` / `cljs.core` symbol. A namespace-qualified
+  symbol cannot be shadowed by a user local, so a compiler-GENERATED core call —
+  the some?-binder's nil test `(core/not= temp nil)` — keeps core semantics even
+  under a hostile `(let [not= (constantly true)] (if-some …))`. `not=` is a plain
+  core function on both hosts (unlike `some?`/`nil?`, which are cljs.core macros
+  and would be rejected by the expression grammar on re-analysis)."
+  [e nm]
+  (symbol (if (= :cljs (:host e)) "cljs.core" "clojure.core") nm))
 
 (defn- binder-temp
   "A deterministic, reserved temp symbol for the if-let-family desugar. Stable
@@ -144,16 +194,23 @@
 
 (defn- desugar-if-let
   "Desugar one if-let/when-let/if-some/when-some form into the analyzer's own
-  let + if/when over a reserved temp — mirroring clojure.core's expansions. The
-  init is an ordinary evaluated expression (it may own a finite reactive site);
-  the pattern binds into the then/body branch ONLY; the else branch never sees
-  it. Both grammar tiers then reuse their EXISTING let/if machinery on the
-  result, so the family inherits the SAME scope threading, destructuring, and
-  reactive-escape rejection as a hand-written let + if — no runtime interpreter,
-  no dynamic site, no open macro system. Fails with the shared bad-let/bad-if
-  ids on a malformed binding vector or branch arity."
-  [e head temp form]
-  (let [{:keys [some? else?]} (get if-let-family head)
+  let + if over a reserved temp — mirroring clojure.core's expansions, but using
+  ONLY host-safe generated semantics (rf2-u53yy.4 audit repair): the conditional
+  is `if` (a special form, so a user local named `when`/`if` cannot capture it),
+  the some?-variants' nil test is a host-qualified core `(not= temp nil)`
+  (un-shadowable by a user local, and — unlike `some?`/`nil?`, which are cljs.core
+  macros — a plain function the expression grammar accepts on re-analysis), and
+  the single-body when-* shape lowers to `(if test body nil)` rather than a
+  generated `when`. `config` is the resolver-confirmed
+  {:some? :else?} for `head`. The init is an ordinary evaluated expression (it
+  may own a finite reactive site); the pattern binds into the then/body branch
+  ONLY; the else branch never sees it. Both grammar tiers then reuse their
+  EXISTING let/if machinery on the result, so the family inherits the SAME scope
+  threading, destructuring, and reactive-escape rejection as a hand-written let +
+  if — no runtime interpreter, no dynamic site, no open macro system. Fails with
+  the shared bad-let/bad-if ids on a malformed binding vector or branch arity."
+  [e head config temp form]
+  (let [{:keys [some? else?]} config
         [_ bindings & body] form]
     (when-not (and (vector? bindings) (= 2 (count bindings)))
       (env/fail! e :rf.ui.compile/bad-let
@@ -161,7 +218,7 @@
                       " [pattern init] " (if else? "then else?" "body …") ")")
                  {:form form}))
     (let [[pattern init] bindings
-          test  (if some? (list 'some? temp) temp)
+          test  (if some? (list (core-sym e "not=") temp nil) temp)
           inner (fn [& tail] (apply list 'let [pattern temp] tail))]
       (if else?
         (do
@@ -173,7 +230,7 @@
           (list 'let [temp init]
                 (list 'if test (inner (first body)) (second body))))
         (list 'let [temp init]
-              (list 'when test (apply inner body)))))))
+              (list 'if test (apply inner body) nil))))))
 
 (defn- fn-form? [f]
   (and (seq? f) (contains? #{'fn 'fn* 'clojure.core/fn 'cljs.core/fn} (first f))))
@@ -1074,16 +1131,18 @@
                    (= 'try head) (rw-try f locals p)
 
                    ;; if-let / when-let / if-some / when-some (rf2-u53yy.4):
-                   ;; admitted conditional binders. Desugar into the analyzer's
-                   ;; own let + if/when — the position-aware binder machinery it
-                   ;; already controls — so the init lowers a reactive site, the
-                   ;; pattern's reactive-escape is rejected, and the deferred /
-                   ;; loop position law all fall out of the existing rw-let / if
-                   ;; recursion. A local shadow of the spelling falls through to
-                   ;; an ordinary call (tier 1's control-heads guard, mirrored).
-                   (and (contains? if-let-family head)
-                        (not (contains? locals head)))
-                   (rw (desugar-if-let e head (binder-temp p) f) locals p)
+                   ;; admitted conditional binders, RESOLVER-confirmed against the
+                   ;; core binder vars (a same-spelled user macro is NOT admitted;
+                   ;; a local shadow yields no resolution and falls through to an
+                   ;; ordinary call). Desugar into the analyzer's own let + if —
+                   ;; the position-aware binder machinery it already controls — so
+                   ;; the init lowers a reactive site, the pattern's
+                   ;; reactive-escape is rejected, and the deferred / loop position
+                   ;; law all fall out of the existing rw-let / if recursion.
+                   (if-let-family-config e* head)
+                   (rw (desugar-if-let e head (if-let-family-config e* head)
+                                       (binder-temp p) f)
+                       locals p)
 
                    (and (macro-info e* head locals)
                         (contains? transparent-macro-fqns
@@ -3227,10 +3286,23 @@
   (analyze-hooks-body e "defview" forms (cons 'defview-body forms)))
 
 (defn- analyze-list [e form]
-  (let [head (first form)]
-    (if (and (symbol? head)
-             (contains? control-heads head)
-             (not (contains? (:locals e) head)))
+  (let [head (first form)
+        fam  (if-let-family-config e head)]
+    (cond
+      ;; if-let / when-let / if-some / when-some (rf2-u53yy.4): admitted
+      ;; conditional binders, RESOLVER-confirmed against the core binder vars (a
+      ;; same-spelled user macro is NOT admitted; a local shadow yields no
+      ;; resolution and falls through to an ordinary call). Desugar into the
+      ;; analyzer's own let + if and re-analyze — the branch is a conditional
+      ;; (its then/else leave the hooks region, exactly like if/when), the init
+      ;; lowers a finite reactive site, and the pattern's reactive-escape is
+      ;; rejected, all through the existing template machinery.
+      fam
+      (analyze e (desugar-if-let e head fam (binder-temp (:path e)) form))
+
+      (and (symbol? head)
+           (contains? control-heads head)
+           (not (contains? (:locals e) head)))
       (case head
         if       (let [[_ t a b & extra] form]
                    (when (seq extra)
@@ -3251,15 +3323,9 @@
         do       (if (:hooks-region? e)
                    (analyze-hooks-body e "do" (vec (rest form)) form)
                    (analyze e (single-body! e "do" (vec (rest form)) form)))
-        for      (analyze-for e form)
-        ;; if-let / when-let / if-some / when-some (rf2-u53yy.4): admitted
-        ;; conditional binders. Desugar into the analyzer's own let + if/when and
-        ;; re-analyze — the branch is a conditional (its then/else leave the
-        ;; hooks region, exactly like if/when), the init lowers a finite reactive
-        ;; site, and the pattern's reactive-escape is rejected, all through the
-        ;; existing template machinery.
-        (if-let when-let if-some when-some)
-        (analyze e (desugar-if-let e head (binder-temp (:path e)) form)))
+        for      (analyze-for e form))
+
+      :else
       (cond
         (raw-form? e form)
         (let [[_ x & extra] form]

--- a/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_accept_cljs_test.cljc
@@ -35,7 +35,14 @@
       error-boundary {:fqn 're-frame.ui/error-boundary :meta {}}
       client-only    {:fqn 're-frame.ui/client-only :meta {}}
       ..          {:fqn 'clojure.core/.. :meta {:macro true}}
-      if-let      {:fqn 'clojure.core/if-let :meta {:macro true}}
+      ;; The if-let binder family (rf2-u53yy.4) — admission is RESOLVER-confirmed,
+      ;; so every member resolves to its core var, and a fully-qualified spelling
+      ;; resolves to the SAME var (admitted identically).
+      if-let      {:fqn 'clojure.core/if-let    :meta {:macro true}}
+      when-let    {:fqn 'clojure.core/when-let  :meta {:macro true}}
+      if-some     {:fqn 'clojure.core/if-some   :meta {:macro true}}
+      when-some   {:fqn 'clojure.core/when-some :meta {:macro true}}
+      clojure.core/if-some {:fqn 'clojure.core/if-some :meta {:macro true}}
       ->          {:fqn 'clojure.core/-> :meta {:macro true}}
       frame-provider {:fqn 're-frame.ui/frame-provider :meta {}}
       child-view  {:fqn 'app.views/child-view
@@ -465,19 +472,31 @@
         (is (= :if (get-in ast [:body :op])) (str "the branch is a conditional: " form))
         (is (= 1 (count (:subs sites)))
             (str "the binding init is a single finite reactive site: " form)))))
-  (testing "some?-variants test the raw init with some?; truthy-variants test it bare"
-    (is (= 'some? (first (get-in (:ast (ana-full '(if-some [u v] [:p "a"] [:p "b"])))
-                                 [:body :test])))
-        "if-some tests (some? temp)")
-    (is (= 'some? (first (get-in (:ast (ana-full '(when-some [u v] [:p "a"])))
-                                 [:body :test])))
-        "when-some tests (some? temp)")
+  (testing "some?-variants test the raw init with a HOST-QUALIFIED core nil test; truthy-variants test it bare"
+    ;; The generated nil test is `(clojure.core/not= temp nil)` (host :clj here) —
+    ;; a namespace-qualified symbol no user local can shadow, and a plain function
+    ;; (not the cljs.core `some?`/`nil?` MACROS) so it survives re-analysis.
+    (let [t (get-in (:ast (ana-full '(if-some [u v] [:p "a"] [:p "b"]))) [:body :test])]
+      (is (= 'clojure.core/not= (first t)) "if-some's nil test is host-qualified core not=")
+      (is (= 3 (count t)) "shape is (not= temp nil)")
+      (is (nil? (nth t 2)) "compared against the nil literal"))
+    (is (= 'clojure.core/not=
+           (first (get-in (:ast (ana-full '(when-some [u v] [:p "a"])))
+                          [:body :test])))
+        "when-some tests (clojure.core/not= temp nil)")
     (is (symbol? (get-in (:ast (ana-full '(if-let [u v] [:p "a"] [:p "b"])))
                          [:body :test]))
         "if-let tests the bare temp")
+    (is (= :if (get-in (:ast (ana-full '(when-let [u v] [:p "a"]))) [:body :op]))
+        "a when-* form lowers to `if … nil` (NOT a generated `when`) so no user local named `when` can capture the branch")
     (is (= :nothing (get-in (:ast (ana-full '(when-let [u v] [:p "a"])))
                             [:body :else :op]))
         "a when-* form renders nothing on the falsy branch (no else)"))
+  (testing "admission is resolver-confirmed: a fully-qualified core binder is admitted"
+    (let [{:keys [ast]} (ana-full '(clojure.core/if-some [u v] [:p "a"] [:p "b"]))]
+      (is (= :let (:op ast)) "the qualified core binder desugars like the bare spelling")
+      (is (= 'clojure.core/not= (first (get-in ast [:body :test])))
+          "and its generated nil test is host-safe too")))
   (testing "expression position (a prop value) lowers the init's reactive site"
     (doseq [form '[[:div {:title (if-let    [x (sub [:q])] x "none")}]
                    [:div {:title (if-some   [x (sub [:q])] x "none")}]
@@ -498,6 +517,29 @@
     (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
                  (ana* '(if-let [a b c] [:p "x"] [:p "y"])))
         "the binding is a single [pattern init] pair")))
+
+(deftest if-let-family-desugar-is-hygienic
+  ;; rf2-u53yy.4 audit repair (chronological reopen 2026-07-21) — the desugar
+  ;; emits ONLY host-safe generated semantics (a host-qualified core `(not= temp
+  ;; nil)` test and the special form `if`), so no hostile user local can capture
+  ;; the compiler-generated test/branch. Without the repair, the generated bare
+  ;; `(some? temp)` was captured by `(let [some? (constantly false)] (if-some [x
+  ;; 1] x :else))` (choosing the wrong arm), and a generated `when` could become
+  ;; an ordinary user call.
+  (testing "a user local named `not=` does NOT capture the some?-variant's nil test"
+    (let [e   (update (mk-env) :locals conj 'not=)
+          ast (ana/analyze e '(if-some [x v] [:p "a"] [:p "b"]))]
+      (is (= 'clojure.core/not= (first (get-in ast [:body :test])))
+          "the generated nil test stays the qualified core `not=`, never the shadowing local (which would flip `(if-some [x 1] …)` to the wrong arm)")))
+  (testing "a user local named `when` cannot capture the when-* branch — it lowers to `if`"
+    (let [e   (update (mk-env) :locals conj 'when)
+          ast (ana/analyze e '(when-let [x v] [:p "a"]))]
+      (is (= :if (get-in ast [:body :op]))
+          "the single-body when-* shape is `(if test body nil)` — `if` is a special form and unshadowable, so no generated `when` exists to capture")))
+  (testing "a LOCAL shadow of the family spelling falls through to an ordinary call (not admitted)"
+    (let [e (update (mk-env) :locals conj 'if-let)]
+      (is (not= :let (:op (ana/analyze e '(if-let [x v] [:p "a"] [:p "b"]))))
+          "a shadowed spelling is an ordinary call, never the admitted binder"))))
 
 (deftest event-sites-index-into-the-manifest
   (let [{:keys [sites]} (ana-full '[:div

--- a/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/analyze_reject_cljs_test.cljc
@@ -116,6 +116,29 @@
   (is (= :rf.ui.compile/unsupported-form
          (reject-id '[:div {:title (sub [:a] [:b])}]))))
 
+(deftest if-let-family-admission-is-resolver-confirmed
+  ;; rf2-u53yy.4 audit repair (chronological reopen 2026-07-21) — the family is
+  ;; admitted by RESOLUTION to the core binder var, not by raw spelling. A
+  ;; namespace-level USER macro spelled `if-let` (a look-alike `:refer`d in)
+  ;; resolves to its OWN fqn, so it is not the core binder: it fails loudly as an
+  ;; unaudited macro, exactly like any other opaque macro. Before the repair the
+  ;; raw-spelling match would have silently rewritten it as the core binder.
+  (let [user-if-let-env
+        (assoc (mk-env)
+               :resolver (fn [sym]
+                           (case sym
+                             if-let {:fqn 'app.userland/if-let :meta {:macro true}}
+                             sub    {:fqn 're-frame.ui/sub :meta {}}
+                             nil)))]
+    (is (= :rf.ui.compile/unsupported-form
+           (reject-id-in user-if-let-env
+                         '(if-let [x (sub [:q])] [:p x] [:p "no"])))
+        "a user macro spelled if-let is not the core binder — it rejects as an unaudited macro, never desugared")
+    (is (= :rf.ui.compile/unsupported-form
+           (reject-id-in user-if-let-env
+                         '[:div {:title (if-let [x (sub [:q])] x "none")}]))
+        "the same rejection holds in expression position")))
+
 (deftest computed-callee-value-escape
   ;; rf2-vxgfnd.252 — a reactive authoring var (sub/frame) is sound ONLY
   ;; as a compiler-owned DIRECT CALL HEAD, which the rewriter lowers to an

--- a/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_macro_resolution_jvm_test.clj
@@ -65,8 +65,9 @@
     (fn [_ e]
       ;; A USER binder macro that expands to the SAME let + if is still opaque —
       ;; only the four core forms if-let/when-let/if-some/when-some are admitted
-      ;; (rf2-u53yy.4), by exact name, never by "looks like a binder". A bare
-      ;; threading step below `->` also stays rejected.
+      ;; (rf2-u53yy.4), by RESOLVED core identity (the host resolver confirms the
+      ;; var), never by raw spelling or "looks like a binder". A bare threading
+      ;; step below `->` also stays rejected.
       (doseq [form
               ['[:div {:title
                        (re-frame.ui.compiler-macro-resolution-jvm-test/user-binder
@@ -83,6 +84,17 @@
             "the admitted if-let lowers the branch (sub …) to one manifest site")
         (is (re-find #"re-frame.ui.reactive/sub-read" (pr-str ast))
             "the lowered runtime site is present in the desugared let + if"))
+      ;; rf2-u53yy.4 audit repair — under REAL CLJS resolution (:host :cljs) the
+      ;; some?-variant's generated nil test is the HOST-QUALIFIED core `not=`
+      ;; (`cljs.core/not=`), un-shadowable by a user local AND a plain function
+      ;; (cljs.core `some?`/`nil?` are MACROS the grammar would reject); the branch
+      ;; is `if`, never a generated `when`. Both keep core semantics under a shadow
+      ;; and both survive this real-resolution re-analysis without rejection.
+      (let [ast (analyze/analyze e '[:div {:title (if-some [x maybe] x "none")}])]
+        (is (re-find #"cljs\.core/not=" (pr-str ast))
+            "if-some tests the host-qualified plain-function cljs.core/not= (un-shadowable, re-analysis-safe)")
+        (is (not (re-find #"\(when " (pr-str ast)))
+            "no generated `when` — the branch is the special form `if`"))
       (is (= :rf.ui.compile/unsupported-form
              (compile-error-id
               #(analyze/analyze

--- a/implementation/ui/test/re_frame/ui/conditional_root_annotation_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/conditional_root_annotation_cljs_test.cljs
@@ -38,6 +38,19 @@
   [{:keys [v]}]
   (if-let [x v] [:span.has (str x)] [:span.none "none"]))
 
+(defview if-some-root
+  "if-some binds on NON-NIL, not truthiness (rf2-u53yy.4 audit crux): a `false`
+  value takes the THEN arm. The generated host-safe `(not= v nil)` makes this
+  correct on a real render — an `if-let` here would wrongly take the else arm."
+  [{:keys [v]}]
+  (if-some [x v] [:span.some (str x)] [:span.none "none"]))
+
+(defview when-some-root
+  "One-arm when-some: the concrete arm renders on any non-nil value (incl. false);
+  the implicit nil else is exempt (lowered to `if … nil`, never a generated `when`)."
+  [{:keys [v]}]
+  (when-some [x v] [:span.present (str x)]))
+
 (defview case-root
   "A (case …) host root: each clause branch and the default is a concrete
   element and is tagged."
@@ -94,6 +107,29 @@
     (let [html (render if-let-root #js {:v nil})]
       (is (str/includes? html "<span class=\"none\"") "the none arm rendered")
       (is (tagged-as? html "if-let-root")))))
+
+(deftest an-if-some-root-binds-on-non-nil-not-truthiness
+  ;; rf2-u53yy.4 audit crux — some? tests nil, NOT truthiness. The generated
+  ;; host-safe `(not= v nil)` executes correctly at real render time.
+  (testing "a non-nil truthy value takes the some arm"
+    (let [html (render if-some-root #js {:v 5})]
+      (is (str/includes? html "<span class=\"some\"") "the some arm rendered")
+      (is (tagged-as? html "if-some-root"))))
+  (testing "a FALSE value is non-nil, so it ALSO takes the some arm (some? ≠ truthy)"
+    (let [html (render if-some-root #js {:v false})]
+      (is (str/includes? html "<span class=\"some\"") "false is non-nil → the some arm")
+      (is (str/includes? html ">false</span>") "the bound false value rendered")))
+  (testing "a nil value takes the else arm"
+    (let [html (render if-some-root #js {:v nil})]
+      (is (str/includes? html "<span class=\"none\"") "nil → the none arm"))))
+
+(deftest a-when-some-root-renders-on-non-nil-incl-false
+  (testing "false is non-nil → the present arm renders"
+    (let [html (render when-some-root #js {:v false})]
+      (is (str/includes? html "<span class=\"present\"") "false is present (some? ≠ truthy)")))
+  (testing "nil → nothing"
+    (let [html (render when-some-root #js {:v nil})]
+      (is (not (str/includes? html "data-rf-view=\"")) "nil renders nothing"))))
 
 (deftest a-case-root-tags-every-clause-and-the-default
   (doseq [[k tag] [[:a "<a "] [:b "<b "] [:z "<i "]]]

--- a/implementation/ui/test/re_frame/ui/emit_cljs_view_evidence_annotation_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/emit_cljs_view_evidence_annotation_jvm_test.clj
@@ -122,7 +122,21 @@
           "two clause branches + the default, each a concrete host element")))
   (testing "the if-let family (let over if) descends to both arms"
     (let [form (cljs-emit 'app.cond 'bound '(if-let [v x] [:a v] [:b]) 7 3)]
-      (is (= 2 (stamp-count form "data-rf-view"))))))
+      (is (= 2 (stamp-count form "data-rf-view")))))
+  (testing "the whole if-let family emits through the real cljs path (rf2-u53yy.4 repair)"
+    ;; if-some / when-some exercise the generated host-qualified `(not= temp nil)`
+    ;; test; when-let / when-some exercise the `if … nil` (never generated `when`)
+    ;; single-body shape. Two-arm forms stamp both arms; one-arm forms stamp the
+    ;; concrete arm only (the implicit nil else is exempt).
+    (is (= 2 (stamp-count (cljs-emit 'app.cond 'som '(if-some [v x] [:a v] [:b]) 7 3)
+                          "data-rf-view"))
+        "if-some descends to both arms")
+    (is (= 1 (stamp-count (cljs-emit 'app.cond 'wl '(when-let [v x] [:a v]) 7 3)
+                          "data-rf-view"))
+        "when-let stamps the one concrete arm; the nil else is exempt")
+    (is (= 1 (stamp-count (cljs-emit 'app.cond 'ws '(when-some [v x] [:a v]) 7 3)
+                          "data-rf-view"))
+        "when-some stamps the one concrete arm; the nil else is exempt")))
 
 (deftest non-host-roots-carry-no-annotation
   (testing "a fragment root is exempt (no positional host node)"

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -152,10 +152,16 @@ be host-native and need not themselves be serialisable.**
 Reagent-familiar hiccup with the ambiguities removed. Control forms — `let` / `letfn` /
 `if` / `if-not` / `when` / `when-not` / `if-let` / `when-let` / `if-some` / `when-some` /
 `cond` / `case` / statically-pure `do` / `for` — normalize **into the AST**; all
-analyzers and both emitters see through branches. The four conditional binders desugar
-into the analyzer's own `let` + `if`/`when` over a reserved temp (mirroring
-`clojure.core`'s expansions), so they inherit the same scope threading, destructuring,
-and reactive-escape rejection as a hand-written `let` + `if`.
+analyzers and both emitters see through branches. The four conditional binders are
+admitted by **resolver-confirmed core identity** (the host resolver confirms the
+`clojure.core` / `cljs.core` var — a same-spelled user macro is not admitted, a local
+shadow falls through to an ordinary call) and desugar into the analyzer's own `let` +
+`if` over a reserved temp, using only host-safe generated semantics: the conditional is
+the special form `if` (never a generated `when`), and the `some?`-variants' nil test is
+a host-qualified core nil check written with a plain core function (never a shadowable
+core predicate macro) — neither can be captured by a user local. They thus inherit the
+same scope threading, destructuring, and reactive-escape rejection as a hand-written
+`let` + `if`.
 
 | Form | Meaning |
 |---|---|
@@ -191,11 +197,13 @@ expression grammar is therefore **closed**:
 - **Binder-aware structural forms**, handled with position-aware traversal:
   `quote` (never traversed — quoted data is not executable), `fn`/`fn*`, `let`/`let*`,
   `loop`/`loop*`, `letfn`/`letfn*`, `try`, and the conditional binders `if-let` /
-  `when-let` / `if-some` / `when-some`. The four conditional binders desugar into the
-  analyzer's own `let` + `if`/`when` over a reserved temp: the binding init is an
-  ordinary evaluated expression that may own a finite reactive site, the pattern binds
-  into the then/body branch only, and the `some?`-variants test the raw init value
-  (never destructure-then-test). Binding patterns and destructuring `:or`
+  `when-let` / `if-some` / `when-some`. The four conditional binders are admitted by
+  resolver-confirmed core identity and desugar into the analyzer's own `let` + `if`
+  over a reserved temp: the binding init is an ordinary evaluated expression that may
+  own a finite reactive site, the pattern binds into the then/body branch only, and the
+  `some?`-variants test the raw init value with a host-qualified core nil check (never
+  destructure-then-test, and un-shadowable by a user local). Binding patterns and
+  destructuring `:or`
   defaults may contain neither reactive calls nor unaudited macros — those positions
   are consumed by the host compiler, not expression rewriting, so they cannot own a
   lexical render site (hoist the read into the view body and bind its value). This is
@@ -243,7 +251,10 @@ compatibility fallback. The set grows only by ruling, and any addition requires
 lexical-scope plus hidden-reactive-injection counterfixtures (the rf2-vxgfnd.100
 hidden-sub / helper / binder-macro proofs in
 `re-frame.ui.compiler-macro-resolution-jvm-test` are the template — the admitted
-`if-let` family adds its own binder-lowering + out-of-family + pattern-escape rows).
+`if-let` family adds its own binder-lowering + out-of-family + pattern-escape rows,
+plus the resolver-confirmation and generated-code-hygiene counterfixtures: a
+same-spelled user macro is rejected, and a hostile local named `some?` / `when`
+cannot capture the compiler-generated nil test or branch).
 
 **DOM prop spelling is pinned:** hyphenated lowercase words mirroring React's camelCase
 — `:on-click`, `:on-key-down`, `:on-input` (never `:on-keydown`). Handler-map options:


### PR DESCRIPTION
Chronological audit repair (rf2-u53yy.4 reopen, 2026-07-21) of merged PR #6585. The four conditional binders `if-let` / `when-let` / `if-some` / `when-some` were already admitted to the closed view grammar; this PR fixes two bounded correctness defects the audit found, with **no grammar growth**.

## What was broken

1. **Generated code was not hygienic.** The desugar emitted an unqualified `(some? temp)` nil test and a generated `when` branch. A user local named `some?` captured the test — `(let [some? (constantly false)] (if-some [x 1] x :else))` wrongly chose the else arm — and a user local named `when` could capture the generated branch.
2. **Admission was raw-spelling.** A `:refer`d look-alike user macro named `if-let` was silently rewritten as the core binder, while a resolver-confirmed qualified `clojure.core/if-let` was rejected.

## The repair

- **Host-safe generated semantics.** The single-body `when-*` shape now lowers to `(if test body nil)` — the special form `if`, which no user local can shadow — never a generated `when`. The `some?`-variants' nil test is a host-qualified core `(not= temp nil)`: un-shadowable by a user local, and a plain function on both hosts (the `cljs.core` `some?`/`nil?` are **macros** that the expression grammar rejects on re-analysis).
- **Resolver-confirmed admission.** `if-let-family-config` confirms the head against the core binder vars: a local shadow falls through to an ordinary call; a spelling resolving to a non-core var (a look-alike user macro) is rejected as an unaudited macro; a bare/qualified spelling resolving to a core binder is admitted; and a resolution-free emit env still admits the plain core spelling (matching the other control heads).

Reuses the existing `let`/`if` machinery — no new AST node, no emitter change, no macro framework, no runtime fallback, no broader grammar matrix. The admitted set is exactly the same four forms.

## Counterfixtures added

- **Analyzer (CLJ+CLJS, `.cljc`):** a hostile local named `not=` / `when` cannot capture the generated test/branch; a local shadow of the spelling is not admitted; a qualified `clojure.core/if-some` is admitted; a same-spelled user macro rejects (`unsupported-form`).
- **Real CLJS resolution (JVM host):** the some?-variant emits the host-qualified plain-function `cljs.core/not=` and no generated `when`, and survives real-resolution re-analysis.
- **Real CLJS render (node):** `if-some`/`when-some` render correctly, including the audit crux — a `false` value is non-nil so it takes the **some** arm (`some? != truthy`).
- **Real CLJS emit:** `if-some` / `when-let` / `when-some` stamp the correct arms through the real defview emit path.

Spec 004 desugar description corrected (`let` + `if`, resolver-confirmed, host-safe nil check). EP-0031 dated erratum records the mechanism corrections. Skills sweep: nothing teaches this family's internal desugar/admission; the ui-context manifest is in sync.

## Quality gates

All run in the foreground to completion:

- `implementation/ui` `clojure -M:test` — **955 tests, 19141 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — **10364 tests, 51212 assertions, 0 failures, 0 errors**
- `npm run test:elision` — **PASS** (production 60/60 absent; control 60/60 present)
- `python -m mkdocs build --strict` — **PASS**
- `python scripts/check_doc_slugs.py` — **PASS**
- api-manifest `ui-context --check` — **in sync (98 ids, 31 authoring vars)**

Rebased onto current `origin/main`; disjoint from live worker `fyt5i` (http/spec-009). Hot-zone `spec/004-Views.md` touched — sole writer; sequence other 004 children behind merge.