### PR TITLE
fix(freehand): keep error attribution failure-local across overlapping throws (rf2-drpa3.106)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/errors.cljc
+++ b/implementation/freehand/src/re_frame/freehand/errors.cljc
@@ -220,53 +220,89 @@
   wrong file."
   :re-frame.freehand/unknown-view)
 
-(def ^:private failing-view
-  "The declared view whose render threw and has not yet been attributed to
-  a boundary. One slot, because a throw is unwound to exactly one catcher."
-  (atom nil))
+(def ^:private failing-views
+  "Which declared view threw WHICH failure — the attribution relay, keyed by
+  the THROWN VALUE'S IDENTITY and held WEAKLY.
+
+  The thrown value is the only thing thrower and catcher demonstrably share:
+  the occurrence seam has it in hand as it rethrows, and the boundary has
+  the same object at the catch (React hands it to `componentDidCatch`
+  verbatim). Keying on it is what makes attribution FAILURE-LOCAL — one
+  note per throw, readable only by the catch that caught THAT throw.
+
+  A single slot cannot express that. Two failures are routinely in flight at
+  once: React finishes rendering every failed subtree of a commit before it
+  runs any `componentDidCatch`, and the structural host renders on whatever
+  thread asked it to. With one slot the first note wins and the second
+  thrower is lost — one report names a view that did not fail this failure
+  while the other goes out as [[unknown-view-id]] for a thrower that was
+  plainly observed — and a note nothing ever collected waits to be read by
+  the next unrelated boundary.
+
+  Weak keys make the lifetime the throw's own: a note lives exactly as long
+  as something still holds the exception it describes, so nothing has to be
+  cleared and nothing accumulates."
+  #?(:clj  (java.util.Collections/synchronizedMap (java.util.WeakHashMap.))
+     :cljs (js/WeakMap.)))
+
+(defn- attributable?
+  "Whether `thrown` can carry a note. The JVM catch clause yields a
+  Throwable; ClojureScript's `:default` catches whatever was thrown, and a
+  relay key must be an object — `(Object x)` answers `x` itself exactly when
+  `x` already is one, which `instance?` cannot say across realms. A thrown
+  primitive is unattributable, and the report says so rather than guessing."
+  [thrown]
+  #?(:clj  (some? thrown)
+     :cljs (and (some? thrown) (identical? thrown (js/Object thrown)))))
 
 (defn note-failing-view!
-  "Record `view-id` as the declared view whose render threw — called by the
-  OCCURRENCE seam of each host (the React function component the interpreted
-  emitter builds, the structural walk's mount) as the throw passes through
-  it, and by nothing else.
+  "Record `view-id` as the declared view whose render threw `thrown` —
+  called by the OCCURRENCE seam of each host (the React function component
+  the interpreted emitter builds, the structural walk's mount) as that throw
+  passes through it, and by nothing else.
 
-  The FIRST writer wins, because the innermost occurrence is the one that
-  threw: on a host where occurrences nest (the structural walk's mount calls
-  the walk which calls mount again) the throw unwinds outward through every
-  enclosing occurrence, and each of those is a bystander that would
-  otherwise overwrite the culprit with itself.
-
-  The note is consumed by [[attributed-failure]] at the catch. A throw that
-  NO boundary contains leaves its note behind — on a host where that
-  happens the root has already been torn down, so the residue outlives
-  nothing that could read it."
-  [view-id]
-  (swap! failing-view #(if (nil? %) view-id %))
+  The FIRST writer for a given throw wins, because the innermost occurrence
+  is the one that threw: the throw unwinds outward through every enclosing
+  occurrence, and each of those is a bystander that would otherwise
+  overwrite the culprit with itself. First-writer-wins is scoped to the ONE
+  throw — a concurrent or interleaved failure is a different key and neither
+  claims nor clears the other's note."
+  [thrown view-id]
+  (when (attributable? thrown)
+    #?(:clj  (.putIfAbsent ^java.util.Map failing-views thrown view-id)
+       :cljs (when-not (.has ^js failing-views thrown)
+               (.set ^js failing-views thrown view-id))))
   nil)
 
-(defn- take-failing-view!
-  "The noted failing view, cleared — nil when no occurrence noted one."
-  []
-  (first (reset-vals! failing-view nil)))
+(defn- noted-failing-view
+  "The view noted for `thrown`, or nil when no occurrence noted one. Reading
+  is not consuming: the note belongs to the throw, so a host that catches
+  the same throw twice (StrictMode, an HMR re-render) reads the same
+  answer."
+  [thrown]
+  (when (attributable? thrown)
+    #?(:clj  (.get ^java.util.Map failing-views thrown)
+       :cljs (.get ^js failing-views thrown))))
 
 (defn attributed-failure
   "Answer `caught` — a host's raw material for one failure — carrying the
   identity of the declared view that actually threw, resolved from the
-  occurrence seam's note ([[note-failing-view!]]).
+  occurrence seam's note on `caught`'s own `:exception`
+  ([[note-failing-view!]]).
 
   This is the whole value of a failure report. A record that names the
   boundary rather than the failing descendant sends a reader to the wrong
   file, and because the [[fingerprint]] is derived from the view id and the
   phase, it also collapses every failure under one boundary onto a SINGLE
   correlation token — two unrelated bugs indistinguishable because they
-  share a catcher.
+  share a catcher. A record that named some OTHER failure's thrower is worse
+  again: it is a confident identification of an innocent view.
 
-  When nothing was noted the record says so — [[unknown-view-id]], evidence
-  marked incomplete, and a `:loss` naming why — rather than substituting an
-  identity it does not have."
-  [caught]
-  (if-let [failing (take-failing-view!)]
+  When nothing was noted for this throw the record says so —
+  [[unknown-view-id]], evidence marked incomplete, and a `:loss` naming why
+  — rather than substituting an identity it does not have."
+  [{:keys [exception] :as caught}]
+  (if-let [failing (noted-failing-view exception)]
     (assoc caught :view-id failing)
     (assoc caught
            :view-id   unknown-view-id
@@ -566,13 +602,11 @@
   [^Boundary b render-thunk context]
   (if (= :failed (status b))
     {:status :contained :summary (:summary (failure b))}
-    (do
-      ;; Enter the guarded region with the attribution relay EMPTY: a note
-      ;; left behind by an earlier throw that nothing contained is not this
-      ;; region's, and reading it as such would name an innocent view.
-      (take-failing-view!)
-      (try
-        {:status :ok :result (render-thunk)}
-        (catch #?(:clj Throwable :cljs :default) e
-          (let [record (capture! b (attributed-failure (assoc context :exception e)))]
-            {:status :contained :summary (:summary record)}))))))
+    (try
+      {:status :ok :result (render-thunk)}
+      (catch #?(:clj Throwable :cljs :default) e
+        ;; The attribution read is keyed by THIS throw, so the guarded region
+        ;; needs no scrubbing on the way in and cannot read a note left by a
+        ;; failure that is not the one it caught.
+        (let [record (capture! b (attributed-failure (assoc context :exception e)))]
+          {:status :contained :summary (:summary record)})))))

--- a/implementation/freehand/src/re_frame/freehand/react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/react.cljs
@@ -307,13 +307,18 @@
                       ;; view in its own component, so a throw arriving here
                       ;; is THIS view's body's — the boundary that catches it
                       ;; several fibers above has no other way to learn whose,
-                      ;; and the throwable carries no view identity.
+                      ;; and the throwable carries no view identity. The note
+                      ;; rides the thrown value, which is the one thing this
+                      ;; render and that catch demonstrably share: React
+                      ;; finishes rendering every failed subtree of a commit
+                      ;; before it runs any `componentDidCatch`, so two
+                      ;; failures are routinely in flight at once.
                       (try
                         (emit cand
                               (body (conv/forward-children
                                       (gobj/get js-props "props"))))
                         (catch :default e
-                          (eb/note-failing-view! view-id)
+                          (eb/note-failing-view! e view-id)
                           (throw e)))))))))]
     (gobj/set c "displayName" (str view-id))
     c))

