### PR TITLE
ci(freehand): arm both host suites on conformance-fixture changes (rf2-drpa3.66)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -702,6 +702,37 @@ else
         cljs_browser=true
         cljs_prod=true
         ;;
+      spec/conformance/freehand/fixtures/*)
+        # rf2-drpa3.66 — false-green fix, the Freehand-corpus counterpart of
+        # the shared spec/conformance/fixtures/* case above.
+        #
+        # Every fixture under this root is a LIVE INPUT to both Freehand host
+        # suites: implementation/freehand/test/re_frame/freehand/conformance.cljc
+        # reads it at MACRO-EXPANSION time and inlines the value, so the JVM
+        # `:test` alias (the required `jvm-freehand` job, gated on
+        # implementation_jvm) and the consolidated `:node-test` build (the
+        # `cljs` job, gated on cljs_node_test) assert against the same bytes.
+        # rf2-drpa3.58 armed those two outputs for implementation/freehand/**
+        # but not for the corpus the suites consume, so a fixture-only PR left
+        # every output false and BOTH newly-required host jobs SKIPPED —
+        # accepted unexplained by `all-required-passed`.
+        #
+        # The always-on freehand-conformance.yml is not a substitute:
+        # check_freehand_conformance_index.py verifies that an active index row
+        # NAMES AN EXISTING FIXTURE, not that the fixture's contract VALUES hold.
+        # Flipping FH-CALL-001's `:predicates :view?` from true to false keeps
+        # the path, the `:fh/id` and the index relationship intact — valid EDN,
+        # green index check — while descriptor_cljs_test.cljc fails on both
+        # hosts once actually run. Arming the two host outputs is what makes it
+        # run.
+        #
+        # Scoped exactly like the implementation/freehand/* case: NOT the
+        # browser/prod/isolation tier. Freehand ships no production-bundle
+        # requirer, so those gates would be pure cost — widen both cases
+        # together when it gains one.
+        implementation_jvm=true
+        cljs_node_test=true
+        ;;
       implementation/scripts/serve-and-run-reagent-slim-smoke.cjs|implementation/scripts/_reagent-slim-smoke-policy.test.cjs)
         # rf2-5v0dg7 — false-green fix, mirroring the xray-feature-gate
         # launcher case below. serve-and-run-reagent-slim-smoke.cjs IS the

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -2115,6 +2115,91 @@ test('implementation/freehand/** stays OFF the heavy per-feature gates (rf2-drpa
   }
 });
 
+// rf2-drpa3.66 — the fixture corpus is the OTHER half of the Freehand surface.
+//
+// conformance.cljc reads spec/conformance/freehand/fixtures/*.edn at
+// MACRO-EXPANSION time and inlines the value, so both host suites assert
+// against those exact bytes. rf2-drpa3.58 armed implementation/freehand/** but
+// not the corpus it consumes: a fixture-only PR classified as nothing and BOTH
+// newly-required host jobs skipped, unexplained, past `all-required-passed`.
+//
+// The always-on conformance-index check is not a substitute — it verifies that
+// an active row NAMES AN EXISTING FIXTURE, never the fixture's contract VALUES.
+// A mutation that preserves the path and the `:fh/id` (e.g. flipping
+// FH-CALL-001's `:predicates :view?`) keeps that check green and reds
+// descriptor_cljs_test.cljc on both hosts — but only if the hosts RUN.
+
+test('freehand conformance fixtures arm both host suites (rf2-drpa3.66)', () => {
+  // Every fixture the corpus ships today, by conformance family.
+  for (const file of [
+    'spec/conformance/freehand/fixtures/fh-call-001.edn',
+    'spec/conformance/freehand/fixtures/fh-props-003.edn',
+    'spec/conformance/freehand/fixtures/fh-event-001.edn',
+    'spec/conformance/freehand/fixtures/fh-struct-007.edn',
+  ]) {
+    const result = classify(file);
+    assert.equal(
+      result.implementation_jvm,
+      'true',
+      `${file} must arm implementation_jvm or the required jvm-freehand job SKIPS on a fixture-only PR`,
+    );
+    assert.equal(
+      result.cljs_node_test,
+      'true',
+      `${file} must arm cljs_node_test — the :node-test build inlines this fixture too`,
+    );
+  }
+});
+
+test('the freehand fixture arm is ROOT matching, not an enumeration (rf2-drpa3.66)', () => {
+  // Same rot argument as the artefact-root test above: a POSIX `case` glob's
+  // `*` spans `/`, so the whole corpus root is covered at any depth. These
+  // paths do not exist yet — they are the shapes the corpus takes if the
+  // fixtures gain per-family subdirectories — pinned so a future narrowing of
+  // the case reds HERE rather than silently skipping two required jobs.
+  for (const file of [
+    'spec/conformance/freehand/fixtures/props/fh-props-004.edn',
+    'spec/conformance/freehand/fixtures/call/deeply/nested/fh-call-999.edn',
+  ]) {
+    const result = classify(file);
+    assert.equal(
+      result.implementation_jvm,
+      'true',
+      `future nested fixture must arm implementation_jvm: ${file}`,
+    );
+    assert.equal(
+      result.cljs_node_test,
+      'true',
+      `future nested fixture must arm cljs_node_test: ${file}`,
+    );
+  }
+});
+
+test('freehand fixtures stay OFF the heavy gates, like the artefact (rf2-drpa3.66)', () => {
+  // Scope guard. The fixtures feed exactly the two suites the artefact case
+  // arms and nothing else, so this arm must not drift wider than
+  // implementation/freehand/* — widen both together or neither.
+  const result = classify('spec/conformance/freehand/fixtures/fh-call-001.edn');
+  for (const key of ['cljs_browser', 'cljs_prod', 'bundle_isolation', 'ui_gates', 'ui_smoke']) {
+    assert.equal(result[key], 'false', `freehand fixtures must not arm ${key}`);
+  }
+});
+
+test('freehand conformance PROSE is not a fixture — no over-broadening (rf2-drpa3.66)', () => {
+  // The route is the fixtures root, not spec/conformance/freehand/**. The
+  // index and its README are held by the always-on conformance workflow and
+  // its validator, which this bead deliberately leaves alone.
+  for (const file of [
+    'spec/conformance/freehand/README.md',
+    'spec/conformance/freehand/conformance-index.md',
+    'spec/conformance/freehand/donor-inventory.md',
+  ]) {
+    const result = classify(file);
+    assert.equal(result.implementation_jvm, 'false', `${file} must not arm implementation_jvm`);
+    assert.equal(result.cljs_node_test, 'false', `${file} must not arm cljs_node_test`);
+  }
+});
+
 test('jvm-freehand is job-level gated and runs the suite + the donor law (rf2-drpa3.58)', () => {
   const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'jvm-freehand');
   assert.match(block, /needs: detect_changed_surfaces/);


### PR DESCRIPTION
Closes rf2-drpa3.66.

PR #6691 made `implementation/freehand/**` a first-class changed surface and folded `jvm-freehand` into the required `test.yml` aggregator. The classifier arm it added omits a live input to **both** Freehand host suites: `spec/conformance/freehand/fixtures/**`.

Every fixture under that root is read at **macro-expansion time** by `implementation/freehand/test/re_frame/freehand/conformance.cljc` and inlined as a quoted literal, so the JVM `:test` alias and the consolidated `:node-test` build assert against the same bytes. Yet a fixture path classified as *nothing* — both newly-required host jobs skipped, and `all-required-passed` accepted the skips.

## The always-on gate is not a substitute

`freehand-conformance.yml` runs unconditionally, but `check_freehand_conformance_index.py` only verifies that an active index row **names an existing fixture**. It does not validate the fixture's contract **values**. Demonstrated below: flipping FH-CALL-001's `:predicates :view?` from `true` to `false` is valid EDN, preserves the path and the `:fh/id`, keeps the index relationship intact — the index validator exits **0** — while `descriptor_cljs_test.cljc` reds on both hosts once actually run.

## The fix

`report-changed-surfaces.sh` already handles this exact class for the shared `spec/conformance/fixtures/**` corpus. This adds the corresponding narrow route for the Freehand-specific corpus, on that precedent's shape.

Scope is deliberately identical to the sibling `implementation/freehand/*` case — `implementation_jvm` + `cljs_node_test`, and **not** the browser/prod/isolation tier. Freehand ships no production-bundle requirer, so those gates would be pure cost; widen both cases together or neither. No new workflow, no job, no change to the conformance index or its validator.

## Relationship to rf2-drpa3.65 (the sibling cache-dependency fix)

**Neither bead alone closes the hole.** They are complementary and both are required:

- **This bead (.66) makes the jobs RUN.** Without it a fixture-only PR arms nothing and both host jobs skip.
- **rf2-drpa3.65 makes the compiled test SEE the new fixture.** Freehand fixtures are not a shadow-cljs build dependency, so a fixture-only edit does not invalidate the build cache and a CLJS run can report GREEN against the *previous* expectations.

That second hole is live and reproduced in this PR's transcript (see the "control" step below): with a warm cache the mutated fixture recompiled 1 file and the CLJS suite reported **0 failures**. Every CLJS result below was therefore taken after `rm -rf .shadow-cljs/builds/{node-test-freehand,node-test,browser-test}`. The JVM side is unaffected by that cache and reds immediately.

## Classifier: before / after

`./.github/scripts/report-changed-surfaces.sh spec/conformance/freehand/fixtures/fh-call-001.edn`

| output | before | after |
| --- | --- | --- |
| `implementation_jvm` | `false` | **`true`** |
| `cljs_node_test` | `false` | **`true`** |

Every other output stays `false` in both columns. Full before, the known-broken control:

```
=== BEFORE: freehand fixture ===
implementation_jvm=false
cljs_node_test=false
ui_gates=false
adapter_diagnostic=false
cljs_browser=false
examples_compile=false
cljs_prod=false
bundle_isolation=false
reagent_slim_bundle=false
adapter_testbed_smokes=false
ui_smoke=false
tools_jvm=false
template_expensive=false
mcp_conformance=false
mcp_live=false
story_xray_browser=false
tenant_switcher_smoke=false
skills_structural=false
playground=false
```

After:

```
=== AFTER: freehand fixture ===
implementation_jvm=true
cljs_node_test=true
ui_gates=false
adapter_diagnostic=false
cljs_browser=false
examples_compile=false
cljs_prod=false
bundle_isolation=false
reagent_slim_bundle=false
adapter_testbed_smokes=false
ui_smoke=false
tools_jvm=false
template_expensive=false
mcp_conformance=false
mcp_live=false
story_xray_browser=false
tenant_switcher_smoke=false
skills_structural=false
playground=false

=== AFTER: future NESTED fixture path ===
$ ./.github/scripts/report-changed-surfaces.sh spec/conformance/freehand/fixtures/props/nested/fh-props-999.edn
implementation_jvm=true
cljs_node_test=true
(... all others false)

=== GUARD: sibling prose, must stay unclassified ===
$ ./.github/scripts/report-changed-surfaces.sh spec/conformance/freehand/README.md
implementation_jvm=false
cljs_node_test=false
```

## Self-tests

`implementation/scripts/_changed-surfaces.test.cjs`: **195 → 199 passed** (+4).

The four new cases pin the shipped corpus (one fixture per `call`/`props`/`event`/`struct` family), **two future NESTED fixture paths** so the route cannot rot when fixtures gain per-family subdirectories, the heavy-gate scope guard, and the three sibling prose files that must stay unclassified.

Criterion 4 — removing the route reds them. The new tests against the unfixed classifier:

```
FAIL freehand conformance fixtures arm both host suites (rf2-drpa3.66)
FAIL the freehand fixture arm is ROOT matching, not an enumeration (rf2-drpa3.66)
changed-surfaces tests: 2 failed.
```

## End-to-end: a fixture-VALUE change reds both hosts

Not just the classifier. The probe is the exact mutation the bead names — `:predicates {:view? true` → `false` in `fh-call-001.edn`, path and `:fh/id` untouched.

**1. The always-on index validator does not notice.**

```
$ python scripts/check_freehand_conformance_index.py
index-validator exit: 0
```

**2. The classifier now schedules both host jobs.**

```
$ ./.github/scripts/report-changed-surfaces.sh spec/conformance/freehand/fixtures/fh-call-001.edn
implementation_jvm=true
cljs_node_test=true
```

**3. JVM — red.**

```
$ cd implementation/freehand && clojure -M:test

Testing re-frame.freehand.descriptor-cljs-test

FAIL in (fh-call-001-declared-view-is-a-non-ifn-descriptor) (descriptor_cljs_test.cljc:52)
(view? subject) is false
expected: (= expected (boolean (f subject)))
  actual: (not (= false true))

Ran 56 tests containing 358 assertions.
1 failures, 0 errors.
JVM exit: 1
```

**4. CLJS — control first (the rf2-drpa3.65 hole), then red.**

Warm cache, mutated fixture on disk — the false green:

```
$ npm run test:freehand
[:node-test-freehand] Build completed. (125 files, 1 compiled, 0 warnings, 5.67s)
Ran 57 tests containing 357 assertions.
0 failures, 0 errors.
```

After `rm -rf .shadow-cljs/builds/{node-test-freehand,node-test,browser-test}`:

```
$ npm run test:freehand
[:node-test-freehand] Build completed. (125 files, 124 compiled, 0 warnings, 20.08s)

Testing re-frame.freehand.descriptor-cljs-test

FAIL in (fh-call-001-declared-view-is-a-non-ifn-descriptor) (re_frame/freehand/descriptor_cljs_test.cljc:52:13)
(view? subject) is false
expected: (= expected (boolean (f subject)))
  actual: (not (= false true))

Ran 57 tests containing 357 assertions.
1 failures, 0 errors.
```

**5. Restored, byte-identical.**

```
pre-flip  sha256: 8dbaf8586ebdf4c7f1052feaa015b84f0bfbc79efc185eed9b3bd59e4df5b073
post-restore    : 8dbaf8586ebdf4c7f1052feaa015b84f0bfbc79efc185eed9b3bd59e4df5b073
$ git status --porcelain   # (empty)
```

Both suites re-run green after the restore, with the cache cleared again since it then held the flipped value: JVM 56 tests / 358 assertions / 0 failures; CLJS 57 tests / 357 assertions / 0 failures. **No fixture change ships in this PR** — the diff is the classifier and its self-test, nothing else.

## Quality gates

All run in the foreground, to completion, on this branch.

| Gate | Result |
| --- | --- |
| `node scripts/_changed-surfaces.test.cjs` | 199 passed (was 195) |
| `npm run test:script-policy && npm run test:script-helpers` | both green (CI runs both after `&&`) |
| `cd implementation/freehand && clojure -M:test` | 56 tests, 358 assertions, 0 failures 0 errors |
| `npm run test:freehand` | 57 tests, 357 assertions, 0 failures 0 errors |
| `sh scripts/check-no-hardcoded-paths.sh` | `Portability gate OK` |

`git ls-files -s .github/scripts/report-changed-surfaces.sh` → `100755` (exec bit preserved; Windows git hides the mode and a `100644` exits 126 on the Linux runner).

This PR edits `.github/scripts/report-changed-surfaces.sh`, which is itself a `mark_all` path — so CI runs the full matrix here regardless.
