### PR TITLE
fix(xray): UIx frame-root boot logs React child errors — refuse hiccup shell mount on React-element substrates (rf2-qgfo4)

### DIFF
--- a/implementation/adapters/uix/testbed/adapter_testbed_uix/core.cljs
+++ b/implementation/adapters/uix/testbed/adapter_testbed_uix/core.cljs
@@ -45,15 +45,16 @@
 
 (defn ^:export init []
   ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
-  ;; absence — `:rf/default` is this testbed's app frame, registered
-  ;; explicitly here (init! installs only the adapter). The boot dispatch
-  ;; runs under the frame scope and the render is wrapped in the UIx
-  ;; `frame-provider` so the `use-subscribe` / `capture-frame` reads inside
-  ;; `root` resolve to it.
+  ;; absence — `:rf/default` is this testbed's app frame. The mount goes
+  ;; through the UIx `frame-root` ENSURE boundary (rf2-qgfo4): it creates
+  ;; the frame at commit time, runs the `:initial-events` seed once, and
+  ;; scopes the frame to the subtree so the `use-subscribe` /
+  ;; `capture-frame` reads inside `root` resolve to it. This is the
+  ;; documented boot idiom (the template scaffold's exact shape) — the
+  ;; real-DOM path the smoke must cover.
   (rf/init! uix-adapter/adapter)
-  (rf/make-frame {:id :rf/default})
-  (rf/with-frame :rf/default
-    (rf/dispatch-sync [:counter/init]))
   (uix-dom/render-root
-    ($ uix-adapter/frame-provider {:frame :rf/default} ($ root))
+    ($ uix-adapter/frame-root {:id             :rf/default
+                               :initial-events [[:counter/init]]}
+       ($ root))
     app-root))

--- a/implementation/adapters/uix/testbed/spec.cjs
+++ b/implementation/adapters/uix/testbed/spec.cjs
@@ -1,10 +1,16 @@
 /*
- * UIx adapter testbed — browser smoke (rf2-eceuv).
+ * UIx adapter testbed — browser smoke (rf2-eceuv, rf2-qgfo4).
  *
- * Proves the UIx adapter wires up end-to-end: mount, subscribe (via
- * use-subscribe), dispatch, re-render. Minimal by design — real
- * coverage lives in the framework's CLJS / browser tests and the
- * Xray feature gate.
+ * Proves the UIx adapter wires up end-to-end on the DOCUMENTED BOOT
+ * PATH: a real-DOM `frame-root` ENSURE mount (the template scaffold's
+ * exact shape), subscribe (via use-subscribe), dispatch, re-render —
+ * and that the boot is CLEAN: zero console errors and zero uncaught
+ * page errors. rf2-qgfo4 recorded a mount-time React-child regression
+ * class (fn-as-child / MapEntry-as-child) that only a real-DOM boot
+ * surfaces; the previous smoke mounted via frame-provider after a
+ * manual make-frame, so frame-root's browser path had no coverage.
+ * Minimal by design — real coverage lives in the framework's CLJS /
+ * browser tests and the Xray feature gate.
  */
 const { expectTextEquals, expectVisible } =
   require('../../../../examples/scripts/spec-helpers.cjs');
@@ -13,12 +19,34 @@ module.exports = {
   name: 'uix adapter smoke',
   url:  '/adapter-testbeds/uix/',
   run:  async (page) => {
+    // The runner navigates before run() is called, so arm the capture
+    // listeners and re-navigate: the mount under assertion must happen
+    // with listeners attached or boot-time errors go unobserved.
+    const consoleErrors = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    const pageErrors = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+    await page.goto(page.url(), { waitUntil: 'load' });
+
     const banner  = page.locator('[data-testid="rf-adapter-testbed-uix"]');
     const counter = page.locator('[data-testid="rf-adapter-counter"]');
     const button  = page.locator('[data-testid="rf-adapter-inc"]');
     await expectVisible(banner, 10000);
+    // '0' proves frame-root's commit-time ENSURE ran the
+    // :initial-events seed exactly once before the children rendered.
     await expectTextEquals(counter, '0');
     await button.click();
     await expectTextEquals(counter, '1');
+
+    if (consoleErrors.length > 0 || pageErrors.length > 0) {
+      throw new Error(
+        'uix frame-root real-DOM boot must be clean (rf2-qgfo4): ' +
+          `${consoleErrors.length} console error(s), ` +
+          `${pageErrors.length} pageerror(s)\n` +
+          [...consoleErrors, ...pageErrors].join('\n'),
+      );
+    }
   },
 };

--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -445,9 +445,22 @@ namespace docstring (see `tools/xray/src/day8/re_frame2_xray/registry.cljs`).
 
 ### Adapter resolution
 
-Xray renders pure hiccup; all four supported substrates (Reagent,
-Reagent-slim, UIx, Helix) accept the same hiccup shape, so the
-component code itself is substrate-agnostic. Where Xray needs an
+Xray renders pure hiccup, so it can mount only through a host adapter
+whose `:render` slot accepts hiccup render-trees — the **ratom family**
+(stock Reagent, Reagent-slim). The React-hook substrates (UIx, Helix,
+the first-party `re-frame.ui`) share an **element-shaped** `render`
+that hands the tree to React untouched; a hiccup shell mounted there
+reaches React children as raw CLJS data (fn-as-child console.error
+plus an uncaught MapEntry pageerror — rf2-qgfo4). On those hosts the
+mount verbs (`open!`, `open-overlay!`, `popout!`, and therefore the
+preload auto-open) MUST refuse cleanly: publish the
+`:unsupported-substrate` diagnostic through the status API, emit one
+`console.warn` (not an error — the host app is healthy), and mount
+nothing. Rendering Xray on the React-element substrates is future
+work (tracked from rf2-qgfo4); until then the supported render hosts
+are the ratom family.
+
+Where Xray needs an
 imperative escape hatch (canvas refs, mount-lifecycle hooks for large
 list virtualisation, etc.) it resolves the active adapter via
 `re-frame.substrate.adapter/current-adapter` and dispatches on the

--- a/tools/xray/spec/011-Launch-Modes.md
+++ b/tools/xray/spec/011-Launch-Modes.md
@@ -466,7 +466,13 @@ The preload MUST NOT mount the shell synchronously during namespace
 load. It MAY schedule a bounded adapter-ready retry. Once the adapter
 is ready, it MUST find the configured layout host and mount the shell
 there. If the host is missing, it MUST emit the diagnostic described in
-§Layout host contract and leave the app running.
+§Layout host contract and leave the app running. If the installed
+adapter is a React-element substrate (UIx / Helix / `re-frame.ui` —
+hosts whose `:render` cannot take the hiccup shell, per
+[`008-Embedding-Contract.md`](./008-Embedding-Contract.md) §Adapter
+resolution), it MUST refuse the mount with the
+`:unsupported-substrate` diagnostic (status API + one `console.warn`)
+and leave the app running (rf2-qgfo4).
 
 **The foundation side-effects fire on the preload path only (rf2-5w06uu).**
 The two-phase boot above runs at the load of

--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -13,12 +13,19 @@
 
   ## Why we use the substrate adapter's render fn
 
-  Xray is substrate-agnostic: the host may be running Reagent, UIx, or
-  Helix. The substrate adapter's `:render` slot is
-  the canonical mount path (`rf/render render-tree mount-point opts`);
-  every adapter's impl produces an unmount fn on first call. Xray
-  calls that path so the shell mounts via the adapter the host
-  installed via `(rf/init! ...)`.
+  The substrate adapter's `:render` slot is the canonical mount path
+  (`rf/render render-tree mount-point opts`); every adapter's impl
+  produces an unmount fn on first call. Xray calls that path so the
+  shell mounts via the adapter the host installed via `(rf/init! ...)`.
+
+  That only works on hosts whose `:render` accepts HICCUP render-trees
+  — the ratom family (stock Reagent / reagent-slim). The React-hook
+  substrates (UIx, Helix, re-frame.ui) share an ELEMENT-shaped `render`
+  that hands the tree to React untouched, so Xray's hiccup shell cannot
+  mount there; the mount verbs refuse with the `:unsupported-substrate`
+  diagnostic instead of letting raw CLJS data reach React children
+  (rf2-qgfo4 — fn-as-child console.error + uncaught MapEntry pageerror
+  on every UIx template boot). See the substrate gate section below.
 
   ## Production posture
 
@@ -170,6 +177,57 @@
 (defn- note-auto-open-disabled! []
   (reset! diagnostic-state {:ok? true :reason :auto-open-disabled})
   nil)
+
+;; ---- substrate render-shape gate (rf2-qgfo4) ------------------------------
+;;
+;; Xray's shell is authored in hiccup (reg-view'd Reagent components), so it
+;; can only mount through a `:render` slot that accepts hiccup render-trees —
+;; the ratom family (stock Reagent / reagent-slim). The React-hook substrates
+;; (UIx, Helix, the first-party re-frame.ui) share the spine's ELEMENT-shaped
+;; `render` (`re-frame.substrate.spine/make-render`): it hands the tree to
+;; React untouched, so the hiccup vector reaches React as an iterable of raw
+;; CLJS values — the component fn becomes a Fragment child ("Functions are
+;; not valid as a React child … frame_provider") and the props map's
+;; MapEntries throw UNCAUGHT ("Objects are not valid as a React child
+;; (found: object with keys {key, val, …})") on every boot. The host app is
+;; unaffected (separate React root) but the boot is noisy and the shell never
+;; renders. Until Xray carries a hiccup-capable mount for those hosts, the
+;; mount verbs refuse loudly-but-cleanly there: one `console.warn` plus the
+;; inspectable status diagnostic — no mount, no uncaught error. DENYLIST
+;; shape on purpose: unknown / `:custom` / test adapters keep today's
+;; permissive behaviour (the mount tests ride `plain-atom` with a stubbed
+;; render), and only the kinds KNOWN to take React elements refuse.
+
+(def ^:private react-element-render-kinds
+  "Adapter `:kind`s whose `:render` slot takes substrate-native React
+  ELEMENTS (the shared React-hook spine), not hiccup — Xray's hiccup shell
+  cannot mount through them (rf2-qgfo4)."
+  #{:rf.adapter/ui :rf.adapter/uix :rf.adapter/helix})
+
+(defn- unsupported-substrate-diagnostic [kind]
+  {:ok?     false
+   :reason  :unsupported-substrate
+   :adapter kind
+   :message (str "Xray cannot mount on the installed substrate adapter ("
+                 kind "): its :render slot takes substrate-native React "
+                 "elements, and Xray's shell is hiccup rendered through the "
+                 "ratom-family adapters (Reagent / reagent-slim). Skipping "
+                 "the Xray mount — the host app is unaffected (rf2-qgfo4).")})
+
+(defn- refuse-unsupported-substrate!
+  "When the installed adapter's `:render` is element-shaped (a React-hook
+  substrate — see `react-element-render-kinds`), publish the
+  `:unsupported-substrate` diagnostic (status API + one `console.warn`; the
+  host app is healthy, so this is not an error) and return it. Returns nil
+  when the installed substrate can host the hiccup shell."
+  []
+  (let [kind (substrate-adapter/current-adapter)]
+    (when (contains? react-element-render-kinds kind)
+      (let [diagnostic (unsupported-substrate-diagnostic kind)]
+        (reset! diagnostic-state diagnostic)
+        (when (and (exists? js/console) (.-warn js/console))
+          (.warn js/console (:message diagnostic)))
+        diagnostic))))
 
 ;; ---- layout-host display snapshot ---------------------------------------
 ;;
@@ -782,8 +840,12 @@
   for the rationale.
 
   If the substrate adapter is absent, returns nil so preload retry can
-  wait. If the layout host is missing, returns an inspectable
-  diagnostic map and logs `console.error` without blocking startup."
+  wait. If the installed adapter is a React-element substrate (UIx /
+  Helix / re-frame.ui — kinds whose `:render` cannot take the hiccup
+  shell, rf2-qgfo4), returns the `:unsupported-substrate` diagnostic and
+  logs one `console.warn` without mounting. If the layout host is
+  missing, returns an inspectable diagnostic map and logs
+  `console.error` without blocking startup."
   []
   (if-let [state @mount-state]
     (if (= :inline (:mode state))
@@ -792,9 +854,10 @@
           @mount-state)
       (switch-surface! :inline))
     (when (substrate-adapter/current-adapter)
-      (if-let [node (create-inline-mount-node!)]
-        (mount-shell-into! node :inline)
-        @diagnostic-state))))
+      (or (refuse-unsupported-substrate!)
+          (if-let [node (create-inline-mount-node!)]
+            (mount-shell-into! node :inline)
+            @diagnostic-state)))))
 
 (defn open-overlay!
   "Debug/fallback launch path: mount Xray as the fixed overlay under
@@ -806,7 +869,10 @@
   mounted as the INLINE surface: realize the requested overlay surface
   — re-parent the shell to `document.body` and re-render fixed
   (rf2-j538f7.23) so the public `open-overlay!` verb honours its
-  distinct-surface contract instead of only flipping attributes."
+  distinct-surface contract instead of only flipping attributes.
+
+  Refuses with the `:unsupported-substrate` diagnostic on a
+  React-element substrate host (rf2-qgfo4), same as `open!`."
   []
   (if-let [state @mount-state]
     (if (= :overlay (:mode state))
@@ -815,7 +881,8 @@
           @mount-state)
       (switch-surface! :overlay))
     (when (substrate-adapter/current-adapter)
-      (mount-shell-into! (create-overlay-mount-node!) :overlay))))
+      (or (refuse-unsupported-substrate!)
+          (mount-shell-into! (create-overlay-mount-node!) :overlay)))))
 
 (defn close!
   "Hide the shell — make the container display:none. The DOM tree and
@@ -1244,7 +1311,9 @@
   "Open a same-origin Xray pop-out window and render the shell into it.
   The pop-out shares the opener runtime and Xray frame; no
   serialisation layer is introduced. Returns a state map, or
-  `{:ok? false :reason :popup-blocked}` when `window.open` fails.
+  `{:ok? false :reason :popup-blocked}` when `window.open` fails, or
+  the `:unsupported-substrate` diagnostic on a React-element substrate
+  host (rf2-qgfo4).
 
   Per rf2-yudol the popout window registers a `pagehide`/`unload`
   listener that clears `popout-state` when the user closes the
@@ -1264,48 +1333,49 @@
     state
     (if-not (substrate-adapter/current-adapter)
       {:ok? false :reason :no-substrate-adapter}
-      (let [win (when (exists? js/window)
-                  (.open js/window "" "rf-xray-popout"
-                         "popup,width=960,height=720"))]
-        (if-not win
-          {:ok? false :reason :popup-blocked}
-          (do
-            (ensure-xray-frame!)
-            (let [doc  (.-document win)
-                  body (.-body doc)
-                  node (.createElement doc "div")]
-              (set! (.-title doc) "Xray")
-              ;; rf2-czcg5 — inject Xray's stylesheet set + the `:root`
-              ;; `--rf-xray-*` custom properties into the pop-out's own
-              ;; document and mirror the persisted theme, so the shell
-              ;; renders fully styled (visually identical to the inline
-              ;; panel) rather than unstyled against the bare window.
-              (style-popout-document! doc)
-              (set! (.-id node) "rf-xray-popout-root")
-              (.setAttribute node "data-rf-xray-mode" "popout")
-              (.appendChild body node)
-              (let [unmount      (substrate-adapter/render
-                                    ;; rf2-tqlmq — same mount-wrap as
-                                    ;; `mount-shell-into!`: wrap the popout
-                                    ;; shell in the shell's frame-provider so
-                                    ;; its own `:rf.view/rendered` trace
-                                    ;; resolves to the trace-disabled Xray
-                                    ;; frame instead of falling through to
-                                    ;; `:rf/default` and leaking into the
-                                    ;; inspected app frame's epoch `:renders`.
-                                    [rf/frame-provider {:frame shell/default-frame-id}
-                                     [shell/shell-view {:mode :popout}]]
-                                    node nil)
-                    overlay-node (install-opener-gone-overlay! doc)
-                    watchdog-id  (start-opener-gone-watchdog! win overlay-node)
-                    state        {:ok?          true
-                                  :window       win
-                                  :node         node
-                                  :unmount      unmount
-                                  :mode         :popout
-                                  :overlay-node overlay-node
-                                  :watchdog-id  watchdog-id}]
-                (reset! popout-state state)
-                (register-popout-unload-cleanup! win)
-                state))))))))
+      (or (refuse-unsupported-substrate!)
+          (let [win (when (exists? js/window)
+                      (.open js/window "" "rf-xray-popout"
+                             "popup,width=960,height=720"))]
+            (if-not win
+              {:ok? false :reason :popup-blocked}
+              (do
+                (ensure-xray-frame!)
+                (let [doc  (.-document win)
+                      body (.-body doc)
+                      node (.createElement doc "div")]
+                  (set! (.-title doc) "Xray")
+                  ;; rf2-czcg5 — inject Xray's stylesheet set + the `:root`
+                  ;; `--rf-xray-*` custom properties into the pop-out's own
+                  ;; document and mirror the persisted theme, so the shell
+                  ;; renders fully styled (visually identical to the inline
+                  ;; panel) rather than unstyled against the bare window.
+                  (style-popout-document! doc)
+                  (set! (.-id node) "rf-xray-popout-root")
+                  (.setAttribute node "data-rf-xray-mode" "popout")
+                  (.appendChild body node)
+                  (let [unmount      (substrate-adapter/render
+                                       ;; rf2-tqlmq — same mount-wrap as
+                                       ;; `mount-shell-into!`: wrap the popout
+                                       ;; shell in the shell's frame-provider so
+                                       ;; its own `:rf.view/rendered` trace
+                                       ;; resolves to the trace-disabled Xray
+                                       ;; frame instead of falling through to
+                                       ;; `:rf/default` and leaking into the
+                                       ;; inspected app frame's epoch `:renders`.
+                                       [rf/frame-provider {:frame shell/default-frame-id}
+                                        [shell/shell-view {:mode :popout}]]
+                                       node nil)
+                        overlay-node (install-opener-gone-overlay! doc)
+                        watchdog-id  (start-opener-gone-watchdog! win overlay-node)
+                        state        {:ok?          true
+                                      :window       win
+                                      :node         node
+                                      :unmount      unmount
+                                      :mode         :popout
+                                      :overlay-node overlay-node
+                                      :watchdog-id  watchdog-id}]
+                    (reset! popout-state state)
+                    (register-popout-unload-cleanup! win)
+                    state)))))))))
 

