### PR TITLE
chore(uix): prune Helix comment residue post-W13 (rf2-v5z52)

### DIFF
--- a/implementation/adapters/uix/deps.edn
+++ b/implementation/adapters/uix/deps.edn
@@ -1,12 +1,12 @@
 ;; day8/re-frame2-uix — UIx adapter.
 ;;
 ;; Each adapter ships separately so consumers only add the selected adapter's
-;; implementation dependencies. Core still carries stock Reagent for its
-;; `reg-view` path; this boundary prevents UIx and Helix adapter dependencies
-;; from pulling one another in.
+;; implementation dependencies. Core carries no substrate dep (stock Reagent
+;; lives in implementation/adapters/reagent), so this boundary keeps uix.core
+;; off non-UIx consumers' classpaths.
 ;;
 ;; React-shaped adapters read the same frame context from core, allowing mixed
-;; Reagent, UIx, and Helix provider trees to compose.
+;; Reagent and UIx provider trees to compose.
 ;;
 ;; "UIx 2.x" names the hooks-based product/API family, not its Maven version.
 ;; That family is published as com.pitch/uix.core 1.x.x; there is no 2.x.y

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -1,7 +1,8 @@
 (ns re-frame.adapter.uix
   "UIx 2.x adapter for the substrate contract in Spec 006.
 
-  UIx and Helix share the React machinery in `re-frame.substrate.spine`.
+  The React machinery lives in `re-frame.substrate.spine`, shared with the
+  compiled-view substrate and any future React-wrapper adapter.
   This namespace supplies UIx's hooks and native `defui` `frame-provider`
   (SCOPE) + `frame-root` (ENSURE) components; keeping them native preserves
   UIx's CLJS prop and trailing-child marshalling."
@@ -39,7 +40,7 @@
   when NEITHER `frame-provider` (SCOPE) nor `frame-root` (ENSURE) installs
   the shared frame-context above. Both boundaries write that one context —
   explicitly not `:rf/default` — and every React-shaped adapter reads it, so
-  mixed Reagent, UIx, and Helix provider trees compose.
+  mixed Reagent and UIx provider trees compose.
 
   This is the narrow raw `useContext` read: it does not map the sentinel to
   nil, nor consult the dynamic-var tier. Use `(rf/current-frame-id)` for the
@@ -168,7 +169,7 @@
       (rf/init! uix/adapter)
 
   Adapter installation is explicit; there is no default-adapter registry.
-  `spine/make-react-adapter` owns the shared UIx/Helix hook routing and
+  `spine/make-react-adapter` owns the shared React-hook routing and
   lifecycle wiring. The native provider stays in this namespace so the spine
   has no dependency on UIx's element macro."
   (spine/make-react-adapter spine-fns

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_after_render_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_after_render_dom_cljs_test.cljs
@@ -71,7 +71,7 @@
   (suite/assert-flush-views-canonical-shape cfg))
 
 ;; rf2-ee38b.1 — the spine `make-render` :hydrate? true branch
-;; (hydrateRoot) had no React-hook coverage; close it for UIx + Helix.
+;; (hydrateRoot) had no React-hook coverage; this closes it.
 (deftest render-hydrate-branch-mounts-without-remount-uix
   (suite/assert-render-hydrate-branch-mounts-without-remount cfg))
 

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_dispatch_frame_capture_cljs_test.cljs
@@ -10,8 +10,6 @@
   registrar mid-flight. The shared-suite assertion bodies are the single
   source of truth; this file binds the UIx adapter + the special fixture.
 
-  Parity sibling: `helix_dispatch_frame_capture_cljs_test.cljs`.
-
   ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
   (:require [cljs.test :refer-macros [deftest async use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_frame_provider_ensure_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_frame_provider_ensure_dom_cljs_test.cljs
@@ -1,8 +1,7 @@
 (ns re-frame.adapter.uix-frame-provider-ensure-dom-cljs-test
   "UIx DOM/browser regression coverage for the NATIVE `frame-root` `defui`'s
   ENSURE (`{:id …}`) config through UIx's `$` → `glue-args` marshalling seam
-  (rf2-0bhnwm; rf2-nyea0r split). Exact twin of the Helix `extract-cljs-props`
-  seam (helix_frame_provider_ensure_dom_cljs_test, rf2-ipqu8p).
+  (rf2-0bhnwm; rf2-nyea0r split).
 
   WHY THIS EXISTS. `re-frame.adapter.uix/frame-root` is a native UIx `defui`
   (the ENSURE component; rf2-nyea0r split `frame-provider` into SCOPE-only

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_react_shared_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_react_shared_cljs_test.cljs
@@ -2,22 +2,22 @@
   "UIx entry-point for the parameterised React-adapter suite
   (`re-frame.adapter.react-shared-suite`, rf2-sx77q).
 
-  UIx and Helix wire their entire public surface out of the same
+  UIx wires its entire public surface out of the
   `spine/make-react-spine` factory, so every spine-shared behaviour is
   asserted once in the shared suite and forwarded here with the UIx
-  config. This file is the structural guarantee that UIx and Helix never
-  drift on the shared contracts: a gap on one is a gap on both because
-  there is exactly one suite source.
+  config. The suite dates from when UIx and Helix were twin spine
+  adapters (Helix removed at S7/W13, rf2-d6epb) and stays parameterised:
+  any future React-hook adapter picks up the whole surface by adding one
+  entry file like this one.
 
-  Per rf2-6hphn the ~50 deftest forwarders previously hand-paired
-  between this file and `helix_react_shared_cljs_test.cljs` are now
-  generated from a single `test-specs` literal in
-  `re-frame.adapter.react-shared-suite-tests` (a `.clj` compile-time
-  macro ns, mirroring the conformance-fixtures pattern). Both entry
-  files reduce to: an adapter `:require`, a fixture, a `cfg` map, and
-  one macro call. Adding a new shared assertion no longer requires two
-  hand-copied edits — append `[name assert-name]` to `test-specs` and
-  both adapters pick it up on next compile.
+  Per rf2-6hphn the ~50 deftest forwarders (once hand-paired with the
+  Helix twin entry file) are generated from a single `test-specs`
+  literal in `re-frame.adapter.react-shared-suite-tests` (a `.clj`
+  compile-time macro ns, mirroring the conformance-fixtures pattern).
+  The entry file reduces to: an adapter `:require`, a fixture, a `cfg`
+  map, and one macro call. Adding a new shared assertion is one edit —
+  append `[name assert-name]` to `test-specs` and every entry file picks
+  it up on next compile.
 
   Coverage forwarded (see `test-specs` in the macro ns for the
   canonical, in-source list — grep-discoverable from there):
@@ -25,7 +25,7 @@
   DOM stamping incl. the format-shape split (G2), view-id tagging,
   frame-context-corrupted (G4), warn-once fire-once + per-id (G5), the
   write-after-destroy guard (rf2-sx77q); plus, per rf2-p4736, the rest
-  of the UIx/Helix twin clusters: render-time parity (hot-reload
+  of the folded twin clusters: render-time parity (hot-reload
   re-register, anonymous render-key, wrap-view callable), reg-event
   metadata-interceptor warnings, render-to-string + late-bind chain
   wiring, the late-bind hook publication set + directory cross-check,
@@ -89,6 +89,6 @@
 
 ;; Emit one (deftest name (re-frame.adapter.react-shared-suite/assert-name cfg))
 ;; per row in `react-shared-suite-tests/test-specs`. The macro ns owns
-;; the single source of truth for the forwarder list; both UIx and
-;; Helix entry files inline the same generated deftests at compile time.
+;; the single source of truth for the forwarder list; the entry file
+;; inlines the generated deftests at compile time.
 (define-react-shared-suite-tests! cfg)

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_source_coord_dom_elision_prod_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_source_coord_dom_elision_prod_test.cljs
@@ -26,9 +26,9 @@
             [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.adapter.uix :as uix-adapter]
-            ;; rf2-5g21s — the react-element-attr accessor is hoisted into
-            ;; the dependency-free shared test home (out of cross-suite
-            ;; duplication with the Helix twin); reference it rather than
+            ;; rf2-5g21s — the react-element-attr accessor lives in the
+            ;; dependency-free shared test home (hoisted there to dedupe
+            ;; the since-removed Helix twin); reference it rather than
             ;; carry a copy. Kept separate from react-shared-suite so this
             ;; prod-elision build does not pull the suite's heavy deps.
             [re-frame.adapter.react-test-support :refer [react-element-attr]]

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_current_frame_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_current_frame_dom_cljs_test.cljs
@@ -14,10 +14,9 @@
   beneath a `frame-root` with no `frame-provider` the correct result is the
   frame id, and this test pins it.
 
-  Twin of the Helix `use-current-frame` DOM test. The frame-root case needs a
-  real client commit — its ENSURE runs in `useLayoutEffect` — so this is a
-  react-dom/client + act DOM test, not an SSR/renderToString one (effects do
-  not fire under renderToString).
+  The frame-root case needs a real client commit — its ENSURE runs in
+  `useLayoutEffect` — so this is a react-dom/client + act DOM test, not an
+  SSR/renderToString one (effects do not fire under renderToString).
 
   ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test` (ns-regexp
   `-dom-cljs-test$`) discovers it for the real DOM assertions; `:node-test`'s

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -10,7 +10,7 @@
   frame/query keywords are built HERE and handed to the suite via the cfg
   map (Approach A: components passed in as elements + atoms + keywords).
   The orchestration (make-frame, dispatch, mount under act, assert) lives
-  once in the suite; a gap on UIx is a gap on Helix by construction.
+  once in the suite.
 
   Coverage forwarded:
     - use-subscribe sees post-dispatch values via useSyncExternalStore
@@ -383,9 +383,10 @@
 
 ;; ---- regression: frame-provider under the idiomatic `$` trailing-children shape (rf2-8svnm / rf2-z7hfp / rf2-7kii2) -
 ;;
-;; The UIx twin of the Helix rf2-9ok1s defect, now pinning the moved-up
-;; seam (rf2-z7hfp) AND the unified trailing-children call shape
-;; (rf2-7kii2). HISTORY: `frame-provider` used to be a plain re-exported
+;; The UIx counterpart of the rf2-9ok1s defect (found on the Helix adapter
+;; before its W13 removal), now pinning the moved-up seam (rf2-z7hfp) AND
+;; the unified trailing-children call shape (rf2-7kii2).
+;; HISTORY: `frame-provider` used to be a plain re-exported
 ;; spine CLJS fn (not a `defui`), so UIx's `$` routed it through
 ;; `uix.compiler.alpha/react-component-element` → `interpret-attrs`, which
 ;; stringified keyword prop values and DROPPED the namespace — `:frame`


### PR DESCRIPTION
Closes rf2-v5z52 (post-W13 residue). W13 (PR #6674) removed the Helix adapter but left comment/docstring-only Helix mentions under `implementation/adapters/uix/**` untouched — they sat behind the then-live rf2-qgfo4 fence (lifted; merged as #6673). This sweep rewrites each comment to the post-removal truth. **Comment/docstring text only; zero code-form changes** (9 files, +37/−39, every hunk is a `;;` line or ns/def docstring).

Roster source: `git grep -il helix -- implementation/adapters/uix/` (9 files). The #6673-rewritten testbed tree (`implementation/adapters/uix/testbed/**`) has no Helix mentions.

## File-by-file disposition

| File | Disposition |
|---|---|
| `deps.edn` | **Rewritten** — boundary rationale retargeted ("prevents UIx and Helix deps pulling one another in" → keeps `uix.core` off non-UIx consumers' classpaths); composition claim now "Reagent and UIx provider trees". Also corrects the stale "Core still carries stock Reagent" claim in the same sentence (core carries no substrate dep, per `implementation/core/deps.edn`). |
| `src/re_frame/adapter/uix.cljs` | **Rewritten** (3 sites) — ns docstring: spine shared with the compiled-view substrate + any future React-wrapper adapter; `use-current-frame`: "Reagent and UIx provider trees compose"; `adapter`: "shared React-hook routing" (was "shared UIx/Helix"). |
| `test/.../uix_after_render_dom_cljs_test.cljs` | **Historical-keep + rewritten** — "rf2-5or96 folded the UIx/Helix after-render twins" kept (past-tense fold event); "close it for UIx + Helix" → "this closes it". |
| `test/.../uix_dispatch_frame_capture_cljs_test.cljs` | **Deleted** — "Parity sibling: `helix_dispatch_frame_capture_cljs_test.cljs`" line removed (file no longer exists; taught nothing present). |
| `test/.../uix_frame_provider_ensure_dom_cljs_test.cljs` | **Deleted** — "Exact twin of the Helix `extract-cljs-props` seam" sentence removed (present-tense claim about a deleted file). |
| `test/.../uix_react_shared_cljs_test.cljs` | **Rewritten** (4 sites) — suite rationale now present-truth (single parameterised suite; twin-adapter origin cited as history with the W13 removal ref rf2-d6epb); rf2-6hphn forwarder paragraph singularised; "UIx/Helix twin clusters" → "folded twin clusters"; macro-call comment no longer names two entry files. |
| `test/.../uix_source_coord_dom_elision_prod_test.cljs` | **Historical-keep (reworded)** — rf2-5g21s hoist motivation kept as past tense: "hoisted there to dedupe the since-removed Helix twin". |
| `test/.../uix_use_current_frame_dom_cljs_test.cljs` | **Deleted** — "Twin of the Helix `use-current-frame` DOM test" sentence removed; the surviving text carries the full rationale. |
| `test/.../uix_use_subscribe_dom_cljs_test.cljs` | **Mixed** — fold citation kept (history); "a gap on UIx is a gap on Helix by construction" deleted (present-false); rf2-9ok1s reference recast as defect provenance ("found on the Helix adapter before its W13 removal"). |

Remaining `helix` hits under the tree (7 lines) are all deliberate past-tense historical citations: fold events (rf2-5or96, rf2-6hphn, rf2-5g21s), the removal citation (rf2-d6epb), and defect provenance (rf2-9ok1s).

Out of scope, noted for the record: `implementation/core/src/re_frame/substrate/spine.cljs` and `implementation/core/test/re_frame/adapter/react_shared_suite.cljs` also mention Helix but live under `implementation/core/**` (outside this bead's fence; the suite header is already past-tense).

## Quality gates

- `npm run test:cljs` (from `implementation/`, foreground): **Ran 10257 tests containing 50920 assertions. 0 failures, 0 errors.**
- `clj-kondo --lint adapters/uix`: **0 errors**; 2 warnings, both pre-existing unused-binding warnings on code lines this PR does not touch.
- Comments-only self-check: full diff reviewed hunk-by-hunk — every changed line is a `;;` comment or ns/def docstring text; `git diff --stat` 9 files, +37/−39.