### PR TITLE
docs(freehand): promote the draft guide into the design record (rf2-xczm2)

### DIFF
--- a/docs/design/freehand/README.md
+++ b/docs/design/freehand/README.md
@@ -12,6 +12,7 @@ built by absorbing the useful `re-frame.ui` machinery.
 | [`fable-design.md`](fable-design.md) | argued dossier: worked code, corpus fitness, semantic traces, alternatives, wounds, and pre-mortems |
 | [`studio/fitness-harness.md`](studio/fitness-harness.md) | evidence and acceptance pressure from applications, re-com, and hard browser cases |
 | [`decisions/`](decisions/README.md) | D001–D021, each with its explicit ratified ruling and rationale |
+| [`draft-guide/`](draft-guide/README.md) | a DRAFT end-user guide, not the shipped guide — the operator's working draft, promoted here for durability and used as the base for the guide-authoring work |
 
 ## Authority
 

--- a/docs/design/freehand/draft-guide/README.md
+++ b/docs/design/freehand/draft-guide/README.md
@@ -1,0 +1,170 @@
+# Freehand user guide (draft)
+
+This is a proposed end-user guide for **Freehand** (`re-frame.freehand`, alias
+`v`). It is derived from the ratified design in `docs/design/freehand/` and
+shaped after the existing `docs/core/re-frame.ui/` guide.
+
+**Voice:** friendly senior developer — simple and direct, tight but not terse.
+Full sentences; a short *why* after instructions; progressive depth. Not a
+telegram dump, not a marketing essay. Would it sound natural at 11pm?
+
+**Authoring standard:** when this graduates into `docs/`, follow
+[`docs/core/AUTHORING.md`](../../../core/AUTHORING.md) — one job per page,
+reader-first order (goal → code → why), day-one stop before depth, unhappy-path
+tables, “when not,” no page chrome navigation, no reader-facing `spec/` links.
+
+## Status
+
+| Item | State |
+|---|---|
+| Source of truth | Product spine + D001–D021 (design record) |
+| Implementation | Incomplete — guide is aspirational |
+| Published mkdocs | Not wired; lives under `ai/findings/` as a working draft |
+| Audience | App authors, library authors, AI assistants writing Freehand views |
+
+## Suggested mkdocs nav (sections)
+
+When this graduates into `docs/`, use sectioned navigation — not a flat peer list:
+
+```text
+Start here
+  index.md
+  mental-model.md
+  vs-reagent.md          # optional; Reagent habits
+  install.md             # target boot / require / status table
+  build-a-view.md
+
+Everyday authoring
+  reactivity-and-ownership.md
+  state.md
+  forms.md
+  events-and-handlers.md
+  debugging.md
+
+Structure & libraries
+  composition.md         # structure + spreads + theming/parts
+  accessibility.md
+  semantic-controllers.md  # optional library pattern only
+
+Performance
+  compilation.md
+
+Host & browser
+  host-boundaries.md     # leaves, behaviors, ->react, error-boundary
+  js-libraries.md        # worked recipes (Framer, GSAP, charts)
+  presence.md
+  ssr.md
+
+Ship & live with it
+  testing.md
+  adoption.md
+  limits-and-escapes.md
+```
+
+## Reading order
+
+1. [index.md](index.md) — what Freehand is (peer view layer, benefits, modes)  
+2. [mental-model.md](mental-model.md) — four shifts  
+3. [vs-reagent.md](vs-reagent.md) — optional if you know Reagent  
+4. [install.md](install.md) — target require / adapter / mount (aspirational until ship)  
+5. [build-a-view.md](build-a-view.md) — end-to-end counter  
+
+Then **fork** by need (not a linear sequel):
+
+- Real app → forms, events, debugging  
+- Library author → composition (incl. theming), accessibility, semantic-controllers  
+- Integrate / JS widgets → host-boundaries, js-libraries, adoption  
+- Hot path → debugging first, then compilation  
+
+## Page inventory
+
+### Start here
+
+| File | Role |
+|---|---|
+| `index.md` | Landing: peer view layer, re-frame-native benefits, mode table |
+| `mental-model.md` | Conceptual shifts; frames, roots, and the DOM |
+| `vs-reagent.md` | Habit comparison with Reagent (not the migration checklist) |
+| `install.md` | Target boot: require, adapter, preflight, mount, API status table |
+| `build-a-view.md` | Progressive tutorial (+ keyed list, mount into DOM) |
+
+### Everyday authoring
+
+| File | Role |
+|---|---|
+| `reactivity-and-ownership.md` | Invalidation, commit ownership, keys, levers |
+| `state.md` | sub, props, A/B/C field-state ladder |
+| `forms.md` | Form-slice, touched/errors, seed-merge, submit |
+| `events-and-handlers.md` | Vectors, projections, fields, typing/Xray, door, callback identity |
+| `debugging.md` | inspect-boundary, hot-views, orphans, perf ladder before compile |
+
+### Structure & libraries
+
+| File | Role |
+|---|---|
+| `composition.md` | Structure ladder + `spread-safe`/`spread` + theming/parts (D018) |
+| `accessibility.md` | Native-first a11y, names/roles, presence exit, provable-only diagnostics |
+| `semantic-controllers.md` | Optional controllers; lifecycle; storage; table; library sketch |
+
+### Performance
+
+| File | Role |
+|---|---|
+| `compilation.md` | `{:compiled true}`, check, placement, closed vocabulary limits |
+
+### Host & browser
+
+| File | Role |
+|---|---|
+| `host-boundaries.md` | Leaves, behaviors, commands, `->react`, top layer, **error-boundary** |
+| `js-libraries.md` | Host recipes: presence first, Framer leaves, GSAP behaviors, hook leaves |
+| `presence.md` | Enter/exit: phases, overrides, CSS/a11y, tests, non-goals |
+| `ssr.md` | Request frame, roots, hydrate, client-only, route-link |
+
+### Ship & live with it
+
+| File | Role |
+|---|---|
+| `testing.md` | Structural → frame → mounted; fixtures, settle, presence clock |
+| `adoption.md` | Incremental Freehand next to existing adapters |
+| `limits-and-escapes.md` | Walls and recoveries |
+
+## Design sources
+
+- `docs/design/freehand/codex-design.md` — product spine
+- `docs/design/freehand/fable-design.md` — worked examples and fitness
+- `docs/design/freehand/decisions/` — D001–D021
+- `docs/core/re-frame.ui/` — tutorial voice and sectioning inspiration
+
+## Maintenance
+
+When a surface graduates into `spec/` or the API lands, update the matching guide
+page and remove speculative install notes. **Authors** verify against the design
+record and specs; **reader pages** stay a standalone corpus — repeat what the
+reader needs, do not link into `spec/` (per AUTHORING.md).
+
+**No page chrome for navigation.** mkdocs supplies sidebar, prev/next, and toc.
+Do **not** put reading-order tables, “Start here” page lists, “Going further”
+chapter farms, “See also,” or “Where to go next” on pages. Cross-link **only**
+inline when the sentence needs a related contract right there — never a map of
+the guide.
+
+**Tutorial shape (AUTHORING):**
+
+- Opening = reader problem in one or two sentences (not a mini-TOC of the page).  
+- Happy path code early; explanation after.  
+- Concept pages: day-one stop (checklist or hard break); depth continues on the
+  same page under plain content headings (not a nav section).  
+- Unhappy path as symptom → recovery table where readers can get stuck.  
+- “When not” when a surface can be misapplied.  
+- Depth (controllers, closed compile grammar, host) earned after the stop.
+
+**Consolidation rules (current):**
+
+- Theming/parts live on `composition.md` — do not revive a separate theming page.  
+- Error boundaries live on `host-boundaries.md` — do not revive a separate errors page.  
+- `js-libraries.md` is recipes for the host section, not a second host contract.  
+- `vs-reagent.md` (habits) and `adoption.md` (migration) stay separate.  
+- Primary term is **view layer**; adapter/substrate = how a view layer plugs in.
+
+Page inventory and draft reading order live in this README only.

