### PR TITLE
fix(story): render-transparent override-provider under goog.DEBUG=false + status-dot canonical statuses (rf2-wh5to)

### DIFF
--- a/tools/story/spec/009-Test-Mode.md
+++ b/tools/story/spec/009-Test-Mode.md
@@ -261,9 +261,9 @@ the sidebar plus the **status dots** that render next to each
 testable variant row.
 
 Both surfaces read from one slot in the shell state —
-`[:tests :runs]`, a `{variant-id → {:status :pass|:fail|:running|
-:pending, :passed, :failed, :skipped, :total, :ran-at-ms, :elapsed-
-ms}}` map. The `:test` mode pane and the chrome widget both write
+`[:tests :runs]`, a `{variant-id → {:status :pass|:fail|:cannot-run|
+:running|:pending, :passed, :failed, :cannot-run, :skipped, :total,
+:ran-at-ms, :elapsed-ms}}` map. The `:test` mode pane and the chrome widget both write
 into it; the sidebar's per-variant row reads its dot's colour from
 it.
 
@@ -281,10 +281,11 @@ hashes]` (the watch-mode detector's drift baseline).
                                               ; aggregate-summary shape
                                               ; from this spec.
 (clear-test-run      state variant-id)       ; → state'
-(variant-test-status state variant-id)       ; → :pass|:fail|:running|:pending
+(variant-test-status state variant-id)       ; → :pass|:fail|:cannot-run
+                                              ;   |:running|:pending
 (test-summary        state variant-ids)      ; → {:total :passed :failed
-                                              ;    :running :pending
-                                              ;    :all-green?}
+                                              ;    :cannot-run :running
+                                              ;    :pending :all-green?}
 (testable-variant-ids id->body)              ; → vector of variant-ids
                                               ; whose :tags contains :test
                                               ; AND :play-script is non-empty.
@@ -307,11 +308,20 @@ variant renders no dot.
 ### Status semantics
 
 - `:pass` — every assertion in the last run passed (and at least one assertion).
-- `:fail` — at least one assertion failed.
+- `:fail` — at least one assertion failed. (A run-level `:error`
+  verdict — a thrown handler / fx / step — lowers to `:fail` at
+  `record-test-run` write time; the per-assertion `:error` detail
+  stays distinct in the `:test` pane's result rows.)
+- `:cannot-run` — the distinct THIRD status ([017 §`:cannot-run`](017-Testing-Story.md)):
+  the only unmet expectations were ones the runner could not even
+  attempt. A refusal is NOT a pass and NOT `:pending` — the dot wears
+  the `:warning`-hued ring from the `theme.status` descriptor, never
+  the neutral pending ring.
 - `:running` — `run-variant` is currently in flight.
 - `:pending` — no run recorded yet, **or** the last run produced zero
   assertions (the variant ran but produced no signal — the dot stays
-  grey rather than green).
+  grey rather than green). Reserved for the genuinely unknown slot;
+  unknown / nil statuses degrade here, real terminal statuses never do.
 
 `:all-green?` on the chrome widget's summary is true only when every
 testable variant has a recorded green run — a sea of `:pending`
@@ -336,7 +346,7 @@ slot, so the chrome widget and the pane stay in sync.
 | `[data-test="story-test-widget-run-all"]`             | The Run all button.                   |
 | `[data-test="story-test-widget-watch-toggle"]`        | The watch-mode eye-icon chip; `aria-pressed` reflects the on/off state, `data-state` reads "on" / "off". |
 | `[data-test="story-test-widget-empty"]`               | "no :test variants" empty state.      |
-| `[data-test="story-sidebar-dot"]`                     | One per testable variant row; `data-status="pass\|fail\|running\|pending"`. |
+| `[data-test="story-sidebar-dot"]`                     | One per testable variant row; `data-status="pass\|fail\|cannot-run\|running\|pending"`. |
 
 ### Watch mode (rf2-z1h0f)
 

--- a/tools/story/spec/016-Design-Tokens.md
+++ b/tools/story/spec/016-Design-Tokens.md
@@ -598,9 +598,10 @@ The colour split is intentional:
 
 Testable variants (those carrying `:test` in `:tags` or a non-empty
 `:play-script` sequence) replace the muted glyph with a **`status-dot`**
-that wears the semantic colour from the variant's last
-`run-variant` outcome (`:success` green pass · `:danger` red fail ·
-`:warning` yellow running · transparent ring pending).
+whose paint projects from the variant's last `run-variant` outcome via
+the canonical `theme.status` descriptors (`:success` green pass ·
+`:danger` red fail · `:warning` translucent fill running · `:warning`
+ring cannot-run · neutral ring pending).
 
 ### Cross-references
 

--- a/tools/story/src/re_frame/story/sub_overrides.cljc
+++ b/tools/story/src/re_frame/story/sub_overrides.cljc
@@ -86,6 +86,7 @@
   `:schema`, matching Spec 010 §`:sub-return`."
   (:refer-clojure :exclude [resolve read])
   #?(:cljs (:require [re-frame.adapter.sub-override-context :as ovr-ctx]
+                     [re-frame.interop :as interop]
                      [re-frame.late-bind :as late-bind])))
 
 ;; ============================================================================
@@ -235,9 +236,18 @@
      keys. Mirrors `re-frame.views.provider/frame-provider-component`'s
      `:r>` Provider mount. When `overrides` is nil/empty this is render-
      transparent (the descendant consult misses and the view reads its
-     real subscription)."
+     real subscription).
+
+     Dev/tool builds only: under `goog.DEBUG=false` (e.g. the `:advanced`
+     static-export release) `ovr-ctx/override-context` is nil — the whole
+     sub-override seam is compiled out, including the `subscribe` consult
+     — so this fn returns `child` unchanged instead of mounting a
+     Provider on a nil context. Mirrors
+     `re-frame.ui.sub-overrides/provider-element`'s gate."
      [overrides child]
-     [:r> (.-Provider ovr-ctx/override-context) #js {:value overrides} child]))
+     (if interop/debug-enabled?
+       [:r> (.-Provider ovr-ctx/override-context) #js {:value overrides} child]
+       child)))
 
 ;; Publish the hook at ns-load time (CLJS only). Core consults it lazily
 ;; via `late-bind/get-fn` inside the dev gate; an unpublished hook (JVM,

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -91,38 +91,45 @@
 
 ;; ---- pure: per-variant status dot (rf2-q0irb) ---------------------------
 
-(def status->dot-style-key
-  "Pure data → data: map a `[:tests :runs]` status keyword to the
-  styles map key that renders its dot colour. The render-only mapping
-  lives next to the canonical statuses so both surfaces (sidebar dot,
-  chrome widget) can JVM-test the projection without booting Reagent.
+(defn dot-style
+  "Pure data → data: project a run status's compact dot paint from the
+  canonical `theme.status` descriptor (spec/018 §12.6) — the SAME single
+  source the signal chips and result pills read, so the dot can never
+  drift from the vocabulary. Two descriptor channels survive at 8px dot
+  scale:
 
-  Covers the run-outcome statuses a testable variant's dot can carry
-  (`theme.status` vocab). `:error` shares `:fail`'s danger tint — both
-  demand attention and resolve to the same `:danger` colour. Any status
-  without a bespoke dot style (`:cannot-run`/`:blocked`/`:dirty`/
-  `:redacted` — chip-axis values that don't normally reach the dot)
-  returns `nil`; the `status-dot` call site falls back to the neutral
-  `:pending` ring for those rather than dereferencing `nil` as a fn
-  (which crashed the whole sidebar render on any `:error`-status run)."
-  {:pass    :dot-pass
-   :fail    :dot-fail
-   :error   :dot-fail
-   :running :dot-running
-   :pending :dot-pending})
+  - colour — the descriptor's `:fg` / `:border` tints the fill or ring;
+  - shape  — settled `:solid` statuses fill; `:half` (running) fills
+    translucent (the in-flight partial treatment); the hollow shapes
+    (`:ring` pending, `:outline` cannot-run / error, `:dashed` redacted)
+    render a transparent ground with a 1px ring in the descriptor's
+    border colour — so `:cannot-run` (warning-hued ring) reads 'could
+    not observe', visibly distinct from `:pending`'s neutral grey ring.
+
+  The dot's run-status domain is `state.tests/test-run-statuses` —
+  `record-test-run` normalizes a run-level `:error` to `:fail` at write
+  time, so `:cannot-run` is the canonical third terminal status here.
+  Unknown / nil statuses degrade through `status/descriptor`'s
+  `:pending` fallback — pending is reserved for the genuinely unknown
+  slot, never a mask over a real terminal status."
+  [status]
+  (let [{:keys [fg border shape]} (status/descriptor status)]
+    (case shape
+      :solid  {:background fg}
+      :half   {:background fg :opacity "0.7"}
+      :dashed {:background "transparent" :border (str "1px dashed " border)}
+      ;; :ring / :outline — a hollow 1px ring in the status's border colour.
+      {:background "transparent" :border (str "1px solid " border)})))
 
 (defn dot-aria-label
-  "Pure data → data: render the status keyword as an accessible label
-  for the per-variant sidebar dot. Used both by the sidebar dot and
-  (for parity) by the JVM test corpus."
+  "Pure data → data: the accessible name for the per-variant sidebar
+  dot — `\"tests: <label>\"` with `<label>` the canonical `theme.status`
+  descriptor label, so the dot voices the SAME vocabulary the chips
+  render (`:cannot-run` → \"tests: Can't run\", accessibly distinct
+  from `:pending` → \"tests: Pending\"). Unknown / nil statuses degrade
+  through `status/descriptor`'s `:pending` fallback."
   [status]
-  (case status
-    :pass    "tests passing"
-    :fail    "tests failing"
-    :error   "tests errored"
-    :running "tests running"
-    :pending "tests not yet run"
-    "tests not yet run"))
+  (str "tests: " (status/label status)))
 
 ;; ---- pure: per-tag badge styling (rf2-nwiwr) ----------------------------
 
