### PR TITLE
spec(freehand): conformance id scheme, index and validator (rf2-drpa3.12)

### DIFF
--- a/.github/workflows/freehand-conformance.yml
+++ b/.github/workflows/freehand-conformance.yml
@@ -1,0 +1,70 @@
+name: freehand-conformance
+
+# Gate for the Freehand executable-law addressing scheme.
+#
+# Freehand proves its interpreted/compiled + React/JVM/SSR parity row by row.
+# Each law carries a permanent `FH-<AREA>-<NNN>` id and the index at
+# spec/conformance/freehand/conformance-index.md binds that id to the canonical
+# spec paragraph that owns it, the modes and hosts it binds, its fixture, and
+# its status. An id is an address: if a row can cite a paragraph that does not
+# exist, name a fixture that was never written, or reuse an id another row
+# already holds, the scheme is decoration. This gate is what makes it load
+# bearing.
+#
+# REQUIRED-CHECK SHAPE. The `pull_request` trigger is deliberately UNFILTERED
+# and the single job is NOT surface-gated, so the `Freehand conformance index`
+# status context is present on every PR and can be required by the branch
+# ruleset without the phantom-pending trap a path-filtered workflow creates.
+# There is no aggregator job because there is nothing to aggregate: one job,
+# always present, ~30 seconds including the pip install.
+#
+# The self-test runs BEFORE the live scan, in the repo-wide house style: the
+# index is empty at establishment, and a validator that has only ever been run
+# against an empty index has not been tested. The self-test drives one
+# deliberately broken fixture index per defect shape and fails if any of them
+# passes.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'spec/conformance/freehand/**'
+      - 'scripts/check_freehand_conformance_index.py'
+      - 'scripts/check_doc_slugs.py'   # supplies the shared slug index
+      - 'requirements.txt'
+      - '.github/workflows/freehand-conformance.yml'
+  # PR trigger is intentionally UNFILTERED (see REQUIRED-CHECK SHAPE above).
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: freehand-conformance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  index:
+    name: Freehand conformance index
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      # The validator resolves a row's #anchor through the same slug index the
+      # docs corpus uses (scripts/check_doc_slugs.py), which needs the pinned
+      # pymdown-extensions. requirements.txt is the one pin.
+      - name: Install doc toolchain
+        run: pip install -r requirements.txt
+
+      - name: Self-test the Freehand conformance-index validator
+        run: python scripts/check_freehand_conformance_index.py --self-test --verbose
+
+      - name: Validate the Freehand conformance index
+        run: python scripts/check_freehand_conformance_index.py --verbose

