### PR TITLE
refactor(build): elements → per-namespace all-members descriptor via PREPARE harvest (rf2-u53yy.1 S1)

### DIFF
--- a/implementation/scripts/check-ui-warm-watch.cjs
+++ b/implementation/scripts/check-ui-warm-watch.cjs
@@ -54,9 +54,10 @@
 //     re-frame.ui.compiler.build-hook/hook -> Shadow never runs the inherited
 //     hook -> the accepted build id falls back to ::default and no manifest is
 //     established -> COLD ACCEPT goes RED (annotation load-bearingness).
-//   * Delete the `build/seed-shadow-elements (harvest-seed …)` call (or the whole
-//     harvest) -> :probe-card is never seeded, so COLD ACCEPT's card-props read
-//     `nil`/attributes -> RED (the real source producer is load-bearing).
+//   * Delete the `build/set-shadow-element-manifest (harvest-all-seed …)` call (or
+//     the whole harvest) -> :probe-card is never seeded, so COLD ACCEPT's
+//     card-props read `nil`/attributes -> RED (the real source producer is
+//     load-bearing).
 //   * Delete the `(reconcile-declaration-edits build-state)` call -> the
 //     DECLARATION-SHRINK pass no longer recompiles the no-require-edge view
 //     (view-output-present stays true) and the stale manifest is not re-baked

--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -509,27 +509,37 @@
     ;; only WHERE the failure is anchored — never who wins, and never whether
     ;; the build fails. `:declarations` evidence is sorted, so it is identical
     ;; under every source / evaluation / build-order permutation.
