### PR TITLE
ci(template): provision Chromium so the browser proofs actually run (rf2-qa5ty)

### DIFF
--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -182,6 +182,18 @@ jobs:
         working-directory: implementation
         run: npm ci
 
+      # rf2-qa5ty — `npm ci` installs the playwright PACKAGE but no browser
+      # BINARY, so both Chromium proofs in this tier (the SSR DOM-adoption
+      # proof and the emitted dev-page boot proof) used to exit 2 = skipped
+      # and this job reported green having loaded no page in any browser.
+      # With a browser provisioned, that skip is now a HARD FAILURE under CI
+      # (`browser-proofs-required?` in `emitted_test_run_test.clj`).
+      # `--with-deps` because the runner carries none of Chromium's shared
+      # libraries and nothing earlier in this job installs them.
+      - name: Install Playwright chromium (for the emitted browser proofs)
+        working-directory: implementation
+        run: npx playwright install --with-deps chromium
+
       - name: Run template emitted-app smoke
         env:
           RF2_TEMPLATE_RUN_EMITTED_TESTS: "1"

--- a/.github/workflows/template-release.yml
+++ b/.github/workflows/template-release.yml
@@ -189,6 +189,20 @@ jobs:
         working-directory: implementation
         run: npm ci
 
+      # rf2-qa5ty — the emitted-app tier's two Chromium proofs (SSR
+      # DOM-adoption, emitted dev-page boot) need a browser BINARY; `npm ci`
+      # only installs the playwright package. Without this step a
+      # `template-v…` tag could cut a Release whose gate never loaded the
+      # emitted `index.html` in any browser — precisely the page a consumer
+      # of that Release opens first. Skipping is not acceptable in the
+      # RELEASE gate, and with the browser provisioned an unlaunchable
+      # Chromium now fails the job (`browser-proofs-required?` in
+      # `emitted_test_run_test.clj`). `--with-deps` because the runner has
+      # none of Chromium's shared libraries.
+      - name: Install Playwright chromium (for the emitted browser proofs)
+        working-directory: implementation
+        run: npx playwright install --with-deps chromium
+
       # rf2-ek857f F1 — RF2_TEMPLATE_RUN_EMITTED_TESTS=1 flips the
       # behavioural emitted-app tier ON (default-off for the local fast
       # loop). The release gate MUST run it, or a tag could publish a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3066,6 +3066,26 @@ jobs:
         working-directory: implementation
         run: npm ci
 
+      # rf2-qa5ty — the emitted-tests tier carries TWO Chromium proofs: the
+      # SSR DOM-adoption proof and the emitted dev-page boot proof. `npm ci`
+      # above installs the playwright PACKAGE but never a browser BINARY, so
+      # before this step BOTH drivers hit their `chromium.launch()` catch,
+      # exited 2, and the tier reported green with zero browser coverage —
+      # the mask that let three template defects ship, two of them a BLANK
+      # first page on every scaffold variant. Because this job now provisions
+      # a browser, an unlaunchable Chromium is a HARD FAILURE here rather
+      # than an excused skip (`browser-proofs-required?` in
+      # `emitted_test_run_test.clj` keys off `CI`).
+      #
+      # `--with-deps` (not the bare install) because this is a stock
+      # ubuntu-latest runner with none of Chromium's shared libraries
+      # present and nothing earlier in the job installs them; a
+      # half-provisioned browser would now red the job, so provision it
+      # properly.
+      - name: Install Playwright chromium (for the emitted browser proofs)
+        working-directory: implementation
+        run: npx playwright install --with-deps chromium
+
       # tools/template is a deps-new template (rf2-dolpf §2; clj-new
       # body dropped in §2.5 / rf2-40vmd) — its tests
       # (`template_test.clj`, `template_emission_test.clj`,

--- a/tools/template/spec/Principles.md
+++ b/tools/template/spec/Principles.md
@@ -190,9 +190,16 @@ is exercised end-to-end across the layers:
      serves the emitted `resources/public`, loads the real
      `index.html` plus the dev bundle, and requires `#app` to paint
      the counter, the click to move it 0 → 1, and Chromium to report
