### PR TITLE
refactor(build): roots + plans -> synthetic descriptor carrier (rf2-u53yy.1 S4)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -869,6 +869,132 @@
   (merge-with (fn [ra rb] (merge-with merge ra rb)) a b))
 
 ;; ---------------------------------------------------------------------------
+;; Root/plan descriptor carrier (rf2-u53yy.1 S4)
+;;
+;; Roots and plans are CALL SITES (`ui/mount` / `ui/create-root` / `ui/render!` /
+;; `ui/hydrate-root`), not defs, so unlike views (S2) they carry NO generated def
+;; whose analyzer var-meta could hold their descriptor. On the Shadow build path
+;; each site is instead stamped onto a SYNTHETIC per-namespace descriptor in the
+;; analyzer namespace map (variant B, S0 proof rf2-u53yy.1.1): a single ns-level
+;; key `[::namespaces <ns> :rf.ui/root-plan-descriptor]` accumulating this
+;; namespace's `{:roots [..] :plans [..]}` sites. Shadow persists the whole ns
+;; analyzer entry to its disk cache and RESTORES it under
+;; `[:compiler-env :cljs.analyzer/namespaces <ns>]` on a cache HIT, so the build
+;; hook harvests the roots/plans registries from it at compile-finish — present
+;; identically for a cached member and a freshly compiled one — instead of from a
+;; macro-expansion side effect a warm cache-hit source never re-runs. Eviction is
+;; automatic and identical to S2's def-meta carrier: Shadow's watch reset dissocs
+;; the WHOLE `[::namespaces <ns>]` entry for a modified source before it recompiles
+;; (`remove-output-by-id`, default `:watch-namespace-reset`), so a removed site
+;; simply vanishes from the re-analyzed carrier. This is the same decoupling S1
+;; gave elements and S2 gave views — the direction S6 needs to drop the blocker.
+;; ---------------------------------------------------------------------------
+
+(def ^{:private true
+       :doc "The SYNTHETIC per-namespace Layer-1 carrier key in the analyzer
+  namespace map (rf2-u53yy.1 S4). Namespaced + analyzer-only: it is compile-time
+  build state, never emitted into any bundle."}
+  root-plan-descriptor-key
+  :rf.ui/root-plan-descriptor)
+
+(defn stamp-root-plan-site!
+  "Accumulate one Layer-1 `site` under `sub-key` (`:roots` | `:plans`) in the live
+  analyzer map's SYNTHETIC per-namespace descriptor for `ns-sym` — the S4
+  variant-B carrier. Called at macro expansion on a real Shadow build pass
+  (`register-root-site!` / `register-plan-site!` gate on `shadow-build-pass?`) in
+  place of the per-source slice contribution: the whole-build roots/plans
+  registries are then harvested from this carrier at compile-finish, present
+  identically for a cache-hit member and a freshly compiled one. A `:roots` site is
+  `{:root-id .. :row {:file .. :line .. :provenance ..}}`; a `:plans` site is
+  `{:frame-id .. :row {:config-fingerprint .. :file .. :line ..}}` (the same row
+  shape the slice path contributes off the Shadow path). A direct `swap!` on the
+  per-thread compiler env (parallel builds each own theirs); a no-op when no
+  compiler env is bound (never reached — the caller gates on a live Shadow pass)."
+  [ns-sym sub-key site]
+  #?(:clj (when-let [a (compiler-env-atom)]
+            (swap! a update-in
+                   [:cljs.analyzer/namespaces ns-sym root-plan-descriptor-key sub-key]
+                   (fnil conj []) site))
+     :cljs nil)
+  nil)
+
+(defn- site-coords
+  "PURE: the `{:file :line}` locator of a stamped Layer-1 row, for conflict
+  evidence."
+  [row]
+  (select-keys row [:file :line]))
+
+(defn harvest-root-plan-registries
+  "PURE: fold the SYNTHETIC analyzer-map root/plan descriptors of every
+  authoritative `members` namespace in `build-state` into per-source registry rows
+  `{source {::roots {root-id row} ::plans {frame-id row}}}`. Reads
+  `[:compiler-env :cljs.analyzer/namespaces <ns> :rf.ui/root-plan-descriptor]` —
+  Shadow's disk-cache-durable variant-B carrier (rf2-u53yy.1 S4), present
+  identically for a cache-hit member and a freshly compiled one. Same-namespace
+  re-declaration replaces (a source's own later site wins — watch/HMR tolerance);
+  the cross-NAMESPACE Layer-1 laws run HERE (a compile-finish error is still a
+  build-time error): two namespaces resolving one root-id THROW
+  `::duplicate-root-id`; two namespaces carrying DIFFERING config fingerprints for
+  one frame-id THROW `::frame-payload-conflict` (matching fingerprints are the
+  ratified idempotent no-op). Members are folded in sorted order so the reported
+  evidence is stable under every graph permutation. Empty (no root/plan sites in
+  the build) yields `{}`, so the finish overlay is a no-op for a mount-free build."
+  [build-state members]
+  (let [nss (get-in build-state [:compiler-env :cljs.analyzer/namespaces])]
+    (loop [srcs        (sort-by str members)
+           regs        {}
+           root-owners {}                ; root-id -> {:source ns :row row}
+           plan-owners {}]               ; frame-id -> {:source ns :row row}
+      (if-let [ns-sym (first srcs)]
+        (let [d         (get (get nss ns-sym) root-plan-descriptor-key)
+              ;; per-source fold: a namespace's own later site replaces its earlier
+              ;; one for the same key (same-ns re-declaration tolerance).
+              src-roots (reduce (fn [m {:keys [root-id row]}] (assoc m root-id row))
+                                {} (:roots d))
+              src-plans (reduce (fn [m {:keys [frame-id row]}] (assoc m frame-id row))
+                                {} (:plans d))]
+          (doseq [[root-id row] src-roots]
+            (when-let [{owner-row :row} (get root-owners root-id)]
+              (throw
+               (ex-info
+                (str "re-frame.ui found two root sites in one build resolving to "
+                     "root-id " root-id " while harvesting the build's compiled "
+                     "roots; refusing to publish a merge-order winner. Root-ids are "
+                     "page-unique identity — author distinct :root-id values")
+                {::error ::duplicate-root-id
+                 :root-id root-id
+                 :provenance [(:provenance owner-row) (:provenance row)]
+                 :sites (vec (sort-by str [(site-coords owner-row) (site-coords row)]))
+                 :recovery :make-root-ids-unique}))))
+          (doseq [[frame-id row] src-plans]
+            (when-let [{owner-row :row} (get plan-owners frame-id)]
+              (when (not= (:config-fingerprint owner-row) (:config-fingerprint row))
+                (throw
+                 (ex-info
+                  (str "re-frame.ui found two root sites in one build carrying "
+                       "static frame plans for frame " frame-id " with DIFFERING "
+                       "config fingerprints while harvesting the build; refusing to "
+                       "publish a merge-order winner. One frame, one plan — align "
+                       "the configs, or drop the duplicate frame-root")
+                  {::error ::frame-payload-conflict
+                   :frame-id frame-id
+                   :fingerprints [(:config-fingerprint owner-row)
+                                  (:config-fingerprint row)]
+                   :sites (vec (sort-by str [(site-coords owner-row) (site-coords row)]))
+                   :recovery :align-frame-plan-config})))))
+          (recur (rest srcs)
+                 (cond-> regs
+                   (seq src-roots) (assoc-in [ns-sym roots] src-roots)
+                   (seq src-plans) (assoc-in [ns-sym plans] src-plans))
+                 (into root-owners
+                       (map (fn [[rid row]] [rid {:source ns-sym :row row}]))
+                       src-roots)
+                 (into plan-owners
+                       (map (fn [[fid row]] [fid {:source ns-sym :row row}]))
+                       src-plans)))
+        regs))))
+
+;; ---------------------------------------------------------------------------
 ;; Pass boundaries
 ;; ---------------------------------------------------------------------------
 
@@ -1018,9 +1144,20 @@
           ;; directly through the slice — the analyzer map is empty and the slice
           ;; rows carry through unchanged.)
           view-registries (harvest-view-registries build-state members)
