### PR TITLE
fix(freehand): refuse target-specific duplicate members in checker-resolved sets (rf2-drpa3.107)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
@@ -88,10 +88,11 @@
   `v/defview` written under `#?(:clj … :cljs …)` is found.
 
   Where selection leaves source the TARGET's own reader would refuse — a map
-  entry with one side elided, two entries selecting the same key — the checker
-  refuses too (see [[resolve-entries]]). A branch that does not READ cannot be
-  eligible, and normalising it into something readable would be a green about
-  a map nobody wrote.
+  entry with one side elided, two entries selecting the same key, two set
+  members selecting the same value — the checker refuses too (see
+  [[resolve-entries]] and [[resolve-members]]). A branch that does not READ
+  cannot be eligible, and normalising it into something readable would be a
+  green about a literal nobody wrote.
 
   A PURE `.cljs` source is the case that has no answer, and it is refused
   rather than approximated (see [[refuse-cljs-source!]]). Resolution needs
@@ -466,7 +467,7 @@
 
   Thrown WITHOUT the file, because the walk does not carry one;
   [[read-declarations]] holds the path and prefixes it, which is what
-  `::unreadable-map` marks this exception for. `sentence` completes \"a map
+  `::unreadable` marks this exception for. `sentence` completes \"a map
   literal … cannot be read for the :cljs target\"."
   [sentence m features]
   (throw (ex-info (str "a map literal " sentence " cannot be read for the "
@@ -475,7 +476,22 @@
                        "conditional around the WHOLE map — #?(:clj {…} :cljs {…}) "
                        "— or give every entry a branch for every target. The map, "
                        "as preserved: " (pr-str m))
-                  {::unreadable-map true :target (first features) :map m})))
+                  {::unreadable true :target (first features) :map m})))
+
+(defn- refuse-unreadable-set!
+  "Refuse a set whose selected `member` collides with one already taken for the
+  `features` target.
+
+  Thrown WITHOUT the file, for the reason [[refuse-unreadable-map!]] is, and
+  marked the same way so [[read-declarations]] prefixes the path."
+  [member s features]
+  (throw (ex-info (str "a set literal whose conditional selection gives two members "
+                       "the same value, " (pr-str member) ", cannot be read for the "
+                       (first features) " target, so the checker will not answer for "
+                       "a declaration containing it. Write the conditional around the "
+                       "WHOLE set — #?(:clj #{…} :cljs #{…}) — so each target's members "
+                       "are written as themselves. The set, as preserved: " (pr-str s))
+                  {::unreadable true :target (first features) :set s :member member})))
 
 (defn- resolve-entries
   "Resolve conditionals across a map's entries, at the refusal boundary the
@@ -545,6 +561,32 @@
              [(resolve-conditionals x features)])))
         xs))
 
