### PR TITLE
test(template): G1-G4 external-alpha train validation fixes (rf2-b16va)

### DIFF
--- a/tools/template/README.md
+++ b/tools/template/README.md
@@ -189,9 +189,13 @@ Then:
 ```bash
 cd my-app
 npm install
-clojure -M:shadow watch app   # or: npx shadow-cljs watch app
+npx shadow-cljs watch app
 # open http://localhost:8280
 ```
+
+(The emitted `:shadow` alias is deps-only — the npx wrapper supplies
+`-m shadow.cljs.devtools.cli` itself, so the pure-JVM form is
+`clojure -M:shadow -m shadow.cljs.devtools.cli watch app`.)
 
 You should see the counter — the same shape walked through in
 [Guide — app-db](../../docs/core/app-db.md).

--- a/tools/template/resources/day8/re_frame2_template/_css_tailwind/index.html
+++ b/tools/template/resources/day8/re_frame2_template/_css_tailwind/index.html
@@ -34,15 +34,22 @@
            anti-clickjacking contract lives in the README's response-header
            snippets ("Production hardening").
 
+         `script-src` also carries `'unsafe-eval'`: shadow-cljs DEV
+         builds (`watch` / `compile`, `:optimizations :none`) load every
+         compiled namespace through `goog.globalEval` — without it the
+         dev page is blank (every module load dies with a CSP
+         EvalError). Release builds don't eval.
+
          For production, serve a Content-Security-Policy RESPONSE HEADER
-         (see README "Production hardening"): drop `'unsafe-inline'` and
+         (see README "Production hardening"): drop `'unsafe-eval'` (the
+         release bundle doesn't eval), drop `'unsafe-inline'` and
          the jsdelivr origin once you've compiled Tailwind with
          `@tailwindcss/cli` and externalised styles, drop `ws: wss:` (no
          dev hot-reload), tighten `connect-src` to your real API
          origin(s), and add `frame-ancestors 'none'` THERE (where it
          works). -->
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'none'">
+          content="default-src 'self'; script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'none'">
     <title>{{name}} — re-frame2</title>
     <!-- Tailwind v4, dev-only Play CDN compiler (@tailwindcss/browser@4).
          It compiles the CSS-first source in the

--- a/tools/template/resources/day8/re_frame2_template/_helix/deps.edn
+++ b/tools/template/resources/day8/re_frame2_template/_helix/deps.edn
@@ -37,11 +37,18 @@
   ;; shadow's classpath under this alias — shadow-cljs reads
   ;; :paths/:extra-paths out of deps.edn (the :source-paths key in
   ;; shadow-cljs.edn is ignored when :deps is active).
+  ;;
+  ;; Deps only, deliberately NO :main-opts: `npx shadow-cljs` already
+  ;; appends `-m shadow.cljs.devtools.cli` when it shells out to clojure,
+  ;; and clojure prepends an alias's :main-opts to the command line — so
+  ;; an :main-opts here becomes a second `-m` and every npx / npm-script
+  ;; command dies on shadow's arg parser with `Unknown option: "-m"`.
+  ;; Pure-JVM route (no node wrapper):
+  ;;   clojure -M:shadow -m shadow.cljs.devtools.cli watch app
   :shadow
   {:extra-paths ["test" "dev"]
    :extra-deps  {thheller/shadow-cljs        {:mvn/version "{{shadow-version}}"}
-                 org.clojure/tools.namespace {:mvn/version "1.5.0"}}
-   :main-opts   ["-m" "shadow.cljs.devtools.cli"]}
+                 org.clojure/tools.namespace {:mvn/version "1.5.0"}}}
 
   ;; cljfmt — `clojure -M:cljfmt check` / `fix`. Config in
   ;; .cljfmt.edn.

--- a/tools/template/resources/day8/re_frame2_template/_reagent/deps.edn
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/deps.edn
@@ -34,14 +34,21 @@
          reagent/reagent           {:mvn/version "2.0.1"}}
 
  :aliases