-     zero uncaught `pageerror`s. Where Chromium is not launchable
-     the cell records a documented skip, printed as a loud
-     NOT PROVEN banner so it cannot read as a pass.
+     zero uncaught `pageerror`s.
+
+   Both browser cells in this tier — the dev-page boot proof and the
+   SSR DOM-adoption proof — treat an unlaunchable Chromium
+   asymmetrically, and deliberately. Every CI job that enables the tier
+   also installs a browser, so under CI a missing one is a broken job
+   and fails the run. Locally it is a skip, printed as a loud
+   NOT PROVEN banner so it cannot read as a pass. Both proofs went
+   unexecuted in CI for months behind a green skip; that is the failure
+   mode the asymmetry closes.
 
 CI sets `RF2_TEMPLATE_RUN_EMITTED_TESTS=1`; a change that breaks
 file-tree shape, drifts the framework surface, breaks the pin

--- a/tools/template/test-support/dev-page-boot-proof.cjs
+++ b/tools/template/test-support/dev-page-boot-proof.cjs
@@ -45,8 +45,11 @@
  *   label      — optional variant name, echoed in diagnostics
  *
  * Exit 0 = all three teeth pass. Exit 1 = the proof FAILED. Exit 2 = Chromium
- * is not launchable here, so the proof was SKIPPED (the caller prints a loud
- * banner — a silent skip is how this whole class of defect stayed invisible).
+ * is not launchable here. Exit 2 is a REPORT, not a verdict: the caller
+ * decides. Under CI it fails the run (every job enabling this tier provisions
+ * a browser, so a missing one is a broken job); locally it is a skip under a
+ * loud NOT PROVEN banner. A silent skip is how this class of defect stayed
+ * invisible.
  */
 
 'use strict';
@@ -150,11 +153,13 @@ function diagnose(lines) {
   let browser;
   let failure = null;
 
-  // Launch is a SKIP boundary, not a failure: the PR-time template job runs
-  // `npm ci` in implementation/ (which installs the playwright PACKAGE) but
-  // never `npx playwright install`, so no browser binary is present there.
-  // Exit 2 = "browser unavailable, skipped"; the caller prints a loud banner so
-  // the skip cannot read as a pass.
+  // Launch failure is REPORTED, not judged, here: exit 2 means "no launchable
+  // browser on this machine" and the caller decides what that is worth. Under
+  // CI it is a hard failure — every job that enables this tier runs
+  // `npx playwright install --with-deps chromium`, so a job with no browser is
+  // broken. Locally it is a skip under a loud NOT PROVEN banner. Keeping the
+  // judgement in the caller is what let the CI half be tightened without
+  // making a browser-less local checkout unrunnable.
   try {
     browser = await chromium.launch({ headless: true });
   } catch (launchErr) {

--- a/tools/template/test-support/ssr-hydration-dom-proof.cjs
+++ b/tools/template/test-support/ssr-hydration-dom-proof.cjs
@@ -36,7 +36,9 @@
  *   publicRoot — <proj>/resources/public (holds _ssr_proof.html + js/ + css/)
  *   implRoot   — <repo>/implementation   (resolves the playwright devDep)
  *
- * Exit 0 iff both teeth pass; 1 otherwise (with diagnostics on stdout).
+ * Exit 0 iff both teeth pass; 1 on failure (with diagnostics on stdout); 2 if
+ * Chromium is not launchable here — a REPORT, not a verdict, judged by the
+ * caller (hard failure under CI, loud NOT PROVEN banner locally).
  */
 
 const http = require('http');
@@ -143,11 +145,11 @@ function initScriptStampServerNode() {
   let browser;
   let failure = null;
 
-  // Launch is a SKIP boundary, not a failure: some CI tiers enable this proof
-  // but do not provision a launchable Chromium (no `npx playwright install
-  // --with-deps`). Exit 2 = "browser unavailable, skipped" so the caller keeps
-  // the tier green; the real tooth still runs wherever a browser is installed
-  // (expensive-tests / template-release / local).
+  // Launch failure is REPORTED, not judged, here: exit 2 means "no launchable
+  // browser on this machine" and the caller decides what that is worth. Under
+  // CI it is a hard failure — every job that enables this tier runs
+  // `npx playwright install --with-deps chromium`, so a job with no browser is
+  // broken. Locally it is a skip under a loud NOT PROVEN banner.
   try {
     browser = await chromium.launch({ headless: true });
   } catch (launchErr) {

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -458,25 +458,88 @@
                    "\n  resolved by the build: " (pr-str (sort resolved))
                    "\n  declared by the scaffold: " (pr-str (sort declared)))))))))
 
