### PR TITLE
fix(freehand): make future donor-ledger rows non-removable (rf2-drpa3.62)

### DIFF
--- a/scripts/check_donor_inventory.py
+++ b/scripts/check_donor_inventory.py
@@ -21,13 +21,15 @@ proves five things:
      it covers still requires the donor.
 
   3. **No row can be deleted.** `ESTABLISHED_ROWS` below is the roster of row
-     identities the ledger has established. Every one of them must still be
-     present. Disposing a row means flipping its status to `done` — the row
-     stays as the audit record — so the pending count can only fall by
-     disposition, never by deletion. This is the tooth the ledger was missing:
-     before it existed, deleting a row lowered the pending count and reported
-     zero defects, which is exactly the confident wrong answer a deletion gate
-     must never produce.
+     identities the ledger has established, and it covers the ledger EXACTLY:
+     every roster identity must still be in the ledger, and every ledger row
+     must be in the roster. Disposing a row means flipping its status to `done`
+     — the row stays as the audit record — so the pending count can only fall
+     by disposition, never by deletion. Exactness is what extends that promise
+     to rows written after the roster was: a row admitted without a roster
+     identity could be added, disposed, and then deleted again with the gate
+     reporting nothing, which is exactly the confident wrong answer a deletion
+     gate must never produce.
 
   4. **No row goes stale.** A still-pending row whose pattern matches no tracked
      file fails. So does a still-pending row whose matched files exist but carry
@@ -79,13 +81,16 @@ audit record.
 
 ## Maintaining the roster
 
-`ESTABLISHED_ROWS` is a floor, not a partition: every identity in it must be in
-the ledger, but a newly added row does not have to be added to it — new donor
-files are already held by the partition check and new consumers by the census.
-The roster exists so that removing an ESTABLISHED row is impossible to do
-quietly. Renaming a row's path is the one legitimate reason to edit an existing
-entry, and it is then a deliberate, reviewable edit in the same change as the
-rename.
+`ESTABLISHED_ROWS` covers the ledger exactly: every identity in it must be in
+the ledger, and every ledger row must be in it. Adding a row is therefore two
+edits in one change — the row and its roster identity — and the failure prints
+the exact line to paste. A row outside the roster is a row that can be removed
+again silently, so a roster that only held the rows present when it was written
+would be load-bearing for those rows alone.
+
+Renaming a row's path edits the row and its roster identity together. That
+remains the one legitimate reason to change an existing entry, and it is then a
+deliberate, reviewable edit in the same change as the rename.
 
 Exit code:
     0  the ledger covers the donor tree and its live consumers, and every row is
