### PR TITLE
fix(docs): bound wrapped-link extraction to real Markdown blocks (rf2-8wcbe)

### DIFF
--- a/scripts/_test_fixtures/check_doc_slugs/README.md
+++ b/scripts/_test_fixtures/check_doc_slugs/README.md
@@ -36,4 +36,6 @@ Fixtures:
 | `wrapped_link_broken_anchor`       | 2               | A link whose TEXT wraps across a newline is still validated (rf2-vpc4c)            |
 | `wrapped_link_ok`                  | 0               | Correct wrapped links — plain, multi-line, same-file, blockquoted — are not flagged (rf2-vpc4c) |
 | `wrapped_link_block_bound`         | 0               | False-positive control: the join stops at a block boundary, so `[text` … blank … `](x.md)` is not a link (rf2-vpc4c) |
+| `multiline_code_span_not_a_link`   | 1               | A code span crossing a line ending is masked whole, so the link-shaped text inside it yields nothing; the 1 is a real broken wrapped link (rf2-8wcbe) |
+| `non_blank_block_bound`            | 1               | The join stops at every NON-blank boundary — heading (before and after), thematic break, list item, table row, blockquote entry; the 1 is a real wrapped link inside one list item (rf2-8wcbe) |
 | `compat_anchor_teeth`              | driven directly | The compat-anchor manifest, placement, and source-comment teeth — invoked with explicit fixture inputs, not from this table (rf2-57k74 / rf2-zq5i6 / rf2-k30r7) |

--- a/scripts/_test_fixtures/check_doc_slugs/multiline_code_span_not_a_link/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/multiline_code_span_not_a_link/docs/index.md
@@ -1,0 +1,20 @@
+# Index — A Multiline Code Span Is Not A Link (rf2-8wcbe)
+
+A CommonMark code span may contain a line ending, so the backticked text
+below is one `<code>` element and holds no link at all — python-markdown
+renders it as `<p><code>[literal link](missing-in-a-code-span.md)</code></p>`.
+Masking inline code per LINE could not see that: neither backtick has a
+partner on its own line, so neither was masked, the joined lines matched the
+link regex, and a target the renderer never produces was reported broken.
+
+`[literal
+link](missing-in-a-code-span.md)`
+
+The expected count for this fixture is 1, not 0, and deliberately so: a
+fixture that only asserted "nothing found" would pass just as well if
+extraction stopped working altogether. The one finding comes from the REAL
+wrapped link below, whose target genuinely does not exist and must still be
+flagged as a BROKEN TARGET.
+
+A real link whose text wraps across a newline and whose [target does not
+exist](missing-for-real.md).

--- a/scripts/_test_fixtures/check_doc_slugs/multiline_code_span_not_a_link/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/multiline_code_span_not_a_link/mkdocs.yml
@@ -1,0 +1,1 @@
+# Self-test fixture marker.

--- a/scripts/_test_fixtures/check_doc_slugs/non_blank_block_bound/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/non_blank_block_bound/docs/index.md
@@ -1,0 +1,54 @@
+# Index — Non-Blank Block Bounds The Join (rf2-8wcbe)
+
+A blank line is a block boundary, but it is not the only one. Every pair
+below sits either side of a boundary that is NOT a blank line, so no
+renderer produces a link from it and the extractor must not either. The
+first is the counterexample from the bead: python-markdown renders a
+paragraph, an H1 and a second paragraph — three blocks, no link.
+
+A stray [opening
+# Separate heading
+](missing-across-a-heading.md)
+
+A single-line leaf block also ENDS where it starts — nothing continues an
+ATX heading — so a stray bracket in a heading title cannot reach into the
+paragraph underneath it:
+
+## A heading holding a stray [ bracket
+](missing-under-a-heading.md) opens the paragraph below it.
+
+A thematic break (read as a setext underline here, which ends the paragraph
+above it just the same) bounds the join:
+
+A stray bracket before a rule [here
+---
+](missing-across-a-rule.md) after it.
+
+Each list item is its own container, so a stray bracket cannot bleed into
+the next bullet:
+
+* A bullet holding a stray [ bracket
+* the next bullet](missing-across-a-bullet.md) closes the list.
+
+A table's rows render as separate cells; no inline construct spans two of
+them:
+
+| Column                        | Note |
+| ----------------------------- | ---- |
+| A cell holding a stray [      | one  |
+| a later row](missing-across-a-table-row.md) | two |
+
+A blockquote interrupts the paragraph above it:
+
+A paragraph holding a stray [ bracket
+> and a quote](missing-across-a-quote.md) that interrupts it.
+
+The expected count for this fixture is 1, not 0, and deliberately so: a
+fixture that only asserted "nothing found" would pass just as well if
+extraction stopped working altogether — the mirror-image failure, where
+bounding the join discards real links. The one finding is the wrapped link
+below, which lives INSIDE a single list item (its continuation line carries
+no marker, so it is one inline run) and is genuinely broken:
+
+* A bullet whose link text wraps onto its continuation line, [which must
+  still be extracted and flagged](missing-for-real.md).