-;; --- loud skips ------------------------------------------------------------
+;; --- browser-proof verdicts ------------------------------------------------
+;;
+;; Both browser proofs in this tier exit 2 when Chromium is not launchable.
+;; What that exit code MEANS depends on where we are running:
+;;
+;;   CI    — a hard FAILURE. Every job that turns this tier on also installs
+;;           a browser, so a job that cannot launch one is broken, not
+;;           excused.
+;;   local — a documented skip, under an unmissable banner.
+;;
+;; The asymmetry is the point. A skip that reads as a pass is the exact
+;; mechanism that let BOTH proofs go unexecuted in CI for months while the
+;; tier reported green.
+
+(def ^:private browser-proofs-required?
+  "Is a launchable Chromium MANDATORY here?
+
+  Yes under CI, no locally. Every workflow job that sets
+  `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` also runs
+  `npx playwright install --with-deps chromium`, so a CI run that cannot
+  launch a browser is a BROKEN JOB — the provisioning regressed, or the
+  install failed — and reporting that as a green skip is how this tier ran
+  for months with zero browser coverage. Locally the skip stays a skip: a
+  contributor without a browser binary should still get the compile/run
+  tiers rather than a red suite they cannot fix.
+
+  `CI` is the de-facto standard flag (GitHub Actions and every other major
+  CI set it). Export `CI=1` to opt a local run into the strict behaviour."
+  (delay (not (string/blank? (System/getenv "CI")))))
 
 (defn- announce-browser-skip!
-  "Print an unmissable banner when a browser proof does NOT run. Both
-  browser proofs in this tier exit 2 when Chromium isn't launchable and
-  keep the tier green — and a quiet, documented skip is precisely how the
-  missing dev-page boot proof stayed invisible while three defects shipped.
-  A skip that reads like a pass in the run output is a mask; this one
-  shouts."
+  "Print an unmissable banner when a browser proof does NOT run — the
+  local-only branch of `check-browser-proof!`. A quiet, documented skip is
+  precisely how the missing dev-page boot proof stayed invisible while
+  three defects shipped; this one shouts."
   [what out]
   (println)
   (println "!!! ================================================================")
   (println (str "!!! NOT PROVEN -- SKIPPED: " what))
   (println "!!! Chromium is not launchable here, so this browser proof did NOT run.")
-  (println "!!! The tier stays green, but NOTHING about the emitted page is proven.")
+  (println "!!! This run stays green, but NOTHING about the emitted page is proven.")
+  (println "!!! (Under CI this is a hard failure — see browser-proofs-required?.)")
   (when-let [line (first (remove string/blank? (string/split-lines (str out))))]
     (println (str "!!! driver: " (string/trim line))))
   (println "!!! ================================================================")
   (println))
+
+(defn- check-browser-proof!
+  "Turn a browser-proof driver's exit code into the right verdict — one
+  place for both proofs in this tier.
+
+    0  PASS. Echo the driver's own verdict line: a proof that speaks only
+       when it fails is indistinguishable in the run output from one that
+       never ran at all.
+    2  Chromium was not launchable. Locally a documented skip under the
+       NOT PROVEN banner; under CI a hard failure (`browser-proofs-required?`).
+    _  the proof FAILED — `failure-msg` says what that means for this proof.
+
+  `what` labels the proof in the skip banner and the CI failure; `echo-tag`
+  prefixes the green verdict line."
+  [what echo-tag exit out failure-msg]
+  (cond
+    (and (= 2 exit) (not @browser-proofs-required?))
+    (do (announce-browser-skip! what out)
+        (is true
+            (str "Chromium unavailable — " what " did not run. Output:\n" out)))
+
+    (= 2 exit)
+    (is false
+        (str what " did NOT run: Chromium was not launchable, and `CI` is set. "
+             "Every job that sets RF2_TEMPLATE_RUN_EMITTED_TESTS=1 also runs "
+             "`npx playwright install --with-deps chromium`, so a CI job that "
+             "finds no browser is BROKEN, not excused — this tier reported "
+             "green for months on exactly that skip. Fix the job's browser "
+             "provisioning (or stop setting RF2_TEMPLATE_RUN_EMITTED_TESTS "
+             "there if the tier genuinely should not run). Output:\n" out))
+
+    :else
+    (do (when (zero? exit)
+          (when-let [line (last (remove string/blank? (string/split-lines (str out))))]
+            (println (str "  [" echo-tag "] " (string/trim line)))))
+        (is (zero? exit) failure-msg))))
 
 ;; --- emitted dev-page boot proof ------------------------------------------
 ;;
