### PR TITLE
docs(s7): Helix sweep — classify occurrences + fix stale-disposition refs (rf2-s1jur)

### DIFF
--- a/docs/core/how-to/use-uix-helix-or-slim.md
+++ b/docs/core/how-to/use-uix-helix-or-slim.md
@@ -10,6 +10,10 @@ We'll take it one step at a time: the single line that picks a substrate, then a
 
     Events, subscriptions, effects, and app-db never learn which React wrapper renders them. The boot call ([`init!`](../glossary.md#init)) names the substrate. Only the view bodies speak its notation. That's the whole story; the rest of this page is detail.
 
+!!! warning "Helix is scheduled for removal at S7"
+
+    Of the four substrates covered here, Helix is the odd one out: it is a transition adapter, scheduled for removal in the S7 Helix-removal wave. Stock Reagent, reagent-slim, and UIx live on as first-class, actively-supported adapters, so for new work reach for one of those three — pick Helix only if you're already committed to it. (The first-party [`re-frame.ui`](../re-frame.ui/index.md) compiled substrate is a separate, experimental option offered alongside them.)
+
 ??? info "Coming from Redux?"
 
     The [adapter](../glossary.md#adapter) plays react-redux's role — `frame-provider` is `<Provider>`, `use-subscribe` is `useSelector` — with two differences. The binding is a value you pass explicitly at boot rather than a package you import, and exactly one is ever installed per runtime. No hidden default, no autowiring.


### PR DESCRIPTION
Sweep + classify every 'Helix' occurrence against the ruled adapter end-state (rf2-s1jur). This is the **classification + (b)-fix** bead; the actual Helix adapter DELETION is the separate W13 wave.

## Authoritative disposition
EP-0030 Resolved Decisions (Mike, 2026-07-17), reconfirmed on vxgfnd.99: re-frame.ui is a NEW experimental substrate offered ALONGSIDE the existing adapters. **Reagent, reagent-slim, and UIx live on as first-class, actively-supported adapters. ONLY HELIX IS REMOVED** (S7 W13). Soak gate waived (Mike, 2026-07-21). The older "UIx+Helix+slim deletion wave" framing is stale — only Helix goes.

## Scope of the sweep
290 tracked files carry `Helix` (2741 occurrences, excl `ai/`/`site/`/`node_modules`). Reproduce: `git grep -c "Helix" -- ':!ai/**' ':!site/**' ':!node_modules/**'`.

**Key finding:** Helix appears everywhere because it is a full LIVE adapter (a), not because of stale mislabels (b). The corpus is overwhelmingly disposition-accurate — `spec/006`, `spec/Ownership`, `spec/Pattern-StatefulComponents`, `spec/AI-Audit` carry explicit `[TRANSITION]`/"only Helix removed" markers; EP-0030/0031/0034 state it; `docs/core/re-frame.ui/*` carry standing notes; the reagent-migration + implementor skills state it correctly; even `test.yml:512` comments "ONLY Helix is removed." (b) is small, exactly as the bead predicted.

## (a) W13-deletion inventory
- **Whole-file/dir deletions (29 files):** `implementation/adapters/helix/` (15 — the artefact), `examples/substrates/helix/` (9), `tools/template/resources/day8/re_frame2_template/_helix/` (3), `tools/machines-viz/.../adapters/helix.cljs` (1), `docs/api/re-frame.adapter.helix.md` (1).
- **Shared-file arm-prune (file survives, Helix content removed):** `shadow-cljs.edn` build-ids, `deps.edn` coord, `release.yml`/`test.yml` Helix jobs+leaves, the `react_shared_suite` Helix host (UIx arm stays — S7-OBLIGATION 1), the adapter-isolation/disposition scripts, spec `[TRANSITION]` rows, and the Helix arms across docs/skills/tools/examples.

Full file roster + per-area anchors are in the **rf2-s1jur bead notes** (the portable, dolt-synced deliverable the W13 worker reads). W13 ordering guard: one combined PR or workflow/config-prune-first.

## (b) fix-now stale-disposition refs
- **Fixed here — `docs/core/how-to/use-uix-helix-or-slim.md`:** the substrate-choice how-to presented Helix as a co-equal, blessed substrate to adopt ("reach for UIx or Helix") with no scheduled-for-removal signal anywhere. Added a `!!! warning` standing note naming Helix's S7 removal + the retained trio, steering new work away from Helix. Teaching prose unchanged (W13 prunes the Helix arm wholesale).
- **Genuine (b) but owned elsewhere + generated — NOT touched:** `skills/re-frame2-ui-context/SKILL.md:235-237` ("the Reagent/UIx/Helix adapters remain first-class") is GENERATED (`do NOT hand-edit`) from `implementation/scripts/api-manifest/.../ui_context.clj`, and is already owned by **rf2-h73l5**'s unmet #6639 audit rider (the vxgfnd.99 ruling assigns it: "reopen h73l5 for that sentence + regenerate").
- No other flatly-false Helix-disposition claims in `docs/*` or `skills/*`.

## Fences honoured
Did NOT delete the Helix adapter (W13 wave), and did NOT touch `shadow-cljs.edn` / `deps.edn` / `.github/workflows/*` / `build.cljc`/`root.cljc` (S4/S6/vxgfnd.99.2 fences), `spec/*`, or the generated ui-context SKILL.md.

## Quality gates
- `python -m mkdocs build --strict` — exit 0
- `python scripts/check_doc_slugs.py` — exit 0
- `python scripts/check_skill_re_frame2_drift.py` — exit 0
- `python scripts/check_skill_setup_counter_drift.py` — exit 0
- `python scripts/check_adapter_disposition.py` — exit 0