### PR TITLE
feat(freehand): the B-spine measurement harness and gate/evidence split (rf2-drpa3.47)

### DIFF
--- a/.github/workflows/freehand-bench.yml
+++ b/.github/workflows/freehand-bench.yml
@@ -1,0 +1,119 @@
+name: freehand bench
+
+# The B-spine's scheduled/release lane (D021).
+#
+# WHY THIS IS NOT A PULL-REQUEST WORKFLOW
+#
+# D021 splits the harness's own work in two, and the split maps onto two
+# different CI shapes:
+#
+#   - the DETERMINISTIC part — the harness's two-way falsifiability proof —
+#     is stable, sub-second, needs no browser and no pinned hardware. It is
+#     the "small smoke subset on pull requests if stable" the decision
+#     allows, and it is already required on every PR WITHOUT a job here:
+#     it ships as ordinary tests in implementation/freehand/test, which the
+#     required `JVM freehand (clojure -M:test)` job and the required `cljs`
+#     node-test job both run. A second workflow asserting the same thing
+#     would be a duplicate that can only ever be advisory — `needs:` cannot
+#     span workflow files, so a job here is unreachable from
+#     `all-required-passed`. That is the exact trap the standalone
+#     freehand-artefact.yml fell into and was deleted for.
+#
+#   - the NOISY part — running workloads and publishing their wall-clock and
+#     byte distributions — is what this workflow owns. D021: "Run noisy full
+#     B1–B5 timing on a pinned scheduled/release worker." Nothing here gates
+#     a merge, because nothing here is allowed to: timing and byte
+#     distributions are published evidence with no automatic numeric
+#     pass/fail.
+#
+# THE PIN. `runs-on` names an explicit runner image rather than
+# `ubuntu-latest`, and `RF2_HARDWARE_CLASS` names the class the numbers may
+# be compared within. Successive results are only comparable because both
+# are held still; a floating image would silently re-baseline the evidence
+# under the same name. The class is CONFIGURED here and DETECTED otherwise
+# (re-frame.freehand.bench.provenance/detect-hardware-class) — a result
+# record never carries a literal naming one machine.
+#
+# WHAT RUNS TODAY. The evidence suite is empty: B1–B5 are separate slices
+# and each registers its workload when the implementation that can run it
+# lands. An empty suite prints an empty report and exits 0, which is the
+# honest answer. The falsifiability proof runs here too — not as a duplicate
+# of the PR gate but because a harness whose gate direction has rotted would
+# otherwise publish evidence nobody should trust.
+
+on:
+  schedule:
+    # 05:41 UTC, comfortably clear of the 15:17 expensive-tests cron so the
+    # two never contend for the same shared-runner capacity.
+    - cron: "41 5 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: freehand-bench-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  evidence:
+    name: Freehand B-spine evidence (pinned worker)
+    # PINNED, deliberately. See THE PIN above.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: implementation/freehand
+    env:
+      # The class these numbers may be compared within — configured, not
+      # detected, because this runner is the pinned one.
+      RF2_HARDWARE_CLASS: release-worker
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-freehand-${{ hashFiles('implementation/freehand/deps.edn', 'implementation/core/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-freehand-
+            ${{ runner.os }}-clj-
+
+      # The harness's own gate, and the ONLY thing in this workflow that may
+      # fail it. Both directions of D021's asymmetry, asserted about exit
+      # codes rather than about milliseconds.
+      - name: Prove the gate/evidence asymmetry both ways
+        run: clojure -M:bench --prove
+
+      # Evidence. Stdout is valid EDN (the human summary rides as `;;`
+      # comments), so the artefact and the thing a reviewer reads are the
+      # same bytes. A violated DETERMINISTIC property still reds this step —
+      # that is what a gate is — but no distribution can, however far it
+      # moves.
+      - name: Run the evidence suite and publish the result records
+        run: |
+          mkdir -p out
+          clojure -M:bench > out/freehand-bench.edn
+          cat out/freehand-bench.edn
+
+      - name: Upload the result records
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: freehand-bench-${{ github.sha }}
+          path: implementation/freehand/out/freehand-bench.edn
+          if-no-files-found: error
+          retention-days: 90

--- a/implementation/freehand/deps.edn
+++ b/implementation/freehand/deps.edn
@@ -41,4 +41,18 @@
  {:test {:extra-paths ["test"]
          :extra-deps  {day8/re-frame2-routing    {:local/root "../routing"}
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
-         :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}
+         :main-opts   ["-m" "re-frame.test-quiet.runner"]}
+
+  ;; The B-spine measurement harness (D021). No extra paths and no extra
+  ;; deps: the harness is ordinary artefact source under :paths, because
+  ;; B5 measures PRODUCTION bundles and a measurement spine that could
+  ;; not be compiled into one would measure the wrong artefact.
+  ;;
+  ;;   clojure -M:bench            the standing evidence suite
+  ;;   clojure -M:bench --prove    the two-way falsifiability proof
+  ;;
+  ;; Stdout is valid EDN (the summary rides as `;;` comments), so a
+  ;; release run is `clojure -M:bench > out/freehand-bench.edn`. Exit 1
+  ;; means a deterministic property was violated, and nothing else — no
+  ;; wall-clock or byte distribution can reach that exit code.
+  :bench {:main-opts ["-m" "re-frame.freehand.bench.runner"]}}}

--- a/implementation/freehand/src/re_frame/freehand/bench.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench.cljc
@@ -1,0 +1,260 @@
+(ns re-frame.freehand.bench
+  "The B-spine: one small repeatable harness that runs a named workload
+  and emits a result record.
+
+  This is the scaffolding B1–B5 hang off. It measures nothing on its own
+  — each of the five workloads arrives with the slice that can actually
+  run it, registers itself with [[register!]], and is measured here under
+  one sampling policy, one provenance record, and one rule about what a
+  measurement is allowed to decide.
+
+  ## The rule
+
+  D021 splits Freehand's performance policy in two and this harness is
+  where that split is mechanical rather than cultural:
+
+    - **deterministic properties are hard gates.** A violated property
+      fails the run, names itself, and exits non-zero.
+    - **wall-clock and byte distributions are published evidence.** They
+      have no threshold, no comparator and no verdict. They cannot fail
+      the run however far they move.
+
+  Both directions matter, and the second is the one that erodes quietly.
+  A harness that reds on a slow run has silently become a threshold —
+  which D021 forbids, because engine, hardware, timer granularity and
+  measurement-boundary drift would then make an otherwise-correct release
+  flap red. So [[run]]'s exit code is derived from ONE source: gate
+  verdicts over `:property`-class measurements. A distribution has no
+  path to it. See [[re-frame.freehand.bench.measure]] for why a fixture
+  cannot file a timing as a gate in the first place, and
+  [[re-frame.freehand.bench.falsifiability]] for the proof that the
+  asymmetry holds in both directions.
+
+  ## A workload
+
+      {:id           :B1/finite-template
+       :doc          \"one boundary renders a finite 10³-node template\"
+       :fixture      {:nodes 1000}
+       :baseline     {:kind :interpreted-vs-compiled :reference {:arm :interpreted}}
+       :sampling     {:warmup 5 :samples 40}
+       :measurements [{:id :B1/node-count :doc \"…\" :observable :count :expect 1000}
+                      {:id :B1/self-time-ms :doc \"…\" :observable :duration-ms}]
+       :run          (fn [fixture] {:B1/node-count … :B1/self-time-ms …})}
+
+  `:run` is called once per iteration and answers its observations. It
+  owns its own measurement boundary — the harness never decides where a
+  workload's self time starts, because \"substrate self time versus
+  end-to-end host time\" is one of D021's four baselines and a harness
+  that imposed one boundary would have picked the answer. The harness
+  does add its own end-to-end reading, [[iteration-ms]], to every
+  workload: that is the outer bound the workload's self time sits inside,
+  and it is why every result record has a distribution to publish.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [re-frame.freehand.bench.measure :as m]
+            [re-frame.freehand.bench.provenance :as prov]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn- reject!
+  [sentence data]
+  (throw (ex-info sentence data)))
+
+;; ---------------------------------------------------------------------------
+;; The harness's own reading
+;; ---------------------------------------------------------------------------
+
+(def iteration-ms
+  "The harness's end-to-end wall time for one iteration, added to every
+  workload.
+
+  Evidence, like every other duration. Its job is to bound the
+  workload's own self-time readings from the outside: when self time
+  falls and this does not, the cost moved rather than went away — which
+  is D021's fourth baseline stated as a number instead of a warning."
+  (m/measurement
+    {:id         :bench/iteration-ms
+     :doc        "the harness's end-to-end wall time for one workload iteration"
+     :observable :duration-ms}))
+
+;; ---------------------------------------------------------------------------
+;; Workloads
+;; ---------------------------------------------------------------------------
+
+(def ^:private workload-provenance-paths
+  "The provenance fields a WORKLOAD is responsible for — the rest are
+  detected at run time. Checked at declaration so a fixture that could
+  never emit a record is rejected before it burns a sampling run."
+  [[:benchmark] [:fixture] [:sampling :warmup] [:sampling :samples]
+   [:baseline :kind] [:baseline :reference]])
+
+(defn workload
+  "Answer the validated, normalised `spec`, or throw.
+
+  Normalisation validates every measurement (which is where the
+  gate/evidence split is enforced) and appends [[iteration-ms]]. It is
+  idempotent, so registering and then running a workload does not
+  measure the harness twice."
+  [{:keys [id doc measurements run fixture sampling baseline] :as spec}]
+  (when-not (keyword? id)
+    (reject! (str "A benchmark workload needs a keyword `:id` — got " (pr-str id) ".")
+             {:bench/defect :workload-id :spec spec}))
+  (when-not (and (string? doc) (seq doc))
+    (reject! (str "Workload " id " needs a one-line `:doc` saying what it measures.")
+             {:bench/defect :workload-doc :workload id}))
+  (when-not (ifn? run)
+    (reject! (str "Workload " id " needs a `:run` function of the fixture, answering a map of "
+                  "observations keyed by measurement id.")
+             {:bench/defect :workload-run :workload id}))
+  (when-not (seq measurements)
+    (reject! (str "Workload " id " declares no `:measurements`. A workload that observes nothing "
+                  "publishes nothing.")
+             {:bench/defect :workload-measurements :workload id}))
+  (let [ds (prov/defects {:benchmark id :fixture fixture :sampling sampling :baseline baseline}
+                         workload-provenance-paths)]
+    (when (seq ds)
+      (throw (ex-info (prov/defects-message ds)
+                      {:bench/defect :incomplete-workload :workload id :defects ds}))))
+  (let [declared (into [] (remove #(= (:id iteration-ms) (:id %))) measurements)
+        norm     (mapv m/measurement declared)
+        ids      (mapv :id norm)]
+    (when-not (apply distinct? (:id iteration-ms) ids)
+      (reject! (str "Workload " id " declares a measurement id twice: " (pr-str ids) ". One id "
+                    "names one observation.")
+               {:bench/defect :duplicate-measurement-id :workload id}))
+    (assoc spec :measurements (conj norm iteration-ms))))
+
+(defonce ^:private registry (atom {}))
+
+(defn register!
+  "Register `w` as a workload of the standing evidence suite, answering
+  its id. Re-registering an id replaces it — a fixture is edited in
+  place, not accumulated."
+  [w]
+  (let [{:keys [id] :as norm} (workload w)]
+    (swap! registry assoc id norm)
+    id))
+
+(defn registered
+  "The registered evidence workloads, by id.
+
+  Empty until the first B-workload lands: B1–B5 are separate slices and
+  each arrives with the implementation that can run it."
+  []
+  @registry)
+
+;; ---------------------------------------------------------------------------
+;; Running one workload
+;; ---------------------------------------------------------------------------
+
+(defn- observation
+  [obs mid workload-id]
+  (let [v (get obs mid ::missing)]
+    (if (= ::missing v)
+      (reject! (str "Workload " workload-id " declares measurement " mid " but its `:run` "
+                    "answered no observation for it. Every declared measurement is observed "
+                    "every iteration, or the distribution is over a different thing each time.")
+               {:bench/defect :missing-observation :workload workload-id :measurement mid})
+      v)))
+
+(defn- sample-observations
+  "Run `warmup` discarded iterations then `samples` measured ones,
+  answering the measured observation maps in order."
+  [{:keys [id run sampling fixture]}]
+  (let [{:keys [warmup samples]} sampling]
+    (dotimes [_ warmup] (run fixture))
+    (into []
+          (for [_ (range samples)]
+            (let [t0  (m/now-ms)
+                  obs (run fixture)
+                  t1  (m/now-ms)]
+              (when-not (map? obs)
+                (reject! (str "Workload " id "'s `:run` must answer a map of observations keyed "
+                              "by measurement id — got " (pr-str obs) ".")
+                         {:bench/defect :non-map-observations :workload id}))
+              (assoc obs (:id iteration-ms) (- t1 t0)))))))
+
+(defn- distribution-entry
+  "Summarise one evidence measurement. Answers a summary and nothing
+  else — there is no verdict in this branch, by construction."
+  [wid observations {:keys [id doc observable]}]
+  [id (assoc (m/summarise (mapv #(observation % id wid) observations))
+             :doc doc
+             :observable observable)])
+
+(defn- property-entry
+  "Judge one gate measurement. Answers `[id entry failure-or-nil]`; the
+  failure is the ONLY thing in this harness that can turn a run red."
+  [wid observations measurement]
+  (let [{:keys [id doc expect]} measurement
+        values  (mapv #(observation % id wid) observations)
+        failure (or (m/instability-failure measurement values)
+                    (m/gate-failure measurement (first values)))]
+    [id
+     {:doc      doc
+      :expected (if (fn? expect) :predicate expect)
+      :observed (first values)
+      :pass?    (nil? failure)}
+     failure]))
+
+(defn run-workload
+  "Run `w` and answer its validated result record.
+
+  `opts` may override the detected `:revision`, `:host` and `:build` —
+  a build pipeline that knows the artefact it shipped should say so
+  rather than let the harness guess from the process it happens to be
+  running in.
+
+  The record carries `:gate-failures`, empty when every deterministic
+  property held. `:status` is always `:evidence`: the RECORD is
+  evidence, and the pass/fail lives in `:properties`, sourced only from
+  deterministic gates."
+  ([w] (run-workload w nil))
+  ([w opts]
+   (let [{:keys [id fixture sampling baseline measurements] :as norm} (workload w)
+         observations (sample-observations norm)
+         evidence     (filterv m/evidence? measurements)
+         gates        (filterv m/gate? measurements)
+         judged       (mapv #(property-entry id observations %) gates)]
+     (prov/result
+       {:benchmark     id
+        :doc           (:doc norm)
+        :revision      (or (:revision opts) (prov/detect-revision))
+        :fixture       fixture
+        :build         (or (:build opts) (prov/detect-build))
+        :host          (or (:host opts) (prov/detect-host))
+        :sampling      sampling
+        :baseline      baseline
+        :distribution  (into {} (map #(distribution-entry id observations %)) evidence)
+        :properties    (into {} (map (fn [[k v _]] [k v])) judged)
+        :gate-failures (into [] (keep (fn [[_ _ f]] f)) judged)
+        :status        :evidence}))))
+
+;; ---------------------------------------------------------------------------
+;; Running a suite
+;; ---------------------------------------------------------------------------
+
+(defn run
+  "Run `workloads` (default: the registered evidence suite) and answer
+  the run outcome.
+
+      {:results       [<result record> …]
+       :gate-failures [<failure> …]
+       :exit-code     0 | 1}
+
+  `:exit-code` is 1 when and only when a DETERMINISTIC property was
+  violated. That is the single line this whole namespace exists to make
+  true: `:gate-failures` is concatenated from the records' own gate
+  verdicts, each of which came from
+  [[re-frame.freehand.bench.measure/gate-failure]], which refuses any
+  measurement that is not a gate. A wall-clock or byte distribution has
+  no route into this number, however far it moves."
+  ([] (run (vals (registered)) nil))
+  ([workloads] (run workloads nil))
+  ([workloads opts]
+   (let [results  (mapv #(run-workload % opts) workloads)
+         failures (into [] (mapcat :gate-failures) results)]
+     {:results       results
+      :gate-failures failures
+      :exit-code     (if (seq failures) 1 0)})))

--- a/implementation/freehand/src/re_frame/freehand/bench/falsifiability.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/falsifiability.cljc
@@ -1,0 +1,240 @@
+(ns re-frame.freehand.bench.falsifiability
+  "The harness's own two-way falsifiability proof.
+
+  D021's asymmetry — deterministic properties gate, timing and byte
+  distributions never do — is only worth having if it is falsifiable in
+  BOTH directions. A harness proven only in the first direction is a
+  harness nobody has checked for the failure mode that actually happens:
+  a slow run reds the build, someone adds a tolerance, and evidence has
+  become a threshold that no one calibrated.
+
+  So [[prove]] runs four workloads over the real interpreted walk and
+  asserts four things:
+
+  | arm | expectation | why |
+  |---|---|---|
+  | `honoured-gate`   | exit 0 | non-vacuity: a gate that holds does not red |
+  | `violated-gate`   | exit 1, naming the property | a violated deterministic property reds CI |
+  | `baseline-timing` | exit 0 | the reference distribution |
+  | `moved-timing`    | exit 0 | a wall-clock reading many times larger still exits 0 |
+
+  and one more, which is what stops the fourth row being a tautology:
+  the moved arm's distribution must actually have MOVED, by a large
+  multiple of the baseline's. A proof that a timing \"did not red\" is
+  worth nothing unless the timing it did not red on was wildly different.
+
+  The four arms are deliberately not registered with
+  [[re-frame.freehand.bench/register!]]. They are a proof about the
+  harness, not evidence about Freehand, and one of them fails on purpose.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [re-frame.freehand.bench :as bench]
+            [re-frame.freehand.bench.measure :as m]
+            [re-frame.freehand.tree :as tree]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---------------------------------------------------------------------------
+;; The fixture — the real interpreted walk, not a stand-in
+;; ---------------------------------------------------------------------------
+
+(defn- template
+  "A finite list template of `n` rows. Plain markup: no declared view, no
+  subscription, no host — the proof is about the harness, so its workload
+  is the smallest real thing the substrate can already do."
+  [n]
+  (into [:ul.rows]
+        (map (fn [i] [:li.row (str "row " i)]))
+        (range n)))
+
+(defn- node-count
+  "The exact number of nodes in a rendered structural tree. Text children
+  are strings, so `map?` is the whole discriminator."
+  [t]
+  (count (filter map? (tree-seq map? :children t))))
+
+(def ^:private row-count
+  "Rows in the proof template. A fixture parameter, not a constant of the
+  language — it appears in every result record this namespace emits."
+  200)
+
+(defn- arm
+  "One proof arm: render the template `repeats` times, observe the node
+  count of the first tree and the self time of the whole burst.
+
+  `expect` is the node count a correct run answers. `repeats` is the
+  timing knob: it changes the duration by roughly its own factor and
+  changes the node count not at all, which is exactly the pair of levers
+  the two directions of the proof need.
+
+  `sampling` is per-arm because the arms are deliberately unequal in
+  cost. The cheap arms buy a warm engine with many discarded iterations;
+  the expensive one is warm after a single discarded iteration and does
+  not need forty."
+  [{:keys [id doc repeats expect sampling]}]
+  {:id           id
+   :doc          doc
+   :fixture      {:rows row-count :repeats repeats}
+   :baseline     {:kind      :self-vs-end-to-end
+                  :reference {:arm  :interpreted
+                              :note "the walk's own self time inside the harness's iteration time"}}
+   :sampling     sampling
+   :measurements [{:id         :falsifiability/node-count
+                   :doc        "the exact node count of the interpreted structural tree"
+                   :observable :count
+                   :expect     expect}
+                  {:id         :falsifiability/render-ms
+                   :doc        "self time for the fixture's burst of interpreted renders"
+                   :observable :duration-ms}]
+   :run          (fn [{:keys [rows repeats]}]
+                   (let [form  (template rows)
+                         t0    (m/now-ms)
+                         trees (doall (repeatedly repeats #(tree/render form)))
+                         t1    (m/now-ms)]
+                     {:falsifiability/node-count (node-count (first trees))
+                      :falsifiability/render-ms  (- t1 t0)}))})
+
+;; The template renders one `:ul` node holding `rows` `:li` nodes; the row
+;; text is a string child, not a node. The expectation is DECLARED from the
+;; fixture parameter rather than read back from the observation — a gate
+;; that expects whatever it saw is not a gate.
+(def ^:private correct-node-count (inc row-count))
+
+(def ^:private light
+  "The cheap arms' policy. The generous warm-up is not politeness: with a
+  cold engine the first renders cost several times a warm one, and a
+  baseline distribution measured cold would understate how far the moved
+  arm actually moved."
+  {:warmup 10 :samples 5})
+
+(def honoured-gate
+  "Positive control. The deterministic property holds, so the run is
+  green — without this arm, criterion 2 could be satisfied by a harness
+  that reds on everything."
+  (arm {:id       :falsifiability/honoured-gate
+        :doc      "a deterministic property that holds"
+        :repeats  4
+        :sampling light
+        :expect   correct-node-count}))
+
+(def violated-gate
+  "The gate direction. The same workload with an expectation a correct
+  run cannot meet, so the deterministic property is violated and the run
+  must red, naming the property."
+  (arm {:id       :falsifiability/violated-gate
+        :doc      "a deterministic property deliberately violated"
+        :repeats  4
+        :sampling light
+        :expect   (+ correct-node-count 1000)}))
+
+(def baseline-timing
+  "The evidence direction's reference distribution."
+  (arm {:id       :falsifiability/baseline-timing
+        :doc      "the reference wall-clock distribution"
+        :repeats  4
+        :sampling light
+        :expect   correct-node-count}))
+
+(def moved-timing
+  "The evidence direction. Identical work, done fifty times over, so the
+  wall-clock distribution moves by a large multiple while every
+  deterministic property answers exactly what it answered before."
+  (arm {:id       :falsifiability/moved-timing
+        :doc      "the same work with a wildly larger wall-clock reading"
+        :repeats  200
+        :sampling {:warmup 1 :samples 3}
+        :expect   correct-node-count}))
+
+;; ---------------------------------------------------------------------------
+;; The proof
+;; ---------------------------------------------------------------------------
+
+(def ^:private minimum-move
+  "How many times the baseline distribution the moved arm must reach for
+  the evidence direction to have proven anything.
+
+  This is a threshold on the PROOF, not on Freehand. It exists to stop
+  the fourth row of the table being satisfied by a timing that did not
+  move — the opposite of a performance budget, and the reason it is set
+  far below the ~50× the fixture actually produces."
+  10)
+
+(defn- p50
+  [result measurement]
+  (get-in result [:distribution measurement :p50]))
+
+(defn- check
+  [ok? sentence]
+  (when-not ok? sentence))
+
+(defn prove
+  "Run the four arms and answer the proof report.
+
+      {:arms     {…}     ; each arm's outcome, for the transcript
+       :move     <ratio> ; how far the moved arm's distribution actually moved
+       :defects  […]     ; empty when the asymmetry holds both ways
+       :proven?  true}
+
+  Answers a report rather than throwing, so a test can assert on it, a
+  CLI can print it, and a failure says which of the four expectations
+  broke instead of which line threw."
+  []
+  (let [holds (bench/run [honoured-gate])
+        reds  (bench/run [violated-gate])
+        green (bench/run [baseline-timing])
+        moved (bench/run [moved-timing])
+        named (some #(= :falsifiability/node-count (:measurement %)) (:gate-failures reds))
+        base  (p50 (first (:results green)) :falsifiability/render-ms)
+        big   (p50 (first (:results moved)) :falsifiability/render-ms)
+        ratio (when (and (number? base) (pos? base) (number? big)) (/ big base))
+        defects
+        (into []
+              (keep identity)
+              [(check (zero? (:exit-code holds))
+                      (str "A deterministic property that HOLDS red the run (exit "
+                           (:exit-code holds) "): " (pr-str (:gate-failures holds))
+                           ". The gate direction is vacuous if the harness reds on everything."))
+
+               (check (= 1 (:exit-code reds))
+                      (str "A deterministic property registered as a GATE was violated and the "
+                           "run exited " (:exit-code reds)
+                           ". A gate that does not red CI is not a gate."))
+
+               (check named
+                      (str "The violated run failed without naming the property "
+                           ":falsifiability/node-count — got "
+                           (pr-str (mapv :measurement (:gate-failures reds)))
+                           ". A gate failure that cannot say what broke is not evidence."))
+
+               (check (zero? (:exit-code green))
+                      (str "The reference timing arm exited " (:exit-code green)
+                           ": " (pr-str (:gate-failures green))))
+
+               (check (zero? (:exit-code moved))
+                      (str "A wall-clock measurement registered as EVIDENCE moved and the run "
+                           "exited " (:exit-code moved)
+                           ". D021 sets no numeric threshold on timing: a harness that fails on "
+                           "a slow run has silently become the threshold it forbids."))
+
+               (check (empty? (:gate-failures moved))
+                      (str "The moved-timing arm reported gate failures: "
+                           (pr-str (:gate-failures moved))
+                           ". Only deterministic properties may produce a verdict."))
+
+               (check (and ratio (>= ratio minimum-move))
+                      (str "The moved-timing arm's distribution did not actually move — p50 "
+                           (pr-str big) "ms against a baseline of " (pr-str base) "ms ("
+                           (pr-str ratio) "×, needed " minimum-move "×). Proving that an "
+                           "unchanged timing does not red the build proves nothing."))])]
+    {:arms    {:honoured-gate   {:exit-code (:exit-code holds)}
+               :violated-gate   {:exit-code     (:exit-code reds)
+                                 :gate-failures (mapv :message (:gate-failures reds))}
+               :baseline-timing {:exit-code (:exit-code green)
+                                 :p50-ms    base}
+               :moved-timing    {:exit-code     (:exit-code moved)
+                                 :p50-ms        big
+                                 :gate-failures (mapv :message (:gate-failures moved))}}
+     :move    ratio
+     :defects defects
+     :proven? (empty? defects)}))

--- a/implementation/freehand/src/re_frame/freehand/bench/falsifiability.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/falsifiability.cljc
@@ -157,7 +157,7 @@
   This is a threshold on the PROOF, not on Freehand. It exists to stop
   the fourth row of the table being satisfied by a timing that did not
   move — the opposite of a performance budget, and the reason it is set
-  far below the ~50× the fixture actually produces."
+  far below the 20x-50x the fixture actually produces."
   10)
 
 (defn- p50
@@ -196,43 +196,43 @@
          ratio   (when (and (number? base) (pos? base) (number? big)) (/ big base))
          defects
          (into []
-              (keep identity)
-              [(check (zero? (:exit-code holds))
-                      (str "A deterministic property that HOLDS red the run (exit "
-                           (:exit-code holds) "): " (pr-str (:gate-failures holds))
-                           ". The gate direction is vacuous if the harness reds on everything."))
+               (keep identity)
+               [(check (zero? (:exit-code holds))
+                       (str "A deterministic property that HOLDS red the run (exit "
+                            (:exit-code holds) "): " (pr-str (:gate-failures holds))
+                            ". The gate direction is vacuous if the harness reds on everything."))
 
-               (check (= 1 (:exit-code reds))
-                      (str "A deterministic property registered as a GATE was violated and the "
-                           "run exited " (:exit-code reds)
-                           ". A gate that does not red CI is not a gate."))
+                (check (= 1 (:exit-code reds))
+                       (str "A deterministic property registered as a GATE was violated and the "
+                            "run exited " (:exit-code reds)
+                            ". A gate that does not red CI is not a gate."))
 
-               (check named
-                      (str "The violated run failed without naming the property "
-                           ":falsifiability/node-count — got "
-                           (pr-str (mapv :measurement (:gate-failures reds)))
-                           ". A gate failure that cannot say what broke is not evidence."))
+                (check named
+                       (str "The violated run failed without naming the property "
+                            ":falsifiability/node-count — got "
+                            (pr-str (mapv :measurement (:gate-failures reds)))
+                            ". A gate failure that cannot say what broke is not evidence."))
 
-               (check (zero? (:exit-code green))
-                      (str "The reference timing arm exited " (:exit-code green)
-                           ": " (pr-str (:gate-failures green))))
+                (check (zero? (:exit-code green))
+                       (str "The reference timing arm exited " (:exit-code green)
+                            ": " (pr-str (:gate-failures green))))
 
-               (check (zero? (:exit-code moved))
-                      (str "A wall-clock measurement registered as EVIDENCE moved and the run "
-                           "exited " (:exit-code moved)
-                           ". D021 sets no numeric threshold on timing: a harness that fails on "
-                           "a slow run has silently become the threshold it forbids."))
+                (check (zero? (:exit-code moved))
+                       (str "A wall-clock measurement registered as EVIDENCE moved and the run "
+                            "exited " (:exit-code moved)
+                            ". D021 sets no numeric threshold on timing: a harness that fails on "
+                            "a slow run has silently become the threshold it forbids."))
 
-               (check (empty? (:gate-failures moved))
-                      (str "The moved-timing arm reported gate failures: "
-                           (pr-str (:gate-failures moved))
-                           ". Only deterministic properties may produce a verdict."))
+                (check (empty? (:gate-failures moved))
+                       (str "The moved-timing arm reported gate failures: "
+                            (pr-str (:gate-failures moved))
+                            ". Only deterministic properties may produce a verdict."))
 
-               (check (and ratio (>= ratio minimum-move))
-                      (str "The moved-timing arm's distribution did not actually move — p50 "
-                           (pr-str big) "ms against a baseline of " (pr-str base) "ms ("
-                           (pr-str ratio) "x, needed " minimum-move "x). Proving that an "
-                           "unchanged timing does not red the build proves nothing."))])]
+                (check (and ratio (>= ratio minimum-move))
+                       (str "The moved-timing arm's distribution did not actually move — p50 "
+                            (pr-str big) "ms against a baseline of " (pr-str base) "ms ("
+                            (pr-str ratio) "x, needed " minimum-move "x). Proving that an "
+                            "unchanged timing does not red the build proves nothing."))])]
      {:arms    {:honoured-gate   {:exit-code (:exit-code holds)}
                 :violated-gate   {:exit-code     (:exit-code reds)
                                   :gate-failures (mapv :message (:gate-failures reds))}

--- a/implementation/freehand/src/re_frame/freehand/bench/falsifiability.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/falsifiability.cljc
@@ -178,18 +178,24 @@
 
   Answers a report rather than throwing, so a test can assert on it, a
   CLI can print it, and a failure says which of the four expectations
-  broke instead of which line threw."
-  []
-  (let [holds (bench/run [honoured-gate])
-        reds  (bench/run [violated-gate])
-        green (bench/run [baseline-timing])
-        moved (bench/run [moved-timing])
-        named (some #(= :falsifiability/node-count (:measurement %)) (:gate-failures reds))
-        base  (p50 (first (:results green)) :falsifiability/render-ms)
-        big   (p50 (first (:results moved)) :falsifiability/render-ms)
-        ratio (when (and (number? base) (pos? base) (number? big)) (/ big base))
-        defects
-        (into []
+  broke instead of which line threw.
+
+  `opts` are [[re-frame.freehand.bench/run-workload]]'s provenance
+  overrides. A host that cannot detect its own revision — a browser, or a
+  ClojureScript test process — supplies one here; a JVM checkout needs
+  nothing."
+  ([] (prove nil))
+  ([opts]
+   (let [holds   (bench/run [honoured-gate] opts)
+         reds    (bench/run [violated-gate] opts)
+         green   (bench/run [baseline-timing] opts)
+         moved   (bench/run [moved-timing] opts)
+         named   (some #(= :falsifiability/node-count (:measurement %)) (:gate-failures reds))
+         base    (p50 (first (:results green)) :falsifiability/render-ms)
+         big     (p50 (first (:results moved)) :falsifiability/render-ms)
+         ratio   (when (and (number? base) (pos? base) (number? big)) (/ big base))
+         defects
+         (into []
               (keep identity)
               [(check (zero? (:exit-code holds))
                       (str "A deterministic property that HOLDS red the run (exit "
@@ -225,16 +231,16 @@
                (check (and ratio (>= ratio minimum-move))
                       (str "The moved-timing arm's distribution did not actually move — p50 "
                            (pr-str big) "ms against a baseline of " (pr-str base) "ms ("
-                           (pr-str ratio) "×, needed " minimum-move "×). Proving that an "
+                           (pr-str ratio) "x, needed " minimum-move "x). Proving that an "
                            "unchanged timing does not red the build proves nothing."))])]
-    {:arms    {:honoured-gate   {:exit-code (:exit-code holds)}
-               :violated-gate   {:exit-code     (:exit-code reds)
-                                 :gate-failures (mapv :message (:gate-failures reds))}
-               :baseline-timing {:exit-code (:exit-code green)
-                                 :p50-ms    base}
-               :moved-timing    {:exit-code     (:exit-code moved)
-                                 :p50-ms        big
-                                 :gate-failures (mapv :message (:gate-failures moved))}}
-     :move    ratio
-     :defects defects
-     :proven? (empty? defects)}))
+     {:arms    {:honoured-gate   {:exit-code (:exit-code holds)}
+                :violated-gate   {:exit-code     (:exit-code reds)
+                                  :gate-failures (mapv :message (:gate-failures reds))}
+                :baseline-timing {:exit-code (:exit-code green)
+                                  :p50-ms    base}
+                :moved-timing    {:exit-code     (:exit-code moved)
+                                  :p50-ms        big
+                                  :gate-failures (mapv :message (:gate-failures moved))}}
+      :move    ratio
+      :defects defects
+      :proven? (empty? defects)})))

--- a/implementation/freehand/src/re_frame/freehand/bench/measure.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/measure.cljc
@@ -1,0 +1,307 @@
+(ns re-frame.freehand.bench.measure
+  "What a benchmark OBSERVES — and what observing it is allowed to decide.
+
+  D021 rules that Freehand's deterministic properties are release gates
+  and that its wall-clock and byte distributions are required published
+  evidence, *never* fixed thresholds. That ruling is one sentence long
+  and erodes in one line of code: a `:max-ms 12` on a timing fixture
+  quietly mints a threshold the decision forbids, and a timing
+  \"gate\" quietly converts runner noise into a red build that the next
+  engineer learns to re-run rather than read.
+
+  So the split is not a convention here. It is a total function of what
+  a measurement observes:
+
+      observable  ->  class          ->  enforcement
+      :count          :property          :gate
+      :flag           :property          :gate
+      :value          :property          :gate
+      :duration-ms    :distribution      :evidence
+      :bytes          :distribution      :evidence
+
+  A fixture author picks the observable — the thing they are actually
+  looking at. They do not pick the enforcement, and there is no third
+  answer. A spec may RESTATE its enforcement (`:enforcement :gate`), and
+  restating it wrongly is rejected at construction, naming both the value
+  stated and the value the observable compels. That is the mechanism
+  behind D021's two-way obligation:
+
+    - a timing or byte measurement CANNOT be registered as a gate. It has
+      no path to a pass/fail verdict: `:duration-ms` classes as a
+      `:distribution`, a distribution enforces as `:evidence`, and
+      [[gate-failure]] refuses anything that is not a `:gate`. Declaring
+      any pass/fail key on evidence ([[pass-fail-keys]]) is rejected —
+      that is the folklore-threshold non-goal, mechanised.
+
+    - a deterministic property CANNOT degrade to advisory. Restating a
+      property as `:evidence` is rejected, and a gate WITHOUT an
+      expectation is rejected too: a gate that cannot fail is advisory
+      wearing a gate's name.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [clojure.string :as str]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---------------------------------------------------------------------------
+;; The clock
+;; ---------------------------------------------------------------------------
+
+(defn now-ms
+  "A monotonic elapsed-time reading in milliseconds, at the finest
+  resolution the host offers.
+
+  Deliberately NOT `re-frame.interop/now-ms`: that surface is the
+  framework's shared elapsed clock and on the JVM it is
+  `System/currentTimeMillis`, whose one-millisecond granularity cannot
+  resolve a view render. A measurement harness that reported `0.0` for
+  everything faster than a millisecond would publish a distribution of
+  rounding error.
+
+  The reading is origin-relative on both hosts and is meaningful only as
+  a difference. Nothing durable is written from it."
+  []
+  #?(:clj  (/ (double (System/nanoTime)) 1e6)
+     :cljs (if (and (exists? js/performance) (exists? js/performance.now))
+             (js/performance.now)
+             (.getTime (js/Date.)))))
+
+;; ---------------------------------------------------------------------------
+;; The observable vocabulary — the whole of D021's split
+;; ---------------------------------------------------------------------------
+
+(def observables
+  "The closed set of things a Freehand benchmark may observe.
+
+  `:class` is the load-bearing field. `:property` is a deterministic fact
+  about the run — an exact count, a correctness flag, an exact value —
+  that is reproducible on any host and therefore safe to gate on.
+  `:distribution` is a sampled magnitude whose spread is a property of
+  the engine, the timer, the hardware and the moment, and which D021
+  therefore publishes rather than judges."
+  {:count       {:class :distribution-free
+                 :doc   "an exact attributable count"}
+   :flag        {:class :distribution-free
+                 :doc   "a boolean correctness property"}
+   :value       {:class :distribution-free
+                 :doc   "an exact value, compared by ="}
+   :duration-ms {:class :distribution
+                 :doc   "wall-clock elapsed milliseconds"}
+   :bytes       {:class :distribution
+                 :doc   "shipped or retained size in bytes"}})
+
+;; `:distribution-free` says exactly the right thing about the first
+;; three: they have no distribution to publish, because a correct run
+;; answers one value. That is the same fact as "deterministic", stated in
+;; the vocabulary of the thing being enforced.
+
+(def enforcement-by-class
+  "D021's ruling as a total function. Two classes, two enforcements, no
+  third answer and no author-supplied override."
+  {:distribution-free :gate
+   :distribution      :evidence})
+
+(defn enforcement-for
+  "The enforcement `observable` compels, or nil when it is not one of
+  [[observables]]."
+  [observable]
+  (some-> (get observables observable) :class enforcement-by-class))
+
+(def pass-fail-keys
+  "Keys that turn a measurement into a pass/fail test. Legal on a gate
+  (`:expect` is REQUIRED there); every one of them is rejected on an
+  evidence measurement, because an evidence measurement carrying a
+  budget is precisely the folklore threshold D021 forbids."
+  #{:expect :threshold :budget :budget-ms :target :tolerance :within
+    :limit :max :min :max-ms :min-ms :max-bytes :min-bytes})
+
+;; ---------------------------------------------------------------------------
+;; Construction
+;; ---------------------------------------------------------------------------
+
+(defn- reject!
+  [sentence data]
+  (throw (ex-info sentence data)))
+
+(defn- blank-doc? [d]
+  (or (not (string? d)) (str/blank? d)))
+
+(defn measurement
+  "Answer the validated, normalised measurement `spec`, or throw.
+
+  A spec names what it observes and says, in one line, what claim the
+  observation supports:
+
+      {:id         :B2/omitted-cells
+       :doc        \"the exact omitted-ViewCell count on the mass mount\"
+       :observable :count
+       :expect     26}
+
+  `:enforcement` and `:class` are ADDED by this function from
+  `:observable`. Supplying `:enforcement` yourself is allowed and is
+  checked, not honoured — a restatement that disagrees with the
+  observable is the exact mistake D021 exists to prevent, so it is
+  rejected rather than silently corrected.
+
+  On a gate, `:expect` is required and is either a literal value
+  (compared with `=`) or a predicate of the observed value.
+
+  Normalisation is idempotent: re-running a normalised spec through this
+  function answers an equal spec."
+  [{:keys [id doc observable] :as spec}]
+  (when-not (qualified-keyword? id)
+    (reject! (str "A benchmark measurement needs a namespaced `:id` so two workloads cannot "
+                  "collide on one name — got " (pr-str id) ".")
+             {:bench/defect :measurement-id :spec spec}))
+  (when (blank-doc? doc)
+    (reject! (str "Measurement " id " needs a one-line `:doc` naming the property or claim it "
+                  "supports — a gate failure that cannot say what broke is a stack trace, not "
+                  "evidence.")
+             {:bench/defect :measurement-doc :spec spec}))
+  (when-not (contains? observables observable)
+    (reject! (str "Measurement " id " declares `:observable " (pr-str observable) "`, which is "
+                  "not one of " (pr-str (vec (sort (keys observables)))) ". The observable is "
+                  "what decides whether a measurement gates or is published as evidence, so it "
+                  "cannot be an open vocabulary.")
+             {:bench/defect :measurement-observable :spec spec}))
+  (let [klass   (:class (get observables observable))
+        derived (enforcement-by-class klass)
+        stated  (:enforcement spec)]
+    (when (and (some? stated) (not= stated derived))
+      (reject! (str "Measurement " id " observes " observable ", which D021 enforces as "
+                    derived ", but the spec states `:enforcement " (pr-str stated) "`. "
+                    (if (= :gate stated)
+                      (str "Wall-clock and byte distributions are published evidence with no "
+                           "automatic numeric pass/fail; a timing gate turns runner noise into "
+                           "a red build.")
+                      (str "Deterministic properties are hard release gates; letting one "
+                           "degrade to advisory is how a correctness regression hides behind "
+                           "benchmark noise."))
+                    " Change the observable or drop the restatement.")
+               {:bench/defect :enforcement-restated
+                :measurement  id
+                :observable   observable
+                :stated       stated
+                :compelled    derived}))
+    (case derived
+      :gate
+      (when-not (contains? spec :expect)
+        (reject! (str "Measurement " id " is a deterministic property and therefore a gate, but "
+                      "declares no `:expect`. A gate with nothing to violate is advisory wearing "
+                      "a gate's name — give it the value (or predicate) a correct run answers.")
+                 {:bench/defect :gate-without-expectation :measurement id}))
+
+      :evidence
+      (when-let [k (first (filter #(contains? spec %) (sort pass-fail-keys)))]
+        (reject! (str "Measurement " id " observes " observable " and is published evidence, but "
+                      "declares `" k "`. D021 sets no numeric threshold on wall-clock or byte "
+                      "distributions: an adverse trend is attributed and dispositioned by a "
+                      "human, never failed automatically by a comparator nobody calibrated.")
+                 {:bench/defect :threshold-on-evidence
+                  :measurement  id
+                  :offending-key k})))
+    (assoc spec :enforcement derived :class klass)))
+
+(defn gate?
+  "True when `m` is a normalised gate measurement."
+  [m]
+  (= :gate (:enforcement m)))
+
+(defn evidence?
+  "True when `m` is a normalised evidence measurement."
+  [m]
+  (= :evidence (:enforcement m)))
+
+;; ---------------------------------------------------------------------------
+;; Gate evaluation — the ONLY producer of a failing verdict in this harness
+;; ---------------------------------------------------------------------------
+
+(defn- satisfied?
+  [expect observed]
+  (if (fn? expect)
+    (boolean (expect observed))
+    (= expect observed)))
+
+(defn- expectation-str
+  [expect]
+  (if (fn? expect) "the declared predicate" (pr-str expect)))
+
+(defn gate-failure
+  "Answer nil when the gate `m` holds for `observed`, otherwise a failure
+  map NAMING the property, its claim, what was expected and what was
+  observed.
+
+  Refuses a measurement that is not a gate. That refusal is what makes
+  criterion 3 structural rather than tested: there is no argument to this
+  function that turns a `:duration-ms` or `:bytes` observation into a
+  failing verdict."
+  [{:keys [id doc expect] :as m} observed]
+  (when-not (gate? m)
+    (reject! (str "Measurement " id " is " (:enforcement m) " and cannot produce a pass/fail "
+                  "verdict. Only deterministic properties gate.")
+             {:bench/defect :verdict-on-evidence :measurement id}))
+  (when-not (satisfied? expect observed)
+    {:measurement id
+     :doc         doc
+     :expected    (if (fn? expect) :predicate expect)
+     :observed    observed
+     :message     (str "GATE FAILED: " id " (" doc "). Expected " (expectation-str expect)
+                       ", observed " (pr-str observed) ".")}))
+
+(defn instability-failure
+  "Answer nil when the gate `m` answered ONE value across the sample set,
+  otherwise a failure naming the property and the values it gave.
+
+  A deterministic property that is not deterministic cannot gate anything:
+  either the workload has a hidden input, or the observable was misfiled
+  and is really a distribution."
+  [{:keys [id doc] :as m} observed-values]
+  (when-not (gate? m)
+    (reject! (str "Measurement " id " is " (:enforcement m) " and has no stability obligation — "
+                  "spread is what a distribution is for.")
+             {:bench/defect :stability-on-evidence :measurement id}))
+  (let [vs (vec (distinct observed-values))]
+    (when (< 1 (count vs))
+      {:measurement id
+       :doc         doc
+       :expected    :one-value-per-run
+       :observed    vs
+       :message     (str "GATE FAILED: " id " (" doc ") is registered as a deterministic "
+                         "property but answered " (count vs) " distinct values across the "
+                         "sample set: " (pr-str vs) ". Either the workload has an undeclared "
+                         "input, or this is a distribution filed as a property.")})))
+
+;; ---------------------------------------------------------------------------
+;; Distribution summary — evidence, and only evidence
+;; ---------------------------------------------------------------------------
+
+(defn- round4 [x]
+  (/ (double (Math/round (* (double x) 10000.0))) 10000.0))
+
+(defn- percentile
+  "Nearest-rank percentile over an ascending vector."
+  [sorted p]
+  (let [n (count sorted)]
+    (nth sorted (max 0 (min (dec n) (dec (int (Math/ceil (* p n)))))))))
+
+(defn summarise
+  "Summarise `samples` as the distribution D021 requires a published
+  result to carry — never a median on its own.
+
+  Answers nothing that can fail. This function has no expectation, no
+  comparator and no verdict, because there is no numeric threshold in
+  Freehand's performance policy to compare against."
+  [samples]
+  (when-not (and (seq samples) (every? number? samples))
+    (reject! (str "A distribution needs at least one numeric sample — got " (pr-str samples) ".")
+             {:bench/defect :non-numeric-samples}))
+  (let [sorted (vec (sort samples))
+        n      (count sorted)]
+    {:n    n
+     :min  (round4 (first sorted))
+     :p50  (round4 (percentile sorted 0.50))
+     :p95  (round4 (percentile sorted 0.95))
+     :p99  (round4 (percentile sorted 0.99))
+     :max  (round4 (peek sorted))
+     :mean (round4 (/ (reduce + 0.0 sorted) n))}))

--- a/implementation/freehand/src/re_frame/freehand/bench/provenance.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/provenance.cljc
@@ -70,13 +70,27 @@
 (defn- blank->nil [s]
   (when (and (string? s) (not (str/blank? s))) s))
 
+#?(:cljs
+   ;; The browser has no environment and no git. A bundle that is going to
+   ;; be measured names the revision it was built from at COMPILE time:
+   ;;
+   ;;   :closure-defines {re-frame.freehand.bench.provenance/build-revision "<sha>"}
+   ;;
+   ;; Left empty, a browser run cannot emit a result record — which is the
+   ;; correct outcome, not an inconvenience: an unattributable bundle
+   ;; measurement is a number about nothing.
+   (goog-define build-revision ""))
+
 (defn detect-revision
   "The source revision the measured code was built from.
 
-  `RF2_REVISION` wins (a build pipeline knows better than a checkout),
-  then `GITHUB_SHA`, then — on the JVM only — `git rev-parse HEAD`. When
-  none of those answer, this answers nil and [[result]] refuses to emit:
-  an unattributable measurement is not evidence of anything."
+  `RF2_REVISION` wins (a build pipeline knows better than the checkout it
+  happens to be standing in), then `GITHUB_SHA`, then the host's own best
+  answer: a compile-time `build-revision` on ClojureScript, `git rev-parse
+  HEAD` on the JVM.
+
+  When none of those answer, this answers nil and [[result]] refuses to
+  emit. That refusal is the policy working, not a gap in it."
   []
   (or (blank->nil (env "RF2_REVISION"))
       (blank->nil (env "GITHUB_SHA"))
@@ -84,7 +98,7 @@
                  (let [{:keys [exit out]} (shell/sh "git" "rev-parse" "HEAD")]
                    (when (zero? exit) (blank->nil (str/trim out))))
                  (catch Exception _ nil))
-         :cljs nil)))
+         :cljs (blank->nil build-revision))))
 
 (defn detect-hardware-class
   "The hardware class this run's numbers may be compared within.

--- a/implementation/freehand/src/re_frame/freehand/bench/provenance.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/provenance.cljc
@@ -1,0 +1,272 @@
+(ns re-frame.freehand.bench.provenance
+  "The result record, and the reason a number without one is not evidence.
+
+  D021: *\"Every stored result must name the source revision, build mode,
+  browser/runtime, hardware class, warm-up/sample policy, fixture
+  parameters, and whether dev instrumentation was enabled. A median
+  without its distribution and environment is not release evidence.\"*
+
+  The obligation is enforced at the only door that emits a record. There
+  is no lenient path, no partial record, and no default that invents a
+  field the run did not actually observe: [[result]] answers a record or
+  throws, and [[required-fields]] is the whole ledger it checks — the
+  same ledger [[re-frame.freehand.bench/workload]] uses to reject a
+  fixture that could never emit one.
+
+  Detection, never a literal. `revision`, `host` and `build` are read
+  from the environment the run is actually in ([[detect-revision]],
+  [[detect-host]], [[detect-build]]) or supplied by the caller. Hardware
+  class in particular is detected or configured — a benchmark record that
+  hardcodes the machine it was written on is a record about nothing.
+
+  The shape follows D021's compact-EDN example, with one deliberate
+  split. D021 puts every observation under one `:result` key; this record
+  separates `:distribution` (evidence, never a verdict) from
+  `:properties` (the deterministic gates and their verdicts), because
+  keeping the two legible in the artefact is the whole point of the
+  ruling.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [clojure.string :as str]
+            #?(:clj [clojure.java.shell :as shell])))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---------------------------------------------------------------------------
+;; The four named baselines
+;; ---------------------------------------------------------------------------
+
+(def baselines
+  "D021 §Baselines. A result with no comparator is a number; these are
+  the four comparators Freehand's evidence is allowed to name.
+
+  Every workload declares one, plus a `:reference` map saying WHICH
+  other arm, donor cut, or revision it is measured against."
+  {:interpreted-vs-compiled
+   "Freehand interpreted versus Freehand compiled — isolates lowering cost under common semantics."
+
+   :absorbed-vs-donor
+   "The absorbed tier versus a named donor cut — detects regressions introduced while moving proven machinery."
+
+   :before-vs-after
+   "Before versus after an implementation change — the regression comparison."
+
+   :self-vs-end-to-end
+   "Substrate self time versus end-to-end host time — stops a substrate-local speedup being sold as an application speedup."})
+
+;; ---------------------------------------------------------------------------
+;; Detection
+;; ---------------------------------------------------------------------------
+
+(defn env
+  "Read environment variable `n`, or nil where the host has no
+  environment (a browser)."
+  [n]
+  #?(:clj  (System/getenv n)
+     :cljs (when (and (exists? js/process) (some? (.-env js/process)))
+             (aget (.-env js/process) n))))
+
+(defn- blank->nil [s]
+  (when (and (string? s) (not (str/blank? s))) s))
+
+(defn detect-revision
+  "The source revision the measured code was built from.
+
+  `RF2_REVISION` wins (a build pipeline knows better than a checkout),
+  then `GITHUB_SHA`, then — on the JVM only — `git rev-parse HEAD`. When
+  none of those answer, this answers nil and [[result]] refuses to emit:
+  an unattributable measurement is not evidence of anything."
+  []
+  (or (blank->nil (env "RF2_REVISION"))
+      (blank->nil (env "GITHUB_SHA"))
+      #?(:clj  (try
+                 (let [{:keys [exit out]} (shell/sh "git" "rev-parse" "HEAD")]
+                   (when (zero? exit) (blank->nil (str/trim out))))
+                 (catch Exception _ nil))
+         :cljs nil)))
+
+(defn detect-hardware-class
+  "The hardware class this run's numbers may be compared within.
+
+  Configured (`RF2_HARDWARE_CLASS`) or detected — never a literal naming
+  one machine. In CI without an explicit class the runner is a
+  `:shared-ci-runner`, which is honest: a shared runner's distribution is
+  comparable with other shared-runner distributions and with nothing
+  else. D021's pinned scheduled worker sets `RF2_HARDWARE_CLASS` to say
+  so."
+  []
+  (if-let [configured (blank->nil (env "RF2_HARDWARE_CLASS"))]
+    (keyword configured)
+    (if (blank->nil (env "CI")) :shared-ci-runner :developer-workstation)))
+
+(defn detect-host
+  "The browser/runtime and hardware class this run happened on."
+  []
+  (merge
+    {:hardware-class (detect-hardware-class)}
+    #?(:clj
+       {:runtime  (str "JVM " (System/getProperty "java.vm.name")
+                       " " (System/getProperty "java.version"))
+        :cpu-count (.availableProcessors (Runtime/getRuntime))}
+       :cljs
+       (cond
+         (and (exists? js/process) (some? (.-version js/process)))
+         {:runtime (str "Node " (.-version js/process))}
+
+         (exists? js/navigator)
+         {:runtime (str (.-userAgent js/navigator))}
+
+         :else
+         {:runtime "ClojureScript (unidentified host)"}))))
+
+(defn detect-build
+  "The build mode and whether dev instrumentation was compiled in.
+
+  On CLJS both answers come from `goog.DEBUG`, which is the switch this
+  repository's dev/tool code elides against, so a production bundle
+  reports `{:optimizations :advanced :instrumentation? false}` without
+  being told. The JVM has no optimization level and no elision, so it
+  reports `:jvm` and an instrumented build — which is true, and is
+  exactly why JVM timings and browser timings are never pooled."
+  []
+  #?(:clj  {:optimizations :jvm :instrumentation? true}
+     :cljs (let [debug? (boolean goog/DEBUG)]
+             {:optimizations    (if debug? :none :advanced)
+              :instrumentation? debug?})))
+
+;; ---------------------------------------------------------------------------
+;; The required-field ledger
+;; ---------------------------------------------------------------------------
+
+(defn- non-blank? [v] (and (string? v) (not (str/blank? v))))
+(defn- populated-map? [v] (and (map? v) (seq v)))
+
+(def required-fields
+  "Every provenance field a result record must name, as data.
+
+  A vector, not a `when-not` cascade, for three reasons: the omission
+  test enumerates it rather than restating it; the workload validator
+  reuses a SUBSET of it so a fixture is rejected at declaration rather
+  than after a ten-minute run; and a reader can see the whole obligation
+  in one screen and check it against D021."
+  [{:path     [:benchmark]
+    :names    "the workload id"
+    :valid?   keyword?
+    :expected "a keyword naming the workload, e.g. :B1/finite-template"}
+
+   {:path     [:revision]
+    :names    "the source revision"
+    :valid?   non-blank?
+    :expected "the revision the measured code was built from — set RF2_REVISION, or run inside a git checkout"}
+
+   {:path     [:fixture]
+    :names    "the fixture parameters"
+    :valid?   populated-map?
+    :expected "a non-empty map of the workload's parameters — sizes are fixture parameters, not language constants"}
+
+   {:path     [:build :optimizations]
+    :names    "the build mode"
+    :valid?   keyword?
+    :expected "the optimization level the measured code was compiled at, e.g. :advanced / :none / :jvm"}
+
+   {:path     [:build :instrumentation?]
+    :names    "the instrumentation mode"
+    :valid?   boolean?
+    :expected "true or false — whether dev instrumentation was compiled in; an instrumented build is not a production build"}
+
+   {:path     [:host :runtime]
+    :names    "the browser/runtime"
+    :valid?   non-blank?
+    :expected "the browser or runtime name and version the workload ran on"}
+
+   {:path     [:host :hardware-class]
+    :names    "the hardware class"
+    :valid?   keyword?
+    :expected "the detected or configured hardware class — never a literal naming one machine"}
+
+   {:path     [:sampling :warmup]
+    :names    "the warm-up policy"
+    :valid?   nat-int?
+    :expected "how many discarded iterations preceded the measured ones"}
+
+   {:path     [:sampling :samples]
+    :names    "the sample policy"
+    :valid?   pos-int?
+    :expected "how many measured iterations the distribution summarises"}
+
+   {:path     [:distribution]
+    :names    "the distribution"
+    :valid?   populated-map?
+    :expected "the sampled distributions this run observed — a median without its distribution is not release evidence"}
+
+   {:path     [:baseline :kind]
+    :names    "the baseline"
+    :valid?   #(contains? baselines %)
+    :expected (str "one of " (pr-str (vec (sort (keys baselines)))))}
+
+   {:path     [:baseline :reference]
+    :names    "the baseline reference"
+    :valid?   populated-map?
+    :expected "which arm, donor cut, or revision this result is measured against"}])
+
+(def all-paths
+  "The path of every entry in [[required-fields]], in ledger order."
+  (mapv :path required-fields))
+
+(defn defects
+  "Answer a vector of provenance defects in `record` — empty when it is
+  emittable.
+
+  A field is `:missing` when its path is absent and `:invalid` when the
+  value there cannot be what the field means. Both refuse the record;
+  the distinction is only there so the message can be useful.
+
+  The two-arity form checks a subset of [[all-paths]], which is how a
+  workload is validated at declaration time against the fields it is
+  responsible for."
+  ([record] (defects record all-paths))
+  ([record paths]
+   (let [wanted (set paths)]
+     (into []
+           (keep (fn [{:keys [path names valid? expected]}]
+                   (when (contains? wanted path)
+                     (let [v (get-in record path ::missing)]
+                       (cond
+                         (= ::missing v)
+                         {:defect :missing :path path :names names :expected expected}
+
+                         (not (valid? v))
+                         {:defect :invalid :path path :names names :expected expected :observed v})))))
+           required-fields))))
+
+(defn- defect-line
+  [{:keys [defect path names expected observed]}]
+  (str (pr-str path) " (" names ") is "
+       (if (= :missing defect) "missing" (str "invalid — " (pr-str observed)))
+       "; expected " expected))
+
+(defn defects-message
+  "The one-line human sentence a refused record throws with."
+  [ds]
+  (str "This benchmark result cannot be emitted: " (count ds)
+       (if (= 1 (count ds)) " provenance field is" " provenance fields are")
+       " missing or malformed — "
+       (str/join "; " (map defect-line ds))
+       ". A median without its distribution and environment is not release evidence (D021)."))
+
+(defn result
+  "Answer `record` when it names every provenance field D021 requires,
+  otherwise throw naming each field that does not hold.
+
+  This is the ONLY door that emits a result record. There is no lenient
+  variant and no `:strict?` flag, because a benchmark result that may be
+  emitted without its environment is a benchmark result that eventually
+  is."
+  [record]
+  (let [ds (defects record)]
+    (when (seq ds)
+      (throw (ex-info (defects-message ds)
+                      {:bench/defect :incomplete-provenance
+                       :defects      ds})))
+    record))

--- a/implementation/freehand/src/re_frame/freehand/bench/runner.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/runner.cljc
@@ -86,24 +86,29 @@
 
   Answers `{:exit-code n :summary [line …] :report <edn>}`. `-main` adds
   printing and process exit and nothing else, so the exit-code contract
-  is testable without a process."
-  [args]
-  (let [flags (set args)]
-    (cond
-      (or (contains? flags "--help") (contains? flags "-h"))
-      {:exit-code 0 :summary usage :report {:command :help}}
+  is testable without a process.
 
-      (contains? flags "--prove")
-      (let [proof (falsifiability/prove)]
-        {:exit-code (if (:proven? proof) 0 1)
-         :summary   (prove-summary proof)
-         :report    (assoc proof :command :prove)})
+  `opts` are [[re-frame.freehand.bench/run-workload]]'s provenance
+  overrides, for a caller that knows the artefact it built better than
+  the process can detect it. `-main` passes none."
+  ([args] (run-cli args nil))
+  ([args opts]
+   (let [flags (set args)]
+     (cond
+       (or (contains? flags "--help") (contains? flags "-h"))
+       {:exit-code 0 :summary usage :report {:command :help}}
 
-      :else
-      (let [outcome (bench/run)]
-        {:exit-code (:exit-code outcome)
-         :summary   (suite-summary outcome)
-         :report    (assoc outcome :command :suite)}))))
+       (contains? flags "--prove")
+       (let [proof (falsifiability/prove opts)]
+         {:exit-code (if (:proven? proof) 0 1)
+          :summary   (prove-summary proof)
+          :report    (assoc proof :command :prove)})
+
+       :else
+       (let [outcome (bench/run (vals (bench/registered)) opts)]
+         {:exit-code (:exit-code outcome)
+          :summary   (suite-summary outcome)
+          :report    (assoc outcome :command :suite)})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Process

--- a/implementation/freehand/src/re_frame/freehand/bench/runner.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/runner.cljc
@@ -1,0 +1,125 @@
+(ns re-frame.freehand.bench.runner
+  "The command line CI runs the B-spine from.
+
+      clojure -M:bench            # the standing evidence suite
+      clojure -M:bench --prove    # the two-way falsifiability proof
+      clojure -M:bench --help
+
+  ## Output
+
+  Everything goes to stdout, and everything on stdout is valid EDN: the
+  human summary is written as `;;` comment lines above the report map, so
+  the same bytes are both the thing a reviewer reads and the artefact a
+  release cites.
+
+      clojure -M:bench > out/freehand-bench.edn
+
+  ## Exit codes
+
+  0 and 1, and 1 means one thing only: a DETERMINISTIC property was
+  violated. A wall-clock or byte distribution cannot reach this number —
+  see [[re-frame.freehand.bench/run]] for why, and
+  [[re-frame.freehand.bench.falsifiability]] for the proof.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [re-frame.freehand.bench :as bench]
+            [re-frame.freehand.bench.falsifiability :as falsifiability]
+            #?(:clj [clojure.pprint :as pp] :cljs [cljs.pprint :as pp])))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(def usage
+  ["Freehand B-spine: the measurement harness (D021)."
+   ""
+   "  clojure -M:bench             run the standing evidence suite"
+   "  clojure -M:bench --prove     run the two-way falsifiability proof"
+   "  clojure -M:bench --help      this"
+   ""
+   "Stdout is valid EDN with the summary as leading `;;` comments."
+   "Exit 1 means a deterministic property was violated, and nothing else."])
+
+;; ---------------------------------------------------------------------------
+;; The two commands
+;; ---------------------------------------------------------------------------
+
+(defn- suite-summary
+  [{:keys [results gate-failures]}]
+  (concat
+    [(str "Freehand evidence suite: " (count results)
+          (if (= 1 (count results)) " workload" " workloads") " run.")]
+    (if (seq results)
+      (for [r results]
+        (str "  " (:benchmark r) ": " (count (:distribution r)) " published distribution(s), "
+             (count (:properties r)) " deterministic gate(s), on "
+             (get-in r [:host :runtime]) " / " (get-in r [:host :hardware-class]) "."))
+      ["  No workloads registered yet. B1-B5 each arrive with the slice that can run them."])
+    (if (seq gate-failures)
+      (cons "GATE FAILURES:" (map #(str "  " (:message %)) gate-failures))
+      ["All deterministic properties held. Distributions below are evidence: no pass/fail."])))
+
+(defn- round1
+  [x]
+  (when (number? x) (/ (double (Math/round (* (double x) 10.0))) 10.0)))
+
+(defn- prove-summary
+  [{:keys [arms move defects proven?]}]
+  (concat
+    ["Freehand B-spine falsifiability proof (D021, both directions)."
+     (str "  a gate that HOLDS      -> exit " (get-in arms [:honoured-gate :exit-code])
+          "   (expected 0)")
+     (str "  a gate VIOLATED        -> exit " (get-in arms [:violated-gate :exit-code])
+          "   (expected 1)")]
+    (map #(str "      " %) (get-in arms [:violated-gate :gate-failures]))
+    [(str "  timing baseline        -> exit " (get-in arms [:baseline-timing :exit-code])
+          "   (expected 0), p50 " (get-in arms [:baseline-timing :p50-ms]) "ms")
+     (str "  timing MOVED           -> exit " (get-in arms [:moved-timing :exit-code])
+          "   (expected 0), p50 " (get-in arms [:moved-timing :p50-ms]) "ms = "
+          (round1 move) "x the baseline")]
+    (if proven?
+      ["  PROVEN both ways: a violated deterministic property reds; a wildly moved"
+       "  wall-clock distribution does not."]
+      (cons "  NOT PROVEN:" (map #(str "    " %) defects)))))
+
+(defn run-cli
+  "The whole CLI, as a pure function of `args`.
+
+  Answers `{:exit-code n :summary [line …] :report <edn>}`. `-main` adds
+  printing and process exit and nothing else, so the exit-code contract
+  is testable without a process."
+  [args]
+  (let [flags (set args)]
+    (cond
+      (or (contains? flags "--help") (contains? flags "-h"))
+      {:exit-code 0 :summary usage :report {:command :help}}
+
+      (contains? flags "--prove")
+      (let [proof (falsifiability/prove)]
+        {:exit-code (if (:proven? proof) 0 1)
+         :summary   (prove-summary proof)
+         :report    (assoc proof :command :prove)})
+
+      :else
+      (let [outcome (bench/run)]
+        {:exit-code (:exit-code outcome)
+         :summary   (suite-summary outcome)
+         :report    (assoc outcome :command :suite)}))))
+
+;; ---------------------------------------------------------------------------
+;; Process
+;; ---------------------------------------------------------------------------
+
+(defn- exit!
+  [code]
+  #?(:clj  (System/exit code)
+     :cljs (js/process.exit code)))
+
+(defn -main
+  [& args]
+  (let [{:keys [exit-code summary report]} (run-cli args)]
+    (doseq [line summary]
+      (println (str ";; " line)))
+    (println ";;")
+    (pp/pprint report)
+    (flush)
+    (exit! exit-code)))

--- a/implementation/freehand/test/re_frame/freehand/bench/falsifiability_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/bench/falsifiability_cljs_test.cljc
@@ -16,6 +16,16 @@
             [re-frame.freehand.bench.falsifiability :as falsifiability]
             [re-frame.freehand.bench.runner :as runner]))
 
+(def ^:private provenance
+  "The revision a TEST supplies.
+
+  A ClojureScript test process is not a build pipeline: no environment
+  variable, no git, and nothing it could truthfully detect. That it
+  cannot emit a record without being told is criterion 1 working, and is
+  asserted directly in the provenance suite — so here the revision is
+  simply supplied and the subject stays the gate/evidence asymmetry."
+  {:revision "test-fixture-revision"})
+
 ;; ---------------------------------------------------------------------------
 ;; Criterion 2 — a deterministic property registered as a GATE reds
 ;; ---------------------------------------------------------------------------
@@ -24,7 +34,8 @@
   (testing "the deliberately violating fixture must fail, naming the
             property — a gate failure that cannot say what broke is a
             stack trace, not a release signal."
-    (let [{:keys [exit-code gate-failures results]} (bench/run [falsifiability/violated-gate])
+    (let [{:keys [exit-code gate-failures results]}
+          (bench/run [falsifiability/violated-gate] provenance)
           failure (first gate-failures)]
       (is (= 1 exit-code))
       (is (= 1 (count gate-failures)))
@@ -36,7 +47,7 @@
 (deftest a-property-that-holds-does-not-red
   (testing "non-vacuity for criterion 2: a harness that reds on
             everything would pass the test above and be worthless."
-    (let [{:keys [exit-code gate-failures]} (bench/run [falsifiability/honoured-gate])]
+    (let [{:keys [exit-code gate-failures]} (bench/run [falsifiability/honoured-gate] provenance)]
       (is (= 0 exit-code))
       (is (empty? gate-failures)))))
 
@@ -49,7 +60,7 @@
             moves by that multiple and the run still exits 0. D021 sets
             no numeric threshold on timing — an adverse trend is
             attributed and dispositioned, never failed automatically."
-    (let [{:keys [exit-code gate-failures results]} (bench/run [falsifiability/moved-timing])
+    (let [{:keys [exit-code gate-failures results]} (bench/run [falsifiability/moved-timing] provenance)
           record (first results)]
       (is (= 0 exit-code))
       (is (empty? gate-failures))
@@ -62,7 +73,7 @@
 (deftest the-moved-timing-really-moved
   (testing "criterion 3's non-vacuity. Without this the assertion above
             is satisfied by a timing that did not change."
-    (let [proof (falsifiability/prove)]
+    (let [proof (falsifiability/prove provenance)]
       (is (number? (:move proof)))
       (is (<= 10 (:move proof))
           (str "the moved arm's p50 was only " (:move proof)
@@ -74,7 +85,7 @@
 
 (deftest the-asymmetry-holds-in-both-directions
   (testing "D021's whole point, as one assertion."
-    (let [{:keys [arms proven? defects]} (falsifiability/prove)]
+    (let [{:keys [arms proven? defects]} (falsifiability/prove provenance)]
       (is (empty? defects))
       (is proven?)
       (is (= 0 (get-in arms [:honoured-gate :exit-code])))
@@ -90,22 +101,22 @@
   (testing "`-main` prints and exits; everything else about the CLI is
             this pure function, so the exit-code contract is testable
             without a process."
-    (let [proof (runner/run-cli ["--prove"])]
+    (let [proof (runner/run-cli ["--prove"] provenance)]
       (is (= 0 (:exit-code proof)))
       (is (true? (get-in proof [:report :proven?])))
       (is (some #(re-find #"PROVEN both ways" %) (:summary proof))))
-    (let [suite (runner/run-cli [])]
+    (let [suite (runner/run-cli [] provenance)]
       (is (= 0 (:exit-code suite))
           "an empty evidence suite is honest, not red: B1-B5 arrive with their slices")
       (is (= :suite (get-in suite [:report :command]))))
-    (let [help (runner/run-cli ["--help"])]
+    (let [help (runner/run-cli ["--help"] provenance)]
       (is (= 0 (:exit-code help)))
       (is (some #(re-find #"deterministic property was violated" %) (:summary help))))))
 
 (deftest the-summary-rides-as-edn-comments
   (testing "stdout is both the thing a reviewer reads and the artefact a
             release cites, so the summary must never break the EDN."
-    (let [{:keys [summary]} (runner/run-cli ["--prove"])]
+    (let [{:keys [summary]} (runner/run-cli ["--prove"] provenance)]
       (is (seq summary))
       (is (every? string? summary))
       (is (not-any? #(re-find #"\r?\n" %) summary)

--- a/implementation/freehand/test/re_frame/freehand/bench/falsifiability_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/bench/falsifiability_cljs_test.cljc
@@ -1,0 +1,121 @@
+(ns re-frame.freehand.bench.falsifiability-cljs-test
+  "The B-spine's own gate: D021's asymmetry, proven in both directions.
+
+  This is the deterministic property the harness itself is judged on, and
+  it is the stable subset that runs in PR smoke — it needs no browser, no
+  pinned worker and no calibration, because it asserts about EXIT CODES
+  rather than about milliseconds.
+
+  Criterion 3 is the one that gets skipped, so it is asserted twice here:
+  once that a wildly moved wall-clock distribution still exits 0, and
+  once that the distribution really did move. A harness that fails on a
+  slow run has silently become a threshold, which D021 forbids; a proof
+  that an unchanged timing did not red the build proves nothing."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand.bench :as bench]
+            [re-frame.freehand.bench.falsifiability :as falsifiability]
+            [re-frame.freehand.bench.runner :as runner]))
+
+;; ---------------------------------------------------------------------------
+;; Criterion 2 — a deterministic property registered as a GATE reds
+;; ---------------------------------------------------------------------------
+
+(deftest a-violated-deterministic-property-reds-and-names-itself
+  (testing "the deliberately violating fixture must fail, naming the
+            property — a gate failure that cannot say what broke is a
+            stack trace, not a release signal."
+    (let [{:keys [exit-code gate-failures results]} (bench/run [falsifiability/violated-gate])
+          failure (first gate-failures)]
+      (is (= 1 exit-code))
+      (is (= 1 (count gate-failures)))
+      (is (= :falsifiability/node-count (:measurement failure)))
+      (is (re-find #"the exact node count" (:message failure)))
+      (is (re-find #"GATE FAILED" (:message failure)))
+      (is (false? (get-in (first results) [:properties :falsifiability/node-count :pass?]))))))
+
+(deftest a-property-that-holds-does-not-red
+  (testing "non-vacuity for criterion 2: a harness that reds on
+            everything would pass the test above and be worthless."
+    (let [{:keys [exit-code gate-failures]} (bench/run [falsifiability/honoured-gate])]
+      (is (= 0 exit-code))
+      (is (empty? gate-failures)))))
+
+;; ---------------------------------------------------------------------------
+;; Criterion 3 — a timing registered as EVIDENCE never reds, however it moves
+;; ---------------------------------------------------------------------------
+
+(deftest a-wildly-moved-timing-still-exits-zero
+  (testing "the same work done 50x over: the wall-clock distribution
+            moves by that multiple and the run still exits 0. D021 sets
+            no numeric threshold on timing — an adverse trend is
+            attributed and dispositioned, never failed automatically."
+    (let [{:keys [exit-code gate-failures results]} (bench/run [falsifiability/moved-timing])
+          record (first results)]
+      (is (= 0 exit-code))
+      (is (empty? gate-failures))
+      (is (pos? (get-in record [:distribution :falsifiability/render-ms :p50]))
+          "the moved arm published a distribution")
+      (is (true? (get-in record [:properties :falsifiability/node-count :pass?]))
+          "the deterministic property is unchanged by the timing knob — which is
+           what makes this arm a test of the timing and not of the property"))))
+
+(deftest the-moved-timing-really-moved
+  (testing "criterion 3's non-vacuity. Without this the assertion above
+            is satisfied by a timing that did not change."
+    (let [proof (falsifiability/prove)]
+      (is (number? (:move proof)))
+      (is (<= 10 (:move proof))
+          (str "the moved arm's p50 was only " (:move proof)
+               "x the baseline's — nothing was proven about a wildly changed timing")))))
+
+;; ---------------------------------------------------------------------------
+;; Both directions at once — the harness's own gate
+;; ---------------------------------------------------------------------------
+
+(deftest the-asymmetry-holds-in-both-directions
+  (testing "D021's whole point, as one assertion."
+    (let [{:keys [arms proven? defects]} (falsifiability/prove)]
+      (is (empty? defects))
+      (is proven?)
+      (is (= 0 (get-in arms [:honoured-gate :exit-code])))
+      (is (= 1 (get-in arms [:violated-gate :exit-code])))
+      (is (= 0 (get-in arms [:baseline-timing :exit-code])))
+      (is (= 0 (get-in arms [:moved-timing :exit-code]))))))
+
+;; ---------------------------------------------------------------------------
+;; The CLI carries the same contract to the process boundary
+;; ---------------------------------------------------------------------------
+
+(deftest the-cli-exit-code-is-the-run-outcome
+  (testing "`-main` prints and exits; everything else about the CLI is
+            this pure function, so the exit-code contract is testable
+            without a process."
+    (let [proof (runner/run-cli ["--prove"])]
+      (is (= 0 (:exit-code proof)))
+      (is (true? (get-in proof [:report :proven?])))
+      (is (some #(re-find #"PROVEN both ways" %) (:summary proof))))
+    (let [suite (runner/run-cli [])]
+      (is (= 0 (:exit-code suite))
+          "an empty evidence suite is honest, not red: B1-B5 arrive with their slices")
+      (is (= :suite (get-in suite [:report :command]))))
+    (let [help (runner/run-cli ["--help"])]
+      (is (= 0 (:exit-code help)))
+      (is (some #(re-find #"deterministic property was violated" %) (:summary help))))))
+
+(deftest the-summary-rides-as-edn-comments
+  (testing "stdout is both the thing a reviewer reads and the artefact a
+            release cites, so the summary must never break the EDN."
+    (let [{:keys [summary]} (runner/run-cli ["--prove"])]
+      (is (seq summary))
+      (is (every? string? summary))
+      (is (not-any? #(re-find #"\r?\n" %) summary)
+          "a multi-line summary line would escape its `;;` prefix"))))
+
+;; ---------------------------------------------------------------------------
+;; The proof arms are not evidence about Freehand
+;; ---------------------------------------------------------------------------
+
+(deftest the-proof-arms-stay-out-of-the-standing-suite
+  (testing "one of them fails on purpose, and none of them measures
+            anything a release should cite."
+    (is (empty? (bench/registered)))))

--- a/implementation/freehand/test/re_frame/freehand/bench/measure_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/bench/measure_cljs_test.cljc
@@ -1,0 +1,169 @@
+(ns re-frame.freehand.bench.measure-cljs-test
+  "D021's split, checked at the door that constructs a measurement.
+
+  The falsifiability suite proves the split holds END TO END — a violated
+  property reds, a moved timing does not. These tests prove the narrower
+  thing that makes that possible: a fixture author cannot file a timing
+  as a gate, and cannot let a deterministic property degrade to
+  advisory, because the construction refuses both."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand.bench.measure :as m]))
+
+(defn- defect
+  "The `:bench/defect` a rejected spec throws with, or nil when the spec
+  was accepted."
+  [spec]
+  (try
+    (m/measurement spec)
+    nil
+    (catch #?(:clj Exception :cljs :default) e
+      (or (:bench/defect (ex-data e)) :threw-without-a-defect))))
+
+(defn- message
+  [spec]
+  (try (m/measurement spec) nil
+       (catch #?(:clj Exception :cljs :default) e (ex-message e))))
+
+(def ^:private a-gate
+  {:id :test/omitted-cells :doc "the exact omitted-ViewCell count" :observable :count :expect 26})
+
+(def ^:private an-evidence
+  {:id :test/self-time-ms :doc "substrate self time" :observable :duration-ms})
+
+;; ---------------------------------------------------------------------------
+;; The vocabulary IS the ruling
+;; ---------------------------------------------------------------------------
+
+(deftest enforcement-is-a-total-function-of-the-observable
+  (testing "D021: deterministic properties gate; wall-clock and byte
+            distributions are evidence. Two classes, two enforcements,
+            and no third answer for an author to reach for."
+    (is (= {:count :gate :flag :gate :value :gate
+            :duration-ms :evidence :bytes :evidence}
+           (into {} (map (juxt key #(m/enforcement-for (key %)))) m/observables)))
+    (is (nil? (m/enforcement-for :vibes)))))
+
+(deftest an-unknown-observable-is-refused
+  (testing "the observable decides gate-versus-evidence, so it cannot be
+            an open vocabulary — an unrecognised one has no enforcement
+            to derive."
+    (is (= :measurement-observable (defect (assoc a-gate :observable :feels-fast))))
+    (is (= :measurement-id (defect (assoc a-gate :id :unqualified))))
+    (is (= :measurement-doc (defect (dissoc a-gate :doc))))))
+
+;; ---------------------------------------------------------------------------
+;; Direction 1 — a timing measurement cannot be registered as a gate
+;; ---------------------------------------------------------------------------
+
+(deftest a-timing-cannot-be-registered-as-a-gate
+  (testing "restating a duration or a byte count as a gate is refused,
+            naming both what was stated and what the observable compels."
+    (doseq [observable [:duration-ms :bytes]]
+      (let [spec {:id :test/thing :doc "a magnitude" :observable observable :enforcement :gate}]
+        (is (= :enforcement-restated (defect spec)))
+        (is (re-find #"published evidence" (message spec)))))))
+
+(deftest a-threshold-on-evidence-is-refused
+  (testing "D021 sets no numeric threshold on wall-clock or byte
+            distributions. Every pass/fail-shaped key is refused on
+            evidence — that is the folklore-threshold non-goal, made
+            mechanical."
+    (doseq [k (sort m/pass-fail-keys)]
+      (is (= :threshold-on-evidence (defect (assoc an-evidence k 12)))
+          (str "an evidence measurement carrying " k " was accepted")))
+    (is (re-find #"attributed and dispositioned by a human"
+                 (message (assoc an-evidence :max-ms 12))))))
+
+(deftest evidence-has-no-route-to-a-verdict
+  (testing "even holding a normalised evidence measurement, there is no
+            call that turns its observation into a pass/fail."
+    (let [ev (m/measurement an-evidence)]
+      (is (m/evidence? ev))
+      (is (not (m/gate? ev)))
+      (is (thrown? #?(:clj Exception :cljs js/Error) (m/gate-failure ev 999999.0)))
+      (is (thrown? #?(:clj Exception :cljs js/Error) (m/instability-failure ev [1.0 2.0]))))))
+
+;; ---------------------------------------------------------------------------
+;; Direction 2 — a deterministic property cannot degrade to advisory
+;; ---------------------------------------------------------------------------
+
+(deftest a-property-cannot-be-registered-as-evidence
+  (testing "the direction people forget: a correctness regression hiding
+            behind benchmark noise because someone relabelled its gate."
+    (doseq [observable [:count :flag :value]]
+      (let [spec {:id :test/thing :doc "a property" :observable observable
+                  :expect 1 :enforcement :evidence}]
+        (is (= :enforcement-restated (defect spec)))
+        (is (re-find #"hard release gates" (message spec)))))))
+
+(deftest a-gate-without-an-expectation-is-refused
+  (testing "a gate with nothing to violate is advisory wearing a gate's
+            name."
+    (is (= :gate-without-expectation (defect (dissoc a-gate :expect))))
+    (is (re-find #"advisory wearing" (message (dissoc a-gate :expect))))))
+
+(deftest a-gate-names-itself-when-it-fails
+  (testing "criterion 2's requirement in the small: the failure carries
+            the measurement id, its one-line claim, the expectation and
+            the observation."
+    (let [g (m/measurement a-gate)]
+      (is (nil? (m/gate-failure g 26)))
+      (let [f (m/gate-failure g 25)]
+        (is (= :test/omitted-cells (:measurement f)))
+        (is (= 26 (:expected f)))
+        (is (= 25 (:observed f)))
+        (is (re-find #"the exact omitted-ViewCell count" (:message f)))
+        (is (re-find #":test/omitted-cells" (:message f)))))))
+
+(deftest a-predicate-expectation-works-too
+  (testing "an exact value is the common case; a predicate is the
+            escape hatch, and reports as one."
+    (let [g (m/measurement (assoc a-gate :expect even?))]
+      (is (nil? (m/gate-failure g 26)))
+      (is (some? (m/gate-failure g 25)))
+      (is (re-find #"the declared predicate" (:message (m/gate-failure g 25)))))))
+
+(deftest a-property-that-is-not-deterministic-cannot-gate
+  (testing "either the workload has an undeclared input, or the
+            observable was misfiled and is really a distribution."
+    (let [g (m/measurement a-gate)]
+      (is (nil? (m/instability-failure g [26 26 26])))
+      (let [f (m/instability-failure g [26 26 25])]
+        (is (= :test/omitted-cells (:measurement f)))
+        (is (= [26 25] (:observed f)))
+        (is (re-find #"distinct values" (:message f)))))))
+
+;; ---------------------------------------------------------------------------
+;; Normalisation and summary
+;; ---------------------------------------------------------------------------
+
+(deftest normalisation-is-idempotent
+  (testing "a workload is normalised at registration and again at run
+            time; measuring the harness twice would be a fine way to
+            publish a wrong number."
+    (let [once (m/measurement a-gate)]
+      (is (= once (m/measurement once)))
+      (is (= :gate (:enforcement once))))))
+
+(deftest a-distribution-is-summarised-never-judged
+  (testing "D021: a median without its distribution is not release
+            evidence."
+    (let [s (m/summarise [1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0])]
+      (is (= 10 (:n s)))
+      (is (= 1.0 (:min s)))
+      (is (= 5.0 (:p50 s)))
+      (is (= 10.0 (:p95 s)))
+      (is (= 10.0 (:max s)))
+      (is (= 5.5 (:mean s)))
+      (is (= #{:n :min :p50 :p95 :p99 :max :mean} (set (keys s)))
+          "a summary carries no verdict, no budget and no comparator"))
+    (is (thrown? #?(:clj Exception :cljs js/Error) (m/summarise [])))))
+
+(deftest the-clock-resolves-better-than-a-millisecond
+  (testing "a harness whose clock could not see a view render would
+            publish a distribution of rounding error."
+    (let [t0 (m/now-ms)
+          _  (dotimes [_ 1000] (reduce + (range 100)))
+          t1 (m/now-ms)]
+      (is (number? t0))
+      (is (>= t1 t0)))))

--- a/implementation/freehand/test/re_frame/freehand/bench/provenance_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/bench/provenance_cljs_test.cljc
@@ -1,0 +1,144 @@
+(ns re-frame.freehand.bench.provenance-cljs-test
+  "D021 §Release evidence artifact — a result record cannot be emitted
+  without its provenance.
+
+  The headline test omits each required field IN TURN, enumerating the
+  ledger rather than restating it: a field added to
+  `provenance/required-fields` is covered the moment it is added, and a
+  field silently dropped from the ledger takes its own coverage with it,
+  which is visible in the count assertion below."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand.bench.provenance :as prov]))
+
+(defn- complete
+  "A result record that names everything D021 requires."
+  []
+  {:benchmark    :test/complete
+   :revision     "0123456789abcdef0123456789abcdef01234567"
+   :fixture      {:rows 200}
+   :build        {:optimizations :advanced :instrumentation? false}
+   :host         {:runtime "Node v24.0.0" :hardware-class :release-worker}
+   :sampling     {:warmup 5 :samples 40}
+   :baseline     {:kind :interpreted-vs-compiled :reference {:arm :interpreted}}
+   :distribution {:test/self-time-ms {:n 40 :p50 1.0 :p95 2.0}}
+   :status       :evidence})
+
+(defn- dissoc-path
+  [m path]
+  (if (= 1 (count path))
+    (dissoc m (first path))
+    (update-in m (butlast path) dissoc (last path))))
+
+(defn- rejected?
+  [record]
+  (try
+    (prov/result record)
+    false
+    (catch #?(:clj Exception :cljs :default) e
+      (:defects (ex-data e)))))
+
+;; ---------------------------------------------------------------------------
+;; Criterion 1 — omit each provenance field in turn
+;; ---------------------------------------------------------------------------
+
+(deftest a-complete-record-is-emitted
+  (testing "the fixture below is only meaningful if the COMPLETE record
+            passes — otherwise every omission test is vacuous."
+    (is (= (complete) (prov/result (complete))))
+    (is (empty? (prov/defects (complete))))))
+
+(deftest every-required-field-is-load-bearing
+  (testing "D021: every stored result names the source revision, build
+            mode, browser/runtime, hardware class, warm-up/sample policy,
+            fixture parameters, and whether dev instrumentation was
+            enabled. Omit each in turn; each must be refused."
+    (doseq [{:keys [path names]} prov/required-fields]
+      (let [record  (dissoc-path (complete) path)
+            defects (rejected? record)]
+        (is defects
+            (str "a record missing " (pr-str path) " (" names ") was emitted anyway"))
+        (when defects
+          (is (= [{:defect :missing :path path}]
+                 (mapv #(select-keys % [:defect :path]) defects))
+              (str "the refusal for " (pr-str path) " must name that field and only that field")))))))
+
+(deftest the-ledger-covers-the-whole-of-d021s-obligation
+  (testing "the eight things D021 names — revision, fixture parameters,
+            build/instrumentation mode, browser/runtime, hardware class,
+            warm-up/sample policy, distribution, baseline — plus the
+            workload id, each addressed by path."
+    (is (= [[:benchmark]
+            [:revision]
+            [:fixture]
+            [:build :optimizations]
+            [:build :instrumentation?]
+            [:host :runtime]
+            [:host :hardware-class]
+            [:sampling :warmup]
+            [:sampling :samples]
+            [:distribution]
+            [:baseline :kind]
+            [:baseline :reference]]
+           prov/all-paths))))
+
+(deftest the-refusal-message-names-every-field-that-failed
+  (testing "a refusal a reader cannot act on is a stack trace. The
+            message names each field, what was expected, and why."
+    (let [record  (-> (complete) (dissoc :revision) (update :host dissoc :hardware-class))
+          defects (rejected? record)
+          msg     (try (prov/result record)
+                       (catch #?(:clj Exception :cljs :default) e (ex-message e)))]
+      (is (= 2 (count defects)))
+      (is (re-find #"\[:revision\]" msg))
+      (is (re-find #"\[:host :hardware-class\]" msg))
+      (is (re-find #"not release evidence" msg)))))
+
+;; ---------------------------------------------------------------------------
+;; A present-but-wrong field is refused too
+;; ---------------------------------------------------------------------------
+
+(deftest a-present-but-meaningless-field-is-refused
+  (testing "`missing` is about the OBLIGATION, not the key. A blank
+            revision, an empty fixture, a nil instrumentation flag and an
+            unnamed baseline each name nothing."
+    (doseq [[path value] [[[:revision] "   "]
+                          [[:fixture] {}]
+                          [[:build :instrumentation?] nil]
+                          [[:host :hardware-class] "the-machine-under-my-desk"]
+                          [[:sampling :samples] 0]
+                          [[:distribution] {}]
+                          [[:baseline :kind] :faster-than-last-time]
+                          [[:baseline :reference] {}]]]
+      (let [defects (rejected? (assoc-in (complete) path value))]
+        (is defects (str (pr-str path) " = " (pr-str value) " was accepted"))
+        (when defects
+          (is (= [path] (mapv :path defects))))))))
+
+(deftest the-four-named-baselines-are-the-whole-vocabulary
+  (testing "D021 §Baselines. A result with no comparator is a number."
+    (is (= [:absorbed-vs-donor
+            :before-vs-after
+            :interpreted-vs-compiled
+            :self-vs-end-to-end]
+           (vec (sort (keys prov/baselines)))))))
+
+;; ---------------------------------------------------------------------------
+;; Detection — never a literal
+;; ---------------------------------------------------------------------------
+
+(deftest the-environment-is-detected-not-written-down
+  (testing "hardware class is configured or detected. A benchmark record
+            that hardcodes the machine it was written on is a record
+            about nothing."
+    (let [host (prov/detect-host)]
+      (is (keyword? (:hardware-class host)))
+      (is (string? (:runtime host)))
+      (is (seq (:runtime host))))
+    (is (keyword? (prov/detect-hardware-class)))
+    (when-not (prov/env "RF2_HARDWARE_CLASS")
+      (is (contains? #{:developer-workstation :shared-ci-runner}
+                     (prov/detect-hardware-class))
+          "unconfigured, the class is detected from the environment — never a machine name"))
+    (let [build (prov/detect-build)]
+      (is (keyword? (:optimizations build)))
+      (is (boolean? (:instrumentation? build))))))

--- a/implementation/freehand/test/re_frame/freehand/bench_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/bench_cljs_test.cljc
@@ -1,0 +1,134 @@
+(ns re-frame.freehand.bench-cljs-test
+  "The harness: what a workload must declare, what a run emits, and where
+  an exit code is allowed to come from."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand.bench :as bench]
+            [re-frame.freehand.bench.measure :as m]))
+
+(defn- a-workload
+  [overrides]
+  (merge
+    {:id           :test/tiny
+     :doc          "a workload that observes one count and one duration"
+     :fixture      {:rows 3}
+     :baseline     {:kind :before-vs-after :reference {:revision "deadbeef"}}
+     :sampling     {:warmup 1 :samples 3}
+     :measurements [{:id :test/rows :doc "the row count" :observable :count :expect 3}
+                    {:id :test/self-ms :doc "self time" :observable :duration-ms}]
+     :run          (fn [{:keys [rows]}]
+                     (let [t0 (m/now-ms)]
+                       {:test/rows rows
+                        :test/self-ms (- (m/now-ms) t0)}))}
+    overrides))
+
+(defn- defect
+  [spec]
+  (try (bench/workload spec) nil
+       (catch #?(:clj Exception :cljs :default) e
+         (or (:bench/defect (ex-data e)) :threw-without-a-defect))))
+
+;; ---------------------------------------------------------------------------
+;; Declaration
+;; ---------------------------------------------------------------------------
+
+(deftest a-workload-is-refused-before-it-burns-a-sampling-run
+  (testing "the provenance a WORKLOAD owns is checked at declaration, not
+            after ten minutes of sampling. The rest is detected at run
+            time and checked when the record is emitted."
+    (is (nil? (defect (a-workload {}))))
+    (is (= :workload-id (defect (a-workload {:id "tiny"}))))
+    (is (= :workload-doc (defect (dissoc (a-workload {}) :doc))))
+    (is (= :workload-run (defect (dissoc (a-workload {}) :run))))
+    (is (= :workload-measurements (defect (assoc (a-workload {}) :measurements []))))
+    (doseq [omitted [:fixture :sampling :baseline]]
+      (is (= :incomplete-workload (defect (dissoc (a-workload {}) omitted)))
+          (str "a workload declaring no " omitted " was accepted")))
+    (is (= :incomplete-workload
+           (defect (assoc (a-workload {}) :baseline {:kind :vibes :reference {:x 1}})))
+        "the baseline vocabulary is the four D021 names")))
+
+(deftest a-duplicate-measurement-id-is-refused
+  (testing "one id names one observation, or a distribution silently
+            summarises two different things."
+    (is (= :duplicate-measurement-id
+           (defect (assoc (a-workload {}) :measurements
+                          [{:id :test/rows :doc "a" :observable :count :expect 3}
+                           {:id :test/rows :doc "b" :observable :count :expect 3}]))))))
+
+(deftest every-workload-publishes-the-harnesss-own-reading
+  (testing "the outer bound the workload's self time sits inside — which
+            is why every result record has a distribution to publish."
+    (let [norm (bench/workload (a-workload {}))]
+      (is (contains? (set (map :id (:measurements norm))) :bench/iteration-ms))
+      (is (m/evidence? bench/iteration-ms)))
+    (testing "and normalisation is idempotent, so registering then
+              running does not add it twice"
+      (let [once (bench/workload (a-workload {}))]
+        (is (= (:measurements once) (:measurements (bench/workload once))))))))
+
+;; ---------------------------------------------------------------------------
+;; The emitted record
+;; ---------------------------------------------------------------------------
+
+(deftest a-run-emits-a-validated-result-record
+  (testing "D021 §Release evidence artifact: a compact EDN result naming
+            its revision, fixture, build, host, sampling policy, baseline
+            and distribution."
+    (let [record (bench/run-workload (a-workload {})
+                                     {:revision "cafebabe"
+                                      :build {:optimizations :advanced :instrumentation? false}
+                                      :host  {:runtime "a pinned worker" :hardware-class :release-worker}})]
+      (is (= :test/tiny (:benchmark record)))
+      (is (= "cafebabe" (:revision record)))
+      (is (= {:rows 3} (:fixture record)))
+      (is (= {:kind :before-vs-after :reference {:revision "deadbeef"}} (:baseline record)))
+      (is (= {:warmup 1 :samples 3} (:sampling record)))
+      (is (= :evidence (:status record)))
+      (testing "the distributions are published, and carry no verdict"
+        (is (= #{:test/self-ms :bench/iteration-ms} (set (keys (:distribution record)))))
+        (doseq [[_ d] (:distribution record)]
+          (is (= 3 (:n d)))
+          (is (not (contains? d :pass?)))))
+      (testing "the deterministic properties carry the verdicts"
+        (is (= {:doc "the row count" :expected 3 :observed 3 :pass? true}
+               (get-in record [:properties :test/rows])))
+        (is (empty? (:gate-failures record)))))))
+
+(deftest a-declared-measurement-must-be-observed-every-iteration
+  (testing "otherwise the distribution is over a different thing each
+            time it is sampled."
+    (is (thrown? #?(:clj Exception :cljs js/Error)
+                 (bench/run-workload (a-workload {:run (fn [_] {:test/rows 3})}))))))
+
+;; ---------------------------------------------------------------------------
+;; Where an exit code comes from
+;; ---------------------------------------------------------------------------
+
+(deftest the-exit-code-has-exactly-one-source
+  (testing "a run over a workload whose only measurements are
+            distributions cannot produce a non-zero exit code, because
+            there is no gate to violate."
+    (let [evidence-only (a-workload {:id :test/evidence-only
+                                     :measurements [{:id :test/self-ms
+                                                     :doc "self time"
+                                                     :observable :duration-ms}]
+                                     :run (fn [_] {:test/self-ms 999999.0})})
+          {:keys [exit-code gate-failures results]} (bench/run [evidence-only])]
+      (is (= 0 exit-code))
+      (is (empty? gate-failures))
+      (is (empty? (:properties (first results))))
+      (is (= 999999.0 (get-in (first results) [:distribution :test/self-ms :p50]))))))
+
+(deftest a-run-over-several-workloads-concatenates-their-verdicts
+  (testing "one red workload reds the run; the others still publish."
+    (let [red (a-workload {:id :test/red
+                           :measurements [{:id :test/rows :doc "the row count"
+                                           :observable :count :expect 99}
+                                          {:id :test/self-ms :doc "self time"
+                                           :observable :duration-ms}]})
+          {:keys [exit-code gate-failures results]} (bench/run [(a-workload {}) red])]
+      (is (= 1 exit-code))
+      (is (= 1 (count gate-failures)))
+      (is (= :test/rows (:measurement (first gate-failures))))
+      (is (= 2 (count results)))
+      (is (every? #(seq (:distribution %)) results)))))

--- a/implementation/freehand/test/re_frame/freehand/bench_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/bench_cljs_test.cljc
@@ -21,6 +21,13 @@
                         :test/self-ms (- (m/now-ms) t0)}))}
     overrides))
 
+(def ^:private provenance
+  "The revision a TEST supplies. A ClojureScript test process is not a
+  build pipeline: no environment variable, no git, and nothing it could
+  truthfully detect. Being unable to emit a record without one is
+  criterion 1 working, and is asserted in the provenance suite."
+  {:revision "test-fixture-revision"})
+
 (defn- defect
   [spec]
   (try (bench/workload spec) nil
@@ -98,7 +105,7 @@
   (testing "otherwise the distribution is over a different thing each
             time it is sampled."
     (is (thrown? #?(:clj Exception :cljs js/Error)
-                 (bench/run-workload (a-workload {:run (fn [_] {:test/rows 3})}))))))
+                 (bench/run-workload (a-workload {:run (fn [_] {:test/rows 3})}) provenance)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Where an exit code comes from
@@ -113,7 +120,7 @@
                                                      :doc "self time"
                                                      :observable :duration-ms}]
                                      :run (fn [_] {:test/self-ms 999999.0})})
-          {:keys [exit-code gate-failures results]} (bench/run [evidence-only])]
+          {:keys [exit-code gate-failures results]} (bench/run [evidence-only] provenance)]
       (is (= 0 exit-code))
       (is (empty? gate-failures))
       (is (empty? (:properties (first results))))
@@ -126,7 +133,7 @@
                                            :observable :count :expect 99}
                                           {:id :test/self-ms :doc "self time"
                                            :observable :duration-ms}]})
-          {:keys [exit-code gate-failures results]} (bench/run [(a-workload {}) red])]
+          {:keys [exit-code gate-failures results]} (bench/run [(a-workload {}) red] provenance)]
       (is (= 1 exit-code))
       (is (= 1 (count gate-failures)))
       (is (= :test/rows (:measurement (first gate-failures))))


### PR DESCRIPTION
Implements rf2-drpa3.47 — the B-spine, the measurement scaffolding B1–B5 hang off.

D021 rules that Freehand's deterministic properties are release gates and that its wall-clock and byte distributions are required published evidence, never fixed thresholds. That ruling is one sentence long and erodes in one line of code. This lands it as a mechanism instead of a convention.

## The shape

Four namespaces under `implementation/freehand/src/re_frame/freehand/`, plus a `:bench` alias:

- **`bench/measure.cljc`** — the split itself. A measurement's enforcement is a *total function of what it observes*: `:count` / `:flag` / `:value` are distribution-free properties and enforce as `:gate`; `:duration-ms` / `:bytes` are distributions and enforce as `:evidence`. A fixture author picks the observable — the thing they are actually looking at — and there is no third answer. A spec may restate its enforcement, and restating it wrongly is refused at construction, naming both the value stated and the value the observable compels. Evidence carrying any pass/fail-shaped key (`:expect`, `:budget`, `:max-ms`, …) is refused; a gate *without* an expectation is refused too, because a gate that cannot fail is advisory wearing a gate's name.
- **`bench/provenance.cljc`** — the result record and its twelve required paths, as data. Revision, host and build are detected or configured, never written down: `RF2_REVISION` → `GITHUB_SHA` → a compile-time `build-revision` goog-define on CLJS / `git rev-parse HEAD` on the JVM. Hardware class is `RF2_HARDWARE_CLASS`, else detected. There is one door that emits a record and no lenient variant of it.
- **`bench.cljc`** — the harness. Workloads declare their fixture parameters, one of the four named baselines, a warm-up/sample policy and their measurements; `:run` owns its own measurement boundary, because "substrate self time versus end-to-end host time" is one of D021's baselines and a harness that imposed one boundary would have picked the answer. The harness adds its own `:bench/iteration-ms` as the outer bound, which is also why every record has a distribution to publish. A deterministic property that answers two different values across the sample set fails as a gate — a property that is not deterministic cannot gate anything.
- **`bench/falsifiability.cljc`** + **`bench/runner.cljc`** — the harness's own gate and the CLI. Stdout is valid EDN with the human summary riding as `;;` comments, so `clojure -M:bench > out/freehand-bench.edn` produces one artefact that is both the thing a reviewer reads and the thing a release cites.

`run`'s exit code has exactly one source: gate verdicts over property-class measurements. `measure/gate-failure` refuses any measurement that is not a gate, so a wall-clock or byte distribution has no route to a non-zero exit — that is structural, not merely tested.

## CI shape

**PR smoke** is the deterministic subset and needs no new job: the falsifiability proof ships as ordinary tests in `implementation/freehand/test`, which the *already-required* `JVM freehand (clojure -M:test)` and `cljs` node-test jobs both run. A standalone PR workflow would repeat the mistake `freehand-artefact.yml` was deleted for — `needs:` cannot span workflow files, so such a job can only ever be advisory.

**Scheduled/release** is `.github/workflows/freehand-bench.yml` — cron + `workflow_dispatch`, `runs-on: ubuntu-24.04` (pinned deliberately; a floating image would silently re-baseline the evidence under the same name), `RF2_HARDWARE_CLASS: release-worker`, EDN uploaded as a 90-day artefact. It gates nothing, because nothing it publishes is allowed to gate. Being cron-only it also picks up the post-merge workflow-sanity canary for free.

The standing evidence suite is empty today and exits 0 saying so: B1–B5 are separate slices and each registers its workload when the implementation that can run it lands.

## Non-goals honoured

No threshold, no compilation quota, no folklore number, no requirement that compiled mode win any workload, and no B1–B5 implementation. The one numeric constant in the diff (`minimum-move`, 10×) is a threshold on the *proof* — it exists to stop criterion 3 being a tautology — and is set far below the 20×–50× the fixture actually produces.

Donor disposition: the donor's `implementation/ui/bench` fixture is **not** moved. It is a relative-ratio *gate* ("p50/p95 within 10% per component"), which is precisely the shape D021 forbids for Freehand; moving it would import the policy along with the code. The G-1 lane stays where it is, owned by the donor, and B1 will declare its own fixture.

## Quality gates

```
$ cd implementation/freehand && clojure -M:test
Ran 338 tests containing 1896 assertions.
0 failures, 0 errors.

$ npm run test:freehand
[:node-test-freehand] Build completed. (213 files, 4 compiled, 0 warnings, 8.34s)
Ran 241 tests containing 1448 assertions.
0 failures, 0 errors.

$ npm run test:script-policy      -> exit 0
$ npm run test:script-helpers     -> exit 0
$ sh scripts/check-no-hardcoded-paths.sh
Portability gate OK: no hardcoded personal/home paths in tracked files.
```

`mkdocs build --strict` not run: no file under `docs/` is touched by this branch.

### Acceptance 1 — a result record cannot be emitted with a missing provenance field

Each of the twelve required paths omitted in turn from an otherwise complete record:

```
complete record emits: true

[:benchmark]                 omitted -> REFUSED: the workload id
[:revision]                  omitted -> REFUSED: the source revision
[:fixture]                   omitted -> REFUSED: the fixture parameters
[:build :optimizations]      omitted -> REFUSED: the build mode
[:build :instrumentation?]   omitted -> REFUSED: the instrumentation mode
[:host :runtime]             omitted -> REFUSED: the browser/runtime
[:host :hardware-class]      omitted -> REFUSED: the hardware class
[:sampling :warmup]          omitted -> REFUSED: the warm-up policy
[:sampling :samples]         omitted -> REFUSED: the sample policy
[:distribution]              omitted -> REFUSED: the distribution
[:baseline :kind]            omitted -> REFUSED: the baseline
[:baseline :reference]       omitted -> REFUSED: the baseline reference

one refusal in full:
  This benchmark result cannot be emitted: 1 provenance field is missing or
  malformed — [:host :hardware-class] (the hardware class) is missing; expected
  the detected or configured hardware class — never a literal naming one machine.
  A median without its distribution and environment is not release evidence (D021).
```

The suite version enumerates `provenance/required-fields` rather than restating it, so a field added to the ledger is covered the moment it is added. The complete record is asserted to emit first — without that, every omission assertion is vacuous. Present-but-meaningless values (a blank revision, an empty fixture, a `nil` instrumentation flag, a hardware class naming a machine, an unnamed baseline) are refused the same way.

### Acceptance 2 — a deterministic property registered as a GATE reds CI, naming the property

A process, exiting on the harness's outcome:

```
$ clojure -M -i c2.clj
a DETERMINISTIC property registered as a GATE, deliberately violated:
   GATE FAILED: :falsifiability/node-count (the exact node count of the interpreted
   structural tree). Expected 1201, observed 201.
  process exit -> 1
shell $? = 1
```

Non-vacuity: the same workload with the expectation a correct run answers exits 0 (`honoured-gate`), so this is not a harness that reds on everything.

### Acceptance 3 — a timing registered as EVIDENCE does not red CI however wildly it moves

The direction people skip. Same fixture, same deterministic property, 50× the work:

```
$ clojure -M -i c3.clj
a WALL-CLOCK measurement registered as EVIDENCE:
   baseline p50 = 3.5591 ms   (exit 0 )
   moved    p50 = 85.2424 ms   (exit 0 )
   the distribution moved 24.0x and reported no gate failure: true
  process exit -> 0
shell $? = 0
```

The moved arm's deterministic property is asserted to be *unchanged* (`:pass? true`), which is what makes this a test of the timing rather than of the property. And the move is asserted to be real: proving that an unchanged timing does not red the build proves nothing.

### Both directions in one command

```
$ clojure -M:bench --prove
;; Freehand B-spine falsifiability proof (D021, both directions).
;;   a gate that HOLDS      -> exit 0   (expected 0)
;;   a gate VIOLATED        -> exit 1   (expected 1)
;;       GATE FAILED: :falsifiability/node-count (the exact node count of the interpreted structural tree). Expected 1201, observed 201.
;;   timing baseline        -> exit 0   (expected 0), p50 2.8285ms
;;   timing MOVED           -> exit 0   (expected 0), p50 57.6999ms = 20.4x the baseline
;;   PROVEN both ways: a violated deterministic property reds; a wildly moved
;;   wall-clock distribution does not.
;;
{:arms
 {:honoured-gate {:exit-code 0},
  :violated-gate
  {:exit-code 1,
   :gate-failures
   ["GATE FAILED: :falsifiability/node-count (the exact node count of the interpreted structural tree). Expected 1201, observed 201."]},
  :baseline-timing {:exit-code 0, :p50-ms 2.8285},
  :moved-timing {:exit-code 0, :p50-ms 57.6999, :gate-failures []}},
 :move 20.399469683577866,
 :defects [],
 :proven? true,
 :command :prove}
shell $? = 0
```

Both hosts run the same proof: the transcripts above are the JVM, and the identical assertions pass under `npm run test:freehand` on Node.

## Follow-ups

- B1–B5 (rf2-drpa3.48 … .52) each register their workload with `bench/register!`; nothing else in the spine changes.
- A browser or Node *evidence* run needs a shadow-cljs `:node-script` / `:browser` build id, which lives in the hot-zone `implementation/shadow-cljs.edn`. Deliberately not added here — the first B-workload that needs a browser arm brings its own build id, and the `.cljc` harness is already proven on both hosts by the node-test suite.
