### PR TITLE
refactor(build): views → analyzer-map descriptor carrier at compile-finish (rf2-u53yy.1 S2)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -363,20 +363,31 @@
                  :manifest manifest
                  :closed-keys closed-keys
                  :children? children?}]
-    (when-let [{:keys [conflict]}
-               (build/contribute-view-checked!
-                ns-sym [ns-sym vname] view-id [tf hs])]
-      (fail :rf.ui.compile/bad-view-id
-            (str "defview " vname ": view id " (pr-str view-id)
-                 " is already owned by a different defview declaration. "
-                 "Explicit :id overrides must be unique across declarations; "
-                 "give this view a distinct qualified keyword (re-expanding "
-                 "the exact same var remains the HMR replacement path)")
-            {:view vname
-             :id view-id
-             :namespace ns-sym
-             :declaration [ns-sym vname]
-             :existing-declaration conflict}))
+    ;; On a real Shadow build PASS the whole-build views registry is harvested at
+    ;; compile-finish from the disk-cache-durable analyzer-map view descriptors
+    ;; (rf2-u53yy.1 S2) — the same direction S1 took elements — so this macro does
+    ;; NOT contribute a view row to the per-source slice (a warm cache-hit source
+    ;; never re-runs it), and the cross-source view-id uniqueness law runs at
+    ;; compile-finish over the analyzer map (`build/harvest-view-registries`, a
+    ;; compile-finish error is still a build-time error). Off that path (plain-JVM
+    ;; / SSR, REPL — there is no compile-finish analyzer harvest) the macro's own
+    ;; contribution populates the per-source slice and reports a collision here at
+    ;; expansion with the declaration's source coordinates.
+    (when-not (build/shadow-build-pass?)
+      (when-let [{:keys [conflict]}
+                 (build/contribute-view-checked!
+                  ns-sym [ns-sym vname] view-id [tf hs])]
+        (fail :rf.ui.compile/bad-view-id
+              (str "defview " vname ": view id " (pr-str view-id)
+                   " is already owned by a different defview declaration. "
+                   "Explicit :id overrides must be unique across declarations; "
+                   "give this view a distinct qualified keyword (re-expanding "
+                   "the exact same var remains the HMR replacement path)")
+              {:view vname
+               :id view-id
+               :namespace ns-sym
+               :declaration [ns-sym vname]
+               :existing-declaration conflict})))
     ;; Per-view static-render facts for the render-static transitive proof
     ;; (Spec 004C §3 / EP-0034 §2). Keyed per declaring ns like every other
     ;; registry row, so a recompiled / removed source replaces / evicts its

--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -766,6 +766,97 @@
     build-state))
 
 ;; ---------------------------------------------------------------------------
