### PR TITLE
fix: route Freehand React into the browser suite, guard rename endpoints, repair stale pointers (rf2-drpa3.70, rf2-ajbgq, rf2-ysw9w)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -527,6 +527,18 @@ else
         bundle_isolation=true
         ui_smoke=true
         ;;
+      implementation/freehand/*.md)
+        # rf2-drpa3.70 — prose under the artefact root. The two host suites
+        # still fire (a README documents contracts those suites assert, and
+        # they are cheap), but Markdown cannot change what React puts on a
+        # page, so it does not pay for a Chromium run. This arm exists only to
+        # keep the browser widening below off documentation-only PRs, and it
+        # MUST stay above the artefact-root arm: a POSIX `case` takes the
+        # first match, and its `*` spans `/`, so this covers prose at any
+        # depth under the artefact.
+        implementation_jvm=true
+        cljs_node_test=true
+        ;;
       implementation/freehand/*)
         # rf2-drpa3.58 — the Freehand view substrate artefact (EP-0036).
         # Its JVM lane shipped as a standalone workflow with its own
@@ -546,15 +558,29 @@ else
         # `cljs` is surface-gated on cljs_node_test, so before this case
         # the CLJS arm skipped on a freehand-only PR too.
         #
-        # Deliberately NOT the full per-feature fan-out (cljs_browser /
-        # cljs_prod / bundle_isolation): Freehand ships no public surface,
-        # no browser-test namespace and no production-bundle requirer yet
-        # (shadow-cljs.edn puts it on `:node-test` only). Widen this case
-        # the moment it gains a `*-dom-cljs-test` namespace or a bundle
-        # requirer — the `implementation/ui/*` case above is the worked
-        # precedent for what that widening looks like.
+        # rf2-drpa3.70 — cljs_browser, the widening rf2-drpa3.58 said to make
+        # "the moment it gains a `*-dom-cljs-test` namespace". F1c shipped the
+        # interpreted React emitter and with it two such namespaces
+        # (react_mount_dom_cljs_test.cljs, route_link_native_dom_cljs_test.cljs)
+        # that mount through `react-dom/client` and read assertions back off
+        # `document`. They already RIDE the `:browser-test` build — freehand/src
+        # and freehand/test are on :source-paths and that build's
+        # `-dom-cljs-test$` ns-regexp selects them — but the `cljs-browser` job
+        # is surface-gated on this output, so a Freehand-only PR skipped the
+        # only lane where they can execute.
+        #
+        # A green `cljs` job is not a substitute: the `:node-test` regex
+        # matches the same two files, where they find no DOM and say so rather
+        # than mounting. That is the same false-green shape rf2-drpa3.58/.61
+        # closed for the host suites, one tier up.
+        #
+        # Still NOT cljs_prod / bundle_isolation / ui_gates / ui_smoke:
+        # Freehand ships no production-bundle requirer and no testbed those
+        # smokes mount. Widen each the moment it gains one — the
+        # `implementation/ui/*` case above is the worked precedent.
         implementation_jvm=true
         cljs_node_test=true
+        cljs_browser=true
         ;;
       implementation/scripts/run-ui-bench.cjs)
         # rf2-vxgfnd.6 — false-green fix, mirroring the launcher cases
@@ -726,12 +752,22 @@ else
         # hosts once actually run. Arming the two host outputs is what makes it
         # run.
         #
-        # Scoped exactly like the implementation/freehand/* case: NOT the
-        # browser/prod/isolation tier. Freehand ships no production-bundle
-        # requirer, so those gates would be pure cost — widen both cases
-        # together when it gains one.
+        # Scoped exactly like the implementation/freehand/* case, which is why
+        # rf2-drpa3.70's browser widening lands on both together. This corpus
+        # is a live input to the MOUNTED tests too: FH-STRUCT-007 is the DOM
+        # table react_mount_dom_cljs_test.cljs reads back off `document`, and
+        # FH-ROUTELINK-001..003 drive route_link_native_dom_cljs_test.cljs. A
+        # fixture edit can therefore change mounted output, so it must schedule
+        # the browser lane. The arm stays the whole fixtures root rather than a
+        # family prefix: two unrelated families already feed browser tests, and
+        # a prefix list would rot silently on the third.
+        #
+        # Still NOT cljs_prod / bundle_isolation — Freehand ships no
+        # production-bundle requirer. Widen both cases together when it gains
+        # one.
         implementation_jvm=true
         cljs_node_test=true
+        cljs_browser=true
         ;;
       implementation/scripts/serve-and-run-reagent-slim-smoke.cjs|implementation/scripts/_reagent-slim-smoke-policy.test.cjs)
         # rf2-5v0dg7 — false-green fix, mirroring the xray-feature-gate

--- a/implementation/freehand/src/re_frame/freehand/compiler/env.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/env.cljc
@@ -15,7 +15,9 @@
        boundary (open props; JS values pass through);
     4. an unresolvable symbol -> COMPILE ERROR (didactic).
 
-  Corners (all test-pinned in re-frame.freehand.q5-heads-cljs-test):
+  Corners (test-pinned in re-frame.freehand.analyze-accept-cljs-test and
+  re-frame.freehand.analyze-reject-cljs-test, with the real-CLJS-analyzer
+  counterpart in re-frame.freehand.compiler-macro-resolution-jvm-test):
     - forward/mutual recursion: `(declare ^:rf.ui/view b)` marks the var
       before definition, so mutually-recursive views are expressible with
       zero extra surface; a plain `(declare b)` head classifies FOREIGN

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -1816,7 +1816,20 @@ test('an ordinary UI cljs test (non-DOM) also fires cljs_browser + node-test (rf
   // The whole implementation/ui/** tree fires the browser gate — an
   // ordinary *_cljs_test.cljc under ui/test is not exempted (conservative
   // routing: UI test changes can move a shared fixture a DOM test :requires).
-  const result = classify('implementation/ui/test/re_frame/ui/eq_cljs_test.cljc');
+  //
+  // This arm is about a DONOR test that stayed, so the path must still name
+  // one: the previous fixture pointed at eq_cljs_test.cljc, which the F3a
+  // compiler transplant moved to implementation/freehand/test/. The classifier
+  // never stats a path, so that rot was silent and permanently green. Unlike
+  // the deliberately-not-yet-existing future paths pinned elsewhere in this
+  // file, this row's whole claim is "an existing ordinary UI test", so assert
+  // it exists.
+  const donorTest = 'implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc';
+  assert.ok(
+    fs.existsSync(path.join(REPO_ROOT, donorTest)),
+    `${donorTest} must exist — this row pins the routing of a REAL donor UI test`,
+  );
+  const result = classify(donorTest);
   assert.equal(result.cljs_browser, 'true');
   assert.equal(result.cljs_node_test, 'true');
 });

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -2118,13 +2118,83 @@ test('the freehand arm is ARTEFACT-ROOT matching, not an enumeration (rf2-drpa3.
 });
 
 test('implementation/freehand/** stays OFF the heavy per-feature gates (rf2-drpa3.58)', () => {
-  // Scope guard, not an aspiration: Freehand ships no public surface, no
-  // *-dom-cljs-test namespace and no production-bundle requirer yet, so the
-  // browser/prod/isolation tier would be pure cost. Widen the classifier case
-  // (and this test) when it gains one — implementation/ui/* is the precedent.
+  // Scope guard, not an aspiration: Freehand ships no production-bundle
+  // requirer and no testbed the smokes mount, so those tiers would be pure
+  // cost. Widen the classifier case (and this test) when it gains one —
+  // implementation/ui/* is the precedent. cljs_browser LEFT this list under
+  // rf2-drpa3.70: the artefact now has mounted-DOM tests, so that gate stopped
+  // being cost and became the only place they can run.
   const result = classify('implementation/freehand/src/re_frame/freehand.cljc');
-  for (const key of ['cljs_browser', 'cljs_prod', 'bundle_isolation', 'ui_gates', 'ui_smoke']) {
+  for (const key of ['cljs_prod', 'bundle_isolation', 'ui_gates', 'ui_smoke']) {
     assert.equal(result[key], 'false', `freehand must not arm ${key} yet`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// rf2-drpa3.70 — the React surfaces and the browser lane.
+//
+// F1c shipped an interpreted React emitter whose real claim is what a BROWSER
+// does with its output, and two `*-dom-cljs-test` namespaces that mount
+// through `react-dom/client` to prove it. Those files already ride the
+// `:browser-test` build (freehand/src + freehand/test are on :source-paths;
+// the build's `-dom-cljs-test$` regex selects them) — but `cljs-browser` is
+// surface-gated, so a Freehand-only PR skipped the only lane that can execute
+// them.
+//
+// The `cljs` job is not a substitute. The `:node-test` regex matches the very
+// same files, where they find no DOM and self-skip. Green, and worth nothing.
+// ---------------------------------------------------------------------------
+
+test('the Freehand React surfaces arm cljs_browser (rf2-drpa3.70)', () => {
+  // Source, mounted-DOM test, the shared view declarations both emitters
+  // render, and a fixture the mounted assertions read — one representative of
+  // each transitive semantic input to mounted output.
+  for (const file of [
+    'implementation/freehand/src/re_frame/freehand/react.cljs',
+    'implementation/freehand/test/re_frame/freehand/react_mount_dom_cljs_test.cljs',
+    'implementation/freehand/test/re_frame/freehand/route_link_native_dom_cljs_test.cljs',
+    'implementation/freehand/test/re_frame/freehand/tree_views.cljc',
+    'implementation/freehand/src/re_frame/freehand/conversion.cljc',
+    'spec/conformance/freehand/fixtures/fh-struct-007.edn',
+    'spec/conformance/freehand/fixtures/fh-routelink-001.edn',
+  ]) {
+    assert.equal(
+      classify(file).cljs_browser,
+      'true',
+      `${file} can change mounted output — it must schedule the cljs-browser job`,
+    );
+  }
+});
+
+test('the Freehand browser-test namespaces actually exist (rf2-drpa3.70)', () => {
+  // The classifier never stats a path, so the row above would stay green if
+  // the mounted tests were renamed or deleted — routing a lane at nothing.
+  // These two ARE the browser proof; pin their existence with the routing.
+  for (const file of [
+    'implementation/freehand/test/re_frame/freehand/react_mount_dom_cljs_test.cljs',
+    'implementation/freehand/test/re_frame/freehand/route_link_native_dom_cljs_test.cljs',
+  ]) {
+    assert.ok(
+      fs.existsSync(path.join(REPO_ROOT, file)),
+      `${file} must exist — it is the mounted proof this routing exists to run`,
+    );
+    // ...and carry the suffix the :browser-test ns-regexp selects on.
+    assert.match(path.basename(file), /_dom_cljs_test\.cljs$/);
+  }
+});
+
+test('Freehand PROSE does not pay for a Chromium run (rf2-drpa3.70)', () => {
+  // The widening is about mounted output. Markdown cannot change it, and the
+  // browser lane is the expensive one — so the prose arm keeps its two host
+  // suites and stops there.
+  for (const file of [
+    'implementation/freehand/README.md',
+    'implementation/freehand/doc/design/emitters.md',
+  ]) {
+    const result = classify(file);
+    assert.equal(result.cljs_browser, 'false', `${file} must not arm cljs_browser`);
+    assert.equal(result.implementation_jvm, 'true', `${file} still arms implementation_jvm`);
+    assert.equal(result.cljs_node_test, 'true', `${file} still arms cljs_node_test`);
   }
 });
 
@@ -2189,13 +2259,31 @@ test('the freehand fixture arm is ROOT matching, not an enumeration (rf2-drpa3.6
 });
 
 test('freehand fixtures stay OFF the heavy gates, like the artefact (rf2-drpa3.66)', () => {
-  // Scope guard. The fixtures feed exactly the two suites the artefact case
-  // arms and nothing else, so this arm must not drift wider than
-  // implementation/freehand/* — widen both together or neither.
+  // Scope guard. The fixtures feed exactly the suites the artefact case arms
+  // and nothing else, so this arm must not drift wider than
+  // implementation/freehand/* — widen both together or neither. cljs_browser
+  // left this list under rf2-drpa3.70, on both cases at once: FH-STRUCT-007
+  // and FH-ROUTELINK-001..003 are read by the mounted-DOM tests.
   const result = classify('spec/conformance/freehand/fixtures/fh-call-001.edn');
-  for (const key of ['cljs_browser', 'cljs_prod', 'bundle_isolation', 'ui_gates', 'ui_smoke']) {
+  for (const key of ['cljs_prod', 'bundle_isolation', 'ui_gates', 'ui_smoke']) {
     assert.equal(result[key], 'false', `freehand fixtures must not arm ${key}`);
   }
+});
+
+test('cljs-browser is job-gated on cljs_browser and is REQUIRED (rf2-drpa3.70)', () => {
+  // Arming the output only helps if the lane it arms is still surface-gated on
+  // that output and still reachable from the single required context. Both
+  // halves, pinned together: rf2-drpa3.58 learned the hard way that a lane
+  // outside the aggregator is advisory however green it looks.
+  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+  const block = jobBlock(workflow, 'cljs-browser');
+  assert.match(block, /if: needs\.detect_changed_surfaces\.outputs\.cljs_browser == 'true'/);
+  assert.match(block, /run: npm run test:browser/);
+  assert.match(
+    jobBlock(workflow, 'all-required-passed'),
+    /- cljs-browser\r?\n/,
+    'aggregator must list cljs-browser in needs: — otherwise the browser lane is advisory',
+  );
 });
 
 test('freehand conformance PROSE is not a fixture — no over-broadening (rf2-drpa3.66)', () => {

--- a/scripts/check-beads-pr-boundary.sh
+++ b/scripts/check-beads-pr-boundary.sh
@@ -44,6 +44,21 @@
 #   cause is a shallow clone that does not contain the branch point; on GitHub
 #   Actions use `actions/checkout` with `fetch-depth: 0`.
 #
+# WHY `--no-renames` (rf2-ajbgq)
+#
+#   Git detects renames by default and `--name-only` then reports the
+#   DESTINATION alone. An exact rename out of the protected tree —
+#   `.beads/issues.jsonl` -> `tracker-snapshot.jsonl` — would therefore reach
+#   the classifier as `tracker-snapshot.jsonl` only: outside `.beads/**`,
+#   permitted, exit 0, while merging the PR deletes the tracker database from
+#   its canonical location.
+#
+#   `--no-renames` presents both endpoints (a deletion plus an addition), so
+#   the shared classifier refuses the protected OLD path with no new rules.
+#   The same Git behaviour bit changed-surface discovery (rf2-vxgfnd.137) and
+#   has the same one-flag fix. A rename endpoint is pinned in layer 5 of
+#   scripts/git-hooks/test-pre-commit.sh; restoring plain `--name-only` reds it.
+#
 # Usage:
 #   sh scripts/check-beads-pr-boundary.sh [BASE_REF]
 #
@@ -100,7 +115,7 @@ if [ -z "$BRANCH_POINT" ]; then
   exit 1
 fi
 
-changed=$(git diff --name-only "$BRANCH_POINT" HEAD)
+changed=$(git diff --no-renames --name-only "$BRANCH_POINT" HEAD)
 
 if printf '%s\n' "$changed" | check_beads_boundary ci; then
   printf 'No beads-database paths in this PR diff.\n'

--- a/scripts/git-hooks/test-pre-commit.sh
+++ b/scripts/git-hooks/test-pre-commit.sh
@@ -589,9 +589,11 @@ CIERR=$(mktemp "${TMPDIR:-/tmp}/rf2-beads-ci-err-XXXXXX")
   git add -A
   git commit -q -m 'seed'
 
-  # Two branches fork HERE, from the same base commit.
+  # Four branches fork HERE, from the same base commit.
   git branch worker/clean
   git branch worker/contaminated
+  git branch worker/renamed-out
+  git branch worker/renamed-to-config
 
   # ...and only THEN does the base advance, with a mayor beads-only
   # checkpoint. This commit is the whole point of the fixture.
@@ -613,6 +615,21 @@ CIERR=$(mktemp "${TMPDIR:-/tmp}/rf2-beads-ci-err-XXXXXX")
     > .beads/issues.jsonl
   git add -A
   git commit -q -m 'worker: real work + bd auto-staged tracker snapshot'
+
+  # An EXACT rename out of the protected tree (rf2-ajbgq). Content is
+  # untouched, so git scores it R100 and `--name-only` reports the
+  # destination alone — the deleted `.beads/issues.jsonl` endpoint simply is
+  # not in the guard's input.
+  git checkout -q worker/renamed-out
+  git mv .beads/issues.jsonl tracker-snapshot.jsonl
+  git commit -q -m 'worker: move the tracker out of .beads/'
+
+  # The same move onto an ALLOW-LISTED beads config path. The destination is
+  # permitted; the source endpoint is still the database leaving its
+  # canonical location.
+  git checkout -q worker/renamed-to-config
+  git mv .beads/issues.jsonl .beads/config.yaml
+  git commit -q -m 'worker: move the tracker onto an allow-listed config path'
 ) >/dev/null 2>&1
 
 run_ci_guard() {
@@ -650,6 +667,58 @@ case "$out" in
       pass "(5b) branch that DID commit the tracker -> refused, names path + remedy"
     else
       fail "(5b) refused, but the diagnostic is missing the path or the remedy"
+      cat "$CIERR" >&2 || true
+    fi
+    ;;
+esac
+
+# 5f: RENAME ENDPOINTS (rf2-ajbgq). A rename presents as a delete plus an add,
+# but git's default rename detection collapses the pair and `--name-only`
+# prints only the destination. An exact rename OUT of `.beads/` therefore
+# reached the classifier as an ordinary top-level file — permitted — while
+# merging the PR deletes the tracker database from its canonical location.
+#
+# Pin the premise first: if git ever stops scoring this R100 the fixture would
+# pass for the wrong reason, and a guard test that cannot fail is not a test.
+rename_premise=$( cd "$CIBOX" \
+  && git checkout -q worker/renamed-out \
+  && git diff --name-status "$(git merge-base origin/main HEAD)" HEAD )
+case "$rename_premise" in
+  *R100*.beads/issues.jsonl*tracker-snapshot.jsonl*)
+    pass "(5f-premise) the fixture really is a git-detected R100 rename" ;;
+  *)
+    fail "(5f-premise) fixture is not a detected rename, so 5f proves nothing"
+    printf '%s\n' "$rename_premise" >&2
+    ;;
+esac
+
+out=$(run_ci_guard worker/renamed-out origin/main)
+case "$out" in
+  EXIT=0)
+    fail "(5f) FALSE GREEN: renaming .beads/issues.jsonl out of the tree was certified"
+    ;;
+  *)
+    if grep -q '\.beads/issues\.jsonl' "$CIERR"; then
+      pass "(5f) rename out of .beads/ -> refused, names the DELETED endpoint"
+    else
+      fail "(5f) refused, but the diagnostic never names the deleted .beads path"
+      cat "$CIERR" >&2 || true
+    fi
+    ;;
+esac
+
+# 5g: the same move onto an ALLOW-LISTED destination. The allow-list covers
+# `.beads/config.yaml`, so only the source endpoint can carry the refusal.
+out=$(run_ci_guard worker/renamed-to-config origin/main)
+case "$out" in
+  EXIT=0)
+    fail "(5g) FALSE GREEN: the tracker was renamed onto an allow-listed path unchallenged"
+    ;;
+  *)
+    if grep -q '\.beads/issues\.jsonl' "$CIERR"; then
+      pass "(5g) rename onto an allow-listed beads path -> refused on the old endpoint"
+    else
+      fail "(5g) refused, but not on the protected source path"
       cat "$CIERR" >&2 || true
     fi
     ;;


### PR DESCRIPTION
Three unrelated small repairs on disjoint surfaces, shipped as one cluster: the Freehand browser routing gap, a rename hole in the Beads PR guard, and two dead pointers left by the compiler transplant. One commit each.

## Quality gates

| Gate | Result |
| --- | --- |
| `npm run test:browser` | Ran 485 tests containing 2762 assertions. 0 failures, 0 errors. (exit 0, post-rebase, `.shadow-cljs/builds/browser-test` cleared first) |
| `npm run test:cljs` | Ran 10327 tests containing 51343 assertions. 0 failures, 0 errors. (exit 0) |
| `implementation/freehand` `clojure -M:test` | Ran 303 tests containing 1713 assertions. 0 failures, 0 errors. |
| `npm run test:script-policy` | exit 0 — `changed-surfaces tests: 203 passed` (was 199) |
| `npm run test:script-helpers` | exit 0 |
| `sh scripts/git-hooks/test-pre-commit.sh` | Summary: 33 passed, 0 failed (was 31) |
| `python scripts/check_doc_slugs.py` | exit 0, no output |
| `python -m mkdocs build --strict` | Documentation built in 32.22 seconds |

Guard preflight on this branch: `GITHUB_EVENT_NAME=pull_request sh scripts/check-beads-pr-boundary.sh origin/main` → `No beads-database paths in this PR diff.`

## rf2-drpa3.70 — route the Freehand React surfaces into the required browser suite

The mounted-DOM tests were already selected by the `:browser-test` build (freehand/src + freehand/test are on `:source-paths`; the build's `-dom-cljs-test$` ns-regexp matches them). What was missing is the schedule: `cljs-browser` is surface-gated on `cljs_browser`, and the Freehand classifier arms fired only the two host suites — so a Freehand-only PR skipped the only lane where a mount can happen, and the aggregator accepted it. No new workflow, no second runner: `cljs-browser` already runs `npm run test:browser` and is already in `all-required-passed`.

**Routing, from the classifier itself** (`./.github/scripts/report-changed-surfaces.sh <path>`):

| path | `implementation_jvm` | `cljs_node_test` | `cljs_browser` |
| --- | --- | --- | --- |
| `implementation/freehand/src/re_frame/freehand/react.cljs` | true | true | **true** |
| `.../test/re_frame/freehand/react_mount_dom_cljs_test.cljs` | true | true | **true** |
| `.../test/re_frame/freehand/tree_views.cljc` | true | true | **true** |
| `implementation/freehand/src/re_frame/freehand/conversion.cljc` | true | true | **true** |
| `spec/conformance/freehand/fixtures/fh-struct-007.edn` | true | true | **true** |
| `spec/conformance/freehand/fixtures/fh-routelink-001.edn` | true | true | **true** |
| `implementation/freehand/README.md` | true | true | **false** |

`cljs_prod`, `bundle_isolation`, `ui_gates`, `ui_smoke` stay `false` on every row and stay scope-guarded.

**Does it actually RUN?** Not "is the suite green" — the suite was green before, with nothing mounted. Proof by inversion: `(is (some? el) …)` in the DOM row checker flipped to `(is (nil? el) …)`, then both lanes re-run.

Browser lane — the assertions execute and the required result goes red:

```
Testing re-frame.freehand.react-mount-dom-cljs-test
FAIL in (fh-struct-007-the-react-emitter-mounts-real-dom) (re_frame/freehand/react_mount_dom_cljs_test.cljs:46:11)
MUTATION PROBE — the root element is the tag the declaration names, with its sugar id — #main matched
FAIL in (fh-struct-007-the-react-emitter-mounts-real-dom) (re_frame/freehand/react_mount_dom_cljs_test.cljs:46:11)
MUTATION PROBE — sugar classes and the truthy flag-map entries compose into one className — #main matched
FAIL in (fh-struct-007-the-react-emitter-mounts-real-dom) (re_frame/freehand/react_mount_dom_cljs_test.cljs:46:11)
MUTATION PROBE — the kebab attribute name reaches the DOM in its collapsed spelling — #main matched
FAIL in (fh-struct-007-the-react-emitter-mounts-real-dom) (re_frame/freehand/react_mount_dom_cljs_test.cljs:46:11)
MUTATION PROBE — static text renders as text, in its own element — #main > h2 matched
FAIL in (fh-struct-007-the-react-emitter-mounts-real-dom) (re_frame/freehand/react_mount_dom_cljs_test.cljs:46:11)
MUTATION PROBE — each child boundary renders its own props — numbers as text — ul.rows > li.row matched
FAIL in (fh-struct-007-the-react-emitter-mounts-real-dom) (re_frame/freehand/react_mount_dom_cljs_test.cljs:46:11)
MUTATION PROBE — the whole subtree's text is the document-order concatenation — #main matched

Ran 485 tests containing 2762 assertions.
6 failures, 0 errors.        EXIT=1
```

Node lane, same mutation, same moment — green, because the test finds no DOM and self-skips:

```
> npm run test:freehand
Ran 206 tests containing 1265 assertions.
0 failures, 0 errors.        EXIT=0
```

That is the bead's point stated as a measurement: a green node result is not evidence of a mount. The mutation was reverted; nothing from it is committed (`git status` clean before the commit).

Classifier self-tests gain four rows: representative source / browser-test / view / fixture paths arming `cljs_browser`; an existence assertion on the two `*_dom_cljs_test.cljs` namespaces (the classifier never stats a path, so routing could otherwise point at nothing); a negative pinning that Freehand prose does not pay for Chromium; and a pin that `cljs-browser` is still `if:`-gated on `cljs_browser`, still runs `npm run test:browser`, and is still in the aggregator's `needs:`.

**Fence note.** This bead cannot be delivered without `.github/scripts/report-changed-surfaces.sh` — the routing IS that file, and its self-test is AC4. My dispatch brief listed it as in-flight/do-not-touch, but the bead is authoritative and no open PR held it (`gh pr list` was empty at the time). The edit is additive: one new `case` arm plus one line in each of two existing arms.

## rf2-ajbgq — keep both rename endpoints visible to the Beads PR guard

`git diff --name-only` reports only the destination of a detected rename, so `.beads/issues.jsonl` → `tracker-snapshot.jsonl` reached the classifier as an ordinary top-level file, was permitted, and exited 0 — while merging the PR deletes the tracker database from its canonical location. `--no-renames` presents the pair as a delete plus an add, and the existing shared classifier refuses the protected old endpoint with no new path rules.

**Real rename, real Git history, in a throwaway repo under the system temp dir** (the script asserts the sandbox is not this repository, and not any re-frame2 checkout, before writing):

```
SANDBOX = /tmp/rf2-rename-proof-MyaAqW
SAFETY OK: sandbox is a fresh temp dir, not the re-frame2 repository.

=== CASE A: .beads/issues.jsonl -> tracker-snapshot.jsonl ===
--- git name-status (rename really detected) ---
R100    .beads/issues.jsonl     tracker-snapshot.jsonl
--- what the OLD enumeration handed the classifier ---
tracker-snapshot.jsonl
--- what the FIXED enumeration hands the classifier ---
.beads/issues.jsonl
tracker-snapshot.jsonl
--- guard verdict ---
ERROR: refusing the beads DATABASE outside the mayor checkout.
  Beads-database paths in this PR diff:
    .beads/issues.jsonl
CASE A EXIT=1

=== CASE B (control): src/seed.cljc -> src/renamed.cljc ===
R100    src/seed.cljc   src/renamed.cljc
--- guard verdict ---
No beads-database paths in this PR diff.
CASE B EXIT=0
```

An ordinary rename of a non-`.beads` file still passes. Layer 5 of `test-pre-commit.sh` gains two branches on real history — a rename out of `.beads/`, and the same move onto the allow-listed `.beads/config.yaml`, where only the source endpoint can carry the refusal — plus a premise row asserting git really scores the move `R100`, so the fixture cannot pass for the wrong reason.

**False-green check (AC4).** Restoring the plain `git diff --name-only` call:

```
PASS  (5f-premise) the fixture really is a git-detected R100 rename
FAIL  (5f) FALSE GREEN: renaming .beads/issues.jsonl out of the tree was certified
FAIL  (5g) FALSE GREEN: the tracker was renamed onto an allow-listed path unchallenged
Summary: 31 passed, 2 failed
```

Only the two new cases move. Diverged-history (5a/5b), missing-base (5c/5d) and mayor-push (5e) stay green throughout, and the guard is otherwise unchanged.

## rf2-ysw9w — two stale pointers from the compiler transplant

**The dead namespace.** `compiler/env.cljc` said its Q5 head-resolution corners were "all test-pinned in `re-frame.freehand.q5-heads-cljs-test`". That namespace does not exist, and the donor spelling never did either — the pointer was already dead before the transplant carried it across. The corners are really pinned, and each one has a home:

- the `(declare ^:rf.ui/view b)` forward/mutual reference and the var-copy row — `re-frame.freehand.analyze-accept-cljs-test` (`q5-head-classification`, `reactive-verb-head-reservation-is-narrow`);
- locals shadowing a view name → `:rf.ui.compile/dynamic-head` — `re-frame.freehand.analyze-reject-cljs-test`;
- the real-CLJS-analyzer counterpart, including "a local shadow of the self spelling is a dynamic head" — `re-frame.freehand.compiler-macro-resolution-jvm-test`.

All three resolve to files on disk carrying exactly those `ns` forms, and the old spelling is now absent from the artefact:

```
implementation/freehand/test/re_frame/freehand/analyze_accept_cljs_test.cljc -> (ns re-frame.freehand.analyze-accept-cljs-test
implementation/freehand/test/re_frame/freehand/analyze_reject_cljs_test.cljc -> (ns re-frame.freehand.analyze-reject-cljs-test
implementation/freehand/test/re_frame/freehand/compiler_macro_resolution_jvm_test.clj -> (ns re-frame.freehand.compiler-macro-resolution-jvm-test
--- old pointer ---
ABSENT under implementation/freehand
```

So the corners are pinned, not unpinned — the docstring simply named the wrong place.

**The fictional fixture path.** The changed-surfaces "ordinary donor UI test" row classified `implementation/ui/test/re_frame/ui/eq_cljs_test.cljc`, which the same transplant moved under `implementation/freehand/test/`. Re-pointed at `implementation/ui/test/re_frame/ui/error_roster_cljs_test.cljc` — a donor test that stayed, which is what the row's claim needs — with an `fs.existsSync` assertion so this cannot rot silently again. (The deliberately-not-yet-existing future paths pinned elsewhere in that file are a different claim and keep no such assertion.) The Freehand arm of the router is untouched.

## Notes

- Nothing under `implementation/freehand/src/re_frame/freehand.cljc`, `defview`, the atomic-shell namespaces, `spec/006`, `spec/004D`, the compiler, `events.cljc`, `conversion.cljc`, `react.cljs`, or `test/re_frame/freehand/conformance.cljc` was modified.
- Rebased onto `origin/main` after the conformance-fixture build-dependency fix landed, and the browser gate was re-run with `.shadow-cljs/builds/browser-test` removed first.
- `scripts/check-beads-pr-boundary.sh` and `.github/scripts/report-changed-surfaces.sh` both keep mode `100755`.
