### PR TITLE
refactor(build): descriptors → the one per-namespace schema on the synthetic carrier (rf2-u53yy.1 S5)

### DIFF
--- a/implementation/ui/src/re_frame/ui/compiler/build.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/build.cljc
@@ -869,15 +869,17 @@
   (merge-with (fn [ra rb] (merge-with merge ra rb)) a b))
 
 ;; ---------------------------------------------------------------------------
-;; Root/plan descriptor carrier (rf2-u53yy.1 S4)
+;; Root/plan/descriptor carrier (rf2-u53yy.1 S4 + S5)
 ;;
-;; Roots and plans are CALL SITES (`ui/mount` / `ui/create-root` / `ui/render!` /
-;; `ui/hydrate-root`), not defs, so unlike views (S2) they carry NO generated def
-;; whose analyzer var-meta could hold their descriptor. On the Shadow build path
-;; each site is instead stamped onto a SYNTHETIC per-namespace descriptor in the
-;; analyzer namespace map (variant B, S0 proof rf2-u53yy.1.1): a single ns-level
-;; key `[::namespaces <ns> :rf.ui/root-plan-descriptor]` accumulating this
-;; namespace's `{:roots [..] :plans [..]}` sites. Shadow persists the whole ns
+;; Roots, plans, and Root Descriptors are CALL SITES (`ui/mount` / `ui/create-root`
+;; / `ui/render!` / `ui/hydrate-root`), not defs, so unlike views (S2) they carry NO
+;; generated def whose analyzer var-meta could hold their descriptor. On the Shadow
+;; build path each site is instead stamped onto a SYNTHETIC per-namespace descriptor
+;; in the analyzer namespace map (variant B, S0 proof rf2-u53yy.1.1): a single
+;; ns-level key `[::namespaces <ns> :rf.ui/root-plan-descriptor]` accumulating this
+;; namespace's `{:roots [..] :plans [..] :descriptors [..]}` sites — S5 folds the
+;; Root Descriptor index onto the SAME carrier (one carrier for all three call-site
+;; registries) rather than inventing a new key. Shadow persists the whole ns
 ;; analyzer entry to its disk cache and RESTORES it under
 ;; `[:compiler-env :cljs.analyzer/namespaces <ns>]` on a cache HIT, so the build
 ;; hook harvests the roots/plans registries from it at compile-finish — present
@@ -898,18 +900,21 @@
   :rf.ui/root-plan-descriptor)
 
 (defn stamp-root-plan-site!
-  "Accumulate one Layer-1 `site` under `sub-key` (`:roots` | `:plans`) in the live
-  analyzer map's SYNTHETIC per-namespace descriptor for `ns-sym` — the S4
-  variant-B carrier. Called at macro expansion on a real Shadow build pass
-  (`register-root-site!` / `register-plan-site!` gate on `shadow-build-pass?`) in
-  place of the per-source slice contribution: the whole-build roots/plans
+  "Accumulate one Layer-1 `site` under `sub-key` (`:roots` | `:plans` |
+  `:descriptors`) in the live analyzer map's SYNTHETIC per-namespace descriptor for
+  `ns-sym` — the S4 variant-B carrier, extended to carry the Root Descriptor index
+  too (rf2-u53yy.1 S5): all three call-site registries ride ONE carrier. Called at
+  macro expansion on a real Shadow build pass (`register-root-site!` /
+  `register-plan-site!` / `register-descriptor!` gate on `shadow-build-pass?`) in
+  place of the per-source slice contribution: the whole-build roots/plans/descriptor
   registries are then harvested from this carrier at compile-finish, present
   identically for a cache-hit member and a freshly compiled one. A `:roots` site is
   `{:root-id .. :row {:file .. :line .. :provenance ..}}`; a `:plans` site is
