### PR TITLE
fix(freehand): release staged handles when a commit-side read fails (rf2-drpa3.77)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/cell.cljc
+++ b/implementation/freehand/src/re_frame/freehand/cell.cljc
@@ -45,10 +45,14 @@
      dependency sets never falls through its zero-owner disposal edge.
      An acquisition failure releases the staged handles in reverse order
      and leaves the PRIOR committed set installed.
-  3. **Re-check.** Currency is re-read at the narrowest boundary — after
-     all callback-capable work, with nothing callback-capable between it
-     and the publish — so a hot reload landing mid-commit cannot publish
-     a stale body.
+  3. **Read and re-check.** Every staged handle's commit-time evidence is
+     read — a fail-loud, callback-capable operation that runs INSIDE the
+     pre-publication transaction, so a read that throws rolls the fresh
+     staging back exactly as an acquisition failure does. Currency is then
+     re-read at the narrowest boundary — after ALL callback-capable work,
+     the reads included, with nothing callback-capable between it and the
+     publish — so a hot reload (or a read that re-entered and advanced
+     authority) landing mid-commit cannot publish a stale body.
   4. **Publish.** Frame, dependencies, evidence and the event site table
      become live with no host yield between them. Nothing can observe a
      partial bundle.
@@ -538,6 +542,24 @@
         (release-all! (rseq @acquired))
         (throw e)))))
 
