### PR TITLE
fix(examples): realworld-ui entry base-path + asset staging (rf2-nn5s8)

### DIFF
--- a/examples/real-apps/realworld_resources/README.md
+++ b/examples/real-apps/realworld_resources/README.md
@@ -231,12 +231,25 @@ adapters, never a replacement).
 | view form | `reg-view` (Reagent) | `ui/defview` (compiled) |
 | mount | `reagent.dom.client/render` + `rf/frame-root` | `ui/mount` + `ui/frame-root` |
 
-Build it under shadow-cljs id `examples/realworld-resources-ui` from
-`implementation/`:
+Run it with the one-command dev front door, from `implementation/`:
 
 ```bash
-shadow-cljs watch examples/realworld-resources-ui
+npm run dev:example -- examples/realworld-resources-ui
 ```
+
+That stages the app's `index.html`, the shared design-system assets, **and** the
+fallback `default-avatar.svg` next to the compiled bundle, serves the build, and
+watches for edits. Open the printed `http://127.0.0.1:<port>/` and the shell
+boots straight into the home route.
+
+The ui arm mounts under its own `/realworld-resources-ui` deployment base — the
+sub-path that matches its `out/examples/realworld-resources-ui` output — declared
+as `url-strategy-ui` in `routing.cljs` (the Reagent arm keeps its own
+`/realworld-resources` base, `url-strategy`). The route table and every bit of
+dataflow are shared verbatim; only the mount point differs, so the two arms never
+collide and every generated ui-arm link targets the `/realworld-resources-ui`
+mount. `strip-base-path` fails safe on `/`, so the shell still boots into home
+when the build is served at the server root (as `dev:example` does).
 
 A few compiled-view idioms the ui arm demonstrates, worth reading for how a real
 CRUD app expresses itself on the substrate:

--- a/examples/real-apps/realworld_resources/routing.cljs
+++ b/examples/real-apps/realworld_resources/routing.cljs
@@ -299,15 +299,35 @@
 ;; ROUTER WIRING  (base-path-aware)
 ;; ============================================================================
 ;;
-;; The dev orchestrator serves this example under `/realworld-resources/`, but
-;; the routes above are written as if it owned `/`. `with-base-path` wraps the
-;; default history strategy so that prefix is
+;; Each entry is served from its OWN deployment sub-path (a host mounting the
+;; demos side by side), but the routes above are written as if the app owned
+;; `/`. `with-base-path` wraps the default history strategy so that prefix is
 ;; stripped/re-added automatically at the framework's four egress/ingress
-;; consult points (Spec 012 §URL strategies). Declared as this app's
-;; `:url-strategy` on the URL-owning frame in core.cljs; the frame's
-;; `:url-bound? true` creation installs the base-path-aware popstate listener
-;; AND does the first URL→route sync itself — which is the trick that fires
-;; the route's `:resources` ensures on entry, with zero hand-rolled listener
-;; or explicit install call.
+;; consult points (Spec 012 §URL strategies). The frame's `:url-bound? true`
+;; creation installs the base-path-aware popstate listener AND does the first
+;; URL→route sync itself — which is the trick that fires the route's
+;; `:resources` ensures on entry, with zero hand-rolled listener or explicit
+;; install call.
+;;
+;; DEPLOYMENT BASE IS ENTRY-SPECIFIC. The route table + all the dataflow above
+;; are shared verbatim between the two arms; only where each is MOUNTED differs,
+;; so each entry names its own base-path strategy:
+;;   - the Reagent arm (core.cljs, build `:examples/realworld-resources`) mounts
+;;     under `/realworld-resources`  → `url-strategy` below;
+;;   - the re-frame.ui arm (ui_core.cljs, build `:examples/realworld-resources-ui`)
+;;     mounts under `/realworld-resources-ui`, the deploy sub-path that MATCHES
+;;     its `out/examples/realworld-resources-ui` output  → `url-strategy-ui` below.
+;; The ui arm must NOT reuse the Reagent `/realworld-resources` base: that prefix
+;; fails to strip off a `/realworld-resources-ui/…` URL (it is a prefix-sharing
+;; SIBLING, not a path-segment ancestor), so the shell would boot into a
+;; not-found route and generated links would target the Reagent mount
+;; (rf2-nn5s8 audit rider). `strip-base-path` fails safe on `/`, so either
+;; strategy also boots correctly when the build is served at the server root.
 (def url-strategy
   (routing/with-base-path routing/history-url-strategy "/realworld-resources"))
