### PR TITLE
feat(freehand): the read-only compile checker (rf2-drpa3.29)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
@@ -1,0 +1,343 @@
+(ns re-frame.freehand.compiler.check
+  "The READ-ONLY compile checker — discovery before commitment.
+
+  `{:compiled true}` is a one-line change to a declaration, which makes
+  it a tempting thing to try and see. Trying and seeing is a poor way to
+  learn a finite language: the build stops at the first form outside
+  `:re-frame.freehand/v1`, and an author who reached that failure by
+  editing has already changed the declaration before finding out whether
+  the change was available. So the order is inverted. The checker runs
+  the SAME analyzer the build runs, against the declaration as it stands
+  today, and answers in data:
+
+      {:view-id          :app.people/people-list
+       :source           {:file \"src/app/people.cljc\" :line 42 :column 1}
+       :current-lowering :interpreted
+       :target-grammar   :re-frame.freehand/v1
+       :compile-eligible? false
+       :findings         [{:id       :rf.ui.compile/markup-returning-map
+                           :source   {:line 47 :column 5}
+                           :form     (map person-item people)
+                           :reason   :markup-hidden-from-analyzer
+                           :recovery [:make-template-visible
+                                      :extract-declared-child
+                                      :keep-interpreted]}]}
+
+  Changing the declaration is then the FINAL step, not the discovery
+  mechanism.
+
+  ## Three laws
+
+  1. **It never writes.** No file is opened for writing, no emitter runs,
+     no registry is contributed to, and nothing is printed. A checker
+     that edited source would make its own advice unfalsifiable, and one
+     that emitted code would no longer be answering a question about the
+     declaration in front of you.
+  2. **It never recommends.** There is no percentage, no \"hot 5%\", and
+     no promotion recommender — an explicit EP-0036 non-goal. Eligibility
+     is a property of the body; whether compiling it is *worth* it is a
+     measurement and a judgement, and neither is this namespace's.
+  3. **It invents no diagnostics.** Findings carry the analyzer's OWN
+     `:rf.ui.compile/*` ids and the recovery ladders
+     [[re-frame.freehand.compiler.grammar/recovery]] already serves the
+     build. One roster, two consumers: a checker with its own id set
+     would be a second grammar to drift.
+
+  The recovery list is the payload. `:id` says which rule stopped you and
+  `:reason` says what kind of thing went wrong, but `:recovery` is the
+  ordered ladder of things you can actually do to the source in front of
+  you, most specific first, drawn from
+  [[re-frame.freehand.compiler.grammar/recoveries]] — whose values are
+  the sentences a tool renders. Its last rung is always
+  `:keep-interpreted`, because declining to compile is a first-class
+  answer: the interpreted mode has no finite grammar, so every body the
+  compiler refuses is a body that already runs.
+
+  ## Hosts
+
+  The ANALYSIS is JVM-only. Head classification resolves symbols through
+  the host compiler exactly as macro expansion does, which happens on the
+  JVM for both targets — the same reason
+  [[re-frame.freehand.compiler]] is JVM-only. This namespace is `.cljc`
+  so that it loads everywhere, and the REPORT VOCABULARY below —
+  [[reasons]], [[reason]], [[finding]], [[report]] — is host-neutral, so
+  a ClojureScript tool can render a report it received over the wire
+  without a second copy of the vocabulary.
+
+  Normative owner:
+  [`spec/004D-Freehand-Compiled-Grammar.md`](../../../../../../spec/004D-Freehand-Compiled-Grammar.md)
+  §The read-only checker."
+  (:require [re-frame.freehand.compiler.grammar :as grammar]
+            #?@(:clj [[clojure.java.io :as io]
+                      [re-frame.freehand :as v]
+                      [re-frame.freehand.compiler.analyze :as ana]
+                      [re-frame.freehand.compiler.env :as env]
+                      [re-frame.freehand.fingerprint :as fingerprint]]))
+  #?(:clj (:import [clojure.lang LineNumberingPushbackReader])))
+
+;; ---------------------------------------------------------------------------
+;; The report vocabulary — host-neutral
+;; ---------------------------------------------------------------------------
+
+(def reasons
+  "Diagnostic id -> the REASON the checker reports for it: a short,
+  unqualified keyword naming the KIND of thing that stopped the body.
+
+  A reason is not a second id. `:id` is the machine discriminator and is
+  the only thing a tool should branch on; `:reason` groups ids into the
+  handful of categories an author actually reasons in — \"the analyzer
+  cannot see this markup\", \"this head is a runtime value\", \"this
+  reactive site is not finite\" — so several ids can and do share one.
+  It is a projection the CHECKER makes for readers; the build itself
+  reports ids and messages and has no use for it.
+
+  Deliberately unqualified, per the shape in
+  `docs/design/freehand/codex-design.md` §Checker-first workflow: a
+  reason is a member of this closed roster, not a keyword in the
+  framework's reserved `:rf.*` scheme, and nothing emits it at runtime."
+  {:rf.ui.compile/dynamic-head         :head-is-a-runtime-value
+   :rf.ui.compile/unresolved-head      :head-does-not-resolve
+   :rf.ui.compile/bad-tag              :head-is-not-an-element-name
+   :rf.ui.compile/keyword-child        :keyword-in-content-position
+   :rf.ui.compile/markup-returning-map :markup-hidden-from-analyzer
+   :rf.ui.compile/lazy-seq-child       :markup-hidden-from-analyzer
+   :rf.ui.compile/unkeyed-list-item    :list-row-carries-no-key
+   :rf.ui.compile/constant-list-key    :list-key-does-not-vary
+   :rf.ui.compile/nested-for-body      :iteration-is-not-lexically-flat
+   :rf.ui.compile/sub-in-loop          :reactive-site-is-not-finite
+   :rf.ui.compile/frame-in-loop        :reactive-site-is-not-finite
+   :rf.ui.compile/void-children        :void-element-carries-children
+   :rf.ui.compile/duplicate-id-sugar   :element-id-declared-twice
+   :rf.ui.compile/id-sugar-conflict    :element-id-declared-twice
+   :rf.ui.compile/unsupported-form     :form-outside-the-grammar})
+
+(def unclassified-reason
+  "The reason for an id nobody has written a category for.
+
+  Total, like [[grammar/recovery]], and for the same reason: a checker
+  that threw on an id it did not recognise would turn every new analyzer
+  diagnostic into a tool outage. `:form-outside-the-grammar` is the
+  honest general statement — the id and the ladder still say which rule
+  and what to do."
+  :form-outside-the-grammar)
+
+(defn reason
+  "The reason keyword for diagnostic `id`. Total over ids."
+  [id]
+  (get reasons id unclassified-reason))
+
+(defn finding
+  "One finding: `id` refused `form`, which sits at `source`.
+
+  Five fields, and they are the whole contract — a stable id, the
+  coordinates, the offending form, the reason, and the recovery ladder.
+  There is deliberately no message: a sentence is stable in meaning and
+  never in bytes, so the renderable prose lives in the closed
+  [[grammar/recoveries]] roster where a tool can look it up and a test
+  can pin it."
+  [id form source]
+  {:id       id
+   :source   source
+   :form     form
+   :reason   (reason id)
+   :recovery (grammar/recovery id)})
+
+(defn report
+  "Assemble a checker report from a declaration's identity and its
+  `findings`.
+
+  `:compile-eligible?` is exactly \"no findings\" — it is derived here
+  rather than passed in, so a report cannot claim eligibility while
+  carrying a reason it is not."
+  [{:keys [view-id source lowering findings]}]
+  {:view-id           view-id
+   :source            source
+   :current-lowering  lowering
+   :target-grammar    grammar/version
+   :compile-eligible? (empty? findings)
+   :findings          (vec findings)})
+
+;; ---------------------------------------------------------------------------
+;; The analysis — JVM
+;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (do
+
+(defn- coords
+  "`{:line … :column …}` for `form` — its own reader coordinates when the
+  reader gave it any, else the declaration's.
+
+  Clojure's reader anchors lists and not vectors, so a refused
+  `(map person-item people)` locates itself and a refused `[tag {} …]`
+  inherits its declaration's line. Falling back keeps the field present
+  and never invents a position: the worst answer is \"somewhere in this
+  declaration\", which is where the form is."
+  [form declaration-source]
+  (let [m (meta form)]
+    (select-keys (if (integer? (:line m)) m declaration-source) [:line :column])))
+
+(defn- findings-for
+  "Run the analyzer over a declaration and answer its findings.
+
+  The analyzer is FAIL-FAST — it refuses at the first form outside the
+  grammar, which is also where the build would stop — so a refused
+  declaration yields one finding and a clean one yields none. Re-run
+  after taking a rung; the ladder is walked one step at a time by
+  construction, not by the checker rationing what it knows.
+
+  Nothing here emits: the analyzer is run for its refusals, its AST is
+  discarded, and neither emitter is reached."
+  [{:keys [view-id vname params body children-policy ns-sym source resolver]}]
+  (try
+    (let [e0  (-> (env/make-env {:host            :clj
+                                 :ns-sym          ns-sym
+                                 :self            vname
+                                 :self-id         view-id
+                                 :resolver        resolver
+                                 :source          source
+                                 :template-anchor (fingerprint/digest "sta1-" body)})
+                  (assoc :self-children? (not= :none children-policy)
+                         :self-closed-keys nil))
+          _   (ana/reject-reactive-binding! e0 params)
+          e   (-> e0
+                  (env/with-locals (set (env/binding-syms (first params))))
+                  (assoc :hooks-region? true))
+          ast (ana/analyze-view-body e body)]
+      (grammar/check! e view-id ast)
+      [])
+    (catch clojure.lang.ExceptionInfo ex
+      (let [data (ex-data ex)
+            id   (:rf.ui.compile/error data)]
+        (when-not id
+          ;; not a grammar refusal — the checker has no opinion about it
+          (throw ex))
+        (let [form (if (contains? data :form) (:form data) (last body))]
+          [(finding id form (coords form source))])))))
+
+(defn check-declaration
+  "Check ONE declaration against `:re-frame.freehand/v1` WITHOUT
+  compiling it, and answer the report.
+
+  The declaration arrives as data — the parts `v/defview` itself parses:
+
+      {:view-id         :app.people/people-list
+       :vname           'people-list      ; for self-recursive heads
+       :ns-sym          'app.people       ; heads resolve through it
+       :params          '[{:keys [people]}]
+       :body            '([:ul (map person-item people)])
+       :compiled?       false             ; what the declaration says TODAY
+       :children-policy :optional
+       :source          {:file \"src/app/people.cljc\" :line 42 :column 1}
+       :resolver        <fn>}             ; optional; tests only
+
+  A declaration that already carries `{:compiled true}` is checked the
+  same way and reports `:current-lowering :compiled` — the question
+  \"is this still eligible?\" is the same question."
+  [{:keys [view-id source compiled?] :as declaration}]
+  (report {:view-id  view-id
+           :source   source
+           :lowering (if compiled? :compiled :interpreted)
+           :findings (findings-for declaration)}))
+
+(def ^:private read-opts
+  "Reader options for a source file. `:read-eval` is refused separately
+  (see [[read-declarations]]); a `.cljc` file is read through its `:clj`
+  branch because that is the host this analysis runs on."
+  {:eof ::eof :read-cond :allow :features #{:clj}})
+
+(defn- source-namespace
+  "The namespace symbol declared by the file's leading `(ns …)` form."
+  [form path]
+  (or (when (and (seq? form) (= 'ns (first form)) (symbol? (second form)))
+        (second form))
+      (throw (ex-info (str "re-frame.freehand check: " path
+                           " does not begin with an (ns …) form, so there is no "
+                           "namespace to resolve its declarations against.")
+                      {:file (str path)}))))
+
+(defn- live-namespace
+  "The LOADED namespace `ns-sym` names.
+
+  Head classification is resolution — a symbol head is an internal view,
+  a foreign component, or an error according to what it resolves to — so
+  the checker reads the same namespace the compiler would. Refusing to
+  guess is the point: checking against an unloaded namespace would
+  report every symbol head as unresolved and call the view ineligible
+  for a reason that is about the checker, not the code."
+  [ns-sym path]
+  (or (find-ns ns-sym)
+      (throw (ex-info (str "re-frame.freehand check: namespace " ns-sym " (" path
+                           ") is not loaded. Heads are classified by resolution, so "
+                           "load it first — (require '" ns-sym ") — and check again.")
+                      {:file (str path) :ns ns-sym}))))
+
+(defn- declaration-at
+  "The declaration data for a `v/defview` form read out of `path`."
+  [path ns-sym form]
+  (let [[_ vname & more] form
+        {:keys [opts params body]}
+        (or (v/parse-defview-args more)
+            (throw (ex-info (str "re-frame.freehand check: " ns-sym "/" vname " in " path
+                                 " does not match (v/defview name docstring? opts? "
+                                 "[props] body …), so there is no declaration to check.")
+                            {:file (str path) :view vname})))
+        m (meta form)]
+    {:view-id         (keyword (str ns-sym) (str vname))
+     :vname           vname
+     :ns-sym          ns-sym
+     :params          params
+     :body            body
+     :compiled?       (get opts :compiled false)
+     :children-policy (get opts :children-policy :optional)
+     :source          (cond-> {:file (str path)}
+                        (:line m)   (assoc :line (:line m))
+                        (:column m) (assoc :column (:column m)))}))
+
+(defn- read-declarations
+  "Every `v/defview` in the file at `path`, in declaration order, as
+  declaration data.
+
+  The file is opened for READING and read with `*read-eval*` false: a
+  checker is pointed at source an author has not yet decided to compile,
+  and evaluating it to find out whether it compiles would be a strange
+  way to answer the question. Forms are read in the file's own
+  namespace so `::keyword` aliases resolve, and a head counts as
+  `v/defview` when it RESOLVES there — an alias, a `:refer`, or the
+  qualified name all read the same."
+  [path]
+  (with-open [rdr (LineNumberingPushbackReader. (io/reader (io/file path)))]
+    (binding [*read-eval* false]
+      (let [ns-sym (source-namespace (read read-opts rdr) path)
+            ns-obj (live-namespace ns-sym path)]
+        (binding [*ns* ns-obj]
+          (loop [declarations []]
+            (let [form (read read-opts rdr)]
+              (cond
+                (= ::eof form)
+                declarations
+
+                (and (seq? form)
+                     (symbol? (first form))
+                     (= #'v/defview (try (ns-resolve ns-obj (first form))
+                                         (catch Exception _ nil))))
+                (recur (conj declarations (declaration-at path ns-sym form)))
+
+                :else
+                (recur declarations)))))))))
+
+(defn check-file
+  "Check every `v/defview` in the source file at `path` and answer one
+  report per declaration, in declaration order.
+
+  This is the discovery workflow: point it at a namespace and read which
+  of its views are already inside `:re-frame.freehand/v1` and, for the
+  rest, why not and what to do about it. The file is only ever read —
+  see the read-only law in this namespace's docstring.
+
+  The file's namespace must be LOADED, because heads are classified by
+  resolution; a tool driving this from a REPL or a build already has it."
+  [path]
+  (mapv check-declaration (read-declarations path)))
+
+))

--- a/implementation/freehand/test/re_frame/freehand/check_fixture_views.cljc
+++ b/implementation/freehand/test/re_frame/freehand/check_fixture_views.cljc
@@ -1,0 +1,35 @@
+(ns re-frame.freehand.check-fixture-views
+  "A file of ORDINARY interpreted declarations for the checker to read.
+
+  Nothing here is written for the checker's convenience: these are two
+  views an author would write without a thought about compilation, and
+  that is the whole point. The checker's subject is a declaration as it
+  stands BEFORE `{:compiled true}` is added, so the fixture must be a
+  real file on disk that compiles, loads, and renders exactly as it did
+  before anyone thought about the compiled tier — otherwise the suite
+  would be checking a shape invented to be checked.
+
+  `roster` is the D010 cliff in its most ordinary clothing: a helper
+  that returns markup, mapped over a collection. The interpreted walk
+  accepts it without comment; the compiled grammar cannot see through
+  it. `row` is the same page's leaf, and is already inside the grammar.
+
+  Read by `re-frame.freehand.check-jvm-test`, which also asserts this
+  file is byte-identical after a run."
+  (:require [re-frame.freehand :as v]))
+
+(defn person-item
+  "A helper that manufactures markup — a plain `defn`, direct-called."
+  [person]
+  [:li.person (:name person)])
+
+(v/defview row
+  "Inside the grammar: a literal element over declared prop slots."
+  [{:keys [label done?]}]
+  [:li.row {:class {:done done?}} label])
+
+(v/defview roster
+  "Outside the grammar: the markup is manufactured by a helper call."
+  [{:keys [people]}]
+  [:ul.roster
+   (map person-item people)])

--- a/implementation/freehand/test/re_frame/freehand/check_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/check_jvm_test.clj
@@ -1,0 +1,136 @@
+(ns re-frame.freehand.check-jvm-test
+  "The read-only compile checker, proven where it runs: the JVM.
+
+  Three things are asserted, and the first two are asserted WHOLE. A
+  checker whose report was pinned key by key would agree with a report
+  that grew a key nobody decided on, and the report is a tool contract —
+  so the expectations here are complete maps, not `select-keys` of them.
+
+    1. the FH-DIAG-001 conformance table — a declaration in, a whole
+       report out, across the eligible case and six refusals;
+    2. the file workflow — point `check-file` at a real source file and
+       read one whole report per declaration in it;
+    3. read-only — that file is byte-identical after the run.
+
+  Head classification is resolution, so the fixture table's bodies
+  resolve against THIS namespace: `map` and `for` are core here, and
+  `person-item` / `nope-not-a-thing` are nothing at all."
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand.check-fixture-views]
+            [re-frame.freehand.compiler.check :as check]
+            [re-frame.freehand.compiler.grammar :as grammar]
+            [re-frame.freehand.conformance :as conformance]))
+
+;; ---------------------------------------------------------------------------
+;; FH-DIAG-001 — the report, whole, per declaration
+;; ---------------------------------------------------------------------------
+
+(def ^:private diag-001 (conformance/fixture :FH-DIAG-001))
+
+(deftest fh-diag-001-the-checker-report
+  (let [{:keys [params cases]} diag-001]
+    (is (= 7 (count cases)) "the fixture table is populated")
+    (doseq [{:keys [note view-id source compiled? body report]} cases]
+      (testing note
+        (is (= report
+               (check/check-declaration
+                 {:view-id         view-id
+                  :vname           (symbol (name view-id))
+                  :ns-sym          (ns-name *ns*)
+                  :params          params
+                  :body            body
+                  :compiled?       compiled?
+                  :children-policy :optional
+                  :source          source}))
+            (str view-id " — the whole report"))))))
+
+(deftest every-finding-carries-a-usable-ladder
+  (testing "a recovery list is the payload, so it is never empty, always ends
+            in the rung that is always available, and every rung names a
+            sentence in the closed roster"
+    (doseq [{:keys [report]} (:cases diag-001)
+            {:keys [id recovery]} (:findings report)]
+      (is (seq recovery) (str id " offers at least one recovery"))
+      (is (= :keep-interpreted (last recovery))
+          (str id " ends in the rung that is always available"))
+      (doseq [rung recovery]
+        (is (string? (get grammar/recoveries rung))
+            (str id " — " rung " is a rung of the closed roster"))))))
+
+;; ---------------------------------------------------------------------------
+;; The file workflow, and the read-only law
+;; ---------------------------------------------------------------------------
+
+(def ^:private fixture-views-path
+  "The checker's subject: a real file of ordinary interpreted
+  declarations, located through the classpath so no path is written down."
+  (.getPath (io/file (io/resource "re_frame/freehand/check_fixture_views.cljc"))))
+
+(defn- report-for [view-id reports]
+  (first (filter #(= view-id (:view-id %)) reports)))
+
+(deftest check-file-reports-one-view-at-a-time
+  (let [reports (check/check-file fixture-views-path)]
+    (is (= [:re-frame.freehand.check-fixture-views/row
+            :re-frame.freehand.check-fixture-views/roster]
+           (mapv :view-id reports))
+        "one report per declaration, in declaration order, and the plain
+         `defn` helper beside them is not a declaration")
+
+    (testing "a view already inside the grammar is eligible, with nothing to say"
+      (is (= {:view-id           :re-frame.freehand.check-fixture-views/row
+              :source            {:file fixture-views-path :line 26 :column 1}
+              :current-lowering  :interpreted
+              :target-grammar    :re-frame.freehand/v1
+              :compile-eligible? true
+              :findings          []}
+             (report-for :re-frame.freehand.check-fixture-views/row reports))))
+
+    (testing "a view whose markup a helper manufactures is not, and says why
+              and what to do — located at the helper call, not the declaration"
+      (is (= {:view-id           :re-frame.freehand.check-fixture-views/roster
+              :source            {:file fixture-views-path :line 31 :column 1}
+              :current-lowering  :interpreted
+              :target-grammar    :re-frame.freehand/v1
+              :compile-eligible? false
+              :findings          [{:id       :rf.ui.compile/markup-returning-map
+                                   :source   {:line 35 :column 4}
+                                   :form     '(map person-item people)
+                                   :reason   :markup-hidden-from-analyzer
+                                   :recovery [:make-template-visible
+                                              :extract-declared-child
+                                              :keep-interpreted]}]}
+             (report-for :re-frame.freehand.check-fixture-views/roster reports))))))
+
+(deftest the-checker-never-writes
+  (testing "the source it was pointed at is byte-identical after a run —
+            changing the declaration is the author's final step, never the
+            checker's discovery mechanism"
+    (let [before (java.nio.file.Files/readAllBytes (.toPath (io/file fixture-views-path)))
+          _      (check/check-file fixture-views-path)
+          after  (java.nio.file.Files/readAllBytes (.toPath (io/file fixture-views-path)))]
+      (is (pos? (alength before)) "the fixture file is not empty")
+      (is (java.util.Arrays/equals ^bytes before ^bytes after)))))
+
+;; ---------------------------------------------------------------------------
+;; The two ways to be pointed at something that cannot be checked
+;; ---------------------------------------------------------------------------
+
+(deftest a-file-that-cannot-be-checked-says-so
+  (testing "no (ns …) form means no namespace to resolve heads against"
+    (let [tmp (java.io.File/createTempFile "fh-check" ".cljc")]
+      (try
+        (spit tmp "(def x 1)\n")
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"does not begin with an \(ns"
+                              (check/check-file (.getPath tmp))))
+        (finally (.delete tmp)))))
+
+  (testing "an unloaded namespace is refused rather than reported as a wall of
+            unresolved heads — the failure would be about the checker"
+    (let [tmp (java.io.File/createTempFile "fh-check" ".cljc")]
+      (try
+        (spit tmp "(ns re-frame.freehand.check-no-such-namespace)\n")
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"is not loaded"
+                              (check/check-file (.getPath tmp))))
+        (finally (.delete tmp))))))

--- a/implementation/freehand/test/re_frame/freehand/check_report_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/check_report_cljs_test.cljc
@@ -1,0 +1,97 @@
+(ns re-frame.freehand.check-report-cljs-test
+  "The checker's REPORT VOCABULARY, on both hosts.
+
+  The analysis is JVM-only — head classification is resolution, and
+  resolution happens on the JVM for both compilation targets. The
+  vocabulary a report is written in is not: a ClojureScript tool that
+  receives a report over the wire has to render `:reason` and turn a
+  `:recovery` ladder into sentences, and it must do so from the same
+  rosters the JVM wrote the report with. So this suite runs on both
+  hosts and pins the parts that are shared — which is also how a
+  `.cljc` claim stops being a claim.
+
+  `re-frame.freehand.check-jvm-test` proves the analysis itself."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand.compiler.check :as check]
+            [re-frame.freehand.compiler.grammar :as grammar]))
+
+(deftest reasons-are-a-closed-unqualified-roster
+  (testing "a reason names a KIND of defect, not a second id — so it is a
+            plain keyword outside the framework's reserved :rf.* scheme,
+            and several ids may share one"
+    (doseq [[id reason] check/reasons]
+      (is (qualified-keyword? id) (str id " is a diagnostic id"))
+      (is (simple-keyword? reason) (str id " -> " reason " is unqualified")))
+    (is (contains? (set (vals check/reasons)) :markup-hidden-from-analyzer)
+        "the D010 cliff keeps the name D010 gave it")
+    (is (< (count (set (vals check/reasons))) (count check/reasons))
+        "reasons GROUP ids; a one-to-one table would just be the ids again")))
+
+(deftest reason-is-total
+  (is (= :markup-hidden-from-analyzer
+         (check/reason :rf.ui.compile/markup-returning-map)))
+  (testing "an id nobody has categorised still answers — a new analyzer
+            diagnostic must not become a tool outage"
+    (is (= check/unclassified-reason (check/reason :rf.ui.compile/not-yet-invented))
+        "and the honest general statement is the fallback")))
+
+(deftest every-catalogued-id-offers-a-ladder
+  (doseq [id (keys check/reasons)]
+    (let [ladder (grammar/recovery id)]
+      (is (seq ladder) (str id " offers at least one recovery"))
+      (is (= :keep-interpreted (last ladder))
+          (str id " ends in the rung that is always available"))
+      (doseq [rung ladder]
+        (is (string? (get grammar/recoveries rung))
+            (str id " — " rung " is a rung of the closed roster"))))))
+
+(deftest a-finding-is-five-fields
+  (is (= {:id       :rf.ui.compile/markup-returning-map
+          :source   {:line 47 :column 5}
+          :form     '(render-person person)
+          :reason   :markup-hidden-from-analyzer
+          :recovery [:make-template-visible
+                     :extract-declared-child
+                     :keep-interpreted]}
+         (check/finding :rf.ui.compile/markup-returning-map
+                        '(render-person person)
+                        {:line 47 :column 5}))
+      "the id, where, what, why, and the ladder — and nothing else; a
+       message would be stable in meaning and never in bytes"))
+
+(deftest a-report-derives-its-own-eligibility
+  (let [source {:file "src/app/people.cljc" :line 42 :column 1}]
+    (testing "no findings is what eligible MEANS"
+      (is (= {:view-id           :app.people/people-list
+              :source            source
+              :current-lowering  :interpreted
+              :target-grammar    :re-frame.freehand/v1
+              :compile-eligible? true
+              :findings          []}
+             (check/report {:view-id  :app.people/people-list
+                            :source   source
+                            :lowering :interpreted
+                            :findings nil}))))
+
+    (testing "a report cannot claim eligibility while carrying a reason it is not"
+      (let [finding (check/finding :rf.ui.compile/markup-returning-map
+                                   '(render-person person)
+                                   {:line 47 :column 5})]
+        (is (= {:view-id           :app.people/people-list
+                :source            source
+                :current-lowering  :interpreted
+                :target-grammar    :re-frame.freehand/v1
+                :compile-eligible? false
+                :findings          [finding]}
+               (check/report {:view-id  :app.people/people-list
+                              :source   source
+                              :lowering :interpreted
+                              :findings [finding]})))))
+
+    (testing "the grammar checked against is the report's own field, never
+              something a caller supplies"
+      (is (= grammar/version
+             (:target-grammar (check/report {:view-id  :app/x
+                                             :source   source
+                                             :lowering :compiled
+                                             :findings []})))))))

--- a/spec/004D-Freehand-Compiled-Grammar.md
+++ b/spec/004D-Freehand-Compiled-Grammar.md
@@ -28,10 +28,12 @@
 > emitter and the host-neutral normalizers they share are **owned by Freehand**
 > and live in the Freehand artifact: `re-frame.freehand.compiler` and its
 > `analyze` / `emit-cljs` / `emit-jvm` / `env` / `grammar` / `header` /
-> `binding-plan` / `a11y` / `build` / `build-hook` / `harvest` / `root`
+> `binding-plan` / `a11y` / `build` / `build-hook` / `harvest` / `root` /
+> `check`
 > namespaces, over `re-frame.freehand.rules`, `re-frame.freehand.fingerprint`
 > and `re-frame.freehand.eq`. `grammar` owns the version keyword, the admitted
-> node-kind roster and the recovery roster; `re-frame.freehand.node` — which
+> node-kind roster and the recovery roster; `check` is the analyzer's
+> read-only face (§The read-only checker); `re-frame.freehand.node` — which
 > sits below the public door, not inside the compiler — owns the canonical
 > structural builders BOTH modes construct nodes through.
 > The two emitters remain **separate implementations**
@@ -1512,6 +1514,146 @@ rather than fabricating them (`tools/xray/spec/021` §3.4.1).
   the compiled substrate emits its own versioned evidence schema (integer render-key +
   separate `:view-id` + `occurrence-path`) in the 009 catalogue. (Helix was removed at
   S7/W13 — rf2-d6epb, 2026-07-22.)
+
+## The read-only checker
+
+`{:compiled true}` is a one-line change, which makes it a tempting thing to try
+and see. Trying and seeing is a poor way to learn a finite language. The build
+stops at the first form outside the grammar, so an author who reached that
+failure by editing has already changed the declaration in order to find out
+whether the change was available — and if the answer is no, the edit and its
+diff have to be unwound before anything else can be learned.
+
+The order is therefore inverted. The **checker** runs the same analyzer the
+build runs, against the declaration as it stands *today* — normally an
+interpreted one, before the marker has been added anywhere — and answers in
+data:
+
+```clojure
+{:view-id           :app.people/people-list
+ :source            {:file "src/app/people.cljc" :line 42 :column 1}
+ :current-lowering  :interpreted
+ :target-grammar    :re-frame.freehand/v1
+ :compile-eligible? false
+ :findings          [{:id       :rf.ui.compile/markup-returning-map
+                      :source   {:line 47 :column 5}
+                      :form     (map person-item people)
+                      :reason   :markup-hidden-from-analyzer
+                      :recovery [:make-template-visible
+                                 :extract-declared-child
+                                 :keep-interpreted]}]}
+```
+
+Changing the declaration is then the **final** step, and not the discovery
+mechanism.
+
+### Three laws
+
+**It never writes.** No source is opened for writing, no emitter runs, no
+registry is contributed to, and nothing is printed. Read-only is a property to
+be *proved*, not asserted — the source a run was pointed at is byte-identical
+afterwards. A checker that edited source would make its own advice
+unfalsifiable, and one that emitted code would have stopped answering a
+question about the declaration in front of you.
+
+**It never recommends.** There is no percentage, no ratio, and no "compile the
+hot 5%" heuristic — a promotion recommender is an explicit
+[EP-0036](../docs/EP/EP-0036-the-freehand-view-substrate-programme.md) non-goal.
+Eligibility is a property of the body and the checker answers it. Whether
+compiling an eligible view is *worth* it is a measurement and a judgement, and
+the checker is not entitled to either.
+
+**It invents no diagnostics.** Findings carry the analyzer's OWN ids and the
+recovery ladders `grammar` already serves the build — one roster with two
+consumers, so a build failure and a checker finding cannot drift into
+disagreeing about the same form. A checker with its own id set would be a
+second grammar.
+
+### The report
+
+One report per declaration, six fields, all of them always present:
+
+| Field | Contract |
+|---|---|
+| `:view-id` | the id the declaration registers under — the same one the descriptor, the manifest and the trace surface use |
+| `:source` | `{:file :line :column}` of the declaration |
+| `:current-lowering` | `:interpreted` or `:compiled` — what the declaration says **today**, never a suggestion |
+| `:target-grammar` | the version keyword it was checked against, so a report read later says which language answered |
+| `:compile-eligible?` | exactly "no findings"; it is derived, so a report cannot claim eligibility while carrying a reason it is not |
+| `:findings` | a vector, empty when eligible |
+
+A declaration that already carries `{:compiled true}` is checked the same way
+and reports `:current-lowering :compiled` — "is this still eligible?" is the
+same question, and it is the one asked when a body is edited.
+
+### The finding
+
+| Field | Contract |
+|---|---|
+| `:id` | the analyzer's stable diagnostic id, and the sole machine discriminator |
+| `:source` | `{:line :column}` of the offending form when the reader anchored it, else the declaration's — a finding always carries a position, and the narrowest true one available |
+| `:form` | the offending form, as read; when a diagnostic names no narrower form, the template |
+| `:reason` | an unqualified keyword naming the KIND of defect |
+| `:recovery` | the ladder, most specific first |
+
+`:reason` is not a second id. Ids are what a tool branches on; reasons group
+several ids into the handful of categories an author reasons in — the markup is
+hidden from the analyzer, the head is a runtime value, the reactive site is not
+finite — so ids sharing a reason is the normal case and the roster is
+deliberately smaller than the id roster. It is a projection the checker makes
+for readers, and nothing emits it at runtime.
+
+**The recovery list is the payload, not decoration.** `:id` says which rule
+stopped you and `:reason` says what kind of thing went wrong, but `:recovery`
+is the ordered list of things that can be done to the source in front of you,
+drawn from the closed roster §The finite grammar and its rejections pins —
+whose entries carry the sentence a tool renders. Its last rung is always
+`:keep-interpreted`, because declining to compile is a first-class answer: the
+interpreted mode has no finite grammar, so every body the compiler refuses is a
+body that already runs.
+
+### One refusal at a time
+
+The analyzer is fail-fast — it refuses at the first form outside the grammar,
+which is exactly where the build would stop — so a refused declaration reports
+one finding and an eligible one reports none. Re-run after taking a rung. The
+ladder is walked a step at a time by construction, and the checker is not
+rationing what it knows: there is no second, more forgiving analysis whose
+findings it could have reported and chose not to.
+
+The discovery unit is therefore the **file**, not the view. Pointing the
+checker at a namespace answers one report per declaration in it, in declaration
+order, which is the question an author or an agent actually has — *which of
+these views are already inside the grammar, and for the rest, why not*.
+
+### Where the checker runs
+
+The **analysis is JVM-only**, for the same reason the rest of the compile front
+end is: head classification is resolution, and resolution happens on the JVM
+for both compilation targets. It follows that the file's namespace must be
+**loaded** — which a REPL or a build driving the checker already has. An
+unloaded namespace is refused loudly rather than reported as a wall of
+unresolved heads, because that failure would be about the checker rather than
+about the code.
+
+The **report vocabulary** — the reason roster, the recovery roster, and the
+report and finding shapes — is host-neutral, so a ClojureScript tool can render
+a report it received over the wire without a second copy of the vocabulary to
+drift.
+
+### Finding ids carry no catalogue row
+
+Checker findings are compile-tier diagnostics: they are produced by static
+analysis and nothing is emitted at runtime, so — exactly as with
+§Compile-tier warnings — they carry no [009](009-Instrumentation.md) error
+catalogue row, per the `:rf.ui.compile/*` reservation in
+[Conventions](Conventions.md#the-single-root-reserved-set). The checker mints
+no id of its own, so it adds nothing to catalogue either way. What 009 owns
+here is the *tool* contract — the report is a stable surface tools consume, and
+[009 §The compile checker report](009-Instrumentation.md#the-compile-checker-report)
+records where its ids come from.
+
+Conformance: `FH-DIAG-001`.
 
 ## The JVM structural subset
 

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -1567,6 +1567,23 @@ External tools consume re-frame2 through stable surfaces. Production builds elid
 - Snapshot state, modify, restore.
 - Read state in any frame; `frame-ids` enumerates them.
 
+### The compile checker report
+
+Not every stable surface a tool consumes is a runtime one. Freehand's **compile checker** analyses a view declaration read-only, before the compiled tier has been selected for it, and answers stable EDN carrying the view id, its source coordinates, its current lowering, the grammar version it was checked against, whether it is eligible, and — when it is not — findings each carrying a stable id, coordinates, the offending form, a reason, and a recovery ladder. The shape and its laws are owned by [004D §The read-only checker](004D-Freehand-Compiled-Grammar.md#the-read-only-checker); what this Spec records is where the ids in it come from, because "stable ids/source/recovery" is a diagnostics obligation and a tool author reading this catalogue is entitled to an answer rather than a silence.
+
+**The checker mints no ids.** A finding carries the *analyzer's own* `:rf.ui.compile/<kebab-id>` — the id the build would fail with on the same form — and the recovery ladder the compiler already serves. One roster with two consumers: a checker with a parallel id set would be a second grammar to drift, and a finding that disagreed with the build failure for the same form would be worse than no finding.
+
+**Those ids carry no error-catalogue row, by construction rather than by exception.** `:rf.ui.compile/*` is reserved in [Conventions](Conventions.md#the-single-root-reserved-set) as a *compile-time only* namespace: every id in it is raised at macroexpansion, nothing in it is ever emitted at runtime, and none of it is a trace event. The error/warning catalogue below is a contract about runtime-emitted events, so a compile-tier id has nothing to be catalogued *as* — the same reason [004D §Compile-tier warnings](004D-Freehand-Compiled-Grammar.md#compile-tier-warnings) gives for the warning roster. Because the checker adds no id, it adds no catalogue obligation either.
+
+| Surface | Stability |
+|---|---|
+| The report's six fields (`:view-id`, `:source`, `:current-lowering`, `:target-grammar`, `:compile-eligible?`, `:findings`) | Preserved |
+| The finding's five fields (`:id`, `:source`, `:form`, `:reason`, `:recovery`) | Preserved |
+| Finding ids | The analyzer's `:rf.ui.compile/*` roster; new values additive |
+| `:reason` | A closed roster of unqualified keywords; several ids may share one; new values additive |
+| `:recovery` | A closed roster, ordered most specific first, always ending in `:keep-interpreted` |
+| `:target-grammar` | The version keyword the body was checked against — a report read later says which language answered |
+
 ## JVM vs. CLJS scope
 
 All trace functionality is **dev-build only** — production builds elide the entire trace surface on both platforms.

--- a/spec/conformance/freehand/conformance-index.md
+++ b/spec/conformance/freehand/conformance-index.md
@@ -163,3 +163,4 @@ provable-only static findings.
 
 | Id | Law | Canonical paragraph | Applicability | Fixture | Status |
 |---|---|---|---|---|---|
+| `FH-DIAG-001` | The checker analyses a declaration read-only against the versioned grammar and answers a stable report — view id, source, current lowering, target grammar, eligibility, and findings each carrying a stable id, source coordinates, the offending form, a reason, and a non-empty recovery ladder ending in `:keep-interpreted` | [004D-Freehand-Compiled-Grammar.md#the-read-only-checker](../../004D-Freehand-Compiled-Grammar.md#the-read-only-checker) | compiled jvm | `spec/conformance/freehand/fixtures/fh-diag-001.edn` | active |

--- a/spec/conformance/freehand/fixtures/fh-diag-001.edn
+++ b/spec/conformance/freehand/fixtures/fh-diag-001.edn
@@ -1,0 +1,149 @@
+;; FH-DIAG-001 — the read-only checker's report.
+;;
+;; Discovery before commitment. The checker runs the compiled tier's own
+;; analyzer against a declaration as it stands TODAY — normally an
+;; interpreted one, before `{:compiled true}` has been added — and
+;; answers stable data: which view, where, what lowering it carries now,
+;; which grammar it was checked against, whether it is eligible, and, if
+;; not, findings carrying a stable id, coordinates, the offending form, a
+;; reason, and a recovery ladder whose last rung is always
+;; `:keep-interpreted`.
+;;
+;; `:cases` are `{:view-id :source :compiled? :params :body :report}` and
+;; the expected `:report` is written LITERALLY, every key included: a
+;; fixture that pinned only the keys a report happens to carry would
+;; agree with a report that carried extra ones.
+;;
+;; The suite supplies `:ns-sym` — its OWN namespace — because head
+;; classification is resolution, and derives `:vname` from the view id.
+;; The bodies below therefore resolve `map` and `for` as core, and
+;; `person-item` / `nope-not-a-thing` as nothing at all, which is what
+;; the last row is about.
+;;
+;; Forms read out of EDN carry no reader coordinates, so every finding
+;; here inherits its declaration's `:line` / `:column`. That fallback is
+;; the law's own rule, not an artefact of the fixture: a finding always
+;; carries a position, and the narrowest true one available.
+{:fh/id "FH-DIAG-001"
+ :fh/law
+ "The checker analyses a declaration read-only against the versioned grammar and answers a stable report — view id, source, current lowering, target grammar, eligibility, and findings each carrying a stable id, source coordinates, the offending form, a reason, and a non-empty recovery ladder ending in :keep-interpreted."
+
+ :params [{:keys [items label tag done?]}]
+
+ :cases
+ [{:note      "a literal element over declared prop slots is inside the grammar"
+   :view-id   :fh.diag/todo-row
+   :source    {:file "fh-diag-001.edn" :line 40 :column 1}
+   :compiled? false
+   :body      [[:li.row {:class {:done done?}} label]]
+   :report    {:view-id           :fh.diag/todo-row
+               :source            {:file "fh-diag-001.edn" :line 40 :column 1}
+               :current-lowering  :interpreted
+               :target-grammar    :re-frame.freehand/v1
+               :compile-eligible? true
+               :findings          []}}
+
+  {:note      "markup manufactured by a helper the analyzer cannot see through — the D010 cliff"
+   :view-id   :fh.diag/roster
+   :source    {:file "fh-diag-001.edn" :line 50 :column 1}
+   :compiled? false
+   :body      [[:ul (map person-item items)]]
+   :report    {:view-id           :fh.diag/roster
+               :source            {:file "fh-diag-001.edn" :line 50 :column 1}
+               :current-lowering  :interpreted
+               :target-grammar    :re-frame.freehand/v1
+               :compile-eligible? false
+               :findings          [{:id       :rf.ui.compile/markup-returning-map
+                                    :source   {:line 50 :column 1}
+                                    :form     (map person-item items)
+                                    :reason   :markup-hidden-from-analyzer
+                                    :recovery [:make-template-visible
+                                               :extract-declared-child
+                                               :keep-interpreted]}]}}
+
+  {:note      "a head computed at runtime, in a declaration that ALREADY says {:compiled true}"
+   :view-id   :fh.diag/wrapper
+   :source    {:file "fh-diag-001.edn" :line 60 :column 1}
+   :compiled? true
+   :body      [[tag {:class "x"} label]]
+   :report    {:view-id           :fh.diag/wrapper
+               :source            {:file "fh-diag-001.edn" :line 60 :column 1}
+               :current-lowering  :compiled
+               :target-grammar    :re-frame.freehand/v1
+               :compile-eligible? false
+               :findings          [{:id       :rf.ui.compile/dynamic-head
+                                    :source   {:line 60 :column 1}
+                                    :form     [tag {:class "x"} label]
+                                    :reason   :head-is-a-runtime-value
+                                    :recovery [:use-a-literal-head
+                                               :extract-declared-child
+                                               :keep-interpreted]}]}}
+
+  {:note      "a list whose rows carry no key"
+   :view-id   :fh.diag/plain-list
+   :source    {:file "fh-diag-001.edn" :line 70 :column 1}
+   :compiled? false
+   :body      [[:ul (for [i items] [:li i])]]
+   :report    {:view-id           :fh.diag/plain-list
+               :source            {:file "fh-diag-001.edn" :line 70 :column 1}
+               :current-lowering  :interpreted
+               :target-grammar    :re-frame.freehand/v1
+               :compile-eligible? false
+               :findings          [{:id       :rf.ui.compile/unkeyed-list-item
+                                    :source   {:line 70 :column 1}
+                                    :form     (for [i items] [:li i])
+                                    :reason   :list-row-carries-no-key
+                                    :recovery [:key-each-row
+                                               :extract-declared-child
+                                               :keep-interpreted]}]}}
+
+  {:note      "a keyword in content position"
+   :view-id   :fh.diag/labelled
+   :source    {:file "fh-diag-001.edn" :line 80 :column 1}
+   :compiled? false
+   :body      [[:div :label]]
+   :report    {:view-id           :fh.diag/labelled
+               :source            {:file "fh-diag-001.edn" :line 80 :column 1}
+               :current-lowering  :interpreted
+               :target-grammar    :re-frame.freehand/v1
+               :compile-eligible? false
+               :findings          [{:id       :rf.ui.compile/keyword-child
+                                    :source   {:line 80 :column 1}
+                                    :form     :label
+                                    :reason   :keyword-in-content-position
+                                    :recovery [:pass-computed-value
+                                               :keep-interpreted]}]}}
+
+  {:note      "children under a void element"
+   :view-id   :fh.diag/rule
+   :source    {:file "fh-diag-001.edn" :line 90 :column 1}
+   :compiled? false
+   :body      [[:div [:br label]]]
+   :report    {:view-id           :fh.diag/rule
+               :source            {:file "fh-diag-001.edn" :line 90 :column 1}
+               :current-lowering  :interpreted
+               :target-grammar    :re-frame.freehand/v1
+               :compile-eligible? false
+               :findings          [{:id       :rf.ui.compile/void-children
+                                    :source   {:line 90 :column 1}
+                                    :form     [:br label]
+                                    :reason   :void-element-carries-children
+                                    :recovery [:pass-computed-value
+                                               :keep-interpreted]}]}}
+
+  {:note      "a head that resolves to nothing — the diagnostic names no form, so the finding falls back to the template"
+   :view-id   :fh.diag/mystery
+   :source    {:file "fh-diag-001.edn" :line 100 :column 1}
+   :compiled? false
+   :body      [[:div [nope-not-a-thing {}]]]
+   :report    {:view-id           :fh.diag/mystery
+               :source            {:file "fh-diag-001.edn" :line 100 :column 1}
+               :current-lowering  :interpreted
+               :target-grammar    :re-frame.freehand/v1
+               :compile-eligible? false
+               :findings          [{:id       :rf.ui.compile/unresolved-head
+                                    :source   {:line 100 :column 1}
+                                    :form     [:div [nope-not-a-thing {}]]
+                                    :reason   :head-does-not-resolve
+                                    :recovery [:use-a-literal-head
+                                               :keep-interpreted]}]}}]}


### PR DESCRIPTION
Implements rf2-drpa3.29 — F3e, the checker that makes compilation a discovery workflow rather than a guess.

`re-frame.freehand.compiler.check` runs the compiled tier's **own** analyzer, read-only, against a declaration as it stands today — normally an interpreted one, before `{:compiled true}` has been added anywhere — and answers stable EDN in the shape `docs/design/freehand/codex-design.md` §Checker-first workflow gives:

```clojure
{:view-id           :app.people/people-list
 :source            {:file "src/app/people.cljc" :line 42 :column 1}
 :current-lowering  :interpreted
 :target-grammar    :re-frame.freehand/v1
 :compile-eligible? false
 :findings          [{:id       :rf.ui.compile/markup-returning-map
                      :source   {:line 47 :column 5}
                      :form     (map person-item people)
                      :reason   :markup-hidden-from-analyzer
                      :recovery [:make-template-visible
                                 :extract-declared-child
                                 :keep-interpreted]}]}
```

Two entries: `check-declaration` (the one-declaration primitive) and `check-file` (the workflow — one report per `v/defview` in a file, in declaration order, which is the question an author or an agent actually has: *which of these views are already inside the grammar, and for the rest, why not*).

### Three laws

- **It never writes.** No source is opened for writing, no emitter runs, no registry is contributed to, nothing is printed. Proved, not asserted (acceptance 3 below).
- **It never recommends.** No percentage, no ratio, no "hot 5%" — an explicit EP-0036 non-goal. Eligibility is a property of the body; whether compiling it is *worth* it is a measurement and a judgement, and neither is the checker's.
- **It invents no diagnostics.** Findings carry the analyzer's own `:rf.ui.compile/*` ids and the `grammar/recovery` ladders that already serve the build. One roster, two consumers — a build failure and a checker finding cannot drift into disagreeing about the same form.

The recovery list is the payload. `:id` says which rule stopped you, `:reason` says what kind of thing went wrong, and `:recovery` is the ordered ladder of things you can do to the source in front of you, drawn from the closed `grammar/recoveries` roster whose values are the sentences a tool renders. Last rung is always `:keep-interpreted`.

### Diagnostic-id channel — chosen deliberately

**No new ids are minted, so the question of channel does not arise, and the three-way ALWAYS-ON co-edit does not apply.** Findings carry the analyzer's existing compile-tier ids. `:rf.ui.compile/*` is reserved in `spec/Conventions.md` as compile-time only — raised at macroexpansion, never emitted at runtime, never a trace — so it carries no Spec 009 error-catalogue row *by construction rather than by exception*, exactly as 004D §Compile-tier warnings already says for the warning roster. Minting a parallel checker id set would have been the drift hazard the third law exists to prevent.

What 009 gains instead is the **tool** contract: a new §The compile checker report recording where the ids come from and why they are not in the error catalogue, plus a stability table for the report's six fields and the finding's five. A tool author reading that catalogue and asking "where are the checker's finding ids?" now gets an answer rather than a silence.

### Hosts — stated and proved on each

- **Analysis: JVM only.** Head classification is resolution, and resolution happens on the JVM for both compilation targets — the same reason `re-frame.freehand.compiler` is JVM-only. Proved by `re-frame.freehand.check-jvm-test` (`clojure -M:test`).
- **Report vocabulary: host-neutral,** so a ClojureScript tool can render a report it received over the wire without a second copy of the roster to drift. Proved on **both** hosts by `re-frame.freehand.check-report-cljs-test` (a `.cljc` suite that runs under `clojure -M:test` *and* `npm run test:freehand`) — reason totality, roster closure, and the finding/report shapes.

A `.cljc` claim green on one host would be a gap, so the split is real: everything under `#?(:clj …)` is proved by the JVM suite, everything above it by the cross-host suite. No `identical?`-against-a-keyword sentinel anywhere.

### Conformance

`FH-DIAG-001` — the DIAG area's first row, with `spec/conformance/freehand/fixtures/fh-diag-001.edn` as its fixture. Seven cases: the eligible declaration plus six refusals spanning six reasons, each pinning the **whole** report map. The `FH-DIAG` section of the index was empty; F6a needs it populated.

### Donor ledger

No ledger change. The donor has no checker to move (`implementation/ui/src/re_frame/ui/compiler/` has no such namespace) — this is new Freehand-owned code over the already-moved analyzer. The F3 label row *"analyzer, both emitters, ViewCell reactor, manifest/elision, diagnostic taxonomy, structural test surface"* stays `pending` because it still covers the ViewCell reactor and manifest/elision, which have not landed. `check_donor_inventory.py` is green.

### Shared-file fence

`spec/004D` is touched in **two hunks only** — one line in the preamble's namespace roster, and one contiguous new `## The read-only checker` section inserted immediately before `## The JVM structural subset`, deliberately far from the crossings/`v/markup` region the parallel F3c worker is editing (their diff sits at ~line 201). Nothing else in the file is reformatted, reordered or re-flowed. `spec/006` untouched; `freehand.cljc` / `cell.cljc` / `shell.cljs` / `events.cljc` / `conversion.cljc` / `react.cljs` / `tree.cljc` untouched.

## Quality gates

All run in the foreground, to completion, on `worker/freehand-f3e-checker-drpa3-29` rebased on `origin/main` (post-rebase counts below).

| Gate | Result |
|---|---|
| `cd implementation/freehand && clojure -M:test` | **Ran 377 tests containing 2348 assertions. 0 failures, 0 errors.** (pre-rebase baseline: 361 / 2221) |
| `npm run test:freehand` | **Ran 262 tests containing 1740 assertions. 0 failures, 0 errors.** (pre-rebase baseline: 251 / 1628) |
| `npm run test:cljs` | **Ran 10383 tests containing 51820 assertions. 0 failures, 0 errors.** (pre-rebase baseline: 10372 / 51706) |
| `npm run test:browser` | **Ran 488 tests containing 2812 assertions. 0 failures, 0 errors.** (the previously-red gate — now green on the race-fixed main) |
| `python scripts/check_keyword_catalogue_drift.py` | exit 0 |
| `python scripts/check_freehand_conformance_index.py` | exit 0 |
| `python scripts/check_donor_inventory.py` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `python -m mkdocs build --strict` | exit 0 — `Documentation built in 32.33 seconds` |

### Rebase

Rebased onto `origin/main` (`d8331678c6`). Main had moved a lot since the branch opened — the descriptor/facade cluster and the emitter-fix branch both landed — but the rebase replayed both commits with **zero conflicts**, and the checker's semantic preconditions all survived:

- The CI red (`IllegalStateException: Attempting to call unbound fn: #'shadow.resource/slurp-resource` in the browser gate) was never this branch's defect — it was a latent race in `requiring-resolve` on main, now fixed there behind a `delay` (#6705). `npm run test:browser` is green post-rebase, confirming the fix cleared it with no branch change.
- `v/parse-defview-args` — read by `check-file` via `declaration-at` — was deliberately KEPT on the public door by the descriptor cluster (it calls into the compiler, so it stays above the descriptor layer). The reader still resolves; verified against `origin/main`'s `freehand.cljc`.
- The new strict `defview` option-key validation (accepted roster `#{:children-policy :compiled}`) does not touch the checker's fixtures: `check_fixture_views.cljc`'s `row`/`roster` declare no options map, so nothing is rejected.
- `spec/004D` landed in its two original hunks (namespace-roster line + the `## The read-only checker` section before `## The JVM structural subset`); main did not touch the file, and the parallel F3c crossings sections were left alone.
- `implementation/freehand/deps.edn` changed on main comment-only; no interaction.

The checker still drives the analyzer directly (never `compile-structural-view`), mints no new diagnostic ids, is fail-fast one-finding-per-run, and reports one whole map per `v/defview` in declaration order — all re-proved by the green suites above.

**Non-vacuity probes** — one per new test file, each inverted, the FULL gate re-run, the failure confirmed to name the test, then restored and re-run green:

- `check_report_cljs_test.cljc` → `npm run test:freehand`: `FAIL in (reason-is-total) (re_frame/freehand/check_report_cljs_test.cljc:31:7)`, 1 failure. Restored → 0 failures.
- `check_jvm_test.clj` → `clojure -M:test`: `FAIL in (the-checker-never-writes) (check_jvm_test.clj:114)`, 1 failure. Restored → 0 failures.
- `check_freehand_conformance_index.py` → citation anchor perturbed: `BROKEN CITATION … has no anchor #the-read-only-checker-PROBE`, exit 1. Restored → exit 0. (This is also the proof that the new 004D anchor resolves.)

Worktree guard, run from the intended checkout before editing: `WORKTREE_ROOT=/c/Users/miket/code/re-frame2-worktrees/freehand-f3e-checker`, `BRANCH=worker/freehand-f3e-checker-drpa3-29`, `OK: worker worktree guard passed.`

### Acceptance, item by item

**1. An INELIGIBLE view returns the documented EDN shape including at least one finding with a non-empty recovery list — the full map, not a subset.**

`check-file-reports-one-view-at-a-time` in `check_jvm_test.clj` asserts the whole map with `=`:

```clojure
{:view-id           :re-frame.freehand.check-fixture-views/roster
 :source            {:file fixture-views-path :line 31 :column 1}
 :current-lowering  :interpreted
 :target-grammar    :re-frame.freehand/v1
 :compile-eligible? false
 :findings          [{:id       :rf.ui.compile/markup-returning-map
                      :source   {:line 35 :column 4}
                      :form     '(map person-item people)
                      :reason   :markup-hidden-from-analyzer
                      :recovery [:make-template-visible
                                 :extract-declared-child
                                 :keep-interpreted]}]}
```

The finding locates itself at the **helper call** (line 35), not at the declaration (line 31) — coordinates that are worth having. `FH-DIAG-001` asserts six more whole reports across six reasons, and `every-finding-carries-a-usable-ladder` proves each ladder is non-empty, ends in `:keep-interpreted`, and names only rungs the closed roster carries a sentence for.

**2. An ELIGIBLE view returns `:compile-eligible? true` with zero findings.**

Same test, same file, asserted whole:

```clojure
{:view-id           :re-frame.freehand.check-fixture-views/row
 :source            {:file fixture-views-path :line 26 :column 1}
 :current-lowering  :interpreted
 :target-grammar    :re-frame.freehand/v1
 :compile-eligible? true
 :findings          []}
```

`:compile-eligible?` is *derived* from `:findings` in `check/report` rather than passed in, so a report cannot claim eligibility while carrying a reason it is not. Case 1 of `FH-DIAG-001` pins the same law through the declaration primitive, and `a-report-derives-its-own-eligibility` pins it on both hosts.

**3. It is genuinely READ-ONLY — the source file is byte-identical after a run.**

`the-checker-never-writes` reads the fixture file's bytes with `Files/readAllBytes`, runs `check-file` over it, re-reads, and asserts `Arrays/equals` — plus `(pos? (alength before))`, so an empty read cannot pass vacuously. The subject is a real tracked source file (`check_fixture_views.cljc` — two ordinary interpreted declarations and a plain `defn` helper), located through the classpath so no path is written down. Inverting that assertion is the non-vacuity probe above.

**4. Finding ids are catalogued in `spec/009-Instrumentation.md` and the keyword-catalogue drift gate passes.**

`spec/009` gains §The compile checker report: the report and finding field contracts, the provenance of the ids (the analyzer's `:rf.ui.compile/*` roster, minted by the analyzer and not by the checker), and the reason they carry no error-catalogue row — `:rf.ui.compile/*` is reserved compile-time-only in Conventions, so nothing in it is ever emitted at runtime and the runtime error catalogue has nothing to catalogue it *as*. `python scripts/check_keyword_catalogue_drift.py` exits 0: CHECK A sees no new `:rf.error/*` / `:rf.warning/*` literal, and CHECK B is satisfied because `:rf.ui.compile/*` is already glob-reserved. No always-on id, so no three-way co-edit and no `implementation/core` conformance-exercise literal was needed.

Closes rf2-drpa3.29.