--- a/scripts/_test_fixtures/check_doc_slugs/non_blank_block_bound/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/non_blank_block_bound/mkdocs.yml
@@ -1,0 +1,1 @@
+# Self-test fixture marker.

--- a/scripts/_test_fixtures/check_readme_links/README.md
+++ b/scripts/_test_fixtures/check_readme_links/README.md
@@ -26,6 +26,7 @@ Fixtures:
 | `dup_suffix_out_of_range_broken`     | 1        | Negative control: `#errors-2` with only two duplicates — the counter is bounded, not a wildcard.     |
 | `github_dup_collision_bump_ok`       | 0        | `## Errors-1` after two `## Errors` → `errors-1-1` (the slugger re-bumps on collision).              |
 | `inline_code_link_ignored`           | 0        | Broken-looking links inside fenced code blocks AND inline code spans — skipped.                      |
+| `block_bound_link_ignored`           | 1        | The shared extractor's block bound + multiline code-span mask reach this gate; the 1 is a real broken wrapped link. |
 | `external_link_skipped_by_default`   | 0        | External `https://` URL — skipped without `--check-external` (the default + `--ci` mode).            |
 | `explicit_id_full_title_ok`          | 0        | `## One {#dup}` is heading TEXT — the id is the full-title slug `one-dup`, so that link resolves.    |
 | `explicit_id_brace_not_a_target`     | 1        | Negative control: a link to the brace id `#dup` targets nothing → flagged.                           |

--- a/scripts/_test_fixtures/check_readme_links/block_bound_link_ignored/README.md
+++ b/scripts/_test_fixtures/check_readme_links/block_bound_link_ignored/README.md
@@ -1,0 +1,25 @@
+# Block Bound Link Ignored
+
+This gate imports `_extract_links` from `check_doc_slugs.py` rather than
+carrying its own copy, so the block bound and the multiline code-span mask
+must reach it too (rf2-8wcbe). Both samples below are link-SHAPED text that
+no renderer turns into a link.
+
+A code span may contain a line ending, so this is one `<code>` element:
+
+`[literal
+link](missing-in-a-code-span.md)`
+
+An ATX heading is a block boundary even without a blank line around it, so
+these three lines are a paragraph, an H1 and a second paragraph:
+
+A stray [opening
+# Separate heading
+](missing-across-a-heading.md)
+
+The expected count is 1, not 0: the finding below is a REAL wrapped link
+whose target does not exist, so this fixture fails if a phantom is invented
+AND if the shared extractor stops seeing wrapped links at all.
+
+A real link whose text wraps and whose [target does not
+exist](missing-for-real.md).

--- a/scripts/_test_fixtures/check_readme_links/block_bound_link_ignored/mkdocs.yml
+++ b/scripts/_test_fixtures/check_readme_links/block_bound_link_ignored/mkdocs.yml
@@ -1,0 +1,1 @@
+# Self-test fixture marker.

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -1438,6 +1438,13 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("wrapped_link_broken_anchor",       2),  # negative control
         ("wrapped_link_ok",                  0),  # no false positives
         ("wrapped_link_block_bound",         0),  # join stops at a blank line
+        # rf2-8wcbe — the join must not bridge a NON-blank block boundary, and
+        # inline code must be masked over the same unit the link regex scans.
+        # Each expects 1, not 0: the single finding is a REAL broken wrapped
+        # link, so the count fails in BOTH directions — upward if a phantom is
+        # invented, downward if bounding the join discards real links.
+        ("multiline_code_span_not_a_link",   1),
+        ("non_blank_block_bound",            1),
     ]
 
     failures = 0
@@ -1750,11 +1757,15 @@ def _run_self_tests(verbose: bool = False) -> int:
             "rejects the drifted mutation\n"
         )
 