+          ;; Roots + plans ride the disk-cache-durable SYNTHETIC per-namespace
+          ;; analyzer-map descriptor on the Shadow path (rf2-u53yy.1 S4). Their
+          ;; register-*-site! macros contribute NO slice row under a Shadow build
+          ;; pass, so harvest every authoritative member's root/plan sites from the
+          ;; carrier and overlay them onto the slice-derived rows of the other
+          ;; registries — a cache-hit member contributes its RESTORED sites
+          ;; identically to a freshly compiled one. The cross-namespace Layer-1 laws
+          ;; run inside the harvest. (Off the Shadow path the analyzer carrier is
+          ;; empty and the slice rows carry through unchanged.)
+          root-plan-registries (harvest-root-plan-registries build-state members)
           snapshot {:build-id build-id
-                    :registries (merge-registries (:committed after)
-                                                  view-registries)
+                    :registries (-> (:committed after)
+                                    (merge-registries view-registries)
+                                    (merge-registries root-plan-registries))
                     :elements (:element-manifest scratch {})
                     :version (inc (long (or (:version accepted) 0)))}]
       {:snapshot snapshot})))

--- a/implementation/ui/src/re_frame/ui/compiler/root.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/root.cljc
@@ -440,27 +440,43 @@
   through the canonical builder, with the both-derived didactic fix per the
   contract. Same-namespace re-registration REPLACES (watch-mode re-expansion
   tolerance — a moved / renamed / deleted site never conflicts with its own
-  ghost). The check-then-write is ONE atomic transition, so parallel
-  compilation cannot miss a duplicate or drop a concurrent write."
+  ghost).
+
+  On a real Shadow build PASS (rf2-u53yy.1 S4) the whole-build roots registry is
+  harvested at compile-finish from the disk-cache-durable SYNTHETIC per-namespace
+  analyzer-map descriptor — root sites are CALL SITES with no def to carry
+  var-meta (unlike views, S2), so this macro stamps the site there via
+  `build/stamp-root-plan-site!` and does NOT contribute a per-source slice row (a
+  warm cache-hit source never re-runs it). The cross-namespace duplicate-root-id
+  law then runs at compile-finish over the carrier
+  (`build/harvest-root-plan-registries`, a compile-finish error is still a
+  build-time error). Off that path (plain-JVM / SSR, REPL — no compile-finish
+  analyzer harvest) the per-source slice contribution + this expansion-time
+  cross-namespace check apply; the check-then-write is ONE atomic transition, so
+  parallel compilation cannot miss a duplicate or drop a concurrent write."
   [where root-id provenance ns-sym coords]
