### PR TITLE
feat(freehand): F5f pilot — controlled field and buffered field (rf2-drpa3.43)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
@@ -1,0 +1,526 @@
+(ns re-frame.freehand.pilot-field
+  "THE FIRST COMPONENT PILOT — a controlled field and a buffered field,
+  built the way a component-library author would build them, plus the
+  application that calls them.
+
+  Everything in this namespace is CONSUMER code. It declares views with
+  `v/defview`, reads with `v/sub`, emits intent as event vectors, and
+  moves state with ordinary `reg-event` / `reg-sub`. It adds no substrate
+  machinery, and it is the artefact the fitness harness's CASE A
+  requirements (`docs/design/freehand/studio/fitness-harness.md`, §A.2)
+  are judged against — one requirement at a time, in
+  `pilot-field-cljs-test` and `pilot-field-dom-cljs-test`.
+
+  ## Two components, and why they are two
+
+  A reusable view is PROPS-ONLY by default: value in, intent out. That is
+  [[field]] — a label, a native control, an error region, and nothing it
+  owns. It is the shape 77 of the corpus's controlled form controls take.
+
+  A SEMANTIC CONTROLLER is the exception a library earns when a control
+  owns a protocol spanning several interactions. That is
+  [[buffered-field]] — it holds a DRAFT the user is editing and commits it
+  on Enter or blur, reverts it on Escape, and lets the caller REJECT it by
+  advancing a revision. Its state is ordinary frame data addressed by
+  `(kind, :control)` and fenced by `(kind, :reset-key)`; there is no
+  registry, no reducer, no second state system.
+
+  Splitting them is the finding, not the ceremony: three quarters of the
+  corpus's inputs need nothing a draft buys, and a control that holds a
+  draft it cannot be told to discard is the re-com defect this whole
+  design exists to remove.
+
+  ## The library's public surface
+
+  Three things, and a caller reads all three off the declaration:
+
+  - the **props schema** on each `v/defview` (`{:props [:map …]}`), which
+    CLOSES the props map — a misspelled prop is an error rather than a
+    value the view will silently never read;
+  - the **part addresses** in [[parts]], emitted as literal `data-part`
+    values under a `data-component` scope, so a stylesheet reaches a
+    named region without a class contract; and
+  - the **tokens** — the cascade carries them (the application scopes a
+    `data-theme`), and an inline namespaced custom property is reserved
+    for the genuinely dynamic value a stylesheet cannot know
+    (`:columns`).
+
+  ## The one thing the library does NOT do
+
+  It never forwards the caller's event vector into a controlled `:on-input`
+  position. A forwarded vector is a DYNAMIC handler expression: the
+  interpreted walk classifies it at render time and opens the synchronous
+  door, but the compiled analyzer can only classify it `:dynamic`, which
+  no door roster admits — so the identical library would take the
+  synchronous round trip interpreted and batch once promoted. The library
+  therefore owns a LITERAL vector at every door site and carries the
+  caller's event as an ARGUMENT inside it. The site proof stays static,
+  the prefix stays a runtime value, and promotion cannot move the field
+  from synchronous to batched.
+
+  ## The domain it is piloted against
+
+  An invoice-line editor: four controlled fields (description, quantity,
+  unit price, account) and one buffered field (the reference the server
+  may normalise or refuse). Small enough to read, and it exercises every
+  A.2 row — the draft/canonical split, touch-gated errors, a derived
+  submit gate both the view and the submit handler read, per-instance
+  async status, and N instances with no coordination."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.control :as control]))
+
+;; ===========================================================================
+;; THE COMPONENT LIBRARY — `acme.ui`
+;; ===========================================================================
+;;
+;; `:acme.ui/*` is LIBRARY vocabulary. The substrate reserves no namespace
+;; for controls and fixes no storage path: the root below, the record
+;; shape and every id are this library's choices.
+
+(def records-root
+  "Where this library keeps its controller records. A library decision,
+  not a substrate one — a second library would pick its own root and the
+  two would never meet."
+  :acme.ui/controllers)
+
+(def buffered-kind
+  "The buffered controller family. It is half of every record key this
+  library writes, so a second family addressed at the SAME domain
+  identity reads its own record rather than this one's."
+  :acme.ui/buffered-field)
+
+(def parts
+  "The PUBLIC part addresses each component emits, by component id.
+
+  A part id is API: renaming one is a breaking change to every stylesheet
+  that reaches it, exactly as renaming a prop is. They are literal
+  `data-part` values under a `data-component` scope, so `label` and
+  `control` can be common names without colliding across libraries.
+
+  Private implementation nodes carry no part id — the `<label>` wrapper is
+  `root` because callers style it; nothing else is addressable."
+  {"acme/field"          ["root" "label" "control" "error"]
+   "acme/buffered-field" ["root" "label" "control" "error"]})
+
+;; ---------------------------------------------------------------------------
+;; The library's dataflow — ordinary re-frame, registered by the consumer
+;; ---------------------------------------------------------------------------
+
+(defn- commit-fx
+  "The buffered commit, decided against COMMITTED state: a record that is
+  still current retires and produces the caller's intent carrying the
+  draft; a superseded one produces nothing at all.
+
+  Shared by the blur site and the Enter branch so the two cannot drift —
+  a control whose keyboard commit and whose blur commit disagreed about
+  which generation is live would commit something the user cannot see."
+  [db record-key revision on-commit]
+  (let [record (get-in db [records-root record-key])]
+    (if (control/current? (:reset-key record) revision)
+      {:db (update db records-root dissoc record-key)
+       :fx [[:dispatch (conj (vec on-commit) (:draft record))]]}
+      {})))
+
+(defn- cancel-fx
+  "Escape, and the Revert affordance: clear the record so a blur already
+  on its way consults committed state and finds no live edit. Escape
+  BEATS a late blur rather than racing it."
+  [db record-key revision]
+  (if (control/current? (:reset-key (get-in db [records-root record-key])) revision)
+    {:db (update db records-root dissoc record-key)}
+    {}))
+
+(defn register!
+  "Register the library's whole dataflow: one read and four transitions.
+
+  A library ships this as an ordinary function its consumer calls at
+  boot. There is no registry to join, no component to instantiate, and
+  nothing here that a `reg-sub` and a `reg-event` do not already do."
+  []
+  ;; --- The read ------------------------------------------------------
+  ;;
+  ;; THE FENCE, read side. The draft while it belongs to the caller's
+  ;; current generation; the caller's baseline otherwise. A superseded
+  ;; draft is not erased — it is INVISIBLE, which is why a reset costs no
+  ;; write and no render-time mutation.
+  (rf/reg-sub :acme.ui.buffered/text
+    (fn [db [_ record-key revision baseline]]
+      (let [record (get-in db [records-root record-key])]
+        (if (control/current? (:reset-key record) revision)
+          (:draft record)
+          baseline))))
+
+  ;; --- The controlled field's ONE transition -------------------------
+  ;;
+  ;; The library owns the SITE so the door's proof stays static; the
+  ;; CALLER owns the state, so all this does is deliver the live value to
+  ;; the caller's own event. It runs inside the synchronous drain the
+  ;; door opened, so the caller's event settles before the listener
+  ;; returns exactly as a direct dispatch would.
+  (rf/reg-event :acme.ui.field/changed
+    (fn [_ [_ on-input text]]
+      {:fx [[:dispatch (conj (vec on-input) text)]]}))
+
+  ;; --- The buffered field's transitions ------------------------------
+  ;;
+  ;; ATOMIC create-or-replace, stamped with the generation the render that
+  ;; produced this edit displayed. An edit that lands after the caller has
+  ;; moved on is BORN STALE rather than authoritative.
+  (rf/reg-event :acme.ui.buffered/edited
+    (fn [{:keys [db]} [_ record-key revision text]]
+      {:db (assoc-in db [records-root record-key] {:reset-key revision :draft text})}))
+
+  (rf/reg-event :acme.ui.buffered/committed
+    (fn [{:keys [db]} [_ record-key revision on-commit]]
+      (commit-fx db record-key revision on-commit)))
+
+  (rf/reg-event :acme.ui.buffered/cancelled
+    (fn [{:keys [db]} [_ record-key revision]]
+      (cancel-fx db record-key revision)))
+
+  ;; The keyboard protocol as DATA. `::v/key` carries the live
+  ;; `KeyboardEvent.key`, so Enter-commits and Escape-reverts are one
+  ;; registered event a structural test drives by equality — no callback
+  ;; body, no `.-key` read, nothing a JVM host cannot run. The cost is
+  ;; stated rather than hidden: this site fires on EVERY key, and every
+  ;; key that is neither Enter nor Escape settles an event that changes
+  ;; nothing (measured in `pilot-field-cljs-test`).
+  (rf/reg-event :acme.ui.buffered/key-pressed
+    (fn [{:keys [db]} [_ record-key revision on-commit pressed]]
+      (cond
+        (= "Enter" pressed)  (commit-fx db record-key revision on-commit)
+        (= "Escape" pressed) (cancel-fx db record-key revision)
+        :else                {}))))
+
+;; ---------------------------------------------------------------------------
+;; `field` — the controlled field. Props only: value in, intent out.
+;; ---------------------------------------------------------------------------
+
+(v/defview field
+  "A controlled text field: a label, a native control bound to `:value`,
+  and an error region that renders only when the caller supplies one.
+
+  `:on-input` is the caller's event PREFIX — `[:invoice/quantity-edited
+  id]` — and the live text arrives as its last argument. The caller never
+  writes a projection marker: the library's own site carries it, which is
+  also what keeps the site a literal vector and the synchronous door's
+  proof static in both execution modes.
+
+  `:columns` is the one value the cascade cannot know, so it is the one
+  value that rides as an inline custom property; everything else is a
+  `data-part` a stylesheet reaches."
+  {:props [:map
+           [:name :string]
+           [:label :string]
+           [:value :string]
+           [:on-input :vector]
+           [:on-blur {:optional true} [:maybe :vector]]
+           [:error {:optional true} [:maybe :string]]
+           [:busy? {:optional true} :boolean]
+           [:columns {:optional true} :int]]}
+  [{:keys [name label value on-input on-blur error busy? columns]}]
+  (let [error-id (str "acme-field-" name "-error")]
+    [:label {:data-component "acme/field"
+             :data-part      "root"
+             :data-field     name
+             :class          "acme-field"
+             :style          (when columns {:--acme-field-columns columns})}
+     [:span {:data-part "label"} label]
+     [:input {:data-part        "control"
+              :type             "text"
+              :value            value
+              :disabled         busy?
+              :aria-invalid     (when error "true")
+              :aria-describedby (when error error-id)
+              :on-input         [:acme.ui.field/changed on-input ::v/value]
+              :on-blur          on-blur}]
+     (when error
+       [:span {:data-part "error" :id error-id :role "alert"} error])]))
+
+;; ---------------------------------------------------------------------------
+;; `buffered-field` — the semantic controller. A draft, and a generation.
+;; ---------------------------------------------------------------------------
+
+(v/defview buffered-field
+  "A field that BUFFERS: the user's keystrokes become a draft, the draft
+  commits on Enter or blur, Escape reverts it, and the caller can reject
+  it by advancing `:reset-key`.
+
+  It asks for its record key and its generation FIRST — that is what makes
+  it a writable, buffered controller at all — and every intent it renders
+  carries the generation the render that produced it displayed, so an
+  intent fired after the caller has moved on speaks for a generation
+  nobody is displaying and lands nowhere.
+
+  `:control` is the domain identity that OWNS the draft
+  (`[:invoice 42 :reference]`), not a render position: a sort, a view
+  rename or a parent extraction leaves it exactly where it was.
+  `:reset-key` is whatever revision the caller advances when it
+  establishes a new baseline — and it is required, because a control with
+  no generation buffers correctly right up to the first rejection and
+  then loses it."
+  {:props [:map
+           [:name :string]
+           [:label :string]
+           [:control :any]
+           [:value :string]
+           [:reset-key :any]
+           [:on-commit :vector]
+           [:error {:optional true} [:maybe :string]]
+           [:busy? {:optional true} :boolean]]}
+  [{:keys [name label value on-commit error busy?] :as props}]
+  (let [k        (control/record-key buffered-kind props)
+        g        (control/reset-revision buffered-kind props)
+        error-id (str "acme-buffered-" name "-error")]
+    [:label {:data-component "acme/buffered-field"
+             :data-part      "root"
+             :data-field     name
+             :class          "acme-buffered-field"}
+     [:span {:data-part "label"} label]
+     [:input {:data-part        "control"
+              :type             "text"
+              :value            (v/sub [:acme.ui.buffered/text k g value])
+              :disabled         busy?
+              :aria-invalid     (when error "true")
+              :aria-describedby (when error error-id)
+              :on-input         [:acme.ui.buffered/edited k g ::v/value]
+              :on-key-down      [:acme.ui.buffered/key-pressed k g on-commit ::v/key]
+              :on-blur          [:acme.ui.buffered/committed k g on-commit]}]
+     (when error
+       [:span {:data-part "error" :id error-id :role "alert"} error])]))
+
+;; ===========================================================================
+;; THE APPLICATION — an invoice-line editor
+;; ===========================================================================
+;;
+;; From here down is ordinary application code. It knows nothing about
+;; controller records: it holds its own values, its own revisions, its own
+;; touched set, and it reads the library's controls the way it reads any
+;; other view.
+
+(def ^:private text-fields
+  "The four controlled fields, in form order. Data, so the error and
+  validity rules below are one rule rather than four."
+  [:description :quantity :unit-price :account])
+
+(defn- blank? [s] (or (nil? s) (str/blank? s)))
+
+(defn- parse-decimal
+  "The CANONICAL value behind raw typed text, or nil when the text is not
+  yet a number. Raw text and canonical value are DIFFERENT THINGS: the
+  field being edited echoes `\"1.\"` verbatim, and every other reader sees
+  nil until the text becomes a number — nothing reformats under the
+  caret."
+  [s]
+  (when-not (blank? s)
+    (let [t (str/trim s)]
+      (when (re-matches #"-?\d+(\.\d+)?" t)
+        #?(:clj (Double/parseDouble t) :cljs (js/parseFloat t))))))
+
+(defn- field-problem
+  "The problem with one field's value, or nil. Pure, and the ONE place the
+  rule lives — the view does not restate it and neither does the submit
+  handler."
+  [line f]
+  (let [raw (get line f)]
+    (case f
+      :description (when (blank? raw) "A description is required.")
+      :quantity    (let [n (parse-decimal raw)]
+                     (cond (blank? raw)  "A quantity is required."
+                           (nil? n)      "Quantity must be a number."
+                           (<= n 0)      "Quantity must be greater than zero."))
+      :unit-price  (let [n (parse-decimal raw)]
+                     (cond (blank? raw) "A unit price is required."
+                           (nil? n)     "Unit price must be a number."))
+      :account     (when (blank? raw) "An account is required.")
+      nil)))
+
+(defn- line-problems
+  "Every field problem on a line, as a map. The submit gate is derived
+  from exactly this."
+  [line]
+  (into {} (keep (fn [f] (when-let [p (field-problem line f)] [f p]))) text-fields))
+
+(defn register-app!
+  "The application's own registrations."
+  []
+  (rf/reg-sub :acme.invoice/line
+    (fn [db [_ id]] (get-in db [:invoice id])))
+
+  (rf/reg-sub :acme.invoice/field-value
+    (fn [db [_ id f]] (get-in db [:invoice id f])))
+
+  ;; R-A4. The canonical value, derived — never written back into the raw
+  ;; text the user is typing.
+  (rf/reg-sub :acme.invoice/quantity-canonical
+    (fn [db [_ id]] (parse-decimal (get-in db [:invoice id :quantity]))))
+
+  (rf/reg-sub :acme.invoice/line-total
+    (fn [db [_ id]]
+      (let [q (parse-decimal (get-in db [:invoice id :quantity]))
+            p (parse-decimal (get-in db [:invoice id :unit-price]))]
+        (when (and q p) (* q p)))))
+
+  ;; R-A5. A problem is a fact about the value; whether it is DISPLAYED is
+  ;; a fact about the interaction. Per field, per instance.
+  (rf/reg-sub :acme.invoice/field-error
+    (fn [db [_ id f]]
+      (let [line (get-in db [:invoice id])
+            ui   (get-in db [:ui id])]
+        (when (or (contains? (:touched ui) f) (:submit-attempted? ui))
+          (field-problem line f)))))
+
+  ;; R-A6. The gate, derived once, read by the view AND by the submit
+  ;; handler. Neither recomputes it.
+  (rf/reg-sub :acme.invoice/can-submit?
+    (fn [db [_ id]]
+      (let [line (get-in db [:invoice id])]
+        (and (empty? (line-problems line))
+             (not (:normalising? line))))))
+
+  ;; R-A10. Busy is the in-flight write's own state, not a local flag.
+  (rf/reg-sub :acme.invoice/normalising?
+    (fn [db [_ id]] (boolean (get-in db [:invoice id :normalising?]))))
+
+  (rf/reg-sub :acme.invoice/reference
+    (fn [db [_ id]] (get-in db [:invoice id :reference])))
+
+  (rf/reg-sub :acme.invoice/reference-revision
+    (fn [db [_ id]] (get-in db [:invoice id :reference-revision])))
+
+  (rf/reg-sub :acme.invoice/theme
+    (fn [db _] (get db :theme "light")))
+
+  ;; --- Transitions ---------------------------------------------------
+
+  (rf/reg-event :acme.invoice/field-edited
+    (fn [{:keys [db]} [_ id f text]]
+      {:db (assoc-in db [:invoice id f] text)}))
+
+  (rf/reg-event :acme.invoice/field-blurred
+    (fn [{:keys [db]} [_ id f]]
+      {:db (update-in db [:ui id :touched] (fnil conj #{}) f)}))
+
+  (rf/reg-event :acme.invoice/submit-attempted
+    (fn [{:keys [db]} [_ id]]
+      (let [db' (assoc-in db [:ui id :submit-attempted?] true)]
+        ;; The gate is READ, not recomputed: one definition, two readers.
+        (if (rf/subscribe-once [:acme.invoice/can-submit? id])
+          {:db (update db' ::submitted (fnil conj []) id)}
+          {:db db'}))))
+
+  ;; The buffered reference's accepted destination. The caller advances
+  ;; the revision on every baseline decision it makes — that is what makes
+  ;; a rejection that reasserts the SAME value visible to the control.
+  (rf/reg-event :acme.invoice/reference-accepted
+    (fn [{:keys [db]} [_ id text]]
+      {:db (-> db
+               (assoc-in [:invoice id :reference] text)
+               (update-in [:invoice id :reference-revision] inc)
+               (update ::accepted (fnil inc 0)))}))
+
+  ;; R-A9. An asynchronous normalisation of the committed text. The
+  ;; request carries a token; only the settle that names the CURRENT token
+  ;; may land, so a superseded reply is inert rather than racing.
+  (rf/reg-event :acme.invoice/reference-submitted
+    (fn [{:keys [db]} [_ id text token]]
+      {:db (-> db
+               (assoc-in [:invoice id :normalising?] true)
+               (assoc-in [:invoice id :normalise-token] token)
+               (assoc-in [:invoice id :submitted-reference] text))}))
+
+  (rf/reg-event :acme.invoice/reference-normalised
+    (fn [{:keys [db]} [_ id token normalised]]
+      (if (= token (get-in db [:invoice id :normalise-token]))
+        {:db (-> db
+                 (assoc-in [:invoice id :normalising?] false)
+                 (assoc-in [:invoice id :reference] normalised)
+                 (update-in [:invoice id :reference-revision] inc)
+                 (update ::normalised (fnil conj []) normalised))}
+        {})))
+
+  ;; THE REJECTION. The caller refuses the committed draft and stands by
+  ;; the value it already had — advancing the revision is what says "this
+  ;; is a NEW baseline decision" in the one case value-equality cannot
+  ;; see.
+  (rf/reg-event :acme.invoice/reference-refused
+    (fn [{:keys [db]} [_ id]]
+      {:db (-> db
+               (assoc-in [:invoice id :normalising?] false)
+               (update-in [:invoice id :reference-revision] inc)
+               (update ::refused (fnil inc 0)))}))
+
+  (rf/reg-event :acme.invoice/theme-changed
+    (fn [{:keys [db]} [_ theme]]
+      {:db (assoc db :theme theme)})))
+
+;; ---------------------------------------------------------------------------
+;; The application's views
+;; ---------------------------------------------------------------------------
+
+(v/defview invoice-line
+  "One invoice line: four controlled fields, one buffered field, a derived
+  total, and a submit button disabled off the same gate its handler
+  reads.
+
+  The theme rides ONE `data-theme` on the form, so a theme switch is one
+  attribute the cascade resolves for every descendant — no token
+  subscription per leaf, and no remount."
+  {:props [:map [:id :any]]}
+  [{:keys [id]}]
+  (let [line    (v/sub [:acme.invoice/line id])
+        busy?   (v/sub [:acme.invoice/normalising? id])
+        gate    (v/sub [:acme.invoice/can-submit? id])
+        total   (v/sub [:acme.invoice/line-total id])
+        theme   (v/sub [:acme.invoice/theme])]
+    [:form {:data-component "acme/invoice-line"
+            :data-theme     theme
+            :on-submit      {:event [:acme.invoice/submit-attempted id]
+                             :prevent-default true}}
+     [field {:name     "description"
+             :label    "Description"
+             :value    (or (:description line) "")
+             :columns  40
+             :error    (v/sub [:acme.invoice/field-error id :description])
+             :on-input [:acme.invoice/field-edited id :description]
+             :on-blur  [:acme.invoice/field-blurred id :description]}]
+     [field {:name     "quantity"
+             :label    "Quantity"
+             :value    (or (:quantity line) "")
+             :error    (v/sub [:acme.invoice/field-error id :quantity])
+             :on-input [:acme.invoice/field-edited id :quantity]
+             :on-blur  [:acme.invoice/field-blurred id :quantity]}]
+     [field {:name     "unit-price"
+             :label    "Unit price"
+             :value    (or (:unit-price line) "")
+             :error    (v/sub [:acme.invoice/field-error id :unit-price])
+             :on-input [:acme.invoice/field-edited id :unit-price]
+             :on-blur  [:acme.invoice/field-blurred id :unit-price]}]
+     [field {:name     "account"
+             :label    "Account"
+             :value    (or (:account line) "")
+             :error    (v/sub [:acme.invoice/field-error id :account])
+             :on-input [:acme.invoice/field-edited id :account]
+             :on-blur  [:acme.invoice/field-blurred id :account]}]
+     [buffered-field {:name      "reference"
+                      :label     "Reference"
+                      :control   [:invoice id :reference]
+                      :value     (or (v/sub [:acme.invoice/reference id]) "")
+                      :reset-key (v/sub [:acme.invoice/reference-revision id])
+                      :busy?     busy?
+                      :on-commit [:acme.invoice/reference-accepted id]}]
+     [:output {:data-part "total"} (str total)]
+     [:button {:data-part "submit" :type "submit" :disabled (not gate)} "Save"]]))
+
+(v/defview invoice-lines
+  "Two lines on one page — the same two components, four buffered records
+  and eight controlled fields, with no coordination between them. Each
+  control's state is addressed by the domain identity that owns it, so
+  there is nothing for two instances to collide over."
+  {:props [:map [:ids [:vector :any]]]}
+  [{:keys [ids]}]
+  [:div {:data-component "acme/invoice-lines"}
+   (for [id ids]
+     [invoice-line {:key id :id id}])])

--- a/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
@@ -387,6 +387,12 @@
   (rf/reg-sub :acme.invoice/reference
     (fn [db [_ id]] (get-in db [:invoice id :reference])))
 
+  ;; Why the caller refused. Ordinary application state, displayed through
+  ;; the control's own error part — the control neither owns the reason
+  ;; nor decides when it is shown.
+  (rf/reg-sub :acme.invoice/reference-error
+    (fn [db [_ id]] (get-in db [:invoice id :reference-error])))
+
   (rf/reg-sub :acme.invoice/reference-revision
     (fn [db [_ id]] (get-in db [:invoice id :reference-revision])))
 
@@ -418,6 +424,7 @@
     (fn [{:keys [db]} [_ id text]]
       {:db (-> db
                (assoc-in [:invoice id :reference] text)
+               (assoc-in [:invoice id :reference-error] nil)
                (update-in [:invoice id :reference-revision] inc)
                (update ::accepted (fnil inc 0)))}))
 
@@ -446,9 +453,10 @@
   ;; is a NEW baseline decision" in the one case value-equality cannot
   ;; see.
   (rf/reg-event :acme.invoice/reference-refused
-    (fn [{:keys [db]} [_ id]]
+    (fn [{:keys [db]} [_ id reason]]
       {:db (-> db
                (assoc-in [:invoice id :normalising?] false)
+               (assoc-in [:invoice id :reference-error] reason)
                (update-in [:invoice id :reference-revision] inc)
                (update ::refused (fnil inc 0)))}))
 
@@ -510,12 +518,13 @@
                       :value     (or (v/sub [:acme.invoice/reference id]) "")
                       :reset-key (v/sub [:acme.invoice/reference-revision id])
                       :busy?     busy?
+                      :error     (v/sub [:acme.invoice/reference-error id])
                       :on-commit [:acme.invoice/reference-accepted id]}]
      [:output {:data-part "total"} (str total)]
      [:button {:data-part "submit" :type "submit" :disabled (not gate)} "Save"]]))
 
 (v/defview invoice-lines
-  "Two lines on one page — the same two components, four buffered records
+  "Two lines on one page — the same two components, two buffered records
   and eight controlled fields, with no coordination between them. Each
   control's state is addressed by the domain identity that owns it, so
   there is nothing for two instances to collide over."
@@ -524,3 +533,12 @@
   [:div {:data-component "acme/invoice-lines"}
    (for [id ids]
      [invoice-line {:key id :id id}])])
+
+(def by-name
+  "Fixture view-name keyword -> the interpreted declaration. The promoted
+  twins in `pilot-field-compiled` are keyed identically, so one table
+  drives both modes."
+  {:field          field
+   :buffered-field buffered-field
+   :invoice-line   invoice-line
+   :invoice-lines  invoice-lines})

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
@@ -405,9 +405,13 @@
         (is (= 1.5 (rf/subscribe-once [:acme.invoice/quantity-canonical 1] {:frame fid})))
         (is (= 225.0 (rf/subscribe-once [:acme.invoice/line-total 1] {:frame fid}))
             "and the derived total follows")
-        (is (= "225.0" (t/text (part-node (render! (line-form mode 1))
-                                          "acme/invoice-line" "total")))
-            "which the view reads as an ordinary value")))))
+        (is (= (str (rf/subscribe-once [:acme.invoice/line-total 1] {:frame fid}))
+               (t/text (part-node (render! (line-form mode 1))
+                                  "acme/invoice-line" "total")))
+            "which the view reads as an ordinary value — compared against the
+             derived read rather than a literal, because `(str 225.0)` is
+             \"225.0\" on the JVM and \"225\" in ClojureScript, and a `.cljc`
+             view that prints a raw double is host-sensitive by construction")))))
 
 ;; ===========================================================================
 ;; R-A5 — validation display gated by touch or submit-attempt

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
@@ -1,0 +1,972 @@
+(ns re-frame.freehand.pilot-field-cljs-test
+  "THE FIRST PILOT, judged: the fitness harness's CASE A §A.2 requirements
+  against [[re-frame.freehand.pilot-field]], one requirement per `deftest`,
+  on both hosts and in BOTH execution modes.
+
+  This is not a substrate law suite. Nothing here pins a Freehand
+  contract; every assertion is a consumer's claim about a consumer's
+  components, and the pass/fail column it fills in is
+  `docs/design/freehand/studio/fitness-harness.md` §A.2 (R-A1 … R-A12).
+  Rows whose evidence is a live DOM — the caret, an IME composition, the
+  synchronous round trip as a user-visible fact — are OWED to
+  `pilot-field-dom-cljs-test` and say so here rather than being restated
+  structurally, because a structural stand-in for a caret proves nothing.
+
+  ## Both modes, one body of assertions
+
+  Every test runs its assertions over [[modes]]: the interpreted
+  declarations and their `{:compiled true}` twins in
+  `pilot-field-compiled`. Same call sites, same props, same expected
+  values — the view-id namespace is the only mechanical substitution, and
+  it is a difference living in another FILE makes, not one promotion
+  makes. The library's dataflow is registered ONCE for both, because a
+  `reg-sub` and a `reg-event` know nothing about execution mode.
+
+  ## Why the render goes through a capture, and why that is a FINDING
+
+  `t/render` is the blessed public structural surface (API manifest tier
+  `:testing`), and it walks a body without opening a render candidate. So
+  `t/render` on ANY view that calls `v/sub` raises
+  `:rf.error/view-read-outside-render` — which is every stateful view a
+  form is made of. [[render-on!]] composes the internal
+  `cell/candidate` + `cell/with-capture` to supply the missing candidate,
+  exactly as the substrate's own controller suites do. That composition is
+  NOT part of the public door; a consumer writing these tests today has
+  to reach past it. Recorded in the PR body as the pilot's principal
+  ergonomic finding, and reproduced verbatim by
+  [[t-render-alone-cannot-render-a-state-reading-view]] below."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [clojure.walk :as walk]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.cell :as cell]
+            [re-frame.freehand.pilot-field :as pilot]
+            [re-frame.freehand.pilot-field-compiled :as promoted]
+            [re-frame.freehand.test :as t]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+;; ===========================================================================
+;; Harness
+;; ===========================================================================
+
+(def ^:private fid :rf/default)
+
+(def modes
+  "The two execution modes, keyed by the roster each holds. Every
+  requirement below is asserted against both."
+  {:interpreted pilot/by-name
+   :compiled    promoted/by-name})
+
+(defn- form
+  "The call form for `view` in `mode` — the SAME props map either way."
+  [mode view props]
+  [(get-in modes [mode view]) props])
+
+(defn- init! []
+  (pilot/register!)
+  (pilot/register-app!))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter
+                                            :init-fn init!}))
+
+(defn- app-db [] (frame/frame-app-db-value fid))
+(defn- seed!  [db] (frame/replace-app-db! fid db))
+(defn- send!  [ev] (rf/dispatch-sync ev {:frame fid}))
+
+(defn- render-on!
+  "Render `f` under `cell` — one candidate, one structural walk, NO commit
+  — and answer the tree.
+
+  The `cell/candidate` + `cell/with-capture` pair is the internal
+  composition `t/render` does not supply; see the namespace docstring."
+  [c f]
+  (cell/with-capture (cell/candidate c fid) (fn [] (t/render f))))
+
+(defn- render!
+  "Render `f` on a fresh cell."
+  [f]
+  (render-on! (cell/cell :acme.ui/probe) f))
+
+(defn- nodes
+  "Every ELEMENT node under `tree` matching `pred`, in document order.
+  Text leaves are excluded, so a predicate may read attributes freely."
+  [tree pred]
+  (t/find-all tree #(and (map? %) (contains? % :tag) (pred %))))
+
+(defn- node
+  "The first element node under `tree` matching `pred`, or nil."
+  [tree pred]
+  (first (nodes tree pred)))
+
+(defn- component-node
+  "The root node of component `component` — the node carrying its
+  `data-component` scope."
+  [tree component]
+  (node tree #(= component (:data-component (:attrs %)))))
+
+(defn- part-node
+  "The node addressed by `part-id` inside the nearest `component` scope —
+  the way a stylesheet reaches a named region of a component."
+  [tree component part-id]
+  (node (component-node tree component) #(= part-id (:data-part (:attrs %)))))
+
+(defn- field-node
+  "The `<label>` root of the controlled field named `nm`."
+  [tree nm]
+  (node tree #(and (= "acme/field" (:data-component (:attrs %)))
+                   (= nm (:data-field (:attrs %))))))
+
+(defn- buffered-node
+  [tree nm]
+  (node tree #(and (= "acme/buffered-field" (:data-component (:attrs %)))
+                   (= nm (:data-field (:attrs %))))))
+
+(defn- control-of
+  "The native control inside a component root."
+  [root]
+  (node root #(= "control" (:data-part (:attrs %)))))
+
+(defn- error-of
+  [root]
+  (node root #(= "error" (:data-part (:attrs %)))))
+
+(defn- intent
+  "The event vector node `n` carries under `prop`."
+  [n prop]
+  (get (t/attrs n) prop))
+
+(defn- fire!
+  "Dispatch the intent `n` carries under `prop`, with `args` filling the
+  projection positions a live payload would."
+  [n prop & args]
+  (let [ev (intent n prop)]
+    (send! (if (seq args) (into (vec (butlast ev)) args) ev))))
+
+(defn- line-form  [mode id]  (form mode :invoice-line {:id id}))
+(defn- lines-form [mode ids] (form mode :invoice-lines {:ids ids}))
+
+(defn- shown
+  "What the control named `nm` displays in `tree`."
+  [tree nm]
+  (:value (t/attrs (control-of (field-node tree nm)))))
+
+(defn- shown-buffered
+  [tree nm]
+  (:value (t/attrs (control-of (buffered-node tree nm)))))
+
+(defn- type!
+  "Type `text` into the controlled field named `nm` — the intent its
+  `:on-input` site carries, fired with the live payload the browser would
+  have supplied."
+  [mode id nm text]
+  (fire! (control-of (field-node (render! (line-form mode id)) nm)) :on-input text))
+
+(defn- blur!
+  [mode id nm]
+  (fire! (control-of (field-node (render! (line-form mode id)) nm)) :on-blur))
+
+(defn- seed-line!
+  ([id] (seed-line! id {}))
+  ([id overrides]
+   (seed! {:invoice {id (merge {:description "Consulting"
+                                :quantity    "2"
+                                :unit-price  "150"
+                                :account     "4000"
+                                :reference   "REF-1"
+                                :reference-revision 0}
+                               overrides)}})))
+
+(defn- seed-lines! [ids]
+  (seed! {:invoice (into {} (map (fn [id] [id {:description "Consulting"
+                                               :quantity    "2"
+                                               :unit-price  "150"
+                                               :account     "4000"
+                                               :reference   (str "REF-" id)
+                                               :reference-revision 0}]))
+                         ids)}))
+
+(defn- record
+  "The library's controller record at `address`."
+  [address]
+  (get-in (app-db) [pilot/records-root [pilot/buffered-kind address]]))
+
+(defn- moved-paths
+  "The leaf paths at which two values differ, in a stable order — what an
+  epoch diff shows a tool, and the honest unit for 'how much state moved'."
+  ([a b] (moved-paths a b []))
+  ([a b path]
+   (cond
+     (= a b)                 []
+     (and (map? a) (map? b)) (into []
+                                   (mapcat #(moved-paths (get a % ::absent)
+                                                         (get b % ::absent)
+                                                         (conj path %)))
+                                   (sort-by str (distinct (concat (keys a) (keys b)))))
+     :else                   [path])))
+
+(def ^:private modes-list [:interpreted :compiled])
+
+(defn- each-mode
+  "Run `f` for each mode, seeding first. The one place the two-mode sweep
+  is spelled, so every requirement below is proven twice by construction."
+  [f]
+  (doseq [mode modes-list]
+    (testing (str "mode " mode)
+      (f mode))))
+
+;; ===========================================================================
+;; The finding this suite had to work around, reproduced
+;; ===========================================================================
+
+(deftest t-render-alone-cannot-render-a-state-reading-view
+  (testing "The blessed public structural surface cannot render a view
+            that reads state. `t/render` walks a body but opens no render
+            candidate, so the first `v/sub` raises
+            `:rf.error/view-read-outside-render` — and every form control
+            that displays application state is such a view. The internal
+            candidate/capture pair this file composes is what closes the
+            gap; a consumer has no published way to do it."
+    (seed-line! 1)
+    (each-mode
+      (fn [mode]
+        (let [thrown (try (t/render (line-form mode 1))
+                          nil
+                          (catch #?(:clj Throwable :cljs :default) e
+                            (:rf.error/id (ex-data e))))]
+          (is (= :rf.error/view-read-outside-render thrown)
+              "t/render alone refuses the state-reading view")
+          (is (some? (render! (line-form mode 1)))
+              "non-vacuous: the SAME form renders once a candidate exists"))))))
+
+;; ===========================================================================
+;; R-A1 — same-tick echo
+;; ===========================================================================
+
+(deftest r-a1-every-editing-site-is-inside-the-controlled-input-door
+  (testing "R-A1 (structural half). The door is one predicate over five
+            final-normalized facts, and the four this suite can see are
+            structural: a supported control tag, `value` PRESENT, a
+            firing attribute that normalizes to `onInput`, and a handler
+            whose outcome is synchronously known — a LITERAL event
+            vector. Every editing site the pilot renders carries all four,
+            in both modes.
+
+            The library owns that literal vector deliberately. Forwarding
+            the caller's event vector into the `:on-input` position would
+            leave the site a DYNAMIC handler expression, which the
+            interpreted walk classifies at render time and the compiled
+            analyzer cannot classify at all — the one promotion parity
+            break D009 names. Carrying the caller's event as an ARGUMENT
+            inside the library's own literal vector keeps the site's proof
+            static and the prefix a runtime value.
+
+            The user-visible half — that a keystroke's state change lands
+            before the browser restores the node — is owed to
+            `pilot-field-dom-cljs-test`."
+    (seed-line! 1)
+    (each-mode
+      (fn [mode]
+        (let [tree     (render! (line-form mode 1))
+              controls (nodes tree #(and (= :input (:tag %))
+                                         (contains? (t/attrs %) :on-input)))]
+          (is (= 5 (count controls))
+              "four controlled fields and one buffered field are editing sites")
+          (doseq [c controls]
+            (let [a  (t/attrs c)
+                  ev (:on-input a)]
+              (is (= :input (:tag c)) "a tag whose value React restores")
+              (is (contains? a :value) "`value` present — controlled by PRESENCE")
+              (is (vector? ev) "the handler's outcome is one event vector, known now")
+              (is (keyword? (first ev)) "headed by a literal event id")
+              (is (= "acme.ui" (subs (namespace (first ev)) 0 7))
+                  "and the id is the LIBRARY's, so the site stays literal")))
+          (is (some #(= :acme.ui.buffered/edited (first (:on-input (t/attrs %))))
+                    (nodes tree #(= :input (:tag %))))
+              "non-vacuous: the buffered control's own site is present too"))))))
+
+(deftest r-a1-the-caller-never-writes-a-projection-marker
+  (testing "R-A1, ergonomic half. The call site names an event PREFIX and
+            nothing else; the live value arrives as its last argument
+            because the library's site appends the marker. A caller that
+            had to write `::v/value` at every call would be writing the
+            library's implementation detail into its own code."
+    (seed-line! 1)
+    (each-mode
+      (fn [mode]
+        (let [tree (render! (line-form mode 1))
+              c    (control-of (field-node tree "quantity"))
+              ev   (:on-input (t/attrs c))]
+          (is (= [:acme.ui.field/changed [:acme.invoice/field-edited 1 :quantity] ::v/value]
+                 ev)
+              "the caller's prefix rides as data inside the library's site")
+          (send! (v/materialize-event ev {::v/value "9"}))
+          (is (= "9" (get-in (app-db) [:invoice 1 :quantity]))
+              "and the materialized event reaches the caller's own handler"))))))
+
+;; ===========================================================================
+;; R-A2 — caret / selection / IME
+;; ===========================================================================
+
+(deftest r-a2-is-owed-to-the-browser
+  (testing "R-A2 is caret position, range selection and IME composition
+            surviving a value the substrate reasserts. None of that has a
+            structural shadow: a tree cannot hold a caret, and asserting
+            some proxy for one here would be the false green this
+            programme keeps catching. What IS assertable headlessly is
+            the precondition — the pilot never remounts to reset, because
+            it holds no host state to reset. That is asserted by R-A3's
+            'no record was deleted' row and by
+            `r-a9-rendering-is-free-of-consequence` below; the caret and
+            the composition are proven in
+            `pilot-field-dom-cljs-test`."
+    (is true "R-A2 evidence lives in the browser suite (stated, not stubbed)")))
+
+;; ===========================================================================
+;; R-A3 — same-value rejection visibility
+;; ===========================================================================
+
+(deftest r-a3-a-rejection-lands-even-though-the-value-never-moved
+  (testing "R-A3. The caller refuses a committed draft by advancing the
+            reference revision and reasserting nothing. The value before
+            the decision and the value after it are IDENTICAL — which is
+            exactly the case value-equality is blind to, and the defect
+            re-com documents at input_text.cljs:91-94 — yet the draft
+            leaves the display at once."
+    (each-mode
+      (fn [mode]
+        (seed-line! 1)
+        (let [address [:invoice 1 :reference]
+              draft   "REF-BAD"]
+          (is (= "REF-1" (shown-buffered (render! (line-form mode 1)) "reference"))
+              "the control starts on the caller's baseline")
+
+          (fire! (control-of (buffered-node (render! (line-form mode 1)) "reference"))
+                 :on-input draft)
+          (is (= draft (shown-buffered (render! (line-form mode 1)) "reference"))
+              "the draft is displayed")
+          (is (= draft (:draft (record address))) "and is ordinary frame data")
+
+          (let [before (get-in (app-db) [:invoice 1 :reference])]
+            (send! [:acme.invoice/reference-refused 1 "That reference is not on file."])
+            (is (= before (get-in (app-db) [:invoice 1 :reference]))
+                "non-vacuous: the caller's VALUE did not move at all")
+            (is (= "REF-1" (shown-buffered (render! (line-form mode 1)) "reference"))
+                "yet the baseline is back on screen")
+            (is (not= draft "REF-1")
+                "non-vacuous: the display really did move off the draft"))
+
+          (testing "and the superseded record is INELIGIBLE, not erased —
+                    keeping the stamp is what lets a tool name the
+                    generation that orphaned it"
+            (is (= {:reset-key 0 :draft draft} (record address)))))))))
+
+(deftest r-a3-an-external-value-change-is-not-a-rejection
+  (testing "R-A3's counter-case. A value that moves while the generation
+            holds is an OBSERVATION, not a decision about the user's
+            edit, so a live draft continues. Without this row the
+            rejection above would be indistinguishable from 'any caller
+            write clobbers the draft'."
+    (each-mode
+      (fn [mode]
+        (seed-line! 1)
+        (fire! (control-of (buffered-node (render! (line-form mode 1)) "reference"))
+               :on-input "REF-DRAFT")
+        (frame/replace-app-db! fid (assoc-in (app-db) [:invoice 1 :reference] "REF-ELSEWHERE"))
+        (is (= "REF-DRAFT" (shown-buffered (render! (line-form mode 1)) "reference"))
+            "the draft survives a value change that made no baseline decision")))))
+
+;; ===========================================================================
+;; R-A4 — draft vs canonical, without reformat-jitter
+;; ===========================================================================
+
+(deftest r-a4-raw-text-and-canonical-value-coexist
+  (testing "R-A4. The field being edited echoes what was typed, verbatim;
+            every other reader sees the derived value. Typing `\"1.\"`
+            leaves `\"1.\"` in the control — nothing reformats under the
+            caret — while the canonical read is nil until the text becomes
+            a number, and the derived total is nil with it."
+    (each-mode
+      (fn [mode]
+        (seed-line! 1)
+        (type! mode 1 "quantity" "1.")
+        (is (= "1." (shown (render! (line-form mode 1)) "quantity"))
+            "the control echoes the keystrokes verbatim")
+        (is (nil? (rf/subscribe-once [:acme.invoice/quantity-canonical 1] {:frame fid}))
+            "the canonical value is absent, not a guess")
+        (is (nil? (rf/subscribe-once [:acme.invoice/line-total 1] {:frame fid}))
+            "and nothing derived from it invents a number")
+
+        (type! mode 1 "quantity" "1.5")
+        (is (= "1.5" (shown (render! (line-form mode 1)) "quantity")))
+        (is (= 1.5 (rf/subscribe-once [:acme.invoice/quantity-canonical 1] {:frame fid})))
+        (is (= 225.0 (rf/subscribe-once [:acme.invoice/line-total 1] {:frame fid}))
+            "and the derived total follows")
+        (is (= "225.0" (t/text (part-node (render! (line-form mode 1))
+                                          "acme/invoice-line" "total")))
+            "which the view reads as an ordinary value")))))
+
+;; ===========================================================================
+;; R-A5 — validation display gated by touch or submit-attempt
+;; ===========================================================================
+
+(deftest r-a5-errors-appear-only-after-touch-or-submit-attempt
+  (testing "R-A5, per field and per instance. A blank description is a
+            problem from the first render; it is DISPLAYED only once the
+            user has left that field, or once submit has been attempted —
+            and touching one field says nothing about another."
+    (each-mode
+      (fn [mode]
+        (seed-line! 1 {:description ""})
+        (is (nil? (error-of (field-node (render! (line-form mode 1)) "description")))
+            "untouched and unsubmitted: no error region at all")
+
+        (blur! mode 1 "description")
+        (let [tree (render! (line-form mode 1))
+              node (field-node tree "description")]
+          (is (= "A description is required." (t/text (error-of node)))
+              "blur reveals the field's own problem")
+          (is (= "true" (:aria-invalid (t/attrs (control-of node))))
+              "and the control is marked invalid for assistive technology")
+          (is (= (:id (t/attrs (error-of node)))
+                 (:aria-describedby (t/attrs (control-of node))))
+              "with the message wired to the control by id"))
+
+        (testing "a second blank field stays quiet until it is touched too"
+          (frame/replace-app-db! fid (assoc-in (app-db) [:invoice 1 :account] ""))
+          (is (nil? (error-of (field-node (render! (line-form mode 1)) "account")))
+              "untouched, still quiet")
+          (send! [:acme.invoice/submit-attempted 1])
+          (is (= "An account is required."
+                 (t/text (error-of (field-node (render! (line-form mode 1)) "account"))))
+              "a submit attempt reveals every field at once"))))))
+
+(deftest r-a5-gating-is-per-instance
+  (testing "R-A5. Two lines on one page: touching a field on the first
+            reveals nothing on the second. The touched set is addressed by
+            the line's own identity, so there is no shared 'form state' to
+            leak across instances."
+    (each-mode
+      (fn [mode]
+        (seed-lines! [1 2])
+        (frame/replace-app-db! fid (-> (app-db)
+                                       (assoc-in [:invoice 1 :description] "")
+                                       (assoc-in [:invoice 2 :description] "")))
+        (send! [:acme.invoice/field-blurred 1 :description])
+        (let [tree  (render! (lines-form mode [1 2]))
+              roots (nodes tree #(= "acme/invoice-line" (:data-component (:attrs %))))]
+          (is (= 2 (count roots)) "non-vacuous: both lines rendered")
+          (is (some? (error-of (field-node (first roots) "description")))
+              "the touched line shows its problem")
+          (is (nil? (error-of (field-node (second roots) "description")))
+              "the untouched line shows nothing"))))))
+
+;; ===========================================================================
+;; R-A6 — a derived gate the view and the handler both read
+;; ===========================================================================
+
+(deftest r-a6-the-submit-gate-cannot-go-stale
+  (testing "R-A6. `:acme.invoice/can-submit?` is defined once. The button
+            disables off it and the submit handler READS it — through the
+            frame-explicit one-shot read, not by recomputing the rule — so
+            the two can never disagree about whether the form is
+            submittable."
+    (each-mode
+      (fn [mode]
+        (seed-line! 1 {:quantity "nope"})
+        (let [button (part-node (render! (line-form mode 1)) "acme/invoice-line" "submit")]
+          (is (true? (:disabled (t/attrs button))) "the view refuses")
+          (is (false? (rf/subscribe-once [:acme.invoice/can-submit? 1] {:frame fid}))
+              "the gate agrees"))
+        (send! [:acme.invoice/submit-attempted 1])
+        (is (nil? (::pilot/submitted (app-db)))
+            "and the handler refused it too — one rule, two readers")
+
+        (send! [:acme.invoice/field-edited 1 :quantity "3"])
+        (let [button (part-node (render! (line-form mode 1)) "acme/invoice-line" "submit")]
+          (is (false? (:disabled (t/attrs button))) "a valid line enables the button")
+          (is (true? (rf/subscribe-once [:acme.invoice/can-submit? 1] {:frame fid}))))
+        (send! [:acme.invoice/submit-attempted 1])
+        (is (= [1] (::pilot/submitted (app-db)))
+            "and the same attempt now submits — non-vacuous in both directions")))))
+
+;; ===========================================================================
+;; R-A7 — the commit / cancel / blur key protocol
+;; ===========================================================================
+
+(deftest r-a7-enter-commits-escape-reverts-blur-commits
+  (testing "R-A7. Three interactions, no component-local state machine:
+            Enter and Escape ride ONE registered event carrying the live
+            `KeyboardEvent.key` as data, and blur is an ordinary intent.
+            Every one of them is decided in the handler against committed
+            state."
+    (each-mode
+      (fn [mode]
+        (let [ctl (fn [] (control-of (buffered-node (render! (line-form mode 1)) "reference")))]
+
+          (testing "Enter commits the draft to the caller"
+            (seed-line! 1)
+            (fire! (ctl) :on-input "REF-ENTER")
+            (fire! (ctl) :on-key-down "Enter")
+            (is (= "REF-ENTER" (get-in (app-db) [:invoice 1 :reference]))
+                "the caller's own event received the draft")
+            (is (nil? (record [:invoice 1 :reference])) "and the session retired"))
+
+          (testing "Escape reverts to the caller's baseline"
+            (seed-line! 1)
+            (fire! (ctl) :on-input "REF-ESCAPE")
+            (fire! (ctl) :on-key-down "Escape")
+            (is (= "REF-1" (get-in (app-db) [:invoice 1 :reference]))
+                "the caller's value is untouched")
+            (is (= "REF-1" (shown-buffered (render! (line-form mode 1)) "reference"))
+                "and the baseline is displayed again"))
+
+          (testing "an ordinary character key changes nothing"
+            (seed-line! 1)
+            (fire! (ctl) :on-input "REF-X")
+            (let [before (app-db)]
+              (fire! (ctl) :on-key-down "x")
+              (is (= before (app-db))
+                  "the key site fires on every key and settles a no-op for most")))
+
+          (testing "blur commits"
+            (seed-line! 1)
+            (fire! (ctl) :on-input "REF-BLUR")
+            (fire! (ctl) :on-blur)
+            (is (= "REF-BLUR" (get-in (app-db) [:invoice 1 :reference]))))
+
+          (testing "and Escape BEATS a blur already on its way — the
+                    cancelled draft is not resurrected by the blur that
+                    follows it"
+            (seed-line! 1)
+            (fire! (ctl) :on-input "REF-GONE")
+            (let [late-blur (intent (ctl) :on-blur)]
+              (is (some? late-blur) "non-vacuous: a blur really was in flight")
+              (fire! (ctl) :on-key-down "Escape")
+              (send! late-blur))
+            (is (= "REF-1" (get-in (app-db) [:invoice 1 :reference]))
+                "the late blur found no live edit")
+            (is (= 0 (::pilot/accepted (app-db) 0))
+                "and the caller's accept event never fired")))))))
+
+(deftest r-a7-a-repeated-commit-is-idempotent
+  (testing "R-A7. A double blur — or a blur behind an Enter — dispatches
+            the caller's event exactly once, because the second commit
+            consults committed state and finds no record."
+    (each-mode
+      (fn [mode]
+        (seed-line! 1)
+        (let [ctl (control-of (buffered-node (render! (line-form mode 1)) "reference"))]
+          (fire! ctl :on-input "REF-ONCE")
+          (let [blur (intent ctl :on-blur)]
+            (send! blur)
+            (send! blur)
+            (send! blur)))
+        (is (= "REF-ONCE" (get-in (app-db) [:invoice 1 :reference])))
+        (is (= 1 (::pilot/accepted (app-db)))
+            "exactly one caller event for three fires")))))
+
+;; ===========================================================================
+;; R-A8 — N instances, zero collisions, zero coordination
+;; ===========================================================================
+
+(deftest r-a8-two-lines-hold-independent-drafts-and-values
+  (testing "R-A8. The same two components, twice on one page, with no
+            coordination between them. Each buffered record is addressed
+            by the domain identity that owns it, so an edit at one line
+            moves one record and leaves the other showing its own
+            baseline."
+    (each-mode
+      (fn [mode]
+        (seed-lines! [1 2])
+        (let [roots (fn [] (nodes (render! (lines-form mode [1 2]))
+                                  #(= "acme/invoice-line" (:data-component (:attrs %)))))]
+          (fire! (control-of (buffered-node (first (roots)) "reference"))
+                 :on-input "DRAFT-1")
+          (fire! (control-of (field-node (first (roots)) "description"))
+                 :on-input "Line one")
+
+          (is (= "DRAFT-1" (:value (t/attrs (control-of (buffered-node (first (roots)) "reference")))))
+              "line 1 shows its draft")
+          (is (= "REF-2" (:value (t/attrs (control-of (buffered-node (second (roots)) "reference")))))
+              "line 2 still shows its own baseline")
+          (is (= "Line one" (:value (t/attrs (control-of (field-node (first (roots)) "description"))))))
+          (is (= "Consulting" (:value (t/attrs (control-of (field-node (second (roots)) "description"))))))
+
+          (is (= 1 (count (get (app-db) pilot/records-root)))
+              "exactly one controller record exists")
+          (is (some? (record [:invoice 1 :reference])) "and it belongs to line 1")
+          (is (nil? (record [:invoice 2 :reference])))
+
+          (testing "rejecting line 1's draft leaves line 2 untouched"
+            (send! [:acme.invoice/reference-refused 1 "That reference is not on file."])
+            (is (= "REF-1" (:value (t/attrs (control-of (buffered-node (first (roots)) "reference"))))))
+            (is (= "REF-2" (:value (t/attrs (control-of (buffered-node (second (roots)) "reference"))))))))))))
+
+;; ===========================================================================
+;; R-A9 — asynchronous transform race safety
+;; ===========================================================================
+
+(deftest r-a9-an-async-normalisation-neither-flickers-nor-needs-arity-tricks
+  (testing "R-A9. The committed reference goes away to be normalised. The
+            settle carries the token of the request it answers, so a
+            superseded reply is INERT; the accepted reply advances the
+            generation, which is what makes the normalised value visible
+            even when it is character-for-character what the user typed.
+            No done-fn, no arity sniffing, no second callback contract."
+    (each-mode
+      (fn [mode]
+        (seed-line! 1)
+        (send! [:acme.invoice/reference-submitted 1 "ref-99" :req-1])
+        (is (true? (rf/subscribe-once [:acme.invoice/normalising? 1] {:frame fid})))
+
+        (testing "a reply to a request the caller has already superseded
+                  lands nowhere"
+          (send! [:acme.invoice/reference-submitted 1 "ref-100" :req-2])
+          (send! [:acme.invoice/reference-normalised 1 :req-1 "REF-99"])
+          (is (= "REF-1" (get-in (app-db) [:invoice 1 :reference]))
+              "the stale reply did not move the value")
+          (is (nil? (::pilot/normalised (app-db)))
+              "and produced no settle at all"))
+
+        (testing "the current reply lands, and the control follows it"
+          (send! [:acme.invoice/reference-normalised 1 :req-2 "REF-100"])
+          (is (= ["REF-100"] (::pilot/normalised (app-db))))
+          (is (= "REF-100" (shown-buffered (render! (line-form mode 1)) "reference"))))
+
+        (testing "and a normalisation that returns exactly what was
+                  submitted still shows — the generation moved even though
+                  the value did not"
+          (fire! (control-of (buffered-node (render! (line-form mode 1)) "reference"))
+                 :on-input "REF-TYPED")
+          (send! [:acme.invoice/reference-submitted 1 "REF-100" :req-3])
+          (let [before (get-in (app-db) [:invoice 1 :reference])]
+            (send! [:acme.invoice/reference-normalised 1 :req-3 "REF-100"])
+            (is (= before (get-in (app-db) [:invoice 1 :reference]))
+                "non-vacuous: the value is unchanged across the settle")
+            (is (= "REF-100" (shown-buffered (render! (line-form mode 1)) "reference"))
+                "yet the typed draft is gone from the display")))))))
+
+(deftest r-a9-rendering-is-free-of-consequence
+  (testing "R-A9's structural precondition, and R-A2's. The buffered read
+            is a pure function of (record, generation, baseline), so
+            repeating a render is uneventful — no render-time dispatch, no
+            render-phase mutation, nothing to abandon. That is what makes
+            a concurrent restart, a StrictMode double-invoke and a
+            rejected candidate all ordinary, and it is why the caret never
+            has to be rescued."
+    (each-mode
+      (fn [mode]
+        (seed-line! 1)
+        (fire! (control-of (buffered-node (render! (line-form mode 1)) "reference"))
+               :on-input "REF-DRAFT")
+        (let [before  (app-db)
+              results (vec (repeatedly 4 #(shown-buffered (render! (line-form mode 1))
+                                                          "reference")))]
+          (is (= before (app-db)) "four renders moved no state at all")
+          (is (apply = results) "and every pass displayed the same thing")
+          (is (= "REF-DRAFT" (first results))
+              "non-vacuous: what they agreed on is the live draft"))))))
+
+;; ===========================================================================
+;; R-A10 — busy from the in-flight write's own state
+;; ===========================================================================
+
+(deftest r-a10-busy-comes-from-the-write-not-a-local-flag
+  (testing "R-A10. The buffered control disables while its own
+            normalisation is in flight, and re-enables when the reply
+            settles. Nothing anywhere holds a `busy?` boolean of its own."
+    (each-mode
+      (fn [mode]
+        (seed-line! 1)
+        (is (false? (:disabled (t/attrs (control-of (buffered-node (render! (line-form mode 1))
+                                                                    "reference")))))
+            "idle: present-false, so the fact is stated rather than absent")
+        (send! [:acme.invoice/reference-submitted 1 "REF-2" :req-1])
+        (is (true? (:disabled (t/attrs (control-of (buffered-node (render! (line-form mode 1))
+                                                                  "reference")))))
+            "in flight: disabled")
+        (send! [:acme.invoice/reference-normalised 1 :req-1 "REF-2"])
+        (is (false? (:disabled (t/attrs (control-of (buffered-node (render! (line-form mode 1))
+                                                                    "reference")))))
+            "settled: enabled again")))))
+
+;; ===========================================================================
+;; R-A11 — headless assertability
+;; ===========================================================================
+
+(deftest r-a11-the-whole-loop-is-assertable-without-a-browser
+  (testing "R-A11. Draft, validity and gate in one pass, with no DOM and
+            no test hooks in the markup: the components are reached by
+            their PUBLIC part addresses, the intents are read as data and
+            fired by equality, and the derived gate is an ordinary value.
+            No `data-testid` appears anywhere in the pilot."
+    (each-mode
+      (fn [mode]
+        (seed-line! 1 {:quantity ""})
+        (let [tree (render! (line-form mode 1))]
+          (is (empty? (nodes tree #(contains? (:attrs %) :data-testid)))
+              "the pilot carries no test-only attribute")
+          (is (= ["root" "label" "control"]
+                 (mapv #(:data-part (:attrs %))
+                       (nodes (field-node tree "quantity")
+                              #(contains? (:attrs %) :data-part))))
+              "the parts a caller may style are exactly the ones emitted"))
+
+        (send! [:acme.invoice/field-blurred 1 :quantity])
+        (is (= "A quantity is required."
+               (t/text (error-of (field-node (render! (line-form mode 1)) "quantity"))))
+            "the error is reachable by part address")
+        (is (false? (rf/subscribe-once [:acme.invoice/can-submit? 1] {:frame fid}))
+            "and the gate is an ordinary value")
+
+        (type! mode 1 "quantity" "4")
+        (is (nil? (error-of (field-node (render! (line-form mode 1)) "quantity")))
+            "typing a valid quantity clears the display")
+        (is (true? (rf/subscribe-once [:acme.invoice/can-submit? 1] {:frame fid}))
+            "and flips the gate — the whole loop, headless")))))
+
+;; ===========================================================================
+;; R-A12 — per-keystroke cost, stated mechanically
+;; ===========================================================================
+
+(defn- per-keystroke
+  "Drive ONE keystroke and answer what it cost: the events that settled,
+  the leaf paths that moved in the frame, and which of the form's declared
+  reads changed value.
+
+  `reads` is the roster of queries the four-field form makes, so the third
+  number is the invalidation fan-out an author actually pays."
+  [reads keystroke!]
+  (let [seen (atom [])]
+    (rf/register-listener! :events ::keystroke-probe #(swap! seen conj (:event-id %)))
+    (let [before      (app-db)
+          before-vals (mapv #(rf/subscribe-once % {:frame fid}) reads)
+          _           (keystroke!)
+          after       (app-db)
+          after-vals  (mapv #(rf/subscribe-once % {:frame fid}) reads)]
+      (rf/unregister-listener! :events ::keystroke-probe)
+      {:events       @seen
+       :db-paths     (moved-paths before after)
+       :reads-moved  (into [] (keep-indexed (fn [i q]
+                                              (when (not= (nth before-vals i)
+                                                          (nth after-vals i))
+                                                q)))
+                           reads)})))
+
+(def ^:private form-reads
+  "Every query the four-field form and its buffered field make of the
+  application, for one line."
+  [[:acme.invoice/line 1]
+   [:acme.invoice/normalising? 1]
+   [:acme.invoice/can-submit? 1]
+   [:acme.invoice/line-total 1]
+   [:acme.invoice/theme]
+   [:acme.invoice/field-error 1 :description]
+   [:acme.invoice/field-error 1 :quantity]
+   [:acme.invoice/field-error 1 :unit-price]
+   [:acme.invoice/field-error 1 :account]
+   [:acme.invoice/reference 1]
+   [:acme.invoice/reference-revision 1]])
+
+(deftest r-a12-the-per-keystroke-cost-of-a-four-field-form
+  (testing "R-A12. EVIDENCE, not a threshold: what one keystroke costs on
+            a four-field form with a buffered fifth. The numbers are
+            asserted exactly so a change to them is a visible decision
+            rather than a drift."
+    (each-mode
+      (fn [mode]
+        (testing "a keystroke in a CONTROLLED field"
+          (seed-line! 1)
+          (let [c   (control-of (field-node (render! (line-form mode 1)) "quantity"))
+                ev  (:on-input (t/attrs c))
+                cost (per-keystroke form-reads
+                                    #(send! (v/materialize-event ev {::v/value "21"})))]
+            (is (= [:acme.ui.field/changed :acme.invoice/field-edited] (:events cost))
+                "TWO events: the library's site, then the caller's own handler")
+            (is (= [[:invoice 1 :quantity]] (:db-paths cost))
+                "ONE leaf path moved in the frame")
+            (is (= [[:acme.invoice/line 1]
+                    [:acme.invoice/line-total 1]]
+                   (:reads-moved cost))
+                "TWO of the form's eleven reads moved")))
+
+        (testing "a keystroke in the BUFFERED field"
+          (seed-line! 1)
+          (let [c    (control-of (buffered-node (render! (line-form mode 1)) "reference"))
+                down (:on-key-down (t/attrs c))
+                edit (:on-input (t/attrs c))
+                cost (per-keystroke form-reads
+                                    (fn []
+                                      (send! (v/materialize-event down {::v/key "R"}))
+                                      (send! (v/materialize-event edit {::v/value "REF-1R"}))))]
+            (is (= [:acme.ui.buffered/key-pressed :acme.ui.buffered/edited] (:events cost))
+                "TWO events: the keydown site settles a no-op, then the edit")
+            (is (= [[:acme.ui/controllers]] (:db-paths cost))
+                "ONE location moved — the record is written atomically, so the
+                 first keystroke of a session materializes the library's whole
+                 root and later ones move the record alone")
+            (is (= [] (:reads-moved cost))
+                "and NONE of the form's application reads moved: a draft is the
+                 library's own state, invisible to the caller until it commits")))
+
+        (testing "the fan-out is stated honestly: a props-only field takes
+                  its value as a prop, so the PARENT boundary is what a
+                  keystroke invalidates. Every field on the line
+                  re-renders, and only the edited one's props changed."
+          (seed-line! 1)
+          (let [before (render! (line-form mode 1))]
+            (send! [:acme.invoice/field-edited 1 :quantity "7"])
+            (let [after (render! (line-form mode 1))]
+              (is (not= before after) "the line's tree moved")
+              (is (= (field-node before "account") (field-node after "account"))
+                  "while three of the four fields render byte-identical output"))))))))
+
+;; ===========================================================================
+;; Promotion parity — the same suite, and the same trees
+;; ===========================================================================
+
+(defn- as-mode-ids
+  "Rewrite the interpreted view-ids onto the promoted twins' namespace —
+  the only difference living in another file makes."
+  [tree]
+  (walk/postwalk
+    (fn [x]
+      (if (and (keyword? x) (= "re-frame.freehand.pilot-field" (namespace x)))
+        (keyword "re-frame.freehand.pilot-field-compiled" (name x))
+        x))
+    tree))
+
+(deftest promotion-changes-no-call-site-and-no-structural-output
+  (testing "Adding `{:compiled true}` is the whole diff. Every call site
+            in `invoice-line` is byte-identical between the two files, the
+            props maps are the same maps, and the structural tree the two
+            modes render is the same value once the view-id namespace is
+            substituted."
+    (seed-line! 1)
+    (send! [:acme.invoice/field-blurred 1 :quantity])
+    (frame/replace-app-db! fid (assoc-in (app-db) [:invoice 1 :quantity] "oops"))
+    (let [interpreted (render! (line-form :interpreted 1))
+          compiled    (render! (line-form :compiled 1))]
+      (is (= (as-mode-ids interpreted) compiled)
+          "one tree, from two modes, over a state that exercises a branch"))
+
+    (testing "with the drafted, rejected and resumed states too"
+      (fire! (control-of (buffered-node (render! (line-form :interpreted 1)) "reference"))
+             :on-input "REF-PARITY")
+      (is (= (as-mode-ids (render! (line-form :interpreted 1)))
+             (render! (line-form :compiled 1))))
+      (send! [:acme.invoice/reference-refused 1 "That reference is not on file."])
+      (is (= (as-mode-ids (render! (line-form :interpreted 1)))
+             (render! (line-form :compiled 1)))))))
+
+(deftest the-parity-proof-is-not-vacuous
+  (testing "A parity proof where both sides are interpreted proves
+            nothing, so each side's declared lowering is asserted before
+            its output is trusted."
+    (doseq [[nm interpreted] pilot/by-name]
+      (let [promoted-view (get promoted/by-name nm)]
+        (is (some? promoted-view) (str nm " has a promoted twin"))
+        (is (= :interpreted (:lowering (v/describe interpreted)))
+            (str nm " is declared interpreted"))
+        (is (= :compiled (:lowering (v/describe promoted-view)))
+            (str nm " is declared compiled"))
+        (is (= (:props-schema (v/describe interpreted))
+               (:props-schema (v/describe promoted-view)))
+            (str nm "'s props contract is the same contract in both modes"))))))
+
+(deftest the-compiled-twins-carry-a-real-manifest
+  (testing "What promotion actually buys, read off the public
+            inspection surface: a compiled declaration reports its
+            analysis, and an interpreted one honestly reports nothing."
+    (doseq [[nm interpreted] pilot/by-name]
+      (is (nil? (v/manifest interpreted))
+          (str nm " interpreted: no analysis to claim"))
+      (let [m (v/manifest (get promoted/by-name nm))]
+        (is (= :re-frame.freehand/v1 (:grammar m))
+            (str nm " compiled: analysed under the v1 grammar"))
+        (is (= (get {:field          true
+                     :buffered-field true
+                     :invoice-line   true
+                     :invoice-lines  false}
+                    nm)
+               (:reactive? m))
+            (str nm " compiled: the capability-elision verdict, on an exact
+                 view rather than a threshold"))))
+    (testing "and the elision is real: the list wrapper reads nothing and
+              owns no committed site, so promotion drops its ViewCell
+              entirely — the one measurable thing compilation buys this
+              pilot"
+      (is (false? (:reactive? (v/manifest promoted/invoice-lines))))
+      (is (= :elided (:view-cell (v/manifest promoted/invoice-lines))))
+      (is (= :present (:view-cell (v/manifest promoted/invoice-line)))
+          "non-vacuous: a view that DOES read keeps its cell"))))
+
+;; ===========================================================================
+;; The library's public surface — schema, parts, tokens
+;; ===========================================================================
+
+(deftest the-props-schema-closes-the-props-map
+  (testing "A declared schema CLOSES the map: a misspelled prop is an
+            error rather than a value the view will silently never read.
+            The schema is inert data — it names which props are legal, and
+            validating their VALUES is a separate seam — so the pilot
+            states what it closes and nothing more."
+    (each-mode
+      (fn [mode]
+        (let [declared (:props-schema (v/describe (get-in modes [mode :field])))]
+          (is (= :map (first declared)) "the schema is a literal map schema")
+          (is (= [:name :label :value :on-input :on-blur :error :busy? :columns]
+                 (mapv first (rest declared)))
+              "and names every prop the component takes, in order"))))))
+
+(deftest the-part-addresses-are-the-published-ones
+  (testing "Part ids are API. Every id the components emit is in the
+            published roster, and every published id is actually emitted —
+            a roster that drifted from the markup would be worse than no
+            roster."
+    (seed-line! 1 {:description ""})
+    (send! [:acme.invoice/submit-attempted 1])
+    (send! [:acme.invoice/reference-refused 1 "That reference is not on file."])
+    (each-mode
+      (fn [mode]
+        (let [tree (render! (line-form mode 1))]
+          (doseq [[component ids] pilot/parts]
+            (let [emitted (into #{}
+                                (comp (mapcat #(nodes % (fn [n] (some? (:data-part (:attrs n))))))
+                                      (map #(:data-part (:attrs %))))
+                                (nodes tree #(= component (:data-component (:attrs %)))))]
+              (is (= (set ids) emitted)
+                  (str component " emits exactly its published parts")))))))))
+
+(deftest tokens-ride-the-cascade-and-the-one-dynamic-value-rides-inline
+  (testing "D018's two planes, as the pilot spells them. The theme is ONE
+            attribute on the form root, so a switch is an attribute change
+            the cascade resolves for every descendant — no token
+            subscription per leaf and no remount. The single value a
+            stylesheet cannot know rides as a namespaced custom property
+            on the one field that has it."
+    (each-mode
+      (fn [mode]
+        (seed-line! 1)
+        (let [form-node (component-node (render! (line-form mode 1)) "acme/invoice-line")]
+          (is (nil? (:data-part (:attrs form-node)))
+              "the form root publishes no part id — it is not a styling target")
+          (is (= "light" (:data-theme (t/attrs form-node))) "the theme scopes at the root")
+          (send! [:acme.invoice/theme-changed "dark"])
+          (let [after (component-node (render! (line-form mode 1)) "acme/invoice-line")]
+            (is (= "dark" (:data-theme (t/attrs after)))
+                "and a switch is one attribute, on one node")
+            (is (= (dissoc (t/attrs form-node) :data-theme)
+                   (dissoc (t/attrs after) :data-theme))
+                "non-vacuous: nothing else about the root moved")))
+
+        (let [tree (render! (line-form mode 1))]
+          (is (= {:--acme-field-columns "40"}
+                 (:style (t/attrs (field-node tree "description"))))
+              "the one dynamic token rides inline, namespaced")
+          (is (nil? (:style (t/attrs (field-node tree "quantity"))))
+              "and a field without one emits no style at all"))))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_compiled.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_compiled.cljc
@@ -1,0 +1,151 @@
+(ns re-frame.freehand.pilot-field-compiled
+  "The [[re-frame.freehand.pilot-field]] declarations, PROMOTED.
+
+  Every declaration below is its twin in [[re-frame.freehand.pilot-field]]
+  with `{:compiled true}` added to the options map and NOTHING else
+  changed — same docstring-free body text, same parameter vector, same
+  props schema, same part addresses, same event sites. The call sites
+  inside `invoice-line` are byte-identical to the interpreted file's;
+  they resolve to this namespace's twins because that is where they
+  lexically sit, which is the only difference living in another file
+  makes.
+
+  Separate namespaces because a view id is derived from where a
+  declaration LIVES, so two declarations of one name cannot share a
+  namespace. The parity suite rewrites exactly that one namespace
+  component and asserts everything else is equal.
+
+  The library's dataflow is NOT re-registered here: `pilot-field/register!`
+  and `pilot-field/register-app!` are ordinary re-frame registrations that
+  know nothing about execution mode, which is itself part of what
+  promotion parity means."
+  (:require [re-frame.freehand :as v]
+            [re-frame.freehand.control :as control]
+            [re-frame.freehand.pilot-field :refer [buffered-kind]]))
+
+(v/defview field
+  {:compiled true
+   :props    [:map
+              [:name :string]
+              [:label :string]
+              [:value :string]
+              [:on-input :vector]
+              [:on-blur {:optional true} [:maybe :vector]]
+              [:error {:optional true} [:maybe :string]]
+              [:busy? {:optional true} :boolean]
+              [:columns {:optional true} :int]]}
+  [{:keys [name label value on-input on-blur error busy? columns]}]
+  (let [error-id (str "acme-field-" name "-error")]
+    [:label {:data-component "acme/field"
+             :data-part      "root"
+             :data-field     name
+             :class          "acme-field"
+             :style          (when columns {:--acme-field-columns columns})}
+     [:span {:data-part "label"} label]
+     [:input {:data-part        "control"
+              :type             "text"
+              :value            value
+              :disabled         busy?
+              :aria-invalid     (when error "true")
+              :aria-describedby (when error error-id)
+              :on-input         [:acme.ui.field/changed on-input ::v/value]
+              :on-blur          on-blur}]
+     (when error
+       [:span {:data-part "error" :id error-id :role "alert"} error])]))
+
+(v/defview buffered-field
+  {:compiled true
+   :props    [:map
+              [:name :string]
+              [:label :string]
+              [:control :any]
+              [:value :string]
+              [:reset-key :any]
+              [:on-commit :vector]
+              [:error {:optional true} [:maybe :string]]
+              [:busy? {:optional true} :boolean]]}
+  [{:keys [name label value on-commit error busy?] :as props}]
+  (let [k        (control/record-key buffered-kind props)
+        g        (control/reset-revision buffered-kind props)
+        error-id (str "acme-buffered-" name "-error")]
+    [:label {:data-component "acme/buffered-field"
+             :data-part      "root"
+             :data-field     name
+             :class          "acme-buffered-field"}
+     [:span {:data-part "label"} label]
+     [:input {:data-part        "control"
+              :type             "text"
+              :value            (v/sub [:acme.ui.buffered/text k g value])
+              :disabled         busy?
+              :aria-invalid     (when error "true")
+              :aria-describedby (when error error-id)
+              :on-input         [:acme.ui.buffered/edited k g ::v/value]
+              :on-key-down      [:acme.ui.buffered/key-pressed k g on-commit ::v/key]
+              :on-blur          [:acme.ui.buffered/committed k g on-commit]}]
+     (when error
+       [:span {:data-part "error" :id error-id :role "alert"} error])]))
+
+(v/defview invoice-line
+  {:compiled true
+   :props    [:map [:id :any]]}
+  [{:keys [id]}]
+  (let [line    (v/sub [:acme.invoice/line id])
+        busy?   (v/sub [:acme.invoice/normalising? id])
+        gate    (v/sub [:acme.invoice/can-submit? id])
+        total   (v/sub [:acme.invoice/line-total id])
+        theme   (v/sub [:acme.invoice/theme])]
+    [:form {:data-component "acme/invoice-line"
+            :data-theme     theme
+            :on-submit      {:event [:acme.invoice/submit-attempted id]
+                             :prevent-default true}}
+     [field {:name     "description"
+             :label    "Description"
+             :value    (or (:description line) "")
+             :columns  40
+             :error    (v/sub [:acme.invoice/field-error id :description])
+             :on-input [:acme.invoice/field-edited id :description]
+             :on-blur  [:acme.invoice/field-blurred id :description]}]
+     [field {:name     "quantity"
+             :label    "Quantity"
+             :value    (or (:quantity line) "")
+             :error    (v/sub [:acme.invoice/field-error id :quantity])
+             :on-input [:acme.invoice/field-edited id :quantity]
+             :on-blur  [:acme.invoice/field-blurred id :quantity]}]
+     [field {:name     "unit-price"
+             :label    "Unit price"
+             :value    (or (:unit-price line) "")
+             :error    (v/sub [:acme.invoice/field-error id :unit-price])
+             :on-input [:acme.invoice/field-edited id :unit-price]
+             :on-blur  [:acme.invoice/field-blurred id :unit-price]}]
+     [field {:name     "account"
+             :label    "Account"
+             :value    (or (:account line) "")
+             :error    (v/sub [:acme.invoice/field-error id :account])
+             :on-input [:acme.invoice/field-edited id :account]
+             :on-blur  [:acme.invoice/field-blurred id :account]}]
+     [buffered-field {:name      "reference"
+                      :label     "Reference"
+                      :control   [:invoice id :reference]
+                      :value     (or (v/sub [:acme.invoice/reference id]) "")
+                      :reset-key (v/sub [:acme.invoice/reference-revision id])
+                      :busy?     busy?
+                      :error     (v/sub [:acme.invoice/reference-error id])
+                      :on-commit [:acme.invoice/reference-accepted id]}]
+     [:output {:data-part "total"} (str total)]
+     [:button {:data-part "submit" :type "submit" :disabled (not gate)} "Save"]]))
+
+(v/defview invoice-lines
+  {:compiled true
+   :props    [:map [:ids [:vector :any]]]}
+  [{:keys [ids]}]
+  [:div {:data-component "acme/invoice-lines"}
+   (for [id ids]
+     [invoice-line {:key id :id id}])])
+
+(def by-name
+  "Fixture view-name keyword -> the promoted declaration. Keyed
+  identically to `pilot-field`'s roster, so one table drives both modes."
+  {:field          field
+   :buffered-field buffered-field
+   :invoice-line   invoice-line
+   :invoice-lines  invoice-lines})

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_dom_cljs_test.cljs
@@ -1,0 +1,509 @@
+(ns re-frame.freehand.pilot-field-dom-cljs-test
+  "THE FIRST PILOT in a real browser — the CASE A rows whose evidence is a
+  live DOM and cannot be anything else.
+
+  `pilot-field-cljs-test` fills in the structural half of §A.2. This file
+  fills in the half a tree cannot hold: whether a keystroke's state change
+  lands before the browser restores the node (R-A1), whether the caret,
+  the selection and an IME composition survive a value the substrate
+  reasserts (R-A2), and whether a caller's rejection RESTORES the input
+  rather than replacing it (R-A3).
+
+  It mounts the pilot's own `invoice-line` — the same four controlled
+  fields and one buffered field the structural suite renders, reached
+  through the same public `data-part` addresses, with no test-only
+  attribute anywhere in the markup.
+
+  ## What this suite is deliberate about
+
+  **The library's extra hop is under test, not assumed.** The pilot's
+  controlled field does not forward the caller's event vector into the
+  `:on-input` position; it owns a literal site and re-dispatches the
+  caller's event as an effect. That buys a static compiled door proof and
+  costs one more event per keystroke — and whether that event still
+  settles INSIDE the browser's discrete event is exactly the kind of
+  claim a pilot must prove rather than reason about. If the hop fell
+  outside the synchronous drain, `pilot-r-a1-rapid-typing-through-the-
+  librarys-own-site` would lose characters.
+
+  **The substrate is the REACTIVE, React-shaped one.** A controlled input
+  is the case where a correction must reach the host inside the event, so
+  the pilot runs on the React-hook spine exactly as `FH-INPUT-003` does.
+
+  **Typing appends.** A keystroke appends to whatever the node currently
+  holds and then fires a real bubbling `input` event, so a character the
+  host restored away is visible as a loss rather than papered over.
+
+  ## The coverage this suite does NOT have
+
+  Interpreted mode only. No compiled view is browser-mountable today —
+  `re-frame.freehand.react` refuses every compiled declaration with
+  `:rf.error/view-lowering-unavailable` — so the compiled arm of every row
+  below is BLOCKED, not passing and not failing. The compiled tier's
+  cross-mode evidence is the JVM structural parity in
+  `pilot-field-cljs-test`."
+  (:require ["react" :as react]
+            ["react-dom/client" :as rdc]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as react-substrate]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand.pilot-field :as pilot]
+            [re-frame.freehand.pilot-field-compiled :as promoted]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.shell :as shell]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       react-substrate/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(def ^:private fid :acme.pilot/frame)
+(def ^:private line-id 1)
+
+(def ^:private seed-line
+  {:description "Consulting"
+   :quantity    "2"
+   :unit-price  "150"
+   :account     "4000"
+   :reference   "REF-1"
+   :reference-revision 0})
+
+;; ---------------------------------------------------------------------------
+;; Browser seams
+;; ---------------------------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- skip! [why]
+  (is true (str "a real browser mount is required — " why)))
+
+(defn- act [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- live!
+  "Leave React's act environment: typing has to reach React as a genuine
+  DISCRETE event, which is the mechanism under test."
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  nil)
+
+(defn- native-value-setter []
+  (.-set (js/Object.getOwnPropertyDescriptor
+           (.-prototype js/HTMLInputElement) "value")))
+
+(defn- set-native-value! [node s]
+  (.call (native-value-setter) node s))
+
+(defn- fire-input!
+  ([node] (fire-input! node nil false))
+  ([node data composing?]
+   (.dispatchEvent node (js/InputEvent. "input"
+                                        #js {:bubbles     true
+                                             :cancelable  false
+                                             :data        data
+                                             :isComposing composing?}))))
+
+(defn- fire-key!
+  [node k]
+  (.dispatchEvent node (js/KeyboardEvent. "keydown"
+                                          #js {:bubbles true :cancelable true :key k})))
+
+(defn- fire-blur! [node]
+  (.dispatchEvent node (js/FocusEvent. "blur" #js {:bubbles false})))
+
+(defn- keystroke!
+  "One keystroke: APPEND `ch` to whatever the node currently holds, then
+  fire a real bubbling `input`. Appending is what makes a dropped
+  character visible."
+  [node ch]
+  (set-native-value! node (str (.-value node) ch))
+  (fire-input! node ch false))
+
+(defn- type-string! [node s]
+  (doseq [ch (seq s)] (keystroke! node (str ch))))
+
+(defn- insert-at!
+  "Insert `ch` at offset `at`, the way a browser does: the text grows at
+  the caret, the caret follows it, then `input` fires."
+  [node at ch]
+  (let [text (.-value node)]
+    (.focus node)
+    (.setSelectionRange node at at)
+    (set-native-value! node (str (subs text 0 at) ch (subs text at)))
+    (.setSelectionRange node (inc at) (inc at))
+    (fire-input! node ch false)))
+
+(defn- caret [node] [(.-selectionStart node) (.-selectionEnd node)])
+
+(defn- mount! []
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    [container (rdc/createRoot container)]))
+
+(defn- teardown! [container root]
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+  (.unmount root)
+  (.remove container)
+  nil)
+
+(defn- control
+  "The native control of the component named `nm`, reached by its PUBLIC
+  part address — no `data-testid` exists in the pilot to reach for."
+  [container nm]
+  (.querySelector container (str "[data-field='" nm "'] [data-part='control']")))
+
+(defn- error-text
+  [container nm]
+  (some-> (.querySelector container (str "[data-field='" nm "'] [data-part='error']"))
+          (.-textContent)))
+
+(defn- seed! []
+  (live-frame/make-frame {:id fid})
+  (frame/replace-app-db! fid {:invoice {line-id seed-line}})
+  (pilot/register!)
+  (pilot/register-app!)
+  fid)
+
+(defn- render-line! [root]
+  (act #(.render root (shell/provide-frame fid (fr/element [pilot/invoice-line {:id line-id}])))))
+
+(defn- app [] (frame/frame-app-db-value fid))
+(defn- line [] (get-in (app) [:invoice line-id]))
+
+(defn- send! [ev] (act #(rf/dispatch-sync ev {:frame fid})))
+
+(defn- draft []
+  (get-in (app) [pilot/records-root
+                 [pilot/buffered-kind [:invoice line-id :reference]]
+                 :draft]))
+
+(defn- with-line
+  "Mount the pilot line, leave the act environment, run `f` with the
+  container, and tear down. `f` may return a promise."
+  [f done]
+  (seed!)
+  (let [[container root] (mount!)]
+    (-> (render-line! root)
+        (.then (fn [_]
+                 (live!)
+                 (js/Promise.resolve (f container))))
+        (.then (fn [_] (teardown! container root) (done)))
+        (.catch (fn [e]
+                  (is false (str "the mounted pilot rejected: " e))
+                  (teardown! container root)
+                  (done))))))
+
+;; ===========================================================================
+;; R-A1 — same-tick echo, through the library's own event site
+;; ===========================================================================
+
+(deftest pilot-r-a1-rapid-typing-through-the-librarys-own-site
+  (testing "R-A1. A burst of keystrokes into the pilot's CONTROLLED field
+            yields a final value equal to the typed string character for
+            character, in the DOM and in application state alike — even
+            though every keystroke travels through the library's own
+            event and then out again as the caller's. The extra hop rides
+            inside the synchronous drain the door opened; if it did not,
+            characters would be lost here and nowhere else."
+    (if-not (browser?)
+      (skip! "the browser job runs the typing assertions")
+      (async done
+        (with-line
+          (fn [container]
+            (let [node  (control container "quantity")
+                  typed "1234567890123456789"]
+              (is (= "2" (.-value node)) "the field starts on the seeded value")
+              (set-native-value! node "")
+              (fire-input! node nil false)
+              (type-string! node typed)
+              (is (= typed (.-value node))
+                  "every one of the nineteen keystrokes survived in the DOM")
+              (is (= typed (:quantity (line)))
+                  "and application state holds exactly what was typed")))
+          done)))))
+
+(deftest pilot-r-a1-four-fields-contend-without-loss
+  (testing "R-A1 under contention. Four controlled fields and a buffered
+            fifth observe one frame, so every keystroke in any of them
+            dirties all of them. Typing into each in turn still yields
+            exactly what was typed — the frame-scoped flush settles the
+            whole line inside each listener."
+    (if-not (browser?)
+      (skip! "the browser job runs the contention assertions")
+      (async done
+        (with-line
+          (fn [container]
+            (doseq [[nm typed] [["description" "Design work"]
+                                ["quantity" "12"]
+                                ["unit-price" "99"]
+                                ["account" "4100"]]]
+              (let [node (control container nm)]
+                (set-native-value! node "")
+                (fire-input! node nil false)
+                (type-string! node typed)
+                (is (= typed (.-value node)) (str nm " kept every character"))))
+            (is (= {:description "Design work" :quantity "12"
+                    :unit-price "99" :account "4100"}
+                   (select-keys (line) [:description :quantity :unit-price :account]))
+                "and the whole line reads back exactly what was typed"))
+          done)))))
+
+;; ===========================================================================
+;; R-A2 — caret, selection, IME
+;; ===========================================================================
+
+(deftest pilot-r-a2-a-mid-string-insert-leaves-the-caret-where-it-was
+  (testing "R-A2. Editing in the middle of an existing value: the
+            character lands at the caret and the caret stays with it. A
+            round trip that completed late would put the whole value back
+            with the cursor at the end."
+    (if-not (browser?)
+      (skip! "the browser job runs the caret assertions")
+      (async done
+        (with-line
+          (fn [container]
+            (let [node (control container "description")]
+              (is (= "Consulting" (.-value node)))
+              (insert-at! node 3 "X")
+              (is (= "ConXsulting" (.-value node)) "the insert landed at the caret")
+              (is (= [4 4] (caret node)) "and the caret did not jump to the end")
+              (is (= "ConXsulting" (:description (line)))
+                  "with application state matching character for character")))
+          done)))))
+
+(deftest pilot-r-a2-a-range-selection-survives-the-round-trip
+  (testing "R-A2. A range selection made after the round trip is intact —
+            the node was neither replaced nor rewritten out from under
+            the user."
+    (if-not (browser?)
+      (skip! "the browser job runs the selection assertions")
+      (async done
+        (with-line
+          (fn [container]
+            (let [node   (control container "description")
+                  before node]
+              (insert-at! node 3 "X")
+              (.setSelectionRange node 2 6)
+              (is (= [2 6] (caret node)) "the range is set")
+              (insert-at! node 1 "Y")
+              (is (identical? before (control container "description"))
+                  "the control is the SAME node throughout")
+              (is (= "CYonXsulting" (.-value node)))
+              (is (= [2 2] (caret node))
+                  "and the caret is exactly where the browser put it")))
+          done)))))
+
+(deftest pilot-r-a2-an-ime-composition-completes-intact
+  (testing "R-A2. A composition is a sequence — start, updates, end — and
+            it dies if the node is replaced beneath it or its in-flight
+            text is rewritten between updates. What a headless Chromium
+            cannot supply is a platform input engine, so this drives the
+            composition-event protocol the browser really dispatches
+            rather than claiming to have exercised a Japanese IME."
+    (if-not (browser?)
+      (skip! "the browser job runs the composition assertions")
+      (async done
+        (with-line
+          (fn [container]
+            (let [node   (control container "description")
+                  before node
+                  steps  ["k" "ka" "かn" "かん" "かんじ"]
+                  final  "漢字"]
+              (set-native-value! node "")
+              (fire-input! node nil false)
+              (.focus node)
+              (.dispatchEvent node (js/CompositionEvent.
+                                     "compositionstart" #js {:bubbles true :data ""}))
+              (doseq [s steps]
+                (.dispatchEvent node (js/CompositionEvent.
+                                       "compositionupdate" #js {:bubbles true :data s}))
+                (set-native-value! node s)
+                (fire-input! node s true)
+                (is (= s (.-value node))
+                    (str "the composition's in-flight text survived update " (pr-str s)))
+                (is (identical? before (control container "description"))
+                    "and the node it is composing into was not replaced"))
+              (.dispatchEvent node (js/CompositionEvent.
+                                     "compositionend" #js {:bubbles true :data final}))
+              (set-native-value! node final)
+              (fire-input! node final false)
+              (is (= final (.-value node)) "the composition committed intact")
+              (is (= final (:description (line))) "and reached application state")))
+          done)))))
+
+;; ===========================================================================
+;; R-A3 — the same-value rejection, restored rather than remounted
+;; ===========================================================================
+
+(deftest pilot-r-a3-a-rejection-restores-the-baseline-on-the-same-node
+  (testing "R-A3, the row this whole design exists for. The user drafts
+            into the buffered field; the caller REFUSES the draft and
+            stands by the reference it already had. The value before that
+            decision and the value after it are identical, so nothing
+            derived from the value could have seen it — yet the baseline
+            comes back, on the SAME node, which still has focus. A
+            key-remount would put the right text on a different node and
+            an effect-driven reset would commit one stale frame first;
+            both would pass every structural assertion and fail here."
+    (if-not (browser?)
+      (skip! "the browser job runs the reject-and-restore assertions")
+      (async done
+        (with-line
+          (fn [container]
+            (let [node   (control container "reference")
+                  before node]
+              (is (= "REF-1" (.-value node)) "the control starts on the baseline")
+              (insert-at! node 4 "X")
+              (is (= "REF-X1" (.-value node)) "the draft is live in the DOM")
+              (is (= [5 5] (caret node)) "with the caret where the user put it")
+              (is (= "REF-X1" (draft)) "and it is controller state, not host state")
+
+              (let [reference-before (:reference (line))]
+                (-> (send! [:acme.invoice/reference-refused
+                            line-id "That reference is not on file."])
+                    (.then
+                      (fn [_]
+                        (is (= reference-before (:reference (line)))
+                            "non-vacuous: the caller's VALUE never moved")
+                        (is (= "REF-1" (.-value node)) "the baseline is back on screen")
+                        (is (identical? before (control container "reference"))
+                            "on the SAME node — restored, not remounted")
+                        (is (identical? before (.-activeElement js/document))
+                            "which still has focus")
+                        (is (= "That reference is not on file."
+                               (error-text container "reference"))
+                            "and the reason is displayed through the control's error part")))))))
+          done)))))
+
+(deftest pilot-r-a3-editing-resumes-at-the-new-generation
+  (testing "R-A3. After the rejection the user types again. The next edit
+            builds on the baseline the caller restored rather than on the
+            draft it refused, and the caret follows the insert."
+    (if-not (browser?)
+      (skip! "the browser job runs the resume assertions")
+      (async done
+        (with-line
+          (fn [container]
+            (let [node (control container "reference")]
+              (insert-at! node 4 "X")
+              (-> (send! [:acme.invoice/reference-refused line-id nil])
+                  (.then
+                    (fn [_]
+                      (insert-at! node 0 "A")
+                      (is (= "AREF-1" (.-value node))
+                          "the resumed edit built on the RESTORED baseline")
+                      (is (= [1 1] (caret node)) "and the caret followed the insert")
+                      (is (= "AREF-1" (draft))
+                          "the new draft is live controller state again"))))))
+          done)))))
+
+;; ===========================================================================
+;; R-A7 — the key protocol, with real keyboard events
+;; ===========================================================================
+
+(deftest pilot-r-a7-enter-commits-and-escape-reverts-in-the-dom
+  (testing "R-A7. Enter and Escape ride ONE registered event carrying the
+            live `KeyboardEvent.key`, so the browser proof is that the
+            real key events reach it and that the control follows."
+    (if-not (browser?)
+      (skip! "the browser job runs the keyboard assertions")
+      (async done
+        (with-line
+          (fn [container]
+            (let [node (control container "reference")]
+              (insert-at! node 4 "E")
+              (is (= "REF-E1" (.-value node)))
+              (fire-key! node "Enter")
+              (is (= "REF-E1" (:reference (line)))
+                  "Enter committed the draft to the caller")
+              (is (nil? (draft)) "and retired the session")
+              (is (= "REF-E1" (.-value node)) "the control now shows the accepted value")
+
+              (insert-at! node 0 "Z")
+              (is (= "ZREF-E1" (.-value node)) "a second draft is live")
+              (fire-key! node "Escape")
+              (is (= "REF-E1" (:reference (line)))
+                  "Escape left the caller's value alone")
+              (is (= "REF-E1" (.-value node))
+                  "and the control is back on the baseline")))
+          done)))))
+
+(deftest pilot-r-a7-a-blur-behind-an-escape-does-not-resurrect-the-draft
+  (testing "R-A7's ordering trap, in the DOM: Escape clears the record, so
+            the blur that follows it consults committed state and finds no
+            live edit. This is todomvc's documented
+            cancel-unmounts-then-blur-fires hazard, with nothing to
+            unmount."
+    (if-not (browser?)
+      (skip! "the browser job runs the blur-ordering assertions")
+      (async done
+        (with-line
+          (fn [container]
+            (let [node (control container "reference")]
+              (insert-at! node 4 "G")
+              (is (= "REF-G1" (draft)) "non-vacuous: a draft really is live")
+              (fire-key! node "Escape")
+              (fire-blur! node)
+              (is (= "REF-1" (:reference (line)))
+                  "the late blur found no live edit to commit")
+              (is (= "REF-1" (.-value node)))))
+          done)))))
+
+;; ===========================================================================
+;; R-A10 — busy disables the control, in the DOM
+;; ===========================================================================
+
+(deftest pilot-r-a10-the-control-disables-while-its-own-write-is-in-flight
+  (testing "R-A10. The buffered control's `disabled` follows the in-flight
+            normalisation's own state and nothing else — a real DOM
+            property, not an attribute a tree happens to carry."
+    (if-not (browser?)
+      (skip! "the browser job runs the busy assertions")
+      (async done
+        (with-line
+          (fn [container]
+            (let [node (control container "reference")]
+              (is (false? (.-disabled node)) "idle")
+              (-> (send! [:acme.invoice/reference-submitted line-id "REF-2" :req-1])
+                  (.then (fn [_]
+                           (is (true? (.-disabled node)) "in flight: disabled")
+                           (send! [:acme.invoice/reference-normalised
+                                   line-id :req-1 "REF-2"])))
+                  (.then (fn [_]
+                           (is (false? (.-disabled node)) "settled: enabled again")
+                           (is (= "REF-2" (.-value node))
+                               "and the normalised value is displayed"))))))
+          done)))))
+
+;; ===========================================================================
+;; The blocked cell, stated rather than skipped quietly
+;; ===========================================================================
+
+(deftest the-compiled-arm-of-every-row-above-is-blocked
+  (testing "No compiled view is browser-mountable today: the React
+            lowering refuses a compiled declaration outright. So every row
+            in this file covers interpreted mode ONLY, and the compiled
+            browser cell of the pilot's matrix is BLOCKED rather than
+            passing. Asserting the refusal here keeps that honest — the
+            day it stops refusing, this row goes red and the matrix is
+            re-opened."
+    (if-not (browser?)
+      (skip! "the browser job runs the lowering-refusal assertion")
+      (async done
+        (seed!)
+        (let [thrown (try
+                       (fr/element [promoted/invoice-line {:id line-id}])
+                       nil
+                       (catch :default e (:rf.error/id (ex-data e))))]
+          (is (= :rf.error/view-lowering-unavailable thrown)
+              "a compiled declaration cannot be lowered to React")
+          (done))))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_dom_cljs_test.cljs
@@ -410,10 +410,28 @@
 ;; R-A7 — the key protocol, with real keyboard events
 ;; ===========================================================================
 
+(defn- settle!
+  "Fire a NON-door interaction and let it settle.
+
+  Typing is different from every other interaction the pilot has: an
+  `:on-input` site on a controlled element is inside the synchronous
+  door, so its state change has landed by the time the listener returns.
+  A keydown and a blur are NOT — `onInput`/`onChange` is the whole door
+  roster — so they take the ordinary batched lane and settle at the next
+  host checkpoint. That is correct and invisible to a user, and it means
+  a browser test has to WAIT rather than assert straight after the
+  dispatch. Re-entering React's act environment is how this suite waits;
+  [[live!]] afterwards puts typing back on the discrete-event path."
+  [thunk]
+  (-> (act thunk)
+      (.then (fn [_] (live!) nil))))
+
 (deftest pilot-r-a7-enter-commits-and-escape-reverts-in-the-dom
   (testing "R-A7. Enter and Escape ride ONE registered event carrying the
             live `KeyboardEvent.key`, so the browser proof is that the
-            real key events reach it and that the control follows."
+            real key events reach it and that the control follows. Both
+            are outside the synchronous door by construction, so each is
+            allowed to settle before it is read back."
     (if-not (browser?)
       (skip! "the browser job runs the keyboard assertions")
       (async done
@@ -421,20 +439,25 @@
           (fn [container]
             (let [node (control container "reference")]
               (insert-at! node 4 "E")
-              (is (= "REF-E1" (.-value node)))
-              (fire-key! node "Enter")
-              (is (= "REF-E1" (:reference (line)))
-                  "Enter committed the draft to the caller")
-              (is (nil? (draft)) "and retired the session")
-              (is (= "REF-E1" (.-value node)) "the control now shows the accepted value")
-
-              (insert-at! node 0 "Z")
-              (is (= "ZREF-E1" (.-value node)) "a second draft is live")
-              (fire-key! node "Escape")
-              (is (= "REF-E1" (:reference (line)))
-                  "Escape left the caller's value alone")
-              (is (= "REF-E1" (.-value node))
-                  "and the control is back on the baseline")))
+              (is (= "REF-E1" (.-value node)) "the draft is live")
+              (-> (settle! #(fire-key! node "Enter"))
+                  (.then
+                    (fn [_]
+                      (is (= "REF-E1" (:reference (line)))
+                          "Enter committed the draft to the caller")
+                      (is (nil? (draft)) "and retired the session")
+                      (is (= "REF-E1" (.-value node))
+                          "the control now shows the accepted value")
+                      (insert-at! node 0 "Z")
+                      (is (= "ZREF-E1" (.-value node)) "a second draft is live")
+                      (settle! #(fire-key! node "Escape"))))
+                  (.then
+                    (fn [_]
+                      (is (= "REF-E1" (:reference (line)))
+                          "Escape left the caller's value alone")
+                      (is (= "REF-E1" (.-value node))
+                          "and the control is back on the baseline")
+                      (is (nil? (draft)) "with the session retired"))))))
           done)))))
 
 (deftest pilot-r-a7-a-blur-behind-an-escape-does-not-resurrect-the-draft
@@ -451,11 +474,16 @@
             (let [node (control container "reference")]
               (insert-at! node 4 "G")
               (is (= "REF-G1" (draft)) "non-vacuous: a draft really is live")
-              (fire-key! node "Escape")
-              (fire-blur! node)
-              (is (= "REF-1" (:reference (line)))
-                  "the late blur found no live edit to commit")
-              (is (= "REF-1" (.-value node)))))
+              (-> (settle! (fn []
+                             (fire-key! node "Escape")
+                             (fire-blur! node)))
+                  (.then
+                    (fn [_]
+                      (is (= "REF-1" (:reference (line)))
+                          "the late blur found no live edit to commit")
+                      (is (= 0 (:re-frame.freehand.pilot-field/accepted (app) 0))
+                          "and the caller's accept event never fired")
+                      (is (= "REF-1" (.-value node))))))))
           done)))))
 
 ;; ===========================================================================


### PR DESCRIPTION
EP-0036 slice F5f — the **first component pilot**. Two components built the way an
application author would build them, the invoice-line form that calls them, and the
fitness harness's CASE A §A.2 requirements judged one at a time.

The pilot is green. What follows is the part that matters more: what building it was
actually like, and the four places the substrate's promise needed care.

Three findings are filed as beads — **rf2-drpa3.121** (P1, `t/render`), **rf2-drpa3.122**
(P1, unpublished controller verbs; **now blocks rf2-drpa3.57, donor deletion**),
**rf2-drpa3.123** (P2, the door spelling) — plus **rf2-drpa3.124** (P3) carrying CASE A's
datum to the D007 gate.

---

## 1. What the authoring experience was actually like

**The good part is genuinely good, and it is the part that was supposed to be hard.**
The buffered field is a `v/defview`, one `reg-sub` worth of read and four `reg-event`s.
There is no controller DSL, no registry, no lifecycle hook, no second state system — the
ruling's claim that "a controller is a `v/defview` plus `reg-sub`s and `reg-event`s and
nothing else" is exactly true, and I did not once want anything more. Rejecting a live
draft is `(update-in db [:invoice id :reference-revision] inc)` in the application's own
event, and the control follows. The re-com defect this design exists to remove is not
merely fixed; there is no place left to put it.

The generation fence composes better than I expected. Because a superseded draft is
*invisible* rather than erased, the reset costs no write, nothing happens during render,
and `r-a9-rendering-is-free-of-consequence` asserts four renders leave the frame
byte-identical. Every awkward question a hand-rolled buffered input raises — what if the
render is abandoned, what about StrictMode, what about hot reload — simply does not arise.

**Three things made me think harder than the task deserved.**

**(a) The public structural-test surface refuses the views a form is made of.** This was
the single biggest friction, and it cost the most time. `t/render` is the blessed public
testing verb; it walks a body but opens no render candidate, so calling it on any view
containing a `v/sub` raises `:rf.error/view-read-outside-render`. That is every stateful
view. The substrate's own controller suites work around it with two INTERNAL functions
(`cell/candidate` + `cell/with-capture`), and this suite has to do the same — a private
`render-on!` helper reaching past the door, reproduced deliberately by
`t-render-alone-cannot-render-a-state-reading-view` so the gap is a red test rather than a
sentence in a PR. **rf2-drpa3.121.**

**(b) The library's own dependencies are not published.** `control/record-key`,
`control/reset-revision` and `control/current?` are the mechanism by which a controller
*is* writable and buffered — D016 makes the revision required — and none of the three is
on the API manifest (`re-frame.freehand.control` is `^:no-doc`, and the manifest generator
scans only `re-frame.freehand` and `re-frame.freehand.test`). So a pilot that is consumer
code by construction has to `:require` an internal namespace to exist at all. It works and
it is green; what is missing is a *decision* about what a component library is on this
surface. Three honest options are on the bead. **rf2-drpa3.122** — filed as a blocker on
**rf2-drpa3.57** (donor deletion), because the F6 decision should not be taken while a
shipped library's dependencies are undeclared.

**(c) The obvious spelling of a reusable controlled input loses the compiled door.** A
library input written the natural way — `[:input {:value value :on-input on-input}]`, the
caller supplying the whole event vector — takes the synchronous door interpreted (the
runtime sees a vector) and **batches once promoted**, because the compiled site proof is
static and a forwarded symbol classifies `:dynamic`. That is D009's one promotion-parity
break, reached not by a substrate divergence but by an author's choice of spelling. The
pilot ships the spelling that keeps the door in both modes — a library-owned LITERAL site
carrying the caller's event as an argument:

```clojure
[:input {:value    value
         :on-input [:acme.ui.field/changed on-input ::v/value]}]
```

with `:acme.ui.field/changed` re-dispatching `(conj on-input text)`. The call site is
cleaner for it (the caller never writes a projection marker), and the browser suite proves
the extra hop rides inside the synchronous drain: nineteen keystrokes, no drops. What is
missing is one normative sentence saying which spelling is paved. **rf2-drpa3.123.**

**Not a finding, but worth an author's time:** `(str 225.0)` is `"225.0"` on the JVM and
`"225"` in ClojureScript, so a `.cljc` view that prints a raw double is host-sensitive by
construction. Caught by the cross-host arm of R-A4; noted in the test.

## 2. Where the substrate's promise did not hold

**Nowhere, with one clarification that is behaviour rather than breakage.**

Every D009/D016 claim I leaned on held under a real browser: same-tick echo through an
extra dispatch hop, caret preservation on a mid-string insert, a range selection intact
across a round trip, an IME composition completing on the node it started on, and a
same-value rejection restoring the baseline **on the identical node, still focused**.

The clarification: **the keyboard commit is outside the synchronous door**, correctly and
by construction — the door roster is `onInput`/`onChange` only. So Enter-to-commit and
Escape-to-revert settle at the next host checkpoint rather than inside the listener. This
is invisible to a user (no input can arrive between the keydown and the checkpoint in one
task) but very visible to a browser test, which must wait. It cost a red run to discover,
and the suite now names it in `settle!` rather than hiding it behind an `act` call. Nothing
to fix; worth knowing before the next pilot writes the same test.

## 3. What I wanted that does not exist

**An author would need** (both filed): a public render bracket for structural tests
(rf2-drpa3.121) and a decision on the controller verbs' publication (rf2-drpa3.122). The
first is a real ergonomic wall — the corpus's 364 `data-testid`s exist because browser
tests are how things get found, and this pilot uses **zero** of them precisely because
headless structural assertion is better; that argument only holds if the door is open.

**I wanted, but an author does not need:** `v/spread-safe` on the door for D018's bounded
`:parts` maps (that is F5a/rf2-drpa3.38 — the pilot does the *portable* plane, tokens and
part addresses, which needs nothing from the substrate); a compile-tier warning for a
`:dynamic` handler on a controlled element (mechanically detectable, but a normative
sentence may be enough — noted as optional on rf2-drpa3.123); and richer manifest
projection (`v/manifest` exposes event `:sid`/`:path` but not the site's classification or
door verdict, so the pilot cannot assert its own door verdict in compiled mode and cites
FH-INPUT-001 instead).

**I deliberately did not ask for** a key-condition map. CASE A expresses Enter/Escape as
one registered event carrying `::v/key` — intent as data, driven by equality on the JVM —
and the only `preventDefault` it wants is form-level, which the existing options map
already covers. The real CASE A argument for the key map turns out to be **dispatch
suppression** (the data site fires on every key; the pilot's R-A12 row asserts the extra
no-op event), which is a different argument from the one in D007 and should be weighed on
its own. **rf2-drpa3.124** carries it to the gate; the gate itself stays F5g's.

## 4. The exact host/mode matrix exercised

| | JVM structural | node structural | browser (real DOM) |
|---|---|---|---|
| **interpreted** | 24 tests | same 24 tests | 10 tests |
| **compiled** | same 24 tests | same 24 tests | **BLOCKED** |

The compiled-browser cell is **blocked on rf2-drpa3.113** — `react.cljs` refuses every
compiled declaration with `:rf.error/view-lowering-unavailable`. It is not passing and not
failing; `the-compiled-arm-of-every-row-above-is-blocked` asserts the refusal, so the day
it lifts, that row goes red and the matrix re-opens. Compiled cross-mode evidence is
therefore JVM/node structural only — the same basis `top_layer_parity` and
`presence_parity` already use.

Every cross-host test runs its assertions over **both** modes via `each-mode`;
`the-parity-proof-is-not-vacuous` asserts each side's declared `:lowering` before its
output is trusted.

## CASE A §A.2 — every requirement, with its proving test

| # | Requirement | Proving test(s) | Host/mode |
|---|---|---|---|
| R-A1 | Same-tick echo | `r-a1-every-editing-site-is-inside-the-controlled-input-door`, `r-a1-the-caller-never-writes-a-projection-marker` | JVM+node, both modes |
| | | `pilot-r-a1-rapid-typing-through-the-librarys-own-site` (19 keystrokes, char-for-char), `pilot-r-a1-four-fields-contend-without-loss` | browser, interpreted |
| R-A2 | Caret / selection / IME | `pilot-r-a2-a-mid-string-insert-leaves-the-caret-where-it-was`, `pilot-r-a2-a-range-selection-survives-the-round-trip`, `pilot-r-a2-an-ime-composition-completes-intact` | browser, interpreted |
| | | `r-a2-is-owed-to-the-browser` states the split rather than stubbing a structural proxy | — |
| R-A3 | Same-value rejection visible | `r-a3-a-rejection-lands-even-though-the-value-never-moved`, `r-a3-an-external-value-change-is-not-a-rejection` | JVM+node, both modes |
| | | `pilot-r-a3-a-rejection-restores-the-baseline-on-the-same-node` (same node, focus kept), `pilot-r-a3-editing-resumes-at-the-new-generation` | browser, interpreted |
| R-A4 | Draft vs canonical, no reformat-jitter | `r-a4-raw-text-and-canonical-value-coexist` (`"1."` echoes verbatim; canonical is nil) | JVM+node, both modes |
| R-A5 | Validation display gated by touch/attempt | `r-a5-errors-appear-only-after-touch-or-submit-attempt`, `r-a5-gating-is-per-instance` | JVM+node, both modes |
| R-A6 | Derived gate that cannot go stale | `r-a6-the-submit-gate-cannot-go-stale` (view and handler read one definition; red in both directions) | JVM+node, both modes |
| R-A7 | Enter / Escape / blur protocol | `r-a7-enter-commits-escape-reverts-blur-commits`, `r-a7-a-repeated-commit-is-idempotent` | JVM+node, both modes |
| | | `pilot-r-a7-enter-commits-and-escape-reverts-in-the-dom`, `pilot-r-a7-a-blur-behind-an-escape-does-not-resurrect-the-draft` | browser, interpreted |
| R-A8 | N instances, no collisions, no coordination | `r-a8-two-lines-hold-independent-drafts-and-values` | JVM+node, both modes |
| R-A9 | Async-transform race safety | `r-a9-an-async-normalisation-neither-flickers-nor-needs-arity-tricks` (superseded reply inert; same-value normalisation still shows), `r-a9-rendering-is-free-of-consequence` | JVM+node, both modes |
| R-A10 | Busy from the write's own state | `r-a10-busy-comes-from-the-write-not-a-local-flag`; `pilot-r-a10-the-control-disables-while-its-own-write-is-in-flight` | JVM+node both modes; browser interpreted |
| R-A11 | Headless assertability | `r-a11-the-whole-loop-is-assertable-without-a-browser` (zero `data-testid` in the pilot; parts are the addresses) — **reachable only past the public door, see finding (a)** | JVM+node, both modes |
| R-A12 | Per-keystroke cost, stated mechanically | `r-a12-the-per-keystroke-cost-of-a-four-field-form` | JVM+node, both modes |

Plus the pilot's own claims: `promotion-changes-no-call-site-and-no-structural-output`,
`the-parity-proof-is-not-vacuous`, `the-compiled-twins-carry-a-real-manifest`,
`the-props-schema-closes-the-props-map`, `the-part-addresses-are-the-published-ones`,
`tokens-ride-the-cascade-and-the-one-dynamic-value-rides-inline`.

### R-A12 — the published per-keystroke numbers (evidence, not a threshold)

Four controlled fields plus a buffered fifth, one line, eleven application reads.

| One keystroke in… | events settled | app-db locations moved | of 11 form reads, moved |
|---|---|---|---|
| a **controlled** field | **2** — `:acme.ui.field/changed`, then the caller's `:acme.invoice/field-edited` | **1** — `[:invoice 1 :quantity]` | **2** — `[:acme.invoice/line 1]`, `[:acme.invoice/line-total 1]` |
| the **buffered** field | **2** — `:acme.ui.buffered/key-pressed` (a no-op for any key but Enter/Escape), then `:acme.ui.buffered/edited` | **1** — the record, written atomically | **0** — a draft is the library's own state, invisible to the caller until it commits |

Read honestly: each number is a consequence of a deliberate choice, not a floor.
The controlled field's second event is the price of the static compiled door proof
(finding (c)); the buffered field's is the price of intent-as-data keyboard handling
(rf2-drpa3.124). Boundary fan-out is stated rather than counted: a props-only field takes
its value as a prop, so the **parent** boundary is what a keystroke invalidates and every
field on the line re-renders — the suite asserts that three of the four produce
byte-identical output. B4 proper (latency distributions under a background storm) is
bench territory and is not touched here.

### Promotion parity

`{:compiled true}` is the whole diff between `pilot_field.cljc` and
`pilot_field_compiled.cljc`: same bodies, same props schemas, same call sites, same part
addresses. The structural trees are equal across modes over the baseline, a validation
branch, a live draft and a post-rejection state. The one measurable thing compilation buys
this pilot is asserted exactly: `invoice-lines` reads nothing and owns no committed site,
so its ViewCell is `:elided`, while `invoice-line`'s is `:present`.

### Non-vacuity

Per new test file, as required.

- `pilot_field_cljs_test.cljc` — inverted the R-A3 restore expectation (`"REF-1"` to
  `"REF-BAD"`). JVM gate red with **2 failures** naming
  `r-a3-a-rejection-lands-even-though-the-value-never-moved` (once per mode); node gate
  red identically. Restored; `git status` clean, byte-identical.
- `pilot_field_dom_cljs_test.cljs` — inverted the same-node assertion inside a promise
  chain (`identical?` to `not identical?`). Browser gate red with **1 failure** naming
  `pilot-r-a3-a-rejection-restores-the-baseline-on-the-same-node`. This also proves the
  async chains are awaited rather than resolving after `done`. Restored; byte-identical.

## Quality gates

All run in the foreground, one at a time, on the rebased branch.

| Gate | Result |
|---|---|
| `cd implementation/freehand && clojure -M:test` | **639 tests, 4577 assertions, 0 failures, 0 errors** |
| `npm run test:freehand` | **552 tests, 3769 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` | **10677 tests, 53862 assertions, 0 failures, 0 errors** |
| `npm run test:browser` | **573 tests, 3345 assertions, 0 failures, 0 errors** |
| `python scripts/check_freehand_conformance_index.py` | exit 0 |
| `python scripts/check_donor_inventory.py` | exit 0 |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `git grep 're-frame\.ui' implementation/freehand/` | empty (positive control confirmed the grep works) |

No spec change and no conformance row: this is a consumer, and per the bead a revealed
contract gap gets a narrow bead against the owning spec rather than an opportunistic edit.
Four such beads are filed above.
