### PR TITLE
fix(freehand): checker cljs-build workflow + per-site manifest coordinates (rf2-drpa3.80, rf2-drpa3.82)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand.cljc
+++ b/implementation/freehand/src/re_frame/freehand.cljc
@@ -343,17 +343,26 @@
       (v/manifest people-list)
       ;; => {:view-id       :app.people/people-list
       ;;     :grammar       :re-frame.freehand/v1
-      ;;     :subscriptions [{:sid … :query [:person 7] :path [0]}]
+      ;;     :subscriptions [{:sid … :query [:person 7]
+      ;;                      :source-coord {:file … :line 42 :column 12}
+      ;;                      :path [0]}]
       ;;     :events [] :slots [] :html-sites [] :frame-ops []
       ;;     :capabilities  #{:sub}
       ;;     :reactive?     true
       ;;     :view-cell     :present
       ;;     :crossings     [{:view-id :re-frame.freehand/markup
-      ;;                      :lowering :interpreted :path [1]}]}
+      ;;                      :lowering :interpreted
+      ;;                      :source-coord {:file … :line 44 :column 3}
+      ;;                      :path [1]}]}
 
   The `:subscriptions` / `:events` / `:slots` / `:html-sites` /
   `:frame-ops` rosters are the view's finite lexical sites and
-  `:capabilities` their union with the structural capability bits.
+  `:capabilities` their union with the structural capability bits. EVERY
+  roster entry carries a `:source-coord` — the coordinates of the form
+  that produced it, or of the enclosing declaration where the reader
+  anchored no narrower position — so a manifest fact is traceable to the
+  source that made it, and never a position the source would not agree
+  with.
   `:reactive?` / `:view-cell` carry the **capability-elision** verdict: a
   view with no reactive site (no `sub`, no committed handler, no
   `dispatch-fn`, no `(frame)`) omits the reactive ViewCell shell, which is