@@ -428,18 +433,48 @@ def check_consumers(rows: list[Row],
 
 
 # --- Check 3: established rows are never deleted ------------------------------
-def check_roster(rows: list[Row]) -> list[str]:
-    """Every established row identity is still in the ledger."""
+def check_roster(rows: list[Row],
+                 roster: tuple[str, ...] | None = None) -> list[str]:
+    """The ledger and the retention roster name exactly the same identities.
+
+    Two directions, and both are load-bearing. A roster identity missing from
+    the ledger is a deleted row. A ledger row missing from the roster is a row
+    that could be deleted later without the first check noticing — which is how
+    a roster written once stops covering everything written after it. `roster`
+    is injectable so the self-tests exercise this function itself rather than a
+    restatement of it.
+    """
+    if roster is None:
+        roster = ESTABLISHED_ROWS
+
     present = {row.key for row in rows}
-    return [
+    problems = [
         f"DONOR-LEDGER-ROW-REMOVED: `{key}` is an established ledger row and it "
         f"is no longer in {LEDGER_REL}. Rows are never deleted — deleting one "
         "lowers the undisposed count without disposing of anything, which is "
         "the one failure a deletion gate must not have. Flip the row's status "
         "to `done` instead; if the row was renamed, update its identity in "
         "ESTABLISHED_ROWS in the same change."
-        for key in ESTABLISHED_ROWS if key not in present
+        for key in roster if key not in present
     ]
+
+    established = set(roster)
+    seen: set[str] = set()
+    for row in rows:
+        if row.key in established or row.key in seen:
+            continue
+        seen.add(row.key)
+        problems.append(
+            f"DONOR-LEDGER-ROW-UNROSTERED: {LEDGER_REL}:{row.lineno} "
+            f"({row.cell}) is a ledger row whose identity is not in "
+            "ESTABLISHED_ROWS. Add the line  "
+            f'"{row.key}",  to ESTABLISHED_ROWS in '
+            "scripts/check_donor_inventory.py in the same change that adds the "
+            "row. Until it is there this row can be deleted again without the "
+            "gate noticing, which lowers historical coverage silently."
+        )
+
+    return problems
 
 
 # --- Check 4: pending rows still point at donor material ----------------------
@@ -762,21 +797,31 @@ def _run_self_tests(*, verbose: bool = False) -> int:
         "`local` and its placement machinery",
     )
 
-    def roster_defects(text: str) -> list[str]:
+    # The real function under the real invariant — `roster` is injected so the
+    # fixtures cannot drift into testing a restatement of the check.
+    def roster_defects(text: str, roster_=roster) -> list[str]:
         parsed, _ = parse_ledger(text)
-        present = {row.key for row in parsed}
-        return [key for key in roster if key not in present]
+        return check_roster(parsed, roster_)
+
+    def classes(problems: list[str]) -> list[str]:
+        return [problem.split(":", 1)[0] for problem in problems]
 
     expect("I1 pristine roster is satisfied", roster_defects(roster_ledger), [])
 
     deleted = roster_ledger.replace(
         "| `spec/004-Views.md` | spec obligation | MOVE | F0 | pending |\n", "")
-    expect("I2 deleted row is caught", roster_defects(deleted), ["spec/004-Views.md"])
+    problems = roster_defects(deleted)
+    expect("I2 deleted row is caught", classes(problems),
+           ["DONOR-LEDGER-ROW-REMOVED"])
+    expect("I3 deleted row is named", "spec/004-Views.md" in problems[0], True)
 
     label_deleted = roster_ledger.replace(
         "| `local` and its placement machinery | donor form | DELETE | F1 | pending |\n", "")
-    expect("I3 deleted label row is caught",
-           roster_defects(label_deleted), ["`local` and its placement machinery"])
+    problems = roster_defects(label_deleted)
+    expect("I4 deleted label row is caught", classes(problems),
+           ["DONOR-LEDGER-ROW-REMOVED"])
+    expect("I5 deleted label row is named",
+           "`local` and its placement machinery" in problems[0], True)
 
     # The composed sequence. A guard that only ever sees a pristine baseline can
     # pass every single-step test and still be inert once the ledger has moved.
@@ -790,10 +835,59 @@ def _run_self_tests(*, verbose: bool = False) -> int:
     then_deleted = progressed.replace(
         "| `spec/004-Views.md` | spec obligation | MOVE | F0 | done |\n", "")
     expect("J3 deletion AFTER disposition still fails",
-           roster_defects(then_deleted), ["spec/004-Views.md"])
+           classes(roster_defects(then_deleted)), ["DONOR-LEDGER-ROW-REMOVED"])
 
-    # The real roster is wired to the real check: an empty ledger loses every
-    # established row, so `check_roster` cannot be inert.
+    # --- The same sequence, for a row added AFTER the roster was written -------
+    # This is the case a floor-shaped roster could not see: the row was never
+    # established, so deleting it looked like nothing had happened. Each step
+    # starts from the state the previous one left, not from the baseline.
+    added = roster_ledger + (
+        "| `tools/newcomer/deps.edn` | a consumer discovered later | MOVE | F6 | pending |\n"
+    )
+    problems = roster_defects(added)
+    expect("L1 a new row must enter the roster", classes(problems),
+           ["DONOR-LEDGER-ROW-UNROSTERED"])
+    expect("L2 the diagnostic names the row's line",
+           f"{LEDGER_REL}:7" in problems[0], True)
+    expect("L3 the diagnostic prints the line to paste",
+           '"tools/newcomer/deps.edn",' in problems[0], True)
+    expect("L4 the diagnostic names the file to paste it into",
+           "ESTABLISHED_ROWS in scripts/check_donor_inventory.py" in problems[0],
+           True)
+
+    # Step 1 — the row and its roster identity land together.
+    grown = roster + ("tools/newcomer/deps.edn",)
+    expect("L5 row + roster identity together is clean",
+           roster_defects(added, grown), [])
+
+    # Step 2 — the consumer goes, the row is disposed. The row stays.
+    added_done = added.replace(
+        "| `tools/newcomer/deps.edn` | a consumer discovered later | MOVE | F6 | pending |",
+        "| `tools/newcomer/deps.edn` | a consumer discovered later | MOVE | F6 | done |")
+    expect("L6 disposing the new row keeps it", roster_defects(added_done, grown), [])
+
+    # Step 3 — deleting the disposed row is the failure the gate exists for.
+    added_gone = added_done.replace(
+        "| `tools/newcomer/deps.edn` | a consumer discovered later | MOVE | F6 | done |\n", "")
+    problems = roster_defects(added_gone, grown)
+    expect("L7 deleting the disposed new row fails", classes(problems),
+           ["DONOR-LEDGER-ROW-REMOVED"])
+    expect("L8 the deletion names the new row",
+           "tools/newcomer/deps.edn" in problems[0], True)
+
+    # A label row added later is held the same way.
+    label_added = roster_ledger + (
+        "| ambient `dev-only` diagnostics | a contract obligation | DELETE | F2 | pending |\n"
+    )
+    expect("L9 a new label row must enter the roster too",
+           classes(roster_defects(label_added)), ["DONOR-LEDGER-ROW-UNROSTERED"])
+    expect("L10 the label identity is its whole cell",
+           '"ambient `dev-only` diagnostics",' in roster_defects(label_added)[0],
+           True)
+
+    # The real roster is wired to the real check in both directions: an empty
+    # ledger loses every established row, and the shipped ledger must cover the
+    # shipped roster exactly, so `check_roster` cannot be inert.
     expect("J4 check_roster reads ESTABLISHED_ROWS",
            len(check_roster([])), len(ESTABLISHED_ROWS))
     expect("J5 the real roster is populated", len(ESTABLISHED_ROWS) > 100, True)

