### PR TITLE
refactor(build): view-static → descriptor (rf2-u53yy.1 S3)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler.cljc
@@ -202,7 +202,14 @@
 (defn build-view-static
   "The ambient build's per-view static-render facts index (view-id ->
   `{:caps :deps}`) — the read `re-frame.ui/render-static`'s transitive proof
-  closes over (Spec 004C §3). Per-build like every other registry read."
+  closes over (Spec 004C §3). Per-build like every other registry read.
+
+  Populated by the `defview` macro's slice contribution ONLY off the Shadow
+  build path (plain-JVM / SSR / REPL): render-static is JVM-only, so a real
+  Shadow build never reads this index and the macro does not contribute to it
+  there (rf2-u53yy.1 S3). A dependency compiled in another build/context resolves
+  from its registered manifest's `:static-facts` instead
+  (`root/registered-view-static-facts`)."
   []
   (build/aggregate build/view-static))
 
@@ -290,10 +297,12 @@
                                   (:id w) ": " (:msg w)))))
         sites   @(:sites e)
         ;; The render-static no-silent-elision facts (Spec 004C §3, EP-0034 §2),
-        ;; computed once: contributed to the ambient `view-static` build index
-        ;; AND carried on the registered manifest so a view compiled in ANOTHER
-        ;; build/context (AOT / precompiled JAR) stays fact-bearing — the
-        ;; render-static proof never treats an unknown dependency as static-safe.
+        ;; computed once: contributed to the ambient `view-static` build index on
+        ;; the plain-JVM/SSR path (render-static's JVM-only read; gated off the
+        ;; Shadow build path below) AND carried on the registered manifest so a
+        ;; view compiled in ANOTHER build/context (AOT / precompiled JAR) stays
+        ;; fact-bearing — the render-static proof never treats an unknown
+        ;; dependency as static-safe.
         static-facts (view-static-facts ast sites)
         ast-projection (ana/template-fingerprint-projection ast)
         tf      (fingerprint/template-fingerprint ast-projection)
@@ -389,11 +398,23 @@
                :declaration [ns-sym vname]
                :existing-declaration conflict})))
     ;; Per-view static-render facts for the render-static transitive proof
