### PR TITLE
feat(freehand): structural test surface and host/mode matrix (rf2-drpa3.19)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/test.cljc
+++ b/implementation/freehand/src/re_frame/freehand/test.cljc
@@ -1,0 +1,229 @@
+(ns ^:no-doc re-frame.freehand.test
+  "`t` — the Freehand STRUCTURAL test surface (EP-0036 F1e; Spec 008).
+
+  A programmer renders a declared view to the versioned semantic tree and
+  asserts on it WITHOUT a browser, on BOTH hosts:
+
+      (t/render [save-button {:article-id 42}])
+      ;; => {:view-id :app.article/save-button
+      ;;     :children [{:tag :button
+      ;;                 :events {:on-click [:article/save 42]}
+      ;;                 :children [\"Save\"]}]
+      ;;     :rf.ui/tree-version 1}
+
+  Five names query semantic VALUES; none simulates behaviour. Handler sites
+  are event vectors as data, so 'what does this button do' is an equality
+  check — no click simulation, no DOM, no flake:
+
+      (deftest save-button-carries-intent
+        (let [tree   (t/render [save-button {:article-id 42}])
+              button (t/find tree #(= :button (:tag %)))]
+          (is (= \"Save\" (t/text button)))
+          (is (= [:article/save 42] (:on-click (t/attrs button))))))
+
+  ## The surface
+
+    (render form)          the versioned STRUCTURAL TREE for a declared-view
+                           call or arbitrary markup — the same value on the
+                           JVM and in ClojureScript, in BOTH execution modes
+                           (an interpreted body is walked, a compiled body's
+                           structural realisation is run — the call spelling
+                           and the tree are identical either way).
+    (find tree pred)       the FIRST node the predicate matches, or nil.
+    (find-all tree pred)   every matching node, in document order.
+    (attrs node)           the MERGED attribute projection of a node.
+    (text node)            the node's text descendants in document order.
+
+  `find` / `find-all` are conveniences over the whole traversal API, which
+  is ordinary Clojure — `(tree-seq map? :children tree)` and a predicate
+  over `(:tag %)` (element tag) or `(:view-id %)` (view boundary).
+
+  ## Frame scope, and what runs headlessly
+
+  There is no frame option. Establish frame scope with the programmer's
+  ordinary bracket — `rf/with-new-frame` for a fresh owned frame
+  (eval-bind-run-destroy), `rf/with-frame` to pin one you hold — drive state
+  with `rf/dispatch-sync`, and assert on a FRESH `render`. The structural
+  walk itself subscribes to nothing and dispatches nothing (Spec 004B): the
+  events and subs a view under test touches must be `.cljc`, the standard
+  re-frame discipline. Host-bearing behaviour (real listeners firing into
+  the DOM, focus, presence timing, error recovery) is the mounted browser
+  tier's, not this one.
+
+  ## Reading a node
+
+  `(:on-click node)` is a FIELD miss — a keyword lookup on a node reads its
+  FIELDS, never its attributes. Event intent lives under `:events` and plain
+  attributes under `:attrs`; `attrs` MERGES the two on an element and reads
+  `:props` on a view boundary, so an intent assertion is
+  `(is (= [:cart/add 42] (:on-click (t/attrs node))))`.
+
+  Dev/test scope ONLY: nothing in a production bundle may `:require` this
+  namespace. It sits alongside the emitters, below the `re-frame.freehand`
+  door — `t/render` wraps the structural emitter the way `v/mount` wraps the
+  host one.
+
+  Normative owner: [`spec/008-Testing.md`](../../../../../spec/008-Testing.md);
+  the node schema and projections are
+  [`spec/004B-UI-Tree-and-Conversion.md`](../../../../../spec/004B-UI-Tree-and-Conversion.md)."
+  (:refer-clojure :exclude [find])
+  (:require [re-frame.error :as error]
+            [re-frame.freehand.tree :as tree]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(def ^:private where
+  "The raising site every projection diagnostic names."
+  're-frame.freehand.test)
+
+(defn- malformed!
+  [reason extra]
+  (error/throw-error!
+    :rf.error/ui-tree-malformed
+    where
+    reason
+    {:recovery :no-recovery :extra extra}))
+
+;; ---------------------------------------------------------------------------
+;; render — the structural emitter, wrapped as the test entry
+;; ---------------------------------------------------------------------------
+
+(defn render
+  "Render `form` and answer its versioned structural tree — the value a
+  structural test asserts against.
+
+  `form` is a declared-view call (`[view props & children]`, in either
+  execution mode) or arbitrary markup; the return is always the ROOT node —
+  a map carrying `:rf.ui/tree-version` — and a form that denotes text,
+  several nodes, or nothing roots in a fragment. Plain, serialisable data:
+  `(tree-seq map? :children tree)` is the whole traversal API, and the tree
+  prints and reads back losslessly.
+
+  The same declaration renders to the same tree on the JVM and in
+  ClojureScript, which is what makes a `.cljc` structural test a cross-host
+  claim rather than a JVM claim with a `.cljc` extension."
+  [form]
+  (tree/render form))
+
+;; ---------------------------------------------------------------------------
+;; Finders — conveniences over (tree-seq map? :children tree)
+;; ---------------------------------------------------------------------------
+
+(defn find-all
+  "Every node under `tree` (the root included) for which `pred` is truthy,
+  in document order. Empty vector when nothing matches. `pred` reads node
+  fields — `(:tag %)` for an element, `(:view-id %)` for a view boundary."
+  [tree pred]
+  (filterv pred (tree-seq map? :children tree)))
+
+(defn find
+  "The FIRST node under `tree` (the root included, document order) for which
+  `pred` is truthy, or nil. `nil` threads through a missed match, so
+  `(t/attrs (t/find tree p))` nil-puns rather than throwing when nothing
+  matched."
+  [tree pred]
+  (first (find-all tree pred)))
+
+;; ---------------------------------------------------------------------------
+;; Node discrimination (Spec 004B §Node schema — the closed five-variant set)
+;; ---------------------------------------------------------------------------
+
+(defn- node-kind
+  "Discriminate a MAP node per the pinned order: `:tag` → element, else
+  `:view-id` → view boundary, else `:html` → trusted-HTML, else `:children`
+  → fragment. More than one primary discriminating field, or none of the
+  four, is malformed — a projection over a malformed node fails loud rather
+  than reading a plausible answer off a broken tree."
+  [m]
+  (let [primaries (cond-> 0
+                    (contains? m :tag)     inc
+                    (contains? m :view-id) inc
+                    (contains? m :html)    inc)]
+    (when (> primaries 1)
+      (malformed!
+        (str "malformed tree node — a map may carry only ONE of :tag / "
+             ":view-id / :html (the closed five-variant node set); got "
+             (pr-str (select-keys m [:tag :view-id :html])))
+        {:value m}))
+    (cond
+      (contains? m :tag)      :element
+      (contains? m :view-id)  :view-boundary
+      (contains? m :html)     :html
+      (contains? m :children) :fragment
+      :else
+      (malformed!
+        (str "malformed tree node — a map node needs a discriminating field "
+             "(:tag / :view-id / :html / :children); got " (pr-str m))
+        {:value m}))))
+
+(defn- not-a-node!
+  [got]
+  (malformed!
+    (str "not a structural tree node — a projection takes a node (the value "
+         "t/render returns, or any node reached by traversing it with "
+         "(tree-seq map? :children tree)); got " (pr-str got))
+    {:value got}))
+
+;; ---------------------------------------------------------------------------
+;; Projections (Spec 004B §Projections)
+;; ---------------------------------------------------------------------------
+
+(defn attrs
+  "The MERGED attribute projection of a structural node — the ONE attribute
+  read:
+
+    element        → `:attrs` merged with `:events` (collision-free by
+                     construction — the compiler routes `:on-*` to `:events`;
+                     handler slots carry event vectors / options maps / an
+                     opaque marker AS DATA)
+    view-boundary  → the `:props` map
+    fragment/html  → `{}` (no attributes exist; total, not an error)
+    nil            → nil (nil-punning threads through a missed traversal)
+
+  A keyword lookup on a node reads its FIELDS, never its attributes:
+  `(:on-click node)` is a field miss. Intent assertion is an equality check
+  `(is (= [:cart/add 42] (:on-click (t/attrs node))))`."
+  [node]
+  (cond
+    (nil? node)    nil
+    (string? node) (malformed!
+                     (str "text content is not a node — attrs projects map "
+                          "nodes; read text with t/text on the PARENT node")
+                     {:value node})
+    (map? node)    (case (node-kind node)
+                     :element          (merge {} (:attrs node) (:events node))
+                     :view-boundary    (or (:props node) {})
+                     (:fragment :html) {})
+    :else          (not-a-node! node)))
+
+(defn- text*
+  [n]
+  (case (node-kind n)
+    :html "" ; trusted-HTML contributes nothing — unparsed markup, not text data
+    (apply str
+           (map (fn [c]
+                  (cond
+                    (string? c) c
+                    (map? c)    (text* c)
+                    :else (malformed!
+                            (str "malformed tree — a :children entry must be a "
+                                 "node map or text content (a string); got "
+                                 (pr-str c))
+                            {:value c})))
+                (:children n)))))
+
+(defn text
+  "The concatenation of `node`'s text descendants in document order —
+  descending through elements, fragments and view boundaries alike;
+  trusted-HTML nodes contribute nothing (their content is unparsed markup).
+  No whitespace normalization beyond what the tree carries. `nil` → nil
+  (nil-punning)."
+  [node]
+  (cond
+    (nil? node)    nil
+    (string? node) (malformed!
+                     (str "text content is not a node — it IS the text; call "
+                          "t/text on the node that contains it")
+                     {:value node})
+    (map? node)    (text* node)
+    :else          (not-a-node! node)))

--- a/implementation/freehand/test/re_frame/freehand/structural_runner.cljc
+++ b/implementation/freehand/test/re_frame/freehand/structural_runner.cljc
@@ -1,0 +1,86 @@
+(ns re-frame.freehand.structural-runner
+  "The conformance RUNNER for structural-render laws (EP-0036 F1e; Spec 008
+  §How a conformance fixture is executed).
+
+  A Freehand law named in the conformance index
+  ([`spec/conformance/freehand/conformance-index.md`](../../../../../spec/conformance/freehand/conformance-index.md))
+  is proven by running its fixture. This runner executes the STRUCTURAL
+  shape — a fixture carrying `:cases` of `{:form <markup> :tree <expected
+  root>}` and `:rejected` of `{:form <markup> :error-id <id>}` — through the
+  PUBLIC structural test surface [[re-frame.freehand.test/render]], on
+  whichever host is running (the JVM lane via `clojure -M:test`, the
+  ClojureScript lane via `npm run test:freehand`), and answers a status
+  report that NAMES the fixture's `FH` id.
+
+  Status FLOWS BACK: a mismatch is a `:failures` entry carrying the id, the
+  case note, the expected value and what `render` actually produced (or the
+  error it raised), so a red row is attributable to its law without a
+  lookup. A run that asserts nothing is the worst failure a table-driven
+  gate can have, so `:ran` is reported and a caller checks it is non-zero.
+
+  Only the structural-render shape runs here — the tier the F1e surface can
+  execute headlessly. A row proven by mounting, by SSR emission, or across a
+  qualified host boundary is that tier's, per the host/mode matrix in Spec
+  008."
+  (:require [clojure.walk :as walk]
+            [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.test :as t]))
+
+(defn- realize
+  "Substitute a real function for the fixture's `:fh/fn` stand-in — EDN
+  carries no functions, and a handler site's classification turns on
+  whether the value IS one (Spec 004B §Element fields)."
+  [form]
+  (walk/postwalk #(if (= :fh/fn %) (fn [_] nil) %) form))
+
+(defn- render-case
+  "Render one `:cases` row and answer nil on a match, or a `:failure` map
+  naming `id` on a mismatch or a render that threw."
+  [id {:keys [note form tree]}]
+  (let [actual (try (t/render (realize form))
+                    (catch #?(:clj Throwable :cljs :default) e
+                      {::threw (or (ex-message e) (str e))}))]
+    (when-not (= tree actual)
+      {:fh/id id :note note :expected tree :actual actual})))
+
+(defn- reject-case
+  "Render one `:rejected` row and answer nil when it raised the expected
+  `:error-id`, or a `:failure` map naming `id` otherwise."
+  [id {:keys [note form error-id]}]
+  (let [actual (conf/caught-id #(t/render (realize form)))]
+    (when-not (= error-id actual)
+      {:fh/id id :note note :expected error-id :actual actual})))
+
+(defn run-structural-fixture
+  "Execute the structural `fixture` through [[re-frame.freehand.test/render]]
+  and return a status report:
+
+      {:fh/id    \"FH-STRUCT-001\"
+       :ran      12          ; total cases + rejections executed
+       :passed   12
+       :failures []}         ; each entry NAMES the FH id
+
+  Every `:failure` carries `:fh/id`, the offending `:note`, the `:expected`
+  value, and the `:actual` render (or `{::threw <message>}` when the render
+  threw where a tree was expected). An empty `:cases`+`:rejected` fixture
+  reports `:ran 0`, which a caller treats as a failure — a law proven by an
+  empty table is proven by nothing."
+  [fixture]
+  (let [id       (:fh/id fixture)
+        failures (into (vec (keep #(render-case id %) (:cases fixture)))
+                       (keep #(reject-case id %) (:rejected fixture)))
+        ran      (+ (count (:cases fixture)) (count (:rejected fixture)))]
+    {:fh/id    id
+     :ran      ran
+     :passed   (- ran (count failures))
+     :failures failures}))
+
+(defn run-all
+  "Run every fixture in `fixtures` and answer `{:ran :passed :failures}`
+  totalled across them. The aggregate a suite asserts a non-zero `:ran` and
+  an empty `:failures` on."
+  [fixtures]
+  (let [reports (map run-structural-fixture fixtures)]
+    {:ran      (reduce + 0 (map :ran reports))
+     :passed   (reduce + 0 (map :passed reports))
+     :failures (vec (mapcat :failures reports))}))

--- a/implementation/freehand/test/re_frame/freehand/structural_test_surface_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/structural_test_surface_cljs_test.cljc
@@ -1,0 +1,161 @@
+(ns re-frame.freehand.structural-test-surface-cljs-test
+  "F1e — the public structural test surface `re-frame.freehand.test` (`t`)
+  and the conformance runner that executes structural laws through it.
+
+  Two claims, both on both hosts. FIRST, the surface itself: a declared
+  view renders to the versioned semantic tree headlessly, event intent is
+  an equality check on data, and the four projections read what the node
+  schema pins. SECOND, the runner: a conformance fixture NAMED in the index
+  is executed through the public `t/render`, its status flows back naming
+  the `FH` id, the run reports a non-zero test count, and a deliberately
+  wrong fixture REDS rather than passing vacuously — the falsifiability
+  proof a table-driven gate lives or dies by."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.structural-runner :as runner]
+            [re-frame.freehand.test :as t]))
+
+;; ---------------------------------------------------------------------------
+;; The declared views the surface tests render
+;; ---------------------------------------------------------------------------
+
+(v/defview save-button
+  "The codex-design headline: a button carrying its intent as data."
+  [{:keys [article-id]}]
+  [:button {:on-click [:article/save article-id]} "Save"])
+
+(v/defview toolbar
+  "Several buttons — so a finder has more than one node to choose between."
+  [{:keys [ids]}]
+  [:div.toolbar
+   (for [id ids]
+     [:button {:key id :on-click [:row/pick id]} (str "row-" id)])])
+
+(v/defview nothing
+  "A view that renders nothing — still a boundary node, so it stays
+  addressable and its projection is total."
+  [_]
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; The surface — render / find / find-all / text / attrs
+;; ---------------------------------------------------------------------------
+
+(deftest render-reads-a-declared-view-headlessly
+  (testing "render answers the versioned semantic tree for a declared-view
+            call, on both hosts, with no browser; the intent is data read
+            through attrs, and (:on-click node) is a FIELD miss."
+    (let [tree   (t/render [save-button {:article-id 42}])
+          button (t/find tree #(= :button (:tag %)))]
+      (is (= 1 (:rf.ui/tree-version tree)) "the root carries the schema version")
+      (is (some? button) "the button node is found by its tag")
+      (is (= "Save" (t/text button)) "text concatenates document-order leaves")
+      (is (= [:article/save 42] (:on-click (t/attrs button)))
+          "the intent is read through attrs — events merge into the projection")
+      (is (nil? (:on-click button))
+          "a bare field lookup is a miss: events live under :events, not the node"))))
+
+(deftest find-and-find-all-traverse-the-tree
+  (testing "find returns the first match or nil; find-all returns every
+            match in document order — conveniences over (tree-seq map?
+            :children tree)."
+    (let [tree    (t/render [toolbar {:ids [1 2 3]}])
+          buttons (t/find-all tree #(= :button (:tag %)))]
+      (is (= 3 (count buttons)) "find-all sees every button")
+      (is (= ["row-1" "row-2" "row-3"] (mapv t/text buttons)) "document order is preserved")
+      (is (= [:row/pick 1] (:on-click (t/attrs (t/find tree #(= :button (:tag %))))))
+          "find returns the first match")
+      (is (nil? (t/find tree #(= :never (:tag %)))) "no match is nil")
+      (is (= [] (t/find-all tree #(= :never (:tag %)))) "no match is the empty vector"))))
+
+(deftest attrs-projects-every-node-variant
+  (testing "attrs is total over the node schema: element merges :attrs and
+            :events, a view boundary reads :props, a fragment/nothing-view
+            has no attributes, and nil nil-puns."
+    (let [tree (t/render [save-button {:article-id 7}])]
+      (is (map? (t/attrs tree)) "the root view boundary projects its props")
+      (is (= {:article-id 7} (t/attrs tree)) "a boundary's attrs are its recorded props")
+      (is (= {} (t/attrs (t/render [nothing {}])))
+          "a nothing-view boundary has no props, so attrs is the empty map")
+      (is (nil? (t/attrs nil)) "nil threads through a missed traversal"))))
+
+(deftest text-descends-in-document-order
+  (testing "text collects string leaves under a node, descending through
+            elements, fragments and boundaries; nil nil-puns."
+    (let [tree (t/render [:section [:h2 "Title"] [:p "a" [:b "b"] "c"]])]
+      (is (= "Titleabc" (t/text tree)) "every leaf, in order")
+      (is (nil? (t/text nil)) "nil nil-puns"))))
+
+(deftest projections-fail-loud-on-a-non-node
+  (testing "a projection over something that is not a tree node fails loud
+            with :rf.error/ui-tree-malformed rather than reading a plausible
+            answer off a broken value — a missing node is almost always a
+            test bug, not a passing case."
+    (is (= :rf.error/ui-tree-malformed
+           (conf/caught-id #(t/attrs "text")))
+        "text content is not a node — read it with t/text on the parent")
+    (is (= :rf.error/ui-tree-malformed
+           (conf/caught-id #(t/text "text")))
+        "text content is not a node — it IS the text")
+    (is (= :rf.error/ui-tree-malformed
+           (conf/caught-id #(t/attrs 42)))
+        "a scalar is not a node")
+    (is (= :rf.error/ui-tree-malformed
+           (conf/caught-id #(t/attrs {:tag :div :view-id :x})))
+        "a map carrying two primary discriminators is malformed")))
+
+;; ---------------------------------------------------------------------------
+;; The runner — executes conformance rows named in the index
+;; ---------------------------------------------------------------------------
+
+(def ^:private index-rows
+  "Structural-render laws from the conformance index this runner executes —
+  the F1c interpreted-tree rows whose fixtures carry the `:cases` / `:rejected`
+  render shape. Each is loaded from the same fixture bytes both hosts read."
+  [(conf/fixture :FH-STRUCT-001)
+   (conf/fixture :FH-STRUCT-002)
+   (conf/fixture :FH-STRUCT-003)
+   (conf/fixture :FH-STRUCT-004)
+   (conf/fixture :FH-STRUCT-005)])
+
+(deftest the-runner-executes-index-fixtures-and-status-flows-back
+  (testing "every named fixture is EXECUTED through the public t/render, the
+            run reports a NON-ZERO test count, and every row is green — its
+            status flows back per fixture."
+    (let [aggregate (runner/run-all index-rows)]
+      (is (pos? (:ran aggregate))
+          "the runner reports a non-zero test count — Ran 0 is a failure")
+      (is (empty? (:failures aggregate))
+          (str "every executed row is green; failures: " (pr-str (:failures aggregate)))))
+    (doseq [fixture index-rows]
+      (let [report (runner/run-structural-fixture fixture)]
+        (is (pos? (:ran report)) (str (:fh/id report) " executed at least one case"))
+        (is (empty? (:failures report))
+            (str (:fh/id report) " is green"))))))
+
+(deftest the-runner-reds-and-names-the-fh-id
+  (testing "falsifiability: a deliberately wrong fixture must RED, and each
+            failure must NAME its FH id. Proven for both arms — a case whose
+            expected tree is wrong, and a rejection that does not raise the
+            expected error — so neither arm can pass a broken law silently."
+    (let [rigged {:fh/id "FH-STRUCT-999"
+                  :cases    [{:note "a div is not a span"
+                              :form [:div] :tree {:tag :span :rf.ui/tree-version 1}}]
+                  :rejected [{:note "a legal element does not raise"
+                              :form [:div] :error-id :rf.error/ui-tree-malformed}]}
+          report (runner/run-structural-fixture rigged)]
+      (is (= 2 (:ran report)) "both rigged rows ran")
+      (is (= 2 (count (:failures report))) "both rigged rows red")
+      (is (every? #(= "FH-STRUCT-999" (:fh/id %)) (:failures report))
+          "every failure names the FH id its status belongs to")
+      (is (some #(= {:tag :span :rf.ui/tree-version 1} (:expected %)) (:failures report))
+          "the case failure carries its expected value, so the red is diagnosable")
+      (is (some #(= :rf.error/ui-tree-malformed (:expected %)) (:failures report))
+          "the rejection failure carries its expected error-id"))))
+
+(deftest an-empty-fixture-is-not-a-vacuous-pass
+  (testing "a fixture with no cases and no rejections reports :ran 0 — the
+            signal a caller treats as a failure, because a law proven by an
+            empty table is proven by nothing."
+    (is (= 0 (:ran (runner/run-structural-fixture {:fh/id "FH-STRUCT-000"}))))))

--- a/spec/008-Testing.md
+++ b/spec/008-Testing.md
@@ -672,6 +672,114 @@ portals, presence timing, error recovery) requires a Tier-3 mounted test. This i
 same JVM-structural-subset boundary [004D-Freehand-Compiled-Grammar.md §The JVM structural subset](004D-Freehand-Compiled-Grammar.md#the-jvm-structural-subset)
 draws — Tier-1 is that subset's test surface.
 
+## Freehand structural and mounted testing
+
+[Freehand](004-Views.md) is one view substrate with two execution modes over one
+semantic model, so its testing surface is one surface, not two. The section above is
+the donor compiled-view surface (`re-frame.ui.test`) that this generalizes; the
+contract here is the paved path — `re-frame.freehand.test`, conventionally aliased
+`t`, over the versioned structural tree owned by
+[004B](004B-UI-Tree-and-Conversion.md#the-node-schema--version-1).
+
+### The structural surface — headless, both hosts, both modes
+
+Five names query semantic **values**; none simulates behaviour.
+
+| Name | Answers |
+|---|---|
+| `(t/render form)` | the versioned structural tree for a declared-view call (`[view props & children]`, in either mode) or arbitrary markup — the ROOT node, a map carrying `:rf.ui/tree-version` |
+| `(t/find tree pred)` | the first node the predicate matches, or nil |
+| `(t/find-all tree pred)` | every matching node, in document order |
+| `(t/attrs node)` | the merged attribute projection — `:attrs` + `:events` on an element, `:props` on a view boundary, `{}` on a fragment, nil on nil |
+| `(t/text node)` | the node's text descendants, concatenated in document order |
+
+`find` / `find-all` are conveniences over the whole traversal API, which is ordinary
+Clojure — `(tree-seq map? :children tree)` and a predicate over `(:tag %)` (element
+tag) or `(:view-id %)` (view boundary). **Node reading is the ruled projection**:
+`(:on-click node)` is a *field* miss — event intent lives under `:events`, read
+through `attrs`, so "what does this button do" is an equality check on data
+(`(is (= [:cart/add 42] (:on-click (t/attrs node))))`) with no browser, no click
+simulation, no flake. Projections are owned by
+[004B §Projections](004B-UI-Tree-and-Conversion.md#projections--how-nodes-are-read); a
+projection over a malformed value fails loud with `:rf.error/ui-tree-malformed` rather
+than reading a plausible answer off a broken tree.
+
+The single most consequential difference from the donor surface: **the structural
+tree is cross-host in both modes.** The donor's compiled emitter targeted React
+directly, so its structural tree was JVM-only. Freehand's interpreted walk and its
+compiled structural realisation each answer the *same* tree on the JVM and in the
+ClojureScript runtime — so `t/render` is a cross-host structural claim proven in node
+(`npm run test:freehand`), not a JVM claim wearing a `.cljc` extension. Frame scope is
+the programmer's ordinary bracket (`rf/with-new-frame` / `rf/with-frame`); drive state
+with `rf/dispatch-sync` and assert on a fresh `render`. The events and subs a view
+under test touches must be `.cljc` — the JVM-structural-subset boundary; host-bearing
+behaviour is the mounted tier's.
+
+### The mounted tier
+
+Real listeners firing into the DOM, focus, controlled-input contention, presence
+timing, and error recovery are outside the structural subset. They are proven by
+**mounting** a real React tree in a browser and reading the DOM natively — the Tier-3
+mounted surface, browser only. It arrives with the mounted browser matrices; the
+structural surface and its runner are the headless tier this section contracts.
+
+### The host/mode matrix
+
+Two axes. A **mode** is `common` (the law binds identically in both modes),
+`interpreted`, or `compiled`; a **host** is `jvm`, `browser`, `ssr`, or a *qualified
+host* (a foreign boundary behind a declared host descriptor). Each cell names the tier
+that proves a law there.
+
+| Mode ↓ / Host → | jvm | browser | ssr | qualified host |
+|---|---|---|---|---|
+| **common** | structural | structural | structural tree → [011](011-SSR.md) | mounted |
+| **interpreted** | structural | structural · mounted | structural tree → [011](011-SSR.md) | mounted |
+| **compiled** | structural | structural · mounted | structural tree → [011](011-SSR.md) | mounted |
+
+- **structural** — the surface and runner execute this **headlessly today**: the JVM
+  lane via `clojure -M:test`, the ClojureScript lane via `npm run test:freehand`. The
+  `browser` column's structural cell is the host-neutral tree proven in the node
+  runtime; it needs no real DOM, because the tree is plain data identical to the JVM's.
+- **mounted** — the real-DOM Tier-3 tier (real listeners, focus, presence timing).
+  Browser only, and **not** executed by the structural runner; it lands with the
+  mounted browser matrices.
+- **structural tree → 011** — the structural tree is the *input* server rendering
+  consumes; the runner proves the tree, and [011](011-SSR.md) owns emission and
+  hydration.
+- **qualified host** — a foreign boundary is opaque to the structural render (the v1
+  node set carries no host variant), so a qualified-host law is proven by connecting
+  the real behaviour or wrapper in a browser under its own host-boundary slice, never
+  by the structural surface.
+
+No cell claims structural coverage the runner cannot execute: the four `structural`
+cells (both modes × {jvm, browser}) are exactly what `t/render` renders headlessly on
+the two lanes.
+
+### How a conformance fixture is executed
+
+A Freehand law carries a permanent `FH-<AREA>-<NNN>` id and resolves to one paragraph
+of normative spec; the [conformance index](conformance/freehand/conformance-index.md)
+binds each id to its canonical paragraph, its applicability cell (the mode/host grammar
+above), and its fixture. The index *addresses* laws; it does not run them
+([conformance/freehand/README.md](conformance/freehand/README.md) §What this is not).
+Executing them is the runner's job.
+
+A structural-render law's fixture carries `:cases` of `{:form <markup> :tree <expected
+root>}` and `:rejected` of `{:form <markup> :error-id <id>}`. The runner reads the
+fixture at macro-expansion time — so the JVM and ClojureScript lanes assert against the
+same bytes — realizes the `:fh/fn` stand-ins EDN cannot carry, renders each `:form`
+through the public `t/render`, and compares: a `:cases` row must produce its pinned
+tree, a `:rejected` row must raise its `:error-id`. **Status flows back** as a report
+naming the fixture's id — `{:fh/id … :ran n :passed n :failures [{:fh/id … :note …
+:expected … :actual …}]}` — so a red row is attributable to its law without a lookup,
+and a run that asserts nothing (`:ran 0`) is itself a failure. The runner's own
+falsifiability proof feeds it a deliberately wrong fixture and asserts the run reds and
+names the id.
+
+Only the structural-render shape runs headlessly here — the tier the `structural`
+matrix cells mark. A law proven by mounting, by server emission, or across a qualified
+host boundary is executed by its own tier.
+
 ## Compiled-view gates
 
 The compiled-view substrate ships the CI gates that [004D-Freehand-Compiled-Grammar.md](004D-Freehand-Compiled-Grammar.md)

--- a/spec/conformance/freehand/donor-inventory.md
+++ b/spec/conformance/freehand/donor-inventory.md
@@ -191,7 +191,7 @@ Every tracked file under `implementation/ui/src/`.
 | `implementation/ui/src/re_frame/ui/semantic.cljc` | semantic normalization — the parity and fingerprint input | MOVE | F1 | pending |
 | `implementation/ui/src/re_frame/ui/sub_overrides.cljs` | the React carriage for story-supplied subscription overrides | MOVE | F2 | pending |
 | `implementation/ui/src/re_frame/ui/substrate.cljs` | the first-party React adapter machinery, frame-context reader, and root-scoped adapter disposal | MOVE | F2 | pending |
-| `implementation/ui/src/re_frame/ui/test.cljc` | the structural and mounted test surface across the JVM and browser hosts | MOVE | F1 | pending |
+| `implementation/ui/src/re_frame/ui/test.cljc` | the structural and mounted test surface across the JVM and browser hosts | MOVE | F1 | done |
 | `implementation/ui/src/re_frame/ui/tool.cljc` | the dev-only read-only projections a debugging consumer reads | MOVE | F4 | pending |
 | `implementation/ui/src/re_frame/ui/tool/evidence.cljc` | the bounded per-cell accumulator over the invalidation-evidence plane | MOVE | F4 | pending |
 | `implementation/ui/src/re_frame/ui/tree.cljc` | builders for the versioned public structural tree in canonical form | MOVE | F1 | pending |


### PR DESCRIPTION
Implements rf2-drpa3.19 (EP-0036 F1e) — the structural render test surface and the host/mode test matrix.

## What lands

- **`re-frame.freehand.test` (`t`)** — the public structural test surface, moved from the donor `re-frame.ui.test` and generalized to Freehand's two execution modes. `render` / `find` / `find-all` / `text` / `attrs` query semantic **values**: a declared view renders to the versioned structural tree headlessly, on both hosts and in both modes, and event intent is an equality check on data (`(:on-click (t/attrs button))`) — no browser, no click simulation. Dev/test scope only.
- **`re-frame.freehand.structural-runner`** — the conformance runner. Executes a structural-render law's fixture (`:cases` / `:rejected`) through the public `t/render`, on whichever lane is running, and flows status back as a report **naming the `FH` id**. A run that asserts nothing (`:ran 0`) is a failure.
- **spec/008** — a new *Freehand structural and mounted testing* section: the surface, the mounted-tier boundary, the **host/mode matrix** (common / interpreted / compiled × jvm / browser / ssr / qualified host), and **how a conformance fixture is executed**. The four `structural` matrix cells (both modes × {jvm, browser}) are exactly what the runner renders headlessly on the two lanes — no cell over-claims. The donor `ui.test` section and its slug are left intact (four in-flight/hot-zone specs link to it).
- **F0c ledger** — the donor `implementation/ui/src/re_frame/ui/test.cljc` structural-surface MOVE recorded as `done`.

## Acceptance

1. **A named fixture is executed and status flows back.** The runner executes `FH-STRUCT-001…005` from the index through `t/render`; a deliberately wrong fixture reds and names its `FH` id (`the-runner-reds-and-names-the-fh-id`).
2. **Non-zero test count** — see transcript below (`Ran 0` would be a failure; both lanes report a non-zero `:ran`).
3. **Matrix matches capability** — `structural` cells are the headless render tier the runner executes; `mounted` / `ssr` / `qualified host` are deferred to their own tiers and not claimed as executed here.

Cross-host: `.cljc`, JVM + node. No `identical?`-on-a-keyword sentinel. `git grep re-frame.ui implementation/freehand/` stays empty.

## Quality gates

All run foreground to completion, post-rebase onto origin/main:

```
cd implementation/freehand && clojure -M:test   Ran 433 tests containing 2837 assertions. 0 failures, 0 errors.
npm run test:freehand                            Ran 316 tests containing 2196 assertions. 0 failures, 0 errors.
npm run test:cljs                                Ran 10426 tests containing 52028 assertions. 0 failures, 0 errors.
python scripts/check_freehand_conformance_index.py   exit 0
python scripts/check_donor_inventory.py              exit 0 (test.cljc row -> done; 29 disposed)
python scripts/check_doc_slugs.py                    exit 0
python -m mkdocs build --strict                      exit 0 (Documentation built)
```
