### PR TITLE
test(ui): true event-to-commit G-8 measurement — Profiler endpoint + alternating order (rf2-dpwel)

### DIFF
--- a/implementation/scripts/_g8-latency-evidence.test.cjs
+++ b/implementation/scripts/_g8-latency-evidence.test.cjs
@@ -7,8 +7,11 @@
  * canonical arms: real attributable React commit counts and the comparative
  * event-to-commit latency. This test pins the comparative-latency evidence
  * MATH — the stated nearest-rank quantile convention, sample-shape validation,
- * the evidence-only p95 budget comparison, and the step-summary rendering —
- * without spawning shadow-cljs or Playwright.
+ * the evidence-only p95 budget comparison, the rf2-dpwel two-channel shape
+ * (commit = true event-to-commit via the arm's Profiler onRender endpoint;
+ * settlement = the former input-to-quiescence metric, retained for
+ * comparison), and the step-summary rendering — without spawning shadow-cljs
+ * or Playwright.
  *
  * PURE by construction, exactly like the sibling `_g13-timing-evidence.test.cjs`:
  * it requires ONLY `assert/strict` and the pure `lib/g8-latency-evidence.cjs`
@@ -34,12 +37,14 @@ const {
   PERCENTILE_CONVENTION,
   RATIO_BUDGET,
   NOISE_POLICY,
+  CHANNELS,
   latencyPercentile,
   validateLatencySamples,
   summarizeLatency,
   withinBudget,
   p95Ratio,
   engineLatencyEvidence,
+  engineLatencyChannels,
   buildPerformanceSummary,
 } = require('./lib/g8-latency-evidence.cjs');
 
@@ -165,35 +170,89 @@ test('engineLatencyEvidence validates BOTH raw arrays (a malformed one fails lou
   assert.throws(() => engineLatencyEvidence('chromium', fill25(1), fill25(1).slice(0, 10)), /exactly 25/);
 });
 
+// ----- engineLatencyChannels: the rf2-dpwel two-channel evidence -------------
+
+// A synthetic fixture latency payload with distinguishable channels: commit
+// (true event-to-commit) well below settlement (input-to-quiescence), the way
+// the real fixture reports them.
+function fixtureLatency() {
+  return {
+    'compiled-commit-raw-ms': fill25(1.2),
+    'handwritten-commit-raw-ms': fill25(1.1),
+    'compiled-settle-raw-ms': fill25(5.0),
+    'handwritten-settle-raw-ms': fill25(4.0),
+    'order-policy': 'alternating pair order: even pairs compiled-first, odd pairs hand-written-first',
+  };
+}
+
+test('CHANNELS names exactly the commit and settlement channels', () => {
+  assert.deepEqual(CHANNELS, ['commit', 'settlement']);
+});
+
+test('engineLatencyChannels builds BOTH channels from the fixture payload and carries the order policy', () => {
+  const e = engineLatencyChannels('chromium', fixtureLatency());
+  assert.equal(e.engine, 'chromium');
+  assert.match(e['order-policy'], /alternating pair order/);
+  assert.equal(e.commit.compiled['p95-ms'], 1.2);
+  assert.equal(e.commit.handwritten['p95-ms'], 1.1);
+  assert.equal(e.settlement.compiled['p95-ms'], 5.0);
+  assert.equal(e.settlement.handwritten['p95-ms'], 4.0);
+  assert.equal(e.commit['within-10pct'], true);
+  assert.equal(e.settlement['within-10pct'], false); // 1.25x — observed, never gated
+});
+
+test('engineLatencyChannels validates every raw array and names the engine/channel', () => {
+  const missingCommit = fixtureLatency();
+  delete missingCommit['compiled-commit-raw-ms'];
+  assert.throws(() => engineLatencyChannels('webkit', missingCommit), /webkit\/commit/);
+  const shortSettle = fixtureLatency();
+  shortSettle['handwritten-settle-raw-ms'] = fill25(1).slice(0, 10);
+  assert.throws(() => engineLatencyChannels('webkit', shortSettle), /exactly 25/);
+  assert.throws(() => engineLatencyChannels('webkit', null), /not an object/);
+});
+
 // ----- buildPerformanceSummary: evidence-only posture + raw visible ----------
 
 function twoEngineEvidence() {
   return [
-    engineLatencyEvidence('chromium', fill25(1.2), fill25(1.1)),
-    engineLatencyEvidence('webkit', fill25(1.4), fill25(1.3)),
+    engineLatencyChannels('chromium', fixtureLatency()),
+    engineLatencyChannels('webkit', {
+      ...fixtureLatency(),
+      'compiled-commit-raw-ms': fill25(1.4),
+      'handwritten-commit-raw-ms': fill25(1.3),
+    }),
   ];
 }
 