- {;; `clojure -M:shadow` runs shadow-cljs in JVM mode via the alias.
-  ;; You can also use `npx shadow-cljs ...` (shadow's own node-side CLI).
-  ;; Both work; the npm-side route is the canonical workflow.
+ {;; shadow-cljs's JVM side. shadow-cljs.edn's `{:deps {:aliases [:shadow]}}`
+  ;; points here, so `npx shadow-cljs watch app` (and every package.json
+  ;; script) builds its classpath from this deps.edn plus this alias.
+  ;;
+  ;; Deps only, deliberately NO :main-opts: `npx shadow-cljs` already
+  ;; appends `-m shadow.cljs.devtools.cli` when it shells out to clojure,
+  ;; and clojure prepends an alias's :main-opts to the command line — so
+  ;; an :main-opts here becomes a second `-m` and every npx / npm-script
+  ;; command dies on shadow's arg parser with `Unknown option: "-m"`.
+  ;; Pure-JVM route (no node wrapper):
+  ;;   clojure -M:shadow -m shadow.cljs.devtools.cli watch app
   :shadow
   {:extra-paths ["test" "dev"]
    :extra-deps  {thheller/shadow-cljs        {:mvn/version "{{shadow-version}}"}
-                 org.clojure/tools.namespace {:mvn/version "1.5.0"}}
-   :main-opts   ["-m" "shadow.cljs.devtools.cli"]}
+                 org.clojure/tools.namespace {:mvn/version "1.5.0"}}}
 
   ;; cljfmt — `clojure -M:cljfmt check` / `fix`. Config in
   ;; .cljfmt.edn. Pinned to the current cljfmt CLI line.

--- a/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_ssr.edn
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_ssr.edn
@@ -81,14 +81,21 @@
                  {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
    :main-opts   ["-m" "cognitect.test-runner"]}
 
-  ;; `clojure -M:shadow` runs shadow-cljs in JVM mode via the alias.
-  ;; You can also use `npx shadow-cljs ...` (shadow's own node-side CLI).
-  ;; Both work; the npm-side route is the canonical workflow.
+  ;; shadow-cljs's JVM side. shadow-cljs.edn's `{:deps {:aliases [:shadow]}}`
+  ;; points here, so `npx shadow-cljs watch app` (and every package.json
+  ;; script) builds its classpath from this deps.edn plus this alias.
+  ;;
+  ;; Deps only, deliberately NO :main-opts: `npx shadow-cljs` already
+  ;; appends `-m shadow.cljs.devtools.cli` when it shells out to clojure,
+  ;; and clojure prepends an alias's :main-opts to the command line — so
+  ;; an :main-opts here becomes a second `-m` and every npx / npm-script
+  ;; command dies on shadow's arg parser with `Unknown option: "-m"`.
+  ;; Pure-JVM route (no node wrapper):
+  ;;   clojure -M:shadow -m shadow.cljs.devtools.cli watch app
   :shadow
   {:extra-paths ["test" "dev"]
    :extra-deps  {thheller/shadow-cljs        {:mvn/version "{{shadow-version}}"}
-                 org.clojure/tools.namespace {:mvn/version "1.5.0"}}
-   :main-opts   ["-m" "shadow.cljs.devtools.cli"]}
+                 org.clojure/tools.namespace {:mvn/version "1.5.0"}}}
 
   ;; cljfmt — `clojure -M:cljfmt check` / `fix`. Config in
   ;; .cljfmt.edn. Pinned to the current cljfmt CLI line.

--- a/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_story.edn
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_story.edn
@@ -41,14 +41,21 @@
          reagent/reagent           {:mvn/version "2.0.1"}}
 
  :aliases