+    ;; During a real Shadow build PASS the compile-time custom-element registry
+    ;; is populated by the build hook's prepare-time ALL-MEMBERS source harvest,
+    ;; which also enforces the cross-source conflict law there (rf2-u53yy.1 S1);
+    ;; the macro is then validation/reporting-only — it validates the declaration
+    ;; grammar above and emits the runtime registration below, but does NOT
+    ;; contribute to (or evict from) the compile-time registry. Off that path
+    ;; (plain-JVM / SSR, REPL — there is no `:compile-prepare` harvest), the
+    ;; macro's own contribution populates the per-source `elements` slice and
+    ;; reports contradictions here with the declaration's source coordinates.
     (let [decl {:properties props}]
-      (when-let [{:keys [conflict]} (build/contribute-element-checked!
-                                     ns-sym tag decl)]
-        (let [build-id (build/current-build-id)
-              rows (vec (sort-by (juxt (comp str :build) (comp str :ns))
-                                 [{:build build-id
-                                   :ns (:owner conflict)
-                                   :properties (:properties (:declaration conflict) #{})}
-                                  {:build build-id :ns ns-sym :properties props}]))]
-          (fail :rf.ui.compile/custom-element-conflict
-                (str "conflicting (ui/custom-element " tag " ...) declarations — "
-                     (str/join " vs "
-                               (map (fn [{:keys [ns properties]}]
-                                      (str ns " declares :properties "
-                                           (pr-str (vec (sort properties)))))
-                                    rows))
-                     ". One tag has ONE property manifest: delete the duplicate "
-                     "declaration, or make both sources declare an IDENTICAL "
-                     ":properties set (identical declarations may co-exist). "
-                     "re-frame.ui will not pick a winner by compile order")
-                {:tag tag :declarations rows}))))
+      (when-not (build/shadow-build-pass?)
+        (when-let [{:keys [conflict]} (build/contribute-element-checked!
+                                       ns-sym tag decl)]
+          (let [build-id (build/current-build-id)
+                rows (vec (sort-by (juxt (comp str :build) (comp str :ns))
+                                   [{:build build-id
+                                     :ns (:owner conflict)
+                                     :properties (:properties (:declaration conflict) #{})}
+                                    {:build build-id :ns ns-sym :properties props}]))]
+            (fail :rf.ui.compile/custom-element-conflict
+                  (str "conflicting (ui/custom-element " tag " ...) declarations — "
+                       (str/join " vs "
+                                 (map (fn [{:keys [ns properties]}]
+                                        (str ns " declares :properties "
+                                             (pr-str (vec (sort properties)))))
+                                      rows))
+                       ". One tag has ONE property manifest: delete the duplicate "
+                       "declaration, or make both sources declare an IDENTICAL "
+                       ":properties set (identical declarations may co-exist). "
+                       "re-frame.ui will not pick a winner by compile order")
+                  {:tag tag :declarations rows})))))
     `(re-frame.ui.rules/register-custom-element!
       ~tag {:properties ~props} '~ns-sym)))
 

--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -54,8 +54,24 @@
 (def roots       ::roots)        ; Layer-1 root-site index
 (def plans       ::plans)        ; Layer-1 frame-plan index
 (def descriptors ::descriptors)  ; Root Descriptor index
-(def elements    ::elements)     ; compile-time custom-element declarations
+(def elements    ::elements)     ; compile-time custom-element declarations (plain-JVM/SSR slice)
 (def ^:private element-declarations ::element-declarations) ; tag -> owning ns
+
+;; Custom-element declarations are DECOUPLED from the view-slice on the Shadow
+;; build path (rf2-u53yy.1 S1). Property lowering is decided at MACROEXPANSION,
+;; before compile-finish, so elements are the one ordering exception that cannot
+;; ride the compile-finish analyzer-map carrier the other registries use. Instead
+;; the build hook HARVESTS every authoritative build member's literal
+;; declarations at `:compile-prepare` (`harvest.clj`, a bounded syntactic reader)
+;; into a flat all-members manifest `{tag {:properties #{…}}}` — a pure function
+;; of the build's SOURCE, independent of which sources re-expand. That manifest
+;; lives beside the accepted snapshot (`:elements`) and in the open pass's scratch
+;; (`:element-manifest`), NEVER in the per-source `:committed`/`:staged`/`:touched`
+;; ledger, so harvesting a WARM source's elements can no longer mark it touched
+;; and evict its committed views at commit. The `ui/custom-element` macro is then
+;; validation/reporting-only during a real Shadow build pass. The plain-JVM / SSR
+;; and REPL paths (no `:compile-prepare` hook) keep populating the per-source
+;; `::elements` slice through the macro + lazy own-source harvest below.
 
 ;; ---------------------------------------------------------------------------
 ;; State
@@ -100,6 +116,7 @@
 (defn- empty-snapshot [build-id]
   {:build-id build-id
    :registries {}
+   :elements {}
    :version 0})
 
 (def ^:private shadow-bridge-key
@@ -169,6 +186,15 @@
   (reduce-kv (fn [m _src regs] (merge m (get regs reg-id)))
              {}
              (:registries (accepted-snapshot build-state-or-compiler-env))))
+
+(defn accepted-element-manifest
+  "The accepted flat custom-element manifest `{tag {:properties #{…}}}` from an
+  explicit Shadow build-state/compiler-env — the all-members harvest the last
+  successful build finalized. Decoupled from `:registries` (it is not a
+  per-source view-slice registry); the coarse warm-invalidation baseline and the
+  warm-watch topology gate read it here."
+  [build-state-or-compiler-env]
+  (:elements (accepted-snapshot build-state-or-compiler-env) {}))
 
 ;; ---------------------------------------------------------------------------
 ;; Ambient build identity
@@ -354,15 +380,33 @@
    (reduce-kv (fn [m _src regs] (merge m (get regs reg-id)))
               {} (:committed (get @state build-id empty-slice)))))
 
+#?(:clj
+   (defn- shadow-pass-manifest
+     "The prepare-harvested flat custom-element manifest of the OPEN Shadow build
+     pass (`[scratch-key :element-manifest]`), or nil. Present only inside a real
+     Shadow build pass the build hook opened; nil on a Shadow REPL overlay
+     (no `:compile-prepare` harvest), plain JVM/SSR, and CLJS — those fall back to
+     the per-source `elements` slice. The carrier's identity is validated
+     (`validated-compiler-state`) before the manifest is observed."
+     []
+     (when-let [cs (validated-compiler-state)]
+       (get-in cs [scratch-key :element-manifest]))))
+
 (defn element-properties
   "The declared `:properties` set for custom-element `tag` in the ambient (or
-  given) build's compile-time `elements` registry — the compile-path read the
+  given) build's compile-time custom-element manifest — the compile-path read the
   template analyzer uses to classify a custom element's props (property vs
-  attribute). Per-build, resolved through the ambient compiler build identity
-  (the SAME `current-build-id` mechanism every other registry read uses), so
-  one daemon's parallel builds never cross-classify; NEVER a process-global
-  last-writer-wins mirror. Empty set when `tag` is undeclared in this build."
-  ([tag] (get-in (aggregate elements) [tag :properties] #{}))
+  attribute). Inside a real Shadow build pass it reads the prepare-time
+  all-members harvest manifest (`shadow-pass-manifest`), which is a pure function
+  of the build's source and independent of macro re-expansion; on the plain-JVM /
+  SSR / REPL path it reads the per-source `elements` slice through the ambient
+  build identity. Per-build either way, so one daemon's parallel builds never
+  cross-classify; NEVER a process-global last-writer-wins mirror. Empty set when
+  `tag` is undeclared in this build."
+  ([tag]
+   (if-let [m #?(:clj (shadow-pass-manifest) :cljs nil)]
+     (get-in m [tag :properties] #{})
+     (get-in (aggregate elements) [tag :properties] #{})))
   ([tag build-id] (get-in (aggregate elements build-id) [tag :properties] #{})))
 
 (defn pass-open?
@@ -383,6 +427,19 @@
   Always false on CLJS (there is no compile-path host there)."
   []
   #?(:clj (boolean (validated-compiler-state)) :cljs false))
+
+(defn shadow-build-pass?
+  "Whether a real Shadow build PASS is bound — a `:compile-prepare`-opened scratch
+  is present. Inside this window the prepare-time all-members custom-element
+  harvest is authoritative and the `ui/custom-element` macro is
+  validation/reporting-only (it does not populate the compile-time registry).
+  False on a Shadow REPL overlay (no scratch, no prepare harvest), plain JVM/SSR,
+  and CLJS — where the macro's own contribution still populates the `elements`
+  slice."
+  []
+  #?(:clj (boolean (when-let [cs (validated-compiler-state)]
+                     (contains? cs scratch-key)))
+     :cljs false))
 
 ;; ---------------------------------------------------------------------------
 ;; Contribution (pure transitions)
@@ -600,14 +657,13 @@
     (::conflict outcome)))
 
 (defn- stage-element-checked
-  "Pure: admit `source`'s `tag` -> `decl` into `slice` under the ruled
-  cross-source conflict law, returning `[slice' conflict|nil]`. The barrier both
-  the ambient `contribute-element-checked!` and the pre-pass
-  `seed-shadow-elements` share, so no aggregation path can pick a merge-order
-  winner regardless of which route wrote the row. An `rf=`-equal duplicate is
-  idempotent; a contradiction from another live source (or a second
-  contradictory declaration in the same open pass of one ns) is refused without
-  writing, leaving the last-known-good slice untouched."
+  "Pure: admit `source`'s `tag` -> `decl` into the per-source `slice` under the
+  ruled cross-source conflict law, returning `[slice' conflict|nil]` — the write
+  barrier the plain-JVM / SSR / REPL `contribute-element-checked!` uses (the
+  Shadow build path re-derives the same verdict wholesale in `element-manifest`).
+  An `rf=`-equal duplicate is idempotent; a contradiction from another live
+  source (or a second contradictory declaration in the same open pass of one ns)
+  is refused without writing, leaving the last-known-good slice untouched."
   [slice source tag decl]
   (let [other-decl (get (effective slice elements source) tag)
         other-owner (get (effective slice element-declarations source) tag)
@@ -663,24 +719,50 @@
          slice')))
     @outcome))
 
-(defn seed-shadow-elements
-  "Purely PRE-STAGE harvested custom-element declarations into `build-state`'s
-  open scratch pass, BEFORE any view analyzes — the order-independence seam the
-  build hook uses at `:compile-prepare` (rf2-vxgfnd.141, dimension 2). Each
-  `[source tag decl]` triple is admitted under the SAME cross-source conflict
-  law as `contribute-element-checked!`: an `rf=`-equal duplicate co-exists, a
-  contradictory same-tag declaration is REFUSED here (the `ui/custom-element`
-  macro reports it with source coordinates when it later expands) so the slice
-  never carries a merge-order winner. A pure build-state transform because
-  `cljs.env/*compiler*` is not bound during hook execution; when no scratch pass
-  is open the build-state is returned unchanged."
-  [build-state seeded]
+(defn- seeded->registries
+  "Pure: group harvested `[source tag decl]` triples into the per-source shape
+  `elements-conflict` folds — `{source {elements {tag decl}}}`."
+  [seeded]
+  (reduce (fn [m [source tag decl]] (assoc-in m [source elements tag] decl))
+          {} seeded))
+
+(defn element-manifest
+  "Pure: fold harvested `[source tag decl]` triples into the flat all-members
+  custom-element manifest `{tag {:properties #{…}}}`. The SAME cross-source
+  conflict law as `contribute-element-checked!` governs admission — a non-`rf=`
+  same-tag declaration from a DIFFERENT source is a contradiction and THROWS
+  (a `:compile-prepare` error is a build-time error), so the manifest never
+  carries a merge-order winner; `rf=`-equal duplicates fold idempotently.
+  `build-id` anchors the thrown evidence."
+  [build-id seeded]
+  (when-let [c (elements-conflict build-id (seeded->registries seeded))]
+    (throw
+     (ex-info
+      (str "re-frame.ui found contradictory custom-element declarations for "
+           (:tag c) " while harvesting the build's declarations; refusing to "
+           "publish a merge-order winner")
+      {::error ::custom-element-conflict
+       :build-id build-id
+       :recovery :reconcile-custom-element-declarations
+       :tag (:tag c)
+       :declarations (:declarations c)})))
+  (reduce (fn [m [_source tag decl]]
+            (assoc m tag {:properties (:properties decl #{})}))
+          {} seeded))
+
+(defn set-shadow-element-manifest
+  "Purely store the prepare-harvested all-members custom-element `manifest`
+  (`{tag {:properties #{…}}}`, built by `element-manifest`) into `build-state`'s
+  open scratch pass, BEFORE any view analyzes — the order-independence +
+  macro-independence seam the build hook uses at `:compile-prepare`
+  (rf2-vxgfnd.141 dim 2, rf2-u53yy.1 S1). The manifest is a pure function of the
+  build's SOURCE, held beside the pass rather than in its per-source `:touched`
+  ledger, so harvesting a warm source's declarations never evicts its committed
+  views. A pure build-state transform (`cljs.env/*compiler*` is not bound during
+  the hook); when no scratch pass is open the build-state is returned unchanged."
+  [build-state manifest]
   (if (get-in build-state [:compiler-env scratch-key])
-    (update-in build-state [:compiler-env scratch-key]
-               (fn [slice]
-                 (reduce (fn [s [source tag decl]]
-                           (first (stage-element-checked s source tag decl)))
-                         slice seeded)))
+    (assoc-in build-state [:compiler-env scratch-key :element-manifest] manifest)
     build-state))
 
 ;; ---------------------------------------------------------------------------
@@ -816,25 +898,15 @@
         {::error ::missing-shadow-scratch
          :build-id build-id
          :recovery :configure-ui-build-hook-once})))
+    ;; Custom elements are NOT in the committed view-slice on this path
+    ;; (rf2-u53yy.1 S1): the manifest was harvested wholesale at
+    ;; `:compile-prepare` (all-members, macro-independent) and its cross-source
+    ;; conflict law was enforced there. Carry that finalized manifest onto the
+    ;; snapshot beside `:registries`.
     (let [after (-> scratch commit-slice (keep-members (set members)))
-          ;; Defence in depth (rf2-vxgfnd.143): `contribute-element-checked!`
-          ;; is the barrier, so a contradiction cannot reach here. Re-deriving
-          ;; the verdict from the FINALIZED rows — once per pass, not per read —
-          ;; means no aggregation can publish a merge-order winner even if a row
-          ;; arrived by a route that bypassed the barrier.
-          _ (when-let [c (elements-conflict build-id (:committed after))]
-              (throw
-               (ex-info
-                (str "re-frame.ui found contradictory custom-element declarations "
-                     "for " (:tag c) " in the finalized build; refusing to publish "
-                     "a merge-order winner")
-                {::error ::custom-element-conflict
-                 :build-id build-id
-                 :recovery :reconcile-custom-element-declarations
-                 :tag (:tag c)
-                 :declarations (:declarations c)})))
           snapshot {:build-id build-id
                     :registries (:committed after)
+                    :elements (:element-manifest scratch {})
                     :version (inc (long (or (:version accepted) 0)))}]
       {:snapshot snapshot})))
 

--- a/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
@@ -523,22 +523,28 @@
     file (try (slurp file) (catch Throwable _ nil))
     :else nil))
 
-(defn- harvest-seed
-  "The `[source tag decl]` triples for every RECOMPILED re-frame.ui-consumer
-  source scheduled this pass — the declarations that must seed the elements
-  slice before any view analyzes."
-  [{:keys [build-sources sources] :as build-state}]
-  (let [parallel? (parallel-build? build-state)]
-    (into []
-          (mapcat
-           (fn [resource-id]
-             (let [{:keys [ns] :as rc} (get sources resource-id)]
-               (when (and ns
-                          (pass-recompiles-cljs? build-state parallel? resource-id)
-                          (ui-cache-blocked-source? rc))
-                 (some->> (resource-source rc)
-                          (harvest/source-seed ns))))))
-          build-sources)))
+(defn- harvest-all-seed
+  "The `[source tag decl]` triples for EVERY authoritative re-frame.ui-consumer
+  source in the build graph — not just the subset Shadow recompiles this pass.
+
+  Harvesting the WHOLE authoritative member set (rf2-u53yy.1 S1) makes the
+  custom-element manifest a pure function of the build's SOURCE: a warm
+  cache-hit's declarations are re-derived by reading its source, never by
+  re-running its macros. That is what lets the manifest be DECOUPLED from the
+  view-slice — a warm source's declarations no longer need staging into the pass
+  (which marked it touched and evicted its committed views), and the manifest no
+  longer depends on macro re-expansion (the direction S6 needs to drop the cache
+  blocker). `harvest/source-seed` is a bounded syntactic reader; a source we
+  cannot read is a graceful no-op."
+  [{:keys [build-sources sources]}]
+  (into []
+        (mapcat
+         (fn [resource-id]
+           (let [{:keys [ns] :as rc} (get sources resource-id)]
+             (when (and ns (ui-cache-blocked-source? rc))
+               (some->> (resource-source rc)
+                        (harvest/source-seed ns))))))
+        build-sources))
 
 ;; ---------------------------------------------------------------------------
 ;; Declaration-edit warm staleness — COARSE invalidation (rf2-vxgfnd.141, dim 3)
@@ -561,29 +567,16 @@
 ;; not either.
 ;; ---------------------------------------------------------------------------
 
-(defn- effective-manifest
-  "The `tag -> decl` manifest this pass WILL commit: the accepted rows of the
-  sources NOT recompiled this pass, overlaid with the harvested declarations of
-  the recompiled sources (whose accepted rows are being replaced). A pure
-  function of the accepted snapshot plus this pass's harvest."
-  [build-state recompiled-nss seed]
-  (let [warm (reduce-kv
-              (fn [m src regs]
-                (if (contains? recompiled-nss src)
-                  m
-                  (merge m (get regs build/elements))))
-              {}
-              (:registries (build/accepted-snapshot build-state)))]
-    (reduce (fn [m [_src tag decl]] (assoc m tag decl)) warm seed)))
-
 (defn- manifest-changed?
-  "Whether this pass's effective `tag -> decl` manifest differs from the accepted
-  one — the coarse invalidation trigger. Compares only the property manifest, so
-  a declaration's provenance (owning namespace) moving does not count as a change
-  unless the declared properties actually differ."
-  [build-state recompiled-nss seed]
-  (not= (build/accepted-aggregate build/elements build-state)
-        (effective-manifest build-state recompiled-nss seed)))
+  "Whether this pass's freshly-harvested all-members `tag -> {:properties …}`
+  manifest differs from the accepted one — the coarse invalidation trigger.
+  Because the manifest is now a wholesale all-members re-derivation over the
+  build's source (rf2-u53yy.1 S1), the comparison is simply the fresh manifest
+  against the accepted manifest; no accepted/recompiled overlay is needed. The
+  manifest carries `:properties` only, so a declaration's provenance (owning
+  namespace) moving does not count as a change unless the properties differ."
+  [build-state fresh-manifest]
+  (not= (build/accepted-element-manifest build-state) fresh-manifest))
 
 (defn- invalidate-ui-consumers
   "Reset retained output for every re-frame.ui literal-consumer source, so the
@@ -600,16 +593,15 @@
           (:build-sources build-state)))
 
 (defn- reconcile-declaration-edits
-  "If this pass changes the custom-element manifest on a WARM build (accepted
-  version > 0), coarse-invalidate the UI literal-consumer set so no view keeps a
-  stale baked lowering (rf2-vxgfnd.141, dimension 3). On the version-0 pass
-  `reset-cold-ui-consumer-output` already covers it, so this only acts warm."
-  [build-state]
+  "If this pass's freshly-harvested `fresh-manifest` changes the custom-element
+  manifest on a WARM build (accepted version > 0), coarse-invalidate the UI
+  literal-consumer set so no view keeps a stale baked lowering (rf2-vxgfnd.141,
+  dimension 3). On the version-0 pass `reset-cold-ui-consumer-output` already
+  covers it, so this only acts warm."
+  [build-state fresh-manifest]
   (let [version (long (or (:version (build/accepted-snapshot build-state)) 0))]
     (if (and (pos? version)
-             (manifest-changed? build-state
-                                (recompiled-member-nss build-state)
-                                (harvest-seed build-state)))
+             (manifest-changed? build-state fresh-manifest))
       (invalidate-ui-consumers build-state)
       build-state)))
 
