### PR TITLE
feat(freehand): absorb the keyed presence runtime (rf2-drpa3.33)

### DIFF
--- a/docs/api/re-frame.freehand.md
+++ b/docs/api/re-frame.freehand.md
@@ -277,6 +277,55 @@ compiled tier are declared vacancies that land with their own EP-0036 slices.
   ;; => [:account/email-edited "mike@example.com"]
   ```
 
+## Presence
+
+### `presence`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (presence {:timeout-ms n} & keyed-children)
+  ```
+- **Description**: declarative enter/exit retention over keyed children —
+  deliberately bounded, and not an animation system. Every keyed child passes
+  `:mounting → :present`; when a key leaves the incoming set its child is RETAINED
+  `:unmounting` until the mandatory `:timeout-ms` fires, then removal is terminal
+  and exactly-once. Re-entry before the timeout interrupts the exit and returns the
+  child to `:present`. Children hold first-appearance order; an incoming reorder is
+  ignored. One contract, both modes: a seq form to the compiler, an ordinary
+  function call to the interpreter. DOM-agnostic — the boundary stamps nothing; a
+  presence-aware child owns its own exit styling and accessibility by reading
+  `v/presence-phase`. See
+  [spec/004-Views.md](../../spec/004-Views.md#presence).
+- **Example**:
+  ```clojure
+  (v/presence {:timeout-ms 300}
+    (for [t toasts]
+      [toast-card {:key (:id t) :toast t}]))
+  ```
+
+### `presence-phase`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (presence-phase) → :mounting | :present | :unmounting
+  ```
+- **Description**: the single presence-phase read — the current phase inside a
+  `v/presence` boundary, and `:present` outside one, so a presence-aware child
+  stays reusable anywhere. A render-time read (a React context read on
+  ClojureScript); the JVM structural render always yields `:present`. A child reads
+  it to stamp its exit class and accessibility (`inert` / `aria-hidden`) while
+  `:unmounting`.
+- **Example**:
+  ```clojure
+  (v/defview toast-card [{:keys [toast]}]
+    (let [exiting? (= :unmounting (v/presence-phase))]
+      [:div.toast {:class       (when exiting? "toast--exit")
+                   :aria-hidden (when exiting? true)}
+       (:message toast)]))
+  ```
+
 ## Framework views
 
 ### `route-link`

--- a/implementation/freehand/src/re_frame/freehand.cljc
+++ b/implementation/freehand/src/re_frame/freehand.cljc
@@ -46,6 +46,7 @@
             ;; require it did not need a moment earlier. `node` sits BELOW this
             ;; namespace and takes nothing back from it.
             [re-frame.freehand.node]
+            [re-frame.freehand.presence-runtime :as presence-runtime]
             [re-frame.freehand.route-link-seam :as route-link-seam]
             [re-frame.interop :as interop]
             #?@(:clj [[re-frame.freehand.compiler :as compiler]
@@ -533,6 +534,78 @@
      Per [Spec 004 §Callback roles and identity](../../../../spec/004-Views.md)."
      [params & body]
      (events/expand-callback :render-fn 'v/render-fn params body)))
+
+;; ---------------------------------------------------------------------------
+;; Presence — keyed enter/exit retention
+;; ---------------------------------------------------------------------------
+;;
+;; Spec 004 §Presence. ONE keyed retention contract, honoured identically by
+;; both execution modes. In COMPILED markup `(v/presence …)` is a seq form the
+;; analyzer recognises and lowers; in INTERPRETED markup it is this ordinary
+;; function call, which returns a reserved-head hiccup vector the interpreted
+;; walks intercept and lower to the SAME retention runtime. The runtime itself
+;; ([[re-frame.freehand.presence-runtime]]) is shared, so retention, the
+;; terminal timeout bound, re-entry and the phase read are the same behaviour
+;; whichever mode wrote the boundary.
+
+(defn presence
+  "(v/presence {:timeout-ms n} keyed-children) — declarative enter/exit
+  retention, deliberately bounded (NOT an animation system). Keyed children
+  pass :mounting → :present → :unmounting; an exiting child is RETAINED for
+  exactly the MANDATORY :timeout-ms — the exit retention duration AND terminal
+  bound — then removal is terminal and exactly-once (all ownership released).
+  Removal-then-reinsertion of a key interrupts the exit and re-enters at
+  :present. Children hold first-appearance order; an incoming reorder is
+  ignored (presence is enter/exit, not reordering).
+
+  DOM-agnostic: the boundary inserts no wrapper node, stamps no attributes, and
+  observes no DOM events. A presence-aware child owns its own exit styling and
+  accessibility — stamp `inert` / `aria-hidden` and the exit class against
+  (v/presence-phase) = :unmounting; the child's stylesheet owns
+  prefers-reduced-motion.
+
+  Called directly in an INTERPRETED body and recognised as a seq form by the
+  COMPILED analyzer — one spelling, one contract, both modes.
+
+  Per [Spec 004 §Presence](../../../../spec/004-Views.md#presence)."
+  [opts & children]
+  (when-not (map? opts)
+    (error/throw-error!
+      :rf.error/ui-tree-malformed 'v/presence
+      (str "(v/presence {:timeout-ms n} children) needs a literal options map with a "
+           "mandatory :timeout-ms (the terminal safety bound); the options map is missing.")
+      {:recovery :no-recovery :extra {:opts (error/diag-value-summary opts)}}))
+  (let [t     (:timeout-ms opts)
+        extra (seq (disj (set (keys opts)) :timeout-ms))]
+    (when-not (and (number? t) (pos? t))
+      (error/throw-error!
+        :rf.error/ui-tree-malformed 'v/presence
+        (str ":timeout-ms is MANDATORY on (v/presence …) and is a positive number of "
+             "milliseconds — the terminal safety bound AND the exit retention duration; "
+             "got " (pr-str t) ".")
+        {:recovery :no-recovery :extra {:timeout-ms (error/diag-value-summary t)}}))
+    (when extra
+      (error/throw-error!
+        :rf.error/ui-tree-malformed 'v/presence
+        (str "the only (v/presence …) option is :timeout-ms; got also "
+             (pr-str (vec extra)) ".")
+        {:recovery :no-recovery :extra {:unknown-options (vec extra)}})))
+  (when (empty? children)
+    (error/throw-error!
+      :rf.error/ui-tree-malformed 'v/presence
+      "(v/presence {:timeout-ms n} children) needs at least one keyed child."
+      {:recovery :no-recovery :extra {}}))
+  (into [descriptor/presence-tag opts] children))
+
+(def ^{:doc "(v/presence-phase) — the single presence-phase read: :mounting /
+  :present / :unmounting inside a (v/presence …) boundary, :present outside one
+  (so presence-aware children stay reusable anywhere). A render-time read (a
+  React context read on ClojureScript); the JVM structural render always yields
+  :present.
+
+  Per [Spec 004 §Presence](../../../../spec/004-Views.md#presence)."
+       :arglists '([])}
+  presence-phase presence-runtime/presence-phase)
 
 ;; ---------------------------------------------------------------------------
 ;; `route-link` — a framework view, declared the ordinary way

--- a/implementation/freehand/src/re_frame/freehand/compiler/grammar.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/grammar.cljc
@@ -39,7 +39,8 @@
   [[check!]] before an emitter ever sees it — the emitters therefore have
   no unknown-node arm, which is what makes escaping structural rather
   than defensive."
-  #{:text :nothing :expr :element :fragment :view :for :if :let :letfn :case})
+  #{:text :nothing :expr :element :fragment :view :for :if :let :letfn :case
+    :presence})
 
 (def ^:private op-rejections
   "Analyzed node kinds outside v1, each with the sentence that names what
@@ -53,8 +54,6 @@
    :html           {:what "the trusted-HTML escaping bypass"
                     :recovery [:keep-interpreted]}
    :slot           {:what "a render-slot invocation"
-                    :recovery [:extract-declared-child :keep-interpreted]}
-   :presence       {:what "a presence boundary"
                     :recovery [:extract-declared-child :keep-interpreted]}
    :client-only    {:what "a browser-only subtree"
                     :recovery [:extract-declared-child :keep-interpreted]}

--- a/implementation/freehand/src/re_frame/freehand/descriptor.cljc
+++ b/implementation/freehand/src/re_frame/freehand/descriptor.cljc
@@ -254,6 +254,24 @@
   (:manifest (.-entry ^ViewDescriptor view)))
 
 ;; ---------------------------------------------------------------------------
+;; Reserved interpreted intrinsic heads
+;; ---------------------------------------------------------------------------
+;;
+;; A compiled `(v/presence …)` is a SEQ form the analyzer recognises at
+;; compile time. An INTERPRETED `(v/presence …)` is an ordinary function call
+;; that runs during the body's evaluation; it returns a plain hiccup vector
+;; whose head is this reserved keyword, which each interpreted walk intercepts
+;; BEFORE `classify-head` — exactly as the fragment head `:<>` is intercepted.
+;; The two mechanisms never meet: compile sees the seq, the walk sees the
+;; vector, and the runtime they lower to is one and the same.
+
+(def presence-tag
+  "The reserved head of the vector `v/presence` returns in interpreted mode.
+  Namespaced, so it can never collide with an author's element keyword, and
+  intercepted by both interpreted walks before head classification."
+  :re-frame.freehand/presence)
+
+;; ---------------------------------------------------------------------------
 ;; Vector-head classification — total
 ;; ---------------------------------------------------------------------------
 ;;

--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -357,14 +357,21 @@
   (if (fn? x) {:rf.ui/opaque :fn} x))
 
 (defn- plain-fragment?
-  "Is `x` a fragment node carrying nothing but its children?"
+  "Is `x` a fragment node carrying nothing but its children?
+
+  A `:rf.ui/presence` node is a fragment-shaped map (children, no tag), but its
+  marker is a LOAD-BEARING child node that must survive as its own node — a
+  presence-rooted view is a boundary wrapping a presence node, not a boundary
+  that adopted the presence children. So a marker-bearing fragment is never
+  plain, and is never adopted."
   [x]
   (and (map? x)
        (contains? x :children)
        (not (contains? x :tag))
        (not (contains? x :view-id))
        (not (contains? x :html))
-       (not (contains? x :key))))
+       (not (contains? x :key))
+       (not (contains? x :rf.ui/presence))))
 
 (defn boundary
   "Assemble one internal-view expansion into a boundary node. The boundary

--- a/implementation/freehand/src/re_frame/freehand/presence_runtime.cljc
+++ b/implementation/freehand/src/re_frame/freehand/presence_runtime.cljc
@@ -1,0 +1,461 @@
+(ns re-frame.freehand.presence-runtime
+  "Presence — declarative enter/exit retention (Spec 004 §Presence, F4).
+
+  The ONE keyed retention machine, shared by both execution modes. The
+  interpreted front ends ([[re-frame.freehand.react]] in the browser,
+  [[re-frame.freehand.tree]] on the JVM structural host) and the compiled
+  emitters both lower a `(v/presence …)` to this runtime, so retention,
+  the terminal timeout bound, re-entry, and the phase read are the SAME
+  code in interpreted and compiled markup — parity by construction, not by
+  agreement.
+
+  DELIBERATELY BOUNDED: not an animation system. The three-phase keyed
+  retention machine plus the `:timeout-ms` terminal safety bound, and
+  nothing more (no easing, no curves, no presence-event bus). The boundary
+  is DOM-AGNOSTIC: it inserts no wrapper node, stamps no attributes, and
+  observes no DOM events. A presence-aware child owns its own exit styling
+  and accessibility by reading `(presence-phase)` = `:unmounting`
+  (rf2-0ufty).
+
+  A `(v/presence {:timeout-ms n} keyed-children)` boundary tracks its
+  children BY KEY across renders. A key passes `:mounting → :present`; when
+  a key leaves the incoming set the child is RETAINED in `:unmounting` (its
+  exit transition runs against that phase) until the `:timeout-ms` safety
+  bound fires, then the removal is terminal and EXACTLY-ONCE (React unmounts
+  the retained subtree, so every subscription / effect it owns is released).
+  Removal-then-reinsertion of a key interrupts the exit and re-enters at
+  `:present`.
+
+  `(presence-phase)` is the single phase read — `react/useContext` on CLJS,
+  `:present` on the JVM structural subset. Outside a boundary it returns
+  `:present`, so presence-aware children stay reusable anywhere.
+
+  The runtime split:
+
+    reconcile          PURE next-entry derivation (both hosts, unit-testable)
+    claim-identities   PURE one-pair-per-key claim over the flattened children
+                       (a key IS a retained identity; two children cannot own one)
+    the presence clock a fake-advanceable exit scheduler; [[flush-presence!]]
+                       drives it deterministically without wall-clock sleeps,
+                       production arms `js/setTimeout`
+    presence-boundary  the React function component that wires the two together
+
+  The JVM structural node lives in [[re-frame.freehand.tree/presence]] (a
+  fragment carrying the `:rf.ui/presence {:phase :present :timeout-ms n}`
+  diagnostic marker, §004B); this namespace's JVM arm is `presence-phase`
+  only.
+
+  Normative owner:
+  [`spec/004-Views.md`](../../../../../spec/004-Views.md) §Presence."
+  #?(:cljs (:require ["react" :as react])))
+
+;; ---------------------------------------------------------------------------
+;; reconcile — the PURE three-phase entry derivation (both hosts)
+;; ---------------------------------------------------------------------------
+
+(defn reconcile
+  "Derive the next ordered entry vector from the COMMITTED entries and the
+  incoming key vector. Pure and idempotent — the same inputs always give the
+  same output, so a StrictMode double-render is harmless.
+
+    committed    ordered [{:key k :phase :mounting|:present|:unmounting} …]
+    incoming     ordered [k …] (the keys present in this render)
+
+  Rules, in committed order then appended new keys:
+    - a committed key still incoming keeps its phase, EXCEPT `:unmounting`
+      flips back to `:present` (removal-then-reinsertion re-entry);
+    - a committed key no longer incoming becomes `:unmounting` (retained —
+      it is dropped from the set only by its removal callback, never here);
+    - a brand-new incoming key is appended as `:mounting`.
+
+  EVERY committed key — still-`:present` and retained (`:unmounting`) alike —
+  holds its committed slot; the incoming ORDER orders only the appended new keys,
+  so children render in first-appearance order and an incoming reorder is ignored
+  (the blessed order contract, rf2-1kb0v — presence is enter/exit, not reordering)."
+  [committed incoming]
+  (let [incoming-set (set incoming)
+        committed-keys (into #{} (map :key) committed)
+        kept (mapv (fn [{:keys [key phase] :as e}]
+                     (cond
+                       (and (incoming-set key) (= :unmounting phase))
+                       (assoc e :phase :present)          ; re-entry
+                       (incoming-set key) e               ; still here
+                       :else (assoc e :phase :unmounting))) ; retained for exit
+                   committed)
+        added (into [] (comp (remove committed-keys)
+                             (map (fn [k] {:key k :phase :mounting})))
+                    incoming)]
+    (into kept added)))
+
+(defn claim-identities
+  "Reduce the ordered flattened `[key element]` pairs to ONE pair per OWNERSHIP
+  IDENTITY — the invariant `reconcile`, the element map and the exit timers all
+  assume but none of them can enforce.
+
+  A boundary tracks its children by key, so a key IS a retained identity. Two
+  children under one key alias: `reconcile` derives two entries sharing a slot,
+  the element and timer maps (plain maps keyed by key) collapse to one, render
+  emits duplicate Provider keys, and the single exit timer removes every entry
+  sharing that identity. The FIRST claimant in document order owns the key;
+  later collisions are dropped and returned for diagnosis (rf2-vxgfnd.96.2).
+
+  React has already string-coerced `.-key`, so plain equality here IS the
+  collision domain the ownership maps use — key `1` and key `\"1\"` alias, and
+  this catches them together. Deliberately boundary-LOCAL: it sees the children
+  of one boundary, already flattened, and keeps no registry.
+
+  -> `[distinct-pairs duplicate-keys]`, both in document order."
+  [pairs]
+  (let [[pairs* dups _]
+        (reduce (fn [[acc dups seen] [k :as pair]]
+                  (if (contains? seen k)
+                    [acc (conj dups k) seen]
+                    [(conj acc pair) dups (conj seen k)]))
+                [[] [] #{}]
+                pairs)]
+    [pairs* dups]))
+
+;; ---------------------------------------------------------------------------
+;; The presence clock — a fake-advanceable exit scheduler
+;;
+;; ONE registry of pending exits owns every retention timer. Production arms a
+;; real `js/setTimeout` per exit; tests advance the logical clock through
+;; [[flush-presence!]] (→ `advance-clock!`), firing due timers with no
+;; wall-clock sleep. `fire-timer!` is id-keyed and idempotent, so a real
+;; setTimeout that lands after a test already flushed its timer is a no-op —
+;; the terminal removal runs EXACTLY ONCE regardless of which path wins.
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (do
+
+(defonce ^:private clock
+  ;; :now      logical milliseconds
+  ;; :next-id  monotonic timer id
+  ;; :pending  {id {:fire-at ms :remove! fn :handle js-timeout-handle}}
+  (atom {:now 0 :next-id 0 :pending {}}))
+
+(defonce ^:private wall-clock?
+  ;; Production arms a real js/setTimeout; a deterministic test disables it so
+  ;; the logical clock (advance-clock!) is the SOLE removal driver.
+  (atom true))
+
+(defn set-wall-clock!
+  "Enable/disable the real-`setTimeout` removal arm. Tests that drive removal
+  purely through [[flush-presence!]] disable it for determinism; production
+  leaves it on. Returns the new value."
+  [on?]
+  (reset! wall-clock? (boolean on?)))
+
+(defn pending-count
+  "How many exits are currently retained (awaiting removal)?"
+  []
+  (count (:pending @clock)))
+
+(defn fire-timer!
+  "Fire the pending timer `id` EXACTLY ONCE: atomically claim + remove it, then
+  run its `:remove!`. A second call (real setTimeout after a test flush, a
+  double advance) finds nothing and is a no-op — the exactly-once guard."
+  [id]
+  (let [entry (get-in @clock [:pending id])]
+    (when entry
+      (let [claimed (volatile! nil)]
+        (swap! clock update :pending
+               (fn [p] (when-let [e (get p id)]
+                         (vreset! claimed e))
+                       (dissoc p id)))
+        (when-let [{:keys [remove! handle]} @claimed]
+          (when handle (js/clearTimeout handle))
+          (remove!))))))
+
+(defn cancel-timer!
+  "Cancel pending timer `id` WITHOUT firing its removal (re-entry / unmount)."
+  [id]
+  (let [entry (get-in @clock [:pending id])]
+    (when-let [handle (:handle entry)] (js/clearTimeout handle))
+    (swap! clock update :pending dissoc id)
+    nil))
+
+(defn schedule-exit!
+  "Register an exit removal to fire after `timeout-ms` of clock time. Returns
+  the timer id (pass to `cancel-timer!` on re-entry / unmount). Production also
+  arms a real `js/setTimeout`; both routes funnel through the id-keyed
+  `fire-timer!`, so the removal is exactly-once."
+  [timeout-ms remove!]
+  (let [id (:next-id @clock)
+        fire-at (+ (:now @clock) timeout-ms)
+        handle (when @wall-clock?
+                 (js/setTimeout #(fire-timer! id) timeout-ms))]
+    (swap! clock (fn [c]
+                   (-> c
+                       (assoc :next-id (inc (:next-id c)))
+                       (assoc-in [:pending id]
+                                 {:fire-at fire-at :remove! remove! :handle handle}))))
+    id))
+
+(defn- due-ids
+  "Pending ids whose fire-at ≤ `t`, in fire-at then id order (deterministic)."
+  [t]
+  (->> (:pending @clock)
+       (filter (fn [[_ {:keys [fire-at]}]] (<= fire-at t)))
+       (sort-by (fn [[id {:keys [fire-at]}]] [fire-at id]))
+       (mapv first)))
+
+(defn advance-clock!
+  "Advance the logical clock by `ms` (or, with no arg, to quiescence — past the
+  last pending fire-at) and fire every timer that comes due, in deterministic
+  order. The deterministic, wall-clock-free driver behind [[flush-presence!]].
+  Returns the number of exits removed."
+  ([]
+   (let [pend (:pending @clock)]
+     (if (empty? pend)
+       0
+       (let [maxf (apply max (map :fire-at (vals pend)))]
+         (advance-clock! (- (inc maxf) (:now @clock)))))))
+  ([ms]
+   (let [target (+ (:now @clock) ms)]
+     (swap! clock assoc :now target)
+     (let [ids (due-ids target)]
+       (doseq [id ids] (fire-timer! id))
+       (count ids)))))
+
+(defn reset-clock!
+  "Drop every pending exit and reset logical time — a test-isolation hook."
+  []
+  (doseq [[_ {:keys [handle]}] (:pending @clock)]
+    (when handle (js/clearTimeout handle)))
+  (reset! clock {:now 0 :next-id 0 :pending {}})
+  nil)
+
+(defn flush-presence!
+  "Deterministically fire retained exits WITHOUT a wall-clock sleep — the test
+  driver Spec 004 §Presence names. It disables the real-`setTimeout` arm so the
+  logical clock is the sole removal driver, then advances that clock: with no
+  argument, to quiescence (every pending exit fires); with `ms`, by that many
+  logical milliseconds (partial advance). Returns the number of exits removed.
+
+  A test drives presence transitions through this and never `js/setTimeout`, so
+  a retention window closes exactly when the test says and a run carries no
+  wall-clock flake."
+  ([]   (set-wall-clock! false) (advance-clock!))
+  ([ms] (set-wall-clock! false) (advance-clock! ms)))
+
+;; ---------------------------------------------------------------------------
+;; presence-context + the boundary component
+;; ---------------------------------------------------------------------------
+
+(defonce ^js presence-context
+  ;; Default `:present` — a presence-aware child rendered OUTSIDE any boundary
+  ;; reads `:present`, so it stays reusable anywhere.
+  (react/createContext :present))
+
+(defn- react-element? [x]
+  (and (some? x) (react/isValidElement x)))
+
+(defn- collect-elements
+  "Flatten the incoming children (a compiled `for` emits nested JS arrays) into
+  an ordered [key element] vector. Keys come from React's own `.-key` (already
+  string-coerced), the identity `reconcile` tracks. The front end guarantees
+  every presence child is keyed, so an element without a key is defensive-only.
+  Flattening can still surface the SAME key twice (explicit siblings, two `for`
+  arrays, colliding dynamic keys) — `claim-identities` reduces the result to one
+  pair per identity before the retention machine ever sees it."
+  [acc x]
+  (cond
+    (nil? x)              acc
+    (js/Array.isArray x)  (reduce collect-elements acc x)
+    (react-element? x)    (if-some [k (.-key x)] (conj acc [k x]) acc)
+    :else                 acc))
+
+(defn- count-keyless
+  "Count the flattened children whose runtime `.-key` is nil — the elements
+  `collect-elements` DROPS (a keyless child cannot be retention-tracked, so it
+  never renders). The compiled tier guarantees a `:key` FORM on every presence
+  child, but the form's runtime VALUE can be `undefined` (e.g. a JS-interop read
+  of an absent property), which React's jsx-runtime leaves as a nil `.-key` —
+  compile cannot catch it. NOTE a CLJS-nil key value is a different case: jsx
+  coerces it to the string \"null\" (a valid key), so `{:key (:id x)}` with a
+  missing `:id` RENDERS rather than dropping. This parallel dev-only walk lets
+  the render path warn about the otherwise-silent drop; the drop itself stays in
+  `collect-elements`, unconditional in production."
+  [n x]
+  (cond
+    (nil? x)              n
+    (js/Array.isArray x)  (reduce count-keyless n x)
+    (react-element? x)    (if (nil? (.-key x)) (inc n) n)
+    :else                 n))
+
+(defn- warn-duplicate-identities!
+  "Dev diagnostic for a key claimed twice at ONE presence boundary. Reuses the
+  catalogued `:rf.error/ui-duplicate-key` — same failure, same string-coercion
+  collision domain as a keyed list site, one boundary further out. Stripped in
+  production by `goog.DEBUG`; the drop itself is unconditional, so a production
+  build still never diverges ownership."
+  [dup-keys]
+  (when ^boolean js/goog.DEBUG
+    (doseq [k dup-keys]
+      (js/console.warn
+       "[:rf.error/ui-duplicate-key] duplicate key at a (v/presence …) boundary:"
+       (pr-str k)
+       (str "— presence tracks children BY KEY, so two children under one key "
+            "would share one retained identity and one exit timer. The later "
+            "child is DROPPED. Give each presence child a distinct key (keys "
+            "compare after React's string coercion: 1 collides with \"1\")."))))
+  nil)
+
+(defn- warn-keyless-drops!
+  "Dev diagnostic for a presence child whose runtime `:key` evaluated to nil.
+  Mirrors `warn-duplicate-identities!`: advisory dev output stripped in
+  production by `goog.DEBUG`, while the drop itself (in `collect-elements`) is
+  unconditional, so a production build never diverges. No catalogued
+  `:rf.error/*` id — a nil runtime key is not a new failure mode (compile still
+  guarantees the `:key` form), and `:rf.error/ui-duplicate-key` does not honestly
+  fit; this is a plain advisory. One warning per dropped element."
+  [n]
+  (when ^boolean js/goog.DEBUG
+    (dotimes [_ n]
+      (js/console.warn
+       (str "presence: a keyless child under a (v/presence …) boundary was "
+            "DROPPED — its :key evaluated to `undefined` (a nil React key), so "
+            "it never renders. Presence tracks children BY KEY; give the child a "
+            "defined key. (A CLJS-nil key value becomes the string \"null\" and "
+            "renders — a nil React key comes from an `undefined` value.)"))))
+  nil)
+
+(defn- incoming-identities
+  "The flattened children of this boundary as ordered, ownership-unique
+  `[key element]` pairs — the only shape the retention machine may see."
+  [incoming]
+  (let [[pairs dups] (claim-identities (collect-elements [] incoming))]
+    (warn-duplicate-identities! dups)
+    ;; `count-keyless` is a SECOND full walk of the child tree, run purely to
+    ;; feed the dev advisory. Gate the traversal AND its warning together behind
+    ;; the compile-time `goog.DEBUG` branch so `:advanced` + `goog.DEBUG=false`
+    ;; DCEs the whole walk — an eager argument would otherwise still execute in
+    ;; production and discard its result (rf2-vz6a1). `dups` above needs no such
+    ;; gate: it is already computed by `claim-identities`, so its warning is free.
+    (when ^boolean js/goog.DEBUG
+      (warn-keyless-drops! (count-keyless 0 incoming)))
+    pairs))
+
+(defn- render-entries
+  "Render each entry as its element wrapped in a phase-carrying context Provider
+  (so `(presence-phase)` in the child reads its phase). The Provider is keyed by
+  the entry key; the wrapped element keeps its own key too."
+  [entries elements]
+  (into-array
+   (keep (fn [{:keys [key phase]}]
+           (when-some [el (get elements key)]
+             (react/createElement (.-Provider presence-context)
+                                  #js {:value phase :key key}
+                                  el)))
+         entries)))
+
+(defn- entries-signature [entries]
+  ;; phase-sensitive identity so the commit effect only re-renders on a real
+  ;; change (avoids an infinite setState loop).
+  (mapv (juxt :key :phase) entries))
+
+(defn ^:private PresenceComponent [^js props]
+  (let [timeout-ms (.-timeoutMs props)
+        incoming   (.-incoming props)
+        ;; forceUpdate cell — the setter identity is stable across renders.
+        tick       (react/useState 0)
+        force!     (fn [] ((aget tick 1) inc))
+        ;; committed state (source of truth) — mutated ONLY in the effect /
+        ;; removal callbacks, never during render, so `reconcile` reads a stable
+        ;; snapshot and a StrictMode double-render is idempotent.
+        st         (react/useRef nil)
+        incoming-pairs (incoming-identities incoming)
+        incoming-keys  (mapv first incoming-pairs)]
+    (when (nil? (.-current st))
+      ;; FIRST render seed — the ordinary client mount: no entries, so
+      ;; `reconcile` classifies the incoming keys `:mounting` and the enter
+      ;; transition runs. Server-adopted hydration (seeding `:present` to match
+      ;; the server's `:present` markup instead of fabricating an enter
+      ;; transition) is the SSR slice's to wire, once Freehand carries the
+      ;; root-scoped phase fact `client-only` will install; F4 presence has no
+      ;; hydration signal to consult, so it always seeds the client-mount path.
+      (set! (.-current st) #js {:entries [] :elements {} :timers {}}))
+    (let [state    (.-current st)
+          ;; keep the latest element for every incoming key; retained keys keep
+          ;; their last-seen element.
+          elements (merge (.-elements state) (into {} incoming-pairs))
+          desired  (reconcile (.-entries state) incoming-keys)]
+      (set! (.-elements state) elements)
+      ;; Commit + phase transitions run AFTER paint (a side-effect, never during
+      ;; render). Runs every commit; idempotent via signature guards.
+      (react/useEffect
+       (fn []
+         (let [state   (.-current st)
+               ;; re-derived from the same props the render saw; the uniqueness
+               ;; claim is pure, so both paths agree on the ordered key set
+               ;; (the dev warning already fired during render).
+               desired (reconcile (.-entries state)
+                                  (mapv first (first (claim-identities
+                                                      (collect-elements [] incoming)))))
+               timers  (.-timers state)
+               ;; 1. schedule a removal timer for each newly-:unmounting key
+               ;; 2. cancel the timer for each re-entered key
+               timers* (reduce
+                        (fn [tm {:keys [key phase]}]
+                          (cond
+                            (and (= :unmounting phase) (not (contains? tm key)))
+                            (assoc tm key
+                                   (schedule-exit!
+                                    timeout-ms
+                                    (fn remove-key! []
+                                      (let [s (.-current st)]
+                                        (set! (.-entries s)
+                                              (filterv #(not= key (:key %)) (.-entries s)))
+                                        (set! (.-elements s) (dissoc (.-elements s) key))
+                                        (set! (.-timers s) (dissoc (.-timers s) key)))
+                                      (force!))))
+                            (and (not= :unmounting phase) (contains? tm key))
+                            (do (cancel-timer! (get tm key)) (dissoc tm key))
+                            :else tm))
+                        timers
+                        desired)
+               ;; 3. flip every :mounting entry to :present (enter transition)
+               next    (mapv (fn [e] (if (= :mounting (:phase e))
+                                       (assoc e :phase :present) e))
+                             desired)]
+           (set! (.-timers state) timers*)
+           (when (not= (entries-signature next) (entries-signature (.-entries state)))
+             (set! (.-entries state) next)
+             (force!)))
+         js/undefined))
+      ;; teardown: cancel every pending timer (React unmounts the retained
+      ;; subtrees itself — the terminal ownership release).
+      (react/useEffect
+       (fn [] (fn []
+                (let [state (.-current st)]
+                  (doseq [[_ id] (.-timers state)] (cancel-timer! id))
+                  (set! (.-timers state) {}))))
+       #js [])
+      (render-entries desired elements))))
+
+(defn presence-boundary
+  "Build a `(v/presence {:timeout-ms n} children)` element (the lowering target
+  both modes emit). `timeout-ms` is the terminal safety bound; `children` is the
+  keyed children as a JS array (possibly nesting the arrays a `for` emits) — the
+  compiled emitter hands `(cljs.core/array …)` and the interpreted React walk
+  hands the walked child elements as an array."
+  [timeout-ms children]
+  (react/createElement PresenceComponent
+                       #js {:timeoutMs timeout-ms :incoming children}))
+
+   ))
+
+;; ---------------------------------------------------------------------------
+;; presence-phase — the single phase read (both hosts)
+;; ---------------------------------------------------------------------------
+
+(defn presence-phase
+  "Read the current presence phase — `:mounting` / `:present` / `:unmounting`
+  inside a `(v/presence …)` boundary, `:present` outside one. A render-time
+  read (CLJS `react/useContext`); on the JVM structural subset it is always
+  `:present`."
+  []
+  #?(:cljs (react/useContext presence-context)
+     :clj  :present))

--- a/implementation/freehand/src/re_frame/freehand/react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/react.cljs
@@ -57,6 +57,7 @@
             [re-frame.freehand.conversion :as conv]
             [re-frame.freehand.descriptor :as descriptor]
             [re-frame.freehand.events :as events]
+            [re-frame.freehand.presence-runtime :as presence-runtime]
             [re-frame.freehand.shell :as shell]
             [re-frame.freehand.tree :as tree]))
 
@@ -273,11 +274,29 @@
       (gobj/set js-props "key" key))
     (react/createElement (component-for view) js-props)))
 
