### PR TITLE
docs(spec): sync spec/API retry-marker wording to shipped terminal-stop (rf2-4xobm)

### DIFF
--- a/spec/API.md
+++ b/spec/API.md
@@ -634,7 +634,7 @@ The eight `:kind` values inside a failure reply, all reserved under `:rf.http/*`
 
 | `:operation` | `:op-type` | When |
 |---|---|---|
-| `:rf.http/retry-attempt` | `:info` | Per intermediate attempt that matched `:retry :on` (and the terminal exhaustion row); carries `:request-id`, `:url`, `:attempt`, `:max-attempts`, `:failure`, `:next-backoff-ms` (`nil` on the terminal row) |
+| `:rf.http/retry-attempt` | `:info` | Per intermediate attempt that matched `:retry :on`, plus a terminal retry-sequence stop marker once the sequence ends (budget spent, or a later attempt failed outside `:retry :on`); carries `:request-id`, `:url`, `:attempt`, `:max-attempts`, `:failure`, `:next-backoff-ms` (`nil` on the terminal stop marker) |
 | `:rf.http.interceptor/registered` | `:info` | A `reg-http-interceptor` succeeded; carries `:frame`, `:id` (per [014 §Middleware](014-HTTPRequests.md#middleware)) |
 | `:rf.http.interceptor/cleared` | `:info` | A `clear-http-interceptor` removed an existing slot; carries `:frame`, `:id` |
 | `:rf.error/http-interceptor-failed` | `:error` | An interceptor `:before` **or** `:after` threw; carries `:frame`, `:interceptor-id`, `:url`, `:cause` (plus `:phase :after` on the response side). Request side: the request is NOT dispatched; response side: the reply is suppressed (per [014 §Middleware §Failure mode](014-HTTPRequests.md#failure-mode)) |


### PR DESCRIPTION
Syncs the one stale wording row in `spec/API.md` for the managed-HTTP `:rf.http/retry-attempt` trace event.

`spec/API.md:637` still described the terminal arm as *"the terminal exhaustion row"*. fyt5i (#6631, MERGED) corrected this everywhere else — runtime + `spec/009-Instrumentation.md` + `spec/014-HTTPRequests.md` — to a **terminal retry-sequence stop marker** that fires in two honest cases: the retry budget was spent, OR a later attempt (2+) failed with a category outside `:retry :on` (so it stopped before the budget was spent). It is *not* always "exhaustion". `spec/API.md` was hot-zone outside fyt5i's fence; this closes the last drift.

**Before:**
> Per intermediate attempt that matched `:retry :on` (and the terminal exhaustion row); … `:next-backoff-ms` (`nil` on the terminal row)

**After:**
> Per intermediate attempt that matched `:retry :on`, plus a terminal retry-sequence stop marker once the sequence ends (budget spent, or a later attempt failed outside `:retry :on`); … `:next-backoff-ms` (`nil` on the terminal stop marker)

Trivial 1-row prose sync, sole `spec/API.md` toucher. No other row touched.

## Quality gates
- `python -m mkdocs build --strict` — exit 0
- `python scripts/check_doc_slugs.py` — exit 0
- `clojure -M -m re-frame.api-manifest.gen --check` — exit 0 (`spec/api-manifest.edn` in sync, 514 public vars; prose-only, no regen)

Closes rf2-4xobm.