+(defn- resolve-members
+  "Resolve conditionals across a set's members, at the refusal boundary the
+  TARGET's reader draws.
+
+  A set has no half-written member — a conditional that selects nothing simply
+  contributes nothing, which is what it contributes to the real reader too, and
+  [[resolve-children]] already drops it. What a set DOES share with a map is
+  the collision: two members distinct as authored can select the SAME value,
+  and the target reader refuses that set as a duplicate. `#{#?(:clj :a :cljs
+  :b) :b}` reads as `#{:a :b}` for `:clj` and does not read at all for `:cljs`.
+  Rebuilding with `into` coalesced it to `#{:b}` and reported the view
+  ELIGIBLE, which is the map's `into` bug in a set: a green that survives
+  source the compiler cannot read is an answer to a different question.
+
+  The check is on the RESOLVED members, and after splicing, because that is
+  where the reader makes it: `#?@` contributes its whole branch, so a duplicate
+  can arrive between a splice and a sibling — or between two members of one
+  splice, as `#{#?@(:clj [:a :a])}` does for `:clj`."
+  [s features]
+  (reduce (fn [acc member]
+            (if (contains? acc member)
+              (refuse-unreadable-set! member s features)
+              (conj acc member)))
+          (empty s)
+          (resolve-children s features)))
+
 (defn- resolve-conditionals
   "Return `form` with every reader conditional resolved for `features`,
   preserving each rebuilt collection's metadata (the reader anchors lists
@@ -562,9 +604,9 @@
   conditional survives the walk, and the analyzer is handed a reader object
   where the browser build has `#{v/sub}`.
 
-  A MAP is the one kind whose target reader can refuse what selection leaves
-  behind, and there the walk stops rather than assembling something the target
-  cannot read — see [[resolve-entries]]."
+  A MAP and a SET are the kinds whose target reader can refuse what selection
+  leaves behind, and there the walk stops rather than assembling something the
+  target cannot read — see [[resolve-entries]] and [[resolve-members]]."
   [form features]
   (cond
     (not (has-reader-conditional? form))
@@ -578,7 +620,7 @@
     (with-meta (resolve-entries form features) (meta form))
 
     (set? form)
-    (with-meta (into (empty form) (resolve-children form features)) (meta form))
+    (with-meta (resolve-members form features) (meta form))
 
     (vector? form)
     (with-meta (resolve-children form features) (meta form))
@@ -710,8 +752,9 @@
   The one shape that read mode cannot read is answered as a refusal rather
   than raised as a reader exception — see [[refuse-preserved-read!]]. This is
   also where the file's NAME is put on a refusal raised deeper in the walk:
-  [[resolve-entries]] knows which map stopped it and for which target but not
-  which file it came from, and every checker refusal names the file."
+  [[resolve-entries]] and [[resolve-members]] know which literal stopped them
+  and for which target but not which file it came from, and every checker
+  refusal names the file."
   [path]
   (with-open [rdr (LineNumberingPushbackReader. (io/reader (io/file path)))]
     (try
@@ -729,10 +772,10 @@
       (catch clojure.lang.LispReader$ReaderException ex
         (refuse-preserved-read! ex path))
       (catch clojure.lang.ExceptionInfo ex
-        (if (::unreadable-map (ex-data ex))
+        (if (::unreadable (ex-data ex))
           (throw (ex-info (str "re-frame.freehand check: " path ": " (ex-message ex))
                           (-> (ex-data ex)
-                              (dissoc ::unreadable-map)
+                              (dissoc ::unreadable)
                               (assoc :file (str path)))))
           (throw ex))))))
 

--- a/implementation/freehand/test/re_frame/freehand/check_conditional_set_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/check_conditional_set_jvm_test.clj
@@ -1,0 +1,279 @@
+(ns re-frame.freehand.check-conditional-set-jvm-test
+  "A green from the checker must mean the target can READ the branch — sets
+  included.
+
+  The checker reads with conditionals preserved and selects each target's
+  branch itself, then rebuilds each collection. For a SET that rebuild used
+  `into`, which coalesces: two members distinct as authored can select the SAME
+  value for one target, and `#{#?(:clj :a :cljs :b) :b}` — which reads as
+  `#{:a :b}` for `:clj` and does not read at all for `:cljs` — was normalized
+  to `#{:b}` and the view reported `:compile-eligible? true` with no findings.
+  That is the map's duplicate-key bug in the adjacent arm, and the same false
+  green: a report about a set nobody wrote.
+
+  Getting this right means pinning BOTH directions, because a rule that only
+  reproduces the refusals is a rule nothing has contradicted. A set is more
+  permissive than a map, and a naive \"any conditional that elides is
+  suspicious\" rule would have shipped a FALSE RED on `#{#?(:clj :a) :b}`,
+  which reads perfectly well as `#{:b}` for `:cljs`. So the load-bearing
+  assertion here is an EQUIVALENCE against an independent reader
+  (`clojure.tools.reader`, which honours `:features` exactly and has no
+  unconditional platform feature): over a table of shapes, checker and reader
+  must agree on WHETHER each target can read the set and, when it can, on WHICH
+  set — and the table must contain a substantial number of each verdict.
+
+  Five things are asserted:
+
+    1. checker selection and a real target reader agree in both directions,
+       over a table that is refused eleven times and accepted nineteen;
+    2. `check-file` — the public surface — refuses the ordinary and the
+       SPLICING collision rather than reporting eligible, naming the file, the
+       set, the colliding member, the target and the recovery;
+    3. valid conditional sets stay eligible, and resolution still answers a set
+       with its metadata intact;
+    4. the refusal is target-symmetric, and a member that selects nothing is
+       DROPPED rather than refused, because that is what the real reader does
+       with it;
+    5. the checker is still read-only, including after a REFUSED run.
+
+  The colliding fixtures are written to a temp file by this suite rather than
+  committed: their `:cljs` branch is source the browser build's reader refuses,
+  so a committed fixture carrying one could not be compiled for CLJS."
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [clojure.tools.reader :as rdr]
+            [clojure.tools.reader.reader-types :as rt]
+            [re-frame.freehand.check-conditional-set-views]
+            [re-frame.freehand.compiler.check :as check]))
+
+(def ^:private uniform-path
+  (.getPath (io/file (io/resource "re_frame/freehand/check_conditional_set_views.cljc"))))
+
+(def ^:private resolve-conditionals
+  "The checker's branch selection, reached directly — the set arm answers per
+  target, and a refusal raised here carries no file yet (`check-file` adds it),
+  so the bare sentence is what these assertions see."
+  #'check/resolve-conditionals)
+
+(defn- thrown-by [f]
+  (try (f) nil (catch Throwable t t)))
+
+;; ---------------------------------------------------------------------------
+;; 1 — the boundary is the target reader's own, in both directions
+;; ---------------------------------------------------------------------------
+
+(def ^:private shapes
+  "Set literals spanning what conditional selection can do to a set: collide
+  with a sibling, collide out of a splice, collide with itself inside one
+  splice, collide on the JVM instead of the browser, collide through
+  `:default`, collide nested inside another set, collide inside a declaration's
+  attribute map — and, just as load-bearing, the shapes that collide on NO
+  target: a member that elides, a divergent member that lands somewhere free, a
+  splice of a different size per target, two one-armed conditionals that select
+  the same value for DIFFERENT targets (so only ever one of them survives), and
+  a set with no conditional in it at all."
+  ["#{#?(:clj :a :cljs :b) :b}"
+   "#{#?@(:clj [:a] :cljs [:b]) :b}"
+   "#{#?@(:clj [:a :b] :cljs [:c]) :c}"
+   "#{#?@(:clj [] :cljs [:b]) :b}"
+   "#{#?(:cljs :a :clj :b) :b}"
+   "#{#?@(:clj [:a :a])}"
+   "#{:a #?(:default :a)}"
+   "#{#?@(:cljs [:x :y]) :x}"
+   "#{#?(:clj #{:a} :cljs #{:b}) #{:b}}"
+   "[:div {:class #{#?(:clj :a :cljs :b) :b}}]"
+   "#{#?(:clj :a) :b}"
+   "#{#?(:clj :a :cljs :b) :c}"
+   "#{#?@(:clj [:a] :cljs [:a :b])}"
+   "#{#?(:clj :a) #?(:cljs :a)}"
+   "#{:plain :members}"])
+
+(defn- read-for
+  "What a REAL reader told to read for `features` makes of `src` — `{:read …}`
+  or `{:refused message}`. `clojure.tools.reader` honours `:features` exactly,
+  splices before checking for duplicates, and has no unconditional platform
+  feature, so this is the independent statement of what each target sees."
+  [src features]
+  (try {:read (rdr/read-string {:read-cond :allow :features features} src)}
+       (catch Throwable t {:refused (ex-message t)})))
+
+(defn- select-for
+  "The same, through the checker: read with conditionals PRESERVED, then select
+  `features`'s branch the way the checker does."
+  [src features]
+  (try {:read (resolve-conditionals (read-string {:read-cond :preserve} src) features)}
+       (catch Throwable t {:refused (ex-message t)})))
+
+(def ^:private verdicts
+  (for [src shapes, features [#{:clj} #{:cljs}]]
+    {:src src :features features :reader (read-for src features) :checker (select-for src features)}))
+
+(deftest selection-agrees-with-a-real-reader-in-both-directions
+  (testing "every shape, for every target: the checker refuses exactly what the
+            target's own reader refuses, and reads exactly what it reads"
+    (doseq [{:keys [src features reader checker]} verdicts]
+      (is (= (contains? reader :read) (contains? checker :read))
+          (str src " for " features ": reader says "
+               (if (contains? reader :read) "READABLE" (str "REFUSED — " (:refused reader)))
+               ", checker says "
+               (if (contains? checker :read) "READABLE" (str "REFUSED — " (:refused checker)))))
+      (when (and (contains? reader :read) (contains? checker :read))
+        (is (= (:read reader) (:read checker))
+            (str src " for " features ": the same verdict, a different set")))))
+
+  (testing "and the table is not one-sided — a rule that only reproduced the
+            refusals would pass a table with no acceptances in it, and a rule
+            that refused nothing would pass a table with no refusals"
+    (is (= 11 (count (filter (comp :refused :reader) verdicts))))
+    (is (= 19 (count (filter (comp #(contains? % :read) :reader) verdicts))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — check-file refuses instead of normalizing
+;; ---------------------------------------------------------------------------
+
+(def ^:private colliding
+  "The two ways a set collides for one target only, as the bead reproduced them.
+  Both `:clj` branches read — `#{:a :b}` — which is why the namespace loads;
+  the refusal is about the `:cljs` branch alone."
+  {"ordinary-member" "[:div {:title (str #{#?(:clj :a :cljs :b) :b})} \"x\"]"
+   "spliced-member"  "[:div {:title (str #{#?@(:clj [:a] :cljs [:b]) :b})} \"x\"]"})
+
+(defn- write-temp-view
+  "Write a one-view `.cljc` namespace whose body is `colliding`'s `nm`, LOAD it
+  so heads resolve, and answer its path."
+  [nm]
+  (let [dir (.toFile (java.nio.file.Files/createTempDirectory
+                      "check-conditional-set"
+                      (make-array java.nio.file.attribute.FileAttribute 0)))
+        f   (io/file dir (str nm ".cljc"))]
+    (.deleteOnExit dir)
+    (.deleteOnExit f)
+    (spit f (str "(ns re-frame.freehand." nm "-temp-set-views\n"
+                 "  (:require [re-frame.freehand :as v]))\n"
+                 "\n"
+                 "(v/defview subject\n"
+                 "  [_]\n"
+                 "  " (get colliding nm) ")\n"))
+    (load-file (.getPath f))
+    (.getPath f)))
+
+(def ^:private temp-view
+  "Each shape is written and loaded ONCE, however many assertions point at it."
+  (memoize write-temp-view))
+
+(defn- read-file-for
+  "Read every form of the file at `path` with a real reader told to read for
+  `features`, and answer nil or the exception it threw."
+  [path features]
+  (let [r (rt/indexing-push-back-reader (slurp path))]
+    (thrown-by
+     #(loop []
+        (when-not (= ::eof (rdr/read {:eof ::eof :read-cond :allow :features features} r))
+          (recur))))))
+
+(deftest check-file-refuses-a-set-the-target-cannot-read
+  (testing "a conditional member that selects a member the set already has is a
+            duplicate for that target, and the checker refuses rather than
+            coalescing it — this reported :compile-eligible? true, no findings"
+    (let [path (temp-view "ordinary-member")]
+      (is (nil? (read-file-for path #{:clj})) "the JVM branch reads: #{:a :b}")
+      (is (re-find #"Duplicate key: :b" (str (read-file-for path #{:cljs}))))
+
+      (let [ex (thrown-by #(check/check-file path))]
+        (is (instance? clojure.lang.ExceptionInfo ex) "a refusal, not a report")
+        (let [msg (ex-message ex)]
+          (is (re-find #"^re-frame\.freehand check: " msg))
+          (is (.contains msg path))
+          (is (.contains msg "two members the same value, :b") "which member collided")
+          (is (.contains msg ":cljs target") "and for which target")
+          (is (.contains msg "#{:b #?(:clj :a :cljs :b)}") "the set, as the checker preserved it")
+          (is (.contains msg "around the WHOLE set") "the recovery is the payload"))
+        (is (= :cljs (:target (ex-data ex))))
+        (is (= path (:file (ex-data ex))))
+        (is (= :b (:member (ex-data ex))))
+        (is (some reader-conditional? (:set (ex-data ex)))
+            "the offending set rides in the data exactly as authored, its
+             conditional intact, so a tool can render it without re-reading"))))
+
+  (testing "and a SPLICING conditional collides the same way — the target reader
+            splices before it checks for duplicates, so the check has to be on
+            the spliced members and not on the conditional that produced them"
+    (let [path (temp-view "spliced-member")]
+      (is (nil? (read-file-for path #{:clj})) "the JVM branch reads: #{:a :b}")
+      (is (re-find #"Duplicate key: :b" (str (read-file-for path #{:cljs}))))
+
+      (let [ex (thrown-by #(check/check-file path))]
+        (is (instance? clojure.lang.ExceptionInfo ex))
+        (is (.contains (ex-message ex) "two members the same value, :b"))
+        (is (.contains (ex-message ex) ":cljs target"))
+        (is (= :cljs (:target (ex-data ex)))))))
+
+  (testing "a duplicate WITHIN one splice is the same refusal, for whichever
+            target the splice lands on"
+    (is (re-find #"two members the same value, :a"
+                 (:refused (select-for "#{#?@(:clj [:a :a])}" #{:clj}))))
+    (is (= #{} (:read (select-for "#{#?@(:clj [:a :a])}" #{:cljs}))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the ordinary case is untouched
+;; ---------------------------------------------------------------------------
+
+(deftest a-readable-conditional-set-stays-eligible
+  (testing "sets whose conditionals collide on no target keep every selected
+            member and the view stays eligible — refusing the unreadable must
+            not cost the readable"
+    (is (= [{:view-id           :re-frame.freehand.check-conditional-set-views/conditional-set-uniform
+             :compile-eligible? true
+             :findings          []}]
+           (mapv #(select-keys % [:view-id :compile-eligible? :findings])
+                 (check/check-file uniform-path)))))
+
+  (testing "and resolution still answers a SET, with the metadata the reader
+            anchored on it — a finding's coordinates ride that metadata"
+    (let [form (vary-meta (read-string {:read-cond :preserve} "#{#?(:clj :a :cljs :b) :c}")
+                          assoc ::marker true)]
+      (is (set? (resolve-conditionals form #{:cljs})))
+      (is (= #{:a :c} (resolve-conditionals form #{:clj})))
+      (is (= #{:b :c} (resolve-conditionals form #{:cljs})))
+      (is (= {::marker true} (meta (resolve-conditionals form #{:cljs})))
+          "the set's metadata rides through the rebuild"))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — symmetry, and the member that legitimately disappears
+;; ---------------------------------------------------------------------------
+
+(deftest the-refusal-follows-the-target
+  (testing "nothing here is :cljs-specific — the JVM target is refused by the
+            same rule when the conditional is the one that collides for it"
+    (let [src "#{#?(:cljs :a :clj :b) :b}"]
+      (is (= #{:a :b} (:read (select-for src #{:cljs}))))
+      (is (re-find #"cannot be read for the :clj target" (:refused (select-for src #{:clj}))))))
+
+  (testing "and a member whose conditional selects NOTHING contributes nothing
+            to the target, exactly as it contributes nothing to the real reader
+            — dropping it is not normalizing, it is agreeing. Refusing it would
+            be the false RED that hides behind a rule checked only against the
+            refusals it was written for"
+    (let [src "#{#?(:clj :a) :b}"]
+      (is (= #{:b}    (:read (select-for src #{:cljs}))))
+      (is (= #{:b}    (:read (read-for   src #{:cljs}))) "independently, per clojure.tools.reader")
+      (is (= #{:a :b} (:read (select-for src #{:clj}))))
+      (is (= #{:a :b} (:read (read-for   src #{:clj})))))
+
+    (testing "including when every member elides and the target's set is empty"
+      (is (= #{} (:read (select-for "#{#?(:clj :a) #?(:clj :b)}" #{:cljs}))))
+      (is (= #{} (:read (read-for   "#{#?(:clj :a) #?(:clj :b)}" #{:cljs})))))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — read-only
+;; ---------------------------------------------------------------------------
+
+(deftest the-checker-never-writes
+  (testing "refusing a set is still read-only — the source pointed at is
+            byte-identical afterwards, refused run included"
+    (doseq [path [uniform-path (temp-view "ordinary-member") (temp-view "spliced-member")]]
+      (let [before (java.nio.file.Files/readAllBytes (.toPath (io/file path)))
+            _      (thrown-by #(check/check-file path))
+            after  (java.nio.file.Files/readAllBytes (.toPath (io/file path)))]
+        (is (pos? (alength before)) (str path " is not empty"))
+        (is (java.util.Arrays/equals ^bytes before ^bytes after))))))

--- a/implementation/freehand/test/re_frame/freehand/check_conditional_set_views.cljc
+++ b/implementation/freehand/test/re_frame/freehand/check_conditional_set_views.cljc
@@ -1,0 +1,31 @@
+(ns re-frame.freehand.check-conditional-set-views
+  "The control for `check-conditional-set-jvm-test`: reader conditionals inside
+  SET literals that every target can read.
+
+  Refusing the sets a target's reader refuses is only worth anything if the
+  sets it accepts stay accepted — and a set has more accepted shapes than a
+  map does, because a member that selects nothing simply is not there. All
+  three sets below diverge across the two targets and collide on neither: an
+  ordinary conditional selecting a different member on each, a splice
+  contributing a different number of members to each, and a one-armed
+  conditional that contributes to `:clj` and vanishes for `:cljs`. Every target
+  gets a well-formed set, so this view is inside the grammar wherever it is
+  compiled and the checker must say so.
+
+  Nothing invalid lives in this file, and nothing invalid can: a set whose
+  `:cljs` selection collides does not READ, and would break the browser build
+  of this test tree. The colliding shapes are written to a temp file by the
+  suite itself, loaded, checked, and thrown away.
+
+  Loaded on the JVM (required by
+  `re-frame.freehand.check-conditional-set-jvm-test`)."
+  (:require [re-frame.freehand :as v]))
+
+(v/defview conditional-set-uniform
+  "Three sets whose conditional selection collides on no target - eligible
+  wherever it is compiled."
+  [_]
+  [:div {:title       (str #{#?(:clj :a :cljs :b) :c})
+         :data-splice (str #{#?@(:clj [:a] :cljs [:a :b])})
+         :data-elided (str #{#?(:clj :jvm-only) :always})}
+   "sets whose conditionals all select something readable"])


### PR DESCRIPTION
The compile checker reads with reader conditionals **preserved** and selects each target's branch itself. PR #6733 made the MAP arm refuse what a target's reader would refuse — a half-written entry, a conditional-selected duplicate key. The adjacent SET arm still rebuilt selected members with `(into (empty form) (resolve-children …))`, and `into` coalesces. Two members distinct as authored can select the same value for one target; the target's reader refuses that set as a duplicate, and the checker normalized it away and called the view eligible.

This is the set counterpart of the map collision, at the same seam. Private helper, no new diagnostic id, no reader of the checker's own, no public surface.

## The defect, reproduced on `main` before the fix

Three one-view `.cljc` files, written and loaded, then read by `clojure.tools.reader` for each target and handed to the public `check/check-file`. On `a12c97e12f` (the branch point):

| body | tools.reader `#{:clj}` | tools.reader `#{:cljs}` | `check-file` on `main` |
| --- | --- | --- | --- |
| `[:div {:title (str #{#?(:clj :a :cljs :b) :b})}]` | `#{:a :b}` | **refused** — `Duplicate key: :b` | `:compile-eligible? true`, `:findings []` |
| `[:div {:title (str #{#?@(:clj [:a] :cljs [:b]) :b})}]` | `#{:a :b}` | **refused** — `Duplicate key: :b` | `:compile-eligible? true`, `:findings []` |
| `[:div {:title (str #{#?(:clj :a :cljs :b) :c})}]` (control) | `#{:a :c}` | `#{:b :c}` | `:compile-eligible? true` — correct |

The `:cljs` branch of the first two does not read at all, so no compile of them can stand; both came back green with no findings. After the fix both are refused, naming the file, the colliding member, the target and the recovery, and the control is still eligible:

```
re-frame.freehand check: …/ordinary.cljc: a set literal whose conditional
selection gives two members the same value, :b, cannot be read for the :cljs
target, so the checker will not answer for a declaration containing it. Write
the conditional around the WHOLE set — #?(:clj #{…} :cljs #{…}) — so each
target's members are written as themselves. The set, as preserved:
#{:b #?(:clj :a :cljs :b)}
```

## The change

`resolve-members` replaces the `into` rebuild: resolve the members (which already splices a matched `#?@` and drops an elided conditional), then `conj` them one at a time and refuse on the first value the set already holds. The check is on the RESOLVED members and AFTER splicing, because that is where the reader makes it — a duplicate can arrive between a splice and a sibling, or between two members of ONE splice (`#{#?@(:clj [:a :a])}` is refused for `:clj` and reads as `#{}` for `:cljs`).

`refuse-unreadable-set!` is the map refusal's sibling and shares its `::unreadable` marker, so `read-declarations` puts the file name on it the same way (the marker was `::unreadable-map`; it is now neutral and both use it).

## The oracle cross-check — both directions

A rule that only reproduces its intended refusals has been checked against nothing, and a set is far MORE permissive than a map: a member whose conditional selects nothing simply is not there, so `#{#?(:clj :a) :b}` reads perfectly well as `#{:b}` for `:cljs`. A naive "refuse any elided side" rule — the map's shape — would have shipped a false RED on it, which is harder to notice than a false green because the tool looks like it is working.

So the load-bearing test is an EQUIVALENCE, not a refusal list. `selection-agrees-with-a-real-reader-in-both-directions` runs fifteen shapes × two targets through `clojure.tools.reader` at `:features #{:clj}` / `#{:cljs}` (which honours `:features` exactly and has no unconditional platform feature) and through the checker's own selection, and asserts they agree on WHETHER the set reads and, when it does, on WHICH set. All thirty verdicts agree:

**Refused by the reader, and now refused by the checker (11):**

| shape | refused for |
| --- | --- |
| `#{#?(:clj :a :cljs :b) :b}` | `:cljs` |
| `#{#?@(:clj [:a] :cljs [:b]) :b}` | `:cljs` (splice vs sibling) |
| `#{#?@(:clj [:a :b] :cljs [:c]) :c}` | `:cljs` |
| `#{#?@(:clj [] :cljs [:b]) :b}` | `:cljs` (empty branch on the other side) |
| `#{#?(:cljs :a :clj :b) :b}` | `:clj` (symmetric — nothing here is `:cljs`-specific) |
| `#{#?@(:clj [:a :a])}` | `:clj` (duplicate WITHIN one splice) |
| `#{:a #?(:default :a)}` | both targets |
| `#{#?@(:cljs [:x :y]) :x}` | `:cljs` |
| `#{#?(:clj #{:a} :cljs #{:b}) #{:b}}` | `:cljs` (nested set as the member) |
| `[:div {:class #{#?(:clj :a :cljs :b) :b}}]` | `:cljs` (set inside an attribute map) |

**Accepted by the reader, and NOT refused by the checker (19) — the direction that catches a false red:**

| shape | `:clj` | `:cljs` |
| --- | --- | --- |
| `#{#?(:clj :a) :b}` | `#{:a :b}` | `#{:b}` — the member elides and is DROPPED, not refused |
| `#{#?(:clj :a :cljs :b) :c}` | `#{:a :c}` | `#{:b :c}` |
| `#{#?@(:clj [:a] :cljs [:a :b])}` | `#{:a}` | `#{:a :b}` — splice of a different size per target |
| `#{#?(:clj :a) #?(:cljs :a)}` | `#{:a}` | `#{:a}` — same value, different targets, so only ever one survives |
| `#{:plain :members}` | `#{:plain :members}` | `#{:plain :members}` |
| `#{#?@(:clj [:a :a])}` | *(refused)* | `#{}` — the colliding splice vanishes entirely |
| `#{#?@(:clj [] :cljs [:b]) :b}` | `#{:b}` | *(refused)* |
| `#{#?@(:cljs [:x :y]) :x}` | `#{:x}` | *(refused)* |
| …and the `:clj` side of every other refused shape above | reads | *(refused)* |

The suite also asserts the split is 11/19, so a table drained of either verdict fails rather than passing vacuously.

## The three checker laws still hold

- **Read-only.** `the-checker-never-writes` reads the bytes before and after `check-file` for the committed control fixture AND for both temp fixtures whose runs are REFUSED, and asserts `java.util.Arrays/equals`.
- **No new diagnostic ids.** Nothing is added to `reasons`; the refusal is an `ex-info` from the read stage, exactly as the map refusals are. Findings still carry only the analyzer's `:rf.ui.compile/*` ids.
- **One finding per run, at the first ineligible form.** Untouched — `findings-for` still `take 1`s, and a set refusal stops the read before any analysis, like the map refusal.

## Non-vacuity

Reverting the one-line set arm back to `(into (empty form) (resolve-children form features))` and leaving the tests alone reds the full freehand JVM gate:

```
Ran 572 tests containing 3891 assertions.
18 failures, 10 errors.
```

Every one of the 28 names the new suite:

```
 9 ERROR check-file-refuses-a-set-the-target-cannot-read
 1 ERROR the-refusal-follows-the-target
 7 FAIL  check-file-refuses-a-set-the-target-cannot-read
11 FAIL  selection-agrees-with-a-real-reader-in-both-directions
```

Restoring gave `git status --porcelain` and `git diff HEAD` both empty — the source is byte-identical to what is committed here — and the gate is green again.

## An adjacent limitation, observed and NOT fixed here

The checker's own preserved read refuses `#{#?(:clj :a) #?(:clj :a)}` with `Duplicate key: clojure.lang.ReaderConditional@…`, because two textually identical conditionals are equal as preserved objects — yet that set is legal for `:cljs` (it reads as `#{}`). This is the set analogue of the `#?@`-in-a-map-literal blind spot `refuse-preserved-read!` already names, it is upstream of this change, and nobody writes it. It is excluded from the oracle table and left alone rather than folded into this fix.

## Quality gates

All run in the worker worktree, foreground, one at a time.

| gate | result |
| --- | --- |
| `cd implementation/freehand && clojure -M:test` | 572 tests, 3891 assertions, **0 failures, 0 errors** |
| `npm run test:freehand` | 461 tests, 3100 assertions, **0 failures, 0 errors** |
| `npm run test:cljs` | 10586 tests, 53193 assertions, **0 failures, 0 errors** |
| `python scripts/check_keyword_catalogue_drift.py` | exit 0 |
| `python scripts/check_freehand_conformance_index.py` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |

`git grep 're-frame.ui' implementation/freehand/` is empty. No `.beads` path, no spec or docs prose, no api-manifest surface: `resolve-members` and `refuse-unreadable-set!` are both private.

Spec unchanged because 004D §Where the checker runs states the branch-selection contract but does not enumerate which selected literals the checker refuses; PR #6733 introduced that refusal class with no spec change, and this is the same class in the adjacent collection kind.
