### PR TITLE
fix(reactive): canonicalize legacy :value cause at weak-store ingress (rf2-ao46i)

### DIFF
--- a/docs/EP/EP-0033-re-frame-ui-view-evidence.md
+++ b/docs/EP/EP-0033-re-frame-ui-view-evidence.md
@@ -127,7 +127,9 @@ capture machine, never a general evidence framework):
 - `:mount` — the first connected commit (`:fresh`→`:connected`); a bare `{:cause :mount}`.
 - `:subscription` — a value-movement port note carrying its ruled detail
   `{:target :query :frame-id :from :to :epoch}` (coalesced: earliest `:from`, latest
-  `:to`). Renamed from the port's `:value` on the record surface.
+  `:to`). The port note itself carries the `:subscription` keyword (unified
+  port-wide from the original `:value` — rf2-ao46i), so the record adopts it
+  unchanged.
 - `:story-override` — a (re)acquired static Story-override target, carrying
   `{:override-id :version}`.
 - `:local-state` — the substrate-owned local writer bridge (gated on an `Object.is`

--- a/implementation/ui/src/re_frame/ui/tool/evidence.cljc
+++ b/implementation/ui/src/re_frame/ui/tool/evidence.cljc
@@ -238,8 +238,26 @@
          :else
          [dynamic-marker false])))))
 
+(defn- canonicalize-causes
+  "Rewrite the pre-rename disposal-cause spelling `:value` to today's
+  `:subscription` in one ingress cause set (rf2-ao46i, RULING 2). Fresh
+  deliveries already speak the unified `:subscription`/`:hmr`/`:disposed`
+  vocabulary, but a RETAINED accrual — or a pending window carried across a
+  reload — minted before the rename can still say `:value`, and carrying it
+  verbatim would union with fresh `:subscription` into the two-vocabulary set
+  the consumer contract forbids. One spelling rewrite at the shared
+  normalization choke point, not a compatibility layer."
+  [causes]
+  (if (contains? causes :value)
+    (-> causes (disj :value) (conj :subscription))
+    causes))
+
 (defn- project-batch-evidence
-  "Replace delivered target identities with bounded non-owning EDN copies.
+  "Replace delivered target identities with bounded non-owning EDN copies,
+  and canonicalize the cause vocabulary (`canonicalize-causes`) — BOTH ingress
+  paths (fresh delivery via `accrete-evidence`, retained-row migration via
+  `reproject-accrual`) normalize here, so no pre-rename `:value` spelling
+  survives into a retained value or a projection read.
   Loss is explicit: `:targets-exact?` covers both shown and dropped target
   identity. `:dropped-exact?` also becomes false after any such loss because
   opaque collisions mean cumulative omitted-target cardinality is no longer
@@ -257,6 +275,7 @@
         (assoc :targets targets
                :dropped dropped
                :targets-exact? targets-exact?)
+        (update :causes canonicalize-causes)
         (cond-> (or (false? (:dropped-exact? ev))
                     (not targets-exact?))
           (assoc :dropped-exact? false)))))
@@ -337,8 +356,12 @@
   This IS the delivery path — `project-batch-evidence` then `fold-target` —
   so a migrated row is indistinguishable from one accreted fresh: the same
   bounded shown sample, the same distinct-loss partition, the same honesty.
-  Counters (`:count`, `:batches`, epochs, causes) are already bounded plain
-  data and carry over verbatim; `:targets` keeps its first-seen order.
+  Counters (`:count`, `:batches`, epochs) are already bounded plain data and
+  carry over verbatim; `:targets` keeps its first-seen order. The cause set is
+  bounded but NOT vocabulary-neutral: a store minted before the disposal-cause
+  rename retains `:value` where today's contract says `:subscription`, so the
+  causes carry over through the normalization's `canonicalize-causes` — never
+  verbatim (rf2-ao46i).
 
   Exactness only ever LOWERS. Re-projection can discover loss the legacy record
   never marked, but it can never prove an exactness the legacy floor already