+;; View descriptor carrier (rf2-u53yy.1 S2)
+;;
+;; On the Shadow build path the whole-build `views` / `view-declarations`
+;; registries are NOT populated by the `defview` macro's per-source slice
+;; contribution — a warm cache-hit source never re-runs that macro. Instead each
+;; compiled view stamps its descriptor onto the generated def's analyzer metadata
+;; (`emit_cljs` var-meta: `:rf.ui/view-id` + `:rf.ui/view-digest`). Shadow persists
+;; a compiled namespace's analyzer data to its disk cache and RESTORES it under
+;; `[:compiler-env :cljs.analyzer/namespaces <ns>]` on a cache HIT (the S0 proof,
+;; rf2-u53yy.1.1: exact-EDN round-trip across shadow 3.4.0/3.4.10/3.4.11). At
+;; compile-finish the hook folds the descriptor of EVERY authoritative member —
+;; cached and compiled alike — into the two registries, so a warm source's views
+;; are restored from the cache-durable analyzer map, not re-stamped by a macro.
+;; This is the same decoupling S1 gave elements, at compile-finish (where views
+;; resolve) rather than compile-prepare (elements are the ordering exception).
+;; ---------------------------------------------------------------------------
+
+(defn- analyzer-view-defs
+  "PURE: `[view-id declaration digest]` triples for the compiled views a
+  namespace's restored/fresh analyzer `:defs` carries. A def is a view iff its
+  metadata carries BOTH `:rf.ui/view-id` and `:rf.ui/view-digest` — a bare
+  `(declare ^:rf.ui/view …)` forward declaration carries neither, and the
+  `$render`/`$host_render` helpers carry no view metadata at all. `declaration`
+  is the ruled `[ns var]` pair; `digest` is the `[template-fingerprint
+  hook-signature]` vector the emitter stamped (the same value the macro slice
+  path contributes off the Shadow path)."
+  [ns-sym ns-analyzer-map]
+  (keep (fn [[var-sym def-map]]
+          (let [m (:meta def-map)
+                view-id (:rf.ui/view-id m)
+                digest (:rf.ui/view-digest m)]
+            (when (and view-id digest)
+              [view-id [ns-sym var-sym] digest])))
+        (:defs ns-analyzer-map)))
+
+(defn harvest-view-registries
+  "PURE: fold the analyzer-map view descriptors of every authoritative `members`
+  namespace in `build-state` into per-source registry rows
+  `{source {::views {view-id digest} ::view-declarations {view-id declaration}}}`.
+  Reads `[:compiler-env :cljs.analyzer/namespaces <ns>]` — Shadow's
+  disk-cache-durable carrier (rf2-u53yy.1 S2), present identically for a cache-hit
+  member and a freshly compiled one. The cross-source view-id uniqueness law runs
+  HERE (a compile-finish error is still a build-time error): two DISTINCT
+  declarations claiming one view-id THROW rather than letting merge order pick a
+  winner. The same declaration cannot appear twice — one def, one `:defs` entry —
+  so an `rf=`-style duplicate cannot arise. Members are folded in sorted order so
+  the reported collision evidence is identical under every graph permutation."
+  [build-state members]
+  (let [nss (get-in build-state [:compiler-env :cljs.analyzer/namespaces])
+        seeded (mapcat (fn [ns-sym]
+                         (analyzer-view-defs ns-sym (get nss ns-sym)))
+                       (sort-by str members))
+        conflict (reduce
+                  (fn [owners [view-id declaration _digest]]
+                    (let [prior (get owners view-id)]
+                      (if (and prior (not= prior declaration))
+                        (reduced
+                         {::conflict
+                          {:view-id view-id
+                           :declarations (vec (sort-by str [prior declaration]))}})
+                        (assoc owners view-id declaration))))
+                  {}
+                  seeded)]
+    (when-let [c (::conflict conflict)]
+      (throw
+       (ex-info
+        (str "re-frame.ui found two distinct defview declarations claiming view "
+             "id " (:view-id c) " while harvesting the build's compiled views; "
+             "refusing to publish a merge-order winner. Give each view a distinct "
+             "qualified keyword (re-expanding the exact same var remains the HMR "
+             "replacement path)")
+        {::error ::view-id-conflict
+         :view-id (:view-id c)
+         :declarations (:declarations c)
+         :recovery :reconcile-defview-declarations})))
+    (reduce (fn [regs [view-id declaration digest]]
+              (let [source (first declaration)]
+                (-> regs
+                    (assoc-in [source views view-id] digest)
+                    (assoc-in [source view-declarations view-id] declaration))))
+            {}
+            seeded)))
+
+(defn- merge-registries
+  "PURE: deep-merge two `{source {reg-id {k v}}}` registry maps; the RIGHT map's
+  rows win per `(source, reg-id, k)`. Used to overlay the analyzer-map-harvested
+  view rows onto the slice-derived rows of the other registries."
+  [a b]
+  (merge-with (fn [ra rb] (merge-with merge ra rb)) a b))
+
+;; ---------------------------------------------------------------------------
 ;; Pass boundaries
 ;; ---------------------------------------------------------------------------
 
@@ -904,8 +995,20 @@
     ;; conflict law was enforced there. Carry that finalized manifest onto the
     ;; snapshot beside `:registries`.
     (let [after (-> scratch commit-slice (keep-members (set members)))
+          ;; Views ride the disk-cache-durable analyzer-map carrier on the Shadow
+          ;; path (rf2-u53yy.1 S2). The defview macro contributes NO view row to
+          ;; the slice under a Shadow build pass, so harvest every authoritative
+          ;; member's compiled view descriptors from the analyzer map and overlay
+          ;; them onto the slice-derived rows of the other registries. A cache-hit
+          ;; member contributes its RESTORED descriptor identically to a freshly
+          ;; compiled one, so a warm source's views survive without the macro
+          ;; re-running. (Off the Shadow path — plain-JVM/REPL/tests staging views
+          ;; directly through the slice — the analyzer map is empty and the slice
+          ;; rows carry through unchanged.)
+          view-registries (harvest-view-registries build-state members)
           snapshot {:build-id build-id
-                    :registries (:committed after)
+                    :registries (merge-registries (:committed after)
+                                                  view-registries)
                     :elements (:element-manifest scratch {})
                     :version (inc (long (or (:version accepted) 0)))}]
       {:snapshot snapshot})))

