### PR TITLE
fix(freehand): keep structural trees EDN-round-trippable for nested non-data values (rf2-drpa3.72)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -50,6 +50,80 @@
   (name (:type (shape x))))
 
 ;; ---------------------------------------------------------------------------
+;; Data — what a recorded value may contain, at every depth
+;; ---------------------------------------------------------------------------
+;;
+;; Spec 004B §The node schema: the tree is plain, serialisable data, and EDN
+;; print/read round-trips it losslessly. Two slots record a value the tree did
+;; not build — a view boundary's `:props` and an element's `:events` — and both
+;; are exactly where a host value can walk in. The rule they share:
+;;
+;;   THE OPAQUE MARKER OCCUPIES A SITE, NEVER A VALUE INSIDE ONE.
+;;
+;; A prop or handler that IS a function records as `{:rf.ui/opaque :fn}`: the
+;; site is named by the grammar, so its existence and spelling stay testable
+;; while its behaviour does not. Below that key the grammar names no sites, so
+;; a marker written there would claim one that does not exist and would quietly
+;; replace a value the author will go looking for — and an event vector, which
+;; is compared as data in a test and dispatched as data at run time, would
+;; record an intent that no longer means what the site does. So a non-data
+;; value nested inside a recorded value is REFUSED, at the site that recorded
+;; it, exactly as every other value outside the tree's closed grammars is.
+
+(defn- edn-scalar?
+  "Is `x` an EDN leaf — a value that prints and reads back as itself on
+  BOTH hosts?"
+  [x]
+  (or (string? x) (keyword? x) (number? x) (boolean? x) (nil? x) (symbol? x)
+      (uuid? x)
+      ;; EDN's other built-in tagged literal. `inst?` is NOT the predicate:
+      ;; it answers true for `java.time.Instant`, which prints `#object[…]`
+      ;; and does not read back. The instant that prints `#inst` is the
+      ;; host's own, and it is the one both readers reconstruct.
+      (instance? #?(:clj java.util.Date :cljs js/Date) x)))
+
+(defn- non-data
+  "`[path value]` for the FIRST value inside `x` that is not data, or nil
+  when `x` is data all the way down. `path` is the map keys and vector
+  indices walked to reach it, so a diagnostic names the offending SITE
+  rather than the whole prop.
+
+  READ-ONLY and short-circuiting — nothing is rebuilt, and the walk stops
+  at the first offender. The ordinary case (a scalar prop, or a small map
+  of them) costs one predicate per value and allocates nothing, which is
+  what lets the rule hold at every depth without a sanitizing copy of
+  every prop on every render."
+  [x]
+  (cond
+    (edn-scalar? x)
+    nil
+
+    ;; `reduce-kv` over a vector answers index/element — exactly the path
+    ;; segment wanted — so maps and vectors share one arm.
+    (or (map? x) (vector? x))
+    (reduce-kv (fn [_ k v]
+                 (if-let [found (or (non-data k)
+                                    (when-let [[p bad] (non-data v)]
+                                      [(into [k] p) bad]))]
+                   (reduced found)
+                   nil))
+               nil
+               x)
+
+    ;; A set or a seq has no position worth naming, so the path stops here.
+    (coll? x)
+    (reduce (fn [_ v] (when-let [found (non-data v)] (reduced found))) nil x)
+
+    :else
+    [[] x]))
+
+(defn- at-path
+  "The ` at [:config :callback]` clause of a diagnostic, or nothing when the
+  offending value IS the recorded value."
+  [path]
+  (if (seq path) (str " at " (pr-str path)) ""))
+
+;; ---------------------------------------------------------------------------
 ;; The namespace context (SVG / MathML)
 ;; ---------------------------------------------------------------------------
 ;;
@@ -255,12 +329,41 @@
   "One `:events` entry value, classified BY THE VALUE PRESENT AT RENDER
   (Spec 004B §Element fields): a vector is a literal event intent, a map is
   an options map, a function is a site whose spelling is testable and whose
-  behaviour is not, and nil drops the entry."
+  behaviour is not, and nil drops the entry.
+
+  An intent and an options map are recorded VERBATIM, so they must already
+  be data — a function riding as an event argument would record an intent
+  that cannot be compared, printed, or dispatched as the site's own
+  (§Data)."
   [tag k v]
   (cond
     (nil? v)    nil
-    (vector? v) v
-    (map? v)    v
+    (vector? v) (do (when-let [[path bad] (non-data v)]
+                      (malformed!
+                        're-frame.freehand/render
+                        (str "The " k " handler on " tag " carries a " (type-name bad)
+                             (at-path path)
+                             " inside its event intent. An event vector is recorded "
+                             "verbatim and is data through and through — a test compares "
+                             "it as data and the event system dispatches it as data, so "
+                             "an argument inside it has no cross-host spelling. A function "
+                             "records as the opaque marker when it IS the handler value; "
+                             "it cannot ride inside the intent.")
+                        {:attr k :path path :value (shape bad)}))
+                    v)
+    (map? v)    (do (when-let [[path bad] (non-data v)]
+                      (malformed!
+                        're-frame.freehand/render
+                        (str "The " k " handler on " tag " carries a " (type-name bad)
+                             (at-path path)
+                             " inside its options map. An options map is recorded verbatim "
+                             "and is data through and through — the structural tree prints "
+                             "and reads back losslessly, so a value inside one has no "
+                             "cross-host spelling. A function records as the opaque marker "
+                             "when it IS the handler value; it cannot ride inside the "
+                             "options.")
+                        {:attr k :path path :value (shape bad)}))
+                    v)
     (fn? v)     {:rf.ui/opaque :fn}
     :else
     (malformed!
@@ -370,11 +473,26 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- recorded-prop
-  "A prop value as the boundary records it. Non-data values become the
-  opaque marker — their existence and spelling stay testable, their
-  behaviour does not (Spec 004B §The opaque marker)."
-  [x]
-  (if (fn? x) {:rf.ui/opaque :fn} x))
+  "A prop value as the boundary records it. A prop that IS a function
+  becomes the opaque marker — its existence and spelling stay testable,
+  its behaviour does not (Spec 004B §The opaque marker). A prop that
+  CONTAINS one is refused: the marker occupies a site, and below a prop key
+  the tree has no site vocabulary to name (§Data)."
+  [view-id k x]
+  (if (fn? x)
+    {:rf.ui/opaque :fn}
+    (do (when-let [[path bad] (non-data x)]
+          (malformed!
+            're-frame.freehand/render
+            (str "The " k " prop on " view-id " carries a " (type-name bad)
+                 (at-path path)
+                 ". A recorded prop is data through and through — the structural "
+                 "tree prints and reads back losslessly on both hosts, so a value "
+                 "inside one has no cross-host spelling. A callback records as the "
+                 "opaque marker when it IS the prop; pass it as its own prop rather "
+                 "than nesting it in data.")
+            {:prop k :path path :value (shape bad)}))
+        x)))
 
 (defn- plain-fragment?
   "Is `x` a fragment node carrying nothing but its children?
@@ -411,7 +529,7 @@
   what makes a `:view-id` predicate a total selector (Spec 004B
   §Coverage Q12)."
   [view-id props key kids]
-  (let [recorded (reduce-kv (fn [m k x] (assoc m k (recorded-prop x)))
+  (let [recorded (reduce-kv (fn [m k x] (assoc m k (recorded-prop view-id k x)))
                             {} (dissoc props :children))
         kids     (if (and (= 1 (count kids)) (plain-fragment? (first kids)))
                    (vec (:children (first kids)))

--- a/implementation/freehand/src/re_frame/freehand/tree.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tree.cljc
@@ -140,7 +140,16 @@
         kids    (case (:status outcome)
                   :ok        (:result outcome)
                   :contained (children [fallback]))]
-    (node/boundary eb/boundary-view-id props key kids)))
+    ;; `:fallback` is dropped from the record for the reason `:children` is
+    ;; (see [[re-frame.freehand.node/boundary]]): it is a markup FORM, not a
+    ;; value. Recorded verbatim it would put an unwalked template — whose head
+    ;; is a view DESCRIPTOR in the documented `{:fallback [broken-page {}]}`
+    ;; shape — into a slot the node schema says holds data, and the tree would
+    ;; stop printing and reading back. Nothing is lost: `read-opts` REQUIRES a
+    ;; fallback, so its presence proves nothing a test could not already
+    ;; assume, and a contained boundary shows the walked fallback subtree as
+    ;; its children.
+    (node/boundary eb/boundary-view-id (dissoc props :fallback) key kids)))
 
 ;; ---------------------------------------------------------------------------
 ;; Element nodes

--- a/implementation/freehand/test/re_frame/freehand/compiled_promotion_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/compiled_promotion_cljs_test.cljc
@@ -69,6 +69,23 @@
         (is (= (as-compiled-ids tree) (tree/render (into [promoted] call)))
             (str note " (compiled — the same tree, from the same call)"))))))
 
+(deftest promotion-does-not-change-what-a-prop-may-carry
+  (testing "Per FH-STRUCT-006's rejection table: the prop-recording rule
+            is ONE rule, because both modes reach `:props` through the
+            same builder. A callback nested inside a recorded prop is
+            refused identically whether the declaration is interpreted or
+            compiled — a mode that quietly accepted one would be a second
+            tree format wearing the first one's name."
+    (is (seq (:rejected struct-006)) "the fixture's rejection table loaded")
+    (doseq [{:keys [note view args error-id]} (:rejected struct-006)]
+      (let [call (into [] (realize args))]
+        (is (= error-id (conf/caught-id
+                          #(tree/render (into [(get views/by-name view)] call))))
+            (str note " (interpreted)"))
+        (is (= error-id (conf/caught-id
+                          #(tree/render (into [(get compiled/by-name view)] call))))
+            (str note " (compiled — the same refusal, from the same call)"))))))
+
 (deftest the-proof-is-not-vacuous
   (testing "Both halves of the comparison must actually be the two modes.
             A promotion proof where both sides are interpreted proves

--- a/implementation/freehand/test/re_frame/freehand/tree_parity_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/tree_parity_cljs_test.cljc
@@ -16,6 +16,7 @@
   (:require [clojure.edn :as edn]
             [clojure.test :refer [deftest is testing]]
             [clojure.walk :as walk]
+            [re-frame.freehand :as v]
             [re-frame.freehand.conformance :as conf]
             [re-frame.freehand.tree :as tree]
             [re-frame.freehand.tree-views :as views]))
@@ -86,6 +87,24 @@
                           ["a callback AT the prop site records as the marker"
                            {:title "Details" :on-pick (fn [_] nil)}]]]
       (let [t (tree/render [views/panel props])]
+        (is (= t (edn/read-string (pr-str t)))
+            (str note " — the tree prints and reads back losslessly"))))))
+
+(deftest fh-struct-006-a-template-option-is-structural-not-recorded
+  (testing "Per FH-STRUCT-006: `v/error-boundary`'s `:fallback` is a markup
+            FORM, and a form is not a value. Recorded verbatim the
+            documented `{:fallback [broken-page {}]}` shape would put a
+            view DESCRIPTOR into a slot the node schema says holds data,
+            and the tree would stop reading back — so the template option
+            is dropped from the record for the reason `:children` is, and
+            every documented fallback spelling round-trips."
+    (doseq [[note fallback] [["a declared-view fallback — the documented shape"
+                              [views/panel {:title "sorry"}]]
+                             ["plain markup" [:p.fallback "sorry"]]
+                             ["a bare declared view" views/panel]]]
+      (let [t (tree/render [v/error-boundary {:fallback fallback}
+                            [views/panel {:title "ok"}]])]
+        (is (nil? (:props t)) (str note " — the template is not recorded as a prop"))
         (is (= t (edn/read-string (pr-str t)))
             (str note " — the tree prints and reads back losslessly"))))))
 

--- a/implementation/freehand/test/re_frame/freehand/tree_parity_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/tree_parity_cljs_test.cljc
@@ -49,3 +49,57 @@
       (is (< 1 (count (tree-seq map? :children t))) "the tree has interior nodes to lose")
       (is (= t (edn/read-string (pr-str t)))
           "the tree round-trips through print and read, losslessly"))))
