### PR TITLE
fix(ui): project the compile-side removed-source delta into the runtime ledger (rf2-4vm19)

### DIFF
--- a/implementation/scripts/check-ui-warm-watch.cjs
+++ b/implementation/scripts/check-ui-warm-watch.cjs
@@ -1,55 +1,78 @@
 #!/usr/bin/env node
 'use strict';
 
-// rf2-tm1xi (Arm 2 of rf2-4vm19) — a real Shadow warm-watch/file-edit fixture
-// proving the re-frame.ui custom-element HARVEST TOPOLOGY survives real warm
-// edits, that a removed/renamed saved source's `:build-sources` graph delta
-// evicts (or re-owns) its runtime declarations, and (rf2-u53yy.1 S6) that a real
-// daemon restart REUSES Shadow's disk cache for the UI-consuming sources without
-// re-expanding them. It complements the
-// synthetic JVM fixtures (compiler_harvest_hook_jvm_test / custom_element_
-// warm_staleness_jvm_test), which hand-build build state and cannot exercise a
-// real Shadow watch, real inherited-then-build-local hook deep-merge, or real
-// file delete/rename/move.
+// rf2-4vm19 (final arm; compile-side lineage rf2-tm1xi/rf2-lkv72) — a real
+// Shadow warm-watch/file-edit fixture proving, END-TO-END, that:
+//
+//   * the re-frame.ui custom-element HARVEST TOPOLOGY survives real warm edits;
+//   * a removed/renamed saved source's `:build-sources` graph delta evicts (or
+//     re-owns) its declarations in BOTH registries — the compile-side accepted
+//     manifest AND the live RUNTIME ledger of one emitted runtime (no DOM, no
+//     browser): the runner loads the fixture's `:node-script` output as a live
+//     node child wired to the watch's devtools server, so real hot reloads and
+//     the removed-source projection (`:build-notify` ->
+//     `re-frame.ui.rules/shadow-build-notify`) drive the runtime ledger with no
+//     page reload;
+//   * (rf2-u53yy.1 S6) a real daemon restart REUSES Shadow's disk cache for the
+//     UI-consuming sources without re-expanding them.
+//
+// It complements the synthetic JVM fixtures (compiler_harvest_hook_jvm_test /
+// custom_element_warm_staleness_jvm_test), which hand-build build state and
+// cannot exercise a real Shadow watch, real inherited-then-build-local hook
+// deep-merge, real file delete/rename/move, or a live hot-reloading runtime.
 //
 // Per the rf2-4vm19 Arm-1 ruling the build-topology obligation is proving ONE
 // real dev build's identity at the runtime seam — a non-::default build id, the
 // inherited hook's discovery/order, and stage-annotation load-bearingness — NOT
-// two-build isolation (a broken realm Shadow does not support). This gate reads
-// only the accepted topology re-frame.ui's inherited hook establishes; a
-// build-local OBSERVE hook (deep-merged AFTER, never mutating build state)
-// records it at :compile-finish.
+// two-build isolation (a broken realm Shadow does not support). The compile
+// gate reads only the accepted topology re-frame.ui's inherited hook
+// establishes (a build-local OBSERVE hook records it at :compile-finish); the
+// runtime gate reads the JSONL the emitted runtime's own observer appends
+// (boot identity, mid-chain open-cycle witness, exact aggregate + ledger
+// membership after every committed reload cycle).
 //
-// ONE warm daemon is walked, via real file edits, through:
+// ONE warm daemon and ONE live runtime are walked, via real file edits, through:
 //   1. COLD ACCEPT — card declares :probe-card #{:model :size}, leaf declares
 //      :probe-leaf #{:flag}, the no-require-edge view consumes :probe-card. The
 //      accepted build id is :ui-warm-watch (never ::default): the inherited hook
-//      ran and its stage annotation is load-bearing.
+//      ran and its stage annotation is load-bearing. The runtime then BOOTS and
+//      its `boot` record proves the SAME identity resolves at the runtime seam,
+//      with the exact write-through aggregate + ledger membership.
 //   2. ZERO-DECLARATION warm pass — a viewless/declarationless trigger edit. The
 //      manifest is unchanged, the consumer view is a warm cache hit (coarse
-//      invalidation does NOT over-fire).
+//      invalidation does NOT over-fire). At the runtime, trigger's top-level
+//      MID-CHAIN witness records the build's reload cycle OPEN while shadow's
+//      loader re-runs it (both lifecycle annotations load-bearing), and the
+//      committed cycle republishes the EXACT unchanged aggregate.
 //   3. DECLARATION-SHRINK warm pass — card drops :size. The harvest re-reads card
 //      (manifest :probe-card -> #{:model}) and the coarse manifest-change
 //      invalidation RECOMPILES the no-require-edge consumer view so it re-bakes.
-//      If the warm rebuild failed to re-harvest, the manifest would still read
-//      #{:model :size} -> RED.
+//      The runtime's committed cycle replaces card's whole contribution:
+//      aggregate exactly {probe-card [model], probe-leaf [flag]}.
 //   4. SAME-NAMESPACE FILE MOVE — leaf.cljs is relocated to the fixture's second
 //      source-path root, keeping its namespace. Because re-frame.ui's eviction
 //      unit is the declaring NAMESPACE (not the resource/file), :probe-leaf's
-//      ownership survives the file move: it stays in the manifest and `…leaf`
-//      stays in `:build-sources`.
+//      ownership survives the file move in BOTH registries: it stays in the
+//      manifest, `…leaf` stays in `:build-sources`, and the runtime ledger keeps
+//      its row.
 //   5. RENAME — leaf's namespace becomes `…leaf-renamed` and the client `:require`
 //      is repointed. The old namespace leaves `:build-sources`, the new one
-//      enters, and :probe-leaf is re-owned by the renamed namespace.
+//      enters, :probe-leaf is re-owned by the renamed namespace — and at the
+//      runtime the projection evicts the OLD namespace's ledger row while the
+//      renamed source's re-registration keeps the aggregate stable.
 //   6. DELETE — the renamed source and its client `:require` are removed. Its
 //      namespace leaves `:build-sources` with no successor, so :probe-leaf is
-//      EVICTED from the accepted manifest — the removed saved-source graph delta,
-//      applied with no page reload.
+//      EVICTED from the accepted manifest AND from the live runtime aggregate —
+//      the removed saved-source graph delta, applied with no page reload. This
+//      is the delta SHADOW_NS_RESET can never report (a deleted source never
+//      re-runs); only the projected compile-side membership can carry it.
 //   7. FAILED COMPILE — card is rewritten to a syntax error. The build fails,
-//      no candidate is finalized (no new :finish record), and the accepted
-//      last-known-good manifest is preserved.
-//   8. SUCCESSFUL RETRY — card is fixed. The build converges clean and the
-//      manifest matches the last good state (:probe-card #{:model}).
+//      no candidate is finalized (no new :finish record), the accepted
+//      last-known-good manifest is preserved, and the RUNTIME receives no
+//      broadcast — its ledger and aggregate stay last-known-good (no record).
+//   8. SUCCESSFUL RETRY — card is fixed. The build converges clean, the
+//      manifest matches the last good state (:probe-card #{:model}), and the
+//      runtime's committed retry cycle republishes exactly that aggregate.
 //
 // TEETH (documented mutation/revert; run at development time, NOT committed):
 //   * Drop the `{:shadow.build/stages …}` annotation on
@@ -66,12 +89,25 @@
 //     -> RED (coarse invalidation).
 //   * Break `keep-members`/membership eviction in shadow-finish-candidate -> the
 //     DELETE pass keeps :probe-leaf's ghost declaration (leaf-tag-present stays
