### PR TITLE
test(template): close the node_modules-junction and dev-page-boot gate masks (rf2-igwf7)

### DIFF
--- a/tools/template/spec/Principles.md
+++ b/tools/template/spec/Principles.md
@@ -169,7 +169,30 @@ is exercised end-to-end across the layers:
 4. **Behavioural.** `emitted_test_run_test.clj` — compiles and runs
    the emitted `events_test.cljs` end-to-end via shadow-cljs + Node.
    Gated behind `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` (CI sets it; off
-   locally for fast loop).
+   locally for fast loop). Two teeth in this tier exist specifically
+   to keep the in-repo run honest about what an EXTERNAL consumer
+   would see, because the tier's own conveniences would otherwise
+   hide two whole classes of defect:
+   - **Emitted-`package.json` completeness.** The tier junctions
+     `implementation/node_modules` into every emitted project rather
+     than paying an `npm install` per variant — so the emitted
+     `package.json` is never consulted and a scaffold that fails to
+     declare a compile-required npm package still compiles green.
+     After `shadow compile app`, the assert reads the `:browser`
+     build's own `manifest.edn` and requires every npm package the
+     build resolved to be one `npm install` would have produced from
+     the emitted `package.json` (declared directly, or pulled in
+     transitively by something declared).
+   - **Dev-page boot proof.** Every other check compiles through the
+     pure-JVM route, and the SSR browser proof drives a synthetic
+     server-painted page that carries no `<meta>` CSP — so nothing
+     loaded the page a newcomer actually opens. A Chromium cell
+     serves the emitted `resources/public`, loads the real
+     `index.html` plus the dev bundle, and requires `#app` to paint
+     the counter, the click to move it 0 → 1, and Chromium to report
+     zero uncaught `pageerror`s. Where Chromium is not launchable
+     the cell records a documented skip, printed as a loud
+     NOT PROVEN banner so it cannot read as a pass.
 
 CI sets `RF2_TEMPLATE_RUN_EMITTED_TESTS=1`; a change that breaks
 file-tree shape, drifts the framework surface, breaks the pin

