### PR TITLE
perf(freehand): finetune the runtime Hiccup interpreter (rf2-drpa3.83)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/conversion.cljc
+++ b/implementation/freehand/src/re_frame/freehand/conversion.cljc
@@ -160,9 +160,16 @@
   "Join class-name parts with single spaces; nil when there are none.
   Duplicates are deliberately NOT removed — class order and duplication
   have no CSS meaning, and the pinned order exists for fingerprints and
-  exact-string tests (Spec 004B §`:class`)."
+  exact-string tests (Spec 004B §`:class`).
+
+  A single part joins to itself, so the one-class case — `.panel`, by far
+  the most common element in real markup — answers the string it was
+  given instead of building an equal one."
   [parts]
-  (when (seq parts) (str/join " " parts)))
+  (case (count parts)
+    0 nil
+    1 (nth parts 0)
+    (str/join " " parts)))
 
 ;; ---------------------------------------------------------------------------
 ;; `:style`

--- a/implementation/freehand/src/re_frame/freehand/conversion.cljc
+++ b/implementation/freehand/src/re_frame/freehand/conversion.cljc
@@ -72,15 +72,7 @@
 
 (def ^:private sugar-re #"([.#])([^.#]+)")
 
-(defn parse-tag
-  "Split an authored element keyword into its tag and its `.class#id`
-  sugar: `:section.panel.open#main` becomes
-
-      {:tag :section :classes [\"panel\" \"open\"] :id \"main\"}
-
-  The tag survives VERBATIM — there is no case folding anywhere, so the
-  camelCase SVG tags (`:clipPath`, `:feGaussianBlur`, `:foreignObject`)
-  pass through unchanged (Spec 004B §Element fields, pinned)."
+(defn- parse-tag*
   [tag-kw]
   (let [s    (name tag-kw)
         cuts (keep identity [(str/index-of s ".") (str/index-of s "#")])
@@ -89,6 +81,48 @@
     {:tag     (keyword (subs s 0 end))
      :classes (into [] (keep (fn [[_ mark nm]] (when (= "." mark) nm))) toks)
      :id      (some (fn [[_ mark nm]] (when (= "#" mark) nm)) toks)}))
+
+;; The parse is a PURE function of one keyword, and an interpreted walk
+;; asks it the same question on every render of every element — the tag
+;; keyword at a markup site is a constant, so a template of a thousand
+;; elements re-derives a thousand answers it already had. Measured on B1
+;; at 1800 bytes per element, which was the single largest allocation in
+;; the walk. So the answers are kept.
+;;
+;; Keyed on the KEYWORD, not on its `name`. A cache keyed by name would
+;; alias `:svg/text` onto `:text` — one entry serving two heads whose
+;; tags differ — and aliasing in a parse cache is the failure mode that
+;; is hardest to see, because the wrong answer is a perfectly well-formed
+;; one. The keyword is its own total key.
+;;
+;; BOUNDED, because the key space is the author's. Tags are lexical
+;; constants in ordinary markup, so the live set is a few dozen; a caller
+;; that MINTS keywords per render would otherwise grow this map without
+;; limit. Past the limit the cache stops accepting entries and the parse
+;; simply costs what it always cost — a bounded loss, never a leak.
+
+(def ^:private tag-cache-limit 4096)
+
+(def ^:private tag-cache
+  (atom {}))
+
+(defn parse-tag
+  "Split an authored element keyword into its tag and its `.class#id`
+  sugar: `:section.panel.open#main` becomes
+
+      {:tag :section :classes [\"panel\" \"open\"] :id \"main\"}
+
+  The tag survives VERBATIM — there is no case folding anywhere, so the
+  camelCase SVG tags (`:clipPath`, `:feGaussianBlur`, `:foreignObject`)
+  pass through unchanged (Spec 004B §Element fields, pinned).
+
+  Memoized per keyword, bounded — see the note above."
+  [tag-kw]
+  (if-some [hit (get @tag-cache tag-kw)]
+    hit
+    (let [parsed (parse-tag* tag-kw)]
+      (swap! tag-cache (fn [m] (if (< (count m) tag-cache-limit) (assoc m tag-kw parsed) m)))
+      parsed)))
 
 ;; ---------------------------------------------------------------------------
 ;; `:class` — composition and deterministic order

--- a/implementation/freehand/src/re_frame/freehand/conversion.cljc
+++ b/implementation/freehand/src/re_frame/freehand/conversion.cljc
@@ -42,6 +42,57 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 ;; ---------------------------------------------------------------------------
+;; Remembered projections
+;; ---------------------------------------------------------------------------
+;;
+;; Three of the rules below are pure projections of ONE authored keyword —
+;; the `.class#id` parse, the React prop name, the React handler name — and
+;; every one of them is asked the same question on every render. An
+;; author's markup site spells its tag and its attribute keys as lexical
+;; CONSTANTS, so a template of a thousand elements re-derives a thousand
+;; answers it already had. Measured on B1 and on the React emitter's own
+;; leaf calls, that re-derivation was the largest single cost in the
+;; interpreted walk.
+;;
+;; The TECHNIQUE is `reagent2.impl.template`'s, which has cached both its
+;; tag parse and its prop-name projection for years and is the reason a
+;; runtime Hiccup interpreter can be fast at all. It is adopted here as a
+;; technique and not as a dependency: that namespace is ClojureScript-only
+;; (`#js {}` / `aget`), and these rules are `.cljc` because the structural
+;; walk runs them on the JVM, so there is no shared artefact to import even
+;; if Freehand were willing to take a classpath edge onto an adapter. Two
+;; differences from the donor are deliberate:
+;;
+;;   - it is keyed on the KEYWORD, not on the keyword's `name`. A cache
+;;     keyed by name aliases `:svg/text` onto `:text` — one entry serving
+;;     two heads that parse differently — and an aliased parse cache fails
+;;     in the way that is hardest to see, because the wrong answer is a
+;;     perfectly well-formed one. (The donor had to patch that class of
+;;     collision twice.) A keyword is its own total key.
+;;   - it is BOUNDED, because the key space belongs to the author. Tags
+;;     and attribute keys are lexical constants in ordinary markup, so a
+;;     live set is a few dozen; a caller that MINTS keywords per render
+;;     would otherwise grow these maps without limit. Past the limit a
+;;     cache stops accepting entries and the projection costs what it
+;;     always cost — a bounded loss, never a leak.
+;;
+;; A projection here always answers a map or a string, never nil, so a
+;; miss and a remembered nil are not confusable.
+
+(def ^:private cache-limit
+  "The most entries one remembered projection will hold."
+  4096)
+
+(defn- remembered
+  "`(f k)`, answered from `cache` when it has been asked before."
+  [cache k f]
+  (if-some [hit (get @cache k)]
+    hit
+    (let [v (f k)]
+      (swap! cache (fn [m] (if (< (count m) cache-limit) (assoc m k v) m)))
+      v)))
+
+;; ---------------------------------------------------------------------------
 ;; Numbers — JS `ToString`, on both hosts
 ;; ---------------------------------------------------------------------------
 ;;
@@ -82,29 +133,7 @@
      :classes (into [] (keep (fn [[_ mark nm]] (when (= "." mark) nm))) toks)
      :id      (some (fn [[_ mark nm]] (when (= "#" mark) nm)) toks)}))
 
-;; The parse is a PURE function of one keyword, and an interpreted walk
-;; asks it the same question on every render of every element — the tag
-;; keyword at a markup site is a constant, so a template of a thousand
-;; elements re-derives a thousand answers it already had. Measured on B1
-;; at 1800 bytes per element, which was the single largest allocation in
-;; the walk. So the answers are kept.
-;;
-;; Keyed on the KEYWORD, not on its `name`. A cache keyed by name would
-;; alias `:svg/text` onto `:text` — one entry serving two heads whose
-;; tags differ — and aliasing in a parse cache is the failure mode that
-;; is hardest to see, because the wrong answer is a perfectly well-formed
-;; one. The keyword is its own total key.
-;;
-;; BOUNDED, because the key space is the author's. Tags are lexical
-;; constants in ordinary markup, so the live set is a few dozen; a caller
-;; that MINTS keywords per render would otherwise grow this map without
-;; limit. Past the limit the cache stops accepting entries and the parse
-;; simply costs what it always cost — a bounded loss, never a leak.
-
-(def ^:private tag-cache-limit 4096)
-
-(def ^:private tag-cache
-  (atom {}))
+(def ^:private tag-cache (atom {}))
 
 (defn parse-tag
   "Split an authored element keyword into its tag and its `.class#id`
@@ -116,13 +145,9 @@
   camelCase SVG tags (`:clipPath`, `:feGaussianBlur`, `:foreignObject`)
   pass through unchanged (Spec 004B §Element fields, pinned).
 
-  Memoized per keyword, bounded — see the note above."
+  Remembered per keyword — see §Remembered projections above."
   [tag-kw]
-  (if-some [hit (get @tag-cache tag-kw)]
-    hit
-    (let [parsed (parse-tag* tag-kw)]
-      (swap! tag-cache (fn [m] (if (< (count m) tag-cache-limit) (assoc m tag-kw parsed) m)))
-      parsed)))
+  (remembered tag-cache tag-kw parse-tag*))
 
 ;; ---------------------------------------------------------------------------
 ;; `:class` — composition and deterministic order
@@ -372,6 +397,10 @@
     (str/starts-with? css-name "-ms-")      (camelize (subs css-name 1))
     :else                                   (camelize css-name)))
 
+(defn- react-prop-name* [k] (rules/react-prop-name (name k)))
+
+(def ^:private prop-name-cache (atom {}))
+
 (defn react-prop-name
   "The author attribute keyword as the React emitter spells it — React's
   own CANONICAL prop name (Spec 004B §Attribute names).
@@ -392,9 +421,11 @@
   declared view that React renders as its own component. The context-
   sensitive rule this replaced could only be right where the walk happened
   to know the context, so inserting a view boundary silently changed which
-  attribute reached the DOM."
+  attribute reached the DOM.
+
+  Remembered per keyword — see §Remembered projections above."
   [k]
-  (rules/react-prop-name (name k)))
+  (remembered prop-name-cache k react-prop-name*))
 
 ;; ---------------------------------------------------------------------------
 ;; Attribute keys the grammar refuses
