### PR TITLE
test(freehand): a deterministic CLJS/React B-arm so render costs are attributable (rf2-drpa3.88)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/bench/b1_react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/bench/b1_react.cljs
@@ -1,0 +1,299 @@
+(ns re-frame.freehand.bench.b1-react
+  "B1's React arm — what the interpreted React emitter builds, counted
+  exactly.
+
+  [[re-frame.freehand.bench.b1]] measures the STRUCTURAL walk and
+  publishes a byte reading beside its timings, because the JVM hands it a
+  monotonic per-thread allocation counter: a difference across a measured
+  region is exactly the bytes that region allocated, whether or not a
+  collection ran in the middle. That counter is what makes a change to
+  the structural walk attributable — the numbers move, and they move
+  because of the change.
+
+  ClojureScript has no such counter. Node's
+  `process.memoryUsage().heapUsed` reports heap OCCUPANCY: a collection
+  between two readings makes the difference smaller than the bytes really
+  allocated, and can make it negative. So the React emitter had a wall
+  clock and a byte reading that could not attribute anything, and
+  candidate changes to [[re-frame.freehand.react]] could be neither
+  shipped on evidence nor rejected on it — which, under a posture that
+  forbids unmeasured micro-optimization, means they could only be
+  declined.
+
+  This arm supplies the missing half. It renders one finite template
+  through the emitter and reports two EXACT counts of what the walk
+  built:
+
+    - `:B1/react-elements` — the React elements the render answered;
+    - `:B1/react-props` — the props those elements carry, `children`
+      excluded.
+
+  Both are deterministic properties, so the harness gates them — and it
+  decides that from the observable rather than from anything asserted
+  here ([[re-frame.freehand.bench.measure]]). Both are also the
+  denominators the interesting changes are actually about: elements for
+  anything per-element in the walk, props for anything per-attribute.
+
+  ## Why a count read off the OUTPUT is a count of the work
+
+  The emitter answers every element it creates — the walk builds nothing
+  it then discards — so the elements reachable from the value
+  [[re-frame.freehand.react/element]] returns are exactly the
+  `react/createElement` calls it made. Nothing is patched, wrapped or
+  instrumented to learn that: the count is read from the ordinary return
+  value through `react/isValidElement`, which is why an arm that measures
+  the emitter needs no change to it.
+
+  ## What this arm deliberately does NOT measure
+
+  React itself. No root is created, nothing mounts, nothing reconciles,
+  and there is no DOM. D021 warns that React reconciliation or a foreign
+  widget may dominate and that the report must not attribute that cost to
+  Hiccup interpretation; the way not to attribute it is not to include
+  it.
+
+  The template is plain markup with no declared view, so there is no
+  ViewCell and no shell commit either. That is forced rather than chosen:
+  a declared boundary becomes a React component whose body runs later,
+  inside React, under its own candidate — so [[element]] over a boundary
+  answers ONE element, and an arm built on one would be measuring a
+  template it never walked.
+
+  The heap reading rides along as `:B1/react-heap-delta-bytes`, published
+  as evidence and gating nothing. It is the reading this arm exists
+  because of: put its spread beside the two counts' and the reason a byte
+  number cannot attribute a change on this host is on the page rather
+  than in a paragraph.
+
+  ## The small case beside the stress case
+
+  Two registered workloads over one template and one `:run`, differing
+  only in the `:rows` fixture parameter — D021 requires a small realistic
+  case beside each stress case, so optimization is not tuned only to
+  synthetic extremes. It also makes the counters' DISCRIMINATION
+  structural: the two workloads gate against different WRITTEN
+  expectations, so a counter that stopped moving with the workload it
+  counts would fail one of them.
+
+  Registered where it can run. `clojure -M:bench` is a JVM process and
+  [[re-frame.freehand.react]] is ClojureScript-only, so this namespace is
+  not in that CLI's require list; it registers itself at load exactly
+  like every other workload, into the suite the ClojureScript host runs.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require ["react" :as react]
+            [goog.object :as gobj]
+            [re-frame.freehand.bench :as bench]
+            [re-frame.freehand.bench.measure :as m]
+            [re-frame.freehand.react :as emitter]))
+
+;; ---------------------------------------------------------------------------
+;; The template
+;; ---------------------------------------------------------------------------
+
+(defn- noop
+  "One shared handler for every row.
+
+  A closure minted per row would be real allocation the walk did not do —
+  it would be the fixture's, billed to the emitter. The arm measures what
+  the emitter does with a handler, not what building handlers costs."
+  [_]
+  nil)
+
+(defn- row
+  "One row of the template: a keyed element carrying every attribute
+  shape the walk treats differently — `.class` sugar composed with a
+  vector `:class`, a `:style` map, a `data-*` name that passes through
+  verbatim, an `:on-*` handler, and a `:key` — over a void child, an
+  element child, a number child, and a nil that is dropped."
+  [i]
+  [:li.row {:key        i
+            :class      ["cell" "wide"]
+            :style      {:padding-left 4 :color "rebeccapurple"}
+            :data-index i
+            :on-click   noop}
+   [:img.avatar {:src "/avatar.png" :alt ""}]
+   [:span.label "row "]
+   i
+   nil])
+
+(defn template
+  "The finite template, at `rows`.
+
+  Ordinary markup: an element with sugar and an attribute, a childless
+  void element, a fragment, and a list whose rows arrive as a SPLICED
+  SEQ — the shape a view body actually produces — so the arm walks the
+  branches the emitter really has rather than the one it is easiest to
+  count.
+
+  Public because the arithmetic below is a claim about THIS markup at any
+  size, and a check that could not render it at any size would be a check
+  of the two sizes the workloads happen to register."
+  [rows]
+  [:section.panel {:aria-label "bench rows"}
+   [:h1.title "Rows"]
+   [:hr.rule]
+   [:<>
+    [:p.note "a fragment's children are elements too"]
+    nil]
+   [:ul#list.rows {:role "list"}
+    (map row (range rows))]])
+
+;; ---------------------------------------------------------------------------
+;; The template's shape, as arithmetic
+;; ---------------------------------------------------------------------------
+
+(defn expected-elements
+  "The exact number of React elements the template answers for `rows`.
+
+  Stated as arithmetic rather than measured, so the gate is against a
+  WRITTEN expectation instead of against whatever the walk happened to
+  produce — a gate that expects what it saw is not a gate.
+
+  Six for the skeleton — the section, the heading, the rule, the
+  fragment and its paragraph, and the list — then three per row: the row
+  element, its image and its label. Text and numbers are children but not
+  elements, and the `nil` in each row is dropped, so neither appears
+  here."
+  [rows]
+  (+ 6 (* 3 rows)))
+
+(defn expected-props
+  "The exact number of props those elements carry for `rows`, `children`
+  excluded.
+
+  Eight for the skeleton: the section's composed class and its
+  `aria-label`, the heading's class, the rule's class, the paragraph's
+  class, and the list's class, id and role. The fragment carries none.
+
+  Then eight per row: the row's class, style, `data-index` and handler —
+  four, not five, because React lifts `:key` out of props onto the
+  element — the image's class, source and alt text, and the label's
+  class."
+  [rows]
+  (+ 8 (* 8 rows)))
+
+;; ---------------------------------------------------------------------------
+;; Counting what the emitter answered
+;; ---------------------------------------------------------------------------
+
+(defn- own-prop-count
+  "The props on one element, `children` excluded.
+
+  `children` is React's own slot for the varargs the emitter spread into
+  `createElement`, not something the attribute walk wrote, so counting it
+  would make the props total a restatement of the element total."
+  [props]
+  (- (alength (js/Object.keys props))
+     (if (gobj/containsKey props "children") 1 0)))
+
+(defn- tally
+  "Fold `x` into `[elements props]`.
+
+  `x` is a React element, a JS array of children, or a leaf React treats
+  as text — a string, here, since the walk has already rendered numbers
+  through the shared number grammar. Only elements are counted; only
+  elements are descended into."
+  [[elements props :as acc] x]
+  (cond
+    (array? x)
+    (reduce tally acc x)
+
+    (react/isValidElement x)
+    (let [p (.-props x)]
+      (tally [(inc elements) (+ props (own-prop-count p))]
+             (gobj/get p "children")))
+
+    :else acc))
+
+(defn counts
+  "Answer `{:elements n :props n}` for the value the emitter answered.
+
+  Public because the discrimination claim is about this function as much
+  as about the workloads: a counter nobody can call over a DIFFERENT tree
+  is a counter nobody can show moves."
+  [element]
+  (let [[elements props] (tally [0 0] element)]
+    {:elements elements :props props}))
+
+;; ---------------------------------------------------------------------------
+;; One iteration
+;; ---------------------------------------------------------------------------
+
+(defn observe
+  "Run one iteration over `fixture` and answer its observations.
+
+  The two clock readings bracket the EMIT and nothing else. The tally
+  runs outside them and the heap readings outside those, so neither the
+  counting nor the cost of taking a reading is billed to the walk —
+  which is the same boundary discipline B1's structural arm keeps, and
+  the reason the two arms' self times mean the same kind of thing."
+  [{:keys [rows]}]
+  (let [h0      (m/allocated-bytes)
+        t0      (m/now-ms)
+        element (emitter/element (template rows))
+        t1      (m/now-ms)
+        h1      (m/allocated-bytes)
+        {:keys [elements props]} (counts element)]
+    {:B1/react-elements         elements
+     :B1/react-props            props
+     :B1/react-self-ms          (- t1 t0)
+     :B1/react-per-element-ms   (/ (- t1 t0) elements)
+     :B1/react-heap-delta-bytes (- h1 h0)}))
+
+;; ---------------------------------------------------------------------------
+;; The workloads
+;; ---------------------------------------------------------------------------
+
+(defn workload
+  "Build the React arm for `rows`, under `id` and `sampling`."
+  [{:keys [id doc rows sampling]}]
+  {:id       id
+   :doc      doc
+   :fixture  {:rows     rows
+              :elements (expected-elements rows)
+              :props    (expected-props rows)}
+   :baseline {:kind :before-vs-after
+              :reference
+              {:revision :the-revision-before-the-change
+               :note     (str "the same template's element and prop counts on the preceding "
+                              "revision — equal counts are what make a movement in the timing "
+                              "attributable to the change rather than to a different tree")}}
+   :sampling sampling
+   :measurements
+   [{:id         :B1/react-elements
+     :doc        "the exact React elements one render of the template answered"
+     :observable :count
+     :expect     (expected-elements rows)}
+    {:id         :B1/react-props
+     :doc        "the exact props those elements carry, children excluded"
+     :observable :count
+     :expect     (expected-props rows)}
+    {:id         :B1/react-self-ms
+     :doc        "self time for one interpreted emit of the template"
+     :observable :duration-ms}
+    {:id         :B1/react-per-element-ms
+     :doc        "self time divided by the element count — cost per element"
+     :observable :duration-ms}
+    {:id         :B1/react-heap-delta-bytes
+     :doc        "node heap occupancy across one emit — published, and attributable to nothing"
+     :observable :bytes}]
+   :run observe})
+
+(def workloads
+  "The React arm's registered workloads: the stress case in the band D021
+  names for B1, and the small realistic case it requires beside it."
+  [(workload {:id       :B1/react-template
+              :doc      "the interpreted React emitter builds a finite 10^3-element template"
+              :rows     400 ; 1206 elements — inside D021's 10^3-10^4 band
+              :sampling {:warmup 5 :samples 40}})
+   (workload {:id       :B1/react-small-template
+              :doc      "the same template at a realistic small size — the control on the stress case"
+              :rows     6
+              :sampling {:warmup 5 :samples 40}})])
+
+(def registered
+  "Registering at load: requiring this namespace puts the React arm in
+  the standing evidence suite the ClojureScript host runs."
+  (mapv bench/register! workloads))

