### PR TITLE
docs(meta): W12 repo meta-docs finish — README map, CLAUDE.md, release-process (rf2-hoo2t)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Per `docs/the-mayor-method/`, the `ai/` directory at repo root holds all AI work
 
 - **Always dispatch beads to a background agent when sensible.** Don't ask permission for clear-cut implementation work, mechanical fixes, or follow-on tasks where the direction is set. Keep the work flowing. Only pause for genuine decisions Mike hasn't made.
 - **Worker worktree guard is mandatory before edits.** Background workers must run the guard from their intended checkout before editing, and report the printed `WORKTREE_ROOT`. Use `sh scripts/assert-worker-worktree.sh` (POSIX primary) or `powershell -ExecutionPolicy Bypass -File scripts/assert-worker-worktree.ps1` (Windows). The guard derives the mayor checkout as the repository's primary worktree (`git worktree list`) and the worktree parent as its `re-frame2-worktrees` sibling — no hardcoded paths; both overridable via `RF2_MAYOR_ROOT` / `RF2_WORKTREE_PARENT`. It refuses the mayor checkout and any root outside the worktree parent. This mitigates observed harness path-resolution leaks; it is not a root-cause fix for the external edit/write bug.
-- **Minimise merge conflicts when dispatching.** Hot-zone files (`spec/Conventions.md`, `migration/from-re-frame-v1/README.md`, `spec/API.md`, `spec/Tool-Pair.md`, `spec/Spec-Schemas.md`, `spec/009-Instrumentation.md`, `spec/006-ReactiveSubstrate.md`, `spec/005-StateMachines.md`, `spec/002-Frames.md`, top-level `implementation/deps.edn`, `implementation/shadow-cljs.edn`, `.github/workflows/*`) are sequential, never parallel — two beads touching the same hot file = sequence them, second waits for the first's PR to merge. Isolated surfaces (single-artefact `implementation/<feature>/src/`, new-file additions, test-only dirs `implementation/<feature>/test/`, `examples/<substrate>/<example>/`) are safe to parallel.
+- **Minimise merge conflicts when dispatching.** Hot-zone files (`spec/Conventions.md`, `migration/from-re-frame-v1/README.md`, `spec/API.md`, `spec/Tool-Pair.md`, `spec/Spec-Schemas.md`, `spec/009-Instrumentation.md`, `spec/006-ReactiveSubstrate.md`, `spec/005-StateMachines.md`, `spec/004-Views.md`, `spec/002-Frames.md`, top-level `implementation/deps.edn`, `implementation/shadow-cljs.edn`, `.github/workflows/*`) are sequential, never parallel — two beads touching the same hot file = sequence them, second waits for the first's PR to merge. Isolated surfaces (single-artefact `implementation/<feature>/src/`, new-file additions, test-only dirs `implementation/<feature>/test/`, `examples/<substrate>/<example>/`) are safe to parallel.
 - **Do not maintain `ai/dashboard.md`.** The dashboard is retired (Mike, 2026-06-20), as is the `ai/decisions.md` index (Mike, 2026-07-17): don't create or refresh either. Decision gates surface in chat and on the beads; everything else operator-facing goes in chat.
 - **Pull `main` from `origin` immediately after every PR merge.** Run `git pull --ff-only` as the very next step after `gh pr merge ... --rebase --admin --delete-branch`. No exceptions, no batching multiple merges before pulling. Mike glances at his local working tree to track progress; staleness leaves him with a wrong picture and breaks subsequent dispatches that worktree off `origin/main`. Same rule applies whether merge happened seconds ago or while another agent was running.
 - **Stash before pull when needed.** `.beads/issues.jsonl` may carry uncommitted local edits; stash before pulling and pop after if necessary. (The `ai/` tree is local-only and won't show up in `git status`.)
@@ -86,18 +86,22 @@ scripts/test-rigorous-local.sh         # expensive local/release-sized sweep
 # From implementation/:
 npm install                          # one-time, installs shadow-cljs + react
 npm run test:cljs                    # node-runtime CLJS tests (fast, default gate)
+npm run test:ui                      # re-frame.ui substrate suite (adapter-isolation check + node tests)
+npm run test:ui-warm-watch           # re-frame.ui warm-watch recompile probe
 npm run test:browser                 # browser tests via Playwright
 npm run test:elision                 # production elision probe
 npm run test:perf-bundle             # perf-budget bundle check
 npm run test:bundle-isolation        # tools must not leak into production bundles
 npm run test:reagent-slim:bundle-isolation # slim must not pull stock Reagent/react-dom/server
-npm run test:adapter-smokes          # adapter-smoke runner (Reagent/UIx/Helix mount+dispatch+assert)
+npm run test:adapter-smokes          # adapter-smoke runner (one mount+dispatch+assert smoke per adapter)
+npm run test:xray-feature-gate       # Xray feature-matrix browser gate
+npm run test:mcp-conformance         # cross-server MCP wire-vocabulary conformance
 npm run story:build                  # build the story artefact
 ```
 
 Per-artefact tests run from each artefact directory via `clojure -M:test` (see e.g. `tools/story/deps.edn` `:test` alias). The canonical matrix and PR/nightly/release split lives in `TESTING.md`; workflow gates live in `.github/workflows/`.
 
-**Examples are test-free (locked 2026-05-19, rf2-8cevm).** No `*.spec.cjs` may live under `examples/`. Browser smoke coverage is exactly 3 adapter-level smokes (Reagent / UIx / Helix) at `implementation/adapters/<name>/testbed/spec.cjs` — mount + dispatch + assert. Real-regression coverage lives in substrate contract tests (`npm run test:cljs`), the Xray feature-matrix gate (`npm run test:xray-feature-gate`), bundle-isolation, the perf-bundle gate, and mcp-conformance. Framework testbeds (`tools/xray/testbeds/`, top-level `testbeds/`) carry their own non-adapter spec.cjs for cross-cutting surfaces (parallel-frames isolation, perf-API live counterpart, SSR, etc.).
+**Examples are test-free (locked 2026-05-19, rf2-8cevm).** No `*.spec.cjs` may live under `examples/`. Browser smoke coverage is one adapter-level smoke per shipped adapter at `implementation/adapters/<name>/testbed/spec.cjs` — mount + dispatch + assert. Real-regression coverage lives in substrate contract tests (`npm run test:cljs`), the Xray feature-matrix gate (`npm run test:xray-feature-gate`), bundle-isolation, the perf-bundle gate, and mcp-conformance. Framework testbeds (`tools/xray/testbeds/`, top-level `testbeds/`) carry their own non-adapter spec.cjs for cross-cutting surfaces (parallel-frames isolation, perf-API live counterpart, SSR, etc.).
 
 Docs build from repo root with `mkdocs build --strict` (config in `mkdocs.yml`).
 
@@ -108,7 +112,7 @@ Docs build from repo root with `mkdocs build --strict` (config in `mkdocs.yml`).
 Top-level layout:
 
 - `spec/` — the specification (primary artefact; AI-targeted)
-- `implementation/` — CLJS reference: `core/` + per-substrate `adapters/` (Reagent, UIx, Helix) + per-feature artefacts (machines, schemas, …). The top-level `implementation/shadow-cljs.edn` + `implementation/deps.edn` coordinate the cross-artefact classpath.
+- `implementation/` — CLJS reference: `core/` + `ui/` (re-frame.ui, the EXPERIMENTAL compiled-view substrate, offered alongside the adapters) + per-substrate `adapters/` (Reagent, reagent-slim, UIx — first-class, actively supported; Helix removal is in flight, S7/W13) + per-feature artefacts (machines, schemas, resources, …). The top-level `implementation/shadow-cljs.edn` + `implementation/deps.edn` coordinate the cross-artefact classpath.
 - `tools/` — dev/inspection tools that consume the Spec 009 instrumentation API and Tool-Pair contract (`template/`, `story/`, `story-mcp/`, `re-frame2-pair-mcp/`, `xray/`, `machines-viz/`, `testbed-support/`, `mcp-base/`, `mcp-conformance/`). Bundle-isolated from production builds; nothing in `implementation/` may `:require` from `tools/`.
 - `examples/` — worked examples per substrate.
 - `docs/` — human-facing guide (`docs/core/`) and operational docs.

--- a/README.md
+++ b/README.md
@@ -156,9 +156,11 @@ docs/
   core/                        Core track
   release-process.md           Operational doc — multi-artefact release pipeline
   quiet-tests.md               Recipe for silent-on-success cljs.test / clojure.test reporters
-examples/                      Worked examples grouped per substrate (reagent canonical full
-                               set — counter, todomvc, realworld, 7GUIs; uix + helix curated
-                               subsets; reagent-slim slim-bundle demo). Test-free.
+examples/                      Worked examples organised by concept — core/ fundamentals,
+                               capabilities/ (one framework subsystem per folder), patterns/
+                               composition recipes, real-apps/ (RealWorld et al.), substrates/
+                               (the same apps on other substrates — UIx, Helix, reagent-slim),
+                               ui/ (re-frame.ui variants). Test-free.
 testbeds/                      Shared framework-behavior testbed surfaces (consumed by Xray + Story
                                + MCP servers). Bundle-isolated from production builds.
   deliberate_throw/            4 :rf.error/* trigger sites (handler / fx / flow / machine)
@@ -178,18 +180,23 @@ implementation/                CLJS reference implementation — per-artefact su
                                jar with its own deps.edn, on the top-level shadow-cljs classpath.
   core/                        day8/re-frame2 — registry, drain, fx, dispatch, subscribe,
                                frame-provider, trace, source-coords, substrate, elision
+  ui/                          day8/re-frame2-ui — re-frame.ui, the compiled-view substrate
+                               (EXPERIMENTAL; offered alongside the adapters, not a replacement)
   adapters/
     reagent/                   day8/re-frame2-reagent — the Reagent adapter (browser default)
     reagent-slim/              day8/reagent-slim — slim Reagent fork (reagent2.core); same view
                                semantics, smaller footprint, capped Form-3 surface
     uix/                       day8/re-frame2-uix — the UIx adapter
-    helix/                     day8/re-frame2-helix — the Helix adapter
+    helix/                     day8/re-frame2-helix — the Helix adapter (removal in flight —
+                               S7/W13, behind the soak gates)
     test-react/                local-test-only (no Maven coord) — pure-CLJC React-lifecycle
                                simulator; catches lifecycle bugs at unit-test speed (no React/DOM/jsdom)
   schemas/                     day8/re-frame2-schemas — Malli boundary-validation artefact
   machines/                    day8/re-frame2-machines — state-machine artefact (xstate-flavoured)
   flows/                       day8/re-frame2-flows — registered computed-state declarations
   http/                        day8/re-frame2-http — managed :rf.http/* effect
+  resources/                   day8/re-frame2-resources — declarative server-state resources
+                               (reg-resource, work ledger, managed-HTTP lowering, SSR preload)
   routing/                     day8/re-frame2-routing — URL ↔ frame routing
   ssr/                         day8/re-frame2-ssr — server-side rendering + hydration
   ssr-ring/                    day8/re-frame2-ssr-ring — Ring adapter for SSR pipeline
@@ -197,6 +204,12 @@ implementation/                CLJS reference implementation — per-artefact su
   test-quiet/                  Quiet-on-success reporter shared across 17 test runners
   security/                    Cross-cutting security regression tests (MCP egress, schema
                                redaction, SSR escaping) — test-only, no shipped namespace
+  derivation-conformance/      test-only, not published — cross-family derivation/process
+                               conformance (subscriptions + flows + resources + machines composed)
+  event-conformance/           test-only, not published — cross-artefact public event-model
+                               conformance (registration, coeffects, replies, error channels)
+  reply-conformance/           test-only, not published — managed-async reply-envelope
+                               conformance across HTTP, resources, machines, routing
   scripts/                     Build / release scripts
   shadow-cljs.edn              Top-level build coordinator: pulls all artefacts onto one classpath
   deps.edn                     Top-level build coordinator (clojure-tools): :local/root deps for all

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -102,6 +102,8 @@ verify-version-lockstep ──► test ──► deploy-core
 
 **Why fan-out (not strict serial).** A strict topological linearization would suffice; the deps-graph data is wider — every leaf has core as its only re-frame2 dependency (the one exception is `ssr-ring`, which also depends on `ssr`; the release workflow rewrites both `:local/root` coordinates and resolves `ssr` from Clojars, so the leaves still fan out with no inter-leaf CI edge). The CI graph realises a valid topological sort that exploits the parallelism: leaves run concurrently after core, cutting wall-clock at the cost of a marginally wider failure surface (see Recovery below). The leaves group into per-feature artefacts (schemas, machines, routing, flows, http, ssr, ssr-ring, resources, epoch) and the view layer — the compiled-view substrate `ui` plus the adapter set (reagent default, reagent-slim, uix, helix). The authoritative roster is always the `deploy-leaf` matrix in [`release.yml`](../.github/workflows/release.yml).
 
+**The view layer, as consumers meet it.** The app template (`tools/template/`, `day8/re-frame2-template`) scaffolds against this released view layer through its substrate menu: `:reagent` (the default), `:uix`, `:helix`, and the experimental `:ui` (re-frame.ui, offered alongside the adapters). The `:helix` variant departs with the Helix adapter's in-flight removal (S7/W13, behind the soak gates); the template menu and the view-layer rows of the `deploy-leaf` matrix move together.
+
 ## Pre-flight checklist
 
 Before tagging:


### PR DESCRIPTION
Executes rf2-hoo2t (S7/W12, docs-only) per rf2-vxgfnd.99 WORKSTREAMS.

## What changed

**README.md — project map truthed to the shipping state**
- `implementation/ui/` added: re-frame.ui, the compiled-view substrate (EXPERIMENTAL; offered alongside the adapters, not a replacement).
- `implementation/resources/` (day8/re-frame2-resources) and the three test-only conformance tiers (`derivation-conformance/`, `event-conformance/`, `reply-conformance/`) added to the map.
- Helix adapter line notes its removal is in flight (S7/W13, behind the soak gates) — the current truth; the sibling W13 bead lands the removal itself.
- `examples/` line updated from the retired per-substrate framing to the by-concept layout (core / capabilities / patterns / real-apps / substrates / ui).

**CLAUDE.md — surgical truthing only, no restructure**
- Build-command list verified against `implementation/package.json`: every previously listed script exists (none dropped); adds `test:ui`, `test:ui-warm-watch`, `test:xray-feature-gate`, `test:mcp-conformance`; the adapter-smokes comment no longer hardcodes the adapter roster.
- Hot-zone list gains `spec/004-Views.md` (the compiled-view program made it a standing hot file).
- Architecture overview: `ui/` among the substrates; adapters restated as Reagent / reagent-slim / UIx first-class with Helix removal in flight.
- Smoke-coverage sentence restated as one smoke per shipped adapter (the rf2-8cevm lock's substance), so it stays true through the in-flight roster changes.

**docs/release-process.md**
- Verified the day8/re-frame2-ui coordinate rows landed by #6654 are coherent: the policy roster, the mermaid DAG, and the ASCII DAG all carry the same 14 leaves as the `release.yml` `deploy-leaf` matrix, including `ui` and the REQUIRED_PUBLISHABLE lockstep gate.
- Added the template substrate-menu state next to the view-layer roster: `:reagent` default / `:uix` / `:helix` / `:ui` experimental, with `:helix` departing at the in-flight Helix removal.

Wording was checked against `scripts/check_adapter_disposition.py`'s SUPERSEDED_PATTERNS before writing; none of the three files is in ACTIVE_AUTHORITIES, but the prose avoids every superseded shape anyway.

## Quality gates

- `python -m mkdocs build --strict` — PASS (built in 21.9s, INFO-level notes only, all pre-existing)
- `python scripts/check_adapter_disposition.py --verbose` — PASS (disposition intact across 6 authorities)
- `python scripts/check_doc_slugs.py` — PASS

Docs-only; no code, no hot-zone files, no overlap with rf2-nojiwy (testbed/workflows/TESTING.md untouched) or rf2-b16va (tools/template untouched).