--- a/scripts/check_donor_inventory.py
+++ b/scripts/check_donor_inventory.py
@@ -432,7 +432,7 @@ def check_consumers(rows: list[Row],
     return problems
 
 
-# --- Check 3: established rows are never deleted ------------------------------
+# --- Check 3: the ledger and the roster cover each other ----------------------
 def check_roster(rows: list[Row],
                  roster: tuple[str, ...] | None = None) -> list[str]:
     """The ledger and the retention roster name exactly the same identities.
@@ -931,8 +931,9 @@ def main(argv: list[str]) -> int:
         description=(
             "Prove the Freehand donor-inventory ledger covers every tracked "
             "re-frame.ui file and every live donor consumer with an explicit "
-            "MOVE/REPLACE/DELETE disposition, that no established row has been "
-            "deleted, and report how many rows are not yet disposed."
+            "MOVE/REPLACE/DELETE disposition, that the ledger and its retention "
+            "roster cover each other exactly so no row can be deleted, and "
+            "report how many rows are not yet disposed."
         ),
     )
     parser.add_argument(

--- a/spec/conformance/freehand/donor-inventory.md
+++ b/spec/conformance/freehand/donor-inventory.md
@@ -106,8 +106,15 @@ The gate fails when:
   never removed. Disposing a row means flipping its status to `done`; the row
   stays as the audit record. The roster of established identities in
   `scripts/check_donor_inventory.py` is what makes a deletion loud instead of
-  looking like progress. Renaming a row's path is a deliberate act that updates
-  that roster in the same change;
+  looking like progress;
+* a **row is not in that roster**. The roster covers this ledger exactly, in
+  both directions: adding a row is two edits in one change — the row here and
+  its identity there — and the failure prints the line to paste. Without that,
+  the retention rule above would hold only for the rows that existed when the
+  roster was written, and every row added afterwards could be added, disposed,
+  and then quietly deleted again. Renaming a row's path edits the row and its
+  roster identity together, which stays the one deliberate reason to change an
+  existing entry;
 * any row is missing a disposition, an owning slice, or a status.
 
 So a new donor file cannot appear undisposed, a donor file cannot quietly vanish


### PR DESCRIPTION
Closes rf2-drpa3.62.

The donor inventory is the absorption-completeness gate that will authorise deleting the `re-frame.ui` artifact. It retained rows by naming each established identity in `ESTABLISHED_ROWS` and checking every one is still in the ledger — but the roster held only the 203 rows present when it was written, and the checker documented itself as a *floor*: "a newly added row does not have to be added to it".

That left a green three-step sequence for every future row:

1. add a new pending consumer row plus the matching live consumer — census and roster pass;
2. remove the consumer and mark the row `done` — passes;
3. **delete the completed row** — still passes, because the consumer is gone and the row was never established.

The pending count falls, historical coverage falls with it, and the eventual donor-deletion proof is quietly incomplete. That contradicts the gate's own stated invariant: rows are disposed by status transition and retained as the audit record.

## The repair

`ESTABLISHED_ROWS` now covers the ledger **exactly, in both directions**. The existing missing-row check is untouched; a second arm rejects any ledger row whose identity is not in the roster, printing the line to paste and the file to paste it into:

```
DONOR-LEDGER-ROW-UNROSTERED: spec/conformance/freehand/donor-inventory.md:372
(`tools/probe-consumer/deps.edn`) is a ledger row whose identity is not in
ESTABLISHED_ROWS. Add the line  "tools/probe-consumer/deps.edn",  to
ESTABLISHED_ROWS in scripts/check_donor_inventory.py in the same change that
adds the row. Until it is there this row can be deleted again without the gate
noticing, which lowers historical coverage silently.
```

Adding a row is therefore two edits in one change. Editing a row **and** its roster identity together remains the deliberate, reviewable rename escape hatch — unchanged.

`check_roster` takes an injectable `roster`, so the self-tests exercise the real function instead of a fixture-local restatement of it. That restatement is precisely how a gate ships with genuine passing teeth while staying inert on the composed case.

No second inventory, no registry, no new workflow, no semantic-inference layer. The shipped ledger already satisfies exact coverage — 203 rows, 203 identities — so no ledger row changed.

## Quality gates

Everything below ran to completion in the foreground.

| Gate | Result |
|---|---|
| `python scripts/check_donor_inventory.py --self-test` | **exit 0** — 62 cases, all pass |
| `python scripts/check_donor_inventory.py --ci --report` (live scan) | **exit 0** — 203 rows, 201 not yet disposed, 2 disposed |
| `python scripts/check_doc_slugs.py` | **exit 0** |
| `python -m mkdocs build --strict` | **exit 0** — built in 18.33s |
| `sh scripts/check-no-hardcoded-paths.sh` | **exit 0** — portability gate OK |
| `.github/workflows/freehand-conformance.yml` | unchanged; it already runs `--self-test --verbose` and `--ci --report`, so both arms are covered by the existing lane |

### Sequence proof

Run live, not as a unit fixture: a throwaway clone of the tracked tree in the system temp dir (asserted to be outside every re-frame2 checkout), with the real gate, the real 203-row ledger and the real roster. Each step starts from the state the previous step left — that is the whole point, since the defect only appears once the ledger has moved off its baseline.

**Sequence A — the row enters the roster alongside the ledger (the workflow):**

| Step | Before (main) | After (this PR) |
|---|---|---|
| 1. add the row + its live consumer | exit **0** | exit **0** |
| 2. drop the consumer, mark the row `done` | exit **0** | exit **0** |
| 3. **DELETE the completed row** | exit **1** | exit **1** — `DONOR-LEDGER-ROW-REMOVED` |

**Sequence B — the row is added without a roster identity (the defect path):**

| Step | Before (main) | After (this PR) |
|---|---|---|
| 1. add the row + its live consumer | exit **0** | exit **1** — `DONOR-LEDGER-ROW-UNROSTERED` |
| 2. drop the consumer, mark the row `done` | exit **0** | exit **1** — still unrostered |
| 3. **DELETE the completed row** | exit **0** ← the defect | exit 0, unreachable |

Read sequence B honestly: after the repair, deleting the row in step 3 is not *detected* — it is made **unreachable**. The gate refuses the state that made the deletion invisible, at the moment that state is created, and CI runs on every change, so a row can never reach step 3 from outside the roster. Every row that does exist is established, and sequence A step 3 shows that deleting an established row fails whether or not it has already been disposed.

Before the repair, sequence B is exactly the reported defect: `step1=0 step2=0 step3=0` — three green steps ending in a silently lowered coverage floor.

### The four original arms still pass

Re-proved live in the same fixture, each from a fresh reset of it, before and after:

| Arm | Before | After | Diagnostic |
|---|---|---|---|
| uncovered consumer | exit 1 | exit 1 | `DONOR-LEDGER-UNCOVERED-CONSUMER` |
| stale path | exit 1 | exit 1 | `DONOR-LEDGER-STALE` |
| double claim | exit 1 | exit 1 | `DONOR-LEDGER-DOUBLE-CLAIMED` |
| premature done | exit 1 | exit 1 | `DONOR-LEDGER-PREMATURE-DONE` |

Pristine fixture and restored fixture both exit 0 in every run, so none of the arms is firing on background noise.

## Files

- `scripts/check_donor_inventory.py` — the second roster arm, the injectable roster, the post-baseline sequence self-tests, and the docstring that no longer describes the roster as a floor.
- `spec/conformance/freehand/donor-inventory.md` — the "How coverage is enforced" list now states the two-directional invariant and the two-edit workflow.