--- a/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc
@@ -983,6 +983,20 @@
                       has-frame-ops? 're-frame.ui.viewcell/render-frame)
         var-meta   (cond-> {:rf.ui/view true
                             :rf.ui/view-id view-id
+                            ;; rf2-u53yy.1 S2: the whole-build view descriptor
+                            ;; rides the def's analyzer metadata. Shadow persists
+                            ;; a compiled namespace's analyzer data to its disk
+                            ;; cache and restores it under
+                            ;; [:compiler-env :cljs.analyzer/namespaces <ns>] on a
+                            ;; cache HIT (S0 proof, rf2-u53yy.1.1), so the build
+                            ;; hook harvests the views registry at compile-finish
+                            ;; from this metadata — present for cached AND compiled
+                            ;; members alike — instead of from a macro-expansion
+                            ;; side effect that a warm cache-hit source never
+                            ;; re-runs. `[template-fingerprint hook-signature]` is
+                            ;; the same digest the macro contributed to the slice.
+                            :rf.ui/view-digest [(:template-fingerprint manifest)
+                                                (:hook-signature manifest)]
                             :rf.ui/children? children?}
                      docstring   (assoc :doc docstring)
                      closed-keys (assoc :rf.ui/closed-prop-keys (vec closed-keys)))]

--- a/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc
@@ -470,6 +470,15 @@
         bind     (:binding-form header)
         var-meta (cond-> {:rf.ui/view true
                           :rf.ui/view-id view-id
+                          ;; Kept byte-identical to the CLJS emitter's view
+                          ;; descriptor (rf2-u53yy.1 S2). On the JVM host the
+                          ;; whole-build view registry still rides the per-source
+                          ;; slice (there is no Shadow disk cache to survive), so
+                          ;; this metadata is not the harvest carrier here; it is
+                          ;; carried for parity so `(meta #'view)` reads the same
+                          ;; descriptor on both hosts.
+                          :rf.ui/view-digest [(:template-fingerprint manifest)
+                                              (:hook-signature manifest)]
                           :rf.ui/children? children?}
                    docstring   (assoc :doc docstring)
                    closed-keys (assoc :rf.ui/closed-prop-keys (vec closed-keys)))]

--- a/implementation/ui/test/re_frame/ui/compiler_build_hook_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_hook_jvm_test.clj
@@ -7,7 +7,6 @@
   optimize/check/flush/watch failure."
   (:require [cljs.env :as cljs-env]
             [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.ui.compiler :as compiler]
             [re-frame.ui.compiler.build :as build]
             [re-frame.ui.compiler.build-hook :as build-hook]
             [re-frame.ui.compiler.root :as root]
@@ -77,14 +76,6 @@
    #(build/contribute! build/descriptors source root-id
                        {:rf.root/schema-version 1 :label label})))
 