-    ;; (Spec 004C §3 / EP-0034 §2). Keyed per declaring ns like every other
-    ;; registry row, so a recompiled / removed source replaces / evicts its
-    ;; contribution; not folded into the build digest (derived from the same
-    ;; source the `views` digest already tracks).
-    (build/contribute! build/view-static ns-sym view-id static-facts)
+    ;; (Spec 004C §3 / EP-0034 §2). render-static is view-static's ONLY reader
+    ;; and is JVM-only (a CLJS expansion is rejected with
+    ;; `:rf.ui.compile/ui-render-static-jvm-only`), so a real Shadow build PASS
+    ;; NEVER reads `view-static` — its slice there has no consumer and, unlike
+    ;; `views`/`elements`, is not blocker/eviction-relevant. Gate the contribution
+    ;; off the Shadow path like S1 (elements) / S2 (views), so the Shadow-path
+    ;; registries stay a pure function of the cache-durable analyzer map,
+    ;; macro-independent — the direction S6 needs (rf2-u53yy.1 S3). Because
+    ;; nothing reads view-static on the Shadow path, it needs NO compile-finish
+    ;; replacement descriptor there (the simpler mechanism the S3 note names).
+    ;; Off that path (plain-JVM / SSR, REPL — where render-static reads
+    ;; `build/view-static` MID-EXPANSION) the macro contributes the facts to the
+    ;; per-source slice, keyed per declaring ns so a recompiled / removed source
+    ;; replaces / evicts its row; the SAME facts also ride the per-view registered
+    ;; manifest (`:static-facts`) for the cross-build/AOT resolution seam.
+    (when-not (build/shadow-build-pass?)
+      (build/contribute! build/view-static ns-sym view-id static-facts))
     (if cljs?
       ;; Direct no-pass REPL evaluation may replace the runtime view body, but
       ;; carries no digest assignment. Only a successful configured file/watch

--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -50,7 +50,7 @@
 
 (def views       ::views)        ; view-id -> [template-fp hook-sig] (digest)
 (def ^:private view-declarations ::view-declarations) ; view-id -> [ns var]
-(def view-static ::view-static)  ; view-id -> {:caps #{..} :deps #{..}} (static-root proof, Spec 004C §3)
+(def view-static ::view-static)  ; view-id -> {:caps #{..} :deps #{..}} (static-root proof, Spec 004C §3; plain-JVM/SSR slice, rf2-u53yy.1 S3)
 (def roots       ::roots)        ; Layer-1 root-site index
 (def plans       ::plans)        ; Layer-1 frame-plan index
 (def descriptors ::descriptors)  ; Root Descriptor index
@@ -72,6 +72,18 @@
 ;; validation/reporting-only during a real Shadow build pass. The plain-JVM / SSR
 ;; and REPL paths (no `:compile-prepare` hook) keep populating the per-source
 ;; `::elements` slice through the macro + lazy own-source harvest below.
+
+;; `::view-static` is similarly DECOUPLED from the Shadow build path (rf2-u53yy.1
+;; S3), but by the simplest mechanism of all: its ONLY reader, `ui/render-static`,
+;; is JVM-only (a CLJS expansion is rejected), so a real Shadow build never reads
+;; it. Unlike `views`/`elements` it is not blocker/eviction-relevant, so it needs
+;; NO cache-durable Shadow-path descriptor — the `defview` macro simply does not
+;; contribute it under a Shadow build pass (`shadow-build-pass?`), keeping the
+;; Shadow-path registries macro-independent (the S6 direction). The per-source
+;; slice here is populated + read only on the plain-JVM / SSR / REPL path, where
+;; render-static reads it MID-EXPANSION; the same per-view `{:caps :deps}` facts
+;; also ride each view's registered manifest (`:static-facts`) for cross-build/AOT
+;; resolution.
 
 ;; ---------------------------------------------------------------------------
 ;; State


### PR DESCRIPTION
## What

S3 of the install/cache-tax re-architecture (rf2-u53yy.1). Decouples the per-view `view-static` `{:caps :deps}` render-static proof facts from the Shadow build path, the same move S1 (elements) and S2 (views) made — completing the set so **every whole-build registry is macro-independent on the Shadow path** (the precondition S6 needs to drop the `:cache-blockers` tax).

## The mechanism (why view-static is the *simpler* one)

`view-static` is read by exactly one consumer: `ui/render-static`, which is **JVM-only** (a CLJS expansion is rejected with `:rf.ui.compile/ui-render-static-jvm-only`). So a real Shadow (CLJS) build **never reads** `view-static` — the `defview` macro's `build/contribute! build/view-static` there writes a slice nobody consumes. Unlike `views`/`elements`, `view-static` is **not blocker/eviction-relevant** and is read **mid-expansion** (by the render-static macro), not at compile-finish.

Therefore, unlike S1/S2, it needs **no cache-durable Shadow-path replacement descriptor** — the macro simply skips the contribution under a real Shadow build pass:

```clojure
(when-not (build/shadow-build-pass?)
  (build/contribute! build/view-static ns-sym view-id static-facts))
```

- **Shadow build path:** no `view-static` contribution (it was dead work; post-S6 a warm cache-hit source wouldn't re-run the macro anyway). Registries stay a pure function of the cache-durable analyzer map.
- **plain-JVM / SSR / REPL path** (render-static's actual read path): `build/shadow-build-pass?` is false, so the per-source slice is populated and read **exactly as before** — render-static's mid-expansion read is unchanged.
- The same per-view facts also ride each view's **registered manifest** (`:static-facts`) for the cross-build/AOT resolution seam (unchanged).

### Rejected alternatives
- **var-meta carrier harvested at finish** (bead Option A): serves no Shadow-path reader (render-static is JVM-only) → additive work with no consumer; violates the net-simplify / no-scaffold fence.
- **Eliminate the build index, resolve solely from the manifest** (maximal collapse): the ssr JVM test runner's shared `reset-runtime` fixture calls `registrar/clear-all!` (wiping the manifest) but does **not** reset build state, and `render_static_jvm_test` has no reset fixture — so its normal-path assertions resolve via the surviving **build index**. Manifest-only would go red under the real runner. Left as a possible later cleanup (see S4 notes on the bead).

## Net effect
Dead Shadow-path work removed; no new carrier; no scaffold; no test churn. `render-static`'s read timing is correct (mid-expansion, JVM slice + manifest, unchanged). A cache-hit proof is **not applicable** (render-static never touches the Shadow disk cache).

## Fence honored
The two `implementation/shadow-cljs.edn` tax lines (S6) and the S0 probe are untouched. Disjoint from `vvdzx` (Story/Xray). `4vm19` (also build.cljc) sequences behind this.

## Quality gates (all foreground, run to completion, GREEN)

| Gate | Result |
|------|--------|
| `implementation/ui` `clojure -M:test` | **929 tests / 18861 assertions / 0 failures, 0 errors** |
| `implementation/ssr` `clojure -M:test` (render-static suite) | **528 tests / 2537 assertions / 0 failures, 0 errors** |
| `npm run test:cljs` | **10366 tests / 51226 assertions / 0 failures, 0 errors** |
| `npm run test:elision` | **PASS** — production 60/60 absent; control 60/60 present |
| `npm run test:perf-bundle` | **PASS** — off=623087 / on=623872 chars, no regression |
| `npm run test:ui-warm-watch` | **PASS** — real Shadow daemon, all phases incl. warm cache-hit view-present, declaration-shrink coarse invalidation, failed-build/last-known-good |
| fresh-consumer sim (`examples/ui/minimal-counter`, `:local/root` → this checkout) | **0 warnings** |
| `scripts/check-no-hardcoded-paths.sh` | **OK** |

Do not merge — S6 is the cut-over PR that drops the cache-blocker.