### PR TITLE
fix(ci): restore nightly expensive-tests to green (rf2-wh5to)

### DIFF
--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -70,20 +70,72 @@ jobs:
       - name: Install Playwright (Chromium + system deps)
         run: npx playwright install --with-deps chromium
 
-      - name: Run rigorous implementation browser and bundle gates
-        run: |
-          set -euo pipefail
-          npm run test:browser
-          npm run test:browser-schemas-boundary-prod
-          npm run test:browser-prod-elision
-          npm run test:elision
-          npm run test:bundle-isolation
-          npm run test:reagent-slim:bundle-isolation
-          npm run test:adapter-smokes
-          npm run test:story-feature-load
-          npm run test:story-play-scripts
-          npm run test:xray-feature-gate
-          npm run test:story-static
+      # rf2-wh5to — the eleven gates below used to be ONE unnamed
+      # `set -euo pipefail` step. That structure is why the
+      # 2026-07-08..07-21 nightly outage cost fourteen red nights and TWO
+      # repair rounds instead of one:
+      #
+      #   - A `set -e` chain aborts at the FIRST failing gate, so every
+      #     later gate is simply not run. `test:story-feature-load` broke
+      #     on 07-08 and `test:story-static` broke on 07-13, but the
+      #     second was invisible until the first was fixed on 07-21 —
+      #     the 07-21 nightly then went red on a bug that had been live
+      #     for eight nights, costing another day of the alpha clock.
+      #   - Because the step had no `name:`, `gh run view --log-failed`
+      #     labelled every line of the blob `UNKNOWN STEP`, so even
+      #     identifying WHICH gate failed meant reading a 2000-line log.
+      #
+      # One named step per gate, each `if: ${{ !cancelled() }}`, so a red
+      # night names the failing gate in the Actions UI and reports EVERY
+      # broken gate in that one night. The gates are independent (each
+      # builds and tears down its own artefacts and servers), the job
+      # still fails if any one of them fails, and nothing here is
+      # skipped, retried, softened or allow-listed — only the reporting
+      # changes. The extra CI minutes are spent only on already-red
+      # nightly runs.
+      - name: Gate — browser tests (test:browser)
+        if: ${{ !cancelled() }}
+        run: npm run test:browser
+
+      - name: Gate — schemas boundary, production build (test:browser-schemas-boundary-prod)
+        if: ${{ !cancelled() }}
+        run: npm run test:browser-schemas-boundary-prod
+
+      - name: Gate — production elision, browser (test:browser-prod-elision)
+        if: ${{ !cancelled() }}
+        run: npm run test:browser-prod-elision
+
+      - name: Gate — production elision probe (test:elision)
+        if: ${{ !cancelled() }}
+        run: npm run test:elision
+
+      - name: Gate — tools must not leak into production bundles (test:bundle-isolation)
+        if: ${{ !cancelled() }}
+        run: npm run test:bundle-isolation
+
+      - name: Gate — reagent-slim bundle isolation (test:reagent-slim:bundle-isolation)
+        if: ${{ !cancelled() }}
+        run: npm run test:reagent-slim:bundle-isolation
+
+      - name: Gate — per-adapter mount/dispatch smokes (test:adapter-smokes)
+        if: ${{ !cancelled() }}
+        run: npm run test:adapter-smokes
+
+      - name: Gate — Story feature-load (test:story-feature-load)
+        if: ${{ !cancelled() }}
+        run: npm run test:story-feature-load
+
+      - name: Gate — Story play scripts (test:story-play-scripts)
+        if: ${{ !cancelled() }}
+        run: npm run test:story-play-scripts
+
+      - name: Gate — Xray feature matrix (test:xray-feature-gate)
+        if: ${{ !cancelled() }}
+        run: npm run test:xray-feature-gate
+
+      - name: Gate — Story static export (test:story-static)
+        if: ${{ !cancelled() }}
+        run: npm run test:story-static
 
   template-emitted-app:
     name: Template emitted-app smoke