--- a/docs/design/freehand/draft-guide/accessibility.md
+++ b/docs/design/freehand/draft-guide/accessibility.md
@@ -1,0 +1,178 @@
+# Accessibility
+
+Freehand does not ship a second accessibility framework. It makes a11y **easier
+to do correctly** because markup, handlers, and structure are data — and it
+refuses diagnostics that pretend to know more than they can prove.
+
+The product bar is **native-element-first**: prefer platform primitives that
+already carry roles, focus, and keyboard behaviour; assert what the structural
+tree can prove; use a real browser for composite widgets and foreign interiors.
+
+## Principles
+
+| Principle | Practice |
+|---|---|
+| **Native element first** | `<button>`, `<a href>`, `<input>`, `<dialog>`, `popover` — before ARIA on a `div` |
+| **Accessible name** | every interactive control has a name (text content, `aria-label`, labelled control, …) |
+| **Owned relations stay owned** | library leaves may lock required roles / ARIA; callers cannot strip them via `:parts` |
+| **Provable-only static findings** | analyzer and structural walks report only what they can prove; unknown is not “pass” |
+| **Browser owns composite proof** | focus traps, roving tabindex, live regions, foreign widget interiors |
+
+Freehand’s contribution is the **data tree** and the **host contracts** (top layer,
+presence overrides, controlled inputs). Your component design still chooses
+semantics.
+
+## Prefer the platform
+
+| UI need | Prefer | Avoid as first move |
+|---|---|---|
+| Button | `:button` or `:input {:type "submit"}` | clickable `:div` + role |
+| Navigation | real `:a` with `href` (route-link laws) | `div` + click only |
+| Modal | top-layer / native dialog semantics | hand-rolled focus trap on day one |
+| Anchored popover | native popover / top-layer desired state | portal soup without focus policy |
+| Expand/collapse | `aria-expanded` on a real button + controlled region | mystery disclosure without name |
+| Form field | labelled control (`:label` wrapping or `aria-labelledby`) | placeholder-as-only-label |
+
+Overlays, measurement, top-layer open state, and presence exit classes are defined
+on their host/presence pages. This page only states the **a11y obligations** those
+features create.
+
+## Names, roles, and keyboard
+
+### Accessible name
+
+In structural tests and dev sweeps, treat “interactive node without a name” as a
+finding when it is **provable**:
+
+```clojure
+;; bad — icon-only, no name
+[:button {:on-click [:cart/open]} [icon-cart {}]]
+
+;; good — visible text or aria-label
+[:button {:on-click [:cart/open]
+          :aria-label "Open cart"}
+ [icon-cart {}]]
+```
+
+Event vectors do not replace names. Tools can see `[:cart/open]`; a screen reader
+still needs a name.
+
+### Roles and relations libraries own
+
+A reusable control may require a role or labelling relation as part of its
+contract. Those must not be overwritable by caller `:parts` maps. Libraries
+merge parts through `v/spread-safe`, which **denies** stripping required roles /
+a11y relations the component owns — see
+[Composition — spreading props](composition.md#spreading-props-attribute-forwarding)
+and [Composition — theming and parts](composition.md#theming-and-parts).
+Structural replacement of a labelled region uses the
+[composition ladder](composition.md), not a part override that deletes the label.
+
+### Keyboard
+
+- Prefer **native** activators (`button`, `a`, `input`) so Enter/Space and tab order
+  work without a custom handler.  
+- Exact-key maps on `:on-key-down` / `:on-key-up` are a **closed data form** for
+  common chords (see [Events](events-and-handlers.md)). Rich listbox/combobox
+  policy often needs `v/event` or a host widget — do not fake a full ARIA composite
+  with half a key map.  
+- IME composition must not commit partial text on Enter; Freehand’s controlled-input
+  door already treats composition as a browser law.
+
+## Presence and exit
+
+While a keyed child is retained as **`:unmounting`**, it can still take focus and
+clicks unless you hide it from interaction and assistive tech:
+
+```clojure
+[v/presence
+ {::v/unmounting {:class ["opacity-0"]
+                  :inert true
+                  :aria-hidden true}}
+ …]
+```
+
+Development checks should warn when retained interactive content lacks `inert`
+(or equivalent) and assistive hiding. Honour `prefers-reduced-motion` in CSS so
+timeout still removes the node without motion.
+
+Presence never owns focus traps or modal UX — only presentation overrides during
+retention. Details: [Presence — accessibility](presence.md#accessibility).
+
+## Top layer and overlays
+
+When open state is a **desired fact** (dialog/popover), the browser can supply
+backdrop, Esc, and much of focus return. Your job:
+
+| Obligation | Note |
+|---|---|
+| Initial focus | native dialog behaviour or an explicit focus intent (`:auto-focus` / focus fx) |
+| Background | inert / non-interactable while modal |
+| Return focus | on close, back to the control that opened |
+| Label | dialog has an accessible name |
+| Nested stacks | LIFO / native stacking — do not invent a second modal manager in app-db |
+
+Do not reimplement portal + trap as neutral Freehand primitives. Use the top-layer
+contract and, when React protocols demand it, a UIx wrapper.
+
+## Forms
+
+- Associate every control with a visible label (or a deliberate `aria-label`).  
+- Surface validation in text the tree can assert — not colour alone.  
+- `aria-invalid` / `aria-describedby` pair well with the form-slice
+  [`:errors`](forms.md) map when you wire them as ordinary attrs.  
+- Disabled submit is not a substitute for explaining why submit failed.
+
+## Testing: two lanes
+
+Accessibility proof is intentionally split so tools do not overclaim.
+
+### Lane 1 — static / structural (provable only)
+
+| Can assert | How |
+|---|---|
+| Missing accessible name on a **static** interactive element | structural tree walk / compile-time finding |
+| Required role still present after `:parts` merge | unit test on attrs |
+| Event intent still present after composition | equality on the tree |
+| Presence plan includes `inert` / `aria-hidden` on exit | presence metadata on the structural tree |
+
+**Cannot** honestly claim from static analysis alone:
+
+- dynamic names built only at runtime from opaque data  
+- interiors of foreign host widgets  
+- real focus order through a composite  
+- live region politeness in a real AT  
+
+Those stay **unknown** in static reports — not “green.”
+
+### Lane 2 — complete tree / mounted browser
+
+| Need | Tier |
+|---|---|
+| Roles and names after full composition | complete structural tree or DOM queries |
+| Keyboard and focus containment/return | mounted browser |
+| Top-layer nesting and background inertness | mounted browser |
+| Third-party (Radix, grid) keyboard | real primitive + disconnect cleanup |
+
+See [Testing](testing.md). Presence exit motion may use a fake clock for
+retention timing and a real browser for CSS/a11y.
+
+## Diagnostics product rule
+
+> Static accessibility findings report **only** facts the analyzer or complete
+> structural tree can prove. Dynamic content and opaque foreign interiors are
+> marked unknown, not guessed.
+
+That rule is a fitness-harness obligation, not a suggestion. A CI check that
+“passes a11y” by assuming every host leaf is fine is a product defect.
+
+## Checklist
+
+1. Prefer **native** elements and top-layer primitives over ARIA-on-div.  
+2. Give every interactive control an **accessible name**.  
+3. Keep library **roles and labels** non-strippable via
+   [`spread-safe`](composition.md#spreading-props-attribute-forwarding) / `:parts`.  
+4. Put **`inert` + `aria-hidden`** on presence exit overrides for interactive trees.  
+5. Wire form errors as **text in the tree**, not only style.  
+6. Assert **provable** facts in structural tests; mount for focus and composites.  
+7. Never treat static “unknown” as pass.

--- a/docs/design/freehand/draft-guide/adoption.md
+++ b/docs/design/freehand/draft-guide/adoption.md
@@ -1,0 +1,89 @@
+# Incremental adoption
+
+You already ship on Reagent or UIx. The question is not “rewrite
+everything” — it is **can Freehand land next to what I have?**
+
+Yes, with clear boundaries. Freehand is another **view layer**, not a forced
+replace. This page is the adoption path (habit comparison is separate).
+
+## What stays shared
+
+- `rf/reg-event`, `rf/reg-sub`, app-db, effects  
+- frames, resources, machines, routing ownership  
+- re-frame-side tooling  
+
+Only **view spelling and host** change where you choose Freehand.
+
+## Strategies (coarse to fine)
+
+### 1. New surface only
+
+Ship a new route, settings panel, or admin tool entirely in Freehand. Leave the
+legacy tree alone. Lowest risk; proves mount, testing, and tooling.
+
+### 2. Per route
+
+Mount Freehand for route A and keep Reagent/UIx for route B. Each root has its own
+DOM container (or you swap the main outlet on navigation). Share one frame when
+the app-db should be shared; use separate frames only when isolation is the point.
+
+### 3. Per region inside a page
+
+Harder: two view layers on one screen. Prefer a clear DOM split (two containers)
+over interleaving Hiccup dialects in one parent. If a Reagent parent must host a
+Freehand island, use a mount into a child DOM node Freehand owns, or expose
+Freehand through `v/->react` into a React/UIx parent that already expects a
+component value.
+
+### 4. Per component (leaf migration)
+
+Rewrite leaf controls to Freehand first (forms, tables), keep page shells on the
+old adapter until the leaves stabilize. Library-style Freehand leaves can compile
+early; pages often stay interpreted.
+
+## Embedding Freehand in an existing React / UIx tree
+
+When the parent is already React:
+
+```clojure
+;; parent is UIx/React; child is Freehand
+{:cellRenderer (v/->react person-cell)}
+;; pass a live :frame when ambient Freehand context is absent
+```
+
+Rules:
+
+- `v/->react` **never creates** a frame — supply a live one.  
+- Freehand owns that island’s `sub` and data events.  
+- Do not expect Freehand Hiccup and Reagent Hiccup to compose as one dialect.  
+
+## Embedding host React in Freehand
+
+The reverse is the normal Freehand host story: qualified leaves, behaviors, and
+small React host components for hooks.
+
+## What not to do
+
+| Approach | Problem |
+|---|---|
+| Mix Reagent and Freehand components as if they were the same Hiccup | Different hosts and contracts |
+| Share ratoms “for a while” into Freehand | Freehand will not adopt that model |
+| Mount Freehand without a frame story | subs and events need a live frame |
+| Expect automatic whole-app migration | Freehand is opt-in per surface you choose |
+
+## Suggested rollout checklist
+
+1. Install Freehand next to the existing adapter (implementation dependent until
+   coordinates land).  
+2. Mount a **toy route** end-to-end (counter shape).  
+3. Add one headless intent assertion without a browser.  
+4. Migrate one real form.  
+5. Use inspect / hot-views habits before performance work.  
+6. Only then promote hot leaves with compilation.  
+7. Keep adapters for the long tail until there is a reason to move them.  
+
+## Donor `re-frame.ui`
+
+If you already use `re-frame.ui`, treat it as **donor machinery** under Freehand’s
+compiled path over time, not a permanent second public product. Programme migration
+notes publish when the absorption gate is ready.

--- a/docs/design/freehand/draft-guide/build-a-view.md
+++ b/docs/design/freehand/draft-guide/build-a-view.md
@@ -1,0 +1,237 @@
+# Build a view
+
+A working Freehand screen, one idea at a time: subscription as a value, handler as
+data, controlled field, mount. Not a tour of every option.
+
+**Prerequisites:** basic re-frame2 events, subscriptions, and frames.
+
+!!! note "Implementation status"
+
+    Names match the ratified design. Adapter install and Shadow recipes land with
+    implementation; sketches may use placeholder adapter names.
+
+One namespace:
+
+```clojure
+(ns my.app
+  (:require [re-frame.core :as rf]
+            [re-frame.freehand :as v :refer [sub]]))
+```
+
+The `:as v` alias matters for projection keywords later. With that alias,
+`::v/value` means Freehand’s reserved value marker
+(`:re-frame.freehand/value`), and the same idea applies to `::v/checked` and
+`::v/key`.
+
+## Step 1 — the dataflow
+
+None of this is Freehand-specific. The counter’s state, the event that changes it,
+and the subscription that reads it are plain re-frame2 — the same code you would
+write behind Reagent or UIx.
+
+```clojure
+(rf/reg-event :app/init  (fn [_ _] {:db {:count 0 :note ""}}))
+(rf/reg-event :count/inc (fn [{:keys [db]} _] {:db (update db :count inc)}))
+(rf/reg-event :note/set
+  (fn [{:keys [db]} [_ text]]
+    {:db (assoc db :note text)}))
+
+(rf/reg-sub :count (fn [db _] (:count db)))
+(rf/reg-sub :note  (fn [db _] (:note db)))
+```
+
+`:app/init` seeds app-db. `:count/inc` bumps the count. `:note/set` stores the
+note text. The view will only *consume* these pieces; it will not invent its own
+store.
+
+## Step 2 — the view
+
+Here is the component in its first form:
+
+```clojure
+(v/defview counter [_]
+  [:div.counter
+   [:p "Count: " (sub [:count])]])
+```
+
+`v/defview` takes one props map. We are not using props yet, so the parameter is
+`_`. The body returns Hiccup.
+
+`(sub [:count])` is the current value of that subscription, dropped straight into
+the paragraph. When `[:count]` changes, this view boundary re-renders. There is no
+`@` and no ratom.
+
+**How you call it:** write `[counter {}]` in a parent (or at the mount root).  
+**How you must not call it:** `(counter {})` — that is for helpers, not for
+declared views.
+
+## Step 3 — an event as data
+
+To change the count, dispatch an event. In Freehand the common handler is a
+vector, not a closure:
+
+```clojure hl_lines="4"
+(v/defview counter [_]
+  [:div.counter
+   [:p "Count: " (sub [:count])]
+   [:button {:on-click [:count/inc]} "Increment"]])
+```
+
+`{:on-click [:count/inc]}` means: when this button is clicked, dispatch
+`[:count/inc]` on the frame this view is running under.
+
+The intent is visible in source and in tools before anything runs. The pipeline is
+the usual re-frame one: click → event → app-db → subscription change → this view
+re-renders with the new number.
+
+## Step 4 — a controlled field
+
+Now put the note in app-db and wire a controlled input. Freehand fills in
+`::v/value` from the live DOM event when the input fires:
+
+```clojure hl_lines="5 6 7"
+(v/defview counter [_]
+  [:div.counter
+   [:p "Count: " (sub [:count])]
+   [:button {:on-click [:count/inc]} "Increment"]
+   [:input {:value       (sub [:note])
+            :on-input    [:note/set ::v/value]
+            :placeholder "A note…"}]])
+```
+
+Because the element has both `:value` and `:on-input`, this site uses Freehand’s
+**synchronous controlled-input door**. In plain language: Freehand dispatches the
+event, lets re-frame settle, and updates the views that care about this frame
+*before* React finishes handling the keystroke. That is what keeps the caret and
+IME from fighting the controlled value. You do not configure the door; eligible
+sites get it by law.
+
+This field is the simple pattern: **every keystroke updates domain state** in
+app-db. That is often exactly what you want. Other patterns (draft-then-commit;
+shared library field protocols) exist when you need them.
+
+## Step 5 — a keyed child (optional, but typical)
+
+Real screens have lists. Freehand’s natural shape is a **keyed declared child** so
+each row is its own reactive boundary:
+
+```clojure
+(v/defview note-row [{:keys [id]}]
+  (let [text (sub [:notes/by-id id])]
+    [:li
+     [:input {:value    text
+              :on-input [:notes/set id ::v/value]}]]))
+
+(v/defview note-list [_]
+  [:ul
+   (for [id (sub [:notes/ids])]
+     [note-row {:key id :id id}])])
+```
+
+A few points worth fixing in your head now:
+
+- `[note-row …]` mounts a boundary. If one note’s text changes, that row is what
+  re-renders — not every row by default.  
+- A plain helper called with parentheses would **inline** into the parent. That is
+  fine for pure markup. It is the wrong tool when each row must subscribe and
+  update on its own.  
+- `:key` tells Freehand and React which sibling is which across reorders. Prefer a
+  stable domain id, not the loop index, when identity matters.
+
+## Step 6 — mount it (Freehand + frame into the DOM)
+
+A view becomes a running app when you mount a Freehand **root** into a DOM node.
+That is how Freehand (and its frame) enter the page — not by tagging raw HTML with
+a frame id.
+
+```clojure
+(defn ^:export run []
+  ;; Adapter install follows re-frame2's (rf/init! adapter) pattern
+  (rf/init! freehand-adapter)
+  (v/mount [counter {}]
+           (js/document.getElementById "root")))
+```
+
+Think of two layers:
+
+| Layer | Meaning |
+|---|---|
+| **DOM container** | e.g. `#root` — where React/Freehand attaches |
+| **Frame** | re-frame world: app-db, events, subs for this UI |
+
+**Seeding before first paint** is frame **preflight** (the Root Descriptor story).
+In production style, the frame should exist and can drain `:initial-events` such as
+`[:app/init]` *before* React paints, so you do not flash empty count and note.
+
+The contracts to remember:
+
+1. seed once before first render  
+2. hot reload should **reuse** the live frame so state survives edits  
+3. multi-root pages need an explicit root identity when containers could collide  
+4. embedding Freehand inside foreign React uses `v/->react` and an **existing**
+   frame  
+
+Until samples land with polished preflight helpers, a temporary dev boot may
+`dispatch-sync` init before `mount`. Prefer preflight for the real boot path so
+first paint and HMR share one story.
+
+## The complete counter
+
+```clojure
+(ns my.app
+  (:require [re-frame.core :as rf]
+            [re-frame.freehand :as v :refer [sub]]))
+
+;; ---- dataflow: plain re-frame2 --------------------------------------------
+
+(rf/reg-event :app/init  (fn [_ _] {:db {:count 0 :note ""}}))
+(rf/reg-event :count/inc (fn [{:keys [db]} _] {:db (update db :count inc)}))
+(rf/reg-event :note/set
+  (fn [{:keys [db]} [_ text]]
+    {:db (assoc db :note text)}))
+
+(rf/reg-sub :count (fn [db _] (:count db)))
+(rf/reg-sub :note  (fn [db _] (:note db)))
+
+;; ---- view -----------------------------------------------------------------
+
+(v/defview counter [_]
+  [:div.counter
+   [:p "Count: " (sub [:count])]
+   [:button {:on-click [:count/inc]} "Increment"]
+   [:input {:value       (sub [:note])
+            :on-input    [:note/set ::v/value]
+            :placeholder "A note…"}]])
+
+;; ---- mount ----------------------------------------------------------------
+
+(defn ^:export run []
+  (rf/init! freehand-adapter)
+  ;; Prefer frame preflight so seed events drain before paint — see install.md
+  (v/mount [counter {}]
+           (js/document.getElementById "root")))
+```
+
+That is a complete Freehand view: a subscription as a value, an event as data, a
+controlled field on the sync door, mounted under a frame. No component-local
+reactive state, and no dispatch closures on the paved path.
+
+## Day-one checklist
+
+You can stop here and still ship a simple Freehand screen if you can:
+
+- register events and subs in plain re-frame2  
+- write a `v/defview` that uses `(sub …)` / `(v/sub …)` as a value  
+- put an event vector on `:on-click`  
+- wire a controlled input with `::v/value` on `:on-input`  
+- mount with `v/mount` (and seed the frame before paint when you care about flash)
+
+## If something feels wrong
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Button does nothing | event not registered / wrong frame | check `reg-event` id; confirm mount bound a live frame |
+| Input caret jumps or characters drop | not on the controlled door | use `:value` + `:on-input` (or `:on-change`) with a data handler |
+| `v/sub` throws outside render | render-only rule | use `rf/subscribe-once` in tools/tests |
+| `(my-view {})` fails | descriptors are not `IFn` | call `[my-view {}]` |
+| First paint empty then flash | seed after paint | preflight / seed before mount |

--- a/docs/design/freehand/draft-guide/compilation.md
+++ b/docs/design/freehand/draft-guide/compilation.md
@@ -1,0 +1,426 @@
+# Compilation
+
+Most Freehand views should stay **interpreted**. Compilation is a power tool for
+hot boundaries and library leaves — not a second product you live in from day one.
+
+High `:stable-renders` means fix subscriptions or props, not compile. Measure
+first; compile second.
+
+Freehand remains **one** view layer. Compiled mode is an option on the same
+`v/defview`. Call sites stay `[view props]`. Structural tests do not change. There
+is no second compiler and no hidden interpreter inside a compiled template.
+
+> **Measure → `v/check` → then `{:compiled true}`. Never the reverse.**
+
+## Day-one: usually do not compile
+
+You can ship entire apps interpreted. Promote a boundary only when:
+
+1. measurement shows interpretation cost on a hot template, **or**  
+2. a library leaf needs static proof / manifests, **and**  
+3. `v/check` is clean for that declaration.
+
+### Promotion recipe
+
+```clojure
+(v/check people-list)          ; fix findings first
+(v/defview people-list
+  {:compiled true}
+  [props]
+  …)
+```
+
+Call sites and structural tests stay the same. Demote by removing `{:compiled true}`
+when debugging.
+
+## What compilation buys — and what it does not
+
+When a view body is inside the finite subset, compilation can give you:
+
+- direct React lowering and a JVM structural emitter  
+- finite manifests for subscriptions, events, key maps, slots, host edges,
+  presence, and top-layer forms (static “what *can* happen,” not only what one
+  render observed)  
+- generated prop comparators and prebound handlers where the compiler can prove
+  them  
+- static diagnostics with source coordinates  
+- static asset / SSR evidence where the emitter supports it  
+- **capability elision** — unused machinery drops out; a proved **sub-free** view
+  can omit the reactive ViewCell shell entirely  
+
+Compilation does **not** buy:
+
+- faster subscription *derivation* (the sub graph still runs)  
+- free React reconciliation in dynamic regions  
+- automatic promotion or a second authoring language  
+- a silent interpreter for “just this one dynamic hole”  
+- omniscience for *interpreted* siblings (they still only report realized reads)  
+
+Think of compilation as a capability you turn on when evidence says you need it —
+not a quota or a badge.
+
+## Selecting compiled mode
+
+```clojure
+(v/defview todo-row
+  {:compiled true}
+  [{:keys [id]}]
+  (let [{:keys [title completed]} (v/sub [:todo/by-id id])]
+    [:li {:class {:completed completed}}
+     [:input {:type :checkbox
+              :checked completed
+              :on-change [:todo/toggle id]}]
+     title]))
+```
+
+Call sites stay `[todo-row props]`. Structural tests do not change. The public var
+remains a **descriptor** (not `IFn`) — you never `(todo-row {})`.
+
+The grammar version is artifact-wide (`:re-frame.freehand/v1`), carried on findings
+and manifests. It is **not** a per-view compatibility profile between products, and
+not a second namespace or macro.
+
+There is **no author-facing `:reads` declaration in v1**. Reads are inline
+`(v/sub …)` only. Tools distinguish evidence with scope / basis / completeness /
+loss, not a second read language.
+
+## Checker-first workflow
+
+Before adding `{:compiled true}`, run the read-only checker against the
+**interpreted** declaration:
+
+```clojure
+(v/check people-list)
+;; ⇒ stable EDN — never auto-edits your source
+```
+
+Illustrative finding envelope (fields may grow; shape is stable):
+
+```clojure
+{:view-id           :app.people/people-list
+ :source            {:file "…" :line 42 :column 1}
+ :current-lowering  :interpreted
+ :target-grammar    :re-frame.freehand/v1
+ :compile-eligible? false
+ :findings
+ [{:id       :re-frame.freehand.compile/opaque-markup-call
+   :source   {:line 47 :column 5}
+   :form     '(render-person person)
+   :reason   :markup-hidden-from-analyzer
+   :recovery [:extract-declared-child
+              :make-template-visible
+              :keep-interpreted]}]}
+```
+
+Each finding’s **recovery** list *is* the work order. Prefer:
+
+- **keep interpreted** — helper-heavy app pages and composition
+- **extract declared child** — hot leaves / rows you still want compiled
+- **make template visible** — finite `for`, literal heads, visible `sub`
+
+Changing the declaration (`{:compiled true}`) is the **last** step, not the
+discovery mechanism. Freehand never promotes from a percentage threshold or silent
+rewrite.
+
+### Mini promotion transcript
+
+```clojure
+;; 1) interpreted, fails check — opaque helper + map markup
+(v/defview people-list [_]
+  [:ul (map (fn [p] (person-row p)) (v/sub [:people]))])
+
+;; 2) after v/check recoveries — keyed for + declared child
+(v/defview person-row
+  {:compiled true}
+  [{:keys [person]}]
+  [:li (:name person)])
+
+(v/defview people-list
+  {:compiled true}
+  [_]
+  [:ul
+   (for [p (v/sub [:people])]
+     [person-row {:key (:id p) :person p}])])
+```
+
+Promotion is **not transitive**. Compiling the list does not force every child
+compiled, and compiling a leaf does not require its parent compiled. Nested
+`[child props]` works both directions when the child is a **statically named**
+descriptor.
+
+## Placement defaults (cold start)
+
+| Surface | Default | Why |
+|---|---|---|
+| App pages, routes, composition | interpreted | freedom and evidence later |
+| Library leaf controls | compile when in-subset | elision; consumers pay your choice N times |
+| Keyed row templates at scale | compile when clean; window first | wide-parent churn |
+| Flap-prone controlled sites | compile to pin the door | predictability |
+| Everything else | interpret until evidence says otherwise | anti-folklore |
+
+Optimization order:
+
+1. narrow subscriptions and choose boundaries
+2. window large collections
+3. use a qualified React leaf if substrate semantics inside the hot leaf do not matter
+4. compile remaining interpretation-dominated or static-evidence needs
+5. measure again with the same counters
+
+---
+
+## The closed vocabulary (what compiled mode can see)
+
+Interpreted mode runs **full Clojure**: any helper may return Hiccup, any head may
+be chosen at runtime, any `sub` may appear in ordinary control flow (subject to
+good style).
+
+Compiled mode is different. The compiler must **prove at compile time**:
+
+- the **structure** of the template (tags, children, keys)
+- every **reactive site** (`v/sub`)
+- event / host / presence shapes where it claims static evidence
+
+Anything it cannot see through is a **checker finding** (and a build failure once
+you mark `{:compiled true}`), with a named recovery — not a silent runtime
+fallback.
+
+### One-sentence rule
+
+> If the compiler cannot prove the structure, the reactive sites, and the list
+> keys of a piece of markup **at compile time**, that spelling is illegal in a
+> compiled `v/defview` body.
+
+Ordinary **branching and binding are free** when they use forms the analyzer
+understands (`let`, `if`, `when`, `if-let` / `when-let` / `if-some` / `when-some`,
+`cond`, `case`, `for`, …). Both arms of an `if` and every `cond` clause are
+visible. You are not forced into one linear template.
+
+### Mode comparison
+
+| Concern | Interpreted | Compiled (`:re-frame.freehand/v1`) |
+|---|---|---|
+| Body language | full Clojure | closed, compiler-visible template/control forms |
+| `(v/sub …)` | dynamic capture; helpers may read | **finite, lexically visible** sites; helpers must not hide reads |
+| View / element heads | runtime choices among descriptors OK | **statically named** or finite explicit branches |
+| Child markup as a value | pass Hiccup around freely | **compiler-owned** structure only |
+| Loops | ordinary `map` / seq realization | compiler-owned keyed **`for`**; reactive rows → **child views** |
+| Props maps | runtime maps OK at the edge | **literal** shape + `v/spread` / `v/spread-safe` ([composition](composition.md#spreading-props-attribute-forwarding)) |
+| Events | runtime-classified common grammar | same grammar; static where knowable |
+| Parameterized rows | ordinary pure fn OK | lexically visible `v/render-fn` / `v/slot` |
+| Presence / top-layer | runtime plans | statically recognized forms |
+| Host leaves / behaviors | qualified descriptors | **statically named** descriptors |
+| `local` / neutral hooks | rejected | rejected (host boundary instead) |
+| Dynamic markup in template | natural | **no inline valve** — see `v/markup` below |
+
+There is **no** `v/interp` and no “compiled except this unknown subtree.”
+
+### Template structure — illegal forms
+
+| You cannot (compiled) | Why | Do this instead |
+|---|---|---|
+| Dynamic tag heads — `[(if big? :h1 :h2) title]` | Emitter must know the constructor | Both branches, or one fixed tag + varying attrs/class |
+| Markup-returning `map` — `(map row-view rows)` | Hides structure, keys, and `sub` sites | `(for [r rows] [row-view {:key … :row r}])` |
+| Unkeyed items in a dynamic list | List identity is a proof obligation | `{:key …}` on every list child |
+| Opaque helper returning Hiccup in template position — `(field-help props)` | Analyzer cannot lower the returned value | `[field-help-view props]` (declared child), inline the markup, or stay interpreted |
+| `(sub …)` inside an unbounded loop | Reactive sites must be finite | Extract a keyed child view that subscribes for one row |
+| Event site capturing a **loop binding** as a closed-over value for many rows | One lexical committed slot cannot mean N instances | Keyed child whose **props** carry `id` / row data |
+| Hiding `sub` inside an unaudited macro or deep helper | Manifest would lie | Visible `v/sub` in the view, or value computed in a pure helper and passed in |
+| Wholly dynamic props map on an **internal** view | Per-slot memo / analysis need known keys | Literal props; `v/spread-safe` (internal/controlled) or `v/spread` (foreign) — [composition](composition.md#spreading-props-attribute-forwarding) |
+| Dynamic head registry — runtime choose among unknown views | Head must be finite | `case`/`cond` over known descriptors, or interpreted parent |
+| Bare fn on a **foreign** callback prop | Phase/identity unknown | `v/event` / `v/handler` / `v/render-fn` / `v/raw-fn` |
+| Bare React component as an ordinary head | Foreign boundary must be named | `host/component` or wrapper |
+| Inline interpreter fallback for “this bit of runtime Hiccup” | Unpredictable cost and false manifests | `[v/markup {:value hiccup}]` or keep parent interpreted |
+| `local` / neutral hooks / refs / effects in the view body | One state system; host is explicit | re-frame state or [host boundaries](host-boundaries.md) |
+| Author `:reads […]` block (v1) | Not in the grammar | Inline `(v/sub …)` only |
+
+**Also named by the checker (donor-class structural rules):** keywords in child
+position (`[:div :oops]`), app props named `:key`, children passed to a view that
+did not accept `:children`, `#js` / hand-rolled camelCase on compiled DOM paths
+(use keyword props; one conversion table).
+
+### Reactive sites must be finite
+
+Every `(v/sub …)` in a compiled view is a compile-indexed site. Conditional
+`sub` in an `if` / `when` is fine (not a hook). **`sub` in a `for` over a
+runtime collection is not** — extract:
+
+```clojure
+;; illegal when compiled — sub site per loop iteration is not finite in the parent
+(for [id ids]
+  [:li (v/sub [:item id])])
+
+;; legal — finite site in the child
+(v/defview item-row
+  {:compiled true}
+  [{:keys [id]}]
+  [:li (:title (v/sub [:item id]))])
+
+(v/defview item-list
+  {:compiled true}
+  [_]
+  [:ul
+   (for [id (v/sub [:item-ids])]
+     [item-row {:key id :id id}])])
+```
+
+Expression positions (prop values, conditions, `for` collections) hold ordinary
+Clojure **values**, but their **syntax** is audited so every reactive call stays
+visible. Prefer transparent core forms and plain functions for computation. Move
+exotic macros out of the template body.
+
+### Dynamic markup: `v/markup`, not a valve
+
+Interpreted code often does this:
+
+```clojure
+(defn field-help [{:keys [error hint]}]
+  (if error [:p.error error] [:p.hint hint]))
+
+(v/defview editor [_]
+  [:section (field-help {:error (v/sub [:e]) :hint "…"})])  ; fine interpreted
+```
+
+Compiled mode **rejects** treating that return value as template syntax. Recoveries:
+
+1. **Declared child** — promote the helper to `v/defview` and call `[field-help …]`.
+2. **Inline** the branches in the parent template.
+3. **Stay interpreted** — leave `{:compiled true}` off.
+4. **Inert markup already in hand** — mount a visible interpreted boundary:
+
+```clojure
+[v/markup {:value some-hiccup-value}]
+```
+
+`v/markup` is an ordinary **declared interpreted child**. The compiled parent sees
+one static descriptor; the child owns the walk. Manifests count those mounts as
+`:interp-slots`. It is **not** an invisible “compile this except here” hole.
+
+### What is still allowed (so the grammar is not barren)
+
+Compiled views still use the **same application-facing vocabulary** as
+interpreted ones where the form is visible:
+
+- Hiccup tags, classes, props, trailing `:children`
+- `(v/sub …)` when sites are finite and visible (including conditional branches)
+- Event vectors, options maps, `::v/value` / `::v/checked` / `::v/key`, key-condition maps
+- `v/event` / `v/handler` / `v/render-fn` / `v/raw-fn` at the right phases
+- `v/presence`, top-layer desired-state props, when forms are statically recognized
+- Qualified host leaves and behaviors when **statically named**
+- `v/spread-safe` / `v/spread` under the common ABI
+- Nested `[child props]` when `child` is a known Freehand descriptor
+- `v/render-fn` + `v/slot` when the slot body is **pure and lexically visible**
+  (parameterized rows); stateful customization is a declared child view, not a
+  closure that hides `sub`
+
+The cliff is **dynamic structure and hidden reactivity**, not “you may not use
+events” or “you may not branch.”
+
+### Parameterized content (`render-fn` / `slot`)
+
+```clojure
+(v/defview data-table
+  {:compiled true}
+  [{:keys [rows row]}]
+  [:table
+   [:tbody
+    (for [item rows]
+      [:tr {:key (:id item)}
+       (v/slot row item)])]])
+
+;; caller — pure, visible body
+[data-table
+ {:rows people
+  :row  (v/render-fn [person]
+          [:td (:name person)])}]
+```
+
+If the row needs a subscription or its own events, extract
+`[person-row {:key … :id …}]`. Do not smuggle `sub` inside an opaque function
+the compiler cannot see.
+
+Full children taxonomy (trailing children, compound regions, when to promote to a
+declared view): **[Composition](composition.md)**.
+
+---
+
+## Crossing modes and seam laws (author-facing)
+
+| Law | Meaning |
+|---|---|
+| **Call-site invariance** | `[view props]` both ways; promotion edits the definition, not callers |
+| **Test invariance** | structural tests cannot tell which mode produced the tree (common subset) |
+| **One meaning** | shared props, keys, events, frame, controlled door, tree schema — not parallel promises |
+| **Evidence continuity** | counters that justified promotion still flow after; manifests **add** proof |
+| **Visible boundary cost** | interpreted children of a compiled parent are explicit (`[child …]` or `v/markup`); no hidden walker |
+
+Mechanically:
+
+- Interpreted parent → compiled child: fine.
+- Compiled parent → **statically named** interpreted child: fine (emitted boundary).
+- Compiled parent → runtime-chosen head: put the dynamic choice **inside** an
+  interpreted child, or stay interpreted.
+- Direct call `(view props)`: always wrong (descriptor is not `IFn`).
+
+### Evidence: static vs realized
+
+| Mode | What tools can claim |
+|---|---|
+| Interpreted | **Realized** reads/events for a committed render; not a full static inventory of every path |
+| Compiled | **Possible** sites from the manifest (static) **and** which sites were active this render |
+
+Every evidence projection should state **scope, basis, completeness, and loss**
+(D012). Compiled does not make interpreted siblings “proven.”
+
+### HMR note
+
+Compatible HMR preserves the shell and reconciles the next target set. Compiled
+views may carry an internal **site-signature generation**: a body change that
+alters the finite site set is fenced so an old speculative render cannot publish
+into new code. Authors do not manage this. Know that a big grammar change can
+remount that shell cleanly.
+
+## Props schemas
+
+Schemas are **optional in the grammar** (including for many compiled app views).
+They are **mandatory by policy** for:
+
+- shipped reusable library / catalogue surfaces
+- claims of generated coverage or generative parity for a particular view
+
+```clojure
+(v/defview todo-row
+  {:compiled true
+   :props [:map [:id :int]]}   ; vector-form Malli; closed by default for maps
+  [{:keys [id]}]
+  …)
+```
+
+- `:key` is outside the schema; children policy is descriptor metadata.
+- Missing schema reports as **absent**, never as implicit `:any`.
+- Literal calls may be checked statically; dynamic calls in development.
+- Validation is removable from production builds.
+- Analyzer-derived prop *slots* are private compiler facts, not a substitute
+  public schema.
+
+## If something feels wrong
+
+| Symptom | Fix |
+|---|---|
+| Checker rejects opaque helper markup | extract declared child, pass values, or stay interpreted |
+| Dynamic tag / unkeyed list under compile | finite branches; real `:key`s |
+| Need a dynamic hole in a compiled parent | `[v/markup {:value …}]` — visible interpreted child |
+| Still slow after compile | host cost or data size — not another Hiccup compiler |
+| High `:stable-renders` | fix subs/props — do **not** promote for that alone |
+
+## What not to do
+
+- Do not compile every view "to be safe."
+- Do not invent a second authoring API for hot views.
+- Do not hide interpretation inside compiled template space.
+- Do not treat donor `re-frame.ui` as a parallel product — its useful machinery is
+  the compiled implementation source under absorption; Freehand is the public door.
+- Do not expect full Clojure markup helpers to “just work” after `{:compiled true}` —
+  run `v/check` first.
+- Do not promote on a high “stable output” rate alone — that usually means
+  **narrower subs**, which helps both modes; promote when **interpretation work**
+  (`nodes` × renders / self-time) still dominates after structural fixes.

--- a/docs/design/freehand/draft-guide/composition.md
+++ b/docs/design/freehand/draft-guide/composition.md
@@ -1,0 +1,510 @@
+# Composition and theming
+
+You need more than “Hiccup in `:children`” — fixed regions, row renderers, safe
+attribute forwarding, or library parts that consumers can style without forking
+your control.
+
+Use the **lightest** structural form that matches the job. Mixing forms is fine;
+inventing a slot registry or post-render tree rewrite is not. Host widgets are a
+separate plane (qualified leaves, behaviors, wrappers).
+
+> **Props → trailing children → compound views → pure slots → declared child views.**
+
+## The ladder (read top-down)
+
+| Need | Form | Example |
+|---|---|---|
+| Plain data (string, number, enum, event vector) | **prop** | `{:title "Cart" :on-close [:cart/close]}` |
+| One default / fixed body region | **trailing children** → reserved `:children` | `[panel {:title "…"} [body {}]]` |
+| Several fixed regions (trigger + panel, label + control) | **compound child views** | named child components for each region |
+| Parameterised row / cell / item renderer (pure) | **`v/render-fn` + `v/slot`** | table row body from the caller |
+| Stateful customisation (own `sub`, events, identity) | **declared child view** | `[person-row {:key id :id id}]` |
+
+Prefer the **highest** row that still fits. A pure string is a prop, not a slot.
+A pure row renderer is a slot, not a child view with empty events. A control that
+must subscribe is a **view boundary**, not a closure smuggled through a prop.
+
+## One props map
+
+Every internal view receives **one** map. There is no second args vector of
+children the way some React APIs split “props” and “kids.”
+
+```clojure
+(v/defview panel [{:keys [title children]}]
+  [:section.panel
+   [:h2 title]
+   children])
+
+[panel {:key panel-id :title "Details"}
+ [details {:id panel-id}]]
+```
+
+Contract details that bite people:
+
+| Rule | Meaning |
+|---|---|
+| Trailing children | become the reserved **`:children`** vector in the props map |
+| Caller `:children` in the props map | **rejected** — write trailing forms, not a hand-built key |
+| `:key` | sibling identity only; **stripped** before the body sees props |
+| Children policy | descriptor metadata **`:children-policy`** (`:none` / `:optional` / `:required`) — a view can refuse children |
+| Equality | internal props use re-frame value equality for memoisation |
+| Host mutables | refs, instances, foreign handles → [host boundary](host-boundaries.md), not neutral props |
+
+Optional props schemas (Malli vector form, closed by default) document and check
+what a library leaf accepts. `:key` stays outside the schema; children policy is
+descriptor metadata, not a prop field you invent ad hoc.
+
+### Declaring children policy
+
+Children policy is descriptor metadata (product spine ABI field
+**`:children-policy`**). Authoring puts the same key on the `v/defview` options
+map alongside `{:compiled true}` when you need to state it. Values are exactly
+`:none`, `:optional`, or `:required` — not a prop, and not a second map key
+named `:children` (that name is reserved for the trailing-children **vector**
+delivered into the body).
+
+```clojure
+;; Leaf that must not be given trailing children
+(v/defview icon-button
+  {:children-policy :none}
+  [{:keys [event label]}]
+  [:button {:on-click event :aria-label label}
+   [icon-glyph {:name label}]])
+
+;; Default region allowed but optional
+(v/defview card
+  {:children-policy :optional}
+  [{:keys [title children]}]
+  [:article.card
+   (when title [:header title])
+   (when (seq children) [:div.card-body children])])
+
+;; Parent that requires a body region
+(v/defview dialog-shell
+  {:children-policy :required}
+  [{:keys [title children]}]
+  [:section.dialog
+   [:h2 title]
+   [:div.dialog-body children]])
+```
+
+| Policy | Meaning |
+|---|---|
+| `:none` | trailing children are a finding / error — misuse is not silent drop |
+| `:optional` | zero or more trailing children → `:children` vector (may be empty) |
+| `:required` | at least one trailing child expected |
+
+Omit the option when you accept the product default for application views
+(typically optional). Library leaves that own a fixed chrome should set `:none`
+or `:required` so the checker and catalog can prove the contract.
+
+## Trailing children (default region)
+
+Use trailing children when the parent has **one** obvious content hole: the body
+of a card, the items of a list shell, the main of a layout.
+
+```clojure
+(v/defview card [{:keys [title children]}]
+  [:article.card
+   (when title [:header title])
+   [:div.card-body children]])
+
+[card {:title "Invoice"}
+ [line-items {:invoice-id id}]
+ [totals {:invoice-id id}]]
+```
+
+Both trailing forms land in one `:children` vector. The parent places that vector
+where the default region lives. No registry, no string slot names.
+
+## Compound child views (fixed regions)
+
+When a control has **several** fixed holes — trigger vs panel, toolbar vs canvas,
+label vs control — prefer **named child views** (or named props that hold Hiccup
+for pure markup) over overloading a single `:children` bag with positional magic.
+
+```clojure
+;; Library shape (illustrative): fixed regions as props that hold structure,
+;; or as dedicated child components the parent knows how to place.
+
+(v/defview disclosure [{:keys [control label children]}]
+  (let [open? (v/sub [:rf.inst/get control :open?])]
+    [:div.disclosure
+     [:button {:aria-expanded open?
+               :on-click [:rf.inst/toggle control :open?]}
+      label]
+     (when open? [:div.body children])]))
+```
+
+Rules of thumb:
+
+- Fixed regions stay **named** in the parent’s contract (schema/docs).  
+- Event vectors inside those regions stay **data** — structural tests still see
+  intent after composition.  
+- Do not use compound regions as a substitute for theming (`:parts` is
+  attrs-only — see [below](#theming-and-parts)). Replacing structure is
+  composition; recolouring is CSS/parts.
+
+## Parameterised content: `v/render-fn` and `v/slot`
+
+Tables, lists, and grids often need “for each row, render **this** pure body.”
+That is not trailing children (the parent owns the loop) and not a full child view
+(the body may be a few cells with no state).
+
+```clojure
+(v/defview data-table [{:keys [rows row]}]
+  [:table
+   [:tbody
+    (for [item rows]
+      [:tr {:key (:id item)}
+       (v/slot row item)])]])
+
+[data-table
+ {:rows people
+  :row  (v/render-fn [person]
+          [:<>
+           [:td (:name person)]
+           [:td (:email person)]])}]
+```
+
+| Piece | Job |
+|---|---|
+| **`v/render-fn`** | caller-supplied pure body; no `sub`, dispatch, hooks, or refs |
+| **`v/slot`** | parent applies that body at a known site with arguments |
+
+**Interpreted** mode may also accept an ordinary pure function for the same job.
+**Compiled** mode needs a **lexically visible** `v/render-fn` / `v/slot` so the
+analyzer can see the body (see [Compilation](compilation.md)).
+
+When the row needs a subscription, its own events, or stable occurrence identity,
+extract a **declared child**:
+
+```clojure
+(v/defview person-row [{:keys [id]}]
+  (let [person (v/sub [:person/by-id id])]
+    [:tr
+     [:td (:name person)]
+     [:td [:button {:on-click [:person/edit id]} "Edit"]]]))
+
+;; parent
+(for [id ids]
+  [person-row {:key id :id id}])
+```
+
+Do not hide `sub` inside an opaque function the parent treats as a “render prop.”
+That breaks compilation, tools, and the “handlers are data” story.
+
+## Keys and repeated children
+
+Repeated view children use **real keys**:
+
+```clojure
+(v/defview todo-list [_]
+  [:ul.todo-list
+   (for [id (v/sub [:todo/visible-ids])]
+     [todo-row {:key id :id id}])])
+```
+
+| Practice | Why |
+|---|---|
+| Stable identity in `:key` | rows move with their cells; presence and memoisation work |
+| Pass domain id as a prop too | the body must not re-derive identity only from React’s key |
+| Keyed `for` of declared views under compiled parents | the closed loop grammar can see structure |
+| Unkeyed dynamic lists | broken identity; compile error when compiled |
+
+A plain helper can still build a deliberately coarse region; isolate changing rows
+as keyed declared children. No separate “region DSL” is required.
+
+## Spreading props (attribute forwarding)
+
+Composition of **structure** uses the ladder above. Forwarding **attributes**
+uses two common-grammar forms. This section is the **canonical** explanation;
+[events](events-and-handlers.md) (controlled door) and
+[host boundaries](host-boundaries.md) (foreign `v/spread`) only point here.
+
+Spreads do **not** replace children. Putting structure into a spread map is the
+wrong plane — use trailing children, compound regions, slots, or child views.
+
+### Two forms
+
+| Form | Where | Promise |
+|---|---|---|
+| **`v/spread-safe`** | internal DOM / library element that must keep controlled + identity invariants | caller attrs sit **under** owned literals; forbidden keys cannot clobber the contract; **preserves the controlled-input door** |
+| **`v/spread`** | **foreign** host head (open prop ABI) | owned literals still win collisions; forwarded map is otherwise opaque — **does not** claim the door |
+
+Same meaning in interpreted and compiled mode. The classic “attrs-forwarding
+wrapper” (`labelled-field` → inner `input`) is ordinary vocabulary, not a
+compiled-only trick.
+
+### Shape
+
+```clojure
+;; owned literals first, caller (or part) map second
+(v/spread-safe
+  {:data-part "control"
+   :value value
+   :on-input (conj on-change ::v/value)}
+  caller-attrs)
+
+;; foreign leaf — open remainder, owned contract wins
+(v/spread
+  {:selected date
+   :on-change (v/event [v] [:picker/picked v])}
+  (dissoc props :date :on-pick))
+```
+
+`(v/spread forwarded)` with no literal part forwards a map alone at a foreign
+head. Wholly dynamic props maps on **internal** views stay a compile problem —
+use literal keys plus `spread-safe` where you need a dynamic residue.
+
+### Merge law (`v/spread-safe`)
+
+1. **Owned literals win.** Caller keys never override what the component wrote
+   for identity, control, or handlers it owns.  
+2. **Caller sits underneath** for everything else (`class`, `data-*`, approved
+   ARIA/DOM attrs, extra listeners the component allows).  
+3. **`:class` composes** — caller and owned classes both apply; the merge does
+   not pick only one side.  
+4. **Deny list** (cannot be overwritten by the caller map):
+
+| Denied | Why |
+|---|---|
+| `:key`, `:ref` | occurrence identity and host handles are not caller toys |
+| `:value`, `:checked`, `:default-value` | controlled / uncontrolled contract |
+| owned handlers | library-wired intents stay the product contract |
+| children / structure | wrong plane — use the composition ladder |
+| required roles / a11y relations the component owns | [accessibility](accessibility.md) |
+| top-layer desired state | open/close is not a part override |
+| node / behavior ownership | host wiring is not a class tweak |
+
+Denied attributes and unknown `:parts` ids should become **source-located
+development findings**, not silent drops that look like success.
+
+### Why `spread-safe` exists
+
+A dynamic props map on a controlled input normally **forfeits** the
+synchronous [controlled door](events-and-handlers.md#controlled-inputs) into
+batching (with a dev diagnostic). Libraries still need to forward consumer
+attrs (`class`, analytics `data-*`, extra ARIA) onto that input.
+
+**`v/spread-safe` is the one dynamic-map form that keeps the door proof:** owned
+`:value`/`:checked` and the owned handler remain literal and eligible; the
+forwarded residue cannot rewrite them. Opaque `v/spread` at a foreign widget
+cannot claim that guarantee — foreign components own their own timing.
+
+### Worked example — library field
+
+```clojure
+(v/defview field
+  [{:keys [label value on-change parts]}]
+  [:label {:data-component "my.lib/field"
+           :data-part "root"
+           :class "my-lib-field"}
+   [:span (v/spread-safe
+           {:data-part "label"}
+           (get parts :label))
+    label]
+   [:input
+    (v/spread-safe
+     {:data-part "control"
+      :value value
+      :on-input (conj on-change ::v/value)}
+     (get parts :control))]])
+
+[field {:label "Email"
+        :value email
+        :on-change [:account/email-changed]
+        :parts {:control {:class "wide-control"
+                          :data-analytics "signup-email"}}}]
+```
+
+The caller can restyle and annotate the control. They cannot pass
+`{:value other :on-input [:different/event] :key :new-id}` through `:parts` and
+steal the door. Full parts/theming policy: [Theming and parts](#theming-and-parts).
+
+### Worked sketch — foreign widget
+
+```clojure
+(v/defview date-field [{:keys [date on-pick] :as props}]
+  [DatePicker
+   (v/spread {:selected date
+              :on-change (v/event [v] (on-pick v))}
+             (dissoc props :date :on-pick))])
+```
+
+Use **`v/spread`** (not `spread-safe`) when the head is foreign and open. The
+literal owned keys still win collisions so a forwarded map cannot clobber your
+committed callback. Callback phase/identity still follows the
+[escape roster](events-and-handlers.md#the-escape-roster).
+
+### Choosing quickly
+
+| You are… | Use |
+|---|---|
+| Forwarding onto an **internal** `input` / DOM node / library leaf that is controlled | `v/spread-safe` |
+| Merging `:parts` attrs onto a declared `data-part` | `v/spread-safe` |
+| Forwarding remainder props onto a **foreign** React/host component | `v/spread` |
+| Replacing a label, row body, or trigger structure | composition ladder — not a spread |
+| Hoping a dynamic map keeps the door without `spread-safe` | it won’t — fix the merge |
+
+## Interpreted vs compiled
+
+The taxonomy is **common** to both modes:
+
+| Surface | Interpreted | Compiled |
+|---|---|---|
+| Trailing `:children` | same contract | same contract |
+| Compound fixed regions | same | same |
+| Parameterised row | ordinary pure fn OK | lexically visible `render-fn` / `slot` |
+| Stateful customisation | declared child view | declared child view (statically named under compiled parents) |
+| Cross-mode children | fine | statically named interpreted children of a compiled parent are explicit; no hidden walker |
+
+Call sites stay `[view props]`. Structural tests should not care which mode produced
+the tree for the common subset. See [Compilation — seam laws](compilation.md#crossing-modes-and-seam-laws-author-facing).
+
+## What is not composition
+
+| Temptation | Why it is wrong | Do this instead |
+|---|---|---|
+| Late tree→tree “theme” that rewrites Hiccup | smashes keys, controlled values, handlers; no runtime tree under compiled leaves | CSS / `data-part` / safe `:parts` + this ladder |
+| `:parts` that swap children or handlers | parts are attrs-only via `spread-safe` | structural form from the ladder |
+| Dynamic map on a controlled input without `spread-safe` | forfeits the door into batching | `v/spread-safe` for the residue |
+| `v/spread` on an internal controlled input | no door promise | `v/spread-safe` |
+| Opaque reactive closure as a slot | hides `sub` / identity | declared child view |
+| Emulating Radix `asChild` / prop cloning in neutral Hiccup | compound React protocol | UIx wrapper |
+| Caller-built `:children` inside the props map | reserved channel is trailing forms only | trailing children syntax |
+| Unkeyed list “for convenience” | identity and presence break | stable `:key` per child |
+
+## Theming and parts
+
+Library authors need a way to restyle controls without rewriting structure or
+breaking controlled inputs. D018 settles Freehand’s contract: **CSS cascade for
+tokens**, **`data-part` / `data-component` for addresses**, and **bounded `:parts`
+maps** merged safely. No late tree-transform theme system.
+
+App authors mainly consume `data-theme` and `:parts` from those libraries.
+
+### Two planes
+
+| Plane | Job | Mechanism |
+|---|---|---|
+| **Portable styling** | colours, spacing, density, motion tokens | CSS custom properties + classes / `data-theme` on a root or scope |
+| **Structure** | replace a label, row, or trigger | this page’s ladder: children, compound children, `v/render-fn`/`v/slot`, declared child views |
+
+Do not use “theme” to mean “rewrite the Hiccup after analysis.” Compiled leaves
+have no runtime tree for that, and uncontrolled rewrites can smash `:key`,
+controlled values, and handlers.
+
+### Tokens: CSS, not reactive subs
+
+Prefer:
+
+```css
+.my-app[data-theme="dark"] {
+  --my-lib-field-bg: #1a1a1a;
+  --my-lib-field-fg: #f5f5f5;
+}
+
+.my-lib-field[data-part="control"] {
+  background: var(--my-lib-field-bg);
+  color: var(--my-lib-field-fg);
+}
+```
+
+A theme switch that only flips `data-theme` (or a class) on a root **re-renders
+nothing** in Freehand. That is intentional: no per-leaf token subscriptions, no
+fan-out.
+
+Reserve re-frame values for the genuinely dynamic residue (user density preference
+that must also drive layout math, not only paint).
+
+### Parts: stable addresses
+
+Components emit **literal** part markers, scoped by a component marker:
+
+```clojure
+(v/defview field
+  [{:keys [label value on-change parts]}]
+  [:label {:data-component "my.lib/field"
+           :data-part "root"
+           :class "my-lib-field"}
+   [:span (v/spread-safe
+           {:data-part "label"}
+           (get parts :label))
+    label]
+   [:input
+    (v/spread-safe
+     {:data-part "control"
+      :value value
+      :on-input (conj on-change ::v/value)}
+     (get parts :control))]])
+```
+
+Rules:
+
+- **`data-part`** is identity for styling and docs — classes carry **variants**
+  only, not “which part this is.”  
+- Renaming a public part id is a **breaking** library change.  
+- Document part ids in the component schema/catalog when you ship library leaves.  
+
+### `:parts` maps: attrs only
+
+Callers may pass bounded overrides:
+
+```clojure
+[field {:label "Email"
+        :value email
+        :on-input [:account/email-changed ::v/value]
+        :parts {:label   {:class "quiet-label"}
+                :control {:class "wide-control"
+                          :data-analytics "signup-email"}}}]
+```
+
+Each declared part merges through **`v/spread-safe`** so the library’s owned
+literals win and the controlled-input door stays intact. That is why `:parts` is
+**legal on controlled parts**. Full merge law:
+[Spreading props](#spreading-props-attribute-forwarding).
+
+This must **not** be allowed as “theming”:
+
+```clojure
+;; illegal intent — must not replace controlled contract via :parts
+{:parts {:control {:value other
+                   :on-input [:different/event]
+                   :key :new-identity}}}
+```
+
+Unknown part ids and denied attributes should become source-located development
+findings.
+
+Structural customisation is not a part map — use the ladder above. Replacing a
+label with “icon + help popover” is structure, not CSS.
+
+### Interpreted vs compiled (theming)
+
+The portable plane (CSS + `data-part` + safe `:parts`) works in **both** modes.
+Do not design a library theme that requires interpreting compiled output at
+runtime. Arbitrary late tree→tree transforms may exist as **interpreted/test
+tooling** only — never as the portable Freehand theme contract.
+
+## Day-one checklist
+
+1. Start with **props**; add trailing children only for a real default region.  
+2. Name **fixed regions** when there is more than one hole.  
+3. Use **`render-fn` / `slot`** only for pure parameterised bodies.  
+4. Promote to a **declared child view** as soon as state or events appear.  
+5. Key every dynamic list of views.  
+6. Forward attrs with **`spread-safe`** (internal/controlled) or **`spread`**
+   (foreign) — never a bare dynamic map on a controlled door.  
+
+## If something feels wrong
+
+| Symptom | Fix |
+|---|---|
+| Controlled input lost door after attrs forward | `v/spread-safe`, not bare merge / `v/spread` |
+| Part override stripped role | owned a11y is denied in part merges — keep library roles |
+| Slot body hides `sub` | declared child view, not a reactive closure prop |
+| Theme requires rewriting structure | CSS / `data-part` / `:parts` attrs — structure uses the ladder |
+
+Library styling depth (tokens, parts maps): sections above. Under compilation,
+keep slot bodies lexically visible and child heads statically named.

--- a/docs/design/freehand/draft-guide/debugging.md
+++ b/docs/design/freehand/draft-guide/debugging.md
@@ -1,0 +1,174 @@
+# Debugging and performance
+
+A view looks stale, something feels slow, or you cannot tell which control owns a
+draft. Freehand answers those questions **as data** — and you climb a performance
+ladder **before** you compile.
+
+> **High `:stable-renders` means fix subs (or props), not compile.**
+
+!!! note "Design-target APIs"
+
+    Names such as `v/inspect-boundary` and `v/hot-views` match the design. Shapes
+    may refine as implementation lands; the **questions** are the contract.
+
+## Questions and where to look
+
+| Question | Where to look |
+|---|---|
+| Why didn’t this view re-render? | Boundary inspector: deps, last cause, props `rf=` |
+| Why re-render “for nothing”? | High `:stable-renders` / parent churn → fix subs or props |
+| What will this button dispatch? | Structural tree / Xray; handlers carry site identity |
+| What dispatched this event? | Trace tags (view source + attr) when present |
+| Where is this field’s draft? | Controller join — address, not mount path |
+| Orphan controller records? | `v/orphans` |
+| Live host behaviors? | `v/behaviors` |
+| Should I compile? | Only after the ladder below |
+
+Evidence records state how complete they are: **scope**, **basis**,
+**completeness**, and **loss**. “Proven / observed / opaque” are labels on that
+grid — not separate product modes.
+
+## Performance ladder (before compilation)
+
+Work in this order:
+
+1. **Inspect the cause** — which query or parent churn drove the render?  
+2. **Narrow the subscription** — classic bug: every cell reads a global
+   “editing id”; fix with per-id predicates so one click dirties two cells, not
+   two thousand.  
+3. **Choose the boundary** — keyed rows for independent change; helpers for pure
+   structure you are happy to re-run with the parent.  
+4. **Window large lists** — do not mount what the user cannot see.  
+5. **Measure again** with `v/hot-views` (below).  
+6. **Only then** compile a remaining hot boundary, or a library leaf that needs
+   static proof.  
+
+If a host library or React reconciliation dominates the budget, another Hiccup
+compiler will not save you — fix the host boundary or the data size.
+
+## `v/hot-views` — anti-folklore measurement
+
+Dev-only counters on work the interpreter (and compiled cells) already do:
+
+```clojure
+(v/hot-views frame)
+;; ⇒ [{:view app/person-list
+;;     :renders 214
+;;     :self-ms-p95 6.2
+;;     :nodes 12040
+;;     :rows-max 1200
+;;     :top-causes [[[:crud/filtered-people] 180]
+;;                  [[:rf.view/parent] 30] …]
+;;     :stable-renders 0.31
+;;     :interp-slots 0}]
+```
+
+How to read it:
+
+| Signal | Meaning |
+|---|---|
+| High `self-ms × renders` and high `nodes` | Interpretation cost may matter — candidate for compile **after** structural fixes |
+| High `:stable-renders` | Output often equal — **narrow subs** or stop rebuilding props |
+| `:top-causes` with `[:rf.view/parent …]` | Parent re-rendered without a moved sub — unstable props (inline maps, per-render fns) |
+| `:interp-slots` | Count of `v/markup` (or similar) interpreted holes under a compiled path |
+
+Promote on interpretation work, not on a percentage of “hot.” After promotion, the
+**same** counters should still flow so you can see whether the win was real
+(evidence continuity).
+
+## `v/inspect-boundary` — “why is this view wrong?”
+
+The first move in most debug sessions is: show me what this boundary actually
+depends on.
+
+```clojure
+(v/inspect-boundary occurrence)
+;; ⇒ {:occurrence …
+;;    :view app/todo-row
+;;    :committed [{:query [:todo/by-id 7] :value … :owned? true} …]
+;;    :last-render {:epoch 812 :cause [:todo/by-id 7]}
+;;    :props {:current … :rf=-prev? true}
+;;    :door-sites [{:attr :on-input :door? true :reason :literal-controlled}]
+;;    :controller {:kind :fh/buffered-field :address [:invoice 42 :amount]}}
+```
+
+Typical uses:
+
+- **Stale view** — compare committed queries to the query you thought you mutated.
+  Mismatch is often the bug (wrong id, wrong frame, conditional branch not taken).  
+- **Props churn** — `:rf=-prev? false` with no meaningful data change → parent is
+  rebuilding maps or functions.  
+- **Controlled door** — which sites are synchronous and why.  
+- **Controller join** — which semantic address is joined to this occurrence (tool
+  plane). Storage is still under the library’s app-db path keyed by that address.  
+
+How you obtain `occurrence` is tooling-dependent (Xray click, mounted-views table,
+error summary). The design requires the read; the UI that picks the occurrence may
+be Xray or a REPL helper.
+
+## Companions: orphans and behaviors
+
+```clojure
+(v/orphans frame {:epochs n})
+;; controller records with no mounted occurrence join for n epochs
+
+(v/behaviors frame)
+;; active behavior connections per occurrence
+```
+
+Orphans matter because controller state is **not** cleared on unmount. After a form
+route leave, orphans should go to zero if your owner clear is correct. Behaviors
+answer “is this Vega/Mapbox connection still live, and under which occurrence?”
+
+## Traces: “what dispatched this?”
+
+UI handlers stamp development tags (view site + attr such as `:on-click`) so a
+dispatch ties back to the tree:
+
+- forward: tree → intent (structural test / Xray)  
+- backward: trace → site  
+
+Production keeps evidence bounded; completeness fields say what was lost.
+
+## Evidence surface roster (design target)
+
+Tools **read** one host-neutral schema — they are not a second Freehand. Names may
+polish; jobs stay stable:
+
+| Projection (illustrative) | Answers |
+|---|---|
+| `v/inspect-boundary` | one occurrence: deps, cause, props, door, controller |
+| `v/hot-views` | expensive / high-churn views |
+| `v/orphans` | controller records without a mounted join |
+| `v/behaviors` | live host connections |
+| manifests / mounted-views / explain-render | static sites, live occurrences, causes |
+
+Every projection should state **scope**, **basis**, **completeness**, and **loss**.
+Detailed evidence is compiled out of production.
+
+## Warnings vs errors
+
+| Kind | When | Author experience |
+|---|---|---|
+| **Hard error** | illegal tree, bad compiled form, render-phase `sub`, invalid event outcome, … | fails loudly with recovery |
+| **Default-on warning** | contract misfire that would surface far away | once per source site + kind |
+| **Opt-in quality lint** | predictive / style / “maybe promote” | `v/check` categories you enable |
+
+Freehand does not nag you into compiling. Fix a site once and the warning should
+stay quiet until the source changes.
+
+## Demote-to-debug (compiled views)
+
+1. Remove `{:compiled true}`.  
+2. Reproduce with ordinary Clojure stacks.  
+3. Fix; run `v/check`.  
+4. Restore `{:compiled true}` if still needed.  
+
+Call sites, structural tests, and identity stay the same. Demotion **is** the
+debug mode — not a second product.
+
+## Xray and related tools
+
+Xray (Story, pair MCP) read the same evidence vocabulary. Use epoch history for
+“what ran,” filters when typing is noisy, and controller badges when join data is
+available. Per-keystroke events are not hidden by default — filter them.

--- a/docs/design/freehand/draft-guide/events-and-handlers.md
+++ b/docs/design/freehand/draft-guide/events-and-handlers.md
@@ -1,0 +1,333 @@
+# Events and handlers
+
+You need the view to **tell re-frame what happened** without burying intent in
+closures. The paved path is an **event vector** on the control.
+
+```clojure
+[:button {:on-click [:cart/add product-id]} "Add to cart"]
+```
+
+When the button is clicked, Freehand dispatches `[:cart/add product-id]` to the
+frame this view is running under. Everywhere else in re-frame2, intent is already
+data; Freehand keeps the last mile the same.
+
+> **A handler is data until it can’t be — and each non-data form names exactly
+> what it needs.**
+
+Vectors win for ordinary UI work because they are readable, assertable on a
+structural tree, free of stale render closures, and friendly to memo.
+
+## The paved path: handlers as data
+
+The everyday handler is not a function. It is an **event vector** as above.
+
+## Projections: three live scalars
+
+Sometimes the event needs a value that only exists when the browser fires — the
+current text of an input, whether a checkbox is checked, which key was pressed.
+
+Freehand reserves three **projection markers** for that:
+
+```clojure
+[:input {:on-input  [:form/typed :email ::v/value]}]
+[:input {:type :checkbox :on-change [:prefs/set :dark ::v/checked]}]
+[:div   {:on-key-down [:editor/key ::v/key]}]   ; "Enter", "a", …
+```
+
+At fire time Freehand fills every matching **top-level** marker, then ordinary
+`dispatch` runs on the finished vector.
+
+- Nested markers stay ordinary data — not magic.  
+- Position zero (the event id) must not be a marker.  
+- Marker present but payload unavailable → typed error, no dispatch.  
+
+The same materializer covers literals, forwarded vectors, options maps, `v/event`
+results, both modes, production and tests. Reuse it in tests
+([Testing](testing.md)) — no second splice path. General `rf/dispatch` does **not**
+grow a payload-map arity; that is Freehand’s job at the event site.
+
+## Options maps
+
+When you need ordinary DOM listener options, use a shallow map with a closed
+vocabulary (`:prevent-default`, `:stop-propagation`, `:capture`, `:passive`,
+`:once`):
+
+```clojure
+[:form {:on-submit {:event [:signup/requested] :prevent-default true}}]
+```
+
+The event is still data. The mechanics are data too, instead of a wrapper function
+that calls `.preventDefault`.
+
+## Keyboard conditions
+
+For simple key branching on `:on-key-down` and `:on-key-up`, Freehand allows one
+extra closed data form: a map from exact key strings to handler forms.
+
+```clojure
+{:on-key-down
+ {"Enter"     {:event [:picker/accept] :prevent-default true}
+  "Escape"    [:picker/close]
+  "ArrowDown" {:event [:picker/move 1] :prevent-default true}}}
+```
+
+Keys are exact `KeyboardEvent.key` values (`"Enter"`, not a key code). Values are
+the same handler shapes you already know: vector, options map, `v/event`, or
+`nil`. Selection is one level deep. A missing key is a no-op. During IME
+composition, no branch matches.
+
+No wildcards, regexes, modifier chords, or state predicates in this map — use
+`v/event` or a host boundary for those. The form is deliberately small; it may be
+removed before release if pilots do not show repeated use.
+
+## One event per user action
+
+An event-producing site yields **exactly one** event vector, or `nil`. A vector of
+vectors is an error.
+
+If one click must do several things, write **one** domain event and return the
+effects from its handler — one epoch, one cause, one place to reason.
+
+## Controlled inputs
+
+```clojure
+[:input {:value (v/sub [:form/email])
+         :on-input [:form/typed :email ::v/value]}]
+```
+
+A **controlled** native node has `:value` or `:checked` in props (key present,
+including `nil`). On **`:on-input`** and **`:on-change` only**, eligible handlers
+ride the **synchronous door**:
+
+1. materialize projections  
+2. dispatch  
+3. drain re-frame  
+4. flush dirty Freehand cells on **this frame**  
+5. then return into React  
+
+That same-tick round trip protects characters, caret, and IME.
+
+Eligible: vector, options map with a vector, or synchronous `v/event` → vector/`nil`.
+Not door-eligible: `v/handler`, promises, foreign components (they own timing).
+Blur, keydown, and friends stay ordinary sites — they do not run the door flush.
+
+**`:on-before-input` is not on the door** (fires before the DOM mutation). Treat it
+as an ordinary listener.
+
+Other dirty cells on the same frame may ride the flush — keystroke latency can
+couple to background work. Measure under load when it matters.
+
+Forwarding attrs onto a controlled input: use **`v/spread-safe`** (preserves door
+proof). Plain `v/spread` does not. Details:
+[Composition — spreading props](composition.md#spreading-props-attribute-forwarding).
+
+## Three ways to wire a text field
+
+No controller required for ordinary forms. Day to day, pick A, B, or (rarely) C.
+
+### A — Live domain field (simplest)
+
+Each keystroke **is** the product value — live filter, simple form field, autosave
+path.
+
+```clojure
+[:input {:value    (v/sub [:lines/label id])
+         :on-input [:lines/set-label id ::v/value]}]
+```
+
+Usually you only need the `on-input` event. Enter might submit a surrounding form,
+or do nothing special for this field.
+
+### B — App-owned draft, then commit (still no controller)
+
+You want: type freely → accept on blur or Enter → cancel on Escape — but only in
+**this** app, with **your** app-db keys.
+
+```clojure
+[:input {:value   (v/sub [:lines/draft id])
+         :on-input [:lines/draft-changed id ::v/value]
+         :on-blur  [:lines/label-committed id]
+         :on-key-down {"Enter"  [:lines/label-committed id]
+                       "Escape" [:lines/draft-cancelled id]}}]
+```
+
+**Which events should match?**
+
+| Sites | Same event? | Why |
+|---|---|---|
+| `on-input` vs Enter | **No** | Keystroke updates the **draft**; Enter means **accept** |
+| `on-blur` vs Enter | **Yes** | Both are the **commit** transition |
+| Escape | Different | **Cancel** — clear draft, do not write the domain value |
+
+Commit handlers usually **read the draft from app-db**. You typically do not need
+`::v/value` on Enter or blur. Put `::v/value` on `on-input`, where the new string
+arrives from the DOM.
+
+You own cleanup: clear drafts in cancel and commit handlers, and when leaving the
+form or route if needed. Unmount does not invent cleanup for you.
+
+### C — Library semantic controller (optional)
+
+Same *kind* of user experience as B, but packaged for reuse: stale blur after
+cancel, required reset generation, many call sites. The call site looks like a
+`buffered-field` with a `:control` address.
+
+That control is **not** core Freehand. See
+[Semantic controllers](semantic-controllers.md).
+
+### Choosing quickly
+
+| Need | Pattern |
+|---|---|
+| Keystroke is the truth | **A** |
+| Draft then commit, app-specific | **B** |
+| Same hard protocol everywhere | **C** (library) |
+
+## Day-one checklist
+
+Stop when you can:
+
+- put event vectors on buttons and forms  
+- use `::v/value` / `::v/checked` / `::v/key` for live scalars  
+- wire pattern **A** or **B** for a text field  
+- keep multi-step work as **one** domain event + effects  
+
+## If something feels wrong
+
+| Symptom | Fix |
+|---|---|
+| Vector of vectors on one click | one semantic event; effects do the rest |
+| Nested `::v/value` “did nothing” | markers only at **top-level** event args |
+| Caret/IME broken while typing | controlled door: `:value`/`:checked` + `:on-input`/`:on-change` |
+| Stale “still open?” in a callback | decide in the re-frame handler at fire time |
+| Bare fn on a foreign component prop | `v/event` / `v/handler` / `v/render-fn` / `v/raw-fn` |
+
+## Each keystroke is an event
+
+On patterns A–C, while the field is controlled and typing updates re-frame,
+**each keystroke dispatches a new re-frame event**. Freehand does not batch
+keystrokes into one event for free.
+
+What that means in practice:
+
+- Typing `hello` is about five edit events, plus whatever those runs emit.  
+- In **Xray**, the event list will look busy while typing. That is expected, not a
+  bug.  
+- Filter by event id (draft-changed vs committed), or focus on commit events when
+  you care about “what was accepted.”  
+- Keep edit handlers cheap and subscriptions narrow. Latency is roughly “one event
+  path per character.”  
+
+If you truly want **zero** per-keystroke re-frame traffic, that is a different
+design — for example a host-owned buffer and one event on commit only. That is an
+escape hatch, not the paved controlled path, and you give up mid-edit
+inspectability in app-db and Xray.
+
+## Uncontrolled inputs (deliberate escape)
+
+The paved path is **controlled** (`:value` / `:checked` present → synchronous
+door). Sometimes a large grid or edit-in-place cell wants **zero mid-edit
+app-db traffic**: the DOM holds text until commit.
+
+```clojure
+;; Uncontrolled: no :value key — not on the Freehand door
+[:input {:default-value raw
+         :auto-focus    true
+         :on-blur       (v/event [e]
+                          [:cells/commit-edit id (.. e -target -value)])
+         :on-key-down   {"Enter"  (v/event [e]
+                                    [:cells/commit-edit id (.. e -target -value)])
+                         "Escape" [:cells/cancel-edit id]}}]
+```
+
+| You gain | You give up |
+|---|---|
+| No per-keystroke events / writes | Mid-edit text **not** in app-db or Xray |
+| Cheap for huge edit grids | No controlled-door caret/IME guarantee from Freehand |
+| Simple commit-on-blur | Harder structural tests of “what is typed right now” |
+
+Rules:
+
+- **Do not mix** `:value` and `:default-value` on the same node as a clever hybrid.  
+- Prefer controlled A/B for ordinary forms; use uncontrolled when cost measurement
+  shows per-keystroke state is the problem (fitness harness cells-style).  
+- Commit still goes through **one** re-frame event; cleanup still is not unmount
+  magic.
+
+## Forwarding intent through components
+
+Parents pass data. The child’s own site dispatches in its committed frame:
+
+```clojure
+(v/defview icon-button [{:keys [event label]}]
+  [:button {:aria-label label :on-click event}
+   label])
+
+[icon-button {:event [:item/deleted item-id] :label "Delete"}]
+```
+
+A library control that cannot know your full event grammar often takes an **event
+prefix** and appends the live payload at its own DOM site:
+
+```clojure
+;; caller
+[text-field {:value email :on-change [:form/set-email]}]
+
+;; inside text-field
+[:input {:value value
+         :on-input (conj on-change ::v/value)}]
+```
+
+## The escape roster
+
+When a vector is not enough, pick the form that matches the job:
+
+| You need | Write | Notes |
+|---|---|---|
+| Dispatch intent (the common case) | `[:event … ::v/value]` | data; canonical |
+| Live event — files, geometry, filters | `(v/event [e] …)` | return one vector or `nil`; no `sub`, hooks, or refs inside |
+| Imperative foreign work | `(v/handler [x] …)` | return ignored; stable per site |
+| Callback invoked **while rendering** | `(v/render-fn [x] …)` | pure; no dispatch or app state |
+| Identity-as-protocol APIs | `(v/raw-fn f)` | identity passes through unchanged |
+| React hooks / portals / context | UIx wrapper | not neutral Freehand |
+| Quick local work on a **native** `:on-*` | bare `#(…)` | legal there only |
+| Any callback on a **foreign** component | one of the explicit forms | bare fn is rejected |
+
+**Phase rule:** event handlers see **committed** values — what the user actually
+saw. Render callbacks see the **current** render. One bare function cannot honestly
+promise both.
+
+There is no generic `v/dispatcher` helper, and no dependency-annotated `v/event`.
+Foreign argument conversion is `v/event`.
+
+## Callback identity and lifetime
+
+Each runtime event or handler site is owned by a pair: the **committed node
+identity** and the **callback prop** (`:on-click`, `:onChange`, and so on). Node
+identity is key-aware among siblings.
+
+A few laws that keep foreign libraries and memoisation sane:
+
+| Law | Meaning |
+|---|---|
+| Equal values at **two sites** | two independent callbacks — they never share `:once` state or lifecycle |
+| Unchanged handler value | the **same** JS function across re-renders of that site |
+| Changed handler value | re-mint at commit with the new body |
+| Abandoned render | never updates live callbacks |
+| Disconnect, key change, HMR fence | that exact callback is **retired** — if something still calls it, it stays inert and does not dispatch into a replacement frame |
+| `v/render-fn` | not on that mutable-proxy scheme; it may run during an uncommitted foreign render |
+
+That is why bare functions are illegal at foreign callback positions: Freehand
+cannot know the phase or the identity contract. Annotate with the roster form that
+matches the protocol.
+
+## Decisions that depend on live state
+
+When acceptance depends on changing application state — stale blur after cancel,
+late dropdown select — put identity or generation in the intent if you need them,
+but make the **decision in the re-frame handler** against the committed frame at
+fire time.
+
+Do not close over a render-time “still editing?” guard inside a minted callback and
+hope it is still true later. That is the classic race Freehand is trying to make
+unattractive.

--- a/docs/design/freehand/draft-guide/forms.md
+++ b/docs/design/freehand/draft-guide/forms.md
@@ -1,0 +1,270 @@
+# Forms
+
+One controlled field is not enough. You need multi-field drafts, validation that
+does not scream early, submit that cannot double-fire, and **async loads that do
+not wipe keystrokes**.
+
+One field is ordinary Freehand wiring. This page covers a **form** — one re-frame
+slice, a blessed shape, and seed-merge.
+
+> **Draft + baseline + touched + errors + submit-attempted? Seed only untouched keys.**
+
+## The blessed form-slice shape
+
+Prefer one coherent map per form (or per form instance), not a scatter of unrelated
+keys:
+
+```clojure
+{:draft             {…}      ; what the inputs show / edit
+ :baseline          {…}      ; last known good server/domain values
+ :touched           #{…}     ; fields the user has edited (or set of keys)
+ :errors            {…}      ; field → message (or structured errors)
+ :submit-attempted? false}
+```
+
+Names can vary; the **jobs** should not. The fitness harness “blessed form-slice”
+is this five-slot shape (P3):
+
+| Slot | Job |
+|---|---|
+| **draft** | current field values under edit |
+| **baseline** | values to reset to / merge from server |
+| **touched** | which fields have been interacted with |
+| **errors** | validation messages (often derived or event-written) |
+| **submit-attempted?** | user tried to submit — unlocks “show all errors” |
+
+**Busy / pending** is not a required form-slice key. Derive it from your mutation
+instance, resource, or a sibling flag, and fold it into submit-enabled? / disabled
+UI (below).
+
+Ordinary app-db under your path (`:editor`, `[:forms invoice-id]`, …). Freehand
+does not ship a form macro — only this **shape** as shared convention.
+
+## Field wiring (still A / B / C)
+
+Each field is still a Freehand controlled input (live domain or app-owned draft):
+
+```clojure
+(v/defview email-field [_]
+  (let [draft  (v/sub [:editor/draft])
+        error  (v/sub [:editor/field-error :email])
+        text   (:email draft)]
+    [:label
+     "Email"
+     [:input {:value    (or text "")
+              :on-input [:editor/edit-field :email ::v/value]
+              :on-blur  [:editor/blur-field :email]}]
+     (when error [:p.error error])]))
+```
+
+Typical event duties:
+
+- **edit-field** — update `:draft`, add key to `:touched`  
+- **blur-field** — optional per-field validate into `:errors`  
+- **submit** — set `:submit-attempted? true`, validate all, dispatch mutation if ok  
+
+## Show errors only when it helps
+
+A common corpus pattern: do **not** scream about empty required fields before the
+user has touched them or tried to submit.
+
+```clojure
+(rf/reg-sub :editor/field-error
+  (fn [db [_ field]]
+    (let [{:keys [errors touched submit-attempted?]} (:editor db)]
+      (when (or submit-attempted? (contains? touched field))
+        (get errors field)))))
+```
+
+Derived **submit enabled?** gates usually combine:
+
+- required draft fields present  
+- no blocking errors (under the same touched/attempted policy)  
+- not busy on a mutation  
+
+Keep that logic in `reg-sub`, not in the view.
+
+## Seed merge: never clobber typed fields (R-C1)
+
+This is the live footgun in many apps (including this repo’s RealWorld editor
+history): a late async load replaces the whole form slice and wipes keystrokes.
+
+**Blessed spelling — seed only untouched fields:**
+
+```clojure
+(rf/reg-event :editor/article-loaded
+  (fn [{:keys [db]} [_ slug article]]
+    (let [{:keys [draft touched]} (get db :editor)
+          seeded (reduce-kv
+                  (fn [d k v]
+                    (if (contains? touched k)
+                      d                 ; user already typed here — keep it
+                      (assoc d k v)))   ; otherwise take server value
+                  draft
+                  article)]
+      {:db (assoc db :editor {:slug     slug
+                              :draft    seeded
+                              :baseline article
+                              :touched  (or touched #{})})})))
+```
+
+Rules of thumb:
+
+- On first open, `touched` is empty → full seed from server.  
+- After the user types, those keys stay in `touched` → late replies cannot
+  overwrite them.  
+- Untouched fields still pick up late server data (title arrived, user never
+  focused it).  
+- Reset / “reload form” is an explicit event that clears `touched` on purpose.  
+
+If you use a single whole-map `assoc` of the server payload into `:draft`, you
+will reintroduce the clobber bug.
+
+## Day-one checklist
+
+- One form-slice map (or instance-keyed path) for the form  
+- Fields wired A/B with edit → `touched`  
+- Errors gated on touched or submit-attempted  
+- Late loads use **seed-merge** (never full `assoc` over draft)  
+- Submit validates once, then starts the mutation  
+
+## If something feels wrong
+
+| Symptom | Fix |
+|---|---|
+| Typing wiped by slow GET | seed only keys not in `touched` |
+| Errors on empty form before touch | gate on `touched` / `submit-attempted?` |
+| Double submit | busy/pending from mutation path |
+| Two editors share one `:editor` | instance key in the path |
+| “Need a form macro” | convention above — Freehand does not ship one |
+
+## Submit, busy, and disabled
+
+The view stays passive: draft, errors, and busy come from subs; submit is one
+event vector (or form options map).
+
+```clojure
+;; Busy is commonly a mutation/resource fact, not a form-slice key
+(rf/reg-sub :editor/busy?
+  (fn [db _]
+    (boolean (get-in db [:mutations :editor-save :pending?]))))
+
+(rf/reg-sub :editor/can-submit?
+  (fn [db _]
+    (let [{:keys [draft errors]} (:editor db)
+          busy? (get-in db [:mutations :editor-save :pending?])]
+      (and (not busy?)
+           (seq (:title draft))
+           (empty? errors)))))
+
+(rf/reg-event :editor/submit
+  (fn [{:keys [db]} _]
+    (let [editor (assoc (:editor db) :submit-attempted? true)
+          errors (validate-editor editor)]
+      (if (seq errors)
+        {:db (assoc db :editor (assoc editor :errors errors))}
+        {:db (assoc db :editor (assoc editor :errors {}))
+         :fx [[:dispatch [:editor/save (:draft editor)]]]}))))
+```
+
+```clojure
+(v/defview editor-actions [_]
+  (let [busy?    (v/sub [:editor/busy?])
+        can-save (v/sub [:editor/can-submit?])]
+    [:button {:disabled (or busy? (not can-save))
+              :on-click [:editor/submit]}
+     (if busy? "Saving…" "Save")]))
+```
+
+Rules of thumb:
+
+- **Validate in events/subs**, not only in the button’s `disabled` expression.  
+- **Busy / pending** (mutation instance, resource, or sibling flag) owns
+  double-submit; clear it on success *and* failure in the mutation path.  
+- Form-level **options map** for native submit is fine:
+  `{:on-submit {:event [:editor/submit] :prevent-default true}}`.  
+- Server errors merge into `:errors` without wiping `:draft` or `:touched`.
+
+## Dual-field live transform (no local state)
+
+Some screens need two fields that reformat each other (temperature C/F, currency
+pair). Keep **raw typing and which field is active** in re-frame — not in a
+component atom — so mid-keystroke text does not reformat under the caret:
+
+```clojure
+;; Conceptual slice
+{:c-text "22" :f-text "71.6" :active :c}
+
+;; Subs: active field echoes raw text; the other shows derived display
+(rf/reg-sub :temp/c-display
+  (fn [db _]
+    (let [{:keys [c-text f-text active]} (:temp db)]
+      (if (= active :c) c-text (f->c-string f-text)))))
+
+;; Events: typing sets :active + raw text; optional derive of the sibling raw
+(rf/reg-event :temp/c-typed
+  (fn [{:keys [db]} [_ text]]
+    {:db (update db :temp
+                 #(assoc % :active :c :c-text text
+                           :f-text (c->f-string text)))}))
+```
+
+```clojure
+[:input {:value (v/sub [:temp/c-display])
+         :on-input [:temp/c-typed ::v/value]}]
+[:input {:value (v/sub [:temp/f-display])
+         :on-input [:temp/f-typed ::v/value]}]
+```
+
+That is ordinary Freehand pattern A with a careful sub graph — not a controller
+and not host-local buffers.
+
+## Async races beyond seed-merge
+
+R-C1 protects **draft** from late seeds. Related races use the same rule: **decide
+in the re-frame handler against committed state**, and carry identity/generation
+in the intent when needed.
+
+| Race | Blessed approach |
+|---|---|
+| Late article load vs typing | seed only untouched keys (above) |
+| Typeahead: slow reply after newer query | store `request-id` / generation; ignore stale replies |
+| Debounced search | cancel-and-replace in the effect layer; one semantic “query changed” event |
+| Stale blur after Escape | commit handler consults live session; ignore retired generation |
+| Unmount mid-flight | owner/route cleanup; do not couple domain success to view mount |
+
+Typeahead / debounce stay ordinary re-frame (generation supersession); package a
+controller only when reuse demands it.
+
+## Multiple instances
+
+Two open editors (or a list of line items) need **instance keys** in the path:
+
+```clojure
+;; e.g. [:forms invoice-id] or [:editor slug]
+(get-in db [:forms invoice-id :draft :amount])
+```
+
+Do not store two forms under one global `:editor` key unless only one can exist.
+Reusable field protocols that are not the whole form use explicit `:control`
+addresses.
+
+## Testing forms
+
+Prefer headless Freehand tests:
+
+1. Make a frame with init / seed events.  
+2. `dispatch-sync` the **same** edit intents the tree would show
+   (`[:editor/edit-field :email "a@b.c"]`).  
+3. Render with `t/render` and assert values, error visibility, disabled submit.  
+4. For R-C1: edit a field, then dispatch a late load; assert the typed field
+   survived.  
+
+## What Freehand does not ship
+
+| Not in Freehand core | Your job / library |
+|---|---|
+| `form-slice` macro | the map shape above as convention |
+| Automatic validation engine | your validate fn + subs |
+| Built-in form component set | build with `v/defview` + data events |
+| Mount-time fetch | routes / resources own loading |

--- a/docs/design/freehand/draft-guide/host-boundaries.md
+++ b/docs/design/freehand/draft-guide/host-boundaries.md
@@ -1,0 +1,357 @@
+# Host boundaries
+
+Most Freehand code never needs this page. Ordinary views stay in data: Hiccup,
+event vectors, subscriptions, props.
+
+Real apps still embed React widgets, canvas libraries, dialogs, and measurement.
+Those are **host facts** — not app-db. Freehand gives a small set of **explicit
+boundaries** so the host work is honest and the rest of the tree stays inspectable.
+
+There is no general “neutral hooks / refs / effects” language in ordinary views.
+
+> **Qualify the host edge. Keep application truth in re-frame.**
+
+## Three host shapes
+
+| Shape | Use when |
+|---|---|
+| **Qualified host leaf** | A React component that is mostly values in and callbacks out |
+| **Registered behavior** | One DOM node owned by an imperative library (`connect` / `update` / `disconnect`, optional commands) |
+| **UIx wrapper** | Hooks, context, portals, refs, effects, compound React protocols (`asChild`, Suspense, …) |
+
+Bare React component heads are outside the Freehand tree — qualify them.
+
+### Qualified React leaf
+
+```clojure
+(ns app.booking
+  (:require [re-frame.freehand :as v]
+            [re-frame.freehand.host :as host]))
+
+(def date-picker-host
+  (host/component ::date-picker DatePicker))
+
+(v/defview booking-date [_]
+  (v/client-only
+   {:fallback [:input {:type :date
+                       :value (v/sub [:booking/date-iso])
+                       :read-only true}]}
+   [date-picker-host
+    {:selected (->js-date (v/sub [:booking/date]))
+     :onChange (v/event [date]
+                 [:booking/date-picked (from-js-date date)])}]))
+```
+
+- Foreign callbacks use the [escape roster](events-and-handlers.md#the-escape-roster)
+  — never a bare function at a declared foreign callback position.
+- Props are open at the foreign head. Values pass through per the host conversion
+  rules for that leaf.
+- A React component does **not** gain SSR semantics merely because it can create
+  browser DOM. Use `client-only` or an explicit JVM/SSR adapter.
+
+### `v/client-only`
+
+Marks a subtree that must not pretend to run on the server:
+
+```clojure
+(v/client-only
+ {:fallback [:div.chart-placeholder "Chart loads in the browser"]}
+ [chart-host {:spec spec}])
+```
+
+| Side | Behaviour |
+|---|---|
+| JVM / SSR | render the **fallback** (or inert policy) |
+| Browser | mount the real host subtree after hydrate |
+| Hydration | mismatch without a truthful fallback is an error |
+
+Use for canvas charts, maps, and libraries with no honest server output.
+
+### Registered behaviors
+
+Use this for **DOM-owned** imperative libraries (Vega View, Mapbox, SpreadJS,
+canvas editors) — not for “I wanted `useEffect`.”
+
+```clojure
+(host/defbehavior vega-view
+  {:connect    connect-vega!
+   :update     update-vega!
+   :disconnect disconnect-vega!
+   :ssr        :inert})   ; or explicit fallback policy
+
+(v/defview chart [{:keys [spec data on-signal]}]
+  [:div.chart
+   {::v/behavior [vega-view
+                  {:spec spec
+                   :data data
+                   :on-signal on-signal}]}])
+```
+
+| Rule | Meaning |
+|---|---|
+| `connect` | after **selected commit**; returns private memory |
+| Timing | registry metadata: `:passive` (default) or `:layout` (before paint) — not use-site syntax |
+| `update` | when public config changes by `rf=` |
+| `disconnect` | exactly once per connection; tolerate reconnect/replay |
+| Config | Clojure values + event intents only — no nodes, refs, prebuilt instances |
+| One behavior per node | a second is illegal |
+| Opaque descendants | if the library owns children, ordinary Hiccup children are **rejected** |
+| Outward intents | dispatch through the **committed** frame; disconnected generation is **inert** |
+| JVM | inert marker + public config, or explicit fallback if the behavior owns visible content |
+| Evidence | connect/update/disconnect are **tool facts**, not domain events |
+
+**`:layout` behaviors** must not flash wrong geometry. Prove measure-then-place,
+state whether they track resize/scroll with bounded observers, and never run a
+silent animation-frame loop. Total cleanup of listeners/observers is part of the
+contract.
+
+This is **not** a general `on-mount` / `on-unmount` callback API.
+
+### Commands (one-shot host ops)
+
+Optional finite command map on a behavior for export, print, focus-cell, etc.:
+
+```clojure
+(host/defbehavior workbook
+  {:connect    connect-workbook!
+   :update     update-workbook!
+   :disconnect disconnect-workbook!
+   :commands   {:export-xlsx export-xlsx!
+                :focus-cell  focus-cell!}})
+
+;; use-site — :instance only when commands need a target
+[:div
+ {::v/behavior
+  [workbook {:instance [:invoice-sheet invoice-id]
+             :document document
+             :on-result [:invoice/workbook-result]}]}]
+
+;; from a re-frame handler
+{:fx [[:re-frame.freehand.host/command
+       {:target [:invoice-sheet invoice-id]
+        :op     :export-xlsx
+        :args   {:filename "invoice.xlsx"}}]]}
+```
+
+| Rule | Meaning |
+|---|---|
+| `:instance` / `:target` | caller-supplied **value** identity in frame/root scope — not a DOM path or “last mounted” |
+| Timing | only the **currently committed** connection; never queued for a future mount |
+| Replay | never replayed after reconnect / trace replay |
+| Multi-root | name the Root Descriptor id when targets could collide; Freehand does not pick |
+| Return | no host handles in effects; async completion → generation-fenced intent |
+| Steady state | still flows through config + `update`; commands are the narrow one-shot escape |
+
+### UIx wrappers
+
+When the integration needs React’s real protocol surface (hooks, context, portals,
+ref merging, `asChild`, Suspense), write an **honest UIx wrapper**. Freehand does
+not emulate those in neutral Hiccup. Keep the wrapper’s **public props and outward
+intents** visible in the structural tree; mark the interior opaque.
+
+## Outward React bridge (`v/->react`)
+
+Some React libraries demand a **component value** as a prop (cell renderer, drag
+overlay). That is how you put Freehand **inside someone else’s React DOM tree** —
+not by mounting a second full app, and not by inventing a fourth host shape.
+
+```clojure
+{:cellRenderer (v/->react person-cell)}
+
+(v/->react person-cell {:map-props cell-props})
+```
+
+Think of it as the reverse of a host leaf: the foreign tree is the parent, Freehand
+is the island.
+
+| Rule | Meaning |
+|---|---|
+| Input | only a declared Freehand **descriptor** |
+| Cache | memoized React component by descriptor (+ stable mapper) identity |
+| Default props | shallow copy of own enumerable props except reserved `frame` |
+| `:map-props` | optional stable adapter: foreign props → one Freehand props map |
+| Frame | reserved `frame` prop or ambient context — **never creates** a frame |
+| Missing/dead frame | loud failure |
+| Not included | deep conversion, key camelCase magic, callback guessing, ref forward, children conversion |
+| JVM | typed host-operation error unless SSR adapter / `client-only` |
+
+**Frame is required for Freehand to work inside that island.** Either the
+surrounding Freehand/React context already provides one, or the foreign parent
+passes a reserved `frame` prop pointing at a **live** frame you already created.
+The bridge will not mint a new world for you.
+
+Protocols needing hooks, refs, or compound cloning still need a real UIx wrapper.
+
+## DOM top layer
+
+Desired **open** state for platform popover/dialog — not presence, not portals:
+
+```clojure
+[:div {:popover :auto
+       ::web/popover-open? open?
+       :on-toggle
+       (v/event [e]
+         (conj on-open-change (= "open" (.-newState e))))}]
+
+[:dialog {::web/modal-open? open?
+          :on-cancel [:dialog/cancelled]}]
+```
+
+| Intrinsic | Constraint |
+|---|---|
+| `::web/popover-open?` | only with a valid `:popover` mode |
+| `::web/modal-open?` | only on `<dialog>` → `showModal()` / `close()` |
+| Non-modal dialog | platform `:open` attribute |
+
+Browser dismissal never silently mutates app-db. Reconcile through intents.
+Development reports a controlled top-layer node with no reconciliation handler.
+**No neutral portal** in v1; React portals stay in wrappers. Timed exit after close
+pairs with [Presence](presence.md). Positioning is CSS anchors or a behavior.
+
+## Error boundaries
+
+Render failures happen: nil assumptions, bad data, a foreign component throw,
+malformed Hiccup. Freehand already guarantees that a **thrown render owns
+nothing** — no half-published subscriptions or handlers. What the **user** sees
+next and what **telemetry** may learn is the D019 contract below.
+
+```clojure
+[v/error-boundary
+ {:reset-key route-revision
+  :fallback  [broken-page {}]
+  :on-error  [:telemetry/ui-render-failed]}
+ [workspace-page {:workspace-id workspace-id}]]
+```
+
+| Prop | Role |
+|---|---|
+| **child region** | one region of UI protected by the boundary |
+| **`:fallback`** | what to show instead — static structure, a declared view, or a pure `v/render-fn` of the safe summary |
+| **`:reset-key`** | when this value changes, remount/retry the child (no imperative `reset!` ref) |
+| **`:on-error`** | optional intent prefix; fires **once per failure generation** after the fallback commits |
+
+There is no public “boundary handle” API. Recovery is data: change `:reset-key`
+(often a route revision or a user “Try again” counter in app-db).
+
+### What a boundary catches — and what it does not
+
+| Failure | Boundary shows fallback? | Who owns reporting |
+|---|---|---|
+| Freehand child render throws | yes | boundary + frame error egress |
+| Hiccup normalization / common validation throws | yes | same |
+| Descendant React throw during render/lifecycle (where React boundaries apply) | yes (browser) | same Freehand boundary |
+| **Fallback itself** throws | no at this boundary — propagates outward | parent boundary / frame |
+| **re-frame event / sub / resource handler** throws | **no** | re-frame error path |
+| **Async** timer / promise / DOM callback after the fact | **no** | browser / owning wrapper |
+| Behavior `connect` / command after commit | not as render fallback by default | behavior diagnostics + frame egress |
+| SSR transport outside view evaluation | no | server / root host |
+
+**Critical:** a Freehand error boundary is a **render** safety net. It will not
+save you from a bad event handler or a failed HTTP effect. Those stay causal-layer
+errors. Do not wrap the whole app and assume “all failures become fallback UI.”
+
+### Safe summary vs host detail (two channels)
+
+**Application intent (`:on-error`).** When you supply `:on-error`, Freehand
+dispatches **at most one** event per captured failure generation. The payload is
+a **safe summary**: stable ids, view ids, phase, correlation facts, evidence
+completeness — **not** raw props, full app-db, exception objects, or host nodes.
+Use that event for a toast, a redacted product log, or serializable analytics.
+
+**Frame error egress (production detail).** In parallel, the host may promote a
+**private** record onto the existing Spec 009 / frame error path: safe summary
+plus capped host/React stack for the configured observer. Redaction, transport,
+and vendor integration live there.
+
+Defaults:
+
+- Freehand does **not** capture all of app-db or recent event payloads.  
+- Snapshots are **opt-in** and allow-listed if you need them.  
+- Development evidence is richer; production may be thinner — completeness fields
+  must say so.  
+- Epoch identity in production reporting stays careful (ordinal / correlation, not
+  “dump the world”).  
+
+### Lifecycle of a failure
+
+1. Child render throws (or React reports a catchable render/lifecycle error).  
+2. Candidate render publishes **nothing**.  
+3. Boundary selects fallback UI.  
+4. After fallback commits, optional `:on-error` fires **once** for this failure
+   generation.  
+5. User or app changes `:reset-key` → child remounts and retries.  
+6. StrictMode / HMR must not spam the same generation as many reports.  
+
+When reporting from production, the useful pair is often **where** (view id /
+occurrence / correlation from the safe summary) and **what** (redacted snapshot
+or release id you opted into). Do not rely on full event history in production
+builds.
+
+On the server, do not pretend a client recovery commit happened mid-stream. Use
+the Root Descriptor’s **server error projection** — see [SSR](ssr.md).
+
+## Focus, autofocus, and measurement (no neutral refs)
+
+Freehand has **no** `v/ref`, `useEffect`, or “run this on mount” form in ordinary
+views. Host ephemera stay at explicit boundaries.
+
+| Need | Prefer first | Escalate to |
+|---|---|---|
+| Focus a field when it appears | native `:auto-focus true` on the input | — |
+| Focus after a **semantic** open (dialog, rename) | top-layer / open state + CSS or browser dialog focus | small **behavior** that `.focus()`s on connect |
+| Measure layout / position before paint | CSS anchors where possible | registered behavior with `:layout` timing |
+| Scroll lock, trap, restore focus | top-layer / native dialog patterns | UIx wrapper if you need a full React focus library |
+| Third-party “needs a ref callback” | qualified leaf / wrapper owns the ref | never a bare ref prop on a Freehand view as app state |
+
+```clojure
+;; Often enough — platform autofocus when the node mounts with the tree
+[:input {:value (v/sub [:rename/draft])
+         :auto-focus true
+         :on-input [:rename/drafted ::v/value]}]
+
+;; When you must call .focus() after connect — same registry shape as any behavior
+(defn connect-focus! [el _config]
+  (.focus el)
+  nil)   ; private memory optional
+
+(host/defbehavior focus-on-connect
+  {:connect    connect-focus!
+   :update     (fn [_el _config mem] mem)
+   :disconnect (fn [_el _mem])
+   :ssr        :inert})
+;; Timing defaults to :passive; use :layout only for measure-then-place work
+;; (registry metadata on the registration — not use-site callback syntax).
+
+[:input {::v/behavior [focus-on-connect {}]
+         :value (v/sub [:rename/draft])
+         :on-input [:rename/drafted ::v/value]}]
+```
+
+Do not store DOM nodes in app-db. Do not invent mount-domain events for “I
+focused.” If focus is product-visible (which field is active), that is a re-frame
+fact driven by events — the DOM call is still host-side. Behaviors are **not** a
+general on-mount API; prefer `:auto-focus` unless you need an imperative call.
+
+## Choosing a shape
+
+| Need | Shape |
+|---|---|
+| DatePicker value + callback | qualified leaf + `v/event` |
+| Vega/Mapbox owns a DOM node | registered behavior |
+| Radix / hooks / portals | UIx wrapper |
+| Grid wants a React component prop | `v/->react` |
+| Render failure UI | `v/error-boundary` (above) |
+| Exit animation after close | presence (+ top-layer for open) |
+| Framer / GSAP / other JS libs | host leaf or behavior (JS-library recipes) |
+| Autofocus / measure / `.focus()` | native attr first; else behavior / wrapper (above) |
+| Structure, spreads, theming | not host shapes — composition plane |
+
+## If something feels wrong
+
+| Symptom | Fix |
+|---|---|
+| Bare React component as a vector head | `host/component` or UIx wrapper |
+| Instance / DOM node in app-db | keep private memory in the behavior; config is data only |
+| Command “for later when it mounts” | commands hit the **live** connection only — no queue |
+| Error boundary never resets | change `:reset-key` — no imperative reset handle |
+| Telemetry spam on StrictMode | once-per-failure-generation for `:on-error` |

--- a/docs/design/freehand/draft-guide/index.md
+++ b/docs/design/freehand/draft-guide/index.md
@@ -1,0 +1,114 @@
+# Freehand
+
+Freehand is re-frame2’s native view layer — it does the same job as Reagent or
+UIx. Turn events, app-db, and subscriptions into something on the screen. It is
+not a second framework. Upstream re-frame2 stays as it is; Freehand only spells
+the **last mile**.
+
+That last mile is **re-frame-native**. Reagent and UIx are excellent React tools
+that *can* host re-frame. Freehand is a view contract that **assumes** re-frame —
+so state, intent, tests, and tools stay in one system.
+
+> **Same re-frame pipeline. A view layer designed for it.**
+
+```clojure
+(v/defview cart-badge [_]
+  [:button {:on-click [:cart/open]}
+   "Cart (" (v/sub [:cart/count]) ")"])
+```
+
+No `@`, no reaction object, no dispatch closure on the paved path — and “what does
+this button do?” is a value you can assert on the JVM.
+
+!!! warning "Design-draft guide"
+
+    This guide describes the **ratified Freehand target**. Implementation is not
+    yet complete; names and install recipes may change. Treat it as a proposed
+    user guide for review, not shipping docs.
+
+New to re-frame2? Learn events, app-db, subscriptions, and frames first. Freehand
+only changes the **view layer**.
+
+## Peer of Reagent and UIx
+
+```text
+                 re-frame2 (events, app-db, subs, fx, frames)
+                                   |
+       ----------------------------+----------------------------
+       |                           |                           |
+  Reagent adapter              Freehand                   UIx adapter
+```
+
+All three fill the **view-layer** slot. Freehand is the re-frame-native choice;
+adapters stay permanent first-class siblings — not a fallback and not scheduled
+for deletion.
+
+| Term | Meaning |
+|---|---|
+| **View layer** | What you write for the screen (this guide’s default word) |
+| **Adapter / substrate** | How a view layer plugs into re-frame2 (mount, frame, host) |
+
+## What stays the same
+
+Everything upstream of the view is ordinary re-frame2: events, app-db,
+subscriptions, effects, frames, resources, machines. You still use `rf/reg-event`
+and `rf/reg-sub`. A Freehand view *consumes* those subscriptions and *dispatches*
+those events. It does not invent a second reactive model.
+
+## Why teams pick Freehand
+
+| Payoff | In practice |
+|---|---|
+| **Intent as data** | `[:button {:on-click [:cart/add id]} "Add"]` — readable, tool-visible, assertable without a click |
+| **Subs without ceremony** | `(v/sub [:cart/count])` **is** the value; Freehand owns the dependency |
+| **One place for app state** | No ratoms/hooks for product truth; host machinery stays behind boundaries |
+| **Tests match the model** | Structural tree on the JVM; browser only for real browser laws |
+| **Tools and AI** | Handlers and structure are values; checker findings are mechanical |
+| **Perf later, same views** | Interpreted by default; `{:compiled true}` after `v/check` on evidence |
+
+Outside a view render, one-shot reads use `rf/subscribe-once` — deliberately not
+`v/sub`, so reactive reads and probes stay distinct.
+
+## Who it is for
+
+| If you are… | Freehand helps because… |
+|---|---|
+| Building a **re-frame2 app** | The view matches events, subs, and frames |
+| Serious about **UI tests** | Intent can be equality on a tree, not only E2E |
+| Shipping **reusable controls** | Props-only leaves, clear event prefixes, optional field protocols |
+| Using **AI assistants** heavily | Small paved vocabulary, data handlers, checkable findings |
+| Drawn to **re-frame.ui** but not compile-only authoring | Freedom first; compiler machinery as the hot path |
+
+## When another view layer is better
+
+Reagent and UIx remain first-class. Prefer them when:
+
+- you need a **mature path today** (Freehand is still landing);
+- you have a large **Reagent / re-com** investment and are not migrating yet;
+- the product is **mostly React**, with re-frame as a thin data layer;
+- you want a **whole-root, subscription-free** renderer (closer to Replicant).
+
+Choosing another layer is a supported choice, not a failure. Freehand is the
+**re-frame-native** bet when you want the UI inside that architecture. Incremental
+landing next to an existing app is covered under adoption.
+
+## Shape at a glance
+
+| Idea | Meaning |
+|---|---|
+| `v/defview` | one way to declare a mounted boundary |
+| `[view props]` vs `(helper …)` | vector = boundary; parens = inline helper |
+| `(v/sub …)` | plain value inside a render; render-only |
+| Event vectors | paved-path handlers; `::v/value` / `::v/checked` / `::v/key` for live scalars |
+| Interpreted mode | default — full Clojure |
+| Compiled mode | `{:compiled true}` after `v/check` — finite grammar, same call sites |
+| Host boundaries | leaves, behaviors, UIx wrappers — not neutral hooks in ordinary views |
+| Roots + frames | `v/mount`; frame preflight; `v/->react` for foreign React |
+
+| Mode | When | You gain | You accept |
+|---|---|---|---|
+| **Interpreted** | app pages, composition, most SPA work | full Clojure, flexible helpers | Hiccup walk on re-rendered boundaries |
+| **Compiled** | hot boundaries, library leaves, static evidence | direct lowering, manifests, elision when proved | finite grammar; `v/check` before promotion |
+
+Call sites and structural tests do not change across modes. Compilation is always
+**manual and evidence-guided** — Freehand never rewrites a declaration for you.

--- a/docs/design/freehand/draft-guide/install.md
+++ b/docs/design/freehand/draft-guide/install.md
@@ -1,0 +1,137 @@
+# Install and boot (target)
+
+You want Freehand on the page: **require → adapter → seed → mount**. This is the
+target day-one boot story. Coordinates and exact helper names are still landing —
+use the sequence, not guessed package pins.
+
+!!! warning "Pre-alpha"
+
+    Freehand is not yet a “paste this and ship” product. When Maven coordinates and
+    the adapter var publish, update this page and drop the placeholders.
+
+## Happy path
+
+```clojure
+(ns my.app
+  (:require [re-frame.core :as rf]
+            [re-frame.freehand :as v :refer [sub]]))
+
+(defn ^:export run []
+  (rf/init! freehand-adapter)   ; placeholder name — same pattern as other adapters
+  ;; Prefer frame preflight so [:app/init] drains before paint (see below).
+  (v/mount [app-root {}]
+           (js/document.getElementById "app")))
+
+;; later
+(v/unmount! mounted)   ; total teardown; not a domain event in the tree
+```
+
+Alias Freehand as **`v`**. Prefer `(sub …)` only where the ns `:refer`s it;
+otherwise write `(v/sub …)`.
+
+```text
+1. Install Freehand adapter  (rf/init! … — same as Reagent/UIx adapters)
+2. Seed a live frame before first paint when you care about flash
+3. v/mount the root view into a DOM container
+4. On leave: v/unmount!
+```
+
+You are installing a **view layer**, not a second framework. Upstream re-frame2
+stays as it is.
+
+## Day-one checklist
+
+- `[re-frame.freehand :as v]` in the ns  
+- Adapter installed once at boot  
+- Seed before paint when empty flash matters  
+- `(v/mount [root {}] el)` for the paved path  
+- `(v/unmount! handle)` on teardown  
+
+### Adapter install
+
+Other re-frame2 view layers use `(rf/init! some-adapter)`. Freehand follows that
+pattern. Until the public adapter var ships, treat the name as a **placeholder**:
+
+```clojure
+(rf/init! freehand-adapter)
+```
+
+Do not invent a second Freehand-only boot protocol.
+
+### Seeding vs mount (do not conflate them)
+
+| Concern | Owner |
+|---|---|
+| Ordered history / seed events | **Frame preflight** — same idea as `rf/make-frame`’s `:initial-events` in tests |
+| Attach a Freehand tree to a DOM node | **`v/mount`** (paved path) |
+| Root identity, SSR, advanced create/render/hydrate | **Root Descriptor** family (names land with implementation) |
+
+The spine does **not** define “third argument to `v/mount` carries
+`:initial-events`” as the public contract. Prefer:
+
+1. mint/bind the frame with preflight so `[:app/init]` (etc.) drains **before**
+   paint, then  
+2. `(v/mount [app-root {}] el)`  
+
+Advanced create/render/**hydrate** operations consume the **same** Root
+Descriptor shape as the paved mount path and return an opaque handle — exact
+helper names land with implementation. Structural tests reuse that plan so boot
+does not fork.
+
+### Dev-style sketch (temporary)
+
+Until polished preflight helpers ship, a temporary boot may seed with
+`dispatch-sync` (accept a possible empty first paint in dev):
+
+```clojure
+(defn ^:export run []
+  (rf/init! freehand-adapter)
+  (rf/dispatch-sync [:app/init])
+  (v/mount [app-root {}]
+           (js/document.getElementById "app")))
+```
+
+### Production obligations
+
+| Concern | Contract |
+|---|---|
+| **Seed before paint** | frame preflight / `:initial-events` (or equivalent), not “hope first render seeds” |
+| **HMR** | reuse the live frame; do not mint a fresh app-db every save |
+| **Multi-root** | supply `:root-id` only when identity could collide |
+| **Teardown** | `(v/unmount! handle)` — total host teardown |
+
+## Shadow / build (when available)
+
+Expect a documented Shadow build that:
+
+- puts Freehand on the classpath with re-frame2  
+- does **not** pull tools into production bundles  
+- keeps test/debug evidence stripable in production  
+
+Exact `shadow-cljs.edn` / deps snippets ship with implementation. Do not invent a
+second compiler plugin for Freehand — the design absorbs donor `re-frame.ui`
+machinery under Freehand ownership.
+
+## Target API status (names)
+
+| Name | Stability for guide purposes |
+|---|---|
+| `v/defview`, `v/sub`, event vectors, `::v/value` / `::v/checked` / `::v/key` | Design-stable authoring core |
+| `v/mount`, `v/unmount!` | Design-stable paved path |
+| Root Descriptor, preflight, advanced create/render/hydrate | Design-stable **contracts**; public helper names may polish |
+| `v/check`, `{:compiled true}`, `v/markup` | Design-stable compile story |
+| `:children-policy` on descriptor / `defview` options | Design-stable ABI field |
+| `v/inspect-boundary`, `v/hot-views`, `v/orphans`, `v/behaviors` | Design-target tool surface; shapes may refine |
+| `re-frame.freehand.test` (`t/render`, settle, presence clock) | Design-target test surface |
+| Adapter install (`rf/init! …`) | re-frame2 pattern; Freehand adapter var name TBD |
+| Frame provider retarget | Design-required **law**; public form unpublished |
+
+## What not to do
+
+| Don’t | Do |
+|---|---|
+| Design new product on `re-frame.ui` | Freehand absorbs the donor; ui is temporary |
+| Put frame ids on raw DOM as the boot path | Mount Freehand roots; frames bind to Freehand trees |
+| Treat mount kwargs as the home of seed events | Frame preflight owns ordered seed history |
+| Seed only after first paint in production | Preflight before paint |
+| Expect Clojars coordinates from this draft alone | Wait for release notes / published install how-to |

--- a/docs/design/freehand/draft-guide/js-libraries.md
+++ b/docs/design/freehand/draft-guide/js-libraries.md
@@ -1,0 +1,295 @@
+# Using Freehand with a JavaScript library
+
+Freehand is not a wall around the browser. Real apps use charts, maps, date
+pickers, animation engines, and grid widgets written in JavaScript. The rule is
+simple:
+
+> **Keep Freehand’s tree data-oriented. Put the JS library behind an explicit host
+> boundary.**
+
+This page stays **inside Freehand**. It does not introduce another view substrate.
+When a library needs a tiny React component of your own (for example so *you* can
+call hooks), that component is still registered as a Freehand **host leaf** — a
+local interop file, not a second app architecture.
+
+Host **contracts** (leaf, behavior, wrapper, `->react`, error-boundary) are the
+law; this page is the **recipe** companion.
+
+## First decision: what kind of library is it?
+
+| Library shape | Freehand approach | Examples (illustrative) |
+|---|---|---|
+| **Only enter/exit retention** | **`v/presence` + CSS** first | toasts, simple panel fade |
+| **React component**: values in, callbacks out (hooks only *inside* the lib) | **Qualified host leaf** | date pickers, many charts, **Framer `motion.*` / `AnimatePresence`** |
+| **Imperative DOM owner**: `new X(el)`, dispose | **Registered behavior** | Vega View, Mapbox GL, GSAP on a node |
+| **Your code must call React hooks** (or similar) | **Small React component** as a qualified host leaf | `useMotionValue`, custom scroll-linked motion |
+
+The fence is **hooks in your Freehand view body**, not “any JS library.” A foreign
+React component that uses hooks **internally** is fine as a leaf. If *you* need to
+call hooks, put them in a small React function component, register it with
+`host/component`, and keep the rest of the screen in Freehand.
+
+If the need is only “keep this node a moment so CSS can fade it,” start with
+`v/presence` before any motion library.
+
+## What never goes in app-db
+
+The JS object, the DOM node, the timeline instance, and cleanup functions are
+**host memory**. They must not ride in event vectors or be stored as “state” in
+app-db.
+
+What *does* live in re-frame:
+
+- whether a panel is open  
+- which step of a wizard is active  
+- whether a toast is in the visible list  
+- configuration you would time-travel or test (spec, series data, duration as data)  
+
+What stays in the host boundary:
+
+- `connect` / `disconnect` of an imperative library  
+- `update` when config changes  
+- animation players, tweens, and observers  
+- Framer’s internal motion state  
+
+## Pattern A — often enough: presence + CSS (no JS library)
+
+For many toasts and panels, Freehand’s own presence API is the smaller design:
+
+```clojure
+(v/presence {:timeout-ms 300}
+  (for [t (v/sub [:toasts/visible])]
+    [:div.toast
+     {:key (:id t)
+      :class ["opacity-100"]
+      ::v/unmounting {:class ["opacity-0"] :inert true :aria-hidden true}}
+     (:message t)]))
+```
+
+Domain events only say which toasts exist. Presence keeps the node for exit; CSS
+animates. Full guide: [Presence](presence.md).
+
+Reach for GSAP or Framer when you need choreography, springs, shared layout,
+gestures, or motion that CSS and presence cannot express cleanly.
+
+## Pattern B — React leaf (values in, callbacks out)
+
+Use this when the library (or its React wrapper) is basically props and callbacks.
+Qualify the foreign head. Do not put a bare npm component in the Freehand tree
+without a host descriptor.
+
+```clojure
+(ns app.ui.chart
+  (:require [re-frame.freehand :as v]
+            [re-frame.freehand.host :as host]
+            ["react-sparkline" :default Sparkline]))
+
+(def sparkline-host
+  (host/component ::sparkline Sparkline))
+
+(v/defview trend-sparkline [_]
+  (v/client-only
+   {:fallback [:div.sparkline-placeholder "…"]}
+   [sparkline-host
+    {:data     (v/sub [:metrics/sparkline])
+     :onSelect (v/event [point]
+                 [:metrics/point-selected (js->clj point :keywordize-keys true)])}]))
+```
+
+Notes:
+
+- Foreign callbacks use `v/event` / `v/handler` / `v/render-fn` / `v/raw-fn` — not
+  a bare `fn`. See [Events — escape roster](events-and-handlers.md#the-escape-roster).  
+- Browser-only leaves need `client-only` (or a real SSR adapter).  
+- Open foreign props may pass JS objects through; that is leaf-specific, not the
+  rule for Freehand’s own DOM nodes (those use keyword props and conversion).  
+
+## Pattern C — Framer Motion as Freehand host leaves
+
+**You stay on Freehand for the app.** Framer’s **component** API (`motion.div`,
+`AnimatePresence`, `motion.button`, …) sits in Freehand as **qualified foreign
+heads**: values in, callbacks out, children in one React tree. Hooks that live
+*inside* those Framer components are Framer’s business — you are not calling them
+from a `v/defview`.
+
+### Sketch (interpreted Freehand)
+
+```clojure
+(ns app.toast
+  (:require [re-frame.freehand :as v :refer [sub]]
+            [re-frame.freehand.host :as host]
+            ["framer-motion" :refer [AnimatePresence motion]]))
+
+(def motion-div
+  (host/component ::motion-div (.-div motion)))
+
+(def animate-presence
+  (host/component ::animate-presence AnimatePresence))
+
+(v/defview toast [{:keys [id text]}]
+  [motion-div
+   {:initial #js {:opacity 0 :y 8}   ; foreign leaf: open props pass through
+    :animate #js {:opacity 1 :y 0}
+    :exit    #js {:opacity 0}
+    :onAnimationComplete (v/event [] [:toast/settled id])}
+   text])
+
+(v/defview toasts [_]
+  [animate-presence {}
+   (for [{:keys [id text]} (sub [:toast/visible])]
+     [toast {:key id :id id :text text}])])
+```
+
+What this is saying:
+
+- re-frame still owns which toasts exist.  
+- Freehand still owns the view tree and data events.  
+- Framer still owns the motion implementation.  
+- Callbacks use Freehand’s roster (`v/event`), not bare functions.  
+- Heads are **qualified** with `host/component` — Freehand’s foreign-leaf rule.  
+
+Conditional render stays familiar: drop the toast from app-db, remove the child;
+`AnimatePresence` is supposed to retain it through exit while `motion` reads
+presence through React context (one React tree under the Freehand host).
+
+### Honesty: designed, not yet a proven pilot
+
+The **AnimatePresence-through-a-Freehand-boundary** path is **designed and
+argued**, not yet proven in a mounted exit pilot. Treat exit animation across a
+Freehand shell as a hypothesis until a test shows:
+
+1. toast removed from app-db  
+2. exit motion runs  
+3. node is gone afterward  
+
+Enter-only motion is a weaker claim; exit is where composition usually breaks.
+Compiled mode is a separate cliff: dynamic foreign heads and `#js` props may need
+different factoring under `v/check`.
+
+### When Framer needs a tiny React component of your own
+
+Use a **small React function component** (registered as a Freehand host leaf) only
+when **your** code must call Framer hook APIs, for example:
+
+- `useMotionValue`, `useTransform`, `useScroll`  
+- `useAnimate`, `useInView`  
+- custom gesture wiring that only makes sense as hooks  
+
+That component is interop glue. It is **not** a second view substrate and not a
+reason to move the rest of the screen out of Freehand.
+
+```clojure
+(ns app.ui.scrubber
+  (:require [re-frame.freehand :as v]
+            [re-frame.freehand.host :as host]
+            ["react" :as react]
+            ["framer-motion" :refer [useMotionValue]]))
+
+;; Plain React component — hooks allowed here only
+(defn Scrubber [props]
+  (let [props (js->clj props :keywordize-keys true)
+        x     (useMotionValue 0)]
+    ;; render using x; call (:on-change props) with plain values
+    (react/createElement "div" nil …)))
+
+(def scrubber-host
+  (host/component ::scrubber Scrubber))
+
+(v/defview panel [_]
+  [scrubber-host
+   {:progress  (v/sub [:scrub/progress])
+    :on-change (v/event [v] [:scrub/set v])}])
+```
+
+Same boundary as any other leaf: Freehand outside, host component at the edge.
+
+## Pattern D — Imperative library on a DOM node (behavior)
+
+Use this when the library wants an element and a lifecycle: create, update,
+destroy. GSAP, anime.js, or raw Web Animations behind your own glue often look
+like this.
+
+```clojure
+(ns app.ui.motion
+  (:require [re-frame.freehand :as v]
+            [re-frame.freehand.host :as host]))
+
+(defn connect-fade! [el {:keys [open? duration-ms]}]
+  {:el el
+   :open? open?
+   :duration-ms (or duration-ms 250)
+   :anim nil})
+
+(defn update-fade! [mem cfg]
+  ;; when open? flips, run enter or leave on (:el mem); never put el in app-db
+  (merge mem cfg))
+
+(defn disconnect-fade! [{:keys [anim]}]
+  ;; cancel tweens, remove listeners
+  nil)
+
+(host/defbehavior fade-panel
+  {:connect    connect-fade!
+   :update     update-fade!
+   :disconnect disconnect-fade!
+   :ssr        :inert})
+
+(v/defview animated-panel [{:keys [title]}]
+  (let [open? (v/sub [:ui/panel-open?])]
+    [:div.panel
+     {::v/behavior [fade-panel {:open? open? :duration-ms 280}]}
+     [:h2 title]
+     (when open?
+       [:div.body "…"])]))
+```
+
+| Rule | Why |
+|---|---|
+| `connect` after **commit** | speculative renders must not create players |
+| Config is Clojure data | `open?`, durations as values |
+| `update` on `rf=` config change | library reacts to re-frame facts |
+| `disconnect` once | no leaked tweens or listeners |
+| One behavior per node | do not co-own descendants with React if the library owns them |
+
+Optional **commands** (export, scrub to time) use a semantic `:instance` target —
+see [Host boundaries — commands](host-boundaries.md#commands-one-shot-host-ops).
+
+Most animation “play when props change” work is **`:passive`** timing. Use
+**`:layout`** only when you must measure before paint and can prove no wrong-frame
+flash. Silent forever-`rAF` loops are not a hidden policy.
+
+## Animation checklist
+
+| Question | Prefer |
+|---|---|
+| Fade/slide on enter/exit only? | **`v/presence` + CSS** |
+| Framer components only (`motion.*`, `AnimatePresence`)? | **Qualified Freehand host leaves** (+ pilot for exit) |
+| You call Framer **hooks** (`useMotionValue`, …)? | **Small React host leaf** (hooks only inside that file) |
+| Drive a non-React player (GSAP on a node)? | **Behavior** |
+| Must mid-animation state time-travel? | Put *intent* in re-frame; keep the player in the host |
+
+**Reduced motion:** read a preference (media query or app setting as data) and
+pass a flag into the leaf or behavior. Freehand does not invent a global motion
+bus.
+
+## Common mistakes
+
+| Mistake | Better |
+|---|---|
+| “Framer means leave Freehand for another UI stack” | Freehand page + Framer host leaves |
+| Store the GSAP/Framer instance in app-db | Host memory only |
+| Domain “unmount” events to own lifetime | re-frame owns whether the fact exists; motion is presentation |
+| Bare foreign head with no host qualification | `host/component` |
+| Bare `fn` on a foreign callback | `v/event` / `v/handler` / … |
+| Assume AnimatePresence exit works untested | mounted pilot before you depend on it |
+| Full motion library for one opacity fade | presence + CSS |
+
+## Other libraries, same shapes
+
+| Library class | Pattern |
+|---|---|
+| Date picker / select (React) | qualified leaf + `v/event` |
+| Vega / Mapbox / SpreadJS | behavior (+ commands if needed) |
+| Props-only React kits | qualified leaf |
+| Hook APIs *you* call | small React component as host leaf |
+| Freehand view inside a React grid cell | `v/->react` + live frame |

--- a/docs/design/freehand/draft-guide/limits-and-escapes.md
+++ b/docs/design/freehand/draft-guide/limits-and-escapes.md
@@ -1,0 +1,103 @@
+# Limits and escapes
+
+Freehand is opinionated on purpose. The walls below are not accidental missing
+features. They keep the paved path small enough that tests, tools, compilation,
+and AI authoring can rely on it.
+
+When you hit a wall, prefer the **named recovery** over inventing a second state
+model or a silent fallback. If an error does not point you at a recovery, that is
+a product defect worth fixing — not a reason to paper over the design.
+
+This page is a map of walls and recoveries.
+
+## Authoring walls
+
+| You cannot | Why | Do this instead |
+|---|---|---|
+| Vector-call a bare `defn` | boundaries are declared descriptors | `v/defview` + `[view props]`, or call the helper with parens |
+| Direct-call a `v/defview` | public vars are not `IFn` | `[view props]` |
+| Use `v/sub` outside a declared render | render-only observation | `rf/subscribe-once` |
+| Call `v/sub` off the render thread | capture is same-thread only | realize on the render thread or extract a child view |
+| Put multi-intent vectors in handlers | one event per user action | one semantic event + effects |
+| Use `local` / neutral hooks in views | one reactive system | re-frame facts, controllers, or host wrappers |
+| Derive writable state from React keys / `v/self` | occurrence ≠ controller identity | explicit `:control` addresses |
+| Bare fn on a foreign callback prop | unknown phase/identity | `v/event` / `v/handler` / `v/render-fn` / `v/raw-fn` |
+| Bare React component as an ordinary head | foreign boundary must be named | `host/component` or UIx wrapper |
+| Neutral portal primitive | not in v1 | top-layer intrinsics, behavior, or React wrapper |
+| Automatic promotion | honesty | `v/check` then `{:compiled true}` |
+| `:children` key inside the props map | reserved trailing channel only | trailing child forms → `:children` |
+| Opaque reactive fn as a “render prop” | hides `sub` / identity | `v/render-fn`/`v/slot` if pure; else declared child view |
+| `:parts` that rewrite structure or strip roles | attrs-only; owned a11y stays owned | composition spreads + a11y ownership rules |
+| Dynamic map on controlled input without `spread-safe` | forfeits door proof | `v/spread-safe` (not bare merge / `v/spread`) |
+| Put `:on-before-input` on the controlled door | precedes DOM mutation; not door-eligible | ordinary listener; door is `:on-input` / `:on-change` only |
+| Invent public APIs the design did not name (`v/frame-provider`, mount seed kwargs, …) | aspirational drift | stick to spine contracts; mark TBD helpers as unpublished |
+
+## Compiled-mode walls
+
+| You cannot | Recovery |
+|---|---|
+| Hide `sub` or markup in opaque helpers | extract a child, pass values, or stay interpreted |
+| Dynamic tag heads | finite branches or vary attributes |
+| Markup-returning `map` as structure | keyed `for` of declared views |
+| Unkeyed dynamic lists | real `:key`s |
+| Inline interpreter fallback in compiled space | `[v/markup {:value …}]` as a declared interpreted child |
+
+Run `v/check` before promotion. Findings are the work order.
+
+## Performance walls
+
+Compilation is not a cure-all. If cost is:
+
+- **over-broad subscriptions** → narrow the graph
+- **collection size** → window
+- **foreign widget** → qualified leaf / behavior; do not invent another Hiccup compiler
+- **interpretation of a hot template** → compile that boundary after measurement
+
+## When Freehand is the wrong tool
+
+- You need a mature Reagent/re-com ecosystem path *today* without riding pre-alpha
+  Freehand implementation.
+- The entire surface is a React app with little re-frame dataflow — UIx may be
+  simpler.
+- You need a pure whole-state renderer with no subscriptions — Replicant is an
+  architectural alternative, not a Freehand mode.
+
+Other **view layers** (Reagent, UIx) remain first-class. Freehand is the
+re-frame-native peer, not a mandate that erases the others.
+
+## Deliberate non-goals (full map)
+
+These are product exclusions from the design spine, not temporary TODOs. Prefer
+the named recovery column.
+
+| Non-goal | Recovery / reality |
+|---|---|
+| Second compiler, `v/interp`, or hidden interpreted fallback inside compiled markup | stay interpreted, extract child, or `[v/markup {:value …}]` |
+| Permanent `re-frame.ui` sibling product | absorb donor; delete at gate |
+| Preserve every donor API because code was useful | Freehand owns the public contract |
+| Third “unprofiled” mode for local state / hooks / refs / effects | host boundary or UIx wrapper |
+| Automatic promotion or a “hot 5%” rule | measure → `v/check` → `{:compiled true}` |
+| Callable declared views or a region DSL | `[view props]` / trailing children / compound views |
+| `:reads` query-template language in v1 | inline `(v/sub …)` only |
+| `v/self` or renderer-derived writable addresses | explicit `:control` / domain ids |
+| Generic component-local storage verbs or widget event namespaces | library events; no `:rf.field/*` in core v1 |
+| Controller / reducer DSL in Freehand | ordinary `reg-event` / `reg-sub` |
+| Render/unmount ownership of domain resources | routes, resources, machines |
+| Neutral portals or arbitrary lifecycle callbacks | top-layer, behavior, or React wrapper |
+| Queued host command bus / service locator | explicit command targets on live connections |
+| Payload-map arity on general re-frame dispatch | Freehand materializes projections at the event site only |
+| React callback-protocol guessing | `v/event` / `v/handler` / `v/render-fn` / `v/raw-fn` |
+| Late tree transforms as a portable theme system | CSS tokens + `data-part` + bounded `:parts` attrs |
+| Automatic app-db / event-history capture in error reports | opt-in observer; safe summary only by default |
+| Replicant-style aliases without library demand | declared views + plain helpers |
+| Structural click simulation / second behavior-test language | assert event vectors; mounted tier for real DOM |
+| Serializing DOM nodes, React elements, callbacks, host instances | host markers in structural trees; opaque interiors |
+| Claiming React and JVM emitters are one implementation | separate emitters; shared semantic ABI |
+
+## Relationship to `re-frame.ui`
+
+`re-frame.ui` is in **donor mode**: its useful machinery (analyzer, emitters,
+ViewCell, presence, tests) is absorbed as Freehand's compiled implementation.
+Freehand does not preserve `re-frame.ui` as a sibling public product. Donor
+deletion is a **gate** (conformance green, pilots pass, consumers migrate), not a
+calendar date. Do not design new features against the donor namespace.

--- a/docs/design/freehand/draft-guide/mental-model.md
+++ b/docs/design/freehand/draft-guide/mental-model.md
@@ -1,0 +1,240 @@
+# Mental model
+
+You are about to write Freehand views and do not want a second mental model next
+to re-frame. Hold **four ideas**. If they stick, the rest of the guide is mostly
+detail.
+
+Freehand is re-frame2’s first-party **view layer** — same *job* as Reagent/UIx,
+re-frame-native in *contract*. Upstream events, app-db, and subscriptions do not
+change; only the last mile does. Hiccup is still Hiccup.
+
+> **Declare a boundary. Read with `sub`. Intent as data. State in re-frame.**
+
+## 1. One way to declare a view — and an optional compiled mode
+
+There is exactly one way to write a Freehand view:
+
+```clojure
+(v/defview greeting [{:keys [name]}]
+  [:p "Hello, " name])
+```
+
+`v/defview` does not merely define a function. It declares a **mounted boundary**:
+something Freehand can track for subscriptions, identity, hot reload, errors,
+profiling, and (later) compilation.
+
+You **call** that boundary with a vector:
+
+```clojure
+[greeting {:name "Ada"}]
+```
+
+Helpers are ordinary functions — call them with parentheses. If a helper reads a
+subscription, that read belongs to the **enclosing** boundary (the nearest
+vector-called view), not to the helper:
+
+```clojure
+(defn price-line [{:keys [label amount]}]
+  [:div.price-line [:span label] [:span (money amount)]])
+
+(v/defview invoice [{:keys [id]}]
+  [:section
+   (price-line {:label "Subtotal"
+                :amount (v/sub [:invoice/subtotal id])})
+   [tax-summary {:invoice-id id}]])
+```
+
+Here is the rule in one table:
+
+| What you wrote | How you call it | What it means |
+|---|---|---|
+| `v/defview` | `[view props]` | a real boundary (identity, invalidation, keys, …) |
+| plain `defn` helper | `(helper …)` | inline structure — never a vector head |
+
+Reverse those spellings and Freehand treats it as an authoring error. The public
+var is a **descriptor**, not `IFn` — `(greeting {:name "Ada"})` fails loudly.
+
+**Compilation is an option on the same declaration**, not a second macro and not a
+second namespace:
+
+```clojure
+(v/defview todo-row
+  {:compiled true}
+  [{:keys [id]}]
+  …)
+```
+
+Day to day you stay in **interpreted** mode: full Clojure, flexible helpers. You
+reach for **compiled** mode when a boundary is hot or you need static proof.
+Call sites and tests stay the same.
+
+## 2. Subscriptions read as values
+
+In Reagent you typically write something like `@(rf/subscribe [:count])`. You get
+a reaction-like object and you deref it.
+
+In Freehand you write:
+
+```clojure
+[:span "Count: " (v/sub [:count])]
+```
+
+`(v/sub [:count])` **is the value** — nothing to deref. Freehand records that this
+boundary read that query; when the value moves, that boundary re-renders.
+
+Conditional reads are fine: untaken branches do not contribute dependencies. Avoid
+an unbounded number of reactive sites in one parent loop — extract a keyed child
+that subscribes for one row. Compiled mode requires that factoring; it is good
+style even when you stay interpreted.
+
+**`v/sub` is only legal during a declared view render.** In a REPL, event handler,
+timer, or tool, use the one-shot read:
+
+```clojure
+(rf/subscribe-once [:basket/total] {:frame :app/main})
+```
+
+That returns a value without installing a view dependency. Reactive read and
+one-shot probe stay separate on purpose. Errors name the case (no active render,
+wrong thread, missing frame) so recovery is obvious.
+
+## 3. Handlers are data
+
+The everyday event handler is not a function. It is an event vector:
+
+```clojure
+[:button {:on-click [:count/inc]} "+"]
+```
+
+On click, Freehand dispatches `[:count/inc]` on the view’s frame. The vector is
+the **intent** — readable in source, visible to tools before it fires, assertable
+on the JVM without a DOM.
+
+Live scalars (text, checked, key) use **projection markers**. Freehand fills them
+in when the event fires:
+
+```clojure
+[:input {:value email
+         :on-input [:form/edit :email ::v/value]}]
+```
+
+Need the raw DOM event or another payload? Use `v/event` (returns one vector or
+`nil`). Need imperative foreign work with no app intent? Use `v/handler`.
+
+**One user action → one semantic event, or nothing.** No vector-of-vectors in the
+view. Several effects from one click means one domain event whose handler returns
+them.
+
+## 4. One reactive state system — re-frame only
+
+Freehand has no `local`, no neutral hooks in ordinary views, and no public
+“who am I in the tree?” handle like `v/self` for writing state.
+
+If state matters to the product, it lives in re-frame: app-db (or another
+frame-scoped store), events, and subscriptions.
+
+A few practical defaults:
+
+- **Reusable leaves** should usually be **props-only**: data in, Hiccup out.  
+- **Controlled fields** keep draft and validity in re-frame and use Freehand’s
+  controlled-input door so typing stays correct.  
+- **Hard multi-step controls** (commit-on-blur, cancel, reject) can use a library
+  **semantic controller** with an explicit `:control` address — optional packaging,
+  not something every field needs.
+
+Keys and mount position answer “which React instance is this?” They are **not**
+automatically “where does my draft live in app-db?”
+
+Host machinery — DOM nodes, third-party widgets, layout measurement, React-only
+protocols — lives behind explicit host boundaries.
+
+## Day-one checklist
+
+You can write ordinary Freehand screens when you can:
+
+- declare with `v/defview` and call with `[view props]`  
+- use `(v/sub …)` only inside a render  
+- put event vectors on `:on-*`  
+- keep product state in re-frame (no view-local ratom model)  
+- leave compilation for later (interpreted is complete)
+
+## If something feels wrong
+
+| Symptom | Recovery |
+|---|---|
+| “I called my view as a function” | `[view props]` — public vars are not `IFn` |
+| `v/sub` outside a view | `rf/subscribe-once` for probes; `v/sub` is render-only |
+| Closure on every button | prefer an event vector; escape forms only when needed |
+| Draft lives in a ratom / hook | move to re-frame (or a library controller later) |
+| “I need Form-2 for local UI” | open/closed facts in app-db, or props-only controlled |
+
+---
+
+## Frames, roots, and the DOM
+
+Every Freehand view runs under a **frame** — the re-frame world for its
+subscriptions and events. A frame is not a DOM attribute. You **mount Freehand**
+into a container (or embed it in a React tree); Freehand binds the frame to that
+tree.
+
+### Putting Freehand on the page
+
+```clojure
+(v/mount [app-root {}]
+         (js/document.getElementById "app"))
+```
+
+**Root** = one React unit in one DOM container.  
+**Frame** = the re-frame world that root’s views use.
+
+**Preflight** ensures the frame exists and can seed before first paint. Inside the
+tree you rarely thread the frame through props — `sub` and handlers already bind
+to the **committed** frame.
+
+### More than one container
+
+Two Freehand mounts can share one frame, or use different frames. When root
+identity could collide, supply an explicit `:root-id` (and frame options as the
+implementation defines them).
+
+### A Freehand island inside someone else’s React tree
+
+Some foreign React libraries want a **component value** as a prop. Freehand’s
+answer is `v/->react`:
+
+```clojure
+{:cellRenderer (v/->react person-cell)}
+```
+
+The bridge never **creates** a frame. It binds to an existing live frame via a
+reserved `frame` prop or ambient context. Missing or dead frames fail loudly.
+
+### A different frame for part of the tree
+
+A Freehand **subtree** can retarget to another already-live frame (tool panel vs
+app). Props can look equal; retarget still rebinds. Ordinary shells always observe
+frame context; compiled shells may elide that only when the manifest proves it
+safe.
+
+| Law | Meaning |
+|---|---|
+| Input | an already-live frame |
+| Effect | descendants’ `sub` and events rebind |
+| **Retarget beats memo** | rebind even when props are `rf=`-equal |
+| Missing / dead frame | loud failure |
+
+Public form is not frozen yet — do not invent `v/frame-provider`. Think “retarget
+this Freehand region,” not `data-frame` on a div. Multi-root mounts are separate:
+explicit `:root-id` when identity can collide.
+
+## What you give up on purpose
+
+| You do not get | Why |
+|---|---|
+| Ratoms, cursors, reactions | second reactive model |
+| Form-2 / Form-3 / positional view args | one declaration, one props map |
+| `local` / neutral refs / effects in ordinary views | app state in re-frame; host work explicit |
+| Automatic promotion to compiled | mode choice stays honest |
+| Bare React components as ordinary heads | foreign UI must be a named boundary |
+
+A small paved path is what tests, tools, compilation, and AI authoring rely on.

--- a/docs/design/freehand/draft-guide/presence.md
+++ b/docs/design/freehand/draft-guide/presence.md
@@ -1,0 +1,242 @@
+# Presence: enter and exit retention
+
+Application state says an element is gone, but the UI should **slide or fade out
+first**. React’s default is instant remove — correct for most UI, awkward for
+toasts and closing panels.
+
+**`v/presence` owns only the gap between “no longer true” and “no longer in the
+tree.”** It retains keyed children for a bounded time and exposes **phase**. It is
+not an animation library — your CSS (or a host animation boundary) does the motion.
+
+> **Default to no presence. Add it only when exit retention is a product need.**
+
+## The idea in one picture
+
+```text
+  app-db says "show toast A"     →  child mounts   :mounting → :present
+  app-db drops toast A           →  child retained :unmounting  (still rendered)
+  :timeout-ms elapses            →  child removed for real (subs/handles released)
+  toast A reappears mid-exit     →  re-entry       back to :present (exit cancelled)
+```
+
+Your domain events still only say “toasts are …”. Presence turns that list into a
+stable enter/exit presentation without mount/unmount **domain** events.
+
+## Basic shape (attribute overrides — paved path)
+
+Freehand’s common path stamps phase as **data on the node**: base attrs plus
+optional `::v/mounting` / `::v/unmounting` overrides.
+
+```clojure
+(v/defview toast-tray [_]
+  (v/presence {:timeout-ms 300}
+    (for [t (v/sub [:toasts/visible])]
+      [:div.toast
+       {:key (:id t)
+        :class ["transition-opacity" "opacity-100"]
+        ::v/mounting   {:class ["opacity-0"]}
+        ::v/unmounting {:class ["opacity-0"]
+                        :inert true
+                        :aria-hidden true}}
+       (:message t)])))
+```
+
+| Piece | Role |
+|---|---|
+| `v/presence` | boundary that retains exiting keyed children |
+| `:timeout-ms` | **mandatory** positive duration — retention length **and** hard terminal bound |
+| `{:key …}` | **required** on each dynamic child — identity for the state machine |
+| base attrs | apply while `:present` (and after mounting overrides yield) |
+| `::v/mounting` | attrs for the initial committed mounting phase, then yield to base |
+| `::v/unmounting` | attrs while retained as exiting |
+
+### What overrides may and may not change
+
+| Allowed | Forbidden |
+|---|---|
+| presentation (class, style, …) | `:key` |
+| a11y (`inert`, `aria-hidden`, …) | children / structure |
+| other non-structural attrs the host allows | controlled `:value` / `:checked` |
+| | refs, event ownership / handler identity |
+
+Overrides are presentation and accessibility only. They do not rewrite what the
+node *is* or who owns its events.
+
+## Phases
+
+Every keyed child moves through:
+
+| Phase | Meaning |
+|---|---|
+| `:mounting` | just entered; mounting overrides apply |
+| `:present` | steady state; base attrs |
+| `:unmounting` | removed from source data but still rendered until timeout |
+
+Rules of the road:
+
+1. **Timeout is mandatory.** Presence does not wait on CSS `transitionend`. Set
+   `:timeout-ms` to match or slightly exceed your longest exit transition so the
+   node is never stuck forever if CSS fails or is disabled.
+2. **Re-entry cancels exit.** If the same key is removed then restored before
+   timeout, the child returns to `:present` per the state machine. Exit does not
+   “finish” then remount as a brand-new enter unless the re-entry rule says so —
+   Freehand follows the absorbed presence machine: re-entry cancels removal.
+3. **Order is for enter/exit, not live sort.** Presence freezes first-appearance
+   slots so an exiting child does not jump mid-animation. If the list must re-sort
+   continuously, order at the data/presentation layer. Do not expect presence to be
+   a reorder animator.
+4. **No wrapper DOM node** is required by the model. The boundary is a Freehand
+   construct, not an extra `<div>` you style. (Host implementation may use internal
+   machinery; author-facing contract is still keyed children + phases.)
+
+## CSS pairing
+
+Presence does not animate. A minimal pairing:
+
+```css
+.toast {
+  /* enter: animation on insertion is robust; see note below */
+  animation: toast-in 200ms ease-out;
+  transition: opacity 250ms, translate 250ms;
+}
+@keyframes toast-in {
+  from { opacity: 0; translate: 0 8px; }
+}
+
+/* exit: drive off unmounting presentation (class and/or override attrs) */
+.toast.opacity-0,
+.toast[data-presence="unmounting"] {
+  opacity: 0;
+  translate: 0 8px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast {
+    animation: none;
+    transition: none;
+  }
+}
+```
+
+Exact class names depend on how you map overrides (class lists in the example
+above vs a data attribute). Keep **exit transition duration ≤ `:timeout-ms`**.
+
+**Enter tip (from the donor presence guide, still good advice):** driving enter
+purely as a `.mounting` → `.present` class flip can race paint. The flip may land
+before the browser ever paints mounting styles. An **animation on insertion** (or
+modern `@starting-style`) is more reliable. Exit is happier as a class/attr
+transition under `:unmounting` because the node is already painted.
+
+## `v/presence-phase` — when structure depends on phase
+
+Attribute overrides cover most toast/modal chrome. When a child’s **structure**
+(not just attrs) must change with phase, read the phase inside a **declared**
+child view:
+
+```clojure
+(v/defview toast-card [{:keys [toast]}]
+  (let [phase (v/presence-phase)]   ; :mounting | :present | :unmounting
+    (case phase
+      :unmounting [:div.toast.exit (:message toast)]
+      [:div.toast (:message toast)])))
+
+(v/defview toast-tray [_]
+  (v/presence {:timeout-ms 300}
+    (for [t (v/sub [:toasts/visible])]
+      [toast-card {:key (:id t) :toast t}])))
+```
+
+Prefer a **keyed `v/defview` child** when reading phase. Inline literal markup is
+easy to get wrong: props are evaluated in the parent’s render, so the phase
+context may not be the per-child one you meant. Outside any presence boundary,
+`v/presence-phase` should behave as **`:present`** so phase-aware children remain
+reusable.
+
+Use phase-structure sparingly. Overrides keep more of the tree as plain data.
+
+## Accessibility
+
+While a node is retained as `:unmounting` it can still receive focus and clicks
+unless you say otherwise. The paved override includes:
+
+```clojure
+::v/unmounting {:inert true
+                :aria-hidden true
+                ;; plus your visual exit classes
+                }
+```
+
+Development checks should warn when retained interactive content lacks `inert` or
+equivalent assistive hiding. Honour `prefers-reduced-motion` in CSS so timeout
+still clears the node without motion.
+
+Broader a11y (names, native elements, top-layer focus, test lanes):
+**[Accessibility](accessibility.md)**.
+
+## What presence never does
+
+Presence phases and overrides are **presentation and tool evidence**. They never:
+
+| Not presence’s job | Who owns it |
+|---|---|
+| Dispatch domain mount/unmount events | you don’t — don’t invent them |
+| Fetch, seed, or cancel resources | routes, resources, machines |
+| Clear controller / domain state | [semantic transitions / owners](semantic-controllers.md) |
+| Focus traps, scroll lock, “modal UX” | top-layer + your a11y patterns / host |
+| Positioning / measurement | CSS anchors or a [behavior](host-boundaries.md) |
+| Springs, timeline choreography | foreign animation lib behind a host boundary |
+
+Mounting, present, re-entry, unmounting, and removal **are** queryable as
+development facts (occurrence + generation) for Xray and tests. That is tool
+data, not app-db lifecycle ownership.
+
+## JVM, SSR, and hydration
+
+On the JVM structural tree there is no real animation clock. Emit **present/base**
+structure with **presence metadata** so tests can see the plan, not a fake client
+timeline.
+
+On SSR/hydration, adopt server-rendered children at **`:present`** and avoid
+replaying enter animations over already-painted markup. A pure client mount may
+still start at `:mounting` then flip to `:present`.
+
+## Testing
+
+| Goal | Approach |
+|---|---|
+| “Exit attrs appear when data drops” | structural or mounted tree; assert overrides / phase |
+| “Node gone after retention” | `t/flush-presence!` advances a **fake clock** — not `Thread/sleep` |
+| Real CSS / reduced motion | real browser suite |
+
+See [Testing](testing.md). Don’t assert wall-clock animation frames in unit tests.
+
+## Common mistakes
+
+| Mistake | What goes wrong | Fix |
+|---|---|---|
+| Missing `:timeout-ms` | illegal / stuck retention | always a positive literal duration |
+| Unkeyed children | identity broken; compile error when compiled | stable `{:key …}` per child |
+| Timeout shorter than CSS exit | snap remove mid-fade | timeout ≥ transition |
+| No `inert` / `aria-hidden` on exit | focusable ghosts | set them on `::v/unmounting` |
+| Domain “unmount” events for cleanup | lifetime coupled to animation | owner/route cleanup; presence is visual only |
+| Wrapping every list “just in case” | cost and complexity | only when design needs enter/exit |
+
+## Pairing with top layer and host UI
+
+| Concern | Tool |
+|---|---|
+| Popover/dialog **open** desired state | top-layer intrinsics (`::web/popover-open?`, …) |
+| Timed exit after close | `v/presence` around the panel/toast content |
+| Measure / position | CSS anchor or registered behavior |
+| Framer Motion / rich motion | Freehand **host leaves** (or behaviors) — still Freehand |
+
+Presence and top-layer compose: open state is re-frame + web host; exit retention
+is presence. Neither replaces the other.
+
+## When not to use it
+
+- Instant remove is fine for most lists and pages — **default to no presence**.
+- Reorder animation, shared-element transitions, gesture physics — not this API;
+  use a host boundary for those libraries.
+- “I need something to run on unmount” for **data** — wrong tool; use causal
+  ownership (routes, machines, controller clear).

--- a/docs/design/freehand/draft-guide/reactivity-and-ownership.md
+++ b/docs/design/freehand/draft-guide/reactivity-and-ownership.md
@@ -1,0 +1,199 @@
+# Reactivity and ownership
+
+When `[:count]` changes, the view that read it should re-render — only that
+boundary, once, if the value really changed. You do not manage subscription
+handles. You do need **what re-runs**, **when ownership attaches**, and **what
+unmount does not clean up**.
+
+> **Render only probes. Commit owns. Unmount is not domain cleanup.**
+
+## What re-computes when something changes
+
+### One reactive unit per declared boundary
+
+Each time you write `[some-view props]`, Freehand mounts (or reuses) a **boundary**.
+That boundary owns the subscription reads it made during its last **committed**
+render.
+
+If a subscription that boundary depends on moves, **that boundary** is marked
+dirty. Its parent is not re-run just because a child is dirty. Siblings that never
+read that subscription stay quiet.
+
+### Same meaning, both modes
+
+**Interpreted** mode captures the queries the body actually reads. **Compiled**
+mode knows a finite set of `sub` sites and can drop the reactive shell when a view
+is proved sub-free. As an author: plain value, owning boundary invalidates when an
+active target changes, no user-facing handle.
+
+### Only real value changes matter
+
+Subscription results are stabilised with re-frame value equality (`rf=`). If a
+handler writes `2` where the value was already `2`, dependent views do not churn.
+Equal values keep the previous reference where possible so memoised children stay
+cheap.
+
+### Children skip work when props are equal
+
+Each boundary is memoised on its one props map using the same value equality. A
+parent can re-render without forcing a child to re-render, as long as the child’s
+props did not actually change.
+
+Practical tip: pass named slots of stable data. Avoid rebuilding a huge map or an
+anonymous function on every parent render and threading it downward — that defeats
+memo for no good reason. Freehand will warn about some of the worst cases in
+development.
+
+### Renders batch at the host checkpoint
+
+When an event settles, several subscriptions may move. Freehand does not re-render
+a dirty boundary once per subscription. Dirty work coalesces into **one flush** at
+the next host checkpoint.
+
+There is one important exception: the **controlled-input synchronous door** (see
+[Events](events-and-handlers.md#controlled-inputs)). Typing into a controlled field
+must update app-db and the controlled value inside the same discrete browser event,
+or the caret and IME break. That path is allowed to flush sooner on purpose.
+
+**In one sentence:** changing a value re-runs exactly the boundaries that read it,
+once, and only if the value really changed. Fix structure first (narrower subs,
+keys, windowing); compile later if interpretation cost still shows up.
+
+## Day-one checklist
+
+- Prefer narrow subscriptions and stable props.  
+- Key repeated children with domain ids.  
+- Do not call `v/sub` off the render thread.  
+- Do not put domain cleanup on unmount.  
+- Measure before compile.
+
+## If something feels wrong
+
+| Symptom | Fix |
+|---|---|
+| Whole list re-renders on one edit | per-id subs; keyed row boundaries |
+| High churn, equal output | unstable props (inline maps/fns) or over-broad subs |
+| Wrong row’s data for one frame | acquire-before-release on conditional targets — usually automatic; check keys/ids |
+| `v/sub` from `future` / worker | realize on render thread or extract a child view |
+| Draft still in app-db after leave | owner/route clear — unmount does not wipe controllers |
+
+## Render only reads; commit owns
+
+Modern React can run a render and then throw the result away. Freehand is built for
+that world.
+
+The rule is strict:
+
+> **While rendering, Freehand only probes. Ownership starts when the host commits
+> the selected render.**
+
+During render, `sub` resolves values and records candidates. Freehand does not
+treat that speculative work as the live subscription set yet.
+
+Only when React (or the host) **selects** that render for commit does Freehand:
+
+- acquire subscription handles for what was read  
+- publish the event-handler table for that generation  
+- connect host behaviors for that generation  
+
+If the render is abandoned or throws, it owns nothing. Strict Mode’s double render
+balances out under that design.
+
+When a boundary disconnects (unmount or generation retirement), Freehand releases
+observation and retires the committed callbacks for that occurrence. It does
+**not** dispatch domain cleanup events for you. Routes, resources, and machines
+own causal lifetime. Unmount is not “delete my form draft from app-db.”
+
+## Conditional subscriptions
+
+If a branch is not taken this render, its subscriptions are not part of the
+capture (interpreted) or are inactive in the site table (compiled).
+
+When the next render takes a different branch, Freehand **acquires the new
+targets before releasing the old ones**. That is what prevents a single frame of
+“order A’s details with order B’s id.”
+
+**Same-thread only.** Do not call `v/sub` from a `future`, `pmap`, `bound-fn`, or
+other conveyed thread. Capture is defined on the render thread. The error will tell
+you to realize work on the render thread or extract a keyed child view.
+
+## Keys and list identity
+
+```clojure
+(v/defview todo-list [_]
+  [:ul.todo-list
+   (for [id (v/sub [:todo/visible-ids])]
+     [todo-row {:key id :id id}])])
+```
+
+`:key` chooses sibling **occurrence** identity among repeated children. Freehand
+strips it before the props map reaches your function body, so your view does not
+see `:key` as a normal prop.
+
+Keys answer: “across reorders and re-renders, which row instance is this?”  
+They do **not** answer: “where does this field’s draft live in app-db?” For that,
+use domain ids or an explicit `:control` address — see [State](state.md).
+
+Unkeyed dynamic lists are a development finding, and a hard failure under compiled
+mode. Prefer stable domain ids over array indexes when identity matters.
+
+### Window large lists before you compile
+
+Mounting ten thousand keyed rows is a data problem first. Prefer a **window** of
+visible ids from a subscription (or a host virtualizer for true virtual scroll):
+
+```clojure
+(v/defview people-page [_]
+  (let [ids (v/sub [:people/visible-window-ids])]  ; e.g. ~40 rows for the viewport
+    [:ul.people
+     (for [id ids]
+       [person-row {:key id :id id}])]))
+```
+
+| Approach | When |
+|---|---|
+| Sub that returns a **window of ids** | Most SPA tables; keeps Freehand trees small |
+| Purpose-built host grid / virtualizer | Huge grids, spreadsheet UX — [JS libraries](js-libraries.md) |
+| Compile every row | After windowing still shows interpretation cost on hot templates |
+
+Do not expect `{:compiled true}` to make an unwindowed 10k-row tree cheap.
+
+## Frames, hot reload, and retarget
+
+Frames are created at **host preflight**, not from inside a view render. That is
+what makes hot reload a designed workflow: you save a file, view code swaps, and
+app-db in the live frame can survive.
+
+On a compatible reload, Freehand keeps the shell, invalidates the descriptor
+revision, and commits the next dependency and event set together. If the host or
+descriptor signature is incompatible, the shell remounts cleanly rather than
+lying about identity.
+
+If a frame provider retargets a subtree from frame A to frame B, children rebind
+even when their props look equal. Ordinary shells always observe frame context.
+Compiled shells may skip some frame machinery only when the manifest proves the
+view and its events do not need it.
+
+## Performance levers (before you compile)
+
+Compilation is not the first tool. In short: narrow subs → choose boundaries →
+window lists → measure → **then** compile. High `:stable-renders` means fix subs
+or props, not compile.
+
+## What tools can answer
+
+In development, committed boundaries expose a versioned evidence surface (stripped
+from production). A good tool session can answer:
+
+1. Which occurrence rendered, and where is its source?  
+2. Which frame and descriptor generation did it use?  
+3. Was the cause props, a subscription, frame retarget, HMR, presence, host work,
+   or mount?  
+4. Which reads and event sites were selected in that same generation?  
+5. Is the evidence statically complete (compiled), only realized (interpreted),
+   opaque (host interior), or capped?
+
+Evidence should always say how complete it is — scope, basis, completeness, and
+loss. Freehand does not claim omniscience for full-Clojure interpreted views.
+There is no separate author-facing `:reads […]` language in v1; reads stay inline
+`(v/sub …)`.

--- a/docs/design/freehand/draft-guide/semantic-controllers.md
+++ b/docs/design/freehand/draft-guide/semantic-controllers.md
@@ -1,0 +1,382 @@
+# Semantic controllers and reusable fields
+
+Most Freehand apps **never** need this page.
+
+If you only need a live field, or an app-specific draft that commits on blur and
+Enter, ordinary Freehand plus re-frame is enough. Open this page only when
+packaging a **hard, reusable multi-step protocol** — commit-on-blur, cancel races,
+same-value reject — so many screens share one correct implementation.
+
+!!! important "Skip this page unless you need it"
+
+    Live field or app-specific draft + blur/Enter → **stop**.  
+    Open here only for a **reusable** multi-event protocol.
+
+!!! note "Not a Freehand built-in"
+
+    Freehand does **not** ship `v/buffered-field` or a widget catalogue in v1.
+    It supplies the **laws**: re-frame-only state, explicit `:control` addresses,
+    one event per action, consult committed state. A library implements controls
+    as normal `v/defview`s plus events and subs. Sketches below are illustrative.
+
+## You can just use `on-blur`
+
+This is valid Freehand and does **not** use a semantic controller:
+
+```clojure
+[:input {:value   (v/sub [:lines/draft id])
+         :on-input [:lines/draft-changed id ::v/value]
+         :on-blur  [:lines/label-committed id]
+         :on-key-down {"Enter"  [:lines/label-committed id]
+                       "Escape" [:lines/draft-cancelled id]}}]
+```
+
+Use the same event on blur and Enter (commit). Use a **different** event on
+`on-input` (draft) — keystroke is draft; commit is accept.
+
+A semantic controller is only worth it when that protocol must be **correct and
+shared** across many call sites — for example stale blur after cancel, a required
+reset generation, or library packaging — without every team reimplementing it.
+
+## Start from the simple case
+
+Most Freehand controls should **not** use a semantic controller.
+
+A disclosure is enough as props-only / controlled:
+
+```clojure
+(v/defview disclosure [{:keys [open? on-toggle label children]}]
+  [:section.disclosure
+   [:button {:aria-expanded open? :on-click on-toggle} label]
+   (when open? [:div.body children])])
+
+[disclosure
+ {:open?     (v/sub [:faq/open? question-id])
+  :on-toggle [:faq/toggled question-id]
+  :label     "Why?"}]
+```
+
+The parent owns `open?` in re-frame. The control is dumb: **value in, intent out.**
+
+Use that pattern whenever the interaction is a single domain fact (or a single
+domain event) and every caller can wire it without reimplementing a multi-step
+protocol.
+
+## When you need a controller
+
+Only when the control owns a **multi-event protocol** that every caller should not
+rebuild:
+
+| Symptom | Example |
+|---|---|
+| Draft vs accepted baseline | commit on blur/Enter |
+| Cancel must beat late blur | Escape then blur must not commit |
+| Same-value rejection | parent reasserts old string; field must reset |
+| Shared library UX | many screens, same rules |
+
+Classic case: **buffered / revision text field.** Dropdown and typeahead are the
+same class once the protocol is clear.
+
+If every keystroke *is* product state (live filter, autosave), stay controlled and
+dispatch domain events — no controller.
+
+## Async search / typeahead (without a second state system)
+
+Dropdown move/select and typeahead are the same *class* of multi-event protocol
+as buffered fields — but many apps implement them as **ordinary re-frame** first
+and only package a controller when reuse demands it.
+
+### Debounce and supersession (app pattern)
+
+```clojure
+;; Each keystroke updates the query string (controlled field A) and kicks search.
+;; re-frame2: :dispatch-later is an fx id; the map key for the event is :event
+;; (not v1's :dispatch).
+(rf/reg-event :search/query-typed
+  (fn [{:keys [db]} [_ text]]
+    (let [gen (inc (get-in db [:search :generation] 0))]
+      {:db (-> db
+               (assoc-in [:search :query] text)
+               (assoc-in [:search :generation] gen)
+               (assoc-in [:search :status] :pending))
+       :fx [[:dispatch-later
+             {:ms 200
+              :event [:search/run gen text]}]]})))
+
+(rf/reg-event :search/run
+  (fn [{:keys [db]} [_ gen text]]
+    (if (not= gen (get-in db [:search :generation]))
+      {}   ; superseded — do nothing
+      {:fx [[:search/fetch {:q text :gen gen}]]})))
+
+(rf/reg-event :search/results-arrived
+  (fn [{:keys [db]} [_ gen results]]
+    (if (not= gen (get-in db [:search :generation]))
+      {}   ; stale network reply
+      {:db (-> db
+               (assoc-in [:search :results] results)
+               (assoc-in [:search :status] :ready))})))
+```
+
+```clojure
+(v/defview search-box [_]
+  [:div.search
+   [:input {:value (v/sub [:search/query])
+            :on-input [:search/query-typed ::v/value]
+            :aria-autocomplete :list}]
+   [:ul
+    (for [id (v/sub [:search/result-ids])]
+      [result-row {:key id :id id}])]])
+```
+
+| Law | Meaning |
+|---|---|
+| Generation / request id | later keystrokes and replies supersede earlier ones |
+| Decide in the handler | never “trust the callback closed over gen 3” without checking db |
+| Effects own HTTP | views only dispatch; cancel-and-replace lives in fx if you have real abort |
+| Optional controller | package open/highlight/commit only when many screens share the same UX |
+
+Debounce begins as **library or app policy**. It graduates into reserved re-frame
+vocabulary only after independent UI and non-UI uses share identity, cancellation,
+frame, SSR, and trace semantics (D017). Do not invent `v/debounce`.
+
+## Where the data lives
+
+Controller state is **ordinary frame-scoped re-frame data** (usually that frame’s
+**app-db**). It is not React state, not `local`, and not a Freehand-private side
+channel.
+
+**There is no single Freehand-mandated path** like “always under
+`[:rf/controllers …]`.” The **library** chooses the root. Freehand fixes the
+**identity model**: kind + caller `:control` address.
+
+Identity is:
+
+```text
+(controller-kind, semantic-address)
+```
+
+- **Kind** — which protocol (buffered field, dropdown, …). Owned by the library.
+- **Address** — which *instance*, as immutable caller-supplied EDN, e.g.
+  `[:invoice invoice-id :amount]` or `[:line line-id :label]`.
+
+Conceptual store (illustrative library choice only):
+
+```clojure
+;; only rows currently mid-edit need an entry
+{:fh.buffer/by-control
+ {[:line 5 :label]  {:reset-key 0 :draft "Alph"}
+  [:line 12 :label] {:reset-key 2 :draft "…"}}}
+```
+
+You work through the library’s `reg-sub` / `reg-event`s, not by hand-walking that
+map. Xray’s app-db view will show whatever root the library used.
+
+### Edit-session lifecycle (buffered field)
+
+| Moment | Controller record |
+|---|---|
+| Idle (showing external `:value`) | **Absent** (or ignored) |
+| **First real keystroke** (not mere focus) | **Created** under `:control` |
+| Further typing | **Updated** (`:draft`) — each keystroke is still a re-frame event |
+| **Enter** or **blur** (commit) | **Removed**; domain gets `:on-commit` |
+| **Escape** (cancel) | **Removed**; domain unchanged |
+| Parent bumps `:reset-key` | Session invalid; show baseline again |
+| Unmount without commit | Record may **linger** until owner clear |
+
+So “created when I start editing, gone when I finish” is right — but finish means
+**commit or cancel**, not only Return. Leave-without-finish needs an **owner**
+that clears the session.
+
+### Two identities (do not collapse them)
+
+| Identity | Job |
+|---|---|
+| **Occurrence** — view id + parent + `:key` / position | reconciliation, callbacks, presence, “this mount” |
+| **Semantic address** — `:control` | “this field’s protocol state” |
+
+Freehand never derives a writable address from the React tree. Tools may *join*
+occurrence ↔ controller for debugging. Your call sites always pass `:control`
+explicitly.
+
+### Cleanup (two layers)
+
+| What | Cleaned how |
+|---|---|
+| View subs / callbacks / host | Automatic on unmount / disconnect |
+| Controller draft session | Commit, cancel, or **owner clear** — **not** unmount |
+| Domain value (saved label) | Your domain events / route leave |
+
+If you forget owner clear, drafts can orphan in app-db. Dev tools should surface
+that. Plan form/route teardown the same way you release resources on leave.
+
+## Call site: one buffered field
+
+```clojure
+[buffered-field
+ {:control   [:invoice invoice-id :amount]
+  :value     (v/sub [:invoice/amount invoice-id])
+  :reset-key (v/sub [:invoice/amount-revision invoice-id])
+  :on-commit [:invoice/amount-committed invoice-id]}]
+```
+
+| Prop | Meaning |
+|---|---|
+| `:control` | semantic address for this instance’s draft session |
+| `:value` | external baseline when not editing |
+| `:reset-key` | **required** generation; new key drops the draft even if text equals the old baseline |
+| `:on-commit` | caller intent prefix; library commit appends the draft and dispatches |
+
+Design rules worth internalising:
+
+- Editing starts on the **first real edit**, not mere focus.
+- Commit (Enter/blur) and cancel (Escape) **consult committed state** at fire time
+  and are idempotent for stale generations.
+- IME composition suppresses Enter commit until composition ends.
+
+## Table: 20 rows × one editable cell
+
+### Controlled (no controller)
+
+When the draft *is* domain truth:
+
+```clojure
+(v/defview line-row [{:keys [line-id]}]
+  (let [label (v/sub [:lines/label line-id])]
+    [:tr
+     [:td
+      [:input {:value    label
+               :on-input [:lines/set-label line-id ::v/value]}]]]))
+
+(v/defview lines-table [_]
+  [:table
+   [:tbody
+    (for [id (v/sub [:lines/visible-ids])]
+      [line-row {:key id :line-id id}])]])
+```
+
+Twenty domain paths; no `:control`.
+
+### Buffered (controller per row)
+
+```clojure
+(v/defview line-row [{:keys [line-id]}]
+  (let [label    (v/sub [:lines/label line-id])
+        revision (v/sub [:lines/label-revision line-id])]
+    [:tr
+     [:td
+      [buffered-field
+       {:control   [:line line-id :label]   ;; unique per row
+        :value     label
+        :reset-key revision
+        :on-commit [:lines/label-committed line-id]}]]]))
+
+(v/defview lines-table [_]
+  [:table
+   [:tbody
+    (for [id (v/sub [:lines/visible-ids])]
+      [line-row {:key id :line-id id}])]])
+```
+
+| Row | `:key` (list identity) | `:control` (protocol state) |
+|---|---|---|
+| line 1 | `1` | `[:line 1 :label]` |
+| line 5 | `5` | `[:line 5 :label]` |
+| line 20 | `20` | `[:line 20 :label]` |
+
+Use **domain ids** in addresses, not row indexes. Using the same `id` in `:key`
+and `:control` is normal; the two props answer different questions. Do not reuse
+one `:control` for two writable cells unless they should share one draft.
+
+You only need buffer records for rows **currently editing** — not twenty permanent
+slots.
+
+## What `buffered-field` looks like (library sketch)
+
+Yes: it is a normal **`v/defview`**, plus library events/subs. It is not a
+substrate special form.
+
+```clojure
+(ns my.ui.buffered-field
+  (:require [re-frame.core :as rf]
+            [re-frame.freehand :as v :refer [sub]]))
+
+;; ---- library dataflow ------------------------------------------------------
+
+(rf/reg-sub :fh.buffer/value
+  (fn [db [_ control reset-key external-value]]
+    (let [rec (get-in db [:fh.buffer/by-control control])]
+      (if (and rec (= (:reset-key rec) reset-key))
+        (:draft rec)
+        (or external-value "")))))
+
+(rf/reg-event :fh.buffer/edited
+  (fn [{:keys [db]} [_ control reset-key text]]
+    {:db (assoc-in db [:fh.buffer/by-control control]
+                   {:reset-key reset-key :draft text})}))
+
+(rf/reg-event :fh.buffer/committed
+  (fn [{:keys [db]} [_ control reset-key on-commit]]
+    (let [rec (get-in db [:fh.buffer/by-control control])]
+      (if (and rec (= (:reset-key rec) reset-key))
+        {:db (update db :fh.buffer/by-control dissoc control)
+         :fx [[:dispatch (conj (vec on-commit) (:draft rec))]]}
+        {}))))   ; stale / already cancelled → no-op
+
+(rf/reg-event :fh.buffer/cancelled
+  (fn [{:keys [db]} [_ control reset-key]]
+    (let [rec (get-in db [:fh.buffer/by-control control])]
+      (if (and rec (= (:reset-key rec) reset-key))
+        {:db (update db :fh.buffer/by-control dissoc control)}
+        {}))))
+
+;; ---- the control -----------------------------------------------------------
+
+(v/defview buffered-field
+  [{:keys [control value reset-key on-commit placeholder]}]
+  (let [text (sub [:fh.buffer/value control reset-key value])]
+    [:input
+     {:value       text
+      :placeholder placeholder
+      :on-input    [:fh.buffer/edited control reset-key ::v/value]
+      :on-blur     [:fh.buffer/committed control reset-key on-commit]
+      :on-key-down {"Enter"  [:fh.buffer/committed control reset-key on-commit]
+                    "Escape" [:fh.buffer/cancelled control reset-key]}}]))
+```
+
+### Behaviour timeline
+
+1. **Not editing** — sub falls through to external `:value`.
+2. **First keystroke** — `edited` writes `{reset-key, draft}` under `control`.
+3. **Further keys** — update draft; controlled input rides Freehand’s
+   [sync door](events-and-handlers.md#controlled-inputs).
+4. **Enter / blur** — `committed` checks generation, clears record, dispatches
+   caller `on-commit` + draft.
+5. **Escape** — `cancelled` clears record; a later blur no-ops (generation check).
+6. **Parent bumps `:reset-key`** — draft no longer matches → show external value
+   again (including same-value rejection).
+
+Namespace prefixes such as `:fh.buffer/*` are **library vocabulary**, not reserved
+Freehand grammar. v1 does not reserve `:rf.field/*` at the framework layer.
+
+## Who owns what
+
+| Freehand (substrate) | Library |
+|---|---|
+| re-frame as the only reactive app state | control `v/defview` (e.g. `buffered-field`) |
+| explicit `:control` addresses for writable protocol state | record schema under each address |
+| one event (or `nil`) per user action | semantic events: edited / committed / cancelled… |
+| consult committed state at fire time (law) | handler bodies that enforce the protocol |
+| no mount-driven domain/controller cleanup | catalog metadata for tools (optional) |
+
+Freehand does not ship generic view-level `put` / `merge` / `toggle` as the way to
+build these protocols in v1.
+
+## Decision cheat sheet
+
+| Situation | Prefer |
+|---|---|
+| Single domain fact, simple event | props-only controlled control |
+| Keystroke = domain write | controlled input + domain event |
+| Commit / cancel / reject / shared field UX | semantic controller + library control |
+| High-rate or opaque editor | qualified [host boundary](host-boundaries.md), not fake “local” |

--- a/docs/design/freehand/draft-guide/ssr.md
+++ b/docs/design/freehand/draft-guide/ssr.md
@@ -1,0 +1,152 @@
+# SSR and hydration
+
+You want the **same Freehand views** on the server — not a second UI stack. Freehand
+emits a **versioned structural tree** on the JVM (and HTML from there). Browser and
+JVM hosts share meaning (props, keys, boundaries, event intent) without sharing one
+emitter implementation.
+
+## What renders on the server
+
+| Full semantics | Honest fallbacks |
+|---|---|
+| Structure, props, branches, keyed lists | Host behaviors → inert marker or explicit fallback (`:ssr` policy) |
+| Subscriptions (snapshot reads under a **request frame**) | `v/client-only` → declared fallback |
+| Event intent as **data** on the tree (not live listeners in HTML) | Top-layer desired state → semantic fact; not “browser layer opened” |
+| Presence **present/base** + metadata | No fake exit animation timeline on the server |
+| Error-boundary structure | Server error projection from Root Descriptor — not a client recovery commit |
+
+A view that *is* its host behaviour (canvas chart, map) wraps the leaf in
+`v/client-only` with an explicit fallback and keeps shared markup outside.
+
+```clojure
+(v/client-only
+ {:fallback [:div.chart-placeholder "Chart available after load"]}
+ [chart-host {:spec (v/sub [:chart/spec])}])
+```
+
+## Request frame and data
+
+SSR is not a second state system. A **request-scoped frame** (or equivalent
+preflight) holds the snapshot the tree will read:
+
+1. Build/seed the frame (initial events, already-fetched data, auth snapshot).
+2. Structural/SSR render under that frame.
+3. Emit HTML (and any serialization the app needs for client resume).
+4. On the client, hydrate into a live frame that continues the same app identity
+   rules your product defines.
+
+Views stay passive: they do not fetch on mount. Routes, resources, and machines
+own causal reads on both sides of the wire.
+
+## Roots and frames
+
+People sometimes ask: “How do I inject a frame into the DOM?”
+
+With Freehand you do not stamp a frame id onto arbitrary markup. You **mount a
+Freehand root into a DOM container**, and Freehand binds a **frame** (re-frame
+world) to that root’s tree. The frame is context for `sub` and dispatch, not a
+DOM attribute.
+
+| Concept | Meaning |
+|---|---|
+| **Root** | one React unit in one DOM container; Root Descriptor identity |
+| **Frame** | one re-frame2 state world (app-db, events, subs) |
+
+They combine freely: two roots may share one frame; one root may scope several
+frames (via provider-style retarget inside Freehand).
+
+### Single-root paved path
+
+```clojure
+(def mounted
+  (v/mount [app-root {}]
+           (.getElementById js/document "app")))
+
+(v/unmount! mounted)   ; total teardown; not a domain event in the tree
+```
+
+Preflight on that root can create/select the frame and run `:initial-events`
+before first paint. Hot reload should reuse the live frame so state survives.
+
+### Multi-root
+
+Identity derives when unambiguous. Supply **`:root-id`** when containers could
+collide or when you need a stable external identity. Exact option maps land with
+implementation; the shape is:
+
+```clojure
+;; illustrative multi-root — same frame, two DOM containers
+(v/mount [panel-a {}] left-el  {:root-id :panel/left  :frame f})
+(v/mount [panel-b {}] right-el {:root-id :panel/right :frame f})
+```
+
+### Freehand inside foreign React
+
+If another React tree owns the DOM and needs a Freehand view as a **component
+value**, use `v/->react` and pass an existing live frame (reserved prop or ambient
+context). The bridge never creates a frame.
+
+Advanced create / render / **hydrate** operations consume the same Root Descriptor
+shape and return an opaque handle. Structural tests accept the same root form so
+boot plans do not fork between test and production.
+
+Root acceptance includes: minimal boot path, explicit multi-root ids, frame
+preflight, hydration, failed-root isolation, and total teardown.
+
+## Hydration
+
+1. Server HTML is painted (or streamed) from the structural/SSR emit.
+2. Client **hydrates** the same Freehand tree over that markup.
+3. **Handlers attach at hydration** — event intent was data in the tree; live
+   listeners are not required as HTML attributes.
+4. Browser-only leaves need matching server fallbacks or `client-only`. Mismatch
+   is an error.
+5. First top-layer host ops (open popover/modal) run after commit when desired
+   state says so — the server did not claim the browser layer was open.
+
+Target client entry: install the Freehand adapter, ensure the request/client
+frame is live (preflight / seed as appropriate), then run the product’s
+**hydrate** operation over the server markup. The product spine groups advanced
+create / render / **hydrate** with the paved `v/mount` path under one **Root
+Descriptor** family — identity, preflight, and teardown stay one story. Prefer
+that plan shared with tests rather than a parallel “SSR-only” constructor.
+
+Exact public helper names land with Spec 004C; do not treat a guessed
+`v/hydrate` arity as frozen API.
+
+Error recovery on the server follows the Root Descriptor’s **server error
+projection**. Do not pretend a client `v/error-boundary` recovery commit ran on
+the stream.
+
+## Routing links
+
+`v/route-link` is an ordinary Freehand view over re-frame2’s routing contract
+(Spec 012 late-bound semantics):
+
+```clojure
+[v/route-link {:to :article :params {:slug slug} :class "title"}
+ title]
+```
+
+| Property | Behaviour |
+|---|---|
+| Element | real `<a>` with strategy-correct `href` |
+| Plain left click | routing intent (in-app navigation) |
+| Modifier / middle click / download / non-`_self` | native browser behaviour |
+| Caller `:on-click` | runs first; may veto |
+| Missing routing artifact | fails loudly |
+| Modes | same declaration interpreted or compiled |
+
+Freehand owns ordinary view + host-neutral rendering. The routing artifact owns
+href and navigation strategy.
+
+## Practical checklist
+
+1. Keep domain ownership (reads, mutations) outside the view — SSR snapshots.
+2. Mark host-only leaves with `client-only` + fallback (or a real SSR adapter).
+3. Prefer props and event vectors that serialize honestly.
+4. Prove structural parity for the common subset in CI when claiming cross-mode
+   sameness.
+5. Seed the request frame the same way you would seed a test frame when possible.
+6. Don’t put secrets only in client-only leaves if the server tree must stay
+   consistent for SEO/accessibility without them — design the fallback.

--- a/docs/design/freehand/draft-guide/state.md
+++ b/docs/design/freehand/draft-guide/state.md
@@ -1,0 +1,196 @@
+# State
+
+**Where does a value live?** Shared app truth, parent props, or (rarely) a reusable
+field protocol — without a second reactive system.
+
+No `local`, ratom, or hook-shaped cell in ordinary Freehand views. Product state
+stays in re-frame. Host ephemera stay behind explicit host boundaries.
+
+| Question | Answer |
+|---|---|
+| Shared application state? | `(v/sub [:query …])` |
+| Given by my parent? | props (one map) |
+| Reusable multi-event protocol? | optional library controller + `:control` (not day one) |
+
+> **Day one is `sub` + props. Controllers are packaging, not a requirement.**
+
+## Shared state: `sub`
+
+```clojure
+(v/defview order-summary [{:keys [order-id]}]
+  (let [order (v/sub [:orders/by-id order-id])
+        total (v/sub [:orders/total order-id])]
+    [:div
+     [:h3 (:title order)]
+     [:strong (str "$" total)]]))
+```
+
+A few habits that keep this healthy:
+
+- `(v/sub …)` returns the **current value** and re-renders this boundary when that
+  value changes. The mechanism is on
+  [Reactivity](reactivity-and-ownership.md).  
+- Parametric queries work. When `order-id` changes, Freehand reconciles the old
+  and new targets carefully so you do not briefly see the wrong order’s data.  
+- Conditional reads are legal. A collapsed panel that reads nothing depends on
+  nothing.  
+- Keep real business calculation in `rf/reg-sub`. Views should do presentation
+  math only.  
+- Outside a view render, use `rf/subscribe-once`, not `v/sub`.
+
+### Prefer props-only leaves when you can
+
+Reusable presentation often reads cleaner when the **page** (or a thin boundary)
+does the subscriptions and the leaf only receives data:
+
+```clojure
+(v/defview app-root [_]
+  [app-page {:model (v/sub [:app/view-model])}])
+
+(v/defview app-page [{:keys [model]}]
+  [workspace {:model model}])   ; no sub below if the model is complete
+```
+
+Put scoped `sub` reads where locality and invalidation pay off. Do not thread the
+entire app-db through props just to satisfy a purity slogan.
+
+## Props
+
+Every internal Freehand view receives **one props map**.
+
+Trailing children arrive as the reserved `:children` vector. `:key` chooses
+sibling identity and is stripped before your function sees props. You must not put
+`:children` inside the props map yourself as a normal field.
+
+```clojure
+(v/defview panel [{:keys [title children]}]
+  [:section.panel
+   [:h2 title]
+   children])
+
+[panel {:key panel-id :title "Details"}
+ [details {:id panel-id}]]
+```
+
+Internal props are compared with re-frame value equality for memoisation. Mutable
+host objects do not belong in ordinary props; put them at an explicit host
+boundary.
+
+Props schemas are optional for ordinary application views. They become mandatory
+by policy for shipped library/catalogue surfaces and for generative parity claims.
+See [Compilation — props schemas](compilation.md#props-schemas).
+
+## Interaction state — the A / B / C ladder
+
+This is the section most people need when they first ask “where does my text field
+live?”
+
+**Freehand does not require semantic controllers.** Most forms never use them.
+
+| Rung | Pattern | Where the draft lives | When to use it |
+|---|---|---|---|
+| **A** | Live controlled input | Domain path in app-db | Each keystroke *is* the value |
+| **B** | Your draft, then commit | **Your** app-db keys | App-specific commit-on-blur / Escape |
+| **C** | Library semantic controller | Library map keyed by `:control` | Same hard protocol on many screens |
+
+**A and B are ordinary Freehand plus re-frame.** **C is optional packaging** for
+libraries that share a hard multi-event protocol.
+
+### Rung A — live domain field
+
+```clojure
+[:input {:value    (v/sub [:form/email])
+         :on-input [:form/set-email ::v/value]}]
+```
+
+Every keystroke updates the real email (or filter string, or whatever the domain
+is). Simple. Often enough.
+
+### Rung B — draft, then commit, still no controller
+
+```clojure
+[:input {:value   (v/sub [:form/email-draft])
+         :on-input [:form/email-drafted ::v/value]
+         :on-blur  [:form/email-committed]
+         :on-key-down {"Enter"  [:form/email-committed]
+                       "Escape" [:form/email-cancelled]}}]
+```
+
+Here the jobs split on purpose:
+
+- **input** updates the draft  
+- **blur** and **Enter** share **commit**  
+- **Escape** cancels  
+
+You own the app-db keys and the cleanup. Freehand does not invent a second store
+for you, and unmount does not magically clear your draft.
+
+## Day-one checklist
+
+Stop when you can:
+
+- read shared state with `(v/sub …)` inside a view  
+- pass one props map between views  
+- wire a live field (A) or an app-owned draft (B) without a controller  
+- keep DOM nodes and third-party instances off app-db  
+
+## If something feels wrong
+
+| Symptom | Fix |
+|---|---|
+| Draft vanishes on unmount / route leave | you expected lifecycle cleanup — clear in route/owner events |
+| “I need `local` for this toggle” | re-frame fact + event, or props-only controlled open? |
+| Mid-edit wiped by async load | seed-merge untouched keys only |
+| Two writers on one draft | one owner path; controllers need unique `:control` addresses |
+
+---
+
+## Rung C — library controller (optional)
+
+Use this only when many screens need the same multi-step protocol and you do not
+want every team to reimplement stale blur, cancel races, and same-value reject.
+
+It is **not** a Freehand built-in widget. A library (or your design system)
+implements something like `buffered-field` as a normal `v/defview` plus library
+events. Call sites look roughly like this:
+
+```clojure
+[buffered-field
+ {:control   [:invoice invoice-id :amount]
+  :value     (v/sub [:invoice/amount invoice-id])
+  :reset-key (v/sub [:invoice/amount-revision invoice-id])
+  :on-commit [:invoice/amount-committed invoice-id]}]
+```
+
+| Piece | Meaning |
+|---|---|
+| Storage | ordinary frame app-db under a **library-chosen** root (no magic Freehand path) |
+| Identity | kind + your `:control` address (plain EDN you choose) |
+| **`:reset-key`** | **required** prop — external baseline/session generation; no weaker hidden mode |
+| Session | created on **first real edit** (not mere focus); cleared on **commit or cancel** |
+| Unmount | does **not** clear the controller record — a form/route owner should |
+
+### What Freehand does not provide
+
+| Absent | Use instead |
+|---|---|
+| `local` | re-frame facts (A/B) or a library controller (C) |
+| `v/self` / tree-derived writable addresses | your domain ids or explicit `:control` |
+| Mount/unmount as domain cleanup | route / resource / machine ownership |
+| Built-in `buffered-field` or reserved `:rf.field/*` in v1 | library vocabulary if you need C |
+
+## Where state lives — quick map
+
+| Kind of fact | Who owns it | Identity | How it goes away |
+|---|---|---|---|
+| Domain data | re-frame events/subs | domain ids | domain / route / workflow |
+| Draft that *is* product state | re-frame | domain path | domain events |
+| Reusable multi-event protocol | library controller | kind + `:control` | commit, cancel, or owner clear |
+| DOM node, observer, third-party instance | host boundary | occurrence / behavior instance | host disconnect |
+| Enter/exit presentation | `v/presence` | keyed child | timeout / re-entry machine |
+
+## Multi-field forms
+
+When several fields share draft, validation, and submit, use a **form-slice**
+shape (draft, baseline, touched, errors, submit-attempted?) and seed-merge rules
+so late loads do not clobber keystrokes — not only single-field wiring.

--- a/docs/design/freehand/draft-guide/testing.md
+++ b/docs/design/freehand/draft-guide/testing.md
@@ -1,0 +1,236 @@
+# Testing
+
+You want to prove what a view shows and what a control will dispatch **without**
+mounting a browser for every check. Handlers are data; structure is data — so the
+everyday test is: known re-frame state → structural tree on the JVM → equality.
+
+> **`rf/` drives and reads state. Freehand test helpers render, project, and settle.**
+
+Work down the tiers and **stop at the first one that answers your question.**
+
+!!! note "API names"
+
+    `re-frame.freehand.test` (alias `t`) is the design target. Exact fixture
+    helpers land with implementation; the **contracts** below are normative for
+    the guide.
+
+## Tier 1 — headless structure (daily driver)
+
+`t/render` runs the real view (interpreted or compiled) on the JVM and returns the
+versioned structural tree — plain data:
+
+```clojure
+(ns shop.ui-test
+  (:require [clojure.test :refer [deftest is]]
+            [re-frame.freehand.test :as t]
+            [shop.ui :as app]))
+
+(deftest add-button-carries-intent
+  (let [tree (t/render [app/add-button {:product-id 42}])]
+    (is (= [:cart/add 42]
+           (-> (some #(when (= :button (:tag %)) %)
+                     (tree-seq map? :children tree))
+               t/attrs
+               :on-click)))))
+```
+
+Because handlers are event vectors, “what does this button do?” is an **equality
+check** — no click simulation.
+
+### Reading the tree
+
+| Do | Don’t |
+|---|---|
+| `(tree-seq map? :children tree)` | invent a selector DSL |
+| `(t/attrs node)` for props **and** event intents | `(:on-click node)` — events live under the structural schema; bare keyword miss is `nil` |
+| `(t/text node)` for concatenated text | assert on host-only fields in tier 1 |
+
+```clojure
+;; first button
+(some #(when (= :button (:tag %)) %) (tree-seq map? :children tree))
+
+;; view boundary by id (shape illustrative)
+(some #(when (= :shop/product-card (:view-id %)) %)
+      (tree-seq map? :children tree))
+```
+
+### Sub overrides
+
+When offered, `:sub-overrides` (query → value) pins **render reads only**:
+
+```clojure
+(t/render [app/badge {}]
+          {:sub-overrides {[:cart/count] 3}})
+```
+
+They do **not** mutate app-db and do **not** make a `compute-sub` derivation test
+pass. To test derivation, use a real frame (tier 2) or pure sub unit tests.
+
+### Ground rules (tier 1)
+
+1. Events and subs the view touches should be **`.cljc`** so they run on the JVM.
+2. Tier 1 is the **structural subset**: host behaviors are markers/fallbacks;
+   client-only shows fallback; presence is present/base + metadata — not a live
+   animation clock.
+3. One root form per `render` — wrap multi-view compositions in one `defview`.
+4. These should run in a JVM watch loop in milliseconds.
+
+## Day-one checklist
+
+- Assert event vectors and visible structure with `t/render` (or equivalent).  
+- Prefer `(t/attrs node)` for intents — not bare `(:on-click node)`.  
+- Keep events/subs `.cljc` so the JVM path works.  
+- Do **not** invent a structural `click!` DSL.
+
+If tier 1 answers the question, stop. Most Freehand view tests should live here.
+
+## Tier 2 — real frame, real events
+
+Step up for registered-sub derivation, event transitions, or isolation.
+
+### Final state only — put the history in `:initial-events`
+
+When you only need a snapshot **after** a known sequence, fold setup into frame
+creation. No separate `dispatch-sync`:
+
+```clojure
+(deftest cart-badge-shows-count-after-add
+  (rf/with-new-frame
+    [_ (rf/make-frame
+        {:initial-events [[:rf/set-db {:cart #{}}]
+                          [:cart/add 42]]})]
+    (let [tree (t/render [app/cart-badge {}])]
+      (is (= "1" (t/text (some #(when (= :span (:tag %)) %)
+                               (tree-seq map? :children tree))))))))
+```
+
+`:initial-events` runs in order when the frame is minted (same idea as production
+preflight seeding). Prefer this for small “given this history, the tree looks
+like …” tests.
+
+### Transition — seed, then `dispatch-sync`
+
+When you need **before and after**, or to mimic “user did X while the app is
+running,” keep a live frame and dispatch:
+
+```clojure
+(deftest adding-to-the-cart-updates-the-badge
+  (rf/with-new-frame
+    [f (rf/make-frame {:initial-events [[:rf/set-db {:cart #{}}]]})]
+    (let [before (t/render [app/cart-badge {}])]
+      (is (= "0" (t/text (some #(when (= :span (:tag %)) %)
+                               (tree-seq map? :children before)))))
+    (rf/dispatch-sync [:cart/add 42] {:frame f})
+    (let [after (t/render [app/cart-badge {}])]
+      (is (= "1" (t/text (some #(when (= :span (:tag %)) %)
+                              (tree-seq map? :children after))))))))
+```
+
+| Piece | Role |
+|---|---|
+| `rf/make-frame` | mint an isolated world |
+| `:initial-events` | ordered history at creation (seed and/or full setup) |
+| `rf/with-new-frame` | bind ambient frame; destroy on exit |
+| `rf/dispatch-sync` + `{:frame f}` | further transitions on a live frame |
+| fresh `t/render` | assert structure after each step you care about |
+
+| Prefer | When |
+|---|---|
+| `:initial-events` only | one final snapshot; less noise |
+| `dispatch-sync` (after seed) | before/after; multi-step; “event while running” |
+
+There is **no** structural `click!` or gesture DSL. Intent is data; behavior is
+re-frame.
+
+### Projection materialization in tests
+
+Production materializes `::v/value` / `::v/checked` / `::v/key` at the Freehand
+adapter. Tests must **reuse that materializer** (helpers such as
+`t/materialize` / `t/dispatch` when implemented) so value-carrying intents never
+grow a second splice path. “Dispatch the vector you read from the tree” should
+mean the same bytes after materialization as a DOM fire would.
+
+### Adapter fixture
+
+`rf/make-frame` needs an installed adapter. Install once per test namespace via the
+project’s reset-runtime fixture (exact helper names land with implementation),
+e.g. a headless JVM adapter for tier 1–2 and the Freehand browser adapter for
+mounted tests. Do not invent a second view programming model for tests.
+
+## Tier 3 — mounted browser
+
+Use the real DOM for:
+
+- controlled input caret / selection / IME under contention
+- focus, top-layer light-dismiss
+- presence transitions with real CSS
+- behavior connect / update / disconnect and command targeting
+- third-party React protocols
+
+### Settling
+
+| Primitive | Role |
+|---|---|
+| host `act` (or equivalent) | around user/DOM writes |
+| production post-drain checkpoint | dirty Freehand cells publish inside that scope |
+| **one** shared `settle!` / `flush!` if needed | fixed point for framework + React — **not** a family of click/query/dispatch mirrors |
+| `t/flush-presence!` | fake clock for presence retention — never `Thread/sleep` |
+
+```clojure
+;; shape illustrative — await promises; no overlapping mounts
+(t/with-root [container [app/counter {}]]
+  (-> (t/flush! #(rf/dispatch-sync [:count/inc] {:frame :app}))
+      (.then (fn []
+               (is (= "1" (.-textContent
+                           (.querySelector container ".count"))))))))
+```
+
+Rules of thumb:
+
+- Await every mount/flush promise before the next mounted operation.
+- Put writes **inside** the flush thunk when the harness requires it.
+- Query with native DOM APIs on the bound container.
+- Presence: `(t/flush-presence!)` to quiescence or `(t/flush-presence! ms)` for a
+  logical advance.
+
+```clojure
+(deftest toast-exits-after-timeout
+  ;; drop toast from app-db, then:
+  (t/flush-presence! 300)
+  ;; assert node gone / unmounting finished
+  )
+```
+
+## Cross-mode parity
+
+A structural test must not care which execution mode produced the tree for forms
+in the **common subset**. Assert public meaning (tags, props, intents, keys,
+presence metadata, host markers). When you promote a view with `{:compiled true}`,
+**re-run the same tests unchanged** — that is test invariance.
+
+For generative parity of library leaves, props schemas and a prop/branch corpus
+support interpreted-vs-compiled equality (see
+[Compilation — schemas](compilation.md#props-schemas)).
+
+## What not to test in the view layer
+
+| Concern | Where |
+|---|---|
+| Event handler pure logic | re-frame unit tests, no renderer |
+| Subscription derivation | re-frame unit / `compute-sub` |
+| Resource lifetime | routes, machines, owners |
+| Pixel animation | browser / visual harness |
+| “Click to prove dispatch” | assert the vector on the tree (tier 1) |
+
+If a view is hard to set up, it is often **reading too much** — narrow its subs.
+That smell surfacing in tests is a feature.
+
+## Common mistakes
+
+| Mistake | Symptom | Fix |
+|---|---|---|
+| `(:on-click node)` | silent `nil` | `(t/attrs node)` |
+| Second mount before first settles | overlapping act error | await promises |
+| Business logic only through views | slow, brittle tests | dataflow unit tests |
+| Wall-clock sleep for presence | flake | `flush-presence!` |
+| Expecting tier 1 to run behaviors | markers only | mounted tier |

--- a/docs/design/freehand/draft-guide/vs-reagent.md
+++ b/docs/design/freehand/draft-guide/vs-reagent.md
@@ -1,0 +1,195 @@
+# How Freehand is different from Reagent
+
+Same *job* (view layer on re-frame). Different *contract*: Freehand is
+**re-frame-native**; Reagent is a React wrapper re-frame *uses*. Hiccup is still
+Hiccup. What changes is subscriptions, events, local state, and how much of the
+UI stays plain data.
+
+This is a **habit comparison**, not a migration checklist.
+
+## The short version
+
+| Topic | Typical Reagent + re-frame | Freehand |
+|---|---|---|
+| Role in re-frame2 | first-class **adapter** (React-shaped view layer) | first-party **re-frame-native** view layer |
+| What a view is | function / form-1 / form-2 / form-3 | one form: `v/defview` |
+| How you call a component | often `[comp]` or subtle Form-2 rules | `[view props]` = boundary; `(helper)` = inline |
+| Subscriptions | `(rf/subscribe …)` then `@` / deref | `(v/sub …)` **is** the value |
+| Event handlers in the tree | usually `#(rf/dispatch …)` closures | usually event **vectors** (data) |
+| Local UI state | ratoms, Form-2 atoms, sometimes Reagent state | **no** `local` / ratom model in ordinary views — re-frame (or a library controller) |
+| React interop | often close to the metal | explicit host boundaries (leaf, behavior, UIx wrapper) |
+| Testing intent | often mount or simulate | structural tree on the JVM; assert vectors with `=` |
+| Performance path | memo, careful Form-2, React tricks | same authoring model; optional `{:compiled true}` after `v/check` |
+
+**One sentence:** Freehand keeps re-frame’s data orientation all the way to the
+view; Reagent is a general React wrapper that re-frame *uses*, so the view layer
+can drift into a second state and handler model.
+
+## What stays comfortable
+
+You will not feel lost on day one.
+
+- **Hiccup** — tags, props maps, children, the usual shapes.  
+- **Props** — one map into the view is the Freehand norm (similar to many modern
+  Reagent styles, stricter than positional args).  
+- **Vector call for components** — `[todo-row {:id id}]` still mounts a child.  
+- **re-frame itself** — `reg-event`, `reg-sub`, app-db, effects, frames. Freehand
+  does not replace that pipeline; it sits on top of it.
+
+If your Reagent code was already “mostly controlled inputs and dispatch,” Freehand
+will feel like a cleanup of that style, not a new architecture.
+
+## The shifts that matter
+
+### 1. One component form, not Form-1 / 2 / 3
+
+Reagent’s Form-2 and Form-3 exist largely to hold local state and lifecycle.
+Freehand collapses that:
+
+```clojure
+;; Freehand — always this shape
+(v/defview greeting [{:keys [name]}]
+  [:p "Hello, " name])
+```
+
+There is no “switch to Form-2 because I need an atom.” If you need state, it goes
+through re-frame (or a documented library controller). Lifecycle that touches the
+DOM goes through host boundaries, not a component class.
+
+Helpers are plain `defn`s called with parentheses. Their `sub` reads belong to the
+enclosing boundary. That replaces a lot of “is this Form-1 or Form-2?” folklore
+with one sharp rule: **vector = boundary, parens = inline.**
+
+### 2. Subscriptions are values, not things you deref
+
+```clojure
+;; Reagent-ish
+(let [n @(rf/subscribe [:count])]
+  [:span n])
+
+;; Freehand
+[:span (v/sub [:count])]
+```
+
+You do not hold a reaction object in application code. Freehand records the read
+while the view renders and re-renders that boundary when the value moves.
+
+Outside a view render, use `rf/subscribe-once` — Freehand will not let `v/sub`
+quietly mean “probe once” in a callback. That separation is intentional.
+
+### 3. Handlers are data on the paved path
+
+```clojure
+;; Reagent-ish
+[:button {:on-click #(rf/dispatch [:count/inc])} "+"]
+
+;; Freehand
+[:button {:on-click [:count/inc]} "+"]
+```
+
+The Freehand form is readable in source, visible to tools before it fires, and
+assertable in a JVM test without clicking. Closures still exist when you need them
+(`v/event`, `v/handler`), but they are the **escape**, not the default.
+
+For inputs, live scalars use projection markers instead of
+`(.. % -target -value)` in a lambda:
+
+```clojure
+[:input {:value (v/sub [:email])
+         :on-input [:form/set-email ::v/value]}]
+```
+
+### 4. No ratom as the app model
+
+Reagent makes it easy (sometimes too easy) to put “just this toggle” in a ratom.
+Freehand removes that escape hatch from ordinary views on purpose.
+
+| Reagent habit | Freehand direction |
+|---|---|
+| `(reagent/atom false)` for open/closed | re-frame fact + event, or props-only controlled component |
+| Form-2 let-binding of atoms | same — re-frame or library controller |
+| “Ephemeral so it doesn’t belong in app-db” | still re-frame if it is product interaction; host-only if it is truly DOM |
+
+That can feel stricter at first. The payoff is one place for truth, one place for
+time-travel and Xray, and fewer “works until reload” bugs.
+
+Hard multi-step fields (commit-on-blur, cancel, same-value reject) can still be
+packaged cleanly — as a **library** pattern with an explicit `:control` address,
+not as silent component-local cells.
+
+### 5. React is a host, not the whole model
+
+In Reagent, the boundary between “my component” and “React” is often soft. In
+Freehand:
+
+- ordinary views stay free of hooks  
+- foreign components are **qualified** host leaves  
+- imperative DOM libraries use **registered behaviors**  
+- real hook/portal/context needs go in a **UIx wrapper**  
+
+You still use React. You just do not pretend every React pattern is a Freehand
+primitive.
+
+### 6. Testing intent without a browser
+
+With Reagent, “what does this button do?” often means mount and simulate, or trust
+a callback mock.
+
+With Freehand, a structural render on the JVM can show the event vector on the
+node. You still use mounted tests for caret, focus, and third-party widgets — but
+not for every handler wiring check.
+
+### 7. Performance path is “same view, optional compile”
+
+Reagent performance work is often memo, Form-2 discipline, and React-level
+tricks.
+
+Freehand’s growth path is: write freely interpreted → measure → optionally mark
+`{:compiled true}` on the **same** `defview` after `v/check`. Call sites and
+tests stay the same. That is different from both “always interpret” and from
+re-frame.ui’s compile-first day-one feel.
+
+## Side-by-side: a tiny screen
+
+```clojure
+;; --- Reagent-ish sketch ---
+(defn counter []
+  (let [n @(rf/subscribe [:count])]
+    [:div
+     [:p "Count: " n]
+     [:button {:on-click #(rf/dispatch [:count/inc])} "Inc"]
+     [:input {:value @(rf/subscribe [:note])
+              :on-change #(rf/dispatch [:note/set (.. % -target -value)])}]]))
+
+;; --- Freehand ---
+(v/defview counter [_]
+  [:div
+   [:p "Count: " (v/sub [:count])]
+   [:button {:on-click [:count/inc]} "Inc"]
+   [:input {:value (v/sub [:note])
+            :on-input [:note/set ::v/value]}]])
+```
+
+Same re-frame events and subscriptions underneath. Different view contract on top.
+
+## What Freehand is *not* trying to be
+
+- A drop-in Reagent replacement with the same Form-2/Form-3 APIs  
+- A promise that every Reagent library will work unchanged  
+- A ban on React — only a ban on treating hooks and ratoms as the app model  
+
+Reagent and UIx remain first-class **view layers** in re-frame2 for ecosystem and
+migration reasons. Freehand is the **re-frame-native** peer for teams that want
+the UI to stay inside that architecture.
+
+## When the comparison bites
+
+| If you loved… | You may feel… | Freehand’s answer |
+|---|---|---|
+| Quick ratom toggles | “App-db for *this*?” | Yes for product UI; host boundary for pure DOM |
+| `#(dispatch …)` everywhere | “Vectors are verbose” | Until you test and inspect them |
+| Form-2 closures | “Where does instance state go?” | Props, re-frame, or library `:control` |
+| Free React components | “Why qualify hosts?” | So the tree stays honest for tools and tests |
+
+None of those frictions are accidents. They are the cost of keeping the view layer
+in the same data story as the rest of re-frame.


### PR DESCRIPTION
Promotes the operator's Freehand draft guide out of the gitignored, local-only `ai/findings/freehand/guide/` tree into the tracked design record at `docs/design/freehand/draft-guide/` (rf2-xczm2). The draft was 22 markdown files (~252K) that existed on exactly one machine — invisible to every worker and to a clean clone, and lost with that checkout. It is the operator's own writing and the base for the guide-authoring bead (rf2-fby7o).

This is a **promotion, not an edit pass**: the prose is not rewritten, restructured, retitled, or reflowed.

## Link repairs

Exactly one link the move forced:

- `docs/design/freehand/draft-guide/README.md` line 12 — `[`docs/core/AUTHORING.md`](../../../../docs/core/AUTHORING.md)` → `../../../core/AUTHORING.md`. From the old location (`ai/findings/freehand/guide/`, 4 levels deep) the target was reached with four `../`; the new location (`docs/design/freehand/draft-guide/`, 3 levels below `docs/`) reaches `docs/core/AUTHORING.md` with three. This is the only link in the whole tree that pointed outside the guide; every other link is a sibling (`file.md` / `file.md#anchor`) and resolves unchanged.

No pre-existing broken links were found (the slug checker passes — see below), so none were left in place.

Two prose references to the old home were deliberately **left unedited** (they are prose, not links, and belong to the authoring bead, not this move):
- draft `README.md` line 22: "lives under `ai/findings/` as a working draft" — now stale.
- draft `README.md` "Design sources" bullets cite `docs/design/freehand/...` — these are backticked path spans, not links.

No `rf2-` ids appear in the promoted prose (checked).

## Line endings

The source files were CRLF. The repo's entire docs tree is stored **LF** (verified: `docs/design/freehand/codex-design.md`, `docs/design/freehand/README.md`, `docs/core/AUTHORING.md`, top-level `README.md` are all LF blobs). Git's `autocrlf=true` normalized one source file (`reactivity-and-ownership.md`) to LF on staging and left the rest CRLF — an inconsistency. All 22 were normalized to LF to match the repo convention and each other. The text is character-for-character identical to source; only the EOL bytes differ.

## Byte-identity evidence

Each promoted blob's SHA-256 was compared against the LF-normalized source (`tr -d '\r' < source`), before deleting the original:

- **21 of 22 files** — blob SHA-256 is identical to the LF-normalized source (character-for-character identical; only CRLF→LF).
- **`README.md`** — the one file whose content changed. Its blob equals the LF-normalized source with only the AUTHORING link edited above (reconstructed hash matches exactly: `38489318…`). A `diff` of blob vs source shows a single changed line (line 12, the link).

The pre-normalization working-copy copies were also confirmed byte-identical to the originals (all 22 SHA-256 matched) immediately after copying, before any edit.

## check_doc_slugs.py scope

**Yes — `scripts/check_doc_slugs.py` scans `docs/design/`.** Its `DEFAULT_ROOTS` includes `docs`, and its `EXCLUDE_DIR_NAMES` (`findings`, `ai`, `site`, …) does not contain `design` or `draft-guide`. Proven empirically: injecting a broken anchor into `docs/design/freehand/draft-guide/index.md` made the checker exit 1 and report `BROKEN ANCHOR: docs\design\freehand\draft-guide\index.md`; removing it returned exit 0. So the draft was **unvalidated** while it lived under `ai/` (excluded) and is **now in scope**. Every intra-draft link and anchor resolves — the checker passes with the real content — including the eight cross-page anchor links (e.g. `composition.md#spreading-props-attribute-forwarding`, `events-and-handlers.md#the-escape-roster`, `compilation.md#props-schemas`).

## Quality gates

- `git ls-files docs/design/freehand/draft-guide | wc -l` → **22** ✅
- `python scripts/check_doc_slugs.py` → **exit 0** ✅ (and proven to scan the new directory)
- `python -m mkdocs build --strict` → **exit 0** ✅
- Draft **absent from the built site** ✅ — `site/` contains no `design/` directory at all; the existing `exclude_docs: design/freehand/` prefix covers the new `draft-guide/` subdirectory (verified: no `*draft-guide*` and no `*design/freehand*` paths under `site/`).
- `docs/design/freehand/README.md` gains one row marking the draft plainly as a DRAFT, not the shipped guide ✅
- No `.beads/issues.jsonl` in the commit ✅

The source `ai/findings/freehand/guide/` is removed only after this branch is committed and pushed.