@@ -281,9 +288,8 @@
   registry the noise is real. `role=\"img\"` keeps the `aria-label`
   exposed as the accessible name without the live-region behaviour."
   [status]
-  (let [k     (status->dot-style-key status)
-        label (dot-aria-label status)]
-    [:span {:style       (merge (:dot styles) (get styles k (:dot-pending styles)))
+  (let [label (dot-aria-label status)]
+    [:span {:style       (merge (:dot styles) (dot-style status))
             :data-test   "story-sidebar-dot"
             :data-status (name (or status :pending))
             :role        "img"

--- a/tools/story/src/re_frame/story/ui/sidebar_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar_styles.cljs
@@ -153,22 +153,17 @@
    :empty        {:color (:text-tertiary colors/tokens)
                   :font-style "italic"
                   :padding "8px 12px"}
-   ;; rf2-q0irb — status dot + chrome-level test widget. The dot tints
-   ;; derive from the SHARED status vocabulary (rf2-ba86n.3 —
-   ;; `theme.status`) so a `:pass` dot is the same green as a `:pass`
-   ;; signal chip / result pill. Pending shows an empty ring (the
-   ;; reserved-but-unrun slot).
+   ;; rf2-q0irb — status dot + chrome-level test widget. Only the dot's
+   ;; GEOMETRY lives here; the per-status paint projects from the
+   ;; canonical `theme.status` descriptors in `sidebar/dot-style`
+   ;; (rf2-ba86n.3 / rf2-wh5to — one source, no duplicate status maps),
+   ;; so a `:pass` dot is the same green as a `:pass` signal chip /
+   ;; result pill and `:cannot-run` stays distinct from `:pending`.
    :dot          {:width "8px"
                   :height "8px"
                   :border-radius "50%"
                   :flex-shrink "0"
                   :display "inline-block"}
-   :dot-pass     {:background (status/fg :pass)}
-   :dot-fail     {:background (status/fg :fail)}
-   :dot-running  {:background (status/fg :running)
-                  :opacity "0.7"}
-   :dot-pending  {:background "transparent"
-                  :border (str "1px solid " (:border-strong colors/tokens))}
    :widget       {:border-top (str "1px solid " (:border-default colors/tokens))
                   :margin-top "auto"
                   :padding "10px 12px"

--- a/tools/story/src/re_frame/story/ui/state/tests.cljc
+++ b/tools/story/src/re_frame/story/ui/state/tests.cljc
@@ -125,7 +125,16 @@
                 ran-at-ms elapsed-ms status]} (or summary {})
         status (cond
                  (contains? verdict/statuses status)
-                 (if (= :error status) :fail status)   ; :error reads as :fail on the dot
+                 ;; This slot carries the FIVE dot-facing run statuses
+                 ;; (`test-run-statuses` — `:cannot-run` is the distinct
+                 ;; third). A run-level `:error` verdict lowers to `:fail`
+                 ;; HERE, at write time — the one place the four-verdict
+                 ;; vocabulary (spec/017, `verdict/statuses`) narrows; both
+                 ;; demand attention and wear the danger tint. The
+                 ;; per-assertion `:error` detail stays distinct in the
+                 ;; test-mode pane's result rows (test-mode.pure), per
+                 ;; spec/018 §12.6.
+                 (if (= :error status) :fail status)
                  (zero? (or total 0)) :pending
                  all-passed?          :pass
                  (pos? (or cannot-run 0)) :cannot-run

--- a/tools/story/test/re_frame/story/theme/status_vocab_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/theme/status_vocab_cljs_test.cljc
@@ -189,11 +189,18 @@
 
 #?(:cljs
    (deftest sidebar-status-dots-derive-from-fg
-     (testing "the per-variant status dots tint from status/fg — the same
-               single source the chips read"
-       (is (= {:background (status/fg :pass)}    (:dot-pass styles)))
-       (is (= {:background (status/fg :fail)}    (:dot-fail styles)))
-       (is (= (status/fg :running) (:background (:dot-running styles)))))))
+     (testing "the per-variant status dots project from the descriptor
+               source (`sidebar/dot-style`) — the same single source the
+               chips read; there are no duplicate per-status style-map
+               entries left to drift (rf2-wh5to)"
+       (is (= {:background (status/fg :pass)} (sidebar/dot-style :pass)))
+       (is (= {:background (status/fg :fail)} (sidebar/dot-style :fail)))
+       (is (= (status/fg :running) (:background (sidebar/dot-style :running))))
+       ;; :cannot-run rings in its own descriptor border colour — the
+       ;; canonical third run status never wears :pending's neutral ring.
+       (is (= (str "1px solid " (:border (status/descriptor :cannot-run)))
+              (:border (sidebar/dot-style :cannot-run))))
+       (is (not= (sidebar/dot-style :pending) (sidebar/dot-style :cannot-run))))))
 
 ;; ---- glyph channel rendered in the sidebar chip (rf2-gsqbp) -------------
 

--- a/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
@@ -13,7 +13,7 @@
     `variant-test-status` lookup; `test-summary` aggregation across a
     fixture of variants in mixed states; `testable-variant-ids`
     filter (must be both `:test`-tagged AND `:play-script`-bearing); the
-    `status->dot-style-key` projection and `dot-aria-label`.
+    `dot-style` descriptor projection and `dot-aria-label`.
   - **CLJS-only**: the rendered hiccup for the chrome widget carries
     the expected counts + headline; the sidebar's variant-row hiccup
     includes the status dot when the variant is testable; the
@@ -23,7 +23,7 @@
             [re-frame.story.registrar :as story-registrar]
             [re-frame.story.ui.state :as state]
             #?@(:cljs [[re-frame.story.ui.sidebar :as sidebar]
-                       [re-frame.story.ui.sidebar-styles :refer [styles]]])))
+                       [re-frame.story.theme.status :as status]])))
 
 ;; ---- fixtures ------------------------------------------------------------
 
