### PR TITLE
feat(examples): realworld_resources complete re-frame.ui full-app variant (S7 P-1, rf2-nn5s8)

### DIFF
--- a/examples/real-apps/realworld_resources/README.md
+++ b/examples/real-apps/realworld_resources/README.md
@@ -208,6 +208,55 @@ Then open the served page in a browser. **No backend ships.** The demo entry (`c
 
 To run against a real backend instead: point `realworld-resources.http/api-base` at the official hosted Conduit API (<https://api.realworld.show/api>) or a local reference backend on `http://localhost:3000/api`, and remove the demo-stub `:fx-overrides` line in `core.cljs`. The frame-wide `:realworld/bearer-auth` interceptor then attaches the JWT to every authenticated call.
 
+## The re-frame.ui variant (same app, compiled views)
+
+Everything above describes the stock-**Reagent** build. The same app also ships a
+twin built entirely on the **re-frame.ui** compiled-view substrate — every view
+authored with `ui/defview` and mounted on a re-frame.ui root via `ui/mount` +
+`ui/frame-root`, instead of `reg-view` + `reagent.dom`. The two are the *same
+application*: they share the identical, substrate-free dataflow — every
+`reg-event` / `reg-sub` / `reg-resource` / `reg-mutation` / `reg-route` /
+`reg-machine` / `reg-flow` in `resources.cljs`, `mutations.cljs`, `routing.cljs`,
+`scope.cljs`, `schema.cljs`, `http.cljs`, and the dataflow that lives beside the
+Reagent views in `views.cljs` / `auth.cljs` / `settings.cljs` /
+`article_editor.cljs`. Only the view tier differs. The ui arm is **purely
+additive** — the Reagent arm is retained untouched (adapter disposition
+2026-07-17: re-frame.ui is experimental, offered *alongside* the supported
+adapters, never a replacement).
+
+| | Reagent arm | re-frame.ui arm |
+|---|---|---|
+| entry / build | `realworld-resources.core/run` · `:examples/realworld-resources` | `realworld-resources.ui-core/run` · `:examples/realworld-resources-ui` |
+| view files | `core.cljs`, `views.cljs`, the views in `auth`/`settings`/`article_editor` | `ui_core.cljs`, `ui_views.cljs`, `ui_auth.cljs`, `ui_settings.cljs`, `ui_editor.cljc` |
+| view form | `reg-view` (Reagent) | `ui/defview` (compiled) |
+| mount | `reagent.dom.client/render` + `rf/frame-root` | `ui/mount` + `ui/frame-root` |
+
+Build it under shadow-cljs id `examples/realworld-resources-ui` from
+`implementation/`:
+
+```bash
+shadow-cljs watch examples/realworld-resources-ui
+```
+
+A few compiled-view idioms the ui arm demonstrates, worth reading for how a real
+CRUD app expresses itself on the substrate:
+
+- **Reads are `sub`, writes are event vectors.** Views read passively with
+  `(sub [:rf.resource/* …])` / `(sub [:rf/mutation …])`; buttons and forms carry
+  a literal `[:event …]` vector, a `{:event … :prevent-default true}` options map
+  where the browser must not navigate, or a `ui/event` when the live native value
+  is needed. Controlled inputs ride the `:rf.ui/value` placeholder; the
+  classified password fields, whose keystrokes carry a map payload, use a
+  synchronous `ui/event` (a placeholder never splices into a map).
+- **Dynamic lists render a keyed child view in `for` child position** — a row
+  whose handler needs a per-row value (a page number, a tag) takes it as a
+  **prop**, because a handler may not capture a `for` binding.
+- **The markdown article body crosses via `ui/raw`.** `md/render` emits sanitized
+  hiccup DATA, and the substrate deliberately will not interpret runtime hiccup as
+  a template — so the one genuinely runtime-shaped subtree is converted to a React
+  element (`hiccup->element`, text preserved as React children — no
+  `dangerouslySetInnerHTML`) and embedded through the sanctioned `ui/raw` door.
+
 ## RealWorld contract conformance
 
 This example follows the official RealWorld "Conduit" contract: its route shapes, the `localStorage["jwtToken"]` session key, the form `name` attributes, the selectors, and the favorite/follow toggle conventions. It reads the contract the same way the `realworld_http/` sibling does. One caveat: the contract assumes **one app per origin**, but the repo's dev orchestrator serves both this app and the sibling from a single origin, so the two share — and clobber — each other's `jwtToken` there. Serve the app standalone (one app per origin) and the problem goes away.

--- a/examples/real-apps/realworld_resources/ui_auth.cljs
+++ b/examples/real-apps/realworld_resources/ui_auth.cljs
@@ -1,0 +1,101 @@
+(ns realworld-resources.ui-auth
+  "Login / register pages for the RealWorld (Conduit) example, rendered in NATIVE
+   re-frame.ui (`ui/defview`) — the compiled-view counterpart of the Reagent
+   `login-page` / `register-page` in `realworld-resources.auth`.
+
+   This file is ONLY the rendering tier. The auth DATAFLOW — the `:auth/flow`
+   machine, session restore, the credential-owning form `:submit` events, the
+   scope teardown, and every `:auth/*` / `:auth.login-form/*` /
+   `:auth.register-form/*` event + sub — lives in `realworld-resources.auth` and
+   is UNCHANGED and shared. These views reach it by keyword, requiring nothing but
+   `re-frame.ui`.
+
+   Two compiled-view idioms carry the forms:
+
+   - **Controlled inputs, the synchronous door.** A non-secret field is a literal
+     `:value` co-present with an `:on-input` event vector carrying the
+     `:rf.ui/value` placeholder, which projects the live DOM value at dispatch and
+     drains synchronously (the caret never jumps).
+
+   - **The password's map payload, via `ui/event`.** The password edit event takes
+     a MAP payload (`[:…/edit-password {:value s}]`) so its `:value` is
+     path-addressable and classifiable `:sensitive` — but placeholders splice only
+     at an event vector's top level, never nested in a map. So the password field's
+     controlled handler is a synchronous `ui/event` that reads the native value and
+     returns the map-payload vector; at a controlled site a `ui/event` returning a
+     vector rides the same synchronous door as a literal vector handler."
+  (:require [re-frame.ui :as ui :refer [defview sub]]))
+
+(defview login-page
+  "Login page — a pure function of subs. Submit fires the credential-owning
+   `:auth.login-form/submit`; the machine + reply events own everything after."
+  []
+  (let [draft       (sub [:auth.login-form/draft])
+        submitting? (sub [:auth/submitting?])
+        err         (sub [:auth/error])]
+    [:div.auth-page {:data-testid "login-page"}
+     [:div.container.page
+      [:div.row
+       [:div.col-md-6.offset-md-3.col-xs-12
+        [:h1.text-xs-center "Sign in"]
+        [:p.text-xs-center
+         [ui/route-link {:to :realworld.auth/register} "Need an account?"]]
+        (when err [:ul.error-messages [:li err]])
+        [:form
+         {:data-testid "login-form"
+          :on-submit {:event [:auth.login-form/submit] :prevent-default true}}
+         [:fieldset
+          [:fieldset.form-group
+           [:input.form-control.form-control-lg
+            {:type "email" :name "email" :data-testid "login-email" :placeholder "Email"
+             :value (:email draft) :disabled submitting?
+             :on-input [:auth.login-form/edit-field :email :rf.ui/value]}]]
+          [:fieldset.form-group
+           [:input.form-control.form-control-lg
+            {:type "password" :name "password" :data-testid "login-password" :placeholder "Password"
+             :value (:password draft) :disabled submitting?
+             ;; Map-payload password edit: read the live value in a ui/event and
+             ;; return the classified map vector; the co-present literal :value
+             ;; keeps it on the synchronous controlled door.
+             :on-input (ui/event [e] [:auth.login-form/edit-password {:value (.. e -target -value)}])}]]
+          [:button.btn.btn-lg.btn-primary.pull-xs-right
+           {:type "submit" :data-testid "login-submit" :disabled submitting?}
+           (if submitting? "Signing in…" "Sign in")]]]]]]]))
+
+(defview register-page
+  "Register page — a pure function of subs. Shares `:auth/session-established`
+   with login: both successes store the session and bounce the same way."
+  []
+  (let [draft       (sub [:auth.register-form/draft])
+        submitting? (sub [:auth/submitting?])
+        err         (sub [:auth/error])]
+    [:div.auth-page {:data-testid "register-page"}
+     [:div.container.page
+      [:div.row
+       [:div.col-md-6.offset-md-3.col-xs-12
+        [:h1.text-xs-center "Sign up"]
+        [:p.text-xs-center
+         [ui/route-link {:to :realworld.auth/login} "Have an account?"]]
+        (when err [:ul.error-messages [:li err]])
+        [:form
+         {:data-testid "register-form"
+          :on-submit {:event [:auth.register-form/submit] :prevent-default true}}
+         [:fieldset
+          [:fieldset.form-group
+           [:input.form-control.form-control-lg
+            {:type "text" :name "username" :data-testid "register-username" :placeholder "Username"
+             :value (:username draft) :disabled submitting?
+             :on-input [:auth.register-form/edit-field :username :rf.ui/value]}]]
+          [:fieldset.form-group
+           [:input.form-control.form-control-lg
+            {:type "email" :name "email" :data-testid "register-email" :placeholder "Email"
+             :value (:email draft) :disabled submitting?
+             :on-input [:auth.register-form/edit-field :email :rf.ui/value]}]]
+          [:fieldset.form-group
+           [:input.form-control.form-control-lg
+            {:type "password" :name "password" :data-testid "register-password" :placeholder "Password"
+             :value (:password draft) :disabled submitting?
+             :on-input (ui/event [e] [:auth.register-form/edit-password {:value (.. e -target -value)}])}]]
+          [:button.btn.btn-lg.btn-primary.pull-xs-right
+           {:type "submit" :data-testid "register-submit" :disabled submitting?}
+           (if submitting? "Signing up…" "Sign up")]]]]]]]))

--- a/examples/real-apps/realworld_resources/ui_core.cljs
+++ b/examples/real-apps/realworld_resources/ui_core.cljs
@@ -1,0 +1,183 @@
+(ns realworld-resources.ui-core
+  "Entry point for the re-frame.ui variant of the RealWorld (Conduit) example —
+   the SAME app as `realworld-resources.core`, authored ENTIRELY on the
+   re-frame.ui COMPILED-VIEW substrate (`ui/defview` + `ui/mount`) instead of the
+   stock-Reagent `reg-view` path. Booted by shadow build `:examples/realworld-
+   resources-ui`; the Reagent arm (`realworld-resources.core`, build
+   `:examples/realworld-resources`) is retained untouched alongside.
+
+   THE SPLIT THIS FILE MAKES CONCRETE. Everything BELOW the view layer is
+   substrate-free re-frame2 dataflow — plain `reg-event` / `reg-sub` /
+   `reg-resource` / `reg-mutation` / `reg-route` / `reg-machine` / `reg-flow` — so
+   the ui variant SHARES it verbatim by requiring the same feature namespaces
+   (`resources`, `mutations`, `routing`, `scope`, `schema`, `http`, and the
+   dataflow that lives beside the Reagent views in `views` / `auth` / `settings` /
+   `article-editor`). Those `reg-view` definitions load inert (they are never
+   mounted here); the ui arm mounts its OWN `ui/defview` tree from
+   `realworld-resources.ui-views` / `.ui-auth` / `.ui-settings` / `.ui-editor`.
+   Nothing is deduplicated and nothing Reagent is removed — the ui arm is purely
+   additive (adapter disposition 2026-07-17).
+
+   WHAT THIS NAMESPACE OWNS (the shell + boot, re-authored for the compiled-view
+   root): the two boot events (`:auth/classify-token`, `:app/initialise`), the
+   frame-wide bearer-auth HTTP interceptor, the compiled app-shell root view, and
+   the `ui/mount` that stands up the re-frame.ui root. It is the compiled-view
+   counterpart of `realworld-resources.core`'s Reagent shell + `rdc/render`."
+  (:require [re-frame.core :as rf]
+            [re-frame.ui :as ui :refer [defview sub]]
+            ;; Managed HTTP — the one built-in transport both resources and
+            ;; mutations lower onto.
+            [re-frame.http.managed]
+            ;; The canned-stub fxs the demo backend leans on.
+            [re-frame.http.test-support]
+            ;; The resources + mutations runtime.
+            [re-frame.resources]
+            ;; Routing + machines. Loading routing unlocks the `:resources` route
+            ;; key; the auth machine needs machines.
+            [re-frame.routing]
+            [re-frame.machines]
+            ;; --- shared substrate-free dataflow (required for its registrations;
+            ;;     the Reagent views these files also carry load inert) ----------
+            [realworld-resources.schema]
+            [realworld-resources.scope]
+            [realworld-resources.http :as rh]
+            [realworld-resources.resources]
+            [realworld-resources.mutations]
+            [realworld-resources.routing :as routing]
+            [realworld-resources.auth]
+            [realworld-resources.settings]
+            [realworld-resources.article-editor]
+            [realworld-resources.views]
+            ;; --- the compiled-view (ui/defview) layer -----------------------
+            [realworld-resources.ui-views :as views]
+            [realworld-resources.ui-auth :as auth]
+            [realworld-resources.ui-settings :as settings]
+            [realworld-resources.ui-editor :as editor]))
+
+;; ============================================================================
+;; INITIALISATION  (shell/boot dataflow — the compiled-view counterpart of
+;; realworld-resources.core's boot events; substrate-independent bodies)
+;; ============================================================================
+
+(rf/reg-event :app/initialise
+  {:doc "App boot. Seeds the two form drafts and registers the editor's
+         `:editor/can-submit?` flow once. Session restore rides its own
+         `:initial-events` step (`:auth/initialise`); the page reads ride the
+         route's `:resources` metadata on the first URL→route sync."}
+  (fn [_ _]
+    {:fx [[:dispatch [:auth.login-form/initialise]]
+          [:dispatch [:auth.register-form/initialise]]
+          [:dispatch [:editor/register-flow]]]}))
+
+(rf/reg-event :auth/classify-token
+  {:doc "Marks the durable JWT path [:auth :token] as sensitive, at frame
+         creation — so the raw token is redacted from any capture, SSR payload,
+         or trace while on-box handlers still read the live value."}
+  (fn [{:keys [db]} _]
+    {:db db :sensitive [[:auth :token]]}))
+
+;; ============================================================================
+;; BEARER-AUTH HTTP INTERCEPTOR
+;; ============================================================================
+;;
+;; One `:before` fn stamps `Authorization: Token <jwt>` on every outbound
+;; managed-HTTP request — the route-caused reads, every write, and the
+;; session-restore `GET /user` — reading the token from the CARRIED frame (so the
+;; header follows a renamed / multi-frame mount) and passing the request through
+;; untouched when there is no token. Substrate-independent: resources and
+;; mutations lower onto `:rf.http/managed` regardless of the view layer.
+(defn bearer-auth-interceptor [ctx]
+  (let [token (some-> (rf/app-db-value (:frame ctx))
+                      :auth :token)]
+    (cond-> ctx
+      token (assoc-in [:request :headers "Authorization"]
+                      (str "Token " token)))))
+
+;; ============================================================================
+;; APP-SHELL ROOT VIEW  (compiled)
+;; ============================================================================
+
+(defview root-view
+  "The compiled app shell: header, the unsaved-changes dialog, the route switch,
+   and the footer. While a cold-boot session restore is in flight the viewer is
+   genuinely unknown, so the viewer-scoped route reads would raise — defer the
+   route page for that one brief window and show a 'restoring session' state."
+  []
+  [:div.app
+   [views/header]
+   [views/pending-nav-dialog]
+   (if (sub [:auth/viewer-resolving?])
+     [:div.container.page {:data-testid "session-restoring"}
+      [:p "Restoring your session…"]]
+     (case (sub [:rf.route/id])
+       :realworld/home              [views/home-page]
+       :realworld/home-tag          [views/home-page]
+       :realworld.auth/login        [auth/login-page]
+       :realworld.auth/register     [auth/register-page]
+       :realworld.article/show      [views/article-page]
+       :realworld.editor/new        [editor/editor-page]
+       :realworld.editor/edit       [editor/editor-page]
+       :realworld.profile/show      [views/profile-page]
+       :realworld.profile/favorites [views/profile-page]
+       :realworld.user/settings     [settings/settings-page]
+       [views/not-found-page]))
+   [views/footer]])
+
+;; ============================================================================
+;; window.__conduit_debug__  — CONFORMANCE-CONTRACT SURFACE (not a re-frame2
+;; pattern; the external RealWorld suite may read it — see realworld-resources.core)
+;; ============================================================================
+
+(defn- install-conduit-debug! [frame-id]
+  (when (exists? js/window)
+    (set! (.-__conduit_debug__ js/window)
+          #js {:getToken       (fn [] (some-> (rf/app-db-value frame-id) :auth :token))
+               :getAuthState   (fn [] (name (if (some-> (rf/app-db-value frame-id) :auth :user)
+                                              :authed :anonymous)))
+               :getCurrentUser (fn [] (clj->js (some-> (rf/app-db-value frame-id) :auth :user)))})))
+
+;; ============================================================================
+;; MOUNT  (a re-frame.ui compiled root — the point of this variant)
+;; ============================================================================
+
+;; The frame id. `ui/frame-root` requires a LITERAL keyword here (plans are
+;; static identity), so it is written inline in the root form below; this def is
+;; the value the post-mount listener installs reference.
+(def app-frame :rf/default)
+
+(defn ^:export run []
+  ;; ONE adapter at boot: the re-frame.ui compiled-view substrate (not the
+  ;; Reagent adapter). This is what makes the mounted `ui/defview` tree the app's
+  ;; real, running root.
+  (rf/init! ui/adapter)
+  ;; Register the frame-wide bearer-auth interceptor before the frame's
+  ;; `:initial-events` dispatch — session restore fires an authenticated
+  ;; `GET /user` the moment the JWT hydrates, so the header must be wired first.
+  (rf/with-frame app-frame
+    (rf/reg-http-interceptor :realworld/bearer-auth
+                             {:before bearer-auth-interceptor}))
+  ;; The one-shot compiled mount: `ui/frame-root` (top-region ENSURE plan) creates
+  ;; + configures + seeds the URL-bound frame at preflight — `:url-bound? true` so
+  ;; it owns the URL and does the first URL→route sync itself (which fires the
+  ;; route's `:resources` ensures), the auth-guard interceptor, the demo backend
+  ;; `:fx-overrides`, and the ordered `:initial-events` — then `ui/mount` renders
+  ;; the compiled `root-view` into #app. IDEMPOTENT per root: a hot reload finds
+  ;; the frame live and reuses it, so durable app-db survives.
+  (ui/mount
+   [ui/frame-root {:id             :rf/default
+                   :doc            "RealWorld-on-resources demo frame (re-frame.ui variant)."
+                   :url-bound?     true
+                   :url-strategy   routing/url-strategy
+                   :interceptors   [:realworld-resources.routing/auth-guard]
+                   :fx-overrides   {:rf.http/managed :realworld-resources.demo/http-stub}
+                   :initial-events [[:auth/classify-token]
+                                    [:auth/initialise]
+                                    [:app/initialise]]}
+    [root-view]]
+   (js/document.getElementById "app"))
+  ;; The frame is now live and session-seeded (and has already synced its first
+  ;; route). Install ongoing listeners AFTER the mount that created the frame.
+  ;; Focus/reconnect revalidation refetches active+stale reads; idempotent.
+  (rf/install-revalidation-listeners! app-frame)
+  ;; The conformance surface — NOT a re-frame2 pattern (see install-conduit-debug!).
+  (install-conduit-debug! app-frame))

--- a/examples/real-apps/realworld_resources/ui_settings.cljs
+++ b/examples/real-apps/realworld_resources/ui_settings.cljs
@@ -1,0 +1,75 @@
+(ns realworld-resources.ui-settings
+  "The user-settings page, rendered in NATIVE re-frame.ui (`ui/defview`) — the
+   compiled-view counterpart of the Reagent `settings-page` in
+   `realworld-resources.settings`.
+
+   Rendering tier only. Updating settings is a WRITE, so it is the
+   `:realworld/update-settings` mutation; the form fires `:rf.mutation/execute`
+   and watches its instance through `[:rf/mutation {:instance …}]`
+   (`:pending?` / `:error?`), and the success continuation is the mutation's
+   `:reply-to [:settings/replied]` target. All of that dataflow lives in
+   `realworld-resources.settings` and is UNCHANGED and shared; this view reaches
+   it by keyword. The password field carries its keystrokes on a classified map
+   payload, so its controlled handler is a synchronous `ui/event` (placeholders
+   never splice into a map); the other fields ride the `:rf.ui/value` placeholder."
+  (:require [re-frame.ui :as ui :refer [defview sub]]
+            [realworld-resources.http :as rh]))
+
+;; The one stable instance id the settings submission watches — the same value
+;; `realworld-resources.settings` declares (`settings-instance`). Kept as a local
+;; literal so this view requires nothing from the `.cljs` dataflow tier.
+(def ^:private settings-instance :settings/save)
+
+(defview settings-page
+  "The settings form — a pure function of subs that never dispatches out of band.
+   Submit fires the update-settings mutation; the success continuation is the
+   mutation's `:reply-to` target, so this view needs no off-render reaction."
+  []
+  (let [draft    (sub [:settings/draft])
+        save     (sub [:rf/mutation {:instance settings-instance}])
+        pending? (:pending? save)]
+    [:div.settings-page
+     [:div.container.page
+      [:div.row
+       [:div.col-md-6.offset-md-3.col-xs-12
+        [:h1.text-xs-center "Your Settings"]
+        (when (:error? save)
+          [:ul.error-messages {:data-testid "settings-error"}
+           [:li (rh/failure->message (:error save))]])
+        [:form
+         {:data-testid "settings-form"
+          :on-submit {:event [:settings/submit] :prevent-default true}}
+         [:fieldset
+          [:fieldset.form-group
+           [:input.form-control
+            {:type "text" :name "image" :placeholder "URL of profile picture"
+             :value (:image draft) :disabled pending?
+             :on-input [:settings/edit-field :image :rf.ui/value]}]]
+          [:fieldset.form-group
+           [:input.form-control.form-control-lg
+            {:type "text" :name "username" :placeholder "Username" :data-testid "settings-username"
+             :value (:username draft) :disabled pending?
+             :on-input [:settings/edit-field :username :rf.ui/value]}]]
+          [:fieldset.form-group
+           [:textarea.form-control.form-control-lg
+            {:rows 8 :name "bio" :placeholder "Short bio about you" :data-testid "settings-bio"
+             :value (:bio draft) :disabled pending?
+             :on-input [:settings/edit-field :bio :rf.ui/value]}]]
+          [:fieldset.form-group
+           [:input.form-control.form-control-lg
+            {:type "email" :name "email" :placeholder "Email"
+             :value (:email draft) :disabled pending?
+             :on-input [:settings/edit-field :email :rf.ui/value]}]]
+          [:fieldset.form-group
+           [:input.form-control.form-control-lg
+            {:type "password" :name "password" :placeholder "New Password"
+             :value (:password draft) :disabled pending?
+             :on-input (ui/event [e] [:settings/edit-password {:value (.. e -target -value)}])}]]
+          [:button.btn.btn-lg.btn-primary.pull-xs-right
+           {:type "submit" :data-testid "settings-submit" :disabled pending?}
+           (if pending? "Updating…" "Update Settings")]]]
+        [:hr]
+        [:button.btn.btn-outline-danger
+         {:type "button" :data-testid "logout-button"
+          :on-click [:auth/flow [:auth/logout]]}
+         "Or click here to logout"]]]]]))

--- a/examples/real-apps/realworld_resources/ui_views.cljs
+++ b/examples/real-apps/realworld_resources/ui_views.cljs
@@ -1,0 +1,548 @@
+(ns realworld-resources.ui-views
+  "The passive pages + shell chrome for the RealWorld (Conduit) example, rendered
+   in NATIVE re-frame.ui (`ui/defview`) — the compiled-view counterpart of the
+   Reagent `realworld-resources.views` (plus the header / footer / dialog chrome
+   that lived in `realworld-resources.core`).
+
+   Rendering tier only. Every read is a passive `(sub [:rf.resource/* …])` /
+   `(sub [:rf/mutation …])`; every write is a committed event vector (a literal
+   `[:event …]`, a `{:event … :prevent-default true}` options map for an anchor /
+   form that must not let the browser navigate, or a `ui/event` when the live
+   native value is needed). The DATAFLOW — the `:home/*` / `:ui/*` /
+   `:comment-form/*` / `:profile/*` events + subs — lives in
+   `realworld-resources.views` and is UNCHANGED and shared; these views reach it by
+   keyword. No view ever fetches; the route's `:resources` metadata causes the
+   load, and the view renders whatever the cache already holds.
+
+   Two compiled-view idioms recur and are worth naming once:
+
+   - **Dynamic lists render a KEYED CHILD VIEW in `for` child position.** A `for`
+     sits directly in a parent element's child position (not `into`, which the
+     compiler cannot see), and each row is an internal `defview` call carrying
+     `:key`. A row whose handler needs a per-row value (a page number, a tag)
+     passes that value as a PROP to the keyed child — a handler may not capture a
+     `for` binding (per-row committed slots need per-row instances), so the child
+     view is where the handler reads it.
+
+   - **Resource status is one canonical `cond`.** `:loading?` → skeleton;
+     `:error` without data → error; otherwise render `:data`, plus a quiet
+     refresh / keep-previous hint. The view never invents stale-while-revalidate;
+     the resource state carries it."
+  (:require ["react" :as react]
+            [re-frame.ui :as ui :refer [defview sub]]
+            [realworld-resources.http :as rh]
+            [realworld-shared.avatar :as avatar]
+            [realworld-shared.markdown :as md]))
+
+;; ============================================================================
+;; APP-SHELL CHROME — header / footer / dialog / not-found
+;; ============================================================================
+
+(defview header
+  "The Conduit navbar. Route-links for Home / New Article / Settings / the user's
+   own profile (with avatar) when signed in, or Sign in / Sign up when not."
+  []
+  (let [authed? (sub [:auth/authenticated?])
+        user    (sub [:auth/user])]
+    [:nav.navbar.navbar-light
+     [:div.container
+      [ui/route-link {:to :realworld/home :class "navbar-brand"} "conduit"]
+      [:ul.nav.navbar-nav.pull-xs-right
+       [:li.nav-item [ui/route-link {:to :realworld/home :class "nav-link"} "Home"]]
+       (if authed?
+         [:<>
+          [:li.nav-item
+           [ui/route-link {:to :realworld.editor/new :class "nav-link" :data-testid "nav-new-article"}
+            [:i.ion-compose] " New Article"]]
+          [:li.nav-item
+           [ui/route-link {:to :realworld.user/settings :class "nav-link" :data-testid "nav-settings"}
+            [:i.ion-gear-a] " Settings"]]
+          [:li.nav-item
+           [ui/route-link {:to :realworld.profile/show :params {:username (:username user)}
+                           :class "nav-link" :data-testid "nav-username"}
+            [:img.user-pic {:src (avatar/avatar-src (:image user)) :alt ""}]
+            " " (:username user)]]
+          [:li.nav-item
+           [:a.nav-link {:data-testid "nav-logout" :href "#"
+                         :on-click {:event [:auth/flow [:auth/logout]] :prevent-default true}}
+            "Logout"]]]
+         [:<>
+          [:li.nav-item [ui/route-link {:to :realworld.auth/login :class "nav-link" :data-testid "nav-signin"} "Sign in"]]
+          [:li.nav-item [ui/route-link {:to :realworld.auth/register :class "nav-link" :data-testid "nav-signup"} "Sign up"]]])]]]))
+
+(defview footer
+  []
+  [:footer
+   [:div.container
+    [ui/route-link {:to :realworld/home :class "logo-font"} "conduit"]
+    [:span.attribution "An interactive learning project from Thinkster."
+     " Code & design licensed under MIT."]]])
+
+(defview pending-nav-dialog
+  "The 'you have unsaved changes' dialog. Appears when a `:can-leave` guard blocks
+   a navigation (the editor refusing to discard a dirty draft). Reads the blocked
+   navigation off `:rf/pending-navigation`; the buttons wave it through or call it
+   off. Renders nothing when there is no pending navigation."
+  []
+  (let [pending (sub [:rf/pending-navigation])
+        id      (:id pending)]
+    [:<>
+     (when pending
+       [:div.pending-nav-overlay {:data-testid "pending-nav-dialog"}
+        [:div.pending-nav-dialog
+         [:p (or (:reason pending) "You have unsaved changes. Leave anyway?")]
+         [:button {:data-testid "pending-nav-discard"
+                   :on-click [:rf.route/continue id]}
+          "Discard changes"]
+         [:button {:data-testid "pending-nav-stay"
+                   :on-click [:rf.route/cancel id]}
+          "Stay"]]])]))
+
+(defview not-found-page
+  []
+  [:div.not-found-page
+   [:h1 "Page not found"]
+   [ui/route-link {:to :realworld/home} "Home"]])
+
+;; ============================================================================
+;; ARTICLE CARD (shared across home + profile lists)
+;; ============================================================================
+
+(defview article-preview
+  "A single article card — a keyed row in a list. Its favourite button is
+   optimistic: the heart + count already show the click (the `:optimistic-tags`
+   patched the cached article before the request left), and `:optimistic?` off the
+   mutation state drives a subtle in-flight cue. Not disabled while pending — the
+   user is already looking at their change."
+  [{:keys [article]}]
+  (let [{:keys [slug title description createdAt favoritesCount favorited author tagList]} article
+        fav-state (sub [:rf/mutation {:instance [:favorite slug]}])]
+    [:div.article-preview {:data-testid (str "article-preview-" slug)}
+     [:div.article-meta
+      [ui/route-link {:to :realworld.profile/show :params {:username (:username author)}}
+       [:img.user-pic {:src (avatar/avatar-src (:image author)) :alt ""}]]
+      [:div.info
+       [ui/route-link {:to :realworld.profile/show :params {:username (:username author)} :class "author"}
+        (:username author)]
+       [:span.date createdAt]]
+      [:button.btn.btn-outline-primary.btn-sm.pull-xs-right
+       {:type "button"
+        :data-testid (str "favorite-" slug)
+        :class (cond-> ""
+                 favorited                (str " active")
+                 (:optimistic? fav-state) (str " optimistic"))
+        :on-click [:ui/favorite slug favorited]}
+       [:i.ion-heart] " "
+       [:span {:data-testid (str "favorites-count-" slug)} favoritesCount]]]
+     [ui/route-link {:to :realworld.article/show :params {:slug slug}
+                     :class "preview-link" :data-testid (str "article-link-" slug)}
+      [:h1 title]
+      [:p description]
+      [:span "Read more..."]
+      [:ul.tag-list
+       (for [tag tagList]
+         [:li.tag-default.tag-pill.tag-outline {:key tag} tag])]]]))
+
+;; ============================================================================
+;; PAGINATION — official Conduit shape (numbered 1-indexed pages)
+;; ============================================================================
+
+(defview page-link
+  "One numbered pagination link — a keyed row. `on-page` is the navigation event
+   id (`:home/go-to-page` / `:profile/go-to-page`) threaded through as a prop, so
+   the click builds `[on-page page]` in a `ui/event` (the row value is a prop, not
+   a captured `for` binding). preventDefault keeps the `href=\"#\"` from jumping."
+  [{:keys [page current-page on-page]}]
+  [:li.page-item {:class (when (= page current-page) "active")}
+   [:a.page-link {:href "#" :data-testid (str "page-" page)
+                  :on-click (ui/event [e] (.preventDefault e) [on-page page])}
+    (str page)]])
+
+(defview pagination
+  "Official-style numbered pagination. `:articles-count` is the server total,
+   `:current-page` is 1-indexed, and `:on-page` is the navigation event id fired
+   with a page number. Renders nothing when there is only one page."
+  [{:keys [articles-count current-page on-page]}]
+  (let [total-pages (rh/page-count articles-count)]
+    [:<>
+     (when (> total-pages 1)
+       [:nav
+        [:ul.pagination {:data-testid "pagination"}
+         (for [p (range 1 (inc total-pages))]
+           [page-link {:key p :page p :current-page current-page :on-page on-page}])]])]))
+
+(defview article-list
+  "Render a list-resource state: skeleton / error / list, with a background-refresh
+   indicator + warning, the keep-previous placeholder, and — when `:articles-count`
+   and `:on-page` are supplied — numbered pagination. While a new page/filter key
+   first-loads, `:previous?` + `:previous-data` keep the prior page on screen (no
+   skeleton flash)."
+  [{:keys [state empty-msg current-page on-page]}]
+  (cond
+    (and (:loading? state) (not (:previous? state)))
+    [:div.article-preview {:data-testid "list-skeleton"} "Loading articles…"]
+
+    (and (:error state) (not (:has-data? state)) (not (:previous? state)))
+    [:div.article-preview.error {:data-testid "list-error"}
+     (str "Couldn't load articles: " (rh/failure->message (:error state)))]
+
+    :else
+    (let [data           (or (:data state) (:previous-data state))
+          articles       (:articles data)
+          articles-count (:articlesCount data)]
+      [:<>
+       (when (:previous? state)
+         [:div.refresh-indicator {:data-testid "list-keeping-previous"} "Loading next page…"])
+       (when (:fetching? state)
+         [:div.refresh-indicator {:data-testid "list-refreshing"} "Refreshing…"])
+       (when (:refresh-error state)
+         [:div.refresh-warn {:data-testid "list-refresh-warn"} "Refresh failed; showing last-known data."])
+       (if (seq articles)
+         [:div {:data-testid "article-list"}
+          (for [a articles]
+            [article-preview {:key (:slug a) :article a}])]
+         [:div.article-preview.empty-feed-message {:data-testid "list-empty"}
+          (or empty-msg "No articles are here… yet.")])
+       (when (and on-page articles-count)
+         [pagination {:articles-count articles-count
+                      :current-page   (or current-page 1)
+                      :on-page        on-page}])])))
+
+;; ============================================================================
+;; HOME PAGE
+;; ============================================================================
+
+(defview sidebar-tag
+  "One popular-tag pill — a keyed row. `tag` is its own prop, so the
+   apply-tag handler reads it without capturing a `for` binding."
+  [{:keys [tag]}]
+  [:a.tag-pill.tag-default {:href "#" :data-testid (str "tag-" tag)
+                            :on-click {:event [:home/apply-tag tag] :prevent-default true}}
+   tag])
+
+(defview home-page
+  "The home page — a pure function of subs. The personalised feed reads through
+   the named `{:from-db :realworld/session}` scope resolver: the subscription
+   resolves its own scope and re-keys reactively across login / logout. A
+   favourite shows up in Your Feed via the mutation's own session-scoped
+   invalidation descriptor — no off-render reaction, no app-level feed patching."
+  []
+  (let [authed?      (sub [:auth/authenticated?])
+        your-feed?   (sub [:home/your-feed?])
+        selected-tag (sub [:home/selected-tag])
+        page         (sub [:home/page])
+        tags-state   (sub [:rf/resource {:resource :realworld/tags :params {}}])
+        list-state   (sub [:rf/resource {:resource :realworld/articles
+                                         :params  {:tag selected-tag :page page}}])
+        feed-state   (when authed?
+                       (sub [:rf/resource {:resource :realworld/feed :params {:page page}}]))]
+    [:div.home-page
+     [:div.banner [:div.container [:h1.logo-font "conduit"] [:p "A place to share your knowledge."]]]
+     [:div.container.page
+      [:div.row
+       [:div.col-md-9
+        [:div.feed-toggle
+         [:ul.nav.nav-pills.outline-active
+          (when authed?
+            [:li.nav-item
+             [:a.nav-link {:href "#" :data-testid "your-feed-tab"
+                           :class (when your-feed? "active")
+                           :on-click {:event [:home/show-your-feed] :prevent-default true}}
+              "Your Feed"]])
+          [:li.nav-item
+           [:a.nav-link {:href "#" :data-testid "global-feed-tab"
+                         :class (when (not your-feed?) "active")
+                         :on-click {:event [:home/show-global-feed] :prevent-default true}}
+            "Global Feed"]]
+          (when selected-tag
+            [:li.nav-item
+             [:a.nav-link.active {:href "#" :data-testid "active-tag"
+                                  :on-click {:event [:home/clear-tag] :prevent-default true}}
+              [:i.ion-pound] " " selected-tag]])]]
+        (if (and authed? your-feed?)
+          [article-list {:state feed-state :empty-msg "Your feed is empty — follow some authors."
+                         :current-page page :on-page :home/go-to-page}]
+          [article-list {:state list-state
+                         :current-page page :on-page :home/go-to-page}])]
+       [:div.col-md-3
+        [:div.sidebar
+         [:p "Popular Tags"]
+         (if (:has-data? tags-state)
+           [:div.tag-list {:data-testid "tag-list"}
+            (for [tag (:tags (:data tags-state))]
+              [sidebar-tag {:key tag :tag tag}])]
+           [:div.tag-list {:data-testid "tags-loading"} "Loading tags…"])]]]]]))
+
+;; ============================================================================
+;; ARTICLE DETAIL + COMMENTS
+;; ============================================================================
+
+;; ----------------------------------------------------------------------------
+;; ARTICLE BODY — the one genuinely runtime-shaped subtree, crossed via ui/raw
+;; ----------------------------------------------------------------------------
+;;
+;; `md/render` (realworld-shared.markdown) emits sanitized CommonMark as HICCUP
+;; DATA — never raw HTML, so React escapes all text (no dangerouslySetInnerHTML).
+;; re-frame.ui compiles views and deliberately will NOT interpret a runtime hiccup
+;; vector as a template ("hiccup is compiled, not interpreted"). So the article
+;; body — the single place in the app whose markup shape is decided at runtime —
+;; crosses into the compiled view through the sanctioned `ui/raw` HOST-ELEMENT
+;; door: this interpreter turns the sanitized hiccup DATA into real React elements
+;; (with every text run a React child), preserving the renderer's escaping
+;; guarantee across the boundary.
+
+(def ^:private md-attr-renames
+  "The handful of HTML→React attribute spellings CommonMark output can carry."
+  {:class :className :for :htmlFor :colspan :colSpan :rowspan :rowSpan})
+
+(defn- md-attrs->js [attrs]
+  (clj->js (persistent!
+            (reduce-kv (fn [m k v] (assoc! m (get md-attr-renames k k) v))
+                       (transient {}) (or attrs {})))))
+
+(defn hiccup->element
+  "Sanitized markdown hiccup DATA → a React element for `ui/raw`. Text runs stay
+   React text children (escaped by React), so the markdown renderer's no-raw-HTML
+   guarantee holds across the boundary."
+  [node]
+  (cond
+    (string? node) node
+    (number? node) node
+    (nil? node)    nil
+    (seq? node)    (apply react/createElement react/Fragment #js {}
+                          (keep hiccup->element node))
+    (vector? node)
+    (let [tag        (nth node 0)
+          has-attrs? (map? (nth node 1 nil))
+          attrs      (when has-attrs? (nth node 1))
+          children   (if has-attrs? (subvec node 2) (subvec node 1))]
+      (apply react/createElement
+             (if (= :<> tag) react/Fragment (name tag))
+             (md-attrs->js attrs)
+             (keep hiccup->element children)))
+    :else (str node)))
+
+(defview comment-card
+  "One comment — a keyed row. The delete control shows only for the author's own
+   comments; `slug` and the comment id are props, so the handler reads them without
+   capturing a `for` binding."
+  [{:keys [comment slug current-user]}]
+  (let [id        (:id comment)
+        mine?     (= (:username current-user) (get-in comment [:author :username]))
+        del-state (sub [:rf/mutation {:instance [:delete-comment slug id]}])]
+    [:div.card {:data-testid (str "comment-card-" id)}
+     [:div.card-block [:p.card-text {:data-testid "comment-body"} (:body comment)]]
+     [:div.card-footer
+      [ui/route-link {:to :realworld.profile/show :params {:username (get-in comment [:author :username])}
+                      :class "comment-author"}
+       [:img.comment-author-img {:src (avatar/avatar-src (get-in comment [:author :image])) :alt ""}] " "
+       (get-in comment [:author :username])]
+      [:span.date-posted (:createdAt comment)]
+      (when mine?
+        [:button.mod-options {:type "button" :data-testid (str "delete-comment-" id)
+                              :aria-label "Delete comment"
+                              :disabled (:pending? del-state)
+                              :on-click [:comment/delete slug id]}
+         [:i.ion-trash-a]])]]))
+
+(defview article-meta
+  "Article-detail contextual controls: the author byline, plus Follow/Unfollow on
+   the author (non-author viewer) or Edit + Delete (the author). A logged-out
+   viewer gets the byline alone. `article` is the unwrapped article map."
+  [{:keys [article del-state]}]
+  (let [author   (:author article)
+        username (:username author)
+        slug     (:slug article)
+        me       (sub [:auth/user])
+        authed?  (sub [:auth/authenticated?])
+        own?     (and me (= (:username me) username))]
+    [:div.article-meta
+     [ui/route-link {:to :realworld.profile/show :params {:username username}}
+      [:img.user-pic {:src (avatar/avatar-src (:image author)) :alt ""}]]
+     [:div.info
+      [ui/route-link {:to :realworld.profile/show :params {:username username} :class "author"}
+       username]
+      [:span.date (:createdAt article)]]
+     (cond
+       own?
+       [:span
+        [ui/route-link {:to :realworld.editor/edit :params {:slug slug}
+                        :class "btn btn-sm btn-outline-secondary"
+                        :data-testid "article-edit"}
+         [:i.ion-edit] " Edit Article"]
+        " "
+        [:button.btn.btn-sm.btn-outline-danger
+         {:type "button" :data-testid "article-delete"
+          :disabled (:pending? del-state)
+          :on-click [:ui/delete-article slug]}
+         [:i.ion-trash-a] " Delete Article"]]
+
+       authed?
+       [:button.btn.btn-sm.btn-outline-secondary
+        {:type "button" :data-testid "article-follow-author"
+         :on-click [:ui/follow-author slug username (:following author)]}
+        [:i.ion-plus-round] " "
+        (if (:following author) "Unfollow " "Follow ") username]
+
+       :else nil)]))
+
+(defview comment-form
+  "The comment composer — shown to a signed-in reader, else a sign-in prompt. A
+   controlled textarea (`:rf.ui/value`) and a submit that preventDefaults."
+  [{:keys [slug current-user]}]
+  (let [post-state (sub [:rf/mutation {:instance [:post-comment slug]}])
+        draft      (sub [:comment-form/body])]
+    (if current-user
+      [:form.card.comment-form
+       {:data-testid "comment-form"
+        :on-submit {:event [:comment-form/submit slug] :prevent-default true}}
+       [:div.card-block
+        [:textarea.form-control {:data-testid "comment-body-input" :rows 3 :placeholder "Write a comment..."
+                                 :value (or draft "") :disabled (:pending? post-state)
+                                 :on-input [:comment-form/edit :rf.ui/value]}]]
+       [:div.card-footer
+        [:button.btn.btn-sm.btn-primary {:type "submit" :data-testid "comment-submit"
+                                         :disabled (:pending? post-state)}
+         (if (:pending? post-state) "Posting…" "Post Comment")]]
+       (when (:error? post-state)
+         [:div.error-messages (rh/failure->message (:error post-state))])]
+      [:p
+       [ui/route-link {:to :realworld.auth/login} "Sign in"] " or "
+       [ui/route-link {:to :realworld.auth/register} "sign up"] " to add comments."])))
+
+(defview article-page
+  "The article-detail page — a pure function of subs. The two settle continuations
+   it needs (navigate-home on delete, re-stale on follow) are the mutations' own
+   `:reply-to` targets in the shared dataflow, so this view holds no off-render
+   reaction."
+  []
+  (let [slug           (:slug (sub [:rf.route/params]))
+        current-user   (sub [:auth/user])
+        article-state  (sub [:rf/resource {:resource :realworld/article :params {:slug slug}}])
+        comments-state (sub [:rf/resource {:resource :realworld/comments :params {:slug slug}}])]
+    [:div.article-page
+     (cond
+       (:loading? article-state)
+       [:div.article-preview {:data-testid "article-skeleton"} "Loading article…"]
+
+       (and (:error article-state) (not (:has-data? article-state)))
+       [:div.article-preview.error {:data-testid "article-error"}
+        (str "Couldn't load article: " (rh/failure->message (:error article-state)))]
+
+       :else
+       (let [article   (:article (:data article-state))
+             {:keys [title description body tagList favoritesCount favorited]} article
+             fav-state (sub [:rf/mutation {:instance [:favorite slug]}])
+             del-state (sub [:rf/mutation {:instance [:delete-article slug]}])]
+         [:<>
+          [:div.banner
+           [:div.container
+            [:h1 {:data-testid "article-title"} title]
+            [:p {:data-testid "article-description"} description]
+            (when (:fetching? article-state)
+              [:span {:data-testid "article-refreshing"} " (refreshing…)"])
+            [:span.article-controls
+             [:button.btn.btn-sm
+              {:type "button" :data-testid "article-favorite"
+               :class (cond-> (if favorited "btn-primary" "btn-outline-primary")
+                        (:optimistic? fav-state) (str " optimistic"))
+               :on-click [:ui/favorite slug favorited]}
+              [:i.ion-heart] " "
+              (if favorited "Unfavorite" "Favorite") " Article "
+              [:span.counter {:data-testid "article-favorites-count"} "(" favoritesCount ")"]]
+             " "
+             [article-meta {:article article :del-state del-state}]]]]
+          [:div.container.page
+           [:div.row.article-content
+            [:div.col-md-12
+             [:div {:data-testid "article-body"}
+              (ui/raw (hiccup->element (md/render body)))]
+             [:ul.tag-list
+              (for [tag tagList]
+                [:li.tag-default.tag-pill.tag-outline {:key tag} tag])]]]
+           [:hr]
+           [:div.article-actions
+            [article-meta {:article article :del-state del-state}]]
+           [:div.row
+            [:div.col-xs-12.col-md-8.offset-md-2
+             [comment-form {:slug slug :current-user current-user}]
+             (cond
+               (:loading? comments-state)
+               [:p {:data-testid "comments-loading"} "Loading comments…"]
+               (and (:error comments-state) (not (:has-data? comments-state)))
+               [:p.error {:data-testid "comments-error"} "Couldn't load comments."]
+               :else
+               [:div {:data-testid "comments-list"}
+                (for [c (:comments (:data comments-state))]
+                  [comment-card {:key (:id c) :comment c :slug slug :current-user current-user}])])]]]]))
+     [:p [ui/route-link {:to :realworld/home :data-testid "back-home"} "← Back to feed"]]]))
+
+;; ============================================================================
+;; PROFILE — two official tabs: My Articles / Favorited Articles
+;; ============================================================================
+
+(defview profile-page
+  "A user's profile banner plus one of two article tabs. The active tab is nothing
+   more than the current route id (`:realworld.profile/show` authored vs
+   `:realworld.profile/favorites`) — there is no tab state in app-db; the view
+   reads the route id to choose which list resource to subscribe to."
+  []
+  (let [username      (:username (sub [:rf.route/params]))
+        favorites?    (sub [:profile/favorites-tab?])
+        page          (sub [:profile/page])
+        current-user  (sub [:auth/user])
+        profile-state (sub [:rf/resource {:resource :realworld/profile :params {:username username}}])
+        list-state    (if favorites?
+                        (sub [:rf/resource {:resource :realworld/favorited-articles
+                                            :params  {:username username :page page}}])
+                        (sub [:rf/resource {:resource :realworld/author-articles
+                                            :params  {:username username :page page}}]))]
+    [:div.profile-page
+     (cond
+       (:loading? profile-state)
+       [:div.article-preview {:data-testid "profile-skeleton"} "Loading profile…"]
+
+       (and (:error profile-state) (not (:has-data? profile-state)))
+       [:div.article-preview.error {:data-testid "profile-error"} "Couldn't load this profile."]
+
+       :else
+       (let [{:keys [bio image following]} (:profile (:data profile-state))
+             profile-username (:username (:profile (:data profile-state)))
+             own?             (= profile-username (:username current-user))
+             follow-state     (sub [:rf/mutation {:instance [:follow profile-username]}])]
+         [:<>
+          [:div.user-info
+           [:div.container
+            [:div.row
+             [:div.col-xs-12.col-md-10.offset-md-1
+              [:img.user-img {:src (avatar/avatar-src image) :alt ""}]
+              [:h4 {:data-testid "profile-username"} profile-username]
+              [:p bio]
+              (when (:fetching? profile-state) [:span {:data-testid "profile-refreshing"} " (refreshing…)"])
+              (when-not own?
+                [:button.btn.btn-sm.btn-outline-secondary.action-btn
+                 {:type "button" :data-testid "follow-button"
+                  :disabled (:pending? follow-state)
+                  :on-click [:ui/follow profile-username following]}
+                 (if following "Unfollow " "Follow ") profile-username])]]]]
+          [:div.container
+           [:div.row
+            [:div.col-xs-12.col-md-10.offset-md-1
+             [:div.articles-toggle
+              [:ul.nav.nav-pills.outline-active
+               [:li.nav-item
+                [ui/route-link {:to :realworld.profile/show :params {:username profile-username}
+                                :class (str "nav-link" (when-not favorites? " active"))
+                                :data-testid "profile-tab-authored"}
+                 "My Articles"]]
+               [:li.nav-item
+                [ui/route-link {:to :realworld.profile/favorites :params {:username profile-username}
+                                :class (str "nav-link" (when favorites? " active"))
+                                :data-testid "profile-tab-favorited"}
+                 "Favorited Articles"]]]]
+             [article-list {:state list-state
+                            :empty-msg (if favorites?
+                                         "No favorited articles are here… yet."
+                                         "No articles here yet.")
+                            :current-page page
+                            :on-page :profile/go-to-page}]]]]]))]))

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -1586,6 +1586,23 @@
    :asset-path "."
    :modules    {:main {:init-fn realworld-resources.core/run}}}
 
+  ;; RealWorld (Conduit) on resources + mutations, authored ENTIRELY on the
+  ;; re-frame.ui COMPILED-VIEW substrate (rf2-nn5s8, S7-entry proof P-1). The
+  ;; ui arm ADDED ALONGSIDE `:examples/realworld-resources` (Reagent) — same
+  ;; substrate-free dataflow (events / subs / resources / mutations / routing /
+  ;; auth machine / flows, shared by require), every VIEW re-authored with
+  ;; `ui/defview` and mounted on a re-frame.ui root via `ui/mount` +
+  ;; `ui/frame-root` (`realworld-resources.ui-core/run`, not the Reagent
+  ;; `.core/run`). The `re-frame.ui` cache-blockers + build-hook are inherited
+  ;; from the top-level `:cache-blockers` / `:build-defaults` (do not duplicate
+  ;; them per build). `realworld-resources.*` resolve via `../examples/real-apps`
+  ;; (already on :source-paths above), so no per-build deps.
+  :examples/realworld-resources-ui
+  {:target     :browser
+   :output-dir "out/examples/realworld-resources-ui"
+   :asset-path "."
+   :modules    {:main {:init-fn realworld-resources.ui-core/run}}}
+
   ;; Pattern-Boot example (rf2-dsm2). Demonstrates the canonical
   ;; re-frame2 application-boot shape: a single :app/boot state
   ;; machine owns the initialisation graph (config → parallel


### PR DESCRIPTION
## What

S7-entry proof **P-1** (rf2-nn5s8, the ruled kill-gate per vxgfnd.99): a COMPLETE
**re-frame.ui** full-app variant of `examples/real-apps/realworld_resources` — the
whole RealWorld (Conduit) app authored on the compiled-view substrate, **alongside**
the existing Reagent arm (retained untouched; adapter disposition 2026-07-17).

The two arms are the *same application*. Everything below the view tier — every
`reg-event` / `reg-sub` / `reg-resource` / `reg-mutation` / `reg-route` /
`reg-machine` / `reg-flow` — is substrate-free and **shared by require** (nothing
deduplicated, nothing removed). Only the view tier is re-authored: every view is a
`ui/defview`, and the app boots a **re-frame.ui root** via `ui/mount` +
`ui/frame-root` (`realworld-resources.ui-core/run`), not the Reagent
`reagent.dom` root.

## Views (all on `ui/defview`)

`ui_core.cljs` — the shell: `root-view` + the `ui/mount` / `ui/frame-root` boot
(`:url-bound?`, the shared base-path `:url-strategy`, the auth-guard
`:interceptors`, the demo backend `:fx-overrides`, ordered `:initial-events`), the
frame-wide bearer-auth HTTP interceptor, and the re-authored boot events.
`ui_views.cljs` — header / footer / unsaved-changes dialog / not-found, home
(feed toggle + tags sidebar + keep-previous list + numbered pagination), article
detail (byline + optimistic favourite + follow/edit/delete + comments), and the
two-tab profile. `ui_auth.cljs` — login / register. `ui_settings.cljs` — settings.
`ui_editor.cljc` — reused as-is (the existing S3 rendition of the editor).

## Idiomatic re-frame.ui

- **Route-owned resources, no atoms, no Form-3.** Views read passively with
  `(sub …)`; the route's `:resources` metadata causes every load. Writes are
  committed event vectors / `{:event … :prevent-default true}` options maps /
  `ui/event` (only where the live native value is needed). Controlled inputs ride
  the `:rf.ui/value` placeholder; the classified password fields use a synchronous
  `ui/event` (a placeholder never splices into a map payload).
- **Keyed child views for dynamic lists** (article cards, pagination, tags,
  comments) — a per-row value a handler needs is threaded as a **prop**, since a
  handler may not capture a `for` binding.
- **The markdown article body crosses via `ui/raw`** — `md/render` emits sanitized
  hiccup DATA, which the substrate deliberately will not interpret as a template,
  so it is converted to a React element (text preserved as React children — no
  `dangerouslySetInnerHTML`) and embedded through the sanctioned `ui/raw` door.
- re-frame.ui's a11y linter drove `:alt` / `:aria-label` additions the Reagent arm
  never had.

## Build wiring (hot-zone, flagged)

Adds one build id — `:examples/realworld-resources-ui`
(`:init-fn realworld-resources.ui-core/run`) — to the top-level
`implementation/shadow-cljs.edn`. This is the only hot-zone touch: **additive**
(a new build id + doc comment), inheriting the top-level re-frame.ui
`:cache-blockers` + build-hook. Disjoint from the live `u53yy.1 S2`
(build/compiler internals) and `g2ytj` (routing/frame.cljc) work; rebased clean on
current `origin/main`.

## Quality gates

- `npx shadow-cljs compile examples/realworld-resources-ui` → **Build completed, 0 warnings** (rerun clean post-rebase).
- `npm run test:cljs` → **Ran 10366 tests / 51226 assertions — 0 failures, 0 errors.**
- `scripts/check_adapter_disposition.py` → green (Reagent/reagent-slim/UIx untouched; nothing removed).
- `scripts/check-no-hardcoded-paths.sh` → green.
- mkdocs not run — no doc under the mkdocs nav is touched (the example README is not in `mkdocs.yml`).

**Live boot note.** A live DOM boot could not be exercised in this worktree (no
browser extension / jsdom available). The clean compile validates the `ui/mount`
literal root form + frame-plan extraction, and the arm reuses the proven Reagent
dataflow verbatim. The live browser run is P-2's (rf2-vvdzx) explicit charter:
Story + Xray green as consumers against this running app.

Do NOT merge — sequences with P-2; P-1 + P-2 + soak open S7.