+
+;; ---------------------------------------------------------------------------
+;; The round-trip at depth — the opaque marker occupies a SITE
+;; ---------------------------------------------------------------------------
+
+(deftest fh-struct-006-a-nested-non-data-value-is-refused
+  (testing "Per FH-STRUCT-006: a prop that IS a callback records as the
+            opaque marker, because the grammar names that site. A callback
+            NESTED inside a recorded prop has no site to occupy, so it is
+            refused at the boundary rather than marked — a marker written
+            below the prop key would claim a site the grammar does not
+            have and would silently replace the value the author passed."
+    (is (seq (:rejected struct-006)) "the fixture's rejection table loaded")
+    (doseq [{:keys [note view args error-id]} (:rejected struct-006)]
+      (let [declared (get views/by-name view)]
+        (is (some? declared) (str "the fixture names a declared view: " view))
+        (is (= error-id
+               (conf/caught-id #(tree/render (into [declared] (realize args)))))
+            note)))))
+
+(deftest fh-struct-006-every-accepted-prop-shape-round-trips
+  (testing "Per FH-STRUCT-006: the round-trip is a claim about the WHOLE
+            recorded value. A prop carrying ordinary EDN at depth — and
+            EDN's own tagged literals — survives print/read unchanged, and
+            so does a prop that is a callback, because the marker it
+            records as IS data. This is the assertion the nested-fn bug
+            broke: the tree printed `#object[…]` and read back nowhere."
+    (doseq [[note props] [["ordinary EDN at depth"
+                           {:title "Details"
+                            :config {:a [1 2 #{:c}] :b 'sym :c nil :d 1.5}}]
+                          ["EDN's own tagged literals"
+                           {:title "Details"
+                            :config {:id #uuid "00000000-0000-0000-0000-000000000001"
+                                     :when #inst "1970-01-01T00:00:00.000-00:00"}}]
+                          ["a callback AT the prop site records as the marker"
+                           {:title "Details" :on-pick (fn [_] nil)}]]]
+      (let [t (tree/render [views/panel props])]
+        (is (= t (edn/read-string (pr-str t)))
+            (str note " — the tree prints and reads back losslessly"))))))
+
+(deftest fh-struct-006-the-round-trip-assertion-can-fail
+  (testing "Per FH-STRUCT-006: the round-trip assertion is not vacuous.
+            The KNOWN-BAD control is the pre-fix tree — the value the
+            boundary used to record when a callback was nested inside a
+            prop — asserted directly, because no boundary will build one
+            any more. Print/read must NOT reproduce it; an assertion that
+            cannot fail proves nothing about the ones that pass."
+    (let [pre-fix {:view-id ::pre-fix
+                   :props   {:config {:callback (fn [_] nil)}}
+                   :rf.ui/tree-version 1}]
+      (is (not= pre-fix
+                (try (edn/read-string (pr-str pre-fix))
+                     (catch #?(:clj Throwable :cljs :default) _ ::unreadable)))
+          "a host value nested in :props does not survive print and read"))))

--- a/spec/004B-UI-Tree-and-Conversion.md
+++ b/spec/004B-UI-Tree-and-Conversion.md
@@ -245,6 +245,25 @@ namespace is reserved (Conventions), so author data can never collide with the m
 the one the interpreted walk produces; the members naming a specific authoring form
 arrive with the slice that lands the form.
 
+**The marker occupies a site, never a value inside one.** Three slots record a value
+the tree did not itself build — a view boundary's `:props`, and an element's `:events`
+entry when it holds an event vector or an options map — and each is recorded
+**verbatim**, so each is a way a host value could walk into a tree that promises to
+print and read back. The rule is one rule at every depth: a prop or handler value that
+**is** a function records as the marker, because the grammar names that site and the
+site's existence and spelling are what a structural test asserts on. A non-data value
+**nested inside** a recorded value is **rejected** — `:rf.error/ui-tree-malformed`,
+raised at the recording site, naming the prop or handler key and the path to the
+offender. Below a prop or handler key the grammar names no sites, so a marker written
+there would claim one that does not exist and would silently replace a value the author
+will go looking for; and an event vector is dispatched as data at run time as well as
+compared as data in a test, so an intent carrying a marker would no longer mean what
+its site does. "Data" here is the **EDN value grammar** exactly — nil, booleans,
+strings, keywords, symbols, numbers, `#uuid`, `#inst`, and collections of those; the
+grammar the round-trip promise is stated in. Ordinary nested EDN is untouched, and the
+check is read-only: nothing is rewritten, so a prop that passes is the value the author
+passed.
+
 `:v/render-fn` is the compiled render-slot member ([004D §Compiled render slots](004D-Freehand-Compiled-Grammar.md#compiled-render-slots--render-fn-and-slot)):
 a `v/render-fn` value carried as a component-call-site prop is recorded on that
 view-boundary's `:props` as `{:rf.ui/opaque :v/render-fn}`. The render-fn's *rendered

--- a/spec/004B-UI-Tree-and-Conversion.md
+++ b/spec/004B-UI-Tree-and-Conversion.md
@@ -264,6 +264,15 @@ grammar the round-trip promise is stated in. Ordinary nested EDN is untouched, a
 check is read-only: nothing is rewritten, so a prop that passes is the value the author
 passed.
 
+A **template option is not a prop at all.** A reserved internal view whose option holds
+*markup* rather than a value — `v/error-boundary`'s `:fallback` — has that option
+dropped from the record, for the same reason `:children` is dropped: a form is
+structural, and it is visible as the expansion it produces (a contained boundary's
+children *are* the walked fallback). Recorded verbatim it would put an unwalked
+template — whose head is a view **descriptor** in the documented `{:fallback
+[broken-page {}]}` spelling — into a slot the schema says holds data. Nothing is lost:
+the option is required, so its presence proves nothing.
+
 `:v/render-fn` is the compiled render-slot member ([004D §Compiled render slots](004D-Freehand-Compiled-Grammar.md#compiled-render-slots--render-fn-and-slot)):
 a `v/render-fn` value carried as a component-call-site prop is recorded on that
 view-boundary's `:props` as `{:rf.ui/opaque :v/render-fn}`. The render-fn's *rendered

--- a/spec/conformance/freehand/fixtures/fh-struct-002.edn
+++ b/spec/conformance/freehand/fixtures/fh-struct-002.edn
@@ -9,7 +9,11 @@
 ;;
 ;; `:fh/fn` is the fixture's stand-in for a function value — EDN carries
 ;; no functions, so the suite substitutes a real one and the fixture pins
-;; what the tree records for it.
+;; what the tree records for it. The stand-in appears in both tables on
+;; purpose: a handler that IS a function records as the opaque marker,
+;; while one nested inside an event intent or an options map is refused,
+;; because the marker occupies a SITE and there is no site vocabulary
+;; below a handler key.
 {:fh/id "FH-STRUCT-002"
  :fh/law
  "An element node carries :tag verbatim, sugar merged sugar-first, disjoint :attrs and :events, :key iff keyed, :ns absent for HTML, and every optional field absent when empty."
@@ -62,7 +66,14 @@
    :tree {:tag :div :attrs {:online "yes"} :rf.ui/tree-version 1}}]
 
  :rejected
- [{:note "two id spellings on one element is an ambiguity, not a precedence question"
+ [{:note "the opaque marker occupies a SITE — a fn inside an event intent is refused, not marked"
+   :form [:button {:on-click [:app/go :fh/fn]}] :error-id :rf.error/ui-tree-malformed}
+  {:note "the same rule at depth — an intent is data all the way down"
+   :form [:button {:on-click [:app/go {:opts [:fh/fn]}]}] :error-id :rf.error/ui-tree-malformed}
+  {:note "an options map is recorded verbatim, so it too is data all the way down"
+   :form [:form {:on-submit {:event [:cart/checkout] :after :fh/fn}}]
+   :error-id :rf.error/ui-tree-malformed}
+  {:note "two id spellings on one element is an ambiguity, not a precedence question"
    :form [:div#a {:id "b"}] :error-id :rf.error/ui-tree-malformed}
   {:note "a void element rejects children — React throws rather than render one"
    :form [:br "x"] :error-id :rf.error/ui-tree-malformed}

--- a/spec/conformance/freehand/fixtures/fh-struct-006.edn
+++ b/spec/conformance/freehand/fixtures/fh-struct-006.edn
@@ -101,4 +101,22 @@
             :attrs {:id "main" :class "panel open" :tab-index "3"}
             :children [{:tag :h2 :children ["Details"]}
                        {:tag :ul :attrs {:class "rows"}}]}]
-          :rf.ui/tree-version 1}}]}
+          :rf.ui/tree-version 1}}]
+
+ ;; The round-trip is the reason a boundary sanitizes props at all, and it
+ ;; is a claim about the WHOLE recorded value, not its first level. The
+ ;; opaque marker occupies a SITE — a prop that IS a callback — because a
+ ;; site is what the grammar names and what a test asserts on. Below the
+ ;; prop key there is no site vocabulary, so a marker written there would
+ ;; claim one that does not exist and would silently replace the value the
+ ;; author passed. Refused instead, at the boundary that recorded it.
+ :rejected
+ [{:note "a callback NESTED in a data prop is refused — the marker occupies a site, not a value inside one"
+   :view :panel
+   :args [{:title "Details" :config {:callback :fh/fn}}]
+   :error-id :rf.error/ui-tree-malformed}
+
+  {:note "the same rule at depth — a recorded prop is data all the way down"
+   :view :panel
+   :args [{:title "Details" :config [:a [:b {:cb :fh/fn}]]}]
+   :error-id :rf.error/ui-tree-malformed}]}


### PR DESCRIPTION
Spec 004B promises every structural tree is plain, serialisable data that EDN
print/read round-trips losslessly. The interpreted walk only replaced a prop
when the prop value *itself* was a function; event vectors and options maps were
recorded verbatim. A non-data value one level down therefore survived into the
tree, and the tree stopped printing.

## The reproduction, on current main

Rendering a Freehand view and asking whether the tree survives `pr-str` →
`read-string`, before the fix:

```
=== A. nested fn in a boundary prop ===
PR-STR:    {:view-id :user/cfg-view, :props {:config {:callback #object[clojure.core$identity …]}}, …}
READ-BACK: THREW java.lang.RuntimeException: No reader function for tag object

=== B. nested fn in an event vector ===
PR-STR:    {:tag :button, :events {:on-click [:app/go #object[clojure.core$identity …]]}, …}
READ-BACK: THREW java.lang.RuntimeException: No reader function for tag object

=== C. nested fn in an event options map ===
PR-STR:    {:tag :button, :events {:on-click {:event [:app/go], :after #object[clojure.core$identity …]}}, …}
READ-BACK: THREW java.lang.RuntimeException: No reader function for tag object
```

Chasing it down surfaced a second, shipped instance of the same bug — the
documented `[v/error-boundary {:fallback [broken-page {}]} child]` spelling. At
run time that markup vector's head is a view **descriptor**, a `deftype` which
prints `#object[…]`, and it was recorded verbatim into the boundary node's
`:props`. The most-cited fallback shape in the docs produced a tree that could
not print, read back, compare or fingerprint. It is fixed here too.

## The ruling: REFUSE, not represent

**The opaque marker occupies a site, never a value inside one.**

A prop or handler value that *is* a function still records as
`{:rf.ui/opaque :fn}` — unchanged. A non-data value *nested inside* a recorded
prop, event vector or options map is **refused** with the existing
`:rf.error/ui-tree-malformed`, raised at the recording site, naming the prop or
handler key and the path to the offender.

The reasoning, in the order it decided the question:

1. **The marker's meaning is a site, not a value.** It exists because a handler
   site and a callback prop are the two places a function is the legitimate
   authored thing, and what a structural test asserts there is *existence and
   spelling* — `(contains? (t/attrs node) :on-save)`. That is what makes the
   marker informative. Below a prop or handler key the grammar names no sites,
   so a marker written there would claim one that does not exist.

2. **Representing would make the tree lie, silently.** `{:config {:callback f}}`
   would record as `{:config {:callback {:rf.ui/opaque :fn}}}` — a value that
   never existed at the boundary, which the author will then fail to recognise
   in a test. The failure mode is a passing assertion about a fiction.

3. **An event vector must stay dispatchable.** `[:app/go f]` recorded as
   `[:app/go {:rf.ui/opaque :fn}]` is an intent that no longer means what its
   site does. The test surface's headline claim — "event intent is an equality
   check on plain data" — depends on the recorded intent *being* the intent.

4. **Refusal is what every neighbour already does.** `attr-entry`,
   `opaque-child!`, `style-map`, `class-string` and `classify-event`'s own
   `:else` all reject a value outside their closed grammar, citing "no
   cross-host spelling to carry". The marker is the single deliberate exception,
   bought for one case; generalising it to every depth would spend that
   exception everywhere.

5. **Representing needs a rebuild; refusing needs only a look.** A deep
   sanitizing walk would copy every nested collection an author passes across a
   boundary, on every render, and would need a policy for records, arrays,
   custom-comparator sorted maps, and lazy seqs — the general serialization
   framework this bead's scope rules out. The check as written is read-only and
   short-circuiting: nothing is rebuilt, so **a prop that passes is the value
   the author passed**, and the ordinary case costs one predicate.

"Data" is the **EDN value grammar** exactly — nil, booleans, strings, keywords,
symbols, numbers, `#uuid`, `#inst`, and collections of those. `inst?` is
deliberately *not* the predicate: it answers true for `java.time.Instant`, which
prints `#object[…]` and does not read back. The instant that prints `#inst` is
the host's own, and it is the one both readers reconstruct.

No new diagnostic id: `:rf.error/ui-tree-malformed` is the id the tree path
already raises for a malformed value, reused as the brief asks.

## The error boundary's `:fallback`

A **template option is not a prop**. `:fallback` is a markup *form*, and a form
is structural, not a value — so it is dropped from the record for the reason
`:children` is, and it is visible as the expansion it produces (a contained
boundary's children *are* the walked fallback). Nothing is lost: `read-opts`
*requires* a fallback, so its presence in `:props` proved nothing a test could
not already assume. All three documented spellings — a declared-view call, plain
markup, and a bare declared view — now render and round-trip.

## What changed

| File | |
|---|---|
| `node.cljc` | the data rule (`edn-scalar?` / `non-data`), wired into `recorded-prop` and `classify-event` |
| `tree.cljc` | `mount-error-boundary` drops `:fallback` from the record |
| `spec/004B` §The opaque marker | states the depth rule and the template-option rule |
| `fh-struct-002.edn` | three `:rejected` rows — the event surface |
| `fh-struct-006.edn` | a new `:rejected` table — the prop surface |
| `tree_parity_cljs_test.cljc` | drives 006's rejections; round-trip rows; the known-bad control |
| `compiled_promotion_cljs_test.cljc` | proves the refusal is identical in both modes |

Both modes reach `:props` and `:events` through the same builders, so the rule
is shared by construction — and asserted, not assumed.

Not a public-verb change; the api-manifest surface is untouched.
`git grep 're-frame.ui' implementation/freehand/` stays empty.

## Quality gates

All foreground, one at a time, on the rebased branch.

| Gate | Result |
|---|---|
| `cd implementation/freehand && clojure -M:test` | **500 tests, 3265 assertions, 0 failures, 0 errors** |
| `npm run test:freehand` | **367 tests, 2573 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` | **10488 tests, 52655 assertions, 0 failures, 0 errors** |
| `python scripts/check_freehand_conformance_index.py` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |

**No regression to the shipped corpus.** Every FH row and conformance fixture
still passes; no existing `:cases` row was edited — the fixture diffs are added
`:rejected` rows and comments only, so every previously pinned tree is
byte-identical.

**Non-vacuity.** Inverting `=` to `not=` in
`fh-struct-006-a-nested-non-data-value-is-refused`:

```
FAIL in (fh-struct-006-a-nested-non-data-value-is-refused) (tree_parity_cljs_test.cljc:68)
  actual: (not (not= :rf.error/ui-tree-malformed :rf.error/ui-tree-malformed))
Ran 491 tests containing 3201 assertions.  2 failures, 0 errors.       [JVM]

FAIL in (fh-struct-006-a-nested-non-data-value-is-refused) (re_frame/freehand/tree_parity_cljs_test.cljc:68:13)
Ran 363 tests containing 2516 assertions.  2 failures, 0 errors.       [CLJS]
```

Both hosts red, naming the test. Restored and verified byte-identical by
`sha256sum` (`d54052100d605bdd…`), and green again. (Those totals are lower than
the table above because the inversion ran before the rebase onto current `main`;
the branch was rebased and every gate re-run to completion afterwards.)

A second, standing control lives in the suite:
`fh-struct-006-the-round-trip-assertion-can-fail` asserts the *pre-fix* tree
directly — the value the boundary used to record — and proves print/read does
not reproduce it. Without it, `(= v (read-string (pr-str v)))` could be passing
for want of anything to break.

Closes rf2-drpa3.72.