@@ -152,33 +152,49 @@
   (testing "no :test variants → empty seq, widget renders 'no :test variants'"
     (is (empty? (state/testable-variant-ids {})))))
 
-;; ---- pure: status → dot style key + aria label --------------------------
+;; ---- pure: status → dot style + aria label -------------------------------
 
 #?(:cljs
-   (deftest status-dot-style-mapping
-     (testing "each canonical status maps to a distinct style key"
-       (is (= :dot-pass    (sidebar/status->dot-style-key :pass)))
-       (is (= :dot-fail    (sidebar/status->dot-style-key :fail)))
-       (is (= :dot-running (sidebar/status->dot-style-key :running)))
-       (is (= :dot-pending (sidebar/status->dot-style-key :pending)))
-       ;; `:error` (a run outcome the chrome widget CAN produce, e.g. a
-       ;; handler that throws) shares the danger tint with `:fail`.
-       (is (= :dot-fail    (sidebar/status->dot-style-key :error)))
-       ;; Chip-axis statuses that don't carry a bespoke dot style return
-       ;; nil — `status-dot` degrades them to the neutral pending ring
-       ;; rather than dereferencing nil as a fn (the sidebar-render crash).
-       (is (nil? (sidebar/status->dot-style-key :cannot-run))))))
+   (deftest status-dot-style-derives-from-descriptor
+     (testing "dot-style projects each run status's paint from the ONE
+               canonical theme.status descriptor source (rf2-wh5to) —
+               settled solid statuses fill with the descriptor fg,
+               running fills translucent, the hollow shapes ring in the
+               descriptor border colour"
+       (is (= {:background (status/fg :pass)} (sidebar/dot-style :pass)))
+       (is (= {:background (status/fg :fail)} (sidebar/dot-style :fail)))
+       (is (= {:background (status/fg :running) :opacity "0.7"}
+              (sidebar/dot-style :running)))
+       (is (= {:background "transparent"
+               :border     (str "1px solid " (:border (status/descriptor :pending)))}
+              (sidebar/dot-style :pending)))
+       (is (= {:background "transparent"
+               :border     (str "1px solid " (:border (status/descriptor :cannot-run)))}
+              (sidebar/dot-style :cannot-run))))
+     (testing ":cannot-run (the canonical third run status,
+               state.tests/test-run-statuses) is visibly DISTINCT from
+               :pending — a warning-hued ring, never the neutral
+               reserved-slot ring"
+       (is (not= (sidebar/dot-style :pending) (sidebar/dot-style :cannot-run))))
+     (testing "pending is reserved for the genuinely unknown/nil slot —
+               unknown statuses degrade through the descriptor fallback"
+       (is (= (sidebar/dot-style :pending) (sidebar/dot-style :unknown)))
+       (is (= (sidebar/dot-style :pending) (sidebar/dot-style nil))))))
 
 #?(:cljs
    (deftest status-dot-aria-labels
-     (testing "every status produces a distinct accessible label"
-       (is (= "tests passing"     (sidebar/dot-aria-label :pass)))
-       (is (= "tests failing"     (sidebar/dot-aria-label :fail)))
-       (is (= "tests errored"     (sidebar/dot-aria-label :error)))
-       (is (= "tests running"     (sidebar/dot-aria-label :running)))
-       (is (= "tests not yet run" (sidebar/dot-aria-label :pending)))
-       ;; Unrecognised → safe fallback.
-       (is (= "tests not yet run" (sidebar/dot-aria-label :unknown))))))
+     (testing "the accessible label voices the canonical descriptor label
+               — every run status distinct, :cannot-run ≠ :pending"
+       (is (= "tests: Pass"      (sidebar/dot-aria-label :pass)))
+       (is (= "tests: Fail"      (sidebar/dot-aria-label :fail)))
+       (is (= "tests: Running"   (sidebar/dot-aria-label :running)))
+       (is (= "tests: Pending"   (sidebar/dot-aria-label :pending)))
+       (is (= "tests: Can't run" (sidebar/dot-aria-label :cannot-run)))
+       (is (not= (sidebar/dot-aria-label :pending)
+                 (sidebar/dot-aria-label :cannot-run)))
+       ;; Unrecognised / nil → the descriptor's pending fallback.
+       (is (= "tests: Pending" (sidebar/dot-aria-label :unknown)))
+       (is (= "tests: Pending" (sidebar/dot-aria-label nil))))))
 
 ;; ---- CLJS-only: rendered hiccup contains the widget ---------------------
 
