### PR TITLE
refactor(freehand): transplant the analyzer and both emitters under Freehand ownership (rf2-drpa3.25)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler.cljc
@@ -1,0 +1,592 @@
+(ns re-frame.freehand.compiler
+  "defview / custom-element expansion pipeline: arity + options parsing,
+  header (Q2) analysis, template analysis, manifest + fingerprint
+  assembly, and per-host emission. Each host build runs the shared
+  analyzer over its own source and hands that build's own AST to exactly
+  one emitter (the portability law: no emitter consumes raw source or
+  another emitter's output).
+
+  Runs on the JVM only (macro expansion for both hosts); .cljc so the
+  namespace stays loadable everywhere."
+  (:require [clojure.string :as str]
+            #?@(:clj [[re-frame.freehand.compiler.analyze :as ana]
+                      [re-frame.freehand.compiler.build :as build]
+                      [re-frame.freehand.compiler.emit-cljs :as emit-cljs]
+                      [re-frame.freehand.compiler.emit-jvm :as emit-jvm]
+                      [re-frame.freehand.compiler.env :as env]
+                      [re-frame.freehand.compiler.header :as header]
+                      [re-frame.freehand.fingerprint :as fingerprint]])))
+
+#?(:clj
+   (do
+
+;; Each Shadow build carries accepted registries plus disposable compiler-env
+;; scratch. A recompiled / edited / renamed source replaces its prior rows and
+;; independent builds never share state. Distinct declarations with equal ids
+;; fail atomically; the same var remains the HMR replacement path. The finalized
+;; candidate registries become accepted only when Shadow retains the returned
+;; build-state after the complete pipeline.
+;;
+;; The compile-time custom-element declarations are a build-scoped registry
+;; like the other four: WRITTEN here (macro expansion → `build/contribute!
+;; build/elements`) and READ on the compile path by the template analyzer
+;; through `build/element-properties`, which resolves the AMBIENT build's
+;; slice (rf2-vxgfnd.91). No process-global mirror atom: the former
+;; `build/register! build/elements rules/custom-elements` bridge was a
+;; last-writer-wins hazard where a sibling build's contribution could flip
+;; another build's classification. The CLJS/JVM RUNTIME arm keeps its own
+;; `re-frame.freehand.rules/custom-elements` ledger (populated by the emitted
+;; `register-custom-element!`, read at render for dynamic `v/spread` props);
+;; it is separate from this compile registry.
+
+(def ^:private defview-option-keys #{:props :id :display-name})
+
+(defn- fail
+  ([id msg] (fail id msg nil))
+  ([id msg data] (throw (env/compile-error id msg data))))
+
+(defn- parse-defview-forms
+  "Parse `[docstring? opts-map? argv & body]`. The body is zero or more leading
+  `(effect …)` statements followed by one final template."
+  [vname forms]
+  (let [[docstring forms] (if (string? (first forms))
+                            [(first forms) (rest forms)]
+                            [nil forms])
+        [opts forms]      (if (map? (first forms))
+                            [(first forms) (rest forms)]
+                            [{} forms])
+        argv              (first forms)
+        body              (rest forms)]
+    (when-not (vector? argv)
+      (fail :rf.ui.compile/bad-defview-args
+            (str "defview " vname ": missing argument vector — "
+                 "(defview name docstring? opts? [props?] template)")
+            {:view vname}))
+    ;; a lone template vector reads as an argv — diagnose the real mistake
+    (when (and (empty? body) (keyword? (first argv)))
+      (fail :rf.ui.compile/bad-defview-args
+            (str "defview " vname ": " (pr-str argv) " looks like the "
+                 "template, but the argument vector is missing — write "
+                 "(defview " vname " [] " (pr-str argv) ") for a zero-prop view")
+            {:view vname}))
+    (let [unknown (remove defview-option-keys (keys opts))]
+      (when (seq unknown)
+        (fail :rf.ui.compile/unknown-option
+              (str "defview " vname ": unknown option"
+                   (when (next unknown) "s") " "
+                   (str/join ", " (map pr-str unknown))
+                   " — the options map is CLOSED for v1: "
+                   ":props, :id, :display-name. (:memo false, :on-mount, "
+                   ":on-unmount, :catch and :fallback were considered and "
+                   "rejected — see Spec 004 §Removed forms)")
+              {:view vname :unknown (vec unknown)})))
+    (when-let [id (:id opts)]
+      (when-not (and (keyword? id) (namespace id))
+        (fail :rf.ui.compile/bad-view-id
+              (str "defview " vname ": :id override must be a qualified "
+                   "keyword; got " (pr-str id))
+              {:view vname :id id})))
+    {:docstring docstring :opts opts :argv argv :body body}))
+
+(defn- capabilities [ast]
+  (let [caps (volatile! #{})]
+    (letfn [(scan [n]
+              (when (map? n)
+                (case (:op n)
+                  :raw     (vswap! caps conj :raw)
+                  :html    (vswap! caps conj :html)
+                  :foreign (vswap! caps conj :foreign)
+                  :slot    (vswap! caps conj :render-slot)
+                  :element (do (when (:custom? n) (vswap! caps conj :custom-element))
+                               (when (get-in n [:props :spread])
+                                 (vswap! caps conj :spread))
+                               (when (get-in n [:props :safe-spread])
+                                 (vswap! caps conj :spread-safe))
+                               (when (:html n) (vswap! caps conj :html)))
+                  nil)
+                ;; A compiled render slot callback (a component prop value or an
+                ;; inline v/slot argument) carries a :render-fn compiled body.
+                (when (:render-fn n) (vswap! caps conj :render-fn))
+                (doseq [[_ v] n]
+                  (cond
+                    (map? v) (scan v)
+                    (vector? v) (doseq [x v] (scan x))))))]
+      (scan ast))
+    @caps))
+
+;; ---------------------------------------------------------------------------
+;; Per-view static-render facts (Spec 004C §3 / EP-0034 §2 — the render-static
+;; no-silent-elision proof)
+;; ---------------------------------------------------------------------------
+
+(def ^:private runtime-requiring-site-caps
+  "Site-kind -> the runtime-requiring capability token render-static rejects.
+  Every one names a live-runtime need a pure `:server` static render cannot
+  honour (a sub read, a committed handler, a frame read, a host hook)."
+  {:events :handler :subs :sub :frame-ops :frame
+   :locals :local :effects :effect :dispatch-fns :dispatch-fn})
+
+(defn view-static-facts
+  "The SERVER-REACHABLE static-render facts for one analyzed body — the small
+  internal projection the render-static transitive proof closes over (Spec 004C
+  §3, EP-0034 §2 no-silent-elision):
+
+    {:caps <set of runtime-requiring capability tokens in THIS body>
+     :deps <set of directly-referenced view-ids>}
+
+  `:caps` unions the runtime-requiring SITE kinds (subs / committed handlers /
+  frame reads / host locals / effects / dispatch-fns), the substrate `v/ref`
+  (-> `:ref`) and the re-frame.freehand.react host hooks (use-context -> `:context`,
+  use-effect family -> `:effect`; `use-id` is EXEMPT — an inert deterministic id
+  is static-safe), authored element/component `:ref` slots (a commit-phase host
+  hook a static render cannot honour -> `:ref`), and foreign heads (`:foreign`,
+  which a `react/lazy` head folds into). `:deps` are the view references to close
+  over transitively.
+
+  SERVER REACHABILITY governs BOTH the dependency walk AND the capability
+  collection: a `v/client-only` subtree is browser-only — the JVM emitter
+  renders only its capability-free FALLBACK — so its views, its authored refs,
+  and its authored SITES (an inline `:on-click`, `sub`, effect …) never reach the
+  static output and must not be counted (a static root never flips). Since the
+  view-wide `sites` atom also carries the browser-only child's sites (the child
+  is analyzed against the shared atom), each client-only node's `:path` is
+  recorded and a site whose `:path` descends from one is excluded — the capability
+  proof only counts the SERVER-REACHABLE sites, mirroring the dependency walk."
+  [ast sites]
+  (let [deps     (volatile! #{})
+        foreign? (volatile! false)
+        ref?     (volatile! false)
+        co-paths (volatile! [])]
+    (letfn [(walk [n]
+              (when (map? n)
+                (if (= :client-only (:op n))
+                  ;; browser-only child never reaches the JVM tree; record its
+                  ;; path (so its sites drop out of the capability proof) and
+                  ;; walk ONLY the capability-free fallback.
+                  (do (vswap! co-paths conj (:path n))
+                      (walk (:fallback n)))
+                  (do
+                    (when (= :view (:op n))    (vswap! deps conj (:view-id n)))
+                    (when (= :foreign (:op n)) (vreset! foreign? true))
+                    ;; an authored `:ref` (element OR component props) is a
+                    ;; commit-phase host hook — a static render cannot honour it,
+                    ;; so a server-reachable ref is a runtime-requiring capability
+                    ;; (the JVM emitter would otherwise drop it silently).
+                    (when (some? (get-in n [:props :ref])) (vreset! ref? true))
+                    (doseq [[_ v] n]
+                      (cond
+                        (map? v)    (walk v)
+                        (vector? v) (run! walk v)))))))]
+      (walk ast))
+    (let [cos       @co-paths
+          reachable (if (empty? cos)
+                      (fn [kind] (get sites kind))
+                      (let [under-co? (fn [p]
+                                        (boolean
+                                         (some (fn [co]
+                                                 (and (<= (count co) (count p))
+                                                      (= co (subvec p 0 (count co)))))
+                                               cos)))]
+                        (fn [kind] (remove #(under-co? (:path %)) (get sites kind)))))]
+      {:caps (cond-> (into (into #{}
+                                 (keep (fn [[kind cap]]
+                                         (when (seq (reachable kind)) cap)))
+                                 runtime-requiring-site-caps)
+                           (keep {:ref :ref :context :context :effect :effect
+                                  :layout-effect :effect :effect-event :effect})
+                           (map :kind (reachable :react)))
+               @foreign? (conj :foreign)
+               @ref?     (conj :ref))
+       :deps @deps})))
+
+(defn build-view-static
+  "The ambient build's per-view static-render facts index (view-id ->
+  `{:caps :deps}`) — the read `re-frame.freehand/render-static`'s transitive proof
+  closes over (Spec 004C §3). Per-build like every other registry read.
+
+  Populated by the `defview` macro's slice contribution ONLY off the Shadow
+  build path (plain-JVM / SSR / REPL): render-static is JVM-only, so a real
+  Shadow build never reads this index and the macro does not contribute to it
+  there (rf2-u53yy.1 S3). A dependency compiled in another build/context resolves
+  from its registered manifest's `:static-facts` instead
+  (`root/registered-view-static-facts`)."
+  []
+  (build/aggregate build/view-static))
+
+(defn- source-coords [form cljs?]
+  (let [m (meta form)]
+    (cond-> {:file (if cljs?
+                     (try @(requiring-resolve 'cljs.analyzer/*cljs-file*)
+                          (catch Exception _ *file*))
+                     *file*)}
+      (:line m)   (assoc :line (:line m))
+      (:column m) (assoc :column (:column m)))))
+
+(defn- anchored
+  "Run `thunk`; a compile error escaping it gains the declaration form's
+  source coordinates (:file/:line/:column) in its ex-data — the S1e
+  file:line anchoring, so every {:rf.ui.compile/error <id>} carries WHERE
+  alongside id + didactic message. Existing ex-data wins on collisions;
+  id, message and cause are preserved."
+  [coords thunk]
+  (try
+    (thunk)
+    (catch clojure.lang.ExceptionInfo ex
+      (let [data (ex-data ex)]
+        (throw
+         (if (and (:rf.ui.compile/error data) (nil? (:file data)))
+           (ex-info (ex-message ex) (merge coords data) ex)
+           ex))))))
+
+(defn- defview**
+  [form menv vname forms]
+  (when-not (simple-symbol? vname)
+    (fail :rf.ui.compile/bad-defview-args
+          (str "defview name must be a simple symbol; got " (pr-str vname))
+          {:view vname}))
+  (let [cljs?   (some? (:ns menv))
+        ns-sym  (if cljs? (-> menv :ns :name) (ns-name *ns*))
+        {:keys [docstring opts argv body]} (parse-defview-forms vname forms)
+        view-id (or (:id opts) (keyword (str ns-sym) (str vname)))
+        hdr     (header/parse-header argv)
+        schema-keys (header/props-schema-keys (:props opts))
+        _       (doseq [k (or schema-keys [])]
+                  (when (contains? #{:key :ref} k)
+                    (fail :rf.ui.compile/key-prop-declared
+                          (str "defview " vname ": " k " cannot be declared in "
+                               ":props — it is a reserved React slot (callers "
+                               "pass it at the call site; it never arrives as "
+                               "a prop). Remove the schema entry")
+                          {:view vname :key k})))
+        slots       (header/declared-slots hdr schema-keys)
+        children?   (boolean (or (:children? hdr)
+                                 (some #(= :children %) (or schema-keys []))))
+        closed-keys (when (contains? opts :props) slots)
+        display-name (or (:display-name opts)
+                         (str (namespace view-id) "/" (name view-id)))
+        header-syms (into (set (mapcat env/binding-syms
+                                       (keep :pattern (:entries hdr))))
+                          (when (:as-sym hdr) [(:as-sym hdr)]))
+        src     (source-coords form cljs?)
+        e0      (-> (env/make-env {:host (if cljs? :cljs :clj)
+                                    :cljs-env menv
+                                    :ns-sym ns-sym
+                                    :self vname
+                                    :self-id view-id
+                                    :source src
+                                    ;; Reader metadata is not guaranteed (macro-
+                                    ;; generated templates). In that case every
+                                    ;; site incorporates this whole-template
+                                    ;; semantic anchor, so an edit safely
+                                    ;; reacquires instead of transferring an
+                                    ;; ordinal to another lexical site.
+                                    :template-anchor
+                                    (fingerprint/digest "sta1-" body)})
+                    (assoc :self-children? children?
+                           :self-closed-keys closed-keys))
+        _       (ana/reject-reactive-binding! e0 argv)
+        ;; The defview body is the UNCONDITIONAL hooks region — where `local` /
+        ;; `effect` host hooks are legal (cleared on entering any branch/loop/
+        ;; deferred callback).
+        e       (-> (env/with-locals e0 header-syms)
+                    (assoc :hooks-region? true))
+        ast     (ana/analyze-view-body e body)
+        _       (doseq [w @(:warnings e)]
+                  (binding [*out* *err*]
+                    (println (str "WARNING re-frame.freehand [" view-id "] "
+                                  (:id w) ": " (:msg w)))))
+        sites   @(:sites e)
+        ;; The render-static no-silent-elision facts (Spec 004C §3, EP-0034 §2),
+        ;; computed once: contributed to the ambient `view-static` build index on
+        ;; the plain-JVM/SSR path (render-static's JVM-only read; gated off the
+        ;; Shadow build path below) AND carried on the registered manifest so a
+        ;; view compiled in ANOTHER build/context (AOT / precompiled JAR) stays
+        ;; fact-bearing — the render-static proof never treats an unknown
+        ;; dependency as static-safe.
+        static-facts (view-static-facts ast sites)
+        ast-projection (ana/template-fingerprint-projection ast)
+        tf      (fingerprint/template-fingerprint ast-projection)
+        ;; The HMR hook signature: `local` sites (all `:local`) and `effect`
+        ;; sites (each `:connect`/`:deps`) in source order. Adding, removing, or
+        ;; changing the KIND of a host hook changes the signature, so the dev
+        ;; view remounts (React hook order must stay stable within a Fiber);
+        ;; `sub` sites stay excluded by design (Spec 004 §Hot reload).
+        hs      (fingerprint/hook-signature-hash
+                 {:locals (mapv (constantly :local) (:locals sites))
+                  :effects (mapv :kind (:effects sites))
+                  ;; the frozen re-frame.freehand.react interop hooks: kind + source-
+                  ;; order position among all let-body host hooks (S3 shape-2).
+                  :react (mapv #(select-keys % [:kind :order]) (:react sites))})
+        manifest {:view-id view-id
+                  :display-name display-name
+                  :doc docstring
+                  :source src
+                  :prop-slots (into []
+                                    (map-indexed
+                                     (fn [i k]
+                                       {:key k :slot (header/slot-name k) :index i}))
+                                    (cond-> slots
+                                      (and children?
+                                           (not (some #(= :children %) slots)))
+                                      (conj :children)))
+                  :props-schema (:props opts)
+                  :open-props? (not (contains? opts :props))
+                  :children? children?
+                  :as? (= :as (:mode hdr))
+                  :template-fingerprint tf
+                  :hook-signature hs
+                  :capabilities (into
+                                 (cond-> (capabilities ast)
+                                   (seq (:locals sites))       (conj :local)
+                                   (seq (:effects sites))      (conj :effect)
+                                   (seq (:dispatch-fns sites)) (conj :dispatch-fn))
+                                 ;; host hooks fold onto the static-root
+                                 ;; vocabulary: v/ref→:ref; use-effect /
+                                 ;; use-layout-effect / use-effect-event→:effect;
+                                 ;; use-context→:context; use-id is exempt (inert
+                                 ;; deterministic ids are static-safe). lazy folds
+                                 ;; into :foreign via the AST scan.
+                                 (keep {:ref :ref :effect :effect
+                                        :layout-effect :effect :effect-event :effect
+                                        :context :context})
+                                 (map :kind (:react sites)))
+                  ;; The render-static server-reachable {:caps :deps} proof
+                  ;; facts, carried so a cross-build/AOT dependency stays
+                  ;; fact-bearing (rf2-uv7n6 hole 2).
+                  :static-facts static-facts
+                  :sites sites}
+        args    {:vname vname
+                 ;; The canonical current-namespace Var a self-recursive head
+                 ;; must emit AGAINST — identical to the `:fqn` env/classify-head
+                 ;; stamps on an exact self component node (rf2-rr26cq). A bare
+                 ;; self head resolves through a same-named `:refer` on CLJS
+                 ;; (refers outrank local defs in cljs.analyzer/resolve-var), so
+                 ;; both emitters target THIS fqn, not the authored spelling.
+                 :self-fqn (symbol (str ns-sym) (str vname))
+                 :view-id view-id
+                 :display-name display-name
+                 :docstring docstring
+                 :header hdr
+                 :slots slots
+                 :ast ast
+                 :manifest manifest
+                 :closed-keys closed-keys
+                 :children? children?}]
+    ;; On a real Shadow build PASS the whole-build views registry is harvested at
+    ;; compile-finish from the disk-cache-durable analyzer-map view descriptors
+    ;; (rf2-u53yy.1 S2) — the same direction S1 took elements — so this macro does
+    ;; NOT contribute a view row to the per-source slice (a warm cache-hit source
+    ;; never re-runs it), and the cross-source view-id uniqueness law runs at
+    ;; compile-finish over the analyzer map (`build/harvest-view-registries`, a
+    ;; compile-finish error is still a build-time error). Off that path (plain-JVM
+    ;; / SSR, REPL — there is no compile-finish analyzer harvest) the macro's own
+    ;; contribution populates the per-source slice and reports a collision here at
+    ;; expansion with the declaration's source coordinates.
+    (when-not (build/shadow-build-pass?)
+      (when-let [{:keys [conflict]}
+                 (build/contribute-view-checked!
+                  ns-sym [ns-sym vname] view-id [tf hs])]
+        (fail :rf.ui.compile/bad-view-id
+              (str "defview " vname ": view id " (pr-str view-id)
+                   " is already owned by a different defview declaration. "
+                   "Explicit :id overrides must be unique across declarations; "
+                   "give this view a distinct qualified keyword (re-expanding "
+                   "the exact same var remains the HMR replacement path)")
+              {:view vname
+               :id view-id
+               :namespace ns-sym
+               :declaration [ns-sym vname]
+               :existing-declaration conflict})))
+    ;; Per-view static-render facts for the render-static transitive proof
+    ;; (Spec 004C §3 / EP-0034 §2). render-static is view-static's ONLY reader
+    ;; and is JVM-only (a CLJS expansion is rejected with
+    ;; `:rf.ui.compile/ui-render-static-jvm-only`), so a real Shadow build PASS
+    ;; NEVER reads `view-static` — its slice there has no consumer and, unlike
+    ;; `views`/`elements`, is not blocker/eviction-relevant. Gate the contribution
+    ;; off the Shadow path like S1 (elements) / S2 (views), so the Shadow-path
+    ;; registries stay a pure function of the cache-durable analyzer map,
+    ;; macro-independent — the direction S6 needs (rf2-u53yy.1 S3). Because
+    ;; nothing reads view-static on the Shadow path, it needs NO compile-finish
+    ;; replacement descriptor there (the simpler mechanism the S3 note names).
+    ;; Off that path (plain-JVM / SSR, REPL — where render-static reads
+    ;; `build/view-static` MID-EXPANSION) the macro contributes the facts to the
+    ;; per-source slice, keyed per declaring ns so a recompiled / removed source
+    ;; replaces / evicts its row; the SAME facts also ride the per-view registered
+    ;; manifest (`:static-facts`) for the cross-build/AOT resolution seam.
+    (when-not (build/shadow-build-pass?)
+      (build/contribute! build/view-static ns-sym view-id static-facts))
+    (if cljs?
+      ;; Direct no-pass REPL evaluation may replace the runtime view body, but
+      ;; never the accepted whole-build registries — those are harvested from
+      ;; cache-durable analyzer descriptors by a successful configured
+      ;; file/watch build pass (rf2-u53yy.1).
+      (emit-cljs/emit-defview args)
+      (emit-jvm/emit-defview args))))
+
+(defn defview*
+  "The defview macro body. `form` = &form, `menv` = &env. Every compile
+  error thrown during expansion is anchored with the defview form's
+  source coordinates (S1e roster: id + didactic message + file:line)."
+  [form menv vname forms]
+  (anchored (source-coords form (some? (:ns menv)))
+            #(defview** form menv vname forms)))
+
+;; ---------------------------------------------------------------------------
+;; re-frame.freehand.react/lazy — the def-level code-splitting constructor
+;; ---------------------------------------------------------------------------
+
+(defn- compile-lazy-fallback
+  "Compile a react/lazy `:fallback` template capability-free to a host render
+  thunk `(fn [] element)`. CLJS emits a self-contained React element; JVM emits
+  the deterministic structural tree."
+  [menv cljs? ns-sym fallback-form]
+  (let [e   (env/make-env {:host (if cljs? :cljs :clj)
+                           :cljs-env menv
+                           :ns-sym ns-sym
+                           ;; a synthetic self-id so a reactive read in the
+                           ;; fallback is recognised as a site and rejected with
+                           ;; the didactic :rf.ui.compile/capability-in-fallback
+                           ;; (the client-only-fallback rule), not a bare
+                           ;; self-less misplacement.
+                           :self-id :re-frame.freehand.react/lazy-fallback
+                           :template-anchor (fingerprint/digest "sta1-" fallback-form)})
+        ast (ana/analyze-capability-free-template
+             e "a re-frame.freehand.react/lazy :fallback" fallback-form)]
+    `(fn [] ~(if cljs?
+               (emit-cljs/emit-standalone ast)
+               (emit-jvm/emit-node ast)))))
+
+(defn expand-lazy
+  "Expand `(re-frame.freehand.react/lazy load-thunk {:fallback tpl}?)` — a DEF-LEVEL
+  foreign-component constructor. CLJS wraps `React.lazy` (with a Suspense
+  boundary when a fallback is given); the JVM structural value renders the
+  compiled fallback / nothing and never references the load thunk. `form` =
+  &form, `menv` = &env, `args` = the argument list."
+  [form menv args]
+  (anchored
+   (source-coords form (some? (:ns menv)))
+   (fn []
+     (let [cljs?  (some? (:ns menv))
+           ns-sym (if cljs? (-> menv :ns :name) (ns-name *ns*))
+           n      (count args)]
+       (when (or (< n 1) (> n 2))
+         (fail :rf.ui.compile/bad-lazy
+               (str "(react/lazy load-thunk {:fallback tpl}?) takes the load "
+                    "thunk and an optional literal opts map; got " n " argument(s)")
+               {:form form}))
+       (let [load-thunk (first args)
+             opts       (second args)]
+         (when (and (some? opts) (not (map? opts)))
+           (fail :rf.ui.compile/bad-lazy
+                 "(react/lazy load-thunk {:fallback tpl}) opts must be a literal map"
+                 {:form form}))
+         (let [bad (remove #{:fallback} (keys opts))]
+           (when (seq bad)
+             (fail :rf.ui.compile/bad-lazy
+                   (str "unknown react/lazy option" (when (next bad) "s") " "
+                        (str/join ", " (map pr-str bad))
+                        " — the only option is :fallback")
+                   {:form form})))
+         (let [fallback    (:fallback opts)
+               fallback-fn (when (some? fallback)
+                             (compile-lazy-fallback menv cljs? ns-sym fallback))]
+           (if cljs?
+             `(re-frame.freehand.hooks/lazy-component ~load-thunk ~fallback-fn)
+             `(re-frame.freehand.hooks/lazy-jvm ~fallback-fn))))))))
+
+(defn- custom-element**
+  [coords ns-sym tag opts]
+  (when-not (and (keyword? tag) (nil? (namespace tag))
+                 (str/includes? (name tag) "-"))
+    (fail :rf.ui.compile/bad-custom-element
+          (str "(v/custom-element tag opts): tag must be an unqualified "
+               "keyword containing '-' (the custom-element grammar); got "
+               (pr-str tag))
+          {:tag tag}))
+  (when-not (map? opts)
+    (fail :rf.ui.compile/bad-custom-element
+          "(v/custom-element tag {:properties #{...}}) needs a literal options map"
+          {:tag tag :opts opts}))
+  (let [unknown (remove #{:properties} (keys opts))]
+    (when (seq unknown)
+      (fail :rf.ui.compile/bad-custom-element
+            (str "unknown custom-element option"
+                 (when (next unknown) "s") " "
+                 (str/join ", " (map pr-str unknown))
+                 " — the v1 grammar is exactly {:properties #{...}} "
+                 "(closed; :events / per-prop types / attribute reflection "
+                 "are future rulings, not silent growth)")
+            {:tag tag :unknown (vec unknown)})))
+  (let [props (:properties opts #{})]
+    (when-not (and (set? props)
+                   (every? #(and (keyword? %) (nil? (namespace %))) props))
+      (fail :rf.ui.compile/bad-custom-element
+            (str ":properties must be a literal set of unqualified keyword "
+                 "property names (kebab; :help-text -> the helpText JS "
+                 "property); got " (pr-str props))
+            {:tag tag :properties props}))
+    ;; compile-time registration (this JVM performs macroexpansion for
+    ;; both hosts) routed through the build-scoped model so a removed /
+    ;; renamed declaration drops its stale property classification with
+    ;; its file (rf2-vxgfnd.16). The emitted runtime registration (v/spread
+    ;; classifies at render via the same registry, on the client) carries the
+    ;; declaring ns so a hot-reload that DROPS this declaration evicts its
+    ;; stale runtime row — the runtime arm of the same eviction model
+    ;; (rf2-vxgfnd.48).
+    ;;
+    ;; The ONE cross-source declaration law (rf2-vxgfnd.143, delegated ruling
+    ;; 2026-07-15 Option A): rf=-equal duplicates co-exist; a CONTRADICTORY
+    ;; declaration of the same tag from another source fails ATOMICALLY with
+    ;; both [build-id ns-sym] anchors and leaves the last-known-good aggregate
+    ;; unchanged. Which of two contradicting sources expands second decides
+    ;; only WHERE the failure is anchored — never who wins, and never whether
+    ;; the build fails. `:declarations` evidence is sorted, so it is identical
+    ;; under every source / evaluation / build-order permutation.
+    ;; During a real Shadow build PASS the compile-time custom-element registry
+    ;; is populated by the build hook's prepare-time ALL-MEMBERS source harvest,
+    ;; which also enforces the cross-source conflict law there (rf2-u53yy.1 S1);
+    ;; the macro is then validation/reporting-only — it validates the declaration
+    ;; grammar above and emits the runtime registration below, but does NOT
+    ;; contribute to (or evict from) the compile-time registry. Off that path
+    ;; (plain-JVM / SSR, REPL — there is no `:compile-prepare` harvest), the
+    ;; macro's own contribution populates the per-source `elements` slice and
+    ;; reports contradictions here with the declaration's source coordinates.
+    (let [decl {:properties props}]
+      (when-not (build/shadow-build-pass?)
+        (when-let [{:keys [conflict]} (build/contribute-element-checked!
+                                       ns-sym tag decl)]
+          (let [build-id (build/current-build-id)
+                rows (vec (sort-by (juxt (comp str :build) (comp str :ns))
+                                   [{:build build-id
+                                     :ns (:owner conflict)
+                                     :properties (:properties (:declaration conflict) #{})}
+                                    {:build build-id :ns ns-sym :properties props}]))]
+            (fail :rf.ui.compile/custom-element-conflict
+                  (str "conflicting (v/custom-element " tag " ...) declarations — "
+                       (str/join " vs "
+                                 (map (fn [{:keys [ns properties]}]
+                                        (str ns " declares :properties "
+                                             (pr-str (vec (sort properties)))))
+                                      rows))
+                       ". One tag has ONE property manifest: delete the duplicate "
+                       "declaration, or make both sources declare an IDENTICAL "
+                       ":properties set (identical declarations may co-exist). "
+                       "re-frame.freehand will not pick a winner by compile order")
+                  {:tag tag :declarations rows})))))
+    `(re-frame.freehand.rules/register-custom-element!
+      ~tag {:properties ~props} '~ns-sym)))
+
+(defn custom-element*
+  "The RULED custom-element declaration grammar (Mike, 2026-07-12):
+  (v/custom-element tag {:properties #{...}}) — top-level,
+  compile-resolvable, registers like defview. The :properties set is the
+  ENTIRE v1 grammar (options map closed); future keys are new rulings,
+  not silent growth. `form` = &form, `menv` = &env — compile errors are
+  anchored with the declaration form's source coordinates (S1e)."
+  [form menv tag opts]
+  (let [coords (source-coords form (some? (:ns menv)))
+        ns-sym (if (:ns menv) (-> menv :ns :name) (ns-name *ns*))]
+    (anchored coords
+              #(custom-element** coords ns-sym tag opts))))
+
+))

--- a/implementation/freehand/src/re_frame/freehand/compiler/a11y.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/a11y.cljc
@@ -1,0 +1,518 @@
+(ns re-frame.freehand.compiler.a11y
+  "COMPILE-TIER accessibility diagnostics — the S4-C roster (rf2-74vlo;
+  Spec 004 §Compile-tier warnings).
+
+  Four `:rf.ui.compile/a11y-*` WARNINGS minted at `defview` expansion from
+  LITERAL template-AST facts. They are warnings, never errors: a finding never
+  fails a build. They ride the existing `env/warn!` accumulator and the existing
+  print path, exactly like the three pre-existing compile warnings.
+
+  ## The high-confidence charter (this namespace's whole design constraint)
+
+  **A false positive is worse than a miss.** Every check fires only when the
+  defect is PROVABLE from the local AST the compiler already built. The instant
+  a shape introduces information the compiler cannot see — a dynamic child, a
+  foreign component, a props spread, an aria value computed at runtime, an
+  IDREF pointing somewhere else in the document — the check goes SILENT. There
+  is no heuristic tier, no confidence score, no \"probably\" warning.
+
+  Deliberate non-goals, so this file cannot grow into an a11y framework: no
+  cross-view recursion (a child `defview`'s body is another view's business),
+  no CSS or computed-style inference, no IDREF/document-wide analysis, no
+  colour-contrast anything, no runtime checking, no rule plugins, and no
+  configuration beyond the per-site suppression below. Spec 004 owns the
+  \"re-frame2 is not an a11y framework\" boundary; this roster serves it.
+
+  ## Suppression — rule-local, with a reason
+
+  A finding is silenced by metadata on the offending literal form:
+
+      ^{:rf.ui/suppress {:rf.ui.compile/a11y-click-non-interactive \"drag surface;
+                                                                    keyboard path
+                                                                    is the toolbar\"}}
+      [:div {:on-click […]} …]
+
+  The map's keys must be ids from this roster and every value a non-blank
+  literal string — a malformed suppression is the compile error
+  `:rf.ui.compile/bad-suppress`, never a silent no-op. There are no wildcards,
+  no project-wide disables, no severity configuration, and no second config
+  file. The metadata never becomes a DOM prop; nothing is stripped at runtime.
+
+  ## Manifest evidence
+
+  Every finding — suppressed or not — is recorded as a `:diagnostics` manifest
+  site carrying the compiler-minted stable site id, so a suppressed finding
+  stays an inspectable fact (with its reason) while printing nothing. Tools
+  read it through `re-frame.freehand.tool/view-manifest`; nothing re-derives site
+  identity downstream."
+  (:require [clojure.string :as str]
+            [re-frame.freehand.compiler.env :as env]))
+
+;; ---------------------------------------------------------------------------
+;; The roster
+;; ---------------------------------------------------------------------------
+
+(def a11y-warning-ids
+  "The four ids this namespace mints. Suppression metadata is validated
+  against exactly this set."
+  #{:rf.ui.compile/a11y-missing-accessible-name
+    :rf.ui.compile/a11y-invalid-literal-aria
+    :rf.ui.compile/a11y-click-non-interactive
+    :rf.ui.compile/a11y-presence-exit-interactive})
+
+;; ---------------------------------------------------------------------------
+;; The ONE pinned WAI-ARIA table
+;; ---------------------------------------------------------------------------
+
+(def ^:private aria-attributes
+  "WAI-ARIA 1.2 states and properties, as authored in this grammar (`aria-*`
+  keywords pass through verbatim — `re-frame.freehand.rules/react-prop-name`).
+
+  The value is the LITERAL value check, and only literal values are checked:
+
+    :any      — free-form text / IDREF / token list: name-only validation
+    #{…}      — a closed token set (booleans normalize to \"true\"/\"false\")
+    :integer  — an integer
+    :number   — a number
+
+  Deprecated ARIA 1.2 attributes (`aria-dropeffect`, `aria-grabbed`) are
+  listed: they are still valid names, and flagging them is a different
+  (unruled) check."
+  {:aria-activedescendant     :any
+   :aria-atomic               #{"true" "false"}
+   :aria-autocomplete         #{"inline" "list" "both" "none"}
+   :aria-braillelabel         :any
+   :aria-brailleroledescription :any
+   :aria-busy                 #{"true" "false"}
+   :aria-checked              #{"true" "false" "mixed" "undefined"}
+   :aria-colcount             :integer
+   :aria-colindex             :integer
+   :aria-colindextext         :any
+   :aria-colspan              :integer
+   :aria-controls             :any
+   :aria-current              #{"page" "step" "location" "date" "time"
+                                "true" "false"}
+   :aria-describedby          :any
+   :aria-description          :any
+   :aria-details              :any
+   :aria-disabled             #{"true" "false"}
+   :aria-dropeffect           #{"copy" "execute" "link" "move" "none" "popup"}
+   :aria-errormessage         :any
+   :aria-expanded             #{"true" "false" "undefined"}
+   :aria-flowto               :any
+   :aria-grabbed              #{"true" "false" "undefined"}
+   :aria-haspopup             #{"false" "true" "menu" "listbox" "tree" "grid"
+                                "dialog"}
+   :aria-hidden               #{"true" "false" "undefined"}
+   :aria-invalid              #{"grammar" "false" "spelling" "true"}
+   :aria-keyshortcuts         :any
+   :aria-label                :any
+   :aria-labelledby           :any
+   :aria-level                :integer
+   :aria-live                 #{"assertive" "off" "polite"}
+   :aria-modal                #{"true" "false"}
+   :aria-multiline            #{"true" "false"}
+   :aria-multiselectable      #{"true" "false"}
+   :aria-orientation          #{"horizontal" "vertical" "undefined"}
+   :aria-owns                 :any
+   :aria-placeholder          :any
+   :aria-posinset             :integer
+   :aria-pressed              #{"true" "false" "mixed" "undefined"}
+   :aria-readonly             #{"true" "false"}
+   :aria-relevant             :any            ; a space-separated token LIST
+   :aria-required             #{"true" "false"}
+   :aria-roledescription      :any
+   :aria-rowcount             :integer
+   :aria-rowindex             :integer
+   :aria-rowindextext         :any
+   :aria-rowspan              :integer
+   :aria-selected             #{"true" "false" "undefined"}
+   :aria-setsize              :integer
+   :aria-sort                 #{"ascending" "descending" "none" "other"}
+   :aria-valuemax             :number
+   :aria-valuemin             :number
+   :aria-valuenow             :number
+   :aria-valuetext            :any})
+
+(def ^:private interactive-roles
+  "ARIA roles that make a generic host element a real control — enough to
+  silence `a11y-click-non-interactive`. Not a full role table: the check needs
+  only \"did the author declare an interactive role?\"."
+  #{"button" "link" "checkbox" "radio" "switch" "tab" "menuitem"
+    "menuitemcheckbox" "menuitemradio" "option" "treeitem" "gridcell"
+    "slider" "spinbutton" "textbox" "searchbox" "combobox"})
+
+(def ^:private generic-tags
+  "Host elements with no native interactive semantics — an `:on-click` on one
+  of these is invisible to keyboard and assistive technology unless the author
+  supplies role + focusability + key handling."
+  #{:div :span :p :li :ul :ol :dl :dt :dd :section :article :header :footer
+    :main :nav :aside :figure :figcaption :h1 :h2 :h3 :h4 :h5 :h6
+    :table :thead :tbody :tfoot :tr :td :th
+    :img :i :b :em :strong :small :pre :blockquote})
+
+(def ^:private natively-interactive-tags
+  "Host elements that are focusable and operable with no author effort — the
+  exit-window population `a11y-presence-exit-interactive` cares about."
+  #{:button :input :select :textarea :summary})
+
+(def ^:private naming-attrs
+  "Attributes that can supply an accessible name from somewhere this analysis
+  deliberately does not follow. Presence of ANY of them — even with a dynamic
+  value — silences the missing-name check."
+  #{:aria-label :aria-labelledby :title})
+
+;; ---------------------------------------------------------------------------
+;; Props-AST readers (the analyzed shape, not the authored form)
+;; ---------------------------------------------------------------------------
+
+(defn- attr-entry
+  "The analyzed attr entry for prop `k`, or nil. `:class` / `:style` / `:ref` /
+  `:key` and `:on-*` handlers never appear here — they have their own slots."
+  [props k]
+  (first (filter #(= k (:k %)) (:attrs props))))
+
+(defn- has-attr? [props k] (some? (attr-entry props k)))
+
+(defn- literal-attr
+  "The LITERAL value of prop `k`, or `::none` when absent or dynamic. `::none`
+  is distinct from a literal `nil`."
+  [props k]
+  (if-some [a (attr-entry props k)]
+    (if (:literal? a) (:value a) ::none)
+    ::none))
+
+(defn- spread?
+  "A props spread makes the prop set open — the compiler cannot prove ANY
+  attribute absent, so every check on this element goes silent."
+  [props]
+  (boolean (or (:spread props) (:safe-spread props))))
+
+(defn- event-named?
+  "Does the element carry a compiler-recognised `:on-<n>` handler? `:name` is
+  the analyzed handler's prop name (\"on-click\", \"on-key-down\", …)."
+  [props n]
+  (boolean (some #(= n (:name %)) (:events props))))
+
+(defn- truthy-literal?
+  "A literal value React would render as a true boolean attribute."
+  [v]
+  (or (true? v) (= "true" v)))
+
+(defn- presentational?
+  "The element declares itself invisible to assistive technology — nothing to
+  name, nothing to operate."
+  [props]
+  (or (truthy-literal? (literal-attr props :aria-hidden))
+      (contains? #{"presentation" "none"} (literal-attr props :role))
+      (truthy-literal? (literal-attr props :inert))))
+
+;; ---------------------------------------------------------------------------
+;; Suppression
+;; ---------------------------------------------------------------------------
+
+(defn suppressions
+  "Validated `^{:rf.ui/suppress {<id> \"reason\"}}` metadata on `form`, as
+  `{id reason}`. nil when absent. A malformed suppression is a compile error,
+  never a silent no-op — a typo that quietly stops silencing a finding is the
+  worst outcome this mechanism can produce."
+  [e form]
+  (when-some [m (:rf.ui/suppress (meta form))]
+    (when-not (and (map? m) (seq m))
+      (env/fail! e :rf.ui.compile/bad-suppress
+                 (str "^{:rf.ui/suppress …} needs a non-empty literal map of "
+                      "{<a11y warning id> \"reason\"}; got " (pr-str m))
+                 {:form form :suppress m}))
+    (doseq [[id reason] m]
+      (when-not (contains? a11y-warning-ids id)
+        (env/fail! e :rf.ui.compile/bad-suppress
+                   (str "unknown suppression id " (pr-str id) " — suppressible "
+                        "diagnostics are "
+                        (str/join ", " (sort (map str a11y-warning-ids))))
+                   {:form form :id id}))
+      (when-not (and (string? reason) (not (str/blank? reason)))
+        (env/fail! e :rf.ui.compile/bad-suppress
+                   (str "suppressing " id " needs a non-blank literal reason "
+                        "string saying WHY the finding is wrong here; got "
+                        (pr-str reason))
+                   {:form form :id id})))
+    m))
+
+;; ---------------------------------------------------------------------------
+;; Finding emission
+;; ---------------------------------------------------------------------------
+
+(defn- report!
+  "Record one finding. It ALWAYS becomes a `:diagnostics` manifest site (so a
+  suppressed finding stays an inspectable fact carrying its reason); it prints
+  only when unsuppressed."
+  [e {:keys [id sid tag msg suppress]}]
+  (let [reason (get suppress id)
+        ;; `sid` is a delay: the vast majority of elements produce no finding,
+        ;; and minting a lexical site id costs a digest. Findings on one element
+        ;; share the one id.
+        sid    @sid]
+    (env/add-site! e :diagnostics
+                   (cond-> {:sid sid :id id :tag tag :path (:path e)
+                            :suppressed? (some? reason)}
+                     (some? reason) (assoc :reason reason)))
+    (when (nil? reason)
+      (env/warn! e {:id id :msg (str msg " [site " sid "]") :sid sid}))
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; Check 1 — a11y-missing-accessible-name
+;; ---------------------------------------------------------------------------
+;;
+;; Fires ONLY when a literal obvious control is PROVABLY nameless: every naming
+;; route the compiler can see is absent AND its whole content subtree is
+;; literal and provably text-free. One dynamic child, one foreign component,
+;; one spread, one `v/html` — and the check goes silent, because the name may
+;; well arrive from there.
+
+(declare content-evidence)
+
+(defn- element-content-evidence
+  "`:name` / `:none` / `:unknown` for one literal element node's contribution
+  to its ancestor's accessible name."
+  [{:keys [tag props children html]}]
+  (cond
+    ;; trusted markup is opaque text
+    (some? html)                 :unknown
+    (spread? props)              :unknown
+    ;; `<title>` inside an inline `<svg>` names the graphic
+    (= :title tag)               :name
+    ;; an `<img alt=…>` contributes its alt text (a dynamic alt might be "",
+    ;; so treating presence as naming keeps us on the SILENT side)
+    (and (= :img tag)
+         (has-attr? props :alt)) :name
+    (some (partial has-attr? props) naming-attrs) :name
+    (presentational? props)      :none
+    :else                        (content-evidence children)))
+
+(defn- content-evidence
+  "Fold a child-node vector into `:name` (some node provably contributes text)
+  / `:none` (every node provably contributes nothing) / `:unknown` (at least
+  one node is opaque to this analysis, so nothing is provable)."
+  [nodes]
+  (reduce
+   (fn [acc n]
+     (let [ev (case (:op n)
+                :text     (if (str/blank? (str (:value n))) :none :name)
+                :nothing  :none
+                :element  (element-content-evidence n)
+                :fragment (content-evidence (:children n))
+                ;; :expr / :if / :for / :view / :foreign / :raw / :html /
+                ;; :slot / :let / … — content this analysis cannot see
+                :unknown)]
+       (cond (= :name ev)                :name
+             (= :name acc)               :name
+             (or (= :unknown ev)
+                 (= :unknown acc))       :unknown
+             :else                       :none)))
+   :none
+   nodes))
+
+(defn- check-missing-accessible-name!
+  [e {:keys [tag props children html sid suppress]}]
+  (let [named? (some (partial has-attr? props) naming-attrs)]
+    ;; `(v/html s)` is hoisted out of `:children` onto the node: trusted markup
+    ;; is opaque text, so the content is unknowable and the check goes silent.
+    (when-not (or (spread? props) named? (presentational? props) (some? html))
+      (cond
+        ;; an <img> is named by @alt — including the deliberate empty alt of a
+        ;; decorative image. NO alt at all is the provable defect.
+        (and (= :img tag) (not (has-attr? props :alt)))
+        (report! e {:id :rf.ui.compile/a11y-missing-accessible-name
+                    :sid sid :tag tag :suppress suppress
+                    :msg (str "<img> has no :alt — a screen reader announces the "
+                              "file name, or nothing. Add :alt with the text the "
+                              "image conveys, or :alt \"\" when it is purely "
+                              "decorative (the explicit empty alt is the correct "
+                              "spelling, not a missing one)")})
+
+        ;; a <button>, and a real <a href>, are named by their CONTENT. The
+        ;; classic defect is the icon-only control: literal markup with no text
+        ;; anywhere in it.
+        (and (or (= :button tag) (and (= :a tag) (has-attr? props :href)))
+             (= :none (content-evidence children)))
+        (report! e {:id :rf.ui.compile/a11y-missing-accessible-name
+                    :sid sid :tag tag :suppress suppress
+                    :msg (str "<" (name tag) "> has no accessible name — its "
+                              "content is literal markup carrying no text (an "
+                              "icon-only control), and it declares no :aria-label "
+                              "/ :aria-labelledby / :title. Add :aria-label with "
+                              "the ACTION it performs, e.g. {:aria-label "
+                              "\"Close dialog\"}")})
+        :else nil))))
+
+;; ---------------------------------------------------------------------------
+;; Check 2 — a11y-invalid-literal-aria
+;; ---------------------------------------------------------------------------
+;;
+;; Literal `aria-*` NAMES are checked against the pinned table; literal VALUES
+;; against that attribute's pinned token set / numeric kind. A dynamic value is
+;; never judged — the compiler does not know what it evaluates to.
+
+(defn- normalize-aria-value [v]
+  (cond (true? v) "true" (false? v) "false" :else v))
+
+(defn- invalid-aria-value
+  "A didactic explanation when literal `v` is invalid for `k`, else nil."
+  [k v]
+  (let [spec (get aria-attributes k)
+        v*   (normalize-aria-value v)]
+    (cond
+      (= :any spec) nil
+      (set? spec)   (when-not (and (string? v*) (contains? spec v*))
+                      (str "expected one of "
+                           (str/join ", " (map pr-str (sort spec)))))
+      (= :integer spec) (when-not (or (integer? v)
+                                      (and (string? v) (re-matches #"-?\d+" v)))
+                          "expected an integer")
+      (= :number spec)  (when-not (or (number? v)
+                                      (and (string? v)
+                                           (re-matches #"-?\d+(\.\d+)?" v)))
+                          "expected a number")
+      :else nil)))
+
+(defn- check-literal-aria!
+  [e {:keys [tag props sid suppress]}]
+  (doseq [{:keys [k value literal?]} (:attrs props)
+          :when (and (keyword? k) (str/starts-with? (name k) "aria-"))]
+    (if-not (contains? aria-attributes k)
+      (report! e {:id :rf.ui.compile/a11y-invalid-literal-aria
+                  :sid sid :tag tag :suppress suppress
+                  :msg (str k " is not a WAI-ARIA attribute — assistive "
+                            "technology ignores it entirely (React passes "
+                            "aria-* through verbatim, so nothing else catches "
+                            "the typo). Check the spelling against the ARIA "
+                            "states and properties, e.g. :aria-labelledby, "
+                            ":aria-describedby, :aria-expanded")})
+      ;; a dynamic value is opaque — the NAME was still worth checking
+      (when literal?
+        (when-some [why (invalid-aria-value k value)]
+          (report! e {:id :rf.ui.compile/a11y-invalid-literal-aria
+                      :sid sid :tag tag :suppress suppress
+                      :msg (str k " has the invalid literal value "
+                                (pr-str value) " — " why
+                                ". An unrecognised value is treated as if the "
+                                "attribute were absent")}))))))
+
+;; ---------------------------------------------------------------------------
+;; Check 3 — a11y-click-non-interactive
+;; ---------------------------------------------------------------------------
+;;
+;; A literal generic host element + a compiler-recognised `:on-click` + no
+;; native and no LITERAL interactive role. Keyboard users and assistive
+;; technology cannot reach it at all. The primary rewrite is the native
+;; element, which is why the message names `:button` first.
+
+(defn- check-click-non-interactive!
+  [e {:keys [tag props sid suppress]}]
+  (when (and (contains? generic-tags tag)
+             (event-named? props "on-click")
+             (not (spread? props))
+             ;; ANY :role — even a dynamic one — means the author is steering
+             ;; the semantics; we cannot prove it wrong.
+             (not (has-attr? props :role))
+             (not (presentational? props))
+             ;; an explicitly focusable element with key handling is a
+             ;; hand-rolled control: incomplete (no role) but deliberate.
+             (not (and (has-attr? props :tab-index)
+                       (or (event-named? props "on-key-down")
+                           (event-named? props "on-key-up")
+                           (event-named? props "on-key-press"))))
+             (not (has-attr? props :content-editable)))
+    (report! e {:id :rf.ui.compile/a11y-click-non-interactive
+                :sid sid :tag tag :suppress suppress
+                :msg (str ":on-click on <" (name tag) "> — a generic element is "
+                          "not focusable and has no role, so keyboard and "
+                          "assistive-technology users cannot activate it at "
+                          "all. Use the native control: [:button {:on-click …} "
+                          "…]. If the element must stay a <" (name tag) ">, give "
+                          "it {:role \"button\" :tab-index 0} AND an "
+                          ":on-key-down that handles Enter/Space")})))
+
+;; ---------------------------------------------------------------------------
+;; Check 4 — a11y-presence-exit-interactive
+;; ---------------------------------------------------------------------------
+;;
+;; rf2-0ufty ruled presence DOM-AGNOSTIC and TIMEOUT-ONLY: the boundary stamps
+;; no `inert` / `aria-hidden`, and a presence-aware CHILD owns its exit
+;; accessibility by reading `(v/presence-phase)` = `:unmounting`. This check
+;; is the compile-time counterpart of that author obligation, and its trigger
+;; is a STRUCTURAL fact rather than a style judgement:
+;;
+;;   the presence runtime wraps each child ELEMENT in the phase-carrying
+;;   context Provider (`presence_runtime/render-entries`), so inline literal
+;;   markup under a presence boundary has its props evaluated in the PARENT's
+;;   render — outside its own Provider. Such an element therefore PROVABLY
+;;   cannot read its own phase, and no amount of author care can make it
+;;   inert during its exit window without extracting a child view.
+;;
+;; It never blanket-warns on `v/presence`: it fires only on inline literal
+;; FOCUSABLE markup. A `[toast-card {:key …}]` child — the idiomatic form, and
+;; the one Spec 004 shows — is a `:view` node and is silent, because the child
+;; view CAN read its phase and this analysis does not cross view boundaries.
+
+(defn- literal-tabindex [props]
+  (let [v (literal-attr props :tab-index)]
+    (cond (integer? v) v
+          (and (string? v) (re-matches #"-?\d+" v)) #?(:clj (Long/parseLong v)
+                                                       :cljs (js/parseInt v 10))
+          :else nil)))
+
+(defn- exit-focusable?
+  "Is this literal element provably focusable during its exit window?"
+  [tag props]
+  (and (not (spread? props))
+       (not (presentational? props))
+       (not (truthy-literal? (literal-attr props :disabled)))
+       (not= -1 (literal-tabindex props))
+       (or (contains? natively-interactive-tags tag)
+           (and (= :a tag) (has-attr? props :href))
+           (some-> (literal-tabindex props) (>= 0)))))
+
+(defn- check-presence-exit-interactive!
+  [e {:keys [tag props sid suppress]}]
+  (when (exit-focusable? tag props)
+    (report! e {:id :rf.ui.compile/a11y-presence-exit-interactive
+                :sid sid :tag tag :suppress suppress
+                :msg (str "<" (name tag) "> is focusable and authored INLINE "
+                          "under (v/presence …). The presence boundary is "
+                          "DOM-agnostic — it stamps no inert/aria-hidden — and "
+                          "the phase Provider wraps the child ELEMENT, so this "
+                          "markup's props are evaluated in the parent's render "
+                          "and it provably cannot read its own "
+                          "(v/presence-phase). It stays in the tab order for "
+                          "the whole exit window. Extract a keyed child view "
+                          "that stamps :inert / :aria-hidden against "
+                          "(v/presence-phase) = :unmounting")})))
+
+;; ---------------------------------------------------------------------------
+;; Entry point
+;; ---------------------------------------------------------------------------
+
+(defn check-element!
+  "Run the compile-tier a11y roster over one analyzed host element.
+
+  `form` is the authored hiccup vector (the suppression-metadata carrier),
+  `node` the element AST just built, and `sid-fn` mints the stable site id
+  from an expression path — the compiler owns site identity; nothing
+  downstream re-derives it.
+
+  Custom elements (`tag` contains `-`) are skipped: their semantics come from
+  a definition this compiler never sees, so no check over them can be
+  high-confidence."
+  [e form {:keys [tag custom? props children html] :as node} sid-fn]
+  (let [suppress (suppressions e form)]
+    (when-not custom?
+      (let [ctx {:tag tag :props props :children children :html html
+                 :sid (delay (sid-fn [:a11y])) :suppress suppress}]
+        (check-missing-accessible-name! e ctx)
+        (check-literal-aria! e ctx)
+        (check-click-non-interactive! e ctx)
+        (when (:presence-inline? e)
+          (check-presence-exit-interactive! e ctx)))))
+  node)

--- a/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
@@ -1,0 +1,3490 @@
+(ns re-frame.freehand.compiler.analyze
+  "Template-grammar analyzer: one normalized, closed-node-set template AST
+  from the blessed hiccup grammar (Spec 004 rewrite §Template grammar).
+  The AST is PRIVATE — the public contract is the JVM tree + the
+  conversion table; both emitters consume ONLY these nodes:
+
+    :text :nothing :expr :element :fragment :view :foreign
+    :if :let :letfn :case :for :raw :html
+
+  Control forms (let/letfn/if/if-not/when/when-not/cond/case/pure-do/for)
+  normalize INTO the AST; every analyzer and both emitters see through
+  branches. Rejected forms throw compile errors with
+  {:rf.ui.compile/error <id>} ex-data (the S1e roster keys off the ids)."
+  (:require [clojure.string :as str]
+            [re-frame.freehand.compiler.a11y :as a11y]
+            [re-frame.freehand.compiler.binding-plan :as bp]
+            [re-frame.freehand.compiler.build :as build]
+            [re-frame.freehand.compiler.env :as env]
+            [re-frame.freehand.fingerprint :as fingerprint]
+            [re-frame.freehand.rules :as rules]
+            #?@(:clj [[re-frame.freehand.compiler.harvest :as harvest]])))
+
+(def node-ops
+  "The CLOSED op set — the AST-shape gate's vocabulary. `:frame-root` (S1c,
+  rf2-vxgfnd.3) appears only inside the static top region of a ROOT form
+  (`v/mount` / `v/render!` / `v/hydrate-root`) — the analyzer rejects it
+  everywhere else, so defview-template ASTs never carry it.
+  `:frame-provider` (S2c, rf2-vxgfnd.9) is the SCOPE form — legal anywhere,
+  scoping a subtree to an already-live frame."
+  #{:text :nothing :expr :element :fragment :view :foreign
+    :if :let :letfn :case :for :raw :html :frame-root :frame-provider :slot
+    :error-boundary :client-only :presence
+    :hook-prefix})
+
+(defn literal-scalar? [x]
+  (or (string? x) (number? x) (keyword? x) (boolean? x) (nil? x)))
+
+(def ^:private ui-raw-fqns    #{'re-frame.freehand/raw})
+(def ^:private ui-html-fqns   #{'re-frame.freehand/html})
+(def ^:private ui-raw-fn-fqns #{'re-frame.freehand/raw-fn})
+(def ^:private ui-spread-fqns #{'re-frame.freehand/spread})
+(def ^:private ui-spread-safe-fqns #{'re-frame.freehand/spread-safe})
+(def ^:private ui-event-fqns  #{'re-frame.freehand/event})
+(def ^:private ui-handler-fqns #{'re-frame.freehand/handler})
+(def ^:private ui-render-fn-fqns #{'re-frame.freehand/render-fn})
+(def ^:private ui-slot-fqns   #{'re-frame.freehand/slot})
+(def ^:private error-boundary-fqns #{'re-frame.freehand/error-boundary})
+(def ^:private client-only-fqns #{'re-frame.freehand/client-only})
+(def ^:private presence-fqns #{'re-frame.freehand/presence})
+(def ^:private sub-fqns       #{'re-frame.freehand/sub})
+(def ^:private frame-fqns     #{'re-frame.freehand/frame})
+(def ^:private local-fqns     #{'re-frame.freehand/local})
+(def ^:private effect-fqns    #{'re-frame.freehand/effect})
+(def ^:private dispatch-fn-fqns #{'re-frame.freehand/dispatch-fn})
+
+;; The frozen re-frame.freehand.react interop tier (Spec 004 §The React interop tier)
+;; plus the promoted substrate host hook `re-frame.freehand/ref` (rf2-u53yy.9). All are
+;; recognised in expression (let-binding value) position by the same finite-site
+;; machinery as `local`, position-checked, and lowered to `re-frame.freehand.hooks/*`
+;; (ref's lowering target stays the `use-ref` runtime fn). `lazy` is def-level
+;; only — recognised in a view body solely to reject it.
+(def ^:private ui-ref-fqns                 #{'re-frame.freehand/ref})
+(def ^:private react-use-effect-fqns       #{'re-frame.freehand.react/use-effect})
+(def ^:private react-use-layout-effect-fqns #{'re-frame.freehand.react/use-layout-effect})
+(def ^:private react-use-effect-event-fqns #{'re-frame.freehand.react/use-effect-event})
+(def ^:private react-use-context-fqns      #{'re-frame.freehand.react/use-context})
+(def ^:private react-use-id-fqns           #{'re-frame.freehand.react/use-id})
+(def ^:private react-lazy-fqns             #{'re-frame.freehand.react/lazy})
+;; :authored = the full authored head spelling used in diagnostics; :kind keyword
+;; + runtime lowering target + call arity, keyed by fqn set.
+(def ^:private react-hook-specs
+  [{:fqns ui-ref-fqns                 :kind :ref          :runtime 're-frame.freehand.hooks/use-ref
+    :min-args 0 :max-args 1 :authored "v/ref"}
+   {:fqns react-use-effect-fqns       :kind :effect       :runtime 're-frame.freehand.hooks/use-effect
+    :min-args 1 :max-args 2 :authored "react/use-effect" :deferred-cb 0 :deps-arg 1}
+   {:fqns react-use-layout-effect-fqns :kind :layout-effect :runtime 're-frame.freehand.hooks/use-layout-effect
+    :min-args 1 :max-args 2 :authored "react/use-layout-effect" :deferred-cb 0 :deps-arg 1}
+   {:fqns react-use-effect-event-fqns :kind :effect-event :runtime 're-frame.freehand.hooks/use-effect-event
+    :min-args 1 :max-args 1 :authored "react/use-effect-event" :deferred-cb 0}
+   {:fqns react-use-context-fqns      :kind :context      :runtime 're-frame.freehand.hooks/use-context
+    :min-args 1 :max-args 1 :authored "react/use-context"}
+   {:fqns react-use-id-fqns           :kind :id           :runtime 're-frame.freehand.hooks/use-id
+    :min-args 0 :max-args 0 :authored "react/use-id"}])
+
+(defn- react-hook-spec-for
+  "The react-hook spec `head` (an unshadowed symbol) resolves to, or nil."
+  [e* head]
+  (some (fn [spec] (when (env/resolves-to? e* head (:fqns spec)) spec))
+        react-hook-specs))
+(def ^:private frame-root-fqns #{'re-frame.freehand/frame-root})
+(def ^:private frame-provider-fqns #{'re-frame.freehand/frame-provider})
+
+(def markup-map-fqns
+  "The map family — heads whose (f render-fn coll) idiom generates markup
+  rows lazily. Rejected in child position (:rf.ui.compile/markup-returning-map)
+  with the keyed-(for ...) escape. CLOSED vocabulary: additions are S1e
+  roster changes."
+  #{'clojure.core/map          'cljs.core/map
+    'clojure.core/map-indexed  'cljs.core/map-indexed
+    'clojure.core/mapcat       'cljs.core/mapcat
+    'clojure.core/keep         'cljs.core/keep
+    'clojure.core/keep-indexed 'cljs.core/keep-indexed})
+
+(def lazy-seq-fqns
+  "Core seq producers whose value in child position is a RAW SEQ — the
+  grammar rejects raw lazy seqs (Spec 004 rewrite §Template grammar:
+  they hide keys and laziness). Rejected in child position
+  (:rf.ui.compile/lazy-seq-child). CLOSED vocabulary: additions are S1e
+  roster changes. Note: these heads stay legal everywhere expressions
+  are opaque — prop values, for-collections, if-tests — only RENDERED
+  CONTENT positions reject them."
+  (into #{}
+        (mapcat (fn [s] [(symbol "clojure.core" (name s))
+                         (symbol "cljs.core" (name s))]))
+        '[filter remove take take-while take-nth take-last drop drop-while
+          drop-last concat interpose interleave sequence repeat repeatedly
+          iterate cycle range distinct dedupe flatten partition
+          partition-all partition-by sort sort-by reverse rest next butlast
+          keys vals seq re-seq]))
+
+(def ^:private control-heads
+  #{'if 'if-not 'when 'when-not 'cond 'case 'let 'letfn 'do 'for})
+
+(def ^:private if-let-family
+  "The admitted conditional-binder family (rf2-u53yy.4): if-let / when-let /
+  if-some / when-some, keyed by the UNQUALIFIED core name. `:some?` selects the
+  `some?`-based nil test over truthiness; `:else?` selects the two-arm
+  if-let/if-some shape over the single-body when-let/when-some shape. This map is
+  the source of truth for `if-let-family-fqns`; admission is RESOLVER-confirmed
+  (see `if-let-family-config`), never keyed on the raw spelling. The set is
+  CLOSED — case in expression position, condp, doto and the rest stay outside the
+  grammar (Spec 004 §Expression positions); additions are S1e roster changes."
+  {'if-let    {:some? false :else? true}
+   'if-some   {:some? true  :else? true}
+   'when-let  {:some? false :else? false}
+   'when-some {:some? true  :else? false}})
+
+(def ^:private if-let-family-fqns
+  "The four admitted binders' fully-qualified `clojure.core` / `cljs.core` names
+  mapped to their desugar config. Admission is RESOLVER-confirmed against this
+  set (rf2-u53yy.4 audit repair): a same-spelled user macro/var resolves to a
+  different fqn and is NOT admitted (it fails loudly as an unaudited macro), a
+  qualified core binder (`clojure.core/if-let`) IS admitted, and a local shadow
+  yields no resolution at all — the spelling alone never decides admission."
+  (into {}
+        (mapcat (fn [[s cfg]]
+                  [[(symbol "clojure.core" (name s)) cfg]
+                   [(symbol "cljs.core" (name s)) cfg]]))
+        if-let-family))
+
+(defn- if-let-family-config
+  "The desugar config {:some? :else?} for `head` when it is the core
+  if-let-family binder, else nil (rf2-u53yy.4 audit repair). Admission is
+  RESOLVER-confirmed, never keyed on the raw spelling alone:
+
+    - a LOCAL shadow (`head` in `(:locals e)`) is never admitted — it falls
+      through to an ordinary call;
+    - a spelling whose unqualified name is in the family and that resolves to a
+      NON-core var (a `:refer`d look-alike user macro, `my.ns/if-let`) is NOT
+      admitted — it fails loudly as an unaudited macro;
+    - a spelling that resolves to a core binder var (bare `if-let` or qualified
+      `clojure.core/if-let`) IS admitted;
+    - a BARE core name whose host offers no resolution (a data-only emit env)
+      falls back to the name — the plain core spelling with no resolver is
+      overwhelmingly the core macro, matching how the other control heads are
+      admitted in that path.
+
+  The caller passes an env whose `:locals` already carry the lexical scope."
+  [e head]
+  (when (and (symbol? head) (not (contains? (:locals e) head)))
+    (when-let [cfg (get if-let-family (symbol (name head)))]
+      (let [r (env/resolve-sym e head)]
+        (cond
+          (contains? if-let-family-fqns (:fqn r))        cfg
+          (and (nil? r) (nil? (namespace head)))         cfg)))))
+
+(defn- core-sym
+  "A host-qualified `clojure.core` / `cljs.core` symbol. A namespace-qualified
+  symbol cannot be shadowed by a user local, so a compiler-GENERATED core call —
+  the some?-binder's nil test `(core/not= temp nil)` — keeps core semantics even
+  under a hostile `(let [not= (constantly true)] (if-some …))`. `not=` is a plain
+  core function on both hosts (unlike `some?`/`nil?`, which are cljs.core macros
+  and would be rejected by the expression grammar on re-analysis)."
+  [e nm]
+  (symbol (if (= :cljs (:host e)) "cljs.core" "clojure.core") nm))
+
+(defn- binder-temp
+  "A deterministic, reserved temp symbol for the if-let-family desugar. Stable
+  per lexical `anchor` (so template identity is stable across compiles) and
+  never a user local (the reserved `rf-ui-` prefix). The temp holds the raw
+  init value so the truthiness / some? test examines it BEFORE the pattern
+  destructures — the exact hygiene clojure.core's own if-let uses (a
+  destructuring pattern must never be tested for truthiness)."
+  [anchor]
+  (symbol (str "rf-ui-binder-" (fingerprint/digest "bnd1-" anchor))))
+
+(defn- desugar-if-let
+  "Desugar one if-let/when-let/if-some/when-some form into the analyzer's own
+  let + if over a reserved temp — mirroring clojure.core's expansions, but using
+  ONLY host-safe generated semantics (rf2-u53yy.4 audit repair): the conditional
+  is `if` (a special form, so a user local named `when`/`if` cannot capture it),
+  the some?-variants' nil test is a host-qualified core `(not= temp nil)`
+  (un-shadowable by a user local, and — unlike `some?`/`nil?`, which are cljs.core
+  macros — a plain function the expression grammar accepts on re-analysis), and
+  the single-body when-* shape lowers to `(if test body nil)` rather than a
+  generated `when`. `config` is the resolver-confirmed
+  {:some? :else?} for `head`. The init is an ordinary evaluated expression (it
+  may own a finite reactive site); the pattern binds into the then/body branch
+  ONLY; the else branch never sees it. Both grammar tiers then reuse their
+  EXISTING let/if machinery on the result, so the family inherits the SAME scope
+  threading, destructuring, and reactive-escape rejection as a hand-written let +
+  if — no runtime interpreter, no dynamic site, no open macro system. Fails with
+  the shared bad-let/bad-if ids on a malformed binding vector or branch arity."
+  [e head config temp form]
+  (let [{:keys [some? else?]} config
+        [_ bindings & body] form]
+    (when-not (and (vector? bindings) (= 2 (count bindings)))
+      (env/fail! e :rf.ui.compile/bad-let
+                 (str head " needs a single binding pair: (" head
+                      " [pattern init] " (if else? "then else?" "body …") ")")
+                 {:form form}))
+    (let [[pattern init] bindings
+          test  (if some? (list (core-sym e "not=") temp nil) temp)
+          inner (fn [& tail] (apply list 'let [pattern temp] tail))]
+      (if else?
+        (do
+          (when-not (<= 1 (count body) 2)
+            (env/fail! e :rf.ui.compile/bad-if
+                       (str head " takes a then and an optional else after the "
+                            "binding: (" head " [pattern init] then else?)")
+                       {:form form}))
+          (list 'let [temp init]
+                (list 'if test (inner (first body)) (second body))))
+        (list 'let [temp init]
+              (list 'if test (apply inner body) nil))))))
+
+(defn- fn-form? [f]
+  (and (seq? f) (contains? #{'fn 'fn* 'clojure.core/fn 'cljs.core/fn} (first f))))
+
+(defn- host-portable-argv?
+  "The raw `fn*` special form binds only DISTINCT simple (unqualified) symbols,
+  with an optional single trailing `& rest`. Applied ONLY to a raw `fn*`
+  initializer: its parameters are what the host compiler binds directly, so
+  destructuring, non-symbol/qualified parameters, and malformed `&` forms are
+  host-illegal (and a map argv otherwise reaches binding-plan as a raw
+  IllegalArgumentException). Macro `fn` / source `letfn` legally destructure —
+  their expansion owns that grammar — so they keep the looser argv shape.
+
+  Distinctness (`[x x]`, `[x & x]`, `[x y x]`) is the rf2-wnhbm seam. Both
+  hosts *compile* a duplicate parameter, but by different mechanisms — the JVM
+  shadows the earlier binding, ClojureScript gensym-renames the later one to
+  `x__$1` — and this analyzer's own lexical model cannot represent either: it
+  threads scope as a SET (`env/binding-syms`), so `[x x]` collapses to one
+  local and a reactive-escape check on the second `x` silently reads the
+  first's scope. A duplicate parameter is never intentional, so the honest
+  bounded rule is to reject it rather than analyze a form we cannot model."
+  [argv]
+  (and (vector? argv)
+       (let [[fixed tail] (split-with #(not= '& %) argv)]
+         (and (every? simple-symbol? fixed)
+              (case (count tail)
+                0 true                            ; no variadic marker
+                2 (simple-symbol? (second tail))  ; `& rest`: exactly one rest sym
+                false)                            ; bare `&`, or `& a b`
+              (let [bound (cond-> (vec fixed) (seq tail) (conj (second tail)))]
+                (= (count bound) (count (distinct bound))))))))
+
+(defn- host-arities-compatible?
+  "Bounded arity-overload check for a raw `fn*`: the host rejects two overloads
+  of the same fixed arity, more than one variadic overload, or a fixed overload
+  that reaches into the variadic overload's arity range. (This is the narrow
+  host-portability seam, NOT a general Clojure arity grammar.)
+
+  The fixed-vs-variadic boundary (rf2-wnhbm) is where the two hosts stop
+  agreeing, so it cannot be left to \"the host compiler\" — there are two of
+  them. Writing `v` for the variadic overload's REQUIRED count (its parameters
+  before `&`, so its emitted parameter count is `v + 1`) and `f` for a fixed
+  overload's arity:
+
+    f <= v      both hosts compile it, identically — legal.
+    f == v + 1  the JVM rejects (`Can't have fixed arity function with more
+                params than variadic function`); ClojureScript compiles it with
+                BOTH a :variadic-max-arity and an :overload-arity
+                (\"Can't have 2 overloads with same arity\") warning, emitting a
+                dispatch that silently drops the fixed overload.
+    f >  v + 1  the JVM rejects; ClojureScript warns :variadic-max-arity and
+                emits the same broken dispatch.
+
+  So every fixed arity must be strictly less than the variadic overload's
+  parameter count — equivalently `f <= v`. That single rule is exactly where
+  the JVM's hard error and ClojureScript's warnings both begin, which is what
+  makes the accept/reject verdict host-portable."
+  [argvs]
+  (let [variadic?   (fn [argv] (boolean (some #(= '& %) argv)))
+        required    (fn [argv] (count (take-while #(not= '& %) argv)))
+        variadics   (filter variadic? argvs)
+        fixed       (map required (remove variadic? argvs))]
+    (and (<= (count variadics) 1)
+         (= (count fixed) (count (set fixed)))
+         (or (empty? variadics)
+             (let [v (required (first variadics))]
+               (every? #(<= % v) fixed))))))
+
+(defn- fn-init-shape?
+  "True when `init` is a structurally well-formed fn/fn* form — the only legal
+  shape for a HOST letfn* binding initializer. Bounded grammar check, not a full
+  semantic one: it guards `rw-fn` against a malformed body (a non-vector arity
+  otherwise throws a raw host `Don't know how to create ISeq` exception) and
+  rejects a non-fn initializer such as a bare `42` up front. Accepted shapes are
+  `(fn <name>? [argv] body*)` (single arity) and `(fn <name>? ([argv] body*)+)`
+  (one or more arity lists); every argv MUST be a vector.
+
+  A RAW `fn*` (the host special form — not the `fn` macro) additionally binds
+  only host-portable parameters (`host-portable-argv?`) with host-compatible
+  arities (`host-arities-compatible?`), and its optional internal name must be
+  a SIMPLE symbol: the host compiler requires it, and without these a
+  destructuring/qualified/malformed argv is either silently accepted here only
+  to crash the later host compiler, or reaches binding-plan as a raw
+  IllegalArgumentException. A qualified internal name is the sharpest of these
+  (rf2-wnhbm): the JVM accepts `(fn* foo/bar ([x] x))`, while ClojureScript
+  compiles it to `function cljs$user$foo.bar(x){…}` — not valid JavaScript, a
+  parse-time SyntaxError far downstream of this analyzer. Macro `fn` / source
+  `letfn` legally destructure, so their argv shape is left to their own
+  expansion."
+  [init]
+  (and (fn-form? init)
+       (let [raw?    (= 'fn* (first init))
+             fname   (when (symbol? (second init)) (second init))
+             tail    (cond-> (rest init) fname rest)
+             arities (cond
+                       (vector? (first tail)) (list tail)   ; single arity
+                       (and (seq tail)
+                            (every? #(and (seq? %) (vector? (first %))) tail))
+                       tail                                  ; arity lists
+                       :else nil)]
+         (boolean
+          (and arities
+               (or (not raw?)
+                   (let [argvs (map first arities)]
+                     (and (or (nil? fname) (simple-symbol? fname))
+                          (every? host-portable-argv? argvs)
+                          (host-arities-compatible? argvs)))))))))
+
+(defn- raw-form? [e f]  (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) ui-raw-fqns)))
+(defn- html-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) ui-html-fqns)))
+(defn- raw-fn-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) ui-raw-fn-fqns)))
+(defn- spread-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) ui-spread-fqns)))
+(defn- spread-safe-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) ui-spread-safe-fqns)))
+(defn- ui-event-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) ui-event-fqns)))
+(defn- ui-handler-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) ui-handler-fqns)))
+(defn- render-fn-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) ui-render-fn-fqns)))
+(defn- slot-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) ui-slot-fqns)))
+(defn- error-boundary-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) error-boundary-fqns)))
+(defn- client-only-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) client-only-fqns)))
+(defn- presence-form? [e f] (and (seq? f) (symbol? (first f)) (env/resolves-to? e (first f) presence-fqns)))
+
+;; ---------------------------------------------------------------------------
+;; Expression rewriting — lexical site indexing + loop finiteness
+;; ---------------------------------------------------------------------------
+
+(def ^:private runtime-sub-fqn 're-frame.freehand.reactive/sub-read)
+(def ^:private runtime-frame-ops-fqn 're-frame.freehand.frames/frame-ops)
+(def ^:private runtime-local-fqn 're-frame.freehand.hooks/local-state)
+(def ^:private runtime-effect-value-fqn 're-frame.freehand.hooks/effect-value)
+(def ^:private runtime-effect-connect-fqn 're-frame.freehand.hooks/effect-connect)
+(def ^:private runtime-dispatch-fn-fqn 're-frame.freehand.hooks/dispatch-fn)
+(def ^:private deferred-scope ::deferred-scope)
+(def ^:private transparent-macro-fqns
+  "Closed macro set whose arguments are host-independent expression slots,
+  with no user-authored binders. Preserve their spelling while recursively
+  lowering explicit sub/frame calls."
+  (into #{}
+        (mapcat (fn [s] [(symbol "clojure.core" (name s))
+                         (symbol "cljs.core" (name s))]))
+        '[or and when when-not cond -> ->> some-> some->> cond-> cond->>]))
+
+(defn- deferred-expr-root?
+  "Expression roots whose value is evaluated by a later host callback, not by
+  the view's render capture. `sub`/`frame` below these roots would be
+  phase-divergent between the JVM data host and React."
+  [expr-root]
+  (or (and (= :handler (first expr-root))
+           (= :event-arg (nth expr-root 2 nil)))
+      (some #{:raw-fn} expr-root)))
+
+(defn runtime-sub-form?
+  "True for the compiler's serialized internal lowering of a lexical sub.
+  Public only within the compiler family (fingerprint/emitter tests use it)."
+  [x]
+  (and (seq? x) (= runtime-sub-fqn (first x)) (= 3 (count x))))
+
+(defn template-fingerprint-projection
+  "Remove compiler-owned lexical site ids from an analyzed AST while retaining
+  the semantic sub query. This makes source-anchor/path movement irrelevant to
+  template/build identity without making the query invisible."
+  [ast]
+  (letfn [(project [x]
+            (cond
+              (and (seq? x) (= 'quote (first x))) x
+
+              (runtime-sub-form? x)
+              (with-meta (list 're-frame.freehand/sub (project (nth x 2))) (meta x))
+
+              (map? x)
+              (with-meta (into (empty x) (map (fn [[k v]] [(project k) (project v)])) x)
+                         (meta x))
+
+              (vector? x) (with-meta (mapv project x) (meta x))
+              (set? x)    (with-meta (into (empty x) (map project) x) (meta x))
+              (seq? x)    (with-meta (apply list (map project x)) (meta x))
+              :else x))]
+    (project ast)))
+
+(defn- relative-source-anchor
+  [e form]
+  (let [m    (meta form)
+        base (:source e)
+        line (:line m)
+        col  (:column m)]
+    (if (and (integer? line) (integer? (:line base)))
+      ;; Reader end coordinates are not host-common (and have changed across
+      ;; reader versions). Start coordinates are the portable lexical anchor.
+      [:relative (- line (:line base)) (or col 0)]
+      ;; No reader anchor means no attempt to history-match sites. The whole
+      ;; template anchor changes all such ids on an edit: safe reacquisition,
+      ;; never ordinal transfer to a different lexical site.
+      [:template (or (:template-anchor e)
+                     (fingerprint/digest "sta1-" form))])))
+
+(defn- lexical-site-id
+  [e kind form expr-path]
+  (fingerprint/digest
+   "sid1-"
+   [1 (:self-id e) kind (relative-source-anchor e form)
+    (:path e) (vec expr-path)]))
+
+(declare rewrite-expr)
+
+(defn- map-path-token [x]
+  (fingerprint/digest "ep1-" x))
+
+(declare reactive-macro-reference-kind)
+
+(defn- reactive-call-kind
+  "Return :sub/:frame when `x` contains an unshadowed resolved
+  reactive CALL. Quoted data is never executable. This scanner is
+  deliberately about calls, not bare symbols, so a binding pattern may
+  still introduce a local named `sub` or `frame`."
+  [e x locals]
+  (let [e* (update e :locals into locals)]
+    (cond
+      (and (seq? x) (= 'quote (first x))) nil
+      (seq? x)
+      (or (let [h (first x)]
+            (when (and (symbol? h) (not (contains? locals h)))
+              (let [info (env/resolve-sym e* h)]
+                (cond
+                  (contains? sub-fqns (:fqn info)) :sub
+                  (contains? frame-fqns (:fqn info)) :frame
+                  ;; Binding/default forms never pass through rewriting later.
+                  ;; An unaudited macro can inject a reactive call even when its
+                  ;; invocation carries no visible sub token, so reject it.
+                  (and (true? (-> info :meta :macro))
+                       (not (contains? transparent-macro-fqns (:fqn info))))
+                  :opaque-macro
+                  (true? (-> info :meta :macro))
+                  (reactive-macro-reference-kind e (rest x) locals)))))
+          (some #(reactive-call-kind e % locals) (rest x)))
+      (map? x) (or (some #(reactive-call-kind e % locals) (keys x))
+                   (some #(reactive-call-kind e % locals) (vals x)))
+      (coll? x) (some #(reactive-call-kind e % locals) x)
+      :else nil)))
+
+(defn- reactive-macro-reference-kind
+  "Like `reactive-call-kind`, plus unquoted bare references. Opaque macros may
+  turn a bare `sub` argument into a call (`->` is the canonical example), so
+  only macro expansion could prove such a reference harmless."
+  [e x locals]
+  (let [e* (update e :locals into locals)]
+    (cond
+      (and (seq? x) (= 'quote (first x))) nil
+      (and (symbol? x) (not (contains? locals x)))
+      (cond
+        (env/resolves-to? e* x sub-fqns) :sub
+        (env/resolves-to? e* x frame-fqns) :frame)
+      (map? x) (or (some #(reactive-macro-reference-kind e % locals) (keys x))
+                   (some #(reactive-macro-reference-kind e % locals) (vals x)))
+      (coll? x) (some #(reactive-macro-reference-kind e % locals) x)
+      :else nil)))
+
+(defn- bare-reactive-reference-kind
+  "Return :sub/:frame for an unquoted BARE reactive var reference. A
+  direct `(sub ...)`/`(frame)` head is not bare—the rewriter
+  owns it—but a threading step such as `(-> query sub)` would become an
+  unindexed call only after macro expansion and must fail loudly."
+  [e x locals]
+  (let [e* (update e :locals into locals)]
+    (cond
+      (and (seq? x) (= 'quote (first x))) nil
+      (and (symbol? x) (not (contains? locals x)))
+      (cond
+        (env/resolves-to? e* x sub-fqns) :sub
+        (env/resolves-to? e* x frame-fqns) :frame)
+      (seq? x)
+      (let [h (first x)
+            direct? (and (symbol? h) (not (contains? locals h))
+                         (or (env/resolves-to? e* h sub-fqns)
+                             (env/resolves-to? e* h frame-fqns)))]
+        (some #(bare-reactive-reference-kind e % locals)
+              (if direct? (rest x) x)))
+      (map? x) (or (some #(bare-reactive-reference-kind e % locals) (keys x))
+                   (some #(bare-reactive-reference-kind e % locals) (vals x)))
+      (coll? x) (some #(bare-reactive-reference-kind e % locals) x)
+      :else nil)))
+
+(defn- reactive-direct-form
+  "The kind-correct compiler-owned direct form a reactive authoring verb must
+  take in evaluated code — the ONLY shape in which the public var is legal, and
+  what every escape diagnostic must recommend. `sub` reads a query, `frame`
+  takes no argument. Kept as one function so no diagnostic can drift into
+  recommending an invalid form."
+  [kind]
+  (case kind
+    :sub   "(sub query)"
+    :frame "(frame)"))
+
+(defn- reactive-authoring-var-kind
+  "Return :sub/:frame when `sym` is an unquoted, unshadowed reference to
+  a public reactive authoring var. Such a var is sound ONLY as a compiler-owned
+  DIRECT CALL HEAD — the rewriter consumes those heads (and lowers them to an
+  indexed runtime site) before this leaf check runs — so a bare reference that
+  reaches any other, value-flow, position has escaped the manifest. `env` must
+  already carry the ambient lexical locals so a local shadow resolves to nil."
+  [env sym]
+  (let [{:keys [fqn]} (env/resolve-sym env sym)]
+    (cond
+      (contains? sub-fqns fqn)   :sub
+      (contains? frame-fqns fqn) :frame)))
+
+(defn- check-portable-map-shape!
+  "Reject the nonportable associative-destructuring shapes the host tolerates
+  but that bind ambiguously across analysis and emission (or across CLJ/CLJS):
+  a keyword or namespace-qualified EXPLICIT local, and a composite (non-simple-
+  symbol) `:or` key. The host strips the namespace off a qualified local and
+  binds a keyword local name-only, while the analyzer's scope walk keeps the
+  written form — a divergence that can mis-lower a reactive read. A composite
+  `:or` key never matches a bound local, so its default is silently dead. We
+  close the portable grammar to simple-symbol (and nested) locals with the
+  shared typed unsupported-form error rather than reproducing those shapes."
+  [e pattern]
+  (doseq [[k _] pattern]
+    (cond
+      (or (= k :as) (= k :or) (bp/key-group-kw? k)) nil
+
+      (keyword? k)
+      (env/fail! e :rf.ui.compile/unsupported-form
+                 (str "keyword destructuring local " k " is not portable — an "
+                      "explicit binding local must be a simple symbol (or a "
+                      "nested destructuring pattern). Bind {a-symbol " k "}")
+                 {:form pattern :key k})
+
+      (and (symbol? k) (namespace k))
+      (env/fail! e :rf.ui.compile/unsupported-form
+                 (str "namespace-qualified destructuring local " k " is not "
+                      "portable — the host binds it name-only while analysis "
+                      "keeps the namespace, so a reactive read can mis-lower. "
+                      "Use the simple symbol " (symbol (name k)))
+                 {:form pattern :key k})))
+  (doseq [k (keys (:or pattern))]
+    (when-not (and (symbol? k) (nil? (namespace k)))
+      (env/fail! e :rf.ui.compile/unsupported-form
+                 (str ":or default key " (pr-str k) " is not a simple symbol — "
+                      "the host only defaults simple-symbol locals, so this "
+                      "default is dead. Default a bound symbol")
+                 {:form pattern :or-key k}))))
+
+(defn- reject-binding-escape!
+  "Reject a reactive authoring escape reaching ONE evaluated destructuring
+  expression `expr`, judged against `scope` — the locals live at this
+  expression's host evaluation point (ambient lexical locals PLUS the
+  same-pattern bindings established before it). Both the executable-call scan
+  and the bare-authoring-var scan use this one point-in-time scope, so an
+  earlier-bound local shadows the authoring var while a later-bound or self
+  binding does not. `slot` names the slot for the diagnostic."
+  [e scope slot pattern expr]
+  (when-let [kind (reactive-call-kind e expr scope)]
+    (env/fail! e :rf.ui.compile/unsupported-form
+               (if (= :opaque-macro kind)
+                 (str "an unaudited macro cannot appear in a binding pattern "
+                      "or " slot " — macro expansion could inject a reactive "
+                      "call after lexical site analysis. Compute it in the view "
+                      "body instead")
+                 (str "(" (name kind) " ...) cannot appear in a binding pattern "
+                      "or " slot " — that position cannot own a lexical render "
+                      "site. Hoist the read into the view body and bind/"
+                      "destructure its value there"))
+               {:form pattern :reactive-kind kind}))
+  (when-let [kind (bare-reactive-reference-kind e expr scope)]
+    (env/fail! e :rf.ui.compile/unsupported-form
+               (str "bare " (name kind) " reference as a " slot
+                    " — re-frame.freehand/" (name kind) " is a reactive authoring "
+                    "var, sound ONLY as a compiler-owned direct call head "
+                    (reactive-direct-form kind)
+                    ". A " slot " is never rewritten, so the bare var flows as "
+                    "a VALUE where the compiler cannot own a lexical render "
+                    "site — the manifest under-declares and the optimized build "
+                    "elides the read. Hoist the read into the view body and "
+                    "destructure its committed value there")
+               {:form pattern :reactive-kind kind})))
+
+(defn- check-binding-scope!
+  "Thread the incremental local scope through binding `pattern` in host
+  evaluation order, rejecting a reactive authoring escape in every EVALUATED
+  binding expression against the scope live at THAT point. Returns `scope`
+  extended with every symbol `pattern` binds, so a caller can carry the roster
+  across sibling patterns. `scope` already carries the ambient locals."
+  [e scope pattern]
+  (cond
+    (symbol? pattern) (conj scope pattern)
+
+    (vector? pattern)
+    ;; Sequential destructuring `[p0 p1 … & prest :as asym]` carries no
+    ;; evaluated expression of its own; its element/rest/`:as` sub-patterns
+    ;; establish bindings left-to-right, so a later nested default sees an
+    ;; earlier sibling's local.
+    (loop [scope scope, xs (seq pattern)]
+      (if (nil? xs)
+        scope
+        (let [x (first xs)]
+          (cond
+            (= '& x)  (recur scope (next xs))
+            (= :as x) (recur (check-binding-scope! e scope (second xs)) (nnext xs))
+            :else     (recur (check-binding-scope! e scope x) (next xs))))))
+
+    (map? pattern)
+    ;; Associative destructuring. Close the portable grammar first, then thread
+    ;; scope in host `destructure` order. `:as` binds the whole map FIRST (host
+    ;; order), so it is in scope for every key default. Then the key bindings are
+    ;; established sequentially (`bp/assoc-binding-units` = the host `bes` order):
+    ;; each key's default AND each explicit lookup-key expression is evaluated
+    ;; against the scope BEFORE that key's own local is bound — the local is
+    ;; added only after, and never in an order the host would not use. Only an
+    ;; `:explicit?` unit's `:key` is a user-written expression that can hide a
+    ;; reactive-authoring escape; a group local's key is a produced literal.
+    (do
+      (check-portable-map-shape! e pattern)
+      (let [defaults (:or pattern)
+            scope    (cond-> scope (:as pattern) (conj (:as pattern)))]
+        (reduce
+         (fn [scope {:keys [local-pattern key explicit?]}]
+           (when explicit?
+             (reject-binding-escape! e scope "destructuring lookup-key expression"
+                                     pattern key))
+           (when (and (symbol? local-pattern) (contains? defaults local-pattern))
+             (reject-binding-escape! e scope "destructuring :or default"
+                                     pattern (get defaults local-pattern)))
+           (check-binding-scope! e scope local-pattern))
+         scope
+         (bp/assoc-binding-units pattern))))
+
+    :else scope))
+
+(defn reject-reactive-binding!
+  "Reject a reactive authoring escape reaching an EVALUATED destructuring
+  expression — an executable `(sub …)`/`(frame)` call OR a bare
+  reactive authoring var — anywhere in a binding pattern. Binding patterns are
+  consumed by the host compiler, not expression rewriting, so such a position
+  can never own a lexical render site: the manifest would under-declare and the
+  optimized build elide the read.
+
+  CLJ/CLJS destructuring binds SEQUENTIALLY, so scope is modelled in host
+  evaluation order (`check-binding-scope!`): each `:or` default and each
+  explicit map lookup-key expression is judged against the locals live at ITS
+  binding point — ambient lexical locals plus the same-pattern bindings
+  established BEFORE it. A bare var reaching a default from OUTSIDE those locals
+  (a later-bound or self shadow — `{:keys [f sub] :or {f sub}}`,
+  `{:keys [sub] :or {sub sub}}`) still resolves to the public authoring var and
+  escapes; a genuine EARLIER-bound local shadows it and is legal
+  (`{:keys [sub a] :or {a sub}}`, `{:keys [sub f] :or {f (sub :fallback)}}`).
+  The call scan and the bare-reference scan share this one point-in-time scope,
+  so neither over-shadows (whole-pattern) nor under-shadows (ambient-only)."
+  [e binding-form]
+  (check-binding-scope! e (:locals e) binding-form)
+  binding-form)
+
+(defn header-binding-order
+  "The explicit/group local-patterns of a defview header map `binding-form`, in
+  host `destructure` `bes` order (`:as` excluded — it binds first). One plan
+  (`bp/assoc-binding-units`), so a dependent `:or` default resolves to the same
+  symbol on both hosts and no public authoring var can survive through a
+  reordered default. Returns nil for a non-map header (`[sym]` ≡ `{:as sym}`)."
+  [binding-form]
+  (when (map? binding-form)
+    (bp/binding-order binding-form)))
+
+(defn- impure-slot-fail!
+  "The didactic rejection for a reactive read inside a `v/render-fn` slot
+  body — a slot body is a pure render fragment; the reactive/dispatch surface
+  belongs to the owning view or a mounted defview."
+  [e verb form]
+  (env/fail! e :rf.ui.compile/impure-slot-body
+             (str "(" verb " …) inside a v/render-fn slot body — a slot body is "
+                  "a PURE render fragment; sub / frame (and dispatch / "
+                  "hooks) are not permitted. Read the value in the OWNING view and "
+                  "pass its committed value into the slot's arguments; a stateful "
+                  "part MOUNTS a defview that owns its own state")
+             {:form form}))
+
+(defn rewrite-expr
+  "Rewrite an opaque expression, lowering resolved unshadowed `(sub q)` calls
+  to the serialized two-argument runtime shape and recording stable lexical
+  sub ids. The returned form MUST be threaded into the AST.
+
+  `expr-root` names the containing AST slot; recursive paths then distinguish
+  every nested expression without a fragile global/preorder ordinal. Binding
+  scopes follow evaluation order for fn/let/loop/letfn and all metadata and
+  collection kinds are preserved."
+  ([e form] (rewrite-expr e [:expr] form))
+  ([e expr-root form]
+   (letfn [(with-same-meta [old x]
+              (with-meta x (meta old)))
+           (rw-fn-arity [arity locals p]
+             (let [[argv & body] arity
+                   _ (reject-reactive-binding! (update e :locals into locals) argv)
+                   body-locals (-> locals
+                                   (into (env/binding-syms argv))
+                                   (conj deferred-scope))]
+               (with-same-meta
+                 arity
+                 (apply list argv
+                        (map-indexed #(rw %2 body-locals (conj p :body %1)) body)))))
+           (rw-fn [f locals p]
+             (let [head (first f)
+                   tail (rest f)
+                   named? (symbol? (first tail))
+                   fname (when named? (first tail))
+                   tail (if named? (rest tail) tail)
+                   locals* (cond-> locals fname (conj fname))
+                   rewritten
+                   (if (vector? (first tail))
+                     (let [[argv & body] tail
+                            _ (reject-reactive-binding! (update e :locals into locals*) argv)
+                            body-locals (-> locals*
+                                            (into (env/binding-syms argv))
+                                            (conj deferred-scope))]
+                       (concat [head] (when fname [fname]) [argv]
+                               (map-indexed #(rw %2 body-locals (conj p :body %1)) body)))
+                     (concat [head] (when fname [fname])
+                             (map-indexed #(rw-fn-arity %2 locals* (conj p :arity %1))
+                                          tail)))]
+               (with-same-meta f (apply list rewritten))))
+           (rw-let [f locals p]
+             (let [head (first f)
+                   bindings (second f)]
+               (if-not (vector? bindings)
+                 (with-same-meta f
+                   (apply list (map-indexed #(rw %2 locals (conj p %1)) f)))
+                 (let [[bindings* locals*]
+                       (loop [pairs (partition 2 bindings)
+                              i 0
+                              out []
+                              scope locals]
+                         (if-let [[pat init] (first pairs)]
+                           (do
+                             (reject-reactive-binding! (update e :locals into scope) pat)
+                             (recur (rest pairs) (inc i)
+                                  (conj out pat (rw init scope (conj p :binding i)))
+                                  (into scope (env/binding-syms pat))))
+                           [(with-same-meta bindings (vec out)) scope]))]
+                   (with-same-meta
+                     f
+                     (apply list head bindings*
+                             (map-indexed #(rw %2 (cond-> locals*
+                                                   (contains? #{'loop 'loop*} head)
+                                                   (conj deferred-scope))
+                                               (conj p :body %1))
+                                          (drop 2 f))))))))
+           (rw-letfn [f locals p]
+             (let [specs (second f)]
+               (if-not (vector? specs)
+                 (with-same-meta f
+                   (apply list (map-indexed #(rw %2 locals (conj p %1)) f)))
+                 (let [names (into #{} (keep #(when (seq? %) (first %))) specs)
+                       scope (into locals names)
+                       specs* (with-same-meta
+                                specs
+                                (mapv (fn [i spec]
+                                        (if (and (seq? spec) (symbol? (first spec)))
+                                          (let [[name & arities] spec
+                                                fake (with-meta (apply list 'fn name arities)
+                                                                (meta spec))
+                                                [_ _ & rewritten] (rw-fn fake scope
+                                                                          (conj p :spec i))]
+                                            (with-same-meta spec (apply list name rewritten)))
+                                          (rw spec scope (conj p :spec i))))
+                                      (range) specs))]
+                   (with-same-meta
+                     f
+                     (apply list (first f) specs*
+                            (map-indexed #(rw %2 scope (conj p :body %1))
+                                         (drop 2 f))))))))
+           (rw-letfn* [f locals p]
+             ;; The HOST special form `letfn*` (what the `letfn` macro expands
+             ;; to) has FLAT name/initializer bindings `[n0 init0 n1 init1 …]`,
+             ;; NOT source `letfn`'s paired fnspec-LIST grammar. Its lexical
+             ;; grammar: every name is in scope for every initializer AND the
+             ;; body (mutual recursion), and each initializer is a `fn*` whose
+             ;; body is deferred — so routing an initializer through `rw`
+             ;; (→ `rw-fn`) makes a render-time `sub`/`frame` inside it illegal,
+             ;; while a visible `sub` in the OUTER body still lowers to a site.
+             (let [bindings (second f)]
+               (if-not (and (vector? bindings) (even? (count bindings)))
+                 (env/fail! e :rf.ui.compile/bad-let
+                            (str "letfn* needs a vector of an even number of flat "
+                                 "name/initializer bindings [name init …]")
+                            {:form f})
+                 (let [pairs (partition 2 bindings)
+                       names (map first pairs)]
+                   ;; Bound the flat grammar BEFORE blindly rewriting each
+                   ;; initializer: a name must be a simple (unqualified) symbol
+                   ;; — the host only defaults simple-symbol locals — and each
+                   ;; initializer must be a well-formed fn/fn* form, else a bare
+                   ;; value (e.g. `42`) slips through to the host compiler and a
+                   ;; malformed arity throws a raw ISeq exception inside rw-fn.
+                   (doseq [[nm init] pairs]
+                     (when-not (simple-symbol? nm)
+                       (env/fail! e :rf.ui.compile/bad-let
+                                  (str "letfn* binding names must be simple "
+                                       "(unqualified) symbols; got " (pr-str nm))
+                                  {:form f}))
+                     (when-not (fn-init-shape? init)
+                       (env/fail! e :rf.ui.compile/bad-let
+                                  (str "each letfn* initializer must be a fn/fn* "
+                                       "form with a [argv] body or ([argv] body …) "
+                                       "arity lists; got " (pr-str init))
+                                  {:form f})))
+                   (let [scope     (into locals names)
+                         bindings* (with-same-meta
+                                     bindings
+                                     (into []
+                                           (comp (map-indexed
+                                                  (fn [i [nm init]]
+                                                    [nm (rw init scope (conj p :binding i))]))
+                                                 cat)
+                                           pairs))]
+                     (with-same-meta
+                       f
+                       (apply list (first f) bindings*
+                              (map-indexed #(rw %2 scope (conj p :body %1))
+                                           (drop 2 f)))))))))
+           (rw-try [f locals p]
+             ;; `catch` introduces a local, so it cannot go through generic
+             ;; traversal. `finally` does not. Preserve the marker/type slots
+             ;; verbatim and rewrite only evaluated bodies.
+             (with-same-meta
+               f
+               (apply list
+                      (first f)
+                      (map-indexed
+                       (fn [i clause]
+                         (cond
+                           (and (seq? clause) (= 'catch (first clause))
+                                (symbol? (nth clause 2 nil)))
+                           (let [[marker type binding & body] clause]
+                             (with-same-meta
+                               clause
+                               (apply list marker type binding
+                                      (map-indexed
+                                       #(rw %2 (conj locals binding)
+                                            (conj p :catch i :body %1))
+                                       body))))
+
+                           (and (seq? clause) (= 'finally (first clause)))
+                           (with-same-meta
+                             clause
+                             (apply list 'finally
+                                    (map-indexed
+                                     #(rw %2 locals (conj p :finally :body %1))
+                                     (rest clause))))
+
+                           :else (rw clause locals (conj p :body i))))
+                       (rest f)))))
+           (rw-map [m locals p]
+             (with-same-meta
+               m
+               (reduce-kv (fn [out k v]
+                            (let [t (map-path-token k)]
+                              (assoc out
+                                     (rw k locals (conj p :map-key t))
+                                     (rw v locals (conj p :map-value t)))))
+                          (empty m)
+                          m)))
+           (macro-info [e* head locals]
+             (when (and (symbol? head) (not (contains? locals head)))
+               (let [info (env/resolve-sym e* head)]
+                 (when (true? (-> info :meta :macro)) info))))
+           (rw [f locals p]
+             (cond
+               (and (seq? f) (= 'quote (first f))) f
+
+               (seq? f)
+               (let [head (first f)
+                     e*   (update e :locals into locals)]
+                 (cond
+                    (and (symbol? head) (not (contains? locals head))
+                         (env/resolves-to? e* head ui-render-fn-fqns))
+                    (env/fail! e :rf.ui.compile/render-fn-misplaced
+                               (str "(v/render-fn …) is a render-slot callback "
+                                    "value — legal ONLY as a component call-site "
+                                    "prop value or a v/slot argument, never as a "
+                                    "plain expression. The library invokes it "
+                                    "through v/slot")
+                               {:form f})
+
+                    (and (symbol? head) (not (contains? locals head))
+                         (env/resolves-to? e* head ui-slot-fqns))
+                    (env/fail! e :rf.ui.compile/bad-slot
+                               (str "(v/slot render-fn-value arg…) renders content "
+                                    "— it is legal only in a child position, not as "
+                                    "a plain expression. Put it where a child goes")
+                               {:form f})
+
+                    (and (symbol? head) (not (contains? locals head))
+                         (env/resolves-to? e* head sub-fqns))
+                    (do
+                      (when-not (= 2 (count f))
+                        (env/fail! e :rf.ui.compile/unsupported-form
+                                   "(sub query) takes exactly one query argument"
+                                   {:form f}))
+                      (when (or (nil? (:self-id e))
+                                (:in-loop? e)
+                                (contains? locals deferred-scope))
+                        (if (:in-render-fn? e)
+                          (impure-slot-fail! e "sub" f)
+                          (env/fail! e :rf.ui.compile/sub-in-loop
+                                     (str "(sub ...) must be a finite render-time site in a "
+                                          "defview — it cannot run in a loop, deferred "
+                                          "callback, raw-fn/ref body, or root expression. "
+                                          "Hoist the read into the view body and let the "
+                                          "callback capture its committed value; for rows, "
+                                          "extract a keyed child view")
+                                     {:form f})))
+                     (let [sid   (lexical-site-id e :sub f p)
+                           query (rw (second f) locals (conj p :query))]
+                       (env/add-site! e :subs {:sid sid :query (second f)
+                                               :path (:path e) :expr-path (vec p)})
+                       (with-same-meta f (list runtime-sub-fqn sid query))))
+
+                    (and (symbol? head) (not (contains? locals head))
+                         (env/resolves-to? e* head frame-fqns))
+                    (do
+                      (when-not (= 1 (count f))
+                        (env/fail! e :rf.ui.compile/unsupported-form
+                                   (str "(frame) takes no arguments — it returns the "
+                                        "operation bundle locked to the committed frame; "
+                                        "to target a different frame, scope the subtree "
+                                        "with [frame-provider {:frame f} ...]")
+                                   {:form f}))
+                      (when (or (nil? (:self-id e))
+                                (:in-loop? e)
+                                (contains? locals deferred-scope))
+                        (if (:in-render-fn? e)
+                          (impure-slot-fail! e "frame" f)
+                          (env/fail! e :rf.ui.compile/frame-in-loop
+                                     (str "(frame) must be a finite render-time site in a "
+                                          "defview — it cannot run in a loop, deferred "
+                                          "callback, raw-fn/ref body, or root expression. "
+                                          "Hoist the read into the view body and let the "
+                                          "callback capture its committed ops bundle")
+                                     {:form f})))
+                      (let [sid (lexical-site-id e :frame f p)]
+                        (env/add-site! e :frame-ops {:sid sid
+                                                     :path (:path e)
+                                                     :expr-path (vec p)})
+                        (with-same-meta f (list runtime-frame-ops-fqn))))
+
+                    ;; (local init) — view-local ephemera, a React useState hook.
+                    ;; Legal ONLY as a binding value in a defview's UNCONDITIONAL
+                    ;; top region (React hooks run once per render in fixed order):
+                    ;; not in a loop / branch / deferred callback / render-fn slot.
+                    (and (symbol? head) (not (contains? locals head))
+                         (env/resolves-to? e* head local-fqns))
+                    (do
+                      (when-not (= 2 (count f))
+                        (env/fail! e :rf.ui.compile/unsupported-form
+                                   "(local init) takes exactly one initial-value argument"
+                                   {:form f}))
+                      (when (or (nil? (:self-id e))
+                                (:in-loop? e)
+                                (contains? locals deferred-scope)
+                                (not (:hooks-region? e)))
+                        (if (:in-render-fn? e)
+                          (impure-slot-fail! e "local" f)
+                          (env/fail! e :rf.ui.compile/hook-misplaced
+                                     (str "(local init) is a host hook — legal ONLY as a "
+                                          "binding value in a defview's UNCONDITIONAL top "
+                                          "region: (let [[value set! update!] (local init)] "
+                                          "…). It cannot run in a loop, branch, deferred "
+                                          "callback, render-fn slot, or root expression "
+                                          "(host hooks run once per render in fixed order)")
+                                     {:form f})))
+                      (let [sid (lexical-site-id e :local f p)]
+                        (env/next-hook-ordinal! e) ; a local advances the shared body-hook ordinal
+                        (env/add-site! e :locals {:sid sid :path (:path e)
+                                                  :expr-path (vec p)})
+                        (with-same-meta
+                          f
+                          (list runtime-local-fqn
+                                (rw (second f) locals (conj p 1))))))
+
+                    ;; Host hooks — the substrate `v/ref` and the re-frame.freehand.react
+                    ;; interop hooks (use-effect / use-layout-effect /
+                    ;; use-effect-event / use-context / use-id) — value-position
+                    ;; host hooks obeying the SAME position law as `local`: legal
+                    ;; only where they evaluate unconditionally, once per render
+                    ;; (the straight-line top region — an outer let binding).
+                    ;; Lowered to hooks/*.
+                    (and (symbol? head) (not (contains? locals head))
+                         (react-hook-spec-for e* head))
+                    (let [{:keys [kind runtime min-args max-args authored deps-arg]}
+                          (react-hook-spec-for e* head)
+                          call-args (rest f)
+                          argc      (count call-args)]
+                      (when (or (< argc min-args) (> argc max-args))
+                        (env/fail! e :rf.ui.compile/unsupported-form
+                                   (str "(" authored " …) takes "
+                                        (if (= min-args max-args)
+                                          (str min-args)
+                                          (str min-args "–" max-args))
+                                        " argument(s); got " argc)
+                                   {:form f}))
+                      (when (or (nil? (:self-id e))
+                                (:in-loop? e)
+                                (contains? locals deferred-scope)
+                                (not (:hooks-region? e)))
+                        (if (:in-render-fn? e)
+                          (impure-slot-fail! e authored f)
+                          (env/fail! e :rf.ui.compile/react-hook-misplaced
+                                     (str "(" authored " …) is a host hook — legal ONLY "
+                                          "where it evaluates unconditionally, once per "
+                                          "render: the straight-line top region of a "
+                                          "defview body (an outer let binding). It cannot "
+                                          "run in a loop, branch, deferred callback, "
+                                          "render-fn slot, or root expression — React's "
+                                          "hook order must be static. Hoist it to the top "
+                                          "of the view body, or extract a keyed child view")
+                                     {:form f})))
+                      (when (and deps-arg (> argc deps-arg)
+                                 (not (vector? (nth call-args deps-arg))))
+                        (env/fail! e :rf.ui.compile/react-hook-bad-deps
+                                   (str "(" authored " setup deps): deps must be a "
+                                        "literal vector (compared by rf= value equality); "
+                                        "got " (pr-str (nth call-args deps-arg)))
+                                   {:form f}))
+                      (let [sid   (lexical-site-id e kind f p)
+                            order (env/next-hook-ordinal! e)
+                            args* (map-indexed
+                                   (fn [i a]
+                                     (if (and deps-arg (= i deps-arg))
+                                       ;; deps vector: walk each slot in ambient
+                                       ;; scope (render-time values).
+                                       (with-same-meta a
+                                         (mapv (fn [j d] (rw d locals (conj p (inc i) j)))
+                                               (range) a))
+                                       ;; setup fn / ctx / initial: ordinary
+                                       ;; expressions (a setup fn is a deferred
+                                       ;; callback — rw-fn rejects reactive sites).
+                                       (rw a locals (conj p (inc i)))))
+                                   call-args)]
+                        (env/add-site! e :react {:sid sid :kind kind :order order
+                                                 :path (:path e) :expr-path (vec p)})
+                        (with-same-meta f (apply list runtime args*))))
+
+                    ;; (react/lazy …) is DEF-LEVEL only — recognised in a body
+                    ;; solely to reject it (per-render construction remount-loops).
+                    (and (symbol? head) (not (contains? locals head))
+                         (env/resolves-to? e* head react-lazy-fqns))
+                    (env/fail! e :rf.ui.compile/react-lazy-misplaced
+                               (str "(react/lazy …) is DEF-LEVEL only — bind it at the top "
+                                    "level: (def HeavyChart (react/lazy load-thunk "
+                                    "{:fallback tpl})), then use the component as a foreign "
+                                    "head [HeavyChart {…}]. Calling it inside a view body "
+                                    "mints a new component type per render and remount-loops")
+                               {:form f})
+
+                    ;; (v/dispatch-fn) — the stable committed-frame dispatcher.
+                    ;; A render-time site like (frame): finite, not in a loop or
+                    ;; deferred callback. Its VALUE (a stable fn) is captured in
+                    ;; the body and used from effect/foreign callbacks later.
+                    (and (symbol? head) (not (contains? locals head))
+                         (env/resolves-to? e* head dispatch-fn-fqns))
+                    (do
+                      (when-not (= 1 (count f))
+                        (env/fail! e :rf.ui.compile/unsupported-form
+                                   (str "(v/dispatch-fn) takes no arguments — it returns "
+                                        "the stable committed-frame dispatcher")
+                                   {:form f}))
+                      (when (or (nil? (:self-id e))
+                                (:in-loop? e)
+                                (contains? locals deferred-scope))
+                        (if (:in-render-fn? e)
+                          (impure-slot-fail! e "dispatch-fn" f)
+                          (env/fail! e :rf.ui.compile/frame-in-loop
+                                     (str "(v/dispatch-fn) must be a finite render-time "
+                                          "site in a defview — it cannot run in a loop, "
+                                          "deferred callback, raw-fn/ref body, or root "
+                                          "expression. Capture it in the view body and use "
+                                          "it from an (effect …) or foreign callback")
+                                     {:form f})))
+                      (let [sid (lexical-site-id e :dispatch-fn f p)]
+                        (env/add-site! e :dispatch-fns {:sid sid :path (:path e)
+                                                        :expr-path (vec p)})
+                        (with-same-meta f (list runtime-dispatch-fn-fqn))))
+
+                    ;; (effect …) is a leading STATEMENT, spliced before the
+                    ;; final template by analyze-hooks-body. Reaching rw means it
+                    ;; appeared as an ordinary expression (a binding value, an
+                    ;; argument, a branch) — misplaced.
+                    (and (symbol? head) (not (contains? locals head))
+                         (env/resolves-to? e* head effect-fqns))
+                    (if (:in-render-fn? e)
+                      (impure-slot-fail! e "effect" f)
+                      (env/fail! e :rf.ui.compile/hook-misplaced
+                                 (str "(effect …) is a host-effect STATEMENT — place it in a "
+                                      "defview's UNCONDITIONAL top region (or a top-region "
+                                      "let/do body) BEFORE the final template, never as an "
+                                      "expression, branch, or deferred callback")
+                                 {:form f}))
+
+                   (fn-form? f) (rw-fn f locals p)
+                   (contains? #{'let 'let* 'loop 'loop*} head) (rw-let f locals p)
+                   (= 'letfn head)  (rw-letfn f locals p)
+                   (= 'letfn* head) (rw-letfn* f locals p)
+                   (= 'try head) (rw-try f locals p)
+
+                   ;; if-let / when-let / if-some / when-some (rf2-u53yy.4):
+                   ;; admitted conditional binders, RESOLVER-confirmed against the
+                   ;; core binder vars (a same-spelled user macro is NOT admitted;
+                   ;; a local shadow yields no resolution and falls through to an
+                   ;; ordinary call). Desugar into the analyzer's own let + if —
+                   ;; the position-aware binder machinery it already controls — so
+                   ;; the init lowers a reactive site, the pattern's
+                   ;; reactive-escape is rejected, and the deferred / loop position
+                   ;; law all fall out of the existing rw-let / if recursion.
+                   (if-let-family-config e* head)
+                   (rw (desugar-if-let e head (if-let-family-config e* head)
+                                       (binder-temp p) f)
+                       locals p)
+
+                   (and (macro-info e* head locals)
+                        (contains? transparent-macro-fqns
+                                   (:fqn (macro-info e* head locals))))
+                   (if-let [kind (bare-reactive-reference-kind e (rest f) locals)]
+                     (env/fail! e :rf.ui.compile/unsupported-form
+                                (str "bare " (name kind) " reference below macro "
+                                     head " would become an unindexed reactive "
+                                     "call after expansion. Write the explicit "
+                                     (reactive-direct-form kind) " call")
+                                {:form f :macro head})
+                     (with-same-meta
+                       f
+                       (apply list head
+                              (map-indexed #(rw %2 locals (conj p (inc %1)))
+                                           (rest f)))))
+
+                   ;; A DEFERRED callback body (fn / v/event / raw-fn / event-arg)
+                   ;; hosts no render-time reactive site — sub/frame are
+                   ;; already illegal here (rejected above) — so there is nothing
+                   ;; for lexical site analysis to protect. Opaque host macros
+                   ;; (`..`, `doto`, `case` in expression position, …) are
+                   ;; ordinary callback code: pass the form through verbatim
+                   ;; (the admitted if-let family is handled above, never here).
+                   ;; A reactive call
+                   ;; smuggled inside one stays illegal in deferred scope and fails
+                   ;; loud at its resolution-only var when the callback runs.
+                   (and (macro-info e* head locals)
+                        (contains? locals deferred-scope))
+                   f
+
+                   (macro-info e* head locals)
+                   (env/fail! e :rf.ui.compile/unsupported-form
+                              (str "macro " head " is outside the compiler's "
+                                   "audited expression set and could inject, "
+                                   "duplicate, or defer a reactive call after "
+                                   "lexical site analysis. Rewrite it with "
+                                   "ordinary functions/control forms, or hoist "
+                                   "the computation around the view template")
+                              {:form f :macro head})
+
+                   :else
+                   ;; A generic invocation. Clojure evaluates the CALLEE before
+                   ;; its arguments, so the callee position is an ordinary
+                   ;; evaluated expression that can host a reactive site:
+                   ;;
+                   ;;   ((if (sub [:op]) inc dec) 1)   ; sub in a computed callee
+                   ;;
+                   ;; A simple symbol/keyword head is not itself an evaluated
+                   ;; expression (a plain fn/special-form name, a keyword lookup
+                   ;; op) and cannot contain a nested site — preserve it verbatim.
+                   ;; A COMPUTED callee (seq/vector/map/set) IS evaluated, so
+                   ;; rewrite it under a stable `:callee` token — BEFORE the
+                   ;; arguments, matching evaluation order — so a visible `(sub …)`
+                   ;; there lowers to its indexed site (or an immediately-invoked
+                   ;; fn / opaque-macro callee is rejected didactically by the
+                   ;; binder/deferred/macro rules `rw` already applies). It must
+                   ;; never survive as a public `v/sub` with an empty manifest.
+                   (with-same-meta
+                     f
+                     (apply list
+                            (if (or (symbol? head) (keyword? head))
+                              head
+                              (rw head locals (conj p :callee)))
+                            (map-indexed #(rw %2 locals (conj p (inc %1)))
+                                         (rest f))))))
+
+               (map? f) (rw-map f locals p)
+               (vector? f)
+               (with-same-meta f (mapv #(rw %2 locals (conj p %1)) (range) f))
+               (set? f)
+               (with-same-meta
+                 f
+                 (into (empty f)
+                       (map #(rw % locals (conj p :set (map-path-token %))))
+                       f))
+
+               ;; A BARE reactive authoring var reaching this leaf is a
+               ;; value-flow escape. Every SOUND reactive site is consumed above
+               ;; as a direct call head (`(sub q)`/`(frame)` → an
+               ;; indexed runtime site) or rejected pre-expansion under a macro.
+               ;; A bare `sub`/`frame` symbol here instead flows as a
+               ;; VALUE — into a computed callee `((if p sub inc) q)`, a let
+               ;; alias `(let [f sub] (f q))`, an argument, or a collection —
+               ;; where the analyzer cannot own a lexical render site, so the
+               ;; manifest under-declares and the optimized build elides the
+               ;; ViewCell, leaving the read to go stale / escape ownership.
+               ;; Reject it loudly. Lexical shadows resolve to nil here and pass
+               ;; through; quoted data was returned by the `quote` branch above.
+               :else
+               (if-let [kind (and (symbol? f) (not (contains? locals f))
+                                  (reactive-authoring-var-kind
+                                   (update e :locals into locals) f))]
+                 (env/fail! e :rf.ui.compile/unsupported-form
+                            (str "bare " (name kind) " reference — re-frame.freehand/"
+                                 (name kind) " is a reactive authoring var, sound "
+                                 "ONLY as a compiler-owned direct call head "
+                                 (reactive-direct-form kind)
+                                 ". Here it flows as a VALUE (into a computed "
+                                 "callee, let-binding, argument, or collection) "
+                                 "where the compiler cannot own a lexical render "
+                                 "site, so the manifest would under-declare and "
+                                 "the optimized build would elide the read. Keep "
+                                 "the read at a visible " (name kind)
+                                 " call site, or make the boundary its own defview")
+                            {:form f :reactive-kind kind})
+                 f)))]
+     ;; A `v/render-fn` slot body is a DEFERRED render: it executes inside a
+     ;; DIFFERENT view (the library seam that invokes the slot), so every
+     ;; expression it walks is deferred — sub/frame there would be
+     ;; phase-divergent and owner-wrong, exactly as in a fn/ui-event callback.
+     (rw form (cond-> #{}
+                (or (deferred-expr-root? expr-root) (:in-render-fn? e))
+                (conj deferred-scope))
+         (vec expr-root)))))
+
+;; Transitional internal name used throughout the analyzer. Unlike its former
+;; side-effect-only implementation it returns the rewritten expression.
+(def walk-expr rewrite-expr)
+
+;; ---------------------------------------------------------------------------
+;; Tag sugar — :div.cls#id / :div#id.cls (both orders)
+;; ---------------------------------------------------------------------------
+
+(defn parse-tag
+  "Parse a keyword element head into {:tag kw :id str|nil :classes [str]}.
+  `.class`/`#id` segments compose in any order; two `#id`s are an error."
+  [e head]
+  (let [s   (name head)
+        ns* (namespace head)]
+    ;; A head in the framework-reserved `:rf/*` scheme gets its OWN reject
+    ;; (rf2-01zvu — the client half of the rf2-j81hs SS4 ruling). re-frame.freehand
+    ;; classifies heads at COMPILE time, so it never painted the phantom the
+    ;; runtime substrates did — but the generic arm below advises "write
+    ;; :<name>", which for a reserved head tells the author to strip the
+    ;; namespace and paint exactly that phantom. Same closed-vocabulary id;
+    ;; the message is what distinguishes the arm.
+    (when (and ns* (or (= "rf" ns*) (str/starts-with? ns* "rf.")))
+      (env/fail! e :rf.ui.compile/bad-tag
+                 (str "element head " head " is in the framework-reserved "
+                      ":rf/* namespace, which is framework-owned (Conventions "
+                      "§Reserved namespaces) — it cannot be an author element. "
+                      "No :rf/* head has a client meaning "
+                      "(:rf/suspense-boundary is a streaming-SSR marker, "
+                      "server-only). Check the spelling, or use an unreserved "
+                      "keyword if you meant a custom element.")
+                 {:head head}))
+    (when ns*
+      (env/fail! e :rf.ui.compile/bad-tag
+                 (str "element head " head " must be an unqualified keyword — "
+                      "tag keywords carry no namespace (write :" s ")")
+                 {:head head}))
+    (when (or (str/blank? s) (str/starts-with? s ".") (str/starts-with? s "#"))
+      (env/fail! e :rf.ui.compile/bad-tag
+                 (str "element head " head " needs a tag name before sugar "
+                      "(e.g. :div.card, :div#main)")
+                 {:head head}))
+    (let [segs (re-seq #"[.#][^.#]+|^[^.#]+" s)
+          tag  (first segs)
+          sugar (rest segs)]
+      (reduce (fn [acc seg]
+                (cond
+                  (str/starts-with? seg "#")
+                  (if (:id acc)
+                    (env/fail! e :rf.ui.compile/duplicate-id-sugar
+                               (str "two #id segments on " head " — an element "
+                                    "has one id. Keep one #id segment (or move "
+                                    "the id to an :id prop)")
+                               {:head head})
+                    (assoc acc :id (subs seg 1)))
+                  (str/starts-with? seg ".")
+                  (update acc :classes conj (subs seg 1))
+                  :else acc))
+              {:tag (keyword tag) :id nil :classes []}
+              sugar))))
+
+;; ---------------------------------------------------------------------------
+;; Handlers (DOM/custom-element :on-* positions)
+;; ---------------------------------------------------------------------------
+
+(defn- check-loop-capture! [e kind form]
+  (when (:in-loop? e)
+    (let [captured (env/captured-loop-syms e form)]
+      (when (seq captured)
+        (env/fail! e :rf.ui.compile/loop-capturing-handler
+                   (str kind " captures loop binding" (when (next captured) "s")
+                        " " (str/join ", " (sort (map str captured)))
+                        " — per-row committed slots need per-row instances. "
+                        "Extract a keyed child view and pass "
+                        (first (sort (map str captured))) " as a prop")
+                   {:form form :captured captured})))))
+
+(defn- check-placeholders! [e vec-form]
+  ;; top-level placeholders splice; NESTED placeholder keywords are almost
+  ;; certainly a bug -> warning (they dispatch as ordinary keywords)
+  (doseq [[i x] (map-indexed vector vec-form)]
+    (when (and (coll? x) (seq (filter rules/placeholders (env/kws-in-form x))))
+      (env/warn! e {:id :rf.ui.compile/placeholder-not-top-level
+                    :msg (str "placeholder keyword nested inside event-vector "
+                              "argument " i " — placeholders splice only at "
+                              "top-level positions; nested ones dispatch as "
+                              "ordinary keywords")
+                    :form vec-form}))))
+
+(defn- event-source-coord
+  "Best available authored coordinate for an event site. Reader metadata on
+  the handler wins; macro-generated forms fall back to the defview anchor.
+  The template path remains a separate, deterministic occurrence coordinate."
+  [e form]
+  (let [m    (meta form)
+        base (:source e)]
+    (cond-> (select-keys base [:file :line :column])
+      (:line m)   (assoc :line (:line m))
+      (:column m) (assoc :column (:column m)))))
+
+(defn- event-site-identity
+  [e k form]
+  {:sid          (lexical-site-id e :event form [:handler k])
+   :site-index   (count (:events @(:sites e)))
+   :view-id      (:self-id e)
+   :source-coord (event-source-coord e form)
+   :path         (:path e)})
+
+(defn- add-event-site!
+  [e identity site]
+  (env/add-site! e :events (merge identity site))
+  identity)
+
+(defn- controlled-event-sync?
+  "The deliberately narrow controlled-input sync door.  It is a property of
+  the whole native element, not of the handler in isolation, so it is applied
+  after every prop has been classified.  The SITE proof is static: a literal
+  vector handler, or a `v/event` handler whose runtime result the invocation
+  classifies as an event vector.  Both ride the one synchronous drain; the
+  prefix/payload stay runtime values."
+  [controlled? handler]
+  (boolean
+   (and controlled?
+        (contains? #{"on-input" "on-change" "on-before-input"}
+                   (:name handler))
+        (contains? #{:vector :ui-event} (:classification handler)))))
+
+(defn- record-event-sync!
+  [e sid sync?]
+  (swap! (:sites e)
+         update :events
+         (fn [sites]
+           (mapv #(if (= sid (:sid %)) (assoc % :sync? sync?) %) sites))))
+
+(defn- analyze-event-vector! [e k form]
+  (when-not (keyword? (first form))
+    (env/fail! e :rf.ui.compile/bad-event-vector
+               (str k " event vector must start with a literal event-id "
+                    "keyword: [:domain/event args...]")
+               {:prop k :form form}))
+  (check-loop-capture! e (str "event vector " (pr-str form) " at " k) form)
+  (check-placeholders! e form)
+  (with-meta
+    (into [(first form)]
+          (map-indexed (fn [i x]
+                         (walk-expr e [:handler k :event-arg i] x)))
+          (rest form))
+    (meta form)))
+
+(defn analyze-handler
+  "Classify one :on-* entry. -> {:k kw :name str :classification
+  :vector|:options|:fn|:dynamic :form form :capture? bool
+  :hoistable? bool :serializable? bool}"
+  [e k form]
+  (when (:in-render-fn? e)
+    (env/fail! e :rf.ui.compile/impure-slot-body
+               (str "an event handler (" k ") inside a v/render-fn slot body — a "
+                    "slot body is a PURE render fragment; a committed handler "
+                    "DISPATCHES, which a slot body may not. Own the interactivity "
+                    "in the library view, or mount a defview that owns its handlers "
+                    "(a stateful part is a pure slot body mounting a defview)")
+               {:prop k :form form}))
+  (let [nm       (name k)
+        identity (event-site-identity e k form)]
+    (cond
+      (vector? form)
+      (let [form* (analyze-event-vector! e k form)]
+        (add-event-site! e identity
+                         {:prop k :handler form*
+                          :classification :vector :serializable? true})
+        (merge identity
+               {:k k :name nm :classification :vector :form form* :capture? false
+                :hoistable? (every? #(or (literal-scalar? %)
+                                         (contains? rules/placeholders %))
+                                    form*)
+                :serializable? true}))
+
+      (map? form)
+      (let [unknown (remove rules/handler-option-keys (keys form))]
+        (when (seq unknown)
+          (env/fail! e :rf.ui.compile/bad-handler-options
+                     (str "unknown handler option" (when (next unknown) "s") " "
+                          (str/join ", " (map pr-str unknown)) " at " k
+                          " — the closed listener vocabulary is "
+                          "{:event :prevent-default :stop-propagation :capture "
+                          ":passive :once}")
+                     {:prop k :form form}))
+        (when (and (:passive form) (:prevent-default form))
+          (env/fail! e :rf.ui.compile/contradictory-handler-options
+                     (str ":passive true with :prevent-default true at " k
+                          " — a passive listener promises the browser it will "
+                          "NEVER call preventDefault, so the combination is a "
+                          "contradiction (in any stage). Drop one of them")
+                     {:prop k :form form}))
+        (when-not (vector? (:event form))
+          (env/fail! e :rf.ui.compile/bad-handler-options
+                     (str "handler options map at " k " needs a literal "
+                          ":event vector — {:event [:domain/event args...] "
+                          ":prevent-default true ...}")
+                     {:prop k :form form}))
+        (let [event* (analyze-event-vector! e k (:event form))
+              form*  (assoc form :event event*)]
+          (add-event-site! e identity
+                           {:prop k :handler form*
+                            :classification :options :serializable? true})
+          (merge identity
+                 {:k k :name nm :classification :options :form form*
+                  :capture? (boolean (:capture form))
+                  :passive? (boolean (:passive form))
+                  :hoistable? (every? #(or (literal-scalar? %)
+                                           (contains? rules/placeholders %))
+                                      event*)
+                  :serializable? true})))
+
+      (ui-event-form? e form)
+      (let [[_ bindings & body] form]
+        (when-not (and (vector? bindings) (= 1 (count bindings)))
+          (env/fail! e :rf.ui.compile/bad-ui-event
+                     (str "(v/event [e] body…) at " k " binds exactly the "
+                          "native event and returns an event vector (or nil to "
+                          "dispatch nothing); got " (pr-str bindings)
+                          ". For imperative work with no dispatch, S3 adds "
+                          "v/handler")
+                     {:prop k :form form}))
+        ;; A v/event handler is a SITE, like a literal vector: capturing a loop
+        ;; binding needs per-row committed slots (its own bindings shadow, so they
+        ;; are excluded from the capture check). Its body is a deferred callback,
+        ;; so render-time sub/frame inside it are rejected by the fn walk.
+        (let [binders (set (env/binding-syms bindings))
+              form*   (walk-expr e [:handler k :ui-event]
+                                 (with-meta (apply list 'fn bindings body)
+                                   (meta form)))]
+          (check-loop-capture! (update e :loop-syms #(reduce disj % binders))
+                               (str "v/event handler at " k) form)
+          (add-event-site! e identity
+                           {:prop k :handler :opaque
+                            :classification :ui-event :serializable? false})
+          (merge identity
+                 {:k k :name nm :classification :ui-event :form form*
+                  :capture? false :hoistable? false :serializable? false})))
+
+      (ui-handler-form? e form)
+      ;; The explicit imperative committed callback (`v/handler`) at a DOM
+      ;; :on-* site — the visible spelling of the bare-fn shorthand. Its body
+      ;; runs after commit; the native event binds its parameter and its return
+      ;; is IGNORED (no dispatch of a returned vector — that is `v/event`).
+      (let [[_ bindings & body] form]
+        (when-not (and (vector? bindings) (not (some #{'&} bindings))
+                       (= 1 (count bindings)))
+          (env/fail! e :rf.ui.compile/bad-ui-handler
+                     (str "(v/handler [x] body…) at " k " binds exactly the "
+                          "invoker's argument (the native event at a DOM site) "
+                          "and does imperative work; got " (pr-str bindings)
+                          ". To DISPATCH a vector, use v/event")
+                     {:prop k :form form}))
+        (let [binders (set (env/binding-syms bindings))
+              form*   (walk-expr e [:handler k :ui-handler]
+                                 (with-meta (apply list 'fn bindings body)
+                                   (meta form)))]
+          (check-loop-capture! (update e :loop-syms #(reduce disj % binders))
+                               (str "v/handler at " k) form)
+          (add-event-site! e identity
+                           {:prop k :handler :opaque
+                            :classification :handler :serializable? false})
+          (merge identity
+                 {:k k :name nm :classification :handler :form form*
+                  :capture? false :hoistable? false :serializable? false})))
+
+      (fn-form? form)
+      (do (when (:in-loop? e)
+            (env/warn! e {:id :rf.ui.compile/bare-fn-in-loop
+                          :msg (str "bare fn handler at " k " inside a loop — "
+                                    "works, at per-row closure cost, and defeats "
+                                    "the data idiom; prefer an event vector or a "
+                                    "keyed child view")
+                          :form form}))
+          (let [form* (walk-expr e [:handler k :fn] form)]
+            (add-event-site! e identity
+                             {:prop k :handler :opaque
+                              :classification :fn :serializable? false})
+            (merge identity
+                   {:k k :name nm :classification :fn :form form* :capture? false
+                    :hoistable? false :serializable? false})))
+
+      :else
+      (let [form* (walk-expr e [:handler k :dynamic] form)]
+        (check-loop-capture! e (str "dynamic handler at " k) form)
+        (add-event-site! e identity
+                         {:prop k :handler :opaque
+                          :classification :dynamic :serializable? false})
+        (merge identity
+               {:k k :name nm :classification :dynamic :form form* :capture? false
+                :hoistable? false :serializable? false})))))
+
+;; ---------------------------------------------------------------------------
+;; :class / :style
+;; ---------------------------------------------------------------------------
+
+(defn analyze-class
+  "-> {:base-str str :flags [[name expr]...] :dyn form|nil :static? bool}
+  Sugar classes first (source order), then the explicit :class form;
+  flag-map entries in lexicographic name order; no de-duplication."
+  [e sugar form]
+  (let [base (vec sugar)]
+    (cond
+      (nil? form)
+      {:base-str (str/join " " base) :flags [] :dyn nil
+       :static? true}
+
+      (or (string? form) (keyword? form))
+      {:base-str (str/join " " (conj base (if (keyword? form) (name form) form)))
+       :flags [] :dyn nil :static? true}
+
+      (and (vector? form) (every? #(or (string? %) (keyword? %) (nil? %)) form))
+      {:base-str (str/join " " (into base (keep #(when % (if (keyword? %) (name %) %))) form))
+       :flags [] :dyn nil :static? true}
+
+      (map? form)
+      (do
+        (when-not (every? #(or (keyword? %) (string? %)) (keys form))
+          (env/fail! e :rf.ui.compile/bad-class
+                     ":class flag-map keys must be literal names (string/keyword)"
+                     {:form form}))
+        (let [{consts true exprs false}
+              (group-by (fn [[_ v]] (literal-scalar? v)) form)
+              const-names (into base
+                                (->> consts
+                                     (keep (fn [[k v]] (when v (if (keyword? k) (name k) k))))
+                                     sort))
+               flags (->> exprs
+                          (map (fn [[k v]]
+                                 [(if (keyword? k) (name k) k)
+                                  (walk-expr e [:class :flag k] v)]))
+                          (sort-by first)
+                          vec)]
+          {:base-str (str/join " " const-names) :flags flags :dyn nil
+           :static? (empty? flags)}))
+
+      (vector? form) ; mixed literal/expr vector — runtime join in vector order
+      (let [form* (with-meta
+                    (mapv (fn [i x]
+                            (if (literal-scalar? x)
+                              x
+                              (walk-expr e [:class :vector i] x)))
+                          (range) form)
+                    (meta form))]
+        {:base-str (str/join " " base) :flags [] :dyn form* :static? false})
+
+      :else
+      {:base-str (str/join " " base) :flags []
+       :dyn (walk-expr e [:class :dynamic] form) :static? false})))
+
+(defn analyze-style
+  "-> {:entries [{:css-name str :value form :literal? bool}] :static? bool}
+  or {:dyn form} for a wholly-dynamic :style expression."
+  [e form]
+  (cond
+    (map? form)
+    (let [entries (mapv (fn [[k v]]
+                          (when-not (keyword? k)
+                            (env/fail! e :rf.ui.compile/bad-style
+                                       (str ":style keys must be literal "
+                                            "keywords — for computed names, "
+                                            "pass the whole :style value as "
+                                            "one dynamic expression")
+                                       {:key k :form form}))
+                           {:css-name (name k)
+                            :value (if (literal-scalar? v)
+                                     v
+                                     (walk-expr e [:style k] v))
+                            :literal? (literal-scalar? v)})
+                         form)]
+      {:entries entries :static? (every? :literal? entries)})
+
+    :else
+    {:dyn (walk-expr e [:style :dynamic] form) :static? false}))
+
+;; ---------------------------------------------------------------------------
+;; Element props
+;; ---------------------------------------------------------------------------
+
+(defn- check-rejected-spelling! [e k]
+  (when-let [replacement (get rules/rejected-prop-spellings k)]
+    (env/fail! e :rf.ui.compile/rejected-prop-spelling
+               (str k " is not a prop — one spelling per name, ambiguities "
+                    "removed. Use " replacement)
+               {:prop k})))
+
+(defn- analyze-ref [e form context]
+  (when (:in-render-fn? e)
+    (env/fail! e :rf.ui.compile/impure-slot-body
+               (str ":ref inside a v/render-fn slot body — a slot body is a PURE "
+                    "render fragment; a ref is a commit-phase host hook, which a "
+                    "slot body may not own. Mount a defview that owns the ref")
+               {:form form}))
+  ;; :element, :view and :foreign share ONE ref contract: object refs preferred,
+  ;; a callback ref MUST be explicit `(v/raw-fn f)` (React invokes it during
+  ;; commit before the owning view's layout publication, so no committed-slot
+  ;; promise), a bare fn is rejected on every tier — Spec 004 and the guide say
+  ;; every callback ref is explicit, so the foreign seam is not an exception
+  ;; (rf2-u53yy.3). An internal view accepts a forwarded ref only by declaring
+  ;; `:ref` in its header; React 19 passes `:ref` as an ordinary prop, so the
+  ;; call site just carries it into the props object.
+  (case context
+    (:element :view)
+    (cond
+      (fn-form? form)
+      (env/fail! e :rf.ui.compile/bare-fn-ref
+                 (str "bare fn in :ref — the bare-fn shorthand applies only to "
+                      "native event properties, never refs. A callback ref must "
+                      "be explicit: (v/raw-fn f); object refs are preferred")
+                 {:form form})
+      (raw-fn-form? e form)
+      {:form (walk-expr e [:ref :raw-fn] (second form)) :raw-fn? true}
+      :else
+      {:form (walk-expr e [:ref context] form) :raw-fn? false})
+    :foreign
+    (if (fn-form? form)
+      (env/fail! e :rf.ui.compile/bare-fn-ref
+                 (str "bare fn in :ref at a foreign component — the bare-fn "
+                      "shorthand applies only to native event properties, never "
+                      "refs. A callback ref must be explicit: (v/raw-fn f); "
+                      "object refs are preferred")
+                 {:form form})
+      {:form (walk-expr e [:ref :foreign] form) :raw-fn? false})))
+
+(defn- analyze-literal-props
+  "Analyze a DOM/custom element's LITERAL props map `m` (`properties` is the
+  build's custom-element property set for the tag, nil for plain DOM). The
+  owned map of a `(v/spread-safe owned caller)` form rides this same path, so
+  a controlled owned site keeps the sync door. -> the props AST."
+  [e tag-info properties m]
+  (let [tag (:tag tag-info)]
+    (doseq [k (keys m)]
+      (when-not (keyword? k)
+        (env/fail! e :rf.ui.compile/non-keyword-prop
+                   (str "prop keys must be literal keywords; got " (pr-str k))
+                   {:key k}))
+      (check-rejected-spelling! e k))
+    (when (and (:id tag-info) (contains? m :id))
+      (env/fail! e :rf.ui.compile/id-sugar-conflict
+                 (str "#" (:id tag-info) " sugar AND an :id prop on " tag
+                      " — two id spellings on one element is an ambiguity, "
+                      "and this grammar removes ambiguities. Keep one")
+                 {:tag tag}))
+    (let [key-form   (get m :key)
+              m*         (dissoc m :key :class :style :ref)
+              ref-form   (get m :ref)
+              on?        (fn [k] (str/starts-with? (name k) "on-"))
+              handler-ks (filter on? (keys m*))
+              attr-ks    (remove on? (keys m*))
+              controlled? (or (contains? m :value) (contains? m :checked))
+              events0    (mapv #(analyze-handler e % (get m* %)) handler-ks)
+              events     (mapv (fn [handler]
+                                 (let [sync? (controlled-event-sync?
+                                              controlled? handler)]
+                                   (record-event-sync! e (:sid handler) sync?)
+                                   (when (and controlled?
+                                              (contains? #{"on-input" "on-change"
+                                                           "on-before-input"}
+                                                         (:name handler))
+                                              (not sync?))
+                                     (env/warn!
+                                      e
+                                      {:id :rf.ui.compile/controlled-input-async-handler
+                                       :msg (str (:k handler)
+                                                 " is paired with a controlled "
+                                                 ":value/:checked prop, but its "
+                                                 "handler is neither a literal event "
+                                                 "vector nor a (v/event …) handler, "
+                                                 "so it stays on the ordinary batched "
+                                                 "path. Open the controlled-input sync "
+                                                 "door with a literal event vector, or "
+                                                 "a (v/event …) handler when the "
+                                                 "native payload must flow")
+                                       :form (:form handler)}))
+                                   (assoc handler :sync? sync?)))
+                               events0)
+              attrs      (mapv (fn [k]
+                                  (let [v (get m* k)
+                                        n (name k)
+                                        property? (boolean (and properties (properties k)))
+                                        v* (if (literal-scalar? v)
+                                             v
+                                             (walk-expr e [:prop k] v))]
+                                   ;; literal collection VALUES only — seq forms
+                                   ;; are dynamic expressions (runtime-normalized)
+                                   (when (and (or (vector? v) (map? v) (set? v))
+                                              (not property?))
+                                     (env/fail! e :rf.ui.compile/collection-attr-value
+                                                (str "collection value for attribute " k
+                                                     " — collections are only meaningful "
+                                                     "for :class/:style (React renders "
+                                                     "\"[object Object]\" garbage). Pass "
+                                                     "a string, e.g. (str/join \" \" xs)")
+                                                {:prop k :value v}))
+                                   (when (fn-form? v)
+                                     (env/fail! e :rf.ui.compile/bare-fn-prop
+                                                (str "bare fn at non-event prop " k " — "
+                                                     "bare fns are legal only in known "
+                                                     "native event properties (:on-* on "
+                                                     "DOM/custom elements). Use v/raw-fn "
+                                                     "for identity-as-protocol callbacks")
+                                                {:prop k}))
+                                   {:k k
+                                    :react-name (if property?
+                                                  (rules/custom-element-property-name n)
+                                                  (rules/react-prop-name n))
+                                    :kind (if property? :property :attr)
+                                     :value v*
+                                     :literal? (literal-scalar? v)}))
+                               attr-ks)
+              sugar-id   (:id tag-info)
+              attrs      (into (if sugar-id
+                                 [{:k :id :react-name "id" :kind :attr
+                                   :value sugar-id :literal? true}]
+                                 [])
+                               attrs)
+              class-a    (when (or (seq (:classes tag-info)) (contains? m :class))
+                           (analyze-class e (:classes tag-info) (get m :class)))
+              style-a    (when (contains? m :style)
+                           (analyze-style e (get m :style)))
+               ref-a      (when (contains? m :ref) (analyze-ref e ref-form :element))
+               key-form*  (if (and (contains? m :key)
+                                    (not (literal-scalar? key-form)))
+                            (walk-expr e [:key] key-form)
+                            key-form)]
+          {:key   {:present? (contains? m :key) :expr key-form*
+                   :literal? (literal-scalar? key-form)}
+           :class class-a
+           :style style-a
+           :attrs attrs
+           :events events
+           :spread nil
+           :ref ref-a
+           :property-props (into #{} (comp (filter #(= :property (:kind %))) (map :k)) attrs)
+           :static? (and (not (contains? m :key))
+                         (nil? ref-a)
+                         (empty? events)
+                         (every? :literal? attrs)
+                         (or (nil? class-a) (:static? class-a))
+                         (or (nil? style-a) (:static? style-a)))})))
+
+(defn- analyze-spread-safe-props
+  "Analyze `(v/spread-safe owned caller)` in an element's props position (the
+  LITERAL safe-spread policy). `owned` is a LITERAL props map, analysed exactly
+  like an element's props (so a controlled owned site RETAINS the sync door);
+  `caller` is the forwarded runtime attr map, guarded by the every-build
+  owned-key deny law (`re-frame.freehand.rules/assert-safe-caller!` at runtime; a
+  LITERAL offender is caught here at compile time). -> the owned props AST plus
+  a `:safe-spread` slot carrying the walked caller form + owned-handler keys."
+  [e tag-info properties props-form]
+  (let [[_ owned caller & extra] props-form]
+    (when (or (not (map? owned)) (not (= 3 (count props-form))))
+      (env/fail! e :rf.ui.compile/bad-spread-safe
+                 (str "(v/spread-safe owned caller) — `owned` must be a LITERAL "
+                      "props map (the component's own props; the compiler proves "
+                      "the controlled site and keeps the sync door) and `caller` "
+                      "the forwarded runtime attr map")
+                 {:form props-form}))
+    (let [owned-props        (analyze-literal-props e tag-info properties owned)
+          owned-handler-keys (into #{}
+                                    (filter #(and (keyword? %)
+                                                  (str/starts-with? (name %) "on-")))
+                                    (keys owned))]
+      ;; A LITERAL caller map is compile-checked against the deny law now — a
+      ;; runtime map is guarded in every build by assert-safe-caller!.
+      (when (map? caller)
+        (doseq [k (keys caller)]
+          (when (rules/spread-safe-denied-key? k owned-handler-keys)
+            (env/fail! e :rf.ui.compile/spread-safe-owned-key
+                       (str "(v/spread-safe owned caller) — the caller map may "
+                            "not carry the owned/structural key " (pr-str k)
+                            "; it is denied in every build so it can never clobber "
+                            "an owned prop. Forward it through the visible-cost "
+                            "(v/spread base overrides) instead, or drop it")
+                       {:prop k :form props-form}))))
+      (let [caller*  (walk-expr e [:spread-safe :caller] caller)
+            identity (event-site-identity e :spread-safe props-form)]
+        ;; ONE opaque runtime site classifies the caller's allowed :on-* handlers
+        ;; (vector/fn/dynamic via the handler decision table) — exactly like a
+        ;; general spread's site, so allowed caller handlers batch. The owned
+        ;; handlers keep their own compiled per-site events (sync door intact).
+        (add-event-site! e identity
+                         {:prop :spread-safe :handler :opaque
+                          :classification :spread :serializable? false
+                          :sync? false})
+        (assoc owned-props
+               :safe-spread (merge identity {:base caller*
+                                             :owned-handler-keys owned-handler-keys})
+               :static? false)))))
+
+(defn analyze-element-props
+  "Analyze a DOM/custom element's props position — a literal map,
+  `(v/spread base overrides)`, or `(v/spread-safe owned caller)`.
+  -> {:key {..} :class {..} :style {..}|nil :attrs [..] :events [..]
+  :spread form|nil :safe-spread form|nil :ref {..}|nil :property-props #{kw}
+  :static? bool}"
+  [e tag-info custom? props-form]
+  (let [tag        (:tag tag-info)
+        ;; Per-build compile-time property classification, read from the
+        ;; ambient build's `elements` slice (rf2-vxgfnd.91). This analysis
+        ;; runs under `cljs.env/*compiler*`, so `build/element-properties`
+        ;; resolves the CURRENT build's declarations — never a process-global
+        ;; last-writer-wins mirror that a sibling build could clobber between
+        ;; this tag's declaration and this classification read.
+        ;;
+        ;; On the plain-JVM / SSR path there is no `:compile-prepare` hook to
+        ;; pre-seed the slice, and macros expand top-to-bottom, so a view
+        ;; expanded before a declaration below it would read an empty slice and
+        ;; lower a declared property to an attribute. Harvest this namespace's
+        ;; OWN literal declarations once, here, before classifying — making the
+        ;; verdict order-independent (rf2-vxgfnd.141, dimension 2). Under a real
+        ;; Shadow compile the build hook already seeded the slice, so this is a
+        ;; no-op there (`shadow-compile?`).
+        properties (when custom?
+                     #?(:clj (when-not (build/shadow-compile?)
+                               (harvest/ensure-namespace-harvested! (:ns e))))
+                     (build/element-properties tag))
+        spread?    (spread-form? e props-form)
+        spread-safe? (spread-safe-form? e props-form)]
+    (when (and (some? props-form) (not (map? props-form))
+               (not spread?) (not spread-safe?))
+      (env/fail! e :rf.ui.compile/dynamic-props-map
+                 (str "props of " tag " must be a literal map, "
+                      "(v/spread base overrides), or (v/spread-safe owned caller)")
+                 {:form props-form}))
+    (cond
+      spread?
+      (let [[_ base overrides & extra] props-form]
+        (when (or (nil? base) (seq extra))
+          (env/fail! e :rf.ui.compile/bad-spread
+                     "(v/spread base) or (v/spread base overrides)"
+                     {:form props-form}))
+        (let [base*      (walk-expr e [:spread :base] base)
+              overrides* (when overrides
+                           (walk-expr e [:spread :overrides] overrides))
+              identity   (event-site-identity e :spread props-form)]
+          (add-event-site! e identity
+                           {:prop :spread :handler :opaque
+                            :classification :spread :serializable? false
+                            :sync? false})
+          {:key {:present? false} :class (analyze-class e (:classes tag-info) nil)
+           :style nil :attrs [] :events []
+           :spread (merge identity {:base base* :overrides overrides*})
+           :safe-spread nil
+           :ref nil :property-props #{} :static? false}))
+
+      spread-safe?
+      (analyze-spread-safe-props e tag-info properties props-form)
+
+      :else
+      (analyze-literal-props e tag-info properties (or props-form {})))))
+
+;; ---------------------------------------------------------------------------
+;; Nodes
+;; ---------------------------------------------------------------------------
+
+(declare analyze)
+
+(defn- node-static? [n] (boolean (:static? n)))
+
+(defn- analyze-children [e forms]
+  (into []
+        (map-indexed (fn [i f] (analyze (update e :path conj i) f)))
+        forms))
+
+(defn- raw-text-structural-child?
+  "A source child form beneath a static single-text-body host element — a
+  `<script>`/`<style>` raw-text element, or a `<textarea>` — that VISIBLY
+  denotes host STRUCTURE rather than text: a hiccup element/fragment vector, or
+  a keyed-list (`for`) markup form. React drops or stringifies such a child
+  (these elements take one text string) and the JVM serialiser rejects it, so it
+  is a compile error here (rf2-ib4fd). A runtime-dynamic expression — a symbol,
+  a `(str …)`/other call, a branch — is NOT visibly structural and stays
+  programmer-trusted: it produces the text string at render time."
+  [e f]
+  (or (vector? f)
+      (and (seq? f)
+           (let [h (first f)]
+             (and (symbol? h)
+                  (= h 'for)
+                  (not (contains? (:locals e) h)))))))
+
+(defn- analyze-element [e form]
+  (let [head      (nth form 0)
+        tag-info  (parse-tag e head)
+        tag       (:tag tag-info)
+        custom?   (str/includes? (name tag) "-")
+        second*   (nth form 1 nil)
+        has-props (or (map? second*) (spread-form? e second*)
+                      (spread-safe-form? e second*))
+        props     (analyze-element-props e tag-info custom? (when has-props second*))
+        child-fs  (vec (if has-props (drop 2 form) (drop 1 form)))
+        html-kid? (and (= 1 (count child-fs)) (html-form? e (first child-fs)))]
+    (when (and (contains? rules/children-rejected-tags tag) (seq child-fs))
+      (env/fail! e :rf.ui.compile/void-children
+                 (str "<" (name tag) "> cannot have children (React throws at "
+                      "render; this grammar rejects earlier)")
+                 {:tag tag :form form}))
+    (doseq [f child-fs]
+      (when (and (html-form? e f) (not html-kid?))
+        (env/fail! e :rf.ui.compile/html-not-sole-child
+                   (str "(v/html ...) must be the SOLE child of a DOM element "
+                        "— the React host owns trusted markup through the "
+                        "parent element. Wrap it: [:div (v/html s)] "
+                        "(conservative S1 pin)")
+                   {:form form})))
+    ;; rf2-ib4fd — (v/html …) beneath a static <textarea> lowers to React
+    ;; `dangerouslySetInnerHTML`, which react-dom/server 19.2 REJECTS on a
+    ;; textarea (its content is `:value`/`defaultValue`, or an ordinary text
+    ;; child). Reject at compile — a clear fail-fast beats a silent wrong render
+    ;; (React throws / the JVM tree emits divergent trusted markup).
+    (when (and (= tag :textarea) html-kid?)
+      (env/fail! e :rf.ui.compile/html-in-textarea
+                 (str "(v/html …) is not valid inside <textarea> — React sets a "
+                      "textarea's content through :value (or an ordinary text "
+                      "child), never trusted markup (dangerouslySetInnerHTML), "
+                      "which React 19 rejects on a <textarea>. Use :value \"…\" "
+                      "or an ordinary text child.")
+                 {:tag tag :form form}))
+    ;; rf2-ib4fd (residual) — a static <textarea>'s CHILD contract, the sibling
+    ;; of the html-in-textarea rule above. React 19.2 renders a textarea's
+    ;; content from ONE channel: its :value/:default-value, OR a single ordinary
+    ;; text child — never both, never several children, never structural markup.
+    ;; `[:textarea "a" "b"]` throws "<textarea> can only have at most one child";
+    ;; :value/:default-value + an authored child throws; a structural child
+    ;; renders "[object Object]" (and the JVM serialiser emits a divergent
+    ;; <span>…</span> body). Reject the host-divergent shapes at compile — a
+    ;; sole text child (literal or runtime-dynamic) and :value alone stay valid.
+    (when (= tag :textarea)
+      (let [literal-value? (and (map? second*)
+                                (or (contains? second* :value)
+                                    (contains? second* :default-value)))]
+        (cond
+          (and literal-value? (seq child-fs))
+          (env/fail! e :rf.ui.compile/textarea-children
+                     (str "<textarea> takes its content from EITHER "
+                          ":value / :default-value OR a single text child, never "
+                          "both — React rejects a textarea given a value AND a "
+                          "child. Drop the child, or drop :value.")
+                     {:tag tag :form form})
+
+          (> (count child-fs) 1)
+          (env/fail! e :rf.ui.compile/textarea-children
+                     (str "<textarea> takes at most ONE child, but "
+                          (count child-fs) " were given — React rejects a "
+                          "textarea with more than one child. Supply a single "
+                          "text child, or set the content through :value.")
+                     {:tag tag :form form})
+
+          (and (= 1 (count child-fs))
+               (raw-text-structural-child? e (first child-fs)))
+          (env/fail! e :rf.ui.compile/textarea-children
+                     (str "<textarea> takes a single TEXT child, not structural "
+                          "markup — React renders an element child as "
+                          "\"[object Object]\". Supply text (a string, or a "
+                          "(str …)), or set the content through :value.")
+                     {:tag tag :form form}))))
+    ;; rf2-ib4fd — a static <script>/<style> is an HTML RAW-TEXT element: React
+    ;; takes a SINGLE text body (one string). Multiple source children reach
+    ;; React as an array that warns and loses the body; a visibly structural
+    ;; sole child (a hiccup element/fragment, or a `for` list) is dropped or
+    ;; stringified by React and rejected by the JVM serialiser. Reject both at
+    ;; compile. A sole (v/html …) is the sanctioned trusted-markup body (the
+    ;; html-kid? path below); a runtime-dynamic expression stays trusted.
+    (when (and (contains? rules/raw-text-tags tag) (not html-kid?))
+      (cond
+        (> (count child-fs) 1)
+        (env/fail! e :rf.ui.compile/raw-text-children
+                   (str "<" (name tag) "> is an HTML raw-text element and takes a "
+                        "SINGLE text child, but " (count child-fs) " children were "
+                        "given — React joins them into an array that warns and "
+                        "loses the body. Construct ONE string, e.g. (str a b …), "
+                        "or use (v/html s) for trusted markup.")
+                   {:tag tag :form form})
+        (and (= 1 (count child-fs))
+             (raw-text-structural-child? e (first child-fs)))
+        (env/fail! e :rf.ui.compile/raw-text-children
+                   (str "<" (name tag) "> is an HTML raw-text element and takes a "
+                        "SINGLE text child, not structural markup — React drops or "
+                        "stringifies an element child here. Construct ONE string, "
+                        "e.g. (str …), or use (v/html s) for trusted markup.")
+                   {:tag tag :form form})))
+    (let [children (if html-kid? [] (analyze-children e child-fs))
+          html-ast (when html-kid?
+                     (let [[_ s & extra] (first child-fs)]
+                       (when (or (nil? s) (seq extra))
+                         (env/fail! e :rf.ui.compile/bad-html
+                                    "(v/html string) takes exactly one argument"
+                                    {:form (first child-fs)}))
+                       (when-not (or (string? s) (not (literal-scalar? s)))
+                         (env/fail! e :rf.ui.compile/bad-html
+                                    "(v/html x) requires a string"
+                                    {:form (first child-fs)}))
+                       (let [s* (if (string? s)
+                                  s
+                                  (walk-expr e [:html] s))]
+                       ;; Record the trusted-markup site in the compiler
+                       ;; manifest (profile row `v/html` — "manifest site
+                       ;; recording"): the visible bypass carries source/
+                       ;; template path so tools can list every place escaping
+                       ;; is bypassed. `:serializable?` is false for a dynamic
+                       ;; string expression, true for a literal.
+                       (env/add-site! e :htmls {:form s*
+                                                :static? (string? s)
+                                                :serializable? (string? s)
+                                                :path (:path e)})
+                       {:op :html :form s* :static? (string? s)})))
+          node     {:op :element
+                    :tag tag
+                    :custom? custom?
+                    :void? (contains? rules/void-tags tag)
+                    :props props
+                    :html html-ast
+                    :children children
+                    :static? (and (:static? props)
+                                  (nil? (:spread props))
+                                  (nil? (:safe-spread props))
+                                  (if html-kid?
+                                    (:static? html-ast)
+                                    (every? node-static? children))
+                                  true)
+                    :path (:path e)}]
+      ;; The compile-tier a11y roster (S4-C) reads the ANALYZED node — literal
+      ;; facts only — and validates the element's suppression metadata. It mints
+      ;; findings, never rejections: the node is returned unchanged.
+      (a11y/check-element! e form node
+                           (fn [expr-path] (lexical-site-id e :a11y form expr-path)))
+      node)))
+
+;; ---------------------------------------------------------------------------
+;; Compiled render slots — `v/render-fn` callback + `v/slot` invocation (S3)
+;; ---------------------------------------------------------------------------
+;;
+;; `v/render-fn` is a compiler-owned PURE render callback authored at the
+;; consumer call site (a component prop value, or an inline v/slot argument),
+;; so its body is COMPILED — the closed template grammar, no runtime hiccup.
+;; The body is a DEFERRED render (the library seam invokes it later, in a
+;; different view), so `:in-render-fn?` seeds the deferred scope: sub/frame
+;; reads and the dispatch/hook surface (event handlers, refs) inside are
+;; didactic `impure-slot-body` errors. Statically-referenced internal view
+;; heads REMAIN legal — a stateful part is a pure slot body mounting a static
+;; defview that owns its own state (the wave-2 registered-`v/view` coverage
+;; argument depends on exactly this).
+
+(defn analyze-render-fn
+  "Analyze `(v/render-fn [args…] template)` → {:params <vec> :body <ast>}.
+  The params bind as locals over a pure deferred-render template body."
+  [e form]
+  (let [[_ params & body] form]
+    (when-not (vector? params)
+      (env/fail! e :rf.ui.compile/bad-render-fn
+                 (str "(v/render-fn [args…] template) needs a literal parameter "
+                      "binding vector before its one template body; got "
+                      (pr-str params))
+                 {:form form}))
+    (when (some #{'&} params)
+      (env/fail! e :rf.ui.compile/bad-render-fn
+                 (str "v/render-fn parameters are a FIXED arg list — variadic & "
+                      "is not permitted (a v/slot passes a fixed number of args)")
+                 {:form form}))
+    (when (not= 1 (count body))
+      (env/fail! e :rf.ui.compile/bad-render-fn
+                 (str "(v/render-fn [args…] template) has exactly ONE template "
+                      "body form — computation goes in (let …); siblings wrap in "
+                      "[:<> …]. Got " (count body) " body forms")
+                 {:form form}))
+    (reject-reactive-binding! e params)
+    (let [binders (env/binding-syms params)
+          e*      (-> e
+                      (env/with-locals binders)
+                      (assoc :in-render-fn? true :in-loop? false :loop-syms #{})
+                      ;; a render-fn body is DEFERRED — it runs wherever the
+                      ;; matching `v/slot` is invoked, so it is not inline
+                      ;; parent-render markup any more.
+                      (dissoc :top-region? :presence-inline?)
+                      (update :path conj :render-fn))]
+      {:params params
+       :body   (analyze e* (first body))})))
+
+(defn- prop-slot-name [k]
+  (if-let [ns* (namespace k)] (str ns* "/" (name k)) (name k)))
+
+(defn- analyze-component-callback
+  "A `v/event` or `v/handler` at a foreign/internal-view component prop: a
+  per-site-stable committed callback that reads the winning commit (the
+  stale-closure boundary law — one closed boundary contract for both invokers).
+  `kind` is :ui-event (its body returns the event vector to dispatch, or nil) or
+  :handler (imperative — its return is dropped). Records an event SITE
+  (loop-capture-checked, manifest-carried) and produces the compiled body fn the
+  emitter lowers to the stable callback."
+  [e head-info k kind form]
+  (let [[_ bindings & body] form
+        verb (if (= kind :ui-event) "v/event" "v/handler")]
+    ;; A committed callback authored as a component prop inside a render-fn slot
+    ;; body is the correctness-critical escape: a repeated slot reuses ONE lexical
+    ;; event-site key, so later rows overwrite the descriptor and every row's
+    ;; callback reads the last row's closure. The purity fence rejects it — the
+    ;; callback belongs to the owning view or a mounted defview (rf2-vtfzn).
+    (when (:in-render-fn? e)
+      (env/fail! e :rf.ui.compile/impure-slot-body
+                 (str "(" verb " …) at prop " k " inside a v/render-fn slot body "
+                      "— a slot body is a PURE render fragment; a committed callback "
+                      "DISPATCHES / runs imperative work, which a slot body may not "
+                      "own (a repeated slot shares ONE lexical callback site, so "
+                      "every row would alias the last row's closure). Own the "
+                      "callback in the OWNING view, or MOUNT a defview that owns its "
+                      "handlers")
+                 {:prop k :form form}))
+    (when-not (and (vector? bindings) (not (some #{'&} bindings))
+                   (if (= kind :ui-event)
+                     (= 1 (count bindings))
+                     (pos? (count bindings))))
+      (env/fail! e :rf.ui.compile/bad-ui-callback
+                 (str "(" verb " " (pr-str bindings) " …) at prop " k " on "
+                      (if (= :view (:kind head-info)) "view " "foreign-component ")
+                      (:sym head-info) " — " verb
+                      (if (= kind :ui-event)
+                        (str " binds exactly the invoker's event argument and "
+                             "returns an event vector (or nil to dispatch nothing)")
+                        (str " binds the invoker's arguments (a fixed-arity "
+                             "vector, no &) and does imperative work")))
+                 {:prop k :form form}))
+    (let [identity (event-site-identity e k form)
+          binders  (set (env/binding-syms bindings))
+          ;; The body is a DEFERRED callback (the invoker calls it later), so the
+          ;; fn walk rejects render-time sub/frame inside it. Its own
+          ;; bindings shadow, so they are excluded from the loop-capture check.
+          form*    (walk-expr e [:component-prop k kind]
+                              (with-meta (apply list 'fn bindings body) (meta form)))]
+      (check-loop-capture! (update e :loop-syms #(reduce disj % binders))
+                           (str verb " at prop " k) form)
+      (add-event-site! e identity
+                       {:prop k :handler :opaque
+                        :classification kind :serializable? false})
+      (merge identity
+             {:k k
+              :slot (prop-slot-name k)
+              :marker kind          ; :ui-event | :handler
+              :callback-fn form*
+              :classification kind
+              :literal? false}))))
+
+(defn- analyze-foreign-spread
+  "Parse `(v/spread …)` in a FOREIGN component's props position (rf2-u53yy.5):
+  an OPTIONAL leading LITERAL map — the component's own props, analysed exactly
+  like a literal call-site props map (compiled `v/handler`/`v/event`/
+  `v/render-fn`, prop-key checks, `:key`/`:ref` extraction) — plus an opaque
+  forwarded runtime map. The forwarded map is the visible foreign-boundary
+  opt-in: a foreign head's props are open and pass through UNCONVERTED (there is
+  no per-slot memo comparator or slot ABI to defend, so nothing is converted),
+  and the compiled LITERAL props WIN any key collision — mirroring
+  `v/spread-safe`'s owned-wins layering, minus the deny law. The forwarded map
+  marks the site `:dynamic` in the manifest exactly as a dynamic handler
+  expression does. -> `[literal-map spread-node|nil]`.
+
+  Shapes: `(v/spread runtime-map)` — the plain forwarded map, no literal part;
+  `(v/spread literal-map runtime-map)` — literal part plus the forwarded map. A
+  leading literal map is the literal part; a leading non-map expression is the
+  forwarded map."
+  [e head-info props-form]
+  (let [args (rest props-form)
+        n    (count args)]
+    (when-not (<= 1 n 2)
+      (env/fail! e :rf.ui.compile/bad-spread
+                 (str "(v/spread runtime-map) or (v/spread literal-part "
+                      "runtime-map) at the foreign component " (:sym head-info))
+                 {:form props-form}))
+    (let [[a b]   args
+          literal (if (map? a)
+                    a
+                    (when (= n 2)
+                      (env/fail! e :rf.ui.compile/bad-spread
+                                 (str "(v/spread literal-part runtime-map) — the "
+                                      "first argument must be a LITERAL props map "
+                                      "(analysed for the component's compiled "
+                                      "handlers and props); the second is the "
+                                      "opaque forwarded runtime map")
+                                 {:form props-form})))
+          runtime (cond
+                    (= n 2)  b
+                    (map? a) nil
+                    :else    a)]
+      [(or literal {})
+       (when (some? runtime)
+         (let [identity (event-site-identity e :spread props-form)]
+           (add-event-site! e identity
+                            {:prop :spread :handler :opaque
+                             :classification :spread :serializable? false
+                             :sync? false})
+           (merge identity {:base (walk-expr e [:spread :base] runtime)})))])))
+
+(defn- analyze-component-props
+  "View/foreign call-site props (Q2/Q3/Q4): a literal map — or, at a FOREIGN
+  head only, `(v/spread …)` (rf2-u53yy.5, the foreign wrapper idiom). :key
+  extracted (never a prop); :children as an explicit key rejected (children are
+  positional). Bare fn values: rejected at a FOREIGN boundary (the narrow
+  bare-fn law — invoker/phase unknown), but LEGAL as an opaque identity-compared
+  value at an INTERNAL-view boundary (C-13a) — the framework never invokes it
+  and promises no phase; v/handler/v/render-fn opt a phase in. `v/event`/
+  `v/handler` are the explicit committed callbacks at either. `v/spread` at an
+  INTERNAL view is rejected — an internal view requires a literal props map (its
+  generated per-slot memo comparator and slot ABI need the literal keys)."
+  [e head-info props-form]
+  (let [spread? (spread-form? e props-form)
+        view?   (= :view (:kind head-info))]
+   (cond
+    (and spread? view?)
+    (env/fail! e :rf.ui.compile/spread-internal-view
+               (str "(v/spread …) at the internal view " (:view-id head-info)
+                    " — an internal view requires a LITERAL props map: its "
+                    "generated per-slot memo comparator and slot ABI need the "
+                    "literal keys. v/spread is admitted at a FOREIGN component "
+                    "call site (its props are open and pass through unconverted) "
+                    "and in a DOM/custom element's props position")
+               {:head (:sym head-info)})
+
+    (and (some? props-form) (not (map? props-form)) (not spread?))
+    (env/fail! e :rf.ui.compile/dynamic-props-map
+               (str "component call sites take a LITERAL props map — a wholly-"
+                    "dynamic props expression is not v1 grammar (conservative "
+                    "S1 pin). At a FOREIGN component forward a runtime map with "
+                    "(v/spread literal-part runtime-map); a DOM/custom element "
+                    "also takes (v/spread base overrides)")
+               {:head (:sym head-info) :form props-form})
+
+    :else
+    (let [[m spread-node] (if spread?
+                            (analyze-foreign-spread e head-info props-form)
+                            [(or props-form {}) nil])]
+    (doseq [k (keys m)]
+      (when-not (keyword? k)
+        (env/fail! e :rf.ui.compile/non-keyword-prop
+                   (str "prop keys must be literal keywords; got " (pr-str k))
+                   {:key k}))
+      (when (= k :children)
+        (env/fail! e :rf.ui.compile/children-prop
+                   (str ":children as an explicit prop at a call site — "
+                        "children are positional ([view {...} child1 child2]) "
+                        "and arrive as :children on the definition side. One "
+                        "spelling per concept")
+                   {:head (:sym head-info)})))
+    (let [key-form (get m :key)
+          ref-a    (when (contains? m :ref)
+                     (analyze-ref e (get m :ref)
+                                  (if (= :view (:kind head-info)) :view :foreign)))
+          m*       (dissoc m :key :ref)
+          entries  (mapv (fn [[k v]]
+                           (cond
+                             (render-fn-form? e v)
+                             ;; A compiled render slot: the body is a lexically
+                             ;; visible pure template compiled HERE (both emitters)
+                             ;; into a callback value the seam invokes via v/slot.
+                             {:k k
+                              :slot (prop-slot-name k)
+                              :render-fn (analyze-render-fn
+                                          (update e :path into [:component-prop k]) v)
+                              :marker :render-fn
+                              :literal? false}
+
+                             ;; The explicit committed callbacks — a per-site
+                             ;; stable identity reading the winning commit at a
+                             ;; foreign or internal-view seam.
+                             (ui-event-form? e v)
+                             (analyze-component-callback e head-info k :ui-event v)
+
+                             (ui-handler-form? e v)
+                             (analyze-component-callback e head-info k :handler v)
+
+                             (fn-form? v)
+                             (if (= :view (:kind head-info))
+                               ;; C-13a: a bare fn between INTERNAL views is a
+                               ;; legal OPAQUE value — identity-compared, NEVER
+                               ;; invoked by the framework, no implicit invocation
+                               ;; phase. A fresh closure repaints via the memo
+                               ;; identity-compare; opt a phase in with v/handler
+                               ;; (per-site stable) or v/render-fn.
+                               {:k k :slot (prop-slot-name k)
+                                :value (walk-expr e [:component-prop k] v)
+                                :marker nil :literal? false}
+                               (env/fail! e :rf.ui.compile/bare-fn-prop
+                                          (str "bare fn prop " k " at a "
+                                               "foreign-component boundary — invoker "
+                                               "and phase are unknown there. Choose "
+                                               "v/raw-fn (identity-as-protocol), "
+                                               "v/event (returns the event vector to "
+                                               "dispatch), v/handler (imperative "
+                                               "work), or v/render-fn (a compiled "
+                                               "render slot) — never a bare fn")
+                                          {:prop k :head (:sym head-info)}))
+
+                             :else
+                             ;; NOTE: vector/data props MAY capture loop bindings —
+                             ;; passing row data into a keyed child view is exactly
+                             ;; the extract-a-keyed-child-view fix; only HANDLER
+                             ;; sites are capture-checked.
+                             (let [raw?    (raw-form? e v)
+                                   raw-fn? (raw-fn-form? e v)
+                                   v*      (cond
+                                             raw? (walk-expr e [:component-prop k :raw]
+                                                             (second v))
+                                             raw-fn? (walk-expr e [:component-prop k :raw-fn]
+                                                                (second v))
+                                             (literal-scalar? v) v
+                                             :else (walk-expr e [:component-prop k] v))]
+                               {:k k
+                                :slot (prop-slot-name k)
+                                :value v*
+                                :marker (cond raw? :foreign raw-fn? :v/raw-fn :else nil)
+                                :literal? (literal-scalar? v)})))
+                          m*)]
+      (let [key-form* (if (and (contains? m :key) (not (literal-scalar? key-form)))
+                        (walk-expr e [:component-key] key-form)
+                        key-form)]
+      (cond-> {:key {:present? (contains? m :key) :expr key-form*
+                     :literal? (literal-scalar? key-form)}
+               :entries entries
+               :ref ref-a}
+        spread-node (assoc :spread spread-node))))))))
+
+(defn- analyze-component [e form]
+  (let [head      (nth form 0)
+        info      (env/classify-head e head)
+        second*   (nth form 1 nil)
+        ;; a `(v/spread …)` second form is PROPS at a component head, not a
+        ;; child — admitted at a FOREIGN head (rf2-u53yy.5), rejected at an
+        ;; internal view by analyze-component-props (literal props required).
+        has-props (or (map? second*) (spread-form? e second*))
+        props     (analyze-component-props e info (when has-props second*))
+        child-fs  (vec (if has-props (drop 2 form) (drop 1 form)))
+        ;; a view/foreign boundary ENDS the static top region (S1c):
+        ;; frame-root below it is a compile error
+        children  (analyze-children (dissoc e :top-region?) child-fs)]
+    (when (and (= :view (:kind info)) (seq children))
+      (let [meta*      (:meta (env/resolve-sym e head))
+            self?      (and (:self e) (= head (:self e)))
+            children-ok? (if self?
+                           (:self-children? e)
+                           (:rf.ui/children? meta*))]
+        (when-not children-ok?
+          (env/fail! e :rf.ui.compile/children-not-accepted
+                     (str "view " (:view-id info) " does not accept children — "
+                          "it declares none (:children in the header "
+                          "destructuring, an :as binding, or a [:children ...] "
+                          "schema entry would declare them). Q4 pin")
+                     {:head head}))))
+    (when (= :view (:kind info))
+      ;; Q2 closed-map: :props present => closed — literal call-site keys
+      ;; must be declared
+      (let [meta*  (:meta (env/resolve-sym e head))
+            self?  (and (:self e) (= head (:self e)))
+            closed (if self? (:self-closed-keys e) (:rf.ui/closed-prop-keys meta*))]
+        (when closed
+          (let [allowed (set closed)
+                bad     (remove #(or (allowed %) (= :key %)) (map :k (:entries props)))]
+            (when (seq bad)
+              (env/fail! e :rf.ui.compile/undeclared-prop
+                         (str "undeclared prop" (when (next bad) "s") " "
+                              (str/join ", " (map pr-str bad)) " passed to "
+                              (:view-id info) " — its :props schema closes the "
+                              "map (declared: " (str/join ", " (map pr-str closed))
+                              "). Q2 pin: absent :props = open, present :props "
+                              "= closed")
+                         {:head head :undeclared (vec bad)}))))))
+    (cond-> {:op (if (= :view (:kind info)) :view :foreign)
+             :sym head
+             :fqn (:fqn info)
+             :view-id (:view-id info)
+             :props props
+             :children children
+             :static? false
+             :path (:path e)}
+      ;; a re-frame.freehand.react/lazy component is a foreign head that IS callable on
+      ;; the JVM structural render (renders its fallback / nothing).
+      (:lazy? info) (assoc :lazy? true))))
+
+(defn- analyze-slot
+  "Analyze `(v/slot render-fn-value arg…)` — the compiler-owned invocation of
+  a compiled render slot in child position. The first argument is an inline
+  `(v/render-fn …)` (compiled here) or an ordinary expression evaluating to a
+  render-fn value or nil (validated at the seam by `slot-ready?`); the
+  remaining args are the library's runtime values, walked in the ambient
+  (library-view) scope — a slot ARGUMENT is not deferred, so a `(sub …)` there
+  is the library's own render-time read. The slot's output participates in the
+  surrounding children exactly like any other child (child-like memo cost).
+
+  A render-fn is a FIXED-arity callback (Spec 004 §render slots), so the slot
+  boundary owns ONE host-independent arity contract: an INLINE render-fn's
+  parameter count is compared with the slot's argument count HERE and a mismatch
+  is a compile error; a PROP-carried render-fn carries its arity into the runtime
+  carrier and `check-slot-arity!` enforces it before invocation on both hosts —
+  neither leans on a native fixed/variadic call quirk (rf2-ckviw)."
+  [e form]
+  (when (< (count form) 2)
+    (env/fail! e :rf.ui.compile/bad-slot
+               (str "(v/slot render-fn-value arg…) needs a render-fn value (or "
+                    "nil) as its first argument; got " (pr-str form))
+               {:form form}))
+  (let [slotval (nth form 1)
+        args    (drop 2 form)
+        argc    (count args)
+        inline? (render-fn-form? e slotval)
+        sid     (lexical-site-id e :slot form (:path e))
+        args*   (into []
+                      (map-indexed (fn [i a] (walk-expr e [:slot :arg i] a)))
+                      args)
+        ;; Analyze the inline body FIRST (so an impure body throws
+        ;; impure-slot-body before the arity check), then compare arity.
+        rf-node (when inline?
+                  (analyze-render-fn (update e :path conj :slot-fn) slotval))]
+    (when inline?
+      (let [pc (count (:params rf-node))]
+        (when (not= pc argc)
+          (env/fail! e :rf.ui.compile/slot-arity
+                     (str "(v/slot render-fn arg…) passes " argc " argument"
+                          (when (not= 1 argc) "s") " to an inline (v/render-fn "
+                          (pr-str (:params rf-node)) " …) that declares " pc
+                          " parameter" (when (not= 1 pc) "s")
+                          " — a render-fn is a FIXED-arity callback, so the slot must "
+                          "pass exactly its declared parameters (host-identically, "
+                          "before invocation). "
+                          (if (< argc pc)
+                            "Pass the missing argument(s), or drop the unused parameter(s)"
+                            "Drop the surplus argument(s), or declare the extra parameter(s)"))
+                     {:form form :expected pc :actual argc}))))
+    (let [node (cond-> {:op :slot
+                        :args args*
+                        :sid sid
+                        :static? false
+                        :path (:path e)}
+                 inline?       (assoc :render-fn rf-node)
+                 (not inline?) (assoc :slot-value (if (literal-scalar? slotval)
+                                                    slotval
+                                                    (walk-expr e [:slot :value] slotval))))]
+      (env/add-site! e :slots {:sid sid
+                               :path (:path e)
+                               :source-coord (event-source-coord e form)
+                               :inline? inline?})
+      node)))
+
+;; ---------------------------------------------------------------------------
+;; v/error-boundary + v/client-only (S3) — the interop recovery/boundary forms
+;; ---------------------------------------------------------------------------
+
+(def ^:private error-boundary-opt-keys #{:fallback :reset-key :on-error})
+
+(defn- analyze-error-boundary
+  "(v/error-boundary {:fallback view :reset-key val :on-error [:ev …]} child)
+  — the explicit error component. Catches render/lifecycle throws below it
+  (React does not catch event-handler or async errors — those keep their typed
+  paths); the fallback VIEW renders with :error on catch; :on-error dispatches
+  AFTER the failing commit through the owning view's captured frame (never
+  during render, I-1); changing :reset-key clears the caught error (retry). One
+  guarded child."
+  [e form]
+  (let [opts  (nth form 1 nil)
+        rest* (drop 2 form)]
+    (when-not (map? opts)
+      (env/fail! e :rf.ui.compile/bad-error-boundary
+                 (str "(v/error-boundary {:fallback view …} child) needs a "
+                      "literal opts map with a :fallback view")
+                 {:form form}))
+    (let [bad (remove error-boundary-opt-keys (keys opts))]
+      (when (seq bad)
+        (env/fail! e :rf.ui.compile/bad-error-boundary
+                   (str "unknown error-boundary option" (when (next bad) "s") " "
+                        (str/join ", " (map pr-str bad))
+                        " — the closed set is {:fallback :reset-key :on-error}")
+                   {:form form})))
+    (when-not (contains? opts :fallback)
+      (env/fail! e :rf.ui.compile/bad-error-boundary
+                 (str ":fallback is REQUIRED — the view that renders with :error "
+                      "when a throw is caught below the boundary")
+                 {:form form}))
+    (let [fallback (:fallback opts)
+          fb-info  (when (and (symbol? fallback) (not (contains? (:locals e) fallback)))
+                     (env/classify-head e fallback))]
+      (when-not (and fb-info (= :view (:kind fb-info)))
+        (env/fail! e :rf.ui.compile/bad-error-boundary
+                   (str ":fallback must be a defview — it renders with :error + "
+                        "declared props and cannot recursively dispatch; got "
+                        (pr-str fallback))
+                   {:form form}))
+      (let [on-error (:on-error opts)]
+        ;; :on-error DISPATCHES after the failing commit — a committed-callback
+        ;; dispatch surface. Inside a render-fn slot body it escapes the purity
+        ;; fence exactly like a component-prop callback, so reject it (the
+        ;; error-boundary and its :on-error belong to the owning view or a mounted
+        ;; defview; rf2-vtfzn). A fallback-only boundary stays legal in a slot.
+        (when (and (some? on-error) (:in-render-fn? e))
+          (env/fail! e :rf.ui.compile/impure-slot-body
+                     (str ":on-error inside a v/render-fn slot body — a slot body "
+                          "is a PURE render fragment, and :on-error DISPATCHES after "
+                          "the failing commit, which a slot body may not own. Place "
+                          "the error-boundary (with its :on-error) in the OWNING "
+                          "view, or MOUNT a defview that owns the boundary")
+                     {:form form}))
+        (when (and (some? on-error)
+                   (not (and (vector? on-error) (keyword? (first on-error)))))
+          (env/fail! e :rf.ui.compile/bad-error-boundary
+                     (str ":on-error must be a literal event vector "
+                          "[:domain/event …] dispatched after the failing commit; "
+                          "got " (pr-str on-error))
+                     {:form form}))
+        (when (not= 1 (count rest*))
+          (env/fail! e :rf.ui.compile/bad-error-boundary
+                     (str "(v/error-boundary {…} child) takes exactly ONE guarded "
+                          "child; wrap siblings in [:<> …]")
+                     {:form form}))
+        {:op :error-boundary
+         :fallback fb-info
+         :has-reset-key? (contains? opts :reset-key)
+         :reset-key (when (contains? opts :reset-key)
+                      (walk-expr e [:error-boundary :reset-key] (:reset-key opts)))
+         ;; :on-error args evaluate when the after-commit dispatch closure builds
+         ;; at render — walk them for site indexing (the head stays the event id).
+         :on-error (when (some? on-error)
+                     (with-meta
+                       (into [(first on-error)]
+                             (map-indexed
+                              (fn [i x] (walk-expr e [:error-boundary :on-error i] x)))
+                             (rest on-error))
+                       (meta on-error)))
+         ;; The child is CONDITIONALLY rendered (child vs fallback) → host hooks
+         ;; below it are illegal; frame-plan extraction DESCENDS through the
+         ;; boundary (004C §6), so :top-region? is preserved.
+         :child (analyze (assoc e :hooks-region? false) (first rest*))
+         :static? false
+         :path (:path e)}))))
+
+(defn- analyze-capability-free
+  "Analyze `form` as a CAPABILITY-FREE template (a client-only :fallback):
+  deterministic structural markup only — the JVM/SSR and first-hydration render
+  must match, so reactive reads (sub/frame), host state/effects (local/
+  effect/dispatch-fn), and committed event handlers are compile errors. Returns
+  the fallback AST. `context` names the position for the diagnostic."
+  [e context form]
+  (let [sub-sites (atom {:events [] :subs [] :htmls [] :frame-ops []
+                         :slots [] :locals [] :effects [] :dispatch-fns []})
+        ast       (analyze (assoc e :sites sub-sites :hooks-region? false) form)
+        found     (->> [:events :subs :frame-ops :locals :effects :dispatch-fns]
+                       (filter #(seq (get @sub-sites %)))
+                       (map name))]
+    (when (seq found)
+      (env/fail! e :rf.ui.compile/capability-in-fallback
+                 (str context " must be CAPABILITY-FREE — the JVM/SSR and first "
+                      "hydration render it deterministically, then the client "
+                      "swaps in the live subtree, so a capability here would tear "
+                      "on hydration. Found " (str/join ", " (sort found))
+                      ". A fallback is static markup (structure, props, branches, "
+                      "v/html); move reactive reads, host state/effects, and "
+                      "event handlers into the client subtree")
+                 {:form form :capabilities (vec (sort found))}))
+    ast))
+
+(defn analyze-capability-free-template
+  "Analyze `form` as a standalone CAPABILITY-FREE template (deterministic
+  structural markup: no reactive reads, host state/effects, or committed event
+  handlers) — the def-level entry for re-frame.freehand.react/lazy's `:fallback`.
+  Returns the AST or fails loud. `context` names the position for diagnostics."
+  [e context form]
+  (analyze-capability-free e context form))
+
+(defn- analyze-client-only
+  "(v/client-only {:fallback tpl} client-tpl) — a browser-only subtree with a
+  mandatory, capability-free fallback (compiler-checked). The JVM/SSR renders
+  the fallback (a deterministic `:rf.ui/boundary :client-only` node); the CLJS
+  emitter lowers the site to a PHASE-CONDITIONAL runtime boundary
+  (`re-frame.freehand.runtime/client-only`) that renders the fallback in `:server`
+  phase and the client subtree in `:client` phase — the S5 phase flip a
+  hydrating root drives `:server` -> `:client` after its hydration commit (Spec
+  011 §Phase flip, rf2-3omxp). A non-hydrating mount reads the `:client` phase
+  default and renders the client subtree on the first render (the S3
+  activation)."
+  [e form]
+  (let [opts  (nth form 1 nil)
+        rest* (drop 2 form)]
+    (when-not (map? opts)
+      (env/fail! e :rf.ui.compile/bad-client-only
+                 (str "(v/client-only {:fallback tpl} client-tpl) needs a literal "
+                      "{:fallback tpl} map")
+                 {:form form}))
+    (let [bad (remove #{:fallback} (keys opts))]
+      (when (seq bad)
+        (env/fail! e :rf.ui.compile/bad-client-only
+                   (str "unknown client-only option" (when (next bad) "s") " "
+                        (str/join ", " (map pr-str bad))
+                        " — the only option is :fallback")
+                   {:form form})))
+    (when-not (contains? opts :fallback)
+      (env/fail! e :rf.ui.compile/bad-client-only
+                 (str ":fallback is REQUIRED and must be capability-free — the "
+                      "deterministic JVM/SSR + first-hydration render")
+                 {:form form}))
+    (when (not= 1 (count rest*))
+      (env/fail! e :rf.ui.compile/bad-client-only
+                 (str "(v/client-only {:fallback tpl} client-tpl) takes exactly "
+                      "ONE client child; wrap siblings in [:<> …]")
+                 {:form form}))
+    {:op :client-only
+     :fallback (analyze-capability-free e "a v/client-only :fallback" (:fallback opts))
+     ;; the client subtree is browser-only — it ends the static top region and
+     ;; the hooks region (host content never appears on the JVM/SSR path).
+     :child (analyze (-> e (dissoc :top-region?) (assoc :hooks-region? false))
+                     (first rest*))
+     :static? false
+     :path (:path e)}))
+
+;; ---------------------------------------------------------------------------
+;; v/presence (S4, rf2-uckeg) — declarative enter/exit retention
+;; ---------------------------------------------------------------------------
+
+(def ^:private presence-opt-keys #{:timeout-ms})
+
+(defn- presence-keyed-child?
+  "A presence child must be STATICALLY keyed — the identity the runtime tracks
+  across renders. A `(for …)` is keyed by construction (analyze-for enforces
+  every row's `:key`); a literal element/view/foreign/fragment must carry a
+  `:key`. A branch (if/let/case) is keyed when each rendered arm is.
+
+  The key's location differs by node, and this predicate reads each node's
+  ACTUAL analyzed shape: a `:fragment` carries its key at the node
+  (`analyze-fragment`), while `:element` (`analyze-element-props`) and
+  `:view`/`:foreign` (`analyze-component-props`) carry it inside their analyzed
+  props map. Reading `[:key :present?]` off an `:element` finds nil and rejects
+  every keyed literal host child (rf2-vxgfnd.96.1).
+
+  Both locations now answer the SAME question — does this node carry a `:key`?
+  A `:fragment` used to report its PROPS MAP's presence there, so `[:<> {} …]`
+  passed as keyed while offering the boundary no identity to retain; the probe
+  is truthful at its source now (rf2-xoz1s), which is why this predicate needs
+  no fragment-specific translation."
+  [ast]
+  (case (:op ast)
+    :for true
+    :fragment (boolean (get-in ast [:key :present?]))
+    (:element :view :foreign) (boolean (get-in ast [:props :key :present?]))
+    :if (and (presence-keyed-child? (:then ast)) (presence-keyed-child? (:else ast)))
+    :let (presence-keyed-child? (:body ast))
+    :letfn (presence-keyed-child? (:body ast))
+    :case (and (every? presence-keyed-child? (map second (:clauses ast)))
+               (or (= ::none (:default ast)) (presence-keyed-child? (:default ast))))
+    :nothing true                       ; a statically-absent arm is fine
+    false))
+
+(defn- analyze-presence
+  "(v/presence {:timeout-ms n} keyed-children) — the three-phase enter/exit
+  retention boundary. `:timeout-ms` is MANDATORY (the terminal safety bound —
+  unit suffixed on the key) and a positive number literal. Children must be
+  statically KEYED (a `(for …)` with `:key`, or keyed element/view rows) —
+  unkeyed presence children are a build failure (§Presence)."
+  [e form]
+  (let [opts  (nth form 1 nil)
+        body  (drop 2 form)]
+    (when-not (map? opts)
+      (env/fail! e :rf.ui.compile/bad-presence
+                 (str "(v/presence {:timeout-ms n} children) needs a literal opts "
+                      "map with a mandatory :timeout-ms (the terminal safety bound)")
+                 {:form form}))
+    (let [bad (remove presence-opt-keys (keys opts))]
+      (when (seq bad)
+        (env/fail! e :rf.ui.compile/bad-presence
+                   (str "unknown presence option" (when (next bad) "s") " "
+                        (str/join ", " (map pr-str bad))
+                        " — the only option is :timeout-ms")
+                   {:form form})))
+    (when-not (contains? opts :timeout-ms)
+      (env/fail! e :rf.ui.compile/bad-presence
+                 (str ":timeout-ms is MANDATORY on (v/presence …) — the terminal "
+                      "safety bound AND the exit retention duration: a retained "
+                      "exiting child is removed when :timeout-ms fires")
+                 {:form form}))
+    (let [t (:timeout-ms opts)]
+      (when-not (and (number? t) (pos? t))
+        (env/fail! e :rf.ui.compile/bad-presence
+                   (str ":timeout-ms must be a positive number of milliseconds; got "
+                        (pr-str t))
+                   {:form form})))
+    (when (empty? body)
+      (env/fail! e :rf.ui.compile/bad-presence
+                 "(v/presence {:timeout-ms n} children) needs at least one keyed child"
+                 {:form form}))
+    (let [child-asts (into []
+                           (map-indexed
+                            (fn [i c]
+                              (analyze (-> e (update :path conj :presence i)
+                                           ;; INLINE literal markup under a
+                                           ;; presence boundary is evaluated in
+                                           ;; the parent's render — outside the
+                                           ;; per-child phase Provider — so it
+                                           ;; provably cannot read its own
+                                           ;; (v/presence-phase). S4-C check 4
+                                           ;; keys off exactly this fact.
+                                           (assoc :hooks-region? false
+                                                  :presence-inline? true))
+                                       c)))
+                           body)]
+      (doseq [ast child-asts]
+        (when-not (presence-keyed-child? ast)
+          (env/fail! e :rf.ui.compile/presence-unkeyed-child
+                     (str "children under (v/presence …) must be KEYED — a "
+                          "(for [x xs] [row {:key (:id x)} …]) or keyed element/view "
+                          "rows. Presence tracks children by key across renders, so "
+                          "unkeyed presence children are a build failure")
+                     {:form form})))
+      {:op :presence
+       :timeout-ms (:timeout-ms opts)
+       :children child-asts
+       :static? false
+       :path (:path e)})))
+
+;; ---------------------------------------------------------------------------
+;; Reactive authoring verbs in head position (rf2-vxgfnd.266)
+;; ---------------------------------------------------------------------------
+;;
+;; sub/frame are reactive authoring verbs, sound in evaluated code ONLY as
+;; their compiler-owned DIRECT forms — (sub query), (frame) — which the
+;; expression rewriter lowers to
+;; indexed runtime sites. A Hiccup component HEAD is not such a form:
+;; env/classify-head resolves any resolved non-:rf.ui/view var to a plain
+;; :foreign React component, so [sub {…}] / [frame] would
+;; otherwise compile as a foreign component with an EMPTY reactive manifest,
+;; leaving the public authoring var to survive to runtime unindexed and
+;; bypassing reactive-site indexing entirely. These verbs are therefore
+;; RESERVED BEFORE generic component classification — `analyze`'s dispatch
+;; checks this head predicate ahead of `analyze-component`/`env/classify-head`
+;; — so a reactive verb can never be reclassified as foreign. A lexical shadow
+;; resolves to nil (`resolve-sym` skips locals) and falls through to the
+;; ordinary local-head (`:dynamic-head`) rule; a genuine foreign component still
+;; classifies as :foreign.
+
+(defn- reactive-authoring-head-kind
+  "Return :sub/:frame when `head` is an unshadowed symbol resolving to a
+  public reactive authoring var — the reserved-head discriminator, mirroring
+  frame-root-head?/frame-provider-head?."
+  [e head]
+  (when (and (symbol? head) (not (contains? (:locals e) head)))
+    (reactive-authoring-var-kind e head)))
+
+(defn- analyze-reactive-authoring-head! [e form head]
+  (let [kind (reactive-authoring-head-kind e head)]
+    (env/fail! e :rf.ui.compile/unsupported-form
+               (str "reactive authoring verb " (name kind) " in component-head "
+                    "position [" (name kind) " …] — re-frame.freehand/" (name kind)
+                    " is sound ONLY as its compiler-owned direct call head "
+                    (reactive-direct-form kind)
+                    ", which the compiler lowers to an indexed render site. As a "
+                    "Hiccup head it would classify as a plain foreign React "
+                    "component with an empty reactive manifest, leaving the "
+                    "public authoring var to survive to runtime unindexed. Keep "
+                    "the read at a visible " (reactive-direct-form kind) " site")
+               {:form form :reactive-kind kind})))
+
+;; ---------------------------------------------------------------------------
+;; frame-root (S1c, rf2-vxgfnd.3) — the static ENSURE-plan position
+;; ---------------------------------------------------------------------------
+;;
+;; The STATIC TOP REGION of a root form (root-identity contract §6) is every
+;; node reachable from the root without crossing a control form, a dynamic
+;; expression, an internal-view boundary, or a foreign component. The walk
+;; carries `:top-region? true` (set only by the root-form entry points —
+;; `v/mount` / `v/render!` / `v/hydrate-root`); DOM elements, fragments
+;; and frame-root itself PRESERVE the flag for their children, and every
+;; other position clears it. `frame-root` is legal exactly while the flag
+;; holds — plans are static identity, extracted at compile time.
+
+(defn- frame-root-head? [e head]
+  (and (symbol? head)
+       (not (contains? (:locals e) head))
+       (env/resolves-to? e head frame-root-fqns)))
+
+(defn- analyze-frame-root [e form]
+  (when-not (:top-region? e)
+    (env/fail! e :rf.ui.compile/frame-root-misplaced
+               (str "frame-root sits outside the static top region of a root "
+                    "form — ENSURE plans are static identity, extracted at "
+                    "compile time. Legal positions: the root form handed to "
+                    "v/mount / v/render! / v/hydrate-root, nested only "
+                    "under unconditional wrappers (DOM elements, fragments, "
+                    "frame-root) — never under a control form, inside a "
+                    "view, or in a defview template (frames are ambient "
+                    "inside views)")
+               {:form form}))
+  (let [props (nth form 1 nil)]
+    (when-not (map? props)
+      (env/fail! e :rf.ui.compile/bad-frame-root
+                 (str "frame-root takes a literal props map: "
+                      "[frame-root {:id :frame-id ...} children...]")
+                 {:form form}))
+    (when (contains? props :frame)
+      (env/fail! e :rf.ui.compile/bad-frame-root
+                 (str "frame-root ENSURES a frame by :id — :frame is "
+                      "frame-provider's scope key (providers scope, roots "
+                      "ensure; the rf2-nyea0r split)")
+                 {:form form}))
+    (let [id (:id props)]
+      (when-not (keyword? id)
+        (env/fail! e :rf.ui.compile/bad-frame-root
+                   (str "frame-root :id must be a compile-time literal "
+                        "keyword — plans are static identity; got "
+                        (pr-str id))
+                   {:form form :id id}))
+      (let [config (not-empty (dissoc props :id))
+            config* (when config
+                      (with-meta
+                        (into (empty config)
+                              (map (fn [[k v]]
+                                     [k (walk-expr e [:frame-root :config k] v)]))
+                              config)
+                        (meta config)))]
+        ;; config values are opaque runtime expressions (evaluated at
+        ;; preflight) — walk them for sub site indexing only
+        {:op :frame-root
+         :frame-id id
+         :config config*
+         :children (analyze-children e (vec (drop 2 form)))
+         :static? false
+         :path (:path e)}))))
+
+;; ---------------------------------------------------------------------------
+;; frame-provider (S2c, rf2-vxgfnd.9) — the SCOPE form
+;; ---------------------------------------------------------------------------
+;;
+;; frame-provider scopes a subtree to an ALREADY-LIVE frame through the
+;; shared React context — it is legal ANYWHERE a template form is (defview
+;; templates and root forms), unlike the static-top-region-only `frame-root`.
+;; Its `:frame` is a RUNTIME frame TARGET (a frame-id keyword OR a live frame
+;; value), so provider-scoped frames are not statically extractable and
+;; contribute NO plan to the Root Descriptor (root-identity contract §6). In
+;; a root form's top region the walk descends THROUGH a frame-provider (it
+;; preserves `:top-region?` for its children), so a nested `frame-root` plan
+;; is still extracted; the provider itself just scopes.
+
+(defn- frame-provider-head? [e head]
+  (and (symbol? head)
+       (not (contains? (:locals e) head))
+       (env/resolves-to? e head frame-provider-fqns)))
+
+(defn- analyze-frame-provider [e form]
+  (let [props (nth form 1 nil)]
+    (when-not (map? props)
+      (env/fail! e :rf.ui.compile/bad-frame-provider
+                 (str "frame-provider takes a literal props map: "
+                      "[frame-provider {:frame f} children...]")
+                 {:form form}))
+    (when (contains? props :id)
+      (env/fail! e :rf.ui.compile/bad-frame-provider
+                 (str "frame-provider SCOPES an already-live frame by :frame — "
+                      ":id is frame-root's ENSURE key (roots ensure, providers "
+                      "scope; the rf2-nyea0r split). Use frame-root {:id ...} to "
+                      "create-if-absent")
+                 {:form form}))
+    (when-not (contains? props :frame)
+      (env/fail! e :rf.ui.compile/bad-frame-provider
+                 (str "frame-provider requires :frame — the already-live frame "
+                      "target (a frame-id keyword or a live frame value) to "
+                      "scope the subtree to")
+                 {:form form}))
+    (let [extra (dissoc props :frame)]
+      (when (seq extra)
+        (env/fail! e :rf.ui.compile/bad-frame-provider
+                   (str "frame-provider takes only {:frame f}; got extra key"
+                        (when (next extra) "s") " "
+                        (str/join ", " (map pr-str (keys extra)))
+                        " — providers only scope (roots ensure)")
+                   {:form form})))
+    (let [target (:frame props)
+          target* (if (literal-scalar? target)
+                    target
+                    (walk-expr e [:frame-provider :frame] target))]
+      ;; the :frame target is a runtime expression — walk it for sub
+      ;; site indexing (a sub in the target expression is still a site)
+      {:op :frame-provider
+       :frame target*
+       ;; children keep whatever region flag `e` carries: preserved in a
+       ;; root form's top region (nested frame-root plans still extract),
+       ;; absent in a defview template
+       :children (analyze-children e (vec (drop 2 form)))
+       :static? false
+       :path (:path e)})))
+
+(defn- analyze-fragment [e form]
+  (let [second*   (nth form 1 nil)
+        has-props (map? second*)
+        _         (when has-props
+                    (let [extra (dissoc second* :key)]
+                      (when (seq extra)
+                        (env/fail! e :rf.ui.compile/bad-fragment-props
+                                   (str "fragments take only {:key ...}; got "
+                                        (str/join ", " (map pr-str (keys extra))))
+                                   {:form form}))))
+        ;; Key PRESENCE is `:key`'s own presence, never the props map's
+        ;; (rf2-xoz1s). `[:<> {} …]` carries a props map and no key; reporting
+        ;; `:present? true` for it claims an identity the fragment does not
+        ;; have, and every downstream key consumer believes the claim — the
+        ;; presence boundary admits it as keyed and then has nothing to track,
+        ;; `analyze-for` mis-reports the empty map as a CONSTANT key, and the
+        ;; JVM structural tree gains a `:key nil` entry. `contains?` is exactly
+        ;; how `:element`/`:view` probe their own props (`analyze-element-props`
+        ;; / `analyze-component-props`), so the three node kinds now answer the
+        ;; same question the same way and `presence-keyed-child?` reads a true
+        ;; `[:key :present?]` off a `:fragment` without further translation.
+        key?      (and has-props (contains? second* :key))
+        key-form  (when key? (get second* :key))
+        key-form* (if (and key? (not (literal-scalar? key-form)))
+                    (walk-expr e [:fragment :key] key-form)
+                    key-form)
+        children  (analyze-children e (vec (if has-props (drop 2 form) (drop 1 form))))]
+    {:op :fragment
+     :key {:present? key? :expr key-form* :literal? (literal-scalar? key-form)}
+     :children children
+     ;; Deliberately still `has-props`, not `key?`: hoisting is a separate
+     ;; question from identity, and `[:<> {} …]` staying un-hoisted is a missed
+     ;; optimisation rather than a wrong answer. Narrowing it would change
+     ;; emitted code for a shape this bead is not about.
+     :static? (and (not has-props) (every? node-static? children))
+     :path (:path e)}))
+
+;; ---------------------------------------------------------------------------
+;; Control forms
+;; ---------------------------------------------------------------------------
+
+(defn- single-body! [e head body form]
+  (when (not= 1 (count body))
+    (env/fail! e :rf.ui.compile/multi-form-body
+               (str head " in template position takes exactly ONE body form — "
+                    "side effects don't belong in templates (statically-pure "
+                    "rule); siblings wrap in [:<> ...]")
+               {:form form}))
+  (first body))
+
+;; ---------------------------------------------------------------------------
+;; Host hooks — `effect` statements + the `local`/`effect` hooks region
+;; ---------------------------------------------------------------------------
+
+(defn effect-statement-form?
+  "True when `form` is a direct, unshadowed call resolving to public
+  `re-frame.freehand/effect` — the only form allowed to occupy the leading statement
+  prefix of a hooks region (a defview's top body or a top-region let/do body)."
+  [e form]
+  (and (seq? form)
+       (symbol? (first form))
+       (not (contains? (:locals e) (first form)))
+       (env/resolves-to? e (first form) effect-fqns)))
+
+(defn- analyze-effect-statement
+  "Analyze one leading `(effect …)` statement -> the lowered runtime call form.
+  `(effect [deps…] body…)` compares deps by rf= (value deps); `(effect :connect
+  body…)` runs at each connect. The body is a DEFERRED callback (sub/frame
+  inside are rejected); it is spliced before the template by `analyze-hooks-body`."
+  [e index form]
+  ;; The purity fence is TRANSITIVE: a render-fn slot body inherits the enclosing
+  ;; hooks region, so a leading (effect …) would otherwise reach this seam and be
+  ;; emitted as a React lifecycle hook INSIDE the deferred callback. A slot body
+  ;; is a PURE render fragment — its effects belong to the owning view or a
+  ;; mounted defview (rf2-vtfzn).
+  (when (:in-render-fn? e)
+    (env/fail! e :rf.ui.compile/impure-slot-body
+               (str "(effect …) inside a v/render-fn slot body — a slot body is a "
+                    "PURE render fragment; a host effect is a lifecycle hook, which "
+                    "a slot body may not own. Run the effect in the OWNING view, or "
+                    "MOUNT a defview that owns its own effects")
+               {:form form}))
+  (when (or (nil? (:self-id e)) (not (:hooks-region? e)))
+    (env/fail! e :rf.ui.compile/hook-misplaced
+               (str "(effect …) is a host-effect statement — legal ONLY in a "
+                    "defview's UNCONDITIONAL top region (or a top-region let/do "
+                    "body), before the final template")
+               {:form form}))
+  (let [[_ deps-or-kw & body] form
+        sid (lexical-site-id e :effect form [:effect index])]
+    (when (empty? body)
+      (env/fail! e :rf.ui.compile/bad-effect
+                 (str "(effect [deps…] body…) / (effect :connect body…) needs a "
+                      "body form after the deps")
+                 {:form form}))
+    (letfn [(body-fn [] ; the deferred callback fn — the fn walk rejects sub/frame
+              (walk-expr e [:effect index :body]
+                         (with-meta (apply list 'fn [] body) (meta form))))]
+      (cond
+        (= :connect deps-or-kw)
+        (do
+          (env/add-site! e :effects {:sid sid :kind :connect :index index
+                                     :path (:path e) :expr-path [:effect index]})
+          (with-meta (list runtime-effect-connect-fqn (body-fn)) (meta form)))
+
+        (vector? deps-or-kw)
+        (let [deps* (mapv (fn [i d] (walk-expr e [:effect index :dep i] d))
+                          (range) deps-or-kw)]
+          (env/add-site! e :effects {:sid sid :kind :deps :index index
+                                     :path (:path e) :expr-path [:effect index]})
+          (with-meta (list runtime-effect-value-fqn (body-fn) (vec deps*))
+            (meta form)))
+
+        :else
+        (env/fail! e :rf.ui.compile/bad-effect
+                   (str "(effect …) first argument must be a literal deps VECTOR "
+                        "(value deps compared by rf=) or the keyword :connect; got "
+                        (pr-str deps-or-kw))
+                   {:form form})))))
+
+(defn- analyze-hooks-body
+  "Analyze a hooks-region body: zero or more leading `(effect …)` STATEMENTS,
+  then exactly ONE final template. Returns the template AST, wrapped in a
+  `:hook-prefix` node carrying the lowered effect statement forms when any are
+  present (the emitters splice them before the template as a `do` sequence)."
+  [e head body form]
+  (loop [effects [] forms (seq body) index 0]
+    (cond
+      (nil? forms)
+      (env/fail! e :rf.ui.compile/multi-form-body
+                 (str head " needs exactly ONE final template after any leading "
+                      "(effect …) statements")
+                 {:form form})
+
+      (effect-statement-form? e (first forms))
+      (recur (conj effects (analyze-effect-statement e index (first forms)))
+             (next forms) (inc index))
+
+      (next forms)
+      (env/fail! e :rf.ui.compile/multi-form-body
+                 (str head " in template position takes leading (effect …) "
+                      "statements then exactly ONE template form — side effects "
+                      "don't belong in templates (statically-pure rule); siblings "
+                      "wrap in [:<> ...]")
+                 {:form form})
+
+      :else
+      (let [tmpl (analyze e (first forms))]
+        (if (seq effects)
+          {:op :hook-prefix :statements effects :body tmpl
+           :static? false :path (:path e)}
+          tmpl)))))
+
+(defn- analyze-if [e test then else form]
+  ;; Branches are CONDITIONAL — host hooks (local/effect) are illegal below them
+  ;; (React hooks run unconditionally, once per render, in fixed order).
+  (let [eb (assoc e :hooks-region? false)]
+    {:op :if :test (walk-expr e [:if :test] test)
+     :then (analyze (update eb :path conj :then) then)
+     :else (if (some? else)
+             (analyze (update eb :path conj :else) else)
+             {:op :nothing :static? true})
+     :static? false :path (:path e)}))
+
+(defn- analyze-cond [e clauses form]
+  (cond
+    (empty? clauses) {:op :nothing :static? true}
+    (odd? (count clauses))
+    (env/fail! e :rf.ui.compile/bad-cond
+               "cond needs test/branch pairs: (cond test1 branch1 ... :else fallback)"
+               {:form form})
+    :else
+    (let [[t b & more] clauses]
+      (if (= :else t)
+        (analyze e b)
+        (analyze-if e t b (when (seq more) (cons 'cond more)) form)))))
+  ;; note: the recursive else is re-entered through analyze-list as (cond ...)
+
+(defn- analyze-case [e form]
+  (let [[_ expr & clauses] form]
+    (let [default? (odd? (count clauses))
+          pairs    (partition 2 (if default? (butlast clauses) clauses))
+          default  (when default? (last clauses))
+          eb       (assoc e :hooks-region? false)]
+      {:op :case
+       :expr (walk-expr e [:case :expr] expr)
+       :clauses (into []
+                      (map-indexed (fn [i [test branch]]
+                                     [test (analyze (update eb :path conj [:case i]) branch)]))
+                      pairs)
+       :default (if default?
+                  (analyze (update eb :path conj :case-default) default)
+                  ::none)
+       :static? false
+       :path (:path e)})))
+
+(defn- analyze-let [e form]
+  (let [[head bindings & body] form]
+    (when-not (and (vector? bindings) (even? (count bindings)))
+      (env/fail! e :rf.ui.compile/bad-let
+                 (str head " needs an even bindings vector") {:form form}))
+    (let [pairs (partition 2 bindings)
+          [e* rewritten]
+          (reduce (fn [[acc out] [i [pat init]]]
+                    (reject-reactive-binding! acc pat)
+                    [(env/with-locals acc (env/binding-syms pat))
+                     (conj out pat
+                           (walk-expr acc [:let :binding i] init))])
+                  [e []]
+                  (map-indexed vector pairs))
+          bindings* (with-meta (vec rewritten) (meta bindings))
+          eb        (update e* :path conj :body)]
+      {:op :let :bindings bindings*
+       ;; A top-region let keeps its body in the hooks region, so leading
+       ;; (effect …) statements are legal there; a let below a branch/loop is
+       ;; not, so it is the strict single-template body.
+       :body (if (:hooks-region? eb)
+               (analyze-hooks-body eb (str head) body form)
+               (analyze eb (single-body! eb (str head) body form)))
+       :static? false :path (:path e)})))
+
+(defn- analyze-letfn [e form]
+  (let [[_ fnspecs & body] form]
+    (when-not (vector? fnspecs)
+      (env/fail! e :rf.ui.compile/bad-let "letfn needs a fnspecs vector" {:form form}))
+    (let [names (map first fnspecs)
+          e*    (env/with-locals e names)
+          ;; Reuse the opaque rewriter's exact letfn scoping (all names in
+          ;; scope for every body; each argv shadows vars within its arity).
+          fnspecs* (second
+                     (walk-expr e [:letfn :bindings]
+                                (list 'letfn fnspecs nil)))]
+      (let [body-form (single-body! e "letfn" body form)]
+        {:op :letfn :fnspecs fnspecs*
+         :body (analyze (update e* :path conj :body) body-form)
+         :static? false :path (:path e)}))))
+
+(defn- analyze-for [e form]
+  (let [[_ seq-exprs & body] form]
+    (when-not (and (vector? seq-exprs) (even? (count seq-exprs)) (seq seq-exprs))
+      (env/fail! e :rf.ui.compile/bad-for
+                 "(for [pattern coll ...modifiers] body) needs a non-empty, even seq-exprs vector"
+                 {:form form}))
+    (let [pairs (partition 2 seq-exprs)]
+      (when (keyword? (ffirst pairs))
+        (env/fail! e :rf.ui.compile/bad-for
+                   "for needs a binding pair before modifiers" {:form form}))
+      ;; Rewrite in evaluation order. The first collection evaluates once per
+      ;; view render; after its binding every later collection/modifier is
+      ;; row-scoped and therefore rejects sub sites.
+      (let [[e-final rewritten]
+            (loop [scope e
+                   first-coll? true
+                   ps (seq (map-indexed vector pairs))
+                   out []]
+              (if-let [[i [l r]] (first ps)]
+                (cond
+                  (= :let l)
+                  (do
+                    (when-not (and (vector? r) (even? (count r)))
+                      (env/fail! e :rf.ui.compile/bad-for
+                                 ":let modifier needs an even bindings vector"
+                                 {:form form}))
+                    (let [[scope* binds*]
+                          (reduce (fn [[s xs] [j [pat init]]]
+                                    (reject-reactive-binding! s pat)
+                                    [(env/with-loop s (env/binding-syms pat))
+                                     (conj xs pat
+                                           (walk-expr (assoc s :in-loop? true)
+                                                      [:for i :let j] init))])
+                                  [scope []]
+                                  (map-indexed vector (partition 2 r)))]
+                      (recur scope* false (next ps)
+                             (conj out l (with-meta (vec binds*) (meta r))))))
+
+                  (contains? #{:when :while} l)
+                  (recur scope false (next ps)
+                         (conj out l
+                               (walk-expr (assoc scope :in-loop? true)
+                                          [:for i l] r)))
+
+                  (keyword? l)
+                  (env/fail! e :rf.ui.compile/bad-for
+                             (str "unknown for modifier " l " — the subgrammar is "
+                                  ":let / :when / :while (Q6 pin)")
+                             {:form form})
+
+                  :else
+                  (let [_  (reject-reactive-binding! scope l)
+                        r* (walk-expr (if first-coll?
+                                        scope
+                                        (assoc scope :in-loop? true))
+                                      [:for i :collection] r)]
+                    (recur (env/with-loop scope (env/binding-syms l))
+                           false (next ps) (conj out l r*))))
+                [scope out]))
+            seq-exprs* (with-meta (vec rewritten) (meta seq-exprs))
+            e-body    (-> e-final (update :path conj :for)
+                          (assoc :hooks-region? false))
+            body-form (single-body! e "for" (vec body) form)
+            _         (when (and (seq? body-form) (= 'for (first body-form)))
+                        (env/fail! e :rf.ui.compile/nested-for-body
+                                   (str "a for directly inside a for body — express "
+                                        "nested iteration as multiple binding pairs in "
+                                        "ONE for: (for [x xs, y (f x)] ...) — one keyed "
+                                        "list site (Q6 pin)")
+                                   {:form form}))
+            body-ast  (analyze e-body body-form)]
+        (when-not (contains? #{:element :view :foreign :fragment} (:op body-ast))
+          (env/fail! e :rf.ui.compile/unkeyed-list-item
+                     (str "for body must be a keyed element/view/fragment — got "
+                          (name (:op body-ast)) ". Keyed lists compile to direct "
+                          "JS arrays; missing key = build failure")
+                     {:form form}))
+        (let [k (get-in body-ast [:props :key] (get body-ast :key))]
+          (when-not (:present? k)
+            (env/fail! e :rf.ui.compile/unkeyed-list-item
+                       (str "missing :key on the for body — every list row needs "
+                            "a literal :key prop (unkeyed list items are a build "
+                            "failure)")
+                       {:form form}))
+          (when (:literal? k)
+            (env/fail! e :rf.ui.compile/constant-list-key
+                       (str "constant :key " (pr-str (:expr k)) " in a list — a "
+                            "key must vary per row (a constant key guarantees "
+                            "duplicates). Key on row data: {:key (:id x)}")
+                       {:form form})))
+        {:op :for
+         :seq-exprs seq-exprs*
+         :body body-ast
+         :static? false
+         :path (:path e)}))))
+
+;; ---------------------------------------------------------------------------
+;; Dispatch
+;; ---------------------------------------------------------------------------
+
+(defn analyze-view-body
+  "Analyze a defview body remainder: zero or
+  more leading `(effect …)` statements, then exactly ONE final template. The
+  env must carry `:hooks-region? true` and `:self-id`. Returns the body AST
+  (a `:hook-prefix` node when effect statements are present)."
+  [e forms]
+  (analyze-hooks-body e "defview" forms (cons 'defview-body forms)))
+
+(defn- analyze-list [e form]
+  (let [head (first form)
+        fam  (if-let-family-config e head)]
+    (cond
+      ;; if-let / when-let / if-some / when-some (rf2-u53yy.4): admitted
+      ;; conditional binders, RESOLVER-confirmed against the core binder vars (a
+      ;; same-spelled user macro is NOT admitted; a local shadow yields no
+      ;; resolution and falls through to an ordinary call). Desugar into the
+      ;; analyzer's own let + if and re-analyze — the branch is a conditional
+      ;; (its then/else leave the hooks region, exactly like if/when), the init
+      ;; lowers a finite reactive site, and the pattern's reactive-escape is
+      ;; rejected, all through the existing template machinery.
+      fam
+      (analyze e (desugar-if-let e head fam (binder-temp (:path e)) form))
+
+      (and (symbol? head)
+           (contains? control-heads head)
+           (not (contains? (:locals e) head)))
+      (case head
+        if       (let [[_ t a b & extra] form]
+                   (when (seq extra)
+                     (env/fail! e :rf.ui.compile/bad-if "if takes test then else?" {:form form}))
+                   (analyze-if e t a b form))
+        if-not   (let [[_ t a b & extra] form]
+                   (when (seq extra)
+                     (env/fail! e :rf.ui.compile/bad-if "if-not takes test then else?" {:form form}))
+                   (analyze-if e (list 'not t) a b form))
+        when     (let [[_ t & body] form]
+                   (analyze-if e t (single-body! e "when" (vec body) form) nil form))
+        when-not (let [[_ t & body] form]
+                   (analyze-if e (list 'not t) (single-body! e "when-not" (vec body) form) nil form))
+        cond     (analyze-cond e (rest form) form)
+        case     (analyze-case e form)
+        let      (analyze-let e form)
+        letfn    (analyze-letfn e form)
+        do       (if (:hooks-region? e)
+                   (analyze-hooks-body e "do" (vec (rest form)) form)
+                   (analyze e (single-body! e "do" (vec (rest form)) form)))
+        for      (analyze-for e form))
+
+      :else
+      (cond
+        (raw-form? e form)
+        (let [[_ x & extra] form]
+          (when (or (nil? x) (seq extra))
+            (env/fail! e :rf.ui.compile/bad-raw "(v/raw react-element) takes one argument"
+                       {:form form}))
+          {:op :raw :form (walk-expr e [:raw] x)
+           :static? false :path (:path e)})
+
+        (html-form? e form)
+        (env/fail! e :rf.ui.compile/html-not-sole-child
+                   (str "(v/html ...) must be the sole child of a DOM element "
+                        "— here it has no host element to own the markup. Wrap "
+                        "it: [:div (v/html s)] (conservative S1 pin)")
+                   {:form form})
+
+        (raw-fn-form? e form)
+        (env/fail! e :rf.ui.compile/raw-fn-child
+                   "(v/raw-fn f) is a callback marker for prop positions, not renderable content"
+                   {:form form})
+
+        (slot-form? e form)
+        (analyze-slot e form)
+
+        (error-boundary-form? e form)
+        (analyze-error-boundary e form)
+
+        (client-only-form? e form)
+        (analyze-client-only e form)
+
+        (presence-form? e form)
+        (analyze-presence e form)
+
+        (render-fn-form? e form)
+        (env/fail! e :rf.ui.compile/render-fn-misplaced
+                   (str "(v/render-fn …) is a render-slot callback value, not "
+                        "renderable content — invoke it with (v/slot render-fn "
+                        "arg…), or pass it as a component prop value")
+                   {:form form})
+
+        (spread-form? e form)
+        (env/fail! e :rf.ui.compile/bad-spread
+                   "(v/spread ...) belongs in a DOM element's props position: [:div (v/spread base overrides)]"
+                   {:form form})
+
+        (spread-safe-form? e form)
+        (env/fail! e :rf.ui.compile/bad-spread-safe
+                   "(v/spread-safe ...) belongs in a DOM element's props position: [:input (v/spread-safe {:value v :on-change …} caller)]"
+                   {:form form})
+
+        (and (symbol? head) (not (contains? (:locals e) head))
+             (env/resolves-to? e head markup-map-fqns))
+        (env/fail! e :rf.ui.compile/markup-returning-map
+                   (str "(" head " f coll) in child position — markup-returning "
+                        "map is rejected: it hides keys and laziness. Use "
+                        "(for [x coll] [row {:key (:id x)}])")
+                   {:form form})
+
+        (and (symbol? head) (not (contains? (:locals e) head))
+             (env/resolves-to? e head lazy-seq-fqns))
+        (env/fail! e :rf.ui.compile/lazy-seq-child
+                   (str "(" head " ...) in child position produces a raw seq — "
+                        "raw lazy seqs are rejected: they hide keys and "
+                        "laziness. Render rows with (for [x coll] "
+                        "[row {:key (:id x)}]); render text with "
+                        "(str/join ...)")
+                   {:form form})
+
+        :else
+        {:op :expr :form (walk-expr e [:expr] form)
+         :static? false :path (:path e)}))))
+
+;; ---------------------------------------------------------------------------
+;; Vector-head precedence (rf2-vxgfnd.274)
+;; ---------------------------------------------------------------------------
+;;
+;; A symbol head classifies by RESOLUTION at expansion time (the Q5 rule,
+;; env/classify-head), but two reservations run in `analyze`'s dispatch
+;; AHEAD of `env/classify-head`: the frame-boundary heads (frame-root /
+;; frame-provider) and the reactive-authoring verbs (sub / frame,
+;; rf2-vxgfnd.266). Both key on Var resolution — so a head equal to the view
+;; being `defview`d right now (`:self`) that ALSO resolves to a referred
+;; public authoring Var (`(defview sub [] [sub …])` in a namespace that
+;; refers `re-frame.freehand/sub`) was reserved-then-rejected BEFORE the Q5
+;; self-recursion rule could select it as an internal view — even though the
+;; view Var may not exist yet, so classification here cannot depend on Var
+;; resolution at all (Q5 rule 1). The one true precedence ordering is:
+;;
+;;   1. a local/dynamic binding of the spelling (checked inside every head
+;;      predicate and env/classify-head) — a lexical shadow outranks self;
+;;   2. the exact, unshadowed `:self` — an internal-view head, resolution-free;
+;;   3. the reserved frame-boundary / reactive-authoring heads (Var-resolved);
+;;   4. ordinary internal/foreign classification (env/classify-head).
+;;
+;; `self-head?` is tier 2 — it fires before every reserved-head predicate so a
+;; genuine self-recursive head is never reclassified as a reserved verb.
+
+(defn- self-head?
+  "True when `head` is the exact, unshadowed symbol of the view currently
+  being compiled (`:self`). Self-recursion outranks every reserved-head
+  reservation because the view Var may not exist yet — classification cannot
+  depend on Var resolution here (Q5 rule 1). A local binding of the same
+  spelling (checked first) still outranks self and yields a dynamic head."
+  [e head]
+  (and (:self e)
+       (symbol? head)
+       (= head (:self e))
+       (not (contains? (:locals e) head))))
+
+(defn analyze
+  "Template form -> AST node."
+  [e form]
+  (cond
+    (string? form)  {:op :text :value form :static? true}
+    (number? form)  {:op :text :value (rules/js-number-str form) :static? true}
+    (nil? form)     {:op :nothing :static? true}
+    (boolean? form) {:op :nothing :static? true}
+    (keyword? form) (env/fail! e :rf.ui.compile/keyword-child
+                               (str "keyword " form " in child position — keywords are "
+                                    "element heads, not content. String content wants "
+                                    (pr-str (name form)))
+                               {:form form})
+    (vector? form)
+    (let [head (nth form 0 nil)]
+      (cond
+        (= :<> head)     (analyze-fragment e form)
+        (keyword? head)  (analyze-element e form)
+        ;; The exact unshadowed self outranks every reserved-head reservation
+        ;; below (rf2-vxgfnd.274): the view Var may not exist yet, so a
+        ;; self-recursive head classifies as an internal view up front —
+        ;; resolution-free — before any Var-resolved reservation (frame
+        ;; boundary / reactive authoring) can reclassify it.
+        (self-head? e head) (analyze-component e form)
+        (frame-root-head? e head) (analyze-frame-root e form)
+        (frame-provider-head? e head) (analyze-frame-provider e form)
+        ;; Reserve sub/frame BEFORE generic component classification
+        ;; (rf2-vxgfnd.266): a reactive authoring verb can never be
+        ;; reclassified as a :foreign component with an empty manifest.
+        (reactive-authoring-head-kind e head)
+        (analyze-reactive-authoring-head! e form head)
+        (symbol? head)   (analyze-component e form)
+        :else
+        (env/fail! e :rf.ui.compile/dynamic-head
+                   (str "dynamic element head " (pr-str head) " — heads must be "
+                        "literal (a keyword or a component var). Runtime-chosen "
+                        "components are v/view / v/element [WAVE-2]; v/raw "
+                        "covers a runtime React element meanwhile")
+                   {:form form})))
+    ;; a control form / opaque expression ends the static top region (S1c)
+    (seq? form)     (analyze-list (dissoc e :top-region?) form)
+    (symbol? form)  {:op :expr :form (walk-expr e [:expr] form)
+                     :static? false :path (:path e)}
+    :else
+    (env/fail! e :rf.ui.compile/unsupported-form
+               (str "unsupported template form " (pr-str form) " of type "
+                    (type form) " — template content is strings/numbers/"
+                    "nil/false, [:tag ...] vectors, control forms, and "
+                    "expressions. Render a value as text with (str ...)")
+               {:form form})))

--- a/implementation/freehand/src/re_frame/freehand/compiler/binding_plan.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/binding_plan.cljc
@@ -1,0 +1,172 @@
+(ns re-frame.freehand.compiler.binding-plan
+  "The ONE canonical, host-faithful associative-destructuring binding plan.
+
+  A map destructuring pattern (`{:keys [x] x :foo}`, `{:keys [acct/id]}`, …)
+  has EXACTLY ONE meaning: whatever `clojure.core/destructure` binds. Both hosts
+  run `destructure` on the JVM at macro-expansion time, so reproducing its
+  remaining-bindings transformation here — rather than invoking a general
+  macroexpander — yields a plan that is faithful to CLJ and CLJS alike.
+
+  This plan is the SINGLE authority every consumer routes through, so none can
+  drift from another or from the host:
+
+  - the analyzer's reactive-binding scope walk (`analyze/check-binding-scope!`);
+  - the defview header parser (`header/parse-header`), whose emitted binding
+    units, schema slots, comparator inputs and manifest metadata are all read
+    off these collapsed entries;
+  - and, transitively, both emitters — the JVM emitter destructures the raw
+    pattern natively; the CLJS emitter lowers exactly these units to property
+    reads. Because the units are the host's collapse, the two emitters agree.
+
+  The critical property is COLLAPSE at the host `bes` map: when two entries share
+  a `bes` KEY (`{:keys [x] x :foo}` — the group directive's `assoc` overwrites the
+  explicit `x`), the host keeps ONE binding with ONE winning lookup key
+  (`x <- :x`), and so does this plan — never two bindings, never a silent
+  last-wins. A qualified group local (`{:keys [acct/id]}`) keeps its qualified
+  lookup key (`:acct/id`), never a bare `:id`.
+
+  One residual case does NOT collapse here, deliberately: a qualified group local
+  whose bare NAME collides an explicit local (`{:keys [ns/x] x :other}`) keeps two
+  DISTINCT `bes` keys (`ns/x`, `x`) that both name-strip to the same local `x`. The
+  host binds it once via `let` last-wins (`x <- :ns/x`), but the two units must
+  stay separate HERE so the analyzer's scope walk judges each unit's lookup-key /
+  `:or` default against the scope live at ITS binding point. The defview header
+  parser (`header/collapse-entries`) folds these two units to the single winning
+  entry for its derived slots; the general scope walk keeps both.")
+
+(defn key-group-kw?
+  "True for a `:keys`/`:strs`/`:syms` map-destructuring group directive (any
+  namespace: `:person/keys` too). Its map-entry VALUE is a vector of symbols;
+  its keys are keyword/string/symbol LITERALS, never evaluated expressions."
+  [k]
+  (and (keyword? k) (contains? #{"keys" "strs" "syms"} (name k))))
+
+(defn key-group-directive-fn
+  "The lookup-key transform host `destructure` applies to a `:keys`/`:strs`/
+  `:syms` group directive `mk` (any namespace). This is the SHARED CLJ/CLJS
+  transform — both hosts run `destructure` on the JVM at macro-expansion time —
+  reproduced verbatim so the produced key (and, through it, the map's iteration
+  order) matches the host exactly."
+  [mk]
+  (let [mkns (namespace mk)]
+    (case (name mk)
+      "keys" #(keyword (or mkns (namespace %)) (name %))
+      "syms" #(list 'quote (symbol (or mkns (namespace %)) (name %)))
+      "strs" str)))
+
+(defn assoc-binding-units
+  "The associative-destructuring binding units of map `pattern`, in the EXACT
+  host `destructure` `bes` order — the ONE canonical, host-faithful binding
+  plan every consumer shares, so none can drift from another or from the host.
+
+  It reproduces `destructure`'s remaining-bindings transformation rather than
+  invoking a general macroexpander: start from `(dissoc pattern :as :or)`, then
+  for each group directive — in the order it appears in the pattern's keys —
+  `dissoc` the directive and `assoc` each expanded local exactly as the host
+  does, and read the units off `(seq bes)` in the resulting map-iteration order.
+  Small patterns stay a `PersistentArrayMap` (insertion order); at nine or more
+  remaining bindings the host promotes to a `PersistentHashMap` and the order
+  becomes hash-driven. Because every host computes this on the JVM the 8→9
+  threshold and the hash order are identical on CLJ and CLJS, so reproducing the
+  transform here is faithful to both.
+
+  Two entries that share a `bes` KEY COLLAPSE, exactly as the host's `bes` map
+  collapses them: `{:keys [x] x :foo}` yields the single unit `x <- :x` (the
+  group directive's `assoc` overwrites the explicit entry's value), never two
+  bindings and never a silent last-wins. A group local keeps its QUALIFIED
+  lookup key: `{:keys [acct/id]}` yields `id <- :acct/id`, never bare `:id`. A
+  qualified group local whose bare name collides an explicit local
+  (`{:keys [ns/x] x :other}`) keeps DISTINCT `bes` keys and so stays TWO units
+  binding one local via host last-wins — consumed in order by the scope walk;
+  the header parser (`collapse-entries`) folds them for its derived slots.
+
+  `:as` is NOT included — it binds first, before `bes`, so the caller seeds it
+  into scope. Each unit is `{:local-pattern p :key k :explicit? bool}`:
+  `:local-pattern` is the bound local (a simple symbol for a group local, or the
+  written local pattern — possibly nested — for an explicit `{p key}` entry);
+  `:key` is the WINNING lookup key after collapse (an EVALUATED expression for an
+  explicit entry, or the produced literal keyword/string/quoted-symbol for a
+  group local); `:explicit?` marks the units whose `:key` is a user-written
+  expression (a scope walk must judge those for a reactive-authoring escape; a
+  group literal never is). The units are consumed in order so each binding's
+  default/lookup-key is judged against the scope established BEFORE it — never
+  against a symbol the same pattern binds later, and never in an order the host
+  would not use."
+  [pattern]
+  (let [start      (dissoc pattern :as :or)
+        transforms (reduce (fn [t k] (if (key-group-kw? k) (assoc t k true) t))
+                           {} (keys pattern))
+        explicit   (set (keys (reduce dissoc start (keys transforms))))
+        bes        (reduce
+                    (fn [bes [mk _]]
+                      (let [f (key-group-directive-fn mk)]
+                        (reduce (fn [b s] (assoc b s (f s)))
+                                (dissoc bes mk)
+                                (get bes mk))))
+                    start
+                    transforms)]
+    (for [[bb bk] bes]
+      (if (contains? explicit bb)
+        {:local-pattern bb :key bk :explicit? true}
+        ;; Reconstruct the group local exactly as the host does — name-stripped
+        ;; (`{:keys [acct/id]}` binds `id`), but carrying the AUTHORED symbol's
+        ;; metadata (`(with-meta (symbol nil (name bb)) (meta bb))`), so a `^js`
+        ;; or other portable type hint survives to the CLJS `let` binding and its
+        ;; Closure interop inference. Only the host's existing metadata is kept;
+        ;; nothing is invented, matching `clojure.core/destructure` verbatim.
+        {:local-pattern (with-meta (symbol nil (name bb)) (meta bb))
+         :key bk :explicit? false}))))
+
+(defn binding-order
+  "The local-patterns of map `pattern`, in host `destructure` `bes` order
+  (`:as` excluded — it binds first). One plan (`assoc-binding-units`), so a
+  dependent `:or` default resolves to the same symbol on every host."
+  [pattern]
+  (mapv :local-pattern (assoc-binding-units pattern)))
+
+(defn pattern-locals
+  "The set of local symbols a destructuring binding PATTERN introduces, exactly
+  as host `destructure` binds them. This is the host-faithful primitive a
+  DERIVED-slot consumer uses to judge which binding units survive host `let`
+  last-wins shadowing: a unit whose every local a LATER unit rebinds contributes
+  no final visible local, so its lookup key is a dead slot even though its
+  initializer still runs (`assoc-binding-units` keeps it in the executable plan).
+
+  A simple symbol binds itself. A sequential `[a b & more :as all]` binds each
+  element pattern (recursively), the rest pattern and `:as`. An associative
+  `{:keys [...] p key :as s :or {...}}` binds each group local NAME-STRIPPED
+  (`:keys [ns/x]` binds `x`, exactly as the plan's group locals arrive), each
+  explicit sub-pattern (recursively), and `:as`. Directives (`:or`, the group
+  keyword) and lookup keys are not locals; the `&` marker is dropped.
+
+  Comparing the LOCALS a pattern binds — not whole `:pattern` values — is what
+  lets a nested or partially overlapping pattern collapse faithfully: a symbol
+  `x <- :ns/x` shadows the `x` a sibling `[x] <- :other` binds (whole-pattern
+  equality would miss it, leaking `:other`), while `[a b] <- :other` survives
+  beside `a <- :ns/a` because `b` is still a final visible local."
+  [pattern]
+  (cond
+    (symbol? pattern)
+    (if (= '& pattern) #{} #{pattern})
+
+    (vector? pattern)
+    (loop [ps (seq pattern), acc #{}]
+      (if (nil? ps)
+        acc
+        (let [p (first ps)]
+          (if (or (= :as p) (= '& p))
+            (recur (nnext ps) (into acc (pattern-locals (second ps))))
+            (recur (next ps)  (into acc (pattern-locals p)))))))
+
+    (map? pattern)
+    (reduce-kv
+     (fn [acc k v]
+       (cond
+         (= k :as)         (into acc (pattern-locals v))
+         (= k :or)         acc
+         (key-group-kw? k) (into acc (map (fn [s] (symbol nil (name s)))) v)
+         :else             (into acc (pattern-locals k))))
+     #{}
+     pattern)
+
+    :else #{}))

--- a/implementation/freehand/src/re_frame/freehand/compiler/build.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/build.cljc
@@ -1,0 +1,1291 @@
+(ns re-frame.freehand.compiler.build
+  "The build-scoped compiler registries and Option-C acceptance transaction.
+
+  A real Shadow build carries its own state. Its retained `:compiler-env`
+  contains one accepted `{build-id registries version}` snapshot and,
+  only while compiling, disposable scratch. Macro expansion mutates scratch
+  through the bound `cljs.env/*compiler*` atom. Compile finish returns a new
+  build-state containing the candidate snapshot; Shadow retaining that value
+  after the entire configured pipeline succeeds IS the commit. A later
+  optimize/check/flush/watch failure discards it. There is no process-global
+  latest-build atom and no private completion callback.
+
+  One daemon can compile many build ids concurrently because each build's
+  functional state and compiler-env are independent. JVM tooling outside a
+  compiler binding must pass the explicit retained build-state it wants to
+  read (`accepted-snapshot`, `accepted-aggregate`).
+
+  A compile slice has the shape:
+
+    {:pass-open? bool
+     :authoritative-members #{ns ...} | nil
+     :committed  {source {reg-id {k v}}}   ; last-known-good, per source
+     :staged     {source {reg-id {k v}}}   ; the OPEN pass's re-declarations
+     :touched    #{source}}                ; sources that re-ran this pass
+
+  `source` is the declaring NAMESPACE symbol (the compile unit — matching
+  the runtime arm's `[build-id ns-sym]` key; file/line live in error coords
+  only, so a REPL pseudo-file never forges a false duplicate and Windows
+  path normalization is a non-issue).
+
+  The effective aggregate is accepted rows of untouched sources plus staged
+  rows for sources recompiled in this pass. Source replacement and every
+  collision check happen inside one compiler-env `swap!`, so parallel macro
+  expansion cannot create an evict/re-add gap or check/write race. Finish
+  commits touched rows and evicts sources absent from Shadow's authoritative
+  `:build-sources` graph; cache silence is never treated as deletion.
+
+  Direct no-pass REPL contributions use a separate overlay seeded from the
+  accepted snapshot. They support immediate body/HMR diagnostics but never
+  change accepted registries; the next prepare clears the
+  overlay and seeds fresh scratch from accepted state.
+
+  `state` plus begin/commit/abort below remain only as a plain-JVM/test harness
+  for the same pure slice transitions. They are not Shadow build authority."
+  (:require [re-frame.freehand.eq :as eq]))
+
+;; ---------------------------------------------------------------------------
+;; Registry ids (opaque keys naming the five build-scoped registries)
+;; ---------------------------------------------------------------------------
+
+(def views       ::views)        ; view-id -> [template-fp hook-sig] (digest)
+(def ^:private view-declarations ::view-declarations) ; view-id -> [ns var]
+(def view-static ::view-static)  ; view-id -> {:caps #{..} :deps #{..}} (static-root proof, Spec 004C §3; plain-JVM/SSR slice, rf2-u53yy.1 S3)
+(def roots       ::roots)        ; Layer-1 root-site index
+(def plans       ::plans)        ; Layer-1 frame-plan index
+(def descriptors ::descriptors)  ; Root Descriptor index
+(def elements    ::elements)     ; compile-time custom-element declarations (plain-JVM/SSR slice)
+(def ^:private element-declarations ::element-declarations) ; tag -> owning ns
+
+;; Custom-element declarations are DECOUPLED from the view-slice on the Shadow
+;; build path (rf2-u53yy.1 S1). Property lowering is decided at MACROEXPANSION,
+;; before compile-finish, so elements are the one ordering exception that cannot
+;; ride the compile-finish analyzer-map carrier the other registries use. Instead
+;; the build hook HARVESTS every authoritative build member's literal
+;; declarations at `:compile-prepare` (`harvest.clj`, a bounded syntactic reader)
+;; into a flat all-members manifest `{tag {:properties #{…}}}` — a pure function
+;; of the build's SOURCE, independent of which sources re-expand. That manifest
+;; lives beside the accepted snapshot (`:elements`) and in the open pass's scratch
+;; (`:element-manifest`), NEVER in the per-source `:committed`/`:staged`/`:touched`
+;; ledger, so harvesting a WARM source's elements can no longer mark it touched
+;; and evict its committed views at commit. The `v/custom-element` macro is then
+;; validation/reporting-only during a real Shadow build pass. The plain-JVM / SSR
+;; and REPL paths (no `:compile-prepare` hook) keep populating the per-source
+;; `::elements` slice through the macro + lazy own-source harvest below.
+
+;; `::view-static` is similarly DECOUPLED from the Shadow build path (rf2-u53yy.1
+;; S3), but by the simplest mechanism of all: its ONLY reader, `v/render-static`,
+;; is JVM-only (a CLJS expansion is rejected), so a real Shadow build never reads
+;; it. Unlike `views`/`elements` it is not blocker/eviction-relevant, so it needs
+;; NO cache-durable Shadow-path descriptor — the `defview` macro simply does not
+;; contribute it under a Shadow build pass (`shadow-build-pass?`), keeping the
+;; Shadow-path registries macro-independent (the S6 direction). The per-source
+;; slice here is populated + read only on the plain-JVM / SSR / REPL path, where
+;; render-static reads it MID-EXPANSION; the same per-view `{:caps :deps}` facts
+;; also ride each view's registered manifest (`:static-facts`) for cross-build/AOT
+;; resolution.
+
+;; ---------------------------------------------------------------------------
+;; State
+;; ---------------------------------------------------------------------------
+
+(def ^{:private true
+       :doc "An empty per-build slice — the pure transition seed."}
+  empty-slice
+  {:pass-open? false
+   :authoritative-members nil
+   :committed {}
+   :staged {}
+   :touched #{}})
+
+(defonce ^{:private true
+           :doc "Plain-JVM/test fallback state only. Real Shadow builds keep
+  their accepted snapshot and disposable pass scratch in Shadow's functional
+  compiler-env; no successful-build authority lives in this process atom."}
+  state (atom {}))
+
+(defonce ^{:private true
+           :doc "The build-id the most recent `begin-build!` opened — the
+  identity fallback for the REPL / plain-JVM paths, where no CLJS compiler
+  env is bound. Never consulted under a real compile (the compiler env wins,
+  and is per-thread correct under parallel builds)."}
+  session-build (atom ::default))
+
+(def ^:dynamic *build-id*
+  "Explicit identity override (tests / REPL). Wins over the compiler env and
+  the session fallback; bind it per-thread to drive interleaved builds."
+  nil)
+
+;; These keys live in Shadow's retained `:compiler-env`. They are deliberately
+;; namespaced and data-only: Shadow's returned build-state is the transaction.
+;; A failed downstream optimize/check/flush/watch step discards that state, so
+;; an external last-known-good commit or private Shadow completion callback is
+;; neither needed nor permitted.
+(def accepted-snapshot-key ::accepted-snapshot)
+(def scratch-key ::scratch)
+(def repl-overlay-key ::repl-overlay)
+
+(defn- empty-snapshot [build-id]
+  {:build-id build-id
+   :registries {}
+   :elements {}
+   :version 0})
+
+(def ^:private shadow-bridge-key
+  "Shadow's OUTER build-bridge marker. re-frame.freehand recognizes it but does NOT
+  depend on it for build authority: a future Shadow rename/removal of this key
+  must not strand re-frame.freehand's own private carrier."
+  :shadow.build.cljs-bridge/state)
+
+(def ^:private private-carrier-keys
+  "re-frame.freehand's OWN compiler-env carrier keys — the accepted snapshot plus the
+  disposable scratch/overlay. Their presence is authoritative re-frame.freehand build
+  ownership, independent of Shadow's outer marker."
+  [accepted-snapshot-key scratch-key repl-overlay-key])
+
+(defn- ui-owned-compiler-state?
+  "The ONE closed re-frame.freehand compiler-ownership recognizer. A compiler-env map
+  is re-frame.freehand-owned when it carries any of re-frame.freehand's own private carrier
+  keys — the authority re-frame.freehand itself established via the build hook — OR
+  Shadow's still-recognized outer bridge marker (the pre-hook window / legacy
+  path). Identity resolution, accepted/scratch reads, contribution writes, and
+  finish all gate on THIS predicate, so a drift of the outer marker cannot route
+  one build's authority onto another's while the private carrier is intact. Pure."
+  [compiler-state]
+  (boolean
+   (or (contains? compiler-state shadow-bridge-key)
+       (some #(contains? compiler-state %) private-carrier-keys))))
+
+#?(:clj
+   (defn- compiler-env-atom []
+     (when-let [compiler-var (resolve 'cljs.env/*compiler*)]
+       (let [v @compiler-var]
+         (when (instance? clojure.lang.IAtom v) v)))))
+
+#?(:clj
+   (defn- owned-compiler-state
+     "Raw recognizer: the bound compiler-env state iff re-frame.freehand-owned (a
+     private carrier key or Shadow's still-recognized outer bridge marker), else
+     nil. Does NOT validate build identity — every ambient read/write that
+     observes or mutates the carrier goes through `validated-compiler-state`,
+     which additionally fails closed on a malformed or contradictory identity."
+     []
+     (when-let [a (compiler-env-atom)]
+       (let [s @a]
+         (when (ui-owned-compiler-state? s) s)))))
+
+(defn accepted-snapshot
+  "Return the accepted re-frame.freehand snapshot carried by an explicit Shadow
+  build-state/compiler-env. This is the only JVM read of a real build's
+  finalized registries; callers must name the build-state they mean.
+  Returns an empty version-0 snapshot when the build has not yet succeeded."
+  [build-state-or-compiler-env]
+  (let [compiler-env (or (:compiler-env build-state-or-compiler-env)
+                         build-state-or-compiler-env)
+        build-id (or (get-in compiler-env [accepted-snapshot-key :build-id])
+                     (:shadow.build/build-id build-state-or-compiler-env)
+                     (get-in compiler-env
+                             [:shadow.build.cljs-bridge/state
+                              :shadow.build/build-id])
+                     ::default)]
+    (or (get compiler-env accepted-snapshot-key)
+        (empty-snapshot build-id))))
+
+(defn accepted-aggregate
+  "Registry aggregate from an explicit accepted Shadow build-state/compiler-env.
+  Scratch and no-pass REPL overlay are intentionally invisible."
+  [reg-id build-state-or-compiler-env]
+  (reduce-kv (fn [m _src regs] (merge m (get regs reg-id)))
+             {}
+             (:registries (accepted-snapshot build-state-or-compiler-env))))
+
+(defn accepted-element-manifest
+  "The accepted flat custom-element manifest `{tag {:properties #{…}}}` from an
+  explicit Shadow build-state/compiler-env — the all-members harvest the last
+  successful build finalized. Decoupled from `:registries` (it is not a
+  per-source view-slice registry); the coarse warm-invalidation baseline and the
+  warm-watch topology gate read it here."
+  [build-state-or-compiler-env]
+  (:elements (accepted-snapshot build-state-or-compiler-env) {}))
+
+;; ---------------------------------------------------------------------------
+;; Ambient build identity
+;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (defn- carrier-build-id
+     "THE single validated re-frame.freehand build-identity resolver — private-carrier
+     presence, build-id extraction, and private-versus-Shadow agreement in ONE
+     place, resolved from re-frame.freehand's OWN authority rather than Shadow's outer
+     marker. Every ambient read/write/finish boundary traverses it, so a
+     malformed or contradictory carrier is rejected fail-closed everywhere, not
+     just where `current-build-id` happens to be consulted.
+
+     Identity lives ONLY in the accepted-snapshot carrier (its `:build-id`); the
+     disposable scratch/overlay slices carry no identity. When `compiler-state`
+     carries that accepted carrier it is authoritative: its `:build-id` is the
+     answer. An accepted carrier with a MISSING build id, or with an id that
+     DISAGREES with a still-present Shadow bridge id, fails loudly — downgrading
+     to the process session fallback could route this compilation into a
+     different parallel build.
+
+     With no accepted carrier yet (the pre-hook window / legacy path, or a
+     no-hook REPL/watch overlay) identity comes from Shadow's outer bridge
+     marker: a recognized bridge supplies the id. A recognized bridge present
+     without its leaf id fails loudly rather than downgrade to the session
+     fallback, which the contract reserves for a genuinely plain CLJS/REPL
+     environment carrying NEITHER recognized marker NOR carrier. Callers pass a
+     state already known re-frame.freehand-owned (see `owned-compiler-state`); the
+     fail-closed throw is the gate."
+     [compiler-state]
+     ;; `private?` is the ACCEPTED-SNAPSHOT identity carrier specifically — not
+     ;; the disposable scratch/overlay (which a no-hook REPL/watch write creates
+     ;; with no accepted snapshot and whose identity legitimately resolves from
+     ;; the Shadow bridge below).
+     (let [private?   (contains? compiler-state accepted-snapshot-key)
+           private-id (get-in compiler-state [accepted-snapshot-key :build-id])
+           shadow-id  (get-in compiler-state
+                              [shadow-bridge-key :shadow.build/build-id])]
+       (if private?
+         (cond
+           (nil? private-id)
+           (throw
+            (ex-info
+             (str "re-frame.freehand compiler found its private build carrier but no "
+                  "build id in the accepted snapshot; refusing the session-build "
+                  "fallback because it can route this compilation into a "
+                  "different parallel build")
+             {::error ::private-build-id-unresolved
+              :recovery :check-ui-build-carrier
+              :expected-path [accepted-snapshot-key :build-id]}))
+
+           (and (some? shadow-id) (not= shadow-id private-id))
+           (throw
+            (ex-info
+             (str "re-frame.freehand compiler private build carrier id " private-id
+                  " disagrees with Shadow's still-present build id " shadow-id
+                  "; refusing to guess which build this compilation belongs to")
+             {::error ::private-build-id-shadow-disagreement
+              :recovery :check-ui-build-carrier
+              :private-build-id private-id
+              :shadow-build-id shadow-id}))
+
+           :else private-id)
+
+         ;; No private carrier yet: the state is re-frame.freehand-recognized only
+         ;; through Shadow's outer bridge, which must therefore carry the id.
+         (do
+           (when (nil? shadow-id)
+             (throw
+              (ex-info
+               (str "re-frame.freehand compiler could not resolve shadow's build id "
+                    "from a recognized build bridge; refusing the session-build "
+                    "fallback because it can route this compilation into a "
+                    "different parallel build")
+               {::error ::shadow-build-id-unresolved
+                :recovery :check-shadow-compiler-env
+                :expected-path [shadow-bridge-key :shadow.build/build-id]})))
+           shadow-id)))))
+
+#?(:clj
+   (defn- validated-compiler-state
+     "The ONE resolver every ambient accepted/scratch/overlay read and every
+     ambient write traverses: the bound owned compiler-state with its build
+     identity validated by `carrier-build-id`, which throws fail-closed on a
+     malformed or contradictory carrier BEFORE it can be observed or mutated.
+     nil when no owned carrier is bound (the genuinely plain / REPL fallback)."
+     []
+     (when-let [s (owned-compiler-state)]
+       (carrier-build-id s)                 ; fail-closed identity gate
+       s)))
+
+#?(:clj
+   (defn- ambient-build-id
+     "The build id the current compilation belongs to, resolved and validated
+     through `carrier-build-id` from re-frame.freehand's OWN authority rather than
+     Shadow's outer marker. nil for a genuinely plain / REPL env (no owned
+     carrier), where `current-build-id` uses the session fallback."
+     []
+     (when-let [s (owned-compiler-state)]
+       (carrier-build-id s))))
+
+(defn current-build-id
+  "The build id a contribution belongs to: the explicit `*build-id*`
+  override, else the ambient shadow compile (per-thread compiler env), else
+  the last `begin-build!` id, else `::default`."
+  []
+  (or *build-id*
+      #?(:clj (ambient-build-id) :cljs nil)
+      @session-build
+      ::default))
+
+;; ---------------------------------------------------------------------------
+;; Pure reads
+;; ---------------------------------------------------------------------------
+
+(defn- effective
+  "One slice's EFFECTIVE aggregate for `reg-id`: committed rows of the
+  sources NOT touched this pass, merged with the staged rows of the sources
+  that re-ran — EXCLUDING `exclude` (pass `::none` to exclude nothing). Pure."
+  [slice reg-id exclude]
+  (let [touched (:touched slice)
+        committed (reduce-kv
+                   (fn [m src regs]
+                     (if (or (= src exclude) (contains? touched src))
+                       m
+                       (merge m (get regs reg-id))))
+                   {} (:committed slice))]
+    (reduce-kv
+     (fn [m src regs] (if (= src exclude) m (merge m (get regs reg-id))))
+     committed (:staged slice))))
+
+#?(:clj
+   (defn- ambient-shadow-slice
+     "Effective disposable slice for the currently bound Shadow compiler.
+     During a file/watch pass this is `scratch`; during no-pass REPL work it is
+     an isolated overlay seeded from the accepted snapshot. Neither is an
+     accepted successful-build authority. The carrier's build identity is
+     validated (`validated-compiler-state`) before any slice is observed."
+     []
+     (when-let [compiler-state (validated-compiler-state)]
+       (or (get compiler-state scratch-key)
+           (get compiler-state repl-overlay-key)
+           (assoc empty-slice
+                  :committed (:registries (accepted-snapshot compiler-state)))))))
+
+#?(:clj
+   (defn- ambient-accepted-slice []
+     (when-let [compiler-state (validated-compiler-state)]
+       (assoc empty-slice
+              :committed (:registries (accepted-snapshot compiler-state))))))
+
+(defn aggregate
+  "The ambient (or given) build's current aggregate for `reg-id` — the
+  effective view (committed last-known-good for untouched sources plus the
+  open pass's staged rows). A pure function of the current build inputs; the
+  read every consumer uses in place of a bare atom deref."
+  ([reg-id]
+   (if-let [slice #?(:clj (ambient-shadow-slice) :cljs nil)]
+     (effective slice reg-id ::none)
+     (aggregate reg-id (current-build-id))))
+  ([reg-id build-id]
+   (effective (get @state build-id empty-slice) reg-id ::none)))
+
+(defn committed-aggregate
+  "The build's LAST-KNOWN-GOOD aggregate for `reg-id`: the merge of the
+  COMMITTED rows only, IGNORING the open pass's staging. Unlike `aggregate`
+  (the effective view — committed-untouched PLUS staged), this reads solely
+  the committed layer, which changes ONLY at a successful commit / finish
+  boundary (`commit-build!` / `finish-build!`; `begin-build!` / `abort-build!`
+  never touch it). So a read during an OPEN, FAILED, or interleaved pass
+  returns the last finalized snapshot — never a partial mid-pass mix — and
+  the value a consumer reads is finalized-at-the-successful-build-boundary by
+  construction. Per-build-id like `aggregate`; on the no-pass REPL / plain-JVM
+  path a contribution upserts straight into committed, so this reader sees it
+  immediately. Pure."
+  ([reg-id]
+   (if-let [slice #?(:clj (ambient-accepted-slice) :cljs nil)]
+     (reduce-kv (fn [m _src regs] (merge m (get regs reg-id)))
+                {} (:committed slice))
+     (committed-aggregate reg-id (current-build-id))))
+  ([reg-id build-id]
+   (reduce-kv (fn [m _src regs] (merge m (get regs reg-id)))
+              {} (:committed (get @state build-id empty-slice)))))
+
+#?(:clj
+   (defn- shadow-pass-manifest
+     "The prepare-harvested flat custom-element manifest of the OPEN Shadow build
+     pass (`[scratch-key :element-manifest]`), or nil. Present only inside a real
+     Shadow build pass the build hook opened; nil on a Shadow REPL overlay
+     (no `:compile-prepare` harvest), plain JVM/SSR, and CLJS — those fall back to
+     the per-source `elements` slice. The carrier's identity is validated
+     (`validated-compiler-state`) before the manifest is observed."
+     []
+     (when-let [cs (validated-compiler-state)]
+       (get-in cs [scratch-key :element-manifest]))))
+
+(defn element-properties
+  "The declared `:properties` set for custom-element `tag` in the ambient (or
+  given) build's compile-time custom-element manifest — the compile-path read the
+  template analyzer uses to classify a custom element's props (property vs
+  attribute). Inside a real Shadow build pass it reads the prepare-time
+  all-members harvest manifest (`shadow-pass-manifest`), which is a pure function
+  of the build's source and independent of macro re-expansion; on the plain-JVM /
+  SSR / REPL path it reads the per-source `elements` slice through the ambient
+  build identity. Per-build either way, so one daemon's parallel builds never
+  cross-classify; NEVER a process-global last-writer-wins mirror. Empty set when
+  `tag` is undeclared in this build."
+  ([tag]
+   (if-let [m #?(:clj (shadow-pass-manifest) :cljs nil)]
+     (get-in m [tag :properties] #{})
+     (get-in (aggregate elements) [tag :properties] #{})))
+  ([tag build-id] (get-in (aggregate elements build-id) [tag :properties] #{})))
+
+(defn pass-open?
+  "Whether a compile pass is currently open for the ambient (or given)
+  build (tests / tooling)."
+  ([]
+   (if-let [slice #?(:clj (ambient-shadow-slice) :cljs nil)]
+     (:pass-open? slice false)
+     (pass-open? (current-build-id))))
+  ([build-id] (:pass-open? (get @state build-id empty-slice) false)))
+
+(defn shadow-compile?
+  "Whether an OWNED Shadow compiler-env carrier is bound — a real Shadow
+  build/watch/REPL compile, where the build hook's `:compile-prepare` harvest
+  (or the REPL's own top-to-bottom order) governs custom-element seeding. False
+  on the plain-JVM / SSR path, where no compiler env is bound and the harvest
+  must lazily read the ambient namespace's own source instead (rf2-vxgfnd.141).
+  Always false on CLJS (there is no compile-path host there)."
+  []
+  #?(:clj (boolean (validated-compiler-state)) :cljs false))
+
+(defn shadow-build-pass?
+  "Whether a real Shadow build PASS is bound — a `:compile-prepare`-opened scratch
+  is present. Inside this window the prepare-time all-members custom-element
+  harvest is authoritative and the `v/custom-element` macro is
+  validation/reporting-only (it does not populate the compile-time registry).
+  False on a Shadow REPL overlay (no scratch, no prepare harvest), plain JVM/SSR,
+  and CLJS — where the macro's own contribution still populates the `elements`
+  slice."
+  []
+  #?(:clj (boolean (when-let [cs (validated-compiler-state)]
+                     (contains? cs scratch-key)))
+     :cljs false))
+
+;; ---------------------------------------------------------------------------
+;; Contribution (pure transitions)
+;; ---------------------------------------------------------------------------
+
+(defn- write-slice
+  "Pure: record `source` contributing `k`->`v` to `reg-id`. A pass open →
+  STAGE it (and mark the source touched, so its committed contribution is
+  superseded on commit). No pass → UPSERT straight into committed (the REPL
+  posture: per-key, no sibling eviction)."
+  [slice reg-id source k v]
+  (if (:pass-open? slice)
+    (-> slice
+        (update :touched conj source)
+        (assoc-in [:staged source reg-id k] v))
+    (assoc-in slice [:committed source reg-id k] v)))
+
+(defn- update-current-slice!
+  "Atomically apply `f` to the current compilation slice. A real Shadow pass
+  mutates only compiler-env scratch. A no-pass Shadow REPL form mutates only a
+  disposable overlay seeded from the accepted snapshot. Plain JVM/tests use
+  the legacy fallback atom. Returns the updated slice."
+  [f]
+  #?(:clj
+     (if-let [compiler-atom (when-not *build-id* (compiler-env-atom))]
+       (if (ui-owned-compiler-state? @compiler-atom)
+         (let [updated (atom nil)]
+           (swap! compiler-atom
+                  (fn [compiler-state]
+                    ;; Fail-closed identity gate BEFORE any scratch/overlay
+                    ;; mutation: a carrier whose build identity is missing or
+                    ;; disagrees with a still-present Shadow bridge id must not
+                    ;; be written (the same authority `validated-compiler-state`
+                    ;; enforces on the read side).
+                    (carrier-build-id compiler-state)
+                    (let [k (if (contains? compiler-state scratch-key)
+                              scratch-key
+                              repl-overlay-key)
+                          seed (or (get compiler-state k)
+                                   (assoc empty-slice
+                                          :committed
+                                          (:registries
+                                           (accepted-snapshot compiler-state))))
+                          next (f seed)]
+                      (reset! updated next)
+                      (assoc compiler-state k next))))
+           @updated)
+         (let [build-id (current-build-id)
+               updated (atom nil)]
+           (swap! state update build-id
+                  (fn [slice]
+                    (let [next (f (or slice empty-slice))]
+                      (reset! updated next)
+                      next)))
+           @updated))
+       (let [build-id (current-build-id)
+             updated (atom nil)]
+         (swap! state update build-id
+                (fn [slice]
+                  (let [next (f (or slice empty-slice))]
+                    (reset! updated next)
+                    next)))
+         @updated))
+     :cljs
+     (let [build-id (current-build-id)
+           updated (atom nil)]
+       (swap! state update build-id
+              (fn [slice]
+                (let [next (f (or slice empty-slice))]
+                  (reset! updated next)
+                  next)))
+       @updated)))
+
+(defn contribute!
+  "Contribute `source`'s `k`->`v` to the plain registry `reg-id` in the
+  ambient build — one `swap!`, pure. Collision-sensitive registries use
+  `contribute-checked!` for their pre-write conflict check."
+  [reg-id source k v]
+  (update-current-slice! #(write-slice % reg-id source k v))
+  nil)
+
+(defn contribute-checked!
+  "An atomic conflict-checked registry contribution. Inside ONE
+  `swap!`: look up `k` in the ambient build's EFFECTIVE map for `reg-id`,
+  EXCLUDING `source`'s own rows (a source never conflicts with itself —
+  same-source re-declaration replaces), and call `(conflict-fn existing)`. If
+  it returns a non-nil value the write is REJECTED and that value is returned
+  (the caller builds + throws its domain error); otherwise `source`
+  contributes `k`->`v` (staged or upserted) and nil is returned. Atomic, so
+  parallel compilation can neither drop a concurrent write (check-then-assoc
+  race) nor miss a genuine duplicate."
+  [reg-id source k v conflict-fn]
+  (let [outcome (atom nil)]             ; call-local — only this call's retries touch it
+    (update-current-slice!
+     (fn [slice]
+       (let [existing (get (effective slice reg-id source) k)
+             conflict (conflict-fn existing)]
+         (if conflict
+           (do (reset! outcome {:conflict conflict}) slice)
+           (do (reset! outcome nil)
+               (write-slice slice reg-id source k v))))))
+    @outcome))
+
+(defn contribute-view-checked!
+  "Atomically contribute one compiled view digest while enforcing declaration
+  identity. `source` (the namespace) remains the pass replacement/eviction
+  unit; `declaration` (`[ns-sym var-name]`) distinguishes an exact same-var
+  HMR/REPL replacement from a different defview claiming the same `view-id`.
+
+  During an open pass, the source's COMMITTED owner is deliberately ignored:
+  that namespace is being replaced wholesale, so its first current
+  declaration may reuse an id after a rename/removal. Its STAGED owner is not
+  ignored, so two distinct current declarations in the same namespace fail.
+  With no pass open, the committed owner is checked so a REPL declaration can
+  replace only itself. Other sources that remain authoritative members always
+  conflict (as do other sources when no prepare membership context exists).
+  The one exception is a COMMITTED owner whose source is absent from the open
+  pass's authoritative member set: it is ignored for admission, but remains
+  committed last-known-good until successful finish evicts it; abort leaves it
+  as last-known-good. Owner + digest writes occur in the SAME `swap!`,
+  preserving cross-namespace atomicity. Returns nil on success or
+  `{:conflict <existing-declaration>}` without writing on conflict."
+  [source declaration view-id digest]
+  (let [outcome (atom nil)]
+    (update-current-slice!
+     (fn [slice]
+             (let [other-views    (effective slice views source)
+                   other-owner    (get (effective slice view-declarations source)
+                                       view-id)
+                   source-owner   (if (:pass-open? slice)
+                                    (get-in slice
+                                            [:staged source view-declarations view-id])
+                                    (get-in slice
+                                            [:committed source view-declarations view-id]))
+                   ;; A prepare hook captures the already-resolved whole graph.
+                   ;; A committed owner absent from it is stale but remains
+                   ;; last-known-good until successful finish. It must not
+                   ;; block the current member that will replace it.
+                   owner-source   (when (vector? other-owner)
+                                    (first other-owner))
+                   stale-owner?   (and (:pass-open? slice)
+                                       (some? (:authoritative-members slice))
+                                       owner-source
+                                       (not (contains? (:authoritative-members slice)
+                                                       owner-source))
+                                       (= other-owner
+                                          (get-in slice
+                                                  [:committed owner-source
+                                                   view-declarations view-id]))
+                                       (nil? (get-in slice
+                                                     [:staged owner-source
+                                                      view-declarations view-id])))
+                   conflict       (cond
+                                    (and (contains? other-views view-id)
+                                         (not stale-owner?))
+                                    (or other-owner ::other-source)
+
+                                    (and source-owner
+                                         (not= source-owner declaration))
+                                    source-owner
+
+                                    :else nil)]
+               (if conflict
+                 (do (reset! outcome {:conflict conflict}) slice)
+                 (do (reset! outcome nil)
+                     (-> slice
+                         (write-slice view-declarations source view-id declaration)
+                         (write-slice views source view-id digest)))))))
+    @outcome))
+
+(defn- element-conflict-row
+  "Pure: one side of a custom-element contradiction, rendered as deterministic
+  evidence. `build-id` + `ns` are the ruled `[build-id ns-sym]` anchor pair."
+  [build-id source decl]
+  {:build build-id
+   :ns source
+   :properties (:properties decl #{})})
+
+(defn elements-conflict
+  "Pure DEFENCE-IN-DEPTH detector: the first cross-source non-`rf=`-equal
+  same-tag collision in a per-source `registries` map (`{source {reg-id {k v}}}`),
+  or nil.
+
+  `contribute-element-checked!` is the write BARRIER — it is the law, and it
+  makes a conflicting row unable to enter a slice in the first place. This
+  function re-derives the same verdict from finalized rows so that NO
+  aggregation path can ever pick a winner by merge order, even if a row
+  arrived by some route that bypassed the barrier. Sources are folded in
+  sorted order and the losing pair is reported with BOTH anchors sorted the
+  same way, so the evidence is identical under every source permutation."
+  [build-id registries]
+  (let [conflict (fn [tag owner prior source decl]
+                   {::conflict
+                    {:tag tag
+                     :declarations
+                     (vec (sort-by (juxt (comp str :build) (comp str :ns))
+                                   [(element-conflict-row build-id owner prior)
+                                    (element-conflict-row build-id source decl)]))}})
+        step (fn [seen source]
+               (reduce-kv
+                (fn [seen tag decl]
+                  (let [[owner prior] (get seen tag)]
+                    (cond
+                      (nil? owner)          (assoc seen tag [source decl])
+                      (eq/rf= prior decl)   seen  ; duplicates co-exist
+                      :else                 (reduced (conflict tag owner prior
+                                                               source decl)))))
+                seen
+                (get-in registries [source elements])))
+        outcome (reduce (fn [seen source]
+                          (let [next (step seen source)]
+                            (if (::conflict next) (reduced next) next)))
+                        {}
+                        (sort-by str (keys registries)))]
+    (::conflict outcome)))
+
+(defn- stage-element-checked
+  "Pure: admit `source`'s `tag` -> `decl` into the per-source `slice` under the
+  ruled cross-source conflict law, returning `[slice' conflict|nil]` — the write
+  barrier the plain-JVM / SSR / REPL `contribute-element-checked!` uses (the
+  Shadow build path re-derives the same verdict wholesale in `element-manifest`).
+  An `rf=`-equal duplicate is idempotent; a contradiction from another live
+  source (or a second contradictory declaration in the same open pass of one ns)
+  is refused without writing, leaving the last-known-good slice untouched."
+  [slice source tag decl]
+  (let [other-decl (get (effective slice elements source) tag)
+        other-owner (get (effective slice element-declarations source) tag)
+        ;; Own STAGED row only: a second, contradictory declaration of the same
+        ;; tag in the same pass of the same ns. Committed/no-pass rows are the
+        ;; source replacing itself and must stay admissible.
+        own-decl (when (:pass-open? slice)
+                   (get-in slice [:staged source elements tag]))
+        conflict (cond
+                   (and (some? other-decl) (not (eq/rf= other-decl decl)))
+                   {:owner other-owner :declaration other-decl}
+
+                   (and (some? own-decl) (not (eq/rf= own-decl decl)))
+                   {:owner source :declaration own-decl}
+
+                   :else nil)]
+    (if conflict
+      [slice conflict]
+      [(-> slice
+           (write-slice element-declarations source tag source)
+           (write-slice elements source tag decl))
+       nil])))
+
+(defn contribute-element-checked!
+  "Atomically contribute ONE custom-element declaration under the ruled
+  cross-source conflict law (rf2-vxgfnd.143, delegated ruling 2026-07-15
+  Option A — fail atomically; never a merge/winner law).
+
+  Inside ONE `swap!`, `source`'s `tag` -> `decl` is admitted iff every OTHER
+  live source's declaration of `tag` is `rf=`-equal to it. `rf=`-equal
+  duplicates co-exist (idempotent — two namespaces may legitimately state the
+  same fact); a non-`rf=`-equal declaration from a DIFFERENT source is a
+  contradiction and is REJECTED without writing, so the losing row never
+  enters the ledger and the last-known-good aggregate is left untouched.
+
+  A source never conflicts with ITSELF across passes: during an open pass the
+  source's COMMITTED rows are excluded (it is being replaced wholesale), and
+  on the no-pass REPL path a re-evaluated declaration simply replaces its own
+  prior row. Its STAGED rows are NOT excluded, so two contradictory
+  declarations of one tag inside a single compile of one namespace do fail —
+  those are two live declarations, not a replacement.
+
+  Owner provenance is written in the SAME `swap!` as the declaration, so the
+  rejected side can always be anchored to BOTH `[build-id ns-sym]` pairs.
+  Returns nil on success, or `{:conflict {:owner <ns> :declaration <decl>}}`
+  without writing."
+  [source tag decl]
+  (let [outcome (atom nil)]
+    (update-current-slice!
+     (fn [slice]
+       (let [[slice' conflict] (stage-element-checked slice source tag decl)]
+         (reset! outcome (when conflict {:conflict conflict}))
+         slice')))
+    @outcome))
+
+(defn- seeded->registries
+  "Pure: group harvested `[source tag decl]` triples into the per-source shape
+  `elements-conflict` folds — `{source {elements {tag decl}}}` — or
+  `{::conflict …}` when two non-`rf=`-equal declarations of one tag arrive from
+  the SAME source in ONE harvest. Grouping itself must not pick a winner:
+  `elements-conflict` compares finalized per-source rows, so a same-source
+  contradiction would otherwise collapse last-wins before the law ever ran
+  (PR #6646 audit rider). Two contradictory declarations in one pass of one
+  namespace are two LIVE declarations — the same law violation
+  `contribute-element-checked!` refuses via its staged rows on the plain-JVM
+  path — not a source replacing itself across passes: each prepare harvest is
+  independent, so an ordinary edit between builds still replaces cleanly.
+  `rf=`-equal duplicates fold idempotently."
+  [build-id seeded]
+  (reduce (fn [m [source tag decl]]
+            (let [prior (get-in m [source elements tag])]
+              (cond
+                (nil? prior)        (assoc-in m [source elements tag] decl)
+                (eq/rf= prior decl) m
+                :else
+                (reduced
+                 {::conflict
+                  {:tag tag
+                   :declarations
+                   (vec (sort-by (juxt (comp str :build) (comp str :ns))
+                                 [(element-conflict-row build-id source prior)
+                                  (element-conflict-row build-id source decl)]))}}))))
+          {} seeded))
+
+(defn element-manifest
+  "Pure: fold harvested `[source tag decl]` triples into the flat all-members
+  custom-element manifest `{tag {:properties #{…}}}`. The SAME conflict law as
+  `contribute-element-checked!` governs admission — a non-`rf=` same-tag
+  declaration from a DIFFERENT source, or a second non-`rf=` declaration of one
+  tag inside the SAME source's single harvest (PR #6646 audit rider), is a
+  contradiction and THROWS (a `:compile-prepare` error is a build-time error),
+  so the manifest never carries a merge-order or source-order winner;
+  `rf=`-equal duplicates fold idempotently. `build-id` anchors the thrown
+  evidence."
+  [build-id seeded]
+  (let [grouped (seeded->registries build-id seeded)]
+    (when-let [c (or (::conflict grouped)
+                     (elements-conflict build-id grouped))]
+      (throw
+       (ex-info
+        (str "re-frame.freehand found contradictory custom-element declarations for "
+             (:tag c) " while harvesting the build's declarations; refusing to "
+             "publish a merge-order winner")
+        {::error ::custom-element-conflict
+         :build-id build-id
+         :recovery :reconcile-custom-element-declarations
+         :tag (:tag c)
+         :declarations (:declarations c)}))))
+  (reduce (fn [m [_source tag decl]]
+            (assoc m tag {:properties (:properties decl #{})}))
+          {} seeded))
+
+(defn set-shadow-element-manifest
+  "Purely store the prepare-harvested all-members custom-element `manifest`
+  (`{tag {:properties #{…}}}`, built by `element-manifest`) into `build-state`'s
+  open scratch pass, BEFORE any view analyzes — the order-independence +
+  macro-independence seam the build hook uses at `:compile-prepare`
+  (rf2-vxgfnd.141 dim 2, rf2-u53yy.1 S1). The manifest is a pure function of the
+  build's SOURCE, held beside the pass rather than in its per-source `:touched`
+  ledger, so harvesting a warm source's declarations never evicts its committed
+  views. A pure build-state transform (`cljs.env/*compiler*` is not bound during
+  the hook); when no scratch pass is open the build-state is returned unchanged."
+  [build-state manifest]
+  (if (get-in build-state [:compiler-env scratch-key])
+    (assoc-in build-state [:compiler-env scratch-key :element-manifest] manifest)
+    build-state))
+
+;; ---------------------------------------------------------------------------
+;; View descriptor carrier (rf2-u53yy.1 S2)
+;;
+;; On the Shadow build path the whole-build `views` / `view-declarations`
+;; registries are NOT populated by the `defview` macro's per-source slice
+;; contribution — a warm cache-hit source never re-runs that macro. Instead each
+;; compiled view stamps its descriptor onto the generated def's analyzer metadata
+;; (`emit_cljs` var-meta: `:rf.ui/view-id` + `:rf.ui/view-digest`). Shadow persists
+;; a compiled namespace's analyzer data to its disk cache and RESTORES it under
+;; `[:compiler-env :cljs.analyzer/namespaces <ns>]` on a cache HIT (the S0 proof,
+;; rf2-u53yy.1.1: exact-EDN round-trip across shadow 3.4.0/3.4.10/3.4.11). At
+;; compile-finish the hook folds the descriptor of EVERY authoritative member —
+;; cached and compiled alike — into the two registries, so a warm source's views
+;; are restored from the cache-durable analyzer map, not re-stamped by a macro.
+;; This is the same decoupling S1 gave elements, at compile-finish (where views
+;; resolve) rather than compile-prepare (elements are the ordering exception).
+;; ---------------------------------------------------------------------------
+
+(defn- analyzer-view-defs
+  "PURE: `[view-id declaration digest]` triples for the compiled views a
+  namespace's restored/fresh analyzer `:defs` carries. A def is a view iff its
+  metadata carries BOTH `:rf.ui/view-id` and `:rf.ui/view-digest` — a bare
+  `(declare ^:rf.ui/view …)` forward declaration carries neither, and the
+  `$render`/`$host_render` helpers carry no view metadata at all. `declaration`
+  is the ruled `[ns var]` pair; `digest` is the `[template-fingerprint
+  hook-signature]` vector the emitter stamped (the same value the macro slice
+  path contributes off the Shadow path)."
+  [ns-sym ns-analyzer-map]
+  (keep (fn [[var-sym def-map]]
+          (let [m (:meta def-map)
+                view-id (:rf.ui/view-id m)
+                digest (:rf.ui/view-digest m)]
+            (when (and view-id digest)
+              [view-id [ns-sym var-sym] digest])))
+        (:defs ns-analyzer-map)))
+
+(defn harvest-view-registries
+  "PURE: fold the analyzer-map view descriptors of every authoritative `members`
+  namespace in `build-state` into per-source registry rows
+  `{source {::views {view-id digest} ::view-declarations {view-id declaration}}}`.
+  Reads `[:compiler-env :cljs.analyzer/namespaces <ns>]` — Shadow's
+  disk-cache-durable carrier (rf2-u53yy.1 S2), present identically for a cache-hit
+  member and a freshly compiled one. The cross-source view-id uniqueness law runs
+  HERE (a compile-finish error is still a build-time error): two DISTINCT
+  declarations claiming one view-id THROW rather than letting merge order pick a
+  winner. The same declaration cannot appear twice — one def, one `:defs` entry —
+  so an `rf=`-style duplicate cannot arise. Members are folded in sorted order so
+  the reported collision evidence is identical under every graph permutation."
+  [build-state members]
+  (let [nss (get-in build-state [:compiler-env :cljs.analyzer/namespaces])
+        seeded (mapcat (fn [ns-sym]
+                         (analyzer-view-defs ns-sym (get nss ns-sym)))
+                       (sort-by str members))
+        conflict (reduce
+                  (fn [owners [view-id declaration _digest]]
+                    (let [prior (get owners view-id)]
+                      (if (and prior (not= prior declaration))
+                        (reduced
+                         {::conflict
+                          {:view-id view-id
+                           :declarations (vec (sort-by str [prior declaration]))}})
+                        (assoc owners view-id declaration))))
+                  {}
+                  seeded)]
+    (when-let [c (::conflict conflict)]
+      (throw
+       (ex-info
+        (str "re-frame.freehand found two distinct defview declarations claiming view "
+             "id " (:view-id c) " while harvesting the build's compiled views; "
+             "refusing to publish a merge-order winner. Give each view a distinct "
+             "qualified keyword (re-expanding the exact same var remains the HMR "
+             "replacement path)")
+        {::error ::view-id-conflict
+         :view-id (:view-id c)
+         :declarations (:declarations c)
+         :recovery :reconcile-defview-declarations})))
+    (reduce (fn [regs [view-id declaration digest]]
+              (let [source (first declaration)]
+                (-> regs
+                    (assoc-in [source views view-id] digest)
+                    (assoc-in [source view-declarations view-id] declaration))))
+            {}
+            seeded)))
+
+(defn- merge-registries
+  "PURE: deep-merge two `{source {reg-id {k v}}}` registry maps; the RIGHT map's
+  rows win per `(source, reg-id, k)`. Used to overlay the analyzer-map-harvested
+  view rows onto the slice-derived rows of the other registries."
+  [a b]
+  (merge-with (fn [ra rb] (merge-with merge ra rb)) a b))
+
+;; ---------------------------------------------------------------------------
+;; Root/plan/descriptor carrier (rf2-u53yy.1 S4 + S5)
+;;
+;; Roots, plans, and Root Descriptors are CALL SITES (`v/mount` / `v/create-root`
+;; / `v/render!` / `v/hydrate-root`), not defs, so unlike views (S2) they carry NO
+;; generated def whose analyzer var-meta could hold their descriptor. On the Shadow
+;; build path each site is instead stamped onto a SYNTHETIC per-namespace descriptor
+;; in the analyzer namespace map (variant B, S0 proof rf2-u53yy.1.1): a single
+;; ns-level key `[::namespaces <ns> :rf.ui/root-plan-descriptor]` accumulating this
+;; namespace's `{:roots [..] :plans [..] :descriptors [..]}` sites — S5 folds the
+;; Root Descriptor index onto the SAME carrier (one carrier for all three call-site
+;; registries) rather than inventing a new key. Shadow persists the whole ns
+;; analyzer entry to its disk cache and RESTORES it under
+;; `[:compiler-env :cljs.analyzer/namespaces <ns>]` on a cache HIT, so the build
+;; hook harvests the roots/plans registries from it at compile-finish — present
+;; identically for a cached member and a freshly compiled one — instead of from a
+;; macro-expansion side effect a warm cache-hit source never re-runs. Eviction is
+;; automatic and identical to S2's def-meta carrier: Shadow's watch reset dissocs
+;; the WHOLE `[::namespaces <ns>]` entry for a modified source before it recompiles
+;; (`remove-output-by-id`, default `:watch-namespace-reset`), so a removed site
+;; simply vanishes from the re-analyzed carrier. This is the same decoupling S1
+;; gave elements and S2 gave views — the direction S6 needs to drop the blocker.
+;; ---------------------------------------------------------------------------
+
+(def ^{:private true
+       :doc "The SYNTHETIC per-namespace Layer-1 carrier key in the analyzer
+  namespace map (rf2-u53yy.1 S4). Namespaced + analyzer-only: it is compile-time
+  build state, never emitted into any bundle."}
+  root-plan-descriptor-key
+  :rf.ui/root-plan-descriptor)
+
+(defn stamp-root-plan-site!
+  "Accumulate one Layer-1 `site` under `sub-key` (`:roots` | `:plans` |
+  `:descriptors`) in the live analyzer map's SYNTHETIC per-namespace descriptor for
+  `ns-sym` — the S4 variant-B carrier, extended to carry the Root Descriptor index
+  too (rf2-u53yy.1 S5): all three call-site registries ride ONE carrier. Called at
+  macro expansion on a real Shadow build pass (`register-root-site!` /
+  `register-plan-site!` / `register-descriptor!` gate on `shadow-build-pass?`) in
+  place of the per-source slice contribution: the whole-build roots/plans/descriptor
+  registries are then harvested from this carrier at compile-finish, present
+  identically for a cache-hit member and a freshly compiled one. A `:roots` site is
+  `{:root-id .. :row {:file .. :line .. :provenance ..}}`; a `:plans` site is
+  `{:frame-id .. :row {:config-fingerprint .. :file .. :line ..}}`; a `:descriptors`
+  site is `{:root-id .. :row <Root Descriptor v1>}` (the same row the slice path
+  contributes off the Shadow path). A direct `swap!` on the per-thread compiler env
+  (parallel builds each own theirs); a no-op when no compiler env is bound (never
+  reached — the caller gates on a live Shadow pass)."
+  [ns-sym sub-key site]
+  #?(:clj (when-let [a (compiler-env-atom)]
+            (swap! a update-in
+                   [:cljs.analyzer/namespaces ns-sym root-plan-descriptor-key sub-key]
+                   (fnil conj []) site))
+     :cljs nil)
+  nil)
+
+(defn- site-coords
+  "PURE: the `{:file :line}` locator of a stamped Layer-1 row, for conflict
+  evidence."
+  [row]
+  (select-keys row [:file :line]))
+
+(defn harvest-root-plan-registries
+  "PURE: fold the SYNTHETIC analyzer-map root/plan/descriptor sites of every
+  authoritative `members` namespace in `build-state` into per-source registry rows
+  `{source {::roots {root-id row} ::plans {frame-id row} ::descriptors {root-id
+  descriptor}}}`. Reads
+  `[:compiler-env :cljs.analyzer/namespaces <ns> :rf.ui/root-plan-descriptor]` —
+  Shadow's disk-cache-durable variant-B carrier (rf2-u53yy.1 S4, extended to the
+  Root Descriptor index at S5), present identically for a cache-hit member and a
+  freshly compiled one. Same-namespace re-declaration replaces (a source's own later
+  site wins — watch/HMR tolerance); the cross-NAMESPACE Layer-1 laws run HERE (a
+  compile-finish error is still a build-time error): two namespaces resolving one
+  root-id THROW `::duplicate-root-id`; two namespaces carrying DIFFERING config
+  fingerprints for one frame-id THROW `::frame-payload-conflict` (matching
+  fingerprints are the ratified idempotent no-op). Root Descriptors ride alongside
+  their root sites keyed by the SAME root-id (every `:descriptors` site is stamped
+  at a site that also stamps a `:roots` site), so the `::duplicate-root-id` law above
+  is their cross-namespace conflict check — no separate descriptor check is needed.
+  Members are folded in sorted order so the reported evidence is stable under every
+  graph permutation. Empty (no root/plan/descriptor sites in the build) yields `{}`,
+  so the finish overlay is a no-op for a mount-free build."
+  [build-state members]
+  (let [nss (get-in build-state [:compiler-env :cljs.analyzer/namespaces])]
+    (loop [srcs        (sort-by str members)
+           regs        {}
+           root-owners {}                ; root-id -> {:source ns :row row}
+           plan-owners {}]               ; frame-id -> {:source ns :row row}
+      (if-let [ns-sym (first srcs)]
+        (let [d         (get (get nss ns-sym) root-plan-descriptor-key)
+              ;; per-source fold: a namespace's own later site replaces its earlier
+              ;; one for the same key (same-ns re-declaration tolerance).
+              src-roots (reduce (fn [m {:keys [root-id row]}] (assoc m root-id row))
+                                {} (:roots d))
+              src-plans (reduce (fn [m {:keys [frame-id row]}] (assoc m frame-id row))
+                                {} (:plans d))
+              src-descs (reduce (fn [m {:keys [root-id row]}] (assoc m root-id row))
+                                {} (:descriptors d))]
+          (doseq [[root-id row] src-roots]
+            (when-let [{owner-row :row} (get root-owners root-id)]
+              (throw
+               (ex-info
+                (str "re-frame.freehand found two root sites in one build resolving to "
+                     "root-id " root-id " while harvesting the build's compiled "
+                     "roots; refusing to publish a merge-order winner. Root-ids are "
+                     "page-unique identity — author distinct :root-id values")
+                {::error ::duplicate-root-id
+                 :root-id root-id
+                 :provenance [(:provenance owner-row) (:provenance row)]
+                 :sites (vec (sort-by str [(site-coords owner-row) (site-coords row)]))
+                 :recovery :make-root-ids-unique}))))
+          (doseq [[frame-id row] src-plans]
+            (when-let [{owner-row :row} (get plan-owners frame-id)]
+              (when (not= (:config-fingerprint owner-row) (:config-fingerprint row))
+                (throw
+                 (ex-info
+                  (str "re-frame.freehand found two root sites in one build carrying "
+                       "static frame plans for frame " frame-id " with DIFFERING "
+                       "config fingerprints while harvesting the build; refusing to "
+                       "publish a merge-order winner. One frame, one plan — align "
+                       "the configs, or drop the duplicate frame-root")
+                  {::error ::frame-payload-conflict
+                   :frame-id frame-id
+                   :fingerprints [(:config-fingerprint owner-row)
+                                  (:config-fingerprint row)]
+                   :sites (vec (sort-by str [(site-coords owner-row) (site-coords row)]))
+                   :recovery :align-frame-plan-config})))))
+          (recur (rest srcs)
+                 (cond-> regs
+                   (seq src-roots) (assoc-in [ns-sym roots] src-roots)
+                   (seq src-plans) (assoc-in [ns-sym plans] src-plans)
+                   (seq src-descs) (assoc-in [ns-sym descriptors] src-descs))
+                 (into root-owners
+                       (map (fn [[rid row]] [rid {:source ns-sym :row row}]))
+                       src-roots)
+                 (into plan-owners
+                       (map (fn [[fid row]] [fid {:source ns-sym :row row}]))
+                       src-plans)))
+        regs))))
+
+;; ---------------------------------------------------------------------------
+;; Pass boundaries
+;; ---------------------------------------------------------------------------
+
+(defn begin-build!
+  "Open a compile pass for `build-id` (the zero-arg form uses the sole
+  default build). DISCARDS any staging a failed prior pass left — a
+  successful pass commits at its close, so there is normally none — and marks
+  the pass open. `authoritative-members`, when supplied by the build hook from
+  Shadow's already-resolved graph, is open-pass conflict context: a committed
+  declaration owned by a nonmember cannot block its current replacement, but
+  stays last-known-good until successful finish. Sets the session-build
+  identity fallback so subsequent contributions on the REPL / plain-JVM path
+  route here."
+  ([] (begin-build! ::default nil))
+  ([build-id] (begin-build! build-id nil))
+  ([build-id authoritative-members]
+   (reset! session-build build-id)
+   (swap! state update build-id
+          (fn [s]
+            (assoc (or s empty-slice)
+                   :pass-open? true
+                   :authoritative-members (when (some? authoritative-members)
+                                            (set authoritative-members))
+                   :staged {}
+                   :touched #{})))
+   nil))
+
+(defn- commit-slice
+  "Pure: fold the open pass's staging into committed — every touched source
+  REPLACES its committed contribution with what it staged, or is evicted if
+  it staged nothing."
+  [slice]
+  (let [committed (reduce
+                   (fn [c src]
+                     (let [staged (get-in slice [:staged src])]
+                       (if (seq staged) (assoc c src staged) (dissoc c src))))
+                   (:committed slice)
+                   (:touched slice))]
+    (assoc slice
+           :committed committed
+           :staged {}
+           :touched #{}
+           :pass-open? false
+           :authoritative-members nil)))
+
+(defn commit-build!
+  "Commit the open pass for `build-id`: every touched source's staged
+  contribution replaces its committed one (or evicts it), untouched committed
+  sources are kept, and the pass closes. The last-known-good publication
+  point for an INCREMENTAL pass."
+  ([] (commit-build! (current-build-id)))
+  ([build-id]
+   (swap! state update build-id (fn [s] (commit-slice (or s empty-slice))))
+   nil))
+
+(defn- keep-members
+  "Pure: drop every committed source absent from `keep?` (a membership
+  predicate over sources)."
+  [slice keep?]
+  (update slice :committed
+          (fn [committed]
+            (select-keys committed (filter keep? (keys committed))))))
+
+(defn- committed-rows
+  "Pure: one finalized slice's COMMITTED rows for `reg-id`, merged across
+  sources (the same fold `committed-aggregate` performs, over an explicit
+  slice)."
+  [slice reg-id]
+  (reduce-kv (fn [m _src regs] (merge m (get regs reg-id)))
+             {} (:committed slice)))
+
+(defn prepare-shadow-build
+  "Purely open a disposable pass in `build-state` from its incoming accepted
+  snapshot. Dirty scratch from an abandoned compile and every no-pass REPL
+  overlay are overwritten/cleared. `recompiled-members` is Shadow's exact
+  compile schedule at `:compile-prepare`: those sources are pre-touched so a
+  successful recompile which removes its final re-frame.freehand declaration evicts
+  the accepted row even though no registry macro runs. Output-present cache
+  hits are not pre-touched and retain their accepted rows. The returned
+  build-state is the sole place this pass exists; no external last-known-good
+  state changes."
+  [build-state build-id members recompiled-members]
+  (let [accepted (accepted-snapshot build-state)
+        scratch (assoc empty-slice
+                       :pass-open? true
+                       :authoritative-members (set members)
+                       :committed (:registries accepted)
+                       :touched (set recompiled-members))]
+    (-> build-state
+        (assoc-in [:compiler-env accepted-snapshot-key]
+                  (assoc accepted :build-id build-id))
+        (assoc-in [:compiler-env scratch-key] scratch)
+        (update :compiler-env dissoc repl-overlay-key))))
+
+(defn shadow-finish-candidate
+  "Derive, but do not externally publish, the successful compiler candidate
+  from `build-state`'s disposable scratch. The snapshot version advances once
+  per finalized pass.
+
+  Before deriving anything, the supplied `build-id` is validated against
+  re-frame.freehand's OWN accepted private carrier and any still-present Shadow bridge
+  id via `carrier-build-id` — the same fail-closed identity every ambient
+  read/write traverses. A carrier for build :A whose id disagrees with a
+  supplied :B (or with a still-present Shadow bridge :B) therefore cannot
+  finalize into a :B-stamped snapshot carrying A's registry rows: it fails
+  before a candidate is derived."
+  [build-state build-id members]
+  ;; Fail-closed identity gate (JVM build-time only): the supplied build-id must
+  ;; agree with the accepted private carrier and any still-present Shadow bridge
+  ;; id before a candidate is derived.
+  #?(:clj
+     (when (ui-owned-compiler-state? (:compiler-env build-state))
+       (let [resolved (carrier-build-id (:compiler-env build-state))]
+         (when (and (some? resolved) (not= resolved build-id))
+           (throw
+            (ex-info
+             (str "re-frame.freehand compile-finish supplied build id " build-id
+                  " disagrees with its accepted private build carrier id "
+                  resolved "; refusing to finalize a cross-build candidate")
+             {::error ::private-build-id-shadow-disagreement
+              :recovery :check-ui-build-carrier
+              :private-build-id resolved
+              :shadow-build-id build-id}))))))
+  (let [accepted (accepted-snapshot build-state)
+        scratch (get-in build-state [:compiler-env scratch-key])]
+    (when-not (and scratch (:pass-open? scratch))
+      (throw
+       (ex-info
+        "re-frame.freehand compile-finish had no matching compiler-env scratch"
+        {::error ::missing-shadow-scratch
+         :build-id build-id
+         :recovery :configure-ui-build-hook-once})))
+    ;; Custom elements are NOT in the committed view-slice on this path
+    ;; (rf2-u53yy.1 S1): the manifest was harvested wholesale at
+    ;; `:compile-prepare` (all-members, macro-independent) and its cross-source
+    ;; conflict law was enforced there. Carry that finalized manifest onto the
+    ;; snapshot beside `:registries`.
+    (let [after (-> scratch commit-slice (keep-members (set members)))
+          ;; Views ride the disk-cache-durable analyzer-map carrier on the Shadow
+          ;; path (rf2-u53yy.1 S2). The defview macro contributes NO view row to
+          ;; the slice under a Shadow build pass, so harvest every authoritative
+          ;; member's compiled view descriptors from the analyzer map and overlay
+          ;; them onto the slice-derived rows of the other registries. A cache-hit
+          ;; member contributes its RESTORED descriptor identically to a freshly
+          ;; compiled one, so a warm source's views survive without the macro
+          ;; re-running. (Off the Shadow path — plain-JVM/REPL/tests staging views
+          ;; directly through the slice — the analyzer map is empty and the slice
+          ;; rows carry through unchanged.)
+          view-registries (harvest-view-registries build-state members)
+          ;; Roots + plans + Root Descriptors ride the disk-cache-durable SYNTHETIC
+          ;; per-namespace analyzer-map descriptor on the Shadow path (rf2-u53yy.1
+          ;; S4 roots/plans, S5 folds descriptors onto the same carrier). Their
+          ;; register-*-site! / register-descriptor! macros contribute NO slice row
+          ;; under a Shadow build pass, so harvest every authoritative member's
+          ;; root/plan/descriptor sites from the carrier and overlay them onto the
+          ;; slice-derived rows of the other registries — a cache-hit member
+          ;; contributes its RESTORED sites identically to a freshly compiled one. The
+          ;; cross-namespace Layer-1 laws run inside the harvest. (Off the Shadow path
+          ;; the analyzer carrier is empty and the slice rows carry through unchanged.)
+          root-plan-registries (harvest-root-plan-registries build-state members)
+          snapshot {:build-id build-id
+                    :registries (-> (:committed after)
+                                    (merge-registries view-registries)
+                                    (merge-registries root-plan-registries))
+                    :elements (:element-manifest scratch {})
+                    :version (inc (long (or (:version accepted) 0)))}]
+      {:snapshot snapshot})))
+
+(defn carry-shadow-candidate
+  "Purely associate `candidate` into the returned Shadow build-state and drop
+  disposable scratch/REPL overlay. Shadow retaining this returned state after
+  all later stages is the commit; a downstream failure discards it."
+  [build-state {:keys [snapshot]}]
+  (-> build-state
+      (assoc-in [:compiler-env accepted-snapshot-key] snapshot)
+      (update :compiler-env dissoc scratch-key repl-overlay-key)))
+
+(defn finish-candidate
+  "Purely derive `build-id`'s successful whole-build finish without publishing
+  it. Returns an opaque candidate containing the observed slice and the
+  finalized slice; the Shadow hook then calls `commit-finish-candidate!`."
+  [build-id members]
+  (let [before (get @state build-id empty-slice)
+        after  (-> before commit-slice (keep-members (set members)))]
+    {:build-id build-id
+     :before before
+     :after after}))
+
+(defn commit-finish-candidate!
+  "Publish a previously derived finish candidate iff its build slice has not
+  changed. A projection failure never calls this function, so compiler state
+  remains last-known-good. Unrelated build ids may advance concurrently; the
+  compare is scoped to this candidate's explicit build id."
+  [{:keys [build-id before after]}]
+  (swap! state
+         (fn [all]
+           (let [current (get all build-id empty-slice)]
+             (when-not (= before current)
+               (throw
+                (ex-info
+                 "re-frame.freehand finish candidate became stale before commit"
+                 {::error ::stale-finish-candidate
+                  :build-id build-id})))
+             (assoc all build-id after))))
+  nil)
+
+(defn reconcile!
+  "Whole-build finalize for `build-id`: commit the open pass, THEN drop every
+  committed source that did NOT re-declare this pass (a deleted / renamed
+  FILE). Sound ONLY after a WHOLE pass — an incremental pass recompiles a
+  subset, whose untouched sources legitimately keep their prior contribution,
+  so it must NOT reconcile."
+  ([] (reconcile! (current-build-id)))
+  ([build-id]
+   (swap! state update build-id
+          (fn [s]
+            (let [s (or s empty-slice)
+                  touched (:touched s)]
+              (-> s commit-slice (keep-members touched)))))
+   nil))
+
+(defn finish-build!
+  "Whole-build finalize against an AUTHORITATIVE member set (the shadow
+  hook's `:build-sources`): commit the open pass, then drop every committed
+  source absent from `members` (a coll/set of source ns-syms). Safe on EVERY
+  pass, incrementals included — macro silence is never the deletion signal,
+  so authoritative membership, not `touched`, drives eviction."
+  [build-id members]
+  (let [members (set members)]
+    (swap! state update build-id
+           (fn [s] (-> (or s empty-slice) commit-slice (keep-members members)))))
+  nil)
+
+(defn abort-build!
+  "Discard the open pass's staging for `build-id`; the committed
+  last-known-good survives untouched. A failed / aborted compile."
+  ([] (abort-build! (current-build-id)))
+  ([build-id]
+   (swap! state update build-id
+          (fn [s]
+            (assoc (or s empty-slice)
+                   :staged {}
+                   :touched #{}
+                   :pass-open? false
+                   :authoritative-members nil)))
+   nil))
+
+(defn reset-build!
+  "Hard-clear every build slice — the clean-build / independent-build /
+  test-isolation boundary. `begin-build!`'s per-source replace covers
+  incremental correctness; this is the fresh top-level state."
+  []
+  (reset! state {})
+  (reset! session-build ::default)
+  nil)

--- a/implementation/freehand/src/re_frame/freehand/compiler/build_hook.clj
+++ b/implementation/freehand/src/re_frame/freehand/compiler/build_hook.clj
@@ -1,0 +1,347 @@
+(ns re-frame.freehand.compiler.build-hook
+  "The Shadow build-lifecycle adapter for re-frame.freehand compiler state.
+
+  Shadow's retained functional build-state is the successful-build authority.
+  The whole-build compiler registries — view digests, the Layer-1 root/plan
+  indexes, the Root Descriptor index, and the compile-time custom-element
+  declarations — are HARVESTED at build time from cache-durable carriers, not
+  reconstructed from macro-expansion side effects (rf2-u53yy.1). That is what let
+  the old `:cache-blockers #{re-frame.freehand}` install tax be removed at the S6
+  cut-over: the hook is now the ONLY re-frame.freehand build setting, and a warm daemon
+  start REUSES Shadow's disk cache instead of re-expanding the UI-consuming
+  namespace set.
+
+  `:compile-prepare`
+    - harvests every authoritative member's literal `(v/custom-element …)`
+      declarations from SOURCE into a flat all-members manifest — a pure function
+      of the build's source, independent of which sources re-expand (S1);
+    - coarse-invalidates the UI literal-consumer set when that manifest CHANGED
+      on a warm build, so no view keeps a stale baked property/attribute lowering
+      (rf2-vxgfnd.141 dim 3);
+    - opens a disposable pass seeded from the incoming accepted snapshot,
+      pre-touching exactly the CLJS sources Shadow scheduled to compile so a
+      recompiled source that dropped its final declaration evicts its accepted
+      row, while output-present cache hits keep theirs;
+    - wires the runtime removed-source projection (rf2-4vm19): points the
+      devtools client's `:build-notify` receiver at
+      `re-frame.freehand.rules/shadow-build-notify` (watched dev builds only, and
+      never over a consumer's own receiver), so each successful build's
+      broadcast `:build-sources` membership evicts a deleted/renamed-away
+      source's runtime custom-element rows without a page reload.
+
+  `:compile-finish`
+    - folds every authoritative member's descriptor — RESTORED from Shadow's disk
+      cache for a cache-hit member (rf2-u53yy.1.1, S0) and freshly stamped for a
+      compiled one — into the whole-build registries, running the cross-source
+      uniqueness/conflict laws there (a compile-finish error is still a build-time
+      error), and carries the finalized candidate in the RETURNED compiler-env.
+
+  The finish harvest is why removing a declaration evicts without any inference
+  of \"which sources recompiled\": a recompiled source is re-analyzed fresh (its
+  removed def/site simply vanishes from the analyzer map) and a cache-hit source's
+  descriptor is restored intact, so the registries are a pure aggregation over the
+  current graph's cache-durable descriptors — present identically for cached and
+  compiled members.
+
+  There is deliberately no external last-known-good commit. Shadow retains the
+  returned state only after the complete optimize/check/flush/watch pipeline
+  succeeds; any later failure discards the candidate. The next prepare therefore
+  starts from the prior accepted snapshot and overwrites all dirty scratch.
+
+  Shadow's no-pass REPL path runs no build hook. Its macro bookkeeping lives in
+  an isolated compiler-env overlay and never changes the accepted snapshot;
+  saving and completing a real build publishes the next accepted snapshot.
+
+  Transaction boundary: the accepted build-state and active HMR runtime are
+  last-known-good. Shadow may have partially rewritten its raw output directory
+  before a late failure; re-frame.freehand does not claim filesystem rollback for that
+  raw directory — Shadow's output directory is Shadow's to publish. A fresh page
+  load served straight from it can therefore briefly execute rejected candidate
+  bytes until the next accepted build overwrites them; the accepted compiler
+  snapshot, which re-frame.freehand does own, reverts."
+  (:require [re-frame.freehand.compiler.build :as build]
+            [re-frame.freehand.compiler.harvest :as harvest]))
+
+;; ---------------------------------------------------------------------------
+;; Authoritative membership + the prepare-time compile schedule
+;; ---------------------------------------------------------------------------
+
+(defn- member-nss
+  "Authoritative declaring namespaces from Shadow's resolved build graph."
+  [{:keys [build-sources sources]}]
+  (reduce
+   (fn [acc resource-id]
+     (let [rc (get sources resource-id)]
+       (into acc (or (:provides rc)
+                     (when-let [n (:ns rc)] #{n})))))
+   #{}
+   build-sources))
+
+(defn- parallel-build?
+  "Whether Shadow schedules this build in parallel — output presence is then the
+  exact cache-hit / recompile signal."
+  [build-state]
+  (and (:executor build-state)
+       (not (false? (get-in build-state
+                            [:compiler-options :parallel-build])))))
+
+(defn- pass-recompiles-cljs?
+  "Whether Shadow will actually (re)compile CLJS resource `resource-id` this pass.
+  At `:compile-prepare`, watch reset has already removed output for modified and
+  affected sources. Parallel compilation schedules precisely sources with no
+  retained output map; sequential compilation calls `generate-output-for-source`,
+  which also recompiles retained outputs carrying warnings. Mirror those two
+  Shadow branches rather than treating every graph member as dirty: warm cache-hit
+  silence must preserve accepted registry rows."
+  [{:keys [sources output] :as build-state} parallel? resource-id]
+  (let [{:keys [type]} (get sources resource-id)
+        prior-output (get output resource-id)]
+    (and (= :cljs type)
+         (if parallel?
+           (not (map? prior-output))
+           (or (nil? prior-output)
+               (seq (:warnings prior-output)))))))
+
+(defn- recompiled-member-nss
+  "Declaring namespaces whose CLJS source Shadow will actually compile this pass —
+  Shadow's own compile schedule, read from output presence at `:compile-prepare`.
+  They are pre-touched so a recompiled source that dropped its final declaration
+  evicts its accepted row; output-present cache hits keep theirs."
+  [{:keys [build-sources sources] :as build-state}]
+  (let [parallel? (parallel-build? build-state)]
+    (reduce
+     (fn [acc resource-id]
+       (if (pass-recompiles-cljs? build-state parallel? resource-id)
+         (let [{:keys [ns provides]} (get sources resource-id)]
+           (into acc (or provides (when ns #{ns}))))
+         acc))
+     #{}
+     build-sources)))
+
+;; ---------------------------------------------------------------------------
+;; Custom-element harvest (rf2-vxgfnd.141 dim 2, rf2-u53yy.1 S1)
+;;
+;; Compile-time property lowering reads the custom-element manifest at
+;; macroexpansion, and macros expand top-to-bottom, so a view expanded before its
+;; tag's `(v/custom-element …)` declaration — or in a source with no `:require`
+;; edge to the declaring source — would classify a declared property as an HTML
+;; attribute. Harvesting EVERY authoritative member's literal declarations from
+;; SOURCE here, at `:compile-prepare`, and storing them beside the open pass makes
+;; classification a pure function of the build's declarations rather than of
+;; evaluation order OR of which sources re-expand — the direction that let S6 drop
+;; the cache blocker.
+;; ---------------------------------------------------------------------------
+
+(defn- ui-cache-blocked-source?
+  "Shadow's `is-cache-blocked?` predicate specialized to re-frame.freehand — the
+  re-frame.freehand literal-consumer set (a `:cljs` source that is, requires, or
+  macro-requires `re-frame.freehand`)."
+  [{:keys [type ns requires macro-requires]}]
+  (and (= :cljs type)
+       (or (= 're-frame.freehand ns)
+           (contains? (set requires) 're-frame.freehand)
+           (contains? (set macro-requires) 're-frame.freehand))))
+
+(defn- resource-source
+  "Source text of a Shadow CLJS resource: its already-loaded `:source` string,
+  else read from `:url` / `:file`. nil (a source we cannot read) makes the
+  harvest a graceful no-op for that member — the `v/custom-element` macro
+  remains the authority."
+  [{:keys [source url file]}]
+  (cond
+    (string? source) source
+    url  (try (slurp url) (catch Throwable _ nil))
+    file (try (slurp file) (catch Throwable _ nil))
+    :else nil))
+
+(defn- harvest-all-seed
+  "The `[source tag decl]` triples for EVERY authoritative re-frame.freehand-consumer
+  source in the build graph — not just the subset Shadow recompiles this pass.
+
+  Harvesting the WHOLE authoritative member set (rf2-u53yy.1 S1) makes the
+  custom-element manifest a pure function of the build's SOURCE: a warm
+  cache-hit's declarations are re-derived by reading its source, never by
+  re-running its macros. That is what lets the manifest be DECOUPLED from the
+  view-slice — a warm source's declarations no longer need staging into the pass
+  (which marked it touched and evicted its committed views), and the manifest no
+  longer depends on macro re-expansion (the direction S6 needed to drop the cache
+  blocker). `harvest/source-seed` is a bounded syntactic reader; a source we
+  cannot read is a graceful no-op."
+  [{:keys [build-sources sources]}]
+  (into []
+        (mapcat
+         (fn [resource-id]
+           (let [{:keys [ns] :as rc} (get sources resource-id)]
+             (when (and ns (ui-cache-blocked-source? rc))
+               (some->> (resource-source rc)
+                        (harvest/source-seed ns))))))
+        build-sources))
+
+;; ---------------------------------------------------------------------------
+;; Declaration-edit warm staleness — COARSE invalidation (rf2-vxgfnd.141, dim 3)
+;;
+;; A literal view bakes its property/attribute classification at compile from the
+;; effective manifest. So a WARM edit that changes only a declaration — a source
+;; whose `(v/custom-element …)` grew, shrank, or vanished — leaves every
+;; consumer view that Shadow does NOT recompile (no `:require` edge to that
+;; declaring source) with a STALE baked lowering: the warm build no longer equals
+;; a clean build.
+;;
+;; The ruled fix (rf2-vxgfnd.141 DECISION, coarse per the Codex opinion) is
+;; deliberately NOT a per-tag declaration->consumer dependency graph: declarations
+;; are few and change rarely, so when the harvested manifest changes THIS pass we
+;; recompile the whole re-frame.freehand literal-consumer set (the set the hook already
+;; identifies). Every consumer then re-bakes against the new manifest = a clean
+;; build. A change is detected against the ACCEPTED manifest, so an ordinary
+;; view-only edit (no declaration delta) invalidates nothing, and a pure
+;; cross-namespace move that leaves the tag->properties manifest identical does
+;; not either.
+;; ---------------------------------------------------------------------------
+
+(defn- manifest-changed?
+  "Whether this pass's freshly-harvested all-members `tag -> {:properties …}`
+  manifest differs from the accepted one — the coarse invalidation trigger.
+  Because the manifest is now a wholesale all-members re-derivation over the
+  build's source (rf2-u53yy.1 S1), the comparison is simply the fresh manifest
+  against the accepted manifest; no accepted/recompiled overlay is needed. The
+  manifest carries `:properties` only, so a declaration's provenance (owning
+  namespace) moving does not count as a change unless the properties differ."
+  [build-state fresh-manifest]
+  (not= (build/accepted-element-manifest build-state) fresh-manifest))
+
+(defn- invalidate-ui-consumers
+  "Reset retained output for every re-frame.freehand literal-consumer source, so the
+  next schedule recompiles and re-bakes them against the changed manifest. Coarse
+  by design (the ruled dimension-3 mechanism): a declaration change is rare, and
+  a full UI-consumer recompile trivially restores warm=clean without a per-tag
+  dependency graph."
+  [build-state]
+  (reduce (fn [bs resource-id]
+            (if (ui-cache-blocked-source? (get-in bs [:sources resource-id]))
+              (update bs :output dissoc resource-id)
+              bs))
+          build-state
+          (:build-sources build-state)))
+
+(defn- reconcile-declaration-edits
+  "If this pass's freshly-harvested `fresh-manifest` changes the custom-element
+  manifest on a WARM build (accepted version > 0), coarse-invalidate the UI
+  literal-consumer set so no view keeps a stale baked lowering (rf2-vxgfnd.141,
+  dimension 3). On a cold (version-0) build there is no prior baked lowering to
+  invalidate, so this only acts warm."
+  [build-state fresh-manifest]
+  (let [version (long (or (:version (build/accepted-snapshot build-state)) 0))]
+    (if (and (pos? version)
+             (manifest-changed? build-state fresh-manifest))
+      (invalidate-ui-consumers build-state)
+      build-state)))
+
+;; ---------------------------------------------------------------------------
+;; The runtime removed-source projection (rf2-4vm19)
+;;
+;; A deleted or renamed-away saved source never re-runs, so the runtime's
+;; SHADOW_NS_RESET producer can never report it and its custom-element ledger
+;; rows would persist until a full page load. The ONLY authority for that delta
+;; is the compile side's `:build-sources` membership — which shadow itself
+;; already broadcasts to every connected runtime on each successful watch build
+;; (`:build-complete` `:info :sources`). The pinned client exposes exactly one
+;; receiver seam for that broadcast: the `:build-notify` fn, carried as the
+;; `custom-notify-fn` closure-define and resolved by munged name off `$CLJS` at
+;; call time. Pointing that define at `re-frame.freehand.rules/shadow-build-notify`
+;; projects the removed-namespace delta into the existing runtime reload cycle
+;; (notify-reload! -> note-reloaded-sources! -> commit-reload!) with no second
+;; protocol and no consumer configuration — the hook stays the one re-frame.freehand
+;; build setting (rf2-u53yy.1 S6).
+;;
+;; Injected only where the delta can exist and land: a WATCHED dev build
+;; (`:worker-info` — the only mode that hot-reloads; release builds carry no
+;; devtools client, so the define would be dead weight there) whose graph
+;; actually contains the runtime ledger namespace. In dev mode the define is
+;; not baked into any cached source — shadow emits the whole define map into
+;; the flushed bootstrap (`CLOSURE_DEFINES`) on every build — so injection at
+;; `:compile-prepare` lands unconditionally, with zero cache interaction.
+;; ---------------------------------------------------------------------------
+
+(def ^:private client-notify-define
+  "The shadow devtools client's ONE `:build-notify` receiver slot
+  (`shadow.cljs.devtools.client.env/custom-notify-fn`), the closure-define
+  `shadow.build.targets.shared/repl-defines` fills from a build's
+  `:devtools {:build-notify …}`."
+  'shadow.cljs.devtools.client.env/custom-notify-fn)
+
+(def ^:private runtime-notify-fn
+  "`re-frame.freehand.rules/shadow-build-notify`, munged the way the client resolves
+  the receiver off `$CLJS` (`cljs.compiler/munge` of the fn symbol)."
+  "re_frame.freehand.rules.shadow_build_notify")
+
+(defn- wire-removed-source-notify
+  "Point the shadow client's `:build-notify` receiver at
+  `re-frame.freehand.rules/shadow-build-notify` for a watched dev build whose graph
+  contains the runtime ledger, unless the build claimed the seam itself — a
+  consumer's own `:devtools {:build-notify …}` (already merged into the
+  closure-defines at configure) always wins; shadow has exactly one receiver
+  slot, and removed-source eviction then degrades to the documented
+  full-reload bound unless that receiver delegates."
+  [build-state members]
+  (if (and (= :dev (:shadow.build/mode build-state))
+           (:worker-info build-state)
+           (contains? members 're-frame.freehand.rules)
+           (not (get-in build-state
+                        [:compiler-options :closure-defines client-notify-define])))
+    (assoc-in build-state
+              [:compiler-options :closure-defines client-notify-define]
+              runtime-notify-fn)
+    build-state))
+
+;; ---------------------------------------------------------------------------
+;; The hook
+;; ---------------------------------------------------------------------------
+
+(defn hook
+  "Shadow build hook. Configure once in `:build-defaults` as
+  `:build-hooks [(re-frame.freehand.compiler.build-hook/hook)]`."
+  {:shadow.build/stages #{:compile-prepare :compile-finish}}
+  [{build-id :shadow.build/build-id
+    stage    :shadow.build/stage
+    :as      build-state}]
+  (case stage
+    :compile-prepare
+    ;; Harvest EVERY authoritative member's literal custom-element declarations
+    ;; ONCE into the flat all-members manifest (rf2-u53yy.1 S1) — a pure function
+    ;; of source, independent of macro re-expansion. `element-manifest` enforces
+    ;; the cross-source conflict law (throws on a contradiction — a build-time
+    ;; error). A warm edit that changed the manifest coarse-invalidates the UI
+    ;; literal consumers so none keeps a stale baked lowering; that must precede
+    ;; the schedule read so the widened set is scheduled and re-baked this pass.
+    (let [fresh-manifest (build/element-manifest build-id
+                                                 (harvest-all-seed build-state))
+          build-state    (reconcile-declaration-edits build-state fresh-manifest)
+          members        (member-nss build-state)
+          ;; Wire the runtime removed-source projection (rf2-4vm19): the
+          ;; client's `:build-notify` receiver becomes the producer that feeds
+          ;; the removed `:build-sources` delta into the runtime ledger — the
+          ;; delta a deleted/renamed-away source can never self-report.
+          build-state    (wire-removed-source-notify build-state members)]
+      (-> (build/prepare-shadow-build build-state
+                                      build-id
+                                      members
+                                      (recompiled-member-nss build-state))
+          ;; Store the all-members manifest beside the open pass BEFORE any view
+          ;; analyzes, so property lowering is a pure function of the build's
+          ;; declarations rather than of evaluation order OR of which sources
+          ;; re-expand (rf2-vxgfnd.141 dim 2, rf2-u53yy.1 S1). The manifest sits
+          ;; outside the per-source `:touched` ledger, so it can never evict a
+          ;; warm source's committed views.
+          (build/set-shadow-element-manifest fresh-manifest)))
+
+    :compile-finish
+    ;; Fold every authoritative member's cache-durable descriptor into the
+    ;; whole-build registries (views S2, roots/plans S4, descriptors S5), restored
+    ;; from Shadow's disk cache for a cache-hit member and freshly stamped for a
+    ;; compiled one. A pure build-state transform; a later Shadow failure discards
+    ;; the returned candidate transactionally.
+    (let [candidate (build/shadow-finish-candidate
+                     build-state build-id (member-nss build-state))]
+      (build/carry-shadow-candidate build-state candidate))
+
+    build-state))

--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_cljs.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_cljs.cljc
@@ -1,0 +1,1055 @@
+(ns re-frame.freehand.compiler.emit-cljs
+  "AST -> direct react/jsx-runtime CLJS forms (the client emitter).
+
+  - jsx/jsxs calls with compile-time-converted quoted prop names
+    (cljs.core/js-obj with literal string keys — safe under :advanced);
+  - maximal fully-static subtrees hoist to module constants;
+  - fully-static props/style objects on otherwise-dynamic elements hoist;
+  - event vectors lower to stable per-site callbacks whose meaning and frame
+    destination are retargeted only by the winning layout commit;
+  - per-slot rf= memo comparator (straight-line over declared slots;
+    generic for :as views);
+  - `(when ^boolean js/goog.DEBUG ...)`-wrapped dev checks strip under
+    :advanced.
+
+  This namespace only RUNS on the JVM (macro expansion) but is .cljc so
+  both hosts' test suites can golden the emission as data."
+  (:require [clojure.string :as str]
+            [clojure.walk :as walk]
+            [re-frame.source-coords :as source-coord]
+            [re-frame.freehand.compiler.analyze :as ana]
+            [re-frame.freehand.rules :as rules]
+            ;; JVM-only: a self-recursive view completes the same-named `:refer`
+            ;; shadowing in the LIVE CLJS analyzer state so its def/declare
+            ;; resolve to the current-ns Var (see `emit-defview`). Never loaded on
+            ;; the CLJS host — the emitter only mutates analyzer state on the JVM
+            ;; macro-expansion path.
+            #?(:clj [cljs.env])))
+
+(def ^:private props-sym 'rf-ui-props)
+
+;; Compiler-local stack of the runtime keys for enclosing keyed rows. It is
+;; carried only into native passive-ref ownership; capture-free data handlers
+;; deliberately keep their one shared lexical callback (Spec 004 §Loops).
+(def ^:dynamic *row-key-forms* [])
+
+(defn- new-state [view-name]
+  (atom {:defs [] :n 0 :sub-queries {}
+         :view-name (name view-name)}))
+
+(defn- hoist! [st kind form]
+  (let [{:keys [n view-name]} @st
+        sym (symbol (str view-name "$" (name kind) "$" n))]
+    (swap! st #(-> % (update :n inc) (update :defs conj `(def ~sym ~form))))
+    sym))
+
+(defn- literal-data?
+  "True for self-evaluating/collection data that CLJS would otherwise rebuild
+  inside the render function. Lists and symbols remain runtime expressions."
+  [x]
+  (cond
+    (ana/literal-scalar? x) true
+    (vector? x) (every? literal-data? x)
+    (map? x) (every? (fn [[k v]] (and (literal-data? k) (literal-data? v))) x)
+    (set? x) (every? literal-data? x)
+    :else false))
+
+(defn- hoist-literal-sub-queries
+  [st form]
+  (letfn [(hoist-one [x]
+            (if (ana/runtime-sub-form? x)
+              (let [[runtime sid query] x]
+                (if (literal-data? query)
+                  (let [query-sym
+                        (or (get-in @st [:sub-queries query])
+                            (let [sym (hoist! st :query query)]
+                              (swap! st assoc-in [:sub-queries query] sym)
+                              sym))]
+                    (with-meta (list runtime sid query-sym) (meta x)))
+                  x))
+              x))
+          (visit [x]
+            ;; `quote` is data, not executable compiler output. Returning the
+            ;; exact form preserves its payload spelling and metadata while the
+            ;; lower-level walk remains post-order everywhere executable.
+            (if (and (seq? x) (= 'quote (first x)))
+              x
+              (walk/walk visit hoist-one x)))]
+    (visit form)))
+
+;; ---------------------------------------------------------------------------
+;; Handlers
+;; ---------------------------------------------------------------------------
+
+(defn- placeholder-form [x]
+  (case x
+    :rf.ui/value   `re-frame.freehand.events/value-placeholder
+    :rf.ui/checked `re-frame.freehand.events/checked-placeholder
+    :rf.ui/key     `re-frame.freehand.events/key-placeholder
+    x))
+
+(defn- site-key-form [{:keys [sid site-index]}]
+  `(if ~(with-meta 'js/goog.DEBUG {:tag 'boolean}) ~sid ~site-index))
+
+(defn- debug-site-form
+  [{:keys [sid view-id source-coord path classification]}]
+  `(when ~(with-meta 'js/goog.DEBUG {:tag 'boolean})
+     {:sid ~sid
+      :view-id ~view-id
+      :source-coord ~source-coord
+      :path ~path
+      :classification ~classification}))
+
+(defn- handler-flags
+  [h prevent? stop?]
+  (+ (if (:sync? h) 1 0)
+     (if prevent? 2 0)
+     (if stop? 4 0)
+     (if (get-in h [:form :once]) 8 0)))
+
+(defn- vector-handler-form
+  [h ev-vec prevent? stop?]
+  `(re-frame.freehand.events/data-handler
+    ~(site-key-form h)
+    [~@(map placeholder-form ev-vec)]
+    ~(handler-flags h prevent? stop?)
+    ~(debug-site-form h)))
+
+(defn- handler-form [h]
+  (case (:classification h)
+    :vector
+    (vector-handler-form h (:form h) false false)
+
+    :options
+    (let [{:keys [event prevent-default stop-propagation]} (:form h)]
+      (vector-handler-form h event prevent-default stop-propagation))
+
+    :ui-event
+    ;; The site proof is static (`handler-flags` carries the controlled-input
+    ;; sync bit exactly as a literal vector does); the compiled fn produces the
+    ;; event vector at invocation, so its outcome is classified there.
+    `(re-frame.freehand.events/event-handler
+      ~(site-key-form h) ~(:form h) ~(handler-flags h false false)
+      ~(debug-site-form h))
+
+    :handler
+    ;; v/handler — the explicit imperative committed callback (the bare-fn
+    ;; shorthand's visible spelling); its return is dropped, no dispatch.
+    `(re-frame.freehand.events/handler-callback
+      ~(site-key-form h) ~(:form h) ~(debug-site-form h))
+
+    :fn
+    `(re-frame.freehand.events/dynamic-handler
+      ~(site-key-form h) ~(:form h) ~(debug-site-form h))
+
+    :dynamic
+    `(re-frame.freehand.events/dynamic-handler
+      ~(site-key-form h) ~(:form h) ~(debug-site-form h))))
+
+(defn- native-event-name
+  "Literal :on-* spelling -> the browser addEventListener event type.  Native
+  DOM event types are the hyphen-collapsed author spelling except dblclick;
+  custom-element event tails are their verbatim author spelling."
+  [handler-name custom?]
+  (if custom?
+    (subs handler-name 3)
+    (case handler-name
+      "on-double-click" "dblclick"
+      (str/replace (subs handler-name 3) "-" ""))))
+
+(defn- passive-listener-spec
+  [h custom?]
+  `[~(site-key-form h)
+    ~(native-event-name (:name h) custom?)
+    ~(handler-form h)
+    ~(:capture? h)])
+
+(defn- emitted-ref-form
+  "Preserve the explicit callback-ref marker. Unmarked dynamic values are
+  object-ref positions; the dev guard rejects a function without invoking it.
+  The branch and single-evaluation carrier disappear under :advanced."
+  [{:keys [form raw-fn?] :as ref-a}]
+  (when ref-a
+    (if raw-fn?
+      form
+      (let [ref-value (gensym "rf-ui-ref")]
+        `(let [~ref-value ~form]
+           (when ~(with-meta 'js/goog.DEBUG {:tag 'boolean})
+             (re-frame.freehand.runtime/assert-object-ref! ~ref-value))
+           ~ref-value)))))
+
+;; ---------------------------------------------------------------------------
+;; Element props
+;; ---------------------------------------------------------------------------
+
+(defn- class-form [c]
+  (let [{:keys [base-str flags dyn]} c]
+    (cond
+      (and (empty? flags) (nil? dyn))
+      (when (seq base-str) base-str)
+
+      ;; The common one-flag/static-base case is exactly a binary string
+      ;; choice. Avoid generic `str`'s conversion of the false `when` arm;
+      ;; the condition is still evaluated once and the non-empty static base
+      ;; keeps both results canonical.
+      (and (seq base-str) (nil? dyn) (= 1 (count flags)))
+      (let [[n f] (first flags)]
+        `(if ~f ~(str base-str " " n) ~base-str))
+
+      ;; literal flag maps over a non-empty static base (the `.sugar
+      ;; {:class {:flag cond}}` idiom) compile STRAIGHT-LINE: the flag
+      ;; order is compile-time-known (analyzer pre-sorts), the base
+      ;; guarantees a non-empty string, and the generic classes-str
+      ;; vector/join machinery costs ~0.5us per element — G-1 measured
+      ;; it as a 20-row-list regression (rf2-vxgfnd.6)
+      (and (seq base-str) (nil? dyn))
+      `(str ~base-str ~@(map (fn [[n f]] `(when ~f ~(str " " n))) flags))
+
+      :else
+      `(re-frame.freehand.rules/classes-str
+        [~@(when (seq base-str) [base-str])
+         ~@(map (fn [[n f]] `(when ~f ~n)) flags)
+         ~@(when dyn [`(re-frame.freehand.rules/class-val ~dyn)])]))))
+
+(defn- style-form [st s inline?]
+  (if-let [dyn (:dyn s)]
+    `(re-frame.freehand.runtime/style-obj ~dyn)
+    (let [pairs (mapcat (fn [{:keys [css-name value literal?]}]
+                          [(rules/react-style-name css-name)
+                           (if literal?
+                             (if (keyword? value) (name value) value)
+                             `(re-frame.freehand.runtime/style-val ~value))])
+                        (:entries s))
+          form  `(cljs.core/js-obj ~@pairs)]
+      (if (and (:static? s) (not inline?))
+        (hoist! st :style form)
+        form))))
+
+(defn- attr-pair [{:keys [react-name kind value literal?]}]
+  [react-name
+   (cond
+     (and literal? (keyword? value)) (name value)
+     literal? value
+     (= kind :property) value                      ; properties pass through
+     :else `(re-frame.freehand.runtime/attr-val ~value))])
+
+(defn- element-prop-pairs
+  "-> [{:name str :form any :static? bool} ...] in canonical order:
+  class, [sugar-id + author props in source order], style, ref."
+  [st node inner-inline?]
+  (let [{:keys [props]} node
+        class-a (:class props)
+        class-p (when class-a
+                  (when-some [f (class-form class-a)]
+                    [{:name "className" :form f :static? (:static? class-a)}]))
+        attr-ps (map (fn [a]
+                       (let [[n f] (attr-pair a)]
+                         {:name n :form f :static? (:literal? a)}))
+                     (:attrs props))
+        passive-events (filter :passive? (:events props))
+        react-events   (remove :passive? (:events props))
+        event-ps (map (fn [h]
+                        {:name (rules/react-event-name (:name h) (:capture? h))
+                         :form (handler-form h)
+                         :static? false})
+                      react-events)
+        style-p (when (:style props)
+                  [{:name "style"
+                    :form (style-form st (:style props) inner-inline?)
+                    :static? (:static? (:style props))}])
+        authored-ref-form (emitted-ref-form (:ref props))
+        ref-form (cond
+                   (seq passive-events)
+                   `(re-frame.freehand.events/passive-ref
+                     [~@(map #(passive-listener-spec % (:custom? node))
+                             passive-events)]
+                     ~authored-ref-form
+                     ~(when (seq *row-key-forms*) (vec *row-key-forms*)))
+
+                   (:ref props)
+                   authored-ref-form)
+        ref-p   (when ref-form
+                  [{:name "ref" :form ref-form :static? false}])
+        html-p  (when (:html node)
+                  [{:name "dangerouslySetInnerHTML"
+                    :form `(cljs.core/js-obj "__html" ~(:form (:html node)))
+                    :static? (:static? (:html node))}])]
+    (vec (concat class-p attr-ps event-ps style-p ref-p html-p))))
+
+;; ---------------------------------------------------------------------------
+;; Nodes
+;; ---------------------------------------------------------------------------
+
+(declare emit-node)
+
+(defn- children-forms [st nodes inline?]
+  (into [] (keep #(emit-node % st inline?)) nodes))
+
+(defn- ordered-literal-object
+  "Emit an object literal for compile-known string keys. `js-obj` preserves
+  dynamic value order through an IIFE; here the literal's own left-to-right
+  property evaluation provides that guarantee without the per-render call.
+  Keys remain string expressions, so :advanced cannot rename React/custom
+  property spelling. JavaScript gives a colon-form `__proto__` definition
+  prototype-setter semantics, so that one magic key uses a computed property:
+  an ordinary own data property with the same evaluation order."
+  [pairs]
+  (let [pairs (vec pairs)]
+    (list* 'js*
+           (str "({"
+                (str/join "," (map (fn [[k _]]
+                                      (if (= "__proto__" k)
+                                        "[~{}]:~{}"
+                                        "~{}:~{}"))
+                                    pairs))
+                "})")
+           (mapcat identity pairs))))
+
+(defn- jsx-runtime-call [multi? tag-form props-form key-info]
+  ;; Invoke the imported JS MODULE PROPERTY, not a CLJS var holding the
+  ;; imported function and not a forwarding wrapper. `js*` is intentional at
+  ;; this emitter boundary: a CLJS property-read invocation is otherwise
+  ;; treated as IFn (or as a receiver-preserving method call), while the JS
+  ;; module alias that makes `(jsxrt/jsx ...)` direct exists only in runtime's
+  ;; namespace. These four closed templates emit exactly the same plain JS
+  ;; call shape as a caller-local `react/jsx-runtime` alias.
+  ;; `:present?` deliberately selects React's 3-argument API even when the
+  ;; authored key expression is nil or false.
+  (list* 'js*
+         (case [multi? (boolean (:present? key-info))]
+           [false false] "(0,~{}.jsx)(~{},~{})"
+           [false true]  "(0,~{}.jsx)(~{},~{},~{})"
+           [true false]  "(0,~{}.jsxs)(~{},~{})"
+           [true true]   "(0,~{}.jsxs)(~{},~{},~{})")
+         're-frame.freehand.runtime/jsx-runtime
+         tag-form
+         props-form
+         (when (:present? key-info) [(:expr key-info)])))
+
+(defn- annotate-host-root-props
+  "Stamp the DEV view-evidence DOM annotation onto a compiler-owned host root's
+  props object: `data-rf2-source-coord` (the `<ns>:<sym>:<line>:<col>` source
+  coordinate — click-to-source) and `data-rf-view` (the view id — the record
+  identity Xray matches its hover-highlight against). This is today's attribute
+  vocabulary (Spec 004 §View identity — Source ↔ DOM navigation; Spec 006
+  §Source-coord annotation + §View tagging contract), reusing the ONE cross-host
+  `re-frame.source-coords` value projections so the compiler-owned host root and
+  the Reagent/UIx adapter walks emit byte-identical attribute values by
+  construction — existing Xray click-to-source works day one.
+
+  The stamp sits behind `^boolean js/goog.DEBUG`, so under :advanced +
+  goog.DEBUG=false Closure constant-folds the gate to false and DCEs the whole
+  branch — the literal `data-rf2-source-coord` / `data-rf-view` strings never
+  reach the production bundle (both are on the standard elision sentinel set).
+  The props object is mutated in place BEFORE it reaches the JSX runtime, exactly
+  as the trusted-markup spread branch sets `dangerouslySetInnerHTML`.
+
+  AUTHORED OWN VALUE WINS (rf2-x1nbv): each attribute is stamped ONLY when the
+  props object does not already carry it — an author-supplied own value (a literal
+  pair, a dynamic attr, a `v/spread` merge, or a `v/spread-safe` result) is never
+  overwritten. This is the adapter / trust-programmer law: because this runs over
+  the FINAL props object (after every spread/spread-safe merge), the surviving
+  authored value wins uniformly, and the JVM `static-form` twin matches it. The
+  `unchecked-get` presence reads sit INSIDE the `goog.DEBUG` gate, so they DCE with
+  the stamp under :advanced + goog.DEBUG=false.
+
+  The per-commit integer `render-key` is deliberately NOT stamped here: it is
+  minted at CONNECTED COMMIT in the ViewCell layout effect (`reactive/commit*`),
+  which runs AFTER this child host element has already committed, so no honest
+  value for THIS commit exists at render time. Stamping render-key onto the DOM
+  is therefore a commit-time concern owned by the substrate, not the compiler."
+  [props-form {:keys [source-coord view-tag]}]
+  (let [p (gensym "rf-ui-host-root")]
+    `(let [~p ~props-form]
+       (when ~(with-meta 'js/goog.DEBUG {:tag 'boolean})
+         (when (cljs.core/undefined? (cljs.core/unchecked-get ~p "data-rf2-source-coord"))
+           (cljs.core/unchecked-set ~p "data-rf2-source-coord" ~source-coord))
+         (when (cljs.core/undefined? (cljs.core/unchecked-get ~p "data-rf-view"))
+           (cljs.core/unchecked-set ~p "data-rf-view" ~view-tag)))
+       ~p)))
+
+(defn- jsx-call
+  ([tag-form pairs children-forms key-info]
+   (jsx-call tag-form pairs children-forms key-info nil))
+  ([tag-form pairs children-forms key-info annotate]
+   (let [nch           (count children-forms)
+         multi?        (> nch 1)
+         children-form (cond
+                         (zero? nch) nil
+                         (= 1 nch)   (first children-forms)
+                         :else       `(cljs.core/array ~@children-forms))
+         props-form    (ordered-literal-object
+                        (concat (map (fn [{:keys [name form]}] [name form]) pairs)
+                                (when (some? children-form)
+                                  [["children" children-form]])))]
+     (jsx-runtime-call multi? tag-form
+                       (cond-> props-form
+                         annotate (annotate-host-root-props annotate))
+                       key-info))))
+
+(defn- emit-element [node st inline?]
+  (let [static?       (:static? node)
+        inner-inline? (or inline? static?)
+        tag-str       (name (:tag node))
+        key-info      (get-in node [:props :key])]
+    (cond
+      (get-in node [:props :spread])
+      ;; v/spread: the props object is runtime-built by `spread->props`;
+      ;; children ride the same call.
+      ;;
+      ;; TRUSTED MARKUP (rf2-29s75): `v/spread` and `v/html` COMPOSE — an
+      ;; element may carry a runtime-built prop map AND a trusted-markup sole
+      ;; child, and BOTH take effect. This branch does not go through
+      ;; `element-prop-pairs` (the `:safe-spread` sibling below does, which is
+      ;; why it already composed), so the compiler-owned
+      ;; `dangerouslySetInnerHTML` is attached here explicitly; without it the
+      ;; markup was silently dropped on CLJS while the JVM emitter kept it —
+      ;; a dual-emitter divergence against Spec 004 §Interop.
+      ;;
+      ;; The prop is set AFTER `spread->props` returns, so the visible
+      ;; `(v/html ...)` site — the trust assertion — WINS any same-key value
+      ;; smuggled through the runtime prop map (see rf2-5pr75).
+      ;;
+      ;; EVALUATION ORDER: `base`/`overrides` are `spread->props` arguments, so
+      ;; they evaluate once each in authored order BEFORE the markup expression,
+      ;; matching source order and the JVM path (whose `:children` thunk runs
+      ;; after the opts map's `:dyn (merge base overrides)`). The
+      ;; single-evaluation `let` temporary mirrors the `:safe-spread` branch and
+      ;; folds away under :advanced.
+      ;;
+      ;; The analyzer sets `:children []` on an html-kid element, so no
+      ;; positional child accompanies the markup and React's
+      ;; children-vs-innerHTML conflict cannot arise.
+      (let [spread     (get-in node [:props :spread])
+            sugar      (get-in node [:props :class :base-str])
+            built      `(re-frame.freehand.runtime/spread->props
+                         ~tag-str
+                         ~(when (seq sugar) sugar)
+                         ~(:base spread)
+                         ~(:overrides spread)
+                         ~(site-key-form spread)
+                         ~(debug-site-form (assoc spread :classification :spread)))
+            props-form (if-some [html (:html node)]
+                         (let [props-sym (gensym "rf-ui-spread")]
+                           `(let [~props-sym ~built]
+                              (cljs.core/unchecked-set
+                               ~props-sym "dangerouslySetInnerHTML"
+                               (cljs.core/js-obj "__html" ~(:form html)))
+                              ~props-sym))
+                         built)
+            ;; A DEV-gated view-evidence annotation rides the host root's props
+            ;; when this spread element is the view's compiler-owned root (a
+            ;; spread element is a single DOM host node, so the same annotation
+            ;; as the plain-element branch applies — parity with emit-jvm's
+            ;; `static-form` and the adapter source-coord walk). It DCEs in
+            ;; production.
+            props-form (cond-> props-form
+                         (:rf.ui/annotate node)
+                         (annotate-host-root-props (:rf.ui/annotate node)))
+            chs        (children-forms st (:children node) inner-inline?)]
+        (if (:present? key-info)
+          `(re-frame.freehand.runtime/jsx-spread3 ~tag-str ~props-form
+                                            ~(:expr key-info)
+                                            (cljs.core/array ~@chs))
+          `(re-frame.freehand.runtime/jsx-spread2 ~tag-str ~props-form
+                                            (cljs.core/array ~@chs))))
+
+      (get-in node [:props :safe-spread])
+      ;; v/spread-safe: the OWNED props compile normally (their :on-* handlers
+      ;; keep the compiled per-site sync-door callback), and the CALLER attrs
+      ;; are a runtime-built object layered UNDER them — owned props win any
+      ;; collision, :class composes (owned classes first), and the owned-key
+      ;; deny law is enforced at runtime by spread-safe->props in EVERY build.
+      ;;
+      ;; EVALUATION ORDER (rf2-m5h0f): the AUTHORED argument order is
+      ;; `(v/spread-safe owned caller)`, so BOTH hosts evaluate the OWNED prop
+      ;; expressions BEFORE the CALLER ones. The JVM emitter already forces this
+      ;; — its `tree/element` opts-map literal lists the owned `:norm`/`:dyn`/
+      ;; `:dyn-events` slots ahead of the `:spread-safe :caller` slot, and a
+      ;; Clojure map literal evaluates its value expressions left-to-right, once
+      ;; each. CLJS matches it here with single-evaluation `let` temporaries:
+      ;; the owned object is bound first, then the caller object; each authored
+      ;; expression runs exactly once, in owned-then-caller order (a bare
+      ;; `(spread-safe-props caller-obj owned-obj)` would evaluate the caller
+      ;; argument first — the pre-fix CLJS-vs-JVM divergence). Under :advanced
+      ;; the temporaries fold away.
+      (let [ss          (get-in node [:props :safe-spread])
+            owned-pairs (element-prop-pairs st node inner-inline?)
+            owned-obj   (ordered-literal-object
+                         (map (fn [{:keys [name form]}] [name form]) owned-pairs))
+            caller-obj  `(re-frame.freehand.runtime/spread-safe->props
+                          ~tag-str
+                          ~(:base ss)
+                          ~(:owned-handler-keys ss)
+                          ~(site-key-form ss)
+                          ~(debug-site-form (assoc ss :classification :spread)))
+            owned-sym   (gensym "rf-ui-owned")
+            caller-sym  (gensym "rf-ui-caller")
+            props-form  `(let [~owned-sym ~owned-obj
+                               ~caller-sym ~caller-obj]
+                           (re-frame.freehand.runtime/spread-safe-props ~caller-sym ~owned-sym))
+            ;; Host-root view-evidence annotation (DEV-gated) when this
+            ;; spread-safe element is the view's compiler-owned root — parity
+            ;; with the plain-element / `v/spread` branches, emit-jvm, and the
+            ;; adapter source-coord walk. Rides ABOVE the owned/caller merge, so
+            ;; it stamps the final props object; it DCEs in production.
+            props-form  (cond-> props-form
+                          (:rf.ui/annotate node)
+                          (annotate-host-root-props (:rf.ui/annotate node)))
+            chs         (children-forms st (:children node) inner-inline?)]
+        (if (:present? key-info)
+          `(re-frame.freehand.runtime/jsx-spread3 ~tag-str ~props-form
+                                            ~(:expr key-info)
+                                            (cljs.core/array ~@chs))
+          `(re-frame.freehand.runtime/jsx-spread2 ~tag-str ~props-form
+                                            (cljs.core/array ~@chs))))
+
+      :else
+      (let [pairs (element-prop-pairs st node inner-inline?)
+            chs   (children-forms st (:children node) inner-inline?)
+            ;; prebuilt static props object under a dynamic key. A DEV-gated
+            ;; view-evidence annotation rides the host root's props when this
+            ;; element is the view's compiler-owned root (marked by
+            ;; `mark-host-root-annotation`); it DCEs in production.
+            call  (jsx-call tag-str pairs chs key-info (:rf.ui/annotate node))]
+        (if (and static? (not inline?))
+          (hoist! st :el call)
+          call)))))
+
+(defn- emit-fragment [node st inline?]
+  (let [static?       (:static? node)
+        inner-inline? (or inline? static?)
+        chs  (children-forms st (:children node) inner-inline?)
+        call (jsx-call `re-frame.freehand.runtime/Fragment [] chs (:key node))]
+    (if (and static? (not inline?))
+      (hoist! st :el call)
+      call)))
+
+(defn- component-prop-pair
+  "One [slot value-form] pair for a component call-site prop. A compiled render
+  slot (`v/render-fn`) emits its lexically-visible pure body as a marked
+  callback the seam invokes via v/slot; a `v/event`/`v/handler` prop lowers
+  to the SAME per-site-stable committed callback a DOM handler rides (the one
+  closed boundary law); every other prop carries its walked value verbatim."
+  [{:keys [slot value render-fn marker callback-fn] :as entry} st]
+  (case marker
+    :render-fn
+    [slot `(re-frame.freehand.runtime/render-fn
+            (fn [~@(:params render-fn)] ~(emit-node (:body render-fn) st false))
+            ~(count (:params render-fn)))]
+
+    :ui-event
+    ;; foreign/view committed event callback — flags 0 (the controlled-input
+    ;; door is DOM-only); the invoker's first arg binds the event.
+    [slot `(re-frame.freehand.events/event-handler
+            ~(site-key-form entry) ~callback-fn 0 ~(debug-site-form entry))]
+
+    :handler
+    [slot `(re-frame.freehand.events/handler-callback
+            ~(site-key-form entry) ~callback-fn ~(debug-site-form entry))]
+
+    [slot value]))
+
+(defn- emit-component [node st inline?]
+  (let [key-info (get-in node [:props :key])
+        chs      (children-forms st (:children node) false)
+        nch      (count chs)
+        children-form (cond
+                        (zero? nch) nil
+                        (= 1 nch)   (first chs)
+                        :else       `(cljs.core/array ~@chs))
+        entries  (get-in node [:props :entries])
+        ref-a    (get-in node [:props :ref])
+        ;; A forwarded ref rides the props object as `ref` (React 19
+        ;; ref-as-prop): a foreign component receives it, and an internal view
+        ;; receives it iff it declares `:ref` in its header. Object refs pass
+        ;; through verbatim; a `(v/raw-fn f)` callback ref carries its fn.
+        props-form (ordered-literal-object
+                    (concat (map #(component-prop-pair % st) entries)
+                            (when ref-a
+                              [["ref" (:form ref-a)]])
+                            (when (some? children-form)
+                              [["children" children-form]])))
+        multi?   (> nch 1)
+        ;; A self-recursive head (the exact view being compiled) MUST target the
+        ;; current-namespace Var (its canonical `:fqn`), never the authored
+        ;; spelling: the render fn is a separate `$render` def emitted BEFORE the
+        ;; view's own `(def …)`, so a bare self head would resolve through any
+        ;; same-named `:refer` (cljs.analyzer/resolve-var checks `:uses` ahead of
+        ;; `:defs`) and capture the public authoring Var. `emit-defview` reads the
+        ;; recorded flag to forward-`declare` the Var so the qualified reference
+        ;; is not undeclared. Unrelated foreign/view heads keep their spelling.
+        self-fqn (:self-fqn @st)
+        self?    (and (some? self-fqn) (= (:fqn node) self-fqn))
+        head-sym (if self? (:fqn node) (:sym node))
+        ;; DEV bare-view-alias diagnostic (rf2-vxgfnd.95.15): a foreign-
+        ;; classified head whose runtime VALUE is a registered view shell is a
+        ;; bare `(def alias other/view)` var copy — the compiler saw a foreign
+        ;; React component and dropped the view's closed-props/children checks +
+        ;; manifest identity. `warn-bare-view-alias!` consults the DEV shell
+        ;; marker and warns once (deduped) at render. goog.DEBUG-gated so
+        ;; `:advanced` folds straight to the bare head — no residue, no cost.
+        ;; View heads resolve the stamped var (classified :view) and stay quiet.
+        head-form (if (= :foreign (:op node))
+                    `(if ~(with-meta 'js/goog.DEBUG {:tag 'boolean})
+                       (re-frame.freehand.runtime/warn-bare-view-alias! ~head-sym)
+                       ~head-sym)
+                    head-sym)
+        spread    (get-in node [:props :spread])]
+    (when self? (swap! st assoc :self-ref? true))
+    (if spread
+      ;; v/spread at a FOREIGN component call site (rf2-u53yy.5): the LITERAL
+      ;; part's compiled props are built as a literal object; the forwarded
+      ;; runtime map is layered UNDER them (literal wins) by
+      ;; `foreign-spread-props`, which passes the forwarded keys through
+      ;; UNCONVERTED (a foreign boundary owns its own prop ABI). Children ride
+      ;; the same jsx-spread call.
+      ;;
+      ;; EVALUATION ORDER: the authored order is `(v/spread literal runtime)`,
+      ;; so the literal object binds BEFORE the forwarded expression — the
+      ;; single-evaluation `let` temporaries mirror the element spread branch
+      ;; and fold away under :advanced.
+      (let [literal-obj (ordered-literal-object
+                         (concat (map #(component-prop-pair % st) entries)
+                                 (when ref-a [["ref" (:form ref-a)]])))
+            lit-sym     (gensym "rf-ui-lit")
+            fwd-sym     (gensym "rf-ui-fwd")
+            props-obj   `(let [~lit-sym ~literal-obj
+                               ~fwd-sym ~(:base spread)]
+                           (re-frame.freehand.runtime/foreign-spread-props ~fwd-sym ~lit-sym))]
+        (if (:present? key-info)
+          `(re-frame.freehand.runtime/jsx-spread3 ~head-form ~props-obj
+                                            ~(:expr key-info)
+                                            (cljs.core/array ~@chs))
+          `(re-frame.freehand.runtime/jsx-spread2 ~head-form ~props-obj
+                                            (cljs.core/array ~@chs))))
+      (jsx-runtime-call multi? head-form props-form key-info))))
+
+(defn- row-key-expr [body]
+  (or (get-in body [:props :key :expr]) (get-in body [:key :expr])))
+
+(defn- replace-row-key-expr
+  "Use the once-bound row key for the body root's React key. The analyzer has
+  already restricted a for body to an element/view/foreign/fragment."
+  [body key-form]
+  (if (= :fragment (:op body))
+    (assoc-in body [:key :expr] key-form)
+    (assoc-in body [:props :key :expr] key-form)))
+
+(defn- emit-for [node st]
+  (let [arr  (gensym "rf-ui-arr")
+        seen (gensym "rf-ui-seen")
+        row-key (gensym "rf-ui-row-key")
+        kexpr (row-key-expr (:body node))
+        row  (binding [*row-key-forms* (conj *row-key-forms* row-key)]
+               (emit-node (replace-row-key-expr (:body node) row-key)
+                          st false))]
+    `(let [~arr (cljs.core/array)
+           ~seen (cljs.core/js-obj)]
+       (doseq [~@(:seq-exprs node)]
+         ;; Bind once: React identity, duplicate checking, and passive native
+         ;; attachment ownership must all name the exact same occurrence.
+         (let [~row-key ~kexpr]
+           (when ~(with-meta 'js/goog.DEBUG {:tag 'boolean})
+             (re-frame.freehand.runtime/check-key! ~seen ~row-key))
+           (.push ~arr ~row)))
+       ~arr)))
+
+(defn- emit-presence
+  "`v/presence` → the runtime retention boundary. The compiled keyed children
+  (a `for` emits a JS array) are handed as one array; the boundary tracks them
+  by React key across renders, driving the :mounting/:present/:unmounting phase
+  each child reads with `(presence-phase)`."
+  [node st]
+  `(re-frame.freehand.presence-runtime/presence-boundary
+    ~(:timeout-ms node)
+    (cljs.core/array ~@(children-forms st (:children node) false))))
+
+(defn- emit-frame-root
+  "A top-region `frame-root` SCOPES its preflight-ensured frame to its
+  children through the shared React frame context (rf2-vxgfnd.25 —
+  `frames/scope-element`), so an ambient `(sub …)` in a descendant view
+  resolves the frame-root's frame (the compiled sub-read consults the
+  React-context tier via the rf2-vxgfnd.24 `:adapter/current-frame` reader).
+  Its ENSURE semantics ride the extracted static plan (the descriptor
+  `:frame-plans` + the client preflight, `re-frame.freehand.frames`), which runs
+  at host preflight BEFORE any render — never the rendered tree; the emitted
+  Provider only SCOPES the already-live frame. Children stay in an array so
+  the Provider keys them (mirrors `emit-frame-provider`)."
+  [node st inline?]
+  `(re-frame.freehand.frames/scope-element
+    ~(:frame-id node)
+    (cljs.core/array ~@(children-forms st (:children node) inline?))))
+
+(defn- emit-frame-provider
+  "S2c: `frame-provider` scopes its children to an already-live frame
+  (a runtime `:frame` target) through the shared React frame context —
+  `re-frame.freehand.frames/provider-scope-element` validates the target
+  (fail-loud on nil / bad / absent-frame) and wraps the children in the
+  context Provider. Children stay in an array so the Provider keys them."
+  [node st inline?]
+  `(re-frame.freehand.frames/provider-scope-element
+    ~(:frame node)
+    (cljs.core/array ~@(children-forms st (:children node) inline?))))
+
+(defn- emit-slot
+  "A `v/slot` invocation: gate the render-fn value (nil renders nothing; a
+  non-render-fn value is the didactic `invalid-slot!`), then invoke it with
+  the runtime args — a fixed-arity call whose args evaluate only when the slot
+  renders. The output joins the surrounding children like any other child."
+  [node st]
+  (let [rf      (gensym "rf-ui-slot")
+        slotval (if-let [{:keys [params body]} (:render-fn node)]
+                  `(re-frame.freehand.runtime/render-fn
+                    (fn [~@params] ~(emit-node body st false))
+                    ~(count params))
+                  (:slot-value node))]
+    `(let [~rf ~slotval]
+       (when (re-frame.freehand.runtime/slot-ready? ~rf)
+         (re-frame.freehand.runtime/check-slot-arity! ~rf ~(count (:args node)))
+         (~rf ~@(:args node))))))
+
+(defn- emit-error-boundary
+  "`v/error-boundary` → the runtime class boundary. The fallback view is the
+  head component (self-recursive fallbacks target the current-ns Var, mirroring
+  emit-component). When :on-error is present, capture the committed frame at the
+  owning view's render and build the after-commit dispatch closure (appends the
+  caught error to the authored event vector)."
+  [node st]
+  (let [fb        (:fallback node)
+        self-fqn  (:self-fqn @st)
+        self-fb?  (and (some? self-fqn) (= (:fqn fb) self-fqn))
+        fb-sym    (if self-fb? (:fqn fb) (:sym fb))
+        _         (when self-fb? (swap! st assoc :self-ref? true))
+        reset-key (when (:has-reset-key? node) (:reset-key node))
+        on-error  (:on-error node)
+        child     (emit-node (:child node) st false)
+        on-error-form
+        (when on-error
+          `(let [ops# (re-frame.freehand.frames/frame-ops)]
+             (fn [error#]
+               ((:dispatch ops#) (conj ~on-error error#) {:source :ui}))))]
+    `(re-frame.freehand.runtime/error-boundary
+      ~fb-sym ~reset-key ~on-error-form ~child)))
+
+(defn emit-standalone
+  "Emit a CAPABILITY-FREE AST as a self-contained CLJS render form (no ViewCell
+  hook skeleton). Used by def-level constructors — re-frame.freehand.react/lazy's
+  fallback template. Static elements the emitter would hoist to module-level
+  defs are bound in a local `let` instead (each is an immutable static React
+  element, built once when the enclosing thunk closure is minted)."
+  [ast]
+  (let [st   (new-state 'rf-ui-standalone)
+        body (emit-node ast st false)
+        defs (:defs @st)]
+    (if (seq defs)
+      `(let [~@(mapcat (fn [d] [(nth d 1) (nth d 2)]) defs)] ~body)
+      body)))
+
+(defn emit-node
+  "AST node -> CLJS form (nil for a statically-absent child)."
+  [node st inline?]
+  (case (:op node)
+    :nothing  nil
+    :text     (:value node)
+    :expr     `(re-frame.freehand.runtime/child ~(:form node))
+    :raw      (:form node)
+    :html     nil ; carried by the parent element's dangerouslySetInnerHTML
+    :element  (emit-element node st inline?)
+    :fragment (emit-fragment node st inline?)
+    :frame-root (emit-frame-root node st inline?)
+    :frame-provider (emit-frame-provider node st inline?)
+    :view     (emit-component node st inline?)
+    :foreign  (emit-component node st inline?)
+    :slot     (emit-slot node st)
+    :error-boundary (emit-error-boundary node st)
+    :presence (emit-presence node st)
+    ;; client-only (S5 phase flip, rf2-3omxp; Spec 011 §Phase flip): the site
+    ;; compiles to a PHASE-CONDITIONAL runtime boundary. It renders the
+    ;; capability-free fallback in `:server` phase (the JVM/SSR + first-hydration
+    ;; render) and the client subtree in `:client` phase, reading a root-scoped
+    ;; phase context a hydrating root flips `:server` -> `:client` in one update
+    ;; after its hydration commit. Both arms therefore ride the client bundle:
+    ;; the fallback template now compiles in (the ruled, perf-budget-covered cost
+    ;; — the browser must materialise the fallback vdom during the hydration
+    ;; render). A non-hydrating mount has no phase Provider, so the boundary reads
+    ;; the `:client` default and renders the client subtree on the first render,
+    ;; byte-identical to S3.
+    :client-only `(re-frame.freehand.runtime/client-only
+                   ~(emit-node (:fallback node) st false)
+                   ~(emit-node (:child node) st false))
+    ;; Leading (effect …) statements spliced before the template: a `do`
+    ;; sequences the lowered effect hook calls, then renders the template.
+    :hook-prefix `(do ~@(:statements node) ~(emit-node (:body node) st inline?))
+    :if       `(if ~(:test node)
+                 ~(emit-node (:then node) st false)
+                 ~(emit-node (:else node) st false))
+    :let      `(let ~(:bindings node) ~(emit-node (:body node) st false))
+    :letfn    `(letfn ~(:fnspecs node) ~(emit-node (:body node) st false))
+    :case     `(case ~(:expr node)
+                 ~@(mapcat (fn [[test branch]] [test (emit-node branch st false)])
+                           (:clauses node))
+                 ~@(when (not= ::ana/none (:default node))
+                     [(emit-node (:default node) st false)]))
+    :for      (emit-for node st)))
+
+;; ---------------------------------------------------------------------------
+;; Inline emission (root templates — S1c)
+;; ---------------------------------------------------------------------------
+
+(defn emit-inline
+  "Emit `ast` as ONE inline CLJS expression: what `hoist!` would lift to
+  module-level `def`s becomes `let` bindings around the body instead
+  (creation order preserves dependencies). The root-template path —
+  `v/mount` / `v/render!` / `v/hydrate-root` sites may sit inside a
+  function body (an init fn), where module-level defs are illegal; module
+  hoisting stays a defview-only optimisation."
+  [ast name-hint]
+  (let [st    (new-state name-hint)
+        body  (emit-node ast st false)
+        binds (into [] (mapcat rest) (:defs @st))]  ; (def sym form) -> sym form
+    (if (seq binds)
+      `(let [~@binds] ~body)
+      body)))
+
+;; ---------------------------------------------------------------------------
+;; Header lowering (Q2)
+;; ---------------------------------------------------------------------------
+
+(defn- slot-read [slot default]
+  (if (some? default)
+    ;; Host-faithful: native destructure lowers a defaulted slot to
+    ;; `(get props :slot default)` — `get` is a function, so the default operand
+    ;; is EVALUATED as part of the lookup even when the slot is present (it is an
+    ;; eager third argument). Evaluate `d#` unconditionally (once), then select
+    ;; it only when the slot is absent — matching the host's eval count/effects,
+    ;; not just its final value.
+    `(let [d# ~default
+           v# (cljs.core/unchecked-get ~props-sym ~slot)]
+       (if (cljs.core/undefined? v#) d# v#))
+    `(cljs.core/unchecked-get ~props-sym ~slot)))
+
+(defn header-bindings
+  "The CLJS header `let` bindings, in canonical host `destructure` order
+  (rf2-vxgfnd.283): `:as` binds the whole props map FIRST — matching the JVM
+  native destructuring the JVM emitter uses — then ONE property-read per host
+  binding UNIT. These consume `parse-header`'s `:binding-units` — the FULL host
+  plan, not the collapsed derived projection — so the emission reproduces the
+  host's executable semantics exactly (rf2-nedxb): every host initializer runs,
+  and a qualified-group-name collision (`{:keys [ns/x] x :other}`) emits BOTH
+  units binding one local, the later `:ns/x` winning by host `let` last-wins.
+  The units are already the host `bes` order with winning lookup slots (a
+  qualified `:keys` local reads its qualified slot), so there is nothing to sort
+  or de-collide here. Emitting `:as` last, or the units in parse order, could
+  resolve a dependent `:or` default to a different symbol on CLJS than on the
+  JVM — including a public reactive authoring var."
+  [header]
+  (concat
+   (when (:as-sym header)
+     [(:as-sym header) `(re-frame.freehand.runtime/props->map ~props-sym)])
+   (mapcat (fn [{:keys [slot pattern default]}]
+             [pattern (slot-read slot default)])
+           (:binding-units header))))
+
+(defn comparator-form
+  "The generated straight-line rf= comparator (RULED: Object.is OR = per
+  slot); generic for :as views."
+  [header slots]
+  (if (= :as (:mode header))
+    `re-frame.freehand.runtime/props-equal-generic?
+    (let [slot-strs (cond-> (mapv #(if-let [ns* (namespace %)]
+                                     (str ns* "/" (name %))
+                                     (name %))
+                                  slots)
+                      (:children? header) (conj "children"))
+          slot-strs (vec (distinct slot-strs))]
+      (if (empty? slot-strs)
+        `(fn [_# _#] true)
+        ;; explicit gensyms — auto-gensyms don't span the nested
+        ;; syntax-quote in the map fn
+        (let [prev (gensym "prev") nxt (gensym "next")]
+          `(fn [~prev ~nxt]
+             (and ~@(map (fn [s]
+                           `(re-frame.freehand.eq/rf=
+                             (cljs.core/unchecked-get ~prev ~s)
+                             (cljs.core/unchecked-get ~nxt ~s)))
+                         slot-strs))))))))
+
+;; ---------------------------------------------------------------------------
+;; defview
+;; ---------------------------------------------------------------------------
+
+(defn- mark-host-root-annotation
+  "Stamp the view-evidence DOM-annotation marker onto the view's effective host
+  root(s) — the DOM `:element`(s) the compiler owns at the top of the render. The
+  UNCONDITIONAL wrappers (`:hook-prefix` effect prefix, an authored `:let` /
+  `:letfn`) are transparent — the marker rides through to the element they wrap.
+
+  A COMMON CONDITIONAL root is narrowly DESCENDED so its concrete DOM arms are
+  tagged: `if` / `if-not` / `when` / `when-not` / `cond` (each an `:if`), `case`
+  (its clauses + default), and the if-let family (`if-let` / `when-let` /
+  `if-some` / `when-some`, which desugar to `:let` over `:if`). So a view rooted
+  at `(if loading? [:spinner] [:page])` tags whichever arm renders. Spec 006
+  exempts only the render that yields nil; a later concrete DOM output must be
+  tagged. The recursion RETAINS the per-branch host-root exemptions: a branch
+  that is nil (`:nothing`, e.g. a one-arm `when`'s absent else), a fragment,
+  another view/foreign component, or a loop (`:for`) is NOT a single
+  compiler-owned host node and carries no annotation — the same exemption the
+  adapter source-coord walk applies to a non-DOM root.
+
+  `emit-element` reads the marker off the plain element and stamps the props
+  behind the goog.DEBUG gate (see `annotate-host-root-props`). This walk is kept
+  byte-identical to `re-frame.freehand.compiler.emit-jvm/mark-host-root-annotation`: a
+  prop/attribute annotation is inherently cross-emitter, so the two walks MUST
+  descend the same forms or a conditional-rooted view diverges under the
+  JVM<->CLJS parity gate and SSR/client hydration."
+  [ast annotate]
+  (case (:op ast)
+    :element (assoc ast :rf.ui/annotate annotate)
+    (:hook-prefix :let :letfn) (update ast :body mark-host-root-annotation annotate)
+    :if   (-> ast
+              (update :then mark-host-root-annotation annotate)
+              (update :else mark-host-root-annotation annotate))
+    :case (-> ast
+              (update :clauses
+                      (fn [clauses]
+                        (mapv (fn [[test branch]]
+                                [test (mark-host-root-annotation branch annotate)])
+                              clauses)))
+              (update :default
+                      (fn [d]
+                        (if (= ::ana/none d) d
+                            (mark-host-root-annotation d annotate)))))
+    ast))
+
+(defn emit-defview
+  [{:keys [vname view-id display-name docstring header slots ast manifest
+           closed-keys children? self-fqn]}]
+  (let [st         (doto (new-state vname) (swap! assoc :self-fqn self-fqn))
+        ;; The DEV view-evidence DOM annotation for this view's compiler-owned
+        ;; host root — the source coordinate + view id, in today's attribute
+        ;; vocabulary (Spec 004 §View identity). Marked onto the effective root
+        ;; element and stamped behind the goog.DEBUG gate; a non-element root
+        ;; carries none. Compile-time literals via the cross-host
+        ;; `re-frame.source-coords` projections (parity with the adapter walks).
+        annotate   {:source-coord (source-coord/format-source-coord
+                                   view-id (:source manifest))
+                    :view-tag     (source-coord/format-view-id view-id)}
+        body       (->> (emit-node (mark-host-root-annotation ast annotate) st false)
+                        (hoist-literal-sub-queries st))
+        binds      (vec (header-bindings header))
+        render-sym (symbol (str (name vname) "$render"))
+        host-render-sym (symbol (str (name vname) "$host_render"))
+        ;; The raw body is descriptor data in DEV. Stable Inner supplies the
+        ;; fixed ViewCell hook skeleton to EVERY dev view, so adding the first
+        ;; sub is a same-signature edit. Production specializes: a sub-bearing
+        ;; view uses the host wrapper below; a sub-free view goes straight from
+        ;; React.memo to the raw body with zero ViewCell hooks.
+        has-subs?  (boolean (seq (:subs (:sites manifest))))
+        has-locals? (boolean (seq (:locals (:sites manifest))))
+        ;; A v/dispatch-fn site reads the committed frame through the EventOwner
+        ;; exactly like an :on-* handler site, so it selects an event-owner
+        ;; wrapper (which also consumes the frame context for provider retargets).
+        has-dispatch-fns? (boolean (seq (:dispatch-fns (:sites manifest))))
+        has-events? (boolean (or (seq (:events (:sites manifest)))
+                                 has-dispatch-fns?))
+        ;; rf2-vxgfnd.253 (extending .228): a `(frame)` site resolves the AMBIENT
+        ;; committed frame, and so does EVERY sub target (a sub site implicitly
+        ;; captures the ambient frame/incarnation). So
+        ;; any reactive view MUST become a real React frame-context CONSUMER or a
+        ;; provider retarget (A→B) memo-bails the non-consumer child and its held
+        ;; subs/ops stay locked to the old frame. The sub wrappers
+        ;; therefore consume the context unconditionally — frame-ops presence no
+        ;; longer forks the selection, so there are NO separate `-frame` variants.
+        ;; `render-frame` covers a frame-only view (a `(frame)` site but no
+        ;; sub — a context consumer with no ViewCell); a view with NONE of
+        ;; the three stays on the inert direct React.memo path.
+        has-frame-ops? (boolean (seq (:frame-ops (:sites manifest))))
+        inner-body (if (seq binds) `(let [~@binds] ~body) body)
+        ;; DEV: a local-bearing body runs under the render-phase guard so a
+        ;; (local …) set!/update! invoked during render fails loud. Production
+        ;; (goog.DEBUG false) emits the body directly — no flag, no thunk.
+        inner      (if has-locals?
+                     `(if ~(with-meta 'js/goog.DEBUG {:tag 'boolean})
+                        (re-frame.freehand.hooks/with-local-render-guard
+                         (fn [] ~inner-body))
+                        ~inner-body)
+                     inner-body)
+        host-render (cond
+                      (and has-subs? has-events?)
+                      're-frame.freehand.viewcell/render-subs-and-events
+                      has-events? 're-frame.freehand.viewcell/render-events
+                      has-subs?  're-frame.freehand.viewcell/render-subs
+                      has-frame-ops? 're-frame.freehand.viewcell/render-frame)
+        var-meta   (cond-> {:rf.ui/view true
+                            :rf.ui/view-id view-id
+                            ;; rf2-u53yy.1 S2: the whole-build view descriptor
+                            ;; rides the def's analyzer metadata. Shadow persists
+                            ;; a compiled namespace's analyzer data to its disk
+                            ;; cache and restores it under
+                            ;; [:compiler-env :cljs.analyzer/namespaces <ns>] on a
+                            ;; cache HIT (S0 proof, rf2-u53yy.1.1), so the build
+                            ;; hook harvests the views registry at compile-finish
+                            ;; from this metadata — present for cached AND compiled
+                            ;; members alike — instead of from a macro-expansion
+                            ;; side effect that a warm cache-hit source never
+                            ;; re-runs. `[template-fingerprint hook-signature]` is
+                            ;; the same digest the macro contributed to the slice.
+                            :rf.ui/view-digest [(:template-fingerprint manifest)
+                                                (:hook-signature manifest)]
+                            :rf.ui/children? children?}
+                     docstring   (assoc :doc docstring)
+                     closed-keys (assoc :rf.ui/closed-prop-keys (vec closed-keys)))]
+    ;; A self-recursive view whose name collides with a same-named `:refer`
+    ;; (e.g. `(defview sub …)` where the ns refers re-frame.freehand/sub) must resolve
+    ;; its OWN declare/def/head to the current-namespace Var, not the refer. The
+    ;; CLJS analyzer already signals this shadowing on the def (its `:redef`
+    ;; warning: "sub … replaced by <ns>/sub", and it adds sub to `:excludes`) —
+    ;; but cljs.analyzer/resolve-var ranks `:uses` (refers) ABOVE `:defs` and
+    ;; ignores `:excludes`, so a bare def name still resolves through the refer
+    ;; and BOTH clobbers the public authoring Var (`re_frame.freehand.sub = …`) and
+    ;; leaves the qualified self head (`<ns>.sub`) undefined — the split identity.
+    ;; Completing the shadowing the analyzer already intends — dropping the view's
+    ;; own name from the live ns `:uses` — makes the declare, the def, and the
+    ;; recursive head share the one canonical current-ns Var. JVM-only: this is
+    ;; the macro-expansion path with the live compiler env; non-recursive views
+    ;; and the CLJS-host golden path are untouched.
+    #?(:clj
+       (when (and (:self-ref? @st) self-fqn (some? cljs.env/*compiler*))
+         (swap! cljs.env/*compiler* update-in
+                [:cljs.analyzer/namespaces (symbol (namespace self-fqn)) :uses]
+                dissoc vname)))
+    `(do
+       ;; A self-recursive view forward-declares its Var so the `$render` fn
+       ;; (emitted before the view's own `(def …)`) may reference the
+       ;; current-namespace Var by its qualified name without an undeclared-Var
+       ;; warning — and so the declaration, not a same-named `:refer`, owns the
+       ;; name at the reference site. Non-recursive views emit unchanged.
+       ~@(when (:self-ref? @st) [`(declare ~vname)])
+       ~@(:defs @st)
+       ;; The `$render` / `$host_render` fns are compiler-internal implementation
+       ;; helpers, never public API — `^:no-doc` so they stay off the documented /
+       ;; manifest public surface (the CLJS api-manifest probe treats a fully-rowed
+       ;; ns like `re-frame.freehand` as exact, and a framework-authored `defview` there
+       ;; would otherwise leak these two helpers as untracked public vars).
+       (defn ~(vary-meta render-sym assoc :no-doc true) [~props-sym]
+         ~inner)
+       ~@(when host-render
+           [`(defn ~(vary-meta host-render-sym assoc :no-doc true) [~props-sym]
+               (~host-render
+                ~view-id (fn [] (~render-sym ~props-sym))))])
+       (def ~(vary-meta vname merge var-meta)
+         (let [compare# ~(comparator-form header slots)]
+           (if ~(with-meta 'js/goog.DEBUG {:tag 'boolean})
+             (re-frame.freehand.runtime/register-view!
+              ~view-id ~render-sym compare# ~display-name (quote ~manifest))
+             ;; The production arm is deliberately direct React.memo. Closure
+             ;; folds away the sibling registration arm and with it every HMR
+             ;; slot/listener/dynamic-lookup/extra-Fiber helper. `memo-view`
+             ;; carries an `@nosideeffects` JSDoc annotation, so Closure DCEs
+             ;; this call whole when the view def is UNREFERENCED (G-18 facade
+             ;; isolation, rf2-edpam).
+             (re-frame.freehand.runtime/memo-view
+              ~(if host-render host-render-sym render-sym)
+              compare# ~display-name))))
+       ~vname)))

--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_jvm.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_jvm.cljc
@@ -1,0 +1,492 @@
+(ns re-frame.freehand.compiler.emit-jvm
+  "AST -> JVM forms building the versioned public structural tree
+  (node schema v1) via `re-frame.freehand.tree`. The same normalized AST the
+  CLJS emitter consumes — no emitter consumes raw source or another
+  emitter's output (the portability law).
+
+  Event vectors are retained AS DATA (placeholders stay keywords);
+  fn-carried sites become the opaque marker; foreign heads and `v/raw`
+  children raise :rf.error/jvm-host-op lazily (only when their branch
+  renders); `v/raw`/`v/raw-fn` PROP values become opaque markers
+  WITHOUT evaluating their expressions (they may be host-only)."
+  (:require [re-frame.source-coords :as source-coord]
+            [re-frame.freehand.compiler.analyze :as ana]
+            [re-frame.freehand.rules :as rules]))
+
+(def ^:private props-sym 'rf-ui-props)
+
+;; The canonical current-namespace Var of the view being emitted, bound by
+;; `emit-defview` around its body. A self-recursive component head targets THIS
+;; fqn (matching its `:fqn`) rather than the authored spelling, so the emitted
+;; call names the current-namespace Var explicitly instead of relying on the
+;; enclosing `defn`'s intern order to shadow a same-named `:refer` (rf2-rr26cq).
+(def ^:dynamic *self-fqn* nil)
+
+(declare emit-node)
+
+;; ---------------------------------------------------------------------------
+;; Element parts
+;; ---------------------------------------------------------------------------
+
+(defn- static-attr-entries
+  "Compile-time semantic normalization of literal attr values."
+  [attrs]
+  (into {}
+        (keep (fn [{:keys [k kind value literal?]}]
+                (when literal?
+                  (let [v (if (= :property kind)
+                            value                       ; properties pass raw
+                            (rules/attr-val-semantic k value))]
+                    (when (some? v) [k v])))))
+        attrs))
+
+(defn- dyn-attr-entries [attrs]
+  (into {}
+        (keep (fn [{:keys [k kind value literal?]}]
+                (when-not literal?
+                  ;; properties pass raw; plain attrs are normalized by
+                  ;; tree/element's :dyn path — mark properties via :norm
+                  (when (not= :property kind)
+                    [k value]))))
+        attrs))
+
+(defn- dyn-property-entries [attrs]
+  (into {}
+        (keep (fn [{:keys [k kind value literal?]}]
+                (when (and (not literal?) (= :property kind))
+                  [k value])))
+        attrs))
+
+(defn- class-entry
+  "Semantic :class value: constant string when static, else a runtime
+  classes-str form (sugar-first + lexicographic flags, pre-sorted by the
+  analyzer)."
+  [c]
+  (when c
+    (let [{:keys [base-str flags dyn]} c]
+      (if (and (empty? flags) (nil? dyn))
+        (when (seq base-str) base-str)
+        `(rules/classes-str
+          [~@(when (seq base-str) [base-str])
+           ~@(map (fn [[n f]] `(when ~f ~n)) flags)
+           ~@(when dyn [`(rules/class-val ~dyn)])])))))
+
+(defn- style-entry
+  "Semantic :style map form: {kw css-string}; literal values normalized
+  at compile time, dynamic ones via css-val->str at render. A wholly-
+  dynamic :style expression routes through tree/element's :dyn path
+  (which applies the same normalization) — returns [:norm form] or
+  [:dyn form]."
+  [s]
+  (when s
+    (if-let [dyn (:dyn s)]
+      [:dyn dyn]
+      (let [m (into {}
+                    (map (fn [{:keys [css-name value literal?]}]
+                           [(keyword css-name)
+                            (if literal?
+                              (rules/css-val->str css-name value)
+                              `(rules/css-val->str ~css-name ~value))]))
+                    (:entries s))]
+        (when (seq m) [:norm m])))))
+
+(defn- event-entries
+  "-> [static-events-map dyn-events-map-form]. Literal vectors/options
+  maps stay data forms (args evaluate at render — locals capture);
+  fn sites become the opaque marker (form NOT evaluated on the JVM);
+  dynamic sites classify at render."
+  [events]
+  (reduce (fn [[stat dyn] {:keys [k classification form]}]
+            (case classification
+              :vector   [(assoc stat k form) dyn]
+              :options  [(assoc stat k form) dyn]
+              ;; v/event and v/handler, like a bare fn, are opaque committed
+              ;; callbacks whose body the JVM tree never evaluates (non-
+              ;; serialisable sites).
+              :ui-event [(assoc stat k `re-frame.freehand.tree/opaque-fn) dyn]
+              :handler  [(assoc stat k `re-frame.freehand.tree/opaque-fn) dyn]
+              :fn       [(assoc stat k `re-frame.freehand.tree/opaque-fn) dyn]
+              :dynamic  [stat (assoc dyn k `(re-frame.freehand.tree/classify-event ~form))]))
+          [{} {}]
+          events))
+
+(defn- static-form
+  "The `:static` slot value form for a `tree/element` call. `static` is the
+  compile-time-normalized literal attr map (or nil). When `annotate` is present
+  — this element is the view's compiler-owned host root, marked by
+  `mark-host-root-annotation` — the DEV view-evidence annotation
+  (`data-rf2-source-coord` + `data-rf-view`, today's attribute vocabulary per
+  Spec 004 §View identity / Spec 006 §Source-coord annotation + §View tagging
+  contract) merges onto the static attrs behind `re-frame.interop/debug-enabled?`
+  (the JVM counterpart to the CLJS `goog.DEBUG` stamp — true by default, off under
+  `-Dre-frame.debug=false`). So a dev JVM/SSR render carries the SAME host-root
+  evidence the CLJS emit stamps (byte-identical values via the one cross-host
+  `re-frame.source-coords` projection), and a production SSR build drops it —
+  symmetric with the CLJS `:advanced` + goog.DEBUG=false DCE.
+
+  AUTHORED OWN VALUE WINS (rf2-x1nbv): the annotation only fills an attribute the
+  view author did NOT already supply as a LITERAL host-root attr — an authored
+  own value in `:static` is preserved, never overwritten. A DYNAMIC / `v/spread`
+  / `v/spread-safe`-caller authored value is layered OVER `:static` at runtime by
+  `tree/element` (dyn over static; caller under owned), so it already wins there;
+  this compile-time guard closes the remaining static path so the JVM law matches
+  the CLJS `annotate-host-root-props` set-if-absent law across the whole collision
+  matrix (static / dynamic / ui.spread / spread-safe)."
+  [static annotate]
+  (if annotate
+    (let [{:keys [source-coord view-tag]} annotate
+          base (or static {})
+          ann  (cond-> {}
+                 (not (contains? base :data-rf2-source-coord))
+                 (assoc :data-rf2-source-coord source-coord)
+                 (not (contains? base :data-rf-view))
+                 (assoc :data-rf-view view-tag))]
+      (if (seq ann)
+        `(cond-> ~base re-frame.interop/debug-enabled? (merge ~ann))
+        (when (seq base) base)))
+    (when (seq static) static)))
+
+(defn- with-host-root-provenance
+  "Attach DEV, debug-gated PROVENANCE metadata to a host-root element node,
+  recording the compiler's canonical view-evidence values
+  (`:data-rf2-source-coord` / `:data-rf-view`) so `render-static`'s strip
+  (`strip-host-root-annotation`) removes ONLY the generated markers — a key
+  whose runtime value still equals the canonical value — and PRESERVES an
+  authored own value of the same spelling under the rf2-x1nbv collision law
+  (rf2-zgezz #3: the recursive strip otherwise deleted programmer-authored
+  nested attributes too).
+
+  Metadata is out-of-band: it is invisible to structural `=` (goldens),
+  normalization N (parity/fingerprint), and every HTML serialiser — only the
+  JVM render-static strip reads it. Gated on `interop/debug-enabled?`, matching
+  the `static-form` stamp, so a production JVM/SSR build attaches nothing."
+  [element-form annotate]
+  (if annotate
+    (let [{:keys [source-coord view-tag]} annotate]
+      `(cond-> ~element-form
+         re-frame.interop/debug-enabled?
+         (vary-meta assoc :rf.ui/host-root-annotation
+                    {:data-rf2-source-coord ~source-coord
+                     :data-rf-view ~view-tag})))
+    element-form))
+
+(defn- emit-element [node]
+  (let [{:keys [props]} node
+        annotate  (:rf.ui/annotate node)
+        tag       (:tag node)
+        key-info  (:key props)
+        child-forms (if (:html node)
+                      [`(re-frame.freehand.tree/html ~(:form (:html node)))]
+                      (into [] (keep emit-node) (:children node)))
+        child-thunk (when (seq child-forms)
+                      `(fn [] (re-frame.freehand.tree/children ~@child-forms)))]
+    (with-host-root-provenance
+     (cond
+      (:spread props)
+      (let [spread (:spread props)
+            sugar (get-in props [:class :base-str])]
+        `(re-frame.freehand.tree/element
+          ~tag
+          {:static ~(static-form (when (seq sugar) {:class sugar}) annotate)
+           :dyn    (merge ~(:base spread) ~(:overrides spread))
+           :key?   ~(:present? key-info)
+           :key-val ~(:expr key-info)
+           :children ~child-thunk}))
+
+      ;; v/spread-safe: the OWNED props emit exactly as a normal element's do
+      ;; (from the same analysed props); the CALLER map rides a `:spread-safe`
+      ;; opt that `tree/element` guards (owned-key deny in EVERY build) and
+      ;; folds UNDER the owned attrs (owned wins, :class composes).
+      ;;
+      ;; EVALUATION ORDER (rf2-m5h0f) is LOAD-BEARING: the opts-map literal below
+      ;; lists the owned `:norm`/`:dyn`/`:dyn-events` slots BEFORE the
+      ;; `:spread-safe :caller` slot, so — a Clojure map literal evaluating its
+      ;; value expressions left-to-right, once each — the owned prop expressions
+      ;; run BEFORE the caller's, matching the authored `(spread-safe owned
+      ;; caller)` order. The CLJS emitter forces the same owned-then-caller order
+      ;; with `let` temporaries. Do NOT reorder these keys.
+      (:safe-spread props)
+      (let [ss      (:safe-spread props)
+            [stat-ev dyn-ev] (event-entries (:events props))
+            cls     (class-entry (:class props))
+            [style-slot style-form] (style-entry (:style props))
+            static  (cond-> (static-attr-entries (:attrs props))
+                      (string? cls) (assoc :class cls))
+            norm    (cond-> (dyn-property-entries (:attrs props))
+                      (and cls (not (string? cls))) (assoc :class cls)
+                      (= :norm style-slot)          (assoc :style style-form))
+            dyn     (cond-> (dyn-attr-entries (:attrs props))
+                      (= :dyn style-slot) (assoc :style style-form))
+            pp      (into #{}
+                          (comp (filter #(= :property (:kind %))) (map :k))
+                          (:attrs props))]
+        `(re-frame.freehand.tree/element
+          ~tag
+          {:static ~(static-form static annotate)
+           :norm   ~(when (seq norm) norm)
+           :dyn    ~(when (seq dyn) dyn)
+           :events ~(when (seq stat-ev) stat-ev)
+           :dyn-events ~(when (seq dyn-ev) dyn-ev)
+           :key?   ~(:present? key-info)
+           :key-val ~(:expr key-info)
+           :props  ~(when (seq pp) pp)
+           :spread-safe {:caller ~(:base ss)
+                         :owned-handler-keys ~(:owned-handler-keys ss)}
+           :children ~child-thunk}))
+
+      :else
+      (let [[stat-ev dyn-ev] (event-entries (:events props))
+            cls     (class-entry (:class props))
+            [style-slot style-form] (style-entry (:style props))
+            static  (cond-> (static-attr-entries (:attrs props))
+                      (string? cls) (assoc :class cls))
+            norm    (cond-> (dyn-property-entries (:attrs props))
+                      (and cls (not (string? cls))) (assoc :class cls)
+                      (= :norm style-slot)          (assoc :style style-form))
+            dyn     (cond-> (dyn-attr-entries (:attrs props))
+                      (= :dyn style-slot) (assoc :style style-form))
+            pp      (into #{}
+                          (comp (filter #(= :property (:kind %))) (map :k))
+                          (:attrs props))]
+        `(re-frame.freehand.tree/element
+          ~tag
+          {:static ~(static-form static annotate)
+           :norm   ~(when (seq norm) norm)
+           :dyn    ~(when (seq dyn) dyn)
+           :events ~(when (seq stat-ev) stat-ev)
+           :dyn-events ~(when (seq dyn-ev) dyn-ev)
+           :key?   ~(:present? key-info)
+           :key-val ~(:expr key-info)
+           :props  ~(when (seq pp) pp)
+           :children ~child-thunk}))) annotate)))
+
+;; ---------------------------------------------------------------------------
+;; Components
+;; ---------------------------------------------------------------------------
+
+(defn- prop-value-form [{:keys [value marker render-fn]}]
+  (case marker
+    :foreign    `re-frame.freehand.tree/opaque-foreign
+    :v/raw-fn  {:rf.ui/opaque :v/raw-fn}
+    ;; v/event and v/handler at a component prop are non-serialisable committed
+    ;; callbacks — opaque on the JVM structural tree (the body never evaluates,
+    ;; the foreign invocation phase never happens server-side).
+    :ui-event   `re-frame.freehand.tree/opaque-fn
+    :handler    `re-frame.freehand.tree/opaque-fn
+    ;; A compiled render slot: the lexically-visible pure body compiles to a
+    ;; carrier the seam invokes via v/slot. On the JVM its rendered output is
+    ;; a structural tree node.
+    :render-fn  `(re-frame.freehand.tree/render-fn
+                  (fn [~@(:params render-fn)] ~(emit-node (:body render-fn)))
+                  ~(count (:params render-fn)))
+    value))
+
+(defn- emit-view [node]
+  (let [entries   (get-in node [:props :entries])
+        key-info  (get-in node [:props :key])
+        child-forms (into [] (keep emit-node) (:children node))
+        props-map (into {}
+                        (map (fn [{:keys [k] :as en}] [k (prop-value-form en)]))
+                        entries)
+        props-form (if (seq child-forms)
+                     `(assoc ~props-map :children
+                             (some-> (re-frame.freehand.tree/children ~@child-forms)
+                                     re-frame.freehand.tree/child-vec))
+                     props-map)
+        self?     (and (some? *self-fqn*) (= (:fqn node) *self-fqn*))
+        head-sym  (if self? (:fqn node) (:sym node))
+        call      `(~head-sym ~props-form)]
+    (if (:present? key-info)
+      `(assoc ~call :key ~(:expr key-info))
+      call)))
+
+(defn- emit-foreign [node]
+  (if (:lazy? node)
+    ;; a re-frame.freehand.react/lazy component IS callable on the JVM structural
+    ;; render: it renders its declared fallback (or nothing) and NEVER invokes
+    ;; the load thunk (which is not even emitted on the JVM). Props/children are
+    ;; irrelevant — the fallback is capability-free markup baked into the value.
+    `(~(:sym node) {})
+    `(re-frame.freehand.tree/jvm-host-op!
+      :foreign-component
+      ~(str "foreign React component " (:sym node) " in a JVM render — "
+            "foreign components never appear in the JVM tree; wrap the "
+            "subtree in v/client-only (S3)"))))
+
+(defn- emit-for [node]
+  `(re-frame.freehand.tree/keyed-run
+    (into [] (for [~@(:seq-exprs node)] ~(emit-node (:body node))))))
+
+(defn- emit-slot
+  "A `v/slot` invocation: gate the render-fn value (nil renders nothing; a
+  non-render-fn value is the didactic `invalid-slot!`), then invoke the
+  carrier's compiled body with the runtime args — a fixed-arity call whose
+  args evaluate only when the slot renders. The rendered output is an
+  ordinary tree child."
+  [node]
+  (let [rf      (gensym "rf-ui-slot")
+        slotval (if-let [{:keys [params body]} (:render-fn node)]
+                  `(re-frame.freehand.tree/render-fn (fn [~@params] ~(emit-node body))
+                                               ~(count params))
+                  (:slot-value node))]
+    `(let [~rf ~slotval]
+       (when (re-frame.freehand.tree/slot-ready? ~rf)
+         (re-frame.freehand.tree/check-slot-arity! ~rf ~(count (:args node)))
+         ((:f ~rf) ~@(:args node))))))
+
+(defn emit-node
+  "AST node -> JVM form (nil for a statically-absent child)."
+  [node]
+  (case (:op node)
+    :nothing  nil
+    :text     (:value node)
+    :expr     (:form node)
+    :raw      `(re-frame.freehand.tree/jvm-host-op!
+                :v/raw "(v/raw ...) is a host React element")
+    :html     nil ; sole-child form carried by the parent element
+    :element  (emit-element node)
+    :fragment (let [k (:key node)]
+                `(re-frame.freehand.tree/fragment
+                  ~(:present? k) ~(:expr k)
+                  ~@(keep emit-node (:children node))))
+    ;; A top-region frame-root SCOPES its ensured frame (rf2-vxgfnd.25): the
+    ;; JVM has no React context, so it BINDS the dynamic-tier ambient frame
+    ;; to the frame-root's literal :id around the subtree's construction (the
+    ;; mirror of the CLJS scope-element / of jvm-provider-scope). ENSURE
+    ;; already ran at host preflight; the subtree itself is a transparent
+    ;; fragment in the structural tree. So an ambient (sub …) in a descendant
+    ;; view resolves the frame-root's frame during a Tier-1 structural render.
+    :frame-root `(re-frame.freehand.frames/jvm-root-scope
+                  ~(:frame-id node)
+                  (fn []
+                    (re-frame.freehand.tree/fragment
+                     false nil ~@(keep emit-node (:children node)))))
+    ;; S2c: frame-provider scopes by BINDING the dynamic-tier ambient frame
+    ;; around the subtree's construction (the JVM has no React context); the
+    ;; subtree itself is a transparent fragment in the structural tree
+    :frame-provider `(re-frame.freehand.frames/jvm-provider-scope
+                      ~(:frame node)
+                      (fn []
+                        (re-frame.freehand.tree/fragment
+                         false nil ~@(keep emit-node (:children node)))))
+    :view     (emit-view node)
+    :foreign  (emit-foreign node)
+    :slot     (emit-slot node)
+    ;; error-boundary is a CLIENT recovery mechanism (Spec 004 §The JVM
+    ;; structural subset): the JVM/SSR renders the guarded CHILD transparently
+    ;; under the server failure policy (per 011); it never renders the fallback
+    ;; (that is client recovery). A throw below it is the server's to project.
+    :error-boundary (emit-node (:child node))
+    ;; presence: the JVM has no lifecycle, so it renders the children :present,
+    ;; wrapped in the `:rf.ui/presence {:phase :present :timeout-ms n}` fragment
+    ;; (§004B — presence metadata exposed structurally).
+    :presence `(re-frame.freehand.tree/presence
+                ~(:timeout-ms node)
+                ~@(keep emit-node (:children node)))
+    ;; client-only: the JVM/SSR renders the deterministic capability-free
+    ;; FALLBACK, wrapped in the `:rf.ui/boundary :client-only` fragment (§004B);
+    ;; the browser-only client subtree never appears on the JVM tree.
+    :client-only `(re-frame.freehand.tree/client-only-fallback
+                   ~(emit-node (:fallback node)))
+    ;; Leading (effect …) statements: a `do` sequences the JVM effect stubs
+    ;; (no-ops) then renders the template. `local` mutators / dispatch-fn stay
+    ;; unevaluated in their statement bodies until a host test invokes them.
+    :hook-prefix `(do ~@(:statements node) ~(emit-node (:body node)))
+    :if       `(if ~(:test node)
+                 ~(emit-node (:then node))
+                 ~(emit-node (:else node)))
+    :let      `(let ~(:bindings node) ~(emit-node (:body node)))
+    :letfn    `(letfn ~(:fnspecs node) ~(emit-node (:body node)))
+    :case     `(case ~(:expr node)
+                 ~@(mapcat (fn [[test branch]] [test (emit-node branch)])
+                           (:clauses node))
+                 ~@(when (not= ::ana/none (:default node))
+                     [(emit-node (:default node))]))
+    :for      (emit-for node)))
+
+;; ---------------------------------------------------------------------------
+;; defview
+;; ---------------------------------------------------------------------------
+
+(defn- mark-host-root-annotation
+  "Stamp the view-evidence DOM-annotation marker onto the view's effective host
+  root(s) — the DOM `:element`(s) the compiler owns at the top of the render. The
+  UNCONDITIONAL wrappers (`:hook-prefix` effect prefix, an authored `:let` /
+  `:letfn`) are transparent — the marker rides through to the element they wrap.
+
+  A COMMON CONDITIONAL root is narrowly DESCENDED so its concrete DOM arms are
+  tagged: `if` / `if-not` / `when` / `when-not` / `cond` (each an `:if`), `case`
+  (its clauses + default), and the if-let family (`if-let` / `when-let` /
+  `if-some` / `when-some`, which desugar to `:let` over `:if`). So a view rooted
+  at `(if loading? [:spinner] [:page])` tags whichever arm renders. Spec 006
+  exempts only the render that yields nil; a later concrete DOM output must be
+  tagged. The recursion RETAINS the per-branch host-root exemptions: a branch
+  that is nil (`:nothing`, e.g. a one-arm `when`'s absent else), a fragment,
+  another view/foreign component, or a loop (`:for`) is NOT a single
+  compiler-owned host node and carries no annotation — the same exemption the
+  CLJS emit and the adapter source-coord walk apply to a non-DOM root.
+
+  `emit-element` reads the marker off the plain element and merges the annotation
+  into its `:static` attrs behind the `interop/debug-enabled?` gate (see
+  `static-form`). The JVM twin of
+  `re-frame.freehand.compiler.emit-cljs/mark-host-root-annotation`, kept BYTE-IDENTICAL:
+  a prop/attribute annotation is inherently cross-emitter, so the two walks MUST
+  descend the same forms or a conditional-rooted view diverges under the
+  JVM<->CLJS parity gate and SSR/client hydration."
+  [ast annotate]
+  (case (:op ast)
+    :element (assoc ast :rf.ui/annotate annotate)
+    (:hook-prefix :let :letfn) (update ast :body mark-host-root-annotation annotate)
+    :if   (-> ast
+              (update :then mark-host-root-annotation annotate)
+              (update :else mark-host-root-annotation annotate))
+    :case (-> ast
+              (update :clauses
+                      (fn [clauses]
+                        (mapv (fn [[test branch]]
+                                [test (mark-host-root-annotation branch annotate)])
+                              clauses)))
+              (update :default
+                      (fn [d]
+                        (if (= ::ana/none d) d
+                            (mark-host-root-annotation d annotate)))))
+    ast))
+
+(defn emit-defview
+  [{:keys [vname view-id docstring header ast manifest closed-keys children?
+           self-fqn]}]
+  (let [;; The DEV view-evidence DOM annotation for this view's compiler-owned
+        ;; host root — the source coordinate + view id, in today's attribute
+        ;; vocabulary (Spec 004 §View identity), via the cross-host
+        ;; `re-frame.source-coords` projections (byte-identical to the CLJS emit
+        ;; and the adapter walks by construction). Marked onto the effective root
+        ;; element and merged behind the `interop/debug-enabled?` gate; a
+        ;; non-element root carries none.
+        annotate {:source-coord (source-coord/format-source-coord
+                                 view-id (:source manifest))
+                  :view-tag     (source-coord/format-view-id view-id)}
+        rendered (binding [*self-fqn* self-fqn]
+                   (emit-node (mark-host-root-annotation ast annotate)))
+        bind     (:binding-form header)
+        var-meta (cond-> {:rf.ui/view true
+                          :rf.ui/view-id view-id
+                          ;; Kept byte-identical to the CLJS emitter's view
+                          ;; descriptor (rf2-u53yy.1 S2). On the JVM host the
+                          ;; whole-build view registry still rides the per-source
+                          ;; slice (there is no Shadow disk cache to survive), so
+                          ;; this metadata is not the harvest carrier here; it is
+                          ;; carried for parity so `(meta #'view)` reads the same
+                          ;; descriptor on both hosts.
+                          :rf.ui/view-digest [(:template-fingerprint manifest)
+                                              (:hook-signature manifest)]
+                          :rf.ui/children? children?}
+                   docstring   (assoc :doc docstring)
+                   closed-keys (assoc :rf.ui/closed-prop-keys (vec closed-keys)))]
+    `(do
+       (defn ~(vary-meta vname merge var-meta) [~props-sym]
+         (re-frame.freehand.tree/view-boundary
+          ~view-id
+          ~props-sym
+          ~(if bind `(let [~bind ~props-sym] ~rendered) rendered)))
+       (re-frame.freehand.tree/register-view! ~view-id ~vname (quote ~manifest))
+       (var ~vname))))

--- a/implementation/freehand/src/re_frame/freehand/compiler/env.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/env.cljc
@@ -1,0 +1,262 @@
+(ns re-frame.freehand.compiler.env
+  "Compile-time environment + head/symbol resolution for the template
+  analyzer (the Q5 surface: internal-vs-foreign head discrimination).
+
+  ## The Q5 discrimination rule (pinned)
+
+  A symbol head classifies by RESOLUTION at expansion time:
+
+    1. the symbol being `defview`d right now (self) -> INTERNAL VIEW
+       (self-recursion works; the var need not exist yet);
+    2. a symbol whose resolved var carries `:rf.ui/view` metadata ->
+       INTERNAL VIEW (`defview` stamps it; aliases resolve through ns
+       aliases and `:refer` naturally);
+    3. a resolvable symbol WITHOUT view metadata -> FOREIGN component
+       boundary (open props; JS values pass through);
+    4. an unresolvable symbol -> COMPILE ERROR (didactic).
+
+  Corners (all test-pinned in re-frame.freehand.q5-heads-cljs-test):
+    - forward/mutual recursion: `(declare ^:rf.ui/view b)` marks the var
+      before definition, so mutually-recursive views are expressible with
+      zero extra surface; a plain `(declare b)` head classifies FOREIGN
+      (rule 3) — the declare-hint is the supported spelling;
+    - var-copies (`(def card2 card)`) do NOT carry view-ness (var meta is
+      not copied by def) — they classify foreign; alias the NAMESPACE or
+      use the original name;
+    - locals shadowing a view name classify as neither (the analyzer
+      treats a local-bound head as a dynamic head -> compile error, since
+      dynamic tag/component heads are rejected)."
+  (:require [clojure.string :as str]))
+
+(defn make-env
+  "host :clj|:cljs; cljs-env = &env when :cljs; ns-sym = consuming ns;
+  self = the view symbol being compiled (nil outside defview);
+  self-id = its view id. `resolver` (tests only) overrides host
+  resolution: (fn [sym]) -> {:fqn sym :meta {..}} | nil."
+  [{:keys [host cljs-env ns-sym self self-id resolver source template-anchor]}]
+  {:host      host
+   :cljs-env  cljs-env
+   :ns        ns-sym
+   :self      self
+   :self-id   self-id
+   :resolver  resolver
+   ;; Compiler-owned lexical-site identity inputs. `source` is the defview
+   ;; declaration anchor (only relative line/column deltas are consumed) and
+   ;; `template-anchor` is a semantic whole-template fallback for reader forms
+   ;; that carry no usable source metadata. Neither reaches emitted code.
+   :source    source
+   :template-anchor template-anchor
+   :locals    #{}
+   :loop-syms #{}
+   :in-loop?  false
+   ;; True in a defview's UNCONDITIONAL top region (the body + top-region
+   ;; let/do bodies), where host hooks (`local` / `effect`) are legal; cleared
+   ;; on entering a branch / loop / deferred callback. Set by the defview
+   ;; driver; false everywhere else (root forms, ui.test).
+   :hooks-region? false
+   :path      []
+   :warnings  (atom [])
+   ;; A shared monotonic ordinal over the LET-BODY host hooks (`local` +
+   ;; the six re-frame.freehand.react hooks) in source order. Stamped on react-hook
+   ;; sites so the hook signature detects a local↔react reorder (both live in
+   ;; the same top-region let, interleaved in React hook order) — a per-category
+   ;; count vector alone could not. Effects are structurally before (hook-prefix)
+   ;; and do not advance it.
+   :hook-ordinal (atom 0)
+   ;; `:diagnostics` carries the compile-tier a11y findings (S4-C) — INCLUDING
+   ;; suppressed ones, which stay manifest facts with their reason but never
+   ;; print. Every other kind is a lowering/ownership site.
+   :sites     (atom {:events [] :subs [] :htmls [] :frame-ops []
+                     :slots [] :locals [] :effects [] :dispatch-fns [] :react []
+                     :diagnostics []})})
+
+(defn warn! [env w]
+  (swap! (:warnings env) conj w)
+  nil)
+
+(defn add-site! [env kind site]
+  (swap! (:sites env) update kind conj site)
+  nil)
+
+(defn next-hook-ordinal!
+  "Advance and return (0-based) the shared body-hook ordinal — the source-order
+  position of a `local` / re-frame.freehand.react hook among the top-region let-body
+  hooks. Locals advance it without storing it; react-hook sites store theirs, so
+  a local↔react reorder shifts a react ordinal and changes the hook signature."
+  [env]
+  (dec (long (swap! (:hook-ordinal env) inc))))
+
+(defn compile-error
+  "All analyzer/emitter compile errors carry {:rf.ui.compile/error <id>}
+  ex-data — the S1e roster/catalogue slice keys off these ids."
+  ([id msg] (compile-error id msg nil))
+  ([id msg data]
+   (ex-info (str "re-frame.freehand compile error: " msg)
+            (merge {:rf.ui.compile/error id} data))))
+
+(defn fail!
+  ([env id msg] (fail! env id msg nil))
+  ([env id msg data]
+   (throw (compile-error id msg (assoc data :path (:path env))))))
+
+;; ---------------------------------------------------------------------------
+;; Resolution
+;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (defn- resolve-cljs [env sym]
+     (try
+       (let [resolve* (requiring-resolve 'cljs.analyzer.api/resolve)
+             info     (resolve* (:cljs-env env) sym)]
+         (when (and info (not (:local info)) (:name info) (symbol? (:name info)))
+           ;; CLJS analyzer macro authority is a TOP-LEVEL `:macro` flag on
+           ;; the resolved info map (not reliably duplicated in `:meta`).
+           ;; Normalize it into the metadata shape shared with CLJ resolution
+           ;; so expression rewriting cannot traverse an opaque binder macro.
+           {:fqn (:name info)
+            :meta (cond-> (or (:meta info) {})
+                    (:macro info) (assoc :macro true))}))
+       (catch Exception _ nil))))
+
+#?(:clj
+   (defn- resolve-clj [env sym]
+     (when-let [ns* (find-ns (:ns env))]
+       (when-let [v (try (ns-resolve ns* sym) (catch Exception _ nil))]
+         (when (var? v)
+           (let [m (meta v)]
+             {:fqn  (symbol (str (ns-name (:ns m))) (str (:name m)))
+              :meta m}))))))
+
+#?(:clj
+   (defn- jvm-lazy-value?
+     "JVM structural compile: `sym` resolves to a bound var whose value is a
+     re-frame.freehand.react/lazy component (marked `:rf.ui/lazy` by lazy-jvm). Lets
+     the JVM emitter render a bare `[HeavyChart …]` head's fallback rather than
+     raise the foreign host-op — without any authored var metadata."
+     [env sym]
+     (boolean
+      (when-let [ns* (find-ns (:ns env))]
+        (when-let [v (try (ns-resolve ns* sym) (catch Exception _ nil))]
+          (and (var? v)
+               (bound? v)
+               (:rf.ui/lazy (try (deref v) (catch Exception _ nil)))))))))
+
+(defn resolve-sym
+  "Resolve `sym` in the consuming namespace. Returns {:fqn sym :meta m}
+  or nil. Local (template-level) bindings shadow vars."
+  [env sym]
+  (when-not (contains? (:locals env) sym)
+    (if-let [r (:resolver env)]
+      (r sym)
+      #?(:clj  (if (= :cljs (:host env))
+                 (resolve-cljs env sym)
+                 (resolve-clj env sym))
+         :cljs nil))))
+
+(defn resolves-to?
+  "Does `sym` resolve to one of the fully-qualified `targets`?"
+  [env sym targets]
+  (when-let [{:keys [fqn]} (resolve-sym env sym)]
+    (contains? targets fqn)))
+
+(defn view-id-of
+  "The view id a resolved internal view registers under: explicit
+  :rf.ui/view-id meta (from an :id override) or the family-rule
+  derivation (keyword ns name)."
+  [fqn meta*]
+  (or (:rf.ui/view-id meta*)
+      (keyword (namespace fqn) (name fqn))))
+
+(defn classify-head
+  "Q5: classify a symbol head. -> {:kind :view|:foreign :sym sym
+  :fqn fqn|nil :view-id kw?} or throws for unresolvable heads."
+  [env sym]
+  (cond
+    (contains? (:locals env) sym)
+    (fail! env :rf.ui.compile/dynamic-head
+           (str "component head " sym " is a local binding — heads must be "
+                "literal: a keyword (DOM/custom element), a defview var, or "
+                "a foreign component var. Runtime-chosen components are "
+                "v/view / v/element [WAVE-2]; v/raw covers a runtime "
+                "React element meanwhile")
+           {:head sym})
+
+    (and (:self env) (= sym (:self env)))
+    {:kind :view :sym sym :fqn (symbol (str (:ns env)) (str sym))
+     :view-id (:self-id env)}
+
+    :else
+    (if-let [{:keys [fqn meta]} (resolve-sym env sym)]
+      (cond
+        (:rf.ui/view meta)
+        {:kind :view :sym sym :fqn fqn :view-id (view-id-of fqn meta)}
+        ;; a re-frame.freehand.react/lazy component: a foreign head that IS callable on
+        ;; the JVM structural render (it renders its fallback / nothing), so the
+        ;; JVM emitter invokes it instead of raising the foreign host-op. Detected
+        ;; by authored var meta OR (JVM structural compile) the marked value.
+        (or (:rf.ui/lazy meta)
+            #?(:clj (and (= :clj (:host env)) (jvm-lazy-value? env sym))
+               :cljs false))
+        {:kind :foreign :sym sym :fqn fqn :lazy? true}
+        :else
+        {:kind :foreign :sym sym :fqn fqn})
+      (fail! env :rf.ui.compile/unresolved-head
+             (str "unresolved component head " sym " — require/refer it, or "
+                  "for a forward/mutual view reference declare it first: "
+                  "(declare ^:rf.ui/view " sym ")")
+             {:head sym}))))
+
+;; ---------------------------------------------------------------------------
+;; Scope helpers
+;; ---------------------------------------------------------------------------
+
+(defn binding-syms
+  "All symbols bound by a destructuring pattern (recursive; ignores :or
+  defaults' values, collects :as)."
+  [pattern]
+  (cond
+    (symbol? pattern) (if (= '& pattern) [] [pattern])
+    (vector? pattern) (into [] (mapcat binding-syms) pattern)
+    (map? pattern)
+    (into []
+          (mapcat (fn [[k v]]
+                    (cond
+                      (= k :as)   [v]
+                      (= k :or)   []
+                      (and (keyword? k) (= "keys" (name k))) (mapv #(symbol (name %)) v)
+                      (and (keyword? k) (= "syms" (name k))) (mapv #(symbol (name %)) v)
+                      (and (keyword? k) (= "strs" (name k))) (mapv #(symbol (name %)) v)
+                      :else (binding-syms k))))
+          pattern)
+    :else []))
+
+(defn with-locals [env syms]
+  (update env :locals into syms))
+
+(defn with-loop [env syms]
+  (-> env
+      (update :locals into syms)
+      (update :loop-syms into syms)
+      (assoc :in-loop? true)))
+
+(defn syms-in-form
+  "Symbols occurring anywhere in `form` (quote-form contents skipped) —
+  the loop-capture detector's currency."
+  [form]
+  (cond
+    (symbol? form) #{form}
+    (and (seq? form) (= 'quote (first form))) #{}
+    (coll? form) (into #{} (mapcat syms-in-form) form)
+    :else #{}))
+
+(defn captured-loop-syms [env form]
+  (into #{} (filter (:loop-syms env)) (syms-in-form form)))
+
+(defn kws-in-form
+  "Keywords occurring anywhere in `form` (quote contents skipped)."
+  [form]
+  (cond
+    (keyword? form) #{form}
+    (and (seq? form) (= 'quote (first form))) #{}
+    (coll? form) (into #{} (mapcat kws-in-form) form)
+    :else #{}))

--- a/implementation/freehand/src/re_frame/freehand/compiler/harvest.clj
+++ b/implementation/freehand/src/re_frame/freehand/compiler/harvest.clj
@@ -1,0 +1,253 @@
+(ns re-frame.freehand.compiler.harvest
+  "Deterministic pre-seed of compile-time custom-element declarations.
+
+  A view's custom-element property lowering (property vs attribute) is decided
+  at MACROEXPANSION by reading the ambient build's `elements` slice through
+  `build/element-properties`. Because macros expand top-to-bottom, a view
+  expanded BEFORE its tag's `(v/custom-element …)` declaration read an EMPTY
+  slice and lowered the prop to an HTML attribute; the same forms in the
+  opposite order lowered it to a JS property. Two source files with no `:require`
+  edge compiled in an arbitrary order and could differ the same way. That
+  violated deterministic compilation (rf2-vxgfnd.141, dimension 2).
+
+  This namespace closes that by reading each build source's TOP-LEVEL LITERAL
+  `(v/custom-element …)` forms and seeding the `elements` slice BEFORE any view
+  analyzes, so classification is a pure function of the build's declarations and
+  NOT of evaluation order. It is a SYNTACTIC read, never a general interpreter:
+  the ruled grammar is top-level, literal and compile-resolvable (`:properties`
+  MUST be a literal set), so recognizing the exact `(<v>/custom-element <kw>
+  <map>)` shape — and rejecting anything the macro would reject rather than
+  seeding it — is sound. A non-literal or malformed form is simply not seeded;
+  the `v/custom-element` macro still expands and reports it with the
+  declaration's own source coordinates.
+
+  Two callers seed through it:
+
+  * the Shadow build hook, at `:compile-prepare`, folds EVERY authoritative UI
+    source's declarations (not just the recompiled subset — rf2-u53yy.1 S1) into
+    the flat all-members manifest held beside the open pass
+    (`build/element-manifest` / `build/set-shadow-element-manifest`) — a pure
+    build-state transform, since `cljs.env/*compiler*` is not bound during hook
+    execution;
+
+  * the plain-JVM / SSR path (which has no `:compile-prepare`) harvests the
+    ambient namespace's own source ONCE, lazily, the first time a view in it
+    classifies a custom element (`ensure-namespace-harvested!`), seeding through
+    the ambient `build/contribute-element-checked!`.
+
+  Both routes admit through the ONE cross-source conflict law: on the Shadow path
+  `build/element-manifest` re-derives the verdict over all members, and on the
+  plain-JVM path `build/contribute-element-checked!` is the write barrier — an
+  `rf=`-equal duplicate co-exists; a contradictory same-tag declaration is refused
+  (and reported with source coordinates on the plain-JVM path, or as a build-time
+  error at prepare on the Shadow path). JVM-only: it reads source text at build
+  time and is never emitted into any bundle."
+  (:require [clojure.java.io :as io]
+            [clojure.tools.reader :as rdr]
+            [clojure.tools.reader.reader-types :as rt]
+            [re-frame.freehand.compiler.build :as build]))
+
+;; ---------------------------------------------------------------------------
+;; ns-form alias analysis — how THIS source names re-frame.freehand/custom-element
+;; ---------------------------------------------------------------------------
+
+(def ^:private custom-element-fqn 're-frame.freehand/custom-element)
+(def ^:private ui-lib 're-frame.freehand)
+
+(defn- lib-spec-seq
+  "Every `:require` / `:require-macros` library spec in an `(ns …)` form."
+  [ns-form]
+  (mapcat (fn [clause]
+            (when (and (seq? clause)
+                       (contains? #{:require :require-macros} (first clause)))
+              (rest clause)))
+          (rest ns-form)))
+
+(defn- ui-heads
+  "The set of head symbols that, in THIS source, name
+  `re-frame.freehand/custom-element`: the fully-qualified symbol always, plus each
+  `:as` alias of `re-frame.freehand`, plus a bare `custom-element` when it is
+  `:refer`red from `re-frame.freehand`. Reading the source's OWN `(ns …)` aliases is
+  what makes recognition robust across `[re-frame.freehand :as v]`,
+  `re-frame.freehand/custom-element`, and `:refer [custom-element]` without resolving
+  vars."
+  [ns-form]
+  (reduce
+   (fn [heads spec]
+     (let [[lib & opts] (if (sequential? spec) spec [spec])
+           opts (apply hash-map opts)]
+       (if (= lib ui-lib)
+         (cond-> heads
+           (symbol? (:as opts))
+           (conj (symbol (name (:as opts)) "custom-element"))
+           (and (sequential? (:refer opts))
+                (some #{'custom-element} (:refer opts)))
+           (conj 'custom-element))
+         heads)))
+   #{custom-element-fqn}
+   (lib-spec-seq ns-form)))
+
+;; ---------------------------------------------------------------------------
+;; Literal-form recognition — mirrors the macro's `:properties` grammar checks
+;; ---------------------------------------------------------------------------
+
+(defn- valid-tag? [tag]
+  (and (keyword? tag) (nil? (namespace tag))
+       (clojure.string/includes? (name tag) "-")))
+
+(defn- valid-properties? [props]
+  (and (set? props)
+       (every? #(and (keyword? %) (nil? (namespace %))) props)))
+
+(defn- declaration
+  "If `form` is a recognized, LITERAL `(<v>/custom-element <tag> <opts>)` — the
+  exact shape the macro accepts — return `{:tag tag :properties #{…}}`, else
+  nil. Anything the macro would reject (non-literal tag, non-map opts, unknown
+  option, non-literal `:properties`) is NOT recognized here: the macro still
+  expands the form and reports the error with its own coordinates, so the
+  declaration never silently seeds a bad classification (rf2-vxgfnd.141)."
+  [heads form]
+  (when (and (seq? form) (contains? heads (first form)))
+    (let [[_ tag opts] form]
+      (when (and (valid-tag? tag)
+                 (map? opts)
+                 (empty? (remove #{:properties} (keys opts))))
+        (let [props (get opts :properties #{})]
+          (when (valid-properties? props)
+            {:tag tag :properties props}))))))
+
+;; ---------------------------------------------------------------------------
+;; Tolerant source reading — well-formed CLJS/CLJC source, top-level forms only
+;; ---------------------------------------------------------------------------
+
+(defn- alias-map
+  "The `alias -> namespace` map for `::alias/kw` resolution, read from the ns
+  form's `:as` clauses. Populated before reading the body so an auto-resolved
+  keyword in a form preceding a declaration does not abort the read."
+  [ns-form]
+  (reduce (fn [m spec]
+            (let [[lib & opts] (if (sequential? spec) spec [spec])
+                  {:keys [as]} (apply hash-map opts)]
+              (if (and lib (symbol? as)) (assoc m as lib) m)))
+          {}
+          (lib-spec-seq ns-form)))
+
+(defn- read-all-forms
+  "Read every top-level form of `src` (a CLJS/CLJC/CLJ source string) tolerantly:
+  reader conditionals resolve under `:cljs`, every tagged literal (`#js`,
+  `#uuid`, custom) degrades to its value, `#=` eval is disabled, and `::alias/kw`
+  resolves through `aliases`. A read failure ends the scan gracefully — the
+  `v/custom-element` macro remains the authority, so a source we cannot fully
+  read merely falls back to evaluation-order behaviour rather than breaking the
+  build. Returns the vector of forms read."
+  [^String src aliases]
+  (let [reader (rt/string-push-back-reader src)
+        eof (Object.)
+        opts {:eof eof :read-cond :allow :features #{:cljs}}]
+    (binding [rdr/*default-data-reader-fn* (fn [_tag v] v)
+              rdr/*read-eval* false
+              rdr/*alias-map* aliases]
+      (loop [forms []]
+        (let [form (try (rdr/read opts reader)
+                        (catch Throwable _ eof))]
+          (if (identical? form eof)
+            forms
+            (recur (conj forms form))))))))
+
+(defn- ns-form [forms]
+  (first (filter #(and (seq? %) (= 'ns (first %))) forms)))
+
+(defn declarations-in-source
+  "PURE: every literal custom-element declaration in CLJS/CLJC/CLJ source string
+  `src`, as `[{:tag … :properties #{…}} …]` in source order. Resolves the
+  source's own `(ns …)` aliases so the recognized head is exactly how that
+  source spells `re-frame.freehand/custom-element`. Order in the returned vector is
+  irrelevant to classification (the conflict barrier makes duplicates idempotent
+  and contradictions refuse); it is kept only for deterministic seeding."
+  [src]
+  (let [;; A cheap first pass gets the ns form (and thus aliases) so the full
+        ;; read can resolve ::alias/kw; the ns form itself never carries one.
+        head-forms (read-all-forms src {})
+        nsf (ns-form head-forms)
+        forms (if nsf (read-all-forms src (alias-map nsf)) head-forms)
+        heads (if nsf (ui-heads nsf) #{custom-element-fqn})]
+    (into [] (keep #(declaration heads %)) forms)))
+
+;; ---------------------------------------------------------------------------
+;; Seeding — the two callers
+;; ---------------------------------------------------------------------------
+
+(defn source-seed
+  "The `[source tag decl]` triples the build hook folds into the flat all-members
+  manifest (`build/element-manifest`), for one build source declaring namespace
+  `ns-sym` with `src` text. `ns-sym` is the declaring source (the conflict/owner
+  unit)."
+  [ns-sym src]
+  (mapv (fn [{:keys [tag properties]}]
+          [ns-sym tag {:properties properties}])
+        (declarations-in-source src)))
+
+;; --- plain-JVM / SSR lazy own-source harvest -------------------------------
+
+(defonce ^{:private true
+           :doc "Namespaces already harvested on the plain-JVM/SSR path, keyed
+  [build-id ns-sym]. The declarations are stable per source-load, so a namespace
+  is read at most once per build identity. Cleared by `reset-harvested!` for
+  test isolation; never consulted on the Shadow pass path (that seeds from the
+  build graph at `:compile-prepare`)."}
+  harvested (atom #{}))
+
+(defn reset-harvested! []
+  (reset! harvested #{})
+  nil)
+
+(defn- classpath-source
+  "Source text of namespace `ns-sym` located on the classpath, or nil. Tries the
+  CLJS/CLJC/CLJ extensions in the order the compiler would."
+  [ns-sym]
+  (let [base (-> (str ns-sym)
+                 (clojure.string/replace "-" "_")
+                 (clojure.string/replace "." "/"))]
+    (some (fn [ext]
+            (when-let [url (io/resource (str base ext))]
+              (slurp url)))
+          [".cljc" ".cljs" ".clj"])))
+
+(defn- current-file-source
+  "Source text of the file currently being compiled (`*file*`), or nil. Covers
+  a source loaded off the classpath (e.g. `clojure.main <script>`); nil for the
+  REPL sentinel `NO_SOURCE_PATH`, whose forms are already ordered."
+  []
+  (let [f *file*]
+    (when (and (string? f) (not= f "NO_SOURCE_PATH"))
+      (or (let [file (io/file f)]
+            (when (.isFile file) (slurp file)))
+          (when-let [url (io/resource f)] (slurp url))))))
+
+(defn- ns->source
+  "The source text for namespace `ns-sym`: the classpath resource (the exact
+  file the compiler loaded) with the file currently being compiled as a
+  fallback for off-classpath sources. nil (REPL forms, generated namespaces)
+  makes the harvest a graceful no-op."
+  [ns-sym]
+  (or (classpath-source ns-sym)
+      (current-file-source)))
+
+(defn ensure-namespace-harvested!
+  "Plain-JVM / SSR path: seed namespace `ns-sym`'s OWN literal custom-element
+  declarations into the ambient build ONCE, before its views classify. Reads the
+  namespace's source from the classpath and admits each declaration through the
+  ambient conflict barrier (`build/contribute-element-checked!`), so a view
+  expanded before a declaration textually below it still classifies against the
+  whole source. Idempotent, memoized per [build-id ns-sym]; a no-op when the
+  source cannot be located (a REPL/generated namespace, whose forms are already
+  ordered)."
+  [ns-sym]
+  (when (symbol? ns-sym)                 ; a missing ns must never memoize a
+    (let [key [(build/current-build-id) ns-sym]]  ; nil key that poisons every ns
+      (when-not (contains? @harvested key)
+        (swap! harvested conj key)
+        (when-let [src (ns->source ns-sym)]
+          (doseq [{:keys [tag properties]} (declarations-in-source src)]
+            (build/contribute-element-checked! ns-sym tag {:properties properties}))))))
+  nil)

--- a/implementation/freehand/src/re_frame/freehand/compiler/header.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/header.cljc
@@ -1,0 +1,263 @@
+(ns re-frame.freehand.compiler.header
+  "defview header (props binding) analysis — the Q2 surface.
+
+  ## The Q2 pins (PR section 'Q2 — props binding policy'; all test-pinned)
+
+  - Zero or one argument, semantically a props map. `[sym]` ≡ `[{:as sym}]`.
+  - Header destructuring lowers to direct property reads on the host props
+    object (CLJS) / native map destructuring (JVM); no CLJS map at entry.
+  - `:as` opts into materialization (a CLJS map of ALL present slots) +
+    GENERIC comparison over the slot union (documented dev cost).
+  - `:or` defaults apply iff the slot is ABSENT (JS undefined), mirroring
+    Clojure map-destructuring; a present-nil slot stays nil. Defaults
+    affect the BINDING only — never the comparator, never the props.
+  - Namespaced `:x/keys [a]` binds slot \"x/a\"; explicit `{p :x/a}`
+    likewise. Nested patterns bind the slot value then destructure it
+    normally (one lowering rule).
+  - Declared slots = header top-level keys ∪ literal `[:map ...]` :props
+    schema top-level keys (header order first, then schema-only keys).
+    The memo comparator runs over exactly these slots (+ children).
+  - `:props` ABSENT = OPEN map (extra call-site props are legal and
+    invisible); `:props` PRESENT = CLOSED map (undeclared keys at literal
+    call sites are compile errors).
+  - `:key` cannot be a declared prop (it feeds React's key slot);
+    `:children` in the header declares child acceptance (Q4); `:ref`
+    is an ordinary declarable slot — a view forwards a ref only by
+    declaring it (React 19 ref-as-prop).
+  - `:strs`/`:syms` are outside the props ABI (slots are keywords)."
+  (:require [re-frame.freehand.compiler.binding-plan :as bp]
+            [re-frame.freehand.compiler.env :as env]))
+
+(defn- fail [id msg data]
+  (throw (env/compile-error id msg data)))
+
+(defn slot-name
+  "Q3 encode E: namespace + \"/\" + name when namespaced, else name —
+  verbatim, no case conversion, no mangling (quoted JS property access
+  makes any spelling legal)."
+  [k]
+  (if-let [ns* (namespace k)] (str ns* "/" (name k)) (name k)))
+
+(defn- reserved-slot-check!
+  "A view prop keyword may not be the reserved React `:key` slot (it feeds
+  React's key slot). It is rejected wherever the author names it — a
+  `:keys [key]` group symbol or an explicit `{p :key}` value alike — judged on
+  what was WRITTEN, so the canonical collapse can never hide a reserved
+  declaration. `:ref` is NOT rejected here: React 19 passes it as an ordinary
+  prop, so a view forwards a ref by declaring `:ref` like any other slot (a
+  ref's commit-phase contract lives at the `:ref` call site, not the header)."
+  [k]
+  (when (= k :key)
+    (fail :rf.ui.compile/key-prop-declared
+          (str ":key cannot be a view prop — it is reserved (it feeds React's "
+               "key slot). Callers pass :key at the call site; it never "
+               "arrives in props — remove the :key binding")
+          {:key k}))
+  k)
+
+(defn- validate-header-map!
+  "Judge a header map's SHAPE on what the author wrote, before the canonical
+  plan collapses it: `:or` must be a map; `:strs`/`:syms` are outside the props
+  ABI; a group needs a vector of symbols; a non-group keyword key is
+  unsupported; an explicit entry's lookup value must be a prop keyword; and no
+  produced slot may be the reserved `:key`. Collapse must never SUPPRESS a
+  diagnostic, so these run on the raw entries, not the de-collided units."
+  [b or-map]
+  (when-not (map? or-map)
+    (fail :rf.ui.compile/bad-defview-args
+          ":or needs a map of binding-symbol -> default"
+          {:or or-map}))
+  (reduce-kv
+   (fn [_ k v]
+     (cond
+       (= k :as) nil
+       (= k :or) nil
+
+       (and (keyword? k) (contains? #{"strs" "syms"} (name k)))
+       (fail :rf.ui.compile/bad-defview-args
+             (str k " is outside the props ABI — prop slots are keywords; use "
+                  ":keys")
+             {:key k})
+
+       (and (keyword? k) (= "keys" (name k)))
+       (do (when-not (and (vector? v) (every? symbol? v))
+             (fail :rf.ui.compile/bad-defview-args
+                   (str k " needs a vector of symbols") {:form v}))
+           ;; Derive each group key with the CANONICAL transform the binding plan
+           ;; uses (`bp/key-group-directive-fn`), so `{:keys [acct/key]}` derives
+           ;; the qualified `:acct/key` — NOT a bare `:key` from `(keyword (name
+           ;; s))` — while a genuinely bare `:keys [key]` still derives the
+           ;; reserved `:key` and fails. One namespace rule for the diagnostic
+           ;; and the plan, so equivalent host spellings agree.
+           (let [group-key (bp/key-group-directive-fn k)]
+             (doseq [s v]
+               (reserved-slot-check! (group-key s)))))
+
+       (keyword? k)
+       (fail :rf.ui.compile/bad-defview-args
+             (str "unsupported header key " k " — supported: :keys,"
+                  " :<ns>/keys, :or, :as, and {pattern :prop-key} entries")
+             {:key k})
+
+       :else
+       ;; {pattern :prop-key} — pattern may itself destructure
+       (do (when-not (keyword? v)
+             (fail :rf.ui.compile/bad-defview-args
+                   (str "header entry {" (pr-str k) " " (pr-str v)
+                        "} — the right side must be a prop keyword")
+                   {:entry [k v]}))
+           (reserved-slot-check! v)))
+     nil)
+   nil
+   b)
+  nil)
+
+(defn- collapse-entries
+  "Project the full host binding-unit plan to its FINAL visible-local slots: keep
+  an entry only where it binds a local NO LATER entry rebinds — the bindings the
+  host's `let` last-wins actually leaves visible. `bp/assoc-binding-units` already
+  collapses two units that share a `bes` KEY (`{:keys [x] x :foo}` → the group's
+  `assoc` overwrites the explicit entry, one `x <- :x`). The residual shadows it
+  does NOT catch arrive as DISTINCT units binding one local via host last-wins:
+    - a QUALIFIED group local whose bare name collides an explicit local
+      (`{:keys [ns/x] x :other}` — `ns/x` ≠ `x` as `bes` keys, both name-strip to
+      the local `x`);
+    - a NESTED or partially overlapping pattern (`{[x] :other :keys [ns/x]}` —
+      `[x]` and `x` are unequal `:pattern` values, but `[x]`'s only local `x` is
+      reclaimed by the group's `x <- :ns/x`).
+  Left uncollapsed these leave a DEAD slot (`:other` here) in the derived `:slots`
+  — over-comparing in the memo comparator (spurious re-renders), over-declaring in
+  the manifest `:prop-slots`, and silently accepting a never-bound key under
+  CLOSED `:props`.
+
+  A reverse sweep restores the 'no dead slot' invariant: walk entries LAST→first,
+  keeping the set of locals a later entry already claimed; retain an entry only
+  where it binds at least one local NOT yet claimed (a final visible local), then
+  add its locals to the claimed set. Comparing the LOCALS each pattern binds
+  (`bp/pattern-locals`) rather than whole `:pattern` values is what catches the
+  nested case a whole-pattern equality misses. The winning entries stay in their
+  `bes` positions, and the FULL executable plan (`:binding-units`) is untouched —
+  every host initializer still runs. Two DISTINCT locals sharing one slot
+  (`{:keys [x] y :x}`) both survive; a partial overlap (`{[a b] :other :keys
+  [ns/a]}`) keeps `:other` because `b` is still a final visible local; the slot
+  `distinct` folds any shared key."
+  [entries]
+  (let [v (vec entries)]
+    (loop [i (dec (count v)), claimed #{}, keep #{}]
+      (if (neg? i)
+        (into [] (keep-indexed (fn [idx e] (when (contains? keep idx) e))) v)
+        (let [locals (bp/pattern-locals (:pattern (nth v i)))]
+          (if (some (complement claimed) locals)
+            (recur (dec i) (into claimed locals) (conj keep i))
+            (recur (dec i) claimed keep)))))))
+
+(defn parse-header
+  "argv -> {:mode :none|:named|:as, :as-sym, :entries [{:key :slot :pattern
+  :default}...], :binding-units [...same shape...], :slots [kw...], :children?
+  bool, :binding-form}
+
+  TWO views of the ONE canonical, host-faithful binding plan
+  (`bp/assoc-binding-units`), split by what the host actually does:
+
+  - `:binding-units` — the FULL host binding-unit plan, one unit per `bes`
+    entry, in host `destructure` order, carrying its winning lookup key and any
+    `:or` default. The EXECUTABLE emission (the CLJS `header-bindings` lowering)
+    and the analyzer's scope walk consume this, so every host initializer runs
+    and the host `let` last-wins is reproduced exactly — including the two units
+    a qualified-group-name collision (`{:keys [ns/x] x :other}`) establishes for
+    one local (rf2-nedxb).
+
+  - `:entries` + `:slots` — the COLLAPSED effective-slot projection (`:entries`
+    run through `collapse-entries`): one entry per bound local, the host-winning
+    last occurrence. DERIVED metadata — the memo comparator, the manifest
+    `:prop-slots`, the closed-`:props` slot set and the schema slot order — reads
+    these, so it never over-declares a dead slot (`{:keys [ns/x] x :other}` drops
+    `:other`), re-collides, or strips a qualified key (`{:keys [acct/id]}` keeps
+    `:acct/id`).
+
+  For every header WITHOUT a qualified-group-name collision the two views are
+  identical; they differ only where the host binds one local through two `bes`
+  keys. The JVM emitter uses `:binding-form` (native destructuring) and needs
+  neither view."
+  [argv]
+  (when-not (vector? argv)
+    (fail :rf.ui.compile/bad-defview-args
+          "defview needs an argument vector: [] or [{...props destructuring...}]"
+          {:argv argv}))
+  (when (> (count argv) 1)
+    (fail :rf.ui.compile/positional-args
+          (str "defview takes zero or one argument — one props map, no "
+               "positional args. Got " (count argv))
+          {:argv argv}))
+  (if (empty? argv)
+    {:mode :none :as-sym nil :entries [] :binding-units [] :slots []
+     :children? false :binding-form nil}
+    (let [b (first argv)]
+      (cond
+        (symbol? b)
+        {:mode :as :as-sym b :entries [] :binding-units [] :slots []
+         :children? true :binding-form b}
+
+        (map? b)
+        (let [as-sym  (get b :as)
+              or-map  (get b :or {})
+              _       (validate-header-map! b or-map)
+              ;; The FULL host binding-unit plan — the host `bes` order with
+              ;; winning lookup keys, EVERY unit the host `let` establishes. A
+              ;; qualified-group-name collision (`{:keys [ns/x] x :other}`) is two
+              ;; units binding one local via host last-wins; both stay here so
+              ;; executable emission runs every host initializer (rf2-nedxb).
+              binding-units
+              (mapv (fn [{:keys [local-pattern key]}]
+                      (cond-> {:key key
+                               :slot (slot-name key)
+                               :pattern local-pattern}
+                        (and (symbol? local-pattern)
+                             (contains? or-map local-pattern))
+                        (assoc :default (get or-map local-pattern))))
+                    (bp/assoc-binding-units b))
+              ;; The COLLAPSED effective-slot projection — one entry per bound
+              ;; local (the host-winning last occurrence). `collapse-entries` folds
+              ;; the qualified-group-name collision to its single winner, so the
+              ;; comparator, manifest and schema slots carry no dead key.
+              entries (collapse-entries binding-units)
+              _ (doseq [s (keys or-map)]
+                  (when-not (some #(= s (:pattern %)) entries)
+                    (fail :rf.ui.compile/bad-defview-args
+                          (str ":or key " s " does not match any bound slot symbol")
+                          {:or or-map})))
+              slots   (into [] (distinct) (map :key entries))]
+          {:mode (if as-sym :as :named)
+           :as-sym as-sym
+           :entries entries
+           :binding-units binding-units
+           :slots slots
+           :children? (boolean (or as-sym (some #(= :children %) slots)))
+           :binding-form b})
+
+        :else
+        (fail :rf.ui.compile/bad-defview-args
+              (str "defview's one argument must be a map-destructuring form "
+                   "or a symbol (≡ {:as sym}); got " (pr-str b))
+              {:argv argv})))))
+
+(defn props-schema-keys
+  "Top-level prop keys of a LITERAL Malli [:map ...] :props schema; nil
+  when the schema is absent or not a literal :map vector (no closed-map
+  enforcement then — an opaque schema cannot be introspected at compile
+  time)."
+  [schema]
+  (when (and (vector? schema) (= :map (first schema)))
+    (let [entries (rest schema)
+          entries (if (map? (first entries)) (rest entries) entries)]
+      (into []
+            (keep #(when (and (vector? %) (keyword? (first %))) (first %)))
+            entries))))
+
+(defn declared-slots
+  "Comparator/manifest slot order: header slots first, then schema-only
+  keys (Q2 pin). :children participates as one slot when declared."
+  [header schema-keys]
+  (let [hs (:slots header)
+        extra (remove (set hs) (or schema-keys []))]
+    (into (vec hs) extra)))

--- a/implementation/freehand/src/re_frame/freehand/compiler/root.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/root.cljc
@@ -1,0 +1,998 @@
+(ns re-frame.freehand.compiler.root
+  "Root identity + mount-surface compiler half (S1c, rf2-vxgfnd.3; the
+  root-identity-and-mount contract).
+
+  What lives here:
+
+    - the ROOT-ID grammar: authored validation (qualified keyword | vector
+      of qualified keyword + scalar disambiguators), the derivation default
+      (the mounted view's registered id, `[view-id disambiguator]` on
+      double-mount), the deterministic root-id SLUG and the
+      `identifierPrefix` default `\"rf2-\" + slug + \"-\"`;
+    - the STATIC TOP-REGION scan over the analyzed root-form AST: the
+      mounted view (exactly one for derivation), the static frame plans
+      (`frame-root` `:id` + `config-fingerprint`), props-shape /
+      static-props extraction;
+    - ROOT DESCRIPTOR v1 assembly (`:rf.root/schema-version 1`) — the
+      compile-time static subset of the Stage-5 Root Manifest; S1 emits
+      descriptors only (manifests land S5);
+    - LAYER-1 duplicate detection (build tier): the per-build root-site
+      index (`:rf.error/duplicate-root-id`) and the frame-plan
+      config-fingerprint index (`:rf.error/frame-payload-conflict`);
+    - the macro bodies for `v/mount` / `v/create-root` / `v/render!` /
+      `v/hydrate-root` (JVM-only — they run at CLJS macro expansion).
+
+  ## Build scope of Layer 1 ([S1-CONFIRM] item 3 — resolved for S1)
+
+  Macro expansion has no entry-point-closure visibility (shadow-cljs
+  assigns modules after analysis), so S1 implements the STRICTER
+  whole-build projection: every root site expanded by one compiler JVM
+  lands in one index, and a duplicate root-id arriving from a DIFFERENT
+  file fails the build. Sites re-expanded from the SAME file replace their
+  entry (watch-mode/hot-reload tolerance — a moved line is not a second
+  site); a genuine same-file duplicate therefore passes Layer 1 and is
+  caught by the Layer-3 live-root registry at runtime, before any render.
+  Entry-closure scoping (which would additionally ADMIT cross-entry reuse)
+  is deferred until the first multi-entry consumer lands, per the
+  contract's own [S1-CONFIRM] note — whole-build cannot admit a duplicate
+  entry-closure would reject, so no consumer written against S1 breaks
+  when the scope narrows.
+
+  Pure analysis fns are host-neutral (resolution is injected via the env,
+  the S1b pattern) so the conformance suites run under both
+  `clojure -M:test` and the node runner; only the macro bodies are
+  JVM-gated."
+  (:require [clojure.string :as str]
+            [re-frame.error :as error]
+            [re-frame.freehand.compiler.analyze :as ana]
+            [re-frame.freehand.compiler.build :as build]
+            [re-frame.freehand.compiler.env :as env]
+            [re-frame.freehand.fingerprint :as fingerprint]
+            #?@(:clj [[re-frame.registrar :as registrar]
+                      [re-frame.freehand.compiler :as compiler]
+                      [re-frame.freehand.compiler.emit-cljs :as emit-cljs]
+                      [re-frame.freehand.compiler.emit-jvm :as emit-jvm]])))
+
+;; ---------------------------------------------------------------------------
+;; Root-id grammar (contract §1)
+;; ---------------------------------------------------------------------------
+
+(defn- fail
+  ([id msg] (fail id msg nil))
+  ([id msg data] (throw (env/compile-error id msg data))))
+
+(defn- qualified-kw? [x]
+  (and (keyword? x) (some? (namespace x))))
+
+(defn scalar-disambiguator?
+  "The disambiguator grammar: keyword, string, or integer (contract §1.2)."
+  [x]
+  (or (keyword? x) (string? x) (integer? x)))
+
+(defn validate-authored-root-id!
+  "Authored `:root-id` shapes (contract §1.1): a qualified keyword
+  (canonical: `:page/shop`) or a vector of a qualified keyword plus scalar
+  disambiguators. Anything else is a compile error — identity opts are
+  literals, so the shape is always statically checkable."
+  [where root-id]
+  (when-not (or (qualified-kw? root-id)
+                (and (vector? root-id)
+                     (<= 2 (count root-id))
+                     (qualified-kw? (first root-id))
+                     (every? scalar-disambiguator? (rest root-id))))
+    (fail :rf.ui.compile/bad-root-id
+          (str where ": :root-id must be a qualified keyword (canonical: "
+               ":page/shop) or a vector of a qualified keyword plus scalar "
+               "disambiguators (e.g. [:shop/product-panel :left]); got "
+               (pr-str root-id))
+          {:root-id root-id}))
+  root-id)
+
+;; The slug is the identity fingerprint that seeds the default React
+;; `identifierPrefix` (§3) and the S5 synthesized locators, so it MUST be
+;; INJECTIVE over the closed valid root-id grammar: distinct valid
+;; root-ids ALWAYS yield distinct slugs, and no two live roots can then
+;; share an effective prefix / locator. The earlier transform (normalise
+;; every disallowed char to `-`, join ns/name with `-`, join vector
+;; components with `--`) was lossy and NOT injective — `:a/b-c` and
+;; `:a-b/c` both flattened to "a-b-c"; `[:x/y "a--b"]` and
+;; `[:x/y "a" "b"]` both to "x-y--a--b".
+;;
+;; Encoding — a decodable, hence injective, canonical form over the
+;; DOM-safe `identifierPrefix` alphabet [A-Za-z0-9_-]:
+;;
+;;   - `_` is the SOLE metacharacter. Every character NOT in [A-Za-z0-9-]
+;;     — INCLUDING `_` itself — is escaped as `_<hex>_`, where <hex> is the
+;;     lowercase UTF-16 code unit. This is a reversible per-char escape, so
+;;     nothing is normalised away; `.`, `*`, whitespace, unicode all round
+;;     trip. The output therefore carries a bare `_` only inside an escape.
+;;   - Structural markers are `_` + an UPPERCASE tag letter — disjoint from
+;;     the lowercase-hex escapes and never emitted by the char escape, so a
+;;     marker can never be mistaken for data (nor data for a marker):
+;;       `_S`  keyword namespace/name separator
+;;       `_V`  vector root-id lead-in
+;;       `_K`  vector element: keyword    `_T` string    `_I` integer
+;;
+;; A keyword root -> `enc-kw`; a vector root -> `_V` + type-tagged, escaped
+;; elements. Every ns/name, element, and type boundary is MARKED rather
+;; than inferred from a data character, so the mapping is losslessly
+;; decodable and thus injective. Keyword roots and vector roots never
+;; collide: a vector slug starts with the literal `_V`, and a keyword slug
+;; starts with either a safe char [A-Za-z0-9-] or `_<lowercase-hex>` — it
+;; can never begin with `_V`.
+
+(defn- code-unit
+  "The UTF-16 code unit at index `i` — host-neutral (a CLJS string is a JS
+  string; a JVM `char` is a 16-bit code unit), so the slug is identical
+  across the JVM and CLJS reference runs (contract determinism)."
+  [s i]
+  #?(:clj  (int (.charAt ^String s i))
+     :cljs (.charCodeAt s i)))
+
+(defn- hex [cc]
+  #?(:clj  (Integer/toHexString (int cc))
+     :cljs (.toString cc 16)))
+
+(defn- safe-code? [cc]
+  (or (<= 48 cc 57)     ; 0-9
+      (<= 65 cc 90)     ; A-Z
+      (<= 97 cc 122)    ; a-z
+      (= cc 45)))       ; -
+
+(defn- enc
+  "Reversibly escape a raw string into the DOM-safe alphabet: a character
+  in [A-Za-z0-9-] passes through; anything else (INCLUDING `_`) becomes
+  `_<lowercase-hex-code-unit>_`. The output therefore contains a bare `_`
+  only inside an escape, so the uppercase structural markers can never be
+  confused with escaped data."
+  [s]
+  (let [n (count s)]
+    (loop [i 0, out ""]
+      (if (< i n)
+        (let [cc (code-unit s i)]
+          (recur (inc i)
+                 (str out (if (safe-code? cc)
+                            (subs s i (inc i))
+                            (str "_" (hex cc) "_")))))
+        out))))
+
+(defn- enc-kw
+  "A keyword -> `enc(namespace) _S enc(name)` when qualified, else
+  `enc(name)`. The `_S` marker fixes the namespace/name boundary, so
+  `:a/b-c` and `:a-b/c` cannot alias, and a qualified keyword can never
+  collide with an unqualified one (only the qualified form carries `_S`)."
+  [k]
+  (if-let [ns* (namespace k)]
+    (str (enc ns*) "_S" (enc (name k)))
+    (enc (name k))))
+
+(defn- enc-elem
+  "A vector element, type-tagged so a keyword, string, and integer
+  disambiguator built from the same characters cannot alias, and so the
+  tag also delimits the element: `_K` keyword, `_T` string, `_I` integer."
+  [x]
+  (cond
+    (keyword? x) (str "_K" (enc-kw x))
+    (integer? x) (str "_I" (enc (str x)))
+    :else        (str "_T" (enc x))))
+
+(defn root-id-slug
+  "The ONE deterministic, INJECTIVE slug (contract §1): distinct valid
+  root-ids ALWAYS produce distinct slugs, so distinct roots can never share
+  an effective `identifierPrefix` (§3) or synthesized locator (S5).
+
+  A keyword root encodes to `enc-kw` (`:page/shop` -> \"page_Sshop\"); a
+  vector root to `_V` + type-tagged, escaped elements (`[:shop/app :left]`
+  -> \"_V_Kshop_Sapp_Kleft\"). Every character outside [A-Za-z0-9-] is
+  reversibly escaped `_<hex>_` rather than normalised, and every ns/name,
+  element, and type boundary is marked — so the mapping is losslessly
+  decodable and thus injective (see the comment above). The slug stays
+  within the DOM-safe alphabet [A-Za-z0-9_-], a valid `identifierPrefix`."
+  [root-id]
+  (if (vector? root-id)
+    (str "_V" (apply str (map enc-elem root-id)))
+    (enc-kw root-id)))
+
+(defn default-identifier-prefix
+  "`\"rf2-\" + root-id-slug + \"-\"` (contract §3) — the `identifierPrefix`
+  default fed to the React root."
+  [root-id]
+  (str "rf2-" (root-id-slug root-id) "-"))
+
+;; ---------------------------------------------------------------------------
+;; Top-region scan (contract §5/§6)
+;; ---------------------------------------------------------------------------
+
+(defn scan-root-ast
+  "Walk an analyzed root-form AST through the top-region wrappers only
+  (element / fragment / frame-root / frame-provider children — the analyzer
+  already guarantees `:frame-root` nodes exist nowhere else) collecting, in
+  document order: `:views` (top-region internal-view nodes) and `:plans`
+  (`{:frame-id :config :config-fingerprint}` per `frame-root`). A
+  `frame-provider` contributes NO plan (its frame is a runtime reference,
+  not statically extractable — root-identity contract §6) but the walk
+  descends THROUGH it, so a `frame-root` nested under a top-region
+  `frame-provider` is still extracted."
+  [ast]
+  (let [acc (volatile! {:views [] :plans []})]
+    (letfn [(walk [n]
+              (case (:op n)
+                :view       (vswap! acc update :views conj n)
+                :frame-root (do (vswap! acc update :plans conj
+                                        {:frame-id (:frame-id n)
+                                         :config   (:config n)
+                                         :config-fingerprint
+                                         (fingerprint/config-fingerprint
+                                          (:frame-id n) (:config n))})
+                                (run! walk (:children n)))
+                (:element :fragment :frame-provider) (run! walk (:children n))
+                nil))]
+      (walk ast))
+    @acc))
+
+(defn check-plan-set!
+  "Reject two plans for ONE frame-id with differing config fingerprints
+  inside one root form (the intra-form arm of the Layer-1 rule; contract
+  §7); dedupe identical `[frame-id fingerprint]` pairs (the ratified
+  idempotent no-op), keeping document order of first sighting."
+  [where plans]
+  (doseq [[fid group] (group-by :frame-id plans)]
+    (let [fps (distinct (map :config-fingerprint group))]
+      (when (< 1 (count fps))
+        (error/throw-error!
+         :rf.error/frame-payload-conflict where
+         (str "one root form carries two static frame plans for frame "
+              (pr-str fid) " with DIFFERING config fingerprints — one "
+              "frame, one plan: frame config belongs in ONE boot/root "
+              "site (align the configs, or drop the duplicate frame-root)")
+         {:recovery :align-frame-plan-config
+          :extra {:frame-id fid :fingerprints (vec fps)}}))))
+  ;; dedupe on the [frame-id fingerprint] identity pair, KEEPING :config
+  ;; (the preflight thunk needs the source forms) and document order
+  (let [seen (volatile! #{})]
+    (filterv (fn [{:keys [frame-id config-fingerprint]}]
+               (let [k [frame-id config-fingerprint]]
+                 (if (contains? @seen k)
+                   false
+                   (do (vswap! seen conj k) true))))
+             plans)))
+
+(defn analyze-root
+  "Analyze a LITERAL root form (`:top-region? true`):
+  -> `{:ast .. :views .. :plans ..}` (plans deduped, conflict-checked,
+  document order). Non-vector root forms are a compile error — the
+  compiler must see the root to keep the AST closed and extract frame
+  plans."
+  [e where form]
+  (when-not (vector? form)
+    (fail :rf.ui.compile/runtime-root-form
+          (str where ": the root form must be a LITERAL vector at the call "
+               "site — the compiler must see the root to keep the AST "
+               "closed and extract frame plans. A runtime-assembled tree "
+               "is not v1 grammar (runtime-chosen components are v/view / "
+               "v/element [WAVE-2]; v/raw covers a runtime React "
+               "element); a control form at root position wraps in a view "
+               "(conservative S1 pin)")
+          {:form form}))
+  (let [ast (ana/analyze (assoc e :top-region? true) form)
+        {:keys [views plans]} (scan-root-ast ast)]
+    {:ast ast :views views :plans (check-plan-set! where plans)}))
+
+;; ---------------------------------------------------------------------------
+;; Identity resolution (contract §1)
+;; ---------------------------------------------------------------------------
+
+(defn validate-disambiguator! [where d]
+  (when-not (scalar-disambiguator? d)
+    (fail :rf.ui.compile/bad-disambiguator
+          (str where ": :disambiguator must be a scalar compile-time "
+               "literal (keyword, string, or integer); got " (pr-str d))
+          {:disambiguator d}))
+  d)
+
+(defn resolve-root-identity
+  "-> `{:root-id .. :provenance :authored|:derived}`. Authored wins;
+  otherwise the root-id derives from the mounted view's registered id
+  (+ `[view-id disambiguator]` when supplied). Derivation requires exactly
+  one top-region internal view — zero (bare DOM / foreign root) or more
+  than one (fragment of two views) is the contract-pinned compile error."
+  [where {:keys [root-id disambiguator]} views]
+  (if (some? root-id)
+    {:root-id (validate-authored-root-id! where root-id)
+     :provenance :authored}
+    (let [n (count views)]
+      (when (not= 1 n)
+        (fail :rf.ui.compile/no-single-mounted-view
+              (str where ": root form has no single mounted view — author "
+                   ":root-id (found " n " top-region internal views; "
+                   "derivation needs exactly one)")
+              {:view-count n :view-ids (mapv :view-id views)}))
+      (let [vid (:view-id (first views))]
+        (if (some? disambiguator)
+          {:root-id [vid (validate-disambiguator! where disambiguator)]
+           :provenance :derived}
+          {:root-id vid :provenance :derived})))))
+
+;; ---------------------------------------------------------------------------
+;; Props extraction (contract §5) + Root Descriptor v1 (contract §2)
+;; ---------------------------------------------------------------------------
+
+(defn- literal-edn? [v]
+  (cond
+    (ana/literal-scalar? v) true
+    (map? v)    (every? (fn [[k v']] (and (literal-edn? k) (literal-edn? v'))) v)
+    (vector? v) (every? literal-edn? v)
+    (set? v)    (every? literal-edn? v)
+    :else false))
+
+(defn props-shape-entry
+  "`:props-shape` / `:static-props` for the mounted view's call-site props
+  map (contract §5): every value a literal EDN datum -> `:literal` +
+  verbatim `:static-props`; any non-literal expression -> `:dynamic`, no
+  static props recorded (no guessing)."
+  [view-node]
+  (let [entries (get-in view-node [:props :entries])]
+    (if (every? (fn [en] (and (nil? (:marker en)) (literal-edn? (:value en))))
+                entries)
+      {:props-shape  :literal
+       :static-props (into {} (map (juxt :k :value)) entries)}
+      {:props-shape :dynamic})))
+
+(defn root-descriptor
+  "Assemble Root Descriptor v1 (`:rf.root/schema-version 1`) — the named,
+  versioned compile-time static SUBSET of the Stage-5 Root Manifest (same
+  key family; the manifest is a strict superset; readers ignore unknown
+  keys; additive keys do not bump the version). `:view-id` /
+  `:props-shape` / `:static-props` are present iff the root form has
+  exactly one top-region mounted view (an authored-id root may legally
+  mount zero or several); `:root-id-provenance` is dev-only and never
+  reaches shipped manifests. Identity keys are omitted when `root-id` is
+  nil (the `render!` descriptor-base — the client completes identity from
+  its Root, fixed at `create-root`).
+
+  This is Root Descriptor v1 (Spec 004C §2): the per-root static facts, baked
+  at expansion into the emitted CLJS and stored on the client live-root
+  registry entry. Every field is a per-root static fact resolvable at the
+  mount site's own expansion — the descriptor carries no whole-build
+  aggregate."
+  [{:keys [root-id provenance views plans ast]}]
+  (let [view (when (= 1 (count views)) (first views))]
+    (cond-> {:rf.root/schema-version 1
+             :frame-plans (mapv #(select-keys % [:frame-id :config-fingerprint])
+                                plans)
+             :template-fingerprint (fingerprint/template-fingerprint ast)}
+      (some? root-id)   (assoc :root-id root-id)
+      (some? provenance) (assoc :root-id-provenance provenance)
+      view (assoc :view-id (:view-id view))
+      view (merge (props-shape-entry view)))))
+
+;; ---------------------------------------------------------------------------
+;; Layer 1 — the build-tier duplicate/conflict indexes (contract §7)
+;; ---------------------------------------------------------------------------
+
+;; The Layer-1 / descriptor aggregates are keyed PER build id in the one
+;; build-scoped authority (`re-frame.freehand.compiler.build`, rf2-df9873) — no
+;; process-global atom to cross-contaminate between the builds one daemon
+;; compiles in parallel. Consumers read the ambient build's aggregate through
+;; these accessors (a pure function of the current build inputs): a
+;; recompiled / edited / renamed / removed source replaces its whole prior
+;; contribution atomically, so a deleted root or plan cannot linger to raise
+;; a FALSE cross-file duplicate/conflict.
+
+(defn build-roots
+  "The ambient build's Layer-1 root-site index: root-id ->
+  {:file :line :provenance}. Cross-NAMESPACE duplicates fail the build;
+  same-namespace re-registration replaces (watch-mode re-expansion tolerance
+  — Layer 3 backstops same-namespace duplicates at runtime)."
+  ([] (build/aggregate build/roots))
+  ([build-state] (build/accepted-aggregate build/roots build-state)))
+
+(defn build-plans
+  "The ambient build's Layer-1 frame-plan index: frame-id ->
+  {:config-fingerprint :file :line}. Two plans for one frame-id with
+  differing fingerprints from different namespaces fail the build
+  (:rf.error/frame-payload-conflict)."
+  ([] (build/aggregate build/plans))
+  ([build-state] (build/accepted-aggregate build/plans build-state)))
+
+(defn build-descriptors
+  "The ambient build's compile-emitted Root Descriptor index: root-id ->
+  descriptor — the build-artefact side of \"S1 emits descriptors\" (S5
+  tooling / Xray read compile output through here; the runtime copy rides the
+  live-root registry, dev-only)."
+  ([] (build/aggregate build/descriptors))
+  ([build-state] (build/accepted-aggregate build/descriptors build-state)))
+
+(defn reset-build-registries!
+  "Hard-clear every build-scoped compiler registry (views, the Layer-1
+  root/plan indexes, the descriptor index, compile-time custom-elements)
+  and the contribution ledger — the clean-build / test-isolation boundary.
+  Delegates to the one build-scoped model; correctness across a watch
+  session comes from per-source replacement on `build/begin-build!`, not
+  from this wipe (rf2-vxgfnd.16 AC6)."
+  []
+  (build/reset-build!)
+  nil)
+
+#?(:clj
+   (defn descriptor-index
+     "The Root Descriptor v1 index projected for READING (the S5 tooling /
+     Xray / ui.test compiler-side read; Spec 004C §2): every stored per-root
+     descriptor. Outside a compiler binding, callers pass the explicit
+     retained Shadow build-state; no global latest build exists. Its CLIENT
+     counterpart is `re-frame.freehand.client/descriptor-index`, which reads the
+     same per-root static descriptors from the live-root registry."
+     ([]
+       ;; Reads must not mix effective open-pass descriptor rows with the
+       ;; accepted set. Compiler diagnostics may use `build-descriptors`;
+       ;; tooling sees one coherent snapshot.
+       (into {} (build/committed-aggregate build/descriptors)))
+     ([build-state]
+      (into {} (build-descriptors build-state)))))
+
+(defn- site-str [{:keys [file line]}]
+  (str (or file "<unknown-file>") (when line (str ":" line))))
+
+(defn register-root-site!
+  "Index one root site's statically resolved root-id (Layer 1), owned by its
+  declaring namespace `ns-sym`. A second site in a DIFFERENT namespace with
+  an equal root-id is the build-tier `:rf.error/duplicate-root-id` — thrown
+  through the canonical builder, with the both-derived didactic fix per the
+  contract. Same-namespace re-registration REPLACES (watch-mode re-expansion
+  tolerance — a moved / renamed / deleted site never conflicts with its own
+  ghost).
+
+  On a real Shadow build PASS (rf2-u53yy.1 S4) the whole-build roots registry is
+  harvested at compile-finish from the disk-cache-durable SYNTHETIC per-namespace
+  analyzer-map descriptor — root sites are CALL SITES with no def to carry
+  var-meta (unlike views, S2), so this macro stamps the site there via
+  `build/stamp-root-plan-site!` and does NOT contribute a per-source slice row (a
+  warm cache-hit source never re-runs it). The cross-namespace duplicate-root-id
+  law then runs at compile-finish over the carrier
+  (`build/harvest-root-plan-registries`, a compile-finish error is still a
+  build-time error). Off that path (plain-JVM / SSR, REPL — no compile-finish
+  analyzer harvest) the per-source slice contribution + this expansion-time
+  cross-namespace check apply; the check-then-write is ONE atomic transition, so
+  parallel compilation cannot miss a duplicate or drop a concurrent write."
+  [where root-id provenance ns-sym coords]
+  (if (build/shadow-build-pass?)
+    (build/stamp-root-plan-site!
+     ns-sym :roots
+     {:root-id root-id :row (assoc coords :provenance provenance)})
+    (when-let [{:keys [conflict]}
+               (build/contribute-checked!
+                build/roots ns-sym root-id (assoc coords :provenance provenance)
+                ;; any OTHER namespace's row for this root-id is the conflict
+                (fn [existing] existing))]
+      (error/throw-error!
+       :rf.error/duplicate-root-id where
+       (str "two root sites in one build resolve to root-id "
+            (pr-str root-id) " — " (site-str conflict) " and "
+            (site-str coords) ". Root-ids are page-unique identity; "
+            (if (= :derived (:provenance conflict) provenance)
+              (str "both ids derived from the same view — add "
+                   ":disambiguator or author :root-id")
+              "author distinct :root-id values"))
+       {:recovery :make-root-ids-unique
+        :extra {:root-id    root-id
+                :provenance [(:provenance conflict) provenance]
+                :sites      [(dissoc conflict :provenance) coords]}})))
+  nil)
+
+(defn register-plan-site!
+  "Index one site's static frame plan (Layer 1), owned by its declaring
+  namespace `ns-sym`. A plan for the same frame-id with a DIFFERING config
+  fingerprint from a different namespace is the build-tier
+  `:rf.error/frame-payload-conflict` (same-namespace re-registration replaces
+  — watch tolerance; matching fingerprints are the ratified idempotent no-op).
+
+  On a real Shadow build PASS (rf2-u53yy.1 S4) the plan site is stamped onto the
+  SYNTHETIC per-namespace analyzer-map descriptor
+  (`build/stamp-root-plan-site!`) rather than the per-source slice, and the
+  cross-namespace frame-payload-conflict law runs at compile-finish over the
+  carrier — the same decoupling S4 gives roots. Off that path (plain-JVM / SSR,
+  REPL) the per-source slice contribution + this expansion-time check apply; the
+  check-then-write is ONE atomic transition."
+  [where {:keys [frame-id config-fingerprint]} ns-sym coords]
+  (if (build/shadow-build-pass?)
+    (build/stamp-root-plan-site!
+     ns-sym :plans
+     {:frame-id frame-id
+      :row {:config-fingerprint config-fingerprint
+            :file (:file coords) :line (:line coords)}})
+    (when-let [{:keys [conflict]}
+               (build/contribute-checked!
+                build/plans ns-sym frame-id
+                {:config-fingerprint config-fingerprint
+                 :file (:file coords) :line (:line coords)}
+                (fn [existing]
+                  (when (and existing
+                             (not= (:config-fingerprint existing) config-fingerprint))
+                    existing)))]
+      (error/throw-error!
+       :rf.error/frame-payload-conflict where
+       (str "two root sites in one build carry static frame plans for "
+            "frame " (pr-str frame-id) " with DIFFERING config "
+            "fingerprints — " (site-str conflict) " and " (site-str coords)
+            ". One frame, one plan: keep the frame's config in ONE "
+            "boot/root site, or align the configs")
+       {:recovery :align-frame-plan-config
+        :extra {:frame-id     frame-id
+                :fingerprints [(:config-fingerprint conflict) config-fingerprint]
+                :sites        [(dissoc conflict :config-fingerprint) coords]}})))
+  nil)
+
+(defn register-descriptor!
+  "Index one root site's compile-emitted Root Descriptor (the build-artefact the
+  S5 tooling / Xray read through `descriptor-index`), keyed by `root-id`, owned by
+  its declaring namespace `ns-sym`.
+
+  On a real Shadow build PASS (rf2-u53yy.1 S5) the descriptor rides the SAME
+  SYNTHETIC per-namespace analyzer-map carrier as roots/plans (S4), under a
+  `:descriptors` sub-key, via `build/stamp-root-plan-site!` — so a warm cache-hit
+  source's descriptor is RESTORED from the disk cache without the macro re-running,
+  and the whole-build descriptor index is harvested from the carrier at
+  compile-finish. It contributes NO per-source slice row on that path. Every
+  descriptor is registered at a mount / hydrate site that ALSO registers a root site
+  under the same `root-id`, so the cross-namespace `:rf.error/duplicate-root-id`
+  law (`register-root-site!` off the Shadow path, `harvest-root-plan-registries` at
+  compile-finish on it) is the descriptor's conflict check too — no separate one is
+  needed. Off the Shadow path (plain-JVM / SSR, REPL — no compile-finish harvest)
+  the per-source slice contribution applies, the read path `descriptor-index` uses."
+  [root-id descriptor ns-sym]
+  (if (build/shadow-build-pass?)
+    (build/stamp-root-plan-site!
+     ns-sym :descriptors {:root-id root-id :row descriptor})
+    (build/contribute! build/descriptors ns-sym root-id descriptor))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Root opts (contract §3)
+;; ---------------------------------------------------------------------------
+
+(def identity-opt-keys #{:root-id :disambiguator :identifier-prefix})
+(def host-opt-keys #{:on-uncaught-error :on-caught-error :on-recoverable-error})
+
+(def mount-opt-keys (into identity-opt-keys host-opt-keys))
+(def create-root-opt-keys (into #{:root-id :identifier-prefix} host-opt-keys))
+(def hydrate-opt-keys host-opt-keys)
+
+(defn parse-root-opts!
+  "Validate a root opts map at compile time: literal map, CLOSED key set,
+  identity opts as compile-time literals (they feed the descriptor and
+  Layer-1 duplicate detection). Host-tier callback values stay opaque
+  runtime expressions. Returns opts."
+  [where opts allowed]
+  (when-not (map? opts)
+    (fail :rf.ui.compile/bad-root-opts
+          (str where ": the root opts map must be a LITERAL map at the "
+               "call site — identity opts (:root-id / :disambiguator / "
+               ":identifier-prefix) are compile-time literals; host "
+               "callbacks may be runtime expressions INSIDE the literal "
+               "map")
+          {:opts opts}))
+  (let [unknown (remove allowed (keys opts))]
+    (when (seq unknown)
+      (fail :rf.ui.compile/bad-root-opts
+            (str where ": unknown root opt" (when (next unknown) "s") " "
+                 (str/join ", " (map pr-str unknown))
+                 " — the opts map is CLOSED; " where " accepts "
+                 (str/join ", " (map pr-str (sort-by str allowed))))
+            {:unknown (vec unknown)})))
+  (when (and (contains? opts :root-id) (contains? opts :disambiguator))
+    (fail :rf.ui.compile/bad-root-opts
+          (str where ": :disambiguator is only meaningful when :root-id "
+               "is absent — it modifies DERIVATION; an authored :root-id "
+               "is already verbatim identity. Keep one")
+          {:root-id (:root-id opts) :disambiguator (:disambiguator opts)}))
+  (when (contains? opts :root-id)
+    (validate-authored-root-id! where (:root-id opts)))
+  (when (contains? opts :disambiguator)
+    (validate-disambiguator! where (:disambiguator opts)))
+  (when (contains? opts :identifier-prefix)
+    (when-not (string? (:identifier-prefix opts))
+      (fail :rf.ui.compile/bad-root-opts
+            (str where ": :identifier-prefix must be a literal string "
+                 "(fed to React's identifierPrefix); got "
+                 (pr-str (:identifier-prefix opts)))
+            {:identifier-prefix (:identifier-prefix opts)})))
+  opts)
+
+;; ---------------------------------------------------------------------------
+;; Macro bodies (JVM only — CLJS macro expansion)
+;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (do
+
+(def ^:private goog-debug (with-meta 'js/goog.DEBUG {:tag 'boolean}))
+
+(defn- dbg-quoted
+  "Emit `x` as quoted data under the goog.DEBUG gate (production carries
+  no descriptors/site coords — I-12)."
+  [x]
+  `(when ~goog-debug (quote ~x)))
+
+(defn- expand-env!
+  "The mount-surface entry points are CLIENT entry points; expanding for
+  the JVM host is a compile error (JVM structural rendering is
+  ui.test/render (S1d) / render-static (S5))."
+  [where menv]
+  (when-not (:ns menv)
+    (fail :rf.ui.compile/client-entry-on-jvm
+          (str where " is a client entry point — there is no DOM on the "
+               "JVM. JVM structural rendering is ui.test/render (S1d) / "
+               "render-static (S5)")
+          {:where where}))
+  (env/make-env {:host :cljs :cljs-env menv :ns-sym (-> menv :ns :name)}))
+
+(defn- source-coords [form cljs?]
+  (let [m (meta form)]
+    (cond-> {:file (if cljs?
+                     (try @(requiring-resolve 'cljs.analyzer/*cljs-file*)
+                          (catch Exception _ *file*))
+                     *file*)}
+      (:line m)   (assoc :line (:line m))
+      (:column m) (assoc :column (:column m)))))
+
+(defn- anchored
+  "Run `thunk`; a compile error escaping it gains the call form's source
+  coordinates (:file/:line/:column) in its ex-data — the S1e file:line
+  anchoring, mirroring the `re-frame.freehand.compiler` expansion wrapper.
+  Existing ex-data wins on collisions; id, message and cause are
+  preserved."
+  [coords thunk]
+  (try
+    (thunk)
+    (catch clojure.lang.ExceptionInfo ex
+      (let [data (ex-data ex)]
+        (throw
+         (if (and (:rf.ui.compile/error data) (nil? (:file data)))
+           (ex-info (ex-message ex) (merge coords data) ex)
+           ex))))))
+
+(defn- print-warnings! [e where]
+  (doseq [w @(:warnings e)]
+    (binding [*out* *err*]
+      (println (str "WARNING re-frame.freehand [" where "] " (:id w) ": " (:msg w))))))
+
+(defn- react-opts-form [prefix opts]
+  `(re-frame.freehand.client/root-options
+    ~prefix
+    ~(:on-uncaught-error opts)
+    ~(:on-caught-error opts)
+    ~(:on-recoverable-error opts)))
+
+(defn- plans-thunk-form
+  "The preflight thunk: evaluates each plan's config EXPRESSIONS exactly
+  when preflight runs (never at S1, where no preflight hook is installed —
+  the S2 frame wiring installs one). nil when the root form carries no
+  plans."
+  [plans]
+  (when (seq plans)
+    `(fn []
+       [~@(map (fn [{:keys [frame-id config-fingerprint config]}]
+                 {:frame-id frame-id
+                  :config-fingerprint config-fingerprint
+                  :config config})
+               plans)])))
+
+(defn mount-form
+  "`(v/mount root-form dom-node opts)` — the one-shot client mount:
+  create-root + frame preflight + render!, idempotent per root."
+  [form menv root-form dom-node opts]
+  (let [coords (source-coords form (some? (:ns menv)))
+        ns-sym (-> menv :ns :name)]
+    (anchored coords
+      (fn []
+        (let [e      (expand-env! 'v/mount menv)
+              opts   (parse-root-opts! 'v/mount opts mount-opt-keys)
+              {:keys [ast views plans]} (analyze-root e 'v/mount root-form)
+              _      (print-warnings! e 'v/mount)
+              {:keys [root-id provenance]} (resolve-root-identity
+                                            'v/mount opts views)
+              prefix (or (:identifier-prefix opts)
+                         (default-identifier-prefix root-id))
+              _      (register-root-site! 'v/mount root-id provenance
+                                          ns-sym coords)
+              _      (doseq [p plans]
+                       (register-plan-site! 'v/mount p ns-sym coords))
+              desc   (root-descriptor {:root-id root-id :provenance provenance
+                                       :views views :plans plans :ast ast})
+              _      (register-descriptor! root-id desc ns-sym)
+              body   (emit-cljs/emit-inline ast 'rf-ui-root)]
+          `(re-frame.freehand.client/mount*
+            {:root-id ~root-id
+             :provenance ~provenance
+             :identifier-prefix ~prefix
+             :site ~(dbg-quoted coords)
+             :descriptor ~(dbg-quoted desc)}
+            ~dom-node
+            (fn [] ~body)
+            ~(react-opts-form prefix opts)
+            ~(plans-thunk-form plans)))))))
+
+(defn create-root-form
+  "`(v/create-root dom-node opts)` — identity is fixed HERE for the
+  Root's lifetime, and there is no root form to derive from, so an
+  authored `:root-id` is REQUIRED (the derivation default belongs to the
+  root-form-bearing entry points; `v/mount` is the one-liner path)."
+  [form menv dom-node opts]
+  (let [coords (source-coords form (some? (:ns menv)))
+        ns-sym (-> menv :ns :name)]
+    (anchored coords
+      (fn []
+        (expand-env! 'v/create-root menv)
+        (when (and (map? opts) (contains? opts :disambiguator))
+          (fail :rf.ui.compile/bad-root-opts
+                (str "v/create-root: :disambiguator modifies DERIVATION and "
+                     "create-root has no root form to derive from — author "
+                     ":root-id")
+                {:disambiguator (:disambiguator opts)}))
+        (let [opts    (parse-root-opts! 'v/create-root opts create-root-opt-keys)
+              root-id (:root-id opts)]
+          (when (nil? root-id)
+            (fail :rf.ui.compile/missing-root-id
+                  (str "v/create-root fixes root identity WITHOUT a root "
+                       "form — there is no mounted view to derive from; "
+                       "author :root-id (or use v/mount, the "
+                       "derivation-default path)")
+                  nil))
+          (let [prefix (or (:identifier-prefix opts)
+                           (default-identifier-prefix root-id))]
+            (register-root-site! 'v/create-root root-id :authored ns-sym coords)
+            `(re-frame.freehand.client/create-root*
+              {:root-id ~root-id
+               :provenance :authored
+               :identifier-prefix ~prefix
+               :site ~(dbg-quoted coords)}
+              ~dom-node
+              ~(react-opts-form prefix opts))))))))
+
+(defn render-form
+  "`(v/render! root root-form)` — render/re-render the literal root form
+  into a Root. Identity was fixed at `create-root` (authored), so no
+  identity resolution happens here; the descriptor-base is completed with
+  the Root's identity at runtime (dev)."
+  [form menv root root-form]
+  (let [coords (source-coords form (some? (:ns menv)))
+        ns-sym (-> menv :ns :name)]
+    (anchored coords
+      (fn []
+        (let [e      (expand-env! 'v/render! menv)
+              {:keys [ast views plans]} (analyze-root e 'v/render! root-form)
+              _      (print-warnings! e 'v/render!)
+              _      (doseq [p plans]
+                       (register-plan-site! 'v/render! p ns-sym coords))
+              desc   (root-descriptor {:views views :plans plans :ast ast})
+              body   (emit-cljs/emit-inline ast 'rf-ui-root)]
+          `(re-frame.freehand.client/render!*
+            ~root
+            (fn [] ~body)
+            ~(plans-thunk-form plans)
+            ~(dbg-quoted desc)))))))
+
+(defn hydrate-root-form
+  "`(v/hydrate-root dom-node root-form opts)` — hydrating mounts take
+  identity FROM the manifest (contract §3/§4): identity opts client-side
+  are a compile error; opts are host-behaviour tier only. Layer 1 indexes
+  the site under its DERIVED root-id when derivable (the manifest carries
+  the same id in the aligned case); the S1 runtime fails loud — manifests
+  land S5."
+  [form menv dom-node root-form opts]
+  (let [coords (source-coords form (some? (:ns menv)))
+        ns-sym (-> menv :ns :name)]
+    (anchored coords
+      (fn []
+        (let [e (expand-env! 'v/hydrate-root menv)]
+          (when-let [bad (seq (filter identity-opt-keys (keys opts)))]
+            (fail :rf.ui.compile/identity-opts-at-hydrate
+                  (str "v/hydrate-root: identity opt"
+                       (when (next bad) "s") " " (str/join ", " (map pr-str bad))
+                       " supplied client-side — hydrating mounts read root-id "
+                       "and identifier-prefix FROM the server-emitted manifest "
+                       "(the client must use the server's prefix or use-id "
+                       "hydration breaks). Host-behaviour opts only")
+                  {:conflicting-keys (vec bad)}))
+          (let [opts (parse-root-opts! 'v/hydrate-root opts hydrate-opt-keys)
+                {:keys [ast views plans]} (analyze-root
+                                           e 'v/hydrate-root root-form)
+                _    (print-warnings! e 'v/hydrate-root)]
+            (when (= 1 (count views))
+              (let [derived (:view-id (first views))]
+                (register-root-site! 'v/hydrate-root derived :derived
+                                     ns-sym coords)
+                (register-descriptor!
+                 derived
+                 (root-descriptor {:root-id derived :provenance :derived
+                                   :views views :plans plans :ast ast})
+                 ns-sym)))
+            (doseq [p plans]
+              (register-plan-site! 'v/hydrate-root p ns-sym coords))
+            (let [body (emit-cljs/emit-inline ast 'rf-ui-root)]
+              `(re-frame.freehand.client/hydrate-root*
+                ~dom-node
+                (fn [] ~body)
+                ~(plans-thunk-form plans)
+                ~(react-opts-form nil opts)))))))))
+
+(defn registered-view-static-facts
+  "The render-static `{:caps :deps}` facts a compiled view carries on its
+  REGISTERED manifest (`re-frame.freehand.tree/register-view!` → the `:view` registrar
+  entry) — the cross-build-context resolution seam (rf2-uv7n6 hole 2). A view
+  compiled in ANOTHER build (AOT / precompiled JAR) is absent from THIS build's
+  `view-static` index, but its registration runs when its namespace loads, so its
+  manifest (carrying `:static-facts`) is resolvable here. nil when the view is
+  unregistered or its manifest predates static-facts — a genuinely UNPROVEN
+  dependency the caller must fail loud on rather than treat as static-safe."
+  [view-id]
+  (get-in (registrar/lookup :view view-id) [:rf.ui/manifest :static-facts]))
+
+(defn- static-capability-offender
+  "The render-static transitive static-capability proof (Spec 004C §3, EP-0034
+  §2 no-silent-elision): given the ROOT form's own `{:caps :deps}` facts and the
+  ambient build's per-view `view-static` index, return
+
+    - `{:view-id .. :caps ..}`     the FIRST server-reachable view (or the root
+                                   form itself, `:rf.root/root-form`) carrying a
+                                   runtime-requiring capability;
+    - `{:view-id .. :unproven? true}`  the first referenced view whose facts are
+                                   genuinely UNOBTAINABLE (absent from BOTH the
+                                   ambient index and the registered manifest);
+    - nil                          the whole server-reachable closure is proven
+                                   static-safe.
+
+  Cycle-safe: the closure follows direct compiled-view dependencies breadth-first
+  over a `seen` set, so a self-recursive or mutually-recursive view terminates.
+  Each dependency's facts resolve from the ambient index first, then from its
+  registered manifest (a cross-build/AOT view). Unknown facts are NOT proof of
+  static safety (rf2-uv7n6 hole 2): a dependency resolvable from NEITHER source is
+  reported UNPROVEN, never silently skipped."
+  [own-facts index]
+  (if (seq (:caps own-facts))
+    {:view-id :rf.root/root-form :caps (:caps own-facts)}
+    (loop [queue (vec (:deps own-facts)), seen #{}]
+      (when (seq queue)
+        (let [vid   (peek queue)
+              queue (pop queue)]
+          (if (contains? seen vid)
+            (recur queue seen)
+            (if-let [{:keys [caps deps]} (or (get index vid)
+                                             (registered-view-static-facts vid))]
+              (if (seq caps)
+                {:view-id vid :caps caps}
+                (recur (into queue deps) (conj seen vid)))
+              {:view-id vid :unproven? true})))))))
+
+(defn render-static-form
+  "`(v/render-static root-form)` — the pure `:server`-phase static-HTML render
+  (Spec 004C §3; Spec 011 §Phase flip). JVM-ONLY, the counterpart of the client
+  mount verbs: it compiles the LITERAL root form to the versioned JVM structural
+  tree and folds it to an INERT HTML string through `re-frame.ssr/emit-ui-tree`
+  (late-resolved — see INDEPENDENCE) — NO manifest, NO hydration payload, NO phase
+  flip (a `client-only` site renders its capability-free fallback and stops there;
+  there is no fallback pass to flip away from). It is the static-page path, not the
+  SSR-then-hydrate path.
+
+  Four invariants, all reusing the mount-surface machinery:
+
+    - LITERAL ROOT FORM — `analyze-root` rejects a runtime-assembled vector with
+      the SAME `:rf.ui.compile/runtime-root-form` compile error mount / render! /
+      hydrate-root / ui.test-render raise (a macro sees the literal form; a fn
+      cannot). This is the kind-label delta a fn could not honour.
+    - NO SILENT ELISION (Spec 004C §3, EP-0034 §2) — a runtime-requiring
+      capability (subs, committed handlers, effects, refs, context, foreign / lazy
+      heads) anywhere in the root's SERVER-REACHABLE view closure is a loud
+      `:rf.ui.compile/static-root-requires-runtime` build error with source
+      coordinates, never a capability dropped from the static output. The proof is
+      transitive: `compiler/view-static-facts` projects each compiled view's own
+      server-reachable capabilities + direct-view dependencies into the
+      `view-static` build index, and `static-capability-offender` closes over it
+      cycle-safe. `use-id` is exempt (an inert deterministic id is static-safe);
+      `v/client-only` stays legal (only its capability-free fallback is
+      server-reachable — a static root never flips).
+    - IDENTITY PARTICIPATION (§7) — with no opts the root-id derives from the
+      single mounted view, so `resolve-root-identity` enforces exactly one view
+      (`:rf.ui.compile/no-single-mounted-view` otherwise). The derived identity is
+      RETAINED and registered into the Layer-1 build-tier duplicate-root-id index
+      via `register-root-site!`, exactly like mount / render! / hydrate-root — a
+      second site resolving to the same root-id is `:rf.error/duplicate-root-id`.
+      Layer-2 duplicate detection (server render time, S5) is the SSR host's
+      per-response registry, not the macro's.
+    - INDEPENDENCE — the macro emits a call to the ui-side late-resolution seam
+      `re-frame.freehand.tree/emit-static-html` (NOT a bare `re-frame.ssr/emit-ui-tree`
+      reference), so `re-frame.freehand` never statically depends on `re-frame.ssr` (Spec
+      011 §wall — no `ui → ssr` static require) AND the caller's namespace carries
+      no compile-time `re-frame.ssr` reference: a documented render-static call in
+      a namespace that requires only `re-frame.freehand` compiles and renders (the seam
+      loads the emitter at render time) instead of failing with a raw
+      `ClassNotFoundException`. A missing `day8/re-frame2-ssr` artefact is the
+      ruled, typed `:rf.error/ssr-artefact-missing`, never a raw host exception.
+
+  Expanding in a CLJS build is a compile error (`:rf.ui.compile/ui-render-static-jvm-only`)
+  — CLJS has no structural trees (the client emitter targets React directly), and
+  a CLJS expansion would emit the JVM tree + SSR serialiser into a browser bundle."
+  [form menv root-form]
+  ;; JVM-only. A CLJS expansion would (a) render statically in a browser — wrong —
+  ;; and (b) pull the JVM tree + SSR emitter into the CLJS bundle (a ui→ssr edge).
+  ;; Reject before touching the compiler, mirroring ui.test/render.
+  (when (some? (:ns menv))
+    (fail :rf.ui.compile/ui-render-static-jvm-only
+          (str "v/render-static is the pure :server static-HTML render — it "
+               "runs on the JVM/server. CLJS builds have no structural trees "
+               "(the client emitter targets React directly); author render-static "
+               "in a .clj / .cljc-on-JVM server render namespace, and mount in the "
+               "browser with v/mount / v/hydrate-root")
+          nil))
+  (let [coords (source-coords form false)
+        ns-sym (ns-name *ns*)]
+    (anchored coords
+      (fn []
+        (let [e (-> (env/make-env {:host :clj :ns-sym ns-sym})
+                    (env/with-locals (keys menv)))
+              {:keys [ast views]} (analyze-root e 'v/render-static root-form)
+              ;; Identity participation (§7): no opts ⇒ derive from the single
+              ;; mounted view; reuse the exact one-view invariant + its frozen
+              ;; compile id.
+              {:keys [root-id provenance]} (resolve-root-identity
+                                            'v/render-static {} views)]
+          (print-warnings! e 'v/render-static)
+          ;; No-silent-elision proof (Spec 004C §3, EP-0034 §2): a pure :server
+          ;; static render cannot honour a live-runtime capability, so any
+          ;; runtime-requiring capability in the root's server-reachable view
+          ;; closure (subs, committed handlers, effects, refs, context, foreign /
+          ;; lazy heads) is a loud BUILD error with source coordinates — never a
+          ;; silently dropped capability. `v/client-only` stays legal (only its
+          ;; capability-free fallback is server-reachable); `use-id` is exempt.
+          (when-let [{:keys [view-id caps unproven?]}
+                     (static-capability-offender
+                      (compiler/view-static-facts ast @(:sites e))
+                      (compiler/build-view-static))]
+            (if unproven?
+              ;; A referenced view whose render-static facts are UNOBTAINABLE
+              ;; (absent from both the ambient index and the registered manifest)
+              ;; is UNPROVEN — a loud build error, never a silently-inert render
+              ;; that could drop an interactive dependency's handler (hole 2).
+              (fail :rf.ui.compile/static-root-unproven-dependency
+                    (str "v/render-static: the static root depends on view "
+                         (pr-str view-id) " whose render-static facts are "
+                         "UNPROVEN — they are absent from this build's view-static "
+                         "index AND from the view's registered manifest (an "
+                         "AOT/precompiled view compiled before static-facts, or a "
+                         "stale registration). Unknown facts are not proof of "
+                         "static safety, so render-static fails loud rather than "
+                         "shipping a possibly-inert render. Recompile "
+                         (pr-str view-id) " against a current re-frame.freehand, or "
+                         "mount this tree in the browser with v/mount / "
+                         "v/hydrate-root")
+                    {:root-id root-id :unproven-view view-id})
+              (fail :rf.ui.compile/static-root-requires-runtime
+                    (str "v/render-static: the static root's server-reachable view "
+                         "closure requires runtime capability "
+                         (str/join ", " (map name (sort caps)))
+                         (if (= :rf.root/root-form view-id)
+                           " in the root form itself"
+                           (str " (via view " (pr-str view-id) ")"))
+                         " — render-static is the pure :server static-HTML path (no "
+                         "subs, handlers, effects, refs, context, or foreign/lazy "
+                         "heads; no manifest, no hydration, no phase flip). Mount "
+                         "this tree in the browser with v/mount / v/hydrate-root, "
+                         "or move the live subtree behind a v/client-only with a "
+                         "capability-free fallback")
+                    {:root-id root-id :offending-view view-id
+                     :capabilities (vec (sort caps))})))
+          ;; Layer-1 identity registration (§7): the static root participates in
+          ;; the build-tier duplicate-root-id index exactly like mount / render! /
+          ;; hydrate-root — the derived identity is retained, not discarded.
+          (register-root-site! 'v/render-static root-id provenance ns-sym coords)
+          ;; Emit a call to the ui-side late-resolution seam (NOT a bare
+          ;; `re-frame.ssr/emit-ui-tree` reference) so the caller's namespace
+          ;; carries no compile-time `re-frame.ssr` reference — a missing SSR
+          ;; artefact is the ruled typed `:rf.error/ssr-artefact-missing`, not a
+          ;; raw ClassNotFoundException. `re-frame.freehand` still takes no static
+          ;; require on `re-frame.ssr` (the resolve is late, at render time).
+          `(~'re-frame.freehand.tree/emit-static-html
+            (~'re-frame.freehand.tree/render-root-tree
+             (fn [] ~(emit-jvm/emit-node ast)))))))))
+
+))

--- a/implementation/freehand/src/re_frame/freehand/eq.cljc
+++ b/implementation/freehand/src/re_frame/freehand/eq.cljc
@@ -1,0 +1,62 @@
+(ns re-frame.freehand.eq
+  "`rf=` — the ruled per-slot equality of the compiled-view substrate.
+
+  RULED (Mike, 2026-07-12, spec-004 rewrite §`v/defview` Memo-by-default):
+  per slot, `rf=` is
+
+      Object.is(a, b)  OR  (= a b)
+
+  Consequences (all pinned by `re-frame.freehand.eq-cljs-test`):
+
+  - CLJS data (anything with `IEquiv`, incl. records and js/Date) compares
+    by VALUE — fresh-but-equal literals do not repaint.
+  - Host/foreign values (plain JS objects, arrays, functions, React
+    elements) fall through to identity — in-place-mutated host objects do
+    not repaint (mutable foreign values belong at an explicit boundary).
+  - `##NaN` props are repaint-stable via the `Object.is` branch.
+  - `-0`/`+0` compare EQUAL via the `=` branch (deliberate, harmless
+    divergence from raw `Object.is`).
+  - JS `undefined` and `null` both read as nil (an absent slot and a
+    present-nil slot compare equal — Q2 consequence).
+
+  The identity check doubles as the generated comparator's fast path.
+  Teach as: \"React.memo, except CLJS data compares by value\".
+
+  On the JVM (where trees are plain Clojure data and no memoization
+  exists) the same truth table holds: `identical?` stands in for
+  `Object.is`, `=` gives the value branch, and a numeric branch supplies
+  what JS number semantics give the client for free — NaN self-equality
+  and `(rf= 1 1.0)`/`(rf= -0.0 0.0)` being true (JS has one number
+  type). One predicate, one truth table, both hosts.")
+
+(defn rf=
+  "The ruled per-slot equality: `Object.is(a,b) OR (= a b)`."
+  [a b]
+  #?(:cljs (or ^boolean (js/Object.is a b)
+               (= a b))
+     :clj  (or (identical? a b)
+               (= a b)
+               (and (number? a) (number? b)
+                    (or (and (Double/isNaN (double a)) (Double/isNaN (double b)))
+                        (== (double a) (double b)))))))
+
+(defn deps-rf=?
+  "The effect-dependency equality doctrine: two authored deps vectors are equal
+  iff they have equal arity and every authored slot is `rf=` its counterpart —
+  the SAME per-slot `rf=` the memo/prop comparator uses, walked element-wise.
+
+  Element-wise is load-bearing: `rf=` on the WHOLE vector would fall to `(= a b)`
+  (the vectors are freshly allocated, so the `Object.is` fast path misses), and
+  `(= [##NaN] [##NaN])` is FALSE — CLJS `=` is not NaN-reflexive — so a stable
+  `##NaN` slot would spuriously re-run the effect every render. The per-slot walk
+  routes each `##NaN` slot through `rf=`'s `Object.is` branch (NaN-reflexive) and
+  each rebuilt-but-equal CLJS collection slot through its `=` branch, so both
+  compare equal and the effect does not re-run."
+  [a b]
+  (and (== (count a) (count b))
+       (loop [i 0]
+         (if (< i (count a))
+           (if (rf= (nth a i) (nth b i))
+             (recur (inc i))
+             false)
+           true))))

--- a/implementation/freehand/src/re_frame/freehand/fingerprint.cljc
+++ b/implementation/freehand/src/re_frame/freehand/fingerprint.cljc
@@ -1,0 +1,294 @@
+(ns re-frame.freehand.fingerprint
+  "The NAMED HOME of the compiled-view identity digests (S0 coverage-pass
+  addendum, rf2-vxgfnd.2): `template-fingerprint` and `hook-signature-hash`.
+  `render-fingerprint` and normalization `N` are NOT
+  here — they stay owned by jvm-tree-and-conversion-contract.md / Spec 011.
+
+  ## The algorithm (shared by all)
+
+      digest  = FNV-1a 64-bit over the UTF-8 bytes of the canonical-EDN
+                serialisation of the input form
+      output  = <prefix> + 16 lowercase hex chars (zero-padded)
+
+  FNV-1a 64 aligns with the repo's checked-in render-fingerprint choice
+  (jvm-tree contract §Normalization: \"FNV-1a is today's checked-in
+  choice\"). Each digest is version-prefixed so the algorithm can rotate
+  without ambiguity:
+
+      template-fingerprint  \"tf1-\"  input: the view's template AST
+                            fingerprint projection (source-location
+                            metadata stripped; forms as read)
+      hook-signature-hash   \"hs1-\"  input (shape 2, S3):
+                            [2 {:locals [...] :effects [...] :react [...]}]
+                            — the ordered host-hook plan. `sub` sites are
+                            deliberately EXCLUDED: dev's fixed full hook
+                            skeleton makes adding your first sub a
+                            same-signature edit (Spec 004 rewrite §Hot
+                            reload). `:react` carries the frozen
+                            re-frame.freehand.react interop hooks as ordered
+                            {:kind :order} entries (kind + source-order
+                            position among ALL let-body host hooks, so a
+                            local↔react reorder — both live in the top-region
+                            let, interleaved in React hook order — changes the
+                            signature). Adding, removing, or reordering any
+                            wrapper changes the plan; editing a deps vector or
+                            setup body does NOT. The S1→S3 shape bump (integer
+                            1→2, prefix \"hs1-\" unchanged — the prefix versions
+                            the ALGORITHM, the integer the INPUT shape)
+                            re-serialises every hook signature: a deliberate
+                            one-time global remount wave when S3 lands (pre-
+                            alpha, no shim).
+      config-fingerprint    \"cf1-\"  input: [frame-id config-source-map]
+                            — a root form's static frame plan (S1c,
+                            root-identity contract §6): the frame-root's
+                            literal :id plus its config SOURCE FORMS
+                            (:initial-events etc. as written, NOT their
+                            runtime values — config expressions evaluate
+                            at preflight; the fingerprint is what
+                            build-time plan-conflict detection compares)
+
+  ## Canonical serialization
+
+  `canonical-string` is a TYPE-PRESERVING, INJECTIVE canonical string (not
+  EDN). Every node is one self-delimiting token — a type-tag char, the
+  char length of its body, a `:`, then the body — so a set / vector / list /
+  map / record carry DISTINCT tags and a set never collides with a vector (or
+  map) of the same flattened elements. A RECORD additionally carries its
+  fully-qualified type name inside its token, so it collides neither with the
+  plain map of the same entries nor with a record of a different type
+  (rf2-59car). Sets, map keys, and record entries are order-normalized;
+  vectors and lists stay order-sensitive; scalars carry their host-identical
+  `pr-str`. Two `=`-equal plans (up to map-key / set authoring order) always
+  digest identically (no spurious plan-conflict); a genuine config change —
+  including a set↔vector↔list type flip, or a record type swap — always
+  digests differently. Cross-host equality of the hex output is pinned by
+  `re-frame.freehand.fingerprint-cljs-test`."
+  (:require [clojure.string :as str]))
+
+;; ---------------------------------------------------------------------------
+;; Canonical serialization
+;; ---------------------------------------------------------------------------
+;;
+;; The digest input is a TYPE-PRESERVING, INJECTIVE canonical string — not
+;; EDN. Every node is emitted as one self-delimiting token
+;;
+;;     <type-tag><char-length of body>":"<body>
+;;
+;; — a single type-tag char, the CHARACTER count of the body, a ":"
+;; separator, then the body. The length turns each token into a netstring:
+;; a parent collection's body is just its child tokens concatenated, and no
+;; two distinct child sequences can share an encoding (the concatenation
+;; parses back unambiguously).
+;;
+;; The TYPE TAG is what makes the encoding type-preserving. A set (`s`),
+;; vector (`v`), list/seq (`l`), map (`m`), and record (`r`) carry DISTINCT
+;; tags, so a set never collides with a vector — or a map — of the same
+;; flattened elements. That was the pre-#5745 hazard: a set was flattened to a
+;; bare vector of its elements' `pr-str` STRINGS, so the distinct configs
+;; `#{:a}` and `[":a"]` shared one canonical form (`[":a"]`). That is a
+;; GUARANTEED pre-hash collision — a real config change reads as an idempotent
+;; no-op — closed here because `#{:a}` -> "s.." and `[":a"]` -> "v.." can never
+;; coincide, and the inner keyword `:a` -> "t..:a" and string `":a"` ->
+;; "t..\":a\"" differ too.
+;;
+;; RECORDS ARE MATCHED FIRST (rf2-59car), because a record also satisfies
+;; `map?`. A leading `map?` branch discarded the record's TYPE, so `(->RecA 1)`,
+;; `(->RecB 1)`, and `{:x 1}` — three pairwise-UNEQUAL values — all encoded as
+;; the plain map `{:x 1}` and digested identically. That is the same class of
+;; GUARANTEED pre-hash collision as the pre-#5745 set flattening, and it lands
+;; on the same failure mode: `config-fingerprint` plan-conflict
+;; detection reads a false digest MATCH as "nothing changed", so a genuine plan
+;; conflict is silently treated as an idempotent no-op. The `r` token therefore
+;; carries the record's fully-qualified type name as its own leading `t` token,
+;; ahead of the entries, and the distinct `r` tag keeps a record clear of the
+;; plain map of the same entries.
+;;
+;; ORDER handling: sets sort their child tokens (order-INSENSITIVE), map and
+;; record entries sort by their canonical KEY token (authoring-order-
+;; insensitive, #5745), and vectors/lists preserve producer order
+;; (order-SENSITIVE). Records share the map's entry canonicalization exactly,
+;; which matters because a record's EXTENSION entries (its `__extmap`) preserve
+;; INSERTION order in the small-map representation: `(assoc (->RecA 1) :b 2 :c 3)`
+;; and `(assoc (->RecA 1) :c 3 :b 2)` are `=`, and must digest identically.
+;; Emitting entries as a length-delimited token stream — rather than reducing
+;; them into an intermediate `sorted-map-by` — means two DISTINCT keys that
+;; share a comparator rank can never overwrite one another; both entries survive
+;; into the digest.
+;;
+;; SCALARS (`t`) carry their `pr-str`, which is host-identical for the
+;; supported terminal types and already type-distinct: a keyword `:a`, the
+;; string `":a"`, and the symbol `a` print differently, so they never collide.
+
+(def ^:private canonical-version
+  "Version marker prefixing every canonical string. It is hashed with the
+  body, so a fingerprint computed under an older encoding is detectably
+  distinct — never silently reinterpreted — when the encoding is revised.
+  `cfp2` is the type-preserving, length-delimited writer (rf2-vxgfnd.78);
+  the unversioned `pr-str`-flattening form (pre-#5745 / #5745) was v1."
+  "cfp2:")
+
+(declare -write)
+
+(defn- token
+  "A self-delimiting canonical token: the `tag` char, the CHARACTER length
+  of `body`, a `:` separator, then `body`. The length makes the token a
+  netstring, so concatenated child tokens parse back unambiguously and no
+  two distinct child sequences share an encoding."
+  [tag body]
+  (str tag (count body) ":" body))
+
+(defn- canonical-entries
+  "The entry-token stream of an associative value: each entry's key and value
+  tokens, with the entries SORTED by their canonical KEY token, concatenated.
+  Shared by the map and the record branch of `-write`, so a record's entries —
+  its declared fields AND its insertion-ordered `__extmap` extensions —
+  canonicalize exactly like a plain map's. A token stream (not a sorted-map)
+  means two distinct keys that share a comparator rank can never overwrite one
+  another."
+  [x]
+  (->> x
+       (map (fn [[k v]] [(-write k) (-write v)]))
+       (sort-by first)
+       (mapcat (fn [[k v]] [k v]))
+       (apply str)))
+
+(defn- record-type-name
+  "The fully-qualified `my.ns/MyRec` name of a record's type, rendered
+  IDENTICALLY on both hosts so tagging a record cannot break the cross-host
+  equality of the hex output.
+
+  On CLJS this is `(pr-str (type x))`: `defrecord` sets the type's
+  `cljs$lang$ctorPrWriter` to write that name as a COMPILE-TIME literal, so it
+  is stable, unique per record type, and survives `:advanced` renaming.
+  `cljs.core/type->str` would NOT do — it reads `cljs$lang$ctorStr`, which
+  `deftype` sets but `defrecord` does not, so it silently degrades to the
+  constructor's JS source text — and neither would `(.-name (type x))`, which
+  `:advanced` munges.
+
+  On the JVM the record's class name carries the same information in host form
+  (the MUNGED namespace, a `.`, then the verbatim record name), so demunging
+  the namespace segment and rejoining it with `/` lands on the very same
+  string."
+  [x]
+  #?(:clj  (let [^String n (.getName (class x))
+                 i         (.lastIndexOf n ".")]
+             (str (clojure.lang.Compiler/demunge (subs n 0 i))
+                  "/"
+                  (subs n (inc i))))
+     :cljs (pr-str (type x))))
+
+(defn- -write
+  "Emit the injective, type-preserving canonical token for `x`. Collections
+  carry a distinct type tag (`m`/`s`/`v`/`l`/`r`) so a map, set, vector, list,
+  and record never collide; sets, map keys, and record entries are
+  order-normalized while vectors and lists keep producer order; scalars (`t`)
+  carry their host-identical, type-distinct `pr-str`."
+  [x]
+  (cond
+    ;; Record — matched BEFORE `map?`, which a record ALSO satisfies
+    ;; (rf2-59car). The body is the record's fully-qualified type name as a
+    ;; leading `t` token, then its entries canonicalized exactly as a map's, so
+    ;; two record types with the same entries — and a record vs the plain map of
+    ;; those entries — always digest differently.
+    (record? x) (token "r" (str (token "t" (record-type-name x))
+                                (canonical-entries x)))
+    ;; Map — sort ENTRIES by their canonical KEY token, then emit key and
+    ;; value tokens in that order. A token stream (not a sorted-map) means
+    ;; two distinct keys can never overwrite one another.
+    (map? x)    (token "m" (canonical-entries x))
+    ;; Set — order-INSENSITIVE: sort the child tokens. The `s` tag keeps a
+    ;; set distinct from a vector/list of the same elements.
+    (set? x)    (token "s" (apply str (sort (map -write x))))
+    ;; Vector — order-SENSITIVE: preserve producer order.
+    (vector? x) (token "v" (apply str (map -write x)))
+    ;; List / seq — order-SENSITIVE; the `l` tag keeps it distinct from a
+    ;; vector of the same elements.
+    (seq? x)    (token "l" (apply str (map -write x)))
+    ;; Scalar — `pr-str` is host-identical and type-distinct for the
+    ;; supported terminals (keyword vs string vs symbol vs number vs nil).
+    :else       (token "t" (pr-str x))))
+
+(defn canonical-string
+  "One deterministic, type-preserving canonical string per value, identical
+  on both hosts (see the section comment above for the token grammar).
+  Equal values — up to map-key / set / record-extension authoring order —
+  produce the same string; distinct values, including a set vs a vector vs a
+  list of the same elements, and a record vs another record type vs the plain
+  map of the same entries, produce different strings."
+  [x]
+  (str canonical-version (-write x)))
+
+;; ---------------------------------------------------------------------------
+;; FNV-1a 64
+;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (defn- fnv1a-64 ^long [^bytes bs]
+     (loop [h (unchecked-long -3750763034362895579)  ; 0xcbf29ce484222325
+            i 0]
+       (if (< i (alength bs))
+         (recur (unchecked-multiply
+                 (bit-xor h (bit-and 255 (long (aget bs i))))
+                 (unchecked-long 1099511628211))
+                (inc i))
+         h)))
+   :cljs
+   (defn- fnv1a-64 [bs]
+     (let [prime (js/BigInt "1099511628211")]
+       (loop [h (js/BigInt "14695981039346656037")
+              i 0]
+         (if (< i (.-length bs))
+           ;; cljs.core/bit-xor and * inline to the raw JS operators in
+           ;; call position, which are BigInt-correct.
+           (recur (js/BigInt.asUintN
+                   64
+                   (* (bit-xor h (js/BigInt (aget bs i))) prime))
+                  (inc i))
+           h)))))
+
+(defn- hex64 [h]
+  #?(:clj  (let [s (Long/toHexString (long h))]
+             (str (subs "0000000000000000" (count s)) s))
+     :cljs (let [s (.toString h 16)]
+             (str (subs "0000000000000000" (count s)) s))))
+
+(defn- utf8-bytes [^String s]
+  #?(:clj  (.getBytes s "UTF-8")
+     :cljs (.encode (js/TextEncoder.) s)))
+
+(defn digest
+  "prefix + FNV-1a-64 hex of the canonical string of `form`."
+  [prefix form]
+  (str prefix (hex64 (fnv1a-64 (utf8-bytes (canonical-string form))))))
+
+;; ---------------------------------------------------------------------------
+;; The three named digests
+;; ---------------------------------------------------------------------------
+
+(defn template-fingerprint
+  "\"tf1-\" digest of the template-AST fingerprint projection."
+  [ast-projection]
+  (digest "tf1-" ast-projection))
+
+(defn hook-signature-hash
+  "\"hs1-\" digest of the ordered host-hook plan
+  `{:locals [...] :effects [...] :react [...]}` (shape-version 2, S3; `sub`
+  sites excluded by design). `:react` entries are `{:kind :order}` maps — the
+  wrapper kind plus its source-order position among ALL top-region let-body
+  host hooks (locals included), so a local↔react reorder changes the signature.
+  The leading integer versions the INPUT SHAPE; the \"hs1-\" prefix (unchanged)
+  versions the algorithm."
+  [{:keys [locals effects react] :or {locals [] effects [] react []}}]
+  (digest "hs1-" [2 {:locals  (vec locals)
+                     :effects (vec effects)
+                     :react   (vec react)}]))
+
+(defn config-fingerprint
+  "\"cf1-\" digest of a static frame plan (S1c root-identity contract §6):
+  `[frame-id config-source-map]` — the frame-root's literal `:id` plus its
+  config SOURCE forms (the props map minus `:id`, as written). Hashing the
+  source keeps the fingerprint computable with no evaluation (config
+  expressions are runtime values, evaluated at preflight); build-time
+  plan-conflict detection compares exactly this digest."
+  [frame-id config]
+  (digest "cf1-" [frame-id (or config {})]))

--- a/implementation/freehand/src/re_frame/freehand/rules.cljc
+++ b/implementation/freehand/src/re_frame/freehand/rules.cljc
@@ -1,0 +1,2254 @@
+(ns re-frame.freehand.rules
+  "THE one DOM prop-conversion rule table (Spec 004 rewrite §Template
+  grammar; owning contract: jvm-tree-and-conversion-contract.md §The DOM
+  conversion table).
+
+  One table, three consumers:
+    - the compile-time analyzers/emitters (static prop conversion for both
+      hosts — names baked into emitted code);
+    - the emitted CLJS runtime paths for DYNAMIC values (`v/spread`, the
+      single sanctioned runtime conversion; dynamic attr/style values);
+    - the JVM tree builder (`re-frame.freehand.tree`) for semantic attr-value
+      normalization.
+
+  ## Provenance ([S1-CONFIRM] discharge)
+
+  The `standard-names` vocabulary mirrors react-dom 19.2.0's
+  `possibleStandardNames` (dev source, extracted 2026-07-12; identity
+  entries elided — a lookup miss falls through to verbatim, which is the
+  same rule React 16+ applies to unrecognized names). `unitless-css`
+  mirrors react-dom 19.2.0's `unitlessNumbers` set verbatim, converted to
+  CSS kebab space (the space our authors write). `void-tags` and
+  `boolean-attrs` were probed against react-dom/server 19.2.0 (renders +
+  throw behaviour); see the S1b PR body for the row-by-row outcomes."
+  (:require [clojure.string :as str]
+            [re-frame.error :as error]
+            [re-frame.freehand.eq :as eq]))
+
+;; ---------------------------------------------------------------------------
+;; Shared vocabulary
+;; ---------------------------------------------------------------------------
+
+(def placeholders
+  "Closed v1 event-vector placeholder vocabulary (02 §3; scalars only).
+  Placeholders splice at TOP-LEVEL positions of a literal event vector at
+  dispatch time; they are compiled, so they are recognized in literal
+  vectors only."
+  #{:rf.ui/value :rf.ui/checked :rf.ui/key})
+
+(def handler-option-keys
+  "Closed v1 handler-map option vocabulary (02 §2). `:passive`/`:once`
+  are grammar-legal but their emission lands with the committed-handler
+  slice (S3) — the S1 emitters reject them with a didactic error."
+  #{:event :prevent-default :stop-propagation :capture :passive :once})
+
+;; ---------------------------------------------------------------------------
+;; Name conversion — author kebab keyword name -> React prop name
+;; ---------------------------------------------------------------------------
+
+(def standard-names
+  "react-dom 19.2.0 `possibleStandardNames`, reduced to non-identity
+  entries and keyed by both the kebab and the hyphen-collapsed lowercase
+  form. Lookup rule (`react-prop-name`): data-*/aria-* verbatim; exact
+  key hit; collapsed-key hit; else verbatim (React's unrecognized-name
+  pass-through)."
+  {"accent-height" "accentHeight"
+   "accentheight" "accentHeight"
+   "accept-charset" "acceptCharset"
+   "acceptcharset" "acceptCharset"
+   "accesskey" "accessKey"
+   "alignment-baseline" "alignmentBaseline"
+   "alignmentbaseline" "alignmentBaseline"
+   "allowfullscreen" "allowFullScreen"
+   "allowreorder" "allowReorder"
+   "arabic-form" "arabicForm"
+   "arabicform" "arabicForm"
+   "attributename" "attributeName"
+   "attributetype" "attributeType"
+   "autocapitalize" "autoCapitalize"
+   "autocomplete" "autoComplete"
+   "autocorrect" "autoCorrect"
+   "autofocus" "autoFocus"
+   "autoplay" "autoPlay"
+   "autoreverse" "autoReverse"
+   "autosave" "autoSave"
+   "basefrequency" "baseFrequency"
+   "baseline-shift" "baselineShift"
+   "baselineshift" "baselineShift"
+   "baseprofile" "baseProfile"
+   "calcmode" "calcMode"
+   "cap-height" "capHeight"
+   "capheight" "capHeight"
+   "cellpadding" "cellPadding"
+   "cellspacing" "cellSpacing"
+   "charset" "charSet"
+   "class" "className"
+   "classid" "classID"
+   "clip-path" "clipPath"
+   "clip-rule" "clipRule"
+   "clippath" "clipPath"
+   "clippathunits" "clipPathUnits"
+   "cliprule" "clipRule"
+   "color-interpolation" "colorInterpolation"
+   "color-interpolation-filters" "colorInterpolationFilters"
+   "color-profile" "colorProfile"
+   "color-rendering" "colorRendering"
+   "colorinterpolation" "colorInterpolation"
+   "colorinterpolationfilters" "colorInterpolationFilters"
+   "colorprofile" "colorProfile"
+   "colorrendering" "colorRendering"
+   "colspan" "colSpan"
+   "contenteditable" "contentEditable"
+   "contentscripttype" "contentScriptType"
+   "contentstyletype" "contentStyleType"
+   "contextmenu" "contextMenu"
+   "controlslist" "controlsList"
+   "crossorigin" "crossOrigin"
+   "datetime" "dateTime"
+   "defaultchecked" "defaultChecked"
+   "defaultvalue" "defaultValue"
+   "diffuseconstant" "diffuseConstant"
+   "disablepictureinpicture" "disablePictureInPicture"
+   "disableremoteplayback" "disableRemotePlayback"
+   "dominant-baseline" "dominantBaseline"
+   "dominantbaseline" "dominantBaseline"
+   "edgemode" "edgeMode"
+   "enable-background" "enableBackground"
+   "enablebackground" "enableBackground"
+   "enctype" "encType"
+   "enterkeyhint" "enterKeyHint"
+   "externalresourcesrequired" "externalResourcesRequired"
+   "fetchpriority" "fetchPriority"
+   "fill-opacity" "fillOpacity"
+   "fill-rule" "fillRule"
+   "fillopacity" "fillOpacity"
+   "fillrule" "fillRule"
+   "filterres" "filterRes"
+   "filterunits" "filterUnits"
+   "flood-color" "floodColor"
+   "flood-opacity" "floodOpacity"
+   "floodcolor" "floodColor"
+   "floodopacity" "floodOpacity"
+   "font-family" "fontFamily"
+   "font-size" "fontSize"
+   "font-size-adjust" "fontSizeAdjust"
+   "font-stretch" "fontStretch"
+   "font-style" "fontStyle"
+   "font-variant" "fontVariant"
+   "font-weight" "fontWeight"
+   "fontfamily" "fontFamily"
+   "fontsize" "fontSize"
+   "fontsizeadjust" "fontSizeAdjust"
+   "fontstretch" "fontStretch"
+   "fontstyle" "fontStyle"
+   "fontvariant" "fontVariant"
+   "fontweight" "fontWeight"
+   "for" "htmlFor"
+   "formaction" "formAction"
+   "formenctype" "formEncType"
+   "formmethod" "formMethod"
+   "formnovalidate" "formNoValidate"
+   "formtarget" "formTarget"
+   "frameborder" "frameBorder"
+   "glyph-name" "glyphName"
+   "glyph-orientation-horizontal" "glyphOrientationHorizontal"
+   "glyph-orientation-vertical" "glyphOrientationVertical"
+   "glyphname" "glyphName"
+   "glyphorientationhorizontal" "glyphOrientationHorizontal"
+   "glyphorientationvertical" "glyphOrientationVertical"
+   "glyphref" "glyphRef"
+   "gradienttransform" "gradientTransform"
+   "gradientunits" "gradientUnits"
+   "horiz-adv-x" "horizAdvX"
+   "horiz-origin-x" "horizOriginX"
+   "horizadvx" "horizAdvX"
+   "horizoriginx" "horizOriginX"
+   "hreflang" "hrefLang"
+   "http-equiv" "httpEquiv"
+   "httpequiv" "httpEquiv"
+   "image-rendering" "imageRendering"
+   "imagerendering" "imageRendering"
+   "imagesizes" "imageSizes"
+   "imagesrcset" "imageSrcSet"
+   "inputmode" "inputMode"
+   "itemid" "itemID"
+   "itemprop" "itemProp"
+   "itemref" "itemRef"
+   "itemscope" "itemScope"
+   "itemtype" "itemType"
+   "kernelmatrix" "kernelMatrix"
+   "kernelunitlength" "kernelUnitLength"
+   "keyparams" "keyParams"
+   "keypoints" "keyPoints"
+   "keysplines" "keySplines"
+   "keytimes" "keyTimes"
+   "keytype" "keyType"
+   "lengthadjust" "lengthAdjust"
+   "letter-spacing" "letterSpacing"
+   "letterspacing" "letterSpacing"
+   "lighting-color" "lightingColor"
+   "lightingcolor" "lightingColor"
+   "limitingconeangle" "limitingConeAngle"
+   "marginheight" "marginHeight"
+   "marginwidth" "marginWidth"
+   "marker-end" "markerEnd"
+   "marker-mid" "markerMid"
+   "marker-start" "markerStart"
+   "markerend" "markerEnd"
+   "markerheight" "markerHeight"
+   "markermid" "markerMid"
+   "markerstart" "markerStart"
+   "markerunits" "markerUnits"
+   "markerwidth" "markerWidth"
+   "maskcontentunits" "maskContentUnits"
+   "maskunits" "maskUnits"
+   "maxlength" "maxLength"
+   "mediagroup" "mediaGroup"
+   "minlength" "minLength"
+   "nomodule" "noModule"
+   "novalidate" "noValidate"
+   "numoctaves" "numOctaves"
+   "overline-position" "overlinePosition"
+   "overline-thickness" "overlineThickness"
+   "overlineposition" "overlinePosition"
+   "overlinethickness" "overlineThickness"
+   "paint-order" "paintOrder"
+   "paintorder" "paintOrder"
+   "panose-1" "panose1"
+   "pathlength" "pathLength"
+   "patterncontentunits" "patternContentUnits"
+   "patterntransform" "patternTransform"
+   "patternunits" "patternUnits"
+   "playsinline" "playsInline"
+   "pointer-events" "pointerEvents"
+   "pointerevents" "pointerEvents"
+   "pointsatx" "pointsAtX"
+   "pointsaty" "pointsAtY"
+   "pointsatz" "pointsAtZ"
+   "popovertarget" "popoverTarget"
+   "popovertargetaction" "popoverTargetAction"
+   "preservealpha" "preserveAlpha"
+   "preserveaspectratio" "preserveAspectRatio"
+   "primitiveunits" "primitiveUnits"
+   "radiogroup" "radioGroup"
+   "readonly" "readOnly"
+   "referrerpolicy" "referrerPolicy"
+   "refx" "refX"
+   "refy" "refY"
+   "rendering-intent" "renderingIntent"
+   "renderingintent" "renderingIntent"
+   "repeatcount" "repeatCount"
+   "repeatdur" "repeatDur"
+   "requiredextensions" "requiredExtensions"
+   "requiredfeatures" "requiredFeatures"
+   "rowspan" "rowSpan"
+   "shape-rendering" "shapeRendering"
+   "shaperendering" "shapeRendering"
+   "specularconstant" "specularConstant"
+   "specularexponent" "specularExponent"
+   "spellcheck" "spellCheck"
+   "spreadmethod" "spreadMethod"
+   "srcdoc" "srcDoc"
+   "srclang" "srcLang"
+   "srcset" "srcSet"
+   "startoffset" "startOffset"
+   "stddeviation" "stdDeviation"
+   "stitchtiles" "stitchTiles"
+   "stop-color" "stopColor"
+   "stop-opacity" "stopOpacity"
+   "stopcolor" "stopColor"
+   "stopopacity" "stopOpacity"
+   "strikethrough-position" "strikethroughPosition"
+   "strikethrough-thickness" "strikethroughThickness"
+   "strikethroughposition" "strikethroughPosition"
+   "strikethroughthickness" "strikethroughThickness"
+   "stroke-dasharray" "strokeDasharray"
+   "stroke-dashoffset" "strokeDashoffset"
+   "stroke-linecap" "strokeLinecap"
+   "stroke-linejoin" "strokeLinejoin"
+   "stroke-miterlimit" "strokeMiterlimit"
+   "stroke-opacity" "strokeOpacity"
+   "stroke-width" "strokeWidth"
+   "strokedasharray" "strokeDasharray"
+   "strokedashoffset" "strokeDashoffset"
+   "strokelinecap" "strokeLinecap"
+   "strokelinejoin" "strokeLinejoin"
+   "strokemiterlimit" "strokeMiterlimit"
+   "strokeopacity" "strokeOpacity"
+   "strokewidth" "strokeWidth"
+   "suppresscontenteditablewarning" "suppressContentEditableWarning"
+   "suppresshydrationwarning" "suppressHydrationWarning"
+   "surfacescale" "surfaceScale"
+   "systemlanguage" "systemLanguage"
+   "tabindex" "tabIndex"
+   "tablevalues" "tableValues"
+   "targetx" "targetX"
+   "targety" "targetY"
+   "text-anchor" "textAnchor"
+   "text-decoration" "textDecoration"
+   "text-rendering" "textRendering"
+   "textanchor" "textAnchor"
+   "textdecoration" "textDecoration"
+   "textlength" "textLength"
+   "textrendering" "textRendering"
+   "transform-origin" "transformOrigin"
+   "transformorigin" "transformOrigin"
+   "underline-position" "underlinePosition"
+   "underline-thickness" "underlineThickness"
+   "underlineposition" "underlinePosition"
+   "underlinethickness" "underlineThickness"
+   "unicode-bidi" "unicodeBidi"
+   "unicode-range" "unicodeRange"
+   "unicodebidi" "unicodeBidi"
+   "unicoderange" "unicodeRange"
+   "units-per-em" "unitsPerEm"
+   "unitsperem" "unitsPerEm"
+   "usemap" "useMap"
+   "v-alphabetic" "vAlphabetic"
+   "v-hanging" "vHanging"
+   "v-ideographic" "vIdeographic"
+   "v-mathematical" "vMathematical"
+   "valphabetic" "vAlphabetic"
+   "vector-effect" "vectorEffect"
+   "vectoreffect" "vectorEffect"
+   "vert-adv-y" "vertAdvY"
+   "vert-origin-x" "vertOriginX"
+   "vert-origin-y" "vertOriginY"
+   "vertadvy" "vertAdvY"
+   "vertoriginx" "vertOriginX"
+   "vertoriginy" "vertOriginY"
+   "vhanging" "vHanging"
+   "videographic" "vIdeographic"
+   "viewbox" "viewBox"
+   "viewtarget" "viewTarget"
+   "vmathematical" "vMathematical"
+   "word-spacing" "wordSpacing"
+   "wordspacing" "wordSpacing"
+   "writing-mode" "writingMode"
+   "writingmode" "writingMode"
+   "x-height" "xHeight"
+   "xchannelselector" "xChannelSelector"
+   "xheight" "xHeight"
+   "xlinkactuate" "xlinkActuate"
+   "xlinkarcrole" "xlinkArcrole"
+   "xlinkhref" "xlinkHref"
+   "xlinkrole" "xlinkRole"
+   "xlinkshow" "xlinkShow"
+   "xlinktitle" "xlinkTitle"
+   "xlinktype" "xlinkType"
+   "xmlbase" "xmlBase"
+   "xmllang" "xmlLang"
+   "xmlnsxlink" "xmlnsXlink"
+   "xmlspace" "xmlSpace"
+   "ychannelselector" "yChannelSelector"
+   "zoomandpan" "zoomAndPan"})
+
+(def rejected-prop-spellings
+  "One spelling per name — ambiguities removed at compile time (conversion
+  table §Attribute names; template grammar). The value is the didactic
+  replacement the compile error names."
+  {:class-name                  ":class"
+   :html-for                    ":for"
+   :dangerously-set-inner-html  "(v/html ...)"
+   :dangerouslySetInnerHTML     "(v/html ...)"
+   :inner-html                  "(v/html ...)"
+   :children                    "positional children"})
+
+(defn- collapsed [n] (str/replace n "-" ""))
+
+(defn react-prop-name
+  "Author kebab prop NAME (string, no namespace) -> React prop name.
+  data-*/aria-* verbatim; recognized names via the react-dom vocabulary
+  (kebab or hyphen-collapsed hit); unrecognized names verbatim (React 16+
+  pass-through)."
+  [n]
+  (cond
+    (or (str/starts-with? n "data-") (str/starts-with? n "aria-"))
+    n
+
+    :else
+    (or (get standard-names n)
+        (get standard-names (collapsed n))
+        n)))
+
+(defn camelize
+  "kebab -> camelCase: 'on-click' -> 'onClick', 'my-event' -> 'myEvent'."
+  [s]
+  (let [[h & t] (str/split s #"-")]
+    (apply str h (map str/capitalize t))))
+
+(defn react-event-name
+  "Handler-position name ('on-click') -> React handler prop ('onClick');
+  `capture?` appends React's Capture suffix."
+  ([n] (react-event-name n false))
+  ([n capture?]
+   (cond-> (camelize n)
+     capture? (str "Capture"))))
+
+(defn custom-element-property-name
+  "RULED custom-element grammar: a declared `:properties` name compiles to
+  the camelCase JS property (`:help-text` -> `helpText`)."
+  [n]
+  (camelize n))
+
+(def dom-attr-aliases
+  "React prop name -> the DOM attribute name react-dom/server writes when
+  the two differ — the serialiser half of the conversion table (consumed
+  by normalization N and, at S5, by the SSR serialiser). Everything NOT
+  in this map serialises as the prop name verbatim (react-dom 19.2.0
+  emits e.g. `readOnly` verbatim — HTML attribute names are ASCII
+  case-insensitive; probed, see the S1b/S1f PR bodies).
+
+  Derived from `standard-names`' hyphenated author spellings (the SVG
+  kebab attrs + the hyphenated HTML attrs `accept-charset`/`http-equiv`
+  — react-dom's alias set is the same DOM metadata), plus the `xlink:`/
+  `xml:` colon families and the probed HTML specials (`class`, `for`,
+  `tabindex`)."
+  (merge (into {}
+               (keep (fn [[k v]] (when (str/includes? k "-") [v k])))
+               standard-names)
+         {"className"    "class"
+          "htmlFor"      "for"
+          "tabIndex"     "tabindex"
+          "xlinkActuate" "xlink:actuate"
+          "xlinkArcrole" "xlink:arcrole"
+          "xlinkHref"    "xlink:href"
+          "xlinkRole"    "xlink:role"
+          "xlinkShow"    "xlink:show"
+          "xlinkTitle"   "xlink:title"
+          "xlinkType"    "xlink:type"
+          "xmlBase"      "xml:base"
+          "xmlLang"      "xml:lang"
+          "xmlSpace"     "xml:space"
+          "xmlnsXlink"   "xmlns:xlink"}))
+
+(defn dom-attr-name
+  "Author kebab attr NAME (string, no namespace) -> the serialised DOM
+  attribute name (the serialiser/normalization half of the table; the
+  client-emitter half is `react-prop-name`). data-*/aria-* verbatim;
+  otherwise the React prop name mapped through `dom-attr-aliases`,
+  falling back to the prop name verbatim."
+  [n]
+  (if (or (str/starts-with? n "data-") (str/starts-with? n "aria-"))
+    n
+    (let [p (react-prop-name n)]
+      (get dom-attr-aliases p p))))
+
+;; ---------------------------------------------------------------------------
+;; :style
+;; ---------------------------------------------------------------------------
+
+(def unitless-css
+  "CSS properties whose numeric values do NOT gain 'px'. Mirrors react-dom
+  19.2.0 `unitlessNumbers` verbatim (converted to CSS kebab space,
+  vendor prefixes included). Version-pinned; the parity corpus detects
+  drift ([S1-CONFIRM] row 9)."
+  #{"-moz-animation-iteration-count" "-moz-box-flex" "-moz-box-flex-group"
+    "-moz-line-clamp" "-ms-animation-iteration-count" "-ms-flex"
+    "-ms-flex-grow" "-ms-flex-negative" "-ms-flex-order" "-ms-flex-positive"
+    "-ms-flex-shrink" "-ms-grid-column" "-ms-grid-column-span" "-ms-grid-row"
+    "-ms-grid-row-span" "-ms-zoom" "-webkit-animation-iteration-count"
+    "-webkit-box-flex" "-webkit-box-flex-group" "-webkit-box-ordinal-group"
+    "-webkit-column-count" "-webkit-columns" "-webkit-flex"
+    "-webkit-flex-grow" "-webkit-flex-positive" "-webkit-flex-shrink"
+    "-webkit-line-clamp" "animation-iteration-count" "aspect-ratio"
+    "border-image-outset" "border-image-slice" "border-image-width"
+    "box-flex" "box-flex-group" "box-ordinal-group" "column-count" "columns"
+    "fill-opacity" "flex" "flex-grow" "flex-negative" "flex-order"
+    "flex-positive" "flex-shrink" "flood-opacity" "font-weight" "grid-area"
+    "grid-column" "grid-column-end" "grid-column-span" "grid-column-start"
+    "grid-row" "grid-row-end" "grid-row-span" "grid-row-start" "line-clamp"
+    "line-height" "opacity" "order" "orphans" "scale" "stop-opacity"
+    "stroke-dasharray" "stroke-dashoffset" "stroke-miterlimit"
+    "stroke-opacity" "stroke-width" "tab-size" "widows" "z-index" "zoom"})
+
+(defn custom-property? [n] (str/starts-with? n "--"))
+
+(defn- upper-first [s]
+  (if (seq s) (str (str/upper-case (subs s 0 1)) (subs s 1)) s))
+
+(defn react-style-name
+  "CSS kebab style name -> React style-object key. Custom properties
+  (`--x`) verbatim, no case mapping. Vendor prefixes follow React's
+  spelling: -webkit- -> Webkit…, -moz- -> Moz…, -ms- -> ms…."
+  [n]
+  (cond
+    (custom-property? n) n
+    (str/starts-with? n "-webkit-") (upper-first (camelize (subs n 1)))
+    (str/starts-with? n "-moz-")    (upper-first (camelize (subs n 1)))
+    (str/starts-with? n "-ms-")     (camelize (subs n 1))
+    :else (camelize n)))
+
+#?(:clj
+   (defn- js-double-str
+     "ECMA-262 `Number::toString(10)` for a FINITE, NON-INTEGRAL double.
+  Built from the JVM's shortest round-trip decimal (`Double/toString` —
+  Ryu shortest digits, the same digit selection JS engines use), then
+  re-laid-out per the ECMA rules: plain notation while the decimal
+  exponent n is in (-6, 21], exponential (`1e+21`, `1.23e-7`) outside.
+  Fixes the previous host-format fallback, which leaked Java notation
+  (`0.0001` -> \"1.0E-4\", `1e21` -> \"1.0E21\") — parity-corpus row 10
+  residual, discharged at S1f."
+     [^double d]
+     (let [neg?   (neg? d)
+           s      (Double/toString (Math/abs d))
+           ;; -> [digits n] with value = 0.d1d2... * 10^n
+           [ds n] (if-let [ei (str/index-of s "E")]
+                    (let [mant   (subs s 0 ei)
+                          ex     (Long/parseLong (subs s (inc ei)))
+                          digits (str/replace mant "." "")]
+                      ;; Java E-notation mantissa is d.ddd (one leading digit)
+                      [digits (inc ex)])
+                    (let [di   (str/index-of s ".")
+                          i    (subs s 0 di)
+                          f    (subs s (inc di))]
+                      (if (= i "0")
+                        (let [z (count (take-while #(= \0 %) f))]
+                          [(subs f z) (- z)])
+                        [(str i f) (count i)])))
+           ds     (let [t (str/replace ds #"0+$" "")]
+                    (if (= t "") "0" t))
+           k      (count ds)
+           body   (cond
+                    ;; 0 handled by the integral path upstream
+                    (and (<= k n) (<= n 21))
+                    (str ds (apply str (repeat (- n k) "0")))
+
+                    (and (< 0 n) (<= n 21))
+                    (str (subs ds 0 n) "." (subs ds n))
+
+                    (and (< -6 n) (<= n 0))
+                    (str "0." (apply str (repeat (- n) "0")) ds)
+
+                    :else
+                    (str (subs ds 0 1)
+                         (when (> k 1) (str "." (subs ds 1)))
+                         "e" (when (pos? (dec n)) "+") (dec n)))]
+       (str (when neg? "-") body))))
+
+(defn js-number-str
+  "JS `ToString` semantics for numbers, on both hosts. The pinned case is
+  integral doubles rendering WITHOUT a trailing `.0` ([S1-CONFIRM] row
+  10); non-integral doubles follow the full ECMA layout via
+  `js-double-str` (plain notation in the (-6, 21] decimal-exponent
+  window, `e`-notation outside — the parity corpus pins both)."
+  [x]
+  #?(:cljs (str x)
+     :clj  (cond
+             (integer? x) (str x)
+             (or (double? x) (float? x))
+             (let [d (double x)]
+               (cond
+                 (Double/isNaN d)                     "NaN"
+                 (= d Double/POSITIVE_INFINITY)       "Infinity"
+                 (= d Double/NEGATIVE_INFINITY)       "-Infinity"
+                 (and (== d (Math/rint d))
+                      (< (Math/abs d) 1.0E21))
+                 (str (.toBigInteger (java.math.BigDecimal. d)))
+                 :else (js-double-str d)))
+             (ratio? x) (js-number-str (double x))
+             :else (str x))))
+
+(defn js-string-coerce
+  "React-style key coercion space: numbers via JS ToString, everything
+  else via `str` — the collision domain for duplicate-key diagnosis
+  ([S1-CONFIRM] row 11)."
+  [v]
+  (if (number? v) (js-number-str v) (str v)))
+
+(defn css-val->str
+  "Style value -> canonical CSS value string (tree semantic space +
+  serialiser space; replicates React's dangerousStyleValue): numbers gain
+  'px' unless the property is unitless, a custom property, or the value
+  is 0; keywords stringify via `name`; strings pass trimmed."
+  [css-name v]
+  (cond
+    (keyword? v) (name v)
+    (number? v)  (if (or (zero? v)
+                         (custom-property? css-name)
+                         (contains? unitless-css css-name))
+                   (js-number-str v)
+                   (str (js-number-str v) "px"))
+    :else        (str/trim (str v))))
+
+;; ---------------------------------------------------------------------------
+;; :class — composition + deterministic order
+;; ---------------------------------------------------------------------------
+
+(defn- class-part->str [p]
+  (cond
+    (nil? p)     nil
+    (false? p)   nil
+    (true? p)    nil
+    (keyword? p) (name p)
+    :else        (let [s (str p)] (when-not (str/blank? s) s))))
+
+(defn classes-str
+  "Join class parts (strings/keywords; nil/false/blank dropped) with
+  single spaces; nil when empty. Order is the caller's — the deterministic
+  ordering rules (vector order; flag maps lexicographic; sugar first) are
+  applied by the compiler/`class-val` before this join."
+  [parts]
+  (let [ps (into [] (keep class-part->str) parts)]
+    (when (seq ps) (str/join " " ps))))
+
+(defn flag-map-classes
+  "Flag map -> class parts in LEXICOGRAPHIC class-name order (one
+  deterministic rule for literal and runtime maps alike — map iteration
+  order is never trusted; conversion table §:class)."
+  [m]
+  (->> m
+       (keep (fn [[k v]] (when v (class-part->str k))))
+       sort
+       vec))
+
+(defn class-val
+  "Runtime conversion for a DYNAMIC `:class` value: string/keyword
+  verbatim; vector in vector order (nils dropped); flag map lexicographic;
+  nil -> nil."
+  [v]
+  (cond
+    (nil? v)     nil
+    (string? v)  (when-not (str/blank? v) v)
+    (keyword? v) (name v)
+    (map? v)     (classes-str (flag-map-classes v))
+    (vector? v)  (classes-str v)
+    :else        (class-part->str v)))
+
+;; ---------------------------------------------------------------------------
+;; Serialiser-half data rows (owned by the conversion table; consumed by
+;; the SSR serialiser at S5 and by normalization N — recorded here so the
+;; table is one artefact; probed against react-dom/server 19.2.0)
+;; ---------------------------------------------------------------------------
+
+(def void-tags
+  "Tags that self-close and MUST NOT have children (compile error).
+  Probe outcome ([S1-CONFIRM] row 12): react-dom/server 19.2.0 throws for
+  children on all of these INCLUDING param and keygen (absent from the
+  contract draft's 13 — corrected here); menuitem also rejects children
+  but is not self-closing, so it lives in `children-rejected-tags` only."
+  #{:area :base :br :col :embed :hr :img :input :link :meta :param
+    :keygen :source :track :wbr})
+
+(def children-rejected-tags
+  "Void set plus menuitem (React 19.2.0: \"menuitems cannot have
+  `children`...\" — rejected, though rendered non-self-closing)."
+  (conj void-tags :menuitem))
+
+(def raw-text-tags
+  "The HTML RAW-TEXT elements — `<script>`/`<style>`. React 19.2 takes a
+  SINGLE text body (one string) for these: multiple children reach React as an
+  array that warns and loses the body, and a structural (element/list) child is
+  dropped or stringified. The compiler holds them to a single text-producing
+  child, a sole `(v/html …)` trusted-markup body, or no body (rf2-ib4fd). The
+  compile-tier KEYWORD counterpart of the SSR serialiser's string set
+  `re-frame.ssr.ui-tree/raw-text-tags` (`#{\"script\" \"style\"}`). `:title`
+  and `:textarea` are escapable RCDATA, NOT raw text, and are absent here."
+  #{:script :style})
+
+(def boolean-attrs
+  "HTML boolean attributes: true -> presence (attr=\"\"), false/absent ->
+  omitted. Probed row-by-row against react-dom/server 19.2.0
+  ([S1-CONFIRM] row 4). Note `ismap` (React 19 dropped the camel `isMap`
+  prop; the author spelling is `:ismap`). `hidden`: React 19.2.0 treats
+  it as PURE boolean — the string \"until-found\" also renders bare
+  presence, so the contract draft's enumerated exception is corrected to
+  boolean-only for this React pin (row 4/probe)."
+  #{"allowfullscreen" "async" "autofocus" "autoplay" "checked" "controls"
+    "default" "defer" "disabled" "formnovalidate" "hidden" "inert" "ismap"
+    "itemscope" "loop" "multiple" "muted" "nomodule" "novalidate" "open"
+    "playsinline" "readonly" "required" "reversed" "selected"})
+
+(def booleanish-attrs
+  "true/false -> \"true\"/\"false\", never omitted (probed: contentEditable,
+  draggable, spellCheck — [S1-CONFIRM] row 5)."
+  #{"contenteditable" "draggable" "spellcheck"})
+
+(def overloaded-boolean-attrs
+  "true -> bare presence, false -> omitted, other values stringify
+  (probed: download, capture — [S1-CONFIRM] row 6)."
+  #{"download" "capture"})
+
+(def property-only-attrs
+  "Names React never serialises to markup on NON-custom elements. Probe
+  outcome ([S1-CONFIRM] row 7): react-dom/server 19.2.0 DOES serialise
+  `muted` on <video> (muted=\"\"), so the contract draft's `:muted`
+  citizen is corrected — no S1 row member remains; the set is kept (empty)
+  as the named home for any future member the parity corpus finds."
+  #{})
+
+(defn escape-html
+  "Full 5-char escaping (& < > \" ') for text and attribute values —
+  `v/html` is the single bypass (conversion table §Children, text, and
+  escaping; matches React's escapeTextForBrowser)."
+  [s]
+  (-> (str s)
+      (str/replace "&" "&amp;")
+      (str/replace "<" "&lt;")
+      (str/replace ">" "&gt;")
+      (str/replace "\"" "&quot;")
+      (str/replace "'" "&#x27;")))
+
+;; ---------------------------------------------------------------------------
+;; Namespace context (SVG / MathML) — conversion table §Namespaces
+;; ---------------------------------------------------------------------------
+
+(defn child-ns-context
+  "Namespace context the CHILDREN of `tag` build under, given the current
+  context (nil = HTML). Rows per the conversion table §Namespaces
+  ([S1-CONFIRM] row 2): :svg enters svg; :foreignObject's children revert
+  to HTML; :math enters mathml; :annotation-xml with an :encoding attr of
+  text/html or application/xhtml+xml reverts to HTML."
+  [ctx tag attrs]
+  (case tag
+    :svg  :svg
+    :math :mathml
+    :foreignObject (when-not (= ctx :svg) ctx)
+    :annotation-xml (if (and (= ctx :mathml)
+                             (contains? #{"text/html" "application/xhtml+xml"}
+                                        (some-> (get attrs :encoding) str/lower-case)))
+                      nil
+                      ctx)
+    ctx))
+
+(defn element-ns
+  "The `:ns` field value for an element built in context `ctx` (nil for
+  HTML — canonical form never writes `:ns :html`)."
+  [ctx]
+  (when (contains? #{:svg :mathml} ctx) ctx))
+
+;; ---------------------------------------------------------------------------
+;; Custom-element declarations (RULED grammar) — runtime reconciliation registry
+;;
+;; The RUNTIME arm of the compile-side build-scoped model (rf2-vxgfnd.16 AC5;
+;; rf2-vxgfnd.48 shipped the first cut; rf2-vxgfnd.67 makes it a full
+;; reconciliation protocol). `v/spread` and the JVM tree builder classify a
+;; custom element's `:properties` by reading the LIVE aggregate
+;; `custom-elements` (tag -> decl). That aggregate must be a PURE FUNCTION of
+;; the CURRENT set of live sources — never of process history — exactly like
+;; the compile-side build registries (`re-frame.freehand.compiler.build`).
+;;
+;; .48 evicted a source's contribution ONLY when it re-registered — i.e. it used
+;; a SURVIVING declaration as the signal that the source was rebuilt. That left
+;; two holes: a source that deletes its LAST declaration (or whose file is
+;; deleted) never re-registers, so its stale rows lingered until a full page
+;; reload; and a reload that threw mid-way left the live registry half-mutated.
+;; .67 replaces registration-triggered eviction with an explicit reload-cycle
+;; protocol driven from the reload BOUNDARY, not from re-registration:
+;;
+;;   (notify-reload! [build?])    ^:dev/before-load — OPEN a reload cycle. From
+;;                                here re-registrations STAGE; the live aggregate
+;;                                stays at its last-known-good until commit.
+;;   register-custom-element!     a declaration re-runs — STAGES into the open
+;;                                cycle (or, at initial load / in production where
+;;                                no cycle is open, writes through directly).
+;;   (note-reloaded-sources! ..)  the SHADOW_NS_RESET producer (rf2-vxgfnd.77;
+;;                                see below) records WHICH sources re-ran this
+;;                                cycle — the signal a zero-declaration source
+;;                                cannot emit for itself (absence cannot
+;;                                self-report). Optional: absent, only the
+;;                                staged sources are reconciled.
+;;   (commit-reload! [build?])    ^:dev/after-load — COMMIT: reconcile the ledger
+;;                                (every staged source REPLACES its whole prior
+;;                                contribution, every reloaded-but-unstaged /
+;;                                removed source is EVICTED, untouched sources are
+;;                                kept) AND close the cycle in ONE atomic swap,
+;;                                then publish the aggregate. shadow-cljs runs
+;;                                after-load only on a SUCCESSFUL reload, so a
+;;                                thrown / aborted reload never commits — the last
+;;                                known-good manifest survives.
+;;
+;; The whole protocol reads and writes ONE authoritative value (`ledger-state`:
+;; live `::sources` + in-flight `::cycles`), so the reload cycle is a
+;; LINEARIZABLE state transition (rf2-vxgfnd.144). The public `custom-elements`
+;; aggregate is a pure projection published AFTER each transition, never interleaved with it —
+;; so a watch that reentrantly registers during publication observes an already-
+;; closed cycle and write-through's into the next generation instead of staging
+;; into a cycle the commit is about to discard.
+;;
+;; A ledger row is keyed [build-id ns-sym]. The `ns-sym` is what partitions a real
+;; host's sources; the `build-id` is the INTERNAL PRODUCER SEAM — the identity the
+;; reset producer stamps and every arity default resolves through — and, in tests,
+;; a STATE-PARTITION TOKEN that lets one process drive several independent ledgers
+;; without them colliding. It is NOT a claim that two dev builds can share one copy
+;; of this namespace and reconcile independently: they cannot, and nothing shadow
+;; exposes could tell them apart. See §THE ISOLATION UNIT below for the contract
+;; that bounds this.
+;;
+;; The key is only worth its weight if `build-id` is COHERENT — every participant
+;; in a cycle must agree on it (rf2-vxgfnd.142). It used to be the placeholder
+;; `::default` on every real path — emitted registrations, both lifecycle hooks,
+;; the reset producer — with a second identity reachable only from a test-only
+;; arity, so an emitted registration and the cycle meant to reconcile it could key
+;; a row differently and strand it. Now `current-build-id` is the ONE rule every
+;; arity default resolves through, so they cannot disagree. The explicit
+;; build-scoped arities remain the seam the producer routes through and the token
+;; tests partition state with.
+;;
+;; ## Production carries none of this (rf2-k9yuy)
+;;
+;; Production never opens a cycle: `notify-reload!` is a `^:dev/before-load` hook
+;; shadow does not install in a release build. So a production registration was
+;; always a plain write-through and classification always a plain lookup — but
+;; until rf2-k9yuy the ledger atom was still ALLOCATED and every production
+;; registration still `swap-vals!`'d against it, shipping unused bookkeeping to
+;; consumers. The `reload-ledger?` compile-time gate now folds the whole ledger
+;; out of `:advanced` + `goog.DEBUG=false`: no ledger atom, no staging branch, no
+;; reload-hook body, and `register-custom-element!` emits the ONE direct
+;; `custom-elements` update it actually needs — still once per declaration at
+;; load, never per render. Dev and the JVM keep the full protocol unchanged.
+;;
+;; The elision is pinned BOTH ways. LEXICALLY: the ledger's namespace-qualified
+;; root keys (`::sources` / `::cycles`) are minted nowhere else, so
+;; `scripts/check-ui-mounted-prod-elision.cjs` greps the real `:advanced` browser
+;; bundle for them — present ⇒ the ledger compiled in. CAUSALLY:
+;; `custom_element_reload_elision_prod_test.cljs` runs IN that bundle and asserts
+;; the private `ledger-state` var holds no atom while registration still
+;; classifies. The dev side is the positive control — `rules_cljs_test` (node,
+;; `goog.DEBUG=true`) stages, reconciles and commits real cycles, so removing the
+;; dev branch reddens there rather than silently satisfying the bundle grep.
+;;
+;; ## THE ISOLATION UNIT — one dev build per CLJS root (rf2-4vm19, NORMATIVE)
+;;
+;; THE CONTRACT: ONE Shadow dev build per CLJS global namespace root containing
+;; `re-frame.freehand.rules`. That is the unit this ledger isolates. It is a stated
+;; boundary, not an aspiration — everything below follows from what shadow's
+;; runtime seam does and does not convey.
+;;
+;; The unit is the CLJS ROOT — not the page, and not the output file. Separate
+;; output files are not automatically separate runtime copies: standard shadow dev
+;; output shares the global root, and single-module release output is wrapped by
+;; default.
+;;
+;; SUPPORTED, and isolated by construction:
+;;   - one app plus its `:preloads` tools — that is ONE build;
+;;   - iframes and workers — separate JS realms, so separate roots;
+;;   - independently compiled release bundles — output-wrapped, own copy, and no
+;;     ledger at all (see §Production carries none of this);
+;;   - separate pages.
+;;
+;; UNSUPPORTED, and UNOBSERVABLE from inside: two dev builds fused onto ONE shared
+;; root. `before-load-src` calls each SHADOW_NS_RESET callback with the reloaded ns
+;; and NOTHING else, and lifecycle hooks are invoked with no arguments after being
+;; resolved by name off the SHARED `$CLJS` object. So a callback learns which build
+;; is reloading only from the identity BAKED INTO ITS OWN BUNDLE — which is exactly
+;; what `current-build-id` reads. Two bundles that each carry their OWN copy of
+;; this namespace are therefore isolated: each copy resolves its own build's name
+;; and reconciles only its own rows. But two builds sharing ONE copy (one `$CLJS`,
+;; one set of atoms, one `defonce`d producer) share one set of hooks — a single
+;; shared singleton — and cannot be told apart by anything shadow exposes.
+;;
+;; There is deliberately NO runtime detection, warning, or error for the fused
+;; case. From inside the shared copy the condition is unobservable, so any check
+;; would be heuristic or tautological — the same "agreeing with itself by
+;; construction" defect this namespace rejects for cycle tokens below. The
+;; boundary is held by construction and stated here, never policed at runtime.
+;;
+;; ## Overlapping cycles are unsupported, and no token can change that (rf2-84173)
+;;
+;; A build's cycle is identified by `build-id` alone. That is not an omission
+;; awaiting a generation token — it is the most any token could achieve, because
+;; of two facts about shadow's loader (read off the pinned shadow-cljs client:
+;; `shadow.cljs.devtools.client.{browser,shared,env}`):
+;;
+;;   1. NO CONVEYANCE. Lifecycle hooks are resolved by name off `$CLJS` and
+;;      invoked with NO arguments. A `^:dev/after-load` invocation is therefore
+;;      ANONYMOUS: it cannot present a claim minted by the `^:dev/before-load`
+;;      that opened its cycle. A token would have to be minted AND checked
+;;      entirely inside this ledger, where `commit-reload!` could only compare it
+;;      against the live slot it already reads — agreeing with itself by
+;;      construction. That is a tautology wearing an identity check's clothes,
+;;      which is precisely why this ledger has none.
+;;
+;;   2. NO PAIRING. `do-js-reload*` walks a task chain and ABANDONS the remainder
+;;      when a task throws, so a failed load never runs `^:dev/after-load` at all.
+;;      before-load and after-load are therefore not a balanced pair, which also
+;;      rules out every depth/refcount scheme: one aborted reload would leave the
+;;      count permanently above zero and hot reload would silently stop
+;;      committing, forever.
+;;
+;; Shadow adds no single-flight guard of its own — no pending flag, no queue, no
+;; dedup — so back-to-back `build-complete` messages each run a full independent
+;; reload chain. What actually serializes them is JavaScript: with only
+;; SYNCHRONOUS lifecycle hooks the whole before -> load -> after chain runs inside
+;; one event-loop turn, so cycle N's after-load always precedes cycle N+1's
+;; before-load and cycles cannot overlap. An `^:dev/before-load-async` /
+;; `^:dev/after-load-async` hook ANYWHERE in the build parks that chain and lets a
+;; second before-load land mid-cycle.
+;;
+;; So the honest boundary is: exactly ONE live cycle per build, overlapping
+;; same-build cycles unsupported, and the supersession made LOUD instead of silent
+;; (`notify-reload!`). The degradation under a genuine overlap is bounded and
+;; self-healing — stale classification rows until the next full page load, the
+;; same bound `note-reloaded-sources!` already documents for a deleted file.
+;;
+;; NOTE the word "generation" elsewhere in this namespace means something
+;; narrower and real: the open-vs-closed cycle state a registration observes
+;; ATOMICALLY (rf2-vxgfnd.144), which decides staging vs write-through. That is a
+;; property of the ledger transition, NOT an identity for a cycle.
+;; ---------------------------------------------------------------------------
+
+(defonce ^{:doc "tag keyword -> {:properties #{kebab-kw}}. The LIVE aggregate
+  `v/spread` and the JVM tree builder read (unchanged; undeclared elements need
+  no declaration — all-attributes default). A pure function of the current live
+  sources: rebuilt from the ledger on every reload commit."}
+  custom-elements
+  (atom {}))
+
+(def ^:private ^boolean reload-ledger?
+  "COMPILE-TIME gate for the ENTIRE hot-reload ledger (rf2-k9yuy).
+
+  Only a host that can OPEN a reload cycle needs the source/cycle ledger below.
+  Development (`goog.DEBUG`) can; `:advanced` production cannot — `notify-reload!`
+  is a `^:dev/before-load` hook shadow never installs in a release build — so in
+  production every registration was already a plain write-through and the whole
+  ledger was unused bookkeeping a consumer shipped for nothing.
+
+  Under `:advanced` + `goog.DEBUG=false` Closure constant-folds this to `false`,
+  which DCEs the ledger atom's construction, every staging/reconcile branch and
+  every reload-hook body — so no source/cycle state is allocated, rooted, read or
+  mutated in production. What survives is the ONE direct `custom-elements` update
+  a production registration actually needs.
+
+  The JVM arm is unconditionally `true` (NOT `interop/debug-enabled?`, which
+  `-Dre-frame.debug=false` can flip): the compiler and the JVM tree-builder
+  fixtures drive the reload protocol headless, so the ledger must always be
+  present there."
+  #?(:cljs ^boolean js/goog.DEBUG
+     :clj  true))
+
+(def ^:private empty-ledger
+  "The quiescent ledger value — no committed sources, no in-flight cycles."
+  {::sources {} ::cycles {}})
+
+(defonce ^{:private true
+           :doc "The ONE authoritative ledger value (rf2-vxgfnd.144), or `nil`
+  in `:advanced` production (rf2-k9yuy — see `reload-ledger?`; a host that can
+  never open a reload cycle allocates no ledger). A single atom so cycle
+  open/close, staged-row ownership and the ledger transition are a LINEARIZABLE
+  state change — check-then-act on the reload cycle can never be split across two
+  atoms and interleaved:
+
+    {::sources {[build-id ns-sym] {tag decl}}   ; the per-source committed ledger
+     ::cycles  {build-id {:staged {[b ns] {tag decl}} :touched #{[b ns]}}}}
+
+  `::sources` is the runtime mirror of the compile-side build ledger — a source
+  whose file is deleted, or whose last declaration is dropped, vanishes the
+  moment its row is reconciled away, no surviving declaration required.
+  `::cycles` holds each build's IN-FLIGHT reload (absent = no cycle → direct
+  write-through): `:staged` accumulates the cycle's re-registrations, held back
+  from the live aggregate until commit; `:touched` is the reloaded/removed source
+  set `note-reloaded-sources!` records — the sources to reconcile even when they
+  staged nothing (zero-declaration / deletion).
+
+  Both keys are NAMESPACE-QUALIFIED (`::sources` / `::cycles`) so the advanced-
+  bundle elision scan has an unambiguous lexical sentinel — this ledger is their
+  only minter, whereas the bare-keyword spellings collide with unrelated corpus
+  keywords and would make the grep meaningless. The scan itself lives in
+  scripts/check-ui-mounted-prod-elision.cjs; it deliberately owns the fully-
+  qualified grep strings, because the elision companion reifies THIS var and so
+  carries this doc into the very bundle being scanned.
+
+  The public `custom-elements` aggregate is a pure PROJECTION of `::sources`,
+  published (one `reset!`) AFTER each authoritative transition completes — never
+  interleaved with it."}
+  ledger-state
+  (when reload-ledger? (atom empty-ledger)))
+
+(def ^:private default-build
+  "The owner token for a source registering outside any real Shadow build: the
+  JVM tree builder, a plain-JVM/REPL host, a `:node-test` bundle, and every
+  `:advanced` production bundle (which never reloads and — rf2-k9yuy — carries no
+  ledger at all, so this token names only the write-through owner)."
+  ::default)
+
+#?(:cljs
+   (defn- shadow-build-id
+     "The REAL build identity of the bundle this code is running in, or nil when
+     there is no Shadow dev build (production, a bare node bundle, a test host).
+
+     shadow-cljs compiles `(name build-id)` into every devtools-enabled build as
+     the `shadow.cljs.devtools.client.env/build-id` closure-define, and PREPENDS
+     that namespace to the module entries — so it is already loaded and defined
+     before any app code (and therefore before any emitted
+     `register-custom-element!`) runs. It is a STABLE identity: the build's own
+     name, not the content/build digest, so it does not change when sources do.
+
+     Read by NAME off `$CLJS`, the way shadow reads its own reload lifecycle fns,
+     rather than by requiring the devtools client — the devtools client must never
+     be reachable from library code that ships to production. `js/goog.DEBUG` gates
+     the sole call site, so `:advanced` constant-folds this away entirely."
+     []
+     (let [root (or (unchecked-get js/goog.global "$CLJS") js/goog.global)
+           v    (js/goog.getObjectByName "shadow.cljs.devtools.client.env.build_id" root)]
+       (when (and (string? v) (seq v))
+         (keyword v)))))
+
+(defn current-build-id
+  "The build identity the ledger keys this host's sources under — ONE rule, shared
+  by every arity default in the reload protocol (`register-custom-element!`,
+  `notify-reload!`, `note-reloaded-sources!`, `commit-reload!`, and the installed
+  `reload-source-reset!` producer). Because they all resolve it the same way, an
+  emitted registration and the reload cycle that reconciles it can never disagree
+  about who owns a row (rf2-vxgfnd.142).
+
+  In a real Shadow dev build this is that build's OWN name (`:app`); everywhere
+  else — production, JVM, a bare node bundle — there is no Shadow build to name and
+  it is `::default`. Resolved per call rather than cached: it is dev-only, called
+  once per declaration at load and once per reload hook (never per render), and a
+  cache would only create a window in which an early miss became permanent."
+  []
+  #?(:cljs (if ^boolean js/goog.DEBUG
+             (or (shadow-build-id) default-build)
+             default-build)
+     :clj  default-build))
+
+;; ---------------------------------------------------------------------------
+;; The ONE cross-source declaration law (rf2-vxgfnd.143)
+;;
+;; Delegated ruling 2026-07-15, Option A — FAIL ATOMICALLY, never a merge or a
+;; winner law. For a given tag the effective declaration is the unique value
+;; contributed by every live source across the one JS realm IFF every
+;; cross-source pair is `rf=`-equal. The runtime aggregate is keyed by TAG alone
+;; — one shared `custom-elements` registry per realm — so `[build-id ns-sym]` is
+;; DECLARER PROVENANCE (the anchor a contradiction names), never a partition key:
+;; two sources with different build-ids that classify one tag differently
+;; contradict, and the runtime cross-build test pins exactly that. (The COMPILE
+;; arm's per-build registry legitimately permits different manifests in different
+;; builds — separate builds are separate compilation units, not one realm.) Any
+;; non-`rf=`-equal same-tag declaration from a DIFFERENT source fails atomically,
+;; carrying a sorted vector of [build-id ns-sym] anchors — every equal incumbent
+;; declarer plus the arrival — and leaves the last-known-good aggregate unchanged.
+;;
+;; ## Where the law lives, and why it is not where it was first ruled
+;;
+;; The 2026-07-15 ruling placed the runtime arm on the ledger paths below
+;; (`register-custom-element!`'s pre-write check, the `commit-reload!` fold).
+;; All of those sit behind `reload-ledger?`, which Closure constant-folds to
+;; false and DCEs under `:advanced` + `goog.DEBUG=false` (rf2-k9yuy) — so
+;; implemented as first written the law would not have existed in the shipped
+;; artefact at all. That is the exact shape of two defects that DID ship in the
+;; same week (rf2-2hkfy #6376, an "always-on" rejection — enforcement meant to
+;; survive every build, NOT the always-on error-emit channel — that was actually
+;; goog.DEBUG-gated; rf2-5pr75 #6352, a live XSS closed only by making the check
+;; fire on every build). The 2026-07-19 placement amendment gives the law a
+;; residence on the ONE registration that survives a release build:
+;;
+;;   `write-element!` — the direct `custom-elements` barrier the ADVANCED-
+;;   PRODUCTION path performs (`reload-ledger?` false, no ledger). On dev/JVM
+;;   hosts (`reload-ledger?` true) the same declaration is instead admitted
+;;   against `ledger-state` — `write-through-verdict` for a direct registration,
+;;   `commit-reload!` for a staged one — and the live `custom-elements` aggregate
+;;   is a published PROJECTION of the ledger, never a `write-element!` call.
+;;
+;; So `ledger-state` is the dev/JVM admission authority and `write-element!` is
+;; the advanced-production barrier; both apply the SAME pure `admit`, and the
+;; `aggregate` re-derivation over `::sources` is defence in depth, not a second
+;; winner rule. `custom_element_reload_elision_prod_test.cljs` runs INSIDE the
+;; `:advanced` bundle and pins the production enforcement so it cannot silently
+;; rot back to dev-only.
+;;
+;; The compile arm (PR #6006) already draws the same two-tier shape:
+;; `build/contribute-element-checked!` is the write BARRIER and
+;; `build/elements-conflict` the re-derived detector. `admit` below is the
+;; runtime barrier's law, and `aggregate` re-derives the same verdict over the
+;; committed ledger — one law, applied twice, unable to drift because both call
+;; the same pure function.
+;; ---------------------------------------------------------------------------
+
+(def ^:private owners-key
+  "Owner provenance slot on a live aggregate entry: the SET of `[build-id ns-sym]`
+  sources whose `rf=`-equal declarations are live for that tag.
+
+  A SET, not a single canonical owner (rf2-7uyl9): several sources may
+  legitimately state the same fact, and a later replacement from one of them must
+  be able to name EVERY other source still contributing it — otherwise it could
+  silently overwrite a manifest another source still declares, and the conflict
+  evidence could not name every declarer. Written in the SAME swap as the
+  declaration itself, because the law's evidence needs every anchor and production
+  carries no ledger to look incumbents up in (rf2-k9yuy). Readers are unaffected —
+  `custom-element-properties` reads `:properties` off the entry — and there is
+  deliberately NO second atom and no parallel index that could drift from it."
+  ::owners)
+
+(defn- declaration
+  "The DECLARATION half of a live entry — the entry minus its provenance. What
+  the equal declarers all agree on, `rf=`, for their declarations to co-exist."
+  [entry]
+  (dissoc entry owners-key))
+
+(defn- conflict-row
+  "One anchor of a contradiction, in the ruled evidence shape (mirrors the
+  compile arm's `build/element-conflict-row`)."
+  [[build-id ns-sym] decl]
+  {:build build-id :ns ns-sym :properties (:properties decl #{})})
+
+(defn- conflict-evidence
+  "Every anchor of a contradiction, SORTED. `incumbent-owners` are all the
+  sources whose `rf=`-equal `incumbent-decl` is live for `tag`; `source`/`decl`
+  is the arriving contradiction. Naming EVERY equal declarer — not one canonical
+  owner (rf2-7uyl9) — is what stops a replacement silently overwriting a manifest
+  another source still declares, and makes the anchors complete. Sorting by
+  `[build ns]` keeps the evidence byte-identical under every permutation of
+  source names, evaluation order and build ids."
+  [tag incumbent-owners incumbent-decl source decl]
+  {:tag tag
+   :declarations (->> (conj (mapv #(conflict-row % incumbent-decl) incumbent-owners)
+                            (conflict-row source decl))
+                      (sort-by (juxt (comp str :build) (comp str :ns)))
+                      vec)})
+
+(defn- admit
+  "THE law, as one pure step: fold `source`'s declaration of `tag` into
+  aggregate `agg`.
+
+  Returns `{:aggregate agg'}` when the declaration is admitted, or
+  `{:conflict evidence}` — naming EVERY equal live declarer plus `source`
+  (rf2-7uyl9) — when it contradicts a live declaration from a DIFFERENT source,
+  in which case NOTHING is written and `agg` remains the last-known-good
+  aggregate.
+
+  Each entry records the SET of sources whose `rf=`-equal declarations are live
+  (`owners-key`). Four cases:
+
+    - no live declaration for `tag`  -> admitted; `source` is its sole declarer.
+    - the arriving decl is `rf=`-EQUAL to the live one -> `source` JOINS the
+                                        declarer set (idempotent if already in);
+                                        duplicates co-exist, and every one is now
+                                        named in any future contradiction.
+    - not equal, but `source` is the SOLE live declarer -> REPLACED. A source
+                                        never conflicts with itself: re-declaration
+                                        is what a reload or a REPL re-eval does.
+    - not equal, and OTHER sources still declare the live value -> CONFLICT,
+                                        naming every remaining declarer. Never a
+                                        merge, never a winner by evaluation order.
+
+  Pure and total, so the production write barrier (`write-element!`) and the
+  dev-side ledger projection (`aggregate`) apply literally the same law and
+  cannot drift from one another."
+  [agg tag decl source]
+  (let [entry  (get agg tag)
+        owners (get entry owners-key)]
+    (cond
+      (nil? owners)
+      {:aggregate (assoc agg tag (assoc decl owners-key #{source}))}
+
+      (eq/rf= (declaration entry) decl)
+      {:aggregate (assoc agg tag (assoc decl owners-key (conj owners source)))}
+
+      (= owners #{source})
+      {:aggregate (assoc agg tag (assoc decl owners-key #{source}))}
+
+      :else
+      {:conflict (conflict-evidence tag (disj owners source)
+                                    (declaration entry) source decl)})))
+
+(defn- throw-element-conflict!
+  "Raise the ruled runtime conflict as an UNCONDITIONAL throw — never a
+  `trace/`-gated path. The law this reports holds in `:advanced` production, so
+  the throw has to fire there too; gating it behind `goog.DEBUG` would re-create
+  the very dev-only-law defect the placement amendment exists to prevent. That is
+  production-surviving ENFORCEMENT — a DISTINCT axis from the always-on
+  error-emit listener CHANNEL. This is a pure `error/throw-error!` that never
+  fans a record to the `:errors` listener, so Spec 009 catalogues
+  `:rf.error/custom-element-conflict` on the DIAGNOSTIC channel (the
+  thrown-ex-info-is-diagnostic rule) even though the enforcement itself is
+  unconditional and survives a release build."
+  [{:keys [tag declarations] :as evidence}]
+  (error/throw-error!
+   :rf.error/custom-element-conflict 're-frame.freehand/custom-element
+   (str "conflicting (v/custom-element " tag " ...) declarations — "
+        (str/join " vs "
+                  (map (fn [{:keys [build ns properties]}]
+                         (str ns " (build " (pr-str build) ") declares :properties "
+                              (pr-str (vec (sort properties)))))
+                       declarations))
+        ". One tag has ONE property manifest: delete the duplicate declaration, "
+        "or make all declaring sources declare an IDENTICAL :properties set (identical "
+        "declarations may co-exist). re-frame.freehand will not pick a winner by "
+        "evaluation or reload order — the live manifest is UNCHANGED")
+   {:recovery :align-custom-element-declarations
+    :extra evidence}))
+
+(defn- write-element!
+  "THE advanced-production residence of the law (placement amendment 2026-07-19):
+  the direct `custom-elements` swap the PRODUCTION registration path performs.
+
+  This is the only registration code that survives `:advanced` +
+  `goog.DEBUG=false`; everything ledger-shaped folds away with `reload-ledger?`,
+  so putting the check anywhere else would make the law dev-only. On dev/JVM
+  hosts the declaration is admitted against `ledger-state` instead (see
+  `register-custom-element!`), never here.
+
+  The verdict is decided INSIDE the one atomic swap, so no interleaved
+  registration is admitted against a value this one has already rejected. The
+  post-swap re-derivation reads the same `old` the WINNING attempt saw, so the
+  evidence reported is exactly the verdict that was applied — never a second,
+  differently-timed opinion."
+  [tag decl source]
+  (let [[old _new] (swap-vals! custom-elements
+                               (fn [agg]
+                                 (:aggregate (admit agg tag decl source) agg)))]
+    (when-let [evidence (:conflict (admit old tag decl source))]
+      (throw-element-conflict! evidence)))
+  nil)
+
+(defn- aggregate
+  "The public aggregate as the conflict-CHECKED fold of every ledger source's
+  map — the live registry is a PURE FUNCTION of `::sources`, computed by the
+  SAME `admit` law the production barrier applies.
+
+  Returns `{:aggregate m}` or `{:conflict evidence}`. Sources are folded in a
+  stable sorted order, so the projection and the anchors of any contradiction it
+  finds are deterministic regardless of ledger insertion order. That order
+  decides only which of two `rf=`-EQUAL declarations is folded first; it can
+  never pick a winner between contradictory ones, which is what makes this a
+  DEFENCE-IN-DEPTH re-derivation rather than a second, sort-order law of the
+  kind the ruling forbids."
+  [sources]
+  (reduce
+   (fn [acc src]
+     (let [step (reduce-kv (fn [acc tag decl]
+                             (let [r (admit (:aggregate acc) tag decl src)]
+                               (if (:conflict r) (reduced r) r)))
+                           acc
+                           (get sources src))]
+       (if (:conflict step) (reduced step) step)))
+   {:aggregate {}}
+   (sort-by str (keys sources))))
+
+(defn- report-publication-escape!
+  "Surface the contained observer failure from ONE reload publication (rf2-za45g).
+
+  Bounded to a single diagnostic per publication and itself contained: the
+  machinery that reports a failed observer must never become a second way for a
+  committed reload to fail. Dev-only by construction — the only caller sits
+  inside `reload-ledger?`, so `:advanced` production carries neither.
+
+  CLJS-only, mirroring the analogous descriptor-HMR reporter in
+  `re-frame.freehand.reactive` (rf2-vxgfnd.215): shadow's `^:dev/after-load` hook — the
+  thing an escaping observer would falsify — exists only on CLJS. The JVM arm of
+  this ledger drives the protocol headless from compiler / tree-builder fixtures,
+  where there is no reload outcome to misreport and no console to report it to."
+  [build-id tag-count error]
+  #?(:cljs
+     (try
+       (when (exists? js/console)
+         (.warn js/console
+                (str "[re-frame.freehand] a custom-element publication observer threw "
+                     "while publishing build " (pr-str build-id)
+                     "'s reload commit (" tag-count
+                     " declared tags live) — the throw was CONTAINED and the "
+                     "reload REMAINS SUCCESSFUL: the ledger was already "
+                     "reconciled and the cycle closed before publication began. "
+                     "Cause: "
+                     (if (nil? error)
+                       "nil"
+                       (error/ex-message-safe error)))))
+       (catch :default _ nil))
+     :clj (do build-id tag-count error nil)))
+
+(defn- publish!
+  "Republish the public aggregate as a pure projection of the CURRENT ledger
+  `::sources`. Called AFTER an authoritative `ledger-state` transition, never
+  interleaved with it, so a reentrant `register-custom-element!` a watch fires
+  during this publish sees the already-transitioned ledger.
+
+  Uses `swap!` reading the LIVE ledger (not a captured snapshot) so that under JVM
+  contention the projection retries and recomputes from the latest `::sources` —
+  it can never overwrite a concurrent write-through's row with a stale aggregate.
+  On CLJS it is a single uncontended recompute.
+
+  ## Publication is DELIVERY, not authority (rf2-za45g)
+
+  By the time this runs the reload is already committed: `commit-reload!`
+  reconciled `::sources` and closed the cycle in ONE atomic swap, and only then
+  called here. Publication is the DELIVERY of that outcome, so it needs delivery's
+  failure semantics — the same split rf2-vxgfnd.215 drew for descriptor HMR.
+
+  An observer of `custom-elements` is arbitrary code. `swap!` notifies watches
+  SYNCHRONOUSLY and with no containment, so a throwing observer used to escape
+  here, out of `commit-reload!`, and into shadow's `^:dev/after-load` hook — which
+  reports the whole reload FAILED even though the framework had committed it. That
+  is a lie about authority told by a listener, so the throw is contained and
+  reported instead.
+
+  Containment is safe because BOTH hosts publish the atom's new value BEFORE
+  notifying watches (CLJS `-reset!` sets state then `-notify-watches`; the JVM
+  `Atom.swap` CAS's then `notifyWatches`). A contained observer throw therefore
+  leaves the live aggregate, the projected ledger and the cycle state exactly as a
+  clean publication would — quiescent and coherent — never half-applied.
+
+  What containment does NOT buy: SIBLING delivery. Watch fan-out belongs to the
+  host's `IAtom`, which abandons the remaining watches when one throws, and
+  replacing that would mean shipping a listener framework this ledger has no
+  consumer for — there are no framework-owned observers of `custom-elements` at
+  all (classification reads `custom-element-properties`, never a watch). So
+  arbitrary watches are explicitly UNSUPPORTED observers: they are contained and
+  diagnosed, but their mutual delivery order and completeness are the host's
+  semantics, not a framework guarantee."
+  [build-id]
+  (let [failure (try
+                  ;; A conflicted projection RETAINS the live aggregate rather
+                  ;; than publishing a partial one. Unreachable in practice —
+                  ;; `commit-reload!` rejects a conflicting cycle before it can
+                  ;; reach here, and the barrier keeps contradictory rows out of
+                  ;; `::sources` in the first place — but publication is DELIVERY
+                  ;; (rf2-za45g), so its failure mode is "deliver nothing new",
+                  ;; never "deliver something half-resolved".
+                  (swap! custom-elements
+                         (fn [live]
+                           (:aggregate (aggregate (::sources @ledger-state)) live)))
+                  {:failed? false :error nil}
+                  ;; The explicit `:failed?` bit — never the truthiness of
+                  ;; `:error` — preserves failure identity when CLJS throws a
+                  ;; falsey value (`(throw nil)`, `(throw false)` are both legal).
+                  (catch #?(:clj Throwable :cljs :default) e
+                    {:failed? true :error e}))]
+    (when (:failed? failure)
+      (report-publication-escape! build-id (count @custom-elements) (:error failure))))
+  nil)
+
+(defn- reconcile-sources
+  "Fold one build's committed cycle into `::sources`: every STAGED source replaces
+  its whole prior contribution; every reconciled source that staged NOTHING (a
+  zero-declaration edit or a removed/deleted file flagged via `:touched`) is
+  evicted; untouched sources are kept."
+  [sources staged touched]
+  (reduce (fn [l src]
+            (if-let [decls (get staged src)]
+              (assoc l src decls)     ; re-declared: replace whole contribution
+              (dissoc l src)))        ; zero-declaration / removed: evict
+          sources
+          (into (set (keys staged)) touched)))
+
+(defn- commit-outcome
+  "Pure: what committing `build-id`'s open cycle in ledger value `st` WOULD do.
+
+  `nil` when no cycle is open; `{:sources reconciled}` when the reconciled
+  ledger projects cleanly; `{:conflict evidence}` when a staged source
+  introduces a cross-source contradiction.
+
+  The verdict is taken on the POST-reconciliation value, which is the only
+  honest place to take it: a staged source REPLACES its whole prior
+  contribution, so a row that looks contradictory mid-cycle may be the very row
+  being retired. Dev-side defence in depth — a staged registration never reaches
+  the production barrier, so this is where the law is enforced for it."
+  [st build-id]
+  (when-let [{:keys [staged touched]} (get (::cycles st) build-id)]
+    (let [reconciled (reconcile-sources (::sources st) staged touched)
+          {:keys [conflict]} (aggregate reconciled)]
+      (if conflict {:conflict conflict} {:sources reconciled}))))
+
+(defn- write-through-verdict
+  "Pure: the verdict of admitting `source`'s declaration of `tag` into ledger
+  value `st` on the WRITE-THROUGH path (no cycle open for the build).
+
+  Decided against the ledger's OWN projection (`aggregate` over `::sources`), so
+  the whole admission is ONE decision on the single `ledger-state` atom
+  (rf2-u25hr) — never a check against a snapshot of `@custom-elements`, which a
+  concurrent, differently-timed live write can leave stale. That split is exactly
+  the defect: two write-throughs each prechecked the still-empty live aggregate,
+  both entered `::sources`, and only one live write won — stranding the loser's
+  row in the ledger while the projection went nil. Deciding against `::sources`
+  instead serialises the two on this one atom: the second sees the first's row
+  and is rejected before it can enter.
+
+  Returns `{:sources st'}` with the row recorded in `::sources` when admitted, or
+  `{:conflict evidence}` when it contradicts a live source, leaving `::sources`
+  untouched. `::sources` is conflict-free by invariant (a rejected row never
+  enters it), so its projection is always a clean aggregate."
+  [st source tag decl]
+  (let [live (:aggregate (aggregate (::sources st)))]
+    (if-let [conflict (:conflict (admit live tag decl source))]
+      {:conflict conflict}
+      {:sources (update-in st [::sources source] (fnil assoc {}) tag decl)})))
+
+(defn register-custom-element!
+  "Register `tag`'s runtime property classification under its declaring source.
+  Emitted top-level by `v/custom-element`, so it re-runs on every ns hot-reload.
+  While a reload cycle is open for the build it STAGES (the live aggregate stays
+  last-known-good until `commit-reload!`); otherwise — initial load, production —
+  it writes through directly. Ownership is [build-id ns-sym]; the 3-arg emit
+  resolves the ambient build via `current-build-id`.
+
+  The stage-vs-write-through decision and the ledger write are ONE atomic
+  transition on `ledger-state` (rf2-vxgfnd.144): a registration can never read
+  'cycle open' and then have its stage recreate a cycle a concurrent commit just
+  removed. A write-through additionally publishes its one row; because it decided
+  against staging atomically, a commit that closed the cycle first cannot delete
+  this row (the closed cycle no longer names it), and a commit still open cannot
+  see it as staged (it went to `::sources`, not `:staged`) — the generation rule
+  the reentrancy fix relies on.
+
+  In `:advanced` production (`reload-ledger?` false) there is no ledger and no
+  cycle can ever be open, so the whole stage-vs-write-through transition folds
+  away and what remains is the single direct aggregate update — the same row the
+  dev write-through publishes, reached without touching any ledger state
+  (rf2-k9yuy).
+
+  Every path applies the SAME pure `admit` law (rf2-vxgfnd.143), so a
+  cross-source contradiction is caught on EVERY host and build mode — advanced
+  production through the direct `write-element!` barrier, dev/JVM through the
+  `ledger-state` admission (`write-through-verdict` here, `commit-reload!` for a
+  staged reload). A contradictory same-tag declaration from a DIFFERENT source is
+  rejected without writing and raises `:rf.error/custom-element-conflict` whose
+  `:declarations` is a sorted vector naming every equal incumbent declarer plus
+  the arriving source, leaving the live manifest exactly as it was. `rf=`-equal
+  duplicates co-exist, and a source re-declaring its own tag replaces its row only
+  while it is the SOLE declarer — while another source still co-declares the live
+  value, a non-`rf=`-equal re-declaration is a contradiction."
+  ([tag decl ns-sym] (register-custom-element! tag decl ns-sym (current-build-id)))
+  ([tag decl ns-sym build-id]
+   (let [source [build-id ns-sym]]
+     (if reload-ledger?
+       (let [[old _new]
+             (swap-vals! ledger-state
+                         (fn [st]
+                           (if (contains? (::cycles st) build-id)
+                             (update-in st [::cycles build-id :staged source]
+                                        (fnil assoc {}) tag decl)
+                             ;; WRITE-THROUGH. The admission verdict is decided
+                             ;; INSIDE this one `ledger-state` swap, against the
+                             ;; ledger's OWN projection (`write-through-verdict`),
+                             ;; never against a snapshot of `@custom-elements` a
+                             ;; concurrent live write can leave stale (rf2-u25hr).
+                             ;; Two write-throughs for one tag therefore serialise
+                             ;; on this atom: the second sees the first's row in
+                             ;; `::sources` and is rejected, so a rejected row can
+                             ;; never remain in `::sources` while the live
+                             ;; aggregate holds the winner. A rejected write-through
+                             ;; leaves `::sources` untouched here and (below)
+                             ;; publishes nothing — NEITHER atom moves off
+                             ;; last-known-good.
+                             ;;
+                             ;; A STAGED row is deliberately NOT checked here: it
+                             ;; is not live yet, and the rows it would be checked
+                             ;; against are the very ones this cycle is about to
+                             ;; replace. `commit-reload!` is the staged path's
+                             ;; check, on the POST-reconciliation value.
+                             (:sources (write-through-verdict st source tag decl)
+                                       st))))]
+         ;; The winning transition saw `old`; re-derive its verdict from that same
+         ;; `old` to PUBLISH or to RAISE. `::sources` already carries the admitted
+         ;; row (written in the swap above), so `publish!` — a pure projection of
+         ;; the LIVE ledger — republishes it without a second, differently-timed
+         ;; opinion and cannot lose it to a concurrent commit; a rejected
+         ;; write-through raises without either atom having moved. (Staged
+         ;; registrations stay invisible until commit.)
+         (when-not (contains? (::cycles old) build-id)
+           (let [{:keys [conflict]} (write-through-verdict old source tag decl)]
+             (if conflict
+               (throw-element-conflict! conflict)
+               (publish! build-id)))))
+       (write-element! tag decl source)))
+   tag))
+
+(defn- report-unpaired-cycle!
+  "Surface an UNPAIRED `^:dev/before-load` — one that found a cycle still open,
+  carrying evidence, and superseded it (rf2-84173).
+
+  Bounded to one diagnostic per supersession and itself contained: a diagnostic
+  must never become a way for opening a cycle to fail. Dev-only by construction
+  (the only caller sits inside `reload-ledger?`).
+
+  Reports the DISCARD because the discard is real and lossy — it is simply the
+  lesser loss (see `notify-reload!`). Silence was the actual defect: the same
+  blind clobber served the routine aborted-reload recovery and the pathological
+  overlapping-cycle case, and nothing told them apart or told anyone."
+  [build-id staged touched]
+  #?(:cljs
+     (try
+       (when (exists? js/console)
+         (.warn js/console
+                (str "[re-frame.freehand] build " (pr-str build-id)
+                     " opened a custom-element reload cycle while one was STILL "
+                     "OPEN; the previous cycle's evidence was discarded ("
+                     (reduce + 0 (map count (vals staged))) " staged declaration(s) across "
+                     (count staged) " source(s), " (count touched)
+                     " touched source(s)). EXPECTED after a reload that threw — "
+                     "shadow-cljs skips ^:dev/after-load entirely when a load "
+                     "task fails, so before/after are not a balanced pair, and "
+                     "discarding is how last-known-good is recovered. UNEXPECTED "
+                     "otherwise: overlapping same-build reload cycles are NOT "
+                     "supported, because shadow passes no cycle identity to "
+                     "^:dev/after-load. If you use ^:dev/before-load-async or "
+                     "^:dev/after-load-async, expect custom-element "
+                     "classification to need a full page reload to converge.")))
+       (catch :default _ nil))
+     :clj (do build-id staged touched nil)))
+
+(defn ^:dev/before-load notify-reload!
+  "shadow-cljs hot-reload hook (dev only): OPEN a reload cycle for `build-id`
+  (the runtime analogue of the compile-side `begin-build!`). Re-registrations
+  from here stage instead of mutating the live aggregate. Production never hot-
+  reloads (shadow installs no `^:dev/before-load` hook in a release build), so
+  this never fires there and its body folds away with the ledger (rf2-k9yuy).
+
+  ## Exactly ONE live cycle per build, and why the supersession is loud
+
+  Opening a fresh cycle REPLACES whatever cycle was open for the build, so a
+  build has exactly one live cycle — the generation every registration and every
+  `:touched` note of that reload belongs to. Replacing is deliberate and is the
+  ABORTED-RELOAD RECOVERY: shadow's `do-js-reload*` abandons the remaining task
+  chain when a task throws, so a failed load never reaches `^:dev/after-load` and
+  leaves its cycle open forever. The next before-load must clear it, or the first
+  successful commit would apply a failed reload's partial staging.
+
+  Replacing is also LOSSY, and until rf2-84173 it was silent. The `:touched`
+  evidence in particular cannot be recovered: it is reported once, during the
+  load phase, and `note-reloaded-sources!` no-ops once no cycle is open. So the
+  supersession now reports what it discarded.
+
+  Discarding is the RULED reading of the ambiguity, not an oversight. A second
+  before-load has two possible causes and the ledger cannot tell them apart:
+  the common one is an aborted predecessor (discarding is correct); the rare one
+  is a genuinely overlapping activation (discarding loses a live cycle). Keeping
+  the evidence instead would trade the rare loss for a common one — a source that
+  re-ran in the aborted cycle sits in `:touched` with its staging thrown away, so
+  the next commit would EVICT declarations that still exist in the new code and
+  will not re-register. Losing live rows on every failed reload is strictly worse
+  than degrading an overlap that requires an async lifecycle hook to occur at all.
+
+  See `## Overlapping cycles are unsupported` above for why no token can do
+  better here."
+  ([] (notify-reload! (current-build-id)))
+  ([build-id]
+   (when reload-ledger?
+     (let [[old _new] (swap-vals! ledger-state
+                                  assoc-in [::cycles build-id]
+                                  {:staged {} :touched #{}})]
+       ;; Only the transition that actually superseded an EVIDENCE-BEARING cycle
+       ;; reports. A cycle opened twice with nothing staged and nothing touched
+       ;; discarded nothing, so there is nothing to warn about — this tests what
+       ;; was LOST, not merely whether a key was present.
+       (when-let [{:keys [staged touched]} (get (::cycles old) build-id)]
+         (when (or (seq staged) (seq touched))
+           (report-unpaired-cycle! build-id staged touched)))))
+   nil))
+
+(defn note-reloaded-sources!
+  "Record the sources that re-ran (or were removed) in the open reload cycle —
+  the signal a zero-declaration source cannot emit for itself, fed in the shipped
+  browser reload path by `reload-source-reset!` (the SHADOW_NS_RESET producer;
+  rf2-vxgfnd.77). `sources` is a coll of ns-syms, or of [build ns] pairs whose
+  ns is taken and whose build is IGNORED. A no-op when no cycle is open (and, in
+  `:advanced` production, when there is no ledger at all — rf2-k9yuy); unions
+  into the cycle so it can be called repeatedly.
+
+  OWNERSHIP TRAVELS WITH THE ADDRESSED CYCLE, NEVER WITH THE PAYLOAD
+  (rf2-4vm19). Every source is normalized to `[build-id ns]` for the build this
+  call addresses, so the reconciliation a cycle performs is total over its OWN
+  rows and can never reach another build's. A ready-made pair used to be taken
+  verbatim, which let evidence handed to build A's open cycle nominate build B
+  as owner — `commit-reload!` then evicted B's row under a cycle B never took
+  part in. Normalizing rather than rejecting keeps the ergonomic ns-only form
+  the only shape anyone needs while making the pair form merely a more verbose
+  spelling of it: one ownership rule, no second path to reason about, and no
+  caller-facing failure mode for a datum whose ns is perfectly usable."
+  ([sources] (note-reloaded-sources! sources (current-build-id)))
+  ([sources build-id]
+   (when reload-ledger?
+     (swap! ledger-state
+            (fn [st]
+              (if (contains? (::cycles st) build-id)
+                (let [pairs (map (fn [s] [build-id (if (vector? s) (second s) s)])
+                                 sources)]
+                  (update-in st [::cycles build-id :touched] (fnil into #{}) pairs))
+                st))))
+   nil))
+
+(defn ^:dev/after-load commit-reload!
+  "shadow-cljs hot-reload hook (dev only): COMMIT the open reload cycle for
+  `build-id`. The reconciliation AND the cycle close are ONE atomic transition on
+  `ledger-state`: `::sources` is reconciled (staged sources replace their whole
+  contribution; touched-but-unstaged sources are evicted; untouched sources are
+  kept) and the cycle is removed in the SAME swap. Only then is the aggregate
+  published.
+
+  This linearizes the commit against a reentrant registration (rf2-vxgfnd.144).
+  Publishing can synchronously fire a watch on `custom-elements` that calls
+  `register-custom-element!`; by then the cycle is ALREADY gone from
+  `ledger-state`, so that registration write-through's into a new generation and
+  survives, instead of staging into a cycle this commit then discards. The old
+  snapshot-then-`dissoc` shape published while the cycle was still open, so such a
+  registration staged and was dropped by the following `dissoc`.
+
+  shadow-cljs runs after-load only on a SUCCESSFUL reload, so an aborted reload
+  never reaches here and the last known-good manifest survives. A no-op when no
+  cycle is open.
+
+  Because this IS the `^:dev/after-load` hook, whatever escapes it is what shadow
+  reports as the reload's outcome. The authority transition above is already
+  complete when `publish!` runs, so a throwing publication observer must not be
+  able to escape and recast a committed reload as a failed one — `publish!`
+  contains it and reports it instead (rf2-za45g)."
+  ([] (commit-reload! (current-build-id)))
+  ([build-id]
+   (when reload-ledger?
+     (let [[old _new]
+           (swap-vals! ledger-state
+                       (fn [st]
+                         (let [{:keys [sources]} (commit-outcome st build-id)]
+                           (cond
+                             ;; Clean commit: reconcile AND close in one swap.
+                             sources
+                             (-> st
+                                 (assoc ::sources sources)
+                                 (update ::cycles dissoc build-id))
+
+                             ;; CONFLICTING cycle — reject ATOMICALLY. `::sources`
+                             ;; is untouched, so the last-known-good manifest
+                             ;; survives and nothing is partially published; the
+                             ;; cycle is closed and its staging DISCARDED, exactly
+                             ;; as an aborted reload's would be. Leaving it open
+                             ;; instead would wedge the session — every later
+                             ;; registration would stage into a cycle no commit
+                             ;; could ever close.
+                             (contains? (::cycles st) build-id)
+                             (update st ::cycles dissoc build-id)
+
+                             :else st))))]
+       ;; Publish only when THIS commit closed a cycle (the winning transition saw
+       ;; one in `old`). The cycle is gone from the ledger, so a reentrant
+       ;; registration during the publish takes the write-through path — it cannot
+       ;; be recaptured or dropped by this commit. `publish!` recomputes from the
+       ;; LIVE ledger, so a concurrent write-through's row is never clobbered.
+       ;;
+       ;; The outcome is re-derived from the same `old` the winning transition
+       ;; saw, so the raised evidence is the verdict that was actually applied.
+       ;; A rejected commit RAISES: this is the `^:dev/after-load` hook, and the
+       ;; reload genuinely did not commit, so reporting it as failed is the truth
+       ;; (rf2-za45g contains a throwing publication OBSERVER precisely because
+       ;; that case is the opposite — a committed reload being recast as failed).
+       (let [{:keys [conflict]} (commit-outcome old build-id)]
+         (cond
+           conflict (throw-element-conflict! conflict)
+           (contains? (::cycles old) build-id) (publish! build-id)))))
+   nil))
+
+;; ---------------------------------------------------------------------------
+;; The production producer: shadow-cljs's real reload machinery feeds
+;; `note-reloaded-sources!` (rf2-vxgfnd.77)
+;;
+;; The ledger above evicts a source that dropped its last declaration ONLY when
+;; `note-reloaded-sources!` is told the source re-ran. But a source that re-runs
+;; declaring NOTHING emits no code to announce itself — absence cannot
+;; self-report — so the signal cannot come from the emitted
+;; `register-custom-element!` calls (a zero-declaration source emits none). It
+;; must come from the reload machinery, which knows which namespaces re-ran
+;; regardless of what they declared.
+;;
+;; shadow-cljs exposes exactly that seam: its `before-load-src` calls every fn on
+;; `js/goog.global.SHADOW_NS_RESET` with the ns symbol of each source it reloads,
+;; DURING the code-load phase — after the `^:dev/before-load` `notify-reload!`
+;; opened the cycle and before the `^:dev/after-load` `commit-reload!` closes it.
+;; `reload-source-reset!` rides that seam: for every reloaded ns it stages a
+;; `:touched` entry, so `commit-reload!` reconciles the sources that ACTUALLY
+;; re-ran and evicts the stale rows of one that now declares nothing — the exact
+;; runtime analogue of the compile side, where `build/commit-slice` evicts a
+;; source that recompiled contributing nothing.
+;;
+;; Bounded case of THIS producer — and the second producer that closes it: a
+;; source FILE deleted (or renamed away) never re-runs, so `before-load-src`
+;; never announces it and no SHADOW_NS_RESET call can ever carry its ns. The
+;; compile side evicts the deleted source from the COMPILE registry via
+;; authoritative `:build-sources` membership; the runtime arm used to converge
+;; only on the next full page load. `note-reloaded-sources!` was always the seam
+;; an authoritative removed-source manifest would feed if one were wired — and
+;; one now is: `shadow-build-notify` below (rf2-4vm19) receives shadow's own
+;; `:build-complete` broadcast of that same `:build-sources` membership and
+;; reconciles the REMOVED delta through this exact seam. What remains genuinely
+;; unobservable is only the UNSAVED bare REPL deletion (rf2-df9873): no saved
+;; graph, no successful build, nothing to project.
+;;
+;; Dev-only: the whole install is `js/goog.DEBUG`-gated, so `:advanced`
+;; production carries no producer and never references SHADOW_NS_RESET.
+;;
+;; ## Why the installed callback is a TRAMPOLINE (rf2-vxgfnd.145)
+;;
+;; `SHADOW_NS_RESET` holds CALLBACK OBJECTS, and the install is `defonce`d (it
+;; must be: re-running it on every reload of this ns would append a duplicate).
+;; Pushing the `reload-source-reset!` fn OBJECT therefore pinned the object
+;; realized at FIRST load forever: hot-reloading rules.cljc rebinds the var to a
+;; new object, but the array kept calling the old one. That stayed invisible only
+;; while the old object delegated to other rebound vars — any fix to the
+;; callback's OWN coercion, build routing or source filtering silently needed a
+;; full page reload to take effect.
+;;
+;; So what is installed is one stable TRAMPOLINE that resolves the CURRENT
+;; `reload-source-reset!` on every call (the same late-lookup discipline shadow
+;; itself applies to lifecycle fns — it re-resolves `fn-str` off `$CLJS` per
+;; reload "in case it gets reloaded"). The trampoline object is stable, so
+;; `defonce` still guarantees exactly one entry, while the BEHAVIOUR it runs is
+;; always the freshly loaded code.
+;;
+;; The trampoline carries its owning build identity as a TAG, and the install
+;; REPLACES the entry it already owns instead of appending — but what identifies
+;; that entry is OBJECT IDENTITY, never the tag (rf2-ymfix); the tag is provenance
+;; a reader can inspect, not an ownership lever. An entry owned by shadow or
+;; another library is never touched at all. The tag names a build because
+;; `SHADOW_NS_RESET` lives on `goog.global`, which is SHARED across a whole JS
+;; realm: two bundles that each carry their OWN copy of this namespace (the
+;; supported multi-copy topology — see §THE ISOLATION UNIT) put two producers on
+;; that one array, so they must coexist rather than evict each other.
+;;
+;; ## And the INSTALL is self-upgrading too (rf2-mp6fz)
+;;
+;; A trampoline keeps the entry's BEHAVIOUR current. It cannot keep the ENTRY
+;; current — the object's own construction, its captured owner, and the installer
+;; that placed it are all fixed at the moment of installation. While the install
+;; was `defonce`d that moment was the page's first load, forever: a live page
+;; kept whatever entry it had, and the only way to adopt a change to this
+;; machinery was a full reload. The concrete failure that names: an entry
+;; installed before shadow's build-id carrier was consulted captured `::default`,
+;; and the page went on routing every reset to the placeholder owner even once
+;; the real build identity became resolvable.
+;;
+;; So the install runs on EVERY load and retires what this copy already owns
+;; (`owned-producer`). Ownership is OBJECT IDENTITY, never the tag: the tag says
+;; which build an entry claims, identity says this copy put it there, and the two
+;; diverge in exactly the cases that matter — our own entry whose captured tag
+;; has gone stale, and a co-loaded bundle's entry carrying the tag we are leaving
+;; behind. `defonce` moved from the install (where it froze the machinery) to the
+;; ownership record (where surviving the reload is the whole point).
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (defn reload-source-reset!
+     "The per-source action shadow-cljs's reload machinery drives (through
+     `js/goog.global.SHADOW_NS_RESET`) for every namespace it reloads this cycle:
+     record `ns` as a source that re-ran, so `commit-reload!` evicts it when it
+     staged no declaration this cycle. A no-op when no reload cycle is open
+     (initial load / production). `ns` is a CLJS ns symbol; a string is coerced.
+     `build-id` is the build whose producer is calling (the installed trampoline
+     passes its own owner); the 1-arg arity uses the ambient build."
+     ([ns] (reload-source-reset! ns (current-build-id)))
+     ([ns build-id]
+      (note-reloaded-sources! [(cond-> ns (string? ns) symbol)] build-id)
+      nil)))
+
+#?(:cljs
+   (def ^:private producer-tag
+     "The JS property re-frame.freehand stamps on its own `SHADOW_NS_RESET` entry,
+     carrying the owning build id as PROVENANCE: it marks an entry as re-frame.freehand's
+     and names the build that installed it, which diagnostics and tests read to
+     tell this framework's producers from shadow's and other libraries'. It is NOT
+     the ownership lever — a re-install finds its own entry by OBJECT IDENTITY,
+     never by tag, because the same tag can appear on a co-loaded bundle's entry
+     that only identity can distinguish from ours (rf2-ymfix)."
+     "reFrameUiReloadSourceReset"))
+
+#?(:cljs
+   (defonce ^{:private true
+              :doc "The array entry THIS copy of the namespace currently owns, or
+  nil before its first install (and always in `:advanced` production, which
+  installs no producer at all — the atom is gated exactly like `ledger-state`, so
+  no cell is allocated there either).
+
+  `defonce` because it is the one thing that must SURVIVE a hot-reload of this
+  namespace while the install itself deliberately does not (rf2-mp6fz): it is how
+  the freshly loaded installer learns which entry the PREVIOUS generation of this
+  code put on the shared array, so it can retire it instead of appending beside
+  it.
+
+  Identity, not tag, is the ownership proof. A tag says which BUILD an entry
+  claims; only object identity says that THIS copy installed it. The two diverge
+  exactly when migration matters — an entry whose captured tag is now stale is
+  still ours, and a co-loaded bundle's entry carrying the very same tag is not.
+  Retiring by tag would get both of those backwards."}
+     owned-producer
+     (when ^boolean js/goog.DEBUG (atom nil))))
+
+#?(:cljs
+   (defn- make-reload-source-producer
+     "One stable callback object owned by `build-id` that resolves the CURRENT
+     `reload-source-reset!` on every call. `reload-source-reset!` compiles to a
+     namespace-global read, so a hot-reload of rules.cljc — which re-assigns that
+     global — is picked up here without a page refresh."
+     [build-id]
+     (let [f (fn [ns] (reload-source-reset! ns build-id))]
+       (unchecked-set f producer-tag (str build-id))
+       f)))
+
+#?(:cljs
+   (defn install-reload-source-producer!
+     "Wire the runtime reload ledger to shadow-cljs's real reload machinery — the
+     PRODUCER that feeds `note-reloaded-sources!` in the shipped browser reload
+     path (rf2-vxgfnd.77). Installs this build's tagged trampoline on
+     `js/goog.global.SHADOW_NS_RESET` (ensuring the array `||`-style, so it
+     neither clobbers nor is clobbered by shadow's own init), so shadow calls it
+     with each reloaded source's ns from `before-load-src`.
+
+     IDEMPOTENT, and SELF-UPGRADING across a hot reload (rf2-mp6fz). Ownership is
+     OBJECT IDENTITY, with NO tag fallback (rf2-ymfix): it reuses the exact entry
+     this copy already installed — found by identity on the shared array, so the
+     slot is reused even when the build tag that entry captured has since gone
+     stale — and REPLACES it in place. A copy that owns nothing there — a first
+     install, or one whose remembered entry has gone — APPENDS its own; it never
+     adopts an entry by tag, because a same-tagged callback may belong to a
+     co-loaded bundle and only identity can tell the two apart. So repeated
+     installs can neither duplicate this copy's producer nor strand a predecessor
+     still routing to an identity this build no longer resolves, and an entry owned
+     by shadow, another library, or another bundle is never replaced, moved,
+     reordered, or invoked. Dev-only (gated on `js/goog.DEBUG`, elided from
+     `:advanced` production)."
+     []
+     (when ^boolean js/goog.DEBUG
+       (let [arr      (or js/goog.global.SHADOW_NS_RESET #js [])
+             build-id (current-build-id)]
+         (set! (.-SHADOW_NS_RESET js/goog.global) arr)
+         (let [prev @owned-producer
+               ;; OWNERSHIP IS OBJECT IDENTITY, with no tag fallback (rf2-ymfix):
+               ;; locate only the exact entry this copy installed. A same-tagged
+               ;; entry we did not install may belong to a co-loaded bundle, and
+               ;; only identity tells the two apart — so an absent predecessor is
+               ;; NOT authority to replace one.
+               i    (if prev (.indexOf arr prev) -1)
+               f    (make-reload-source-producer build-id)]
+           (if (neg? i)
+             (.push arr f)    ; own nothing on the array → APPEND; never adopt by tag
+             (aset arr i f))  ; replace exactly this copy's own entry, in place
+           (reset! owned-producer f))
+         true))))
+
+;; Install at client load so the shipped reload path has a producer the moment
+;; this ns is present — and re-install on EVERY load, which is what makes the
+;; producer self-upgrading (rf2-mp6fz).
+;;
+;; This deliberately is NOT `defonce`d. The `defonce` existed to stop the
+;; original `.push` from appending a duplicate on each reload; once .145 gave the
+;; entry an owner tag and a replace-in-place install, that job belonged to the
+;; install itself — and the `defonce` had become the thing PINNING the installer,
+;; so no change to it, to the trampoline's construction, or to the owner tag
+;; could reach a page without a full reload. That is the same staleness .145 fixed
+;; one level down, at the level above it: .145 made the entry run current code,
+;; this makes the ENTRY ITSELF current. `owned-producer` carries the ownership
+;; record across the reload boundary that this form no longer needs to.
+#?(:cljs (install-reload-source-producer!))
+
+;; ---------------------------------------------------------------------------
+;; The removed-source producer: shadow's build-lifecycle broadcast feeds the
+;; delta SHADOW_NS_RESET cannot report (rf2-4vm19)
+;;
+;; `reload-source-reset!` above records the sources that RE-RAN. A source whose
+;; file is deleted or renamed away never re-runs — shadow's loader has nothing
+;; to load for it — so no SHADOW_NS_RESET call fires, no `:touched` entry is
+;; recorded, and its committed rows used to survive every hot reload until the
+;; next full page load. The compile side has no such blind spot: its registries
+;; fold over the authoritative `:build-sources` membership at finish, so the
+;; deleted source falls out of the COMPILE registry on the very pass that
+;; removed it. What was missing was the projection of that same authority into
+;; the runtime cycle.
+;;
+;; Shadow itself already delivers it. Every successful watch build broadcasts
+;; `:build-complete` to each connected runtime carrying `:info :sources` — the
+;; per-source image of exactly the `:build-sources` graph the compile hook folds
+;; (`shadow.build/extract-build-info`, sent by the worker on success only). The
+;; pinned client exposes ONE seam for that message: the `:build-notify` receiver
+;; (`shadow.cljs.devtools.client.env/run-custom-notify!` resolves the configured
+;; fn by munged name off `$CLJS` — the same late-lookup discipline shadow applies
+;; to its lifecycle fns). `shadow-build-notify` is that receiver: it diffs THIS
+;; build's committed ledger rows against the broadcast membership and reconciles
+;; the REMOVED namespaces through the existing cycle protocol —
+;; `notify-reload!` -> `note-reloaded-sources!` -> `commit-reload!`, one bounded
+;; removal cycle reusing the same eviction law as every other reload (a touched
+;; source that stages nothing is evicted). No second ledger, no parallel
+;; protocol, no new commit path.
+;;
+;; The wiring is automatic: the re-frame.freehand compile hook injects the
+;; `custom-notify-fn` closure-define pointing here whenever the WATCHED dev
+;; build did not claim shadow's one `:build-notify` seam itself (see
+;; `re-frame.freehand.compiler.build-hook/wire-removed-source-notify`). A build that
+;; DOES claim it keeps it — shadow has exactly one receiver slot — and
+;; removed-source eviction degrades to the pre-existing bound (stale rows until
+;; the next full page load) unless the app's own receiver delegates:
+;; `(re-frame.freehand.rules/shadow-build-notify msg)`.
+;;
+;; Host ordering is deliberately immaterial. The browser client runs the
+;; receiver BEFORE the reload chain settles (source fetches are async); the
+;; node client runs it AFTER the chain committed (imports are synchronous). Both
+;; are the same case here: no cycle is open when the receiver runs, so the
+;; removal cycle opens and commits on its own and shadow's own chain is
+;; untouched. A cycle found OPEN here is a predecessor an aborted load stranded
+;; (shadow skips `^:dev/after-load` when a load task throws); opening the
+;; removal cycle performs exactly the supersession the next before-load would,
+;; with the same loud report (`report-unpaired-cycle!`). Under the unsupported
+;; async-lifecycle overlap (§Overlapping cycles above) the degradation is the
+;; documented one — stale classification until the next full reload.
+;;
+;; Dev-only: the define is injected only into a watched dev build, and the body
+;; folds away with the ledger under `:advanced` (rf2-k9yuy).
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (defn shadow-build-notify
+     "shadow-cljs `:build-notify` receiver (dev only): reconcile this build's
+     committed ledger rows against the successful build's authoritative
+     `:build-sources` membership (`:info :sources` on the `:build-complete`
+     broadcast), evicting the rows of every namespace the saved graph REMOVED.
+     A deleted or renamed-away source never re-runs, so the SHADOW_NS_RESET
+     producer can never report it — this broadcast is the only authority that
+     can, and it is the same membership the compile-side registries fold at
+     finish (rf2-4vm19).
+
+     Wired automatically by the re-frame.freehand compile hook unless the build
+     claims `:devtools {:build-notify …}` itself; an app's own receiver can
+     delegate by calling this with the same `msg`.
+
+     Only `:build-complete` carries an accepted graph; every other notify type
+     (`:build-failure`, `:build-start`, `:build-init`) is ignored, so a failed
+     compile/evaluation leaves the last-known-good ledger untouched and the
+     successful retry's `:build-complete` converges it."
+     [{:keys [type info] :as _msg}]
+     (when reload-ledger?
+       (when (= :build-complete type)
+         (let [build-id (current-build-id)
+               member?  (into #{}
+                              (mapcat (fn [{:keys [ns provides]}]
+                                        (or (seq provides) (when ns [ns]))))
+                              (:sources info))
+               removed  (into []
+                              (keep (fn [[b n]]
+                                      (when (and (= b build-id)
+                                                 (not (member? n)))
+                                        n)))
+                              (keys (::sources @ledger-state)))]
+           (when (seq removed)
+             ;; ONE bounded removal cycle through the existing seam. The removed
+             ;; sources by definition cannot re-register during it, so the
+             ;; commit evicts exactly their rows and touches nothing else; a
+             ;; removal-only reconciliation can never introduce a cross-source
+             ;; contradiction, so this commit never raises.
+             (notify-reload! build-id)
+             (note-reloaded-sources! removed build-id)
+             (commit-reload! build-id)))))
+     nil))
+
+(defn reset-custom-elements!
+  "Test support: clear the runtime custom-element registry, the per-source
+  ledger, and any in-flight reload cycles. In `:advanced` production there is no
+  ledger to clear, so only the aggregate is reset (rf2-k9yuy)."
+  []
+  (reset! custom-elements {})
+  (when reload-ledger?
+    (reset! ledger-state empty-ledger))
+  nil)
+
+(defn in-flight-cycles
+  "Test support: the set of build-ids with a reload cycle currently OPEN. A
+  quiescent ledger has none; a lingering entry after a commit settles is an
+  orphan cycle. Always empty where there is no ledger (`:advanced` production
+  can never open a cycle). Observability only — not a consumer API
+  (classification reads `custom-element-properties`)."
+  []
+  (if reload-ledger?
+    (set (keys (::cycles @ledger-state)))
+    #{}))
+
+(defn ledger-sources
+  "Test support: the runtime SOURCE-MEMBERSHIP graph — the set of `[build-id
+  ns-sym]` the ledger currently holds a committed contribution for. This is the
+  runtime mirror of the compile side's `:build-sources` membership (see
+  `ledger-state`): a saved source that is removed or renamed away drops out of
+  this set the moment its reload cycle is reconciled (`reconcile-sources`
+  evicts a touched-but-unstaged row), a rename swaps the old ns key for the new,
+  and a same-namespace file move keeps its key. Always empty where there is no
+  ledger (`:advanced` production allocates none). Observability only — not a
+  consumer API (classification reads `custom-element-properties`)."
+  []
+  (if reload-ledger?
+    (set (keys (::sources @ledger-state)))
+    #{}))
+
+(defn projected-aggregate
+  "Test support: the aggregate the public `custom-elements` atom MUST equal — the
+  pure projection of the current ledger `::sources`. A settled ledger's published
+  aggregate always equals this; a divergence is a torn or clobbered projection.
+  Where there is no ledger (`:advanced` production) registrations write straight
+  through, so the live aggregate IS the projection. Observability only.
+
+  A ledger holding a contradiction projects to `nil` — a loud divergence from
+  any live aggregate, which is the intended reading: there IS no valid manifest
+  for such a ledger, and the law is that no path invents one."
+  []
+  (if reload-ledger?
+    (:aggregate (aggregate (::sources @ledger-state)))
+    @custom-elements))
+
+(defn custom-element-properties [tag]
+  (get-in @custom-elements [tag :properties] #{}))
+
+;; ---------------------------------------------------------------------------
+;; Semantic attr-value normalization (tree space) — shared with v/spread
+;; ---------------------------------------------------------------------------
+
+(defn attr-val-semantic
+  "Normalize a DYNAMIC attr value into the tree's semantic space
+  (jvm-tree contract §Attr value normalization): keywords/symbols ->
+  `name` (namespace ignored); numbers -> JS ToString; booleans stay
+  booleans; nil -> nil (caller drops); strings verbatim; collections ->
+  typed error (React would render garbage)."
+  [attr-kw v]
+  (cond
+    (nil? v)      nil
+    (string? v)   v
+    (boolean? v)  v
+    (number? v)   (js-number-str v)
+    (keyword? v)  (name v)
+    (symbol? v)   (name v)
+    (coll? v)     (error/throw-error!
+                   :rf.error/ui-tree-malformed 're-frame.freehand/render
+                   (str "collection value for attribute " attr-kw
+                        " — collections are only meaningful for :class/:style"
+                        " (React would render \"[object Object]\" garbage)")
+                   {:extra {:attr attr-kw :value v}})
+    :else         (str v)))
+
+;; ---------------------------------------------------------------------------
+;; v/spread-safe — the literal safe-spread policy (owned-key deny, EVERY build)
+;;
+;; A component library forwards a consumer's runtime attr map onto an internal
+;; element through `(v/spread-safe owned caller)`. `owned` is the component's
+;; LITERAL props (the compiler proves the controlled site and keeps the sync
+;; door); `caller` is the forwarded runtime map. The structural/controlled/
+;; identity keys below, PLUS the component's owned `:on-*` handler keys, are
+;; denied to `caller` in every build — a runtime offender throws here, never
+;; goog.DEBUG-gated, so the guarantee survives an advanced build.
+;; ---------------------------------------------------------------------------
+
+(def spread-safe-denied-structural
+  "The structural / controlled / identity keys a `v/spread-safe` CALLER map
+  may never carry. `:key`/`:ref` are structural identity slots (keys are
+  literal at the site, refs are a reserved React slot); `:value`/`:checked`
+  are the controlled-input contract the sync-door proof depends on. A caller
+  that could set them would clobber owned state, so they are denied in every
+  build (not dev-only). The component's own `:on-*` handler keys JOIN this set
+  per call."
+  #{:key :ref :value :checked})
+
+(defn caller-key-name
+  "The CANONICAL author NAME of a `v/spread-safe` caller key — `(name k)`,
+  the SAME canonicalization both host converters apply (namespace dropped, so
+  `:caller/ref` -> \"ref\", `\"ref\"` -> \"ref\", `'ref` -> \"ref\"). Returns
+  nil when `k` is NOT a nameable attribute key (a keyword, string, or symbol);
+  a non-nameable key is malformed — rejected by `assert-safe-caller!` — not
+  merely 'not denied'. The author NAME drives BOTH the emitted-slot the deny law
+  compares (`caller-key-slot`) and the canonical keyword an accepted key is
+  rewritten to (`(keyword (name k))`), so denial and conversion never diverge."
+  [k]
+  (when (or (keyword? k) (string? k) (symbol? k))
+    (name k)))
+
+(defn caller-key-slot
+  "The React/DOM prop-name SLOT the host converters actually emit a
+  `v/spread-safe` caller key into — the ONE canonicalization the owned-key deny
+  law compares (against the structural slots and the owned handler families),
+  driven by `(name k)` EXACTLY as the converters classify: an author `on-*` name
+  camelizes to its React handler slot (`:on-change` / `\"on-change\"` ->
+  `onChange`); everything else — already-camel handler spellings like
+  `\"onChange\"` / `\"onChangeCapture\"` included — resolves through the
+  react-dom attr table (`react-prop-name`, so `:class` -> `className`). Returns
+  nil for a NON-nameable key (rejected as malformed upstream), never nil for a
+  nameable one. NOT the property-camel slot for a custom-element `:properties`
+  name (that camelization is tag-scoped and irrelevant to the deny, which never
+  targets properties) — this is the deny/structural/handler classification."
+  [k]
+  (when-some [n (caller-key-name k)]
+    (if (str/starts-with? n "on-")
+      (react-event-name n false)
+      (react-prop-name n))))
+
+(def ^:private spread-safe-denied-structural-slots
+  "The canonical emitted SLOTS of the denied structural/controlled keys — the
+  form both host converters reduce a caller key to via `caller-key-slot`. The
+  deny law compares canonical slots, so `:key`/`:ref`/`:value`/`:checked` AND
+  every alternate spelling that resolves to one of those slots (`:caller/ref`,
+  `\"ref\"`, `'ref`) are denied uniformly (rf2-izep3/rf2-xdvob)."
+  (into #{} (keep caller-key-slot) spread-safe-denied-structural))
+
+(defn- owned-handler-slots
+  "The React handler SLOTS an owned `:on-*` family occupies — BOTH the bubble
+  (`onChange`) and capture (`onChangeCapture`) phases, whichever phase the owned
+  handler itself uses. A caller may install NEITHER phase on an owned event, so
+  the deny law reduces every owned handler key to its two-slot family: an
+  already-camel `\"onChange\"`, a capture `\"onChangeCapture\"`, a kebab
+  `on-change-capture`, and every namespaced/string/symbol alias all resolve to a
+  slot in this set (rf2-xdvob)."
+  [owned-handler-keys]
+  (into #{}
+        (mapcat (fn [h]
+                  (when-some [n (caller-key-name h)]
+                    (when (str/starts-with? n "on-")
+                      [(react-event-name n false)
+                       (react-event-name n true)]))))
+        owned-handler-keys))
+
+(defn spread-safe-denied-key?
+  "Is caller key `k` denied to a `v/spread-safe` caller map, given the
+  component's `owned-handler-keys` (the literal `:on-*` keys of its owned map)?
+  Compares the caller key's canonical emitted SLOT (`caller-key-slot`) against
+  the denied structural/controlled slots and the owned handler FAMILY slots
+  (bubble + capture), so an alternate spelling — kebab, already-camel
+  (`\"onChange\"` / `\"onChangeCapture\"`), string, symbol, or namespaced — that
+  emits into an owned/structural slot cannot bypass the law (rf2-xdvob). A
+  non-nameable key is not 'denied' here (it is rejected as malformed by
+  `assert-safe-caller!`); returns false so the literal/compile-time path reports
+  it through its own channel."
+  [k owned-handler-keys]
+  (boolean
+   (when-some [slot (caller-key-slot k)]
+     (or (contains? spread-safe-denied-structural-slots slot)
+         (contains? (owned-handler-slots owned-handler-keys) slot)))))
+
+(defn- spread-safe-denial-reason [slot owned-slots]
+  (cond
+    (= "key" slot)                        "a structural identity slot (keys are literal at the site)"
+    (= "ref" slot)                        "a reserved React ref slot"
+    (contains? #{"value" "checked"} slot) "the controlled-input contract the sync door proves"
+    (contains? owned-slots slot)          "an owned event handler the component controls"
+    :else                                 "owned by the component"))
+
+(defn assert-safe-caller!
+  "EVERY-BUILD guard + canonicalizer for `(v/spread-safe owned caller)`. The
+  `caller` must be an author-space attr MAP (or nil = empty); each key must be a
+  nameable attribute key; then its canonical emitted SLOT (`caller-key-slot`) is
+  compared against the denied structural/controlled slots and the owned handler
+  FAMILY slots (bubble + capture). Alternate spellings — kebab, already-camel
+  (`\"onChange\"` / `\"onChangeCapture\"`), a namespaced keyword, string, or
+  symbol — that resolve to an owned/structural slot are therefore denied
+  uniformly, and a non-map caller (e.g. a sequence of pairs) or a non-nameable
+  key can no longer slip through. A non-map caller, a non-nameable key, or a
+  denied key throws `:rf.error/ui-tree-malformed`, consistently on BOTH hosts.
+  NOT `goog.DEBUG`-gated — the denial is a production invariant a component
+  library relies on, so it survives an advanced build.
+
+  Returns the CANONICALIZED caller map: every ACCEPTED key is rewritten to its
+  author-canonical keyword (`(keyword (name k))`), so an alternate spelling lands
+  in the SAME emitted slot as the literal author keyword and the emitted prop set
+  matches the classification on BOTH hosts — a caller `:ns/class`/`\"class\"`
+  routes through `:class` composition, and a caller ordinary key dedupes against
+  an owned collision by the same identity (rf2-xdvob). A nil caller returns nil."
+  [caller owned-handler-keys]
+  (if (nil? caller)
+    nil
+    (do
+      (when-not (map? caller)
+        (error/throw-error!
+         :rf.error/ui-tree-malformed 're-frame.freehand/spread-safe
+         (str "(v/spread-safe owned caller) — the caller must be an author-space "
+              "attr MAP (or nil), not a " (name (:type (error/diag-value-summary caller)))
+              ". A non-map caller (e.g. a sequence of pairs) cannot be canonicalized "
+              "and checked against the owned-key deny law; pass a map literal or a "
+              "map-valued expression")
+         {:extra {:caller (error/diag-value-summary caller)}}))
+      (let [owned-slots (owned-handler-slots owned-handler-keys)]
+        (reduce-kv
+         (fn [acc k v]
+           (let [slot (caller-key-slot k)]
+             (cond
+               (nil? slot)
+               (error/throw-error!
+                :rf.error/ui-tree-malformed 're-frame.freehand/spread-safe
+                (str "(v/spread-safe owned caller) — the caller attr key " (pr-str k)
+                     " is not a nameable attribute key (a keyword, string, or symbol), "
+                     "so it has no canonical DOM/React name to check against the "
+                     "owned-key deny law. Use a keyword attr key")
+                {:extra {:key k}})
+
+               (or (contains? spread-safe-denied-structural-slots slot)
+                   (contains? owned-slots slot))
+               (error/throw-error!
+                :rf.error/ui-tree-malformed 're-frame.freehand/spread-safe
+                (str "(v/spread-safe owned caller) — the caller attr map may not "
+                     "carry " (pr-str k) ": it is "
+                     (spread-safe-denial-reason slot owned-slots)
+                     ", denied in every build so it can never clobber an owned prop "
+                     "(an alternate spelling — kebab, already-camel, a namespaced "
+                     "keyword, string, or symbol — canonicalizes to the same slot and "
+                     "is denied too). Forward it through the visible-cost (v/spread "
+                     "base overrides) instead, or drop it from the caller map")
+                {:extra {:key k}})
+
+               :else
+               (assoc acc (keyword (caller-key-name k)) v))))
+         {} caller)))))
+
+;; ---------------------------------------------------------------------------
+;; v/spread + v/spread-safe — the RUNTIME rejected-spelling deny (EVERY build)
+;;
+;; `rejected-prop-spellings` ("one spelling per name, and it is a node variant")
+;; is enforced on LITERAL props by the analyzer (`check-rejected-spelling!`),
+;; which cannot see a prop map assembled at RUNTIME. A `(v/spread base
+;; overrides)` map therefore reached the host converters unchecked, and
+;; `react-prop-name` passes an unrecognized name VERBATIM — so
+;; `{:dangerouslySetInnerHTML #js {:__html s}}` landed in React's raw-markup
+;; slot with NO visible `(v/html …)` trust assertion anywhere in the source
+;; (rf2-5pr75). The deny below closes that at the ONE runtime seam both hosts
+;; fold a spread map through (`runtime/convert-prop-map!` on CLJS,
+;; `tree/fold-dyn-entry` on the JVM), so `v/spread` and the `v/spread-safe`
+;; caller map are covered together.
+;; ---------------------------------------------------------------------------
+
+(def ^:private rejected-prop-slots
+  "`rejected-prop-spellings` reduced to the canonical emitted SLOTS the host
+  converters actually write into (`caller-key-slot` — the same rf2-xdvob
+  canonicalization the spread-safe owned-key deny compares), each mapped to the
+  didactic replacement its compile error names.
+
+  Comparing SLOTS rather than literal keywords is what makes the deny TOTAL for
+  the one spelling that carries a trust boundary: every alias of React's
+  raw-markup prop — `\"dangerouslySetInnerHTML\"`, `'dangerouslySetInnerHTML`,
+  the namespaced `:x/dangerouslySetInnerHTML` — reduces to the SAME slot and is
+  denied, while a spelling that reduces to any OTHER slot (`:dangerouslysetinnerhtml`)
+  cannot reach React's slot at all and needs no deny. No legitimate prop
+  collides: `:class` slots to `className` and `:for` to `htmlFor`, distinct from
+  the rejected `:class-name` / `:html-for`."
+  (into {}
+        (keep (fn [[k replacement]]
+                (when-some [slot (caller-key-slot k)] [slot replacement])))
+        rejected-prop-spellings))
+
+(defn spread-rejected-key?
+  "Is runtime prop key `k` a rejected spelling — the runtime twin of the
+  analyzer's literal `check-rejected-spelling!`? Compares `k`'s canonical
+  emitted slot, so every alias reaches the same verdict on both hosts. A
+  non-nameable key has no slot and is not 'rejected' here (the converters
+  report it through their own channel)."
+  [k]
+  (contains? rejected-prop-slots (caller-key-slot k)))
+
+(defn assert-spread-prop-key!
+  "EVERY-BUILD deny for ONE prop key arriving through a RUNTIME prop map — a
+  `(v/spread base overrides)` map or a `(v/spread-safe owned caller)` caller
+  map. A rejected spelling throws `:rf.error/ui-tree-malformed`, NOT
+  `goog.DEBUG`-gated, so an `:advanced` production build is exactly as safe as
+  dev — the same production-reachability the sibling `assert-safe-caller!`
+  owned-key deny has, and the only defensible choice for a key whose whole
+  meaning is 'bypass HTML escaping'.
+
+  The key is denied on PRESENCE, value irrelevant: `rejected-prop-spellings`
+  rejects the NAME, so a nil value is still an illegal spelling, and a
+  value-dependent guard would be a trust check with a hole in it.
+
+  DENY, not silently drop. Dropping would be fail-safe against injection but
+  invisible twice over: an author who MEANT raw markup would ship a silently
+  empty element, and an author who did NOT would never learn their forwarded
+  prop map carries a smuggled key. The message names the escape — `(v/html …)`,
+  the visible trust assertion — exactly as the compile error does.
+
+  `re-frame.freehand` sanitises NOTHING: the fix is not to clean the markup but to
+  require it be asserted at a visible site."
+  [k]
+  (when-some [replacement (get rejected-prop-slots (caller-key-slot k))]
+    (error/throw-error!
+     :rf.error/ui-tree-malformed 're-frame.freehand/spread
+     (str "a runtime spread prop map may not carry " (pr-str k)
+          ": it is not a prop — one spelling per name, ambiguities removed — and "
+          "the rule holds for a map assembled at RUNTIME exactly as it does for "
+          "literal props, which the compiler checks and this map it cannot see. "
+          "Use " replacement ". An alternate spelling (kebab, already-camel, a "
+          "namespaced keyword, string, or symbol) canonicalizes to the same "
+          "emitted slot and is denied too, so raw markup can never reach the DOM "
+          "without the visible (v/html ...) trust assertion at the site")
+     {:extra {:key k}})))

--- a/implementation/freehand/src/re_frame/freehand/rules.cljc
+++ b/implementation/freehand/src/re_frame/freehand/rules.cljc
@@ -1736,8 +1736,13 @@
      tell this framework's producers from shadow's and other libraries'. It is NOT
      the ownership lever — a re-install finds its own entry by OBJECT IDENTITY,
      never by tag, because the same tag can appear on a co-loaded bundle's entry
-     that only identity can distinguish from ours (rf2-ymfix)."
-     "reFrameUiReloadSourceReset"))
+     that only identity can distinguish from ours (rf2-ymfix).
+
+     The tag names the FRAMEWORK COPY, so the absorbed table carries its own
+     spelling: during coexistence the donor's copy and this one are both
+     loadable in one JS realm, and a shared tag would make each copy's
+     producer count the other's."
+     "reFrameFreehandReloadSourceReset"))
 
 #?(:cljs
    (defonce ^{:private true

--- a/implementation/freehand/test/re_frame/freehand/a11y_diagnostics_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/a11y_diagnostics_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.ui.a11y-diagnostics-cljs-test
+(ns re-frame.freehand.a11y-diagnostics-cljs-test
   "The S4-C compile-tier a11y roster (rf2-74vlo; Spec 004 §Compile-tier
   warnings) — host-shared, pure-analyzer.
 
@@ -15,9 +15,9 @@
   loud compile error `:rf.ui.compile/bad-suppress` rather than a silent no-op."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.ui.compiler.a11y :as a11y]
-            [re-frame.ui.compiler.analyze :as ana]
-            [re-frame.ui.compiler.env :as env]))
+            [re-frame.freehand.compiler.a11y :as a11y]
+            [re-frame.freehand.compiler.analyze :as ana]
+            [re-frame.freehand.compiler.env :as env]))
 
 ;; ---------------------------------------------------------------------------
 ;; Injected environment (identical to the frozen-roster suite's)
@@ -25,13 +25,13 @@
 
 (defn- resolver [sym]
   (case sym
-    sub         {:fqn 're-frame.ui/sub :meta {}}
-    spread      {:fqn 're-frame.ui/spread :meta {}}
-    spread-safe {:fqn 're-frame.ui/spread-safe :meta {}}
-    event       {:fqn 're-frame.ui/event :meta {}}
-    handler     {:fqn 're-frame.ui/handler :meta {}}
-    html        {:fqn 're-frame.ui/html :meta {}}
-    presence    {:fqn 're-frame.ui/presence :meta {}}
+    sub         {:fqn 're-frame.freehand/sub :meta {}}
+    spread      {:fqn 're-frame.freehand/spread :meta {}}
+    spread-safe {:fqn 're-frame.freehand/spread-safe :meta {}}
+    event       {:fqn 're-frame.freehand/event :meta {}}
+    handler     {:fqn 're-frame.freehand/handler :meta {}}
+    html        {:fqn 're-frame.freehand/html :meta {}}
+    presence    {:fqn 're-frame.freehand/presence :meta {}}
     child-view  {:fqn 'app.views/child-view
                  :meta {:rf.ui/view true :rf.ui/children? true}}
     ForeignComp {:fqn 'app.interop/ForeignComp :meta {}}
@@ -233,7 +233,7 @@
 ;;
 ;; rf2-0ufty ruled presence DOM-agnostic and timeout-only: the framework stamps
 ;; NO inert/aria-hidden, and the child owns its exit accessibility by reading
-;; (ui/presence-phase). This check is not a style opinion — it fires on the one
+;; (v/presence-phase). This check is not a style opinion — it fires on the one
 ;; shape where that author remedy is STRUCTURALLY unavailable: inline literal
 ;; markup, whose props evaluate in the parent's render, outside the per-child
 ;; phase Provider.
@@ -246,7 +246,7 @@
                      (for [t toasts]
                        [:div {:key (:id t)}
                         [:button {:on-click [:toast/dismiss]} "Dismiss"]]))
-          "(ui/presence-phase) = :unmounting" "keyed child view")
+          "(v/presence-phase) = :unmounting" "keyed child view")
   (testing "an explicitly focusable generic element counts too"
     (is (= [exit-interactive]
            (ids '(presence {:timeout-ms 300}
@@ -255,7 +255,7 @@
 
 (deftest presence-exit-interactive-is-silent-when-the-child-can-remedy-it
   ;; THE headline bound: Spec 004's own presence example must stay silent.
-  (silent! "a child VIEW reads its own (ui/presence-phase) and stamps inert"
+  (silent! "a child VIEW reads its own (v/presence-phase) and stamps inert"
            '(presence {:timeout-ms 300}
                       (for [t toasts] [child-view {:key (:id t) :toast t}])))
   (silent! "a foreign component owns its own exit behaviour"

--- a/implementation/freehand/test/re_frame/freehand/analyze_accept_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/analyze_accept_cljs_test.cljc
@@ -1,39 +1,39 @@
-(ns re-frame.ui.analyze-accept-cljs-test
+(ns re-frame.freehand.analyze-accept-cljs-test
   "Template-grammar ACCEPT table: the blessed forms lower into the closed
   AST node set, on both hosts (the analyzer is pure — resolution is
   injected, so this suite runs identically under `clojure -M:test` and
-  `npm run test:ui`). Also pins the AST-shape gate (closed op set) and
+  `npm run test:freehand`). Also pins the AST-shape gate (closed op set) and
   the serialisation boundary (AST print/read round-trip)."
   (:require [clojure.test :refer [deftest is testing]]
             #?(:clj [clojure.edn :as edn] :cljs [cljs.reader :as edn])
-            [re-frame.ui.compiler.analyze :as ana]
-            [re-frame.ui.compiler.env :as env]
-            [re-frame.ui.fingerprint :as fingerprint]))
+            [re-frame.freehand.compiler.analyze :as ana]
+            [re-frame.freehand.compiler.env :as env]
+            [re-frame.freehand.fingerprint :as fingerprint]))
 
 (def resolver
   "Injected Q5 resolution stub — fqn + var meta per symbol."
   (fn [sym]
     (case sym
       map         {:fqn 'clojure.core/map :meta {}}
-      sub         {:fqn 're-frame.ui/sub :meta {}}
-      frame       {:fqn 're-frame.ui/frame :meta {}}
+      sub         {:fqn 're-frame.freehand/sub :meta {}}
+      frame       {:fqn 're-frame.freehand/frame :meta {}}
       ;; aliased + fully-qualified spellings resolve to the same vars
       ;; (rf2-vxgfnd.266 head reservation must key on the fqn, not the spelling)
-      ui/sub            {:fqn 're-frame.ui/sub :meta {}}
-      ui/frame          {:fqn 're-frame.ui/frame :meta {}}
-      re-frame.ui/sub   {:fqn 're-frame.ui/sub :meta {}}
-      re-frame.ui/frame {:fqn 're-frame.ui/frame :meta {}}
-      raw         {:fqn 're-frame.ui/raw :meta {}}
-      html        {:fqn 're-frame.ui/html :meta {}}
-      raw-fn      {:fqn 're-frame.ui/raw-fn :meta {}}
-      spread      {:fqn 're-frame.ui/spread :meta {}}
-      spread-safe {:fqn 're-frame.ui/spread-safe :meta {}}
-      event       {:fqn 're-frame.ui/event :meta {}}
-      handler     {:fqn 're-frame.ui/handler :meta {}}
-      render-fn   {:fqn 're-frame.ui/render-fn :meta {}}
-      slot        {:fqn 're-frame.ui/slot :meta {}}
-      error-boundary {:fqn 're-frame.ui/error-boundary :meta {}}
-      client-only    {:fqn 're-frame.ui/client-only :meta {}}
+      v/sub            {:fqn 're-frame.freehand/sub :meta {}}
+      v/frame          {:fqn 're-frame.freehand/frame :meta {}}
+      re-frame.freehand/sub   {:fqn 're-frame.freehand/sub :meta {}}
+      re-frame.freehand/frame {:fqn 're-frame.freehand/frame :meta {}}
+      raw         {:fqn 're-frame.freehand/raw :meta {}}
+      html        {:fqn 're-frame.freehand/html :meta {}}
+      raw-fn      {:fqn 're-frame.freehand/raw-fn :meta {}}
+      spread      {:fqn 're-frame.freehand/spread :meta {}}
+      spread-safe {:fqn 're-frame.freehand/spread-safe :meta {}}
+      event       {:fqn 're-frame.freehand/event :meta {}}
+      handler     {:fqn 're-frame.freehand/handler :meta {}}
+      render-fn   {:fqn 're-frame.freehand/render-fn :meta {}}
+      slot        {:fqn 're-frame.freehand/slot :meta {}}
+      error-boundary {:fqn 're-frame.freehand/error-boundary :meta {}}
+      client-only    {:fqn 're-frame.freehand/client-only :meta {}}
       ..          {:fqn 'clojure.core/.. :meta {:macro true}}
       ;; The if-let binder family (rf2-u53yy.4) — admission is RESOLVER-confirmed,
       ;; so every member resolves to its core var, and a fully-qualified spelling
@@ -44,7 +44,7 @@
       when-some   {:fqn 'clojure.core/when-some :meta {:macro true}}
       clojure.core/if-some {:fqn 'clojure.core/if-some :meta {:macro true}}
       ->          {:fqn 'clojure.core/-> :meta {:macro true}}
-      frame-provider {:fqn 're-frame.ui/frame-provider :meta {}}
+      frame-provider {:fqn 're-frame.freehand/frame-provider :meta {}}
       child-view  {:fqn 'app.views/child-view
                    :meta {:rf.ui/view true :rf.ui/children? true}}
       leaf-view   {:fqn 'app.views/leaf-view
@@ -278,11 +278,11 @@
   (let [el (ana* '[:input {:on-input (event [e] [:form/typed (.. e -target -value)])}])
         h  (first (get-in el [:props :events]))]
     (is (= :ui-event (:classification h))
-        "a ui/event handler is its own compiler-known committed-callback class")
+        "a v/event handler is its own compiler-known committed-callback class")
     (is (false? (:serializable? h)))
     (is (false? (:hoistable? h)))
     (is (= 'fn (first (:form h)))
-        "the ui/event body lowers to a fn the runtime calls with the native event"))
+        "the v/event body lowers to a fn the runtime calls with the native event"))
   (let [el (ana* '[:button {:on-click (if a [:x/a] [:x/b])} "x"])]
     (is (= :dynamic (:classification (first (get-in el [:props :events]))))))
   (let [{:keys [ast sites]}
@@ -292,7 +292,7 @@
         "dynamic handler classification runs at render, so its sub is finite")))
 
 ;; ---------------------------------------------------------------------------
-;; S3 explicit callback boundaries (rf2-vxgfnd.95.3) — ui/handler, and the
+;; S3 explicit callback boundaries (rf2-vxgfnd.95.3) — v/handler, and the
 ;; committed callbacks + C-13a opaque fn-props at component seams
 ;; ---------------------------------------------------------------------------
 
@@ -300,15 +300,15 @@
   (let [el (ana* '[:button {:on-click (handler [e] (.preventDefault e))} "x"])
         h  (first (get-in el [:props :events]))]
     (is (= :handler (:classification h))
-        "ui/handler — the explicit imperative committed callback (bare-fn shorthand)")
+        "v/handler — the explicit imperative committed callback (bare-fn shorthand)")
     (is (false? (:serializable? h)))
     (is (= 'fn (first (:form h)))
         "the body lowers to a fn the runtime calls with the native event"))
-  ;; ui/handler is NOT a controlled-input sync-door class (imperative, not a vector)
+  ;; v/handler is NOT a controlled-input sync-door class (imperative, not a vector)
   (let [el (ana* '[:input {:value v :on-input (handler [e] (do-something e))}])
         h  (first (get-in el [:props :events]))]
     (is (= :handler (:classification h)))
-    (is (not (:sync? h)) "an imperative ui/handler never rides the sync door")))
+    (is (not (:sync? h)) "an imperative v/handler never rides the sync door")))
 
 (deftest c13a-internal-fn-props-are-legal-opaque-values
   (testing "a bare fn between INTERNAL views is a legal opaque value (marker nil)"
@@ -320,31 +320,31 @@
                  (ana* '[ForeignComp {:cb (fn [x] x)}])))))
 
 (deftest committed-callbacks-at-component-seams
-  (testing "ui/event at a foreign prop is a committed event callback"
+  (testing "v/event at a foreign prop is a committed event callback"
     (let [{:keys [ast sites]}
           (ana-full '[ForeignComp {:on-select (event [e] [:sel/pick e])}])
           en (first (get-in ast [:props :entries]))]
       (is (= :ui-event (:marker en)))
       (is (= 'fn (first (:callback-fn en))) "the body lowers to a fn")
       (is (= 1 (count (:events sites))) "it records an event site")))
-  (testing "ui/handler at a foreign prop is an imperative committed callback"
+  (testing "v/handler at a foreign prop is an imperative committed callback"
     (let [en (first (get-in (ana* '[ForeignComp {:on-open (handler [a b] (do-it a b))}])
                             [:props :entries]))]
       (is (= :handler (:marker en)))
       (is (= '[a b] (second (:callback-fn en))) "the full fixed arg list binds through")))
-  (testing "ui/event / ui/handler are equally legal at an INTERNAL-view seam"
+  (testing "v/event / v/handler are equally legal at an INTERNAL-view seam"
     (let [en (first (get-in (ana* '[child-view {:cb (handler [x] (use-it x))}])
                             [:props :entries]))]
       (is (= :handler (:marker en))
           "a per-site stable identity at an internal-view seam (C-13a)")))
-  (testing "ui/event at a foreign prop capturing a loop binding is rejected"
+  (testing "v/event at a foreign prop capturing a loop binding is rejected"
     (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
                  (ana* '(for [row rows]
                           [ForeignComp {:key (:id row)
                                         :on-select (event [e] [:pick (:id row)])}]))))))
 
 ;; ---------------------------------------------------------------------------
-;; ui/spread at a FOREIGN component call site (rf2-u53yy.5)
+;; v/spread at a FOREIGN component call site (rf2-u53yy.5)
 ;; ---------------------------------------------------------------------------
 
 (deftest foreign-spread-admits-literal-part-plus-opaque-forwarded-map
@@ -363,7 +363,7 @@
           "the literal part's keys are analysed as ordinary call-site props")
       (is (= :handler (:marker (some #(when (= :on-change (:k %)) %)
                                      (get-in ast [:props :entries]))))
-          "a ui/handler in the literal part compiles to a committed callback")
+          "a v/handler in the literal part compiles to a committed callback")
       (is (some #(= :spread (:classification %)) (:events sites))
           (str "the forwarded map records ONE opaque :spread event site — "
                "the manifest marks the call site :dynamic"))))
@@ -393,7 +393,7 @@
                  (ana* '[ForeignComp (spread {:on-select (fn [x] x)} m)])))))
 
 ;; ---------------------------------------------------------------------------
-;; ui/error-boundary + ui/client-only (rf2-vxgfnd.95.3)
+;; v/error-boundary + v/client-only (rf2-vxgfnd.95.3)
 ;; ---------------------------------------------------------------------------
 
 (deftest error-boundary-lowers
@@ -433,13 +433,13 @@
         "a reactive read in the fallback would tear on hydration")))
 
 (deftest deferred-callback-bodies-accept-opaque-host-macros
-  ;; A deferred callback (ui/event / bare fn) is opaque host code: interop and
+  ;; A deferred callback (v/event / bare fn) is opaque host code: interop and
   ;; other non-admitted macros (.. , doto, …) that a RENDER body rejects pass
   ;; through here verbatim, because sub/frame — the only things lexical analysis
-  ;; protects — are already illegal in deferred scope. The canonical ui/event
+  ;; protects — are already illegal in deferred scope. The canonical v/event
   ;; payload `(.. e -target -value)` therefore compiles. (The admitted if-let
   ;; family is analyzed, not passed through — see the admitted-family deftest.)
-  (testing "a ui/event body keeps its interop macro verbatim"
+  (testing "a v/event body keeps its interop macro verbatim"
     (let [el (ana* '[:input {:on-input
                              (event [e] (conj on-value (.. e -target -value)))}])
           h  (first (get-in el [:props :events]))]
@@ -504,7 +504,7 @@
                    [:div {:title (when-some [x (sub [:q])] x)}]]]
       (let [{:keys [ast sites]} (ana-full form)]
         (is (= 1 (count (:subs sites))) (str "prop-value init lowers one site: " form))
-        (is (re-find #"re-frame.ui.reactive/sub-read" (pr-str ast))
+        (is (re-find #"re-frame.freehand.reactive/sub-read" (pr-str ast))
             (str "the lowered runtime site is present: " form)))))
   (testing "the binding pattern is still host-consumed — a reactive escape rejects"
     (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
@@ -579,7 +579,7 @@
     (is (true? (-> (ana* '[:input {:checked checked?
                                     :on-before-input [:form/check]}])
                    (get-in [:props :events 0 :sync?])))))
-  (testing "a synchronous ui/event body rides the same door as a literal vector"
+  (testing "a synchronous v/event body rides the same door as a literal vector"
     ;; The widening (readiness P0-2): the site proof stays static (literal
     ;; controlled prop co-present); the appended prefix/payload stay runtime.
     (let [{:keys [ast warnings]}
@@ -588,13 +588,13 @@
                                           (conj on-value (.. e -target -value)))}])]
       (is (= :ui-event (get-in ast [:props :events 0 :classification])))
       (is (true? (get-in ast [:props :events 0 :sync?]))
-          "a controlled ui/event site opens the one sync door")
+          "a controlled v/event site opens the one sync door")
       (is (empty? warnings)
-          "a proven ui/event door emits no async-handler fallback warning"))
+          "a proven v/event door emits no async-handler fallback warning"))
     (is (true? (-> (ana* '[:input {:checked checked?
                                    :on-change (event [e] [:prefs/set (.. e -target -checked)])}])
                    (get-in [:props :events 0 :sync?])))))
-  (testing "an uncontrolled ui/event site simply batches, with no diagnostic"
+  (testing "an uncontrolled v/event site simply batches, with no diagnostic"
     (let [{:keys [ast warnings]}
           (ana-full '[:input {:on-input (event [e] [:log (.. e -target -value)])}])]
       (is (= :ui-event (get-in ast [:props :events 0 :classification])))
@@ -612,14 +612,14 @@
           "a fallback site names the exact conditions it failed to prove")
       ;; rf2-r0775 — the recovery guidance must name BOTH sync-door forms
       ;; (#{:vector :ui-event} per controlled-event-sync?): a literal event
-      ;; vector OR a (ui/event …) handler. A reusable control that needs the
+      ;; vector OR a (v/event …) handler. A reusable control that needs the
       ;; native payload may not be expressible as a literal vector, so the
       ;; diagnostic must not prescribe only the vector door.
       (let [msg (:msg (first warnings))]
         (is (re-find #"literal event vector" msg)
             "the diagnostic still names the literal-event-vector door")
-        (is (re-find #"ui/event" msg)
-            "the diagnostic ALSO names the (ui/event …) door")))
+        (is (re-find #"v/event" msg)
+            "the diagnostic ALSO names the (v/event …) door")))
     (testing "a bare fn at a controlled site still batches with the diagnostic"
       (let [{:keys [ast warnings]}
             (ana-full '[:input {:value value :on-input (fn [e] (js/console.log e))}])]
@@ -639,7 +639,7 @@
   ;; so the function/callee position is an ordinary evaluated expression that can
   ;; host a finite render-time (sub …). It must be rewritten + indexed under a
   ;; stable :callee token, never preserved verbatim with an empty manifest (which
-  ;; leaves a public ui/sub as an unlowered call at runtime).
+  ;; leaves a public v/sub as an unlowered call at runtime).
   (testing "an (if …) computed callee with one sub → exactly one indexed site"
     (let [{:keys [sites]} (ana-full '[:div {:title ((if (sub [:op]) inc dec) 1)}])
           site (first (:subs sites))]
@@ -774,7 +774,7 @@
     (let [{:keys [sites]}
           (ana-full '[:div {:title (let [{:keys [sub f] :or {f (sub :fallback)}} m] f)}])]
       (is (empty? (:subs sites))
-          "(sub :fallback) calls the earlier local sub, never re-frame.ui/sub")))
+          "(sub :fallback) calls the earlier local sub, never re-frame.freehand/sub")))
   (testing "an explicit lookup key referencing an earlier-bound local (no site)"
     (let [{:keys [sites]}
           (ana-full '[:div {:title (let [{sub :s x sub} m] x)}])]
@@ -811,7 +811,7 @@
         "site id is projected out, but the semantic query remains")))
 
 (deftest quoted-runtime-sub-lookalikes-are-fingerprint-opaque
-  (let [runtime  're-frame.ui.reactive/sub-read
+  (let [runtime  're-frame.freehand.reactive/sub-read
         quoted   (with-meta
                    (list 'quote (list runtime :quoted/sid [:quoted/query]))
                    {:line 17 :column 9})
@@ -846,7 +846,7 @@
          no bare preorder ordinal can transfer A's ownership to inserted B")))
 
 (deftest lexical-shadowing-never-mints-a-reactive-site
-  (testing "a local named sub is an ordinary call, not re-frame.ui/sub"
+  (testing "a local named sub is an ordinary call, not re-frame.freehand/sub"
     (let [{:keys [ast sites]}
           (ana-full '[:div {:title (let [sub identity] (sub query))}])]
       (is (empty? (:subs sites)))
@@ -874,7 +874,7 @@
           (ana-full '(let [{:keys [frame dispatch]} (frame)]
                        [:div.bridge (str frame)]))]
       (is (= :let (:op ast)))
-      (is (= '(re-frame.ui.frames/frame-ops)
+      (is (= '(re-frame.freehand.frames/frame-ops)
              (second (:bindings ast)))
           "the zero-arg call lowers to the internal frame-ops bridge")
       (is (= 1 (count (:frame-ops sites)))
@@ -884,7 +884,7 @@
   (testing "an expression-position read lowers too"
     (let [{:keys [ast sites]}
           (ana-full '[:div {:data-frame (:frame (frame))} "x"])]
-      (is (= '(:frame (re-frame.ui.frames/frame-ops))
+      (is (= '(:frame (re-frame.freehand.frames/frame-ops))
              (get-in ast [:props :attrs 0 :value])))
       (is (= 1 (count (:frame-ops sites))))))
   (testing "two sites are two manifest rows with distinct sids"
@@ -894,7 +894,7 @@
       (is (= 2 (count (distinct (map :sid (:frame-ops sites)))))))))
 
 (deftest frame-shadowing-never-mints-a-frame-site
-  (testing "a local named frame is an ordinary call, not re-frame.ui/frame"
+  (testing "a local named frame is an ordinary call, not re-frame.freehand/frame"
     (let [{:keys [ast sites]}
           (ana-full '[:div {:title (let [frame identity] (frame))}])]
       (is (empty? (:frame-ops sites)))
@@ -907,7 +907,7 @@
           "exactly the init call is a site; the bound local is a plain symbol"))))
 
 (deftest html-sites-index
-  (testing "ui/html records a manifest site — the profile row's 'manifest
+  (testing "v/html records a manifest site — the profile row's 'manifest
   site recording' sub-assertion: every visible escaping bypass is listed with
   its source/template path and serialisability flag"
     (let [{:keys [sites]} (ana-full '[:div
@@ -934,12 +934,12 @@
   (is (= :raw (:op (ana* '(raw some-element)))))
   (let [el (ana* '[:div.content (html "<b>x</b>")])]
     (is (= :element (:op el)))
-    (is (= "<b>x</b>" (get-in el [:html :form])) "sole-child ui/html rides the element"))
+    (is (= "<b>x</b>" (get-in el [:html :form])) "sole-child v/html rides the element"))
   (let [el (ana* '[:div (spread base {:class "x"})])]
     (is (some? (get-in el [:props :spread])))))
 
 ;; ---------------------------------------------------------------------------
-;; ui/spread-safe — the literal safe-spread policy (S3, rf2-isdqjv)
+;; v/spread-safe — the literal safe-spread policy (S3, rf2-isdqjv)
 ;; ---------------------------------------------------------------------------
 
 (deftest spread-safe-lowers-owned-props-plus-guarded-caller
@@ -969,7 +969,7 @@
           "no compiled per-site handler — the site is opaque")
       (is (not (true? (get-in el [:props :spread :sync?])))
           "a general spread never opens the sync door")))
-  (testing "a ui/event owned handler also keeps the door under the policy form"
+  (testing "a v/event owned handler also keeps the door under the policy form"
     (let [el (ana* '[:input (spread-safe {:checked c
                                           :on-change (event [e] [:set (.. e -target -checked)])}
                                          attr)])]
@@ -999,7 +999,7 @@
 
 (deftest raw-and-raw-fn-props-mark
   (let [v (ana* '[ForeignComp {:el (raw host-el) :cb (raw-fn f)}])]
-    (is (= [:foreign :ui/raw-fn]
+    (is (= [:foreign :v/raw-fn]
            (mapv :marker (get-in v [:props :entries]))))))
 
 ;; ---------------------------------------------------------------------------
@@ -1045,11 +1045,11 @@
       (is (= 1 (count (:subs sites))) "the (sub ...) in the target is a finite site"))))
 
 ;; ---------------------------------------------------------------------------
-;; Compiled render slots (S3, rf2-ri0k6n) — ui/render-fn + ui/slot
+;; Compiled render slots (S3, rf2-ri0k6n) — v/render-fn + v/slot
 ;; ---------------------------------------------------------------------------
 
 (deftest render-fn-prop-lowers-to-a-compiled-slot-callback
-  (testing "a ui/render-fn prop value compiles its body into a slot callback"
+  (testing "a v/render-fn prop value compiles its body into a slot callback"
     (let [v (ana* '[child-view {:row (render-fn [i x] [:li.item i x])}])
           e (first (get-in v [:props :entries]))]
       (is (= :render-fn (:marker e)) "the entry is marked a compiled render slot")
@@ -1063,7 +1063,7 @@
         "a foreign component invokes it at an unknown phase — reject")))
 
 (deftest ui-slot-lowers-and-indexes-its-site
-  (testing "ui/slot over a prop-carried render-fn value"
+  (testing "v/slot over a prop-carried render-fn value"
     (let [{:keys [ast sites]}
           (ana-full '[:ul (slot row-renderer 3 item)])
           slot (first (get-in ast [:children]))]
@@ -1074,7 +1074,7 @@
       (is (= 1 (count (:slots sites))) "the slot site indexes into the manifest")
       (is (false? (:inline? (first (:slots sites)))))
       (is (vector? (:path (first (:slots sites)))) "the site carries its template path")))
-  (testing "ui/slot over an INLINE ui/render-fn compiles the body here"
+  (testing "v/slot over an INLINE v/render-fn compiles the body here"
     (let [{:keys [ast sites]}
           (ana-full '[:ul (slot (render-fn [x] [:li x]) item)])
           slot (first (get-in ast [:children]))]
@@ -1082,7 +1082,7 @@
       (is (= '[x] (get-in slot [:render-fn :params])))
       (is (= :element (get-in slot [:render-fn :body :op])) "inline body is compiled")
       (is (true? (:inline? (first (:slots sites)))))))
-  (testing "nil is a legal ui/slot value (renders nothing)"
+  (testing "nil is a legal v/slot value (renders nothing)"
     (let [ast (ana* '[:ul (slot nil)])]
       (is (= :slot (:op (first (:children ast)))))
       (is (nil? (get-in ast [:children 0 :slot-value]))))))

--- a/implementation/freehand/test/re_frame/freehand/analyze_reject_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/analyze_reject_cljs_test.cljc
@@ -1,11 +1,11 @@
-(ns re-frame.ui.analyze-reject-cljs-test
+(ns re-frame.freehand.analyze-reject-cljs-test
   "Template-grammar REJECT table: every rejected form throws a compile
   error carrying {:rf.ui.compile/error <id>} — the S1e didactic-message
   roster keys off these ids. Runs on both hosts (injected resolution)."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.ui.compiler.analyze :as ana]
-            [re-frame.ui.analyze-accept-cljs-test :refer [mk-env mk-self-env]]))
+            [re-frame.freehand.compiler.analyze :as ana]
+            [re-frame.freehand.analyze-accept-cljs-test :refer [mk-env mk-self-env]]))
 
 (defn reject-id
   "nil when accepted; the :rf.ui.compile/error id when rejected."
@@ -128,7 +128,7 @@
                :resolver (fn [sym]
                            (case sym
                              if-let {:fqn 'app.userland/if-let :meta {:macro true}}
-                             sub    {:fqn 're-frame.ui/sub :meta {}}
+                             sub    {:fqn 're-frame.freehand/sub :meta {}}
                              nil)))]
     (is (= :rf.ui.compile/unsupported-form
            (reject-id-in user-if-let-env
@@ -233,7 +233,7 @@
   ;; ordered scope re-accepts them all, so this deftest is the mutation fixture.
   (testing "a LATER-bound local does not shadow an earlier default (over-accept)"
     ;; `f` binds first; its :or default `sub` evaluates before local `sub` — it
-    ;; is the outer re-frame.ui/sub, not the later local.
+    ;; is the outer re-frame.freehand/sub, not the later local.
     (is (= :rf.ui.compile/unsupported-form
            (reject-id '[:div {:title (let [{:keys [f sub] :or {f sub}} m] f)}]))
         "bare sub default shadowed only by a LATER binding escapes")
@@ -342,9 +342,9 @@
   (is (= :rf.ui.compile/unsupported-form (reject-id '[sub {} [:p "child"]]))
       "children do not change the reserved-head classification")
   ;; qualified + aliased spellings resolve to the exact vars — reserved too
-  (is (= :rf.ui.compile/unsupported-form (reject-id '[ui/sub {}]))
-      "an aliased spelling resolving to re-frame.ui/sub is reserved")
-  (is (= :rf.ui.compile/unsupported-form (reject-id '[re-frame.ui/frame]))
+  (is (= :rf.ui.compile/unsupported-form (reject-id '[v/sub {}]))
+      "an aliased spelling resolving to re-frame.freehand/sub is reserved")
+  (is (= :rf.ui.compile/unsupported-form (reject-id '[re-frame.freehand/frame]))
       "a fully-qualified frame head is reserved")
   ;; a lexical shadow is NOT the reactive var: it falls through to the ordinary
   ;; local-head rule (a local binding can never be a literal head → dynamic-head)
@@ -586,13 +586,13 @@
                        [:input {:key (:id t)
                                 :on-input (event [e] (conj [::set (:id t)]
                                                            (.. e -target -value)))}])))
-      "a ui/event capturing the loop binding is a site too — extract a keyed child")
+      "a v/event capturing the loop binding is a site too — extract a keyed child")
   (is (nil? (reject-id '(let [id 1] [:li {:on-click [::open id]} "x"])))
       "non-loop locals in event vectors are the normal case")
   (is (nil? (reject-id '[:input {:value v
                                  :on-input (event [e] (conj on-value
                                                             (.. e -target -value)))}]))
-      "a ui/event capturing a view-level prefix (not a loop var) is the reusable case"))
+      "a v/event capturing a view-level prefix (not a loop var) is the reusable case"))
 
 (deftest handler-grammar
   (is (= :rf.ui.compile/bad-event-vector
@@ -606,10 +606,10 @@
       "options maps need a literal :event vector")
   (is (= :rf.ui.compile/bad-ui-event
          (reject-id '[:input {:on-input (event [] [:x])}]))
-      "ui/event binds exactly the native event")
+      "v/event binds exactly the native event")
   (is (= :rf.ui.compile/bad-ui-event
          (reject-id '[:input {:on-input (event [a b] [:x])}]))
-      "ui/event binds exactly one event arg, not several"))
+      "v/event binds exactly one event arg, not several"))
 
 (deftest bare-fn-law
   (is (= :rf.ui.compile/bare-fn-prop
@@ -625,42 +625,42 @@
       "bare fn at a non-event DOM prop")
   (is (= :rf.ui.compile/bare-fn-ref
          (reject-id '[:div {:ref (fn [el] el)} "x"]))
-      "callback refs must be explicit (ui/raw-fn f)")
+      "callback refs must be explicit (v/raw-fn f)")
   (is (nil? (reject-id '[:div {:ref (raw-fn (fn [el] el))} "x"]))
-      "(ui/raw-fn f) is the callback-ref spelling")
+      "(v/raw-fn f) is the callback-ref spelling")
   ;; rf2-u53yy.3: an internal view forwards :ref (React 19 ref-as-prop) — an
   ;; object ref carries through the props object; the ref contract is the
-  ;; element's, so a bare fn still needs the explicit (ui/raw-fn f).
+  ;; element's, so a bare fn still needs the explicit (v/raw-fn f).
   (is (nil? (reject-id '[child-view {:ref object-ref}]))
       "an object :ref forwards to an internal view (declared-ref forwarding)")
   (is (nil? (reject-id '[child-view {:ref (raw-fn (fn [el] el))}]))
-      "(ui/raw-fn f) is the callback-ref forwarding spelling on a view")
+      "(v/raw-fn f) is the callback-ref forwarding spelling on a view")
   (is (= :rf.ui.compile/bare-fn-ref
          (reject-id '[child-view {:ref (fn [el] el)}]))
-      "a bare-fn :ref on an internal view still needs (ui/raw-fn f)")
+      "a bare-fn :ref on an internal view still needs (v/raw-fn f)")
   ;; rf2-u53yy.3 obligation 3: the foreign seam is NOT a bare-fn exception —
-  ;; Spec 004 and the guide say every callback ref is explicit (ui/raw-fn f).
+  ;; Spec 004 and the guide say every callback ref is explicit (v/raw-fn f).
   (is (= :rf.ui.compile/bare-fn-ref
          (reject-id '[ForeignComp {:ref (fn [el] el)}]))
-      "a bare-fn :ref at a foreign component still needs (ui/raw-fn f)")
+      "a bare-fn :ref at a foreign component still needs (v/raw-fn f)")
   (is (nil? (reject-id '[ForeignComp {:ref (raw-fn (fn [el] el))}]))
-      "(ui/raw-fn f) is the callback-ref spelling at a foreign component")
+      "(v/raw-fn f) is the callback-ref spelling at a foreign component")
   (is (nil? (reject-id '[ForeignComp {:ref object-ref}]))
       "an object :ref forwards to a foreign component (ordinary foreign props stay open)"))
 
 (deftest ui-handler-grammar
   (is (= :rf.ui.compile/bad-ui-handler
          (reject-id '[:button {:on-click (handler [] (f))} "x"]))
-      "ui/handler binds at least the invoker's argument")
+      "v/handler binds at least the invoker's argument")
   (is (= :rf.ui.compile/bad-ui-handler
          (reject-id '[:button {:on-click (handler [a b] (f a b))} "x"]))
-      "ui/handler at a DOM site binds exactly the native event")
+      "v/handler at a DOM site binds exactly the native event")
   (is (= :rf.ui.compile/bad-ui-callback
          (reject-id '[ForeignComp {:on-select (event [a b] [:x])}]))
-      "ui/event at a component prop binds exactly one invoker arg")
+      "v/event at a component prop binds exactly one invoker arg")
   (is (= :rf.ui.compile/bad-ui-callback
          (reject-id '[ForeignComp {:on-open (handler [& rest] (f rest))}]))
-      "a component-prop ui/handler is a fixed-arity vector (no &)"))
+      "a component-prop v/handler is a fixed-arity vector (no &)"))
 
 (deftest error-boundary-grammar
   (is (= :rf.ui.compile/bad-error-boundary
@@ -704,7 +704,7 @@
       "one spelling per name: :for")
   (is (= :rf.ui.compile/rejected-prop-spelling
          (reject-id '[:div {:dangerouslySetInnerHTML {:__html "x"}}]))
-      "dangerouslySetInnerHTML does not exist — ui/html is the spelling")
+      "dangerouslySetInnerHTML does not exist — v/html is the spelling")
   (is (= :rf.ui.compile/rejected-prop-spelling (reject-id '[:div {:children [x]}]))
       "children are positional")
   (is (= :rf.ui.compile/id-sugar-conflict (reject-id '[:div#a {:id "b"}]))
@@ -719,7 +719,7 @@
       ":class flag-map keys must be literal names")
   ;; hiccup structure disambiguates props: a non-map second element is a
   ;; CHILD, never a dynamic props map — runtime prop maps go through
-  ;; (ui/spread base overrides)
+  ;; (v/spread base overrides)
   (is (nil? (reject-id '[:div some-expr "x"]))
       "a non-map expression after the tag is a dynamic child, not props"))
 
@@ -747,17 +747,17 @@
   (is (= :rf.ui.compile/children-not-accepted
          (reject-id '[leaf-view props-expr]))
       "no dynamic-props back door — a non-map is a child, and leaf views take none")
-  ;; rf2-u53yy.5 — ui/spread IS admitted at a FOREIGN component call site, but an
+  ;; rf2-u53yy.5 — v/spread IS admitted at a FOREIGN component call site, but an
   ;; internal view keeps the literal-props requirement (its per-slot memo
   ;; comparator and slot ABI need the literal keys).
   (is (nil? (reject-id '[ForeignComp (spread {:selected d :on-change (handler [v] (pick v))}
                                              forwarded)]))
-      "a foreign head accepts (ui/spread literal-part runtime-map)")
+      "a foreign head accepts (v/spread literal-part runtime-map)")
   (is (nil? (reject-id '[ForeignComp (spread forwarded)]))
       "a foreign head accepts a plain forwarded map spelled through spread")
   (is (= :rf.ui.compile/spread-internal-view
          (reject-id '[child-view (spread {:a 1} forwarded)]))
-      "an internal view rejects ui/spread — literal props required")
+      "an internal view rejects v/spread — literal props required")
   (is (= :rf.ui.compile/spread-internal-view
          (reject-id '[leaf-view (spread forwarded)]))
       "the internal-view spread rejection covers the plain forwarded form too"))
@@ -765,15 +765,15 @@
 (deftest interop-positions
   (is (= :rf.ui.compile/html-not-sole-child
          (reject-id '[:div [:span "s"] (html "<b>x</b>")]))
-      "(ui/html ...) must be the SOLE child of a DOM element")
+      "(v/html ...) must be the SOLE child of a DOM element")
   (is (= :rf.ui.compile/html-not-sole-child
          (reject-id '(html "<b>x</b>")))
-      "standalone ui/html has no host element to own the markup")
+      "standalone v/html has no host element to own the markup")
   (is (= :rf.ui.compile/raw-fn-child (reject-id '(raw-fn f))))
   (is (= :rf.ui.compile/bad-spread (reject-id '(spread base)))
-      "(ui/spread ...) belongs in an element's props position")
+      "(v/spread ...) belongs in an element's props position")
   (is (= :rf.ui.compile/bad-raw (reject-id '(raw)))
-      "(ui/raw react-element) takes one argument")
+      "(v/raw react-element) takes one argument")
   (is (= :rf.ui.compile/void-children (reject-id '[:br (html "<b>x</b>")]))
       "void elements cannot own trusted markup either"))
 
@@ -781,7 +781,7 @@
   ;; rf2-ib4fd — static special-element child shapes the TARGET (React 19.2 /
   ;; the JVM serialiser) rejects are rejected at COMPILE, not emitted to fail
   ;; later. Fail-fast with a clear diagnostic beats a silent wrong render.
-  (testing "(ui/html …) beneath a static <textarea> is rejected (React 19.2 "
+  (testing "(v/html …) beneath a static <textarea> is rejected (React 19.2 "
            "rejects dangerouslySetInnerHTML on a textarea)"
     ;; RED-BEFORE lever: this compiled and lowered to React
     ;; dangerouslySetInnerHTML / a divergent JVM trusted-markup body.
@@ -790,7 +790,7 @@
         "a textarea's content is :value or a text child, not trusted markup"))
   (testing "a static <textarea>'s single-text-child contract rejects the "
            "host-divergent multi/value+child/structural shapes (rf2-ib4fd "
-           "residual — the cases #6517's (ui/html …) rule did NOT cover)"
+           "residual — the cases #6517's (v/html …) rule did NOT cover)"
     ;; RED-BEFORE lever: each of these COMPILED before this rule — React 19.2
     ;; throws "<textarea> can only have at most one child" for two children and
     ;; for value+child, and renders a structural child as "[object Object]",
@@ -847,7 +847,7 @@
     (is (nil? (reject-id '[:script js-src]))
         "a runtime-dynamic scalar stays programmer-trusted")
     (is (nil? (reject-id '[:script (html "console.log(1)")]))
-        "a sole (ui/html …) is the sanctioned trusted-markup body")
+        "a sole (v/html …) is the sanctioned trusted-markup body")
     (is (nil? (reject-id '[:style]))
         "no body is fine")
     (is (nil? (reject-id '[:script {:src "/main.js"}]))

--- a/implementation/freehand/test/re_frame/freehand/binding_plan_host_faithful_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/binding_plan_host_faithful_jvm_test.clj
@@ -1,4 +1,4 @@
-(ns re-frame.ui.binding-plan-host-faithful-jvm-test
+(ns re-frame.freehand.binding-plan-host-faithful-jvm-test
   "rf2-vxgfnd.283 — the ONE host-faithful binding plan. The analyzer's scope
   walk and the CLJS header emitter must derive their binding order from a single
   plan that reproduces the host `destructure` `bes` transformation, so neither
@@ -12,10 +12,10 @@
   end to end."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.walk :as walk]
-            [re-frame.ui.compiler.analyze :as ana]
-            [re-frame.ui.compiler.binding-plan :as bp]
-            [re-frame.ui.compiler.emit-cljs :as emit-cljs]
-            [re-frame.ui.compiler.header :as header]))
+            [re-frame.freehand.compiler.analyze :as ana]
+            [re-frame.freehand.compiler.binding-plan :as bp]
+            [re-frame.freehand.compiler.emit-cljs :as emit-cljs]
+            [re-frame.freehand.compiler.header :as header]))
 
 (defn- real-local-order
   "The user locals `clojure.core/destructure` binds for map `pat`, in order —
@@ -445,7 +445,7 @@
   "Evaluate the JVM emitter path — native `let` destructuring of the raw pattern
   — on keyword-keyed `props`. Returns {local -> final value}; the ground truth."
   [pat props]
-  (binding [*ns* (find-ns 're-frame.ui.binding-plan-host-faithful-jvm-test)]
+  (binding [*ns* (find-ns 're-frame.freehand.binding-plan-host-faithful-jvm-test)]
     (let [locals (->> (destructure [pat 'the-map]) (partition 2) (map first)
                       (remove #(re-find #"^(map__|vec__|seq__|first__|p__|the-map)"
                                         (name %)))
@@ -460,7 +460,7 @@
   keyword-keyed and converted to the slot STRINGS the emitter reads. Returns
   {local -> final value}; `:or` default side effects run for real."
   [argv props]
-  (binding [*ns* (find-ns 're-frame.ui.binding-plan-host-faithful-jvm-test)]
+  (binding [*ns* (find-ns 're-frame.freehand.binding-plan-host-faithful-jvm-test)]
     (let [binds  (vec (emit-cljs/header-bindings (header/parse-header argv)))
           subbed (walk/postwalk-replace
                   {'cljs.core/unchecked-get `uget

--- a/implementation/freehand/test/re_frame/freehand/build_repl_hmr_convergence_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/build_repl_hmr_convergence_jvm_test.clj
@@ -1,4 +1,4 @@
-(ns re-frame.ui.build-repl-hmr-convergence-jvm-test
+(ns re-frame.freehand.build-repl-hmr-convergence-jvm-test
   "S2e (rf2-vxgfnd.11) — REPL == file-save reload at the compiler-state
   authority (03 §10; 02 §8; df9873's ruled posture). A view re-registration
   reaches the build authority two ways:
@@ -14,11 +14,11 @@
   Both paths must converge on the IDENTICAL committed `:views` aggregate for the
   same source — otherwise a REPL session and a saved file could diverge. This
   fixture drives the REAL `defview` macro body (the JVM emitter path) under a
-  controlled declaring namespace, exactly as `re-frame.ui.compiler-build-jvm-test`
+  controlled declaring namespace, exactly as `re-frame.freehand.compiler-build-jvm-test`
   does, and compares the two committed aggregates."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.ui.compiler :as compiler]
-            [re-frame.ui.compiler.build :as build]))
+            [re-frame.freehand.compiler :as compiler]
+            [re-frame.freehand.compiler.build :as build]))
 
 (use-fixtures :each
   (fn [f] (build/reset-build!) (try (f) (finally (build/reset-build!)))))

--- a/implementation/freehand/test/re_frame/freehand/compiler_build_hook_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/compiler_build_hook_jvm_test.clj
@@ -1,4 +1,4 @@
-(ns re-frame.ui.compiler-build-hook-jvm-test
+(ns re-frame.freehand.compiler-build-hook-jvm-test
   "Functional Shadow build-state authority tests for Option C.
 
   These fixtures deliberately thread the build-state returned by the real hook.
@@ -7,9 +7,9 @@
   optimize/check/flush/watch failure."
   (:require [cljs.env :as cljs-env]
             [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.ui.compiler.build :as build]
-            [re-frame.ui.compiler.build-hook :as build-hook]
-            [re-frame.ui.compiler.root :as root]))
+            [re-frame.freehand.compiler.build :as build]
+            [re-frame.freehand.compiler.build-hook :as build-hook]
+            [re-frame.freehand.compiler.root :as root]))
 
 (use-fixtures :each
   (fn [f] (build/reset-build!) (try (f) (finally (build/reset-build!)))))
@@ -21,7 +21,7 @@
    ;; Truthy executor + default parallel-build mirrors Shadow watch. In that
    ;; branch output presence is the exact cache-hit / compile-schedule signal.
    :executor (Object.)
-   ;; As `shadow.build.api/init` seeds it: the seam re-frame.ui installs its
+   ;; As `shadow.build.api/init` seeds it: the seam re-frame.freehand installs its
    ;; per-pass compile witness into.
    :analyzer-passes []
    :build-sources (vec member-nss)
@@ -227,7 +227,7 @@
                    [['app.a :app.a/view ["tf1-a" "hs1-a"]]
                     ['app.b :app.b/view ["tf1-b" "hs1-b"]]])
         ;; app.a remains an authoritative build member but was reset and
-        ;; recompiled after removing its final re-frame.ui declaration. No
+        ;; recompiled after removing its final re-frame.freehand declaration. No
         ;; macro call can mark it touched, so prepare must do so from Shadow's
         ;; missing-output schedule. app.b is an output-present cache hit.
         without-a (pass both '#{app.a app.b} '#{app.a} [])]
@@ -292,8 +292,8 @@
                 nil
                 (catch clojure.lang.ExceptionInfo e e))]
     (is (some? ex) "distinct declarations sharing a view-id must fail the build")
-    (is (= :re-frame.ui.compiler.build/view-id-conflict
-           (:re-frame.ui.compiler.build/error (ex-data ex))))
+    (is (= :re-frame.freehand.compiler.build/view-id-conflict
+           (:re-frame.freehand.compiler.build/error (ex-data ex))))
     (is (= :shared/card (:view-id (ex-data ex))))
     (is (= [['app.new 'card] ['app.old 'card]]
            (:declarations (ex-data ex)))
@@ -437,8 +437,8 @@
         ex (try (finish collision '#{app.old app.new}) nil
                 (catch clojure.lang.ExceptionInfo e e))]
     (is (some? ex) "two live sites for one root-id must fail the build")
-    (is (= :re-frame.ui.compiler.build/duplicate-root-id
-           (:re-frame.ui.compiler.build/error (ex-data ex))))
+    (is (= :re-frame.freehand.compiler.build/duplicate-root-id
+           (:re-frame.freehand.compiler.build/error (ex-data ex))))
     (is (= :shared/root (:root-id (ex-data ex))))
     (is (= 2 (count (:sites (ex-data ex)))) "both sites named with coords")))
 
@@ -450,8 +450,8 @@
         ex (try (finish collision '#{app.a app.b}) nil
                 (catch clojure.lang.ExceptionInfo e e))]
     (is (some? ex) "differing fingerprints for one frame-id must fail the build")
-    (is (= :re-frame.ui.compiler.build/frame-payload-conflict
-           (:re-frame.ui.compiler.build/error (ex-data ex))))
+    (is (= :re-frame.freehand.compiler.build/frame-payload-conflict
+           (:re-frame.freehand.compiler.build/error (ex-data ex))))
     (is (= :shop (:frame-id (ex-data ex))))
     (is (= ["cf-a" "cf-b"] (:fingerprints (ex-data ex))))))
 
@@ -588,7 +588,7 @@
 ;; broadcasts to every runtime on success. `:compile-prepare` points the
 ;; devtools client's ONE `:build-notify` receiver
 ;; (`shadow.cljs.devtools.client.env/custom-notify-fn`) at
-;; `re-frame.ui.rules/shadow-build-notify` — exactly when the delta can exist
+;; `re-frame.freehand.rules/shadow-build-notify` — exactly when the delta can exist
 ;; and land, and never over a consumer's own receiver. The projection itself is
 ;; pinned CLJS-side (rules-cljs-test) and end-to-end by test:ui-warm-watch.
 
@@ -596,13 +596,13 @@
   'shadow.cljs.devtools.client.env/custom-notify-fn)
 
 (def ^:private notify-target
-  "re_frame.ui.rules.shadow_build_notify")
+  "re_frame.freehand.rules.shadow_build_notify")
 
 (defn- notify-define-of [state]
   (get-in state [:compiler-options :closure-defines notify-define]))
 
 (deftest prepare-wires-the-removed-source-notify-for-a-watched-dev-build
-  (let [members '#{re-frame.ui.rules app.main}
+  (let [members '#{re-frame.freehand.rules app.main}
         watched (-> (graph-state :app :compile-prepare members)
                     (assoc :shadow.build/mode :dev
                            :worker-info {:host "localhost" :port 9630}))]

--- a/implementation/freehand/test/re_frame/freehand/compiler_build_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/compiler_build_jvm_test.clj
@@ -1,4 +1,4 @@
-(ns re-frame.ui.compiler-build-jvm-test
+(ns re-frame.freehand.compiler-build-jvm-test
   "The ONE build-scoped compiler-state authority (rf2-vxgfnd.16 → rf2-df9873):
   the S1 compiler's build registries are a PURE FUNCTION of the current build
   inputs, keyed PER shadow build id, with explicit begin/commit/abort pass
@@ -7,7 +7,7 @@
   The adversarial cruces:
 
     - MULTI-BUILD ISOLATION (the headline regression): one long-lived JVM
-      compiles `re-frame.ui` for several builds at once; two build ids must
+      compiles `re-frame.freehand` for several builds at once; two build ids must
       NOT wipe each other's registries (the prior global-build-id +
       wipe-on-switch model did — regressing cross-file duplicate detection).
     - PASS BOUNDARIES: an incremental commit replaces only the touched
@@ -22,17 +22,17 @@
 
   The mount-surface macros are client entry points (JVM-host expansion is a
   compile error), so the Layer-1 / descriptor writes are driven the way
-  `re-frame.ui.compiler.root/mount-form` drives them — `mount-site!` runs the
-  REAL assembly path. `defview` and `ui/custom-element` run their real macro
+  `re-frame.freehand.compiler.root/mount-form` drives them — `mount-site!` runs the
+  REAL assembly path. `defview` and `v/custom-element` run their real macro
   bodies under a bound `*ns*` so distinct declaring namespaces (the ledger's
   source key, rf2-df9873) are addressable."
   (:require [cljs.env :as cljs-env]
             [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.ui.compiler :as compiler]
-            [re-frame.ui.compiler.analyze :as ana]
-            [re-frame.ui.compiler.build :as build]
-            [re-frame.ui.compiler.env :as env]
-            [re-frame.ui.compiler.root :as root]))
+            [re-frame.freehand.compiler :as compiler]
+            [re-frame.freehand.compiler.analyze :as ana]
+            [re-frame.freehand.compiler.build :as build]
+            [re-frame.freehand.compiler.env :as env]
+            [re-frame.freehand.compiler.root :as root]))
 
 ;; Every test starts from a clean authority; correctness across a watch
 ;; session comes from per-source replacement on the pass boundaries, but
@@ -63,7 +63,7 @@
      {} vname (list {:id view-id} [] template))))
 
 (defn- declare-element!
-  "Run the real `ui/custom-element` macro body with `ns-sym` bound as the
+  "Run the real `v/custom-element` macro body with `ns-sym` bound as the
   declaring namespace — contributes the compile-time property classification
   for `tag`, owned by `ns-sym`."
   [ns-sym tag properties]
@@ -78,7 +78,7 @@
   `mount-site!` (mirrors root-analysis-cljs-test's stub)."
   (fn [sym]
     (case sym
-      frame-root {:fqn 're-frame.ui/frame-root :meta {}}
+      frame-root {:fqn 're-frame.freehand/frame-root :meta {}}
       app-view   {:fqn 'app.views/app-view
                   :meta {:rf.ui/view true :rf.ui/view-id :app.views/app-view}}
       nil)))
@@ -88,16 +88,16 @@
   `ns-sym` (file only feeds the error coords): analyze the LITERAL root form,
   resolve identity, index the root-id + each EXTRACTED frame plan, and
   contribute the Root Descriptor built by the actual `root/root-descriptor`
-  assembly — exactly the sequence a `ui/mount` expansion performs."
+  assembly — exactly the sequence a `v/mount` expansion performs."
   [ns-sym file root-form opts]
   (binding [*file* file]
     (let [coords {:file file :line 1}
           e (env/make-env {:host :clj :ns-sym 'app.test :resolver resolver})
-          {:keys [ast views plans]} (root/analyze-root e 'ui/mount root-form)
+          {:keys [ast views plans]} (root/analyze-root e 'v/mount root-form)
           {:keys [root-id provenance]} (root/resolve-root-identity
-                                        'ui/mount opts views)]
-      (root/register-root-site! 'ui/mount root-id provenance ns-sym coords)
-      (doseq [p plans] (root/register-plan-site! 'ui/mount p ns-sym coords))
+                                        'v/mount opts views)]
+      (root/register-root-site! 'v/mount root-id provenance ns-sym coords)
+      (doseq [p plans] (root/register-plan-site! 'v/mount p ns-sym coords))
       (root/register-descriptor! root-id
                                  (root/root-descriptor
                                   {:root-id root-id :provenance provenance
@@ -115,7 +115,7 @@
    :elements    (build/aggregate build/elements)})
 
 ;; ---------------------------------------------------------------------------
-;; The pure-transition model itself (re-frame.ui.compiler.build)
+;; The pure-transition model itself (re-frame.freehand.compiler.build)
 ;; ---------------------------------------------------------------------------
 
 (deftest per-source-contribution-replaces-atomically
@@ -246,8 +246,8 @@
                (catch clojure.lang.ExceptionInfo ex ex))]
       (is (some? ex)
           "a shadow compiler env with no build id must not use session-build")
-      (is (= :re-frame.ui.compiler.build/shadow-build-id-unresolved
-             (:re-frame.ui.compiler.build/error (ex-data ex)))))))
+      (is (= :re-frame.freehand.compiler.build/shadow-build-id-unresolved
+             (:re-frame.freehand.compiler.build/error (ex-data ex)))))))
 
 (deftest hook-open-plain-cljs-compiler-uses-session-fallback
   ;; A bound cljs compiler atom is not necessarily shadow. An unrelated/open
@@ -260,16 +260,16 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Shadow OUTER-marker drift (rf2-vxgfnd.192): compiler authority must follow
-;; re-frame.ui's OWN private build carrier, not Shadow's implementation-detail
+;; re-frame.freehand's OWN private build carrier, not Shadow's implementation-detail
 ;; outer `:shadow.build.cljs-bridge/state` bridge key. A Shadow rename/removal
 ;; of that outer key while the private carrier stays intact must NOT downgrade
 ;; identity, reads, or writes to the process/session fallback.
 ;; ---------------------------------------------------------------------------
 
 (defn- drifted-env
-  "A compiler-env atom carrying re-frame.ui's private accepted + scratch carrier
+  "A compiler-env atom carrying re-frame.freehand's private accepted + scratch carrier
   for `build-id` but WITHOUT Shadow's outer bridge marker — the exact state a
-  Shadow rename/removal of that outer key produces while re-frame.ui's own
+  Shadow rename/removal of that outer key produces while re-frame.freehand's own
   carrier stays intact."
   [build-id members]
   (atom (:compiler-env (build/prepare-shadow-build {} build-id (set members)
@@ -289,8 +289,8 @@
     (let [ex (try (build/current-build-id) nil
                   (catch clojure.lang.ExceptionInfo ex ex))]
       (is (some? ex) "a private carrier missing its build id must not downgrade")
-      (is (= :re-frame.ui.compiler.build/private-build-id-unresolved
-             (:re-frame.ui.compiler.build/error (ex-data ex)))))))
+      (is (= :re-frame.freehand.compiler.build/private-build-id-unresolved
+             (:re-frame.freehand.compiler.build/error (ex-data ex)))))))
 
 (deftest private-carrier-disagreeing-with-present-shadow-id-fails-loud
   (binding [cljs-env/*compiler*
@@ -300,8 +300,8 @@
     (let [ex (try (build/current-build-id) nil
                   (catch clojure.lang.ExceptionInfo ex ex))]
       (is (some? ex) "a private/shadow build-id disagreement must fail, not guess")
-      (is (= :re-frame.ui.compiler.build/private-build-id-shadow-disagreement
-             (:re-frame.ui.compiler.build/error (ex-data ex)))))))
+      (is (= :re-frame.freehand.compiler.build/private-build-id-shadow-disagreement
+             (:re-frame.freehand.compiler.build/error (ex-data ex)))))))
 
 (deftest canonical-shadow-marker-still-resolves-to-the-private-build-id
   ;; The current (non-drifted) path: bridge marker present with an AGREEING id.
@@ -358,7 +358,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- ab-carrier
-  "A compiler-env atom carrying re-frame.ui's PRIVATE accepted+scratch carrier
+  "A compiler-env atom carrying re-frame.freehand's PRIVATE accepted+scratch carrier
   for `private-build` AND a still-present Shadow outer bridge naming a DIFFERENT
   `shadow-build` — the exact A/B contradiction the boundary guards reject."
   [private-build shadow-build members]
@@ -388,8 +388,8 @@
         (let [ex (try (read-fn) nil (catch clojure.lang.ExceptionInfo e e))]
           (is (some? ex)
               (str (name label) " must reject the A-carrier + B-bridge read"))
-          (is (= :re-frame.ui.compiler.build/private-build-id-shadow-disagreement
-                 (:re-frame.ui.compiler.build/error (ex-data ex)))))))))
+          (is (= :re-frame.freehand.compiler.build/private-build-id-shadow-disagreement
+                 (:re-frame.freehand.compiler.build/error (ex-data ex)))))))))
 
 (deftest write-through-an-a-carrier-with-a-b-bridge-is-rejected-before-mutation
   ;; contribute! (the sole write boundary) must reject the mismatched carrier
@@ -402,8 +402,8 @@
                     (catch clojure.lang.ExceptionInfo e e))]
         (is (some? ex)
             "contribute! must reject a private-A / shadow-B carrier")
-        (is (= :re-frame.ui.compiler.build/private-build-id-shadow-disagreement
-               (:re-frame.ui.compiler.build/error (ex-data ex))))))
+        (is (= :re-frame.freehand.compiler.build/private-build-id-shadow-disagreement
+               (:re-frame.freehand.compiler.build/error (ex-data ex))))))
     (is (nil? (get-in @carrier [build/scratch-key :staged 'app.a]))
         "the rejected write staged nothing — fail BEFORE mutation")))
 
@@ -416,14 +416,14 @@
                     :version 0}})]        ; NO :build-id
     (let [read-ex (try (build/aggregate build/views) nil
                        (catch clojure.lang.ExceptionInfo e e))]
-      (is (= :re-frame.ui.compiler.build/private-build-id-unresolved
-             (:re-frame.ui.compiler.build/error (ex-data read-ex)))
+      (is (= :re-frame.freehand.compiler.build/private-build-id-unresolved
+             (:re-frame.freehand.compiler.build/error (ex-data read-ex)))
           "aggregate must reject a private carrier missing its build id"))
     (let [write-ex (try (build/contribute! build/views 'app.a :b/view ["tfb" "hsb"])
                         nil
                         (catch clojure.lang.ExceptionInfo e e))]
-      (is (= :re-frame.ui.compiler.build/private-build-id-unresolved
-             (:re-frame.ui.compiler.build/error (ex-data write-ex)))
+      (is (= :re-frame.freehand.compiler.build/private-build-id-unresolved
+             (:re-frame.freehand.compiler.build/error (ex-data write-ex)))
           "contribute! must reject the same carrier before mutation"))))
 
 (deftest recognized-bridge-without-build-id-fails-loud-even-with-no-pass-open
@@ -437,8 +437,8 @@
                   (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex)
           "a recognized bridge with no id must fail even with no pass open")
-      (is (= :re-frame.ui.compiler.build/shadow-build-id-unresolved
-             (:re-frame.ui.compiler.build/error (ex-data ex)))))
+      (is (= :re-frame.freehand.compiler.build/shadow-build-id-unresolved
+             (:re-frame.freehand.compiler.build/error (ex-data ex)))))
     (is (thrown? clojure.lang.ExceptionInfo (build/aggregate build/views))
         "and the ambient read fails closed the same way")))
 
@@ -462,8 +462,8 @@
                     (catch clojure.lang.ExceptionInfo e e))]
         (is (some? ex)
             "finish must reject a supplied id contradicting the accepted carrier")
-        (is (= :re-frame.ui.compiler.build/private-build-id-shadow-disagreement
-               (:re-frame.ui.compiler.build/error (ex-data ex))))
+        (is (= :re-frame.freehand.compiler.build/private-build-id-shadow-disagreement
+               (:re-frame.freehand.compiler.build/error (ex-data ex))))
         (is (= :app-a (:private-build-id (ex-data ex))))
         (is (= :app-b (:shadow-build-id (ex-data ex))))))))
 
@@ -577,7 +577,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest interleaved-builds-do-not-wipe-each-others-registries
-  ;; ONE JVM compiling `re-frame.ui` for two builds. The prior model held a
+  ;; ONE JVM compiling `re-frame.freehand` for two builds. The prior model held a
   ;; single GLOBAL build-id and WIPED on switch, so opening the node-test
   ;; pass BETWEEN app's two root registrations would erase app's first root —
   ;; regressing app's own cross-file duplicate detection. Per-build slices
@@ -585,15 +585,15 @@
   (build/begin-build! :app)
   (build/begin-build! :node-test)
   (binding [build/*build-id* :app]
-    (root/register-root-site! 'ui/mount :page/one :authored 'app.a
+    (root/register-root-site! 'v/mount :page/one :authored 'app.a
                               {:file "app/a.cljs" :line 1}))
   ;; the node-test build compiles the SAME namespaces — its :page/one is a
   ;; different build's row, must not touch app's slice
   (binding [build/*build-id* :node-test]
-    (root/register-root-site! 'ui/mount :page/one :authored 'ntest.x
+    (root/register-root-site! 'v/mount :page/one :authored 'ntest.x
                               {:file "app/a.cljs" :line 1}))
   (binding [build/*build-id* :app]
-    (root/register-root-site! 'ui/mount :page/two :authored 'app.b
+    (root/register-root-site! 'v/mount :page/two :authored 'app.b
                               {:file "app/b.cljs" :line 1}))
   (is (= #{:page/one :page/two}
          (set (keys (build/aggregate build/roots :app))))
@@ -604,7 +604,7 @@
   (testing "app STILL detects its own cross-namespace duplicate"
     (is (thrown? clojure.lang.ExceptionInfo
                  (binding [build/*build-id* :app]
-                   (root/register-root-site! 'ui/mount :page/one :authored 'app.c
+                   (root/register-root-site! 'v/mount :page/one :authored 'app.c
                                              {:file "app/c.cljs" :line 1})))
         "a genuine duplicate in app fires — the interleaved build did not erase :page/one")))
 
@@ -649,7 +649,7 @@
                 (future
                   (binding [build/*build-id* b]
                     (root/register-root-site!
-                     'ui/mount (keyword "page" (str (name b) "-" i))
+                     'v/mount (keyword "page" (str (name b) "-" i))
                      :authored (symbol (str "ns." (name b) "." i))
                      {:file (str (name b) "-" i ".cljs") :line 1})))))]
     (run! deref futs)
@@ -671,7 +671,7 @@
                (future
                  (binding [build/*build-id* :app]
                    (try
-                     (root/register-root-site! 'ui/mount :page/dup :authored
+                     (root/register-root-site! 'v/mount :page/dup :authored
                                                (symbol (str "ns.dup." i))
                                                {:file (str "dup-" i ".cljs") :line 1})
                      :ok
@@ -751,14 +751,14 @@
 (deftest deleted-root-site-does-not-falsely-duplicate-a-later-file
   ;; original: app.a mounts :page/shop
   (build/begin-build! :app)
-  (root/register-root-site! 'ui/mount :page/shop :authored 'app.a {:file "a.cljs" :line 1})
+  (root/register-root-site! 'v/mount :page/shop :authored 'app.a {:file "a.cljs" :line 1})
   (build/commit-build! :app)
   ;; edit app.a: the :page/shop site is DELETED (app.a now mounts :page/cart)
   (build/begin-build! :app)
-  (root/register-root-site! 'ui/mount :page/cart :authored 'app.a {:file "a.cljs" :line 1})
+  (root/register-root-site! 'v/mount :page/cart :authored 'app.a {:file "a.cljs" :line 1})
   ;; app.b legitimately takes over the now-free :page/shop — the deleted
   ;; app.a site must NOT raise a false :rf.error/duplicate-root-id
-  (is (nil? (root/register-root-site! 'ui/mount :page/shop :authored 'app.b
+  (is (nil? (root/register-root-site! 'v/mount :page/shop :authored 'app.b
                                       {:file "b.cljs" :line 1}))
       "a deleted root site cannot fail a later file (rf2-df9873)")
   (build/commit-build! :app)
@@ -766,8 +766,8 @@
 
 (deftest genuine-current-cross-file-duplicate-still-fails
   (build/begin-build! :app)
-  (root/register-root-site! 'ui/mount :page/dup :authored 'app.a {:file "a.cljs" :line 1})
-  (let [ex (try (root/register-root-site! 'ui/mount :page/dup :authored 'app.b
+  (root/register-root-site! 'v/mount :page/dup :authored 'app.a {:file "a.cljs" :line 1})
+  (let [ex (try (root/register-root-site! 'v/mount :page/dup :authored 'app.b
                                           {:file "b.cljs" :line 2})
                 nil (catch clojure.lang.ExceptionInfo e e))]
     (is (some? ex) "two LIVE sites for one root-id still fail the build")
@@ -777,7 +777,7 @@
 (deftest deleted-frame-plan-does-not-falsely-conflict-a-later-file
   ;; original: app.a carries a :shop plan
   (build/begin-build! :app)
-  (root/register-plan-site! 'ui/mount {:frame-id :shop :config-fingerprint "cf1-a"}
+  (root/register-plan-site! 'v/mount {:frame-id :shop :config-fingerprint "cf1-a"}
                             'app.a {:file "a.cljs" :line 1})
   (is (contains? (root/build-plans) :shop))
   (build/commit-build! :app)
@@ -785,11 +785,11 @@
   ;; (it no longer touches the plan registry at all). Re-touching app.a must
   ;; still evict its stale :shop plan (cross-registry sweep at commit).
   (build/begin-build! :app)
-  (root/register-root-site! 'ui/mount :page/a :authored 'app.a {:file "a.cljs" :line 1})
+  (root/register-root-site! 'v/mount :page/a :authored 'app.a {:file "a.cljs" :line 1})
   (is (not (contains? (root/build-plans) :shop))
       "re-touching the recompiled app.a evicted its dropped :shop plan")
   ;; app.b now carries :shop with a DIFFERENT fingerprint — no false conflict
-  (is (nil? (root/register-plan-site! 'ui/mount
+  (is (nil? (root/register-plan-site! 'v/mount
                                       {:frame-id :shop :config-fingerprint "cf1-b"}
                                       'app.b {:file "b.cljs" :line 1}))
       "a deleted plan cannot fail a later file's differing plan (rf2-df9873)")
@@ -798,9 +798,9 @@
 
 (deftest genuine-current-cross-file-plan-conflict-still-fails
   (build/begin-build! :app)
-  (root/register-plan-site! 'ui/mount {:frame-id :shop :config-fingerprint "cf1-a"}
+  (root/register-plan-site! 'v/mount {:frame-id :shop :config-fingerprint "cf1-a"}
                             'app.a {:file "a.cljs" :line 1})
-  (let [ex (try (root/register-plan-site! 'ui/mount
+  (let [ex (try (root/register-plan-site! 'v/mount
                                           {:frame-id :shop :config-fingerprint "cf1-b"}
                                           'app.b {:file "b.cljs" :line 2})
                 nil (catch clojure.lang.ExceptionInfo e e))]

--- a/implementation/freehand/test/re_frame/freehand/compiler_harvest_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/compiler_harvest_jvm_test.clj
@@ -1,45 +1,45 @@
-(ns re-frame.ui.compiler-harvest-jvm-test
+(ns re-frame.freehand.compiler-harvest-jvm-test
   "Unit tests for the custom-element source harvest (rf2-vxgfnd.141, dimension 2).
 
   `declarations-in-source` is a PURE syntactic read: it recognizes the exact
-  literal `(<ui>/custom-element <tag> <opts>)` shape — resolving how the source's
-  own `(ns …)` aliases spell `re-frame.ui/custom-element` — and rejects anything
+  literal `(<v>/custom-element <tag> <opts>)` shape — resolving how the source's
+  own `(ns …)` aliases spell `re-frame.freehand/custom-element` — and rejects anything
   the macro would reject rather than seeding it. These tests pin the recognition
   and the rejection so the harvest can never seed a classification the macro
   would not, nor miss one it would."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.ui.compiler.harvest :as harvest]))
+            [re-frame.freehand.compiler.harvest :as harvest]))
 
 (defn- decls [src] (harvest/declarations-in-source src))
 
 (deftest recognizes-aliased-head
-  (let [src "(ns app.a (:require [re-frame.ui :as ui]))
-             (ui/custom-element :x-card {:properties #{:model :help-text}})"]
+  (let [src "(ns app.a (:require [re-frame.freehand :as v]))
+             (v/custom-element :x-card {:properties #{:model :help-text}})"]
     (is (= [{:tag :x-card :properties #{:model :help-text}}] (decls src)))))
 
 (deftest recognizes-fully-qualified-head
-  (let [src "(ns app.a (:require [re-frame.ui]))
-             (re-frame.ui/custom-element :x-badge {:properties #{:count}})"]
+  (let [src "(ns app.a (:require [re-frame.freehand]))
+             (re-frame.freehand/custom-element :x-badge {:properties #{:count}})"]
     (is (= [{:tag :x-badge :properties #{:count}}] (decls src)))))
 
 (deftest recognizes-referred-head
-  (let [src "(ns app.a (:require [re-frame.ui :refer [custom-element]]))
+  (let [src "(ns app.a (:require [re-frame.freehand :refer [custom-element]]))
              (custom-element :x-tag {:properties #{:value}})"]
     (is (= [{:tag :x-tag :properties #{:value}}] (decls src)))))
 
 (deftest bare-alias-only-matches-that-spelling
-  ;; With only `:as ui`, a bare `custom-element` (unreferred) is NOT the macro
+  ;; With only `:as v`, a bare `custom-element` (unreferred) is NOT the macro
   ;; and must not be harvested — nor a foreign `other/custom-element`.
-  (let [src "(ns app.a (:require [re-frame.ui :as ui] [other.lib :as other]))
-             (ui/custom-element :x-real {:properties #{:model}})
+  (let [src "(ns app.a (:require [re-frame.freehand :as v] [other.lib :as other]))
+             (v/custom-element :x-real {:properties #{:model}})
              (custom-element :x-bare {:properties #{:nope}})
              (other/custom-element :x-foreign {:properties #{:nope}})"]
     (is (= [{:tag :x-real :properties #{:model}}] (decls src)))))
 
 (deftest empty-properties-declaration-is-recognized
-  (let [src "(ns app.a (:require [re-frame.ui :as ui]))
-             (ui/custom-element :x-plain {:properties #{}})
-             (ui/custom-element :x-empty {})"]
+  (let [src "(ns app.a (:require [re-frame.freehand :as v]))
+             (v/custom-element :x-plain {:properties #{}})
+             (v/custom-element :x-empty {})"]
     (is (= [{:tag :x-plain :properties #{}}
             {:tag :x-empty :properties #{}}]
            (decls src)))))
@@ -47,27 +47,27 @@
 (deftest finds-declarations-regardless-of-position
   ;; A declaration textually BELOW a view is exactly the dimension-2 defect; the
   ;; harvest must find it wherever it sits.
-  (let [src "(ns app.a (:require [re-frame.ui :as ui :refer [defview]]))
+  (let [src "(ns app.a (:require [re-frame.freehand :as v :refer [defview]]))
              (defview v [] [:x-card {:model \"m\"}])
-             (ui/custom-element :x-card {:properties #{:model}})"]
+             (v/custom-element :x-card {:properties #{:model}})"]
     (is (= [{:tag :x-card :properties #{:model}}] (decls src)))))
 
 (deftest rejects-what-the-macro-would-reject
   (testing "non-literal :properties (a symbol) is not seeded"
-    (let [src "(ns app.a (:require [re-frame.ui :as ui]))
-               (ui/custom-element :x-dyn {:properties some-var})"]
+    (let [src "(ns app.a (:require [re-frame.freehand :as v]))
+               (v/custom-element :x-dyn {:properties some-var})"]
       (is (= [] (decls src)))))
   (testing "unknown option is not seeded"
-    (let [src "(ns app.a (:require [re-frame.ui :as ui]))
-               (ui/custom-element :x-opt {:properties #{:m} :events #{:go}})"]
+    (let [src "(ns app.a (:require [re-frame.freehand :as v]))
+               (v/custom-element :x-opt {:properties #{:m} :events #{:go}})"]
       (is (= [] (decls src)))))
   (testing "a tag without '-' is not a custom element and is not seeded"
-    (let [src "(ns app.a (:require [re-frame.ui :as ui]))
-               (ui/custom-element :plain {:properties #{:m}})"]
+    (let [src "(ns app.a (:require [re-frame.freehand :as v]))
+               (v/custom-element :plain {:properties #{:m}})"]
       (is (= [] (decls src)))))
   (testing "qualified property keywords are not seeded"
-    (let [src "(ns app.a (:require [re-frame.ui :as ui]))
-               (ui/custom-element :x-q {:properties #{:ns/q}})"]
+    (let [src "(ns app.a (:require [re-frame.freehand :as v]))
+               (v/custom-element :x-q {:properties #{:ns/q}})"]
       (is (= [] (decls src))))))
 
 (deftest tolerates-reader-conditionals-tagged-literals-and-alias-keywords
@@ -75,14 +75,14 @@
   ;; surrounding the declaration must still yield the declaration — the harvest
   ;; reads under `:cljs`, degrades unknown tags to their value, and resolves
   ;; alias keywords from the ns form.
-  (let [src "(ns app.a (:require [re-frame.ui :as ui] [other.lib :as o]))
+  (let [src "(ns app.a (:require [re-frame.freehand :as v] [other.lib :as o]))
              (def opts #?(:cljs #js {:a 1} :clj {:a 1}))
              (def k ::o/thing)
-             (ui/custom-element :x-cond {:properties #{:model}})"]
+             (v/custom-element :x-cond {:properties #{:model}})"]
     (is (= [{:tag :x-cond :properties #{:model}}] (decls src)))))
 
 (deftest source-seed-carries-the-declaring-namespace
-  (let [src "(ns app.a (:require [re-frame.ui :as ui]))
-             (ui/custom-element :x-card {:properties #{:model}})"]
+  (let [src "(ns app.a (:require [re-frame.freehand :as v]))
+             (v/custom-element :x-card {:properties #{:model}})"]
     (is (= [['app.decl :x-card {:properties #{:model}}]]
            (harvest/source-seed 'app.decl src)))))

--- a/implementation/freehand/test/re_frame/freehand/compiler_macro_resolution_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/compiler_macro_resolution_jvm_test.clj
@@ -1,4 +1,4 @@
-(ns re-frame.ui.compiler-macro-resolution-jvm-test
+(ns re-frame.freehand.compiler-macro-resolution-jvm-test
   "Real CLJS-analyzer resolution proofs for the expression macro barrier."
   (:require [cljs.analyzer :as cljs-analyzer]
             [cljs.analyzer.api :as cljs-api]
@@ -8,12 +8,12 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [clojure.walk :as walk]
-            [re-frame.ui.compiler.analyze :as analyze]
-            [re-frame.ui.compiler.emit-cljs :as emit-cljs]
-            [re-frame.ui.compiler.emit-jvm :as emit-jvm]
-            [re-frame.ui.compiler.env :as env]
-            [re-frame.ui.compiler.header :as header]
-            [re-frame.ui.compiler.root :as root]))
+            [re-frame.freehand.compiler.analyze :as analyze]
+            [re-frame.freehand.compiler.emit-cljs :as emit-cljs]
+            [re-frame.freehand.compiler.emit-jvm :as emit-jvm]
+            [re-frame.freehand.compiler.env :as env]
+            [re-frame.freehand.compiler.header :as header]
+            [re-frame.freehand.compiler.root :as root]))
 
 (defmacro user-binder
   [[binding init] then else]
@@ -30,14 +30,14 @@
     ;; that exact authority rather than injecting a synthetic :macro flag.
     (cljs-analyzer/intern-macros 'cljs.core)
     (cljs-analyzer/intern-macros
-     're-frame.ui.compiler-macro-resolution-jvm-test)
+     're-frame.freehand.compiler-macro-resolution-jvm-test)
     (let [cljs-e (cljs-api/empty-env)]
       (cljs-api/analyze cljs-e '(def ordinary-call (fn [x] x)))
       (let [base (env/make-env {:host :cljs :cljs-env cljs-e
                                 :ns-sym 'cljs.user})
             resolve* (fn [sym]
                        (case sym
-                         sub   {:fqn 're-frame.ui/sub :meta {}}
+                         sub   {:fqn 're-frame.freehand/sub :meta {}}
                          (env/resolve-sym base sym)))
             e (env/make-env {:host :cljs :cljs-env cljs-e
                              :ns-sym 'cljs.user
@@ -54,7 +54,7 @@
              (get-in
               (env/resolve-sym
                base
-               're-frame.ui.compiler-macro-resolution-jvm-test/user-binder)
+               're-frame.freehand.compiler-macro-resolution-jvm-test/user-binder)
               [:meta :macro]))))
       (testing "a real analyzed ordinary function is not over-classified"
         (is (not (true? (get-in (env/resolve-sym base 'ordinary-call)
@@ -70,7 +70,7 @@
       ;; step below `->` also stays rejected.
       (doseq [form
               ['[:div {:title
-                       (re-frame.ui.compiler-macro-resolution-jvm-test/user-binder
+                       (re-frame.freehand.compiler-macro-resolution-jvm-test/user-binder
                         [x maybe] (sub [:q x]) nil)}]
                '[:div {:title (-> [:q] sub)}]]]
         (is (= :rf.ui.compile/unsupported-form
@@ -82,7 +82,7 @@
             ast (analyze/analyze e* '[:div {:title (if-let [x maybe] (sub [:q x]) nil)}])]
         (is (= 1 (count (:subs @(:sites e*))))
             "the admitted if-let lowers the branch (sub …) to one manifest site")
-        (is (re-find #"re-frame.ui.reactive/sub-read" (pr-str ast))
+        (is (re-find #"re-frame.freehand.reactive/sub-read" (pr-str ast))
             "the lowered runtime site is present in the desugared let + if"))
       ;; rf2-u53yy.4 audit repair — under REAL CLJS resolution (:host :cljs) the
       ;; some?-variant's generated nil test is the HOST-QUALIFIED core `not=`
@@ -99,7 +99,7 @@
              (compile-error-id
               #(analyze/analyze
                 e '[:div {:title
-                           (re-frame.ui.compiler-macro-resolution-jvm-test/user-binder)}])))
+                           (re-frame.freehand.compiler-macro-resolution-jvm-test/user-binder)}])))
           "an opaque zero-arg invocation cannot inject an invisible site")
       (is (= :rf.ui.compile/unsupported-form
              (compile-error-id
@@ -115,7 +115,7 @@
         (let [e*  (assoc e :sites (atom {:events [] :subs [] :htmls []}))
               ast (analyze/analyze e* form)]
           (is (= 1 (count (:subs @(:sites e*)))) (pr-str form))
-          (is (re-find #"re-frame.ui.reactive/sub-read" (pr-str ast))
+          (is (re-find #"re-frame.freehand.reactive/sub-read" (pr-str ast))
               (pr-str form)))))))
 
 (deftest real-cljs-destructuring-scope-follows-host-evaluation-order
@@ -150,29 +150,29 @@
 ;; spellings only. Neither exercised production `cljs.analyzer.api/resolve` with
 ;; REFERRED / ALIASED spellings, nor the separate CLJS root-entry compiler. This
 ;; harness stands up a REAL CLJS analyzer namespace state where cljs.user refers
-;; re-frame.ui/{sub,frame} (and aliases the ns `ui`), so every spelling
+;; re-frame.freehand/{sub,frame} (and aliases the ns `v`), so every spelling
 ;; resolves through the production resolver — NOT an injected stub — and drives
 ;; both the defview route (analyze) and the root-entry route (root/analyze-root).
 
 (defn- with-referred-cljs-env
-  "Populate a real CLJS compiler state where cljs.user REFERS re-frame.ui/sub,
-  frame (+ frame-root/frame-provider) and aliases the ns as `ui`, then
+  "Populate a real CLJS compiler state where cljs.user REFERS re-frame.freehand/sub,
+  frame (+ frame-root/frame-provider) and aliases the ns as `v`, then
   call `(f aenv)` with a live analyzer env over that ns. Resolution runs through
   production `cljs.analyzer.api/resolve` — there is no injected `:resolver`."
   [f]
   (binding [cljs-env/*compiler* (cljs-env/default-compiler-env)]
     (swap! cljs-env/*compiler* update :cljs.analyzer/namespaces merge
-           {'re-frame.ui  {:name 're-frame.ui
-                           :defs {'sub            {:name 're-frame.ui/sub}
-                                  'frame          {:name 're-frame.ui/frame}
-                                  'frame-root     {:name 're-frame.ui/frame-root}
-                                  'frame-provider {:name 're-frame.ui/frame-provider}}}
+           {'re-frame.freehand  {:name 're-frame.freehand
+                           :defs {'sub            {:name 're-frame.freehand/sub}
+                                  'frame          {:name 're-frame.freehand/frame}
+                                  'frame-root     {:name 're-frame.freehand/frame-root}
+                                  'frame-provider {:name 're-frame.freehand/frame-provider}}}
             'cljs.user    {:name 'cljs.user
-                           ;; `(:require [re-frame.ui :as ui :refer [...]])`
-                           :requires {'ui 're-frame.ui 're-frame.ui 're-frame.ui}
-                           :uses     {'sub 're-frame.ui
-                                      'frame 're-frame.ui 'frame-root 're-frame.ui
-                                      'frame-provider 're-frame.ui}
+                           ;; `(:require [re-frame.freehand :as v :refer [...]])`
+                           :requires {'v 're-frame.freehand 're-frame.freehand 're-frame.freehand}
+                           :uses     {'sub 're-frame.freehand
+                                      'frame 're-frame.freehand 'frame-root 're-frame.freehand
+                                      'frame-provider 're-frame.freehand}
                            :defs {}}})
     (f (assoc (cljs-api/empty-env)
               :ns (get-in @cljs-env/*compiler*
@@ -190,15 +190,15 @@
 (deftest real-cljs-referred-verb-resolution-is-genuine
   ;; Sanity: production cljs.analyzer.api/resolve — not an injected resolver —
   ;; resolves every referred / aliased / fully-qualified spelling to the
-  ;; re-frame.ui authoring vars. The rows below route through THIS resolution.
+  ;; re-frame.freehand authoring vars. The rows below route through THIS resolution.
   (with-referred-cljs-env
     (fn [aenv]
       (let [base (referred-env aenv nil)]
-        (doseq [[sym fqn] '{sub               re-frame.ui/sub
-                            ui/sub            re-frame.ui/sub
-                            re-frame.ui/sub   re-frame.ui/sub
-                            frame             re-frame.ui/frame
-                            re-frame.ui/frame re-frame.ui/frame}]
+        (doseq [[sym fqn] '{sub               re-frame.freehand/sub
+                            v/sub            re-frame.freehand/sub
+                            re-frame.freehand/sub   re-frame.freehand/sub
+                            frame             re-frame.freehand/frame
+                            re-frame.freehand/frame re-frame.freehand/frame}]
           (is (= fqn (:fqn (env/resolve-sym base sym))) (str sym)))
         (is (nil? (env/resolve-sym base 'not-a-thing))
             "an unresolvable spelling is genuinely unresolved (no stub)")))))
@@ -219,8 +219,8 @@
             (is (= (keyword "cljs.user" (name verb)) (:view-id ast)) (str verb)))))
       (testing "aliased / fully-qualified / referred verbs in an unrelated view stay reserved"
         (let [e (referred-env aenv nil)]
-          (doseq [form '[[ui/sub {}] [frame]
-                         [ui/frame {}] [re-frame.ui/sub {}]]]
+          (doseq [form '[[v/sub {}] [frame]
+                         [v/frame {}] [re-frame.freehand/sub {}]]]
             (is (= :rf.ui.compile/unsupported-form
                    (compile-error-id #(analyze/analyze e form)))
                 (pr-str form)))))
@@ -244,13 +244,13 @@
   ;; self-precedence tier never applies here — only the reservation does.)
   (with-referred-cljs-env
     (fn [aenv]
-      (doseq [form '[[sub {}] [re-frame.ui/frame] [frame]]]
+      (doseq [form '[[sub {}] [re-frame.freehand/frame] [frame]]]
         (is (= :rf.ui.compile/unsupported-form
-               (compile-error-id #(root/analyze-root (referred-env aenv nil) 'ui/mount form)))
+               (compile-error-id #(root/analyze-root (referred-env aenv nil) 'v/mount form)))
             (pr-str form)))
       (testing "a legal element root still analyzes through the root compiler"
         (is (= :element
-               (:op (:ast (root/analyze-root (referred-env aenv nil) 'ui/mount '[:div "x"])))))))))
+               (:op (:ast (root/analyze-root (referred-env aenv nil) 'v/mount '[:div "x"])))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-rr26cq — emit a recursive self head against the current-namespace Var
@@ -262,7 +262,7 @@
 ;; view before its def. A self head emitted as the raw authored spelling
 ;; therefore resolves through the same-named `:refer` — cljs.analyzer/resolve-var
 ;; checks `:uses` (refers) BEFORE `:defs` — and captures the public authoring
-;; Var (`re-frame.ui/sub`) in the emitted JavaScript. The fix carries the
+;; Var (`re-frame.freehand/sub`) in the emitted JavaScript. The fix carries the
 ;; canonical `:fqn` (the current-namespace Var) for the self component node and
 ;; forward-`declare`s it. These rows drive the REAL emitters and compile the
 ;; emitted self head to REAL JavaScript through cljs.compiler.
@@ -326,7 +326,7 @@
 
 (deftest real-cljs-self-head-emits-against-current-namespace-var
   ;; rf2-rr26cq accept rows. Reverting the emitter to the raw authored `:sym`
-  ;; re-captures `re-frame.ui/<verb>` in the emitted JavaScript and drops the
+  ;; re-captures `re-frame.freehand/<verb>` in the emitted JavaScript and drops the
   ;; forward declaration, failing every row below.
   (with-referred-cljs-env
     (fn [aenv]
@@ -355,7 +355,7 @@
               (let [js (emit-var-js aenv h)]
                 (is (= (str "cljs.user." (name verb)) js)
                     (str "self head " h " munges to the current-namespace Var"))
-                (is (not (str/includes? js (str "re_frame.ui." (name verb))))
+                (is (not (str/includes? js (str "re_frame.freehand." (name verb))))
                     "zero authoring-Var reference in the emitted JavaScript"))))
           (testing (str "JVM: the self call targets the current-namespace fqn (" verb ")")
             (let [jvm-heads (call-head-syms jvm-form verb)]
@@ -371,7 +371,7 @@
   (with-referred-cljs-env
     (fn [aenv]
       (doseq [verb '[sub frame]]
-        (is (= (str "re_frame.ui." (name verb)) (emit-var-js aenv verb))
+        (is (= (str "re_frame.freehand." (name verb)) (emit-var-js aenv verb))
             (str "a bare " verb " head resolves through the refer to the authoring Var"))
         (is (= (str "cljs.user." (name verb))
                (emit-var-js aenv (symbol "cljs.user" (name verb))))
@@ -384,14 +384,14 @@
 ;; PR #6053 fixed the recursive JSX HEAD (self-fqn) but left the view's own
 ;; declare/def on the raw bare name. The focused rows above compile EXTRACTED
 ;; reference symbols in isolation and check the raw def is bare — a FALSE GREEN:
-;; a bare `(def sub …)` in a ns referring re-frame.ui/sub resolves the def NAME
+;; a bare `(def sub …)` in a ns referring re-frame.freehand/sub resolves the def NAME
 ;; through the same-named `:refer` (cljs.analyzer/resolve-var ranks `:uses` above
 ;; `:defs` and IGNORES `:excludes`), so the WHOLE form both clobbers the public
-;; authoring Var (`re_frame.ui.sub = …`) and leaves the qualified self head
+;; authoring Var (`re_frame.freehand.sub = …`) and leaves the qualified self head
 ;; (`cljs.user.sub`) undefined — the split identity. The row below analyzes AND
 ;; compiles the ENTIRE emitted `(declare/defn/def)` do-form as one unit through
 ;; real cljs.analyzer + cljs.compiler. Against pre-fix output every assertion is
-;; RED (the def targets re-frame.ui/<verb>, the JS assigns re_frame.ui.<verb>).
+;; RED (the def targets re-frame.freehand/<verb>, the JS assigns re_frame.freehand.<verb>).
 
 (defn- analyze-whole-form
   "Analyze the COMPLETE production do-form in the referred cljs.user ns (warnings
@@ -412,8 +412,8 @@
 
 (defn- munged-ref?
   "True iff `js` references the exact munged Var `pre.<verb>` at an identifier
-  boundary (so `re_frame.ui.frame` does not spuriously match
-  `re_frame.ui.frames`, nor `cljs.user.sub` match `cljs.user.sub$render`)."
+  boundary (so `re_frame.freehand.frame` does not spuriously match
+  `re_frame.freehand.frames`, nor `cljs.user.sub` match `cljs.user.sub$render`)."
   [js pre verb]
   (boolean (re-find (re-pattern (str (java.util.regex.Pattern/quote (str pre "." (name verb)))
                                      "(?![A-Za-z0-9_$])"))
@@ -426,7 +426,7 @@
     (fn [aenv]
       (doseq [verb '[sub frame]]
         (let [self-fqn      (symbol "cljs.user" (name verb))
-              authoring-fqn (symbol "re-frame.ui" (name verb))
+              authoring-fqn (symbol "re-frame.freehand" (name verb))
               args          (self-emit-args aenv verb)
               do-form       (emit-cljs/emit-defview args)
               {:keys [def-names js]} (analyze-whole-form aenv do-form)]
@@ -434,17 +434,17 @@
             (is (some #(= self-fqn %) def-names)
                 (str "a def in the whole form targets cljs.user/" verb))
             (is (not-any? #(= authoring-fqn %) def-names)
-                (str "no def targets the authoring Var re-frame.ui/" verb)))
+                (str "no def targets the authoring Var re-frame.freehand/" verb)))
           (testing (str "whole form: emitted JS assigns the current-ns Var, never the authoring Var (" verb ")")
             (is (str/includes? js (str "cljs.user." (name verb) " ="))
                 (str "the emitted JS assigns cljs.user." (name verb)))
-            (is (not (str/includes? js (str "re_frame.ui." (name verb) " =")))
-                (str "the emitted JS never assigns (clobbers) re_frame.ui." (name verb))))
+            (is (not (str/includes? js (str "re_frame.freehand." (name verb) " =")))
+                (str "the emitted JS never assigns (clobbers) re_frame.freehand." (name verb))))
           (testing (str "whole form: def + recursive head share ONE current-ns Var, authoring Var untouched (" verb ")")
             (is (munged-ref? js "cljs.user" verb)
                 (str "the recursive head references cljs.user." (name verb)))
-            (is (not (munged-ref? js "re_frame.ui" verb))
-                (str "zero re_frame.ui." (name verb)
+            (is (not (munged-ref? js "re_frame.freehand" verb))
+                (str "zero re_frame.freehand." (name verb)
                      " reference anywhere in the whole emitted form"))))))))
 
 (deftest a-non-recursive-defview-emits-no-self-declaration

--- a/implementation/freehand/test/re_frame/freehand/emit_cljs_lowering_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/emit_cljs_lowering_cljs_test.cljc
@@ -1,10 +1,10 @@
-(ns re-frame.ui.emit-cljs-lowering-cljs-test
+(ns re-frame.freehand.emit-cljs-lowering-cljs-test
   "Focused golden for the production JSX call shape (rf2-dj7pav)."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.ui.compiler.analyze :as ana]
-            [re-frame.ui.compiler.emit-cljs :as emit]
-            [re-frame.ui.compiler.env :as env]))
+            [re-frame.freehand.compiler.analyze :as ana]
+            [re-frame.freehand.compiler.emit-cljs :as emit]
+            [re-frame.freehand.compiler.env :as env]))
 
 (defn- resolve-sym [sym]
   (case sym
@@ -13,11 +13,11 @@
     ;; a NAMESPACE alias resolving a stamped view var (`:require [app.views :as v]`)
     v/card     {:fqn 'app.views/card :meta {:rf.ui/view true}}
     ForeignComp {:fqn 'app.interop/ForeignComp :meta {}}
-    raw-fn {:fqn 're-frame.ui/raw-fn :meta {}}
-    event  {:fqn 're-frame.ui/event :meta {}}
-    ui/spread      {:fqn 're-frame.ui/spread :meta {}}
-    ui/spread-safe {:fqn 're-frame.ui/spread-safe :meta {}}
-    ui/html        {:fqn 're-frame.ui/html :meta {}}
+    raw-fn {:fqn 're-frame.freehand/raw-fn :meta {}}
+    event  {:fqn 're-frame.freehand/event :meta {}}
+    v/spread      {:fqn 're-frame.freehand/spread :meta {}}
+    v/spread-safe {:fqn 're-frame.freehand/spread-safe :meta {}}
+    v/html        {:fqn 're-frame.freehand/html :meta {}}
     nil))
 
 (defn- emitted [form]
@@ -38,14 +38,14 @@
           (forms-of form)))
 
 (def wrapper-symbols
-  '#{re-frame.ui.runtime/jsx2 re-frame.ui.runtime/jsx3
-     re-frame.ui.runtime/jsxs2 re-frame.ui.runtime/jsxs3})
+  '#{re-frame.freehand.runtime/jsx2 re-frame.freehand.runtime/jsx3
+     re-frame.freehand.runtime/jsxs2 re-frame.freehand.runtime/jsxs3})
 
 (deftest compiler-authored-sites-call-jsx-runtime-module-directly
   (let [form  (emitted '[:div [child-view {:label label}] [:span "tail"]])
         calls (vec (jsx-calls form))]
     (is (seq calls))
-    (is (every? #(= 're-frame.ui.runtime/jsx-runtime
+    (is (every? #(= 're-frame.freehand.runtime/jsx-runtime
                     (nth % 2)) calls)
         "every ordinary element/component call uses the imported module object")
     (is (not-any? wrapper-symbols (forms-of form))
@@ -74,8 +74,8 @@
                                               :checked (mark! :second)}])))
         props-form (nth call 4)]
     (is (= 'js* (first props-form)))
-    (is (= '("data-z" (re-frame.ui.runtime/attr-val (mark! :first))
-             "checked" (re-frame.ui.runtime/attr-val (mark! :second)))
+    (is (= '("data-z" (re-frame.freehand.runtime/attr-val (mark! :first))
+             "checked" (re-frame.freehand.runtime/attr-val (mark! :second)))
            (drop 2 props-form))
         "literal string keys and authored value order are explicit arguments")
     (is (re-find #"^\(\{~\{\}:~\{\},~\{\}:~\{\}\}\)$"
@@ -94,7 +94,7 @@
   (let [call       (first (jsx-calls
                            (emitted '[:div {:class {:done done?}}])))
         props-form (nth call 4)]
-    (is (some #{'re-frame.ui.rules/classes-str} (forms-of props-form))
+    (is (some #{'re-frame.freehand.rules/classes-str} (forms-of props-form))
         "without a static base the general empty-class semantics remain")))
 
 (deftest event-sites-lower-to-committed-runtime-callbacks
@@ -105,19 +105,19 @@
                                                    :once true}} "save"])
         dynamic    (emitted '[:button {:on-click handler-value} "go"])
         data-call  (first (filter #(and (seq? %)
-                                       (= 're-frame.ui.events/data-handler
+                                       (= 're-frame.freehand.events/data-handler
                                           (first %)))
                                   (forms-of controlled)))
         dyn-call   (first (filter #(and (seq? %)
-                                       (= 're-frame.ui.events/dynamic-handler
+                                       (= 're-frame.freehand.events/dynamic-handler
                                           (first %)))
                                   (forms-of dynamic)))
         once-call  (first (filter #(and (seq? %)
-                                       (= 're-frame.ui.events/data-handler
+                                       (= 're-frame.freehand.events/data-handler
                                           (first %)))
                                   (forms-of once-form)))]
-    (is (some #{'re-frame.ui.events/data-handler} (forms-of ordinary)))
-    (is (not-any? #{'re-frame.ui.runtime/dispatch-event!}
+    (is (some #{'re-frame.freehand.events/data-handler} (forms-of ordinary)))
+    (is (not-any? #{'re-frame.freehand.runtime/dispatch-event!}
                   (forms-of ordinary))
         "the staging dispatch hook is no longer generated")
     (is (some? data-call))
@@ -135,24 +135,24 @@
         uncontrolled (emitted '[:input {:on-input (event [e]
                                                     [:log (.. e -target -value)])}])
         ev-call    (first (filter #(and (seq? %)
-                                        (= 're-frame.ui.events/event-handler
+                                        (= 're-frame.freehand.events/event-handler
                                            (first %)))
                                   (forms-of controlled)))
         un-call    (first (filter #(and (seq? %)
-                                        (= 're-frame.ui.events/event-handler
+                                        (= 're-frame.freehand.events/event-handler
                                            (first %)))
                                   (forms-of uncontrolled)))]
     (is (some? ev-call)
-        "a ui/event handler lowers to the compiler-known event-handler seam")
+        "a v/event handler lowers to the compiler-known event-handler seam")
     (is (= 'fn (first (nth ev-call 2)))
         "the compiled fn body is passed for invocation with the native event")
     (is (odd? (nth ev-call 3))
         "bit 0 rides the controlled-input synchronous door, as a literal vector does")
     (is (some? un-call))
     (is (even? (nth un-call 3))
-        "an uncontrolled ui/event site batches — no sync bit")
-    (is (not-any? #{'re-frame.ui.events/dynamic-handler} (forms-of controlled))
-        "ui/event is compiler-known, not runtime-classified like a dynamic value")))
+        "an uncontrolled v/event site batches — no sync bit")
+    (is (not-any? #{'re-frame.freehand.events/dynamic-handler} (forms-of controlled))
+        "v/event is compiler-known, not runtime-classified like a dynamic value")))
 
 (deftest passive-handler-maps-lower-to-one-native-ref-not-a-react-handler
   (let [form (emitted
@@ -163,7 +163,7 @@
                                     :once true}}
                 "scroll"])
         printed (pr-str form)]
-    (is (some #{'re-frame.ui.events/passive-ref} (forms-of form))
+    (is (some #{'re-frame.freehand.events/passive-ref} (forms-of form))
         "the native listener composes through the element's sole ref prop")
     (is (not (str/includes? printed "onWheelCapture"))
         "the passive site never also installs React's synthetic handler")
@@ -185,11 +185,11 @@
         custom-event (emitted
                       '[:rf-probe {:on-my-event {:event [:probe/fired]
                                                  :passive true}}])]
-    (is (some #{'re-frame.ui.runtime/assert-object-ref!} (forms-of unmarked))
+    (is (some #{'re-frame.freehand.runtime/assert-object-ref!} (forms-of unmarked))
         "an unmarked dynamic ref is guarded as an object-ref position")
-    (is (not-any? #{'re-frame.ui.runtime/assert-object-ref!}
+    (is (not-any? #{'re-frame.freehand.runtime/assert-object-ref!}
                   (forms-of explicit))
-        "ui/raw-fn is the explicit callback-ref capability")
+        "v/raw-fn is the explicit callback-ref capability")
     (is (= 1 (count (filter #{'authored-ref} (forms-of unmarked))))
         "the guarded dynamic ref expression is evaluated once")
     (is (str/includes? (pr-str dom-event) "\"keydown\"")
@@ -203,7 +203,7 @@
   ;; carries it on the props object under the `ref` key; the callee accepts it by
   ;; declaring :ref in its header. Object refs pass through verbatim (no
   ;; element-only object-ref guard at the seam — the view forwards like a foreign
-  ;; component); a (ui/raw-fn f) callback ref forwards its fn.
+  ;; component); a (v/raw-fn f) callback ref forwards its fn.
   (let [form       (emitted '[child-view {:label label :ref my-ref}])
         call       (first (jsx-calls form))
         props-form (nth call 4)]
@@ -211,11 +211,11 @@
         "the forwarded ref rides the props object under the `ref` key")
     (is (some #{'my-ref} (forms-of props-form))
         "the authored object ref is carried into the view's props")
-    (is (= 're-frame.ui.runtime/jsx-runtime (nth call 2))
+    (is (= 're-frame.freehand.runtime/jsx-runtime (nth call 2))
         "the forwarded-ref view still lowers through the ordinary jsx runtime")
-    (is (not-any? #{'re-frame.ui.runtime/assert-object-ref!} (forms-of props-form))
+    (is (not-any? #{'re-frame.freehand.runtime/assert-object-ref!} (forms-of props-form))
         "the object ref forwards verbatim at the view seam, as at a foreign one"))
-  (testing "a (ui/raw-fn f) callback ref forwards its fn to the internal view"
+  (testing "a (v/raw-fn f) callback ref forwards its fn to the internal view"
     (let [props-form (nth (first (jsx-calls (emitted '[child-view {:ref (raw-fn cb)}]))) 4)]
       (is (some #{"ref"} (forms-of props-form)))
       (is (some #{'cb} (forms-of props-form))
@@ -230,7 +230,7 @@
                                       :passive true}}
                   "row"]))
         passive-call (first (filter #(and (seq? %)
-                                          (= 're-frame.ui.events/passive-ref
+                                          (= 're-frame.freehand.events/passive-ref
                                              (first %)))
                                     (forms-of form)))
         occurrence-path (nth passive-call 3)
@@ -255,7 +255,7 @@
       (is (= "({[~{}]:~{}})" (second props-form))
           (str (name surface) " avoids object-literal prototype-setter grammar"))
       (is (= (if (contains? #{:dom :custom-element} surface)
-               '("__proto__" (re-frame.ui.runtime/attr-val value))
+               '("__proto__" (re-frame.freehand.runtime/attr-val value))
                '("__proto__" value))
              (drop 2 props-form))
           (str (name surface) " retains the authored own property and value")))))
@@ -272,7 +272,7 @@
 (defn- bare-alias-guard [form]
   (first (filter #(and (seq? %)
                        (= 'if (first %))
-                       (some #{'re-frame.ui.runtime/warn-bare-view-alias!}
+                       (some #{'re-frame.freehand.runtime/warn-bare-view-alias!}
                              (forms-of %)))
                  (forms-of form))))
 
@@ -283,7 +283,7 @@
         "a foreign-classified head is consulted at runtime for a bare view-alias")
     (is (= 'js/goog.DEBUG (second guard))
         "the guard is goog.DEBUG-gated so :advanced elides it in production")
-    (is (= '(re-frame.ui.runtime/warn-bare-view-alias! ForeignComp) (nth guard 2))
+    (is (= '(re-frame.freehand.runtime/warn-bare-view-alias! ForeignComp) (nth guard 2))
         "the dev arm consults the shell marker, passing the authored head")
     (is (= 'ForeignComp (nth guard 3))
         "the production arm is the bare head verbatim — no residue")))
@@ -294,43 +294,43 @@
   (testing "a namespace-aliased view head resolves the stamped var and stays quiet"
     (is (nil? (bare-alias-guard (emitted '[v/card {:x 1}])))))
   (testing "no view head ever routes through the runtime bare-view-alias guard"
-    (is (not-any? #{'re-frame.ui.runtime/warn-bare-view-alias!}
+    (is (not-any? #{'re-frame.freehand.runtime/warn-bare-view-alias!}
                   (forms-of (emitted '[:div [child-view {:label l}]
                                        [v/card {:x 1}]]))))))
 
 ;; ---------------------------------------------------------------------------
-;; ui/spread at a FOREIGN component call site (rf2-u53yy.5)
+;; v/spread at a FOREIGN component call site (rf2-u53yy.5)
 ;; ---------------------------------------------------------------------------
 
 (deftest foreign-spread-merges-the-forwarded-map-under-the-literal-props
   (let [form  (emitted '[ForeignComp
-                         (ui/spread {:selected d :on-change (event [v] [:pick v])}
+                         (v/spread {:selected d :on-change (event [v] [:pick v])}
                                     forwarded)])
         props (nth form 2)]
-    (is (= 're-frame.ui.runtime/jsx-spread2 (first form))
+    (is (= 're-frame.freehand.runtime/jsx-spread2 (first form))
         "a foreign spread routes through the runtime-built-props jsx helper")
-    (is (= '(re-frame.ui.runtime/warn-bare-view-alias! ForeignComp)
+    (is (= '(re-frame.freehand.runtime/warn-bare-view-alias! ForeignComp)
            (nth (nth form 1) 2))
         "the foreign head keeps its dev-gated bare-view-alias guard")
     (is (= "let" (name (first props)))
         "the merged props object binds single-evaluation temporaries")
-    (is (some #{'re-frame.ui.runtime/foreign-spread-props} (forms-of props))
+    (is (some #{'re-frame.freehand.runtime/foreign-spread-props} (forms-of props))
         "the literal props are layered over the forwarded map by foreign-spread-props")
-    (is (some #{'re-frame.ui.events/event-handler} (forms-of props))
-        "the literal part's ui/event compiles to a committed callback")
+    (is (some #{'re-frame.freehand.events/event-handler} (forms-of props))
+        "the literal part's v/event compiles to a committed callback")
     (is (= 1 (count (filter #{'forwarded} (forms-of form))))
         "the forwarded runtime map evaluates exactly once")
     (is (= '(cljs.core/array) (last form))
         "no positional children on this call site")))
 
 (deftest foreign-spread-with-a-key-selects-the-three-arg-jsx-helper
-  (let [form (emitted '[ForeignComp (ui/spread {:key k :a 1} m)])]
-    (is (= 're-frame.ui.runtime/jsx-spread3 (first form))
+  (let [form (emitted '[ForeignComp (v/spread {:key k :a 1} m)])]
+    (is (= 're-frame.freehand.runtime/jsx-spread3 (first form))
         "a literal :key in the spread's literal part selects the 3-arg spread jsx")
     (is (= 'k (nth form 3)) "the key expression rides the jsx key argument")))
 
 ;; ---------------------------------------------------------------------------
-;; ui/spread + ui/html compose (rf2-29s75)
+;; v/spread + v/html compose (rf2-29s75)
 ;;
 ;; The general-spread branch builds its props object at RUNTIME and never goes
 ;; through `element-prop-pairs`, so the compiler-owned dangerouslySetInnerHTML
@@ -357,24 +357,24 @@
           (forms-of form)))
 
 (deftest general-spread-carries-trusted-markup-to-react
-  (let [form     (emitted '[:div (ui/spread base ovr) (ui/html markup)])
+  (let [form     (emitted '[:div (v/spread base ovr) (v/html markup)])
         sets     (vec (inner-html-sets form))
         objs     (vec (html-objs form))
         children (last form)]
-    (is (= 're-frame.ui.runtime/jsx-spread2 (first form))
+    (is (= 're-frame.freehand.runtime/jsx-spread2 (first form))
         "an unkeyed spread element still routes through the spread jsx helper")
     (is (= 1 (count sets))
         "exactly one dangerouslySetInnerHTML is attached to the spread props object")
     (is (= 1 (count objs))
         "exactly one __html carrier is built")
     (is (= '(cljs.core/js-obj "__html" markup) (first objs))
-        "the authored ui/html expression is the __html value, unwrapped and unsanitised")
+        "the authored v/html expression is the __html value, unwrapped and unsanitised")
     (is (= '(cljs.core/array) children)
         "the markup takes NO positional child slot — React's children-vs-innerHTML
          conflict cannot arise")))
 
 (deftest spread-and-markup-expressions-evaluate-once-each-in-source-order
-  (let [form    (emitted '[:div (ui/spread base ovr) (ui/html markup)])
+  (let [form    (emitted '[:div (v/spread base ovr) (v/html markup)])
         props   (nth form 2)
         [_ bindings & body] props
         init    (second bindings)]
@@ -384,7 +384,7 @@
     ;; the node-test build. Assert the binding form, not the core alias.
     (is (= "let" (name (first props)))
         "the runtime-built props object is bound to a single-evaluation temporary")
-    (is (= 're-frame.ui.runtime/spread->props (first init))
+    (is (= 're-frame.freehand.runtime/spread->props (first init))
         "the temporary is the object spread->props returned")
     (is (every? #(= 1 (occurrences % form)) '[base ovr markup])
         "base, overrides and the markup expression each evaluate exactly once")
@@ -399,21 +399,21 @@
         "the let returns the same props object it mutated")))
 
 (deftest trusted-markup-wins-over-a-runtime-smuggled-inner-html-key
-  (let [form  (emitted '[:div (ui/spread base ovr) (ui/html markup)])
+  (let [form  (emitted '[:div (v/spread base ovr) (v/html markup)])
         props (nth form 2)
         [_ _ & body] props]
     (is (= 'cljs.core/unchecked-set (ffirst body))
         "the compiler-owned prop is set AFTER spread->props returns, so the
-         visible (ui/html …) site — the trust assertion — wins any same-key
+         visible (v/html …) site — the trust assertion — wins any same-key
          value carried in through the runtime prop map (see rf2-5pr75)")))
 
 (deftest spread-without-trusted-markup-is-unchanged
-  (let [plain (emitted '[:div (ui/spread base ovr) [:span "a"] [:span "b"]])]
+  (let [plain (emitted '[:div (v/spread base ovr) [:span "a"] [:span "b"]])]
     (is (empty? (inner-html-sets plain))
         "an ordinary spread element gains no innerHTML prop")
     (is (empty? (html-objs plain)))
     (is (some #(and (seq? %)
-                    (= 're-frame.ui.runtime/spread->props (first %)))
+                    (= 're-frame.freehand.runtime/spread->props (first %)))
               (forms-of plain))
         "the runtime-built props object is still the bare spread->props call")
     (is (= 2 (count (rest (last (filter #(and (seq? %)
@@ -423,16 +423,16 @@
 
 (deftest safe-spread-composes-with-trusted-markup-in-both-key-shapes
   (testing "keyless — the sibling spread form already composed; pin it"
-    (let [form (emitted '[:div (ui/spread-safe {:class "owned"} caller)
-                          (ui/html markup)])]
-      (is (= 're-frame.ui.runtime/jsx-spread2 (first form)))
+    (let [form (emitted '[:div (v/spread-safe {:class "owned"} caller)
+                          (v/html markup)])]
+      (is (= 're-frame.freehand.runtime/jsx-spread2 (first form)))
       (is (= 1 (count (html-objs form))))
       (is (= '(cljs.core/array) (last form))
           "no positional child accompanies the markup")))
   (testing "keyed — the jsx-spread3 arm carries the markup too"
-    (let [form (emitted '[:div (ui/spread-safe {:key k :class "owned"} caller)
-                          (ui/html markup)])]
-      (is (= 're-frame.ui.runtime/jsx-spread3 (first form)))
+    (let [form (emitted '[:div (v/spread-safe {:key k :class "owned"} caller)
+                          (v/html markup)])]
+      (is (= 're-frame.freehand.runtime/jsx-spread3 (first form)))
       (is (= 1 (count (html-objs form))))
       (is (= 'k (nth form 3))
           "the authored key still reaches React's third argument")

--- a/implementation/freehand/test/re_frame/freehand/emit_cljs_view_evidence_annotation_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/emit_cljs_view_evidence_annotation_cljs_test.cljc
@@ -1,13 +1,13 @@
-(ns re-frame.ui.emit-cljs-view-evidence-annotation-cljs-test
+(ns re-frame.freehand.emit-cljs-view-evidence-annotation-cljs-test
   "98.1 slice (c) — cross-host golden for the host-root view-evidence annotation
   wiring (rf2-hac8p). The emitter is `.cljc`, so the exact CLJS expansion is data
   on BOTH hosts: a host-root-marked element lowers to the DEV-gated
   `data-rf2-source-coord` / `data-rf-view` stamp on its props object, and an
   unmarked element lowers unchanged."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.ui.compiler.analyze :as ana]
-            [re-frame.ui.compiler.emit-cljs :as emit]
-            [re-frame.ui.compiler.env :as env]))
+            [re-frame.freehand.compiler.analyze :as ana]
+            [re-frame.freehand.compiler.emit-cljs :as emit]
+            [re-frame.freehand.compiler.env :as env]))
 
 (defn- forms-of [form] (tree-seq coll? seq form))
 

--- a/implementation/freehand/test/re_frame/freehand/emit_cljs_view_evidence_annotation_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/emit_cljs_view_evidence_annotation_jvm_test.clj
@@ -1,4 +1,4 @@
-(ns re-frame.ui.emit-cljs-view-evidence-annotation-jvm-test
+(ns re-frame.freehand.emit-cljs-view-evidence-annotation-jvm-test
   "98.1 slice (c) — the compiler emits the view-evidence DOM annotation onto its
   compiler-owned host root (rf2-hac8p).
 
@@ -11,7 +11,7 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [re-frame.source-coords :as source-coord]
-            [re-frame.ui.compiler :as compiler]))
+            [re-frame.freehand.compiler :as compiler]))
 
 (defn- cljs-emit
   "Run the REAL cljs `defview*` emit path for `template` under `ns-sym`/`vname`

--- a/implementation/freehand/test/re_frame/freehand/eq_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/eq_cljs_test.cljc
@@ -1,7 +1,7 @@
-(ns re-frame.ui.eq-cljs-test
+(ns re-frame.freehand.eq-cljs-test
   "The ruled rf= truth table (Object.is OR =, per slot) — both hosts."
   (:require [clojure.test :refer [deftest is]]
-            [re-frame.ui.eq :refer [rf= deps-rf=?]]))
+            [re-frame.freehand.eq :refer [rf= deps-rf=?]]))
 
 (deftest value-branch
   (is (true? (rf= {:a [1 2]} {:a [1 2]}))

--- a/implementation/freehand/test/re_frame/freehand/fingerprint_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/fingerprint_cljs_test.cljc
@@ -1,11 +1,11 @@
-(ns re-frame.ui.fingerprint-cljs-test
+(ns re-frame.freehand.fingerprint-cljs-test
   "template-fingerprint / hook-signature-hash / config-fingerprint — the named
   home's algorithm pins (FNV-1a 64 over canonical EDN, version-prefixed
   hex). The literal golden pins CROSS-HOST equality: the same input must
-  digest identically under `clojure -M:test` and `npm run test:ui`."
+  digest identically under `clojure -M:test` and `npm run test:freehand`."
   (:require [clojure.string :as string]
             [clojure.test :refer [deftest is]]
-            [re-frame.ui.fingerprint :as fp]))
+            [re-frame.freehand.fingerprint :as fp]))
 
 (deftest canonical-string-is-order-insensitive
   (is (= (fp/canonical-string {:b 2 :a 1})
@@ -185,16 +185,16 @@
 (deftest record-tag-cross-host-golden
   ;; The record TAG is the one part of the encoding whose natural host
   ;; renderings DIVERGE — the JVM has a munged, dotted class name
-  ;; (`re_frame.ui.fingerprint_cljs_test.RecA`) where CLJS has the
-  ;; `cljs$lang$ctorPrWriter` literal (`re-frame.ui.fingerprint-cljs-test/RecA`).
+  ;; (`re_frame.freehand.fingerprint_cljs_test.RecA`) where CLJS has the
+  ;; `cljs$lang$ctorPrWriter` literal (`re-frame.freehand.fingerprint-cljs-test/RecA`).
   ;; `record-type-name` normalizes the JVM side onto the CLJS form, so these
   ;; JVM-computed literals must reproduce EXACTLY under the CLJS run. Without
   ;; that normalization a build-time (JVM) digest and a client (CLJS) digest of
   ;; the SAME plan would differ — a spurious plan conflict, the mirror-image
   ;; failure of the collapse this bead fixed.
-  (is (= "cf1-b812168c861e3c0c" (fp/config-fingerprint :frame/f (->RecA 1)))
+  (is (= "cf1-703c3e470d333f0b" (fp/config-fingerprint :frame/f (->RecA 1)))
       "cross-host golden — JVM-computed literal; the CLJS run must match")
-  (is (= "cf1-d5f464cf44df9810" (fp/config-fingerprint :frame/f {:k (->RecA 1)}))
+  (is (= "cf1-e1749d778d5b993d" (fp/config-fingerprint :frame/f {:k (->RecA 1)}))
       "cross-host golden — record nested as a map value")
   ;; The record branch is CONSERVATIVE: it changes the encoding of nothing but
   ;; records, so no fingerprint over the record-free value space moves and the

--- a/implementation/freehand/test/re_frame/freehand/reserved_head_reject_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/reserved_head_reject_cljs_test.cljc
@@ -1,11 +1,11 @@
-(ns re-frame.ui.reserved-head-reject-cljs-test
-  "re-frame.ui rejects an UNRECOGNISED `:rf/*` hiccup head (rf2-01zvu, the
+(ns re-frame.freehand.reserved-head-reject-cljs-test
+  "re-frame.freehand rejects an UNRECOGNISED `:rf/*` hiccup head (rf2-01zvu, the
   client half of the rf2-j81hs SS4 ruling).
 
   Unlike reagent-slim — whose head classification is a RUNTIME dispatch —
-  re-frame.ui classifies heads at COMPILE time: `analyze` routes every
+  re-frame.freehand classifies heads at COMPILE time: `analyze` routes every
   keyword head to `analyze-element` → `parse-tag`, which already rejected
-  EVERY namespaced keyword with `:rf.ui.compile/bad-tag`. So re-frame.ui
+  EVERY namespaced keyword with `:rf.ui.compile/bad-tag`. So re-frame.freehand
   never painted a phantom; the gap here was the ADVICE. For a reserved
   head the generic message read \"tag keywords carry no namespace (write
   :suspense-boundary)\" — which tells the author to strip the namespace and
@@ -20,8 +20,8 @@
   (the catalogue covers the RUNTIME `:rf.error/*` axis)."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
-            [re-frame.ui.compiler.analyze :as ana]
-            [re-frame.ui.analyze-accept-cljs-test :refer [mk-env]]))
+            [re-frame.freehand.compiler.analyze :as ana]
+            [re-frame.freehand.analyze-accept-cljs-test :refer [mk-env]]))
 
 (defn- reject
   "{:id … :msg …} for a rejected form; nil when accepted."

--- a/implementation/ui/src/re_frame/ui/eq.cljc
+++ b/implementation/ui/src/re_frame/ui/eq.cljc
@@ -6,7 +6,7 @@
 
       Object.is(a, b)  OR  (= a b)
 
-  Consequences (all pinned by `re-frame.ui.eq-cljs-test`):
+  Consequences (all pinned by `re-frame.freehand.eq-cljs-test`):
 
   - CLJS data (anything with `IEquiv`, incl. records and js/Date) compares
     by VALUE — fresh-but-equal literals do not repaint.

--- a/implementation/ui/src/re_frame/ui/fingerprint.cljc
+++ b/implementation/ui/src/re_frame/ui/fingerprint.cljc
@@ -62,7 +62,7 @@
   digest identically (no spurious plan-conflict); a genuine config change —
   including a set↔vector↔list type flip, or a record type swap — always
   digests differently. Cross-host equality of the hex output is pinned by
-  `re-frame.ui.fingerprint-cljs-test`."
+  `re-frame.freehand.fingerprint-cljs-test`."
   (:require [clojure.string :as str]))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc
@@ -613,7 +613,7 @@
 (def ^:private a11y-suite-warning-ids
   "The S4-C a11y ids, frozen HERE but exercised — in BOTH the firing and the
   silent direction, which is the load-bearing half — by their owning suite
-  `re-frame.ui.a11y-diagnostics-cljs-test`."
+  `re-frame.freehand.a11y-diagnostics-cljs-test`."
   #{:rf.ui.compile/a11y-missing-accessible-name
     :rf.ui.compile/a11y-invalid-literal-aria
     :rf.ui.compile/a11y-click-non-interactive

--- a/implementation/ui/test/re_frame/ui/reactive_hmr_matrix_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/reactive_hmr_matrix_cljs_test.cljc
@@ -34,7 +34,7 @@
        and a file-save reload carrying the same hook signature both keep the
        generation; both carrying a changed signature both bump — identical
        outcomes. (The build-authority upsert-vs-pass convergence is
-       `re-frame.ui.build-repl-hmr-convergence-jvm-test`.)"
+       `re-frame.freehand.build-repl-hmr-convergence-jvm-test`.)"
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core                  :as rf]

--- a/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_cljs_test.cljc
@@ -183,7 +183,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Custom-element runtime reconciliation registry — the reload-cycle protocol
 ;; (rf2-vxgfnd.67, residual of .48). The RUNTIME arm of .16 AC5; the compile/JVM
-;; arm lives in re-frame.ui.compiler-build-jvm-test. Eviction is driven from the
+;; arm lives in re-frame.freehand.compiler-build-jvm-test. Eviction is driven from the
 ;; reload BOUNDARY (notify-reload! / commit-reload!), NOT from a surviving
 ;; re-registration — so a source that now declares zero elements, or whose file
 ;; is deleted, is reconciled away too.

--- a/implementation/ui/test/re_frame/ui/rules_custom_element_conflict_cljs_test.cljc
+++ b/implementation/ui/test/re_frame/ui/rules_custom_element_conflict_cljs_test.cljc
@@ -27,7 +27,7 @@
 
   WHERE THE OTHER ARMS ARE PINNED. The COMPILE arm's barrier and detector
   (`build/contribute-element-checked!` / `build/elements-conflict`, PR #6006)
-  are pinned by `re-frame.ui.compiler-build-jvm-test`. The PRODUCTION arm —
+  are pinned by `re-frame.freehand.compiler-build-jvm-test`. The PRODUCTION arm —
   that this law survives `:advanced` + `goog.DEBUG=false` at all, which is the
   whole point of the placement amendment — is pinned from INSIDE the release
   bundle by `re-frame.ui.custom-element-reload-elision-prod-test`. This suite

--- a/implementation/ui/test/re_frame/ui/s4_conformance_profile_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/s4_conformance_profile_jvm_test.clj
@@ -208,7 +208,12 @@
                     "`(ui/presence-phase) = :unmounting`"]}})
 
 (def a11y-suppress-error :rf.ui.compile/bad-suppress)
-(def a11y-proof-home "re-frame.ui.a11y-diagnostics-cljs-test")
+;; The a11y roster's proof home moved with the compile tier itself (EP-0036
+;; slice F3a): the analyzer, both emitters and the a11y diagnostics they mint
+;; are owned by `implementation/freehand/` now, so the suite that proves this
+;; roster lives there. The profile is donor-era evidence and is deleted at the
+;; retirement gate; until then it must name where the proof ACTUALLY is.
+(def a11y-proof-home "re-frame.freehand.a11y-diagnostics-cljs-test")
 
 ;; ---------------------------------------------------------------------------
 ;; (3) The W14 dual-emitter PARITY rows S4 contributes to the compiled-view
@@ -663,18 +668,23 @@
 (deftest profile-names-real-proof-homes
   ;; A proof home that is not a real test namespace is a lie the row-binding
   ;; checks above cannot see — they only prove the STRING is in the row.
-  (let [test-root (io/file (repo-root) "implementation" "ui" "test")
+  (let [test-roots [(io/file (repo-root) "implementation" "ui" "test")
+                    ;; The absorbed compile tier's suites (EP-0036 slice F3a).
+                    (io/file (repo-root) "implementation" "freehand" "test")]
         exists?   (fn [ns-name]
                     (let [base (-> ns-name (str/replace "-" "_") (str/replace "." "/"))]
-                      (some #(.exists (io/file test-root (str base %)))
-                            [".clj" ".cljs" ".cljc"])))]
+                      (some (fn [root]
+                              (some #(.exists (io/file root (str base %)))
+                                    [".clj" ".cljs" ".cljc"]))
+                            test-roots)))]
     (doseq [home (concat (mapcat (juxt :jvm-proof :cljs-proof) (vals frozen-s4-forms))
                          [(:jvm-proof frozen-foreign-head)
                           (:cljs-proof frozen-foreign-head)
                           a11y-proof-home])]
       (is (exists? home)
           (str "the profile names proof home " home
-               ", which is not a test namespace under implementation/ui/test")))))
+               ", which is not a test namespace under implementation/ui/test "
+               "or implementation/freehand/test")))))
 
 ;; --- the ruled sequencing, non-parity, S5-wall and hand-off obligations ------
 

--- a/spec/004D-Freehand-Compiled-Grammar.md
+++ b/spec/004D-Freehand-Compiled-Grammar.md
@@ -263,7 +263,7 @@ runtime dynamic reactive site, no ViewCell overhead for sub-free views, and no
 compatibility fallback. The set grows only by ruling, and any addition requires
 lexical-scope plus hidden-reactive-injection counterfixtures (the rf2-vxgfnd.100
 hidden-sub / helper / binder-macro proofs in
-`re-frame.ui.compiler-macro-resolution-jvm-test` are the template — the admitted
+`re-frame.freehand.compiler-macro-resolution-jvm-test` are the template — the admitted
 `if-let` family adds its own binder-lowering + out-of-family + pattern-escape rows,
 plus the resolver-confirmation and generated-code-hygiene counterfixtures: a
 same-spelled user macro is rejected, and a hostile local named `some?` / `when`

--- a/spec/004D-Freehand-Compiled-Grammar.md
+++ b/spec/004D-Freehand-Compiled-Grammar.md
@@ -23,6 +23,20 @@
 > (artifact `day8/re-frame2-ui`, alias `ui/`), the donor absorbed by Freehand; frames
 > are created at host preflight (per [002](002-Frames.md)), never from render. SSR
 > ([011](011-SSR.md)) renders the same views on the JVM without React.
+>
+> **Where the compile tier lives.** The analyzer, the React emitter, the JVM
+> emitter and the host-neutral normalizers they share are **owned by Freehand**
+> and live in the Freehand artifact: `re-frame.freehand.compiler` and its
+> `analyze` / `emit-cljs` / `emit-jvm` / `env` / `header` / `binding-plan` /
+> `a11y` / `build` / `build-hook` / `harvest` / `root` namespaces, over
+> `re-frame.freehand.rules`, `re-frame.freehand.fingerprint` and
+> `re-frame.freehand.eq`. The two emitters remain **separate implementations**
+> over one normalized AST: sharing a normalizer is not sharing an emitter, and
+> neither consumes the other's output. The donor artifact keeps its own frozen
+> copy of that code only so it still builds while the two coexist — that copy is
+> not a second owner, and it is deleted with the artifact. Reuse of donor code
+> confers no API status: none of these namespaces is Freehand API, which is
+> `re-frame.freehand` alone.
 
 ## Abstract
 

--- a/spec/conformance/S4-view-conformance-profile.md
+++ b/spec/conformance/S4-view-conformance-profile.md
@@ -133,7 +133,7 @@ warning while the finding remains a manifest `:diagnostics` fact carrying its
 reason. A malformed suppression — an unknown id, a blank or non-string reason —
 is the loud compile error `:rf.ui.compile/bad-suppress`, never a silent no-op.
 
-Proven by `re-frame.ui.a11y-diagnostics-cljs-test` (host-shared, pure analyzer);
+Proven by `re-frame.freehand.a11y-diagnostics-cljs-test` (host-shared, pure analyzer);
 the diagnostics reach tooling through the Xray diagnostics channel.
 
 ### 1.4 The foreign boundary
@@ -238,7 +238,7 @@ owns it:
 |---|---|---|
 | `ui/raw` / foreign component head | a **host escape** — rendering it on the JVM raises `:rf.error/jvm-host-op` by contract, so there is **no JVM side to compare** | paired: `re-frame.ui.raw-foreign-boundary-jvm-test` + `re-frame.ui.raw-foreign-boundary-dom-cljs-test` |
 | the document head | an **absence of surface** (§3), not an emitted shape — there is nothing for either emitter to produce | the facade/op-set absence guards in this profile's drift guard |
-| the a11y roster | **compile-time analyzer facts** — findings are produced during analysis and never reach either emitter's output | `re-frame.ui.a11y-diagnostics-cljs-test` (host-shared, pure analyzer) |
+| the a11y roster | **compile-time analyzer facts** — findings are produced during analysis and never reach either emitter's output | `re-frame.freehand.a11y-diagnostics-cljs-test` (host-shared, pure analyzer) |
 | presence's three-phase machine | **host-bearing** — retention timers, and the phase a *first* render reports, are mounted questions (and, for the server, S5's) | `re-frame.ui.presence-dom-cljs-test` (mounted) + `re-frame.ui.presence-jvm-test` (structural) |
 
 The corpus rows above carry only the **portable** half of each S4 surface — the

--- a/spec/conformance/freehand/donor-inventory.md
+++ b/spec/conformance/freehand/donor-inventory.md
@@ -33,6 +33,18 @@ Reuse of donor code confers no API status. A `MOVE` row means the
 implementation is worth keeping, never that the donor's public spelling
 survives.
 
+For a donor **source** file, `done` records that Freehand owns the code — not
+that the donor's file has vanished. Absorbed code diverges the moment it
+lands: the moved analyzer recognizes Freehand vars and the moved emitters
+lower to Freehand runtime namespaces, so the donor cannot run on its own
+absorbed code, and the donor artifact has to keep building for the whole of
+coexistence. Its copy therefore stays where it is — vestigial and frozen —
+until the artifact is deleted whole. What `done` asserts is precisely this:
+nothing further has to be extracted from that file, and deleting the donor
+costs Freehand nothing. Donor **tests** are different: a suite proves a
+contract, and the contract has one owner, so a moved suite leaves the donor
+tree in the change that moves it.
+
 ## Granularity rules
 
 Three rules fix what gets a row, so coverage can be checked mechanically rather
@@ -153,28 +165,28 @@ Every tracked file under `implementation/ui/src/`.
 |---|---|---|---|---|
 | `implementation/ui/src/re_frame/ui.cljc` | the donor public facade — `defview`, `custom-element`, `sub`, interop forms, `local`, `effect`, `ref`, `presence`, `route-link`, mount | REPLACE | F1 | pending |
 | `implementation/ui/src/re_frame/ui/client.cljs` | Root handle, live-root claim registry, mount / render! / hydrate-root / unmount! | MOVE | F1 | pending |
-| `implementation/ui/src/re_frame/ui/compiler.cljc` | the declaration expansion pipeline: arity and options parsing, header analysis, manifest and fingerprint assembly, per-host emission | MOVE | F3 | pending |
-| `implementation/ui/src/re_frame/ui/compiler/a11y.cljc` | compile-tier accessibility diagnostics minted from literal template facts | MOVE | F3 | pending |
-| `implementation/ui/src/re_frame/ui/compiler/analyze.cljc` | the template-grammar analyzer and its closed normalized AST | MOVE | F3 | pending |
-| `implementation/ui/src/re_frame/ui/compiler/binding_plan.cljc` | the one host-faithful associative-destructuring binding plan | MOVE | F3 | pending |
-| `implementation/ui/src/re_frame/ui/compiler/build.cljc` | build-scoped compiler registries and the acceptance transaction | MOVE | F3 | pending |
-| `implementation/ui/src/re_frame/ui/compiler/build_hook.clj` | the shadow-cljs build-lifecycle adapter that harvests whole-build registries | MOVE | F3 | pending |
-| `implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc` | the React emitter — direct jsx-runtime lowering, static hoisting, per-slot comparators | MOVE | F3 | pending |
-| `implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc` | the JVM emitter — the versioned structural tree, event vectors retained as data | MOVE | F3 | pending |
-| `implementation/ui/src/re_frame/ui/compiler/env.cljc` | compile-time environment and internal-versus-foreign head resolution | MOVE | F3 | pending |
-| `implementation/ui/src/re_frame/ui/compiler/harvest.clj` | deterministic pre-seed of compile-time custom-element declarations | MOVE | F3 | pending |
-| `implementation/ui/src/re_frame/ui/compiler/header.cljc` | props-binding analysis: destructuring lowering, `:as` materialization, `:or` defaults | MOVE | F3 | pending |
-| `implementation/ui/src/re_frame/ui/compiler/root.cljc` | root-id grammar, deterministic slug, and the static top-region scan | MOVE | F3 | pending |
-| `implementation/ui/src/re_frame/ui/eq.cljc` | `rf=`, the ruled per-slot equality behind memo-by-default | MOVE | F1 | pending |
+| `implementation/ui/src/re_frame/ui/compiler.cljc` | the declaration expansion pipeline: arity and options parsing, header analysis, manifest and fingerprint assembly, per-host emission | MOVE | F3 | done |
+| `implementation/ui/src/re_frame/ui/compiler/a11y.cljc` | compile-tier accessibility diagnostics minted from literal template facts | MOVE | F3 | done |
+| `implementation/ui/src/re_frame/ui/compiler/analyze.cljc` | the template-grammar analyzer and its closed normalized AST | MOVE | F3 | done |
+| `implementation/ui/src/re_frame/ui/compiler/binding_plan.cljc` | the one host-faithful associative-destructuring binding plan | MOVE | F3 | done |
+| `implementation/ui/src/re_frame/ui/compiler/build.cljc` | build-scoped compiler registries and the acceptance transaction | MOVE | F3 | done |
+| `implementation/ui/src/re_frame/ui/compiler/build_hook.clj` | the shadow-cljs build-lifecycle adapter that harvests whole-build registries | MOVE | F3 | done |
+| `implementation/ui/src/re_frame/ui/compiler/emit_cljs.cljc` | the React emitter — direct jsx-runtime lowering, static hoisting, per-slot comparators | MOVE | F3 | done |
+| `implementation/ui/src/re_frame/ui/compiler/emit_jvm.cljc` | the JVM emitter — the versioned structural tree, event vectors retained as data | MOVE | F3 | done |
+| `implementation/ui/src/re_frame/ui/compiler/env.cljc` | compile-time environment and internal-versus-foreign head resolution | MOVE | F3 | done |
+| `implementation/ui/src/re_frame/ui/compiler/harvest.clj` | deterministic pre-seed of compile-time custom-element declarations | MOVE | F3 | done |
+| `implementation/ui/src/re_frame/ui/compiler/header.cljc` | props-binding analysis: destructuring lowering, `:as` materialization, `:or` defaults | MOVE | F3 | done |
+| `implementation/ui/src/re_frame/ui/compiler/root.cljc` | root-id grammar, deterministic slug, and the static top-region scan | MOVE | F3 | done |
+| `implementation/ui/src/re_frame/ui/eq.cljc` | `rf=`, the ruled per-slot equality behind memo-by-default | MOVE | F3 | done |
 | `implementation/ui/src/re_frame/ui/events.cljs` | commit-owned native event callbacks; the candidate table an abandoned render cannot retarget | MOVE | F2 | pending |
-| `implementation/ui/src/re_frame/ui/fingerprint.cljc` | template fingerprint and hook-signature digests; the hook-signature arm goes with the hook tier | MOVE | F1 | pending |
+| `implementation/ui/src/re_frame/ui/fingerprint.cljc` | template fingerprint and hook-signature digests; the hook-signature arm goes with the hook tier | MOVE | F3 | done |
 | `implementation/ui/src/re_frame/ui/frames.cljc` | preflight ENSURE executor, plan-install registry, frame-scope elements, ambient frame resolution | MOVE | F2 | pending |
 | `implementation/ui/src/re_frame/ui/hooks.cljc` | the host-hook lowering targets `local` / `effect` / `dispatch-fn` / `use-ref` lower to | DELETE | F1 | pending |
 | `implementation/ui/src/re_frame/ui/presence_runtime.cljc` | the three-phase keyed retention machine and its terminal timeout bound | MOVE | F4 | pending |
 | `implementation/ui/src/re_frame/ui/react.cljc` | the six-wrapper neutral React tier: effect, layout-effect, effect-event, context, id, lazy | DELETE | F5 | pending |
 | `implementation/ui/src/re_frame/ui/reactive.cljc` | the ViewCell, the render-side probe/record protocol, the layout-commit reconciler, the lifecycle | MOVE | F2 | pending |
 | `implementation/ui/src/re_frame/ui/route_link_seam.cljc` | runtime helpers consuming the late-bound routing link-model and activate hooks | MOVE | F5 | pending |
-| `implementation/ui/src/re_frame/ui/rules.cljc` | the one DOM prop-conversion rule table shared by analyzers, emitters, and the JVM tree | MOVE | F1 | pending |
+| `implementation/ui/src/re_frame/ui/rules.cljc` | the one DOM prop-conversion rule table shared by analyzers, emitters, and the JVM tree | MOVE | F3 | done |
 | `implementation/ui/src/re_frame/ui/runtime.cljs` | the small client vocabulary emitted code calls, including the one sanctioned runtime conversion | MOVE | F3 | pending |
 | `implementation/ui/src/re_frame/ui/semantic.cljc` | semantic normalization — the parity and fingerprint input | MOVE | F1 | pending |
 | `implementation/ui/src/re_frame/ui/sub_overrides.cljs` | the React carriage for story-supplied subscription overrides | MOVE | F2 | pending |
@@ -194,27 +206,27 @@ re-proved against the Freehand contract rather than ported line by line.
 
 | Donor row | What it is | Disposition | Slice | Status |
 |---|---|---|---|---|
-| `implementation/ui/test/re_frame/ui/a11y_*` | compile-tier accessibility diagnostics | MOVE | F3 | pending |
+| `implementation/ui/test/re_frame/ui/a11y_*` | compile-tier accessibility diagnostics | MOVE | F3 | done |
 | `implementation/ui/test/re_frame/ui/adapter_*` | substrate adapter installation, conformance, generation fence, public root disposal | MOVE | F2 | pending |
-| `implementation/ui/test/re_frame/ui/analyze_*` | analyzer accept and reject corpora | MOVE | F3 | pending |
+| `implementation/ui/test/re_frame/ui/analyze_*` | analyzer accept and reject corpora | MOVE | F3 | done |
 | `implementation/ui/test/re_frame/ui/authored_collision_*` | authored view-id collision detection | MOVE | F1 | pending |
 | `implementation/ui/test/re_frame/ui/binding_plan_*` | host-faithful destructuring plan, including advanced-build elision | MOVE | F3 | pending |
 | `implementation/ui/test/re_frame/ui/build_*` | build probe and REPL/HMR build convergence | MOVE | F3 | pending |
 | `implementation/ui/test/re_frame/ui/callbacks_*` | callback boundary ownership across hosts | MOVE | F2 | pending |
 | `implementation/ui/test/re_frame/ui/committed_events_*` | the committed-events publication law | MOVE | F2 | pending |
-| `implementation/ui/test/re_frame/ui/compiler_*` | build hook, build state, harvest, and macro resolution | MOVE | F3 | pending |
+| `implementation/ui/test/re_frame/ui/compiler_*` | build hook, build state, harvest, and macro resolution | MOVE | F3 | done |
 | `implementation/ui/test/re_frame/ui/conditional_root_annotation_*` | root annotation under conditional markup | MOVE | F3 | pending |
 | `implementation/ui/test/re_frame/ui/conditional_sub_*` | subscriptions inside conditional branches | MOVE | F2 | pending |
 | `implementation/ui/test/re_frame/ui/custom_element_*` | custom-element classification, ordering, conflict, spread parity, warm staleness, elision | MOVE | F3 | pending |
 | `implementation/ui/test/re_frame/ui/defview_grammar_*` | the declaration grammar itself | MOVE | F1 | pending |
 | `implementation/ui/test/re_frame/ui/digest_probe/*` | the warm-watch digest probe project used by the recompile gate | MOVE | F3 | pending |
-| `implementation/ui/test/re_frame/ui/emit_cljs_*` | React-emitter lowering and view-evidence annotation | MOVE | F3 | pending |
-| `implementation/ui/test/re_frame/ui/eq_*` | the per-slot equality law | MOVE | F1 | pending |
+| `implementation/ui/test/re_frame/ui/emit_cljs_*` | React-emitter lowering and view-evidence annotation | MOVE | F3 | done |
+| `implementation/ui/test/re_frame/ui/eq_*` | the per-slot equality law | MOVE | F3 | done |
 | `implementation/ui/test/re_frame/ui/error_roster_*` | the diagnostic-id roster | MOVE | F1 | pending |
 | `implementation/ui/test/re_frame/ui/event_*` | event warning scope and event-wrapper shapes | MOVE | F2 | pending |
 | `implementation/ui/test/re_frame/ui/exact_render_capture_*` | exact render capture in the browser | MOVE | F2 | pending |
 | `implementation/ui/test/re_frame/ui/fast_refresh_shell_*` | fast-refresh shell identity | MOVE | F1 | pending |
-| `implementation/ui/test/re_frame/ui/fingerprint_*` | identity digests | MOVE | F1 | pending |
+| `implementation/ui/test/re_frame/ui/fingerprint_*` | identity digests | MOVE | F3 | done |
 | `implementation/ui/test/re_frame/ui/frame_*` | frame ops, plans, scope resolution, preflight races, publication linearization, context | MOVE | F2 | pending |
 | `implementation/ui/test/re_frame/ui/g13/*` | the mass-mount evidence fixture's own measurement test | MOVE | F6 | pending |
 | `implementation/ui/test/re_frame/ui/g14_*` | the compile-budget gate | MOVE | F3 | pending |
@@ -235,7 +247,7 @@ re-proved against the Freehand contract rather than ported line by line.
 | `implementation/ui/test/re_frame/ui/render_capture_*` | render-capture thread ownership | MOVE | F2 | pending |
 | `implementation/ui/test/re_frame/ui/render_key_dom_stamp_*` | key stamping in the DOM and its production elision | MOVE | F1 | pending |
 | `implementation/ui/test/re_frame/ui/render_static_strip_*` | static-subtree stripping | MOVE | F3 | pending |
-| `implementation/ui/test/re_frame/ui/reserved_head_reject_*` | rejection of reserved template heads | MOVE | F3 | pending |
+| `implementation/ui/test/re_frame/ui/reserved_head_reject_*` | rejection of reserved template heads | MOVE | F3 | done |
 | `implementation/ui/test/re_frame/ui/root_*` | root analysis, registry, incarnation, mount, teardown, wiring | MOVE | F1 | pending |
 | `implementation/ui/test/re_frame/ui/route_link_*` | anchor semantics and the click law over the routing seam | MOVE | F5 | pending |
 | `implementation/ui/test/re_frame/ui/rules_*` | the DOM conversion table and its custom-element conflict rule | MOVE | F1 | pending |


### PR DESCRIPTION
EP-0036 slice F3a (rf2-drpa3.25). The compile tier moves under Freehand ownership.

## What moved

Fifteen donor source files arrive under `implementation/freehand/`:

| From | To |
|---|---|
| `re-frame.ui.compiler` | `re-frame.freehand.compiler` |
| `re-frame.ui.compiler.{analyze, emit-cljs, emit-jvm, env, header, binding-plan, a11y, build, build-hook, harvest, root}` | `re-frame.freehand.compiler.*` |
| `re-frame.ui.{eq, fingerprint, rules}` | `re-frame.freehand.{eq, fingerprint, rules}` |

and fifteen donor test files leave the donor tree for `implementation/freehand/test/re_frame/freehand/`.

This is a **move, not a rewrite**. Every transplanted file is the donor file with
donor spellings mechanically re-spelled (`re-frame.ui` → `re-frame.freehand`, the
`ui/` authoring alias → `v/`). No donor algorithm was touched. The consequence of
that rename is exactly the outcome the slice wanted: the analyzer's reserved-var
roster, the React emitter's lowering targets and the JVM emitter's tree
constructors now name Freehand vars and Freehand runtime namespaces.

**The two emitters remain separate.** They share only the host-neutral normalizers
the donor already shared — `rules` (the DOM conversion table), `fingerprint`, `eq`,
`binding-plan`. Neither consumes the other's output, and nothing here describes
them as one implementation.

`rules.cljc` came along as the closure: `analyze`, `emit-cljs` and `emit-jvm` all
require it, and it is precisely the "host-neutral normalizer" the slice sanctions
sharing. It, `eq` and `fingerprint` were carried on F1 ledger rows; the slice column
names the slice whose work disposes a row, so they now read F3.

**In flight, needs a look on merge:** rf2-drpa3.17 (F1c) is writing the interpreted
tree and the conversion table's two-mode generalization. If that slice also creates
`re-frame.freehand.rules`, it should reconcile onto this one rather than add a
second.

## Why the donor keeps a frozen copy

`implementation/ui/src/re_frame/ui/compiler/**` is still on disk, and its rows are
nonetheless `done`. That is not an oversight, it is forced:

* absorbed code diverges the moment it lands — a Freehand analyzer recognizes
  `re-frame.freehand/sub`, and Freehand emitters lower to `re-frame.freehand.runtime`
  and `re-frame.freehand.tree`, so the donor cannot run on its own absorbed code;
* the donor artifact has to keep building for the whole of coexistence
  (acceptance 4), and its runtime namespaces are F2/F4/F5 rows this slice must not
  touch;
* Freehand must declare no dependency on the donor (acceptance 3), so a shared file
  is not available either.

So the donor's copy is vestigial and frozen until rf2-drpa3.57 deletes the artifact
whole. The ledger's "How to read a row" now states this rule explicitly, and states
the opposite rule for tests: a suite proves a contract, a contract has one owner, so
a moved suite leaves the donor tree in the change that moves it.

## The gate that would have silently stopped checking

`s4_conformance_profile_jvm_test/profile-names-real-proof-homes` resolves every
proof home the S4 profile names against a test tree. Moving
`a11y_diagnostics_cljs_test` out of `implementation/ui/test` reds it. Both the
profile and the checker now name `re-frame.freehand.a11y-diagnostics-cljs-test`, and
the checker resolves against the Freehand test tree as well as the donor's.

The `:ns-regexp` hazard was checked positively, not assumed: every moved
`*-cljs-test` namespace was confirmed **present in the compiled node-test bundle**
under its new name and absent under its old one, and the focused
`clojure -M:test -n …` run over the fifteen moved namespaces returns the donor's
exact count.

## Quality gates

Test counts, not assertion counts, are the contract. The moved suites' assertion
count happens to be identical too.

| Gate | Before | After |
|---|---|---|
| the moved compiler suites, focused JVM run over the 15 namespaces | **238 tests / 1312 assertions** (`implementation/ui`) | **238 tests / 1312 assertions** (`implementation/freehand`) |
| `implementation/freehand` `clojure -M:test` | 22 tests / 112 assertions | 260 tests / 1424 assertions at the branch point; 282 / 1574 after rebase, green |
| `implementation/ui` `clojure -M:test` | 942 tests / 18923 assertions | 704 tests / 17612 assertions — green (942 − 238, the moved suites) |
| `npm run test:cljs` | 10279 tests / 51052 assertions | 10279 tests / 51052 assertions — net zero; 10302 / 51204 after rebase, green |
| `npm run test:freehand` (focused CLJS) | 21 tests | 158 tests at the branch point; 181 after rebase, green |
| `npm run test:ui` (donor node suite + adapter isolation) | — | 800 tests green; adapter isolation PASS |
| `npm run test:bundle-isolation` | — | PASS (23 artefacts, 39 sentinels, uix-reagent-free, login) |
| `python scripts/check_donor_inventory.py` | 200 rows undisposed | **178 rows undisposed** — 22 disposed here; gate + `--self-test` green |
| `python scripts/check_freehand_conformance_index.py` | — | OK, 6 rows / 14 areas |
| donor-boundary gate: `git grep -e 're-frame\.ui' -e 're_frame/ui' -e 're-frame2-ui' -- implementation/freehand` | — | **empty** |
| repo checkers (30 python gates incl. retired-spellings, thrown-error messages, keyword-catalogue, doc-slugs, readme links/inventories, UI root lifecycle, ambient durable reads, skill drift) | — | all green |
| `node scripts/check-per-ns-isolation.cjs` | — | 17 namespaces pass standalone |
| `bash scripts/check-no-hardcoded-paths.sh` | — | OK |

`mkdocs build --strict` soft-skipped: mkdocs is not on PATH on this worker; CI runs it.

## Deviations from a pure rename, each disclosed

1. **`producer-tag`** in the absorbed conversion table is now
   `reFrameFreehandReloadSourceReset`. The tag is the JS property a copy of the
   table stamps on its shared-realm `SHADOW_NS_RESET` entry, and it identifies the
   *framework copy*. With both copies loadable in one JS realm a shared tag makes
   each copy count the other's producer, and the donor's "exactly one producer" law
   reads 2. This is the one behavioural divergence in the change, and it is required
   by coexistence rather than an improvement to the algorithm.
2. **`:as ui` → `:as v`** inside the CLJS-analyzer and harvest *source fixtures* of
   two moved suites. Those fixtures are strings of CLJS source; renaming the vars
   without renaming the alias that spells them leaves an inconsistent fixture.
3. **Two `record-tag-cross-host-golden` literals** move. The digest they pin embeds
   the record's namespace-qualified type name, and the record is defined in the test
   namespace that was renamed. The test's claim — that the JVM and CLJS digests
   agree — is unchanged and still passes on both hosts.

## Found, not fixed

* `compiler/env.cljc`'s docstring cites `re-frame.ui.q5-heads-cljs-test` as the
  home of its corner-case pins. **That namespace does not exist anywhere in the
  tree** and did not before this change — pre-existing doc rot, carried across by
  the mechanical rename (now equally stale as
  `re-frame.freehand.q5-heads-cljs-test`). Repairing it means finding where those
  corners are actually pinned, which is a reading task, not a move.
* `implementation/scripts/_changed-surfaces.test.cjs` uses
  `implementation/ui/test/re_frame/ui/eq_cljs_test.cljc` as a **classification
  fixture**. It classifies path strings and never stats them, so it stays green,
  but that path is now fictional. rf2-drpa3.61 owns the changed-surface router's
  Freehand arm and is the right place to re-point it.
* `implementation/scripts/_playground-sci-inputs.test.cjs` fails 2 tests locally
  ("classifier returned 1 verdicts for N paths"). **Reproduced on `main` in a clean
  checkout** — a pre-existing Windows-local environment failure, not caused by this
  PR.

## Residue deliberately left in place

Each of these would be a behaviour change buried inside a thirty-file move, where
nobody could tell the move from the change:

* the reserved **keyword** namespaces `:rf.ui/*` and `:rf.ui.compile/*` (the
  diagnostic ids and the suppression key). Renaming them moves a published
  diagnostic vocabulary — F3e owns the findings surface, and `Conventions.md`'s
  reserved-namespace roster is an F6 row.
* the private `rf-ui-*` generated-symbol prefixes and the `:ui-event` AST
  classification key — internals whose spelling rides in golden expectations.
* the analyzer still lowers the donor hook tier, now spelled
  `re-frame.freehand.hooks/*` and `re-frame.freehand.react/*` — namespaces that do
  not exist. Those arms are ledger `DELETE` rows owned by F1 and F5; a move must not
  quietly delete them.

## Not in scope

`{:compiled true}` selection (F3b), manifests and elision (F3d), the checker's
public findings surface (F3e). No donor algorithm was improved here.