-  (when-let [{:keys [conflict]}
-             (build/contribute-checked!
-              build/roots ns-sym root-id (assoc coords :provenance provenance)
-              ;; any OTHER namespace's row for this root-id is the conflict
-              (fn [existing] existing))]
-    (error/throw-error!
-     :rf.error/duplicate-root-id where
-     (str "two root sites in one build resolve to root-id "
-          (pr-str root-id) " — " (site-str conflict) " and "
-          (site-str coords) ". Root-ids are page-unique identity; "
-          (if (= :derived (:provenance conflict) provenance)
-            (str "both ids derived from the same view — add "
-                 ":disambiguator or author :root-id")
-            "author distinct :root-id values"))
-     {:recovery :make-root-ids-unique
-      :extra {:root-id    root-id
-              :provenance [(:provenance conflict) provenance]
-              :sites      [(dissoc conflict :provenance) coords]}}))
+  (if (build/shadow-build-pass?)
+    (build/stamp-root-plan-site!
+     ns-sym :roots
+     {:root-id root-id :row (assoc coords :provenance provenance)})
+    (when-let [{:keys [conflict]}
+               (build/contribute-checked!
+                build/roots ns-sym root-id (assoc coords :provenance provenance)
+                ;; any OTHER namespace's row for this root-id is the conflict
+                (fn [existing] existing))]
+      (error/throw-error!
+       :rf.error/duplicate-root-id where
+       (str "two root sites in one build resolve to root-id "
+            (pr-str root-id) " — " (site-str conflict) " and "
+            (site-str coords) ". Root-ids are page-unique identity; "
+            (if (= :derived (:provenance conflict) provenance)
+              (str "both ids derived from the same view — add "
+                   ":disambiguator or author :root-id")
+              "author distinct :root-id values"))
+       {:recovery :make-root-ids-unique
+        :extra {:root-id    root-id
+                :provenance [(:provenance conflict) provenance]
+                :sites      [(dissoc conflict :provenance) coords]}})))
   nil)
 
 (defn register-plan-site!
@@ -468,29 +484,42 @@
   namespace `ns-sym`. A plan for the same frame-id with a DIFFERING config
   fingerprint from a different namespace is the build-tier
   `:rf.error/frame-payload-conflict` (same-namespace re-registration replaces
-  — watch tolerance; matching fingerprints are the ratified idempotent
-  no-op). The check-then-write is ONE atomic transition."
+  — watch tolerance; matching fingerprints are the ratified idempotent no-op).
+
+  On a real Shadow build PASS (rf2-u53yy.1 S4) the plan site is stamped onto the
+  SYNTHETIC per-namespace analyzer-map descriptor
+  (`build/stamp-root-plan-site!`) rather than the per-source slice, and the
+  cross-namespace frame-payload-conflict law runs at compile-finish over the
+  carrier — the same decoupling S4 gives roots. Off that path (plain-JVM / SSR,
+  REPL) the per-source slice contribution + this expansion-time check apply; the
+  check-then-write is ONE atomic transition."
   [where {:keys [frame-id config-fingerprint]} ns-sym coords]