@@ -349,7 +372,7 @@
   (let [acc0 (merge empty-accrual acc)
         ev   (project-batch-evidence acc0)]
     (-> acc0
-        (assoc :targets [] :dropped #{})
+        (assoc :causes (:causes ev) :targets [] :dropped #{})
         (as-> a (reduce fold-target a (concat (:targets ev) (:dropped ev))))
         (cond-> (false? (:targets-exact? ev)) (assoc :targets-exact? false)
                 (false? (:dropped-exact? ev)) (assoc :dropped-exact? false)))))
@@ -365,18 +388,24 @@
 
 (def ^:private ^:const weak-store-tag
   ;; The CURRENT retained-value contract version. A store carrying EXACTLY this
-  ;; tag has had every entry through today's `project-target-value`; any other
-  ;; shape — an older tag, or the untagged defrecord/strong-map stores left by
-  ;; earlier heads — is LEGACY, and its entries are re-projected on migration
-  ;; (rf2-vxgfnd.94.18). BUMP THIS whenever the copier changes what a retained
-  ;; value may hold: v1 admitted metadata-bearing symbols, whose metadata could
-  ;; hold the very ViewCell the entry is weak-keyed by (rf2-vxgfnd.94.17). v2 was
-  ;; minted at an intermediate head whose copier ALSO returned those symbols
-  ;; verbatim, and the copier was then FIXED under the same v2 tag — so a store
-  ;; HMR-migrated at that head carries a v2 tag over metadata-bearing values and
-  ;; would be trusted forever. v3 rejects every pre-final store and re-projects
-  ;; it (rf2-1hob1).
-  ::weak-cell-entries-v3)
+  ;; tag has had every entry through today's normalization (the
+  ;; `project-target-value` copier AND the cause-vocabulary canonicalization);
+  ;; any other shape — an older tag, or the untagged defrecord/strong-map
+  ;; stores left by earlier heads — is LEGACY, and its entries are re-projected
+  ;; on migration (rf2-vxgfnd.94.18). BUMP THIS whenever normalization changes
+  ;; what a retained value may hold: v1 admitted metadata-bearing symbols,
+  ;; whose metadata could hold the very ViewCell the entry is weak-keyed by
+  ;; (rf2-vxgfnd.94.17). v2 was minted at an intermediate head whose copier
+  ;; ALSO returned those symbols verbatim, and the copier was then FIXED under
+  ;; the same v2 tag — so a store HMR-migrated at that head carries a v2 tag
+  ;; over metadata-bearing values and would be trusted forever. v3 rejects
+  ;; every pre-final store and re-projects it (rf2-1hob1). v3 was ALSO current
+  ;; before the disposal-cause rename (:value → :subscription, rf2-ao46i), so
+  ;; a same-owner HMR store tagged v3 can retain :causes #{:value}; trusting
+  ;; that tag would skip the sanitation pass that canonicalizes the spelling,
+  ;; and the stale row would later union with fresh :subscription and egress a
+  ;; two-vocabulary set through explain-render. v4 forces that one pass.
+  ::weak-cell-entries-v4)
 
 (def ^:private ^:const weak-store-tag-key ::weak-cell-entries)
 

--- a/implementation/ui/test/re_frame/ui/tool_evidence_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/tool_evidence_cljs_test.cljc
@@ -31,6 +31,7 @@
             [re-frame.substrate.plain-atom  :as plain-atom]
             [re-frame.test-support          :as test-support]
             [re-frame.ui.reactive           :as reactive]
