### PR TITLE
feat(freehand): make compiled views runnable through the public door (rf2-drpa3.81)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand.cljc
+++ b/implementation/freehand/src/re_frame/freehand.cljc
@@ -48,6 +48,17 @@
             ;; namespace and takes nothing back from it.
             [re-frame.freehand.node]
             [re-frame.freehand.presence-runtime :as presence-runtime]
+            ;; The compiled tier's render-time reactive runtime — what an
+            ;; authored `(v/sub …)` inside a `{:compiled true}` body lowers to.
+            ;; Required here for the SAME reason `node` is: promotion is a
+            ;; one-line change to the declaration, so adding `{:compiled true}`
+            ;; must not oblige a namespace to acquire a require it did not need
+            ;; a moment earlier. Without it a compiled declaration carrying a
+            ;; subscription cannot even LOAD — the emitted lowering names a
+            ;; namespace nothing on the consumer's path has loaded. `reactive`
+            ;; sits BELOW this namespace (it reaches only the shell) and takes
+            ;; nothing back from it.
+            [re-frame.freehand.reactive]
             [re-frame.freehand.route-link-seam :as route-link-seam]
             [re-frame.interop :as interop]
             #?@(:clj  [[re-frame.freehand.compiler :as compiler]
@@ -202,7 +213,19 @@
                                 :body            body
                                 :props-schema    schema
                                 :children-policy policy})]