@@ -514,30 +577,18 @@
             {:keys [exit out]}
             (run-process! ["node" driver pub-root impl-root label]
                           proj {"NODE_PATH" node-path})]
-        ;; Exit 2 = Chromium not launchable (the PR-time template job installs
-        ;; the playwright PACKAGE but no browser binary). Documented skip, but
-        ;; a LOUD one. Exit 0 = booted clean; anything else = the proof FAILED.
-        (if (= 2 exit)
-          (do (announce-browser-skip! (str "dev-page boot proof -- " label) out)
-              (is true
-                  (str "Chromium unavailable — the emitted dev-page boot proof "
-                       "did not run for " label ". Output:\n" out)))
-          (do
-            ;; Echo the driver's verdict line on a green run too — a browser
-            ;; proof that only speaks when it fails is indistinguishable in
-            ;; the run output from one that silently skipped.
-            (when (zero? exit)
-              (when-let [line (last (remove string/blank? (string/split-lines (str out))))]
-                (println (str "  [dev-page boot] " (string/trim line)))))
-            (is (zero? exit)
-                (str "the emitted dev-page boot proof exited " exit " for " label
-                     " — the page a newcomer opens after `npx shadow-cljs watch "
-                     "app` did not boot cleanly. Either #app never painted (a "
-                     "BLANK first page: the emitted index.html's <meta> CSP "
-                     "blocks the dev bundle's goog.globalEval, a broken "
-                     ":init-fn, or a namespace that throws on load), the counter "
-                     "did not move 0 -> 1, or Chromium raised an uncaught "
-                     "pageerror. Output:\n" out))))))))
+        (check-browser-proof!
+          (str "dev-page boot proof -- " label)
+          "dev-page boot"
+          exit out
+          (str "the emitted dev-page boot proof exited " exit " for " label
+               " — the page a newcomer opens after `npx shadow-cljs watch "
+               "app` did not boot cleanly. Either #app never painted (a "
+               "BLANK first page: the emitted index.html's <meta> CSP "
+               "blocks the dev bundle's goog.globalEval, a broken "
+               ":init-fn, or a namespace that throws on load), the counter "
+               "did not move 0 -> 1, or Chromium raised an uncaught "
+               "pageerror. Output:\n" out))))))
 
 ;; --- SSR DOM-adoption browser proof ---------------------------------------
 ;;
@@ -598,22 +649,15 @@
               {:keys [exit out]}
               (run-process! ["node" driver pub-root impl-root]
                             proj {"NODE_PATH" node-path})]
-          ;; Exit 2 = the driver could not launch Chromium (a tier that enables
-          ;; this proof without `npx playwright install --with-deps`); record a
-          ;; documented skip so the tier stays green. Exit 0 = adopted; any
-          ;; other exit = the proof FAILED (fresh mount / dead handler).
-          (if (= 2 exit)
-            (do (announce-browser-skip! "SSR DOM-adoption browser proof" out)
-                (is true
-                    (str "Chromium unavailable — skipping the SSR DOM-adoption "
-                         "browser proof (the real tooth runs where a browser is "
-                         "provisioned). Output:\n" out)))
-            (is (zero? exit)
-                (str "the SSR DOM-adoption browser proof exited " exit
-                     " — the generated scaffold did not adopt the server-painted "
-                     "DOM (hydrate-root) on a payload-backed boot: the live #app "
-                     "node was not the server node, or its handler was dead. "
-                     "Output:\n" out))))))))
+          (check-browser-proof!
+            "SSR DOM-adoption browser proof"
+            "ssr dom-adoption"
+            exit out
+            (str "the SSR DOM-adoption browser proof exited " exit
+                 " — the generated scaffold did not adopt the server-painted "
+                 "DOM (hydrate-root) on a payload-backed boot: the live #app "
+                 "node was not the server node, or its handler was dead. "
+                 "Output:\n" out)))))))
 
 ;; --- The orchestration -----------------------------------------------------
 

--- a/tools/template/test/day8/re_frame2_template/release_gate_test.clj
+++ b/tools/template/test/day8/re_frame2_template/release_gate_test.clj
@@ -106,6 +106,19 @@
         (is (string/includes? job "working-directory: implementation")
             "the npm ci step must run in implementation/ (where the
              node_modules tree the smoke links to lives).")