--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -81,12 +81,16 @@ jobs:
       #     second was invisible until the first was fixed on 07-21 —
       #     the 07-21 nightly then went red on a bug that had been live
       #     for eight nights, costing another day of the alpha clock.
-      #   - Because the step had no `name:`, `gh run view --log-failed`
-      #     labelled every line of the blob `UNKNOWN STEP`, so even
-      #     identifying WHICH gate failed meant reading a 2000-line log.
+      #   - The blob was also a single step-level result, so nothing —
+      #     not the Actions UI, not the jobs API — recorded WHICH gate
+      #     failed. Finding that out meant reading a 2000-line step log.
+      #     (`gh run view --log-failed` prints `UNKNOWN STEP` against
+      #     every line either way; that is a `gh` limitation, not
+      #     something this restructure fixes.)
       #
       # One named step per gate, each `if: ${{ !cancelled() }}`, so a red
-      # night names the failing gate in the Actions UI and reports EVERY
+      # night names the failing gate in the Actions UI and in
+      # `gh api repos/<o>/<r>/actions/runs/<id>/jobs`, and reports EVERY
       # broken gate in that one night. The gates are independent (each
       # builds and tears down its own artefacts and servers), the job
       # still fails if any one of them fails, and nothing here is

--- a/implementation/scripts/_rigorous-local-inventory.test.cjs
+++ b/implementation/scripts/_rigorous-local-inventory.test.cjs
@@ -34,10 +34,11 @@
  * night could only ever reveal ONE broken gate — which is why the
  * 2026-07-08..07-21 nightly outage took two repair rounds and fourteen red
  * nights: `test:story-static` broke on 07-13 but stayed invisible behind
- * `test:story-feature-load` until 07-21. Being unnamed also made
- * `gh run view --log-failed` label the whole blob `UNKNOWN STEP`. One command
- * per named step is therefore load-bearing, not cosmetic, and is pinned here
- * so a later tidy-up cannot silently reintroduce the masking shape.
+ * `test:story-feature-load` until 07-21. The blob was also a single step-level
+ * result, so neither the Actions UI nor the jobs API recorded WHICH gate had
+ * failed. One command per named step is therefore load-bearing, not cosmetic,
+ * and is pinned here so a later tidy-up cannot silently reintroduce the
+ * masking shape.
  *
  * Comment lines are stripped before any parse, so prose mentioning a command
  * can neither satisfy lockstep nor trip the one-command-per-step rule.

--- a/implementation/scripts/_rigorous-local-inventory.test.cjs
+++ b/implementation/scripts/_rigorous-local-inventory.test.cjs
@@ -18,15 +18,29 @@
  * runtime needed, mirroring the test.yml-shape assertions in
  * `_lint-workflow-policy.test.cjs`):
  *