--- a/implementation/freehand/src/re_frame/freehand/tree.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tree.cljc
@@ -295,13 +295,14 @@
           ;; is this view's, and an enclosing boundary has no other way to
           ;; learn whose it was — the throwable carries no view identity, and
           ;; a boundary that guessed would name the guarded child or itself.
-          ;; The note is dropped if an inner occurrence already made one.
+          ;; The note is against THIS throw, and is dropped if an inner
+          ;; occurrence already made one for it.
           kids    (try
                     (if-let [structural (descriptor/structural-body view)]
                       (node/children (structural props*))
                       (children [((descriptor/render-body view) props*)]))
                     (catch #?(:clj Throwable :cljs :default) e
-                      (eb/note-failing-view! view-id)
+                      (eb/note-failing-view! e view-id)
                       (throw e)))]
       (node/boundary view-id props key kids))))
 

--- a/implementation/freehand/test/re_frame/freehand/errors_concurrency_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/errors_concurrency_jvm_test.clj
@@ -109,17 +109,16 @@
                                           (throw e))))
                                     {:phase :render :frame-id nil}))))
           quiet   (future
-                    (do
-                      (rendezvous! barrier)                      ; 1
-                      (rendezvous! barrier)                      ; 2
-                      ;; Enter a containment NOW — after the peer's note, before
-                      ;; the peer's catch.
-                      (let [b (eb/boundary eb/boundary-view-id :rk)]
-                        (eb/contain b
-                                    (fn []
-                                      (rendezvous! barrier)      ; 3
-                                      (tree/render [healthy {}]))
-                                    {:phase :render :frame-id nil}))))
+                    (rendezvous! barrier)                        ; 1
+                    (rendezvous! barrier)                        ; 2
+                    ;; Enter a containment NOW — after the peer's note, before
+                    ;; the peer's catch.
+                    (let [b (eb/boundary eb/boundary-view-id :rk)]
+                      (eb/contain b
+                                  (fn []
+                                    (rendezvous! barrier)        ; 3
+                                    (tree/render [healthy {}]))
+                                  {:phase :render :frame-id nil})))
           summary (deref failing 15000 ::timeout)
           outcome (deref quiet 15000 ::timeout)]
       (is (not= ::timeout summary) "the failing walk finished")