-  `{:frame-id .. :row {:config-fingerprint .. :file .. :line ..}}` (the same row
-  shape the slice path contributes off the Shadow path). A direct `swap!` on the
-  per-thread compiler env (parallel builds each own theirs); a no-op when no
-  compiler env is bound (never reached — the caller gates on a live Shadow pass)."
+  `{:frame-id .. :row {:config-fingerprint .. :file .. :line ..}}`; a `:descriptors`
+  site is `{:root-id .. :row <Root Descriptor v1>}` (the same row the slice path
+  contributes off the Shadow path). A direct `swap!` on the per-thread compiler env
+  (parallel builds each own theirs); a no-op when no compiler env is bound (never
+  reached — the caller gates on a live Shadow pass)."
   [ns-sym sub-key site]
   #?(:clj (when-let [a (compiler-env-atom)]
             (swap! a update-in
@@ -925,20 +930,25 @@
   (select-keys row [:file :line]))
 
 (defn harvest-root-plan-registries
-  "PURE: fold the SYNTHETIC analyzer-map root/plan descriptors of every
+  "PURE: fold the SYNTHETIC analyzer-map root/plan/descriptor sites of every
   authoritative `members` namespace in `build-state` into per-source registry rows
-  `{source {::roots {root-id row} ::plans {frame-id row}}}`. Reads
+  `{source {::roots {root-id row} ::plans {frame-id row} ::descriptors {root-id
+  descriptor}}}`. Reads
   `[:compiler-env :cljs.analyzer/namespaces <ns> :rf.ui/root-plan-descriptor]` —
-  Shadow's disk-cache-durable variant-B carrier (rf2-u53yy.1 S4), present
-  identically for a cache-hit member and a freshly compiled one. Same-namespace
-  re-declaration replaces (a source's own later site wins — watch/HMR tolerance);
-  the cross-NAMESPACE Layer-1 laws run HERE (a compile-finish error is still a
-  build-time error): two namespaces resolving one root-id THROW
-  `::duplicate-root-id`; two namespaces carrying DIFFERING config fingerprints for
-  one frame-id THROW `::frame-payload-conflict` (matching fingerprints are the
-  ratified idempotent no-op). Members are folded in sorted order so the reported
-  evidence is stable under every graph permutation. Empty (no root/plan sites in
-  the build) yields `{}`, so the finish overlay is a no-op for a mount-free build."
+  Shadow's disk-cache-durable variant-B carrier (rf2-u53yy.1 S4, extended to the
+  Root Descriptor index at S5), present identically for a cache-hit member and a
+  freshly compiled one. Same-namespace re-declaration replaces (a source's own later
+  site wins — watch/HMR tolerance); the cross-NAMESPACE Layer-1 laws run HERE (a
+  compile-finish error is still a build-time error): two namespaces resolving one
+  root-id THROW `::duplicate-root-id`; two namespaces carrying DIFFERING config
+  fingerprints for one frame-id THROW `::frame-payload-conflict` (matching
+  fingerprints are the ratified idempotent no-op). Root Descriptors ride alongside
+  their root sites keyed by the SAME root-id (every `:descriptors` site is stamped
+  at a site that also stamps a `:roots` site), so the `::duplicate-root-id` law above
+  is their cross-namespace conflict check — no separate descriptor check is needed.
+  Members are folded in sorted order so the reported evidence is stable under every
+  graph permutation. Empty (no root/plan/descriptor sites in the build) yields `{}`,
+  so the finish overlay is a no-op for a mount-free build."
   [build-state members]
   (let [nss (get-in build-state [:compiler-env :cljs.analyzer/namespaces])]
     (loop [srcs        (sort-by str members)
@@ -952,7 +962,9 @@
               src-roots (reduce (fn [m {:keys [root-id row]}] (assoc m root-id row))
                                 {} (:roots d))
               src-plans (reduce (fn [m {:keys [frame-id row]}] (assoc m frame-id row))
-                                {} (:plans d))]
+                                {} (:plans d))
+              src-descs (reduce (fn [m {:keys [root-id row]}] (assoc m root-id row))
+                                {} (:descriptors d))]
           (doseq [[root-id row] src-roots]
             (when-let [{owner-row :row} (get root-owners root-id)]
               (throw
@@ -985,7 +997,8 @@
           (recur (rest srcs)
                  (cond-> regs
                    (seq src-roots) (assoc-in [ns-sym roots] src-roots)
-                   (seq src-plans) (assoc-in [ns-sym plans] src-plans))
+                   (seq src-plans) (assoc-in [ns-sym plans] src-plans)
+                   (seq src-descs) (assoc-in [ns-sym descriptors] src-descs))
                  (into root-owners
                        (map (fn [[rid row]] [rid {:source ns-sym :row row}]))
                        src-roots)
@@ -1144,15 +1157,16 @@
           ;; directly through the slice — the analyzer map is empty and the slice
           ;; rows carry through unchanged.)
           view-registries (harvest-view-registries build-state members)
-          ;; Roots + plans ride the disk-cache-durable SYNTHETIC per-namespace
-          ;; analyzer-map descriptor on the Shadow path (rf2-u53yy.1 S4). Their
-          ;; register-*-site! macros contribute NO slice row under a Shadow build
-          ;; pass, so harvest every authoritative member's root/plan sites from the
-          ;; carrier and overlay them onto the slice-derived rows of the other
-          ;; registries — a cache-hit member contributes its RESTORED sites
-          ;; identically to a freshly compiled one. The cross-namespace Layer-1 laws
-          ;; run inside the harvest. (Off the Shadow path the analyzer carrier is
-          ;; empty and the slice rows carry through unchanged.)
+          ;; Roots + plans + Root Descriptors ride the disk-cache-durable SYNTHETIC
+          ;; per-namespace analyzer-map descriptor on the Shadow path (rf2-u53yy.1
+          ;; S4 roots/plans, S5 folds descriptors onto the same carrier). Their
+          ;; register-*-site! / register-descriptor! macros contribute NO slice row
+          ;; under a Shadow build pass, so harvest every authoritative member's
+          ;; root/plan/descriptor sites from the carrier and overlay them onto the
+          ;; slice-derived rows of the other registries — a cache-hit member
+          ;; contributes its RESTORED sites identically to a freshly compiled one. The
+          ;; cross-namespace Layer-1 laws run inside the harvest. (Off the Shadow path
+          ;; the analyzer carrier is empty and the slice rows carry through unchanged.)
           root-plan-registries (harvest-root-plan-registries build-state members)
           snapshot {:build-id build-id
                     :registries (-> (:committed after)

--- a/implementation/ui/src/re_frame/ui/compiler/root.cljc
+++ b/implementation/ui/src/re_frame/ui/compiler/root.cljc
@@ -522,6 +522,30 @@
                 :sites        [(dissoc conflict :config-fingerprint) coords]}})))
   nil)
 