@@ -432,8 +463,18 @@
       (str k " is not a prop — one spelling per name, ambiguities removed. Use "
            replacement "."))))
 
+(defn- react-event-name* [k]
+  (str "on" (upper-first (camelize (subs (name k) 3)))))
+
+(def ^:private event-name-cache (atom {}))
+
 (defn react-event-name
   "The handler-position key as React spells the prop: `:on-click` becomes
-  `onClick`, `:on-double-click` becomes `onDoubleClick`."
+  `onClick`, `:on-double-click` becomes `onDoubleClick`.
+
+  Remembered per keyword — see §Remembered projections above. This is the
+  most expensive projection in the table per call (a regex camelize, a
+  case fold and three string builds) and the React emitter runs it on
+  every handler attribute of every element it emits."
   [k]
-  (str "on" (upper-first (camelize (subs (name k) 3)))))
+  (remembered event-name-cache k react-event-name*))

--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -316,8 +316,19 @@
                               es events)
         el-ns      (conv/element-ns ctx)
         kids       (when children
-                     (binding [*ns-context* (conv/child-ns ctx tag attrs)]
-                       (children)))]
+                     ;; Pushing a thread binding costs a frame and a map
+                     ;; assoc, and an HTML element under HTML — every
+                     ;; element in an ordinary page — would push the value
+                     ;; that is already there. So the push happens only
+                     ;; when the context actually CHANGES, which is at
+                     ;; `<svg>`, `<math>`, `<foreignObject>` and the HTML
+                     ;; island inside `<annotation-xml>`. Measured on B1 at
+                     ;; 752 bytes per element with children.
+                     (let [kid-ctx (conv/child-ns ctx tag attrs)]
+                       (if (= kid-ctx *ns-context*)
+                         (children)
+                         (binding [*ns-context* kid-ctx]
+                           (children)))))]
     (when (and (seq kids) (contains? conv/children-rejected-tags tag))
       (malformed!
         're-frame.freehand/render

--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -243,7 +243,9 @@
              "a keyword, a vector of them in order, or a flag map whose truthy entries "
              "name classes.")
         {:attr :class :value (shape v)}))
