### PR TITLE
fix(freehand): make the B-spine falsifiability control deterministic, not timing-based (rf2-e3jhy)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/bench/falsifiability.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/falsifiability.cljc
@@ -19,9 +19,20 @@
   | `moved-timing`    | exit 0 | a wall-clock reading many times larger still exits 0 |
 
   and one more, which is what stops the fourth row being a tautology:
-  the moved arm's distribution must actually have MOVED, by a large
-  multiple of the baseline's. A proof that a timing \"did not red\" is
-  worth nothing unless the timing it did not red on was wildly different.
+  the moved arm must actually have DONE more work than the baseline. A
+  proof that a timing \"did not red\" is worth nothing if the timing had
+  no reason to move in the first place.
+
+  That last claim is read off a DETERMINISTIC signal — the nodes each arm
+  actually rendered, which the repeat knob scales by exactly its own
+  factor — and never off the wall clock. The distinction is the whole
+  ruling applied to the ruling's own proof: a harness that mechanises
+  \"no numeric wall-clock thresholds\" must not contain one, and a proof
+  that gated on a measured ratio would flake for precisely the reason
+  D021 bans such gates. It did: under concurrent load a 50x workload was
+  once observed returning an 8.79x wall-clock ratio. The workload ratio
+  is 50x always. The wall-clock ratio is still reported, because it is
+  what a reader wants to see — and it decides nothing.
 
   The four arms are deliberately not registered with
   [[re-frame.freehand.bench/register!]]. They are a proof about the
@@ -59,14 +70,31 @@
   language — it appears in every result record this namespace emits."
   200)
 
+;; The template renders one `:ul` node holding `rows` `:li` nodes; the row
+;; text is a string child, not a node. The expectation is DECLARED from the
+;; fixture parameter rather than read back from the observation — a gate
+;; that expects whatever it saw is not a gate.
+(def ^:private correct-node-count (inc row-count))
+
 (defn- arm
   "One proof arm: render the template `repeats` times, observe the node
-  count of the first tree and the self time of the whole burst.
+  count of the first tree, the total nodes rendered across the burst, and
+  the self time of the whole burst.
 
   `expect` is the node count a correct run answers. `repeats` is the
-  timing knob: it changes the duration by roughly its own factor and
-  changes the node count not at all, which is exactly the pair of levers
-  the two directions of the proof need.
+  knob, and it moves the three observations differently — which is
+  exactly the set of levers the two directions of the proof need:
+
+    - the first tree's node count, NOT AT ALL. The deterministic property
+      is untouched by the knob, so the moved arm is a test of the timing
+      rather than of the property.
+    - the total nodes rendered, by EXACTLY its own factor. That is the
+      fixture's workload size: deterministic, reproducible on any host
+      under any load, and the signal the proof reads to know the moved
+      arm really did more work.
+    - the duration, by ROUGHLY its own factor. Roughly is the whole
+      point: a wall clock under load is why D021 publishes this as
+      evidence instead of gating it, and why the proof does not read it.
 
   `sampling` is per-arm because the arms are deliberately unequal in
   cost. The cheap arms buy a warm engine with many discarded iterations;
@@ -84,6 +112,10 @@
                    :doc        "the exact node count of the interpreted structural tree"
                    :observable :count
                    :expect     expect}
+                  {:id         :falsifiability/render-nodes
+                   :doc        "the exact nodes rendered across the whole burst — the fixture's workload size"
+                   :observable :count
+                   :expect     (* repeats correct-node-count)}
                   {:id         :falsifiability/render-ms
                    :doc        "self time for the fixture's burst of interpreted renders"
                    :observable :duration-ms}]
