### PR TITLE
fix(freehand): commit-owned presence across abandoned renders + explicit nil keys (rf2-drpa3.86, rf2-drpa3.87)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/descriptor.cljc
+++ b/implementation/freehand/src/re_frame/freehand/descriptor.cljc
@@ -400,8 +400,9 @@
   call vector — the props map followed by any trailing children.
 
       [panel {:key panel-id :title \"Details\"} [details {:id panel-id}]]
-      ;; => {:key panel-id
-      ;;     :props {:title \"Details\" :children [[details {:id panel-id}]]}}
+      ;; => {:key    panel-id
+      ;;     :keyed? true
+      ;;     :props  {:title \"Details\" :children [[details {:id panel-id}]]}}
 
   The laws it enforces, identically in both execution modes:
 
@@ -413,7 +414,11 @@
     yields the smallest props map that can compare equal;
   - **`:key` is stripped** — it selects sibling identity for
     reconciliation and the view body never sees it. It is returned
-    separately, and it is not part of the props map's equality;
+    separately, and it is not part of the props map's equality.
+    `:keyed?` reports whether the call supplied one AT ALL: React
+    string-coerces a supplied key, so an explicit `nil` is the legal
+    identity `\"null\"` and a different authored fact from no key —
+    a distinction `:key` alone cannot carry, since both read `nil`;
   - **the declared children policy holds** — children against a `:none`
     view, or none against a `:required` view, is
     `:rf.error/view-children-policy`."
@@ -456,7 +461,8 @@
            :extra    {:view-id         view-id
                       :children-policy policy
                       :children-count  (count children)}}))
-      {:key   (:key props)
-       :props (cond-> (dissoc props :key)
-                children (assoc :children children))})))
+      {:key    (:key props)
+       :keyed? (contains? props :key)
+       :props  (cond-> (dissoc props :key)
+                 children (assoc :children children))})))
 

--- a/implementation/freehand/src/re_frame/freehand/presence_runtime.cljc
+++ b/implementation/freehand/src/re_frame/freehand/presence_runtime.cljc
@@ -362,9 +362,13 @@
         ;; forceUpdate cell — the setter identity is stable across renders.
         tick       (react/useState 0)
         force!     (fn [] ((aget tick 1) inc))
-        ;; committed state (source of truth) — mutated ONLY in the effect /
-        ;; removal callbacks, never during render, so `reconcile` reads a stable
-        ;; snapshot and a StrictMode double-render is idempotent.
+        ;; COMMITTED state (source of truth) — one ref the current and the
+        ;; work-in-progress fiber BOTH see. Mutated only in the commit effect
+        ;; and the removal callbacks, never during render, so `reconcile` reads
+        ;; a stable snapshot, a StrictMode double-render is idempotent, and a
+        ;; render React abandons leaves it exactly as it found it. The lazy seed
+        ;; below is the one render-phase write, and it can only ever install the
+        ;; empty state.
         st         (react/useRef nil)
         incoming-pairs (incoming-identities incoming)
         incoming-keys  (mapv first incoming-pairs)]
@@ -378,11 +382,12 @@
       ;; hydration signal to consult, so it always seeds the client-mount path.
       (set! (.-current st) #js {:entries [] :elements {} :timers {}}))
     (let [state    (.-current st)
-          ;; keep the latest element for every incoming key; retained keys keep
-          ;; their last-seen element.
+          ;; THIS RENDER'S CANDIDATE element map — a value this render holds and
+          ;; returns its output from, never a publication. The committed
+          ;; snapshot with the incoming elements laid over it; a retained key
+          ;; keeps its last COMMITTED element.
           elements (merge (.-elements state) (into {} incoming-pairs))
           desired  (reconcile (.-entries state) incoming-keys)]
-      (set! (.-elements state) elements)
       ;; Commit + phase transitions run AFTER paint (a side-effect, never during
       ;; render). Runs every commit; idempotent via signature guards.
       (react/useEffect
@@ -391,9 +396,22 @@
                ;; re-derived from the same props the render saw; the uniqueness
                ;; claim is pure, so both paths agree on the ordered key set
                ;; (the dev warning already fired during render).
-               desired (reconcile (.-entries state)
-                                  (mapv first (first (claim-identities
-                                                      (collect-elements [] incoming)))))
+               pairs   (first (claim-identities (collect-elements [] incoming)))
+               ;; PUBLISH the elements — here, because React runs an effect only
+               ;; for a render it COMMITTED. A candidate React abandons (a
+               ;; transition that suspends, a superseded render) runs no effect
+               ;; and so publishes nothing, exactly as a dropped
+               ;; `re-frame.freehand.cell` candidate does. Publishing during
+               ;; render instead would hand a never-committed element to the
+               ;; shared ref that the CURRENT tree renders from, and the next
+               ;; timer-driven commit would paint it.
+               ;;
+               ;; `.-elements` is re-read here rather than reusing the render's
+               ;; merge, so a removal callback that fired in the render→commit
+               ;; gap is not undone by a stale snapshot.
+               _       (set! (.-elements state)
+                             (merge (.-elements state) (into {} pairs)))
+               desired (reconcile (.-entries state) (mapv first pairs))
                timers  (.-timers state)
                ;; 1. schedule a removal timer for each newly-:unmounting key
                ;; 2. cancel the timer for each re-entered key

--- a/implementation/freehand/src/re_frame/freehand/react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/react.cljs
@@ -163,7 +163,14 @@
             (put-attr! o tag k raw))
 
         :else (put-attr! o tag k raw)))