@@ -265,17 +281,36 @@
          (is (= "pass"    (get (second dot-pass) :data-status)))
          (is (= "running" (get (second dot-running) :data-status)))
          ;; aria-label round-trips for screen-reader users.
-         (is (= "tests failing" (get (second dot-fail) :aria-label)))
-         ;; A status with no bespoke dot style (a chip-axis value that
-         ;; reaches the dot) must render — never crash — falling back to
-         ;; the neutral pending ring (regression guard for the sidebar
-         ;; null-deref that reddened the nightly for 13 nights).
-         (let [dot-unmapped (sidebar/status-dot :cannot-run)]
-           (is (= "cannot-run" (get (second dot-unmapped) :data-status)))
-           (is (= (:dot-pending styles)
-                  (select-keys (get (second dot-unmapped) :style)
-                               (keys (:dot-pending styles))))
-               "unmapped status degrades to the pending ring, not a crash"))))))
+         (is (= "tests: Fail" (get (second dot-fail) :aria-label)))))))
+
+;; ---- rf2-wh5to — :cannot-run ≠ :pending THROUGH the dot -------------------
+
+#?(:cljs
+   (deftest sidebar-dot-cannot-run-distinct-from-pending
+     (testing ":cannot-run — the distinct third run status
+               (state.tests/test-run-statuses, spec/017 §:cannot-run) —
+               renders visibly AND accessibly distinct from :pending
+               through the dot component itself: different paint
+               (warning ring vs neutral ring), different accessible
+               name, different data-status. Pending stays reserved for
+               the genuinely unknown slot; a refusal never wears it."
+       (let [dot-cannot  (sidebar/status-dot :cannot-run)
+             dot-pending (sidebar/status-dot :pending)
+             props       (fn [dot] (second dot))]
+         (is (= "cannot-run" (:data-status (props dot-cannot))))
+         (is (= "pending"    (:data-status (props dot-pending))))
+         ;; Visible channel — the rendered inline style differs.
+         (is (not= (:style (props dot-cannot)) (:style (props dot-pending)))
+             ":cannot-run must not wear the pending ring")
+         ;; The paint comes from the canonical descriptor source.
+         (is (= (str "1px solid " (:border (status/descriptor :cannot-run)))
+                (:border (:style (props dot-cannot)))))
+         ;; Accessible channel — label + title both voice the refusal.
+         (is (= "tests: Can't run" (:aria-label (props dot-cannot))))
+         (is (= "tests: Pending"   (:aria-label (props dot-pending))))
+         (is (not= (:aria-label (props dot-cannot))
+                   (:aria-label (props dot-pending))))
+         (is (= "tests: Can't run" (:title (props dot-cannot))))))))
 
 ;; ---- rf2-k3y92 — status-dot is decorative img (not a live region) -------
 


