### PR TITLE
fix(freehand): checker reader-conditional crash, identity and refusal (rf2-drpa3.90, rf2-drpa3.97, rf2-drpa3.98)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
@@ -87,6 +87,12 @@
   and discovery ([[declaration-for]]) runs on the resolved BRANCHES, so a
   `v/defview` written under `#?(:clj … :cljs …)` is found.
 
+  Where selection leaves source the TARGET's own reader would refuse — a map
+  entry with one side elided, two entries selecting the same key — the checker
+  refuses too (see [[resolve-entries]]). A branch that does not READ cannot be
+  eligible, and normalising it into something readable would be a green about
+  a map nobody wrote.
+
   A PURE `.cljs` source is the case that has no answer, and it is refused
   rather than approximated (see [[refuse-cljs-source!]]). Resolution needs
   either a namespace loaded on the JVM — which a `.cljs` namespace never is
@@ -448,6 +454,80 @@
 
 (declare resolve-conditionals)
 
+(defn- elides?
+  "Does `form` select NOTHING for `features`? Only a reader conditional can;
+  every other form contributes itself to every target."
+  [form features]
+  (and (reader-conditional? form)
+       (= ::elide (select-branch form features))))
+
+(defn- refuse-unreadable-map!
+  "Refuse a map the `features` target's reader would not accept.
+
+  Thrown WITHOUT the file, because the walk does not carry one;
+  [[read-declarations]] holds the path and prefixes it, which is what
+  `::unreadable-map` marks this exception for. `sentence` completes \"a map
+  literal … cannot be read for the :cljs target\"."
+  [sentence m features]
+  (throw (ex-info (str "a map literal " sentence " cannot be read for the "
+                       (first features) " target, so the checker will not "
+                       "answer for a declaration containing it. Write the "
+                       "conditional around the WHOLE map — #?(:clj {…} :cljs {…}) "
+                       "— or give every entry a branch for every target. The map, "
+                       "as preserved: " (pr-str m))
+                  {::unreadable-map true :target (first features) :map m})))
+
+(defn- resolve-entries
+  "Resolve conditionals across a map's entries, at the refusal boundary the
+  TARGET's reader draws.
+
+  The file is read with conditionals preserved, so a map arrives already
+  PAIRED. The reader that compiles the target pairs its forms AFTER selection,
+  and two things can happen in between that no rebuilt-from-pairs map can
+  express. A conditional in key or value position that selects nothing leaves
+  its entry half-written — the target reader sees an odd number of forms. And
+  two keys distinct as authored can select the SAME key, which the target
+  reader refuses as a duplicate.
+
+  Resolving each side independently and rebuilding with `into` did neither: it
+  fabricated `{:title nil}` for `{:title #?(:clj 1)}` and silently kept one
+  entry of `{#?(:clj :a :cljs :b) 1 :b 2}`, then reported the view ELIGIBLE.
+  A branch that does not READ cannot be eligible, and a checker whose green
+  survives source the compiler cannot read is answering a different question
+  than the one it was asked. So both are refused.
+
+  An entry whose key and value BOTH elide contributes nothing at all, which is
+  exactly what it contributes to the real reader, and is dropped. What is NOT
+  reconstructed is a map whose surviving forms RE-PAIR into a different map —
+  `{#?(:clj :a) 1 :b #?(:clj 2)}` reads as `{1 :b}` for `:cljs`. Recovering
+  that needs maps read as flat form sequences, a reader of the checker's own,
+  and it is refused with the rest: an honest refusal on source nobody writes
+  is the right trade against the general-purpose-analyzer non-goal."
+  [m features]
+  (reduce-kv
+   (fn [acc k v]
+     (let [k-gone? (elides? k features)
+           v-gone? (elides? v features)]
+       (cond
+         (and k-gone? v-gone?) acc
+         (or k-gone? v-gone?)
+         (refuse-unreadable-map!
+          (str "whose conditional selects nothing for the "
+               (if k-gone? "KEY" "VALUE") " of the entry " (pr-str [k v])
+               ", leaving that entry half-written,")
+          m features)
+
+         :else
+         (let [k' (resolve-conditionals k features)]
+           (if (contains? acc k')
+             (refuse-unreadable-map!
+              (str "whose conditional selection gives two entries the same key, "
+                   (pr-str k') ",")
+              m features)
+             (assoc acc k' (resolve-conditionals v features)))))))
+   (empty m)
+   m))
+
 (defn- resolve-children
   "Resolve conditionals across a sequence of sibling forms, SPLICING a
   matched `#?@` and dropping an elided conditional — the two things a
@@ -480,7 +560,11 @@
   EVERY collection kind is descended into, sets included. A kind left out is
   not a smaller fix, it is the same false-green in a new position: the
   conditional survives the walk, and the analyzer is handed a reader object
-  where the browser build has `#{v/sub}`."
+  where the browser build has `#{v/sub}`.
+
+  A MAP is the one kind whose target reader can refuse what selection leaves
+  behind, and there the walk stops rather than assembling something the target
+  cannot read — see [[resolve-entries]]."
   [form features]
   (cond
     (not (has-reader-conditional? form))
@@ -491,11 +575,7 @@
       (when-not (= ::elide branch) (resolve-conditionals branch features)))
 
     (map? form)
-    (with-meta (into (empty form)
-                     (map (fn [[k v]] [(resolve-conditionals k features)
-                                       (resolve-conditionals v features)]))
-                     form)
-               (meta form))
+    (with-meta (resolve-entries form features) (meta form))
 
     (set? form)
     (with-meta (into (empty form) (resolve-children form features)) (meta form))
@@ -628,7 +708,10 @@
   aliases resolve.
 
   The one shape that read mode cannot read is answered as a refusal rather
-  than raised as a reader exception — see [[refuse-preserved-read!]]."
+  than raised as a reader exception — see [[refuse-preserved-read!]]. This is
+  also where the file's NAME is put on a refusal raised deeper in the walk:
+  [[resolve-entries]] knows which map stopped it and for which target but not
+  which file it came from, and every checker refusal names the file."
   [path]
   (with-open [rdr (LineNumberingPushbackReader. (io/reader (io/file path)))]
     (try
@@ -644,7 +727,14 @@
                            (conj declarations declaration)
                            declarations))))))))
       (catch clojure.lang.LispReader$ReaderException ex
-        (refuse-preserved-read! ex path)))))
+        (refuse-preserved-read! ex path))
+      (catch clojure.lang.ExceptionInfo ex
+        (if (::unreadable-map (ex-data ex))
+          (throw (ex-info (str "re-frame.freehand check: " path ": " (ex-message ex))
+                          (-> (ex-data ex)
+                              (dissoc ::unreadable-map)
+                              (assoc :file (str path)))))
+          (throw ex))))))
 
 (defn- refuse-cljs-source!
   "Refuse a pure `.cljs` `path`, naming the two workflows that answer.

--- a/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
@@ -322,8 +322,50 @@
   the browser build compiles is elided before the analyzer can see it, and
   the checker false-greens it. Preserving the conditionals instead hands
   BOTH branches to [[resolve-conditionals]], which selects each target's
-  branch itself — a selection the platform feature cannot override."
+  branch itself — a selection the platform feature cannot override.
+
+  It buys one blind spot, which is REPORTED rather than crashed on: see
+  [[refuse-preserved-read!]]."
   {:eof ::eof :read-cond :preserve})