- {;; `clojure -M:shadow` runs shadow-cljs in JVM mode via the alias.
-  ;; You can also use `npx shadow-cljs ...` (shadow's own node-side CLI).
-  ;; Both work; the npm-side route is the canonical workflow.
+ {;; shadow-cljs's JVM side. shadow-cljs.edn's `{:deps {:aliases [:shadow]}}`
+  ;; points here, so `npx shadow-cljs watch app` (and every package.json
+  ;; script) builds its classpath from this deps.edn plus this alias.
+  ;;
+  ;; Deps only, deliberately NO :main-opts: `npx shadow-cljs` already
+  ;; appends `-m shadow.cljs.devtools.cli` when it shells out to clojure,
+  ;; and clojure prepends an alias's :main-opts to the command line — so
+  ;; an :main-opts here becomes a second `-m` and every npx / npm-script
+  ;; command dies on shadow's arg parser with `Unknown option: "-m"`.
+  ;; Pure-JVM route (no node wrapper):
+  ;;   clojure -M:shadow -m shadow.cljs.devtools.cli watch app
   :shadow
   {:extra-paths ["test" "dev"]
    :extra-deps  {thheller/shadow-cljs        {:mvn/version "{{shadow-version}}"}
-                 org.clojure/tools.namespace {:mvn/version "1.5.0"}}
-   :main-opts   ["-m" "shadow.cljs.devtools.cli"]}
+                 org.clojure/tools.namespace {:mvn/version "1.5.0"}}}
 
   ;; cljfmt — `clojure -M:cljfmt check` / `fix`. Config in
   ;; .cljfmt.edn. Pinned to the current cljfmt CLI line.

--- a/tools/template/resources/day8/re_frame2_template/_shared/package.json
+++ b/tools/template/resources/day8/re_frame2_template/_shared/package.json
@@ -9,7 +9,7 @@
     "test":    "{{test-script}}"
   },
   "devDependencies": {
-    "shadow-cljs": "{{shadow-version}}"
+    "shadow-cljs": "{{shadow-version}}"{{xray-npm-deps}}
   },
   "dependencies": {
     "react":     "{{react-version}}",

--- a/tools/template/resources/day8/re_frame2_template/_ui/deps.edn
+++ b/tools/template/resources/day8/re_frame2_template/_ui/deps.edn
@@ -44,11 +44,18 @@
   ;; that range — docs/core/how-to/install-re-frame-ui.md §Supported
   ;; Shadow versions). Keep it matching package.json — the two halves
   ;; of shadow-cljs must ride the same version.
+  ;;
+  ;; Deps only, deliberately NO :main-opts: `npx shadow-cljs` already
+  ;; appends `-m shadow.cljs.devtools.cli` when it shells out to clojure,
+  ;; and clojure prepends an alias's :main-opts to the command line — so
+  ;; an :main-opts here becomes a second `-m` and every npx / npm-script
+  ;; command dies on shadow's arg parser with `Unknown option: "-m"`.
+  ;; Pure-JVM route (no node wrapper):
+  ;;   clojure -M:shadow -m shadow.cljs.devtools.cli watch app
   :shadow
   {:extra-paths ["test" "dev"]
    :extra-deps  {thheller/shadow-cljs        {:mvn/version "{{shadow-version}}"}
-                 org.clojure/tools.namespace {:mvn/version "1.5.0"}}
-   :main-opts   ["-m" "shadow.cljs.devtools.cli"]}
+                 org.clojure/tools.namespace {:mvn/version "1.5.0"}}}
 
   ;; cljfmt — `clojure -M:cljfmt check` / `fix`. Config in
   ;; .cljfmt.edn.

--- a/tools/template/resources/day8/re_frame2_template/_uix/deps.edn
+++ b/tools/template/resources/day8/re_frame2_template/_uix/deps.edn
@@ -39,11 +39,18 @@
   ;; shadow's classpath under this alias — shadow-cljs reads
   ;; :paths/:extra-paths out of deps.edn (the :source-paths key in
   ;; shadow-cljs.edn is ignored when :deps is active).
+  ;;
+  ;; Deps only, deliberately NO :main-opts: `npx shadow-cljs` already
+  ;; appends `-m shadow.cljs.devtools.cli` when it shells out to clojure,
+  ;; and clojure prepends an alias's :main-opts to the command line — so
+  ;; an :main-opts here becomes a second `-m` and every npx / npm-script
+  ;; command dies on shadow's arg parser with `Unknown option: "-m"`.
+  ;; Pure-JVM route (no node wrapper):
+  ;;   clojure -M:shadow -m shadow.cljs.devtools.cli watch app
   :shadow
   {:extra-paths ["test" "dev"]
    :extra-deps  {thheller/shadow-cljs        {:mvn/version "{{shadow-version}}"}
-                 org.clojure/tools.namespace {:mvn/version "1.5.0"}}
-   :main-opts   ["-m" "shadow.cljs.devtools.cli"]}
+                 org.clojure/tools.namespace {:mvn/version "1.5.0"}}}
 
   ;; cljfmt — `clojure -M:cljfmt check` / `fix`. Config in
   ;; .cljfmt.edn.