+
+;; The re-frame.ui arm's entry-specific twin (see the note above): SAME shared
+;; route table + dataflow, mounted under its own `/realworld-resources-ui` base.
+;; The Reagent `url-strategy` above is left exactly as it was.
+(def url-strategy-ui
+  (routing/with-base-path routing/history-url-strategy "/realworld-resources-ui"))

--- a/examples/real-apps/realworld_resources/ui_core.cljs
+++ b/examples/real-apps/realworld_resources/ui_core.cljs
@@ -167,7 +167,14 @@
    [ui/frame-root {:id             :rf/default
                    :doc            "RealWorld-on-resources demo frame (re-frame.ui variant)."
                    :url-bound?     true
-                   :url-strategy   routing/url-strategy
+                   ;; The re-frame.ui arm is served under its OWN mount point,
+                   ;; `/realworld-resources-ui` (matching its
+                   ;; `out/examples/realworld-resources-ui` output) — so it uses
+                   ;; routing's entry-specific `url-strategy-ui`, NOT the Reagent
+                   ;; arm's `/realworld-resources` base (which would strip the
+                   ;; wrong prefix and boot the shell into a not-found route —
+                   ;; rf2-nn5s8 audit rider).
+                   :url-strategy   routing/url-strategy-ui
                    :interceptors   [:realworld-resources.routing/auth-guard]
                    :fx-overrides   {:rf.http/managed :realworld-resources.demo/http-stub}
                    :initial-events [[:auth/classify-token]

--- a/examples/scripts/examples-asset-manifest.cjs
+++ b/examples/scripts/examples-asset-manifest.cjs
@@ -122,6 +122,24 @@ const EXAMPLE_ASSET_MANIFEST = [
       { from: 'src', src: 'default-avatar.svg', dest: 'default-avatar.svg', htmlLinked: false },
     ],
   },
+  {
+    build: 'examples/realworld-resources-ui',
+    page: 'examples/real-apps/realworld_resources/index.html',
+    reason:
+      'The RealWorld resources re-frame.ui variant (ui_core / ui_views) falls ' +
+      'a nil/blank avatar back to default-avatar.svg exactly like the Reagent ' +
+      'arm — ui_views calls realworld_shared.avatar/avatar-src throughout and ' +
+      'the canned corpus has blank :image values. The build resolves to the ' +
+      'SAME colocated source folder as the Reagent arm, so the asset is the ' +
+      'same colocated default-avatar.svg. Without this entry the enumerator ' +
+      'discovers the ui build but stages no avatar, so clean staging serves ' +
+      'broken avatars. Referenced from app code, not linked in the HTML — no ' +
+      'scanner exemption, staging-only.',
+    assetExemptions: [],
+    assets: [
+      { from: 'src', src: 'default-avatar.svg', dest: 'default-avatar.svg', htmlLinked: false },
+    ],
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -62,6 +62,11 @@
             [re-frame.resources.state :as state]
             [re-frame.resources.test-support]
             [re-frame.routing :as routing]
+            ;; the shared node window/history/location stub (rf2-y6e2zb) — the
+            ;; existing browser seam the ui-arm url-strategy pins below drive
+            ;; the ingress `:decode` leg through (rf2-nn5s8 audit rider).
+            [re-frame.routing-browser-test-support
+             :refer [with-window-stub-fixture]]
             ;; the framework trace-ring buffer (Spec 009) — cleared around each
             ;; test body so this dispatching suite leaves no trace residue for a
             ;; later cross-cutting tooling test (e.g. the Xray/Story panel e2e
@@ -70,6 +75,10 @@
             ;; the example's production source — chains in every feature ns.
             [realworld-resources.core :as core]
             [realworld-resources.scope :as scope]
+            ;; the example's shared route table + the two ENTRY-SPECIFIC url
+            ;; strategies (already loaded via core; aliased for the ui-arm
+            ;; url-strategy pins — rf2-nn5s8 audit rider).
+            [realworld-resources.routing :as app-routing]
             ;; The shared WIRE contract (User / UserResponse) + this app's durable
             ;; app-db schemas (AuthSlice), for the default-frame validator
             ;; regression (rf2-3fc89f.32).
@@ -1339,3 +1348,64 @@
             "an unmatched URL is not gated — the guard leaves it alone")
         (is (= crumb (return-to f))
             "an unmatched URL leaves the existing crumb untouched — no spurious re-stash")))))
