### PR TITLE
fix(ci): repair the nightly expensive-tests failures (rf2-wh5to)

### DIFF
--- a/implementation/ssr/deps.edn
+++ b/implementation/ssr/deps.edn
@@ -97,6 +97,16 @@
                  day8/re-frame2-flows      {:local/root "../flows"}
                  day8/re-frame2-routing    {:local/root "../routing"}
                  day8/re-frame2-machines   {:local/root "../machines"}
+                 ;; TEST-ONLY (rf2-2mq2f): the Root Manifest v1
+                 ;; subset-property suite (`emit_ui_tree_cljs_test`)
+                 ;; `:require`s `re-frame.ui.rules`. cognitect
+                 ;; test-runner LOADS every test namespace at discovery
+                 ;; time before filtering by var metadata, so ui must be
+                 ;; on the classpath here too — matching the `:test`
+                 ;; alias above. Without it the nightly `:slow-test` run
+                 ;; dies at load with a FileNotFoundException for
+                 ;; `re_frame/ui/rules`.
+                 day8/re-frame2-ui         {:local/root "../ui"}
                  day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -95,9 +95,19 @@
   "Pure data → data: map a `[:tests :runs]` status keyword to the
   styles map key that renders its dot colour. The render-only mapping
   lives next to the canonical statuses so both surfaces (sidebar dot,
-  chrome widget) can JVM-test the projection without booting Reagent."
+  chrome widget) can JVM-test the projection without booting Reagent.
+
+  Covers the run-outcome statuses a testable variant's dot can carry
+  (`theme.status` vocab). `:error` shares `:fail`'s danger tint — both
+  demand attention and resolve to the same `:danger` colour. Any status
+  without a bespoke dot style (`:cannot-run`/`:blocked`/`:dirty`/
+  `:redacted` — chip-axis values that don't normally reach the dot)
+  returns `nil`; the `status-dot` call site falls back to the neutral
+  `:pending` ring for those rather than dereferencing `nil` as a fn
+  (which crashed the whole sidebar render on any `:error`-status run)."
   {:pass    :dot-pass
    :fail    :dot-fail
+   :error   :dot-fail
    :running :dot-running
    :pending :dot-pending})
 
@@ -109,6 +119,7 @@
   (case status
     :pass    "tests passing"
     :fail    "tests failing"
+    :error   "tests errored"
     :running "tests running"
     :pending "tests not yet run"
     "tests not yet run"))