--- a/tools/template/resources/day8/re_frame2_template/root/README.md
+++ b/tools/template/resources/day8/re_frame2_template/root/README.md
@@ -169,8 +169,10 @@ emit CSP violations on the first page and block Xray styling. The meta
 tag also drops `frame-ancestors` (browsers ignore it from `<meta>`).
 
 For production, serve the **stricter** policy below as a response
-header. It tightens three things relative to the dev meta tag:
-**drops `'unsafe-inline'`** (do this only after you have externalised
+header. It tightens four things relative to the dev meta tag:
+**drops `'unsafe-eval'`** (shadow's dev watch bundle loads compiled
+namespaces via eval; the release bundle is one static file and never
+evals); **drops `'unsafe-inline'`** (do this only after you have externalised
 all inline styles — move the views' `:style` props to `css/app.css`
 classes, and either drop the dev-only Xray preload from your release
 build [it already is — see "In-app devtools" above] or serve Xray under
@@ -200,9 +202,12 @@ origin), `'self'` will block it — add that origin explicitly, e.g.
 silently forbids any cross-origin request you haven't whitelisted, so
 add API origins here as you wire them up.
 
-`script-src` stays strict (`'self'`, no `'unsafe-inline'`) in both the
-dev meta tag and the production header — the scaffold has no inline
-`<script>`. If you add a CDN, embed in an iframe, inline a `<script>`,
+`script-src` allows no inline `<script>` in either policy — the
+scaffold has none. The dev meta tag carries `'unsafe-eval'` because
+shadow-cljs dev builds load every compiled namespace through
+`goog.globalEval` (without it the watch page is blank); the release
+bundle never evals, so the production header drops it and `script-src`
+collapses to a strict `'self'`. If you add a CDN, embed in an iframe, inline a `<script>`,
 or load an analytics snippet, **explicitly widen the policy** for that
 origin / hash — don't drop it to `'unsafe-inline'` wholesale. (For
 inline *styles*, see the `style-src` note above: the dev meta tag

--- a/tools/template/resources/day8/re_frame2_template/root/resources/public/index.html
+++ b/tools/template/resources/day8/re_frame2_template/root/resources/public/index.html
@@ -8,6 +8,14 @@
          to the RUNTIME the scaffold actually produces, not an aspirational
          strict baseline.
 
+         - `script-src 'self' 'unsafe-eval'` — shadow-cljs DEV builds
+           (`watch` / `compile`, `:optimizations :none`) load every
+           compiled namespace through `goog.globalEval`, so without
+           `'unsafe-eval'` the dev page is blank: every module load dies
+           with a CSP EvalError. Release builds (`shadow-cljs release`)
+           ship one static bundle and do NOT eval — the production
+           response header drops `'unsafe-eval'` (README "Production
+           hardening").
          - `style-src 'self' 'unsafe-inline'` — the generated views use
            inline `:style` props, and the default-on Xray devtools surface
            injects `<style>` blocks and inline styles. Without
@@ -27,12 +35,13 @@
            snippets ("Production hardening").
 
          For production, serve a Content-Security-Policy RESPONSE HEADER
-         (see README "Production hardening"): drop `'unsafe-inline'` once
+         (see README "Production hardening"): drop `'unsafe-eval'` (the
+         release bundle doesn't eval), drop `'unsafe-inline'` once
          you've externalised styles, drop `ws: wss:` (no dev hot-reload),
          tighten `connect-src` to your real API origin(s), and add
          `frame-ancestors 'none'` THERE (where it works). -->
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'none'">
+          content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'none'">
     <title>{{name}} — re-frame2</title>
     <link rel="stylesheet" href="/css/app.css">
   </head>

--- a/tools/template/spec/002-Generated-Shape.md
+++ b/tools/template/spec/002-Generated-Shape.md
@@ -12,7 +12,7 @@ For substrate `:reagent` (the default):
 my-app/
 ├── deps.edn                  re-frame2 + Reagent adapter + schemas + Xray + shadow-cljs
 ├── shadow-cljs.edn           :app (watch/release) + :test builds; Xray preload on :app
-├── package.json              react + react-dom + shadow-cljs
+├── package.json              react + react-dom + shadow-cljs (+ @xyflow/react + elkjs for the Xray preload)
 ├── README.md                 "run shadow-cljs watch app; open localhost:8280"
 ├── .gitignore
 ├── .editorconfig             2-space, LF, trim trailing, final newline
@@ -259,6 +259,7 @@ the template's own additions.
 | `{{substrate}}` | The chosen substrate name, lower-case | `reagent`, `uix`, `helix`, `ui` |
 | `{{substrate-label}}` | The chosen substrate's display name (used in the `shadow-cljs.edn` comment + `package.json` description) | `Reagent`, `UIx`, `Helix`, `re-frame.ui` |
 | `{{story-tag}}` | `package.json` `description` suffix that varies by `:include-story?` — lets one shared `package.json` serve both paths | `""`, `", with Story playground"` |
+| `{{xray-npm-deps}}` | `package.json` `devDependencies` fragment carrying the npm packages the Xray preload compiles against (`@xyflow/react` + `elkjs`, required by the machine canvas via `day8/re-frame2-machines-viz`). Empty for the `:ui` variant, which ships no Xray coord. | `""`, `",\n    \"@xyflow/react\": \"12.4.2\",\n    \"elkjs\": \"^0.11.1\""` |
 | `{{substrate-badge-url}}` | shields.io badge URL by substrate | `https://img.shields.io/badge/substrate-Reagent-1abc9c.svg` |
 | `{{rf2-version}}` | re-frame2 coord version | `0.0.1.alpha` |
 | `{{shadow-version}}` | shadow-cljs pin | `3.4.10` |
@@ -297,6 +298,9 @@ They are bumped in lockstep with the repo-root `VERSION` and
 - `:react-version` matches `implementation/package.json`
   :devDependencies/react (and react-dom — those two are kept
   pinned together).
+- The `:xray-npm-deps` fragment's `@xyflow/react` and `elkjs` pins
+  match `implementation/package.json` — the versions the monorepo
+  compiles and tests the Xray machine canvas against.
 
 The
 [`version_lockstep_test.clj`](../test/day8/re_frame2_template/version_lockstep_test.clj)

--- a/tools/template/src/day8/re_frame2_template/hooks.clj
+++ b/tools/template/src/day8/re_frame2_template/hooks.clj
@@ -323,6 +323,23 @@
        ;; shell also loads the Tailwind dev compiler.
        :css-name            (if css (name css) "")
        :story-tag           (if include-story? ", with Story playground" "")
+       ;; Xray rides the dev build of every adapter substrate (the
+       ;; :devtools/preloads entry in the shared shadow-cljs.edn), and its
+       ;; machine canvas compiles against two npm packages (@xyflow/react +
+       ;; elkjs, required by day8/re-frame2-machines-viz). shadow-cljs
+       ;; resolves JS deps from the project-local node_modules at compile
+       ;; time, so the emitted package.json must carry both — omit them and
+       ;; the scaffold's first `shadow-cljs watch app` fails with a missing
+       ;; JS dependency (found by the rf2-b16va G1-G4 external-consumer
+       ;; validation; the in-repo emitted-test tier masks it by junctioning
+       ;; implementation/node_modules). The EXPERIMENTAL :ui variant ships
+       ;; no Xray coord (minimal consumer shape) and gets none of this.
+       ;; Pins ride lockstep with implementation/package.json
+       ;; (version_lockstep_test.clj).
+       :xray-npm-deps       (if (= substrate :ui)
+                              ""
+                              (str ",\n    \"@xyflow/react\": \"12.4.2\","
+                                   "\n    \"elkjs\": \"^0.11.1\""))
        ;; SSR emits a JVM test instead of the shared CLJS test.
        :test-script         (if include-ssr?
                               "clojure -M:test"

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -458,10 +458,16 @@
                     "a symlink or `mklink /J` junction."))
 
            ;; --- compile -----------------------------------------------------
+           ;; The emitted :shadow alias is deps-only (NO :main-opts — the
+           ;; npx wrapper appends its own `-m`, and a second one kills
+           ;; shadow's arg parser), so the pure-JVM route here names the
+           ;; CLI ns explicitly.
            (testing (str label " — shadow-cljs compile "
                          (string/join " " compile-targets))
              (let [{:keys [exit out]}
-                   (run-process! (into ["clojure" "-M:shadow" "compile"]
+                   (run-process! (into ["clojure" "-M:shadow"
+                                        "-m" "shadow.cljs.devtools.cli"
+                                        "compile"]
                                        compile-targets)
                                  proj env-overrides)]
                (is (zero? exit)
@@ -502,7 +508,9 @@
            (when release?
              (testing (str label " — clojure -M:shadow release app (:advanced)")
                (let [{:keys [exit out]}
-                     (run-process! ["clojure" "-M:shadow" "release" "app"]
+                     (run-process! ["clojure" "-M:shadow"
+                                    "-m" "shadow.cljs.devtools.cli"
+                                    "release" "app"]
                                    proj env-overrides)]
                  (is (zero? exit)
                      (str "`clojure -M:shadow release app` exited " exit
@@ -616,7 +624,9 @@
           ;; `npx shadow-cljs watch app`.
           (testing "reagent-ssr — clojure -M:shadow compile app (client :cljs hydration branch)"
             (let [{:keys [exit out]}
-                  (run-process! ["clojure" "-M:shadow" "compile" "app"]
+                  (run-process! ["clojure" "-M:shadow"
+                                 "-m" "shadow.cljs.devtools.cli"
+                                 "compile" "app"]
                                 proj env-overrides)]
               (is (zero? exit)
                   (str "`clojure -M:shadow compile app` exited " exit
@@ -1126,8 +1136,13 @@
           ;; --- compile the :app build -------------------------------------
           (testing (str "setup-skill " (name substrate)
                         " scaffold — clojure -M:shadow compile app")
+            ;; The harvested :shadow alias is deps-only (no :main-opts),
+            ;; so name the shadow CLI ns explicitly — same rationale as
+            ;; the template variants above.
             (let [{:keys [exit out]}
-                  (run-process! ["clojure" "-M:shadow" "compile" "app"] proj env)]
+                  (run-process! ["clojure" "-M:shadow"
+                                 "-m" "shadow.cljs.devtools.cli"
+                                 "compile" "app"] proj env)]
               (is (zero? exit)
                   (str "`clojure -M:shadow compile app` exited " exit
                        " for the MANUAL setup-skill " (name substrate)

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -273,7 +273,15 @@
           (is (.contains pj-text "\"shadow-cljs\"")
               "package.json declares shadow-cljs devDependency")
           (is (.contains pj-text "\"react\"")
-              "package.json declares react"))
+              "package.json declares react")
+          ;; The Xray preload compiles day8/re-frame2-machines-viz's
+          ;; machine canvas, which requires these npm packages. Without
+          ;; them the scaffold's first `shadow-cljs watch app` fails with
+          ;; a missing JS dependency (rf2-b16va).
+          (is (.contains pj-text "\"@xyflow/react\"")
+              "package.json declares @xyflow/react (Xray machine-canvas npm dep)")
+          (is (.contains pj-text "\"elkjs\"")
+              "package.json declares elkjs (Xray machine-canvas npm dep)"))
 
         ;; -- views.cljs picks up the substrate-specific shape --
         (let [views-text (slurp (io/file root "src/acme/my_app/views.cljs"))]
@@ -613,6 +621,19 @@
                  views + default-on Xray both rely on them — rf2-l4prz
                  Finding 2)")
 
+            ;; shadow-cljs DEV builds (:optimizations :none) load every
+            ;; compiled namespace through goog.globalEval. Without
+            ;; 'unsafe-eval' in script-src the documented first run
+            ;; (`npx shadow-cljs watch app` → open localhost:8280) is a
+            ;; BLANK page — every module load dies with a CSP EvalError.
+            ;; The release bundle never evals; the production response
+            ;; header drops it (README). Found by the rf2-b16va G1-G4
+            ;; external boot proof.
+            (is (.contains csp-policy "script-src 'self' 'unsafe-eval'")
+                "index.html meta CSP script-src admits 'unsafe-eval' —
+                 shadow dev builds eval compiled namespaces; without it
+                 the dev page is blank (rf2-b16va)")
+
             ;; `frame-ancestors` delivered via a <meta> tag is IGNORED by
             ;; browsers; only a response header honours it. Asserting it on
             ;; the meta tag would be a false anti-clickjacking pass. The CSP
@@ -776,7 +797,13 @@
             (is (.contains pj-text "\"shadow-cljs\"")
                 ":ui package.json declares shadow-cljs devDependency")
             (is (.contains pj-text "\"react\"")
-                ":ui package.json declares react")))
+                ":ui package.json declares react")
+            ;; The minimal consumer shape carries no Xray coord, so the
+            ;; Xray machine-canvas npm deps must NOT leak into it.
+            (is (not (.contains pj-text "@xyflow/react"))
+                ":ui package.json does NOT carry @xyflow/react (no Xray)")
+            (is (not (.contains pj-text "\"elkjs\""))
+                ":ui package.json does NOT carry elkjs (no Xray)")))
         (finally
           (delete-recursively tmp))))))
 
@@ -1114,7 +1141,9 @@
 
 (def ^:private expected-package-json-default
   "Expected `_shared/package.json` emission for `acme/my-app` on the
-  Reagent default path (`:include-story? false`, subst vars resolved)."
+  Reagent default path (`:include-story? false`, subst vars resolved —
+  including the `{{xray-npm-deps}}` fragment carrying the Xray
+  machine-canvas npm deps, rf2-b16va)."
   (str "{\n"
        "  \"name\": \"acme/my-app\",\n"
        "  \"version\": \"0.1.0\",\n"
@@ -1126,7 +1155,9 @@
        "    \"test\":    \"shadow-cljs compile test && node out/node-test.js\"\n"
        "  },\n"
        "  \"devDependencies\": {\n"
-       "    \"shadow-cljs\": \"3.4.10\"\n"
+       "    \"shadow-cljs\": \"3.4.10\",\n"
+       "    \"@xyflow/react\": \"12.4.2\",\n"
+       "    \"elkjs\": \"^0.11.1\"\n"
        "  },\n"
        "  \"dependencies\": {\n"
        "    \"react\":     \"19.2.0\",\n"
@@ -1149,7 +1180,9 @@
        "    \"test\":    \"shadow-cljs compile test && node out/node-test.js\"\n"
        "  },\n"
        "  \"devDependencies\": {\n"
-       "    \"shadow-cljs\": \"3.4.10\"\n"
+       "    \"shadow-cljs\": \"3.4.10\",\n"
+       "    \"@xyflow/react\": \"12.4.2\",\n"
+       "    \"elkjs\": \"^0.11.1\"\n"
        "  },\n"
        "  \"dependencies\": {\n"
        "    \"react\":     \"19.2.0\",\n"
@@ -1650,6 +1683,9 @@
               "tailwind index.html loads the @tailwindcss/browser@4 dev CDN")
           (is (re-find #"script-src[^;]*cdn\.jsdelivr\.net" index)
               "tailwind index.html CSP script-src admits the jsdelivr CDN")
+          (is (re-find #"script-src[^;]*'unsafe-eval'" index)
+              "tailwind index.html CSP script-src admits 'unsafe-eval'
+               (shadow dev builds eval compiled namespaces — rf2-b16va)")
           ;; -- the RIGHT-side Xray host DOM order survives the swap --
           (is (< (.indexOf index "id=\"app\"")
                  (.indexOf index "data-rf-xray-host"))

--- a/tools/template/test/day8/re_frame2_template/version_lockstep_test.clj
+++ b/tools/template/test/day8/re_frame2_template/version_lockstep_test.clj
@@ -219,6 +219,34 @@
         (finally
           (delete-recursively tmp))))))
 
+(deftest xray-npm-deps-lockstep
+  (testing "Template's Xray machine-canvas npm pins match implementation/package.json"
+    ;; The adapter scaffolds carry @xyflow/react + elkjs because the Xray
+    ;; preload compiles day8/re-frame2-machines-viz's machine canvas
+    ;; (rf2-b16va). The pins must ride lockstep with
+    ;; implementation/package.json — the versions the monorepo actually
+    ;; compiles and tests against.
+    (let [pkg-xyflow (read-package-json-pin "@xyflow/react")
+          pkg-elkjs  (read-package-json-pin "elkjs")
+          tmp        (tmp-dir "rf2-template-lockstep-xray-npm-")]
+      (try
+        (let [root       (run-template! tmp "acme/my-app" :reagent)
+              pj-text    (slurp (io/file root "package.json"))
+              tpl-xyflow (extract-pin pj-text "@xyflow/react")
+              tpl-elkjs  (extract-pin pj-text "elkjs")]
+          (is (= pkg-xyflow tpl-xyflow)
+              (str "Template @xyflow/react pin (" tpl-xyflow ") must match "
+                   "implementation/package.json (" pkg-xyflow ") — "
+                   "P5 lockstep. Bump :xray-npm-deps in "
+                   "tools/template/src/day8/re_frame2_template/hooks.clj."))
+          (is (= pkg-elkjs tpl-elkjs)
+              (str "Template elkjs pin (" tpl-elkjs ") must match "
+                   "implementation/package.json (" pkg-elkjs ") — "
+                   "P5 lockstep. Bump :xray-npm-deps in "
+                   "tools/template/src/day8/re_frame2_template/hooks.clj.")))
+        (finally
+          (delete-recursively tmp))))))
+
 (deftest rf2-version-lockstep
   (testing "Template's :rf2-version literal matches repo-root VERSION"
     (let [version-file (read-version-file)


### PR DESCRIPTION
## Summary

Executes the rf2-deiym external-alpha template gate (S7-OBLIGATION 5 on rf2-vxgfnd.99) as a true external consumer: each supported variant (:reagent default, :uix, :ui experimental) scaffolded from the documented deps-new invocation in a fresh directory, with ONLY the scaffold's own `npm install` — no repo node_modules junction (the documented pre-publication `:local/root` rewrite is the sole repo-internal step, per docs/core/how-to/install-re-frame-ui.md §Pre-publication coordinates). :helix is deliberately skipped — it exists until W13 lands but is not part of the external-alpha menu (2026-07-19 template-menu ruling: only Helix departs).

The run found three template-side defects the in-repo gates structurally mask, and fixes all three:

1. **Emitted package.json missing Xray's npm deps.** The Xray preload compiles `day8/re-frame2-machines-viz`'s machine canvas, which requires `@xyflow/react` + `elkjs`. Every adapter scaffold failed its first `shadow-cljs watch app` with a missing JS dependency. The in-repo emitted-run tier junctions `implementation/node_modules` (which has both), so it never sees this. Fixed with a `{{xray-npm-deps}}` substitution — empty for the minimal :ui variant — pinned lockstep with `implementation/package.json` and guarded by a new `xray-npm-deps-lockstep` test plus positive/negative shape asserts.

2. **Emitted `:shadow` alias broke the canonical npx route.** The alias carried `:main-opts ["-m" "shadow.cljs.devtools.cli"]`; the npx wrapper appends its own `-m`, and clojure prepends alias :main-opts — so shadow's CLI received a literal `-m` and every npx / npm-script command (`npm run watch`, `npm test`, the emitted CI) died with `Unknown option: "-m"`. `examples/ui/minimal-counter/deps.edn` already documents this exact trap and the resolution: deps-only alias. Applied to all six emitted deps.edn variants; the emitted-run tier's pure-JVM invocations now name the CLI ns explicitly.

3. **Emitted dev CSP blocked shadow dev builds outright.** `script-src 'self'` without `'unsafe-eval'` — but shadow `:none` builds load every namespace via `goog.globalEval`, so the documented first run (watch → open localhost:8280) rendered a BLANK page with a wall of CSP EvalErrors. Added `'unsafe-eval'` to both index.html variants with inline rationale; the production response header in the README still drops it (release bundles never eval); regression asserts pin it.

Full G1-G4 verdict + evidence recorded on rf2-b16va; production-side and skill-side defects found during the run are filed as separate beads (UIx `frame-root` mount-time React child errors; setup-skill references teaching the npx+:main-opts collision and omitting the Xray npm deps).

## Quality gates

- `tools/template` `clojure -M:test` — 64 tests / 836 assertions, 0 failures (includes the new lockstep + CSP + package.json asserts and the updated byte-identical goldens)
- `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` vars: `reagent-emitted-tests-run-test` (incl. `:advanced` release + Xray-cut invariants), `ui-emitted-tests-run-test`, `reagent-ssr-emitted-tests-run-test` (incl. the Chromium DOM-adoption proof), `setup-skill-scaffold-compiles-test` — all green
- External-consumer runs per variant (own npm install only): `npx shadow-cljs compile app test` clean (0 warnings), `node out/node-test.js` 3/3 green, `npx shadow-cljs watch app` + headless-Chromium boot proof — reagent and ui: counter renders, click increments 0→1, zero console/page errors; uix: functional (renders + increments) with mount-time React errors from the production adapter (filed separately, not a template defect)
- `npm run release` on the reagent scaffold: clean :advanced bundle (795 KB)