+
+;; ============================================================================
+;; UI-ARM URL STRATEGY — entry-specific deployment base (rf2-nn5s8 audit rider)
+;; ============================================================================
+;;
+;; The re-frame.ui arm (`ui_core.cljs`, build `:examples/realworld-resources-ui`)
+;; is served under its OWN mount, `/realworld-resources-ui` — a prefix-sharing
+;; SIBLING of the Reagent arm's `/realworld-resources`, not a path under it.
+;; PR #6648 shipped the ui entry reusing the Reagent arm's `url-strategy`, so
+;; the shell booted into not-found and every generated link targeted the
+;; Reagent mount (the audit's browser repro). These pins prove the repaired
+;; entry-specific `url-strategy-ui` at the framework's REAL consult points —
+;; ingress `:decode` against the shared node window stub feeding the shared
+;; route table, and egress `route-link` href synthesis — while the examples
+;; tree itself stays test-free (rf2-8cevm).
+
+(deftest ui-arm-url-strategy-decodes-and-links-its-own-mount
+  (testing "ingress: the ui strategy decodes its own served mount — the initial
+            boot URL resolves home, a deep link resolves its route — and the
+            Reagent strategy pins WHY the ui entry may not reuse it"
+    (with-window-stub-fixture
+      (fn []
+        ;; INITIAL DECODE at the ui build's served mount root: the boot URL the
+        ;; frame's first URL→route sync feeds is the app root — the home route's
+        ;; own `"/"` pattern. (Home ownership of `"/"` is the app's `reg-route`
+        ;; declaration; a global `match-url` pin on `"/"` would be test-BUNDLE
+        ;; ambiguous — other co-loaded example apps also register `"/"`.)
+        (.pushState js/globalThis.window.history nil "" "/realworld-resources-ui/")
+        (is (= "/" ((:decode app-routing/url-strategy-ui)))
+            "the ui mount root decodes to the app root — the home boot URL")
+        ;; DEEP LINK under the ui mount, through to route resolution.
+        (.pushState js/globalThis.window.history nil ""
+                    "/realworld-resources-ui/article/how-it-works")
+        (is (= "/article/how-it-works" ((:decode app-routing/url-strategy-ui)))
+            "a deep link under the ui mount decodes to its app-relative path")
+        (is (= {:route-id :realworld.article/show :params {:slug "how-it-works"}}
+               (-> (routing/match-url ((:decode app-routing/url-strategy-ui)))
+                   (select-keys [:route-id :params])))
+            "…which resolves the article route with its slug")
+        ;; THE AUDIT DEFECT, PINNED. `/realworld-resources` is a prefix-sharing
+        ;; SIBLING of `/realworld-resources-ui`, not a segment ancestor — the
+        ;; Reagent strategy fails safe (no strip), so the router receives the
+        ;; raw mount URL, which matches no app route and boots the shell into
+        ;; not-found. This is the Page-not-found repro that reopened rf2-nn5s8.
+        (.pushState js/globalThis.window.history nil "" "/realworld-resources-ui/")
+        (is (= "/realworld-resources-ui/" ((:decode app-routing/url-strategy)))
+            "the Reagent strategy leaves the sibling ui URL unstripped — why the ui entry declares its own"))))
+  (testing "egress: a route-link rendered on the ui entry's frame config targets
+            the ui mount; the Reagent arm's links still target ITS mount"
+    (with-new-frame [f (frame/make-anon-frame-record!
+                         {:url-strategy app-routing/url-strategy-ui})]
+      (let [[_ attrs] (rf/with-frame f
+                        (routing/route-link-render {:to :realworld.auth/login}))]
+        (is (= "/realworld-resources-ui/login" (:href attrs))
+            "the ui arm's generated link carries the ui mount base")))
+    (with-new-frame [f (frame/make-anon-frame-record!
+                         {:url-strategy app-routing/url-strategy})]
+      (let [[_ attrs] (rf/with-frame f
+                        (routing/route-link-render {:to :realworld.auth/login}))]
+        (is (= "/realworld-resources/login" (:href attrs))
+            "the Reagent arm's generated link still carries its own base — untouched")))))

--- a/implementation/scripts/_examples-staging.test.cjs
+++ b/implementation/scripts/_examples-staging.test.cjs
@@ -539,6 +539,7 @@ it('the LIVE staging PER_EXAMPLE_ASSETS IS the real manifest projection, non-vac
     'examples/managed-http-counter',
     'examples/realworld',
     'examples/realworld-resources',
+    'examples/realworld-resources-ui',
   ]) {
     assert.ok(
       Array.isArray(PER_EXAMPLE_ASSETS[build]) && PER_EXAMPLE_ASSETS[build].length > 0,


### PR DESCRIPTION
Repairs the two bounded standalone-integration defects from the PR #6648 three-lens audit rider that reopened rf2-nn5s8 (S7-ENTRY PROOF 1/2).

## 1. Route/mount base mismatch

The ui build emits under `out/examples/realworld-resources-ui` but `ui_core.cljs` reused the Reagent arm's `url-strategy`, hard-coded to `/realworld-resources` — a prefix-sharing SIBLING of the ui mount, not a segment ancestor, so `strip-base-path` failed safe, the shell booted into Page not found, and generated links targeted the Reagent mount.

Smallest fix, per the rider: `routing.cljs` gains an entry-specific `url-strategy-ui` (`with-base-path` over the same history strategy, base `/realworld-resources-ui`); `ui_core.cljs` declares it on its `ui/frame-root`. The Reagent `url-strategy` def is byte-identical to main; no base-path registry, no new runner.

**Proof via the existing config seam** (examples stay test-free, rf2-8cevm): one deftest in the example's existing integration suite (`implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs`), driving the ingress `:decode` leg through the shared node window stub (`re-frame.routing-browser-test-support`):
- initial decode: `/realworld-resources-ui/` → `/` (the home boot URL);
- deep link: `/realworld-resources-ui/article/how-it-works` → `/article/how-it-works` → `match-url` resolves `:realworld.article/show` + slug;
- outbound: a `route-link` rendered on a frame carrying `url-strategy-ui` hrefs `/realworld-resources-ui/login`;
- the defect pinned: the Reagent strategy leaves the sibling ui URL unstripped (the audit's Page-not-found repro), and its own links still target `/realworld-resources/login`.

## 2. Asset-staging gap

`PER_EXAMPLE_ASSETS` had no entry for the ui build → projection returned `assets=null` → clean staging served broken `default-avatar.svg` fallbacks. Fix: one entry in `examples/scripts/examples-asset-manifest.cjs` (same colocated `default-avatar.svg` declaration as the Reagent arm; staging-only, no scanner exemption, schema untouched) + the build added to the existing manifest/staging roster assertion in `implementation/scripts/_examples-staging.test.cjs`. Direct Node projection now returns the avatar asset.

## Run ergonomics

README's ui-arm section now names ONE coherent front door — `npm run dev:example -- examples/realworld-resources-ui` (stages index.html + `_shared` + the avatar, serves, watches) — and states the URL topology: the ui arm owns the `/realworld-resources-ui` deployment base (matching its output sub-path under a shared-root serve), and `strip-base-path` fails safe on `/` so the shell still boots home when `dev:example` serves the build at the server root.

## Constraints held

- Reagent variant untouched: `core.cljs` / `views.cljs` untouched; the `url-strategy` def unchanged; `check_adapter_disposition.py` green.
- `implementation/shadow-cljs.edn` untouched (hot-zone; the build id already exists there).
- No `*.spec.cjs` under `examples/`; no manifest-schema generalization.

## Quality gates

| Gate | Result |
|---|---|
| `shadow-cljs compile examples/realworld-resources-ui` | PASS — 330 files, 0 warnings |
| `npm run test:cljs` (implementation/) | PASS — 10373 tests / 51283 assertions, 0 failures, 0 errors |
| `python scripts/check_adapter_disposition.py` | PASS |
| `node scripts/_examples-staging.test.cjs` | PASS — all passed (incl. extended roster assertion) |
| `node scripts/check-examples-assets.test.cjs` | PASS — all passed (scanner projection unchanged: staging-only entry) |
| `sh scripts/check-no-hardcoded-paths.sh` | PASS |

Entry-proof evidence posts to rf2-vxgfnd.99.2 on merge (mayor-handled).