-//     true) -> RED (the `:build-sources` delta).
+//     true) -> RED (the `:build-sources` delta, compile side).
+//   * Delete `wire-removed-source-notify` in the build hook (or the
+//     `shadow-build-notify` receiver body in rules.cljc) -> the DELETE pass's
+//     runtime aggregate keeps :probe-leaf's ghost row and the RENAME pass never
+//     evicts the old namespace's ledger row -> RED (the removed-source
+//     projection producer is load-bearing end-to-end).
+//   * Drop the `^:dev/before-load` annotation on rules/notify-reload! -> the
+//     control pass's mid-chain witness records NO open cycle
+//     (`cycles-open` []) -> RED (the before-load annotation is load-bearing).
+//   * Drop the `^:dev/after-load` annotation on rules/commit-reload! -> the
+//     DECLARATION-SHRINK pass's staged replacement is never committed, so the
+//     runtime aggregate never reaches {probe-card [model], …} -> RED (the
+//     after-load annotation is load-bearing).
 // All were exercised red-before-green during development.
 
 const fs = require('fs');
 const path = require('path');
 const {
+  createHarnessCleanup,
   spawnHarnessProcess,
   terminateProcessTree,
 } = require('./lib/local-browser-harness.cjs');
@@ -91,8 +127,26 @@ const ALT_LEAF = path.join(
 const LEAF_RENAMED = path.join(FIX, 'leaf_renamed.cljs');
 const TARGET = path.join(IMPL, 'target', 'ui-warm-watch');
 const OUT = path.join(IMPL, 'out', 'ui-warm-watch');
+const MAIN_JS = path.join(OUT, 'main.js');
+const RUNTIME_LOG = path.join(TARGET, 'runtime.jsonl');
 const BUILD_ID = 'ui-warm-watch';
+const BUILD_KW = ':ui-warm-watch';
 const TIMEOUT = 120000;
+
+const CARD_NS = 're-frame.ui.digest-probe.warm-watch.card';
+const LEAF_NS = 're-frame.ui.digest-probe.warm-watch.leaf';
+const LEAF_RENAMED_NS = 're-frame.ui.digest-probe.warm-watch.leaf-renamed';
+
+// Exact runtime aggregate images (sorted tags -> sorted property names), the
+// observe fixture's canonical serialization.
+const AGG_FULL = { 'probe-card': ['model', 'size'], 'probe-leaf': ['flag'] };
+const AGG_SHRUNK = { 'probe-card': ['model'], 'probe-leaf': ['flag'] };
+const AGG_FINAL = { 'probe-card': ['model'] };
+
+// Exit/signal cleanup for every spawned child (watch daemons + the emitted
+// runtime): SIGINT/SIGTERM/exit sweep the whole process tree.
+const cleanup = createHarnessCleanup();
+cleanup.installSignalHandlers();
 
 function fail(message) {
   throw new Error(`FAIL: ${message}`);
@@ -110,10 +164,6 @@ function bool(line, key) {
   const m = line.match(new RegExp(`:${key} (true|false)`));
   return m ? m[1] === 'true' : null;
 }
-function num(line, key) {
-  const m = line.match(new RegExp(`:${key} (-?\\d+)`));
-  return m ? Number(m[1]) : null;
-}
 function str(line, key) {
   const m = line.match(new RegExp(`:${key} "([^"]*)"`));
   return m ? m[1] : null;
@@ -124,6 +174,44 @@ function lastOfStage(stage) {
 }
 function countStage(stage) {
   return readRecords().filter((l) => l.includes(`:stage :${stage}`)).length;
+}
+
+// --- the runtime observation log ---------------------------------------------
+
+function readRuntimeRecords() {
+  if (!fs.existsSync(RUNTIME_LOG)) return [];
+  return fs.readFileSync(RUNTIME_LOG, 'utf8')
+    .trim().split(/\r?\n/).filter(Boolean)
+    .map((l) => { try { return JSON.parse(l); } catch (_) { return null; } })
+    .filter(Boolean);
+}
+function runtimeCount() {
+  return readRuntimeRecords().length;
+}
+// Canonical (key-sorted) stringify so aggregate images compare exactly.
+function canon(v) {
+  if (Array.isArray(v)) return `[${v.map(canon).join(',')}]`;
+  if (v && typeof v === 'object') {
+    return `{${Object.keys(v).sort().map((k) => `${JSON.stringify(k)}:${canon(v[k])}`).join(',')}}`;
+  }
+  return JSON.stringify(v);
+}
+function aggIs(rec, expected) {
+  return canon(rec.aggregate) === canon(expected);
+}
+function ledgerHas(rec, ns) {
+  return (rec.ledger || []).some(([b, n]) => b === BUILD_KW && n === ns);
+}
+async function awaitRuntimeRecord(sinceIdx, pred, what) {
+  for (let i = 0; i < 200; i += 1) {
+    const recs = readRuntimeRecords().slice(sinceIdx);
+    for (let j = recs.length - 1; j >= 0; j -= 1) {
+      if (pred(recs[j])) return recs[j];
+    }
+    await sleep(50);
+  }
+  return fail(`runtime: ${what} never appeared; records after ${sinceIdx}: ${
+    JSON.stringify(readRuntimeRecords().slice(sinceIdx)).slice(0, 2500)}`);
 }
 
 // --- real source edits ------------------------------------------------------
@@ -182,10 +270,10 @@ function setClientLeaf(mode) {
 // --- shadow watch driver -----------------------------------------------------
 
 function watch() {
-  const child = spawnHarnessProcess(process.execPath, [
+  const child = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [
     require.resolve('shadow-cljs/cli/runner.js', { paths: [IMPL] }),
     'watch', BUILD_ID,
-  ], { cwd: FIX, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
+  ], { cwd: FIX, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] }));
 
   let successes = 0;
   let failures = 0;
@@ -238,6 +326,22 @@ function watch() {
   };
 }
 
+// --- the emitted runtime (one live node child, no DOM) -----------------------
+
+function startRuntime() {
+  const child = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [MAIN_JS], {
+    cwd: IMPL,
+    env: { ...process.env, RF2_WARM_WATCH_RUNTIME_LOG: RUNTIME_LOG },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }));
+  const forward = (chunk) => process.stdout.write(
+    String(chunk).split(/\r?\n/).filter(Boolean).map((l) => `  [runtime] ${l}\n`).join(''),
+  );
+  child.stdout.on('data', forward);
+  child.stderr.on('data', forward);
+  return child;
+}
+
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 async function awaitRecord(stage, priorCount) {
@@ -270,9 +374,29 @@ async function coldAccept(w) {
   console.log(`  cold accept: build id ${str(fin, 'accepted-build-id')}, :probe-card #{:model :size}, :probe-leaf #{:flag}`);
 }
 
+// Boot the emitted runtime against the accepted cold build and prove the REAL
+// build identity resolves at the runtime seam, with the exact write-through
+// aggregate + ledger membership of the initial load.
+async function runtimeBoot() {
+  const child = startRuntime();
+  const boot = await awaitRuntimeRecord(0, (r) => r.evt === 'boot', 'the boot record');
+  if (boot['build-id'] !== BUILD_KW) {
+    fail(`runtime boot: current-build-id resolved ${boot['build-id']}, not ${BUILD_KW} — the real dev build identity did not reach the runtime seam`);
+  }
+  if (!aggIs(boot, AGG_FULL)) {
+    fail(`runtime boot: aggregate ${JSON.stringify(boot.aggregate)} != ${JSON.stringify(AGG_FULL)}`);
+  }
+  if (!ledgerHas(boot, CARD_NS) || !ledgerHas(boot, LEAF_NS)) {
+    fail(`runtime boot: ledger membership missing a declaring source (${JSON.stringify(boot.ledger)})`);
+  }
+  console.log(`  runtime boot: build id ${boot['build-id']} at the runtime seam, aggregate + ledger exact`);
+  return child;
+}
+
 async function zeroDeclarationPass(w) {
   const sc = w.successCount();
   const fc = countStage('finish');
+  const rt = runtimeCount();
   editTrigger('control');
   await w.waitSuccess(sc);
   await awaitRecord('finish', fc);
@@ -284,12 +408,28 @@ async function zeroDeclarationPass(w) {
   if (str(fin, 'card-props') !== '[:model :size]' || str(fin, 'leaf-props') !== '[:flag]') {
     fail(`zero-declaration: a viewless edit perturbed the manifest (${fin})`);
   }
-  console.log('  zero-declaration pass: manifest stable, consumer view a warm cache hit');
+  // RUNTIME: trigger's top-level mid-chain witness must observe the reload
+  // cycle OPEN (both lifecycle annotations load-bearing), and the committed
+  // cycle must republish the EXACT unchanged aggregate.
+  const load = await awaitRuntimeRecord(rt,
+    (r) => r.evt === 'source-load' && r.src === 'trigger',
+    'the mid-chain trigger load witness');
+  if (canon(load['cycles-open']) !== canon([BUILD_KW])) {
+    fail(`zero-declaration: mid-chain witness saw cycles-open ${JSON.stringify(load['cycles-open'])} — the ^:dev/before-load cycle was not open during the load phase`);
+  }
+  const pub = await awaitRuntimeRecord(rt,
+    (r) => r.evt === 'publish' && aggIs(r, AGG_FULL),
+    'the committed zero-declaration republish');
+  if (!ledgerHas(pub, CARD_NS) || !ledgerHas(pub, LEAF_NS)) {
+    fail(`zero-declaration: runtime ledger membership perturbed (${JSON.stringify(pub.ledger)})`);
+  }
+  console.log('  zero-declaration pass: manifest stable, consumer view a warm cache hit; runtime cycle open mid-chain, aggregate stable');
 }
 
 async function declarationShrinkPass(w) {
   const sc = w.successCount();
   const fc = countStage('finish');
+  const rt = runtimeCount();
   writeCard('#{:model}', 'model');
   await w.waitSuccess(sc);
   await awaitRecord('finish', fc);
@@ -301,12 +441,18 @@ async function declarationShrinkPass(w) {
   if (bool(prep, 'view-output-present') !== false) {
     fail(`declaration-shrink: coarse invalidation did not recompile the no-require-edge consumer view (${prep})`);
   }
-  console.log('  declaration-shrink pass: :probe-card -> #{:model}, consumer view re-baked (coarse invalidation)');
+  // RUNTIME: the hot-reloaded card re-registers into the open cycle; the
+  // ^:dev/after-load commit replaces its whole contribution.
+  await awaitRuntimeRecord(rt,
+    (r) => r.evt === 'publish' && aggIs(r, AGG_SHRUNK),
+    'the committed shrink republish (:probe-card -> #{:model})');
+  console.log('  declaration-shrink pass: :probe-card -> #{:model} in the manifest AND the live runtime aggregate (staged replace committed)');
 }
 
 async function sameNamespaceMovePass(w) {
   const sc = w.successCount();
   const fc = countStage('finish');
+  const rt = runtimeCount();
   fs.mkdirSync(path.dirname(ALT_LEAF), { recursive: true });
   fs.renameSync(LEAF, ALT_LEAF); // same namespace, new source-path root
   await w.waitSuccess(sc);
@@ -318,12 +464,19 @@ async function sameNamespaceMovePass(w) {
   if (bool(fin, 'member-leaf') !== true) {
     fail(`same-namespace move: the moved namespace left :build-sources (${fin})`);
   }
-  console.log('  same-namespace file move: :probe-leaf ownership preserved (eviction unit is the namespace, not the file)');
+  // RUNTIME: the namespace stayed in the graph, so the projection must NOT
+  // evict — its ledger row and the aggregate survive the file move.
+  const pub = await awaitRuntimeRecord(rt,
+    (r) => r.evt === 'publish' && aggIs(r, AGG_SHRUNK) && ledgerHas(r, LEAF_NS),
+    'the file-move republish preserving :probe-leaf ownership');
+  if (!pub) fail('unreachable');
+  console.log('  same-namespace file move: :probe-leaf ownership preserved in :build-sources AND the runtime ledger (eviction unit is the namespace, not the file)');
 }
 
 async function renamePass(w) {
   const sc = w.successCount();
   const fc = countStage('finish');
+  const rt = runtimeCount();
   fs.writeFileSync(LEAF_RENAMED,
     '(ns re-frame.ui.digest-probe.warm-watch.leaf-renamed\n'
     + '  (:require [re-frame.ui :as ui]))\n'
@@ -342,12 +495,21 @@ async function renamePass(w) {
   if (bool(fin, 'leaf-tag-present') !== true) {
     fail(`rename: :probe-leaf was lost across a namespace rename (${fin})`);
   }
-  console.log('  rename: `…leaf` -> `…leaf-renamed` in :build-sources, :probe-leaf re-owned by the renamed namespace');
+  // RUNTIME: the renamed source re-registers :probe-leaf under the NEW
+  // namespace, and the projection evicts the OLD namespace's row — the
+  // rename-away delta SHADOW_NS_RESET can never report. The aggregate is
+  // stable throughout (equal declaration, new owner).
+  await awaitRuntimeRecord(rt,
+    (r) => r.evt === 'publish' && aggIs(r, AGG_SHRUNK)
+      && ledgerHas(r, LEAF_RENAMED_NS) && !ledgerHas(r, LEAF_NS),
+    'the rename republish (old ns evicted, new ns owning, aggregate stable)');
+  console.log('  rename: `…leaf` -> `…leaf-renamed` in :build-sources AND the runtime ledger (old row evicted via the projected delta), :probe-leaf re-owned');
 }
 
 async function deletePass(w) {
   const sc = w.successCount();
   const fc = countStage('finish');
+  const rt = runtimeCount();
   setClientLeaf('none');
   fs.rmSync(LEAF_RENAMED, { force: true });
   await w.waitSuccess(sc);
@@ -362,22 +524,42 @@ async function deletePass(w) {
   if (str(fin, 'card-props') !== '[:model]') {
     fail(`delete: an unrelated declaration was disturbed (${fin})`);
   }
-  console.log('  delete: `…leaf-renamed` left :build-sources, :probe-leaf evicted from the manifest with no page reload');
+  // RUNTIME — the headline proof: the deleted namespace never re-runs, so only
+  // the projected compile-side membership can evict its live rows. The
+  // aggregate converges to exactly {probe-card [model]} with NO page reload,
+  // and the ledger holds neither leaf namespace.
+  await awaitRuntimeRecord(rt,
+    (r) => r.evt === 'publish' && aggIs(r, AGG_FINAL)
+      && !ledgerHas(r, LEAF_RENAMED_NS) && !ledgerHas(r, LEAF_NS),
+    'the delete eviction republish (:probe-leaf gone from the live aggregate)');
+  console.log('  delete: `…leaf-renamed` left :build-sources; :probe-leaf evicted from the manifest AND the live runtime aggregate with no page reload');
 }
 
 async function failedCompileThenRetry(w) {
-  // FAILED COMPILE — last-known-good manifest preserved.
+  // Let any trailing runtime records from the delete pass settle before
+  // snapshotting the count the failure arm must hold constant.
+  await sleep(500);
+
+  // FAILED COMPILE — last-known-good preserved on BOTH sides.
   const failBefore = w.failureCount();
   const finBefore = countStage('finish');
+  const rtBefore = runtimeCount();
   breakCard();
   await w.waitFailure(failBefore);
   await sleep(300);
   if (countStage('finish') !== finBefore) {
     fail('failed-compile: a candidate was finalized despite a compile failure');
   }
-  console.log('  failed compile: build failed, no candidate finalized, last-known-good manifest preserved');
+  // RUNTIME: a failed build broadcasts no accepted graph — no reload chain, no
+  // projection, no publish. The live ledger/aggregate stay last-known-good.
+  await sleep(1200);
+  if (runtimeCount() !== rtBefore) {
+    fail(`failed-compile: the runtime moved on a FAILED build (${
+      JSON.stringify(readRuntimeRecords().slice(rtBefore))})`);
+  }
+  console.log('  failed compile: build failed, no candidate finalized, compile manifest AND runtime ledger stay last-known-good');
 
-  // SUCCESSFUL RETRY — converges clean at the last good manifest.
+  // SUCCESSFUL RETRY — converges clean at the last good manifest, end-to-end.
   const sc = w.successCount();
   writeCard('#{:model}', 'model'); // rewrites the broken file to the good #{:model} form
   await w.waitSuccess(sc);
@@ -386,7 +568,10 @@ async function failedCompileThenRetry(w) {
   if (str(fin, 'card-props') !== '[:model]') {
     fail(`retry: the fixed build did not converge to the last good manifest (${str(fin, 'card-props')})`);
   }
-  console.log('  successful retry: build converged clean, :probe-card #{:model}');
+  await awaitRuntimeRecord(rtBefore,
+    (r) => r.evt === 'publish' && aggIs(r, AGG_FINAL),
+    'the retry republish converging the runtime');
+  console.log('  successful retry: build converged clean, :probe-card #{:model} in the manifest AND the live runtime aggregate');
 }
 
 // WARM DISK-CACHE REUSE — the S6 binary acceptance (rf2-u53yy.1). Stop the watch
@@ -430,10 +615,12 @@ async function warmRestartReuse(w) {
 }
 
 async function drive() {
-  console.log(`\n=== ${BUILD_ID} (real warm watch, parallel compile schedule) ===`);
+  console.log(`\n=== ${BUILD_ID} (real warm watch + one live emitted runtime, parallel compile schedule) ===`);
   let active = watch();
+  let runtime = null;
   try {
     await coldAccept(active);
+    runtime = await runtimeBoot();
     await zeroDeclarationPass(active);
     await declarationShrinkPass(active);
     await sameNamespaceMovePass(active);
@@ -441,8 +628,12 @@ async function drive() {
     await deletePass(active);
     await failedCompileThenRetry(active);
     active = await warmRestartReuse(active);
+    if (runtime.exitCode !== null) {
+      fail(`the emitted runtime exited prematurely (code=${runtime.exitCode})`);
+    }
     console.log(`  PASS ${BUILD_ID}`);
   } finally {
+    if (runtime) await terminateProcessTree(runtime, { timeoutMs: 5000 });
     await terminateProcessTree(active.child, { timeoutMs: 5000 });
   }
 }
@@ -474,9 +665,10 @@ async function run() {
   fs.rmSync(TARGET, { recursive: true, force: true });
   fs.rmSync(OUT, { recursive: true, force: true });
   fs.mkdirSync(TARGET, { recursive: true });
+  cleanup.addCleanup(restore);
   try {
     await drive();
-    console.log('\nui warm-watch harvest topology: PASS');
+    console.log('\nui warm-watch harvest topology + runtime removed-source projection: PASS');
   } finally {
     restore();
   }

--- a/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
+++ b/implementation/ui/src/re_frame/ui/compiler/build_hook.clj
@@ -21,7 +21,13 @@
     - opens a disposable pass seeded from the incoming accepted snapshot,
       pre-touching exactly the CLJS sources Shadow scheduled to compile so a
       recompiled source that dropped its final declaration evicts its accepted
-      row, while output-present cache hits keep theirs.
+      row, while output-present cache hits keep theirs;
+    - wires the runtime removed-source projection (rf2-4vm19): points the
+      devtools client's `:build-notify` receiver at
+      `re-frame.ui.rules/shadow-build-notify` (watched dev builds only, and
+      never over a consumer's own receiver), so each successful build's
+      broadcast `:build-sources` membership evicts a deleted/renamed-away
+      source's runtime custom-element rows without a page reload.
 
   `:compile-finish`
     - folds every authoritative member's descriptor — RESTORED from Shadow's disk
@@ -231,6 +237,63 @@
       build-state)))
 
 ;; ---------------------------------------------------------------------------
+;; The runtime removed-source projection (rf2-4vm19)
+;;
+;; A deleted or renamed-away saved source never re-runs, so the runtime's
+;; SHADOW_NS_RESET producer can never report it and its custom-element ledger
+;; rows would persist until a full page load. The ONLY authority for that delta
+;; is the compile side's `:build-sources` membership — which shadow itself
+;; already broadcasts to every connected runtime on each successful watch build
+;; (`:build-complete` `:info :sources`). The pinned client exposes exactly one
+;; receiver seam for that broadcast: the `:build-notify` fn, carried as the
+;; `custom-notify-fn` closure-define and resolved by munged name off `$CLJS` at
+;; call time. Pointing that define at `re-frame.ui.rules/shadow-build-notify`
+;; projects the removed-namespace delta into the existing runtime reload cycle
+;; (notify-reload! -> note-reloaded-sources! -> commit-reload!) with no second
+;; protocol and no consumer configuration — the hook stays the one re-frame.ui
+;; build setting (rf2-u53yy.1 S6).
+;;
+;; Injected only where the delta can exist and land: a WATCHED dev build
+;; (`:worker-info` — the only mode that hot-reloads; release builds carry no
+;; devtools client, so the define would be dead weight there) whose graph
+;; actually contains the runtime ledger namespace. In dev mode the define is
+;; not baked into any cached source — shadow emits the whole define map into
+;; the flushed bootstrap (`CLOSURE_DEFINES`) on every build — so injection at
+;; `:compile-prepare` lands unconditionally, with zero cache interaction.
+;; ---------------------------------------------------------------------------
+
+(def ^:private client-notify-define
+  "The shadow devtools client's ONE `:build-notify` receiver slot
+  (`shadow.cljs.devtools.client.env/custom-notify-fn`), the closure-define
+  `shadow.build.targets.shared/repl-defines` fills from a build's
+  `:devtools {:build-notify …}`."
+  'shadow.cljs.devtools.client.env/custom-notify-fn)
+
+(def ^:private runtime-notify-fn
+  "`re-frame.ui.rules/shadow-build-notify`, munged the way the client resolves
+  the receiver off `$CLJS` (`cljs.compiler/munge` of the fn symbol)."
+  "re_frame.ui.rules.shadow_build_notify")
+
+(defn- wire-removed-source-notify
+  "Point the shadow client's `:build-notify` receiver at
+  `re-frame.ui.rules/shadow-build-notify` for a watched dev build whose graph
+  contains the runtime ledger, unless the build claimed the seam itself — a
+  consumer's own `:devtools {:build-notify …}` (already merged into the
+  closure-defines at configure) always wins; shadow has exactly one receiver
+  slot, and removed-source eviction then degrades to the documented
+  full-reload bound unless that receiver delegates."
+  [build-state members]
+  (if (and (= :dev (:shadow.build/mode build-state))
+           (:worker-info build-state)
+           (contains? members 're-frame.ui.rules)
+           (not (get-in build-state
+                        [:compiler-options :closure-defines client-notify-define])))
+    (assoc-in build-state
+              [:compiler-options :closure-defines client-notify-define]
+              runtime-notify-fn)
+    build-state))
+
+;; ---------------------------------------------------------------------------
 ;; The hook
 ;; ---------------------------------------------------------------------------
 
@@ -252,10 +315,16 @@
     ;; the schedule read so the widened set is scheduled and re-baked this pass.
     (let [fresh-manifest (build/element-manifest build-id
                                                  (harvest-all-seed build-state))
-          build-state    (reconcile-declaration-edits build-state fresh-manifest)]
+          build-state    (reconcile-declaration-edits build-state fresh-manifest)
+          members        (member-nss build-state)
+          ;; Wire the runtime removed-source projection (rf2-4vm19): the
+          ;; client's `:build-notify` receiver becomes the producer that feeds
+          ;; the removed `:build-sources` delta into the runtime ledger — the
+          ;; delta a deleted/renamed-away source can never self-report.
+          build-state    (wire-removed-source-notify build-state members)]
       (-> (build/prepare-shadow-build build-state
                                       build-id
-                                      (member-nss build-state)
+                                      members
                                       (recompiled-member-nss build-state))
           ;; Store the all-members manifest beside the open pass BEFORE any view
           ;; analyzes, so property lowering is a pure function of the build's

--- a/implementation/ui/src/re_frame/ui/rules.cljc
+++ b/implementation/ui/src/re_frame/ui/rules.cljc
@@ -1649,13 +1649,18 @@
 ;; runtime analogue of the compile side, where `build/commit-slice` evicts a
 ;; source that recompiled contributing nothing.
 ;;
-;; Bounded case (matches rf2-df9873's ruling AND the compile side): a source FILE
-;; deleted with no reloading dependent never re-runs, so shadow never reports it
-;; and its runtime rows persist until the next full page load — "no design can
-;; observe an unsaved deletion." The compile-side `finish-build!` evicts the
-;; deleted source from the COMPILE registry via `:build-sources` membership; the
-;; runtime arm converges on the next full reload. `note-reloaded-sources!` stays
-;; the seam an authoritative removed-source manifest would feed if one is wired.
+;; Bounded case of THIS producer — and the second producer that closes it: a
+;; source FILE deleted (or renamed away) never re-runs, so `before-load-src`
+;; never announces it and no SHADOW_NS_RESET call can ever carry its ns. The
+;; compile side evicts the deleted source from the COMPILE registry via
+;; authoritative `:build-sources` membership; the runtime arm used to converge
+;; only on the next full page load. `note-reloaded-sources!` was always the seam
+;; an authoritative removed-source manifest would feed if one were wired — and
+;; one now is: `shadow-build-notify` below (rf2-4vm19) receives shadow's own
+;; `:build-complete` broadcast of that same `:build-sources` membership and
+;; reconciles the REMOVED delta through this exact seam. What remains genuinely
+;; unobservable is only the UNSAVED bare REPL deletion (rf2-df9873): no saved
+;; graph, no successful build, nothing to project.
 ;;
 ;; Dev-only: the whole install is `js/goog.DEBUG`-gated, so `:advanced`
 ;; production carries no producer and never references SHADOW_NS_RESET.
@@ -1821,6 +1826,104 @@
 ;; this makes the ENTRY ITSELF current. `owned-producer` carries the ownership
 ;; record across the reload boundary that this form no longer needs to.
 #?(:cljs (install-reload-source-producer!))
+
+;; ---------------------------------------------------------------------------
+;; The removed-source producer: shadow's build-lifecycle broadcast feeds the
+;; delta SHADOW_NS_RESET cannot report (rf2-4vm19)
+;;
+;; `reload-source-reset!` above records the sources that RE-RAN. A source whose
+;; file is deleted or renamed away never re-runs — shadow's loader has nothing
+;; to load for it — so no SHADOW_NS_RESET call fires, no `:touched` entry is
+;; recorded, and its committed rows used to survive every hot reload until the
+;; next full page load. The compile side has no such blind spot: its registries
+;; fold over the authoritative `:build-sources` membership at finish, so the
+;; deleted source falls out of the COMPILE registry on the very pass that
+;; removed it. What was missing was the projection of that same authority into
+;; the runtime cycle.
+;;
+;; Shadow itself already delivers it. Every successful watch build broadcasts
+;; `:build-complete` to each connected runtime carrying `:info :sources` — the
+;; per-source image of exactly the `:build-sources` graph the compile hook folds
+;; (`shadow.build/extract-build-info`, sent by the worker on success only). The
+;; pinned client exposes ONE seam for that message: the `:build-notify` receiver
+;; (`shadow.cljs.devtools.client.env/run-custom-notify!` resolves the configured
+;; fn by munged name off `$CLJS` — the same late-lookup discipline shadow applies
+;; to its lifecycle fns). `shadow-build-notify` is that receiver: it diffs THIS
+;; build's committed ledger rows against the broadcast membership and reconciles
+;; the REMOVED namespaces through the existing cycle protocol —
+;; `notify-reload!` -> `note-reloaded-sources!` -> `commit-reload!`, one bounded
+;; removal cycle reusing the same eviction law as every other reload (a touched
+;; source that stages nothing is evicted). No second ledger, no parallel
+;; protocol, no new commit path.
+;;
+;; The wiring is automatic: the re-frame.ui compile hook injects the
+;; `custom-notify-fn` closure-define pointing here whenever the WATCHED dev
+;; build did not claim shadow's one `:build-notify` seam itself (see
+;; `re-frame.ui.compiler.build-hook/wire-removed-source-notify`). A build that
+;; DOES claim it keeps it — shadow has exactly one receiver slot — and
+;; removed-source eviction degrades to the pre-existing bound (stale rows until
+;; the next full page load) unless the app's own receiver delegates:
+;; `(re-frame.ui.rules/shadow-build-notify msg)`.
+;;
+;; Host ordering is deliberately immaterial. The browser client runs the
+;; receiver BEFORE the reload chain settles (source fetches are async); the
+;; node client runs it AFTER the chain committed (imports are synchronous). Both
+;; are the same case here: no cycle is open when the receiver runs, so the
+;; removal cycle opens and commits on its own and shadow's own chain is
+;; untouched. A cycle found OPEN here is a predecessor an aborted load stranded
+;; (shadow skips `^:dev/after-load` when a load task throws); opening the
+;; removal cycle performs exactly the supersession the next before-load would,
+;; with the same loud report (`report-unpaired-cycle!`). Under the unsupported
+;; async-lifecycle overlap (§Overlapping cycles above) the degradation is the
+;; documented one — stale classification until the next full reload.
+;;
+;; Dev-only: the define is injected only into a watched dev build, and the body
+;; folds away with the ledger under `:advanced` (rf2-k9yuy).
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (defn shadow-build-notify
+     "shadow-cljs `:build-notify` receiver (dev only): reconcile this build's
+     committed ledger rows against the successful build's authoritative
+     `:build-sources` membership (`:info :sources` on the `:build-complete`
+     broadcast), evicting the rows of every namespace the saved graph REMOVED.
+     A deleted or renamed-away source never re-runs, so the SHADOW_NS_RESET
+     producer can never report it — this broadcast is the only authority that
+     can, and it is the same membership the compile-side registries fold at
+     finish (rf2-4vm19).
+
+     Wired automatically by the re-frame.ui compile hook unless the build
+     claims `:devtools {:build-notify …}` itself; an app's own receiver can
+     delegate by calling this with the same `msg`.
+
+     Only `:build-complete` carries an accepted graph; every other notify type
+     (`:build-failure`, `:build-start`, `:build-init`) is ignored, so a failed
+     compile/evaluation leaves the last-known-good ledger untouched and the
+     successful retry's `:build-complete` converges it."
+     [{:keys [type info] :as _msg}]
+     (when reload-ledger?
+       (when (= :build-complete type)
+         (let [build-id (current-build-id)
+               member?  (into #{}
+                              (mapcat (fn [{:keys [ns provides]}]
+                                        (or (seq provides) (when ns [ns]))))
+                              (:sources info))
+               removed  (into []
+                              (keep (fn [[b n]]
+                                      (when (and (= b build-id)
+                                                 (not (member? n)))
+                                        n)))
+                              (keys (::sources @ledger-state)))]
+           (when (seq removed)
+             ;; ONE bounded removal cycle through the existing seam. The removed
+             ;; sources by definition cannot re-register during it, so the
+             ;; commit evicts exactly their rows and touches nothing else; a
+             ;; removal-only reconciliation can never introduce a cross-source
+             ;; contradiction, so this commit never raises.
+             (notify-reload! build-id)
+             (note-reloaded-sources! removed build-id)
+             (commit-reload! build-id)))))
+     nil))
 
 (defn reset-custom-elements!
   "Test support: clear the runtime custom-element registry, the per-source

--- a/implementation/ui/test/re_frame/ui/compiler_build_hook_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/compiler_build_hook_jvm_test.clj
@@ -579,3 +579,57 @@
                      (declare-descriptor 'app.pending :page/pending :pending))
           ambient-index (read-in-compiler open-a #(root/descriptor-index))]
       (is (= #{:page/a} (set (keys ambient-index)))))))
+
+;; --- rf2-4vm19: the runtime removed-source projection wiring ----------------
+;;
+;; A deleted/renamed-away saved source never re-runs, so the runtime's
+;; SHADOW_NS_RESET producer can never report it; the only authority for that
+;; delta is the compile side's `:build-sources` membership, which shadow itself
+;; broadcasts to every runtime on success. `:compile-prepare` points the
+;; devtools client's ONE `:build-notify` receiver
+;; (`shadow.cljs.devtools.client.env/custom-notify-fn`) at
+;; `re-frame.ui.rules/shadow-build-notify` — exactly when the delta can exist
+;; and land, and never over a consumer's own receiver. The projection itself is
+;; pinned CLJS-side (rules-cljs-test) and end-to-end by test:ui-warm-watch.
+
+(def ^:private notify-define
+  'shadow.cljs.devtools.client.env/custom-notify-fn)
+
+(def ^:private notify-target
+  "re_frame.ui.rules.shadow_build_notify")
+
+(defn- notify-define-of [state]
+  (get-in state [:compiler-options :closure-defines notify-define]))
+
+(deftest prepare-wires-the-removed-source-notify-for-a-watched-dev-build
+  (let [members '#{re-frame.ui.rules app.main}
+        watched (-> (graph-state :app :compile-prepare members)
+                    (assoc :shadow.build/mode :dev
+                           :worker-info {:host "localhost" :port 9630}))]
+    (testing "a watched dev build whose graph carries the runtime ledger is wired"
+      (is (= notify-target (notify-define-of (prepare watched members)))))
+
+    (testing "idempotent across warm passes — the same value every prepare"
+      (let [once (prepare watched members)]
+        (is (= notify-target (notify-define-of (prepare once members))))))
+
+    (testing "a consumer's own :build-notify receiver always wins (shadow has one slot)"
+      (let [claimed (assoc-in watched
+                              [:compiler-options :closure-defines notify-define]
+                              "my_app.build_notify")]
+        (is (= "my_app.build_notify" (notify-define-of (prepare claimed members))))))
+
+    (testing "a release build is never wired — no devtools client to receive"
+      (is (nil? (notify-define-of
+                 (prepare (assoc watched :shadow.build/mode :release) members)))))
+
+    (testing "a dev compile without a watch worker is never wired — nothing hot-reloads"
+      (is (nil? (notify-define-of
+                 (prepare (dissoc watched :worker-info) members)))))
+
+    (testing "a graph without the runtime ledger namespace is never wired"
+      (let [no-rules '#{app.main}
+            state (-> (graph-state :app :compile-prepare no-rules)
+                      (assoc :shadow.build/mode :dev
+                             :worker-info {:host "localhost" :port 9630}))]
+        (is (nil? (notify-define-of (prepare state no-rules))))))))

--- a/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/client.cljs
+++ b/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/client.cljs
@@ -5,11 +5,29 @@
 
   The runner rewrites the `:require` list below to drop `leaf` (on the RENAME and
   DELETE passes) so the removed/renamed saved source really leaves Shadow's
-  authoritative `:build-sources`; every other pass leaves this file untouched."
+  authoritative `:build-sources`; every other pass leaves this file untouched.
+
+  `main` is the `:node-script` entry (rf2-4vm19): the runner spawns the emitted
+  runtime as a live node child connected to the watch's devtools server, so real
+  hot reloads drive the runtime custom-element ledger end-to-end (no DOM). It
+  installs the publish watch, writes the `boot` record — the proof this bundle's
+  `current-build-id` resolves the REAL dev build id at the runtime seam — and
+  keeps the event loop alive across devtools reconnects."
   (:require [re-frame.ui.client]
             ;; warm-watch-client-requires:start
             [re-frame.ui.digest-probe.warm-watch.card]
             [re-frame.ui.digest-probe.warm-watch.view]
             [re-frame.ui.digest-probe.warm-watch.leaf]
             ;; warm-watch-client-requires:end
-            [re-frame.ui.digest-probe.warm-watch.trigger]))
+            [re-frame.ui.digest-probe.warm-watch.trigger]
+            [re-frame.ui.digest-probe.warm-watch.observe :as observe]))
+
+(defn main
+  "Node-script entry: wire the runtime observer, then stay alive. The devtools
+  websocket keeps the loop busy while connected; the explicit interval keeps
+  the process alive across a daemon restart's reconnect window (the S6
+  warm-restart arm stops one watch daemon and starts another)."
+  [& _]
+  (observe/install!)
+  (observe/record! "boot" {})
+  (js/setInterval (fn keep-alive []) 2147483647))

--- a/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/observe.cljs
+++ b/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/observe.cljs
@@ -1,0 +1,87 @@
+(ns re-frame.ui.digest-probe.warm-watch.observe
+  "Runtime-side observer for the real Shadow warm-watch fixture (rf2-4vm19).
+
+  The emitted `:node-script` runtime appends one JSON line per observation to
+  the runner's runtime log (RF2_WARM_WATCH_RUNTIME_LOG), mirroring the JSONL
+  protocol the JVM observe hook uses for the compile side. Three record kinds:
+
+  * `boot` — written once by `client/main` after the initial load: the REAL
+    build identity `current-build-id` resolved at the runtime seam (must be
+    `:ui-warm-watch`, never `::default`), plus the write-through aggregate and
+    ledger membership of the initial load.
+  * `publish` — written by a watch on the public `custom-elements` aggregate,
+    so every committed reload cycle (including the removed-source projection's
+    removal cycle) produces exactly one runtime snapshot the runner can await.
+  * `source-load` — the MID-CHAIN witness `trigger.cljs` emits at its own top
+    level while shadow's loader is re-running it: at that moment the
+    `^:dev/before-load` `notify-reload!` must already have OPENED the build's
+    reload cycle and the `^:dev/after-load` `commit-reload!` must not yet have
+    closed it, so `:cycles-open` here is direct proof both lifecycle
+    annotations are load-bearing (drop either and the record — or the commit
+    that follows it — goes wrong, reddening the runner).
+
+  Every record carries the same image set (build id, open cycles, the exact
+  sorted aggregate, the ledger source membership), so the runner's assertions
+  are exact-manifest equality, not presence probes. Recording is contained: a
+  throw here must never abort shadow's load chain, so failures degrade to a
+  missing record — which the runner's await then reports loudly.
+
+  Test-only fixture code; never part of any production build."
+  (:require ["fs" :as fs]
+            [re-frame.ui.rules :as rules]))
+
+(def ^:private log-file
+  (or (unchecked-get (.-env js/process) "RF2_WARM_WATCH_RUNTIME_LOG")
+      "target/ui-warm-watch/runtime.jsonl"))
+
+(defn- aggregate-image
+  "The live aggregate as an exactly-comparable image: sorted tag name ->
+  sorted property-name vector."
+  []
+  (into (sorted-map)
+        (map (fn [[tag decl]]
+               [(name tag) (vec (sort (map name (:properties decl))))]))
+        @rules/custom-elements))
+
+(defn- ledger-image
+  "The committed ledger membership as sorted [build-str ns-str] pairs — the
+  runtime mirror of the compile side's `:build-sources` membership."
+  []
+  (->> (rules/ledger-sources)
+       (map (fn [[b n]] [(str b) (str n)]))
+       sort
+       vec))
+
+(defn record!
+  "Append one observation record; contained so a recording failure can never
+  abort shadow's load chain (it degrades to a missing record the runner's
+  await reports)."
+  [evt extra]
+  (try
+    (let [m (merge {:evt         evt
+                    :build-id    (str (rules/current-build-id))
+                    :cycles-open (vec (sort (map str (rules/in-flight-cycles))))
+                    :aggregate   (aggregate-image)
+                    :ledger      (ledger-image)}
+                   extra)]
+      (fs/appendFileSync log-file (str (js/JSON.stringify (clj->js m)) "\n")))
+    (catch :default e
+      (when (exists? js/console)
+        (.error js/console "[warm-watch observe] record! failed" e))))
+  nil)
+
+(defn note-load!
+  "Top-level mid-chain witness: called from a fixture source's own top level,
+  so it runs exactly while shadow's loader is re-evaluating that source —
+  between `notify-reload!` (before-load) and `commit-reload!` (after-load)."
+  [src]
+  (record! "source-load" {:src src}))
+
+(defn install!
+  "Install the publish watch: one `publish` record per committed reload cycle
+  (the public aggregate is republished after every ledger commit, including
+  the removed-source projection's removal cycle)."
+  []
+  (add-watch rules/custom-elements ::runtime-observe
+             (fn [_ _ _ _] (record! "publish" {})))
+  nil)

--- a/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/shadow-cljs.edn
+++ b/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/shadow-cljs.edn
@@ -1,15 +1,24 @@
 ;; Real Shadow fixture for the warm-watch/file-edit harvest-topology proof
-;; (rf2-tm1xi, Arm 2 of rf2-4vm19; warm disk-cache reuse arm, rf2-u53yy.1 S6).
+;; (rf2-tm1xi, Arm 2 of rf2-4vm19; warm disk-cache reuse arm, rf2-u53yy.1 S6;
+;; runtime removed-source projection arm, rf2-4vm19).
 ;;
 ;; A genuine UI client dev build whose INHERITED re-frame.ui compile hook
 ;; (configured in :build-defaults, so Shadow deep-merges it FIRST) establishes the
-;; custom-element harvest topology, coarse manifest-change invalidation, and
-;; `:build-sources`-keyed eviction; a build-local OBSERVE hook (deep-merged AFTER)
-;; records the accepted topology at :compile-finish so the runner can assert it
-;; survives each real warm edit. Per the rf2-4vm19 Arm-1 ruling this proves ONE
-;; real dev build's identity at the runtime seam (a non-::default build id, the
-;; inherited-hook discovery/order, annotation load-bearingness) — NOT two-build
-;; isolation.
+;; custom-element harvest topology, coarse manifest-change invalidation,
+;; `:build-sources`-keyed eviction, and the runtime removed-source projection
+;; (the injected `:build-notify` define); a build-local OBSERVE hook (deep-merged
+;; AFTER) records the accepted topology at :compile-finish so the runner can
+;; assert it survives each real warm edit. Per the rf2-4vm19 Arm-1 ruling this
+;; proves ONE real dev build's identity at the runtime seam (a non-::default
+;; build id, the inherited-hook discovery/order, annotation load-bearingness) —
+;; NOT two-build isolation.
+;;
+;; `:target :node-script` (rf2-4vm19): the runner LOADS the emitted runtime as a
+;; live node child (no DOM, no browser) connected to this watch's devtools
+;; server, so real hot reloads drive the runtime ledger end-to-end — the saved
+;; delete/rename proof needs a runtime that stays alive across builds, which a
+;; compile-side-only fixture cannot supply. The compile-side observations are
+;; target-independent.
 ;;
 ;; Kept independent of implementation/shadow-cljs.edn on purpose (the same choice
 ;; the sibling final-schedule fixture makes): its defining property is a REAL,
@@ -29,11 +38,16 @@
  :build-defaults {:build-hooks [(re-frame.ui.compiler.build-hook/hook)]}
  :builds
  {:ui-warm-watch
-  {:target :browser
-   :output-dir "../../../../../../out/ui-warm-watch"
-   :asset-path "."
-   :modules
-   {:main {:entries [re-frame.ui.digest-probe.warm-watch.client]}}
+  {:target :node-script
+   :main re-frame.ui.digest-probe.warm-watch.client/main
+   :output-to "../../../../../../out/ui-warm-watch/main.js"
+   :output-dir "../../../../../../out/ui-warm-watch/js"
+   ;; A dev node fixture needs no externs inference (that is :advanced release
+   ;; machinery), and its warning noise is LOAD-BEARINGLY absent here: shadow's
+   ;; client skips hot-reload autoload while a build carries warnings, and the
+   ;; runtime arm of this proof is exactly that autoload path. Same setting the
+   ;; top-level node-test builds use to silence the class.
+   :compiler-options {:infer-externs false}
    ;; Deep-merged AFTER the inherited re-frame.ui compile hook: this build-local
    ;; OBSERVE hook records the accepted topology at :compile-finish (and the
    ;; consumer-recompile witness at :compile-prepare) without mutating build

--- a/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/trigger.cljs
+++ b/implementation/ui/test/re_frame/ui/digest_probe/warm_watch/trigger.cljs
@@ -3,7 +3,18 @@
   pass WITHOUT any custom-element manifest delta. Editing it must move nothing in
   the manifest and must NOT trigger the coarse consumer invalidation, so it is the
   zero-declaration warm-edit proof and the control against which a real
-  declaration edit is measured.")
+  declaration edit is measured.
+
+  Its top level also emits the runtime MID-CHAIN witness (rf2-4vm19): when a warm
+  edit recompiles this source, shadow's loader re-runs it between the
+  `^:dev/before-load` `notify-reload!` and the `^:dev/after-load`
+  `commit-reload!`, so the recorded `:cycles-open` proves the build's reload
+  cycle is genuinely OPEN mid-load — the lifecycle-annotation load-bearingness
+  proof at the runtime seam. (Requiring the observe ns adds no re-frame.ui
+  require edge, so this source stays outside the UI literal-consumer set.)"
+  (:require [re-frame.ui.digest-probe.warm-watch.observe :as observe]))
 
 ;; warm-watch-trigger-marker:v1
 (def trigger :v1)
+
+(observe/note-load! "trigger")

--- a/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
@@ -1174,3 +1174,115 @@
            ;; finds exactly one re-frame.ui producer tagged with the ambient id.
            (set-shadow-build-id! original)
            (rules/install-reload-source-producer!))))))
+
+;; ---------------------------------------------------------------------------
+;; `shadow-build-notify` (rf2-4vm19) — the removed-source projection: shadow's
+;; `:build-complete` broadcast of the authoritative `:build-sources` membership
+;; reconciles the ledger's REMOVED delta through the existing cycle seam. These
+;; pin the projection ALGEBRA; the end-to-end wiring (define injection, a real
+;; watch, a live emitted runtime) is proven by `npm run test:ui-warm-watch`.
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (defn- build-complete-msg
+     "A `:build-complete` notify msg whose `:info :sources` carries exactly
+     `source-maps` — the per-source image shadow's worker broadcasts
+     (`shadow.build/extract-build-info`: each entry has `:ns` and/or
+     `:provides`)."
+     [source-maps]
+     {:type :build-complete :info {:sources source-maps}}))
+
+#?(:cljs
+   (deftest build-notify-evicts-the-removed-membership-delta
+     ;; The headline algebra: a namespace the successful graph no longer
+     ;; contains loses its committed rows; members keep theirs. The eviction
+     ;; runs through the existing cycle protocol and leaves no cycle open.
+     (rules/reset-custom-elements!)
+     (rules/register-custom-element! :keep-el {:properties #{:k}} 'app.keep)
+     (rules/register-custom-element! :gone-el {:properties #{:g}} 'app.gone)
+     (rules/shadow-build-notify (build-complete-msg [{:ns 'app.keep}]))
+     (is (= #{} (rules/custom-element-properties :gone-el))
+         "the namespace that left :build-sources is evicted from the aggregate")
+     (is (= #{:k} (rules/custom-element-properties :keep-el))
+         "a member namespace keeps its classification")
+     (is (= #{[(rules/current-build-id) 'app.keep]} (rules/ledger-sources))
+         "the ledger membership mirrors the broadcast graph")
+     (is (= #{} (rules/in-flight-cycles))
+         "the removal cycle committed and closed — nothing is left open")))
+
+#?(:cljs
+   (deftest build-notify-honours-provides-membership
+     ;; extract-build-info reports `:provides` (a set) alongside `:ns`; a
+     ;; namespace present only via :provides is a member, never a removal.
+     (rules/reset-custom-elements!)
+     (rules/register-custom-element! :p-el {:properties #{:p}} 'app.provided)
+     (rules/shadow-build-notify
+      (build-complete-msg [{:provides #{'app.provided 'app.alias}}]))
+     (is (= #{:p} (rules/custom-element-properties :p-el))
+         "a :provides-only member is not treated as removed")))
+
+#?(:cljs
+   (deftest build-notify-with-unchanged-membership-is-inert
+     ;; The common case — every ledger source still in the graph — must move
+     ;; NOTHING: no cycle churn, no republish (the aggregate watch stays
+     ;; silent), no ledger transition.
+     (rules/reset-custom-elements!)
+     (rules/register-custom-element! :s-el {:properties #{:s}} 'app.stable)
+     (let [publishes (atom 0)]
+       (add-watch rules/custom-elements ::notify-inert (fn [_ _ _ _] (swap! publishes inc)))
+       (try
+         (rules/shadow-build-notify (build-complete-msg [{:ns 'app.stable}]))
+         (is (zero? @publishes)
+             "an unchanged membership publishes nothing — no removal cycle runs")
+         (finally (remove-watch rules/custom-elements ::notify-inert)))
+       (is (= #{:s} (rules/custom-element-properties :s-el)))
+       (is (= #{} (rules/in-flight-cycles))))))
+
+#?(:cljs
+   (deftest build-notify-ignores-every-non-complete-broadcast
+     ;; Only :build-complete carries an accepted graph. A failed build (and the
+     ;; start/init chatter) must leave the last-known-good ledger untouched —
+     ;; that IS the failed-compile/LKG contract at this seam; the successful
+     ;; retry's :build-complete converges it.
+     (rules/reset-custom-elements!)
+     (rules/register-custom-element! :lkg-el {:properties #{:l}} 'app.lkg)
+     (doseq [type [:build-failure :build-start :build-init]]
+       (rules/shadow-build-notify {:type type :info {:sources []}})
+       (is (= #{:l} (rules/custom-element-properties :lkg-el))
+           (str "a " type " broadcast never evicts — last-known-good survives")))
+     ;; the retry's accepted graph then converges the ledger
+     (rules/shadow-build-notify (build-complete-msg []))
+     (is (= #{} (rules/custom-element-properties :lkg-el))
+         "the successful retry's membership is authoritative")))
+
+#?(:cljs
+   (deftest build-notify-reconciles-only-the-addressed-build
+     ;; Rows keyed under ANOTHER build id (a test-state partition token here —
+     ;; see §THE ISOLATION UNIT) are never this projection's to evict: the
+     ;; broadcast is diffed against the ambient build's rows only.
+     (rules/reset-custom-elements!)
+     (rules/register-custom-element! :f-el {:properties #{:f}} 'app.shared :foreign-build)
+     (rules/shadow-build-notify (build-complete-msg []))
+     (is (= #{:f} (rules/custom-element-properties :f-el))
+         "another build's row survives the ambient build's membership diff")
+     (is (= #{[:foreign-build 'app.shared]} (rules/ledger-sources)))))
+
+#?(:cljs
+   (deftest build-notify-supersedes-a-stranded-cycle-and-still-evicts
+     ;; A load task that threw leaves its cycle open forever (shadow skips
+     ;; ^:dev/after-load on a failed chain). The projection's removal cycle
+     ;; performs exactly the supersession the next before-load would — loud,
+     ;; per rf2-84173 — and the removal still commits.
+     (rules/reset-custom-elements!)
+     (rules/register-custom-element! :z-el {:properties #{:z}} 'app.zombie)
+     (rules/notify-reload!)                    ; the stranded cycle opens…
+     (rules/note-reloaded-sources! ['app.other]) ; …and carries evidence
+     (let [warnings (capturing-console-warn
+                     (fn []
+                       (rules/shadow-build-notify (build-complete-msg []))))]
+       (is (= 1 (count warnings))
+           "the supersession is DIAGNOSED, exactly as a before-load's would be"))
+     (is (= #{} (rules/custom-element-properties :z-el))
+         "the removal is projected despite the stranded predecessor cycle")
+     (is (= #{} (rules/in-flight-cycles))
+         "no cycle survives — the zombie was superseded and the removal committed")))


### PR DESCRIPTION
## What

Closes the final rf2-4vm19 arm (the AUDIT CORRECTION after #6552): a saved source DELETE or RENAME-AWAY left stale custom-element rows in the runtime ledger until a full page load, because a removed source never re-runs and shadow's SHADOW_NS_RESET can therefore never report it. The only authority for that delta is the compile side's `:build-sources` membership — and shadow itself already broadcasts exactly that to every connected runtime on each successful watch build (`:build-complete` `:info :sources`, built by `shadow.build/extract-build-info` over `:build-sources`).

**One authoritative path, reusing the existing ledger and cycle protocol:**

- `rules.cljc` — `shadow-build-notify`, the shadow `:build-notify` receiver (dev-only, folds away with the ledger under `:advanced`): diffs THIS build's committed ledger rows against the broadcast membership and reconciles the REMOVED namespaces through the existing seam — `notify-reload!` -> `note-reloaded-sources!` -> `commit-reload!`, one bounded removal cycle. No second ledger, no parallel protocol, no public API. `:build-failure` is ignored, so last-known-good survives a failed compile/eval and the successful retry's broadcast converges it. Host ordering is immaterial (browser runs the receiver before the chain, node after it — both see no open cycle); a cycle stranded by an aborted load is superseded with the existing loud report.
- `build_hook.clj` — `wire-removed-source-notify` at `:compile-prepare`: points the devtools client's ONE `custom-notify-fn` closure-define at the receiver, only for a WATCHED dev build (`:worker-info`) whose graph contains `re-frame.ui.rules`, and NEVER over a consumer's own `:devtools {:build-notify …}` (theirs wins; delegation documented). Dev defines ride the flushed `CLOSURE_DEFINES` bootstrap, so there is zero cache interaction. The hook stays the one re-frame.ui build setting.

**End-to-end proof — the existing real-Shadow warm-watch runner, extended (`npm run test:ui-warm-watch`, already CI-wired):**

- Fixture converted to `:target :node-script`; the runner loads ONE emitted runtime (no DOM, no browser) as a live child wired to the watch's devtools server, hot-reloading for real across every pass. A tiny runtime observer (`observe.cljs`) appends boot/publish/mid-chain JSONL records; assertions are EXACT aggregate + ledger images, never presence probes.
- Proven live, per pass: boot identity (`current-build-id` = `:ui-warm-watch` at the runtime seam, never `::default`); mid-chain OPEN-cycle witness on the control edit (lifecycle-annotation discovery/order); declaration-shrink staged-replace commit; same-namespace file move preserves ownership; RENAME-AWAY evicts the old namespace's runtime row via the projected delta while the aggregate stays stable; saved DELETE evicts `:probe-leaf` from the live aggregate with NO page reload (the headline); failed compile keeps runtime ledger/aggregate last-known-good (no broadcast, no record); successful retry converges exactly; S6 warm-restart disk-cache reuse unchanged and the runtime survives the daemon restart.
- Fixture sets `:compiler-options {:infer-externs false}` (same as the top-level node-test builds): shadow's client SKIPS hot-reload autoload while a build carries warnings, and that autoload path is exactly what this gate proves — externs inference is `:advanced` release machinery a dev node fixture does not need.
- Runner uses `createHarnessCleanup` (signal/exit sweep of watch daemons + the runtime child, plus fixture restore).

**Unit tests:**

- CLJS (`rules_cljs_test.cljc`): the projection algebra — removed-membership eviction, `:provides` membership, inert unchanged membership (no cycle churn, no republish), non-`:build-complete` broadcasts ignored (LKG), addressed-build scoping (foreign rows untouched), stranded-cycle supersession (loud, then commits).
- JVM (`compiler_build_hook_jvm_test.clj`): define injection wired for watched dev builds; idempotent across warm passes; consumer's own receiver always wins; never wired for release / non-watched / rules-less graphs.

## Teeth (each exercised red-before-green in this worktree)

- Drop `^:dev/before-load` on `notify-reload!` -> RED: `zero-declaration: mid-chain witness saw cycles-open []`.
- Drop `^:dev/after-load` on `commit-reload!` -> RED: `the committed zero-declaration republish never appeared` (cycle opened, never committed).
- Sever `wire-removed-source-notify` (the projection producer) -> RED: `the rename republish … never appeared` — the old namespace's ledger row is never evicted (delete pass would equally red).
- The pre-existing compile-side teeth (stage annotation, harvest producer, coarse invalidation, membership eviction) are unchanged and documented in the runner header.

## Quality gates

- `implementation/ui`: `clojure -M:test` — 942 tests / 18920 assertions, 0 failures, 0 errors
- `implementation`: `npm run test:cljs` — 10382 tests / 51321 assertions, 0 failures, 0 errors
- `implementation`: `npm run test:ui-warm-watch` — full battery PASS (all eight passes + runtime arms + warm-restart reuse), on the exact committed tree

## Notes

- No `.github/workflows/*`, no top-level `implementation/shadow-cljs.edn`, no spec/docs edits; surface is `implementation/ui` src/test + `implementation/scripts/check-ui-warm-watch.cjs` + the fixture-local shadow-cljs.edn.
- Scope note: shadow's pinned node client passes `output-name` (a string) to `env/before-load-src`, so SHADOW_NS_RESET never fires under a node runtime (upstream shadow-cljs quirk; the browser client is unaffected). The fixture's runtime arms are therefore built on the paths that ARE host-uniform (lifecycle hooks, staged re-registration, the new broadcast projection), and the projection itself is what closes the removed-source gap on every host.