### PR TITLE
fix(freehand): make conformance fixtures a shadow-cljs build dependency (rf2-drpa3.65)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/conformance.cljc
+++ b/implementation/freehand/test/re_frame/freehand/conformance.cljc
@@ -15,55 +15,106 @@
   A fixture that cannot be resolved fails the COMPILE, loudly, rather
   than yielding an empty table that would make a suite pass vacuously —
   a table-driven test whose table is empty is the worst failure mode
-  available, so it is made impossible here."
+  available, so it is made impossible here.
+
+  ## Why the ClojureScript read goes through shadow-cljs
+
+  Inlining at macro-expansion time hides the fixture from the build: a
+  ClojureScript compile that caches a test namespace has no edge back to
+  the `.edn` whose bytes it froze, so a FIXTURE-ONLY edit leaves the
+  cached namespace asserting the PREVIOUS expectations — a confident
+  green over an expectation nobody is checking, which is the worst
+  failure a table-driven gate can have.
+
+  So the ClojureScript read goes through `shadow.resource/slurp-resource`,
+  which records the fixture's classpath path and last-modified against
+  the compiling namespace; shadow-cljs re-checks both before reusing that
+  namespace's cache. Edit a fixture and the suites that read it
+  recompile — no cache clearing, no ritual. `spec/conformance/` is a
+  shadow-cljs `:source-path` (a classpath root of `.edn` data, no
+  sources) so `:FH-PROPS-001` resolves as
+  `freehand/fixtures/fh-props-001.edn`.
+
+  The JVM lane needs no such edge — `clojure -M:test` has no persistent
+  analyzer cache, so every run re-reads the file — and it does not carry
+  the fixture root on its classpath, so it locates the same file by
+  walking up from the compile CWD to the repository root."
   #?(:clj (:require [clojure.edn :as edn]
                     [clojure.java.io :as io]
                     [clojure.string :as str]))
   #?(:cljs (:require-macros [re-frame.freehand.conformance :refer [fixture]])))
 
 #?(:clj
-   (def ^:private fixture-roots
-     "Candidate fixture directories, in resolution order — the compile CWD
-     differs per gate:
+   (def ^:private fixture-root
+     "Where the fixtures live, as path segments below the repository root.
+     The tail of this path is also the classpath path shadow-cljs
+     resolves, because `spec/conformance/` is the `:source-path` root."
+     ["spec" "conformance" "freehand" "fixtures"]))
 
