### PR TITLE
fix(ui): finish foreign ui/spread own-property merge semantics (rf2-xu095)

### DIFF
--- a/docs/EP/EP-0031-re-frame-ui-programming-model.md
+++ b/docs/EP/EP-0031-re-frame-ui-programming-model.md
@@ -204,6 +204,21 @@ dispatch `(conj prefix payload…)`.
 | `ui/->react` | the outward migration bridge (export a view as a React component) — memoised per view identity; scopes a supplied frame without owning it; no root/manifest/preflight; one shallow props rule (children + ref preserved) | shipped (S6 delta #2; rf2-u53yy.2 — ahead of the migration wave) |
 | `ui/element` / `ui/view` / `ui/portal` / `re-frame.ui.data` | wave-2, demand-gated — no v1 existence. General `ui/element` is rejected outright; `ui/view` stays gated on an open-set-identity trigger; `ui/portal` is covered in part by the inline + top-layer overlay plan (EP-0035 records the rulings) | — |
 
+> **Erratum — 2026-07-21 (rf2-xu095 foreign-spread completion).** The `ui/spread`
+> row above, and the "one rule table (004B) serves static props, `ui/spread`, and
+> both emitters" claim in §2, describe `ui/spread` at a **DOM / custom-element**
+> props position — the generic runtime map converted through the 004B rule table,
+> later-arg-wins. They do **not** govern `ui/spread` at a **FOREIGN component** call
+> site, which is a distinct, unconverted merge: the forwarded runtime map passes
+> through **verbatim** (no rule table, no kebab→camel, no handler classification —
+> the foreign head owns its own prop ABI) and is layered **under** the compiled
+> literal props, which win every collision **by presence** — even an explicit null
+> literal wins (`false`/`0` retained), and `__proto__` stays a verbatim own prop
+> rather than mutating the output object's prototype. There is no deny law (a
+> foreign boundary defends no owned/structural key). Normative home:
+> [spec/004-Views.md §`ui/spread` at a foreign component call site](../../spec/004-Views.md);
+> the completed merge helper is `re-frame.ui.runtime/foreign-spread-props`.
+
 The foreign-React hook tier (`re-frame.ui.react`, seven wrappers) belongs to
 this surface; its contract detail is Spec 004 §The React interop tier.
 

--- a/implementation/ui/src/re_frame/ui/runtime.cljs
+++ b/implementation/ui/src/re_frame/ui/runtime.cljs
@@ -539,31 +539,51 @@
 ;; ui/spread at a FOREIGN component call site (rf2-u53yy.5)
 ;; ---------------------------------------------------------------------------
 
+(defn- set-own!
+  "Set `k`→`v` as an OWN enumerable data property on the plain object `o`. Routes
+  the one magic key `\"__proto__\"` through `defineProperty`: a bare
+  `o[\"__proto__\"] = v` on an Object.prototype-backed object invokes the prototype
+  SETTER (mutating the chain) instead of defining an own property. The
+  `defineProperty` data descriptor writes the verbatim own prop and leaves the
+  output's prototype untouched — the runtime counterpart of the compiler's
+  literal-JSX invariant (`ordered-literal-object`'s computed-key trick). Ordinary
+  keys take the direct `unchecked-set` path."
+  [o k v]
+  (if (= "__proto__" k)
+    (js/Object.defineProperty o k #js {:value v :writable true :enumerable true :configurable true})
+    (unchecked-set o k v)))
+
 (defn foreign-spread-props
   "Merge a FOREIGN component spread's forwarded runtime map (`fwd`) UNDER its
-  LITERAL compiled props object (`literal-obj`). The literal props — the
-  component's own compiled handlers and props — WIN every key collision; the
-  forwarded map fills in the rest. A foreign boundary is OPEN: its props pass
-  through UNCONVERTED (no DOM rule table, no kebab→camel, no handler
-  classification — the foreign head owns its own prop ABI), so each forwarded
-  key is the author keyword's verbatim name (`namespace/name`, matching the
-  compiler's `prop-slot-name`) and its value is set as-is.
+  LITERAL compiled props object (`literal-obj`), returning a fresh plain JS
+  object. The literal props — the component's own compiled handlers and props —
+  WIN every key collision BY PRESENCE; the forwarded map fills in the rest. A
+  foreign boundary is OPEN: its props pass through UNCONVERTED (no DOM rule
+  table, no kebab→camel, no handler classification — the foreign head owns its
+  own prop ABI), so each forwarded key is the author keyword's verbatim name
+  (`namespace/name`, matching the compiler's `prop-slot-name`) and its value is
+  set as-is.
 
-  Mirrors `spread-safe-props`' owned-wins layering, minus the deny law — a
-  foreign boundary defends no owned/structural key (there is no per-slot memo
-  comparator or slot ABI to protect). NIL-MEANS-ABSENT: a compiled literal prop
-  whose dynamic value normalizes to nil sits in `literal-obj` as an explicit
-  null; layer key-by-key skipping nil so a nil literal stays ABSENT and the
-  forwarded value survives. Returns the merged JS object."
+  LITERAL-WINS-BY-PRESENCE (rf2-xu095): a foreign literal defends its slots by
+  KEY PRESENCE, not by value — unlike `spread-safe-props`' DOM-parity
+  NIL-MEANS-ABSENT rule. A compiled literal prop present with an explicit null
+  still WINS the collision (the forwarded value does NOT survive), and `false`/
+  `0` are retained; layer EVERY own key of `literal-obj` over the forwarded
+  value. There is no per-slot deny law — a foreign boundary defends no
+  owned/structural key (no memo comparator or slot ABI to protect).
+
+  `__proto__` (rf2-xu095): the one magic key with prototype-setter grammar on a
+  normal object. Every own set routes through `set-own!` so a forwarded (or
+  literal) `__proto__` lands as a VERBATIM own data property and the output
+  keeps its ordinary Object.prototype — never a prototype mutation, matching the
+  literal-JSX invariant. Returns the merged JS object."
   [fwd literal-obj]
   (let [o (js-obj)]
     (when (some? fwd)
       (doseq [[k v] fwd]
-        (unchecked-set o (if-some [ns* (namespace k)] (str ns* "/" (name k)) (name k)) v)))
+        (set-own! o (if-some [ns* (namespace k)] (str ns* "/" (name k)) (name k)) v)))
     (doseq [k (js/Object.keys literal-obj)]
-      (let [v (unchecked-get literal-obj k)]
-        (when (some? v)
-          (unchecked-set o k v))))
+      (set-own! o k (unchecked-get literal-obj k)))
     o))
 
 (defn jsx-spread2

--- a/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
+++ b/implementation/ui/test/re_frame/ui/react_render_cljs_test.cljs
@@ -550,6 +550,46 @@
                       (.-prototype js/Object))
           (str (name surface) " keeps Object.prototype unchanged")))))
 