--- a/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
@@ -335,6 +335,103 @@
                   (set! js/console prior-console))))))))))
 
 ;; -------------------------------------------------------------------------
+;; (2b) Substrate render-shape gate (rf2-qgfo4)
+;; -------------------------------------------------------------------------
+;;
+;; Xray's shell is hiccup; the React-hook substrates' `:render` slot takes
+;; substrate-native React ELEMENTS, so mounting there hands raw CLJS data to
+;; React children (fn-as-child console.error + an UNCAUGHT MapEntry
+;; pageerror on every UIx template boot). The mount verbs must refuse those
+;; hosts with the `:unsupported-substrate` diagnostic — one console.warn,
+;; status-API visibility, no mount, no render call — while the ratom family
+;; (and permissive default for custom/test adapters, e.g. the fixture's
+;; plain-atom) mounts exactly as before.
+
+(defn- with-warn-counter*
+  "Run `f` with js/console replaced by a warn-counting stub; restores the
+  prior console in a finally. `f` receives the warn-count atom."
+  [f]
+  (let [warns         (atom 0)
+        prior-console (when (exists? js/console) js/console)]
+    (set! js/console (js-obj "warn" (fn [& _args] (swap! warns inc) nil)
+                             "error" (fn [& _args] nil)))
+    (try
+      (f warns)
+      (finally
+        (set! js/console prior-console)))))
+
+(deftest open!-on-react-element-substrate-refuses-cleanly
+  (testing "open! on a UIx host (element-shaped :render) publishes the
+            :unsupported-substrate diagnostic, warns once, and mounts
+            NOTHING — no DOM node, no substrate render call (rf2-qgfo4)"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render          render-fn
+                        substrate-adapter/current-adapter (fn [] :rf.adapter/uix)]
+            (with-warn-counter*
+              (fn [warns]
+                (let [result     (mount/open!)
+                      diagnostic (:diagnostic (mount/status))]
+                  (is (= :unsupported-substrate (:reason result))
+                      "open! returns the refusal diagnostic")
+                  (is (false? (:ok? result)))
+                  (is (= :rf.adapter/uix (:adapter result))
+                      "the diagnostic names the installed adapter kind")
+                  (is (= :unsupported-substrate (:reason diagnostic))
+                      "the status API exposes the same diagnostic")
+                  (is (= 1 @warns) "exactly one console.warn")
+                  (is (false? (mount/mounted?)) "nothing mounted")
+                  (is (zero? (count @calls))
+                      "substrate-adapter/render never invoked"))))))))))
+
+(deftest open-overlay!-on-react-element-substrate-refuses-cleanly
+  (testing "open-overlay! refuses a React-element substrate host the same
+            way as open! (rf2-qgfo4)"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render          render-fn
+                        substrate-adapter/current-adapter (fn [] :rf.adapter/ui)]
+            (with-warn-counter*
+              (fn [_warns]
+                (let [result (mount/open-overlay!)]
+                  (is (= :unsupported-substrate (:reason result)))
+                  (is (= :rf.adapter/ui (:adapter result)))
+                  (is (false? (mount/mounted?)))
+                  (is (zero? (count @calls))))))))))))
+
+(deftest popout!-on-react-element-substrate-refuses-cleanly
+  (testing "popout! refuses a React-element substrate host BEFORE opening
+            a window (rf2-qgfo4)"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render          render-fn
+                        substrate-adapter/current-adapter (fn [] :rf.adapter/helix)]
+            (with-warn-counter*
+              (fn [_warns]
+                (let [result (mount/popout!)]
+                  (is (= :unsupported-substrate (:reason result)))
+                  (is (nil? @@#'mount/popout-state) "no popout state minted")
+                  (is (zero? (count @calls))))))))))))
+
+(deftest open!-on-ratom-substrate-still-mounts
+  (testing "the gate is a denylist of the element-shaped kinds only — a
+            ratom-family kind mounts exactly as before (polarity guard for
+            react-element-render-kinds)"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render          render-fn
+                        substrate-adapter/current-adapter (fn [] :rf.adapter/reagent-slim)]
+            (let [result (mount/open!)]
+              (is (map? result) "open! returns the mount-state map")
+              (is (true? (mount/mounted?)))
+              (is (= 1 (count @calls))
+                  "substrate-adapter/render invoked exactly once"))))))))
+
+;; -------------------------------------------------------------------------
 ;; (3) Open — second call (already mounted; no re-render)
 ;; -------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes rf2-qgfo4 — every real-DOM boot of a UIx frame-root app (the template scaffold shape) logged a React fn-as-child `console.error` naming `re_frame$views$provider$frame_provider` plus an uncaught MapEntry pageerror.