+        ;; `npm ci` installs the playwright PACKAGE but no browser BINARY.
+        ;; Without an explicit install the tier's two Chromium proofs (SSR
+        ;; DOM-adoption, emitted dev-page boot) cannot launch, and a
+        ;; `template-v…` tag would cut a Release whose gate never loaded the
+        ;; emitted index.html in any browser. The tier now hard-fails on an
+        ;; unlaunchable browser under CI, so dropping this step reds the
+        ;; release — but only at tag time; this assertion catches it at PR
+        ;; time instead.
+        (is (re-find #"playwright install --with-deps chromium" job)
+            "test-template must `npx playwright install --with-deps chromium`
+             — `npm ci` installs the playwright package but no browser
+             binary, and the emitted-app tier's dev-page boot + SSR
+             DOM-adoption proofs both need a launchable Chromium.")
         ;; Still actually invokes the JVM test suite.
         (is (re-find #"clojure -M:test" job)
             "test-template must run `clojure -M:test` from tools/template


### PR DESCRIPTION
Closes rf2-qa5ty.

The `RF2_TEMPLATE_RUN_EMITTED_TESTS` tier carries two Chromium proofs — the SSR
DOM-adoption proof and the emitted dev-page boot proof added by #6686. **Neither
has ever executed in CI.** All three jobs that enable the tier run `npm ci` in
`implementation/`, which installs the playwright *package* but no browser
*binary*, so both drivers hit their `chromium.launch()` catch, exited 2, and the
tier reported green with zero browser coverage. A proof that has never run has
never passed.

This PR provisions the browser and closes the skip that hid it.

## What changed

**Provisioning.** `npx playwright install --with-deps chromium` in the three
jobs that set the variable, immediately after their existing `npm ci`:

| Workflow | Job | Why it needs a browser |
| --- | --- | --- |
| `test.yml` | `jvm-tools-template` | PR-time tier; runs `clojure -M:test` in `tools/template`, which reaches both proofs |
| `expensive-tests.yml` | `template-emitted-app` | nightly full matrix; same suite, same two proofs |
| `template-release.yml` | `test-template` | the release gate — a `template-v…` tag must not cut a Release whose gate never loaded the emitted `index.html` in a browser |

Those are exactly the three jobs that set `RF2_TEMPLATE_RUN_EMITTED_TESTS=1`, all
three reach the proofs, and nothing else was touched.

**CI cost.** `--with-deps` runs `apt-get install` for Chromium's shared libraries
and is not free. It is used in all three because all three are stock
`ubuntu-latest` runners where nothing earlier in the job installs those
libraries, and because a half-provisioned browser now *reds* the job rather than
excusing itself — so provisioning properly is the cheaper failure mode. This
matches every other Chromium-using job in the repo.

## Skip policy — the call, stated explicitly

**A missing browser is now a hard FAILURE under CI, and a loud skip locally.**

#6686 made the skip unmissable (the `!!! NOT PROVEN -- SKIPPED` banner) but
deliberately kept it green, because hard-failing before any provisioning existed
would have redded every PR on infrastructure. That reason is now gone. Every job
that turns the tier on also installs a browser, so a CI job that finds no browser
is a *broken job*, not an excused one — the provisioning regressed, or the
install failed, and either way the run proves nothing about the emitted page.
Reporting that as green is precisely the mechanism that kept both proofs
unexecuted for months.

Locally the skip stays a skip. A contributor without a browser binary should
still get the compile/run tiers rather than a red suite they cannot fix, and the
banner already makes the gap impossible to miss.

The discriminator is the `CI` env var — the de-facto standard flag GitHub Actions
and every other major CI set, so it needs no new coordination between workflow
and test, and it cannot drift out of sync the way a bespoke
`RF2_TEMPLATE_REQUIRE_BROWSER=1` opt-in would (forget to set it and you are back
to a silent skip). `export CI=1` opts a local run into the strict behaviour.

It lives in `browser-proofs-required?` in `emitted_test_run_test.clj`, and both
call sites now share one `check-browser-proof!` verdict helper: exit 0 → pass
**and echo the driver's own verdict line**; exit 2 → hard fail under CI, banner
skip locally; anything else → the proof failed. The green echo matters as much as
the failure — a proof that speaks only when it fails is indistinguishable in the
run log from one that never ran.

`release_gate_test.clj` gains one assertion pinning the release job's browser
provisioning, so removing that step is caught at PR time rather than at tag time.
The two `.cjs` drivers keep exit 2 as a *report*, not a verdict; the caller
judges. That split is what let the CI half be tightened without making a
browser-less local checkout unrunnable.

## CI evidence: the proofs now execute

This is the acceptance criterion — a green PR where they skipped again would
prove nothing. Both runs are the same job (`JVM tools/template`), same suite.

**Before** — `main`, run `29920059591`, job `88923714042` (2026-07-22 12:35Z),
the last `main` run in which this job actually executed:

```
!!! ================================================================
!!! NOT PROVEN -- SKIPPED: dev-page boot proof -- uix
!!! Chromium is not launchable here, so this browser proof did NOT run.
!!! driver: dev-page boot proof SKIPPED (uix): Chromium is not launchable here
    (browserType.launch: Executable doesn't exist at
     /home/runner/.cache/ms-playwright/chromium_headless_shell-1217/…)
!!! ================================================================
…
!!! NOT PROVEN -- SKIPPED: SSR DOM-adoption browser proof
…
Ran 62 tests containing 826 assertions.
0 failures, 0 errors.
```

Five `NOT PROVEN` banners — four dev-page boot variants plus the SSR proof — and
the job reported success.

**After** — this PR, run `29925064331`, job `88940745451`:

```
  [dev-page boot] dev-page boot proof PASS (uix): the emitted index.html booted the dev bundle, #app painted the counter, the click moved it 0 -> 1, and Chromium reported zero uncaught pageerrors.
  [ssr dom-adoption] SSR hydration DOM proof PASS: server-painted #app node adopted (hydrate-root) and its handler went live (0 -> 1).
  [dev-page boot] dev-page boot proof PASS (reagent): …
  [dev-page boot] dev-page boot proof PASS (reagent-with-story): …
  [dev-page boot] dev-page boot proof PASS (ui): …

Ran 62 tests containing 827 assertions.
0 failures, 0 errors.
```

`NOT PROVEN` occurrences in the new log: **0**. Verdict lines from a real
Chromium: **5**. (The +1 assertion is the new `release_gate_test.clj` shape
assert.)

## What the first-ever execution revealed

**The SSR hydration proof passes.** It ran for the first time ever in CI on this
PR and proved what it claims: the server-painted `#app` node survives into the
live tree — `hydrate-root` adoption, not a fresh `create-root` mount — and its
handler goes live (0 → 1). It was correct all along; nobody could know that,
because it had never executed. Same for all four dev-page boot variants (uix,
reagent, reagent-with-story, ui), which had only ever run on the #6686 author's
machine.

So: no new defect surfaced, and that is the honest report. What changed is that
five browser assertions moved from *asserted-by-nobody* to *executed on every
run that touches the template*.

**Cost, measured rather than guessed.** The `--with-deps` step took **23 s**
(13:45:00 → 13:45:23). The job went 8m02s → 10m47s, so ~2m20s of that is the
five browser proofs actually doing work — which is the entire point. Timeout is
35 min; ample headroom.

## Quality gates

All run locally to completion, plus this PR's own CI.

- **Template tier, focused variants** — `RF2_TEMPLATE_RUN_EMITTED_TESTS=1 clojure -M:test -v …` for
  `reagent-ssr-emitted-tests-run-test` and `reagent-emitted-tests-run-test`.
  Green, with both proofs executing against a real Chromium:
  `[ssr dom-adoption] … PASS`, `[dev-page boot] dev-page boot proof PASS (reagent)`.
- **Skip-policy acceptance** — three runs proving the new branch structure, using
  a bogus `PLAYWRIGHT_BROWSERS_PATH` to make Chromium unlaunchable (the same
  technique #6686 used to prove the banner):
  - `CI=1` + no browser → **exit 1**, `SSR DOM-adoption browser proof did NOT run: Chromium was not launchable, and 'CI' is set …` — the hard failure fires.
  - `CI` unset + no browser → **exit 0**, `!!! NOT PROVEN -- SKIPPED` banner — the local skip survives.
  - browser present → **exit 0**, proof PASS — the happy path is unaffected.
- **`npm run test:script-policy && npm run test:script-helpers`** — both green
  (run as a single `&&` chain, as CI does). `lint-workflow-policy` (4) and
  `changed-surfaces` (195) both pass over the edited workflows.
- **`sh scripts/check-no-hardcoded-paths.sh`** — `Portability gate OK`.
- **This PR's CI** — all checks green, and the template job's log carries the
  five PASS lines and zero skip banners quoted above.

Full template suite on Linux is covered by this PR's own `jvm-tools-template`
job (62 tests / 827 assertions, 0 failures) rather than re-run locally on
Windows.