-test('buildPerformanceSummary states the evidence-only posture and the conventions', () => {
+test('buildPerformanceSummary states the evidence-only posture, the conventions, and both channels', () => {
   const md = buildPerformanceSummary(twoEngineEvidence());
   assert.match(md, /EVIDENCE ONLY/);
   assert.match(md, /no wall-clock threshold/);
+  assert.match(md, /TRUE event-to-commit/);
+  assert.match(md, /former metric, retained for comparison/);
   assert.equal(md.includes(PERCENTILE_CONVENTION), true);
   assert.equal(md.includes(NOISE_POLICY), true);
 });
 
-test('buildPerformanceSummary emits a per-engine p95 + ratio row and exposes the raw samples', () => {
+test('buildPerformanceSummary emits a per-engine, per-channel p95 + ratio row and exposes the raw samples', () => {
   const md = buildPerformanceSummary(twoEngineEvidence());
-  assert.match(md, /\| chromium \| 1\.200 \| 1\.100 \| 1\.091 \| ✓ \|/);
-  assert.match(md, /\| webkit \| 1\.400 \| 1\.300 \| 1\.077 \| ✓ \|/);
-  // Raw distributions must be present, not just the two percentiles.
-  assert.match(md, /chromium compiled/);
-  assert.match(md, /webkit hand-written/);
+  assert.match(md, /\| chromium \| commit \| 1\.200 \| 1\.100 \| 1\.091 \| ✓ \|/);
+  assert.match(md, /\| chromium \| settlement \| 5\.000 \| 4\.000 \| 1\.250 \| observed over \|/);
+  assert.match(md, /\| webkit \| commit \| 1\.400 \| 1\.300 \| 1\.077 \| ✓ \|/);
+  // Raw distributions must be present for both channels, not just percentiles.
+  assert.match(md, /chromium commit compiled/);
+  assert.match(md, /chromium settlement compiled/);
+  assert.match(md, /webkit settlement hand-written/);
 });
 
-test('buildPerformanceSummary reports an over-budget engine as observed-over (evidence, not a gate)', () => {
-  const md = buildPerformanceSummary([engineLatencyEvidence('chromium', fill25(2.0), fill25(1.0))]);
-  assert.match(md, /\| chromium \| 2\.000 \| 1\.000 \| 2\.000 \| observed over \|/);
+test('buildPerformanceSummary reports an over-budget commit channel as observed-over (evidence, not a gate)', () => {
+  const over = engineLatencyChannels('chromium', {
+    ...fixtureLatency(),
+    'compiled-commit-raw-ms': fill25(2.0),
+    'handwritten-commit-raw-ms': fill25(1.0),
+  });
+  const md = buildPerformanceSummary([over]);
+  assert.match(md, /\| chromium \| commit \| 2\.000 \| 1\.000 \| 2\.000 \| observed over \|/);
 });
 
 test('buildPerformanceSummary rejects an empty per-engine set', () => {

--- a/implementation/scripts/lib/g8-latency-evidence.cjs
+++ b/implementation/scripts/lib/g8-latency-evidence.cjs
@@ -11,7 +11,10 @@
 // comparative REFERENCE BUDGET for that evidence — not as a gate requirement;
 // this module MEASURES that ratio, records the sample count + noise policy, and
 // REPORTS `within-10pct` — but nothing here becomes a pass/fail wall-clock
-// threshold. The gate follows G-13's
+// threshold. Since rf2-dpwel the evidence carries TWO channels per engine:
+// `commit` (the true event-to-commit boundary — the arm's own Profiler
+// onRender commitTime) and `settlement` (the former input-to-quiescence
+// metric, retained for comparison); the ratio is reported for both. The gate follows G-13's
 // evidence-only/no-threshold posture: a noisy CI host must never redden a
 // correctness gate on a timing number. Deterministic correctness (one React
 // commit per ordinary input, exactly one at the committed IME boundary) is the
@@ -41,13 +44,26 @@ const PERCENTILE_CONVENTION =
 const RATIO_BUDGET = 1.1;
 
 // The noise policy recorded in the artifact so the stated relative budget is
-// reproducible and meaningful.
+// reproducible and meaningful. rf2-dpwel resolved the two measurement effects
+// the rf2-5qz8z audit surfaced: the endpoint is now the arm's own Profiler
+// commit (not flush settlement), and the pair order alternates (no fixed
+// compiled-first sequence bias).
 const NOISE_POLICY =
-  'interleaved per sample (compiled then hand-written, same warmed run); ' +
-  `first ${WARMUP_SAMPLES} warm-up samples per control discarded; ` +
-  `${RECORDED_SAMPLES} recorded samples per control per engine; ` +
-  'each sample is one fresh-value native input dispatched to React commit ' +
-  `under awaited React act; ${PERCENTILE_CONVENTION}`;
+  'one compiled + one hand-written sample per pair, same warmed run; pair ' +
+  'order ALTERNATES compiled-first / hand-written-first (no fixed sequence ' +
+  `bias); first ${WARMUP_SAMPLES} warm-up pairs per engine discarded; ` +
+  `${RECORDED_SAMPLES} recorded samples per control per channel per engine; ` +
+  'each sample keys one fresh-value native input to its own React.Profiler ' +
+  'onRender commitTime with exactly one attributable commit asserted per ' +
+  `sample; ${PERCENTILE_CONVENTION}`;
+
+// The two measurement channels every sample carries (rf2-dpwel):
+//   commit     — TRUE event-to-commit: native input dispatch to the arm's own
+//                React.Profiler onRender commitTime.
+//   settlement — the FORMER metric, retained for comparison: the same input to
+//                ui.test/flush! settlement (awaited React act + framework
+//                draining to the fixed point — input-to-global-quiescence).
+const CHANNELS = ['commit', 'settlement'];
 
 function evidenceFail(message) {
   return new Error(`G-8 latency-evidence FAIL: ${message}`);
@@ -132,12 +148,12 @@ function p95Ratio(compiledP95, baselineP95) {
   return compiledP95 / baselineP95;
 }
 
-// The per-engine comparative-latency evidence object built from the two raw
-// sample arrays measured in the SAME warmed run. Pure — the runner folds this
-// into the artifact's `performance` section.
+// The comparative-latency evidence object for ONE channel, built from the two
+// raw sample arrays measured in the SAME warmed run. Pure — the runner folds
+// this into the artifact's `performance` section (per engine, per channel).
 function engineLatencyEvidence(engine, compiledRaw, handwrittenRaw) {
-  const compiled = summarizeLatency(compiledRaw, `[${engine}] compiled event-to-commit`);
-  const handwritten = summarizeLatency(handwrittenRaw, `[${engine}] hand-written event-to-commit`);
+  const compiled = summarizeLatency(compiledRaw, `[${engine}] compiled latency`);
+  const handwritten = summarizeLatency(handwrittenRaw, `[${engine}] hand-written latency`);
   return {
     engine,
     'samples-recorded': RECORDED_SAMPLES,
@@ -150,47 +166,77 @@ function engineLatencyEvidence(engine, compiledRaw, handwrittenRaw) {
   };
 }
 
+// The per-engine TWO-CHANNEL comparative-latency evidence built from the
+// fixture's latency payload: the `commit` channel is the true event-to-commit
+// evidence; the `settlement` channel is the former input-to-quiescence metric,
+// retained so the two boundaries stay comparable in the same artifact. Pure.
+function engineLatencyChannels(engine, lat) {
+  if (!lat || typeof lat !== 'object') {
+    throw evidenceFail(`[${engine}] latency payload is not an object: ${JSON.stringify(lat)}`);
+  }
+  return {
+    engine,
+    'order-policy': lat['order-policy'],
+    endpoints: lat.endpoints,
+    commit: engineLatencyEvidence(
+      `${engine}/commit`, lat['compiled-commit-raw-ms'], lat['handwritten-commit-raw-ms']),
+    settlement: engineLatencyEvidence(
+      `${engine}/settlement`, lat['compiled-settle-raw-ms'], lat['handwritten-settle-raw-ms']),
+  };
+}
+
 function fmt(x) {
   return Number(x).toFixed(3);
 }
 
 // Render the GitHub Actions step summary for the comparative-latency evidence.
-// Emits, per engine, the compiled + hand-written p95, the ratio, and the
-// within-10% OBSERVATION — the raw distributions collapsed behind a <details>
-// so the packet stays compact but nothing is hidden. Returns the markdown
-// string (the fs write lives in the runner so this stays pure).
+// Emits, per engine and per channel, the compiled + hand-written p95, the
+// ratio, and the within-10% OBSERVATION — the raw distributions collapsed
+// behind a <details> so the packet stays compact but nothing is hidden.
+// Returns the markdown string (the fs write lives in the runner so this stays
+// pure). Takes the per-engine TWO-CHANNEL shape from `engineLatencyChannels`.
 function buildPerformanceSummary(perEngine) {
   if (!Array.isArray(perEngine) || perEngine.length === 0) {
     throw evidenceFail(`summary requires a non-empty per-engine array; got ${JSON.stringify(perEngine)}`);
   }
   const lines = [
-    '### re-frame.ui G-8 comparative event-to-commit latency',
+    '### re-frame.ui G-8 comparative latency (commit + settlement channels)',
     '',
     'Compiled reusable control vs an equivalent hand-written React control — ' +
       'EVIDENCE ONLY; G-8 has no wall-clock threshold (the correctness matrix is ' +
       'the hard gate).',
+    'Channels: `commit` = TRUE event-to-commit (the arm\'s own React.Profiler ' +
+      'onRender commitTime, one attributable commit asserted per sample); ' +
+      '`settlement` = input to flush settlement (awaited React act + framework ' +
+      'draining — the former metric, retained for comparison).',
     `Percentiles: ${PERCENTILE_CONVENTION}.`,
     `Noise policy: ${NOISE_POLICY}.`,
     '',
-    '| engine | compiled p95 ms | hand-written p95 ms | p95 ratio | within 10% (evidence) |',
-    '|---|---:|---:|---:|:---:|',
+    '| engine | channel | compiled p95 ms | hand-written p95 ms | p95 ratio | within 10% (evidence) |',
+    '|---|---|---:|---:|---:|:---:|',
   ];
   for (const e of perEngine) {
-    lines.push(
-      `| ${e.engine} | ${fmt(e.compiled['p95-ms'])} | ${fmt(e.handwritten['p95-ms'])} | ` +
-        `${fmt(e['p95-ratio'])} | ${e['within-10pct'] ? '✓' : 'observed over'} |`,
-    );
+    for (const ch of CHANNELS) {
+      const ev = e[ch];
+      lines.push(
+        `| ${e.engine} | ${ch} | ${fmt(ev.compiled['p95-ms'])} | ${fmt(ev.handwritten['p95-ms'])} | ` +
+          `${fmt(ev['p95-ratio'])} | ${ev['within-10pct'] ? '✓' : 'observed over'} |`,
+      );
+    }
   }
   lines.push('');
-  lines.push('<details><summary>Raw event-to-commit samples (ms)</summary>');
+  lines.push('<details><summary>Raw latency samples (ms)</summary>');
   lines.push('');
   for (const e of perEngine) {
-    lines.push(
-      `- **${e.engine} compiled** — [${e.compiled['raw-ms'].map(fmt).join(', ')}]`,
-    );
-    lines.push(
-      `- **${e.engine} hand-written** — [${e.handwritten['raw-ms'].map(fmt).join(', ')}]`,
-    );
+    for (const ch of CHANNELS) {
+      const ev = e[ch];
+      lines.push(
+        `- **${e.engine} ${ch} compiled** — [${ev.compiled['raw-ms'].map(fmt).join(', ')}]`,
+      );
+      lines.push(
+        `- **${e.engine} ${ch} hand-written** — [${ev.handwritten['raw-ms'].map(fmt).join(', ')}]`,
+      );
+    }
   }
   lines.push('');
   lines.push('</details>');
@@ -204,11 +250,13 @@ module.exports = {
   PERCENTILE_CONVENTION,
   RATIO_BUDGET,
   NOISE_POLICY,
+  CHANNELS,
   latencyPercentile,
   validateLatencySamples,
   summarizeLatency,
   withinBudget,
   p95Ratio,
   engineLatencyEvidence,
+  engineLatencyChannels,
   buildPerformanceSummary,
 };

--- a/implementation/scripts/run-ui-g8.cjs
+++ b/implementation/scripts/run-ui-g8.cjs
@@ -17,11 +17,17 @@
 //   counter.
 //
 //   COMPARATIVE LATENCY (evidence only; NO threshold — G-13's posture) — the
-//   compiled reusable control's event-to-commit p95 measured against an
-//   equivalent hand-written React control in the SAME warmed run. The p95
-//   ratio, the within-10% observation, the sample count, and the noise policy
-//   are RECORDED and reported; nothing gates on a wall-clock number. The budget
-//   comparison is kept non-vacuous by mutation teeth over synthetic data.
+//   compiled reusable control measured against an equivalent hand-written
+//   React control in the SAME warmed run, on TWO channels per engine
+//   (rf2-dpwel): `commit` — the TRUE event-to-commit boundary, each sample
+//   keyed to a fresh input and ended at the arm's own React.Profiler onRender
+//   commitTime with exactly one attributable commit asserted; `settlement` —
+//   the former input-to-flush-settlement metric, retained for comparison.
+//   Pair order alternates compiled-first / hand-written-first (no fixed
+//   sequence bias). The p95 ratios, the within-10% observation, the sample
+//   count, and the noise policy are RECORDED and reported; nothing gates on a
+//   wall-clock number. The budget comparison is kept non-vacuous by mutation
+//   teeth over synthetic data.
 
 const fs = require('fs');
 const path = require('path');
@@ -38,8 +44,10 @@ const {
   PERCENTILE_CONVENTION,
   RATIO_BUDGET,
   NOISE_POLICY,
+  CHANNELS,
   withinBudget,
   engineLatencyEvidence,
+  engineLatencyChannels,
   buildPerformanceSummary,
 } = require('./lib/g8-latency-evidence.cjs');
 
@@ -317,16 +325,16 @@ async function main() {
       engines[name] = await driveEngine(name, url);
     }
 
-    // Comparative-latency evidence — derive the per-engine p95s, ratio, and
-    // within-10% OBSERVATION from the raw event-to-commit samples the fixture
-    // measured in the same warmed run. Evidence-only; the gate's pass/fail does
-    // NOT depend on any of these numbers (only their sample SHAPE is validated,
-    // inside engineLatencyEvidence). The stated relative budget is surfaced as
-    // an observation, not a threshold.
-    const perfEngines = ENGINES.map((name) => {
-      const lat = engines[name].latency;
-      return engineLatencyEvidence(name, lat['compiled-raw-ms'], lat['handwritten-raw-ms']);
-    });
+    // Comparative-latency evidence — derive the per-engine, per-channel p95s,
+    // ratios, and within-10% OBSERVATIONS from the raw samples the fixture
+    // measured in the same warmed run: the `commit` channel (true
+    // event-to-commit — Profiler onRender endpoint) and the `settlement`
+    // channel (the former input-to-quiescence metric, retained for
+    // comparison). Evidence-only; the gate's pass/fail does NOT depend on any
+    // of these numbers (only their sample SHAPE is validated, inside
+    // engineLatencyEvidence). The stated relative budget is surfaced as an
+    // observation, not a threshold.
+    const perfEngines = ENGINES.map((name) => engineLatencyChannels(name, engines[name].latency));
 
     const report = {
       gate: 'G-8', status: 'pass',
@@ -342,11 +350,11 @@ async function main() {
         mutationTeeth,
       },
       // Comparative latency — EVIDENCE ONLY; no wall-clock threshold. The p95
-      // ratio and within-10% observation are recorded, never gated; the budget
-      // comparison is kept non-vacuous by the budget teeth.
+      // ratios and within-10% observations are recorded per channel, never
+      // gated; the budget comparison is kept non-vacuous by the budget teeth.
       performance: {
         posture: 'evidence-only; no wall-clock threshold',
-        contract: 'compiled reusable control event-to-commit p95 measured against an equivalent hand-written React control (useState/onChange) in the same warmed run',
+        contract: 'compiled reusable control vs an equivalent hand-written React control (useState/onChange) in the same warmed run; commit channel = TRUE event-to-commit (per-sample Profiler onRender commitTime, exactly one attributable commit asserted); settlement channel = the former input-to-flush-settlement metric, retained for comparison; pair order alternates compiled-first / hand-written-first',
         percentileConvention: PERCENTILE_CONVENTION,
         noisePolicy: NOISE_POLICY,
         ratioBudget: RATIO_BUDGET,
@@ -361,11 +369,17 @@ async function main() {
     appendSummary(report);
     console.log(`G-8 PASS (${ENGINES.join(' + ')}) — report: ${REPORT}`);
     for (const e of perfEngines) {
-      console.log(
-        `  [${e.engine}] event-to-commit p95: compiled ${e.compiled['p95-ms'].toFixed(3)}ms ` +
-          `vs hand-written ${e.handwritten['p95-ms'].toFixed(3)}ms ` +
-          `(ratio ${e['p95-ratio'].toFixed(3)}, within-10% ${e['within-10pct']}) — evidence only`,
-      );
+      for (const ch of CHANNELS) {
+        const ev = e[ch];
+        const label = ch === 'commit'
+          ? 'commit (true event-to-commit)'
+          : 'settlement (former metric)';
+        console.log(
+          `  [${e.engine}] ${label} p95: compiled ${ev.compiled['p95-ms'].toFixed(3)}ms ` +
+            `vs hand-written ${ev.handwritten['p95-ms'].toFixed(3)}ms ` +
+            `(ratio ${ev['p95-ratio'].toFixed(3)}, within-10% ${ev['within-10pct']}) — evidence only`,
+        );
+      }
     }
   } catch (error) {
     writeReport({ gate: 'G-8', status: 'fail', error: error.stack || String(error) });

--- a/implementation/ui/g8/re_frame/ui/g8/dev.cljs
+++ b/implementation/ui/g8/re_frame/ui/g8/dev.cljs
@@ -36,11 +36,25 @@
   COMPARATIVE LATENCY (evidence only; NO threshold — G-13's posture). The
   compiled reusable control's event-to-commit time is measured against an
   EQUIVALENT HAND-WRITTEN React control (a plain `useState`/`onChange`
-  controlled input) in the SAME warmed run, interleaved per sample, warm-ups
-  discarded. The runner owns the (stated nearest-rank) quantile convention,
-  records the sample count + noise policy, and reports the compiled-vs-baseline
-  p95 ratio and the within-10% OBSERVATION. Nothing here gates on a wall-clock
-  number; the runner's budget mutation teeth keep the comparison non-vacuous.
+  controlled input) in the SAME warmed run, warm-ups discarded. Two measurement
+  effects the rf2-5qz8z audit surfaced are resolved here (rf2-dpwel):
+
+    - TRUE event-to-commit endpoint — each sample is keyed to a fresh input
+      value and its endpoint is the arm's OWN `React.Profiler` `onRender`
+      commit timestamp, with the exact-one-attributable-commit assertion
+      retained per sample. The former metric — input to `ui.test/flush!`
+      settlement (awaited React act + framework draining to the fixed point)
+      — is recorded ALONGSIDE as the `settle` channel so the two boundaries
+      stay comparable; it is no longer presented as event-to-commit.
+    - ALTERNATING pair order — successive pairs alternate compiled-first and
+      hand-written-first, removing the fixed compiled-always-first sequence
+      bias of the original interleaving.
+
+  The runner owns the (stated nearest-rank) quantile convention, records the
+  sample count + noise policy, and reports the compiled-vs-baseline p95 ratio
+  and the within-10% OBSERVATION per channel. Nothing here gates on a
+  wall-clock number; the runner's budget mutation teeth keep the comparison
+  non-vacuous.
 
   The TOOTH: a second control — the deliberate ASYNC-DOOR REGRESSION — is the
   SAME controlled input whose write is deferred to a `setTimeout(0)` (a
@@ -60,17 +74,25 @@
 
 (defonce ^:private delivered (atom []))
 
-;; Attributable React commit counters. A `React.Profiler` around each control
-;; increments its counter in `onRender` — the ACTUAL React commit signal, read
-;; separately from the ViewCell revision. Reset at mount so a measured delta
-;; counts only the commits of the arm under observation.
+;; Attributable React commit counters + commit timestamps. A `React.Profiler`
+;; around each control increments its counter in `onRender` — the ACTUAL React
+;; commit signal, read separately from the ViewCell revision — and records the
+;; commit's `commitTime` (React's own `performance.now()`-based timestamp of
+;; the commit). The timestamp is the TRUE event-to-commit endpoint for the
+;; latency arm; the counter keeps every latency sample attributable to exactly
+;; one commit. Reset at mount so a measured delta counts only the commits of
+;; the arm under observation.
 (defonce ^:private sync-commit-count (atom 0))
 (defonce ^:private hw-commit-count (atom 0))
+(defonce ^:private sync-commit-at (atom 0))
+(defonce ^:private hw-commit-at (atom 0))
 
 (defn- register! []
   (reset! delivered [])
   (reset! sync-commit-count 0)
   (reset! hw-commit-count 0)
+  (reset! sync-commit-at 0)
+  (reset! hw-commit-at 0)
   (rf/reg-sub ::text (fn [db _] (:text db)))
   (rf/reg-sub ::async-text (fn [db _] (:async-text db)))
   (rf/reg-event
@@ -121,6 +143,17 @@
 ;; React baseline (comparative-latency counterpart)
 ;; ---------------------------------------------------------------------------
 
+(defn- profiler-on-render
+  "Build a Profiler `onRender` callback that counts the commit AND records its
+  `commitTime` — React's own timestamp (same `performance.now()` timebase) of
+  the moment the commit landed. The recorded timestamp is the latency arm's
+  TRUE event-to-commit endpoint; each sample's exact-one-commit assertion keys
+  it to that sample's fresh input."
+  [commit-count commit-at]
+  (fn [_id _phase _actual-dur _base-dur _start-time commit-time]
+    (swap! commit-count inc)
+    (reset! commit-at (or commit-time (js/performance.now)))))
+
 (defview profiled-sync-input [{:keys [on-change]}]
   ;; Wrap the reusable control in a real `React.Profiler`; `onRender` fires once
   ;; per React commit of the control's subtree. The frame context established by
@@ -130,7 +163,7 @@
    (React/createElement
     (.-Profiler React)
     #js {:id "g8-sync"
-         :onRender (fn [& _] (swap! sync-commit-count inc))}
+         :onRender (profiler-on-render sync-commit-count sync-commit-at)}
     (React/createElement reusable-prefix-input #js {:on-change on-change}))))
 
 (defn- handwritten-input [_props]
@@ -153,7 +186,7 @@
    (React/createElement
     (.-Profiler React)
     #js {:id "g8-handwritten"
-         :onRender (fn [& _] (swap! hw-commit-count inc))}
+         :onRender (profiler-on-render hw-commit-count hw-commit-at)}
     (React/createElement handwritten-input #js {}))))
 
 ;; ---------------------------------------------------------------------------
@@ -326,44 +359,99 @@
 (def ^:private latency-recorded 25)
 
 (defn- latency-sample!
-  "One dispatch-to-commit span for a single fresh-value native input, mirroring
-  G-13's timing-cycle: the timer starts immediately before the flush that fires
-  the input and stops the instant the post-commit Promise resolves — no evidence
-  scan, DOM read, or assertion runs inside the measured interval."
-  [el value]
-  (let [started (js/performance.now)]
-    (-> (uit/flush! (fn [] (fire-native-input! el value)))
-        (.then (fn [_] (- (js/performance.now) started))))))
+  "One latency sample for a single FRESH-VALUE native input, measured at TWO
+  boundaries at once (rf2-dpwel):
+
+    :commit-ms — the TRUE event-to-commit span. The timer starts inside the
+      awaited act thunk immediately before the native input dispatch; the
+      endpoint is the arm's own `React.Profiler` `onRender` `commitTime` for
+      the ONE commit this fresh input produced. No settlement, evidence scan,
+      DOM read, or assertion is inside the measured interval.
+    :settle-ms — the FORMER metric, retained for comparison: the same start,
+      ended when the `ui.test/flush!` Promise resolves (awaited React act +
+      framework draining to the fixed point — input-to-global-quiescence).
+
+  The exact-one-attributable-commit assertion is retained PER SAMPLE: the
+  arm's Profiler must record exactly one commit for the fresh input, else the
+  recorded `commitTime` would not be this sample's endpoint and the fixture
+  throws (a structural measurement failure, not a timing threshold)."
+  [el value commit-count commit-at]
+  (let [commits-before @commit-count
+        started        (atom 0)]
+    (-> (uit/flush! (fn []
+                      (reset! started (js/performance.now))
+                      (fire-native-input! el value)))
+        (.then (fn [_]
+                 (let [settled (js/performance.now)
+                       commits (- @commit-count commits-before)]
+                   (when-not (= 1 commits)
+                     (throw (ex-info (str "G-8 latency sample not attributable: "
+                                          "expected exactly one Profiler commit for "
+                                          (pr-str value) ", observed " commits)
+                                     {:value value :commits commits})))
+                   {:commit-ms (- @commit-at @started)
+                    :settle-ms (- settled @started)}))))))
+
+(def ^:private latency-order-policy
+  "alternating pair order: even pairs compiled-first, odd pairs hand-written-first")
+
+(def ^:private latency-endpoints
+  {:commit "arm's own React.Profiler onRender commitTime (true event-to-commit)"
+   :settle "ui.test/flush! settlement (awaited React act + framework draining; the former metric, retained for comparison)"})
 
 (defn- run-latency!
-  "Comparative event-to-commit latency — the compiled reusable control vs the
-  equivalent hand-written React control, INTERLEAVED per sample (compiled then
-  hand-written) in the same warmed run. The first `latency-warmups` samples per
-  control are discarded; the next `latency-recorded` are returned as raw ms
-  arrays (the runner owns the stated nearest-rank quantile convention). EVIDENCE
-  ONLY — no threshold is applied here."
+  "Comparative latency — the compiled reusable control vs the equivalent
+  hand-written React control, one pair per iteration in the same warmed run,
+  pair order ALTERNATING compiled-first / hand-written-first so neither arm
+  always pays a fixed sequence position. Every sample keys a fresh input value
+  to its own Profiler-commit endpoint (see `latency-sample!`) and carries the
+  settlement span alongside. The first `latency-warmups` pairs are discarded;
+  the next `latency-recorded` are returned as raw ms arrays per channel (the
+  runner owns the stated nearest-rank quantile convention). EVIDENCE ONLY — no
+  threshold is applied here."
   [root]
   (let [compiled-el (.querySelector root "[data-role='sync']")
         hw-el       (.querySelector root "[data-role='handwritten']")
         n           (atom 0)
-        compiled    (atom [])
-        handwritten (atom [])]
-    (letfn [(step [i]
+        acc         (atom {:compiled-commit []    :compiled-settle []
+                           :handwritten-commit [] :handwritten-settle []})]
+    (letfn [(sample-compiled! []
+              (latency-sample! compiled-el (str "c" (swap! n inc))
+                               sync-commit-count sync-commit-at))
+            (sample-handwritten! []
+              (latency-sample! hw-el (str "h" (swap! n inc))
+                               hw-commit-count hw-commit-at))
+            (record! [i c h]
+              (when (>= i latency-warmups)
+                (swap! acc
+                       (fn [m]
+                         (-> m
+                             (update :compiled-commit conj (:commit-ms c))
+                             (update :compiled-settle conj (:settle-ms c))
+                             (update :handwritten-commit conj (:commit-ms h))
+                             (update :handwritten-settle conj (:settle-ms h)))))))
+            (step [i]
               (if (>= i (+ latency-warmups latency-recorded))
-                (js/Promise.resolve {:compiled-raw-ms @compiled
-                                     :handwritten-raw-ms @handwritten
-                                     :samples-recorded latency-recorded
-                                     :warmups latency-warmups})
-                (-> (latency-sample! compiled-el (str "c" (swap! n inc)))
-                    (.then
-                     (fn [c-ms]
-                       (-> (latency-sample! hw-el (str "h" (swap! n inc)))
-                           (.then
-                            (fn [h-ms]
-                              (when (>= i latency-warmups)
-                                (swap! compiled conj c-ms)
-                                (swap! handwritten conj h-ms))
-                              (step (inc i))))))))))]
+                (js/Promise.resolve
+                 (let [{:keys [compiled-commit compiled-settle
+                               handwritten-commit handwritten-settle]} @acc]
+                   {:compiled-commit-raw-ms    compiled-commit
+                    :compiled-settle-raw-ms    compiled-settle
+                    :handwritten-commit-raw-ms handwritten-commit
+                    :handwritten-settle-raw-ms handwritten-settle
+                    :samples-recorded latency-recorded
+                    :warmups latency-warmups
+                    :order-policy latency-order-policy
+                    :endpoints latency-endpoints}))
+                (if (even? i)
+                  (-> (sample-compiled!)
+                      (.then (fn [c]
+                               (-> (sample-handwritten!)
+                                   (.then (fn [h] (record! i c h) (step (inc i))))))))
+                  (-> (sample-handwritten!)
+                      (.then (fn [h]
+                               (-> (sample-compiled!)
+                                   (.then (fn [c] (record! i c h) (step (inc i)))))))))))]
       (step 0))))
 
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes rf2-dpwel. The rf2-5qz8z audit of the G-8 evidence (PR #6224) proved the comparative-latency metric measured **input-to-global-quiescence** (`latency-sample!` spanned the whole `ui.test/flush!` settlement — awaited React act + framework draining to the fixed point), not input-to-Profiler-commit, and every pair ran **compiled-first**. This PR resolves both measurement effects before attributing the observed ~2-5ms Chromium delta as framework cost, keeping the evidence-only / no-threshold posture intact.

## What changed

- **True event-to-commit endpoint** — each latency sample keys a fresh input value to its own arm's `React.Profiler` `onRender` `commitTime`. The exact-one-attributable-commit assertion is retained *per sample*: a commit delta ≠ 1 is a structural measurement failure and throws (never a timing threshold).
- **Settlement channel retained for comparison** — the former input-to-flush-settlement span is recorded alongside as a second channel per engine, so the two boundaries stay comparable in the same `out/ui-g8.json` artifact.
- **Alternating pair order** — even pairs run compiled-first, odd pairs hand-written-first, removing the fixed sequence bias.
- Evidence lib gains the pure two-channel builder (`engineLatencyChannels`, `CHANNELS`); runner report, step summary, and unit tests updated. No thresholds, no gates, no benchmark framework; raw per-engine distributions preserved verbatim.

Files: `implementation/ui/g8/re_frame/ui/g8/dev.cljs`, `implementation/scripts/run-ui-g8.cjs`, `implementation/scripts/lib/g8-latency-evidence.cjs`, `implementation/scripts/_g8-latency-evidence.test.cjs`. No compiler or `shadow-cljs.edn` changes (the `:ui-g8` build is untouched).

## Findings — corrected p95s vs the former settlement metric

Two local runs (Windows 11, Playwright headless), 25 recorded samples per control per channel per engine:

| engine | channel | compiled p95 ms | hand-written p95 ms | ratio |
|---|---|---:|---:|---:|
| chromium | **commit (true)** | 1.400 / 1.700 | 0.200 / 0.200 | 7.0 / 8.5 |
| chromium | settlement (former) | 2.300 / 2.000 | 0.300 / 0.400 | 7.7 / 5.0 |
| webkit | **commit (true)** | 5.000 / 3.000 | 1.000 / 1.000 | 5.0 / 3.0 |
| webkit | settlement (former) | 19.000 / 16.000 | 16.000 / 16.000 | 1.19 / 1.00 |

(p50s: chromium commit 1.0 vs 0.1; webkit commit 3.0 vs 1.0; webkit settlement 15-16 vs 16 for both arms.)

## Delta attribution

1. **WebKit's former numbers (~18 vs ~16) were almost entirely measurement.** Both arms sit on the same ~16ms rAF-quantized settlement plateau (settlement ratio 1.0-1.19); the true commit channel shows 3-5ms vs 1ms. The settlement boundary simultaneously fabricated most of the absolute magnitude and hid the real relative difference.
2. **Chromium's settlement boundary inflated the compiled arm** by ~+0.5-0.9ms p95 (2.0-2.3 settlement vs 1.4-1.7 commit) while barely touching the hand-written arm (0.3-0.4 vs 0.2) — the compiled arm pays framework draining after its commit, while the bare `useState` control has nothing to drain. The CI-observed ~5.2ms compiled p95 is consistent with that inflation plus CI-host noise; the true event-to-commit compiled p95 here is ~1.4-1.7ms.
3. **Sequence order was not the driver.** With alternating pair order the picture is unchanged run-to-run, so the fixed compiled-first ordering was not producing the delta.
4. **The residual delta is real framework dispatch cost, and it is small**: ~0.9-1.5ms per keystroke in Chromium (p50 1.0 vs 0.1), ~2ms in WebKit (p50 3 vs 1). That span is the genuine pipeline — native input → capture-dispatch sync door → handler → app-db commit + epoch/instrumentation bookkeeping → ViewCell revision → React subtree re-render + commit — measured in the **un-optimized** `:ui-g8` dev bundle (no elision, instrumentation live) against a bare `setState`→commit baseline. The dramatic-looking ratio (3-8x) is a ~1ms fixed cost divided by a ~0.1-0.2ms baseline at Chromium's 0.1ms timer granularity.

**Conclusion:** the previously reported ~2-5ms Chromium delta (and the WebKit 18-vs-16 shape) was substantially measurement boundary — settlement/quiescence span plus WebKit rAF quantization — not commit latency. The true per-keystroke framework cost over hand-written React is ~1ms in Chromium and ~2ms in WebKit for a dev-mode bundle: real, fixed, and comfortably within frame budget. No fix warranted; the evidence-only/no-threshold posture stands vindicated, and G-8 now reports both boundaries so the distinction can never silently regress.

## Quality gates

- `node scripts/_g8-latency-evidence.test.cjs` — 23 passed
- `npm run test:ui-g8` — G-8 PASS (chromium + webkit), run twice; correctness matrix, async-door tooth, mutation + budget teeth all green with the new per-sample one-commit assertion live
- `npm run test:cljs` — 10372 tests, 51277 assertions, 0 failures, 0 errors