@@ -272,7 +283,7 @@
   [status]
   (let [k     (status->dot-style-key status)
         label (dot-aria-label status)]
-    [:span {:style       (merge (:dot styles) (k styles))
+    [:span {:style       (merge (:dot styles) (get styles k (:dot-pending styles)))
             :data-test   "story-sidebar-dot"
             :data-status (name (or status :pending))
             :role        "img"

--- a/tools/story/src/re_frame/story/ui/state/transitions.cljc
+++ b/tools/story/src/re_frame/story/ui/state/transitions.cljc
@@ -153,18 +153,35 @@
   value into the collection kind the NEXT path segment actually needs
   (`vivify-for-key`) instead of letting plain `assoc-in` mint an
   int-keyed MAP for a missing vector/set, or throwing when it tries to
-  `assoc` a set by index (rf2-mzfh9c). When `coll` (or any intermediate
-  value walked along `path`) was a `set`, the walked result at that
-  level is coerced BACK into a set before returning — the vector
-  projection `vivify-for-key` uses is an addressing convenience, not a
-  change of the arg's declared collection kind."
-  [coll path value]
+  `assoc` a set by index (rf2-mzfh9c). When the level being written was a
+  `set`, the walked result is coerced BACK into a set before returning —
+  the vector projection `vivify-for-key` uses is an addressing
+  convenience, not a change of the arg's declared collection kind.
+
+  `override` is the current override collection at this level (`nil` when
+  none exists yet). `base` is the arg's resolved value navigated in
+  PARALLEL along `path`, consulted ONLY to seed a not-yet-overridden
+  `:vector`/`:set` level. That distinction is load-bearing (rf2-57ikh):
+  args resolution DEEP-MERGES maps but REPLACES vectors/sets wholesale
+  (002-Runtime.md). So a `:vector`/`:set` level MUST carry its sibling
+  entries — seed it from `base` or the edit truncates to a singleton
+  (rf2-mzfh9c) — while a `:map` level stays MINIMAL, vivified from `{}`
+  and carrying only the edited branch: deep-merge restores its unrelated
+  sibling KEYS from base at read time, so writing them into the override
+  would be redundant, would make a `:title` edit spuriously mark its
+  `:enabled?` sibling overridden, and would shadow later base changes."
+  [override base path value]
   (if (empty? path)
     value
     (let [[k & more] path
-          was-set?   (set? coll)
-          coll'      (vivify-for-key coll k)
-          updated    (assoc coll' k (assoc-in-kind-aware (get coll' k) more value))]
+          ;; Seed a not-yet-overridden vector/set from base (its siblings
+          ;; can't be restored by resolution). A map level — or any level
+          ;; that already has an override — starts from itself.
+          src        (if (and (int? k) (nil? override)) base override)
+          was-set?   (set? src)
+          coll'      (vivify-for-key src k)
+          child      (assoc-in-kind-aware (get coll' k) (get base k) more value)
+          updated    (assoc coll' k child)]
       (if was-set? (set updated) updated))))
 
 (defn set-cell-override
@@ -174,17 +191,19 @@
   nested Malli walker.
 
   A non-empty `sub-path` walks `assoc-in-kind-aware` against the
-  ARG-KEY's current override (or `base` when no override exists yet)
-  rather than raw `assoc-in` against `state` — the collection at
-  `[:cell-overrides variant-id arg-key]` may be absent (no override
-  established yet) or, for a `:set`-kind repeater, a real `set`; plain
-  `assoc-in` would either mint an int-keyed MAP for the absent case or
-  throw trying to `assoc` a set by index (rf2-mzfh9c). `base` — typically
-  the arg's current resolved value (the SAME 'saved' value the controls
-  panel already computes for its diff-from-saved affordance,
-  active-modes applied, cell-overrides excluded) — seeds the walk so an
-  edit to ONE entry of a not-yet-overridden `:vector`/`:set` preserves
-  every sibling entry instead of silently truncating to a singleton.
+  ARG-KEY's current override rather than raw `assoc-in` against `state`
+  — the collection at `[:cell-overrides variant-id arg-key]` may be
+  absent (no override established yet) or, for a `:set`-kind repeater, a
+  real `set`; plain `assoc-in` would either mint an int-keyed MAP for the
+  absent case or throw trying to `assoc` a set by index (rf2-mzfh9c).
+  `base` — typically the arg's current resolved value (the SAME 'saved'
+  value the controls panel already computes for its diff-from-saved
+  affordance, active-modes applied, cell-overrides excluded) — is
+  navigated in parallel and seeds ONLY not-yet-overridden `:vector`/`:set`
+  levels, so an edit to ONE entry preserves every sibling entry instead
+  of truncating to a singleton. `:map` levels stay minimal: deep-merge
+  resolution restores their unrelated sibling keys from base, so a nested
+  `:title` edit leaves its `:enabled?` sibling unwritten (rf2-57ikh).
 
   An empty path is a no-op (caller error; the state is returned
   unchanged). For top-level scalar overrides use `set-cell-override-
@@ -198,7 +217,8 @@
          (assoc-in state [:cell-overrides variant-id top-key] value)
          (assoc-in state [:cell-overrides variant-id top-key]
                    (assoc-in-kind-aware
-                     (get-in state [:cell-overrides variant-id top-key] base)
+                     (get-in state [:cell-overrides variant-id top-key])
+                     base
                      sub-path value))))
      state)))
 

--- a/tools/story/test/re_frame/story/ui/controls_nested_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/controls_nested_cljs_test.cljc
@@ -314,16 +314,22 @@
 (deftest set-cell-override-deeply-nested-vivifies-map-levels-with-set-base
   (testing "a deep path mixes map-vivification (keyword segments) and
             set-vivification (the integer segment) correctly at each
-            level, preserving sibling keys at every level"
+            level: the nested SET is seeded from base so its sibling
+            entries survive (replace-semantics), while the enclosing MAP
+            stays MINIMAL — its unrelated :other key is NOT written into
+            the override (rf2-57ikh), because deep-merge resolution
+            restores unrelated map keys from base at read time"
     (let [s  state/default-shell-state
           ;; :group has an unrelated sibling key + a nested :tags SET,
           ;; none of it overridden yet.
           s1 (state/set-cell-override s :story.a/x [:group :tags 0] "x"
                                       {:tags #{"a" "b"} :other 1})]
-      (is (= {:tags #{"x" "b"} :other 1}
+      (is (= {:tags #{"x" "b"}}
              (get-in s1 [:cell-overrides :story.a/x :group]))
-          "the nested set becomes {x b}; the group's :other sibling
-           survives untouched"))))
+          "the nested set becomes {x b} (its sibling entry \"b\" preserved
+           from base); the group's :other map sibling is NOT stored — a
+           deep-merge read against base restores it, so pinning it in the
+           override would be redundant and would shadow later base changes"))))
 
 ;; ---- rf2-mzfh9c: the edit -> resolve-args ROUND TRIP ---------------------
 ;;
@@ -393,6 +399,31 @@
         (is (= #{"y" "x"} (:tags overrides2))
             "sort-by str on #{x b} is [b x] — index 0 is \"b\"; replacing
              it with \"y\" leaves {y x}")))))
+
+(deftest set-cell-override-edit-nested-map-key-then-resolve-args-round-trip
+  (testing "rf2-57ikh: editing ONE key of a registered variant's nested
+            :map arg writes ONLY that key into the override (its map
+            siblings stay unwritten), yet `resolve-args`' deep-merge
+            restores the untouched siblings from base — the edit->read
+            round trip the isolated set-cell-override test can't prove"
+    (story/reg-variant :story.nest.roundtrip/map-arg
+      {:args   {:settings {:title "Nested title" :enabled? true}}
+       :events []})
+    (let [base      (get (args/resolve-args :story.nest.roundtrip/map-arg) :settings)
+          shell     (state/set-cell-override state/default-shell-state
+                                             :story.nest.roundtrip/map-arg
+                                             [:settings :title] "Edited" base)
+          overrides (get-in shell [:cell-overrides :story.nest.roundtrip/map-arg])
+          eff       (args/resolve-args :story.nest.roundtrip/map-arg
+                                       {:cell-overrides overrides})]
+      (is (= {:title "Nested title" :enabled? true} base)
+          "precondition: the registered base map")
+      (is (= {:title "Edited"} (:settings overrides))
+          "only the edited :title key is written; the :enabled? sibling
+           stays OUT of the override (rf2-57ikh)")
+      (is (= {:title "Edited" :enabled? true} (:settings eff))
+          "resolve-args' deep-merge restores the untouched :enabled?
+           sibling from base while reflecting the :title edit"))))
 
 (deftest set-cell-override-singleton-path-equivalent-to-scalar-wrapper
   (testing "a 1-element path produces the same result as the scalar wrapper"

--- a/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
@@ -22,7 +22,8 @@
             [re-frame.story :as story]
             [re-frame.story.registrar :as story-registrar]
             [re-frame.story.ui.state :as state]
-            #?@(:cljs [[re-frame.story.ui.sidebar :as sidebar]])))
+            #?@(:cljs [[re-frame.story.ui.sidebar :as sidebar]
+                       [re-frame.story.ui.sidebar-styles :refer [styles]]])))
 
 ;; ---- fixtures ------------------------------------------------------------
 
@@ -159,13 +160,21 @@
        (is (= :dot-pass    (sidebar/status->dot-style-key :pass)))
        (is (= :dot-fail    (sidebar/status->dot-style-key :fail)))
        (is (= :dot-running (sidebar/status->dot-style-key :running)))
-       (is (= :dot-pending (sidebar/status->dot-style-key :pending))))))
+       (is (= :dot-pending (sidebar/status->dot-style-key :pending)))
+       ;; `:error` (a run outcome the chrome widget CAN produce, e.g. a
+       ;; handler that throws) shares the danger tint with `:fail`.
+       (is (= :dot-fail    (sidebar/status->dot-style-key :error)))
+       ;; Chip-axis statuses that don't carry a bespoke dot style return
+       ;; nil — `status-dot` degrades them to the neutral pending ring
+       ;; rather than dereferencing nil as a fn (the sidebar-render crash).
+       (is (nil? (sidebar/status->dot-style-key :cannot-run))))))
 
 #?(:cljs
    (deftest status-dot-aria-labels
      (testing "every status produces a distinct accessible label"
        (is (= "tests passing"     (sidebar/dot-aria-label :pass)))
        (is (= "tests failing"     (sidebar/dot-aria-label :fail)))
+       (is (= "tests errored"     (sidebar/dot-aria-label :error)))
        (is (= "tests running"     (sidebar/dot-aria-label :running)))
        (is (= "tests not yet run" (sidebar/dot-aria-label :pending)))
        ;; Unrecognised → safe fallback.
@@ -256,7 +265,17 @@
          (is (= "pass"    (get (second dot-pass) :data-status)))
          (is (= "running" (get (second dot-running) :data-status)))
          ;; aria-label round-trips for screen-reader users.
-         (is (= "tests failing" (get (second dot-fail) :aria-label)))))))
+         (is (= "tests failing" (get (second dot-fail) :aria-label)))
+         ;; A status with no bespoke dot style (a chip-axis value that
+         ;; reaches the dot) must render — never crash — falling back to
+         ;; the neutral pending ring (regression guard for the sidebar
+         ;; null-deref that reddened the nightly for 13 nights).
+         (let [dot-unmapped (sidebar/status-dot :cannot-run)]
+           (is (= "cannot-run" (get (second dot-unmapped) :data-status)))
+           (is (= (:dot-pending styles)
+                  (select-keys (get (second dot-unmapped) :style)
+                               (keys (:dot-pending styles))))
+               "unmapped status degrades to the pending ring, not a crash"))))))
 
 ;; ---- rf2-k3y92 — status-dot is decorative img (not a live region) -------
 


### PR DESCRIPTION
Repairs the scheduled nightly `expensive-tests.yml`, red 13 consecutive nights (2026-07-08..20). Diagnosed via the last-green (`adf45559b3`) → first-red (`2475b812b0`) bisect + per-job `--log-failed`. Fixes the two DETERMINISTIC root causes; the intermittent routing flake is split to a sibling bead.

## Root causes + fixes

**1. Browser job (`Run rigorous implementation browser and bundle gates`) — persistent, every night.** `npm run test:story-feature-load` runs two specs, both failed:

- **`story_feature_load.cjs`** — `re-frame.story.ui.sidebar/status-dot` did `(k styles)` where `k = (status->dot-style-key status)`. The map only covered `:pass/:fail/:running/:pending`, so an `:error`-status run (the `counter-with-stories` `failing-event-throws` variant) yielded `k = nil` → `(nil styles)` → `TypeError: Cannot read properties of null (reading 'cljs$core$IFn$_invoke$arity$1')`, crashing the whole sidebar render and blocking the chrome test-widget → `run-all counts update within 15000ms` timeout. The status vocab widened to 9 statuses back in May (`2a12f85f14`) but the dot map never followed — latent until a matrix run produced `:error`. **Fix:** map `:error` → `:dot-fail`, add an `:error` aria-label, and make `status-dot` null-safe (`(get styles k (:dot-pending styles))`) so any unmapped status degrades to the neutral pending ring instead of crashing.

- **`story_browser_scenarios.cjs`** (`controls-nested-edit-by-path-rf2-57ikh`) — editing nested `:settings :title` also wrote the untouched `:enabled?` sibling into `[:cell-overrides]`. **Regression** from `ee9cda6807` (2026-07-08, the first-red day): the vector/set repeater fix (rf2-mzfh9c) added `base`-seeding to `set-cell-override`, but seeded the *whole* resolved arg map at the top, polluting the map-nested case. **Fix:** `assoc-in-kind-aware` now threads `base` and seeds **only** `:vector`/`:set` levels (which resolution replaces wholesale); `:map` levels stay minimal (`{}`-rooted) because args resolution deep-merges maps (`002-Runtime.md`), restoring unrelated siblings at read time. Updated the one conflicting unit test and added an edit→`resolve-args` map round-trip proving the sibling is restored by deep-merge.

**2. `JVM slow/stress (ssr)` — intermittent, from 2026-07-19.** The `:slow-test` alias in `implementation/ssr/deps.edn` was missing `day8/re-frame2-ui`, which the `:test` alias gained in `b24c6ab015` (rf2-2mq2f). `emit_ui_tree_cljs_test` requires `re-frame.ui.rules`, and cognitect test-runner loads every test namespace at discovery → `FileNotFoundException` under the nightly `:slow-test` run. **Fix:** add `re-frame2-ui` to `:slow-test`, matching `:test`.

## Split out (not fixed here)

**`JVM slow/stress (routing)` `popstate-mid-push-stress`** is an intermittent, load-dependent concurrency flake (invariant-3 slice non-convergence). It passes 12/12 + isolated locally and could not be reliably reproduced or a fix validated this turn. Filed as **rf2-g2ytj** with findings and leads (prime suspect `02ec7dbc4c`, the 07-08 frame-state I/O consolidation). Per the bead's guidance, a speculative concurrency patch that can't be reproduced/validated is not applied — no skip/retry papering-over.

## Quality gates

All foreground, to completion:

- `test:story-feature-load` — **reproduced RED** (reverted the 2 source fixes → both specs fail with the exact CI errors: the `status_dot` null-deref timeout + the `:enabled?` sibling override), then **GREEN** with the fixes: `Ran 2 Story feature-load specs. 0 failures.`, zero pageerrors.
- ssr `clojure -M:slow-test` — reproduced RED (`FileNotFoundException`), then GREEN.
- `npm run test:cljs` — `Ran 10367 tests containing 51234 assertions. 0 failures, 0 errors.`
- tools/story JVM `clojure -M:test` — `Ran 1847 tests / 0 failures`.
- routing `popstate-mid-push-stress` — 12/12 green locally (confirms the flake is not reproducible locally).

No skip / retry / `continue-on-error` scaffolding. The two-consecutive-green-nightly acceptance is for the mayor to watch post-merge. Disjoint from C0/u53yy.1 (the compiler-cache/digest surface is untouched).

Closes rf2-wh5to (browser + ssr causes); routing split to rf2-g2ytj.
