### PR TITLE
fix(freehand): checker reader-conditionals in sets and around declarations (rf2-drpa3.85)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
@@ -78,6 +78,15 @@
   outside the grammar is analyzed and found, never silently elided. See
   [[read-declarations]] and [[findings-for]].
 
+  Selection follows the conditional wherever a conditional may legally
+  stand, because an uncovered PLACEMENT is the same false-green in a new
+  syntactic position: a preserved conditional the walk does not descend
+  into survives as a reader object where the browser build has a form, and
+  a declaration the walk does not recognise is not reported at all. So
+  [[resolve-conditionals]] descends every collection kind including SETS,
+  and discovery ([[declaration-for]]) runs on the resolved BRANCHES, so a
+  `v/defview` written under `#?(:clj … :cljs …)` is found.
+
   A PURE `.cljs` source is the case that has no answer, and it is refused
   rather than approximated (see [[refuse-cljs-source!]]). Resolution needs
   either a namespace loaded on the JVM — which a `.cljs` namespace never is
@@ -249,20 +258,25 @@
 
   A `{:compiled true}` `.cljc` view compiles to BOTH a JVM structural tree
   and a CLJS React tree, each from its OWN reader-conditional branch, and
-  both must be inside the grammar for the compile to stand. `:body` is the
-  branch the JVM reader selected (`#{:clj}`); `:cljs-body`, present only
-  when the two branches read DIFFERENTLY, is the branch the browser build
-  compiles (`#{:cljs}`) — the branch an author is most likely to
-  false-green, because the JVM reader never elides to it.
+  both must be inside the grammar for the compile to stand. The declaration
+  itself is the branch the JVM reader selected (`#{:clj}`); `:cljs-branch`,
+  present only when the two branches read DIFFERENTLY, carries what the
+  browser build's branch (`#{:cljs}`) BINDS and RENDERS — the branch an
+  author is most likely to false-green, because the JVM reader never elides
+  to it. It is MERGED over the declaration rather than substituted for its
+  body alone, because a conditional around the whole declaration diverges
+  the params too, and a body analyzed against the other branch's params
+  would be refused (or excused) for the wrong reason.
 
   Both branches are analyzed JVM-side with the SAME head resolution either
   target uses — resolution is JVM for both hosts, so only the FORMS the
   reader produced differ. One finding is reported: the first ineligible
   form across the branches, JVM branch first, keeping the
   one-refusal-at-a-time law."
-  [{:keys [body cljs-body] :as declaration}]
-  (vec (take 1 (concat (when body      (findings-for-branch declaration body))
-                       (when cljs-body (findings-for-branch declaration cljs-body))))))
+  [{:keys [body cljs-branch] :as declaration}]
+  (vec (take 1 (concat (when body        (findings-for-branch declaration body))
+                       (when cljs-branch (findings-for-branch (merge declaration cljs-branch)
+                                                              (:body cljs-branch)))))))
 
 (defn check-declaration
   "Check ONE declaration against `:re-frame.freehand/v1` WITHOUT
@@ -275,16 +289,18 @@
        :ns-sym          'app.people       ; heads resolve through it
        :params          '[{:keys [people]}]
        :body            '([:ul (map person-item people)])   ; the :clj branch
-       :cljs-body       nil               ; the :cljs branch, when it DIVERGES
+       :cljs-branch     nil               ; the :cljs branch, when it DIVERGES
        :compiled?       false             ; what the declaration says TODAY
        :children-policy :optional
        :source          {:file \"src/app/people.cljc\" :line 42 :column 1}
        :resolver        <fn>}             ; optional; tests only
 
-  `:cljs-body` is supplied by [[read-declarations]] only for a `.cljc`
-  view whose `#?(:clj … :cljs …)` branches read differently; both branches
-  are then analyzed (see [[findings-for]]), so a `:cljs`-only ineligible
-  form is found rather than false-greened.
+  `:cljs-branch` is supplied by [[read-declarations]] only for a `.cljc`
+  view whose `#?(:clj … :cljs …)` branches read differently. It carries the
+  branch-owned parts alone — `:params`, `:children-policy`, `:body` — and
+  is merged over the declaration to analyze the CLJS target (see
+  [[findings-for]]), so a `:cljs`-only ineligible form is found rather than
+  false-greened.
 
   A declaration that already carries `{:compiled true}` is checked the
   same way and reports `:current-lowering :compiled` — the question
@@ -412,7 +428,13 @@
   read with conditionals PRESERVED (see [[read-opts]]), and the target's
   branch is selected HERE, past the reach of the reader's `:clj` platform
   feature. `form` is not itself a splicing conditional — those are handled
-  in sibling context by [[resolve-children]]."
+  in sibling context by [[resolve-children]], the reader allowing `#?@` only
+  inside a collection.
+
+  EVERY collection kind is descended into, sets included. A kind left out is
+  not a smaller fix, it is the same false-green in a new position: the
+  conditional survives the walk, and the analyzer is handed a reader object
+  where the browser build has `#{v/sub}`."
   [form features]
   (cond
     (not (has-reader-conditional? form))
@@ -429,6 +451,9 @@
                      form)
                (meta form))
 