-(defn- declare-explicit-view [state source vname view-id template]
-  (in-compiler
-   state
-   #(binding [*ns* (create-ns source)]
-      (compiler/defview*
-       (with-meta (list 'defview vname {:id view-id} [] template) {:line 1})
-       {} vname (list {:id view-id} [] template)))))
-
 (defn- finish
   ([state member-nss] (finish state member-nss (set member-nss)))
   ([state member-nss recompiled-nss]
@@ -117,6 +108,34 @@
 
 (defn- views [state]
   (build/accepted-aggregate build/views state))
+
+;; --- rf2-u53yy.1 S2: views ride the analyzer-map descriptor carrier ---------
+;;
+;; On a real Shadow build PASS the `defview` macro contributes NO view row to the
+;; per-source slice (compiler.cljc gates it on `build/shadow-build-pass?`): a
+;; compiled view's descriptor rides its generated def's analyzer metadata, which
+;; Shadow persists to its disk cache and RESTORES under
+;; [:compiler-env :cljs.analyzer/namespaces <ns> :defs <var> :meta] on a warm hit
+;; (the S0 proof, rf2-u53yy.1.1). `seed-analyzer-view` stamps that carrier exactly
+;; where the analyzer stores it, so the build hook harvests the views registry
+;; from it at compile-finish — for a cache-hit member the macro never re-runs.
+
+(defn- seed-analyzer-view
+  "Stamp a compiled view's descriptor onto `state`'s analyzer map the way Shadow's
+  analyzer stores a `defview`'s generated def metadata (and restores it from the
+  disk cache on a warm hit). `var` is the def name; the ruled declaration is
+  `[source var]`; `digest` is the `[template-fingerprint hook-signature]` vector
+  the emitter stamps."
+  [state source var view-id digest]
+  (assoc-in state
+            [:compiler-env :cljs.analyzer/namespaces source :defs var :meta]
+            {:rf.ui/view true :rf.ui/view-id view-id :rf.ui/view-digest digest}))
+
+(defn- forget-analyzer-ns
+  "Model Shadow re-analyzing `source` from scratch on a recompile: its analyzer
+  `:defs` are rebuilt, so a view removed from the source vanishes from the carrier."
+  [state source]
+  (update-in state [:compiler-env :cljs.analyzer/namespaces] dissoc source))
 
 (deftest hook-declares-only-the-two-compiler-stages
   (is (= #{:compile-prepare :compile-finish}
@@ -219,30 +238,89 @@
     (is (= {:app.b/view ["tf1-b" "hs1-b"]}
            (views without-a)))))
 
-(deftest live-id-collision-fails-but-nonmember-transfer-converges
-  (let [seed (graph-state :app :compile-prepare '#{app.old})
-        old (-> seed
+(deftest view-descriptor-survives-a-cache-hit-via-the-analyzer-map-carrier
+  ;; The S2 analog of the S0 carrier proof (rf2-u53yy.1.1), for REAL view
+  ;; descriptors: a warm cache-hit source's macro never re-runs, yet its view
+  ;; survives because Shadow RESTORED the descriptor onto the analyzer map and the
+  ;; hook harvests the views registry from there — not from a macro side effect.
+  (let [seed (graph-state :app :compile-prepare '#{app.a app.b})
+        ;; COLD: both compiled; each stamps its view descriptor onto its def meta.
+        ;; Nothing is contributed to the slice (the macro is gated on the Shadow
+        ;; path), so a harvested row here proves the analyzer-map carrier is the
+        ;; sole source of the views registry.
+        cold (-> (prepare seed '#{app.a app.b})
+                 (seed-analyzer-view 'app.a 'view :app.a/view ["tf-a" "hs-a"])
+                 (seed-analyzer-view 'app.b 'view :app.b/view ["tf-b" "hs-b"])
+                 (finish '#{app.a app.b}))]
+    (is (= {:app.a/view ["tf-a" "hs-a"] :app.b/view ["tf-b" "hs-b"]} (views cold))
+        "cold: both views are harvested from the analyzer-map carrier")
+    ;; WARM: only app.b recompiles. app.a is a cache HIT — its macro does NOT run
+    ;; (no seed this pass), but Shadow RESTORED its analyzer descriptor, which the
+    ;; threaded build-state carries unchanged. app.a's view must survive from the
+    ;; carrier alone; app.b re-stamps a fresh digest.
+    (let [warm (-> (prepare cold '#{app.a app.b} '#{app.b})
+                   (seed-analyzer-view 'app.b 'view :app.b/view ["tf-b2" "hs-b"])
+                   (finish '#{app.a app.b} '#{app.b}))]
+      (is (= {:app.a/view ["tf-a" "hs-a"]
+              :app.b/view ["tf-b2" "hs-b"]}
+             (views warm))
+          (str "warm: the cache-hit source's view is RESTORED from the analyzer "
+               "map without the macro re-running")))))
+
+(deftest a-removed-view-is-evicted-from-the-analyzer-map-carrier
+  (let [seed (graph-state :app :compile-prepare '#{app.a app.b})
+        both (-> (prepare seed '#{app.a app.b})
+                 (seed-analyzer-view 'app.a 'view :app.a/view ["tf-a" "hs-a"])
+                 (seed-analyzer-view 'app.b 'view :app.b/view ["tf-b" "hs-b"])
+                 (finish '#{app.a app.b}))
+        ;; app.a is recompiled with its defview removed: Shadow re-analyzes it
+        ;; fresh, so its analyzer :defs no longer carry the descriptor. app.b is
+        ;; an untouched cache hit whose descriptor is restored.
+        removed (-> (prepare both '#{app.a app.b} '#{app.a})
+                    (forget-analyzer-ns 'app.a)
+                    (finish '#{app.a app.b} '#{app.a}))]
+    (is (= #{:app.a/view :app.b/view} (set (keys (views both)))))
+    (is (= {:app.b/view ["tf-b" "hs-b"]} (views removed))
+        "a view removed from its recompiled source is evicted from the carrier")))
+
+(deftest cross-source-view-id-collision-fails-at-compile-finish
+  ;; Two DISTINCT defview declarations claiming one view-id fail when the hook
+  ;; harvests the carrier at compile-finish — the cross-source uniqueness law moved
+  ;; there from macro expansion (rf2-u53yy.1 S2); a compile-finish error is still a
+  ;; build-time error.
+  (let [seed (graph-state :app :compile-prepare '#{app.old app.new})
+        collision (-> (prepare seed '#{app.old app.new})
+                      (seed-analyzer-view 'app.old 'card :shared/card ["tf-old" "hs"])
+                      (seed-analyzer-view 'app.new 'card :shared/card ["tf-new" "hs"]))
+        ex (try (finish collision '#{app.old app.new})
+                nil
+                (catch clojure.lang.ExceptionInfo e e))]
+    (is (some? ex) "distinct declarations sharing a view-id must fail the build")
+    (is (= :re-frame.ui.compiler.build/view-id-conflict
+           (:re-frame.ui.compiler.build/error (ex-data ex))))
+    (is (= :shared/card (:view-id (ex-data ex))))
+    (is (= [['app.new 'card] ['app.old 'card]]
+           (:declarations (ex-data ex)))
+        "the collision evidence anchors both declarations, sorted deterministically")))
+
+(deftest a-view-id-transfers-cleanly-to-a-new-owner
+  ;; app.old owned :shared/card; it is deleted and app.new takes the id over. With
+  ;; app.old absent from :build-sources the carrier fold sees only app.new's
+  ;; descriptor, so no collision fires and the new owner publishes its own view
+  ;; identity.
+  (let [old (-> (graph-state :app :compile-prepare '#{app.old})
                 (prepare '#{app.old})
-                (declare-explicit-view 'app.old 'card :shared/card [:div "old"])
+                (seed-analyzer-view 'app.old 'card :shared/card ["tf-old" "hs"])
                 (finish '#{app.old}))
-        ;; app.old is a live cache hit; app.new alone is scheduled and cannot
-        ;; steal its accepted id.
-        collision-state (prepare old '#{app.old app.new} '#{app.new})
-        ex (try
-             (declare-explicit-view collision-state 'app.new 'card
-                                    :shared/card [:div "new"])
-             nil
-             (catch clojure.lang.ExceptionInfo e e))]
-    (is (= :rf.ui.compile/bad-view-id
-           (:rf.ui.compile/error (ex-data ex))))
-    (let [moved (-> old
-                    (prepare '#{app.new})
-                    (declare-explicit-view 'app.new 'card
-                                           :shared/card [:div "new"])
-                    (finish '#{app.new}))]
-      (is (= #{:shared/card} (set (keys (views moved)))))
-      (is (not= (get (views old) :shared/card)
-                (get (views moved) :shared/card))))))
+        moved (-> (graph-state :app :compile-prepare '#{app.new})
+                  (prepare '#{app.new})
+                  (seed-analyzer-view 'app.new 'card :shared/card ["tf-new" "hs"])
+                  (finish '#{app.new}))]
+    (is (= #{:shared/card} (set (keys (views old)))))
+    (is (= #{:shared/card} (set (keys (views moved)))))
+    (is (not= (get (views old) :shared/card)
+              (get (views moved) :shared/card))
+        "the new owner publishes its own view identity")))
 
 (deftest independent-build-states-never-cross-contribute
   (let [a (pass (graph-state :a :compile-prepare '#{app.view})


### PR DESCRIPTION
## What

The hard-core slice of the install/cache-tax re-architecture (`rf2-u53yy.1`): move the whole-build **views** registry off macro-expansion side effects onto the Shadow-disk-cache-durable **analyzer-map carrier** — the same decoupling S1 gave elements, at compile-finish (where views resolve) rather than compile-prepare.

## Mechanism (before → after)

**Before:** every compiled `defview` contributed its `view-id → [template-fingerprint hook-signature]` digest to a per-source build slice via a macro side effect. A warm cache-hit source never re-runs that macro, so its views were retained only via the in-memory accepted snapshot — which is why `:cache-blockers #{re-frame.ui}` is load-bearing (it forces re-expansion on every daemon start).

**After:** each compiled view stamps its descriptor onto the generated def's analyzer metadata (`emit_cljs`/`emit_jvm` var-meta: `:rf.ui/view-id` + `:rf.ui/view-digest`). Shadow persists a compiled namespace's analyzer data to its disk cache and **restores** it under `[:compiler-env :cljs.analyzer/namespaces <ns>]` on a cache HIT — proven by S0 (`rf2-u53yy.1.1`: exact-EDN round-trip across shadow 3.4.0 / 3.4.10 / 3.4.11). At compile-finish the build hook harvests the `views` + `view-declarations` registries by folding that descriptor over **every authoritative member — cached and freshly compiled alike** — so a warm cache-hit source's views are **RESTORED from the analyzer map, not re-stamped** by a macro that never re-runs.

## Changes

- **`emit_cljs.cljc` / `emit_jvm.cljc`** — stamp `:rf.ui/view-digest [template-fingerprint hook-signature]` onto the view def's var-meta (the analyzer captures it into `:defs <var> :meta`; CLJS is the load-bearing carrier, JVM carries it for parity).
- **`build.cljc`** — `harvest-view-registries` folds the analyzer-map descriptors over the authoritative members; the cross-source view-id uniqueness law runs here (a compile-finish error is still a build-time error). `shadow-finish-candidate` overlays the harvested view rows onto the slice-derived rows of the other registries.
- **`compiler.cljc`** — gate the per-source slice contribution on `build/shadow-build-pass?`: on a real Shadow build pass the `defview` macro contributes **no** view row; off it (plain-JVM / SSR / REPL) the slice remains authoritative, unchanged (the same shape S1 used for `custom-element`).

## Cache-hit restore proof

The S0 proof, now for **real** view descriptors: a new JVM harness test seeds a member's analyzer view descriptor, then finishes a pass in which that member is a cache hit (its macro never runs this pass) — and asserts the view is present in the finished registry, RESTORED from the carrier. Plus eviction-on-recompile and the finish-time cross-source collision.

## Scope / fence (transitional)

Net-additive by design: the cache-blocker and the slice / marker / witness / eviction machinery **stay** — the other four registries (view-static, roots, plans, descriptors) still ride the slice, and their move + the blocker drop + the machinery deletion are the **S6 cut-over**. The two `shadow-cljs.edn:423-424` tax lines and the S0 probe are untouched. No second descriptor system at the end (S6).

## Coordination

Disjoint from `rf2-4vm19` (removed-source reconciliation on `build.cljc`): this PR is the primary S2 occupant of `build.cljc`; 4vm19 sequences after it. No overlap with the `shadow-cljs.edn` build-sources lines.

## Quality gates

Run foreground from `implementation/` (JVM) and via shadow-cljs (real builds) on Windows:

- `implementation/ui` `clojure -M:test` — **929 tests, 0 failures** (the full UI JVM suite: all compiler / emit / build-hook / carrier-proof tests).
- `npx shadow-cljs compile node-test` — **1758 files, 0 warnings**.
- `npm run test:elision` — **PASS** (production 60/60 absent — the view-digest does NOT leak into the production bundle; EP-0023 provenance + assembly-DCE intact).
- `npm run test:perf-bundle` — **PASS** (off=623087, on=623872 chars — no bundle regression).
- `npm run test:ui-warm-watch` — **PASS** (real Shadow daemon, all 8 phases incl. the cold-accept `view-present` assertion driven by the new analyzer-map harvest, + element eviction/rename/delete/failed-compile/retry topology).
- fresh-consumer sim (`examples/ui/minimal-counter`, a real consumer carrying the cache-blocker contract) — **compiles clean, 0 warnings**.
- `npm run test:cljs` (node-test run) — **10366 tests, 0 failures, 0 errors** on a clean re-run. (A first run showed 24 red, all `spawnSync node.exe ETIMEDOUT` in `test_quiet_shadow_node_cljs_test.cljs` — the **test-runner's own self-tests** that spawn child `node` processes; they timed out only because the local Windows machine was momentarily saturated by concurrent gate-run JVMs/node children. The surface is disjoint from this change, and the re-run went fully green.)

Does **not** merge; S6 is the cut-over that drops the blocker and deletes the now-dead machinery.