--- a/implementation/freehand/src/re_frame/freehand/compiler.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler.cljc
@@ -531,23 +531,32 @@
 
       {:view-id       :app.people/people-list
        :grammar       :re-frame.freehand/v1
-       :subscriptions [{:sid \"…\" :query [:person/by-id 7] :path [0]}]
+       :subscriptions [{:sid \"…\" :query [:person/by-id 7]
+                        :source-coord {…} :path [0]}]
        :events        [{:sid \"…\" :source-coord {…} :path [1 0]}]
-       :slots         [{:sid \"…\" :inline? true :path [2]}]
+       :slots         [{:sid \"…\" :inline? true :source-coord {…} :path [2]}]
        :html-sites    []
        :frame-ops     []
        :capabilities  #{:sub :event}
        :reactive?     true
        :view-cell     :present
-       :crossings     [{:view-id :app.people/person-row
-                        :lowering :compiled    :path [0 :for]}
-                       {:view-id :re-frame.freehand/markup
-                        :lowering :interpreted :path [1]}]}
+       :crossings     [{:view-id :app.people/person-row  :lowering :compiled
+                        :source-coord {…} :path [0 :for]}
+                       {:view-id :re-frame.freehand/markup :lowering :interpreted
+                        :source-coord {…} :path [1]}]}
 
   - `:subscriptions` / `:events` / `:slots` / `:html-sites` / `:frame-ops`
     are the view's finite reactive, intent, render-slot, trusted-markup
     and committed-frame site rosters — the same lexical sites the
     analyzer indexed, projected to their statically knowable facts.
+  - EVERY roster entry carries a `:source-coord` — `{:file :line :column}`
+    of the form that produced it, or of the enclosing declaration when the
+    reader anchored no narrower position (see
+    [[re-frame.freehand.compiler.analyze]]). Total and never invented, so a
+    manifest fact and a build-log line name the same lexical position, and
+    a diagnostic can say which SITE a capability came from rather than only
+    which view. The `:path` beside it is the deterministic occurrence
+    coordinate and answers a different question.
   - `:capabilities` is the union of the structural and reactive
     capability bits ([[compiled-capabilities]]).
   - `:reactive?` and `:view-cell` carry the **capability-elision** verdict
@@ -570,15 +579,16 @@
   (let [elided? (view-cell-elided? sites)]
     {:view-id       view-id
      :grammar       grammar/version
-     :subscriptions (mapv #(select-keys % [:sid :query :path]) (:subs sites))
+     :subscriptions (mapv #(select-keys % [:sid :query :source-coord :path]) (:subs sites))
      :events        (mapv #(select-keys % [:sid :source-coord :path]) (:events sites))
      :slots         (mapv #(select-keys % [:sid :inline? :source-coord :path]) (:slots sites))
-     :html-sites    (mapv #(select-keys % [:path]) (:htmls sites))
-     :frame-ops     (mapv #(select-keys % [:sid :path]) (:frame-ops sites))
+     :html-sites    (mapv #(select-keys % [:source-coord :path]) (:htmls sites))
+     :frame-ops     (mapv #(select-keys % [:sid :source-coord :path]) (:frame-ops sites))
      :capabilities  (compiled-capabilities ast sites)
      :reactive?     (not elided?)
      :view-cell     (if elided? :elided :present)
-     :crossings     (vec (:views sites))}))
+     :crossings     (mapv #(select-keys % [:view-id :lowering :source-coord :path])
+                          (:views sites))}))
 
 (defn compile-structural-view
   "Lower a `{:compiled true}` declaration's body to its STRUCTURAL

--- a/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
@@ -434,6 +434,29 @@
    [1 (:self-id e) kind (relative-source-anchor e form)
     (:path e) (vec expr-path)]))
 
+(defn- site-source-coord
+  "The authored `{:file :line :column}` for a manifest site whose form is
+  `form` — its OWN reader position when the reader anchored it, else the
+  declaration's.
+
+  TOTAL and never invented. Every roster entry carries a coordinate, so a
+  manifest fact and a build-log line can name the same lexical position;
+  and the coordinate is always one a reader really produced. The reader
+  anchors lists on both hosts and macro-generated templates carry no
+  metadata at all, so a site whose form was not anchored inherits its
+  enclosing DECLARATION's position — the widest true statement available —
+  rather than a fabricated line the source would not agree with.
+
+  It is the AUTHORED coordinate and nothing else. The template `:path`
+  beside it is the deterministic occurrence coordinate and answers a
+  different question; neither is derivable from the other."
+  [e form]
+  (let [m    (meta form)
+        base (:source e)]
+    (cond-> (select-keys base [:file :line :column])
+      (:line m)   (assoc :line (:line m))
+      (:column m) (assoc :column (:column m)))))
+
 (declare rewrite-expr)
 
 (defn- map-path-token [x]
@@ -943,6 +966,7 @@
                      (let [sid   (lexical-site-id e :sub f p)
                            query (rw (second f) locals (conj p :query))]
                        (env/add-site! e :subs {:sid sid :query (second f)
+                                               :source-coord (site-source-coord e f)
                                                :path (:path e) :expr-path (vec p)})
                        (with-same-meta f (list runtime-sub-fqn sid query))))
 
@@ -970,6 +994,7 @@
                                      {:form f})))
                       (let [sid (lexical-site-id e :frame f p)]
                         (env/add-site! e :frame-ops {:sid sid
+                                                     :source-coord (site-source-coord e f)
                                                      :path (:path e)
                                                      :expr-path (vec p)})
                         (with-same-meta f (list runtime-frame-ops-fqn))))
@@ -1350,23 +1375,12 @@
                               "ordinary keywords")
                     :form vec-form}))))
 
-(defn- event-source-coord
-  "Best available authored coordinate for an event site. Reader metadata on
-  the handler wins; macro-generated forms fall back to the defview anchor.
-  The template path remains a separate, deterministic occurrence coordinate."
-  [e form]
-  (let [m    (meta form)
-        base (:source e)]
-    (cond-> (select-keys base [:file :line :column])
-      (:line m)   (assoc :line (:line m))
-      (:column m) (assoc :column (:column m)))))
-
 (defn- event-site-identity
   [e k form]
   {:sid          (lexical-site-id e :event form [:handler k])
    :site-index   (count (:events @(:sites e)))
    :view-id      (:self-id e)
-   :source-coord (event-source-coord e form)
+   :source-coord (site-source-coord e form)
    :path         (:path e)})
 
 (defn- add-event-site!
@@ -2093,6 +2107,8 @@
                        (env/add-site! e :htmls {:form s*
                                                 :static? (string? s)
                                                 :serializable? (string? s)
+                                                :source-coord (site-source-coord
+                                                               e (first child-fs))
                                                 :path (:path e)})
                        {:op :html :form s* :static? (string? s)})))
           node     {:op :element
@@ -2458,9 +2474,10 @@
     ;; not the AST node, deliberately: a child's promotion is not an edit to
     ;; this template and must not move this template's fingerprint.
     (when (= :view (:kind info))
-      (env/add-site! e :views {:view-id  (:view-id info)
-                               :lowering (:lowering info)
-                               :path     (:path e)}))
+      (env/add-site! e :views {:view-id      (:view-id info)
+                               :lowering     (:lowering info)
+                               :source-coord (site-source-coord e form)
+                               :path         (:path e)}))
     (cond-> {:op (if (= :view (:kind info)) :view :foreign)
              :sym head
              :fqn (:fqn info)
@@ -2533,7 +2550,7 @@
                                                     (walk-expr e [:slot :value] slotval))))]
       (env/add-site! e :slots {:sid sid
                                :path (:path e)
-                               :source-coord (event-source-coord e form)
+                               :source-coord (site-source-coord e form)
                                :inline? inline?})
       node)))
 