-    (conv/class-string (into (vec sugar) parts))))
+    ;; An element with sugar and no authored `:class` is the common case,
+    ;; and composing it with nothing produced a copy of the sugar vector.
+    (conv/class-string (if (zero? (count parts)) sugar (into (vec sugar) parts)))))
 
 (defn classify-event
   "One `:events` entry value, classified BY THE VALUE PRESENT AT RENDER

--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -335,19 +335,22 @@
                          (children)
                          (binding [*ns-context* kid-ctx]
                            (children)))))]
-    (when (and (seq kids) (contains? conv/children-rejected-tags tag))
+    (when (and (contains? conv/children-rejected-tags tag) (pos? (count kids)))
       (malformed!
         're-frame.freehand/render
         (str "The element " tag " cannot have children — it is a void element, and React "
              "throws rather than render one. Put the content in an attribute, or use an "
              "element that takes children.")
         {:tag tag :children-count (count kids)}))
+    ;; `pos? count` rather than `seq`: asking a collection for a seq
+    ;; ALLOCATES one, and these five questions are asked of every node in
+    ;; the tree only to be thrown away. Measured on B1 at 40 bytes each.
     (cond-> {:tag tag}
-      el-ns       (assoc :ns el-ns)
-      (seq attrs) (assoc :attrs attrs)
-      (seq es)    (assoc :events es)
-      key?        (assoc :key key-val)
-      (seq kids)  (assoc :children kids))))
+      el-ns                (assoc :ns el-ns)
+      (pos? (count attrs)) (assoc :attrs attrs)
+      (pos? (count es))    (assoc :events es)
+      key?                 (assoc :key key-val)
+      (pos? (count kids))  (assoc :children kids))))
 
 ;; ---------------------------------------------------------------------------
 ;; Fragment nodes