+(defn- presence-node
+  "A `(v/presence …)` boundary in interpreted markup — `[presence-tag opts &
+  kids]`. Its keyed children are walked into React elements HERE and handed as
+  one array to the shared retention runtime, the SAME lowering target the
+  compiled React emitter emits, so the retention behaviour is one implementation
+  across modes. The children carry their own React `.-key`, which is the
+  identity the runtime tracks."
+  [cand form]
+  (let [opts (second form)
+        kids (children cand (drop 2 form))]
+    (presence-runtime/presence-boundary (:timeout-ms opts) (into-array kids))))
+
 (defn- node
   [cand form]
   (let [head (first form)]
-    (if (= tree/fragment-tag head)
+    (cond
+      (= tree/fragment-tag head)
       (fragment-node cand (rest form))
+
+      (= descriptor/presence-tag head)
+      (presence-node cand form)
+
+      :else
       (case (descriptor/classify-head head)
         :element (element-node cand head (rest form))
         ;; A nested boundary is a React ELEMENT this walk does not enter:

--- a/implementation/freehand/src/re_frame/freehand/tree.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tree.cljc
@@ -151,6 +151,28 @@
               :children (when (seq kid-forms) #(children kid-forms))}))))
 
 ;; ---------------------------------------------------------------------------
+;; Presence — the keyed enter/exit structural node
+;; ---------------------------------------------------------------------------
+
+(defn presence
+  "The JVM/SSR structural node for `(v/presence {:timeout-ms n} …)`: a fragment
+  carrying the `:rf.ui/presence {:phase :present :timeout-ms n}` diagnostic
+  marker (§004B — presence metadata exposed structurally; a droppable reserved
+  key, stripped by semantic normalization). The JVM structural host has no
+  lifecycle, so every retained child renders `:present`.
+
+  This is the ONE lowering target the compiled JVM emitter and the interpreted
+  structural walk both build, so the structural projection of a presence
+  boundary is identical across modes. `xs` are already-evaluated child VALUES —
+  the compiled emitter's emitted child nodes, or the interpreted walk's walked
+  child nodes — canonicalised here through [[re-frame.freehand.node/children]].
+  `:children` is retained even when empty, like a fragment: it is the node's
+  discriminator."
+  [timeout-ms & xs]
+  {:rf.ui/presence {:phase :present :timeout-ms timeout-ms}
+   :children (vec (apply node/children xs))})
+
+;; ---------------------------------------------------------------------------
 ;; The walk
 ;; ---------------------------------------------------------------------------
 
@@ -158,11 +180,21 @@
   "One markup vector -> one node."
   [form]
   (let [head (first form)]
-    (if (= fragment-tag head)
+    (cond
+      (= fragment-tag head)
       (let [args   (rest form)
             attrs? (map? (first args))
             k      (when attrs? (:key (first args)))]
         (node/fragment (some? k) k (children (if attrs? (rest args) args))))
+
+      ;; A presence boundary: `v/presence` returns `[presence-tag opts & kids]`
+      ;; in interpreted markup. Its children are lowered HERE — walked into
+      ;; structural nodes — and handed to the shared [[presence]] builder, so an
+      ;; interpreted `(v/presence …)` and a compiled one produce the SAME node.
+      (= descriptor/presence-tag head)
+      (apply presence (:timeout-ms (second form)) (children (drop 2 form)))
+
+      :else
       (case (descriptor/classify-head head)
         :element (element-node head (rest form))
         ;; Trailing children are the CALLER's markup and are lowered HERE,

--- a/implementation/freehand/test/re_frame/freehand/compiled_grammar_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/compiled_grammar_jvm_test.clj
@@ -153,7 +153,8 @@
             grow under a running codebase, so the roster is asserted
             rather than left implicit."
     (is (= :re-frame.freehand/v1 grammar/version))
-    (is (= #{:text :nothing :expr :element :fragment :view :for :if :let :letfn :case}
+    (is (= #{:text :nothing :expr :element :fragment :view :for :if :let :letfn :case
+             :presence}
            grammar/admitted-ops)
         "the admitted node kinds are exactly the v1 roster")
     (is (contains? grammar/recoveries :keep-interpreted)

--- a/implementation/freehand/test/re_frame/freehand/presence_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/presence_dom_cljs_test.cljs
@@ -1,0 +1,212 @@
+(ns re-frame.freehand.presence-dom-cljs-test
+  "FH-PRESENCE-003 — presence retention, timeout and accessibility in a real
+  browser.
+
+  The structural row (FH-PRESENCE-001) proves what the tree SAYS; the pure
+  row (FH-PRESENCE-002) proves the transition algebra. This one proves what
+  REACT DOES with a retained subtree, which is a different claim: a
+  reconcile that is perfectly shaped can still leave a departed child in the
+  DOM forever, unmount it twice, or never let it read `:unmounting` — and no
+  headless assertion would notice, because the assertion and the bug would
+  share an author.
+
+  So: a real `react-dom/client` mount, a real `useContext` presence-phase
+  read inside the child, and every claim read back off `document`. Retention
+  is driven by the deterministic `flush-presence!` clock — the real
+  `setTimeout` arm is disabled — so a retention window closes exactly when
+  the test says and the run carries no wall-clock flake.
+
+  This file rides the browser lane through its `-dom-cljs-test` suffix. It
+  also matches the node suites' broader regex, where it has no DOM to mount
+  and says so rather than passing quietly."
+  (:require ["react" :as react]
+            ["react-dom/client" :as rdc]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.presence-runtime :as presence]
+            [re-frame.freehand.react :as fr]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(def fx (conf/fixture :FH-PRESENCE-003))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       plain-atom/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- act
+  "A React 19 `act` boundary as a promise, so assertions run after the
+  commit and its flushed effects rather than racing them."
+  [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+;; ---------------------------------------------------------------------------
+;; Views. Module-level — a declared view cannot close over a test's locals.
+;;
+;; `toast` is the presence-aware CHILD: it reads its own phase and, while
+;; `:unmounting`, stamps `aria-hidden` and an exit class. That is the whole
+;; DOM-agnostic contract — the boundary stamps nothing; the child owns its
+;; exit accessibility against `(v/presence-phase)`.
+;; ---------------------------------------------------------------------------
+
+(v/defview toast
+  [{:keys [label]}]
+  (let [phase    (v/presence-phase)
+        exiting? (= :unmounting phase)]
+    [:div.toast {:data-label  (str label)
+                 :data-phase  (name phase)
+                 :class       (when exiting? (:exit-class fx))
+                 :aria-hidden (when exiting? true)
+                 :inert       (when exiting? true)}
+     (str label)]))
+
+(v/defview toaster
+  [{:keys [ids timeout-ms]}]
+  [:div#stack
+   (v/presence {:timeout-ms timeout-ms}
+     (for [k ids]
+       [toast {:key k :label k}]))])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- mount! []
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    [container (rdc/createRoot container)]))
+
+(defn- teardown! [container root]
+  (.unmount root)
+  (.remove container)
+  nil)
+
+(defn- toast-el [container label]
+  (.querySelector container (str ".toast[data-label='" label "']")))
+
+(defn- phase-of [container label]
+  (some-> (toast-el container label) (.getAttribute "data-phase")))
+
+(defn- present? [container label] (some? (toast-el container label)))
+
+(defn- render-ids [root ids]
+  (act #(.render root (fr/element [toaster {:ids ids :timeout-ms (:timeout-ms fx)}]))))
+
+(defn- skip! [why]
+  (is true (str "a real React mount needs a DOM host — " why)))
+
+;; ===========================================================================
+;; FH-PRESENCE-003 — retention, exit accessibility, terminal timeout
+;; ===========================================================================
+
+(deftest fh-presence-003-a-departed-key-is-retained-then-flushed
+  (testing "Per FH-PRESENCE-003 (browser): removing a key RETAINS its child
+            in the DOM `:unmounting`, the child hides itself from assistive
+            technology by reading its own phase, and the deterministic
+            timeout finally removes it — exactly once."
+    (if-not (browser?)
+      (skip! "the browser job runs the retention assertions")
+      (async done
+        (presence/reset-clock!)
+        (presence/set-wall-clock! false)
+        (let [[container root] (mount!)]
+          (-> (render-ids root ["a" "b"])
+              (.then (fn [_]
+                       (is (present? container "a") "a mounted")
+                       (is (present? container "b") "b mounted")
+                       (is (= "present" (phase-of container "a")) "a settled :present")
+                       (is (= "present" (phase-of container "b")) "b settled :present")
+                       (is (nil? (.getAttribute (toast-el container "b") "aria-hidden"))
+                           "a present child is NOT hidden from assistive tech")
+                       (is (= 0 (presence/pending-count)) "no exits pending yet")
+                       ;; remove b — it must be retained, not gone
+                       (render-ids root ["a"])))
+              (.then (fn [_]
+                       (is (present? container "a") "a stays")
+                       (is (present? container "b")
+                           "b is RETAINED in the DOM while exiting, not removed")
+                       (is (= "present" (phase-of container "a")) "a is still :present")
+                       (is (= "unmounting" (phase-of container "b"))
+                           "b's own (v/presence-phase) read reaches :unmounting")
+                       (is (= (get (:exit-aria fx) "aria-hidden")
+                              (.getAttribute (toast-el container "b") "aria-hidden"))
+                           "the exiting child hid itself from assistive technology")
+                       (is (some? (.getAttribute (toast-el container "b") "inert"))
+                           "and took itself out of the interaction tree")
+                       (is (= 1 (presence/pending-count)) "exactly one exit is retained")
+                       ;; drive the deterministic clock: the exit fires
+                       (act #(presence/flush-presence!))))
+              (.then (fn [_]
+                       (is (present? container "a") "a is untouched by b's removal")
+                       (is (not (present? container "b"))
+                           "the timeout removed b terminally — its subtree is unmounted")
+                       (is (= 0 (presence/pending-count))
+                           "and the exit fired exactly once, leaving nothing pending")
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (teardown! container root)
+                        (done)))))))))
+
+;; ===========================================================================
+;; FH-PRESENCE-003 — re-entry cancels the exit
+;; ===========================================================================
+
+(deftest fh-presence-003-re-entry-before-the-flush-cancels-removal
+  (testing "Per FH-PRESENCE-003 (browser): re-adding a departed key BEFORE
+            its timeout fires interrupts the exit — the child returns to
+            `:present`, drops its exit accessibility, and the pending removal
+            is cancelled so the later flush never unmounts it."
+    (if-not (browser?)
+      (skip! "the browser job runs the re-entry assertions")
+      (async done
+        (presence/reset-clock!)
+        (presence/set-wall-clock! false)
+        (let [[container root] (mount!)]
+          (-> (render-ids root ["a" "b"])
+              (.then (fn [_]
+                       (is (= "present" (phase-of container "b")) "b starts :present")
+                       (render-ids root ["a"])))          ; b departs -> :unmounting
+              (.then (fn [_]
+                       (is (= "unmounting" (phase-of container "b")) "b is retained :unmounting")
+                       (is (= 1 (presence/pending-count)) "its exit is scheduled")
+                       (render-ids root ["a" "b"])))       ; b re-enters BEFORE the flush
+              (.then (fn [_]
+                       (is (present? container "b") "b is still in the DOM")
+                       (is (= "present" (phase-of container "b"))
+                           "re-entry flipped b back to :present, interrupting the exit")
+                       (is (nil? (.getAttribute (toast-el container "b") "aria-hidden"))
+                           "b dropped its exit accessibility on re-entry")
+                       (is (= 0 (presence/pending-count))
+                           "the pending exit was cancelled — re-entry is not a second child")
+                       ;; a flush now must NOT remove the re-entered child
+                       (act #(presence/flush-presence!))))
+              (.then (fn [_]
+                       (is (present? container "b")
+                           "a flush after re-entry leaves the re-entered child mounted")
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (teardown! container root)
+                        (done)))))))))
+
+(deftest the-fixture-is-loaded
+  (testing "Non-vacuity: the browser assertions read their expectations from
+            the fixture, so a suite that silently loaded no fixture would
+            assert nothing. Pin the shape the tests above depend on."
+    (is (number? (:timeout-ms fx)) "the fixture carries a terminal timeout")
+    (is (= "true" (get (:exit-aria fx) "aria-hidden"))
+        "and the exit accessibility the retained child must show")
+    (is (string? (:exit-class fx)) "and the exit class the child stamps")))

--- a/implementation/freehand/test/re_frame/freehand/presence_parity_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/presence_parity_cljs_test.cljc
@@ -1,0 +1,111 @@
+(ns re-frame.freehand.presence-parity-cljs-test
+  "FH-PRESENCE-001 — a presence boundary projects one structural value, in
+  both modes and on both hosts.
+
+  The retention behaviour is a runtime machine (FH-PRESENCE-002 pins the
+  state machine, FH-PRESENCE-003 the real browser). This suite pins the
+  STRUCTURAL projection: the `:rf.ui/presence` marker, the terminal
+  `:timeout-ms`, and the retained children rendered `:present`. It renders
+  the interpreted views in `re-frame.freehand.presence-views` AND their
+  `{:compiled true}` twins against the SAME `FH-PRESENCE-001` fixture rows —
+  same call sites, same pinned trees, the view-id namespace the only
+  mechanical substitution — so an interpreted `(v/presence …)` and a
+  compiled one are proven to denote the same node.
+
+  Running on the JVM and in ClojureScript is the cross-host arm: the
+  lowering is `.cljc` and its output is asserted against one fixture value
+  in two runtimes. The JVM structural render is where a compiled presence
+  view is renderable today, so this is also the cross-host / cross-mode
+  parity the acceptance names."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.walk :as walk]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.descriptor :as descriptor]
+            [re-frame.freehand.presence-views :as views]
+            [re-frame.freehand.presence-views-compiled :as compiled]
+            [re-frame.freehand.tree :as tree]))
+
+(def presence-001 (conf/fixture :FH-PRESENCE-001))
+
+(def ^:private interpreted-ns "re-frame.freehand.presence-views")
+(def ^:private compiled-ns "re-frame.freehand.presence-views-compiled")
+
+(defn- as-compiled-ids
+  "Rewrite the fixture's expected `:view-id`s onto the compiled twins'
+  namespace — the ONLY difference promotion is allowed to make, and it is
+  not a difference promotion makes at all: it is a difference LIVING IN
+  ANOTHER FILE makes."
+  [tree]
+  (walk/postwalk
+    (fn [x]
+      (if (and (keyword? x) (= interpreted-ns (namespace x)))
+        (keyword compiled-ns (name x))
+        x))
+    tree))
+
+(deftest fh-presence-001-one-boundary-one-node-both-modes
+  (testing "Per FH-PRESENCE-001: a presence boundary projects the
+            `:rf.ui/presence` marker, the terminal `:timeout-ms`, and its
+            children `:present` — the same structural value from the
+            interpreted view and its compiled twin, rendered against the
+            same fixture rows on this host."
+    (is (seq (:cases presence-001)) "the fixture's case table loaded")
+    (doseq [{:keys [note view args tree]} (:cases presence-001)]
+      (let [interpreted (get views/by-name view)
+            promoted    (get compiled/by-name view)
+            call        (into [] args)]
+        (is (some? interpreted) (str "the fixture names an interpreted view: " view))
+        (is (some? promoted) (str "the fixture names a promoted twin: " view))
+        (is (= tree (tree/render (into [interpreted] call)))
+            (str note " (interpreted)"))
+        (is (= (as-compiled-ids tree) (tree/render (into [promoted] call)))
+            (str note " (compiled — the same node, from the same call)"))))))
+
+(deftest the-proof-is-not-vacuous
+  (testing "A parity proof where both sides are interpreted proves nothing,
+            so the lowering each descriptor reports is asserted before its
+            output is trusted — one side really is the interpreted walk, the
+            other really is the compiled emitter."
+    (doseq [[view-name interpreted] views/by-name]
+      (let [promoted (get compiled/by-name view-name)]
+        (is (= :interpreted (:lowering (v/describe interpreted)))
+            (str view-name " is declared interpreted"))
+        (is (= :compiled (:lowering (v/describe promoted)))
+            (str view-name " is declared compiled"))))))
+
+(deftest presence-survives-as-a-marker-node
+  (testing "The presence marker is a load-bearing node the tree exposes, not
+            metadata: it is discoverable by a plain map/`:children` walk, and
+            it round-trips as EDN. A consumer (SSR, a tool) reads
+            `:rf.ui/presence` off the tree the same way on either host."
+    (let [t        (tree/render [views/rooted {}])
+          presence (->> (tree-seq map? :children t)
+                        (filter #(contains? % :rf.ui/presence))
+                        first)]
+      (is (some? presence) "the presence node is reachable by an ordinary tree walk")
+      (is (= {:phase :present :timeout-ms 250} (:rf.ui/presence presence))
+          "and carries the marker the JVM structural host renders")
+      (is (= 2 (count (:children presence)))
+          "with its retained children present in the tree")
+      ;; presence at a view root is NOT flattened into the boundary — the
+      ;; boundary keeps it as its own child (guarded in node/plain-fragment?).
+      (is (= :re-frame.freehand.presence-views/rooted (:view-id t))
+          "the root is the view boundary, wrapping the presence node")
+      (is (contains? (first (:children t)) :rf.ui/presence)
+          "the presence node is the boundary's child, not adopted away"))))
+
+(deftest the-timeout-must-be-legal
+  (testing "The interpreted `v/presence` enforces the same terminal-bound
+            contract the compiled analyzer does: `:timeout-ms` is mandatory
+            and a positive number, and there is at least one child."
+    (is (= descriptor/presence-tag (first (v/presence {:timeout-ms 10} [:div {:key 1}])))
+        "a well-formed call returns the reserved-head presence vector")
+    (is (thrown? #?(:clj Throwable :cljs :default) (v/presence {} [:div {:key 1}]))
+        "a missing :timeout-ms is refused")
+    (is (thrown? #?(:clj Throwable :cljs :default) (v/presence {:timeout-ms 0} [:div {:key 1}]))
+        "a non-positive :timeout-ms is refused")
+    (is (thrown? #?(:clj Throwable :cljs :default) (v/presence {:timeout-ms 10 :easing :ease} [:div {:key 1}]))
+        "an unknown option is refused")
+    (is (thrown? #?(:clj Throwable :cljs :default) (v/presence {:timeout-ms 10}))
+        "a childless presence boundary is refused")))

--- a/implementation/freehand/test/re_frame/freehand/presence_reconcile_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/presence_reconcile_cljs_test.cljc
@@ -1,0 +1,58 @@
+(ns re-frame.freehand.presence-reconcile-cljs-test
+  "FH-PRESENCE-002 — the keyed retention state machine, proven pure and on
+  both hosts.
+
+  Retention, re-entry, the terminal-timeout ordering and first-appearance
+  order are not two implementations that agree; they are ONE. Both execution
+  modes lower a `(v/presence …)` to `re-frame.freehand.presence-runtime`, so
+  `reconcile` and `claim-identities` are the retention contract, and a fixture
+  run against them on the JVM and in ClojureScript is what makes 'identical in
+  both modes' a fact about shared code rather than a hope about two.
+
+  These are pure functions: no React, no clock, no host. The clock and the
+  real browser are FH-PRESENCE-003's; this row pins the transition algebra
+  underneath them."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.presence-runtime :as presence]))
+
+(def presence-002 (conf/fixture :FH-PRESENCE-002))
+
+(deftest fh-presence-002-reconcile-derives-the-retention-plan
+  (testing "Per FH-PRESENCE-002: reconcile derives the three-phase plan —
+            new keys mount, present keys hold, a departed key is retained
+            `:unmounting`, a re-entered key flips back to `:present`, and the
+            committed order is frozen against an incoming reorder."
+    (is (seq (:reconcile presence-002)) "the reconcile case table loaded")
+    (doseq [{:keys [note committed incoming expected]} (:reconcile presence-002)]
+      (is (= expected (presence/reconcile committed incoming)) note))))
+
+(deftest fh-presence-002-claim-identities-keeps-one-pair-per-key
+  (testing "Per FH-PRESENCE-002: claim-identities reduces the flattened
+            children to one pair per key — a key IS a retained identity — with
+            the FIRST claimant winning and the duplicates reported for
+            diagnosis."
+    (is (seq (:claim presence-002)) "the claim case table loaded")
+    (doseq [{:keys [note pairs distinct dups]} (:claim presence-002)]
+      (let [[got-distinct got-dups] (presence/claim-identities pairs)]
+        (is (= distinct got-distinct) (str note " — distinct pairs"))
+        (is (= dups got-dups) (str note " — duplicate keys"))))))
+
+(deftest the-reconcile-proof-is-not-vacuous
+  (testing "reconcile must actually MOVE phases — a table where every
+            expected value equalled its committed input would pass against an
+            identity function. So at least one case must change a phase, and
+            the three transitions the contract names must each appear."
+    (let [cases  (:reconcile presence-002)
+          phases (fn [entries] (set (map :phase entries)))
+          out    (map (fn [{:keys [committed incoming]}]
+                        (presence/reconcile committed incoming))
+                      cases)
+          seen   (reduce into #{} (map phases out))]
+      (is (contains? seen :mounting) "some case derives a :mounting entry")
+      (is (contains? seen :present) "some case derives a :present entry")
+      (is (contains? seen :unmounting) "some case derives an :unmounting entry")
+      (is (some (fn [{:keys [committed incoming]}]
+                  (not= committed (presence/reconcile committed incoming)))
+                cases)
+          "at least one case changes the committed entries — the table is not identity"))))

--- a/implementation/freehand/test/re_frame/freehand/presence_views.cljc
+++ b/implementation/freehand/test/re_frame/freehand/presence_views.cljc
@@ -1,0 +1,40 @@
+(ns re-frame.freehand.presence-views
+  "The declared views the `FH-PRESENCE` structural rows render, INTERPRETED.
+
+  A view's `:view-id` is derived from the namespace it is declared in, and
+  the `FH-PRESENCE-001` fixture pins expected structural trees LITERALLY —
+  view-ids included — so these declarations give the fixture a stable
+  spelling to name, and let the structural suite (both hosts) render the
+  SAME declaration the compiled twin in
+  [[re-frame.freehand.presence-views-compiled]] renders.
+
+  Everything here is host-neutral: no subscriptions, no host objects, no
+  React. `(v/presence …)` is called as an ordinary function in the
+  interpreted body and returns a reserved-head vector the structural walk
+  lowers to the presence node — the same node the compiled emitter builds."
+  (:require [re-frame.freehand :as v]))
+
+(v/defview toasts
+  "A presence boundary over two literal keyed children — the smallest shape
+  that pins the structural projection: the `:rf.ui/presence` marker, the
+  terminal `:timeout-ms`, and the retained children rendered `:present`."
+  [_]
+  [:div.stack
+   (v/presence {:timeout-ms 300}
+     [:div.toast {:key "a"} "A"]
+     [:div.toast {:key "b"} "B"])])
+
+(v/defview rooted
+  "A presence boundary as the ROOT of a declared view — proves the marker
+  survives view-boundary adoption (a fragment-shaped node carrying the
+  presence marker is NOT flattened into the boundary)."
+  [_]
+  (v/presence {:timeout-ms 250}
+    [:li.row {:key 1} "one"]
+    [:li.row {:key 2} "two"]))
+
+(def by-name
+  "Fixture view-name keyword -> the declared view. A fixture is EDN, so it
+  names a view rather than carrying one."
+  {:toasts toasts
+   :rooted rooted})

--- a/implementation/freehand/test/re_frame/freehand/presence_views_compiled.cljc
+++ b/implementation/freehand/test/re_frame/freehand/presence_views_compiled.cljc
@@ -1,0 +1,42 @@
+(ns re-frame.freehand.presence-views-compiled
+  "The [[re-frame.freehand.presence-views]] declarations, PROMOTED.
+
+  Every declaration below is its twin in
+  [[re-frame.freehand.presence-views]] with `{:compiled true}` added and
+  nothing else changed — same parameter vector, same body. The compiled
+  analyzer recognises `(v/presence …)` as a seq form and the JVM emitter
+  lowers it to `re-frame.freehand.tree/presence`; the interpreted twin
+  reaches the SAME builder through the structural walk. `FH-PRESENCE-001`
+  is rendered against BOTH, so the presence node's structural projection is
+  proven identical across modes.
+
+  Separate namespaces because a view id is derived from where a declaration
+  LIVES, so two declarations of one name cannot share a namespace."
+  (:require [re-frame.freehand :as v]))
+
+(v/defview toasts
+  "A presence boundary over two literal keyed children — the smallest shape
+  that pins the structural projection: the `:rf.ui/presence` marker, the
+  terminal `:timeout-ms`, and the retained children rendered `:present`."
+  {:compiled true}
+  [_]
+  [:div.stack
+   (v/presence {:timeout-ms 300}
+     [:div.toast {:key "a"} "A"]
+     [:div.toast {:key "b"} "B"])])
+
+(v/defview rooted
+  "A presence boundary as the ROOT of a declared view — proves the marker
+  survives view-boundary adoption (a fragment-shaped node carrying the
+  presence marker is NOT flattened into the boundary)."
+  {:compiled true}
+  [_]
+  (v/presence {:timeout-ms 250}
+    [:li.row {:key 1} "one"]
+    [:li.row {:key 2} "two"]))
+
+(def by-name
+  "Fixture view-name keyword -> the declared view. Keyed identically to
+  `presence-views/by-name`, so one fixture table drives both."
+  {:toasts toasts
+   :rooted rooted})

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -648,9 +648,67 @@ framework laws and component-library widget vocabulary.
 
 ### Presence
 
-**Lands in:** F4 — data and host lifecycle. Carries the keyed enter/exit plan, the
-phase set and attribute overrides, the mandatory terminal bound, and the structural
-projection.
+Presence is declarative enter/exit retention over keyed children — deliberately
+bounded, and not an animation system. It keeps a departed child mounted long
+enough for the child's own exit transition to run, and nothing more: no easing,
+no curves, no timeline, no presence-event bus.
+
+```clojure
+(v/presence {:timeout-ms 300}
+  (for [t toasts]
+    [toast-card {:key (:id t) :toast t}]))
+```
+
+One retention contract, honoured identically by both execution modes. In the
+interpreted mode `(v/presence …)` is an ordinary function call whose result the
+walk lowers; in the compiled mode it is a form the analyzer recognises and the
+emitter lowers. Both modes reach the SAME retention runtime, so the behaviour
+below is one implementation, not two that agree.
+
+- **The phase machine.** Every keyed child passes `:mounting → :present`. When a
+  key leaves the incoming set its child is not removed but RETAINED in
+  `:unmounting`, so its exit transition runs; the child is dropped from the set
+  only by its own removal, never by a later render.
+- **The terminal bound.** `:timeout-ms` is MANDATORY and is a positive number of
+  milliseconds. It is the exit retention duration AND the terminal safety bound
+  in one: a retained child is removed when `:timeout-ms` fires — not when some
+  other completion signal arrives — and the removal is terminal and
+  exactly-once, releasing every subscription, event and effect the retained
+  subtree owned.
+- **Keyed children.** Presence tracks children BY KEY — a key IS a retained
+  identity — so every child must be keyed. The compiled mode rejects an unkeyed
+  presence child at build time; the interpreted mode drops a child whose runtime
+  key is absent and reports it, and two children under one key resolve to the
+  first claimant with the collision reported.
+- **First-appearance order is frozen.** A key holds the slot it first mounted
+  into; a newly-appearing key appends at the tail regardless of its incoming
+  position, and an incoming reorder is ignored. An exiting child never jumps
+  position mid-transition. A list whose rendered order must track a changing sort
+  does not belong under a presence boundary — sort upstream, and handle display
+  order at the presentation layer.
+- **Re-entry interrupts.** Removal-then-reinsertion of a key before its timeout
+  fires flips it from `:unmounting` back to `:present` and cancels the pending
+  removal; re-entry is the same child returning, never a second one.
+- **The phase read.** `(v/presence-phase)` is the single phase read — `:mounting`
+  / `:present` / `:unmounting` inside a boundary, and `:present` outside one, so
+  a presence-aware child stays reusable anywhere.
+- **DOM-agnostic.** The boundary inserts no wrapper node, stamps no attributes,
+  and observes no DOM events. A presence-aware child owns its own exit styling
+  and accessibility: it stamps `inert` / `aria-hidden` and its exit class against
+  `(v/presence-phase)` = `:unmounting`, and its stylesheet honours
+  `prefers-reduced-motion`.
+- **The structural projection.** The JVM structural host has no lifecycle, so it
+  renders every retained child `:present` and exposes the presence fact
+  structurally as a fragment carrying `:rf.ui/presence {:phase :present
+  :timeout-ms n}` — a droppable reserved marker, so a consumer that does not
+  read it sees a plain fragment of `:present` children.
+- **Test behaviour.** A deterministic clock advances retention without a
+  wall-clock sleep, so a retention window closes exactly when a test says and a
+  run carries no wall-clock flake.
+
+`(v/presence-phase)` remains for the uncommon child whose STRUCTURE, rather than
+its attributes, depends on phase; the ordinary case reads the phase for styling
+and accessibility alone.
 
 ### Error boundaries and error egress
 

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -1286,6 +1286,13 @@
   ["re-frame.freehand" "raw-fn"]            {:tier :advanced    :owner "004" :status "EP-0036"}
   ["re-frame.freehand" "projections"]       {:tier :advanced    :owner "004" :status "EP-0036"}
   ["re-frame.freehand" "materialize-event"] {:tier :advanced    :owner "004" :status "EP-0036"}
+  ;; Presence — keyed enter/exit retention (Spec 004 §Presence). `presence` is
+  ;; the authoring form (a seq form to the compiler, a function call to the
+  ;; interpreter), `presence-phase` the single phase read; both `.cljc` and
+  ;; host-neutral, so the JVM generator owns their kind and the CLJS probe
+  ;; reconciles the same rows.
+  ["re-frame.freehand" "presence"]          {:tier :advanced    :owner "004" :status "EP-0036"}
+  ["re-frame.freehand" "presence-phase"]    {:tier :advanced    :owner "004" :status "EP-0036"}
   ;; A framework-supplied view is not a privileged one: `route-link` is an
   ;; ORDINARY declaration, so its manifest row is an ordinary descriptor Var.
   ;; Routing owns the href / click law (Spec 012); Freehand supplies the

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 518,
+ :var-count 520,
  :tier-vocab
  [:front-porch
   :advanced
@@ -199,6 +199,8 @@
   {:namespace "re-frame.freehand", :var "manifest", :tier :tooling, :kind :fn, :owner "004", :status "EP-0036", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.freehand", :var "markup", :tier :advanced, :kind :var, :owner "004", :status "EP-0036", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.freehand", :var "materialize-event", :tier :advanced, :kind :fn, :owner "004", :status "EP-0036", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.freehand", :var "presence", :tier :advanced, :kind :fn, :owner "004", :status "EP-0036", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.freehand", :var "presence-phase", :tier :advanced, :kind :fn, :owner "004", :status "EP-0036", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.freehand", :var "projections", :tier :advanced, :kind :var, :owner "004", :status "EP-0036", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.freehand", :var "raw-fn", :tier :advanced, :kind :fn, :owner "004", :status "EP-0036", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.freehand", :var "render-fn", :tier :advanced, :kind :macro, :owner "004", :status "EP-0036", :facade? false, :runtime-verified? true}

--- a/spec/conformance/freehand/conformance-index.md
+++ b/spec/conformance/freehand/conformance-index.md
@@ -96,6 +96,9 @@ Keyed retention, override, timeout, accessibility, and test contract.
 
 | Id | Law | Canonical paragraph | Applicability | Fixture | Status |
 |---|---|---|---|---|---|
+| `FH-PRESENCE-001` | A presence boundary projects the `:rf.ui/presence {:phase :present :timeout-ms n}` fragment with its retained children `:present`, identically from an interpreted `(v/presence …)` and its `{:compiled true}` twin and on both hosts; the marker survives view-boundary adoption when presence is a view's root | [004-Views.md#presence](../../004-Views.md#presence) | common jvm browser | `spec/conformance/freehand/fixtures/fh-presence-001.edn` | active |
+| `FH-PRESENCE-002` | The keyed retention machine both modes lower to derives the three-phase plan — new keys mount, present keys hold, a departed key is retained `:unmounting`, a re-entered key flips back to `:present`, and first-appearance order is frozen against an incoming reorder — and claims one pair per key, the first claimant winning and duplicates reported | [004-Views.md#presence](../../004-Views.md#presence) | common jvm browser | `spec/conformance/freehand/fixtures/fh-presence-002.edn` | active |
+| `FH-PRESENCE-003` | In a real browser a departed key's child is retained `:unmounting` and owns its exit accessibility (`aria-hidden` read from `(v/presence-phase)`); the deterministic timeout removes it terminally and exactly once, and a re-entry before the flush cancels the removal and restores `:present` | [004-Views.md#presence](../../004-Views.md#presence) | interpreted browser | `spec/conformance/freehand/fixtures/fh-presence-003.edn` | active |
 
 ### FH-TOPLAYER — Top layer
 

--- a/spec/conformance/freehand/donor-inventory.md
+++ b/spec/conformance/freehand/donor-inventory.md
@@ -153,7 +153,7 @@ in a per-file table. The file rows below inherit them.
 | controlled scheduling | the final-normalized native input predicate and one frame-scoped synchronous scheduler shared by both modes | MOVE | F2 | pending |
 | key-condition event maps | the closed exact-key `:on-key-down`/`:on-key-up` form with existing event values and pre-dispatch mechanics | MOVE | F2 | pending |
 | `spread-safe`/`spread` and `render-fn`/`slot` | forwarding and parameterized-content grammar, absorbed without the donor hook tier | MOVE | F5 | pending |
-| presence runtime | keyed enter/exit retention, made common to both modes | MOVE | F4 | pending |
+| presence runtime | keyed enter/exit retention, made common to both modes | MOVE | F4 | done |
 | `route-link` | the ordinary routing-aware view over the late-bound routing seam, crossing by rename | MOVE | F5 | done |
 | analyzer, both emitters, ViewCell reactor, manifest/elision, diagnostic taxonomy, structural test surface | the useful donor machinery named by the programme as absorbed | MOVE | F3 | pending |
 
@@ -182,7 +182,7 @@ Every tracked file under `implementation/ui/src/`.
 | `implementation/ui/src/re_frame/ui/fingerprint.cljc` | template fingerprint and hook-signature digests; the hook-signature arm goes with the hook tier | MOVE | F3 | done |
 | `implementation/ui/src/re_frame/ui/frames.cljc` | preflight ENSURE executor, plan-install registry, frame-scope elements, ambient frame resolution | MOVE | F2 | pending |
 | `implementation/ui/src/re_frame/ui/hooks.cljc` | the host-hook lowering targets `local` / `effect` / `dispatch-fn` / `use-ref` lower to | DELETE | F1 | pending |
-| `implementation/ui/src/re_frame/ui/presence_runtime.cljc` | the three-phase keyed retention machine and its terminal timeout bound | MOVE | F4 | pending |
+| `implementation/ui/src/re_frame/ui/presence_runtime.cljc` | the three-phase keyed retention machine and its terminal timeout bound | MOVE | F4 | done |
 | `implementation/ui/src/re_frame/ui/react.cljc` | the six-wrapper neutral React tier: effect, layout-effect, effect-event, context, id, lazy | DELETE | F5 | pending |
 | `implementation/ui/src/re_frame/ui/reactive.cljc` | the ViewCell, the render-side probe/record protocol, the layout-commit reconciler, the lifecycle | MOVE | F2 | pending |
 | `implementation/ui/src/re_frame/ui/route_link_seam.cljc` | runtime helpers consuming the late-bound routing link-model and activate hooks | MOVE | F5 | pending |

--- a/spec/conformance/freehand/fixtures/fh-presence-001.edn
+++ b/spec/conformance/freehand/fixtures/fh-presence-001.edn
@@ -1,0 +1,47 @@
+;; FH-PRESENCE-001 — the presence node's structural projection, one value on
+;; both hosts and in both modes.
+;;
+;; Presence retention is a RUNTIME machine (the React clock, FH-PRESENCE-003),
+;; but its STRUCTURAL projection is a value: the `:rf.ui/presence` marker, the
+;; terminal `:timeout-ms`, and the retained children rendered `:present` (the
+;; JVM structural host has no lifecycle). This fixture pins that value.
+;;
+;; It is rendered against BOTH the interpreted views in
+;; `re-frame.freehand.presence-views` and their `{:compiled true}` twins in
+;; `re-frame.freehand.presence-views-compiled` — same call sites, same pinned
+;; trees — so an interpreted `(v/presence …)` and a compiled one are proven to
+;; project the SAME node. Running on the JVM and in ClojureScript is the
+;; cross-host arm: two hosts producing this one pinned value is what "equal on
+;; both hosts" means operationally.
+;;
+;; `:view` names a declaration in the presence-views namespaces; `:args` is the
+;; boundary call's argument tail; the expected `:view-id`s are the interpreted
+;; namespace's, and the compiled arm rewrites them onto the twin namespace.
+{:fh/id "FH-PRESENCE-001"
+ :fh/law
+ "A presence boundary projects the `:rf.ui/presence {:phase :present :timeout-ms n}` fragment with its retained children rendered `:present`, identically in the interpreted and compiled modes and on both hosts; the marker survives view-boundary adoption when presence is a view's root."
+
+ :cases
+ [{:note "a presence boundary inside an element — the marker, the timeout, and two `:present` children"
+   :view :toasts
+   :args [{}]
+   :tree {:view-id :re-frame.freehand.presence-views/toasts
+          :children
+          [{:tag :div :attrs {:class "stack"}
+            :children
+            [{:rf.ui/presence {:phase :present :timeout-ms 300}
+              :children
+              [{:tag :div :attrs {:class "toast"} :key "a" :children ["A"]}
+               {:tag :div :attrs {:class "toast"} :key "b" :children ["B"]}]}]}]
+          :rf.ui/tree-version 1}}
+
+  {:note "presence as the ROOT of a view — the marker is a load-bearing child node, never adopted away"
+   :view :rooted
+   :args [{}]
+   :tree {:view-id :re-frame.freehand.presence-views/rooted
+          :children
+          [{:rf.ui/presence {:phase :present :timeout-ms 250}
+            :children
+            [{:tag :li :attrs {:class "row"} :key 1 :children ["one"]}
+             {:tag :li :attrs {:class "row"} :key 2 :children ["two"]}]}]
+          :rf.ui/tree-version 1}}]}

--- a/spec/conformance/freehand/fixtures/fh-presence-002.edn
+++ b/spec/conformance/freehand/fixtures/fh-presence-002.edn
@@ -1,0 +1,64 @@
+;; FH-PRESENCE-002 — the keyed retention state machine, as pure data.
+;;
+;; The retention machine is the ONE runtime both modes lower to: an
+;; interpreted `(v/presence …)` and a compiled one reach the identical
+;; `reconcile` / `claim-identities` in `re-frame.freehand.presence-runtime`.
+;; So the retention, re-entry, timeout-ordering and first-appearance-order
+;; contract is proven ONCE, on both hosts, over these pure functions —
+;; "identical in both modes" holds by shared construction, and this fixture
+;; pins the semantics the shared code must have.
+;;
+;; `reconcile` derives the next ordered `[{:key :phase} …]` from the committed
+;; entries and the keys present this render. `claim-identities` reduces the
+;; flattened `[key element]` children to one pair per key (first claimant wins)
+;; and returns the duplicate keys — the ownership invariant retention assumes.
+{:fh/id "FH-PRESENCE-002"
+ :fh/law
+ "reconcile derives the three-phase retention plan: new keys mount, present keys hold, a departed key is retained `:unmounting`, a re-entered key flips back to `:present`, and children hold first-appearance order (an incoming reorder is ignored); claim-identities keeps one pair per key, first claimant winning, and reports duplicates."
+
+ :reconcile
+ [{:note "brand-new keys enter :mounting, in first-appearance order"
+   :committed []
+   :incoming ["a" "b"]
+   :expected [{:key "a" :phase :mounting} {:key "b" :phase :mounting}]}
+
+  {:note "present keys still incoming keep their phase"
+   :committed [{:key "a" :phase :present} {:key "b" :phase :present}]
+   :incoming ["a" "b"]
+   :expected [{:key "a" :phase :present} {:key "b" :phase :present}]}
+
+  {:note "a departed key is RETAINED :unmounting — dropped only by its removal timer, never here"
+   :committed [{:key "a" :phase :present} {:key "b" :phase :present}]
+   :incoming ["a"]
+   :expected [{:key "a" :phase :present} {:key "b" :phase :unmounting}]}
+
+  {:note "removal-then-reinsertion RE-ENTERS: :unmounting flips back to :present, interrupting the exit"
+   :committed [{:key "a" :phase :present} {:key "b" :phase :unmounting}]
+   :incoming ["a" "b"]
+   :expected [{:key "a" :phase :present} {:key "b" :phase :present}]}
+
+  {:note "an incoming REORDER is ignored — committed keys hold first-appearance order (blessed order)"
+   :committed [{:key "a" :phase :present} {:key "b" :phase :present}]
+   :incoming ["b" "a"]
+   :expected [{:key "a" :phase :present} {:key "b" :phase :present}]}
+
+  {:note "a new key appends at the TAIL regardless of its incoming position"
+   :committed [{:key "b" :phase :present}]
+   :incoming ["a" "b"]
+   :expected [{:key "b" :phase :present} {:key "a" :phase :mounting}]}
+
+  {:note "every departed key is retained and holds its slot while a new key appends"
+   :committed [{:key "a" :phase :present} {:key "b" :phase :present}]
+   :incoming ["c"]
+   :expected [{:key "a" :phase :unmounting} {:key "b" :phase :unmounting} {:key "c" :phase :mounting}]}]
+
+ :claim
+ [{:note "distinct keys pass through unchanged, no duplicates"
+   :pairs [["a" 1] ["b" 2]]
+   :distinct [["a" 1] ["b" 2]]
+   :dups []}
+
+  {:note "a key claimed twice keeps its FIRST claimant; the later collision is dropped and reported"
+   :pairs [["a" 1] ["b" 2] ["a" 3]]
+   :distinct [["a" 1] ["b" 2]]
+   :dups ["a"]}]}

--- a/spec/conformance/freehand/fixtures/fh-presence-003.edn
+++ b/spec/conformance/freehand/fixtures/fh-presence-003.edn
@@ -1,0 +1,24 @@
+;; FH-PRESENCE-003 — presence retention, timeout and accessibility in a REAL
+;; browser.
+;;
+;; FH-PRESENCE-001 pins what the tree SAYS about presence and FH-PRESENCE-002
+;; the pure transition algebra. Neither can prove what REACT DOES with a
+;; retained subtree: that a departed key's child stays MOUNTED in the document
+;; while exiting, that the child's own `(v/presence-phase)` read reaches
+;; `:unmounting` so it can hide itself from assistive technology, that the
+;; terminal timeout finally unmounts it exactly once, and that a re-entry
+;; before the timeout cancels the removal. Those are facts about a live
+;; `react-dom/client` mount, read back off `document`, driven by the
+;; deterministic `flush-presence!` clock with no wall-clock sleep.
+;;
+;; The child owns its exit accessibility (the boundary is DOM-agnostic): the
+;; `toast` view reads its phase and stamps `aria-hidden` while `:unmounting`,
+;; which is exactly what this row asserts is present on the retained node and
+;; absent again after re-entry.
+{:fh/id "FH-PRESENCE-003"
+ :fh/law
+ "In a real browser a departed key's child is RETAINED in the DOM while :unmounting and owns its exit accessibility (aria-hidden read from (v/presence-phase)); flush-presence! removes it terminally and exactly once; a re-entry before the flush cancels the removal and restores :present."
+
+ :timeout-ms 3000
+ :exit-aria {"aria-hidden" "true"}
+ :exit-class "exiting"}


### PR DESCRIPTION
Absorbs the keyed presence runtime under Freehand ownership and makes the
INTERPRETED mode join the SAME retention contract the compiled mode already
lowered to — one implementation, both modes (EP-0036 F4c, rf2-drpa3.33).

## What changed

- **The runtime, moved.** `re-frame.ui.presence-runtime` → `re-frame.freehand.presence-runtime`, re-spelled to Freehand ownership. The pure `reconcile` / `claim-identities`, the fake-advanceable exit clock, and the React retention boundary are unchanged in behaviour. The server-adopted hydration seed is dropped for now (Freehand carries no phase-context yet; the SSR slice re-wires it) — F4 presence seeds the ordinary client-mount path.
- **Interpreted mode joins it, no parallel model.** `v/presence` is an ordinary function call in an interpreted body; it returns a reserved-head vector (`descriptor/presence-tag`) that both interpreted walks intercept before head classification — `re-frame.freehand.react` to the retention boundary, `re-frame.freehand.tree` to the new `tree/presence` structural node. The compiled analyzer still recognises the seq form; `:presence` is now admitted into the `:re-frame.freehand/v1` grammar. No second presence model.
- **Facade.** `v/presence` and `v/presence-phase` — a small contiguous block; validated at runtime (mandatory positive `:timeout-ms`, at least one child), mirroring the compiled analyzer's checks.
- **Contract.** DOM-agnostic, timeout-only: the boundary stamps nothing; a presence-aware child owns its exit styling and accessibility by reading `(v/presence-phase)` = `:unmounting`.
- **Ledger.** The `presence runtime` disposition and the donor-source row flip to `done` (Freehand owns the code; the donor's frozen copy stays until the artefact is deleted whole).

## Quality gates

All foreground, to completion, rebased onto current `origin/main` (through the `v/sub` merge):

| Gate | Result |
|---|---|
| `cd implementation/freehand && clojure -M:test` | 444 tests, 2909 assertions, 0 failures |
| `npm run test:freehand` | 330 tests, 2273 assertions, 0 failures |
| `npm run test:cljs` | 10451 tests, 52353 assertions, 0 failures |
| `npm run test:browser` | 498 tests, 2882 assertions, 0 failures |
| `clojure -M -m re-frame.api-manifest.gen --check` | **exit 0** — in sync (520 public vars); `git diff` after a fresh `gen` is empty |
| `api-md-check` | in sync (217 var-rows) |
| `doc-api-check` | in sync (200 eligible vars have page + member entry) |
| `python scripts/check_freehand_conformance_index.py` | pass |
| `python scripts/check_donor_inventory.py` | pass (presence disposed) |
| `python scripts/check_doc_slugs.py` | pass |
| `python -m mkdocs build --strict` | pass |

Conformance: FH-PRESENCE-001 (structural projection, both modes, JVM + CLJS), FH-PRESENCE-002 (the pure retention machine, both hosts), FH-PRESENCE-003 (retention + exit accessibility + terminal timeout + re-entry in real Chromium). Each new test file carries a non-vacuity probe. `git grep re-frame.ui implementation/freehand/` stays empty.

## Manifest drift-check

Rebased onto current main through the `v/sub` merge (#6711). The only conflict of substance was the GENERATED `spec/api-manifest.edn`, resolved by **regenerate** (never by `--ours`/`--theirs` content): the regenerated manifest carries main's `sub` / `markup` / `manifest` / `route-link` PLUS `presence` / `presence-phase`, at 520 vars. The sidecar, `spec/API.md` and `docs/api/re-frame.freehand.md` kept BOTH main's rows and mine.

The original drift was never a toolchain-formatting difference — it was a stale `:var-count` header left by git's auto-merge. Proof: after a plain `gen`, `git diff spec/api-manifest.edn` is empty and `gen --check` exits 0. The two new facade verbs also needed a `docs/api/re-frame.freehand.md` member entry (doc-api-check) — added.
