### PR TITLE
docs(ui): presence child-order contract (rf2-1kb0v)

### DIFF
--- a/docs/core/re-frame.ui/presence.md
+++ b/docs/core/re-frame.ui/presence.md
@@ -63,6 +63,13 @@ How it behaves:
   timeout is the mandatory exit retention duration *and* the terminal bound; the
   boundary watches no transition events, so make it match (or exceed) your CSS
   transition time.
+- Children render in **first-appearance order**, and that order is frozen: each key
+  holds the slot it first mounted into, an incoming reorder is ignored, and a
+  newly-appearing key is appended at the tail — even one whose value sorts first.
+  The slot stability is deliberate: an exiting child never jumps position
+  mid-animation. Presence is for enter/exit, not reordering — if the rendered order
+  must track a changing sort, order it at the presentation layer rather than
+  wrapping the sorted list in a boundary.
 - `(ui/presence-phase)` is the single phase read. Outside any presence boundary it
   returns `:present`, so presence-aware children stay reusable anywhere.
 - The per-child phase Provider wraps each child **element**, which is why the

--- a/implementation/ui/src/re_frame/ui/presence_runtime.cljc
+++ b/implementation/ui/src/re_frame/ui/presence_runtime.cljc
@@ -53,7 +53,10 @@
       it is dropped from the set only by its removal callback, never here);
     - a brand-new incoming key is appended as `:mounting`.
 
-  Retained (`:unmounting`) keys hold their slot; new keys append at the end."
+  EVERY committed key — still-`:present` and retained (`:unmounting`) alike —
+  holds its committed slot; the incoming ORDER orders only the appended new keys,
+  so children render in first-appearance order and an incoming reorder is ignored
+  (the blessed order contract, rf2-1kb0v — presence is enter/exit, not reordering)."
   [committed incoming]
   (let [incoming-set (set incoming)
         committed-keys (into #{} (map :key) committed)

--- a/implementation/ui/test/re_frame/ui/presence_reconcile_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/presence_reconcile_cljs_test.cljc
@@ -63,6 +63,20 @@
            (phases next))
         "b holds its slot as :unmounting; d appends at the end")))
 
+(deftest incoming-reorder-is-ignored
+  ;; The blessed order contract (rf2-1kb0v): children render in FIRST-APPEARANCE
+  ;; order. EVERY kept key — not only a retained :unmounting one — holds its
+  ;; committed slot, so an incoming reorder of still-:present keys changes
+  ;; nothing, and a new key appends at the tail even when it arrives first in
+  ;; the incoming vector.
+  (let [committed [{:key "a" :phase :present} {:key "b" :phase :present}]]
+    (testing "committed [a b] + incoming [b a] -> entries stay [a b], both :present"
+      (is (= [["a" :present] ["b" :present]]
+             (phases (presence/reconcile committed ["b" "a"])))))
+    (testing "a prepended new key still appends at the tail: incoming [x a b] -> [a b x]"
+      (is (= [["a" :present] ["b" :present] ["x" :mounting]]
+             (phases (presence/reconcile committed ["x" "a" "b"])))))))
+
 ;; ---------------------------------------------------------------------------
 ;; Idempotence — a StrictMode double-render is harmless
 ;; ---------------------------------------------------------------------------

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -691,6 +691,13 @@ enter/exit retention is out of scope):
   *and* terminal bound, not a cap over some other completion signal — then cleanup is
   terminal and exactly-once (all ownership released). Unkeyed children under a presence
   boundary are a build failure.
+- Children render in **first-appearance order**, and that order is frozen: a key holds
+  the slot it first mounted into, an incoming reorder is deliberately ignored, and a
+  newly-appearing key appends at the tail regardless of its incoming position. Slot
+  stability is part of the retention contract — an exiting child never jumps position
+  mid-animation. Sort upstream of the boundary when first-appearance order matters; a
+  list whose rendered order must track a changing sort does not belong under a presence
+  boundary — handle display order at the presentation layer (rf2-1kb0v).
 - `(presence-phase)` is the single phase read. Outside a presence boundary it returns
   `:present`, so presence-aware children stay reusable anywhere.
 - Removal-then-reinsertion of a key has deterministic interruption/re-entry; hydration


### PR DESCRIPTION
## Summary

Implements the recorded ruling on rf2-1kb0v — **(A) bless the freeze**: presence children render in **first-appearance order**; an incoming reorder is deliberately ignored; a newly-appearing key appends at the tail regardless of its incoming position; slot stability during exits is part of the retention contract. Reorder-sensitive lists sort upstream of the boundary, and a list whose rendered order must track a changing sort does not belong under a presence boundary. **No runtime behavior change.**

- `spec/004-Views.md` §Presence — one normative order-contract bullet (hot-zone 004; sole toucher in flight).
- `implementation/ui/src/re_frame/ui/presence_runtime.cljc` — `reconcile` docstring truth-up: ALL kept keys (still-`:present` and retained alike) hold their committed slot, not only `:unmounting` ones.
- `docs/core/re-frame.ui/presence.md` — order-contract paragraph in the behavior list (the shipped rf2-xqmt7 page had no order sentence).
- `implementation/ui/test/re_frame/ui/presence_reconcile_cljs_test.cljc` — pinning test `incoming-reorder-is-ignored`: committed `[a b]` + incoming `[b a]` stays `[a b]` (both `:present`); a prepended new key still appends at the tail (`[x a b]` → `[a b x]`).

Resumes and completes the stranded WIP from the interrupted session (docstring + guide paragraph kept as salvaged; spec bullet + test added).

## Quality gates

- `clojure -M:test` (implementation/ui): 938 tests, 18897 assertions, 0 failures, 0 errors
- `npm run test:cljs` (implementation/): 10373 tests, 51279 assertions, 0 failures, 0 errors
- `mkdocs build --strict` (repo root): built clean, INFO-only notices

Closes rf2-1kb0v.