-       - `implementation/freehand/` — this artefact's JVM `:test` alias;
-       - `implementation/`          — the shadow-cljs builds;
-       - the repository root        — a REPL or tool run from the top."
-     ["../../spec/conformance/freehand/fixtures"
-      "../spec/conformance/freehand/fixtures"
-      "spec/conformance/freehand/fixtures"]))
+#?(:clj
+   (defn ^:private fixture-resource-path
+     "The classpath path of the fixture for `id`, relative to the
+     `spec/conformance/` root — e.g. `freehand/fixtures/fh-props-001.edn`.
+     The filename mirrors the id in lower case, per the fixture
+     convention in `spec/conformance/freehand/README.md`."
+     [id]
+     (str/join "/" (conj (subvec fixture-root 2)
+                         (str (str/lower-case (name id)) ".edn")))))
+
+#?(:clj
+   (defn ^:private fixture-file
+     "Locate the fixture file for classpath path `path` by walking up from
+     the compile CWD looking for the fixture root — the JVM lane's
+     locator, where `spec/conformance/` is not on the classpath. Throws
+     an actionable error rather than yielding an absent table."
+     [path]
+     (loop [dir (io/file (System/getProperty "user.dir"))]
+       (when (nil? dir)
+         (throw (ex-info (str "Freehand conformance fixture " path " not found: no "
+                              (str/join "/" fixture-root) " directory walking up from "
+                              (System/getProperty "user.dir") ".")
+                         {:path path :root fixture-root})))
+       (let [candidate (apply io/file dir (conj (subvec fixture-root 0 2) path))]
+         (if (.exists candidate)
+           candidate
+           (recur (.getParentFile dir)))))))
+
+#?(:clj
+   (defn ^:private slurp-fixture
+     "Return the text of the fixture at `path`.
+
+     Under a ClojureScript compile (`&env` carries the compiling `:ns`)
+     the read goes through shadow-cljs, which registers `path` as a build
+     dependency of that namespace — the edge that makes a fixture edit
+     invalidate the cached suite. Under the JVM there is no cache to
+     invalidate, and the file is read from the tree directly."
+     [env path]
+     (if (:ns env)
+       ((requiring-resolve 'shadow.resource/slurp-resource) env path)
+       (slurp (fixture-file path)))))
 
 #?(:clj
    (defn ^:no-doc read-fixture
-     "Read the fixture for conformance id `id` (e.g. `:FH-PROPS-003`).
-     The filename mirrors the id in lower case, per the fixture
-     convention in `spec/conformance/freehand/README.md`. Throws when no
-     candidate root holds the file."
-     [id]
-     (let [filename (str (str/lower-case (name id)) ".edn")
-           file     (->> fixture-roots
-                         (map #(io/file % filename))
-                         (filter #(.exists ^java.io.File %))
-                         first)]
-       (when-not file
-         (throw (ex-info (str "Freehand conformance fixture " id " (" filename ") not found. "
-                              "Looked under " (pr-str fixture-roots) " relative to "
-                              (System/getProperty "user.dir") ".")
-                         {:id id :filename filename :roots fixture-roots})))
-       (let [value (edn/read-string (slurp file))]
-         (when-not (= (name id) (:fh/id value))
-           (throw (ex-info (str "Freehand conformance fixture " id " declares :fh/id "
-                                (pr-str (:fh/id value)) " — the file and the id disagree.")
-                           {:id id :declared (:fh/id value)})))
-         value))))
+     "Read the fixture for conformance id `id` (e.g. `:FH-PROPS-003`) in
+     the macro-expansion environment `env`. Throws when the fixture is
+     absent or declares a different `:fh/id`."
+     [env id]
+     (let [path  (fixture-resource-path id)
+           value (edn/read-string (slurp-fixture env path))]
+       (when-not (= (name id) (:fh/id value))
+         (throw (ex-info (str "Freehand conformance fixture " id " declares :fh/id "
+                              (pr-str (:fh/id value)) " — the file and the id disagree.")
+                         {:id id :declared (:fh/id value)})))
+       value)))
 
 #?(:clj
    (defmacro fixture
      "Inline the conformance fixture for `id` as a quoted literal, read at
      macro-expansion time. Identical data on the JVM and in
-     ClojureScript."
+     ClojureScript, and — in ClojureScript — a build dependency, so an
+     edit to the fixture recompiles this call site."
      [id]
-     (list 'quote (read-fixture id))))
+     (list 'quote (read-fixture &env id))))
 
 (def no-throw
   "What [[caught-id]] answers when the thunk returned normally. Named so a

--- a/implementation/freehand/test/re_frame/freehand/conformance.cljc
+++ b/implementation/freehand/test/re_frame/freehand/conformance.cljc
@@ -45,36 +45,36 @@
   #?(:cljs (:require-macros [re-frame.freehand.conformance :refer [fixture]])))
 
 #?(:clj
-   (def ^:private fixture-root
-     "Where the fixtures live, as path segments below the repository root.
-     The tail of this path is also the classpath path shadow-cljs
-     resolves, because `spec/conformance/` is the `:source-path` root."
-     ["spec" "conformance" "freehand" "fixtures"]))
+   (def ^:private classpath-root
+     "The directory that is the classpath ROOT for fixture lookups, as path
+     segments below the repository root — the shadow-cljs `:source-path`
+     the ClojureScript lane resolves resource paths against, and what the
+     JVM lane walks up the tree looking for."
+     ["spec" "conformance"]))
 
 #?(:clj
    (defn ^:private fixture-resource-path
-     "The classpath path of the fixture for `id`, relative to the
-     `spec/conformance/` root — e.g. `freehand/fixtures/fh-props-001.edn`.
-     The filename mirrors the id in lower case, per the fixture
-     convention in `spec/conformance/freehand/README.md`."
+     "The fixture for `id` as a path below [[classpath-root]] — e.g.
+     `freehand/fixtures/fh-props-001.edn`. The filename mirrors the id in
+     lower case, per the fixture convention in
+     `spec/conformance/freehand/README.md`."
      [id]
-     (str/join "/" (conj (subvec fixture-root 2)
-                         (str (str/lower-case (name id)) ".edn")))))
+     (str "freehand/fixtures/" (str/lower-case (name id)) ".edn")))
 
 #?(:clj
    (defn ^:private fixture-file
-     "Locate the fixture file for classpath path `path` by walking up from
-     the compile CWD looking for the fixture root — the JVM lane's
-     locator, where `spec/conformance/` is not on the classpath. Throws
-     an actionable error rather than yielding an absent table."
+     "Locate the fixture at `path` by walking up from the compile CWD
+     looking for [[classpath-root]] — the JVM lane's locator, where that
+     root is not on the classpath. Throws an actionable error rather than
+     yielding an absent table."
      [path]
      (loop [dir (io/file (System/getProperty "user.dir"))]
        (when (nil? dir)
          (throw (ex-info (str "Freehand conformance fixture " path " not found: no "
-                              (str/join "/" fixture-root) " directory walking up from "
+                              (str/join "/" classpath-root) " directory walking up from "
                               (System/getProperty "user.dir") ".")
-                         {:path path :root fixture-root})))
-       (let [candidate (apply io/file dir (conj (subvec fixture-root 0 2) path))]
+                         {:path path :root classpath-root})))
+       (let [candidate (apply io/file dir (conj classpath-root path))]
          (if (.exists candidate)
            candidate
            (recur (.getParentFile dir)))))))

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -153,8 +153,9 @@
                 ;; `shadow.resource/slurp-resource` records the fixture's
                 ;; last-modified against the namespace that inlines it, so
                 ;; the fixture participates in that namespace's cache key.