-                         (assoc entry :structural body :manifest manifest))
+                         ;; The manifest is INERT DATA about the declaration,
+                         ;; and it is QUOTED because it contains authored FORMS:
+                         ;; a subscription site records the query the author
+                         ;; wrote, and a query that reads a prop —
+                         ;; `(v/sub [:person/by-id id])` — carries the body's
+                         ;; own local symbol. Spliced unquoted into the entry
+                         ;; map, that symbol would be EVALUATED where no such
+                         ;; local exists and the declaration would not compile.
+                         ;; The structural body beside it is the opposite kind
+                         ;; of value — a form to evaluate — so only the manifest
+                         ;; is quoted. (The JVM emitter's own `register-view!`
+                         ;; call has always quoted it, for exactly this reason.)
+                         (assoc entry :structural body :manifest (list 'quote manifest)))
                        (assoc entry :render
                               `(fn ~(symbol (str sym "-render")) ~params ~@body)))]
          ;; The var metadata is what a COMPILE-TIME head classifier reads: a

--- a/implementation/freehand/src/re_frame/freehand/cell.cljc
+++ b/implementation/freehand/src/re_frame/freehand/cell.cljc
@@ -166,6 +166,7 @@
            :lifecycle  :new
            :frame      nil
            :deps       {}
+           :dep-order  []
            :events     (events/owner view-id)
            :revision   0
            :listeners  {}
@@ -193,10 +194,16 @@
   (:deps @(st cell)))
 
 (defn dependency-queries
-  "The queries the SELECTED commit owns, in render order."
+  "The queries the SELECTED commit owns, in RENDER order.
+
+  The order is the one the commit published, not a sort of the site keys.
+  A site key is whatever the tier that recorded it uses — the
+  interpreted walk's document ordinal, the compiled tier's proven lexical
+  site id — and only an ordinal happens to sort into render order. Reading
+  the published order keeps this projection true for both."
   [^ViewCell cell]
-  (let [deps (:deps @(st cell))]
-    (mapv #(:query (get deps %)) (sort (keys deps)))))
+  (let [{:keys [deps dep-order]} @(st cell)]
+    (mapv #(:query (get deps %)) dep-order)))
 
 ;; ---------------------------------------------------------------------------
 ;; The render candidate — a value the caller holds
@@ -311,6 +318,30 @@
               (forked-capture! owner query)))
      :cljs nil))
 
+(defn- record-read!
+  "The ONE reactive read, under the site key its tier names.
+
+  Resolve, probe, stabilize against the same site's prior committed
+  observation, record on the candidate in render order, and answer the
+  value. Ownership-free: [[obs/probe]] creates no cache entry, no watch
+  and no disposal obligation."
+  [^RenderCandidate cand site-key query]
+  (let [^ViewCell owner-cell (.-cell cand)
+        reads     (.-reads cand)
+        prior     (get (:deps @(st owner-cell)) site-key)
+        query*    (if (and prior (eq/rf= query (:query prior))) (:query prior) query)
+        target    (obs/resolve-target {:query-v query*})
+        ev        (obs/probe target)
+        v         (:value ev)
+        v*        (if (and prior (eq/rf= v (:value prior))) (:value prior) v)]
+    (vswap! reads
+            (fn [r]
+              (-> r
+                  (update :order conj site-key)
+                  (assoc-in [:by-site site-key]
+                            {:query query* :target target :evidence ev :value v*}))))
+    v*))
+
 (defn observe!
   "RENDER time: resolve, probe and RECORD one reactive read on the active
   candidate, and return the observed value.
@@ -340,22 +371,30 @@
     (when (nil? cand)
       (read-outside-render! query))
     (ensure-render-thread! cand query)
-    (let [^ViewCell owner-cell (.-cell cand)
-          reads     (.-reads cand)
-          site-key  (count (:order @reads))
-          prior     (get (:deps @(st owner-cell)) site-key)
-          query*    (if (and prior (eq/rf= query (:query prior))) (:query prior) query)
-          target    (obs/resolve-target {:query-v query*})
-          ev        (obs/probe target)
-          v         (:value ev)
-          v*        (if (and prior (eq/rf= v (:value prior))) (:value prior) v)]
-      (vswap! reads
-              (fn [r]
-                (-> r
-                    (update :order conj site-key)
-                    (assoc-in [:by-site site-key]
-                              {:query query* :target target :evidence ev :value v*}))))
-      v*)))
+    (record-read! cand (count (:order @(.-reads cand))) query)))
+
+(defn observe-site!
+  "The SAME render-time read as [[observe!]], recorded under the site key
+  `site-key` the caller names rather than the document-order ordinal.
+
+  This is the COMPILED tier's door. Its analyzer has already proven a
+  FINITE set of read sites and given each one a stable lexical id, so the
+  compiled lowering can name the site it is reading at instead of counting
+  its way to it — which is what makes a read's identity survive a body
+  edit that moves it, and what lets the manifest's subscription roster and
+  the cell's committed dependency set be indexed by the same key.
+
+  Everything else is the one shell: the same capture, the same
+  same-thread rule, the same outside-render diagnostic, the same
+  stabilization, and the same commit. There is no second reactive path —
+  the compiled tier differs in WHEN the site was identified, never in what
+  a read means."
+  [site-key query]
+  (let [^RenderCandidate cand *render*]
+    (when (nil? cand)
+      (read-outside-render! query))
+    (ensure-render-thread! cand query)
+    (record-read! cand site-key query)))
 
 ;; ---------------------------------------------------------------------------
 ;; The repaint channel
@@ -747,6 +786,7 @@
                    :lifecycle :connected
                    :frame     fid
                    :deps      staged
+                   :dep-order (vec order)
                    :evidence  bundle)
             (events/commit! (.-events cand)
                             (frame-dispatcher fid)
@@ -787,6 +827,7 @@
              :lifecycle :disconnected
              :frame     nil
              :deps      {}
+             :dep-order []
              :evidence  nil
              :dirty     nil)
       (swap! pending-cells disj cell)

--- a/implementation/freehand/src/re_frame/freehand/reactive.cljc
+++ b/implementation/freehand/src/re_frame/freehand/reactive.cljc
@@ -1,0 +1,63 @@
+(ns re-frame.freehand.reactive
+  "The COMPILED tier's render-time reactive runtime — the namespace the
+  `:re-frame.freehand/v1` lowering resolves an authored `(v/sub …)`
+  against.
+
+  A compiled body never carries the authoring verb into its output. The
+  analyzer recognises the site, gives it a stable LEXICAL id, records it
+  on the manifest's subscription roster, and rewrites the call to
+  [[sub-read]] carrying that id — so what runs is a read that already
+  knows which proven site it is.
+
+  ## Why this is a doorway and not a system
+
+  There is exactly ONE reactive path in Freehand: the atomic shell in
+  [[re-frame.freehand.cell]]. A read resolves and probes against the
+  render's own candidate, owns nothing, and becomes an owned dependency
+  only when the SELECTED commit publishes the whole bundle — frame,
+  dependencies, event sites and evidence — in one write. The compiled
+  tier does not get its own version of that, a second cache, or a second
+  commit discipline; it gets the same [[re-frame.freehand.cell/observe-site!]]
+  the interpreted `v/sub` reaches through
+  [[re-frame.freehand.cell/observe!]], with a proven site key in place of
+  a counted one.
+
+  That is the whole difference between the modes, and it is why adding
+  `{:compiled true}` to a declaration cannot change what its reads mean:
+  the same query resolves the same way, stabilizes the same way, fails
+  the same way outside a render, and is owned by the same commit. A
+  compiled view and its interpreted twin observe the same values in the
+  same commit discipline because they observe through the same function.
+
+  `.cljc`, because the lowering is host-neutral: the JVM structural host
+  runs a compiled body directly, and the browser runs it inside the React
+  shell. Both drive the same cell.
+
+  INTERNAL. Nothing here is application API — the authoring surface is
+  `v/sub`, and this is what the compiler lowers it to.
+
+  Normative owner:
+  [`spec/006-ReactiveSubstrate.md`](../../../../../spec/006-ReactiveSubstrate.md)
+  §The Freehand atomic shell; the grammar that admits the site is
+  [`spec/004D-Freehand-Compiled-Grammar.md`](../../../../../spec/004D-Freehand-Compiled-Grammar.md)."
+  (:require [re-frame.freehand.cell :as cell]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn sub-read
+  "The compiled lowering of `(v/sub query)`: read `query` at the proven
+  lexical site `site-id`, and answer the observed value.
+
+  `site-id` is the analyzer's own id for this read — the same id the
+  declaration's manifest carries on its `:subscriptions` roster — so the
+  committed dependency the shell installs is indexed by the coordinate a
+  reader, a tool and the build all already have a name for. It is stable
+  across re-renders and across body edits that move the site, which is
+  what an interpreted body's document ordinal cannot promise.
+
+  Everything a read means is [[re-frame.freehand.cell/observe-site!]]'s:
+  ownership-free at render, owned by the SELECTED commit, stabilized
+  against the site's prior committed observation, and fail-loud outside
+  an active declared render."
+  [site-id query]
+  (cell/observe-site! site-id query))

--- a/implementation/freehand/test/re_frame/freehand/compiled_reactive_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/compiled_reactive_cljs_test.cljc
@@ -1,0 +1,244 @@
+(ns re-frame.freehand.compiled-reactive-cljs-test
+  "THE COMPILED TIER READS STATE — and reads it through the one shell.
+
+  A `(v/sub …)` inside a `{:compiled true}` body lowers to
+  `re-frame.freehand.reactive/sub-read`. That namespace did not exist, so
+  a compiled declaration carrying a subscription could not even LOAD
+  through the public `v/defview` door: it failed at macro expansion with
+  a missing-namespace error, on both hosts, before any render. Two
+  independent slices measured the consequence — the manifest census could
+  not populate its `:subscriptions` roster through `v/manifest`, and the
+  compiled-schemas suite had to assert that gap executably rather than
+  leave it as a comment.
+
+  THE PRE-FIX REGRESSION IS THIS FILE LOADING. `re-frame.freehand.manifest-views`
+  declares a compiled sub-bearing view; requiring it is what used to fail,
+  and it fails at COMPILE, so a suite asserting over it cannot be green
+  for the wrong reason. There were two causes, and both are load-time:
+  the missing runtime namespace, and — reachable only once that was
+  fixed — a descriptor entry that spliced the manifest UNQUOTED, so a
+  query reading a prop (`(v/sub [:basket/total basket-id])`) evaluated
+  the body's own local symbol where no such local exists.
+
+  ## What is actually proven here
+
+  Loading is necessary and nowhere near sufficient. The claim this suite
+  makes is SEMANTIC AGREEMENT: a compiled view carrying a subscription
+  observes the same values, in the same commit discipline, as its
+  interpreted twin — because both reach the same atomic shell. Every
+  behavioural row below runs the SAME assertions over both arms from one
+  table, so a compiled-only regression cannot hide behind an
+  interpreted-only green, and a claim that holds for neither fails twice.
+
+  The one thing that is deliberately DIFFERENT is the site key. The
+  interpreted walk numbers reads in document order — it has nothing
+  better, because an unrestricted body's reads are discovered, not
+  proven. The compiled tier's analyzer has already proven a finite set of
+  read sites and given each a stable LEXICAL id, so its read is recorded
+  under the very id the manifest publishes on its `:subscriptions`
+  roster. That is asserted here as the identity it is: the manifest's
+  `:sid` IS the committed dependency's key.
+
+  Both hosts, from one file: the shell, the lowering and the runtime are
+  all `.cljc`, and a compiled body runs directly on the JVM structural
+  host. `t/render` is the public structural door, so nothing below
+  reaches past a surface an application has."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.cell :as cell]
+            [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.manifest-views :as mv]
+            [re-frame.freehand.test :as t]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; The two arms
+;; ---------------------------------------------------------------------------
+
+(v/defview interpreted-basket-total
+  "The INTERPRETED twin of `re-frame.freehand.manifest-views/basket-total`
+  — the same parameter vector, the same body, and no `{:compiled true}`.
+  The one-line promotion, written out as a second declaration so both
+  lowerings are live in one process and one table can drive both."
+  [{:keys [basket-id]}]
+  [:output.total (v/sub [:basket/total basket-id])])
+
+(def ^:private compiled-view mv/basket-total)
+
+(def ^:private fid :rf/default)
+(def ^:private basket-id 7)
+(def ^:private query [:basket/total basket-id])
+
+(def ^:private arms
+  "mode -> the declaration that mode declares. Every behavioural row runs
+  over both, so a claim is a claim about the SUBSTRATE and not about one
+  lowering that happens to be green."
+  {:compiled    compiled-view
+   :interpreted interpreted-basket-total})
+
+(defn- register-sub! []
+  (rf/reg-sub :basket/total (fn [db [_ id]] (get-in db [:baskets id :total]))))
+
+(defn- seed! [db] (frame/replace-app-db! fid db))
+
+(defn- render-under-capture!
+  "One render pass of `view` inside cell `c`'s candidate — through the
+  PUBLIC structural door. Returns `[candidate tree]`; nothing is
+  published, because a render owns nothing."
+  [c view]
+  (let [cand (cell/candidate c fid)
+        tree (cell/with-capture cand (fn [] (t/render [view {:basket-id basket-id}])))]
+    [cand tree]))
+
+(defn- rendered-total
+  [tree]
+  (t/text (t/find tree #(= :output (:tag %)))))
+
+;; ---------------------------------------------------------------------------
+;; Loading, and the manifest the declaration now carries
+;; ---------------------------------------------------------------------------
+
+(deftest a-compiled-subscription-declaration-loads-and-reports-its-site
+  (testing "The declaration compiles, the var holds a view, and its manifest
+            names the subscription site the body actually carries — the query
+            the author wrote (including the prop-reading local symbol that used
+            to be evaluated), with a whole source coordinate. Loading is the
+            regression: before the runtime landed, requiring the census
+            namespace failed at macro expansion."
+    (is (v/view? compiled-view) "the compiled declaration produced a view")
+    (let [m (v/manifest compiled-view)]
+      (is (= 1 (count (:subscriptions m)))
+          "exactly the one subscription site the body carries")
+      (let [site (first (:subscriptions m))]
+        (is (= '[:basket/total basket-id] (:query site))
+            "the roster carries the AUTHORED query form, local symbol and all")
+        (is (string? (:sid site)))
+        (is (seq (:sid site)) "with a real lexical site id")
+        (is (= #{:file :line :column} (set (keys (:source-coord site))))
+            "and a whole source coordinate")
+        (is (pos-int? (:line (:source-coord site))))))))
+
+(deftest the-elision-verdict-matches-the-reactive-site-it-reports
+  (testing "A subscription is a reactive site, so the compiled tier retains the
+            ViewCell shell and says so — the verdict and the roster are one
+            fact, not two that could drift. The inert census arm is the control:
+            without it a `:present` verdict could be a constant."
+    (let [m (v/manifest compiled-view)]
+      (is (= :present (:view-cell m)))
+      (is (true? (:reactive? m)))
+      (is (contains? (:capabilities m) :sub)
+          "the capability set names the site that forced the shell"))
+    (testing "and the control — an inert compiled declaration still elides"
+      (let [m (v/manifest (:label mv/by-name))]
+        (is (= :elided (:view-cell m)))
+        (is (false? (:reactive? m)))
+        (is (empty? (:subscriptions m)))))))
+
+;; ---------------------------------------------------------------------------
+;; The read itself — both arms, one table
+;; ---------------------------------------------------------------------------
+
+(deftest a-read-outside-a-render-is-refused-identically-in-both-modes
+  (testing "Promotion cannot change what a read MEANS. A subscription read with
+            no active declared render has no owner in either mode, so both arms
+            are refused with the same stable diagnostic id rather than one of
+            them probing a value nobody owns."
+    (register-sub!)
+    (seed! {:baskets {basket-id {:total 42}}})
+    (doseq [[mode view] arms]
+      (is (false? (cell/observing?)) (str mode " — no active render"))
+      (is (= :rf.error/view-read-outside-render
+             (conf/caught-id #(rf/with-frame fid (t/render [view {:basket-id basket-id}]))))
+          (str mode " — refused loudly, with the id the other mode raises")))))
+
+(deftest a-render-read-observes-and-the-commit-owns-it-in-both-modes
+  (testing "The whole claim, arm for arm: the body reads the subscription's
+            current value, the render owns nothing, and the SELECTED commit
+            publishes the read as an owned dependency carrying that value. A
+            compiled body reaches this through `reactive/sub-read`; an
+            interpreted one through `v/sub`; both land in the one shell."
+    (register-sub!)
+    (seed! {:baskets {basket-id {:total 42}}})
+    (doseq [[mode view] arms]
+      (let [c           (cell/cell (keyword "compiled-reactive" (name mode)))
+            [cand tree] (render-under-capture! c view)]
+        (is (= "42" (rendered-total tree))
+            (str mode " — the rendered output carries the observed value"))
+        (is (empty? (cell/dependencies c))
+            (str mode " — before the commit the render owns nothing"))
+        (is (= :published (cell/commit! cand))
+            (str mode " — the render was current, so its bundle published"))
+        (is (= [query] (cell/dependency-queries c))
+            (str mode " — the commit owns exactly the query the body read"))
+        (is (= [42] (mapv :value (:observations (cell/evidence c))))
+            (str mode " — and the published bundle carries its value"))
+        (is (every? :owned? (:observations (cell/evidence c)))
+            (str mode " — as an OWNED dependency"))
+        (is (= 1 (count (cell/dependencies c)))
+            (str mode " — non-vacuous: one dependency, not zero"))))))
+
+(deftest a-changed-input-recomputes-and-recommits-in-both-modes
+  (testing "The repaint half. When the state a committed read depends on moves,
+            a re-render recomputes it and the commit republishes the whole
+            bundle against the SAME retained handle — acquire-before-release,
+            in both modes, with the compiled arm proving it through a proven
+            site key rather than a counted one."
+    (register-sub!)
+    (doseq [[mode view] arms]
+      ;; Re-seeded per arm: each mode starts from the same state and moves it
+      ;; itself, so the second arm proves the move rather than inheriting it.
+      (seed! {:baskets {basket-id {:total 42}}})
+      (let [c              (cell/cell (keyword "compiled-reactive-move" (name mode)))
+            [cand1 tree1]  (render-under-capture! c view)]
+        (is (= "42" (rendered-total tree1)))
+        (is (= :published (cell/commit! cand1)))
+        (let [site-key (first (keys (cell/dependencies c)))
+              handle1  (:handle (get (cell/dependencies c) site-key))]
+          (seed! {:baskets {basket-id {:total 99}}})
+          (is (= [42] (mapv :value (:observations (cell/evidence c))))
+              (str mode " — the committed bundle is unchanged until a re-commit"))
+          (let [[cand2 tree2] (render-under-capture! c view)]
+            (is (= "99" (rendered-total tree2))
+                (str mode " — the re-render recomputed the moved value"))
+            (is (= :published (cell/commit! cand2)))
+            (is (= [99] (mapv :value (:observations (cell/evidence c))))
+                (str mode " — and the bundle flipped as a unit"))
+            (is (identical? handle1 (:handle (get (cell/dependencies c) site-key)))
+                (str mode " — against the same retained handle"))
+            (is (= 1 (count (cell/dependencies c)))
+                (str mode " — non-vacuous: still exactly one dependency"))))))))
+
+;; ---------------------------------------------------------------------------
+;; The one difference, asserted as the identity it is
+;; ---------------------------------------------------------------------------
+
+(deftest the-compiled-read-is-owned-under-its-proven-lexical-site-id
+  (testing "The compiled tier does not count its way to a site — its analyzer
+            proved one and named it, and that name is what the manifest
+            publishes. So the key the shell files the committed dependency
+            under IS the manifest's `:sid`, and a tool holding a manifest can
+            find the dependency it describes. The interpreted twin is the
+            control: it has no proven site, so it files under the document
+            ordinal, which is the honest key an unrestricted body can offer."
+    (register-sub!)
+    (seed! {:baskets {basket-id {:total 42}}})
+    (let [sid (:sid (first (:subscriptions (v/manifest compiled-view))))
+          c   (cell/cell :compiled-reactive/keys)
+          [cand _] (render-under-capture! c compiled-view)]
+      (is (= :published (cell/commit! cand)))
+      (is (= [sid] (vec (keys (cell/dependencies c))))
+          "the committed dependency is keyed by the manifest's own site id")
+      (is (not= [0] (vec (keys (cell/dependencies c))))
+          "non-vacuous: it is the lexical id, not the ordinal that would also fit"))
+    (let [c        (cell/cell :interpreted-reactive/keys)
+          [cand _] (render-under-capture! c interpreted-basket-total)]
+      (is (= :published (cell/commit! cand)))
+      (is (= [0] (vec (keys (cell/dependencies c))))
+          "the interpreted control files under its document ordinal"))))

--- a/implementation/freehand/test/re_frame/freehand/manifest_roster_coverage_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/manifest_roster_coverage_cljs_test.cljc
@@ -16,14 +16,20 @@
 
   ## Two surfaces, and the gap named rather than hidden
 
-  `:events` and `:crossings` are read back through `v/manifest`, the highest
-  public surface there is. The other four cannot reach it today: `slot`,
-  `html` and `frame` are not published vars, and a compiled `(sub …)` lowers to
-  a runtime namespace that has not landed, so no declaration carrying one
-  compiles. They are proven one tier down, over the same analyzer `v/defview`
-  calls — and the gap is asserted, not assumed: an `:analyzer` roster must be
-  EMPTY across the public census, so the day one becomes reachable its fixture
-  row has to move deliberately.
+  `:subscriptions`, `:events` and `:crossings` are read back through
+  `v/manifest`, the highest public surface there is. The other three cannot
+  reach it: `slot`, `html` and `frame` have no published var behind them, so no
+  declaration can carry one. They are proven one tier down, over the same
+  analyzer `v/defview` calls — and the gap is asserted, not assumed: an
+  `:analyzer` roster must be EMPTY across the public census, so the day one
+  becomes reachable its fixture row has to move deliberately.
+
+  `:subscriptions` is the row that moved. It sat on the analyzer tier not
+  because `v/sub` was unpublished — it always was — but because the compiled
+  lowering resolved it against a runtime namespace that did not exist, so no
+  census declaration carrying a subscription could LOAD. The runtime landed,
+  the census gained a sub-bearing declaration, and this suite reddened until
+  the fixture row was moved: the tripwire doing exactly its job.
 
   ## Which host proves which half
 
@@ -62,13 +68,13 @@
 
 (def ^:private resolver
   "The injected resolution stub. `slot`, `html` and `frame` are analyzer-known
-  authoring forms with no published var behind them, and `sub` has one whose
-  compiled lowering targets a runtime namespace that has not landed — which is
-  precisely why these four rosters are proven here rather than through
-  `v/manifest`. The stub resolves them to the vars the door will publish."
+  authoring forms with no published var behind them — which is precisely why
+  those three rosters are proven here rather than through `v/manifest`. The
+  stub resolves them to the vars the door will publish. `sub` is deliberately
+  NOT among them any more: it is public, its compiled lowering runs, and its
+  roster is proven through `v/manifest` over the census like `:events` is."
   (fn [sym]
     (case sym
-      sub   {:fqn 're-frame.freehand/sub :meta {}}
       frame {:fqn 're-frame.freehand/frame :meta {}}
       slot  {:fqn 're-frame.freehand/slot :meta {}}
       html  {:fqn 're-frame.freehand/html :meta {}}
@@ -94,8 +100,7 @@
   "roster -> the site-index key the projection reads it from, and one body
   carrying EXACTLY the number of sites the fixture declares. Hand-countable, so
   a count that moves is an edit someone made rather than a number that drifted."
-  {:subscriptions {:site-key :subs      :template '[:span (sub [:probe/count])]}
-   :frame-ops     {:site-key :frame-ops :template '[:span (str (:frame (frame)))]}
+  {:frame-ops     {:site-key :frame-ops :template '[:span (str (:frame (frame)))]}
    :slots         {:site-key :slots     :template '[:ul (slot row-renderer item)]}
    :html-sites    {:site-key :htmls     :template '[:div (html "<b>probe</b>")]}})
 

--- a/implementation/freehand/test/re_frame/freehand/manifest_views.cljc
+++ b/implementation/freehand/test/re_frame/freehand/manifest_views.cljc
@@ -6,19 +6,23 @@
   lexical sites, so the manifest each one reports and the ViewCell-elision
   verdict each one earns are facts a reader can check against the source
   without running anything. Four declarations carry no reactive site and
-  OMIT the reactive ViewCell shell; two carry an event site and RETAIN it.
-  The exact omitted count is therefore four — an integer, not a threshold
-  — and that is what `FH-DIAG-002` asserts, while `FH-STRUCT-010` asserts
-  each declaration's finite manifest rosters against these bodies.
+  OMIT the reactive ViewCell shell; three carry one — two an event site,
+  one a subscription — and RETAIN it. The exact omitted count is therefore
+  four — an integer, not a threshold — and that is what `FH-DIAG-002`
+  asserts, while `FH-STRUCT-010` asserts each declaration's finite
+  manifest rosters against these bodies.
 
-  `sub` and `(frame)` reads are not part of the census: the reactive-read
-  authoring forms are recognised by the analyzer but are not yet public
-  vars on the door, so a census that must compile through the ordinary
-  `v/defview` uses the publicly reachable reactive discriminator — a
-  committed event handler. Only `:events` and `:crossings` are therefore
-  non-empty here. The four rosters this census cannot populate —
-  `:subscriptions`, `:frame-ops`, `:slots` and `:html-sites` — are
-  covered one tier down in
+  `v/sub` IS part of the census. It is a published var on the door, and
+  since the compiled tier's reactive runtime landed a compiled
+  declaration carrying one compiles and loads — so `:subscriptions` is
+  populated here, through `v/manifest`, like `:events` and `:crossings`.
+  (It was not, once, and the reason recorded in this docstring named the
+  wrong cause: the door published `v/sub` all along; what was missing was
+  the runtime namespace the compiled lowering resolves it against.)
+
+  The three rosters this census still cannot populate — `:frame-ops`,
+  `:slots` and `:html-sites` — need `frame`, `slot` and `html`, which are
+  not published vars. They are covered one tier down in
   `re-frame.freehand.manifest-roster-coverage-cljs-test`, which injects
   the resolver those forms need and asserts the gap rather than leaving
   it implied; `viewcell-elision-oracle-jvm-test` reads the elision
@@ -60,9 +64,18 @@
   [:div.host [label {:text text}]])
 
 ;; ---------------------------------------------------------------------------
-;; Present — a committed event handler is a reactive site, so the ViewCell
-;; shell is retained.
+;; Present — a reactive site, so the ViewCell shell is retained. A committed
+;; event handler reads the committed frame; a subscription reads state.
 ;; ---------------------------------------------------------------------------
+
+(v/defview basket-total
+  "One subscription, reading a query built from a prop. The reactive read
+  the compiled tier proves statically: the site is finite and lexical, so
+  it lands on the `:subscriptions` roster with the query the author wrote
+  — local symbol and all — and the view keeps its ViewCell."
+  {:compiled true}
+  [{:keys [basket-id]}]
+  [:output.total (v/sub [:basket/total basket-id])])
 
 (v/defview button
   "One committed event handler. An `:on-*` intent reads the committed
@@ -89,5 +102,6 @@
    :card         card
    :list-view    list-view
    :mounts-label mounts-label
+   :basket-total basket-total
    :button       button
    :two-buttons  two-buttons})

--- a/spec/conformance/freehand/fixtures/fh-diag-002.edn
+++ b/spec/conformance/freehand/fixtures/fh-diag-002.edn
@@ -5,15 +5,16 @@
 ;; function of the analyzed sites (EP-0036 D021), so the number of views that
 ;; omit the shell over a census of known cardinality is an exact integer.
 ;;
-;; The census is `re-frame.freehand.manifest-views`: six compiled views, four
-;; without a reactive site (elided) and two with a committed event handler
-;; (present). The count is four, and it is asserted as an integer, never a
-;; threshold.
+;; The census is `re-frame.freehand.manifest-views`: seven compiled views, four
+;; without a reactive site (elided) and three with one (present) — two carrying
+;; a committed event handler, one carrying a subscription. The count is four,
+;; and it is asserted as an integer, never a threshold.
 {:fh/id "FH-DIAG-002"
  :omitted-view-cell-count 4
  :views {:label        :elided
          :card         :elided
          :list-view    :elided
          :mounts-label :elided
+         :basket-total :present
          :button       :present
          :two-buttons  :present}}

--- a/spec/conformance/freehand/fixtures/fh-struct-010.edn
+++ b/spec/conformance/freehand/fixtures/fh-struct-010.edn
@@ -21,28 +21,32 @@
 ;; declaration's position, never omit the field and never invent a line.
 ;;
 ;; `:roster-coverage` is what stops that shape row being VACUOUS. A key contract
-;; asserted over zero entries passes loudest of all, and four of the six rosters
-;; are empty across the census, so the shape row was reading green on two of
-;; them. Each roster therefore declares how many entries the proof actually
+;; asserted over zero entries passes loudest of all, and three of the six
+;; rosters are still empty across the census, so the shape row would read green
+;; over nothing for them. Each roster therefore declares how many entries the proof actually
 ;; inspects — a positive integer, never a lower bound — and the SURFACE it
 ;; inspects them through:
 ;;
 ;;   :public   — reachable through the public door: a `v/defview` census
 ;;               declaration, read back with `v/manifest`.
 ;;   :analyzer — NOT reachable through the public door today, and named as a gap
-;;               rather than quietly omitted. `slot`, `html` and `frame` are not
-;;               published vars, and a compiled `(sub …)` lowers to a runtime
-;;               namespace that does not exist yet, so no census declaration
-;;               carrying one can compile. These rosters are proven one tier
-;;               down, over the same analyzer the door will call once those
-;;               forms are public.
+;;               rather than quietly omitted. `slot`, `html` and `frame` have no
+;;               published var behind them, so no census declaration can carry
+;;               one. These rosters are proven one tier down, over the same
+;;               analyzer the door will call once those forms are public.
+;;               `:subscriptions` used to sit here too — not because `v/sub` was
+;;               unpublished (it always was) but because the compiled lowering
+;;               resolved it against a runtime namespace that did not exist, so
+;;               no census declaration carrying one could LOAD. That runtime
+;;               landed and the row moved to `:public` — which is exactly the
+;;               deliberate move the split below exists to force.
 ;;
 ;; The split is ASSERTED, not assumed: an `:analyzer` roster must be empty across
 ;; the public census, so the day one becomes reachable its row has to move here
 ;; deliberately instead of drifting.
 {:fh/id "FH-STRUCT-010"
  :roster-coverage
- {:subscriptions {:surface :analyzer :entries 1}
+ {:subscriptions {:surface :public   :entries 1}
   :events        {:surface :public   :entries 3}
   :slots         {:surface :analyzer :entries 1}
   :html-sites    {:surface :analyzer :entries 1}
@@ -70,6 +74,9 @@
   {:events 0 :subscriptions 0 :slots 0 :frame-ops 0 :crossings 1
    :capabilities #{} :view-cell :elided :reactive? false
    :crossing {:view-id :re-frame.freehand.manifest-views/label :lowering :compiled}}
+  :basket-total
+  {:events 0 :subscriptions 1 :slots 0 :frame-ops 0 :crossings 0
+   :capabilities #{:sub} :view-cell :present :reactive? true}
   :button
   {:events 1 :subscriptions 0 :slots 0 :frame-ops 0 :crossings 0
    :capabilities #{:event} :view-cell :present :reactive? true}


### PR DESCRIPTION
Closes the cross-host half of the compiled-runtime hole: a `(v/sub …)` inside a `{:compiled true}` body lowers to `re-frame.freehand.reactive/sub-read`, and that namespace did not exist — so a compiled declaration carrying a subscription could not **load** through the public `v/defview` door, on either host.

## The pre-fix failure, transcript

The bead's own reproduction, run from `implementation/freehand` before the change:

```
$ clojure -M -e "(require '[re-frame.freehand :as v]) \
    (v/defview probe {:compiled true} [p] [:span (v/sub [:person/by-id (:id p)])])"

Syntax error (ClassNotFoundException) compiling at (REPL:1:83).
re-frame.freehand.reactive
```

The inert control succeeded and reported `:view-cell :elided`, which is exactly why every suite could stay green: nothing reachable carried a subscription.

There turned out to be **two** load-time causes, the second reachable only once the first was fixed. With the namespace in place the same declaration still failed:

```
Syntax error compiling at (REPL:3:1).
Unable to resolve symbol: id in this context
```

The descriptor entry spliced the manifest **unquoted**, and a subscription roster entry carries the *authored query form* — so `(v/sub [:basket/total basket-id])` evaluated the body's own local symbol where no such local exists. Only a subscription site puts a symbol in a manifest, so this was unreachable while the first cause was open. Both are fixed; after the change:

```
:view-cell :present :reactive? true
:capabilities #{:sub}
:subscriptions [{:sid sid1-da3bc45ec6f892a1, :query [:person/by-id id],
                 :source-coord {:file …, :line 3, :column 57}, :path [0]}]
```

## What landed

- **`re-frame.freehand.reactive/sub-read`** — the compiled tier's render-time reactive read. It is a *doorway*, not a system: it calls the atomic shell's `observe-site!`, keyed by the analyzer's proven **lexical site id** instead of the interpreted walk's document ordinal. Same capture, same same-thread rule, same outside-render diagnostic, same stabilization, same commit. There is no second reactive path, cache or commit discipline.
- **`cell/observe-site!`** beside `cell/observe!` — one shared `record-read!` under both, so the two modes cannot drift by construction.
- **`cell` publishes its dependency ORDER**, so `dependency-queries` answers render order for a proven-site key as well as for an ordinal (sorting the keys only happened to work for integers).
- **The door requires the runtime**, for the same reason it already requires `node`: promotion is a one-line change to a declaration and must not oblige a consumer to acquire a require.
- **The descriptor's manifest entry is quoted.**
- **The census docstring's stated cause was wrong and is corrected.** It claimed `v/sub` was "not yet a public var on the door". `v/sub` shipped public; the blocker was always the runtime namespace.

## Which manifest rosters became reachable

`:subscriptions` — and only that one. The census (`re-frame.freehand.manifest-views`) gains one sub-bearing compiled declaration, so `FH-STRUCT-010`'s coverage row moves from `:analyzer` to `:public`.

**The compiled-schemas tripwire fired exactly as designed.** `manifest-roster-coverage-cljs-test` asserts that every `:analyzer` roster is EMPTY across the public census; the moment `basket-total` landed, that test reddened until the fixture row was moved deliberately. That is the mechanism working. `:frame-ops`, `:slots` and `:html-sites` stay on the analyzer tier — `frame`, `slot` and `html` have no published var behind them — and the `sub` stub is removed from that suite's injected resolver, because the public census now proves the roster.

`FH-DIAG-002` gains its row. **The omitted-ViewCell count is unchanged at exactly four** (a subscription is a reactive site, so the new declaration *retains* its shell: seven views, four elided, three present).

## Honest scoping: the browser half is a separate tier, and the gap is wider than the bead documents

The mayor asked for an enumeration rather than the bead's list. Every `re-frame.freehand.*/var` the compiled emitters name, resolved:

| namespace | status | named by |
|---|---|---|
| `reactive` | **landed here** (`sub-read`) | analyzer lowering, both hosts |
| `runtime` | absent — 22 vars | `emit_cljs` |
| `viewcell` | absent — 4 vars | `emit_cljs/emit-defview` |
| `hooks` | absent — 12 vars | analyzer lowering of `local` / `effect` / `v/ref` / react hooks |
| `frames` | absent — 5 vars | analyzer `(frame)`, `:frame-root`, `:frame-provider` |
| `client` | absent — 6 vars | `compiler/root.cljc` |

Absent **vars** in namespaces that do exist: `events/{data-handler, event-handler, handler-callback, dynamic-handler, passive-ref, value-placeholder, checked-placeholder, key-placeholder}`; `react/{lazy, use-context, use-effect, use-effect-event, use-id, use-layout-effect}`; `tree/{view-boundary, register-view!, jvm-host-op!, opaque-foreign, render-fn, slot-ready?, check-slot-arity!, client-only-fallback, emit-static-html, render-root-tree}`.

Crossing the `:re-frame.freehand/v1` grammar with the published door, **`reactive/sub-read` is the only one of those reachable today.** `hooks/*` and `frames/*` need `local`, `effect`, `v/ref`, `frame`, `frame-root` or `frame-provider`, none of which is a published var or an admitted op. And `runtime/*` / `viewcell/*` are named **only** by `emit_cljs/emit-defview`, which `v/defview` does not call: the public door calls `compiler/compile-structural-view`, which uses `emit_jvm/emit-structural-body` on *both* hosts.

The consequence is worth stating plainly: **no compiled view is browser-mountable today, subscription or not.** `re-frame.freehand.react/interpreted-component` refuses every compiled declaration with a deliberate `:rf.error/view-lowering-unavailable` — "the compiled tier's React lowering is not built yet … it lands with the slice that owns the ViewCell it renders inside". That gap is not caused by the missing `reactive` namespace and is not closed by adding it, and closing it is design work rather than transcription: `emit_cljs` is the donor's emitter and targets a donor ABI Freehand does not have (a `defview` var holds a **descriptor**, not a React component; the donor's event flags pre-encode a controlled-input `:sync` bit Freehand derives from element facts at record time, through one `events/site` taking an explicitly threaded candidate the compiled lowering has none of; `emit-defview` emits a whole `def` where the door needs a body on the descriptor; and the two props ABIs disagree).

Split to **rf2-drpa3.113** with the full inventory, the four ABI mismatches, and the browser acceptance criteria. **No new public verb was added**, so the api-manifest serial lane is untouched.

## Quality gates

All foreground, one at a time, from this worktree.

| gate | result |
|---|---|
| `cd implementation/freehand && clojure -M:test` | **573 tests, 3862 assertions, 0 failures, 0 errors** |
| `npm run test:freehand` | **467 tests, 3169 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` | **10592 tests, 53262 assertions, 0 failures, 0 errors** |
| `npm run test:browser` | **542 tests, 3170 assertions, 0 failures, 0 errors** |
| `npm run test:elision` | **PASS** — production 60/60 absent (1 108 456 chars); EP-0023 1/1 provenance-survives + 2/2 assembly-DCE; control 60/60 present (1 280 496 chars) |
| `python scripts/check_freehand_conformance_index.py` | exit 0 |
| `python scripts/check_donor_inventory.py` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `git grep 're-frame.ui' implementation/freehand/` | empty |

**Elision did not regress.** The probe is green with the same 60/60 absent, and the manifest-level verdict is unchanged: the omitted-ViewCell count is still the exact integer **4**.

**Non-vacuity.** In `compiled-reactive-cljs-test`, the site-identity assertion `(= [sid] (vec (keys (cell/dependencies c))))` was inverted to `(= [(str sid "-INVERTED")] …)`. The full JVM gate reddened naming the test:

```
Testing re-frame.freehand.compiled-reactive-cljs-test
FAIL in (the-compiled-read-is-owned-under-its-proven-lexical-site-id) (compiled_reactive_cljs_test.cljc:236)
Ran 573 tests containing 3862 assertions.
1 failures, 0 errors.
```

Restored and verified byte-identical (`sha256 41199a45e058ee3f36f52c6937129876d105eebf3e9679da74997e1949e360ca`, clean working tree).

## What the new suite proves

`compiled-reactive-cljs-test` runs on both hosts. **Its loading is the regression** — requiring a compiled sub-bearing declaration is what used to fail, and it failed at compile, so the suite cannot be green for the wrong reason. On top of that it proves **semantic agreement arm for arm**: the compiled census view and a hand-written interpreted twin run the same table — refused identically outside a render (`:rf.error/view-read-outside-render`), observing the same value through the public `t/render` door, owning the same query, flipping the same bundle against the same retained handle on a state change. The one deliberate difference is asserted as the identity it is: the compiled read is filed under the manifest's own `:sid`, and the interpreted control under its document ordinal.