+(defn- fresh-handles
+  "The handles THIS candidate freshly acquired — the render `order`
+  restricted to the sites [[stage!]] acquired rather than RETAINED from
+  the prior committed set — in ACQUISITION order.
+
+  Its reverse is the release order for any pre-publication rollback (a
+  read failure or a lost currency re-check): layered acquisitions unwind
+  symmetrically, and a retained prior handle — untouched by this
+  candidate and still owned by the installed set — is never in it, so a
+  rollback releases exactly what this candidate acquired and nothing the
+  prior bundle still needs."
+  [order staged]
+  (into []
+        (keep (fn [site-key]
+                (let [record (get staged site-key)]
+                  (when (and record (not (:retained? record))) (:handle record)))))
+        order))
+
 (defn- superseded-handles
   "The handles the PRIOR committed set owned that the new one does not —
   a dropped site's handle, and a retargeted site's OLD handle. Compared
@@ -570,18 +592,35 @@
       (let [{:keys [order by-site]} @(.-reads cand)
             prior  (:deps s0)
             fid    (.-frame cand)
-            staged (stage! owner-cell prior order by-site)]
-        ;; The narrowest publication boundary: acquisition ran cache
-        ;; installs and disposal hooks, any of which can synchronously
-        ;; advance the cell's authority. Re-read it here, with nothing
-        ;; callback-capable between this check and the publish.
+            staged (stage! owner-cell prior order by-site)
+            ;; The commit-side reads are part of the pre-publication
+            ;; TRANSACTION, not a step past it. `obs/read` is a fail-loud
+            ;; port op that may deref application subscription code — it can
+            ;; throw, and it can synchronously advance the cell's authority.
+            ;; So it runs inside the rollback guard: a read that throws
+            ;; releases every handle THIS candidate freshly acquired, in
+            ;; reverse acquisition order, leaves the prior committed set
+            ;; installed, and rethrows the ORIGINAL failure untranslated.
+            readings (try
+                       (into {}
+                             (map (fn [[k {:keys [handle]}]] [k (obs/read handle)]))
+                             staged)
+                       (catch #?(:clj Throwable :cljs :default) e
+                         (release-all! (rseq (fresh-handles order staged)))
+                         (throw e)))]
+        ;; The narrowest publication boundary: acquisition AND the
+        ;; commit-side reads ran cache installs, disposal hooks and
+        ;; application recompute, any of which can synchronously advance the
+        ;; cell's authority. Re-read it here — AFTER every callback-capable
+        ;; or fail-loud pre-publication operation, with nothing
+        ;; callback-capable between this check and the publish — so a read
+        ;; that advanced body or frame authority rolls back its fresh
+        ;; staging and publishes nothing rather than publishing stale
+        ;; ownership.
         (if-not (current? cand @(st owner-cell))
-          (do (release-all! (into [] (comp (remove :retained?) (map :handle)) (vals staged)))
+          (do (release-all! (rseq (fresh-handles order staged)))
               :abandoned)
-          (let [readings (into {}
-                               (map (fn [[k {:keys [handle]}]] [k (obs/read handle)]))
-                               staged)
-                bundle   {:frame        fid
+          (let [bundle   {:frame        fid
                           :generation   (.-generation cand)
                           :observations (mapv (fn [k]
                                                 (let [r (get staged k)]

--- a/implementation/freehand/test/re_frame/freehand/shell_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/shell_cljs_test.cljc
@@ -80,6 +80,18 @@
       (thunk))
     @seen))
 
+(defn- mock-fn
+  "Wrap a single-argument observation-port mock `f` as a genuinely
+  multi-arity replacement (calling `f` on the FIRST argument at both
+  arities). A bare single-arity `(fn [x] …)` closure lacks the
+  `cljs$core$IFn$_invoke$arity$N` methods ClojureScript's `:static-fns`
+  dispatch calls the port vars through — including the two-argument
+  `obs/acquire!` — so a `with-redefs` replacement must carry them, which a
+  multi-arity fn does. The JVM reaches the same value through ordinary var
+  indirection."
+  [f]
+  (fn ([a] (f a)) ([a _b] (f a))))
+
 ;; ===========================================================================
 ;; FH-SUB-001 — the selected commit publishes ONE bundle
 ;; ===========================================================================
@@ -228,6 +240,85 @@
           (is (= (:prior-ref-count rollback) (ref-count fid query)))
           (is (= (:rolled-back-ref-count rollback) (ref-count fid other-query))
               "the staged handle the failed reconcile acquired was released"))))))
+
+(deftest fh-sub-002-a-commit-side-read-failure-releases-every-staged-handle
+  (testing "Per FH-SUB-002 (hazard: abandoned render, the commit-side-read
+            half): the pre-publication phase is transactional THROUGH the
+            commit-side reads, not merely through acquisition. `obs/read` is a
+            fail-loud port op that may deref application subscription code, so
+            a read that throws before publication must release every handle
+            THIS candidate freshly acquired — exactly once, in reverse
+            acquisition order — leave the prior committed set installed, and
+            rethrow the ORIGINAL failure unwrapped. A candidate that publishes
+            nothing must OWN nothing: a stranded handle is a dependency nobody
+            will ever release. The port is fully mocked so the failure is
+            deterministic on both hosts."
+    (let [q1       [:read-fail/a]
+          q2       [:read-fail/b]
+          acquired (atom [])
+          released (atom [])
+          boom     (ex-info "commit-side read blew up" {:probe :read})]
+      (with-redefs [obs/resolve-target (mock-fn (fn [{:keys [query-v]}] {:query-v query-v}))
+                    obs/probe          (mock-fn (fn [_target] {:value :probed}))
+                    obs/acquire!       (mock-fn (fn [target]
+                                                  (let [h {:handle-for (:query-v target)}]
+                                                    (swap! acquired conj h)
+                                                    h)))
+                    obs/read           (mock-fn (fn [_handle] (throw boom)))
+                    obs/release!       (mock-fn (fn [h] (swap! released conj h) nil))]
+        (let [c      (cell/cell :shell/panel)
+              cand   (cell/candidate c nil)
+              caught (atom nil)]
+          (cell/with-capture cand (fn [] (mapv cell/observe! [q1 q2])))
+          (try (cell/commit! cand)
+               (catch #?(:clj Throwable :cljs :default) e (reset! caught e)))
+          (is (identical? boom @caught)
+              "the original observation failure escapes, unwrapped")
+          (is (= 2 (count @acquired)) "staging acquired both fresh handles")
+          (is (= 2 (count @released)) "and released exactly two — neither stranded")
+          (is (= (vec (rseq (vec @acquired))) @released)
+              "every staged handle was released exactly once, in REVERSE
+               acquisition order")
+          (is (= :new (cell/lifecycle c)) "the cell published nothing")
+          (is (= 0 (count (cell/dependencies c))))
+          (is (= 0 (cell/generation c)))
+          (is (nil? (cell/evidence c))))))))
+
+(deftest fh-sub-002-a-commit-side-read-that-advances-authority-abandons
+  (testing "Per FH-SUB-002 (hazard: abandoned render, the re-entrancy half):
+            a commit-side `obs/read` can RE-ENTER application subscription code
+            that advances the cell's authority — a hot reload of the body
+            landing mid-read. The final currency boundary is therefore AFTER
+            every commit-side read: a read that advances the body revision
+            makes the candidate stale, so it rolls back its fresh staging and
+            returns `:abandoned` rather than publishing stale ownership.
+            Nothing from that candidate publishes."
+    (let [q1       [:reentrant/a]
+          acquired (atom [])
+          released (atom [])
+          c        (cell/cell :shell/panel)]
+      (with-redefs [obs/resolve-target (mock-fn (fn [{:keys [query-v]}] {:query-v query-v}))
+                    obs/probe          (mock-fn (fn [_target] {:value :probed}))
+                    obs/acquire!       (mock-fn (fn [target]
+                                                  (let [h {:handle-for (:query-v target)}]
+                                                    (swap! acquired conj h)
+                                                    h)))
+                    ;; The read re-enters and advances the body revision — a hot
+                    ;; reload landing mid-read, AFTER the first currency check.
+                    obs/read           (mock-fn (fn [_handle]
+                                                  (cell/advance-generation! c)
+                                                  {:value :probed}))
+                    obs/release!       (mock-fn (fn [h] (swap! released conj h) nil))]
+        (let [cand (cell/candidate c nil)]
+          (cell/with-capture cand (fn [] (cell/observe! q1)))
+          (is (= :abandoned (cell/commit! cand))
+              "the re-check at the narrowest boundary — now AFTER the reads —
+               sees the advanced authority and abandons")
+          (is (= 1 (count @acquired)))
+          (is (= @acquired @released) "the fresh staging was released")
+          (is (= :new (cell/lifecycle c)) "nothing from that candidate published")
+          (is (= 0 (count (cell/dependencies c))))
+          (is (nil? (cell/evidence c))))))))
 
 ;; ===========================================================================
 ;; FH-SUB-003 — HAZARD 2: hot reload across a LIVE cell

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -1428,11 +1428,13 @@ generation, checked at **two points**:
 1. **Render→commit (step 1).** Commit entry samples the authority once and rejects a
    stale capture before touching any ownership — the host simply re-renders.
 2. **Final publication boundary.** Step 1 samples *once*, but the staging window between
-   it and publication — the acquire/cache callbacks — can each synchronously advance the
-   authoritative revision (a same-shell re-registration mid-commit). So commit **re-reads**
-   the authority at the narrowest boundary — after all callback-capable work, with nothing
-   callback-capable between it and the publish swap — and refuses to publish a stale
-   capture: it releases **only the newly-staged handles** (reverse acquisition order),
+   it and publication — the acquire/cache callbacks **and the commit-side evidence
+   reads**, both callback-capable — can each synchronously advance the authoritative
+   revision (a same-shell re-registration mid-commit). So commit **re-reads** the
+   authority at the narrowest boundary — after all callback-capable work, `read`
+   included, with nothing callback-capable between it and the publish swap — and refuses
+   to publish a stale capture: it releases **only the newly-staged handles** (reverse
+   acquisition order),
    leaves the prior committed set, published values, and lifecycle untouched, and returns
    `:stale`. No revision advances, because the re-registration already notified the shell
    and a fresh render at the new body is inbound.
@@ -1855,8 +1857,13 @@ double render, and a time-sliced tear-off ordinary rather than special.
 A candidate whose reconcile **fails** publishes nothing either. Acquisition failure
 unwinds per [§Transactional multi-acquire](#transactional-multi-acquire--staging-and-rollback):
 the staged handles are released in reverse order, the prior committed set stays installed
-with its published values, and the typed error propagates. A partly-owned cell — one
-whose dependencies came from two different renders — is not a state the shell can reach.
+with its published values, and the typed error propagates. The same rollback covers a
+failure in the **commit-side evidence reads**: `read` is a fail-loud port operation that
+may re-enter application subscription code, so it runs inside the pre-publication
+transaction, and a read that throws before the publish swap releases every handle this
+candidate freshly acquired — reverse acquisition order — leaves the prior committed set
+untouched, and rethrows the original failure unchanged. A partly-owned cell — one whose
+dependencies came from two different renders — is not a state the shell can reach.
 
 ### Body authority across a live cell
 


### PR DESCRIPTION
## What & why

The atomic shell (`implementation/freehand/src/re_frame/freehand/cell.cljc`)
staged handles transactionally **only through acquisition**. After `stage!`
succeeded, `commit!` read every staged handle's commit-time evidence
(`obs/read`) **outside** the rollback guard and **before** the final currency
re-check. `obs/read` is a fail-loud port op that may re-enter application
subscription code, so:

- a read that **threw** stranded every freshly-acquired handle — the candidate
  published nothing yet owned everything it staged, contradicting the shell's
  failed-candidate rollback law; and
- a read that **re-entered and advanced body/frame authority** was never
  re-checked, so the stale candidate could still publish.

### The fix

Move the commit-side reads **inside** the pre-publication transaction. A read
that throws releases every handle this candidate freshly acquired, **in reverse
acquisition order**, leaves the prior committed set installed, and rethrows the
**original** failure untranslated. The final currency boundary now sits **after
every callback-capable/fail-loud pre-publication operation** (the reads
included), with nothing callback-capable between it and the publish — so a read
that advanced authority rolls back its fresh staging and returns `:abandoned`
rather than publishing stale ownership. A new `fresh-handles` helper gives both
rollback paths one reverse-order release.

Preserved invariants (verified against the six hazard tests + FH-SUB rows,
unchanged): dual-axis currency (body revision **and** frame incarnation),
`disconnect!` stays non-terminal (StrictMode replay reconnects), a
failed/abandoned candidate publishes nothing, acquisition-failure rollback, and
acquire-before-release ordering. Cross-host (`.cljc`, JVM + CLJS); no
`identical?`-on-keyword sentinels.

Spec 006's *Abandoned and failed candidates* and *Final publication boundary*
wording now name the commit-side reads as fail-loud pre-publication operations
the boundary follows (acceptance criterion 5).

Scope: `cell.cljc` + its test + Spec 006 only. No public-API/manifest surface
touched.

## Regression — non-vacuity (JVM `re-frame.freehand.shell-cljs-test`)

**Pre-fix (RED)** — the two new FH-SUB-002 regressions fail exactly as the bug
predicts (read-failure leaks: release log empty; re-entrancy publishes stale:
deps=1, evidence non-nil):

```
Ran 23 tests containing 118 assertions.
7 failures, 0 errors.
```
```
FAIL fh-sub-002-a-commit-side-read-failure-releases-every-staged-handle
  expected: (= (vec (rseq (vec @acquired))) @released)
    actual: (not (= [{:handle-for [:read-fail/b]} {:handle-for [:read-fail/a]}] []))
FAIL fh-sub-002-a-commit-side-read-that-advances-authority-abandons
  expected: (nil? (cell/evidence c))
    actual: (not (nil? {:frame nil, :generation 0, :observations [...]}))
```

**Post-fix (GREEN):**

```
Ran 23 tests containing 118 assertions.
0 failures, 0 errors.
```

**Mutation (RED)** — reverting the read-failure rollback in the catch
(`release-all! nil`) reds the guard again:

```
Ran 23 tests containing 118 assertions.
2 failures, 0 errors.
```

## Quality gates

All foreground, to completion:

| Gate | Result |
|---|---|
| `cd implementation/freehand && clojure -M:test` | Ran 435 tests, 2851 assertions — **0 failures, 0 errors** |
| `npm run test:freehand` | Ran 318 tests, 2210 assertions — **0 failures, 0 errors** |
| `npm run test:cljs` | Ran 10439 tests, 52290 assertions — **0 failures, 0 errors** |
| `npm run test:browser` | Ran 495 tests, 2855 assertions — **0 failures, 0 errors** |
| `python scripts/check_freehand_conformance_index.py` | OK: 36 rows across 15 area sections |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `git grep 're-frame.ui' implementation/freehand/` | empty |