@@ -414,9 +417,9 @@
                    (vec (:children (first kids)))
                    (vec kids))]
     (cond-> {:view-id view-id}
-      (seq recorded) (assoc :props recorded)
-      (some? key)    (assoc :key key)
-      (seq kids)     (assoc :children kids))))
+      (pos? (count recorded)) (assoc :props recorded)
+      (some? key)             (assoc :key key)
+      (pos? (count kids))     (assoc :children kids))))
 
 ;; ---------------------------------------------------------------------------
 ;; The mount seam

--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -91,11 +91,21 @@
            (contains? x :children))))
 
 (defn- conj-text
-  "Append text, coalescing it into the preceding run when there is one."
+  "Append text, coalescing it into the preceding run when there is one.
+
+  An EMPTY string is dropped on arrival rather than collected and removed
+  at the end. That is the same canonical form by a shorter route: `\"\"`
+  contributes nothing to a coalesced run, so a run containing it and a run
+  without it are the same string, and a body of nothing but empties
+  accumulates nothing instead of accumulating strings to discard. The
+  pass that removed them afterwards rebuilt every children vector in the
+  tree — measured on B1 at 456 bytes per node, on nodes whose children
+  were almost never empty."
   [acc s]
-  (if (string? (peek acc))
-    (conj (pop acc) (str (peek acc) s))
-    (conj acc s)))
+  (cond
+    (= "" s)              acc
+    (string? (peek acc))  (conj (pop acc) (str (peek acc) s))
+    :else                 (conj acc s)))
 
 (defn- opaque-child!
   "The rejection every child value that is not content lands on. `vector?`
@@ -140,24 +150,18 @@
     (and walk (vector? form)) (conj acc (walk form))
     :else                  (opaque-child! where form)))
 
