### PR TITLE
fix(ui): reconcile root-attempt evidence across runtime, spec/004C+009, and tooling (rf2-vxgfnd.249)

### DIFF
--- a/implementation/ui/src/re_frame/ui/frames.cljc
+++ b/implementation/ui/src/re_frame/ui/frames.cljc
@@ -421,22 +421,26 @@
 (defn- throw-preflight-lifecycle-loss!
   "Fail preflight CLOSED (rf2-5svfa1): the exact frame authority a plan was
   bound to stopped being the live incarnation mid-preflight, so ENSURE cannot
-  honour it. Raised on two arms of the SAME failure class — the plan's frame
+  honour it. Raised on three arms of the SAME failure class — the plan's frame
   authority was lost — under one id `:rf.error/frame-preflight-lifecycle-loss`:
 
-    :ensured-frame-lost      — publication was rejected AND the frame this
-                               `:install` / `:refresh` / `:adopt` had to leave
-                               live is now ABSENT. The usual cause is a
-                               self-destroying setup: an `:initial-events`
-                               handler destroyed the very frame it was seating.
-                               Previously the executor SILENTLY skipped the
-                               write and returned a normal receipt, so the
-                               client mounted a live host root scoped to an
-                               ABSENT frame (there is no frame-liveness guard
-                               between preflight and `createRoot`). A rejection
-                               The shared per-id reservation excludes a foreign
-                               concurrent destroy; any rejection is therefore
-                               fail-closed, never a silent successful ENSURE.
+    :ensured-frame-lost      — publication was rejected: the exact incarnation
+                               this `:install` / `:refresh` / `:adopt` had to
+                               leave live was destroyed, closed, or replaced
+                               before its plan record could be published. The
+                               usual cause is a self-destroying setup: an
+                               `:initial-events` handler destroyed the very
+                               frame it was seating. Previously the executor
+                               SILENTLY skipped the write and returned a normal
+                               receipt, so the client mounted a live host root
+                               scoped to a gone frame (there is no frame-
+                               liveness guard between preflight and
+                               `createRoot`). The authority-scoped per-id
+                               reservation excludes a foreign concurrent
+                               destroy, so EVERY rejection is fail-closed —
+                               whether the incarnation is now absent, still
+                               present but CLOSING, or replaced by a same-id
+                               successor — never a silent successful ENSURE.
     :refresh-target-replaced — a `:refresh` decided against the incarnation live
                                 at decision time, but that incarnation was
                                 destroyed or replaced by a different same-id

--- a/implementation/ui/test/re_frame/ui/preflight_authority_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/preflight_authority_cljs_test.cljc
@@ -2,8 +2,10 @@
   "rf2-5svfa1 — the bounded, non-design-bearing core split out of parent
   rf2-vxgfnd.191: preflight ENSURE binds its plan decisions to the EXACT frame
   authority and FAILS CLOSED (a typed `:rf.error/frame-preflight-lifecycle-loss`)
-  when that authority is lost mid-preflight. Two arms, host-shared (.cljc: node
-  `test:cljs` / `test:ui` AND JVM `clojure -M:test`), against the REAL executor:
+  when that authority is lost mid-preflight. All THREE lifecycle-loss kinds are
+  pinned — `:ensured-frame-lost`, `:refresh-target-replaced`, and
+  `:found-live-authority-lost` — host-shared (.cljc: node `test:cljs` / `test:ui`
+  AND JVM `clojure -M:test`), against the REAL executor:
 
     (A) FAIL-CLOSED SETUP — a same-owner destroy from `:initial-events` joins
         the transaction and makes its provisional row lifecycle-dead; ordinary
@@ -12,15 +14,23 @@
         preflight lifecycle loss when a sibling plan destroys the boot frame a
         later config-less plan scopes.
 
-    (B) DECISION-TIME TOKEN REVALIDATION — a `:refresh` decided against the
+    (B) DECISION-TIME AUTHORITY REVALIDATION — a `:refresh` decided against the
         incarnation live at decision time must not apply to a same-id replacement
         that overtook it before the surgical `make-frame`. The executor captures
         the decision-time token in phase 1 and revalidates it before mutating in
-        phase 2; a stale target fails closed BEFORE any create-if-absent.
+        phase 2; a stale target fails closed (`:refresh-target-replaced`) BEFORE
+        any create-if-absent. A found-live no-op is pinned the same way: if its
+        decision-time incarnation or install/adopt record is lost before phase 2,
+        the stale receipt cannot settle an absent or replaced lifetime and fails
+        closed (`:found-live-authority-lost`).
 
-  The concurrent-destroy CLOSING race (a still-PRESENT rejected incarnation) is
-  deliberately NOT covered here — its coordination is parent .191 part C; the
-  pre-existing `frame-plan-publication-race` skip-not-throw contract stands.
+  Every publication rejection is fail-closed under this id — whether the exact
+  incarnation is now absent, still present but CLOSING, or replaced by a same-id
+  successor; the two publish sites throw on ANY rejection, with no absence check.
+  The concurrent-destroy CLOSING race is caught earlier still: the shared per-id
+  reservation rejects an overlapping run promptly with
+  `:rf.error/frame-preflight-overlap` (companion `frame-plan-publication-race`
+  JVM coverage), so it never reaches publication.
 
   Each fail-loud assertion checks the `:rf.error/id` discriminator + `:kind`,
   never message bytes (Spec 009 §The thrown-error shape rule 3)."

--- a/spec/004C-Roots-and-Mount.md
+++ b/spec/004C-Roots-and-Mount.md
@@ -462,7 +462,7 @@ prefix-uniqueness backstop share the roster:
 | `:rf.error/root-not-live` | `render!` on a `Root` whose id is no longer live — `unmount!`ed, tearing-down, or superseded by a newer root claiming the same id (guarded like `unmount!`, but fails loud rather than no-op, before any side effect) |
 | `:rf.error/root-manifest-invalid` | manifest missing/unreadable at hydrate, schema-version incompatible, identity opts passed client-side, unserialisable props at emit, prefix conflict |
 | `:rf.error/frame-payload-conflict` | below |
-| `:rf.error/root-hydration-mismatch` | fingerprint/digest disagreement (an existing Spec 009 catalogue row — unchanged by this Spec) |
+| `:rf.ssr/hydration-mismatch` | server↔client render-tree fingerprint/digest disagreement at hydration (an existing Spec 009 catalogue row — unchanged by this Spec) |
 
 **Payload/frame-config conflict — fail-loud at preflight.** At any root's preflight
 (hydration or client mount), before install/hydrate:


### PR DESCRIPTION
Reopened-bead follow-up to PR #6400. #6400 reconciled the normative surfaces (spec/004C §7.1, the spec/009 three-kind lifecycle-loss roster + payload-conflict projection, and the `check_ui_root_lifecycle_drift.py` gate) but explicitly left `implementation/ui/src/**` fenced. The runtime docstrings and one spec/004C cross-reference therefore still told a different lifecycle story than the already-reconciled spec/009 catalogue and the shipped runtime. This finishes the bounded remainder — one truth across runtime, spec/004C, spec/009, and tooling.

## What drifted, before -> after

**1. `frames.cljc` `throw-preflight-lifecycle-loss!` docstring (the fenced contradiction)**
- "Raised on **two arms**" -> "**three arms**" (the docstring already enumerated three kinds; the `case` already had three branches).
- `:ensured-frame-lost` said "publication was rejected AND the frame ... **is now ABSENT**" -> "publication was rejected: the exact incarnation ... was **destroyed, closed, or replaced**". Both publish sites (frames.cljc adopt + install/refresh) throw on ANY rejection with no absence check, matching spec/009:2387's "EVERY publication rejection is fail-closed ... whether ... absent, still present but CLOSING, or replaced by a same-id successor".
- Repaired the malformed splice "A rejection The shared per-id reservation ..." into a coherent sentence.

**2. `preflight_authority_cljs_test.cljc` header (stale test prose)**
- "Two arms" -> all three lifecycle-loss kinds; section (B) now names the `:found-live-authority-lost` arm it already tests (deftest at line 140).
- Removed the obsolete deferral "the concurrent-destroy CLOSING race ... deliberately NOT covered here ... the pre-existing `frame-plan-publication-race` skip-not-throw contract stands" — refuted by the reconciled runtime and by that companion test's own current contract (it now rejects with `:rf.error/frame-preflight-overlap`). Replaced with the reconciled truth.

**3. `spec/004C` §7 diagnostic roster (dangling reference, rf2-vxgfnd.97.2 finding)**
- `:rf.error/root-hydration-mismatch` (absent from spec/009, tooling, and the implementation) -> `:rf.ssr/hydration-mismatch`, the real existing spec/009 catalogue row (009:1975) owned by Spec 011. The "an existing Spec 009 catalogue row — unchanged by this Spec" framing is now accurate.

## Scope discipline
Truth reconciliation of existing evidence only. No new evidence flags, record shape, tooling, gate teeth, public API, or lifecycle machinery. `installed-plan-entry` (strips internal `:rev`, exposes `:committed` / `:mount-incomplete` / `:preflight-attempt-failed`) is unchanged. All edits are docstring/test-prose/spec-reference.

## Quality gates
- `scripts/check_ui_root_lifecycle_drift.py`: clean (32 anchors) — every tooth preserved
- `python scripts/check_doc_slugs.py`: exit 0
- `python -m mkdocs build --strict`: exit 0
- `implementation/ui` `clojure -M:test`: 953 tests / 19118 assertions, 0 failures, 0 errors
- `implementation/core` `clojure -M:test` (catalogue-conformance): 2104 tests / 10413 assertions, 0 failures, 0 errors
- `npm run test:cljs`: 10360 tests / 51195 assertions, 0 failures, 0 errors

Refs rf2-vxgfnd.249. Advances the vxgfnd spine epic.