+(deftest foreign-spread-props-literal-wins-by-presence-and-proto-ownership
+  ;; rf2-xu095 — the FOREIGN `ui/spread` merge helper, executed directly. A
+  ;; foreign boundary is OPEN: forwarded keys pass through VERBATIM as own props;
+  ;; the compiled literal object WINS every collision BY PRESENCE (even an
+  ;; explicit null literal), retaining false/0; and the magic `__proto__` key
+  ;; stays a verbatim OWN prop, never a prototype mutation.
+  (testing "verbatim forwarded names; ordinary + nil collision precedence; false/0 retained"
+    (let [fwd     {:label "hi" :data/x "keep" :id "fwd" :title "fwd-title"}
+          literal (js-obj)]
+      ;; literal owns: id (ordinary win), title=null (nil win), disabled=false, count=0
+      (unchecked-set literal "id" "lit")
+      (unchecked-set literal "title" nil)      ; explicit own null, as a nil dynamic literal materializes
+      (unchecked-set literal "disabled" false)
+      (unchecked-set literal "count" 0)
+      (let [o (rt/foreign-spread-props fwd literal)]
+        (is (= "hi" (unchecked-get o "label")) "plain forwarded name is verbatim")
+        (is (= "keep" (unchecked-get o "data/x")) "namespaced forwarded name is verbatim ns/name")
+        (is (= "lit" (unchecked-get o "id")) "ordinary collision: literal wins")
+        (is (has-own? o "title") "nil-literal collision still materializes the key by presence")
+        (is (nil? (unchecked-get o "title")) "nil literal WINS the collision — forwarded value does not survive")
+        (is (false? (unchecked-get o "disabled")) "false literal retained")
+        (is (= 0 (unchecked-get o "count")) "0 literal retained"))))
+  (testing "forwarded __proto__ is an OWN prop; output prototype unchanged"
+    (let [sentinel (js-obj "tag" "fwd-proto")
+          o        (rt/foreign-spread-props {:__proto__ sentinel} (js-obj))]
+      (is (has-own? o "__proto__") "forwarded __proto__ is an own data property")
+      (is (identical? sentinel (unchecked-get o "__proto__")) "verbatim forwarded value")
+      (is (identical? (js/Object.getPrototypeOf o) (.-prototype js/Object))
+          "output keeps Object.prototype — no prototype mutation")))
+  (testing "literal __proto__ wins the collision and stays an own prop"
+    (let [lit-proto (js-obj "tag" "lit-proto")
+          literal   (js-obj)]
+      (js/Object.defineProperty
+       literal "__proto__" #js {:value lit-proto :writable true :enumerable true :configurable true})
+      (let [o (rt/foreign-spread-props {:__proto__ (js-obj "tag" "fwd-proto")} literal)]
+        (is (has-own? o "__proto__") "own data property, not a prototype mutation")
+        (is (identical? lit-proto (unchecked-get o "__proto__")) "literal __proto__ wins the collision")
+        (is (identical? (js/Object.getPrototypeOf o) (.-prototype js/Object))
+            "output keeps Object.prototype unchanged")))))
+
 ;; ---------------------------------------------------------------------------
 ;; Handlers — committed callback identity + compile-time placeholder provenance
 ;; ---------------------------------------------------------------------------

--- a/skills/reagent-migration/references/catalog-judgment.md
+++ b/skills/reagent-migration/references/catalog-judgment.md
@@ -200,7 +200,7 @@ Keep the caveat: views using refs/effects need `ui/client-only` (or restructure)
 
 ## MIG-28 — computed / dynamic DOM props → `ui/spread-safe` or `ui/spread`
 
-**The decision: which spread?** re-frame.ui ships an *ergonomic fork* (both DOM elements only) — reach for the safe form first, and drop to the generic one only when the props are genuinely opaque.
+**The decision: which spread?** For a DOM / custom-element props map re-frame.ui ships an *ergonomic fork* — reach for the safe form first, and drop to the generic one only when the props are genuinely opaque. (`ui/spread-safe` is DOM/custom-element only; the generic `ui/spread` *also* serves a foreign component call site — the wrapper idiom documented at the end of this section.)
 
 - **Literal owned props + a caller-forwarded attr map → `ui/spread-safe`** (the component-library shape, and the ergonomic default). `(ui/spread-safe owned caller)` takes a **literal** `owned` map — the compiler analyses it exactly like an element's props map, so a literal `:value`/`:checked` co-present with its handler **retains the controlled-input synchrony door** — and merges the runtime `caller` attrs over it. A compiler-visible **deny law** (enforced in *every* build) keeps `caller` from clobbering the structural/controlled/owned keys `:key` `:ref` `:value` `:checked` and the component's own `:on-*` handlers; owned props win a collision and `:class` composes. This is the shape a reusable input/control uses to forward a consumer's `data-*`/`aria-*`/`:class` without losing its own guarantees:
 


### PR DESCRIPTION
Finishes the foreign-component `ui/spread` merge contract shipped by #6597. `re-frame.ui.runtime/foreign-spread-props` did not fully implement the open-props/literal-wins contract, and no test executed the helper.

## The gap (before)
- **nil literal skipped.** The literal-copy loop guarded on `(some? v)`, so a forwarded value survived when the compiled literal supplied an explicit null — even though a foreign literal is specified to win **every** collision. The compiler still materializes a nil dynamic literal as an own `null`, so the forwarded value should have lost.
- **`__proto__` prototype mutation.** A forwarded (or literal) `__proto__` key was written with `unchecked-set` onto a plain `{}`, invoking JavaScript's prototype **setter** instead of defining an own property — unlike the existing literal-JSX invariant (`ordered-literal-object`'s computed-key trick).