--- a/tools/template/test-support/dev-page-boot-proof.cjs
+++ b/tools/template/test-support/dev-page-boot-proof.cjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+/*
+ * Browser proof that the generated scaffold's EMITTED `index.html` boots the
+ * DEV bundle — the page a newcomer actually opens after
+ * `npx shadow-cljs watch app`.
+ *
+ * Driven by `emitted_test_run_test.clj` (behind `RF2_TEMPLATE_RUN_EMITTED_TESTS`),
+ * as a sibling of `ssr-hydration-dom-proof.cjs`. The JVM half has already
+ * generated the scaffold, rewritten its deps to :local/root, linked
+ * node_modules, and run `shadow compile app` — so `<proj>/resources/public`
+ * holds the emitted `index.html`, `css/app.css`, and the DEV (`:optimizations
+ * :none`) bundle at `js/main.js` + `js/cljs-runtime/`.
+ *
+ * WHY THIS EXISTS. Until this proof, no gate anywhere loaded the emitted
+ * `index.html` in a browser. Everything upstream compiles through the pure-JVM
+ * route, and the only browser proof drives a SYNTHETIC `_ssr_proof.html`
+ * rendered by the SSR server — a page that never carries the emitted
+ * `index.html`'s `<meta http-equiv="Content-Security-Policy">`. So a CSP that
+ * blocks the dev bundle outright shipped green: shadow's `:none` builds load
+ * every namespace through `goog.globalEval`, and without `'unsafe-eval'` in
+ * `script-src` the documented first run is a BLANK PAGE on every variant.
+ * That is the defect this driver exists to catch, and it can only be caught by
+ * loading the REAL emitted page.
+ *
+ * The three teeth, in order:
+ *
+ *   1. MOUNT — `#app` must paint the scaffold's counter (an `<h1>` with the
+ *      project name, a `<button>`, and the counter `<span>`). A CSP that
+ *      blocks `eval`, a broken `:init-fn`, or a namespace that throws on load
+ *      all leave `#app` empty; this is the blank-first-page tooth.
+ *   2. LIVE — clicking the `+1` button must move the counter 0 -> 1, so the
+ *      dataflow (event -> app-db -> subscription -> re-render) is actually
+ *      wired, not just server-shaped markup.
+ *   3. CLEAN — ZERO uncaught `pageerror`s. Console noise stays diagnostic
+ *      (a 404 favicon, a dev-only warn); only `pageerror` is fatal, matching
+ *      every adjacent runner's policy in this repo.
+ *
+ * The static server sets NO Content-Security-Policy response header — the
+ * emitted `<meta>` CSP is the only policy in play, which is exactly the
+ * surface under test.
+ *
+ * Usage:  node dev-page-boot-proof.cjs <publicRoot> <implRoot> [label]
+ *   publicRoot — <proj>/resources/public (holds index.html + js/ + css/)
+ *   implRoot   — <repo>/implementation   (resolves the playwright devDep)
+ *   label      — optional variant name, echoed in diagnostics
+ *
+ * Exit 0 = all three teeth pass. Exit 1 = the proof FAILED. Exit 2 = Chromium
+ * is not launchable here, so the proof was SKIPPED (the caller prints a loud
+ * banner — a silent skip is how this whole class of defect stayed invisible).
+ */
+
+'use strict';
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const [, , PUBLIC_ROOT, IMPL_ROOT, LABEL] = process.argv;
+if (!PUBLIC_ROOT || !IMPL_ROOT) {
+  console.error('usage: node dev-page-boot-proof.cjs <publicRoot> <implRoot> [label]');
+  process.exit(2);
+}
+const label = LABEL || 'emitted scaffold';
+
+const { chromium } = require(require.resolve('playwright', { paths: [IMPL_ROOT] }));
+
+const BOOT_PAGE = '/index.html';
+const TIMEOUT_MS = parseInt(process.env.RF2_TEMPLATE_BROWSER_PROOF_TIMEOUT_MS || '30000', 10);
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.ico': 'image/x-icon',
+};
+
+// A tiny contained static file server rooted at PUBLIC_ROOT — enough to serve
+// the emitted index.html, the dev bundle, its cljs-runtime chunks and the CSS.
+// Never escapes the root, and deliberately sets no CSP header so the emitted
+// page's own <meta> policy is the one under test.
+function startStaticServer(root) {
+  const canonRoot = path.resolve(root);
+  const server = http.createServer((req, res) => {
+    const urlPath = decodeURIComponent(req.url.split('?')[0]);
+    const rel = urlPath === '/' ? '/index.html' : urlPath;
+    const target = path.resolve(canonRoot, '.' + rel);
+    if (target !== canonRoot && !target.startsWith(canonRoot + path.sep)) {
+      res.statusCode = 403;
+      res.end('forbidden');
+      return;
+    }
+    fs.readFile(target, (err, buf) => {
+      if (err) {
+        res.statusCode = 404;
+        res.end('not found: ' + urlPath);
+        return;
+      }
+      res.setHeader('Content-Type', MIME[path.extname(target)] || 'application/octet-stream');
+      res.end(buf);
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+// Turn the captured browser noise into a POINTED diagnosis where we can. A
+// bare "the counter never appeared" is a true but useless verdict; naming the
+// CSP as the blocker is what makes this gate worth having.
+function diagnose(lines) {
+  const blob = lines.join('\n');
+  const hints = [];
+  if (/Content Security Policy|EvalError|unsafe-eval|refused to evaluate/i.test(blob)) {
+    hints.push(
+      "the emitted index.html's <meta> Content-Security-Policy BLOCKS the dev " +
+        "bundle: shadow-cljs :none builds load every namespace through " +
+        "goog.globalEval, so `script-src` must admit 'unsafe-eval' or the " +
+        'documented first run is a blank page.',
+    );
+  }
+  if (/Refused to load|violates the following Content Security Policy/i.test(blob)) {
+    hints.push(
+      'a resource the emitted page needs was refused by its own <meta> CSP — ' +
+        'widen the offending directive or drop the resource.',
+    );
+  }
+  if (/Failed to load resource.*(main\.js|cljs-runtime)/i.test(blob)) {
+    hints.push(
+      'the dev bundle (js/main.js or a js/cljs-runtime chunk) did not load — ' +
+        'check the emitted :output-dir / :asset-path against the index.html ' +
+        '<script src>.',
+    );
+  }
+  return hints;
+}
+
+(async () => {
+  const server = await startStaticServer(PUBLIC_ROOT);
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const consoleLines = [];
+  // Tracked SEPARATELY from the diagnostic console buffer: the verdict below
+  // flips to FAIL on a non-empty pageErrors array. Console noise is
+  // diagnostic-only (a favicon 404 must not red the gate); an uncaught
+  // pageerror is fatal.
+  const pageErrors = [];
+  let browser;
+  let failure = null;
+
+  // Launch is a SKIP boundary, not a failure: the PR-time template job runs
+  // `npm ci` in implementation/ (which installs the playwright PACKAGE) but
+  // never `npx playwright install`, so no browser binary is present there.
+  // Exit 2 = "browser unavailable, skipped"; the caller prints a loud banner so
+  // the skip cannot read as a pass.
+  try {
+    browser = await chromium.launch({ headless: true });
+  } catch (launchErr) {
+    server.close();
+    console.log(
+      `dev-page boot proof SKIPPED (${label}): Chromium is not launchable here ` +
+        `(${launchErr.message.split('\n')[0]}).`,
+    );
+    process.exit(2);
+  }
+
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    page.on('console', (msg) => {
+      consoleLines.push(`[browser:${msg.type()}] ${msg.text()}`);
+    });
+    page.on('pageerror', (err) => {
+      consoleLines.push(`[browser:pageerror] ${err.message}`);
+      pageErrors.push(err.message);
+    });
+
+    await page.goto(baseUrl + BOOT_PAGE, { waitUntil: 'load', timeout: TIMEOUT_MS });
+
+    // -- Tooth 1: the dev bundle booted and PAINTED the counter into #app ----
+    try {
+      await page.waitForFunction(
+        () => {
+          const h1 = document.querySelector('#app h1');
+          const btn = document.querySelector('#app button');
+          const val = document.querySelector('#app span');
+          return (
+            !!h1 &&
+            !!btn &&
+            !!val &&
+            h1.textContent.trim().length > 0 &&
+            val.textContent.trim().length > 0
+          );
+        },
+        { timeout: TIMEOUT_MS },
+      );
+    } catch (waitErr) {
+      const appHtml = await page
+        .evaluate(() => {
+          const app = document.querySelector('#app');
+          return app ? app.innerHTML : '<no #app element>';
+        })
+        .catch(() => '<unreadable>');
+      const hints = diagnose(consoleLines.concat(pageErrors));
+      throw new Error(
+        `the emitted dev page did NOT mount: #app never painted the scaffold ` +
+          `counter (BLANK FIRST PAGE). #app innerHTML was ${JSON.stringify(appHtml)}.` +
+          (hints.length ? `\nLikely cause:\n  - ${hints.join('\n  - ')}` : '') +
+          `\n(underlying wait: ${waitErr.message.split('\n')[0]})`,
+      );
+    }
+
+    // -- Tooth 2: the dataflow is LIVE — clicking +1 moves the counter -------
+    const initial = await page.evaluate(() =>
+      (document.querySelector('#app span').textContent || '').trim(),
+    );
+    if (initial !== '0') {
+      throw new Error(`expected the seeded counter to read 0, got '${initial}'`);
+    }
+    await page.click('#app button');
+    await page.waitForFunction(
+      () => (document.querySelector('#app span').textContent || '').trim() === '1',
+      { timeout: TIMEOUT_MS },
+    );
+
+    await context.close();
+  } catch (err) {
+    failure = err;
+  } finally {
+    if (browser) await browser.close();
+    server.close();
+  }
+
+  // -- Tooth 3: ZERO uncaught pageerrors on the emitted dev page ------------
+  if (!failure && pageErrors.length) {
+    const hints = diagnose(consoleLines.concat(pageErrors));
+    failure = new Error(
+      `the emitted dev page mounted but raised ${pageErrors.length} uncaught ` +
+        `pageerror(s):\n  ${pageErrors.join('\n  ')}` +
+        (hints.length ? `\nLikely cause:\n  - ${hints.join('\n  - ')}` : ''),
+    );
+  }
+
+  if (failure) {
+    console.log(`=== dev-page boot proof (${label}): FAIL ===`);
+    console.log(failure.message);
+    if (consoleLines.length) {
+      console.log('--- browser console ---');
+      for (const l of consoleLines) console.log(l);
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `dev-page boot proof PASS (${label}): the emitted index.html booted the dev ` +
+      'bundle, #app painted the counter, the click moved it 0 -> 1, and Chromium ' +
+      'reported zero uncaught pageerrors.',
+  );
+  process.exit(0);
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -470,7 +470,7 @@
   [what out]
   (println)
   (println "!!! ================================================================")
-  (println (str "!!! NOT PROVEN — SKIPPED: " what))
+  (println (str "!!! NOT PROVEN -- SKIPPED: " what))
   (println "!!! Chromium is not launchable here, so this browser proof did NOT run.")
   (println "!!! The tier stays green, but NOTHING about the emitted page is proven.")
   (when-let [line (first (remove string/blank? (string/split-lines (str out))))]
@@ -502,7 +502,7 @@
   (testing (str label " — Chromium dev-page boot proof (emitted index.html + "
                 "dev bundle mounts, zero pageerror)")
     (if-not @node-available?
-      (do (announce-browser-skip! (str "dev-page boot proof — " label)
+      (do (announce-browser-skip! (str "dev-page boot proof -- " label)
                                   "`node` is not on PATH")
           (is true
               "`node` unavailable — skipping the emitted dev-page boot proof"))
@@ -518,7 +518,7 @@
         ;; the playwright PACKAGE but no browser binary). Documented skip, but
         ;; a LOUD one. Exit 0 = booted clean; anything else = the proof FAILED.
         (if (= 2 exit)
-          (do (announce-browser-skip! (str "dev-page boot proof — " label) out)
+          (do (announce-browser-skip! (str "dev-page boot proof -- " label) out)
               (is true
                   (str "Chromium unavailable — the emitted dev-page boot proof "
                        "did not run for " label ". Output:\n" out)))

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -424,6 +424,15 @@
               installed (npm-install-closure (io/file root "implementation/node_modules")
                                              declared)
               missing   (sort (remove installed resolved))]
+          ;; Say what was actually checked. A gate whose only output on a
+          ;; green run is silence cannot be told apart from a gate that
+          ;; degraded into a no-op.
+          (println (str "  [package.json completeness] " label ": build resolves "
+                        (count resolved) " npm package(s) "
+                        (pr-str (sort resolved))
+                        (if (seq missing)
+                          (str " -- UNDECLARED: " (pr-str (vec missing)))
+                          " -- all reachable from the emitted package.json")))
           ;; Vacuous-pass guard: an unparsed / empty manifest would make the
           ;; set-difference trivially empty and the tooth would prove nothing.
           ;; Every variant's dev build resolves React at minimum.
@@ -513,15 +522,22 @@
               (is true
                   (str "Chromium unavailable — the emitted dev-page boot proof "
                        "did not run for " label ". Output:\n" out)))
-          (is (zero? exit)
-              (str "the emitted dev-page boot proof exited " exit " for " label
-                   " — the page a newcomer opens after `npx shadow-cljs watch "
-                   "app` did not boot cleanly. Either #app never painted (a "
-                   "BLANK first page: the emitted index.html's <meta> CSP "
-                   "blocks the dev bundle's goog.globalEval, a broken "
-                   ":init-fn, or a namespace that throws on load), the counter "
-                   "did not move 0 -> 1, or Chromium raised an uncaught "
-                   "pageerror. Output:\n" out)))))))
+          (do
+            ;; Echo the driver's verdict line on a green run too — a browser
+            ;; proof that only speaks when it fails is indistinguishable in
+            ;; the run output from one that silently skipped.
+            (when (zero? exit)
+              (when-let [line (last (remove string/blank? (string/split-lines (str out))))]
+                (println (str "  [dev-page boot] " (string/trim line)))))
+            (is (zero? exit)
+                (str "the emitted dev-page boot proof exited " exit " for " label
+                     " — the page a newcomer opens after `npx shadow-cljs watch "
+                     "app` did not boot cleanly. Either #app never painted (a "
+                     "BLANK first page: the emitted index.html's <meta> CSP "
+                     "blocks the dev bundle's goog.globalEval, a broken "
+                     ":init-fn, or a namespace that throws on load), the counter "
+                     "did not move 0 -> 1, or Chromium raised an uncaught "
+                     "pageerror. Output:\n" out))))))))
 
 ;; --- SSR DOM-adoption browser proof ---------------------------------------
 ;;

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -22,6 +22,33 @@
    executes the resulting `out/node-test.js` bundle with `node`.
    Asserts exit code 0 and the cljs.test summary line.
 
+   ## The two consumer-realism teeth
+
+   A compile-and-run tier that resolves everything from the monorepo is
+   still blind in two specific ways, and three real defects shipped GREEN
+   through it because of them. Both masks are closed here, in this tier:
+
+     * NODE_MODULES JUNCTION. `link-node-modules!` junctions
+       `implementation/node_modules` into every emitted project, so the
+       emitted `package.json` is never consulted — a scaffold that fails
+       to declare a compile-required npm package still compiles. Closed by
+       `assert-emitted-package-json-complete!`, which reads the `:browser`
+       build's own `manifest.edn` and asserts every npm package the build
+       resolved is one `npm install` would have produced from the EMITTED
+       `package.json`.
+     * NO DEV-PAGE BOOT PROOF. Nothing loaded the emitted `index.html` in
+       a browser: this tier compiles through the pure-JVM route and the
+       only browser proof drives a synthetic SSR page with no `<meta>`
+       CSP. Closed by `run-dev-page-boot-proof!` + its
+       `test-support/dev-page-boot-proof.cjs` driver, which loads the real
+       emitted page and proves it mounts, increments, and raises zero
+       uncaught pageerrors.
+
+   Both ride this file's existing `RF2_TEMPLATE_RUN_EMITTED_TESTS` gate and
+   the compile each variant already pays for; neither is a separate
+   harness. Both must run BEFORE the optional `:advanced` release build,
+   which overwrites the dev bundle and its manifest.
+
    ## Gating
 
    Default off (opt-in via `RF2_TEMPLATE_RUN_EMITTED_TESTS=1`). Two
@@ -295,6 +322,207 @@
         (zero? (.waitFor (.start pb))))
       (catch Throwable _ false))))
 