+
+(defn- refuse-preserved-read!
+  "Re-throw reader exception `ex` from `path` as a checker REFUSAL when the
+  checker's own read mode is what caused it.
+
+  Clojure's map reader counts the forms it read BEFORE any splicing is
+  applied, and a PRESERVED `#?@` is one form. So a map literal containing a
+  splicing conditional reads for every compile and not here:
+
+      {:a 1 #?@(:clj [:b 2])}   ; :read-cond :allow -> {:a 1 :b 2}
+                                ; :read-cond :preserve -> refused, odd forms
+
+  Recovering it would mean reading maps as flat form sequences and pairing
+  them after selection — a reader of the checker's own, which is the
+  general-purpose source analyzer this namespace is not. So the limitation is
+  named instead. A refusal that says which shape stopped it and how to write
+  the shape differently is an answer; a reader stack trace is not, and it says
+  the wrong thing besides — that the declaration is broken rather than that
+  the checker cannot see it.
+
+  Any OTHER read failure is re-thrown untouched, for the reason
+  [[findings-for-branch]] re-throws a non-grammar exception: a file that does
+  not read at all was not made unreadable by the checker, and the reader's own
+  message about it is already the best answer — the same one the compile gives."
+  [^clojure.lang.LispReader$ReaderException ex path]
+  (if (= "Map literal must contain an even number of forms"
+         (some-> (.getCause ex) .getMessage))
+    (let [{:clojure.error/keys [line column]} (ex-data ex)]
+      (throw (ex-info (str "re-frame.freehand check: " path " could not be read at line " line
+                           ", column " column ". The checker reads with reader conditionals "
+                           "PRESERVED so it can select each target's branch itself, and "
+                           "Clojure's map reader counts forms BEFORE splicing — so a map "
+                           "literal containing a SPLICING conditional, {:a 1 #?@(:clj [:b 2])}, "
+                           "reads for a compile and not here. Write the conditional around the "
+                           "whole map, #?(:clj {:a 1 :b 2} :cljs {:a 1}), or around each entry's "
+                           "value, and check again. (If that map has no splicing conditional, it "
+                           "really does have an odd number of forms.)")
+                      {:file (str path) :read-cond :preserve :line line :column column})))
+    (throw ex)))
 
 (defn- source-namespace
   "The namespace symbol declared by the file's leading `(ns …)` form."
@@ -526,20 +568,26 @@
   way to answer the question. Reader conditionals are PRESERVED rather than
   resolved by the reader (see [[read-opts]]) so the `:cljs` branch survives
   to be analyzed. Forms are read in the file's own namespace so `::keyword`
-  aliases resolve."
+  aliases resolve.
+
+  The one shape that read mode cannot read is answered as a refusal rather
+  than raised as a reader exception — see [[refuse-preserved-read!]]."
   [path]
   (with-open [rdr (LineNumberingPushbackReader. (io/reader (io/file path)))]
-    (binding [*read-eval* false]
-      (let [ns-sym (source-namespace (read read-opts rdr) path)
-            ns-obj (live-namespace ns-sym path)]
-        (binding [*ns* ns-obj]
-          (loop [declarations []]
-            (let [form (read read-opts rdr)]
-              (if (= ::eof form)
-                declarations
-                (recur (if-let [declaration (declaration-for path ns-sym ns-obj form)]
-                         (conj declarations declaration)
-                         declarations))))))))))
+    (try
+      (binding [*read-eval* false]
+        (let [ns-sym (source-namespace (read read-opts rdr) path)
+              ns-obj (live-namespace ns-sym path)]
+          (binding [*ns* ns-obj]
+            (loop [declarations []]
+              (let [form (read read-opts rdr)]
+                (if (= ::eof form)
+                  declarations
+                  (recur (if-let [declaration (declaration-for path ns-sym ns-obj form)]
+                           (conj declarations declaration)
+                           declarations))))))))
+      (catch clojure.lang.LispReader$ReaderException ex
+        (refuse-preserved-read! ex path)))))
 
 (defn- refuse-cljs-source!
   "Refuse a pure `.cljs` `path`, naming the two workflows that answer.

--- a/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
@@ -261,12 +261,14 @@
   both must be inside the grammar for the compile to stand. The declaration
   itself is the branch the JVM reader selected (`#{:clj}`); `:cljs-branch`,
   present only when the two branches read DIFFERENTLY, carries what the
-  browser build's branch (`#{:cljs}`) BINDS and RENDERS — the branch an
-  author is most likely to false-green, because the JVM reader never elides
-  to it. It is MERGED over the declaration rather than substituted for its
-  body alone, because a conditional around the whole declaration diverges
-  the params too, and a body analyzed against the other branch's params
-  would be refused (or excused) for the wrong reason.
+  browser build's branch (`#{:cljs}`) BINDS, RENDERS and IS WRITTEN AT — the
+  branch an author is most likely to false-green, because the JVM reader
+  never elides to it. It is MERGED over the declaration rather than
+  substituted for its body alone, because a conditional around the whole
+  declaration diverges the params too, and a body analyzed against the other
+  branch's params would be refused (or excused) for the wrong reason — and
+  because a finding is anchored at its declaration's source, which for that
+  branch is its own line and not the JVM branch's.
 
   Both branches are analyzed JVM-side with the SAME head resolution either
   target uses — resolution is JVM for both hosts, so only the FORMS the
@@ -297,10 +299,12 @@
 
   `:cljs-branch` is supplied by [[read-declarations]] only for a `.cljc`
   view whose `#?(:clj … :cljs …)` branches read differently. It carries the
-  branch-owned parts alone — `:params`, `:children-policy`, `:body` — and
-  is merged over the declaration to analyze the CLJS target (see
-  [[findings-for]]), so a `:cljs`-only ineligible form is found rather than
-  false-greened.
+  branch-owned parts alone — the [[branch-keys]] — and is merged over the
+  declaration to analyze the CLJS target (see [[findings-for]]), so a
+  `:cljs`-only ineligible form is found rather than false-greened, and is
+  reported at the line that branch occupies. The view's id and its declared
+  lowering are NOT branch-owned: branches that disagree about either are
+  refused outright (see [[identity-keys]]).
 
   A declaration that already carries `{:compiled true}` is checked the
   same way and reports `:current-lowering :compiled` — the question
@@ -517,11 +521,53 @@
 
 (def ^:private branch-keys
   "The declaration parts a reader conditional can make target-specific: what
-  the branch BINDS and what it RENDERS. Everything else — the view's id, its
-  name, its source coordinates, whether it says `{:compiled true}` — is the
-  declaration's identity, and one identity is what the file declares however
-  many branches it was written across."
-  [:params :children-policy :body])
+  the branch BINDS, what it RENDERS, and WHERE it is written.
+
+  `:source` is here because a conditional around the whole declaration puts
+  the two branches at two places in the file, and a finding from the CLJS
+  branch anchored at the CLJ branch's line sends an author to source that is
+  not the source that failed. A finding's coordinates fall back to its
+  declaration's (see [[coords]]) whenever the reader anchored no metadata of
+  its own — which is most of the time, the reader anchoring lists and not
+  vectors — so the fallback has to be the branch's own."
+  [:params :children-policy :body :source])
+
+(def ^:private identity-keys
+  "The declaration parts a reader conditional may NOT make target-specific.
+
+  A report names one view and one lowering. These are those fields, and if the
+  branches disagree about either, no single report is true of both — so the
+  divergence is refused rather than resolved by preferring a branch. Preferring
+  one is what [[declaration-for]] used to do, and it produced the worst answer
+  a checker can give: a finding drawn from the CLJS branch's body, labelled
+  with the CLJ branch's view id and anchored at the CLJ branch's line. The
+  declaration that actually failed never appeared at all, and the one that was
+  named is fine."
+  [:view-id :compiled?])
+
+(defn- refuse-divergent-identity!
+  "Refuse a top-level conditional whose branches declare DIFFERENT views.
+
+  Two declarations written as one form are two declarations, and the recovery
+  says so: give each its own top-level conditional. Discovery already handles
+  a one-armed conditional — `#?(:clj (v/defview …))` resolves to the
+  declaration for `:clj` and to nothing for `:cljs` — so each is then found,
+  checked against its own target, and reported as ITSELF."
+  [path clj-decl cljs-decl]
+  (let [differing (filter #(not= (get clj-decl %) (get cljs-decl %)) identity-keys)
+        rendered  (str/join ", " (map #(str % " " (pr-str (get clj-decl %))
+                                          " vs " (pr-str (get cljs-decl %)))
+                                      differing))]
+    (throw (ex-info (str "re-frame.freehand check: " path ": the :clj and :cljs branches of one "
+                         "top-level reader conditional disagree about the declaration's IDENTITY "
+                         "— they differ in " rendered ". A report names ONE view and ONE lowering, "
+                         "so answering for both branches would attribute one branch's body to the "
+                         "other's identity. Give each target its own top-level conditional — "
+                         "#?(:clj (v/defview …)) and #?(:cljs (v/defview …)) — and each is "
+                         "discovered, checked against its own target, and reported as itself.")
+                    {:file (str path)
+                     :clj  (select-keys clj-decl (cons :source identity-keys))
+                     :cljs (select-keys cljs-decl (cons :source identity-keys))}))))
 
 (defn- declaration-for
   "The declaration data for top-level `form`, or nil when it declares no view.
@@ -537,12 +583,19 @@
   about it — the loudest false-green there is, since the author reads
   silence as \"no findings\".
 
-  What the branches contain is still ONE declaration. Its identity is the
-  JVM branch's — or the CLJS branch's, for a view that exists only in the
-  browser build — and `:cljs-branch` carries the [[branch-keys]] whenever
-  the CLJS branch's differ. Both are then analyzed by [[findings-for]], so a
-  `:cljs`-only form outside the grammar is FOUND rather than elided by the
-  reader and false-greened."
+  What the branches contain is ONE declaration only if they AGREE about which
+  declaration it is. [[identity-keys]] is that agreement, and a divergence in
+  it is refused ([[refuse-divergent-identity!]]) rather than settled by
+  preferring a branch. What remains is genuinely branch-owned — the
+  [[branch-keys]] — and rides in `:cljs-branch` whenever the CLJS branch's
+  differ, which for a declaration under a conditional includes its own source
+  coordinates. Both are then analyzed by [[findings-for]], so a `:cljs`-only
+  form outside the grammar is FOUND rather than elided by the reader and
+  false-greened, and it is found at the line it was written on.
+
+  A one-armed conditional is not a divergence: `#?(:clj (v/defview …))`
+  resolves to a declaration for `:clj` and to nothing for `:cljs`, so the view
+  is checked for the one target that has it."
   [path ns-sym ns-obj form]
   (let [decl-for  (fn [features]
                     (let [f (resolve-conditionals form features)]
@@ -552,6 +605,10 @@
         cljs-decl (decl-for #{:cljs})
         decl      (or clj-decl cljs-decl)]
     (when decl
+      (when (and clj-decl cljs-decl
+                 (not= (select-keys clj-decl identity-keys)
+                       (select-keys cljs-decl identity-keys)))
+        (refuse-divergent-identity! path clj-decl cljs-decl))
       (cond-> decl
         (and cljs-decl (not= (select-keys cljs-decl branch-keys)
                              (select-keys decl branch-keys)))

--- a/implementation/freehand/test/re_frame/freehand/check_branch_identity_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/check_branch_identity_jvm_test.clj
@@ -1,0 +1,213 @@
+(ns re-frame.freehand.check-branch-identity-jvm-test
+  "A report must be true of the declaration it names.
+
+  `check-conditional-placement-jvm-test` pins that a `v/defview` written under
+  a top-level reader conditional is DISCOVERED. Discovery assumed the two
+  branches were one declaration and settled identity by preferring the `:clj`
+  branch — which is right when the branches agree about which view they
+  declare, and produces the worst answer a checker can give when they do not:
+  a finding drawn from the CLJS branch's body, labelled with the CLJ branch's
+  view id, anchored at the CLJ branch's line. The declaration that failed
+  never appeared; the one that was named is fine. That is not an unsupported
+  shape reported as unsupported — it is confident misattribution, and an
+  author reading it edits the wrong view.
+
+  Four things are asserted:
+
+    1. a real reader (`clojure.tools.reader`, independent of the code under
+       test) really does see two DIFFERENT declarations here, one per target —
+       so the refusal is about the source and not about the checker's walk;
+    2. `check-file` refuses the divergent identity, naming both view ids and
+       the recovery, and never emits a report labelled with one branch's id
+       carrying the other's body;
+    3. the recovery works: split into two one-armed conditionals, each view is
+       discovered on the target that declares it and reported as ITSELF —
+       including the browser-only view the JVM reader elides;
+    4. identity is the view id AND the declared lowering, because a report
+       carries one `:current-lowering` too;
+
+  and, for the same-name declarations that are still one declaration, that a
+  finding from the CLJS branch anchors at the CLJS branch's line rather than
+  the CLJ branch's."
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [clojure.tools.reader :as rdr]
+            [clojure.tools.reader.reader-types :as rt]
+            [re-frame.freehand.check-branch-identity-split-views]
+            [re-frame.freehand.check-branch-identity-views]
+            [re-frame.freehand.check-conditional-placement-views]
+            [re-frame.freehand.compiler.check :as check]))
+
+(def ^:private divergent-resource
+  "re_frame/freehand/check_branch_identity_views.cljc")
+
+(def ^:private divergent-path
+  (.getPath (io/file (io/resource divergent-resource))))
+
+(def ^:private split-path
+  (.getPath (io/file (io/resource "re_frame/freehand/check_branch_identity_split_views.cljc"))))
+
+(def ^:private placement-path
+  (.getPath (io/file (io/resource "re_frame/freehand/check_conditional_placement_views.cljc"))))
+
+(defn- thrown-by [f]
+  (try (f) nil (catch Throwable t t)))
+
+(defn- report-for [view-id reports]
+  (first (filter #(= view-id (:view-id %)) reports)))
+
+;; ---------------------------------------------------------------------------
+;; 1 — the source really does declare two different views
+;; ---------------------------------------------------------------------------
+
+(defn- declared-names-for
+  "The `v/defview` names a REAL reader finds in `resource`, reading it for
+  `features`. `clojure.tools.reader` honours `:features` exactly — it has no
+  unconditional platform feature — so this is what each target's compile
+  actually declares, established without the checker."
+  [resource features]
+  (let [r (rt/indexing-push-back-reader (slurp (io/resource resource)))]
+    (loop [acc []]
+      (let [form (rdr/read {:eof ::eof :read-cond :allow :features features} r)]
+        (cond
+          (= ::eof form)                               acc
+          (and (seq? form) (= 'v/defview (first form))) (recur (conj acc (second form)))
+          :else                                        (recur acc))))))
+
+(deftest the-branches-declare-different-views
+  (testing "one form, two declarations — the JVM build gets jvm-view and the
+            browser build gets browser-view, and no single report names both"
+    (is (= '[jvm-view]     (declared-names-for divergent-resource #{:clj})))
+    (is (= '[browser-view] (declared-names-for divergent-resource #{:cljs})))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — check-file refuses rather than misattributing
+;; ---------------------------------------------------------------------------
+
+(deftest a-divergent-identity-is-refused
+  (let [ex (thrown-by #(check/check-file divergent-path))]
+    (is (instance? clojure.lang.ExceptionInfo ex)
+        "a refusal — not a report. Before this, check-file answered one report:
+         :.../jvm-view, ineligible, offending form [tag \"browser view\"] — a
+         body jvm-view does not have, at a line browser-view is not on")
+
+    (testing "the sentence names the checker, the file, what diverged, and the
+              recovery"
+      (let [msg (ex-message ex)]
+        (is (re-find #"^re-frame\.freehand check: " msg))
+        (is (.contains msg divergent-path))
+        (is (.contains msg ":view-id") "what diverged is named")
+        (is (.contains msg "check-branch-identity-views/jvm-view"))
+        (is (.contains msg "check-branch-identity-views/browser-view")
+            "and BOTH declarations are named — the browser one was previously
+             invisible in every answer the checker gave about this file")
+        (is (.contains msg "own top-level conditional") "the recovery is the payload")))
+
+    (testing "and the data carries each branch as itself, so a tool can render
+              both without re-reading the file"
+      (is (= :re-frame.freehand.check-branch-identity-views/jvm-view
+             (get-in (ex-data ex) [:clj :view-id])))
+      (is (= :re-frame.freehand.check-branch-identity-views/browser-view
+             (get-in (ex-data ex) [:cljs :view-id])))
+      (is (= 25 (get-in (ex-data ex) [:clj :source :line])))
+      (is (= 31 (get-in (ex-data ex) [:cljs :source :line]))
+          "the browser declaration's own line, which no previous answer carried")
+      (is (= divergent-path (:file (ex-data ex)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the recovery the refusal names actually answers
+;; ---------------------------------------------------------------------------
+
+(deftest split-declarations-are-each-reported-as-themselves
+  (let [reports (check/check-file split-path)]
+    (is (= [:re-frame.freehand.check-branch-identity-split-views/jvm-only
+            :re-frame.freehand.check-branch-identity-split-views/browser-only]
+           (mapv :view-id reports))
+        "both declarations, in declaration order, each under its own id —
+         including the browser-only one the JVM reader elides entirely")
+
+    (testing "the JVM-only view is inside the grammar and says nothing"
+      (is (= {:compile-eligible? true :findings []}
+             (select-keys (report-for :re-frame.freehand.check-branch-identity-split-views/jvm-only
+                                      reports)
+                          [:compile-eligible? :findings]))))
+
+    (testing "and the browser-only view is refused as ITSELF, at its own line,
+              for its own body — the answer the divergent form could not give"
+      (is (= {:view-id           :re-frame.freehand.check-branch-identity-split-views/browser-only
+              :source            {:file split-path :line 26 :column 4}
+              :current-lowering  :interpreted
+              :target-grammar    :re-frame.freehand/v1
+              :compile-eligible? false
+              :findings          [{:id       :rf.ui.compile/dynamic-head
+                                   :source   {:line 26 :column 4}
+                                   :form     '[tag "browser only"]
+                                   :reason   :head-is-a-runtime-value
+                                   :recovery [:use-a-literal-head
+                                              :extract-declared-child
+                                              :keep-interpreted]}]}
+             (report-for :re-frame.freehand.check-branch-identity-split-views/browser-only
+                         reports))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — identity is the id AND the declared lowering
+;; ---------------------------------------------------------------------------
+
+(def ^:private declaration-for
+  "Discovery for one top-level form, reached directly: a lowering divergence
+  refuses for the same reason a name divergence does, and a report cannot
+  carry two `:current-lowering` values any more than it can carry two ids."
+  #'check/declaration-for)
+
+(deftest a-divergent-lowering-is-refused-too
+  (let [ns-obj (find-ns 're-frame.freehand.check-branch-identity-views)
+        form   (read-string {:read-cond :preserve}
+                            (str "#?(:clj  (v/defview thing {:compiled true} [_] [:div \"x\"])"
+                                 "   :cljs (v/defview thing [_] [:div \"x\"]))"))
+        ex     (thrown-by #(declaration-for "identity.cljc" 'app.identity ns-obj form))]
+    (is (instance? clojure.lang.ExceptionInfo ex))
+    (is (.contains (ex-message ex) ":compiled? true vs false")
+        "the report would otherwise claim :current-lowering :compiled for a
+         browser branch that declares nothing of the sort"))
+
+  (testing "and agreement is not refused: same id, same lowering, different
+            body is one declaration and checks fine"
+    (let [ns-obj (find-ns 're-frame.freehand.check-branch-identity-views)
+          form   (read-string {:read-cond :preserve}
+                              (str "#?(:clj  (v/defview thing [_] [:div \"jvm\"])"
+                                   "   :cljs (v/defview thing [_] [:span \"spa\"]))"))
+          decl   (declaration-for "identity.cljc" 'app.identity ns-obj form)]
+      (is (= :app.identity/thing (:view-id decl)))
+      (is (= '([:span "spa"]) (get-in decl [:cljs-branch :body]))))))
+
+;; ---------------------------------------------------------------------------
+;; The same-name case: one declaration, two branches, truthful anchors
+;; ---------------------------------------------------------------------------
+
+(deftest a-cljs-finding-anchors-at-the-cljs-branch
+  (testing "branches that agree about identity ARE one declaration, and stay
+            one report — but a finding from the CLJS branch is anchored where
+            that branch is written (line 69), not where the report identity
+            comes from (line 65). Sending an author to the branch that did not
+            fail is the same misdirection in a smaller form"
+    (let [report (report-for :re-frame.freehand.check-conditional-placement-views/declaration-divergent
+                             (check/check-file placement-path))]
+      (is (= 65 (-> report :source :line)) "the declaration's identity anchor")
+      (is (= 69 (-> report :findings first :source :line))
+          "and the CLJS branch's own line for the CLJS branch's refusal")
+      (is (= '[tag {} "the CLJS branch has a dynamic head - ineligible"]
+             (-> report :findings first :form))))))
+
+;; ---------------------------------------------------------------------------
+;; Read-only
+;; ---------------------------------------------------------------------------
+
+(deftest the-checker-never-writes
+  (testing "refusing and reporting are both read-only — every source pointed
+            at is byte-identical afterwards"
+    (doseq [path [divergent-path split-path]]
+      (let [before (java.nio.file.Files/readAllBytes (.toPath (io/file path)))
+            _      (thrown-by #(check/check-file path))
+            after  (java.nio.file.Files/readAllBytes (.toPath (io/file path)))]
+        (is (pos? (alength before)) (str path " is not empty"))
+        (is (java.util.Arrays/equals ^bytes before ^bytes after))))))

--- a/implementation/freehand/test/re_frame/freehand/check_branch_identity_split_views.cljc
+++ b/implementation/freehand/test/re_frame/freehand/check_branch_identity_split_views.cljc
@@ -1,0 +1,30 @@
+(ns re-frame.freehand.check-branch-identity-split-views
+  "The recovery `check-branch-identity-views` is refused with: two views, two
+  top-level conditionals.
+
+  A one-armed `#?(:clj …)` resolves to its declaration for the JVM target and
+  to nothing for the browser one, so each view here is discovered exactly on
+  the target that declares it, checked against that target, and reported under
+  its OWN id at its OWN line. `browser-only` is deliberately ineligible — a
+  head bound from props — so the file also proves the recovery answers the
+  question the refused shape could not: which of the two declarations is
+  outside the grammar.
+
+  Loaded on the JVM (required by
+  `re-frame.freehand.check-branch-identity-jvm-test`), where only `jvm-only`
+  is declared; `browser-only` exists for the browser build and for the
+  checker."
+  (:require [re-frame.freehand :as v]))
+
+#?(:clj
+   (v/defview jvm-only
+     "Declared for the JVM build alone - a literal element, inside the grammar."
+     [_]
+     [:div "JVM only"]))
+
+#?(:cljs
+   (v/defview browser-only
+     "Declared for the browser build alone - a head bound from props, outside
+     the grammar."
+     [{:keys [tag]}]
+     [tag "browser only"]))

--- a/implementation/freehand/test/re_frame/freehand/check_branch_identity_views.cljc
+++ b/implementation/freehand/test/re_frame/freehand/check_branch_identity_views.cljc
@@ -1,0 +1,35 @@
+(ns re-frame.freehand.check-branch-identity-views
+  "One top-level reader conditional declaring a DIFFERENT view per target.
+
+  `check-conditional-placement-views` covers the ordinary case: a declaration
+  written across a conditional that says the same thing about itself on both
+  targets — same name, same declared lowering — and differs only in what it
+  binds and renders. That is one declaration, and one report answers for it.
+
+  This is the other case, and it is two declarations wearing one form. The JVM
+  build declares `jvm-view`; the browser build declares `browser-view`, with
+  different params and a head bound from them. Nothing here is illegal — a
+  `.cljc` namespace may absolutely offer a different view per host — but no
+  single report is true of both, because a report names one view id and one
+  lowering. The checker used to answer anyway, by preferring the `:clj` branch
+  for identity and the `:cljs` branch for findings, which produced a confident
+  report about a view that has no such body: `jvm-view`, ineligible, offending
+  form `[tag \"browser view\"]`. `browser-view` never appeared at all.
+
+  Loaded on the JVM (required by
+  `re-frame.freehand.check-branch-identity-jvm-test`), where the reader takes
+  the `:clj` branch, so only `jvm-view` exists here at runtime."
+  (:require [re-frame.freehand :as v]))
+
+#?(:clj
+   (v/defview jvm-view
+     "The view the JVM build declares."
+     [_]
+     [:div "JVM view"])
+
+   :cljs
+   (v/defview browser-view
+     "The view the browser build declares - a different name, different
+     params, and a head bound from them."
+     [{:keys [tag]}]
+     [tag "browser view"]))

--- a/implementation/freehand/test/re_frame/freehand/check_conditional_map_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/check_conditional_map_jvm_test.clj
@@ -1,0 +1,202 @@
+(ns re-frame.freehand.check-conditional-map-jvm-test
+  "A green from the checker must mean the target can READ the branch.
+
+  The checker reads with conditionals preserved, so a map arrives already
+  PAIRED. The reader that compiles the target pairs its forms AFTER selection,
+  and two shapes fall between the two: an entry with one side elided, which
+  leaves the target reader an odd number of forms, and two keys distinct as
+  authored that select the SAME key, which the target reader refuses as a
+  duplicate. Resolving each side independently and rebuilding with `into` did
+  neither — it fabricated `{:title nil}` for the first and silently kept one
+  entry for the second, and both views came back `:compile-eligible? true`
+  with no findings. A branch that does not read at all cannot be eligible;
+  that green was about a map nobody wrote.
+
+  Five things are asserted:
+
+    1. an INDEPENDENT target reader (`clojure.tools.reader` at `:features
+       #{:cljs}`, which has no unconditional platform feature) refuses each
+       shape, and accepts it for `:clj` — the boundary is the reader's, not
+       the checker's opinion;
+    2. `check-file` refuses each shape rather than reporting eligible, naming
+       the file, the map, the target and the recovery;
+    3. valid conditional keys and values stay eligible, keep both entries, and
+       retain the map's metadata — refusing must not cost the ordinary case;
+    4. the refusal is target-symmetric, and an entry whose key and value BOTH
+       elide is DROPPED rather than refused, because that is what the real
+       reader does with it;
+    5. the checker is still read-only.
+
+  The unreadable fixtures are written to a temp file by this suite rather than
+  committed: their `:cljs` branch is source the browser build's reader
+  refuses, so a committed fixture carrying one could not be compiled for CLJS."
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [clojure.tools.reader :as rdr]
+            [clojure.tools.reader.reader-types :as rt]
+            [re-frame.freehand.check-conditional-map-views]
+            [re-frame.freehand.compiler.check :as check]))
+
+(def ^:private uniform-path
+  (.getPath (io/file (io/resource "re_frame/freehand/check_conditional_map_views.cljc"))))
+
+(def ^:private resolve-conditionals
+  "The checker's branch selection, reached directly — the map arm answers per
+  target, and a refusal raised here carries no file yet (`check-file` adds
+  it), so the bare sentence is what these assertions see."
+  #'check/resolve-conditionals)
+
+(defn- thrown-by [f]
+  (try (f) nil (catch Throwable t t)))
+
+(def ^:private shapes
+  "The two shapes a target's reader refuses, as the bead reproduced them."
+  {"elided-value"  "[:div {:title #?(:clj 1)} \"x\"]"
+   "colliding-key" "[:div {#?(:clj :a :cljs :b) 1\n         :b 2} \"x\"]"})
+
+(defn- write-temp-view
+  "Write a one-view `.cljc` namespace whose body is `shapes`'s `nm`, LOAD it so
+  heads resolve, and answer its path. The `:clj` branch of each shape is
+  perfectly readable, which is why the namespace loads — the refusal is about
+  the `:cljs` branch alone."
+  [nm]
+  (let [dir (.toFile (java.nio.file.Files/createTempDirectory
+                      "check-conditional-map"
+                      (make-array java.nio.file.attribute.FileAttribute 0)))
+        f   (io/file dir (str nm ".cljc"))]
+    (.deleteOnExit dir)
+    (.deleteOnExit f)
+    (spit f (str "(ns re-frame.freehand." nm "-temp-views\n"
+                 "  (:require [re-frame.freehand :as v]))\n"
+                 "\n"
+                 "(v/defview subject\n"
+                 "  [_]\n"
+                 "  " (get shapes nm) ")\n"))
+    (load-file (.getPath f))
+    (.getPath f)))
+
+(def ^:private temp-view
+  "Each shape is written and loaded ONCE, however many assertions point at it —
+  re-loading would redeclare the same view id for no gain."
+  (memoize write-temp-view))
+
+;; ---------------------------------------------------------------------------
+;; 1 — the boundary is the target reader's own
+;; ---------------------------------------------------------------------------
+
+(defn- read-all-for
+  "Read every form of the file at `path` with a REAL reader told to read for
+  `features`, and answer nil or the exception it threw."
+  [path features]
+  (let [r (rt/indexing-push-back-reader (slurp path))]
+    (thrown-by
+     #(loop []
+        (when-not (= ::eof (rdr/read {:eof ::eof :read-cond :allow :features features} r))
+          (recur))))))
+
+(deftest the-target-reader-refuses-both-shapes
+  (testing "an entry whose value elides leaves the target reader an odd number
+            of map forms"
+    (let [path (temp-view "elided-value")]
+      (is (nil? (read-all-for path #{:clj})) "the JVM branch reads: {:title 1}")
+      (is (re-find #"even number of forms" (str (read-all-for path #{:cljs}))))))
+
+  (testing "and a conditional key that selects an authored key is a duplicate"
+    (let [path (temp-view "colliding-key")]
+      (is (nil? (read-all-for path #{:clj})) "the JVM branch reads: {:a 1 :b 2}")
+      (is (re-find #"Duplicate key: :b" (str (read-all-for path #{:cljs})))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — check-file refuses instead of normalizing
+;; ---------------------------------------------------------------------------
+
+(deftest check-file-refuses-a-map-the-target-cannot-read
+  (testing "an elided entry side is refused, not fabricated into {:title nil}"
+    (let [path (temp-view "elided-value")
+          ex   (thrown-by #(check/check-file path))]
+      (is (instance? clojure.lang.ExceptionInfo ex)
+          "a refusal — this reported :compile-eligible? true with no findings")
+      (let [msg (ex-message ex)]
+        (is (re-find #"^re-frame\.freehand check: " msg))
+        (is (.contains msg path))
+        (is (.contains msg "VALUE") "which side of the entry went missing")
+        (is (.contains msg ":cljs target") "and for which target")
+        (is (.contains msg "{:title #?(:clj 1)}") "the map, as the checker preserved it")
+        (is (.contains msg "around the WHOLE map") "the recovery is the payload"))
+      (is (= :cljs (:target (ex-data ex))))
+      (is (= path (:file (ex-data ex))))
+      (is (= '(:title) (keys (:map (ex-data ex)))))
+      (is (reader-conditional? (:title (:map (ex-data ex))))
+          "the offending map rides in the data exactly as authored, its
+           conditional intact, so a tool can render it without re-reading")))
+
+  (testing "and a duplicate target key is refused, not silently overwritten to
+            {:b 2}"
+    (let [path (temp-view "colliding-key")
+          ex   (thrown-by #(check/check-file path))]
+      (is (instance? clojure.lang.ExceptionInfo ex))
+      (let [msg (ex-message ex)]
+        (is (.contains msg "two entries the same key, :b"))
+        (is (.contains msg ":cljs target")))
+      (is (= :cljs (:target (ex-data ex)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the ordinary case is untouched
+;; ---------------------------------------------------------------------------
+
+(deftest a-readable-conditional-map-stays-eligible
+  (testing "conditionals that select on every target keep both entries and the
+            view stays eligible — refusing the unreadable must not cost the
+            readable"
+    (is (= [{:view-id           :re-frame.freehand.check-conditional-map-views/conditional-map-uniform
+             :compile-eligible? true
+             :findings          []}]
+           (mapv #(select-keys % [:view-id :compile-eligible? :findings])
+                 (check/check-file uniform-path)))))
+
+  (testing "and the selected maps are what each target reads, metadata and all"
+    (let [form (vary-meta (read-string {:read-cond :preserve}
+                                       "{#?(:clj :title :cljs :data-title) \"hover\"
+                                         :class #?(:clj \"jvm\" :cljs \"spa\")}")
+                          assoc ::marker true)]
+      (is (= {:title "hover" :class "jvm"}          (resolve-conditionals form #{:clj})))
+      (is (= {:data-title "hover" :class "spa"}     (resolve-conditionals form #{:cljs})))
+      (is (= {::marker true} (meta (resolve-conditionals form #{:cljs})))
+          "the map's metadata rides through the rebuild"))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — symmetry, and the entry that legitimately disappears
+;; ---------------------------------------------------------------------------
+
+(deftest the-refusal-follows-the-target
+  (testing "nothing here is :cljs-specific — the JVM target is refused by the
+            same rule when the conditional is the one that elides for it"
+    (let [form (read-string {:read-cond :preserve} "{:title #?(:cljs 1)}")]
+      (is (= {:title 1} (resolve-conditionals form #{:cljs})))
+      (is (re-find #"cannot be read for the :clj target"
+                   (str (ex-message (thrown-by #(resolve-conditionals form #{:clj}))))))))
+
+  (testing "and an entry whose key AND value both elide contributes nothing to
+            the target, exactly as it contributes nothing to the real reader —
+            dropping it is not normalizing, it is agreeing"
+    (let [src  "{#?(:clj :a) #?(:clj 1) :keep 2}"
+          form (read-string {:read-cond :preserve} src)]
+      (is (= {:keep 2} (resolve-conditionals form #{:cljs})))
+      (is (= {:keep 2} (rdr/read-string {:read-cond :allow :features #{:cljs}} src))
+          "which is what clojure.tools.reader makes of it, independently")
+      (is (= {:a 1 :keep 2} (resolve-conditionals form #{:clj})))
+      (is (= {:a 1 :keep 2} (rdr/read-string {:read-cond :allow :features #{:clj}} src))))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — read-only
+;; ---------------------------------------------------------------------------
+
+(deftest the-checker-never-writes
+  (testing "refusing a map is still read-only — the source pointed at is
+            byte-identical afterwards"
+    (doseq [path [uniform-path (temp-view "elided-value")]]
+      (let [before (java.nio.file.Files/readAllBytes (.toPath (io/file path)))
+            _      (thrown-by #(check/check-file path))
+            after  (java.nio.file.Files/readAllBytes (.toPath (io/file path)))]
+        (is (pos? (alength before)) (str path " is not empty"))
+        (is (java.util.Arrays/equals ^bytes before ^bytes after))))))

--- a/implementation/freehand/test/re_frame/freehand/check_conditional_map_views.cljc
+++ b/implementation/freehand/test/re_frame/freehand/check_conditional_map_views.cljc
@@ -1,0 +1,26 @@
+(ns re-frame.freehand.check-conditional-map-views
+  "The control for `check-conditional-map-jvm-test`: reader conditionals in
+  map KEY and map VALUE position that every target can read.
+
+  Refusing the map shapes a target's reader refuses is only worth anything if
+  the shapes it accepts stay accepted. Both entries here diverge across the
+  two targets — a different key on each, a different value on each — and both
+  targets get a well-formed map with the same number of entries, so this view
+  is inside the grammar wherever it is compiled and the checker must say so.
+
+  Nothing invalid lives in this file, and nothing invalid can: source whose
+  `:cljs` branch does not READ would break the browser build of this test
+  tree. The unreadable shapes are written to a temp file by the suite itself,
+  loaded, checked, and thrown away.
+
+  Loaded on the JVM (required by
+  `re-frame.freehand.check-conditional-map-jvm-test`)."
+  (:require [re-frame.freehand :as v]))
+
+(v/defview conditional-map-uniform
+  "A conditional key and a conditional value, both selecting a form on every
+  target - eligible wherever it is compiled."
+  [_]
+  [:div {#?(:clj :title :cljs :data-title) "hover"
+         :class                            #?(:clj "jvm" :cljs "spa")}
+   "a map whose conditionals all select something"])

--- a/implementation/freehand/test/re_frame/freehand/check_conditional_placement_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/check_conditional_placement_jvm_test.clj
@@ -104,14 +104,16 @@
     (testing "a declaration written under a top-level conditional is reported,
               and its CLJS branch's head is bound from THAT branch's params —
               analyzing it against the :clj branch's params would refuse it as
-              an unresolved head, which is the wrong diagnosis"
+              an unresolved head, which is the wrong diagnosis. The finding
+              anchors at the CLJS branch's own line 69, not the :clj branch's
+              65 that the report identity carries"
       (is (= {:view-id           :re-frame.freehand.check-conditional-placement-views/declaration-divergent
               :source            {:file fixture-path :line 65 :column 10}
               :current-lowering  :interpreted
               :target-grammar    :re-frame.freehand/v1
               :compile-eligible? false
               :findings          [{:id       :rf.ui.compile/dynamic-head
-                                   :source   {:line 65 :column 10}
+                                   :source   {:line 69 :column 10}
                                    :form     '[tag {} "the CLJS branch has a dynamic head - ineligible"]
                                    :reason   :head-is-a-runtime-value
                                    :recovery [:use-a-literal-head

--- a/implementation/freehand/test/re_frame/freehand/check_splicing_map_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/check_splicing_map_jvm_test.clj
@@ -1,0 +1,142 @@
+(ns re-frame.freehand.check-splicing-map-jvm-test
+  "The checker's own read mode has exactly one blind spot, and it must be
+  ANSWERED rather than crashed through.
+
+  Reading with `:read-cond :preserve` is what lets the checker reach the
+  `:cljs` branch at all (`check-host-divergent-jvm-test` pins that). It costs
+  one shape: Clojure's map reader counts the forms it read BEFORE splicing is
+  applied, and a preserved `#?@` is one form, so a map literal containing a
+  splicing conditional reads for every compile and not for the checker.
+
+  Before this suite, that shape made `check-file` throw
+  `clojure.lang.LispReader$ReaderException` — \"Map literal must contain an
+  even number of forms\" — a false-ERROR, and one whose message says nothing
+  about the checker, names no workaround, and blames a declaration that is
+  perfectly legal. Four things are asserted:
+
+    1. the fixture really is legal — a reader told to read it for EITHER
+       target reads it, so the failure is the checker's read mode and not the
+       source (the oracle is `clojure.tools.reader`, independent of the code
+       under test);
+    2. `check-file` answers a checker REFUSAL: an `ex-info` naming the file,
+       the shape and the workaround, carrying the read mode in its data —
+       never a raw reader exception;
+    3. a read failure the checker did NOT cause is re-thrown untouched, so
+       the refusal cannot become a blanket \"unreadable\" that hides real
+       syntax errors behind advice about conditionals;
+    4. the fixture is byte-identical after the refused run — refusing is
+       still read-only."
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [clojure.tools.reader :as rdr]
+            [clojure.tools.reader.reader-types :as rt]
+            [re-frame.freehand.check-splicing-map-views]
+            [re-frame.freehand.compiler.check :as check]))
+
+(def ^:private fixture-resource
+  "re_frame/freehand/check_splicing_map_views.cljc")
+
+(def ^:private fixture-path
+  (.getPath (io/file (io/resource fixture-resource))))
+
+(defn- thrown-by
+  "The exception `f` throws, or nil."
+  [f]
+  (try (f) nil (catch Throwable t t)))
+
+;; ---------------------------------------------------------------------------
+;; 1 — the source is legal; the read mode is the limitation
+;; ---------------------------------------------------------------------------
+
+(defn- attrs-read-for
+  "The attribute map of the fixture's declaration, as a REAL reader reads the
+  file for `features`. `clojure.tools.reader` honours `:features` exactly and
+  splices before pairing, exactly as the compile's reader does — so this is
+  the independent statement of what the file MEANS."
+  [features]
+  (let [r (rt/indexing-push-back-reader (slurp (io/resource fixture-resource)))]
+    (loop []
+      (let [form (rdr/read {:eof ::eof :read-cond :allow :features features} r)]
+        (cond
+          (= ::eof form)                        nil
+          (and (seq? form) (= 'v/defview (first form)))
+          (first (filter map? (tree-seq coll? seq form)))
+          :else                                 (recur))))))
+
+(deftest the-fixture-is-legal-for-both-targets
+  (testing "a reader told to read the file for either target splices the
+            conditional into the map and produces a well-formed map — the
+            declaration is not the problem"
+    (is (= {:class "card" :title "JVM"}     (attrs-read-for #{:clj})))
+    (is (= {:class "card" :title "browser"} (attrs-read-for #{:cljs}))))
+
+  (testing "and the same map is unreadable with conditionals PRESERVED, which
+            is the mode the checker must use to reach the :cljs branch — the
+            limitation the refusal reports"
+    (let [read-all (fn []
+                     (with-open [r (clojure.lang.LineNumberingPushbackReader.
+                                    (java.io.StringReader.
+                                     (slurp (io/resource fixture-resource))))]
+                       (loop []
+                         (when-not (= ::eof (read {:eof ::eof :read-cond :preserve} r))
+                           (recur)))))
+          ex       (thrown-by read-all)]
+      (is (some? ex))
+      (is (re-find #"Map literal must contain an even number of forms" (str ex))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — check-file refuses; it does not raise the reader's exception
+;; ---------------------------------------------------------------------------
+
+(deftest check-file-refuses-rather-than-crashing
+  (let [ex (thrown-by #(check/check-file fixture-path))]
+    (is (instance? clojure.lang.ExceptionInfo ex)
+        "a checker refusal, not the clojure.lang.LispReader$ReaderException
+         the preserved read raises — that was the pre-fix behaviour, and it
+         reported a reader's private difficulty as if the declaration were
+         at fault")
+    (is (not (instance? clojure.lang.LispReader$ReaderException ex)))
+
+    (testing "the sentence names the checker, the file, the shape that stopped
+              it, and what to write instead"
+      (let [msg (ex-message ex)]
+        (is (re-find #"^re-frame\.freehand check: " msg))
+        (is (.contains msg fixture-path))
+        (is (.contains msg "#?@(:clj [:b 2])") "the shape is shown, not described")
+        (is (.contains msg "PRESERVED") "and why the checker reads that way")
+        (is (.contains msg "Write the conditional around the whole map")
+            "the workaround is the payload")))
+
+    (testing "and the data says where and why, so a tool can render it"
+      (is (= {:file fixture-path :read-cond :preserve}
+             (select-keys (ex-data ex) [:file :read-cond])))
+      (is (integer? (:line (ex-data ex))))
+      (is (integer? (:column (ex-data ex)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — a failure the checker did not cause stays the reader's
+;; ---------------------------------------------------------------------------
+
+(deftest an-unrelated-read-failure-is-not-reframed
+  (testing "the refusal is narrow: a file that no reader can read is answered
+            by the reader's own message, the same one the compile gives, not
+            by advice about splicing conditionals"
+    (let [f (doto (java.io.File/createTempFile "check-splicing-map" ".cljc") .deleteOnExit)]
+      (spit f "(ns re-frame.freehand.unbalanced-views\n")
+      (let [ex (thrown-by #(check/check-file (.getPath f)))]
+        (is (instance? clojure.lang.LispReader$ReaderException ex)
+            "re-thrown untouched")
+        (is (not (re-find #"re-frame\.freehand check:" (str (ex-message ex)))))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — read-only
+;; ---------------------------------------------------------------------------
+
+(deftest the-checker-never-writes
+  (testing "a refused run is still read-only — the source it was pointed at is
+            byte-identical afterwards"
+    (let [before (java.nio.file.Files/readAllBytes (.toPath (io/file fixture-path)))
+          _      (thrown-by #(check/check-file fixture-path))
+          after  (java.nio.file.Files/readAllBytes (.toPath (io/file fixture-path)))]
+      (is (pos? (alength before)) "the fixture file is not empty")
+      (is (java.util.Arrays/equals ^bytes before ^bytes after)))))

--- a/implementation/freehand/test/re_frame/freehand/check_splicing_map_views.cljc
+++ b/implementation/freehand/test/re_frame/freehand/check_splicing_map_views.cljc
@@ -1,0 +1,30 @@
+(ns re-frame.freehand.check-splicing-map-views
+  "One declaration carrying the single shape the checker's read mode cannot
+  read: a map literal containing a SPLICING reader conditional.
+
+  `#?@` inside a map is ordinary, legal Clojure. Every compile reads this file
+  with `:read-cond :allow`, which splices the branch's forms into the map's
+  form sequence before the map is built, so the JVM sees `{:class \"card\"
+  :title \"JVM\"}` and the browser build sees `{:class \"card\" :title
+  \"browser\"}` — two well-formed maps, and a view that is inside the grammar
+  on both targets.
+
+  The CHECKER reads with `:read-cond :preserve` instead, because that is the
+  only way past the JVM reader's unconditional `:clj` platform feature to the
+  `:cljs` branch. Under `:preserve` a splicing conditional stays ONE form, and
+  Clojure's map reader counts its forms before splicing — so this map is odd
+  and the read fails. The limitation belongs to the checker, not to this file,
+  and the checker says so rather than raising a reader exception at an author
+  who wrote nothing wrong.
+
+  Loaded on the JVM (required by `re-frame.freehand.check-splicing-map-jvm-test`)
+  precisely to prove that: the namespace loads without incident, so a refusal
+  from the checker cannot be blamed on the source being unloadable."
+  (:require [re-frame.freehand :as v]))
+
+(v/defview splicing-map-attrs
+  "An attribute map assembled by a splicing conditional - legal for both
+  targets, unreadable with conditionals preserved."
+  [_]
+  [:div {:class "card" #?@(:clj [:title "JVM"] :cljs [:title "browser"])}
+   "a map literal carrying a splicing conditional"])


### PR DESCRIPTION
Three reader-conditional defects in the compile checker, one surface, one commit each. All three degrade the same promise from different sides: **a green answer must mean something.** A crash is unusable, a report naming the wrong declaration misdirects, and a silently-normalized invalid map is a false green. Each fix ends with the checker either answering correctly or REFUSING with a named diagnostic — never guessing, never normalizing a problem away.

Built on the shipped mechanism, not a re-derivation of it: the checker still reads with `:read-cond :preserve` and selects each target's branch itself, past the JVM reader's unconditional `:clj` platform feature. No change to branch selection, no second analyzer, no new public verb.

## Quality gates

All foreground, one at a time, to completion, on the rebased base (`origin/main` @ `ec0b906242`, i.e. after PR #6732).

| Gate | Result |
| --- | --- |
| `cd implementation/freehand && clojure -M:test` | **525 tests, 3424 assertions, 0 failures, 0 errors** |
| `npm run test:freehand` | **398 tests, 2737 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` | **10523 tests, 52830 assertions, 0 failures, 0 errors** |
| `python scripts/check_keyword_catalogue_drift.py` | exit 0 |
| `python scripts/check_freehand_conformance_index.py` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `git grep 're-frame.ui' implementation/freehand/` | empty |

The freehand JVM suite was 506 tests / 3327 assertions on `origin/main` before the first commit.

### Laws held

- **Read-only.** Each of the three new suites asserts the source it was pointed at is byte-identical after a run — including after a *refused* run, which is the new path.
- **No new diagnostic ids.** Nothing here mints a `:rf.ui.compile/*` id, or any other. A refusal is not a finding: it is an `ex-info` carrying the file, what stopped the checker, and the recovery — exactly the shape `refuse-cljs-source!` already used.
- **One finding per run, at the first ineligible form.** `findings-for` is untouched.

### Non-vacuity

One assertion inverted per new test file; the full JVM gate reds naming that test; restored and verified byte-identical by `sha256sum`.

| File | Inverted | Gate named |
| --- | --- | --- |
| `check_splicing_map_jvm_test.clj` | `(instance? ExceptionInfo ex)` | `FAIL in (check-file-refuses-rather-than-crashing)` |
| `check_branch_identity_jvm_test.clj` | finding anchor `69` → `65` | `FAIL in (a-cljs-finding-anchors-at-the-cljs-branch)`, `actual: (not (= 65 69))` |
| `check_conditional_map_jvm_test.clj` | `(instance? ExceptionInfo ex)` | `FAIL in (check-file-refuses-a-map-the-target-cannot-read)` |

### Independent oracle

The technique the previous slice established is reused throughout. `clojure.tools.reader` honours the `:features` it is handed exactly — it has no unconditional platform feature — so at `#{:clj}` and `#{:cljs}` it states what each target's compile actually reads, without consulting the code under test. It establishes the premise of all three fixes: that the fixture is legal (.90), that the branches really do declare two different views (.97), and that the refusal boundary is the *reader's* rather than the checker's opinion (.98).

---

## rf2-drpa3.90 — the checker crashed on a map splicing conditional

`{:a 1 #?@(:clj [:b 2])}` is ordinary Clojure. Every compile reads it with `:read-cond :allow`, which splices before the map is built. The checker must read with `:preserve` to reach the `:cljs` branch at all, and Clojure's map reader counts its forms *before* splicing — so a preserved `#?@` is one form and the map is odd.

**Pre-fix reproduction.** `check-file` over a loaded `.cljc` namespace whose view body is `[:div {:a 1 #?@(:clj [:b 2] :cljs [:b 3])} "hi"]`:

```
;; reader, :read-cond :allow
{:a 1, :b 2}
;; reader, :read-cond :preserve
THREW java.lang.RuntimeException Map literal must contain an even number of forms
;; public check-file
check-file THREW clojure.lang.LispReader$ReaderException
  | java.lang.RuntimeException: Map literal must contain an even number of forms
  | ex-data: #:clojure.error{:line 6, :column 45}
```

A false-ERROR — the opposite failure mode to the false-greens the placement work fixed — whose message names neither the checker nor a workaround, and blames a declaration that is perfectly legal.

Recovering the shape means reading maps as flat form sequences: a reader of the checker's own, squarely the general-purpose-analyzer non-goal the bead puts out of scope. So the limitation is **named** instead:

```
re-frame.freehand check: …/check_splicing_map_views.cljc could not be read at
line 29, column 74. The checker reads with reader conditionals PRESERVED so it
can select each target's branch itself, and Clojure's map reader counts forms
BEFORE splicing — so a map literal containing a SPLICING conditional,
{:a 1 #?@(:clj [:b 2])}, reads for a compile and not here. Write the conditional
around the whole map, #?(:clj {:a 1 :b 2} :cljs {:a 1}), or around each entry's
value, and check again. (If that map has no splicing conditional, it really does
have an odd number of forms.)
```

The refusal stays **narrow**: only the even-forms failure is reframed. Any other read failure is re-thrown untouched, for the reason `findings-for-branch` re-throws a non-grammar exception — a file that does not read at all was not made unreadable by the checker, and the reader's own message is already the best answer, the same one the compile gives. Pinned by a test that points `check-file` at a file with an unterminated `ns` form and asserts the `LispReader$ReaderException` comes back unwrapped.

## rf2-drpa3.97 — target declaration identity was not preserved

Discovery assumed the two branches of a top-level conditional were one declaration, settled identity by preferring the `:clj` branch, and copied only `[:params :children-policy :body]` from the `:cljs` one.

**Pre-fix reproduction.** `check-file` over the loaded `.cljc` from the bead — `jvm-view` declared at line 5, `browser-view` at line 9:

```
report view-id : :…/jvm-view
report source  : {:line 5, :column 4}
findings       : [{:id :rf.ui.compile/dynamic-head,
                   :source {:line 5, :column 4},
                   :form [tag "browser view"]}]
```

One report, labelled `jvm-view`, ineligible, offending form `[tag "browser view"]` — a body `jvm-view` does not have, at a line `browser-view` is not on. The declaration that failed never appeared as itself; the one that was named is fine. An author reading that edits the wrong view.

And the same misdirection in a smaller form, for **same-name** branches — `declaration-divergent` in the existing placement fixture, `:clj` branch at line 65 and `:cljs` branch at line 69:

```
report source : {:line 65, :column 10}
finding source: {:line 65, :column 10}     ← but the CLJS branch is at line 69
```

Identity is now the view id **and** the declared lowering — the two fields a report carries exactly one of. Branches that disagree about either are refused, naming both declarations and the recovery:

```
re-frame.freehand check: …/check_branch_identity_views.cljc: the :clj and :cljs
branches of one top-level reader conditional disagree about the declaration's
IDENTITY — they differ in :view-id :…/jvm-view vs :…/browser-view. A report names
ONE view and ONE lowering, so answering for both branches would attribute one
branch's body to the other's identity. Give each target its own top-level
conditional — #?(:clj (v/defview …)) and #?(:cljs (v/defview …)) — and each is
discovered, checked against its own target, and reported as itself.
```

The recovery is **proved**, not merely asserted. `check_branch_identity_split_views.cljc` writes the two views as two one-armed conditionals, and the suite pins that both come back in declaration order under their own ids — including the browser-only one the JVM reader elides entirely, refused as itself, at its own line, for its own body.

Branches that *agree* are still one declaration and still one report, but `:source` joins the branch-owned keys. A finding falls back to its declaration's coordinates whenever the reader anchored none of its own — which is most of the time, the reader anchoring lists and not vectors — so the CLJS-branch finding above now reports `{:line 69 :column 10}` while the report identity stays at 65. That is the one behavioural change to an existing expectation (`check_conditional_placement_jvm_test.clj`), and it is the point.

## rf2-drpa3.98 — target-invalid conditional maps were normalized

The file is read with conditionals preserved, so a map arrives already **paired**. The target's reader pairs its forms *after* selection, and two shapes fall between the two. `resolve-conditionals` resolved each side independently and rebuilt with `into`, which expresses neither.

**Pre-fix reproduction.** Both as public `check-file` over loaded `.cljc` views, each cross-checked against the independent reader:

```
;; [:div {:title #?(:clj 1)} "x"]
check-file      : [{:view-id :…/elided-value, :compile-eligible? true, :findings []}]
oracle #{:cljs} : THREW [line 6, col 28] The map literal starting with :title on
                  line 6 column 9 contains 1 form(s). Map literals must contain
                  an even number of forms.
oracle #{:clj}  : read 2 forms OK

;; [:div {#?(:clj :a :cljs :b) 1 :b 2} "x"]
check-file      : [{:view-id :…/colliding-key, :compile-eligible? true, :findings []}]
oracle #{:cljs} : THREW Duplicate key: :b
oracle #{:clj}  : read 2 forms OK

;; and what the resolver was building for #{:cljs}
{:title #?(:clj 1)}            -> {:title nil}
{#?(:clj :a :cljs :b) 1 :b 2}  -> {:b 2}
```

A green about a branch the compiler cannot **read** — the same false-green this checker exists to prevent, arrived at from the other side.

Map resolution now stops at the boundary the target's own reader draws, naming the map, the entry, the target and the recovery:

```
re-frame.freehand check: …/msg_views.cljc: a map literal whose conditional selects
nothing for the VALUE of the entry [:title #?(:clj 1)], leaving that entry
half-written, cannot be read for the :cljs target, so the checker will not answer
for a declaration containing it. Write the conditional around the WHOLE map —
#?(:clj {…} :cljs {…}) — or give every entry a branch for every target. The map,
as preserved: {:title #?(:clj 1)}
```

```
re-frame.freehand check: …/msg2_views.cljc: a map literal whose conditional
selection gives two entries the same key, :b, cannot be read for the :cljs
target, so the checker will not answer …
```

Deliberate boundaries, each pinned against `clojure.tools.reader`:

- An entry whose key **and** value both elide is **dropped, not refused** — `{#?(:clj :a) #?(:clj 1) :keep 2}` is `{:keep 2}` for `:cljs`, which is exactly what the real reader makes of it. Dropping it is not normalizing, it is agreeing.
- The refusal is **target-symmetric**: `{:title #?(:cljs 1)}` resolves for `:cljs` and is refused for `:clj`, by the same rule.
- What is **not** reconstructed is a map whose surviving forms re-pair into a different one — `{#?(:clj :a) 1 :b #?(:clj 2)}` reads as `{1 :b}` for `:cljs`. That needs the flat-form reader, so it is refused with the rest. An honest refusal on source nobody writes is the right trade against the non-goal, and it is a refusal rather than a false green.

Valid conditional keys and values keep the existing fast path, both entries, and the map's metadata — pinned by a committed control fixture that stays `:compile-eligible? true`, and by a `::marker` metadata assertion on the rebuild.

### Why the unreadable fixtures are temp files

`check_conditional_map_jvm_test.clj` writes its two unreadable shapes to a temp `.cljc`, loads it, checks it, and lets it go. Their `:cljs` branch is source the browser build's reader refuses, so a committed fixture carrying one could not be compiled for CLJS — it would break the very build it describes. The bead's own reproduction did the same and removed the fixtures afterwards. Everything readable is a committed fixture.