@@ -92,14 +124,9 @@
                          t0    (m/now-ms)
                          trees (doall (repeatedly repeats #(tree/render form)))
                          t1    (m/now-ms)]
-                     {:falsifiability/node-count (node-count (first trees))
-                      :falsifiability/render-ms  (- t1 t0)}))})
-
-;; The template renders one `:ul` node holding `rows` `:li` nodes; the row
-;; text is a string child, not a node. The expectation is DECLARED from the
-;; fixture parameter rather than read back from the observation — a gate
-;; that expects whatever it saw is not a gate.
-(def ^:private correct-node-count (inc row-count))
+                     {:falsifiability/node-count   (node-count (first trees))
+                      :falsifiability/render-nodes (reduce + (map node-count trees))
+                      :falsifiability/render-ms    (- t1 t0)}))})
 
 (def ^:private light
   "The cheap arms' policy. The generous warm-up is not politeness: with a
@@ -151,18 +178,31 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private minimum-move
-  "How many times the baseline distribution the moved arm must reach for
-  the evidence direction to have proven anything.
+  "How many times the baseline's WORK the moved arm must do for the
+  evidence direction to have proven anything.
 
-  This is a threshold on the PROOF, not on Freehand. It exists to stop
-  the fourth row of the table being satisfied by a timing that did not
-  move — the opposite of a performance budget, and the reason it is set
-  far below the 20x-50x the fixture actually produces."
+  This is a threshold on the PROOF, not on Freehand, and it is read off a
+  DETERMINISTIC signal — the nodes each arm actually rendered — never off
+  the wall clock. It exists to stop the fourth row of the table being
+  satisfied by a moved arm whose timing had no reason to move.
+
+  A threshold on the wall clock here would be the very shape D021 forbids
+  everywhere else, and it flaked for exactly the reason D021 gives:
+  under concurrent load a 50x workload was observed returning an 8.79x
+  wall-clock ratio. The workload ratio is 50x on every host under any
+  load, so this bound sits far below the multiple actually produced and
+  has nothing to flake against."
   10)
 
 (defn- p50
   [result measurement]
   (get-in result [:distribution measurement :p50]))