+            [re-frame.ui.tool               :as tool]
             [re-frame.ui.tool.evidence      :as evidence]))
 
 (use-fixtures :each
@@ -556,13 +557,17 @@
 
 (defn- legacy-accrual
   "The exact accrual a PRE-projection head accreted: RAW target keys, claimed
-  exact — its copier did not exist yet, so it had nothing to be inexact about."
+  exact — its copier did not exist yet, so it had nothing to be inexact about.
+  Every pre-projection head ALSO predates the disposal-cause rename
+  (rf2-ao46i), so the true legacy cause spelling is `:value` — seeding
+  `#{:subscription}` here would mask the very transition migration must
+  canonicalize."
   [targets dropped]
   {:first-epoch    1
    :latest-epoch   2
    :count          3
    :batches        1
-   :causes         #{:subscription}
+   :causes         #{:value}
    :targets        (vec targets)
    :targets-exact? true
    :dropped        (set dropped)
@@ -578,6 +583,11 @@
 ;; copier still returned metadata-bearing symbols verbatim, then kept over the
 ;; copier fix. A store stamped with it must be treated as legacy (rf2-1hob1).
 (def ^:private v2-tag :re-frame.ui.tool.evidence/weak-cell-entries-v2)
+
+;; The prior contract tag (`::weak-cell-entries-v3`) — current at the heads
+;; BEFORE the disposal-cause rename (rf2-ao46i), so an ordinary same-owner HMR
+;; store can carry it over accruals whose cause set still says `:value`.
+(def ^:private v3-tag :re-frame.ui.tool.evidence/weak-cell-entries-v3)
 
 (deftest compatible-hmr-sanitizes-a-legacy-strong-map-store
   ;; The pre-weak head kept `:entries` as a STRONG persistent map keyed by
@@ -623,7 +633,8 @@
         (is (= 1 (:batches ev)))
         (is (= 1 (:first-epoch ev)))
         (is (= 2 (:latest-epoch ev)))
-        (is (= #{:subscription} (:causes ev))))
+        (is (= #{:subscription} (:causes ev))
+            "the pre-rename :value cause reads canonicalized, never verbatim"))
       (is (= bounded-evidence-keys
              (set (keys (:evidence (entry-for ::legacy-direct)))))
           "migration adds no keys"))
@@ -786,6 +797,46 @@
        (is (true? (gc-until #(nil? (.get ^java.lang.ref.WeakReference ref))))
            "the re-projected v2 store no longer roots its own weak key")
        (is (= [] (evidence/projection))))))
+
+(deftest compatible-hmr-canonicalizes-a-v3-tagged-pre-rename-cause-set
+  ;; rf2-ao46i [the #6589 audit rider]. `::weak-cell-entries-v3` was current
+  ;; BEFORE the disposal-cause rename, so an ordinary same-owner HMR store
+  ;; tagged v3 can retain `:causes #{:value}`. `weak-store-current?` trusted
+  ;; that tag (skipping sanitation) and `reproject-accrual` carried causes
+  ;; verbatim, so the stale row later unioned with a fresh `:subscription`
+  ;; delivery and `explain-render` exposed `#{:value :subscription}` — a
+  ;; two-vocabulary set the consumer contract (:subscription/:hmr/:disposed)
+  ;; forbids. RED before the v4 tag bump + cause canonicalization; observed
+  ;; through the PUBLIC explain-render path, the surface whose contract the
+  ;; union violated.
+  (is (true? (evidence/install! ::tool-a)))
+  (let [state* @#'evidence/state*
+        cell   (connect-empty! (reactive/make-cell ::v3-pre-rename))
+        store  (:entries @state*)]
+    (#'evidence/store-seed-entry!
+     store cell
+     (legacy-entry 5 ::v3-pre-rename
+                   (legacy-accrual [[:sub fid [::q 1]]] [])))
+    ;; stamp the pre-rename current tag over the seeded store
+    (swap! state* assoc-in [:entries tag-key] v3-tag)
+
+    (is (true? (evidence/install! ::tool-a)) "the reload re-arms the same owner")
+
+    ;; fresh post-rename movement unions into the SAME retained accrual
+    (publish-target! (evidence/installed-sink) cell [:sub fid [::q 2]])
+
+    (testing "the retained :value canonicalizes — no two-vocabulary union"
+      (let [occ (first (:occurrences (tool/explain-render ::v3-pre-rename)))]
+        (is (some? occ) "the migrated row reaches the public projection")
+        (is (= #{:subscription} (:causes occ))
+            "explain-render speaks exactly the unified vocabulary — the
+            retained :value reads as :subscription, never alongside it")
+        (is (= 5 (:occurrence occ)) "the ordinal survives the migration")))
+
+    (testing "the store is re-tagged current, so repeat HMR is idempotent"
+      (let [before (evidence/projection)]
+        (is (true? (evidence/install! ::tool-a)))
+        (is (= before (evidence/projection)))))))
 
 ;; ===========================================================================
 ;; Cross-batch loss honesty (the rf2-vxgfnd.74 axis, cumulative tier)


### PR DESCRIPTION
Closes the unresolved rf2-ao46i audit residual (the #6589 rider, confirmed unresolved through #6646 by the #6642 three-lens audit).

## Defect

A pre-rename same-owner HMR evidence store already tagged `::weak-cell-entries-v3` can retain `:causes #{:value}`. `reproject-accrual` carried causes verbatim and `weak-store-current?` trusted the v3 tag, so the stale row bypassed sanitation and later unioned with fresh `:subscription` — `explain-render` could expose `#{:value :subscription}` while the consumer contract promises only `:subscription`/`:hmr`/`:disposed`. The legacy fixture had been mechanically renamed to seed `#{:subscription}`, so no test could catch the transition.

## The smallest repair (exactly the audit's ruling)

- **Canonicalize cause ingress** — `canonicalize-causes` rewrites `:value` → `:subscription` inside `project-batch-evidence`, the one normalization choke point both ingress paths share (fresh/pending delivery via `accrete-evidence`, retained-row migration via `reproject-accrual`); `reproject-accrual` now takes the canonicalized cause set instead of carrying it verbatim.
- **Private tag bump only** — `::weak-cell-entries-v3` → `::weak-cell-entries-v4` forces one sanitation pass over stores minted before the rename. No public schema bump (`schema-version` 3 unchanged), no compatibility framework.
- **True pre-rename fixture restored** — `legacy-accrual` seeds `:causes #{:value}` again, and a new `compatible-hmr-canonicalizes-a-v3-tagged-pre-rename-cause-set` test drives the exact bypass scenario (v3-tagged store + same-owner re-install + fresh `:subscription` union) observed through the PUBLIC `tool/explain-render` path. RED before the tag bump + canonicalization.
- **EP-0033** — corrects the adjacent stale historical sentence ("Renamed from the port's `:value` on the record surface") left behind by the port-wide unification.

Deferred consumer sweeps stay owned by rf2-0sray / rf2-u53yy.4 — not absorbed here.

## Quality gates

- `implementation/ui` `clojure -M:test` — 938 tests / 18910 assertions, 0 failures, 0 errors
- `implementation/core` `clojure -M:test` — 2104 tests / 10413 assertions, 0 failures, 0 errors
- `implementation/` `npm run test:cljs` — 10373 tests / 51284 assertions, 0 failures, 0 errors
- `implementation/` `npm run test:xray-feature-gate` — 16 scenarios, 0 failures, 13 matrix rows covered