@@ -625,12 +617,21 @@
     (do
       (validate-ui-cache-blocker! build-state)
       (let [build-state (reset-cold-ui-consumer-output build-state)
+            ;; Harvest EVERY authoritative member's literal custom-element
+            ;; declarations ONCE, up front, into the flat all-members manifest
+            ;; (rf2-u53yy.1 S1). Source is stable across the invalidation/stamp
+            ;; transforms below, so this is computed once and reused for both the
+            ;; coarse-invalidation comparison and the scratch manifest. `element-
+            ;; manifest` enforces the cross-source conflict law (throws on a
+            ;; contradiction — a build-time error).
+            fresh-manifest (build/element-manifest build-id
+                                                    (harvest-all-seed build-state))
             ;; Coarse dimension-3 invalidation: a WARM edit that changed the
             ;; custom-element manifest recompiles every UI literal consumer so
             ;; none keeps a stale baked lowering (rf2-vxgfnd.141). Must precede
             ;; the schedule/stamp so the widened consumer set is scheduled and
-            ;; re-seeded this same pass.
-            build-state (reconcile-declaration-edits build-state)
+            ;; re-baked this same pass.
+            build-state (reconcile-declaration-edits build-state fresh-manifest)
             pass-token  (str (java.util.UUID/randomUUID))
             witnessed   (atom #{})
             stamped     (-> build-state
@@ -654,11 +655,14 @@
                                         build-id
                                         (member-nss stamped)
                                         (recompiled-member-nss stamped))
-            ;; Pre-seed this pass's recompiled custom-element declarations into
-            ;; the open scratch BEFORE any view analyzes, so property lowering is
-            ;; order-independent (rf2-vxgfnd.141, dimension 2). Pure build-state
+            ;; Store the all-members custom-element manifest beside the open pass
+            ;; BEFORE any view analyzes, so property lowering is a pure function
+            ;; of the build's declarations rather than of evaluation order OR of
+            ;; which sources re-expand (rf2-vxgfnd.141 dim 2, rf2-u53yy.1 S1). The
+            ;; manifest sits outside the per-source `:touched` ledger, so it can
+            ;; never evict a warm source's committed views. Pure build-state
             ;; transform — `cljs.env/*compiler*` is not bound during the hook.
-            (build/seed-shadow-elements (harvest-seed stamped))
+            (build/set-shadow-element-manifest fresh-manifest)
             (assoc-in [:compiler-env build/scratch-key :pass-token]
                       pass-token)
             (assoc-in [:compiler-env build/scratch-key :compile-witness]

--- a/implementation/ui/src/re_frame/ui/compiler/harvest.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/harvest.clj
@@ -23,21 +23,25 @@
 
   Two callers seed through it:
 
-  * the Shadow build hook, at `:compile-prepare`, folds every RECOMPILED UI
-    source's declarations into the open pass's disposable scratch
-    (`build/seed-shadow-elements`) — a pure build-state transform, since
-    `cljs.env/*compiler*` is not bound during hook execution;
+  * the Shadow build hook, at `:compile-prepare`, folds EVERY authoritative UI
+    source's declarations (not just the recompiled subset — rf2-u53yy.1 S1) into
+    the flat all-members manifest held beside the open pass
+    (`build/element-manifest` / `build/set-shadow-element-manifest`) — a pure
+    build-state transform, since `cljs.env/*compiler*` is not bound during hook
+    execution;
 
   * the plain-JVM / SSR path (which has no `:compile-prepare`) harvests the
     ambient namespace's own source ONCE, lazily, the first time a view in it
     classifies a custom element (`ensure-namespace-harvested!`), seeding through
     the ambient `build/contribute-element-checked!`.
 
-  Both routes admit through the ONE cross-source conflict barrier
-  (`build/contribute-element-checked!` / `build/seed-shadow-elements`): an
-  `rf=`-equal duplicate co-exists; a contradictory same-tag declaration is
-  refused here and reported by the macro with source coordinates. JVM-only: it
-  reads source text at build time and is never emitted into any bundle."
+  Both routes admit through the ONE cross-source conflict law: on the Shadow path
+  `build/element-manifest` re-derives the verdict over all members, and on the
+  plain-JVM path `build/contribute-element-checked!` is the write barrier — an
+  `rf=`-equal duplicate co-exists; a contradictory same-tag declaration is refused
+  (and reported with source coordinates on the plain-JVM path, or as a build-time
+  error at prepare on the Shadow path). JVM-only: it reads source text at build
+  time and is never emitted into any bundle."
   (:require [clojure.java.io :as io]
             [clojure.tools.reader :as rdr]
             [clojure.tools.reader.reader-types :as rt]
@@ -174,9 +178,10 @@
 ;; ---------------------------------------------------------------------------
 
 (defn source-seed
-  "The `[source tag decl]` triples `build/seed-shadow-elements` folds into an
-  open scratch pass, for one build source declaring namespace `ns-sym` with
-  `src` text. `ns-sym` is the declaring source (the conflict/eviction unit)."
+  "The `[source tag decl]` triples the build hook folds into the flat all-members
+  manifest (`build/element-manifest`), for one build source declaring namespace
+  `ns-sym` with `src` text. `ns-sym` is the declaring source (the conflict/owner
+  unit)."
   [ns-sym src]
   (mapv (fn [{:keys [tag properties]}]
           [ns-sym tag {:properties properties}])

--- a/implementation/ui/test/re_frame/ui/custom_element_harvest_hook_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/custom_element_harvest_hook_jvm_test.clj
@@ -13,10 +13,11 @@
 
   The declaring source's own macro is never run here; the ONLY thing that can
   declare `:ce-two` is the prepare-time harvest reading its `:source`. So this
-  is a clean red-before lever of its own: revert the `build/seed-shadow-elements`
-  call in `build-hook/hook` and both orders classify `:model` as an attribute
-  (the emitted node carries no `:rf.ui/property-props`), while every other proof
-  stays green. The observable is the emitted node, not merely that nothing threw."
+  is a clean red-before lever of its own: revert the
+  `build/set-shadow-element-manifest` call in `build-hook/hook` and both orders
+  classify `:model` as an attribute (the emitted node carries no
+  `:rf.ui/property-props`), while every other proof stays green. The observable
+  is the emitted node, not merely that nothing threw."
   (:require [cljs.env :as cljs-env]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.ui.compiler :as compiler]

--- a/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/hook.clj
+++ b/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/hook.clj
@@ -98,7 +98,7 @@
 
     :compile-finish
     (let [snap     (build/accepted-snapshot build-state)
-          manifest (build/accepted-aggregate build/elements build-state)
+          manifest (build/accepted-element-manifest build-state)
           views    (build/accepted-aggregate build/views build-state)
           members  (member-nss build-state)]
       (record! build-id


### PR DESCRIPTION
## What

Slice **S1** of the staged install-tax re-architecture (rf2-u53yy.1). C0 (whole-build digest deletion, #6640) unblocked this by removing the views+elements digest fold.

**Before:** compile-time custom-element declarations lived INSIDE the per-source view-slice (`:committed`/`:staged`/`:touched`) and were seeded at `:compile-prepare` only for RECOMPILED sources — because staging a warm source's elements marked it `:touched` and evicted its committed views at commit.

**After:** the build hook harvests **every authoritative build member's** literal `(ui/custom-element …)` declarations at `:compile-prepare` (via `harvest.clj`, a bounded syntactic reader) into a flat all-members manifest `{tag {:properties #{…}}}` held **beside** the pass (scratch `:element-manifest`, accepted snapshot `:elements`) — never in the per-source `:touched` ledger. The manifest is a pure function of the build's SOURCE, independent of which sources re-expand (the direction S6 needs to drop the cache blocker).

Because elements no longer enter the view-slice on the Shadow path, **a warm source's elements can no longer evict its committed views**, and the recompiled-only restriction is removed (`harvest-seed` → `harvest-all-seed`).

The `ui/custom-element` macro is now **validation/reporting-only during a real Shadow build pass** (new `build/shadow-build-pass?`): it validates grammar and emits the runtime registration, but no longer contributes to the compile-time registry (the prepare harvest is authoritative and enforces the cross-source conflict law via `build/element-manifest`). The **plain-JVM / SSR / REPL path is unchanged** — the per-source slice, macro contribution, and lazy own-source harvest stay, so the ruled cross-source conflict law (rf2-vxgfnd.143) and its tests are untouched.

Coarse warm-invalidation on element-manifest change is retained and simplified (wholesale manifest vs accepted; `effective-manifest` overlay deleted). Net simplification: `seed-shadow-elements` and `effective-manifest` removed; Shadow-path element eviction is now the wholesale prepare rebuild.

## Quality gates

All run foreground to completion:

| Gate | Result |
|---|---|
| `implementation/ui` `clojure -M:test` | **926 tests, 0 failures, 0 errors** |
| `npm run test:cljs` | **10365 tests, 0 failures, 0 errors** |
| `npm run test:elision` | **PASS** (real Shadow release compile of a UI build) |
| `npm run test:perf-bundle` | **PASS** |
| `npm run test:ui-warm-watch` | **PASS** — real Shadow daemon, all 8 phases (cold / zero-decl / shrink / same-ns move / rename / delete / failed-compile-preserve / retry) |
| fresh-consumer sim | `examples/ui/minimal-counter` compiles clean, **0 warnings** (resolves modified re-frame.ui via `:local/root`) |

## Fence

The two `implementation/shadow-cljs.edn` tax lines (S6) and the S0 cache-carrier probe are **untouched**. Disjoint from the live loose cluster (spec/API, skills, tools) and wh5to's nightly workflow.

## Programme note

S1 unblocks **S2** (views → analyzer-map descriptor carrier at `[:compiler-env :cljs.analyzer/namespaces <ns>]`, the S0-proven mechanism — the hard core). Elements were the ordering exception (property lowering runs during view expansion, before compile-finish), which is why S1 uses a PREPARE-time source harvest rather than the compile-finish analyzer-map carrier.

Part of rf2-u53yy.1 (multi-day SOLO compiler programme). Do not merge independently of the mayor's sequencing.