+
+(defn- observed
+  "The value a GATE measurement answered — read from `:properties`, which
+  is where a deterministic property lands, and where a timing never does."
+  [result measurement]
+  (get-in result [:properties measurement :observed]))
 
 (defn- check
   [ok? sentence]
@@ -171,10 +211,17 @@
 (defn prove
   "Run the four arms and answer the proof report.
 
-      {:arms     {…}     ; each arm's outcome, for the transcript
-       :move     <ratio> ; how far the moved arm's distribution actually moved
-       :defects  […]     ; empty when the asymmetry holds both ways
-       :proven?  true}
+      {:arms         {…}     ; each arm's outcome, for the transcript
+       :move         <ratio> ; times the baseline's WORK the moved arm did — deterministic
+       :timing-ratio <ratio> ; times its wall clock — published evidence, gates nothing
+       :defects      […]     ; empty when the asymmetry holds both ways
+       :proven?      true}
+
+  `:move` is the proof's own quantity and is read off the arms' rendered
+  node counts, so it is 50 on every host under any load. `:timing-ratio`
+  is the same comparison over the wall clock: reported because it is the
+  thing a reader wants to see, and load-bearing on nothing, because a
+  proof that read it would be the threshold this harness forbids.
 
   Answers a report rather than throwing, so a test can assert on it, a
   CLI can print it, and a failure says which of the four expectations
@@ -191,9 +238,30 @@
          green   (bench/run [baseline-timing] opts)
          moved   (bench/run [moved-timing] opts)
          named   (some #(= :falsifiability/node-count (:measurement %)) (:gate-failures reds))
-         base    (p50 (first (:results green)) :falsifiability/render-ms)
-         big     (p50 (first (:results moved)) :falsifiability/render-ms)
-         ratio   (when (and (number? base) (pos? base) (number? big)) (/ big base))
+         base-r  (first (:results green))
+         moved-r (first (:results moved))
+
+         ;; The proof's own quantity: how much more WORK the moved arm did,
+         ;; counted in nodes it actually rendered. Deterministic on every
+         ;; host under any load.
+         base-work  (observed base-r :falsifiability/render-nodes)
+         moved-work (observed moved-r :falsifiability/render-nodes)
+         work-ratio (when (and (number? base-work) (pos? base-work) (number? moved-work))
+                      (/ moved-work base-work))
+
+         ;; The same comparison over the wall clock. Reported, never read.
+         base       (p50 base-r :falsifiability/render-ms)
+         big        (p50 moved-r :falsifiability/render-ms)
+         ratio      (when (and (number? base) (pos? base) (number? big)) (/ big base))
+
+         ;; The timing is EVIDENCE: a published distribution and not a
+         ;; judged property. Asserted structurally rather than inferred
+         ;; from an exit code, so the arm that proves "a moved timing does
+         ;; not red" also proves the thing that moved was never a gate.
+         timing-is-evidence?
+         (and (contains? (:distribution moved-r) :falsifiability/render-ms)
+              (not (contains? (:properties moved-r) :falsifiability/render-ms)))
+
          defects
          (into []
                (keep identity)
@@ -228,19 +296,29 @@
                             (pr-str (:gate-failures moved))
                             ". Only deterministic properties may produce a verdict."))
 
-                (check (and ratio (>= ratio minimum-move))
-                       (str "The moved-timing arm's distribution did not actually move — p50 "
-                            (pr-str big) "ms against a baseline of " (pr-str base) "ms ("
-                            (pr-str ratio) "x, needed " minimum-move "x). Proving that an "
-                            "unchanged timing does not red the build proves nothing."))])]
+                (check timing-is-evidence?
+                       (str "The moved arm's :falsifiability/render-ms did not route as "
+                            "EVIDENCE: a timing must be a published distribution and never a "
+                            "judged property. Wired as a gate, it turns runner noise into a red "
+                            "build — the failure mode this whole proof exists to detect."))
+
+                (check (and work-ratio (>= work-ratio minimum-move))
+                       (str "The moved-timing arm did no more work than the baseline — it "
+                            "rendered " (pr-str moved-work) " nodes against the baseline's "
+                            (pr-str base-work) " (" (pr-str work-ratio) "x, needed "
+                            minimum-move "x). Proving that a timing with no reason to move did "
+                            "not red the build proves nothing."))])]
      {:arms    {:honoured-gate   {:exit-code (:exit-code holds)}
                 :violated-gate   {:exit-code     (:exit-code reds)
                                   :gate-failures (mapv :message (:gate-failures reds))}
                 :baseline-timing {:exit-code (:exit-code green)
-                                  :p50-ms    base}
+                                  :p50-ms    base
+                                  :nodes     base-work}
                 :moved-timing    {:exit-code     (:exit-code moved)
                                   :p50-ms        big
+                                  :nodes         moved-work
                                   :gate-failures (mapv :message (:gate-failures moved))}}
-      :move    ratio
-      :defects defects
-      :proven? (empty? defects)})))
+      :move         work-ratio
+      :timing-ratio ratio
+      :defects      defects
+      :proven?      (empty? defects)})))