-                ;; The JVM counterpart is the `../../spec/conformance`
-                ;; entry in implementation/freehand/deps.edn `:test`.
+                ;; The JVM lane needs no such edge (`clojure -M:test` has
+                ;; no persistent analyzer cache) and does not carry this
+                ;; root: it walks up from the compile CWD instead.
                 "../spec/conformance"
                 ;; rf2-nojiwy — re-frame.ui testbed (the four-suites rule's
                 ;; new-UI smoke). Standalone counter app under ui/testbed/

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -142,6 +142,20 @@
                 ;; `ui/` donor above.
                 "freehand/src"
                 "freehand/test"
+                ;; The Freehand conformance FIXTURES, as a classpath root
+                ;; — data only (`.edn`), no sources, nothing compilable.
+                ;; `re-frame.freehand.conformance/fixture` inlines a
+                ;; fixture at macro-expansion time, which by itself hides
+                ;; the file from the build: a fixture-only edit would not
+                ;; invalidate the cached test namespace, and the compiled
+                ;; suite would keep asserting the PREVIOUS expectations.
+                ;; Reading it as a classpath resource through
+                ;; `shadow.resource/slurp-resource` records the fixture's
+                ;; last-modified against the namespace that inlines it, so
+                ;; the fixture participates in that namespace's cache key.
+                ;; The JVM counterpart is the `../../spec/conformance`
+                ;; entry in implementation/freehand/deps.edn `:test`.
+                "../spec/conformance"
                 ;; rf2-nojiwy — re-frame.ui testbed (the four-suites rule's
                 ;; new-UI smoke). Standalone counter app under ui/testbed/
                 ;; that proves the compiled-view substrate wires up


### PR DESCRIPTION
Closes rf2-drpa3.65.

`re-frame.freehand.conformance/fixture` inlines a fixture `.edn` at macro-expansion
time. That hid the file from the ClojureScript build: shadow-cljs had no dependency
edge from a test namespace to the fixture whose bytes it froze, so a FIXTURE-ONLY
edit did not invalidate the cache and the compiled suite kept asserting the
PREVIOUS expectations. Every `FH-*` row was affected — a table-driven gate
reporting a confident green over an expectation nobody was checking.

