### PR TITLE
chore(ci): update stale lint.yml comment to the consolidated skill path (rf2-hxeg5)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -358,7 +358,7 @@ jobs:
       # The re-frame.ui AI context sheet (rf2-u53yy.8). Its compile-rejection
       # roster is GENERATED from the compiler's own env/fail! / env/warn!
       # didactic messages in analyze.cljc; this check regenerates the sheet in
-      # memory and reds until skills/re-frame2-ui-context/SKILL.md is
+      # memory and reds until skills/re-frame2-ui/references/ui-context.md is
       # regenerated — so a reworded / added / removed compiler diagnostic can
       # never silently drift the sheet.
       - name: Regenerate re-frame.ui context sheet + assert no drift


### PR DESCRIPTION
One-line comment fix: the ui-context drift gate's comment still named `skills/re-frame2-ui-context/SKILL.md`, which PR #6665 (rf2-cv8a2y consolidation) replaced with `skills/re-frame2-ui/references/ui-context.md`. The `run:` command is path-agnostic; behavior unchanged.

## Quality gates
- Comment-only diff in .github/workflows/lint.yml — no job, `needs`, or gating change; the workflow's own CI run on this PR is the proof.

Closes rf2-hxeg5.