## Root cause (proven, not the one the bead guessed)

The UIx frame-root/defui fold is **clean** — a real-DOM frame-root boot without the Xray preload logs zero errors. The errors come from the **Xray preload** riding the template's dev build: `day8.re-frame2-xray.mount` hands its **hiccup** shell tree `[rf/frame-provider {:frame :rf/xray} [shell/shell-view …]]` to `substrate-adapter/render`. On a UIx host that slot is the React-hook spine's **element-shaped** `make-render`, which passes the tree to React untouched inside its Fragment wrap. React iterates the CLJS vector (ES6-iterable) as children:

- the `frame-provider` **fn** becomes a Fragment child → `Functions are not valid as a React child … <Fragment>{re_frame$views$provider$frame_provider}</Fragment>`
- the props **map** iterates to MapEntry objects (not themselves iterable) → uncaught `Objects are not valid as a React child (found: object with keys {key, val, __hash, …})`

The Reagent template boots clean because its `:render` slot is hiccup-native. The host app was never affected (separate React root); Xray's shell never rendered.

## Fix

- `tools/xray/…/mount.cljs`: substrate render-shape gate — `open!` / `open-overlay!` / `popout!` refuse on the element-shaped kinds `#{:rf.adapter/ui :rf.adapter/uix :rf.adapter/helix}` with an `:unsupported-substrate` diagnostic (status API + one `console.warn`; not an error — the host app is healthy). Denylist by design: ratom-family and custom/test adapters keep today's behaviour.
- `implementation/adapters/uix/testbed/`: the smoke now mounts via **frame-root** (the documented boot idiom — the previously uncovered real-DOM path; the old smoke mounted via `frame-provider` after a manual `make-frame`, which is why this class was missed) and asserts a **clean boot**: zero console errors, zero pageerrors, `:initial-events` seed visible, dispatch re-renders.
- `tools/xray/test/…/mount_cljs_test.cljs`: four new tests — refusal on `:rf.adapter/uix` / `:rf.adapter/ui` / `:rf.adapter/helix` (diagnostic shape, one warn, zero renders, nothing mounted) + a polarity guard that a ratom kind still mounts.
- `tools/xray/spec/008-Embedding-Contract.md` §Adapter resolution + `011-Launch-Modes.md` §preload contract: the "all four substrates accept the same hiccup shape" claim was false — replaced with the supported-hosts truth and the refusal contract.