-    # rf2-vpc4c — link extraction driven directly with explicit line lists, so
-    # the wrap contract is pinned at the mechanism rather than only through a
-    # fixture's aggregate count. Each case states the (line_no, destination)
-    # pairs `_iter_inline_links` must yield from fence-stripped, inline-code-
-    # masked input. `_extract_links` reduces a file to exactly this shape.
+    # rf2-vpc4c / rf2-8wcbe — link extraction driven directly with explicit line
+    # lists, so the wrap contract is pinned at the mechanism rather than only
+    # through a fixture's aggregate count. Each case states the (line_no,
+    # destination) pairs `_iter_inline_links` must yield from FENCE-STRIPPED
+    # input — `_extract_links` reduces a file to exactly this shape, and inline
+    # code is masked inside `_iter_inline_links` over the joined unit, so these
+    # inputs are raw source lines. The cases run in both directions: the join
+    # must reach across a wrap (rf2-vpc4c) and must stop at every real block
+    # boundary and inside a multiline code span (rf2-8wcbe).
     extraction_cases: list[tuple[str, list[tuple[int, str]], list[tuple[int, str]]]] = [
         # POSITIVE CONTROL — the unwrapped case that always worked. The reported
         # line is the link's own line, exactly as before the fix.
@@ -1792,6 +1803,63 @@ def _run_self_tests(verbose: bool = False) -> int:
         # The destination itself is still correct and still found.
         ("stray bracket does not lose the destination",
          [(1, "An unclosed [ bracket opens here,"),
+          (2, "and [the real link](target.md#anchor) follows.")],
+         [(2, "target.md#anchor")]),
+        # rf2-8wcbe — NON-BLANK block boundaries. A blank line is not the only
+        # boundary; each pair below spans a real one, so no renderer produces a
+        # link from it. THE BEAD'S SECOND COUNTEREXAMPLE leads.
+        ("ATX heading is not bridged",
+         [(1, "A stray [opening"), (2, "# Separate heading"),
+          (3, "](missing.md)")],
+         []),
+        ("a heading does not reach the paragraph below it",
+         [(1, "# A heading holding a stray ["),
+          (2, "bracket](missing.md) opens the next paragraph.")],
+         []),
+        ("thematic break / setext underline is not bridged",
+         [(1, "A stray bracket [here"), (2, "---"), (3, "](missing.md) after.")],
+         []),
+        ("list-item start is not bridged",
+         [(1, "* A bullet holding a stray ["),
+          (2, "* the next bullet](missing.md) closes the list.")],
+         []),
+        ("table row is not bridged",
+         [(1, "| A cell holding a stray [ | one |"),
+          (2, "| a later row](missing.md) | two |")],
+         []),
+        ("blockquote entry is not bridged",
+         [(1, "A paragraph holding a stray ["),
+          (2, "> and a quote](missing.md) interrupts it.")],
+         []),
+        # POSITIVE CONTROLS for those bounds — the mirror-image failure is
+        # bounding so aggressively that real wrapped links are discarded.
+        # A list item's CONTINUATION line carries no marker, and an unprefixed
+        # line after a quoted one is CommonMark lazy continuation: both are one
+        # inline run, so a link wrapping inside them is still extracted.
+        ("wrapped link inside one list item still extracted",
+         [(1, "* See [the compiled"),
+          (2, "  views](API.md#compiled-views) doc.")],
+         [(2, "API.md#compiled-views")]),
+        ("blockquote lazy continuation still joins",
+         [(1, "> Per the note, [§Compiled"),
+          (2, "views](API.md#compiled-views) is live.")],
+         [(2, "API.md#compiled-views")]),
+        # rf2-8wcbe — code spans are masked over the JOINED unit, because a
+        # CommonMark code span may contain a line ending. THE BEAD'S FIRST
+        # COUNTEREXAMPLE: per-line masking saw two unpaired backticks, masked
+        # neither, and invented a link the renderer never produces.
+        ("multiline code span yields no link",
+         [(1, "`[literal"), (2, "link](missing.md)`")],
+         []),
+        ("multiline code span masks only itself",
+         [(1, "See [the doc](target.md#anchor) and a `[fake"),
+          (2, "link](nowhere.md)` placeholder.")],
+         [(1, "target.md#anchor")]),
+        # POSITIVE CONTROL for the mask: an UNPAIRED backtick opens no span in
+        # CommonMark, so it must not swallow the rest of the unit — the risk
+        # that kept masking per-line in the first place.
+        ("unpaired backtick masks nothing",
+         [(1, "A stray ` backtick opens no span,"),
           (2, "and [the real link](target.md#anchor) follows.")],
          [(2, "target.md#anchor")]),
     ]

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -135,8 +135,10 @@ _HTML_ANCHOR_RE = re.compile(
 # `[§Compiled\nviews](Doc.md#anchor)` is one rendered link.  The negated
 # character classes match `\n` already — what mattered was that `_extract_links`
 # fed this regex one line at a time, so a wrapped link never matched and was
-# never validated (rf2-vpc4c).  It is now run over a joined block (see
-# `_iter_inline_links`).  The DESTINATION deliberately still forbids whitespace
+# never validated (rf2-vpc4c).  It is now run over one joined INLINE BLOCK (see
+# `_iter_inline_links` / `_inline_blocks`), which is the largest span the
+# renderer parses as a single run of inline text — and therefore the largest
+# span over which a link may legitimately wrap.  The DESTINATION still forbids whitespace
 # (`[^)\s]+`): CommonMark does not permit a bare destination to wrap, so a
 # newline there is not a link the renderer would produce either.
 _LINK_RE = re.compile(r"\[(?:[^\]\\]|\\.)*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
@@ -157,13 +159,96 @@ _FENCE_RE = re.compile(r"^(```|~~~)")
 # (often) flag it as BROKEN TARGET.
 #
 # Scope:
-# * Single-line only.  Multi-line inline code is rare in this corpus and
-#   the validator already processes line-by-line after `_strip_fences`.
+# * Single-line only — this is the ANCHOR-recognition variant, applied by
+#   `_strip_inline_code` to one line at a time (see `_scan_rendered_ids`).
+#   Link extraction uses `_INLINE_CODE_SPAN_RE` below, which spans the whole
+#   joined scan unit because a code span may legally cross a line ending.
 # * Backslash escaping of backticks (`\``) is NOT honoured — CommonMark
 #   itself does not honour it; backticks are always literal markup.
 # * `_strip_fences` has already blanked fenced-block lines, so this regex
 #   never sees the language tag of a fence as a stray backtick run.
 _INLINE_CODE_RE = re.compile(r"(`+)(?:.+?)\1(?!`)")
+
+# The same span rule, applied over a JOINED scan unit (rf2-8wcbe).  Identical
+# to `_INLINE_CODE_RE` but for `re.DOTALL`: CommonMark §6.1 explicitly permits
+# a code span to contain a line ending, so
+#
+#     `[literal
+#     link](missing.md)`
+#
+# is ONE `<code>` element and contains no link at all.  Masking per line could
+# not see that — neither backtick has a partner on its own line, so neither was
+# masked, the lines were joined, and `_LINK_RE` invented a link the renderer
+# never produces.  Masking over the same unit the link regex scans is what makes
+# the two agree.  A backtick run with no matching partner anywhere in the unit
+# still opens no span (the regex simply does not match), which is also what
+# CommonMark does — an unpaired backtick is literal text.
+_INLINE_CODE_SPAN_RE = re.compile(r"(`+)(?:.+?)\1(?!`)", re.DOTALL)
+
+# Non-blank block boundaries (rf2-8wcbe).  A blank line is a block boundary in
+# every markdown flavour, but it is NOT the only one: these leaf blocks all
+# INTERRUPT an open paragraph, so the text either side of one is never a single
+# run of inline content and no inline construct — link, emphasis, code span —
+# can bridge them.  Recognising them is what stops the join from stitching
+#
+#     A stray [opening
+#     # Separate heading
+#     ](missing.md)
+#
+# (a paragraph, an H1 and a second paragraph — three rendered blocks) into a
+# link to `missing.md` that python-markdown never produces.
+#
+# Deliberately bounded: this is boundary recognition for a CI guard, not a
+# markdown parser.  Only the interrupting starters this corpus actually uses are
+# listed, each matched at the ≤3-space indent CommonMark allows (4+ spaces is an
+# indented code block, which cannot interrupt a paragraph and so is a
+# continuation line here, exactly as it is for the renderer).  They split in two
+# by whether the block can be CONTINUED by the following line:
+#
+# `_LEAF_LINE_BLOCK_RE` — blocks that are complete on their own line, so they
+# bound the unit on BOTH sides (nothing after them continues them either):
+#   * ATX heading — `#` .. `######`.
+#   * Thematic break / setext underline — `---`, `***`, `___`, `===`.  A setext
+#     underline ENDS the paragraph above it (turning it into a heading), so it
+#     bounds the unit either way and the two readings need not be told apart.
+#   * Table row — a leading `|`.  A table's rows render as separate cells; no
+#     inline construct spans two of them.
+#
+# `_LIST_ITEM_START_RE` — a container that DOES continue, so it opens a unit but
+# does not close one:
+#   * `-`/`+`/`*` or `1.`/`1)`.  Each item is its own container, so the corpus's
+#     very common one-link-per-bullet lists cannot bleed a stray bracket into the
+#     next bullet — while a continuation line of an item carries no marker, so a
+#     link wrapping inside one item still joins.
+#
+# Blockquote entry is handled separately in `_inline_blocks` because it is
+# relative, not absolute: entering (or nesting deeper into) a quote interrupts
+# the paragraph above, while a following unprefixed line is CommonMark lazy
+# continuation of the quoted paragraph and must NOT bound the unit.
+_LEAF_LINE_BLOCK_RE = re.compile(
+    r"""^[ ]{0,3}(?:
+          \#{1,6}(?:[ \t]|$)              # ATX heading
+        | (?:\*[ \t]*){3,}$               # thematic break ***
+        | (?:-[ \t]*){3,}$                # thematic break --- / setext H2
+        | (?:_[ \t]*){3,}$                # thematic break ___
+        | =+[ \t]*$                       # setext H1 underline
+        | \|                              # table row
+    )""",
+    re.VERBOSE,
+)
+
+_LIST_ITEM_START_RE = re.compile(
+    r"""^[ ]{0,3}(?:
+          [-+*](?:[ \t]|$)                # bullet list item
+        | \d{1,9}[.)](?:[ \t]|$)          # ordered list item
+    )""",
+    re.VERBOSE,
+)
+
+# Leading blockquote markers, e.g. `> ` or `> > `.  The count of `>` is the
+# quote depth; the remainder is the quoted line's own content, which is what
+# `_BLOCK_START_RE` must be tested against (a `> # Heading` is still a heading).
+_QUOTE_PREFIX_RE = re.compile(r"^(?:[ ]{0,3}>[ \t]?)+")
 
 
 # rf2-t0ituo / rf2-57k74 — cross-handbook compatibility-anchor manifest +
@@ -624,32 +709,87 @@ def _strip_inline_code(line: str) -> str:
     return _INLINE_CODE_RE.sub(lambda m: " " * (m.end() - m.start()), line)
 
 
-def _blank_line_blocks(
+def _quote_depth_and_body(content: str) -> tuple[int, str]:
+    """Split a line into its blockquote depth and the quoted line's own content."""
+    m = _QUOTE_PREFIX_RE.match(content)
+    if not m:
+        return 0, content
+    return m.group(0).count(">"), content[m.end():]
+
+
+def _inline_blocks(
     pairs: Iterable[tuple[int, str]],
 ) -> Iterable[list[tuple[int, str]]]:
-    """Group (line_no, content) pairs into blank-line-separated blocks.
+    """Group (line_no, content) pairs into single INLINE blocks.
 
-    A blank line ends a block.  This is the unit over which a markdown inline
-    construct may wrap: a paragraph (or table, or list) is parsed as one run of
-    inline text, and NO inline construct survives a blank line — a blank line is
-    a block boundary in every markdown flavour.  Scanning per block rather than
-    per line is what lets `_iter_inline_links` see a wrapped link; bounding the
-    join at the blank line is what stops it from stitching two unrelated
-    paragraphs into a link that no renderer would produce (rf2-vpc4c).
+    A scan unit is a maximal run of lines the renderer parses as ONE run of
+    inline content, so it is exactly the span over which a markdown inline
+    construct may wrap.  Scanning per unit rather than per line is what lets
+    `_iter_inline_links` see a wrapped link (rf2-vpc4c); bounding the unit at
+    every real block boundary is what stops it from stitching unrelated blocks
+    into a link no renderer would produce (rf2-8wcbe).
 
-    Fence lines and fenced-block bodies arrive already blanked by
-    `_strip_fences`, so a code block is a block boundary here too, for free.
+    Four kinds of boundary end a unit:
+
+    1. A blank line — the universal block boundary.  Fence lines and
+       fenced-block bodies arrive already blanked by `_strip_fences`, so a code
+       block bounds a unit here too, for free.
+    2. A paragraph-interrupting block start — `_LEAF_LINE_BLOCK_RE` (ATX
+       heading, thematic break / setext underline, table row) or
+       `_LIST_ITEM_START_RE`.  The line STARTS the next unit rather than being
+       dropped, so a link that lives on it is still extracted.
+    3. The END of a single-line leaf block: nothing continues an ATX heading, a
+       thematic break or a table row, so the following line opens a fresh unit
+       and a stray `[` in a heading cannot reach into the paragraph under it.
+       A list item is a container that DOES continue, so it only opens a unit.
+    4. Entering a blockquote (or nesting one level deeper).  A quote interrupts
+       the paragraph above it.  The converse is not a boundary: an unprefixed
+       line after a quoted one is CommonMark lazy continuation of the SAME
+       quoted paragraph, and a `>`-prefixed continuation line inside one quote
+       keeps the depth unchanged — which is why the corpus's blockquoted
+       wrapped links still join.
+
+    The block tests run against the line's content with any blockquote markers
+    removed, so `> ## Heading` bounds a unit just as `## Heading` does.
     """
     block: list[tuple[int, str]] = []
+    prev_depth = 0
+    ended = False
     for line_no, content in pairs:
         if not content.strip():
             if block:
                 yield block
                 block = []
+            prev_depth = 0
+            ended = False
             continue
+        depth, body = _quote_depth_and_body(content)
+        leaf = bool(_LEAF_LINE_BLOCK_RE.match(body))
+        if block and (
+            ended or leaf or depth > prev_depth or _LIST_ITEM_START_RE.match(body)
+        ):
+            yield block
+            block = []
         block.append((line_no, content))
+        prev_depth = depth
+        ended = leaf
     if block:
         yield block
+
+
+def _mask_code_spans(text: str) -> str:
+    """Mask inline-code spans across a joined scan unit (rf2-8wcbe).
+
+    Length- and newline-preserving, so a match position in the masked text still
+    maps back to its source line.  Unlike the per-line `_strip_inline_code`, this
+    honours CommonMark §6.1's allowance for a code span to contain a line ending
+    — the reason a backticked, line-wrapped link PLACEHOLDER must not be
+    extracted as a link.
+    """
+    def _blank(m: re.Match[str]) -> str:
+        return "".join("\n" if ch == "\n" else " " for ch in m.group(0))
+
+    return _INLINE_CODE_SPAN_RE.sub(_blank, text)
 
 
 def _iter_inline_links(
@@ -658,14 +798,20 @@ def _iter_inline_links(
     """Yield (line-number, destination) for every inline link in the given lines.
 
     `pairs` are (line_no, content) pairs the CALLER has already reduced to
-    scannable source — fence-stripped and inline-code-masked.
+    scannable source — fence-stripped.  Inline code is masked HERE, over the
+    joined unit, not by the caller (rf2-8wcbe).
 
-    Each blank-line-delimited block is joined with `\\n` and scanned as ONE
+    Each inline block (`_inline_blocks`) is joined with `\\n` and scanned as ONE
     string, so a link whose text wraps across a newline is seen.  The
     predecessor scanned line by line, so `](target#anchor)` landing on the
     following line never matched `_LINK_RE` and the link was therefore never
     validated — silently unguarded, since `mkdocs build --strict` reports a
     broken anchor as INFO and still exits 0 (rf2-vpc4c).
+
+    Masking runs over the same joined unit `_LINK_RE` scans, so the two agree on
+    what the text is: a code span that crosses a line ending is masked whole and
+    yields no link, where per-line masking saw two unpaired backticks, masked
+    neither, and invented one (rf2-8wcbe).
 
     The reported line is the one carrying the DESTINATION (`m.start(1)`), not
     the one carrying the opening `[`.  For an unwrapped link the two are the
@@ -674,10 +820,10 @@ def _iter_inline_links(
     the more robust of the two — an unclosed stray `[` earlier in the block can
     drag the match start backwards, but never the destination.
     """
-    for block in _blank_line_blocks(pairs):
-        joined = "\n".join(content for _, content in block)
+    for block in _inline_blocks(pairs):
+        joined = _mask_code_spans("\n".join(content for _, content in block))
         # Offset of each line's first character within `joined`, for mapping a
-        # match position back to a line number.  `_strip_inline_code` masks
+        # match position back to a line number.  `_mask_code_spans` masks
         # length-preservingly, so these offsets are exact.
         line_starts: list[int] = []
         offset = 0
@@ -695,18 +841,15 @@ def _extract_links(path: Path) -> Iterable[tuple[int, str]]:
     Links inside fenced code blocks AND inside inline-code spans are
     skipped — both are "code", not real cross-references (rf2-mqv8s).
     Links that wrap across a newline ARE seen (rf2-vpc4c) — see
-    `_iter_inline_links`.
+    `_iter_inline_links`, which is also where inline code is masked and where
+    the join is bounded to one rendered inline block (rf2-8wcbe).
 
-    Inline code is masked per LINE, before the block join: a CommonMark code
-    span closes on the line it opens, so masking the joined text would let a
-    stray backtick swallow everything up to a backtick on some later line —
-    and with it any real link in between.
+    This function's only job is reducing the file to fence-stripped
+    (line_no, content) pairs.  `check_readme_links.py` imports it so both gates
+    share one extractor and cannot drift apart (rf2-vpc4c).
     """
     text = path.read_text(encoding="utf-8", errors="replace")
-    yield from _iter_inline_links(
-        (line_no, _strip_inline_code(content))
-        for line_no, content in _strip_fences(text.splitlines())
-    )
+    yield from _iter_inline_links(_strip_fences(text.splitlines()))
 
 
 def _resolve_target(

--- a/scripts/check_readme_links.py
+++ b/scripts/check_readme_links.py
@@ -511,6 +511,11 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("dup_suffix_out_of_range_broken",   1),  # `#errors-2` with only two headings
         ("github_dup_collision_bump_ok",     0),  # `## Errors-1` after two `## Errors`
         ("inline_code_link_ignored",         0),  # fence + inline-code guard
+        # rf2-8wcbe — the shared extractor's block bound and multiline
+        # code-span mask reach this gate too. Expects 1, not 0: the finding is
+        # a REAL broken wrapped link, so the count moves if a phantom is
+        # invented (up) or if wrapped links stop being seen (down).
+        ("block_bound_link_ignored",         1),
         ("external_link_skipped_by_default", 0),  # off without --check-external
         ("explicit_id_full_title_ok",        0),  # `{#id}` is heading TEXT (rf2-w6ltl)
         ("explicit_id_brace_not_a_target",   1),  # ...so the brace id resolves nowhere


### PR DESCRIPTION
Closes rf2-8wcbe.

PR #6690 correctly made line-wrapped links visible to `scripts/check_doc_slugs.py` — this repo's real anchor gate, since `mkdocs build --strict` logs broken anchors as INFO and exits 0. But it grouped lines into scan units with `_blank_line_blocks`, which equates "no blank line" with "one Markdown inline block". A blank line is a block boundary; it is not the only one. And a CommonMark code span may legally cross a line ending, while `_strip_inline_code` masked one line at a time. Both gaps let the join invent links the renderer never produces.

This keeps the shared extractor and the wrapped-link capability, and bounds the join to the span the renderer actually parses as one run of inline content.

## The two counterexamples

Both are mechanism defects, not live-corpus breakage — the corpus is green, which is exactly why they need regression tests rather than a corpus sweep. Verified against `main` before changing anything:

**1. A multiline code span.** One backtick before `[`, one after `)`:

```markdown
`[literal
link](missing.md)`
```

```
>>> markdown.markdown('`[literal\nlink](missing.md)`')
'<p><code>[literal\nlink](missing.md)</code></p>'          # one <code>, no link

main:  _iter_inline_links(...) -> [(2, 'missing.md')]      # phantom
here:  _iter_inline_links(...) -> []
```

Neither backtick has a partner on its own line, so per-line masking masked neither, the lines were joined, and `_LINK_RE` matched.

**2. Real block boundaries with no blank line.**

```markdown
A stray [opening
# Separate heading
](missing.md)
```

```
>>> markdown.markdown('A stray [opening\n# Separate heading\n](missing.md)')
'<p>A stray [opening</p>\n<h1>Separate heading</h1>\n<p>](missing.md)</p>'   # three blocks

main:  _iter_inline_links(...) -> [(3, 'missing.md')]      # phantom
here:  _iter_inline_links(...) -> []
```

## The repair

`_blank_line_blocks` becomes `_inline_blocks`, and inline code is masked over the joined unit rather than per line.

A unit now ends at:

- a blank line (as before — fenced blocks arrive pre-blanked by `_strip_fences`, so they bound a unit for free);
- a paragraph-interrupting block start: ATX heading, thematic break / setext underline, table row, list-item marker. The boundary line *starts* the next unit rather than being dropped, so a link living on it is still extracted;
- the end of a single-line leaf block — nothing continues an ATX heading, a thematic break or a table row, so a stray `[` in a heading title cannot reach the paragraph beneath it. A list item is a container that *does* continue, so it only opens a unit;
- entering a blockquote, or nesting one level deeper. The converse is deliberately not a boundary: an unprefixed line after a quoted one is CommonMark lazy continuation of the same quoted paragraph.

`_INLINE_CODE_SPAN_RE` is `_INLINE_CODE_RE` plus `re.DOTALL`, applied to the joined unit, length- and newline-preserving so destination-line reporting stays exact. An unpaired backtick run still opens no span and masks nothing — which is what CommonMark does, and the risk that motivated per-line masking in the first place. It is pinned by a positive control.

Deliberately not done, per the bead's non-goals: no general-purpose Markdown parser, and no document reflowed to hide the problem. Python-Markdown's own block machinery was considered and rejected — it discards line numbers, and every diagnostic this gate emits is `file:line`.

`check_readme_links.py` keeps importing `_extract_links`, so both gates are still one implementation and get the fix together; a new README-side fixture proves it.

## Balance — the three numbers

Bounding a join can fail in the mirror direction, discarding real links. Measured over the full corpus before and after:

| | before (main) | after |
| --- | --- | --- |
| corpus links extracted | 16838 | **16838** |
| wrapped-only links (invisible to a per-line scan — the #6690 capability) | 100 | **100** |
| phantoms from the two counterexamples | 2 | **0** |

The full `file:line -> destination` inventory is **byte-identical** before and after — not merely equal in count. Nothing was lost and nothing was invented across 588 files: the live corpus contained no phantom (it is green), and every one of the 100 wrapped links #6690 made visible is still extracted and still validated.

## Wrapped-link capability — re-break / restore transcript

The wrapped anchor at `spec/API.md:272-273`, re-broken and restored:

```
$ python scripts/check_doc_slugs.py                    # after re-breaking
1 broken anchor link(s) found:

  BROKEN ANCHOR: spec\API.md:273 -> #compiled-views--rf2-8wcbe-rebreak-probe
      (target: spec\API.md)
EXIT=1

$ git diff --numstat                                   # after restoring
                                                       # (empty)
$ python scripts/check_doc_slugs.py
RESTORED_EXIT=0
```

The gate reds, names the file, and reports line **273** — the destination's line, on the far side of the wrap. A per-line extractor sees nothing here.

## Tests

Two end-to-end fixtures, one per counterexample, plus a README-side fixture. Each expects **1**, not 0, and deliberately so: a fixture that only asserts "nothing found" passes just as well if extraction stops working altogether. The single finding in each is a genuinely broken *wrapped* link, so the count moves if a phantom is invented (up) **or** if the bound discards real links (down).

Mutating `_inline_blocks` back to blank-line-only grouping with per-line masking:

```
multiline_code_span_not_a_link -> 2 links (expected 1)  FAIL
  (11, 'missing-in-a-code-span.md')                     <- phantom
  (20, 'missing-for-real.md')

non_blank_block_bound          -> 7 links (expected 1)  FAIL
  (11, 'missing-across-a-heading.md')                   <- phantom
  (18, 'missing-under-a-heading.md')                    <- phantom
  (25, 'missing-across-a-rule.md')                      <- phantom
  (31, 'missing-across-a-bullet.md')                    <- phantom
  (39, 'missing-across-a-table-row.md')                 <- phantom
  (44, 'missing-across-a-quote.md')                     <- phantom
  (54, 'missing-for-real.md')
```

Every boundary kind is exercised causally, not just asserted.

Eleven direct mechanism cases join the existing `_iter_inline_links` suite, covering each boundary and — as positive controls against over-bounding — a wrapped link inside one list item, a lazy blockquote continuation, and a code span that masks only itself.

## Quality gates

All run in the foreground, to completion, from the worker worktree.

| Gate | Result |
| --- | --- |
| `python scripts/check_doc_slugs.py --self-test` | **58 self-tests passed** (was 45: +2 fixtures, +11 mechanism cases) |
| `python scripts/check_doc_slugs.py` (live corpus) | exit 0 — 16838 links extracted, 0 broken |
| `python scripts/check_readme_links.py --self-test` | **14 self-tests passed** (was 13: +1 fixture) |
| `python scripts/check_readme_links.py --ci` | exit 0 |
| `python -m mkdocs build --strict` | exit 0 — built in 20.3s |
| all 32 `scripts/check_*.py` gates | 32 PASS, 0 FAIL |
