### PR TITLE
fix(http): re-check abort at the cancellation-safe point so a cancelled request is not retried (rf2-6nczv9)

### DIFF
--- a/implementation/http/src/re_frame/http/transport.cljc
+++ b/implementation/http/src/re_frame/http/transport.cljc
@@ -1003,11 +1003,13 @@
   `ScheduledExecutorService` + `ScheduledFuture.cancel`), so the backoff
   scheduling and its cancellation are uniform across hosts.
 
-  rf2-fyt5i — `failure` is the just-failed attempt's classified failure
-  map, threaded through solely so the timer callback can emit the honest
-  intermediate `:rf.http/retry-attempt` `:recovery :retried` trace at the
-  cancellation-safe point (the instant attempt N+1 is actually permitted
-  to start), never before."
+  rf2-fyt5i / rf2-6nczv9 — `failure` is the just-failed attempt's
+  classified failure map, threaded through (in the `:rf.http/retry-handoff`
+  payload) solely so the honest intermediate `:rf.http/retry-attempt`
+  `:recovery :retried` trace can be emitted at the cancellation-safe point —
+  which is now INSIDE `run-attempt!`, after the successor attempt is
+  registered and re-confirmed not-aborted (the instant attempt N+1 is
+  actually permitted to start), never before."
   [ctx delay-ms prev-handle failure]
   ;; rf2-6nczv9 — test-only interleaving seam: an abort injected HERE resolves
   ;; the prior live-fetch handle (still registered — the backoff has not yet
@@ -1138,36 +1140,39 @@
         timer      (interop/set-timeout!
                      (fn []
                        (when (compare-and-set! fired? false true)
-                         (registry/clear-in-flight! request-id handle)
-                         ;; rf2-6nczv9 — never re-issue a fresh attempt for a
-                         ;; request the caller already cancelled. If the shared
-                         ;; `:aborted?` cell was flipped during the backoff
-                         ;; window, the terminal aborted reply already went out;
-                         ;; issuing attempt N+1 would re-send a cancelled
-                         ;; (possibly non-idempotent) request (Spec 014
-                         ;; §486-492). This is load-bearing for the interleaving
-                         ;; where the prior handle's abort-fn EXECUTES after the
-                         ;; post-arm re-check ran — the re-check missed the flip
-                         ;; but the fresh attempt is still suppressed here.
-                         (when-not (some? @aborted?)
-                           ;; rf2-fyt5i — HONEST timing for the intermediate
-                           ;; `:recovery :retried` disposition: emit it ONLY
-                           ;; here, the cancellation-safe point. The timer won
-                           ;; its `fired?` transition, the shared abort cell is
-                           ;; still clear, and attempt N+1 is about to start —
-                           ;; so `:retried` truthfully reports a retry the
-                           ;; runtime is actually running. An abort that landed
-                           ;; anywhere earlier (the `:maybe-retry/before-
-                           ;; schedule` window or during the backoff) flips
-                           ;; `@aborted?`, so this arm never runs and no phantom
-                           ;; `:retried` row is emitted for a retry that never
-                           ;; happened. `:next-backoff-ms` carries the backoff
-                           ;; `delay-ms` that governed this now-starting attempt.
-                           (when interop/debug-enabled?
-                             (emit-retry-attempt! ctx failure delay-ms :retried))
-                           (run-attempt! (-> ctx
-                                             (dissoc :handle)
-                                             (update :attempt inc))))))
+                         ;; rf2-6nczv9 — CONTINUOUS HANDOFF into attempt N+1.
+                         ;; Winning `fired?` owns the transition out of the
+                         ;; backoff, but the successor is NOT yet registered. Do
+                         ;; NOT clear this backoff handle here, and do NOT emit
+                         ;; `:retried` / issue the attempt here: that early
+                         ;; clear + one-shot abort-sample + late fresh-cell
+                         ;; registration WAS the timer-fire→attempt-N+1 gap — an
+                         ;; abort landing between the sample and the successor's
+                         ;; registration resolved NO handle and the retry fired
+                         ;; anyway, re-sending a cancelled request. Instead hand
+                         ;; the predecessor backoff handle AND the SHARED
+                         ;; cancellation cells to `run-attempt!`, which registers
+                         ;; the successor FIRST, drops this predecessor only
+                         ;; after (identity-conditional), and re-checks the
+                         ;; shared abort cell at the cancellation-safe point —
+                         ;; mirroring the live-fetch→backoff handoff. The honest
+                         ;; `:retried` trace and the fresh attempt both fire
+                         ;; inside `run-attempt!`, only once the successor
+                         ;; re-confirms the request was not aborted; so a request
+                         ;; cancelled at the handoff is never re-issued and emits
+                         ;; no phantom `:retried` (Spec 014 §486-492).
+                         (interleave! :retry/before-attempt ctx)
+                         (run-attempt!
+                           (-> ctx
+                               (dissoc :handle)
+                               (update :attempt inc)
+                               (assoc :rf.http/retry-handoff
+                                      {:prev-handle handle
+                                       :finalised?  finalised?
+                                       :aborted?    aborted?
+                                       :failure     failure
+                                       :delay-ms    delay-ms
+                                       :emit-ctx    ctx})))))
                      delay-ms)]
     (reset! timer-cell timer)
     (cond
@@ -1526,7 +1531,18 @@
   `maybe-retry!` → final-failure path (a `:rf.http/transport` reply to
   `:on-failure`) rather than escaping as `:rf.error/fx-handler-exception`."
   [ctx]
-  (let [{:keys [request timeout-ms request-id actor-id abort-signal]} ctx
+  (let [;; rf2-6nczv9 — retry handoff, present ONLY on the timer-fire→attempt
+        ;; N+1 path (nil on the first attempt). It carries the predecessor
+        ;; backoff handle (for the continuous-registration clear performed AFTER
+        ;; this successor registers), the SHARED `:finalised?` / `:aborted?`
+        ;; cancellation cells to REUSE (so the request's once-only reply guard
+        ;; and abort-precedence state thread UNBROKEN across the handoff — a
+        ;; cancelled request cannot slip through a fresh-cell seam), and the
+        ;; honest-`:retried` trace payload (emitted below at the
+        ;; cancellation-safe point, never before).
+        handoff  (:rf.http/retry-handoff ctx)
+        ctx      (dissoc ctx :rf.http/retry-handoff)
+        {:keys [request timeout-ms request-id actor-id abort-signal]} ctx
         method   (or (:method request) :get)
         url      (encoding/merge-params (:url request) (:params request))
         ;; rf2-065xo — body realization + encoding are DEFERRED past handle
@@ -1576,7 +1592,12 @@
         ;; abort reply itself. JVM additionally cancels the underlying
         ;; CompletableFuture so the work actually stops (not just the
         ;; reply path).
-        finalised? (atom false)
+        ;; rf2-6nczv9 — on the retry handoff REUSE the shared once-only reply
+        ;; guard so the predecessor (backoff) handle and this successor act as
+        ;; ONE reply-guarded unit: an abort that resolved the predecessor and
+        ;; delivered the terminal reply has already won this cell, so no second
+        ;; reply and no re-issue can follow. Fresh atom on the first attempt.
+        finalised? (or (:finalised? handoff) (atom false))
         ;; The abort closure flips this precedence cell
         ;; BEFORE racing the once-only `:finalised?` CAS, so even if a
         ;; synchronously-completing decode wins the CAS, the finalise-*
@@ -1586,7 +1607,11 @@
         ;; canonical reply shape (and the `:actor-id` slot, when
         ;; actor-destroy was the source) is reconstructable inside
         ;; finalise-failure! without re-deriving from `failure`.
-        aborted?   (atom nil)
+        ;; rf2-6nczv9 — on the retry handoff REUSE the shared abort-precedence
+        ;; cell so an abort landing anywhere in the timer-fire→attempt-N+1
+        ;; window is consulted END-TO-END at the post-registration re-check
+        ;; below (never a stale sample against a disconnected fresh cell).
+        aborted?   (or (:aborted? handoff) (atom nil))
         ;; On the JVM the abort closure must `.cancel cf true`
         ;; on the underlying CompletableFuture, but cf only exists AFTER
         ;; this binding (built inside the try-body below). Forward via a
@@ -1721,6 +1746,17 @@
         ;; happens synchronously here, before any fetch is issued, so the
         ;; cell is always populated by the time any abort can fire.
         _        (reset! handle-holder handle)
+        ;; rf2-6nczv9 — CONTINUOUS REGISTRATION on the retry handoff: the
+        ;; successor live-fetch handle now owns the request-id slot
+        ;; (`record-in-flight!` overwrote it above), so the request is never
+        ;; absent from the registry across the timer-fire→attempt-N+1 handoff.
+        ;; Drop the predecessor backoff handle only NOW — after the successor is
+        ;; registered. The 2-arg clear is identity-conditional (rf2-ous9e5): the
+        ;; request-id slot holds the successor, so it no-ops there and only
+        ;; removes the predecessor from the actor index (no stale accumulation
+        ;; across retries, rf2-wvkn). No-op on the first attempt (no handoff).
+        _        (when-let [prev (:prev-handle handoff)]
+                   (registry/clear-in-flight! request-id prev))
         ;; rf2-3fc89f.9 — bind the external `:abort-signal` to THIS live-fetch
         ;; handle's canonical abort-fn (`:reason :user`), detaching the prior
         ;; phase's listener (ownership transfer). An ALREADY-aborted signal
@@ -1736,6 +1772,35 @@
                    external-abort
                    (fn [] ((:abort-fn handle) :user)))])
         ctx'     (assoc ctx-no-handle :handle handle)]
+    ;; rf2-6nczv9 — CANCELLATION-SAFE RE-CHECK at the timer-fire→attempt-N+1
+    ;; handoff. If an abort flipped the SHARED cell during the handoff, a
+    ;; request the caller cancelled MUST NOT issue a fresh attempt (Spec 014
+    ;; §486-492). Drop the successor handle we just registered (idempotent if an
+    ;; abort-fn already cleared it), and — iff no terminal reply has gone out —
+    ;; deliver the single canonical `:rf.http/aborted` reply here through the
+    ;; SHARED once-only guard. That "no reply yet" case is the load-bearing one:
+    ;; an abort resolving the PREDECESSOR backoff handle LOSES the timer's
+    ;; already-won `fired?` CAS and so its abort-fn dispatched nothing — the
+    ;; reply is ours to deliver. Winning the guard here ALSO makes the
+    ;; `when-not @finalised?` below short-circuit, so no fresh attempt issues.
+    ;; (On the first attempt / steady-state retry the cell is nil and this is a
+    ;; single volatile read.)
+    (when (some? @aborted?)
+      (registry/clear-in-flight! request-id handle)
+      (when (compare-and-set! finalised? false true)
+        (dispatch-aborted! ctx-no-handle (:reason @aborted?))))
+    ;; rf2-6nczv9 / rf2-fyt5i — HONEST `:retried` (retry handoff only): the
+    ;; successor is registered and the shared abort cell is still clear, so
+    ;; attempt N+1 is genuinely about to issue. Emitting here — never at the
+    ;; earlier decision point in `maybe-retry!` — means an in-window
+    ;; cancellation emits NO phantom `:retried` for a retry that never happened
+    ;; (Spec 009 recovery law). `:emit-ctx` is the just-failed attempt's ctx so
+    ;; the trace's `:attempt` / `:next-backoff-ms` are unchanged from fyt5i.
+    (when (and (some? handoff)
+               (not (some? @aborted?))
+               (not @finalised?)
+               interop/debug-enabled?)
+      (emit-retry-attempt! (:emit-ctx handoff) (:failure handoff) (:delay-ms handoff) :retried))
     ;; rf2-3fc89f.9 — short-circuit when an already-aborted external signal
     ;; won the CAS synchronously during the bind above: the request is already
     ;; terminal (reply dispatched, registry cleared, listener detached), so

--- a/implementation/http/test/re_frame/http_abort_retry_race_test.clj
+++ b/implementation/http/test/re_frame/http_abort_retry_race_test.clj
@@ -30,11 +30,29 @@
    - Spec 014 §Abort precedence (abort always wins), §486-492
    - Spec 014 §Retry and backoff / §Aborts
 
+  The SECOND transition — timer-fire→attempt-N+1 — is the symmetric boundary
+  (rf2-6nczv9, completing the original two-gap finding). When the backoff timer
+  fires it wins its once-only `fired?` transition, then hands off to
+  `run-attempt!`. Previously the callback cleared the backoff handle FIRST,
+  sampled the abort cell ONCE, then called `run-attempt!`, which minted FRESH
+  cancellation cells and only later re-registered — so an abort landing in that
+  window resolved NO handle (its abort-fn LOST the timer's `fired?` CAS and
+  dispatched nothing) and the fresh attempt started anyway: a cancelled
+  (possibly non-idempotent POST) request re-issued. The fix threads the SHARED
+  cells and the predecessor handle into `run-attempt!` (continuous handoff): the
+  successor registers FIRST, the predecessor is dropped only after, and a
+  post-registration re-check delivers the single aborted reply and suppresses
+  the fresh attempt.
+
   Coverage:
    1. abort injected in `maybe-retry!` (post-abort-snapshot, pre-schedule)
       → exactly one :rf.http/aborted reply, ZERO extra server hits.
    2. abort injected at the START of `schedule-backoff-handle!`
       (the narrower-sibling window) → same: one aborted reply, no retry.
+   2b. abort injected at the timer-fire→attempt-N+1 HANDOFF
+      (`:retry/before-attempt`, after the timer won `fired?`, before the
+      successor registers) → same: one aborted reply, ZERO re-issue, no phantom
+      `:retried`. This is the second transition gap the audit named.
    3. rf2-ous9e5 unit: `clear-in-flight!` (2-arg) is identity-conditional —
       a completing OLD attempt does NOT evict a same-id SUCCESSOR's handle."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
@@ -109,7 +127,16 @@
   the fix the intermediate `:retried` emit was ordered ahead of the
   cancellation-safe backoff handoff, so a listener saw a `:retried` row (with
   non-nil `:next-backoff-ms`) for a retry that never happened — a tool could
-  report a retry the runtime did not perform."
+  report a retry the runtime did not perform.
+
+  The `inject-point` selects WHICH transition window the abort lands in: the
+  `:maybe-retry/*` / `:backoff/*` points fire during the live-fetch→backoff
+  transition (attempt 1's completion thread, prior handle still registered),
+  while `:retry/before-attempt` fires at the timer-fire→attempt-N+1 handoff
+  (the timer has won `fired?`, the successor has not yet registered). Every
+  point yields the SAME contract outcome — one aborted reply, no re-issue,
+  clean registry, no phantom `:retried` — which is exactly the point: an abort
+  anywhere in the transition cancels the request cleanly."
   [inject-point]
   (let [{:keys [^AtomicInteger hits] :as srv} (start-counting-500-server!)
         replies     (atom [])
@@ -188,6 +215,12 @@
 (deftest abort-injected-at-backoff-registration-boundary-no-reissue
   (testing "rf2-6nczv9 (narrower sibling) — an abort landing at the backoff registration boundary (prior clear now deferred, so the prior handle is still resolvable) yields one aborted reply and no retry"
     (run-injected-abort-case! :backoff/before-register)))
+
+;; ---- (2b) timer-fire → attempt-N+1 handoff window --------------------------
+
+(deftest abort-injected-at-timer-fire-handoff-no-reissue-no-phantom-retried
+  (testing "rf2-6nczv9 (second transition) — an abort landing at the timer-fire→attempt-N+1 handoff (after the timer won `fired?`, before the successor registers) yields exactly one :rf.http/aborted reply, ZERO re-issue, and NO phantom :retried; the abort resolves the still-registered predecessor backoff handle (its abort-fn loses the timer's fired? CAS), and run-attempt!'s post-registration re-check delivers the single reply and suppresses the fresh attempt"
+    (run-injected-abort-case! :retry/before-attempt)))
 
 ;; ---- (3) rf2-ous9e5 — identity-conditional clear-in-flight! ----------------
 


### PR DESCRIPTION
## What

Completes the abort-vs-retry continuous-handoff fix at the **second** transition gap the http correctness audit (rf2-k0pa70) named: **timer-fire → attempt N+1**.

`rf2-wj8vv` closed the live-fetch→backoff gap (continuous registration into the backoff handle); `rf2-fyt5i` moved the intermediate `:retried` emit to the cancellation-safe point. But the symmetric boundary was still non-continuous: the backoff timer callback cleared the backoff handle **first**, sampled the abort cell **once**, then called `run-attempt!`, which minted **fresh** cancellation cells and only re-registered later. On the JVM an abort landing in that window resolved **no** live handle (its abort-fn lost the timer's already-won `fired?` CAS and dispatched nothing) and the fresh attempt started regardless — a cancelled, possibly non-idempotent, request was **re-issued** (Spec 014 §486-492).

## Fix (mirrors the live-fetch→backoff handoff — minimal, no locks/scheduler/state-machine)

- The timer callback no longer clears the backoff handle or emits `:retried` early. It hands the predecessor backoff handle **and the SHARED** `:finalised?`/`:aborted?` cancellation cells to `run-attempt!` via a `:rf.http/retry-handoff` payload.
- `run-attempt!` on the handoff **reuses** the shared cells (so the request's once-only reply guard and abort-precedence state thread unbroken across the boundary — carry/consult the cancellation state end-to-end), registers the successor **first**, then drops the predecessor (identity-conditional) — continuous registration, no registry gap.
- A **post-registration re-check** reads the shared abort cell at the cancellation-safe point: if flipped, it drops the successor and delivers the single canonical `:rf.http/aborted` reply through the shared once-only guard (winning it also short-circuits the fresh attempt). The honest `:retried` trace now fires here too, only once the successor re-confirms not-aborted — no phantom `:retried` for a retry that never happened.

Built directly on fyt5i's cancellation-safe structure (the `:retried` emit already lived in the retry-commit path; the abort re-check now sits with it).

## Proof (red → green on the ACTUAL race window)

A deterministic JVM interleaving test injects the abort at a new `:retry/before-attempt` seam (the timer has won `fired?`, the successor is not yet registered — the exact window). Disabling only the post-registration re-check:

```
FAIL ... ZERO extra server hits — the cancelled request was NEVER re-issued
expected: (= 1 (.get hits))
  actual: (not (= 1 2))
```

The cancelled request was re-issued (server hit twice). With the re-check restored: exactly one `:rf.http/aborted` reply, one server hit, clean registry, no phantom `:retried`.

## Quality gates

- **http artefact** `clojure -M:test` (foreground, unpiped): **493 tests, 3787 assertions, 0 failures, 0 errors** (exit 0). Includes the new handoff regression and fyt5i's retry-timeline honesty tests — no regression.
- **`npm run test:cljs`** (foreground, unpiped): **10365 tests, 51218 assertions, 0 failures, 0 errors** (exit 0). The CLJS path (single-threaded, immune to the race) is unaffected by the cell-reuse.
- Red→green demonstrated on the actual race window (above).

Spec unchanged: 014:486-492 already mandates abort-always-wins / no re-issue during the backoff-to-attempt handoff; this brings the runtime into compliance at the second transition.

Closes rf2-6nczv9.
