### PR TITLE
fix(freehand): explicit nil keys, round-trip validation and #id alias guard (rf2-rqmsw, rf2-hre9z, rf2-drpa3.101)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
@@ -1795,12 +1795,24 @@
                    (str "prop keys must be literal keywords; got " (pr-str k))
                    {:key k}))
       (check-rejected-spelling! e k))
-    (when (and (:id tag-info) (contains? m :id))
+    ;; The `#id` conflict, judged by the emitted SLOT the key projects onto
+    ;; rather than by the raw `:id`. `:x/id` compiles to the same React
+    ;; property the sugar does, and the compiled emitter writes the sugar
+    ;; pair first, so the authored one won — while the structural lowering
+    ;; carried both. Same projection `check-rejected-spelling!` above reads
+    ;; (rf2-drpa3.101).
+    (when-some [dup (and (:id tag-info)
+                         (first (filter #(= rules/sugar-id-slot (rules/caller-key-slot %))
+                                        (keys m))))]
       (env/fail! e :rf.ui.compile/id-sugar-conflict
-                 (str "#" (:id tag-info) " sugar AND an :id prop on " tag
+                 (str "#" (:id tag-info) " sugar AND " dup " on " tag
                       " — two id spellings on one element is an ambiguity, "
-                      "and this grammar removes ambiguities. Keep one")
-                 {:tag tag}))
+                      "and this grammar removes ambiguities. Keep one"
+                      (when (not= :id dup)
+                        (str " (" dup " is :id written differently — a namespace is "
+                             "dropped on the way to the DOM, so both compile to the "
+                             "same prop)")))
+                 {:tag tag :prop dup}))
     (let [m          (reduce-kv #(assoc %1 (rules/canonical-attr-key %2) %3) {} m)
               key-form   (get m :key)
               m*         (dissoc m :key :class :style :ref)

--- a/implementation/freehand/src/re_frame/freehand/conversion.cljc
+++ b/implementation/freehand/src/re_frame/freehand/conversion.cljc
@@ -76,8 +76,8 @@
 ;;     cache stops accepting entries and the projection costs what it
 ;;     always cost — a bounded loss, never a leak.
 ;;
-;; A projection here always answers a map or a string, never nil, so a
-;; miss and a remembered nil are not confusable.
+;; A projection here always answers a map, a string, a keyword or a
+;; boolean, never nil, so a miss and a remembered nil are not confusable.
 
 (def ^:private cache-limit
   "The most entries one remembered projection will hold."
@@ -563,6 +563,35 @@
   distinct authored key rather than once per attribute per render."
   [k]
   (remembered attr-key-cache k rules/canonical-attr-key))
+
+(defn- id-slot-key?* [k]
+  (= rules/sugar-id-slot (rules/caller-key-slot k)))
+
+(def ^:private id-slot-cache (atom {}))
+
+(defn id-slot-key?
+  "Does attribute key `k` project onto the slot the tag parser's `#id`
+  shorthand already occupies?
+
+  The question both walks ask when — and only when — an element carries
+  `#id` sugar, because two spellings of one id on one element is an
+  ambiguity the grammar removes rather than ranks (Spec 004B). It is asked
+  of the emitted SLOT, through
+  [[re-frame.freehand.rules/caller-key-slot]], for the reason
+  [[attr-key-refusal]] asks about the same projection: a key is classified
+  by the name it is about to be written under, so `:x/id`, `\"id\"` and
+  `'id` are `:id` written differently and reach React's `id` all the same.
+  Comparing the raw key let an aliased spelling through, and the tree then
+  carried the sugar id beside an authored one that overwrote it in the DOM.
+
+  This does NOT canonicalize the key. An `:x/id` on an element with no
+  sugar is an ordinary qualified attribute and keeps its authored name —
+  the structural tree carries author space, and the ambiguity being ruled
+  out is the one the sugar creates.
+
+  Remembered per key — see §Remembered projections above."
+  [k]
+  (remembered id-slot-cache k id-slot-key?*))
 
 (defn- react-event-name* [k]
   (str "on" (upper-first (camelize (subs (name k) 3)))))

--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -70,12 +70,39 @@
 ;; value nested inside a recorded value is REFUSED, at the site that recorded
 ;; it, exactly as every other value outside the tree's closed grammars is.
 
-(defn- edn-scalar?
-  "Is `x` an EDN leaf — a value that prints and reads back as itself on
-  BOTH hosts?"
+(defn- nan?
+  "Is `x` `##NaN` — the one value in the scalar grammar below that prints
+  and reads back and is STILL not itself?
+
+  Asked through NUMERIC equality, not `=` and not a host `isNaN`. `(= x x)`
+  cannot answer it: `clojure.lang.Util/equiv` returns true on reference
+  identity before it looks at the values, so a value compared with itself
+  is equal to itself by construction. A host `isNaN` cannot be asked
+  either — the JVM's takes a `double`, and a Ratio or a BigDecimal cannot
+  be handed to one. `==` is defined on every number on both hosts and
+  compares numerically, which is the only comparison NaN fails."
   [x]
-  (or (string? x) (keyword? x) (number? x) (boolean? x) (nil? x) (symbol? x)
+  (and (number? x) (not (== x x))))
+
+(defn- edn-scalar?
+  "Is `x` an EDN leaf — a value that prints and READS BACK EQUAL on the
+  host it was written on?
+
+  Equal, not merely readable, because the tree is an equality input: a
+  fingerprint compares one, a structural test asserts on one, and a
+  reconciler is handed one. `##NaN` is the single value that satisfies
+  print/read and fails that: it is not equal to itself, so a tree holding
+  one is not equal to itself either. It is refused with everything else
+  the tree cannot promise."
+  [x]
+  (or (string? x) (keyword? x) (boolean? x) (nil? x) (symbol? x)
+      (and (number? x) (not (nan? x)))
       (uuid? x)
+      ;; A JVM character is ordinary EDN — `\\a` prints and reads back —
+      ;; and the host it does not exist on has nothing to disagree about:
+      ;; ClojureScript reads `\\a` as the one-character string it already
+      ;; accepts, which is what `char?` answers there.
+      (char? x)
       ;; EDN's other built-in tagged literal. `inst?` is NOT the predicate:
       ;; it answers true for `java.time.Instant`, which prints `#object[…]`
       ;; and does not read back. The instant that prints `#inst` is the
@@ -88,6 +115,16 @@
   indices walked to reach it, so a diagnostic names the offending SITE
   rather than the whole prop.
 
+  DATA is the EDN value grammar exactly — the scalars above, and the four
+  collections EDN spells: map, vector, set, list. The arms below name
+  those four rather than asking `coll?`, because `coll?` is a question
+  about a host INTERFACE and collections implement it with no EDN spelling
+  at all: a `defrecord` value answers `map?` while printing `#user.R{…}`,
+  which no EDN reader has a tag for, and a persistent QUEUE answers a
+  collection predicate on either host while printing outside EDN on both.
+  Such a value was accepted, printed, and failed to read back — the round
+  trip this rule exists to promise.
+
   READ-ONLY and short-circuiting — nothing is rebuilt, and the walk stops
   at the first offender. The ordinary case (a scalar prop, or a small map
   of them) costs one predicate per value and allocates nothing, which is
@@ -98,9 +135,19 @@
     (edn-scalar? x)
     nil
 
+    ;; A QUEUE, named — the one collection whose EDN status differs BY
+    ;; HOST, which is the sharpest reason the rule cannot be a host
+    ;; predicate. On the JVM it prints `#object[…]` and no reader takes it;
+    ;; in ClojureScript it satisfies `ISeq` and prints `#queue […]`, a tag
+    ;; `clojure.edn` does not have. Accepting it where it happens to read
+    ;; back would make one declaration answer a tree on one host and a
+    ;; refusal on the other, and the tree is ONE value on two hosts.
+    (instance? #?(:clj clojure.lang.PersistentQueue :cljs PersistentQueue) x)
+    [[] x]
+
     ;; `reduce-kv` over a vector answers index/element — exactly the path
     ;; segment wanted — so maps and vectors share one arm.
-    (or (map? x) (vector? x))
+    (or (and (map? x) (not (record? x))) (vector? x))
     (reduce-kv (fn [_ k v]
                  (if-let [found (or (non-data k)
                                     (when-let [[p bad] (non-data v)]
@@ -111,7 +158,10 @@
                x)
 
     ;; A set or a seq has no position worth naming, so the path stops here.
-    (coll? x)
+    ;; `seq?` rather than `list?`: EDN's list is anything that prints as
+    ;; `(…)`, which is every `ISeq`, and `list?` additionally answers true
+    ;; for a PersistentQueue.
+    (or (set? x) (seq? x))
     (reduce (fn [_ v] (when-let [found (non-data v)] (reduced found))) nil x)
 
     :else
@@ -122,6 +172,14 @@
   offending value IS the recorded value."
   [path]
   (if (seq path) (str " at " (pr-str path)) ""))
+
+(defn- offender-name
+  "How a refusal NAMES the value that may not be recorded. `##NaN` by its
+  own spelling rather than as `number`, because the number grammar is
+  otherwise wide open and `carries a number` would leave the refusal
+  unreadable."
+  [x]
+  (if (nan? x) "##NaN" (type-name x)))
 
 ;; ---------------------------------------------------------------------------
 ;; The namespace context (SVG / MathML)
@@ -341,25 +399,25 @@
     (vector? v) (do (when-let [[path bad] (non-data v)]
                       (malformed!
                         're-frame.freehand/render
-                        (str "The " k " handler on " tag " carries a " (type-name bad)
+                        (str "The " k " handler on " tag " carries a " (offender-name bad)
                              (at-path path)
                              " inside its event intent. An event vector is recorded "
                              "verbatim and is data through and through — a test compares "
                              "it as data and the event system dispatches it as data, so "
-                             "an argument inside it has no cross-host spelling. A function "
-                             "records as the opaque marker when it IS the handler value; "
-                             "it cannot ride inside the intent.")
+                             "an argument inside it has to print and read back EQUAL. A "
+                             "function records as the opaque marker when it IS the handler "
+                             "value; it cannot ride inside the intent.")
                         {:attr k :path path :value (shape bad)}))
                     v)
     (map? v)    (do (when-let [[path bad] (non-data v)]
                       (malformed!
                         're-frame.freehand/render
-                        (str "The " k " handler on " tag " carries a " (type-name bad)
+                        (str "The " k " handler on " tag " carries a " (offender-name bad)
                              (at-path path)
                              " inside its options map. An options map is recorded verbatim "
                              "and is data through and through — the structural tree prints "
-                             "and reads back losslessly, so a value inside one has no "
-                             "cross-host spelling. A function records as the opaque marker "
+                             "and reads back EQUAL, so a value inside one has to survive "
+                             "that round trip. A function records as the opaque marker "
                              "when it IS the handler value; it cannot ride inside the "
                              "options.")
                         {:attr k :path path :value (shape bad)}))
@@ -504,11 +562,11 @@
     (do (when-let [[path bad] (non-data x)]
           (malformed!
             're-frame.freehand/render
-            (str "The " k " prop on " view-id " carries a " (type-name bad)
+            (str "The " k " prop on " view-id " carries a " (offender-name bad)
                  (at-path path)
                  ". A recorded prop is data through and through — the structural "
-                 "tree prints and reads back losslessly on both hosts, so a value "
-                 "inside one has no cross-host spelling. A callback records as the "
+                 "tree prints and reads back EQUAL on both hosts, so a value inside "
+                 "one has to survive that round trip. A callback records as the "
                  "opaque marker when it IS the prop; pass it as its own prop rather "
                  "than nesting it in data.")
             {:prop k :path path :value (shape bad)}))

--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -547,8 +547,17 @@
   fragment-rooted view is a boundary with several children and a
   nil-rooted view is a boundary with none. Both stay matchable, which is
   what makes a `:view-id` predicate a total selector (Spec 004B
-  §Coverage Q12)."
-  [view-id props key kids]
+  §Coverage Q12).
+
+  `key?` and `key-val` are key PRESENCE and key VALUE, threaded separately
+  exactly as [[element]] and [[fragment]] thread them, because `:key` is
+  present on the node iff the call was explicitly keyed (Spec 004B). An
+  explicit `nil` key is legal authored presence — React string-coerces a
+  supplied key, so it is the identity `\"null\"` — and asking `(some? key)`
+  instead would answer the same for an explicit nil and an absent key,
+  flattening a fact the caller established into a value that cannot carry
+  it. `v/normalize-call` reports the presence as `:keyed?` for this reason."
+  [view-id props key? key-val kids]
   (let [recorded (reduce-kv (fn [m k x] (assoc m k (recorded-prop view-id k x)))
                             {} (dissoc props :children))
         kids     (if (and (= 1 (count kids)) (plain-fragment? (first kids)))
@@ -556,7 +565,7 @@
                    (vec kids))]
     (cond-> {:view-id view-id}
       (pos? (count recorded)) (assoc :props recorded)
-      (some? key)             (assoc :key key)
+      key?                    (assoc :key key-val)
       (pos? (count kids))     (assoc :children kids))))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/freehand/src/re_frame/freehand/react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/react.cljs
@@ -131,6 +131,20 @@
       (when-some [refusal (conv/attr-key-refusal k)]
         (malformed! (str "The element " tag " carries " k ". " refusal)
                     {:attr k}))
+      ;; The `#id` conflict, judged by the emitted SLOT rather than by the
+      ;; raw key — and this walk is where the raw comparison SHOWED: React
+      ;; writes `:id` and `:x/id` into one JavaScript property, so the
+      ;; aliased pair silently replaced the sugar while the structural tree
+      ;; reported both. Asked only when there IS sugar to conflict with.
+      (when (and sugar-id (some? raw) (conv/id-slot-key? k))
+        (malformed! (str "The element " tag " spells its id twice — once as #" sugar-id
+                         " sugar and once as " k ". Two id spellings on one element is an "
+                         "ambiguity; keep one."
+                         (when (not= :id k)
+                           (str " " k " is :id written differently: a namespace is dropped "
+                                "on the way to the DOM, so both land in the same "
+                                "attribute.")))
+                    {:attr k :value (shape raw)}))
       (cond
         (= :key k)   nil
         (nil? raw)   nil
@@ -160,14 +174,6 @@
 
         (= :style k)
         (gobj/set o "style" (react-style tag raw))
-
-        (= :id k)
-        (do (when (and sugar-id (some? raw))
-              (malformed! (str "The element " tag " spells its id twice — once as #" sugar-id
-                               " sugar and once as :id. Two id spellings on one element is an "
-                               "ambiguity; keep one.")
-                          {:attr :id :value (shape raw)}))
-            (put-attr! o tag k raw))
 
         :else (put-attr! o tag k raw)))
     ;; Key PRESENCE, not key truth. React string-coerces whatever key it is

--- a/implementation/freehand/src/re_frame/freehand/rules.cljc
+++ b/implementation/freehand/src/re_frame/freehand/rules.cljc
@@ -2115,6 +2115,22 @@
   remount where none was intended."
   (caller-key-slot :key))
 
+(def sugar-id-slot
+  "The emitted SLOT the tag parser's `#id` shorthand writes into, DERIVED
+  from `:id` through the same `caller-key-slot` projection an authored key
+  takes rather than spelled as a literal.
+
+  `#id` sugar and an authored id are two spellings of ONE emitted
+  attribute, and Spec 004B removes that ambiguity rather than ranking it.
+  The guard that says so compared the raw key `:id`, so it saw one
+  spelling of the name and missed the rest: `:x/id`, `\"id\"` and `'id`
+  all project HERE, and the sugar id therefore survived into the
+  structural tree while React — which writes both pairs into one JavaScript
+  property — kept only the authored one. One declaration, two ids, and a
+  selector or a label targeting the tree's answer would miss the DOM's
+  (rf2-drpa3.101)."
+  (caller-key-slot :id))
+
 (def ^:private slot-owning-attr-keys
   "The author-space attribute keys that OWN a slot of their own in both
   walks — `:class`, which composes with the `.class#id` sugar, and `:style`,

--- a/implementation/freehand/src/re_frame/freehand/tree.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tree.cljc
@@ -156,7 +156,15 @@
 
   Every value here is only known now, so they all ride `:dyn` — the
   interpreted front end has no compile step in which to settle one.
-  `:key` is structural and `:class` composes after the sugar classes."
+  `:key` is structural and `:class` composes after the sugar classes.
+
+  The `#id` conflict is judged by the emitted SLOT
+  ([[re-frame.freehand.conversion/id-slot-key?]]) rather than by the raw
+  key, because the sugar and an authored id are two spellings of one
+  attribute and the grammar removes that ambiguity rather than ranking it.
+  Asked only when there IS sugar: with no sugar there is no second
+  spelling, and `:x/id` is an ordinary qualified attribute that keeps its
+  authored name."
   [m tag sugar-id attrs]
   (reduce-kv
     (fn [m k raw]
@@ -164,17 +172,19 @@
         (malformed!
           (str "The element " tag " carries " k ". " refusal)
           {:attr k}))
+      (when (and sugar-id (some? raw) (conv/id-slot-key? k))
+        (malformed!
+          (str "The element " tag " spells its id twice — once as #" sugar-id
+               " sugar and once as " k ". Two id spellings on one element is an "
+               "ambiguity; keep one." (when (not= :id k)
+                                        (str " " k " is :id written differently: a "
+                                             "namespace is dropped on the way to the DOM, "
+                                             "so both land in the same attribute.")))
+          {:attr k :value (shape raw)}))
       (cond
         (= :key k)   m
         (= :class k) (assoc m :class raw)
         (= :style k) (assoc m :style raw)
-        (= :id k)    (do (when (and sugar-id (some? raw))
-                           (malformed!
-                             (str "The element " tag " spells its id twice — once as #"
-                                  sugar-id " sugar and once as :id. Two id spellings on "
-                                  "one element is an ambiguity; keep one.")
-                             {:attr :id :value (shape raw)}))
-                         (update m :dyn assoc :id raw))
         :else        (update m :dyn assoc k raw)))
     m
     attrs))

--- a/implementation/freehand/src/re_frame/freehand/tree.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tree.cljc
@@ -118,7 +118,7 @@
   child's walk, and answer the boundary node holding the child subtree on
   success or the fallback subtree on a caught render throw."
   [view args]
-  (let [{:keys [key props]} (descriptor/normalize-call view args)
+  (let [{:keys [key keyed? props]} (descriptor/normalize-call view args)
         {:keys [fallback] :as opts} (eb/read-opts props)
         child   (first (:children opts))
         b       (eb/boundary eb/boundary-view-id (:reset-key opts))
@@ -138,7 +138,7 @@
     ;; fallback, so its presence proves nothing a test could not already
     ;; assume, and a contained boundary shows the walked fallback subtree as
     ;; its children.
-    (node/boundary eb/boundary-view-id (dissoc props :fallback) key kids)))
+    (node/boundary eb/boundary-view-id (dissoc props :fallback) keyed? key kids)))
 
 ;; ---------------------------------------------------------------------------
 ;; Element nodes
@@ -236,10 +236,16 @@
   (let [head (first form)]
     (cond
       (= fragment-tag head)
-      (let [args   (rest form)
-            attrs? (map? (first args))
-            k      (when attrs? (:key (first args)))]
-        (node/fragment (some? k) k (children (if attrs? (rest args) args))))
+      ;; Key PRESENCE, not key truth — the question [[element-node]] and the
+      ;; React walk already ask. `(:key attrs)` answers nil for an explicit
+      ;; nil key and for no key at all, and those are different authored
+      ;; facts: React string-coerces a supplied key, so an explicit nil is
+      ;; the identity "null". `contains?` is the honest question.
+      (let [args  (rest form)
+            attrs (when (map? (first args)) (first args))]
+        (node/fragment (contains? attrs :key)
+                       (:key attrs)
+                       (children (if attrs (rest args) args))))
 
       ;; A presence boundary: `v/presence` returns `[presence-tag opts & kids]`
       ;; in interpreted markup. Its children are lowered HERE — walked into
@@ -288,7 +294,7 @@
 (extend-type #?(:clj re_frame.freehand.descriptor.ViewDescriptor :cljs descriptor/ViewDescriptor)
   node/IMount
   (-mount [view args]
-    (let [{:keys [key props]} (descriptor/normalize-call view args)
+    (let [{:keys [key keyed? props]} (descriptor/normalize-call view args)
           props*  (conv/forward-children props)
           view-id (:view-id (descriptor/describe view))
           ;; The OCCURRENCE SEAM. A render-class throw passing through here
@@ -303,7 +309,7 @@
                     (catch #?(:clj Throwable :cljs :default) e
                       (eb/note-failing-view! view-id)
                       (throw e)))]
-      (node/boundary view-id props key kids))))
+      (node/boundary view-id props keyed? key kids))))
 
 ;; ---------------------------------------------------------------------------
 ;; Render entry

--- a/implementation/freehand/test/re_frame/freehand/structural_data_round_trip_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/structural_data_round_trip_cljs_test.cljc
@@ -1,0 +1,207 @@
+(ns re-frame.freehand.structural-data-round-trip-cljs-test
+  "The structural tree's DATA rule, held to the round trip it promises.
+
+  Spec 004B: the tree is plain, serialisable data, and EDN print/read
+  round-trips it losslessly. Two slots record a value the tree did not
+  build — a view boundary's `:props` and an element's `:events` — and the
+  rule they share is that the opaque marker occupies a SITE, never a value
+  inside one: a prop or handler that IS a function records as
+  `{:rf.ui/opaque :fn}`, and a non-data value NESTED inside a recorded
+  prop, event vector or options map is refused.
+
+  What that rule turns on is the definition of DATA, and the definition is
+  the EDN value grammar exactly — not `coll?` and not `number?`, which are
+  questions about a host interface and a host numeric tower:
+
+  - a `defrecord` value answers `map?` and prints `#user.R{…}`, which no
+    EDN reader has a tag for. It was accepted, printed, and failed to
+    read back.
+  - a persistent QUEUE answers a collection predicate on both hosts and
+    prints outside EDN on both — `#object[…]` on the JVM, `#queue […]` in
+    ClojureScript — and NEITHER host's reader takes the other's. Accepting
+    it where it happens to read back would make one declaration answer a
+    tree on one host and a refusal on the other.
+  - a JVM character IS ordinary EDN — `\\a` prints and reads back — and was
+    refused.
+  - `##NaN` prints and reads back and is STILL not equal to itself, so a
+    tree carrying one is not equal to itself. The tree is an equality
+    input: a fingerprint compares one, a structural test asserts on one.
+    Print/read alone is not the promise; print/read EQUAL is.
+
+  Every row runs through the public renderer, on whichever host is running
+  it, and the refusals are asserted over a COMPILED boundary as well —
+  `re-frame.freehand.node/boundary` is the one canonicalizer both front
+  ends record props through, so a value one mode refused and the other
+  recorded would be a tree that existed only when compiled."
+  (:require [clojure.edn :as edn]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.tree :as tree]))
+
+(v/defview sink
+  "A boundary that records whatever prop it is handed."
+  [{:keys [label]}]
+  [:span label])
+
+(v/defview sink-compiled
+  "Its promoted twin — same body, one option map apart."
+  {:compiled true}
+  [{:keys [label]}]
+  [:span label])
+
+(defrecord Box [v])
+
+(def ^:private a-queue
+  "A persistent queue: a first-class collection on both hosts, and the
+  canonical example of one EDN cannot spell."
+  (conj #?(:clj clojure.lang.PersistentQueue/EMPTY
+           :cljs (.-EMPTY cljs.core/PersistentQueue))
+        :job))
+
+;; ---------------------------------------------------------------------------
+;; What the tree accepts, and what accepting it promises
+;; ---------------------------------------------------------------------------
+
+(def ^:private accepted
+  "Prop values the grammar admits. Each must survive `pr-str` ->
+  `read-string` as an EQUAL value on the host running the row."
+  (into [["EDN at depth"        {:a [1 2 #{:c}] :b 'sym :c nil :d 1.5}]
+         ["a list"              (list 1 2 3)]
+         ["a lazy seq"          (map inc [1 2 3])]
+         ["a sorted map"        (sorted-map :b 2 :a 1)]
+         ["a sorted set"        (sorted-set 3 1 2)]
+         ["EDN's tagged literals"
+          {:id #uuid "00000000-0000-0000-0000-000000000001"
+           :when #inst "1970-01-01T00:00:00.000-00:00"}]
+         ["the infinities"      [##Inf ##-Inf]]]
+        ;; A JVM character is EDN and reads back; the JVM's own numeric
+        ;; tower prints and reads back too. ClojureScript reads `\a` as the
+        ;; one-character string it already accepts, so the row has no
+        ;; separate CLJS spelling — the host's reader, not the tree's rule.
+        #?(:clj [["a character" \a]
+                 ["the JVM numeric tower" [1/3 10N 1.5M]]]
+           :cljs [])))
+
+(deftest an-accepted-prop-round-trips-through-print-and-read
+  (testing "The promise is not that the tree PRINTS. It is that the whole
+            tree prints and reads back EQUAL, because every consumer
+            downstream compares one: a fingerprint, a structural
+            assertion, a cross-host conformance row."
+    (is (<= 7 (count accepted)) "the table is not vacuously small")
+    (doseq [[note value] accepted]
+      (let [t (tree/render [sink {:payload value :label "d"}])]
+        (is (= t (edn/read-string (pr-str t)))
+            (str note " — the tree prints and reads back equal"))))))
+
+(deftest an-accepted-event-intent-round-trips-too
+  (testing "An event vector is recorded VERBATIM and is compared as data by
+            a test and dispatched as data at run time, so it carries the
+            same obligation a recorded prop does."
+    (doseq [[note value] accepted]
+      (let [t (tree/render [:div {:on-click [:app/go value]}])]
+        (is (= t (edn/read-string (pr-str t)))
+            (str note " — in an event intent"))))))
+
+;; ---------------------------------------------------------------------------
+;; What it refuses, and why each one is not data
+;; ---------------------------------------------------------------------------
+
+(def ^:private refused
+  "Values that may not be recorded, each with the reason it is not data.
+  Every one is refused with the walk's EXISTING malformed-tree
+  diagnostic — no new id, and no second tree format."
+  [["a queue — a collection whose EDN status differs by host" a-queue]
+   ["a queue nested in a map"                   {:jobs a-queue}]
+   ["a queue nested in a vector"                [:a [:b a-queue]]]
+   ["a record — map?, and no EDN spelling"      (->Box 1)]
+   ["a record nested at depth"                  {:a {:b (->Box 1)}}]
+   ["##NaN — reads back, never equal to itself" ##NaN]
+   ["##NaN nested at depth"                     {:ratio {:value ##NaN}}]
+   ["##NaN inside a vector"                     [1 ##NaN]]
+   ["a host object with no EDN spelling"        (atom 1)]])
+
+(deftest a-value-that-cannot-round-trip-is-refused-at-the-site-that-records-it
+  (testing "Refuse, not represent: the opaque marker occupies a SITE — a
+            prop that IS a callback — because a site is what the grammar
+            names. Below the prop key there is no site vocabulary, so a
+            value written there that cannot survive the round trip is
+            refused where it was recorded rather than silently replaced."
+    (doseq [[note value] refused]
+      (is (= :rf.error/ui-tree-malformed
+             (conf/caught-id #(tree/render [sink {:payload value :label "d"}])))
+          (str note " — refused at a boundary prop")))))
+
+(deftest the-same-values-are-refused-in-an-event-intent-and-its-options
+  (testing "The rule is one rule across the two slots that record a value
+            the tree did not build. An event vector and an options map are
+            both recorded verbatim, so both carry it."
+    (doseq [[note value] refused]
+      (is (= :rf.error/ui-tree-malformed
+             (conf/caught-id #(tree/render [:div {:on-click [:app/go value]}])))
+          (str note " — refused inside an event intent"))
+      (is (= :rf.error/ui-tree-malformed
+             (conf/caught-id #(tree/render [:div {:on-click {:event [:app/go value]}}])))
+          (str note " — refused inside an options map")))))
+
+(deftest a-compiled-boundary-refuses-exactly-what-an-interpreted-one-does
+  (testing "`node/boundary` is the ONE canonicalizer both front ends record
+            props through, so the two modes cannot hold different opinions
+            about what data is. A value accepted only when compiled would
+            be a tree that existed in one mode."
+    (doseq [[note value] refused]
+      (is (= :rf.error/ui-tree-malformed
+             (conf/caught-id #(tree/render [sink-compiled {:payload value :label "d"}])))
+          (str note " — refused at a COMPILED boundary")))
+    (doseq [[note value] accepted]
+      (let [t (tree/render [sink-compiled {:payload value :label "d"}])]
+        (is (= t (edn/read-string (pr-str t)))
+            (str note " — and accepted, and round-tripping, at a COMPILED boundary"))))))
+
+;; ---------------------------------------------------------------------------
+;; Non-vacuity
+;; ---------------------------------------------------------------------------
+
+(deftest the-round-trip-assertion-and-the-nan-assertion-can-both-fail
+  (testing "Both assertions above are proven able to fail, because an
+            assertion that cannot is worth nothing. The controls are
+            asserted DIRECTLY on hand-built values — no boundary will
+            build either shape any more.
+
+            The host-object control shows print/read really does lose a
+            value the tree used to accept; the NaN control shows that
+            print/read alone is the WRONG promise, since the value survives
+            the trip and the comparison still fails."
+    (let [host-tree {:view-id ::control :props {:cell (atom 1)} :rf.ui/tree-version 1}]
+      (is (not= host-tree
+                (try (edn/read-string (pr-str host-tree))
+                     (catch #?(:clj Exception :cljs :default) _ ::unreadable)))
+          "a host object in a tree does not survive print/read"))
+    (let [nan-tree {:view-id ::control :props {:ratio ##NaN} :rf.ui/tree-version 1}
+          read-back (edn/read-string (pr-str nan-tree))]
+      (is (= "##NaN" (pr-str (get-in read-back [:props :ratio])))
+          "##NaN really does print and read back")
+      (is (not= nan-tree read-back)
+          "and the tree is STILL not equal to itself — which is the promise print/read alone misses"))
+    (is (= :rf.error/ui-tree-malformed
+           (conf/caught-id #(tree/render [sink {:payload ##NaN :label "d"}])))
+        "so the renderer refuses it")))
+
+;; ---------------------------------------------------------------------------
+;; The scope fence
+;; ---------------------------------------------------------------------------
+
+(deftest the-site-level-marker-and-the-ordinary-shapes-are-unchanged
+  (testing "The repair is about which values may be RECORDED. A callback AT
+            a prop site still records as the opaque marker, an ordinary
+            data prop is still recorded verbatim, and the error boundary's
+            template option is still not recorded at all."
+    (let [t (tree/render [sink {:on-pick (fn [_] nil) :title "Details" :label "d"}])]
+      (is (= {:rf.ui/opaque :fn} (get-in t [:props :on-pick]))
+          "a callback AT the site is the marker, not a refusal")
+      (is (= "Details" (get-in t [:props :title])) "and an ordinary prop is verbatim")
+      (is (= t (edn/read-string (pr-str t))) "and the whole tree round-trips"))
+    (let [t (tree/render [:div {:on-click (fn [_] nil)}])]
+      (is (= {:rf.ui/opaque :fn} (get-in t [:events :on-click]))
+          "the same at a handler site")
+      (is (= t (edn/read-string (pr-str t))) "and that tree round-trips too"))))

--- a/implementation/freehand/test/re_frame/freehand/structural_key_presence_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/structural_key_presence_cljs_test.cljc
@@ -1,0 +1,195 @@
+(ns re-frame.freehand.structural-key-presence-cljs-test
+  "`:key` is on a structural node IFF the site was explicitly keyed
+  (Spec 004B) — and PRESENCE is the question, never the value.
+
+  An explicit `nil` key is legal authored presence. React string-coerces a
+  supplied key, so `{:key nil}` is the ordinary identity `\"null\"` and a
+  different authored fact from no key at all — which is why
+  `v/normalize-call` reports `:keyed?` beside `:key`: the stripped value
+  alone reads `nil` for both. Any site that asks `(some? key)`, `(if key
+  …)` or `(when key …)` collapses the two, and the collapse is invisible:
+  the node still builds, the tree still prints, and the only symptom is a
+  keyed child that a keyed reconciler treats as unkeyed.
+
+  The four structural sites that can be keyed are asserted here TOGETHER —
+  element, fragment, view boundary, and the reserved `v/error-boundary` —
+  because a rule that held at three of them is exactly the shape the
+  interpreted React walk had before it was repaired: presence threaded
+  where it was noticed, `some?` where it was not.
+
+  The boundary rows run in all FOUR mode pairings from one body written
+  the same characters each time. A view boundary is the seam both front
+  ends cross through `re-frame.freehand.node/mount`, so key presence
+  surviving in one mode and not the other would mean adding
+  `{:compiled true}` to a declaration changed whether its children were
+  keyed — the cross-mode divergence two emitters over one semantic value
+  exist to rule out."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.descriptor :as descriptor]
+            [re-frame.freehand.tree :as tree]))
+
+;; ---------------------------------------------------------------------------
+;; The children, and the four parents that mount them
+;; ---------------------------------------------------------------------------
+
+(v/defview kid
+  "An interpreted child, mounted at three lexical sites below."
+  [{:keys [label]}]
+  [:span label])
+
+(v/defview kid-compiled
+  "Its promoted twin — the same body, one option map apart — so the table
+  below is asserted over a compiled child as well as an interpreted one."
+  {:compiled true}
+  [{:keys [label]}]
+  [:span label])
+
+;; The three spellings ride ONE body, because a compiled declaration
+;; settles key presence at BUILD time from the literal props map: a
+;; runtime flag could not vary it, so each spelling needs its own lexical
+;; site and all three belong in the same declaration to stay comparable.
+
+(v/defview interpreted-parent-interpreted-child
+  [_]
+  [:<> [kid {:key nil :label "d"}] [kid {:label "d"}] [kid {:key "k" :label "d"}]])
+
+(v/defview interpreted-parent-compiled-child
+  [_]
+  [:<> [kid-compiled {:key nil :label "d"}]
+       [kid-compiled {:label "d"}]
+       [kid-compiled {:key "k" :label "d"}]])
+
+(v/defview compiled-parent-interpreted-child
+  {:compiled true}
+  [_]
+  [:<> [kid {:key nil :label "d"}] [kid {:label "d"}] [kid {:key "k" :label "d"}]])
+
+(v/defview compiled-parent-compiled-child
+  {:compiled true}
+  [_]
+  [:<> [kid-compiled {:key nil :label "d"}]
+       [kid-compiled {:label "d"}]
+       [kid-compiled {:key "k" :label "d"}]])
+
+(def ^:private kid-id (:view-id (descriptor/describe kid)))
+(def ^:private kid-compiled-id (:view-id (descriptor/describe kid-compiled)))
+
+(defn- expected-child
+  "The ONE boundary node a `[kid {…}]` site denotes. `keyed?` decides
+  whether `:key` is on the node at all; `key-val` is what it carries."
+  [view-id keyed? key-val]
+  (cond-> {:view-id  view-id
+           :props    {:label "d"}
+           :children [{:tag :span :children ["d"]}]}
+    keyed? (assoc :key key-val)))
+
+(defn- expected-children
+  "The pinned expansion of every parent above: explicitly-nil-keyed,
+  unkeyed, and ordinarily keyed, in source order."
+  [child-id]
+  [(expected-child child-id true nil)
+   (expected-child child-id false nil)
+   (expected-child child-id true "k")])
+
+(def ^:private pairings
+  [{:note "interpreted parent, interpreted child" :parent interpreted-parent-interpreted-child :child kid-id}
+   {:note "interpreted parent, COMPILED child"    :parent interpreted-parent-compiled-child    :child kid-compiled-id}
+   {:note "COMPILED parent, interpreted child"    :parent compiled-parent-interpreted-child    :child kid-id}
+   {:note "COMPILED parent, COMPILED child"       :parent compiled-parent-compiled-child       :child kid-compiled-id}])
+
+(deftest a-view-boundary-carries-key-iff-the-call-was-keyed
+  (testing "Spec 004B: `:key` is present on the node iff the site was
+            explicitly keyed. An explicit nil key is presence — React
+            coerces it to the identity \"null\" — so it lands on the
+            boundary as `:key nil`, distinct from the unkeyed sibling
+            beside it, which carries no `:key` key at all."
+    (doseq [{:keys [note parent child]} pairings]
+      (let [kids (:children (tree/render [parent {}]))]
+        (is (= 3 (count kids)) (str note " — three sites, three boundaries"))
+        (is (contains? (first kids) :key)
+            (str note " — an explicit nil key is PRESENT on the boundary"))
+        (is (nil? (:key (first kids)))
+            (str note " — and it carries the nil the call supplied"))
+        (is (not (contains? (second kids) :key))
+            (str note " — while an absent key stays absent"))
+        (is (= "k" (:key (nth kids 2)))
+            (str note " — and an ordinary key is untouched"))))))
+
+(deftest key-presence-survives-the-mount-seam-in-either-mode
+  (testing "`node/mount` is the ONE call either front end emits for an
+            internal boundary, so the whole pinned expansion is asserted
+            per pairing rather than only the `:key` slot. A rule that held
+            interpreted and not compiled would mean adding
+            `{:compiled true}` to a declaration changed whether its
+            children were keyed."
+    (doseq [{:keys [note parent child]} pairings]
+      (is (= (expected-children child) (:children (tree/render [parent {}])))
+          (str note " — one pinned expansion")))))
+
+;; ---------------------------------------------------------------------------
+;; The reserved boundary
+;; ---------------------------------------------------------------------------
+
+(deftest the-error-boundary-node-follows-the-same-presence-rule
+  (testing "`v/error-boundary` is a declared internal boundary like any
+            other — the structural host mounts it through its own
+            containment path, and that path assembles the same node
+            builder. A framework boundary is not a privileged one, so it
+            cannot have its own answer about what `:key` means."
+    (let [keyed   (tree/render [v/error-boundary {:key nil :fallback [:i "f"]} [:b "ok"]])
+          unkeyed (tree/render [v/error-boundary {:fallback [:i "f"]} [:b "ok"]])
+          valued  (tree/render [v/error-boundary {:key "k" :fallback [:i "f"]} [:b "ok"]])]
+      (is (contains? keyed :key) "an explicit nil key is present on the boundary")
+      (is (nil? (:key keyed)) "and carries nil")
+      (is (not (contains? unkeyed :key)) "an absent key stays absent")
+      (is (= "k" (:key valued)) "and an ordinary key is untouched"))))
+
+;; ---------------------------------------------------------------------------
+;; The other two keyable sites
+;; ---------------------------------------------------------------------------
+
+(def ^:private literal-rows
+  "Every remaining structural site a `:key` can be written at, in all three
+  spellings. Elements and fragments are keyed by the same law as
+  boundaries, and the fragment row is the one that used to read the key's
+  VALUE to decide its presence."
+  [{:note "an element"  :form [:div {:key nil}]  :keyed? true  :key nil}
+   {:note "an element"  :form [:div {}]          :keyed? false :key nil}
+   {:note "an element"  :form [:div {:key "k"}]  :keyed? true  :key "k"}
+   {:note "a fragment"  :form [:<> {:key nil} "x"] :keyed? true  :key nil}
+   {:note "a fragment"  :form [:<> {} "x"]         :keyed? false :key nil}
+   {:note "a fragment"  :form [:<> "x"]            :keyed? false :key nil}
+   {:note "a fragment"  :form [:<> {:key "k"} "x"] :keyed? true  :key "k"}])
+
+(deftest an-element-and-a-fragment-carry-key-iff-explicitly-keyed
+  (testing "The law is one law across the node set. Asserting the literal
+            sites beside the boundary sites is what makes it a law rather
+            than four independent behaviours that happen to agree today."
+    (doseq [{:keys [note form keyed?] k :key} literal-rows]
+      (let [node (tree/render form)]
+        (is (= keyed? (contains? node :key))
+            (str note " " (pr-str form) " — key presence"))
+        (is (= k (:key node))
+            (str note " " (pr-str form) " — key value"))))))
+
+;; ---------------------------------------------------------------------------
+;; The scope fence
+;; ---------------------------------------------------------------------------
+
+(deftest normalize-call-still-strips-key-and-keeps-it-out-of-props
+  (testing "Presence is reported BESIDE the props map, never inside it.
+            `:key` selects sibling identity and the view body never sees
+            it, and two calls that differ only in their key still compare
+            equal on props — which is what lets a boundary re-render
+            without its identity leaking into its inputs."
+    (let [explicit (descriptor/normalize-call kid [{:key nil :label "d"}])
+          absent   (descriptor/normalize-call kid [{:label "d"}])
+          valued   (descriptor/normalize-call kid [{:key "k" :label "d"}])]
+      (is (= {:label "d"} (:props explicit)) ":key is stripped from the body's props")
+      (is (= (:props explicit) (:props absent) (:props valued))
+          "and stays outside props equality")
+      (is (true? (:keyed? explicit)) "an explicit nil key is reported PRESENT")
+      (is (nil? (:key explicit)) "with the nil value the call supplied")
+      (is (false? (:keyed? absent)) "and an absent key is reported absent")
+      (is (nil? (:key absent)) "with the same nil value — which is why :keyed? exists"))))

--- a/implementation/freehand/test/re_frame/freehand/structural_slot_alias_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/structural_slot_alias_jvm_test.clj
@@ -3,12 +3,12 @@
   slots, ruled — and ruled two different ways, which is why it is proved
   here rather than assumed.
 
-  Three authored keys reduce to a slot the walks own rather than to an
-  ordinary attribute: `:key`, `:class` and `:style`. Every representation
-  of those names reaches the SAME slot, because both emitters classify an
-  attribute key by its `name` — so `:x/class`, `\"class\"` and `'class` are
-  one key spelled three ways, and a guard or a router that compared the raw
-  map key would see three.
+  Four authored keys reduce to a slot the walks own rather than to an
+  ordinary attribute: `:key`, `:class`, `:style` — and `:id`, whenever the
+  tag carries `#id` sugar. Every representation of those names reaches the
+  SAME slot, because both emitters classify an attribute key by its `name`
+  — so `:x/class`, `\"class\"` and `'class` are one key spelled three ways,
+  and a guard or a router that compared the raw map key would see three.
 
   The ruling SPLITS them, because they are not the same kind of thing:
 
@@ -23,6 +23,14 @@
       `v/spread-safe` already accepts an aliased spelling of an accepted key
       and routes it. Refusing them on the direct path would make it stricter
       than the spread path for the same key.
+    - `:id` is neither, and is the third answer: an id is an ordinary prop,
+      but `#id` sugar has ALREADY written it, so an authored one is a
+      SECOND spelling of an attribute the element already has. Two id
+      spellings on one element is an ambiguity the grammar removes rather
+      than ranks, and it was already refused for the exact `:id` — the
+      alias just walked round the guard, because the guard compared the raw
+      key. With no sugar there is no second spelling and nothing to rule
+      on, so `:x/id` there stays an ordinary qualified attribute.
 
   Routing `:class` carries the obligation this file exists to hold down: the
   routed value must COMPOSE into the class string beside the tag shorthand,
@@ -235,6 +243,93 @@
                  :body            ['[:div {:key "k"}]]
                  :children-policy :optional}))
         "while the exact :key spelling still compiles — the refusal is about the ALIAS")))
+
+;; ---------------------------------------------------------------------------
+;; The slot the TAG already occupies — `#id` sugar
+;; ---------------------------------------------------------------------------
+
+(def id-aliases
+  "Every representation of an authored id an element can carry beside `#id`
+  sugar. All four reduce to the emitted `id` slot the sugar already wrote,
+  so all four are the one ambiguity."
+  ['[:div#sugar {:id "alias"}]
+   '[:div#sugar {:x/id "alias"}]
+   '[:div#sugar {"id" "alias"}]
+   '[:div#sugar {id "alias"}]])
+
+(deftest an-authored-id-beside-id-sugar-is-refused-however-it-is-spelled
+  (testing "`#sugar` already wrote the emitted id, so an authored key that
+            projects onto that slot spells the element's id a second time.
+            The exact `:id` was always refused; the ALIASES were not,
+            because the guard compared the raw key — and React writes both
+            pairs into one JavaScript property, so the authored one
+            silently replaced the sugar while the structural tree went on
+            reporting both. A selector, a label or a debug tool reading the
+            tree would target an id the browser does not have."
+    (doseq [body id-aliases]
+      (let [ex (try (tree/render body)
+                    nil
+                    (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? ex) (str (pr-str body) " is refused"))
+        (when ex
+          (is (= :rf.error/ui-tree-malformed (:rf.error/id (ex-data ex)))
+              (str (pr-str body) " — the walk's existing diagnostic id, not a new one"))
+          (is (str/includes? (ex-message ex) "twice")
+              (str (pr-str body) " — the message says the id is spelled twice")))))))
+
+(deftest the-compiled-analyzer-refuses-the-same-four-spellings
+  (testing "The compiled tier reaches the same verdict through its own
+            diagnostic, `:rf.ui.compile/id-sugar-conflict` — the id
+            already had one, so the alias needs no new id. A declaration
+            the interpreted walk refuses and the compiler accepted would be
+            the two-answers-for-one-declaration split the guard exists to
+            close.
+
+            The string and symbol spellings are refused at the compiled
+            tier by the prior non-keyword-prop rule, so only the keyword
+            pair is asserted here — a compiled props map's keys are literal
+            keywords by grammar."
+    (doseq [body '[[:div#sugar {:id "alias"}] [:div#sugar {:x/id "alias"}]]]
+      (let [ex (try (compiled-tree body) nil (catch Exception e e))]
+        (is (some? ex) (str (pr-str body) " is refused at compile time"))
+        (when ex
+          (is (= :rf.ui.compile/id-sugar-conflict
+                 (:rf.ui.compile/error (ex-data (or (ex-cause ex) ex))))
+              (str (pr-str body) " — reusing the existing compile diagnostic")))))))
+
+(def id-control-rows
+  "The control that makes the refusals above mean something. A guard that
+  turned every id away — or every qualified attribute — would look
+  identical in a table of rejections and would be a worse defect than the
+  bypass it closed. These forms carry exactly ONE id and are accepted."
+  [{:note "the shorthand alone is the ordinary case"
+    :body '[:div#sugar]
+    :tree {:tag :div :attrs {:id "sugar"}}}
+
+   {:note "an :id prop with no sugar is untouched — the ambiguity is the shorthand's"
+    :body '[:div {:id "plain"}]
+    :tree {:tag :div :attrs {:id "plain"}}}
+
+   {:note "and a qualified id with no sugar keeps its authored name, as every ordinary qualified attribute does"
+    :body '[:div {:x/id "alias"}]
+    :tree {:tag :div :attrs {:x/id "alias"}}}
+
+   {:note "the shorthand beside an unrelated attribute is not a conflict"
+    :body '[:div#sugar {:x/title "ok"}]
+    :tree {:tag :div :attrs {:id "sugar" :x/title "ok"}}}
+
+   {:note "nor is a handler whose name merely contains id"
+    :body '[:div#sugar {:data-id "d"}]
+    :tree {:tag :div :attrs {:id "sugar" :data-id "d"}}}])
+
+(deftest one-id-is-accepted-in-both-modes-however-it-is-spelled
+  (testing "The guard fires on the SECOND spelling, not on the name. An
+            element with one id — from the shorthand, from a prop, or from
+            a qualified prop with no shorthand to collide with — renders
+            exactly as it did, in both modes."
+    (doseq [{:keys [note body tree]} id-control-rows]
+      (is (= tree (interpreted-tree body)) (str note " — interpreted"))
+      (is (= tree (compiled-tree body)) (str note " — compiled")))))
 
 ;; ---------------------------------------------------------------------------
 ;; The scope fence

--- a/spec/004B-UI-Tree-and-Conversion.md
+++ b/spec/004B-UI-Tree-and-Conversion.md
@@ -259,10 +259,23 @@ there would claim one that does not exist and would silently replace a value the
 will go looking for; and an event vector is dispatched as data at run time as well as
 compared as data in a test, so an intent carrying a marker would no longer mean what
 its site does. "Data" here is the **EDN value grammar** exactly — nil, booleans,
-strings, keywords, symbols, numbers, `#uuid`, `#inst`, and collections of those; the
-grammar the round-trip promise is stated in. Ordinary nested EDN is untouched, and the
-check is read-only: nothing is rewritten, so a prop that passes is the value the author
-passed.
+strings, characters, keywords, symbols, numbers, `#uuid`, `#inst`, and EDN's four
+collections (list, vector, map, set) of those; the grammar the round-trip promise is
+stated in. Ordinary nested EDN is untouched, and the check is read-only: nothing is
+rewritten, so a prop that passes is the value the author passed.
+
+Two boundaries follow from stating that grammar as **EDN's**, rather than as whatever
+the host's collection and number predicates happen to admit. A collection a host
+implements *outside* those four is not data however collection-like it is: a persistent
+queue prints `#object[…]` on the JVM and `#queue […]` in ClojureScript and reads back
+on neither host's counterpart, and a record prints a tag no EDN reader has — so a tree
+holding either would print and fail to read, or read on one host only, which is the
+same defect as a host object. And `##NaN` is not data either, because the promise is
+that the tree prints and reads back **equal**: `##NaN` is the one value that survives
+print/read while never comparing equal to itself, so a tree carrying one is not equal
+to itself — and the tree is an equality input (a fingerprint hashes one, a structural
+assertion compares one, §Canonical uniqueness). Both are rejected exactly as any other
+non-data value is, at the site that recorded them.
 
 A **template option is not a prop at all.** A reserved internal view whose option holds
 *markup* rather than a value — `v/error-boundary`'s `:fallback` — has that option

--- a/spec/conformance/freehand/fixtures/fh-struct-009.edn
+++ b/spec/conformance/freehand/fixtures/fh-struct-009.edn
@@ -174,7 +174,24 @@
   {:note "the string spelling reaches the same slot"
    :form [:div {"key" "k"}] :error-id :rf.error/ui-tree-malformed}
   {:note "and so does the symbol one"
-   :form [:div {key "k"}] :error-id :rf.error/ui-tree-malformed}]
+   :form [:div {key "k"}] :error-id :rf.error/ui-tree-malformed}
+
+  ;; The `#id` shorthand OWNS the emitted id slot, so an authored key that
+  ;; projects onto it spells the element's id a SECOND time — the
+  ;; ambiguity this grammar removes rather than ranks. The exact `:id` was
+  ;; always refused here; the aliases were not, because that guard also
+  ;; compared the raw key. React writes every one of these pairs into the
+  ;; same JavaScript property, so the authored id replaced the shorthand's
+  ;; while the structural tree went on reporting both — a selector or a
+  ;; label reading the tree would target an id the browser does not have.
+  {:note "the shorthand and an :id prop are two spellings of one attribute"
+   :form [:div#sugar {:id "alias"}] :error-id :rf.error/ui-tree-malformed}
+  {:note "a namespaced id reaches the shorthand's slot all the same"
+   :form [:div#sugar {:x/id "alias"}] :error-id :rf.error/ui-tree-malformed}
+  {:note "as does the string spelling"
+   :form [:div#sugar {"id" "alias"}] :error-id :rf.error/ui-tree-malformed}
+  {:note "and the symbol one"
+   :form [:div#sugar {id "alias"}] :error-id :rf.error/ui-tree-malformed}]
 
  ;; The control that makes the rows above mean something. Refusing by
  ;; emitted prop name is only correct if it refuses the names that ARE
@@ -254,7 +271,29 @@
   {:note "the canonical :key is still lifted onto the node and is never an attribute"
    :form [:div {:key "k"}]
    :tree {:tag :div :key "k" :rf.ui/tree-version 1}
-   :react-key "k"}]
+   :react-key "k"}
+
+  ;; The id rows, and the reason they carry a `:props` map: the tree's id
+  ;; and React's `id` must be the SAME id. That is what the shorthand
+  ;; conflict guard buys, and these are the forms it must not have touched
+  ;; — a guard that turned every id away would look identical in a table of
+  ;; rejections. Each carries exactly one id, spelled one way.
+  {:note "the .class#id shorthand alone — the tree's id is the one React receives"
+   :form [:div#sugar]
+   :tree {:tag :div :attrs {:id "sugar"} :rf.ui/tree-version 1}
+   :props {"id" "sugar"}}
+  {:note "an :id prop with no shorthand to collide with is untouched"
+   :form [:div {:id "plain"}]
+   :tree {:tag :div :attrs {:id "plain"} :rf.ui/tree-version 1}
+   :props {"id" "plain"}}
+  {:note "and a QUALIFIED id with no shorthand stays in author space, carrying the value React writes into id — one id, two vocabularies"
+   :form [:div {:x/id "alias"}]
+   :tree {:tag :div :attrs {:x/id "alias"} :rf.ui/tree-version 1}
+   :props {"id" "alias"}}
+  {:note "the shorthand beside an unrelated qualified attribute is no conflict at all"
+   :form [:div#sugar {:x/title "ok"}]
+   :tree {:tag :div :attrs {:id "sugar" :x/title "ok"} :rf.ui/tree-version 1}
+   :props {"id" "sugar" "title" "ok"}}]
 
  ;; The BEHAVIOURAL control for the reserved `children` slot: React really
  ;; does render a `children` prop as content. Mounted through


### PR DESCRIPTION
Three correctness gaps on the interpreted structural path, each the sibling of a fix that landed hours ago, each a case of a guard or a projection looking at the wrong thing — the value instead of the key's presence, the surface instead of the nesting, the literal spelling instead of the canonical slot. One repair in three commits: **ask the question the emitter will actually ask.**

Closes rf2-rqmsw, rf2-hre9z, rf2-drpa3.101. Nothing was dropped.

---

## 1. Explicit `nil` keys on structural nodes (rf2-rqmsw)

`Spec 004B`: `:key` is present on a node **iff** the site was explicitly keyed. React string-coerces a supplied key, so `{:key nil}` is the ordinary identity `"null"` and a different authored fact from no key at all — which is why PR #6728 added `:keyed?` to `v/normalize-call`: the stripped `:key` value reads `nil` for both.

The React walk consumes that fact. The structural walk dropped it.

**Pre-fix reproduction, on merged main:**

```clojure
(v/defview chip [{:keys [label]}] [:span label])

(tree/render [chip {:key nil :label "d"}])
;; => {:view-id :user/chip, :props {:label "d"}, :children […]}   ← no :key
(tree/render [chip {:label "d"}])
;; => {:view-id :user/chip, :props {:label "d"}, :children […]}   ← byte-identical

(descriptor/normalize-call chip [{:key nil :label "d"}])
;; => {:key nil, :keyed? true, :props {:label "d"}}   ← the fact was there, unread

(tree/render [:<> {:key nil} "x"])   ;; => {:children ["x"]}      ← same defect
(tree/render [:<> {} "x"])           ;; => {:children ["x"]}
```

`node/boundary` associated `:key` under `(some? key)`, and the fragment arm of the walk computed its presence flag as `(some? k)`. Both collapse presence into value. Adding `{:compiled true}` to a declaration therefore changed whether its children were keyed, because the React walk (which asks `contains?`) disagreed.

**The fix.** `node/boundary` takes key presence and key value separately, exactly as `node/element` and `node/fragment` already do; both mount paths — the ordinary boundary and the reserved `v/error-boundary` — thread `normalize-call`'s `:keyed?` into it; the fragment arm asks `contains?`.

Beyond the bead: the **fragment** row. The bead states that fragments already thread presence separately, and `node/fragment` does — but its interpreted caller flattened it, so `[:<> {:key nil} …]` was the same defect at the same depth in the same function I was editing. Fixed and asserted rather than left as a known-false law one line away.

Unchanged: `:key` is still stripped from a boundary's recorded props and still outside props equality; the element and React paths are untouched. No new key type, coercion policy, registry, wrapper node or public verb.

`structural_key_presence_cljs_test.cljc` (JVM + CLJS) asserts all four keyable structural sites together, and runs the boundary rows in **all four parent/child mode pairings** from one body written the same characters each time.

## 2. Structural data validation vs. its round-trip promise (rf2-hre9z)

PR #6727 added `non-data` to guarantee that every accepted tree is plain EDN surviving `pr-str` → `read-string` under the suite's equality assertion. The predicate asked host questions — `coll?` after maps and vectors, a bare `number?` — and those admit values EDN cannot spell and reject values it can.

**Pre-fix reproduction, on merged main:**

```clojure
(def q (conj clojure.lang.PersistentQueue/EMPTY :job))
(pr-str (tree/render [chip {:payload q}]))
;; "… :payload #object[clojure.lang.PersistentQueue …] …"
(edn/read-string *1)   ;; throws: No reader function for tag object

(tree/render [chip {:c (char 97)}])
;; throws :rf.error/ui-tree-malformed — but \a is ordinary EDN and reads back

(tree/render [chip {:n ##NaN}])
;; accepted — and (= t (edn/read-string (pr-str t))) is FALSE
```

A `defrecord` value is the same class as the queue: it answers `map?` and prints a tag no EDN reader has.

**The fix.** The walk now names EDN's own grammar: the scalars, plus its four collections (map, vector, set, list) instead of any `coll?`; records and queues excluded; characters admitted; `##NaN` refused with everything else the tree cannot promise.

Two judgement calls worth stating:

- **`##NaN` is refused, not represented.** It prints and reads back — but it is not equal to itself, so a tree carrying one is not equal to itself, and the tree is an equality input (a fingerprint hashes one, a structural assertion compares one, §Canonical uniqueness). Print/read alone is the wrong promise; print/read *equal* is the one the tree makes.
- **The queue is refused on BOTH hosts.** It is the sharpest case *for* an EDN rule rather than a host rule: on the JVM it prints `#object[…]`, in ClojureScript it satisfies `ISeq` and prints `#queue […]`, and neither host's reader takes the other's. Accepting it where it happens to read back would make one declaration answer a tree on one host and a refusal on the other, and the tree is one value on two hosts.

The rf2-drpa3.72 ruling is untouched — refuse, not represent. The site-level opaque marker, the nested-value refusal, `:rf.error/ui-tree-malformed` and the error-boundary fallback treatment all behave exactly as they did. No codec, reader registry, schema framework or sanitizing copy.

One implementation note that cost a cycle: **`==`, not `=`, decides NaN.** `clojure.lang.Util/equiv` returns true on reference identity before it compares values, so `(= x x)` cannot detect it. `##NaN` is named by its own spelling in the diagnostic, because `carries a number` would leave that refusal unreadable.

Spec 004B §The opaque marker now states the boundary: EDN's four collections and its scalars, why a host collection predicate is not the question, and why `##NaN` is not data.

## 3. The `#id` sugar conflict guard sees aliases of `id` (rf2-drpa3.101)

PR #6731 ruled on aliases reaching React-owned structural slots and named three: `key`, `class`, `style`. The tag parser's `#id` shorthand owns the emitted `id` slot too, and the guard that says so compared the raw key `:id`.

**Pre-fix reproduction, on merged main:**

```clojure
(tree/render [:div#sugar {:x/id "alias"}])
;; => {:tag :div, :attrs {:id "sugar", :x/id "alias"}}   ← two ids
;; …while React receives ONE prop: props.id == "alias"

(tree/render [:div#sugar {"id" "alias"}])
;; => {:tag :div, :attrs {:id "sugar", "id" "alias"}}

(tree/render [:div#sugar {:id "alias"}])
;; throws :rf.error/ui-tree-malformed   ← only the exact spelling was caught
```

A namespace changes the authored spelling, not the emitted slot. The compiled emitter writes the sugar pair first and the authored pair second, so it lost the same way. A selector, a label, or any tool reading the semantic tree would target an id the browser does not have.

**The fix.** All three sites — the interpreted structural walk, the interpreted React walk, the compiled analyzer — judge the emitted SLOT, through the projection the emitters already classify by: `rules/caller-key-slot`, reached as the derived `rules/sugar-id-slot` and the memoized `conv/id-slot-key?`, which sits beside the `attr-key` / `attr-key-refusal` pair that read the same projection at the same two moments. Existing diagnostic ids throughout: `:rf.error/ui-tree-malformed` in both walks, `:rf.ui.compile/id-sugar-conflict` in the analyzer, which now names the offending key.

The question is asked **only when the tag carries sugar**, and that is what keeps this a conflict guard rather than an aliasing framework: with no shorthand there is no second spelling, so `:x/id` alone stays an ordinary qualified attribute in author space, exactly as ruled. The exact `:id` behaves as it always did.

**Deliberately out of scope, per the bead:** `[:div {:id "a" :x/id "b"}]` — two authored id spellings with *no* sugar — is still accepted. The bead scopes this to the shorthand conflict and says not to canonicalize ordinary `:x/id`. Filed as a follow-up rather than widened here.

FH-STRUCT-009's `:rejected` and `:accepted-keys` tables are extended in place rather than duplicated, so the rows run through the structural walk on both hosts and through the React walk in a browser. The accepted rows carry a `:props` map deliberately: they are the cross-host/mode probe that the tree's id and React's `id` are the **same** id — including `[:div {:x/id "alias"}]`, which the tree carries in author space and React writes into `id`, one id in two vocabularies.

---

## Quality gates

All foreground, all to completion, on this branch.

| Gate | Result |
| --- | --- |
| `cd implementation/freehand && clojure -M:test` | **525 tests, 3500 assertions, 0 failures, 0 errors** |
| `npm run test:freehand` | **410 tests, 2869 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` | **10535 tests, 52962 assertions, 0 failures, 0 errors** |
| `npm run test:browser` | **516 tests, 3027 assertions, 0 failures, 0 errors** |
| `python scripts/check_freehand_conformance_index.py` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |

**Non-vacuity.** Each new test surface was proven able to fail, then restored and verified byte-identical by `sha256sum`:

- `structural_key_presence_cljs_test.cljc` — inverted the explicit-nil presence assertion: **4 failures**, all naming `a-view-boundary-carries-key-iff-the-call-was-keyed`.
- `structural_data_round_trip_cljs_test.cljc` — inverted the refusal assertion: **9 failures**, all naming `a-value-that-cannot-round-trip-is-refused-at-the-site-that-records-it`. The file additionally carries a *permanent* two-part control: a host object that does not survive print/read, and `##NaN`, which does survive it and is still not equal — the row that shows print/read alone is the wrong promise.
- `structural_slot_alias_jvm_test.clj` + `fh-struct-009.edn` — inverted one assertion and one fixture `:error-id`: **5 failures**, naming `an-authored-id-beside-id-sugar-is-refused-however-it-is-spelled` and `fh-struct-009-reserved-and-rejected-spellings-are-refused`.

Every defect above was reproduced on merged `main` first; those reproductions are the regression rows.

**Fences held.** No new diagnostic id anywhere. No public verb: `spec/api-manifest.edn`, its sidecar, `spec/API.md` and `docs/api/**` are untouched. `git grep 're-frame.ui' implementation/freehand/` is empty. No in-flight file touched — `root.cljs`, `compiler/check.cljc`, `events.cljc`, `cell.cljc`, `bench/**`, `spec/004`, `spec/004D` and the manifest/conformance machinery are all unmodified; `react.cljs` is touched only in `react-props`' attribute cond, well clear of the controlled-input surface.