--- a/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
@@ -78,11 +78,24 @@
   outside the grammar is analyzed and found, never silently elided. See
   [[read-declarations]] and [[findings-for]].
 
+  A PURE `.cljs` source is the case that has no answer, and it is refused
+  rather than approximated (see [[refuse-cljs-source!]]). Resolution needs
+  either a namespace loaded on the JVM — which a `.cljs` namespace never is
+  — or a genuine ClojureScript analyzer environment, which exists only
+  INSIDE a running ClojureScript compile; a standalone read is not one, and
+  cannot be handed one. Loading a stand-in JVM namespace of the same name
+  would answer about that namespace instead, which is the false-green this
+  checker exists to prevent. So `.cljs` is refused with the two workflows
+  that do answer: make the declaration `.cljc` — whose `:cljs` branch the
+  checker DOES analyze — or let the build answer, which is the same
+  analyzer and the same diagnostics.
+
   Normative owner:
   [`spec/004D-Freehand-Compiled-Grammar.md`](../../../../../../spec/004D-Freehand-Compiled-Grammar.md)
   §The read-only checker."
   (:require [re-frame.freehand.compiler.grammar :as grammar]
             #?@(:clj [[clojure.java.io :as io]
+                      [clojure.string :as str]
                       [re-frame.freehand :as v]
                       [re-frame.freehand.compiler.analyze :as ana]
                       [re-frame.freehand.compiler.env :as env]
@@ -474,6 +487,36 @@
                 :else
                 (recur declarations)))))))))
 
+(defn- refuse-cljs-source!
+  "Refuse a pure `.cljs` `path`, naming the two workflows that answer.
+
+  The checker's whole claim is that it runs the analyzer the BUILD runs, and
+  the analyzer classifies heads by RESOLUTION. On the JVM that is a loaded
+  namespace; for a ClojureScript target it is a real `cljs.analyzer`
+  environment, and a real one exists only inside a running ClojureScript
+  compile — a standalone read cannot receive one, and a `.cljs` namespace is
+  never loaded on the JVM.
+
+  What is left is a stand-in, and every stand-in is a lie: `(require …)` on a
+  same-named JVM namespace answers about THAT namespace's vars, and
+  resolving through the checker's own namespace answers about the checker.
+  Either produces a confident report about code nobody wrote — the exact
+  false-green [[findings-for]] exists to prevent. So the answer is a refusal
+  that says what to do instead."
+  [path]
+  (when (.endsWith (str/lower-case (str path)) ".cljs")
+    (throw (ex-info (str "re-frame.freehand check: " path " is a ClojureScript "
+                         "source. Heads are classified by resolution, and a .cljs "
+                         "namespace has neither a loaded JVM namespace nor — outside "
+                         "a running ClojureScript compile — an analyzer environment "
+                         "to resolve through, so there is no build context to check "
+                         "against and the checker will not invent one. Make the "
+                         "declaration .cljc and check that (both reader-conditional "
+                         "branches are analyzed, including the :cljs branch the "
+                         "browser build compiles), or let the build answer — it is "
+                         "the same analyzer and the same diagnostics.")
+                    {:file (str path) :target :cljs}))))
+
 (defn check-file
   "Check every `v/defview` in the source file at `path` and answer one
   report per declaration, in declaration order.
@@ -483,9 +526,15 @@
   rest, why not and what to do about it. The file is only ever read —
   see the read-only law in this namespace's docstring.
 
-  The file's namespace must be LOADED, because heads are classified by
-  resolution; a tool driving this from a REPL or a build already has it."
+  `path` is a `.clj` or `.cljc` source whose namespace is LOADED, because
+  heads are classified by resolution; a tool driving this from a REPL or a
+  build already has it. A `.cljc` declaration is checked for BOTH targets —
+  each reader-conditional branch a compile visits is analyzed (see
+  [[findings-for]]) — which is how a CLJS-target question is answered. A
+  pure `.cljs` source has no build context to answer from and is refused,
+  not approximated: see [[refuse-cljs-source!]]."
   [path]
+  (refuse-cljs-source! path)
   (mapv check-declaration (read-declarations path)))
 
 ))

--- a/implementation/freehand/test/re_frame/freehand/check_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/check_jvm_test.clj
@@ -114,8 +114,36 @@
       (is (java.util.Arrays/equals ^bytes before ^bytes after)))))
 
 ;; ---------------------------------------------------------------------------