## The fix (after) — minimal, no framework
- Layer **every** own key of `literal-obj` over the forwarded value: a foreign literal wins **by presence**, even for `nil`/`null`; `false`/`0` retained.
- Route every own set through a small private `set-own!` that uses `Object.defineProperty` for the one magic key `"__proto__"`, so it lands as a verbatim own data property and the output keeps its ordinary `Object.prototype` — no prototype mutation.
- No new public API, validator, sanitizer, or merge vocabulary. String equality on `"__proto__"` (never `identical?` on a keyword).

## Test (red → green)
A focused CLJS test executes `foreign-spread-props` directly and pins verbatim forwarded names (`namespace/name`), ordinary + nil collision precedence, `false`/`0` retention, and `__proto__` ownership across both forwarded and literal sources. Reproduced red (5 failures on the pre-fix helper), green after.

## Contract projection
- **EP-0031**: dated erratum distinguishing `ui/spread` at a DOM/custom-element position (the 004B rule-table conversion) from the unconverted foreign-component merge (verbatim passthrough, literal-wins-by-presence, `__proto__` own-prop).
- **reagent-migration skill** (`catalog-judgment.md` MIG-28): removed the "both DOM elements only" claim that contradicted the foreign-spread paragraph immediately below it.
- `spec/004-Views.md` already mandates "the literal props win any key collision" and already distinguishes DOM from foreign, so **no spec change is required** (disjoint from u53yy.9, which owns spec/004-Views).

## Quality gates
- `npm run test:cljs` (full node CLJS suite): **10366 tests / 51226 assertions — 0 failures, 0 errors**.
- `cd implementation/ui && clojure -M:test` (UI JVM): **955 tests / 19141 assertions — 0 failures, 0 errors**.
- Focused UI CLJS build (`node-test-ui`) red→green: **5 failures (all the new test) → 0 failures / 930 tests**.
- Migration skill drift gates (`check_skill_migration_contract_drift.py`, `check_skill_migration_cites.py`, `check_skill_migration_o1617_router_drift.py`): all exit 0.
- Portability/hardcoded-paths guard: OK.
- `mkdocs --strict` not run (mkdocs not installed locally; CI owns it). EP link `../../spec/004-Views.md` resolves correctly. `test:browser`/`test:elision` not applicable — the proof executes the helper directly (no real-DOM mount) and there is no debug/elision path.