--- a/implementation/freehand/src/re_frame/freehand/bench/runner.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/runner.cljc
@@ -68,7 +68,7 @@
   (when (number? x) (/ (double (Math/round (* (double x) 10.0))) 10.0)))
 
 (defn- prove-summary
-  [{:keys [arms move defects proven?]}]
+  [{:keys [arms move timing-ratio defects proven?]}]
   (concat
     ["Freehand B-spine falsifiability proof (D021, both directions)."
      (str "  a gate that HOLDS      -> exit " (get-in arms [:honoured-gate :exit-code])
@@ -79,8 +79,15 @@
     [(str "  timing baseline        -> exit " (get-in arms [:baseline-timing :exit-code])
           "   (expected 0), p50 " (get-in arms [:baseline-timing :p50-ms]) "ms")
      (str "  timing MOVED           -> exit " (get-in arms [:moved-timing :exit-code])
-          "   (expected 0), p50 " (get-in arms [:moved-timing :p50-ms]) "ms = "
-          (round1 move) "x the baseline")]
+          "   (expected 0), p50 " (get-in arms [:moved-timing :p50-ms]) "ms")
+     ;; The proof's quantity and the reader's quantity, kept apart on
+     ;; purpose: one decides the exit code, the other is evidence.
+     (str "  the moved arm did " (round1 move) "x the baseline's WORK ("
+          (get-in arms [:moved-timing :nodes]) " vs "
+          (get-in arms [:baseline-timing :nodes]) " nodes rendered) -- deterministic, "
+          "and the only thing this proof reads.")
+     (str "  its wall clock moved " (round1 timing-ratio)
+          "x -- published evidence, gating nothing.")]
     (if proven?
       ["  PROVEN both ways: a violated deterministic property reds; a wildly moved"
        "  wall-clock distribution does not."]

--- a/implementation/freehand/test/re_frame/freehand/bench/falsifiability_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/bench/falsifiability_cljs_test.cljc
@@ -3,14 +3,20 @@
 
   This is the deterministic property the harness itself is judged on, and
   it is the stable subset that runs in PR smoke — it needs no browser, no
-  pinned worker and no calibration, because it asserts about EXIT CODES
-  rather than about milliseconds.
+  pinned worker and no calibration, because it asserts about EXIT CODES,
+  ROUTING and exact COUNTS, and never about milliseconds. Not one
+  assertion in this namespace reads a wall clock, which is the same rule
+  the harness enforces on everyone else, held to here.
 
-  Criterion 3 is the one that gets skipped, so it is asserted twice here:
-  once that a wildly moved wall-clock distribution still exits 0, and
-  once that the distribution really did move. A harness that fails on a
-  slow run has silently become a threshold, which D021 forbids; a proof
-  that an unchanged timing did not red the build proves nothing."
+  Criterion 3 is the one that gets skipped, so it is asserted three ways:
+  that a wildly moved wall-clock distribution still exits 0; that the
+  fixture genuinely did more work, so that result is not vacuous; and
+  that the reading which moved was routed as evidence rather than judged
+  as a property. A harness that fails on a slow run has silently become a
+  threshold, which D021 forbids — and a control that policed that with a
+  wall-clock threshold of its own would be the same mistake, one level
+  up. The second of the three is therefore read off the fixture's
+  workload size, which is exact on any host under any load."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.freehand.bench :as bench]
             [re-frame.freehand.bench.falsifiability :as falsifiability]
@@ -72,12 +78,39 @@
 
 (deftest the-moved-timing-really-moved
   (testing "criterion 3's non-vacuity. Without this the assertion above
-            is satisfied by a timing that did not change."
+            is satisfied by a timing that had no reason to change.
+
+            Proven on the fixture's WORKLOAD SIZE — the nodes the arm
+            actually rendered, which the repeat knob scales by exactly its
+            own factor — and not on the wall-clock ratio. A numeric
+            wall-clock threshold here would be the shape D021 forbids
+            everywhere else, sitting inside the harness that mechanises the
+            ban, and it flaked for the reason D021 gives: under concurrent
+            load a 50x workload returned an 8.79x ratio."
     (let [proof (falsifiability/prove provenance)]
       (is (number? (:move proof)))
       (is (<= 10 (:move proof))
-          (str "the moved arm's p50 was only " (:move proof)
-               "x the baseline's — nothing was proven about a wildly changed timing")))))
+          (str "the moved arm rendered only " (:move proof)
+               "x the baseline's nodes — nothing was proven about a moved timing, "
+               "because the fixture gave it no reason to move"))
+      (is (number? (:timing-ratio proof))
+          "the wall-clock ratio is still reported — as evidence, deciding nothing"))))
+
+(deftest the-moved-arms-timing-is-evidence-and-not-a-gate
+  (testing "what makes the arm above a control at all: the reading that
+            moved must be ROUTED as evidence. A `:duration-ms` published
+            as a distribution has no path to a verdict; the same reading
+            judged as a property would turn runner noise into a red build,
+            which is the mis-wiring criterion 3 exists to catch."
+    (let [record (first (:results (bench/run [falsifiability/moved-timing] provenance)))]
+      (is (contains? (:distribution record) :falsifiability/render-ms)
+          "the moved arm's wall-clock reading is a published distribution")
+      (is (not (contains? (:properties record) :falsifiability/render-ms))
+          "and never a judged property — only deterministic properties gate")
+      (is (contains? (:properties record) :falsifiability/render-nodes)
+          "while the workload size, being deterministic, IS a gated property")
+      (is (not (contains? (:distribution record) :falsifiability/render-nodes))
+          "and has no distribution: a correct run answers it once"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Both directions at once — the harness's own gate

--- a/implementation/freehand/test/re_frame/freehand/bench/falsifiability_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/bench/falsifiability_cljs_test.cljc
@@ -62,10 +62,11 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-wildly-moved-timing-still-exits-zero
-  (testing "the same work done 50x over: the wall-clock distribution
-            moves by that multiple and the run still exits 0. D021 sets
-            no numeric threshold on timing — an adverse trend is
-            attributed and dispositioned, never failed automatically."
+  (testing "the same work done 50x over — exactly 50x by node count,
+            roughly 50x by the clock, and the run still exits 0 either
+            way. D021 sets no numeric threshold on timing: an adverse
+            trend is attributed and dispositioned by a human, never
+            failed automatically. `roughly` is why."
     (let [{:keys [exit-code gate-failures results]} (bench/run [falsifiability/moved-timing] provenance)
           record (first results)]
       (is (= 0 exit-code))


### PR DESCRIPTION
The B-spine harness exists to make D021's split mechanical rather than cultural: deterministic properties are hard gates, wall-clock and byte distributions are published evidence with **no** automatic numeric pass/fail. The control proving that split's second direction is non-vacuous contained exactly the numeric wall-clock threshold D021 forbids everywhere else — and it flaked for precisely the reason D021 gives for banning them. Under six concurrent workers a 50x workload returned an **8.79x** ratio against a required 10x.

A flaky gate is worse than a missing one: it trains readers to re-run rather than read.

## What the control is for, and what changed

`the-moved-timing-really-moved` stops criterion 3 being a tautology. Asserting "a wildly moved timing still exits 0" proves nothing unless the timing genuinely had a reason to move — so the control must show the moved arm really did more work.

It was proving that off the wall clock. It now proves it off a deterministic signal.

The arms gained `:falsifiability/render-nodes` — the exact nodes rendered across the whole burst. The repeat knob moves the three observations differently, which is the point:

| observation | how `repeats` moves it | role |
|---|---|---|
| first tree's node count | **not at all** | the property the timing knob must not touch |
| nodes rendered across the burst | **exactly** its own factor | deterministic workload size — what the proof now reads |
| burst duration | *roughly* its own factor | evidence; load-dependent; read by nothing |

`prove`'s `:move` is now the workload ratio — `40200 / 804 = 50`, on every host under any load. The wall-clock ratio is still computed and reported as `:timing-ratio`, because it is what a reader wants to see, and it now decides nothing.

This is option 1 from the bead. No timing assertion was retained anywhere, so the fallback in option 2 needs no justification.

## The control still reds when the timing is mis-wired as a gate

This is the control's real purpose, so it was verified by actually breaking it. `:falsifiability/render-ms` was temporarily re-declared as the classic folklore threshold — a timing budget as a gate:

```clojure
{:id :falsifiability/render-ms
 :observable :value          ; was :duration-ms
 :expect     #(< % 200)}     ; a wall-clock budget
```

Result: **16 failures, 1 error** (reverted afterwards). The new routing assertion named the fault directly:

```
FAIL in (the-moved-arms-timing-is-evidence-and-not-a-gate)
expected: (contains? (:distribution record) :falsifiability/render-ms)
expected: (not (contains? (:properties record) :falsifiability/render-ms))
```

and `prove` reported it as a defect:

> The moved arm's :falsifiability/render-ms did not route as EVIDENCE: a timing must be a published distribution and never a judged property. Wired as a gate, it turns runner noise into a red build — the failure mode this whole proof exists to detect.

The harness's own `instability-failure` also fired, reporting that a measurement registered as a deterministic property had answered 5 distinct values across the sample set.

Note what stayed correct throughout the mis-wire: `the moved arm did 50.0x the baseline's WORK (40200 vs 804 nodes rendered)`. The deterministic signal is invariant; the **routing** assertion is what catches the mis-wiring. That division of labour is deliberate, and it is why this PR adds `the-moved-arms-timing-is-evidence-and-not-a-gate` — so the routing claim is asserted structurally rather than merely inferred from an exit code.

## Under-load runs

Not an idle box: 24 cores deliberately oversubscribed 2:1 with 48 CPU burners, alongside the other workers active on this machine.

**40 consecutive proofs in one JVM under load:**

```
runs                          : 40
distinct :move values         : [50]   <- deterministic
every run proven?             : true
timing-ratio min / max        : 22.40 / 99.34
timing-ratio spread (max-min) : 76.94
runs under the old 10x gate   : 0
```

**10 separate JVM launches under load** (`clojure -M:bench --prove`, a fresh process each time):

| run | `:move` | `:timing-ratio` |
|---|---|---|
| 1 | 50 | 41.75 |
| 2 | 50 | 46.78 |
| 3 | 50 | 55.19 |
| 4 | 50 | 41.13 |
| 5 | 50 | 39.50 |
| 6 | 50 | 57.20 |
| 7 | 50 | 46.75 |
| 8 | 50 | 39.85 |
| 9 | 50 | 43.04 |
| 10 | 50 | 37.66 |

`:move` was **50 in all 50 runs**. The quantity the old control gated on ranged **22.40 to 99.34** — a 4.4x swing in the same measurement, on the same fixture, on one machine. A reported 8.79 sits in the tail of a distribution that wide, which is the flake, and is why widening the margin would not have been an honest fix.

On an otherwise-quiet box the wall-clock ratio reads ~26x against a workload ratio of 50x: the clock under-reports the work by half before any load at all.

## Why the baseline arm is the fragile end

Worth recording, because it explains the specific number. The ratio's denominator is the baseline arm's p50 — about 3.5 ms over 5 samples. The moved arm is ~91 ms and averages its noise away; the baseline does not. A single scheduling stall landing on the median baseline sample inflates the denominator several-fold and collapses the ratio, which is how a 50x workload reports 8.79x. The deterministic signal has no denominator that noise can reach.

## Quality gates

All run from the rebased branch.

| gate | result |
|---|---|
| `implementation/freehand` → `clojure -M:test` | 463 tests, 3055 assertions, **0 failures, 0 errors** |
| `npm run test:freehand` | 339 tests, 2388 assertions, **0 failures, 0 errors** |
| `npm run test:cljs` | 10460 tests, 52468 assertions, **0 failures, 0 errors** |
| `python scripts/check_freehand_conformance_index.py` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `git grep 're-frame.ui' implementation/freehand/` | empty |

**Worth recording for anyone who hits it.** The first post-rebase `test:cljs` failed to compile, in `scripts/api-manifest/probe/`, with `IllegalStateException: Attempting to call unbound fn: #'shadow.resource/slurp-resource`. That is a stale-classpath-cache symptom rather than a test failure, in a tree this PR does not touch. `6328dca436 fix(api-manifest): make the sidecar a shadow-cljs build dependency` landed on main between my two runs and, by its own commit message, *replaces* `spec/conformance` with `spec/` as the `:source-path` classpath root — while this worktree's `.shadow-cljs/classpath.edn` predated it. Removing `.shadow-cljs` and rebuilding cold compiled 1811 files with 0 warnings and produced the green figure in the table. So: after pulling that commit, warm worktrees need their `.shadow-cljs` cleared once.

Measured before the rebase, the freehand suites isolate this change's own effect: `test:freehand` moved 326 → 327 tests and 2324 → 2329 assertions — +1 test (the new routing control) and +5 assertions (4 in it, 1 added to the reworked control). The larger post-rebase counts are other workers' tests arriving on main.

Scope is `implementation/freehand/src/re_frame/freehand/bench/**` and its test. No public-verb change, so the api-manifest surface is untouched.

Closes rf2-e3jhy.