-  (when-let [{:keys [conflict]}
-             (build/contribute-checked!
-              build/plans ns-sym frame-id
-              {:config-fingerprint config-fingerprint
-               :file (:file coords) :line (:line coords)}
-              (fn [existing]
-                (when (and existing
-                           (not= (:config-fingerprint existing) config-fingerprint))
-                  existing)))]
-    (error/throw-error!
-     :rf.error/frame-payload-conflict where
-     (str "two root sites in one build carry static frame plans for "
-          "frame " (pr-str frame-id) " with DIFFERING config "
-          "fingerprints — " (site-str conflict) " and " (site-str coords)
-          ". One frame, one plan: keep the frame's config in ONE "
-          "boot/root site, or align the configs")
-     {:recovery :align-frame-plan-config
-      :extra {:frame-id     frame-id
-              :fingerprints [(:config-fingerprint conflict) config-fingerprint]
-              :sites        [(dissoc conflict :config-fingerprint) coords]}}))
+  (if (build/shadow-build-pass?)
+    (build/stamp-root-plan-site!
+     ns-sym :plans
+     {:frame-id frame-id
+      :row {:config-fingerprint config-fingerprint
+            :file (:file coords) :line (:line coords)}})
+    (when-let [{:keys [conflict]}
+               (build/contribute-checked!
+                build/plans ns-sym frame-id
+                {:config-fingerprint config-fingerprint
+                 :file (:file coords) :line (:line coords)}
+                (fn [existing]
+                  (when (and existing
+                             (not= (:config-fingerprint existing) config-fingerprint))
+                    existing)))]
+      (error/throw-error!
+       :rf.error/frame-payload-conflict where
+       (str "two root sites in one build carry static frame plans for "
+            "frame " (pr-str frame-id) " with DIFFERING config "
+            "fingerprints — " (site-str conflict) " and " (site-str coords)
+            ". One frame, one plan: keep the frame's config in ONE "
+            "boot/root site, or align the configs")
+       {:recovery :align-frame-plan-config
+        :extra {:frame-id     frame-id
+                :fingerprints [(:config-fingerprint conflict) config-fingerprint]
+                :sites        [(dissoc conflict :config-fingerprint) coords]}})))
   nil)
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/ui/test/re_frame/ui/compiler_build_hook_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_hook_jvm_test.clj
@@ -322,6 +322,154 @@
               (get (views moved) :shared/card))
         "the new owner publishes its own view identity")))
 