+;; --- emitted package.json completeness ------------------------------------
+;;
+;; MASK: this tier junctions `<repo>/implementation/node_modules` into every
+;; emitted project (see `link-node-modules!` above). That is what makes the
+;; tier affordable — no `npm install` per variant — but it also means the
+;; emitted `package.json` is NEVER consulted: every npm package the compile
+;; graph reaches resolves out of the monorepo's tree regardless of what the
+;; scaffold declares. An emitted `package.json` that omits a compile-required
+;; package therefore compiles GREEN here and fails on the FIRST
+;; `npx shadow-cljs watch app` a real consumer runs. That is not hypothetical:
+;; the scaffold shipped without `@xyflow/react` + `elkjs` (which the Xray
+;; preload's machine canvas requires) and every adapter variant's first
+;; compile failed for an external consumer while this tier stayed green.
+;;
+;; THE TOOTH: after `shadow compile app`, shadow writes `manifest.edn` into the
+;; build's `:output-dir` listing every source in the build — including the
+;; `node_modules/<pkg>/…` files it resolved. Assert that every npm package in
+;; there is one `npm install` would actually have produced from the EMITTED
+;; `package.json`: declared directly, or pulled in transitively by something
+;; declared. Anything else is a package the scaffold uses but does not declare.
+;;
+;; This is derived from the real compile graph, not a string pin — a future
+;; framework change that adds a new npm requirement to the dev build fails here
+;; without anyone remembering to update a list.
+
+(defn- json-string-map-keys
+  "The keys of the JSON object at top-level `field` in `json-text`
+  (e.g. \"dependencies\"), as a set of strings; nil when the field is
+  absent. Only ever applied to npm dependency maps, whose values are
+  always strings — so the object body contains no nested braces and a
+  non-greedy `[^}]*` body match is exact. The leading quote in the
+  pattern keeps `\"dependencies\"` from matching inside
+  `\"devDependencies\"`."
+  [json-text field]
+  (when-let [[_ body] (re-find (re-pattern (str "\"" field "\"\\s*:\\s*\\{([^}]*)\\}"))
+                               json-text)]
+    (set (map second (re-seq #"\"([^\"]+)\"\s*:" body)))))
+
+(defn- top-level-npm-package
+  "The npm package a shadow manifest resource path belongs to:
+  `node_modules/react/index.js` → `react`,
+  `node_modules/@xyflow/react/dist/esm/index.js` → `@xyflow/react`.
+  Splits on the LAST `node_modules/` so a nested (non-hoisted) install
+  and an absolute resolved path both reduce correctly."
+  [resource-path]
+  (let [tail (last (string/split resource-path #"node_modules/"))
+        segs (string/split tail #"/")]
+    (if (string/starts-with? (first segs) "@")
+      (str (first segs) "/" (second segs))
+      (first segs))))
+
+(defn- manifest-npm-packages
+  "Every npm package the built module graph resolved, read out of the
+  `:browser` build's emitted `manifest.edn`."
+  [^java.io.File manifest]
+  (->> (re-seq #"\"([^\"]*node_modules/[^\"]+)\"" (slurp manifest))
+       (map (comp top-level-npm-package second))
+       set))
+
+(defn- npm-install-closure
+  "Every package `npm install` would materialise from a top-level
+  dependency set, resolved against the monorepo's installed tree: the
+  seeds themselves plus the transitive closure of each package's own
+  `dependencies` + `peerDependencies` (npm 7+ installs peers). A
+  package's `devDependencies` are NOT installed for a dependency, so
+  they are deliberately not followed."
+  [^java.io.File node-modules seeds]
+  (loop [seen #{} queue (vec seeds)]
+    (if-let [pkg (first queue)]
+      (if (seen pkg)
+        (recur seen (subvec queue 1))
+        (let [pj   (io/file node-modules pkg "package.json")
+              next (when (.isFile pj)
+                     (let [t (slurp pj)]
+                       (into (or (json-string-map-keys t "dependencies") #{})
+                             (or (json-string-map-keys t "peerDependencies") #{}))))]
+          (recur (conj seen pkg) (into (subvec queue 1) next))))
+      seen)))
+
+(defn- assert-emitted-package-json-complete!
+  "The completeness tooth. Requires a finished `shadow compile app` (it
+  reads that build's `manifest.edn`) and must run BEFORE any `release`
+  build overwrites it."
+  [^java.io.File root ^java.io.File proj label]
+  (testing (str label " — emitted package.json declares every npm package the "
+                "compile graph resolves")
+    (let [manifest (io/file proj "resources/public/js/manifest.edn")
+          pkg-json (io/file proj "package.json")]
+      (is (.isFile manifest)
+          (str "`shadow compile app` must emit resources/public/js/manifest.edn "
+               "for " label " — without it the emitted-package.json completeness "
+               "assert cannot see the build's resolved npm packages."))
+      (is (.isFile pkg-json)
+          (str "the scaffold must emit a package.json for " label))
+      (when (and (.isFile manifest) (.isFile pkg-json))
+        (let [resolved  (manifest-npm-packages manifest)
+              pj-text   (slurp pkg-json)
+              declared  (into (or (json-string-map-keys pj-text "dependencies") #{})
+                              (or (json-string-map-keys pj-text "devDependencies") #{}))
+              installed (npm-install-closure (io/file root "implementation/node_modules")
+                                             declared)
+              missing   (sort (remove installed resolved))]
+          ;; Vacuous-pass guard: an unparsed / empty manifest would make the
+          ;; set-difference trivially empty and the tooth would prove nothing.
+          ;; Every variant's dev build resolves React at minimum.
+          (is (seq resolved)
+              (str "the " label " build's manifest.edn must list at least one "
+                   "node_modules source — an empty resolved set means the "
+                   "manifest was not parsed and this assert is vacuous. "
+                   "Manifest: " (.getPath manifest)))
+          (is (empty? missing)
+              (str "EMITTED package.json IS INCOMPLETE for " label ": the "
+                   "compile graph resolves " (pr-str missing)
+                   " but the scaffold neither declares it nor pulls it in "
+                   "transitively from something it declares — so a real "
+                   "consumer's `npm install` would NOT install it and their "
+                   "first `npx shadow-cljs watch app` fails with a missing JS "
+                   "dependency. This tier junctions implementation/node_modules "
+                   "into the project, so the compile above resolved it from the "
+                   "monorepo and stayed green — that junction is exactly the "
+                   "mask this assert closes. Declare the package in the emitted "
+                   "package.json (hooks.clj :xray-npm-deps or "
+                   "_shared/package.json) and pin it lockstep with "
+                   "implementation/package.json."
+                   "\n  resolved by the build: " (pr-str (sort resolved))
+                   "\n  declared by the scaffold: " (pr-str (sort declared)))))))))
+
+;; --- loud skips ------------------------------------------------------------
+
+(defn- announce-browser-skip!
+  "Print an unmissable banner when a browser proof does NOT run. Both
+  browser proofs in this tier exit 2 when Chromium isn't launchable and
+  keep the tier green — and a quiet, documented skip is precisely how the
+  missing dev-page boot proof stayed invisible while three defects shipped.
+  A skip that reads like a pass in the run output is a mask; this one
+  shouts."
+  [what out]
+  (println)
+  (println "!!! ================================================================")
+  (println (str "!!! NOT PROVEN — SKIPPED: " what))
+  (println "!!! Chromium is not launchable here, so this browser proof did NOT run.")
+  (println "!!! The tier stays green, but NOTHING about the emitted page is proven.")
+  (when-let [line (first (remove string/blank? (string/split-lines (str out))))]
+    (println (str "!!! driver: " (string/trim line))))
+  (println "!!! ================================================================")
+  (println))
+
+;; --- emitted dev-page boot proof ------------------------------------------
+;;
+;; MASK: no gate anywhere loaded the emitted `index.html` in a browser. The
+;; tier compiles through the pure-JVM route, and the only browser proof drives
+;; a SYNTHETIC `_ssr_proof.html` painted by the SSR server — a page that never
+;; carries the emitted `index.html`'s `<meta>` Content-Security-Policy. So a
+;; dev CSP without `'unsafe-eval'` shipped green even though shadow's `:none`
+;; builds load every namespace via `goog.globalEval`: the documented first run
+;; (`watch app`, open the page) was BLANK on every variant.
+;;
+;; THE TOOTH: serve the emitted `resources/public` and load the REAL
+;; `index.html` in Chromium — CSP meta and all — then prove #app paints the
+;; counter, the click moves it 0 -> 1, and Chromium reports zero uncaught
+;; pageerrors. See `test-support/dev-page-boot-proof.cjs`.
+
+(defn- run-dev-page-boot-proof!
+  "Drive Chromium over the emitted `index.html` + dev bundle. Assumes
+  `shadow compile app` already built the dev bundle into
+  `resources/public/js` — so it must run BEFORE any `release` build
+  replaces it with the `:advanced` output."
+  [^java.io.File root ^java.io.File proj label]
+  (testing (str label " — Chromium dev-page boot proof (emitted index.html + "
+                "dev bundle mounts, zero pageerror)")
+    (if-not @node-available?
+      (do (announce-browser-skip! (str "dev-page boot proof — " label)
+                                  "`node` is not on PATH")
+          (is true
+              "`node` unavailable — skipping the emitted dev-page boot proof"))
+      (let [driver    (.getCanonicalPath
+                        (io/file root "tools/template/test-support/dev-page-boot-proof.cjs"))
+            pub-root  (.getCanonicalPath (io/file proj "resources/public"))
+            impl-root (.getCanonicalPath (io/file root "implementation"))
+            node-path (.getCanonicalPath (io/file root "implementation/node_modules"))
+            {:keys [exit out]}
+            (run-process! ["node" driver pub-root impl-root label]
+                          proj {"NODE_PATH" node-path})]
+        ;; Exit 2 = Chromium not launchable (the PR-time template job installs
+        ;; the playwright PACKAGE but no browser binary). Documented skip, but
+        ;; a LOUD one. Exit 0 = booted clean; anything else = the proof FAILED.
+        (if (= 2 exit)
+          (do (announce-browser-skip! (str "dev-page boot proof — " label) out)
+              (is true
+                  (str "Chromium unavailable — the emitted dev-page boot proof "
+                       "did not run for " label ". Output:\n" out)))
+          (is (zero? exit)
+              (str "the emitted dev-page boot proof exited " exit " for " label
+                   " — the page a newcomer opens after `npx shadow-cljs watch "
+                   "app` did not boot cleanly. Either #app never painted (a "
+                   "BLANK first page: the emitted index.html's <meta> CSP "
+                   "blocks the dev bundle's goog.globalEval, a broken "
+                   ":init-fn, or a namespace that throws on load), the counter "
+                   "did not move 0 -> 1, or Chromium raised an uncaught "
+                   "pageerror. Output:\n" out)))))))
+
 ;; --- SSR DOM-adoption browser proof ---------------------------------------
 ;;
 ;; A short Clojure script that renders the REAL `/` response through the emitted
@@ -359,10 +587,11 @@
           ;; documented skip so the tier stays green. Exit 0 = adopted; any
           ;; other exit = the proof FAILED (fresh mount / dead handler).
           (if (= 2 exit)
-            (is true
-                (str "Chromium unavailable — skipping the SSR DOM-adoption "
-                     "browser proof (the real tooth runs where a browser is "
-                     "provisioned). Output:\n" out))
+            (do (announce-browser-skip! "SSR DOM-adoption browser proof" out)
+                (is true
+                    (str "Chromium unavailable — skipping the SSR DOM-adoption "
+                         "browser proof (the real tooth runs where a browser is "
+                         "provisioned). Output:\n" out)))
             (is (zero? exit)
                 (str "the SSR DOM-adoption browser proof exited " exit
                      " — the generated scaffold did not adopt the server-painted "
@@ -478,6 +707,21 @@
                    (str "`clojure -M:shadow compile "
                         (string/join " " compile-targets) "` exited " exit
                         " for " label ". Output:\n" out))))
+
+           ;; --- emitted package.json completeness ---------------------------
+           ;; Closes the node_modules-junction mask: the compile above resolved
+           ;; every npm package from the monorepo tree, so it cannot tell us
+           ;; whether the EMITTED package.json declares them. Reads the just-
+           ;; written manifest.edn, so it must precede the `release` build
+           ;; (which overwrites it).
+           (assert-emitted-package-json-complete! root proj label)
+
+           ;; --- emitted dev-page boot proof ---------------------------------
+           ;; Closes the no-dev-page-boot mask: load the REAL emitted
+           ;; index.html (CSP meta and all) plus the dev bundle just compiled,
+           ;; and prove the page a newcomer opens actually mounts. Must also
+           ;; precede the `release` build, which replaces the dev bundle.
+           (run-dev-page-boot-proof! root proj label)
 
            ;; --- run ---------------------------------------------------------
            (testing (str label " — node out/node-test.js")
@@ -638,6 +882,13 @@
                        "hydration branch of core.cljc did not compile against "
                        "the in-repo source (reagent/re-frame2-* rewritten to "
                        ":local/root). Output:\n" out))))
+
+          ;; --- emitted package.json completeness ---------------------------
+          ;; Same junction mask as the SPA variants: the compile above resolves
+          ;; npm packages from the monorepo tree, never from the emitted
+          ;; package.json. Reads the manifest the compile just wrote.
+          (assert-emitted-package-json-complete!
+            root proj (str "reagent-ssr-" (if css (name css) "plain")))
 
           ;; --- server gate -------------------------------------------------
           (testing "reagent-ssr — clojure -M:test (headless JVM ssr_test.clj)"


### PR DESCRIPTION
## Summary

Two structural masks let template defects ship GREEN through every in-repo gate, and three real defects did exactly that (found by the rf2-b16va external-consumer run, fixed in #6671). This adds the two teeth the rf2-igwf7 mayor disposition names, both riding the EXISTING `RF2_TEMPLATE_RUN_EMITTED_TESTS` tier and the compile each variant already pays for. Neither is a new harness: no new runner, no new config surface, no fixture tree — one new assert function and one new Chromium cell in `emitted_test_run_test.clj`, plus a driver `.cjs` sitting beside the SSR proof it mirrors.

**(a) Emitted-`package.json` completeness.** The tier junctions `implementation/node_modules` into every emitted project, so the emitted `package.json` is never consulted: a scaffold that fails to declare a compile-required npm package compiles green regardless. After `shadow compile app`, the new assert reads the `:browser` build's own `manifest.edn`, extracts every npm package the build actually resolved, and requires each to be one `npm install` would have produced from the EMITTED `package.json` — declared directly, or pulled in transitively by something declared (`dependencies` + `peerDependencies`, the packages npm installs for a dependency; a dependency's own `devDependencies` are correctly not followed). This is derived from the real compile graph, not a string pin: a future framework change that adds a new npm requirement to the dev build fails here without anyone remembering to update a list. It also carries a vacuous-pass guard (the resolved set must be non-empty) so an unparsed manifest cannot false-green.

**(b) Chromium dev-page boot cell.** No gate anywhere loaded the emitted `index.html` in a browser: the tier compiles via the pure-JVM route, and the only browser proof drives a synthetic `_ssr_proof.html` painted by the SSR server — a page that never carries the emitted `index.html`'s `<meta>` CSP. The new cell serves the emitted `resources/public` over a contained static server (no CSP response header — the emitted `<meta>` policy is the surface under test), loads the real `index.html` plus the dev bundle, and proves three things: `#app` paints the counter, the click moves it 0 → 1, and Chromium reports ZERO uncaught `pageerror`s. Console noise stays diagnostic-only (a favicon 404 must not red a gate); only `pageerror` is fatal, matching every adjacent runner's policy. When the boot fails, the driver diagnoses rather than just reporting a timeout — it names the CSP as the blocker when it sees one.

Both teeth run before the optional `:advanced` release build, which overwrites the dev bundle and its manifest. Both print their evidence on a GREEN run too, so a tooth that degrades into a no-op is distinguishable from one that passed:

```
  [package.json completeness] reagent: build resolves 6 npm package(s) ("@xyflow/react" "elkjs" "process" "react" "react-dom" "scheduler") -- all reachable from the emitted package.json
  [dev-page boot] dev-page boot proof PASS (reagent): the emitted index.html booted the dev bundle, #app painted the counter, the click moved it 0 -> 1, and Chromium reported zero uncaught pageerrors.
```

Coverage: the completeness assert runs on every variant that compiles `:app` — `reagent`, `reagent-with-story`, `uix`, `ui`, `reagent-ssr-plain`, `reagent-ssr-tailwind`. The boot cell runs on every variant with an emitted `index.html` — `reagent`, `reagent-with-story`, `uix`, `ui` (the SSR cells already have their own browser proof against the server-painted page).

## Falsifiability — each tooth reds on its actual defect

A tooth that has never failed has proven nothing. Both original defects were reconstructed in the template source, the gate shown to RED and NAME the problem, then the source restored and the gate shown to pass.

### Tooth (a) vs defect 1 — emitted `package.json` omits `@xyflow/react` + `elkjs`

Mutation (the exact pre-#6671 state): `hooks.clj` `:xray-npm-deps` reverted to `""` for every substrate.

```
$ RF2_TEMPLATE_RUN_EMITTED_TESTS=1 clojure -M:test -v …/reagent-emitted-tests-run-test

  [package.json completeness] reagent: build resolves 6 npm package(s) ("@xyflow/react" "elkjs" "process" "react" "react-dom" "scheduler") -- UNDECLARED: ["@xyflow/react" "elkjs"]

FAIL in (reagent-emitted-tests-run-test) (emitted_test_run_test.clj:444)
reagent - emitted package.json declares every npm package the compile graph resolves
EMITTED package.json IS INCOMPLETE for reagent: the compile graph resolves ("@xyflow/react" "elkjs") but the scaffold neither declares it nor pulls it in transitively from something it declares - so a real consumer's `npm install` would NOT install it and their first `npx shadow-cljs watch app` fails with a missing JS dependency. This tier junctions implementation/node_modules into the project, so the compile above resolved it from the monorepo and stayed green - that junction is exactly the mask this assert closes. Declare the package in the emitted package.json (hooks.clj :xray-npm-deps or _shared/package.json) and pin it lockstep with implementation/package.json.
  resolved by the build: ("@xyflow/react" "elkjs" "process" "react" "react-dom" "scheduler")
  declared by the scaffold: ("react" "react-dom" "shadow-cljs")
expected: (empty? missing)
  actual: (not (empty? ("@xyflow/react" "elkjs")))

Ran 1 tests containing 17 assertions.
1 failures, 0 errors.
```

Note what else that run shows: the `shadow compile app test` step still passed, and the dev-page boot proof still passed. The mask is visible in the transcript — everything resolved out of the junctioned monorepo tree, exactly as it did when this defect shipped.

Restored:

```
  [package.json completeness] reagent: build resolves 6 npm package(s) ("@xyflow/react" "elkjs" "process" "react" "react-dom" "scheduler") -- all reachable from the emitted package.json

Ran 1 tests containing 17 assertions.
0 failures, 0 errors.
```

### Tooth (b) vs defect 3 — dev CSP missing `'unsafe-eval'` (blank first page)

Mutation (the exact pre-#6671 state): `root/resources/public/index.html` meta CSP `script-src 'self' 'unsafe-eval'` → `script-src 'self'`.

```
$ RF2_TEMPLATE_RUN_EMITTED_TESTS=1 clojure -M:test -v …/reagent-emitted-tests-run-test

  [package.json completeness] reagent: build resolves 6 npm package(s) (…) -- all reachable from the emitted package.json

FAIL in (reagent-emitted-tests-run-test) (emitted_test_run_test.clj:532)
reagent - Chromium dev-page boot proof (emitted index.html + dev bundle mounts, zero pageerror)
the emitted dev-page boot proof exited 1 for reagent - the page a newcomer opens after `npx shadow-cljs watch app` did not boot cleanly. …
=== dev-page boot proof (reagent): FAIL ===
the emitted dev page did NOT mount: #app never painted the scaffold counter (BLANK FIRST PAGE). #app innerHTML was "".
Likely cause:
  - the emitted index.html's <meta> Content-Security-Policy BLOCKS the dev bundle: shadow-cljs :none builds load every namespace through goog.globalEval, so `script-src` must admit 'unsafe-eval' or the documented first run is a blank page.
  - a resource the emitted page needs was refused by its own <meta> CSP - widen the offending directive or drop the resource.
(underlying wait: page.waitForFunction: Timeout 30000ms exceeded.)
--- browser console ---
[browser:error] EvalError: Evaluating a string as JavaScript violates the following Content Security Policy directive because 'unsafe-eval' is not an allowed source of script: script-src 'self'".
    at eval (<anonymous>)
    at goog.globalEval (http://127.0.0.1:60347/js/main.js:451:11)
    at env.evalLoad (http://127.0.0.1:60347/js/main.js:1408:12)
[… one EvalError per namespace load: cljs.core, reagent, re_frame.*, acme.my_app.* …]

Ran 1 tests containing 17 assertions.
1 failures, 0 errors.
```

Restored: the green transcript at the top of this PR body (17 assertions, 0 failures, boot proof PASS).

In that failing run the completeness assert passed and the compile passed — this defect is invisible to everything except loading the real page, which is the whole point.

### Bonus — defect 2 (`:shadow` alias `:main-opts` vs the npx `-m`) also reds

Mutation: `:main-opts ["-m" "shadow.cljs.devtools.cli"]` restored to the emitted `_reagent/deps.edn` `:shadow` alias. Clojure PREPENDS an alias's `:main-opts` to the command line, so the tier's own `clojure -M:shadow -m shadow.cljs.devtools.cli compile app test` becomes a double `-m` — the same collision the npx wrapper produced. The tier reds with 4 failures, two of them the new teeth:

```
FAIL … reagent - emitted package.json declares every npm package the compile graph resolves
`shadow compile app` must emit resources/public/js/manifest.edn for reagent …
expected: (.isFile manifest)  actual: false

FAIL … reagent - Chromium dev-page boot proof …
the emitted dev page did NOT mount: #app never painted the scaffold counter (BLANK FIRST PAGE). #app innerHTML was "".

FAIL … Compile step produced out/node-test.js for reagent
FAIL … `shadow release app` must emit a non-empty resources/public/js/main.js

Ran 1 tests containing 10 assertions.
4 failures, 0 errors.
```

Worth recording: the existing `(is (zero? exit))` on the compile step did **not** fail — shadow's CLI exits 0 after rejecting the stray `-m`, having built nothing. A compile that exits 0 having produced no output is precisely the false-green shape both new teeth are designed to catch, and the manifest-presence assert now closes it.

## Chromium skip policy — stated explicitly

**The boot cell SKIPS when Chromium is not launchable; it does not fail.** Rationale: no CI job that sets `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` provisions a browser binary (all three run `npm ci` in `implementation/` and nothing else — that installs the playwright *package*, never `npx playwright install`), so a hard failure would red every PR on infrastructure rather than on a defect.

**But the skip does not inherit the quiet one.** The pre-existing SSR proof recorded its skip as a bare passing `is true`, which reads as a pass in the run output — part of how mask 2 stayed invisible. Both proofs now print an unmissable banner instead (the SSR proof's skip was upgraded in the same change). Proven by forcing `PLAYWRIGHT_BROWSERS_PATH` at a nonexistent directory:

```
$ RF2_TEMPLATE_RUN_EMITTED_TESTS=1 PLAYWRIGHT_BROWSERS_PATH=…/no-such-browsers clojure -M:test -v …/ui-emitted-tests-run-test

  [package.json completeness] ui: build resolves 4 npm package(s) ("process" "react" "react-dom" "scheduler") -- all reachable from the emitted package.json

!!! ================================================================
!!! NOT PROVEN -- SKIPPED: dev-page boot proof -- ui
!!! Chromium is not launchable here, so this browser proof did NOT run.
!!! The tier stays green, but NOTHING about the emitted page is proven.
!!! driver: dev-page boot proof SKIPPED (ui): Chromium is not launchable here (browserType.launch: Executable doesn't exist at …\chrome-headless-shell.exe).
!!! ================================================================

Ran 1 tests containing 13 assertions.
0 failures, 0 errors.
```

Consequence, stated plainly: **as merged, mask 2 is closed LOCALLY only.** The boot cell runs on a developer machine and in nothing else until a browser is provisioned in CI. Filed as **rf2-qa5ty** (P2, `discovered-from: rf2-igwf7`): add `npx playwright install --with-deps chromium` to the three template jobs, then flip the exit-2 skip into a hard failure. That touches `.github/workflows/*` (hot-zone, and in flight from other workers), so it is deliberately not in this PR.

## Quality gates

All run foreground to completion, on Windows 11 / Clojure CLI 1.12 / node v24 / Chromium via the repo's pinned Playwright.

| Gate | Result |
| --- | --- |
| `tools/template` `clojure -M:test` (fast loop, gate off) | **62 tests / 729 assertions, 0 failures** |
| `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` — `reagent-emitted-tests-run-test` (incl. `:advanced` release + Xray-cut + DCE invariants) | **1 test / 17 assertions, 0 failures** (12 before this PR — both new teeth ran, neither skipped) |
| `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` — `uix-` + `ui-emitted-tests-run-test` | **2 tests / 26 assertions, 0 failures** |
| `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` — `reagent-with-story-emitted-tests-run-test` (incl. `:advanced` release) | **1 test / 17 assertions, 0 failures** |
| `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` — `reagent-ssr-` + `reagent-ssr-tailwind-emitted-tests-run-test` (incl. the Chromium DOM-adoption proof) | **2 tests / 23 assertions, 0 failures** |
| `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` — `setup-skill-scaffold-compiles-test` | **1 test / 21 assertions, 0 failures** |
| `implementation` `npm run test:script-policy` | pass (28 policy suites) |
| `implementation` `npm run test:script-helpers` | pass (10 helper suites) |
| `scripts/check-no-hardcoded-paths.sh` | `Portability gate OK: no hardcoded personal/home paths in tracked files.` |

Negative-control runs (the falsifiability section above) are additionally recorded: 1 failure for the dropped npm declaration, 1 failure for the CSP mutation, 4 failures for the `:main-opts` collision — each restored to green afterwards.

## Scope

`tools/template` only — three files:

- `tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj` — the two teeth, wired into the existing `compile-and-run-emitted-test!` / `run-ssr-emitted-test!` paths; the loud-skip banner (also applied to the pre-existing SSR proof's skip).
- `tools/template/test-support/dev-page-boot-proof.cjs` — new driver, sibling of `ssr-hydration-dom-proof.cjs`, same exit-code contract (0 pass / 1 fail / 2 skip).
- `tools/template/spec/Principles.md` — the behavioural tier's description now names both teeth.

No production source, no emitted-template source, no workflow files, no hot-zone files.

Closes rf2-igwf7.