+(defn register-descriptor!
+  "Index one root site's compile-emitted Root Descriptor (the build-artefact the
+  S5 tooling / Xray read through `descriptor-index`), keyed by `root-id`, owned by
+  its declaring namespace `ns-sym`.
+
+  On a real Shadow build PASS (rf2-u53yy.1 S5) the descriptor rides the SAME
+  SYNTHETIC per-namespace analyzer-map carrier as roots/plans (S4), under a
+  `:descriptors` sub-key, via `build/stamp-root-plan-site!` — so a warm cache-hit
+  source's descriptor is RESTORED from the disk cache without the macro re-running,
+  and the whole-build descriptor index is harvested from the carrier at
+  compile-finish. It contributes NO per-source slice row on that path. Every
+  descriptor is registered at a mount / hydrate site that ALSO registers a root site
+  under the same `root-id`, so the cross-namespace `:rf.error/duplicate-root-id`
+  law (`register-root-site!` off the Shadow path, `harvest-root-plan-registries` at
+  compile-finish on it) is the descriptor's conflict check too — no separate one is
+  needed. Off the Shadow path (plain-JVM / SSR, REPL — no compile-finish harvest)
+  the per-source slice contribution applies, the read path `descriptor-index` uses."
+  [root-id descriptor ns-sym]
+  (if (build/shadow-build-pass?)
+    (build/stamp-root-plan-site!
+     ns-sym :descriptors {:root-id root-id :row descriptor})
+    (build/contribute! build/descriptors ns-sym root-id descriptor))
+  nil)
+
 ;; ---------------------------------------------------------------------------
 ;; Root opts (contract §3)
 ;; ---------------------------------------------------------------------------
