### PR TITLE
fix(docs): make the doc-slug gate see links that wrap across a newline (rf2-vpc4c)

### DIFF
--- a/migration/from-clj-new-template/README.md
+++ b/migration/from-clj-new-template/README.md
@@ -140,8 +140,8 @@ clojure -Tnew create :template io.github.day8/re-frame2-template :name acme/my-a
   `lefthook.yml` — emitted identically across the
   substrates.
 - **The counter throughline.** Every variant emits a working
-  counter, mirroring [the Guide quickstart — a counter in five
-  minutes](https://github.com/day8/re-frame2/blob/main/docs/core/quickstart.md)
+  counter, mirroring [the Guide introduction — a tiny counter
+  application](https://github.com/day8/re-frame2/blob/main/docs/core/introduction.md)
   and the canonical `examples/<substrate>/counter*/` apps.
 - **Pin lockstep.** `:rf2-version`, `:shadow-version`,
   `:react-version` continue to track

--- a/scripts/_test_fixtures/check_doc_slugs/README.md
+++ b/scripts/_test_fixtures/check_doc_slugs/README.md
@@ -4,8 +4,7 @@ Each subdirectory is a self-contained mini-repo the validator script
 treats as a real corpus when invoked with `--repo-root <fixture-dir>`.
 Required minimum: a top-level `mkdocs.yml` (so the repo-root guard
 accepts the directory) and at least one `.md` file under the scope the
-fixture exercises (`docs/` by default, or the exact synthesis guide/drafts
-roots for `--synthesis-only`).
+fixture exercises (`docs/`).
 
 Run all fixtures via:
 
@@ -31,6 +30,10 @@ Fixtures:
 | `ai_findings_dir_link_flagged`     | 1               | Link into the bare `ai/findings/` directory is flagged (rf2-l7yj8)                 |
 | `blockquoted_heading_ok`           | 0               | Link into a blockquoted heading (`> #### Foo`, incl. nested) resolves (rf2-869k9m) |
 | `indented_heading_not_indexed`     | 1               | Negative control: an *indented bare* `#` line still mints no anchor (rf2-869k9m)   |
-| `synthesis_broken_target`          | default 0 / synthesis 1 | The unchanged default corpus excludes the guide; opt-in catches a missing target (rf2-vxgfnd.135) |
-| `synthesis_broken_anchor`          | default 0 / synthesis 1 | The unchanged default corpus excludes the guide; opt-in catches a missing anchor (rf2-vxgfnd.135) |
-| `synthesis_valid_narrow_scope`     | 0               | Exactly guide + drafts are enumerated; unrelated broken `ai/` scratch remains excluded |
+| `explicit_id_full_title_ok`        | 0               | `attr_list` is off, so `## One {#dup}` mints `one-dup` — the full visible title (rf2-ru0wg) |
+| `explicit_id_brace_not_a_target`   | 1               | Negative control: the brace suffix `#dup` is NOT a fragment target (rf2-ru0wg)     |
+| `explicit_id_duplicate`            | 0               | Two `{#dup}` headings disambiguate as `one-dup` / `one-dup_1` (rf2-ru0wg)          |
+| `wrapped_link_broken_anchor`       | 2               | A link whose TEXT wraps across a newline is still validated (rf2-vpc4c)            |
+| `wrapped_link_ok`                  | 0               | Correct wrapped links — plain, multi-line, same-file, blockquoted — are not flagged (rf2-vpc4c) |
+| `wrapped_link_block_bound`         | 0               | False-positive control: the join stops at a block boundary, so `[text` … blank … `](x.md)` is not a link (rf2-vpc4c) |
+| `compat_anchor_teeth`              | driven directly | The compat-anchor manifest, placement, and source-comment teeth — invoked with explicit fixture inputs, not from this table (rf2-57k74 / rf2-zq5i6 / rf2-k30r7) |

--- a/scripts/_test_fixtures/check_doc_slugs/wrapped_link_block_bound/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/wrapped_link_block_bound/docs/index.md
@@ -1,0 +1,27 @@
+# Index — Wrapped-Link Block Bound (rf2-vpc4c)
+
+The false-positive control for the wrapped-link fix. Joining lines to see
+a wrapped link must not join across a BLOCK boundary: no markdown inline
+construct survives a blank line, so text either side of one can never be
+one link. Each pair below would resolve to a link — and be flagged as a
+BROKEN TARGET — under a naive whole-file join, so this fixture expects
+zero findings only if the block bound holds.
+
+A stray unclosed bracket at the end of a paragraph [like this one
+
+](missing-across-a-blank-line.md) and a paragraph opening with what looks
+like the tail of a link.
+
+A stray bracket ending a paragraph [again
+
+<!-- an intervening block -->
+
+](missing-across-two-blanks.md) with two block boundaries in between.
+
+A stray bracket before a fenced block [here
+
+```clojure
+(comment "a fenced block is a block boundary too")
+```
+
+](missing-across-a-fence.md) and text after it.

--- a/scripts/_test_fixtures/check_doc_slugs/wrapped_link_block_bound/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/wrapped_link_block_bound/mkdocs.yml
@@ -1,0 +1,1 @@
+# Self-test fixture marker.

--- a/scripts/_test_fixtures/check_doc_slugs/wrapped_link_broken_anchor/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/wrapped_link_broken_anchor/docs/index.md
@@ -1,0 +1,17 @@
+# Index — Wrapped Link, Broken Anchor (rf2-vpc4c)
+
+The negative control for line-wrap blindness. The link below is one
+rendered link whose text wraps across a newline, so `](target.md#...)`
+lands on the second line. A line-oriented extractor never matches it and
+the broken anchor ships silently — `mkdocs build --strict` will not catch
+it either (it reports a broken anchor as INFO and exits 0).
+
+This page links to [a real file whose anchor does not
+exist](target.md#not-a-real-anchor) — the file exists, the anchor does
+not, so the validator must flag it as a BROKEN ANCHOR.
+
+The same wrap inside a blockquote, which is how the defect was first
+found in the real corpus:
+
+> Per the freeze note above, [§Some
+> Section](target.md#also-not-a-real-anchor) is the live projection.

--- a/scripts/_test_fixtures/check_doc_slugs/wrapped_link_broken_anchor/docs/target.md
+++ b/scripts/_test_fixtures/check_doc_slugs/wrapped_link_broken_anchor/docs/target.md
@@ -1,0 +1,6 @@
+# Target
+
+## Hello World
+
+This heading exists; `#not-a-real-anchor` and `#also-not-a-real-anchor`
+do not.

--- a/scripts/_test_fixtures/check_doc_slugs/wrapped_link_broken_anchor/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/wrapped_link_broken_anchor/mkdocs.yml
@@ -1,0 +1,1 @@
+# Self-test fixture marker.

--- a/scripts/_test_fixtures/check_doc_slugs/wrapped_link_ok/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/wrapped_link_ok/docs/index.md
@@ -1,0 +1,24 @@
+# Index — Wrapped Link, Valid (rf2-vpc4c)
+
+Seeing wrapped links must not mean flagging correct ones. Every link
+below wraps and every one resolves, so this fixture expects zero
+findings.
+
+Text wrapping once: [a target file and a live
+anchor](target.md#hello-world).
+
+Text wrapping across three lines, with the destination alone on the
+last: [a rather long piece of link
+text that keeps
+going](target.md#hello-world).
+
+A same-file anchor whose text wraps: [back to the
+top](#index--wrapped-link-valid-rf2-vpc4c).
+
+Inside a blockquote, where the continuation line carries a `>` marker:
+
+> Per the note above, [§Hello
+> World](target.md#hello-world) is the section that matters.
+
+Inline code still masks a wrapped PLACEHOLDER, so this backticked
+link-shaped text is not resolved: `[placeholder](nowhere.md)`.

--- a/scripts/_test_fixtures/check_doc_slugs/wrapped_link_ok/docs/target.md
+++ b/scripts/_test_fixtures/check_doc_slugs/wrapped_link_ok/docs/target.md
@@ -1,0 +1,5 @@
+# Target
+
+## Hello World
+
+The anchor the wrapped links point at.

--- a/scripts/_test_fixtures/check_doc_slugs/wrapped_link_ok/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/wrapped_link_ok/mkdocs.yml
@@ -1,0 +1,1 @@
+# Self-test fixture marker.

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -43,6 +43,7 @@ on the Python stdlib.
 from __future__ import annotations
 
 import argparse
+import bisect
 import re
 import subprocess
 import sys
@@ -129,6 +130,15 @@ _HTML_ANCHOR_RE = re.compile(
 # Markdown inline link.  Captures destination only.  Reference-style links
 # ([text][ref]) are ignored — none in this corpus per spot-check, and a full
 # parser is out of scope for a CI guard.
+#
+# The link TEXT may contain newlines: markdown wraps a paragraph freely, so
+# `[§Compiled\nviews](Doc.md#anchor)` is one rendered link.  The negated
+# character classes match `\n` already — what mattered was that `_extract_links`
+# fed this regex one line at a time, so a wrapped link never matched and was
+# never validated (rf2-vpc4c).  It is now run over a joined block (see
+# `_iter_inline_links`).  The DESTINATION deliberately still forbids whitespace
+# (`[^)\s]+`): CommonMark does not permit a bare destination to wrap, so a
+# newline there is not a link the renderer would produce either.
 _LINK_RE = re.compile(r"\[(?:[^\]\\]|\\.)*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
 
 # Fenced code block delimiter (``` or ~~~ optionally followed by language).
@@ -614,18 +624,89 @@ def _strip_inline_code(line: str) -> str:
     return _INLINE_CODE_RE.sub(lambda m: " " * (m.end() - m.start()), line)
 
 
+def _blank_line_blocks(
+    pairs: Iterable[tuple[int, str]],
+) -> Iterable[list[tuple[int, str]]]:
+    """Group (line_no, content) pairs into blank-line-separated blocks.
+
+    A blank line ends a block.  This is the unit over which a markdown inline
+    construct may wrap: a paragraph (or table, or list) is parsed as one run of
+    inline text, and NO inline construct survives a blank line — a blank line is
+    a block boundary in every markdown flavour.  Scanning per block rather than
+    per line is what lets `_iter_inline_links` see a wrapped link; bounding the
+    join at the blank line is what stops it from stitching two unrelated
+    paragraphs into a link that no renderer would produce (rf2-vpc4c).
+
+    Fence lines and fenced-block bodies arrive already blanked by
+    `_strip_fences`, so a code block is a block boundary here too, for free.
+    """
+    block: list[tuple[int, str]] = []
+    for line_no, content in pairs:
+        if not content.strip():
+            if block:
+                yield block
+                block = []
+            continue
+        block.append((line_no, content))
+    if block:
+        yield block
+
+
+def _iter_inline_links(
+    pairs: Iterable[tuple[int, str]],
+) -> Iterable[tuple[int, str]]:
+    """Yield (line-number, destination) for every inline link in the given lines.
+
+    `pairs` are (line_no, content) pairs the CALLER has already reduced to
+    scannable source — fence-stripped and inline-code-masked.
+
+    Each blank-line-delimited block is joined with `\\n` and scanned as ONE
+    string, so a link whose text wraps across a newline is seen.  The
+    predecessor scanned line by line, so `](target#anchor)` landing on the
+    following line never matched `_LINK_RE` and the link was therefore never
+    validated — silently unguarded, since `mkdocs build --strict` reports a
+    broken anchor as INFO and still exits 0 (rf2-vpc4c).
+
+    The reported line is the one carrying the DESTINATION (`m.start(1)`), not
+    the one carrying the opening `[`.  For an unwrapped link the two are the
+    same line, so single-line diagnostics are unchanged; for a wrapped one the
+    destination's line is the line an author edits to fix the anchor, and it is
+    the more robust of the two — an unclosed stray `[` earlier in the block can
+    drag the match start backwards, but never the destination.
+    """
+    for block in _blank_line_blocks(pairs):
+        joined = "\n".join(content for _, content in block)
+        # Offset of each line's first character within `joined`, for mapping a
+        # match position back to a line number.  `_strip_inline_code` masks
+        # length-preservingly, so these offsets are exact.
+        line_starts: list[int] = []
+        offset = 0
+        for _, content in block:
+            line_starts.append(offset)
+            offset += len(content) + 1  # +1 for the joining newline
+        for m in _LINK_RE.finditer(joined):
+            i = bisect.bisect_right(line_starts, m.start(1)) - 1
+            yield block[i][0], m.group(1)
+
+
 def _extract_links(path: Path) -> Iterable[tuple[int, str]]:
     """Yield (line-number, destination) for every inline markdown link.
 
     Links inside fenced code blocks AND inside inline-code spans are
     skipped — both are "code", not real cross-references (rf2-mqv8s).
+    Links that wrap across a newline ARE seen (rf2-vpc4c) — see
+    `_iter_inline_links`.
+
+    Inline code is masked per LINE, before the block join: a CommonMark code
+    span closes on the line it opens, so masking the joined text would let a
+    stray backtick swallow everything up to a backtick on some later line —
+    and with it any real link in between.
     """
     text = path.read_text(encoding="utf-8", errors="replace")
-    for line_no, content in _strip_fences(text.splitlines()):
-        if not content:
-            continue
-        for m in _LINK_RE.finditer(_strip_inline_code(content)):
-            yield line_no, m.group(1)
+    yield from _iter_inline_links(
+        (line_no, _strip_inline_code(content))
+        for line_no, content in _strip_fences(text.splitlines())
+    )
 
 
 def _resolve_target(

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -1271,6 +1271,10 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("absolute_path_ok",                 0),
         ("relative_dotdot_ok",               0),
         ("inline_code_placeholder_ignored",  0),  # rf2-mqv8s
+        # POSITIVE CONTROL for the wrapped-link fix (rf2-vpc4c): the
+        # single-line broken link this gate always caught must keep reding.
+        # `broken_anchor` / `broken_target` above pin the unwrapped cases;
+        # this one pins a broken link sharing a line with a masked placeholder.
         ("inline_code_negative_control",     1),  # rf2-mqv8s
         ("ai_findings_link_flagged",         1),  # rf2-l7yj8
         ("ai_findings_dir_link_flagged",     1),  # rf2-l7yj8
@@ -1283,6 +1287,14 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("explicit_id_full_title_ok",        0),  # `{#dup}` -> id `one-dup`
         ("explicit_id_brace_not_a_target",   1),  # `#dup` is NOT a target
         ("explicit_id_duplicate",            0),  # -> `one-dup`, `one-dup_1`
+        # rf2-vpc4c — line-wrap blindness. A link whose text wraps across a
+        # newline is a real rendered link and must be validated (the gate was
+        # blind to it, and mkdocs strict does not cover the gap); a correct
+        # wrapped link must NOT be flagged; and the join that makes wrapped
+        # links visible must stop at a block boundary.
+        ("wrapped_link_broken_anchor",       2),  # negative control
+        ("wrapped_link_ok",                  0),  # no false positives
+        ("wrapped_link_block_bound",         0),  # join stops at a blank line
     ]
 
     failures = 0
@@ -1595,12 +1607,71 @@ def _run_self_tests(verbose: bool = False) -> int:
             "rejects the drifted mutation\n"
         )
 
+    # rf2-vpc4c — link extraction driven directly with explicit line lists, so
+    # the wrap contract is pinned at the mechanism rather than only through a
+    # fixture's aggregate count. Each case states the (line_no, destination)
+    # pairs `_iter_inline_links` must yield from fence-stripped, inline-code-
+    # masked input. `_extract_links` reduces a file to exactly this shape.
+    extraction_cases: list[tuple[str, list[tuple[int, str]], list[tuple[int, str]]]] = [
+        # POSITIVE CONTROL — the unwrapped case that always worked. The reported
+        # line is the link's own line, exactly as before the fix.
+        ("single-line link still extracted",
+         [(1, "See [the doc](target.md#anchor) for detail.")],
+         [(1, "target.md#anchor")]),
+        # THE FIX — text wraps, so `](dest)` lands on the next line. The
+        # predecessor yielded nothing here.
+        ("wrapped link extracted, reported at the destination's line",
+         [(1, "See [the"), (2, "doc](target.md#anchor) for detail.")],
+         [(2, "target.md#anchor")]),
+        # Blockquote continuation markers ride along in the link TEXT; only the
+        # destination is captured, so the `>` prefix is harmless.
+        ("wrapped link inside a blockquote",
+         [(7, "> Per the note, [§Compiled"),
+          (8, "> views](API.md#compiled-views) is live.")],
+         [(8, "API.md#compiled-views")]),
+        # BLOCK BOUND — a blank line ends the block, so these are never one link.
+        ("blank line is not bridged",
+         [(1, "A stray bracket [here"), (2, ""), (3, "](missing.md) after.")],
+         []),
+        # A fenced block arrives already blanked by `_strip_fences`, so it acts
+        # as a block boundary for free.
+        ("blanked fence lines are not bridged",
+         [(1, "A stray bracket [here"), (2, ""), (3, ""), (4, ""),
+          (5, "](missing.md) after.")],
+         []),
+        # A destination may not itself wrap: CommonMark forbids whitespace in a
+        # bare destination, so this is not a link the renderer would produce.
+        ("wrapped DESTINATION is not a link",
+         [(1, "See [the doc](target.md#an"), (2, "chor) for detail.")],
+         []),
+        # An unclosed stray `[` earlier in the same block drags the match START
+        # backwards, which is why the DESTINATION's line is what gets reported.
+        # The destination itself is still correct and still found.
+        ("stray bracket does not lose the destination",
+         [(1, "An unclosed [ bracket opens here,"),
+          (2, "and [the real link](target.md#anchor) follows.")],
+         [(2, "target.md#anchor")]),
+    ]
+    for label, lines, expected_links in extraction_cases:
+        got_links = list(_iter_inline_links(lines))
+        if got_links == expected_links:
+            if verbose:
+                sys.stderr.write(
+                    f"self-test PASS: extraction [{label}]\n"
+                )
+        else:
+            sys.stderr.write(
+                f"self-test FAIL: extraction [{label}] expected "
+                f"{expected_links}, got {got_links}\n"
+            )
+            failures += 1
+
     if failures:
         sys.stderr.write(f"\n{failures} self-test failure(s).\n")
         return 1
     if verbose:
         sys.stderr.write(
-            f"all {len(cases) + len(teeth_cases) + 4} "
+            f"all {len(cases) + len(teeth_cases) + len(extraction_cases) + 4} "
             "self-tests passed.\n"
         )
     return 0

--- a/scripts/check_readme_links.py
+++ b/scripts/check_readme_links.py
@@ -96,15 +96,19 @@ from typing import Iterable
 # scope until a real README heading exercises it.
 #
 # What is NOT shared is the duplicate-heading suffix — see `_slug_index`.
+#
+# `_extract_links` is imported rather than reimplemented (rf2-vpc4c). It used
+# to be a verbatim copy here, which meant this gate inherited the same
+# line-wrap blindness — a link whose `](target#anchor)` fell on the following
+# line was never validated in EITHER corpus. One extractor, one fix.
 try:
     from check_doc_slugs import (
         SLUGIFY,
         SLUG_SEP,
         _HEADING_RE,
         _HTML_ANCHOR_RE,
-        _LINK_RE,
+        _extract_links,
         _strip_fences,
-        _strip_inline_code,
     )
 except ImportError as exc:  # pragma: no cover - dev-env path
     # Make `python scripts/check_readme_links.py` work from repo root
@@ -116,9 +120,8 @@ except ImportError as exc:  # pragma: no cover - dev-env path
             SLUG_SEP,
             _HEADING_RE,
             _HTML_ANCHOR_RE,
-            _LINK_RE,
+            _extract_links,
             _strip_fences,
-            _strip_inline_code,
         )
     except ImportError:
         sys.stderr.write(
@@ -280,20 +283,6 @@ def _slug_index(path: Path) -> set[str]:
             continue
         slugs.add(_github_dedupe(slug, occurrences))
     return slugs
-
-
-def _extract_links(path: Path) -> Iterable[tuple[int, str]]:
-    """Yield (line-number, destination) for every inline markdown link.
-
-    Links inside fenced code blocks AND inside inline-code spans are
-    skipped (matches check_doc_slugs.py behaviour).
-    """
-    text = path.read_text(encoding="utf-8", errors="replace")
-    for line_no, content in _strip_fences(text.splitlines()):
-        if not content:
-            continue
-        for m in _LINK_RE.finditer(_strip_inline_code(content)):
-            yield line_no, m.group(1)
 
 
 def _resolve_target(linker: Path, dest_path: str, repo_root: Path) -> Path | None:

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1907,7 +1907,7 @@ chart has not rendered a viewport yet (an empty / nil-definition
 placeholder renders no chart), and `:rf.machines-viz.export/no-chart-state`
 when `chart-element` is not a rendered `MachineChart` root (or descendant
 of one). Per the thrown-error contract ([Spec 009 §The thrown-error
-shape](../../spec/009-Instrumentation.md)) the `ex-message` is a human
+shape](../../../spec/009-Instrumentation.md)) the `ex-message` is a human
 sentence naming the public concept (a rendered MachineChart element) plus
 the trailing `[:rf.error/<id>]` token; `:rf.error/id` is the canonical
 machine discriminator and `:reason` carries the same human sentence — the
@@ -2175,7 +2175,7 @@ back.
 ### Error modes
 
 Per the thrown-error contract ([Spec 009 §The thrown-error
-shape](../../spec/009-Instrumentation.md)): `:rf.error/id` is the canonical
+shape](../../../spec/009-Instrumentation.md)): `:rf.error/id` is the canonical
 machine discriminator (tools branch on it), `:reason` is the human
 sentence, and `ex-message` leads with the sentence and trails the
 `[:rf.error/<id>]` token.
@@ -2270,7 +2270,7 @@ clean up or accept as-is).
 ### Error modes
 
 Per the thrown-error contract ([Spec 009 §The thrown-error
-shape](../../spec/009-Instrumentation.md)): `:rf.error/id` is the canonical
+shape](../../../spec/009-Instrumentation.md)): `:rf.error/id` is the canonical
 machine discriminator (tools branch on it), `:reason` is the human
 sentence, and `ex-message` leads with the sentence and trails the
 `[:rf.error/<id>]` token.

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -746,7 +746,7 @@ on the whole vector — no prefix / sub-id fuzzing, so an override never
 leaks into a sibling query the author did not name; a `nil`-valued
 override is a genuine hit), short-circuits build-and-cache with a constant
 reaction holding the pinned value. See [006 §The sub-override subscribe
-seam](../../spec/006-ReactiveSubstrate.md#the-sub-override-subscribe-seam-debug-gated)
+seam](../../../spec/006-ReactiveSubstrate.md#the-sub-override-subscribe-seam-debug-gated)
 for the core-side contract.
 
 The override never writes app-db and never calls `compute-sub`. That

--- a/tools/template/spec/DESIGN-RATIONALE.md
+++ b/tools/template/spec/DESIGN-RATIONALE.md
@@ -139,8 +139,8 @@ hello-world, not a routing-demo.
 
 **Why.**
 
-- **rf2-2kzw throughline.** [The Guide quickstart — a counter in
-  five minutes](../../../docs/core/quickstart.md) walks through a
+- **rf2-2kzw throughline.** [The Guide introduction — a tiny counter
+  application](../../../docs/core/introduction.md) walks through a
   counter. The reference `examples/<substrate>/counter*/` apps
   are counters. The template emits a counter. A developer who
   runs the template and then opens the guide sees the same code

--- a/tools/template/spec/Principles.md
+++ b/tools/template/spec/Principles.md
@@ -38,8 +38,8 @@ template's role is over.
 
 Every variant emits a working counter. The counter:
 
-- Is the same shape developers read about in [the Guide quickstart
-  — a counter in five minutes](../../../docs/core/quickstart.md).
+- Is the same shape developers read about in [the Guide introduction
+  — a tiny counter application](../../../docs/core/introduction.md).
 - Matches the per-substrate `examples/<substrate>/counter*/`
   reference apps.
 - Uses the smallest amount of re-frame2 surface that demonstrates


### PR DESCRIPTION
Closes rf2-vpc4c.

`scripts/check_doc_slugs.py` — the repo's real anchor gate — could not see a markdown link whose text wraps across a newline. `_extract_links` iterated `text.splitlines()`, so a link whose `](target#anchor)` landed on the following line never matched `_LINK_RE` and was therefore **never validated**.

This matters because there is no second gate behind it: `mkdocs build --strict` reports a broken anchor as `INFO` and still exits 0 (visible in the transcript below). A wrapped link had no gate at all, so every heading rename in this repo's history could have orphaned one with CI green.

## What changed

Link extraction now runs over **blank-line-delimited blocks** joined with a newline, instead of line by line. Three judgement calls in the mechanism:

- **The join stops at a block boundary.** No markdown inline construct survives a blank line, so text either side of one can never be one link. This is what keeps the fix from inventing links — a naive whole-file join fabricates three in the `wrapped_link_block_bound` fixture alone.
- **Inline code is masked per line, before the join.** A CommonMark code span closes on the line it opens; masking the joined text would let a stray backtick swallow everything up to a backtick on some later line, and any real link in between with it.
- **The reported line is the destination's, not the opening `[`'s.** For an unwrapped link these are the same line, so single-line diagnostics are byte-identical to before. For a wrapped one, the destination's line is the line an author edits — and it is the robust choice, since an unclosed stray `[` earlier in the block can drag the match start backwards but never the destination.

`_LINK_RE` itself is unchanged. Its negated character classes always matched `\n`; the only thing wrong was what it was being fed. The destination still forbids whitespace, because CommonMark does not permit a bare destination to wrap either.

**Third instance, so the extractor is now shared.** `scripts/check_readme_links.py` carried a verbatim copy of `_extract_links` and inherited the identical blindness. It already imports the slugifier and masking helpers from `check_doc_slugs` (a deliberate direct import, per its own module docstring), so that is where the shared helper belongs — no new module. The copy is deleted and the one extractor imported. The README gate gains wrapped-link coverage over 68 READMEs (15 wrapped links, none already broken).

## Corpus sweep

| Measure | Count |
| --- | --- |
| Markdown files scanned | 588 |
| **Wrapped links in the corpus** (invisible to the old extractor) | **100** |
| **Already broken among them** | **6** |
| Links the new extractor reports that are *not* genuinely wrapped (false positives) | **0** |
| Links the old extractor saw that the new one loses | **0** |

The false-positive column is the one that mattered, per the risk that a join stitches a table cell or two adjacent lines into a link. Every one of the 100 new extractions was verified to be a genuine wrap — its `[` on an earlier line than its destination — with nothing lost in the other direction.

### The 6 already-broken wrapped links, all fixed here

Four are relative-path depth errors that had been unguarded since they were written; two point at a page deleted in #5210.

| Link | Was | Now |
| --- | --- | --- |
| `tools/machines-viz/spec/API.md:1910` | `../../spec/009-Instrumentation.md` | `../../../spec/009-Instrumentation.md` |
| `tools/machines-viz/spec/API.md:2178` | `../../spec/009-Instrumentation.md` | `../../../spec/009-Instrumentation.md` |
| `tools/machines-viz/spec/API.md:2273` | `../../spec/009-Instrumentation.md` | `../../../spec/009-Instrumentation.md` |
| `tools/story/spec/017-Testing-Story.md:749` | `../../spec/006-ReactiveSubstrate.md#…` | `../../../spec/006-ReactiveSubstrate.md#…` |
| `tools/template/spec/DESIGN-RATIONALE.md:143` | `../../../docs/core/quickstart.md` | `../../../docs/core/introduction.md` |
| `tools/template/spec/Principles.md:42` | `../../../docs/core/quickstart.md` | `../../../docs/core/introduction.md` |

The depth errors are unambiguous: `../../../spec/` is the convention in those same files (9 correct occurrences in `machines-viz/spec/API.md` against the 3 broken ones). `docs/core/quickstart.md` was removed by #5210 ("Introduction (was core/README.md) and Our First App (was quickstart.md)"); the counter walkthrough it named now lives in `docs/core/introduction.md`, so the link text names the live page.

**One more, outside the gate's scope.** The sweep also surfaced the same deleted page linked as an external GitHub URL from `migration/from-clj-new-template/README.md:144` — also wrapped. The gate skips external URLs by design, so it will never catch this; it is knowingly dead and one line, so it is repointed here rather than left.

No corpus reflowing: every wrapped link stays wrapped. Reflowing treats the symptom and silently regresses.

## Tests

Three fixtures plus a direct-drive tooth block. Both fixtures that pin new behaviour were verified **causal** — they fail against the code they guard against, rather than merely passing:

- `wrapped_link_broken_anchor` (expect 2) — the permanent negative control, including the blockquoted wrap that is the real-corpus shape. The old per-line extractor sees **zero links** in this fixture.
- `wrapped_link_ok` (expect 0) — correct wrapped links: plain, three-line, same-file, blockquoted, and a wrapped backticked placeholder that must stay masked.
- `wrapped_link_block_bound` (expect 0) — the false-positive control. A naive whole-file join invents **three** links here; the block bound must yield none.

The `extraction_cases` block drives `_iter_inline_links` with explicit line lists, pinning the **positive control** (a single-line link still extracts, at its own line number), the wrapped case, the blockquote case, blank-line and fence boundaries, that a wrapped *destination* is not a link, and that a stray `[` cannot lose the destination.

The fixture README table had drifted independently — it listed three fixtures that no longer exist and a retired `--synthesis-only` flag, and was missing four that do. Corrected while adding the new rows.

## Quality gates

Negative control on real corpus content, both directions, against the fixed gate:

```
$ sed -n 272,273p spec/API.md
> that tree was tombstoned at the S3→S4 boundary (rf2-mgy7pz, 2026-07-18). [§Compiled
> views](#compiled-views-RETIRED-SLUG) above is the **live shipping projection**;

$ python scripts/check_doc_slugs.py

1 broken anchor link(s) found:

  BROKEN ANCHOR: spec\API.md:273 -> #compiled-views-RETIRED-SLUG
      (target: spec\API.md)

Fix: confirm the heading still exists in the target file and update the link, or rename the heading and re-link.
EXIT=1

$ git checkout -- spec/API.md
$ python scripts/check_doc_slugs.py
EXIT=0

$ git diff --numstat
(empty = no residue)
$ git status --short
(empty = clean)
```

For contrast, the same break **before** this PR — on current `main`, with the single-line equivalent at `spec/API.md:31` broken to the *same* retired slug at the same time:

```
$ python scripts/check_doc_slugs.py     # pre-fix, BOTH broken

1 broken anchor link(s) found:

  BROKEN ANCHOR: spec\API.md:31 -> #compiled-views-re-frame-ui-RETIRED-SLUG
      (target: spec\API.md)

EXIT=1
```

Two identical breaks, one detected. The wrapped one at 272-273 was invisible; after the fix both are named.

| Gate | Result |
| --- | --- |
| `python scripts/check_doc_slugs.py --self-test` | 0 — all 45 self-tests passed (was 35) |
| `python scripts/check_doc_slugs.py --verbose` | 0 — 588 files, no broken links |
| `python scripts/check_readme_links.py --self-test` | 0 — all 13 self-tests passed |
| `python scripts/check_readme_links.py --ci` | 0 |
| `python scripts/check_freehand_conformance_index.py` | 0 — imports `_slug_index` from this module |
| `python scripts/check_ep_status_sync.py` | 0 |
| `python scripts/check_readme_inventories.py` | 0 |
| `python scripts/check_skill_redirect_anchors.py` | 0 |
| `python -m mkdocs build --strict` | 0 — built in 20.24s |

The `mkdocs build --strict` run exits 0 while printing `INFO - Doc file '…' contains an unrecognized relative link '…'`, which is the bead's premise: mkdocs is not the anchor gate, this checker is.