--- a/implementation/freehand/test/re_frame/freehand/bench/b1_react_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b1_react_cljs_test.cljs
@@ -1,0 +1,228 @@
+(ns re-frame.freehand.bench.b1-react-cljs-test
+  "B1's React arm — the instrument, checked as an instrument.
+
+  A measurement that only ever runs green tells you nothing about the
+  thing it measures, so the three claims here are the three an instrument
+  has to answer before anyone may cite it:
+
+    - it SETTLES — the counters answer one value across repeated runs of
+      an unchanged tree;
+    - it DISCRIMINATES — they move when the tree changes, and the two of
+      them move independently, so neither is a restatement of the other;
+    - it cannot QUIETLY DEGRADE — a counter that stopped settling reds
+      the run, and the wall clock beside it cannot red anything however
+      far it moves.
+
+  The third is checked through the harness rather than restated: the
+  drift control below hands `bench/run` a workload whose count changes
+  per iteration and requires exit 1 naming the property, and the
+  gate/evidence split is read off the normalised workload rather than
+  asserted about it. A timing filed as a gate would be refused when the
+  workload is CONSTRUCTED, before this file could have an opinion."
+  (:require ["react" :as react]
+            [cljs.test :refer [deftest is testing]]
+            [re-frame.freehand.bench :as bench]
+            [re-frame.freehand.bench.b1-react :as b1r]
+            [re-frame.freehand.bench.measure :as m]
+            [re-frame.freehand.react :as emitter]))
+
+(def ^:private provenance
+  "The revision a TEST supplies. A ClojureScript test process is not a
+  build pipeline: no environment variable, no git, and nothing it could
+  truthfully detect. The published run detects its own."
+  {:revision "test-fixture-revision"})
+
+(def ^:private stress
+  (first (filter #(= :B1/react-template (:id %)) b1r/workloads)))
+
+(def ^:private small
+  (first (filter #(= :B1/react-small-template (:id %)) b1r/workloads)))
+
+(def ^:private sweep
+  "The sizes the counters are checked over. Both claims below are about
+  the template at ANY size, so both read this one roster rather than each
+  picking a pair."
+  [0 1 2 6 40 400])
+
+(defn- measured
+  "The counts actually read off an emit of the template at `rows` — the
+  measured value, never the prediction."
+  [rows]
+  (b1r/counts (emitter/element (b1r/template rows))))
+
+;; ---------------------------------------------------------------------------
+;; It settles
+;; ---------------------------------------------------------------------------
+
+(def ^:private repeats
+  "How many times the unchanged tree is rendered when the settling claim
+  is made directly. A fixture parameter: it is the number of independent
+  observations behind the sentence \"identical across repeated runs\", and
+  a reader should be able to see it rather than infer it."
+  25)
+
+(deftest react-arm-counts-settle-across-repeated-runs
+  (testing "The claim the whole arm rests on, demonstrated rather than
+            asserted: the same template rendered many times over answers
+            ONE element count and ONE prop count. A counter that drifted
+            with heap state, iteration order or the scheduler could not
+            attribute anything, which is the exact complaint against the
+            heap reading published beside it."
+    (doseq [w [stress small]]
+      (let [obs (vec (repeatedly repeats #(b1r/observe (:fixture w))))
+            label (str (:id w) ": ")]
+        (doseq [mid [:B1/react-elements :B1/react-props]]
+          (is (= 1 (count (distinct (map mid obs))))
+              (str label mid " answered one value across " repeats " renders — got "
+                   (pr-str (distinct (map mid obs))))))))))
+
+(deftest react-arm-counts-are-the-written-arithmetic
+  (testing "And the value they settle on is the one the template's shape
+            PREDICTS, at every size — not whatever the walk happened to
+            produce. A gate that expects what it saw is not a gate, so the
+            expectation is arithmetic over the fixture parameter and this
+            row is where the arithmetic is checked against the walk."
+    (doseq [rows sweep]
+      (let [{:keys [elements props]} (measured rows)]
+        (is (= (b1r/expected-elements rows) elements)
+            (str rows " rows: the element count is the one the shape predicts"))
+        (is (= (b1r/expected-props rows) props)
+            (str rows " rows: the prop count is the one the shape predicts"))))))
+
+;; ---------------------------------------------------------------------------
+;; It discriminates
+;; ---------------------------------------------------------------------------
+
+(deftest react-arm-counts-move-with-the-tree
+  (testing "A green reading is vacuous if the counter could never have
+            read anything else. Both counters rise strictly with the
+            workload, so a change that built fewer elements — or the same
+            elements with fewer props — is a change either of them would
+            show."
+    (let [counts (mapv measured sweep)
+          els    (mapv :elements counts)
+          props  (mapv :props counts)]
+      (is (= els (vec (sort els))) "the element count rises with the workload")
+      (is (apply distinct? els) "and never repeats a value across the sweep")
+      (is (= props (vec (sort props))) "the prop count rises with the workload")
+      (is (apply distinct? props) "and never repeats a value across the sweep"))
+    (testing "the two workloads registered over one template therefore
+              gate against DIFFERENT written expectations, which is what
+              makes the discrimination structural: a counter that stopped
+              moving with the workload would fail one of them"
+      (is (not= (:elements (:fixture stress)) (:elements (:fixture small))))
+      (is (not= (:props (:fixture stress)) (:props (:fixture small)))))))
+
+(deftest react-arm-the-two-counters-are-independent
+  (testing "Props are not a restatement of elements. One pair of trees
+            holds the element count fixed and moves the props; the other
+            holds the props at zero and moves the elements. If either
+            counter were derived from the other, one of these pairs could
+            not exist."
+    (let [bare    (b1r/counts (emitter/element [:div [:span]]))
+          dressed (b1r/counts (emitter/element [:div.x [:span.y {:id "z"}]]))
+          wider   (b1r/counts (emitter/element [:div [:span] [:span]]))]
+      (is (= (:elements bare) (:elements dressed))
+          "same elements")
+      (is (< (:props bare) (:props dressed))
+          "and the prop counter alone moved")
+      (is (= (:props bare) (:props wider))
+          "same props")
+      (is (< (:elements bare) (:elements wider))
+          "and the element counter alone moved"))))
+
+(deftest react-arm-counts-what-the-emitter-answered
+  (testing "The count is read off the ordinary return value, so it is a
+            claim about React elements rather than about a shape this file
+            invented. React's own predicate agrees with the walk: the
+            emitted root is an element, its element children are elements,
+            and its text children are not."
+    (let [el (emitter/element (b1r/template 1))]
+      (is (react/isValidElement el) "the emitter answered a React element")
+      (is (= 9 (:elements (b1r/counts el)))
+          "one row over the six-element skeleton")
+      (is (not (react/isValidElement "row "))
+          "text is a child but not an element, and is not counted as one"))))
+
+;; ---------------------------------------------------------------------------
+;; It runs through the harness, and the harness decides what may gate
+;; ---------------------------------------------------------------------------
+
+(deftest react-arm-registers-the-stress-case-and-the-small-case
+  (testing "D021 requires a small realistic case beside the stress case.
+            Both are registered into the standing evidence suite, both run
+            one template, and the stress case is in the band the decision
+            names for B1."
+    (let [registered (bench/registered)]
+      (doseq [id [:B1/react-template :B1/react-small-template]]
+        (is (contains? registered id) (str id " is in the standing evidence suite"))))
+    (is (<= 1000 (:elements (:fixture stress)) 10000)
+        "the stress case builds a 10^3-10^4-element template")
+    (is (< (:elements (:fixture small)) 100)
+        "and the small case is genuinely small")
+    (is (= :before-vs-after (:kind (:baseline stress)))
+        "under the baseline this instrument exists to serve")))
+
+(deftest react-arm-runs-green-and-publishes-its-evidence
+  (testing "Each registered workload runs, its deterministic properties
+            hold at their declared sampling policy, and every evidence
+            measurement arrives with a full distribution. Nothing here
+            asserts how BIG a number is — that is the half D021 forbids
+            gating on."
+    (doseq [w b1r/workloads]
+      (let [record (bench/run-workload w provenance)
+            label  (str (:id w) ": ")]
+        (is (empty? (:gate-failures record)) (str label "no deterministic property was violated"))
+        (is (= (:elements (:fixture w)) (get-in record [:properties :B1/react-elements :observed]))
+            (str label "over the predicted element count"))
+        (is (= (:props (:fixture w)) (get-in record [:properties :B1/react-props :observed]))
+            (str label "and the predicted prop count"))
+        (testing "and the required evidence is published, with its distribution"
+          (doseq [mid [:B1/react-self-ms :B1/react-per-element-ms
+                       :B1/react-heap-delta-bytes :bench/iteration-ms]]
+            (let [d (get-in record [:distribution mid])]
+              (is (some? d) (str label mid " was published"))
+              (is (= (:samples (:sampling w)) (:n d))
+                  (str label mid " summarises every measured iteration"))
+              (is (not (contains? d :pass?))
+                  (str label mid " carries no verdict — it is evidence")))))))))
+
+(deftest react-arm-timings-cannot-gate
+  (testing "The asymmetry, read off the arm's own declarations rather than
+            asserted about them: its two counts class as gates, and its
+            durations and its heap reading class as evidence. A future
+            edit that reached for a budget on the heap delta would be
+            refused when the workload is CONSTRUCTED, not here."
+    (let [by-id (into {} (map (juxt :id identity))
+                     (:measurements (bench/workload stress)))]
+      (doseq [mid [:B1/react-elements :B1/react-props]]
+        (is (m/gate? (get by-id mid)) (str mid " gates")))
+      (doseq [mid [:B1/react-self-ms :B1/react-per-element-ms :B1/react-heap-delta-bytes]]
+        (is (m/evidence? (get by-id mid)) (str mid " is evidence"))))))
+
+(deftest react-arm-a-counter-that-stopped-settling-would-red
+  (testing "The settling claim is enforced by the HARNESS, not by the row
+            above that demonstrates it. This control hands `bench/run` the
+            same workload with a count that drifts by one per iteration:
+            the run exits 1, names the property, and says how many values
+            it saw. Without this, a counter that quietly began to drift
+            would be caught only by whoever happened to read the numbers."
+    (let [n       (volatile! 0)
+          control (assoc (b1r/workload {:id       :B1/react-drift-control
+                                        :doc      "a count that drifts by one per iteration"
+                                        :rows     2
+                                        :sampling {:warmup 0 :samples 4}})
+                         :run
+                         (fn [fixture]
+                           (update (b1r/observe fixture) :B1/react-elements + (vswap! n inc))))
+          outcome (bench/run [control] provenance)
+          failure (first (:gate-failures outcome))]
+      (is (= 1 (:exit-code outcome)) "a drifting deterministic property reds the run")
+      (is (= :B1/react-elements (:measurement failure)) "and the failure names the property")
+      (is (= :one-value-per-run (:expected failure))
+          "as an instability, not merely as a wrong value")
+      (is (re-find #"distinct values" (:message failure))
+          "and the message says what it saw"))
+    (testing "and the control stays out of the standing suite — it fails
+              on purpose, and a suite that carried it would never be green"
+      (is (not (contains? (bench/registered) :B1/react-drift-control))))))


### PR DESCRIPTION
The JVM interpreter path has a monotonic per-thread allocation counter, and that
counter is what made the interpreter-tuning slice attributable commit by commit —
including the candidate it *rejected* on measurement rather than on taste.

The CLJS/React path had no equivalent. Node's `process.memoryUsage().heapUsed`
reports heap OCCUPANCY, not allocation: a collection between two readings makes
the difference smaller than the bytes really allocated, and can make it negative.
So candidate changes to `re-frame.freehand.react` could be neither shipped on
evidence nor rejected on it — which, under a posture that forbids unmeasured
micro-optimization, means they could only be declined.

This adds the instrument. It does not take the optimizations.

## What lands

`re-frame.freehand.bench.b1-react` — B1's React arm. It renders one finite
template through the interpreted React emitter and reports two EXACT counts,
read off the ordinary value `re-frame.freehand.react/element` returns:

| measurement | observable | enforcement |
|---|---|---|
| `:B1/react-elements` | `:count` | **gate** |
| `:B1/react-props` | `:count` | **gate** |
| `:B1/react-self-ms` | `:duration-ms` | evidence |
| `:B1/react-per-element-ms` | `:duration-ms` | evidence |
| `:B1/react-heap-delta-bytes` | `:bytes` | evidence |

The enforcement column is not written anywhere in the new code. It is a total
function of the observable in `bench.measure`, so a timing filed as a gate is
refused when the workload is CONSTRUCTED — which is why the D021 split here is
mechanical rather than a convention this arm agreed to follow.

Two workloads over one template and one `:run`, differing only in the `:rows`
fixture parameter: the stress case D021's B1 row asks for and the small realistic
case it requires beside it.

Nothing is patched, wrapped or instrumented to get the counts. The walk answers
every element it creates, so the elements reachable from its return value are
exactly the `react/createElement` calls it made, and `react/isValidElement` is the
whole discriminator. **`react.cljs` is untouched** — the diff is two new files.

## The counter settles: 8 concurrent processes, under load

The bundle was compiled once and run 8 times **concurrently**, on a machine
already running other workers. Each process runs 40 harness samples per workload
plus 25 direct repeats, and the counts gate against a WRITTEN literal
(`6 + 3·rows` elements, `8 + 8·rows` props), so a green run means every
observation in it equalled that literal:

```
process 1  :B1/react-template elements=1206 props=3208  self-ms p50=12.237  heap-bytes min=-49689792 p50=10026000 max=10067408
process 2  :B1/react-template elements=1206 props=3208  self-ms p50=11.1816 heap-bytes min=-49709776 p50=10026072 max=10066480
process 3  :B1/react-template elements=1206 props=3208  self-ms p50=10.9002 heap-bytes min=-56218640 p50=10028464 max=10072856
process 4  :B1/react-template elements=1206 props=3208  self-ms p50=11.1622 heap-bytes min=-56210360 p50=10028352 max=10066688
process 5  :B1/react-template elements=1206 props=3208  self-ms p50=11.3335 heap-bytes min=-56206192 p50=10027640 max=10067152
process 6  :B1/react-template elements=1206 props=3208  self-ms p50=12.603  heap-bytes min=-49706864 p50=10026040 max=10066688
process 7  :B1/react-template elements=1206 props=3208  self-ms p50=11.5649 heap-bytes min=-56196024 p50=10027520 max=10067488
process 8  :B1/react-template elements=1206 props=3208  self-ms p50=11.4835 heap-bytes min=-49684840 p50=10026160 max=10066960

process 1  :B1/react-small-template elements=24 props=56  self-ms p50=0.1378 heap-bytes min=167032 p50=167048 max=167376
process 2  :B1/react-small-template elements=24 props=56  self-ms p50=0.1462 heap-bytes min=167032 p50=167040 max=167376
process 3  :B1/react-small-template elements=24 props=56  self-ms p50=0.1939 heap-bytes min=167032 p50=167048 max=168160
process 4  :B1/react-small-template elements=24 props=56  self-ms p50=0.1987 heap-bytes min=167032 p50=167040 max=168184
process 5  :B1/react-small-template elements=24 props=56  self-ms p50=0.1542 heap-bytes min=167032 p50=167048 max=167632
process 6  :B1/react-small-template elements=24 props=56  self-ms p50=0.2116 heap-bytes min=167032 p50=167032 max=167392
process 7  :B1/react-small-template elements=24 props=56  self-ms p50=0.1787 heap-bytes min=167032 p50=167040 max=167392
process 8  :B1/react-small-template elements=24 props=56  self-ms p50=0.1758 heap-bytes min=167032 p50=167040 max=167176
```

`1206 / 3208` and `24 / 56`, eight times out of eight, 0 failures each.

Read the same rows sideways for the reason this bead exists. Within a single
40-sample run of the stress workload the heap delta spans **-56,218,640 to
+10,072,856 bytes** — a 66 MB swing, sign included, for a render that is
byte-for-byte the same work — and the p50 self time moves 10.9 to 12.6 ms across
processes. Those two columns cannot attribute anything, which is exactly why they
are published as evidence and cannot reach the exit code. The count columns can,
and do.

The settling is enforced, not merely observed: `bench.measure/instability-failure`
reds any `:count` measurement that answers two values across a sample set, and
`react-arm-a-counter-that-stopped-settling-would-red` hands `bench/run` a workload
whose count drifts by one per iteration and requires exit 1 naming the property.

## The counter discriminates

A green reading that could never have been anything else is vacuous. Over the same
sweep both counters move — measured, not predicted:

```
DISCRIMINATION rows= [0 1 2 6 40 400] elements= [6 9 12 24 126 1206] props= [8 16 24 56 328 3208]
```

Strictly increasing, no repeated value. And they move INDEPENDENTLY, so neither is
a restatement of the other: `[:div [:span]]` and `[:div.x [:span.y {:id "z"}]]`
hold the element count fixed while the props move; `[:div [:span]]` and
`[:div [:span] [:span]]` hold the props at zero while the elements move.

Discrimination is structural as well as tested: the two registered workloads gate
against different written expectations, so a counter that stopped tracking the
workload it counts would fail one of them.

## Scope

Measurement only. No semantic change to `react.cljs`, `tree.cljc` or any render
path — the candidate optimizations this unblocks (the attribute loop, the repeated
`:key` lookup, the void-tag check ordering) are a separate slice, and they can now
be argued with numbers instead of plausibility.

Registered where it can run: `clojure -M:bench` is a JVM process and
`re-frame.freehand.react` is ClojureScript-only, so the arm registers itself at
load into the suite the ClojureScript host runs, exactly as B1's structural arm
registers into the JVM one. `bench/runner.cljc` is untouched.

## Quality gates

All run in this worktree, foreground, one at a time, on the rebased branch.

| gate | result |
|---|---|
| `cd implementation/freehand && clojure -M:test` | 495 tests, 3242 assertions, **0 failures, 0 errors** |
| `npm run test:freehand` | 374 tests, 2634 assertions, **0 failures, 0 errors** |
| `npm run test:cljs` | 10495 tests, 52716 assertions, **0 failures, 0 errors** |
| `python scripts/check_freehand_conformance_index.py` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `git grep 're-frame.ui' implementation/freehand/` | empty |

### Non-vacuity

`react-arm-a-counter-that-stopped-settling-would-red`'s `(= 1 (:exit-code outcome))`
was inverted to `(= 0 ...)`. `npm run test:freehand` went red naming the file and
the test:

```
Testing re-frame.freehand.bench.b1-react-cljs-test

FAIL in (react-arm-a-counter-that-stopped-settling-would-red) (re_frame/freehand/bench/b1_react_cljs_test.cljs:220:11)
a drifting deterministic property reds the run
expected: (= 0 (:exit-code outcome))
  actual: (not (= 0 1))

Ran 368 tests containing 2573 assertions.
1 failures, 0 errors.
```

Restored; `git status` clean and `git diff HEAD` empty, i.e. byte-identical.