@@ -675,8 +699,7 @@
                        (register-plan-site! 'ui/mount p ns-sym coords))
               desc   (root-descriptor {:root-id root-id :provenance provenance
                                        :views views :plans plans :ast ast})
-              _      (build/contribute! build/descriptors ns-sym
-                                        root-id desc)
+              _      (register-descriptor! root-id desc ns-sym)
               body   (emit-cljs/emit-inline ast 'rf-ui-root)]
           `(re-frame.ui.client/mount*
             {:root-id ~root-id
@@ -779,9 +802,11 @@
               (let [derived (:view-id (first views))]
                 (register-root-site! 'ui/hydrate-root derived :derived
                                      ns-sym coords)
-                (build/contribute! build/descriptors ns-sym derived
-                       (root-descriptor {:root-id derived :provenance :derived
-                                         :views views :plans plans :ast ast}))))
+                (register-descriptor!
+                 derived
+                 (root-descriptor {:root-id derived :provenance :derived
+                                   :views views :plans plans :ast ast})
+                 ns-sym)))
             (doseq [p plans]
               (register-plan-site! 'ui/hydrate-root p ns-sym coords))
             (let [body (emit-cljs/emit-inline ast 'rf-ui-root)]

--- a/implementation/ui/test/re_frame/ui/compiler_build_hook_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_hook_jvm_test.clj
@@ -364,6 +364,20 @@
                            :file (str source ".cljs") :line 1}})
                   sites)))
 
+(defn- seed-analyzer-descriptors
+  "Stamp `source`'s Root Descriptor sites onto `state`'s analyzer map the way the
+  register-descriptor! macro does on a Shadow build pass (rf2-u53yy.1 S5 — the
+  descriptors ride the SAME synthetic carrier as roots/plans). `sites` is a coll of
+  `[root-id label]`; the row is a minimal Root Descriptor v1."
+  [state source sites]
+  (assoc-in state
+            [:compiler-env :cljs.analyzer/namespaces source
+             :rf.ui/root-plan-descriptor :descriptors]
+            (mapv (fn [[root-id label]]
+                    {:root-id root-id
+                     :row {:rf.root/schema-version 1 :root-id root-id :label label}})
+                  sites)))
+
 (deftest root-and-plan-descriptors-survive-a-cache-hit-via-the-analyzer-carrier
   ;; The S4 analog of the S0 carrier proof (rf2-u53yy.1.1) for REAL root/plan sites:
   ;; a warm cache-hit source's macro never re-runs, yet its root and plan survive
@@ -469,6 +483,65 @@
                   (finish '#{app.new}))]
     (is (= #{:shared/root} (set (keys (roots old)))))
     (is (= #{:shared/root} (set (keys (roots moved)))))))
+
+;; --- rf2-u53yy.1 S5: Root Descriptors ride the SAME synthetic carrier ----------
+;;
+;; The Root Descriptor index is the last registry folded onto the analyzer-map
+;; carrier (S5). `register-descriptor!` stamps `[::namespaces <ns>
+;; :rf.ui/root-plan-descriptor :descriptors]` at the same mount / hydrate site that
+;; stamps a `:roots` site, so the hook harvests the descriptor index from the carrier
+;; at compile-finish — for a cache-hit member the macro never re-runs, yet Shadow
+;; RESTORED the descriptor from disk, so `descriptor-index` reads it back.
+
+(deftest root-descriptors-survive-a-cache-hit-via-the-analyzer-carrier
+  ;; The S5 analog of the S4 root/plan carrier proof for the Root Descriptor index:
+  ;; a warm cache-hit source's macro never re-runs, yet its descriptor survives
+  ;; because Shadow RESTORED the synthetic carrier and the hook harvests the index
+  ;; from there — not from a macro side effect / the per-source slice.
+  (let [seed (graph-state :app :compile-prepare '#{app.a app.b})
+        ;; COLD: both compiled; each stamps its root + descriptor. Nothing is
+        ;; contributed to the slice (the macro is gated on the Shadow path), so a
+        ;; harvested descriptor here proves the analyzer-map carrier is the sole
+        ;; source.
+        cold (-> (prepare seed '#{app.a app.b})
+                 (seed-analyzer-roots 'app.a [[:page/a :authored]])
+                 (seed-analyzer-descriptors 'app.a [[:page/a :a]])
+                 (seed-analyzer-roots 'app.b [[:page/b :derived]])
+                 (seed-analyzer-descriptors 'app.b [[:page/b :b]])
+                 (finish '#{app.a app.b}))]
+    (is (= #{:page/a :page/b} (set (keys (root/descriptor-index cold))))
+        "cold: both descriptors are harvested from the analyzer-map carrier")
+    (is (= :a (:label (get (root/descriptor-index cold) :page/a)))
+        "cold: the harvested descriptor is the stamped Root Descriptor v1")
+    ;; WARM: only app.b recompiles. app.a is a cache HIT — its macro does NOT run
+    ;; (no re-seed this pass), but Shadow RESTORED its analyzer descriptor, which the
+    ;; threaded build-state carries unchanged.
+    (let [warm (-> (prepare cold '#{app.a app.b} '#{app.b})
+                   (seed-analyzer-roots 'app.b [[:page/b :derived]])
+                   (seed-analyzer-descriptors 'app.b [[:page/b :b]])
+                   (finish '#{app.a app.b} '#{app.b}))]
+      (is (= #{:page/a :page/b} (set (keys (root/descriptor-index warm))))
+          "warm: the cache-hit source's descriptor is RESTORED without the macro re-running")
+      (is (= :a (:label (get (root/descriptor-index warm) :page/a)))
+          "warm: the RESTORED descriptor is intact, byte-for-byte"))))
+
+(deftest a-removed-root-descriptor-is-evicted-from-the-analyzer-carrier
+  (let [seed (graph-state :app :compile-prepare '#{app.a app.b})
+        both (-> (prepare seed '#{app.a app.b})
+                 (seed-analyzer-roots 'app.a [[:page/a :authored]])
+                 (seed-analyzer-descriptors 'app.a [[:page/a :a]])
+                 (seed-analyzer-roots 'app.b [[:page/b :authored]])
+                 (seed-analyzer-descriptors 'app.b [[:page/b :b]])
+                 (finish '#{app.a app.b}))
+        ;; app.a is recompiled with its mount removed: Shadow's watch reset dissocs
+        ;; the whole ns entry, so its synthetic descriptor is gone. app.b is an
+        ;; untouched cache hit whose descriptor is restored.
+        removed (-> (prepare both '#{app.a app.b} '#{app.a})
+                    (forget-analyzer-ns 'app.a)
+                    (finish '#{app.a app.b} '#{app.a}))]
+    (is (= #{:page/a :page/b} (set (keys (root/descriptor-index both)))))
+    (is (= #{:page/b} (set (keys (root/descriptor-index removed))))
+        "a descriptor removed from its recompiled source is evicted from the carrier")))
 
 (deftest independent-build-states-never-cross-contribute
   (let [a (pass (graph-state :a :compile-prepare '#{app.view})

--- a/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_jvm_test.clj
@@ -98,10 +98,11 @@
                                         'ui/mount opts views)]
       (root/register-root-site! 'ui/mount root-id provenance ns-sym coords)
       (doseq [p plans] (root/register-plan-site! 'ui/mount p ns-sym coords))
-      (build/contribute! build/descriptors ns-sym root-id
-                         (root/root-descriptor
-                          {:root-id root-id :provenance provenance
-                           :views views :plans plans :ast ast})))))
+      (root/register-descriptor! root-id
+                                 (root/root-descriptor
+                                  {:root-id root-id :provenance provenance
+                                   :views views :plans plans :ast ast})
+                                 ns-sym))))
 
 (defn- snapshot
   "The observable state of all five build registries for the ambient build.


### PR DESCRIPTION
## What

S5 of the staged install/cache-tax re-architecture (rf2-u53yy.1). Folds the **Root Descriptor index** — the last slice-based + ungated whole-build registry — onto the SAME synthetic per-namespace analyzer-map carrier S4 introduced for roots/plans, under a new `:descriptors` sub-key. After S5, **all five whole-build registries** (elements S1, views S2, view-static S3, roots+plans S4, descriptors S5) are macro-independent on the Shadow path — the precondition S6 needs to drop the cache-blocker.

Per the bead's S5 note, option (a): one carrier for all three call-site registries; no new carrier key invented.

## Mechanism

- **`root.cljc`** — new `register-descriptor!` mirrors `register-root-site!`/`register-plan-site!`: on a real Shadow build pass (`build/shadow-build-pass?`) it stamps the descriptor onto `[::namespaces <ns> :rf.ui/root-plan-descriptor :descriptors]` via `build/stamp-root-plan-site!`; off that path (plain-JVM / SSR / REPL) it contributes the per-source slice row `descriptor-index` reads. The `ui/mount` and `ui/hydrate-root` sites now call it in place of the raw `build/contribute! build/descriptors` write.
- **`build.cljc`** — `harvest-root-plan-registries` folds the carrier's `:descriptors` sites into the `::descriptors` registry at compile-finish, present identically for a cache-hit member and a freshly compiled one. `shadow-finish-candidate`'s existing generic overlay carries them into the accepted snapshot — no overlay change needed.

## Cross-namespace conflict / "parallel mutation ledger"

Every `:descriptors` site is stamped at a mount/hydrate site that also stamps a `:roots` site under the **same root-id**, so the existing `::duplicate-root-id` law in the harvest is the descriptor's cross-namespace conflict check too — **no separate descriptor check is added**. The descriptor's separate Shadow-path slice mutation (a second write parallel to the root site) is removed: descriptors now ride the one carrier and are harvested in the same fold as roots/plans. The plain-JVM/SSR/REPL slice path is retained unchanged (the non-Shadow read authority), exactly as S1–S4 retained theirs.

## Proof

- **Descriptor cache-hit restore** (new JVM test `root-descriptors-survive-a-cache-hit-via-the-analyzer-carrier`): cold build stamps + harvests both descriptors; a warm pass recompiles only one source — the cache-hit source's descriptor is RESTORED from the carrier without its macro re-running, byte-for-byte.
- **Eviction** (new JVM test): a descriptor removed from a recompiled source vanishes from the carrier.
- **Real-Shadow duplicate-root-id**: a duplicate `:my.app/counter` across two namespaces in minimal-counter FAILS at `:compile-finish` with `:re-frame.ui.compiler.build/duplicate-root-id`, both sites anchored — the full stamp→harvest→conflict path firing on a genuine Shadow build (reverted after).

## Fence

The two `shadow-cljs.edn` tax lines (S6 owns the cut-over) and the S0 probe are untouched. Disjoint from s1jur (Helix docs) and vxgfnd.99.2 (workflows/deps.edn).

## Quality gates

All foreground, run to completion:

- `implementation/ui` `clojure -M:test` — **937 tests / 18892 assertions, 0 failures, 0 errors** (2 new descriptor carrier tests)
- `npm run test:cljs` — **10372 tests / 51277 assertions, 0 failures, 0 errors**
- `npm run test:elision` — PASS (production 60/60 absent; 0 warnings)
- `npm run test:perf-bundle` — PASS (no regression)
- `npm run test:ui-warm-watch` — PASS (real Shadow daemon; warm cache-hit + failed-build/last-known-good + delete-eviction phases)
- fresh-consumer sim: `examples/ui/minimal-counter` release build — 0 warnings
- duplicate-root-id conflict proof on real Shadow — fails at compile-finish as expected
- `scripts/check-no-hardcoded-paths.sh` — OK

Does NOT merge — S6 is the cut-over.