- *  1. Every `npm run test:*` command in the expensive-tests.yml "Run rigorous
- *     implementation browser and bundle gates" step also runs in the local
- *     script (lockstep — the local mirror must not drift BEHIND the nightly
- *     sweep for implementation browser/bundle commands).
+ *  1. Every `npm run test:*` command in the expensive-tests.yml
+ *     `browser-bundle-and-story-gates` job also runs in the local script
+ *     (lockstep — the local mirror must not drift BEHIND the nightly sweep
+ *     for implementation browser/bundle commands).
  *  2. The two inventory commands — `test:examples-compile` and
  *     `test:story-play-scripts` — are present in the local script (a direct
  *     pin, independent of the parse, so neither can silently drop out again).
  *  3. Every command the local script invokes is a real `package.json` script
  *     (catches a typo'd or renamed-away gate).
+ *  4. Each of those nightly commands runs in its OWN named step (rf2-wh5to).
+ *
+ * On (4): the eleven browser/bundle/Story/Xray gates used to be one unnamed
+ * `run: |` block. A `set -e` chain aborts at the first failing gate, so a red
+ * night could only ever reveal ONE broken gate — which is why the
+ * 2026-07-08..07-21 nightly outage took two repair rounds and fourteen red
+ * nights: `test:story-static` broke on 07-13 but stayed invisible behind
+ * `test:story-feature-load` until 07-21. Being unnamed also made
+ * `gh run view --log-failed` label the whole blob `UNKNOWN STEP`. One command
+ * per named step is therefore load-bearing, not cosmetic, and is pinned here
+ * so a later tidy-up cannot silently reintroduce the masking shape.
+ *
+ * Comment lines are stripped before any parse, so prose mentioning a command
+ * can neither satisfy lockstep nor trip the one-command-per-step rule.
  *
  * Wired into `test:script-policy`.
  */
@@ -67,29 +81,65 @@ const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf8'));
 
 const localScripts = npmRunScripts(scriptText);
 
-// Narrow the workflow to the rigorous browser/bundle `run: |` step body: from
-// the named step header to the next `- name:` sibling. Scopes the parse so we
-// only compare against the implementation browser/bundle sweep, not other
-// steps in the file.
-function rigorousSweepStep(text) {
-  const headerRe = /- name: Run rigorous implementation browser and bundle gates\r?\n/;
+// Drop full-line YAML comments. Prose in a comment must not be able to satisfy
+// lockstep, nor to look like a second command inside a gate step.
+function stripComments(text) {
+  return text
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n');
+}
+
+// Narrow the workflow to the `browser-bundle-and-story-gates` job body: from
+// its 2-space-indented job key to the next job key at the same indent. Scopes
+// the parse so we only compare against the implementation browser/bundle
+// sweep, not the template / mcp-live / jvm-slow-tests jobs in the same file.
+const GATES_JOB = 'browser-bundle-and-story-gates';
+
+function gatesJobBody(text) {
+  const headerRe = new RegExp(`\\n {2}${GATES_JOB}:\\r?\\n`);
   const m = headerRe.exec(text);
   assert.notEqual(
     m,
     null,
-    'expensive-tests.yml must carry the "Run rigorous implementation browser and bundle gates" step',
+    `expensive-tests.yml must carry the \`${GATES_JOB}\` job`,
   );
   const rest = text.slice(m.index + m[0].length);
-  const next = rest.search(/\n\s+- name:/);
+  const next = rest.search(/\n {2}[A-Za-z0-9_-]+:\s*\r?\n/);
   return next === -1 ? rest : rest.slice(0, next);
 }
 
-const sweepScripts = npmRunScripts(rigorousSweepStep(workflowText));
+const gatesJobText = stripComments(gatesJobBody(workflowText));
+const sweepScripts = npmRunScripts(gatesJobText);
+
+// Split the job body into step chunks on the 6-space `- ` step bullet.
+function jobSteps(jobText) {
+  return jobText.split(/\n {6}- /).slice(1);
+}
 
 test('expensive-tests.yml sweep is non-empty (parse sanity) (rf2-lm5mu9)', () => {
   assert.ok(
     sweepScripts.size >= 8,
     `expected the rigorous sweep to list many npm scripts, parsed ${sweepScripts.size}`,
+  );
+});
+
+test('every nightly sweep command runs in its own named step (rf2-wh5to)', () => {
+  const offenders = [];
+  for (const step of jobSteps(gatesJobText)) {
+    const commands = [...step.matchAll(/npm run ([A-Za-z0-9:._-]+)/g)].map((m) => m[1]);
+    if (commands.length === 0) continue;
+    const named = /(^|\n\s*)name:\s*\S/.test(step);
+    if (commands.length > 1 || !named) {
+      offenders.push(`${named ? '' : '(unnamed) '}${commands.join(' + ')}`);
+    }
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    'each nightly gate must be the whole body of its OWN named step, so a red night '
+      + 'names the failing gate and reports EVERY broken gate instead of aborting the '
+      + `chain at the first one (rf2-wh5to). Offending step(s): ${offenders.join('; ')}`,
   );
 });
 


### PR DESCRIPTION
rf2-wh5to.

## Root cause — what was actually broken, and since when

The nightly `expensive tests` workflow was red for **fourteen consecutive
scheduled runs**, 2026-07-08 through 2026-07-21. Last green scheduled run:
`28880733495` (2026-07-07). It was never one bug — it was **four independent
breakages**, and the job's structure hid three of them behind the first.

| # | What broke | Since | How it surfaced | Fixed by |
|---|---|---|---|---|
| 1 | `re-frame.story.ui.sidebar/status-dot` null-deref (`status->dot-style-key` was never widened when the status vocab grew to nine on 05-30, `2a12f85f14`) + `set-cell-override` seeding the whole resolved arg map, polluting map-nested edits | 07-08 (`ee9cda6807`) | `test:story-feature-load`, **both** specs, every night of the streak | #6644 (07-21) |
| 2 | `implementation/ssr/deps.edn` `:slow-test` alias missing `day8/re-frame2-ui`, which `:test` had gained | 07-19 (`b24c6ab015`) | `FileNotFoundException` on `re-frame.ui.rules` — the cognitect runner loads every test ns at discovery | #6644 (07-21) |
| 3 | `re-frame.story.sub-overrides/override-provider` read `(.-Provider …)` ungated after `override-context` became nil under `goog.DEBUG=false` | 07-13 (`6521c0cb71`) | `test:story-static` — `Cannot read properties of null (reading 'Provider')` on **every** variant render of the `:story-static/*` release build | #6663 (07-22) |
| 4 | routing `popstate-mid-push-stress` CPU-starvation wall-clock timeout (8 threads reached ~650/5000 iters inside the 120s deref bound) | intermittent | `JVM slow/stress (routing)` | #6656 / rf2-g2ytj |

**All four functional fixes are already on `main`. This PR adds none of them.**
What it fixes is the structural defect that turned a one-round outage into a
two-round, fourteen-night one.

Breakage 3 went live on 07-13 and stayed **invisible for eight nights**, because
`test:story-static` was the eleventh command in a `set -euo pipefail` chain whose
eighth command (`test:story-feature-load`) was already failing. Repairing 1 and 2
on 07-21 did not turn the nightly green — it merely promoted 3 to the visible
failure, and the streak gained a fourteenth night.

## `main` is now green

Full `expensive tests` dispatched against `main` @ `0695cb1ef6`:
**[run 29915191298](https://github.com/day8/re-frame2/actions/runs/29915191298) — 9/9 jobs green**, including the job
that had failed every night of the streak. Per-gate counts in the table below.

## What this PR changes

Two files.

**`.github/workflows/expensive-tests.yml`** — the eleven browser / bundle /
Story / Xray gates were one **unnamed** `run:` block. Two costs:

- **Serial masking.** `set -e` aborts at the first failing gate, so later gates
  never run. One red night could only ever reveal one broken gate — which is
  exactly how an 07-13 regression survived to 07-21.
- **No per-gate result.** The blob was a single step-level pass/fail, so neither
  the Actions UI nor the jobs API recorded *which* gate failed; finding out
  meant reading a 2000-line step log.

Now one named step per gate, each `if: ${{ !cancelled() }}`. A red night names
the failing gate in the Actions UI and in `gh api …/runs/<id>/jobs`, and reports
**every** broken gate at once. The gates are independent — each builds and tears
down its own artefacts and http-servers.

**Nothing is skipped, retried, softened, allow-listed, or given
`continue-on-error`.** The job still fails if any one gate fails. Only the
reporting changes, and the extra minutes are spent solely on nights that were
already red.

> **Honesty correction.** An earlier revision of this PR claimed the split also
> fixed `gh run view --log-failed` printing `UNKNOWN STEP`. Measured against the
> probe run below: it prints `UNKNOWN STEP` either way. That is a `gh`
> limitation, not something this change touches. The committed comments were
> corrected in `9a812b6933`.

**`implementation/scripts/_rigorous-local-inventory.test.cjs`** — see next
section.

## The inventory pin: which side was wrong

Neither, exactly — **the pin's intent was right and is kept; only its parse
anchor was stale.** The guard exists because this repo has repeatedly shipped
gates that silently stopped running, so it was deliberately *not* weakened.

It located the nightly's gate list by matching the literal step name
`Run rigorous implementation browser and bundle gates`. That step is gone
because it *was* the defect — a name for eleven chained commands. The gates it
named all still run, unchanged, one per step.

So the anchor moved up one level, to the shape-independent scope the pin always
meant: the **`browser-bundle-and-story-gates` job**. Net effect on the guard:

| | Before | After |
|---|---|---|
| Lockstep scope | one named step's body | the whole gates **job** — strictly wider (also covers `test:examples-compile`, which the local mirror already ran and test 2 pinned directly) |
| Parse-sanity assert | step must exist | **job** must exist (`M3` below) |
| Comment handling | n/a (scope was a `run:` body) | comment lines stripped before any parse — prose can neither satisfy lockstep nor fake a second command |
| Tests | 4 | **5** |

The added test 4 pins **one command per named step**. That shape is load-bearing
rather than cosmetic — it is the whole subject of this PR — so without a pin the
next tidy-up silently reintroduces the masking shape that cost fourteen nights.
`scripts/test-rigorous-local.sh` needed no change: it already ran all twelve
commands, so lockstep held on the merits.

## Non-vacuity

### The restructure does what it claims

A green run only proves the steps run in order. Proven on a throwaway branch
carrying this exact workflow with gate 1 replaced by `exit 1` and nothing else
changed — [run 29917490854](https://github.com/day8/re-frame2/actions/runs/29917490854):

| Step | Result |
|---|---|
| `Gate — browser tests (test:browser)` | **failure** (deliberate) |
| `Gate — schemas boundary, production build` | success |
| `Gate — production elision, browser` | success |
| `Gate — production elision probe` | success |
| `Gate — tools must not leak into production bundles` | success |
| `Gate — reagent-slim bundle isolation` | success |
| `Gate — per-adapter mount/dispatch smokes` | success |
| `Gate — Story feature-load` | success |
| `Gate — Story play scripts` | success |
| `Gate — Xray feature matrix` | success |
| `Gate — Story static export` | success |
| **Job** | **failure** |

The ten gates after the failing one **all ran and reported their own results**,
and the job still failed. Under the old blob they would not have run at all.

### The pin still has teeth

Mutation-tested against the committed files (each mutation reverted after):

| # | Mutation | Result |
|---|---|---|
| M0 | none (baseline) | `5 passed`, exit 0 |
| M1 | local mirror drops `test:story-static` | **exit 1** — `has drifted BEHIND expensive-tests.yml — missing: test:story-static` |
| M2 | two gates re-collapsed into one blob step | **exit 1** — `each nightly gate must be the whole body of its OWN named step … Offending step(s): test:browser + test:browser-schemas-boundary-prod` |
| M3 | gates job renamed away | **exit 1** — `expensive-tests.yml must carry the \`browser-bundle-and-story-gates\` job` |
| M4 | gate demoted to a YAML comment **and** dropped locally | passes — comment-stripping works: prose creates no phantom obligation (without stripping this would have false-failed) |
| M6 | comment inside a gate step naming another `npm run` | passes — no phantom second command |

## Quality gates

All foreground. All non-zero.

### Local — the previously-failing check

```
$ node implementation/scripts/_rigorous-local-inventory.test.cjs
rigorous-local-inventory tests: 5 passed.
EXIT=0
```

| Gate | Result |
|---|---|
| `_rigorous-local-inventory.test.cjs` (the failing check) | **5** passed, exit 0 |
| full `test:script-policy` chain (27 scripts) | **25** passed, 0 failed; 2 exceeded a 25s local budget |
| `_changed-surfaces.test.cjs` (one of those 2, re-run at 420s — the other guard naming `expensive-tests.yml`) | **183** passed, exit 0 |
| `sh scripts/check-no-hardcoded-paths.sh` | `Portability gate OK` |
| `yaml.safe_load` on the edited workflow | parses; 4 jobs, 20 steps in the gates job, **11/11** gates carry `if: ${{ !cancelled() }}` |

### `main` @ `0695cb1ef6` — [run 29915191298](https://github.com/day8/re-frame2/actions/runs/29915191298), **9/9 jobs green**

| Gate | Result |
|---|---|
| `test:browser` | Ran **480** tests / **2705** assertions — 0 failures, 0 errors |
| `test:browser-schemas-boundary-prod` | Ran **7** tests / **9** assertions — 0 failures, 0 errors |
| `test:browser-prod-elision` | Ran **116** tests / **516** assertions — 0 failures; `ui mounted production elision: PASS` |
| `test:elision` | PASS — production **60/60** absent, control **60/60** present; EP-0023 1/1 provenance + 2/2 assembly-DCE |
| `test:bundle-isolation` | PASS — **23** artefacts, **39** sentinels absent, **39** positive controls present, 12 runtimes covered |
| `test:reagent-slim:bundle-isolation` | PASS — **6** contracts, **25** sentinel checks |
| `test:adapter-smokes` | Ran **3** adapter-smoke specs — 0 failures |
| `test:story-feature-load` | Ran **2** specs — 0 failures ← *red every night 07-08…07-20* |
| `test:story-play-scripts` | Ran **30** `:play-script` rows — 0 unexpected outcomes |
| `test:xray-feature-gate` | Ran **16** scenarios (nightly-full sweep) — 0 failures, 13 matrix rows |
| `test:story-static` | `Story static smoke passed.` ← *red on 07-21* |
| `test:examples-compile` | green |
| JVM slow/stress `core` | Ran **4** tests / **8** assertions |
| JVM slow/stress `routing` | Ran **3** tests / **73** assertions ← *intermittently red in the streak* |
| JVM slow/stress `machines` | Ran **1** test / **35** assertions |
| JVM slow/stress `flows` | Ran **1** test / **60** assertions |
| JVM slow/stress `ssr` | Ran **2** tests / **8** assertions ← *red 07-19…07-20* |
| JVM slow/stress `ssr-ring` | Ran **3** tests / **33** assertions |
| MCP live + client conformance | green (2m17s) |
| Template emitted-app smoke | green (10m30s) |

### The restructured workflow, full suite — [run 29915537802](https://github.com/day8/re-frame2/actions/runs/29915537802), **9/9 jobs green**

All eleven gate steps executed (none skipped), in order:
`test:browser` 1m10s · schemas-boundary 33s · prod-elision 1m38s · elision 1m01s ·
bundle-isolation 2m16s · reagent-slim 34s · adapter-smokes 45s · story-feature-load
5m07s · story-play-scripts 57s · xray-feature-gate 3m05s · story-static 1m23s.

*(Recorded at `304343f337`, before the guard commit and the rebase onto current
`main`; workflow content byte-identical — verified.)*

## Follow-up

Bead acceptance is **two consecutive green scheduled nightlies**, which only the
15:17 UTC cron can supply. Merging a workflow file also fires
`post-merge-workflow-sanity.yml`, which `workflow_dispatch`es
`expensive-tests.yml` against the merge commit within minutes — so the
restructured job gets an immediate independent verification without waiting for
cron.