+    (set? form)
+    (with-meta (into (empty form) (resolve-children form features)) (meta form))
+
     (vector? form)
     (with-meta (resolve-children form features) (meta form))
 
@@ -438,25 +463,62 @@
     :else
     form))
 
-(defn- declaration-with-branches
-  "The declaration data for a preserved `v/defview` `form`, carrying the
-  branch each compilation target compiles.
+(defn- defview-form?
+  "Is `form` a `v/defview` declaration, read in `ns-obj`? A head counts when
+  it RESOLVES to the var there — an alias, a `:refer`, or the qualified name
+  all read the same."
+  [ns-obj form]
+  (and (seq? form)
+       (symbol? (first form))
+       (= #'v/defview (try (ns-resolve ns-obj (first form))
+                           (catch Exception _ nil)))))
 
-  `:body` is the `:clj` branch (the JVM structural tree's source) and
-  `:cljs-body`, present only when the two branches read DIFFERENTLY, is the
-  `:cljs` branch the browser build compiles. Both are analyzed by
-  [[findings-for]], so a `:cljs`-only form outside the grammar is FOUND
-  rather than elided by the reader and false-greened."
-  [path ns-sym form]
-  (let [clj-decl  (declaration-at path ns-sym (resolve-conditionals form #{:clj}))
-        cljs-body (:body (declaration-at path ns-sym (resolve-conditionals form #{:cljs})))]
-    (cond-> clj-decl
-      (not= (:body clj-decl) cljs-body) (assoc :cljs-body cljs-body))))
+(def ^:private branch-keys
+  "The declaration parts a reader conditional can make target-specific: what
+  the branch BINDS and what it RENDERS. Everything else — the view's id, its
+  name, its source coordinates, whether it says `{:compiled true}` — is the
+  declaration's identity, and one identity is what the file declares however
+  many branches it was written across."
+  [:params :children-policy :body])
+
+(defn- declaration-for
+  "The declaration data for top-level `form`, or nil when it declares no view.
+
+  Discovery runs on the RESOLVED BRANCHES rather than on the form as read,
+  because a whole declaration may be written under a reader conditional:
+
+      #?(:clj  (v/defview thing [_]           [:div …])
+         :cljs (v/defview thing [{:keys [tag]}] [tag {} …]))
+
+  A preserved conditional is not a seq, so a discovery test applied to the
+  form itself skips such a declaration entirely and the file reports NOTHING
+  about it — the loudest false-green there is, since the author reads
+  silence as \"no findings\".
+
+  What the branches contain is still ONE declaration. Its identity is the
+  JVM branch's — or the CLJS branch's, for a view that exists only in the
+  browser build — and `:cljs-branch` carries the [[branch-keys]] whenever
+  the CLJS branch's differ. Both are then analyzed by [[findings-for]], so a
+  `:cljs`-only form outside the grammar is FOUND rather than elided by the
+  reader and false-greened."
+  [path ns-sym ns-obj form]
+  (let [decl-for  (fn [features]
+                    (let [f (resolve-conditionals form features)]
+                      (when (defview-form? ns-obj f)
+                        (declaration-at path ns-sym f))))
+        clj-decl  (decl-for #{:clj})
+        cljs-decl (decl-for #{:cljs})
+        decl      (or clj-decl cljs-decl)]
+    (when decl
+      (cond-> decl
+        (and cljs-decl (not= (select-keys cljs-decl branch-keys)
+                             (select-keys decl branch-keys)))
+        (assoc :cljs-branch (select-keys cljs-decl branch-keys))))))
 
 (defn- read-declarations
   "Every `v/defview` in the file at `path`, in declaration order, as
   declaration data — each carrying both reader-conditional branches a
-  `.cljc` compile visits (see [[declaration-with-branches]]).
+  `.cljc` compile visits (see [[declaration-for]]).
 
   The file is opened for READING and read with `*read-eval*` false: a
   checker is pointed at source an author has not yet decided to compile,
@@ -464,8 +526,7 @@
   way to answer the question. Reader conditionals are PRESERVED rather than
   resolved by the reader (see [[read-opts]]) so the `:cljs` branch survives
   to be analyzed. Forms are read in the file's own namespace so `::keyword`
-  aliases resolve, and a head counts as `v/defview` when it RESOLVES there
-  — an alias, a `:refer`, or the qualified name all read the same."
+  aliases resolve."
   [path]
   (with-open [rdr (LineNumberingPushbackReader. (io/reader (io/file path)))]
     (binding [*read-eval* false]
@@ -474,18 +535,11 @@
         (binding [*ns* ns-obj]
           (loop [declarations []]
             (let [form (read read-opts rdr)]
-              (cond
-                (= ::eof form)
+              (if (= ::eof form)
                 declarations
-
-                (and (seq? form)
-                     (symbol? (first form))
-                     (= #'v/defview (try (ns-resolve ns-obj (first form))
-                                         (catch Exception _ nil))))
-                (recur (conj declarations (declaration-with-branches path ns-sym form)))
-
-                :else
-                (recur declarations)))))))))
+                (recur (if-let [declaration (declaration-for path ns-sym ns-obj form)]
+                         (conj declarations declaration)
+                         declarations))))))))))
 
 (defn- refuse-cljs-source!
   "Refuse a pure `.cljs` `path`, naming the two workflows that answer.

--- a/implementation/freehand/test/re_frame/freehand/check_conditional_placement_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/check_conditional_placement_jvm_test.clj
@@ -1,0 +1,243 @@
+(ns re-frame.freehand.check-conditional-placement-jvm-test
+  "The checker must answer for the browser build's branch wherever the
+  conditional was WRITTEN, not only where it is easiest to walk.
+
+  `check-host-divergent-jvm-test` pins the selection itself: the checker
+  reads with conditionals preserved and picks the `:cljs` branch past the
+  JVM reader's unconditional `:clj` platform feature. This suite pins its
+  REACH. A conditional is legal anywhere a form is, and two placements are
+  invisible to a walk that knows only maps, vectors and seqs — inside a set,
+  and around the whole declaration. Both were false-greens of the same kind
+  the selection exists to prevent, in new syntactic positions:
+
+    * a conditional inside a set survived the walk intact, so the analyzer
+      saw a reader object where the browser build has `#{v/sub}`, and the
+      view reported ELIGIBLE;
+    * a declaration written under `#?(:clj (v/defview …) :cljs (v/defview
+      …))` is not a seq once preserved, so discovery skipped it and the file
+      reported NOTHING about it — the loudest false-green there is, since an
+      author reads silence as \"no findings\".
+
+  Four things are asserted:
+
+    1. every placement is discovered and checked, whole report per
+       declaration, in declaration order;
+    2. the refusal names the CLJS-branch form — proof the branch was
+       analyzed rather than the one the JVM reader elides to — and each
+       placement's UNIFORM control stays eligible, so covering a placement
+       cannot manufacture a false NO;
+    3. the selected branches are what a REAL reader told to read for each
+       target produces (`clojure.tools.reader` honours `:features` exactly,
+       unlike the JVM reader), so the hand-selection is checked against an
+       independent oracle rather than against itself;
+    4. resolution rebuilds a set AS a set, with its metadata;
+    5. the fixture is byte-identical after a run — the read-only law holds
+       for the widened walk too."
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [clojure.tools.reader :as rdr]
+            [clojure.tools.reader.reader-types :as rt]
+            [re-frame.freehand.check-conditional-placement-views]
+            [re-frame.freehand.compiler.check :as check]))
+
+(def ^:private fixture-resource
+  "re_frame/freehand/check_conditional_placement_views.cljc")
+
+(def ^:private fixture-path
+  (.getPath (io/file (io/resource fixture-resource))))
+
+(defn- report-for [view-id reports]
+  (first (filter #(= view-id (:view-id %)) reports)))
+
+;; ---------------------------------------------------------------------------
+;; 1 — every placement is discovered and checked
+;; ---------------------------------------------------------------------------
+
+(deftest every-placement-is-discovered-and-checked
+  (let [reports (check/check-file fixture-path)]
+    (is (= [:re-frame.freehand.check-conditional-placement-views/set-divergent
+            :re-frame.freehand.check-conditional-placement-views/set-splice-divergent
+            :re-frame.freehand.check-conditional-placement-views/set-uniform
+            :re-frame.freehand.check-conditional-placement-views/declaration-divergent
+            :re-frame.freehand.check-conditional-placement-views/declaration-uniform]
+           (mapv :view-id reports))
+        "one report per declaration, in declaration order — INCLUDING the two
+         written under a top-level reader conditional, which a discovery test
+         applied to the preserved form skips entirely")
+
+    (testing "a bare v/sub selected out of a set is a reactive read the manifest
+              cannot own, so the view is ineligible"
+      (is (= {:view-id           :re-frame.freehand.check-conditional-placement-views/set-divergent
+              :source            {:file fixture-path :line 41 :column 1}
+              :current-lowering  :interpreted
+              :target-grammar    :re-frame.freehand/v1
+              :compile-eligible? false
+              :findings          [{:id       :rf.ui.compile/unsupported-form
+                                   :source   {:line 41 :column 1}
+                                   :form     'v/sub
+                                   :reason   :form-outside-the-grammar
+                                   :recovery [:make-template-visible
+                                              :pass-computed-value
+                                              :extract-declared-child
+                                              :keep-interpreted]}]}
+             (report-for :re-frame.freehand.check-conditional-placement-views/set-divergent
+                         reports))))
+
+    (testing "and the same through a SPLICING conditional, which contributes its
+              branch's forms as siblings rather than as one form"
+      (is (= {:view-id           :re-frame.freehand.check-conditional-placement-views/set-splice-divergent
+              :source            {:file fixture-path :line 47 :column 1}
+              :current-lowering  :interpreted
+              :target-grammar    :re-frame.freehand/v1
+              :compile-eligible? false
+              :findings          [{:id       :rf.ui.compile/unsupported-form
+                                   :source   {:line 47 :column 1}
+                                   :form     'v/sub
+                                   :reason   :form-outside-the-grammar
+                                   :recovery [:make-template-visible
+                                              :pass-computed-value
+                                              :extract-declared-child
+                                              :keep-interpreted]}]}
+             (report-for :re-frame.freehand.check-conditional-placement-views/set-splice-divergent
+                         reports))))
+
+    (testing "a declaration written under a top-level conditional is reported,
+              and its CLJS branch's head is bound from THAT branch's params —
+              analyzing it against the :clj branch's params would refuse it as
+              an unresolved head, which is the wrong diagnosis"
+      (is (= {:view-id           :re-frame.freehand.check-conditional-placement-views/declaration-divergent
+              :source            {:file fixture-path :line 65 :column 10}
+              :current-lowering  :interpreted
+              :target-grammar    :re-frame.freehand/v1
+              :compile-eligible? false
+              :findings          [{:id       :rf.ui.compile/dynamic-head
+                                   :source   {:line 65 :column 10}
+                                   :form     '[tag {} "the CLJS branch has a dynamic head - ineligible"]
+                                   :reason   :head-is-a-runtime-value
+                                   :recovery [:use-a-literal-head
+                                              :extract-declared-child
+                                              :keep-interpreted]}]}
+             (report-for :re-frame.freehand.check-conditional-placement-views/declaration-divergent
+                         reports))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the CLJS branch is what was analyzed, and no placement invents a NO
+;; ---------------------------------------------------------------------------
+
+(deftest covering-a-placement-never-manufactures-a-refusal
+  (testing "each placement's control — branches that read DIFFERENTLY yet are
+            both inside the grammar — stays eligible with nothing to say"
+    (let [reports (check/check-file fixture-path)]
+      (doseq [view-id [:re-frame.freehand.check-conditional-placement-views/set-uniform
+                       :re-frame.freehand.check-conditional-placement-views/declaration-uniform]]
+        (is (= {:compile-eligible? true :findings []}
+               (select-keys (report-for view-id reports) [:compile-eligible? :findings]))
+            (str view-id " is genuinely eligible on both targets"))))))
+
+(deftest the-refusal-names-the-cljs-branch-form
+  (testing "non-vacuity: every refusal here names a form that exists ONLY in the
+            `:cljs` branch. Before the walk covered these placements the set
+            views reported eligible with no findings at all, and the two
+            declarations under a conditional were not reported at all"
+    (let [reports (check/check-file fixture-path)]
+      (is (= ['v/sub 'v/sub '[tag {} "the CLJS branch has a dynamic head - ineligible"]]
+             (->> reports
+                  (remove :compile-eligible?)
+                  (mapv #(-> % :findings first :form))))
+          "the CLJS-branch forms — never the :clj branch's 1, #{1 2} or [:div …]")
+      (is (= 5 (count reports))
+          "and silence is not an answer: every declaration in the file is
+           reported, however it was written"))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the selection agrees with a real reader
+;; ---------------------------------------------------------------------------
+
+(defn- declarations-read-for
+  "Every `v/defview` form in the fixture, as a REAL reader reads the file for
+  `features`. `clojure.tools.reader` honours the `:features` it is handed
+  exactly — it has no unconditional platform feature — so it produces the
+  `:cljs` forms the browser build compiles, and is an oracle independent of
+  the checker's own hand-selection."
+  [features]
+  (let [r (rt/indexing-push-back-reader (slurp (io/resource fixture-resource)))]
+    (loop [acc []]
+      (let [form (rdr/read {:eof ::eof :read-cond :allow :features features} r)]
+        (cond
+          (= ::eof form)                             acc
+          (and (seq? form) (= 'v/defview (first form))) (recur (conj acc form))
+          :else                                      (recur acc))))))
+
+(defn- sets-in [form]
+  (filterv set? (tree-seq coll? seq form)))
+
+(defn- named [vname forms]
+  (first (filter #(= vname (second %)) forms)))
+
+(deftest the-selected-branches-are-the-readers-own
+  (let [clj-forms  (declarations-read-for #{:clj})
+        cljs-forms (declarations-read-for #{:cljs})]
+
+    (testing "the real reader finds the same five declarations on either target,
+              resolving the top-level conditionals into plain declarations —
+              which is what the checker's discovery must match"
+      (is (= '[set-divergent set-splice-divergent set-uniform
+               declaration-divergent declaration-uniform]
+             (mapv second clj-forms)
+             (mapv second cljs-forms))))
+
+    (testing "the sets the reader builds per target are the sets the checker
+              analyzed: constants on the JVM, the bare v/sub the checker
+              refused in the browser"
+      (is (= [#{1}] (sets-in (named 'set-divergent clj-forms))))
+      (is (= ['#{v/sub}] (sets-in (named 'set-divergent cljs-forms))))
+      (is (= [#{1 2}] (sets-in (named 'set-splice-divergent clj-forms))))
+      (is (= ['#{v/sub}] (sets-in (named 'set-splice-divergent cljs-forms))))
+      (is (= [#{1} #{3 4}] (sets-in (named 'set-uniform clj-forms))))
+      (is (= [#{2} #{5}] (sets-in (named 'set-uniform cljs-forms)))))
+
+    (testing "and a declaration under a conditional is TWO declarations to the
+              reader — different params, different body — which is why the CLJS
+              branch is analyzed against its own params"
+      (let [clj-decl  (named 'declaration-divergent clj-forms)
+            cljs-decl (named 'declaration-divergent cljs-forms)]
+        (is (= '[_] (nth clj-decl 3)))
+        (is (= '[{:keys [tag]}] (nth cljs-decl 3)))
+        (is (= '[tag {} "the CLJS branch has a dynamic head - ineligible"]
+               (last cljs-decl))
+            "the form the checker reported is the one this reader produced")))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — a set comes back a set
+;; ---------------------------------------------------------------------------
+
+(def ^:private resolve-conditionals
+  "The checker's branch selection, reached directly: set-ness and metadata
+  survive resolution, which no report can observe because both readings are
+  inside the grammar."
+  #'check/resolve-conditionals)
+
+(deftest resolution-rebuilds-a-set-as-a-set
+  (let [form (vary-meta (read-string {:read-cond :preserve}
+                                     "#{#?(:clj 1 :cljs 2) #?@(:clj [3] :cljs [4 5])}")
+                        assoc ::marker true)]
+    (is (= #{1 3} (resolve-conditionals form #{:clj})))
+    (is (= #{2 4 5} (resolve-conditionals form #{:cljs}))
+        "the splicing conditional contributes its branch's forms as members")
+    (is (set? (resolve-conditionals form #{:cljs}))
+        "a set, not the vector the sibling walk assembles")
+    (is (= {::marker true} (meta (resolve-conditionals form #{:cljs})))
+        "and the collection's metadata rides through the rebuild")))
+
+;; ---------------------------------------------------------------------------
+;; 5 — read-only
+;; ---------------------------------------------------------------------------
+
+(deftest the-checker-never-writes
+  (testing "the widened walk is still read-only — the source it was pointed at
+            is byte-identical after a run"
+    (let [before (java.nio.file.Files/readAllBytes (.toPath (io/file fixture-path)))
+          _      (check/check-file fixture-path)
+          after  (java.nio.file.Files/readAllBytes (.toPath (io/file fixture-path)))]
+      (is (pos? (alength before)) "the fixture file is not empty")
+      (is (java.util.Arrays/equals ^bytes before ^bytes after)))))

--- a/implementation/freehand/test/re_frame/freehand/check_conditional_placement_views.cljc
+++ b/implementation/freehand/test/re_frame/freehand/check_conditional_placement_views.cljc
@@ -1,0 +1,81 @@
+(ns re-frame.freehand.check-conditional-placement-views
+  "Reader conditionals in the two legal PLACEMENTS a body-level walk misses:
+  inside a SET, and around the WHOLE declaration.
+
+  `re-frame.freehand.check-host-divergent-views` proves the checker selects
+  the `:cljs` branch rather than the one the JVM reader elides to. It proves
+  it in the easy placement — a conditional standing where the body itself
+  stands. A conditional is legal anywhere a form is, and two placements are
+  invisible to a walk that knows only maps, vectors and seqs:
+
+    * inside a **set** (`#{#?(…)}`, and the splicing `#{#?@(…)}`), which is
+      neither a map nor a vector nor a seq, so the conditional survives the
+      walk intact and the `:cljs` branch is never selected — the analyzer
+      then sees a reader object where the browser build sees a form;
+    * around the **whole declaration** (`#?(:clj (v/defview …) :cljs
+      (v/defview …))`), where the preserved conditional is not a seq, so
+      declaration discovery skips it and the file reports NOTHING at all.
+
+  Both placements false-green: an author asks whether a view is eligible and
+  is told yes about a branch the browser build refuses. Each therefore
+  appears here twice — a DIVERGENT view whose `:cljs` branch is outside the
+  grammar while its `:clj` branch is inside it (the hazard), and a UNIFORM
+  view whose branches differ textually but are both inside the grammar (the
+  control, so that covering the placement cannot manufacture a false NO).
+
+  The ineligible `:cljs` branches use the two refusals those placements
+  naturally produce: a bare `v/sub` reference, which is a reactive read the
+  manifest cannot own outside a call head, and a head bound from props,
+  which is a runtime value.
+
+  Loaded on the JVM — the checker classifies heads by resolution, so the
+  namespace it is pointed at must be live. The JVM reader takes the `:clj`
+  branch everywhere here, so every view loads interpreted without incident;
+  the `:cljs` branches are reached by the checker alone."
+  (:require [re-frame.freehand :as v]))
+
+;; ---------------------------------------------------------------------------
+;; Placement 1 — inside a set
+;; ---------------------------------------------------------------------------
+
+(v/defview set-divergent
+  "CLJ branch a constant; CLJS branch a bare `v/sub` — a reactive read
+  flowing as a value, which the manifest cannot own."
+  [_]
+  [:div {:title (str #{#?(:clj 1 :cljs v/sub)})}])
+
+(v/defview set-splice-divergent
+  "The same hazard through a SPLICING conditional: `#?@` contributes two
+  constants on the JVM and a bare `v/sub` in the browser."
+  [_]
+  [:div {:title (str #{#?@(:clj [1 2] :cljs [v/sub])})}])
+
+(v/defview set-uniform
+  "The control. Both placements, both branches inside the grammar, and the
+  two reads are not textually equal — covering sets must not invent a
+  refusal, and must leave the set a set."
+  [_]
+  [:div {:title (str #{#?(:clj 1 :cljs 2)}
+                     #{#?@(:clj [3 4] :cljs [5])})}])
+
+;; ---------------------------------------------------------------------------
+;; Placement 2 — around the whole declaration
+;; ---------------------------------------------------------------------------
+
+#?(:clj  (v/defview declaration-divergent
+           "CLJ branch a literal element - eligible."
+           [_]
+           [:div "the JVM branch is a literal element - eligible"])
+   :cljs (v/defview declaration-divergent
+           "CLJS branch has a head bound from props - ineligible."
+           [{:keys [tag]}]
+           [tag {} "the CLJS branch has a dynamic head - ineligible"]))
+
+#?(:clj  (v/defview declaration-uniform
+           "Both branches literal elements - eligible on either target."
+           [{:keys [label]}]
+           [:span.jvm label])
+   :cljs (v/defview declaration-uniform
+           "Both branches literal elements - eligible on either target."
+           [{:keys [label]}]
+           [:span.spa label]))

--- a/implementation/freehand/test/re_frame/freehand/check_host_divergent_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/check_host_divergent_jvm_test.clj
@@ -40,12 +40,12 @@
               the finding names the CLJS-branch form the JVM reader elides —
               so the report can only be right by having analyzed that branch"
       (is (= {:view-id           :re-frame.freehand.check-host-divergent-views/host-divergent
-              :source            {:file fixture-path :line 25 :column 1}
+              :source            {:file fixture-path :line 27 :column 1}
               :current-lowering  :interpreted
               :target-grammar    :re-frame.freehand/v1
               :compile-eligible? false
               :findings          [{:id       :rf.ui.compile/dynamic-head
-                                   :source   {:line 25 :column 1}
+                                   :source   {:line 27 :column 1}
                                    :form     '[tag {} "the CLJS branch has a dynamic head - ineligible"]
                                    :reason   :head-is-a-runtime-value
                                    :recovery [:use-a-literal-head
@@ -57,7 +57,7 @@
               eligible, even though the two branches are not textually equal —
               reading both branches never invents a refusal"
       (is (= {:view-id           :re-frame.freehand.check-host-divergent-views/host-uniform
-              :source            {:file fixture-path :line 32 :column 1}
+              :source            {:file fixture-path :line 34 :column 1}
               :current-lowering  :interpreted
               :target-grammar    :re-frame.freehand/v1
               :compile-eligible? true

--- a/implementation/freehand/test/re_frame/freehand/check_host_divergent_views.cljc
+++ b/implementation/freehand/test/re_frame/freehand/check_host_divergent_views.cljc
@@ -18,8 +18,10 @@
   Loaded on the JVM (a `.cljc` namespace, required by
   `re-frame.freehand.check-host-divergent-jvm-test`); the JVM reader sees
   the `:clj` branch at load time, so both views mount interpreted without
-  incident. The checker reaches the `:cljs` branch by RE-READING the
-  source with the reader's `:features #{:cljs}`."
+  incident. The checker reaches the `:cljs` branch by re-reading the source
+  with the conditionals PRESERVED and selecting the branch itself — handing
+  the reader `:features #{:cljs}` would not do it, because the JVM reader's
+  `:clj` platform feature is always present and wins."
   (:require [re-frame.freehand :as v]))
 
 (v/defview host-divergent


### PR DESCRIPTION
Finishes the reader-conditional work started in #6717. That PR established the mechanism — read with `:read-cond :preserve` and select each target's branch by hand, past the JVM reader's unconditional `:clj` platform feature — and this one gives it the reach it claimed. Two legal placements were uncovered, and each was the same false-green in a new syntactic position.

**Inside a set.** `resolve-conditionals` descended maps, vectors and seqs. A set is none of those, so the preserved conditional fell through to the identity leg and survived: the analyzer was handed a reader object where the browser build has `#{v/sub}`, and the view reported eligible. Sets are now descended, ordinary `#?` and splicing `#?@` alike, and come back sets with their metadata.

**Around the whole declaration.** A preserved conditional is not a seq, so the `seq?`-then-resolve discovery test skipped `#?(:clj (v/defview …) :cljs (v/defview …))` entirely and the file reported *nothing* about it — the loudest false-green there is, since an author reads silence as "no findings". Discovery now runs on the resolved branches.

That second placement diverges the **params** as well as the body, so `:cljs-body` becomes `:cljs-branch` — `:params` / `:children-policy` / `:body`, the parts a conditional can make target-specific — merged over the declaration before the CLJS analysis. Analyzing the CLJS body against the `:clj` branch's params is what turns a `dynamic-head` into an `unresolved-head`: the right verdict for the wrong reason, and one edit away from being the wrong verdict.

No new diagnostic ids (the analyzer's own `:rf.ui.compile/*`), still one refusal per declaration at the first ineligible form, still read-only, and a conditional-free declaration still takes the identity fast path byte-for-byte.

**Spec unchanged**, deliberately. 004D §Where the checker runs already states the law — the checker "analyzes **every branch a compile would visit**" — so this is the implementation catching up to the spec, not a contract change. The fixture prose that claimed the checker reaches CLJS by handing the reader `:features #{:cljs}` is corrected; that was never how it worked.

## Reproduction

Fixture: `implementation/freehand/test/re_frame/freehand/check_conditional_placement_views.cljc`. Each placement appears twice — a divergent view whose `:clj` branch is inside the grammar while its `:cljs` branch is outside it, and a uniform control whose branches read differently yet are both inside it.

### Before — public `check-file`, on `main`

```
=== check-file reports ===
…/set-divergent        => :compile-eligible? true  findings: []
…/set-splice-divergent => :compile-eligible? true  findings: []
…/set-uniform          => :compile-eligible? true  findings: []

=== declaration count ===
3
```

Two false-greens, and the two declarations written under a top-level conditional are absent from the report vector altogether.

### After

```
=== check-file reports ===
…/set-divergent          => :compile-eligible? false  findings: [:rf.ui.compile/unsupported-form]
…/set-splice-divergent   => :compile-eligible? false  findings: [:rf.ui.compile/unsupported-form]
…/set-uniform            => :compile-eligible? true   findings: []
…/declaration-divergent  => :compile-eligible? false  findings: [:rf.ui.compile/dynamic-head]
…/declaration-uniform    => :compile-eligible? true   findings: []

=== declaration count ===
5
```

The refusals name the CLJS-branch forms — the bare `v/sub` the set contributes, and `[tag {} …]` — never the `:clj` branch's `1`, `#{1 2}` or `[:div …]`. Both controls stay eligible, so covering a placement manufactures no false NO. `declaration-divergent` reports `dynamic-head` rather than `unresolved-head`, which is only possible if the CLJS body was analyzed against the CLJS branch's own params.

### Checked against a real reader

`check-conditional-placement-jvm-test` also reads the fixture with `clojure.tools.reader` — which honours the `:features` set it is handed exactly, having no unconditional platform feature — and asserts the checker's hand-selection matches what that reader produces per target: the same five declarations either way, `#{1}` / `#{1 2}` on the JVM against `#{v/sub}` in the browser, and `[_]` against `[{:keys [tag]}]` for the params. The oracle is independent of the code under test.

## Known limitation, filed not fixed

A *map* splicing conditional — `{:a 1 #?@(:clj [:b 2])}` — is legal Clojure that reads fine under `:read-cond :allow` but throws `Map literal must contain an even number of forms` under `:preserve`, because the map reader counts forms before splicing. `check-file` on such a source raises a raw reader exception instead of answering. That is a limitation of the reader in preserve mode rather than a hole in the branch selection, and reaching it needs the checker to read maps flat — the "general-purpose source analyzer" non-goal. Filed as a separate bug with two proportionate options; the cheap one is to catch and re-throw as a checker refusal naming the workaround.

## Quality gates

All run in this worktree, foreground, one at a time.

| Gate | Result |
|---|---|
| `cd implementation/freehand && clojure -M:test` | **477 tests, 3112 assertions, 0 failures, 0 errors** |
| `npm run test:freehand` | **343 tests, 2406 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` | **10464 tests, 52486 assertions, 0 failures, 0 errors** |
| `python scripts/check_keyword_catalogue_drift.py` | clean (exit 0) |
| `python scripts/check_freehand_conformance_index.py` | clean (exit 0) |
| `python scripts/check_doc_slugs.py` | clean (exit 0) |

**Non-vacuity.** `(is (= 5 (count reports)))` in `the-refusal-names-the-cljs-branch-form` inverted to `3` — the pre-fix count. The full `clojure -M:test` gate went red naming the test:

```
Testing re-frame.freehand.check-conditional-placement-jvm-test
FAIL in (the-refusal-names-the-cljs-branch-form) (check_conditional_placement_jvm_test.clj:148)
Ran 477 tests containing 3112 assertions.
1 failures, 0 errors.
```

Restored, and the file is byte-identical: `sha256 58736674f7e02177f80969d92569d0f501cf1daaacb0349c66697c6a573fb6f8` before and after.

**Read-only.** Both checker fixtures are asserted byte-identical after a `check-file` run — `check_conditional_placement_views.cljc` by the new suite, `check_host_divergent_views.cljc` by the existing one.