--- a/implementation/freehand/test/re_frame/freehand/errors_concurrency_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/errors_concurrency_jvm_test.clj
@@ -1,0 +1,131 @@
+(ns re-frame.freehand.errors-concurrency-jvm-test
+  "FH-ERROR-003 under OVERLAPPING failures — attribution is failure-local.
+
+  The structural host renders on whatever thread asked it to, and a server
+  rendering two responses runs two walks at once. Each walk may contain its
+  own failure, and the two are unrelated: they have different throwers,
+  different boundaries, and different readers. Attribution that lived in one
+  process-wide slot cannot represent both — the second thrower's identity is
+  dropped, stolen, or cleared by the first, and a report that named the wrong
+  view would send its reader to the wrong file while the failure it was
+  actually about went out as `unknown-view`.
+
+  This suite is JVM-only because the defect it guards is only reachable where
+  two renders genuinely overlap. The single-threaded shape of the same law —
+  an abandoned throw, a later unrelated boundary — is cross-host and lives in
+  `errors-tree-cljs-test`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand.descriptor :as descriptor]
+            [re-frame.freehand.errors :as eb]
+            [re-frame.freehand.tree :as tree])
+  (:import [java.util.concurrent BrokenBarrierException CyclicBarrier TimeUnit]))
+
+(def ^:private thrower-a
+  (descriptor/declare-view
+    {:view-id :audit/a :lowering :interpreted :children-policy :optional
+     :render  (fn [_] (throw (ex-info "A's render threw" {})))}))
+
+(def ^:private thrower-b
+  (descriptor/declare-view
+    {:view-id :audit/b :lowering :interpreted :children-policy :optional
+     :render  (fn [_] (throw (ex-info "B's render threw" {})))}))
+
+(defn- rendezvous!
+  "Wait for the other walk to reach the same point, or fail loudly. A
+  deadlock here is a test bug, never a silent pass."
+  [^CyclicBarrier barrier]
+  (try
+    (.await barrier 10 TimeUnit/SECONDS)
+    (catch BrokenBarrierException _ nil)))
+
+(defn- contained-summary-in-lockstep
+  "Walk `child` under a fresh boundary on THIS thread, rendezvousing with the
+  peer walk twice: once inside the guarded region before anything has thrown,
+  and once after the occurrence seam has seen the throw but before the
+  boundary catches it. Both walks are therefore mid-failure at the same
+  instant — the overlap a process-wide relay cannot represent."
+  [child ^CyclicBarrier barrier]
+  (let [b (eb/boundary eb/boundary-view-id :rk)]
+    (:summary
+      (eb/contain b
+                  (fn []
+                    (rendezvous! barrier)
+                    (try
+                      (tree/render child)
+                      (catch Throwable e
+                        ;; The seam noted this walk's thrower a frame ago.
+                        (rendezvous! barrier)
+                        (throw e))))
+                  {:phase :render :frame-id nil}))))
+
+(deftest fh-error-003-two-overlapping-walks-keep-their-own-attribution
+  (testing "Per FH-ERROR-003: two boundaries containing two different
+            failures at the same instant each name their OWN thrower. One
+            relay slot cannot: the first note wins and the second walk's
+            thrower is lost, so one report names a view that did not fail
+            this failure and the other reports `unknown-view` for a thrower
+            that was plainly observed."
+    (let [barrier (CyclicBarrier. 2)
+          a       (future (contained-summary-in-lockstep [thrower-a {}] barrier))
+          bb      (future (contained-summary-in-lockstep [thrower-b {}] barrier))
+          summaries [(deref a 15000 ::timeout) (deref bb 15000 ::timeout)]]
+      (is (not-any? #{::timeout} summaries) "both walks finished")
+      (is (= #{:audit/a :audit/b} (set (map :view-id summaries)))
+          "each overlapping failure names its own thrower")
+      (is (not-any? #(= eb/unknown-view-id (:view-id %)) summaries)
+          "and neither is suppressed into unknown by the other")
+      (is (= 2 (count (set (map :fingerprint summaries))))
+          "so the two failures carry two correlation tokens")
+      (is (every? #(true? (:complete? (:evidence %))) summaries)
+          "with complete evidence on both — nothing was lost to the overlap"))))
+
+(def ^:private healthy
+  (descriptor/declare-view
+    {:view-id :audit/healthy :lowering :interpreted :children-policy :optional
+     :render  (fn [_] [:span "ok"])}))
+
+(deftest fh-error-003-an-overlapping-walk-does-not-clear-a-peers-attribution
+  (testing "Per FH-ERROR-003: the reverse hazard. A peer walk that ENTERS a
+            containment while this walk is already mid-failure must not wipe
+            what this walk's seam observed. Only ONE walk here fails; the
+            other is a bystander that never throws at all, and it opens its
+            guarded region in the window between the failing walk's note and
+            the failing walk's catch. A boundary that scrubbed shared
+            attribution state on entry would erase a peer's observed thrower
+            and turn a perfectly attributable failure into `unknown-view` —
+            with no failure of its own to show for it."
+    (let [barrier (CyclicBarrier. 2)
+          failing (future
+                    (let [b (eb/boundary eb/boundary-view-id :rk)]
+                      (:summary
+                        (eb/contain b
+                                    (fn []
+                                      (rendezvous! barrier)      ; 1: both inside
+                                      (try
+                                        (tree/render [thrower-a {}])
+                                        (catch Throwable e
+                                          (rendezvous! barrier)  ; 2: the note is made
+                                          (rendezvous! barrier)  ; 3: the peer has entered
+                                          (throw e))))
+                                    {:phase :render :frame-id nil}))))
+          quiet   (future
+                    (do
+                      (rendezvous! barrier)                      ; 1
+                      (rendezvous! barrier)                      ; 2
+                      ;; Enter a containment NOW — after the peer's note, before
+                      ;; the peer's catch.
+                      (let [b (eb/boundary eb/boundary-view-id :rk)]
+                        (eb/contain b
+                                    (fn []
+                                      (rendezvous! barrier)      ; 3
+                                      (tree/render [healthy {}]))
+                                    {:phase :render :frame-id nil}))))
+          summary (deref failing 15000 ::timeout)
+          outcome (deref quiet 15000 ::timeout)]
+      (is (not= ::timeout summary) "the failing walk finished")
+      (is (not= ::timeout outcome) "and so did the bystander")
+      (is (= :ok (:status outcome)) "the bystander rendered — it never failed")
+      (is (= :audit/a (:view-id summary))
+          "and the failing walk still names the view that threw")
+      (is (true? (:complete? (:evidence summary)))
+          "with complete evidence — the bystander took nothing from it"))))

--- a/implementation/freehand/test/re_frame/freehand/errors_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/errors_dom_cljs_test.cljs
@@ -90,6 +90,12 @@
   [_]
   (throw (ex-info "a grandchild render threw" {})))
 
+(v/defview failing-fallback
+  "A FALLBACK that itself throws — the second failure, which the boundary
+  above the failing one has to catch and name."
+  [_]
+  (throw (ex-info "a fallback render threw" {})))
+
 (v/defview healthy-wrapper
   "Renders fine itself and mounts the view that throws — so the guarded
   child, the catcher, and the thrower are three different views."
@@ -168,6 +174,29 @@
                (fn [e]
                  (teardown! container root close!)
                  (js/Promise.reject e))))))
+
+(defn- mount-form!
+  "Render one Freehand `form` into a fresh root and answer a promise of every
+  private egress record the commit promoted, in promotion order."
+  [form]
+  (let [[container root] (mount!)
+        {:keys [egress close!]} (open-channels!)]
+    (-> (act #(.render root (fr/element form)))
+        (.then (fn [_]
+                 (let [records @egress]
+                   (teardown! container root close!)
+                   records))
+               (fn [e]
+                 (teardown! container root close!)
+                 (js/Promise.reject e))))))
+
+(defn- guard
+  "One boundary over `child`, reporting through the fixture's `:on-error`."
+  [child]
+  [v/error-boundary {:fallback  [:p {:class "fallback"} "contained"]
+                     :reset-key (:reset-key-1 error-002)
+                     :on-error  (:on-error error-002)}
+   child])
 
 ;; ===========================================================================
 ;; FH-ERROR-002 (browser) — the INITIAL-MOUNT generation is promoted.
@@ -343,6 +372,77 @@
                    (fn [e]
                      (is false (str "mount rejected: " e))
                      (done))))))))