Full React-element-substrate support (or dropping the preload from the `:uix` template) is filed as **rf2-p6f6u**.

## Red/green evidence (actual failing path)

Isolated repro: scratch shadow build = template shape (`rf/init!` UIx adapter + `frame-root {:id :rf/default :initial-events […]}`) + `day8.re-frame2-xray.preload`, real-DOM Chromium capture.

- **RED (before fix):** exactly the two recorded errors — fn-as-child console.error + uncaught MapEntry pageerror; app functional (counter seeds + increments).
- **Control:** same build minus the Xray preload → **zero** errors — frame-root path clean, attribution proven.
- **GREEN (after fix):** zero console errors, zero pageerrors, one intentional `console.warn` (`:unsupported-substrate` diagnostic), app functional.

## Quality gates

- `node adapters/scripts/serve-and-run-adapter-smokes.cjs --filter uix/testbed` — PASS (1/1), including the new clean-boot assertions; re-run PASS after rebase onto origin/main.
- `npm run test:adapter-smokes` (full sweep) — PASS (4/4: reagent, uix, helix, ui).
- `npm run test:cljs` — PASS (10386 tests, 51338 assertions, 0 failures) — includes the 4 new xray mount tests (verified compiled into the node-test runtime).
- `npm run test:xray-feature-gate:smoke` — 3 runs, rotating single-scenario `locator.waitFor` visibility timeouts (different scenario each run; the shell demonstrably mounts — locator resolves to the mounted `shell-view`, hidden). Environment flake under load; the gate's hosts are Reagent-kind, which this diff's gate provably does not touch.
- `clj-kondo` over changed CLJS files — 0 errors (1 pre-existing warning: unused `db` binding that predates this PR).
- No shared core files touched (fix is tools/xray + uix testbed content only).
