### PR TITLE
docs(routing): update EP-0012 route-url examples + finish spec/012 route-link wording (rf2-o06n1 rf2-sxpu1)

### DIFF
--- a/docs/EP/EP-0012-path-optics-and-canonical-forms.md
+++ b/docs/EP/EP-0012-path-optics-and-canonical-forms.md
@@ -816,7 +816,7 @@ route data and URL strings in the route's domain.
 For every route id and every valid path params, query params, and fragment:
 
 ```text
-match-url(route-url(route-id, path-params, query-params, fragment))
+match-url(route-url({:to route-id :params path-params :query query-params :fragment fragment}))
 =
 {:route-id route-id
  :params   canonical-route-path-params
@@ -868,10 +868,10 @@ Example:
             [:page {:optional true} :int]]})
 
 (rf.routing/route-url
-  :route/article
-  {:slug "welcome"}
-  {:page 2 :tab "comments"}
-  "discussion")
+  {:to       :route/article
+   :params   {:slug "welcome"}
+   :query    {:page 2 :tab "comments"}
+   :fragment "discussion"})
 ;; => "/articles/welcome?page=2&tab=comments#discussion"
 
 (rf.routing/match-url "/articles/welcome?page=2&tab=comments#discussion")
@@ -886,10 +886,10 @@ The same route with query params in a different map insertion order prints the
 same URL:
 
 ```clojure
-(= (rf.routing/route-url :route/article {:slug "welcome"}
-                         {:tab "comments" :page 2})
-   (rf.routing/route-url :route/article {:slug "welcome"}
-                         {:page 2 :tab "comments"}))
+(= (rf.routing/route-url {:to :route/article :params {:slug "welcome"}
+                          :query {:tab "comments" :page 2}})
+   (rf.routing/route-url {:to :route/article :params {:slug "welcome"}
+                          :query {:page 2 :tab "comments"}}))
 ;; => true
 ```
 
@@ -1161,11 +1161,11 @@ Non-EDN values are rejected:
            [:archived? {:optional true} :boolean]]})
 
 (def url
-  (rf.routing/route-url :route/search
-                        {}
-                        {:archived? false
-                         :q "clojure data"
-                         :page 2}))
+  (rf.routing/route-url {:to     :route/search
+                         :params {}
+                         :query  {:archived? false
+                                  :q "clojure data"
+                                  :page 2}}))
 
 url
 ;; => "/search?archived%3F=false&page=2&q=clojure%20data"

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -961,24 +961,21 @@ An external classification emits `:rf.route/external-url-requested` (carrying `:
 ```clojure
 (rf/reg-view ^{:rf/id :route/link} route-link
   [{:keys [to params query fragment on-click] :as props} & children]
-  (let [base-url (rf.routing/route-url {:to to :params (or params {}) :query (or query {})})
-        url      (if (and fragment (not= "" fragment))
-                   (str base-url "#" fragment)
-                   base-url)
-        attrs    (-> props
-                     (dissoc :to :params :query :fragment :on-click)
-                     (assoc :href url
-                            :on-click
-                            (fn [e]
-                              (when on-click (on-click e))
-                              (when (and (not (.-defaultPrevented e))
-                                         (plain-left-click? e))   ;; no modifier keys; primary button
-                                (.preventDefault e)
-                                (dispatch [:rf.route/url-requested
-                                           (cond-> {:url url :to to}
-                                             (seq params) (assoc :params params)
-                                             (seq query)  (assoc :query query)
-                                             fragment     (assoc :fragment fragment))])))))]
+  (let [url   (rf.routing/route-url {:to to :params (or params {}) :query (or query {}) :fragment fragment})
+        attrs (-> props
+                  (dissoc :to :params :query :fragment :on-click)
+                  (assoc :href url
+                         :on-click
+                         (fn [e]
+                           (when on-click (on-click e))
+                           (when (and (not (.-defaultPrevented e))
+                                      (plain-left-click? e))   ;; no modifier keys; primary button
+                             (.preventDefault e)
+                             (dispatch [:rf.route/url-requested
+                                        (cond-> {:url url :to to}
+                                          (seq params) (assoc :params params)
+                                          (seq query)  (assoc :query query)
+                                          fragment     (assoc :fragment fragment))])))))]
     (into [:a attrs] children)))
 ```
 