## The fix

The ClojureScript read now goes through `shadow.resource/slurp-resource`. It records
the fixture's classpath path and last-modified against the compiling namespace
(`::ana/namespaces <ns> :shadow.resource/resource-refs`), and `shadow.build.compiler`
re-resolves every recorded path and compares timestamps before reusing that
namespace's cache. Edit a fixture, the suites that read it recompile.

That requires the fixture to be resolvable by `io/resource` — both at expansion and
at cache-validation — so `spec/conformance/` joins the shadow-cljs `:source-paths`
as a classpath root. It is data only: `.edn` files, no sources, nothing compilable,
and no production build requires any of it.

The JVM lane keeps a filesystem read, but locates the fixture by walking up from the
compile CWD to the repository root (the locator `scripts/api-manifest/probe`'s
`find-sidecar` already uses) instead of trying three hard-coded relative candidate
roots — one locator per host, neither CWD-fragile.

## The JVM lane never had this hole

Stated explicitly because a fix that silently covers one host is the recurring
defect shape here. `clojure -M:test` has no persistent analyzer cache: every run
re-loads `conformance.cljc` as Clojure source and re-expands the macro against the
fixture on disk. Verified against the same mutated fixture that the ClojureScript
lanes reported green on, BEFORE any fix was written:

```
$ cd implementation/freehand && clojure -M:test        # fh-props-001 mutated, pre-fix
FAIL in (fh-props-001-one-map-no-positional-args) (props_cljs_test.cljc:34)
  actual: (not (= {:title "STALE-CACHE-PROBE"} {:title "Details"}))
Ran 56 tests containing 358 assertions.
1 failures, 0 errors.
```

So the JVM half needed no dependency edge and did not get one; what it got is the
simpler, CWD-robust locator.

## Known-broken control (pre-fix, reproduced on this branch's base)

Not taken on trust from the bead — reproduced first-hand on both ClojureScript
lanes, with the fix absent, no cache cleared between runs.

**Node lane** (`npm run test:freehand`), mutating `fh-props-001.edn`'s
`:props {:title "Details"}` to `{:title "STALE-CACHE-PROBE"}`:

```
# 1. baseline, correct fixture — builds the warm cache
[:node-test-freehand] Build completed. (125 files, 124 compiled, 0 warnings, 8.95s)
Ran 57 tests containing 357 assertions.
0 failures, 0 errors.

# 2. fixture mutated to an expectation that MUST fail; NO cache clear
[:node-test-freehand] Build completed. (125 files, 1 compiled, 0 warnings, 6.43s)
Ran 57 tests containing 357 assertions.
0 failures, 0 errors.      <-- green over a lie
```

**Browser lane** (`npm run test:browser`), mutating `fh-struct-007.edn`'s
`{:selector "#main > h2" :text "Details"}` to `:text "STALE-CACHE-PROBE"`.
(`:browser-test`'s ns-regexp is `-dom-cljs-test$`, so the fixture has to be one a
DOM suite reads — `fh-props-001` is invisible to this lane.)

```
# 1. baseline, correct fixture — warm cache
[:browser-test] Build completed. (939 files, 3 compiled, 0 warnings, 18.18s)
Browser tests: Ran 481 tests containing 2721 assertions. 0 failures, 0 errors.

# 2. fixture mutated; NO cache clear
[:browser-test] Build completed. (939 files, 1 compiled, 0 warnings, 20.57s)
Browser tests: Ran 481 tests containing 2721 assertions. 0 failures, 0 errors.
```

Both lanes: green on a fixture that must fail. That is the state this PR ends.

## Acceptance: red then green, no cache cleared

Same mutations, same commands, fix in place, and — the whole point — nothing
deleted from `.shadow-cljs/` at any step.

**The bead's own repro**, `fh-routelink-002.edn` ctrl-click `:intercepted?`
`false` -> `true`, `npm run test:browser`:

```
# 1. correct fixture, warm cache
[:browser-test] Build completed. (941 files, 102 compiled, 0 warnings, 35.94s)
Browser tests: Ran 485 tests containing 2762 assertions. 0 failures, 0 errors.

# 2. fixture mutated; NO cache clear
[:browser-test] Build completed. (941 files, 2 compiled, 0 warnings, 24.49s)
FAIL in (fh-routelink-002-native-clicks-keep-their-native-behaviour) (re_frame/freehand/route_link_native_dom_cljs_test.cljs:199:21)
expected: (= intercepted? (:intercepted? verdict))
  actual: (not (= true false))
Ran 485 tests containing 2762 assertions.
1 failures, 0 errors.      <-- RED, and it names the row

# 3. fixture restored; NO cache clear
[:browser-test] Build completed. (941 files, 2 compiled, 0 warnings, 42.47s)
Browser tests: Ran 485 tests containing 2762 assertions. 0 failures, 0 errors.
```

**Node lane**, `fh-props-001.edn`, `npm run test:freehand`:

```
# 1. correct fixture, warm cache
Ran 57 tests containing 357 assertions.  0 failures, 0 errors.

# 2. fixture mutated; NO cache clear
[:node-test-freehand] Build completed. (125 files, 2 compiled, 0 warnings, 6.19s)
FAIL in (fh-props-001-one-map-no-positional-args) (re_frame/freehand/props_cljs_test.cljc:34:11)
expected: (= props (:props (v/normalize-call panel args)))
  actual: (not (= {:title "STALE-CACHE-PROBE"} {:title "Details"}))
Ran 57 tests containing 357 assertions.
1 failures, 0 errors.      <-- RED

# 3. fixture restored; NO cache clear
Ran 57 tests containing 357 assertions.  0 failures, 0 errors.
```

The node-lane red/green pair was re-run after the final refactor commit, and the
browser pair after the rebase onto current `main`, both times without clearing a
cache.

### About cache clearing in this PR

Given the subject, the accounting matters. `.shadow-cljs/` in this worktree was
created cold by the first build and **never deleted, in whole or in part, at any
point** — not between control runs, not between proof runs, not before the gates.
Every "Build completed" line above is shadow deciding for itself what to recompile.

## Quality gates

All foreground, all on the rebased branch head.

| Gate | Result |
| --- | --- |
| `cd implementation/freehand && clojure -M:test` | Ran 303 tests, 1713 assertions. 0 failures, 0 errors. |
| `npm run test:freehand` | Ran 206 tests, 1265 assertions. 0 failures, 0 errors. |
| `npm run test:cljs` | Ran 10327 tests, 51343 assertions. 0 failures, 0 errors. |
| `npm run test:browser` | Ran 485 tests, 2762 assertions. 0 failures, 0 errors. |
| `python scripts/check_freehand_conformance_index.py -v` | index OK: 23 rows across 15 area sections (`--self-test`: 29/29 pass) |
| `python scripts/check_doc_slugs.py -v` | 588 markdown files scanned, no broken links |
| `clj-kondo` + `clojure -M:splint` on the changed namespace | 0 errors, 0 warnings / 0 style warnings |

`git grep 're-frame.ui' implementation/freehand/` — empty; the donor boundary is
untouched.

## Not done here

- **No fixture contents changed.** Every mutation above was reverted with
  `git checkout --`; `git status` is clean and the diff is two files.
- **No new harness.** A permanent guard would have to assert shadow's
  `resource-refs` registration from a JVM test, which needs ClojureScript and
  shadow-cljs on the Freehand artefact's test classpath. Not worth that dependency
  for a mechanism whose failure is now one fixture edit away from being visible.
- **The same defect shape exists elsewhere**, in
  `implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj`:
  its macros slurp `spec/api-manifest-metadata.edn` at expansion time with no build
  dependency, so a sidecar-only edit can leave the CLJS manifest probe asserting
  stale rows. Filed separately (rf2-ze3ai) rather than widened into this PR.