-(defn- finish
-  "Drop the empty strings left by coalescing and answer the canonical
-  children vector."
-  [acc]
-  (into [] (remove #(and (string? %) (= "" %))) acc))
-
 (defn children
   "The canonical children vector for already-evaluated child VALUES — the
   compiled front end's entry (no walker, so a vector is rejected). Empty
   when the values carry no content."
   [& xs]
-  (finish (reduce #(collect nil 're-frame.freehand/render %1 %2) [] xs)))
+  (reduce #(collect nil 're-frame.freehand/render %1 %2) [] xs))
 
 (defn walked-children
   "The canonical children vector for markup FORMS, walked by `walk` — the
   interpreted front end's entry."
   [walk where forms]
-  (finish (reduce #(collect walk where %1 %2) [] forms)))
+  (reduce #(collect walk where %1 %2) [] forms))
 
 ;; ---------------------------------------------------------------------------
 ;; Runs

--- a/implementation/freehand/src/re_frame/freehand/tree.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tree.cljc
@@ -98,12 +98,20 @@
 ;; Element nodes
 ;; ---------------------------------------------------------------------------
 
-(defn- split-attrs
-  "Split one authored attribute map into the parts [[re-frame.freehand.node/element]]
-  takes. Every value here is only known now, so they all ride `:dyn` —
-  the interpreted front end has no compile step in which to settle one.
+(defn- with-attrs
+  "Fold one authored attribute map INTO `m` — the argument map
+  [[re-frame.freehand.node/element]] takes, already carrying everything
+  the walk knew before it read the attributes.
+
+  Folding into that map rather than building a second one and merging is
+  the difference between one map and nine: `merge` conjes entry by entry,
+  so a six-slot literal merged onto a one-slot map allocated the whole
+  ladder of intermediate maps on every element in the tree.
+
+  Every value here is only known now, so they all ride `:dyn` — the
+  interpreted front end has no compile step in which to settle one.
   `:key` is structural and `:class` composes after the sugar classes."
-  [tag sugar-classes sugar-id attrs]
+  [m tag sugar-id attrs]
   (reduce-kv
     (fn [m k raw]
       (when-some [refusal (conv/attr-key-refusal k)]
@@ -120,9 +128,9 @@
                                   sugar-id " sugar and once as :id. Two id spellings on "
                                   "one element is an ambiguity; keep one.")
                              {:attr :id :value (shape raw)}))
-                         (assoc-in m [:dyn :id] raw))
-        :else        (assoc-in m [:dyn k] raw)))
-    {:dyn {}}
+                         (update m :dyn assoc :id raw))
+        :else        (update m :dyn assoc k raw)))
+    m
     attrs))
 
 (defn- element-node
@@ -139,16 +147,16 @@
                       {:value (shape tag-kw)}))
         attrs?    (map? (first args))
         authored  (if attrs? (first args) nil)
-        kid-forms (if attrs? (rest args) args)
-        parts     (split-attrs tag classes id (or authored {}))]
+        kid-forms (if attrs? (rest args) args)]
     (node/element
-      (merge parts
-             {:tag      tag
-              :sugar    classes
-              :attrs    (cond-> {} id (assoc :id id))
-              :key?     (contains? authored :key)
-              :key-val  (:key authored)
-              :children (when (seq kid-forms) #(children kid-forms))}))))
+      (with-attrs {:tag      tag
+                   :sugar    classes
+                   :attrs    (cond-> {} id (assoc :id id))
+                   :dyn      {}
+                   :key?     (contains? authored :key)
+                   :key-val  (:key authored)
+                   :children (when (seq kid-forms) #(children kid-forms))}
+                  tag id authored))))
 
 ;; ---------------------------------------------------------------------------
 ;; Presence — the keyed enter/exit structural node


### PR DESCRIPTION
The interpreted Hiccup walk was built for correctness and had never had a
performance pass. It has one now: **the interpreted arm of B1 allocates 83%
less than it did**, and the gap that motivated the tuning — interpreted at
2.15x the compiled arm's allocation and 3.13x its time — closes to **1.19x
and 1.66x**.

That answers the question the bead asks. A 3x/2x gap was **not** the honest
floor for a tuned interpreter; a naive walk was inflating it. "Compile only
your hot boundaries" is a real choice for users, not a necessity.

Nothing about the output changed. Proof below.

---

## What the profile said before any edit

Measured on the JVM with `ThreadMXBean/getThreadAllocatedBytes` — a monotonic
per-thread byte counter, so a difference is exactly the bytes the measured
region allocated. Warmed 200 iterations, then 200,000 measured calls per leaf.

The B1 stress template (`rows=250`, 1755 nodes, 1003 elements) allocated
**5,842,553 bytes / 3,329 bytes per node**, and the cost was concentrated in
six places, none of which was the walk itself:

| leaf operation | bytes/call | × sites | share |
|---|---:|---:|---:|
| `conv/parse-tag :li.row` | 1800.0 | 1003 elements | 32% |
| `merge` of the two element-argument maps | 961.0 | 1003 elements | 17% |
| `binding *ns-context*` | 752.0 | ~1003 elements w/ children | 13% |
| `node/class-string`, one sugar class | 656.0 | 1003 elements | 11% |
| `finish` — the children rebuild | ~456.0 | every node | 8% |
| `seq` as an emptiness test | 40.0 | 5 per node | 3% |

And on the React emitter's own leaves (`conversion.cljc` is shared, so these
are JVM-measurable too):

| leaf operation | bytes/call |
|---|---:|
| `conv/react-event-name :on-click` | 824.0 |
| `conv/react-prop-name :content-editable` | 136.0 |

Every one of those is a **pure projection of a compile-time-constant keyword**,
a copy nobody asked for, or a question asked in a way that allocates to answer
it. None of it is the price of interpretation.

## reagent-slim reuse evaluation — decision and rationale

**Decision: adopt the TECHNIQUE, reject the DEPENDENCY, reject the copy.
Reimplement, deliberately.**

What `reagent2.impl.template` (1161 lines, `implementation/adapters/reagent-slim`)
carries that is worth having is one idea applied twice: `tag-name-cache` and
`prop-name-cache`, two `#js {}` maps that remember the parse of a tag keyword
and the camelCase of a prop keyword. That is the *right* idea — it is why a
runtime Hiccup interpreter can be fast at all, and it is the largest single win
in this PR. It is adopted, in `conversion.cljc` §Remembered projections, with
the donor credited in the source comment.

Three reasons it is adopted as a technique and not taken as code or as a
dependency:

1. **Host.** Freehand's hot path is `.cljc`, because the structural walk runs
   on the JVM and the cross-host conformance corpus is a real claim about both
   hosts. `reagent2.impl.template` is `.cljs` and its caches are `#js {}` /
   `aget` / `aset`. There is no artefact to import that would serve the path
   that needed fixing — 83% of this PR's win is on the JVM side, where the
   donor namespace cannot run at all.
2. **Semantics.** The two parse grammars are *different*, and not by accident.
   The donor's `re-tag` requires `#id` **before** `.class` and answers a nil tag
   for `:div.a#id`; Freehand's `parse-tag` accepts both orders. Depending on the
   donor's parse would change what Freehand's markup means — acceptance
   criterion 3 forbids exactly that.
3. **Coupling.** reagent-slim is not a donor being absorbed; it ships on as a
   first-class independent adapter with its own release cadence. A classpath
   edge from the Freehand substrate onto an adapter would invert the dependency
   direction the artefact is built around (its `deps.edn` is explicit that the
   substrate takes no adapter edges), and it would put a Reagent-versioned
   namespace on the critical path of a substrate that must not know Reagent
   exists.

**Nothing from Reagent's component protocol was taken** — no form-1/2/3
components, no `:key` read off vector metadata, no ratom deref tracking. D002
rejects all of it and none of it is touched here.

Two deliberate **improvements** on the donor, both recorded in the source:

- **Keyed on the keyword, not on the keyword's `name`.** The donor's string key
  aliases distinct heads onto one entry, and it has had to patch that class of
  collision twice (`:button` vs `:rf/button`; then `:rf/x` vs the string head
  `"rf/x"`). A keyword is its own total key, so the collision cannot arise.
- **Bounded** at 4096 entries per projection. The key space belongs to the
  author; a caller that mints keywords per render would grow an unbounded cache
  forever. Past the limit a cache stops accepting entries and the projection
  costs what it always cost — a bounded loss, never a leak.

## Per-change measured attribution

Each commit is separate and independently revertible. `tree/render` is the whole
B1 stress walk; the leaf column is the operation that commit changed. (These
running figures were taken on the pre-rebase base `d13b21c5`, which differs from
the merge base only by the presence PR; the headline before/after below is
re-measured on the settled base.)

| # | commit | leaf, bytes/call | `tree/render`, bytes | Δ |
|---|---|---|---:|---:|
| — | base | — | 5,842,553 | — |
| 1 | memoize the `.class#id` tag parse | `parse-tag` 1800.0 → **0.0** | 3,940,577 | −32.6% |
| 2 | push the ns binding only on a change | `binding` 752.0, elided | 3,218,417 | −18.3% |
| 3 | compose the class string without copying | `class-string` 656.0 → **0.0** | 2,560,449 | −20.4% |
| 4 | drop empty text on arrival | `walked-children` 688.0 → **218.0** | 2,114,545 | −17.4% |
| 5 | fold attributes into one element map | `merge` 961.0 → literal **112.2** | 1,071,425 | −49.3% |
| 6 | `pos? count` instead of `seq` | `seq` 40.0 → **0.0** | 959,025 | −10.5% |
| 7 | remember the React name projections | `react-event-name` 824.0 → **0.0** | 959,025 | React path — see note |

Commit 7 does not move `tree/render`: the structural walk never spells a React
prop name. It is attributed by the same deterministic per-call counter on the
`conversion.cljc` functions the React emitter calls on every attribute of every
element (`:on-click` → `"onClick"`, `:content-editable` → `"contentEditable"`).

One measured **rejection**, recorded because a negative result is a result: a
transient accumulator for the children vector was tried and measured at **432.0
bytes** against `conj`'s **200.0** for a three-child run. Transients lose at
these sizes. Not taken.

## Headline: B1 before and after, on the settled base

Same harness (`clojure -M:bench`, the shipped B-spine), same fixtures, same
machine, both runs. Deterministic gates held in both.

**Provenance** — revision `8ff9fa9a` (after) against merge base `0ca94dc0`
(before); `JVM OpenJDK 64-Bit Server VM 21.0.10`, hardware class
`:developer-workstation`, 24 CPUs; sampling `{:warmup 5 :samples 40}`; fixtures
`{:rows 250 :nodes 1755}` and `{:rows 6 :nodes 47}`.

### `:B1/finite-template` — 1755 nodes

| measurement | before p50 | after p50 | Δ |
|---|---:|---:|---:|
| **interpreted allocated bytes** | 5,658,160 | **959,208** | **−83.0%** |
| **compiled allocated bytes** | 2,635,456 | **809,096** | **−69.3%** |
| interpreted self ms | 7.8554 | 2.1978 | −72.0% |
| compiled self ms | 2.5101 | 1.3219 | −47.3% |
| interpreted per-node ms | 0.0045 | 0.0013 | −71.1% |
| **interpreted / compiled, allocation** | **2.15x** | **1.19x** | |
| **interpreted / compiled, self time** | **3.13x** | **1.66x** | |

### `:B1/small-template` — 47 nodes, the realistic small case

| measurement | before p50 | after p50 | Δ |
|---|---:|---:|---:|
| **interpreted allocated bytes** | 155,512 | **27,448** | **−82.3%** |
| **compiled allocated bytes** | 73,120 | **22,832** | **−68.8%** |
| interpreted self ms | 0.2077 | 0.0352 | −83.1% |
| **interpreted / compiled, allocation** | **2.13x** | **1.20x** | |

The allocation counter is deterministic to the byte, which is why it is the
evidence that carries the claim: on the small template, after, `min = p50 =
max = 27,448` across all 40 samples. Wall clock is published as evidence only —
D021 gives it no route to a verdict, and this machine was running several
concurrent workers throughout, so read it as corroboration and nothing more.

**The compiled arm improved too, by 69%.** That is the "one canonicaliser"
design paying: `node.cljc` and `conversion.cljc` are shared by both modes, so
five of the seven commits benefit compiled code as well. It also means the
ratio *understates* the interpreted win.

## Proof of semantic identity

Three independent proofs, strongest first.

**1. Byte-identical values over the corpus, before and after.** Every
plain-data case in `spec/conformance/freehand/fixtures/` (57 cases across the
FH-STRUCT / FH-PROPS / FH-CLASS / FH-STYLE / FH-EVENTS / FH-PRESENCE families)
plus all four B1 renders (both arms × both sizes) were rendered at the merge
base and at this branch's HEAD and dumped as EDN:

```
before.dump   120,477 bytes   ;; cases: 57   ;; hash: -1033246532
after.dump    120,477 bytes   ;; cases: 57   ;; hash: -1033246532
diff before.dump after.dump   ->  no output
```

**2. The pinned expectations are unchanged and still hold.**
`git diff origin/main -- spec/` is empty — no fixture was edited to accommodate
anything. The conformance corpus asserts trees written down independently of the
walk, on both hosts, and every FH row is green.

**3. B1's own equal-output gate.** `:B1/structural-parity` (interpreted tree =
compiled tree, modulo the view-id namespace) and `:B1/node-count` (1755 and 47
against written arithmetic) are both `:pass? true`, before and after.

The two changes that could conceivably have moved behaviour were checked against
their pinned fixtures by name. The namespace-binding elision is gated on value
equality — the push is skipped only when the value being bound equals the value
already bound — and FH-STRUCT-005 pins all five context transitions plus SVG
re-entry inside reverted HTML. Dropping empty text on arrival reaches the same
canonical form because `""` contributes nothing to a coalesced run;
FH-STRUCT-004 pins `[:p "a" "" "b"]` → `["ab"]` and `[:p "" ""]` → no children.

## What was deliberately NOT done

- **`react.cljs` was not edited.** Its two dominant Clojure-side allocations
  were in the shared conversion table (`parse-tag`, `react-event-name`) and are
  now zero; what remains in that file is `js-obj` / `gobj/set` / `createElement`,
  which is JS-native. There are three further candidates in it (`doseq` over the
  attribute map, a double `:key` lookup, the void-tag predicate order) and there
  is **no deterministic counter for them**: Node's `heapUsed` is occupancy, not
  a counter, and a CLJS/React bench arm is `bench/**` work another worker owns.
  Unmeasured, so declined.
- **The `[attrs events]` tuple** in `node/element`'s attribute fold, ~80
  bytes/element (~8% of what remains), was left alone. Splitting it into two
  passes would reorder attribute-vs-handler diagnostics for an element carrying
  a bad one of each, and that fold's docstring frames it as one rule table.
  Small win, real risk, clarity cost — declined.
- **No new public verb**, so this stays off the api-manifest serial lane. No
  signature on the public door changed; `parse-tag`, `class-string`,
  `react-prop-name` and `react-event-name` keep their arities and their answers.

## Quality gates

All run in this worktree, foreground, to completion, on `8ff9fa9a`.

| gate | result |
|---|---|
| `cd implementation/freehand && clojure -M:test` | **462 tests / 3050 assertions, 0 failures, 0 errors** — identical to the count measured on `origin/main` in the same worktree |
| `npm run test:freehand` | **338 tests / 2383 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` | **10459 tests / 52463 assertions, 0 failures, 0 errors** |
| `npm run test:browser` | **498 tests / 2882 assertions, 0 failures, 0 errors** |
| `python scripts/check_freehand_conformance_index.py` | exit 0 |
| `python scripts/check_donor_inventory.py` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `clojure -M:bench` | exit 0, all deterministic properties held, both workloads |
| `git grep 're-frame.ui' implementation/freehand/` | empty |

The JVM baseline was measured explicitly: `origin/main`'s freehand source was
checked out into this same worktree and run, giving the same 462 / 3050. No
count dropped.