@@ -988,7 +985,7 @@ The view exposes three behavioural seams: passthrough attributes (`:class`, `:ti
 
 ## Scroll restoration
 
-Browser-default behaviour on `popstate` restores scroll position. For SPA-controlled scroll (e.g., scroll to top on forward navigation, restore on back), declare a `:scroll` strategy on the route or pass `:scroll` in the `:rf.route/navigate` opts.
+Browser-default behaviour on `popstate` restores scroll position. For SPA-controlled scroll (e.g., scroll to top on forward navigation, restore on back), declare a `:scroll` strategy on the route or pass `:scroll` in the `:rf.route/navigate` request map.
 
 The `:scroll` value is one of:
 
@@ -1002,7 +999,7 @@ The `:scroll` value is one of:
 The vocabulary is **closed** to those three keywords. Any other value — including a map — is rejected: the `:rf.nav/scroll` args schema (`:rf.fx.nav/scroll-args`) enumerates exactly `:top`, `:restore`, `:preserve`, so an unsupported strategy fails at the `:fx-args` boundary and the effect is skipped ([010 §Validation order step 5](010-Schemas.md#validation-order-on-event-processing)); and the registered fx handler — the always-on leg, since the schemas artefact is optional — emits `:rf.error/unsupported-scroll-strategy` rather than doing nothing. That handler leg fans through the two-channel error seam (`re-frame.error-emit/emit-error-both!`), so the rejection is genuinely unconditional: it survives `:advanced` + `goog.DEBUG=false` on a host that never loaded the schemas artefact, where the dev trace is elided. See [§Custom scroll strategies](#custom-scroll-strategies) and [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue).
 
 Resolution order at navigation time:
-1. `:scroll` key in `:rf.route/navigate`'s `opts` map (per-call override). Wins.
+1. `:scroll` key in `:rf.route/navigate`'s request map (per-call override). Wins.
 2. `:scroll` key on the route's metadata.
 3. Implicit default: `:top` for forward navigation, `:restore` for popstate-driven navigation.
 


### PR DESCRIPTION
Two routing-documentation truth-ups on the flat request-map grammar (same-domain cluster). Docs/spec are the artefact; both verified against the SHIPPED address-map `route-url` / route-link API (vwwvp flat request-map grammar + oq0ld/0zsvw navigate/route-url boundary + PR #6598 route-link → address-map).

## rf2-o06n1 — EP-0012 route-url examples → address-map API

The five copyable `route-url` calls in `docs/EP/EP-0012-path-optics-and-canonical-forms.md` still used the deleted positional arities (`route-id, path-params, query-params, fragment`), which now throw. `route-url` takes a single address map `{:to … :params … :query … :fragment …}` (confirmed against `routing/src/re_frame/routing/registry.cljc`).

- Prism-law notation (`match-url(route-url(route-id, path-params, query-params, fragment))`) → address-map form.
- Article example (`:route/article` + `"discussion"` fragment) → `{:to … :params … :query … :fragment …}`.
- Insertion-order example (two calls) → address maps.
- Search round-trip example → address map.

Every URL result and law preserved; only the call form changed. Abstract inverse-law notation (`route-url(match-url(url))`, `match-url(route-url(...))`) left as-is — single-expression placeholders, not positional calls. No executable positional `route-url` call remains.

## rf2-sxpu1 — Spec 012 route-link fragment + flat-request wording

PR #6598 migrated the route-link reference call to an address map but left the fragment synthesised **outside** `route-url`: the snippet appended a raw `#fragment` via `(str base-url "#" fragment)`, bypassing route-url's per-component percent-encoding contract and disagreeing with the shipped `routing/src/re_frame/routing/link.cljc` (which passes `:fragment fragment` into `route-url`).

- Pass `:fragment fragment` in the route-url address map; drop the manual gate + string append. `route-url` owns the nil/empty policy and encoding (`url/url-encode`), so an encoding-sensitive fragment like `"50% done"` now emits `#50%25%20done` — the documented contract (§Bidirectional URL ↔ params, line ~681) and the exact inverse of `match-url`.
- Rename the flat navigation request from "opts map"/"opts" to "request map" in the two scroll-section references, matching the flat request-map grammar (§The request grammar). The historical "positional opts map left over from the deleted `[target opts]` split" reference is correctly left as history.

## Quality gates

All run foreground to completion (repo root), exit codes captured by redirect:

- `python -m mkdocs build --strict` → exit 0
- `python scripts/check_doc_slugs.py` → exit 0
- `python scripts/check_ep_status_sync.py` → exit 0
- `python scripts/check_retired_composition_vocab.py` / `check_retired_spellings.py` / `check_retired_image_keys.py` / `check_runtime_subsystem_grading.py` / `check_inject_cofx_residue.py` / `check_failure_corpus_residue.py` → exit 0 each
- `sh scripts/check-no-hardcoded-paths.sh` → exit 0
- Residue greps: no positional `route-url` call and no manual `#fragment` append remain (EP-0012 + spec/012)

Sole open-PR toucher of `spec/012-Routing.md` and `EP-0012`. Disjoint from live workers `u53yy.1 S2` (build/compiler), `nn5s8` (realworld app), `g2ytj` (frame.cljc routing runtime) — this PR touches routing DOCS only.