+;; --- rf2-u53yy.1 S4: roots + plans ride the SYNTHETIC analyzer-map carrier -----
+;;
+;; Root/plan CALL SITES carry no def (unlike views, S2), so on a real Shadow build
+;; PASS `register-root-site!` / `register-plan-site!` stamp a SYNTHETIC per-namespace
+;; descriptor `[::namespaces <ns> :rf.ui/root-plan-descriptor {:roots [..] :plans [..]}]`
+;; into the analyzer map (compiler.cljc-style gating on `build/shadow-build-pass?`),
+;; which Shadow persists to its disk cache and RESTORES on a warm hit (the S0 proof
+;; variant B, rf2-u53yy.1.1). `seed-analyzer-root`/`seed-analyzer-plan` stamp that
+;; carrier exactly where the analyzer stores it, so the build hook harvests the
+;; roots/plans registries from it at compile-finish — for a cache-hit member the
+;; macro never re-runs. Eviction is automatic: Shadow's watch reset dissocs the whole
+;; ns entry (`forget-analyzer-ns` models it), so a removed site vanishes.
+
+(defn- roots [state] (build/accepted-aggregate build/roots state))
+(defn- plans [state] (build/accepted-aggregate build/plans state))
+
+(defn- seed-analyzer-roots
+  "Stamp `source`'s root sites onto `state`'s analyzer map the way the
+  register-root-site! macro does on a Shadow build pass (and Shadow restores from
+  the disk cache on a warm hit). `sites` is a coll of `[root-id provenance]`."
+  [state source sites]
+  (assoc-in state
+            [:compiler-env :cljs.analyzer/namespaces source
+             :rf.ui/root-plan-descriptor :roots]
+            (mapv (fn [[root-id provenance]]
+                    {:root-id root-id
+                     :row {:file (str source ".cljs") :line 1 :provenance provenance}})
+                  sites)))
+
+(defn- seed-analyzer-plans
+  "Stamp `source`'s frame-plan sites onto `state`'s analyzer map. `sites` is a coll
+  of `[frame-id config-fingerprint]`."
+  [state source sites]
+  (assoc-in state
+            [:compiler-env :cljs.analyzer/namespaces source
+             :rf.ui/root-plan-descriptor :plans]
+            (mapv (fn [[frame-id cf]]
+                    {:frame-id frame-id
+                     :row {:config-fingerprint cf
+                           :file (str source ".cljs") :line 1}})
+                  sites)))
+
+(deftest root-and-plan-descriptors-survive-a-cache-hit-via-the-analyzer-carrier
+  ;; The S4 analog of the S0 carrier proof (rf2-u53yy.1.1) for REAL root/plan sites:
+  ;; a warm cache-hit source's macro never re-runs, yet its root and plan survive
+  ;; because Shadow RESTORED the synthetic descriptor onto the analyzer map and the
+  ;; hook harvests the registries from there — not from a macro side effect.
+  (let [seed (graph-state :app :compile-prepare '#{app.a app.b})
+        ;; COLD: both compiled; each stamps its root/plan descriptor. Nothing is
+        ;; contributed to the slice (the macro is gated on the Shadow path), so a
+        ;; harvested row here proves the analyzer-map carrier is the sole source.
+        cold (-> (prepare seed '#{app.a app.b})
+                 (seed-analyzer-roots 'app.a [[:page/a :authored]])
+                 (seed-analyzer-plans 'app.a [[:shop "cf-a"]])
+                 (seed-analyzer-roots 'app.b [[:page/b :derived]])
+                 (finish '#{app.a app.b}))]
+    (is (= #{:page/a :page/b} (set (keys (roots cold))))
+        "cold: both roots are harvested from the analyzer-map carrier")
+    (is (= :authored (:provenance (get (roots cold) :page/a))))
+    (is (= {:shop "cf-a"}
+           (update-vals (plans cold) :config-fingerprint))
+        "cold: the plan is harvested from the analyzer-map carrier")
+    ;; WARM: only app.b recompiles. app.a is a cache HIT — its macro does NOT run
+    ;; (no re-seed this pass), but Shadow RESTORED its analyzer descriptor, which the
+    ;; threaded build-state carries unchanged.
+    (let [warm (-> (prepare cold '#{app.a app.b} '#{app.b})
+                   (seed-analyzer-roots 'app.b [[:page/b :derived]])
+                   (finish '#{app.a app.b} '#{app.b}))]
+      (is (= #{:page/a :page/b} (set (keys (roots warm))))
+          "warm: the cache-hit source's root is RESTORED without the macro re-running")
+      (is (= {:shop "cf-a"} (update-vals (plans warm) :config-fingerprint))
+          "warm: the cache-hit source's plan is RESTORED without the macro re-running"))))
+
+(deftest a-removed-root-or-plan-is-evicted-from-the-analyzer-carrier
+  (let [seed (graph-state :app :compile-prepare '#{app.a app.b})
+        both (-> (prepare seed '#{app.a app.b})
+                 (seed-analyzer-roots 'app.a [[:page/a :authored]])
+                 (seed-analyzer-plans 'app.a [[:shop "cf-a"]])
+                 (seed-analyzer-roots 'app.b [[:page/b :authored]])
+                 (finish '#{app.a app.b}))
+        ;; app.a is recompiled with its mount removed: Shadow's watch reset dissocs
+        ;; the whole ns entry, so its synthetic descriptor is gone. app.b is an
+        ;; untouched cache hit whose descriptor is restored.
+        removed (-> (prepare both '#{app.a app.b} '#{app.a})
+                    (forget-analyzer-ns 'app.a)
+                    (finish '#{app.a app.b} '#{app.a}))]
+    (is (= #{:page/a :page/b} (set (keys (roots both)))))
+    (is (= #{:shop} (set (keys (plans both)))))
+    (is (= #{:page/b} (set (keys (roots removed))))
+        "a root removed from its recompiled source is evicted from the carrier")
+    (is (= {} (plans removed))
+        "the removed source's plan is evicted from the carrier")))
+
+(deftest cross-source-duplicate-root-id-fails-at-compile-finish
+  ;; Two root sites in DIFFERENT namespaces resolving to one root-id fail when the
+  ;; hook harvests the carrier at compile-finish — the cross-namespace Layer-1 law
+  ;; moved there from macro expansion (rf2-u53yy.1 S4); a compile-finish error is
+  ;; still a build-time error.
+  (let [seed (graph-state :app :compile-prepare '#{app.old app.new})
+        collision (-> (prepare seed '#{app.old app.new})
+                      (seed-analyzer-roots 'app.old [[:shared/root :authored]])
+                      (seed-analyzer-roots 'app.new [[:shared/root :authored]]))
+        ex (try (finish collision '#{app.old app.new}) nil
+                (catch clojure.lang.ExceptionInfo e e))]
+    (is (some? ex) "two live sites for one root-id must fail the build")
+    (is (= :re-frame.ui.compiler.build/duplicate-root-id
+           (:re-frame.ui.compiler.build/error (ex-data ex))))
+    (is (= :shared/root (:root-id (ex-data ex))))
+    (is (= 2 (count (:sites (ex-data ex)))) "both sites named with coords")))
+
+(deftest cross-source-frame-payload-conflict-fails-at-compile-finish
+  (let [seed (graph-state :app :compile-prepare '#{app.a app.b})
+        collision (-> (prepare seed '#{app.a app.b})
+                      (seed-analyzer-plans 'app.a [[:shop "cf-a"]])
+                      (seed-analyzer-plans 'app.b [[:shop "cf-b"]]))
+        ex (try (finish collision '#{app.a app.b}) nil
+                (catch clojure.lang.ExceptionInfo e e))]
+    (is (some? ex) "differing fingerprints for one frame-id must fail the build")
+    (is (= :re-frame.ui.compiler.build/frame-payload-conflict
+           (:re-frame.ui.compiler.build/error (ex-data ex))))
+    (is (= :shop (:frame-id (ex-data ex))))
+    (is (= ["cf-a" "cf-b"] (:fingerprints (ex-data ex))))))
+
+(deftest cross-source-matching-plan-fingerprints-are-the-idempotent-no-op
+  ;; Two namespaces legitimately declaring the same frame plan (matching
+  ;; fingerprint) co-exist — the ratified idempotent no-op, re-derived at finish.
+  (let [seed (graph-state :app :compile-prepare '#{app.a app.b})
+        ok (-> (prepare seed '#{app.a app.b})
+               (seed-analyzer-plans 'app.a [[:shop "cf-same"]])
+               (seed-analyzer-plans 'app.b [[:shop "cf-same"]])
+               (finish '#{app.a app.b}))]
+    (is (= {:shop "cf-same"} (update-vals (plans ok) :config-fingerprint)))))
+
+(deftest a-root-id-transfers-cleanly-to-a-new-owner-via-the-carrier
+  ;; app.old owned :shared/root; it is deleted and app.new takes it over. With
+  ;; app.old absent from :build-sources the carrier fold sees only app.new's site,
+  ;; so no collision fires.
+  (let [old (-> (graph-state :app :compile-prepare '#{app.old})
+                (prepare '#{app.old})
+                (seed-analyzer-roots 'app.old [[:shared/root :authored]])
+                (finish '#{app.old}))
+        moved (-> (graph-state :app :compile-prepare '#{app.new})
+                  (prepare '#{app.new})
+                  (seed-analyzer-roots 'app.new [[:shared/root :authored]])
+                  (finish '#{app.new}))]
+    (is (= #{:shared/root} (set (keys (roots old)))))
+    (is (= #{:shared/root} (set (keys (roots moved)))))))
+
 (deftest independent-build-states-never-cross-contribute
   (let [a (pass (graph-state :a :compile-prepare '#{app.view})
                 '#{app.view} [['app.view :app/view ["tf1-a" "hs1-a"]]])


### PR DESCRIPTION
## What

Slice S4 of the install/cache-tax re-architecture (rf2-u53yy.1): moves the **roots + plans** whole-build registries off macro-expansion side effects onto a cache-durable **synthetic per-namespace analyzer-map descriptor**, harvested at compile-finish. After S4 all five registries (elements S1, views S2, view-static S3, roots+plans S4) are macro-independent on the Shadow path — the precondition S6 needs to drop the `:cache-blockers` line.

Roots/plans are **call sites** (`ui/mount` / `ui/create-root` / `ui/render!` / `ui/hydrate-root`) with no `def` to carry analyzer var-meta (unlike views, S2), so they ride a **synthetic ns-level key** `[::namespaces <ns> :rf.ui/root-plan-descriptor {:roots [..] :plans [..]}]` (S0 proof variant B) instead of a generated def's `:meta`.

## Mechanism (mirrors S2)

- **`root.cljc`** — `register-root-site!` / `register-plan-site!` gate their per-source slice contribution off the Shadow path (`build/shadow-build-pass?`, the S1/S2/S3 pattern); on a real Shadow build pass they instead stamp the site onto the synthetic analyzer-map descriptor via `build/stamp-root-plan-site!`. The plain-JVM / SSR / REPL path (and `render-static`, JVM-only) is unchanged — slice contribution + expansion-time `:rf.error/duplicate-root-id` / `:rf.error/frame-payload-conflict` checks.
- **`build.cljc`** — `stamp-root-plan-site!` accumulates sites into the live analyzer map; `harvest-root-plan-registries` folds every authoritative member's descriptor into the `::roots`/`::plans` registries at compile-finish, running the cross-namespace Layer-1 laws there (a compile-finish error is still a build-time error). `shadow-finish-candidate` overlays the harvested rows onto the slice-derived rows via `merge-registries`, exactly as it does for views.

## Eviction is automatic (no clearing mechanism needed)

Shadow's watch reset (`remove-output-by-id`, default `:watch-namespace-reset`) dissocs the **whole** `[::ana/namespaces <ns>]` entry for a modified source before it recompiles, so a removed root/plan site vanishes from the re-analyzed carrier — identical to how a removed view's `:defs` entry evicts (S2). Verified against the pinned shadow-cljs 3.4.10 jar.

## Cache-hit restore proof

`root-and-plan-descriptors-survive-a-cache-hit-via-the-analyzer-carrier` (JVM): a warm cache-hit source's macro never re-runs, yet its root + plan survive because Shadow restored the synthetic descriptor onto the analyzer map and the hook harvests from there — the S0 proof for real roots/plans. Plus real-Shadow proof: a `minimal-counter` build with a duplicate `:my.app/counter` across two namespaces fails at `:compile-finish` with `:re-frame.ui.compiler.build/duplicate-root-id`, both sites anchored (`my/app.cljs:31` derived + `my/dup.cljs:5` authored) — the full stamp → harvest → conflict-law path firing on a genuine Shadow build.

## Net simplification

Additive this slice (the machinery deletion + blocker drop is S6, per the programme's binary acceptance). No emit-side change needed (the carrier is compile-time analyzer data, never emitted — simpler than S2's var-meta). No scaffold; the old slice path is fully gated off the Shadow path, not kept "just in case".

## Fence honored

The two `implementation/shadow-cljs.edn` tax lines (S6) and the S0 probe untouched. Disjoint from `vvdzx` (Story/Xray). `4vm19` (build.cljc) sequences behind.

## Quality gates

All foreground, to completion:

- `implementation/ui` `clojure -M:test` — **935/0**
- `implementation/ssr` `clojure -M:test` — **528/0** (render-static path unchanged)
- `npm run test:cljs` — **10366/0** (validates host-neutral CLJS compile)
- `npm run test:elision` — PASS (synthetic descriptor absent from prod: 60/60)
- `npm run test:perf-bundle` — PASS (no regression)
- `npm run test:ui-warm-watch` — PASS (real Shadow daemon, all 8 phases incl warm cache-hit + delete-eviction; harvest a no-op for the mount-free fixture)
- fresh-consumer sim `examples/ui/minimal-counter` `shadow-cljs release app` — **0 warnings**; duplicate-root-id variant fails correctly at compile-finish
- real Shadow builds compiled clean: elision-probe, examples/counter, ui-warm-watch, minimal-counter
- `check-no-hardcoded-paths` — OK

Does NOT merge — S6 is the cut-over. S4 unblocks S5 (descriptors) and releases 4vm19 (build.cljc) after merge.