-    (when (some? (:key attrs))
+    ;; Key PRESENCE, not key truth. React string-coerces whatever key it is
+    ;; given, so an explicit `nil` is the ordinary identity "null" — and a
+    ;; different authored fact from no key at all, which matters wherever a
+    ;; keyed reconciler is watching (`(v/presence …)` DROPS a keyless child).
+    ;; `(:key attrs)` answers nil for both, so the question is `contains?`.
+    ;; A key whose value is `js/undefined` stays absent, which is React's own
+    ;; rule and what the presence keyless advisory describes.
+    (when (contains? attrs :key)
       (gobj/set o "key" (:key attrs)))
     o))
 
@@ -373,18 +380,22 @@
 (defn- fragment-node
   [cand args]
   (let [attrs? (map? (first args))
-        k      (when attrs? (:key (first args)))
+        attrs  (when attrs? (first args))
         kids   (children cand (if attrs? (rest args) args))]
     (apply react/createElement
            react/Fragment
-           (when (some? k) #js {:key k})
+           ;; Key PRESENCE — see `react-props`.
+           (when (contains? attrs :key) #js {:key (:key attrs)})
            kids)))
 
 (defn- boundary-node
   [view args]
-  (let [{:keys [key props]} (descriptor/normalize-call view args)
+  (let [{:keys [key keyed? props]} (descriptor/normalize-call view args)
         js-props (js-obj "props" props)]
-    (when (some? key)
+    ;; Key PRESENCE — see `react-props`. `normalize-call` reports it, because
+    ;; the stripped `:key` value alone cannot tell an explicit nil from an
+    ;; absent key.
+    (when keyed?
       (gobj/set js-props "key" key))
     (react/createElement (component-for view) js-props)))
 

--- a/implementation/freehand/test/re_frame/freehand/presence_commit_ownership_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/presence_commit_ownership_dom_cljs_test.cljs
@@ -1,0 +1,277 @@
+(ns re-frame.freehand.presence-commit-ownership-dom-cljs-test
+  "Presence is COMMIT-OWNED — a render React abandons publishes nothing.
+
+  The atomic shell's governing law (`re-frame.freehand.cell`) is that a
+  speculative render owns nothing and only the SELECTED commit publishes.
+  The presence boundary holds committed state of its own — the retained
+  element per key — and it is under the same law: React may render a
+  candidate and then throw it away (a suspended transition, a superseded
+  render), and that candidate must not leave its elements where a later
+  COMMITTED update can render them.
+
+  The probe below is a real `react-dom/client` mount driving a genuinely
+  abandoned render: a transition re-enters a retained key with a new
+  element and then suspends in a sibling, so the candidate really renders
+  and really never commits. An unrelated, EARLIER exit timer then fires and
+  force-updates the current tree — the one commit that would publish a
+  leaked element. The retained child must still show its last COMMITTED
+  element.
+
+  The retention runtime is SHARED by interpreted and compiled markup (one
+  `presence-runtime/PresenceComponent`, two lowerings onto it), so this
+  proof binds both modes: there is no second element store for a compiled
+  presence boundary to leak through.
+
+  This file rides the browser lane through its `-dom-cljs-test` suffix. It
+  also matches the node suites' broader regex, where it has no DOM to mount
+  and says so rather than passing quietly."
+  (:require ["react" :as react]
+            ["react-dom/client" :as rdc]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.presence-runtime :as presence]
+            [re-frame.freehand.react :as fr]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       plain-atom/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- act
+  "A React 19 `act` boundary as a promise, so assertions run after the
+  commit and its flushed effects rather than racing them."
+  [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+;; ---------------------------------------------------------------------------
+;; The tree under probe
+;;
+;; `marker` carries its identity (`data-id`, stable) and its CONTENT
+;; (`data-label`, what a re-entry changes) as separate attributes, so the
+;; assertions can find a retained child by identity and read which element
+;; is on screen.
+;; ---------------------------------------------------------------------------
+
+(def ^:private timeout-ms 100)
+
+(v/defview marker
+  [{:keys [id label]}]
+  [:div.marker {:data-id    (str id)
+                :data-label (str label)
+                :data-phase (name (v/presence-phase))}
+   (str label)])
+
+(v/defview stack
+  [{:keys [items]}]
+  [:div#stack
+   (v/presence {:timeout-ms timeout-ms}
+     (for [{:keys [k label]} items]
+       [marker {:key k :id k :label label}]))])
+
+;; ---------------------------------------------------------------------------
+;; The suspending sibling — how a render is genuinely ABANDONED
+;;
+;; A plain React component, deliberately: suspending is a React-host fact,
+;; not something a Freehand view declares. It sits AFTER the presence
+;; boundary in document order, so the candidate has already rendered the
+;; boundary and its children by the time this throws. React renders
+;; transition work that suspends but never commits it — which is exactly the
+;; abandoned candidate the law is about.
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private never-resolves (js/Promise. (fn [_ _] nil)))
+
+(def ^:private suspender-renders
+  "How many times the suspending sibling has been rendered. Non-zero is the
+  evidence that the abandoned candidate really RAN."
+  (atom 0))
+
+(defn- suspender [^js props]
+  (when (.-suspend props)
+    (swap! suspender-renders inc)
+    ;; `use` may be called conditionally — it is the one hook that may.
+    (react/use never-resolves))
+  nil)
+
+(defn- probe-element [items suspend?]
+  (react/createElement
+    react/Suspense
+    #js {:fallback (react/createElement "div" #js {:id "fallback"} "waiting")}
+    (fr/element [stack {:items items}])
+    (react/createElement suspender #js {:suspend suspend?})))
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- mount! []
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    [container (rdc/createRoot container)]))
+
+(defn- teardown! [container root]
+  (.unmount root)
+  (.remove container)
+  nil)
+
+(defn- marker-el [container id]
+  (.querySelector container (str ".marker[data-id='" id "']")))
+
+(defn- label-of [container id]
+  (some-> (marker-el container id) (.getAttribute "data-label")))
+
+(defn- phase-of [container id]
+  (some-> (marker-el container id) (.getAttribute "data-phase")))
+
+(defn- render! [root items]
+  (act #(.render root (probe-element items false))))
+
+(defn- render-abandoned! [root items]
+  (act #(react/startTransition (fn [] (.render root (probe-element items true))))))
+
+(def ^:private all      [{:k "a" :label "a"}
+                         {:k "b" :label "committed-b"}
+                         {:k "c" :label "c"}])
+(def ^:private minus-c  [{:k "a" :label "a"} {:k "b" :label "committed-b"}])
+(def ^:private minus-bc [{:k "a" :label "a"}])
+(def ^:private re-enter [{:k "a" :label "a"} {:k "b" :label "abandoned-b"}])
+
+(defn- skip! [why]
+  (is true (str "a real React mount needs a DOM host — " why)))
+
+;; ===========================================================================
+;; The law
+;; ===========================================================================
+
+(deftest an-abandoned-render-publishes-no-presence-element
+  (testing "A candidate render that re-enters a retained key with a NEW
+            element and then suspends never commits, so the element it
+            derived must stay unpublished: when an unrelated, earlier exit
+            timer force-updates the CURRENT tree, the retained child still
+            renders its last COMMITTED element."
+    (if-not (browser? )
+      (skip! "the browser job runs the commit-ownership assertions")
+      (async done
+        (presence/reset-clock!)
+        (presence/set-wall-clock! false)
+        (reset! suspender-renders 0)
+        (let [[container root] (mount!)]
+          (-> (render! root all)
+              (.then (fn [_]
+                       (is (= "committed-b" (label-of container "b")) "b mounted committed")
+                       (is (some? (marker-el container "c")) "c mounted")
+                       (is (= 0 (presence/pending-count)) "nothing is retained yet")
+                       ;; t=0 — c departs, its exit is due at t=100
+                       (render! root minus-c)))
+              (.then (fn [_]
+                       (is (= "unmounting" (phase-of container "c")) "c is retained :unmounting")
+                       (is (= 1 (presence/pending-count)) "c's exit is scheduled")
+                       ;; advance to t=50 without firing anything
+                       (act #(presence/flush-presence! 50))))
+              (.then (fn [_]
+                       (is (= 1 (presence/pending-count)) "c's exit is still pending at t=50")
+                       ;; t=50 — b departs, its exit is due at t=150 (AFTER c's)
+                       (render! root minus-bc)))
+              (.then (fn [_]
+                       (is (= "unmounting" (phase-of container "b")) "b is retained :unmounting")
+                       (is (= "committed-b" (label-of container "b"))
+                           "and retains its last committed element")
+                       (is (= 2 (presence/pending-count)) "two exits are pending")
+                       ;; the abandoned candidate: b re-enters as "abandoned-b",
+                       ;; then a sibling suspends, so nothing commits
+                       (render-abandoned! root re-enter)))
+              (.then (fn [_]
+                       (is (pos? @suspender-renders)
+                           "the candidate really rendered — it reached the suspending sibling")
+                       (is (= "committed-b" (label-of container "b"))
+                           "and really did not commit — the DOM is untouched")
+                       (is (= "unmounting" (phase-of container "b"))
+                           "b's committed phase is untouched too")
+                       (is (= 2 (presence/pending-count))
+                           "and the abandoned candidate cancelled no exit")
+                       ;; t=101 — ONLY c's earlier exit comes due. Its removal
+                       ;; callback force-updates the CURRENT tree: the one commit
+                       ;; a leaked element would ride out on.
+                       (act #(presence/flush-presence! 51))))
+              (.then (fn [_]
+                       (is (nil? (marker-el container "c"))
+                           "c's exit fired and removed it terminally")
+                       (is (some? (marker-el container "b"))
+                           "b is still retained — its own exit is not due")
+                       (is (= "committed-b" (label-of container "b"))
+                           "and STILL renders its last committed element: the abandoned
+                            candidate published nothing")
+                       (is (= 1 (presence/pending-count)) "only b's exit remains")
+                       ;; the retention machine is otherwise untouched
+                       (act #(presence/flush-presence!))))
+              (.then (fn [_]
+                       (is (nil? (marker-el container "b"))
+                           "b's own exit still removes it terminally")
+                       (is (some? (marker-el container "a")) "a is untouched throughout")
+                       (is (= 0 (presence/pending-count)) "every exit fired exactly once")
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (teardown! container root)
+                        (done)))))))))
+
+;; ===========================================================================
+;; A COMMITTED render still owns its elements
+;; ===========================================================================
+
+(deftest a-committed-render-still-publishes-its-elements
+  (testing "The other half of the law: withholding publication from a
+            candidate must not withhold it from a COMMIT. A same-key prop
+            update still replaces the rendered element, and a committed
+            re-entry still cancels the exit and returns the child to
+            `:present` — with the element the re-entry supplied."
+    (if-not (browser?)
+      (skip! "the browser job runs the committed-publication assertions")
+      (async done
+        (presence/reset-clock!)
+        (presence/set-wall-clock! false)
+        (let [[container root] (mount!)]
+          (-> (render! root all)
+              (.then (fn [_]
+                       (is (= "committed-b" (label-of container "b")) "b mounted committed")
+                       ;; a plain same-key prop update
+                       (render! root [{:k "a" :label "a"}
+                                      {:k "b" :label "updated-b"}
+                                      {:k "c" :label "c"}])))
+              (.then (fn [_]
+                       (is (= "updated-b" (label-of container "b"))
+                           "a committed prop update replaces the rendered element")
+                       ;; b departs, then re-enters with a THIRD element
+                       (render! root [{:k "a" :label "a"} {:k "c" :label "c"}])))
+              (.then (fn [_]
+                       (is (= "unmounting" (phase-of container "b")) "b is retained :unmounting")
+                       (is (= "updated-b" (label-of container "b"))
+                           "retaining the LAST committed element, not the first")
+                       (is (= 1 (presence/pending-count)) "its exit is scheduled")
+                       (render! root [{:k "a" :label "a"}
+                                      {:k "b" :label "re-entered-b"}
+                                      {:k "c" :label "c"}])))
+              (.then (fn [_]
+                       (is (= "present" (phase-of container "b"))
+                           "a committed re-entry returns the child to :present")
+                       (is (= "re-entered-b" (label-of container "b"))
+                           "with the element the re-entry supplied")
+                       (is (= 0 (presence/pending-count))
+                           "and cancels the pending exit")
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (teardown! container root)
+                        (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/presence_nil_key_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/presence_nil_key_dom_cljs_test.cljs
@@ -1,0 +1,236 @@
+(ns re-frame.freehand.presence-nil-key-dom-cljs-test
+  "An explicit `nil` key is a KEY. An absent one is not.
+
+  React coerces a supplied key to a string, so `{:key nil}` is the identity
+  `\"null\"` — a perfectly ordinary sibling identity, and one a keyed
+  reconciler tracks like any other. `{}` supplies no key at all. The two
+  mean different things, and the interpreted emitter must not flatten them
+  together: `(:key m)` answers `nil` for both, so key PRESENCE is asked with
+  `contains?`, not by testing the value.
+
+  It matters most under `(v/presence …)`, which tracks children BY KEY and
+  drops a keyless child. Erasing an explicit `nil` there turns a legal
+  identity into silent content loss — and turns `{:compiled true}`, which
+  tracks key presence separately and emits the nil expression to React, into
+  a behaviour switch.
+
+  The three interpreted child paths are asserted against React's own
+  coercion as the control: a literal element, a declared-view boundary, and
+  a keyed fragment.
+
+  This file rides the browser lane through its `-dom-cljs-test` suffix; the
+  key-parity assertions need no DOM and fire in Node too."
+  (:require ["react" :as react]
+            ["react-dom/client" :as rdc]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.descriptor :as descriptor]
+            [re-frame.freehand.presence-runtime :as presence]
+            [re-frame.freehand.react :as fr]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       plain-atom/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- act
+  [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(def ^:private timeout-ms 100)
+
+(v/defview chip
+  [{:keys [label]}]
+  [:div.chip {:data-label (str label)
+              :data-phase (name (v/presence-phase))}
+   (str label)])
+
+(v/defview nil-key-stack
+  [{:keys [show?]}]
+  [:div#nil-key-stack
+   (v/presence {:timeout-ms timeout-ms}
+     (when show? [chip {:key nil :label "draft"}]))])
+
+(v/defview nil-key-element-stack
+  [{:keys [show?]}]
+  [:div#nil-key-element-stack
+   (v/presence {:timeout-ms timeout-ms}
+     (when show? [:div.chip {:key nil :data-label "draft"} "draft"]))])
+
+(v/defview duplicate-nil-stack
+  [_]
+  [:div#duplicate-nil-stack
+   (v/presence {:timeout-ms timeout-ms}
+     [chip {:key nil :label "first"}]
+     [chip {:key nil :label "second"}])])
+
+;; ===========================================================================
+;; The three interpreted child paths, against React's own coercion
+;; ===========================================================================
+
+(deftest an-explicit-nil-key-reaches-react-from-every-interpreted-path
+  (testing "React string-coerces a supplied key, so `nil` is the identity
+            \"null\". Every interpreted child path must deliver it — a
+            literal element, a declared-view boundary, and a keyed fragment
+            — matching React's own control and the compiled emitter, which
+            passes the nil key expression through."
+    (is (= "null" (.-key (react/createElement "div" #js {:key nil})))
+        "the control: React itself coerces a nil key to \"null\"")
+    (is (= "null" (.-key (fr/element [:div {:key nil} "draft"])))
+        "an interpreted literal element carries the explicit nil key")
+    (is (= "null" (.-key (fr/element [chip {:key nil :label "draft"}])))
+        "so does an interpreted declared-view boundary")
+    (is (= "null" (.-key (fr/element [:<> {:key nil} "draft"])))
+        "and so does an interpreted keyed fragment")))
+
+(deftest an-absent-key-is-still-absent-from-every-interpreted-path
+  (testing "The other half: key ABSENCE must survive too. A value of `nil`
+            and no key at all are different authored facts, and the emitter
+            may not conflate them in either direction."
+    (is (nil? (.-key (react/createElement "div" #js {})))
+        "the control: React leaves an unsupplied key nil")
+    (is (nil? (.-key (fr/element [:div {} "draft"])))
+        "an interpreted literal element with no :key has no React key")
+    (is (nil? (.-key (fr/element [chip {:label "draft"}])))
+        "nor does a declared-view boundary with no :key")
+    (is (nil? (.-key (fr/element [:<> {} "draft"])))
+        "nor does a fragment with no :key")))
+
+(deftest normalize-call-reports-key-presence-without-widening-props
+  (testing "`normalize-call` is the one normalizer both emitters share, so
+            it is where a boundary call's key presence has to survive. It
+            keeps stripping `:key` from the props the body sees and keeping
+            it outside props equality — and now also reports whether the
+            call supplied one at all, which is the only thing that tells an
+            explicit nil from an absent key."
+    (let [explicit (descriptor/normalize-call chip [{:key nil :label "draft"}])
+          valued   (descriptor/normalize-call chip [{:key "k" :label "draft"}])
+          absent   (descriptor/normalize-call chip [{:label "draft"}])]
+      (is (= {:label "draft"} (:props explicit))
+          ":key is stripped from the props map")
+      (is (= (:props absent) (:props explicit) (:props valued))
+          "so it stays outside props equality, whatever its value")
+      (is (true? (:keyed? explicit)) "an explicit nil key is reported PRESENT")
+      (is (nil? (:key explicit)) "carrying its authored value, nil")
+      (is (true? (:keyed? valued)) "an ordinary key is reported present too")
+      (is (false? (:keyed? absent)) "and an absent key is reported absent")
+      (is (nil? (:key absent)) "with the same nil value — which is why :keyed? exists"))))
+
+;; ===========================================================================
+;; Mounted: an explicit-nil-key child is a full presence citizen
+;; ===========================================================================
+
+(defn- mount! []
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    [container (rdc/createRoot container)]))
+
+(defn- teardown! [container root]
+  (.unmount root)
+  (.remove container)
+  nil)
+
+(defn- chip-el [container] (.querySelector container ".chip"))
+(defn- phase-of [container] (some-> (chip-el container) (.getAttribute "data-phase")))
+
+(defn- skip! [why]
+  (is true (str "a real React mount needs a DOM host — " why)))
+
+(deftest a-nil-keyed-view-child-lives-the-whole-presence-lifecycle
+  (testing "A declared-view presence child keyed with an explicit `nil`
+            renders, settles `:present`, is RETAINED `:unmounting` when it
+            departs, and is removed terminally by the timeout — never
+            dropped as keyless."
+    (if-not (browser?)
+      (skip! "the browser job runs the mounted lifecycle assertions")
+      (async done
+        (presence/reset-clock!)
+        (presence/set-wall-clock! false)
+        (let [[container root] (mount!)]
+          (-> (act #(.render root (fr/element [nil-key-stack {:show? true}])))
+              (.then (fn [_]
+                       (is (some? (chip-el container))
+                           "the explicit-nil-key child RENDERED — it was not dropped")
+                       (is (= "present" (phase-of container))
+                           "and settled :present, so the enter transition ran")
+                       (is (= 0 (presence/pending-count)) "nothing is retained yet")
+                       (act #(.render root (fr/element [nil-key-stack {:show? false}])))))
+              (.then (fn [_]
+                       (is (some? (chip-el container))
+                           "departing RETAINS it — presence tracked it by the \"null\" identity")
+                       (is (= "unmounting" (phase-of container))
+                           "and it reads :unmounting through the phase context")
+                       (is (= 1 (presence/pending-count)) "its exit is scheduled")
+                       (act #(presence/flush-presence!))))
+              (.then (fn [_]
+                       (is (nil? (chip-el container))
+                           "and the timeout removes it terminally")
+                       (is (= 0 (presence/pending-count)) "leaving nothing pending")
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (teardown! container root)
+                        (done)))))))))
+
+(deftest a-nil-keyed-literal-element-child-is-retained-too
+  (testing "The literal-element path is a presence citizen on the same
+            terms: an explicit-nil-key `[:div …]` child renders, is retained
+            when it departs, and is removed by the timeout."
+    (if-not (browser?)
+      (skip! "the browser job runs the mounted element-path assertions")
+      (async done
+        (presence/reset-clock!)
+        (presence/set-wall-clock! false)
+        (let [[container root] (mount!)]
+          (-> (act #(.render root (fr/element [nil-key-element-stack {:show? true}])))
+              (.then (fn [_]
+                       (is (some? (chip-el container))
+                           "the explicit-nil-key element child RENDERED")
+                       (act #(.render root (fr/element [nil-key-element-stack {:show? false}])))))
+              (.then (fn [_]
+                       (is (some? (chip-el container)) "departing RETAINS it")
+                       (is (= 1 (presence/pending-count)) "its exit is scheduled")
+                       (act #(presence/flush-presence!))))
+              (.then (fn [_]
+                       (is (nil? (chip-el container)) "and the timeout removes it")
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (teardown! container root)
+                        (done)))))))))
+
+(deftest duplicate-nil-keys-collide-in-the-string-coerced-domain
+  (testing "\"null\" is an ordinary identity, so two explicit-nil-key
+            children of one boundary COLLIDE exactly as `1` and `\"1\"` do —
+            the existing duplicate-identity law applies unchanged, and the
+            FIRST claimant keeps the key."
+    (if-not (browser?)
+      (skip! "the browser job runs the duplicate-identity assertions")
+      (async done
+        (presence/reset-clock!)
+        (presence/set-wall-clock! false)
+        (let [[container root] (mount!)]
+          (-> (act #(.render root (fr/element [duplicate-nil-stack {}])))
+              (.then (fn [_]
+                       (is (= 1 (.-length (.querySelectorAll container ".chip")))
+                           "one child owns the \"null\" identity, not two")
+                       (is (= "first" (.getAttribute (chip-el container) "data-label"))
+                           "and it is the FIRST claimant in document order")
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (teardown! container root)
+                        (done)))))))))


### PR DESCRIPTION
Two defects in the keyed presence runtime that shipped in #6713 — same surface, one commit each. Both were reproduced on the pre-fix tree before anything was changed.

## Commit-owned presence across abandoned renders (rf2-drpa3.86, P1)

`PresenceComponent` published its retained-element map **during render**:

```clojure
elements (merge (.-elements state) (into {} incoming-pairs))
(set! (.-elements state) elements)
```

That ref is shared by the current and the work-in-progress fiber. A render React abandons — a transition that suspends, a superseded render — therefore overwrote a retained key's committed element even though none of its effects ran, and a later exit timer force-updating the **current** tree painted the element from the render that never happened. The source comment two lines up already claimed committed state was mutated only in effects and removal callbacks; the render-phase assignment was the thing violating it.

Publication moves to the commit effect, which React runs only for a render it committed. That is the atomic shell's own discipline reused rather than re-invented (`cell.cljc`: a speculative render owns nothing, the selected commit publishes): the render derives a **candidate** element map, holds it, returns its output from it, and a dropped candidate publishes nothing. The effect re-reads `.-elements` instead of reusing the render's merge, so a removal callback that fired in the render→commit gap is not undone by a stale snapshot.

**Pre-fix reproduction** — a real `createRoot` probe drives a genuinely abandoned render: mount `a`/`b`/`c`; `c` departs at logical `t=0` (due 100); advance to `t=50`; `b` departs (due 150); a transition re-enters `b` with a new element and suspends in a sibling; advance 51 so only `c`'s earlier exit fires and force-updates the current tree. On the pre-fix tree the browser gate reds with exactly one failure:

```
FAIL in (an-abandoned-render-publishes-no-presence-element) (presence_commit_ownership_dom_cljs_test.cljs:211)
expected: (= "committed-b" (label-of container "b"))
  actual: (not (= "committed-b" "abandoned-b"))
```

The assertions before it pass on both trees, which is what makes the proof honest: the suspending sibling really rendered (the candidate ran), and the DOM was still `committed-b` with two exits pending (it really did not commit). A second test pins the other half of the law — a committed same-key prop update still replaces the rendered element, and a committed re-entry still cancels the exit and returns the child to `:present` with the element the re-entry supplied.

**Cross-mode:** interpreted and compiled markup lower to this one `PresenceComponent`, so there is no second element store for a compiled boundary to leak through; the fix binds both modes by construction.

## Explicit nil keys in interpreted child paths (rf2-drpa3.87, P2)

React string-coerces a supplied key, so `{:key nil}` is the ordinary identity `"null"` — legal, and a different authored fact from supplying no key at all. All three interpreted child paths asked the wrong question:

```clojure
(when (some? (:key attrs)) …)   ; literal element
(when (some? key) …)            ; declared-view boundary
(when (some? k) …)              ; fragment
```

`(:key m)` answers `nil` for a missing entry *and* for a present nil one, so `some?` erased the explicit key before React saw it. Under `(v/presence …)`, which tracks children by key and drops a keyless child, that turned a legal identity into silent content loss — and made `{:compiled true}` a behaviour switch, since the compiled analyzer tracks key presence separately (`:present?`) and emits the nil expression straight through.

Presence is now asked with `contains?`. The boundary path needs the fact from `normalize-call`, whose stripped `:key` value cannot carry it, so the normalizer additionally reports `:keyed?` — key presence, independent of key value. `:key` is still stripped from the props the body sees and still outside props equality, and a key whose runtime value is `undefined` stays absent, which is React's own rule and what the existing keyless advisory describes.

**Pre-fix reproduction** — four assertions failed on the pre-fix tree, matching the reported probe:

```
expected: (= "null" (.-key (fr/element [:div {:key nil} "draft"])))          actual: (not (= "null" nil))
expected: (= "null" (.-key (fr/element [chip {:key nil, :label "draft"}])))  actual: (not (= "null" nil))
expected: (= "null" (.-key (fr/element [:<> {:key nil} "draft"])))           actual: (not (= "null" nil))
expected: (true? (:keyed? explicit))                                        actual: (not (true? nil))
```

The React `createElement` control (`.key` = `"null"`) and every absent-key assertion passed on both trees, so value-nil and key-absence are pinned in both directions. On top of the three paths: a mounted interpreted presence lifecycle on an explicit-nil-key child (renders, retained `:unmounting`, terminal timeout) for both the declared-view and the literal-element path, and the duplicate-identity law holding in the string-coerced `"null"` domain — first claimant wins.

**Cross-mode:** this is an interpreted-only lowering fix; compiled already emitted the nil key expression. The point of the change is that interpreted now agrees with it, so `{:compiled true}` stops changing whether the child exists.

## Notes

- No public verb added. `spec/api-manifest.edn`, its sidecar, `spec/API.md` and `docs/api/re-frame.freehand.md` are untouched, and no conformance row was added or moved — both fixes restore laws already stated normatively (spec/004 §Pattern-level commitments 2–3 for commit ownership; the presence key contract for identity).
- `:keyed?` is an additive key on the `normalize-call` result map. Both other call sites (`tree.cljc`) destructure and are unaffected.
- Rebased twice onto a moving `main`, most recently over the HMR occurrence-preservation change to `react.cljs`; no conflicts, and every gate below was re-run on the final base.

## Quality gates

All foreground, one at a time, on the final rebased tree:

| Gate | Result |
| --- | --- |
| `cd implementation/freehand && clojure -M:test` | Ran 495 tests, 3242 assertions — 0 failures, 0 errors |
| `npm run test:freehand` | Ran 373 tests, 2580 assertions — 0 failures, 0 errors (0 warnings) |
| `npm run test:cljs` | Ran 10494 tests, 52662 assertions — 0 failures, 0 errors |
| `npm run test:browser` | Ran 509 tests, 2976 assertions — 0 failures, 0 errors |
| `python scripts/check_freehand_conformance_index.py` | exit 0 |
| `python scripts/check_donor_inventory.py` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | exit 0 — no beads-database paths in the diff |
| `git grep 're-frame.ui' implementation/freehand/` | empty |

**Non-vacuity**, one inversion per new test file, each run against the full browser gate and then restored byte-identically (`sha256` verified):

- `presence_commit_ownership_dom_cljs_test.cljs` — inverting the retained-element assertion reds the gate: `1 failures` naming `FAIL in (an-abandoned-render-publishes-no-presence-element) … :211`.
- `presence_nil_key_dom_cljs_test.cljs` — inverting the mounted lifecycle's "child rendered" assertion reds the gate: `1 failures` naming `FAIL in (a-nil-keyed-view-child-lives-the-whole-presence-lifecycle) … :162`. Its key-parity arm needs no artificial inversion — the four failures quoted above are its real pre-fix red.