-;; The two ways to be pointed at something that cannot be checked
+;; The three ways to be pointed at something that cannot be checked
 ;; ---------------------------------------------------------------------------
+
+(deftest a-pure-cljs-source-is-refused-and-names-the-workflows-that-answer
+  (testing "a .cljs namespace is never loaded on the JVM and a real
+            ClojureScript analyzer environment exists only inside a running
+            compile, so there is no build context to resolve heads through.
+            The checker refuses rather than resolving through a stand-in
+            namespace, which would report confidently about code nobody
+            wrote."
+    (let [tmp (java.io.File/createTempFile "fh-check" ".cljs")]
+      (try
+        (spit tmp "(ns re-frame.freehand.check-cljs-probe)\n")
+        (let [ex  (try (check/check-file (.getPath tmp))
+                       nil
+                       (catch clojure.lang.ExceptionInfo e e))
+              msg (str (ex-message ex))]
+          (is (some? ex) "a .cljs source is refused, not checked")
+          (is (= :cljs (:target (ex-data ex)))
+              "the refusal is discriminable as the CLJS-target one rather than
+               the unloaded-namespace one — the file is refused before it is
+               even read")
+          (is (re-find #"ClojureScript source" msg))
+          (is (re-find #"\.cljc" msg)
+              "and it names the workflow that DOES answer a CLJS-target
+               question — a .cljc declaration, whose :cljs branch is analyzed")
+          (is (not (re-find #"\(require" msg))
+              "never the unloaded-namespace advice: requiring a .cljs
+               namespace on the JVM is not a thing an author can do"))
+        (finally (.delete tmp))))))
 
 (deftest a-file-that-cannot-be-checked-says-so
   (testing "no (ns …) form means no namespace to resolve heads against"

--- a/implementation/freehand/test/re_frame/freehand/crossing_lowering_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/crossing_lowering_jvm_test.clj
@@ -228,7 +228,7 @@
         (is (= :re-frame.freehand/v1 (:grammar manifest)))
         (is (= [{:view-id ::an-interpreted-child :lowering :interpreted :path [0]}
                 {:view-id ::a-compiled-child     :lowering :compiled    :path [1]}]
-               (:crossings manifest))
+               (mapv #(dissoc % :source-coord) (:crossings manifest)))
             "both crossings, in source order, each marked and separately addressed")
         (is (= (count (:crossings manifest)) (count (boundary-calls body)))
             "one manifest crossing per emitted boundary — the two halves agree"))))
@@ -240,4 +240,4 @@
     (let [{:keys [manifest]} (lower '[{:keys [items]}]
                                     '[:ul (for [i items] [subject {:key i}])])]
       (is (= [{:view-id ::subject :lowering :compiled :path [0 :for]}]
-             (:crossings manifest))))))
+             (mapv #(dissoc % :source-coord) (:crossings manifest)))))))

--- a/implementation/freehand/test/re_frame/freehand/crossings_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/crossings_cljs_test.cljc
@@ -193,7 +193,7 @@
           "the manifest names the grammar that produced it")
       (is (= [{:view-id (view-id compiled/row) :lowering :compiled}
               {:view-id (:view-id call-005)    :lowering :interpreted}]
-             (mapv #(dissoc % :path) (:crossings m)))
+             (mapv #(dissoc % :path :source-coord) (:crossings m)))
           "both crossings, in source order, each marked with the mode it enters")
       (is (= 2 (count (distinct (map :path (:crossings m)))))
           "and the two sites are separately addressable"))))

--- a/implementation/freehand/test/re_frame/freehand/manifest_census_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/manifest_census_cljs_test.cljc
@@ -11,13 +11,20 @@
   ViewCell shell. The interpreted shell always observes context; compiled
   elision is earned by proof, and the proof is the manifest.
 
-  Two claims, on both hosts:
+  Three claims, on both hosts:
 
   1. **The rosters match the sites** — `FH-STRUCT-010`. Each census view's
      manifest reports exactly the sites its body carries; a manifest that
      over-reported would be claiming evidence it lacks, and one that
      under-reported would hide a reactive site.
-  2. **The omitted count is an integer** — `FH-DIAG-002`. Over the census,
+  2. **Every entry is source-locatable** — `FH-STRUCT-010` again. A count
+     of three subscriptions that cannot say which three lines is a fact
+     nothing can act on, so each entry carries the required keys and a
+     whole `:source-coord`. The coordinate is TOTAL — a site the reader
+     anchored nowhere inherits its declaration's position — which is why
+     this half is host-neutral even though the exact positions are not
+     (`re-frame.freehand.manifest-source-coord-jvm-test` pins those).
+  3. **The omitted count is an integer** — `FH-DIAG-002`. Over the census,
      the number of views that omit the ViewCell is exactly four — asserted
      as an integer, never a threshold (EP-0036 D021: elision is a
      deterministic gate, not timing evidence)."
@@ -86,8 +93,44 @@
         (is (= (:reactive? expected) (:reactive? m))
             (str k " — reactive? flag"))
         (when-let [crossing (:crossing expected)]
-          (is (= crossing (dissoc (first (:crossings m)) :path))
+          (is (= crossing (dissoc (first (:crossings m)) :path :source-coord))
               (str k " — the one crossing is marked with the mode it enters")))))))
+
+(deftest every-roster-entry-is-source-locatable
+  (testing "Per FH-STRUCT-010: cardinality is only half the promise. Every
+            entry of every roster carries the keys the fixture requires —
+            including the `:source-coord` that names the form which produced
+            it — so a manifest fact traces back to a line rather than only to
+            a view. The coordinate is TOTAL: a site the reader anchored
+            nowhere inherits its declaration's position, so the field is
+            present on every entry on every host."
+    (let [required (:required-keys struct-010)
+          coord-ks (:source-coord-keys struct-010)]
+      (is (= (set (keys required))
+             (set (keys (dissoc (v/manifest (census-view :label))
+                                :view-id :grammar :capabilities
+                                :reactive? :view-cell))))
+          "the fixture names every roster the manifest carries and no other")
+      (doseq [[nm view] mv/by-name
+              [roster ks] required
+              entry       (get (v/manifest view) roster)]
+        (is (= ks (set (keys entry)))
+            (str nm " — every " roster " entry carries exactly the required keys"))
+        (is (= coord-ks (set (keys (:source-coord entry))))
+            (str nm " — its :source-coord is a whole {:file :line :column}"))
+        (is (pos-int? (:line (:source-coord entry)))
+            (str nm " — with a real line, never a placeholder"))))))
+
+(deftest the-per-entry-gate-is-not-vacuous
+  (testing "A key contract asserted over zero entries would pass loudest of
+            all. The census reaches two of the six rosters through the public
+            door, and those two are named here so an emptied census cannot
+            read green."
+    (let [rosters (fn [k] (mapcat #(get (v/manifest %) k) (vals mv/by-name)))]
+      (is (= 3 (count (rosters :events)))
+          "three event sites across the census")
+      (is (= 1 (count (rosters :crossings)))
+          "one crossing across the census"))))
 
 (deftest reactive-and-elided-are-mutually-exclusive-and-agree
   (testing "The two facets of the verdict cannot disagree: :view-cell

--- a/implementation/freehand/test/re_frame/freehand/manifest_source_coord_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/manifest_source_coord_jvm_test.clj
@@ -1,0 +1,123 @@
+(ns re-frame.freehand.manifest-source-coord-jvm-test
+  "SOURCE COORDINATES RIDE EACH SITE — asserted through the public
+  `v/manifest`, on two site kinds at two known positions.
+
+  A roster's cardinality says a view has three subscriptions; a roster's
+  coordinates say WHICH THREE LINES. Only the second is actionable: a
+  diagnostic that can name the site a capability came from is a thing a
+  reader or an agent can act on, and one that can only name the view is
+  not. So the manifest's promise (Spec 004D §The finite manifest —
+  \"source coordinates ride each site so a manifest fact and a build-log
+  line name the same lexical position\") is proven here on the shape the
+  public read actually returns, not on the analyzer's internal index.
+
+  ## The two halves of a TOTAL coordinate
+
+  Clojure's reader anchors LISTS and not vectors, so the two sites below
+  are deliberately of different reader provenance:
+
+    - the `(v/event …)` handler is a list, so it locates ITSELF and the
+      manifest reports its own line and column;
+    - the `[coord-child …]` crossing is a vector the reader anchored
+      nowhere, so the site INHERITS the enclosing declaration's position.
+
+  Both entries carry a coordinate, and neither carries an invented one.
+  That is the whole discipline: the worst answer a manifest gives is
+  \"somewhere in this declaration\", which is a place the site really is —
+  never a line the source would not agree with.
+
+  ## Why JVM-only, and what the cross-host suite asserts instead
+
+  The reader is the variable. `clojure.lang.LispReader` anchors lists
+  alone; ClojureScript reads the same `.cljc` through `tools.reader`,
+  which anchors every collection — so a vector-formed site's coordinate is
+  narrower under a browser build than under a JVM one. That is CORRECT,
+  not drift: the manifest names the position its own compile read, and the
+  build-log line it must agree with came from the same reader. A single
+  cross-host table of exact coordinates would therefore have to assert
+  something false on one host. The host-neutral half of the contract —
+  that every roster entry carries a well-formed `:source-coord` at all —
+  is `FH-STRUCT-010`, asserted on both hosts in
+  `re-frame.freehand.manifest-census-cljs-test`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand :as v]))
+
+(v/defview coord-child
+  "The crossing's target. Nothing about it is under test; it exists so the
+  subject below has an internal boundary to mount."
+  {:compiled true}
+  [_]
+  [:span.child])
+
+;; The subject. Its own declaration form is the anchor every expectation
+;; below is expressed against — offsets, not absolute lines, because a
+;; test that pinned line 74 would be pinning this FILE rather than the
+;; contract, and would go red the day someone adds a paragraph above it.
+(v/defview coord-probe                                    ; the declaration anchor
+  "Two manifest sites of different reader provenance."
+  {:compiled true}
+  [{:keys [caption]}]
+  [:div.probe
+   [:button.go {:on-click (v/event [_] [:probe/pressed])} ; a LIST: locates itself
+    caption]
+   [coord-child {}]])                                     ; a VECTOR: inherits
+
+(def ^:private declaration
+  "The subject's own line and column, read from the public descriptor.
+
+  Not its `:file`: the descriptor resolves the declaring file to an
+  absolute path for an editor to open, while a manifest site names the
+  classpath-relative path the compiler read — two true answers to two
+  different questions, so [[source-file]] is stated rather than borrowed."
+  (select-keys (:source (v/describe coord-probe)) [:line :column]))
+
+(def ^:private source-file
+  "This file, as the compiler names it."
+  "re_frame/freehand/manifest_source_coord_jvm_test.clj")
+
+(def ^:private manifest (v/manifest coord-probe))
+
+;; Offsets from the declaration's line, counted in the source above. The
+;; event handler is the sixth line of the declaration form; the crossing
+;; inherits, so its offset is zero by contract rather than by counting.
+(def ^:private event-line-offset 5)
+(def ^:private event-column 27)
+
+(deftest a-list-anchored-site-reports-its-own-position
+  (testing "the (v/event …) handler is a list, so the reader anchored it and
+            the manifest reports the handler's OWN line and column — the
+            narrowest true position available, which is what makes the fact
+            actionable"
+    (let [[entry :as roster] (:events manifest)]
+      (is (= 1 (count roster)) "one event site, so the row below is unambiguous")
+      (is (= {:file   source-file
+              :line   (+ (:line declaration) event-line-offset)
+              :column event-column}
+             (:source-coord entry))
+          "the handler's own line and column, in the declaring file"))))
+
+(deftest an-unanchored-site-inherits-the-declaration
+  (testing "the [coord-child …] crossing is a vector, which this host's reader
+            anchors nowhere. The site inherits the enclosing declaration's
+            position rather than inventing one or omitting the field: a
+            coordinate is TOTAL, and the widest true statement beats a
+            precise false one"
+    (let [[entry :as roster] (:crossings manifest)]
+      (is (= 1 (count roster)) "one crossing, so the row below is unambiguous")
+      (is (= (assoc declaration :file source-file)
+             (:source-coord entry))
+          "exactly the declaration's coordinates — inherited, not fabricated")
+      (is (= :re-frame.freehand.manifest-source-coord-jvm-test/coord-child
+             (:view-id entry))
+          "and the crossing's existing facts are untouched by the addition"))))
+
+(deftest the-two-site-kinds-are-distinguishable
+  (testing "the point of per-site coordinates: two sites in ONE declaration
+            name two different positions. A manifest whose entries all
+            reported the declaration would pass every totality check and
+            still be unable to say where anything is"
+    (let [event-coord    (:source-coord (first (:events manifest)))
+          crossing-coord (:source-coord (first (:crossings manifest)))]
+      (is (not= event-coord crossing-coord))
+      (is (< (:line crossing-coord) (:line event-coord))
+          "and the anchored site really is further into the declaration"))))

--- a/spec/004D-Freehand-Compiled-Grammar.md
+++ b/spec/004D-Freehand-Compiled-Grammar.md
@@ -299,8 +299,26 @@ one would be silence a reader could not distinguish from an un-analyzed view. Th
 rosters whose authoring forms land with a later slice (presence, top-layer, error
 boundaries, and the reactive-read forms themselves) are declared here and
 populate as those forms become part of the grammar; a manifest never reports a
-site it could not have seen. Source coordinates ride each site so a manifest fact
-and a build-log line name the same lexical position.
+site it could not have seen.
+
+**Source coordinates ride each site**, so a manifest fact and a build-log line
+name the same lexical position. Every roster entry carries a `:source-coord` —
+`{:file :line :column}` — beside the deterministic template `:path`, and the two
+answer different questions: the path says *which occurrence*, the coordinate
+says *which line an author would edit*. A roster that could name a capability
+but not the site it came from is a count rather than a fact, and a diagnostic
+built on it can only say that a view has a capability somewhere.
+
+The coordinate is **total, and never invented**. A site whose form the reader
+anchored reports its own position; one the reader anchored nowhere — Clojure's
+reader anchors lists and not vectors, and a macro-generated template carries no
+metadata at all — inherits its enclosing declaration's position. "Somewhere in
+this declaration" is a place the site really is; a fabricated line is not, and an
+omitted field would make every consumer branch on absence. It follows that the
+coordinate is the one the **compiling reader** produced: the same `.cljc` site
+can report a narrower position under a ClojureScript build than under a JVM one,
+which is correct rather than drift — the build-log line it must agree with came
+from that same reader.
 
 ### The capability-elision verdict
 

--- a/spec/004D-Freehand-Compiled-Grammar.md
+++ b/spec/004D-Freehand-Compiled-Grammar.md
@@ -1800,6 +1800,30 @@ unloaded namespace is refused loudly rather than reported as a wall of
 unresolved heads, because that failure would be about the checker rather than
 about the code.
 
+Only resolution is host-uniform; the **forms** are not. A `.cljc` declaration
+compiles a different reader-conditional branch per target, and the branch a SPA
+author is most likely to false-green is the `:cljs` one, because the JVM never
+reads it. Handing the reader a `:features` set does not fix this: the JVM
+reader's `:clj` platform feature is always present and cannot be turned off, so
+`#?(:clj … :cljs …)` resolves to `:clj` whatever it is asked for, and the other
+branch is elided before any analysis can see it. The checker therefore reads
+with reader conditionals **preserved** and selects each target's branch
+**itself**, past the platform feature, and analyzes **every branch a compile
+would visit** — one refusal at a time still, JVM branch first. A declaration is
+eligible only when both branches are.
+
+A **pure `.cljs` source is refused**, and refusing is the whole answer. A
+`.cljs` namespace is never loaded on the JVM, and the genuine ClojureScript
+analyzer environment that would resolve through instead exists only *inside* a
+running ClojureScript compile — a standalone read is not one and cannot be
+handed one. Every remaining option is a stand-in: a same-named JVM namespace
+answers about that namespace's vars, and the checker's own namespace answers
+about the checker. Either would report confidently about code nobody wrote,
+which is precisely the false-green the branch discipline above exists to
+prevent. The refusal names the two workflows that do answer — write the
+declaration in `.cljc`, whose `:cljs` branch the checker analyzes, or let the
+build answer, which is the same analyzer and the same diagnostics.
+
 The **report vocabulary** — the reason roster, the recovery roster, and the
 report and finding shapes — is host-neutral, so a ClojureScript tool can render
 a report it received over the wire without a second copy of the vocabulary to

--- a/spec/conformance/freehand/fixtures/fh-struct-010.edn
+++ b/spec/conformance/freehand/fixtures/fh-struct-010.edn
@@ -11,7 +11,23 @@
 ;;
 ;; `:crossing` names the one crossing `mounts-label` records, marked with the
 ;; mode it enters — the manifest half of D010.
+;;
+;; `:required-keys` pins the per-entry SHAPE beside the cardinality. A count is
+;; only half the promise: a roster of three entries that cannot say which three
+;; lines is a fact nothing can act on, so every entry of every roster carries
+;; the keys named here — including the `:source-coord` that traces it back to
+;; the form that produced it. `:source-coord-keys` pins that coordinate's own
+;; shape, which is total: absent reader metadata makes a site inherit its
+;; declaration's position, never omit the field and never invent a line.
 {:fh/id "FH-STRUCT-010"
+ :required-keys
+ {:subscriptions #{:sid :query :source-coord :path}
+  :events        #{:sid :source-coord :path}
+  :slots         #{:sid :inline? :source-coord :path}
+  :html-sites    #{:source-coord :path}
+  :frame-ops     #{:sid :source-coord :path}
+  :crossings     #{:view-id :lowering :source-coord :path}}
+ :source-coord-keys #{:file :line :column}
  :views
  {:label
   {:events 0 :subscriptions 0 :slots 0 :frame-ops 0 :crossings 0


### PR DESCRIPTION
Two small compiler-area follow-ups, one commit each. Both beads shipped; nothing dropped.

## rf2-drpa3.80 — checker: the pure-`.cljs` workflow, and the 004D host claim

The two ACs rf2-drpa3.76 / PR #6717 deliberately deferred.

**AC2 — the supported `.cljs` / CLJS-target workflow is a refusal.** The checker classifies heads by resolution. A pure `.cljs` namespace is never loaded on the JVM, and the genuine ClojureScript analyzer environment that would resolve through instead exists only *inside* a running ClojureScript compile — a standalone read is not one and cannot be handed one. Until now such a file reached `live-namespace` and was refused with "is not loaded", advising a `(require …)` an author cannot perform.

`check-file` now refuses a `.cljs` path up front, before the file is read, naming the two workflows that do answer: write the declaration in `.cljc` — whose `:cljs` branch the checker already analyzes, per drpa3.76 — or let the build answer, which is the same analyzer and the same diagnostics. The refusal carries `:target :cljs` in its ex-data so a tool can tell it from the unloaded-namespace refusal. No stand-in namespace is loaded and none is invented: resolving through a same-named JVM namespace would report confidently about code nobody wrote, which is the false-green drpa3.76 fixed.

**AC4 — spec wording.** `spec/004D` §Where the checker runs claimed only that resolution is JVM-side for both targets. It now also states what the checker does about the *forms*, which are not host-uniform: reader conditionals are read `:read-cond :preserve` and each target's branch is selected by the checker itself, past the JVM reader's always-present `:clj` platform feature, with every branch a compile would visit analyzed. The `.cljs` refusal is stated in the same section.

`spec/009` §The compile checker report **needed no change** and was not touched (it is also in flight): it delegates the report shape and its laws to 004D and records only where the finding ids come from — a claim this PR does not alter.

One new JVM test in the existing `check-jvm-test` suite. Non-vacuity probe: inverting `(= :cljs (:target (ex-data ex)))` reds `clojure -M:test` naming `a-pure-cljs-source-is-refused-and-names-the-workflows-that-answer`; restored byte-identical (sha256 verified).

## rf2-drpa3.82 — per-site source coordinates in compiled manifests

Spec 004D promised "source coordinates ride each site so a manifest fact and a build-log line name the same lexical position", and only `:events` and `:slots` delivered. `:subscriptions`, `:frame-ops`, `:html-sites` and `:crossings` named a `:sid` and a template `:path` and nothing an author could open — so a manifest could say a view has a capability without saying which site it came from. A count, not a fact.

The analyzer already had the mechanism. `event-source-coord` is generalised to `site-source-coord`, recorded on the four remaining site kinds, and projected in `structural-manifest`. **No second source-map format, no index, no tooling database, and no new public verb** — the same helper, four more callers, four more projected keys. Existing `:sid` / `:path` / `:query` / crossing mode / `:inline?` are untouched and still serializable.

The coordinate is **total and never invented**, the discipline the checker slice established. Clojure's reader anchors lists and not vectors, so a `(v/event …)` handler locates itself while a `[child {…}]` crossing inherits its enclosing declaration's position — the widest true statement rather than a fabricated line, and never an absent field a consumer would branch on. It follows that the coordinate is the *compiling* reader's: the same `.cljc` site reports a narrower position under a ClojureScript build (tools.reader anchors every collection) than under a JVM one. That is correct rather than drift — the build-log line it must agree with came from that same reader — and 004D §The finite manifest now says so.

**FH-STRUCT-010 can no longer read green on cardinality alone.** The fixture gains `:required-keys` (the per-entry key roster per manifest roster) and `:source-coord-keys`; the cross-host census suite asserts both, plus the entry counts that stop the key gate passing over an empty table. Exact positions are pinned JVM-side in a new suite where the reader is one thing — two site kinds of different reader provenance in one declaration, asserted through the public `v/manifest` rather than the analyzer's index, proving both halves of totality.

Two pre-existing crossing assertions compared the whole entry and now `dissoc` `:source-coord` alongside `:path`, exactly as the census suite already did.

`docs/api/re-frame.freehand.md` was deliberately **not** touched — its `v/manifest` example is an elided three-key excerpt that makes no completeness claim, and that file belongs to the serial verb-adding lane.

Non-vacuity probes (one per new test file): perturbing `event-line-offset` reds `clojure -M:test` naming `a-list-anchored-site-reports-its-own-position`; adding a key to the expected `:source-coord` roster reds `npm run test:freehand` naming `every-roster-entry-is-source-locatable` on four rows. Both restored byte-identical (sha256 verified).

## Quality gates

All foreground, all to completion, from the worker worktree.

| Gate | Result |
|---|---|
| `cd implementation/freehand && clojure -M:test` | **468 tests / 3077 assertions, 0 failures, 0 errors** (463/3055 measured after the .80 commit alone, so +5 tests / +22 assertions for .82 and +1 / +5 for .80 — the additions are real, not re-counts) |
| `npm run test:freehand` | **340 tests / 2398 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` | **10461 tests / 52478 assertions, 0 failures, 0 errors** |
| `python scripts/check_keyword_catalogue_drift.py` | exit 0 |
| `python scripts/check_freehand_conformance_index.py` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `python -m mkdocs build --strict` | exit 0 |

`git grep 're-frame.ui' implementation/freehand/` — empty, as required.

Do not merge on my account — mayor merges.