--- a/scripts/check_freehand_conformance_index.py
+++ b/scripts/check_freehand_conformance_index.py
@@ -128,11 +128,11 @@ def _check_citation(
     """Return None when the canonical-paragraph cell resolves, else the reason."""
     m = _LINK_RE.match(cell)
     if not m:
-        return "not a markdown link — expected [text](../../00X-Doc.md#anchor)"
+        return "not a markdown link - expected [text](../../00X-Doc.md#anchor)"
     dest = m.group(1)
     path_part, _, anchor = dest.partition("#")
     if not anchor:
-        return f"`{dest}` has no #anchor — a row cites a paragraph, not a document"
+        return f"`{dest}` has no #anchor - a row cites a paragraph, not a document"
     if not path_part.endswith(".md"):
         return f"`{dest}` does not point at a markdown file"
 
@@ -143,13 +143,13 @@ def _check_citation(
         return f"`{dest}` resolves outside the repository"
     if rel.parts[0] != "spec":
         return (
-            f"`{dest}` resolves to {rel.as_posix()} — a canonical paragraph "
+            f"`{dest}` resolves to {rel.as_posix()} - a canonical paragraph "
             "lives under spec/, not in a design record or guide"
         )
     if not target.is_file():
-        return f"`{dest}` — no such file ({rel.as_posix()})"
+        return f"`{dest}` - no such file ({rel.as_posix()})"
     if anchor not in _slug_index(target):
-        return f"`{dest}` — {rel.as_posix()} has no anchor #{anchor}"
+        return f"`{dest}` - {rel.as_posix()} has no anchor #{anchor}"
     return None
 
 
@@ -157,7 +157,7 @@ def _check_applicability(cell: str) -> str | None:
     """Return None when the applicability cell is well-formed, else the reason."""
     tokens = cell.split()
     if not tokens:
-        return "empty — name one mode token and at least one host token"
+        return "empty - name one mode token and at least one host token"
     unknown = [
         t
         for t in tokens
@@ -167,18 +167,18 @@ def _check_applicability(cell: str) -> str | None:
     ]
     if unknown:
         return (
-            f"unknown token(s) {', '.join(unknown)} — expected one of "
+            f"unknown token(s) {', '.join(unknown)} - expected one of "
             "common/interpreted/compiled plus jvm/browser/ssr/host:<name>"
         )
     modes = [t for t in tokens if t in MODE_TOKENS]
     if len(modes) != 1:
         return (
-            f"{len(modes)} mode token(s) ({', '.join(modes) or 'none'}) — "
+            f"{len(modes)} mode token(s) ({', '.join(modes) or 'none'}) - "
             "exactly one of common/interpreted/compiled is required"
         )
     hosts = [t for t in tokens if t not in MODE_TOKENS]
     if not hosts:
-        return "no host token — name at least one of jvm/browser/ssr/host:<name>"
+        return "no host token - name at least one of jvm/browser/ssr/host:<name>"
     return None
 
 
@@ -190,7 +190,7 @@ def _check_fixture(cell: str, status: str, repo_root: Path) -> str | None:
             return "an `active` row must name the fixture that proves it"
         path = _unquote(raw)
         if not (repo_root / path).is_file():
-            return f"`{path}` — no such file"
+            return f"`{path}` - no such file"
         return None
     if raw != NO_FIXTURE:
         return (
@@ -328,7 +328,7 @@ def check(repo_root: Path, verbose: bool = False) -> int:
 
         if status not in STATUSES:
             defect(line_no, "BAD STATUS", label,
-                   f"`{status}` — expected one of {', '.join(sorted(STATUSES))}")
+                   f"`{status}` - expected one of {', '.join(sorted(STATUSES))}")
         else:
             reason = _check_fixture(fixture, status, repo_root)
             if reason:
@@ -361,7 +361,7 @@ def check(repo_root: Path, verbose: bool = False) -> int:
         for line in defects:
             sys.stderr.write(line + "\n")
         sys.stderr.write(
-            "\nFix: see spec/conformance/freehand/README.md — an FH id is a "
+            "\nFix: see spec/conformance/freehand/README.md - an FH id is a "
             "permanent address, so it must be well-formed, unique, filed under "
             "its own area, and resolve to a real spec paragraph and (when "
             "active) a real fixture.\n"

--- a/scripts/check_freehand_conformance_index.py
+++ b/scripts/check_freehand_conformance_index.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+"""Validate the Freehand conformance index — ids, citations, fixtures, sections.
+
+The Freehand view substrate proves its two-mode / multi-host parity row by row.
+Each law carries a permanent `FH-<AREA>-<NNN>` id, and the index at
+`spec/conformance/freehand/conformance-index.md` binds that id to the canonical
+spec paragraph that OWNS the law, the modes and hosts it binds, the fixture that
+proves it, and its status.  The scheme, the allocation rule, and the column
+grammar are documented in `spec/conformance/freehand/README.md`.
+
+An id is an address.  An address that resolves to nothing is worse than no
+address at all, so this guard fails the build when:
+
+    * ILL-FORMED ID        — the id is not `FH-<AREA>-<NNN>` with a roster AREA
+                             and a three-digit ordinal.
+    * DUPLICATE ID         — the same id appears on two rows (an id is a
+                             permanent citation; two rows make it ambiguous).
+    * AREA MISMATCH        — the row's AREA is not the section it sits in.
+    * OUT-OF-ORDER ID      — ordinals within a section are dense and ascending;
+                             appending out of order means the allocation rule was
+                             not followed and a collision is one merge away.
+    * MISSING CITATION     — the canonical-paragraph cell is not a markdown link
+                             with an anchor.
+    * BROKEN CITATION      — the cited spec file does not exist, the anchor does
+                             not resolve, or the target is not under `spec/`.
+    * MISSING FIXTURE      — an `active` row names a fixture file that does not
+                             exist, or names none at all.
+    * MISPLACED FIXTURE    — a `planned` / `retired` row names a fixture.
+    * BAD APPLICABILITY    — an unknown token, no mode token or two, or no host.
+    * BAD STATUS           — a status outside the closed vocabulary.
+    * BAD ROW              — a table row whose column count is not six.
+    * ORPHAN ROW           — a row before the first area section.
+    * BAD TABLE HEADER     — a section's table header is not the six columns.
+    * UNKNOWN / DUPLICATE / MISSING AREA SECTION — the section roster no longer
+                             matches the area roster.
+
+Every defect names the offending row (its id, or its raw first cell when the id
+itself is the defect) and its line number.
+
+Exit code:
+    0  the index is valid
+    1  at least one defect
+    2  invocation / setup error
+
+Anchor resolution reuses the slug index from `check_doc_slugs.py` rather than
+re-deriving it, so a citation resolves under exactly the rule that governs every
+other link in the corpus — one slugifier, one authority.  That import is the
+script's only dependency beyond the stdlib (it pulls in pymdown-extensions,
+already pinned in requirements.txt).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+# One slugifier for the whole corpus (see module docstring).  check_doc_slugs
+# lives beside this file and exits(2) itself if pymdown-extensions is absent.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_doc_slugs import _slug_index  # noqa: E402
+
+INDEX_REL = Path("spec/conformance/freehand/conformance-index.md")
+
+# The closed area roster, in index order.  Fixed by the Freehand programme EP;
+# implementation work allocates ids within it and never extends it.
+AREAS: tuple[str, ...] = (
+    "CALL",
+    "PROPS",
+    "EVENT",
+    "INPUT",
+    "SUB",
+    "CTRL",
+    "PRESENCE",
+    "TOPLAYER",
+    "BEHAVIOR",
+    "REACT",
+    "ERROR",
+    "ROOT",
+    "STRUCT",
+    "DIAG",
+)
+
+COLUMNS: tuple[str, ...] = (
+    "Id",
+    "Law",
+    "Canonical paragraph",
+    "Applicability",
+    "Fixture",
+    "Status",
+)
+
+STATUSES = frozenset({"planned", "active", "retired"})
+
+# Applicability is two axes: exactly one mode token, one or more host tokens.
+MODE_TOKENS = frozenset({"common", "interpreted", "compiled"})
+HOST_TOKENS = frozenset({"jvm", "browser", "ssr"})
+_QUALIFIED_HOST_RE = re.compile(r"^host:[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+# The em dash is the "no fixture" cell.  Nothing else stands in for it.
+NO_FIXTURE = "—"
+
+_ID_RE = re.compile(r"^FH-([A-Z]+)-(\d{3})$")
+# `### FH-CALL — Calls`; the token is what binds, the prose name is for readers.
+_SECTION_RE = re.compile(r"^###\s+FH-([A-Z]+)\b")
+_FENCE_RE = re.compile(r"^\s*(```|~~~)")
+_LINK_RE = re.compile(r"^\[[^\]]+\]\(([^)\s]+)\)$")
+_SEPARATOR_CELL_RE = re.compile(r"^:?-{3,}:?$")
+
+
+def _cells(line: str) -> list[str]:
+    """Split a markdown table row into trimmed cells (outer pipes dropped)."""
+    return [c.strip() for c in line.strip().strip("|").split("|")]
+
+
+def _unquote(cell: str) -> str:
+    """Strip the backticks an index cell wraps a literal in."""
+    return cell.strip().strip("`").strip()
+
+
+def _check_citation(
+    cell: str,
+    index_dir: Path,
+    repo_root: Path,
+) -> str | None:
+    """Return None when the canonical-paragraph cell resolves, else the reason."""
+    m = _LINK_RE.match(cell)
+    if not m:
+        return "not a markdown link — expected [text](../../00X-Doc.md#anchor)"
+    dest = m.group(1)
+    path_part, _, anchor = dest.partition("#")
+    if not anchor:
+        return f"`{dest}` has no #anchor — a row cites a paragraph, not a document"
+    if not path_part.endswith(".md"):
+        return f"`{dest}` does not point at a markdown file"
+
+    target = (index_dir / path_part).resolve()
+    try:
+        rel = target.relative_to(repo_root.resolve())
+    except ValueError:
+        return f"`{dest}` resolves outside the repository"
+    if rel.parts[0] != "spec":
+        return (
+            f"`{dest}` resolves to {rel.as_posix()} — a canonical paragraph "
+            "lives under spec/, not in a design record or guide"
+        )
+    if not target.is_file():
+        return f"`{dest}` — no such file ({rel.as_posix()})"
+    if anchor not in _slug_index(target):
+        return f"`{dest}` — {rel.as_posix()} has no anchor #{anchor}"
+    return None
+
+
+def _check_applicability(cell: str) -> str | None:
+    """Return None when the applicability cell is well-formed, else the reason."""
+    tokens = cell.split()
+    if not tokens:
+        return "empty — name one mode token and at least one host token"
+    unknown = [
+        t
+        for t in tokens
+        if t not in MODE_TOKENS
+        and t not in HOST_TOKENS
+        and not _QUALIFIED_HOST_RE.match(t)
+    ]
+    if unknown:
+        return (
+            f"unknown token(s) {', '.join(unknown)} — expected one of "
+            "common/interpreted/compiled plus jvm/browser/ssr/host:<name>"
+        )
+    modes = [t for t in tokens if t in MODE_TOKENS]
+    if len(modes) != 1:
+        return (
+            f"{len(modes)} mode token(s) ({', '.join(modes) or 'none'}) — "
+            "exactly one of common/interpreted/compiled is required"
+        )
+    hosts = [t for t in tokens if t not in MODE_TOKENS]
+    if not hosts:
+        return "no host token — name at least one of jvm/browser/ssr/host:<name>"
+    return None
+
+
+def _check_fixture(cell: str, status: str, repo_root: Path) -> str | None:
+    """Return None when the fixture cell agrees with the row's status."""
+    raw = cell.strip()
+    if status == "active":
+        if raw == NO_FIXTURE or not raw:
+            return "an `active` row must name the fixture that proves it"
+        path = _unquote(raw)
+        if not (repo_root / path).is_file():
+            return f"`{path}` — no such file"
+        return None
+    if raw != NO_FIXTURE:
+        return (
+            f"a `{status}` row must leave the fixture cell as {NO_FIXTURE} "
+            f"(found `{_unquote(raw)}`)"
+        )
+    return None
+
+
+def check(repo_root: Path, verbose: bool = False) -> int:
+    """Validate the Freehand conformance index.  Return the defect count."""
+    index = repo_root / INDEX_REL
+    if not index.is_file():
+        sys.stderr.write(f"error: no Freehand conformance index at {index}\n")
+        return 1
+    index_dir = index.parent
+
+    defects: list[str] = []
+
+    def defect(line_no: int, kind: str, row: str, detail: str) -> None:
+        defects.append(f"  {kind}: {INDEX_REL.as_posix()}:{line_no} [{row}] {detail}")
+
+    seen_ids: dict[str, int] = {}
+    sections_seen: list[str] = []
+    section_area: str | None = None
+    section_has_header = False
+    last_ordinal: dict[str, int] = {}
+    row_count = 0
+
+    in_fence = False
+    for line_no, raw in enumerate(
+        index.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        if _FENCE_RE.match(raw):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+
+        section = _SECTION_RE.match(raw)
+        if section:
+            section_area = section.group(1)
+            section_has_header = False
+            sections_seen.append(section_area)
+            continue
+
+        if not raw.lstrip().startswith("|"):
+            continue
+
+        cells = _cells(raw)
+
+        # Separator rows carry no data.
+        if cells and all(_SEPARATOR_CELL_RE.match(c) for c in cells):
+            continue
+
+        if section_area is None:
+            defect(line_no, "ORPHAN ROW", cells[0] if cells else "",
+                   "table row before the first area section")
+            continue
+
+        # The first table row in a section is its header, and it is pinned so a
+        # later slice cannot quietly add, drop, or rename a column.
+        if not section_has_header:
+            section_has_header = True
+            if tuple(cells) != COLUMNS:
+                defect(
+                    line_no,
+                    "BAD TABLE HEADER",
+                    f"FH-{section_area}",
+                    f"expected | {' | '.join(COLUMNS)} |",
+                )
+            continue
+
+        if len(cells) != len(COLUMNS):
+            defect(
+                line_no,
+                "BAD ROW",
+                cells[0] if cells else "",
+                f"{len(cells)} column(s), expected {len(COLUMNS)}",
+            )
+            continue
+
+        row_count += 1
+        id_cell, law, citation, applicability, fixture, status = cells
+        row_id = _unquote(id_cell)
+        label = row_id or "<empty id>"
+
+        m = _ID_RE.match(row_id)
+        if not m:
+            defect(
+                line_no,
+                "ILL-FORMED ID",
+                label,
+                "expected FH-<AREA>-<NNN> with a roster AREA and three digits",
+            )
+            continue
+        area, ordinal_text = m.group(1), m.group(2)
+        ordinal = int(ordinal_text)
+
+        if area not in AREAS:
+            defect(line_no, "ILL-FORMED ID", label,
+                   f"`{area}` is not in the area roster ({', '.join(AREAS)})")
+            continue
+
+        duplicate = row_id in seen_ids
+        if duplicate:
+            defect(line_no, "DUPLICATE ID", label,
+                   f"already allocated at line {seen_ids[row_id]}")
+        else:
+            seen_ids[row_id] = line_no
+
+        if area != section_area:
+            defect(line_no, "AREA MISMATCH", label,
+                   f"filed under the FH-{section_area} section")
+        elif not duplicate:
+            # Ordering is only meaningful for a fresh id — a duplicate has
+            # already been reported and would otherwise report twice.
+            previous = last_ordinal.get(area)
+            if previous is not None and ordinal <= previous:
+                defect(line_no, "OUT-OF-ORDER ID", label,
+                       f"follows {area}-{previous:03d}; ids ascend within an area")
+            last_ordinal[area] = max(ordinal, previous or 0)
+
+        if not law:
+            defect(line_no, "BAD ROW", label, "empty Law cell")
+
+        reason = _check_citation(citation, index_dir, repo_root)
+        if reason:
+            kind = "MISSING CITATION" if not _LINK_RE.match(citation) else "BROKEN CITATION"
+            defect(line_no, kind, label, reason)
+
+        reason = _check_applicability(applicability)
+        if reason:
+            defect(line_no, "BAD APPLICABILITY", label, reason)
+
+        if status not in STATUSES:
+            defect(line_no, "BAD STATUS", label,
+                   f"`{status}` — expected one of {', '.join(sorted(STATUSES))}")
+        else:
+            reason = _check_fixture(fixture, status, repo_root)
+            if reason:
+                kind = "MISSING FIXTURE" if status == "active" else "MISPLACED FIXTURE"
+                defect(line_no, kind, label, reason)
+
+    for area in sections_seen:
+        if area not in AREAS:
+            defects.append(
+                f"  UNKNOWN AREA SECTION: {INDEX_REL.as_posix()} has a "
+                f"### FH-{area} section; the roster is closed "
+                f"({', '.join(AREAS)})"
+            )
+    for area in sorted({a for a in sections_seen if sections_seen.count(a) > 1}):
+        defects.append(
+            f"  DUPLICATE AREA SECTION: {INDEX_REL.as_posix()} has more than one "
+            f"### FH-{area} section; one section per area keeps allocation honest"
+        )
+    for area in AREAS:
+        if area not in sections_seen:
+            defects.append(
+                f"  MISSING AREA SECTION: {INDEX_REL.as_posix()} has no "
+                f"### FH-{area} section; every roster area carries one"
+            )
+
+    if defects:
+        sys.stderr.write(
+            f"\n{len(defects)} Freehand conformance-index defect(s) found:\n\n"
+        )
+        for line in defects:
+            sys.stderr.write(line + "\n")
+        sys.stderr.write(
+            "\nFix: see spec/conformance/freehand/README.md — an FH id is a "
+            "permanent address, so it must be well-formed, unique, filed under "
+            "its own area, and resolve to a real spec paragraph and (when "
+            "active) a real fixture.\n"
+        )
+    elif verbose:
+        sys.stderr.write(
+            f"Freehand conformance index OK: {row_count} row(s) across "
+            f"{len(sections_seen)} area section(s).\n"
+        )
+
+    return len(defects)
+
+
+# --------------------------------------------------------------------------
+# Self-tests — hermetic fixtures generated into a temp dir, mirroring
+# scripts/check_ep_status_sync.py's style.  Each fixture is a mini-repo: an
+# mkdocs.yml at the root (the repo-root guard), a spec/ doc with a real
+# heading to cite, an existing fixture file, and one index.
+#
+# The clean case and the EMPTY case both pass; every other case injects one
+# defect shape and must fail.  An index this file's production copy is empty
+# would otherwise be validated by a guard that has never said no.
+# --------------------------------------------------------------------------
+
+_HEADER = "| " + " | ".join(COLUMNS) + " |\n|---|---|---|---|---|---|\n"
+
+_GOOD_CITATION = "[004-Views.md#template-grammar](../../004-Views.md#template-grammar)"
+
+
+def _row(
+    row_id: str = "FH-CALL-001",
+    law: str = "a declared view is a vector-called descriptor",
+    citation: str = _GOOD_CITATION,
+    applicability: str = "common jvm browser",
+    fixture: str = "`spec/conformance/freehand/fixtures/fh-call-001.edn`",
+    status: str = "active",
+) -> str:
+    return (
+        f"| `{row_id}` | {law} | {citation} | {applicability} | "
+        f"{fixture} | {status} |\n"
+    )
+
+
+def _write_fixture(root: Path, sections: dict[str, str]) -> None:
+    """Write a mini-repo whose index carries `sections` (area -> row block)."""
+    (root / "mkdocs.yml").write_text("site_name: fixture\n", encoding="utf-8")
+    spec = root / "spec"
+    (spec / "conformance" / "freehand" / "fixtures").mkdir(parents=True, exist_ok=True)
+    (spec / "004-Views.md").write_text(
+        "# Views\n\n## Template grammar\n\nx\n", encoding="utf-8"
+    )
+    (root / "docs").mkdir(exist_ok=True)
+    (root / "docs" / "note.md").write_text("# Note\n\n## Template grammar\n\nx\n",
+                                           encoding="utf-8")
+    (spec / "conformance" / "freehand" / "fixtures" / "fh-call-001.edn").write_text(
+        "{}\n", encoding="utf-8"
+    )
+    body = ["# Freehand Conformance Index\n"]
+    for area in AREAS:
+        body.append(f"\n### FH-{area} — {area.title()}\n\n")
+        body.append(_HEADER)
+        body.append(sections.get(area, ""))
+    (root / INDEX_REL).write_text("".join(body), encoding="utf-8")
+
+
+def _build_self_test_fixtures(base: Path) -> None:
+    cases: dict[str, dict[str, str]] = {
+        # Both green cases: a real row, and the empty index this slice ships.
+        "clean": {"CALL": _row()},
+        "empty": {},
+        "clean_planned": {"CALL": _row(fixture=NO_FIXTURE, status="planned")},
+        "clean_qualified_host": {
+            "CALL": _row(applicability="compiled host:ag-grid")
+        },
+        # One defect each.
+        "duplicate_id": {"CALL": _row() + _row(law="a second row, same id")},
+        "ill_formed_id": {"CALL": _row(row_id="FH-CALL-1")},
+        "unknown_area_in_id": {"CALL": _row(row_id="FH-BANANA-001")},
+        "area_mismatch": {"PROPS": _row()},
+        "out_of_order_id": {
+            "CALL": _row(row_id="FH-CALL-002") + _row(row_id="FH-CALL-001")
+        },
+        "citation_not_a_link": {"CALL": _row(citation="004-Views.md#template-grammar")},
+        "citation_no_anchor": {"CALL": _row(citation="[v](../../004-Views.md)")},
+        "citation_missing_file": {
+            "CALL": _row(citation="[v](../../004Z-Gone.md#template-grammar)")
+        },
+        "citation_missing_anchor": {
+            "CALL": _row(citation="[v](../../004-Views.md#no-such-anchor)")
+        },
+        "citation_outside_spec": {
+            "CALL": _row(citation="[v](../../../docs/note.md#template-grammar)")
+        },
+        "fixture_missing": {
+            "CALL": _row(fixture="`spec/conformance/freehand/fixtures/nope.edn`")
+        },
+        "fixture_absent_on_active": {"CALL": _row(fixture=NO_FIXTURE)},
+        "fixture_on_planned": {"CALL": _row(status="planned")},
+        "applicability_unknown_token": {"CALL": _row(applicability="common node")},
+        "applicability_two_modes": {
+            "CALL": _row(applicability="common compiled browser")
+        },
+        "applicability_no_host": {"CALL": _row(applicability="common")},
+        "applicability_no_mode": {"CALL": _row(applicability="browser jvm")},
+        "bad_status": {"CALL": _row(status="green")},
+        "bad_row_shape": {"CALL": "| `FH-CALL-001` | law | too few |\n"},
+        "empty_law": {"CALL": _row(law="")},
+    }
+    for name, sections in cases.items():
+        root = base / name
+        root.mkdir(parents=True, exist_ok=True)
+        _write_fixture(root, sections)
+
+    # Section-roster defects need surgery on the rendered index, not a row.
+    dropped = base / "missing_area_section"
+    dropped.mkdir(parents=True, exist_ok=True)
+    _write_fixture(dropped, {})
+    text = (dropped / INDEX_REL).read_text(encoding="utf-8")
+    (dropped / INDEX_REL).write_text(
+        text.replace(f"### FH-{AREAS[-1]} — {AREAS[-1].title()}\n\n" + _HEADER, ""),
+        encoding="utf-8",
+    )
+
+    unknown = base / "unknown_area_section"
+    unknown.mkdir(parents=True, exist_ok=True)
+    _write_fixture(unknown, {})
+    text = (unknown / INDEX_REL).read_text(encoding="utf-8")
+    (unknown / INDEX_REL).write_text(
+        text + "\n### FH-BANANA — Banana\n\n" + _HEADER, encoding="utf-8"
+    )
+
+    duplicate = base / "duplicate_area_section"
+    duplicate.mkdir(parents=True, exist_ok=True)
+    _write_fixture(duplicate, {})
+    text = (duplicate / INDEX_REL).read_text(encoding="utf-8")
+    (duplicate / INDEX_REL).write_text(
+        text + f"\n### FH-{AREAS[0]} — Again\n\n" + _HEADER, encoding="utf-8"
+    )
+
+    header = base / "bad_table_header"
+    header.mkdir(parents=True, exist_ok=True)
+    _write_fixture(header, {})
+    text = (header / INDEX_REL).read_text(encoding="utf-8")
+    (header / INDEX_REL).write_text(
+        text.replace("| Law |", "| Rule |", 1), encoding="utf-8"
+    )
+
+    orphan = base / "orphan_row"
+    orphan.mkdir(parents=True, exist_ok=True)
+    _write_fixture(orphan, {})
+    text = (orphan / INDEX_REL).read_text(encoding="utf-8")
+    (orphan / INDEX_REL).write_text(
+        text.replace("# Freehand Conformance Index\n",
+                     "# Freehand Conformance Index\n\n" + _HEADER + _row(), 1),
+        encoding="utf-8",
+    )
+
+
+def _run_self_tests(verbose: bool = False) -> int:
+    cases: list[tuple[str, int]] = [
+        ("clean", 0),
+        ("empty", 0),
+        ("clean_planned", 0),
+        ("clean_qualified_host", 0),
+        ("duplicate_id", 1),
+        ("ill_formed_id", 1),
+        ("unknown_area_in_id", 1),
+        ("area_mismatch", 1),
+        ("out_of_order_id", 1),
+        ("citation_not_a_link", 1),
+        ("citation_no_anchor", 1),
+        ("citation_missing_file", 1),
+        ("citation_missing_anchor", 1),
+        ("citation_outside_spec", 1),
+        ("fixture_missing", 1),
+        ("fixture_absent_on_active", 1),
+        ("fixture_on_planned", 1),
+        ("applicability_unknown_token", 1),
+        ("applicability_two_modes", 1),
+        ("applicability_no_host", 1),
+        ("applicability_no_mode", 1),
+        ("bad_status", 1),
+        ("bad_row_shape", 1),
+        ("empty_law", 1),
+        ("missing_area_section", 1),
+        ("unknown_area_section", 1),
+        ("duplicate_area_section", 1),
+        ("bad_table_header", 1),
+        # A block before the first section orphans both its header and its row.
+        ("orphan_row", 2),
+    ]
+    failures = 0
+    with tempfile.TemporaryDirectory(prefix="fh_index_selftest_") as tmp:
+        base = Path(tmp)
+        _build_self_test_fixtures(base)
+        for fixture, expected in cases:
+            root = base / fixture
+            saved_stderr = sys.stderr
+            sys.stderr = _DevNull()
+            try:
+                got = check(root, verbose=False)
+            finally:
+                sys.stderr = saved_stderr
+            if got == expected:
+                if verbose:
+                    sys.stderr.write(f"self-test PASS: {fixture} (defects={got})\n")
+            else:
+                sys.stderr.write(
+                    f"self-test FAIL: {fixture} expected defects={expected}, "
+                    f"got {got}\n"
+                )
+                failures += 1
+    if failures:
+        sys.stderr.write(f"\n{failures} self-test failure(s).\n")
+        return 1
+    if verbose:
+        sys.stderr.write(f"all {len(cases)} self-tests passed.\n")
+    return 0
+
+
+class _DevNull:
+    def write(self, *_args, **_kwargs) -> int:
+        return 0
+
+    def flush(self) -> None:  # pragma: no cover
+        return None
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate the Freehand conformance index (FH-<AREA>-<NNN>).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Path to the repo root.  Defaults to the script's grandparent.",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Print progress to stderr."
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Run the bundled fixture-based self-tests and exit.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return _run_self_tests(verbose=args.verbose)
+
+    if args.repo_root:
+        repo_root = Path(args.repo_root).resolve()
+    else:
+        repo_root = Path(__file__).resolve().parent.parent
+
+    if not (repo_root / "mkdocs.yml").is_file():
+        sys.stderr.write(
+            f"error: {repo_root} does not look like the re-frame2 repo root "
+            "(no mkdocs.yml).  Pass --repo-root explicitly.\n"
+        )
+        return 2
+
+    defects = check(repo_root, verbose=args.verbose)
+    return 0 if defects == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/spec/conformance/freehand/README.md
+++ b/spec/conformance/freehand/README.md
@@ -1,0 +1,158 @@
+# Freehand Executable Laws
+
+> **Type:** Reference
+> This directory owns **how a Freehand law is named, cited, and indexed** — the
+> `FH-<AREA>-<NNN>` addressing scheme and the index that binds each id to its
+> canonical spec paragraph, its host/mode applicability, its fixture, and its
+> status. It does not own how a fixture runs, and it never restates a law
+> normatively.
+
+Freehand is one view substrate with two modes — interpreted and compiled — and
+one semantic model shared between them. Parity between the modes, and across the
+React, JVM, and SSR hosts, is not asserted in prose: it is proven row by row. A
+**law** is one such provable statement. Every law has a permanent id, and every
+id resolves to exactly one paragraph of normative spec.
+
+- [`conformance-index.md`](conformance-index.md) — the index: one row per law.
+- `fixtures/` — the fixture values laws are proven by, added as laws land.
+
+## The id scheme
+
+```
+FH-<AREA>-<NNN>
+```
+
+- `FH` — fixed prefix. It marks a Freehand view-substrate law and nothing else.
+- `<AREA>` — one uppercase token from the roster below. The roster is closed.
+- `<NNN>` — a three-digit zero-padded ordinal, unique within its area.
+
+`FH-PROPS-007` is a **citation**, not a description: spec prose, fixture files,
+test names, tool output, review conversation, and release evidence all name the
+law by id. Ids are therefore permanent — they are never renumbered, never
+reassigned, and never recycled. A law that is withdrawn keeps its id at status
+`retired` so an old citation resolves to an honest answer instead of dangling.
+
+### Area roster
+
+The roster is fixed by the Freehand programme EP and is not extended by
+implementation work. A law is filed under the area whose **canonical paragraph**
+owns it; when two areas could plausibly hold it, the owning spec decides.
+
+| Token | Area | Scope |
+|---|---|---|
+| `CALL` | Calls | The declared boundary: vector-called descriptors, plain-helper direct calls, statically named children crossing the boundary, `:key`, occurrence identity and hot reload, and the rejected local/effect/ref declaration forms. |
+| `PROPS` | Props | One props map: reserved `:children`, stripped `:key`, shared equality and conversion, and the optional schema's metadata and validation semantics. |
+| `EVENT` | Events | The projection materializer, the options and key-map grammar, site and proxy lifetime, the atomic selected bundle, and the route-link descriptor's href/click behaviour over the routing-owned law. |
+| `INPUT` | Controlled input | The one exact door predicate, the frame-scoped synchronous flush, and the real-browser contention matrix. |
+| `SUB` | Subscriptions | Render-only subscription reads: value, resolution, invalidation, and commit safety; separately named one-shot reads; frame-context observation and the proof a compiled elision demands. |
+| `CTRL` | Controllers | Props-only by default; ordinary frame data keyed by kind plus an explicit address; semantic transitions and owner cleanup. |
+| `PRESENCE` | Presence | One keyed retention, override, timeout, accessibility, and test contract. |
+| `TOPLAYER` | Top layer | The popover/modal desired-state pair, the commit and generation law, structural metadata, and the browser matrix. |
+| `BEHAVIOR` | Behaviors | The id/config/timing/optional-command protocol, commit-only connection, explicit command target, private memory, and the JVM marker and fallback. |
+| `REACT` | React bridges | The descriptor-only outward bridge, common frame and props semantics, the explicit mapper, the SSR policy, and the qualified host boundaries the three host shapes rest on. |
+| `ERROR` | Errors | The boundary, reset, fallback, and safe-intent contract; private frame error egress; and the rule that a failed candidate publishes nothing. |
+| `ROOT` | Roots and SSR | One Root Descriptor: preflight, identity, teardown, multi-root isolation, SSR emission, and hydration. |
+| `STRUCT` | Structure | The versioned semantic tree, the conversion table, and the explicit host policy. |
+| `DIAG` | Diagnostics | The versioned occurrence schema (scope, basis, completeness, loss), stable ids, source and recovery, bounded retention, and provable-only static findings. |
+
+### Allocation rule
+
+1. Choose the area whose canonical paragraph owns the law.
+2. Take the next number after the highest already allocated **in that area** —
+   including retired ones. Numbers within an area are dense and ascending;
+   gaps are only ever created by a mistake, never by a deletion.
+3. Append the row to that area's section in the index. One section per area
+   keeps concurrent slices out of each other's diffs.
+4. Land the row in the same change as the spec paragraph it cites. A row whose
+   anchor does not yet exist fails the validator, which is the point: an id is
+   an address, and an address to nowhere is not one.
+
+## The index
+
+Every row has six columns, and the validator enforces all six.
+
+| Column | Contract |
+|---|---|
+| Id | `FH-<AREA>-<NNN>`, unique, ascending within its section, area matching its section. |
+| Law | One line, stating what is proven — enough to recognise the row, never enough to replace the spec. |
+| Canonical paragraph | A markdown link into `spec/`, **with an anchor**. This is the normative owner; the row is its address, not a second copy of it. |
+| Applicability | Which modes and hosts the law binds (grammar below). |
+| Fixture | The fixture path when the row is `active`; `—` otherwise. |
+| Status | `planned`, `active`, or `retired`. |
+
+### Applicability grammar
+
+Two axes, space-separated in one cell — for example `common jvm browser ssr`,
+`compiled browser`, or `common host:vega`.
+
+- **Mode axis — exactly one token.** `common` (the law binds identically in both
+  modes), `interpreted`, or `compiled`.
+- **Host axis — one or more tokens.** `jvm`, `browser`, `ssr`, or
+  `host:<name>` for a law that binds only at a named qualified host boundary
+  (`host:vega`, `host:ag-grid`, …).
+
+A law is proven for every mode/host combination its cell names, and for no
+others. Narrowing the cell narrows the claim, so a narrow cell needs a reason.
+
+### Status vocabulary
+
+| Status | Meaning | Fixture cell |
+|---|---|---|
+| `planned` | The law is fixed and addressed; its fixture is not written yet. | `—` |
+| `active` | The fixture exists and the law is in force. | the fixture path |
+| `retired` | The id is burned so citations stay honest. The law no longer binds. | `—` |
+
+Rows do not carry a pass/fail column. Whether an `active` law is currently green
+is a fact about a run, not about the index; the harness reports it.
+
+### Fixture convention
+
+A fixture path is written repo-relative in backticks, and the filename mirrors
+the id in lower case:
+
+```
+spec/conformance/freehand/fixtures/fh-props-007.edn
+```
+
+The validator only requires that the named file exists. What the file contains,
+which hosts load it, and how results are reported are the testing spec's
+concern (`008-Testing.md`) and the harness's — this directory owns addressing,
+not execution.
+
+## The validator
+
+```bash
+python scripts/check_freehand_conformance_index.py            # validate the index
+python scripts/check_freehand_conformance_index.py --self-test  # prove the gate has teeth
+```
+
+It fails on a duplicate or ill-formed id, a row filed under the wrong area, an
+out-of-order id, a citation whose spec file or anchor does not exist, a citation
+that points outside `spec/`, a missing or misplaced fixture, an unknown
+applicability token or a broken axis, an unknown status, and a section roster
+that no longer matches the area roster above. Each defect names the offending
+row and line. It runs on every pull request.
+
+## What this is not
+
+**Not the donor stage profiles.** The stage profiles at
+[`S3-view-conformance-profile.md`](../S3-view-conformance-profile.md),
+[`S4-view-conformance-profile.md`](../S4-view-conformance-profile.md), and
+[`S5-view-conformance-profile.md`](../S5-view-conformance-profile.md) catalogue
+the frozen surface of the donor compiled-view substrate. They remain useful
+**migration evidence** — they record what the donor froze and which gate proved
+it, which is exactly what an absorption audit needs. They are **not a second
+Freehand conformance authority**: no `FH-*` row is discharged by citing one, no
+Freehand claim rests on one, and nothing in this directory defers to one. When a
+donor obligation crosses into Freehand it arrives as an `FH-*` row citing a
+Freehand-owned spec paragraph, or it does not cross at all.
+
+**Not the cross-host conformance corpus.** The corpus indexed by
+[`../README.md`](../README.md) proves that an implementation of the whole
+framework, in any host language, is a faithful port. Its fixtures carry
+`:fixture/id` keywords and answer a different question. Freehand ids address one
+substrate's two-mode, multi-host parity contract, and the two schemes never
+share an id space.
+
+**Not a fixture runner.** Nothing here executes. Adding a row makes a law
+addressable and citable; making it *run* is the harness's job.

--- a/spec/conformance/freehand/conformance-index.md
+++ b/spec/conformance/freehand/conformance-index.md
@@ -1,0 +1,130 @@
+# Freehand Conformance Index
+
+> **Type:** Reference
+> One row per Freehand executable law. The id scheme, the allocation rule, the
+> column contracts, the applicability grammar, and the status vocabulary are
+> defined in [README.md](README.md) — read it before adding a row.
+
+The index is the single roster of Freehand laws. It is empty at establishment
+and grows one row at a time: each slice that lands a contract appends its own
+rows to its own area section, in the same change as the spec paragraph each row
+cites. Nothing here is normative — every row is an address into `spec/`, plus
+the fixture that proves the paragraph it names.
+
+Row shape, for reference — a template, not an allocation:
+
+```
+| `FH-AREA-NNN` | one line stating what is proven | [00X-Doc.md#anchor](../../00X-Doc.md#anchor) | common jvm browser | `spec/conformance/freehand/fixtures/fh-area-nnn.edn` | active |
+```
+
+## Areas
+
+### FH-CALL — Calls
+
+The declared boundary: descriptors, plain helpers, children, `:key`, occurrence
+identity, hot reload, rejected declaration forms.
+
+| Id | Law | Canonical paragraph | Applicability | Fixture | Status |
+|---|---|---|---|---|---|
+
+### FH-PROPS — Props
+
+One props map: reserved `:children`, stripped `:key`, equality and conversion,
+optional schema semantics.
+
+| Id | Law | Canonical paragraph | Applicability | Fixture | Status |
+|---|---|---|---|---|---|
+
+### FH-EVENT — Events
+
+Projection materializer, options and key-map grammar, site and proxy lifetime,
+the atomic selected bundle, route-link href and click behaviour.
+
+| Id | Law | Canonical paragraph | Applicability | Fixture | Status |
+|---|---|---|---|---|---|
+
+### FH-INPUT — Controlled input
+
+The exact door predicate, the frame-scoped synchronous flush, the browser
+contention matrix.
+
+| Id | Law | Canonical paragraph | Applicability | Fixture | Status |
+|---|---|---|---|---|---|
+
+### FH-SUB — Subscriptions
+
+Render-only reads: value, resolution, invalidation, commit safety; one-shot
+reads; frame-context observation and compiled-elision proof.
+
+| Id | Law | Canonical paragraph | Applicability | Fixture | Status |
+|---|---|---|---|---|---|
+
+### FH-CTRL — Controllers
+
+Props-only default, frame data keyed by kind plus explicit address, semantic
+transitions, owner cleanup.
+
+| Id | Law | Canonical paragraph | Applicability | Fixture | Status |
+|---|---|---|---|---|---|
+
+### FH-PRESENCE — Presence
+
+Keyed retention, override, timeout, accessibility, and test contract.
+
+| Id | Law | Canonical paragraph | Applicability | Fixture | Status |
+|---|---|---|---|---|---|
+
+### FH-TOPLAYER — Top layer
+
+The popover/modal desired-state pair, commit and generation law, structural
+metadata, browser matrix.
+
+| Id | Law | Canonical paragraph | Applicability | Fixture | Status |
+|---|---|---|---|---|---|
+
+### FH-BEHAVIOR — Behaviors
+
+Id/config/timing/optional-command protocol, commit-only connection, explicit
+command target, private memory, JVM marker and fallback.
+
+| Id | Law | Canonical paragraph | Applicability | Fixture | Status |
+|---|---|---|---|---|---|
+
+### FH-REACT — React bridges
+
+Descriptor-only outward bridge, common frame and props semantics, the explicit
+mapper, SSR policy, qualified host boundaries.
+
+| Id | Law | Canonical paragraph | Applicability | Fixture | Status |
+|---|---|---|---|---|---|
+
+### FH-ERROR — Errors
+
+Boundary, reset, fallback, and safe-intent contract; private frame error egress;
+a failed candidate publishes nothing.
+
+| Id | Law | Canonical paragraph | Applicability | Fixture | Status |
+|---|---|---|---|---|---|
+
+### FH-ROOT — Roots and SSR
+
+Root Descriptor, preflight, identity, teardown, multi-root isolation, SSR
+emission, hydration.
+
+| Id | Law | Canonical paragraph | Applicability | Fixture | Status |
+|---|---|---|---|---|---|
+
+### FH-STRUCT — Structure
+
+The versioned semantic tree, the conversion table, the explicit host policy.
+
+| Id | Law | Canonical paragraph | Applicability | Fixture | Status |
+|---|---|---|---|---|---|
+
+### FH-DIAG — Diagnostics
+
+Versioned occurrence schema, stable ids, source and recovery, bounded retention,
+provable-only static findings.
+
+| Id | Law | Canonical paragraph | Applicability | Fixture | Status |
+|---|---|---|---|---|---|


### PR DESCRIPTION
EP-0036 slice F0b (rf2-drpa3.12). Establishes `spec/conformance/freehand/` as the addressing home for Freehand's executable laws. No rows are allocated: this bead fixes the scheme, the roster, the index shape, and the gate that keeps them honest. Each later slice appends its own rows.

## What landed

**`spec/conformance/freehand/README.md`** — the scheme.

- `FH-<AREA>-<NNN>`: fixed prefix, one token from a closed 14-area roster, a three-digit ordinal unique within its area. An id is a permanent citation, so ids are never renumbered, reassigned, or recycled; a withdrawn law keeps its id at status `retired` so old citations resolve instead of dangling.
- The area roster fixed by EP-0036 — `CALL`, `PROPS`, `EVENT`, `INPUT`, `SUB`, `CTRL`, `PRESENCE`, `TOPLAYER`, `BEHAVIOR`, `REACT`, `ERROR`, `ROOT`, `STRUCT`, `DIAG` — each with a scope line that absorbs the codex §6 parity surfaces it covers (identity/HMR and children under `CALL`, frame observation and compiled elision under `SUB`, route-link under `EVENT`, the three host shapes under `REACT`, and so on), so allocation is unambiguous without a second roster to drift.
- The allocation rule: pick the area whose canonical paragraph owns the law, take the next ordinal in that area, append to that area's section, and land the row in the same change as the paragraph it cites.
- Applicability is two axes in one cell — **exactly one** mode token (`common` / `interpreted` / `compiled`) plus **one or more** host tokens (`jvm` / `browser` / `ssr` / `host:<name>` for a qualified host boundary). That covers all seven forms the bead requires.
- Status vocabulary `planned` / `active` / `retired`, each with its fixture-cell obligation. There is deliberately no pass/fail column: greenness is a fact about a run, not about the index.
- The donor stage profiles (`spec/conformance/S3/S4/S5-view-conformance-profile.md`) are stated to remain **migration evidence** and explicitly **not a second Freehand conformance authority** — no `FH-*` row is discharged by citing one, and a donor obligation crosses only as an `FH-*` row citing a Freehand-owned spec paragraph. The cross-host conformance corpus (`spec/conformance/README.md`) is likewise distinguished: different question, different id space. And nothing here executes — the runner is a later slice's.

**`spec/conformance/freehand/conformance-index.md`** — the index. One `### FH-<AREA>` section per roster area, each carrying its pinned six-column header (`Id | Law | Canonical paragraph | Applicability | Fixture | Status`) and zero rows. One section per area keeps concurrent slices out of each other's diffs.

**`scripts/check_freehand_conformance_index.py`** — the validator. Fails on a duplicate, ill-formed, misfiled, or out-of-order id; a citation that is not a markdown link, carries no anchor, names a missing file, names a missing anchor, or resolves outside `spec/`; a missing fixture on an `active` row or a fixture on a non-active row; a broken applicability axis or unknown token; an unknown status; a wrong column count; a row before the first section; a drifted table header; and any unknown, duplicate, or missing area section. Every defect names the offending row and line. Anchors resolve through `check_doc_slugs.py`'s slug index rather than a second slugifier, so an `FH` citation resolves under exactly the rule that governs every other link in the corpus.

**`.github/workflows/freehand-conformance.yml`** — a NEW workflow (no existing workflow file was touched). Unfiltered `pull_request` trigger with a single always-present job, so the `Freehand conformance index` context is on every PR and can be required without the phantom-pending trap; no aggregator, because there is nothing to aggregate. Self-test first, then the live scan — the house shape.

## Non-vacuity: the validator discriminates

The index is empty at merge, so "it passed" proves nothing on its own. Two proofs.

**1. Deliberately broken rows.** Two temp rows were appended to the `FH-PROPS` section: the second reuses the first's id **and** cites an anchor that does not exist in `spec/004-Views.md`.

```
--- injected rows (bogus anchor + duplicate id) ---
| Id | Law | Canonical paragraph | Applicability | Fixture | Status |
|---|---|---|---|---|---|
| `FH-PROPS-001` | one props map reaches the view | [004-Views.md#template-grammar](../../004-Views.md#template-grammar) | common jvm browser | — | planned |
| `FH-PROPS-001` | `:key` is stripped before props reach the view | [004-Views.md#no-such-paragraph](../../004-Views.md#no-such-paragraph) | common jvm browser | — | planned |

--- validator run ---

2 Freehand conformance-index defect(s) found:

  DUPLICATE ID: spec/conformance/freehand/conformance-index.md:38 [FH-PROPS-001] already allocated at line 37
  BROKEN CITATION: spec/conformance/freehand/conformance-index.md:38 [FH-PROPS-001] `../../004-Views.md#no-such-paragraph` - spec/004-Views.md has no anchor #no-such-paragraph

Fix: see spec/conformance/freehand/README.md - an FH id is a permanent address, so it must be well-formed, unique, filed under its own area, and resolve to a real spec paragraph and (when active) a real fixture.
EXIT=1
```

Both defects fire, both name the offending row and its line. The temp rows were then removed:

```
--- temp rows removed ---
--- validator run ---
Freehand conformance index OK: 0 row(s) across 14 area section(s).
EXIT=0
```

**2. Twenty-nine hermetic self-tests**, run in CI before the live scan. Four green cases (a real row, the *empty* index this slice ships, a `planned` row, a `host:<name>` row) and twenty-five each carrying exactly one deliberate defect — duplicate id, ill-formed id, unknown area in an id, area mismatch, out-of-order id, citation not a link / no anchor / missing file / missing anchor / outside `spec/`, missing fixture, absent fixture on `active`, fixture on `planned`, unknown applicability token, two modes, no host, no mode, bad status, wrong column count, empty law, missing / unknown / duplicate area section, drifted table header, orphan row. Each fixture is a generated mini-repo in a temp dir; nothing is left in the tree.

## Quality gates

| Gate | Result |
|---|---|
| `python scripts/check_freehand_conformance_index.py --self-test --verbose` | **0** — all 29 self-tests passed |
| `python scripts/check_freehand_conformance_index.py --verbose` (clean index) | **0** — `0 row(s) across 14 area section(s)` |
| `python scripts/check_freehand_conformance_index.py --verbose` (broken rows injected) | **1** — 2 defects, both naming the row (transcript above) |
| `python scripts/check_doc_slugs.py --verbose` | **0** — 586 markdown files, no broken links |
| `python -m mkdocs build --strict` | **0** — built in 19.4s (`mkdocs` is not on PATH here; `python -m` is) |
| `python scripts/check_readme_inventories.py` | **0** |
| `python scripts/check_readme_links.py` | **0** |
| `python scripts/check_ep_status_sync.py` | **0** |
| `sh scripts/check-no-hardcoded-paths.sh` | **0** |

## Scope notes

- No rows allocated. No fixture runner. No donor profile moved, edited, or deleted.
- No existing `.github/workflows/*` file was edited — the gate is a new workflow, leaving the workflow-wiring hot zone free for the parallel donor-inventory slice.
- Nothing under `spec/004*`, `spec/Ownership.md`, `spec/API.md`, `spec/Conventions.md`, `mkdocs.yml`, `implementation/**`, or `spec/conformance/freehand/donor-inventory.md` was touched.
- The index citation column links only within `spec/` (relative `../../<doc>.md#anchor`), which resolves identically in the source tree and in the staged mkdocs tree — a depth-3 link out to `docs/` would not, and `--strict` would red.
