### PR TITLE
fix(ci): lower routing stress-test iterations so the nightly completes under load (rf2-g2ytj)

### DIFF
--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -255,4 +255,18 @@ jobs:
             ${{ runner.os }}-clj-
 
       - name: Run JVM slow/stress tests
+        # rf2-g2ytj — the routing `popstate-mid-push-stress` suite defaults
+        # to 5000 iters × 8 threads (~60s on an unstarved box), but the
+        # loaded nightly runner starves it ~8× so all 8 threads finish only
+        # ~650/5000 iters before the test's 120s per-future deref bound and
+        # the run TIMES OUT (a CPU-starvation wall-clock timeout, NOT a
+        # concurrency race — the correctness invariants are unchanged and
+        # still assert). Lower JUST the nightly routing run to 500 iters via
+        # the test's `RF2_KSBUR_STRESS_ITERS` override so it completes well
+        # within the bound; 500 × 8 threads still exercises the invariants
+        # meaningfully. The default (5000) is unchanged — the local rigorous
+        # sweep (`scripts/test-rigorous-local.sh`) still runs full strength.
+        # Scoped to `routing`; the other matrix artefacts never read this var.
+        env:
+          RF2_KSBUR_STRESS_ITERS: ${{ matrix.artefact == 'routing' && '500' || '' }}
         run: clojure -M:slow-test


### PR DESCRIPTION
Mike-ruled Option 1 (2026-07-22): lower the nightly CI iteration count for the routing `popstate-mid-push-stress` stress test so it completes within its 120s per-future deref bound under the loaded runner. Minimal tuning fix — no correctness invariant, assertion, deref-bound logic, or frame-state I/O changed.

## Root cause (worker evidence, per the ruling)
The failure in the nightly `JVM slow/stress tests (routing)` job is a **CPU-starvation wall-clock timeout, not a concurrency race**. The fetched CI log (run 29760811080) showed the 8 threads completing only ~650/5000 iters each before the 120s deref bound — invariants 1/2/3 "fail" only because the run never *finishes*, not because of a lost write. An instrumented multi-writer detector saw zero concurrent writers across ~580 runs; faithful `clojure -M:slow-test` at normal heap / 2-vCPU pins was green 24+ times. The prime-suspect commit-RMW is a red herring (the RMW predates it).

## The change
`.github/workflows/expensive-tests.yml` only: set `RF2_KSBUR_STRESS_ITERS: 500` on the `Run JVM slow/stress tests` step, scoped to the `routing` matrix artefact via a matrix conditional. 500 × 8 threads still exercises the concurrency invariants meaningfully; worst-case ~5.4 iters/s under starvation × 500 is well within the 120s bound.

- The test's **default (5000) is unchanged** — consistent with the sibling machines/core/flows stress tests, and `scripts/test-rigorous-local.sh` still runs the routing slow-test at full 5000 strength on an unstarved local box.
- The env var is read only by the routing stress test; the other matrix artefacts never read it.
- No change to `frame.cljc`, the invariants, the deref-bound logic, or any assertion. No retry/skip/loosened-invariant logic.

## Quality gates
- `RF2_KSBUR_STRESS_ITERS=500 clojure -M:slow-test` (implementation/routing), foreground: **EXIT 0 in ~88s** — 3 stress tests / 73 assertions / 0 failures, 0 errors (the flaky `popstate-mid-push-stress` included and green; completes far under the 120s bound).
- `clojure -M:test` (implementation/routing), foreground: **EXIT 0** — 458 tests / 2382 assertions / 0 failures, 0 errors.
- YAML parse of `expensive-tests.yml`: **OK** (4 jobs; routing env expression `${{ matrix.artefact == 'routing' && '500' || '' }}`).

Rebased onto current `origin/main` (incorporates rf2-vxgfnd.99.2's release work); sole toucher of `expensive-tests.yml`; disjoint from live workers `u53yy.1 S6` (shadow-cljs.edn/build_hook) and `vxgfnd.99.2` (release.yml/deps.edn).

Closes rf2-g2ytj.