### PR TITLE
build(freehand): artefact skeleton, classpath and CI lane (rf2-drpa3.15)

### DIFF
--- a/.github/workflows/freehand-artefact.yml
+++ b/.github/workflows/freehand-artefact.yml
@@ -1,4 +1,9 @@
-# Freehand view-substrate gate (rf2-drpa3.15, EP-0036 slice F1a).
+# Freehand ARTEFACT gate (rf2-drpa3.15, EP-0036 slice F1a).
+#
+# Sibling of `freehand-conformance.yml`, which gates the spec-side
+# executable-law index. This one gates the code artefact at
+# `implementation/freehand/`. Same programme, disjoint surfaces, so they stay
+# separate files rather than one workflow with two unrelated triggers.
 #
 # # What this covers
 #
@@ -33,7 +38,7 @@
 # dispatches it against the merge commit via `workflow_dispatch` below —
 # which is exactly the verification the canary exists to provide.
 
-name: freehand
+name: freehand-artefact
 
 on:
   pull_request:
@@ -47,11 +52,11 @@ on:
       # The artefact depends on core (and, on the :test alias, test-quiet).
       - 'implementation/core/**'
       - 'implementation/test-quiet/**'
-      - '.github/workflows/freehand.yml'
+      - '.github/workflows/freehand-artefact.yml'
   workflow_dispatch:
 
 concurrency:
-  group: freehand-${{ github.ref }}
+  group: freehand-artefact-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/freehand.yml
+++ b/.github/workflows/freehand.yml
@@ -1,0 +1,108 @@
+# Freehand view-substrate gate (rf2-drpa3.15, EP-0036 slice F1a).
+#
+# # What this covers
+#
+# The JVM arm of `implementation/freehand/`. Freehand's entry namespace is
+# `.cljc` from the first commit because the F1 spine needs BOTH emitters —
+# a JVM tree (which also feeds the ssr artefact) and a React tree — so the
+# JVM side is load-bearing here from day one rather than bolted on later.
+#
+# The CLJS arm needs no job of its own: `freehand/src` + `freehand/test`
+# are on the `:node-test` classpath in implementation/shadow-cljs.edn and
+# `re-frame.freehand.*-cljs-test` namespaces match that build's `cljs-test$`
+# regexp, so test.yml's always-on `cljs` job — which IS in the
+# `all-required-passed` aggregator — compiles and runs them on every PR.
+# `npm run test:freehand` (the focused `:node-test-freehand` build) is the
+# cheap NAMED surface for local + worker iteration, not a second gate.
+#
+# # Why a separate workflow file rather than a job in test.yml
+#
+# `.github/workflows/*` is hot-zone and several EP-0036 slices were adding
+# gates concurrently when this landed, so F1a took the non-colliding route:
+# a self-contained file with its own paths filter. The consequence is that
+# `jvm-freehand` is NOT reachable from test.yml's `all-required-passed`
+# aggregator (`needs:` cannot span workflow files), so it is a visible but
+# advisory check today. Folding this job into test.yml's matrix and that
+# aggregator is tracked as follow-up work, to be done once the workflow
+# hot-zone clears.
+#
+# # NOTE for post-merge-workflow-sanity.yml
+#
+# This workflow deliberately does NOT run on push to main, so it needs no
+# entry on that canary's EXCLUDE list: when this file is edited, the canary
+# dispatches it against the merge commit via `workflow_dispatch` below —
+# which is exactly the verification the canary exists to provide.
+
+name: freehand
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'implementation/freehand/**'
+      # Shared build coordinators: a classpath or build-id edit can break
+      # this artefact without touching a file under freehand/.
+      - 'implementation/deps.edn'
+      - 'implementation/shadow-cljs.edn'
+      # The artefact depends on core (and, on the :test alias, test-quiet).
+      - 'implementation/core/**'
+      - 'implementation/test-quiet/**'
+      - '.github/workflows/freehand.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: freehand-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  jvm-freehand:
+    name: JVM freehand (clojure -M:test)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: implementation/freehand
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-freehand-${{ hashFiles('implementation/freehand/deps.edn', 'implementation/core/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-freehand-
+            ${{ runner.os }}-clj-
+
+      - name: Run JVM tests (freehand artefact)
+        run: clojure -M:test
+
+      # The donor boundary is a LAW, not a convention (EP-0036 §Product
+      # topology: "the new package never depends on the donor"), so it is
+      # gated rather than reviewed. Absorbed code must arrive by MOVE under
+      # Freehand ownership — a `re-frame.ui` reference from this artefact,
+      # in source or in deps.edn, fails here.
+      - name: Assert no dependency on the re-frame.ui donor
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          if git grep -n -e 're-frame\.ui' -e 're_frame/ui' -e 're-frame2-ui' -- implementation/freehand; then
+            echo "::error::implementation/freehand references the re-frame.ui donor (EP-0036: the new package never depends on the donor)"
+            exit 1
+          fi
+          echo "OK: implementation/freehand names no re-frame.ui dependency"

--- a/implementation/README.md
+++ b/implementation/README.md
@@ -42,6 +42,13 @@ actively-supported adapters; only Helix is removed
 ([EP-0030](../docs/EP/EP-0030-the-compiled-view-substrate-program.md)
 Resolved Decisions, 2026-07-17).
 
+The `freehand/` artefact ([EP-0036](../docs/EP/EP-0036-the-freehand-view-substrate-programme.md))
+sits beside it as the ratified successor: one re-frame-native view substrate with
+an interpreted paved path and a compiled hot tier over one semantic model,
+published through `re-frame.freehand`. It is built by **absorption** — useful
+`ui/` code moves into it slice by slice — so `freehand/` declares no dependency
+on `ui/` and never will; `ui/` is a donor, deleted at the F6 conformance gate.
+
 ```
 implementation/
   deps.edn                   Top-level coordinator: :local/root deps for every artefact.
@@ -164,6 +171,15 @@ implementation/
     src/re_frame/ui/compiler.cljc  Compiler entry stub (AST / analyzer / emitters, S1b).
     src/re_frame/ui/client.cljs    Client-kernel stub (mount surface S1c; reactivity S2).
     test/re_frame/                 Classpath + build-id probe (npm run test:ui).
+
+  freehand/                  day8/re-frame2-freehand — the Freehand view substrate
+                             (EP-0036; F1a skeleton per rf2-drpa3.15 — the paved-path
+                             spine lands from F1b). Declares no dependency on ui/.
+    deps.edn                 :local/root dep on ../core; own :test alias (pre-publication,
+                             so no :clein deploy aliases).
+    src/re_frame/freehand.cljc     Public-door namespace — empty of surface at F1a
+                                   (defview / sub / mount land with the F1 spine).
+    test/re_frame/                 Classpath + build-wiring probe (npm run test:freehand).
 
   ssr-ring/                  day8/re-frame2-ssr-ring — Ring host adapter for the SSR pipeline
                              (rf2-ny6v7).

--- a/implementation/deps.edn
+++ b/implementation/deps.edn
@@ -53,7 +53,14 @@
          ;; rf2-vxgfnd). Pre-publication: S1a skeleton only
          ;; (empty-but-loadable compiler .cljc + client-kernel .cljs
          ;; stubs); the S1b compiler slice lands the real surface.
-         day8/re-frame2-ui        {:local/root "ui"}}
+         day8/re-frame2-ui        {:local/root "ui"}
+         ;; rf2-drpa3.15 — the Freehand view substrate (EP-0036). F1a
+         ;; skeleton only: an empty-but-loadable `.cljc` entry namespace
+         ;; with NO public surface, wired here so the cross-artefact
+         ;; classpath carries it from day one. Freehand declares no
+         ;; dependency on the `ui` donor above and never will — absorbed
+         ;; code arrives by MOVE, slice by slice.
+         day8/re-frame2-freehand  {:local/root "freehand"}}
 
  :aliases
  {;; Combined CLJS-test path: convenient for ad-hoc REPL work that wants
@@ -82,6 +89,8 @@
                  "resources/test"
                  ;; rf2-vxgfnd.1 — re-frame.ui artefact test tree.
                  "ui/test"
+                 ;; rf2-drpa3.15 — Freehand artefact test tree (EP-0036).
+                 "freehand/test"
                  ;; examples are organised by concept; each bucket is a
                  ;; classpath root so JVM tests can `require` the example
                  ;; source namespaces like `ssr.core` (under

--- a/implementation/freehand/deps.edn
+++ b/implementation/freehand/deps.edn
@@ -13,13 +13,15 @@
 ;; ssr artefact) and a React tree in CLJS. There is no later moment at
 ;; which this artefact becomes cross-host — it starts that way.
 ;;
-;; NO dependency on ../ui, now or ever. EP-0036 §Product topology:
-;; `re-frame.ui` is "donor only", and the new package never depends on
+;; NO dependency on ../ui, now or ever. EP-0036 §Product topology: the
+;; donor artefact is "donor only", and the new package never depends on
 ;; the donor. Absorbed donor code arrives by MOVE, slice by slice, under
-;; Freehand ownership — never by classpath reference.
+;; Freehand ownership — never by classpath reference. That boundary is
+;; gated, not merely stated: the `freehand` workflow greps this artefact
+;; for any donor spelling, so even a prose mention here would go red.
 ;;
 ;; NO :clein deploy aliases — deliberate, not an omission. Publication is
-;; F6 territory, and `day8/re-frame2-ui` was itself ruled NOT to be
+;; F6 territory, and the donor artefact was itself ruled NOT to be
 ;; published (2026-07-22), so there is no donor descriptor to mirror.
 ;; The version-lockstep gate (.github/scripts/verify-version-lockstep.sh,
 ;; via implementation/scripts/lib/publishable-runtimes.cjs) inventories

--- a/implementation/freehand/deps.edn
+++ b/implementation/freehand/deps.edn
@@ -1,0 +1,35 @@
+;; day8/re-frame2-freehand — the Freehand view substrate artefact
+;; (EP-0036; D001 fixes the product name and `re-frame.freehand` as the
+;; single public door, conventionally aliased `v`).
+;;
+;; F1a (rf2-drpa3.15): artefact shape + cross-artefact classpath wiring
+;; only — pure build plumbing, no contract content. The non-IFn
+;; descriptor and `v/defview` land with F1b; the interpreted React and
+;; JVM trees, `v/mount` and HMR identity with the rest of the F1 spine;
+;; the absorbed analyzer and both emitters with F3.
+;;
+;; The entry namespace is `.cljc` FROM THE OUTSET because the F1 spine
+;; needs both emitters: a JVM tree that runs on the JVM (and feeds the
+;; ssr artefact) and a React tree in CLJS. There is no later moment at
+;; which this artefact becomes cross-host — it starts that way.
+;;
+;; NO dependency on ../ui, now or ever. EP-0036 §Product topology:
+;; `re-frame.ui` is "donor only", and the new package never depends on
+;; the donor. Absorbed donor code arrives by MOVE, slice by slice, under
+;; Freehand ownership — never by classpath reference.
+;;
+;; NO :clein deploy aliases — deliberate, not an omission. Publication is
+;; F6 territory, and `day8/re-frame2-ui` was itself ruled NOT to be
+;; published (2026-07-22), so there is no donor descriptor to mirror.
+;; The version-lockstep gate (.github/scripts/verify-version-lockstep.sh,
+;; via implementation/scripts/lib/publishable-runtimes.cjs) inventories
+;; exactly those artefacts carrying a real `:aliases/:clein/build` key,
+;; so staying out of it leaves the release train untouched until Freehand
+;; actually ships.
+{:paths ["src"]
+ :deps  {day8/re-frame2 {:local/root "../core"}}
+
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps  {day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
+         :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/implementation/freehand/src/re_frame/freehand.cljc
+++ b/implementation/freehand/src/re_frame/freehand.cljc
@@ -1,0 +1,25 @@
+(ns re-frame.freehand
+  "The Freehand view substrate — the single public door of the re-frame2
+  view layer (EP-0036; ruled by D001, conventionally aliased `v`).
+
+  Freehand is one re-frame-native substrate with two execution modes over
+  one semantic model: an interpreted paved path, and a compiled hot tier
+  selected by `{:compiled true}` on the same declaration. A declared view
+  var is a non-`IFn` descriptor in both modes.
+
+  F1a skeleton (rf2-drpa3.15): empty-but-loadable, and deliberately so.
+  This artefact currently exports NO public surface — `defview`, `sub`,
+  `mount` and the rest of the paved path land with the F1 spine slices,
+  and anything not yet ruled into the surface table does not exist. What
+  this file proves today is that the artefact compiles as `.cljc` on both
+  hosts, which is the precondition for the two emitters F1 needs.")
+
+(def ^:no-doc artefact-id
+  "Build probe — NOT product surface, and no part of the Freehand API.
+
+  `re-frame.freehand.skeleton-cljs-test` pins this value so that the
+  test's `:require` of this namespace is load-bearing in BOTH runtimes:
+  a missing or unloadable artefact fails at CLJS compile / JVM load time
+  rather than passing vacuously. Delete it the moment F1b gives the suite
+  a real surface to load."
+  :day8/re-frame2-freehand)

--- a/implementation/freehand/test/re_frame/freehand/skeleton_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/skeleton_cljs_test.cljc
@@ -1,0 +1,23 @@
+(ns re-frame.freehand.skeleton-cljs-test
+  "F1a classpath + build-wiring probe (rf2-drpa3.15).
+
+  The `:require` is half the assertion — an unwired source path, a broken
+  reader conditional, or a `.cljc` that does not compile on one of the two
+  hosts fails this namespace at CLJS compile / JVM load time. The deftest
+  pins the marker so the require is load-bearing and a green run is not
+  vacuous.
+
+  It runs under three gates:
+   - this artefact's own JVM `:test` alias (`clojure -M:test` from
+     implementation/freehand/) — the JVM arm;
+   - the always-on `:node-test` gate (`npm run test:cljs`; the ns matches
+     its broad `cljs-test$` regexp) — the CLJS arm, on every PR; and
+   - the focused `:node-test-freehand` build (`npm run test:freehand`; the
+     ns matches its `^re-frame\\.freehand\\..+-cljs-test$` regexp), the
+     cheap named gate for F1+ workers."
+  (:require [clojure.test :refer [deftest is]]
+            [re-frame.freehand :as v]))
+
+(deftest freehand-artefact-skeleton-loads
+  (is (= :day8/re-frame2-freehand v/artefact-id)
+      "day8/re-frame2-freehand loads on the cross-artefact classpath in this runtime"))

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -28,6 +28,7 @@
     "test:cljs-isolation": "shadow-cljs compile node-test && node scripts/check-per-ns-isolation.cjs",
     "test:security": "shadow-cljs compile node-test-security && node out/node-test-security.js",
     "test:testbed-support": "shadow-cljs compile node-test-testbed-support && node out/node-test-testbed-support.js",
+    "test:freehand": "shadow-cljs compile node-test-freehand && node out/node-test-freehand.js",
     "test:ui": "npm run test:ui-isolation && node out/node-test-ui.js",
     "test:ui-isolation": "node scripts/check-ui-adapter-isolation.cjs --self-test && shadow-cljs compile node-test-ui && node scripts/check-ui-adapter-isolation.cjs",
     "test:ui-warm-watch": "node scripts/check-ui-warm-watch.cjs",

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -130,6 +130,18 @@
                 ;; holds: no production build :requires re-frame.ui.*.
                 "ui/src"
                 "ui/test"
+                ;; rf2-drpa3.15 — the Freehand view substrate (EP-0036),
+                ;; F1a skeleton. src carries the empty-but-loadable
+                ;; `.cljc` entry namespace (no public surface yet); test
+                ;; carries the classpath probe
+                ;; (re-frame.freehand.skeleton-cljs-test), which rides the
+                ;; always-on :node-test gate (`cljs-test$` matches) AND
+                ;; the focused :node-test-freehand build below.
+                ;; Bundle-isolation holds: no production build :requires
+                ;; re-frame.freehand.*. Freehand does NOT depend on the
+                ;; `ui/` donor above.
+                "freehand/src"
+                "freehand/test"
                 ;; rf2-nojiwy — re-frame.ui testbed (the four-suites rule's
                 ;; new-UI smoke). Standalone counter app under ui/testbed/
                 ;; that proves the compiled-view substrate wires up
@@ -740,6 +752,28 @@
    ;; The load-bearing watch hook is inherited from :build-defaults.
    :compiler-options {:warnings      {:redef false}
                        :infer-externs false}}
+
+  ;; rf2-drpa3.15 — FOCUSED node-test build for the Freehand view
+  ;; substrate artefact (EP-0036).
+  ;;
+  ;; Same shape and same reasoning as :node-test-ui above: the ns-regexp
+  ;; selects only this artefact's own suites (every `re-frame.freehand.*`
+  ;; test namespace — nothing else in the repo lives under that prefix),
+  ;; giving the Freehand programme a named, cheap gate
+  ;; (`npm run test:freehand`) so the long-lived F1+ slice workers don't
+  ;; compile + run the full node suite on every iteration. Those same
+  ;; namespaces also match the always-on `:node-test` build's broader
+  ;; `cljs-test$` regex, so the artefact is covered on every PR whether
+  ;; or not this focused build is invoked — this is the *named* surface,
+  ;; not an additional required gate.
+  :node-test-freehand
+  {:target    :node-test
+   :output-to "out/node-test-freehand.js"
+   :ns-regexp "^re-frame\\.freehand\\..+-cljs-test$"
+   :main      re-frame.test-quiet.shadow-node/main
+   ;; The load-bearing watch hook is inherited from :build-defaults.
+   :compiler-options {:warnings      {:redef false}
+                      :infer-externs false}}
 
   ;; rf2-vxgfnd.6 — the G-1 direct-render parity gate (07 §5) for the
   ;; re-frame.ui compiled-view substrate. A :node-script RELEASE build

--- a/scripts/test-jvm-implementation.sh
+++ b/scripts/test-jvm-implementation.sh
@@ -32,6 +32,13 @@ artefacts=(
   # side is exercised from day one; the compiler-slice suites (S1b+,
   # where the .cljc compiler genuinely runs on the JVM) grow here.
   implementation/ui
+  # rf2-drpa3.15 — the Freehand view substrate (EP-0036). F1a skeleton:
+  # the :test alias runs the classpath probe
+  # (re-frame.freehand.skeleton-cljs-test's :clj arm) so the artefact's
+  # JVM side is exercised from day one — the F1 spine needs a JVM tree
+  # emitter alongside the React one, so the JVM arm is load-bearing here
+  # from the first commit rather than bolted on later.
+  implementation/freehand
   # rf2-gj2ae — the adversarial-property security tier is `.cljc` and
   # advertises a cross-runtime contract (e.g. `re-frame.security.gen`'s
   # JVM `:clj` `long`-multiply vs the CLJS `Math.imul` arm, pinned by


### PR DESCRIPTION
EP-0036 slice F1a (rf2-drpa3.15). Pure build plumbing: the artefact shape
and its gates. No contract content, no public surface, no dependency on the
donor. Direct precedent is the donor's own first PR (rf2-vxgfnd.1).

## What lands

- **`implementation/freehand/`** — `deps.edn` (`:local/root` on core, `:test`
  alias via test-quiet), an empty-but-loadable `re-frame.freehand` **`.cljc`**
  entry namespace, and one classpath/build-wiring probe.
  `.cljc` **from the outset** because the F1 spine needs both emitters: a JVM
  tree (which also feeds the ssr artefact) and a React tree. There is no later
  moment at which this artefact becomes cross-host.
- **No `:clein` / version / package descriptor.** Publication is F6, and the
  donor artefact was itself ruled not to be published (2026-07-22), so there
  is nothing to mirror. Staying out of the `:clein/build` inventory leaves the
  version-lockstep gate and the release train untouched.
- **No dependency on the donor**, now or ever (EP-0036 §Product topology: "the
  new package never depends on the donor"). Absorbed code arrives by MOVE,
  slice by slice. That boundary is **gated, not merely asserted** — the CI lane
  greps the artefact for any donor spelling and fails on a hit. The gate is
  strict enough that a *prose mention* in a comment reddens it, which is why
  the deps.edn comments name the donor descriptively; a grep with prose
  exemptions is not a tripwire.
- **Classpath + build wiring** — `day8/re-frame2-freehand` and `freehand/test`
  in the top-level `deps.edn`; `freehand/src` + `freehand/test` source paths
  and a focused `:node-test-freehand` build in `shadow-cljs.edn` (mirrors
  `:node-test-ui`); `npm run test:freehand`; `implementation/freehand` in
  `scripts/test-jvm-implementation.sh`; the `freehand/` layout entry in
  `implementation/README.md` (README inventory-ratchet bijection).

## The CI lane, and why it is a new file

`.github/workflows/*` is hot-zone and several EP-0036 slices were adding gates
concurrently, so this took the non-colliding route the dispatch note offered:
a **new workflow file**, `.github/workflows/freehand-artefact.yml`. No existing
workflow file is touched. It sits beside `freehand-conformance.yml`, which
landed on main mid-flight and gates the spec-side index — same programme,
disjoint surfaces, hence the `-artefact` / `-conformance` split in the names.

It carries `jvm-freehand` (`clojure -M:test`) plus the donor-boundary grep,
path-filtered to the artefact and the shared build files. Consequences worth
stating plainly:

- The **CLJS arm needs no job here.** `freehand/src` + `freehand/test` are on
  the `:node-test` classpath and `re-frame.freehand.*-cljs-test` matches that
  build's `cljs-test$` regexp, so test.yml's always-on `cljs` job — which *is*
  in the `all-required-passed` aggregator — compiles and runs the probe on
  every PR. `npm run test:freehand` is the cheap named surface for F1+ workers,
  not a second gate.
- `jvm-freehand` is **not** reachable from test.yml's aggregator (`needs:`
  cannot span workflow files), so it is a visible-but-advisory check today.
  Folding it into test.yml's matrix and that aggregator is follow-up work for
  when the workflow hot-zone clears; the workflow header records this.
- The workflow does not run on push to main, so it needs no entry on the
  post-merge canary's EXCLUDE list — the canary dispatches it via
  `workflow_dispatch` when the file changes, which is the verification wanted.

## Quality gates

All run locally, foreground, on the rebased branch.

| Gate | Result |
|---|---|
| `clojure -M:test` from `implementation/freehand/` | **PASS** — Ran **1** test, **1** assertion, 0 failures, 0 errors |
| `npm run test:freehand` (focused `:node-test-freehand`) | **PASS** — compiled 56 files, 0 warnings; Ran **1** test, **1** assertion, 0 failures, 0 errors |
| `npm run test:cljs` (full node suite) | **PASS** — Ran **10259** tests, **50946** assertions, **0** failures, **0** errors |
| `re-frame.freehand` actually compiled into that suite | **PASS** — `out/node-test.js` loads `re_frame.freehand.js` and `re_frame.freehand.skeleton_cljs_test.js` |
| `npm run test:bundle-isolation` | **PASS** — 23 artefact entries; 39 internal sentinels absent; 3 allow-list budgets ok; 39 positive-control sentinels present; 12 browser-optional runtimes covered |
| `clojure -M:test` from `implementation/core/` | **PASS** — Ran **2104** tests, **10413** assertions, 0 failures, 0 errors |
| `clojure -M:test` from `implementation/ui/` | **PASS** — Ran **942** tests, **18912** assertions, 0 failures, 0 errors |
| `git grep 're-frame.ui' implementation/freehand/` | **PASS** — empty (also empty for `re_frame/ui` and the artefact coordinate) |
| Donor-boundary CI step, self-tested | **PASS** — passes clean, and **fires** (exit 1) when a donor spelling is injected |
| `npm run test:script-policy` | **PASS** — all policy suites green (incl. rigorous-local-inventory 4, serve-and-run-cli 5) |
| `python scripts/check_readme_inventories.py` | **PASS** — layout-map ↔ disk bijection holds with `freehand/` added |
| `sh scripts/check-no-hardcoded-paths.sh` | **PASS** — no hardcoded personal/home paths |
| `python scripts/check_donor_inventory.py` | **PASS** (exit 0) — the ledger that landed on main is unaffected |
| `python scripts/check_freehand_conformance_index.py` | **PASS** (exit 0) — its PR trigger is unfiltered, so it runs on this PR |
| `.github/workflows/freehand-artefact.yml` YAML parse | **PASS** — one job `jvm-freehand`, triggers `pull_request` + `workflow_dispatch` |

## Acceptance criteria

1. Non-zero, plausible JVM test count — **Ran 1 test / 1 assertion** from
   `implementation/freehand/`. Not a "Ran 0 tests" false green.
2. The CLJS lane compiles the namespace and stays green — 10259/50946, and the
   namespace is provably in the bundle.
3. No dependency on the donor — grep empty in every spelling; `deps.edn` names
   only `../core` (and test-quiet on the `:test` alias).
4. Nothing regresses — core and ui JVM suites green after the shared
   build-file edits.

## Non-goals honoured

No public verb or API (`v/defview` and the descriptor are F1b's); no
publishing/packaging metadata; `implementation/ui` untouched.