### PR DESCRIPTION
## What

Two items on the same tools/story surface for rf2-wh5to (nightly expensive-tests red — the remaining story-STATIC failure, plus the bead's reopened status-honesty residual).

### 1. Story static-export crash: `null.Provider` (the 2026-07-21 nightly failure)

**Root cause — commit `6521c0cb71` (PR #5819, 2026-07-13).** That commit made `re-frame.adapter.sub-override-context/override-context` nil under `goog.DEBUG=false` (production keeps no `createContext` residue — asserted by `sub_overrides_elision_prod_test`). But the Story-side consumer `re-frame.story.sub-overrides/override-provider` still read `(.-Provider ovr-ctx/override-context)` **ungated**. The `:story-static/*` build is a `shadow-cljs release` (`goog.DEBUG=false`), so rendering ANY variant (the canvas wraps every variant view in `sub-overrides-scope`) threw `TypeError: Cannot read properties of null (reading 'Provider')` — exactly the CI pageerror, followed by the smoke's 10s `waitFor` timeout on the variant title.

Why it surfaced only on 2026-07-21: `test:story-static` runs last in the nightly step, after `test:story-feature-load`. The feature-load failures (fixed in #6644) masked it every night 07-08..07-20; the first night they passed, story-static ran and hit this. The regression window is 07-07 (last time the smoke ran green) .. 07-21, and `6521c0cb71` (07-13) sits inside it.

**Fix:** gate `override-provider` on `interop/debug-enabled?` (compile-time) — it returns `child` unchanged when the sub-override seam is compiled out, mirroring `re-frame.ui.sub-overrides/provider-element`. No behaviour is lost: `subscribe`'s override consult is already elided under `goog.DEBUG=false` (spec 013 §Static-mode keeps standard release elision), so the Provider mount carried no behaviour in those builds — only the crash.

Reproduced locally before the fix (identical pageerror + timeout), green after.

### 2. Status-dot canonical statuses (audit rider on this bead)

- `sidebar/dot-style` (new) projects the compact dot paint from the one `theme.status` descriptor source — colour from `:fg`/`:border`, shape at dot scale (`:solid` fills, `:half` translucent fill, hollow shapes ring in the descriptor border colour). `dot-aria-label` projects from the descriptor `:label`.
- `:cannot-run` — the distinct third run status (`ui.state.tests/test-run-statuses`, spec/017) — now renders a warning-hued ring with `tests: Can't run`, visibly AND accessibly distinct from `:pending`'s neutral ring; `:pending` is reserved for genuinely unknown/nil via the descriptor fallback.
- Deleted the duplicate mappings the canonical source replaces: `status->dot-style-key` and the `:dot-pass/:dot-fail/:dot-running/:dot-pending` style entries.
- `:error → :fail` reconciliation: the lowering stays at `record-test-run` write time — the one place the four-verdict vocabulary (spec/017 `verdict/statuses`) narrows to the five dot-facing statuses; the test-mode pane keeps per-assertion `:error` distinct. Now documented at the seam instead of a drive-by alias comment.
- Focused test proves `:cannot-run ≠ :pending` through the dot component itself (paint + aria-label + data-status).
- Spec 009/016 dot vocabulary brought current with the shipped third status.

No registry, no linter, no skip/retry scaffolding, no broad refactor.

Not in scope: the benign Closure JSDoc parse warning (`unknown JSDoc tag "configured"`) logged during story:build comes from a wrapped docstring line in `tools/xray/src/day8/re_frame2_xray/config.cljc` (~line 1401) — log noise only, left for a trivial follow-up.

## Quality gates

All run FOREGROUND to completion in the worker worktree; story-static re-run after rebasing onto current main:

| Gate | Result |
|---|---|
| `npm run test:story-static` (the failing nightly gate; builds `:story-static/counter-with-stories` release + smoke) | PASS — red before the fix with the exact CI pageerror, green after; re-run green post-rebase |
| tools/story `clojure -M:test` | 1847 tests, 6825 assertions, **0 failures, 0 errors** |
| `npm run test:story-feature-load` | Ran 2 specs, **0 failures** |
| `npm run test:cljs` | 10373 tests, 51289 assertions, **0 failures, 0 errors** |

Bead rf2-wh5to stays OPEN — acceptance is two consecutive green scheduled nightlies, watched post-merge.