+
+(deftest fh-error-003-two-sibling-boundaries-failing-together-each-name-their-own
+  (testing "Per FH-ERROR-003 (browser): two sibling boundaries over two
+            different failing views, mounted in ONE React commit. React
+            finishes rendering BOTH failed subtrees before either
+            `componentDidCatch` runs, so the two failures are in flight at
+            the same time — and each report must still name the view that
+            threw it. Attribution held in one shared slot cannot do this: the
+            first thrower's id is the only one kept, so one report names a
+            view that did not fail this failure and the other goes out as
+            `unknown-view` for a thrower that was plainly observed. Both
+            readers are then sent to the wrong file, and the two bugs share
+            one correlation token."
+    (if-not (browser?)
+      (skip! "the browser job runs the sibling-attribution assertions")
+      (async done
+        (reset! throwing? true)
+        (-> (mount-form! [:div
+                          (guard [guarded-child {}])
+                          (guard [other-guarded-child {}])])
+            (.then (fn [records]
+                     (let [ids (set (map #(:view-id (:summary %)) records))]
+                       (is (= 2 (count records))
+                           "both boundaries contained and both reported")
+                       (is (= #{(id-of guarded-child) (id-of other-guarded-child)} ids)
+                           "each report names its own thrower")
+                       (is (not (contains? ids eb/unknown-view-id))
+                           "neither failure was suppressed into unknown by the other")
+                       (is (= 2 (count (set (map #(:fingerprint (:summary %)) records))))
+                           "so the two failures carry two correlation tokens"))
+                     (done))
+                  (fn [e]
+                    (is false (str "mount rejected: " e))
+                    (done))))))))
+
+(deftest fh-error-003-a-failure-inside-a-fallback-is-attributed-to-the-fallback
+  (testing "Per FH-ERROR-003 (browser): a fallback is ordinary markup and may
+            fail like any other, so it may guard itself. That makes two
+            failures in ONE commit that are causally ordered — the second is
+            rendered BECAUSE the first was caught — and the second is
+            observed before the first has been reported. Each boundary must
+            still name its own thrower: the outer one the guarded child, the
+            one inside the fallback the view that failed inside the fallback.
+            A shared relay hands the first thrower to whichever catch runs
+            first and leaves the other with `unknown-view`."
+    (if-not (browser?)
+      (skip! "the browser job runs the nested-fallback assertions")
+      (async done
+        (reset! throwing? true)
+        (-> (mount-form!
+              [v/error-boundary
+               {:fallback  [v/error-boundary
+                            {:fallback  [:p {:class "inner"} "fallback contained"]
+                             :reset-key (:reset-key-1 error-002)
+                             :on-error  (:on-error error-002)}
+                            [failing-fallback {}]]
+                :reset-key (:reset-key-1 error-002)
+                :on-error  (:on-error error-002)}
+               [guarded-child {}]])
+            (.then (fn [records]
+                     (let [ids (set (map #(:view-id (:summary %)) records))]
+                       (is (= 2 (count records))
+                           "both failures were contained and both reported")
+                       (is (= #{(id-of guarded-child) (id-of failing-fallback)} ids)
+                           "the guarded child's failure and the fallback's are told apart")
+                       (is (not (contains? ids eb/unknown-view-id))
+                           "and neither borrowed or lost the other's identity"))
+                     (done))
+                  (fn [e]
+                    (is false (str "mount rejected: " e))
+                    (done))))))))
 
 ;; ===========================================================================
 ;; Non-vacuity probe — the channels are really open and the child really

--- a/implementation/freehand/test/re_frame/freehand/errors_tree_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/errors_tree_cljs_test.cljc
@@ -169,6 +169,49 @@
       (is (= {:reason :failing-view-unobserved} (:loss (:evidence summary)))
           "naming why"))))
 
+(deftest fh-error-003-an-abandoned-throw-cannot-attribute-a-later-failure
+  (testing "Per FH-ERROR-003: attribution belongs to the FAILURE, not to the
+            boundary that happens to catch next. A throw that passed an
+            occurrence seam and was then swallowed — retry logic, a probe, a
+            body that catches its own child — is abandoned: nothing will ever
+            report it. The DIFFERENT failure that reaches the boundary
+            afterwards must still name its own thrower. Reading the abandoned
+            note here names an innocent view and, because the fingerprint
+            derives from it, files the new bug under the old one's
+            correlation token."
+    (let [b       (eb/boundary eb/boundary-view-id :rk)
+          summary (:summary
+                    (eb/contain
+                      b
+                      (fn []
+                        ;; Abandoned: seen by :app/throwing's seam, swallowed here.
+                        (try (tree/render [throwing-child {}])
+                             (catch #?(:clj Throwable :cljs :default) _ nil))
+                        ;; The failure that actually reaches the boundary.
+                        (tree/render [other-throwing-child {}]))
+                      {:phase :render :frame-id nil}))]
+      (is (= :app/other-throwing (:view-id summary))
+          "the view that threw THIS failure, not the abandoned one")
+      (is (= (eb/fingerprint :app/other-throwing :render) (:fingerprint summary))
+          "and the correlation token follows the real thrower"))))
+
+(deftest fh-error-003-an-uncontained-throw-leaves-nothing-a-later-boundary-reads
+  (testing "Per FH-ERROR-003: a throw that NOTHING contains — it escaped the
+            root — was still seen by an occurrence seam on the way out. A
+            boundary mounted afterwards, catching an entirely unrelated and
+            unobservable failure, must still report the truthful unknown: the
+            escaped throw's identity belongs to the escaped throw."
+    (is (thrown? #?(:clj Throwable :cljs :default)
+                 (tree/render [:div [throwing-child {}]]))
+        "the throw escapes with no boundary to contain it")
+    (let [b       (eb/boundary eb/boundary-view-id :rk)
+          summary (:summary (eb/contain b
+                                        #(throw (ex-info "raw" {}))
+                                        {:phase :render :frame-id nil}))]
+      (is (= eb/unknown-view-id (:view-id summary))
+          "the later boundary reports what IT observed — nothing")
+      (is (= {:reason :failing-view-unobserved} (:loss (:evidence summary)))))))
+
 ;; ===========================================================================
 ;; The exact-one-child grammar — the interpreted half of the table the
 ;; compiled analyzer already refuses (`analyze-reject-cljs-test`

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -1056,6 +1056,14 @@ summary says so: the view id is `:re-frame.freehand/unknown-view` and the
 evidence is incomplete with a `:loss` naming why. Truthful ignorance, never the
 boundary's own id in the failing slot.
 
+Attribution is **failure-local**: it belongs to the throw, not to the boundary
+that catches next. Failures overlap routinely — a host may finish rendering
+every failed subtree of a commit before it reports any of them, a fallback may
+fail while the failure it replaced is still unreported, and two renders may run
+at once — and each report names the view that threw the failure that report is
+about. One failure can neither borrow, suppress, nor erase another's identity,
+and a failure nothing ever reported leaves nothing a later boundary can read.
+
 The summary carries **nothing** host-shaped: not the raw exception, not
 `ex-data`, not props, not app-db, not event payloads — every one of those is a
 data-classification hazard, and the envelope is what may reach an event vector


### PR DESCRIPTION
The occurrence-seam relay that PR #6732 introduced held **one process-wide
slot**, on the reasoning that a throw unwinds to exactly one catcher. It does —
but not one at a time. React finishes rendering every failed subtree of a commit
before it runs any `componentDidCatch`, and the structural walk renders on
whatever thread asked it to. First-writer-wins then keeps the first thrower and
drops the second: one report names a view that did not fail that failure, the
other goes out as `unknown-view` for a thrower that was plainly observed, and a
note nothing ever collected waits in the slot for the next unrelated boundary to
read.

## The repair

Key the relay by the **thrown value's identity** — the one thing thrower and
catcher demonstrably share, since React hands `componentDidCatch` the same
object the seam rethrew. First-writer-wins is now scoped to one throw, so an
enclosing occurrence still cannot overwrite the culprit while a concurrent
failure neither claims nor clears it. Weak keys (`WeakHashMap` on the JVM,
`WeakMap` in the browser) make a note's lifetime the throw's own, which retires
the entry-time scrub of the guarded region in `contain` along with the residue
it existed to hide.

Bounded exactly as the bead required: no public API, no component-stack parser,
no component registry, no async-context machinery, **no new diagnostic id**. The
egress field set is unchanged, and a throw no occurrence observed still reports
the truthful `:re-frame.freehand/unknown-view` with `:complete? false` and
`:loss {:reason :failing-view-unobserved}`.

## The cross-contamination, reproduced on main first

Every new assertion was run red against `origin/main` before the fix.

**Two overlapping structural walks** (`errors-concurrency-jvm-test`), each
containing its own failure, rendezvoused so both are mid-failure at the same
instant:

```
FAIL in (fh-error-003-two-overlapping-walks-keep-their-own-attribution)
expected: (= #{:audit/b :audit/a} (set (map :view-id summaries)))
  actual: (not (= #{:audit/b :audit/a} #{:audit/b :re-frame.freehand/unknown-view}))

FAIL in (fh-error-003-two-overlapping-walks-keep-their-own-attribution)
expected: (not-any? #(= eb/unknown-view-id (:view-id %)) summaries)
  actual: … :view-id :re-frame.freehand/unknown-view … :loss {:reason :failing-view-unobserved} …
```

**A bystander walk** that opens a containment inside a peer's note-to-catch
window — no failure of its own, and it erased the peer's:

```
FAIL in (fh-error-003-an-overlapping-walk-does-not-clear-a-peers-attribution)
expected: (= :audit/a (:view-id summary))
  actual: (not (= :audit/a :re-frame.freehand/unknown-view))
```

**An abandoned throw** ahead of a real one, on the common host (JVM *and* node
CLJS) — the swallowed failure's id was confidently reported for a different
failure, fingerprint and all:

```
FAIL in (fh-error-003-an-abandoned-throw-cannot-attribute-a-later-failure)
expected: (= :app/other-throwing (:view-id summary))
  actual: (not (= :app/other-throwing :app/throwing))

expected: (= (eb/fingerprint :app/other-throwing :render) (:fingerprint summary))
  actual: (not (= "fh-render-failed::app/other-throwing|render"
                  "fh-render-failed::app/throwing|render"))
```

**Two sibling React boundaries** failing in one commit, in Chromium — the exact
shape the bead reported:

```
FAIL in (fh-error-003-two-sibling-boundaries-failing-together-each-name-their-own)
expected: (= #{(id-of guarded-child) (id-of other-guarded-child)} ids)
  actual: (not (= #{…/guarded-child …/other-guarded-child}
                  #{…/guarded-child :re-frame.freehand/unknown-view}))
```

**A fallback that guards its own failure** — two causally ordered failures in one
commit, the second observed before the first is reported:

```
FAIL in (fh-error-003-a-failure-inside-a-fallback-is-attributed-to-the-fallback)
expected: (= [(id-of guarded-child) (id-of failing-fallback)] ids)
  actual: (not (= [… …] […/guarded-child]))
```

The shipped `.95` behaviour is unchanged and still proven by its own rows: a
single failing descendant is named however deep it sits, a healthy wrapper does
not absorb the attribution, two descendants of one boundary fingerprint apart,
and an unobservable thrower yields the documented `:loss` shape. A new
cross-host row also guards the removal of the entry-time scrub: an uncontained
throw that escaped the root leaves nothing a later boundary reads.

## Quality gates

All foreground, one at a time, on this branch.

| Gate | Result |
| --- | --- |
| `cd implementation/freehand && clojure -M:test` | **571 tests / 3815 assertions, 0 failures, 0 errors** |
| `npm run test:freehand` | **465 tests / 3107 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` | **10590 tests / 53200 assertions, 0 failures, 0 errors** |
| `npm run test:browser` | **544 tests / 3177 assertions, 0 failures, 0 errors** |
| `python scripts/check_freehand_conformance_index.py` | clean (exit 0) |
| `python scripts/check_doc_slugs.py` | clean (exit 0) |
| `clj-kondo` on the touched files | 0 errors |

**Non-vacuity.** Inverting `(= #{:audit/a :audit/b} …)` to `not=` in
`fh-error-003-two-overlapping-walks-keep-their-own-attribution` reds the full JVM
gate naming that test (`1 failures, 0 errors`); restoring it returns the file to
`sha256 7aa9ead338598f8aa7d37a3cac20922c7840a77668ab67e9df547eba45fc8173` and
the gate to green. The pre-fix transcripts above are the primary non-vacuity
evidence.

## Spec

One normative sentence in `spec/004-Views.md` §The safe summary and the private
frame egress: attribution is failure-local — it belongs to the throw, not to the
boundary that catches next. No new conformance row and no new fixture: this
sharpens FH-ERROR-003's existing claim rather than adding one.

## Note for the merge order

`implementation/freehand/src/re_frame/freehand/tree.cljc` gains one argument at
the occurrence seam (`(eb/note-failing-view! e view-id)`). PR #6738 edits lines
two away from it. If #6738 lands first this branch wants a rebase; the
resolution is to keep both changes.
